### PR TITLE
Ensure concurrency_violation is available in Threads

### DIFF
--- a/base/threads.jl
+++ b/base/threads.jl
@@ -5,6 +5,8 @@ Experimental multithreading support.
 """
 module Threads
 
+using .Base: concurrency_violation
+
 global Condition # we'll define this later, make sure we don't import Base.Condition
 
 include("threadingconstructs.jl")

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -672,3 +672,16 @@ let ch = Channel{Char}(0), t
     schedule(t)
     @test String(collect(ch)) == "hello"
 end
+
+@testset "Issue #32873" begin
+    m = Mutex()
+    try
+        lock(m)
+        lock(m)
+    catch ex
+        @test ex isa ErrorException
+        @test occursin("concurrency violation detected", sprint(showerror, ex))
+    finally
+        unlock(m)
+    end
+end


### PR DESCRIPTION
The `concurrency_violation` function is defined in Base and referenced unqualified in the Threads submodule, which means that instead of actually getting a concurrency violation error, you get an `UndefVarError` regarding `concurrency_violation`.

Fixes #32873.