### PR TITLE
fix for checking FMA_NATIVE

### DIFF
--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -141,7 +141,8 @@ const t_log_Float32 = (0.0,0.007782140442054949,0.015504186535965254,0.023167059
 
 # determine if hardware FMA is available
 # should probably check with LLVM, see #9855.
-const FMA_NATIVE = muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)) != 0
+# needs to be run inside a compiled function
+const FMA_NATIVE = (() -> muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)))()
 
 # truncate lower order bits (up to 26)
 # ideally, this should be able to use ANDPD instructions, see #9868.

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -142,7 +142,7 @@ const t_log_Float32 = (0.0,0.007782140442054949,0.015504186535965254,0.023167059
 # determine if hardware FMA is available
 # should probably check with LLVM, see #9855.
 # needs to be run inside a compiled function
-const FMA_NATIVE = (() -> muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)))()
+const FMA_NATIVE = (() -> muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)))() != 0
 
 # truncate lower order bits (up to 26)
 # ideally, this should be able to use ANDPD instructions, see #9868.


### PR DESCRIPTION
I guess this needs to be run inside a compiled function to not get run by the interpreter or something along those lines?

```jl
julia> Base.Math.FMA_NATIVE
false

julia> muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2))
4.930380657631324e-32

julia> (() -> muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)))()
0.0

julia> @code_native debuginfo=:none muladd(1.0, 2.0, 3.0)
        .section        __TEXT,__text,regular,pure_instructions
        vfmadd213sd     %xmm2, %xmm1, %xmm0  # <--------- yes, I have it
        retq
        nopw    %cs:(%rax,%rax)
```

Might improve performance for `hypot` and `log` in some cases.