### PR TITLE
Fix a typo in mathematical-operations.md

### DIFF
--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -252,7 +252,7 @@ julia> NaN > NaN
 false
 ```
 
-and can cause especial headaches with [arrays](@ref man-multi-dim-arrays):
+and can cause headaches when working with [arrays](@ref man-multi-dim-arrays):
 
 ```jldoctest
 julia> [1 NaN] == [1 NaN]


### PR DESCRIPTION
"Especial" isn't an English word. I tried replacing it with the correct "especially", but I think it sounds cleaner this way.