### PR TITLE
fix #32970, at-threads disabled after a loop errors

### DIFF
--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -670,3 +670,19 @@ let ch = Channel{Char}(0), t
     schedule(t)
     @test String(collect(ch)) == "hello"
 end
+
+# errors inside @threads
+function _atthreads_with_error(a, err)
+    Threads.@threads for i in eachindex(a)
+        if err
+            error("failed")
+        end
+        a[i] = Threads.threadid()
+    end
+    a
+end
+@test_throws TaskFailedException _atthreads_with_error(zeros(nthreads()), true)
+let a = zeros(nthreads())
+    _atthreads_with_error(a, false)
+    @test a == [1:nthreads();]
+end


### PR DESCRIPTION
#32477 also fixes this issue, but until that is deemed safe this simpler fix might work.

fix #32970