### PR TITLE
add `ispossemdef`

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -443,6 +443,7 @@ LinearAlgebra.issuccess
 LinearAlgebra.issymmetric
 LinearAlgebra.isposdef
 LinearAlgebra.isposdef!
+LinearAlgebra.ispossemdef
 LinearAlgebra.istril
 LinearAlgebra.istriu
 LinearAlgebra.isdiag

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -90,6 +90,7 @@ export
     ishermitian,
     isposdef,
     isposdef!,
+    ispossemdef,
     issuccess,
     issymmetric,
     istril,

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -117,6 +117,10 @@ ishermitian(D::Diagonal) = all(ishermitian, D.diag)
 issymmetric(D::Diagonal{<:Number}) = true
 issymmetric(D::Diagonal) = all(issymmetric, D.diag)
 isposdef(D::Diagonal) = all(isposdef, D.diag)
+function ispossemdef(D::Diagonal, k::Int)
+    _check_rank_range(k, length(D.diag))
+    return ishermitian(D) && _k_positive_eigenvalues(sort(real.(D.diag)), k, 0.0)
+end
 
 factorize(D::Diagonal) = D
 

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -124,6 +124,13 @@ Base.iterate(S::Union{Eigen,GeneralizedEigen}, ::Val{:done}) = nothing
 
 isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0, A.values)
 
+function ispossemdef(A::Union{Eigen,GeneralizedEigen}, k::Int;
+                     atol::Real=0.0,
+                     rtol::Real=(length(A.values)*eps(real(float(one(eltype(A.values))))))*iszero(atol))
+    _check_rank_range(k, length(A.values))
+    return isreal(A.values) && _k_positive_eigenvalues(real.(A.values), k, atol, rtol)
+end
+
 # pick a canonical ordering to avoid returning eigenvalues in "random" order
 # as is the LAPACK default (for complex λ — LAPACK sorts by λ for the Hermitian/Symmetric case)
 eigsortby(λ::Real) = λ

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -52,6 +52,31 @@ bimg  = randn(n,2)/2
             @test isposdef!(copy(apd))
         end
     end
+    @testset "Positive semi-definiteness" begin
+
+        notsymmetric = ainit
+        notsquare    = [ainit ainit]
+
+        for truerank in 0:n
+
+            X = ainit[:, 1:truerank]
+            A = truerank == 0 ? zeros(eltya, n, n) : X * X'
+
+            for testrank in 0:n
+                if testrank == truerank
+                    @test ispossemdef(A, testrank)
+                else
+                    @test !ispossemdef(A, testrank)
+                end
+            end
+            #  not hermitian should return false regardless what k is
+            @test !ispossemdef(notsymmetric, truerank)
+            @test !ispossemdef(notsquare, truerank)
+
+            @test_throws ArgumentError ispossemdef(A, -1)
+            @test_throws ArgumentError ispossemdef(A, n + 1)
+        end
+    end
     @testset "For b containing $eltyb" for eltyb in (Float32, Float64, ComplexF32, ComplexF64, Int)
         binit = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex.(breal, bimg) : breal)
         εb = eps(abs(float(one(eltyb))))
@@ -873,6 +898,10 @@ end
 @testset "test ops on Numbers for $elty" for elty in [Float32,Float64,ComplexF32,ComplexF64]
     a = rand(elty)
     @test isposdef(one(elty))
+    @test ispossemdef(one(elty), 1)
+    @test !ispossemdef(one(elty), 0)
+    @test !ispossemdef(zero(elty), 1)
+    @test ispossemdef(zero(elty), 0)
     @test lyap(one(elty),a) == -a/2
 end
 

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -341,6 +341,37 @@ end
     @test !isposdef(Diagonal([[1 0; 0 1], [1 0; 1 1]]))
 end
 
+@testset "ispossemdef" begin
+    areal  = rand(n)/2
+    aimg   = zeros(n)
+    for eltya in (Float32, Float64, ComplexF32, ComplexF64, Int)
+        ainit = eltya == Int ? rand(1:7, n) : convert(Vector{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
+
+        for truerank in 0:n
+            d = vcat(ainit[1:truerank], zeros(n - truerank))
+            D = Diagonal( shuffle( d ) )
+
+            for testrank in 0:n
+                if testrank == truerank
+                    @test ispossemdef(D, testrank)
+                else
+                    @test !ispossemdef(D, testrank)
+                end
+            end
+            @test_throws ArgumentError ispossemdef(D, -1)
+            @test_throws ArgumentError ispossemdef(D, n + 1)
+        end
+    end
+    D = Diagonal(-areal)
+    for testrank in 0:n
+        @test !ispossemdef(D, testrank)
+    end
+    D = Diagonal(areal + areal*im)
+    for testrank in 0:n
+        @test !ispossemdef(D, testrank)
+    end
+end
+
 @testset "getindex" begin
     d = randn(n)
     D = Diagonal(d)

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -41,6 +41,9 @@ aimg  = randn(n,n)/2
             @test det(a) ≈ det(f)
             @test inv(a) ≈ inv(f)
             @test isposdef(a) == isposdef(f)
+            for testrank in 0:n
+                @test ispossemdef(a, testrank) == ispossemdef(f, testrank)
+            end
             @test eigvals(f) === f.values
             @test eigvecs(f) === f.vectors
             @test Array(f) ≈ a


### PR DESCRIPTION
Adds `ispossemdef(A, k) -> Bool` for checking if a matrix `A` is positive semi-definite with a specified rank `k`. Does this by checking if `A` has `k` positive eigenvalues and the rest are zero. To check the eigenvalues, I am basically emulating the [`rank`](https://github.com/JuliaLang/julia/blob/a8a567e72b669525dc4d3a38af275fe042f44a42/stdlib/LinearAlgebra/src/generic.jl#L833) function.

Use case: there are matrix-variate probability distributions defined over the space of positive semi-definite matrices of some rank, and this function is handy for unit testing that the sampler for such a distribution is returning matrices in the correct space. 