### PR TITLE
improve precompilation coverage

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -142,12 +142,6 @@ function generate_precompile_statements()
             push!(statements, statement)
         end
 
-        if have_repl
-            # Seems like a reasonable number right now, adjust as needed
-            # comment out if debugging script
-            @assert length(statements) > 700
-        end
-
         # Create a staging area where all the loaded packages are available
         PrecompileStagingArea = Module()
         for (_pkgid, _mod) in Base.loaded_modules
@@ -157,22 +151,23 @@ function generate_precompile_statements()
         end
 
         # Execute the collected precompile statements
+        n_succeeded = 0
         include_time = @elapsed for statement in sort(collect(statements))
             # println(statement)
-            # Workarounds for #28808
-            occursin("\"YYYY-mm-dd\\THH:MM:SS\"", statement) && continue
-            statement == "precompile(Tuple{typeof(Base.show), Base.IOContext{Base.TTY}, Type{Vararg{Any, N} where N}})" && continue
-            # check for `#x##s66` style variable names not in quotes
-            occursin(r"#\w", statement) &&
-                count(r"(?:#+\w+)+", statement) !=
-                count(r"\"(?:#+\w+)+\"", statement) && continue
             try
                 Base.include_string(PrecompileStagingArea, statement)
+                n_succeeded += 1
             catch
-                @error "Failed to precompile $statement"
-                rethrow()
+                # See #28808
+                # @error "Failed to precompile $statement"
             end
         end
+        if have_repl
+            # Seems like a reasonable number right now, adjust as needed
+            # comment out if debugging script
+            @assert n_succeeded > 3500
+        end
+
         print(" $(length(statements)) generated in ")
         tot_time = time() - start_time
         Base.time_print(tot_time * 10^9)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -765,15 +765,21 @@ setup_interface(
     repl::LineEditREPL;
     # those keyword arguments may be deprecated eventually in favor of the Options mechanism
     hascolor::Bool = repl.options.hascolor,
-    extra_repl_keymap::Union{Dict,Vector{<:Dict}} = repl.options.extra_keymap
+    extra_repl_keymap::Any = repl.options.extra_keymap
 ) = setup_interface(repl, hascolor, extra_repl_keymap)
 
 # This non keyword method can be precompiled which is important
 function setup_interface(
     repl::LineEditREPL,
     hascolor::Bool,
-    extra_repl_keymap::Union{Dict,Vector{<:Dict}},
+    extra_repl_keymap::Any, # Union{Dict,Vector{<:Dict}},
 )
+    # The precompile statement emitter has problem outputting valid syntax for the
+    # type of `Union{Dict,Vector{<:Dict}}` (see #28808).
+    # This function is however important to precompile for REPL startup time, therefore,
+    # make the type Any and just assert that we have the correct type below.
+    @assert extra_repl_keymap isa Union{Dict,Vector{<:Dict}}
+
     ###
     #
     # This function returns the main interface that describes the REPL


### PR DESCRIPTION
- move the place where `--trace-compile` outputs precompile statement to a location that catches more cases (it now sits next to where SnoopCompile outputs statements)
- tweak the REPL code to be more amenable to precompilation in light of #28808
- instead of trying to encode all the rules where the precompile emitter
  fails (#28808) just try to precompile and do nothing if it fails.

With this, startup time is back to normal and the time to prompt (measured with the patch in https://github.com/JuliaLang/julia/issues/32971#issue-482685346) is significantly improved, although not yet completely back to 1.1 levels:

### 1.1
```
Generating precompile statements... 1082 generated in 179.581295 seconds (overhead 141.594243 seconds)
./julia -e ''  0.14s user 0.09s system 107% cpu 0.211 total
./julia  0.42s user 0.16s system 191% cpu 0.302 total
```

### 1.2
```
Generating precompile statements... 863 generated in 130.453900 seconds (overhead 100.843763 seconds)
./julia -e ''  0.18s user 0.09s system 124% cpu 0.222 total
./julia  1.09s user 0.19s system 138% cpu 0.929 total
```

### PR
```
Generating precompile statements... 4087 generated in 130.619177 seconds (overhead  98.529712 seconds)
./julia -e ''  0.13s user 0.08s system 105% cpu 0.208 total
./julia  0.60s user 0.18s system 186% cpu 0.419 total
```


Probably good enough to say that it fixes #32971 after being backported