### PR TITLE
document return nothing in Functions man page (2nd PR)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # Julia Documentation README
 
-Julia's documentation is written in Markdown. A reference of all supported syntax can be found in the [manual](https://docs.julialang.org/en/latest/manual/documentation/#Markdown-syntax-1). All documentation can be found in the Markdown files in `doc/src/` and the docstrings in Julia source files in `base/`.
+Julia's documentation is written in Markdown. A reference of all supported syntax can be found in the [manual](https://docs.julialang.org/en/latest/stdlib/Markdown/). All documentation can be found in the Markdown files in `doc/src/` and the docstrings in Julia source files in `base/`.
 
 ## Requirements
 
@@ -27,4 +27,3 @@ $ make -C doc doctest=true
 ```
 
 from the root directory.
-

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -146,9 +146,6 @@ Int8
 This function will always return an `Int8` regardless of the types of `x` and `y`.
 See [Type Declarations](@ref) for more on return types.
 
-Incidentally, the type of the arguments can also be specified similarly,
-but this is the topic of the [Methods](@ref) chapter.
-
 ### Returning nothing
 
 For functions that do not need to return a value (functions used only for some side effects),

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -151,8 +151,8 @@ but this is the topic of the [Methods](@ref) chapter.
 
 ### Returning nothing
 
-Some functions are used only for their side effects, and do not need to return a value.
-In these cases, the Julia convention is to return the value [`nothing`](@ref):
+For functions that do not need to return a value (functions used only for some side effects),
+the Julia convention is to return the value [`nothing`](@ref):
 
 ```julia
 function printx(x)
@@ -163,6 +163,8 @@ end
 
 This is a *convention* in the sense that `nothing` is not a Julia keyword
 but a only singleton object of type `Nothing`.
+Also, you may notice that the `printx` function example above is contrived,
+because `println` already returns `nothing`, so that the `return` line is redundant.
 
 There are two possible shortened forms for the `return nothing` expression.
 On the one hand, the `return` keyword implicitly returns `nothing`, so it can be used alone.

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -11,6 +11,9 @@ julia> function f(x,y)
 f (generic function with 1 method)
 ```
 
+This function accepts two arguments `x` and `y` and returns the value
+of the last expression evaluated, which is `x + y`.
+
 There is a second, more terse syntax for defining a function in Julia. The traditional function
 declaration syntax demonstrated above is equivalent to the following compact "assignment form":
 
@@ -64,8 +67,9 @@ Python, Ruby and Perl, among other dynamic languages.
 
 The value returned by a function is the value of the last expression evaluated, which, by default,
 is the last expression in the body of the function definition. In the example function, `f`, from
-the previous section this is the value of the expression `x + y`. As in C and most other imperative
-or functional languages, the `return` keyword causes a function to return immediately, providing
+the previous section this is the value of the expression `x + y`.
+As an alternative, as in many other languages,
+the `return` keyword causes a function to return immediately, providing
 an expression whose value is returned:
 
 ```julia
@@ -125,7 +129,9 @@ There are three possible points of return from this function, returning the valu
 expressions, depending on the values of `x` and `y`. The `return` on the last line could be omitted
 since it is the last expression.
 
-A return type can also be specified in the function declaration using the `::` operator. This converts
+### Return type
+
+A return type can be specified in the function declaration using the `::` operator. This converts
 the return value to the specified type.
 
 ```jldoctest
@@ -139,6 +145,31 @@ Int8
 
 This function will always return an `Int8` regardless of the types of `x` and `y`.
 See [Type Declarations](@ref) for more on return types.
+
+Incidentally, the type of the arguments can also be specified similarly,
+but this is the topic of the [Methods](@ref) chapter.
+
+### Returning nothing
+
+Some functions are used only for their side effects, and do not need to return a value.
+In these cases, the Julia convention is to return the value [`nothing`](@ref):
+
+```julia
+function printx(x)
+    println("x = $x")
+    return nothing
+end
+```
+
+This is a *convention* in the sense that `nothing` is not a Julia keyword
+but a only singleton object of type `Nothing`.
+
+There are two possible shortened forms for the `return nothing` expression.
+On the one hand, the `return` keyword implicitly returns `nothing`, so it can be used alone.
+On the other hand, since functions implicitly return their last expression evaluated,
+`nothing` can be used alone when it's the last expression.
+The preference for the expression `return nothing` as opposed to `return` or `nothing`
+alone is a matter of coding style.
 
 ## Operators Are Functions
 


### PR DESCRIPTION
Hi,

This is my 2nd try to document the `return nothing` convention in the [Functions](https://docs.julialang.org/en/v1/manual/functions/) manual. My first PR #27286 was 1 year old, so that some of my changes became superfluous (in particular, the documentation of `return` in base/docs/basedocs.jl now does mention `nothing` thanks to PR #30716).

Still, the Functions manual lacks the changes I proposed. Here a more compact PR, which answers @KristofferC feedback (e.g. I removed any reference to C's `return;`). The increased compactness should hopefully make it easier to merge!

I kept only one offtopic change: in the first PR, I was updating the link to Markdown syntax in doc/ README.md. In the meantime, it was changed, but it's again broken, so here is a one line fix which may not deserve a PR of its own.