### PR TITLE
Missing error test for printf macro

### DIFF
--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -271,6 +271,7 @@ end
 @test (@sprintf "%s %s %s %d %d %d %f %f %f" Any[10^x+y for x=1:3,y=1:3 ]...) == "11 101 1001 12 102 1002 13.000000 103.000000 1003.000000"
 
 # @printf
+@test_me ArgumentError("@printf: called with no arguments") @macroexpand(@printf)
 @test_me ArgumentError("@printf: first or second argument must be a format string") @macroexpand(@printf 1)
 
 # Check bug with trailing nul printing BigFloat


### PR DESCRIPTION
Although the line where this error may be thrown is covered, the error condition itself isn't.