### PR TITLE
Use OpenLibm by default on armv7l

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -804,7 +804,6 @@ JCFLAGS += -fsigned-char
 USE_BLAS64:=0
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV7
-USE_SYSTEM_LIBM:=1
 endif
 
 # If we are running on aarch64 (e.g. ARMv8 or ARM64), set certain options automatically


### PR DESCRIPTION
We used to have problems with openlibm on armv7l, but we fixed those a few years ago.  Let's be consistent, and use openlibm everywhere we can.