### PR TITLE
WIP: Warn if @code_typed, @code_warntype, etc. are showing inaccurate specialization

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -458,7 +458,7 @@ static jl_value_t *ml_matches(jl_typemap_t *ml, int offs,
                               size_t world, size_t *min_valid, size_t *max_valid);
 
 // get the compilation signature specialization for this method
-static void jl_compilation_sig(
+JL_DLLEXPORT void jl_compilation_sig(
     jl_tupletype_t *const tt, // the original tupletype of the call : this is expected to be a relative simple type (no Varags, Union, UnionAll, etc.)
     jl_svec_t *sparams,
     jl_method_t *definition,

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -17,7 +17,7 @@ function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
 end
 
 """
-    code_warntype([io::IO], f, types; debuginfo=:default)
+    code_warntype([io::IO], f, types; debuginfo=:default, optimize=false, warn_about_lying=true)
 
 Prints lowered and type-inferred ASTs for the methods matching the given generic function
 and type signature to `io` which defaults to `stdout`. The ASTs are annotated in such a way
@@ -31,10 +31,10 @@ Keyword argument `debuginfo` may be one of `:source` or `:none` (default), to sp
 
 See [`@code_warntype`](@ref man-code-warntype) for more information.
 """
-function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); debuginfo::Symbol=:default, optimize::Bool=false)
+function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); debuginfo::Symbol=:default, optimize::Bool=false, warn_about_lying::Bool=true)
     debuginfo = Base.IRShow.debuginfo(debuginfo)
     lineprinter = Base.IRShow.__debuginfo[debuginfo]
-    for (src, rettype) in code_typed(f, t, optimize=optimize)
+    for (src, rettype) in code_typed(f, t; debuginfo=debuginfo, optimize=optimize, warn_about_lying=warn_about_lying)
         lambda_io::IOContext = io
         if src.slotnames !== nothing
             slotnames = Base.sourceinfo_slotnames(src)


### PR DESCRIPTION
This is an experiment in addressing the problem described in:
- Issue #23749 _@code_warntype with non-specialized type arguments shows the wrong specialization_ 
- Issue #32834 _Can we support a way to make `@code_typed` stop lying to us all? :)_ 
