### PR TITLE
Adds interpolation syntax to `Threads.@spawn`, to evaluate arguments immediately

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@ Language changes
 Multi-threading changes
 -----------------------
 
+* Values can now be interpolated into `@async` and `@spawn` via `$`, which copies the value directly into the constructed
+underlying closure. ([#33119])
 
 Build system changes
 --------------------

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -330,6 +330,8 @@ function is_short_function_def(ex)
     return false
 end
 
+
+
 function findmeta(ex::Expr)
     if ex.head === :function || is_short_function_def(ex)
         body::Expr = ex.args[2]

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -330,8 +330,6 @@ function is_short_function_def(ex)
     return false
 end
 
-
-
 function findmeta(ex::Expr)
     if ex.head === :function || is_short_function_def(ex)
         body::Expr = ex.args[2]

--- a/base/task.jl
+++ b/base/task.jl
@@ -344,6 +344,13 @@ end
     @async
 
 Wrap an expression in a [`Task`](@ref) and add it to the local machine's scheduler queue.
+
+Values can be interpolated into `@async` via `\$`, which copies the value directly into the
+constructed underlying closure. This allows you to insert the _value_ of a variable,
+isolating the aysnchronous code from changes to the variable's value in the current task.
+
+!!! compat "Julia 1.4"
+    Interpolating values via `\$` is available as of Julia 1.4.
 """
 macro async(expr)
     letargs = Base._lift_one_interp!(expr)
@@ -378,7 +385,6 @@ function _lift_one_interp_helper(expr::Expr, in_quote_context, letargs)
             newarg = gensym()
             push!(letargs, :($(esc(newarg)) = $(esc(expr.args[1]))))
             return newarg  # Don't recurse into the lifted $() exprs
->>>>>>> fb29992... Factor out `$`-lifting; share b/w `@async` & `@spawn`
         end
     elseif expr.head == :quote
         in_quote_context = true   # Don't try to lift $ directly out of quotes

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -107,13 +107,18 @@ Create and run a [`Task`](@ref) on any available thread. To wait for the task to
 finish, call [`wait`](@ref) on the result of this macro, or call [`fetch`](@ref)
 to wait and then obtain its return value.
 
-(Values can be interpolated into `@spawn` via `\$` to evaluate them in the current task.)
+Values can be interpolated into `@spawn` via `\$`, which copies the value directly into the
+constructed underlying closure. This allows you to insert the _value_ of a variable,
+isolating the aysnchronous code from changes to the variable's value in the current task.
 
 !!! note
     This feature is currently considered experimental.
 
 !!! compat "Julia 1.3"
     This macro is available as of Julia 1.3.
+
+!!! compat "Julia 1.4"
+    Interpolating values via `\$` is available as of Julia 1.4.
 """
 macro spawn(expr)
     letargs = Base._lift_one_interp!(expr)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -107,6 +107,8 @@ Create and run a [`Task`](@ref) on any available thread. To wait for the task to
 finish, call [`wait`](@ref) on the result of this macro, or call [`fetch`](@ref)
 to wait and then obtain its return value.
 
+(Values can be interpolated into `@spawn` via `$` to evaluate them in the current task.)
+
 !!! note
     This feature is currently considered experimental.
 
@@ -114,53 +116,38 @@ to wait and then obtain its return value.
     This macro is available as of Julia 1.3.
 """
 macro spawn(expr)
-    thunk = esc(:(()->($expr)))
+    # Capture interpolated variables in $() and move them to let-block
+    letargs = Any[]  # store the new gensymed arguments
+    lift_one_interp!(v) = v
+    function lift_one_interp!(expr::Expr)
+        if expr.head == :quote  # Don't try to lift $ out of quotes
+            return expr
+        end
+        if expr.head == :$
+            newarg = gensym()
+            push!(letargs, :($(esc(newarg)) = $(esc(expr.args[1]))))
+            return newarg  # Don't recurse into the $() exprs
+        end
+        for (i,e) in enumerate(expr.args)
+            expr.args[i] = lift_one_interp(e)
+        end
+        expr
+    end
+    lifted_expr = lift_one_interp!(expr)
+
+    thunk = esc(:(()->($lifted_expr)))
     var = esc(Base.sync_varname)
     quote
-        local task = Task($thunk)
-        task.sticky = false
-        if $(Expr(:islocal, var))
-            push!($var, task)
+        let $(letargs...)
+            local task = Task($thunk)
+            task.sticky = false
+            if $(Expr(:islocal, var))
+                push!($var, task)
+            end
+            schedule(task)
+            task
         end
-        schedule(task)
-        task
     end
 end
 
-"""
-    @spawncall f(args...)
-
-Like [`Threads.@spawn`](@ref), creates a [`Task`](@ref) that will run the given function
-call on any available thread. The arguments to the provided function, `args`, will be
-evaluated immediately in the current task, like a normal function call.
-
-This is different from [`@spawn`](@ref), where `@spawn` runs an arbitrary provided
-expression, wrapped in an empty closure, so that the entire expression is evaluated in the
-new task. Instead, the argument to `@spawncall` must be a function call, and that function,
-`f` is invoked with the values of the arguments evaluated in the current task. (This
-prevents variables from being "boxed" to capture them in the closure.)
-
-# Examples:
-- `@spawncall println(i)`
-- `@spawncall peakflops()`
-
-!!! note
-    This feature is currently considered experimental.
-
-!!! compat "Julia 1.3"
-    This macro is available as of Julia 1.3.
-"""
-macro spawncall(expr)
-    @assert expr.head == :call "The argument to @spawncall must be a function call, e.g. " *
-                               "`@spawncall f(x)``. Provided expr `$expr` is not a function call."
-    escf = esc(expr.args[1])
-    args = expr.args[2:end]
-
-    newargs = [gensym(string(a)) for a in args]
-    letargs = [:($a=$(esc(b))) for (a,b) in zip(newargs,args)]
-    quote
-        let $(letargs...)
-            @spawn $escf($(newargs...))
-        end
-    end
 end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -703,3 +703,27 @@ catch ex
     @test ex isa LoadError
     @test ex.error isa ArgumentError
 end
+
+@testset "@spawncall" begin
+    # Issue #30896: evaluating argumentss immediately
+    begin
+        outs = zeros(5)
+        @sync begin
+            local i = 1
+            while i <= 5
+                Threads.@spawncall setindex!(outs, i, i)
+                i += 1
+            end
+        end
+        @test outs == 1:5
+    end
+
+    # Args
+    @test fetch(Threads.@spawncall 2+2) == 4
+    @test fetch(Threads.@spawncall Int(2.0)) == 2
+    a = 2
+    @test fetch(Threads.@spawncall *(a,a)) == a^2
+    # kwargs
+    @test fetch(Threads.@spawncall sort([3 2; 1 0], dims=2)) == [2 3; 0 1]
+    @test fetch(Threads.@spawncall sort([3 2; 1 0]; dims=2)) == [2 3; 0 1]
+end


### PR DESCRIPTION
Adds $-interpolation syntax to `@async` and `Threads.@spawn`, to evaluate arguments immediately.

Add the ability to evaluate some parts of a `@spawn`/`@async`
immediately, in the current thread context.

This prevents variables being "boxed" in order to capture them in the
closure, exactly the same as wrapping them in a let-block locally.

For example, `$x` expands like this:
```julia
julia> @macroexpand @async $x + 2
quote
    #= task.jl:361 =#
    let var"##454" = x
        #= task.jl:362 =#
        local var"#9#task" = Base.Task((()->begin
                            #= task.jl:358 =#
                            var"##454" + 2
                        end))
        #= task.jl:363 =#
        if $(Expr(:islocal, Symbol("##sync#95")))
            #= task.jl:364 =#
            Base.push!(var"##sync#95", var"#9#task")
        end
        #= task.jl:366 =#
        Base.schedule(var"#9#task")
        #= task.jl:367 =#
        var"#9#task"
    end
end
```


------------------------------------





Fixes #30896

Add the ability to evaluate some parts of a `@spawn` immediately, in the current thread context.

~Adds a new macro, `Threads.@spawncall`, which evaluates its arguments immediately, then `@spawn`s the closure with the argument values.~

~This acts more like a "parallel function call", where the arguments are evaluated immediately, in the current thread, and the function is then invoked in any available thread with the stored argument values.~

EDIT: Updated to add `$`-interpolation syntax support to `@spawn` to allow you to manually specify which parts of the expression to evaluate early.


This prevents variables being "boxed" when capturing them in the closure.

~This mirrors the behavior of golangs `go` command, which requires it be used with a function call.~

Fixes #30896