### PR TITLE
Fix PDF doc build.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,7 @@ Standard library changes
 ------------------------
 
 * `Regex` can now be multiplied (`*`) and exponentiated (`^`), like strings ([#23422]).
-* `Cmd` interpolation (`` `$(x::Cmd) a b c` `` where) now propagates `x`'s process flags
+* `Cmd` interpolation (``` `$(x::Cmd) a b c` ``` where) now propagates `x`'s process flags
   (environment, flags, working directory, etc) if `x` is the first interpolant and errors
   otherwise ([#24353]).
 * Zero-dimensional arrays are now consistently preserved in the return values of mathematical


### PR DESCRIPTION
Julias Markdown treats double backticks as inline math, which makes the pdf doc build fail due to the $ in latex math mode.

cc @mortenpi 