### PR TITLE
avoid finalizing LLVMContext on exit

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -148,7 +148,7 @@ extern void _chkstk(void);
 #define DISABLE_FLOAT16
 
 // llvm state
-JL_DLLEXPORT LLVMContext jl_LLVMContext;
+JL_DLLEXPORT LLVMContext &jl_LLVMContext = *(new LLVMContext());
 TargetMachine *jl_TargetMachine;
 
 extern JITEventListener *CreateJuliaJITEventListener();
@@ -160,7 +160,7 @@ Module *shadow_output;
 #define jl_Module ctx.f->getParent()
 #define jl_builderModule(builder) (builder).GetInsertBlock()->getParent()->getParent()
 
-static DataLayout jl_data_layout("");
+static DataLayout &jl_data_layout = *(new DataLayout(""));
 
 // types
 static Type *T_jlvalue;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -191,7 +191,7 @@ private:
     SymbolTableT LocalSymbolTable;
 };
 extern JuliaOJIT *jl_ExecutionEngine;
-JL_DLLEXPORT extern LLVMContext jl_LLVMContext;
+JL_DLLEXPORT extern LLVMContext &jl_LLVMContext;
 
 Pass *createLowerPTLSPass(bool imaging_mode);
 Pass *createCombineMulAddPass();


### PR DESCRIPTION
I observed a rare event during process exit, where the LLVMContext destructor was being called while another thread was trying to compile something. This change avoids that, by making the context a pointer that we leak.

cc @maleadt since this changes the type of `jl_LLVMContext`.