### PR TITLE
mktemp/dir: delete temp files on exit by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@ Standard library changes
 * `nothing` can now be `print`ed, and interplated into strings etc. as the string `"nothing"`. It is still not permitted to be interplated into Cmds (i.e. ``echo `$(nothing)` `` will still error without running anything.) ([#32148])
 * When `open` is called with a function, command, and keyword argument (e.g. ```open(`ls`, read=true) do f ...```)
   it now correctly throws a `ProcessFailedException` like other similar calls ([#32193]).
+* `mktemp` and `mktempdir` now try, by default, to remove temporary paths they create before the process exits ([#32851]).
 
 #### Libdl
 

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -293,7 +293,7 @@ end
 
 ## atexit: register exit hooks ##
 
-const atexit_hooks = []
+const atexit_hooks = Callable[Filesystem.temp_cleanup_purge]
 
 """
     atexit(f)

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -29,10 +29,10 @@ Base.Filesystem.rm
 Base.Filesystem.touch
 Base.Filesystem.tempname
 Base.Filesystem.tempdir
-Base.Filesystem.mktemp(::Any)
-Base.Filesystem.mktemp(::Function, ::Any)
-Base.Filesystem.mktempdir(::Any)
-Base.Filesystem.mktempdir(::Function, ::Any)
+Base.Filesystem.mktemp(::AbstractString)
+Base.Filesystem.mktemp(::Function, ::AbstractString)
+Base.Filesystem.mktempdir(::AbstractString)
+Base.Filesystem.mktempdir(::Function, ::AbstractString)
 Base.Filesystem.isblockdev
 Base.Filesystem.ischardev
 Base.Filesystem.isdir

--- a/test/file.jl
+++ b/test/file.jl
@@ -48,6 +48,193 @@ if !Sys.iswindows()
     cd(pwd_)
 end
 
+child_eval(code::String) = eval(Meta.parse(readchomp(`$(Base.julia_cmd()) -E $code`)))
+
+@testset "mktemp/dir basic cleanup" begin
+    # mktemp without cleanup
+    t = child_eval("t = mktemp(cleanup=false)[1]; @assert isfile(t); t")
+    @test isfile(t)
+    rm(t, force=true)
+    @test !ispath(t)
+    # mktemp with cleanup
+    t = child_eval("t = mktemp()[1]; @assert isfile(t); t")
+    @test !ispath(t)
+    # mktempdir without cleanup
+    t = child_eval("t = mktempdir(cleanup=false); touch(joinpath(t, \"file.txt\")); t")
+    @test isfile("$t/file.txt")
+    rm(t, recursive=true, force=true)
+    @test !ispath(t)
+    # mktempdir with cleanup
+    t = child_eval("t = mktempdir(); touch(joinpath(t, \"file.txt\")); t")
+    @test !ispath(t)
+end
+
+import Base.Filesystem: TEMP_CLEANUP_MIN, TEMP_CLEANUP_MAX, TEMP_CLEANUP
+
+function with_temp_cleanup(f::Function, n::Int)
+    SAVE_TEMP_CLEANUP_MIN = TEMP_CLEANUP_MIN[]
+    SAVE_TEMP_CLEANUP_MAX = TEMP_CLEANUP_MAX[]
+    SAVE_TEMP_CLEANUP = copy(TEMP_CLEANUP)
+    empty!(TEMP_CLEANUP)
+    TEMP_CLEANUP_MIN[] = n
+    TEMP_CLEANUP_MAX[] = n
+    try f()
+    finally
+        Sys.iswindows() && GC.gc(true)
+        for t in keys(TEMP_CLEANUP)
+            rm(t, recursive=true, force=true)
+        end
+        copy!(TEMP_CLEANUP, SAVE_TEMP_CLEANUP)
+        TEMP_CLEANUP_MAX[] = SAVE_TEMP_CLEANUP_MAX
+        TEMP_CLEANUP_MIN[] = SAVE_TEMP_CLEANUP_MIN
+    end
+end
+
+function mktempfile(; cleanup=true)
+    (file, io) = mktemp(cleanup=cleanup)
+    Sys.iswindows() && close(io)
+    return file
+end
+
+@testset "mktemp/dir cleanup list purging" begin
+    n = 12 # cleanup min & max
+    @assert n % 2 == n % 3 == 0 # otherwise tests won't work
+    with_temp_cleanup(n) do
+        @test length(TEMP_CLEANUP) == 0
+        @test TEMP_CLEANUP_MAX[] == n
+        # for n mktemps, no purging is triggered
+        temps = String[]
+        for i = 1:n
+            t = i % 2 == 0 ? mktempfile() : mktempdir()
+            push!(temps, t)
+            @test ispath(t)
+            @test length(TEMP_CLEANUP) == i 
+            @test TEMP_CLEANUP_MAX[] == n
+            # delete 1/3 of the temp paths
+            i % 3 == 0 && rm(t, recursive=true, force=true)
+        end
+        # without cleanup no purge is triggered
+        t = mktempdir(cleanup=false)
+        @test isdir(t)
+        @test length(TEMP_CLEANUP) == n
+        @test TEMP_CLEANUP_MAX[] == n
+        rm(t, recursive=true, force=true)
+        # purge triggered by next mktemp with cleanup
+        t = mktempfile()
+        push!(temps, t)
+        n′ = 2n÷3 + 1
+        @test 2n′ > n
+        @test isfile(t)
+        @test length(TEMP_CLEANUP) == n′
+        @test TEMP_CLEANUP_MAX[] == 2n′
+        # remove all temp files
+        for t in temps
+            rm(t, recursive=true, force=true)
+        end
+        # for n′ mktemps, no purging is triggered
+        for i = 1:n′
+            t = i % 2 == 0 ? mktempfile() : mktempdir()
+            push!(temps, t)
+            @test ispath(t)
+            @test length(TEMP_CLEANUP) == n′ + i
+            @test TEMP_CLEANUP_MAX[] == 2n′
+            # delete 2/3 of the temp paths
+            i % 3 != 0 && rm(t, recursive=true, force=true)
+        end
+        # without cleanup no purge is triggered
+        t = mktempfile(cleanup=false)
+        @test isfile(t)
+        @test length(TEMP_CLEANUP) == 2n′
+        @test TEMP_CLEANUP_MAX[] == 2n′
+        rm(t, force=true)
+        # purge triggered by next mktemp
+        t = mktempdir()
+        push!(temps, t)
+        n′′ = n′÷3 + 1
+        @test 2n′′ < n
+        @test isdir(t)
+        @test length(TEMP_CLEANUP) == n′′
+        @test TEMP_CLEANUP_MAX[] == n
+    end
+end
+
+no_error_logging(f::Function) =
+    Base.CoreLogging.with_logger(f, Base.CoreLogging.NullLogger())
+
+@testset "hof mktemp/dir when cleanup is prevented" begin
+    d = mktempdir()
+    with_temp_cleanup(3) do
+        @test length(TEMP_CLEANUP) == 0
+        @test TEMP_CLEANUP_MAX[] == 3
+        local t, f
+        temps = String[]
+        # mktemp is normally cleaned up on completion
+        mktemp(d) do path, _
+            @test isfile(path)
+            t = path
+        end
+        @test !ispath(t)
+        @test length(TEMP_CLEANUP) == 0
+        @test TEMP_CLEANUP_MAX[] == 3
+        # mktemp when cleanup is prevented
+        no_error_logging() do
+            mktemp(d) do path, _
+                @test isfile(path)
+                f = open(path) # make undeletable on Windows
+                chmod(d, 0o400) # make undeletable on UNIX
+                t = path
+            end
+        end
+        chmod(d, 0o700)
+        close(f)
+        @test isfile(t)
+        @test length(TEMP_CLEANUP) == 1
+        @test TEMP_CLEANUP_MAX[] == 3
+        push!(temps, t)
+        # mktempdir is normally cleaned up on completion
+        mktempdir(d) do path
+            @test isdir(path)
+            t = path
+        end
+        @test !ispath(t)
+        @test length(TEMP_CLEANUP) == 1
+        @test TEMP_CLEANUP_MAX[] == 3
+        # mktempdir when cleanup is prevented
+        no_error_logging() do
+            mktempdir(d) do path
+                @test isdir(path)
+                # make undeletable on Windows:
+                f = open(joinpath(path, "file.txt"), "w+")
+                chmod(d, 0o400) # make undeletable on UNIX
+                t = path
+            end
+        end
+        chmod(d, 0o700)
+        close(f)
+        @test isdir(t)
+        @test length(TEMP_CLEANUP) == 2
+        @test TEMP_CLEANUP_MAX[] == 3
+        push!(temps, t)
+        # make one more temp file
+        t = mktemp()[1]
+        @test isfile(t)
+        @test length(TEMP_CLEANUP) == 3
+        @test TEMP_CLEANUP_MAX[] == 3
+        # nothing has been deleted yet
+        for t in temps
+            @test ispath(t)
+        end
+        # another temp file triggers purge
+        t = mktempdir()
+        @test isdir(t)
+        @test length(TEMP_CLEANUP) == 2
+        @test TEMP_CLEANUP_MAX[] == 4
+        # now all the temps are gone
+        for t in temps
+            @test !ispath(t)
+        end
+    end
+end
 
 #######################################################################
 # This section tests some of the features of the stat-based file info #


### PR DESCRIPTION
An alternative to #32335. Still needs tests and NEWS, which can maybe be taken from there. Sorry to snipe your PR, @DilumAluthge 😬

Instead of putting lots of atexit handlers in the list, this uses a single one and keeps a list of temporary paths to cleanup. If the list gets long (≥ 1024) it will be scanned for already-deleted paths when adding a new path to the cleanup list. To avoid running too frequently, it doubles the "too many paths" threshold after this.

Needs the generate_precompile improvements in #32850 which in turn needs the `count(regex, string)` method added in #32849. A yak shave in chained pull request form.