### PR TITLE
Add empty(::NamedTuple)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@ Standard library changes
   when operating over zero-dimensional arrays ([#32122]).
 * `IPAddr` subtypes now behave like scalars when used in broadcasting ([#32133]).
 * `clamp` can now handle missing values ([#31066]).
+* `empty` now accepts a `NamedTuple` ([#32534])
 
 #### Libdl
 

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -106,6 +106,7 @@ getindex(t::NamedTuple, i::Symbol) = getfield(t, i)
 indexed_iterate(t::NamedTuple, i::Int, state=1) = (getfield(t, i), i+1)
 isempty(::NamedTuple{()}) = true
 isempty(::NamedTuple) = false
+empty(::NamedTuple) = NamedTuple()
 
 convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names,T}) where {names,T<:Tuple} = nt
 convert(::Type{NamedTuple{names}}, nt::NamedTuple{names}) where {names} = nt

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -38,6 +38,8 @@
 
 @test isempty(NamedTuple())
 @test !isempty((a=1,))
+@test empty((a=1,)) === NamedTuple()
+@test isempty(empty((a=1,)))
 
 @test (a=1,b=2) === (a=1,b=2)
 @test (a=1,b=2) !== (b=1,a=2)


### PR DESCRIPTION
This PR adds a method `empty(::NamedTuple)` so that you can run

```julia
julia> empty((a=1,b=2))
NamedTuple()
```