### PR TITLE
WIP: Make `hasmethod` able to be used for static dispatch

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -175,7 +175,7 @@ function store_backedges(frame::InferenceState)
     toplevel = !isa(frame.linfo.def, Method)
     if !toplevel && (frame.cached || frame.parent !== nothing)
         caller = frame.result.linfo
-        for edges in frame.stmt_edges
+        for edges in (frame.stmt_edges..., frame.src.edges)
             edges === nothing && continue
             i = 1
             while i <= length(edges)
@@ -191,15 +191,7 @@ function store_backedges(frame::InferenceState)
                 end
             end
         end
-        edges = frame.src.edges
-        if edges !== nothing
-            edges = edges::Vector{MethodInstance}
-            for edge in edges
-                @assert isa(edge, MethodInstance)
-                ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any), edge, caller)
-            end
-            frame.src.edges = nothing
-        end
+        frame.src.edges = nothing
     end
 end
 

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -178,7 +178,7 @@ function store_backedges(frame::InferenceState)
         for edges in frame.stmt_edges
             store_backedges(caller, edges)
         end
-        store_backedges(caller, frame.src, edges)
+        store_backedges(caller, frame.src.edges)
         frame.src.edges = nothing
     end
 end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -175,23 +175,28 @@ function store_backedges(frame::InferenceState)
     toplevel = !isa(frame.linfo.def, Method)
     if !toplevel && (frame.cached || frame.parent !== nothing)
         caller = frame.result.linfo
-        for edges in (frame.stmt_edges..., frame.src.edges)
-            edges === nothing && continue
-            i = 1
-            while i <= length(edges)
-                to = edges[i]
-                if isa(to, MethodInstance)
-                    ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any), to, caller)
-                    i += 1
-                else
-                    typeassert(to, Core.MethodTable)
-                    typ = edges[i + 1]
-                    ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any, Any), to, typ, caller)
-                    i += 2
-                end
-            end
+        for edges in frame.stmt_edges
+            store_backedges(caller, edges)
         end
+        store_backedges(caller, frame.src, edges)
         frame.src.edges = nothing
+    end
+end
+
+store_backedges(caller, edges::Nothing) = nothing
+function store_backedges(caller, edges::Vector)
+    i = 1
+    while i <= length(edges)
+        to = edges[i]
+        if isa(to, MethodInstance)
+            ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any), to, caller)
+            i += 1
+        else
+            typeassert(to, Core.MethodTable)
+            typ = edges[i + 1]
+            ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any, Any), to, typ, caller)
+            i += 2
+        end
     end
 end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -234,10 +234,11 @@ function unwrap_unionall(@nospecialize(a))
 end
 
 function rewrap_unionall(@nospecialize(t), @nospecialize(u))
-    if !isa(u, UnionAll)
+    if isa(u, UnionAll)
+        return UnionAll(u.var, rewrap_unionall(t, u.body))
+    else
         return t
     end
-    return UnionAll(u.var, rewrap_unionall(t, u.body))
 end
 
 # replace TypeVars in all enclosing UnionAlls with fresh TypeVars

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1238,9 +1238,7 @@ julia> hasmethod(g, Tuple{}, (:a, :b, :c, :d))  # g accepts arbitrary kwargs
 true
 ```
 """
-function hasmethod(@nospecialize(f), @nospecialize(t); world=typemax(UInt))
-    hasmethod(f, to_tuple_type(t); world=world)
-end
+function hasmethod end
 
 # This is just declaring a simplified version of `@generated` earlier in bootstrappping
 # to be used by hasmethod. TODO: Replace this with just using @eval ?

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1263,8 +1263,9 @@ _hasmethod_false(@nospecialize(f), @nospecialize(t), @nospecialize(w)) = false
         @nospecialize(world::Val{W})
     ) where {T<:Tuple, W},
     begin
-        fi = f.instance  #TODO: make this work with constructors and functors.
-        typ = signature_type(fi, T)
+        # The signature type:
+        typ = rewrap_unionall(Tuple{f, unwrap_unionall(T).parameters...}, T)
+
         method_doesnot_exist = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), typ, W) === nothing
         if method_doesnot_exist
             ci_orig = uncompressed_ast(typeof(_hasmethod_false).name.mt.defs.func)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1287,11 +1287,15 @@ function static_hasmethod(@nospecialize(f), @nospecialize(t); world=typemax(UInt
     return static_hasmethod(f, t, Val{world}())
 end
 
-# TODO: delete this and rename static_hasmethod above
-function hasmethod(@nospecialize(f), @nospecialize(t); world=typemax(UInt))
+
+function dynamic_hasmethod(@nospecialize(f), @nospecialize(t); world=typemax(UInt))
     t = to_tuple_type(t)
     t = signature_type(f, t)
     return ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), t, world) !== nothing
+end
+
+function hasmethod(@nospecialize(f), @nospecialize(t); world=typemax(UInt))
+    return static_hasmethod(f, t; world=world)
 end
 
 function hasmethod(@nospecialize(f), @nospecialize(t), kwnames::Tuple{Vararg{Symbol}}; world=typemax(UInt))


### PR DESCRIPTION
We can make `hasmethod` able to be used for static dispatch, for truely excellent traits,
by making it trigger recompilation of the all functions using it when/if the answer changes.

This is a minor extension of #32237 (in particular addressing [this comment](https://github.com/JuliaLang/julia/pull/32237/files#r290056685))
This will close #32704 

### TODO:
Very small steps / fine-grained tasks: 

- [x] make edges connectable to MethodTables
- [x] Connect the edges in `hasmethod`
- [x] Workout how to write the CodeInfo that should be returned for constant false.
- [ ] Make this play nice with `delete_method`
- [x] Make it work with Functors and Constructors
- [ ] Test all the above