### PR TITLE
Remove unnecessary and slow Bidiagonal times Vector fallback

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -632,7 +632,6 @@ function *(A::SymTridiagonal, B::Diagonal)
 end
 
 #Generic multiplication
-*(A::Bidiagonal{T}, B::AbstractVector{T}) where {T} = *(Array(A), B)
 *(adjA::Adjoint{<:Any,<:Bidiagonal{T}}, B::AbstractVector{T}) where {T} = *(adjoint(Array(adjA.parent)), B)
 *(A::Bidiagonal{T}, adjB::Adjoint{<:Any,<:AbstractVector{T}}) where {T} = *(Array(A), adjoint(adjB.parent))
 /(A::Bidiagonal{T}, B::AbstractVector{T}) where {T} = /(Array(A), B)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -631,12 +631,6 @@ function *(A::SymTridiagonal, B::Diagonal)
     A_mul_B_td!(Tridiagonal(zeros(TS, size(A, 1)-1), zeros(TS, size(A, 1)), zeros(TS, size(A, 1)-1)), A, B)
 end
 
-#Generic multiplication
-*(adjA::Adjoint{<:Any,<:Bidiagonal{T}}, B::AbstractVector{T}) where {T} = *(adjoint(Array(adjA.parent)), B)
-*(A::Bidiagonal{T}, adjB::Adjoint{<:Any,<:AbstractVector{T}}) where {T} = *(Array(A), adjoint(adjB.parent))
-/(A::Bidiagonal{T}, B::AbstractVector{T}) where {T} = /(Array(A), B)
-/(A::Bidiagonal{T}, adjB::Adjoint{<:Any,<:AbstractVector{T}}) where {T} = /(Array(A), adjoint(adjB.parent))
-
 #Linear solvers
 ldiv!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(A, b)
 ldiv!(A::Transpose{<:Any,<:Bidiagonal}, b::AbstractVector) = ldiv!(copy(A), b)


### PR DESCRIPTION
`Bidiagonal` times `AbstractVector` currently falls back to:

https://github.com/JuliaLang/julia/blob/f552fb2071fb1b2ad66d0ff4602f5ff88acbf3a3/stdlib/LinearAlgebra/src/bidiag.jl#L635

which is unnecessarily slow. Removing this causes it to fallback to the same multiplication that `Tridiagonal` etc uses, which is faster (this can also be improved further for structured matrices).

Some timings:

Current:

```julia
julia> A = Bidiagonal(rand(1000), rand(999), 'U'); x = rand(1000)

julia> @time A*x
  0.014599 seconds (7 allocations: 7.637 MiB)

julia> versioninfo()
Julia Version 1.1.1
Commit 55e36cc308 (2019-05-16 04:10 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.1 (ORCJIT, skylake)
```

This PR:

```julia

julia> A = Bidiagonal(rand(1000), rand(999), 'U'); x = rand(1000)

julia> @time A*x
  0.000020 seconds (6 allocations: 16.031 KiB)
```