### PR TITLE
fix test for sparse matrix assignment

### DIFF
--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -103,7 +103,10 @@ do33 = fill(1.,3)
 end
 
 @testset "Issue #30006" begin
-    SparseMatrixCSC{Float64,Int32}(spzeros(3,3))[:, 1] == [1, 2, 3]
+    A = SparseMatrixCSC{Float64,Int32}(spzeros(3,3))
+    A[:, 1] = [1, 2, 3]
+    @test nnz(A) == 3
+    @test nonzeros(A) == [1, 2, 3]
 end
 
 @testset "concatenation tests" begin


### PR DESCRIPTION
This "test" was introduced in #30405, but (i) it doesn't test anything, and (ii) what was written returns false. Judging from #30006, I guess what was supposed to be tested is assignment to previous zero elements, not comparison. Anyway, please feel free to change to whatever is more meaningful.

Edit: those patches were backported, so this may apply here as well?