### PR TITLE
docs: prepend v to tag string

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -202,7 +202,7 @@ env_mappings = [
 ]
 
 if Base.GIT_VERSION_INFO.tagged_commit
-    push!(env_mappings, "TRAVIS_TAG" => string(Base.VERSION))
+    push!(env_mappings, "TRAVIS_TAG" => "v$(Base.VERSION)")
 end
 
 withenv(env_mappings...) do


### PR DESCRIPTION
To make sure that `TRAVIS_TAG` is e.g. `v1.3.0` and not just `1.3.0`. It would be good to backport this to 1.3 too. cc @staticfloat 