### PR TITLE
Fix missing GC root

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -607,10 +607,12 @@ JL_CALLABLE(jl_f__apply)
                 jl_value_t *state = jl_fieldref(next, 1);
                 roots[stackalloc] = state;
                 _grow_to(&roots[0], &newargs, &arg_heap, &n_alloc, n + precount + 1, extra);
+                JL_GC_ASSERT_LIVE(value);
                 newargs[n++] = value;
                 if (arg_heap)
                     jl_gc_wb(arg_heap, value);
                 roots[stackalloc + 1] = NULL;
+                JL_GC_ASSERT_LIVE(state);
                 args[1] = state;
                 next = jl_apply_generic(jl_iterate_func, args, 2);
             }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -603,7 +603,7 @@ JL_CALLABLE(jl_f__apply)
             while (next != jl_nothing) {
                 roots[stackalloc] = next;
                 jl_value_t *value = jl_fieldref(next, 0);
-                roots[stackalloc + 1] = next;
+                roots[stackalloc + 1] = value;
                 jl_value_t *state = jl_fieldref(next, 1);
                 roots[stackalloc] = state;
                 _grow_to(&roots[0], &newargs, &arg_heap, &n_alloc, n + precount + 1, extra);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1062,6 +1062,16 @@ extern arraylist_t partial_inst;
 #define JL_GCC_IGNORE_STOP
 #endif // _COMPILER_GCC_
 
+#ifdef __clang_analyzer__
+  // Not a safepoint (so it dosn't free other values), but an artificial use.
+  // Usually this is unnecessary because the analyzer can see all real uses,
+  // but sometimes real uses are harder for the analyzer to see, or it may
+  // give up before it sees it, so this can be helpful to be explicit.
+  void JL_GC_ASSERT_LIVE(jl_value_t *v) JL_NOTSAFEPOINT;
+#else
+  #define JL_GC_ASSERT_LIVE(x) (void)(x)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/support/analyzer_annotations.h
+++ b/src/support/analyzer_annotations.h
@@ -45,5 +45,6 @@ extern "C" {
 #define JL_ROOTED_VALUE_COLLECTION
 #define JL_GC_PROMISE_ROOTED(x) (void)(x)
 #define jl_may_leak(x) (void)(x)
+#define JL_GC_ASSERT_LIVE(x)
 
 #endif


### PR DESCRIPTION
There is at least two bugs here:
1. We have a missing GC root
2. The analyzer didn't catch it

The second problem is perhaps the more interesting of the two. At first I thought, there may be a missing case in the analyzer, but it turns out the function is just too complicated, so while the analyzer knows the value is unrooted, it has a hard time seeing the use (an assignment to an array is only illegal if the analyzer knows the array on the LHS is an array of rooted locations), because `newargs` gets reassigned all over the places. To have at least some modicum of regression-safety, here, add a fake use that is easier for the analyzer to understand (and would have caught this issue), but it seems we're still very close to some sort of detectability threshold here.

Fixes #32751