### PR TITLE
a couple printing improvements

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1502,8 +1502,15 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type)
         printstyled(io, name, "(...)", color=color)
         return
     end
-    sig = unwrap_unionall(sig).parameters
-    with_output_color(color, io) do io
+    tv = Any[]
+    env_io = io
+    while isa(sig, UnionAll)
+        push!(tv, sig.var)
+        env_io = IOContext(env_io, :unionall_env => sig.var)
+        sig = sig.body
+    end
+    sig = sig.parameters
+    with_output_color(color, env_io) do io
         ft = sig[1]
         uw = unwrap_unionall(ft)
         if ft <: Function && isa(uw,DataType) && isempty(uw.parameters) &&
@@ -1523,9 +1530,10 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type)
     for i = 2:length(sig)  # fixme (iter): `eachindex` with offset?
         first || print(io, ", ")
         first = false
-        print(io, "::", sig[i])
+        print(env_io, "::", sig[i])
     end
     printstyled(io, ")", color=print_style)
+    show_method_params(io, tv)
     nothing
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1663,6 +1663,10 @@ function dump(io::IOContext, x::SimpleVector, n::Int, indent)
 end
 
 function dump(io::IOContext, @nospecialize(x), n::Int, indent)
+    if x === Union{}
+        show(io, x)
+        return
+    end
     T = typeof(x)
     if isa(x, Function)
         print(io, x, " (function of type ", T, ")")

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -92,12 +92,12 @@ julia> dump(Array)
 UnionAll
   var: TypeVar
     name: Symbol T
-    lb: Core.TypeofBottom Union{}
+    lb: Union{}
     ub: Any
   body: UnionAll
     var: TypeVar
       name: Symbol N
-      lb: Core.TypeofBottom Union{}
+      lb: Union{}
       ub: Any
     body: Array{T,N} <: DenseArray{T,N}
 ```
@@ -178,12 +178,12 @@ TypeName
   wrapper: UnionAll
     var: TypeVar
       name: Symbol T
-      lb: Core.TypeofBottom Union{}
+      lb: Union{}
       ub: Any
     body: UnionAll
       var: TypeVar
         name: Symbol N
-        lb: Core.TypeofBottom Union{}
+        lb: Union{}
         ub: Any
       body: Array{T,N} <: DenseArray{T,N}
   cache: SimpleVector

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -67,6 +67,19 @@ let err = try
     @test lines[6] == "  ambig(::Integer, ::Integer)"
 end
 
+ambig_with_bounds(x, ::Int, ::T) where {T<:Integer,S} = 0
+ambig_with_bounds(::Int, x, ::T) where {T<:Integer,S} = 1
+let err = try
+              ambig_with_bounds(1, 2, 3)
+          catch _e_
+              _e_
+          end
+    io = IOBuffer()
+    Base.showerror(io, err)
+    lines = split(String(take!(io)), '\n')
+    @test lines[end] == "  ambig_with_bounds(::$Int, ::$Int, ::T) where T<:Integer"
+end
+
 ## Other ways of accessing functions
 # Test that non-ambiguous cases work
 let io = IOBuffer()


### PR DESCRIPTION
Before:
```
julia> dump(Union{})
Core.TypeofBottom Union{}
```
That gets annoying when looking at lots of typevars. After:
```
julia> dump(Union{})
Union{}
```

The other change:
```
julia> g(x, ::Int, ::T) where {T<:Integer,S} = 0

julia> g(::Int, x, ::T) where {T<:Integer,S} = 1

julia> g(1, 2, 3)
ERROR: MethodError: g(::Int64, ::Int64, ::Int64) is ambiguous. Candidates:
  g(x, ::Int64, ::T) where {T<:Integer, S} in Main at REPL[1]:1
  g(::Int64, x, ::T) where {T<:Integer, S} in Main at REPL[2]:1
Possible fix, define
  g(::Int64, ::Int64, ::T) where T<:Integer
```
Previously the `where T<:Integer` was missing from the last line.