### PR TITLE
add generalized dot product

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ Standard library changes
 
 * `qr` and `qr!` functions support `blocksize` keyword argument ([#33053]).
 
+* `dot` now admits a 3-argument method `dot(x, A, y)` to compute generalized dot products `dot(x, A*y)`, but without computing and storing the intermediate result `A*y` ([#32739]).
 
 #### SparseArrays
 

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -657,22 +657,22 @@ function dot(x::AbstractVector, B::Bidiagonal, y::AbstractVector)
     ev, dv = B.ev, B.dv
     if B.uplo == 'U'
         x₀ = adjoint(x[1])
-        r = x₀ * dv[1] * y[1]
+        r = dot(x[1], dv[1], y[1])
         @inbounds for j in 2:nx-1
             x₋, x₀ = x₀, adjoint(x[j])
-            r += (x₋*ev[j-1] + x₀*dv[j]) * y[j]
+            r += dot(adjoint(x₋*ev[j-1] + x₀*dv[j]), y[j])
         end
-        r += (x₀*ev[nx-1] + adjoint(x[nx])*dv[nx]) * y[nx]
+        r += dot(adjoint(x₀*ev[nx-1] + adjoint(x[nx])*dv[nx]), y[nx])
         return r
     else # B.uplo == 'L'
         x₀ = adjoint(x[1])
         x₊ = adjoint(x[2])
-        r = (x₀*dv[1] + x₊*ev[1]) * y[1]
+        r = dot(adjoint(x₀*dv[1] + x₊*ev[1]), y[1])
         @inbounds for j in 2:nx-1
             x₀, x₊ = x₊, adjoint(x[j+1])
-            r += (x₀*dv[j] + x₊*ev[j]) * y[j]
+            r += dot(adjoint(x₀*dv[j] + x₊*ev[j]), y[j])
         end
-        r += x₊ * dv[nx] * y[nx]
+        r += dot(adjoint(x₊), dv[nx], y[nx])
         return r
     end
 end

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -656,23 +656,23 @@ function dot(x::AbstractVector, B::Bidiagonal, y::AbstractVector)
     end
     ev, dv = B.ev, B.dv
     if B.uplo == 'U'
-        x₀ = adjoint(x[1])
+        x₀ = x[1]
         r = dot(x[1], dv[1], y[1])
         @inbounds for j in 2:nx-1
-            x₋, x₀ = x₀, adjoint(x[j])
-            r += dot(adjoint(x₋*ev[j-1] + x₀*dv[j]), y[j])
+            x₋, x₀ = x₀, x[j]
+            r += dot(adjoint(ev[j-1])*x₋ + adjoint(dv[j])*x₀, y[j])
         end
-        r += dot(adjoint(x₀*ev[nx-1] + adjoint(x[nx])*dv[nx]), y[nx])
+        r += dot(adjoint(ev[nx-1])*x₀ + adjoint(dv[nx])*x[nx], y[nx])
         return r
     else # B.uplo == 'L'
-        x₀ = adjoint(x[1])
-        x₊ = adjoint(x[2])
-        r = dot(adjoint(x₀*dv[1] + x₊*ev[1]), y[1])
+        x₀ = x[1]
+        x₊ = x[2]
+        r = dot(adjoint(dv[1])*x₀ + adjoint(ev[1])*x₊, y[1])
         @inbounds for j in 2:nx-1
-            x₀, x₊ = x₊, adjoint(x[j+1])
-            r += dot(adjoint(x₀*dv[j] + x₊*ev[j]), y[j])
+            x₀, x₊ = x₊, x[j+1]
+            r += dot(adjoint(dv[j])*x₀ + adjoint(ev[j])*x₊, y[j])
         end
-        r += dot(adjoint(x₊), dv[nx], y[nx])
+        r += dot(x₊, dv[nx], y[nx])
         return r
     end
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -637,11 +637,12 @@ end
 
 # disambiguation methods: * of Diagonal and Adj/Trans AbsVec
 *(x::Adjoint{<:Any,<:AbstractVector}, D::Diagonal) = Adjoint(map((t,s) -> t'*s, D.diag, parent(x)))
-*(x::Adjoint{<:Any,<:AbstractVector}, D::Diagonal, y::AbstractVector) =
-    mapreduce(t -> t[1]*t[2]*t[3], +, zip(x, D.diag, y))
 *(x::Transpose{<:Any,<:AbstractVector}, D::Diagonal) = Transpose(map((t,s) -> transpose(t)*s, D.diag, parent(x)))
 *(x::Transpose{<:Any,<:AbstractVector}, D::Diagonal, y::AbstractVector) =
     mapreduce(t -> t[1]*t[2]*t[3], +, zip(x, D.diag, y))
+function dot(x::AbstractVector, D::Diagonal, y::AbstractVector)
+    mapreduce(t -> adjoint(t[1])*t[2]*t[3], +, zip(x, D.diag, y))
+end
 
 function cholesky!(A::Diagonal, ::Val{false} = Val(false); check::Bool = true)
     info = 0

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -638,10 +638,12 @@ end
 # disambiguation methods: * of Diagonal and Adj/Trans AbsVec
 *(x::Adjoint{<:Any,<:AbstractVector}, D::Diagonal) = Adjoint(map((t,s) -> t'*s, D.diag, parent(x)))
 *(x::Transpose{<:Any,<:AbstractVector}, D::Diagonal) = Transpose(map((t,s) -> transpose(t)*s, D.diag, parent(x)))
+*(x::Adjoint{<:Any,<:AbstractVector}, D::Diagonal, y::AbstractVector) =
+    mapreduce(t -> t[1]*t[2]*t[3], +, zip(x, D.diag, y))
 *(x::Transpose{<:Any,<:AbstractVector}, D::Diagonal, y::AbstractVector) =
     mapreduce(t -> t[1]*t[2]*t[3], +, zip(x, D.diag, y))
 function dot(x::AbstractVector, D::Diagonal, y::AbstractVector)
-    mapreduce(t -> adjoint(t[1])*t[2]*t[3], +, zip(x, D.diag, y))
+    mapreduce(t -> dot(t[1], t[2], t[3]), +, zip(x, D.diag, y))
 end
 
 function cholesky!(A::Diagonal, ::Val{false} = Val(false); check::Bool = true)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -882,7 +882,7 @@ without storing the intermediate result of `A*y`. As for the two-argument
 [`dot(_,_)`](@ref), this acts recursively. Moreover, for complex vectors, the
 first vector is conjugated.
 """
-dot(x, A, y) = dot(A'x, y) # generic fallback for cases that are not covered by specialized methods
+dot(x, A, y) = dot(x, A*y) # generic fallback for cases that are not covered by specialized methods
 
 dot(x::Number, A::Number, y::Number) = conj(x) * A * y
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -882,9 +882,8 @@ without storing the intermediate result of `A*y`. As for the two-argument
 [`dot(_,_)`](@ref), this acts recursively. Moreover, for complex vectors, the
 first vector is conjugated.
 """
-function dot end
-
 dot(x, A, y) = dot(x, A*y) # generic fallback for cases that are not covered by specialized methods
+
 dot(x::Number, A::Number, y::Number) = conj(x) * A * y
 
 function dot(x::AbstractVector, A::AbstractMatrix, y::AbstractVector)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -877,8 +877,10 @@ end
 """
     dot(x, A, y)
 
-Compute the generalized dot product `x' * A * y` between two vectors `x` and `y`.
-For complex vectors, the first vector is conjugated.
+Compute the generalized dot product `dot(A'x, y)` between two vectors `x` and `y`,
+without storing the intermediate result of `A'x`. As for the two-argument
+[`dot(_,_)`](@ref), this acts recursively. Moreover, for complex vectors, the
+first vector is conjugated.
 """
 dot(x::Number, A::Number, y::Number) = conj(x) * A * y
 
@@ -891,11 +893,11 @@ function dot(x::AbstractVector, A::AbstractMatrix, y::AbstractVector)
     @inbounds for j in eachindex(y)
         yj = y[j]
         if !iszero(yj)
-            temp = zero(adjoint(x₁) * A[i₁,j])
+            temp = zero(adjoint(A[i₁,j]) * x₁)
             @simd for i in eachindex(x)
-                temp += adjoint(x[i]) * A[i,j]
+                temp += adjoint(A[i,j]) * x[i]
             end
-            s += dot(adjoint(temp), yj)
+            s += dot(temp, yj)
         end
     end
     return s

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -885,12 +885,11 @@ dot(x::Number, A::Number, y::Number) = conj(x) * A * y
 function dot(x::AbstractVector, A::AbstractMatrix, y::AbstractVector)
     (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
     T = typeof(dot(first(x), first(A), first(y)))
-    zeroxA = zero(adjoint(first(x))*first(A))
     s = zero(T)
     @inbounds for j in eachindex(y)
         yj = y[j]
         if !iszero(yj)
-            temp = zeroxA
+            temp = zero(adjoint(yj))
             @simd for i in eachindex(x)
                 temp += adjoint(x[i]) * A[i,j]
             end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -877,11 +877,13 @@ end
 """
     dot(x, A, y)
 
-Compute the generalized dot product `dot(A'x, y)` between two vectors `x` and `y`,
-without storing the intermediate result of `A'x`. As for the two-argument
+Compute the generalized dot product `dot(x, A*y)` between two vectors `x` and `y`,
+without storing the intermediate result of `A*y`. As for the two-argument
 [`dot(_,_)`](@ref), this acts recursively. Moreover, for complex vectors, the
 first vector is conjugated.
 """
+function dot end
+
 dot(x::Number, A::Number, y::Number) = conj(x) * A * y
 
 function dot(x::AbstractVector, A::AbstractMatrix, y::AbstractVector)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -882,7 +882,7 @@ without storing the intermediate result of `A*y`. As for the two-argument
 [`dot(_,_)`](@ref), this acts recursively. Moreover, for complex vectors, the
 first vector is conjugated.
 """
-dot(x, A, y) = dot(x, A*y) # generic fallback for cases that are not covered by specialized methods
+dot(x, A, y) = dot(A'x, y) # generic fallback for cases that are not covered by specialized methods
 
 dot(x::Number, A::Number, y::Number) = conj(x) * A * y
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -886,14 +886,16 @@ function dot(x::AbstractVector, A::AbstractMatrix, y::AbstractVector)
     (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
     T = typeof(dot(first(x), first(A), first(y)))
     s = zero(T)
+    i₁ = first(eachindex(x))
+    x₁ = first(x)
     @inbounds for j in eachindex(y)
         yj = y[j]
         if !iszero(yj)
-            temp = zero(adjoint(yj))
+            temp = zero(adjoint(x₁) * A[i₁,j])
             @simd for i in eachindex(x)
                 temp += adjoint(x[i]) * A[i,j]
             end
-            s += temp * yj
+            s += dot(adjoint(temp), yj)
         end
     end
     return s

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -899,8 +899,6 @@ true
 """
 dot(x, A, y) = dot(x, A*y) # generic fallback for cases that are not covered by specialized methods
 
-dot(x::Number, A::Number, y::Number) = conj(x) * A * y
-
 function dot(x::AbstractVector, A::AbstractMatrix, y::AbstractVector)
     (axes(x)..., axes(y)...) == axes(A) || throw(DimensionMismatch())
     T = typeof(dot(first(x), first(A), first(y)))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -881,6 +881,21 @@ Compute the generalized dot product `dot(x, A*y)` between two vectors `x` and `y
 without storing the intermediate result of `A*y`. As for the two-argument
 [`dot(_,_)`](@ref), this acts recursively. Moreover, for complex vectors, the
 first vector is conjugated.
+
+!!! compat "Julia 1.4"
+    Three-argument `dot` requires at least Julia 1.4.
+
+# Examples
+```jldoctest
+julia> dot([1; 1], [1 2; 3 4], [2; 3])
+26
+
+julia> dot(1:5, reshape(1:25, 5, 5), 2:6)
+4850
+
+julia> ⋅(1:5, reshape(1:25, 5, 5), 2:6) == dot(1:5, reshape(1:25, 5, 5), 2:6)
+true
+```
 """
 dot(x, A, y) = dot(x, A*y) # generic fallback for cases that are not covered by specialized methods
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -884,6 +884,7 @@ first vector is conjugated.
 """
 function dot end
 
+dot(x, A, y) = dot(x, A*y) # generic fallback for cases that are not covered by specialized methods
 dot(x::Number, A::Number, y::Number) = conj(x) * A * y
 
 function dot(x::AbstractVector, A::AbstractMatrix, y::AbstractVector)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -40,9 +40,6 @@ function *(transx::Transpose{<:Any,<:StridedVector{T}}, y::StridedVector{T}) whe
     return BLAS.dotu(x, y)
 end
 
-# I'm no longer sure we want ternary multiplication to be generally interpreted recursively
-# (*)(x::Adjoint{<:Any,<:AbstractVector}, A::AbstractMatrix, y::AbstractVector) = dot(parent(x), A, y)
-
 # Matrix-vector multiplication
 function (*)(A::StridedMatrix{T}, x::StridedVector{S}) where {T<:BlasFloat,S<:Real}
     TS = promote_op(matprod, T, S)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -3,7 +3,6 @@
 # matmul.jl: Everything to do with dense matrix multiplication
 
 matprod(x, y) = x*y + x*y
-gendot(x, A, y) = adjoint(x)*A*y + adjoint(x)*A*y
 
 # dot products
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -3,6 +3,7 @@
 # matmul.jl: Everything to do with dense matrix multiplication
 
 matprod(x, y) = x*y + x*y
+gendot(x, A, y) = adjoint(x)*A*y + adjoint(x)*A*y
 
 # dot products
 
@@ -39,6 +40,8 @@ function *(transx::Transpose{<:Any,<:StridedVector{T}}, y::StridedVector{T}) whe
     x = transx.parent
     return BLAS.dotu(x, y)
 end
+
+(*)(x::Adjoint{<:Any,<:AbstractVector}, A::AbstractMatrix, y::AbstractVector) = dot(parent(x), A, y)
 
 # Matrix-vector multiplication
 function (*)(A::StridedMatrix{T}, x::StridedVector{S}) where {T<:BlasFloat,S<:Real}

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -40,7 +40,8 @@ function *(transx::Transpose{<:Any,<:StridedVector{T}}, y::StridedVector{T}) whe
     return BLAS.dotu(x, y)
 end
 
-(*)(x::Adjoint{<:Any,<:AbstractVector}, A::AbstractMatrix, y::AbstractVector) = dot(parent(x), A, y)
+# I'm no longer sure we want ternary multiplication to be generally interpreted recursively
+# (*)(x::Adjoint{<:Any,<:AbstractVector}, A::AbstractMatrix, y::AbstractVector) = dot(parent(x), A, y)
 
 # Matrix-vector multiplication
 function (*)(A::StridedMatrix{T}, x::StridedVector{S}) where {T<:BlasFloat,S<:Real}

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -463,7 +463,7 @@ function dot(x::AbstractVector, A::RealHermSymComplexHerm, y::AbstractVector)
     if x === y
         return 2dot(x, Δ, x) - dot(x, D, x)
     else
-        return dot(x, Δ, y) + dot(y, Δ, x) - dot(x, D, x)
+        return dot(x, Δ, y) + dot(y, Δ, x) - dot(x, D, y)
     end
 end
 

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -457,6 +457,16 @@ end
 
 *(A::HermOrSym, B::HermOrSym) = A * copyto!(similar(parent(B)), B)
 
+function dot(x::AbstractVector, A::RealHermSymComplexHerm, y::AbstractVector)
+    Δ = A.uplo == 'U' ? UpperTriangular(A) : LowerTriangular(A)
+    D = Diagonal(A)
+    if x === y
+        return 2dot(x, Δ, x) - dot(x, D, x)
+    else
+        return dot(x, Δ, y) + dot(y, Δ, x) - dot(x, D, x)
+    end
+end
+
 # Fallbacks to avoid generic_matvecmul!/generic_matmatmul!
 ## Symmetric{<:Number} and Hermitian{<:Real} are invariant to transpose; peel off the t
 *(transA::Transpose{<:Any,<:RealHermSymComplexSym}, B::AbstractVector) = transA.parent * B

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -552,9 +552,9 @@ function dot(x::AbstractVector, A::UpperTriangular, y::AbstractVector)
     if iszero(m)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
-    x₁ = first(x)
-    r = zero(typeof(dot(x₁, first(A), first(y))))
-    @inbounds for j in 1:m
+    x₁ = x[1]
+    r = dot(x₁, A[1,1], y[1])
+    @inbounds for j in 2:m
         yj = y[j]
         if !iszero(yj)
             temp = adjoint(x₁) * A[1,j]
@@ -615,8 +615,8 @@ function dot(x::AbstractVector, A::UnitLowerTriangular, y::AbstractVector)
     if iszero(m)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
-    r = dot(x[1], y[1])
-    @inbounds for j in 2:m
+    r = zero(typeof(dot(first(x), first(y))))
+    @inbounds for j in 1:m
         yj = y[j]
         if !iszero(yj)
             temp = dot(x[j], yj)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -557,11 +557,11 @@ function dot(x::AbstractVector, A::UpperTriangular, y::AbstractVector)
     @inbounds for j in 2:m
         yj = y[j]
         if !iszero(yj)
-            temp = adjoint(x₁) * A[1,j]
+            temp = adjoint(A[1,j]) * x₁
             @simd for i in 2:j
-                temp += adjoint(x[i]) * A[i,j]
+                temp += adjoint(A[i,j]) * x[i]
             end
-            r += dot(adjoint(temp), yj)
+            r += dot(temp, yj)
         end
     end
     return r
@@ -578,11 +578,11 @@ function dot(x::AbstractVector, A::UnitUpperTriangular, y::AbstractVector)
     @inbounds for j in 2:m
         yj = y[j]
         if !iszero(yj)
-            temp = adjoint(x₁) * A[1,j]
+            temp = adjoint(A[1,j]) * x₁
             @simd for i in 2:j-1
-                temp += adjoint(x[i]) * A[i,j]
+                temp += adjoint(A[i,j]) * x[i]
             end
-            r += dot(adjoint(temp), yj)
+            r += dot(temp, yj)
             r += dot(x[j], yj)
         end
     end
@@ -599,11 +599,11 @@ function dot(x::AbstractVector, A::LowerTriangular, y::AbstractVector)
     @inbounds for j in 1:m
         yj = y[j]
         if !iszero(yj)
-            temp = adjoint(x[j]) * A[j,j]
+            temp = adjoint(A[j,j]) * x[j]
             @simd for i in j+1:m
-                temp += adjoint(x[i]) * A[i,j]
+                temp += adjoint(A[i,j]) * x[i]
             end
-            r += dot(adjoint(temp), yj)
+            r += dot(temp, yj)
         end
     end
     return r
@@ -619,11 +619,11 @@ function dot(x::AbstractVector, A::UnitLowerTriangular, y::AbstractVector)
     @inbounds for j in 1:m
         yj = y[j]
         if !iszero(yj)
-            temp = adjoint(x[j])
+            temp = x[j]
             @simd for i in j+1:m
-                temp += adjoint(x[i]) * A[i,j]
+                temp += adjoint(A[i,j]) * x[i]
             end
-            r += dot(adjoint(temp), yj)
+            r += dot(temp, yj)
         end
     end
     return r

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -546,6 +546,7 @@ rmul!(A::Union{UpperTriangular,LowerTriangular}, c::Number) = mul!(A, A, c)
 lmul!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = mul!(A, c, A)
 
 function dot(x::AbstractVector, A::UpperTriangular, y::AbstractVector)
+    require_one_based_indexing(x, y)
     m = size(A, 1)
     (length(x) == m == length(y)) || throw(DimensionMismatch())
     if iszero(m)
@@ -566,6 +567,7 @@ function dot(x::AbstractVector, A::UpperTriangular, y::AbstractVector)
     return r
 end
 function dot(x::AbstractVector, A::UnitUpperTriangular, y::AbstractVector)
+    require_one_based_indexing(x, y)
     m = size(A, 1)
     (length(x) == m == length(y)) || throw(DimensionMismatch())
     if iszero(m)
@@ -587,6 +589,7 @@ function dot(x::AbstractVector, A::UnitUpperTriangular, y::AbstractVector)
     return r
 end
 function dot(x::AbstractVector, A::LowerTriangular, y::AbstractVector)
+    require_one_based_indexing(x, y)
     m = size(A, 1)
     (length(x) == m == length(y)) || throw(DimensionMismatch())
     if iszero(m)
@@ -607,6 +610,7 @@ function dot(x::AbstractVector, A::LowerTriangular, y::AbstractVector)
     return r
 end
 function dot(x::AbstractVector, A::UnitLowerTriangular, y::AbstractVector)
+    require_one_based_indexing(x, y)
     m = size(A, 1)
     (length(x) == m == length(y)) || throw(DimensionMismatch())
 

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -582,7 +582,7 @@ function dot(x::AbstractVector, A::UnitUpperTriangular, y::AbstractVector)
             @simd for i in 1:j-1
                 temp += adjoint(x[i]) * A[i,j]
             end
-            temp += A[j,j]
+            temp += adjoint(x[j])
             r += temp * yj
         end
     end
@@ -597,7 +597,7 @@ function dot(x::AbstractVector, A::LowerTriangular, y::AbstractVector)
     end
     T = typeof(dot(first(x), first(A), first(y)))
     r = zero(T)
-    @inbounds for j in 1:n
+    @inbounds for j in 1:m
         yj = y[j]
         if !iszero(yj)
             temp = zero(T)
@@ -613,13 +613,15 @@ function dot(x::AbstractVector, A::UnitLowerTriangular, y::AbstractVector)
     require_one_based_indexing(x, y)
     m = size(A, 1)
     (length(x) == m == length(y)) || throw(DimensionMismatch())
-
+    if iszero(m)
+        return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
+    end
     T = typeof(dot(first(x), first(A), first(y)))
     r = zero(T)
-    @inbounds for j in 1:n
+    @inbounds for j in 1:m
         yj = y[j]
         if !iszero(yj)
-            temp = convert(T, A[j,j])
+            temp = adjoint(x[j])
             @simd for i in j+1:m
                 temp += adjoint(x[i]) * A[i,j]
             end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -619,7 +619,7 @@ function dot(x::AbstractVector, A::UnitLowerTriangular, y::AbstractVector)
     @inbounds for j in 1:m
         yj = y[j]
         if !iszero(yj)
-            temp = dot(x[j], yj)
+            temp = adjoint(x[j])
             @simd for i in j+1:m
                 temp += adjoint(x[i]) * A[i,j]
             end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -203,16 +203,23 @@ end
 end
 
 function dot(x::AbstractVector, S::SymTridiagonal, y::AbstractVector)
+    require_one_based_indexing(x, y)
     nx, ny = length(x), length(y)
     (nx == size(S, 1) == ny) || throw(DimensionMismatch())
     if iszero(nx)
-        return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
+        return dot(zero(eltype(x)), zero(eltype(S)), zero(eltype(y)))
     end
-    r = (adjoint(x[1]) * S.dv[1] + adjoint(x[2]) * transpose(S.ev[1])) * y[1]
+    dv, ev = S.dv, S.ev
+    x₀ = adjoint(x[1])
+    x₊ = adjoint(x[2])
+    sub = transpose(ev[1])
+    r = (x₀*dv[1] + x₊*sub) * y[1]
     @inbounds for j in 2:nx-1
-        r += (adjoint(x[j-1])*S.ev[j-1] + adjoint(x[j])*S.dv[j] + adjoint(x[j+1])*transpose(S.ev[j])) * yj
+        x₋, x₀, x₊ = x₀, x₊, adjoint(x[j+1])
+        sup, sub = transpose(sub), transpose(ev[j])
+        r += (x₋*sup + x₀*dv[j] + x₊*sub) * y[j]
     end
-    r += (adjoint(x[nx-1]) * S.ev[nx-1] + adjoint(x[nx]) * transpose(S.dv[nx])) * y[nx]
+    r += (x₀*transpose(sub) + x_₊*dv[nx]) * y[nx]
     return r
 end
 
@@ -673,15 +680,20 @@ Base._sum(A::Tridiagonal, ::Colon) = sum(A.d) + sum(A.dl) + sum(A.du)
 Base._sum(A::SymTridiagonal, ::Colon) = sum(A.dv) + 2sum(A.ev)
 
 function dot(x::AbstractVector, A::Tridiagonal, y::AbstractVector)
+    require_one_based_indexing(x, y)
     nx, ny = length(x), length(y)
     (nx == size(A, 1) == ny) || throw(DimensionMismatch())
     if iszero(nx)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
-    r = (adjoint(x[1]) * A.d[1] + adjoint(x[2]) * A.dl[1]) * y[1]
+    x₀ = adjoint(x[1])
+    x₊ = adjoint(x[2])
+    dl, d, du = A.dl, A.d, A.du
+    r = (x₀*d[1] + x₊*dl[1]) * y[1]
     @inbounds for j in 2:nx-1
-        r += (adjoint(x[j-1])*A.du[j-1] + adjoint(x[j])*A.d[j] + adjoint(x[j+1])*A.dl[j]) * yj
+        x₋, x₀, x₊ = x₀, x₊, adjoint(x[j+1])
+        r += (x₋*du[j-1] + x₀*d[j] + x₊*dl[j]) * y[j]
     end
-    r += (adjoint(x[nx-1]) * A.du[nx-1] + adjoint(x[nx]) * A.d[nx]) * y[nx]
+    r += (x₀*du[nx-1] + x₊*d[nx]) * y[nx]
     return r
 end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -219,7 +219,7 @@ function dot(x::AbstractVector, S::SymTridiagonal, y::AbstractVector)
         sup, sub = transpose(sub), transpose(ev[j])
         r += (x₋*sup + x₀*dv[j] + x₊*sub) * y[j]
     end
-    r += (x₀*transpose(sub) + x_₊*dv[nx]) * y[nx]
+    r += (x₀*transpose(sub) + x₊*dv[nx]) * y[nx]
     return r
 end
 

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -208,11 +208,11 @@ function dot(x::AbstractVector, S::SymTridiagonal, y::AbstractVector)
     if iszero(nx)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
-    r = (adjoint(x[1]) * S.dv[1] + adjoint(x[2]) * adjoint(S.ev[1])) * y[1]
+    r = (adjoint(x[1]) * S.dv[1] + adjoint(x[2]) * transpose(S.ev[1])) * y[1]
     @inbounds for j in 2:nx-1
-        r += (adjoint(x[j-1])*S.ev[j-1] + adjoint(x[j])*S.dv[j] + adjoint(x[j+1])*adjoint(S.ev[j])) * yj
+        r += (adjoint(x[j-1])*S.ev[j-1] + adjoint(x[j])*S.dv[j] + adjoint(x[j+1])*transpose(S.ev[j])) * yj
     end
-    r += (adjoint(x[nx-1]) * S.ev[nx-1] + adjoint(x[nx]) * adjoint(S.dv[nx])) * y[nx]
+    r += (adjoint(x[nx-1]) * S.ev[nx-1] + adjoint(x[nx]) * transpose(S.dv[nx])) * y[nx]
     return r
 end
 
@@ -678,7 +678,7 @@ function dot(x::AbstractVector, A::Tridiagonal, y::AbstractVector)
     if iszero(nx)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
-    r = (adjoint(x[1]) * A.d[1] + adjoint(x[2]) * adjoint(A.dl[1])) * y[1]
+    r = (adjoint(x[1]) * A.d[1] + adjoint(x[2]) * A.dl[1]) * y[1]
     @inbounds for j in 2:nx-1
         r += (adjoint(x[j-1])*A.du[j-1] + adjoint(x[j])*A.d[j] + adjoint(x[j+1])*A.dl[j]) * yj
     end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -210,16 +210,16 @@ function dot(x::AbstractVector, S::SymTridiagonal, y::AbstractVector)
         return dot(zero(eltype(x)), zero(eltype(S)), zero(eltype(y)))
     end
     dv, ev = S.dv, S.ev
-    x₀ = adjoint(x[1])
-    x₊ = adjoint(x[2])
+    x₀ = x[1]
+    x₊ = x[2]
     sub = transpose(ev[1])
-    r = dot(adjoint(x₀*dv[1] + x₊*sub), y[1])
+    r = dot(adjoint(dv[1])*x₀ + adjoint(sub)*x₊, y[1])
     @inbounds for j in 2:nx-1
-        x₋, x₀, x₊ = x₀, x₊, adjoint(x[j+1])
+        x₋, x₀, x₊ = x₀, x₊, x[j+1]
         sup, sub = transpose(sub), transpose(ev[j])
-        r += dot(adjoint(x₋*sup + x₀*dv[j] + x₊*sub), y[j])
+        r += dot(adjoint(sup)*x₋ + adjoint(dv[j])*x₀ + adjoint(sub)*x₊, y[j])
     end
-    r += dot(adjoint(x₀*transpose(sub) + x₊*dv[nx]), y[nx])
+    r += dot(adjoint(transpose(sub))*x₀ + adjoint(dv[nx])*x₊, y[nx])
     return r
 end
 
@@ -686,14 +686,14 @@ function dot(x::AbstractVector, A::Tridiagonal, y::AbstractVector)
     if iszero(nx)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
-    x₀ = adjoint(x[1])
-    x₊ = adjoint(x[2])
+    x₀ = x[1]
+    x₊ = x[2]
     dl, d, du = A.dl, A.d, A.du
-    r = dot(adjoint(x₀*d[1] + x₊*dl[1]), y[1])
+    r = dot(adjoint(d[1])*x₀ + adjoint(dl[1])*x₊, y[1])
     @inbounds for j in 2:nx-1
-        x₋, x₀, x₊ = x₀, x₊, adjoint(x[j+1])
-        r += dot(adjoint(x₋*du[j-1] + x₀*d[j] + x₊*dl[j]), y[j])
+        x₋, x₀, x₊ = x₀, x₊, x[j+1]
+        r += dot(adjoint(du[j-1])*x₋ + adjoint(d[j])*x₀ + adjoint(dl[j])*x₊, y[j])
     end
-    r += dot(adjoint(x₀*du[nx-1] + x₊*d[nx]), y[nx])
+    r += dot(adjoint(du[nx-1])*x₀ + adjoint(d[nx])*x₊, y[nx])
     return r
 end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -213,13 +213,13 @@ function dot(x::AbstractVector, S::SymTridiagonal, y::AbstractVector)
     x₀ = adjoint(x[1])
     x₊ = adjoint(x[2])
     sub = transpose(ev[1])
-    r = (x₀*dv[1] + x₊*sub) * y[1]
+    r = dot(adjoint(x₀*dv[1] + x₊*sub), y[1])
     @inbounds for j in 2:nx-1
         x₋, x₀, x₊ = x₀, x₊, adjoint(x[j+1])
         sup, sub = transpose(sub), transpose(ev[j])
-        r += (x₋*sup + x₀*dv[j] + x₊*sub) * y[j]
+        r += dot(adjoint(x₋*sup + x₀*dv[j] + x₊*sub), y[j])
     end
-    r += (x₀*transpose(sub) + x₊*dv[nx]) * y[nx]
+    r += dot(adjoint(x₀*transpose(sub) + x₊*dv[nx]), y[nx])
     return r
 end
 
@@ -689,11 +689,11 @@ function dot(x::AbstractVector, A::Tridiagonal, y::AbstractVector)
     x₀ = adjoint(x[1])
     x₊ = adjoint(x[2])
     dl, d, du = A.dl, A.d, A.du
-    r = (x₀*d[1] + x₊*dl[1]) * y[1]
+    r = dot(adjoint(x₀*d[1] + x₊*dl[1]), y[1])
     @inbounds for j in 2:nx-1
         x₋, x₀, x₊ = x₀, x₊, adjoint(x[j+1])
-        r += (x₋*du[j-1] + x₀*d[j] + x₊*dl[j]) * y[j]
+        r += dot(adjoint(x₋*du[j-1] + x₀*d[j] + x₊*dl[j]), y[j])
     end
-    r += (x₀*du[nx-1] + x₊*d[nx]) * y[nx]
+    r += dot(adjoint(x₀*du[nx-1] + x₊*d[nx]), y[nx])
     return r
 end

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -400,3 +400,5 @@ Array(s::UniformScaling, dims::Dims{2}) = Matrix(s, dims)
 ## Diagonal construction from UniformScaling
 Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))
 Diagonal(s::UniformScaling, m::Integer) = Diagonal{eltype(s)}(s, m)
+
+dot(x::AbstractVector, J::UniformScaling, y::AbstractVector) = J.λ * dot(x, y)

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -401,4 +401,7 @@ Array(s::UniformScaling, dims::Dims{2}) = Matrix(s, dims)
 Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))
 Diagonal(s::UniformScaling, m::Integer) = Diagonal{eltype(s)}(s, m)
 
-dot(x::AbstractVector, J::UniformScaling, y::AbstractVector) = J.λ * dot(x, y)
+function dot(x::AbstractVector, J::UniformScaling, y::AbstractVector)
+    return mapreduce(t -> dot(t[1], J.λ, t[2]), +, zip(x, y))
+end
+dot(x::AbstractVector, J::UniformScaling{<:Union{Real,Complex}}, y::AbstractVector) = J.λ*dot(x, y)

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -401,11 +401,6 @@ Array(s::UniformScaling, dims::Dims{2}) = Matrix(s, dims)
 Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))
 Diagonal(s::UniformScaling, m::Integer) = Diagonal{eltype(s)}(s, m)
 
-function dot(x::AbstractVector, J::UniformScaling, y::AbstractVector)
-    return mapreduce(t -> dot(t[1], J.λ, t[2]), +, zip(x, y))
-end
-function dot(x::AbstractVector, a::Number, y::AbstractVector)
-    return mapreduce(t -> dot(t[1], a, t[2]), +, zip(x, y))
-end
-dot(x::AbstractVector, J::UniformScaling{<:Union{Real,Complex}}, y::AbstractVector) = J.λ*dot(x, y)
+dot(x::AbstractVector, J::UniformScaling, y::AbstractVector) = dot(x, J.λ, y)
+dot(x::AbstractVector, a::Number, y::AbstractVector) = sum(t -> dot(t[1], a, t[2]), zip(x, y))
 dot(x::AbstractVector, a::Union{Real,Complex}, y::AbstractVector) = a*dot(x, y)

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -404,4 +404,8 @@ Diagonal(s::UniformScaling, m::Integer) = Diagonal{eltype(s)}(s, m)
 function dot(x::AbstractVector, J::UniformScaling, y::AbstractVector)
     return mapreduce(t -> dot(t[1], J.λ, t[2]), +, zip(x, y))
 end
+function dot(x::AbstractVector, a::Number, y::AbstractVector)
+    return mapreduce(t -> dot(t[1], a, t[2]), +, zip(x, y))
+end
 dot(x::AbstractVector, J::UniformScaling{<:Union{Real,Complex}}, y::AbstractVector) = J.λ*dot(x, y)
+dot(x::AbstractVector, a::Union{Real,Complex}, y::AbstractVector) = a*dot(x, y)

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -463,7 +463,7 @@ end
         y = randn(elty, 5)
         for uplo in (:U, :L)
             B = Bidiagonal(dv, ev, uplo)
-            @test dot(x, B, y) ≈ x' * B * y ≈ *(x', B, y) ≈ (x'B)*y
+            @test dot(x, B, y) ≈ dot(B'x, y) ≈ dot(x, Matrix(B), y)
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -455,4 +455,17 @@ end
     @test A * Tridiagonal(ones(1, 1)) == A
 end
 
+@testset "generalized dot" begin
+    for elty in (Float64, ComplexF64)
+        dv = randn(elty, 5)
+        ev = randn(elty, 4)
+        x = randn(elty, 5)
+        y = randn(elty, 5)
+        for uplo in (:U, :L)
+            B = Bidiagonal(dv, ev, uplo)
+            @test dot(x, B, y) ≈ x' * B * y ≈ *(x', B, y) ≈ (x'B)*y
+        end
+    end
+end
+
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -425,15 +425,15 @@ end
             x = rand(elty, n)
             y = rand(elty, n)
         end
-        @test dot(x, A, y) ≈ x' * A * y ≈ *(x', A, y) ≈ (x'A)*y
-        @test dot(x, A', y) ≈ x' * A' * y ≈ *(x', A', y) ≈ (x'A')*y
-        elty <: Real && @test dot(x, transpose(A), y) ≈ x' * transpose(A) * y ≈ *(x', transpose(A), y) ≈ (x'*transpose(A))*y
+        @test dot(x, A, y) ≈ dot(A'x, y) ≈ *(x', A, y) ≈ (x'A)*y
+        @test dot(x, A', y) ≈ dot(A*x, y) ≈ *(x', A', y) ≈ (x'A')*y
+        elty <: Real && @test dot(x, transpose(A), y) ≈ dot(x, transpose(A)*y) ≈ *(x', transpose(A), y) ≈ (x'*transpose(A))*y
         B = reshape([A], 1, 1)
         x = [x]
         y = [y]
-        @test dot(x, B, y) ≈ x' * B * y ≈ *(x', B, y) ≈ (x'B)*y
-        @test dot(x, B', y) ≈ x' * B' * y ≈ *(x', B', y) ≈ (x'B')*y
-        elty <: Real && @test dot(x, transpose(B), y) ≈ x' * transpose(B) * y ≈ *(x', transpose(B), y) ≈ (x'*transpose(B))*y
+        @test dot(x, B, y) ≈ dot(B'x, y)
+        @test dot(x, B', y) ≈ dot(B*x, y)
+        elty <: Real && @test dot(x, transpose(B), y) ≈ dot(x, transpose(B)*y)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -409,4 +409,32 @@ end
     @test all(!isnan, lmul!(false, Any[NaN]))
 end
 
+@testset "generalized dot #32739" begin
+    for elty in (Int, Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Complex{BigFloat})
+        n = 10
+        if elty <: Int
+            A = rand(-n:n, n, n)
+            x = rand(-n:n, n)
+            y = rand(-n:n, n)
+        elseif elty <: Real
+            A = convert(Matrix{elty}, randn(n,n))
+            x = rand(elty, n)
+            y = rand(elty, n)
+        else
+            A = convert(Matrix{elty}, complex.(randn(n,n), randn(n,n)))
+            x = rand(elty, n)
+            y = rand(elty, n)
+        end
+        @test dot(x, A, y) ≈ x' * A * y ≈ *(x', A, y) ≈ (x'A)*y
+        @test dot(x, A', y) ≈ x' * A' * y ≈ *(x', A', y) ≈ (x'A')*y
+        elty <: Real && @test dot(x, transpose(A), y) ≈ x' * transpose(A) * y ≈ *(x', transpose(A), y) ≈ (x'*transpose(A))*y
+        B = reshape([A], 1, 1)
+        x = [x]
+        y = [y]
+        @test dot(x, B, y) ≈ x' * B * y ≈ *(x', B, y) ≈ (x'B)*y
+        @test dot(x, B', y) ≈ x' * B' * y ≈ *(x', B', y) ≈ (x'B')*y
+        elty <: Real && @test dot(x, transpose(B), y) ≈ x' * transpose(B) * y ≈ *(x', transpose(B), y) ≈ (x'*transpose(B))*y
+    end
+end
+
 end # module TestGeneric

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -88,6 +88,11 @@ let n = 10
             @test det(H + shift*I) ≈ det(A + shift*I)
             @test logabsdet(H + shift*I) ≅ logabsdet(A + shift*I)
         end
+
+        HM = Matrix(h)
+        @test dot(b, h, b) ≈ dot(h'b, b) ≈ dot(b, HM, b) ≈ dot(HM'b, b)
+        c = b .+ 1
+        @test dot(b, h, c) ≈ dot(h'b, c) ≈ dot(b, HM, c) ≈ dot(HM'b, c)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -366,8 +366,16 @@ end
             end
         end
         @testset "generalized dot product" begin
-            @test dot(x, aherm, y) ≈ x'aherm*y ≈ x'*aherm*y
-            @test dot(x, aherm, x) ≈ x'aherm*x ≈ x'*aherm*x
+            for uplo in (:U, :L)
+                @test dot(x, Hermitian(aherm, uplo), y) ≈ x'aherm*y ≈ x'*Hermitian(aherm, uplo)*y
+                @test dot(x, Hermitian(aherm, uplo), x) ≈ x'aherm*x ≈ x'*Hermitian(aherm, uplo)*x
+            end
+            if eltya <: Real
+                for uplo in (:U, :L)
+                    @test dot(x, Symmetric(aherm, uplo), y) ≈ x'aherm*y ≈ x'*Symmetric(aherm, uplo)*y
+                    @test dot(x, Symmetric(aherm, uplo), x) ≈ x'aherm*x ≈ x'*Symmetric(aherm, uplo)*x
+                end
+            end
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -367,13 +367,13 @@ end
         end
         @testset "generalized dot product" begin
             for uplo in (:U, :L)
-                @test dot(x, Hermitian(aherm, uplo), y) ≈ dot(x, Hermitian(aherm, uplo)*y) ≈ dot(x, Matrix(Hermitian(aherm, uplo))*y)
-                @test dot(x, Hermitian(aherm, uplo), x) ≈ dot(x, Hermitian(aherm, uplo)*x) ≈ dot(x, Matrix(Hermitian(aherm, uplo))*x)
+                @test dot(x, Hermitian(aherm, uplo), y) ≈ dot(x, Hermitian(aherm, uplo)*y) ≈ dot(x, Matrix(Hermitian(aherm, uplo)), y)
+                @test dot(x, Hermitian(aherm, uplo), x) ≈ dot(x, Hermitian(aherm, uplo)*x) ≈ dot(x, Matrix(Hermitian(aherm, uplo)), x)
             end
             if eltya <: Real
                 for uplo in (:U, :L)
-                    @test dot(x, Symmetric(aherm, uplo), y) ≈ dot(x, Symmetric(aherm, uplo)*y) ≈ dot(x, Matrix(Symmetric(aherm, uplo))*y)
-                    @test dot(x, Symmetric(aherm, uplo), x) ≈ dot(x, Symmetric(aherm, uplo)*x) ≈ dot(x, Matrix(Symmetric(aherm, uplo))*x)
+                    @test dot(x, Symmetric(aherm, uplo), y) ≈ dot(x, Symmetric(aherm, uplo)*y) ≈ dot(x, Matrix(Symmetric(aherm, uplo)), y)
+                    @test dot(x, Symmetric(aherm, uplo), x) ≈ dot(x, Symmetric(aherm, uplo)*x) ≈ dot(x, Matrix(Symmetric(aherm, uplo)), x)
                 end
             end
         end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -367,13 +367,13 @@ end
         end
         @testset "generalized dot product" begin
             for uplo in (:U, :L)
-                @test dot(x, Hermitian(aherm, uplo), y) ≈ x'aherm*y ≈ x'*Hermitian(aherm, uplo)*y
-                @test dot(x, Hermitian(aherm, uplo), x) ≈ x'aherm*x ≈ x'*Hermitian(aherm, uplo)*x
+                @test dot(x, Hermitian(aherm, uplo), y) ≈ dot(x, Hermitian(aherm, uplo)*y) ≈ dot(x, Matrix(Hermitian(aherm, uplo))*y)
+                @test dot(x, Hermitian(aherm, uplo), x) ≈ dot(x, Hermitian(aherm, uplo)*x) ≈ dot(x, Matrix(Hermitian(aherm, uplo))*x)
             end
             if eltya <: Real
                 for uplo in (:U, :L)
-                    @test dot(x, Symmetric(aherm, uplo), y) ≈ x'aherm*y ≈ x'*Symmetric(aherm, uplo)*y
-                    @test dot(x, Symmetric(aherm, uplo), x) ≈ x'aherm*x ≈ x'*Symmetric(aherm, uplo)*x
+                    @test dot(x, Symmetric(aherm, uplo), y) ≈ dot(x, Symmetric(aherm, uplo)*y) ≈ dot(x, Matrix(Symmetric(aherm, uplo))*y)
+                    @test dot(x, Symmetric(aherm, uplo), x) ≈ dot(x, Symmetric(aherm, uplo)*x) ≈ dot(x, Matrix(Symmetric(aherm, uplo))*x)
                 end
             end
         end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -365,6 +365,10 @@ end
                 @test Symmetric(asym)\b  ≈ asym\b
             end
         end
+        @testset "generalized dot product" begin
+            @test dot(x, aherm, y) ≈ x'aherm*y ≈ x'*aherm*y
+            @test dot(x, aherm, x) ≈ x'aherm*x ≈ x'*aherm*x
+        end
     end
 end
 

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -240,7 +240,11 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         for eltyb in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFloat})
             b1 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1)*fill(1., n))
             b2 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1)*randn(n))
-            @test dot(b1, A1, b2) ≈ b1' * A1 * b2 ≈ *(b1', A1, b2) ≈ (b1'A1)*b2
+            if elty1 in (BigFloat, Complex{BigFloat}) || eltyb in (BigFloat, Complex{BigFloat})
+                @test dot(b1, A1, b2) ≈ (b1'A1)*b2  atol=sqrt(max(eps(real(float(one(elty1)))),eps(real(float(one(eltyb))))))*n*n
+            else
+                @test dot(b1, A1, b2) ≈ (b1'A1)*b2
+            end
         end
 
         # Binary operations

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -243,7 +243,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
             if elty1 in (BigFloat, Complex{BigFloat}) || eltyb in (BigFloat, Complex{BigFloat})
                 @test dot(b1, A1, b2) ≈ dot(A1'b1, b2)  atol=sqrt(max(eps(real(float(one(elty1)))),eps(real(float(one(eltyb))))))*n*n
             else
-                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2)
+                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2)  atol=sqrt(max(eps(real(float(one(elty1)))),eps(real(float(one(eltyb))))))*n*n
             end
         end
 

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -236,6 +236,13 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
             end
         end
 
+        # generalized dot
+        for eltyb in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFloat})
+            b1 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1)*fill(1., n))
+            b2 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1)*randn(n))
+            @test dot(b1, A1, b2) ≈ b1' * A1 * b2 ≈ *(b1', A1, b2) ≈ (b1'A1)*b2
+        end
+
         # Binary operations
         @test A1*0.5 == Matrix(A1)*0.5
         @test 0.5*A1 == 0.5*Matrix(A1)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -241,9 +241,9 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
             b1 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1)*fill(1., n))
             b2 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1)*randn(n))
             if elty1 in (BigFloat, Complex{BigFloat}) || eltyb in (BigFloat, Complex{BigFloat})
-                @test dot(b1, A1, b2) ≈ (b1'A1)*b2  atol=sqrt(max(eps(real(float(one(elty1)))),eps(real(float(one(eltyb))))))*n*n
+                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2)  atol=sqrt(max(eps(real(float(one(elty1)))),eps(real(float(one(eltyb))))))*n*n
             else
-                @test dot(b1, A1, b2) ≈ (b1'A1)*b2
+                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2)
             end
         end
 

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -390,6 +390,11 @@ end
                 end
             end
         end
+        @testset "generalized dot" begin
+            x = fill(convert(elty, 1), n)
+            y = fill(convert(elty, 1), n)
+            @test dot(x, A, y) ≈ x' * A * y ≈ *(x', A, y) ≈ (x'A)*y
+        end
     end
 end
 

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -393,7 +393,7 @@ end
         @testset "generalized dot" begin
             x = fill(convert(elty, 1), n)
             y = fill(convert(elty, 1), n)
-            @test dot(x, A, y) ≈ x' * A * y ≈ *(x', A, y) ≈ (x'A)*y
+            @test dot(x, A, y) ≈ dot(A'x, y)
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -330,4 +330,12 @@ end
     @test I(3) == [1 0 0; 0 1 0; 0 0 1]
 end
 
+@testset "generalized dot" begin
+    x = rand(-10:10, 3)
+    y = rand(-10:10, 3)
+    λ = rand(-10:10)
+    J = UniformScaling(λ)
+    @test dot(x, J, y) == λ*dot(x, y)
+end
+
 end # module TestUniformscaling

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -4,6 +4,10 @@ module TestUniformscaling
 
 using Test, LinearAlgebra, Random, SparseArrays
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :Quaternions) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Quaternions.jl"))
+using .Main.Quaternions
+
 Random.seed!(123)
 
 @testset "basic functions" begin
@@ -336,6 +340,9 @@ end
     λ = rand(-10:10)
     J = UniformScaling(λ)
     @test dot(x, J, y) == λ*dot(x, y)
+    λ = Quaternion(0.44567, 0.755871, 0.882548, 0.423612)
+    x, y = Quaternion(rand(4)...), Quaternion(rand(4)...)
+    @test dot([x], λ*I, [y]) ≈ dot(x, λ, y) ≈ dot(x, λ*I, y) ≈ dot(x, λ*y)
 end
 
 end # module TestUniformscaling

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -342,7 +342,7 @@ end
     @test dot(x, J, y) == λ*dot(x, y)
     λ = Quaternion(0.44567, 0.755871, 0.882548, 0.423612)
     x, y = Quaternion(rand(4)...), Quaternion(rand(4)...)
-    @test dot([x], λ*I, [y]) ≈ dot(x, λ, y) ≈ dot(x, λ*I, y) ≈ dot(x, λ*y)
+    @test dot([x], λ*I, [y]) ≈ dot(x, λ, y) ≈ dot(x, λ*y)
 end
 
 end # module TestUniformscaling

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -321,17 +321,18 @@ function dot(A::AbstractSparseMatrixCSC{T1,S1},B::AbstractSparseMatrixCSC{T2,S2}
     return r
 end
 
-function dot(x::AbstractVector, A::SparseMatrixCSC, y::AbstractVector)
+function dot(x::AbstractVector, A::AbstractSparseMatrixCSC, y::AbstractVector)
     require_one_based_indexing(x, y)
-    (length(x) == A.m && A.n == length(y)) || throw(DimensionMismatch())
-    if iszero(A.m) || iszero(A.n)
+    m, n = size(A)
+    (length(x) == m && n == length(y)) || throw(DimensionMismatch())
+    if iszero(m) || iszero(n)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
     T = promote_type(eltype(x), eltype(A), eltype(y))
     r = zero(T)
-    rvals = rowvals(A)
-    nzvals = nonzeros(A)
-    @inbounds for col in 1:A.n
+    rvals = getrowval(A)
+    nzvals = getnzval(A)
+    @inbounds for col in 1:n
         ycol = y[col]
         if !iszero(ycol)
             temp = zero(T)
@@ -343,18 +344,26 @@ function dot(x::AbstractVector, A::SparseMatrixCSC, y::AbstractVector)
     end
     return r
 end
-function dot(x::SparseVector, A::SparseMatrixCSC, y::SparseVector)
-    x.n == A.m && A.n == y.n || throw(DimensionMismatch())
-    if iszero(A.m) || iszero(A.n)
+function dot(x::SparseVector, A::AbstractSparseMatrixCSC, y::SparseVector)
+    m, n = size(A)
+    length(x) == m && n == length(y) || throw(DimensionMismatch())
+    if iszero(m) || iszero(n)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))
     end
     r = zero(promote_type(eltype(x), eltype(A), eltype(y)))
-    for (yi, yv) in zip(y.nzind, y.nzval)
-        A_ptr_lo = A.colptr[yi]
-        A_ptr_hi = A.colptr[yi+1] - 1
+    xnzind = nonzeroinds(x)
+    xnzval = nonzeros(x)
+    ynzind = nonzeroinds(y)
+    ynzval = nonzeros(y)
+    Acolptr = getcolptr(A)
+    Arowval = getrowval(A)
+    Anzval = getnzval(A)
+    for (yi, yv) in zip(ynzind, ynzval)
+        A_ptr_lo = Acolptr[yi]
+        A_ptr_hi = Acolptr[yi+1] - 1
         if A_ptr_lo <= A_ptr_hi
-            r += _spdot(dot, 1, length(x.nzind), x.nzind, x.nzval,
-                                            A_ptr_lo, A_ptr_hi, A.rowval, A.nzval) * yv
+            r += _spdot(dot, 1, length(xnzind), xnzind, xnzval,
+                                            A_ptr_lo, A_ptr_hi, Arowval, Anzval) * yv
         end
     end
     r

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -322,6 +322,7 @@ function dot(A::AbstractSparseMatrixCSC{T1,S1},B::AbstractSparseMatrixCSC{T2,S2}
 end
 
 function dot(x::AbstractVector, A::SparseMatrixCSC, y::AbstractVector)
+    require_one_based_indexing(x, y)
     (length(x) == A.m && A.n == length(y)) || throw(DimensionMismatch())
     if iszero(A.m) || iszero(A.n)
         return dot(zero(eltype(x)), zero(eltype(A)), zero(eltype(y)))

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -336,7 +336,7 @@ function dot(x::AbstractVector, A::SparseMatrixCSC, y::AbstractVector)
         if !iszero(ycol)
             temp = zero(T)
             for k in nzrange(A, col)
-                temp += x[rvals[k]] * nzvals[k]
+                temp += adjoint(x[rvals[k]]) * nzvals[k]
             end
             r += temp * ycol
         end

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -424,6 +424,15 @@ end
     @test_throws DimensionMismatch dot(sprand(5,5,0.2),sprand(5,6,0.2))
 end
 
+@testset "generalized dot product" begin
+    for i = 1:5
+        A = sprand(ComplexF64, 10, 15, 0.4)
+        x = sprand(ComplexF64, 10, 0.5)
+        y = sprand(ComplexF64, 15, 0.5)
+        @test dot(x, A, y) ≈ dot(Vector(x), A, Vector(y)) ≈ (Vector(x)' * Matrix(A)) * Vector(y)
+    end
+end
+
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :Quaternions) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Quaternions.jl"))
 using .Main.Quaternions

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -427,9 +427,11 @@ end
 @testset "generalized dot product" begin
     for i = 1:5
         A = sprand(ComplexF64, 10, 15, 0.4)
+        Av = view(A, :, :)
         x = sprand(ComplexF64, 10, 0.5)
         y = sprand(ComplexF64, 15, 0.5)
         @test dot(x, A, y) ≈ dot(Vector(x), A, Vector(y)) ≈ (Vector(x)' * Matrix(A)) * Vector(y)
+        @test dot(x, A, y) ≈ dot(x, Av, y)
     end
 end
 


### PR DESCRIPTION
I went ahead and added a generalized dot product `dot(x, A, y)`, as discussed in JuliaLang/LinearAlgebra.jl#334. I shamelessly copied (and slightly adjusted) @simonbyrne's code for the completely sparse case https://github.com/JuliaLang/LinearAlgebra.jl/issues/334 and the dense case https://github.com/JuliaLang/LinearAlgebra.jl/issues/334, and added methods for structured matrices and sparse matrices/generic vectors. There are presumably a couple of things to do:

- [x] add tests

- [x] NEWS entry (I'm not sure, but I guess we would want to announce this feature)

- [x] further optimizations (edit: I tried to reduce memory access similar to the corresponding multiplication functions, such that I hope that avoiding allocating the intermediate multiplication result will pay off)

I'm not an expert in `@simd` and these kind of enhancements, so I'm happy to learn whether one would expect improvements by using such features.

This is written with the option of block matrices in mind, and that should be tested obviously.~~Since we need `zero` of eltypes for type promotion, how would one do that? We don't have StaticArrays to our disposal.~~

If I'm not mistaken, then this would close JuliaLang/LinearAlgebra.jl#334. ~~I don't see how one would leverage symmetry of `A`, or the fact that `x === y`.~~