### PR TITLE
Use .category to pick admonition color in terminal

### DIFF
--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -34,13 +34,13 @@ end
 function term(io::IO, md::Admonition, columns)
     col = :default
     # If the types below are modified, the page manual/documentation.md must be updated accordingly.
-    if lowercase(md.title) == "danger"
+    if md.category == "danger"
         col = Base.error_color()
-    elseif lowercase(md.title) == "warning"
+    elseif md.category == "warning"
         col = Base.warn_color()
-    elseif lowercase(md.title) in ("info", "note")
+    elseif md.category in ("info", "note")
         col = Base.info_color()
-    elseif lowercase(md.title) == "tip"
+    elseif md.category == "tip"
         col = :green
     end
     printstyled(io, ' '^margin, "│ "; color=col, bold=true)


### PR DESCRIPTION
Currently, admonitions like this

```
julia> using Markdown

julia> md"""
       !!! note "Note this!"

       !!! danger "Note"
       """
```

do not get colored correctly when printing in the terminal / docstrings (first stays white, second gets the color of a note). As [per the manual](https://docs.julialang.org/en/v1.3-dev/stdlib/Markdown/#Admonitions-1) the admonition type/category should be used to determine its styling. Here's a before (left) and after (right):

![Screenshot from 2019-08-11 16-25-03](https://user-images.githubusercontent.com/147757/62829562-badf9380-bc54-11e9-9e20-94e8f683f639.png)

