### PR TITLE
reduce number of heaps used by partr

### DIFF
--- a/src/partr.c
+++ b/src/partr.c
@@ -47,10 +47,10 @@ typedef struct taskheap_tag {
 
 /* multiqueue parameters */
 static const int32_t heap_d = 8;
-static const int heap_c = 16;
+static const int heap_c = 2;
 
 /* size of each heap */
-static const int tasks_per_heap = 16384; // TODO: this should be smaller by default, but growable!
+static const int tasks_per_heap = 65536; // TODO: this should be smaller by default, but growable!
 
 /* the multiqueue's heaps */
 static taskheap_t *heaps;


### PR DESCRIPTION
Inspired by https://github.com/JuliaLang/julia/issues/32701#issuecomment-517892965. Using more heaps theoretically reduces contention, but also increases the number of times we're likely to spin looking for a non-empty heap. This change improves the time for `pfib(31)` with 2 threads from ~6 to ~4 seconds.