### PR TITLE
Document assignment in multiple return values.

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -397,7 +397,7 @@ julia> x[1, [2 3; 4 1]]
  13  1
 ```
 
-## Assignment
+## [Assignment](@id multi-dim-arrays-assignment)
 
 The general syntax for assigning values in an n-dimensional array `A` is:
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -324,6 +324,23 @@ end
 
 This has the exact same effect as the previous definition of `foo`.
 
+[Assignment](@ref multi-dim-arrays-assignment) into arrays works as expected with multiple
+return values:
+```jldoctest
+julia> A = [0, 0]
+2-element Array{Int64,1}:
+ 0
+ 0
+
+julia> A[1], c = foo(2, 3)
+(5, 6)
+
+julia> A
+2-element Array{Int64,1}:
+ 5
+ 0
+```
+
 ## Argument destructuring
 
 The destructuring feature can also be used within a function argument.


### PR DESCRIPTION
Fixes #32547.

This is a *minimal* fix that explains the feature. I am not sure that the *Functions* section is the best place for it, as it has nothing to do with functions *per se*. Incidentally, there are no multiple return values in Julia, just a convenient mechanism that substitutes for it, so the whole section is a bit weird.

I did not go into details about corner cases, or what this is lowered to, since it is way too early in the docs for that in case it is read more or less linearly (even `setindex!`-style assignment comes later, which is why I linked it). Suggestions are welcome: I am happy to do more, but would prefer some advice on this.

@PaulSoderlind