### PR TITLE
Add minor code formatting to GC docs

### DIFF
--- a/doc/src/devdocs/gc-sa.md
+++ b/doc/src/devdocs/gc-sa.md
@@ -48,7 +48,7 @@ code base to make things work.
 ## GC Invariants
 
 There is two simple invariants correctness:
-- All GC_PUSH calls need to be followed by an appropriate GC_POP (in practice we enforce this
+- All `GC_PUSH` calls need to be followed by an appropriate `GC_POP` (in practice we enforce this
   at the function level)
 - If a value was previously not rooted at any safepoint, it may no longer be referenced
   afterwards


### PR DESCRIPTION
The `_`s here were rendering as italics. Simple fix.