### PR TITLE
fix #32582, type intersection bug in unions

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2026,8 +2026,14 @@ static jl_value_t *intersect_union(jl_value_t *x, jl_uniontype_t *u, jl_stenv_t 
         jl_value_t *a=NULL, *b=NULL;
         JL_GC_PUSH2(&a, &b);
         jl_unionstate_t oldRunions = e->Runions;
-        a = R ? intersect_all(x, u->a, e) : intersect_all(u->a, x, e);
-        b = R ? intersect_all(x, u->b, e) : intersect_all(u->b, x, e);
+        if (param == 2) {
+            a = R ? intersect(x, u->a, e, param) : intersect(u->a, x, e, param);
+            b = R ? intersect(x, u->b, e, param) : intersect(u->b, x, e, param);
+        }
+        else {
+            a = R ? intersect_all(x, u->a, e) : intersect_all(u->a, x, e);
+            b = R ? intersect_all(x, u->b, e) : intersect_all(u->b, x, e);
+        }
         e->Runions = oldRunions;
         jl_value_t *i = simple_join(a,b);
         JL_GC_POP();

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1392,6 +1392,18 @@ end
 @testintersect((Tuple{Int, Array{T}} where T),
                (Tuple{Any, Vector{Union{Missing,Nothing,T}}} where T),
                (Tuple{Int, Vector{Union{Missing,Nothing,T}}} where T))
+# issue #32582
+let A = Tuple{Any, Type{Union{Nothing, Int64}}},
+    B = Tuple{T, Type{Union{Nothing, T}}} where T,
+    I = typeintersect(A, B),
+    J = typeintersect(B, A)
+    # TODO: improve precision
+    @test I >: Tuple{Int64,Type{Union{Nothing, Int64}}}
+    @test J >: Tuple{Int64,Type{Union{Nothing, Int64}}}
+end
+@testintersect(Union{Array{T,1},Array{T,2}} where T<:Union{Float32,Float64},
+               Union{AbstractMatrix{Float32},AbstractVector{Float32}},
+               Union{Array{Float32,2}, Array{Float32,1}})
 
 # issue #29955
 struct M29955{T, TV<:AbstractVector{T}}


### PR DESCRIPTION
Caused by 4f8a7b965a98c307f48820c35ca98f9d754096a9; reverts part of that.

fix #32582