### PR TITLE
Update misleading examples for IteratorSize and eltype

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -113,10 +113,10 @@ types.
 
 # Examples
 ```jldoctest
-julia> eltype(fill(1f0, (2,2)))
+julia> eltype(typeof(fill(1f0, (2,2))))
 Float32
 
-julia> eltype(fill(0x1, (2,2)))
+julia> eltype(typeof(fill(0x1, (2,2))))
 UInt8
 ```
 """

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -76,7 +76,8 @@ Given the type of an iterator, return one of the following values:
 The default value (for iterator types that do not define this function) is `HasLength()`.
 This means that most iterators are assumed to implement [`length`](@ref).
 An example of changing this default:
-```Base.IteratorSize(::Type{MyIteratorType}) = SizeUnknown()```
+```Base.IteratorSize(::Type{<:MyIteratorType}) = SizeUnknown()```
+Note that we use `<:` in case `MyIteratorType` has type parameters.
 
 This trait is generally used to select between algorithms that pre-allocate space for their
 result, and algorithms that resize their result incrementally.

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -73,17 +73,19 @@ Given the type of an iterator, return one of the following values:
    for the iterator.
 * `IsInfinite()` if the iterator yields values forever.
 
-The default value (for iterators that do not define this function) is `HasLength()`.
+The default value (for iterator types that do not define this function) is `HasLength()`.
 This means that most iterators are assumed to implement [`length`](@ref).
+An example of changing this default:
+```Base.IteratorSize(::Type{MyIteratorType}) = SizeUnknown()```
 
 This trait is generally used to select between algorithms that pre-allocate space for their
 result, and algorithms that resize their result incrementally.
 
 ```jldoctest
-julia> Base.IteratorSize(1:5)
+julia> Base.IteratorSize(typeof(1:5))
 Base.HasShape{1}()
 
-julia> Base.IteratorSize((2,3))
+julia> Base.IteratorSize(typeof((2,3)))
 Base.HasLength()
 ```
 """


### PR DESCRIPTION
It seems to be a common mistake to define IteratorSize and eltype on iterator instances rather than types. These doc updates are meant to clarify the issue a bit further.