### PR TITLE
5-arg mul! bug fixes

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -395,6 +395,7 @@ function A_mul_B_td!(C::AbstractMatrix, A::BiTriSym, B::BiTriSym,
     # `_modify!` in the following loop will not update the
     # off-diagonal elements for non-zero beta.
     _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return C
     Al = _diag(A, -1)
     Ad = _diag(A, 0)
     Au = _diag(A, 1)
@@ -449,6 +450,7 @@ function A_mul_B_td!(C::AbstractMatrix, A::BiTriSym, B::Diagonal,
     n = size(A,1)
     n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
     _rmul_or_fill!(C, _add.beta)  # see the same use above
+    iszero(_add.alpha) && return C
     Al = _diag(A, -1)
     Ad = _diag(A, 0)
     Au = _diag(A, 1)
@@ -489,6 +491,7 @@ function A_mul_B_td!(C::AbstractVecOrMat, A::BiTriSym, B::AbstractVecOrMat,
     if size(C,2) != nB
         throw(DimensionMismatch("A has second dimension $nA, B has $(size(B,2)), C has $(size(C,2)) but all must match"))
     end
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     nA <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
     l = _diag(A, -1)
     d = _diag(A, 0)
@@ -510,6 +513,7 @@ end
 function A_mul_B_td!(C::AbstractMatrix, A::AbstractMatrix, B::BiTriSym,
                      _add::MulAddMul = MulAddMul())
     check_A_mul_B!_sizes(C, A, B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     n = size(A,1)
     n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
     m = size(B,2)
@@ -545,6 +549,7 @@ function A_mul_B_td!(C::AbstractMatrix, A::Diagonal, B::BiTriSym,
     n = size(A,1)
     n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
     _rmul_or_fill!(C, _add.beta)  # see the same use above
+    iszero(_add.alpha) && return C
     Ad = A.diag
     Bl = _diag(B, -1)
     Bd = _diag(B, 0)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -457,24 +457,24 @@ function A_mul_B_td!(C::AbstractMatrix, A::BiTriSym, B::Diagonal,
     Bd = B.diag
     @inbounds begin
         # first row of C
-        _modify!(_add, A[1,1]*B[1,1], C, (1,1))
-        _modify!(_add, A[1,2]*B[2,2], C, (1,2))
+        C[1,1] += _add(A[1,1]*B[1,1])
+        C[1,2] += _add(A[1,2]*B[2,2])
         # second row of C
-        _modify!(_add, A[2,1]*B[1,1], C, (2,1))
-        _modify!(_add, A[2,2]*B[2,2], C, (2,2))
-        _modify!(_add, A[2,3]*B[3,3], C, (2,3))
+        C[2,1] += _add(A[2,1]*B[1,1])
+        C[2,2] += _add(A[2,2]*B[2,2])
+        C[2,3] += _add(A[2,3]*B[3,3])
         for j in 3:n-2
-            _modify!(_add, Al[j-1]*Bd[j-1], C, (j, j-1))
-            _modify!(_add, Ad[j  ]*Bd[j  ], C, (j, j  ))
-            _modify!(_add, Au[j  ]*Bd[j+1], C, (j, j+1))
+            C[j, j-1] += _add(Al[j-1]*Bd[j-1])
+            C[j, j  ] += _add(Ad[j  ]*Bd[j  ])
+            C[j, j+1] += _add(Au[j  ]*Bd[j+1])
         end
         # row before last of C
-        _modify!(_add, A[n-1,n-2]*B[n-2,n-2], C, (n-1,n-2))
-        _modify!(_add, A[n-1,n-1]*B[n-1,n-1], C, (n-1,n-1))
-        _modify!(_add, A[n-1,  n]*B[n  ,n  ], C, (n-1,n  ))
+        C[n-1,n-2] += _add(A[n-1,n-2]*B[n-2,n-2])
+        C[n-1,n-1] += _add(A[n-1,n-1]*B[n-1,n-1])
+        C[n-1,n  ] += _add(A[n-1,  n]*B[n  ,n  ])
         # last row of C
-        _modify!(_add, A[n,n-1]*B[n-1,n-1], C, (n,n-1))
-        _modify!(_add, A[n,n  ]*B[n,  n  ], C, (n,n  ))
+        C[n,n-1] += _add(A[n,n-1]*B[n-1,n-1])
+        C[n,n  ] += _add(A[n,n  ]*B[n,  n  ])
     end # inbounds
     C
 end

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -447,8 +447,8 @@ function A_mul_B_td!(C::AbstractMatrix, A::BiTriSym, B::Diagonal,
                      _add::MulAddMul = MulAddMul())
     check_A_mul_B!_sizes(C, A, B)
     n = size(A,1)
-    n <= 3 && return mul!(C, Array(A), Array(B))
-    fill!(C, zero(eltype(C)))
+    n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
+    _rmul_or_fill!(C, _add.beta)  # see the same use above
     Al = _diag(A, -1)
     Ad = _diag(A, 0)
     Au = _diag(A, 1)
@@ -542,8 +542,8 @@ end
 function A_mul_B_td!(C::AbstractMatrix, A::Diagonal, B::BiTriSym)
     check_A_mul_B!_sizes(C, A, B)
     n = size(A,1)
-    n <= 3 && return mul!(C, Array(A), Array(B))
-    fill!(C, zero(eltype(C)))
+    n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
+    _rmul_or_fill!(C, _add.beta)  # see the same use above
     Ad = A.diag
     Bl = _diag(B, -1)
     Bd = _diag(B, 0)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -556,25 +556,25 @@ function A_mul_B_td!(C::AbstractMatrix, A::Diagonal, B::BiTriSym,
     Bu = _diag(B, 1)
     @inbounds begin
         # first row of C
-        C[1,1] = A[1,1]*B[1,1]
-        C[1,2] = A[1,1]*B[1,2]
+        C[1,1] += _add(A[1,1]*B[1,1])
+        C[1,2] += _add(A[1,1]*B[1,2])
         # second row of C
-        C[2,1] = A[2,2]*B[2,1]
-        C[2,2] = A[2,2]*B[2,2]
-        C[2,3] = A[2,2]*B[2,3]
+        C[2,1] += _add(A[2,2]*B[2,1])
+        C[2,2] += _add(A[2,2]*B[2,2])
+        C[2,3] += _add(A[2,2]*B[2,3])
         for j in 3:n-2
             Ajj       = Ad[j]
-            C[j, j-1] = Ajj*Bl[j-1]
-            C[j, j  ] = Ajj*Bd[j]
-            C[j, j+1] = Ajj*Bu[j]
+            C[j, j-1] += _add(Ajj*Bl[j-1])
+            C[j, j  ] += _add(Ajj*Bd[j])
+            C[j, j+1] += _add(Ajj*Bu[j])
         end
         # row before last of C
-        C[n-1,n-2] = A[n-1,n-1]*B[n-1,n-2]
-        C[n-1,n-1] = A[n-1,n-1]*B[n-1,n-1]
-        C[n-1,n  ] = A[n-1,n-1]*B[n-1,n  ]
+        C[n-1,n-2] += _add(A[n-1,n-1]*B[n-1,n-2])
+        C[n-1,n-1] += _add(A[n-1,n-1]*B[n-1,n-1])
+        C[n-1,n  ] += _add(A[n-1,n-1]*B[n-1,n  ])
         # last row of C
-        C[n,n-1] = A[n,n]*B[n,n-1]
-        C[n,n  ] = A[n,n]*B[n,n  ]
+        C[n,n-1] += _add(A[n,n]*B[n,n-1])
+        C[n,n  ] += _add(A[n,n]*B[n,n  ])
     end # inbounds
     C
 end

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -539,7 +539,8 @@ function A_mul_B_td!(C::AbstractMatrix, A::AbstractMatrix, B::BiTriSym,
     C
 end
 
-function A_mul_B_td!(C::AbstractMatrix, A::Diagonal, B::BiTriSym)
+function A_mul_B_td!(C::AbstractMatrix, A::Diagonal, B::BiTriSym,
+                     _add::MulAddMul = MulAddMul())
     check_A_mul_B!_sizes(C, A, B)
     n = size(A,1)
     n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -515,8 +515,10 @@ function A_mul_B_td!(C::AbstractMatrix, A::AbstractMatrix, B::BiTriSym,
     check_A_mul_B!_sizes(C, A, B)
     iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     n = size(A,1)
-    n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
     m = size(B,2)
+    if n <= 3 || m <= 1
+        return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
+    end
     Bl = _diag(B, -1)
     Bd = _diag(B, 0)
     Bu = _diag(B, 1)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -282,76 +282,78 @@ end
 # inside this function.
 _scaledout(out, beta) = iszero(beta) ? false : broadcasted(*, out, beta)
 
+_strong0(alpha) = iszero(alpha) ? false : alpha
+
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
 @inline mul!(out::AbstractVector, A::Diagonal, in::AbstractVector,
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* alpha .+ _scaledout(out, beta)
+    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractVector, A::Adjoint{<:Any,<:Diagonal}, in::AbstractVector,
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractVector, A::Transpose{<:Any,<:Diagonal}, in::AbstractVector,
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 
 @inline mul!(out::AbstractMatrix, A::Diagonal, in::StridedMatrix,
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* alpha .+ _scaledout(out, beta)
+    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::StridedMatrix,
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::StridedMatrix,
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 
 @inline mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* alpha
+    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 
 @inline mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* alpha .+ _scaledout(out, beta)
+    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* alpha .+ _scaledout(out, beta)
+    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
 
 @inline mul!(out::AbstractMatrix, in::StridedMatrix, A::Diagonal,
              alpha::Number, beta::Number) =
-    out .= in .* permutedims(A.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* permutedims(A.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, in::StridedMatrix, A::Adjoint{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* adjoint(A.parent.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* adjoint(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, in::StridedMatrix, A::Transpose{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* transpose(A.parent.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* transpose(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 
 @inline mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Diagonal,
              alpha::Number, beta::Number) =
-    out .= in .* permutedims(A.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* permutedims(A.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* adjoint(A.parent.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* adjoint(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* transpose(A.parent.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* transpose(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 
 @inline mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Diagonal,
              alpha::Number, beta::Number) =
-    out .= in .* permutedims(A.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* permutedims(A.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* adjoint(A.parent.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* adjoint(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 @inline mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* transpose(A.parent.diag) .* alpha .+ _scaledout(out, beta)
+    out .= in .* transpose(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
 
 # ambiguities with Symmetric/Hermitian
 # RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose
@@ -382,11 +384,11 @@ mul!(C::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:Rea
 @inline mul!(C::AbstractMatrix,
              A::Adjoint{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:RealHermSymComplexSym},
              alpha::Number, beta::Number) =
-    C .= adjoint.(A.parent.diag) .* B .* alpha .+ C .* beta
+    C .= adjoint.(A.parent.diag) .* B .* _strong0(alpha) .+ _scaledout(C, beta)
 @inline mul!(C::AbstractMatrix,
              A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:RealHermSymComplexHerm},
              alpha::Number, beta::Number) =
-    C .= transpose.(A.parent.diag) .* B .* alpha .+ C .* beta
+    C .= transpose.(A.parent.diag) .* B .* _strong0(alpha) .+ _scaledout(C, beta)
 
 (/)(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag)
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -277,83 +277,83 @@ function rmul!(A::AbstractMatrix, transB::Transpose{<:Any,<:Diagonal})
 end
 
 # Elements of `out` may not be defined (e.g., for `BigFloat`). To make
-# `mul!(out, A, B)` work for such cases, `_scaledout` short-circuits
+# `mul!(out, A, B)` work for such cases, `out .*ₛ beta` short-circuits
 # `out * beta`.  Using `broadcasted` to avoid the multiplication
 # inside this function.
-_scaledout(out, beta) = iszero(beta) ? false : broadcasted(*, out, beta)
-
-_strong0(alpha) = iszero(alpha) ? false : alpha
+function *ₛ end
+Broadcast.broadcasted(::typeof(*ₛ), out, beta) =
+    iszero(beta::Number) ? false : broadcasted(*, out, beta)
 
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
 @inline mul!(out::AbstractVector, A::Diagonal, in::AbstractVector,
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (A.diag .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractVector, A::Adjoint{<:Any,<:Diagonal}, in::AbstractVector,
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (adjoint.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractVector, A::Transpose{<:Any,<:Diagonal}, in::AbstractVector,
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (transpose.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 
 @inline mul!(out::AbstractMatrix, A::Diagonal, in::StridedMatrix,
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (A.diag .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::StridedMatrix,
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (adjoint.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::StridedMatrix,
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (transpose.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 
 @inline mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (A.diag .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (adjoint.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (transpose.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 
 @inline mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= A.diag .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (A.diag .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= adjoint.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (adjoint.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix},
              alpha::Number, beta::Number) =
-    out .= transpose.(A.parent.diag) .* in .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (transpose.(A.parent.diag) .* in) .*ₛ alpha .+ out .*ₛ beta
 
 @inline mul!(out::AbstractMatrix, in::StridedMatrix, A::Diagonal,
              alpha::Number, beta::Number) =
-    out .= in .* permutedims(A.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* permutedims(A.diag)) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, in::StridedMatrix, A::Adjoint{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* adjoint(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* adjoint(A.parent.diag)) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, in::StridedMatrix, A::Transpose{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* transpose(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* transpose(A.parent.diag)) .*ₛ alpha .+ out .*ₛ beta
 
 @inline mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Diagonal,
              alpha::Number, beta::Number) =
-    out .= in .* permutedims(A.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* permutedims(A.diag)) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* adjoint(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* adjoint(A.parent.diag)) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* transpose(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* transpose(A.parent.diag)) .*ₛ alpha .+ out .*ₛ beta
 
 @inline mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Diagonal,
              alpha::Number, beta::Number) =
-    out .= in .* permutedims(A.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* permutedims(A.diag)) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* adjoint(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* adjoint(A.parent.diag)) .*ₛ alpha .+ out .*ₛ beta
 @inline mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal},
              alpha::Number, beta::Number) =
-    out .= in .* transpose(A.parent.diag) .* _strong0(alpha) .+ _scaledout(out, beta)
+    out .= (in .* transpose(A.parent.diag)) .*ₛ alpha .+ out .*ₛ beta
 
 # ambiguities with Symmetric/Hermitian
 # RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose
@@ -384,11 +384,11 @@ mul!(C::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:Rea
 @inline mul!(C::AbstractMatrix,
              A::Adjoint{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:RealHermSymComplexSym},
              alpha::Number, beta::Number) =
-    C .= adjoint.(A.parent.diag) .* B .* _strong0(alpha) .+ _scaledout(C, beta)
+    C .= (adjoint.(A.parent.diag) .* B) .*ₛ alpha .+ C .*ₛ beta
 @inline mul!(C::AbstractMatrix,
              A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:RealHermSymComplexHerm},
              alpha::Number, beta::Number) =
-    C .= transpose.(A.parent.diag) .* B .* _strong0(alpha) .+ _scaledout(C, beta)
+    C .= (transpose.(A.parent.diag) .* B) .*ₛ alpha .+ C .*ₛ beta
 
 (/)(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag)
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -467,7 +467,7 @@ function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat
     if nC != mA
         throw(DimensionMismatch("output matrix has size: $(nC), but should have size $(mA)"))
     end
-    if mA == 0 || nA == 0
+    if mA == 0 || nA == 0 || iszero(_add.alpha)
         return _rmul_or_fill!(C, _add.beta)
     end
     if mA == 2 && nA == 2
@@ -671,6 +671,9 @@ function generic_matmatmul!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::Abs
     mB, nB = lapack_size(tB, B)
     mC, nC = size(C)
 
+    if iszero(_add.alpha)
+        return _rmul_or_fill!(C, _add.beta)
+    end
     if mA == nA == mB == nB == mC == nC == 2
         return matmul2x2!(C, tA, tB, A, B, _add)
     end
@@ -694,7 +697,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
     if size(C,1) != mA || size(C,2) != nB
         throw(DimensionMismatch("result C has dimensions $(size(C)), needs ($mA,$nB)"))
     end
-    if isempty(A) || isempty(B)
+    if isempty(A) || isempty(B) || iszero(_add.alpha)
         return _rmul_or_fill!(C, _add.beta)
     end
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -538,7 +538,7 @@ function gemm_wrapper!(C::StridedVecOrMat{T}, tA::AbstractChar, tB::AbstractChar
         throw(ArgumentError("output matrix must not be aliased with input matrix"))
     end
 
-    if mA == 0 || nA == 0 || nB == 0
+    if mA == 0 || nA == 0 || nB == 0 || iszero(_add.alpha)
         if size(C) != (mA, nB)
             throw(DimensionMismatch("C has dimensions $(size(C)), should have ($mA,$nB)"))
         end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -459,6 +459,7 @@ end
 
 @inline function _mul!(A::UpperTriangular, B::UpperTriangular, c::Number, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         for i = 1:j
             @inbounds _modify!(_add, B[i,j] * c, A, (i,j))
@@ -468,6 +469,7 @@ end
 end
 @inline function _mul!(A::UpperTriangular, c::Number, B::UpperTriangular, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         for i = 1:j
             @inbounds _modify!(_add, c * B[i,j], A, (i,j))
@@ -477,6 +479,7 @@ end
 end
 @inline function _mul!(A::UpperTriangular, B::UnitUpperTriangular, c::Number, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = 1:(j - 1)
@@ -487,6 +490,7 @@ end
 end
 @inline function _mul!(A::UpperTriangular, c::Number, B::UnitUpperTriangular, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = 1:(j - 1)
@@ -497,6 +501,7 @@ end
 end
 @inline function _mul!(A::LowerTriangular, B::LowerTriangular, c::Number, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         for i = j:n
             @inbounds _modify!(_add, B[i,j] * c, A, (i,j))
@@ -506,6 +511,7 @@ end
 end
 @inline function _mul!(A::LowerTriangular, c::Number, B::LowerTriangular, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         for i = j:n
             @inbounds _modify!(_add, c * B[i,j], A, (i,j))
@@ -515,6 +521,7 @@ end
 end
 @inline function _mul!(A::LowerTriangular, B::UnitLowerTriangular, c::Number, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = (j + 1):n
@@ -525,6 +532,7 @@ end
 end
 @inline function _mul!(A::LowerTriangular, c::Number, B::UnitLowerTriangular, _add::MulAddMul)
     n = checksquare(B)
+    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = (j + 1):n

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -178,6 +178,8 @@ end
 
     if m == 0
         return C
+    elseif iszero(_add.alpha)
+        return _rmul_or_fill!(C, _add.beta)
     end
 
     α = S.dv

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -155,41 +155,19 @@ end
                    rtoldefault.(real.(typeof.((α, β))))...)
 
         Cc = copy(C)
+        Ac = Matrix(A)
+        Bc = Matrix(B)
         returned_mat = mul!(C, A, B, α, β)
         @test returned_mat === C
-        if (A isa Bidiagonal && B isa AbstractTriangular) ||
-                (A isa Diagonal && (eltype(A) <: AbstractFloat || !isinteger(α)) &&
-                 B isa AbstractTriangular && eltype(B) <: Integer) ||
-                (A isa Diagonal && (eltype(A) <: Complex || !isreal(α)) &&
-                 B isa AbstractTriangular && eltype(B) <: Real)
-            # see https://github.com/JuliaLang/julia/issues/30094
-
-            # If `B` is an `AbstractTriangular{<:Integer}` and
-            # elements are all zero (which can happen with non-zero
-            # probability), this test can pass.  But let's keep this
-            # code here since it'd be useful for checking if the bugs
-            # are fixed.
-            # @test_broken returned_mat ≈ α * A * B + β * Cc  rtol=rtol
-
-            Ac = Matrix(A)
-            Bc = Matrix(B)
-            @test collect(returned_mat) ≈ collect(α * Ac * Bc + β * Cc)  rtol=rtol
-        else
-            @test collect(returned_mat) ≈ collect(α * A * B + β * Cc)  rtol=rtol
-        end
+        @test collect(returned_mat) ≈ α * Ac * Bc + β * Cc  rtol=rtol
 
         y = C[:, 1]
         x = B[:, 1]
-        y0 = copy(y)
+        yc = Vector(y)
+        xc = Vector(x)
         returned_vec = mul!(y, A, x, α, β)
         @test returned_vec === y
-        if A isa AbstractTriangular && x isa SparseVector
-            @test_broken returned_vec ≈ α * A * x + β * y0  rtol=rtol
-            xc = Vector(x)
-            @test collect(returned_vec) ≈ collect(α * A * xc + β * y0)  rtol=rtol
-        else
-            @test collect(returned_vec) ≈ collect(α * A * x + β * y0)  rtol=rtol
-        end
+        @test collect(returned_vec) ≈ α * Ac * xc + β * yc  rtol=rtol
     end
 end
 

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -168,6 +168,26 @@ end
         returned_vec = mul!(y, A, x, α, β)
         @test returned_vec === y
         @test collect(returned_vec) ≈ α * Ac * xc + β * yc  rtol=rtol
+
+        if TC <: Matrix
+            @testset "adjoint and transpose" begin
+                @testset for fa in [identity, adjoint, transpose],
+                             fb in [identity, adjoint, transpose]
+                    fa === fb === identity && continue
+
+                    Af = fa === identity ? A : fa(_rand(TA, reverse(asize)))
+                    Bf = fb === identity ? B : fb(_rand(TB, reverse(bsize)))
+
+                    Ac = collect(Af)
+                    Bc = collect(Bf)
+                    Cc = collect(C)
+
+                    returned_mat = mul!(C, Af, Bf, α, β)
+                    @test returned_mat === C
+                    @test collect(returned_mat) ≈ α * Ac * Bc + β * Cc  rtol=rtol
+                end
+            end
+        end
     end
 end
 

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -146,8 +146,8 @@ end
     bsize = (na2, nb2)
     csize = (na1, nb2)
 
-    for α in Any[true, eltype(TC)(1), _rand(eltype(TC))],
-        β in Any[false, eltype(TC)(0), _rand(eltype(TC))]
+    @testset for α in Any[true, eltype(TC)(1), _rand(eltype(TC))],
+                 β in Any[false, eltype(TC)(0), _rand(eltype(TC))]
 
         C = _rand(TC, csize)
         A = _rand(TA, asize)

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -142,8 +142,8 @@ end
     bsize = (na2, nb2)
     csize = (na1, nb2)
 
-    for α in [true, eltype(TC)(1), _rand(eltype(TC))],
-        β in [false, eltype(TC)(0), _rand(eltype(TC))]
+    for α in Any[true, eltype(TC)(1), _rand(eltype(TC))],
+        β in Any[false, eltype(TC)(0), _rand(eltype(TC))]
 
         C = _rand(TC, csize)
         A = _rand(TA, asize)

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -188,6 +188,27 @@ end
                 end
             end
         end
+
+        if eltype(C) <: AbstractFloat
+            @testset "β = 0 ignores C .= NaN" begin
+                C .= NaN
+                Ac = Matrix(A)
+                Bc = Matrix(B)
+                returned_mat = mul!(C, A, B, α, zero(eltype(C)))
+                @test returned_mat === C
+                @test collect(returned_mat) ≈ α * Ac * Bc  rtol=rtol
+            end
+        end
+
+        if eltype(A) <: AbstractFloat
+            @testset "α = 0 ignores A .= NaN" begin
+                A .= NaN
+                Cc = copy(C)
+                returned_mat = mul!(C, A, B, zero(eltype(A)), β)
+                @test returned_mat === C
+                @test collect(returned_mat) ≈ β * Cc  rtol=rtol
+            end
+        end
     end
 end
 

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -191,7 +191,7 @@ end
 
         if eltype(C) <: AbstractFloat
             @testset "β = 0 ignores C .= NaN" begin
-                C .= NaN
+                parent(C) .= NaN
                 Ac = Matrix(A)
                 Bc = Matrix(B)
                 returned_mat = mul!(C, A, B, α, zero(eltype(C)))
@@ -202,7 +202,7 @@ end
 
         if eltype(A) <: AbstractFloat
             @testset "α = 0 ignores A .= NaN" begin
-                A .= NaN
+                parent(A) .= NaN
                 Cc = copy(C)
                 returned_mat = mul!(C, A, B, zero(eltype(A)), β)
                 @test returned_mat === C

--- a/stdlib/LinearAlgebra/test/addmul.jl
+++ b/stdlib/LinearAlgebra/test/addmul.jl
@@ -73,6 +73,10 @@ mattypes = [
     UpperTriangular,
 ]
 
+isnanfillable(::AbstractArray) = false
+isnanfillable(::Array{<:AbstractFloat}) = true
+isnanfillable(A::AbstractArray{<:AbstractFloat}) = parent(A) isa Array
+
 """
 Sample `n` elements from `S` on average but make sure at least one
 element is sampled.
@@ -189,7 +193,7 @@ end
             end
         end
 
-        if eltype(C) <: AbstractFloat
+        if isnanfillable(C)
             @testset "β = 0 ignores C .= NaN" begin
                 parent(C) .= NaN
                 Ac = Matrix(A)
@@ -200,7 +204,7 @@ end
             end
         end
 
-        if eltype(A) <: AbstractFloat
+        if isnanfillable(A)
             @testset "α = 0 ignores A .= NaN" begin
                 parent(A) .= NaN
                 Cc = copy(C)

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -449,4 +449,10 @@ end
     @test sum(Bidiagonal([1,2,3], [1,2], :L)) == 9
 end
 
+@testset "empty sub-diagonal" begin
+    # `mul!` must use non-specialized method when sub-diagonal is empty
+    A = [1 2 3 4]'
+    @test A * Tridiagonal(ones(1, 1)) == A
+end
+
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -566,4 +566,13 @@ Base.:*(x::Float64, a::A32092) = x * a.x
     @test ones(2, 2) * [A32092(1.0), A32092(2.0)] == fill(3.0, (2,))
 end
 
+@testset "strong zero" begin
+    @testset for α in Any[false, 0.0, 0], n in 1:4
+        C = ones(n, n)
+        A = fill!(zeros(n, n), NaN)
+        B = ones(n, n)
+        @test mul!(copy(C), A, B, α, 1.0) == C
+    end
+end
+
 end # module TestMatmul


### PR DESCRIPTION
Another followup of #29634:

* Enforce strong-zero behavior for alpha
* Fix 5-arg mul! for Bi/Tri/Sym * Diag
