### PR TITLE
RFC: throw MethodError when passing kwargs to a function that doesn't accept any

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -194,10 +194,7 @@ JL_DLLEXPORT void JL_NORETURN jl_eof_error(void)
 // get kwsorter field, with appropriate error check and message
 JL_DLLEXPORT jl_value_t *jl_get_keyword_sorter(jl_value_t *f)
 {
-    jl_methtable_t *mt = jl_gf_mtable(f);
-    if (mt->kwsorter == NULL)
-        jl_errorf("function %s does not accept keyword arguments", jl_symbol_name(mt->name));
-    return mt->kwsorter;
+    return jl_get_kwsorter(jl_typeof(f));
 }
 
 JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t)

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -357,3 +357,7 @@ end
 # issue #33026
 using InteractiveUtils
 @test (@which kwf1(1, tens=2)).line > 0
+
+no_kw_args(x::Int) = 0
+@test_throws MethodError no_kw_args(1, k=1)
+@test_throws MethodError no_kw_args("", k=1)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -87,7 +87,7 @@ try
               (::Task)(::UInt8, ::UInt16, ::UInt32) = 2
 
               # issue 16471 (capturing references to a kwfunc)
-              Test.@test_throws ErrorException Core.kwfunc(Base.nothing)
+              Test.@test !isdefined(Base.Nothing.name.mt, :kwsorter)
               Base.nothing(::UInt8, ::UInt16, ::UInt32; x = 52) = x
               const nothingkw = Core.kwfunc(Base.nothing)
 
@@ -165,7 +165,8 @@ try
               const a31488 = fill(String(_v31488), 100)
           end
           """)
-    @test_throws ErrorException Core.kwfunc(Base.nothing) # make sure `nothing` didn't have a kwfunc (which would invalidate the attempted test)
+    # make sure `nothing` didn't have a kwfunc (which would invalidate the attempted test)
+    @test !isdefined(Base.Nothing.name.mt, :kwsorter)
 
     # Issue #12623
     @test __precompile__(false) === nothing


### PR DESCRIPTION
Setup:
```
julia> f(x::Int) = 0

julia> f(2, k=1)
ERROR: function f does not accept keyword arguments
```
Now an unrelated new method is added:
```
julia> f(x::String; k = 0) = 1
```
Now the error for the first call changes:
```
julia> f(2, k=1)
ERROR: MethodError: no method matching f(::Int64; k=1)
Closest candidates are:
  f(::Int64) at REPL[1]:1 got unsupported keyword argument "k"
```

So, that is kind of weird action-at-a-distance. This changes it to always give the `MethodError`. Since the MethodError contains more information it seems universally better to me, in addition to being more consistent.