### PR TITLE
Fix which behavior when passed an empty string

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -459,6 +459,9 @@ for executable permissions only (with `.exe` and `.com` extensions added on
 Windows platforms); no searching of `PATH` is performed.
 """
 function which(program_name::String)
+    if isempty(program_name)
+       return nothing
+    end
     # Build a list of program names that we're going to try
     program_names = String[]
     base_pname = basename(program_name)

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -504,7 +504,7 @@ function which(program_name::String)
         for pname in program_names
             program_path = joinpath(path_dir, pname)
             # If we find something that matches our name and we can execute
-            if isexecutable(program_path)
+            if isfile(program_path) && isexecutable(program_path)
                 return realpath(program_path)
             end
         end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -556,6 +556,10 @@ withenv("PATH" => "$(Sys.BINDIR)$(psep)$(ENV["PATH"])") do
     @test Sys.which(julia_exe) == realpath(julia_exe)
 end
 
+# Check that which behaves correctly when passed an empty string
+@test isnothing(Base.Sys.which(""))
+
+
 mktempdir() do dir
     withenv("PATH" => "$(dir)$(psep)$(ENV["PATH"])") do
         # Test that files lacking executable permissions fail Sys.which
@@ -572,8 +576,15 @@ mktempdir() do dir
             @test Sys.which(foo_path) === nothing
         end
 
+    end
+
+    # Ensure these tests are done only with a PATH of known contents
+    withenv("PATH" => "$(dir)") do
         # Test that completely missing files also return nothing
         @test Sys.which("this_is_not_a_command") === nothing
+
+        # Check that which behaves correctly when passed a blank string
+        @test isnothing(Base.Sys.which(" "))
     end
 end
 

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -6,9 +6,3 @@
 sprint(Base.Sys.cpu_summary)
 @test Base.Sys.uptime() > 0
 Base.Sys.loadavg()
-
-# Check that which behaves correctly when passed an empty string
-@test isnothing(Base.Sys.which(""))
-
-# Check that which behaves correctly when passed a blank string
-@test isnothing(Base.Sys.which(" "))

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -9,3 +9,6 @@ Base.Sys.loadavg()
 
 # Check that which behaves correctly when passed an empty string
 @test isnothing(Base.Sys.which(""))
+
+# Check that which behaves correctly when passed a blank string
+@test isnothing(Base.Sys.which(" "))

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -6,3 +6,6 @@
 sprint(Base.Sys.cpu_summary)
 @test Base.Sys.uptime() > 0
 Base.Sys.loadavg()
+
+# Check that which behaves correctly when passed an empty string
+@test isnothing(Base.Sys.which(""))


### PR DESCRIPTION
Currently when passed an argument that is the empty string Sys.which() returns the path of a directory.

For example:

```
julia> Sys.which("")
"/usr/local/sbin"
```
This is not correct since the empty string is not a valid path component on any OS of which I am aware.  

This PR fixes this issue so that Sys.which("") returns nothing in accord with its documentation.