### PR TITLE
Disable all git EOL conversions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# treat patches as files that should not be modified
-*.patch -text
+# treat all files as files that should not be modified
+* -text


### PR DESCRIPTION
This replaces https://github.com/JuliaLang/julia/pull/27291, or rather is a second attempt to achieve the same thing. https://github.com/JuliaLang/julia/pull/27291 was reverted because it only worked with git >=2.10 and that was deemed unacceptable.

I think this PR here should also work with older git versions, but I'm not 100% positive.

I think if this was merged it should happen sometime early in a release cycle. If this PR does not work for some reason, it would probably be fairly disruptive, so better to try it early in a cycle rather than just before a release. So now might be a good time :)

CCing @vtjnash, @ararslan.