### PR TITLE
fix #32777, regression in type intersection of unions

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2026,14 +2026,8 @@ static jl_value_t *intersect_union(jl_value_t *x, jl_uniontype_t *u, jl_stenv_t 
         jl_value_t *a=NULL, *b=NULL;
         JL_GC_PUSH2(&a, &b);
         jl_unionstate_t oldRunions = e->Runions;
-        if (param == 2) {
-            a = R ? intersect(x, u->a, e, param) : intersect(u->a, x, e, param);
-            b = R ? intersect(x, u->b, e, param) : intersect(u->b, x, e, param);
-        }
-        else {
-            a = R ? intersect_all(x, u->a, e) : intersect_all(u->a, x, e);
-            b = R ? intersect_all(x, u->b, e) : intersect_all(u->b, x, e);
-        }
+        a = R ? intersect_all(x, u->a, e) : intersect_all(u->a, x, e);
+        b = R ? intersect_all(x, u->b, e) : intersect_all(u->b, x, e);
         e->Runions = oldRunions;
         jl_value_t *i = simple_join(a,b);
         JL_GC_POP();

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -16,6 +16,7 @@ end
     @test convert(Union{Int, Missing}, 1.0) === 1
     @test convert(Union{Nothing, Missing}, missing) === missing
     @test convert(Union{Nothing, Missing}, nothing) === nothing
+    @test convert(Union{Missing, Nothing, Float64}, 1) === 1.0
 
     @test_throws MethodError convert(Missing, 1)
     @test_throws MethodError convert(Union{Nothing, Missing}, 1)
@@ -241,6 +242,14 @@ end
     @test isa(x, Vector{Union{Int, Missing}})
     @test isequal(x, [missing])
     @test eltype(adjoint([1, missing])) == Union{Int, Missing}
+    # issue #32777
+    let a = [0, nothing, 0.0, missing]
+        @test a[1] === 0.0
+        @test a[2] === nothing
+        @test a[3] === 0.0
+        @test a[4] === missing
+        @test a isa Vector{Union{Missing, Nothing, Float64}}
+    end
 end
 
 @testset "== and != on arrays" begin

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1415,6 +1415,13 @@ end
 @testintersect(Union{Array{T,1},Array{T,2}} where T<:Union{Float32,Float64},
                Union{AbstractMatrix{Float32},AbstractVector{Float32}},
                Union{Array{Float32,2}, Array{Float32,1}})
+let A = Tuple{Type{Union{Missing,T}},Any} where T,
+    B = Tuple{Type{Union{Nothing,T}},Any} where T
+    I = typeintersect(A, B)
+    J = typeintersect(B, A)
+    @test I >: Tuple{Type{Union{Nothing,Missing,T}}, Any} where T
+    @test J >: Tuple{Type{Union{Nothing,Missing,T}}, Any} where T
+end
 
 # issue #29955
 struct M29955{T, TV<:AbstractVector{T}}


### PR DESCRIPTION
Fortunately, #32771 allows reverting the offending change. It seems to be a better fix to both problems.

fix #32777