### PR TITLE
Add LaTeX like sequence completions `\land`, `\lor` and `\lnot`

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -112,7 +112,7 @@ const latex_symbols = Dict(
     "\\to" => "→",
     "\\euler" => "ℯ",
     "\\ohm" => "Ω",
-    "\\lnot" => "¬"
+    "\\lnot" => "¬",
     "\\land" => "∧",
     "\\lor" => "∨",
 

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -112,6 +112,7 @@ const latex_symbols = Dict(
     "\\to" => "→",
     "\\euler" => "ℯ",
     "\\ohm" => "Ω",
+    "\\lnot" => "¬"
     "\\land" => "∧",
     "\\lor" => "∨",
 

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -112,6 +112,8 @@ const latex_symbols = Dict(
     "\\to" => "→",
     "\\euler" => "ℯ",
     "\\ohm" => "Ω",
+    "\\land" => "∧",
+    "\\lor" => "∨",
 
     # Superscripts
     "\\^0" => "⁰",


### PR DESCRIPTION
Add `\land` and `\lor`, they are synonyms of `\wedge` and `\vee`.
http://tug.ctan.org/info/symbols/comprehensive/symbols-a4.pdf, p. 32.