### PR TITLE
allow for newlines in splitdrive

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -35,7 +35,7 @@ elseif Sys.iswindows()
     const path_ext_splitter = r"^((?:.*[/\\])?(?:\.|[^/\\\.])[^/\\]*?)(\.[^/\\\.]*|)$"
 
     function splitdrive(path::String)
-        m = match(r"^([^\\]+:|\\\\[^\\]+\\[^\\]+|\\\\\?\\UNC\\[^\\]+\\[^\\]+|\\\\\?\\[^\\]+:|)(.*)$", path)
+        m = match(r"^([^\\]+:|\\\\[^\\]+\\[^\\]+|\\\\\?\\UNC\\[^\\]+\\[^\\]+|\\\\\?\\[^\\]+:|)(.*)$"s, path)
         String(m.captures[1]), String(m.captures[2])
     end
 else

--- a/test/path.jl
+++ b/test/path.jl
@@ -124,6 +124,7 @@
     @testset "splitting" begin
         @test joinpath(splitdir(S(homedir()))...) == homedir()
         @test string(splitdrive(S(homedir()))...) == homedir()
+        @test splitdrive("a\nb") == ("", "a\nb")
 
         if Sys.iswindows()
             @test splitdrive(S("\\\\servername\\hello.world\\filename.ext")) ==


### PR DESCRIPTION
Allows for newlines ('\n') in strings passed to `splitdrive`