### PR TITLE
Fix various alignment violations

### DIFF
--- a/src/flisp/cvalues.c
+++ b/src/flisp/cvalues.c
@@ -242,7 +242,8 @@ static int cvalue_##ctype##_init(fl_context_t *fl_ctx, fltype_t *type, \
     else {                                                             \
         return 1;                                                      \
     }                                                                  \
-    *((fl_##ctype##_t*)dest) = n;                                      \
+    memcpy(jl_assume_aligned(dest, sizeof(void*)), &n,                 \
+            sizeof(fl_##ctype##_t));                                   \
     return 0;                                                          \
 }
 num_init(int8, int32, T_INT8)

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -990,11 +990,12 @@ static uint32_t process_keys(fl_context_t *fl_ctx, value_t kwtable,
     ((int16_t)                                  \
     ((((int16_t)a[0])<<0)  |                    \
      (((int16_t)a[1])<<8)))
-#define PUT_INT32(a,i) (*(int32_t*)(a) = bswap_32((int32_t)(i)))
+#define PUT_INT32(a,i) jl_store_unaligned_i32((void*)a,
+    (uint32_t)bswap_32((int32_t)(i)))
 #else
-#define GET_INT32(a) (*(int32_t*)a)
-#define GET_INT16(a) (*(int16_t*)a)
-#define PUT_INT32(a,i) (*(int32_t*)(a) = (int32_t)(i))
+#define GET_INT32(a) (int32_t)jl_load_unaligned_i32((void*)a)
+#define GET_INT16(a) (int16_t)jl_load_unaligned_i16((void*)a)
+#define PUT_INT32(a,i) jl_store_unaligned_i32((void*)a, (uint32_t)(i))
 #endif
 #define SWAP_INT32(a) (*(int32_t*)(a) = bswap_32(*(int32_t*)(a)))
 #define SWAP_INT16(a) (*(int16_t*)(a) = bswap_16(*(int16_t*)(a)))

--- a/src/julia.h
+++ b/src/julia.h
@@ -20,13 +20,16 @@
 #include <setjmp.h>
 #ifndef _OS_WINDOWS_
 #  define jl_jmp_buf sigjmp_buf
-#  if defined(_CPU_ARM_) || defined(_CPU_PPC_)
+#  if defined(_CPU_ARM_) || defined(_CPU_PPC_) || defined(_CPU_WASM_)
 #    define MAX_ALIGN 8
 #  elif defined(_CPU_AARCH64_)
 // int128 is 16 bytes aligned on aarch64
 #    define MAX_ALIGN 16
+#  elif defined(_P64)
+// Generically we assume MAX_ALIGN is sizeof(void*)
+#    define MAX_ALIGN 8
 #  else
-#    define MAX_ALIGN sizeof(void*)
+#    define MAX_ALIGN 4
 #  endif
 #else
 #  include "win32_ucontext.h"

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -100,7 +100,7 @@ typedef struct {
     // variables for allocating objects from pools
 #ifdef _P64
 #  define JL_GC_N_POOLS 41
-#elif defined(_CPU_ARM_) || defined(_CPU_PPC_)
+#elif MAX_ALIGN == 8
 #  define JL_GC_N_POOLS 42
 #else
 #  define JL_GC_N_POOLS 43

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -891,7 +891,7 @@ static void jl_write_gv_ints(jl_serializer_state *s)
 
 static inline uint32_t load_uint32(uintptr_t *base)
 {
-    uint32_t v = **(uint32_t**)base;
+    uint32_t v = jl_load_unaligned_i32((void*)*base);
     *base += 4;
     return v;
 }

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -131,6 +131,74 @@
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)
 #endif
 
+#ifdef __has_builtin
+#  define jl_has_builtin(x) __has_builtin(x)
+#else
+#  define jl_has_builtin(x) 0
+#endif
+
+#if jl_has_builtin(__builtin_assume)
+#define jl_assume(cond) (__extension__ ({               \
+                __typeof__(cond) cond_ = (cond);        \
+                __builtin_assume(!!(cond_));            \
+                cond_;                                  \
+            }))
+#elif defined(_COMPILER_MICROSOFT_) && defined(__cplusplus)
+template<typename T>
+static inline T
+jl_assume(T v)
+{
+    __assume(!!v);
+    return v;
+}
+#elif defined(_COMPILER_INTEL_)
+#define jl_assume(cond) (__extension__ ({               \
+                __typeof__(cond) cond_ = (cond);        \
+                __assume(!!(cond_));                    \
+                cond_;                                  \
+            }))
+#elif defined(__GNUC__)
+static inline void jl_assume_(int cond)
+{
+    if (!cond) {
+        __builtin_unreachable();
+    }
+}
+#define jl_assume(cond) (__extension__ ({               \
+                __typeof__(cond) cond_ = (cond);        \
+                jl_assume_(!!(cond_));                  \
+                cond_;                                  \
+            }))
+#else
+#define jl_assume(cond) (cond)
+#endif
+
+#if jl_has_builtin(__builtin_assume_aligned) || defined(_COMPILER_GCC_)
+#define jl_assume_aligned(ptr, align) __builtin_assume_aligned(ptr, align)
+#elif defined(_COMPILER_INTEL_)
+#define jl_assume_aligned(ptr, align) (__extension__ ({         \
+                __typeof__(ptr) ptr_ = (ptr);                   \
+                __assume_aligned(ptr_, align);                  \
+                ptr_;                                           \
+            }))
+#elif defined(__GNUC__)
+#define jl_assume_aligned(ptr, align) (__extension__ ({         \
+                __typeof__(ptr) ptr_ = (ptr);                   \
+                jl_assume(((uintptr_t)ptr) % (align) == 0);     \
+                ptr_;                                           \
+            }))
+#elif defined(__cplusplus)
+template<typename T>
+static inline T
+jl_assume_aligned(T ptr, unsigned align)
+{
+    (void)jl_assume(((uintptr_t)ptr) % align == 0);
+    return ptr;
+}
+#else
+#define jl_assume_aligned(ptr, align) (ptr)
+#endif
+
 typedef int bool_t;
 typedef unsigned char  byte_t;   /* 1 byte */
 
@@ -221,12 +289,35 @@ typedef enum { T_INT8, T_UINT8, T_INT16, T_UINT16, T_INT32, T_UINT32,
 #define JL_UNUSED
 #endif
 
+STATIC_INLINE double jl_load_unaligned_f64(const void *ptr) JL_NOTSAFEPOINT
+{
+    double val;
+    memcpy(&val, ptr, sizeof(double));
+    return val;
+}
+
 STATIC_INLINE uint64_t jl_load_unaligned_i64(const void *ptr) JL_NOTSAFEPOINT
 {
     uint64_t val;
-    memcpy(&val, ptr, 8);
+    memcpy(&val, ptr, sizeof(uint64_t));
     return val;
 }
+
+STATIC_INLINE double jl_load_ptraligned_f64(const void *ptr) JL_NOTSAFEPOINT
+{
+    double val;
+    memcpy(&val, jl_assume_aligned(ptr, sizeof(void*)), sizeof(double));
+    return val;
+}
+
+STATIC_INLINE uint64_t jl_load_ptraligned_i64(const void *ptr) JL_NOTSAFEPOINT
+{
+    uint64_t val;
+    memcpy(&val, jl_assume_aligned(ptr, sizeof(void*)), sizeof(uint64_t));
+    return val;
+}
+
+
 STATIC_INLINE uint32_t jl_load_unaligned_i32(const void *ptr) JL_NOTSAFEPOINT
 {
     uint32_t val;

--- a/src/support/operators.c
+++ b/src/support/operators.c
@@ -21,35 +21,37 @@ double conv_to_double(void *data, numerictype_t tag)
     case T_UINT16: d = (double)*(uint16_t*)data; break;
     case T_INT32:  d = (double)*(int32_t*)data; break;
     case T_UINT32: d = (double)*(uint32_t*)data; break;
-    case T_INT64:
-        d = (double)*(int64_t*)data;
-        if (d > 0 && *(int64_t*)data < 0)  // can happen!
+    case T_INT64: {
+        int64_t l = (int64_t)jl_load_ptraligned_i64(data);
+        d = (double)l;
+        if (d > 0 && l < 0)  // can happen!
             d = -d;
         break;
-    case T_UINT64: d = (double)*(uint64_t*)data; break;
+    }
+    case T_UINT64: d = (double)jl_load_ptraligned_i64(data); break;
     case T_FLOAT:  d = (double)*(float*)data; break;
-    case T_DOUBLE: return *(double*)data;
+    case T_DOUBLE: return jl_load_ptraligned_f64(data);
     }
     return d;
 }
 
-#define CONV_TO_INTTYPE(type)                               \
-type##_t conv_to_##type(void *data, numerictype_t tag)      \
-{                                                           \
-    type##_t i=0;                                           \
-    switch (tag) {                                          \
-    case T_INT8:   i = (type##_t)*(int8_t*)data; break;     \
-    case T_UINT8:  i = (type##_t)*(uint8_t*)data; break;    \
-    case T_INT16:  i = (type##_t)*(int16_t*)data; break;    \
-    case T_UINT16: i = (type##_t)*(uint16_t*)data; break;   \
-    case T_INT32:  i = (type##_t)*(int32_t*)data; break;    \
-    case T_UINT32: i = (type##_t)*(uint32_t*)data; break;   \
-    case T_INT64:  i = (type##_t)*(int64_t*)data; break;    \
-    case T_UINT64: i = (type##_t)*(uint64_t*)data; break;   \
-    case T_FLOAT:  i = (type##_t)*(float*)data; break;      \
-    case T_DOUBLE: i = (type##_t)*(double*)data; break;     \
-    }                                                       \
-    return i;                                               \
+#define CONV_TO_INTTYPE(type)                                                  \
+type##_t conv_to_##type(void *data, numerictype_t tag)                         \
+{                                                                              \
+    type##_t i=0;                                                              \
+    switch (tag) {                                                             \
+    case T_INT8:   i = (type##_t)*(int8_t*)data; break;                        \
+    case T_UINT8:  i = (type##_t)*(uint8_t*)data; break;                       \
+    case T_INT16:  i = (type##_t)*(int16_t*)(data); break;                     \
+    case T_UINT16: i = (type##_t)*(uint16_t*)(data); break;                    \
+    case T_INT32:  i = (type##_t)*(int32_t*)(data); break;                     \
+    case T_UINT32: i = (type##_t)*(uint32_t*)(data); break;                    \
+    case T_INT64:  i = (type##_t)(int64_t)jl_load_ptraligned_i64(data); break; \
+    case T_UINT64: i = (type##_t)jl_load_ptraligned_i64(data); break;          \
+    case T_FLOAT:  i = (type##_t)*(float*)data; break;                         \
+    case T_DOUBLE: i = (type##_t)jl_load_ptraligned_f64(data); break;          \
+    }                                                                          \
+    return i;                                                                  \
 }
 
 CONV_TO_INTTYPE(int64)
@@ -69,8 +71,8 @@ uint64_t conv_to_uint64(void *data, numerictype_t tag)
     case T_UINT16: i = (uint64_t)*(uint16_t*)data; break;
     case T_INT32:  i = (uint64_t)*(int32_t*)data; break;
     case T_UINT32: i = (uint64_t)*(uint32_t*)data; break;
-    case T_INT64:  i = (uint64_t)*(int64_t*)data; break;
-    case T_UINT64: i = (uint64_t)*(uint64_t*)data; break;
+    case T_INT64:  i = (uint64_t)jl_load_ptraligned_i64(data); break;
+    case T_UINT64: i = (uint64_t)jl_load_ptraligned_i64(data); break;
     case T_FLOAT:
         if (*(float*)data >= 0)
             i = (uint64_t)*(float*)data;
@@ -78,10 +80,10 @@ uint64_t conv_to_uint64(void *data, numerictype_t tag)
             i = (uint64_t)(int64_t)*(float*)data;
         break;
     case T_DOUBLE:
-        if (*(double*)data >= 0)
-            i = (uint64_t)*(double*)data;
+        if (jl_load_ptraligned_f64(data) >= 0)
+            i = (uint64_t)jl_load_ptraligned_f64(data);
         else
-            i = (uint64_t)(int64_t)*(double*)data;
+            i = (uint64_t)(int64_t)jl_load_ptraligned_f64(data);
         break;
     }
     return i;
@@ -96,10 +98,10 @@ int cmp_same_lt(void *a, void *b, numerictype_t tag)
     case T_UINT16: return *(uint16_t*)a < *(uint16_t*)b;
     case T_INT32:  return *(int32_t*)a < *(int32_t*)b;
     case T_UINT32: return *(uint32_t*)a < *(uint32_t*)b;
-    case T_INT64:  return *(int64_t*)a < *(int64_t*)b;
-    case T_UINT64: return *(uint64_t*)a < *(uint64_t*)b;
+    case T_INT64:  return (int64_t)jl_load_ptraligned_i64(a) < (int64_t)jl_load_ptraligned_i64(b);
+    case T_UINT64: return jl_load_ptraligned_i64(a) < jl_load_ptraligned_i64(b);
     case T_FLOAT:  return *(float*)a < *(float*)b;
-    case T_DOUBLE: return *(double*)a < *(double*)b;
+    case T_DOUBLE: return jl_load_ptraligned_f64(a) < jl_load_ptraligned_f64(b);
     }
     return 0;
 }
@@ -113,10 +115,10 @@ int cmp_same_eq(void *a, void *b, numerictype_t tag)
     case T_UINT16: return *(uint16_t*)a == *(uint16_t*)b;
     case T_INT32:  return *(int32_t*)a == *(int32_t*)b;
     case T_UINT32: return *(uint32_t*)a == *(uint32_t*)b;
-    case T_INT64:  return *(int64_t*)a == *(int64_t*)b;
-    case T_UINT64: return *(uint64_t*)a == *(uint64_t*)b;
+    case T_INT64:  return jl_load_ptraligned_i64(a) == jl_load_ptraligned_i64(b);
+    case T_UINT64: return jl_load_ptraligned_i64(a) == jl_load_ptraligned_i64(b);
     case T_FLOAT:  return *(float*)a == *(float*)b;
-    case T_DOUBLE: return *(double*)a == *(double*)b;
+    case T_DOUBLE: return jl_load_ptraligned_f64(a) == jl_load_ptraligned_f64(b);
     }
     return 0;
 }
@@ -138,38 +140,40 @@ int cmp_lt(void *a, numerictype_t atag, void *b, numerictype_t btag)
 
     if (atag == T_UINT64) {
         if (btag == T_INT64) {
-            if (*(int64_t*)b >= 0) {
-                return (*(uint64_t*)a < (uint64_t)*(int64_t*)b);
+            if ((int64_t)jl_load_ptraligned_i64(b) >= 0) {
+                return (jl_load_ptraligned_i64(a) < jl_load_ptraligned_i64(b));
             }
-            return ((int64_t)*(uint64_t*)a < *(int64_t*)b);
+            return ((int64_t)jl_load_ptraligned_i64(a) <
+                    (int64_t)jl_load_ptraligned_i64(b));
         }
         else if (btag == T_DOUBLE) {
             if (db != db) return 0;
-            return (*(uint64_t*)a < (uint64_t)*(double*)b);
+            return (jl_load_ptraligned_i64(a) < (uint64_t)jl_load_ptraligned_f64(b));
         }
     }
     else if (atag == T_INT64) {
         if (btag == T_UINT64) {
-            if (*(int64_t*)a >= 0) {
-                return ((uint64_t)*(int64_t*)a < *(uint64_t*)b);
+            if ((int64_t)jl_load_ptraligned_i64(a) >= 0) {
+                return (jl_load_ptraligned_i64(a) < jl_load_ptraligned_i64(b));
             }
-            return (*(int64_t*)a < (int64_t)*(uint64_t*)b);
+            return ((int64_t)jl_load_ptraligned_i64(a) <
+                    (int64_t)jl_load_ptraligned_i64(b));
         }
         else if (btag == T_DOUBLE) {
             if (db != db) return 0;
-            return (*(int64_t*)a < (int64_t)*(double*)b);
+            return ((int64_t)jl_load_ptraligned_i64(a) < (int64_t)jl_load_ptraligned_f64(b));
         }
     }
     if (btag == T_UINT64) {
         if (atag == T_DOUBLE) {
             if (da != da) return 0;
-            return (*(uint64_t*)b > (uint64_t)*(double*)a);
+            return (jl_load_ptraligned_i64(b) > (uint64_t)jl_load_ptraligned_f64(a));
         }
     }
     else if (btag == T_INT64) {
         if (atag == T_DOUBLE) {
             if (da != da) return 0;
-            return (*(int64_t*)b > (int64_t)*(double*)a);
+            return ((int64_t)jl_load_ptraligned_i64(b) > (int64_t)jl_load_ptraligned_f64(a));
         }
     }
     return 0;
@@ -200,34 +204,30 @@ int cmp_eq(void *a, numerictype_t atag, void *b, numerictype_t btag,
         // this is safe because if a had been bigger than S64_MAX,
         // we would already have concluded that it's bigger than b.
         if (btag == T_INT64) {
-            return ((int64_t)*(uint64_t*)a == *(int64_t*)b);
+            return (jl_load_ptraligned_i64(a) == jl_load_ptraligned_i64(b));
         }
         else if (btag == T_DOUBLE) {
-            return (*(uint64_t*)a == (uint64_t)(int64_t)*(double*)b);
+            return (jl_load_ptraligned_i64(a) == (uint64_t)(int64_t)jl_load_ptraligned_f64(b));
         }
     }
     else if (atag == T_INT64) {
         if (btag == T_UINT64) {
-            return (*(int64_t*)a == (int64_t)*(uint64_t*)b);
+            return (jl_load_ptraligned_i64(a) == jl_load_ptraligned_i64(b));
         }
         else if (btag == T_DOUBLE) {
-            return (*(int64_t*)a == (int64_t)*(double*)b);
+            return ((int64_t)jl_load_ptraligned_i64(a) == (int64_t)jl_load_ptraligned_f64(b));
         }
     }
     else if (btag == T_UINT64) {
-        if (atag == T_INT64) {
-            return ((int64_t)*(uint64_t*)b == *(int64_t*)a);
-        }
-        else if (atag == T_DOUBLE) {
-            return (*(uint64_t*)b == (uint64_t)(int64_t)*(double*)a);
+        assert(atag != T_INT64); // Taken care of above
+        if (atag == T_DOUBLE) {
+            return (jl_load_ptraligned_i64(b) == (uint64_t)(int64_t)jl_load_ptraligned_f64(a));
         }
     }
     else if (btag == T_INT64) {
-        if (atag == T_UINT64) {
-            return (*(int64_t*)b == (int64_t)*(uint64_t*)a);
-        }
-        else if (atag == T_DOUBLE) {
-            return (*(int64_t*)b == (int64_t)*(double*)a);
+        assert(atag != T_UINT64); // Taken care of above
+        if (atag == T_DOUBLE) {
+            return ((int64_t)jl_load_ptraligned_i64(b) == (int64_t)jl_load_ptraligned_f64(a));
         }
     }
     return 1;


### PR DESCRIPTION
The C standard forbids accessing pointers that are not sufficiently
aligned for their base type under the penalty of undefined behavior.
On most architectures we support, this doesn't make a difference
(except if the compiler tries to SIMD things), but it does matter
on some (e.g. SAFE_HEAP mode in wasm), so make some progress
on using the proper unaligned accessors in various places that use
underaligned pointers.