### PR TITLE
fix #32620, crash when assigning to static parameter

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1563,6 +1563,23 @@ end
         return convert(B, b)
     end
 end) == Expr(:error, "local variable name \"B\" conflicts with a static parameter")
+# issue #32620
+@test Meta.lower(@__MODULE__, quote
+    function foo(a::T) where {T}
+        for i = 1:1
+            T = 0
+        end
+    end
+end) == Expr(:error, "local variable name \"T\" conflicts with a static parameter")
+function f32620(x::T) where T
+    local y
+    let T = 3
+        T = 2
+        y = T
+    end
+    return (T, y)
+end
+@test f32620(0) === (Int, 2)
 
 # issue #28044
 code28044(x) = 10x


### PR DESCRIPTION
In version 1.0 (and some prior versions) we gave a warning for *any* local variable with the same name as a static parameter. Then #30184 changed that to an error, but only in some cases. This rationalizes things by covering all cases with either (1) giving an error, or (2) allowing explicit shadowing with `let`.

fixes #32620