### PR TITLE
Rename: getcolptr -> colptrs

### DIFF
--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -4,7 +4,7 @@ module SparseVectorTests
 
 using Test
 using SparseArrays
-using SparseArrays: nonzeroinds, getcolptr
+using SparseArrays: nonzeroinds, colptrs
 using LinearAlgebra
 using Random
 include("forbidproperties.jl")
@@ -1008,8 +1008,8 @@ end
 
         sprmat = sprand(m, m, 0.2)
         sparsefloatmat = I + sprmat/(2m)
-        sparsecomplexmat = I + SparseMatrixCSC(m, m, getcolptr(sprmat), rowvals(sprmat), complex.(nonzeros(sprmat), nonzeros(sprmat))/(4m))
-        sparseintmat = 10m*I + SparseMatrixCSC(m, m, getcolptr(sprmat), rowvals(sprmat), round.(Int, nonzeros(sprmat)*10))
+        sparsecomplexmat = I + SparseMatrixCSC(m, m, colptrs(sprmat), rowvals(sprmat), complex.(nonzeros(sprmat), nonzeros(sprmat))/(4m))
+        sparseintmat = 10m*I + SparseMatrixCSC(m, m, colptrs(sprmat), rowvals(sprmat), round.(Int, nonzeros(sprmat)*10))
 
         denseintmat = I*10m + rand(1:m, m, m)
         densefloatmat = I + randn(m, m)/(2m)
@@ -1302,21 +1302,21 @@ end
     simA = similar(A, (6,6))
     @test typeof(simA) == SparseMatrixCSC{eltype(nonzeros(A)),eltype(nonzeroinds(A))}
     @test size(simA) == (6,6)
-    @test getcolptr(simA) == fill(1, 6+1)
+    @test colptrs(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(nonzeroinds(A))
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, (6,6))
     @test typeof(simA) == SparseMatrixCSC{Float32,eltype(nonzeroinds(A))}
     @test size(simA) == (6,6)
-    @test getcolptr(simA) == fill(1, 6+1)
+    @test colptrs(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(nonzeroinds(A))
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type, index type, and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, Int8, (6,6))
     @test typeof(simA) == SparseMatrixCSC{Float32, Int8}
     @test size(simA) == (6,6)
-    @test getcolptr(simA) == fill(1, 6+1)
+    @test colptrs(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(nonzeroinds(A))
     @test length(nonzeros(simA)) == length(nonzeros(A))
 end

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -8,7 +8,7 @@ Standard library module for basic statistics functionality.
 module Statistics
 
 using LinearAlgebra, SparseArrays
-using SparseArrays: getcolptr
+using SparseArrays: colptrs
 
 using Base: has_offset_axes, require_one_based_indexing
 
@@ -1004,7 +1004,7 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::SparseMatrixCSC{Tv,Ti}, mea
     isempty(R) || fill!(R, zero(S))
     isempty(A) && return R
 
-    colptr = getcolptr(A)
+    colptr = colptrs(A)
     rowval = rowvals(A)
     nzval = nonzeros(A)
     m = size(A, 1)

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -24,7 +24,7 @@ const ORDERING_BESTAMD = Int32(9) # try COLAMD and AMD; pick best#
 # the best of AMD and METIS. METIS is not tried if it isn't installed.
 
 using SparseArrays
-using SparseArrays: getcolptr
+using SparseArrays: colptrs
 using ..SuiteSparse.CHOLMOD
 using ..SuiteSparse.CHOLMOD: change_stype!, free!
 
@@ -160,7 +160,7 @@ function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol = _default_tol(A)) where {
                     vec(Array(CHOLMOD.Dense(HTau[]))),
                     SparseMatrixCSC(min(size(A)...),
                                     size(R_, 2),
-                                    getcolptr(R_),
+                                    colptrs(R_),
                                     rowvals(R_),
                                     nonzeros(R_)),
                     p, hpinv)

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
 import LinearAlgebra: Factorization, det, lu, ldiv!
 
 using SparseArrays
-using SparseArrays: getcolptr
+using SparseArrays: colptrs
 import SparseArrays: nnz
 
 import Serialization: AbstractSerializer, deserialize
@@ -152,9 +152,9 @@ The relation between `F` and `A` is
     `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 """
 function lu(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes}; check::Bool = true)
-    zerobased = getcolptr(S)[1] == 0
+    zerobased = colptrs(S)[1] == 0
     res = UmfpackLU(C_NULL, C_NULL, size(S, 1), size(S, 2),
-                    zerobased ? copy(getcolptr(S)) : decrement(getcolptr(S)),
+                    zerobased ? copy(colptrs(S)) : decrement(colptrs(S)),
                     zerobased ? copy(rowvals(S)) : decrement(rowvals(S)),
                     copy(nonzeros(S)), 0)
     finalizer(umfpack_free_symbolic, res)

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -7,7 +7,7 @@ using Random
 using Serialization
 using LinearAlgebra: issuccess, PosDefException
 using SparseArrays
-using SparseArrays: getcolptr
+using SparseArrays: colptrs
 
 # CHOLMOD tests
 Random.seed!(123)
@@ -334,7 +334,7 @@ end
     A1pdSparse = CHOLMOD.Sparse(
         size(A1pd, 1),
         size(A1pd, 2),
-        SuiteSparse.decrement(getcolptr(A1pd)),
+        SuiteSparse.decrement(colptrs(A1pd)),
         SuiteSparse.decrement(rowvals(A1pd)),
         nonzeros(A1pd))
 
@@ -768,7 +768,7 @@ end
 @testset "Check inputs to Sparse. Related to #20024" for A_ in (
     SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1,2], Float64[]),
     SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1,2], Float64[1.0]))
-    args = (size(A_)..., getcolptr(A_) .- 1, rowvals(A_) .- 1, nonzeros(A_))
+    args = (size(A_)..., colptrs(A_) .- 1, rowvals(A_) .- 1, nonzeros(A_))
     @test_throws ArgumentError CHOLMOD.Sparse(args...)
     @test_throws ArgumentError CHOLMOD.Sparse(A_)
 end


### PR DESCRIPTION
As @ViralBShah suggested in https://github.com/JuliaLang/julia/pull/32953#issuecomment-523811353, it makes sense to drop `get` prefix from `getcolptr(::SparseMatrixCSC)`.  To be compatible with `rowvals` and `nonzeros`, it may be better to use `colptrs`?

Also, maybe it's better to remove `getrowval` and `getnzval` (or deprecate them, if we want to be extra careful) as they are just aliases of `rowvals` and `nonzeros`?

See also #33039