### PR TITLE
link numeric literal coefficients from math operations manual

### DIFF
--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -380,7 +380,7 @@ Julia applies the following order and associativity of operations, from highest 
 For a complete list of *every* Julia operator's precedence, see the top of this file:
 [`src/julia-parser.scm`](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm)
 
-[Numeric literal cefficients](@ref man-numeric-literal-coefficients), e.g. `2x`, are treated as a multiplication with higher precedence than any other binary operation, and also have higher precedence than `^`.
+[Numeric literal coefficients](@ref man-numeric-literal-coefficients), e.g. `2x`, are treated as multiplications with higher precedence than any other binary operation, and also have higher precedence than `^`.
 
 You can also find the numerical precedence for any given operator via the built-in function `Base.operator_precedence`, where higher numbers take precedence:
 

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -28,7 +28,7 @@ as well as the negation on [`Bool`](@ref) types:
 |:---------- |:-------- |:---------------------------------------- |
 | `!x`       | negation | changes `true` to `false` and vice versa |
 
-A numeric literal placed directly before a variable or parentheses, e.g. `2x` or `2(x+y)`, is treated as a multiplication, except with higher precedence than other binary operations.  See [Numeric Literal Coefficients](@ref man-numeric-literal-coefficients) for details.
+A numeric literal placed directly before an identifier or parentheses, e.g. `2x` or `2(x+y)`, is treated as a multiplication, except with higher precedence than other binary operations.  See [Numeric Literal Coefficients](@ref man-numeric-literal-coefficients) for details.
 
 Julia's promotion system makes arithmetic operations on mixtures of argument types "just work"
 naturally and automatically. See [Conversion and Promotion](@ref conversion-and-promotion) for details of the promotion

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -28,6 +28,8 @@ as well as the negation on [`Bool`](@ref) types:
 |:---------- |:-------- |:---------------------------------------- |
 | `!x`       | negation | changes `true` to `false` and vice versa |
 
+A numeric literal placed directly before a variable or parentheses, e.g. `2x` or `2(x+y)`, is treated as a multiplication, except with higher precedence than other binary operations.  See [Numeric Literal Coefficients](@ref man-numeric-literal-coefficients) for details.
+
 Julia's promotion system makes arithmetic operations on mixtures of argument types "just work"
 naturally and automatically. See [Conversion and Promotion](@ref conversion-and-promotion) for details of the promotion
 system.
@@ -377,6 +379,8 @@ Julia applies the following order and associativity of operations, from highest 
 
 For a complete list of *every* Julia operator's precedence, see the top of this file:
 [`src/julia-parser.scm`](https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm)
+
+[Numeric literal cefficients](@ref man-numeric-literal-coefficients), e.g. `2x`, are treated as a multiplication with higher precedence than any other binary operation, and also have higher precedence than `^`.
 
 You can also find the numerical precedence for any given operator via the built-in function `Base.operator_precedence`, where higher numbers take precedence:
 


### PR DESCRIPTION
Numeric literal coefficients are documented in the [*Integers and Floating-Point Numbers*](https://docs.julialang.org/en/latest/manual/integers-and-floating-point-numbers/#man-numeric-literal-coefficients-1) section of the manual, but not under *Mathematical Operations*.

This PR adds a couple of mentions under *Mathematical Operations*, following a suggestion by @ron-rivest.