### PR TITLE
fix printing symbols with names `true` and `false`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -798,6 +798,7 @@ is_id_start_char(c::AbstractChar) = ccall(:jl_id_start_char, Cint, (UInt32,), c)
 is_id_char(c::AbstractChar) = ccall(:jl_id_char, Cint, (UInt32,), c) != 0
 function isidentifier(s::AbstractString)
     isempty(s) && return false
+    (s == "true" || s == "false") && return false
     c, rest = Iterators.peel(s)
     is_id_start_char(c) || return false
     return all(is_id_char, rest)
@@ -1050,7 +1051,7 @@ end
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
-        if (isidentifier(s) || isoperator(value)) && !(s == "true" || s == "false")
+        if (isidentifier(s) || isoperator(value))
             print(io, ":")
             print(io, value)
         else

--- a/base/show.jl
+++ b/base/show.jl
@@ -1050,7 +1050,7 @@ end
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
-        if isidentifier(s) || isoperator(value)
+        if (isidentifier(s) || isoperator(value)) && !(s == "true" || s == "false")
             print(io, ":")
             print(io, value)
         else

--- a/test/show.jl
+++ b/test/show.jl
@@ -1533,3 +1533,9 @@ Z = Array{Float64}(undef,0,0)
     @test sdastr(2, 2) == "[2, 3]"
     @test sdastr(3, 3) == "[3, 4, 5]"
 end
+
+# issue #31402, Print Symbol("true") as Symbol("true") instead of :true
+@test sprint(show, Symbol(true)) == "Symbol(\"true\")"
+@test sprint(show, Symbol("true")) == "Symbol(\"true\")"
+@test sprint(show, Symbol(false)) == "Symbol(\"false\")"
+@test sprint(show, Symbol("false")) == "Symbol(\"false\")"


### PR DESCRIPTION
This is a continuation of #32006; I'm just applying the suggested change there and fixing conflicts to push it over the line!