### PR TITLE
Fix incorrect use of `isimmutable`

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -26,8 +26,8 @@ end
 
 function finalizer(f::Ptr{Cvoid}, o::T) where T
     @_inline_meta
-    if isimmutable(T)
-        error("objects of type ", T, " cannot be finalized")
+    if isimmutable(o)
+        error("objects of type ", typeof(o), " cannot be finalized")
     end
     ccall(:jl_gc_add_ptr_finalizer, Cvoid, (Ptr{Cvoid}, Any, Ptr{Cvoid}),
           Core.getptls(), o, f)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -735,3 +735,7 @@ end
 
 # Pointer 0-arg constructor
 @test Ptr{Cvoid}() == C_NULL
+
+# Finalizer with immutable should throw
+@test_throws ErrorException finalizer(x->nothing, 1)
+@test_throws ErrorException finalizer(C_NULL, 1)


### PR DESCRIPTION
This function operates on values not on types (though it is a bit of
a trap). Also add a test to catch this bug.