### PR TITLE
remove an object allocation in the scheduler

### DIFF
--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -98,10 +98,10 @@ uv_error(prefix::AbstractString, c::Integer) = c < 0 ? throw(_UVError(prefix, c)
 
 ## event loop ##
 
-eventloop() = uv_eventloop::Ptr{Cvoid}
+eventloop() = ccall(:jl_global_event_loop, Ptr{Cvoid}, ())
 
 function process_events()
-    return ccall(:jl_process_events, Int32, (Ptr{Cvoid},), eventloop())
+    return ccall(:jl_process_events, Int32, ())
 end
 
 function uv_alloc_buf end
@@ -119,7 +119,6 @@ function reinit_stdio()
     global uv_jl_asynccb       = @cfunction(uv_asynccb, Cvoid, (Ptr{Cvoid},))
     global uv_jl_timercb       = @cfunction(uv_timercb, Cvoid, (Ptr{Cvoid},))
 
-    global uv_eventloop = ccall(:jl_global_event_loop, Ptr{Cvoid}, ())
     global stdin = init_stdio(ccall(:jl_stdin_stream, Ptr{Cvoid}, ()))
     global stdout = init_stdio(ccall(:jl_stdout_stream, Ptr{Cvoid}, ()))
     global stderr = init_stdio(ccall(:jl_stderr_stream, Ptr{Cvoid}, ()))

--- a/base/task.jl
+++ b/base/task.jl
@@ -656,8 +656,7 @@ end
 @noinline function poptaskref(W::StickyWorkqueue)
     task = trypoptask(W)
     if !(task isa Task)
-        gettask = () -> trypoptask(W)
-        task = ccall(:jl_task_get_next, Any, (Any,), gettask)::Task
+        task = ccall(:jl_task_get_next, Ref{Task}, (Any, Any), trypoptask, W)
     end
     return Ref(task)
 end

--- a/src/julia.h
+++ b/src/julia.h
@@ -1797,9 +1797,7 @@ extern int had_exception;
 #define JL_STDERR jl_uv_stderr
 #define JL_STDIN  jl_uv_stdin
 
-JL_DLLEXPORT void jl_run_event_loop(uv_loop_t *loop);
-JL_DLLEXPORT int jl_run_once(uv_loop_t *loop);
-JL_DLLEXPORT int jl_process_events(uv_loop_t *loop);
+JL_DLLEXPORT int jl_process_events(void);
 
 JL_DLLEXPORT uv_loop_t *jl_global_event_loop(void);
 

--- a/src/partr.c
+++ b/src/partr.c
@@ -373,10 +373,11 @@ JL_DLLEXPORT void jl_set_task_tid(jl_task_t *task, int tid) JL_NOTSAFEPOINT
 }
 
 // get the next runnable task from the multiq
-static jl_task_t *get_next_task(jl_value_t *getsticky)
+static jl_task_t *get_next_task(jl_value_t *trypoptask, jl_value_t *q)
 {
     jl_gc_safepoint();
-    jl_task_t *task = (jl_task_t*)jl_apply(&getsticky, 1);
+    jl_value_t *args[2] = { trypoptask, q };
+    jl_task_t *task = (jl_task_t*)jl_apply(&args, 2);
     if (jl_typeis(task, jl_task_type)) {
         int self = jl_get_ptls_states()->tid;
         jl_set_task_tid(task, self);
@@ -393,14 +394,14 @@ static int may_sleep(jl_ptls_t ptls)
 
 extern volatile unsigned _threadedregion;
 
-JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *getsticky)
+JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *trypoptask, jl_value_t *q)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     uint64_t start_cycles = 0;
     jl_task_t *task;
 
     while (1) {
-        task = get_next_task(getsticky);
+        task = get_next_task(trypoptask, q);
         if (task)
             return task;
 
@@ -416,7 +417,7 @@ JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *getsticky)
             if (!sleep_check_now(ptls->tid))
                 continue;
             jl_atomic_store(&ptls->sleep_check_state, sleeping); // acquire sleep-check lock
-            task = get_next_task(getsticky);
+            task = get_next_task(trypoptask, q);
             if (task)
                 return task;
             // one thread should win this race and watch the event loop
@@ -483,7 +484,7 @@ JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *getsticky)
 #ifndef JL_HAVE_ASYNCIFY
             // maybe check the kernel for new messages too
             if (jl_atomic_load(&jl_uv_n_waiters) == 0)
-                jl_process_events(jl_global_event_loop());
+                jl_process_events();
 #else
             // Yield back to browser event loop
             return ptls->root_task;


### PR DESCRIPTION
- avoid allocating `gettask` closure
- stop using a non-const global for eventloop()
- remove some unused code