### PR TITLE
add function to get total live bytes

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -60,6 +60,19 @@ end
 # total time spend in garbage collection, in nanoseconds
 gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())
 
+"""
+    Base.gc_live_bytes()
+
+Return the total size (in bytes) of objects currently in memory.
+This is computed as the total size of live objects after
+the last garbage collection, plus the number of bytes allocated
+since then.
+"""
+function gc_live_bytes()
+    num = gc_num()
+    Int(ccall(:jl_gc_live_bytes, Int64, ())) + num.allocd + num.deferred_alloc
+end
+
 # print elapsed time, return expression value
 const _mem_units = ["byte", "KiB", "MiB", "GiB", "TiB", "PiB"]
 const _cnt_units = ["", " k", " M", " G", " T", " P"]

--- a/src/gc.c
+++ b/src/gc.c
@@ -2656,6 +2656,11 @@ void jl_gc_sync_total_bytes(void)
     jl_gc_get_total_bytes(&last_gc_total_bytes);
 }
 
+JL_DLLEXPORT int64_t jl_gc_live_bytes(void)
+{
+    return live_bytes;
+}
+
 static void jl_gc_premark(jl_ptls_t ptls2)
 {
     arraylist_t *remset = ptls2->heap.remset;


### PR DESCRIPTION
The GC has this counter but AFAICT we don't expose it in any way. This can be pretty useful, since it's one of the most accurate ways to see how much memory your program is actually using.

Of course, the only way to determine *actually live* bytes is to do a full GC right before looking at the counter. That gives the most accurate result, but is slow and also leaves out memory used due to GC not running yet, which could be important in practice. So we need to decide whether to run GC (implemented here), or instead return live_bytes from the *last* GC plus the number of (possibly garbage) bytes allocated since then.