### PR TITLE
WIP: intfuncs: use literal power in power-by-squaring

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -183,14 +183,14 @@ to_power_type(x) = convert(Base._return_type(*, Tuple{typeof(x), typeof(x)}), x)
           "\nMake x a float matrix by adding a zero decimal ",
           "(e.g., [2.0 1.0;1.0 0.0]^$p instead ",
           "of [2 1;1 0]^$p), or write float(x)^$p or Rational.(x)^$p")))
-function power_by_squaring(x_, p::Integer)
+function power_by_squaring(x_, p::Integer; square=x->x*x)
     x = to_power_type(x_)
     if p == 1
         return copy(x)
     elseif p == 0
         return one(x)
     elseif p == 2
-        return x*x
+        return square(x)
     elseif p < 0
         isone(x) && return copy(x)
         isone(-x) && return iseven(p) ? one(x) : copy(x)
@@ -199,14 +199,14 @@ function power_by_squaring(x_, p::Integer)
     t = trailing_zeros(p) + 1
     p >>= t
     while (t -= 1) > 0
-        x *= x
+        x = square(x)
     end
     y = x
     while p > 0
         t = trailing_zeros(p) + 1
         p >>= t
         while (t -= 1) >= 0
-            x *= x
+            x = square(x)
         end
         y *= x
     end


### PR DESCRIPTION
For some types, `x^2` can have a faster implementation than `x*x`: e.g. polynomials benefit from ~half the number of operations.

Of course, for other types, the opposite may be the case, but that case is taken care of by `literal_pow(...)`. This pull request proposes relying on the latter mechanic to decide which is faster and therefore which should be used inside `power_by_squaring`.

I'm marking this as "WIP" because in its current form, this isn't backwards compatible for packages that _themselves_ define `^` in terms of `power_by_squaring`, which is rather common.

Any thoughts?