### PR TITLE
add specialized codegen for `jl_get_current_task`

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1014,6 +1014,7 @@ JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);
 
 JL_DLLEXPORT uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_get_current_task(void);
 
 // -- synchronization utilities -- //
 


### PR DESCRIPTION
The code_llvm for this seems to be nastier than I'd expect:
```
julia> @code_llvm current_task()

;  @ task.jl:95 within `current_task'
define nonnull %jl_value_t addrspace(10)* @jsys1_current_task_15548(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32) #0 {
top:
  %3 = alloca %jl_value_t addrspace(10)**, align 8
  store volatile %jl_value_t addrspace(10)** %1, %jl_value_t addrspace(10)*** %3, align 8
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"()
  %ptls_i8 = getelementptr i8, i8* %thread_ptr, i64 -15712
  %ptls = bitcast i8* %ptls_i8 to %jl_value_t***
  %4 = getelementptr %jl_value_t**, %jl_value_t*** %ptls, i64 826
  %5 = bitcast %jl_value_t*** %4 to %jl_value_t addrspace(10)**
  %6 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %5, align 8
  ret %jl_value_t addrspace(10)* %6
}
```
Why is this using a less efficient calling convention, and what's with the volatile store?