### PR TITLE
Fix pagetable1 sweeping on 32bit

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1339,7 +1339,8 @@ static void sweep_pool_pagetable(jl_taggedvalue_t ***pfl, int sweep_full) JL_NOT
 {
     if (REGION2_PG_COUNT == 1) { // compile-time optimization
         pagetable1_t *pagetable1 = memory_map.meta1[0];
-        sweep_pool_pagetable1(pfl, pagetable1, sweep_full);
+        if (pagetable1)
+            sweep_pool_pagetable1(pfl, pagetable1, sweep_full);
         return;
     }
     unsigned ub = 0;


### PR DESCRIPTION
If no pool allocations have occurred before the first GC (e.g.
because MEMDEBUG was set), the pagetable1 that covers the entire
(32bit) memory region on 32 bit machines may not have been
initialized yet, while the corresponding sweep function was making
the assumption that the passed in pagetable was non-null.
Add the appropriate check for initialization.

cc @yuyichao