### PR TITLE
hof mktemp/dir: don't error if temp path is already gone

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ New library functions
 Standard library changes
 ------------------------
 
+* The methods of `mktemp` and `mktempdir` which take a function body to pass temporary paths to no longer throw errors if the path is already deleted when the function body returns ([#33091]).
 
 #### Libdl
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -612,7 +612,7 @@ function mktemp(fn::Function, parent::AbstractString=tempdir())
     finally
         try
             close(tmp_io)
-            rm(tmp_path)
+            ispath(tmp_path) && rm(tmp_path)
         catch ex
             @error "mktemp cleanup" _group=:file exception=(ex, catch_backtrace())
             # might be possible to remove later
@@ -634,7 +634,7 @@ function mktempdir(fn::Function, parent::AbstractString=tempdir();
         fn(tmpdir)
     finally
         try
-            rm(tmpdir, recursive=true)
+            ispath(tmpdir) && rm(tmpdir, recursive=true)
         catch ex
             @error "mktempdir cleanup" _group=:file exception=(ex, catch_backtrace())
             # might be possible to remove later


### PR DESCRIPTION
@staticfloat, I know you mentioned that you'd prefer if this worked without an error.