### PR TITLE
[LLVM8] Prepare debuginfo emission for NVPTX

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -926,6 +926,8 @@ function method_instances(@nospecialize(f), @nospecialize(t), world::UInt = type
     return results
 end
 
+default_debug_info_kind() = unsafe_load(cglobal(:jl_default_debug_info_kind, Cint))
+
 # this type mirrors jl_cgparams_t (documented in julia.h)
 struct CodegenParams
     cached::Cint
@@ -934,6 +936,8 @@ struct CodegenParams
     code_coverage::Cint
     static_alloc::Cint
     prefer_specsig::Cint
+    gnu_pubnames::Cint
+    debug_info_kind::Cint
 
     module_setup::Any
     module_activation::Any
@@ -944,11 +948,13 @@ struct CodegenParams
     CodegenParams(;cached::Bool=true,
                    track_allocations::Bool=true, code_coverage::Bool=true,
                    static_alloc::Bool=true, prefer_specsig::Bool=false,
+                   gnu_pubnames=true, debug_info_kind::Cint = default_debug_info_kind(),
                    module_setup=nothing, module_activation=nothing, raise_exception=nothing,
                    emit_function=nothing, emitted_function=nothing) =
         new(Cint(cached),
             Cint(track_allocations), Cint(code_coverage),
             Cint(static_alloc), Cint(prefer_specsig),
+            Cint(gnu_pubnames), debug_info_kind,
             module_setup, module_activation, raise_exception,
             emit_function, emitted_function)
 end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -340,7 +340,8 @@ static std::map<jl_fptr_args_t, Function*> builtin_func_map;
 // --- code generation ---
 extern "C" {
     int globalUnique = 0;
-    jl_cgparams_t jl_default_cgparams = {1, 1, 1, 1, 0, NULL, NULL, NULL, NULL, NULL};
+    int jl_default_debug_info_kind = (int) DICompileUnit::DebugEmissionKind::FullDebug;
+    jl_cgparams_t jl_default_cgparams = {1, 1, 1, 1, 0, 1, jl_default_debug_info_kind, NULL, NULL, NULL, NULL, NULL};
 }
 
 template<typename T>
@@ -5631,9 +5632,37 @@ static std::unique_ptr<Module> emit_function(
     DISubprogram *SP = NULL;
     DebugLoc noDbg, topdebugloc;
     if (ctx.debug_enabled) {
+        DICompileUnit::DebugEmissionKind emissionKind = (DICompileUnit::DebugEmissionKind) ctx.params->debug_info_kind;
+
+#if JL_LLVM_VERSION >= 80000
+        DICompileUnit::DebugNameTableKind tableKind;
+
+        if (JL_FEAT_TEST(ctx, gnu_pubnames)) {
+            tableKind = DICompileUnit::DebugNameTableKind::GNU;
+        }
+        else {
+            tableKind = DICompileUnit::DebugNameTableKind::None;
+        }
+#endif
         // TODO: Fix when moving to new LLVM version
         topfile = dbuilder.createFile(ctx.file, ".");
-        DICompileUnit *CU = dbuilder.createCompileUnit(0x01, topfile, "julia", true, "", 0);
+        DICompileUnit *CU =
+            dbuilder.createCompileUnit(0x01          // Language -- C89
+                                       ,topfile      // File
+                                       ,"julia"      // Producer
+                                       ,true         // isOptimized
+                                       ,""           // Flags
+                                       ,0            // RuntimeVersion
+                                       ,""           // SplitName
+                                       ,emissionKind // Kind
+                                       ,0            // DWOId
+                                       ,true         // SplitDebugInlining
+                                       ,false        // DebugInfoForProfiling
+#if JL_LLVM_VERSION >= 80000
+                                       ,tableKind    // NameTableKind
+#endif
+                                       );
+
         DISubroutineType *subrty;
         if (jl_options.debug_level <= 1) {
             subrty = jl_di_func_null_sig;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5644,10 +5644,9 @@ static std::unique_ptr<Module> emit_function(
             tableKind = DICompileUnit::DebugNameTableKind::None;
         }
 #endif
-        // TODO: Fix when moving to new LLVM version
         topfile = dbuilder.createFile(ctx.file, ".");
         DICompileUnit *CU =
-            dbuilder.createCompileUnit(0x01          // Language -- C89
+            dbuilder.createCompileUnit(llvm::dwarf::DW_LANG_Julia
                                        ,topfile      // File
                                        ,"julia"      // Producer
                                        ,true         // isOptimized

--- a/src/julia.h
+++ b/src/julia.h
@@ -1980,6 +1980,10 @@ typedef struct {
     int static_alloc;       // is the compiler allowed to allocate statically?
     int prefer_specsig;     // are specialized function signatures preferred?
 
+    // controls the emission of debug-info. mirrors the clang options
+    int gnu_pubnames;       // can we emit the gnu pubnames debuginfo
+    int debug_info_kind; // Enum for line-table-only, line-directives-only,
+                            // limited, standalone
 
     // hooks
 
@@ -2009,6 +2013,7 @@ typedef struct {
     jl_value_t *emitted_function;
 } jl_cgparams_t;
 extern JL_DLLEXPORT jl_cgparams_t jl_default_cgparams;
+extern JL_DLLEXPORT int jl_default_debug_info_kind;
 
 #if defined(JULIA_ENABLE_THREADING) && !defined(_OS_DARWIN_) && !defined(_OS_WINDOWS_)
 #define JULIA_DEFINE_FAST_TLS()                                                             \


### PR DESCRIPTION
Currently CUDAnative produces invalid NVPTX assembly on LLVM 8.0. During the development of 8.0 a lot of progress was made to enable debug information
for the NVPTX target, but in the release version it is turned off due to various bugs, my PR in #32496 backports from LLVM trunk/9.0 various fixes and the commit that enables debug-information. 

This PR configurates the debug- information emission to be compatible with the NVPTX target, this is necessary even without the full-support enabled.
As an example in the NVPTX IR for https://github.com/JuliaGPU/CUDAnative.jl/issues/428#issuecomment-507849310 
 we can see in https://gist.github.com/vchuravy/e83018007ef4ab1c7927e89f2a58e9c6#file-ptxcall_kernel_95-ptx-L404-L453 the emission of Label for GNU pubnames, even though
everything else is commented out (and yes they disabled emission by commenting it out)...

So this PR is necessary even if we decide not to go with #32496. 
