### PR TITLE
Add unwrap function to allow wrapper types to avoid over-overloading convert

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -166,11 +166,20 @@ function convert end
 convert(::Type{Any}, @nospecialize(x)) = x
 convert(::Type{T}, x::T) where {T} = x
 
+"""
+    Base.unwrap(x)
+
+Lower, or "unwrap" a value that has Base-defined representation. Currently
+only used in a generic `convert(::Type{T}, x)` definition, that allows
+custom "wrapper" types to avoid having to define their own
+`convert(::Type{Any}, x)` methods, which can cause large amounts of
+recompilation.
+"""
 unwrap(x) = x
 
 function convert(::Type{T}, x) where {T}
     y = unwrap(x)
-    return y === x ? x : convert(T, y)
+    return y === x ? throw(MethodError(convert, (T, x))) : convert(T, y)
 end
 
 convert(::Type{Type}, x::Type) = x # the ssair optimizer is strongly dependent on this method existing to avoid over-specialization

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -165,6 +165,14 @@ function convert end
 
 convert(::Type{Any}, @nospecialize(x)) = x
 convert(::Type{T}, x::T) where {T} = x
+
+unwrap(x) = x
+
+function convert(::Type{T}, x) where {T}
+    y = unwrap(x)
+    return y === x ? x : convert(T, y)
+end
+
 convert(::Type{Type}, x::Type) = x # the ssair optimizer is strongly dependent on this method existing to avoid over-specialization
                                    # in the absence of inlining-enabled
                                    # (due to fields typed as `Type`, which is generally a bad idea)

--- a/test/core.jl
+++ b/test/core.jl
@@ -7024,3 +7024,15 @@ let code = code_lowered(FieldConvert)[1].code
     @test code[10] == Expr(:new, Core.SSAValue(1), Core.SSAValue(3), Core.SSAValue(5), Core.SlotNumber(4), Core.SSAValue(7), Core.SSAValue(9))
     @test code[11] == Expr(:return, Core.SSAValue(10))
  end
+
+ # Base.unwrap + convert
+ @test Base.unwrap(1) === 1
+
+ struct WrapperStruct{T}
+    x::T
+ end
+
+ wrapperstruct = WrapperStruct("hey")
+ @test_throws MethodError convert(String, wrapperstruct)
+ Base.unwrap(x::WrapperStruct) = x.x
+ @test convert(String, wrapperstruct) == "hey"


### PR DESCRIPTION
Would allow packages like CategoricalArrays and DataValues to avoid having to overload `convert(::Type{Any}, x)` with their own definitions (due to wanting generic `convert(::Type{T}, x::MyType)` definitions). Just putting this up as a POC to get feedback.

Ref: https://github.com/JuliaData/CategoricalArrays.jl/issues/177, https://github.com/queryverse/DataValues.jl/issues/51