### PR TITLE
Two missing tests for SparseColumnView

### DIFF
--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1359,4 +1359,12 @@ end
     end
 end
 
+@testset "SparseColumnView properties" begin
+    n = 10
+    A = sprand(n, n, 0.5)
+    scv = view(A, :, 1)
+    @test SparseArrays.indtype(scv) == SparseArrays.indtype(A)
+    @test nnz(scv) == nnz(A[:, 1])
+end
+
 end # module


### PR DESCRIPTION
It's been awhile ... [these methods](https://codecov.io/gh/julialang/julia/src/master/stdlib/SparseArrays/src/sparsevector.jl#L62) aren't covered right now.


(Also, we require more supply depots)