### PR TITLE
Revert "Identify used SSAValues from within :struct_type Exprs (#30936)"

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -394,26 +394,11 @@ iterate(it::UseRefIterator) = (it.use[1].op = 0; iterate(it, nothing))
     end
 end
 
-function scan_ssa_use_recursive!(push!, used, @nospecialize(a))
-    if isa(a, SSAValue)
-        push!(used, a.id)
-    elseif isa(a, Expr)
-        for aa in a.args
-            scan_ssa_use_recursive!(push!, used, aa)
-        end
-    end
-    return used
-end
-
 # This function is used from the show code, which may have a different
 # `push!`/`used` type since it's in Base.
 function scan_ssa_use!(push!, used, @nospecialize(stmt))
     if isa(stmt, SSAValue)
         push!(used, stmt.id)
-    elseif isexpr(stmt, :struct_type)
-        for a in stmt.args
-            scan_ssa_use_recursive!(push!, used, a)
-        end
     end
     for useref in userefs(stmt)
         val = useref[]

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -81,23 +81,6 @@ let
     # XXX: missing @test
 end
 
-let
-    ex = quote
-        function fouter(x)
-            finner(::Float16) = 2x
-            return finner(Float16(1))
-        end
-    end
-    thunk1 = Meta.lower(Main, ex)
-    thunk2 = thunk1.args[1].code[2]
-    code = thunk2.args[1]
-    used = BitSet()
-    for stmt in code.code
-        Compiler.scan_ssa_use!(push!, used, stmt)
-    end
-    @test !isempty(used)
-end
-
 for compile in ("min", "yes")
     cmd = `$(Base.julia_cmd()) --compile=$compile interpreter_exec.jl`
     if !success(pipeline(Cmd(cmd, dir=@__DIR__); stdout=stdout, stderr=stderr))


### PR DESCRIPTION
This reverts commit c1e27605483bc178c22796c1fed987766b63247f.

Reverting so we have a functioning CI again.

cc @timholy 