### PR TITLE
add `GC.safepoint()` for compute-bound threads

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -94,4 +94,19 @@ macro preserve(args...)
     end)
 end
 
+"""
+    GC.safepoint()
+
+Inserts a point in the program where garbage collection may run.
+This can be useful in rare cases in multi-threaded programs where some threads
+are allocating memory (and hence may need to run GC) but other threads are doing
+only simple operations (no allocation, task switches, or I/O).
+Calling this function periodically in non-allocating threads allows garbage
+collection to run.
+
+!!! compat "Julia 1.4"
+    This function is available as of Julia 1.4.
+"""
+safepoint() = ccall(:jl_gc_safepoint, Cvoid, ())
+
 end # module GC

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -395,6 +395,7 @@ Base.functionloc(::Method)
 Base.GC.gc
 Base.GC.enable
 Base.GC.@preserve
+Base.GC.safepoint
 Meta.lower
 Meta.@lower
 Meta.parse(::AbstractString, ::Int)


### PR DESCRIPTION
This will now sometimes be needed to avoid long-running, non-allocating computations from blocking other threads from running GC. Of course it would be better to have codegen insert gc state transitions, but that is quite fancy and not necessarily free, so we might as well let people work around it manually for now.