### PR TITLE
Allow download to take a local directory to download into

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@ New library functions
 
 Standard library changes
 ------------------------
-
+ * `download` now accepts a path to a directory to download into as its second argument ([#33088]).
 
 #### Libdl
 

--- a/base/download.jl
+++ b/base/download.jl
@@ -55,7 +55,8 @@ function download_url(url::String)
     return url
 end
 
-function download(url::AbstractString, filename::AbstractString)
+function download(url::AbstractString, localpath::AbstractString)
+    filename = isdir(localpath) ? tempname(localpath) : localpath
     url = download_url(url)
     curl_exe = find_curl()
     if curl_exe !== nothing
@@ -83,10 +84,12 @@ function download(url::AbstractString)
 end
 
 """
-    download(url::AbstractString, [localfile::AbstractString])
+    download(url::AbstractString, [localpath::AbstractString])
 
-Download a file from the given url, optionally renaming it to the given local file name. If
-no filename is given this will download into a randomly-named file in your temp directory.
+Download a file from the given url, to a local path. If no local path is given, then this
+will download into a randomly-named file in your temp directory. If a path to a directory
+is given, then this will download to a randomly-named file in that directory.
+Otherwise, `localpath` is the file path to download to.
 Note that this function relies on the availability of external tools such as `curl`, `wget`
 or `fetch` to download the file and is provided for convenience. For production use or
 situations in which more options are needed, please use a package that provides the desired
@@ -94,4 +97,4 @@ functionality instead.
 
 Returns the filename of the downloaded file.
 """
-download(url, filename)
+download(url, localpath)

--- a/base/file.jl
+++ b/base/file.jl
@@ -500,8 +500,7 @@ function mktemp(parent::AbstractString=tempdir(); cleanup::Bool=true)
     return (filename, Base.open(filename, "r+"))
 end
 
-function tempname()
-    parent = tempdir()
+function tempname(parent = tempdir())
     seed::UInt32 = rand(UInt32)
     while true
         if (seed & typemax(UInt16)) == 0
@@ -517,9 +516,9 @@ end
 
 else # !windows
 # Obtain a temporary filename.
-function tempname()
-    d = tempdir() # tempnam ignores TMPDIR on darwin
-    p = ccall(:tempnam, Cstring, (Cstring, Cstring), d, temp_prefix)
+function tempname(parent=tempdir())
+    # tempname ignores TMPDIR on darwin
+    p = ccall(:tempnam, Cstring, (Cstring, Cstring), parent, temp_prefix)
     systemerror(:tempnam, p == C_NULL)
     s = unsafe_string(p)
     Libc.free(p)

--- a/test/download.jl
+++ b/test/download.jl
@@ -22,6 +22,13 @@ mktempdir() do temp_dir
     @test !isempty(read(file))
     ip = read(file, String)
 
+    # Download a file to a directory
+    subdir = mkdir(joinpath(temp_dir, "sub"))
+    subdirfile = download("http://httpbin.org/ip", subdir)
+    @test dirname(subdirfile) == subdir
+    @test isfile(subdirfile)
+    @test ip == read(subdirfile, String)
+
     # Test download rewrite hook
     push!(Base.DOWNLOAD_HOOKS, url->replace(url, r"/status/404$" => "/ip"))
     @test download("http://httpbin.org/status/404", file) == file


### PR DESCRIPTION
With this PR if the user does `download(url, localdir)` where `localdir` is a path to a directory that currently exiists, 
then `download` will create a file with a `tempname` within that directory and download into it.

This has a few minor uses. Like easier debugging if you can specify all your downloads go somewhere specific so you can manually inspect them; and the ability to clean them all up after by deleting that known directory.

In the future we might be able to provide the full functionality `HTTP.download` has
where the filename is worked out based on the HTTP rules, and then placed into the directory, with that name.
https://github.com/JuliaWeb/HTTP.jl/blob/668e7e68747bb333ebde13af8d16add5b82b3b8a/src/download.jl#L78-L85
(There are some flags for this in curl and wget, [fetch had an argument about adding this 12 years ago, idk if they did add it or not](https://lists.freebsd.org/pipermail/freebsd-current/2005-December/059398.html), but anyway that is a future PR)

This is non-breaking, as without this PR providing a local-path to a directory would cause an error to be thrown.
