### PR TITLE
add NVPTX debuginfo patches

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -387,7 +387,7 @@ endif # LLVM_VER
 LLVM_PATCH_PREV :=
 define LLVM_PATCH
 $$(LLVM_SRC_DIR)/$1.patch-applied: $$(LLVM_SRC_DIR)/source-extracted | $$(SRCDIR)/patches/$1.patch $$(LLVM_PATCH_PREV)
-	cd $$(LLVM_SRC_DIR) && patch -p1 < $$(SRCDIR)/patches/$1.patch
+	cd $$(LLVM_SRC_DIR) && patch -p$(if $2,$2,1) < $$(SRCDIR)/patches/$1.patch
 	echo 1 > $$@
 # declare that applying any patch must re-run the compile step
 $$(LLVM_BUILDDIR_withtype)/build-compiled: $$(LLVM_SRC_DIR)/$1.patch-applied
@@ -472,6 +472,11 @@ $(eval $(call LLVM_PATCH,llvm-8.0-D50167-scev-umin))
 $(eval $(call LLVM_PATCH,llvm7-windows-race))
 $(eval $(call LLVM_PATCH,llvm-D57118-powerpc)) # remove for 9.0
 $(eval $(call LLVM_PATCH,llvm8-WASM-addrspaces)) # WebAssembly
+$(eval $(call LLVM_PATCH,llvm-nvptx-fix-relocation-info, 2)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm-nvptx-debuginfo, 2)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm-nvptx-dw_at_address_class, 2)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm-nvptx-debugloc, 2)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm-nvptx-ptxas-di, 2)) # remove for 9.0
 endif # LLVM_VER 8.0
 
 # Add a JL prefix to the version map. DO NOT REMOVE

--- a/deps/patches/llvm-nvptx-debuginfo.patch
+++ b/deps/patches/llvm-nvptx-debuginfo.patch
@@ -1,0 +1,10743 @@
+From ee969b84428149f2fb13e2bf6268d1972a1cff0f Mon Sep 17 00:00:00 2001
+From: Alexey Bataev <a.bataev@hotmail.com>
+Date: Wed, 23 Jan 2019 18:59:54 +0000
+Subject: [PATCH 2/5] [DEBUGINFO, NVPTX] Enable support for the debug info on
+ NVPTX target.
+
+Enable full support for the debug info.
+
+Differential revision: https://reviews.llvm.org/D46189
+
+llvm-svn: 351974
+---
+ .../NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp     |    9 +-
+ .../MCTargetDesc/NVPTXTargetStreamer.cpp      |   13 +-
+ .../NVPTX/MCTargetDesc/NVPTXTargetStreamer.h  |    3 +
+ llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp     |    7 +-
+ llvm/test/DebugInfo/NVPTX/cu-range-hole.ll    |  280 +-
+ .../DebugInfo/NVPTX/dbg-declare-alloca.ll     |  328 +-
+ llvm/test/DebugInfo/NVPTX/debug-empty.ll      |   18 +
+ llvm/test/DebugInfo/NVPTX/debug-file-loc.ll   |   94 +-
+ llvm/test/DebugInfo/NVPTX/debug-info.ll       | 9386 ++++++++---------
+ llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll |  410 +-
+ 10 files changed, 5286 insertions(+), 5262 deletions(-)
+ create mode 100644 llvm/test/DebugInfo/NVPTX/debug-empty.ll
+
+diff --git a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
+index f6cbd23f01c..ed6df502e9a 100644
+--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
++++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
+@@ -38,12 +38,11 @@ NVPTXMCAsmInfo::NVPTXMCAsmInfo(const Triple &TheTriple) {
+   HiddenDeclarationVisibilityAttr = HiddenVisibilityAttr = MCSA_Invalid;
+   ProtectedVisibilityAttr = MCSA_Invalid;
+ 
+-  // FIXME: remove comment once debug info is properly supported.
+-  Data8bitsDirective = "// .b8 ";
++  Data8bitsDirective = ".b8 ";
+   Data16bitsDirective = nullptr; // not supported
+-  Data32bitsDirective = "// .b32 ";
+-  Data64bitsDirective = "// .b64 ";
+-  ZeroDirective = "// .b8";
++  Data32bitsDirective = ".b32 ";
++  Data64bitsDirective = ".b64 ";
++  ZeroDirective = ".b8";
+   AsciiDirective = nullptr; // not supported
+   AscizDirective = nullptr; // not supported
+   SupportsQuotedNames = false;
+diff --git a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
+index f7b4cf3a0f7..0f3eea63d8c 100644
+--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
++++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
+@@ -31,6 +31,11 @@ void NVPTXTargetStreamer::outputDwarfFileDirectives() {
+   DwarfFiles.clear();
+ }
+ 
++void NVPTXTargetStreamer::closeLastSection() {
++  if (HasSections)
++    getStreamer().EmitRawText("\t}");
++}
++
+ void NVPTXTargetStreamer::emitDwarfFileDirective(StringRef Directive) {
+   DwarfFiles.emplace_back(Directive);
+ }
+@@ -82,18 +87,18 @@ void NVPTXTargetStreamer::changeSection(const MCSection *CurSection,
+                                         raw_ostream &OS) {
+   assert(!SubSection && "SubSection is not null!");
+   const MCObjectFileInfo *FI = getStreamer().getContext().getObjectFileInfo();
+-  // FIXME: remove comment once debug info is properly supported.
+   // Emit closing brace for DWARF sections only.
+   if (isDwarfSection(FI, CurSection))
+-    OS << "//\t}\n";
++    OS << "\t}\n";
+   if (isDwarfSection(FI, Section)) {
+     // Emit DWARF .file directives in the outermost scope.
+     outputDwarfFileDirectives();
+-    OS << "//\t.section";
++    OS << "\t.section";
+     Section->PrintSwitchToSection(*getStreamer().getContext().getAsmInfo(),
+                                   FI->getTargetTriple(), OS, SubSection);
+     // DWARF sections are enclosed into braces - emit the open one.
+-    OS << "//\t{\n";
++    OS << "\t{\n";
++    HasSections = true;
+   }
+ }
+ 
+diff --git a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.h b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.h
+index f18e61cdca5..03a64797e7a 100644
+--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.h
++++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.h
+@@ -19,6 +19,7 @@ class MCSection;
+ class NVPTXTargetStreamer : public MCTargetStreamer {
+ private:
+   SmallVector<std::string, 4> DwarfFiles;
++  bool HasSections = false;
+ 
+ public:
+   NVPTXTargetStreamer(MCStreamer &S);
+@@ -26,6 +27,8 @@ public:
+ 
+   /// Outputs the list of the DWARF '.file' directives to the streamer.
+   void outputDwarfFileDirectives();
++  /// Close last section.
++  void closeLastSection();
+ 
+   /// Record DWARF file directives for later output.
+   /// According to PTX ISA, CUDA Toolkit documentation, 11.5.3. Debugging
+diff --git a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+index 45703ef8f20..db91369a524 100644
+--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
++++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+@@ -902,9 +902,8 @@ void NVPTXAsmPrinter::emitHeader(Module &M, raw_ostream &O,
+     if (HasFullDebugInfo)
+       break;
+   }
+-  // FIXME: remove comment once debug info is properly supported.
+   if (MMI && MMI->hasDebugInfo() && HasFullDebugInfo)
+-    O << "//, debug";
++    O << ", debug";
+ 
+   O << "\n";
+ 
+@@ -955,10 +954,10 @@ bool NVPTXAsmPrinter::doFinalization(Module &M) {
+   clearAnnotationCache(&M);
+ 
+   delete[] gv_array;
+-  // FIXME: remove comment once debug info is properly supported.
+   // Close the last emitted section
+   if (HasDebugInfo)
+-    OutStreamer->EmitRawText("//\t}");
++    static_cast<NVPTXTargetStreamer *>(OutStreamer->getTargetStreamer())
++        ->closeLastSection();
+ 
+   // Output last DWARF .file directives, if any.
+   static_cast<NVPTXTargetStreamer *>(OutStreamer->getTargetStreamer())
+diff --git a/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll b/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
+index 48570e090c8..ccc5c1201fd 100644
+--- a/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
++++ b/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
+@@ -1,6 +1,6 @@
+ ; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda | FileCheck %s
+ 
+-; CHECK: .target sm_{{[0-9]+}}//, debug
++; CHECK: .target sm_{{[0-9]+}}, debug
+ 
+ ; CHECK: .visible .func  (.param .b32 func_retval0) b(
+ ; CHECK: .param .b32 b_param_0
+@@ -72,145 +72,145 @@ entry:
+   ret i32 %add, !dbg !16
+ }
+ 
+-; CHECK: // .section .debug_abbrev
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 1                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 17                               // DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 37                               // DW_AT_producer
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 19                               // DW_AT_language
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 16                               // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 6                                // DW_FORM_data4
+-; CHECK-NEXT: // .b8 27                               // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 2                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 64                               // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 39                               // DW_AT_prototyped
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 3                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 5                                // DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 4                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 36                               // DW_TAG_base_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 62                               // DW_AT_encoding
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 0                                // EOM(3)
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_info
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b32 183                             // Length of Unit
+-; CHECK-NEXT: // .b8 2                                // DWARF version number
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+-; CHECK-NEXT: // .b8 8                                // Address Size (in bytes)
+-; CHECK-NEXT: // .b8 1                                // Abbrev [1] 0xb:0xb0 DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,116,114,117,110,107,32,50,48,52,49,54,52,41,32,40,108,108,118,109 // DW_AT_producer
+-; CHECK-NEXT: // .b8 47,116,114,117,110,107,32,50,48,52,49,56,51,41
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_language
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 98,46,99                         // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 47,115,111,117,114,99,101        // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end2                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 2                                // Abbrev [2] 0x65:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 156
+-; CHECK-NEXT: // .b8 98                               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_prototyped
+-; CHECK-NEXT: // .b32 179                             // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x82:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 99                               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 179                             // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 2                                // Abbrev [2] 0x8c:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b64 Lfunc_begin2                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end2                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 156
+-; CHECK-NEXT: // .b8 100                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_prototyped
+-; CHECK-NEXT: // .b32 179                             // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xa9:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 101                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 179                             // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0xb3:0x7 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 105,110,116                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_macinfo
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 0                                // End Of Macro List Mark
+-; CHECK:      // }
++; CHECK: .section .debug_abbrev
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 1                                // Abbreviation Code
++; CHECK-NEXT: .b8 17                               // DW_TAG_compile_unit
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 37                               // DW_AT_producer
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 19                               // DW_AT_language
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 16                               // DW_AT_stmt_list
++; CHECK-NEXT: .b8 6                                // DW_FORM_data4
++; CHECK-NEXT: .b8 27                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 2                                // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 39                               // DW_AT_prototyped
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 3                                // Abbreviation Code
++; CHECK-NEXT: .b8 5                                // DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 4                                // Abbreviation Code
++; CHECK-NEXT: .b8 36                               // DW_TAG_base_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 62                               // DW_AT_encoding
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 0                                // EOM(3)
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_info
++; CHECK-NEXT: {
++; CHECK-NEXT: .b32 183                             // Length of Unit
++; CHECK-NEXT: .b8 2                                // DWARF version number
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
++; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
++; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0xb0 DW_TAG_compile_unit
++; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,116,114,117,110,107,32,50,48,52,49,54,52,41,32,40,108,108,118,109 // DW_AT_producer
++; CHECK-NEXT: .b8 47,116,114,117,110,107,32,50,48,52,49,56,51,41
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_language
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 98,46,99                         // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
++; CHECK-NEXT: .b8 47,115,111,117,114,99,101        // DW_AT_comp_dir
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end2                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x65:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
++; CHECK-NEXT: .b8 156
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_prototyped
++; CHECK-NEXT: .b32 179                             // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x82:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 179                             // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x8c:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b64 Lfunc_begin2                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end2                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
++; CHECK-NEXT: .b8 156
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_prototyped
++; CHECK-NEXT: .b32 179                             // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xa9:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 179                             // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0xb3:0x7 DW_TAG_base_type
++; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_macinfo
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 0                                // End Of Macro List Mark
++; CHECK:      }
+ 
+ attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+ attributes #1 = { nounwind readnone }
+diff --git a/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll b/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
+index d6a77ca9422..ed2fb88e6a2 100644
+--- a/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
++++ b/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
+@@ -1,6 +1,6 @@
+ ; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda | FileCheck %s
+ 
+-; CHECK: .target sm_20//, debug
++; CHECK: .target sm_20, debug
+ 
+ ; CHECK: .visible .func use_dbg_declare()
+ ; CHECK: .local .align 8 .b8 __local_depot0[8];
+@@ -23,169 +23,169 @@
+ 
+ ; CHECK: .file 1 "test{{(/|\\\\)}}t.c"
+ 
+-; CHECK: // .section .debug_abbrev
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 1                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 17                               // DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 37                               // DW_AT_producer
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 19                               // DW_AT_language
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 16                               // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 6                                // DW_FORM_data4
+-; CHECK-NEXT: // .b8 27                               // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 2                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 64                               // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 39                               // DW_AT_prototyped
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 3                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 52                               // DW_TAG_variable
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 2                                // DW_AT_location
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 4                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 19                               // DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 5                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 13                               // DW_TAG_member
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 56                               // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 6                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 36                               // DW_TAG_base_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 62                               // DW_AT_encoding
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 0                                // EOM(3)
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_info
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b32 135                             // Length of Unit
+-; CHECK-NEXT: // .b8 2                                // DWARF version number
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+-; CHECK-NEXT: // .b8 8                                // Address Size (in bytes)
+-; CHECK-NEXT: // .b8 1                                // Abbrev [1] 0xb:0x80 DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 99,108,97,110,103                // DW_AT_producer
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_language
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,46,99                        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 116,101,115,116                  // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 2                                // Abbrev [2] 0x31:0x3d DW_TAG_subprogram
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 156
+-; CHECK-NEXT: // .b8 117,115,101,95,100,98,103,95,100,101,99,108,97,114,101 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_prototyped
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x58:0x15 DW_TAG_variable
+-; CHECK-NEXT: // .b8 11                               // DW_AT_location
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b64 __local_depot0
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 110                             // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x6e:0x15 DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 70,111,111                       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x76:0xc DW_TAG_member
+-; CHECK-NEXT: // .b8 120                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 131                             // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x83:0x7 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 105,110,116                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // }
++; CHECK: .section .debug_abbrev
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 1                                // Abbreviation Code
++; CHECK-NEXT: .b8 17                               // DW_TAG_compile_unit
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 37                               // DW_AT_producer
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 19                               // DW_AT_language
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 16                               // DW_AT_stmt_list
++; CHECK-NEXT: .b8 6                                // DW_FORM_data4
++; CHECK-NEXT: .b8 27                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 2                                // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 39                               // DW_AT_prototyped
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 3                                // Abbreviation Code
++; CHECK-NEXT: .b8 52                               // DW_TAG_variable
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 2                                // DW_AT_location
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 4                                // Abbreviation Code
++; CHECK-NEXT: .b8 19                               // DW_TAG_structure_type
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 5                                // Abbreviation Code
++; CHECK-NEXT: .b8 13                               // DW_TAG_member
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 56                               // DW_AT_data_member_location
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 6                                // Abbreviation Code
++; CHECK-NEXT: .b8 36                               // DW_TAG_base_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 62                               // DW_AT_encoding
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 0                                // EOM(3)
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_info
++; CHECK-NEXT: {
++; CHECK-NEXT: .b32 135                             // Length of Unit
++; CHECK-NEXT: .b8 2                                // DWARF version number
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
++; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
++; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x80 DW_TAG_compile_unit
++; CHECK-NEXT: .b8 99,108,97,110,103                // DW_AT_producer
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_language
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,46,99                        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
++; CHECK-NEXT: .b8 116,101,115,116                  // DW_AT_comp_dir
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x31:0x3d DW_TAG_subprogram
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
++; CHECK-NEXT: .b8 156
++; CHECK-NEXT: .b8 117,115,101,95,100,98,103,95,100,101,99,108,97,114,101 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_prototyped
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x58:0x15 DW_TAG_variable
++; CHECK-NEXT: .b8 11                               // DW_AT_location
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b64 __local_depot0
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 110                             // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x6e:0x15 DW_TAG_structure_type
++; CHECK-NEXT: .b8 70,111,111                       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x76:0xc DW_TAG_member
++; CHECK-NEXT: .b8 120                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 131                             // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x83:0x7 DW_TAG_base_type
++; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: }
+ 
+ %struct.Foo = type { i32 }
+ 
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-empty.ll b/llvm/test/DebugInfo/NVPTX/debug-empty.ll
+new file mode 100644
+index 00000000000..f1ebf739d2f
+--- /dev/null
++++ b/llvm/test/DebugInfo/NVPTX/debug-empty.ll
+@@ -0,0 +1,18 @@
++; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda | FileCheck %s
++
++; CHECK: .target sm_{{[0-9]+$}}
++; CHECK-NOT: }
++
++!llvm.dbg.cu = !{!0}
++!llvm.module.flags = !{!3, !4, !5, !6, !7}
++!llvm.ident = !{!8}
++
++!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 9.0.0 (trunk 351924) (llvm/trunk 351968)", isOptimized: false, runtimeVersion: 0, emissionKind: DebugDirectivesOnly, enums: !2, nameTableKind: None)
++!1 = !DIFile(filename: "new.cc", directory: "/test")
++!2 = !{}
++!3 = !{i32 2, !"Dwarf Version", i32 2}
++!4 = !{i32 2, !"Debug Info Version", i32 3}
++!5 = !{i32 1, !"wchar_size", i32 4}
++!6 = !{i32 4, !"nvvm-reflect-ftz", i32 0}
++!7 = !{i32 7, !"PIC Level", i32 2}
++!8 = !{!"clang version 9.0.0 (trunk 351924) (llvm/trunk 351968)"}
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll b/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
+index be4b2efd314..631e1e2d2b2 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
+@@ -8,7 +8,7 @@
+ ;__device__ void bar() {}
+ ;}
+ 
+-; CHECK: .target sm_{{[0-9]+}}//, debug
++; CHECK: .target sm_{{[0-9]+}}, debug
+ 
+ ; CHECK: .visible .func foo()
+ ; CHECK: .loc [[FOO:[0-9]+]] 1 31
+@@ -29,52 +29,52 @@ bb:
+ 
+ ; CHECK-DAG: .file [[FOO]] "{{.*}}foo.h"
+ ; CHECK-DAG: .file [[BAR]] "{{.*}}bar.cu"
+-; CHECK: // .section .debug_abbrev
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 1                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 17                               // DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 37                               // DW_AT_producer
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 19                               // DW_AT_language
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 16                               // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 6                                // DW_FORM_data4
+-; CHECK-NEXT: // .b8 27                               // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 0                                // EOM(3)
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_info
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b32 50                              // Length of Unit
+-; CHECK-NEXT: // .b8 2                                // DWARF version number
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+-; CHECK-NEXT: // .b8 8                                // Address Size (in bytes)
+-; CHECK-NEXT: // .b8 1                                // Abbrev [1] 0xb:0x2b DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 0                                // DW_AT_producer
+-; CHECK-NEXT: // .b8 4                                // DW_AT_language
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 98,97,114,46,99,117              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 47,115,111,117,114,99,101,47,100,105,114                // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end1                      // DW_AT_high_pc
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_macinfo
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 0                                // End Of Macro List Mark
+-; CHECK:      // }
++; CHECK: .section .debug_abbrev
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 1                                // Abbreviation Code
++; CHECK-NEXT: .b8 17                               // DW_TAG_compile_unit
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 37                               // DW_AT_producer
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 19                               // DW_AT_language
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 16                               // DW_AT_stmt_list
++; CHECK-NEXT: .b8 6                                // DW_FORM_data4
++; CHECK-NEXT: .b8 27                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 0                                // EOM(3)
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_info
++; CHECK-NEXT: {
++; CHECK-NEXT: .b32 50                              // Length of Unit
++; CHECK-NEXT: .b8 2                                // DWARF version number
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
++; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
++; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x2b DW_TAG_compile_unit
++; CHECK-NEXT: .b8 0                                // DW_AT_producer
++; CHECK-NEXT: .b8 4                                // DW_AT_language
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 98,97,114,46,99,117              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
++; CHECK-NEXT: .b8 47,115,111,117,114,99,101,47,100,105,114                // DW_AT_comp_dir
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end1                      // DW_AT_high_pc
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_macinfo
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 0                                // End Of Macro List Mark
++; CHECK:      }
+ 
+ !llvm.dbg.cu = !{!0}
+ !llvm.module.flags = !{!8, !9}
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-info.ll b/llvm/test/DebugInfo/NVPTX/debug-info.ll
+index aac34da0eff..b7d871a0b8c 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-info.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-info.ll
+@@ -9,7 +9,7 @@
+ ;    res(a * x[i], y[i], &y[i]);
+ ;}
+ 
+-; CHECK: .target sm_{{[0-9]+}}//, debug
++; CHECK: .target sm_{{[0-9]+}}, debug
+ 
+ ; CHECK: .visible .entry _Z5saxpyifPfS_(
+ ; CHECK: .param .u32 {{.+}},
+@@ -105,4698 +105,4698 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-DAG: .file [[DEBUG_INFO_CU]] "{{.*}}debug-info.cu"
+ ; CHECK-DAG: .file [[BUILTUIN_VARS_H]] "{{.*}}clang/include{{/|\\\\}}__clang_cuda_builtin_vars.h"
+ 
+-; CHECK: // .section .debug_abbrev
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 1                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 17                               // DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 37                               // DW_AT_producer
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 19                               // DW_AT_language
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 16                               // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 6                                // DW_FORM_data4
+-; CHECK-NEXT: // .b8 27                               // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 2                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 57                               // DW_TAG_namespace
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 3                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 8                                // DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 24                               // DW_AT_import
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 4                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 8                                // DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 24                               // DW_AT_import
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 5                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 6                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 5                                // DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 7                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 36                               // DW_TAG_base_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 62                               // DW_AT_encoding
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 8                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 15                               // DW_TAG_pointer_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 9                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 38                               // DW_TAG_const_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 10                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 11                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 22                               // DW_TAG_typedef
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 12                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 19                               // DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 13                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 19                               // DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 14                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 13                               // DW_TAG_member
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 56                               // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 15                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 135,1                            // DW_AT_noreturn
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 16                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 17                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 21                               // DW_TAG_subroutine_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 18                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 15                               // DW_TAG_pointer_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 19                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 38                               // DW_TAG_const_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 20                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 22                               // DW_TAG_typedef
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 21                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 21                               // DW_TAG_subroutine_type
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 22                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 135,1                            // DW_AT_noreturn
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 23                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 24                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 25                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 26                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 27                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 19                               // DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 28                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 29                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 5                                // DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 52                               // DW_AT_artificial
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 30                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 50                               // DW_AT_accessibility
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 31                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 50                               // DW_AT_accessibility
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 32                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 50                               // DW_AT_accessibility
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 33                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 16                               // DW_TAG_reference_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 34                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 71                               // DW_AT_specification
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 32                               // DW_AT_inline
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 35                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 19                               // DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 36                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 13                               // DW_TAG_member
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 56                               // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 37                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 38                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 32                               // DW_AT_inline
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 39                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 5                                // DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 40                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 64                               // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 41                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 52                               // DW_TAG_variable
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 42                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 29                               // DW_TAG_inlined_subroutine
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 49                               // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 88                               // DW_AT_call_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 89                               // DW_AT_call_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 43                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 29                               // DW_TAG_inlined_subroutine
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 49                               // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 88                               // DW_AT_call_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 89                               // DW_AT_call_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 44                               // Abbreviation Code
+-; CHECK-NEXT: // .b8 5                                // DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 49                               // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 0                                // EOM(3)
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_info
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b32 10030                           // Length of Unit
+-; CHECK-NEXT: // .b8 2                                // DWARF version number
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+-; CHECK-NEXT: // .b8 8                                // Address Size (in bytes)
+-; CHECK-NEXT: // .b8 1                                // Abbrev [1] 0xb:0x2727 DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 0                                // DW_AT_producer
+-; CHECK-NEXT: // .b8 4                                // DW_AT_language
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 100,101,98,117,103,45,105,110,102,111,46,99,117 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 47,115,111,109,101,47,100,105,114,101,99,116,111,114,121 // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 2                                // Abbrev [2] 0x41:0x588 DW_TAG_namespace
+-; CHECK-NEXT: // .b8 115,116,100                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x46:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 202                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1481                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x4d:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 203                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1525                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x54:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 204                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1563                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x5b:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 205                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1594                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x62:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 206                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1623                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x69:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 207                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1654                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x70:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 208                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1683                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x77:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 209                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1720                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x7e:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 210                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1751                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x85:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 211                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1780                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x8c:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 212                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1809                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x93:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 213                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1852                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x9a:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 214                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1879                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xa1:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 215                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1908                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xa8:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 216                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1935                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xaf:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 217                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1964                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xb6:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 218                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1991                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xbd:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 219                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2020                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xc4:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 220                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2051                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xcb:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 221                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2080                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xd2:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 222                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2115                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xd9:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 223                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2146                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xe0:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 224                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2185                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xe7:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 225                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2220                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xee:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 226                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2255                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xf5:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 227                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2290                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0xfc:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 228                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2339                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x103:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 229                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2382                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x10a:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 230                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2419                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x111:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 231                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2450                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x118:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 232                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2495                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x11f:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 233                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2540                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x126:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 234                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2596                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x12d:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 235                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2627                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x134:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 236                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2666                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x13b:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 237                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2716                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x142:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 238                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2770                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x149:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 239                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2801                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x150:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 240                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2838                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x157:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 241                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2888                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x15e:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 242                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2929                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x165:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 243                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2966                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x16c:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 244                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2999                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x173:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 245                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3030                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x17a:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 246                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3063                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x181:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 247                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3090                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x188:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 248                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3121                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x18f:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 249                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3152                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x196:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 250                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3181                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x19d:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 251                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3210                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1a4:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 252                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3241                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1ab:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 253                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3274                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1b2:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 254                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3309                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1b9:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 255                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3350                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1c0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 0                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3407                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1c8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3438                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1d0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3477                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1d8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3522                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1e0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3555                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1e8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3600                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1f0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 6                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3646                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x1f8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 7                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3675                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x200:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 8                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3706                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x208:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3747                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x210:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3786                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x218:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3821                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x220:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3848                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x228:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3877                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x230:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3906                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x238:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 15                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3933                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x240:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 16                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3962                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x248:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 17                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 3995                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x250:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 102                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4026                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x257:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 121                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4046                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x25e:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 140                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4066                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x265:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 159                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4086                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x26c:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 180                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4112                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x273:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 199                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4132                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x27a:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 218                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4151                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x281:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 237                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4171                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x288:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 0                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4190                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x290:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 19                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4210                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x298:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 38                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4231                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2a0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4256                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2a8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 78                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4282                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2b0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 97                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4308                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2b8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 116                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4327                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2c0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 135                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4348                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2c8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 147                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4378                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2d0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 184                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4402                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2d8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 203                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4421                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2e0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 222                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4441                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2e8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 241                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4461                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x2f0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 4480                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x2f8:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 118                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4500                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x2ff:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 119                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4515                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x306:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 121                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4563                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x30d:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 122                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4576                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x314:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 123                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4596                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x31b:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 129                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4625                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x322:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 130                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4645                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x329:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 131                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4666                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x330:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 132                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4687                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x337:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 133                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4815                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x33e:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 134                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4843                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x345:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 135                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4868                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x34c:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 136                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4886                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x353:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 137                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4903                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x35a:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 138                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4931                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x361:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 139                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4952                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x368:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 140                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4978                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x36f:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 142                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5001                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x376:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 143                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5028                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x37d:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 144                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5079                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x384:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 146                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5112                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x38b:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 152                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5145                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x392:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 153                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5160                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x399:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 154                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5189                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3a0:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 155                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5223                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3a7:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 156                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5255                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3ae:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 157                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5287                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3b5:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 158                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5320                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3bc:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 160                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5343                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3c3:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 161                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5388                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3ca:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 241                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5536                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3d1:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 243                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5585                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3d8:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 245                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5604                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3df:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 246                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5490                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3e6:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 247                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5626                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3ed:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 249                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5653                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3f4:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 250                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5768                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x3fb:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 251                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5675                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x402:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 252                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5708                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x409:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 253                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5795                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x410:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 149                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 5838                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x418:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 150                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 5870                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x420:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 151                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 5904                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x428:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 152                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 5936                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x430:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 153                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 5970                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x438:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 154                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6010                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x440:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 155                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6042                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x448:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 156                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6076                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x450:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 157                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6108                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x458:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 158                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6140                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x460:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 159                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6186                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x468:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 160                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6216                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x470:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 161                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6248                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x478:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 162                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6280                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x480:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 163                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6310                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x488:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 164                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6342                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x490:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 165                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6372                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x498:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 166                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6406                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4a0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 167                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6438                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4a8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 168                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6476                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4b0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 169                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6510                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4b8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 170                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6552                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4c0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 171                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6590                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4c8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 172                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6628                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4d0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 173                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6666                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4d8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 174                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6707                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4e0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 175                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6747                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4e8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 176                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6781                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4f0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 177                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6821                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x4f8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 178                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6857                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x500:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 179                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6893                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x508:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 180                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6931                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x510:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 181                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6965                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x518:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 182                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 6999                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x520:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 183                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7031                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x528:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 184                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7063                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x530:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 185                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7093                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x538:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 186                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7127                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x540:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 187                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7163                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x548:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 188                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7202                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x550:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 189                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7245                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x558:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 190                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7294                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x560:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 191                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7330                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x568:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 192                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7379                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x570:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 193                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7428                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x578:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 194                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7460                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x580:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 195                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7494                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x588:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 196                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7538                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x590:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 197                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7580                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x598:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 198                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7610                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x5a0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 199                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7642                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x5a8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 200                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7674                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x5b0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 201                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7704                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x5b8:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 202                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7736                            // DW_AT_import
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x5c0:0x8 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 10                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 203                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 7772                            // DW_AT_import
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x5c9:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,97,98,115,120        // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,98,115                        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 44                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x5de:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x5e4:0x11 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 108,111,110,103,32,108,111,110,103,32,105,110,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 8                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x5f5:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,97,99,111,115,102    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,99,111,115                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 46                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x60c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x612:0x9 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 102,108,111,97,116               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x61b:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,97,99,111,115,104,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,99,111,115,104                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 48                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x634:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x63a:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,97,115,105,110,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,115,105,110                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 50                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x651:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x657:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,97,115,105,110,104,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,115,105,110,104               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 52                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x670:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x676:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,97,116,97,110,102    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,116,97,110                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 56                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x68d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x693:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,97,116,97,110,50,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,116,97,110,50                 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 54                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x6ad:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x6b2:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x6b8:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,97,116,97,110,104,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,116,97,110,104                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x6d1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x6d7:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,99,98,114,116,102    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,98,114,116                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 60                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x6ee:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x6f4:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,99,101,105,108,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,101,105,108                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 62                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x70b:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x711:0x2b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,56,99,111,112,121,115,105,103,110,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,111,112,121,115,105,103,110   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 64                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x731:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x736:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x73c:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,99,111,115,102       // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,111,115                       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 66                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x751:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x757:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,99,111,115,104,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,111,115,104                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 68                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x76e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x774:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,101,114,102,102      // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,114,102                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 72                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x789:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x78f:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,101,114,102,99,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,114,102,99                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 70                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x7a6:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x7ac:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,101,120,112,102      // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,120,112                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 76                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x7c1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x7c7:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,101,120,112,50,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,120,112,50                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 74                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x7de:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x7e4:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,101,120,112,109,49,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,120,112,109,49               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 78                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x7fd:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x803:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,102,97,98,115,102    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,97,98,115                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 80                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x81a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x820:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,102,100,105,109,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,100,105,109                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 82                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x838:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x83d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x843:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,102,108,111,111,114,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,108,111,111,114              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 84                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x85c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x862:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,102,109,97,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,97                       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 86                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x879:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x87e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x883:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x889:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,102,109,97,120,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,97,120                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 88                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x8a1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x8a6:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x8ac:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,102,109,105,110,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,105,110                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 90                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x8c4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x8c9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x8cf:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,102,109,111,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,111,100                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 92                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x8e7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x8ec:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x8f2:0x2a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,48,102,112,99,108,97,115,115,105,102,121,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,112,99,108,97,115,115,105,102,121 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 94                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x916:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x91c:0x7 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 105,110,116                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x923:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,102,114,101,120,112,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,114,101,120,112              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 96                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x93e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x943:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2377                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x949:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x94e:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,104,121,112,111,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 104,121,112,111,116              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 98                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x968:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x96d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x973:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,105,108,111,103,98,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,108,111,103,98               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 100                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x98c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x992:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,56,105,115,102,105,110,105,116,101,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,102,105,110,105,116,101  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 102                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x9b1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x9b7:0x8 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 98,111,111,108                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 1                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x9bf:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,57,105,115,103,114,101,97,116,101,114,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,103,114,101,97,116,101,114 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 106                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x9e1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x9e6:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x9ec:0x38 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,52,105,115,103,114,101,97,116,101,114,101,113,117,97,108,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,103,114,101,97,116,101,114,101,113,117,97,108 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 105                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xa19:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xa1e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xa24:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,105,115,105,110,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,105,110,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 108                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xa3d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xa43:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,105,115,108,101,115,115,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,108,101,115,115          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 112                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xa5f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xa64:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xa6a:0x32 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,49,105,115,108,101,115,115,101,113,117,97,108,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,108,101,115,115,101,113,117,97,108 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 111                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xa91:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xa96:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xa9c:0x36 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,51,105,115,108,101,115,115,103,114,101,97,116,101,114,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,108,101,115,115,103,114,101,97,116,101,114 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 114                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xac7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xacc:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xad2:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,105,115,110,97,110,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,110,97,110               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 116                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xaeb:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xaf1:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,56,105,115,110,111,114,109,97,108,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,110,111,114,109,97,108   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 118                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xb10:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xb16:0x32 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,49,105,115,117,110,111,114,100,101,114,101,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,115,117,110,111,114,100,101,114,101,100 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 120                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xb3d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xb42:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xb48:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,108,97,98,115,108    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,97,98,115                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 121                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xb5f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0xb65:0xc DW_TAG_base_type
+-; CHECK-NEXT: // .b8 108,111,110,103,32,105,110,116   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 8                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xb71:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,108,100,101,120,112,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,100,101,120,112              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 123                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xb8b:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xb90:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xb96:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,108,103,97,109,109,97,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,103,97,109,109,97            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 125                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xbb1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xbb7:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,108,108,97,98,115,120 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,108,97,98,115                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 126                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xbd0:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xbd6:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,108,108,114,105,110,116,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,108,114,105,110,116          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 128                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xbf1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xbf7:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,108,111,103,102      // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 138                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xc0c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xc12:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,108,111,103,49,48,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,49,48                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 130                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xc2b:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xc31:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,108,111,103,49,112,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,49,112               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 132                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xc4a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xc50:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,108,111,103,50,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,50                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 134                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xc67:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xc6d:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,108,111,103,98,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,98                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 136                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xc84:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xc8a:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,108,114,105,110,116,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,114,105,110,116              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 140                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xca3:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xca9:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,108,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,114,111,117,110,100          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 142                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xcc4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xcca:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,108,108,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,108,114,111,117,110,100      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 143                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xce7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xced:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,109,111,100,102,102,80,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 109,111,100,102                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 145                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xd06:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xd0b:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3345                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0xd11:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xd16:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,110,97,110,80,75,99  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 110,97,110                       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 146                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xd2d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0xd33:0xa DW_TAG_base_type
+-; CHECK-NEXT: // .b8 100,111,117,98,108,101           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 8                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0xd3d:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 3394                            // DW_AT_type
+-; CHECK-NEXT: // .b8 9                                // Abbrev [9] 0xd42:0x5 DW_TAG_const_type
+-; CHECK-NEXT: // .b32 3399                            // DW_AT_type
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0xd47:0x8 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 99,104,97,114                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 8                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 1                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xd4f:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,110,97,110,102,80,75,99 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 110,97,110,102                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 147                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xd68:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xd6e:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,57,110,101,97,114,98,121,105,110,116,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 110,101,97,114,98,121,105,110,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 149                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xd8f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xd95:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,57,110,101,120,116,97,102,116,101,114,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 110,101,120,116,97,102,116,101,114 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 151                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xdb7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xdbc:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xdc2:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,112,111,119,102,105  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 112,111,119                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 155                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xdd8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xddd:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xde3:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,57,114,101,109,97,105,110,100,101,114,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,101,109,97,105,110,100,101,114 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 157                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe05:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe0a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xe10:0x2e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,114,101,109,113,117,111,102,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,101,109,113,117,111          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 159                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe2e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe33:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe38:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2377                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xe3e:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,114,105,110,116,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,105,110,116                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 161                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe55:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xe5b:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,111,117,110,100              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 163                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe74:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xe7a:0x29 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,115,99,97,108,98,108,110,102,108 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,99,97,108,98,108,110         // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 165                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe98:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xe9d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xea3:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,115,99,97,108,98,110,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,99,97,108,98,110             // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 167                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xebf:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xec4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xeca:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,115,105,103,110,98,105,116,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,105,103,110,98,105,116       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 169                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2487                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xee7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xeed:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,115,105,110,102      // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,105,110                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 171                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xf02:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xf08:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,115,105,110,104,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,105,110,104                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 173                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xf1f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xf25:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,115,113,114,116,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,113,114,116                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 175                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xf3c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xf42:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,51,116,97,110,102       // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,97,110                       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 177                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xf57:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xf5d:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,116,97,110,104,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,97,110,104                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 179                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xf74:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xf7a:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,116,103,97,109,109,97,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,103,97,109,109,97            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 181                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xf95:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0xf9b:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,116,114,117,110,99,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,114,117,110,99               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 183                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xfb4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0xfba:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,99,111,115                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 54                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xfc8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0xfce:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,115,105,110                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 56                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xfdc:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0xfe2:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,116,97,110                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0xff0:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0xff6:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,116,97,110,50                 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 60                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1005:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x100a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1010:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 99,101,105,108                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 178                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x101e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1024:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 99,111,115                       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 63                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1031:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1037:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 99,111,115,104                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 72                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1045:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x104b:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 101,120,112                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 100                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1058:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x105e:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 102,97,98,115                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 181                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x106c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1072:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 102,108,111,111,114              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 184                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1081:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1087:0x19 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 102,109,111,100                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 187                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1095:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x109a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x10a0:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 102,114,101,120,112              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 103                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x10af:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x10b4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2377                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x10ba:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 108,100,101,120,112              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 106                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x10c9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x10ce:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x10d4:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 108,111,103                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 109                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x10e1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x10e7:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 108,111,103,49,48                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 112                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x10f6:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x10fc:0x19 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 109,111,100,102                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 115                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x110a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x110f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4373                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x1115:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x111a:0x18 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 112,111,119                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 153                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1127:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x112c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1132:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,105,110                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 65                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x113f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1145:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,105,110,104                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 74                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1153:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1159:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,113,114,116                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 156                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1167:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x116d:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 116,97,110                       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 67                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x117a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1180:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 116,97,110,104                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 76                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x118e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 11                               // Abbrev [11] 0x1194:0xd DW_TAG_typedef
+-; CHECK-NEXT: // .b32 4513                            // DW_AT_type
+-; CHECK-NEXT: // .b8 100,105,118,95,116               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 101                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 12                               // Abbrev [12] 0x11a1:0x2 DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 11                               // Abbrev [11] 0x11a3:0xe DW_TAG_typedef
+-; CHECK-NEXT: // .b32 4529                            // DW_AT_type
+-; CHECK-NEXT: // .b8 108,100,105,118,95,116           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 109                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 13                               // Abbrev [13] 0x11b1:0x22 DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 16                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 105                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 14                               // Abbrev [14] 0x11b5:0xf DW_TAG_member
+-; CHECK-NEXT: // .b8 113,117,111,116                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 107                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 14                               // Abbrev [14] 0x11c4:0xe DW_TAG_member
+-; CHECK-NEXT: // .b8 114,101,109                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 108                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 8
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 15                               // Abbrev [15] 0x11d3:0xd DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,98,111,114,116                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 1                                // DW_AT_noreturn
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x11e0:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,98,115                        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 7                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x11ee:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x11f4:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,116,101,120,105,116           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 7                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1205:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4619                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x120b:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 4624                            // DW_AT_type
+-; CHECK-NEXT: // .b8 17                               // Abbrev [17] 0x1210:0x1 DW_TAG_subroutine_type
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1211:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,116,111,102                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 6                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 26                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x121f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1225:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,116,111,105                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 22                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1234:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x123a:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,116,111,108                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 27                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1249:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x124f:0x2b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 98,115,101,97,114,99,104         // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 7                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 20                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4730                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1260:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4731                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1265:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4731                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x126a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x126f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1274:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4772                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 18                               // Abbrev [18] 0x127a:0x1 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x127b:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 4736                            // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // Abbrev [19] 0x1280:0x1 DW_TAG_const_type
+-; CHECK-NEXT: // .b8 11                               // Abbrev [11] 0x1281:0xe DW_TAG_typedef
+-; CHECK-NEXT: // .b32 4751                            // DW_AT_type
+-; CHECK-NEXT: // .b8 115,105,122,101,95,116           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 8                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 62                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x128f:0x15 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 108,111,110,103,32,117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 7                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 8                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 20                               // Abbrev [20] 0x12a4:0x16 DW_TAG_typedef
+-; CHECK-NEXT: // .b32 4794                            // DW_AT_type
+-; CHECK-NEXT: // .b8 95,95,99,111,109,112,97,114,95,102,110,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 230                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x12ba:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 4799                            // DW_AT_type
+-; CHECK-NEXT: // .b8 21                               // Abbrev [21] 0x12bf:0x10 DW_TAG_subroutine_type
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x12c4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4731                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x12c9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4731                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x12cf:0x1c DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 99,97,108,108,111,99             // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 212                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4730                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x12e0:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x12e5:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x12eb:0x19 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 100,105,118                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 21                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 4500                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x12f9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x12fe:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 22                               // Abbrev [22] 0x1304:0x12 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 101,120,105,116                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 31                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 1                                // DW_AT_noreturn
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1310:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 23                               // Abbrev [23] 0x1316:0x11 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 102,114,101,101                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 227                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1321:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4730                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1327:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 103,101,116,101,110,118          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 52                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 4926                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1338:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x133e:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 3399                            // DW_AT_type
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1343:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 108,97,98,115                    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 8                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1352:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1358:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 108,100,105,118                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 23                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 4515                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1367:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x136c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1372:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 109,97,108,108,111,99            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 210                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4730                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1383:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1389:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 109,98,108,101,110               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 95                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1399:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x139e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x13a4:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 109,98,115,116,111,119,99,115    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 106                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x13b7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5063                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x13bc:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x13c1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x13c7:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 5068                            // DW_AT_type
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x13cc:0xb DW_TAG_base_type
+-; CHECK-NEXT: // .b8 119,99,104,97,114,95,116         // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x13d7:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 109,98,116,111,119,99            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 98                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x13e8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5063                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x13ed:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x13f2:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 23                               // Abbrev [23] 0x13f8:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 113,115,111,114,116              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 253                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1404:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4730                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1409:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x140e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1413:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4772                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 24                               // Abbrev [24] 0x1419:0xf DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 114,97,110,100                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 118                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1428:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 114,101,97,108,108,111,99        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 224                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 4730                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x143a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4730                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x143f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 23                               // Abbrev [23] 0x1445:0x12 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,114,97,110,100               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 120                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1451:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x1457:0x10 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 7                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1467:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,116,114,116,111,100          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 164                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3379                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1477:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x147c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5250                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x1482:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 4926                            // DW_AT_type
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1487:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,116,114,116,111,108          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 183                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1497:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x149c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5250                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14a1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x14a7:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,116,114,116,111,117,108      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 187                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 4751                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14b8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14bd:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5250                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14c2:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x14c8:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,121,115,116,101,109          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 205                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14d9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x14df:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 119,99,115,116,111,109,98,115    // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 109                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14f2:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4926                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14f7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5378                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x14fc:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4737                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x1502:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 5383                            // DW_AT_type
+-; CHECK-NEXT: // .b8 9                                // Abbrev [9] 0x1507:0x5 DW_TAG_const_type
+-; CHECK-NEXT: // .b32 5068                            // DW_AT_type
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x150c:0x1c DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 119,99,116,111,109,98            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 102                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x151d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 4926                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1522:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5068                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 2                                // Abbrev [2] 0x1528:0x78 DW_TAG_namespace
+-; CHECK-NEXT: // .b8 95,95,103,110,117,95,99,120,120  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1533:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 201                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5536                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x153a:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 207                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5585                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1541:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 211                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5604                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1548:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 217                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5626                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x154f:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 228                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5653                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1556:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 229                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5675                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x155d:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 230                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5708                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x1564:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 232                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5768                            // DW_AT_import
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x156b:0x7 DW_TAG_imported_declaration
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 233                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5795                            // DW_AT_import
+-; CHECK-NEXT: // .b8 25                               // Abbrev [25] 0x1572:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,57,95,95,103,110,117,95,99,120,120,51,100,105,118,69,120,120 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 100,105,118                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 214                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5536                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1594:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1599:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 11                               // Abbrev [11] 0x15a0:0xf DW_TAG_typedef
+-; CHECK-NEXT: // .b32 5551                            // DW_AT_type
+-; CHECK-NEXT: // .b8 108,108,100,105,118,95,116       // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 121                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 13                               // Abbrev [13] 0x15af:0x22 DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 16                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 117                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 14                               // Abbrev [14] 0x15b3:0xf DW_TAG_member
+-; CHECK-NEXT: // .b8 113,117,111,116                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 119                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 14                               // Abbrev [14] 0x15c2:0xe DW_TAG_member
+-; CHECK-NEXT: // .b8 114,101,109                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 120                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 8
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 22                               // Abbrev [22] 0x15d1:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,69,120,105,116                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 45                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 1                                // DW_AT_noreturn
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x15de:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x15e4:0x16 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 108,108,97,98,115                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x15f4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x15fa:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 108,108,100,105,118              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 29                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 5536                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x160a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x160f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 16                               // Abbrev [16] 0x1615:0x16 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 97,116,111,108,108               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 36                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1625:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x162b:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,116,114,116,111,108,108      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 209                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x163c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1641:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5250                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1646:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x164c:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,116,114,116,111,117,108,108  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 214                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5742                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x165e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1663:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5250                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1668:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x166e:0x1a DW_TAG_base_type
+-; CHECK-NEXT: // .b8 108,111,110,103,32,108,111,110,103,32,117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 7                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 8                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x1688:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,116,114,116,111,102          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 172                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1698:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x169d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5250                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 10                               // Abbrev [10] 0x16a3:0x1c DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 115,116,114,116,111,108,100      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 175                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5823                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x16b4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3389                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x16b9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5250                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x16bf:0xf DW_TAG_base_type
+-; CHECK-NEXT: // .b8 108,111,110,103,32,100,111,117,98,108,101 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 8                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x16ce:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,97,99,111,115,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,99,111,115,102                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 62                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x16e8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x16ee:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,97,99,111,115,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,99,111,115,104,102            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 90                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x170a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1710:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,97,115,105,110,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,115,105,110,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 57                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x172a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1730:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,97,115,105,110,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,115,105,110,104,102           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 95                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x174c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1752:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,97,116,97,110,50,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,116,97,110,50,102             // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 47                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x176f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1774:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x177a:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,97,116,97,110,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,116,97,110,102                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 52                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1794:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x179a:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,97,116,97,110,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 97,116,97,110,104,102            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 100                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x17b6:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x17bc:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,99,98,114,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,98,114,116,102                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 150                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x17d6:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x17dc:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,99,101,105,108,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,101,105,108,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 155                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x17f6:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x17fc:0x2e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,57,99,111,112,121,115,105,103,110,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,111,112,121,115,105,103,110,102 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 165                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x181f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1824:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x182a:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,99,111,115,102,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,111,115,102                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 219                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1842:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1848:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,99,111,115,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 99,111,115,104,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 32                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1862:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1868:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,101,114,102,99,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,114,102,99,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 210                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1882:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1888:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,101,114,102,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,114,102,102                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 200                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x18a0:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x18a6:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,101,120,112,50,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,120,112,50,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 145                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x18c0:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x18c6:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,101,120,112,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,120,112,102                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x18de:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x18e4:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,101,120,112,109,49,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 101,120,112,109,49,102           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 105                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1900:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1906:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,102,97,98,115,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,97,98,115,102                // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 95                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1920:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1926:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,102,100,105,109,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,100,105,109,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 80                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1941:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1946:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x194c:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,102,108,111,111,114,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,108,111,111,114,102          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 85                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1968:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x196e:0x2a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,102,109,97,102,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,97,102                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 32                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1988:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x198d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1992:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1998:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,102,109,97,120,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,97,120,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 110                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x19b3:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x19b8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x19be:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,102,109,105,110,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,105,110,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 105                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x19d9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x19de:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x19e4:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,102,109,111,100,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,109,111,100,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 17                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x19ff:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a04:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1a0a:0x29 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,102,114,101,120,112,102,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 102,114,101,120,112,102          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 7                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a28:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a2d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2377                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1a33:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,104,121,112,111,116,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 104,121,112,111,116,102          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 110                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a50:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a55:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1a5b:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,105,108,111,103,98,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 105,108,111,103,98,102           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 85                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a77:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1a7d:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,108,100,101,120,112,102,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,100,101,120,112,102          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 240                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a9a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1a9f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1aa5:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,108,103,97,109,109,97,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,103,97,109,109,97,102        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 235                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1ac3:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1ac9:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,108,108,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,108,114,105,110,116,102      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 125                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1ae7:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1aed:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,56,108,108,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,108,114,111,117,110,100,102  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 66                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1508                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1b0d:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1b13:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,108,111,103,49,48,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,49,48,102            // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 76                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1b2f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1b35:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,108,111,103,49,112,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,49,112,102           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 85                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1b51:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1b57:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,108,111,103,50,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,50,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1b71:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1b77:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,108,111,103,98,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,98,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 90                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1b91:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1b97:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,108,111,103,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,111,103,102                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 67                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1baf:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1bb5:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,108,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,114,105,110,116,102          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 116                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1bd1:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1bd7:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,108,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 108,114,111,117,110,100,102      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 71                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1bf5:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1bfb:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,109,111,100,102,102,102,80,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 109,111,100,102,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1c17:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1c1c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 3345                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1c22:0x2b DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,48,110,101,97,114,98,121,105,110,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 110,101,97,114,98,121,105,110,116,102 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 130                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1c47:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1c4d:0x31 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,48,110,101,120,116,97,102,116,101,114,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 110,101,120,116,97,102,116,101,114,102 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 194                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1c73:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1c78:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1c7e:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,112,111,119,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 112,111,119,102                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 47                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1c97:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1c9c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1ca2:0x31 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,49,48,114,101,109,97,105,110,100,101,114,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,101,109,97,105,110,100,101,114,102 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 22                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1cc8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1ccd:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1cd3:0x31 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,114,101,109,113,117,111,102,102,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,101,109,113,117,111,102      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 27                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1cf4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1cf9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1cfe:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2377                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1d04:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,105,110,116,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 111                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1d1e:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1d24:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,111,117,110,100,102          // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 61                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1d40:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1d46:0x2c DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,56,115,99,97,108,98,108,110,102,102,108 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,99,97,108,98,108,110,102     // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 250                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1d67:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1d6c:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2917                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1d72:0x2a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,115,99,97,108,98,110,102,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,99,97,108,98,110,102         // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 245                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1d91:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1d96:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1d9c:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,115,105,110,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,105,110,102                  // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 210                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1db4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1dba:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,115,105,110,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,105,110,104,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 37                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1dd4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1dda:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,115,113,114,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,113,114,116,102              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 139                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 3
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1df4:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1dfa:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,52,116,97,110,102,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,97,110,102                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 252                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1e12:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1e18:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,53,116,97,110,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,97,110,104,102               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 42                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 5
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1e32:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1e38:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,55,116,103,97,109,109,97,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,103,97,109,109,97,102        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 9                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 56                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 6
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1e56:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 26                               // Abbrev [26] 0x1e5c:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,76,54,116,114,117,110,99,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 116,114,117,110,99,102           // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 11                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 150                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x1e78:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 27                               // Abbrev [27] 0x1e7e:0x22a DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 77                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x1e9c:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 98,117,105,108,116,105,110,95,120,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 78                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x1eeb:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 98,117,105,108,116,105,110,95,121,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 79                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x1f3a:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 98,117,105,108,116,105,110,95,122,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 80                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 25                               // Abbrev [25] 0x1f89:0x49 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,99,118,53,117,105,110,116,51,69 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 83                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 8360                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x1fcb:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 8407                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 30                               // Abbrev [30] 0x1fd2:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 85                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x1ff2:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 8417                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 30                               // Abbrev [30] 0x1ff9:0x2c DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 85                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x2019:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 8417                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x201f:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 8422                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 31                               // Abbrev [31] 0x2025:0x43 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 85                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x205c:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 8407                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x2062:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 8422                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 32                               // Abbrev [32] 0x2068:0x3f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 85                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 8427                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x20a0:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 8407                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 27                               // Abbrev [27] 0x20a8:0x2f DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 117,105,110,116,51               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 190                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 14                               // Abbrev [14] 0x20b2:0xc DW_TAG_member
+-; CHECK-NEXT: // .b8 120                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 192                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 14                               // Abbrev [14] 0x20be:0xc DW_TAG_member
+-; CHECK-NEXT: // .b8 121                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 192                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b8 14                               // Abbrev [14] 0x20ca:0xc DW_TAG_member
+-; CHECK-NEXT: // .b8 122                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 192                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 8
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x20d7:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 8412                            // DW_AT_type
+-; CHECK-NEXT: // .b8 9                                // Abbrev [9] 0x20dc:0x5 DW_TAG_const_type
+-; CHECK-NEXT: // .b32 7806                            // DW_AT_type
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x20e1:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 7806                            // DW_AT_type
+-; CHECK-NEXT: // .b8 33                               // Abbrev [33] 0x20e6:0x5 DW_TAG_reference_type
+-; CHECK-NEXT: // .b32 8412                            // DW_AT_type
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x20eb:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 7806                            // DW_AT_type
+-; CHECK-NEXT: // .b8 34                               // Abbrev [34] 0x20f0:0x6 DW_TAG_subprogram
+-; CHECK-NEXT: // .b32 7836                            // DW_AT_specification
+-; CHECK-NEXT: // .b8 1                                // DW_AT_inline
+-; CHECK-NEXT: // .b8 27                               // Abbrev [27] 0x20f6:0x228 DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 88                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x2114:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 98,117,105,108,116,105,110,95,120,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 89                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x2163:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 98,117,105,108,116,105,110,95,121,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 90                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x21b2:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 98,117,105,108,116,105,110,95,122,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 91                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 25                               // Abbrev [25] 0x2201:0x47 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,99,118,52,100,105,109,51,69,118 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,32,100,105,109,51 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 94                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 8990                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x2241:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9166                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 30                               // Abbrev [30] 0x2248:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 96                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x2268:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9176                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 30                               // Abbrev [30] 0x226f:0x2c DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 96                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x228f:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9176                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x2295:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9181                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 31                               // Abbrev [31] 0x229b:0x43 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 96                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x22d2:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9166                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x22d8:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9181                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 32                               // Abbrev [32] 0x22de:0x3f DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 96                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 9186                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x2316:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9166                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 35                               // Abbrev [35] 0x231e:0x9d DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 100,105,109,51                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 161                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 36                               // Abbrev [36] 0x2328:0xd DW_TAG_member
+-; CHECK-NEXT: // .b8 120                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 163                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 36                               // Abbrev [36] 0x2335:0xd DW_TAG_member
+-; CHECK-NEXT: // .b8 121                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 163                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 4
+-; CHECK-NEXT: // .b8 36                               // Abbrev [36] 0x2342:0xd DW_TAG_member
+-; CHECK-NEXT: // .b8 122                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 163                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 2                                // DW_AT_data_member_location
+-; CHECK-NEXT: // .b8 35
+-; CHECK-NEXT: // .b8 8
+-; CHECK-NEXT: // .b8 23                               // Abbrev [23] 0x234f:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 100,105,109,51                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 165                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x235a:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9147                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x2360:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x2365:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x236a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 23                               // Abbrev [23] 0x2370:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 100,105,109,51                   // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 166                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x237b:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9147                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x2381:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9152                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 37                               // Abbrev [37] 0x2387:0x33 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,52,100,105,109,51,99,118,53,117,105,110,116,51,69,118 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 167                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b32 9152                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x23b3:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9147                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x23bb:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 8990                            // DW_AT_type
+-; CHECK-NEXT: // .b8 20                               // Abbrev [20] 0x23c0:0xe DW_TAG_typedef
+-; CHECK-NEXT: // .b32 8360                            // DW_AT_type
+-; CHECK-NEXT: // .b8 117,105,110,116,51               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 14                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 127                              // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x23ce:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 9171                            // DW_AT_type
+-; CHECK-NEXT: // .b8 9                                // Abbrev [9] 0x23d3:0x5 DW_TAG_const_type
+-; CHECK-NEXT: // .b32 8438                            // DW_AT_type
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x23d8:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 8438                            // DW_AT_type
+-; CHECK-NEXT: // .b8 33                               // Abbrev [33] 0x23dd:0x5 DW_TAG_reference_type
+-; CHECK-NEXT: // .b32 9171                            // DW_AT_type
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x23e2:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 8438                            // DW_AT_type
+-; CHECK-NEXT: // .b8 34                               // Abbrev [34] 0x23e7:0x6 DW_TAG_subprogram
+-; CHECK-NEXT: // .b32 8468                            // DW_AT_specification
+-; CHECK-NEXT: // .b8 1                                // DW_AT_inline
+-; CHECK-NEXT: // .b8 27                               // Abbrev [27] 0x23ed:0x233 DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 66                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x240c:0x50 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 95,98,117,105,108,116,105,110,95,120,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 67                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x245c:0x50 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 95,98,117,105,108,116,105,110,95,121,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 68                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 28                               // Abbrev [28] 0x24ac:0x50 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 95,98,117,105,108,116,105,110,95,122,69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 69                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 5207                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 25                               // Abbrev [25] 0x24fc:0x4a DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,99,118,53,117,105,110,116,51 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 69,118
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 72                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 8360                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x253f:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9760                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 30                               // Abbrev [30] 0x2546:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 74                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x2567:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9770                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 30                               // Abbrev [30] 0x256e:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 74                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x258f:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9770                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x2595:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9775                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 31                               // Abbrev [31] 0x259b:0x44 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 74                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x25d3:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9760                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x25d9:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9775                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 32                               // Abbrev [32] 0x25df:0x40 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 13                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 74                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 9780                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 3                                // DW_AT_accessibility
+-; CHECK-NEXT:                                         // DW_ACCESS_private
+-; CHECK-NEXT: // .b8 29                               // Abbrev [29] 0x2618:0x6 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9760                            // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_artificial
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x2620:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 9765                            // DW_AT_type
+-; CHECK-NEXT: // .b8 9                                // Abbrev [9] 0x2625:0x5 DW_TAG_const_type
+-; CHECK-NEXT: // .b32 9197                            // DW_AT_type
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x262a:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 9197                            // DW_AT_type
+-; CHECK-NEXT: // .b8 33                               // Abbrev [33] 0x262f:0x5 DW_TAG_reference_type
+-; CHECK-NEXT: // .b32 9765                            // DW_AT_type
+-; CHECK-NEXT: // .b8 8                                // Abbrev [8] 0x2634:0x5 DW_TAG_pointer_type
+-; CHECK-NEXT: // .b32 9197                            // DW_AT_type
+-; CHECK-NEXT: // .b8 34                               // Abbrev [34] 0x2639:0x6 DW_TAG_subprogram
+-; CHECK-NEXT: // .b32 9228                            // DW_AT_specification
+-; CHECK-NEXT: // .b8 1                                // DW_AT_inline
+-; CHECK-NEXT: // .b8 38                               // Abbrev [38] 0x263f:0x32 DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 95,90,51,114,101,115,102,102,80,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 114,101,115                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 1                                // DW_AT_inline
+-; CHECK-NEXT: // .b8 39                               // Abbrev [39] 0x2653:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 120                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 39                               // Abbrev [39] 0x265c:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 121                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 39                               // Abbrev [39] 0x2665:0xb DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 114,101,115                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 3                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3345                            // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 40                               // Abbrev [40] 0x2671:0xc0 DW_TAG_subprogram
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 156
+-; CHECK-NEXT: // .b8 95,90,53,115,97,120,112,121,105,102,80,102,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 115,97,120,112,121               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 39                               // Abbrev [39] 0x269c:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 110                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 39                               // Abbrev [39] 0x26a5:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 97                               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 1554                            // DW_AT_type
+-; CHECK-NEXT: // .b8 39                               // Abbrev [39] 0x26ae:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 120                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3345                            // DW_AT_type
+-; CHECK-NEXT: // .b8 39                               // Abbrev [39] 0x26b7:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 121                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 5                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 3345                            // DW_AT_type
+-; CHECK-NEXT: // .b8 41                               // Abbrev [41] 0x26c0:0x9 DW_TAG_variable
+-; CHECK-NEXT: // .b8 105                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 12                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 6                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 2332                            // DW_AT_type
+-; CHECK-NEXT: // .b8 42                               // Abbrev [42] 0x26c9:0x17 DW_TAG_inlined_subroutine
+-; CHECK-NEXT: // .b32 8432                            // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b64 Ltmp0                           // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Ltmp1                           // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 12                               // DW_AT_call_file
+-; CHECK-NEXT: // .b8 6                                // DW_AT_call_line
+-; CHECK-NEXT: // .b8 42                               // Abbrev [42] 0x26e0:0x17 DW_TAG_inlined_subroutine
+-; CHECK-NEXT: // .b32 9191                            // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b64 Ltmp1                           // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Ltmp2                           // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 12                               // DW_AT_call_file
+-; CHECK-NEXT: // .b8 6                                // DW_AT_call_line
+-; CHECK-NEXT: // .b8 42                               // Abbrev [42] 0x26f7:0x17 DW_TAG_inlined_subroutine
+-; CHECK-NEXT: // .b32 9785                            // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b64 Ltmp2                           // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Ltmp3                           // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 12                               // DW_AT_call_file
+-; CHECK-NEXT: // .b8 6                                // DW_AT_call_line
+-; CHECK-NEXT: // .b8 43                               // Abbrev [43] 0x270e:0x22 DW_TAG_inlined_subroutine
+-; CHECK-NEXT: // .b32 9791                            // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b64 Ltmp8                           // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Ltmp9                           // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 12                               // DW_AT_call_file
+-; CHECK-NEXT: // .b8 8                                // DW_AT_call_line
+-; CHECK-NEXT: // .b8 44                               // Abbrev [44] 0x2725:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9811                            // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b8 44                               // Abbrev [44] 0x272a:0x5 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b32 9820                            // DW_AT_abstract_origin
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_macinfo
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 0                                // End Of Macro List Mark
+-; CHECK:      // }
++; CHECK: .section .debug_abbrev
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 1                                // Abbreviation Code
++; CHECK-NEXT: .b8 17                               // DW_TAG_compile_unit
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 37                               // DW_AT_producer
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 19                               // DW_AT_language
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 16                               // DW_AT_stmt_list
++; CHECK-NEXT: .b8 6                                // DW_FORM_data4
++; CHECK-NEXT: .b8 27                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 2                                // Abbreviation Code
++; CHECK-NEXT: .b8 57                               // DW_TAG_namespace
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 3                                // Abbreviation Code
++; CHECK-NEXT: .b8 8                                // DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 24                               // DW_AT_import
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 4                                // Abbreviation Code
++; CHECK-NEXT: .b8 8                                // DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 24                               // DW_AT_import
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 5                                // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 6                                // Abbreviation Code
++; CHECK-NEXT: .b8 5                                // DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 7                                // Abbreviation Code
++; CHECK-NEXT: .b8 36                               // DW_TAG_base_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 62                               // DW_AT_encoding
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 8                                // Abbreviation Code
++; CHECK-NEXT: .b8 15                               // DW_TAG_pointer_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 9                                // Abbreviation Code
++; CHECK-NEXT: .b8 38                               // DW_TAG_const_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 10                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 11                               // Abbreviation Code
++; CHECK-NEXT: .b8 22                               // DW_TAG_typedef
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 12                               // Abbreviation Code
++; CHECK-NEXT: .b8 19                               // DW_TAG_structure_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 13                               // Abbreviation Code
++; CHECK-NEXT: .b8 19                               // DW_TAG_structure_type
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 14                               // Abbreviation Code
++; CHECK-NEXT: .b8 13                               // DW_TAG_member
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 56                               // DW_AT_data_member_location
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 15                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 135,1                            // DW_AT_noreturn
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 16                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 17                               // Abbreviation Code
++; CHECK-NEXT: .b8 21                               // DW_TAG_subroutine_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 18                               // Abbreviation Code
++; CHECK-NEXT: .b8 15                               // DW_TAG_pointer_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 19                               // Abbreviation Code
++; CHECK-NEXT: .b8 38                               // DW_TAG_const_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 20                               // Abbreviation Code
++; CHECK-NEXT: .b8 22                               // DW_TAG_typedef
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 21                               // Abbreviation Code
++; CHECK-NEXT: .b8 21                               // DW_TAG_subroutine_type
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 22                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 135,1                            // DW_AT_noreturn
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 23                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 24                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 25                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 26                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 27                               // Abbreviation Code
++; CHECK-NEXT: .b8 19                               // DW_TAG_structure_type
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 28                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 29                               // Abbreviation Code
++; CHECK-NEXT: .b8 5                                // DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 52                               // DW_AT_artificial
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 30                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 50                               // DW_AT_accessibility
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 31                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 50                               // DW_AT_accessibility
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 32                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 50                               // DW_AT_accessibility
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 33                               // Abbreviation Code
++; CHECK-NEXT: .b8 16                               // DW_TAG_reference_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 34                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 71                               // DW_AT_specification
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 32                               // DW_AT_inline
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 35                               // Abbreviation Code
++; CHECK-NEXT: .b8 19                               // DW_TAG_structure_type
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 36                               // Abbreviation Code
++; CHECK-NEXT: .b8 13                               // DW_TAG_member
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 56                               // DW_AT_data_member_location
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 37                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 38                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 32                               // DW_AT_inline
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 39                               // Abbreviation Code
++; CHECK-NEXT: .b8 5                                // DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 40                               // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 41                               // Abbreviation Code
++; CHECK-NEXT: .b8 52                               // DW_TAG_variable
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 42                               // Abbreviation Code
++; CHECK-NEXT: .b8 29                               // DW_TAG_inlined_subroutine
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 49                               // DW_AT_abstract_origin
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 88                               // DW_AT_call_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 89                               // DW_AT_call_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 43                               // Abbreviation Code
++; CHECK-NEXT: .b8 29                               // DW_TAG_inlined_subroutine
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 49                               // DW_AT_abstract_origin
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 88                               // DW_AT_call_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 89                               // DW_AT_call_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 44                               // Abbreviation Code
++; CHECK-NEXT: .b8 5                                // DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 49                               // DW_AT_abstract_origin
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 0                                // EOM(3)
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_info
++; CHECK-NEXT: {
++; CHECK-NEXT: .b32 10030                           // Length of Unit
++; CHECK-NEXT: .b8 2                                // DWARF version number
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
++; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
++; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x2727 DW_TAG_compile_unit
++; CHECK-NEXT: .b8 0                                // DW_AT_producer
++; CHECK-NEXT: .b8 4                                // DW_AT_language
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 100,101,98,117,103,45,105,110,102,111,46,99,117 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
++; CHECK-NEXT: .b8 47,115,111,109,101,47,100,105,114,101,99,116,111,114,121 // DW_AT_comp_dir
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x41:0x588 DW_TAG_namespace
++; CHECK-NEXT: .b8 115,116,100                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x46:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 202                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1481                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x4d:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 203                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1525                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x54:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 204                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1563                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x5b:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 205                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1594                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x62:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 206                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1623                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x69:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 207                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1654                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x70:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 208                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1683                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x77:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 209                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1720                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x7e:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 210                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1751                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x85:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 211                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1780                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x8c:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 212                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1809                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x93:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 213                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1852                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x9a:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 214                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1879                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xa1:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 215                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1908                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xa8:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 216                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1935                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xaf:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 217                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1964                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xb6:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 218                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1991                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xbd:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 219                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2020                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xc4:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 220                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2051                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xcb:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 221                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2080                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xd2:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 222                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2115                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xd9:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 223                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2146                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xe0:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 224                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2185                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xe7:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 225                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2220                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xee:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 226                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2255                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xf5:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 227                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2290                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0xfc:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 228                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2339                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x103:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 229                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2382                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x10a:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 230                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2419                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x111:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 231                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2450                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x118:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 232                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2495                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x11f:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 233                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2540                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x126:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 234                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2596                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x12d:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 235                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2627                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x134:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 236                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2666                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x13b:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 237                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2716                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x142:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 238                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2770                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x149:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 239                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2801                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x150:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 240                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2838                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x157:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 241                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2888                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x15e:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 242                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2929                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x165:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 243                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2966                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x16c:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 244                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2999                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x173:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 245                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3030                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x17a:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 246                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3063                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x181:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 247                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3090                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x188:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 248                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3121                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x18f:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 249                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3152                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x196:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 250                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3181                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x19d:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 251                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3210                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1a4:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 252                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3241                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1ab:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 253                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3274                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1b2:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 254                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3309                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1b9:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 255                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3350                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1c0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 0                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3407                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1c8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3438                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1d0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3477                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1d8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3522                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1e0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3555                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1e8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3600                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1f0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 6                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3646                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x1f8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3675                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x200:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 8                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3706                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x208:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3747                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x210:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3786                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x218:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3821                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x220:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3848                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x228:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3877                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x230:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3906                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x238:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 15                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3933                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x240:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 16                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3962                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x248:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 17                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 3995                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x250:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 102                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4026                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x257:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 121                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4046                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x25e:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 140                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4066                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x265:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 159                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4086                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x26c:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 180                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4112                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x273:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 199                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4132                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x27a:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 218                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4151                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x281:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 237                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4171                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x288:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 0                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4190                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x290:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 19                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4210                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x298:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 38                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4231                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2a0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4256                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2a8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 78                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4282                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2b0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 97                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4308                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2b8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 116                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4327                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2c0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 135                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4348                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2c8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 147                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4378                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2d0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 184                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4402                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2d8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 203                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4421                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2e0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 222                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4441                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2e8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 241                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4461                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x2f0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 4480                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x2f8:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 118                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4500                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x2ff:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 119                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4515                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x306:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 121                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4563                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x30d:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 122                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4576                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x314:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 123                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4596                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x31b:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 129                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4625                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x322:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 130                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4645                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x329:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 131                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4666                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x330:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 132                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4687                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x337:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 133                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4815                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x33e:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 134                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4843                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x345:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 135                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4868                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x34c:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 136                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4886                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x353:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 137                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4903                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x35a:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 138                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4931                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x361:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 139                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4952                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x368:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 140                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4978                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x36f:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 142                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5001                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x376:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 143                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5028                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x37d:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 144                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5079                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x384:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 146                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5112                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x38b:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 152                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5145                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x392:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 153                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5160                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x399:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 154                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5189                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3a0:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 155                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5223                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3a7:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 156                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5255                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3ae:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 157                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5287                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3b5:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 158                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5320                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3bc:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 160                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5343                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3c3:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 161                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5388                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3ca:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 241                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5536                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3d1:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 243                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5585                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3d8:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 245                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5604                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3df:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 246                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5490                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3e6:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 247                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5626                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3ed:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 249                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5653                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3f4:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 250                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5768                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x3fb:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 251                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5675                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x402:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 252                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5708                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x409:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 253                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5795                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x410:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 149                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 5838                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x418:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 150                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 5870                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x420:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 151                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 5904                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x428:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 152                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 5936                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x430:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 153                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 5970                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x438:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 154                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6010                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x440:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 155                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6042                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x448:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 156                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6076                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x450:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 157                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6108                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x458:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 158                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6140                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x460:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 159                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6186                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x468:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 160                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6216                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x470:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 161                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6248                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x478:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 162                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6280                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x480:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 163                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6310                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x488:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 164                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6342                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x490:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 165                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6372                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x498:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 166                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6406                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4a0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 167                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6438                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4a8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 168                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6476                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4b0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 169                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6510                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4b8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 170                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6552                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4c0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 171                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6590                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4c8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 172                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6628                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4d0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 173                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6666                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4d8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 174                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6707                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4e0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 175                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6747                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4e8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 176                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6781                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4f0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 177                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6821                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x4f8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 178                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6857                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x500:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 179                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6893                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x508:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 180                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6931                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x510:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 181                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6965                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x518:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 182                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 6999                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x520:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 183                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7031                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x528:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 184                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7063                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x530:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 185                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7093                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x538:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 186                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7127                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x540:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 187                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7163                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x548:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 188                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7202                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x550:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 189                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7245                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x558:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 190                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7294                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x560:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 191                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7330                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x568:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 192                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7379                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x570:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 193                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7428                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x578:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 194                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7460                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x580:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 195                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7494                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x588:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 196                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7538                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x590:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 197                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7580                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x598:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 198                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7610                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x5a0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 199                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7642                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x5a8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 200                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7674                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x5b0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 201                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7704                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x5b8:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 202                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7736                            // DW_AT_import
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x5c0:0x8 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 10                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 203                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 7772                            // DW_AT_import
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x5c9:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,97,98,115,120        // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,98,115                        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 44                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x5de:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x5e4:0x11 DW_TAG_base_type
++; CHECK-NEXT: .b8 108,111,110,103,32,108,111,110,103,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_encoding
++; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x5f5:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,97,99,111,115,102    // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,99,111,115                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 46                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x60c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x612:0x9 DW_TAG_base_type
++; CHECK-NEXT: .b8 102,108,111,97,116               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x61b:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,97,99,111,115,104,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,99,111,115,104                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 48                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x634:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x63a:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,97,115,105,110,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,115,105,110                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 50                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x651:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x657:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,97,115,105,110,104,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,115,105,110,104               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 52                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x670:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x676:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,97,116,97,110,102    // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,116,97,110                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 56                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x68d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x693:0x25 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,97,116,97,110,50,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,116,97,110,50                 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 54                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x6ad:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x6b2:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x6b8:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,97,116,97,110,104,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,116,97,110,104                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x6d1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x6d7:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,99,98,114,116,102    // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,98,114,116                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 60                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x6ee:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x6f4:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,99,101,105,108,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,101,105,108                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 62                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x70b:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x711:0x2b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,56,99,111,112,121,115,105,103,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,111,112,121,115,105,103,110   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 64                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x731:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x736:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x73c:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,99,111,115,102       // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,111,115                       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 66                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x751:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x757:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,99,111,115,104,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,111,115,104                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 68                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x76e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x774:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,101,114,102,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,114,102                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 72                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x789:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x78f:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,101,114,102,99,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,114,102,99                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 70                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x7a6:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x7ac:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,101,120,112,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,120,112                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 76                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x7c1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x7c7:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,101,120,112,50,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,120,112,50                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x7de:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x7e4:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,101,120,112,109,49,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,120,112,109,49               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 78                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x7fd:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x803:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,102,97,98,115,102    // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 80                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x81a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x820:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,102,100,105,109,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,100,105,109                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 82                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x838:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x83d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x843:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,102,108,111,111,114,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,108,111,111,114              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 84                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x85c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x862:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,102,109,97,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,97                       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 86                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x879:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x87e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x883:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x889:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,102,109,97,120,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,97,120                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 88                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x8a1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x8a6:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x8ac:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,102,109,105,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,105,110                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x8c4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x8c9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x8cf:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,102,109,111,100,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,111,100                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 92                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x8e7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x8ec:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x8f2:0x2a DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,48,102,112,99,108,97,115,115,105,102,121,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,112,99,108,97,115,115,105,102,121 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 94                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x916:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x91c:0x7 DW_TAG_base_type
++; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x923:0x26 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,102,114,101,120,112,102,80,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,114,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x93e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x943:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2377                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x949:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x94e:0x25 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,104,121,112,111,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 104,121,112,111,116              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 98                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x968:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x96d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x973:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,105,108,111,103,98,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,108,111,103,98               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 100                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x98c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x992:0x25 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,56,105,115,102,105,110,105,116,101,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,102,105,110,105,116,101  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 102                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x9b1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x9b7:0x8 DW_TAG_base_type
++; CHECK-NEXT: .b8 98,111,111,108                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_encoding
++; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x9bf:0x2d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,57,105,115,103,114,101,97,116,101,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,103,114,101,97,116,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 106                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x9e1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x9e6:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x9ec:0x38 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,52,105,115,103,114,101,97,116,101,114,101,113,117,97,108,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,103,114,101,97,116,101,114,101,113,117,97,108 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xa19:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xa1e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa24:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,105,115,105,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,105,110,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 108                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xa3d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa43:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,105,115,108,101,115,115,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,108,101,115,115          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 112                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xa5f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xa64:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa6a:0x32 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,49,105,115,108,101,115,115,101,113,117,97,108,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,108,101,115,115,101,113,117,97,108 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 111                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xa91:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xa96:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa9c:0x36 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,51,105,115,108,101,115,115,103,114,101,97,116,101,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,108,101,115,115,103,114,101,97,116,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 114                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xac7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xacc:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xad2:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,105,115,110,97,110,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,110,97,110               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 116                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xaeb:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xaf1:0x25 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,56,105,115,110,111,114,109,97,108,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,110,111,114,109,97,108   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 118                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xb10:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb16:0x32 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,49,105,115,117,110,111,114,100,101,114,101,100,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,115,117,110,111,114,100,101,114,101,100 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 120                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xb3d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xb42:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb48:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,108,97,98,115,108    // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 121                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xb5f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0xb65:0xc DW_TAG_base_type
++; CHECK-NEXT: .b8 108,111,110,103,32,105,110,116   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_encoding
++; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb71:0x25 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,108,100,101,120,112,102,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,100,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 123                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xb8b:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xb90:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb96:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,108,103,97,109,109,97,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,103,97,109,109,97            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 125                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xbb1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xbb7:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,108,108,97,98,115,120 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,108,97,98,115                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 126                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xbd0:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xbd6:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,108,108,114,105,110,116,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,108,114,105,110,116          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 128                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xbf1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xbf7:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,108,111,103,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 138                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xc0c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc12:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,108,111,103,49,48,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,49,48                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 130                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xc2b:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc31:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,108,111,103,49,112,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,49,112               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 132                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xc4a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc50:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,108,111,103,50,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,50                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 134                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xc67:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc6d:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,108,111,103,98,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,98                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 136                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xc84:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc8a:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,108,114,105,110,116,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,114,105,110,116              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 140                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xca3:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xca9:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,108,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,114,111,117,110,100          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 142                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xcc4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xcca:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,108,108,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,108,114,111,117,110,100      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 143                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xce7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xced:0x24 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,109,111,100,102,102,80,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 109,111,100,102                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 145                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xd06:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xd0b:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3345                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0xd11:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd16:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,110,97,110,80,75,99  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 110,97,110                       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 146                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xd2d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0xd33:0xa DW_TAG_base_type
++; CHECK-NEXT: .b8 100,111,117,98,108,101           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_encoding
++; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0xd3d:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 3394                            // DW_AT_type
++; CHECK-NEXT: .b8 9                                // Abbrev [9] 0xd42:0x5 DW_TAG_const_type
++; CHECK-NEXT: .b32 3399                            // DW_AT_type
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0xd47:0x8 DW_TAG_base_type
++; CHECK-NEXT: .b8 99,104,97,114                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 8                                // DW_AT_encoding
++; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd4f:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,110,97,110,102,80,75,99 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 110,97,110,102                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 147                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xd68:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd6e:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,57,110,101,97,114,98,121,105,110,116,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 110,101,97,114,98,121,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 149                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xd8f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd95:0x2d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,57,110,101,120,116,97,102,116,101,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 110,101,120,116,97,102,116,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 151                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xdb7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xdbc:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xdc2:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,112,111,119,102,105  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 112,111,119                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 155                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xdd8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xddd:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xde3:0x2d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,57,114,101,109,97,105,110,100,101,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,101,109,97,105,110,100,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 157                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe05:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe0a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe10:0x2e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,114,101,109,113,117,111,102,102,80,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,101,109,113,117,111          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 159                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe2e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe33:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe38:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2377                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe3e:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,114,105,110,116,102  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,105,110,116                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 161                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe55:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe5b:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,111,117,110,100              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 163                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe74:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe7a:0x29 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,115,99,97,108,98,108,110,102,108 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,99,97,108,98,108,110         // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 165                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe98:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xe9d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xea3:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,115,99,97,108,98,110,102,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,99,97,108,98,110             // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 167                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xebf:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xec4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xeca:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,115,105,103,110,98,105,116,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,105,103,110,98,105,116       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 169                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2487                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xee7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xeed:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,115,105,110,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,105,110                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 171                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xf02:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf08:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,115,105,110,104,102  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,105,110,104                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 173                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xf1f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf25:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,115,113,114,116,102  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,113,114,116                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 175                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xf3c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf42:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,51,116,97,110,102       // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,97,110                       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 177                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xf57:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf5d:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,116,97,110,104,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,97,110,104                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 179                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xf74:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf7a:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,116,103,97,109,109,97,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,103,97,109,109,97            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 181                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xf95:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf9b:0x1f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,116,114,117,110,99,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,114,117,110,99               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 183                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xfb4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xfba:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,99,111,115                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 54                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xfc8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xfce:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,115,105,110                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 56                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xfdc:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xfe2:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,116,97,110                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0xff0:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xff6:0x1a DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,116,97,110,50                 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 60                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1005:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x100a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1010:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 99,101,105,108                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 178                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x101e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1024:0x13 DW_TAG_subprogram
++; CHECK-NEXT: .b8 99,111,115                       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 63                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1031:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1037:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 99,111,115,104                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 72                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1045:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x104b:0x13 DW_TAG_subprogram
++; CHECK-NEXT: .b8 101,120,112                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 100                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1058:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x105e:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 102,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 181                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x106c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1072:0x15 DW_TAG_subprogram
++; CHECK-NEXT: .b8 102,108,111,111,114              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 184                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1081:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1087:0x19 DW_TAG_subprogram
++; CHECK-NEXT: .b8 102,109,111,100                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 187                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1095:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x109a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10a0:0x1a DW_TAG_subprogram
++; CHECK-NEXT: .b8 102,114,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 103                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x10af:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x10b4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2377                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10ba:0x1a DW_TAG_subprogram
++; CHECK-NEXT: .b8 108,100,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 106                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x10c9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x10ce:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10d4:0x13 DW_TAG_subprogram
++; CHECK-NEXT: .b8 108,111,103                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 109                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x10e1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10e7:0x15 DW_TAG_subprogram
++; CHECK-NEXT: .b8 108,111,103,49,48                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 112                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x10f6:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10fc:0x19 DW_TAG_subprogram
++; CHECK-NEXT: .b8 109,111,100,102                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 115                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x110a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x110f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4373                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x1115:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x111a:0x18 DW_TAG_subprogram
++; CHECK-NEXT: .b8 112,111,119                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 153                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1127:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x112c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1132:0x13 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,105,110                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 65                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x113f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1145:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,105,110,104                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1153:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1159:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,113,114,116                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 156                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1167:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x116d:0x13 DW_TAG_subprogram
++; CHECK-NEXT: .b8 116,97,110                       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 67                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x117a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1180:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 116,97,110,104                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 76                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x118e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x1194:0xd DW_TAG_typedef
++; CHECK-NEXT: .b32 4513                            // DW_AT_type
++; CHECK-NEXT: .b8 100,105,118,95,116               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 101                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 12                               // Abbrev [12] 0x11a1:0x2 DW_TAG_structure_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x11a3:0xe DW_TAG_typedef
++; CHECK-NEXT: .b32 4529                            // DW_AT_type
++; CHECK-NEXT: .b8 108,100,105,118,95,116           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 109                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 13                               // Abbrev [13] 0x11b1:0x22 DW_TAG_structure_type
++; CHECK-NEXT: .b8 16                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x11b5:0xf DW_TAG_member
++; CHECK-NEXT: .b8 113,117,111,116                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 107                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x11c4:0xe DW_TAG_member
++; CHECK-NEXT: .b8 114,101,109                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 108                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 8
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 15                               // Abbrev [15] 0x11d3:0xd DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,98,111,114,116                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 1                                // DW_AT_noreturn
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x11e0:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,98,115                        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x11ee:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x11f4:0x17 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,116,101,120,105,116           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1205:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4619                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x120b:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 4624                            // DW_AT_type
++; CHECK-NEXT: .b8 17                               // Abbrev [17] 0x1210:0x1 DW_TAG_subroutine_type
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1211:0x14 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,116,111,102                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 6                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 26                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x121f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1225:0x15 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,116,111,105                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 22                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1234:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x123a:0x15 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,116,111,108                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 27                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1249:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x124f:0x2b DW_TAG_subprogram
++; CHECK-NEXT: .b8 98,115,101,97,114,99,104         // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 7                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 20                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 4730                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1260:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4731                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1265:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4731                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x126a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x126f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1274:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4772                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 18                               // Abbrev [18] 0x127a:0x1 DW_TAG_pointer_type
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x127b:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 4736                            // DW_AT_type
++; CHECK-NEXT: .b8 19                               // Abbrev [19] 0x1280:0x1 DW_TAG_const_type
++; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x1281:0xe DW_TAG_typedef
++; CHECK-NEXT: .b32 4751                            // DW_AT_type
++; CHECK-NEXT: .b8 115,105,122,101,95,116           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 8                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 62                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x128f:0x15 DW_TAG_base_type
++; CHECK-NEXT: .b8 108,111,110,103,32,117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 7                                // DW_AT_encoding
++; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 20                               // Abbrev [20] 0x12a4:0x16 DW_TAG_typedef
++; CHECK-NEXT: .b32 4794                            // DW_AT_type
++; CHECK-NEXT: .b8 95,95,99,111,109,112,97,114,95,102,110,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 230                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x12ba:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 4799                            // DW_AT_type
++; CHECK-NEXT: .b8 21                               // Abbrev [21] 0x12bf:0x10 DW_TAG_subroutine_type
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x12c4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4731                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x12c9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4731                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x12cf:0x1c DW_TAG_subprogram
++; CHECK-NEXT: .b8 99,97,108,108,111,99             // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 212                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4730                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x12e0:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x12e5:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x12eb:0x19 DW_TAG_subprogram
++; CHECK-NEXT: .b8 100,105,118                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 21                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 4500                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x12f9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x12fe:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 22                               // Abbrev [22] 0x1304:0x12 DW_TAG_subprogram
++; CHECK-NEXT: .b8 101,120,105,116                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 31                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 1                                // DW_AT_noreturn
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1310:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x1316:0x11 DW_TAG_subprogram
++; CHECK-NEXT: .b8 102,114,101,101                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 227                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1321:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4730                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1327:0x17 DW_TAG_subprogram
++; CHECK-NEXT: .b8 103,101,116,101,110,118          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 52                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 4926                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1338:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x133e:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 3399                            // DW_AT_type
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1343:0x15 DW_TAG_subprogram
++; CHECK-NEXT: .b8 108,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 8                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1352:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1358:0x1a DW_TAG_subprogram
++; CHECK-NEXT: .b8 108,100,105,118                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 23                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 4515                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1367:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x136c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1372:0x17 DW_TAG_subprogram
++; CHECK-NEXT: .b8 109,97,108,108,111,99            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 210                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4730                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1383:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1389:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 109,98,108,101,110               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 95                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1399:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x139e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x13a4:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 109,98,115,116,111,119,99,115    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 106                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x13b7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5063                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x13bc:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x13c1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x13c7:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 5068                            // DW_AT_type
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x13cc:0xb DW_TAG_base_type
++; CHECK-NEXT: .b8 119,99,104,97,114,95,116         // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x13d7:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 109,98,116,111,119,99            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 98                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x13e8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5063                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x13ed:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x13f2:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x13f8:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 113,115,111,114,116              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 253                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1404:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4730                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1409:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x140e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1413:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4772                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 24                               // Abbrev [24] 0x1419:0xf DW_TAG_subprogram
++; CHECK-NEXT: .b8 114,97,110,100                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 118                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1428:0x1d DW_TAG_subprogram
++; CHECK-NEXT: .b8 114,101,97,108,108,111,99        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 224                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 4730                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x143a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4730                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x143f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x1445:0x12 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,114,97,110,100               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 120                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1451:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x1457:0x10 DW_TAG_base_type
++; CHECK-NEXT: .b8 117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 7                                // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1467:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,116,114,116,111,100          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 164                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 3379                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1477:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x147c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5250                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x1482:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 4926                            // DW_AT_type
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1487:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,116,114,116,111,108          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 183                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1497:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x149c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5250                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14a1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x14a7:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,116,114,116,111,117,108      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 187                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 4751                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14b8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14bd:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5250                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14c2:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x14c8:0x17 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,121,115,116,101,109          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 205                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14d9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x14df:0x23 DW_TAG_subprogram
++; CHECK-NEXT: .b8 119,99,115,116,111,109,98,115    // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 109                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14f2:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4926                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14f7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5378                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x14fc:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4737                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x1502:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 5383                            // DW_AT_type
++; CHECK-NEXT: .b8 9                                // Abbrev [9] 0x1507:0x5 DW_TAG_const_type
++; CHECK-NEXT: .b32 5068                            // DW_AT_type
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x150c:0x1c DW_TAG_subprogram
++; CHECK-NEXT: .b8 119,99,116,111,109,98            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 102                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x151d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 4926                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1522:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5068                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x1528:0x78 DW_TAG_namespace
++; CHECK-NEXT: .b8 95,95,103,110,117,95,99,120,120  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1533:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 201                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5536                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x153a:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 207                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5585                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1541:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 211                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5604                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1548:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 217                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5626                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x154f:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 228                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5653                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1556:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 229                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5675                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x155d:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 230                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5708                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1564:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 232                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5768                            // DW_AT_import
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x156b:0x7 DW_TAG_imported_declaration
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 233                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5795                            // DW_AT_import
++; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x1572:0x2d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,57,95,95,103,110,117,95,99,120,120,51,100,105,118,69,120,120 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 100,105,118                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 214                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5536                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1594:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1599:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x15a0:0xf DW_TAG_typedef
++; CHECK-NEXT: .b32 5551                            // DW_AT_type
++; CHECK-NEXT: .b8 108,108,100,105,118,95,116       // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 121                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 13                               // Abbrev [13] 0x15af:0x22 DW_TAG_structure_type
++; CHECK-NEXT: .b8 16                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 117                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x15b3:0xf DW_TAG_member
++; CHECK-NEXT: .b8 113,117,111,116                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 119                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x15c2:0xe DW_TAG_member
++; CHECK-NEXT: .b8 114,101,109                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 120                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 8
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 22                               // Abbrev [22] 0x15d1:0x13 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,69,120,105,116                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 45                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 1                                // DW_AT_noreturn
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x15de:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x15e4:0x16 DW_TAG_subprogram
++; CHECK-NEXT: .b8 108,108,97,98,115                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x15f4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x15fa:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 108,108,100,105,118              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 29                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 5536                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x160a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x160f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1615:0x16 DW_TAG_subprogram
++; CHECK-NEXT: .b8 97,116,111,108,108               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 36                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1625:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x162b:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,116,114,116,111,108,108      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 209                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x163c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1641:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5250                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1646:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x164c:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,116,114,116,111,117,108,108  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 214                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5742                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x165e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1663:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5250                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1668:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x166e:0x1a DW_TAG_base_type
++; CHECK-NEXT: .b8 108,111,110,103,32,108,111,110,103,32,117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 7                                // DW_AT_encoding
++; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1688:0x1b DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,116,114,116,111,102          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 172                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1698:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x169d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5250                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x16a3:0x1c DW_TAG_subprogram
++; CHECK-NEXT: .b8 115,116,114,116,111,108,100      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 175                              // DW_AT_decl_line
++; CHECK-NEXT: .b32 5823                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x16b4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3389                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x16b9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5250                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x16bf:0xf DW_TAG_base_type
++; CHECK-NEXT: .b8 108,111,110,103,32,100,111,117,98,108,101 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_encoding
++; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x16ce:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,97,99,111,115,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,99,111,115,102                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 62                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x16e8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x16ee:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,97,99,111,115,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,99,111,115,104,102            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x170a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1710:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,97,115,105,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,115,105,110,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 57                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x172a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1730:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,97,115,105,110,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,115,105,110,104,102           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 95                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x174c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1752:0x28 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,97,116,97,110,50,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,116,97,110,50,102             // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 47                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x176f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1774:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x177a:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,97,116,97,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,116,97,110,102                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 52                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1794:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x179a:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,97,116,97,110,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 97,116,97,110,104,102            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 100                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x17b6:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x17bc:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,99,98,114,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,98,114,116,102                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 150                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x17d6:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x17dc:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,99,101,105,108,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,101,105,108,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 155                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x17f6:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x17fc:0x2e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,57,99,111,112,121,115,105,103,110,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,111,112,121,115,105,103,110,102 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 165                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x181f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1824:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x182a:0x1e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,99,111,115,102,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,111,115,102                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 219                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1842:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1848:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,99,111,115,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99,111,115,104,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 32                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1862:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1868:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,101,114,102,99,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,114,102,99,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 210                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1882:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1888:0x1e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,101,114,102,102,102  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,114,102,102                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 200                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x18a0:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x18a6:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,101,120,112,50,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,120,112,50,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 145                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x18c0:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x18c6:0x1e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,101,120,112,102,102  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,120,112,102                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x18de:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x18e4:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,101,120,112,109,49,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101,120,112,109,49,102           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1900:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1906:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,102,97,98,115,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,97,98,115,102                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 95                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1920:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1926:0x26 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,102,100,105,109,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,100,105,109,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 80                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1941:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1946:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x194c:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,102,108,111,111,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,108,111,111,114,102          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1968:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x196e:0x2a DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,102,109,97,102,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,97,102                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 32                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1988:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x198d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1992:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1998:0x26 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,102,109,97,120,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,97,120,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 110                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x19b3:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x19b8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x19be:0x26 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,102,109,105,110,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,105,110,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x19d9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x19de:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x19e4:0x26 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,102,109,111,100,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,109,111,100,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 17                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x19ff:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a04:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a0a:0x29 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,102,114,101,120,112,102,102,80,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102,114,101,120,112,102          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a28:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a2d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2377                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a33:0x28 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,104,121,112,111,116,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 104,121,112,111,116,102          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 110                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a50:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a55:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a5b:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,105,108,111,103,98,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 105,108,111,103,98,102           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a77:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a7d:0x28 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,108,100,101,120,112,102,102,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,100,101,120,112,102          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 240                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a9a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1a9f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1aa5:0x24 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,108,103,97,109,109,97,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,103,97,109,109,97,102        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 235                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1ac3:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1ac9:0x24 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,108,108,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,108,114,105,110,116,102      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 125                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1ae7:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1aed:0x26 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,56,108,108,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,108,114,111,117,110,100,102  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 66                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1508                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1b0d:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b13:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,108,111,103,49,48,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,49,48,102            // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 76                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1b2f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b35:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,108,111,103,49,112,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,49,112,102           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1b51:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b57:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,108,111,103,50,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,50,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1b71:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b77:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,108,111,103,98,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,98,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1b91:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b97:0x1e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,108,111,103,102,102  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,111,103,102                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 67                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1baf:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1bb5:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,108,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,114,105,110,116,102          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 116                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1bd1:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1bd7:0x24 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,108,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108,114,111,117,110,100,102      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 71                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1bf5:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1bfb:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,109,111,100,102,102,102,80,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 109,111,100,102,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1c17:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1c1c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 3345                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1c22:0x2b DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,48,110,101,97,114,98,121,105,110,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 110,101,97,114,98,121,105,110,116,102 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 130                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1c47:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1c4d:0x31 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,48,110,101,120,116,97,102,116,101,114,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 110,101,120,116,97,102,116,101,114,102 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 194                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1c73:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1c78:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1c7e:0x24 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,112,111,119,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 112,111,119,102                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 47                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1c97:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1c9c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1ca2:0x31 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,49,48,114,101,109,97,105,110,100,101,114,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,101,109,97,105,110,100,101,114,102 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 22                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1cc8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1ccd:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1cd3:0x31 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,114,101,109,113,117,111,102,102,102,80,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,101,109,113,117,111,102      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 27                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1cf4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1cf9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1cfe:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2377                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d04:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,105,110,116,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 111                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1d1e:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d24:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,111,117,110,100,102          // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 61                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1d40:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d46:0x2c DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,56,115,99,97,108,98,108,110,102,102,108 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,99,97,108,98,108,110,102     // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 250                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1d67:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1d6c:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2917                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d72:0x2a DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,115,99,97,108,98,110,102,102,105 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,99,97,108,98,110,102         // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 245                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1d91:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1d96:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d9c:0x1e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,115,105,110,102,102  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,105,110,102                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 210                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1db4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1dba:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,115,105,110,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,105,110,104,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 37                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1dd4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1dda:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,115,113,114,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,113,114,116,102              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 139                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1df4:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1dfa:0x1e DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,52,116,97,110,102,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,97,110,102                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 252                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1e12:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1e18:0x20 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,53,116,97,110,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,97,110,104,102               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 42                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 5
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1e32:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1e38:0x24 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,55,116,103,97,109,109,97,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,103,97,109,109,97,102        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 56                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 6
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1e56:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1e5c:0x22 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,76,54,116,114,117,110,99,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,114,117,110,99,102           // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 150                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x1e78:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x1e7e:0x22a DW_TAG_structure_type
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 77                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x1e9c:0x4f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,120,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 78                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x1eeb:0x4f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,121,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 79                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x1f3a:0x4f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,122,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 80                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x1f89:0x49 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,99,118,53,117,105,110,116,51,69 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 83                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 8360                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x1fcb:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 8407                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x1fd2:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x1ff2:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 8417                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x1ff9:0x2c DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x2019:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 8417                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x201f:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 8422                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 31                               // Abbrev [31] 0x2025:0x43 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x205c:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 8407                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x2062:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 8422                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 32                               // Abbrev [32] 0x2068:0x3f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 8427                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x20a0:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 8407                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x20a8:0x2f DW_TAG_structure_type
++; CHECK-NEXT: .b8 117,105,110,116,51               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 190                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x20b2:0xc DW_TAG_member
++; CHECK-NEXT: .b8 120                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 192                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x20be:0xc DW_TAG_member
++; CHECK-NEXT: .b8 121                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 192                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x20ca:0xc DW_TAG_member
++; CHECK-NEXT: .b8 122                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 192                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 8
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x20d7:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 8412                            // DW_AT_type
++; CHECK-NEXT: .b8 9                                // Abbrev [9] 0x20dc:0x5 DW_TAG_const_type
++; CHECK-NEXT: .b32 7806                            // DW_AT_type
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x20e1:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 7806                            // DW_AT_type
++; CHECK-NEXT: .b8 33                               // Abbrev [33] 0x20e6:0x5 DW_TAG_reference_type
++; CHECK-NEXT: .b32 8412                            // DW_AT_type
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x20eb:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 7806                            // DW_AT_type
++; CHECK-NEXT: .b8 34                               // Abbrev [34] 0x20f0:0x6 DW_TAG_subprogram
++; CHECK-NEXT: .b32 7836                            // DW_AT_specification
++; CHECK-NEXT: .b8 1                                // DW_AT_inline
++; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x20f6:0x228 DW_TAG_structure_type
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 88                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x2114:0x4f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,120,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 89                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x2163:0x4f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,121,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x21b2:0x4f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,122,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 91                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x2201:0x47 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,99,118,52,100,105,109,51,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,100,105,109,51 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 94                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 8990                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x2241:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9166                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x2248:0x27 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x2268:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9176                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x226f:0x2c DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x228f:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9176                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x2295:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9181                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 31                               // Abbrev [31] 0x229b:0x43 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x22d2:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9166                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x22d8:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9181                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 32                               // Abbrev [32] 0x22de:0x3f DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 9186                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x2316:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9166                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 35                               // Abbrev [35] 0x231e:0x9d DW_TAG_structure_type
++; CHECK-NEXT: .b8 100,105,109,51                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 161                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 36                               // Abbrev [36] 0x2328:0xd DW_TAG_member
++; CHECK-NEXT: .b8 120                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 163                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 36                               // Abbrev [36] 0x2335:0xd DW_TAG_member
++; CHECK-NEXT: .b8 121                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 163                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 4
++; CHECK-NEXT: .b8 36                               // Abbrev [36] 0x2342:0xd DW_TAG_member
++; CHECK-NEXT: .b8 122                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 163                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
++; CHECK-NEXT: .b8 35
++; CHECK-NEXT: .b8 8
++; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x234f:0x21 DW_TAG_subprogram
++; CHECK-NEXT: .b8 100,105,109,51                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 165                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x235a:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9147                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x2360:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x2365:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x236a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x2370:0x17 DW_TAG_subprogram
++; CHECK-NEXT: .b8 100,105,109,51                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 166                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x237b:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9147                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x2381:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9152                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 37                               // Abbrev [37] 0x2387:0x33 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,52,100,105,109,51,99,118,53,117,105,110,116,51,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 167                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b32 9152                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x23b3:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9147                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x23bb:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 8990                            // DW_AT_type
++; CHECK-NEXT: .b8 20                               // Abbrev [20] 0x23c0:0xe DW_TAG_typedef
++; CHECK-NEXT: .b32 8360                            // DW_AT_type
++; CHECK-NEXT: .b8 117,105,110,116,51               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 127                              // DW_AT_decl_line
++; CHECK-NEXT: .b8 1
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x23ce:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 9171                            // DW_AT_type
++; CHECK-NEXT: .b8 9                                // Abbrev [9] 0x23d3:0x5 DW_TAG_const_type
++; CHECK-NEXT: .b32 8438                            // DW_AT_type
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x23d8:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 8438                            // DW_AT_type
++; CHECK-NEXT: .b8 33                               // Abbrev [33] 0x23dd:0x5 DW_TAG_reference_type
++; CHECK-NEXT: .b32 9171                            // DW_AT_type
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x23e2:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 8438                            // DW_AT_type
++; CHECK-NEXT: .b8 34                               // Abbrev [34] 0x23e7:0x6 DW_TAG_subprogram
++; CHECK-NEXT: .b32 8468                            // DW_AT_specification
++; CHECK-NEXT: .b8 1                                // DW_AT_inline
++; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x23ed:0x233 DW_TAG_structure_type
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 66                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x240c:0x50 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95,98,117,105,108,116,105,110,95,120,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 67                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x245c:0x50 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95,98,117,105,108,116,105,110,95,121,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 68                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x24ac:0x50 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95,98,117,105,108,116,105,110,95,122,69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 69                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 5207                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x24fc:0x4a DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,99,118,53,117,105,110,116,51 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 69,118
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 72                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 8360                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x253f:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9760                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x2546:0x28 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x2567:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9770                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x256e:0x2d DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x258f:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9770                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x2595:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9775                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 31                               // Abbrev [31] 0x259b:0x44 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x25d3:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9760                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x25d9:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9775                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 32                               // Abbrev [32] 0x25df:0x40 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
++; CHECK-NEXT: .b32 9780                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 3                                // DW_AT_accessibility
++; CHECK-NEXT:                                      // DW_ACCESS_private
++; CHECK-NEXT: .b8 29                               // Abbrev [29] 0x2618:0x6 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9760                            // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_artificial
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x2620:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 9765                            // DW_AT_type
++; CHECK-NEXT: .b8 9                                // Abbrev [9] 0x2625:0x5 DW_TAG_const_type
++; CHECK-NEXT: .b32 9197                            // DW_AT_type
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x262a:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 9197                            // DW_AT_type
++; CHECK-NEXT: .b8 33                               // Abbrev [33] 0x262f:0x5 DW_TAG_reference_type
++; CHECK-NEXT: .b32 9765                            // DW_AT_type
++; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x2634:0x5 DW_TAG_pointer_type
++; CHECK-NEXT: .b32 9197                            // DW_AT_type
++; CHECK-NEXT: .b8 34                               // Abbrev [34] 0x2639:0x6 DW_TAG_subprogram
++; CHECK-NEXT: .b32 9228                            // DW_AT_specification
++; CHECK-NEXT: .b8 1                                // DW_AT_inline
++; CHECK-NEXT: .b8 38                               // Abbrev [38] 0x263f:0x32 DW_TAG_subprogram
++; CHECK-NEXT: .b8 95,90,51,114,101,115,102,102,80,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114,101,115                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 1                                // DW_AT_inline
++; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x2653:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 120                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x265c:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 121                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x2665:0xb DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 114,101,115                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 3345                            // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 40                               // Abbrev [40] 0x2671:0xc0 DW_TAG_subprogram
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
++; CHECK-NEXT: .b8 156
++; CHECK-NEXT: .b8 95,90,53,115,97,120,112,121,105,102,80,102,83,95 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115,97,120,112,121               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x269c:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 110                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x26a5:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 1554                            // DW_AT_type
++; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x26ae:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 120                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 3345                            // DW_AT_type
++; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x26b7:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 121                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 3345                            // DW_AT_type
++; CHECK-NEXT: .b8 41                               // Abbrev [41] 0x26c0:0x9 DW_TAG_variable
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 6                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 2332                            // DW_AT_type
++; CHECK-NEXT: .b8 42                               // Abbrev [42] 0x26c9:0x17 DW_TAG_inlined_subroutine
++; CHECK-NEXT: .b32 8432                            // DW_AT_abstract_origin
++; CHECK-NEXT: .b64 Ltmp0                           // DW_AT_low_pc
++; CHECK-NEXT: .b64 Ltmp1                           // DW_AT_high_pc
++; CHECK-NEXT: .b8 12                               // DW_AT_call_file
++; CHECK-NEXT: .b8 6                                // DW_AT_call_line
++; CHECK-NEXT: .b8 42                               // Abbrev [42] 0x26e0:0x17 DW_TAG_inlined_subroutine
++; CHECK-NEXT: .b32 9191                            // DW_AT_abstract_origin
++; CHECK-NEXT: .b64 Ltmp1                           // DW_AT_low_pc
++; CHECK-NEXT: .b64 Ltmp2                           // DW_AT_high_pc
++; CHECK-NEXT: .b8 12                               // DW_AT_call_file
++; CHECK-NEXT: .b8 6                                // DW_AT_call_line
++; CHECK-NEXT: .b8 42                               // Abbrev [42] 0x26f7:0x17 DW_TAG_inlined_subroutine
++; CHECK-NEXT: .b32 9785                            // DW_AT_abstract_origin
++; CHECK-NEXT: .b64 Ltmp2                           // DW_AT_low_pc
++; CHECK-NEXT: .b64 Ltmp3                           // DW_AT_high_pc
++; CHECK-NEXT: .b8 12                               // DW_AT_call_file
++; CHECK-NEXT: .b8 6                                // DW_AT_call_line
++; CHECK-NEXT: .b8 43                               // Abbrev [43] 0x270e:0x22 DW_TAG_inlined_subroutine
++; CHECK-NEXT: .b32 9791                            // DW_AT_abstract_origin
++; CHECK-NEXT: .b64 Ltmp8                           // DW_AT_low_pc
++; CHECK-NEXT: .b64 Ltmp9                           // DW_AT_high_pc
++; CHECK-NEXT: .b8 12                               // DW_AT_call_file
++; CHECK-NEXT: .b8 8                                // DW_AT_call_line
++; CHECK-NEXT: .b8 44                               // Abbrev [44] 0x2725:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9811                            // DW_AT_abstract_origin
++; CHECK-NEXT: .b8 44                               // Abbrev [44] 0x272a:0x5 DW_TAG_formal_parameter
++; CHECK-NEXT: .b32 9820                            // DW_AT_abstract_origin
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_macinfo
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 0                                // End Of Macro List Mark
++; CHECK:      }
+ 
+ ; Function Attrs: nounwind readnone
+ declare i32 @llvm.nvvm.read.ptx.sreg.ctaid.x() #1
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll b/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
+index 72ed6c1cc2f..e1366b970ca 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
+@@ -1,6 +1,6 @@
+ ; RUN: llc -mtriple=nvptx64-nvidia-cuda < %s | FileCheck %s
+ 
+-; CHECK: .target sm_{{[0-9]+}}//, debug
++; CHECK: .target sm_{{[0-9]+}}, debug
+ 
+ ; CHECK: .extern .func  (.param .b32 func_retval0) _ZN1A3fooEv
+ ; CHECK: (
+@@ -129,207 +129,207 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ !33 = !DILocation(line: 11, scope: !32)
+ !34 = !DILocation(line: 12, scope: !14)
+ 
+-; CHECK: // .section .debug_abbrev
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 1                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 17                               // DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 37                               // DW_AT_producer
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 19                               // DW_AT_language
+-; CHECK-NEXT: // .b8 5                                // DW_FORM_data2
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 16                               // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 6                                // DW_FORM_data4
+-; CHECK-NEXT: // .b8 27                               // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 2                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 19                               // DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 60                               // DW_AT_declaration
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 3                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 64                               // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 4                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 52                               // DW_TAG_variable
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 16                               // DW_FORM_ref_addr
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 5                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 46                               // DW_TAG_subprogram
+-; CHECK-NEXT: // .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: // .b8 17                               // DW_AT_low_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 18                               // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_FORM_addr
+-; CHECK-NEXT: // .b8 64                               // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: // .b8 135,64                           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 63                               // DW_AT_external
+-; CHECK-NEXT: // .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 6                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 5                                // DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 58                               // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 59                               // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 73                               // DW_AT_type
+-; CHECK-NEXT: // .b8 19                               // DW_FORM_ref4
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 7                                // Abbreviation Code
+-; CHECK-NEXT: // .b8 36                               // DW_TAG_base_type
+-; CHECK-NEXT: // .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: // .b8 3                                // DW_AT_name
+-; CHECK-NEXT: // .b8 8                                // DW_FORM_string
+-; CHECK-NEXT: // .b8 62                               // DW_AT_encoding
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 11                               // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 11                               // DW_FORM_data1
+-; CHECK-NEXT: // .b8 0                                // EOM(1)
+-; CHECK-NEXT: // .b8 0                                // EOM(2)
+-; CHECK-NEXT: // .b8 0                                // EOM(3)
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_info
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b32 150                             // Length of Unit
+-; CHECK-NEXT: // .b8 2                                // DWARF version number
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+-; CHECK-NEXT: // .b8 8                                // Address Size (in bytes)
+-; CHECK-NEXT: // .b8 1                                // Abbrev [1] 0xb:0x8f DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,50,49,48,52,55,57,41 // DW_AT_producer
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_language
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 100,101,98,117,103,45,108,111,99,45,111,102,102,115,101,116,50,46,99,99 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 47,108,108,118,109,95,99,109,97,107,101,95,103,99,99 // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b64 Lfunc_begin1                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end1                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 2                                // Abbrev [2] 0x64:0x4 DW_TAG_structure_type
+-; CHECK-NEXT: // .b8 65                               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_declaration
+-; CHECK-NEXT: // .b8 3                                // Abbrev [3] 0x68:0x31 DW_TAG_subprogram
+-; CHECK-NEXT: // .b64 Lfunc_begin1                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end1                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 156
+-; CHECK-NEXT: // .b8 95,90,51,98,97,122,49,65         // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 98,97,122                        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 6                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 4                                // Abbrev [4] 0x8b:0xd DW_TAG_variable
+-; CHECK-NEXT: // .b8 122                              // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 2                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 7                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b64 .debug_info+302                 // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b32 152                             // Length of Unit
+-; CHECK-NEXT: // .b8 2                                // DWARF version number
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+-; CHECK-NEXT: // .b8 8                                // Address Size (in bytes)
+-; CHECK-NEXT: // .b8 1                                // Abbrev [1] 0xb:0x91 DW_TAG_compile_unit
+-; CHECK-NEXT: // .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,50,49,48,52,55,57,41 // DW_AT_producer
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 4                                // DW_AT_language
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 100,101,98,117,103,45,108,111,99,45,111,102,102,115,101,116,49,46,99,99 // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: // .b8 47,108,108,118,109,95,99,109,97,107,101,95,103,99,99 // DW_AT_comp_dir
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 5                                // Abbrev [5] 0x64:0x30 DW_TAG_subprogram
+-; CHECK-NEXT: // .b64 Lfunc_begin0                    // DW_AT_low_pc
+-; CHECK-NEXT: // .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: // .b8 1                                // DW_AT_frame_base
+-; CHECK-NEXT: // .b8 156
+-; CHECK-NEXT: // .b8 95,90,51,98,97,114,105           // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 98,97,114                        // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 148                             // DW_AT_type
+-; CHECK-NEXT: // .b8 1                                // DW_AT_external
+-; CHECK-NEXT: // .b8 6                                // Abbrev [6] 0x8a:0x9 DW_TAG_formal_parameter
+-; CHECK-NEXT: // .b8 98                               // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_file
+-; CHECK-NEXT: // .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: // .b32 148                             // DW_AT_type
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // .b8 7                                // Abbrev [7] 0x94:0x7 DW_TAG_base_type
+-; CHECK-NEXT: // .b8 105,110,116                      // DW_AT_name
+-; CHECK-NEXT: // .b8 0
+-; CHECK-NEXT: // .b8 5                                // DW_AT_encoding
+-; CHECK-NEXT: // .b8 4                                // DW_AT_byte_size
+-; CHECK-NEXT: // .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: // }
+-; CHECK-NEXT: // .section .debug_macinfo
+-; CHECK-NEXT: // {
+-; CHECK-NEXT: // .b8 0                                // End Of Macro List Mark
+-; CHECK:      // }
++; CHECK: .section .debug_abbrev
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 1                                // Abbreviation Code
++; CHECK-NEXT: .b8 17                               // DW_TAG_compile_unit
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 37                               // DW_AT_producer
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 19                               // DW_AT_language
++; CHECK-NEXT: .b8 5                                // DW_FORM_data2
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 16                               // DW_AT_stmt_list
++; CHECK-NEXT: .b8 6                                // DW_FORM_data4
++; CHECK-NEXT: .b8 27                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 2                                // Abbreviation Code
++; CHECK-NEXT: .b8 19                               // DW_TAG_structure_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 60                               // DW_AT_declaration
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 3                                // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 4                                // Abbreviation Code
++; CHECK-NEXT: .b8 52                               // DW_TAG_variable
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 16                               // DW_FORM_ref_addr
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 5                                // Abbreviation Code
++; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 17                               // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 18                               // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_FORM_addr
++; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
++; CHECK-NEXT: .b8 10                               // DW_FORM_block1
++; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 63                               // DW_AT_external
++; CHECK-NEXT: .b8 12                               // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 6                                // Abbreviation Code
++; CHECK-NEXT: .b8 5                                // DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 58                               // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 59                               // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 73                               // DW_AT_type
++; CHECK-NEXT: .b8 19                               // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 7                                // Abbreviation Code
++; CHECK-NEXT: .b8 36                               // DW_TAG_base_type
++; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                // DW_AT_name
++; CHECK-NEXT: .b8 8                                // DW_FORM_string
++; CHECK-NEXT: .b8 62                               // DW_AT_encoding
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 11                               // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                // EOM(1)
++; CHECK-NEXT: .b8 0                                // EOM(2)
++; CHECK-NEXT: .b8 0                                // EOM(3)
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_info
++; CHECK-NEXT: {
++; CHECK-NEXT: .b32 150                             // Length of Unit
++; CHECK-NEXT: .b8 2                                // DWARF version number
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
++; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
++; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x8f DW_TAG_compile_unit
++; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,50,49,48,52,55,57,41 // DW_AT_producer
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_language
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 100,101,98,117,103,45,108,111,99,45,111,102,102,115,101,116,50,46,99,99 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
++; CHECK-NEXT: .b8 47,108,108,118,109,95,99,109,97,107,101,95,103,99,99 // DW_AT_comp_dir
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b64 Lfunc_begin1                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end1                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x64:0x4 DW_TAG_structure_type
++; CHECK-NEXT: .b8 65                               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_declaration
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x68:0x31 DW_TAG_subprogram
++; CHECK-NEXT: .b64 Lfunc_begin1                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end1                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
++; CHECK-NEXT: .b8 156
++; CHECK-NEXT: .b8 95,90,51,98,97,122,49,65         // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 98,97,122                        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 6                                // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x8b:0xd DW_TAG_variable
++; CHECK-NEXT: .b8 122                              // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
++; CHECK-NEXT: .b64 .debug_info+302                 // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b32 152                             // Length of Unit
++; CHECK-NEXT: .b8 2                                // DWARF version number
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
++; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
++; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x91 DW_TAG_compile_unit
++; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,50,49,48,52,55,57,41 // DW_AT_producer
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                // DW_AT_language
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 100,101,98,117,103,45,108,111,99,45,111,102,102,115,101,116,49,46,99,99 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
++; CHECK-NEXT: .b8 47,108,108,118,109,95,99,109,97,107,101,95,103,99,99 // DW_AT_comp_dir
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x64:0x30 DW_TAG_subprogram
++; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
++; CHECK-NEXT: .b8 156
++; CHECK-NEXT: .b8 95,90,51,98,97,114,105           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 98,97,114                        // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 148                             // DW_AT_type
++; CHECK-NEXT: .b8 1                                // DW_AT_external
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x8a:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
++; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
++; CHECK-NEXT: .b32 148                             // DW_AT_type
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x94:0x7 DW_TAG_base_type
++; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
++; CHECK-NEXT: .b8 0                                // End Of Children Mark
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_macinfo
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 0                                // End Of Macro List Mark
++; CHECK:      }
+-- 
+2.22.0
+

--- a/deps/patches/llvm-nvptx-debugloc.patch
+++ b/deps/patches/llvm-nvptx-debugloc.patch
@@ -1,0 +1,59 @@
+From 0f37ab35afdee0fa4a105ac587c2a7eeb70bdbab Mon Sep 17 00:00:00 2001
+From: Alexey Bataev <a.bataev@hotmail.com>
+Date: Fri, 8 Mar 2019 20:08:04 +0000
+Subject: [PATCH 4/5] [DEBUG_INFO][NVPTX]Emit empty .debug_loc section in
+ presence of the debug option.
+
+Summary:
+If the LLVM module shows that it has debug info, but the file is
+actually empty and the real debug info is not emitted, the ptxas tool
+emits error 'Debug information not found in presence of .target debug'.
+We need at leas one empty debug section to silence this message. Section
+`.debug_loc` is not emitted for PTX and we can emit empty `.debug_loc`
+section if `debug` option was emitted.
+
+Reviewers: tra
+
+Subscribers: jholewinski, aprantl, llvm-commits
+
+Differential Revision: https://reviews.llvm.org/D57250
+
+llvm-svn: 355719
+---
+ llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp | 5 ++++-
+ llvm/test/DebugInfo/NVPTX/debug-empty.ll  | 1 +
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+index db91369a524..83095e1adb8 100644
+--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
++++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+@@ -955,9 +955,12 @@ bool NVPTXAsmPrinter::doFinalization(Module &M) {
+ 
+   delete[] gv_array;
+   // Close the last emitted section
+-  if (HasDebugInfo)
++  if (HasDebugInfo) {
+     static_cast<NVPTXTargetStreamer *>(OutStreamer->getTargetStreamer())
+         ->closeLastSection();
++    // Emit empty .debug_loc section for better support of the empty files.
++    OutStreamer->EmitRawText("\t.section\t.debug_loc\t{\t}");
++  }
+ 
+   // Output last DWARF .file directives, if any.
+   static_cast<NVPTXTargetStreamer *>(OutStreamer->getTargetStreamer())
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-empty.ll b/llvm/test/DebugInfo/NVPTX/debug-empty.ll
+index f1ebf739d2f..cae258815e4 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-empty.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-empty.ll
+@@ -1,6 +1,7 @@
+ ; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda | FileCheck %s
+ 
+ ; CHECK: .target sm_{{[0-9]+$}}
++; CHECK: .section .debug_loc { }
+ ; CHECK-NOT: }
+ 
+ !llvm.dbg.cu = !{!0}
+-- 
+2.22.0
+

--- a/deps/patches/llvm-nvptx-dw_at_address_class.patch
+++ b/deps/patches/llvm-nvptx-dw_at_address_class.patch
@@ -1,0 +1,531 @@
+From f6d56f28bf7f94ed348ff00955bdf5e6033ceb1a Mon Sep 17 00:00:00 2001
+From: Alexey Bataev <a.bataev@hotmail.com>
+Date: Tue, 5 Feb 2019 19:33:47 +0000
+Subject: [PATCH 3/5] [DEBUG_INFO][NVPTX] Generate DW_AT_address_class to get
+ the values in debugger.
+
+Summary:
+According to
+https://docs.nvidia.com/cuda/archive/10.0/ptx-writers-guide-to-interoperability/index.html#cuda-specific-dwarf,
+the compiler should emit the DW_AT_address_class attribute for all
+variable and parameter. It means, that DW_AT_address_class attribute
+should be used in the non-standard way to support compatibility with the
+cuda-gdb debugger.
+Clang is able to generate the information about the variable address
+class. This information is emitted as the expression sequence
+`DW_OP_constu <DWARF Address Space> DW_OP_swap DW_OP_xderef`. The patch
+tries to find all such expressions and transform them into
+`DW_AT_address_class <DWARF Address Space>` if target is NVPTX and the debugger is gdb.
+If the expression is not found, then default values are used. For the
+local variables <DWARF Address Space> is set to ADDR_local_space(6), for
+the globals <DWARF Address Space> is set to ADDR_global_space(5). The
+values are taken from the table in the same section 5.2. CUDA-Specific
+DWARF Definitions.
+
+Reviewers: echristo, probinson
+
+Subscribers: jholewinski, aprantl, llvm-commits
+
+Differential Revision: https://reviews.llvm.org/D57157
+
+llvm-svn: 353203
+---
+ llvm/include/llvm/IR/DebugInfoMetadata.h      |   6 +
+ .../CodeGen/AsmPrinter/DwarfCompileUnit.cpp   |  56 +++-
+ llvm/lib/IR/DebugInfoMetadata.cpp             |  18 ++
+ .../DebugInfo/NVPTX/dbg-declare-alloca.ll     |  21 +-
+ llvm/test/DebugInfo/NVPTX/debug-addr-class.ll | 255 ++++++++++++++++++
+ 5 files changed, 345 insertions(+), 11 deletions(-)
+ create mode 100644 llvm/test/DebugInfo/NVPTX/debug-addr-class.ll
+
+diff --git a/llvm/include/llvm/IR/DebugInfoMetadata.h b/llvm/include/llvm/IR/DebugInfoMetadata.h
+index a461d1bd4fe..7b8e0776704 100644
+--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
++++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
+@@ -2511,6 +2511,12 @@ public:
+   /// return true with an offset of zero.
+   bool extractIfOffset(int64_t &Offset) const;
+ 
++  /// Checks if the last 4 elements of the expression are DW_OP_constu <DWARF
++  /// Address Space> DW_OP_swap DW_OP_xderef and extracts the <DWARF Address
++  /// Space>.
++  static const DIExpression *extractAddressClass(const DIExpression *Expr,
++                                                 unsigned &AddrClass);
++
+   /// Constants for DIExpression::prepend.
+   enum { NoDeref = false, WithDeref = true, WithStackValue = true };
+ 
+diff --git a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+index 1dca3f0fce5..c866cd8ebb9 100644
+--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
++++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+@@ -168,6 +168,7 @@ DIE *DwarfCompileUnit::getOrCreateGlobalVariableDIE(
+   // Add location.
+   bool addToAccelTable = false;
+   DIELoc *Loc = nullptr;
++  Optional<unsigned> NVPTXAddressSpace;
+   std::unique_ptr<DIEDwarfExpression> DwarfExpr;
+   for (const auto &GE : GlobalExprs) {
+     const GlobalVariable *Global = GE.Var;
+@@ -201,8 +202,24 @@ DIE *DwarfCompileUnit::getOrCreateGlobalVariableDIE(
+       DwarfExpr = llvm::make_unique<DIEDwarfExpression>(*Asm, *this, *Loc);
+     }
+ 
+-    if (Expr)
++    if (Expr) {
++      // According to
++      // https://docs.nvidia.com/cuda/archive/10.0/ptx-writers-guide-to-interoperability/index.html#cuda-specific-dwarf
++      // cuda-gdb requires DW_AT_address_class for all variables to be able to
++      // correctly interpret address space of the variable address.
++      // Decode DW_OP_constu <DWARF Address Space> DW_OP_swap DW_OP_xderef
++      // sequence for the NVPTX + gdb target.
++      unsigned LocalNVPTXAddressSpace;
++      if (Asm->TM.getTargetTriple().isNVPTX() && DD->tuneForGDB()) {
++        const DIExpression *NewExpr =
++            DIExpression::extractAddressClass(Expr, LocalNVPTXAddressSpace);
++        if (NewExpr != Expr) {
++          Expr = NewExpr;
++          NVPTXAddressSpace = LocalNVPTXAddressSpace;
++        }
++      }
+       DwarfExpr->addFragmentOffset(Expr);
++    }
+ 
+     if (Global) {
+       const MCSymbol *Sym = Asm->getSymbol(Global);
+@@ -247,6 +264,15 @@ DIE *DwarfCompileUnit::getOrCreateGlobalVariableDIE(
+       DwarfExpr->setMemoryLocationKind();
+     DwarfExpr->addExpression(Expr);
+   }
++  if (Asm->TM.getTargetTriple().isNVPTX() && DD->tuneForGDB()) {
++    // According to
++    // https://docs.nvidia.com/cuda/archive/10.0/ptx-writers-guide-to-interoperability/index.html#cuda-specific-dwarf
++    // cuda-gdb requires DW_AT_address_class for all variables to be able to
++    // correctly interpret address space of the variable address.
++    const unsigned NVPTX_ADDR_global_space = 5;
++    addUInt(*VariableDIE, dwarf::DW_AT_address_class, dwarf::DW_FORM_data1,
++            NVPTXAddressSpace ? *NVPTXAddressSpace : NVPTX_ADDR_global_space);
++  }
+   if (Loc)
+     addBlock(*VariableDIE, dwarf::DW_AT_location, DwarfExpr->finalize());
+ 
+@@ -592,6 +618,7 @@ DIE *DwarfCompileUnit::constructVariableDIEImpl(const DbgVariable &DV,
+   if (!DV.hasFrameIndexExprs())
+     return VariableDie;
+ 
++  Optional<unsigned> NVPTXAddressSpace;
+   DIELoc *Loc = new (DIEValueAllocator) DIELoc;
+   DIEDwarfExpression DwarfExpr(*Asm, *this, *Loc);
+   for (auto &Fragment : DV.getFrameIndexExprs()) {
+@@ -603,7 +630,23 @@ DIE *DwarfCompileUnit::constructVariableDIEImpl(const DbgVariable &DV,
+     SmallVector<uint64_t, 8> Ops;
+     Ops.push_back(dwarf::DW_OP_plus_uconst);
+     Ops.push_back(Offset);
+-    Ops.append(Expr->elements_begin(), Expr->elements_end());
++    // According to
++    // https://docs.nvidia.com/cuda/archive/10.0/ptx-writers-guide-to-interoperability/index.html#cuda-specific-dwarf
++    // cuda-gdb requires DW_AT_address_class for all variables to be able to
++    // correctly interpret address space of the variable address.
++    // Decode DW_OP_constu <DWARF Address Space> DW_OP_swap DW_OP_xderef
++    // sequence for the NVPTX + gdb target.
++    unsigned LocalNVPTXAddressSpace;
++    if (Asm->TM.getTargetTriple().isNVPTX() && DD->tuneForGDB()) {
++      const DIExpression *NewExpr =
++          DIExpression::extractAddressClass(Expr, LocalNVPTXAddressSpace);
++      if (NewExpr != Expr) {
++        Expr = NewExpr;
++        NVPTXAddressSpace = LocalNVPTXAddressSpace;
++      }
++    }
++    if (Expr)
++      Ops.append(Expr->elements_begin(), Expr->elements_end());
+     DIExpressionCursor Cursor(Ops);
+     DwarfExpr.setMemoryLocationKind();
+     if (const MCSymbol *FrameSymbol = Asm->getFunctionFrameSymbol())
+@@ -613,6 +656,15 @@ DIE *DwarfCompileUnit::constructVariableDIEImpl(const DbgVariable &DV,
+           *Asm->MF->getSubtarget().getRegisterInfo(), Cursor, FrameReg);
+     DwarfExpr.addExpression(std::move(Cursor));
+   }
++  if (Asm->TM.getTargetTriple().isNVPTX() && DD->tuneForGDB()) {
++    // According to
++    // https://docs.nvidia.com/cuda/archive/10.0/ptx-writers-guide-to-interoperability/index.html#cuda-specific-dwarf
++    // cuda-gdb requires DW_AT_address_class for all variables to be able to
++    // correctly interpret address space of the variable address.
++    const unsigned NVPTX_ADDR_local_space = 6;
++    addUInt(*VariableDie, dwarf::DW_AT_address_class, dwarf::DW_FORM_data1,
++            NVPTXAddressSpace ? *NVPTXAddressSpace : NVPTX_ADDR_local_space);
++  }
+   addBlock(*VariableDie, dwarf::DW_AT_location, DwarfExpr.finalize());
+ 
+   return VariableDie;
+diff --git a/llvm/lib/IR/DebugInfoMetadata.cpp b/llvm/lib/IR/DebugInfoMetadata.cpp
+index 92f3f21f754..7ded2ce32de 100644
+--- a/llvm/lib/IR/DebugInfoMetadata.cpp
++++ b/llvm/lib/IR/DebugInfoMetadata.cpp
+@@ -929,6 +929,24 @@ bool DIExpression::extractIfOffset(int64_t &Offset) const {
+   return false;
+ }
+ 
++const DIExpression *DIExpression::extractAddressClass(const DIExpression *Expr,
++                                                      unsigned &AddrClass) {
++  const unsigned PatternSize = 4;
++  if (Expr->Elements.size() >= PatternSize &&
++      Expr->Elements[PatternSize - 4] == dwarf::DW_OP_constu &&
++      Expr->Elements[PatternSize - 2] == dwarf::DW_OP_swap &&
++      Expr->Elements[PatternSize - 1] == dwarf::DW_OP_xderef) {
++    AddrClass = Expr->Elements[PatternSize - 3];
++
++    if (Expr->Elements.size() == PatternSize)
++      return nullptr;
++    return DIExpression::get(Expr->getContext(),
++                             makeArrayRef(&*Expr->Elements.begin(),
++                                          Expr->Elements.size() - PatternSize));
++  }
++  return Expr;
++}
++
+ DIExpression *DIExpression::prepend(const DIExpression *Expr, bool DerefBefore,
+                                     int64_t Offset, bool DerefAfter,
+                                     bool StackValue) {
+diff --git a/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll b/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
+index ed2fb88e6a2..a6a9826d6c3 100644
+--- a/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
++++ b/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
+@@ -68,6 +68,8 @@
+ ; CHECK-NEXT: .b8 3                                // Abbreviation Code
+ ; CHECK-NEXT: .b8 52                               // DW_TAG_variable
+ ; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
++; CHECK-NEXT: .b8 51                               // DW_AT_address_class
++; CHECK-NEXT: .b8 11                               // DW_FORM_data1
+ ; CHECK-NEXT: .b8 2                                // DW_AT_location
+ ; CHECK-NEXT: .b8 10                               // DW_FORM_block1
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+@@ -123,12 +125,12 @@
+ ; CHECK-NEXT: }
+ ; CHECK-NEXT: .section .debug_info
+ ; CHECK-NEXT: {
+-; CHECK-NEXT: .b32 135                             // Length of Unit
++; CHECK-NEXT: .b32 136                             // Length of Unit
+ ; CHECK-NEXT: .b8 2                                // DWARF version number
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+ ; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
+-; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x80 DW_TAG_compile_unit
++; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x81 DW_TAG_compile_unit
+ ; CHECK-NEXT: .b8 99,108,97,110,103                // DW_AT_producer
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_language
+@@ -140,7 +142,7 @@
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+-; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x31:0x3d DW_TAG_subprogram
++; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x31:0x3e DW_TAG_subprogram
+ ; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
+@@ -151,7 +153,8 @@
+ ; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 1                                // DW_AT_prototyped
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+-; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x58:0x15 DW_TAG_variable
++; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x58:0x16 DW_TAG_variable
++; CHECK-NEXT: .b8 6                                // DW_AT_address_class
+ ; CHECK-NEXT: .b8 11                               // DW_AT_location
+ ; CHECK-NEXT: .b8 3
+ ; CHECK-NEXT: .b64 __local_depot0
+@@ -161,25 +164,25 @@
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_line
+-; CHECK-NEXT: .b32 110                             // DW_AT_type
++; CHECK-NEXT: .b32 111                             // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x6e:0x15 DW_TAG_structure_type
++; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x6f:0x15 DW_TAG_structure_type
+ ; CHECK-NEXT: .b8 70,111,111                       // DW_AT_name
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
+-; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x76:0xc DW_TAG_member
++; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x77:0xc DW_TAG_member
+ ; CHECK-NEXT: .b8 120                              // DW_AT_name
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b32 131                             // DW_AT_type
++; CHECK-NEXT: .b32 132                             // DW_AT_type
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 2                                // DW_AT_data_member_location
+ ; CHECK-NEXT: .b8 35
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+-; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x83:0x7 DW_TAG_base_type
++; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x84:0x7 DW_TAG_base_type
+ ; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-addr-class.ll b/llvm/test/DebugInfo/NVPTX/debug-addr-class.ll
+new file mode 100644
+index 00000000000..3d8460d8247
+--- /dev/null
++++ b/llvm/test/DebugInfo/NVPTX/debug-addr-class.ll
+@@ -0,0 +1,255 @@
++; RUN: llc -mtriple=nvptx64-nvidia-cuda < %s | FileCheck %s
++
++@GLOBAL = addrspace(1) externally_initialized global i32 0, align 4, !dbg !0
++@SHARED = addrspace(3) externally_initialized global i32 undef, align 4, !dbg !6
++
++define void @test(float, float*, float*, i32) !dbg !17 {
++  %5 = alloca float, align 4
++  %6 = alloca float*, align 8
++  %7 = alloca float*, align 8
++  %8 = alloca i32, align 4
++  store float %0, float* %5, align 4
++  call void @llvm.dbg.declare(metadata float* %5, metadata !22, metadata !DIExpression()), !dbg !23
++  store float* %1, float** %6, align 8
++  call void @llvm.dbg.declare(metadata float** %6, metadata !24, metadata !DIExpression()), !dbg !25
++  store float* %2, float** %7, align 8
++  call void @llvm.dbg.declare(metadata float** %7, metadata !26, metadata !DIExpression()), !dbg !27
++  store i32 %3, i32* %8, align 4
++  call void @llvm.dbg.declare(metadata i32* %8, metadata !28, metadata !DIExpression()), !dbg !29
++  %9 = load float, float* %5, align 4, !dbg !30
++  %10 = load float*, float** %6, align 8, !dbg !31
++  %11 = load i32, i32* %8, align 4, !dbg !32
++  %12 = sext i32 %11 to i64, !dbg !31
++  %13 = getelementptr inbounds float, float* %10, i64 %12, !dbg !31
++  %14 = load float, float* %13, align 4, !dbg !31
++  %15 = fmul contract float %9, %14, !dbg !33
++  %16 = load float*, float** %7, align 8, !dbg !34
++  %17 = load i32, i32* %8, align 4, !dbg !35
++  %18 = sext i32 %17 to i64, !dbg !34
++  %19 = getelementptr inbounds float, float* %16, i64 %18, !dbg !34
++  store float %15, float* %19, align 4, !dbg !36
++  store i32 0, i32* addrspacecast (i32 addrspace(1)* @GLOBAL to i32*), align 4, !dbg !37
++  store i32 0, i32* addrspacecast (i32 addrspace(3)* @SHARED to i32*), align 4, !dbg !38
++  ret void, !dbg !39
++}
++
++; Function Attrs: nounwind readnone speculatable
++declare void @llvm.dbg.declare(metadata, metadata, metadata)
++
++!llvm.dbg.cu = !{!2}
++!nvvm.annotations = !{!10}
++!llvm.module.flags = !{!11, !12, !13, !14, !15}
++!llvm.ident = !{!16}
++
++!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
++!1 = distinct !DIGlobalVariable(name: "GLOBAL", scope: !2, file: !8, line: 3, type: !9, isLocal: false, isDefinition: true)
++!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "clang version 9.0.0 (trunk 351969) (llvm/trunk 351973)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5, nameTableKind: None)
++!3 = !DIFile(filename: "new.cc", directory: "/tmp")
++!4 = !{}
++!5 = !{!0, !6}
++!6 = !DIGlobalVariableExpression(var: !7, expr: !DIExpression(DW_OP_constu, 8, DW_OP_swap, DW_OP_xderef))
++!7 = distinct !DIGlobalVariable(name: "SHARED", scope: !2, file: !8, line: 4, type: !9, isLocal: false, isDefinition: true)
++!8 = !DIFile(filename: "test.cu", directory: "/tmp")
++!9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
++!10 = !{void (float, float*, float*, i32)* @test, !"kernel", i32 1}
++!11 = !{i32 2, !"Dwarf Version", i32 2}
++!12 = !{i32 2, !"Debug Info Version", i32 3}
++!13 = !{i32 1, !"wchar_size", i32 4}
++!14 = !{i32 4, !"nvvm-reflect-ftz", i32 0}
++!15 = !{i32 7, !"PIC Level", i32 2}
++!16 = !{!"clang version 9.0.0 (trunk 351969) (llvm/trunk 351973)"}
++!17 = distinct !DISubprogram(name: "test", linkageName: "test", scope: !8, file: !8, line: 6, type: !18, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
++!18 = !DISubroutineType(types: !19)
++!19 = !{null, !20, !21, !21, !9}
++!20 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
++!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
++!22 = !DILocalVariable(name: "a", arg: 1, scope: !17, file: !8, line: 6, type: !20)
++!23 = !DILocation(line: 6, column: 41, scope: !17)
++!24 = !DILocalVariable(name: "x", arg: 2, scope: !17, file: !8, line: 6, type: !21)
++!25 = !DILocation(line: 6, column: 51, scope: !17)
++!26 = !DILocalVariable(name: "y", arg: 3, scope: !17, file: !8, line: 6, type: !21)
++!27 = !DILocation(line: 6, column: 61, scope: !17)
++!28 = !DILocalVariable(name: "i", arg: 4, scope: !17, file: !8, line: 6, type: !9)
++!29 = !DILocation(line: 6, column: 68, scope: !17)
++!30 = !DILocation(line: 7, column: 10, scope: !17)
++!31 = !DILocation(line: 7, column: 14, scope: !17)
++!32 = !DILocation(line: 7, column: 16, scope: !17)
++!33 = !DILocation(line: 7, column: 12, scope: !17)
++!34 = !DILocation(line: 7, column: 3, scope: !17)
++!35 = !DILocation(line: 7, column: 5, scope: !17)
++!36 = !DILocation(line: 7, column: 8, scope: !17)
++!37 = !DILocation(line: 8, column: 10, scope: !17)
++!38 = !DILocation(line: 9, column: 10, scope: !17)
++!39 = !DILocation(line: 10, column: 1, scope: !17)
++
++; CHECK: .section .debug_abbrev
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 1                                   // Abbreviation Code
++; CHECK-NEXT: .b8 17                                  // DW_TAG_compile_unit
++; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 37                                  // DW_AT_producer
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 19                                  // DW_AT_language
++; CHECK-NEXT: .b8 5                                   // DW_FORM_data2
++; CHECK-NEXT: .b8 3                                   // DW_AT_name
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 16                                  // DW_AT_stmt_list
++; CHECK-NEXT: .b8 6                                   // DW_FORM_data4
++; CHECK-NEXT: .b8 27                                  // DW_AT_comp_dir
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 17                                  // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
++; CHECK-NEXT: .b8 18                                  // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
++; CHECK-NEXT: .b8 0                                   // EOM(1)
++; CHECK-NEXT: .b8 0                                   // EOM(2)
++; CHECK-NEXT: .b8 2                                   // Abbreviation Code
++; CHECK-NEXT: .b8 52                                  // DW_TAG_variable
++; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                   // DW_AT_name
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 73                                  // DW_AT_type
++; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
++; CHECK-NEXT: .b8 63                                  // DW_AT_external
++; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
++; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 51                                  // DW_AT_address_class
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 2                                   // DW_AT_location
++; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
++; CHECK-NEXT: .b8 0                                   // EOM(1)
++; CHECK-NEXT: .b8 0                                   // EOM(2)
++; CHECK-NEXT: .b8 3                                   // Abbreviation Code
++; CHECK-NEXT: .b8 36                                  // DW_TAG_base_type
++; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                   // DW_AT_name
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 62                                  // DW_AT_encoding
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 11                                  // DW_AT_byte_size
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 0                                   // EOM(1)
++; CHECK-NEXT: .b8 0                                   // EOM(2)
++; CHECK-NEXT: .b8 4                                   // Abbreviation Code
++; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
++; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
++; CHECK-NEXT: .b8 17                                  // DW_AT_low_pc
++; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
++; CHECK-NEXT: .b8 18                                  // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
++; CHECK-NEXT: .b8 64                                  // DW_AT_frame_base
++; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
++; CHECK-NEXT: .b8 135,64                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 3                                   // DW_AT_name
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 63                                  // DW_AT_external
++; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
++; CHECK-NEXT: .b8 0                                   // EOM(1)
++; CHECK-NEXT: .b8 0                                   // EOM(2)
++; CHECK-NEXT: .b8 5                                   // Abbreviation Code
++; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
++; CHECK-NEXT: .b8 3                                   // DW_AT_name
++; CHECK-NEXT: .b8 8                                   // DW_FORM_string
++; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
++; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
++; CHECK-NEXT: .b8 73                                  // DW_AT_type
++; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
++; CHECK-NEXT: .b8 0                                   // EOM(1)
++; CHECK-NEXT: .b8 0                                   // EOM(2)
++; CHECK-NEXT: .b8 0                                   // EOM(3)
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_info
++; CHECK-NEXT: {
++; CHECK-NEXT: .b32 217                                // Length of Unit
++; CHECK-NEXT: .b8 2                                   // DWARF version number
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_abbrev                      // Offset Into Abbrev. Section
++; CHECK-NEXT: .b8 8                                   // Address Size (in bytes)
++; CHECK-NEXT: .b8 1                                   // Abbrev [1] 0xb:0xd2 DW_TAG_compile_unit
++; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,57,46,48,46,48,32,40,116,114,117,110,107,32,51,53,49,57,54,57,41,32,40,108,108,118,109 // DW_AT_producer
++; CHECK-NEXT: .b8 47,116,114,117,110,107,32,51,53,49,57,55,51,41
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                   // DW_AT_language
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 110,101,119,46,99,99                // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 .debug_line                        // DW_AT_stmt_list
++; CHECK-NEXT: .b8 47,116,109,112                      // DW_AT_comp_dir
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b64 Lfunc_begin0                       // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                         // DW_AT_high_pc
++; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x65:0x1a DW_TAG_variable
++; CHECK-NEXT: .b8 71,76,79,66,65,76                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 127                                // DW_AT_type
++; CHECK-NEXT: .b8 1                                   // DW_AT_external
++; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
++; CHECK-NEXT: .b8 3                                   // DW_AT_decl_line
++; CHECK-NEXT: .b8 5                                   // DW_AT_address_class
++; CHECK-NEXT: .b8 9                                   // DW_AT_location
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b64 GLOBAL
++; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x7f:0x7 DW_TAG_base_type
++; CHECK-NEXT: .b8 105,110,116                         // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 5                                   // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
++; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x86:0x1a DW_TAG_variable
++; CHECK-NEXT: .b8 83,72,65,82,69,68                   // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b32 127                                // DW_AT_type
++; CHECK-NEXT: .b8 1                                   // DW_AT_external
++; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
++; CHECK-NEXT: .b8 4                                   // DW_AT_decl_line
++; CHECK-NEXT: .b8 8                                   // DW_AT_address_class
++; CHECK-NEXT: .b8 9                                   // DW_AT_location
++; CHECK-NEXT: .b8 3
++; CHECK-NEXT: .b64 SHARED
++; CHECK-NEXT: .b8 4                                   // Abbrev [4] 0xa0:0x33 DW_TAG_subprogram
++; CHECK-NEXT: .b64 Lfunc_begin0                       // DW_AT_low_pc
++; CHECK-NEXT: .b64 Lfunc_end0                         // DW_AT_high_pc
++; CHECK-NEXT: .b8 1                                   // DW_AT_frame_base
++; CHECK-NEXT: .b8 156
++; CHECK-NEXT: .b8 116,101,115,116                     // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116,101,115,116                     // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
++; CHECK-NEXT: .b8 6                                   // DW_AT_decl_line
++; CHECK-NEXT: .b8 1                                   // DW_AT_external
++; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0xc0:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 97                                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
++; CHECK-NEXT: .b8 6                                   // DW_AT_decl_line
++; CHECK-NEXT: .b32 211                                // DW_AT_type
++; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0xc9:0x9 DW_TAG_formal_parameter
++; CHECK-NEXT: .b8 105                                 // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
++; CHECK-NEXT: .b8 6                                   // DW_AT_decl_line
++; CHECK-NEXT: .b32 127                                // DW_AT_type
++; CHECK-NEXT: .b8 0                                   // End Of Children Mark
++; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0xd3:0x9 DW_TAG_base_type
++; CHECK-NEXT: .b8 102,108,111,97,116                  // DW_AT_name
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 4                                   // DW_AT_encoding
++; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
++; CHECK-NEXT: .b8 0                                   // End Of Children Mark
++; CHECK-NEXT: }
++; CHECK-NEXT: .section .debug_macinfo
++; CHECK-NEXT: {
++; CHECK-NEXT: .b8 0                                   // End Of Macro List Mark
++; CHECK:      }
++
+-- 
+2.22.0
+

--- a/deps/patches/llvm-nvptx-fix-relocation-info.patch
+++ b/deps/patches/llvm-nvptx-fix-relocation-info.patch
@@ -1,0 +1,224 @@
+From fa7c088eee6f4e7882e61ba11ce097e6748d377a Mon Sep 17 00:00:00 2001
+From: Alexey Bataev <a.bataev@hotmail.com>
+Date: Tue, 22 Jan 2019 17:24:16 +0000
+Subject: [PATCH 1/5] [DEBUG_INFO, NVPTX] Fix relocation info.
+
+Summary: Initial function labels must follow the debug location for the correct relocation info generation.
+
+Reviewers: tra, jlebar, echristo
+
+Subscribers: jholewinski, llvm-commits
+
+Differential Revision: https://reviews.llvm.org/D45784
+
+llvm-svn: 351843
+---
+ llvm/include/llvm/CodeGen/AsmPrinter.h        |  3 +
+ llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp    |  6 ++
+ llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp    | 67 +++++++++++++------
+ llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h      |  3 +
+ llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp     |  3 +
+ llvm/test/DebugInfo/NVPTX/cu-range-hole.ll    |  2 +
+ llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll |  6 +-
+ 7 files changed, 66 insertions(+), 24 deletions(-)
+
+diff --git a/llvm/include/llvm/CodeGen/AsmPrinter.h b/llvm/include/llvm/CodeGen/AsmPrinter.h
+index 413901d218f..df9c1d09941 100644
+--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
++++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
+@@ -227,6 +227,9 @@ public:
+ 
+   void EmitToStreamer(MCStreamer &S, const MCInst &Inst);
+ 
++  /// Emits inital debug location directive.
++  void emitInitialRawDwarfLocDirective(const MachineFunction &MF);
++
+   /// Return the current section we are emitting to.
+   const MCSection *getCurrentSection() const;
+ 
+diff --git a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+index 7070451e333..25387217e82 100644
+--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
++++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+@@ -232,6 +232,12 @@ void AsmPrinter::EmitToStreamer(MCStreamer &S, const MCInst &Inst) {
+   S.EmitInstruction(Inst, getSubtargetInfo());
+ }
+ 
++void AsmPrinter::emitInitialRawDwarfLocDirective(const MachineFunction &MF) {
++  assert(DD && "Dwarf debug file is not defined.");
++  assert(OutStreamer->hasRawTextSupport() && "Expected assembly output mode.");
++  (void)DD->emitInitialLocDirective(MF, /*CUID=*/0);
++}
++
+ /// getCurrentSection() - Return the current section we are emitting to.
+ const MCSection *AsmPrinter::getCurrentSection() const {
+   return OutStreamer->getCurrentSectionOnly();
+diff --git a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+index 18c5fe27b1a..3b07a5a9c89 100644
+--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
++++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+@@ -1521,6 +1521,46 @@ static DebugLoc findPrologueEndLoc(const MachineFunction *MF) {
+   return DebugLoc();
+ }
+ 
++/// Register a source line with debug info. Returns the  unique label that was
++/// emitted and which provides correspondence to the source line list.
++static void recordSourceLine(AsmPrinter &Asm, unsigned Line, unsigned Col,
++                             const MDNode *S, unsigned Flags, unsigned CUID,
++                             uint16_t DwarfVersion,
++                             ArrayRef<std::unique_ptr<DwarfCompileUnit>> DCUs) {
++  StringRef Fn;
++  unsigned FileNo = 1;
++  unsigned Discriminator = 0;
++  if (auto *Scope = cast_or_null<DIScope>(S)) {
++    Fn = Scope->getFilename();
++    if (Line != 0 && DwarfVersion >= 4)
++      if (auto *LBF = dyn_cast<DILexicalBlockFile>(Scope))
++        Discriminator = LBF->getDiscriminator();
++
++    FileNo = static_cast<DwarfCompileUnit &>(*DCUs[CUID])
++                 .getOrCreateSourceID(Scope->getFile());
++  }
++  Asm.OutStreamer->EmitDwarfLocDirective(FileNo, Line, Col, Flags, 0,
++                                         Discriminator, Fn);
++}
++
++DebugLoc DwarfDebug::emitInitialLocDirective(const MachineFunction &MF,
++                                             unsigned CUID) {
++  // Get beginning of function.
++  if (DebugLoc PrologEndLoc = findPrologueEndLoc(&MF)) {
++    // Ensure the compile unit is created if the function is called before
++    // beginFunction().
++    (void)getOrCreateDwarfCompileUnit(
++        MF.getFunction().getSubprogram()->getUnit());
++    // We'd like to list the prologue as "not statements" but GDB behaves
++    // poorly if we do that. Revisit this with caution/GDB (7.5+) testing.
++    const DISubprogram *SP = PrologEndLoc->getInlinedAtScope()->getSubprogram();
++    ::recordSourceLine(*Asm, SP->getScopeLine(), 0, SP, DWARF2_FLAG_IS_STMT,
++                       CUID, getDwarfVersion(), getUnits());
++    return PrologEndLoc;
++  }
++  return DebugLoc();
++}
++
+ // Gather pre-function debug information.  Assumes being called immediately
+ // after the function entry point has been emitted.
+ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
+@@ -1543,13 +1583,8 @@ void DwarfDebug::beginFunctionImpl(const MachineFunction *MF) {
+     Asm->OutStreamer->getContext().setDwarfCompileUnitID(CU.getUniqueID());
+ 
+   // Record beginning of function.
+-  PrologEndLoc = findPrologueEndLoc(MF);
+-  if (PrologEndLoc) {
+-    // We'd like to list the prologue as "not statements" but GDB behaves
+-    // poorly if we do that. Revisit this with caution/GDB (7.5+) testing.
+-    auto *SP = PrologEndLoc->getInlinedAtScope()->getSubprogram();
+-    recordSourceLine(SP->getScopeLine(), 0, SP, DWARF2_FLAG_IS_STMT);
+-  }
++  PrologEndLoc = emitInitialLocDirective(
++      *MF, Asm->OutStreamer->getContext().getDwarfCompileUnitID());
+ }
+ 
+ void DwarfDebug::skippedNonDebugFunction() {
+@@ -1647,21 +1682,9 @@ void DwarfDebug::endFunctionImpl(const MachineFunction *MF) {
+ // emitted and which provides correspondence to the source line list.
+ void DwarfDebug::recordSourceLine(unsigned Line, unsigned Col, const MDNode *S,
+                                   unsigned Flags) {
+-  StringRef Fn;
+-  unsigned FileNo = 1;
+-  unsigned Discriminator = 0;
+-  if (auto *Scope = cast_or_null<DIScope>(S)) {
+-    Fn = Scope->getFilename();
+-    if (Line != 0 && getDwarfVersion() >= 4)
+-      if (auto *LBF = dyn_cast<DILexicalBlockFile>(Scope))
+-        Discriminator = LBF->getDiscriminator();
+-
+-    unsigned CUID = Asm->OutStreamer->getContext().getDwarfCompileUnitID();
+-    FileNo = static_cast<DwarfCompileUnit &>(*InfoHolder.getUnits()[CUID])
+-              .getOrCreateSourceID(Scope->getFile());
+-  }
+-  Asm->OutStreamer->EmitDwarfLocDirective(FileNo, Line, Col, Flags, 0,
+-                                          Discriminator, Fn);
++  ::recordSourceLine(*Asm, Line, Col, S, Flags,
++                     Asm->OutStreamer->getContext().getDwarfCompileUnitID(),
++                     getDwarfVersion(), getUnits());
+ }
+ 
+ //===----------------------------------------------------------------------===//
+diff --git a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+index 8a31e989b28..cece974b736 100644
+--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
++++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+@@ -593,6 +593,9 @@ public:
+   /// Emit all Dwarf sections that should come after the content.
+   void endModule() override;
+ 
++  /// Emits inital debug location directive.
++  DebugLoc emitInitialLocDirective(const MachineFunction &MF, unsigned CUID);
++
+   /// Process beginning of an instruction.
+   void beginInstruction(const MachineInstr *MI) override;
+ 
+diff --git a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+index 6284ad8b82e..45703ef8f20 100644
+--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
++++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+@@ -473,6 +473,9 @@ void NVPTXAsmPrinter::EmitFunctionEntryLabel() {
+   // Emit open brace for function body.
+   OutStreamer->EmitRawText(StringRef("{\n"));
+   setAndEmitFunctionVirtualRegisters(*MF);
++  // Emit initial .loc debug directive for correct relocation symbol data.
++  if (MMI && MMI->hasDebugInfo())
++    emitInitialRawDwarfLocDirective(*MF);
+ }
+ 
+ bool NVPTXAsmPrinter::runOnMachineFunction(MachineFunction &F) {
+diff --git a/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll b/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
+index e44b43d2b90..48570e090c8 100644
+--- a/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
++++ b/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
+@@ -6,6 +6,7 @@
+ ; CHECK: .param .b32 b_param_0
+ ; CHECK: )
+ ; CHECK: {
++; CHECK: .loc 1 1 0
+ ; CHECK: Lfunc_begin0:
+ ; CHECK: .loc 1 1 0
+ ; CHECK: .loc 1 1 0
+@@ -27,6 +28,7 @@
+ ; CHECK: .param .b32 d_param_0
+ ; CHECK: )
+ ; CHECK: {
++; CHECK: .loc 1 3 0
+ ; CHECK: Lfunc_begin2:
+ ; CHECK: .loc 1 3 0
+ ; CHECK: ret;
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll b/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
+index df7835f8a2d..72ed6c1cc2f 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
+@@ -11,8 +11,9 @@
+ 
+ ; CHECK: .visible .func  (.param .b32 func_retval0) _Z3bari(
+ ; CHECK: {
+-; CHECK: Lfunc_begin0:
+ ; CHECK: .loc [[CU1:[0-9]+]] 1 0
++; CHECK: Lfunc_begin0:
++; CHECK: .loc [[CU1]] 1 0
+ 
+ ; CHECK: //DEBUG_VALUE: bar:b <- {{[0-9]+}}
+ ; CHECK: //DEBUG_VALUE: bar:b <- {{[0-9]+}}
+@@ -39,8 +40,9 @@ declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+ 
+ ; CHECK: .visible .func _Z3baz1A(
+ ; CHECK: {
+-; CHECK: Lfunc_begin1:
+ ; CHECK: .loc [[CU2:[0-9]+]] 6 0
++; CHECK: Lfunc_begin1:
++; CHECK: .loc [[CU2]] 6 0
+ ; CHECK: //DEBUG_VALUE: baz:z <- {{[0-9]+}}
+ ; CHECK: //DEBUG_VALUE: baz:z <- {{[0-9]+}}
+ ; CHECK: .loc [[CU2]] 10 0
+-- 
+2.22.0
+

--- a/deps/patches/llvm-nvptx-ptxas-di.patch
+++ b/deps/patches/llvm-nvptx-ptxas-di.patch
@@ -1,0 +1,7086 @@
+From 792b8cf643a9f3c0bdbaf8c4a21eb5812ad9ab4c Mon Sep 17 00:00:00 2001
+From: Alexey Bataev <a.bataev@hotmail.com>
+Date: Fri, 8 Mar 2019 21:29:17 +0000
+Subject: [PATCH 5/5] [NVPTX][DEBUGINFO]Temp workaround for crash of ptxas:
+ disable packed bytes in debug sections.
+
+Summary:
+This patch works around the bug in the ptxas tool with the processing of bytes
+separated by the comma symbol. The emission of the packed string is
+temporarily disabled.
+
+Reviewers: tra
+
+Subscribers: jholewinski, jdoerfert, llvm-commits
+
+Tags: #llvm
+
+Differential Revision: https://reviews.llvm.org/D59148
+
+llvm-svn: 355740
+---
+ .../MCTargetDesc/NVPTXTargetStreamer.cpp      |    6 +
+ llvm/test/DebugInfo/NVPTX/cu-range-hole.ll    |   72 +-
+ .../DebugInfo/NVPTX/dbg-declare-alloca.ll     |   39 +-
+ llvm/test/DebugInfo/NVPTX/debug-addr-class.ll |  105 +-
+ llvm/test/DebugInfo/NVPTX/debug-file-loc.ll   |   19 +-
+ llvm/test/DebugInfo/NVPTX/debug-info.ll       | 4618 +++++++++++++++--
+ llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll |  167 +-
+ 7 files changed, 4480 insertions(+), 546 deletions(-)
+
+diff --git a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
+index 0f3eea63d8c..514cfb9d204 100644
+--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
++++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXTargetStreamer.cpp
+@@ -103,6 +103,11 @@ void NVPTXTargetStreamer::changeSection(const MCSection *CurSection,
+ }
+ 
+ void NVPTXTargetStreamer::emitRawBytes(StringRef Data) {
++  MCTargetStreamer::emitRawBytes(Data);
++  // TODO: enable this once the bug in the ptxas with the packed bytes is
++  // resolved. Currently, (it is confirmed by NVidia) it causes a crash in
++  // ptxas.
++#if 0
+   const MCAsmInfo *MAI = Streamer.getContext().getAsmInfo();
+   const char *Directive = MAI->getData8bitsDirective();
+   unsigned NumElements = Data.size();
+@@ -126,5 +131,6 @@ void NVPTXTargetStreamer::emitRawBytes(StringRef Data) {
+     }
+     Streamer.EmitRawText(OS.str());
+   }
++#endif
+ }
+ 
+diff --git a/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll b/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
+index ccc5c1201fd..e7852cc6d3b 100644
+--- a/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
++++ b/llvm/test/DebugInfo/NVPTX/cu-range-hole.ll
+@@ -150,15 +150,75 @@ entry:
+ ; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+ ; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
+ ; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0xb0 DW_TAG_compile_unit
+-; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,116,114,117,110,107,32,50,48,52,49,54,52,41,32,40,108,108,118,109 // DW_AT_producer
+-; CHECK-NEXT: .b8 47,116,114,117,110,107,32,50,48,52,49,56,51,41
++; CHECK-NEXT: .b8 99                               // DW_AT_producer
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 40
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 41
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 40
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 47
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 56
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 41
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_language
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 98,46,99                         // DW_AT_name
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: .b8 47,115,111,117,114,99,101        // DW_AT_comp_dir
++; CHECK-NEXT: .b8 47                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 101
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end2                      // DW_AT_high_pc
+@@ -201,7 +261,9 @@ entry:
+ ; CHECK-NEXT: .b32 179                             // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 4                                // Abbrev [4] 0xb3:0x7 DW_TAG_base_type
+-; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+diff --git a/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll b/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
+index a6a9826d6c3..4753071b28b 100644
+--- a/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
++++ b/llvm/test/DebugInfo/NVPTX/dbg-declare-alloca.ll
+@@ -131,14 +131,23 @@
+ ; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+ ; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
+ ; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x81 DW_TAG_compile_unit
+-; CHECK-NEXT: .b8 99,108,97,110,103                // DW_AT_producer
++; CHECK-NEXT: .b8 99                               // DW_AT_producer
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_language
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,46,99                        // DW_AT_name
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: .b8 116,101,115,116                  // DW_AT_comp_dir
++; CHECK-NEXT: .b8 116                              // DW_AT_comp_dir
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+@@ -147,7 +156,21 @@
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 156
+-; CHECK-NEXT: .b8 117,115,101,95,100,98,103,95,100,101,99,108,97,114,101 // DW_AT_name
++; CHECK-NEXT: .b8 117                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
+@@ -167,7 +190,9 @@
+ ; CHECK-NEXT: .b32 111                             // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 4                                // Abbrev [4] 0x6f:0x15 DW_TAG_structure_type
+-; CHECK-NEXT: .b8 70,111,111                       // DW_AT_name
++; CHECK-NEXT: .b8 70                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 111
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+@@ -183,7 +208,9 @@
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 6                                // Abbrev [6] 0x84:0x7 DW_TAG_base_type
+-; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-addr-class.ll b/llvm/test/DebugInfo/NVPTX/debug-addr-class.ll
+index 3d8460d8247..e5ca8defc84 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-addr-class.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-addr-class.ll
+@@ -142,7 +142,8 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata)
+ ; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
+ ; CHECK-NEXT: .b8 64                                  // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
+-; CHECK-NEXT: .b8 135,64                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                   // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+@@ -177,20 +178,85 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata)
+ ; CHECK-NEXT: .b32 .debug_abbrev                      // Offset Into Abbrev. Section
+ ; CHECK-NEXT: .b8 8                                   // Address Size (in bytes)
+ ; CHECK-NEXT: .b8 1                                   // Abbrev [1] 0xb:0xd2 DW_TAG_compile_unit
+-; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,57,46,48,46,48,32,40,116,114,117,110,107,32,51,53,49,57,54,57,41,32,40,108,108,118,109 // DW_AT_producer
+-; CHECK-NEXT: .b8 47,116,114,117,110,107,32,51,53,49,57,55,51,41
++; CHECK-NEXT: .b8 99                                  // DW_AT_producer
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 40
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 41
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 40
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 47
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 41
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                   // DW_AT_language
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 110,101,119,46,99,99                // DW_AT_name
++; CHECK-NEXT: .b8 110                                 // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 119
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_line                        // DW_AT_stmt_list
+-; CHECK-NEXT: .b8 47,116,109,112                      // DW_AT_comp_dir
++; CHECK-NEXT: .b8 47                                  // DW_AT_comp_dir
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin0                       // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end0                         // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x65:0x1a DW_TAG_variable
+-; CHECK-NEXT: .b8 71,76,79,66,65,76                   // DW_AT_name
++; CHECK-NEXT: .b8 71                                  // DW_AT_name
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 79
++; CHECK-NEXT: .b8 66
++; CHECK-NEXT: .b8 65
++; CHECK-NEXT: .b8 76
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 127                                // DW_AT_type
+ ; CHECK-NEXT: .b8 1                                   // DW_AT_external
+@@ -201,12 +267,19 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata)
+ ; CHECK-NEXT: .b8 3
+ ; CHECK-NEXT: .b64 GLOBAL
+ ; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x7f:0x7 DW_TAG_base_type
+-; CHECK-NEXT: .b8 105,110,116                         // DW_AT_name
++; CHECK-NEXT: .b8 105                                 // DW_AT_name
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                   // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x86:0x1a DW_TAG_variable
+-; CHECK-NEXT: .b8 83,72,65,82,69,68                   // DW_AT_name
++; CHECK-NEXT: .b8 83                                  // DW_AT_name
++; CHECK-NEXT: .b8 72
++; CHECK-NEXT: .b8 65
++; CHECK-NEXT: .b8 82
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 68
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 127                                // DW_AT_type
+ ; CHECK-NEXT: .b8 1                                   // DW_AT_external
+@@ -221,9 +294,15 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata)
+ ; CHECK-NEXT: .b64 Lfunc_end0                         // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 1                                   // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 156
+-; CHECK-NEXT: .b8 116,101,115,116                     // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 116                                 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,101,115,116                     // DW_AT_name
++; CHECK-NEXT: .b8 116                                 // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 6                                   // DW_AT_decl_line
+@@ -242,7 +321,11 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata)
+ ; CHECK-NEXT: .b32 127                                // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+ ; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0xd3:0x9 DW_TAG_base_type
+-; CHECK-NEXT: .b8 102,108,111,97,116                  // DW_AT_name
++; CHECK-NEXT: .b8 102                                 // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                   // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll b/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
+index 631e1e2d2b2..36fb59c7271 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-file-loc.ll
+@@ -63,10 +63,25 @@ bb:
+ ; CHECK-NEXT: .b8 0                                // DW_AT_producer
+ ; CHECK-NEXT: .b8 4                                // DW_AT_language
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 98,97,114,46,99,117              // DW_AT_name
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: .b8 47,115,111,117,114,99,101,47,100,105,114                // DW_AT_comp_dir
++; CHECK-NEXT: .b8 47                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 47
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end1                      // DW_AT_high_pc
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-info.ll b/llvm/test/DebugInfo/NVPTX/debug-info.ll
+index b7d871a0b8c..df377e1134b 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-info.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-info.ll
+@@ -158,7 +158,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 5                                // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -280,7 +281,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 12                               // DW_FORM_flag
+ ; CHECK-NEXT: .b8 63                               // DW_AT_external
+ ; CHECK-NEXT: .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: .b8 135,1                            // DW_AT_noreturn
++; CHECK-NEXT: .b8 135                              // DW_AT_noreturn
++; CHECK-NEXT: .b8 1
+ ; CHECK-NEXT: .b8 12                               // DW_FORM_flag
+ ; CHECK-NEXT: .b8 0                                // EOM(1)
+ ; CHECK-NEXT: .b8 0                                // EOM(2)
+@@ -349,7 +351,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 12                               // DW_FORM_flag
+ ; CHECK-NEXT: .b8 63                               // DW_AT_external
+ ; CHECK-NEXT: .b8 12                               // DW_FORM_flag
+-; CHECK-NEXT: .b8 135,1                            // DW_AT_noreturn
++; CHECK-NEXT: .b8 135                              // DW_AT_noreturn
++; CHECK-NEXT: .b8 1
+ ; CHECK-NEXT: .b8 12                               // DW_FORM_flag
+ ; CHECK-NEXT: .b8 0                                // EOM(1)
+ ; CHECK-NEXT: .b8 0                                // EOM(2)
+@@ -388,7 +391,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 25                               // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -407,7 +411,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 26                               // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -437,7 +442,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 28                               // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 0                                // DW_CHILDREN_no
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -482,7 +488,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 31                               // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                             // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -501,7 +508,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 32                               // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -566,7 +574,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 37                               // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -585,7 +594,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 38                               // Abbreviation Code
+ ; CHECK-NEXT: .b8 46                               // DW_TAG_subprogram
+ ; CHECK-NEXT: .b8 1                                // DW_CHILDREN_yes
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -621,7 +631,8 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_FORM_addr
+ ; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -696,15 +707,43 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 0                                // DW_AT_producer
+ ; CHECK-NEXT: .b8 4                                // DW_AT_language
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 100,101,98,117,103,45,105,110,102,111,46,99,117 // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 45
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: .b8 47,115,111,109,101,47,100,105,114,101,99,116,111,114,121 // DW_AT_comp_dir
++; CHECK-NEXT: .b8 47                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 47
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 121
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x41:0x588 DW_TAG_namespace
+-; CHECK-NEXT: .b8 115,116,100                      // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x46:0x7 DW_TAG_imported_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+@@ -1551,9 +1590,18 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 7772                            // DW_AT_import
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x5c9:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,97,98,115,120        // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 120
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,98,115                        // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 44                               // DW_AT_decl_line
+@@ -1563,14 +1611,37 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1508                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x5e4:0x11 DW_TAG_base_type
+-; CHECK-NEXT: .b8 108,111,110,103,32,108,111,110,103,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x5f5:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,97,99,111,115,102    // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,99,111,115                    // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 46                               // DW_AT_decl_line
+@@ -1580,14 +1651,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x612:0x9 DW_TAG_base_type
+-; CHECK-NEXT: .b8 102,108,111,97,116               // DW_AT_name
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x61b:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,97,99,111,115,104,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,99,111,115,104                // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 48                               // DW_AT_decl_line
+@@ -1597,9 +1685,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x63a:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,97,115,105,110,102   // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,115,105,110                   // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 50                               // DW_AT_decl_line
+@@ -1609,9 +1708,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x657:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,97,115,105,110,104,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,115,105,110,104               // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 52                               // DW_AT_decl_line
+@@ -1621,9 +1733,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x676:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,97,116,97,110,102    // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,116,97,110                    // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 56                               // DW_AT_decl_line
+@@ -1633,9 +1756,23 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x693:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,97,116,97,110,50,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,116,97,110,50                 // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 50
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 54                               // DW_AT_decl_line
+@@ -1647,9 +1784,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x6b8:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,97,116,97,110,104,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,116,97,110,104                // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 58                               // DW_AT_decl_line
+@@ -1659,9 +1809,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x6d7:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,99,98,114,116,102    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,98,114,116                    // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 60                               // DW_AT_decl_line
+@@ -1671,9 +1832,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x6f4:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,99,101,105,108,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,101,105,108                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 62                               // DW_AT_decl_line
+@@ -1683,9 +1855,29 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x711:0x2b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,56,99,111,112,121,115,105,103,110,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,111,112,121,115,105,103,110   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 56
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 64                               // DW_AT_decl_line
+@@ -1697,9 +1889,18 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x73c:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,99,111,115,102       // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,111,115                       // DW_AT_name
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 66                               // DW_AT_decl_line
+@@ -1709,9 +1910,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x757:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,99,111,115,104,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,111,115,104                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 68                               // DW_AT_decl_line
+@@ -1721,9 +1933,18 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x774:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,101,114,102,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,114,102                      // DW_AT_name
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 72                               // DW_AT_decl_line
+@@ -1733,9 +1954,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x78f:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,101,114,102,99,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,114,102,99                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 70                               // DW_AT_decl_line
+@@ -1745,9 +1977,18 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x7ac:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,101,120,112,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,120,112                      // DW_AT_name
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 76                               // DW_AT_decl_line
+@@ -1757,9 +1998,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x7c7:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,101,120,112,50,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,120,112,50                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 50
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
+@@ -1769,9 +2021,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x7e4:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,101,120,112,109,49,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,120,112,109,49               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 49
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 78                               // DW_AT_decl_line
+@@ -1781,9 +2046,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x803:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,102,97,98,115,102    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 80                               // DW_AT_decl_line
+@@ -1793,9 +2069,21 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x820:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,102,100,105,109,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,100,105,109                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 82                               // DW_AT_decl_line
+@@ -1807,9 +2095,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x843:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,102,108,111,111,114,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,108,111,111,114              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 84                               // DW_AT_decl_line
+@@ -1819,9 +2120,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x862:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,102,109,97,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,97                       // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 86                               // DW_AT_decl_line
+@@ -1835,9 +2147,21 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x889:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,102,109,97,120,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,97,120                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 120
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 88                               // DW_AT_decl_line
+@@ -1849,9 +2173,21 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x8ac:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,102,109,105,110,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,105,110                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
+@@ -1863,9 +2199,21 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x8cf:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,102,109,111,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,111,100                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 92                               // DW_AT_decl_line
+@@ -1877,9 +2225,33 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x8f2:0x2a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,48,102,112,99,108,97,115,115,105,102,121,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,112,99,108,97,115,115,105,102,121 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 121
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 94                               // DW_AT_decl_line
+@@ -1889,14 +2261,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x91c:0x7 DW_TAG_base_type
+-; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x923:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,102,114,101,120,112,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,114,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
+@@ -1910,9 +2299,23 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x949:0x5 DW_TAG_pointer_type
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x94e:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,104,121,112,111,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 104,121,112,111,116              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 104                              // DW_AT_name
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 98                               // DW_AT_decl_line
+@@ -1924,9 +2327,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x973:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,105,108,111,103,98,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,108,111,103,98               // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 100                              // DW_AT_decl_line
+@@ -1936,9 +2352,28 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x992:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,56,105,115,102,105,110,105,116,101,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 56
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,102,105,110,105,116,101  // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 102                              // DW_AT_decl_line
+@@ -1948,14 +2383,39 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x9b7:0x8 DW_TAG_base_type
+-; CHECK-NEXT: .b8 98,111,111,108                   // DW_AT_name
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x9bf:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,57,105,115,103,114,101,97,116,101,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,103,114,101,97,116,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 106                              // DW_AT_decl_line
+@@ -1967,9 +2427,42 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0x9ec:0x38 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,52,105,115,103,114,101,97,116,101,114,101,113,117,97,108,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,103,114,101,97,116,101,114,101,113,117,97,108 // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
+@@ -1981,9 +2474,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa24:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,105,115,105,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,105,110,102              // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 108                              // DW_AT_decl_line
+@@ -1993,9 +2499,25 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa43:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,105,115,108,101,115,115,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,108,101,115,115          // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 112                              // DW_AT_decl_line
+@@ -2007,9 +2529,36 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa6a:0x32 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,49,105,115,108,101,115,115,101,113,117,97,108,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,108,101,115,115,101,113,117,97,108 // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 111                              // DW_AT_decl_line
+@@ -2021,9 +2570,40 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xa9c:0x36 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,51,105,115,108,101,115,115,103,114,101,97,116,101,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,108,101,115,115,103,114,101,97,116,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 114                              // DW_AT_decl_line
+@@ -2035,9 +2615,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xad2:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,105,115,110,97,110,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,110,97,110               // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 116                              // DW_AT_decl_line
+@@ -2047,9 +2640,28 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xaf1:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,56,105,115,110,111,114,109,97,108,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 56
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,110,111,114,109,97,108   // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 118                              // DW_AT_decl_line
+@@ -2059,9 +2671,36 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb16:0x32 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,49,105,115,117,110,111,114,100,101,114,101,100,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,115,117,110,111,114,100,101,114,101,100 // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 120                              // DW_AT_decl_line
+@@ -2073,9 +2712,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb48:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,108,97,98,115,108    // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 121                              // DW_AT_decl_line
+@@ -2085,14 +2735,35 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2917                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0xb65:0xc DW_TAG_base_type
+-; CHECK-NEXT: .b8 108,111,110,103,32,105,110,116   // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb71:0x25 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,108,100,101,120,112,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,100,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 123                              // DW_AT_decl_line
+@@ -2104,9 +2775,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xb96:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,108,103,97,109,109,97,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,103,97,109,109,97            // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 125                              // DW_AT_decl_line
+@@ -2116,9 +2802,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xbb7:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,108,108,97,98,115,120 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,108,97,98,115                // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 126                              // DW_AT_decl_line
+@@ -2128,9 +2827,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1508                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xbd6:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,108,108,114,105,110,116,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,108,114,105,110,116          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 128                              // DW_AT_decl_line
+@@ -2140,9 +2854,18 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xbf7:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,108,111,103,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103                      // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 138                              // DW_AT_decl_line
+@@ -2152,9 +2875,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc12:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,108,111,103,49,48,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,49,48                // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 130                              // DW_AT_decl_line
+@@ -2164,9 +2900,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc31:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,108,111,103,49,112,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,49,112               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 132                              // DW_AT_decl_line
+@@ -2176,9 +2925,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc50:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,108,111,103,50,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,50                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 50
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 134                              // DW_AT_decl_line
+@@ -2188,9 +2948,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc6d:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,108,111,103,98,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,98                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 136                              // DW_AT_decl_line
+@@ -2200,9 +2971,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xc8a:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,108,114,105,110,116,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,114,105,110,116              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 140                              // DW_AT_decl_line
+@@ -2212,9 +2996,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xca9:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,108,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,114,111,117,110,100          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 142                              // DW_AT_decl_line
+@@ -2224,9 +3023,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xcca:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,108,108,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,108,114,111,117,110,100      // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 143                              // DW_AT_decl_line
+@@ -2236,9 +3052,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xced:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,109,111,100,102,102,80,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 109,111,100,102                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 109                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 145                              // DW_AT_decl_line
+@@ -2252,9 +3081,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8                                // Abbrev [8] 0xd11:0x5 DW_TAG_pointer_type
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd16:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,110,97,110,80,75,99  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 110,97,110                       // DW_AT_name
++; CHECK-NEXT: .b8 110                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 146                              // DW_AT_decl_line
+@@ -2264,7 +3104,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3389                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0xd33:0xa DW_TAG_base_type
+-; CHECK-NEXT: .b8 100,111,117,98,108,101           // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
+@@ -2273,14 +3118,30 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 9                                // Abbrev [9] 0xd42:0x5 DW_TAG_const_type
+ ; CHECK-NEXT: .b32 3399                            // DW_AT_type
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0xd47:0x8 DW_TAG_base_type
+-; CHECK-NEXT: .b8 99,104,97,114                    // DW_AT_name
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 8                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd4f:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,110,97,110,102,80,75,99 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 110,97,110,102                   // DW_AT_name
++; CHECK-NEXT: .b8 110                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 147                              // DW_AT_decl_line
+@@ -2290,9 +3151,30 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3389                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd6e:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,57,110,101,97,114,98,121,105,110,116,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 110,101,97,114,98,121,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 110                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 149                              // DW_AT_decl_line
+@@ -2302,9 +3184,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xd95:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,57,110,101,120,116,97,102,116,101,114,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 110,101,120,116,97,102,116,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 110                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 151                              // DW_AT_decl_line
+@@ -2316,9 +3220,19 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xdc2:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,112,111,119,102,105  // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 119
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 105
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 112,111,119                      // DW_AT_name
++; CHECK-NEXT: .b8 112                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 119
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 155                              // DW_AT_decl_line
+@@ -2330,9 +3244,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xde3:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,57,114,101,109,97,105,110,100,101,114,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,101,109,97,105,110,100,101,114 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 157                              // DW_AT_decl_line
+@@ -2344,9 +3280,27 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe10:0x2e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,114,101,109,113,117,111,102,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,101,109,113,117,111          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 111
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 159                              // DW_AT_decl_line
+@@ -2360,9 +3314,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2377                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe3e:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,114,105,110,116,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,105,110,116                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 161                              // DW_AT_decl_line
+@@ -2372,9 +3337,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe5b:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,114,111,117,110,100,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,111,117,110,100              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 163                              // DW_AT_decl_line
+@@ -2384,9 +3362,27 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xe7a:0x29 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,115,99,97,108,98,108,110,102,108 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,99,97,108,98,108,110         // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 165                              // DW_AT_decl_line
+@@ -2398,9 +3394,25 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2917                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xea3:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,115,99,97,108,98,110,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,99,97,108,98,110             // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 167                              // DW_AT_decl_line
+@@ -2412,9 +3424,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xeca:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,115,105,103,110,98,105,116,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,105,103,110,98,105,116       // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 169                              // DW_AT_decl_line
+@@ -2424,9 +3453,18 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xeed:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,115,105,110,102      // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,105,110                      // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 171                              // DW_AT_decl_line
+@@ -2436,9 +3474,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf08:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,115,105,110,104,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,105,110,104                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 173                              // DW_AT_decl_line
+@@ -2448,9 +3497,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf25:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,115,113,114,116,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,113,114,116                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 175                              // DW_AT_decl_line
+@@ -2460,9 +3520,18 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf42:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,51,116,97,110,102       // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,97,110                       // DW_AT_name
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 177                              // DW_AT_decl_line
+@@ -2472,9 +3541,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf5d:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,116,97,110,104,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,97,110,104                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 179                              // DW_AT_decl_line
+@@ -2484,9 +3564,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf7a:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,116,103,97,109,109,97,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,103,97,109,109,97            // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 181                              // DW_AT_decl_line
+@@ -2496,9 +3591,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 5                                // Abbrev [5] 0xf9b:0x1f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,116,114,117,110,99,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,114,117,110,99               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 183                              // DW_AT_decl_line
+@@ -2508,7 +3616,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xfba:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,99,111,115                    // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 54                               // DW_AT_decl_line
+@@ -2519,7 +3630,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xfce:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,115,105,110                   // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 56                               // DW_AT_decl_line
+@@ -2530,7 +3644,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xfe2:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,116,97,110                    // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 58                               // DW_AT_decl_line
+@@ -2541,7 +3658,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0xff6:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,116,97,110,50                 // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 50
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 60                               // DW_AT_decl_line
+@@ -2554,7 +3675,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1010:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 99,101,105,108                   // DW_AT_name
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 178                              // DW_AT_decl_line
+@@ -2565,7 +3689,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1024:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 99,111,115                       // DW_AT_name
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 63                               // DW_AT_decl_line
+@@ -2576,7 +3702,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1037:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 99,111,115,104                   // DW_AT_name
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 72                               // DW_AT_decl_line
+@@ -2587,7 +3716,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x104b:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 101,120,112                      // DW_AT_name
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 100                              // DW_AT_decl_line
+@@ -2598,7 +3729,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x105e:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 102,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 181                              // DW_AT_decl_line
+@@ -2609,7 +3743,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1072:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 102,108,111,111,114              // DW_AT_name
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 184                              // DW_AT_decl_line
+@@ -2620,7 +3758,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1087:0x19 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 102,109,111,100                  // DW_AT_name
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 187                              // DW_AT_decl_line
+@@ -2633,7 +3774,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10a0:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 102,114,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 103                              // DW_AT_decl_line
+@@ -2646,7 +3791,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2377                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10ba:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 108,100,101,120,112              // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 106                              // DW_AT_decl_line
+@@ -2659,7 +3808,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10d4:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 108,111,103                      // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 109                              // DW_AT_decl_line
+@@ -2670,7 +3821,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10e7:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 108,111,103,49,48                // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 112                              // DW_AT_decl_line
+@@ -2681,7 +3836,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x10fc:0x19 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 109,111,100,102                  // DW_AT_name
++; CHECK-NEXT: .b8 109                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 115                              // DW_AT_decl_line
+@@ -2696,7 +3854,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x1115:0x5 DW_TAG_pointer_type
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x111a:0x18 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 112,111,119                      // DW_AT_name
++; CHECK-NEXT: .b8 112                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 119
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 153                              // DW_AT_decl_line
+@@ -2709,7 +3869,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1132:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,105,110                      // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 65                               // DW_AT_decl_line
+@@ -2720,7 +3882,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1145:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,105,110,104                  // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
+@@ -2731,7 +3896,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1159:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,113,114,116                  // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 156                              // DW_AT_decl_line
+@@ -2742,7 +3910,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x116d:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 116,97,110                       // DW_AT_name
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 67                               // DW_AT_decl_line
+@@ -2753,7 +3923,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3379                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1180:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 116,97,110,104                   // DW_AT_name
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 76                               // DW_AT_decl_line
+@@ -2765,7 +3938,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x1194:0xd DW_TAG_typedef
+ ; CHECK-NEXT: .b32 4513                            // DW_AT_type
+-; CHECK-NEXT: .b8 100,105,118,95,116               // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 101                              // DW_AT_decl_line
+@@ -2773,7 +3950,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x11a3:0xe DW_TAG_typedef
+ ; CHECK-NEXT: .b32 4529                            // DW_AT_type
+-; CHECK-NEXT: .b8 108,100,105,118,95,116           // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 109                              // DW_AT_decl_line
+@@ -2782,7 +3964,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x11b5:0xf DW_TAG_member
+-; CHECK-NEXT: .b8 113,117,111,116                  // DW_AT_name
++; CHECK-NEXT: .b8 113                              // DW_AT_name
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 2917                            // DW_AT_type
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+@@ -2791,7 +3976,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 35
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x11c4:0xe DW_TAG_member
+-; CHECK-NEXT: .b8 114,101,109                      // DW_AT_name
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 2917                            // DW_AT_type
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+@@ -2801,7 +3988,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 15                               // Abbrev [15] 0x11d3:0xd DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,98,111,114,116                // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
+@@ -2810,7 +4001,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 1                                // DW_AT_noreturn
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x11e0:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,98,115                        // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
+@@ -2822,7 +4015,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x11f4:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,116,101,120,105,116           // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
+@@ -2837,7 +4035,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4624                            // DW_AT_type
+ ; CHECK-NEXT: .b8 17                               // Abbrev [17] 0x1210:0x1 DW_TAG_subroutine_type
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1211:0x14 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,116,111,102                   // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 6                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 26                               // DW_AT_decl_line
+@@ -2848,7 +4049,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3389                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1225:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,116,111,105                   // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 105
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 22                               // DW_AT_decl_line
+@@ -2860,7 +4064,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3389                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x123a:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,116,111,108                   // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 27                               // DW_AT_decl_line
+@@ -2872,7 +4079,13 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3389                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x124f:0x2b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 98,115,101,97,114,99,104         // DW_AT_name
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 7                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 20                               // DW_AT_decl_line
+@@ -2896,18 +4109,51 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 19                               // Abbrev [19] 0x1280:0x1 DW_TAG_const_type
+ ; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x1281:0xe DW_TAG_typedef
+ ; CHECK-NEXT: .b32 4751                            // DW_AT_type
+-; CHECK-NEXT: .b8 115,105,122,101,95,116           // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 122
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 8                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 62                               // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x128f:0x15 DW_TAG_base_type
+-; CHECK-NEXT: .b8 108,111,110,103,32,117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 7                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 20                               // Abbrev [20] 0x12a4:0x16 DW_TAG_typedef
+ ; CHECK-NEXT: .b32 4794                            // DW_AT_type
+-; CHECK-NEXT: .b8 95,95,99,111,109,112,97,114,95,102,110,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 230                              // DW_AT_decl_line
+@@ -2922,7 +4168,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4731                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x12cf:0x1c DW_TAG_subprogram
+-; CHECK-NEXT: .b8 99,97,108,108,111,99             // DW_AT_name
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 212                              // DW_AT_decl_line
+@@ -2936,7 +4187,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4737                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x12eb:0x19 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 100,105,118                      // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 21                               // DW_AT_decl_line
+@@ -2950,7 +4203,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 22                               // Abbrev [22] 0x1304:0x12 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 101,120,105,116                  // DW_AT_name
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 31                               // DW_AT_decl_line
+@@ -2962,7 +4218,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x1316:0x11 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 102,114,101,101                  // DW_AT_name
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 101
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 227                              // DW_AT_decl_line
+@@ -2973,7 +4232,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4730                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1327:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 103,101,116,101,110,118          // DW_AT_name
++; CHECK-NEXT: .b8 103                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 52                               // DW_AT_decl_line
+@@ -2987,7 +4251,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x133e:0x5 DW_TAG_pointer_type
+ ; CHECK-NEXT: .b32 3399                            // DW_AT_type
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1343:0x15 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 108,97,98,115                    // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 8                                // DW_AT_decl_line
+@@ -2999,7 +4266,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2917                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1358:0x1a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 108,100,105,118                  // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 23                               // DW_AT_decl_line
+@@ -3013,7 +4283,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2917                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1372:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 109,97,108,108,111,99            // DW_AT_name
++; CHECK-NEXT: .b8 109                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 210                              // DW_AT_decl_line
+@@ -3025,7 +4300,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4737                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1389:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 109,98,108,101,110               // DW_AT_name
++; CHECK-NEXT: .b8 109                              // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 110
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 95                               // DW_AT_decl_line
+@@ -3039,7 +4318,14 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4737                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x13a4:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 109,98,115,116,111,119,99,115    // DW_AT_name
++; CHECK-NEXT: .b8 109                              // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 119
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 106                              // DW_AT_decl_line
+@@ -3057,12 +4343,23 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x13c7:0x5 DW_TAG_pointer_type
+ ; CHECK-NEXT: .b32 5068                            // DW_AT_type
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x13cc:0xb DW_TAG_base_type
+-; CHECK-NEXT: .b8 119,99,104,97,114,95,116         // DW_AT_name
++; CHECK-NEXT: .b8 119                              // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x13d7:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 109,98,116,111,119,99            // DW_AT_name
++; CHECK-NEXT: .b8 109                              // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 119
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 98                               // DW_AT_decl_line
+@@ -3078,7 +4375,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4737                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x13f8:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 113,115,111,114,116              // DW_AT_name
++; CHECK-NEXT: .b8 113                              // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 253                              // DW_AT_decl_line
+@@ -3095,7 +4396,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4772                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 24                               // Abbrev [24] 0x1419:0xf DW_TAG_subprogram
+-; CHECK-NEXT: .b8 114,97,110,100                   // DW_AT_name
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 118                              // DW_AT_decl_line
+@@ -3104,7 +4408,13 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1428:0x1d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 114,101,97,108,108,111,99        // DW_AT_name
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 224                              // DW_AT_decl_line
+@@ -3118,7 +4428,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 4737                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x1445:0x12 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,114,97,110,100               // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 120                              // DW_AT_decl_line
+@@ -3129,12 +4443,28 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 5207                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x1457:0x10 DW_TAG_base_type
+-; CHECK-NEXT: .b8 117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 117                              // DW_AT_name
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 7                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1467:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,116,114,116,111,100          // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 164                              // DW_AT_decl_line
+@@ -3149,7 +4479,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8                                // Abbrev [8] 0x1482:0x5 DW_TAG_pointer_type
+ ; CHECK-NEXT: .b32 4926                            // DW_AT_type
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1487:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,116,114,116,111,108          // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 183                              // DW_AT_decl_line
+@@ -3164,7 +4499,13 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x14a7:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,116,114,116,111,117,108      // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 187                              // DW_AT_decl_line
+@@ -3179,7 +4520,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x14c8:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,121,115,116,101,109          // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 205                              // DW_AT_decl_line
+@@ -3191,7 +4537,14 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3389                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x14df:0x23 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 119,99,115,116,111,109,98,115    // DW_AT_name
++; CHECK-NEXT: .b8 119                              // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 109                              // DW_AT_decl_line
+@@ -3211,7 +4564,12 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 9                                // Abbrev [9] 0x1507:0x5 DW_TAG_const_type
+ ; CHECK-NEXT: .b32 5068                            // DW_AT_type
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x150c:0x1c DW_TAG_subprogram
+-; CHECK-NEXT: .b8 119,99,116,111,109,98            // DW_AT_name
++; CHECK-NEXT: .b8 119                              // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 98
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 102                              // DW_AT_decl_line
+@@ -3225,7 +4583,15 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 5068                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 2                                // Abbrev [2] 0x1528:0x78 DW_TAG_namespace
+-; CHECK-NEXT: .b8 95,95,103,110,117,95,99,120,120  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 120
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 3                                // Abbrev [3] 0x1533:0x7 DW_TAG_imported_declaration
+ ; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
+@@ -3264,9 +4630,30 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 233                              // DW_AT_decl_line
+ ; CHECK-NEXT: .b32 5795                            // DW_AT_import
+ ; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x1572:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,57,95,95,103,110,117,95,99,120,120,51,100,105,118,69,120,120 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 120
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 100,105,118                      // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 214                              // DW_AT_decl_line
+@@ -3281,7 +4668,13 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 11                               // Abbrev [11] 0x15a0:0xf DW_TAG_typedef
+ ; CHECK-NEXT: .b32 5551                            // DW_AT_type
+-; CHECK-NEXT: .b8 108,108,100,105,118,95,116       // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 121                              // DW_AT_decl_line
+@@ -3290,7 +4683,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 117                              // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x15b3:0xf DW_TAG_member
+-; CHECK-NEXT: .b8 113,117,111,116                  // DW_AT_name
++; CHECK-NEXT: .b8 113                              // DW_AT_name
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 1508                            // DW_AT_type
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+@@ -3299,7 +4695,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 35
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 14                               // Abbrev [14] 0x15c2:0xe DW_TAG_member
+-; CHECK-NEXT: .b8 114,101,109                      // DW_AT_name
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 1508                            // DW_AT_type
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+@@ -3309,7 +4707,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 8
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 22                               // Abbrev [22] 0x15d1:0x13 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,69,120,105,116                // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 45                               // DW_AT_decl_line
+@@ -3321,7 +4723,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x15e4:0x16 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 108,108,97,98,115                // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 12                               // DW_AT_decl_line
+@@ -3333,7 +4739,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1508                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x15fa:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 108,108,100,105,118              // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 29                               // DW_AT_decl_line
+@@ -3347,7 +4757,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1508                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 16                               // Abbrev [16] 0x1615:0x16 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 97,116,111,108,108               // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 36                               // DW_AT_decl_line
+@@ -3359,7 +4773,13 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3389                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x162b:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,116,114,116,111,108,108      // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 209                              // DW_AT_decl_line
+@@ -3374,7 +4794,14 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x164c:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,116,114,116,111,117,108,108  // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 214                              // DW_AT_decl_line
+@@ -3389,12 +4816,38 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x166e:0x1a DW_TAG_base_type
+-; CHECK-NEXT: .b8 108,111,110,103,32,108,111,110,103,32,117,110,115,105,103,110,101,100,32,105,110,116 // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 7                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x1688:0x1b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,116,114,116,111,102          // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 172                              // DW_AT_decl_line
+@@ -3407,7 +4860,13 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 5250                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 10                               // Abbrev [10] 0x16a3:0x1c DW_TAG_subprogram
+-; CHECK-NEXT: .b8 115,116,114,116,111,108,100      // DW_AT_name
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 100
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 175                              // DW_AT_decl_line
+@@ -3420,14 +4879,37 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 5250                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x16bf:0xf DW_TAG_base_type
+-; CHECK-NEXT: .b8 108,111,110,103,32,100,111,117,98,108,101 // DW_AT_name
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 101
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 8                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x16ce:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,97,99,111,115,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,99,111,115,102                // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 62                               // DW_AT_decl_line
+@@ -3438,9 +4920,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x16ee:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,97,99,111,115,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,99,111,115,104,102            // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
+@@ -3451,9 +4948,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1710:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,97,115,105,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,115,105,110,102               // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 57                               // DW_AT_decl_line
+@@ -3464,9 +4974,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1730:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,97,115,105,110,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,115,105,110,104,102           // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 95                               // DW_AT_decl_line
+@@ -3477,9 +5002,25 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1752:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,97,116,97,110,50,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,116,97,110,50,102             // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 47                               // DW_AT_decl_line
+@@ -3492,9 +5033,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x177a:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,97,116,97,110,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,116,97,110,102                // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 52                               // DW_AT_decl_line
+@@ -3505,9 +5059,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x179a:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,97,116,97,110,104,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 97,116,97,110,104,102            // DW_AT_name
++; CHECK-NEXT: .b8 97                               // DW_AT_name
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 100                              // DW_AT_decl_line
+@@ -3518,9 +5087,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x17bc:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,99,98,114,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,98,114,116,102                // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 150                              // DW_AT_decl_line
+@@ -3531,9 +5113,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x17dc:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,99,101,105,108,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,101,105,108,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 155                              // DW_AT_decl_line
+@@ -3544,9 +5139,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x17fc:0x2e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,57,99,111,112,121,115,105,103,110,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,111,112,121,115,105,103,110,102 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 165                              // DW_AT_decl_line
+@@ -3559,9 +5176,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x182a:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,99,111,115,102,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,111,115,102                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 219                              // DW_AT_decl_line
+@@ -3572,9 +5200,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1848:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,99,111,115,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 99,111,115,104,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 99                               // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 32                               // DW_AT_decl_line
+@@ -3585,9 +5226,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1868:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,101,114,102,99,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,114,102,99,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 210                              // DW_AT_decl_line
+@@ -3598,9 +5252,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1888:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,101,114,102,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,114,102,102                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 200                              // DW_AT_decl_line
+@@ -3611,9 +5276,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x18a6:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,101,120,112,50,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,120,112,50,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 145                              // DW_AT_decl_line
+@@ -3624,9 +5302,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x18c6:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,101,120,112,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,120,112,102                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 14                               // DW_AT_decl_line
+@@ -3637,9 +5326,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x18e4:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,101,120,112,109,49,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 101,120,112,109,49,102           // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 101                              // DW_AT_name
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
+@@ -3650,9 +5354,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1906:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,102,97,98,115,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,97,98,115,102                // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 95                               // DW_AT_decl_line
+@@ -3663,9 +5380,23 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1926:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,102,100,105,109,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,100,105,109,102              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 80                               // DW_AT_decl_line
+@@ -3678,9 +5409,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x194c:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,102,108,111,111,114,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,108,111,111,114,102          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
+@@ -3691,9 +5437,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x196e:0x2a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,102,109,97,102,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,97,102                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 32                               // DW_AT_decl_line
+@@ -3708,9 +5467,23 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1998:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,102,109,97,120,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,97,120,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 110                              // DW_AT_decl_line
+@@ -3723,9 +5496,23 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x19be:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,102,109,105,110,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,105,110,102              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 105                              // DW_AT_decl_line
+@@ -3738,9 +5525,23 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x19e4:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,102,109,111,100,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,109,111,100,102              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 17                               // DW_AT_decl_line
+@@ -3753,9 +5554,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a0a:0x29 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,102,114,101,120,112,102,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 102,114,101,120,112,102          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 102                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 7                                // DW_AT_decl_line
+@@ -3768,9 +5586,25 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2377                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a33:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,104,121,112,111,116,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 104,121,112,111,116,102          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 104                              // DW_AT_name
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 110                              // DW_AT_decl_line
+@@ -3783,9 +5617,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a5b:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,105,108,111,103,98,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 105,108,111,103,98,102           // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
+@@ -3796,9 +5645,25 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1a7d:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,108,100,101,120,112,102,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,100,101,120,112,102          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 240                              // DW_AT_decl_line
+@@ -3811,9 +5676,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1aa5:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,108,103,97,109,109,97,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,103,97,109,109,97,102        // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 235                              // DW_AT_decl_line
+@@ -3824,9 +5706,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1ac9:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,108,108,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,108,114,105,110,116,102      // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 125                              // DW_AT_decl_line
+@@ -3837,9 +5736,28 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1aed:0x26 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,56,108,108,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,108,114,111,117,110,100,102  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 56
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 66                               // DW_AT_decl_line
+@@ -3850,9 +5768,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b13:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,108,111,103,49,48,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,49,48,102            // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 76                               // DW_AT_decl_line
+@@ -3863,9 +5796,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b35:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,108,111,103,49,112,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,49,112,102           // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
+@@ -3876,9 +5824,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b57:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,108,111,103,50,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,50,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
+@@ -3889,9 +5850,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b77:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,108,111,103,98,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,98,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
+@@ -3902,9 +5876,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1b97:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,108,111,103,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,111,103,102                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 67                               // DW_AT_decl_line
+@@ -3915,9 +5900,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1bb5:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,108,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,114,105,110,116,102          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 116                              // DW_AT_decl_line
+@@ -3928,9 +5928,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1bd7:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,108,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 108,114,111,117,110,100,102      // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 108                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 71                               // DW_AT_decl_line
+@@ -3941,9 +5958,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1bfb:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,109,111,100,102,102,102,80,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 109,111,100,102,102              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 109                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 12                               // DW_AT_decl_line
+@@ -3956,9 +5988,33 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 3345                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1c22:0x2b DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,48,110,101,97,114,98,121,105,110,116,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 110,101,97,114,98,121,105,110,116,102 // DW_AT_name
++; CHECK-NEXT: .b8 110                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 130                              // DW_AT_decl_line
+@@ -3969,9 +6025,34 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1c4d:0x31 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,48,110,101,120,116,97,102,116,101,114,102,102,102 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 110,101,120,116,97,102,116,101,114,102 // DW_AT_name
++; CHECK-NEXT: .b8 110                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 194                              // DW_AT_decl_line
+@@ -3984,9 +6065,21 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1c7e:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,112,111,119,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 112,111,119,102                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 119
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 112                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 119
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 47                               // DW_AT_decl_line
+@@ -3999,9 +6092,34 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1ca2:0x31 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,49,48,114,101,109,97,105,110,100,101,114,102,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,101,109,97,105,110,100,101,114,102 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 22                               // DW_AT_decl_line
+@@ -4014,9 +6132,29 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1cd3:0x31 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,114,101,109,113,117,111,102,102,102,80,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,101,109,113,117,111,102      // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 27                               // DW_AT_decl_line
+@@ -4031,9 +6169,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2377                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d04:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,114,105,110,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,105,110,116,102              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 111                              // DW_AT_decl_line
+@@ -4044,9 +6195,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d24:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,114,111,117,110,100,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,111,117,110,100,102          // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 61                               // DW_AT_decl_line
+@@ -4057,9 +6223,29 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d46:0x2c DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,56,115,99,97,108,98,108,110,102,102,108 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,99,97,108,98,108,110,102     // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 56
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 250                              // DW_AT_decl_line
+@@ -4072,9 +6258,27 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2917                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d72:0x2a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,115,99,97,108,98,110,102,102,105 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,99,97,108,98,110,102         // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 245                              // DW_AT_decl_line
+@@ -4087,9 +6291,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 2332                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1d9c:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,115,105,110,102,102  // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,105,110,102                  // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 210                              // DW_AT_decl_line
+@@ -4100,9 +6315,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1dba:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,115,105,110,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,105,110,104,102              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 37                               // DW_AT_decl_line
+@@ -4113,9 +6341,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1dda:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,115,113,114,116,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,113,114,116,102              // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 113
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 139                              // DW_AT_decl_line
+@@ -4126,9 +6367,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1dfa:0x1e DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,52,116,97,110,102,102   // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,97,110,102                   // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 252                              // DW_AT_decl_line
+@@ -4139,9 +6391,22 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1e18:0x20 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,53,116,97,110,104,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,97,110,104,102               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 42                               // DW_AT_decl_line
+@@ -4152,9 +6417,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1e38:0x24 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,55,116,103,97,109,109,97,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,103,97,109,109,97,102        // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 9                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 56                               // DW_AT_decl_line
+@@ -4165,9 +6447,24 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 26                               // Abbrev [26] 0x1e5c:0x22 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,76,54,116,114,117,110,99,102,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 116,114,117,110,99,102           // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 76
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 116                              // DW_AT_name
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 102
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 11                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 150                              // DW_AT_decl_line
+@@ -4178,16 +6475,105 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x1e7e:0x22a DW_TAG_structure_type
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 77                               // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x1e9c:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,120,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 120
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 78                               // DW_AT_decl_line
+@@ -4195,10 +6581,75 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x1eeb:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,121,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 121
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 79                               // DW_AT_decl_line
+@@ -4206,10 +6657,75 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x1f3a:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,122,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 122
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 122
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 80                               // DW_AT_decl_line
+@@ -4217,10 +6733,62 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x1f89:0x49 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,99,118,53,117,105,110,116,51,69 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 69
+ ; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 83                               // DW_AT_decl_line
+@@ -4232,7 +6800,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_artificial
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x1fd2:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
+@@ -4245,7 +6837,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_artificial
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x1ff9:0x2c DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
+@@ -4260,9 +6876,54 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 8422                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 31                               // Abbrev [31] 0x2025:0x43 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 83
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 82
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 83
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 61
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
+@@ -4277,9 +6938,51 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 8422                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 32                               // Abbrev [32] 0x2068:0x3f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,73,100,120,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 38
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 85                               // DW_AT_decl_line
+@@ -4294,7 +6997,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x20a8:0x2f DW_TAG_structure_type
+-; CHECK-NEXT: .b8 117,105,110,116,51               // DW_AT_name
++; CHECK-NEXT: .b8 117                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
+@@ -4341,16 +7048,105 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 7836                            // DW_AT_specification
+ ; CHECK-NEXT: .b8 1                                // DW_AT_inline
+ ; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x20f6:0x228 DW_TAG_structure_type
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 88                               // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x2114:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,120,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 120
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 89                               // DW_AT_decl_line
+@@ -4358,10 +7154,75 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x2163:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,121,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 121
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 90                               // DW_AT_decl_line
+@@ -4369,10 +7230,75 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x21b2:0x4f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,49,55,95,95,102,101,116,99,104,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 98,117,105,108,116,105,110,95,122,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 122
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 122
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 91                               // DW_AT_decl_line
+@@ -4380,9 +7306,60 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x2201:0x47 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,99,118,52,100,105,109,51,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,100,105,109,51 // DW_AT_name
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 94                               // DW_AT_decl_line
+@@ -4394,7 +7371,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_artificial
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x2248:0x27 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
+@@ -4407,7 +7408,31 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_artificial
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x226f:0x2c DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
+@@ -4422,9 +7447,54 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 9181                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 31                               // Abbrev [31] 0x229b:0x43 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 83
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 82
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 83
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 61
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
+@@ -4439,9 +7509,51 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 9181                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 32                               // Abbrev [32] 0x22de:0x3f DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,53,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,98,108,111,99,107,68,105,109,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 68
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 38
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 96                               // DW_AT_decl_line
+@@ -4456,7 +7568,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 35                               // Abbrev [35] 0x231e:0x9d DW_TAG_structure_type
+-; CHECK-NEXT: .b8 100,105,109,51                   // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
+@@ -4493,7 +7608,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 35
+ ; CHECK-NEXT: .b8 8
+ ; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x234f:0x21 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 100,105,109,51                   // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 165                              // DW_AT_decl_line
+@@ -4511,7 +7629,10 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 5207                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 23                               // Abbrev [23] 0x2370:0x17 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 100,105,109,51                   // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 166                              // DW_AT_decl_line
+@@ -4525,9 +7646,39 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 9152                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 37                               // Abbrev [37] 0x2387:0x33 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,52,100,105,109,51,99,118,53,117,105,110,116,51,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 167                              // DW_AT_decl_line
+@@ -4544,7 +7695,11 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 8990                            // DW_AT_type
+ ; CHECK-NEXT: .b8 20                               // Abbrev [20] 0x23c0:0xe DW_TAG_typedef
+ ; CHECK-NEXT: .b32 8360                            // DW_AT_type
+-; CHECK-NEXT: .b8 117,105,110,116,51               // DW_AT_name
++; CHECK-NEXT: .b8 117                              // DW_AT_name
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 14                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 127                              // DW_AT_decl_line
+@@ -4563,16 +7718,107 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 8468                            // DW_AT_specification
+ ; CHECK-NEXT: .b8 1                                // DW_AT_inline
+ ; CHECK-NEXT: .b8 27                               // Abbrev [27] 0x23ed:0x233 DW_TAG_structure_type
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_byte_size
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 66                               // DW_AT_decl_line
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x240c:0x50 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 95,98,117,105,108,116,105,110,95,120,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,120 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 120
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 67                               // DW_AT_decl_line
+@@ -4580,10 +7826,76 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x245c:0x50 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 95,98,117,105,108,116,105,110,95,121,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,121 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 121
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 68                               // DW_AT_decl_line
+@@ -4591,10 +7903,76 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 28                               // Abbrev [28] 0x24ac:0x50 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,49,55,95,95,102,101,116,99,104 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 95,98,117,105,108,116,105,110,95,122,69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 122
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 95,95,102,101,116,99,104,95,98,117,105,108,116,105,110,95,122 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 122
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 69                               // DW_AT_decl_line
+@@ -4602,10 +7980,63 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_declaration
+ ; CHECK-NEXT: .b8 1                                // DW_AT_external
+ ; CHECK-NEXT: .b8 25                               // Abbrev [25] 0x24fc:0x4a DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,99,118,53,117,105,110,116,51 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 69,118
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,32,117,105,110,116,51 // DW_AT_name
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 51
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 72                               // DW_AT_decl_line
+@@ -4617,7 +8048,32 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_artificial
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x2546:0x28 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
+@@ -4630,7 +8086,32 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 1                                // DW_AT_artificial
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 30                               // Abbrev [30] 0x256e:0x2d DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_name
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
+@@ -4645,9 +8126,55 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 9775                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 31                               // Abbrev [31] 0x259b:0x44 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,97,83,69,82,75,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,61 // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 83
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 82
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 83
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 61
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
+@@ -4662,9 +8189,52 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 9775                            // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 32                               // Abbrev [32] 0x25df:0x40 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,78,75,50,54,95,95,99,117,100,97,95,98,117,105,108,116,105,110,95,116,104,114,101,97,100,73,100,120,95,116,97,100,69,118 // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 78
++; CHECK-NEXT: .b8 75
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 54
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 104
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 73
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 100
++; CHECK-NEXT: .b8 69
++; CHECK-NEXT: .b8 118
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 111,112,101,114,97,116,111,114,38 // DW_AT_name
++; CHECK-NEXT: .b8 111                              // DW_AT_name
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 38
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 13                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 74                               // DW_AT_decl_line
+@@ -4692,9 +8262,20 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b32 9228                            // DW_AT_specification
+ ; CHECK-NEXT: .b8 1                                // DW_AT_inline
+ ; CHECK-NEXT: .b8 38                               // Abbrev [38] 0x263f:0x32 DW_TAG_subprogram
+-; CHECK-NEXT: .b8 95,90,51,114,101,115,102,102,80,102 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 114,101,115                      // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
+@@ -4713,7 +8294,9 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
+ ; CHECK-NEXT: .b32 1554                            // DW_AT_type
+ ; CHECK-NEXT: .b8 39                               // Abbrev [39] 0x2665:0xb DW_TAG_formal_parameter
+-; CHECK-NEXT: .b8 114,101,115                      // DW_AT_name
++; CHECK-NEXT: .b8 114                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 115
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 3                                // DW_AT_decl_line
+@@ -4724,9 +8307,26 @@ if.end:                                           ; preds = %if.then, %entry
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 156
+-; CHECK-NEXT: .b8 95,90,53,115,97,120,112,121,105,102,80,102,83,95 // DW_AT_MIPS_linkage_name
+-; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 115,97,120,112,121               // DW_AT_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 121
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 80
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 83
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 0
++; CHECK-NEXT: .b8 115                              // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 120
++; CHECK-NEXT: .b8 112
++; CHECK-NEXT: .b8 121
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 12                               // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 5                                // DW_AT_decl_line
+diff --git a/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll b/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
+index e1366b970ca..f1510e1b4a9 100644
+--- a/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
++++ b/llvm/test/DebugInfo/NVPTX/debug-loc-offset.ll
+@@ -168,7 +168,8 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ ; CHECK-NEXT: .b8 1                                // DW_FORM_addr
+ ; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -202,7 +203,8 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ ; CHECK-NEXT: .b8 1                                // DW_FORM_addr
+ ; CHECK-NEXT: .b8 64                               // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 10                               // DW_FORM_block1
+-; CHECK-NEXT: .b8 135,64                           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 135                              // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 64
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+ ; CHECK-NEXT: .b8 3                                // DW_AT_name
+ ; CHECK-NEXT: .b8 8                                // DW_FORM_string
+@@ -250,14 +252,74 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ ; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+ ; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
+ ; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x8f DW_TAG_compile_unit
+-; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,50,49,48,52,55,57,41 // DW_AT_producer
++; CHECK-NEXT: .b8 99                               // DW_AT_producer
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 40
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 41
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_language
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 100,101,98,117,103,45,108,111,99,45,111,102,102,115,101,116,50,46,99,99 // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 45
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 45
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: .b8 47,108,108,118,109,95,99,109,97,107,101,95,103,99,99 // DW_AT_comp_dir
++; CHECK-NEXT: .b8 47                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin1                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end1                      // DW_AT_high_pc
+@@ -270,9 +332,18 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ ; CHECK-NEXT: .b64 Lfunc_end1                      // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 156
+-; CHECK-NEXT: .b8 95,90,51,98,97,122,49,65         // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 122
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 65
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 98,97,122                        // DW_AT_name
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 122
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 2                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 6                                // DW_AT_decl_line
+@@ -291,14 +362,74 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ ; CHECK-NEXT: .b32 .debug_abbrev                   // Offset Into Abbrev. Section
+ ; CHECK-NEXT: .b8 8                                // Address Size (in bytes)
+ ; CHECK-NEXT: .b8 1                                // Abbrev [1] 0xb:0x91 DW_TAG_compile_unit
+-; CHECK-NEXT: .b8 99,108,97,110,103,32,118,101,114,115,105,111,110,32,51,46,53,46,48,32,40,50,49,48,52,55,57,41 // DW_AT_producer
++; CHECK-NEXT: .b8 99                               // DW_AT_producer
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 105
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 53
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 32
++; CHECK-NEXT: .b8 40
++; CHECK-NEXT: .b8 50
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 48
++; CHECK-NEXT: .b8 52
++; CHECK-NEXT: .b8 55
++; CHECK-NEXT: .b8 57
++; CHECK-NEXT: .b8 41
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 4                                // DW_AT_language
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 100,101,98,117,103,45,108,111,99,45,111,102,102,115,101,116,49,46,99,99 // DW_AT_name
++; CHECK-NEXT: .b8 100                              // DW_AT_name
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 117
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 45
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 45
++; CHECK-NEXT: .b8 111
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 102
++; CHECK-NEXT: .b8 115
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 116
++; CHECK-NEXT: .b8 49
++; CHECK-NEXT: .b8 46
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b32 .debug_line                     // DW_AT_stmt_list
+-; CHECK-NEXT: .b8 47,108,108,118,109,95,99,109,97,107,101,95,103,99,99 // DW_AT_comp_dir
++; CHECK-NEXT: .b8 47                               // DW_AT_comp_dir
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 108
++; CHECK-NEXT: .b8 118
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 109
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 107
++; CHECK-NEXT: .b8 101
++; CHECK-NEXT: .b8 95
++; CHECK-NEXT: .b8 103
++; CHECK-NEXT: .b8 99
++; CHECK-NEXT: .b8 99
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b64 Lfunc_begin0                    // DW_AT_low_pc
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+@@ -307,9 +438,17 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ ; CHECK-NEXT: .b64 Lfunc_end0                      // DW_AT_high_pc
+ ; CHECK-NEXT: .b8 1                                // DW_AT_frame_base
+ ; CHECK-NEXT: .b8 156
+-; CHECK-NEXT: .b8 95,90,51,98,97,114,105           // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 95                               // DW_AT_MIPS_linkage_name
++; CHECK-NEXT: .b8 90
++; CHECK-NEXT: .b8 51
++; CHECK-NEXT: .b8 98
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
++; CHECK-NEXT: .b8 105
+ ; CHECK-NEXT: .b8 0
+-; CHECK-NEXT: .b8 98,97,114                        // DW_AT_name
++; CHECK-NEXT: .b8 98                               // DW_AT_name
++; CHECK-NEXT: .b8 97
++; CHECK-NEXT: .b8 114
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_file
+ ; CHECK-NEXT: .b8 1                                // DW_AT_decl_line
+@@ -323,7 +462,9 @@ attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "n
+ ; CHECK-NEXT: .b32 148                             // DW_AT_type
+ ; CHECK-NEXT: .b8 0                                // End Of Children Mark
+ ; CHECK-NEXT: .b8 7                                // Abbrev [7] 0x94:0x7 DW_TAG_base_type
+-; CHECK-NEXT: .b8 105,110,116                      // DW_AT_name
++; CHECK-NEXT: .b8 105                              // DW_AT_name
++; CHECK-NEXT: .b8 110
++; CHECK-NEXT: .b8 116
+ ; CHECK-NEXT: .b8 0
+ ; CHECK-NEXT: .b8 5                                // DW_AT_encoding
+ ; CHECK-NEXT: .b8 4                                // DW_AT_byte_size
+-- 
+2.22.0
+


### PR DESCRIPTION
This backports patches from LLVM 9 enabling us to emit debuginfo for NVPTX on LLVM 8 and is one way to fix https://github.com/JuliaGPU/CUDAnative.jl/issues/428
