### PR TITLE
Allow changing arbitrary entries in symmetric/Hermitian matrices

### DIFF
--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2065,7 +2065,6 @@ end
 
         W[1,1] = 4
         @test W == T(sparse([4 -1; -1 1]))
-        @test_throws ArgumentError (W[1,2] = 2)
 
         @test Y + I == T(sparse([2 -1; -1 2]))
         @test Y - I == T(sparse([0 -1; -1 0]))


### PR DESCRIPTION
This PR enables the ability to change arbitrary entries in symmetric and Hermitian matrices, as it was previously discussed in https://github.com/JuliaLang/LinearAlgebra.jl/issues/110.

I have tried to do this in the most reasonable way:

- Setting an entry `v` at `(i, j)` (`i != j`) means that the corresponding entry at `(j, i)` gets set as well (to keep the matrix symmetric or Hermitian).
- If `A` is a symmetric (or Hermitian) block matrix and we set a diagonal element `v` at `(i, j)`, we set it to the symmetric (or Hermitian) version of `v` with the same `uplo` as the underlying matrix `A`. This has to be done to keep the matrix `A` symmetric (or Hermitian).
- It is still disallowed to set diagonal elements with non-real values (throws an `ArgumentError`) in the Hermitian case. Another approach would be to silently truncate the imaginary part of the value.

This PR also fixes JuliaLang/LinearAlgebra.jl#646.