### PR TITLE
Fix compiler warning caused by duplicate definition

### DIFF
--- a/src/support/analyzer_annotations.h
+++ b/src/support/analyzer_annotations.h
@@ -45,6 +45,5 @@ extern "C" {
 #define JL_ROOTED_VALUE_COLLECTION
 #define JL_GC_PROMISE_ROOTED(x) (void)(x)
 #define jl_may_leak(x) (void)(x)
-#define JL_GC_ASSERT_LIVE(x)
 
 #endif


### PR DESCRIPTION
Maybe we should turn on Werror on CI