### PR TITLE
Add missing `seed!(::_GLOBAL_RNG)` method

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -320,6 +320,7 @@ copy(::_GLOBAL_RNG) = copy(default_rng())
 seed!(::_GLOBAL_RNG, seed::Vector{UInt32}) = seed!(default_rng(), seed)
 seed!(::_GLOBAL_RNG, n::Integer) = seed!(default_rng(), n)
 seed!(::_GLOBAL_RNG, ::Nothing) = seed!(default_rng(), nothing)
+seed!(::_GLOBAL_RNG) = seed!(default_rng(), nothing)
 
 rng_native_52(::_GLOBAL_RNG) = rng_native_52(default_rng())
 rand(::_GLOBAL_RNG, sp::SamplerBoolBitInteger) = rand(default_rng(), sp)

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -722,6 +722,7 @@ end
     @test Random.seed!(GLOBAL_RNG, nothing) === LOCAL_RNG
     @test Random.seed!(GLOBAL_RNG, UInt32[0]) === LOCAL_RNG
     @test Random.seed!(GLOBAL_RNG, 0) === LOCAL_RNG
+    @test Random.seed!(GLOBAL_RNG) === LOCAL_RNG
 
     mt = MersenneTwister(1)
     @test copy!(mt, GLOBAL_RNG) === mt


### PR DESCRIPTION
The docs specify that this is a supported method, and needed for Revise tests to pass on 1.3+.