### PR TITLE
div with rounding modes [+ rounded division]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@ Standard library changes
 
 * The methods of `mktemp` and `mktempdir` which take a function body to pass temporary paths to no longer throw errors if the path is already deleted when the function body returns ([#33091]).
 
+* `div` now accepts a rounding mode as the third argument, consistent with the corresponding argument to `rem`. Support for rounding division, by passing one of the RoundNearest modes to this function, was added. For future compatibility, library authors should now extend this function, rather than extending the two-argument `fld`/`cld`/`div` directly. ([#33040])
+
 * Verbose `display` of `Char` (`text/plain` output) now shows the codepoint value in standard-conforming `"U+XXXX"` format ([#33291]).
 
 #### Libdl

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -116,6 +116,7 @@ include("namedtuple.jl")
 include("hashing.jl")
 include("rounding.jl")
 using .Rounding
+include("div.jl")
 include("float.jl")
 include("twiceprecision.jl")
 include("complex.jl")

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -112,7 +112,5 @@ end
 *(y::AbstractFloat, x::Bool) = x * y
 
 div(x::Bool, y::Bool) = y ? x : throw(DivideError())
-fld(x::Bool, y::Bool) = div(x,y)
-cld(x::Bool, y::Bool) = div(x,y)
 rem(x::Bool, y::Bool) = y ? false : throw(DivideError())
 mod(x::Bool, y::Bool) = rem(x,y)

--- a/base/div.jl
+++ b/base/div.jl
@@ -117,15 +117,15 @@ function divrem(x::Integer, y::Integer, rnd::typeof(RoundNearest))
     (q, r) = divrem(x, y)
     if x >= 0
         if y >= 0
-            r >= (y÷2) + (isodd(y) | iseven(q)) ? (q+true, r-y) : (q, r)
+            r >=        (y÷2) + (isodd(y) | iseven(q)) ? (q+true, r-y) : (q, r)
         else
-            r >= -(y÷2) + (isodd(y) | iseven(q)) ? (q-true, r+y) : (q, r)
+            r >=       -(y÷2) + (isodd(y) | iseven(q)) ? (q-true, r+y) : (q, r)
         end
     else
         if y >= 0
-            r <= -signed(y÷2) - (isodd(y)| iseven(q)) ? (q-true, r+y) : (q, r)
+            r <= -signed(y÷2) - (isodd(y) | iseven(q)) ? (q-true, r+y) : (q, r)
         else
-            r <= (y÷2) - (isodd(y) | iseven(q)) ? (q+true, r-y) : (q, r)
+            r <=        (y÷2) - (isodd(y) | iseven(q)) ? (q+true, r-y) : (q, r)
         end
     end
 end
@@ -133,15 +133,15 @@ function divrem(x::Integer, y::Integer, rnd:: typeof(RoundNearestTiesAway))
     (q, r) = divrem(x, y)
     if x >= 0
         if y >= 0
-            r >= (y÷2) + isodd(y) ? (q+true, r-y) : (q, r)
+            r >=        (y÷2) + isodd(y) ? (q+true, r-y) : (q, r)
         else
-            r >= -(y÷2) + isodd(y) ? (q-true, r+y) : (q, r)
+            r >=       -(y÷2) + isodd(y) ? (q-true, r+y) : (q, r)
         end
     else
         if y >= 0
             r <= -signed(y÷2) - isodd(y) ? (q-true, r+y) : (q, r)
         else
-            r <= (y÷2) - isodd(y) ? (q+true, r-y) : (q, r)
+            r <=        (y÷2) - isodd(y) ? (q+true, r-y) : (q, r)
         end
     end
 end
@@ -149,15 +149,15 @@ function divrem(x::Integer, y::Integer, rnd::typeof(RoundNearestTiesUp))
     (q, r) = divrem(x, y)
     if x >= 0
         if y >= 0
-            r >= (y÷2) + isodd(y) ? (q+true, r-y) : (q, r)
+            r >=        (y÷2) + isodd(y) ? (q+true, r-y) : (q, r)
         else
-            r >= -(y÷2) + true ? (q-true, r+y) : (q, r)
+            r >=       -(y÷2) + true     ? (q-true, r+y) : (q, r)
         end
     else
         if y >= 0
-            r <= -signed(y÷2) - true ? (q-true, r+y) : (q, r)
+            r <= -signed(y÷2) - true     ? (q-true, r+y) : (q, r)
         else
-            r <= (y÷2) - isodd(y) ? (q+true, r-y) : (q, r)
+            r <=        (y÷2) - isodd(y) ? (q+true, r-y) : (q, r)
         end
     end
 end

--- a/base/div.jl
+++ b/base/div.jl
@@ -1,0 +1,74 @@
+# Div is truncating by default
+div(a, b) = div(a, b, RoundToZero)
+
+"""
+    fld(x, y)
+
+Largest integer less than or equal to `x/y`.
+
+# Examples
+```jldoctest
+julia> fld(7.3,5.5)
+1.0
+```
+"""
+fld(a, b) = div(a, b, RoundDown)
+
+"""
+    cld(x, y)
+
+Smallest integer larger than or equal to `x/y`.
+
+# Examples
+```jldoctest
+julia> cld(5.5,2.2)
+3.0
+```
+"""
+cld(a, b) = div(a, b, RoundUp)
+
+# We definite generic rounding methods for other rounding modes in terms of
+# RoundToZero.
+div(x::Signed, y::Unsigned, ::typeof(RoundDown)) = div(x, y, RoundToZero) - (signbit(x) & (rem(x, y) != 0))
+div(x::Unsigned, y::Signed, ::typeof(RoundDown)) = div(x, y, RoundToZero) - (signbit(y) & (rem(x, y) != 0))
+
+div(x::Signed, y::Unsigned, ::typeof(RoundUp)) = div(x, y, RoundToZero) + (!signbit(x) & (rem(x, y) != 0))
+div(x::Unsigned, y::Signed, ::typeof(RoundUp)) = div(x, y, RoundToZero) + (!signbit(y) & (rem(x, y) != 0))
+
+# For bootstrapping purposes, we define div for integers directly. Provide the
+# generic signature also
+div(a::T, b::T, ::typeof(RoundToZero)) where {T<:Union{BitSigned, BitUnsigned64}} = div(a, b)
+div(a::Bool, b::Bool, r::RoundingMode) = div(a, b)
+
+# For compatibility
+fld(a::T, b::T) where {T<:Integer} = div(a, b, RoundDown)
+cld(a::T, b::T) where {T<:Integer} = div(a, b, RoundDown)
+
+# Promotion
+div(x::Real, y::Real, r::RoundingMode) = div(promote(x, y)..., r)
+
+# Integers
+# fld(x,y) == div(x,y) - ((x>=0) != (y>=0) && rem(x,y) != 0 ? 1 : 0)
+div(x::T, y::T, ::typeof(RoundDown)) where {T<:Unsigned} = div(x,y)
+function div(x::T, y::T, ::typeof(RoundDown)) where T<:Integer
+    d = div(x, y, RoundToZero)
+    return d - (signbit(x ⊻ y) & (d * y != x))
+end
+
+# cld(x,y) = div(x,y) + ((x>0) == (y>0) && rem(x,y) != 0 ? 1 : 0)
+function div(x::T, y::T, ::typeof(RoundUp)) where T<:Unsigned
+    d = div(x, y, RoundToZero)
+    return d + (d * y != x)
+end
+function div(x::T, y::T, ::typeof(RoundUp)) where T<:Integer
+    d = div(x, y, RoundToZero)
+    return d + (((x > 0) == (y > 0)) & (d * y != x))
+end
+
+# Real
+div(x::T, y::T, ::typeof(RoundDown)) where {T<:Real} = convert(T,round((x-mod(x,y))/y))
+
+div(x::T, y::T, ::typeof(RoundUp)) where {T<:Real} = convert(T,round((x-modCeil(x,y))/y))
+#rem(x::T, y::T) where {T<:Real} = convert(T,x-y*trunc(x/y))
+#mod(x::T, y::T) where {T<:Real} = convert(T,x-y*floor(x/y))
+modCeil(x::T, y::T) where {T<:Real} = convert(T,x-y*ceil(x/y))

--- a/base/div.jl
+++ b/base/div.jl
@@ -35,7 +35,7 @@ div(x, y, r::RoundingMode)
 div(a, b) = div(a, b, RoundToZero)
 
 """
-    rem(x, y, r::RoundingMode)
+    rem(x, y, r::RoundingMode=RoundToZero)
 
 Compute the remainder of `x` after integer division by `y`, with the quotient rounded
 according to the rounding mode `r`. In other words, the quantity
@@ -98,10 +98,11 @@ cld(a, b) = div(a, b, RoundUp)
 
 # divrem
 """
-    divrem(x, y)
+    divrem(x, y, r::RoundingMode=RoundToZero)
 
-The quotient and remainder from Euclidean division. Equivalent to `(div(x,y), rem(x,y))` or
-`(x÷y, x%y)`.
+The quotient and remainder from Euclidean division.
+Equivalent to `(div(x,y,r), rem(x,y,r))`. Equivalently, with the the default
+value of `r`, this call is equivalent to `(x÷y, x%y)`.
 
 # Examples
 ```jldoctest
@@ -113,6 +114,7 @@ julia> divrem(7,3)
 ```
 """
 divrem(x, y) = divrem(x, y, RoundToZero)
+divrem(a, b, r::RoundingMode) = (div(a, b, r), rem(a, b, r))
 function divrem(x::Integer, y::Integer, rnd::typeof(RoundNearest))
     (q, r) = divrem(x, y)
     if x >= 0
@@ -161,9 +163,6 @@ function divrem(x::Integer, y::Integer, rnd::typeof(RoundNearestTiesUp))
         end
     end
 end
-
-
-divrem(a, b, r::RoundingMode) = (div(a, b, r), rem(a, b, r))
 
 """
     fldmod(x, y)

--- a/base/div.jl
+++ b/base/div.jl
@@ -202,8 +202,21 @@ end
 # generic signature also
 div(a::T, b::T, ::typeof(RoundToZero)) where {T<:Union{BitSigned, BitUnsigned64}} = div(a, b)
 div(a::Bool, b::Bool, r::RoundingMode) = div(a, b)
+# Prevent ambiguities
+for rm in (RoundUp, RoundDown, RoundToZero)
+    @eval div(a::Bool, b::Bool, r::$(typeof(rm))) = div(a, b)
+end
+function div(x::Bool, y::Bool, rnd::Union{typeof(RoundNearest),
+                                        typeof(RoundNearestTiesAway),
+                                        typeof(RoundNearestTiesUp)})
+    div(x, y)
+end
 fld(a::T, b::T) where {T<:Union{Integer,AbstractFloat}} = div(a, b, RoundDown)
 cld(a::T, b::T) where {T<:Union{Integer,AbstractFloat}} = div(a, b, RoundUp)
+div(a::Int128, b::Int128, ::typeof(RoundToZero)) = div(a, b)
+div(a::UInt128, b::UInt128, ::typeof(RoundToZero)) = div(a, b)
+rem(a::Int128, b::Int128, ::typeof(RoundToZero)) = rem(a, b)
+rem(a::UInt128, b::UInt128, ::typeof(RoundToZero)) = rem(a, b)
 
 # These are kept for compatibility with external packages overriding fld/cld.
 # In 2.0, packages should extend div(a,b,r) instead, in which case, these can

--- a/base/div.jl
+++ b/base/div.jl
@@ -252,5 +252,7 @@ function div(x::T, y::T, ::typeof(RoundUp)) where T<:Integer
 end
 
 # Real
-div(x::T, y::T, r::RoundingMode) where {T<:Real} = convert(T,round((x-rem(x,y,r))/y))
-rem(x::T, y::T, ::typeof(RoundUp)) where {T<:Real} = convert(T,x-y*ceil(x/y))
+# NOTE: C89 fmod() and x87 FPREM implicitly provide truncating float division,
+# so it is used here as the basis of float div().
+div(x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} = convert(T,round((x-rem(x,y,r))/y))
+rem(x::T, y::T, ::typeof(RoundUp)) where {T<:AbstractFloat} = convert(T,x-y*ceil(x/y))

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -5,7 +5,7 @@ module GMP
 export BigInt
 
 import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
-             binomial, cmp, convert, div, divrem, factorial, fld, gcd, gcdx, lcm, mod,
+             binomial, cmp, convert, div, divrem, factorial, cld, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, powermod,
              sum, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
@@ -146,7 +146,8 @@ sizeinbase(a::BigInt, b) = Int(ccall((:__gmpz_sizeinbase, :libgmp), Csize_t, (mp
 
 for (op, nbits) in (:add => :(BITS_PER_LIMB*(1 + max(abs(a.size), abs(b.size)))),
                     :sub => :(BITS_PER_LIMB*(1 + max(abs(a.size), abs(b.size)))),
-                    :mul => 0, :fdiv_q => 0, :tdiv_q => 0, :fdiv_r => 0, :tdiv_r => 0,
+                    :mul => 0, :fdiv_q => 0, :tdiv_q => 0, :cdiv_q => 0,
+                    :fdiv_r => 0, :tdiv_r => 0, :cdiv_r => 0,
                     :gcd => 0, :lcm => 0, :and => 0, :ior => 0, :xor => 0)
     op! = Symbol(op, :!)
     @eval begin
@@ -478,6 +479,11 @@ for (r, f) in ((RoundToZero, :tdiv_q),
                (RoundUp, :cdiv_q))
     @eval div(x::BigInt, y::BigInt, ::typeof($r)) = MPZ.$f(x, y)
 end
+
+# For compat only. Remove in 2.0.
+div(x::BigInt, y::BigInt) = div(x, y, RoundToZero)
+fld(x::BigInt, y::BigInt) = div(x, y, RoundDown)
+cld(x::BigInt, y::BigInt) = div(x, y, RoundUp)
 
 /(x::BigInt, y::BigInt) = float(x)/float(y)
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -465,12 +465,18 @@ big(n::Integer) = convert(BigInt, n)
 
 # Binary ops
 for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
-                 (:fld, :fdiv_q), (:div, :tdiv_q), (:mod, :fdiv_r), (:rem, :tdiv_r),
+                 (:mod, :fdiv_r), (:rem, :tdiv_r),
                  (:gcd, :gcd), (:lcm, :lcm),
                  (:&, :and), (:|, :ior), (:xor, :xor))
     @eval begin
         ($fJ)(x::BigInt, y::BigInt) = MPZ.$fC(x, y)
     end
+end
+
+for (r, f) in ((RoundToZero, :tdiv_q),
+               (RoundDown, :fdiv_q),
+               (RoundUp, :cdiv_q))
+    @eval div(x::BigInt, y::BigInt, ::typeof($r)) = MPZ.$f(x, y)
 end
 
 /(x::BigInt, y::BigInt) = float(x)/float(y)

--- a/base/int.jl
+++ b/base/int.jl
@@ -175,10 +175,6 @@ div(x::Unsigned, y::BitSigned) = unsigned(flipsign(signed(div(x, unsigned(abs(y)
 rem(x::BitSigned, y::Unsigned) = flipsign(signed(rem(unsigned(abs(x)), y)), x)
 rem(x::Unsigned, y::BitSigned) = rem(x, unsigned(abs(y)))
 
-fld(x::Signed, y::Unsigned) = div(x, y) - (signbit(x) & (rem(x, y) != 0))
-fld(x::Unsigned, y::Signed) = div(x, y) - (signbit(y) & (rem(x, y) != 0))
-
-
 """
     mod(x, y)
     rem(x, y, RoundDown)
@@ -220,33 +216,12 @@ mod(x::BitSigned, y::Unsigned) = rem(y + unsigned(rem(x, y)), y)
 mod(x::Unsigned, y::Signed) = rem(y + signed(rem(x, y)), y)
 mod(x::T, y::T) where {T<:Unsigned} = rem(x, y)
 
-cld(x::Signed, y::Unsigned) = div(x, y) + (!signbit(x) & (rem(x, y) != 0))
-cld(x::Unsigned, y::Signed) = div(x, y) + (!signbit(y) & (rem(x, y) != 0))
-
 # Don't promote integers for div/rem/mod since there is no danger of overflow,
 # while there is a substantial performance penalty to 64-bit promotion.
 div(x::T, y::T) where {T<:BitSigned64} = checked_sdiv_int(x, y)
 rem(x::T, y::T) where {T<:BitSigned64} = checked_srem_int(x, y)
 div(x::T, y::T) where {T<:BitUnsigned64} = checked_udiv_int(x, y)
 rem(x::T, y::T) where {T<:BitUnsigned64} = checked_urem_int(x, y)
-
-
-# fld(x,y) == div(x,y) - ((x>=0) != (y>=0) && rem(x,y) != 0 ? 1 : 0)
-fld(x::T, y::T) where {T<:Unsigned} = div(x,y)
-function fld(x::T, y::T) where T<:Integer
-    d = div(x, y)
-    return d - (signbit(x ⊻ y) & (d * y != x))
-end
-
-# cld(x,y) = div(x,y) + ((x>0) == (y>0) && rem(x,y) != 0 ? 1 : 0)
-function cld(x::T, y::T) where T<:Unsigned
-    d = div(x, y)
-    return d + (d * y != x)
-end
-function cld(x::T, y::T) where T<:Integer
-    d = div(x, y)
-    return d + (((x > 0) == (y > 0)) & (d * y != x))
-end
 
 ## integer bitwise operations ##
 

--- a/base/int.jl
+++ b/base/int.jl
@@ -175,6 +175,17 @@ div(x::Unsigned, y::BitSigned) = unsigned(flipsign(signed(div(x, unsigned(abs(y)
 rem(x::BitSigned, y::Unsigned) = flipsign(signed(rem(unsigned(abs(x)), y)), x)
 rem(x::Unsigned, y::BitSigned) = rem(x, unsigned(abs(y)))
 
+function divrem(x::BitSigned, y::Unsigned)
+    q, r = divrem(unsigned(abs(x)), y)
+    flipsign(signed(q), x), flipsign(signed(r), x)
+end
+
+function divrem(x::Unsigned, y::BitSigned)
+    q, r = divrem(x, unsigned(abs(y)))
+    unsigned(flipsign(signed(q), y)), r
+end
+
+
 """
     mod(x, y)
     rem(x, y, RoundDown)

--- a/base/math.jl
+++ b/base/math.jl
@@ -755,35 +755,6 @@ function frexp(x::T) where T<:IEEEFloat
     return reinterpret(T, xu), k
 end
 
-"""
-    rem(x, y, r::RoundingMode)
-
-Compute the remainder of `x` after integer division by `y`, with the quotient rounded
-according to the rounding mode `r`. In other words, the quantity
-
-    x - y*round(x/y,r)
-
-without any intermediate rounding.
-
-- if `r == RoundNearest`, then the result is exact, and in the interval
-  ``[-|y|/2, |y|/2]``. See also [`RoundNearest`](@ref).
-
-- if `r == RoundToZero` (default), then the result is exact, and in the interval
-  ``[0, |y|)`` if `x` is positive, or ``(-|y|, 0]`` otherwise. See also [`RoundToZero`](@ref).
-
-- if `r == RoundDown`, then the result is in the interval ``[0, y)`` if `y` is positive, or
-  ``(y, 0]`` otherwise. The result may not be exact if `x` and `y` have different signs, and
-  `abs(x) < abs(y)`. See also[`RoundDown`](@ref).
-
-- if `r == RoundUp`, then the result is in the interval `(-y,0]` if `y` is positive, or
-  `[0,-y)` otherwise. The result may not be exact if `x` and `y` have the same sign, and
-  `abs(x) < abs(y)`. See also [`RoundUp`](@ref).
-
-"""
-rem(x, y, ::RoundingMode{:ToZero}) = rem(x,y)
-rem(x, y, ::RoundingMode{:Down}) = mod(x,y)
-rem(x, y, ::RoundingMode{:Up}) = mod(x,-y)
-
 rem(x::Float64, y::Float64, ::RoundingMode{:Nearest}) =
     ccall((:remainder, libm),Float64,(Float64,Float64),x,y)
 rem(x::Float32, y::Float32, ::RoundingMode{:Nearest}) =

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -108,7 +108,7 @@ for f in (:(Base.zero), :(Base.one), :(Base.oneunit))
 end
 
 # Binary operators/functions
-for f in (:(+), :(-), :(*), :(/), :(^), :(div), :(mod), :(fld), :(rem))
+for f in (:(+), :(-), :(*), :(/), :(^), :(mod), :(rem))
     @eval begin
         # Scalar with missing
         ($f)(::Missing, ::Missing) = missing
@@ -116,6 +116,10 @@ for f in (:(+), :(-), :(*), :(/), :(^), :(div), :(mod), :(fld), :(rem))
         ($f)(::Number,  ::Missing) = missing
     end
 end
+
+div(::Missing, ::Missing, r::RoundingMode) = missing
+div(::Missing, ::Number, r::RoundingMode) = missing
+div(::Number, ::Missing, r::RoundingMode) = missing
 
 min(::Missing, ::Missing) = missing
 min(::Missing, ::Any)     = missing

--- a/base/number.jl
+++ b/base/number.jl
@@ -88,30 +88,6 @@ last(x::Number) = x
 copy(x::Number) = x # some code treats numbers as collection-like
 
 """
-    divrem(x, y)
-
-The quotient and remainder from Euclidean division. Equivalent to `(div(x,y), rem(x,y))` or
-`(x÷y, x%y)`.
-
-# Examples
-```jldoctest
-julia> divrem(3,7)
-(0, 3)
-
-julia> divrem(7,3)
-(2, 1)
-```
-"""
-divrem(x,y) = (div(x,y),rem(x,y))
-
-"""
-    fldmod(x, y)
-
-The floored quotient and modulus after division. Equivalent to `(fld(x,y), mod(x,y))`.
-"""
-fldmod(x,y) = (fld(x,y),mod(x,y))
-
-"""
     signbit(x)
 
 Returns `true` if the value of the sign of `x` is negative, otherwise `false`.

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -687,34 +687,6 @@ end
 # so it is used here as the basis of float div().
 div(x::T, y::T) where {T<:Real} = convert(T,round((x-rem(x,y))/y))
 
-"""
-    fld(x, y)
-
-Largest integer less than or equal to `x/y`.
-
-# Examples
-```jldoctest
-julia> fld(7.3,5.5)
-1.0
-```
-"""
-fld(x::T, y::T) where {T<:Real} = convert(T,round((x-mod(x,y))/y))
-
-"""
-    cld(x, y)
-
-Smallest integer larger than or equal to `x/y`.
-
-# Examples
-```jldoctest
-julia> cld(5.5,2.2)
-3.0
-```
-"""
-cld(x::T, y::T) where {T<:Real} = convert(T,round((x-modCeil(x,y))/y))
-#rem(x::T, y::T) where {T<:Real} = convert(T,x-y*trunc(x/y))
-#mod(x::T, y::T) where {T<:Real} = convert(T,x-y*floor(x/y))
-modCeil(x::T, y::T) where {T<:Real} = convert(T,x-y*ceil(x/y))
 
 # operator alias
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -682,12 +682,6 @@ function >>>(x::Integer, c::Unsigned)
 end
 >>>(x::Integer, c::Int) = c >= 0 ? x >>> unsigned(c) : x << unsigned(-c)
 
-# fallback div, fld, and cld implementations
-# NOTE: C89 fmod() and x87 FPREM implicitly provide truncating float division,
-# so it is used here as the basis of float div().
-div(x::T, y::T) where {T<:Real} = convert(T,round((x-rem(x,y))/y))
-
-
 # operator alias
 
 """

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -351,12 +351,6 @@ div(x::Real, y::Real) = div(promote(x,y)...)
 rem(x::Real, y::Real) = rem(promote(x,y)...)
 mod(x::Real, y::Real) = mod(promote(x,y)...)
 
-# These are kept for compatibility with external packages overriding fld/cld.
-# In 2.0, packages should extend div(a,b,r) instead, in which case, these can
-# be removed.
-fld(x::Real, y::Real) = fld(promote(x,y)...)
-cld(x::Real, y::Real) = cld(promote(x,y)...)
-
 mod1(x::Real, y::Real) = mod1(promote(x,y)...)
 fld1(x::Real, y::Real) = fld1(promote(x,y)...)
 

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -348,10 +348,14 @@ muladd(x::Number, y::Number, z::Number) = muladd(promote(x,y,z)...)
 <=(x::Real, y::Real)     = (<=)(promote(x,y)...)
 
 div(x::Real, y::Real) = div(promote(x,y)...)
-fld(x::Real, y::Real) = fld(promote(x,y)...)
-cld(x::Real, y::Real) = cld(promote(x,y)...)
 rem(x::Real, y::Real) = rem(promote(x,y)...)
 mod(x::Real, y::Real) = mod(promote(x,y)...)
+
+# These are kept for compatibility with external packages overriding fld/cld.
+# In 2.0, packages should extend div(a,b,r) instead, in which case, these can
+# be removed.
+fld(x::Real, y::Real) = fld(promote(x,y)...)
+cld(x::Real, y::Real) = cld(promote(x,y)...)
 
 mod1(x::Real, y::Real) = mod1(promote(x,y)...)
 fld1(x::Real, y::Real) = fld1(promote(x,y)...)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -347,7 +347,6 @@ muladd(x::Number, y::Number, z::Number) = muladd(promote(x,y,z)...)
 <( x::Real, y::Real)     = (< )(promote(x,y)...)
 <=(x::Real, y::Real)     = (<=)(promote(x,y)...)
 
-div(x::Real, y::Real) = div(promote(x,y)...)
 rem(x::Real, y::Real) = rem(promote(x,y)...)
 mod(x::Real, y::Real) = mod(promote(x,y)...)
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -364,6 +364,18 @@ function div(x::Rational, y::Rational, r::RoundingMode)
     div(checked_mul(xn,yd), checked_mul(xd,yn), r)
 end
 
+# For compatibility - to be removed in 2.0 when the generic fallbacks
+# are removed from div.jl
+div(x::T, y::T, r::RoundingMode) where {T<:Rational} =
+    invoke(div, Tuple{Rational, Rational, RoundingMode}, x, y, r)
+for (S, T) in ((Rational, Integer), (Integer, Rational), (Rational, Rational))
+    @eval begin
+        div(x::$S, y::$T) = div(x, y, RoundToZero)
+        fld(x::$S, y::$T) = div(x, y, RoundDown)
+        cld(x::$S, y::$T) = div(x, y, RoundUp)
+    end
+end
+
 trunc(::Type{T}, x::Rational) where {T} = convert(T,div(x.num,x.den))
 floor(::Type{T}, x::Rational) where {T} = convert(T,fld(x.num,x.den))
 ceil(::Type{T}, x::Rational) where {T} = convert(T,cld(x.num,x.den))

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -350,22 +350,18 @@ end
 ==(z::Complex , x::Rational) = isreal(z) & (real(z) == x)
 ==(x::Rational, z::Complex ) = isreal(z) & (real(z) == x)
 
-for op in (:div, :fld, :cld)
-    @eval begin
-        function ($op)(x::Rational, y::Integer )
-            xn,yn = divgcd(x.num,y)
-            ($op)(xn, checked_mul(x.den,yn))
-        end
-        function ($op)(x::Integer,  y::Rational)
-            xn,yn = divgcd(x,y.num)
-            ($op)(checked_mul(xn,y.den), yn)
-        end
-        function ($op)(x::Rational, y::Rational)
-            xn,yn = divgcd(x.num,y.num)
-            xd,yd = divgcd(x.den,y.den)
-            ($op)(checked_mul(xn,yd), checked_mul(xd,yn))
-        end
-    end
+function div(x::Rational, y::Integer, r::RoundingMode)
+    xn,yn = divgcd(x.num,y)
+    div(xn, checked_mul(x.den,yn), r)
+end
+function div(x::Integer, y::Rational, r::RoundingMode)
+    xn,yn = divgcd(x,y.num)
+    div(checked_mul(xn,y.den), yn, r)
+end
+function div(x::Rational, y::Rational, r::RoundingMode)
+    xn,yn = divgcd(x.num,y.num)
+    xd,yd = divgcd(x.den,y.den)
+    div(checked_mul(xn,yd), checked_mul(xd,yn), r)
 end
 
 trunc(::Type{T}, x::Rational) where {T} = convert(T,div(x.num,x.den))

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -75,12 +75,10 @@ for op in (:+, :-, :lcm, :gcd)
     @eval ($op)(x::P, y::P) where {P<:Period} = P(($op)(value(x), value(y)))
 end
 
-for op in (:/, :div, :fld)
-    @eval begin
-        ($op)(x::P, y::P) where {P<:Period} = ($op)(value(x), value(y))
-        ($op)(x::P, y::Real) where {P<:Period} = P(($op)(value(x), Int64(y)))
-    end
-end
+/(x::P, y::P) where {P<:Period} = /(value(x), value(y))
+/(x::P, y::Real) where {P<:Period} = P(/(value(x), Int64(y)))
+div(x::P, y::P, r::RoundingMode) where {P<:Period} = div(value(x), value(y), r)
+div(x::P, y::Real, r::RoundingMode) where {P<:Period} = P(div(value(x), Int64(y), r))
 
 for op in (:rem, :mod)
     @eval begin

--- a/test/int.jl
+++ b/test/int.jl
@@ -305,3 +305,26 @@ let i = MyInt26779(1)
     @test_throws MethodError i << 1
     @test_throws MethodError i >>> 1
 end
+
+@testset "rounding division" begin
+    for (a, b, nearest, away, up) in (
+            (3, 2, 2, 2, 2),
+            (5, 3, 2, 2, 2),
+            (-3, 2, -2, -2, -1),
+            (5, 2, 2, 3, 3),
+            (-5, 2, -2, -3, -2),
+            (-5, 3, -2, -2, -2),
+            (5, -3, -2, -2, -2))
+        for sign in (+1, -1)
+            (a, b) = (a*sign, b*sign)
+            @test div(a, b, RoundNearest) == nearest
+            @test div(a, b, RoundNearestTiesAway) == away
+            @test div(a, b, RoundNearestTiesUp) == up
+        end
+    end
+
+    @test div(typemax(Int64), typemax(Int64)-1, RoundNearest) == 1
+    @test div(-typemax(Int64), typemax(Int64)-1, RoundNearest) == -2
+    @test div(typemax(Int64), 2, RoundNearest) == 4611686018427387904
+    @test div(-typemax(Int64), 2, RoundNearestTiesUp) == -4611686018427387903
+end

--- a/test/int.jl
+++ b/test/int.jl
@@ -307,6 +307,14 @@ let i = MyInt26779(1)
 end
 
 @testset "rounding division" begin
+    for x = -100:100
+        for y = 1:100
+            for rnd in (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
+                @test div(x,y,rnd) == round(x/y,rnd)
+                @test div(x,-y,rnd) == round(x/-y,rnd)
+            end
+        end
+    end
     for (a, b, nearest, away, up) in (
             (3, 2, 2, 2, 2),
             (5, 3, 2, 2, 2),

--- a/test/int.jl
+++ b/test/int.jl
@@ -332,7 +332,8 @@ end
     end
 
     @test div(typemax(Int64), typemax(Int64)-1, RoundNearest) == 1
-    @test div(-typemax(Int64), typemax(Int64)-1, RoundNearest) == -2
+    @test div(-typemax(Int64), typemax(Int64)-1, RoundNearest) == -1
     @test div(typemax(Int64), 2, RoundNearest) == 4611686018427387904
     @test div(-typemax(Int64), 2, RoundNearestTiesUp) == -4611686018427387903
+    @test div(typemax(Int)-2, typemax(Int), RoundNearest) == 1
 end

--- a/test/int.jl
+++ b/test/int.jl
@@ -336,4 +336,19 @@ end
     @test div(typemax(Int64), 2, RoundNearest) == 4611686018427387904
     @test div(-typemax(Int64), 2, RoundNearestTiesUp) == -4611686018427387903
     @test div(typemax(Int)-2, typemax(Int), RoundNearest) == 1
+
+    # Exhaustively test (U)Int8 to catch any overflow-style issues
+    for r in (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
+        for T in (UInt8, Int8)
+            for x in typemin(T):typemax(T)
+                for y in typemin(T):typemax(T)
+                    if y == 0 || (T <: Signed && x == typemin(T) && y == -1)
+                        @test_throws DivideError div(x, y, r)
+                    else
+                        @test div(x, y, r) == T(div(widen(T)(x), widen(T)(y), r))
+                    end
+                end
+            end
+        end
+    end
 end


### PR DESCRIPTION
I found myself needing a rounding integer division, i.e. one that does RoundToNearestTiesAway (actually the reference implementation calls for RoundToNearestTiesToward, but the paper doesn't specified and either should be ok). Rather than adding a rntad (round-to-neearest-ties-away-division) function, I figured it may make sense to instead create a generic `div(x, y, r::RoundingMode=RoundToZero)` function, while keeping `fld`,`cld` (and the two-argument div) as useful shorthands for the rounding modes they represent.

~~This PR just does the re-arranging for the existing code. I haven't yet added the new functionality for round-nearest. Let's discuss whether this direction is sensible.~~