### PR TITLE
Add `dot` method for symmetric matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -436,9 +436,6 @@ function dot(A::Symmetric, B::Symmetric)
             end
         end
     else
-        if A.uplo == 'L' && B.uplo == 'U'
-            A, B = B, A
-        end
         for j in 1:n
             for i in 1:(j - 1)
                 dotprod += 2 * dot(A[i, j], B[j, i])

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -435,14 +435,14 @@ function dot(A::Symmetric{Ta,<:AbstractArray}, B::Symmetric{Tb,<:AbstractArray})
                 dotprod += 2 * dot(A.data[i, j], B.data[i, j])
             end
         end
-    elseif A.uplo == 'L' && B.uplo == 'U'
+    elseif A.uplo == 'U' && B.uplo == 'L'
         for j in 1:n
             for i in 1:(j - 1)
                 dotprod += 2 * dot(A.data[i, j], B.data[j, i])
             end
             dotprod += dot(A.data[j, j], B.data[j, j])
         end
-    elseif A.uplo == 'U' && B.uplo == 'L'
+    elseif A.uplo == 'L' && B.uplo == 'U'
         for j in 1:n
             dotprod += dot(A.data[j, j], B.data[j, j])
             for i in (j + 1):n

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -446,7 +446,7 @@ function dot(A::Symmetric{Ta,<:AbstractArray}, B::Symmetric{Tb,<:AbstractArray})
         for j in 1:n
             dotprod += dot(A.data[j, j], B.data[j, j])
             for i in (j + 1):n
-                dotprod += 2 * dot(A.data[i,j], B.data[j, i])
+                dotprod += 2 * dot(A.data[i, j], B.data[j, i])
             end
         end
     end

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -424,15 +424,15 @@ function dot(A::Symmetric, B::Symmetric)
     @inbounds if A.uplo == 'U' && B.uplo == 'U'
         for j in 1:n
             for i in 1:(j - 1)
-                dotprod += 2 * dot(A.data[i, j], B.data[i, j])
+                dotprod += 2 * dot(A[i, j], B[i, j])
             end
-            dotprod += dot(A.data[j, j], B.data[j, j])
+            dotprod += dot(A[j, j], B[j, j])
         end
     elseif A.uplo == 'L' && B.uplo == 'L'
         for j in 1:n
-            dotprod += dot(A.data[j, j], B.data[j, j])
+            dotprod += dot(A[j, j], B[j, j])
             for i in (j + 1):n
-                dotprod += 2 * dot(A.data[i, j], B.data[i, j])
+                dotprod += 2 * dot(A[i, j], B[i, j])
             end
         end
     else
@@ -441,9 +441,9 @@ function dot(A::Symmetric, B::Symmetric)
         end
         for j in 1:n
             for i in 1:(j - 1)
-                dotprod += 2 * dot(A.data[i, j], B.data[j, i])
+                dotprod += 2 * dot(A[i, j], B[j, i])
             end
-            dotprod += dot(A.data[j, j], B.data[j, j])
+            dotprod += dot(A[j, j], B[j, j])
         end
     end
     return dotprod

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -425,15 +425,15 @@ function dot(A::Symmetric, B::Symmetric)
     @inbounds if A.uplo == 'U' && B.uplo == 'U'
         for j in 1:n
             for i in 1:(j - 1)
-                dotprod += 2 * A.data[i, j] * conj(B.data[i, j])
+                dotprod += 2 * dot(A.data[i, j], B.data[i, j])
             end
-            dotprod += A.data[j, j] * conj(B.data[j, j])
+            dotprod += dot(A.data[j, j], B.data[j, j])
         end
     elseif A.uplo == 'L' && B.uplo == 'L'
         for j in 1:n
-            dotprod += A.data[j, j] * conj(B.data[j, j])
+            dotprod += dot(A.data[j, j], B.data[j, j])
             for i in (j + 1):n
-                dotprod += 2 * A.data[i, j] * conj(B.data[i, j])
+                dotprod += 2 * dot(A.data[i, j], B.data[i, j])
             end
         end
     else
@@ -442,9 +442,9 @@ function dot(A::Symmetric, B::Symmetric)
         end
         for j in 1:n
             for i in 1:(j - 1)
-                dotprod += 2 * A.data[i, j] * conj(B.data[j, i])
+                dotprod += 2 * dot(A.data[i, j], B.data[j, i])
             end
-            dotprod += A.data[j, j] * conj(B.data[j, j])
+            dotprod += dot(A.data[j, j], B.data[j, j])
         end
     end
     return dotprod

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -424,23 +424,30 @@ function dot(A::Symmetric{Ta,<:AbstractArray}, B::Symmetric{Tb,<:AbstractArray})
     @inbounds if A.uplo == 'U' && B.uplo == 'U'
         for j in 1:n
             for i in 1:(j - 1)
-                dotprod += 2 * dot(A[i, j], B[i, j])
+                dotprod += 2 * dot(A.data[i, j], B.data[i, j])
             end
-            dotprod += dot(A[j, j], B[j, j])
+            dotprod += dot(A.data[j, j], B.data[j, j])
         end
     elseif A.uplo == 'L' && B.uplo == 'L'
         for j in 1:n
-            dotprod += dot(A[j, j], B[j, j])
+            dotprod += dot(A.data[j, j], B.data[j, j])
             for i in (j + 1):n
-                dotprod += 2 * dot(A[i, j], B[i, j])
+                dotprod += 2 * dot(A.data[i, j], B.data[i, j])
             end
         end
-    else
+    elseif A.uplo == 'L' && B.uplo == 'U'
         for j in 1:n
             for i in 1:(j - 1)
-                dotprod += 2 * dot(A[i, j], B[j, i])
+                dotprod += 2 * dot(A.data[i, j], B.data[j, i])
             end
-            dotprod += dot(A[j, j], B[j, j])
+            dotprod += dot(A.data[j, j], B.data[j, j])
+        end
+    elseif A.uplo == 'U' && B.uplo == 'L'
+        for j in 1:n
+            dotprod += dot(A.data[j, j], B.data[j, j])
+            for i in (j + 1):n
+                dotprod += 2 * dot(A.data[i,j], B.data[j, i])
+            end
         end
     end
     return dotprod

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -416,11 +416,10 @@ end
 
 function dot(A::Symmetric, B::Symmetric)
     dotprod = zero(dot(first(A), first(B)))
-    m, n = size(A)
-    mB, nB = size(B)
 
-    if m != mB || n != nB
-        throw(DimensionMismatch("A has dimensions ($m,$n) but B has dimensions ($mB,$nB)"))
+    n = size(A, 2)
+    if n != size(B, 2)
+        throw(DimensionMismatch("A has dimensions $(size(A)) but B has dimensions $(size(B))"))
     end
 
     @inbounds if A.uplo == 'U' && B.uplo == 'U'
@@ -433,7 +432,7 @@ function dot(A::Symmetric, B::Symmetric)
     elseif A.uplo == 'L' && B.uplo == 'L'
         for j in 1:n
             dotprod += A.data[j, j] * conj(B.data[j, j])
-            for i in (j + 1):m
+            for i in (j + 1):n
                 dotprod += 2 * A.data[i, j] * conj(B.data[i, j])
             end
         end

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -415,13 +415,12 @@ function triu(A::Symmetric, k::Integer=0)
 end
 
 function dot(A::Symmetric, B::Symmetric)
-    dotprod = zero(dot(first(A), first(B)))
-
     n = size(A, 2)
     if n != size(B, 2)
         throw(DimensionMismatch("A has dimensions $(size(A)) but B has dimensions $(size(B))"))
     end
 
+    dotprod = zero(dot(first(A), first(B)))
     @inbounds if A.uplo == 'U' && B.uplo == 'U'
         for j in 1:n
             for i in 1:(j - 1)

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -414,8 +414,8 @@ function triu(A::Symmetric, k::Integer=0)
     end
 end
 
-function dot(A::Symmetric{T, Matrix{T}}, B::Symmetric{T, Matrix{T}}) where T
-    dotprod = zero(T)
+function dot(A::Symmetric, B::Symmetric)
+    dotprod = zero(dot(first(A), first(B)))
     m, n = size(A)
     mB, nB = size(B)
 

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -453,6 +453,45 @@ function dot(A::Symmetric, B::Symmetric)
     return dotprod
 end
 
+function dot(A::Hermitian, B::Hermitian)
+    n = size(A, 2)
+    if n != size(B, 2)
+        throw(DimensionMismatch("A has dimensions $(size(A)) but B has dimensions $(size(B))"))
+    end
+
+    dotprod = zero(dot(first(A), first(B)))
+    @inbounds if A.uplo == 'U' && B.uplo == 'U'
+        for j in 1:n
+            for i in 1:(j - 1)
+                dotprod += 2 * real(dot(A.data[i, j], B.data[i, j]))
+            end
+            dotprod += dot(A[j, j], B[j, j])
+        end
+    elseif A.uplo == 'L' && B.uplo == 'L'
+        for j in 1:n
+            dotprod += dot(A[j, j], B[j, j])
+            for i in (j + 1):n
+                dotprod += 2 * real(dot(A.data[i, j], B.data[i, j]))
+            end
+        end
+    elseif A.uplo == 'U' && B.uplo == 'L'
+        for j in 1:n
+            for i in 1:(j - 1)
+                dotprod += 2 * real(dot(A.data[i, j], adjoint(B.data[j, i])))
+            end
+            dotprod += dot(A[j, j], B[j, j])
+        end
+    elseif A.uplo == 'L' && B.uplo == 'U'
+        for j in 1:n
+            dotprod += dot(A[j, j], B[j, j])
+            for i in (j + 1):n
+                dotprod += 2 * real(dot(A.data[i, j], adjoint(B.data[j, i])))
+            end
+        end
+    end
+    return dotprod
+end
+
 (-)(A::Symmetric) = Symmetric(-A.data, sym_uplo(A.uplo))
 (-)(A::Hermitian) = Hermitian(-A.data, sym_uplo(A.uplo))
 

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -414,7 +414,7 @@ function triu(A::Symmetric, k::Integer=0)
     end
 end
 
-function dot(A::Symmetric{Ta,<:AbstractArray}, B::Symmetric{Tb,<:AbstractArray}) where {Ta,Tb<:Number}
+function dot(A::Symmetric, B::Symmetric)
     n = size(A, 2)
     if n != size(B, 2)
         throw(DimensionMismatch("A has dimensions $(size(A)) but B has dimensions $(size(B))"))
@@ -426,11 +426,11 @@ function dot(A::Symmetric{Ta,<:AbstractArray}, B::Symmetric{Tb,<:AbstractArray})
             for i in 1:(j - 1)
                 dotprod += 2 * dot(A.data[i, j], B.data[i, j])
             end
-            dotprod += dot(A.data[j, j], B.data[j, j])
+            dotprod += dot(A[j, j], B[j, j])
         end
     elseif A.uplo == 'L' && B.uplo == 'L'
         for j in 1:n
-            dotprod += dot(A.data[j, j], B.data[j, j])
+            dotprod += dot(A[j, j], B[j, j])
             for i in (j + 1):n
                 dotprod += 2 * dot(A.data[i, j], B.data[i, j])
             end
@@ -438,15 +438,15 @@ function dot(A::Symmetric{Ta,<:AbstractArray}, B::Symmetric{Tb,<:AbstractArray})
     elseif A.uplo == 'U' && B.uplo == 'L'
         for j in 1:n
             for i in 1:(j - 1)
-                dotprod += 2 * dot(A.data[i, j], B.data[j, i])
+                dotprod += 2 * dot(A.data[i, j], transpose(B.data[j, i]))
             end
-            dotprod += dot(A.data[j, j], B.data[j, j])
+            dotprod += dot(A[j, j], B[j, j])
         end
     elseif A.uplo == 'L' && B.uplo == 'U'
         for j in 1:n
-            dotprod += dot(A.data[j, j], B.data[j, j])
+            dotprod += dot(A[j, j], B[j, j])
             for i in (j + 1):n
-                dotprod += 2 * dot(A.data[i, j], B.data[j, i])
+                dotprod += 2 * dot(A.data[i, j], transpose(B.data[j, i]))
             end
         end
     end

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -414,7 +414,7 @@ function triu(A::Symmetric, k::Integer=0)
     end
 end
 
-function dot(A::Symmetric, B::Symmetric)
+function dot(A::Symmetric{Ta,<:AbstractArray}, B::Symmetric{Tb,<:AbstractArray}) where {Ta,Tb<:Number}
     n = size(A, 2)
     if n != size(B, 2)
         throw(DimensionMismatch("A has dimensions $(size(A)) but B has dimensions $(size(B))"))

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -442,7 +442,7 @@ function dot(A::Symmetric, B::Symmetric)
             end
             dotprod += dot(A[j, j], B[j, j])
         end
-    elseif A.uplo == 'L' && B.uplo == 'U'
+    else
         for j in 1:n
             dotprod += dot(A[j, j], B[j, j])
             for i in (j + 1):n
@@ -481,7 +481,7 @@ function dot(A::Hermitian, B::Hermitian)
             end
             dotprod += dot(A[j, j], B[j, j])
         end
-    elseif A.uplo == 'L' && B.uplo == 'U'
+    else
         for j in 1:n
             dotprod += dot(A[j, j], B[j, j])
             for i in (j + 1):n

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -376,6 +376,14 @@ end
                     @test dot(x, Symmetric(aherm, uplo), x) ≈ dot(x, Symmetric(aherm, uplo)*x) ≈ dot(x, Matrix(Symmetric(aherm, uplo)), x)
                 end
             end
+
+        @testset "dot product of symmetric matrices" begin
+            rhs = dot(asym, asym)
+            @test dot(Symmetric(asym), Symmetric(asym)) ≈ rhs
+            @test dot(Symmetric(asym, :L), Symmetric(asym, :L)) ≈ rhs
+            @test dot(Symmetric(asym), Symmetric(asym, :L)) ≈ rhs
+            @test dot(Symmetric(asym, :L), Symmetric(asym)) ≈ rhs
+            @test_throws DimensionMismatch dot(Symmetric(asym), Symmetric(Matrix{eltya}(undef, n-1, n-1)))
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -396,17 +396,6 @@ end
                 @test dot(symal, symcu) ≈ dot(msymal, msymcu)
                 @test dot(symal, symcl) ≈ dot(msymal, msymcl)
             end
-
-            # block matrices
-            blockm = [eltya == Int ? rand(1:7, 3, 3) : convert(Matrix{eltya}, eltya <: Complex ? complex.(randn(3, 3)/2, randn(3, 3)/2) : randn(3, 3)/2) for _ in 1:3, _ in 1:3]
-            symblockmu = Symmetric(blockm, :U)
-            symblockml = Symmetric(blockm, :L)
-            msymblockmu = Matrix(symblockmu)
-            msymblockml = Matrix(symblockml)
-            @test dot(symblockmu, symblockmu) ≈ dot(msymblockmu, msymblockmu)
-            @test dot(symblockmu, symblockml) ≈ dot(msymblockmu, msymblockml)
-            @test dot(symblockml, symblockmu) ≈ dot(msymblockml, msymblockmu)
-            @test dot(symblockml, symblockml) ≈ dot(msymblockml, msymblockml)
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -396,6 +396,17 @@ end
                 @test dot(symal, symcu) ≈ dot(msymal, msymcu)
                 @test dot(symal, symcl) ≈ dot(msymal, msymcl)
             end
+
+            # block matrices
+            blockm = [eltya == Int ? rand(1:7, 3, 3) : convert(Matrix{eltya}, eltya <: Complex ? complex.(randn(3, 3)/2, randn(3, 3)/2) : randn(3, 3)/2) for _ in 1:3, _ in 1:3]
+            symblockmu = Symmetric(blockm, :U)
+            symblockml = Symmetric(blockm, :L)
+            msymblockmu = Matrix(symblockmu)
+            msymblockml = Matrix(symblockml)
+            @test dot(symblockmu, symblockmu) ≈ dot(msymblockmu, msymblockmu)
+            @test dot(symblockmu, symblockml) ≈ dot(msymblockmu, msymblockml)
+            @test dot(symblockml, symblockmu) ≈ dot(msymblockml, msymblockmu)
+            @test dot(symblockml, symblockml) ≈ dot(msymblockml, msymblockml)
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -376,6 +376,7 @@ end
                     @test dot(x, Symmetric(aherm, uplo), x) ≈ dot(x, Symmetric(aherm, uplo)*x) ≈ dot(x, Matrix(Symmetric(aherm, uplo)), x)
                 end
             end
+        end
 
         @testset "dot product of symmetric and Hermitian matrices" begin
             for mtype in (Symmetric, Hermitian)

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -383,7 +383,7 @@ end
             @test dot(Symmetric(asym, :L), Symmetric(asym, :L)) ≈ rhs
             @test dot(Symmetric(asym), Symmetric(asym, :L)) ≈ rhs
             @test dot(Symmetric(asym, :L), Symmetric(asym)) ≈ rhs
-            @test_throws DimensionMismatch dot(Symmetric(asym), Symmetric(Matrix{eltya}(undef, n-1, n-1)))
+            @test_throws DimensionMismatch dot(Symmetric(asym), Symmetric(zeros(eltya, n-1, n-1)))
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -377,36 +377,38 @@ end
                 end
             end
 
-        @testset "dot product of symmetric matrices" begin
-            symau = Symmetric(a, :U)
-            symal = Symmetric(a, :L)
-            msymau = Matrix(symau)
-            msymal = Matrix(symal)
-            @test_throws DimensionMismatch dot(symau, Symmetric(zeros(eltya, n-1, n-1)))
-            for eltyc in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
-                creal = randn(n, n)/2
-                cimag = randn(n, n)/2
-                c = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(creal, cimag) : creal)
-                symcu = Symmetric(c, :U)
-                symcl = Symmetric(c, :L)
-                msymcu = Matrix(symcu)
-                msymcl = Matrix(symcl)
-                @test dot(symau, symcu) ≈ dot(msymau, msymcu)
-                @test dot(symau, symcl) ≈ dot(msymau, msymcl)
-                @test dot(symal, symcu) ≈ dot(msymal, msymcu)
-                @test dot(symal, symcl) ≈ dot(msymal, msymcl)
-            end
+        @testset "dot product of symmetric and Hermitian matrices" begin
+            for mtype in (Symmetric, Hermitian)
+                symau = mtype(a, :U)
+                symal = mtype(a, :L)
+                msymau = Matrix(symau)
+                msymal = Matrix(symal)
+                @test_throws DimensionMismatch dot(symau, mtype(zeros(eltya, n-1, n-1)))
+                for eltyc in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
+                    creal = randn(n, n)/2
+                    cimag = randn(n, n)/2
+                    c = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(creal, cimag) : creal)
+                    symcu = mtype(c, :U)
+                    symcl = mtype(c, :L)
+                    msymcu = Matrix(symcu)
+                    msymcl = Matrix(symcl)
+                    @test dot(symau, symcu) ≈ dot(msymau, msymcu)
+                    @test dot(symau, symcl) ≈ dot(msymau, msymcl)
+                    @test dot(symal, symcu) ≈ dot(msymal, msymcu)
+                    @test dot(symal, symcl) ≈ dot(msymal, msymcl)
+                end
 
-            # block matrices
-            blockm = [eltya == Int ? rand(1:7, 3, 3) : convert(Matrix{eltya}, eltya <: Complex ? complex.(randn(3, 3)/2, randn(3, 3)/2) : randn(3, 3)/2) for _ in 1:3, _ in 1:3]
-            symblockmu = Symmetric(blockm, :U)
-            symblockml = Symmetric(blockm, :L)
-            msymblockmu = Matrix(symblockmu)
-            msymblockml = Matrix(symblockml)
-            @test dot(symblockmu, symblockmu) ≈ dot(msymblockmu, msymblockmu)
-            @test dot(symblockmu, symblockml) ≈ dot(msymblockmu, msymblockml)
-            @test dot(symblockml, symblockmu) ≈ dot(msymblockml, msymblockmu)
-            @test dot(symblockml, symblockml) ≈ dot(msymblockml, msymblockml)
+                # block matrices
+                blockm = [eltya == Int ? rand(1:7, 3, 3) : convert(Matrix{eltya}, eltya <: Complex ? complex.(randn(3, 3)/2, randn(3, 3)/2) : randn(3, 3)/2) for _ in 1:3, _ in 1:3]
+                symblockmu = mtype(blockm, :U)
+                symblockml = mtype(blockm, :L)
+                msymblockmu = Matrix(symblockmu)
+                msymblockml = Matrix(symblockml)
+                @test dot(symblockmu, symblockmu) ≈ dot(msymblockmu, msymblockmu)
+                @test dot(symblockmu, symblockml) ≈ dot(msymblockmu, msymblockml)
+                @test dot(symblockml, symblockmu) ≈ dot(msymblockml, msymblockmu)
+                @test dot(symblockml, symblockml) ≈ dot(msymblockml, msymblockml)
+            end
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -378,12 +378,24 @@ end
             end
 
         @testset "dot product of symmetric matrices" begin
-            rhs = dot(asym, asym)
-            @test dot(Symmetric(asym), Symmetric(asym)) ≈ rhs
-            @test dot(Symmetric(asym, :L), Symmetric(asym, :L)) ≈ rhs
-            @test dot(Symmetric(asym), Symmetric(asym, :L)) ≈ rhs
-            @test dot(Symmetric(asym, :L), Symmetric(asym)) ≈ rhs
-            @test_throws DimensionMismatch dot(Symmetric(asym), Symmetric(zeros(eltya, n-1, n-1)))
+            symau = Symmetric(a, :U)
+            symal = Symmetric(a, :L)
+            msymau = Matrix(symau)
+            msymal = Matrix(symal)
+            @test_throws DimensionMismatch dot(symau, Symmetric(zeros(eltya, n-1, n-1)))
+            for eltyc in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
+                creal = randn(n, n)/2
+                cimag = randn(n, n)/2
+                c = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(creal, cimag) : creal)
+                symcu = Symmetric(c, :U)
+                symcl = Symmetric(c, :L)
+                msymcu = Matrix(symcu)
+                msymcl = Matrix(symcl)
+                @test dot(symau, symcu) ≈ dot(msymau, msymcu)
+                @test dot(symau, symcl) ≈ dot(msymau, msymcl)
+                @test dot(symal, symcu) ≈ dot(msymal, msymcu)
+                @test dot(symal, symcl) ≈ dot(msymal, msymcl)
+            end
         end
     end
 end


### PR DESCRIPTION
This PR adds a `dot` method for symmetric matrices, which makes the calculation of the dot product of two symmetric matrices significantly faster (see benchmarks below). It intends to fix JuliaLang/LinearAlgebra.jl#647.

To perform the benchmarks, this code was used:
```julia
using LinearAlgebra
using BenchmarkTools

n = 10_000
X = randn(n, n)
Y = randn(n, n)

A = Symmetric(X)  # or A = Symmetric(X, :L)
B = Symmetric(Y)  # or B = Symmetric(Y, :L)
@btime dot(A, B)
```

These are the results:

| A.uplo | B.uplo | Julia 1.1    | PR            |
| :--------: | :--------: | -------------: | -------------: |
| 'U'       | 'U'       | 1.4 s         | 72 ms        |
| 'U'       | 'L'       | 1.33 s        | 537 ms      |
| 'L'       | 'U'       | 1.33 s        | 538 ms      |
| 'L'        | 'L'        | 1.4 s         | 72 ms        |