### PR TITLE
Duplicate include(::String) for nicer stacktraces

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -442,7 +442,7 @@ function include(fname::AbstractString)
     tls[:SOURCE_PATH] = path
     local result
     try
-        result = ccall(:jl_load_, Any, (Any, Any), mod, fname)
+        result = ccall(:jl_load_, Any, (Any, Any), mod, path)
     finally
         if prev === nothing
             Main.Base.delete!(tls, :SOURCE_PATH)

--- a/base/client.jl
+++ b/base/client.jl
@@ -429,7 +429,29 @@ end
 
 # MainInclude exists to hide Main.include and eval from `names(Main)`.
 baremodule MainInclude
-include(fname::AbstractString) = Main.Base.include(Main, fname)
+# We inline the definition of include from loading.jl/include_relative to get one-frame stacktraces.
+# include(fname::AbstractString) = Main.Base.include(Main, fname)
+function include(fname::AbstractString)
+    mod = Main
+    isa(fname, String) || (fname = String(fname))
+    path, prev = Main.Base._include_dependency(mod, fname)
+    for callback in Main.Base.include_callbacks # to preserve order, must come before Core.include
+        Main.Base.invokelatest(callback, mod, path)
+    end
+    tls = Main.Base.task_local_storage()
+    tls[:SOURCE_PATH] = path
+    local result
+    try
+        result = ccall(:jl_load_, Any, (Any, Any), mod, fname)
+    finally
+        if prev === nothing
+            Main.Base.delete!(tls, :SOURCE_PATH)
+        else
+            tls[:SOURCE_PATH] = prev
+        end
+    end
+    return result
+end
 eval(x) = Core.eval(Main, x)
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1092,6 +1092,8 @@ function source_dir()
     return p === nothing ? pwd() : dirname(p)
 end
 
+# These functions are duplicated in client.jl/include(::String) for
+# nicer stacktraces. Modifications here have to be backported there
 include_relative(mod::Module, path::AbstractString) = include_relative(mod, String(path))
 function include_relative(mod::Module, _path::String)
     path, prev = _include_dependency(mod, _path)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -561,15 +561,12 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
         "Bool(Base.JLOptions().use_sysimage_native_code)"`) == "false"
 end
 
-# backtrace contains type and line number info (esp. on windows #17179)
+# backtrace contains line number info (esp. on windows #17179)
 for precomp in ("yes", "no")
-    succ, out, bt = readchomperrors(`$(Base.julia_cmd()) --startup-file=no --sysimage-native-code=$precomp -E 'include("____nonexistent_file")'`)
+    succ, out, bt = readchomperrors(`$(Base.julia_cmd()) --startup-file=no --sysimage-native-code=$precomp -E 'sqrt(-2)'`)
     @test !succ
     @test out == ""
-    @test occursin("include_relative(::Module, ::String) at $(joinpath(".", "loading.jl"))", bt)
-    lno = match(r"at \.[\/\\]loading\.jl:(\d+)", bt)
-    @test length(lno.captures) == 1
-    @test parse(Int, lno.captures[1]) > 0
+    @test occursin(r"\.jl:(\d+)", bt)
 end
 
 # PR #23002


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/33065#issuecomment-525069663

Before:
```
ERROR: LoadError: UndefVarError: STOP not defined
Stacktrace:
 [1] top-level scope at /home/antoine/scratch.jl:1
 [2] include at ./boot.jl:328 [inlined]
 [3] include_relative(::Module, ::String) at ./loading.jl:1105
 [4] include(::Module, ::String) at ./Base.jl:31
 [5] include(::String) at ./client.jl:432
 [6] top-level scope at REPL[2]:1
in expression starting at /home/antoine/scratch.jl:1
```
After:
```
julia> include("scratch.jl")
ERROR: LoadError: UndefVarError: STOP not defined
Stacktrace:
 [1] top-level scope at /home/antoine/scratch.jl:1
 [2] include(::String) at /home/antoine/julia-fork/base/client.jl:443
 [3] top-level scope at REPL[4]:1
in expression starting at /home/antoine/scratch.jl:1
```