### PR TITLE
count(regex, string) computes length(findall(regex, string)) better

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ New library functions
 * `findfirst`, `findlast`, `findnext` and `findprev` now accept a character as first argument
   to search for that character in a string passed as the second argument ([#31664]).
 * New `findall(pattern, string)` method where `pattern` is a string or regex ([#31834]).
+* `count(pattern, string)` gives the number of things `findall` would match ([#32849]).
 * `istaskfailed` is now documented and exported, like its siblings `istaskdone` and `istaskstarted` ([#32300]).
 * `RefArray` and `RefValue` objects now accept index `CartesianIndex()` in  `getindex` and `setindex!` ([#32653])
 

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -46,11 +46,17 @@
     @test_throws ArgumentError match(r"test", GenericString("this is a test"))
     @test_throws ArgumentError findfirst(r"test", GenericString("this is a test"))
 
-    # findall:
+    # findall
     @test findall(r"\w+", "foo bar") == [1:3, 5:7]
     @test findall(r"\w+", "foo bar", overlap=true) == [1:3, 2:3, 3:3, 5:7, 6:7, 7:7]
     @test findall(r"\w*", "foo bar") == [1:3, 4:3, 5:7, 8:7]
     @test findall(r"\b", "foo bar") == [1:0, 4:3, 5:4, 8:7]
+
+    # count
+    @test count(r"\w+", "foo bar") == 2
+    @test count(r"\w+", "foo bar", overlap=true) == 6
+    @test count(r"\w*", "foo bar") == 4
+    @test count(r"\b", "foo bar") == 4
 
     # Named subpatterns
     let m = match(r"(?<a>.)(.)(?<b>.)", "xyz")


### PR DESCRIPTION
Sometimes you just want to count how many times something occurs. I basically just copied the `findall` method above and counted instead of pushing. It could be refactored to share logic, but that seemed like overkill.