### PR TITLE
Mutually recursive field types, the easy version

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -428,6 +428,11 @@ function isprimitivetype(@nospecialize(t::Type))
     return !hasfield && t.size != 0 && !t.abstract
 end
 
+struct IncompleteTypeException
+    dt::DataType
+end
+must_be_complete(t::DataType) = (t.incomplete && throw(IncompleteTypeException(t)); t)
+
 """
     isbitstype(T)
 
@@ -449,14 +454,14 @@ julia> isbitstype(Complex)
 false
 ```
 """
-isbitstype(@nospecialize(t::Type)) = (@_pure_meta; isa(t, DataType) && t.isbitstype)
+isbitstype(@nospecialize(t::Type)) = (@_pure_meta; isa(t, DataType) && must_be_complete(t).isbitstype)
 
 """
     isbits(x)
 
 Return `true` if `x` is an instance of an `isbitstype` type.
 """
-isbits(@nospecialize x) = (@_pure_meta; typeof(x).isbitstype)
+isbits(@nospecialize x) = typeof(x).isbitstype
 
 """
     isdispatchtuple(T)
@@ -465,7 +470,7 @@ Determine whether type `T` is a tuple "leaf type",
 meaning it could appear as a type signature in dispatch
 and has no subtypes (or supertypes) which could appear in a call.
 """
-isdispatchtuple(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && t.isdispatchtuple)
+isdispatchtuple(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && must_be_complete(t).isdispatchtuple)
 
 iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
 isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)

--- a/src/ast.c
+++ b/src/ast.c
@@ -45,6 +45,7 @@ jl_sym_t *splatnew_sym;
 jl_sym_t *const_sym;   jl_sym_t *thunk_sym;
 jl_sym_t *abstracttype_sym; jl_sym_t *primtype_sym;
 jl_sym_t *structtype_sym;   jl_sym_t *foreigncall_sym;
+jl_sym_t *incompletetype_sym;
 jl_sym_t *global_sym; jl_sym_t *list_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *inbounds_sym;
@@ -334,6 +335,7 @@ void jl_init_frontend(void)
     abstracttype_sym = jl_symbol("abstract_type");
     primtype_sym = jl_symbol("primitive_type");
     structtype_sym = jl_symbol("struct_type");
+    incompletetype_sym = jl_symbol("incomplete_type");
     toplevel_sym = jl_symbol("toplevel");
     dot_sym = jl_symbol(".");
     colon_sym = jl_symbol(":");

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -794,6 +794,8 @@ static jl_value_t *get_fieldtype(jl_value_t *t, jl_value_t *f, int dothrow)
     if (!jl_is_datatype(t))
         jl_type_error("fieldtype", (jl_value_t*)jl_datatype_type, t);
     jl_datatype_t *st = (jl_datatype_t*)t;
+    if (st->incomplete)
+        jl_error("Type is incomplete");
     int field_index;
     if (jl_is_long(f)) {
         field_index = jl_unbox_long(f) - 1;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4248,7 +4248,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
             return ghostValue(jl_void_type);
         }
         if (head == abstracttype_sym || head == structtype_sym ||
-            head == primtype_sym) {
+            head == primtype_sym || head == incompletetype_sym) {
             jl_errorf("type definition not allowed inside a local scope");
         }
         else {

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -88,6 +88,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     t->has_concrete_subtype = 1;
     t->layout = NULL;
     t->names = NULL;
+    t->incomplete = 0;
     return t;
 }
 

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -88,7 +88,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     t->has_concrete_subtype = 1;
     t->layout = NULL;
     t->names = NULL;
-    t->incomplete = 0;
+    t->incomplete = 1;
     return t;
 }
 
@@ -540,6 +540,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *
     bt->size = nbytes;
     bt->layout = jl_get_layout(0, alignm, 0, NULL);
     bt->instance = NULL;
+    bt->incomplete = 0;
     return bt;
 }
 
@@ -568,6 +569,7 @@ JL_DLLEXPORT jl_datatype_t * jl_new_foreign_type(jl_sym_t *name,
     desc->sweepfunc = sweepfunc;
     bt->layout = layout;
     bt->instance = NULL;
+    bt->incomplete = 0;
     return bt;
 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -363,7 +363,8 @@ static void jl_serialize_datatype(jl_serializer_state *s, jl_datatype_t *dt) JL_
     write_int32(s->s, dt->size);
     int has_instance = (dt->instance != NULL);
     int has_layout = (dt->layout != NULL);
-    write_uint8(s->s, dt->abstract | (dt->mutabl << 1) | (has_layout << 2) | (has_instance << 3));
+    write_uint8(s->s, dt->abstract | (dt->mutabl << 1) | (has_layout << 2) |
+        (has_instance << 3) | (dt->incomplete << 4));
     write_uint8(s->s, dt->hasfreetypevars
             | (dt->isconcretetype << 1)
             | (dt->isdispatchtuple << 2)
@@ -1398,6 +1399,7 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
     dt->mutabl = (flags >> 1) & 1;
     int has_layout = (flags >> 2) & 1;
     int has_instance = (flags >> 3) & 1;
+    dt->incomplete = (flags >> 4) & 1;
     dt->hasfreetypevars = memflags & 1;
     dt->isconcretetype = (memflags >> 1) & 1;
     dt->isdispatchtuple = (memflags >> 2) & 1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -2367,6 +2367,7 @@ jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_
     jl_set_const(module, tname, (jl_value_t*)ftype);
     jl_value_t *f = jl_new_struct(ftype);
     ftype->instance = f; jl_gc_wb(ftype, f);
+    ftype->incomplete = 0;
     JL_GC_POP();
     return (jl_function_t*)f;
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1707,7 +1707,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_datatype_type->name->wrapper = (jl_value_t*)jl_datatype_type;
     jl_datatype_type->super = (jl_datatype_t*)jl_type_type;
     jl_datatype_type->parameters = jl_emptysvec;
-    jl_datatype_type->name->names = jl_perm_symsvec(21,
+    jl_datatype_type->name->names = jl_perm_symsvec(22,
                                                     "name",
                                                     "super",
                                                     "parameters",
@@ -1720,6 +1720,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                                     "uid",
                                                     "abstract",
                                                     "mutable",
+                                                    "incomplete",
                                                     "hasfreetypevars",
                                                     "isconcretetype",
                                                     "isdispatchtuple",
@@ -1729,12 +1730,13 @@ void jl_init_types(void) JL_GC_DISABLED
                                                     "has_concrete_subtype",
                                                     "llvm::StructType",
                                                     "llvm::DIType");
-    jl_datatype_type->types = jl_svec(21,
+    jl_datatype_type->types = jl_svec(22,
                                       jl_typename_type,
                                       jl_datatype_type,
                                       jl_simplevector_type,
                                       jl_simplevector_type, jl_simplevector_type,
                                       jl_any_type, // instance
+                                      jl_any_type,
                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type,
                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type,
                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type,
@@ -2297,8 +2299,9 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_datatype_type->types, 16, jl_bool_type);
     jl_svecset(jl_datatype_type->types, 17, jl_bool_type);
     jl_svecset(jl_datatype_type->types, 18, jl_bool_type);
-    jl_svecset(jl_datatype_type->types, 19, jl_voidpointer_type);
+    jl_svecset(jl_datatype_type->types, 19, jl_bool_type);
     jl_svecset(jl_datatype_type->types, 20, jl_voidpointer_type);
+    jl_svecset(jl_datatype_type->types, 21, jl_voidpointer_type);
     jl_svecset(jl_typename_type->types, 1, jl_module_type);
     jl_svecset(jl_typename_type->types, 6, jl_long_type);
     jl_svecset(jl_typename_type->types, 3, jl_type_type);

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -701,7 +701,7 @@
 ;; symbol tokens that do not simply parse to themselves when appearing alone as
 ;; an element of an argument list
 (define non-standalone-symbol-token?
-  (Set (append operators reserved-words '(.... mutable primitive abstract))))
+  (Set (append operators reserved-words '(.... mutable primitive abstract incomplete))))
 
 ; parse-eq* is used where commas are special, for example in an argument list
 (define (parse-eq* s)
@@ -1062,7 +1062,7 @@
              (fix-syntactic-unary (list op arg)))))))
 
 (define block-form? (Set '(block quote if for while let function macro abstract primitive struct
-                                 try module)))
+                                 try module incomplete)))
 
 ;; handle ^ and .^
 ;; -2^3 is parsed as -(2^3), so call parse-decl for the first argument,
@@ -1103,7 +1103,7 @@
   (parse-call-with-initial-ex s (parse-unary-prefix s)))
 
 (define (parse-call-with-initial-ex s ex)
-  (if (or (initial-reserved-word? ex) (eq? ex 'mutable) (eq? ex 'primitive) (eq? ex 'abstract))
+  (if (or (initial-reserved-word? ex) (eq? ex 'mutable) (eq? ex 'primitive) (eq? ex 'abstract) (eq? ex 'incomplete))
       (parse-resword s ex)
       (parse-call-chain s ex #f)))
 
@@ -1429,6 +1429,13 @@
                      (body (parse-block s)))
                 (expect-end s word)
                 (list word def body)))))
+       ((incomplete)
+        (if (not (eq? (peek-token s) 'type))
+            (parse-call-chain s word #f)
+            (begin (take-token s)
+                   (let ((spec (parse-subtype-spec s)))
+                     (begin0 (list 'type_incomplete spec)
+                             (expect-end (take-lineendings s) "incomplete type"))))))
 
        ((abstract)
         (if (not (eq? (peek-token s) 'type))

--- a/src/julia.h
+++ b/src/julia.h
@@ -439,6 +439,7 @@ typedef struct _jl_datatype_t {
     uint32_t uid;
     uint8_t abstract;
     uint8_t mutabl;
+    uint8_t incomplete; // If 1, this dt is not yet complete.
     // memoized properties
     uint8_t hasfreetypevars; // majority part of isconcrete computation
     uint8_t isconcretetype; // whether this type can have instances

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1010,6 +1010,7 @@ extern jl_sym_t *pop_exception_sym;
 extern jl_sym_t *const_sym;   extern jl_sym_t *thunk_sym;
 extern jl_sym_t *abstracttype_sym; extern jl_sym_t *primtype_sym;
 extern jl_sym_t *structtype_sym;   extern jl_sym_t *foreigncall_sym;
+extern jl_sym_t *incompletetype_sym;
 extern jl_sym_t *global_sym; extern jl_sym_t *list_sym;
 extern jl_sym_t *dot_sym;    extern jl_sym_t *newvar_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *inbounds_sym;

--- a/src/method.c
+++ b/src/method.c
@@ -127,7 +127,7 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
                 i++;
             }
             if (e->head == method_sym || e->head == abstracttype_sym || e->head == structtype_sym ||
-                     e->head == primtype_sym || e->head == module_sym) {
+                     e->head == primtype_sym || e->head == module_sym || e->head == incompletetype_sym) {
                 i++;
             }
             for (; i < nargs; i++) {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -304,7 +304,7 @@ static void expr_attributes(jl_value_t *v, int *has_intrinsics, int *has_defs)
         return;
     }
     else if (head == method_sym || head == abstracttype_sym || head == primtype_sym ||
-             head == structtype_sym || jl_is_toplevel_only_expr(v)) {
+             head == structtype_sym || head == incompletetype_sym || jl_is_toplevel_only_expr(v)) {
         *has_defs = 1;
     }
     else if (head == cfunction_sym) {

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1151,6 +1151,7 @@ function deserialize_typename(s::AbstractSerializer, number)
             # use setfield! directly to avoid `fieldtype` lowering expecting to see a Singleton object already on ty
             Core.setfield!(ty, :instance, ccall(:jl_new_struct, Any, (Any, Any...), ty))
         end
+        Core.setfield!(ndt, :incomplete, false)
     end
 
     tag = Int32(read(s.io, UInt8)::UInt8)

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -54,7 +54,8 @@ function choosetests(choices = [])
         "checked", "bitset", "floatfuncs", "precompile",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
-        "reinterpretarray", "syntax", "logging", "missing", "asyncmap"
+        "reinterpretarray", "syntax", "logging", "missing", "asyncmap",
+        "incompletetype"
     ]
 
     tests = []

--- a/test/core.jl
+++ b/test/core.jl
@@ -7024,3 +7024,10 @@ let code = code_lowered(FieldConvert)[1].code
     @test code[10] == Expr(:new, Core.SSAValue(1), Core.SSAValue(3), Core.SSAValue(5), Core.SlotNumber(4), Core.SSAValue(7), Core.SSAValue(9))
     @test code[11] == Expr(:return, Core.SSAValue(10))
  end
+
+# Using a type before it's complete
+@test_throws Base.IncompleteTypeException Core.eval(Module(), quote
+    struct Bar
+        x::Val{isbitstype(Bar)}
+    end
+end)

--- a/test/incompletetype.jl
+++ b/test/incompletetype.jl
@@ -1,0 +1,44 @@
+using Test
+
+incomplete type Bar; end
+@test Bar.incomplete
+struct Foo
+    x::Bar
+end
+@test !Foo.incomplete
+struct Bar
+    x::Foo
+end
+@test !Bar.incomplete
+@test Bar.types[1] === Foo
+@test Foo.types[1] === Bar
+
+@test_throws ErrorException Core.eval(Module(), quote
+    incomplete type Bar{A}; end
+    struct Bar; end
+end)
+
+@test_throws ErrorException Core.eval(Module(), quote
+    incomplete type Bar{A}; end
+    struct Bar{A,B}; end
+end)
+
+@test_throws ErrorException Core.eval(Module(), quote
+    abstract type Foo; end
+    incomplete type Bar <: Foo ; end
+    struct Bar; end
+end)
+
+@test_throws ErrorException Core.eval(Module(), quote
+    abstract type Foo1; end
+    abstract type Foo2; end
+    incomplete type Bar <: Foo1; end
+    incomplete type Bar <: Foo2; end
+end)
+
+incomplete type FieldNamesTest; end
+struct FieldNamesTest
+    a::Int64
+    b::Int64
+end
+@test fieldnames(FieldNamesTest) == (:a, :b)


### PR DESCRIPTION
This is an alternative to #32581, that is easier to implement, but
more restrictivive. Here, the forward declaration must contain
everything except for the field types:
```
incomplete type Foo{Bar} <: Baz; end
```
with it being an error to deviate from this specification when
completing the type
```
struct Foo <: Baz; end # Error: Missing type parameter
struct Foo{A, B} <: Baz; end # Error: Too many type parameters
struct Foo{Qux} <: Baz; end # Error: Name of type parameter doesn't match
struct Foo{Bar<:Int64} <: Baz; end # Error: Bounds of type parameter don't match
struct Foo{Bar}; end; # Error supertype dosesn't match
```
This is easier because this way we have enough information for subtyping
and type application and therefor do not need to delay this until
the entire dependency graph is complete as we did in #32581.
Of course this also means that we don't get the union feature that
was requested in #269:
```
incomplete type U; end
struct A; x::U; end
struct B; x::U; end
U = Union{A, B}; #ERROR
```
However, it could of course be emulated by wrapping the union type:
```
struct U
   data::Union{A, B}
end
```

However, given the simplicity of this change and the difficulty of #32581,
this seems like the way to go for the moment. We may want to revisit all
this if we ever want to do computed field types, which will encounter similar
challenges as #32581.

Fixes #269.