### PR TITLE
Document the role of Ref in broadcasting.

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -21,7 +21,7 @@ a `ccall` Ref argument.
 
 # Use in broadcasting
 
-Broadcasting with `Ref(x)` treats `x` as a scalar (except when it is a `Ptr`):
+Broadcasting with `Ref(x)` treats `x` as a scalar:
 ```jldoctest
 julia> isa.(Ref([1,2,3]), [Array, Dict, Int])
 3-element BitArray{1}:

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -16,7 +16,18 @@ it can be written `Ref(a, i)` for creating a reference to the `i`-th element of 
 When passed as a `ccall` argument (either as a `Ptr` or `Ref` type), a `Ref` object will be
 converted to a native pointer to the data it references.
 
-There is no invalid (NULL) `Ref` in Julia, but a `C_NULL` instance of `Ptr` can be passed to a `ccall` Ref argument.
+There is no invalid (NULL) `Ref` in Julia, but a `C_NULL` instance of `Ptr` can be passed to
+a `ccall` Ref argument.
+
+# Use in broadcasting
+
+Broadcasting with `Ref(x)` treats `x` as a scalar (except when it is a `Ptr`):
+```jldoctest
+julia> round.(Ref(Int), [1.2, 3.7])
+2-element Array{Int64,1}:
+ 1
+ 4
+```
 """
 Ref
 

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -23,10 +23,11 @@ a `ccall` Ref argument.
 
 Broadcasting with `Ref(x)` treats `x` as a scalar (except when it is a `Ptr`):
 ```jldoctest
-julia> round.(Ref(Int), [1.2, 3.7])
-2-element Array{Int64,1}:
+julia> isa.(Ref([1,2,3]), [Array, Dict, Int])
+3-element BitArray{1}:
  1
- 4
+ 0
+ 0
 ```
 """
 Ref


### PR DESCRIPTION
When newbies who have not read the [relevant section of the manual](https://docs.julialang.org/en/v1/manual/arrays/#Broadcasting-1) encounter `Ref` and look up its docstring, they find no reference to its role in broadcasting.

This trivial PR remedies that by adding a few lines of documentation.