### PR TITLE
fix #32703, bad ambiguity error

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3032,6 +3032,14 @@ static jl_value_t *intersect_types(jl_value_t *x, jl_value_t *y, int emptiness_o
     jl_stenv_t e;
     if (obviously_disjoint(x, y, 0))
         return jl_bottom_type;
+    if (jl_is_dispatch_tupletype(x) || jl_is_dispatch_tupletype(y)) {
+        if (jl_subtype(x, y))
+            return x;
+        else if (jl_subtype(y, x))
+            return y;
+        else
+            return jl_bottom_type;
+    }
     init_stenv(&e, NULL, 0);
     e.intersection = e.ignore_free = 1;
     e.emptiness_only = emptiness_only;


### PR DESCRIPTION
caused by 52838478aabe93120a0152ec5da733c9d8f0c39a
This adds a workaround.

fix #32703