### PR TITLE
tempname: add `parent` and `cleanup` arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@ New library functions
 
 * The `splitpath` function now accepts any `AbstractString` whereas previously it only accepted paths of type `String` ([#33012]).
 * The `tempname` function now takes an optional `parent::AbstractString` argument to give it a directory in which to attempt to produce a temporary path name ([#33090]).
-* The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `false`; when set to `true` the process will try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
+* The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `true`, which causes the process to try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
 
 
 Standard library changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ New library functions
 ---------------------
 
 * The `splitpath` function now accepts any `AbstractString` whereas previously it only accepted paths of type `String` ([#33012]).
+* The `tempname` function now takes an optional `parent::AbstractString` argument to give it a directory in which to attempt to produce a temporary path name ([#33090]).
 
 
 Standard library changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ New library functions
 
 * The `splitpath` function now accepts any `AbstractString` whereas previously it only accepted paths of type `String` ([#33012]).
 * The `tempname` function now takes an optional `parent::AbstractString` argument to give it a directory in which to attempt to produce a temporary path name ([#33090]).
+* The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `false`; when set to `true` the process will try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
 
 
 Standard library changes

--- a/base/file.jl
+++ b/base/file.jl
@@ -500,7 +500,7 @@ function mktemp(parent::AbstractString=tempdir(); cleanup::Bool=true)
     return (filename, Base.open(filename, "r+"))
 end
 
-function tempname(parent::AbstractString=tempdir(); cleanup::Bool=false)
+function tempname(parent::AbstractString=tempdir(); cleanup::Bool=true)
     isdir(parent) || throw(ArgumentError("$(repr(parent)) is not a directory"))
     seed::UInt32 = rand(UInt32)
     while true
@@ -519,7 +519,7 @@ end
 else # !windows
 
 # Obtain a temporary filename.
-function tempname(parent::AbstractString=tempdir(); cleanup::Bool=false)
+function tempname(parent::AbstractString=tempdir(); cleanup::Bool=true)
     isdir(parent) || throw(ArgumentError("$(repr(parent)) is not a directory"))
     p = ccall(:tempnam, Cstring, (Cstring, Cstring), parent, temp_prefix)
     systemerror(:tempnam, p == C_NULL)
@@ -543,7 +543,7 @@ end # os-test
 
 
 """
-    tempname(parent=tempdir(); cleanup=false) -> String
+    tempname(parent=tempdir(); cleanup=true) -> String
 
 Generate a temporary file path. This function only returns a path; no file is
 created. The path is likely to be unique, but this cannot be guaranteed due to

--- a/test/file.jl
+++ b/test/file.jl
@@ -79,6 +79,14 @@ child_eval(code::String) = eval(Meta.parse(readchomp(`$(Base.julia_cmd()) -E $co
     # mktempdir with cleanup
     t = child_eval("t = mktempdir(); touch(joinpath(t, \"file.txt\")); t")
     @test !ispath(t)
+    # tempname without cleanup
+    t = child_eval("t = tempname(); touch(t); t")
+    @test isfile(t)
+    rm(t, force=true)
+    @test !ispath(t)
+    # tempname with cleanup
+    t = child_eval("t = tempname(cleanup=true); touch(t); t")
+    @test !ispath(t)
 end
 
 import Base.Filesystem: TEMP_CLEANUP_MIN, TEMP_CLEANUP_MAX, TEMP_CLEANUP

--- a/test/file.jl
+++ b/test/file.jl
@@ -48,6 +48,18 @@ if !Sys.iswindows()
     cd(pwd_)
 end
 
+using Random
+
+@testset "tempname with parent" begin
+    t = tempname()
+    @test dirname(t) == tempdir()
+    mktempdir() do d
+        t = tempname(d)
+        @test dirname(t) == d
+    end
+    @test_throws ArgumentError tempname(randstring())
+end
+
 child_eval(code::String) = eval(Meta.parse(readchomp(`$(Base.julia_cmd()) -E $code`)))
 
 @testset "mktemp/dir basic cleanup" begin

--- a/test/file.jl
+++ b/test/file.jl
@@ -80,12 +80,12 @@ child_eval(code::String) = eval(Meta.parse(readchomp(`$(Base.julia_cmd()) -E $co
     t = child_eval("t = mktempdir(); touch(joinpath(t, \"file.txt\")); t")
     @test !ispath(t)
     # tempname without cleanup
-    t = child_eval("t = tempname(); touch(t); t")
+    t = child_eval("t = tempname(cleanup=false); touch(t); t")
     @test isfile(t)
     rm(t, force=true)
     @test !ispath(t)
     # tempname with cleanup
-    t = child_eval("t = tempname(cleanup=true); touch(t); t")
+    t = child_eval("t = tempname(); touch(t); t")
     @test !ispath(t)
 end
 


### PR DESCRIPTION
I think that adding `parent` and `cleanup` to `tempname` to match all the other temp file functions only makes sense. Whether the default for `cleanup` should be `true` or `false` is more debatable. I think it should be `true` to match all the other temp path functions.