### PR TITLE
RFC: Allow calls to `exit` from within exit hooks

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -300,15 +300,23 @@ const atexit_hooks = Callable[Filesystem.temp_cleanup_purge]
 
 Register a zero-argument function `f()` to be called at process exit. `atexit()` hooks are
 called in last in first out (LIFO) order and run before object finalizers.
+
+Exit hooks are allowed to call `exit(n)`, in which case Julia will exit with
+exit code `n` (instead of the original exit code). If more than one exit hook
+calls `exit(n)`, then Julia will exit with the exit code corresponding to the
+last called exit hook that calls `exit(n)`. (Because exit hooks are called in
+LIFO order, "last called" is equivalent to "first registered".)
 """
 atexit(f::Function) = (pushfirst!(atexit_hooks, f); nothing)
 
 function _atexit()
-    for f in atexit_hooks
+    while !isempty(atexit_hooks)
+        f = popfirst!(atexit_hooks)
         try
             f()
-        catch err
-            show(stderr, err)
+        catch ex
+            showerror(stderr, ex)
+            Base.show_backtrace(stderr, catch_backtrace())
             println(stderr)
         end
     end

--- a/test/atexit.jl
+++ b/test/atexit.jl
@@ -1,0 +1,152 @@
+using Test
+
+@testset "atexit.jl" begin
+    function _atexit_tests_gen_cmd_eval(expr::String)
+        cmd_eval = ```
+        $(Base.julia_cmd()) -e $(expr)
+        ```
+        return cmd_eval
+    end
+    function _atexit_tests_gen_cmd_script(temp_dir::String, expr::String)
+        script, io = mktemp(temp_dir)
+        println(io, expr)
+        close(io)
+        cmd_script = ```
+        $(Base.julia_cmd()) $(script)
+        ```
+        return cmd_script
+    end
+    atexit_temp_dir = mktempdir()
+    atexit(() -> rm(atexit_temp_dir; force = true, recursive = true))
+    @testset "these should exit with exit code 0" begin
+        julia_expr_list = Dict(
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(0))
+            exit(22)
+            """ => 0,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test success(cmd_eval)
+            @test success(cmd_script)
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    @testset "these should exit with exit code 1" begin
+        julia_expr_list = Dict(
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(1))
+            exit(22)
+            """ => 1,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> println("No error"))
+            atexit(() -> exit(1))
+            exit(22)
+            """ => 1,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(1))
+            atexit(() -> exit(1))
+            exit(22)
+            """ => 1,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test_throws ProcessFailedException run(cmd_eval)
+            @test_throws ProcessFailedException run(cmd_script)
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    @testset "test exit codes other than 0 or 1" begin
+        julia_expr_list = Dict(
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(13))
+            exit(22)
+            """ => 13,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> println("No error"))
+            atexit(() -> exit(5))
+            exit(22)
+            """ => 5,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(33))
+            atexit(() -> exit(33))
+            exit(22)
+            """ => 33,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(21))
+            atexit(() -> exit(21))
+            exit(22)
+            """ => 21,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test_throws(ProcessFailedException, run(cmd_eval))
+            @test_throws(ProcessFailedException, run(cmd_script))
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    @testset "test what happens if multiple places call exit(n)" begin
+        julia_expr_list = Dict(
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(22))
+            atexit(() -> exit(11))
+            atexit(() -> exit(33))
+            """ => 22,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            """
+            atexit(() -> exit(4))
+            atexit(() -> exit(16))
+            atexit(() -> exit(7))
+            exit(22)
+            """ => 4,
+            # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test_throws(ProcessFailedException, run(cmd_eval))
+            @test_throws(ProcessFailedException, run(cmd_script))
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    rm(atexit_temp_dir; force = true, recursive = true)
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -54,7 +54,7 @@ function choosetests(choices = [])
         "checked", "bitset", "floatfuncs", "precompile",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
-        "reinterpretarray", "syntax", "logging", "missing", "asyncmap"
+        "reinterpretarray", "syntax", "logging", "missing", "asyncmap", "atexit"
     ]
 
     tests = []


### PR DESCRIPTION
Fixes #31743 

This is an alternative to pull request #32253. I personally prefer the approach in #32253. 

This pull request allows calls to `exit(n)` from within exit hooks registered with `Base.atexit`.

From the updated docstring for `Base.atexit`:
- Exit hooks are allowed to call `exit(n)`, in which case Julia will exit with
exit code `n` (instead of the original exit code). If more than one exit hook
calls `exit(n)`, then Julia will exit with the exit code corresponding to the
last called exit hook that calls `exit(n)`. (Because exit hooks are called in
LIFO order, "last called" is equivalent to "first registered".)

I have included some tests. They are located in the `test/atexit.jl` file.