### PR TITLE
RFC: Add `@will_specialize` macro and `will_specialize` function to `InteractiveUtils`

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -4,7 +4,8 @@ module InteractiveUtils
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, clipboard
+    @code_typed, @code_lowered, @code_llvm, @code_native, clipboard,
+    @will_specialize, will_specialize
 
 import Base.Docs.apropos
 

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -150,3 +150,16 @@ code_native(io::IO, @nospecialize(f), @nospecialize(types=Tuple); syntax::Symbol
 code_native(@nospecialize(f), @nospecialize(types=Tuple); syntax::Symbol=:att, debuginfo::Symbol=:default) =
     code_native(stdout, f, types; syntax=syntax, debuginfo=debuginfo)
 code_native(::IO, ::Any, ::Symbol) = error("illegal code_native call") # resolve ambiguous call
+
+"""
+    will_specialize(f, types)
+
+Returns `true` if the specialization on this method signature will be compiled
+into the cache for this method.
+"""
+function will_specialize(@nospecialize(f), @nospecialize(t))
+    isa_compileable_sig = map(Base.method_instances(f, t)) do mi
+        ccall(:jl_isa_compileable_sig, Cint, (Any, Any), mi.specTypes, mi.def) != 0
+    end
+    return !isempty(isa_compileable_sig) && all(isa_compileable_sig)
+end

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -153,6 +153,13 @@ macro code_lowered(ex0...)
     end
 end
 
+macro will_specialize(ex0...)
+    thecall = gen_call_with_extracted_types_and_kwargs(__module__, :will_specialize, ex0)
+    quote
+        $thecall
+    end
+end
+
 """
     @functionloc
 
@@ -247,3 +254,11 @@ Set the optional keyword argument `debuginfo` by putting it before the function 
 `debuginfo` may be one of `:source` (default) or `:none`, to specify the verbosity of code comments.
 """
 :@code_native
+
+"""
+    @will_specialize
+
+Evaluates the arguments to the function or macro call, determines their types, and calls
+[`will_specialize`](@ref) on the resulting expression.
+"""
+:@will_specialize

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -389,3 +389,45 @@ if Sys.iswindows() || Sys.isapple()
         @test clipboard() == str
     end
 end
+
+# tests for @will_specialize
+let
+    f1(x) = typemax(x)
+    @test !(@will_specialize f1(Int))
+    @test !(@will_specialize f1(Float32))
+    @test !(@will_specialize f1(Float64))
+    f2(t::Type) = t
+    @test !(@will_specialize f2(Int))
+    @test !(@will_specialize f2(Float32))
+    @test !(@will_specialize f2(Float64))
+    @test !(@will_specialize f2(String))
+    function f3(t::Type)
+        x = ones(t, 10)
+        return sum(map(sin, x))
+    end
+    @test !(@will_specialize f3(Int))
+    @test !(@will_specialize f3(Float32))
+    @test !(@will_specialize f3(Float64))
+    g0() = 0
+    @test @will_specialize g0()
+    g1(x) = x
+    @test @will_specialize g1(1)
+    @test @will_specialize g1(1.1)
+    @test @will_specialize g1("foo")
+    g2(x, y) = x * y
+    @test @will_specialize g2(1, 2)
+    @test @will_specialize g2(1, 2.2)
+    @test @will_specialize g2(1.1, 2)
+    @test @will_specialize g2(1.1, 2.2)
+    @test @will_specialize g2("foo", "bar")
+    g3(x, y, z) = x * y * z
+    @test @will_specialize g3(1, 2, 3)
+    @test @will_specialize g3(1, 2, 3.3)
+    @test @will_specialize g3(1, 2.2, 3)
+    @test @will_specialize g3(1, 2.2, 3.3)
+    @test @will_specialize g3(1.1, 2, 3)
+    @test @will_specialize g3(1.1, 2, 3.3)
+    @test @will_specialize g3(1.1, 2.2, 3)
+    @test @will_specialize g3(1.1, 2.2, 3)
+    @test @will_specialize g3("foo", "bar", "baz")
+end


### PR DESCRIPTION
See also: https://github.com/JuliaLang/julia/pull/33142

This pull request adds the `InteractiveUtils.@will_specialize` macro and the `InteractiveUtils.will_specialize` function.

- `InteractiveUtils.@will_specialize f(x, y, z...)` returns `true` if the call to `f(x, y, z...)` will be fully specialized on its arguments, and `false` otherwise.

- `InteractiveUtils.will_specialize f(x, Tuple{R, S, T...}` returns `true` if the call to `f` with argument types `R, S, T...` will be fully specialized on its arguments, and `false` otherwise.

## Examples

```julia
julia> f1(x) = Base.typemax(x)
f1 (generic function with 1 method)

julia> @will_specialize f1(Int)
false

julia> g(x) = x + x
g (generic function with 1 method)

julia> @will_specialize g(1)
true

julia> foo(t::Type) = t
foo (generic function with 1 method)

julia> @will_specialize foo(Int)
false

julia> function foo2(t::Type)
           x = ones(t, 10)
           return sum(map(sin, x))
       end
foo2 (generic function with 1 method)

julia> @will_specialize foo2(Int)
false
```

## Motivation

As discussed in https://github.com/JuliaLang/julia/issues/23749, https://github.com/JuliaLang/julia/issues/32834, and https://github.com/JuliaLang/julia/pull/32817:

> @code_typed and friends will always show you specialized code, even if Julia
would not normally specialize that method call

The `InteractiveUtils.@will_specialize` macro and `InteractiveUtils.will_specialize` function introduced in this pull request provide a convenient way to find out whether or not Julia would normally specialize a given method call.

