### PR TITLE
fix some broadcast patterns to avoid allocations

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -503,7 +503,7 @@ function check_broadcast_shape(shp, Ashp::Tuple)
     _bcsm(shp[1], Ashp[1]) || throw(DimensionMismatch("array could not be broadcast to match destination"))
     check_broadcast_shape(tail(shp), tail(Ashp))
 end
-check_broadcast_axes(shp, A) = check_broadcast_shape(shp, axes(A))
+@inline check_broadcast_axes(shp, A) = check_broadcast_shape(shp, axes(A))
 # comparing many inputs
 @inline function check_broadcast_axes(shp, A, As...)
     check_broadcast_axes(shp, A)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -835,3 +835,10 @@ end
 # treat Pair as scalar:
 @test replace.(split("The quick brown fox jumps over the lazy dog"), r"[aeiou]"i => "_") ==
       ["Th_", "q__ck", "br_wn", "f_x", "j_mps", "_v_r", "th_", "l_zy", "d_g"]
+
+# Test assigning into matrix doesn't allocate
+perf_op_bcast!(R, x, y) = R .= 3 .* x .- 4 .* y.^2 .+ x .* y .- x .^ 3
+let x = rand(10^3), y = rand(10^3), R = Matrix{Float64}(undef, length(x), length(y))
+    perf_op_bcast!(R, x, y)
+    @test @allocated(perf_op_bcast!(R, x, y)) == 0
+end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -835,10 +835,3 @@ end
 # treat Pair as scalar:
 @test replace.(split("The quick brown fox jumps over the lazy dog"), r"[aeiou]"i => "_") ==
       ["Th_", "q__ck", "br_wn", "f_x", "j_mps", "_v_r", "th_", "l_zy", "d_g"]
-
-# Test assigning into matrix doesn't allocate
-perf_op_bcast!(R, x, y) = R .= 3 .* x .- 4 .* y.^2 .+ x .* y .- x .^ 3
-let x = rand(10^3), y = rand(10^3), R = Matrix{Float64}(undef, length(x), length(y))
-    perf_op_bcast!(R, x, y)
-    @test @allocated(perf_op_bcast!(R, x, y)) == 0
-end


### PR DESCRIPTION
Fixes the memory regression in https://github.com/JuliaLang/julia/issues/32985#issuecomment-523133723 for broadcasting array.

