### PR TITLE
Refactoring: Use accessor methods when manipulating sparse matrices/vectors

### DIFF
--- a/stdlib/SparseArrays/src/sparseconvert.jl
+++ b/stdlib/SparseArrays/src/sparseconvert.jl
@@ -100,13 +100,13 @@ _sparsem(A::AbstractSparseVector) = A
 function _sparsem(A::Union{Transpose{<:Any,<:AbstractSparseVector},Adjoint{<:Any,<:AbstractSparseVector}})
     B = parent(A)
     n = length(B)
-    Ti = eltype(B.nzind)
+    Ti = eltype(nonzeroinds(B))
     fadj = A isa Transpose ? transpose : adjoint
     colptr = fill!(Vector{Ti}(undef, n + 1), 0)
     colptr[1] = 1
-    colptr[B.nzind .+ 1] .= 1
+    colptr[nonzeroinds(B) .+ 1] .= 1
     cumsum!(colptr, colptr)
-    rowval = fill!(similar(B.nzind), 1)
+    rowval = fill!(similar(nonzeroinds(B)), 1)
     nzval = fadj.(nonzeros(B))
     SparseMatrixCSC(1, n, colptr, rowval, nzval)
 end

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -38,24 +38,23 @@ const AdjOrTransSparseVectorUnion{T} = LinearAlgebra.AdjOrTrans{T, <:SparseVecto
 
 ### Basic properties
 
-length(x::SparseVector)   = x.n
-size(x::SparseVector)     = (x.n,)
-nnz(x::SparseVector)      = length(x.nzval)
-count(f, x::SparseVector) = count(f, x.nzval) + f(zero(eltype(x)))*(length(x) - nnz(x))
+size(x::SparseVector)     = (getfield(x, :n),)
+nnz(x::SparseVector)      = length(nonzeros(x))
+count(f, x::SparseVector) = count(f, nonzeros(x)) + f(zero(eltype(x)))*(length(x) - nnz(x))
 
-nonzeros(x::SparseVector) = x.nzval
+nonzeros(x::SparseVector) = getfield(x, :nzval)
 function nonzeros(x::SparseColumnView)
     rowidx, colidx = parentindices(x)
     A = parent(x)
-    @inbounds y = view(A.nzval, nzrange(A, colidx))
+    @inbounds y = view(nonzeros(A), nzrange(A, colidx))
     return y
 end
 
-nonzeroinds(x::SparseVector) = x.nzind
+nonzeroinds(x::SparseVector) = getfield(x, :nzind)
 function nonzeroinds(x::SparseColumnView)
     rowidx, colidx = parentindices(x)
     A = parent(x)
-    @inbounds y = view(A.rowval, nzrange(A, colidx))
+    @inbounds y = view(rowvals(A), nzrange(A, colidx))
     return y
 end
 
@@ -69,13 +68,13 @@ end
 #
 # parent method for similar that preserves stored-entry structure (for when new and old dims match)
 _sparsesimilar(S::SparseVector, ::Type{TvNew}, ::Type{TiNew}) where {TvNew,TiNew} =
-    SparseVector(S.n, copyto!(similar(S.nzind, TiNew), S.nzind), similar(S.nzval, TvNew))
+    SparseVector(length(S), copyto!(similar(nonzeroinds(S), TiNew), nonzeroinds(S)), similar(nonzeros(S), TvNew))
 # parent method for similar that preserves nothing (for when old and new dims differ, and new is 1d)
 _sparsesimilar(S::SparseVector, ::Type{TvNew}, ::Type{TiNew}, dims::Dims{1}) where {TvNew,TiNew} =
-    SparseVector(dims..., similar(S.nzind, TiNew, 0), similar(S.nzval, TvNew, 0))
+    SparseVector(dims..., similar(nonzeroinds(S), TiNew, 0), similar(nonzeros(S), TvNew, 0))
 # parent method for similar that preserves storage space (for old and new dims differ, and new is 2d)
 _sparsesimilar(S::SparseVector, ::Type{TvNew}, ::Type{TiNew}, dims::Dims{2}) where {TvNew,TiNew} =
-    SparseMatrixCSC(dims..., fill(one(TiNew), last(dims)+1), similar(S.nzind, TiNew), similar(S.nzval, TvNew))
+    SparseMatrixCSC(dims..., fill(one(TiNew), last(dims)+1), similar(nonzeroinds(S), TiNew), similar(nonzeros(S), TvNew))
 # The following methods hook into the AbstractArray similar hierarchy. The first method
 # covers similar(A[, Tv]) calls, which preserve stored-entry structure, and the latter
 # methods cover similar(A[, Tv], shape...) calls, which preserve nothing if the dims
@@ -100,8 +99,8 @@ similar(S::SparseVector, ::Type{TvNew}, ::Type{TiNew}, m::Integer, n::Integer) w
 
 ## Alias detection and prevention
 using Base: dataids, unaliascopy
-Base.dataids(S::SparseVector) = (dataids(S.nzind)..., dataids(S.nzval)...)
-Base.unaliascopy(S::SparseVector) = typeof(S)(S.n, unaliascopy(S.nzind), unaliascopy(S.nzval))
+Base.dataids(S::SparseVector) = (dataids(nonzeroinds(S))..., dataids(nonzeros(S))...)
+Base.unaliascopy(S::SparseVector) = typeof(S)(length(S), unaliascopy(nonzeroinds(S)), unaliascopy(nonzeros(S)))
 
 ### Construct empty sparse vector
 
@@ -109,7 +108,7 @@ spzeros(len::Integer) = spzeros(Float64, len)
 spzeros(::Type{T}, len::Integer) where {T} = SparseVector(len, Int[], T[])
 spzeros(::Type{Tv}, ::Type{Ti}, len::Integer) where {Tv,Ti<:Integer} = SparseVector(len, Ti[], Tv[])
 
-LinearAlgebra.fillstored!(x::SparseVector, y) = (fill!(x.nzval, y); x)
+LinearAlgebra.fillstored!(x::SparseVector, y) = (fill!(nonzeros(x), y); x)
 
 ### Construction from lists of indices and values
 
@@ -335,14 +334,14 @@ julia> SparseArrays.dropstored!(x, 2)
 ```
 """
 function dropstored!(x::SparseVector, i::Integer)
-    if !(1 <= i <= x.n)
+    if !(1 <= i <= length(x::SparseVector))
         throw(BoundsError(x, i))
     end
-    searchk = searchsortedfirst(x.nzind, i)
-    if searchk <= length(x.nzind) && x.nzind[searchk] == i
+    searchk = searchsortedfirst(nonzeroinds(x), i)
+    if searchk <= length(nonzeroinds(x)) && nonzeroinds(x)[searchk] == i
         # Entry x[i] is stored. Drop and return.
-        deleteat!(x.nzind, searchk)
-        deleteat!(x.nzval, searchk)
+        deleteat!(nonzeroinds(x), searchk)
+        deleteat!(nonzeros(x), searchk)
     end
     return x
 end
@@ -355,7 +354,7 @@ end
 # convert SparseMatrixCSC to SparseVector
 function SparseVector{Tv,Ti}(s::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti<:Integer}
     size(s, 2) == 1 || throw(ArgumentError("The input argument must have a single-column."))
-    SparseVector(s.m, s.rowval, s.nzval)
+    SparseVector(size(s, 1), rowvals(s), nonzeros(s))
 end
 
 SparseVector{Tv}(s::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(s)
@@ -427,10 +426,10 @@ SparseVector(s::AbstractVector{Tv}) where {Tv} = SparseVector{Tv,Int}(s)
 SparseVector{Tv}(s::SparseVector{Tv}) where {Tv} = s
 SparseVector{Tv,Ti}(s::SparseVector{Tv,Ti}) where {Tv,Ti} = s
 SparseVector{Tv,Ti}(s::SparseVector) where {Tv,Ti} =
-    SparseVector{Tv,Ti}(s.n, convert(Vector{Ti}, s.nzind), convert(Vector{Tv}, s.nzval))
+    SparseVector{Tv,Ti}(length(s::SparseVector), convert(Vector{Ti}, nonzeroinds(s)), convert(Vector{Tv}, nonzeros(s)))
 
 SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti} =
-    SparseVector{Tv,Ti}(s.n, s.nzind, convert(Vector{Tv}, s.nzval))
+    SparseVector{Tv,Ti}(length(s::SparseVector), nonzeroinds(s), convert(Vector{Tv}, nonzeros(s)))
 
 convert(T::Type{<:SparseVector}, m::AbstractVector) = m isa T ? m : T(m)
 
@@ -443,30 +442,30 @@ function prep_sparsevec_copy_dest!(A::SparseVector, lB, nnzB)
     lA >= lB || throw(BoundsError())
     # If the two vectors have the same length then all the elements in A will be overwritten.
     if length(A) == lB
-        resize!(A.nzval, nnzB)
-        resize!(A.nzind, nnzB)
+        resize!(nonzeros(A), nnzB)
+        resize!(nonzeroinds(A), nnzB)
     else
         nnzA = nnz(A)
 
-        lastmodindA = searchsortedlast(A.nzind, lB)
+        lastmodindA = searchsortedlast(nonzeroinds(A), lB)
         if lastmodindA >= nnzB
             # A will have fewer non-zero elements; unmodified elements are kept at the end.
-            deleteat!(A.nzind, nnzB+1:lastmodindA)
-            deleteat!(A.nzval, nnzB+1:lastmodindA)
+            deleteat!(nonzeroinds(A), nnzB+1:lastmodindA)
+            deleteat!(nonzeros(A), nnzB+1:lastmodindA)
         else
             # A will have more non-zero elements; unmodified elements are kept at the end.
-            resize!(A.nzind, nnzB + nnzA - lastmodindA)
-            resize!(A.nzval, nnzB + nnzA - lastmodindA)
-            copyto!(A.nzind, nnzB+1, A.nzind, lastmodindA+1, nnzA-lastmodindA)
-            copyto!(A.nzval, nnzB+1, A.nzval, lastmodindA+1, nnzA-lastmodindA)
+            resize!(nonzeroinds(A), nnzB + nnzA - lastmodindA)
+            resize!(nonzeros(A), nnzB + nnzA - lastmodindA)
+            copyto!(nonzeroinds(A), nnzB+1, nonzeroinds(A), lastmodindA+1, nnzA-lastmodindA)
+            copyto!(nonzeros(A), nnzB+1, nonzeros(A), lastmodindA+1, nnzA-lastmodindA)
         end
     end
 end
 
 function copyto!(A::SparseVector, B::SparseVector)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))
-    copyto!(A.nzind, B.nzind)
-    copyto!(A.nzval, B.nzval)
+    copyto!(nonzeroinds(A), nonzeroinds(B))
+    copyto!(nonzeros(A), nonzeros(B))
     return A
 end
 
@@ -476,21 +475,21 @@ function copyto!(A::SparseVector, B::SparseMatrixCSC)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))
 
     ptr = 1
-    @assert length(A.nzind) >= length(B.rowval)
-    maximum(B.colptr)-1 <= length(B.rowval) || throw(BoundsError())
-    @inbounds for col=1:length(B.colptr)-1
-        offsetA = (col - 1) * B.m
-        while ptr <= B.colptr[col+1]-1
-            A.nzind[ptr] = B.rowval[ptr] + offsetA
+    @assert length(nonzeroinds(A)) >= length(rowvals(B))
+    maximum(getcolptr(B))-1 <= length(rowvals(B)) || throw(BoundsError())
+    @inbounds for col=1:length(getcolptr(B))-1
+        offsetA = (col - 1) * size(B, 1)
+        while ptr <= getcolptr(B)[col+1]-1
+            nonzeroinds(A)[ptr] = rowvals(B)[ptr] + offsetA
             ptr += 1
         end
     end
-    copyto!(A.nzval, B.nzval)
+    copyto!(nonzeros(A), nonzeros(B))
     return A
 end
 
 copyto!(A::SparseMatrixCSC, B::SparseVector{TvB,TiB}) where {TvB,TiB} =
-    copyto!(A, SparseMatrixCSC{TvB,TiB}(B.n, 1, TiB[1, length(B.nzind)+1], B.nzind, B.nzval))
+    copyto!(A, SparseMatrixCSC{TvB,TiB}(length(B), 1, TiB[1, length(nonzeroinds(B))+1], nonzeroinds(B), nonzeros(B)))
 
 
 ### Rand Construction
@@ -525,26 +524,26 @@ sprandn(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where T = spran
 # Column slices
 function getindex(x::SparseMatrixCSC, ::Colon, j::Integer)
     checkbounds(x, :, j)
-    r1 = convert(Int, x.colptr[j])
-    r2 = convert(Int, x.colptr[j+1]) - 1
-    SparseVector(x.m, x.rowval[r1:r2], x.nzval[r1:r2])
+    r1 = convert(Int, getcolptr(x)[j])
+    r2 = convert(Int, getcolptr(x)[j+1]) - 1
+    SparseVector(size(x, 1), rowvals(x)[r1:r2], nonzeros(x)[r1:r2])
 end
 
 function getindex(x::SparseMatrixCSC, I::AbstractUnitRange, j::Integer)
     checkbounds(x, I, j)
     # Get the selected column
-    c1 = convert(Int, x.colptr[j])
-    c2 = convert(Int, x.colptr[j+1]) - 1
+    c1 = convert(Int, getcolptr(x)[j])
+    c2 = convert(Int, getcolptr(x)[j+1]) - 1
     # Restrict to the selected rows
-    r1 = searchsortedfirst(x.rowval, first(I), c1, c2, Forward)
-    r2 = searchsortedlast(x.rowval, last(I), c1, c2, Forward)
-    SparseVector(length(I), [x.rowval[i] - first(I) + 1 for i = r1:r2], x.nzval[r1:r2])
+    r1 = searchsortedfirst(rowvals(x), first(I), c1, c2, Forward)
+    r2 = searchsortedlast(rowvals(x), last(I), c1, c2, Forward)
+    SparseVector(length(I), [rowvals(x)[i] - first(I) + 1 for i = r1:r2], nonzeros(x)[r1:r2])
 end
 
 # In the general case, we piggy back upon SparseMatrixCSC's optimized solution
 @inline function getindex(A::SparseMatrixCSC, I::AbstractVector, J::Integer)
     M = A[I, [J]]
-    SparseVector(M.m, M.rowval, M.nzval)
+    SparseVector(size(M, 1), rowvals(M), nonzeros(M))
 end
 
 # Row slices
@@ -553,7 +552,7 @@ function Base.getindex(A::SparseMatrixCSC{Tv,Ti}, i::Integer, J::AbstractVector)
     require_one_based_indexing(A, J)
     checkbounds(A, i, J)
     nJ = length(J)
-    colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
+    colptrA = getcolptr(A); rowvalA = rowvals(A); nzvalA = nonzeros(A)
 
     nzinds = Vector{Ti}()
     nzvals = Vector{Tv}()
@@ -589,17 +588,17 @@ function _logical_index(A::SparseMatrixCSC{Tv}, I::AbstractArray{Bool}) where Tv
     n = sum(I)
     nnzB = min(n, nnz(A))
 
-    colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
+    colptrA = getcolptr(A); rowvalA = rowvals(A); nzvalA = nonzeros(A)
     rowvalB = Vector{Int}(undef, nnzB)
     nzvalB = Vector{Tv}(undef, nnzB)
     c = 1
     rowB = 1
 
-    @inbounds for col in 1:A.n
+    @inbounds for col in 1:size(A, 2)
         r1 = colptrA[col]
         r2 = colptrA[col+1]-1
 
-        for row in 1:A.m
+        for row in 1:size(A, 1)
             if I[row, col]
                 while (r1 <= r2) && (rowvalA[r1] < row)
                     r1 += 1
@@ -630,9 +629,9 @@ function getindex(A::SparseMatrixCSC{Tv}, I::AbstractUnitRange) where Tv
     checkbounds(A, I)
     szA = size(A)
     nA = szA[1]*szA[2]
-    colptrA = A.colptr
-    rowvalA = A.rowval
-    nzvalA = A.nzval
+    colptrA = getcolptr(A)
+    rowvalA = rowvals(A)
+    nzvalA = nonzeros(A)
 
     n = length(I)
     nnzB = min(n, nnz(A))
@@ -666,9 +665,9 @@ function getindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector) where {Tv,Ti}
     require_one_based_indexing(A, I)
     szA = size(A)
     nA = szA[1]*szA[2]
-    colptrA = A.colptr
-    rowvalA = A.rowval
-    nzvalA = A.nzval
+    colptrA = getcolptr(A)
+    rowvalA = rowvals(A)
+    nzvalA = nonzeros(A)
 
     n = length(I)
     nnzB = min(n, nnz(A))
@@ -713,8 +712,8 @@ function findall(p::Function, x::SparseVector{<:Any,Ti}) where Ti
     numnz = nnz(x)
     I = Vector{Ti}(undef, numnz)
 
-    nzind = x.nzind
-    nzval = x.nzval
+    nzind = nonzeroinds(x)
+    nzval = nonzeros(x)
 
     count = 1
     @inbounds for i = 1 : numnz
@@ -740,8 +739,8 @@ function findnz(x::SparseVector{Tv,Ti}) where {Tv,Ti}
     I = Vector{Ti}(undef, numnz)
     V = Vector{Tv}(undef, numnz)
 
-    nzind = x.nzind
-    nzval = x.nzval
+    nzind = nonzeroinds(x)
+    nzval = nonzeros(x)
 
     @inbounds for i = 1 : numnz
         I[i] = nzind[i]
@@ -752,20 +751,20 @@ function findnz(x::SparseVector{Tv,Ti}) where {Tv,Ti}
 end
 
 function _sparse_findnextnz(v::SparseVector, i::Integer)
-    n = searchsortedfirst(v.nzind, i)
-    if n > length(v.nzind)
+    n = searchsortedfirst(nonzeroinds(v), i)
+    if n > length(nonzeroinds(v))
         return nothing
     else
-        return v.nzind[n]
+        return nonzeroinds(v)[n]
     end
 end
 
 function _sparse_findprevnz(v::SparseVector, i::Integer)
-    n = searchsortedlast(v.nzind, i)
+    n = searchsortedlast(nonzeroinds(v), i)
     if iszero(n)
         return nothing
     else
-        return v.nzind[n]
+        return nonzeroinds(v)[n]
     end
 end
 
@@ -818,13 +817,13 @@ getindex(x::AbstractSparseVector, I::AbstractVector{Bool}) = x[findall(I)]
 getindex(x::AbstractSparseVector, I::AbstractArray{Bool}) = x[findall(I)]
 @inline function getindex(x::AbstractSparseVector{Tv,Ti}, I::AbstractVector) where {Tv,Ti}
     # SparseMatrixCSC has a nicely optimized routine for this; punt
-    S = SparseMatrixCSC(x.n, 1, Ti[1,length(x.nzind)+1], x.nzind, x.nzval)
+    S = SparseMatrixCSC(length(x::SparseVector), 1, Ti[1,length(nonzeroinds(x))+1], nonzeroinds(x), nonzeros(x))
     S[I, 1]
 end
 
 function getindex(x::AbstractSparseVector{Tv,Ti}, I::AbstractArray) where {Tv,Ti}
     # punt to SparseMatrixCSC
-    S = SparseMatrixCSC(x.n, 1, Ti[1,length(x.nzind)+1], x.nzind, x.nzval)
+    S = SparseMatrixCSC(length(x::SparseVector), 1, Ti[1,length(nonzeroinds(x))+1], nonzeroinds(x), nonzeros(x))
     S[I]
 end
 
@@ -1655,9 +1654,9 @@ function mul!(y::AbstractVector, A::SparseMatrixCSC, x::AbstractSparseVector, α
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
-    Acolptr = A.colptr
-    Arowval = A.rowval
-    Anzval = A.nzval
+    Acolptr = getcolptr(A)
+    Arowval = rowvals(A)
+    Anzval = nonzeros(A)
 
     @inbounds for i = 1:length(xnzind)
         v = xnzval[i]
@@ -1700,9 +1699,9 @@ function _At_or_Ac_mul_B!(tfun::Function,
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
-    Acolptr = A.colptr
-    Arowval = A.rowval
-    Anzval = A.nzval
+    Acolptr = getcolptr(A)
+    Arowval = rowvals(A)
+    Anzval = nonzeros(A)
     mx = length(xnzind)
 
     for j = 1:n
@@ -1739,9 +1738,9 @@ function _At_or_Ac_mul_B(tfun::Function, A::SparseMatrixCSC{TvA,TiA}, x::Abstrac
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
-    Acolptr = A.colptr
-    Arowval = A.rowval
-    Anzval = A.nzval
+    Acolptr = getcolptr(A)
+    Arowval = rowvals(A)
+    Anzval = nonzeros(A)
     mx = length(xnzind)
 
     ynzind = Vector{Ti}(undef, n)
@@ -1806,8 +1805,8 @@ for isunittri in (true, false), islowertri in (true, false)
             # operate on solely b[nzrange] for efficiency.
             if nnz(b) != 0
                 nzrange = $( (islowertri && !istrans) || (!islowertri && istrans) ?
-                    :(b.nzind[1]:b.n) :
-                    :(1:b.nzind[end]) )
+                    :(nonzeroinds(b)[1]:length(b::SparseVector)) :
+                    :(1:nonzeroinds(b)[end]) )
                 nzrangeviewr = view(r, nzrange)
                 nzrangeviewA = $tritype(view(A.data, nzrange, nzrange))
                 LinearAlgebra.ldiv!($xformop(convert(AbstractArray{TAb}, nzrangeviewA)), nzrangeviewr)
@@ -1849,9 +1848,9 @@ for isunittri in (true, false), islowertri in (true, false)
                 # furthermore we operate on that section as a dense vector
                 # such that dispatch has a chance to exploit, e.g., tuned BLAS
                 nzrange = $( (islowertri && !istrans) || (!islowertri && istrans) ?
-                    :(b.nzind[1]:b.n) :
-                    :(1:b.nzind[end]) )
-                nzrangeviewbnz = view(b.nzval, nzrange .- (b.nzind[1] - 1))
+                    :(nonzeroinds(b)[1]:length(b::SparseVector)) :
+                    :(1:nonzeroinds(b)[end]) )
+                nzrangeviewbnz = view(nonzeros(b), nzrange .- (nonzeroinds(b)[1] - 1))
                 nzrangeviewA = $tritype(view(A.data, nzrange, nzrange))
                 LinearAlgebra.ldiv!($xformop(nzrangeviewA), nzrangeviewbnz)
             end
@@ -1861,50 +1860,50 @@ for isunittri in (true, false), islowertri in (true, false)
 end
 
 # helper functions for in-place matrix division operations defined above
-"Densifies `x::SparseVector` from its first nonzero (`x[x.nzind[1]]`) through its end (`x[x.n]`)."
+"Densifies `x::SparseVector` from its first nonzero (`x[nonzeroinds(x)[1]]`) through its end (`x[length(x::SparseVector)]`)."
 function _densifyfirstnztoend!(x::SparseVector)
     # lengthen containers
     oldnnz = nnz(x)
-    newnnz = x.n - x.nzind[1] + 1
-    resize!(x.nzval, newnnz)
-    resize!(x.nzind, newnnz)
+    newnnz = length(x::SparseVector) - nonzeroinds(x)[1] + 1
+    resize!(nonzeros(x), newnnz)
+    resize!(nonzeroinds(x), newnnz)
     # redistribute nonzero values over lengthened container
     # initialize now-allocated zero values simultaneously
     nextpos = newnnz
     @inbounds for oldpos in oldnnz:-1:1
-        nzi = x.nzind[oldpos]
-        nzv = x.nzval[oldpos]
-        newpos = nzi - x.nzind[1] + 1
-        newpos < nextpos && (x.nzval[newpos+1:nextpos] .= 0)
+        nzi = nonzeroinds(x)[oldpos]
+        nzv = nonzeros(x)[oldpos]
+        newpos = nzi - nonzeroinds(x)[1] + 1
+        newpos < nextpos && (nonzeros(x)[newpos+1:nextpos] .= 0)
         newpos == oldpos && break
-        x.nzval[newpos] = nzv
+        nonzeros(x)[newpos] = nzv
         nextpos = newpos - 1
     end
     # finally update lengthened nzinds
-    x.nzind[2:end] = (x.nzind[1]+1):x.n
+    nonzeroinds(x)[2:end] = (nonzeroinds(x)[1]+1):length(x::SparseVector)
     x
 end
-"Densifies `x::SparseVector` from its beginning (`x[1]`) through its last nonzero (`x[x.nzind[end]]`)."
+"Densifies `x::SparseVector` from its beginning (`x[1]`) through its last nonzero (`x[nonzeroinds(x)[end]]`)."
 function _densifystarttolastnz!(x::SparseVector)
     # lengthen containers
     oldnnz = nnz(x)
-    newnnz = x.nzind[end]
-    resize!(x.nzval, newnnz)
-    resize!(x.nzind, newnnz)
+    newnnz = nonzeroinds(x)[end]
+    resize!(nonzeros(x), newnnz)
+    resize!(nonzeroinds(x), newnnz)
     # redistribute nonzero values over lengthened container
     # initialize now-allocated zero values simultaneously
     nextpos = newnnz
     @inbounds for oldpos in oldnnz:-1:1
-        nzi = x.nzind[oldpos]
-        nzv = x.nzval[oldpos]
-        nzi < nextpos && (x.nzval[nzi+1:nextpos] .= 0)
+        nzi = nonzeroinds(x)[oldpos]
+        nzv = nonzeros(x)[oldpos]
+        nzi < nextpos && (nonzeros(x)[nzi+1:nextpos] .= 0)
         nzi == oldpos && (nextpos = 0; break)
-        x.nzval[nzi] = nzv
+        nonzeros(x)[nzi] = nzv
         nextpos = nzi - 1
     end
-    nextpos > 0 && (x.nzval[1:nextpos] .= 0)
+    nextpos > 0 && (nonzeros(x)[1:nextpos] .= 0)
     # finally update lengthened nzinds
-    x.nzind[1:newnnz] = 1:newnnz
+    nonzeroinds(x)[1:newnnz] = 1:newnnz
     x
 end
 
@@ -1921,9 +1920,9 @@ function sort(x::SparseVector{Tv,Ti}; kws...) where {Tv,Ti}
 end
 
 function fkeep!(x::SparseVector, f, trim::Bool = true)
-    n = x.n
-    nzind = x.nzind
-    nzval = x.nzval
+    n = length(x::SparseVector)
+    nzind = nonzeroinds(x)
+    nzval = nonzeros(x)
 
     x_writepos = 1
     @inbounds for xk in 1:nnz(x)
@@ -1955,7 +1954,7 @@ end
     droptol!(x::SparseVector, tol; trim::Bool = true)
 
 Removes stored values from `x` whose absolute value is less than or equal to `tol`,
-optionally trimming resulting excess space from `A.rowval` and `A.nzval` when `trim`
+optionally trimming resulting excess space from `rowvals(A)` and `nonzeros(A)` when `trim`
 is `true`.
 """
 droptol!(x::SparseVector, tol; trim::Bool = true) = fkeep!(x, (i, x) -> abs(x) > tol, trim)
@@ -1964,7 +1963,7 @@ droptol!(x::SparseVector, tol; trim::Bool = true) = fkeep!(x, (i, x) -> abs(x) >
     dropzeros!(x::SparseVector; trim::Bool = true)
 
 Removes stored numerical zeros from `x`, optionally trimming resulting excess space from
-`x.nzind` and `x.nzval` when `trim` is `true`.
+`nonzeroinds(x)` and `nonzeros(x)` when `trim` is `true`.
 
 For an out-of-place version, see [`dropzeros`](@ref). For
 algorithmic information, see `fkeep!`.
@@ -1996,29 +1995,29 @@ julia> dropzeros(A)
 dropzeros(x::SparseVector; trim::Bool = true) = dropzeros!(copy(x), trim = trim)
 
 function copy!(dst::SparseVector, src::SparseVector)
-    dst.n == src.n || throw(ArgumentError("Sparse vectors should have the same length for copy!"))
-    copy!(dst.nzval, src.nzval)
-    copy!(dst.nzind, src.nzind)
+    length(dst::SparseVector) == length(src::SparseVector) || throw(ArgumentError("Sparse vectors should have the same length for copy!"))
+    copy!(nonzeros(dst), nonzeros(src))
+    copy!(nonzeroinds(dst), nonzeroinds(src))
     return dst
 end
 
 function copy!(dst::SparseVector, src::AbstractVector)
-    dst.n == length(src) || throw(ArgumentError("Sparse vector should have the same length as source for copy!"))
-    _dense2indval!(dst.nzind, dst.nzval, src)
+    length(dst::SparseVector) == length(src) || throw(ArgumentError("Sparse vector should have the same length as source for copy!"))
+    _dense2indval!(nonzeroinds(dst), nonzeros(dst), src)
     return dst
 end
 
 function _fillnonzero!(arr::SparseMatrixCSC{Tv, Ti}, val) where {Tv,Ti}
     m, n = size(arr)
-    resize!(arr.colptr, n+1)
-    resize!(arr.rowval, m*n)
-    resize!(arr.nzval, m*n)
-    copyto!(arr.colptr, 1:m:n*m+1)
-    fill!(arr.nzval, val)
+    resize!(getcolptr(arr), n+1)
+    resize!(rowvals(arr), m*n)
+    resize!(nonzeros(arr), m*n)
+    copyto!(getcolptr(arr), 1:m:n*m+1)
+    fill!(nonzeros(arr), val)
     index = 1
     @inbounds for _ in 1:n
         for i in 1:m
-            arr.rowval[index] = Ti(i)
+            rowvals(arr)[index] = Ti(i)
             index += 1
         end
     end
@@ -2026,13 +2025,13 @@ function _fillnonzero!(arr::SparseMatrixCSC{Tv, Ti}, val) where {Tv,Ti}
 end
 
 function _fillnonzero!(arr::SparseVector{Tv,Ti}, val) where {Tv,Ti}
-    n = arr.n
-    resize!(arr.nzind, n)
-    resize!(arr.nzval, n)
+    n = length(arr::SparseVector)
+    resize!(nonzeroinds(arr), n)
+    resize!(nonzeros(arr), n)
     @inbounds for i in 1:n
-        arr.nzind[i] = Ti(i)
+        nonzeroinds(arr)[i] = Ti(i)
     end
-    fill!(arr.nzval, val)
+    fill!(nonzeros(arr), val)
     arr
 end
 
@@ -2041,7 +2040,7 @@ function fill!(A::Union{SparseVector, SparseMatrixCSC}, x)
     T = eltype(A)
     xT = convert(T, x)
     if xT == zero(T)
-        fill!(A.nzval, xT)
+        fill!(nonzeros(A), xT)
     else
         _fillnonzero!(A, xT)
     end
@@ -2080,7 +2079,7 @@ end
 
 function circshift!(O::SparseVector, X::SparseVector, (r,)::Base.DimsInteger{1})
     copy!(O, X)
-    subvector_shifter!(O.nzind, O.nzval, 1, length(O.nzind), O.n, mod(r, X.n))
+    subvector_shifter!(nonzeroinds(O), nonzeros(O), 1, length(nonzeroinds(O)), length(O), mod(r, length(X)))
     return O
 end
 

--- a/stdlib/SparseArrays/test/forbidproperties.jl
+++ b/stdlib/SparseArrays/test/forbidproperties.jl
@@ -1,0 +1,3 @@
+using SparseArrays
+Base.getproperty(S::SparseMatrixCSC, ::Symbol) = error("use accessor function")
+Base.getproperty(S::SparseVector, ::Symbol) = error("use accessor function")

--- a/stdlib/SparseArrays/test/higherorderfns.jl
+++ b/stdlib/SparseArrays/test/higherorderfns.jl
@@ -10,6 +10,7 @@ using Test
 using SparseArrays
 using LinearAlgebra
 using Random
+include("forbidproperties.jl")
 
 @testset "map[!] implementation specialized for a single (input) sparse vector/matrix" begin
     N, M = 10, 12

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -4,12 +4,14 @@ module SparseTests
 
 using Test
 using SparseArrays
+using SparseArrays: getcolptr, nonzeroinds
 using LinearAlgebra
 using Base.Printf: @printf
 using Random
 using Test: guardseed
 using InteractiveUtils: @which
 using Dates
+include("forbidproperties.jl")
 
 @testset "issparse" begin
     @test issparse(sparse(fill(1,5,5)))
@@ -114,14 +116,14 @@ end
 
     @testset "horizontal concatenation" begin
         @test [se33 se33] == [Array(se33) Array(se33)]
-        @test length(([sp33 0I]).nzval) == 3
+        @test length(nonzeros([sp33 0I])) == 3
     end
 
     @testset "vertical concatenation" begin
         @test [se33; se33] == [Array(se33); Array(se33)]
         se33_32bit = convert(SparseMatrixCSC{Float32,Int32}, se33)
         @test [se33; se33_32bit] == [Array(se33); Array(se33_32bit)]
-        @test length(([sp33; 0I]).nzval) == 3
+        @test length(nonzeros([sp33; 0I])) == 3
     end
 
     se44 = sparse(1.0I, 4, 4)
@@ -131,7 +133,7 @@ end
     se77 = sparse(1.0I, 7, 7)
     @testset "h+v concatenation" begin
         @test [se44 sz42 sz41; sz34 se33] == se77
-        @test length(([sp33 0I; 1I 0I]).nzval) == 6
+        @test length(nonzeros([sp33 0I; 1I 0I])) == 6
     end
 
     @testset "blockdiag concatenation" begin
@@ -491,9 +493,9 @@ end
     B = sprand(5, 5, 0.2)
     copyto!(A, B)
     @test A == B
-    @test pointer(A.nzval) != pointer(B.nzval)
-    @test pointer(A.rowval) != pointer(B.rowval)
-    @test pointer(A.colptr) != pointer(B.colptr)
+    @test pointer(nonzeros(A)) != pointer(nonzeros(B))
+    @test pointer(rowvals(A)) != pointer(rowvals(B))
+    @test pointer(getcolptr(A)) != pointer(getcolptr(B))
     # Test size(A) != size(B), but length(A) == length(B)
     B = sprand(25, 1, 0.2)
     copyto!(A, B)
@@ -544,8 +546,8 @@ end
     @testset "common error checking of [c]transpose! methods (ftranspose!)" begin
         @test_throws DimensionMismatch transpose!(A[:, 1:(smalldim - 1)], A)
         @test_throws DimensionMismatch transpose!(A[1:(smalldim - 1), 1], A)
-        @test_throws ArgumentError transpose!((B = similar(A); resize!(B.rowval, nnz(A) - 1); B), A)
-        @test_throws ArgumentError transpose!((B = similar(A); resize!(B.nzval, nnz(A) - 1); B), A)
+        @test_throws ArgumentError transpose!((B = similar(A); resize!(rowvals(B), nnz(A) - 1); B), A)
+        @test_throws ArgumentError transpose!((B = similar(A); resize!(nonzeros(B), nnz(A) - 1); B), A)
     end
     @testset "common error checking of permute[!] methods / source-perm compat" begin
         @test_throws DimensionMismatch permute(A, p[1:(end - 1)], q)
@@ -554,17 +556,17 @@ end
     @testset "common error checking of permute[!] methods / source-dest compat" begin
         @test_throws DimensionMismatch permute!(A[1:(m - 1), :], A, p, q)
         @test_throws DimensionMismatch permute!(A[:, 1:(m - 1)], A, p, q)
-        @test_throws ArgumentError permute!((Y = copy(X); resize!(Y.rowval, nnz(A) - 1); Y), A, p, q)
-        @test_throws ArgumentError permute!((Y = copy(X); resize!(Y.nzval, nnz(A) - 1); Y), A, p, q)
+        @test_throws ArgumentError permute!((Y = copy(X); resize!(rowvals(Y), nnz(A) - 1); Y), A, p, q)
+        @test_throws ArgumentError permute!((Y = copy(X); resize!(nonzeros(Y), nnz(A) - 1); Y), A, p, q)
     end
     @testset "common error checking of permute[!] methods / source-workmat compat" begin
         @test_throws DimensionMismatch permute!(X, A, p, q, C[1:(m - 1), :])
         @test_throws DimensionMismatch permute!(X, A, p, q, C[:, 1:(m - 1)])
-        @test_throws ArgumentError permute!(X, A, p, q, (D = copy(C); resize!(D.rowval, nnz(A) - 1); D))
-        @test_throws ArgumentError permute!(X, A, p, q, (D = copy(C); resize!(D.nzval, nnz(A) - 1); D))
+        @test_throws ArgumentError permute!(X, A, p, q, (D = copy(C); resize!(rowvals(D), nnz(A) - 1); D))
+        @test_throws ArgumentError permute!(X, A, p, q, (D = copy(C); resize!(nonzeros(D), nnz(A) - 1); D))
     end
     @testset "common error checking of permute[!] methods / source-workcolptr compat" begin
-        @test_throws DimensionMismatch permute!(A, p, q, C, Vector{eltype(A.rowval)}(undef, length(A.colptr) - 1))
+        @test_throws DimensionMismatch permute!(A, p, q, C, Vector{eltype(rowvals(A))}(undef, length(getcolptr(A)) - 1))
     end
     @testset "common error checking of permute[!] methods / permutation validity" begin
         @test_throws ArgumentError permute!(A, (r = copy(p); r[2] = r[1]; r), q)
@@ -594,7 +596,7 @@ end
             @test permute!(similar(A), A, p, q, similar(At)) == fullPAQ
             @test permute!(copy(A), p, q) == fullPAQ
             @test permute!(copy(A), p, q, similar(At)) == fullPAQ
-            @test permute!(copy(A), p, q, similar(At), similar(A.colptr)) == fullPAQ
+            @test permute!(copy(A), p, q, similar(At), similar(getcolptr(A))) == fullPAQ
         end
     end
 end
@@ -922,7 +924,7 @@ end
     @test nnz(a) == 20
     @test count(!iszero, a) == 11
     a = copy(b)
-    a[1:2,:] = let c = sparse(fill(1,2,10)); fill!(c.nzval, 0); c; end
+    a[1:2,:] = let c = sparse(fill(1,2,10)); fill!(nonzeros(c), 0); c; end
     @test nnz(a) == 19
     @test count(!iszero, a) == 8
     a[1:2,1:3] = let c = sparse(fill(1,2,3)); c[1,2] = c[2,1] = c[2,2] = 0; c; end
@@ -1346,7 +1348,7 @@ end
     debug = false
 
     if debug
-        println("row sizes: $([round(Int,nnz(S)/S.n) for S in SA])")
+        println("row sizes: $([round(Int,nnz(S)/size(S, 2)) for S in SA])")
         println("I sizes: $([length(I) for I in IA])")
         @printf("    S    |    I    | binary S | binary I |  linear  | best\n")
     end
@@ -1369,7 +1371,7 @@ end
             end
 
             if debug
-                @printf(" %7d | %7d | %4.2e | %4.2e | %4.2e | %s\n", round(Int,nnz(S)/S.n), length(I), times[1], times[2], times[3],
+                @printf(" %7d | %7d | %4.2e | %4.2e | %4.2e | %s\n", round(Int,nnz(S)/size(S, 2)), length(I), times[1], times[2], times[3],
                             (0 == best[2]) ? "binary S" : (1 == best[2]) ? "binary I" : "linear")
             end
             if res[1] != res[2]
@@ -1419,7 +1421,7 @@ end
             GC.gc()
             rs = @timed S[Isorted, Jsorted]
             if debug
-                @printf(" %7d | %7d | %7d | %4.2e | %4.2e | %4.2e | %4.2e |\n", round(Int,nnz(S)/S.n), length(I), length(J), rs[2], ru[2], rs[3], ru[3])
+                @printf(" %7d | %7d | %7d | %4.2e | %4.2e | %4.2e | %4.2e |\n", round(Int,nnz(S)/size(S, 2)), length(I), length(J), rs[2], ru[2], rs[3], ru[3])
             end
         end
     end
@@ -1554,7 +1556,7 @@ end
     local A = guardseed(1234321) do
         triu(sprand(10, 10, 0.2))
     end
-    @test SparseArrays.droptol!(A, 0.01).colptr ==  [1, 2, 2, 3, 4, 5, 5, 6, 8, 10, 13]
+    @test getcolptr(SparseArrays.droptol!(A, 0.01)) == [1, 2, 2, 3, 4, 5, 5, 6, 8, 10, 13]
     @test isequal(SparseArrays.droptol!(sparse([1], [1], [1]), 1), SparseMatrixCSC(1, 1, Int[1, 1], Int[], Int[]))
 end
 
@@ -1575,9 +1577,9 @@ end
         Anegzeros[negzerosinds] .= -2
         Abothsigns = copy(Aposzeros)
         Abothsigns[negzerosinds] .= -2
-        map!(x -> x == 2 ? 0.0 : x, Aposzeros.nzval, Aposzeros.nzval)
-        map!(x -> x == -2 ? -0.0 : x, Anegzeros.nzval, Anegzeros.nzval)
-        map!(x -> x == 2 ? 0.0 : x == -2 ? -0.0 : x, Abothsigns.nzval, Abothsigns.nzval)
+        map!(x -> x == 2 ? 0.0 : x, nonzeros(Aposzeros), nonzeros(Aposzeros))
+        map!(x -> x == -2 ? -0.0 : x, nonzeros(Anegzeros), nonzeros(Anegzeros))
+        map!(x -> x == 2 ? 0.0 : x == -2 ? -0.0 : x, nonzeros(Abothsigns), nonzeros(Abothsigns))
         for Awithzeros in (Aposzeros, Anegzeros, Abothsigns)
             # Basic functionality / dropzeros!
             @test dropzeros!(copy(Awithzeros)) == A
@@ -1586,16 +1588,16 @@ end
             @test dropzeros(Awithzeros) == A
             @test dropzeros(Awithzeros, trim = false) == A
             # Check trimming works as expected
-            @test length(dropzeros!(copy(Awithzeros)).nzval) == length(A.nzval)
-            @test length(dropzeros!(copy(Awithzeros)).rowval) == length(A.rowval)
-            @test length(dropzeros!(copy(Awithzeros), trim = false).nzval) == length(Awithzeros.nzval)
-            @test length(dropzeros!(copy(Awithzeros), trim = false).rowval) == length(Awithzeros.rowval)
+            @test length(nonzeros(dropzeros!(copy(Awithzeros)))) == length(nonzeros(A))
+            @test length(rowvals(dropzeros!(copy(Awithzeros)))) == length(rowvals(A))
+            @test length(nonzeros(dropzeros!(copy(Awithzeros), trim = false))) == length(nonzeros(Awithzeros))
+            @test length(rowvals(dropzeros!(copy(Awithzeros), trim = false))) == length(rowvals(Awithzeros))
         end
     end
     # original lone dropzeros test
     local A = sparse([1 2 3; 4 5 6; 7 8 9])
-    A.nzval[2] = A.nzval[6] = A.nzval[7] = 0
-    @test dropzeros!(A).colptr == [1, 3, 5, 7]
+    nonzeros(A)[2] = nonzeros(A)[6] = nonzeros(A)[7] = 0
+    @test getcolptr(dropzeros!(A)) == [1, 3, 5, 7]
     # test for issue #5169, modified for new behavior following #15242/#14798
     @test nnz(sparse([1, 1], [1, 2], [0.0, -0.0])) == 2
     @test nnz(dropzeros!(sparse([1, 1], [1, 2], [0.0, -0.0]))) == 0
@@ -1653,15 +1655,15 @@ end
     end
     # test that stored zeros are still stored zeros in the diagonal
     S = sparse([1,3],[1,3],[0.0,0.0]); V = diag(S)
-    @test V.nzind == [1,3]
-    @test V.nzval == [0.0,0.0]
+    @test nonzeroinds(V) == [1,3]
+    @test nonzeros(V) == [0.0,0.0]
 end
 
 @testset "expandptr" begin
     local A = sparse(1.0I, 5, 5)
-    @test SparseArrays.expandptr(A.colptr) == 1:5
+    @test SparseArrays.expandptr(getcolptr(A)) == 1:5
     A[1,2] = 1
-    @test SparseArrays.expandptr(A.colptr) == [1; 2; 2; 3; 4; 5]
+    @test SparseArrays.expandptr(getcolptr(A)) == [1; 2; 2; 3; 4; 5]
     @test_throws ArgumentError SparseArrays.expandptr([2; 3])
 end
 
@@ -1679,7 +1681,7 @@ end
     @test triu(A, n + 2) == zero(A)
 
     # fkeep trim option
-    @test isequal(length(tril!(sparse([1,2,3], [1,2,3], [1,2,3], 3, 4), -1).rowval), 0)
+    @test isequal(length(rowvals(tril!(sparse([1,2,3], [1,2,3], [1,2,3], 3, 4), -1))), 0)
 end
 
 @testset "norm" begin
@@ -1728,7 +1730,7 @@ end
     # explicit zeros
     A = sparse(ComplexF64(1)I, 5, 5)
     A[3,1] = 2
-    A.nzval[2] = 0.0
+    nonzeros(A)[2] = 0.0
     @test ishermitian(A) == true
     @test issymmetric(A) == true
 
@@ -1739,7 +1741,7 @@ end
     nzval = [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0]
     A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
     @test issymmetric(A) == true
-    A.nzval[end - 3]  = 2.0
+    nonzeros(A)[end - 3]  = 2.0
     @test issymmetric(A) == false
 
     # 16521
@@ -1832,8 +1834,8 @@ end
     # the range specified in colptr do not
     # impact norm of a sparse matrix
     foo = sparse(1.0I, 4, 4)
-    resize!(foo.nzval, 5)
-    setindex!(foo.nzval, NaN, 5)
+    resize!(nonzeros(foo), 5)
+    setindex!(nonzeros(foo), NaN, 5)
     @test norm(foo) == 2.0
 
     # Test (m x 1) sparse matrix
@@ -2103,15 +2105,15 @@ end
     x = sparse(rand(3,3))
     SparseArrays.dropstored!(x, 1, 1)
     @test x[1, 1] == 0.0
-    @test x.colptr == [1, 3, 6, 9]
+    @test getcolptr(x) == [1, 3, 6, 9]
     SparseArrays.dropstored!(x, 2, 1)
-    @test x.colptr == [1, 2, 5, 8]
+    @test getcolptr(x) == [1, 2, 5, 8]
     @test x[2, 1] == 0.0
     SparseArrays.dropstored!(x, 2, 2)
-    @test x.colptr == [1, 2, 4, 7]
+    @test getcolptr(x) == [1, 2, 4, 7]
     @test x[2, 2] == 0.0
     SparseArrays.dropstored!(x, 2, 3)
-    @test x.colptr == [1, 2, 4, 6]
+    @test getcolptr(x) == [1, 2, 4, 6]
     @test x[2, 3] == 0.0
 end
 
@@ -2211,8 +2213,8 @@ end
     b = similar(a, Float32, Int32)
     c = similar(b, Float32, Int32)
     SparseArrays.dropstored!(b, 1, 1)
-    @test length(c.rowval) == 9
-    @test length(c.nzval) == 9
+    @test length(rowvals(c)) == 9
+    @test length(nonzeros(c)) == 9
 end
 
 @testset "similar with type conversion" begin
@@ -2231,62 +2233,62 @@ end
     simA = similar(A)
     @test typeof(simA) == typeof(A)
     @test size(simA) == size(A)
-    @test simA.colptr == A.colptr
-    @test simA.rowval == A.rowval
-    @test length(simA.nzval) == length(A.nzval)
+    @test getcolptr(simA) == getcolptr(A)
+    @test rowvals(simA) == rowvals(A)
+    @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type specification (preserves stored-entry structure)
     simA = similar(A, Float32)
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(A.colptr)}
+    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(getcolptr(A))}
     @test size(simA) == size(A)
-    @test simA.colptr == A.colptr
-    @test simA.rowval == A.rowval
-    @test length(simA.nzval) == length(A.nzval)
+    @test getcolptr(simA) == getcolptr(A)
+    @test rowvals(simA) == rowvals(A)
+    @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry and index type specification (preserves stored-entry structure)
     simA = similar(A, Float32, Int8)
     @test typeof(simA) == SparseMatrixCSC{Float32,Int8}
     @test size(simA) == size(A)
-    @test simA.colptr == A.colptr
-    @test simA.rowval == A.rowval
-    @test length(simA.nzval) == length(A.nzval)
+    @test getcolptr(simA) == getcolptr(A)
+    @test rowvals(simA) == rowvals(A)
+    @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with Dims{2} specification (preserves storage space only, not stored-entry structure)
     simA = similar(A, (6,6))
     @test typeof(simA) == typeof(A)
     @test size(simA) == (6,6)
-    @test simA.colptr == fill(1, 6+1)
-    @test length(simA.rowval) == length(A.rowval)
-    @test length(simA.nzval) == length(A.nzval)
+    @test getcolptr(simA) == fill(1, 6+1)
+    @test length(rowvals(simA)) == length(rowvals(A))
+    @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(A.colptr)}
+    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(getcolptr(A))}
     @test size(simA) == (6,6)
-    @test simA.colptr == fill(1, 6+1)
-    @test length(simA.rowval) == length(A.rowval)
-    @test length(simA.nzval) == length(A.nzval)
+    @test getcolptr(simA) == fill(1, 6+1)
+    @test length(rowvals(simA)) == length(rowvals(A))
+    @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type, index type, and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, Int8, (6,6))
     @test typeof(simA) == SparseMatrixCSC{Float32, Int8}
     @test size(simA) == (6,6)
-    @test simA.colptr == fill(1, 6+1)
-    @test length(simA.rowval) == length(A.rowval)
-    @test length(simA.nzval) == length(A.nzval)
+    @test getcolptr(simA) == fill(1, 6+1)
+    @test length(rowvals(simA)) == length(rowvals(A))
+    @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with Dims{1} specification (preserves nothing)
     simA = similar(A, (6,))
-    @test typeof(simA) == SparseVector{eltype(A.nzval),eltype(A.colptr)}
+    @test typeof(simA) == SparseVector{eltype(nonzeros(A)),eltype(getcolptr(A))}
     @test size(simA) == (6,)
-    @test length(simA.nzind) == 0
-    @test length(simA.nzval) == 0
+    @test length(nonzeroinds(simA)) == 0
+    @test length(nonzeros(simA)) == 0
     # test similar with entry type and Dims{1} specification (preserves nothing)
     simA = similar(A, Float32, (6,))
-    @test typeof(simA) == SparseVector{Float32,eltype(A.colptr)}
+    @test typeof(simA) == SparseVector{Float32,eltype(getcolptr(A))}
     @test size(simA) == (6,)
-    @test length(simA.nzind) == 0
-    @test length(simA.nzval) == 0
+    @test length(nonzeroinds(simA)) == 0
+    @test length(nonzeros(simA)) == 0
     # test similar with entry type, index type, and Dims{1} specification (preserves nothing)
     simA = similar(A, Float32, Int8, (6,))
     @test typeof(simA) == SparseVector{Float32,Int8}
     @test size(simA) == (6,)
-    @test length(simA.nzind) == 0
-    @test length(simA.nzval) == 0
+    @test length(nonzeroinds(simA)) == 0
+    @test length(nonzeros(simA)) == 0
     # test entry points to similar with entry type, index type, and non-Dims shape specification
     @test similar(A, Float32, Int8, 6, 6) == similar(A, Float32, Int8, (6, 6))
     @test similar(A, Float32, Int8, 6) == similar(A, Float32, Int8, (6,))
@@ -2296,7 +2298,7 @@ end
     # count should throw for sparse arrays for which zero(eltype) does not exist
     @test_throws MethodError count(SparseMatrixCSC(2, 2, Int[1, 2, 3], Int[1, 2], Any[true, true]))
     @test_throws MethodError count(SparseVector(2, Int[1], Any[true]))
-    # count should run only over S.nzval[1:nnz(S)], not S.nzval in full
+    # count should run only over nonzeros(S)[1:nnz(S)], not nonzeros(S) in full
     @test count(SparseMatrixCSC(2, 2, Int[1, 2, 3], Int[1, 2], Bool[true, true, true])) == 2
 end
 
@@ -2629,8 +2631,8 @@ end
     A = SparseMatrixCSC(Complex{BigInt}[1+im 2+2im]')'[1:1, 2:2]
     # ...ensure it does! If necessary, the test needs to be updated to use
     # another mechanism to create a suitable A.
-    resize!(A.nzval, 2)
-    @assert length(A.nzval) > nnz(A)
+    resize!(nonzeros(A), 2)
+    @assert length(nonzeros(A)) > nnz(A)
     @test -A == fill(-2-2im, 1, 1)
     @test conj(A) == fill(2-2im, 1, 1)
     conj!(A)

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -1003,9 +1003,9 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::SparseMatrixCSC{Tv,Ti}, mea
     isempty(R) || fill!(R, zero(S))
     isempty(A) && return R
 
-    colptr = A.colptr
-    rowval = A.rowval
-    nzval = A.nzval
+    colptr = getcolptr(A)
+    rowval = rowvals(A)
+    nzval = nonzeros(A)
     m = size(A, 1)
     n = size(A, 2)
 

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -8,6 +8,7 @@ Standard library module for basic statistics functionality.
 module Statistics
 
 using LinearAlgebra, SparseArrays
+using SparseArrays: getcolptr
 
 using Base: has_offset_axes, require_one_based_indexing
 


### PR DESCRIPTION
This is the first step towards extensible sparse arrays. Based on discussion with @ViralBShah https://github.com/JuliaLang/julia/pull/30173#issuecomment-506602182, I changed all code touching fields of `SparseMatrixCSC` and `SparseVector` with the corresponding accessor methods that already exist.

I'd like to make this PR minimal and mechanistic to focus on the refactoring side. I prefer to do the second step mentioned in https://github.com/JuliaLang/julia/pull/30173#issuecomment-506602182 later.
