### PR TITLE
Use Libc.GetLastError() in windowserror

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -145,8 +145,14 @@ end
 Like [`systemerror`](@ref), but for Windows API functions that use [`GetLastError`](@ref) instead
 of setting [`errno`](@ref).
 """
-windowserror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), WindowsErrorInfo(Libc.GetLastError(), extrainfo))) : nothing
-
+function windowserror(p, b::Bool; extrainfo=nothing)
+    if b
+        err = Libc.GetLastError() #Only read once from volatile function
+        throw(Base.SystemError(string(p), err, WindowsErrorInfo(err, extrainfo)))
+    else
+        nothing
+    end
+end
 
 ## assertion macro ##
 


### PR DESCRIPTION
`Base.windowserror` called both `Libc.errno()` and `Libc.GetLastError()`.  Change to use only `Libc.GetLastErrno()` for accessing errors in Windows API.

Previously the error code was lost.
```
realpath("C:\\thisfolderdoesntexist")
ERROR: SystemError: realpath: The operation completed successfully.
```

Returns the correct error code in #32298 

```
realpath("\\\\.\\C:")
ERROR: SystemError: realpath: Incorrect function. 
```

Returns the correct error code in #32597 when accessing 

```
realpath("H:\\")
ERROR: SystemError: realpath: Access is denied. 
```

Returns the correct error code for a missing file.
```
realpath("C:\\thisfolderdoesntexist")
ERROR: SystemError: realpath: The system cannot find the file specified. 
```