### PR TITLE
Preserve structured matrix types more often when broadcasting

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -92,7 +92,7 @@ isstructurepreserving(::Union{typeof(abs),typeof(big)}, ::StructuredMatrix) = tr
 isstructurepreserving(::TypeFuncs, ::StructuredMatrix) = true
 isstructurepreserving(::TypeFuncs, ::Ref{<:Type}, ::StructuredMatrix) = true
 function isstructurepreserving(::typeof(Base.literal_pow), ::Ref{typeof(^)}, ::StructuredMatrix, ::Ref{Val{N}}) where N
-    return N isa Integer && N != 0
+    return N isa Integer && N > 0
 end
 isstructurepreserving(f, args...) = false
 

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -35,11 +35,12 @@ using Test, LinearAlgebra
         @test isequal(X .* Inf, fX .* Inf)
 
         two = 2
-        @test X .^ 2 ==  X .^ (2,) = fX .^ 2 == X .^ two
+        @test X .^ 2 ==  X .^ (2,) == fX .^ 2 == X .^ two
         @test X .^ 2 isa typeof(X)
         @test X .^ (2,) isa typeof(X)
         @test X .^ two isa typeof(X)
         @test X .^ 0 == fX .^ 0
+        @test X .^ -1 == fX .^ -1
 
         for (Y, fY) in zip(structuredarrays, fstructuredarrays)
             @test broadcast(+, X, Y) == broadcast(+, fX, fY)

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -28,6 +28,19 @@ using Test, LinearAlgebra
         @test broadcast!(+, Z, fV, fA, X) == broadcast(+, fV, fA, fX)
         @test (Q = broadcast(*, s, fV, fA, X); Q isa Matrix && Q == broadcast(*, s, fV, fA, fX))
         @test broadcast!(*, Z, s, fV, fA, X) == broadcast(*, s, fV, fA, fX)
+
+        @test X .* 2.0 == X .* (2.0,) == fX .* 2.0
+        @test X .* 2.0 isa typeof(X)
+        @test X .* (2.0,) isa typeof(X)
+        @test isequal(X .* Inf, fX .* Inf)
+
+        two = 2
+        @test X .^ 2 ==  X .^ (2,) = fX .^ 2 == X .^ two
+        @test X .^ 2 isa typeof(X)
+        @test X .^ (2,) isa typeof(X)
+        @test X .^ two isa typeof(X)
+        @test X .^ 0 == fX .^ 0
+
         for (Y, fY) in zip(structuredarrays, fstructuredarrays)
             @test broadcast(+, X, Y) == broadcast(+, fX, fY)
             @test broadcast!(+, Z, X, Y) == broadcast(+, fX, fY)


### PR DESCRIPTION
The primary motivation here is exponentiation (fixes JuliaLang/LinearAlgebra.jl#648). Previously `X .^ 2` would return a Matrix but `two=2; X .^ two` would return the same structured matrix type as `X`. This simply teaches LinearAlgebra a little bit more about broadcast so it can safely compute the zero-preservation property of broadcasts involving `Ref`s, which is sufficient to handle the literal pow argument list.