### PR TITLE
fix #33135, wrong scope resolution with conflicting sparams and let vars

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2554,7 +2554,7 @@
                                           (append locals-nondef locals-def)
                                           ;; global declarations at the top level are not inherited
                                           (if toplevel? '() globals)
-                                          (scope:sp scope)
+                                          '()
                                           (append (map cons need-rename renamed)
                                                   (map cons need-rename-def renamed-def))
                                           scope)))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1928,3 +1928,10 @@ end
 # Stream positioning after parsing var
 @test Meta.parse("var'", 1, greedy=false) == (:var, 4)
 
+# issue #33135
+function f33135(x::T) where {C1, T}
+    let C1 = 1, C2 = 2
+        C1
+    end
+end
+@test f33135(0) == 1


### PR DESCRIPTION
The static parameters of an outer scope should not be passed along to inner scopes; it instead needs to be handled by the lookup process iterating back to enclosing scopes.
