### PR TITLE
Add tests for `mean` of iterables

### DIFF
--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -3,6 +3,8 @@
 using Statistics, Test, Random, LinearAlgebra, SparseArrays
 using Test: guardseed
 
+Random.seed!(123)
+
 @testset "middle" begin
     @test middle(3) === 3.0
     @test middle(2, 3) === 2.5
@@ -81,6 +83,14 @@ end
     @test mean(i->i+1, 0:2) === 2.
     @test mean(isodd, [3]) === 1.
     @test mean(x->3x, (1,1)) === 3.
+
+    # mean of iterables:
+    n = 10; a = randn(n); b = randn(n)
+    @test mean(Tuple(a)) ≈ mean(a)
+    @test mean(Tuple(a + b*im)) ≈ mean(a + b*im)
+    @test mean(cos, Tuple(a)) ≈ mean(cos, a)
+    @test mean(x->x/2, a + b*im) ≈ mean(a + b*im) / 2.
+    @test ismissing(mean(Tuple((1, 2, missing, 4, 5))))
 
     @test isnan(mean([NaN]))
     @test isnan(mean([0.0,NaN]))


### PR DESCRIPTION
According to *codecov.io* there were no tests for the `mean` of iterables, so I added some.