### PR TITLE
fix #32515, Dates test is locale dependent

### DIFF
--- a/stdlib/Dates/test/io.jl
+++ b/stdlib/Dates/test/io.jl
@@ -579,7 +579,7 @@ end
         @test Time(tmstruct) == t
         @test uppercase(t12) == Dates.format(t, "II:MMp") ==
                                 Dates.format(d, "II:MMp") ==
-              Libc.strftime("%I:%M%p", tmstruct)
+              uppercase(Libc.strftime("%I:%M%p", tmstruct))
     end
     for bad in ("00:24am", "00:24pm", "13:24pm", "2pm", "12:24p.m.", "12:24 pm", "12:24pµ")
         @eval @test_throws ArgumentError Time($bad, "II:MMp")


### PR DESCRIPTION
`Libc.strftime("%I:%M%p", tmstruct)` may end with upper or lowercase am/pm dependent on locale.
The tests assume uppercase, thus wrap it in a call to `uppercase`.

Note that while this makes tests also pass in locales where it would be lowercase, it does not in any way address the fact that julia ignores the locale as far as am/pm is concerned.
E.g.  https://github.com/JuliaLang/julia/blob/073cbbb4912fbc5ddd82163b31d18b203802fb47/stdlib/Dates/src/io.jl#L177