### PR TITLE
Better docs; was: Not silence error on creating symlink on Windows

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -808,7 +808,7 @@ function symlink(p::AbstractString, np::AbstractString)
     err = ccall(:jl_fs_symlink, Int32, (Cstring, Cstring, Cint), p, np, flags)
     @static if Sys.iswindows()
         if err < 0 && !isdir(p)
-            @warn "On Windows, creating file symlinks requires Administrator privileges" maxlog=1 _group=:file
+            throw("On Windows, creating file symlinks requires Administrator privileges")
         end
     end
     uv_error("symlink",err)

--- a/base/file.jl
+++ b/base/file.jl
@@ -790,7 +790,7 @@ Creates a symbolic link to `target` with the name `link`.
 
 !!! note
     This function raises an error under operating systems that do not support
-    soft symbolic links, such as Windows XP, or on newer when unless in Administrator mode.
+    soft symbolic links, such as Windows XP; and on later versions unless in Administrator mode.
 """
 function symlink(p::AbstractString, np::AbstractString)
     @static if Sys.iswindows()

--- a/base/file.jl
+++ b/base/file.jl
@@ -789,8 +789,8 @@ end
 Creates a symbolic link to `target` with the name `link`.
 
 !!! note
-    This function raises an error under operating systems that do not support
-    soft symbolic links, such as Windows XP; and on later versions unless in Administrator mode.
+    This function raises an error under operating systems that do not support soft symbolic links,
+    uch as Windows XP; and on later versions (by default) unless in Administrator mode.
 """
 function symlink(p::AbstractString, np::AbstractString)
     @static if Sys.iswindows()

--- a/base/file.jl
+++ b/base/file.jl
@@ -790,7 +790,7 @@ Creates a symbolic link to `target` with the name `link`.
 
 !!! note
     This function raises an error under operating systems that do not support
-    soft symbolic links, such as Windows XP.
+    soft symbolic links, such as Windows XP, or on newer when unless in Administrator mode.
 """
 function symlink(p::AbstractString, np::AbstractString)
     @static if Sys.iswindows()
@@ -808,7 +808,7 @@ function symlink(p::AbstractString, np::AbstractString)
     err = ccall(:jl_fs_symlink, Int32, (Cstring, Cstring, Cint), p, np, flags)
     @static if Sys.iswindows()
         if err < 0 && !isdir(p)
-            throw("On Windows, creating file symlinks requires Administrator privileges")
+            @warn "On Windows, creating file symlinks requires Administrator privileges" maxlog=1 _group=:file
         end
     end
     uv_error("symlink",err)


### PR DESCRIPTION
It doesn't seem sensible. Seems e.g. Java doesn't:

https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createSymbolicLink-java.nio.file.Path-java.nio.file.Path-java.nio.file.attribute.FileAttribute...-

#7274