### PR TITLE
Add rmrf shorthand for rm(x, force=true, recursive=true)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@ New library functions
 * `istaskfailed` is now documented and exported, like its siblings `istaskdone` and `istaskstarted` ([#32300]).
 * `RefArray` and `RefValue` objects now accept index `CartesianIndex()` in  `getindex` and `setindex!` ([#32653])
 * Added `sincosd(x)` to simultaneously compute the sine and cosine of `x`, where `x` is in degrees ([#30134]).
+* `rmrf` has been added as a shorthand for `rm(x, force=true, recursive=true)` ([#32831]).
 
 Standard library changes
 ------------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -879,6 +879,7 @@ export
     pwd,
     readlink,
     rm,
+    rmrf,
     stat,
     symlink,
     tempdir,

--- a/base/file.jl
+++ b/base/file.jl
@@ -18,6 +18,7 @@ export
     readlink,
     readdir,
     rm,
+    rmrf,
     samefile,
     sendfile,
     symlink,
@@ -280,6 +281,18 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
     end
 end
 
+"""
+    rmrf(path)
+
+Forcibly and recursively remove the provided path.
+Shorthand for `rm(path, force=true, recursive=true)`.
+
+See also [`rm`](@ref).
+
+!!! compat "Julia 1.3"
+    This function requires Julia 1.3 or later.
+"""
+rmrf(path) = rm(path, force=true, recursive=true)
 
 # The following use Unix command line facilities
 function checkfor_mv_cp_cptree(src::AbstractString, dst::AbstractString, txt::AbstractString;

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -26,6 +26,7 @@ Base.Filesystem.cp
 Base.download
 Base.Filesystem.mv
 Base.Filesystem.rm
+Base.Filesystem.rmrf
 Base.Filesystem.touch
 Base.Filesystem.tempname
 Base.Filesystem.tempdir

--- a/test/file.jl
+++ b/test/file.jl
@@ -184,6 +184,16 @@ rm(c_tmpdir, recursive=true)
 @test_throws Base.IOError rm(c_tmpdir, recursive=true)
 @test rm(c_tmpdir, force=true, recursive=true) === nothing
 
+@testset "rmrf" begin
+    d = mktempdir()
+    write(joinpath(d, "hi.txt"), "hi")
+    @test isdir(d)
+    @test !isempty(readdir(d))
+    @test_throws SystemError rm(d)
+    @test rmrf(d) === nothing
+    @test !isdir(d)
+end
+
 if !Sys.iswindows()
     # chown will give an error if the user does not have permissions to change files
     if get(ENV, "USER", "") == "root" || get(ENV, "HOME", "") == "/root"


### PR DESCRIPTION
As suggested by Stefan in https://github.com/JuliaLang/julia/pull/32335#issuecomment-519661907.