### PR TITLE
Make UUIDs act as scalars when broadcasting

### DIFF
--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -67,3 +67,6 @@ print(io::IO, u::UUID) = print(io, string(u))
 show(io::IO, u::UUID) = print(io, "UUID(\"", u, "\")")
 
 isless(a::UUID, b::UUID) = isless(a.value, b.value)
+
+# give UUID scalar behavior in broadcasting
+Base.broadcastable(x::UUID) = Ref(x)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -112,6 +112,11 @@ let uuidstr = "ab"^4 * "-" * "ab"^2 * "-" * "ab"^2 * "-" * "ab"^2 * "-" * "ab"^6
     @test UUID(UInt128(uuid)) == uuid
     @test UUID(convert(NTuple{2, UInt64}, uuid)) == uuid
     @test UUID(convert(NTuple{4, UInt32}, uuid)) == uuid
+
+    uuidstr2 = "ba"^4 * "-" * "ba"^2 * "-" * "ba"^2 * "-" * "ba"^2 * "-" * "ba"^6
+    uuid2 = UUID(uuidstr2)
+    uuids = [uuid, uuid2]
+    @test (uuids .== uuid) == [true, false]
 end
 @test_throws ArgumentError UUID("@"^4 * "-" * "@"^2 * "-" * "@"^2 * "-" * "@"^2 * "-" * "@"^6)
 


### PR DESCRIPTION
I ran into this when attempting to find a UUID in an array with

```
uuids .== uuid
```