### PR TITLE
Very WIP: Mutually recursive types

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1308,6 +1308,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("TypeName", (jl_value_t*)jl_typename_type);
     add_builtin("DataType", (jl_value_t*)jl_datatype_type);
     add_builtin("TypeVar", (jl_value_t*)jl_tvar_type);
+    add_builtin("Placeholder", (jl_value_t*)jl_placeholder_type);
     add_builtin("UnionAll", (jl_value_t*)jl_unionall_type);
     add_builtin("Union", (jl_value_t*)jl_uniontype_type);
     add_builtin("TypeofBottom", (jl_value_t*)jl_typeofbottom_type);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -907,7 +907,9 @@ static int valid_type_param(jl_value_t *v)
     if (jl_is_vararg_type(v))
         return 0;
     // TODO: maybe more things
-    return jl_is_type(v) || jl_is_typevar(v) || jl_is_symbol(v) || jl_isbits(jl_typeof(v));
+    return jl_is_type(v) || jl_is_typevar(v) ||
+        jl_is_symbol(v) || jl_isbits(jl_typeof(v)) ||
+        jl_typeis(v, jl_placeholder_type);
 }
 
 JL_CALLABLE(jl_f_apply_type)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -84,6 +84,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     t->isdispatchtuple = 0;
     t->isbitstype = 0;
     t->zeroinit = 0;
+    t->incomplete = 0;
     t->isinlinealloc = 0;
     t->has_concrete_subtype = 1;
     t->layout = NULL;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -504,6 +504,13 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
     t->name->names = fnames;
     jl_gc_wb(t->name, t->name->names);
 
+    for (int i = 0; i < jl_svec_len(t->parameters); ++i) {
+        jl_value_t *p = jl_svecref(t->parameters, i);
+        if (jl_typeis(p, jl_placeholder_type)) {
+            dt_mark_incomplete(t, (jl_placeholder_t*)p);
+        }
+    }
+
     if (t->name->wrapper == NULL) {
         t->name->wrapper = (jl_value_t*)t;
         jl_gc_wb(t->name, t);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1323,6 +1323,24 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         jl_compute_field_offsets(ndt);
     }
 
+    for (int i = 0; ndt->types && i < jl_svec_len(ndt->types); ++i) {
+        jl_value_t *v = jl_svecref(ndt->types, i);
+        if (jl_typeis(v, jl_placeholder_type)) {
+            dt_mark_incomplete(ndt, v);
+        } else if (jl_is_datatype(v) && ((jl_datatype_t*)v)->incomplete) {
+            dt_mark_incomplete(ndt, v);
+        }
+    }
+
+    for (int i = 0; ndt->parameters && i < jl_svec_len(ndt->parameters); ++i) {
+        jl_value_t *p = jl_svecref(ndt->parameters, i);
+        if (jl_typeis(p, jl_placeholder_type)) {
+            dt_mark_incomplete(ndt, p);
+        } else if (jl_is_datatype(p) && ((jl_datatype_t*)p)->incomplete) {
+            dt_mark_incomplete(ndt, p);
+        }
+    }
+
     if (istuple)
         ndt->ninitialized = ntp - isvatuple;
     else if (isnamedtuple)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -39,6 +39,7 @@ jl_typename_t *jl_vecelement_typename;
 jl_unionall_t *jl_vararg_type;
 jl_typename_t *jl_vararg_typename;
 jl_datatype_t *jl_tvar_type;
+jl_datatype_t *jl_placeholder_type;
 jl_datatype_t *jl_uniontype_type;
 jl_datatype_t *jl_unionall_type;
 jl_datatype_t *jl_datatype_type;
@@ -1707,7 +1708,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_datatype_type->name->wrapper = (jl_value_t*)jl_datatype_type;
     jl_datatype_type->super = (jl_datatype_t*)jl_type_type;
     jl_datatype_type->parameters = jl_emptysvec;
-    jl_datatype_type->name->names = jl_perm_symsvec(21,
+    jl_datatype_type->name->names = jl_perm_symsvec(23,
                                                     "name",
                                                     "super",
                                                     "parameters",
@@ -1720,6 +1721,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                                     "uid",
                                                     "abstract",
                                                     "mutable",
+                                                    "incomplete",
                                                     "hasfreetypevars",
                                                     "isconcretetype",
                                                     "isdispatchtuple",
@@ -1728,8 +1730,10 @@ void jl_init_types(void) JL_GC_DISABLED
                                                     "isinlinealloc",
                                                     "has_concrete_subtype",
                                                     "llvm::StructType",
-                                                    "llvm::DIType");
-    jl_datatype_type->types = jl_svec(21,
+                                                    "llvm::DIType",
+                                                    "padding");
+
+    jl_datatype_type->types = jl_svec(23,
                                       jl_typename_type,
                                       jl_datatype_type,
                                       jl_simplevector_type,
@@ -1738,7 +1742,8 @@ void jl_init_types(void) JL_GC_DISABLED
                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type,
                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type,
                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type,
-                                      jl_any_type, jl_any_type, jl_any_type);
+                                      jl_any_type, jl_any_type, jl_any_type, jl_any_type,
+                                      jl_any_type);
     jl_datatype_type->instance = NULL;
     jl_datatype_type->uid = jl_assign_type_uid();
     jl_datatype_type->struct_decl = NULL;
@@ -2004,6 +2009,11 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_array_symbol_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_symbol_type, jl_box_long(1));
     jl_array_uint8_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_uint8_type, jl_box_long(1));
     jl_array_int32_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_int32_type, jl_box_long(1));
+
+    jl_placeholder_type = jl_new_datatype(jl_symbol("Placeholder"), core, jl_any_type, jl_emptysvec,
+                                   jl_perm_symsvec(1, "dependents"),
+                                   jl_svec(1, jl_array_any_type),
+                                   0, 1, 1);
 
     jl_expr_type =
         jl_new_datatype(jl_symbol("Expr"), core,
@@ -2297,8 +2307,10 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_datatype_type->types, 16, jl_bool_type);
     jl_svecset(jl_datatype_type->types, 17, jl_bool_type);
     jl_svecset(jl_datatype_type->types, 18, jl_bool_type);
-    jl_svecset(jl_datatype_type->types, 19, jl_voidpointer_type);
+    jl_svecset(jl_datatype_type->types, 19, jl_bool_type);
     jl_svecset(jl_datatype_type->types, 20, jl_voidpointer_type);
+    jl_svecset(jl_datatype_type->types, 21, jl_voidpointer_type);
+    jl_svecset(jl_datatype_type->types, 22, jl_voidpointer_type);
     jl_svecset(jl_typename_type->types, 1, jl_module_type);
     jl_svecset(jl_typename_type->types, 6, jl_long_type);
     jl_svecset(jl_typename_type->types, 3, jl_type_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1198,6 +1198,16 @@ JL_DLLEXPORT jl_value_t *jl_new_structt(jl_datatype_t *type, jl_value_t *tup);
 JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
 JL_DLLEXPORT jl_method_instance_t *jl_new_method_instance_uninit(void);
 JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...) JL_MAYBE_UNROOTED;
+#ifdef __GNUC__
+#define jl_svec(n, ...) \
+    (jl_svec)(                                                               \
+        __extension__({                                                      \
+            void *names[] = { __VA_ARGS__ };                                 \
+            _Static_assert(n == sizeof(names)/sizeof(names[0]),              \
+            "Number of passed arguments does not match expected number");    \
+            n;                                                               \
+        }), __VA_ARGS__)
+#endif
 JL_DLLEXPORT jl_svec_t *jl_svec1(void *a);
 JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b);
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n);

--- a/src/julia.h
+++ b/src/julia.h
@@ -487,6 +487,8 @@ typedef struct _jl_module_t {
     int32_t nospecialize;  // global bit flags: initialization for new methods
     uint8_t istopmod;
     jl_mutex_t lock;
+    // Any method definitions that are deferred to due to incomplete types
+    arraylist_t deferred;
 } jl_module_t;
 
 // one Type-to-Value entry

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -277,6 +277,17 @@ jl_value_t *jl_permbox32(jl_datatype_t *t, int32_t x);
 jl_value_t *jl_permbox64(jl_datatype_t *t, int64_t x);
 jl_svec_t *jl_perm_symsvec(size_t n, ...);
 
+#ifdef __GNUC__
+#define jl_perm_symsvec(n, ...) \
+    (jl_perm_symsvec)(                                                       \
+        __extension__({                                                      \
+            const char *names[] = { __VA_ARGS__ };                           \
+            _Static_assert(n == sizeof(names)/sizeof(names[0]),              \
+            "Number of passed arguments does not match expected number");    \
+            n;                                                               \
+        }), __VA_ARGS__)
+#endif
+
 // Returns a int32 where the high 16 bits are a lower bound of the number of non-pointer fields
 // at the beginning of the type and the low 16 bits are a lower bound on the number of non-pointer
 // fields at the end of the type. This field only exists for a layout that has at least one

--- a/src/module.c
+++ b/src/module.c
@@ -38,6 +38,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     JL_MUTEX_INIT(&m->lock);
     htable_new(&m->bindings, 0);
     arraylist_new(&m->usings, 0);
+    arraylist_new(&m->deferred, 0);
     if (jl_core_module) {
         jl_module_using(m, jl_core_module);
     }

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -7,7 +7,7 @@
 #include "julia_internal.h"
 #include "julia_assert.h"
 
-JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
+JL_DLLEXPORT jl_svec_t *(jl_svec)(size_t n, ...)
 {
     va_list args;
     if (n == 0) return jl_emptysvec;
@@ -19,7 +19,7 @@ JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
     return jv;
 }
 
-jl_svec_t *jl_perm_symsvec(size_t n, ...)
+jl_svec_t *(jl_perm_symsvec)(size_t n, ...)
 {
     if (n == 0) return jl_emptysvec;
     jl_svec_t *jv = (jl_svec_t*)jl_gc_permobj((n + 1) * sizeof(void*), jl_simplevector_type);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -506,9 +506,9 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
 
     // The deferred list should be empty
     memset(&newm->deferred._space, 0, sizeof(newm->deferred._space));
-    newm->deferred.len = 1;
+    newm->deferred.len = 0;
     newm->deferred.max = AL_N_INLINE;
-    newm->deferred.items = (void**)offsetof(jl_module_t, usings._space);
+    newm->deferred.items = (void**)offsetof(jl_module_t, deferred._space);
     arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_module_t, deferred.items)));
     arraylist_push(&s->relocs_list, (void*)(((uintptr_t)DataRef << RELOC_TAG_OFFSET) + item));
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -55,7 +55,7 @@ static void *const _tags[] = {
          &jl_uint32_type, &jl_uint64_type, &jl_char_type, &jl_weakref_type,
          &jl_int8_type, &jl_int16_type, &jl_uint16_type,
          &jl_float16_type, &jl_float32_type, &jl_float64_type, &jl_floatingpoint_type,
-         &jl_number_type, &jl_signed_type,
+         &jl_number_type, &jl_signed_type, &jl_placeholder_type,
          // special typenames
          &jl_tuple_typename, &jl_pointer_typename, &jl_array_typename, &jl_type_typename,
          &jl_vararg_typename, &jl_namedtuple_typename,

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -504,6 +504,14 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
     newm->bindings.table = NULL;
     memset(&newm->bindings._space, 0, sizeof(newm->bindings._space));
 
+    // The deferred list should be empty
+    memset(&newm->deferred._space, 0, sizeof(newm->deferred._space));
+    newm->deferred.len = 1;
+    newm->deferred.max = AL_N_INLINE;
+    newm->deferred.items = (void**)offsetof(jl_module_t, usings._space);
+    arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_module_t, deferred.items)));
+    arraylist_push(&s->relocs_list, (void*)(((uintptr_t)DataRef << RELOC_TAG_OFFSET) + item));
+
     // write out the usings list
     memset(&newm->usings._space, 0, sizeof(newm->usings._space));
     if (m == jl_main_module) {

--- a/test/incomplete.jl
+++ b/test/incomplete.jl
@@ -1,0 +1,33 @@
+using Test
+
+macro placeholder(sym)
+    :(const $(esc(sym)) = $(Expr(:new, Core.Placeholder, :(Any[]))))
+end
+
+@placeholder Bar1
+struct Foo1
+    x::Bar1
+end
+@test length(methods(Foo1)) == 0
+@test Foo1.incomplete
+struct Bar1
+    x::Foo1
+end
+@test length(methods(Bar1)) == 2
+@test length(methods(Foo1)) == 2
+
+
+@placeholder Bar2
+@placeholder Baz2
+struct Foo2
+    x::Bar2
+    y::Baz2
+end
+@test Foo2.incomplete
+struct Bar2
+    x::Foo2
+end
+@test length(methods(Bar2)) == 0
+@test Bar2.incomplete
+struct Baz2; end
+@test !Foo2.incomplete && !Bar2.incomplete


### PR DESCRIPTION
This is a very WIP start at #269. In fact it's so WIP that it doesn't build and is probably not worth looking at the code in its current form (http://wiki.c2.com/?PlanToThrowOneAway).

Here's how things currently work on this PR:
```
incomplete type Bar end
struct Foo; b::Bar; end
struct Bar; b::Foo; end
```

this declares two mutually recursive structs Foo and Bar, with an explicit forward declaration for Bar. At the moment this is being accomplished by having `Bar` be an incomplete DataType that then gets updated in place when it is completed. However, I suspect this will need to be changed to a more general mechanism with pointers being replaced after the fact, since in general we don't necessarily want to assume that `Bar` will be a DataType (e.g. as in the `Union` example in #269).

We also keep track of the completeness or non-completness of any given data type:
```
julia> incomplete type Bar end

julia> Bar.incomplete
0x1

julia> struct Foo; b::Bar; end

julia> Foo.incomplete
0x2

julia> struct Bar; b::Foo; end

julia> Bar.incomplete
0x0

julia> Foo.incomplete
0x0
```
(0x0 indicates complete). All types in a strongly connected component of the dependency graph are finalized together when the last dependency of the SCC is resolved. 

Additionally, incomplete types are invalid in subtyping, so method definitions are delayed until
the relevant types are completed:
```
julia> incomplete type Bar end

julia> f(x::Bar) = 1
f (generic function with 0 methods)

julia> struct Bar; end

julia> f
f (generic function with 1 method)
```

I'm planning to require all types to be completed by the end of their defining module, though I haven't implemented that yet, i.e. we'd have:
```
julia> module X; incomplete type Foo end; end
ERROR: Type `Foo` remained incomplete at the end of the module
```

Additionally, there's of course the question of automatically inserting forward definitions. I think that's more of a UX tradeoff than a technical one. I see basically three possibilities.

1. Insert forward declarations automatically for any undefined identifier directly attached to a declaration, i.e.
```
struct Foo
x::NotDefinedYet
end
```
would be semantically equivalent to
```
# Potentially with some sort of weak binding that allows redefinition, and forbids reference
# outside a struct definitions
incomplete type NotDefinedYet end 
struct Foo
x::NotDefinedYet
end
```
though of course this would be done in the runtime, not during lowering, since we don't know what identifiers have been defined already during lowering.

This'd probably be the most convenient, but I'm slightly worried about causing user confusion as to when the RHS of a struct definition is evaluated, particularly wrt evaluated definitions:
```
struct Foo
x::identity(NotDefinedYet) # Error: NotDefinedYet not defined
end
```

I'm also a bit worried about user confusion around typos, e.g.
```
struct Foo
x::Int31
end

# Foo is now incomplete, with no obvious error particularly at the REPL where the module never ends
```

That could probably be addressed with appropriate error messages and warnings, but I think it's a not-insignificant concern.

2. Insert forward declarations in lowering for blocks that are lowered together.

This is basically what was proposed in #269. Note that I don't actually think this lets us avoid any technical difficulties over the other proposal, but does of course have a more limited scope for the automatic forward declarations so avoids some of the UX difficulties of the previous option. To recap, the proposal would be that:
```
begin
    struct Foo; x::Bar; end
    struct Bar; x::Foo; end
end
```
would lower to
```
begin
    incomplete type Bar end
    struct Foo; x::Bar; end
    struct Bar; x::Foo; end
end
```

I think the biggest problem with this is that it makes the extent of the lowering scope semantically significant at top level, far more than anything else in the language. I.e. you could no longer safely paste the inside of that `begin/end` block into the REPL (particularly if we allow it without begin/end in an enclosing module or at the file level).

3. Do nothing, require explicit forward declarations

Simple, but perhaps not satisfying.

Anyway, comments welcome. cc @StefanKarpinski @JeffBezanson 