### PR TITLE
Added `sym"..."` string macro for making `Symbol`s

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -933,6 +933,7 @@ export
     @s_str,    # regex substitution string
     @v_str,    # version number
     @raw_str,  # raw string with no interpolation/unescaping
+    @sym_str,  # symbol
 
     # documentation
     @text_str,

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -30,6 +30,37 @@ macro gensym(names...)
     return blk
 end
 
+"""
+    sym"..."
+
+Construct a `Symbol` out of the quoted string. Useful for creating/representing symbols
+which are not usually allowed in surface-level syntax.
+
+# Examples
+
+```jldoctest
+julia> sym"a"
+:a
+
+julia> sym"a#"
+sym"a#"
+
+julia> i = 10
+10
+
+julia> sym"a_\$i"
+:a_10
+```
+"""
+macro sym_str(in)
+    str = Meta.parse('"' * replace(in, '"' => "\\\"") * '"')
+    if str isa String
+        return QuoteNode(Symbol(str))
+    else
+        return Expr(:call, :Symbol, esc(str))
+    end
+end
+
 ## expressions ##
 
 function copy(e::Expr)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1054,7 +1054,7 @@ function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, pre
             print(io, ":")
             print(io, value)
         else
-            print(io, "Symbol(", repr(s), ")")
+            print(io, "sym", repr(s))
         end
     else
         if isa(value,Expr) && value.head === :block

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -25,6 +25,7 @@ Base.SubstitutionString
 Base.@s_str
 Base.@raw_str
 Base.@b_str
+Base.@sym_str
 Base.Docs.@html_str
 Base.Docs.@text_str
 Base.isvalid(::Any)

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -127,7 +127,8 @@ julia> Symbol(:var,'_',"sym")
 ```
 
 Note that to use `:` syntax, the symbol's name must be a valid identifier.
-Otherwise the `Symbol(str)` constructor must be used.
+Otherwise the `Symbol(str)` constructor or `sym"..."` non-standard string literal form must
+be used.
 
 In the context of an expression, symbols are used to indicate access to variables; when an expression
 is evaluated, a symbol is replaced with the value bound to that symbol in the appropriate [scope](@ref scope-of-variables).

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -1167,3 +1167,20 @@ Notice that the first two backslashes appear verbatim in the output, since they 
 precede a quote character.
 However, the next backslash character escapes the backslash that follows it, and the
 last backslash escapes a quote, since these backslashes appear before a quote.
+
+## [Symbol Literals](@id man-symbol-literals)
+
+While symbols of valid identifiers can be writen in the form `:a`, sometimes we have
+`Symbol`s which are not valid identifiers or which we may want to create via interpolation.
+
+The `sym"..."` non-standard string literal constructs a `Symbol` from the given string
+using all the usual string parsing and interpolation rules. For example, we can create a
+`Symbol` by interpolating a variable's value into the symbol itself:
+
+```jldoctest
+julia> i = 10
+10
+
+julia> sym"a_$i"
+:a_10
+```

--- a/test/show.jl
+++ b/test/show.jl
@@ -346,8 +346,8 @@ end
 
 # issue #7188
 @test sprint(show, :foo) == ":foo"
-@test sprint(show, Symbol("foo bar")) == "Symbol(\"foo bar\")"
-@test sprint(show, Symbol("foo \"bar")) == "Symbol(\"foo \\\"bar\")"
+@test sprint(show, Symbol("foo bar")) == "sym\"foo bar\""
+@test sprint(show, Symbol("foo \"bar")) == "sym\"foo \\\"bar\""
 @test sprint(show, :+) == ":+"
 @test sprint(show, :end) == ":end"
 
@@ -1498,7 +1498,7 @@ replstrcolor(x) = sprint((io, x) -> show(IOContext(io, :limit => true, :color =>
 @test occursin("\e[", replstrcolor(`curl abc`))
 
 # issue #30303
-@test repr(Symbol("a\$")) == "Symbol(\"a\\\$\")"
+@test repr(Symbol("a\$")) == "sym\"a\\\$\""
 
 @test string(sin) == "sin"
 @test string(:) == "Colon()"

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -171,7 +171,15 @@ end
     @test startswith(string(gensym()),"##")
     @test_throws ArgumentError Symbol("ab\0")
     @test_throws ArgumentError gensym("ab\0")
+
+    @test sym"a" === :a
+    @test sym"a#" === Symbol("a#")
+    i = 10
+    @test sym"a_$i" === :a_10
+    @test sym"\"" === Symbol("\"")
+    @test sym"\n" === Symbol("\n")
 end
+
 @testset "issue #6949" begin
     f = IOBuffer()
     x = split("1 2 3")


### PR DESCRIPTION
A new non-standard string literal using `sym_str` macro to construct `Symbol`s. Supports interpolation.

This is the sibling PR of #32408, and is the product of the South-West Brisbane (Australia) edition of JuliaCon Hackathon 2019.

Some examples:

```julia
julia> sym"a"
:a

julia> sym"a#"
sym"a#"

julia> i = 10
10

julia> sym"a_$i"
:a_10
```

Co-authored-by: Chris Foster <chris42f@gmail.com>