### PR TITLE
Have threading functions (lock, unlock, ...) throw Error for old `Base.Condition`

### DIFF
--- a/base/condition.jl
+++ b/base/condition.jl
@@ -162,3 +162,8 @@ this, and can be used for level-triggered events.
 This object is NOT thread-safe. See [`Threads.Condition`](@ref) for a thread-safe version.
 """
 const Condition = GenericCondition{AlwaysLockedST}
+
+lock(c::GenericCondition{AlwaysLockedST}) =
+    throw(ArgumentError("`Condition` is NOT thread-safe. Please use `Threads.Condition` instead for concurrent code."))
+unlock(c::GenericCondition{AlwaysLockedST}) =
+    throw(ArgumentError("`Condition` is NOT thread-safe. Please use `Threads.Condition` instead for concurrent code."))

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -166,4 +166,4 @@ const Condition = GenericCondition{AlwaysLockedST}
 lock(c::GenericCondition{AlwaysLockedST}) =
     throw(ArgumentError("`Condition` is not thread-safe. Please use `Threads.Condition` instead for multi-threaded code."))
 unlock(c::GenericCondition{AlwaysLockedST}) =
-    throw(ArgumentError("`Condition` is NOT thread-safe. Please use `Threads.Condition` instead for concurrent code."))
+    throw(ArgumentError("`Condition` is not thread-safe. Please use `Threads.Condition` instead for multi-threaded code."))

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -164,6 +164,6 @@ This object is NOT thread-safe. See [`Threads.Condition`](@ref) for a thread-saf
 const Condition = GenericCondition{AlwaysLockedST}
 
 lock(c::GenericCondition{AlwaysLockedST}) =
-    throw(ArgumentError("`Condition` is NOT thread-safe. Please use `Threads.Condition` instead for concurrent code."))
+    throw(ArgumentError("`Condition` is not thread-safe. Please use `Threads.Condition` instead for multi-threaded code."))
 unlock(c::GenericCondition{AlwaysLockedST}) =
     throw(ArgumentError("`Condition` is NOT thread-safe. Please use `Threads.Condition` instead for concurrent code."))


### PR DESCRIPTION
Address the issue referenced in https://github.com/JuliaLang/julia/pull/30061#issuecomment-527933552:

The old-style `Base.Condition` is NOT thread-safe and does not support the threading API. This PR tries to help the user notice when they should be using `Threads.Condition` by throwing an error to fail early.

If there are other functions we should add error-throwing overloads for, please let me know.