### PR TITLE
Implement isdiag(::Tridiagonal), add related tests

### DIFF
--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -584,6 +584,7 @@ iszero(M::Tridiagonal) = iszero(M.dl) && iszero(M.d) && iszero(M.du)
 isone(M::Tridiagonal) = iszero(M.dl) && all(isone, M.d) && iszero(M.du)
 istriu(M::Tridiagonal) = iszero(M.dl)
 istril(M::Tridiagonal) = iszero(M.du)
+isdiag(M::Tridiagonal) = iszero(M.dl) && iszero(M.du)
 
 function tril!(M::Tridiagonal, k::Integer=0)
     n = length(M.d)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -137,9 +137,20 @@ end
         @test triu(Tridiagonal(dl,d,du),2)  == Tridiagonal(zerosdl,zerosd,zerosdu)
 
         @test !istril(SymTridiagonal(d,dl))
+        @test istril(SymTridiagonal(d,zerosdl))
         @test !istriu(SymTridiagonal(d,dl))
+        @test istriu(SymTridiagonal(d,zerosdl))
         @test istriu(Tridiagonal(zerosdl,d,du))
+        @test !istriu(Tridiagonal(dl,d,zerosdu))
         @test istril(Tridiagonal(dl,d,zerosdu))
+        @test !istril(Tridiagonal(zerosdl,d,du))
+
+        @test isdiag(SymTridiagonal(d,zerosdl))
+        @test !isdiag(SymTridiagonal(d,dl))
+        @test isdiag(Tridiagonal(zerosdl,d,zerosdu))
+        @test !isdiag(Tridiagonal(dl,d,zerosdu))
+        @test !isdiag(Tridiagonal(zerosdl,d,du))
+        @test !isdiag(Tridiagonal(dl,d,du))
     end
 
     @testset "iszero and isone" begin


### PR DESCRIPTION
Implemented `isdiag(::Tridiagonal)` and added tests for it.  Added tests too for `isdiag(::SymTridiagonal)`, which was previously implemented but untested.  Also expanded tests for `istril` and `istriu` on these tridiagonal types.