### PR TITLE
Index cols with `j` in SparseMatrix docs

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -20,7 +20,7 @@ row indices. The internal representation of `SparseMatrixCSC` is as follows:
 struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows
     n::Int                  # Number of columns
-    colptr::Vector{Ti}      # Column i is in colptr[i]:(colptr[i+1]-1)
+    colptr::Vector{Ti}      # Column j is in colptr[j]:(colptr[j+1]-1)
     rowval::Vector{Ti}      # Row indices of stored values
     nzval::Vector{Tv}       # Stored values, typically nonzeros
 end


### PR DESCRIPTION
This is a super minor change to documentation. 

The SparseMatrixCSC documentation currently discusses indexing `Column i`... but we usually index columns by `j`, not `i` when we talk about matrices. This PR just changes the index from `i` to `j`.