### PR TITLE
Add Channel constructor keyword argument to `@spawn` new Task in parallel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,10 +20,11 @@ Multi-threading changes
   ([#32309], [#32174], [#31981], [#32421]).
 * The global random number generator (`GLOBAL_RNG`) is now thread-safe (and thread-local) ([#32407]).
 * New experimental `Threads.@spawn` macro that runs a task on any available thread ([#32600]).
-* New `Channel(f::Function)` constructor param (`spawn=true`) to schedule created Task on
-  any available thread ([#32872]). Also simplified the `Channel` constructor, which is now
-  easier to read and more idiomatic julia. The old constructor (which used kwargs) is still
-  available, but use is discouraged ([#30855], [#32818]).
+* New `Channel(f::Function)` constructor param (`spawn=true`) to schedule the created Task on
+  any available thread, matching the behavior of `Threads.@spawn` ([#32872]).
+* Simplified the `Channel` constructor, which is now easier to read and more idiomatic julia.
+  The old constructor (which used keyword arguments) is still available, but use is discouraged.
+  ([#30855], [#32818]).
 
 Build system changes
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,8 +20,10 @@ Multi-threading changes
   ([#32309], [#32174], [#31981], [#32421]).
 * The global random number generator (`GLOBAL_RNG`) is now thread-safe (and thread-local) ([#32407]).
 * New experimental `Threads.@spawn` macro that runs a task on any available thread ([#32600]).
-* Simplified the `Channel` constructor, which is now easier to read and more idiomatic julia.
-  The old constructor (which used kwargs) is still available, but use is discouraged ([#30855], [#32818]).
+* New `Channel(f::Function)` constructor param (`spawn=true`) to schedule created Task on
+  any available thread ([#32872]). Also simplified the `Channel` constructor, which is now
+  easier to read and more idiomatic julia. The old constructor (which used kwargs) is still
+  available, but use is discouraged ([#30855], [#32818]).
 
 Build system changes
 --------------------

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -55,7 +55,7 @@ Channel(sz=0) = Channel{Any}(sz)
 
 # special constructors
 """
-    Channel{T=Any}(func::Function, size=0; taskref=nothing)
+    Channel{T=Any}(func::Function, size=0; taskref=nothing, spawn=false)
 
 Create a new task from `func`, bind it to a new channel of type
 `T` and size `size`, and schedule the task, all in a single call.
@@ -64,6 +64,9 @@ Create a new task from `func`, bind it to a new channel of type
 
 If you need a reference to the created task, pass a `Ref{Task}` object via
 the keyword argument `taskref`.
+
+If `spawn = true`, the Task created for `func` may be scheduled on another thread
+in parallel, equivalent to creating a task via `Threads.@spawn`.
 
 Return a `Channel`.
 
@@ -105,11 +108,12 @@ true
 ```
 
 !!! compat "Julia 1.3"
-  This constructor was added in Julia 1.3. Earlier versions of Julia used kwargs
-  to set `size` and `T`, but those constructors are deprecated.
+  The `spawn=` parameter was added in Julia 1.3. This constructor was added in Julia 1.3.
+  Earlier versions of Julia used kwargs to set `size` and `T`, but those constructors are
+  deprecated.
 
 ```jldoctest
-julia> chnl = Channel{Char}(1) do ch
+julia> chnl = Channel{Char}(1, spawn=true) do ch
            for c in "hello world"
                put!(ch, c)
            end
@@ -120,12 +124,16 @@ julia> String(collect(chnl))
 "hello world"
 ```
 """
-function Channel{T}(func::Function, size=0; taskref=nothing) where T
+function Channel{T}(func::Function, size=0; taskref=nothing, spawn=false) where T
     chnl = Channel{T}(size)
     task = Task(() -> func(chnl))
+    task.sticky = !spawn
     bind(chnl, task)
-    yield(task) # immediately start it
-
+    if spawn
+        schedule(task) # start it on (potentially) another thread
+    else
+        yield(task) # immediately start it, yielding the current thread
+    end
     isa(taskref, Ref{Task}) && (taskref[] = task)
     return chnl
 end

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -66,7 +66,7 @@ If you need a reference to the created task, pass a `Ref{Task}` object via
 the keyword argument `taskref`.
 
 If `spawn = true`, the Task created for `func` may be scheduled on another thread
-in parallel, equivalent to creating a task via `Threads.@spawn`.
+in parallel, equivalent to creating a task via [`Threads.@spawn`](@ref).
 
 Return a `Channel`.
 
@@ -108,7 +108,7 @@ true
 ```
 
 !!! compat "Julia 1.3"
-  The `spawn=` parameter was added in Julia 1.3. This constructor was added in Julia 1.3.
+  The `spawn` keyword argument was added in Julia 1.3. This constructor was added in Julia 1.3.
   Earlier versions of Julia used kwargs to set `size` and `T`, but those constructors are
   deprecated.
 

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -108,9 +108,9 @@ true
 ```
 
 !!! compat "Julia 1.3"
-  The `spawn` keyword argument was added in Julia 1.3. This constructor was added in Julia 1.3.
-  Earlier versions of Julia used kwargs to set `size` and `T`, but those constructors are
-  deprecated.
+  The `spawn=` parameter was added in Julia 1.3. This constructor was added in Julia 1.3.
+  In earlier versions of Julia, Channel used keyword arguments to set `size` and `T`, but
+  those constructors are deprecated.
 
 ```jldoctest
 julia> chnl = Channel{Char}(1, spawn=true) do ch
@@ -140,6 +140,8 @@ end
 Channel(func::Function, args...; kwargs...) = Channel{Any}(func, args...; kwargs...)
 
 # This constructor is deprecated as of Julia v1.3, and should not be used.
+# (Note that this constructor also matches `Channel(::Function)` w/out any kwargs, which is
+# of course not deprecated.)
 function Channel(func::Function; ctype=Any, csize=0, taskref=nothing)
     return Channel{ctype}(func, csize; taskref=taskref)
 end

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -76,6 +76,13 @@ end
     @test isopen(c)
     @test collect(c) == 1:100
 end
+@testset "Multithreaded task constructors" begin
+    taskref = Ref{Task}()
+    c = Channel(spawn=true, taskref=taskref) do c; put!(c, 0); end
+    # Test that the task is using the multithreaded scheduler
+    @test taskref[].sticky == false
+    @test collect(c) == [0]
+end
 
 @testset "multiple concurrent put!/take! on a channel for different sizes" begin
     function testcpt(sz)


### PR DESCRIPTION
Adds a `spawn=` keyword argument to `Channel()`, which  causes the new `Task` created for the provided `func` to be scheduled on any thread, in parallel, equivalent to creating the task via `@spawn`.

Defaults to false for backwards compatability.

This adds the param to the new constructor added in #32818, and updates the NEWS item.