### PR TITLE
add llvm 9 support files (includes llvm 8)

### DIFF
--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -42,7 +42,7 @@ $(LIBUV_BUILDDIR)/build-compiled: $(LIBUV_BUILDDIR)/build-configured
 
 $(LIBUV_BUILDDIR)/build-checked: $(LIBUV_BUILDDIR)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-	-$(MAKE) -C $(dir $@) check
+	$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
 

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -171,7 +171,12 @@ ifeq ($(BUILD_LLDB),0)
 LLVM_CMAKE += -DLLVM_TOOL_LLDB_BUILD=OFF
 endif
 
+ifeq (,$(findstring rc,$(LLVM_VER)))
 LLVM_SRC_URL := http://releases.llvm.org/$(LLVM_VER)
+else
+LLVM_VER_SPLIT := $(subst rc, ,$(LLVM_VER))
+LLVM_SRC_URL := https://prereleases.llvm.org/$(word 1,$(LLVM_VER_SPLIT))/rc$(word 2,$(LLVM_VER_SPLIT))
+endif
 
 ifneq ($(LLVM_CLANG_TAR),)
 $(LLVM_CLANG_TAR): | $(SRCCACHE)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -470,6 +470,7 @@ $(eval $(call LLVM_PATCH,llvm7-D51842-win64-byval-cc)) # remove for 8.0
 $(eval $(call LLVM_PATCH,llvm-D57118-powerpc))
 $(eval $(call LLVM_PATCH,llvm-rL349068-llvm-config)) # remove for 8.0
 $(eval $(call LLVM_PATCH,llvm7-WASM-addrspaces)) # WebAssembly
+$(eval $(call LLVM_PATCH,llvm7-revert-D44485))
 endif # LLVM_VER 7.0
 
 ifeq ($(LLVM_VER_SHORT),8.0)
@@ -486,6 +487,7 @@ $(eval $(call LLVM_PATCH,llvm8-WASM-addrspaces)) # WebAssembly
 $(eval $(call LLVM_PATCH,llvm-exegesis-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-8.0-D66401-mingw-reloc)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm7-revert-D44485))
 endif # LLVM_VER 8.0
 
 ifeq ($(LLVM_VER_SHORT),9.0)
@@ -499,6 +501,7 @@ $(eval $(call LLVM_PATCH,llvm-6.0-DISABLE_ABI_CHECKS))
 $(eval $(call LLVM_PATCH,llvm8-WASM-addrspaces)) # WebAssembly
 $(eval $(call LLVM_PATCH,llvm-exegesis-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
+$(eval $(call LLVM_PATCH,llvm7-revert-D44485))
 endif # LLVM_VER 9.0
 
 

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -485,6 +485,7 @@ $(eval $(call LLVM_PATCH,llvm-D57118-powerpc)) # remove for 9.0
 $(eval $(call LLVM_PATCH,llvm8-WASM-addrspaces)) # WebAssembly
 $(eval $(call LLVM_PATCH,llvm-exegesis-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
+$(eval $(call LLVM_PATCH,llvm-8.0-D66401-mingw-reloc)) # remove for 9.0
 endif # LLVM_VER 8.0
 
 # Add a JL prefix to the version map. DO NOT REMOVE

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -171,8 +171,13 @@ ifeq ($(BUILD_LLDB),0)
 LLVM_CMAKE += -DLLVM_TOOL_LLDB_BUILD=OFF
 endif
 
+ifneq ($(LLVM_VER),svn)
 ifeq (,$(findstring rc,$(LLVM_VER)))
+ifeq ($(shell [ $(LLVM_VER_MAJ) -ge 8 -a $(LLVM_VER) != 8.0.0 ]; echo $$?),0)
+LLVM_SRC_URL := https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VER)
+else
 LLVM_SRC_URL := http://releases.llvm.org/$(LLVM_VER)
+endif
 else
 LLVM_VER_SPLIT := $(subst rc, ,$(LLVM_VER))
 LLVM_SRC_URL := https://prereleases.llvm.org/$(word 1,$(LLVM_VER_SPLIT))/rc$(word 2,$(LLVM_VER_SPLIT))
@@ -203,6 +208,7 @@ endif
 ifeq ($(BUILD_LLDB),1)
 $(LLVM_SRC_DIR)/tools/lldb:
 $(LLVM_SRC_DIR)/source-extracted: $(LLVM_SRC_DIR)/tools/lldb
+endif
 endif
 
 # LLDB still relies on plenty of python 2.x infrastructure, without checking

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -488,6 +488,20 @@ $(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-8.0-D66401-mingw-reloc)) # remove for 9.0
 endif # LLVM_VER 8.0
 
+ifeq ($(LLVM_VER_SHORT),9.0)
+$(eval $(call LLVM_PATCH,llvm-D27629-AArch64-large_model_6.0.1))
+$(eval $(call LLVM_PATCH,llvm8-D34078-vectorize-fdiv))
+$(eval $(call LLVM_PATCH,llvm-6.0-NVPTX-addrspaces)) # NVPTX -- warning: this fails check-llvm-codegen-nvptx
+$(eval $(call LLVM_PATCH,llvm-7.0-D44650)) # mingw32 build fix
+$(eval $(call LLVM_PATCH,llvm-6.0-DISABLE_ABI_CHECKS))
+#$(eval $(call LLVM_PATCH,llvm7-D50010-VNCoercion-ni)) # TODO
+#$(eval $(call LLVM_PATCH,llvm7-windows-race)) # TODO
+$(eval $(call LLVM_PATCH,llvm8-WASM-addrspaces)) # WebAssembly
+$(eval $(call LLVM_PATCH,llvm-exegesis-mingw)) # mingw build
+$(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
+endif # LLVM_VER 9.0
+
+
 # Add a JL prefix to the version map. DO NOT REMOVE
 ifneq ($(LLVM_VER), svn)
 ifeq ($(LLVM_VER_SHORT), 6.0)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -483,6 +483,8 @@ $(eval $(call LLVM_PATCH,llvm-8.0-D50167-scev-umin))
 $(eval $(call LLVM_PATCH,llvm7-windows-race))
 $(eval $(call LLVM_PATCH,llvm-D57118-powerpc)) # remove for 9.0
 $(eval $(call LLVM_PATCH,llvm8-WASM-addrspaces)) # WebAssembly
+$(eval $(call LLVM_PATCH,llvm-exegesis-mingw)) # mingw build
+$(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
 endif # LLVM_VER 8.0
 
 # Add a JL prefix to the version map. DO NOT REMOVE

--- a/deps/patches/llvm-8.0-D66401-mingw-reloc.patch
+++ b/deps/patches/llvm-8.0-D66401-mingw-reloc.patch
@@ -1,0 +1,69 @@
+diff --git a/test/CodeGen/X86/mingw-refptr.ll b/test/CodeGen/X86/mingw-refptr.ll
+--- a/test/CodeGen/X86/mingw-refptr.ll
++++ b/test/CodeGen/X86/mingw-refptr.ll
+@@ -1,5 +1,6 @@
+ ; RUN: llc < %s -mtriple=x86_64-w64-mingw32 | FileCheck %s -check-prefix=CHECK-X64
+ ; RUN: llc < %s -mtriple=i686-w64-mingw32 | FileCheck %s -check-prefix=CHECK-X86
++; RUN: llc < %s -mtriple=i686-w64-mingw32-none-elf | FileCheck %s -check-prefix=CHECK-X86-ELF
+ 
+ @var = external local_unnamed_addr global i32, align 4
+ @dsolocalvar = external dso_local local_unnamed_addr global i32, align 4
+@@ -16,6 +17,9 @@
+ ; CHECK-X86:    movl .refptr._var, %eax
+ ; CHECK-X86:    movl (%eax), %eax
+ ; CHECK-X86:    retl
++; CHECK-X86-ELF-LABEL: getVar:
++; CHECK-X86-ELF:    movl var, %eax
++; CHECK-X86-ELF:    retl
+ entry:
+   %0 = load i32, i32* @var, align 4
+   ret i32 %0
+@@ -66,6 +70,9 @@
+ ; CHECK-X86:    movl __imp__extvar, %eax
+ ; CHECK-X86:    movl (%eax), %eax
+ ; CHECK-X86:    retl
++; CHECK-X86-ELF-LABEL: getExtVar:
++; CHECK-X86-ELF:    movl extvar, %eax
++; CHECK-X86-ELF:    retl
+ entry:
+   %0 = load i32, i32* @extvar, align 4
+   ret i32 %0
+diff --git a/lib/Target/X86/X86Subtarget.cpp b/lib/Target/X86/X86Subtarget.cpp
+--- a/lib/Target/X86/X86Subtarget.cpp
++++ b/lib/Target/X86/X86Subtarget.cpp
+@@ -146,6 +146,9 @@
+       return X86II::MO_DLLIMPORT;
+     return X86II::MO_COFFSTUB;
+   }
++  // Some JIT users use *-win32-elf triples; these shouldn't use GOT tables.
++  if (isOSWindows())
++    return X86II::MO_NO_FLAG;
+ 
+   if (is64Bit()) {
+     // ELF supports a large, truly PIC code model with non-PC relative GOT
+diff --git a/lib/Target/TargetMachine.cpp b/lib/Target/TargetMachine.cpp
+--- a/lib/Target/TargetMachine.cpp
++++ b/lib/Target/TargetMachine.cpp
+@@ -128,8 +128,8 @@
+   // don't assume the variables to be DSO local unless we actually know
+   // that for sure. This only has to be done for variables; for functions
+   // the linker can insert thunks for calling functions from another DLL.
+-  if (TT.isWindowsGNUEnvironment() && GV && GV->isDeclarationForLinker() &&
+-      isa<GlobalVariable>(GV))
++  if (TT.isWindowsGNUEnvironment() && TT.isOSBinFormatCOFF() && GV &&
++      GV->isDeclarationForLinker() && isa<GlobalVariable>(GV))
+     return false;
+ 
+   // On COFF, don't mark 'extern_weak' symbols as DSO local. If these symbols
+@@ -142,7 +142,9 @@
+   // Make an exception for windows OS in the triple: Some firmware builds use
+   // *-win32-macho triples. This (accidentally?) produced windows relocations
+   // without GOT tables in older clang versions; Keep this behaviour.
+-  if (TT.isOSBinFormatCOFF() || (TT.isOSWindows() && TT.isOSBinFormatMachO()))
++  // Some JIT users use *-win32-elf triples; these shouldn't use GOT tables
++  // either.
++  if (TT.isOSBinFormatCOFF() || TT.isOSWindows())
+     return true;
+ 
+   // Most PIC code sequences that assume that a symbol is local cannot
+

--- a/deps/patches/llvm-exegesis-mingw.patch
+++ b/deps/patches/llvm-exegesis-mingw.patch
@@ -1,0 +1,24 @@
+From 9ba86352649a39b03adce98670714c4c8eb5341d Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Wed, 24 Jul 2019 21:19:20 -0400
+Subject: [PATCH] Fix build of llvm-exegis on mingw32
+
+---
+ llvm/tools/llvm-exegesis/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/llvm-exegesis/CMakeLists.txt b/tools/llvm-exegesis/CMakeLists.txt
+index a59e1b74024..7a30e0ea98f 100644
+--- a/tools/llvm-exegesis/CMakeLists.txt
++++ b/tools/llvm-exegesis/CMakeLists.txt
+@@ -4,7 +4,7 @@ set(LLVM_LINK_COMPONENTS
+   native
+   )
+ 
+-add_llvm_tool(llvm-exegesis
++add_llvm_tool(llvm-exegesis DISABLE_LLVM_LINK_LLVM_DYLIB
+   llvm-exegesis.cpp
+   )
+ 
+-- 
+2.22.0

--- a/deps/patches/llvm-test-plugin-mingw.patch
+++ b/deps/patches/llvm-test-plugin-mingw.patch
@@ -1,0 +1,24 @@
+From 9bd3774db73533c8df475639805ff1516aea274c Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Wed, 24 Jul 2019 21:45:33 -0400
+Subject: [PATCH] add missing components to TestPlugin
+
+---
+ llvm/unittests/Passes/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unittests/Passes/CMakeLists.txt b/unittests/Passes/CMakeLists.txt
+index 3e83b527958..4b09f47c234 100644
+--- a/unittests/Passes/CMakeLists.txt
++++ b/unittests/Passes/CMakeLists.txt
+@@ -14,7 +14,7 @@ add_llvm_unittest(PluginsTests
+ export_executable_symbols(PluginsTests)
+ target_link_libraries(PluginsTests PRIVATE LLVMTestingSupport)
+ 
+-set(LLVM_LINK_COMPONENTS)
++set(LLVM_LINK_COMPONENTS Support Passes Core)
+ add_llvm_library(TestPlugin MODULE BUILDTREE_ONLY
+   TestPlugin.cpp
+   )
+-- 
+2.22.0

--- a/deps/patches/llvm7-revert-D44485.patch
+++ b/deps/patches/llvm7-revert-D44485.patch
@@ -1,0 +1,94 @@
+From 4370214628487ac8495f963ae05960b5ecc31103 Mon Sep 17 00:00:00 2001
+From: Jameson Nash <vtjnash@gmail.com>
+Date: Thu, 12 Sep 2019 11:45:07 -0400
+Subject: [PATCH] Revert "[MC] Always emit relocations for same-section
+ function references"
+
+This reverts commit 9232972575cafac29c3e4817c8714c9aca0e8585.
+---
+ lib/MC/WinCOFFObjectWriter.cpp | 12 +++++-------
+ test/MC/COFF/diff.s            | 25 ++++++++-----------------
+ 2 files changed, 13 insertions(+), 24 deletions(-)
+
+diff --git a/lib/MC/WinCOFFObjectWriter.cpp b/lib/MC/WinCOFFObjectWriter.cpp
+index 9ffecd99df6..0214161e03c 100644
+--- a/lib/MC/WinCOFFObjectWriter.cpp
++++ b/lib/MC/WinCOFFObjectWriter.cpp
+@@ -690,14 +690,12 @@ void WinCOFFObjectWriter::executePostLayoutBinding(MCAssembler &Asm,
+ bool WinCOFFObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(
+     const MCAssembler &Asm, const MCSymbol &SymA, const MCFragment &FB,
+     bool InSet, bool IsPCRel) const {
+-  // Don't drop relocations between functions, even if they are in the same text
+-  // section. Multiple Visual C++ linker features depend on having the
+-  // relocations present. The /INCREMENTAL flag will cause these relocations to
+-  // point to thunks, and the /GUARD:CF flag assumes that it can use relocations
+-  // to approximate the set of all address taken functions. LLD's implementation
+-  // of /GUARD:CF also relies on the existance of these relocations.
++  // MS LINK expects to be able to replace all references to a function with a
++  // thunk to implement their /INCREMENTAL feature.  Make sure we don't optimize
++  // away any relocations to functions.
+   uint16_t Type = cast<MCSymbolCOFF>(SymA).getType();
+-  if ((Type >> COFF::SCT_COMPLEX_TYPE_SHIFT) == COFF::IMAGE_SYM_DTYPE_FUNCTION)
++  if (Asm.isIncrementalLinkerCompatible() &&
++      (Type >> COFF::SCT_COMPLEX_TYPE_SHIFT) == COFF::IMAGE_SYM_DTYPE_FUNCTION)
+     return false;
+   return MCObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(Asm, SymA, FB,
+                                                                 InSet, IsPCRel);
+diff --git a/test/MC/COFF/diff.s b/test/MC/COFF/diff.s
+index f89e4ed8901..d68e628577b 100644
+--- a/test/MC/COFF/diff.s
++++ b/test/MC/COFF/diff.s
+@@ -1,14 +1,19 @@
+ // RUN: llvm-mc -filetype=obj -triple i686-pc-mingw32 %s | llvm-readobj -s -sr -sd | FileCheck %s
+ 
+-// COFF resolves differences between labels in the same section, unless that
+-// label is declared with function type.
+-
+ .section baz, "xr"
++	.def	X
++	.scl	2;
++	.type	32;
++	.endef
+ 	.globl	X
+ X:
+ 	mov	Y-X+42,	%eax
+ 	retl
+ 
++	.def	Y
++	.scl	2;
++	.type	32;
++	.endef
+ 	.globl	Y
+ Y:
+ 	retl
+@@ -25,11 +30,6 @@ _foobar:                                # @foobar
+ # %bb.0:
+ 	ret
+ 
+-	.globl	_baz
+-_baz:
+-	calll	_foobar
+-	retl
+-
+ 	.data
+ 	.globl	_rust_crate             # @rust_crate
+ 	.align	4
+@@ -39,15 +39,6 @@ _rust_crate:
+ 	.long	_foobar-_rust_crate
+ 	.long	_foobar-_rust_crate
+ 
+-// Even though _baz and _foobar are in the same .text section, we keep the
+-// relocation for compatibility with the VC linker's /guard:cf and /incremental
+-// flags, even on mingw.
+-
+-// CHECK:        Name: .text
+-// CHECK:        Relocations [
+-// CHECK-NEXT:     0x12 IMAGE_REL_I386_REL32 _foobar
+-// CHECK-NEXT:   ]
+-
+ // CHECK:        Name: .data
+ // CHECK:        Relocations [
+ // CHECK-NEXT:     0x4 IMAGE_REL_I386_DIR32 _foobar
+-- 
+2.17.1
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -336,7 +336,7 @@ clean-support:
 cleanall: clean clean-flisp clean-support clean-analyzegc
 
 $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/GCChecker.cpp
-	@$(call PRINT_CC, $(CXX) -g -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CPPFLAGS) $(CFLAGS) $< $(shell $(LLVM_CONFIG_HOST) --ldflags) $(LDFLAGS) -L$(build_libdir) -lclangAnalysis -lclangStaticAnalyzerCore -lclangASTMatchers -lclangAST -lclangLex -lclangBasic)
+	@$(call PRINT_CC, $(CXX) -g $(fPIC) -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CPPFLAGS) $(CFLAGS) $< $(shell $(LLVM_CONFIG_HOST) --ldflags) $(LDFLAGS) -L$(build_libdir) -lclangAnalysis -lclangStaticAnalyzerCore -lclangASTMatchers -lclangAST -lclangLex -lclangBasic)
 
 # Throw an error if a proper version of `clang` is not available.
 # Note that for a default install, you will need to have run the following

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -12,7 +12,7 @@
 #include "clang/StaticAnalyzer/Core/BugReporter/CommonBugCategories.h"
 #include "clang/StaticAnalyzer/Frontend/AnalysisConsumer.h"
 #include "clang/StaticAnalyzer/Checkers/SValExplainer.h"
-#if LLVM_VERSION_MAJOR >= 9
+#if LLVM_VERSION_MAJOR >= 8
 #include "clang/StaticAnalyzer/Frontend/CheckerRegistry.h"
 #else
 #include "clang/StaticAnalyzer/Core/CheckerRegistry.h"
@@ -211,7 +211,7 @@ namespace {
           }
 
           PDP VisitNode(const ExplodedNode *N,
-#if LLVM_VERSION_MAJOR <= 8
+#if LLVM_VERSION_MAJOR < 8
                         const ExplodedNode *PrevN,
 #endif
                         BugReporterContext &BRC,
@@ -242,7 +242,7 @@ namespace {
               const ExplodedNode *N, PathDiagnosticLocation Pos, BugReporterContext &BRC, BugReport &BR);
 
           PDP VisitNode(const ExplodedNode *N,
-#if LLVM_VERSION_MAJOR <= 8
+#if LLVM_VERSION_MAJOR < 8
                                                          const ExplodedNode *PrevN,
 #endif
                                                          BugReporterContext &BRC,
@@ -326,7 +326,7 @@ namespace Helpers {
 
 PDP GCChecker::GCBugVisitor::VisitNode(
   const ExplodedNode *N,
-#if LLVM_VERSION_MAJOR <= 8
+#if LLVM_VERSION_MAJOR < 8
   const ExplodedNode *,
 #endif
   BugReporterContext &BRC, BugReport &BR) {
@@ -425,7 +425,7 @@ PDP GCChecker::GCValueBugVisitor::ExplainNoPropagation(
 
 PDP GCChecker::GCValueBugVisitor::VisitNode(
   const ExplodedNode *N,
-#if LLVM_VERSION_MAJOR <= 8
+#if LLVM_VERSION_MAJOR < 8
   const ExplodedNode *,
 #endif
   BugReporterContext &BRC, BugReport &BR) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -338,7 +338,13 @@ static std::map<jl_fptr_args_t, Function*> builtin_func_map;
 extern "C" {
     int globalUnique = 0;
     int jl_default_debug_info_kind = (int) DICompileUnit::DebugEmissionKind::FullDebug;
-    jl_cgparams_t jl_default_cgparams = {1, 1, 1, 1, 0, 1, jl_default_debug_info_kind, NULL, NULL, NULL, NULL, NULL};
+    jl_cgparams_t jl_default_cgparams = {1, 1, 1, 1, 0,
+#ifdef _OS_WINDOWS_
+        0,
+#else
+        1,
+#endif
+        jl_default_debug_info_kind, NULL, NULL, NULL, NULL, NULL};
 }
 
 template<typename T>

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -168,11 +168,13 @@ public:
 
     jl_method_instance_t *lookupLinfo(size_t pointer)
     {
-        auto linfo = linfomap.lower_bound(pointer);
-        if (linfo != linfomap.end() && pointer < linfo->first + linfo->second.first)
-            return linfo->second.second;
-        else
-            return NULL;
+        uv_rwlock_rdlock(&threadsafe);
+        auto region = linfomap.lower_bound(pointer);
+        jl_method_instance_t *linfo = NULL;
+        if (region != linfomap.end() && pointer < region->first + region->second.first)
+            linfo = region->second.second;
+        uv_rwlock_rdunlock(&threadsafe);
+        return linfo;
     }
 
     virtual void NotifyObjectEmitted(const object::ObjectFile &obj,
@@ -190,7 +192,6 @@ public:
         // This function modify codeinst->fptr in GC safe region.
         // This should be fine since the GC won't scan this field.
         int8_t gc_state = jl_gc_safe_enter(ptls);
-        uv_rwlock_wrlock(&threadsafe);
         object::section_iterator Section = debugObj.section_begin();
         object::section_iterator EndSection = debugObj.section_end();
 
@@ -324,8 +325,6 @@ public:
 #endif // defined(_OS_X86_64_)
 #endif // defined(_OS_WINDOWS_)
 
-        std::vector<std::pair<jl_code_instance_t*, uintptr_t>> def_spec;
-        std::vector<std::pair<jl_code_instance_t*, uintptr_t>> def_invoke;
         auto symbols = object::computeSymbolSizes(debugObj);
         bool first = true;
         for (const auto &sym_size : symbols) {
@@ -366,21 +365,8 @@ public:
             if (linfo_it != ncode_in_flight.end()) {
                 codeinst = linfo_it->second;
                 ncode_in_flight.erase(linfo_it);
-                const char *F = codeinst->functionObjectsDecls.functionObject;
-                const char *specF = codeinst->functionObjectsDecls.specFunctionObject;
-                if (codeinst->invoke == NULL) {
-                    if (specF && sName.equals(specF)) {
-                        def_spec.push_back({codeinst, Addr});
-                        if (!strcmp(F, "jl_fptr_args"))
-                            def_invoke.push_back({codeinst, (uintptr_t)&jl_fptr_args});
-                        else if (!strcmp(F, "jl_fptr_sparam"))
-                            def_invoke.push_back({codeinst, (uintptr_t)&jl_fptr_sparam});
-                    }
-                    else if (sName.equals(F)) {
-                        def_invoke.push_back({codeinst, Addr});
-                    }
-                }
             }
+            uv_rwlock_wrlock(&threadsafe);
             if (codeinst)
                 linfomap[Addr] = std::make_pair(Size, codeinst->def);
             if (first) {
@@ -391,18 +377,9 @@ public:
                     };
                 objectmap[SectionLoadAddr] = tmp;
                 first = false;
-           }
-       }
-       // now process these in order, so we ensure the closure values are updated before enabling the invoke pointer
-       // TODO: this sets these pointers a bit too early, allowing other threads to see
-       // the addresses before the code has been filled in.
-       /*
-       for (auto &def : def_spec)
-           def.first->specptr.fptr = (void*)def.second;
-       for (auto &def : def_invoke)
-           def.first->invoke = (jl_callptr_t)def.second;
-       */
-        uv_rwlock_wrunlock(&threadsafe);
+            }
+            uv_rwlock_wrunlock(&threadsafe);
+        }
         jl_gc_safe_leave(ptls, gc_state);
     }
 

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -574,7 +574,14 @@ static debug_link_info getDebuglink(const object::ObjectFile &Obj)
         StringRef sName;
         if (!Section.getName(sName) && sName == ".gnu_debuglink") {
             StringRef Contents;
-            if (!Section.getContents(Contents)) {
+#if JL_LLVM_VERSION >= 90000
+            auto found = Section.getContents();
+            if (found)
+                Contents = *found;
+#else
+            bool found = !Section.getContents(Contents);
+#endif
+            if (found) {
                 size_t length = Contents.find('\0');
                 info.filename = Contents.substr(0, length);
                 info.crc32 = *(const uint32_t*)Contents.substr(LLT_ALIGN(length + 1, 4), 4).data();

--- a/test/llvmpasses/loopinfo.jl
+++ b/test/llvmpasses/loopinfo.jl
@@ -73,8 +73,8 @@ end
 
 # Example from a GPU kernel where we want to unroll the outer loop
 # and the inner loop is a boundschecked single iteration loop.
-# The `@show` is used to bloat the loop and `FINAL-COUNT-10:` seems
-# not to be working so we duplicate the checks.
+# The `@show` is used to bloat the loop and `X-COUNT-10:` seems
+# not to be working so we duplicate the checks. FIXME LLVM8
 # CHECK-LABEL: @julia_loop_unroll2
 # LOWER-LABEL: @julia_loop_unroll2
 # FINAL-LABEL: @julia_loop_unroll2


### PR DESCRIPTION
Just to see where we're at with the upcoming LLVM 9.0.0 release (currently in rc4). Two patches need to be updated, but seems like tests are passing.
```
$ make -C deps uninstall-llvm
$ make -C deps install-llvm USE_BINARYBUILDER_LLVM=0 LLVM_VER=9.0.0rc4
$ make all
```