### PR TITLE
Use porcelain `git` commands to get branch name

### DIFF
--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -39,7 +39,7 @@ if [ -n "$(git status --porcelain)" ]; then
     # append dirty mark '*' if the repository has uncommitted changes
     commit_short="$commit_short"*
 fi
-branch=$(git branch | sed -n '/\* /s///p')
+branch=$(git rev-parse --abbrev-ref HEAD)
 
 topdir=$(git rev-parse --show-toplevel)
 verchanged=$(git blame -L ,1 -sl -- "$topdir/VERSION" | cut -f 1 -d " ")


### PR DESCRIPTION
By using `git branch`, we sometimes capture terminal color codes, which
is suboptimal.  Use porcelain commands instead, that's what they're
there for.