### PR TITLE
partr: fix rare segfault

### DIFF
--- a/src/partr.c
+++ b/src/partr.c
@@ -123,10 +123,10 @@ static inline int multiq_insert(jl_task_t *task, int16_t priority)
 
     heaps[rn].tasks[heaps[rn].ntasks++] = task;
     sift_up(&heaps[rn], heaps[rn].ntasks-1);
-    jl_mutex_unlock_nogc(&heaps[rn].lock);
     int16_t prio = jl_atomic_load(&heaps[rn].prio);
     if (task->prio < prio)
-        jl_atomic_compare_exchange(&heaps[rn].prio, prio, task->prio);
+        jl_atomic_store(&heaps[rn].prio, task->prio);
+    jl_mutex_unlock_nogc(&heaps[rn].lock);
 
     return 0;
 }


### PR DESCRIPTION
The write to 'prio' might be arbitrarily delayed, after some other
thread has already popped the task. This commit ensures that all writes
to that field are always behind the same lock as the modification to the
queue itself.

@RalphAS can you test to see if this fixes #32520 for you? We weren't able to reproduce, but from your debugging work, I was able to quickly find that this lock was getting released in the wrong place.