### PR TITLE
Corrected precedence ordering

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -39,7 +39,7 @@
 
 (define prec-names '(prec-assignment
                      prec-pair prec-conditional prec-lazy-or prec-lazy-and prec-arrow prec-comparison
-                     prec-pipe< prec-pipe> prec-colon prec-plus prec-bitshift prec-times prec-rational
+                     prec-pipe< prec-pipe> prec-colon prec-plus prec-times prec-rational prec-bitshift 
                      prec-power prec-decl prec-dot))
 
 (define trans-op (string->symbol ".'"))


### PR DESCRIPTION
`Base.operator_precedence` lists `>> << >>>` as having a lower precedence than `//` and `*`, but a `dump` of a few expressions reveals this to be a bug in `operator_precedence`. It in fact has higher precedence.

See [this error in the Julia documentation](https://github.com/JuliaLang/julia/pull/32944) for more.