### PR TITLE
llvm: add SONAME suffix to solve dlopen conflict on FreeBSD

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -290,6 +290,11 @@ distclean-libcxxabi:
 LLVM_CMAKE += -DCMAKE_EXE_LINKER_FLAGS="$(LLVM_LDFLAGS) $(LLVM_LIBCXX_LDFLAGS)" \
 	-DCMAKE_SHARED_LINKER_FLAGS="$(LLVM_LDFLAGS) $(LLVM_LIBCXX_LDFLAGS)"
 
+# change the SONAME of Julia's private LLVM
+# i.e. libLLVM-6.0jl.so
+# see #32462
+LLVM_CMAKE += -DLLVM_VERSION_SUFFIX:STRING="jl"
+
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
 LIBCXX_DEPENDENCY := $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++.so.1.0
 get-llvm: get-libcxx get-libcxxabi


### PR DESCRIPTION
close #32462

```
objdump -x ./usr/lib/libLLVM-6.0jl.so | grep SONAME 
  SONAME      libLLVM-6.0jl.so
```
and `dlopen`ing on `r600_dri.so` works fine now.