### PR TITLE
bugfixes in Libc.rand for Windows

### DIFF
--- a/base/libc.jl
+++ b/base/libc.jl
@@ -386,7 +386,7 @@ rand() = ccall(:rand, Cint, ())
     # Windows RAND_MAX is 2^15-1
     rand(::Type{UInt32}) = ((rand() % UInt32) << 17) ⊻ ((rand() % UInt32) << 8) ⊻ (rand() % UInt32)
 else
-    # RAND_MAX at least 2^15-1 in theory, but we assume 2^16-1
+    # RAND_MAX is at least 2^15-1 in theory, but we assume 2^16-1
     # on non-Windows systems (in practice, it's 2^31-1)
     rand(::Type{UInt32}) = ((rand() % UInt32) << 16) ⊻ (rand() % UInt32)
 end

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -382,9 +382,15 @@ Interface to the C `rand()` function. If `T` is provided, generate a value of ty
 by composing two calls to `rand()`. `T` can be `UInt32` or `Float64`.
 """
 rand() = ccall(:rand, Cint, ())
-# RAND_MAX at least 2^15-1 in theory, but we assume 2^16-1 (in practice, it's 2^31-1)
-rand(::Type{UInt32}) = ((rand() % UInt32) << 16) ⊻ (rand() % UInt32)
-rand(::Type{Float64}) = rand(UInt32) / 2^32
+@static if Sys.iswindows()
+    # Windows RAND_MAX is 2^15-1
+    rand(::Type{UInt32}) = ((rand() % UInt32) << 17) ⊻ ((rand() % UInt32) << 8) ⊻ (rand() % UInt32)
+else
+    # RAND_MAX at least 2^15-1 in theory, but we assume 2^16-1
+    # on non-Windows systems (in practice, it's 2^31-1)
+    rand(::Type{UInt32}) = ((rand() % UInt32) << 16) ⊻ (rand() % UInt32)
+end
+rand(::Type{Float64}) = rand(UInt32) * 2.0^-32
 
 """
     srand([seed])

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -733,5 +733,12 @@ end
     @test sort([a, b]) == [b, a]
 end
 
+@testset "Libc.rand" begin
+    low, high = extrema(Libc.rand(Float64) for i=1:10^4)
+    # these fail with probability 2^(-10^4) ≈ 5e-3011
+    @test 0 ≤ low < 0.5
+    @test 0.5 < high < 1
+end
+
 # Pointer 0-arg constructor
 @test Ptr{Cvoid}() == C_NULL


### PR DESCRIPTION
Fixes a bug noted by @mschauer in https://github.com/JuliaLang/julia/issues/32894#issuecomment-521284511, which seems to originate in #24874 by @rfourquet, where the code used a `/ 2^32` expression that overflows on 32-bit machines.  This PR uses `* 2.0^-32` instead, which constant folds and is exact in `Float64`.

Also fixes another problem in the same code on Windows — the code assumed that `RAND_MAX` is at least `2^16-1`, which seems to be true on supported Unix systems (GNU and BSD), but [on Windows](https://docs.microsoft.com/en-us/previous-versions/398ax69y(v%3Dvs.140)) it is `2^15-1` so we need a third `rand` call to get 32 bits of randomness (or "randomness"). 