### PR TITLE
Add logabsdet(::Diagonal).

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -597,3 +597,8 @@ cholesky(A::Diagonal, ::Val{false} = Val(false); check::Bool = true) =
     cholesky!(cholcopy(A), Val(false); check = check)
 
 Base._sum(A::Diagonal, ::Colon) = sum(A.diag)
+
+function logabsdet(A::Diagonal)
+     mapreduce(x -> (log(abs(x)), sign(x)), ((d1, s1), (d2, s2)) -> (d1 + d2, s1 * s2),
+               A.diag)
+end

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -282,10 +282,15 @@ Random.seed!(1)
         @test(transpose(D) * vv == D * vv)
     end
 
-    #logdet
+    # logdet and logabsdet
     if relty <: Real
-        ld=convert(Vector{relty},rand(n))
-        @test logdet(Diagonal(ld)) ≈ logdet(Matrix(Diagonal(ld)))
+        lD = Diagonal(convert(Vector{relty}, rand(n)))
+        lM = Matrix(lD)
+        @test logdet(lD) ≈ logdet(lM)
+        d1, s1 = @inferred logabsdet(lD)
+        d2, s2 = logabsdet(lM)
+        @test d1 ≈ d2
+        @test s1 == s2
     end
 
     @testset "similar" begin
@@ -553,6 +558,14 @@ end
 
 @testset "sum" begin
     @test sum(Diagonal([1,2,3])) == 6
+end
+
+@testset "logabsdet for generic eltype" begin
+    d = Any[1, -2.0, -3.0]
+    D = Diagonal(d)
+    d1, s1 = logabsdet(D)
+    @test d1 ≈ sum(log ∘ abs, d)
+    @test s1 == prod(sign, d)
 end
 
 end # module TestDiagonal


### PR DESCRIPTION
Works with generic eltypes. Fixes JuliaLang/LinearAlgebra.jl#657.