### PR TITLE
remove trim option to fkeep! and related functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,10 @@ Standard library changes
 
 #### SparseArrays
 * `lu!` accepts `UmfpackLU` as an argument to make use of its symbolic factorization.
+* The `trim` keyword argument for the functions `fkeep!`, `tril!`, `triu!`,
+  `droptol!`,`dropzeros!` and `dropzeros` has been removed in favour of always
+  trimming. Calling these with `trim=false` could result in invalid sparse
+  arrays.
 
 #### Dates
 

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1920,7 +1920,7 @@ function sort(x::SparseVector{Tv,Ti}; kws...) where {Tv,Ti}
     SparseVector(n,newnzind,newnzvals)
 end
 
-function fkeep!(x::SparseVector, f, trim::Bool = true)
+function fkeep!(x::SparseVector, f)
     n = length(x::SparseVector)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
@@ -1939,43 +1939,35 @@ function fkeep!(x::SparseVector, f, trim::Bool = true)
         end
     end
 
-    # Trim x's storage if necessary and desired
-    if trim
-        x_nnz = x_writepos - 1
-        if length(nzind) != x_nnz
-            resize!(nzval, x_nnz)
-            resize!(nzind, x_nnz)
-        end
-    end
+    # Trim x's storage if necessary
+    x_nnz = x_writepos - 1
+    resize!(nzval, x_nnz)
+    resize!(nzind, x_nnz)
 
-    x
+    return x
 end
 
 """
-    droptol!(x::SparseVector, tol; trim::Bool = true)
+    droptol!(x::SparseVector, tol)
 
-Removes stored values from `x` whose absolute value is less than or equal to `tol`,
-optionally trimming resulting excess space from `nonzeroinds(x)` and `nonzeros(x)` when `trim`
-is `true`.
+Removes stored values from `x` whose absolute value is less than or equal to `tol`.
 """
-droptol!(x::SparseVector, tol; trim::Bool = true) = fkeep!(x, (i, x) -> abs(x) > tol, trim)
+droptol!(x::SparseVector, tol) = fkeep!(x, (i, x) -> abs(x) > tol)
 
 """
-    dropzeros!(x::SparseVector; trim::Bool = true)
+    dropzeros!(x::SparseVector)
 
-Removes stored numerical zeros from `x`, optionally trimming resulting excess space from
-`nonzeroinds(x)` and `nonzeros(x)` when `trim` is `true`.
+Removes stored numerical zeros from `x`.
 
 For an out-of-place version, see [`dropzeros`](@ref). For
 algorithmic information, see `fkeep!`.
 """
-dropzeros!(x::SparseVector; trim::Bool = true) = fkeep!(x, (i, x) -> !iszero(x), trim)
+dropzeros!(x::SparseVector) = fkeep!(x, (i, x) -> !iszero(x))
 
 """
-    dropzeros(x::SparseVector; trim::Bool = true)
+    dropzeros(x::SparseVector)
 
-Generates a copy of `x` and removes numerical zeros from that copy, optionally trimming
-excess space from the result's `nzind` and `nzval` arrays when `trim` is `true`.
+Generates a copy of `x` and removes numerical zeros from that copy.
 
 For an in-place version and algorithmic information, see [`dropzeros!`](@ref).
 
@@ -1993,7 +1985,7 @@ julia> dropzeros(A)
   [3]  =  1.0
 ```
 """
-dropzeros(x::SparseVector; trim::Bool = true) = dropzeros!(copy(x), trim = trim)
+dropzeros(x::SparseVector) = dropzeros!(copy(x))
 
 function copy!(dst::SparseVector, src::SparseVector)
     length(dst::SparseVector) == length(src::SparseVector) || throw(ArgumentError("Sparse vectors should have the same length for copy!"))

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1679,15 +1679,11 @@ end
         for Awithzeros in (Aposzeros, Anegzeros, Abothsigns)
             # Basic functionality / dropzeros!
             @test dropzeros!(copy(Awithzeros)) == A
-            @test dropzeros!(copy(Awithzeros), trim = false) == A
             # Basic functionality / dropzeros
             @test dropzeros(Awithzeros) == A
-            @test dropzeros(Awithzeros, trim = false) == A
             # Check trimming works as expected
             @test length(nonzeros(dropzeros!(copy(Awithzeros)))) == length(nonzeros(A))
             @test length(rowvals(dropzeros!(copy(Awithzeros)))) == length(rowvals(A))
-            @test length(nonzeros(dropzeros!(copy(Awithzeros), trim = false))) == length(nonzeros(Awithzeros))
-            @test length(rowvals(dropzeros!(copy(Awithzeros), trim = false))) == length(rowvals(Awithzeros))
         end
     end
     # original lone dropzeros test

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1163,15 +1163,11 @@ end
     for vwithzeros in (vposzeros, vnegzeros, vbothsigns)
         # Basic functionality / dropzeros!
         @test dropzeros!(copy(vwithzeros)) == v
-        @test dropzeros!(copy(vwithzeros), trim = false) == v
         # Basic functionality / dropzeros
         @test dropzeros(vwithzeros) == v
-        @test dropzeros(vwithzeros, trim = false) == v
         # Check trimming works as expected
         @test length(nonzeros(dropzeros!(copy(vwithzeros)))) == length(nonzeros(v))
         @test length(nonzeroinds(dropzeros!(copy(vwithzeros)))) == length(nonzeroinds(v))
-        @test length(nonzeros(dropzeros!(copy(vwithzeros), trim = false))) == length(nonzeros(vwithzeros))
-        @test length(nonzeroinds(dropzeros!(copy(vwithzeros), trim = false))) == length(nonzeroinds(vwithzeros))
     end
 end
 


### PR DESCRIPTION
After https://github.com/JuliaLang/julia/pull/31724, the whole `trim` thing doesn't make sense since it is producing SparseArrays that are invalid according to our consistency checks.
Therefore, just remove the `trim` option.

AFAIU, we are also trying to move away from having an uninitialized "tail" in the different internal vectors as well.

Fixes https://github.com/JuliaLang/julia/issues/32967