### PR TITLE
Profile,test: fix busy-wait test

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -360,11 +360,11 @@ end
 
 function flat(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoDict, LineInfoFlatDict}, cols::Int, fmt::ProfileFormat)
     iplist, n = count_flat(data)
+    lilist, n = parse_flat(iplist, n, lidict, fmt.C)
     if isempty(n)
         warning_empty()
         return
     end
-    lilist, n = parse_flat(iplist, n, lidict, fmt.C)
     print_flat(io, lilist, n, cols, fmt)
     nothing
 end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -2,16 +2,26 @@
 
 using Test, Profile, Serialization
 
-function busywait(t, n_tries)
+Profile.clear()
+Profile.init()
+
+let iobuf = IOBuffer()
+    for fmt in (:tree, :flat)
+        Test.@test_logs (:warn, r"^There were no samples collected\.") Profile.print(iobuf, format=fmt, C=true)
+        Test.@test_logs (:warn, r"^There were no samples collected\.") Profile.print(iobuf, [0x0000000000000001], Dict(0x0000000000000001 => [Base.StackTraces.UNKNOWN]), format=fmt, C=false)
+    end
+end
+
+@noinline function busywait(t, n_tries)
     iter = 0
-    while iter < n_tries && Profile.len_data() == 0
+    init_data = Profile.len_data()
+    while iter < n_tries && Profile.len_data() == init_data
         iter += 1
         tend = time() + t
         while time() < tend end
     end
 end
 
-Profile.clear()
 @profile busywait(1, 20)
 
 let r = Profile.retrieve()


### PR DESCRIPTION
When d7a90c0bbfa228e920d509f2639c364feade84d3 was added,
it potentially reduced the sleep timeout to zero
if we took a snapshot right away, unintentionally
ensuring we did not have any samples inside Julia!

fix #29880 and add a test for the empty printing case