### PR TITLE
fix ALWAYS_COPY_STACKS with threads

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -125,6 +125,9 @@ JL_DLLEXPORT void jl_free_stack(void *stkbuf, size_t bufsz)
 
 void jl_release_task_stack(jl_ptls_t ptls, jl_task_t *task)
 {
+    // avoid adding an original thread stack to the free list
+    if (task == ptls->root_task && !task->copy_stack)
+        return;
     void *stkbuf = task->stkbuf;
     size_t bufsz = task->bufsz;
     if (bufsz <= pool_sizes[JL_N_STACK_POOLS - 1]) {

--- a/src/init.c
+++ b/src/init.c
@@ -89,7 +89,7 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
         pthread_attr_getstack(&attr, &stackaddr, &stacksize);
         pthread_attr_destroy(&attr);
         *stack_lo = (void*)stackaddr;
-        *stack_hi = (void*)((char*)stackaddr + stacksize);
+        *stack_hi = (void*)&stacksize;
         return;
 #  elif defined(_OS_DARWIN_)
         extern void *pthread_get_stackaddr_np(pthread_t thread);
@@ -97,8 +97,8 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
         pthread_t thread = pthread_self();
         void *stackaddr = pthread_get_stackaddr_np(thread);
         size_t stacksize = pthread_get_stacksize_np(thread);
-        *stack_lo = (char*)stackaddr;
-        *stack_hi = (void*)((char*)stackaddr + stacksize);
+        *stack_lo = (void*)stackaddr;
+        *stack_hi = (void*)&stacksize;
         return;
 #  elif defined(_OS_FREEBSD_)
         pthread_attr_t attr;
@@ -108,8 +108,8 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
         size_t stacksize;
         pthread_attr_getstack(&attr, &stackaddr, &stacksize);
         pthread_attr_destroy(&attr);
-        *stack_lo = (char*)stackaddr;
-        *stack_hi = (void*)((char*)stackaddr + stacksize);
+        *stack_lo = (void*)stackaddr;
+        *stack_hi = (void*)&stacksize;
         return;
 #  else
 #      warning "Getting precise stack size for thread is not supported."
@@ -117,9 +117,9 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
     }
     struct rlimit rl;
     getrlimit(RLIMIT_STACK, &rl);
-    size_t stack_size = rl.rlim_cur;
-    *stack_hi = (void*)&stack_size;
-    *stack_lo = (void*)((char*)*stack_hi - stack_size);
+    size_t stacksize = rl.rlim_cur;
+    *stack_hi = (void*)&stacksize;
+    *stack_lo = (void*)((char*)*stack_hi - stacksize);
 #endif
 }
 


### PR DESCRIPTION
`ALWAYS_COPY_STACKS` was crashing with multiple threads, e.g. on my favorite program:
```
function pfib(n::Int)
    if n <= 1
        return n
    end
    t = Threads.@spawn pfib(n-2)
    return pfib(n-1) + fetch(t)::Int
end

@time pfib(31)
```

This was because we directly used the stack extents returned by pthreads. In fact, the top of the stack area is used for thread-local values and the area actually usable as stack is lower, causing stack copying to clobber data.

I assumed the same fix is needed on all Unices, but I'm not sure. Also might be needed on windows.