### PR TITLE
`fieldnames()` can throw for types such as `typeof(+)`

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -154,7 +154,7 @@ function complete_symbol(sym, ffunc, context_module=Main)::Vector{Completion}
         # Looking for a member of a type
         if t isa DataType && t != Any
             # Check for cases like Type{typeof(+)}
-            if t isa Type && length(t.parameters) >= 1
+            if t isa Type && !isconcretetype(t) && length(t.parameters) >= 1
                 t = t.parameters[1]
             end
             # Only look for fields if this is a concrete type

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -154,7 +154,7 @@ function complete_symbol(sym, ffunc, context_module=Main)::Vector{Completion}
         # Looking for a member of a type
         if t isa DataType && t != Any
             # Check for cases like Type{typeof(+)}
-            if t isa Type && !isconcretetype(t) && length(t.parameters) >= 1
+            if t isa DataType && t.name === Base._TYPE_NAME
                 t = t.parameters[1]
             end
             # Only look for fields if this is a concrete type

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -155,7 +155,7 @@ function complete_symbol(sym, ffunc, context_module=Main)::Vector{Completion}
         if t isa DataType && t != Any
             # Check for cases like Type{typeof(+)}
             if t isa DataType && t.name === Base._TYPE_NAME
-                t = t.parameters[1]
+                t = typeof(t.parameters[1])
             end
             # Only look for fields if this is a concrete type
             if isconcretetype(t)

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -154,7 +154,7 @@ function complete_symbol(sym, ffunc, context_module=Main)::Vector{Completion}
         # Looking for a member of a type
         if t isa DataType && t != Any
             # Check for cases like Type{typeof(+)}
-            if t isa Type
+            if t isa Type && length(t.parameters) >= 1
                 t = t.parameters[1]
             end
             # Only look for fields if this is a concrete type

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -153,11 +153,18 @@ function complete_symbol(sym, ffunc, context_module=Main)::Vector{Completion}
     else
         # Looking for a member of a type
         if t isa DataType && t != Any
-            fields = fieldnames(t)
-            for field in fields
-                s = string(field)
-                if startswith(s, name)
-                    push!(suggestions, FieldCompletion(t, field))
+            # Check for cases like Type{typeof(+)}
+            if t isa Type
+                t = t.parameters[1]
+            end
+            # Only look for fields if this is a concrete type
+            if isconcretetype(t)
+                fields = fieldnames(t)
+                for field in fields
+                    s = string(field)
+                    if startswith(s, name)
+                        push!(suggestions, FieldCompletion(t, field))
+                    end
                 end
             end
         end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1049,3 +1049,9 @@ let s = "prevind(\"θ\",1,"
     @test r == 1:7
     @test s[r] == "prevind"
 end
+
+# Issue #32840
+let s = "typeof(+)."
+    c, r = test_complete_context(s)
+    @test isempty(c)
+end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -103,6 +103,7 @@ let s = ""
 end
 
 let s = "using REP"
+    @show completions(s, lastindex(s))[1]
     c, r = test_complete(s)
     @test count(isequal("REPL"), c) == 1
     # issue #30234
@@ -1053,5 +1054,5 @@ end
 # Issue #32840
 let s = "typeof(+)."
     c, r = test_complete_context(s)
-    @test isempty(c)
+    @test length(c) == length(fieldnames(DataType))
 end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -103,7 +103,6 @@ let s = ""
 end
 
 let s = "using REP"
-    @show completions(s, lastindex(s))[1]
     c, r = test_complete(s)
     @test count(isequal("REPL"), c) == 1
     # issue #30234


### PR DESCRIPTION
Wrap its invocation here in a `try` block.  Fixes #32558