### PR TITLE
RFC: Refactor LinearAlgebra to use `isa` instead of method dispatch to avoid ambiguity hell

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -251,10 +251,6 @@ function *(u::TransposeAbsVec, v::AbstractVector)
 end
 # vector * Adjoint/Transpose-vector
 *(u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, u, v)
-# Adjoint/Transpose-vector * Adjoint/Transpose-vector
-# (necessary for disambiguation with fallback methods in linalg/matmul)
-*(u::AdjointAbsVec, v::AdjointAbsVec) = throw(MethodError(*, (u, v)))
-*(u::TransposeAbsVec, v::TransposeAbsVec) = throw(MethodError(*, (u, v)))
 
 # AdjOrTransAbsVec{<:Any,<:AdjOrTransAbsVec} is a lazy conj vectors
 # We need to expand the combinations to avoid ambiguities

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -129,10 +129,6 @@ end
     return generic_matvecmul!(y, 'C', A, x, MulAddMul(alpha, beta))
 end
 
-# Vector-Matrix multiplication
-(*)(x::AdjointAbsVec,   A::AbstractMatrix) = (A'*x')'
-(*)(x::TransposeAbsVec, A::AbstractMatrix) = transpose(transpose(A)*transpose(x))
-
 # Matrix-matrix multiplication
 
 """
@@ -149,6 +145,11 @@ julia> [1 1; 0 1] * [1 0; 1 1]
 ```
 """
 function (*)(A::AbstractMatrix, B::AbstractMatrix)
+    if A isa AdjointAbsVec
+        return (A'*x')'
+    elseif A isa TransposeAbsVec
+        return transpose(transpose(A)*transpose(x))
+    end
     TS = promote_op(matprod, eltype(A), eltype(B))
     mul!(similar(B, TS, (size(A,1), size(B,2))), A, B)
 end

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -725,7 +725,6 @@ function *(A::StridedMatrix, adjB::Adjoint{<:Any,<:AbstractQ})
         throw(DimensionMismatch("matrix A has dimensions $(size(A)) but matrix B has dimensions $(size(B))"))
     end
 end
-*(u::AdjointAbsVec, A::Adjoint{<:Any,<:AbstractQ}) = adjoint(A.parent * u.parent)
 
 
 ### AcQ/AcQc

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2020,11 +2020,6 @@ function *(A::AbstractMatrix, transB::Transpose{<:Any,<:AbstractTriangular})
     copyto!(AA, A)
     rmul!(AA, transpose(convert(AbstractArray{TAB}, B)))
 end
-# ambiguity resolution with definitions in linalg/rowvector.jl
-*(v::AdjointAbsVec, A::AbstractTriangular) = adjoint(adjoint(A) * v.parent)
-*(v::TransposeAbsVec, A::AbstractTriangular) = transpose(transpose(A) * v.parent)
-*(v::AdjointAbsVec, A::Adjoint{<:Any,<:AbstractTriangular}) = adjoint(A.parent * v.parent)
-*(v::TransposeAbsVec, A::Transpose{<:Any,<:AbstractTriangular}) = transpose(A.parent * v.parent)
 
 
 # If these are not defined, they will fallback to the versions in matmul.jl


### PR DESCRIPTION
I think there are too many method definitions in LinearAlgebra just to resolve ambiguities.  One simple solution might be to use "type-level" if branches using `isa`.  That is to say, remove definitions like this

```diff
-(*)(x::AdjointAbsVec,   A::AbstractMatrix) = (A'*x')'
-(*)(x::TransposeAbsVec, A::AbstractMatrix) = transpose(transpose(A)*transpose(x))
```

and inline them into more generic definition:

```diff
 function (*)(A::AbstractMatrix, B::AbstractMatrix)
+    if A isa AdjointAbsVec
+        return (A'*x')'
+    elseif A isa TransposeAbsVec
+        return transpose(transpose(A)*transpose(x))
+    end
     TS = promote_op(matprod, eltype(A), eltype(B))
     mul!(similar(B, TS, (size(A,1), size(B,2))), A, B)
 end
```

An obvious benefit is that this lets us remove many (7 by above change; c7fadec33fd943d5c16afbbc7a18ca63c74b7d9f) method definitions that existed just for ambiguity resolutions.  Also, I think it would make it easier for us to understand when/how certain combination of matrices is computed in a certain way.

A disadvantage may be that it would make `@edit A * B` useless when the given combination is handled inside the `if` block.  But I think this effect is small now that we have debuggers.

Admittedly, this is not a super elegant solution.  If anyone has a more elegant plan to resolve it, I'll be happy to wait for it.  But I'm also guessing that `if` branches might not be so bad.  I think it'll likely be better than the very fragile state of the current method definitions.  What do you think?
