### PR TITLE
fix #33020, check axes for broadcasted assignment from tuples

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -826,6 +826,7 @@ end
 end
 
 ## general `copy` methods
+@inline copy(bc::Broadcasted{<:AbstractArrayStyle{0}}) = bc[CartesianIndex()]
 copy(bc::Broadcasted{<:Union{Nothing,Unknown}}) =
     throw(ArgumentError("broadcasting requires an assigned BroadcastStyle"))
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -260,8 +260,13 @@ of the `Broadcasted` object empty (populated with [`nothing`](@ref)).
     end
     return Broadcasted{Style}(bc.f, bc.args, axes)
 end
-instantiate(bc::Broadcasted{<:Union{AbstractArrayStyle{0}, Style{Tuple}}}) = bc
-
+instantiate(bc::Broadcasted{<:AbstractArrayStyle{0}}) = bc
+# Tuples don't need axes, but when they have axes (for .= assignment), we need to check them (#33020)
+instantiate(bc::Broadcasted{Style{Tuple}, Nothing}) = bc
+function instantiate(bc::Broadcasted{Style{Tuple}})
+    check_broadcast_axes(bc.axes, bc.args...)
+    return bc
+end
 ## Flattening
 
 """
@@ -821,7 +826,6 @@ end
 end
 
 ## general `copy` methods
-@inline copy(bc::Broadcasted{<:AbstractArrayStyle{0}}) = bc[CartesianIndex()]
 copy(bc::Broadcasted{<:Union{Nothing,Unknown}}) =
     throw(ArgumentError("broadcasting requires an assigned BroadcastStyle"))
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -663,6 +663,25 @@ end
     @test_throws DimensionMismatch (1, 2) .+ (1, 2, 3)
 end
 
+@testset "broadcasted assignment from tuples and tuple styles (#33020)" begin
+    a = zeros(3)
+    @test_throws DimensionMismatch a .= (1,2)
+    @test_throws DimensionMismatch a .= sqrt.((1,2))
+    a .= (1,)
+    @test all(==(1), a)
+    a .= sqrt.((2,))
+    @test all(==(√2), a)
+    a = zeros(3, 2)
+    @test_throws DimensionMismatch a .= (1,2)
+    @test_throws DimensionMismatch a .= sqrt.((1,2))
+    a .= (1,)
+    @test all(==(1), a)
+    a .= sqrt.((2,))
+    @test all(==(√2), a)
+    a .= (1,2,3)
+    @test a == [1 1; 2 2; 3 3]
+end
+
 @testset "scalar .=" begin
     A = [[1,2,3],4:5,6]
     A[1] .= 0


### PR DESCRIPTION
We avoid computing axes for tuples -- which is a valuable optimization -- but when we explicitly construct a tuple broadcast with axes pre-set (for, e.g., broadcasted assignment), we need to check that those axes are compatible with the ones inside the broadcasted expression before accepting them.

This should cleanly backport into all releases (I only checked against 1.0 and master, but if those two work, then I'd imagine 1.2 and 1.3 to work as well).