### PR TITLE
fix thread scheduler variable used

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -190,14 +190,12 @@ struct _jl_tls_states_t {
     // this is limited to the few places we do synchronous IO
     // we can make this more general (similar to defer_signal) if necessary
     volatile sig_atomic_t io_wait;
-#ifndef _OS_WINDOWS_
-    // These are only used on unix now
-    pthread_t system_id;
-    void *signal_stack;
-#endif
 #ifdef _OS_WINDOWS_
     int needs_resetstkoflw;
+#else
+    void *signal_stack;
 #endif
+    unsigned long system_id;
     // execution of certain certain impure
     // statements is prohibited from certain
     // callbacks (such as generated functions)

--- a/src/threading.c
+++ b/src/threading.c
@@ -241,6 +241,7 @@ JL_DLLEXPORT int16_t jl_threadid(void)
 void jl_init_threadtls(int16_t tid)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
+    ptls->system_id = jl_thread_self();
     seed_cong(&ptls->rngseed);
 #ifdef _OS_WINDOWS_
     if (tid == 0) {
@@ -251,8 +252,6 @@ void jl_init_threadtls(int16_t tid)
             hMainThread = INVALID_HANDLE_VALUE;
         }
     }
-#else
-    ptls->system_id = pthread_self();
 #endif
     assert(ptls->world_age == 0);
     ptls->world_age = 1; // OK to run Julia code on this thread

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ end
 # Base.compilecache only works from node 1, so precompile test is handled specially
 move_to_node1("precompile")
 move_to_node1("SharedArrays")
+move_to_node1("threads")
 # Ensure things like consuming all kernel pipe memory doesn't interfere with other tests
 move_to_node1("stress")
 

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -653,3 +653,15 @@ function pfib(n::Int)
     return pfib(n-1) + fetch(t)::Int
 end
 @test pfib(20) == 6765
+
+
+# scheduling wake/sleep test (#32511)
+let timeout = 300 # this test should take about 1-10 seconds
+    t = Timer(timeout) do t
+        ccall(:uv_kill, Cint, (Cint, Cint), getpid(), Base.SIGTERM)
+    end # set up a watchdog alarm
+    for _ = 1:10^5
+        @threads for idx in 1:1024; #=nothing=# end
+    end
+    close(t) # stop the watchdog
+end


### PR DESCRIPTION
It turns out that a scheduler can get stuck if you wake up the wrong thread. Who knew that using the wrong variable could cause such subtle issues. Might be a contender for worst-bug-debugging award (I'll let you parse that with any associativity you want).  Meanwhile, we get some extra optimizations too from staring at this code for several days straight.

fixes #32511

note that to reproduce more, it helps to disable `sleep_check_after_threshold`