### PR TITLE
Add example of Hessenberg decomposition to docstring

### DIFF
--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -362,7 +362,18 @@ julia> A = [4. 9. 7.; 4. 4. 1.; 4. 3. 2.]
  4.0  4.0  1.0
  4.0  3.0  2.0
 
-julia> F = hessenberg(A);
+julia> F = hessenberg(A)
+Hessenberg{Float64,UpperHessenberg{Float64,Array{Float64,2}},Array{Float64,2},Array{Float64,1},Bool}
+Q factor:
+3×3 LinearAlgebra.HessenbergQ{Float64,Array{Float64,2},Array{Float64,1},false}:
+ 1.0   0.0        0.0
+ 0.0  -0.707107  -0.707107
+ 0.0  -0.707107   0.707107
+H factor:
+3×3 UpperHessenberg{Float64,Array{Float64,2}}:
+  4.0      -11.3137       -1.41421
+ -5.65685    5.0           2.0
+   ⋅        -8.88178e-16   1.0
 
 julia> F.Q * F.H * F.Q'
 3×3 Array{Float64,2}:


### PR DESCRIPTION
I have just noticed that *better printing* of Hessenberg decompositions is already done. But there is no visible example in the docstring. Is there any reason for this? If so, feel free to close that PR.

@andreasnoack Could you add check marks to the check boxes **Hessenberg** and **SVD** in JuliaLang/LinearAlgebra.jl#485? Thank you.