### PR TITLE
Move `functionloc` to methodshow.jl and make it Revise-aware

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1146,43 +1146,6 @@ function nameof(f::Function)
     return mt.name
 end
 
-functionloc(m::Core.MethodInstance) = functionloc(m.def)
-
-"""
-    functionloc(m::Method)
-
-Returns a tuple `(filename,line)` giving the location of a `Method` definition.
-"""
-function functionloc(m::Method)
-    ln = m.line
-    if ln <= 0
-        error("could not determine location of method definition")
-    end
-    return (find_source_file(string(m.file)), ln)
-end
-
-"""
-    functionloc(f::Function, types)
-
-Returns a tuple `(filename,line)` giving the location of a generic `Function` definition.
-"""
-functionloc(@nospecialize(f), @nospecialize(types)) = functionloc(which(f,types))
-
-function functionloc(@nospecialize(f))
-    mt = methods(f)
-    if isempty(mt)
-        if isa(f, Function)
-            error("function has no definitions")
-        else
-            error("object is not callable")
-        end
-    end
-    if length(mt) > 1
-        error("function has multiple methods; please specify a type signature")
-    end
-    return functionloc(first(mt))
-end
-
 """
     parentmodule(f::Function) -> Module
 


### PR DESCRIPTION
A user question revealed that `@edit foo(arg)` is not Revise-aware for most editors. This PR changes that. The move to a new file is motivated by bootstrap issues. `functionloc` is not really reflection in the sense of the compiler, so this doesn't seem too inappropriate.