### PR TITLE
WIP: Generated function recompilation with edges

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -521,8 +521,8 @@ end
 
 # invoke and wrap the results of @generated
 function (g::GeneratedFunctionStub)(@nospecialize args...)
-    body = g.gen(args...)
-    #body = Core._apply_pure(g.gen, (args...,))
+    #body = g.gen(args...)
+    body = Core._apply_pure(g.gen, (args...,))
     if body isa CodeInfo
         return body
     end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -521,8 +521,8 @@ end
 
 # invoke and wrap the results of @generated
 function (g::GeneratedFunctionStub)(@nospecialize args...)
-    #body = g.gen(args...)
-    body = Core._apply_pure(g.gen, (args...,))
+    body = g.gen(args...)
+    #body = Core._apply_pure(g.gen, (args...,))
     if body isa CodeInfo
         return body
     end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -522,6 +522,7 @@ end
 # invoke and wrap the results of @generated
 function (g::GeneratedFunctionStub)(@nospecialize args...)
     body = g.gen(args...)
+    #body = Core._apply_pure(g.gen, (args...,))
     if body isa CodeInfo
         return body
     end

--- a/src/julia.h
+++ b/src/julia.h
@@ -1202,6 +1202,7 @@ JL_DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n);
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n);
 JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a);
 JL_DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x);
+// Construct the DataType for `Tuple{v, v, v...}`
 JL_DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v);
 JL_DLLEXPORT jl_sym_t *jl_symbol(const char *str) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_sym_t *jl_symbol_lookup(const char *str) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -991,6 +991,11 @@ void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
 
 int isabspath(const char *in);
 
+JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world);
+JL_CALLABLE(jl_f__apply_pure);
+JL_CALLABLE(jl_f__apply_latest);
+
+
 extern jl_sym_t *call_sym;    extern jl_sym_t *invoke_sym;
 extern jl_sym_t *empty_sym;   extern jl_sym_t *top_sym;
 extern jl_sym_t *module_sym;  extern jl_sym_t *slot_sym;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -991,10 +991,8 @@ void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
 
 int isabspath(const char *in);
 
+// TODO(NHDALY): Find the right place for this.
 JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world);
-JL_CALLABLE(jl_f__apply_pure);
-JL_CALLABLE(jl_f__apply_latest);
-
 
 extern jl_sym_t *call_sym;    extern jl_sym_t *invoke_sym;
 extern jl_sym_t *empty_sym;   extern jl_sym_t *top_sym;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -991,9 +991,6 @@ void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
 
 int isabspath(const char *in);
 
-// TODO(NHDALY): Find the right place for this.
-JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world);
-
 extern jl_sym_t *call_sym;    extern jl_sym_t *invoke_sym;
 extern jl_sym_t *empty_sym;   extern jl_sym_t *top_sym;
 extern jl_sym_t *module_sym;  extern jl_sym_t *slot_sym;

--- a/src/method.c
+++ b/src/method.c
@@ -444,12 +444,12 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
     jl_ptls_t ptls = jl_get_ptls_states();
     int last_lineno = jl_lineno;
     int last_in = ptls->in_pure_callback;
-    size_t last_age = jl_get_ptls_states()->world_age;
+    //size_t last_age = jl_get_ptls_states()->world_age;
 
     JL_TRY {
         ptls->in_pure_callback = 1;
         // and the right world
-        ptls->world_age = def->primary_world;
+        //ptls->world_age = def->primary_world;
 
         // invoke code generator
         jl_tupletype_t *ttdt = (jl_tupletype_t*)jl_unwrap_unionall(tt);
@@ -479,7 +479,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
 
         ptls->in_pure_callback = last_in;
         jl_lineno = last_lineno;
-        ptls->world_age = last_age;
+        //ptls->world_age = last_age;
         jl_linenumber_to_lineinfo(func, (jl_value_t*)def->name);
     }
     JL_CATCH {

--- a/src/method.c
+++ b/src/method.c
@@ -453,23 +453,33 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         jl_value_t* types = jl_argtype_with_function(gen_func, weird_types_tuple);
         jl_static_show(JL_STDERR, (jl_value_t*)types);
 
-        // TODO: The bootstrap segfault comes from jl_gf_invoke_lookup. We can't call
-        // this at this point! Try something else.
-        jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_gf_invoke_lookup(types, -1);
-        //return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), t, lim, 0, world, min, max)
-        //size_t min_valid = 0;
-        //size_t max_valid = ~(size_t)0;
-        //jl_value_t *matches = jl_matching_methods((jl_tupletype_t*)sig, -1, 1, 0, &min_valid, &max_valid);
-        //if (matches == jl_false)
-        //    valid = 0;
+//        // TODO: The bootstrap segfault comes from jl_gf_invoke_lookup. We can't call
+//        // this at this point! Try something else.
+//        jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_gf_invoke_lookup(types, -1);
+//        //return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), t, lim, 0, world, min, max)
+//        //size_t min_valid = 0;
+//        //size_t max_valid = ~(size_t)0;
+//        //jl_value_t *matches = jl_matching_methods((jl_tupletype_t*)sig, -1, 1, 0, &min_valid, &max_valid);
+//        //if (matches == jl_false)
+//        //    valid = 0;
+//
+//
+//        // now we have found the matching definition.
+//        // next look for or create a specialization of this definition.
+//        jl_method_t *method = entry->func.method;
+//        jl_static_show(JL_STDERR, (jl_value_t*)method);
+//        jl_method_instance_t *edge = jl_specializations_get_linfo(method, types, linfo->sparam_vals);
+
+        // next look for or create a specialization of this definition.
+        size_t min_valid = 0;
+        size_t max_valid = ~(size_t)0;
+        jl_method_instance_t *edge = jl_get_specialization1((jl_tupletype_t*)types, -1,
+                                                            &min_valid, &max_valid,
+                                                            1 /* store new specialization */);
+
+        jl_printf(JL_STDERR, "\nedge: "); jl_static_show(JL_STDERR, (jl_value_t*)edge); jl_printf(JL_STDERR, "\n");
 
         JL_GC_POP();
-
-        // now we have found the matching definition.
-        // next look for or create a specialization of this definition.
-        jl_method_t *method = entry->func.method;
-        jl_static_show(JL_STDERR, (jl_value_t*)method);
-        jl_method_instance_t *edge = jl_specializations_get_linfo(method, types, linfo->sparam_vals);
 
 
         // Now create the edges array and set the edge!

--- a/src/method.c
+++ b/src/method.c
@@ -442,7 +442,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         jl_static_show(JL_STDERR, (jl_value_t*)ttdt);
         jl_printf(JL_STDERR, "\n");
         ssize_t numargs = jl_svec_len(ttdt->parameters);  // TODO: is there a better way to get the length of a Tuple?
-        jl_value_t* weird_types_tuple = jl_tupletype_fill(numargs, (jl_value_t*)jl_type_type);
+        jl_value_t* weird_types_tuple = jl_tupletype_fill(numargs, (jl_value_t*)jl_any_type);
         jl_printf(JL_STDERR, "\nWeird Tuple types: ");
         jl_static_show(JL_STDERR, (jl_value_t*)weird_types_tuple);
         jl_printf(JL_STDERR, "\n");

--- a/src/method.c
+++ b/src/method.c
@@ -444,12 +444,12 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
     jl_ptls_t ptls = jl_get_ptls_states();
     int last_lineno = jl_lineno;
     int last_in = ptls->in_pure_callback;
-    //size_t last_age = jl_get_ptls_states()->world_age;
+    size_t last_age = jl_get_ptls_states()->world_age;
 
     JL_TRY {
         ptls->in_pure_callback = 1;
         // and the right world
-        //ptls->world_age = def->primary_world;
+        ptls->world_age = def->primary_world;
 
         // invoke code generator
         jl_tupletype_t *ttdt = (jl_tupletype_t*)jl_unwrap_unionall(tt);
@@ -479,7 +479,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
 
         ptls->in_pure_callback = last_in;
         jl_lineno = last_lineno;
-        //ptls->world_age = last_age;
+        ptls->world_age = last_age;
         jl_linenumber_to_lineinfo(func, (jl_value_t*)def->name);
     }
     JL_CATCH {

--- a/src/method.c
+++ b/src/method.c
@@ -479,8 +479,6 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
 
         jl_printf(JL_STDERR, "\nedge: "); jl_static_show(JL_STDERR, (jl_value_t*)edge); jl_printf(JL_STDERR, "\n");
 
-        JL_GC_POP();
-
 
         // Now create the edges array and set the edge!
         jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");

--- a/src/method.c
+++ b/src/method.c
@@ -466,12 +466,21 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         jl_method_t *method = entry->func.method;
         //jl_static_show(JL_STDERR, (jl_value_t*)method);
 
+        //jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
+        if (func->edges == jl_nothing) {
+          // TODO: How to construct this array type properly
+          jl_value_t* array_mi_type = jl_apply_type2((jl_value_t*)jl_array_type,
+                                                     (jl_value_t*)jl_method_instance_type, jl_box_long(1));
+
+          //jl_static_show(JL_STDERR, array_mi_type);
+          func->edges = (jl_value_t*)jl_alloc_array_1d(array_mi_type, 0);
+        }
+        //jl_static_show(JL_STDERR, (jl_value_t*)func->edges);
+
         jl_method_instance_t *edge = jl_specializations_get_linfo(method, types, linfo->sparam_vals);
-        //jl_printf(JL_STDERR, "\nNATHAN: edge: %p\n", edge);
-        //jl_static_show(JL_STDERR, (jl_value_t*)edge);
-
-
-        jl_method_instance_add_backedge(edge, linfo);
+        //jl_method_instance_add_backedge(edge, linfo);
+        jl_array_ptr_1d_push((jl_array_t*)func->edges, (jl_value_t*)edge);
+        //jl_static_show(JL_STDERR, (jl_value_t*)func->edges);
 
         ptls->in_pure_callback = last_in;
         jl_lineno = last_lineno;

--- a/src/method.c
+++ b/src/method.c
@@ -419,12 +419,12 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
             jl_array_t *stmts = (jl_array_t*)func->code;
             jl_resolve_globals_in_ir(stmts, def->module, linfo->sparam_vals, 1);
         }
-        jl_printf(JL_STDERR, "\nHELLO\n");
-        jl_printf(JL_STDERR, "def: "); jl_static_show(JL_STDERR, (jl_value_t*)def); jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "\nHELLO\n");
+        //jl_printf(JL_STDERR, "def: "); jl_static_show(JL_STDERR, (jl_value_t*)def); jl_printf(JL_STDERR, "\n");
 
         // Get generator function body
         jl_value_t* gen_func = jl_get_field(generator, "gen");
-        jl_printf(JL_STDERR, "gen_func: "); jl_static_show(JL_STDERR, (jl_value_t*)gen_func); jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "gen_func: "); jl_static_show(JL_STDERR, (jl_value_t*)gen_func); jl_printf(JL_STDERR, "\n");
 
         //// Main user-named staged function
         //jl_value_t* staged_function = def->sig;
@@ -440,15 +440,15 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         // Apparently the backedge needs to be from `##s4#3(typeof(func), Type)` instead of
         // the actual types of the aruments! Who knows why!! Weirdness.
         // Manually construct that weird signature, here:
-        jl_printf(JL_STDERR, "\nttdt: "); jl_static_show(JL_STDERR, (jl_value_t*)ttdt); jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "\nttdt: "); jl_static_show(JL_STDERR, (jl_value_t*)ttdt); jl_printf(JL_STDERR, "\n");
         ssize_t numargs = jl_svec_len(ttdt->parameters);  // TODO: is there a better way to get the length of a Tuple?
         jl_value_t* weird_types_tuple = jl_tupletype_fill(numargs, (jl_value_t*)jl_any_type);
-        jl_printf(JL_STDERR, "\nWeird Tuple types: "); jl_static_show(JL_STDERR, (jl_value_t*)weird_types_tuple); jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "\nWeird Tuple types: "); jl_static_show(JL_STDERR, (jl_value_t*)weird_types_tuple); jl_printf(JL_STDERR, "\n");
         // One would expect to be able to just use `tt` here, but we have to use the weird
         // thing instead.
         //jl_value_t* types = jl_argtype_with_function(gen_func, tt);
         jl_tupletype_t* types = (jl_tupletype_t*)jl_argtype_with_function(gen_func, weird_types_tuple);
-        jl_printf(JL_STDERR, "\ntypes: "); jl_static_show(JL_STDERR, (jl_value_t*)types); jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "\ntypes: "); jl_static_show(JL_STDERR, (jl_value_t*)types); jl_printf(JL_STDERR, "\n");
 
         // TODO: The bootstrap segfault comes from jl_gf_invoke_lookup. We can't call
         // this at this point! Try something else.
@@ -465,27 +465,27 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         size_t max_valid = ~(size_t)0;
         jl_value_t *matches = jl_matching_methods(types, /*limit*/ 1, /*ambiguous*/ 1,
                                                   /*world age*/ -1, &min_valid, &max_valid);
-        jl_printf(JL_STDERR, "matches: "); jl_static_show(JL_STDERR, (jl_value_t*)matches); jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "matches: "); jl_static_show(JL_STDERR, (jl_value_t*)matches); jl_printf(JL_STDERR, "\n");
 
         if (matches != jl_false) {
             jl_value_t *method_match = jl_arrayref((jl_array_t*)matches, 0);
-            jl_printf(JL_STDERR, "method_match: %p:", method_match); jl_static_show(JL_STDERR, (jl_value_t*)method_match); jl_printf(JL_STDERR, "\n");
-            jl_printf(JL_STDERR, "jl_typeof(method_match):"); jl_static_show(JL_STDERR, (jl_value_t*)jl_typeof(method_match)); jl_printf(JL_STDERR, "\n");
-            jl_printf(JL_STDERR, "svec_len(method_match): %d\n", jl_svec_len(method_match));
+            //jl_printf(JL_STDERR, "method_match: %p:", method_match); jl_static_show(JL_STDERR, (jl_value_t*)method_match); jl_printf(JL_STDERR, "\n");
+            //jl_printf(JL_STDERR, "jl_typeof(method_match):"); jl_static_show(JL_STDERR, (jl_value_t*)jl_typeof(method_match)); jl_printf(JL_STDERR, "\n");
+            //jl_printf(JL_STDERR, "svec_len(method_match): %d\n", jl_svec_len(method_match));
             //jl_value_t *tt = jl_svecref(method_match, 0);  // unused, already have `types`.
             jl_svec_t *spvals = (jl_svec_t*)jl_svecref(method_match, 1);
-            jl_printf(JL_STDERR, "spvals: "); jl_static_show(JL_STDERR, (jl_value_t*)spvals); jl_printf(JL_STDERR, "\n");
+            //jl_printf(JL_STDERR, "spvals: "); jl_static_show(JL_STDERR, (jl_value_t*)spvals); jl_printf(JL_STDERR, "\n");
             jl_method_t *method = (jl_method_t*)jl_svecref(method_match, 2);
-            jl_printf(JL_STDERR, "method: "); jl_static_show(JL_STDERR, (jl_value_t*)method); jl_printf(JL_STDERR, "\n");
+            //jl_printf(JL_STDERR, "method: "); jl_static_show(JL_STDERR, (jl_value_t*)method); jl_printf(JL_STDERR, "\n");
 
             // now we have found the matching definition.
             // next look for or create a specialization of this definition.
             jl_method_instance_t *edge = jl_specializations_get_linfo(method, (jl_value_t*)types, spvals);
-            jl_printf(JL_STDERR, "edge: "); jl_static_show(JL_STDERR, (jl_value_t*)edge); jl_printf(JL_STDERR, "\n");
+            //jl_printf(JL_STDERR, "edge: "); jl_static_show(JL_STDERR, (jl_value_t*)edge); jl_printf(JL_STDERR, "\n");
 
             if (edge != NULL && (jl_value_t*)edge != jl_nothing) {
                 // Now create the edges array and set the edge!
-                jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
+                //jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
                 if (func->edges == jl_nothing) {
                   // TODO: How to construct this array type properly
                   jl_value_t* array_mi_type = jl_apply_type2((jl_value_t*)jl_array_type,
@@ -497,7 +497,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
 
                 //jl_method_instance_add_backedge(edge, linfo);
                 jl_array_ptr_1d_push((jl_array_t*)func->edges, (jl_value_t*)edge);
-                jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
+                //jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
             }
         }
 

--- a/src/method.c
+++ b/src/method.c
@@ -420,10 +420,11 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
             jl_resolve_globals_in_ir(stmts, def->module, linfo->sparam_vals, 1);
         }
         jl_printf(JL_STDERR, "\nHELLO\n");
+        jl_printf(JL_STDERR, "def: "); jl_static_show(JL_STDERR, (jl_value_t*)def); jl_printf(JL_STDERR, "\n");
 
         // Get generator function body
         jl_value_t* gen_func = jl_get_field(generator, "gen");
-        jl_static_show(JL_STDERR, (jl_value_t*)gen_func);
+        jl_printf(JL_STDERR, "gen_func: "); jl_static_show(JL_STDERR, (jl_value_t*)gen_func); jl_printf(JL_STDERR, "\n");
 
         //// Main user-named staged function
         //jl_value_t* staged_function = def->sig;
@@ -439,62 +440,66 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         // Apparently the backedge needs to be from `##s4#3(typeof(func), Type)` instead of
         // the actual types of the aruments! Who knows why!! Weirdness.
         // Manually construct that weird signature, here:
-        jl_printf(JL_STDERR, "\nttdt: ");
-        jl_static_show(JL_STDERR, (jl_value_t*)ttdt);
-        jl_printf(JL_STDERR, "\n");
+        jl_printf(JL_STDERR, "\nttdt: "); jl_static_show(JL_STDERR, (jl_value_t*)ttdt); jl_printf(JL_STDERR, "\n");
         ssize_t numargs = jl_svec_len(ttdt->parameters);  // TODO: is there a better way to get the length of a Tuple?
         jl_value_t* weird_types_tuple = jl_tupletype_fill(numargs, (jl_value_t*)jl_any_type);
-        jl_printf(JL_STDERR, "\nWeird Tuple types: ");
-        jl_static_show(JL_STDERR, (jl_value_t*)weird_types_tuple);
-        jl_printf(JL_STDERR, "\n");
+        jl_printf(JL_STDERR, "\nWeird Tuple types: "); jl_static_show(JL_STDERR, (jl_value_t*)weird_types_tuple); jl_printf(JL_STDERR, "\n");
         // One would expect to be able to just use `tt` here, but we have to use the weird
         // thing instead.
         //jl_value_t* types = jl_argtype_with_function(gen_func, tt);
-        jl_value_t* types = jl_argtype_with_function(gen_func, weird_types_tuple);
-        jl_static_show(JL_STDERR, (jl_value_t*)types);
+        jl_tupletype_t* types = (jl_tupletype_t*)jl_argtype_with_function(gen_func, weird_types_tuple);
+        jl_printf(JL_STDERR, "\ntypes: "); jl_static_show(JL_STDERR, (jl_value_t*)types); jl_printf(JL_STDERR, "\n");
 
-//        // TODO: The bootstrap segfault comes from jl_gf_invoke_lookup. We can't call
-//        // this at this point! Try something else.
-//        jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_gf_invoke_lookup(types, -1);
-//        //return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), t, lim, 0, world, min, max)
-//        //size_t min_valid = 0;
-//        //size_t max_valid = ~(size_t)0;
-//        //jl_value_t *matches = jl_matching_methods((jl_tupletype_t*)sig, -1, 1, 0, &min_valid, &max_valid);
-//        //if (matches == jl_false)
-//        //    valid = 0;
-//
-//
-//        // now we have found the matching definition.
+        // TODO: The bootstrap segfault comes from jl_gf_invoke_lookup. We can't call
+        // this at this point! Try something else.
+
 //        // next look for or create a specialization of this definition.
-//        jl_method_t *method = entry->func.method;
-//        jl_static_show(JL_STDERR, (jl_value_t*)method);
-//        jl_method_instance_t *edge = jl_specializations_get_linfo(method, types, linfo->sparam_vals);
+//        size_t min_valid = 0;
+//        size_t max_valid = ~(size_t)0;
+//        jl_method_instance_t *edge = jl_get_specialization1((jl_tupletype_t*)types, -1,
+//                                                            &min_valid, &max_valid,
+//                                                            1 /* store new specialization */);
 
-        // next look for or create a specialization of this definition.
+
         size_t min_valid = 0;
         size_t max_valid = ~(size_t)0;
-        jl_method_instance_t *edge = jl_get_specialization1((jl_tupletype_t*)types, -1,
-                                                            &min_valid, &max_valid,
-                                                            1 /* store new specialization */);
+        jl_value_t *matches = jl_matching_methods(types, /*limit*/ 1, /*ambiguous*/ 1,
+                                                  /*world age*/ -1, &min_valid, &max_valid);
+        jl_printf(JL_STDERR, "matches: "); jl_static_show(JL_STDERR, (jl_value_t*)matches); jl_printf(JL_STDERR, "\n");
 
-        jl_printf(JL_STDERR, "\nedge: "); jl_static_show(JL_STDERR, (jl_value_t*)edge); jl_printf(JL_STDERR, "\n");
+        if (matches != jl_false) {
+            jl_value_t *method_match = jl_arrayref((jl_array_t*)matches, 0);
+            jl_printf(JL_STDERR, "method_match: %p:", method_match); jl_static_show(JL_STDERR, (jl_value_t*)method_match); jl_printf(JL_STDERR, "\n");
+            jl_printf(JL_STDERR, "jl_typeof(method_match):"); jl_static_show(JL_STDERR, (jl_value_t*)jl_typeof(method_match)); jl_printf(JL_STDERR, "\n");
+            jl_printf(JL_STDERR, "svec_len(method_match): %d\n", jl_svec_len(method_match));
+            //jl_value_t *tt = jl_svecref(method_match, 0);  // unused, already have `types`.
+            jl_svec_t *spvals = (jl_svec_t*)jl_svecref(method_match, 1);
+            jl_printf(JL_STDERR, "spvals: "); jl_static_show(JL_STDERR, (jl_value_t*)spvals); jl_printf(JL_STDERR, "\n");
+            jl_method_t *method = (jl_method_t*)jl_svecref(method_match, 2);
+            jl_printf(JL_STDERR, "method: "); jl_static_show(JL_STDERR, (jl_value_t*)method); jl_printf(JL_STDERR, "\n");
 
+            // now we have found the matching definition.
+            // next look for or create a specialization of this definition.
+            jl_method_instance_t *edge = jl_specializations_get_linfo(method, (jl_value_t*)types, spvals);
+            jl_printf(JL_STDERR, "edge: "); jl_static_show(JL_STDERR, (jl_value_t*)edge); jl_printf(JL_STDERR, "\n");
 
-        // Now create the edges array and set the edge!
-        jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
-        if (func->edges == jl_nothing) {
-          // TODO: How to construct this array type properly
-          jl_value_t* array_mi_type = jl_apply_type2((jl_value_t*)jl_array_type,
-                                                     (jl_value_t*)jl_method_instance_type, jl_box_long(1));
+            if (edge != NULL && (jl_value_t*)edge != jl_nothing) {
+                // Now create the edges array and set the edge!
+                jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
+                if (func->edges == jl_nothing) {
+                  // TODO: How to construct this array type properly
+                  jl_value_t* array_mi_type = jl_apply_type2((jl_value_t*)jl_array_type,
+                                                             (jl_value_t*)jl_method_instance_type, jl_box_long(1));
 
-          //jl_static_show(JL_STDERR, array_mi_type);
-          func->edges = (jl_value_t*)jl_alloc_array_1d(array_mi_type, 0);
+                  //jl_static_show(JL_STDERR, array_mi_type);
+                  func->edges = (jl_value_t*)jl_alloc_array_1d(array_mi_type, 0);
+                }
+
+                //jl_method_instance_add_backedge(edge, linfo);
+                jl_array_ptr_1d_push((jl_array_t*)func->edges, (jl_value_t*)edge);
+                jl_printf(JL_STDERR, "\nedges: "); jl_static_show(JL_STDERR, (jl_value_t*)func->edges); jl_printf(JL_STDERR, "\n");
+            }
         }
-        //jl_static_show(JL_STDERR, (jl_value_t*)func->edges);
-
-        //jl_method_instance_add_backedge(edge, linfo);
-        jl_array_ptr_1d_push((jl_array_t*)func->edges, (jl_value_t*)edge);
-        //jl_static_show(JL_STDERR, (jl_value_t*)func->edges);
 
         ptls->in_pure_callback = last_in;
         jl_lineno = last_lineno;

--- a/src/method.c
+++ b/src/method.c
@@ -438,19 +438,19 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         // Apparently the backedge needs to be from `##s4#3(typeof(func), Type)` instead of
         // the actual types of the aruments! Who knows why!! Weirdness.
         // Manually construct that weird signature, here:
-        jl_printf(JL_STDERR, "\nttdt: ");
-        jl_static_show(JL_STDERR, (jl_value_t*)ttdt);
-        jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "\nttdt: ");
+        //jl_static_show(JL_STDERR, (jl_value_t*)ttdt);
+        //jl_printf(JL_STDERR, "\n");
         ssize_t numargs = jl_svec_len(ttdt->parameters);  // TODO: is there a better way to get the length of a Tuple?
         jl_value_t* weird_types_tuple = jl_tupletype_fill(numargs, (jl_value_t*)jl_any_type);
-        jl_printf(JL_STDERR, "\nWeird Tuple types: ");
-        jl_static_show(JL_STDERR, (jl_value_t*)weird_types_tuple);
-        jl_printf(JL_STDERR, "\n");
+        //jl_printf(JL_STDERR, "\nWeird Tuple types: ");
+        //jl_static_show(JL_STDERR, (jl_value_t*)weird_types_tuple);
+        //jl_printf(JL_STDERR, "\n");
         // One would expect to be able to just use `tt` here, but we have to use the weird
         // thing instead.
         //jl_value_t* types = jl_argtype_with_function(gen_func, tt);
         jl_value_t* types = jl_argtype_with_function(gen_func, weird_types_tuple);
-        jl_static_show(JL_STDERR, (jl_value_t*)types);
+        //jl_static_show(JL_STDERR, (jl_value_t*)types);
 
         jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_gf_invoke_lookup(types, -1);
         JL_GC_POP();
@@ -464,7 +464,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         // now we have found the matching definition.
         // next look for or create a specialization of this definition.
         jl_method_t *method = entry->func.method;
-        jl_static_show(JL_STDERR, (jl_value_t*)method);
+        //jl_static_show(JL_STDERR, (jl_value_t*)method);
 
         jl_method_instance_t *edge = jl_specializations_get_linfo(method, types, linfo->sparam_vals);
         //jl_printf(JL_STDERR, "\nNATHAN: edge: %p\n", edge);

--- a/test/method.jl
+++ b/test/method.jl
@@ -1,0 +1,68 @@
+using Test
+
+@testset "Normal generated functions" begin
+    @generated g1(x) = :(x)
+    @test g1(1) == 1
+    @test g1("hi") == "hi"
+end
+
+# Invalidating Generated Functions
+# TODO: For some reason this doesn't work inside a testset right now (See below)
+@generated foo() = bar()
+bar() = 2
+# We can still call foo() even though bar() was defined after! Hooray! :)
+@test foo() == 2
+# Now we can change bar(), and foo() is also updated! Woohoo! :D
+bar() = 3
+@test foo() == 3
+
+
+@testset "invalidating generated functions in a testset" begin
+    @generated foo() = bar()
+    bar() = 2
+
+    # TODO: It seems like this doesn't work becuase of the @testset. Is that expected?
+    # Would this work for regular functions? I think it's broken...
+    @test foo() == 2
+    bar() = 3
+    @test_broken foo() == 3
+end
+
+
+# Functions that take arguments
+@generated f(x) = f2(x) + f2(x)
+f2(x::Type) = sizeof(x)
+@test f(1) == 16
+f2(x::Type) = sizeof(x)÷2
+@test f(1) == 8
+
+
+# Method at bottom of call-stack accepts ::Type, not ::Any
+# The simple case -- bar(::Any):
+@generated foo(x) = bar(x)
+bar(x) = 2
+@test foo(1) == 2
+bar(x) = 3
+@test foo(1) == 3
+# TODO: This doesn't work for some reason
+# The complex case -- bar(::Type):
+@generated f_type(x) = t1(x)
+t1(::Type{Int}) = 2
+@test f_type(1) == 2
+t(::Type) = 3
+@test_broken f_type(1) == 3
+
+
+## Functions with type params
+#@generated f(x::T) where T<:Number = biggest(T)
+#biggest(::Type{T}) where T = typemax(T)
+#f(10)
+## It also works for newly defined types
+#struct MyNum <: Number x::Int end
+#Base.typemax(::Type{MyNum}) = MyNum(typemax(Int))
+#f(MyNum(10))
+## And still allows users to interactively change their mind about these definitions
+#Base.typemax(::Type{MyNum}) = MyNum(100)
+#biggest(::Type{MyNum}) = MyNum(100)
+#f(MyNum(10))
+#

--- a/test/method.jl
+++ b/test/method.jl
@@ -59,16 +59,16 @@ t1(T) = 3
 @test_broken f_type2(1) == 3
 
 
-## Functions with type params
-#@generated f(x::T) where T<:Number = biggest(T)
-#biggest(::Type{T}) where T = typemax(T)
-#f(10)
-## It also works for newly defined types
-#struct MyNum <: Number x::Int end
-#Base.typemax(::Type{MyNum}) = MyNum(typemax(Int))
-#f(MyNum(10))
-## And still allows users to interactively change their mind about these definitions
-#Base.typemax(::Type{MyNum}) = MyNum(100)
-#biggest(::Type{MyNum}) = MyNum(100)
-#f(MyNum(10))
-#
+# Functions with type params
+@generated f(x::T) where T<:Number = width(T)
+width(::Type{Int}) where T = 5
+@test f(10) == 5
+width(::Type{Int}) where T = 100
+@test f(10) == 100
+
+# It also works for newly defined types
+struct MyNum <: Number x::Int end
+width(::Type{MyNum}) where T = MyNum(5)
+@test f(MyNum(10)) == MyNum(5)
+width(::Type{MyNum}) where T = MyNum(100)
+@test f(MyNum(10)) == MyNum(100)

--- a/test/method.jl
+++ b/test/method.jl
@@ -44,13 +44,19 @@ bar(x) = 2
 @test foo(1) == 2
 bar(x) = 3
 @test foo(1) == 3
-# TODO: This doesn't work for some reason
-# The complex case -- bar(::Type):
-@generated f_type(x) = t1(x)
-t1(::Type{Int}) = 2
+# This also works, with t(::Type{Int})
+@generated f_type(x) = t(x)
+t(::Type{Int}) = 2
 @test f_type(1) == 2
 t(::Type{Int}) = 3
-@test_broken f_type(1) == 3
+@test f_type(1) == 3
+# Yet for some reason this does not work:
+# Somehow having t1(T) call typemax prevents forming a backedge from t1 to the generator.
+@generated f_type2(x) = t1(x)
+t1(T) = typemax(T)
+@test f_type2(1) == typemax(Int)
+t1(T) = 3
+@test_broken f_type2(1) == 3
 
 
 ## Functions with type params

--- a/test/method.jl
+++ b/test/method.jl
@@ -49,7 +49,7 @@ bar(x) = 3
 @generated f_type(x) = t1(x)
 t1(::Type{Int}) = 2
 @test f_type(1) == 2
-t(::Type) = 3
+t(::Type{Int}) = 3
 @test_broken f_type(1) == 3
 
 

--- a/test/method.jl
+++ b/test/method.jl
@@ -21,7 +21,7 @@ bar() = 3
     @generated foo() = bar()
     bar() = 2
 
-    # TODO: It seems like this doesn't work becuase of the @testset. Is that expected?
+    # TODO: It seems like this doesn't work because of the @testset. Is that expected?
     # Would this work for regular functions? I think it's broken...
     @test foo() == 2
     bar() = 3
@@ -72,3 +72,12 @@ width(::Type{MyNum}) where T = MyNum(5)
 @test f(MyNum(10)) == MyNum(5)
 width(::Type{MyNum}) where T = MyNum(100)
 @test f(MyNum(10)) == MyNum(100)
+
+
+# Functions with varargs
+@generated f(a::T, b, c...) where T<:Number = bar(T) + bar(a) + bar(b) + sum(bar(v) for v in c)
+bar(x) = 2
+@test f(2,3,4) == 8
+bar(x) = 3
+@test f(2,3,4) == 12
+@test f(2,3,4,5) == 15


### PR DESCRIPTION
# WIP: Generated function recompilation with edges

This PR changes the implementation of Generated Functions to always set a backedge from the generator to the staged function itself, so that if the body of the generator is invalidated, the generated function is recompiled. This allows us to stop freezing the world-age on generated function bodies, which -- among other things -- allows generated functions to be used for computing _values_, as part of generic interfaces.

In particular, the aim of this PR is to enable us to remove [this restriction](https://docs.julialang.org/en/v1.1.1/manual/metaprogramming/#Generated-functions-1) from Generated Functions:
> 3. Instead of calculating something or performing some action, you return a quoted expression which, when evaluated, does what you want.

An example using julia built from this PR:
```julia
julia> @generated function zero_tuple(::Type{T}) where T<:Tuple
           Tuple(zero(t) for t in fieldtypes(T))
       end
zero_tuple (generic function with 1 method)

julia> @code_typed zero_tuple(Tuple{Int, Float32})
CodeInfo(
1 ─     return (0, 0.0f0)
) => Tuple{Int64,Float32}

julia> using FixedPointDecimals

julia> @code_typed zero_tuple(Tuple{Int, Float32, FixedDecimal{Int,2}})
CodeInfo(
1 ─     return (0, 0.0f0, FixedDecimal{Int64,2}(0.00))
) => Tuple{Int64,Float32,FixedDecimal{Int64,2}}
```

From what I understand, there were a lot of changes implemented in the compiler to fix the #265-style issues that plagued Cassette, culminating here: https://github.com/JuliaLang/julia/pull/32237.

My understanding is that the work done to fix #265 for julia at large was not able to extend to generated functions for a number of reasons, but that the huge amount of work done for Cassette, above, has largely alleviated those problems. I understand that #32237 now allows generated functions to set forward edges for methods that should trigger recompilation of the generated function if they are invalidated. This mechanism is opt-in, and was not applied to all generated functions by default.

In this PR, we simply use that mechanism to set a backedge from the `generator` function body to the staged function itself, so that if the generator is invalidated (because any functions _it_ calls are invalidated), then the generated function will be re-generated the next time it's called.


This recompilation means that generated functions can participate in the same recompilation process as normal Julia functions, and therefor no longer need to have their world-age frozen. Lifting this restriction gives us these benefits:
1. Generated functions can safely be used to stage the computation of _values_, because the values will be re-computed if their dependent computations change, so there shouldn't be surpising/mismatched results.
2. Generated functions can call functions whose method-tables might be updated by users, allowing them to be part of generic interfaces, and perform reflection/inspection on user-defined types.
3. Generated functions will behave the same at the REPL as they do inside precompiled packages, eliminating this confusing behavior.
4. Interactive programming w/ generated functions becomes much easier, allowing you to experiment with generated functions at the REPL the same as you would with other functions.

_Together, the first two benefits allows us to stage computation of values that depends on user-defined computations over user-defined types._ There is currently no good way to express such computations, such that they are _safe_ and _guaranteed to compute at compile-time_.

----------------------------------

This PR is still WIP. I would not be surprised if there are still some lingering roadblocks that make this more challenging than just slapping a backedge onto the generated functions. But the benefits of this PR would be very substantial, and would lead to significantly simpler, and easier to reason about, code. So I think it's worth working through those issues to get this right! :)

---------------------------------

#### ¿¿Stretch goals??:
1. ??? With this well-defined recompilation behavior, maybe we can remove the mystery around whether generated functions can "be recompiled arbitrarily often", and provide stronger guarantees about that performance?
2. ??? Maybe this improvement/extension can be applied to `@pure` functions as well, so that users can write code that is intended to execute at compiletime, without the overhead of generating entire methodinstances just to make the result of a computation available to the compiler.

----------------
## Motivating Examples

I discussed a number of examples for which the existing mechanisms for controlling compiletime execution are not sufficiently satisfying in my talk at JuliaCon 2019. You can reference those here:
https://github.com/NHDaly/juliaCon2019-If_Runtime_isn-t_Funtime-Slides

A number of those examples would be greatly simplified or solved by this PR. Here are a couple of them reiterated:

### Calculating "magic numbers"
```julia
coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
```
After this PR, this could be written as
```julia
@generated coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
```
And if we were able to apply this same extension to `@pure` functions (see **stretch goals** above), this could become:
```julia
@pure coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
```
I used the coefficient example because it's simple yet it doesn't const-fold. But a bigger issue is this function, which is quite complex, and once could really never expect it to constfold:
https://github.com/JuliaMath/FixedPointDecimals.jl/blob/v0.3.0/src/FixedPointDecimals.jl#L465

Or, dearer to my heart, this example, which we want to add as part of https://github.com/JuliaMath/FixedPointDecimals.jl/pull/45, where we want to precompute `2^64/10^f` so that we can replace `÷ 100` with `* 184467440737095516 << 64`, which computes the same value but much more cheaply:
https://github.com/JuliaMath/FixedPointDecimals.jl/blob/026513ffb3a09e7b1e4943a3c15ffec8e3181b42/src/fldmod_by_const.jl#L126

### Error-checking of types and compiler constants
The error-checking computation in this function only refers to compiler constants and types, but there is no safe way to stage that computation such that it occurs only at compiletime:
https://github.com/JuliaMath/FixedPointDecimals.jl/blob/07d24d994d67a6f0980ad127898f89c2b4767283/src/FixedPointDecimals.jl#L84-L98


