### PR TITLE
[MAKE] duplicate SRCCACHE for out-of-tree builds

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,12 +1,13 @@
 ## high-level setup ##
 default: install
 SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-SRCCACHE := $(abspath $(SRCDIR)/srccache)
 JULIAHOME := $(abspath $(SRCDIR)/..)
 ifeq ($(abspath .),$(abspath $(SRCDIR)))
 BUILDDIR := scratch
+SRCCACHE := $(abspath $(SRCDIR)/srccache)
 else
 BUILDDIR := .
+SRCCACHE := $(abspath ./srccache)
 endif
 include $(SRCDIR)/Versions.make
 include $(JULIAHOME)/Make.inc


### PR DESCRIPTION
I just noticed that patches that were applied in one out-of-tree build directory were picked up in another.
