### PR TITLE
workaround wrong paths reported for stdlib functions 

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -119,17 +119,24 @@ end
 # In case the line numbers in the source code have changed since the code was compiled,
 # allow packages to set a callback function that corrects them.
 # (Used by Revise and perhaps other packages.)
-default_methodloc(method::Method) = method.file, method.line
-const methodloc_callback = Ref{Function}(default_methodloc)
+const methodloc_callback = Ref{Union{Function, Nothing}}(nothing)
 
 # This function does the method location updating
-function updated_methodloc(m)
-    file, line = invokelatest(methodloc_callback[], m)
-    if file !== nothing && isdefined(@__MODULE__, :Sys)
-        # BUILD_STDLIB_PATH gets defined in sysinfo.jl
-        file = replace(String(file), normpath(Sys.BUILD_STDLIB_PATH) => normpath(Sys.STDLIB))
+function updated_methodloc(m::Method)::Tuple{String, Int32}
+    file, line = m.file, m.line
+    if methodloc_callback[] !== nothing
+        try
+            file, line = invokelatest(methodloc_callback[], m)
+        catch
+        end
     end
-    return Symbol(file), line
+    # The file defining Base.Sys gets included after this file is included so make sure
+    # this function is valid even in this intermediary state
+    if isdefined(@__MODULE__, :Sys) && Sys.BUILD_STDLIB_PATH != Sys.STDLIB
+        # BUILD_STDLIB_PATH gets defined in sysinfo.jl
+        file = replace(string(file), normpath(Sys.BUILD_STDLIB_PATH) => normpath(Sys.STDLIB))
+    end
+    return string(file), line
 end
 
 functionloc(m::Core.MethodInstance) = functionloc(m.def)
@@ -205,10 +212,7 @@ function show(io::IO, m::Method)
     show_method_params(io, tv)
     print(io, " in ", m.module)
     if line > 0
-        try
-            file, line = updated_methodloc(m)
-        catch
-        end
+        file, line = updated_methodloc(m)
         print(io, " at ", file, ":", line)
     end
 end
@@ -257,11 +261,7 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
             println(io)
             print(io, "[$(n)] ")
             show(io, meth)
-            file, line = meth.file, meth.line
-            try
-                file, line = updated_methodloc(m)
-            catch
-            end
+            file, line = updated_methodloc(meth)
             push!(LAST_SHOWN_LINE_INFOS, (string(file), line))
         else
             rest += 1
@@ -371,10 +371,7 @@ function show(io::IO, ::MIME"text/html", m::Method)
     end
     print(io, " in ", m.module)
     if line > 0
-        try
-            file, line = updated_methodloc(m)
-        catch
-        end
+        file, line = updated_methodloc(m)
         u = url(m)
         if isempty(u)
             print(io, " at ", file, ":", line)
@@ -408,11 +405,7 @@ function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
         first = false
         print(io, "[$(i)] ")
         show(io, m)
-        file, line = m.file, m.line
-        try
-            file, line = updated_methodloc(m)
-        catch
-        end
+        file, line = updated_methodloc(m)
         push!(LAST_SHOWN_LINE_INFOS, (string(file), line))
     end
 end

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -49,6 +49,9 @@ A string containing the full path to the directory containing the `julia` execut
 A string containing the full path to the directory containing the `stdlib` packages.
 """
 STDLIB = "$BINDIR/../share/julia/stdlib/v$(VERSION.major).$(VERSION.minor)" # for bootstrap
+# In case STDLIB change after julia is built, the variable below can be used
+# to update cached method locations to updated ones.
+const BUILD_STDLIB_PATH = STDLIB
 
 # helper to avoid triggering precompile warnings
 

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -84,16 +84,6 @@ function edit(path::AbstractString, line::Integer=0)
     nothing
 end
 
-# Workaround for https://github.com/JuliaLang/julia/issues/26314
-const BUILDBOT_STDLIB_PATH = dirname(abspath(joinpath(functionloc(eval)[1]), "..", "..", ".."))
-function functionloc_stdlib_workaround(args...)
-    loc, line = functionloc(args...)
-    if loc !== nothing
-        loc = replace(loc, BUILDBOT_STDLIB_PATH => Sys.STDLIB)
-    end
-    return loc, line
-end
-
 """
     edit(function, [types])
     edit(module)
@@ -108,8 +98,8 @@ method to edit. For modules, open the main source file. The module needs to be l
 The editor can be changed by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environment
 variable.
 """
-edit(f)                   = edit(functionloc_stdlib_workaround(f)...)
-edit(f, @nospecialize t)  = edit(functionloc_stdlib_workaround(f,t)...)
+edit(f)                   = edit(functionloc(f)...)
+edit(f, @nospecialize t)  = edit(functionloc(f,t)...)
 edit(file, line::Integer) = error("could not find source file for function")
 edit(m::Module) = edit(pathof(m))
 
@@ -144,6 +134,6 @@ less(file::AbstractString) = less(file, 1)
 Show the definition of a function using the default pager, optionally specifying a tuple of
 types to indicate which method to see.
 """
-less(f)                   = less(functionloc_stdlib_workaround(f)...)
-less(f, @nospecialize t)  = less(functionloc_stdlib_workaround(f,t)...)
+less(f)                   = less(functionloc(f)...)
+less(f, @nospecialize t)  = less(functionloc(f,t)...)
 less(file, line::Integer) = error("could not find source file for function")

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -84,6 +84,16 @@ function edit(path::AbstractString, line::Integer=0)
     nothing
 end
 
+# Workaround for https://github.com/JuliaLang/julia/issues/26314
+const BUILDBOT_STDLIB_PATH = dirname(abspath(joinpath(functionloc(eval)[1]), "..", "..", ".."))
+function functionloc_stdlib_workaround(args...)
+    loc, line = functionloc(args...)
+    if loc !== nothing
+        loc = replace(loc, BUILDBOT_STDLIB_PATH => Sys.STDLIB)
+    end
+    return loc, line
+end
+
 """
     edit(function, [types])
     edit(module)
@@ -98,8 +108,8 @@ method to edit. For modules, open the main source file. The module needs to be l
 The editor can be changed by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environment
 variable.
 """
-edit(f)                   = edit(functionloc(f)...)
-edit(f, @nospecialize t)  = edit(functionloc(f,t)...)
+edit(f)                   = edit(functionloc_stdlib_workaround(f)...)
+edit(f, @nospecialize t)  = edit(functionloc_stdlib_workaround(f,t)...)
 edit(file, line::Integer) = error("could not find source file for function")
 edit(m::Module) = edit(pathof(m))
 
@@ -134,6 +144,6 @@ less(file::AbstractString) = less(file, 1)
 Show the definition of a function using the default pager, optionally specifying a tuple of
 types to indicate which method to see.
 """
-less(f)                   = less(functionloc(f)...)
-less(f, @nospecialize t)  = less(functionloc(f,t)...)
+less(f)                   = less(functionloc_stdlib_workaround(f)...)
+less(f, @nospecialize t)  = less(functionloc_stdlib_workaround(f,t)...)
 less(file, line::Integer) = error("could not find source file for function")

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -389,3 +389,7 @@ if Sys.iswindows() || Sys.isapple()
         @test clipboard() == str
     end
 end
+
+# buildbot path updating
+file, ln = functionloc(versioninfo, Tuple{})
+@test isfile(file)

--- a/test/show.jl
+++ b/test/show.jl
@@ -637,7 +637,6 @@ else
 end
 
 # Method location correction (Revise integration)
-methloc = Base.methodloc_callback[]
 dummyloc(m::Method) = :nofile, 123456789
 Base.methodloc_callback[] = dummyloc
 let repr = sprint(show, "text/plain", methods(Base.inbase))
@@ -646,7 +645,7 @@ end
 let repr = sprint(show, "text/html", methods(Base.inbase))
     @test occursin("nofile:123456789", repr)
 end
-Base.methodloc_callback[] = methloc
+Base.methodloc_callback[] = nothing
 
 @testset "matrix printing" begin
     # print_matrix should be able to handle small and large objects easily, test by


### PR DESCRIPTION
Not really clean to special case it just ofr `less` and `edit` but that is where people seems to encounter this issue the most. The workaround could potentially be put in `find_source_file` but that is a bit more "invasive".

This is also kinda hard to test. I tested it by evaluating this into `InteractveUtils` in a released julia.

Fixes https://github.com/JuliaLang/julia/issues/26314