### PR TITLE
Tasking for Emscripten/Wasm target

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -607,7 +607,7 @@ function wait()
     W = Workqueues[Threads.threadid()]
     reftask = poptaskref(W)
     result = try_yieldto(ensure_rescheduled, reftask)
-    process_events()
+    Sys.isjsvm() || process_events()
     # return when we come out of the queue
     return result
 end

--- a/src/jsvm-emscripten/asyncify_setup.js
+++ b/src/jsvm-emscripten/asyncify_setup.js
@@ -1,0 +1,144 @@
+Module.preRun.push(function() {
+    if (typeof Asyncify !== "undefined") {
+        Asyncify.instrumentWasmExports = function (exports) { return exports; };
+        Asyncify.handleSleep = function (startAsync) {
+            if (ABORT) return;
+            Module['noExitRuntime'] = true;
+            if (Asyncify.state === Asyncify.State.Normal) {
+                // Prepare to sleep. Call startAsync, and see what happens:
+                // if the code decided to call our callback synchronously,
+                // then no async operation was in fact begun, and we don't
+                // need to do anything.
+                var reachedCallback = false;
+                var reachedAfterCallback = false;
+                var task = get_current_task();
+                startAsync(function(returnValue) {
+                assert(!returnValue || typeof returnValue === 'number'); // old emterpretify API supported other stuff
+                if (ABORT) return;
+                Asyncify.returnValue = returnValue || 0;
+                reachedCallback = true;
+                if (!reachedAfterCallback) {
+                    // We are happening synchronously, so no need for async.
+                    return;
+                }
+                schedule_and_wait(task);
+                });
+                reachedAfterCallback = true;
+                if (!reachedCallback) {
+                    Module['_jl_task_wait']();
+                }
+            } else if (Asyncify.state === Asyncify.State.Rewinding) {
+                // Stop a resume.
+                finish_schedule_task();
+            } else {
+                abort('invalid state: ' + Asyncify.state);
+            }
+            return Asyncify.returnValue;
+        };
+    }
+});
+
+function get_current_task() {
+    return Module['_jl_get_current_task']();
+}
+
+function get_root_task() {
+    return Module['_jl_get_root_task']();
+}
+
+function task_ctx_ptr(task) {
+    return Module["_task_ctx_ptr"](task);
+}
+
+function ctx_save(ctx) {
+    var stackPtr = stackSave();
+
+    // Save the bottom of the C stack in the task context. It simultaneously
+    // serves as the top of the asyncify stack.
+    HEAP32[ctx + 4 >> 2] = stackPtr;
+
+    Asyncify.state = Asyncify.State.Unwinding;
+    Module['_asyncify_start_unwind'](ctx);
+    if (Browser.mainLoop.func) {
+        Browser.mainLoop.pause();
+    }
+}
+
+function do_start_task(old_stack)
+{
+    try {
+        // start_task is always the entry point for any task
+        Module['_start_task']();
+    } catch(e) {
+        stackRestore(old_stack)
+        if (e !== e+0 && e !== 'killed') throw e;
+        maybe_schedule_next();
+        return;
+    }
+    // Either unwind or normal exit. In either case, we're back at the main task
+    if (Asyncify.state === Asyncify.State.Unwinding) {
+        // We just finished unwinding for a sleep.
+        Asyncify.state = Asyncify.State.Normal;
+        Module['_asyncify_stop_unwind']();
+    }
+    stackRestore(old_stack);
+    maybe_schedule_next();
+}
+
+function schedule_and_wait(task) {
+    Module['_jl_schedule_task'](task);
+    Module['_jl_task_wait']();
+}
+
+function finish_schedule_task() {
+    Asyncify.state = Asyncify.State.Normal;
+    Module['_asyncify_stop_rewind']();
+}
+
+next_ctx = 0;
+next_need_start = true;
+function set_next_ctx(ctx, needs_start) {
+    next_ctx = ctx;
+    next_need_start = needs_start;
+}
+
+function root_ctx() {
+    return task_ctx_ptr(get_root_task())
+}
+
+function ctx_switch(lastt_ctx) {
+    if (lastt_ctx == root_ctx()) {
+        // If we're in the root context, switch to
+        // the new ctx now, else we'll get there after
+        // unwinding.
+        return schedule_next()
+    } else if (lastt_ctx == 0) {
+        throw 'killed';
+    } else {
+        return ctx_save(lastt_ctx);
+    }
+}
+
+function schedule_next()
+{
+    old_stack = stackSave();
+    var next_task_stack = HEAP32[next_ctx + 4 >> 2];
+    if (!next_need_start) {
+        Asyncify.state = Asyncify.State.Rewinding;
+        Module['_asyncify_start_rewind'](next_ctx);
+        if (Browser.mainLoop.func) {
+            Browser.mainLoop.resume();
+        }
+    }
+    next_ctx = -1;
+    stackRestore(next_task_stack);
+    do_start_task(old_stack)
+}
+
+function maybe_schedule_next() {
+    assert(next_ctx != -1);
+    if (next_ctx == root_ctx() || next_ctx == 0) {
+        return;
+    }
+    schedule_next()
+}

--- a/src/jsvm-emscripten/task.js
+++ b/src/jsvm-emscripten/task.js
@@ -1,0 +1,15 @@
+mergeInto(LibraryManager.library, {
+  jl_set_fiber: function(ctx) {
+    set_next_ctx(ctx, false);
+    return ctx_switch(0)
+  },
+  jl_swap_fiber: function(lastt_ctx, ctx) {
+    set_next_ctx(ctx, false);
+    return ctx_switch(lastt_ctx)
+  },
+  jl_start_fiber: function(lastt_ctx, ctx) {
+    set_next_ctx(ctx, true);
+    return ctx_switch(lastt_ctx)
+  }
+});
+

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -16,6 +16,7 @@
 
 //  Options for task switching algorithm (in order of preference):
 // JL_HAVE_ASM -- mostly setjmp
+// JL_HAVE_ASYNCIFY -- task switching based on the binaryen asyncify transform
 // JL_HAVE_UNW_CONTEXT -- hybrid of libunwind for start, setjmp for resume
 // JL_HAVE_UCONTEXT -- posix standard API, requires syscall for resume
 // JL_HAVE_SIGALTSTACK -- requires several syscall for start, setjmp for resume
@@ -27,7 +28,8 @@ typedef win32_ucontext_t jl_ucontext_t;
 #if !defined(JL_HAVE_UCONTEXT) && \
     !defined(JL_HAVE_ASM) && \
     !defined(JL_HAVE_UNW_CONTEXT) && \
-    !defined(JL_HAVE_SIGALTSTACK)
+    !defined(JL_HAVE_SIGALTSTACK) && \
+    !defined(JL_HAVE_ASYNCIFY)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
      defined(_CPU_ARM_) || defined(_CPU_PPC64_))
 #define JL_HAVE_ASM
@@ -35,6 +37,8 @@ typedef win32_ucontext_t jl_ucontext_t;
 #define JL_HAVE_UNW_CONTEXT
 #elif defined(_OS_LINUX_)
 #define JL_HAVE_UCONTEXT
+#elif defined(_OS_EMSCRIPTEN_)
+#define JL_HAVE_ASYNCIFY
 #else
 #define JL_HAVE_UNW_CONTEXT
 #endif
@@ -43,6 +47,16 @@ typedef win32_ucontext_t jl_ucontext_t;
 #if defined(JL_HAVE_ASM) || defined(JL_HAVE_SIGALTSTACK)
 typedef struct {
     jl_jmp_buf uc_mcontext;
+} jl_ucontext_t;
+#endif
+#if defined(JL_HAVE_ASYNCIFY)
+typedef struct {
+    // This is the extent of the asyncify stack, but because the top of the
+    // asyncify stack (stacktop) is also the bottom of the C stack, we can
+    // reuse stacktop for both. N.B.: This matches the layout of the
+    // __asyncify_data struct.
+    void *stackbottom;
+    void *stacktop;
 } jl_ucontext_t;
 #endif
 #if defined(JL_HAVE_UCONTEXT) || defined(JL_HAVE_UNW_CONTEXT)

--- a/src/partr.c
+++ b/src/partr.c
@@ -505,9 +505,14 @@ JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *getsticky)
             start_cycles = 0;
         }
         else {
+#ifndef JL_HAVE_ASYNCIFY
             // maybe check the kernel for new messages too
             if (jl_atomic_load(&jl_uv_n_waiters) == 0)
                 jl_process_events(jl_global_event_loop());
+#else
+            // Yield back to browser event loop
+            return ptls->root_task;
+#endif
         }
     }
 }


### PR DESCRIPTION
This is an implementation of Julia's coroutine/tasking system on top of
the binaryen Bysyncify transform [1] recently implemented by @kripken.
The wasm target is unusual in several ways:

1. It has an implicitly managed call stack that we may not modify directly
   (i.e. is only modified through calls/returns).
2. The event loop is inverted, in that the browser runs the main event loop and
   we get callbacks for events, rather than Julia being the main event loop.

Bysyncify takes care of the first problem by providing a mechanism to explicitly
unwind and rewind the implicitly managed stack (essentially copying it to an
explicitly managed stack - see the linked implementation for more information).

For the second, I am currently using the ptls root_task to represent the browser
event loop, i.e. yielding to that task will return control back to the browser
and this is the task in which functions called by javascript will run unless they
explicitly construct a task to run. As a result, julia code executed in the main
task may not perform any blocking operations (though this is currently not enforced).
I think this is a sensible setup since the main task will want to run some minor julia
code (e.g. to introspect some data structures), but the bulk of the code will run in
their own tasks (e.g. the REPL backend task).

[1] https://github.com/WebAssembly/binaryen/blob/master/src/passes/Bysyncify.cpp