### PR TITLE
consistent quoting of import Base.:operator and warnings thereof

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ New language features
 
 * Structs with all isbits and isbitsunion fields are now stored inline in arrays ([#32448]).
 
-* `import` now allows quoted symbols, e.g. `import Base.:+` ([#33152]).
+* `import` now allows quoted symbols, e.g. `import Base.:+` ([#33158]).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ New language features
 
 * Structs with all isbits and isbitsunion fields are now stored inline in arrays ([#32448]).
 
+* `import` now allows quoted symbols, e.g. `import Base.:+` ([#33152]).
+
 Language changes
 ----------------
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -235,15 +235,14 @@ function showerror(io::IO, ex::MethodError)
     if f_is_function && isdefined(Base, name)
         basef = getfield(Base, name)
         if basef !== ex.f && hasmethod(basef, arg_types)
-            println(io)
-            print(io, "You may have intended to import Base.", name)
+            print(io, "\nYou may have intended to import ")
+            show_unquoted(io, Expr(:., :Base, QuoteNode(name)))
         end
     end
     if (ex.world != typemax(UInt) && hasmethod(ex.f, arg_types) &&
         !hasmethod(ex.f, arg_types, world = ex.world))
         curworld = get_world_counter()
-        println(io)
-        print(io, "The applicable method may be too new: running in world age $(ex.world), while current world is $(curworld).")
+        print(io, "\nThe applicable method may be too new: running in world age $(ex.world), while current world is $(curworld).")
     end
     if !is_arg_types
         # Check for row vectors used where a column vector is intended.
@@ -455,8 +454,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
 
     if !isempty(lines) # Display up to three closest candidates
         Base.with_output_color(:normal, io) do io
-            println(io)
-            print(io, "Closest candidates are:")
+            print(io, "\nClosest candidates are:")
             sort!(lines, by = x -> -x[2])
             i = 0
             for line in lines

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -275,7 +275,7 @@
 (define (quoted? e) (memq (car e) '(quote top core globalref outerref line break inert meta)))
 (define (quotify e) `',e)
 (define (unquote e)
-  (if (and (pair? e) (quoted? e))
+  (if (and (pair? e) (memq (car e) '(quote inert)))
       (cadr e)
       e))
 

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -274,6 +274,10 @@
 
 (define (quoted? e) (memq (car e) '(quote top core globalref outerref line break inert meta)))
 (define (quotify e) `',e)
+(define (unquote e)
+  (if (and (pair? e) (quoted? e))
+      (cadr e)
+      e))
 
 (define (lam:args x) (cadr x))
 (define (lam:vars x) (llist-vars (lam:args x)))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1602,7 +1602,7 @@
        ((eq? nxt '|.|)
         (if (ts:space? s) (disallowed-space word nxt))
         (take-token s)
-        (loop (cons (macrocall-to-atsym (parse-unary-prefix s)) path)))
+        (loop (cons (unquote (macrocall-to-atsym (parse-unary-prefix s))) path)))
        ((or (memv nxt '(#\newline #\; #\, :))
             (eof-object? nxt))
         (cons '|.| (reverse path)))

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -206,7 +206,7 @@ import ..@except_str
 global +
 +() = nothing
 err_str = @except_str 1 + 2 MethodError
-@test occursin("import Base.+", err_str)
+@test occursin("import Base.:+", err_str)
 
 err_str = @except_str Float64[](1) MethodError
 @test !occursin("import Base.Array", err_str)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1928,6 +1928,6 @@ end
 # Stream positioning after parsing var
 @test Meta.parse("var'", 1, greedy=false) == (:var, 4)
 
-# quoted names in import (#33152)
+# quoted names in import (#33158)
 @test Meta.parse("import Base.:+") == :(import Base.+)
 @test Meta.parse("import Base.Foo.:(==).bar") == :(import Base.Foo.==.bar)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1930,3 +1930,4 @@ end
 
 # quoted names in import (#33152)
 @test Meta.parse("import Base.:+") == :(import Base.+)
+@test Meta.parse("import Base.Foo.:(==).bar") == :(import Base.Foo.==.bar)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1928,3 +1928,5 @@ end
 # Stream positioning after parsing var
 @test Meta.parse("var'", 1, greedy=false) == (:var, 4)
 
+# quoted names in import (#33152)
+@test Meta.parse("import Base.:+") == :(import Base.+)


### PR DESCRIPTION
TLDR: This PR allows quoting in `import` statements, e.g. `import Base.:+`, similar to other Julia contexts, and uses quoting for `MethodError` warnings about shadowed operators.

As was [noted recently on discourse](https://discourse.julialang.org/t/definition-of-unary-operator-inside-a-module-removes-the-base-definition/28371), the `MethodError` printing currently shows a potentially confusing suggestion when a function shadows a `Base` function if it is an operator, and in general the quoting of symbols (e.g. `Base.+` vs. `Base.:+`) was a bit inconsistent.

For example, if you accidentally shadow `+`, it prints `You may have intended to import Base.+`, which may be confusing because if you try to define the function as `Base.+` Julia will give an error.  This PR changes the error message to quote operators.

Unfortunately, while `function Base.:+(...)` works, `import Base.:+` gave a syntax error, which seems a little inconsistent.   So this PR also updates the parser to allow quoted symbols in `import` statements.  Backwards compatible since it was a syntax error previously.