### PR TITLE
allow CodeInfo edges to be attached to MethodTable

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -176,29 +176,26 @@ function store_backedges(frame::InferenceState)
     if !toplevel && (frame.cached || frame.parent !== nothing)
         caller = frame.result.linfo
         for edges in frame.stmt_edges
-            edges === nothing && continue
-            i = 1
-            while i <= length(edges)
-                to = edges[i]
-                if isa(to, MethodInstance)
-                    ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any), to, caller)
-                    i += 1
-                else
-                    typeassert(to, Core.MethodTable)
-                    typ = edges[i + 1]
-                    ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any, Any), to, typ, caller)
-                    i += 2
-                end
-            end
+            store_backedges(caller, edges)
         end
-        edges = frame.src.edges
-        if edges !== nothing
-            edges = edges::Vector{MethodInstance}
-            for edge in edges
-                @assert isa(edge, MethodInstance)
-                ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any), edge, caller)
-            end
-            frame.src.edges = nothing
+        store_backedges(caller, frame.src.edges)
+        frame.src.edges = nothing
+    end
+end
+
+store_backedges(caller, edges::Nothing) = nothing
+function store_backedges(caller, edges::Vector)
+    i = 1
+    while i <= length(edges)
+        to = edges[i]
+        if isa(to, MethodInstance)
+            ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any), to, caller)
+            i += 1
+        else
+            typeassert(to, Core.MethodTable)
+            typ = edges[i + 1]
+            ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any, Any), to, typ, caller)
+            i += 2
         end
     end
 end


### PR DESCRIPTION
This exacts just the part that is apparently technically feasible from, #32732 
re:  https://github.com/JuliaLang/julia/pull/32732#issuecomment-517827997
@vtjnash 

> Can you make the "edges connectable to MethodTables" parts a separate PR? I see no issues with that aspect.

This is a minor extension of #32237 (in particular addressing this [comment](https://github.com/JuliaLang/julia/pull/32237/files#r290056685))