### PR TITLE
Add inbounds macro to dot prodcut for sparse vectors

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1416,7 +1416,7 @@ function dot(x::AbstractVector{Tx}, y::SparseVectorUnion{Ty}) where {Tx<:Number,
     nzind = nonzeroinds(y)
     nzval = nonzeros(y)
     s = dot(zero(Tx), zero(Ty))
-    for i = 1:length(nzind)
+    @inbounds for i = 1:length(nzind)
         s += dot(x[nzind[i]], nzval[i])
     end
     return s


### PR DESCRIPTION
That PR is just a small improvement. It adds the `@inbounds` macro to the method `dot(x::AbstractVector{Tx}, y::SparseVectorUnion{Ty})` as it is already done in the similar method `dot(x::SparseVectorUnion{Tx}, y::AbstractVector{Ty})` (see https://github.com/goggle/julia/blob/6dad38e65e00525eb889abb33e6b23109c34e666/stdlib/SparseArrays/src/sparsevector.jl#L1432).