### PR TITLE
Changed @generated body purity error

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -413,7 +413,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
                     ptls->in_pure_callback = 0;
                     jl_toplevel_eval(def->module, (jl_value_t*)func);
                 }
-                jl_error("generated function body is not pure. this likely means it contains a closure or comprehension.");
+                jl_error("The function body AST defined by this @generated function is not pure. This likely means it contains a closure or comprehension.");
             }
 
             jl_array_t *stmts = (jl_array_t*)func->code;

--- a/test/core.jl
+++ b/test/core.jl
@@ -4942,7 +4942,7 @@ gVararg(a::fVararg(Int)) = length(a)
     false
 catch e
     (e::ErrorException).msg
-end == "generated function body is not pure. this likely means it contains a closure or comprehension."
+end == "The function body AST defined by this @generated function is not pure. This likely means it contains a closure or comprehension."
 
 let x = 1
     global g18444


### PR DESCRIPTION
Note:
I am still not happy about this message text,
since it doesn't really define pure or give reference to look it up.

Also because as per the test case it applies to anon local functions that are not closures.

Also because I wish this wasn't an error.

But I think this is an improvement,
as I was confused as to what the body meant and has assumed it was the generator itself, not the returned AST