### PR TITLE
Improve printing of LDLt factorization

### DIFF
--- a/stdlib/LinearAlgebra/src/ldlt.jl
+++ b/stdlib/LinearAlgebra/src/ldlt.jl
@@ -18,7 +18,17 @@ julia> S = SymTridiagonal([3., 4., 5.], [1., 2.])
   ⋅   2.0  5.0
 
 julia> F = ldlt(S)
-LDLt{Float64,SymTridiagonal{Float64,Array{Float64,1}}}([3.0 0.3333333333333333 0.0; 0.3333333333333333 3.6666666666666665 0.5454545454545455; 0.0 0.5454545454545455 3.909090909090909])
+LDLt{Float64,SymTridiagonal{Float64,Array{Float64,1}}}
+L factor:
+3×3 UnitLowerTriangular{Float64,SymTridiagonal{Float64,Array{Float64,1}}}:
+ 1.0        ⋅         ⋅
+ 0.333333  1.0        ⋅
+ 0.0       0.545455  1.0
+diagonal values:
+3-element Array{Float64,1}:
+ 3.0
+ 3.6666666666666665
+ 3.909090909090909
 ```
 """
 struct LDLt{T,S<:AbstractMatrix{T}} <: Factorization{T}
@@ -42,6 +52,14 @@ LDLt{T}(F::LDLt) where {T} = LDLt(convert(AbstractMatrix{T}, F.data)::AbstractMa
 
 Factorization{T}(F::LDLt{T}) where {T} = F
 Factorization{T}(F::LDLt) where {T} = LDLt{T}(F)
+
+function show(io::IO, mime::MIME{Symbol("text/plain")}, F::LDLt)
+    summary(io, F); println(io)
+    println(io, "L factor:")
+    show(io, mime, UnitLowerTriangular(F.data))
+    println(io, "\ndiagonal values:")
+    show(io, mime, F.data.dv)
+end
 
 # SymTridiagonal
 """

--- a/stdlib/LinearAlgebra/test/ldlt.jl
+++ b/stdlib/LinearAlgebra/test/ldlt.jl
@@ -10,9 +10,9 @@ Random.seed!(123)
     S = SymTridiagonal(randn(5), randn(4))
     F = ldlt(S)
     ldltstring = sprint((t, s) -> show(t, "text/plain", s), F)
-    lstring = sprint((t, s) -> show(t, "text/plain", s), UnitLowerTriangular(F.data))
-    dstring = sprint((t, s) -> show(t, "text/plain", s), F.data.dv)
-    @test ldltstring == "$(summary(F))\nL factor:\n$lstring\ndiagonal values:\n$dstring"
+    lstring = sprint((t, s) -> show(t, "text/plain", s), F.L)
+    dstring = sprint((t, s) -> show(t, "text/plain", s), F.D)
+    @test ldltstring == "$(summary(F))\nL factor:\n$lstring\nD factor:\n$dstring"
 end
 
 end # module TestLDLT

--- a/stdlib/LinearAlgebra/test/ldlt.jl
+++ b/stdlib/LinearAlgebra/test/ldlt.jl
@@ -1,0 +1,18 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module TestLDLT
+
+using Test, LinearAlgebra, Random
+
+Random.seed!(123)
+
+@testset "REPL printing of LDLT" begin
+    S = SymTridiagonal(randn(5), randn(4))
+    F = ldlt(S)
+    ldltstring = sprint((t, s) -> show(t, "text/plain", s), F)
+    lstring = sprint((t, s) -> show(t, "text/plain", s), UnitLowerTriangular(F.data))
+    dstring = sprint((t, s) -> show(t, "text/plain", s), F.data.dv)
+    @test ldltstring == "$(summary(F))\nL factor:\n$lstring\ndiagonal values:\n$dstring"
+end
+
+end # module TestLDLT


### PR DESCRIPTION
This PR improves the REPL printing of LDLt factorizations as proposed in JuliaLang/LinearAlgebra.jl#485.

```julia
using LinearAlgebra
S = SymTridiagonal([1., 2., 3.], [-1., 1.])
```

Prior to this PR it looked like this:
```julia
julia> F = ldlt(S)
LDLt{Float64,SymTridiagonal{Float64,Array{Float64,1}}}([1.0 -1.0 0.0; -1.0 1.0 1.0; 0.0 1.0 2.0])
```

With this PR it now looks like this:
```julia
LDLt{Float64,SymTridiagonal{Float64,Array{Float64,1}}}
L factor:
3×3 UnitLowerTriangular{Float64,SymTridiagonal{Float64,Array{Float64,1}}}:
  1.0   ⋅    ⋅ 
 -1.0  1.0   ⋅ 
  0.0  1.0  1.0
diagonal values:
3-element Array{Float64,1}:
 1.0
 1.0
 2.0
```

Instead of printing *diagonal values*, we could call it *D factor* and print a diagonal matrix. Let me know which method is preferred.

I have also added a new test file `stdlib/LinearAlgebra/test/ldlt.jl` to add a basic test for this.
