### PR TITLE
Factor-out logic to determine the path of the precompilation cache file.

### DIFF
--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -332,7 +332,8 @@ try
           end
           """)
 
-    Base.compilecache(Base.PkgId("FooBar"))
+    cachefile = Base.compilecache(Base.PkgId("FooBar"))
+    @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"))
     @test isfile(joinpath(cachedir, "FooBar.ji"))
     @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) isa Vector
     @test !isdefined(Main, :FooBar)


### PR DESCRIPTION
CUDAdrv.jl and LLVM.jl need to be able to wipe the precompilation cache file in order to force recompilation, since there's global state that depends on resp. the CUDA and LLVM library version. After https://github.com/JuliaLang/julia/pull/32651, that became a little cumbersome, so factor out the logic to get the path to the current cache file.