### PR TITLE
asyncmap: Include original backtrace in rethrown exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,7 +43,9 @@ Standard library changes
 
 * The methods of `mktemp` and `mktempdir` which take a function body to pass temporary paths to no longer throw errors if the path is already deleted when the function body returns ([#33091]).
 * `asyncmap` now preserves the backtrace of inner exceptions by wrapping them
-  in `TaskFailedException` and `CompositeException` ([#32749])
+  in `TaskFailedException` and `CompositeException`. Also the value of
+  `ntasks` has been reinterpreted as the maximum allowed concurrent tasks
+  instead of the total number of task objects ([#32749]).
 
 * `div` now accepts a rounding mode as the third argument, consistent with the corresponding argument to `rem`. Support for rounding division, by passing one of the RoundNearest modes to this function, was added. For future compatibility, library authors should now extend this function, rather than extending the two-argument `fld`/`cld`/`div` directly. ([#33040])
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@ Standard library changes
 ------------------------
 
 * The methods of `mktemp` and `mktempdir` which take a function body to pass temporary paths to no longer throw errors if the path is already deleted when the function body returns ([#33091]).
+* `asyncmap` now preserves the backtrace of inner exceptions by wrapping them
+  in `TaskFailedException` and `CompositeException` ([#32749])
 
 * `div` now accepts a rounding mode as the third argument, consistent with the corresponding argument to `rem`. Support for rounding division, by passing one of the RoundNearest modes to this function, was added. For future compatibility, library authors should now extend this function, rather than extending the two-argument `fld`/`cld`/`div` directly. ([#33040])
 

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -2,6 +2,8 @@
 
 using Base.Iterators: Enumerate
 
+struct AbortMapException <: Exception end
+
 """
     asyncmap(f, c...; ntasks=0, batch_size=nothing)
 
@@ -9,14 +11,13 @@ Uses multiple concurrent tasks to map `f` over a collection (or multiple
 equal length collections). For multiple collection arguments, `f` is
 applied elementwise.
 
-`ntasks` specifies the number of tasks to run concurrently.
-Depending on the length of the collections, if `ntasks` is unspecified,
-up to 100 tasks will be used for concurrent mapping.
+`ntasks` specifies the maximum number of tasks permitted to run
+concurrently. the default is 100.
 
-`ntasks` can also be specified as a zero-arg function. In this case, the
-number of tasks to run in parallel is checked before processing every element and a new
-task started if the value of `ntasks_func` is less than the current number
-of tasks.
+`ntasks` can also be specified as a zero-arg function. This is called before
+each task is scheduled (each iteration) to be used as the new
+maximum. Changing the maximum will not effect tasks that have already been
+scheduled, but it may effect the scheduling of new tasks.
 
 If `batch_size` is specified, the collection is processed in batch mode. `f` must
 then be a function that must accept a `Vector` of argument tuples and must
@@ -52,50 +53,62 @@ julia> result = asyncmap(1:2) do x
 The following examples highlight execution in different tasks by returning
 the `objectid` of the tasks in which the mapping function is executed.
 
-First, with `ntasks` undefined, each element is processed in a different task.
+First, with `ntasks` undefined, all three iterations can be started at once.
 ```
-julia> tskoid() = objectid(current_task());
-
-julia> asyncmap(x->tskoid(), 1:5)
-5-element Array{UInt64,1}:
- 0x6e15e66c75c75853
- 0x440f8819a1baa682
- 0x9fb3eeadd0c83985
- 0xebd3e35fe90d4050
- 0x29efc93edce2b961
-
-julia> length(unique(asyncmap(x->tskoid(), 1:5)))
-5
+julia> asyncmap(1:3) do i
+         println("before sleep \$i")
+         sleep(1/i)
+         println("after sleep \$i")
+         i
+       end
+before sleep 1
+before sleep 2
+before sleep 3
+after sleep 3
+after sleep 2
+after sleep 1
+3-element Array{Int64,1}:
+ 1
+ 2
+ 3
 ```
 
-With `ntasks=2` all elements are processed in 2 tasks.
+With `ntasks=2` the third iteration must wait until the second
+completes. However it can still start and finish before the first completes.
 ```
-julia> asyncmap(x->tskoid(), 1:5; ntasks=2)
-5-element Array{UInt64,1}:
- 0x027ab1680df7ae94
- 0xa23d2f80cd7cf157
- 0x027ab1680df7ae94
- 0xa23d2f80cd7cf157
- 0x027ab1680df7ae94
-
-julia> length(unique(asyncmap(x->tskoid(), 1:5; ntasks=2)))
-2
+julia> asyncmap(1:3; ntasks=2) do i
+         println("before sleep \$i")
+         sleep(1/i)
+         println("after sleep \$i")
+         i
+       end
+before sleep 1
+before sleep 2
+after sleep 2
+before sleep 3
+after sleep 3
+after sleep 1
+3-element Array{Int64,1}:
+ 1
+ 2
+ 3
 ```
 
 With `batch_size` defined, the mapping function needs to be changed to accept an array
 of argument tuples and return an array of results. `map` is used in the modified mapping
 function to achieve this.
 ```
-julia> batch_func(input) = map(x->string("args_tuple: ", x, ", element_val: ", x[1], ", task: ", tskoid()), input)
-batch_func (generic function with 1 method)
-
-julia> asyncmap(batch_func, 1:5; ntasks=2, batch_size=2)
+julia> asyncmap(1:5; ntasks=2, batch_size=2) do input
+         map(input) do x
+           string("args_tuple: ", x, ", element_val: ", x[1], ", ", current_task())
+         end
+       end
 5-element Array{String,1}:
- "args_tuple: (1,), element_val: 1, task: 9118321258196414413"
- "args_tuple: (2,), element_val: 2, task: 4904288162898683522"
- "args_tuple: (3,), element_val: 3, task: 9118321258196414413"
- "args_tuple: (4,), element_val: 4, task: 4904288162898683522"
- "args_tuple: (5,), element_val: 5, task: 9118321258196414413"
+ "args_tuple: 1, element_val: 1, Task (runnable) @0x00007f6629271390"
+ "args_tuple: 2, element_val: 2, Task (runnable) @0x00007f6629271390"
+ "args_tuple: 3, element_val: 3, Task (runnable) @0x00007f6629271600"
+ "args_tuple: 4, element_val: 4, Task (runnable) @0x00007f6629271600"
+ "args_tuple: 5, element_val: 5, Task (runnable) @0x00007f6629271870"
 ```
 
 !!! note
@@ -104,30 +117,132 @@ julia> asyncmap(batch_func, 1:5; ntasks=2, batch_size=2)
     worker invocation, etc. See [`Threads`](@ref) and `Distributed` for alternatives.
 
 """
-function asyncmap(f, c...; ntasks=0, batch_size=nothing)
-    return async_usemap(f, c...; ntasks=ntasks, batch_size=batch_size)
-end
+asyncmap(f, c...; kwargs...) = do_asyncmap(f, c...; kwargs...)
 
-function async_usemap(f, c...; ntasks=0, batch_size=nothing)
+# This goes to great lengths to use `map` internally so that we do not have
+# to reimplement all of map's special behaviours.
+function do_asyncmap(f, c...; ntasks=0, batch_size=nothing)
     ntasks = verify_ntasks(c[1], ntasks)
     batch_size = verify_batch_size(batch_size)
 
-    if batch_size !== nothing
-        exec_func = batch -> begin
-            # extract the Refs from the input tuple
-            batch_refs = map(x->x[1], batch)
-
-            # and the args tuple....
-            batched_args = map(x->x[2], batch)
-
-            results = f(batched_args)
-            foreach(x -> (batch_refs[x[1]].x = x[2]), enumerate(results))
-        end
+    res = if batch_size === nothing
+        do_asyncmap(f, c, ntasks)
     else
-        exec_func = (r,args) -> (r.x = f(args...))
+        do_asyncmap(f, c, ntasks, batch_size)
     end
-    chnl, err_chnl, worker_tasks = setup_chnl_and_tasks(exec_func, ntasks, batch_size)
-    return wrap_n_exec_twice(chnl, err_chnl, worker_tasks, ntasks, exec_func, c...)
+
+    if res isa Ref
+        # scalar case: map(f, x...) = f(x...)
+        res.x
+    else
+        map(ref -> ref.x, res)
+    end
+end
+
+mutable struct AsyncmapCtx
+    tasks::Vector{Task}
+    ntasks::Function
+    concur::Int
+    echnl::Channel{Task}
+end
+
+AsyncmapCtx(ntasks) =
+    AsyncmapCtx([], ntasks, 0, Channel{Task}(typemax(Int)))
+
+# Schedule a task to map f(xs). This will block if too many
+# tasks are concurrently active. Callers should catch
+# AbortMapException.
+function do_asyncmap_task!(f::Function, s::AsyncmapCtx, xs...)
+    t = @task try
+        f(xs...)
+    catch
+        put!(s.echnl, current_task())
+        rethrow()
+    finally
+        s.concur -= 1
+    end
+
+    while s.concur >= s.ntasks() && !isready(s.echnl)
+        yield()
+    end
+
+    isready(s.echnl) && throw(AbortMapException());
+
+    s.concur += 1
+    schedule(t)
+    push!(s.tasks, t)
+end
+
+function wait_done(s::AsyncmapCtx)
+    foreach(_wait, s.tasks)
+    close(s.echnl)
+
+    isready(s.echnl) &&
+        throw(CompositeException(TaskFailedException.(s.echnl)))
+end
+
+function do_asyncmap(f, c::Tuple, ntasks::Function)
+    s = AsyncmapCtx(ntasks)
+
+    res = try
+        map(c...) do x...
+            r = Ref{Any}(nothing)
+
+            do_asyncmap_task!(s) do
+                r.x = f(x...)
+            end
+
+            r
+        end
+    catch ex
+        ex isa AbortMapException || rethrow()
+    end
+
+    wait_done(s)
+
+    res
+end
+
+function do_asyncmap(f, c::Tuple, ntasks::Function, batch_size)
+    s = AsyncmapCtx(ntasks)
+    local batch_in
+    local batch_out
+
+    function new_batch()
+        batch_in = sizehint!(Vector{Any}(), batch_size)
+        batch_out = sizehint!(Vector{Ref{Any}}(), batch_size)
+    end
+
+    exec_batch(args, res) = for (i, x) in enumerate(f(args))
+        res[i].x = x
+    end
+
+    new_batch()
+    res = try
+        rs = map(c...) do x
+            r = Ref{Any}(undef)
+
+            push!(batch_in, x)
+            push!(batch_out, r)
+
+            if length(batch_in) >= batch_size
+                do_asyncmap_task!(exec_batch, s, batch_in, batch_out)
+                new_batch()
+            end
+
+            r
+        end
+
+        do_asyncmap_task!(exec_batch, s, batch_in, batch_out)
+
+        rs
+    catch ex
+        ex isa AbortMapException || rethrow()
+    end
+
+    wait_done(s)
+
+    res
 end
 
 batch_size_err_str(batch_size) = string("batch_size must be specified as a positive integer. batch_size=", batch_size)
@@ -144,7 +259,7 @@ function verify_batch_size(batch_size)
 end
 
 
-function verify_ntasks(iterable, ntasks)
+function verify_ntasks(iterable, ntasks)::Function
     if !((isa(ntasks, Number) && (ntasks >= 0)) || isa(ntasks, Function))
         err = string("ntasks must be specified as a positive integer or a 0-arg function. ntasks=", ntasks)
         throw(ArgumentError(err))
@@ -158,116 +273,8 @@ function verify_ntasks(iterable, ntasks)
             ntasks = 100
         end
     end
-    return ntasks
-end
 
-function wrap_n_exec_twice(chnl, err_chnl, worker_tasks, ntasks, exec_func, c...)
-    # The driver task, creates a Ref object and writes it and the args tuple to
-    # the communication channel for processing by a free worker task.
-    push_arg_to_channel = (x...) -> (r=Ref{Any}(nothing); put!(chnl,(r,x));r)
-
-    if isa(ntasks, Function)
-        map_f = (x...) -> begin
-            # check number of tasks every time, and start one if required.
-            # number_tasks > optimal_number is fine, the other way around is inefficient.
-            if length(worker_tasks) < ntasks()
-                start_worker_task!(worker_tasks, exec_func, chnl, err_chnl)
-            end
-            push_arg_to_channel(x...)
-        end
-    else
-        map_f = push_arg_to_channel
-    end
-    maptwice(map_f, chnl, err_chnl, worker_tasks, c...)
-end
-
-function maptwice(wrapped_f, chnl, err_chnl, worker_tasks, c...)
-    # first run, returns a collection of Refs
-    asyncrun = try
-        map(wrapped_f, c...)
-    catch ex
-        # the work channel was closed early and we have the error
-        ex isa InvalidStateException && isready(err_chnl) || rethrow()
-    finally
-        close(chnl)
-    end
-
-    # wait for all worker tasks to finish. We try not to throw
-    # task errors here because they would be in task creation
-    # order.
-    try
-        @sync foreach(t -> @sync_add(t), worker_tasks)
-    catch
-        isready(err_chnl) || rethrow()
-    finally
-        close(err_chnl)
-    end
-
-    # throw task errors in chronological order
-    if isready(err_chnl)
-        exs = [TaskFailedException(task) for task in err_chnl]
-        throw(CompositeException(exs))
-    end
-
-    if isa(asyncrun, Ref)
-        # scalar case
-        return asyncrun.x
-    else
-        # second run, extract values from the Refs and return
-        return map(ref->ref.x, asyncrun)
-    end
-end
-
-function setup_chnl_and_tasks(exec_func, ntasks, batch_size=nothing)
-    if isa(ntasks, Function)
-        nt = ntasks()
-        # start at least one worker task.
-        if nt == 0
-            nt = 1
-        end
-    else
-        nt = ntasks
-    end
-
-    # Use an unbuffered channel for communicating with the worker tasks. In the event
-    # of an error in any of the worker tasks, the channel is closed. This
-    # results in the `put!` in the driver task failing immediately.
-    chnl = Channel(0)
-    err_chnl = Channel(nt)
-    worker_tasks = []
-    foreach(_ -> start_worker_task!(worker_tasks, exec_func, chnl, err_chnl, batch_size), 1:nt)
-    yield()
-    return (chnl, err_chnl, worker_tasks)
-end
-
-start_worker_task(exec_func, chnl) = foreach(exec_data -> exec_func(exec_data...), chnl)
-start_worker_task(exec_func, chnl, ::Nothing) = start_worker_task(exec_func, chnl)
-start_worker_task(exec_func, chnl, batch_size) = while isopen(chnl)
-    # The mapping function expects an array of input args, as it processes
-    # elements in a batch.
-    batch_collection=Any[]
-    n = 0
-    for exec_data in chnl
-        push!(batch_collection, exec_data)
-        n += 1
-        (n == batch_size) && break
-    end
-    if n > 0
-        exec_func(batch_collection)
-    end
-end
-
-function start_worker_task!(worker_tasks, exec_func, chnl, err_chnl, batch_size=nothing)
-    t = @async begin
-        try
-            start_worker_task(exec_func, chnl, batch_size)
-        catch
-            put!(err_chnl, current_task())
-            close(chnl)
-            rethrow()
-        end
-    end
-    push!(worker_tasks, t)
+    ntasks isa Number ? () -> ntasks : ntasks
 end
 
 # Special handling for some types.
@@ -279,7 +286,7 @@ end
 
 # map on a single BitArray returns a BitArray if the mapping function is boolean.
 function asyncmap(f, b::BitArray; kwargs...)
-    b2 = async_usemap(f, b; kwargs...)
+    b2 = do_asyncmap(f, b; kwargs...)
     if eltype(b2) == Bool
         return BitArray(b2)
     end
@@ -322,71 +329,53 @@ function AsyncCollector(f, results, c...; ntasks=0, batch_size=nothing)
 end
 
 mutable struct AsyncCollectorState
-    chnl::Channel
-    err_chnl::Channel
-    worker_tasks::Array{Task,1}
+    ctx::AsyncmapCtx
+    batch::Vector{Any}
     enum_state      # enumerator state
-    AsyncCollectorState(chnl::Channel, err_chnl::Channel, worker_tasks::Vector) =
-        new(chnl, err_chnl, convert(Vector{Task}, worker_tasks))
+
+    AsyncCollectorState(ntasks::Function) = new(AsyncmapCtx(ntasks), [])
 end
 
 function iterate(itr::AsyncCollector)
     itr.ntasks = verify_ntasks(itr.enumerator, itr.ntasks)
     itr.batch_size = verify_batch_size(itr.batch_size)
-    if itr.batch_size !== nothing
-        exec_func = batch -> begin
-            # extract indices from the input tuple
-            batch_idxs = map(x->x[1], batch)
 
-            # and the args tuple....
-            batched_args = map(x->x[2], batch)
-
-            results = f(batched_args)
-            foreach(x -> (itr.results[batch_idxs[x[1]]] = x[2]), enumerate(results))
-        end
-    else
-        exec_func = (i,args) -> (itr.results[i]=itr.f(args...))
-    end
-
-    chnl, err_chnl, worker_tasks = setup_chnl_and_tasks(itr.ntasks, itr.batch_size) do i, args
-        itr.results[i]=itr.f(args...)
-    end
-
-    return iterate(itr, AsyncCollectorState(chnl, err_chnl, worker_tasks))
-end
-
-function wait_done(itr::AsyncCollector, state::AsyncCollectorState)
-    close(state.chnl)
-
-    # wait for all tasks to finish
-    @sync foreach(t -> @sync_add(t), state.worker_tasks)
-    empty!(state.worker_tasks)
-
-    close(state.err_chnl)
-    isready(state.err_chnl) && throw(CompositeException(collect(state.err_chnl)))
+    return iterate(itr, AsyncCollectorState(itr.ntasks))
 end
 
 function iterate(itr::AsyncCollector, state::AsyncCollectorState)
-    if itr.nt_check && (length(state.worker_tasks) < itr.ntasks())
-        start_worker_task!(state.worker_tasks, itr.f, state.chnl)
-    end
-
-    # Get index and mapped function arguments from enumeration iterator.
     y = isdefined(state, :enum_state) ?
         iterate(itr.enumerator, state.enum_state) :
         iterate(itr.enumerator)
+
     if y === nothing
-        wait_done(itr, state)
+        wait_done(state.ctx)
         return nothing
     end
+
     (i, args), state.enum_state = y
 
     try
-        put!(state.chnl, (i, args))
+        if itr.batch_size in (1, nothing)
+            do_asyncmap_task!(state.ctx, i, args) do i, args
+                itr.results[i] = itr.f(args...)
+            end
+        else
+            push!(state.batch, args)
+
+            if length(state.batch) >= itr.batch_size
+                do_asyncmap_task!(state.ctx, state.batch) do batch
+                    for (j, res) in enumerate(itr.f(batch))
+                        itr.results[i - length(batch) + j] = res
+                    end
+                end
+
+                state.batch = []
+            end
+        end
     catch ex
-        put!(state.err_chnl, ex)
-        wait_done(itr, state)
-        rethrow() # Should never reach here
+        ex isa AbortMapException || rethrow()
+        wait_done()
     end
 
     return (nothing, state)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -589,13 +589,18 @@ generic_map_tests(pmap_fallback)
 run_map_equivalence_tests(pmap)
 @test pmap(uppercase, "Hello World!") == map(uppercase, "Hello World!")
 
+unpack(ex::CompositeException) = unpack(ex.exceptions[1])
+unpack(ex::CapturedException) = unpack(ex.ex)
+unpack(ex::RemoteException) = unpack(ex.captured)
+unpack(ex::TaskFailedException) = unpack(ex.task.exception)
+unpack(ex) = ex
 
 # Simple test for pmap throws error
 let error_thrown = false
     try
         pmap(x -> x == 50 ? error("foobar") : x, 1:100)
     catch e
-        @test e.captured.ex.msg == "foobar"
+        @test unpack(e).msg == "foobar"
         error_thrown = true
     end
     @test error_thrown


### PR DESCRIPTION
Wrap the exception from the user code in CapturedException which contains the
original backtrace to the user's code.