### PR TITLE
fix use of jl_n_threads in gc; scale default collect interval

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -35,8 +35,7 @@ struct GC_Diff
 end
 
 gc_total_bytes(gc_num::GC_Num) =
-    (gc_num.allocd + gc_num.deferred_alloc +
-     Int64(gc_num.collect) + Int64(gc_num.total_allocd))
+    (gc_num.allocd + gc_num.deferred_alloc + Int64(gc_num.total_allocd))
 
 function GC_Diff(new::GC_Num, old::GC_Num)
     # logic from `src/gc.c:jl_gc_total_bytes`


### PR DESCRIPTION
~~`The first commit fixes a bug where `jl_gc_init` saw `jl_n_threads == 0` because it hadn't been set yet. The second commit scales the default collect interval by the number of threads. Otherwise, adding more threads basically translates directly to spending a higher % of runtime in GC.~~

This makes the collect interval fully thread-local, allowing it to naturally scale (if allocation happens on n threads, the effective interval is n times bigger). This also removes the dependence of gc_init on the number of threads (which wasn't working, since jl_n_threads wasn't initialized yet).