### PR TITLE
Link to StatProfileHTML in Profile docs

### DIFF
--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -57,7 +57,8 @@ julia> using Profile
 julia> @profile myfunc()
 ```
 
-To see the profiling results, there is a [graphical browser](https://github.com/timholy/ProfileView.jl)
+To see the profiling results, there are several graphical browsers
+including [ProfileView.jl](https://github.com/timholy/ProfileView.jl) and [https://github.com/tkluck/StatProfilerHTML.jl](StatProfilerHTML)
 available, but here we'll use the text-based display that comes with the standard library:
 
 ```julia-repl

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -57,9 +57,17 @@ julia> using Profile
 julia> @profile myfunc()
 ```
 
-To see the profiling results, there are several graphical browsers
-including [ProfileView.jl](https://github.com/timholy/ProfileView.jl) and [https://github.com/tkluck/StatProfilerHTML.jl](StatProfilerHTML)
-available, but here we'll use the text-based display that comes with the standard library:
+To see the profiling results, there are several graphical browsers.
+One "family" of visualizers is based on [FlameGraphs.jl](https://github.com/timholy/FlameGraphs.jl), with each family member providing a different user interface:
+- [Juno](https://junolab.org/) is a full IDE with built-in support for profile visualization
+- [ProfileView.jl](https://github.com/timholy/ProfileView.jl) is a stand-alone visualizer based on GTK
+- [ProfileVega.jl](https://github.com/davidanthoff/ProfileVega.jl) uses VegaLight and integrates well with Jupyter notebooks
+- [StatProfilerHTML](https://github.com/tkluck/StatProfilerHTML.jl) produces HTML and presents some additional summaries, and also integrates well with Jupyter notebooks
+- [ProfileSVG](https://github.com/timholy/ProfileSVG.jl) renders SVG
+
+An entirely independent approach to profile visualization is [PProf.jl](https://github.com/vchuravy/PProf.jl), which uses the external `pprof` tool.
+
+Here, though, we'll use the text-based display that comes with the standard library:
 
 ```julia-repl
 julia> Profile.print()


### PR DESCRIPTION
If we are going to link to ProfileView then we need to be fair and do both.
I like StatProfileHTML better,

other option is to delete all reference