### PR TITLE
more efficient representation of `SpinLock`

### DIFF
--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -26,10 +26,33 @@ Test-and-test-and-set spin locks are quickest up to about 30ish
 contending threads. If you have more contention than that, different
 synchronization approaches should be considered.
 """
-struct SpinLock <: AbstractLock
-    handle::Atomic{Int}
-    SpinLock() = new(Atomic{Int}(0))
+mutable struct SpinLock <: AbstractLock
+    handle::Int
+    SpinLock() = new(0)
 end
+
+import Base.Sys.WORD_SIZE
+
+@eval _xchg!(x::SpinLock, v::Int) =
+    llvmcall($"""
+             %ptr = inttoptr i$WORD_SIZE %0 to i$WORD_SIZE*
+             %rv = atomicrmw xchg i$WORD_SIZE* %ptr, i$WORD_SIZE %1 acq_rel
+             ret i$WORD_SIZE %rv
+             """, Int, Tuple{Ptr{Int}, Int}, unsafe_convert(Ptr{Int}, pointer_from_objref(x)), v)
+
+@eval _get(x::SpinLock) =
+    llvmcall($"""
+             %ptr = inttoptr i$WORD_SIZE %0 to i$WORD_SIZE*
+             %rv = load atomic i$WORD_SIZE, i$WORD_SIZE* %ptr acquire, align $(gc_alignment(Int))
+             ret i$WORD_SIZE %rv
+             """, Int, Tuple{Ptr{Int}}, unsafe_convert(Ptr{Int}, pointer_from_objref(x)))
+
+@eval _set!(x::SpinLock, v::Int) =
+    llvmcall($"""
+             %ptr = inttoptr i$WORD_SIZE %0 to i$WORD_SIZE*
+             store atomic i$WORD_SIZE %1, i$WORD_SIZE* %ptr release, align $(gc_alignment(Int))
+             ret void
+             """, Cvoid, Tuple{Ptr{Int}, Int}, unsafe_convert(Ptr{Int}, pointer_from_objref(x)), v)
 
 # Note: this cannot assert that the lock is held by the correct thread, because we do not
 # track which thread locked it. Users beware.
@@ -37,8 +60,8 @@ Base.assert_havelock(l::SpinLock) = islocked(l) ? nothing : concurrency_violatio
 
 function lock(l::SpinLock)
     while true
-        if l.handle[] == 0
-            p = atomic_xchg!(l.handle, 1)
+        if _get(l) == 0
+            p = _xchg!(l, 1)
             if p == 0
                 return
             end
@@ -50,18 +73,18 @@ function lock(l::SpinLock)
 end
 
 function trylock(l::SpinLock)
-    if l.handle[] == 0
-        return atomic_xchg!(l.handle, 1) == 0
+    if _get(l) == 0
+        return _xchg!(l, 1) == 0
     end
     return false
 end
 
 function unlock(l::SpinLock)
-    l.handle[] = 0
+    _set!(l, 0)
     ccall(:jl_cpu_wake, Cvoid, ())
     return
 end
 
 function islocked(l::SpinLock)
-    return l.handle[] != 0
+    return _get(l) != 0
 end


### PR DESCRIPTION
Now, I know this is kind of an ugly hack and we need support for atomic operations on general object fields. But this is an especially important type and it's easy to optimize now, so this is hard to resist.