### PR TITLE
Very WIP: [wasm] Bidirectional Julia/JS object access

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -196,6 +196,8 @@ include(string((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "version_git.jl")) # 
 include("osutils.jl")
 include("c.jl")
 
+Sys.isjsvm() && include("jsobject.jl")
+
 # Core I/O
 include("io.jl")
 include("iostream.jl")

--- a/base/jsobject.jl
+++ b/base/jsobject.jl
@@ -1,0 +1,74 @@
+module JS
+
+using .Base.Meta
+import .Base: convert
+
+export @jscall
+
+abstract type JSBoxed end
+primitive type JSObject <: JSBoxed 32 end
+primitive type JSString <: JSBoxed 32 end
+primitive type JSSymbol <: JSBoxed 32 end
+struct JSUndefined; end
+struct JSNull; end
+
+const JSNumber = Float64
+
+const undefined = JSUndefined.instance
+const null = JSNull.instance
+
+const JSAny = Union{JSBoxed, Float64, JSUndefined, JSNull}
+
+macro jscall(expr)
+    isexpr(expr, :call) || error("@jscall argument must be a call")
+    target_expr = expr.args[1]
+    if isa(target_expr, Symbol)
+        target = QuoteNode(target_expr)
+    else
+        if !isexpr(target_expr, :(.)) ||
+           !isa(target_expr.args[1], Symbol) ||
+           !(isa(target_expr.args[2], QuoteNode) &&
+             isa(target_expr.args[2].value, Symbol))
+            error("Unsupported call target `$(target_expr)`")
+        end
+        target = (target_expr.args[1], target_expr.args[2].value)
+    end
+    b = Expr(:block)
+    converted_args = Symbol[]
+    for a in expr.args[2:end]
+        x = gensym()
+        push!(b.args, :($x = jsconvert($(esc(a)))))
+        push!(converted_args, x)
+    end
+    atypes = [JSAny for _ in converted_args]
+    quote
+        $b
+        $(Expr(:foreigncall, target, JSAny, Core.svec(atypes...), QuoteNode(:jscall),
+            length(atypes), converted_args...))
+    end
+end
+
+jsconvert(x) = convert(JSAny, x)
+
+function getproperty(this::JSObject, sym::Symbol)
+    @jscall Reflect.get(this, sym)
+end
+
+function setproperty!(this::JSObject, sym::Symbol, val)
+    @jscall Reflect.set(this, sym, val)
+end
+
+# Yes, we're converting a pointer to Float64 here, but at least in
+# compiled code, we basically expect the compiler on both sides to
+# undo this conversion.
+jsconvert(x::Ptr) = convert(JSNumber, convert(Int32, x))
+jsconvert(x::AbstractString) = convert(JSString, x)
+
+function convert(::Type{JSString}, x::String)
+    @GC.preserve x begin
+        ptr = pointer(x)
+        @jscall UTF8ToString(ptr)
+    end
+end
+
+end

--- a/base/jsobject.jl
+++ b/base/jsobject.jl
@@ -61,7 +61,7 @@ end
 # Yes, we're converting a pointer to Float64 here, but at least in
 # compiled code, we basically expect the compiler on both sides to
 # undo this conversion.
-jsconvert(x::Ptr) = convert(JSNumber, convert(Int32, x))
+jsconvert(x::Ptr) = convert(JSNumber, convert(UInt32, x))
 jsconvert(x::AbstractString) = convert(JSString, x)
 
 function convert(::Type{JSString}, x::String)

--- a/base/jsobject.jl
+++ b/base/jsobject.jl
@@ -31,7 +31,7 @@ macro jscall(expr)
              isa(target_expr.args[2].value, Symbol))
             error("Unsupported call target `$(target_expr)`")
         end
-        target = (target_expr.args[1], target_expr.args[2].value)
+        target = (target_expr.args[2].value, target_expr.args[1])
     end
     b = Expr(:block)
     converted_args = Symbol[]

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -80,6 +80,9 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_datatype_t *t = (jl_datatype_t*)jl_gc_alloc(ptls, sizeof(jl_datatype_t), jl_datatype_type);
+    // We require 16 byte alignment for datatypes, since we are using the low
+    // bits of pointers to them for GC bits.
+    // assert( ((uintptr_t)t & ~(uintptr_t)15) == 0 );
     t->hasfreetypevars = 0;
     t->isdispatchtuple = 0;
     t->isbitstype = 0;

--- a/src/gc.c
+++ b/src/gc.c
@@ -921,7 +921,7 @@ static bigval_t **sweep_big_list(int sweep_full, bigval_t **pv) JL_NOTSAFEPOINT
         bigval_t *nxt = v->next;
         int bits = v->bits.gc;
         int old_bits = bits;
-        if (gc_marked(bits)) {
+        if (gc_alive(v->bits)) {
             pv = &v->next;
             int age = v->age;
             if (age >= PROMOTE_AGE || bits == GC_OLD_MARKED) {
@@ -1069,8 +1069,8 @@ static void sweep_malloced_arrays(void) JL_NOTSAFEPOINT
         mallocarray_t **pma = &ptls2->heap.mallocarrays;
         while (ma != NULL) {
             mallocarray_t *nxt = ma->next;
-            int bits = jl_astaggedvalue(ma->a)->bits.gc;
-            if (gc_marked(bits)) {
+            struct _jl_taggedvalue_bits bits = jl_astaggedvalue(ma->a)->bits;
+            if (gc_alive(bits)) {
                 pma = &ma->next;
             }
             else {
@@ -1080,7 +1080,7 @@ static void sweep_malloced_arrays(void) JL_NOTSAFEPOINT
                 ma->next = ptls2->heap.mafreelist;
                 ptls2->heap.mafreelist = ma;
             }
-            gc_time_count_mallocd_array(bits);
+            gc_time_count_mallocd_array(bits.gc);
             ma = nxt;
         }
     }
@@ -1263,7 +1263,7 @@ static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_t
         uint8_t msk = 1; // mask for the age bit in the current age byte
         while ((char*)v <= lim) {
             int bits = v->bits.gc;
-            if (!gc_marked(bits)) {
+            if (!gc_alive(v->bits)) {
                 *pfl = v;
                 pfl = &v->next;
                 pfl_begin = pfl_begin ? pfl_begin : pfl;

--- a/src/gc.h
+++ b/src/gc.h
@@ -232,9 +232,7 @@ JL_EXTENSION typedef struct _bigval_t {
     //struct jl_taggedvalue_t <>;
     union {
         uintptr_t header;
-        struct {
-            uintptr_t gc:2;
-        } bits;
+        struct _jl_taggedvalue_bits bits;
     };
     // must be 64-byte aligned here, in 32 & 64 bit modes
 } bigval_t;
@@ -399,6 +397,11 @@ STATIC_INLINE jl_taggedvalue_t *page_pfl_end(jl_gc_pagemeta_t *p) JL_NOTSAFEPOIN
 STATIC_INLINE int gc_marked(uintptr_t bits) JL_NOTSAFEPOINT
 {
     return (bits & GC_MARKED) != 0;
+}
+
+STATIC_INLINE int gc_alive(struct _jl_taggedvalue_bits bits) JL_NOTSAFEPOINT
+{
+    return gc_marked(bits.gc) || bits.gc_held;
 }
 
 STATIC_INLINE int gc_old(uintptr_t bits) JL_NOTSAFEPOINT

--- a/src/jsvm-emscripten/boxed.js
+++ b/src/jsvm-emscripten/boxed.js
@@ -68,8 +68,12 @@ Module.initialize_jscall_runtime = function() {
     Module["_free"](name_buf);
 }
 
+function jl_typeof(arg_ptr) {
+    return HEAP32[(arg_ptr >> 2) - 1] & 0xfffffffb;
+}
+
 function jlboxed_to_js(arg_ptr) {
-    arg_type = HEAP32[(arg_ptr >> 2) - 1];
+    arg_type = jl_typeof(arg_ptr)
     if (arg_type == jl_float64_type) {
         return HEAPF64[arg_ptr >> 3];
     } else if (arg_type == jl_jsundefined_type) {

--- a/src/jsvm-emscripten/boxed.js
+++ b/src/jsvm-emscripten/boxed.js
@@ -1,0 +1,172 @@
+var julia_boxed_heap = {
+    table: new WebAssembly.Table({initial: 4096, element: "anyref"}),
+    allocated: new WeakMap(),
+    freelist: -1,
+    max_allocated: 0,
+    proxies: new Map()
+};
+
+function allocate_index() {
+    if (julia_boxed_heap.freelist != -1) {
+        var idx = julia_boxed_heap.freelist;
+        julia_boxed_heap.freelist = julia_boxed_heap.table[idx];
+        return idx;
+    } else if (julia_boxed_heap.max_allocated < julia_boxed_heap.table.length) {
+        julia_boxed_heap.max_allocated += 1;
+        return julia_boxed_heap.max_allocated;
+    }
+    julia_boxed_heap.table.grow(julia_boxed_heap.table.length + 4096);
+    julia_boxed_heap.max_allocated += 1;
+    return julia_boxed_heap.max_allocated;
+}
+
+function box_jsval(val) {
+    var idx = julia_boxed_heap.allocated[val];
+    if (idx !== undefined)
+        return idx;
+    var idx = allocate_index();
+    julia_boxed_heap.table.set(idx, val);
+    julia_boxed_heap.allocated[val] = idx;
+    return idx;
+}
+
+function get_boxed_jsval(idx) {
+    return julia_boxed_heap.table.get(idx);
+}
+
+var jl_float64_type;
+var jl_jsundefined_type; var jl_jsundefined;
+var jl_bool_type; var jl_true; var jl_false;
+var jl_jsnull_type; var jl_jsnull;
+var jl_jsobject_type;
+var jl_jsstring_type;
+var jl_jssymbol_type;
+
+Module.initialize_jscall_runtime = function() {
+    // TODO: Should this be base?
+    let main_module = Module['_jl_get_main_module']()
+    let name_buf = Module['_malloc'](1024)
+    function jl_get_global(the_module, name) {
+        stringToUTF8(name, name_buf, 1024);
+        let sym = Module['_jl_symbol'](name_buf);
+        return Module['_jl_get_global'](the_module, sym);
+    }
+    jl_float64_type = jl_get_global(main_module, "Float64")
+    jl_bool_type = jl_get_global(main_module, "Bool")
+    jl_true = jl_get_global(main_module, "true")
+    jl_false = jl_get_global(main_module, "false")
+
+    let js_module = jl_get_global(main_module, "JS");
+    assert(js_module != 0);
+    jl_jsundefined_type = jl_get_global(js_module, "JSUndefined")
+    jl_jsundefined = jl_get_global(js_module, "undefined")
+    jl_jsnull_type = jl_get_global(js_module, "JSNull")
+    jl_jsnull = jl_get_global(js_module, "null")
+    jl_jsobject_type = jl_get_global(js_module, "JSObject")
+    jl_jsstring_type = jl_get_global(js_module, "JSString")
+    jl_jssymbol_type = jl_get_global(js_module, "JSSymbol")
+    Module["_free"](name_buf);
+}
+
+function jlboxed_to_js(arg_ptr) {
+    arg_type = HEAP32[(arg_ptr >> 2) - 1];
+    if (arg_type == jl_float64_type) {
+        return HEAPF64[arg_ptr >> 3];
+    } else if (arg_type == jl_jsundefined_type) {
+        return undefined;
+    } else if (arg_type == jl_jsnull_type) {
+        return null;
+    } else if (arg_type == jl_bool_type) {
+        return arg_ptr == jl_true ? true : false;
+    } else {
+        assert(arg_type == jl_jsobject_type ||
+                arg_type == jl_jsstring_type ||
+                arg_type == jl_jssymbol_type);
+        obj_idx = HEAP32[arg_ptr >> 2];
+        return get_boxed_jsval(obj_idx);
+    }
+}
+
+var JLProxy = {
+    isExtensible: function() { return false; },
+    isJlProxy: function (jsobj) {
+        return jsobj['$$'] !== undefined && jsobj['$$']['type'] === 'JLProxy';
+    },
+    has: function(jsobj, key) {
+        return false;
+    },
+    getPtr: function(jsobj) {
+        return jsobj['$$']['ptr'];
+    }
+}
+
+const JL_GC_HELD = 0x4
+function mark(ptr) {
+    HEAP32[(ptr >> 2) - 1] |= 0x4
+}
+
+function unmark(ptr) {
+    HEAP32[(ptr >> 2) - 1] &= 0xfffffffb
+}
+
+var JLFinalize;
+if (typeof FinalizationGroup !== 'undefined') {
+    function free_jl_proxy(ptrs) {
+        for (const ptr of ptrs) {
+            unmark(ptr)
+            julia_boxed_heap.delete(ptr)
+        }
+    }
+    JLFinalize = new FinalizationGroup(free_jl_proxy);
+}
+
+function makeProxy(ptr) {
+    var proxy = julia_boxed_heap.proxies[ptr];
+    if (proxy !== undefined) {
+        if (JLFinalize !== undefined) {
+            proxy = proxy.get();
+            if (proxy !== null) {
+                return proxy;
+            }
+        } else {
+            return proxy;
+        }
+    }
+    var target = function(){};
+    target['$$'] = { ptr : ptr, type : 'JLProxy' };
+    proxy = new Proxy(target, JLProxy);
+    if (JLFinalize !== undefined) {
+        JLFinalize.register(proxy, ptr);
+        julia_boxed_heap.proxies[ptr] = new WeakRef(proxy);
+    } else {
+        julia_boxed_heap.proxies[ptr] = proxy;
+    }
+    mark(ptr);
+    return proxy;
+}
+
+function js_to_jlboxed(val) {
+    if (typeof val == 'number') {
+        return Module['jl_box_float64'](val);
+    } else if (typeof val == 'undefined') {
+        return jl_jsundefined;
+    } else if (typeof val == 'object' && val === null) {
+        return jl_jsnull;
+    } else if (typeof val == 'boolean') {
+        return val ? jl_true : jl_false;
+    } else if (JLProxy.isJlProxy(val)) {
+        return JLProxy.getPtr(val);
+    } else {
+        assert (typeof val == 'string' ||
+                typeof val == 'symbol' ||
+                typeof val == 'object');
+        let idx = box_jsval(val);
+        let ptls = Module['_jl_get_ptls_states']()
+        let ptr = Module['_jl_gc_alloc'](ptls, 2,
+            typeof val == 'string' ? jl_jsstring_type :
+            typeof val == 'symbol' ? jl_jssymbol_type :
+                                     jl_jsobject_type);
+        HEAP32[ptr >> 2] = idx;
+        return ptr;
+    }
+}

--- a/src/jsvm-emscripten/jscall.js
+++ b/src/jsvm-emscripten/jscall.js
@@ -1,0 +1,20 @@
+mergeInto(LibraryManager.library, {
+  jl_do_jscall: function(libname, fname, args, nargs) {
+    var parent;
+    if (libname == 0) {
+        parent = self;
+    } else {
+        parent = window[UTF8ToString(libname)];
+    }
+    f = parent[UTF8ToString(fname)];
+    js_args = new Array(nargs);
+    for (var arg_idx = 0; arg_idx < nargs; arg_idx++) {
+      arg_ptr = HEAP32[args >> 2 + arg_idx];
+      js_args[arg_idx] = jlboxed_to_js(arg_ptr);
+    }
+    return js_to_jlboxed(Reflect.apply(f, undefined, js_args));
+  },
+  jl_init_jscall: function() {
+    initialize_runtime()
+  }
+});

--- a/src/jsvm-emscripten/jscall.js
+++ b/src/jsvm-emscripten/jscall.js
@@ -9,7 +9,7 @@ mergeInto(LibraryManager.library, {
     f = parent[UTF8ToString(fname)];
     js_args = new Array(nargs);
     for (var arg_idx = 0; arg_idx < nargs; arg_idx++) {
-      arg_ptr = HEAP32[args >> 2 + arg_idx];
+      arg_ptr = HEAP32[(args >> 2) + arg_idx];
       js_args[arg_idx] = jlboxed_to_js(arg_ptr);
     }
     return js_to_jlboxed(Reflect.apply(f, undefined, js_args));

--- a/src/julia.h
+++ b/src/julia.h
@@ -88,7 +88,8 @@ extern "C" {
 typedef struct _jl_value_t jl_value_t;
 
 struct _jl_taggedvalue_bits {
-    uintptr_t gc:2;
+    uintptr_t gc:2;         // GC marking bits
+    uintptr_t gc_held:1;    // GC held bit
 };
 
 JL_EXTENSION struct _jl_taggedvalue_t {
@@ -1396,6 +1397,7 @@ extern JL_DLLEXPORT jl_module_t *jl_main_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_core_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_base_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_top_module JL_GLOBALLY_ROOTED;
+JL_DLLEXPORT jl_module_t *jl_get_main_module();
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on);
 // get binding for reading

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -104,6 +104,7 @@ STATIC_INLINE uint32_t jl_int32hash_fast(uint32_t a)
 #define GC_MARKED 1 // reachable and young
 #define GC_OLD    2 // if it is reachable it will be marked as old
 #define GC_OLD_MARKED (GC_OLD | GC_MARKED) // reachable and old
+#define GC_HELD   3 // An external system is holding a reference - do not free
 
 // useful constants
 extern jl_methtable_t *jl_type_type_mt JL_GLOBALLY_ROOTED;

--- a/src/module.c
+++ b/src/module.c
@@ -16,6 +16,11 @@ jl_module_t *jl_core_module = NULL;
 jl_module_t *jl_base_module = NULL;
 jl_module_t *jl_top_module = NULL;
 
+JL_DLLEXPORT jl_module_t *jl_get_main_module()
+{
+    return jl_main_module;
+}
+
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 {
     jl_ptls_t ptls = jl_get_ptls_states();


### PR DESCRIPTION
This is a start at what I think is the last major feature on the wasm
porting punch list: sharing/accessing objects between Julia and the
native javascript environment. This PR currently contains a rough sketch
of the interpreter version of this integration, though we should of
course try to get the compiled version going as soon as possible, since
we now ship a compiled system image for the wasm target.

For the compiled version of this we'd like to use the reference-types
(https://github.com/WebAssembly/reference-types) wasm extension, which
is currently in development, so even the interpreter parts are written
with that extension in mind. In particular, we have a wasm table of
javascript objects that represents our (indexed) managed heap of
javascript objects. A boxed reference to javascript is then the julia
type tag, plus an index into this table (in compiled mode an unboxed
reference would just be a raw `anyref` without going through the table).
The reference-types proposal should have sufficient support that we
can emit boxing/unboxing performantly in wasm without going through
js helper function.

The julia GC is responsible for managing this table of javascript objects,
marking any JS objects that are reachable and sweeping the unreachable
ones by nulling out the references (this part isn't implemented yet).

On the julia side, we provide one julia type for every javascript builtin
type ('number' corresponds to Float64 and 'boolean' to Bool, but otherwise
the types are dedicated), with the non-singleton types being primitive
types of pointer size to store the index into the table of javascript
objects (at least semantically, as mentioned codegen will not use the
table if possible). There is a bit of logic in javascript to convert these
boxed representations on the julia heap into proper javascript objects,
but otherwise the julia code is responsible for conversions from Julia
objects to javascript objects (e.g. `String` to `JSString`,
or `Ptr` to `JSNumber` - i.e. Float64).

A `@jscall` macro is provided to call javascript functions from within
julia. Under the hood this lowers to an `Expr(:foreigncall, ...)` with
`jscall` calling convention for which we implement support in the
interpreter. I don't forsee any problems with codegen for this
representation, but that part is not implemented yet.

For the reverse (referencing julia objects from javascript), I mostly
followed what pyodide does and used a javascript `Proxy` object that
wraps a boxed julia pointer (set/getproperty aren't implemented yet,
but that should be straightforward). For GC integration, we make use
of the (experimental) [JavaScript WeakRef](https://github.com/tc39/proposal-weakrefs)
support, which essentially implements finalizers. On the julia side,
I stole one of the remaining GC bits (at least one of the bits
documented to be remaining - it looks like we don't overalign types
sufficiently for this to actually work at the moment) to mark an object
as being borrowed by the external VM and thus being protected from
collection even if there is no remaining julia references. The JS side
finalizer clears this bit on an object when there are no remaining
references on the JS side. As always with these kinds of systems,
reference cycles are not collected. I don't think there's much to be
done about that, until WebAssembly gets more native integration with
the JavaScript JC and we can re-use that for Julia objects.
It should be noted that the WeakRef proposal is curently behind a
flag in both Firefox and Chrome, but my understanding is that the
timeline for this fetaure is comparable to that of the reference types
proposal this builds on, so it should be ok to use (and I don't know
of any other mechanism to learn whether the JS side has been collected).

Remaining TODOs:
- [ ] Hook up get/setproperty on the JS side
- [ ] Julia GC marking/sweeping slots in the JS object table
- [ ] Finish GC_HELD implementation
- [ ] Convert arrays using typed views of the HEAP array 
- [ ] Codegen

For codegen, the major obstacle is lack of support in the toolchains
(llvm, emscripten). I'm thinking it should be possible to just represent
anyref as a non-integral pointer type in LLVM and get somewhere, but
plumbing everything through is still a decent amount of work, that I'm
unlikely to have the time for - I'm hoping somebody else will take that on.
Another problem we'll run into is that Asyncify will need an adjustment once
we start emitting code with anyrefs in them, since it can't just dump them on
the stack. 

Example: `@jscall alert("Hello World")` - note that the String needs to get converted to JS, which is implemented in julia, so this exercise a bunch of the object conversion logic also:

<img width="650" alt="Screen Shot 2019-08-05 at 12 57 11 AM" src="https://user-images.githubusercontent.com/1291671/62439955-01e0fc80-b71c-11e9-946a-65a870838a6a.png">

cc @SimonDanisch 
cc @mdboom, who may have some words of wisdom from the pyodide experience
cc @kripken as a heads up that we'll likely be interested in the combination of Asyncify and reference-types fairly soon