### PR TITLE
Revert "Document some exported Sys CPU stuff (#31204)"

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -65,13 +65,6 @@ See Hwloc.jl or CpuId.jl for extended information, including number of physical 
 CPU_THREADS = 1 # for bootstrap, changed on startup
 
 """
-    Sys.CPU_NAME
-
-The name of the host CPU as a string.
-"""
-CPU_NAME = "" # for bootstrap, changed on startup
-
-"""
     Sys.ARCH
 
 A symbol representing the architecture of the build configuration.
@@ -195,15 +188,6 @@ function _cpu_summary(io::IO, cpu::AbstractVector{CPUinfo}, i, j)
     println(io)
 end
 
-"""
-    Sys.cpu_summary(io::IO=stdout, cpu::AbstractVector{CPUinfo} = cpu_info())
-
-Print a summary of information about each processor in `cpu` gathered from [`cpu_info](@ref). This is generally:
-  - Its index in the `cpu` vector
-  - The CPU model
-  - The CPU speed
-  - The amount of time spent in `user`, `nice`, `sys`, `idle`, and `irq` modes
-"""
 function cpu_summary(io::IO=stdout, cpu::AbstractVector{CPUinfo} = cpu_info())
     model = cpu[1].model
     first = 1
@@ -216,11 +200,6 @@ function cpu_summary(io::IO=stdout, cpu::AbstractVector{CPUinfo} = cpu_info())
     _cpu_summary(io, cpu, first, length(cpu))
 end
 
-"""
-    Sys.cpu_info()
-
-Gather information about all CPUs in the system through a syscall using LibUV.
-"""
 function cpu_info()
     UVcpus = Ref{Ptr{UV_cpu_info_t}}()
     count = Ref{Int32}()
@@ -237,7 +216,7 @@ end
 """
     Sys.uptime()
 
-Get the current system uptime in seconds.
+Gets the current system uptime in seconds.
 """
 function uptime()
     uptime_ = Ref{Float64}()

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -298,8 +298,6 @@ Base.@elapsed
 Base.@allocated
 Base.EnvDict
 Base.ENV
-Base.Sys.cpu_summary
-Base.Sys.cpu_info
 Base.Sys.isunix
 Base.Sys.isapple
 Base.Sys.islinux

--- a/doc/src/base/constants.md
+++ b/doc/src/base/constants.md
@@ -10,7 +10,6 @@ Base.DEPOT_PATH
 Base.LOAD_PATH
 Base.Sys.BINDIR
 Base.Sys.CPU_THREADS
-Base.Sys.CPU_NAME
 Base.Sys.WORD_SIZE
 Base.Sys.KERNEL
 Base.Sys.ARCH


### PR DESCRIPTION
This reverts commit 7f2922eb0935e03ba702001c827167561d20e88a.

I think this commit broke Documenter, which is breaking all our buildbot builds.  Let's see if this actually fixes it.