### PR TITLE
Add an assertion that DataTypes are allocated suitably aligned

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -80,6 +80,9 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_datatype_t *t = (jl_datatype_t*)jl_gc_alloc(ptls, sizeof(jl_datatype_t), jl_datatype_type);
+    // We require 16 byte alignment for datatypes, since we are using the low
+    // bits of pointers to them for GC bits.
+    assert( ((uintptr_t)t & (uintptr_t)15) == 0 );
     t->hasfreetypevars = 0;
     t->isdispatchtuple = 0;
     t->isbitstype = 0;


### PR DESCRIPTION
We rely on DataTypes being allocated aligned, such that we may steal
the low order bits for GC flags. However, this is sort of an implicit
assumption guaranteed by pool alignment. Make this assumption explicit
by adding an assert, such that somebody will notice when porting to new
platforms where this may not be true (yet - because the appropriate
support wasn't hooked up).