### PR TITLE
inline arithmetic between chars and Integers

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -218,10 +218,10 @@ isless(x::AbstractChar, y::AbstractChar) = isless(Char(x), Char(y))
 hash(x::AbstractChar, h::UInt) = hash(Char(x), h)
 widen(::Type{T}) where {T<:AbstractChar} = T
 
--(x::AbstractChar, y::AbstractChar) = Int(x) - Int(y)
--(x::T, y::Integer) where {T<:AbstractChar} = T(Int32(x) - Int32(y))
-+(x::T, y::Integer) where {T<:AbstractChar} = T(Int32(x) + Int32(y))
-+(x::Integer, y::AbstractChar) = y + x
+@inline -(x::AbstractChar, y::AbstractChar) = Int(x) - Int(y)
+@inline -(x::T, y::Integer) where {T<:AbstractChar} = T(Int32(x) - Int32(y))
+@inline +(x::T, y::Integer) where {T<:AbstractChar} = T(Int32(x) + Int32(y))
+@inline +(x::Integer, y::AbstractChar) = y + x
 
 # `print` should output UTF-8 by default for all AbstractChar types.
 # (Packages may implement other IO subtypes to specify different encodings.)


### PR DESCRIPTION
Arithmetic between Chars and Integers is often used in quite tight parts of parsing and other string / char manipulations.

As an example

Before

```jl
julia> @btime uppercase($(Ref('a'))[])
  5.332 ns (0 allocations: 0 bytes)
'A': ASCII/Unicode U+0041 (category Lu: Letter, uppercase)
```

After

```jl
julia> @btime uppercase($(Ref('a'))[])  
  3.858 ns (0 allocations: 0 bytes)
'A': ASCII/Unicode U+0041 (category Lu: Letter, uppercase)
```