### PR TITLE
Make higher-order functions composable

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2151,7 +2151,35 @@ julia> a
 """
 map!(f::F, dest::AbstractArray, As::AbstractArray...) where {F} = map_n!(f, dest, As)
 
-map(f) = f()
+"""
+    map(f)
+
+Return a function mapping `f` to its input.
+# Examples
+```jldoctest
+julia> a = ones(3);
+
+julia> doubler = map(x -> 2x);
+
+julia> tripler = map(x -> 3x);
+
+julia> doubler(tripler(a))
+3-element Array{Float64,1}:
+ 6.0
+ 6.0
+ 6.0
+
+julia> a |> doubler |> tripler
+3-element Array{Float64,1}:
+ 6.0
+ 6.0
+ 6.0
+```
+"""
+Base.map(f) = function(iters...)
+    map(f, iters...)
+end
+
 map(f, iters...) = collect(Generator(f, iters...))
 
 # multi-item push!, pushfirst! (built on top of type-specific 1-item version)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2370,6 +2370,29 @@ function filter(f, a::AbstractArray)
 end
 
 """
+    filter(f)
+
+Return a function filtering its inputs with `f`.
+
+# Examples
+```jldoctest
+julia> a = collect(1:8);
+
+julia> remove_odd = filter(iseven);
+
+julia> atleast5 = filter(>=(5));
+
+julia> remove_odd(atleast5(a))
+2-element Array{Int64,1}:
+ 6
+ 8
+```
+"""
+Base.filter(f) = function(iters...)
+    filter(f, iters...)
+end
+
+"""
     filter!(f, a::AbstractVector)
 
 Update `a`, removing elements for which `f` is `false`.


### PR DESCRIPTION
This proposal allows the direct composition of higher-order functions, starting with map and filter.

This is especially convenient with the piping syntax:
```julia
xs = rand(50)
xs |> filter(>(0.5)) |> map(x -> 2x) |> map(string)
```