### PR TITLE
Fix signature for mpfr's set_emin/_emax calls

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -1031,8 +1031,9 @@ get_emin() = ccall((:mpfr_get_emin, :libmpfr), Clong, ())
 get_emin_min() = ccall((:mpfr_get_emin_min, :libmpfr), Clong, ())
 get_emin_max() = ccall((:mpfr_get_emin_max, :libmpfr), Clong, ())
 
-set_emax!(x) = ccall((:mpfr_set_emax, :libmpfr), Cvoid, (Clong,), x)
-set_emin!(x) = ccall((:mpfr_set_emin, :libmpfr), Cvoid, (Clong,), x)
+check_exponent_err(ret) = ret == 0 || throw(ArgumentError("Invalid MPFR exponent range"))
+set_emax!(x) = check_exponent_err(ccall((:mpfr_set_emax, :libmpfr), Cint, (Clong,), x))
+set_emin!(x) = check_exponent_err(ccall((:mpfr_set_emin, :libmpfr), Cint, (Clong,), x))
 
 function Base.deepcopy_internal(x::BigFloat, stackdict::IdDict)
     haskey(stackdict, x) && return stackdict[x]


### PR DESCRIPTION
These functions can error and thus return a Cint error code.
Most architectures aren't particularly picky about a mismatched
signature for the return value (particularly something like Cint
that is often ignored), but it is both wrong and can cause problems
on architectures that have strict checking (e.g. wasm).

I'll leave to others whether this error should be detected and translated into a julia
error or whether to silently suppress it as we have been (cc @simonbyrne on that).