### PR TITLE
Fix linkage to eval section

### DIFF
--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -348,7 +348,7 @@ QuoteNode
 
 `QuoteNode` can also be used for certain advanced metaprogramming tasks.
 
-### [`eval`](@ref) and effects
+### Evaluating expressions
 
 Given an expression object, one can cause Julia to evaluate (execute) it at global scope using
 [`eval`](@ref):


### PR DESCRIPTION
Removing the reference to `eval` in order to fix the link to the section.  There's already another link to the `eval` function in the first sentence so there is no need to have another one in the header.