### PR TITLE
Add eachrow, eachcol, and eachslice to manual

### DIFF
--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -159,6 +159,9 @@ Base.rot180
 Base.rotl90
 Base.rotr90
 Base.mapslices
+Base.eachrow
+Base.eachcol
+Base.eachslice
 ```
 
 ## Combinatorics


### PR DESCRIPTION
These functions are all nicely documented but don't seem to appear in the manual.

Doesn't the documenter CI check the exports against the documented functions?  Or didn't it do that at some point in the past?  Am I missing it somewhere?  Or can we get it back?