### PR TITLE
Mention `BenchmarkTools.@btime` in the docstring for `@time`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -137,9 +137,9 @@ See also [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref), and
 [`@allocated`](@ref).
 
 !!! note
-    For more serious benchmarking, consider the `@btime` macro from the
-    [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl) package which
-    among other things evaluates the function multiple times in order to reduce noise.
+    For more serious benchmarking, consider the `@btime` macro from the BenchmarkTools.jl
+    package which among other things evaluates the function multiple times in order to
+    reduce noise.
 
 ```julia-repl
 julia> @time rand(10^6);

--- a/base/util.jl
+++ b/base/util.jl
@@ -136,6 +136,11 @@ returning the value of the expression.
 See also [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref), and
 [`@allocated`](@ref).
 
+!!! note
+    For more serious benchmarking, consider the `@btime` macro from the
+    [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl) package which
+    among other things evaluates the function multiple times in order to reduce noise.
+
 ```julia-repl
 julia> @time rand(10^6);
   0.001525 seconds (7 allocations: 7.630 MiB)


### PR DESCRIPTION
The [Performance Tips](https://github.com/JuliaLang/julia/blob/master/doc/src/manual/performance-tips.md) page of the manual includes a note that reads:

> For more serious benchmarking, consider the BenchmarkTools.jl package which among other things evaluates the function multiple times in order to reduce noise.

However, the docstring for the `Base.@time` macro does not contain any such information. Therefore, if a user only reads the docstring for `@time` and does not read the manual, they may end up relying on `@time` in situations where `BenchmarkTools.@btime` may be more appropriate.

This pull request adds a note about BenchmarkTools and the `@btime` macro to the docstring for `@time`.