### PR TITLE
WIP: allow changing context module in REPL

### DIFF
--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -64,7 +64,7 @@ available, but here we'll use the text-based display that comes with the standar
 julia> Profile.print()
 80 ./event.jl:73; (::Base.REPL.##1#2{Base.REPL.REPLBackend})()
  80 ./REPL.jl:97; macro expansion
-  80 ./REPL.jl:66; eval_user_input(::Any, ::Base.REPL.REPLBackend)
+  80 ./REPL.jl:66; eval_user_input(::Any, ::Module, ::Base.REPL.REPLBackend)
    80 ./boot.jl:235; eval(::Module, ::Any)
     80 ./<missing>:?; anonymous
      80 ./profile.jl:23; macro expansion

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -11,8 +11,7 @@ The primary function used to obtain a stack trace is [`stacktrace`](@ref):
 6-element Array{Base.StackTraces.StackFrame,1}:
  top-level scope
  eval at boot.jl:317 [inlined]
- eval(::Module, ::Expr) at REPL.jl:5
- eval_user_input(::Any, ::REPL.REPLBackend) at REPL.jl:85
+ eval_user_input(::Any, ::Module, ::REPL.REPLBackend) at REPL.jl:91
  macro expansion at REPL.jl:116 [inlined]
  (::getfield(REPL, Symbol("##28#29")){REPL.REPLBackend})() at event.jl:92
 ```
@@ -29,7 +28,7 @@ julia> example()
 7-element Array{Base.StackTraces.StackFrame,1}:
  example() at REPL[1]:1
  top-level scope
- eval at boot.jl:317 [inlined]
+ eval at boot.jl:330 [inlined]
 [...]
 
 julia> @noinline child() = stacktrace()
@@ -61,11 +60,10 @@ julia> example()
 7-element Array{Base.StackTraces.StackFrame,1}:
  example() at REPL[1]:1
  top-level scope
- eval at boot.jl:317 [inlined]
- eval(::Module, ::Expr) at REPL.jl:5
- eval_user_input(::Any, ::REPL.REPLBackend) at REPL.jl:85
- macro expansion at REPL.jl:116 [inlined]
- (::getfield(REPL, Symbol("##28#29")){REPL.REPLBackend})() at event.jl:92
+ eval at boot.jl:330 [inlined]
+ eval_user_input(::Any, ::Module, ::REPL.REPLBackend) at REPL.jl:91
+ macro expansion at REPL.jl:123 [inlined]
+ (::REPL.var"##26#27"{REPL.REPLBackend})() at task.jl:333
 ```
 
 ## Extracting useful information
@@ -217,7 +215,7 @@ Stacktrace:
  [1] error(::String) at error.jl:33
  [2] top-level scope at REPL[7]:2
  [3] eval(::Module, ::Any) at boot.jl:319
- [4] eval_user_input(::Any, ::REPL.REPLBackend) at REPL.jl:85
+ [4] eval_user_input(::Any, ::Module, ::REPL.REPLBackend) at REPL.jl:91
  [5] macro expansion at REPL.jl:117 [inlined]
  [6] (::getfield(REPL, Symbol("##26#27")){REPL.REPLBackend})() at task.jl:259
 (B) An exception while handling the exception
@@ -225,7 +223,7 @@ Stacktrace:
  [1] error(::String) at error.jl:33
  [2] top-level scope at REPL[7]:5
  [3] eval(::Module, ::Any) at boot.jl:319
- [4] eval_user_input(::Any, ::REPL.REPLBackend) at REPL.jl:85
+ [4] eval_user_input(::Any, ::Module, ::REPL.REPLBackend) at REPL.jl:91
  [5] macro expansion at REPL.jl:117 [inlined]
  [6] (::getfield(REPL, Symbol("##26#27")){REPL.REPLBackend})() at task.jl:259
 ```

--- a/stdlib/REPL/Project.toml
+++ b/stdlib/REPL/Project.toml
@@ -7,8 +7,8 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Random"]

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -229,7 +229,7 @@ repl_search(s) = repl_search(stdout, s)
 
 function repl_corrections(io::IO, s)
     print(io, "Couldn't find ")
-    pre = context_module == Main ? [] : [context_module, '.']
+    pre = context_module[] == Main ? [] : [context_module[], '.']
     printstyled(io, pre..., s, '\n', color=:cyan)
     print_correction(io, s)
 end
@@ -280,7 +280,7 @@ function repl(io::IO, s::Symbol)
     quote
         repl_latex($io, $str)
         repl_search($io, $str)
-        $(if !isdefined(context_module, s) && !haskey(keywords, s)
+        $(if !isdefined(context_module[], s) && !haskey(keywords, s)
                :(repl_corrections($io, $str))
           end)
         $(_repl(s))
@@ -348,7 +348,7 @@ function _repl(x)
     end
     # docs = lookup_doc(x) # TODO
     expr = :(@doc $x)
-    docs = esc(:(Core.eval($context_module, $expr)))
+    docs = esc(:(Core.eval($context_module[], $expr)))
     if isfield(x)
         quote
             if isa($(esc(x.args[1])), DataType)
@@ -509,7 +509,7 @@ end
 print_joined_cols(args...; cols = displaysize(stdout)[2]) = print_joined_cols(stdout, args...; cols=cols)
 
 function print_correction(io, word)
-    cors = levsort(word, accessible(context_module))
+    cors = levsort(word, accessible(context_module[]))
     pre = "Perhaps you meant "
     print(io, pre)
     print_joined_cols(io, cors, ", ", " or "; cols = displaysize(io)[2] - length(pre))
@@ -537,7 +537,7 @@ accessible(mod::Module) =
      map(names, moduleusings(mod))...;
      builtins] |> unique |> filtervalid
 
-doc_completions(name) = fuzzysort(name, accessible(context_module))
+doc_completions(name) = fuzzysort(name, accessible(context_module[]))
 doc_completions(name::Symbol) = doc_completions(string(name))
 
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1042,12 +1042,12 @@ fake_repl() do stdin_write, stdout_read, repl
     sendrepl(code) = write(stdin_write, "$code\n notify($(curmod_prefix)c)\n")
     existhelp(val) = begin
         regex = Regex("is of type `$(Int)`")
-        str = sprint(show, REPL.context_module.eval(REPL._helpmode(IOBuffer(), val))::Union{Markdown.MD, Nothing})
+        str = sprint(show, REPL.context_module[].eval(REPL._helpmode(IOBuffer(), val))::Union{Markdown.MD, Nothing})
         occursin(regex, str)
     end
 
     # default context module
-    @test REPL.context_module == Main
+    @test REPL.context_module[] == Main
     sendrepl("inmodulemain = 1")
     wait(c)
     @test isdefined(Main, :inmodulemain)
@@ -1058,7 +1058,7 @@ fake_repl() do stdin_write, stdout_read, repl
 
     # change context module
     REPL.set_context_module(REPL)
-    @test REPL.context_module == REPL
+    @test REPL.context_module[] == REPL
     sendrepl("inmodulerepl = 1")
     wait(c)
     # evaluation


### PR DESCRIPTION
### UPDATED

[After a discussion](https://github.com/JuliaLang/julia/pull/33102#issuecomment-525724114), I decided to add a functionality to change the REPL context module for execution, completion, and docs, in this PR

#### How works

The context module can be set via calling `REPL.set_context_module(mod)`, and then execution/completion/show docs/display are all done in the context of `mod`

#### TODO

- [x] add tests
    * change module in the context of execution
    * change module in the context of completion
    * change module in the context of help
- update docs ?: the method signature of `eval_user_input` has been changed and it appears in some docs like stack trace, and profiling. 

***

[The original description]

### Purpose

Allow REPL [tab] completions in a module context other than `Main`.

### Description

Currently REPL's [tab] completions work only in the context of the `Main` module, but there are cases when we want to get completions in a context of the other specific module:
E.g.: Juno can change REPL's module so that an entered code gets evaluated in a context of that module, and in this case we may want to get completions in the context of the module as well.

With this PR, each REPL provider could call `REPL.set_context_module(mod)` hooking on its module change, and then can get the corresponding completions.

If this idea is acceptable, I would really like to add tests for that, of course.

/cc @pfitzseb 