### PR TITLE
Disallow var syntax in string interpolation

### DIFF
--- a/base/shell.jl
+++ b/base/shell.jl
@@ -70,7 +70,14 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
             isempty(st) && error("\$ right before end of command")
             stpos, c = popfirst!(st)
             isspace(c) && error("space not allowed right after \$")
-            ex, j = Meta.parse(s,stpos,greedy=false)
+            if startswith(SubString(s, stpos), "var\"")
+                # Disallow var"#" syntax in cmd interpolations.
+                # TODO: Allow only identifiers after the $ for consistency with
+                # string interpolation syntax (see #3150)
+                ex, j = :var, stpos+3
+            else
+                ex, j = Meta.parse(s,stpos,greedy=false)
+            end
             last_parse = (stpos:prevind(s, j)) .+ s.offset
             update_arg(ex);
             s = SubString(s, j)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -461,6 +461,15 @@ let c = setenv(`x`, "A"=>true)
     @test_throws ArgumentError `"$c "`
 end
 
+# Interaction of cmd parsing with var syntax (#32408)
+let var = "x", vars="z"
+    @test `ls $var` == Cmd(["ls", "x"])
+    @test `ls $vars` == Cmd(["ls", "z"])
+    @test `ls $var"y"` == Cmd(["ls", "xy"])
+    @test `ls "'$var'"` == Cmd(["ls", "'x'"])
+    @test `ls $var "y"` == Cmd(["ls", "x", "y"])
+end
+
 # equality tests for AndCmds
 @test Base.AndCmds(`$echocmd abc`, `$echocmd def`) == Base.AndCmds(`$echocmd abc`, `$echocmd def`)
 @test Base.AndCmds(`$echocmd abc`, `$echocmd def`) != Base.AndCmds(`$echocmd abc`, `$echocmd xyz`)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1922,3 +1922,9 @@ end
 @test Base.remove_linenums!(Meta.parse("try a catch var\"#\" b end")) ==
       Expr(:try, Expr(:block, :a), Symbol("#"), Expr(:block, :b))
 @test Meta.parse("(var\"function\" = 1,)") == Expr(:tuple, Expr(:(=), Symbol("function"), 1))
+# Non-standard identifiers require parens for string interpolation
+@test Meta.parse("\"\$var\\\"#\\\"\"") == Expr(:string, :var, "\"#\"")
+@test Meta.parse("\"\$(var\"#\")\"") == Expr(:string, Symbol("#"))
+# Stream positioning after parsing var
+@test Meta.parse("var'", 1, greedy=false) == (:var, 4)
+


### PR DESCRIPTION
The `var"##"` syntax should be disabled in string interpolation.

Also work around a subtle problem with command interpolation's use of Meta.parse in non-greedy mode, combined with the new `var` syntax which would cause `Base.shell_parse("\"(\$var)\"")` to miss the trailing `)` character.

This is a quick fix for a bit of fallout from #32408 which affects PyCall's build script, among other things.

Fixes #32951