### PR TITLE
implement enumeration of modules ourselves

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -543,7 +543,7 @@ JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle)
 #elif defined(_OS_WINDOWS_)
 
     wchar_t *pth16 = (wchar_t*)malloc_s(32768 * sizeof(*pth16)); // max long path length
-    DWORD n16 = GetModuleFileNameW((HMODULE)handle,pth16,32768);
+    DWORD n16 = GetModuleFileNameW((HMODULE)handle, pth16, 32768);
     if (n16 <= 0) {
         free(pth16);
         return NULL;
@@ -582,23 +582,30 @@ JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle)
 }
 
 #ifdef _OS_WINDOWS_
-static BOOL CALLBACK jl_EnumerateLoadedModulesProc64(
-  _In_      PCTSTR ModuleName,
-  _In_      DWORD64 ModuleBase,
-  _In_      ULONG ModuleSize,
-  _In_opt_  PVOID a
-)
-{
-    jl_array_grow_end((jl_array_t*)a, 1);
-    //XXX: change to jl_arrayset if array storage allocation for Array{String,1} changes:
-    jl_value_t *v = jl_cstr_to_string(ModuleName);
-    jl_array_ptr_set(a, jl_array_dim0(a)-1, v);
-    return TRUE;
-}
-// Takes a handle (as returned from dlopen()) and returns the absolute path to the image loaded
+// Get a list of all the modules in this process.
 JL_DLLEXPORT int jl_dllist(jl_array_t *list)
 {
-    return EnumerateLoadedModules64(GetCurrentProcess(), jl_EnumerateLoadedModulesProc64, list);
+    DWORD cb, cbNeeded;
+    HMODULE *hMods = NULL;
+    unsigned int i;
+    cbNeeded = 1024 * sizeof(*hMods);
+    do {
+        cb = cbNeeded;
+        hMods = (HMODULE*)realloc_s(hMods, cb);
+        if (!EnumProcessModulesEx(GetCurrentProcess(), hMods, cb, &cbNeeded, LIST_MODULES_ALL)) {
+          free(hMods);
+          return FALSE;
+        }
+    } while (cb < cbNeeded);
+    for (i = 0; i < cbNeeded / sizeof(HMODULE); i++) {
+        jl_array_grow_end((jl_array_t*)list, 1);
+        const char *path = jl_pathname_for_handle(hMods[i]);
+        // XXX: change to jl_arrayset if array storage allocation for Array{String,1} changes:
+        jl_value_t *v = jl_cstr_to_string(path);
+        jl_array_ptr_set(list, jl_array_dim0(list) - 1, v);
+    }
+    free(hMods);
+    return TRUE;
 }
 #endif
 


### PR DESCRIPTION
Attempts a fix of #33060

On wine:
```
dll = "Z:\\mnt\\build\\usr\\bin\\julia.exe"
dll = "C:\\windows\\system32\\ntdll.dll"
dll = "C:\\windows\\system32\\KERNEL32.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libjulia.dll"
dll = "C:\\windows\\system32\\advapi32.dll"
dll = "C:\\windows\\system32\\dbghelp.dll"
dll = "C:\\windows\\system32\\iphlpapi.dll"
dll = "C:\\windows\\system32\\msvcrt.dll"
dll = "C:\\windows\\system32\\psapi.dll"
dll = "C:\\windows\\system32\\secur32.dll"
dll = "C:\\windows\\system32\\netapi32.dll"
dll = "C:\\windows\\system32\\rpcrt4.dll"
dll = "C:\\windows\\system32\\ws2_32.dll"
dll = "C:\\windows\\system32\\user32.dll"
dll = "C:\\windows\\system32\\gdi32.dll"
dll = "C:\\windows\\system32\\version.dll"
dll = "C:\\windows\\system32\\userenv.dll"
dll = "C:\\windows\\system32\\winmm.dll"
dll = "C:\\windows\\system32\\ole32.dll"
dll = "C:\\windows\\system32\\msacm32.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libgcc_s_sjlj-1.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libwinpthread-1.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libssp-0.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libstdc++-6.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\LLVM.dll"
dll = "C:\\windows\\system32\\shell32.dll"
dll = "C:\\windows\\system32\\shlwapi.dll"
dll = "C:\\windows\\system32\\shcore.dll"
dll = "C:\\windows\\system32\\imm32.dll"
dll = "C:\\windows\\system32\\powrprof.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libpcre2-8.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libgmp.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libmpfr.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libgmp-10.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libgit2.dll"
dll = "C:\\windows\\system32\\crypt32.dll"
dll = "C:\\windows\\system32\\bcrypt.dll"
dll = "C:\\windows\\system32\\winhttp.dll"
dll = "C:\\windows\\system32\\jsproxy.dll"
dll = "C:\\windows\\system32\\oleaut32.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libssh2.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libdSFMT.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libopenblas.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libgfortran-5.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libquadmath-0.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libsuitesparse_wrapper.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libumfpack.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libcholmod.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libcamd.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libsuitesparseconfig.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libccolamd.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libcolamd.dll"
dll = "Z:\\mnt\\build\\usr\\bin\\libamd.dll"
```

Instead of

```
dll = "julia"
dll = "ntdll"
dll = "kernel32"
dll = "libjulia"
dll = "advapi32"
dll = "dbghelp"
dll = "iphlpapi"
dll = "msvcrt"
dll = "psapi"
dll = "secur32"
dll = "netapi32"
dll = "rpcrt4"
dll = "ws2_32"
dll = "user32"
dll = "gdi32"
dll = "version"
dll = "userenv"
dll = "winmm"
dll = "ole32"
dll = "msacm32"
dll = "libgcc_s_sjlj-1"
dll = "libwinpthread-1"
dll = "libssp-0"
dll = "libstdc++-6"
dll = "llvm"
dll = "shell32"
dll = "shlwapi"
dll = "shcore"
dll = "imm32"
dll = "powrprof"
dll = "libpcre2-8"
dll = "libgmp"
dll = "libmpfr"
dll = "libgmp-10"
dll = "libgit2"
dll = "crypt32"
dll = "bcrypt"
dll = "winhttp"
dll = "jsproxy"
dll = "oleaut32"
dll = "libssh2"
dll = "libdsfmt"
dll = "libopenblas"
dll = "libgfortran-5"
dll = "libquadmath-0"
dll = "libsuitesparse_wrapper"
dll = "libumfpack"
dll = "libcholmod"
dll = "libcamd"
dll = "libsuitesparseconfig"
dll = "libccolamd"
dll = "libcolamd"
dll = "libamd"
```