### PR TITLE
fix #32626, allow parsing `'a'..'b'`

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -541,9 +541,10 @@
                         ((char-numeric? nextc)
                          (read-number port #t #f))
                         ((opchar? nextc)
-                         (let ((op (read-operator port c)))
-                           (if (and (eq? op '..) (opchar? (peek-char port)))
-                               (error (string "invalid operator \"" op (peek-char port) "\"" (scolno port))))
+                         (let* ((op (read-operator port c))
+                                (nx (peek-char port)))
+                           (if (and (eq? op '..) (opchar? nx) (not (memv nx '(#\' #\:))))
+                               (error (string "invalid operator \"" op nx "\"" (scolno port))))
                            op))
                         (else '|.|)))))
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1889,3 +1889,7 @@ x32499 = begin
     S32499(x=2)
 end
 @test x32499 == 2
+
+# issue #32626
+@test Meta.parse("'a'..'b'") == Expr(:call, :(..), 'a', 'b')
+@test Meta.parse(":a..:b") == Expr(:call, :(..), QuoteNode(:a), QuoteNode(:b))


### PR DESCRIPTION
An error for this was added to fix #3348, but it seems there should be some exceptions. The cases I identified were single quote and colon, which are both cases where an operator character following `..` clearly begins a new expression. Are there any others?

fixes #32626