### PR TITLE
NEWS: move sincosd entry to the correct section

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,6 @@ New language features
 
 * Support for Unicode 12.1.0 ([#32002]).
 * Methods can now be added to an abstract type ([#31916]).
-* Added `sincosd(x)` to simultaneously compute the sine and cosine of `x`, where `x` is in degrees ([#30134]).
 
 Language changes
 ----------------
@@ -35,6 +34,7 @@ New library functions
 * `count(pattern, string)` gives the number of things `findall` would match ([#32849]).
 * `istaskfailed` is now documented and exported, like its siblings `istaskdone` and `istaskstarted` ([#32300]).
 * `RefArray` and `RefValue` objects now accept index `CartesianIndex()` in  `getindex` and `setindex!` ([#32653])
+* Added `sincosd(x)` to simultaneously compute the sine and cosine of `x`, where `x` is in degrees ([#30134]).
 
 Standard library changes
 ------------------------


### PR DESCRIPTION
This is a new library function, not a new language feature.