### PR TITLE
Refactoring: add at-sc macro to improve readability of mul! code

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -496,12 +496,12 @@ function A_mul_B_td!(C::AbstractVecOrMat, A::BiTriSym, B::AbstractVecOrMat,
     @inbounds begin
         for j = 1:nB
             b₀, b₊ = B[1, j], B[2, j]
-            _modify!(_add, d[1]*b₀ + u[1]*b₊, C, (1, j))
+            @sc _add C[1, j] += d[1]*b₀ + u[1]*b₊
             for i = 2:nA - 1
                 b₋, b₀, b₊ = b₀, b₊, B[i + 1, j]
-                _modify!(_add, l[i - 1]*b₋ + d[i]*b₀ + u[i]*b₊, C, (i, j))
+                @sc _add C[i, j] += l[i - 1]*b₋ + d[i]*b₀ + u[i]*b₊
             end
-            _modify!(_add, l[nA - 1]*b₀ + d[nA]*b₊, C, (nA, j))
+            @sc _add C[nA, j] += l[nA - 1]*b₀ + d[nA]*b₊
         end
     end
     C
@@ -523,8 +523,8 @@ function A_mul_B_td!(C::AbstractMatrix, A::AbstractMatrix, B::BiTriSym,
         Bmm = Bd[m]
         Bm₋1m = Bu[m-1]
         for i in 1:n
-            _modify!(_add, A[i,1] * B11 + A[i, 2] * B21, C, (i, 1))
-            _modify!(_add, A[i, m-1] * Bm₋1m + A[i, m] * Bmm, C, (i, m))
+            @sc _add C[i, 1] += A[i,1] * B11 + A[i, 2] * B21
+            @sc _add C[i, m] += A[i, m-1] * Bm₋1m + A[i, m] * Bmm
         end
         # middle columns of C
         for j = 2:m-1
@@ -532,7 +532,7 @@ function A_mul_B_td!(C::AbstractMatrix, A::AbstractMatrix, B::BiTriSym,
             Bjj = Bd[j]
             Bj₊1j = Bl[j]
             for i = 1:n
-                _modify!(_add, A[i, j-1] * Bj₋1j + A[i, j]*Bjj + A[i, j+1] * Bj₊1j, C, (i, j))
+                @sc _add C[i, j] += A[i, j-1] * Bj₋1j + A[i, j]*Bjj + A[i, j+1] * Bj₊1j
             end
         end
     end # inbounds

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -618,7 +618,7 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
             for i = 1:nA
                 s += transpose(A[aoffs+i]) * B[i]
             end
-            _modify!(_add, s, C, k)
+            @sc _add C[k] += s
         end
     elseif tA == 'C'
         for k = 1:mA
@@ -631,7 +631,7 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
             for i = 1:nA
                 s += A[aoffs + i]'B[i]
             end
-            _modify!(_add, s, C, k)
+            @sc _add C[k] += s
         end
     else # tA == 'N'
         for i = 1:mA
@@ -726,7 +726,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         s += Atile[aoff+k] * Btile[boff+k]
                     end
-                    _modify!(_add, s, C, (i,j))
+                    @sc _add C[i,j] += s
                 end
             end
         else
@@ -774,7 +774,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += A[i, k]*B[k, j]
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
@@ -783,7 +783,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += A[i, k] * transpose(B[j, k])
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             else
                 for i = 1:mA, j = 1:nB
@@ -792,7 +792,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += A[i, k]*B[j, k]'
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             end
         elseif tA == 'T'
@@ -803,7 +803,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += transpose(A[k, i]) * B[k, j]
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
@@ -812,7 +812,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += transpose(A[k, i]) * transpose(B[j, k])
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             else
                 for i = 1:mA, j = 1:nB
@@ -821,7 +821,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += transpose(A[k, i]) * adjoint(B[j, k])
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             end
         else
@@ -832,7 +832,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += A[k, i]'B[k, j]
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
@@ -841,7 +841,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += adjoint(A[k, i]) * transpose(B[j, k])
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             else
                 for i = 1:mA, j = 1:nB
@@ -850,7 +850,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     for k = 1:nA
                         Ctmp += A[k, i]'B[j, k]'
                     end
-                    _modify!(_add, Ctmp, C, (i,j))
+                    @sc _add C[i,j] += Ctmp
                 end
             end
         end
@@ -895,10 +895,10 @@ function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMat
         B11 = B[1,1]; B12 = B[1,2];
         B21 = B[2,1]; B22 = B[2,2]
     end
-    _modify!(_add, A11*B11 + A12*B21, C, (1,1))
-    _modify!(_add, A11*B12 + A12*B22, C, (1,2))
-    _modify!(_add, A21*B11 + A22*B21, C, (2,1))
-    _modify!(_add, A21*B12 + A22*B22, C, (2,2))
+    @sc _add C[1,1] += A11*B11 + A12*B21
+    @sc _add C[1,2] += A11*B12 + A12*B22
+    @sc _add C[2,1] += A21*B11 + A22*B21
+    @sc _add C[2,2] += A21*B12 + A22*B22
     end # inbounds
     C
 end
@@ -947,17 +947,17 @@ function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMat
         B31 = B[3,1]; B32 = B[3,2]; B33 = B[3,3]
     end
 
-    _modify!(_add, A11*B11 + A12*B21 + A13*B31, C, (1,1))
-    _modify!(_add, A11*B12 + A12*B22 + A13*B32, C, (1,2))
-    _modify!(_add, A11*B13 + A12*B23 + A13*B33, C, (1,3))
+    @sc _add C[1,1] += A11*B11 + A12*B21 + A13*B31
+    @sc _add C[1,2] += A11*B12 + A12*B22 + A13*B32
+    @sc _add C[1,3] += A11*B13 + A12*B23 + A13*B33
 
-    _modify!(_add, A21*B11 + A22*B21 + A23*B31, C, (2,1))
-    _modify!(_add, A21*B12 + A22*B22 + A23*B32, C, (2,2))
-    _modify!(_add, A21*B13 + A22*B23 + A23*B33, C, (2,3))
+    @sc _add C[2,1] += A21*B11 + A22*B21 + A23*B31
+    @sc _add C[2,2] += A21*B12 + A22*B22 + A23*B32
+    @sc _add C[2,3] += A21*B13 + A22*B23 + A23*B33
 
-    _modify!(_add, A31*B11 + A32*B21 + A33*B31, C, (3,1))
-    _modify!(_add, A31*B12 + A32*B22 + A33*B32, C, (3,2))
-    _modify!(_add, A31*B13 + A32*B23 + A33*B33, C, (3,3))
+    @sc _add C[3,1] += A31*B11 + A32*B21 + A33*B31
+    @sc _add C[3,2] += A31*B12 + A32*B22 + A33*B32
+    @sc _add C[3,3] += A31*B13 + A32*B23 + A33*B33
     end # inbounds
     C
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -461,7 +461,7 @@ end
     n = checksquare(B)
     for j = 1:n
         for i = 1:j
-            @inbounds _modify!(_add, B[i,j] * c, A, (i,j))
+            @inbounds @sc _add A[i,j] += B[i,j] * c
         end
     end
     return A
@@ -470,7 +470,7 @@ end
     n = checksquare(B)
     for j = 1:n
         for i = 1:j
-            @inbounds _modify!(_add, c * B[i,j], A, (i,j))
+            @inbounds @sc _add A[i,j] += c * B[i,j]
         end
     end
     return A
@@ -478,9 +478,9 @@ end
 @inline function _mul!(A::UpperTriangular, B::UnitUpperTriangular, c::Number, _add::MulAddMul)
     n = checksquare(B)
     for j = 1:n
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds @sc _add A[j,j] += c
         for i = 1:(j - 1)
-            @inbounds _modify!(_add, B[i,j] * c, A, (i,j))
+            @inbounds @sc _add A[i,j] += B[i,j] * c
         end
     end
     return A
@@ -488,9 +488,9 @@ end
 @inline function _mul!(A::UpperTriangular, c::Number, B::UnitUpperTriangular, _add::MulAddMul)
     n = checksquare(B)
     for j = 1:n
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds @sc _add A[j,j] += c
         for i = 1:(j - 1)
-            @inbounds _modify!(_add, c * B[i,j], A, (i,j))
+            @inbounds @sc _add A[i,j] += c * B[i,j]
         end
     end
     return A
@@ -499,7 +499,7 @@ end
     n = checksquare(B)
     for j = 1:n
         for i = j:n
-            @inbounds _modify!(_add, B[i,j] * c, A, (i,j))
+            @inbounds @sc _add A[i,j] += B[i,j] * c
         end
     end
     return A
@@ -508,7 +508,7 @@ end
     n = checksquare(B)
     for j = 1:n
         for i = j:n
-            @inbounds _modify!(_add, c * B[i,j], A, (i,j))
+            @inbounds @sc _add A[i,j] += c * B[i,j]
         end
     end
     return A
@@ -516,9 +516,9 @@ end
 @inline function _mul!(A::LowerTriangular, B::UnitLowerTriangular, c::Number, _add::MulAddMul)
     n = checksquare(B)
     for j = 1:n
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds @sc _add A[j,j] += c
         for i = (j + 1):n
-            @inbounds _modify!(_add, B[i,j] * c, A, (i,j))
+            @inbounds @sc _add A[i,j] += B[i,j] * c
         end
     end
     return A
@@ -526,9 +526,9 @@ end
 @inline function _mul!(A::LowerTriangular, c::Number, B::UnitLowerTriangular, _add::MulAddMul)
     n = checksquare(B)
     for j = 1:n
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds @sc _add A[j,j] += c
         for i = (j + 1):n
-            @inbounds _modify!(_add, c * B[i,j], A, (i,j))
+            @inbounds @sc _add A[i,j] += c * B[i,j]
         end
     end
     return A

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -191,9 +191,9 @@ end
             for i = 1:m - 1
                 x₋, x₀, x₊ = x₀, x₊, B[i + 1, j]
                 β₋, β₀ = β₀, β[i]
-                _modify!(_add, β₋*x₋ + α[i]*x₀ + β₀*x₊, C, (i, j))
+                @sc _add C[i, j] += β₋*x₋ + α[i]*x₀ + β₀*x₊
             end
-            _modify!(_add, β₀*x₀ + α[m]*x₊, C, (m, j))
+            @sc _add C[m, j] += β₀*x₀ + α[m]*x₊
         end
     end
 


### PR DESCRIPTION
(Yet another followup of #29634.  This patch is orthogonal to #32901.)

The idea is to add a macro `@sc` (**S**hort-**C**ircuiting update) such that

```julia
@sc _add C[idx] += rhs
```

expands to

```julia
_modify!(_add, rhs, C, idx)
```

(Code above is roughly equivalent to

```julia
C[idx] = α * rhs + β * C[idx]
```

but avoids indexing `C[idx]` on the right-hand side when β is 0. This trick was required to implement #29634 in general cases.)

I think this makes the code much more readable.  But I don't mind if this patch is rejected since this approach may make code harder to understand for some people.  In particular, now multiplications by α and β become much more implicit with this approach.
