### PR TITLE
improve performance of setindex! on IdDict

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -579,7 +579,9 @@ end
 
 function setindex!(d::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where {K, V}
     !isa(key, K) && throw(ArgumentError("$(limitrepr(key)) is not a valid key for type $K"))
-    val = convert(V, val)
+    if !(val isa V) && V !== Any
+        val = convert(V, val)
+    end
     if d.ndel >= ((3*length(d.ht))>>2)
         rehash!(d, max(length(d.ht)>>1, 32))
         d.ndel = 0

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -579,7 +579,7 @@ end
 
 function setindex!(d::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where {K, V}
     !isa(key, K) && throw(ArgumentError("$(limitrepr(key)) is not a valid key for type $K"))
-    if !(val isa V) && V !== Any
+    if !(val isa V) # avoid a dynamic call
         val = convert(V, val)
     end
     if d.ndel >= ((3*length(d.ht))>>2)


### PR DESCRIPTION
The benchmark run of 1.3 vs 1.2 showed some performance regressions for IdDict. Profiling, it seems that the `convert` call now goes through `jl_apply_generic`:

```
              123 ./abstractdict.jl:479; push!
               62 ./abstractdict.jl:582; setindex!(::IdDict{Int64,Int64}, ::Any, ... # <--- convert call
                46 ...kristoffer/julia/src/gf.c:2296; jl_apply_generic
                 37 ...kristoffer/julia/src/gf.c:2247; jl_lookup_generic_
                  36 ...ia/src/./julia_internal.h:939; jl_typemap_assoc_exact
                   11 ...ffer/julia/src/typemap.c:850; jl_typemap_level_assoc_exact
                    3 ...ffer/julia/src/typemap.c:255; mtcache_hash_lookup
                     3 ...ffer/julia/src/typemap.c:186; jl_intref
                      3 ...fer/julia/src/./julia.h:802; jl_svecref
                    3 ...ffer/julia/src/typemap.c:269; mtcache_hash_lookup
                   21 ...ffer/julia/src/typemap.c:851; jl_typemap_level_assoc_exact
                    20 ...a/src/./julia_internal.h:935; jl_typemap_assoc_exact
                     4 ...ffer/julia/src/typemap.c:803; jl_typemap_entry_assoc_exact
                      2 ...fer/julia/src/typemap.c:123; sig_match_simple
                     6 ...ffer/julia/src/typemap.c:816; jl_typemap_entry_assoc_exact
                      2 ...fer/julia/src/typemap.c:136; sig_match_simple
                       1 ...fer/julia/src/./julia.h:1127; jl_is_type_type
                       1 ...fer/julia/src/./julia.h:1128; jl_is_type_type
                10 ...a/usr/lib/julia/sys.dylib:?; jfptr_convert_4167
                 7 ...ffer/julia/src/datatype.c:724; jl_box_int64
                  4 ...ia/src/./julia_internal.h:233; jl_gc_alloc_
```

Workaround this by only calling the `convert` when it is not known to be a no-op.

With

```
function perf_push!(c, elts)
    for e in elts
        push!(c, e)
    end
end

elts = [rand(Int) => rand(Int) for i in 1:100]
```

The relevant benchmarks are:

#### 1.2

```
@btime perf_push!(IdDict{Int,Int}(), elts)
#  11.889 μs (206 allocations: 11.48 KiB)

@btime perf_push!(IdDict{Any,Any}(), elts)
#  12.150 μs (206 allocations: 11.48 KiB)
```

##### Master
```
@btime perf_push!(IdDict{Int,Int}(), elts)
#  20.218 μs (306 allocations: 13.05 KiB)

@btime perf_push!(IdDict{Any,Any}(), elts)
#  13.461 μs (206 allocations: 11.48 KiB)
```

#### PR
```
@btime perf_push!(IdDict{Int,Int}(), elts)
#  11.182 μs (205 allocations: 7.36 KiB)

@btime perf_push!(IdDict{Any,Any}(), elts)
#  11.121 μs (205 allocations: 7.36 KiB)
```





