### PR TITLE
Corrected precedence ordering (2)

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -38,7 +38,7 @@
 (define prec-dot         '(|.|))
 
 (define prec-names '(prec-assignment
-                     prec-pair prec-conditional prec-lazy-or prec-lazy-and prec-arrow prec-comparison
+                     prec-pair prec-conditional prec-arrow prec-lazy-or prec-lazy-and prec-comparison
                      prec-pipe< prec-pipe> prec-colon prec-plus prec-times prec-rational prec-bitshift
                      prec-power prec-decl prec-dot))
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -39,7 +39,7 @@
 
 (define prec-names '(prec-assignment
                      prec-pair prec-conditional prec-lazy-or prec-lazy-and prec-arrow prec-comparison
-                     prec-pipe< prec-pipe> prec-colon prec-plus prec-bitshift prec-times prec-rational
+                     prec-pipe< prec-pipe> prec-colon prec-plus prec-times prec-rational prec-bitshift 
                      prec-power prec-decl prec-dot))
 
 (define trans-op (string->symbol ".'"))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -39,7 +39,7 @@
 
 (define prec-names '(prec-assignment
                      prec-pair prec-conditional prec-lazy-or prec-lazy-and prec-arrow prec-comparison
-                     prec-pipe< prec-pipe> prec-colon prec-plus prec-times prec-rational prec-bitshift 
+                     prec-pipe< prec-pipe> prec-colon prec-plus prec-times prec-rational prec-bitshift
                      prec-power prec-decl prec-dot))
 
 (define trans-op (string->symbol ".'"))

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -197,7 +197,6 @@ end
     @test fy(x) == x / y
 end
 
-
 @testset "curried comparisons" begin
     eql5 = (==)(5)
     neq5 = (!=)(5)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -352,3 +352,15 @@ end
         @test isequal(parse(Float64, s), sign(v))
     end
 end
+
+@testset "operator precedence correctness" begin
+    ops = map(Symbol, split("= => || && --> < <| |> : + * // << ^ :: ."))
+    for f in ops, g in ops
+        f == g && continue
+        pf = Base.operator_precedence(f)
+        pg = Base.operator_precedence(g)
+        @test pf != pg
+        expr = Meta.parse("x$(f)y$(g)z")
+        @test expr == Meta.parse(pf > pg ? "(x$(f)y)$(g)z" : "x$(f)(y$(g)z)")
+    end
+end


### PR DESCRIPTION
`Base.operator_precedence` lists `>> << >>>` as having a lower precedence than `//` and `*`, but a `dump` of a few expressions reveals this to be a bug in `operator_precedence`. It in fact has higher precedence.

See [this error in the Julia documentation](https://github.com/JuliaLang/julia/pull/32944) for more.


(I had [another PR](https://github.com/JuliaLang/julia/pull/32962) but it failed code tests due to trailing whitespace. Oops!)
