### PR TITLE
fix the docstring of min_enabled_level

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -49,7 +49,7 @@ function shouldlog end
 """
     min_enabled_level(logger)
 
-Return the maximum disabled level for `logger` for early filtering.  That is,
+Return the minimum enabled level for `logger` for early filtering.  That is,
 the log level below or equal to which all messages are filtered.
 """
 function min_enabled_level end


### PR DESCRIPTION
If I don't read it wrong, "the maximum disabled level" and "the minimum enabled level" are different by 1. That is, the minimum enabled level is the maximum disabled level plus one. Since this function returns the minimum enabled level as the function name suggests, I think this docstring should be fixed accordingly.