### PR TITLE
fix bug in the example code of `init` function

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1280,7 +1280,7 @@ julia> addprocs(3)
 
 julia> @everywhere using SharedArrays
 
-julia> S = SharedArray{Int,2}((3,4), init = S -> S[localindices(S)] = myid())
+julia> S = SharedArray{Int,2}((3,4), init = S -> S[localindices(S)] = repeat([myid()], length(localindices(S))))
 3×4 SharedArray{Int64,2}:
  2  2  3  4
  2  3  3  4
@@ -1301,7 +1301,7 @@ convenient for splitting up tasks among processes. You can, of course, divide th
 you wish:
 
 ```julia-repl
-julia> S = SharedArray{Int,2}((3,4), init = S -> S[indexpids(S):length(procs(S)):length(S)] = myid())
+julia> S = SharedArray{Int,2}((3,4), init = S -> S[indexpids(S):length(procs(S)):length(S)] = repeat([myid()], length( indexpids(S):length(procs(S)):length(S))))
 3×4 SharedArray{Int64,2}:
  2  2  2  2
  3  3  3  3


### PR DESCRIPTION
When I ran the example code, 
```julia
S = SharedArray{Int,2}((3,4), init = S -> S[localindices(S)] = myid())
```
it throws the error

> MethodError: no method matching setindex_shape_check(::Int64, ::Int64)

the following example involved `init` function also has the same problem. 

So I fix it in a naive way, just replace the single integer `myid()` with the array `repeat([myid()], length(localindices(S)))`. 

Actually, I had tried `S[localindices(S)] .= myid()`, but it does not work. 

> MethodError: Cannot `convert` an object of type RemoteException to an object of type Array{Int64,1}

I even tried `int = map(x->myid(), S[localindices(S)] )`, but then all elements are 0. Maybe there are some elegant solutions.