### PR TITLE
Update col index to `j` in sparse docs

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -463,7 +463,7 @@ checks and is only meant to improve readability of the call.
     ```julia
     str1 = "foo"
     str2 = "bar"
-    ccall(:test, Void, (Ptr{UInt8}, Ptr{UInt8}, Csize_t, Csize_t),
+    ccall(:test, Cvoid, (Ptr{UInt8}, Ptr{UInt8}, Csize_t, Csize_t),
                         str1, str2, sizeof(str1), sizeof(str2))
     ```
 

--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -20,7 +20,7 @@ row indices. The internal representation of `SparseMatrixCSC` is as follows:
 struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows
     n::Int                  # Number of columns
-    colptr::Vector{Ti}      # Column i is in colptr[i]:(colptr[i+1]-1)
+    colptr::Vector{Ti}      # Column j is in colptr[j]:(colptr[j+1]-1)
     rowval::Vector{Ti}      # Row indices of stored values
     nzval::Vector{Tv}       # Stored values, typically nonzeros
 end

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -176,10 +176,10 @@ column. In conjunction with [`nonzeros`](@ref) and
     rows = rowvals(A)
     vals = nonzeros(A)
     m, n = size(A)
-    for i = 1:n
-       for j in nzrange(A, i)
-          row = rows[j]
-          val = vals[j]
+    for j = 1:n
+       for i in nzrange(A, j)
+          row = rows[i]
+          val = vals[i]
           # perform sparse wizardry...
        end
     end


### PR DESCRIPTION
@ViralBShah , I'm afraid that I deleted #32769 since it was so nitpicky, but here are the changes again.

The example of how to use `nzrange` to iterate through a sparse matrix had the same `i`/`j` index swap, so I updated it as well.

