### PR TITLE
Workaround for performance penalty of splatting a number

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -60,7 +60,9 @@ julia> C
 ```
 """
 @inline @propagate_inbounds function _modify!(p::MulAddMul{ais1, bis0},
-                                              x, C, idx) where {ais1, bis0}
+                                              x, C, idx′) where {ais1, bis0}
+    # Workaround for performance penalty of splatting a number (#29114):
+    idx = idx′ isa Integer ? (idx′,) : idx′
     if bis0
         C[idx...] = p(x)
     else


### PR DESCRIPTION
This PR adds a workaround for the performance penalty of splatting a number (#29114) which is problematic in `mul!` performance.

I don't know the time-frame of the solution of JuliaLang/julia#29114 but it may make sense to have this workaround until we have a builtin solution for JuliaLang/julia#29114?

close JuliaLang/LinearAlgebra.jl#661; cc @dkarrasch @KristofferC

### Quick benchmarks

Before (9a8b2fd72b675bb8a5bf0322943ee9451787b86a):

```julia
julia> x = rand(10); y = similar(x); λ = rand();

julia> @btime mul!($y, $λ, $x);
  938.111 ns (30 allocations: 640 bytes)

julia> @btime $y .= $λ .* $x;  # as a reference
  7.870 ns (0 allocations: 0 bytes)
```

After (aeaa4644c472f8781f922118aae10b86772070c0):

```julia
julia> @btime mul!($y, $λ, $x);
  9.506 ns (0 allocations: 0 bytes)
```

The difference to the broadcasting may be the `@simd` macro.
