### PR TITLE
RFC: AbstractSparseMatrixCSC interface

### DIFF
--- a/stdlib/SparseArrays/docs/src/AbstractSparseMatrixCSC.md
+++ b/stdlib/SparseArrays/docs/src/AbstractSparseMatrixCSC.md
@@ -1,0 +1,59 @@
+    AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
+
+Supertype for matrix with compressed sparse column (CSC).
+
+## `AbstractSparseMatrixCSC` interface
+
+In addition to the [Abstract array interface](@ref man-interface-array), every
+`AbstractSparseMatrixCSC` subtype `TS` must provide the following methods:
+
+* [`size(::TS)`](@ref size)
+* [`getcolptr(::TS) :: AbstractVector{<:Ti}`](@ref getcolptr)
+* [`rowvals(::TS) :: AbstractVector{<:Ti}`](@ref rowvals)
+* [`nonzeros(::TS) :: AbstractVector{<:Tv}`](@ref nonzeros)
+
+Other sparse matrix methods such as [`nzrange`](@ref) and [`nnz`](@ref) are automatically
+defined in terms of above functions.
+
+## Assumed invariance
+
+To use algorithms defined in SparseArrays, a matrix `A` of type `AbstractSparseMatrixCSC`
+must satisfy the following constraints.
+
+### Matrix `A` and all vectors constituting `A` have one-based indexing
+
+```julia
+@assert !has_offset_axes(A)
+@assert !has_offset_axes(getcolptr(A))
+@assert !has_offset_axes(rowvals(A))
+@assert !has_offset_axes(nonzeros(A))
+```
+
+### Row indices in `rowval(A)` for each column are sorted
+
+```julia
+for col in axes(A, 2)
+    @assert issorted(rowval(A)[nzrange(A, col)])
+end
+```
+
+### Column pointers in `getcolptr(A)` are increasing, started at 1
+
+```julia
+@assert getcolptr(A)[1] === 1
+@assert all(diff(getcolptr(A)) .>= 0)
+```
+
+### Row index vector `rowvals(A)` and non-zero value vector `nonzeros(A)` are long enough
+
+```julia
+@assert nnz(A) <= length(rowvals(A))
+@assert nnz(A) <= length(nonzeros(A))
+```
+
+### Indices for rows, `rowvals(A)` and `nonzeros(A)` are representable by `Ti`
+
+```julia
+@assert size(A, 1) <= typemax(Ti)
+@assert nnz(A) <= typemax(Ti)
+```

--- a/stdlib/SparseArrays/docs/src/AbstractSparseMatrixCSC.md
+++ b/stdlib/SparseArrays/docs/src/AbstractSparseMatrixCSC.md
@@ -2,6 +2,9 @@
 
 Supertype for matrix with compressed sparse column (CSC).
 
+!!! compat "Julia 1.4"
+    `AbstractSparseMatrixCSC` requires at least Julia 1.4.
+
 ## `AbstractSparseMatrixCSC` interface
 
 In addition to the [Abstract array interface](@ref man-interface-array), every

--- a/stdlib/SparseArrays/docs/src/AbstractSparseMatrixCSC.md
+++ b/stdlib/SparseArrays/docs/src/AbstractSparseMatrixCSC.md
@@ -11,7 +11,7 @@ In addition to the [Abstract array interface](@ref man-interface-array), every
 `AbstractSparseMatrixCSC` subtype `TS` must provide the following methods:
 
 * [`size(::TS)`](@ref size)
-* [`getcolptr(::TS) :: AbstractVector{<:Ti}`](@ref getcolptr)
+* [`coloffsets(::TS) :: AbstractVector{<:Ti}`](@ref coloffsets)
 * [`rowvals(::TS) :: AbstractVector{<:Ti}`](@ref rowvals)
 * [`nonzeros(::TS) :: AbstractVector{<:Tv}`](@ref nonzeros)
 
@@ -27,7 +27,7 @@ must satisfy the following constraints.
 
 ```julia
 @assert !has_offset_axes(A)
-@assert !has_offset_axes(getcolptr(A))
+@assert !has_offset_axes(coloffsets(A))
 @assert !has_offset_axes(rowvals(A))
 @assert !has_offset_axes(nonzeros(A))
 ```
@@ -40,11 +40,11 @@ for col in axes(A, 2)
 end
 ```
 
-### Column pointers in `getcolptr(A)` are increasing, started at 1
+### Column pointers in `coloffsets(A)` are increasing, started at 1
 
 ```julia
-@assert getcolptr(A)[1] === 1
-@assert all(diff(getcolptr(A)) .>= 0)
+@assert coloffsets(A)[1] === 1
+@assert all(diff(coloffsets(A)) .>= 0)
 ```
 
 ### Row index vector `rowvals(A)` and non-zero value vector `nonzeros(A)` are long enough


### PR DESCRIPTION
This PR should finalize the changes to make SparseArrays.jl extensible (for previous PRs, see: #30173, #32953, #33039, etc.).  Now that #33039 is (hopefully) about to get merged I'd like to know what is the best way to formalize the interface for `AbstractSparseMatrixCSC`.  I created a first draft based on the comments:

https://github.com/JuliaLang/julia/blob/19a2b2e417fe80e83e2d2964db70451835abb4d4/stdlib/SparseArrays/src/sparsematrix.jl#L3-L9

To make it easy to review the documentation, I put the docstring in a markdown file so that GitHub renders it in a (somewhat) readable form.  I'll move it to `AbstractSparseMatrixCSC`'s docstring before this PR is merged.  You can read the latest rendered version here: https://github.com/tkf/julia/blob/RFC-AbstractSparseMatrixCSC/stdlib/SparseArrays/docs/src/AbstractSparseMatrixCSC.md

There are a few things that are not clear. Especially discussions related to #31724. I'll make inline comments about them.

TODOs before merge:

- [ ] Rename `getcolptr` to something (`coloffsets`?) cf #33041.
- [ ] Copy the markdown to docstring of `AbstractSparseMatrixCSC`.
- [ ] Add NEWS (cf #33050).
- [ ] Export `AbstractSparseMatrixCSC`