### PR TITLE
Simplify lowering of typed comprehension

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -159,7 +159,7 @@ function generate_precompile_statements()
         include_time = @elapsed for statement in sort(collect(statements))
             # println(statement)
             # Work around #28808
-            occursin("\"YYYY-mm-dd\\THH:MM:SS\"", statement) && continue
+            occursin("\"YYYY-mm-dd\\THH:MM:SS", statement) && continue
             statement == "precompile(Tuple{typeof(Base.show), Base.IOContext{Base.TTY}, Type{Vararg{Any, N} where N}})" && continue
             try
                 Base.include_string(PrecompileStagingArea, statement)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2283,17 +2283,7 @@
 
    'typed_comprehension
    (lambda (e)
-     (expand-forms
-      (or (and (eq? (caaddr e) 'generator)
-               (let ((ranges (cddr (caddr e))))
-                 (if (any (lambda (x) (eq? x ':)) ranges)
-                     (error "comprehension syntax with `:` ranges has been removed"))
-                 (and (every (lambda (x) (and (pair? x) (eq? (car x) '=)))
-                             ranges)
-                      ;; TODO: this is a hack to lower simple comprehensions to loops very
-                      ;; early, to greatly reduce the # of functions and load on the compiler
-                      (lower-comprehension (cadr e) (cadr (caddr e)) ranges))))
-          `(call (top collect) ,(cadr e) ,(caddr e)))))))
+     (expand-forms `(call (top collect) ,(cadr e) ,(caddr e))))))
 
 (define (has-return? e)
   (expr-contains-p return? e (lambda (x) (not (function-def? x)))))


### PR DESCRIPTION
For implementing special syntax it's useful for typed comprehension to
lower to `collect(T, gen)`. This changes typed comprehensions to use the
same lowering pattern as normal comprehensions.

@andyferris 