### PR TITLE
Add blocksize keyword argument to qr[!]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@ Standard library changes
 
 #### LinearAlgebra
 
+* `qr` and `qr!` functions support `blocksize` keyword argument ([#33053]).
+
 
 #### SparseArrays
 


### PR DESCRIPTION
A few quick benchmarks (see below) show that increasing block size helps when the matrix is not smalll.  I propose to add a keyword argument `blocksize` to control it.

## `LAPACK.geqrt!` with some large matrices

### `m = n = 10000`

```julia
julia> @time LAPACK.geqrt!(randn(10000, 10000), 1000);
 12.204004 seconds (11 allocations: 915.528 MiB, 0.61% gc time)

julia> @time LAPACK.geqrt!(randn(10000, 10000), 100);
 13.498686 seconds (11 allocations: 778.199 MiB, 0.66% gc time)

julia> @time LAPACK.geqrt!(randn(10000, 10000), 50);
 17.521465 seconds (11 allocations: 770.569 MiB, 0.51% gc time)

julia> @time LAPACK.geqrt!(randn(10000, 10000), 36);
 21.275011 seconds (11 allocations: 768.433 MiB, 0.48% gc time)
```

### `m = n = 5000`

```julia
julia> @time LAPACK.geqrt!(randn(5000, 5000), 1000);
  1.889297 seconds (11 allocations: 267.029 MiB)

julia> @time LAPACK.geqrt!(randn(5000, 5000), 100);
  1.908479 seconds (11 allocations: 198.365 MiB)

julia> @time LAPACK.geqrt!(randn(5000, 5000), 50);
  2.518595 seconds (11 allocations: 194.550 MiB)

julia> @time LAPACK.geqrt!(randn(5000, 5000), 36);
  2.854150 seconds (11 allocations: 193.482 MiB)
```
