### PR TITLE
RFC: Change `Sockets.recvfrom` to return full InetAddr instead of just host

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@ Standard library changes
 * `clamp` can now handle missing values ([#31066]).
 * `empty` now accepts a `NamedTuple` ([#32534]).
 * `mod` now accepts a unit range as the second argument to easily perform offset modular arithmetic to ensure the result is inside the range ([#32628]).
+* `Sockets.recvfrom` now returns both host and port as an InetAddr ([#32729]).
 
 #### Libdl
 

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -325,10 +325,14 @@ function recv(sock::UDPSocket)
 end
 
 """
-    recvfrom(socket::UDPSocket) -> (address, data)
+    recvfrom(socket::UDPSocket) -> (host_port, data)
 
-Read a UDP packet from the specified socket, returning a tuple of `(address, data)`, where
-`address` will be either IPv4 or IPv6 as appropriate.
+Read a UDP packet from the specified socket, returning a tuple of `(host_port, data)`, where
+`host_port` will be an InetAddr{IPv4} or InetAddr{IPv6}, as appropriate.
+
+!!! compat "Julia 1.3"
+    This method requires at least Julia 1.3.
+
 """
 function recvfrom(sock::UDPSocket)
     iolock_begin()
@@ -348,7 +352,7 @@ function recvfrom(sock::UDPSocket)
         From = Union{InetAddr{IPv4}, InetAddr{IPv6}}
         Data = Vector{UInt8}
         from, data = wait(sock.recvnotify)::Tuple{From, Data}
-        return (from.host, data)
+        return (from, data)
     finally
         unlock(sock.recvnotify)
     end

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -284,8 +284,8 @@ end
             @test fetch(tsk) == msg
         end
         let tsk = @async send(b, ip"127.0.0.1", randport, "WORLD HELLO")
-            (addr, data) = recvfrom(a)
-            @test addr == ip"127.0.0.1" && String(data) == "WORLD HELLO"
+            (inetaddr, data) = recvfrom(a)
+            @test inetaddr.host == ip"127.0.0.1" && String(data) == "WORLD HELLO"
             wait(tsk)
         end
         close(a)
@@ -302,8 +302,8 @@ end
 
         for i = 1:3
             tsk = @async begin
-                let (addr, data) = recvfrom(a)
-                    @test addr == ip"::1"
+                let (inetaddr, data) = recvfrom(a)
+                    @test inetaddr.host == ip"::1"
                     @test String(data) == "Hello World"
                 end
             end


### PR DESCRIPTION
When awaiting PDUs from as yet unknown UDP clients, it is necessary to know the port of the client's socket in order to reply to said client. Returning not only the source address but, also, the source port of received PDUs ensures we can reply to clients without relaying this information in application data.