### PR TITLE
Improve message error in broadcast: "arrays could not be broadcast to a common size"

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -479,10 +479,10 @@ function _bcs(shape::Tuple, newshape::Tuple)
     return (_bcs1(shape[1], newshape[1]), _bcs(tail(shape), tail(newshape))...)
 end
 # _bcs1 handles the logic for a single dimension
-_bcs1(a::Integer, b::Integer) = a == 1 ? b : (b == 1 ? a : (a == b ? a : throw(DimensionMismatch("arrays could not be broadcast to a common size"))))
-_bcs1(a::Integer, b) = a == 1 ? b : (first(b) == 1 && last(b) == a ? b : throw(DimensionMismatch("arrays could not be broadcast to a common size")))
+_bcs1(a::Integer, b::Integer) = a == 1 ? b : (b == 1 ? a : (a == b ? a : throw(DimensionMismatch("arrays could not be broadcast to a common size; computed a dimension with lengths $(length(a)) and $(length(b))"))))
+_bcs1(a::Integer, b) = a == 1 ? b : (first(b) == 1 && last(b) == a ? b : throw(DimensionMismatch("arrays could not be broadcast to a common size; computed a dimension with lengths $(length(a)) and $(length(b))")))
 _bcs1(a, b::Integer) = _bcs1(b, a)
-_bcs1(a, b) = _bcsm(b, a) ? axistype(b, a) : (_bcsm(a, b) ? axistype(a, b) : throw(DimensionMismatch("arrays could not be broadcast to a common size")))
+_bcs1(a, b) = _bcsm(b, a) ? axistype(b, a) : (_bcsm(a, b) ? axistype(a, b) : throw(DimensionMismatch("arrays could not be broadcast to a common size; computed a dimension with lengths $(length(a)) and $(length(b))")))
 # _bcsm tests whether the second index is consistent with the first
 _bcsm(a, b) = a == b || length(b) == 1
 _bcsm(a, b::Number) = b == 1


### PR DESCRIPTION
Following suggestion from ##30438, I have update messages indicating the distance. Now the error message is:

"arrays could not be broadcast to a common size; computed a dimension with lengths $(length(a)) and $(length(b))"

I consider that good error messages is very important for the user-friendliness. I have suffered the previous error message, and in my opinion it should be changed. 

In #30438 it was suggested to use directly "$a", not "$(length(a))", but in that case it always said Base.OneTo(X) and with length says directly "X". 