### PR TITLE
readdir: default to "." or pwd() depending on join keyword

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -737,7 +737,7 @@ julia> readdir(abspath("base"), join=true)
  "/home/JuliaUser/dev/julia/base/weakkeydict.jl"
 ```
 """
-function readdir(dir::AbstractString=pwd(); join::Bool=false)
+function readdir(dir::AbstractString; join::Bool=false)
     # Allocate space for uv_fs_t struct
     uv_readdir_req = zeros(UInt8, ccall(:jl_sizeof_uv_fs_t, Int32, ()))
 
@@ -759,6 +759,7 @@ function readdir(dir::AbstractString=pwd(); join::Bool=false)
 
     return entries
 end
+readdir(; join::Bool=false) = readdir(join ? pwd() : ".", join=join)
 
 """
     walkdir(dir; topdown=true, follow_symlinks=false, onerror=throw)

--- a/test/file.jl
+++ b/test/file.jl
@@ -1405,7 +1405,7 @@ end
     end
 end
 
-@testset "readir tests" begin
+@testset "readdir tests" begin
     ≛(a, b) = sort(a) == sort(b)
     mktempdir() do dir
         d = cd(pwd, dir) # might resolve symlinks
@@ -1429,6 +1429,23 @@ end
         cd(t) do
             @test readdir(b) ≛ names
             @test readdir(b, join=true) ≛ [joinpath(b, x) for x in names]
+        end
+    end
+    if !Sys.iswindows()
+        mktempdir() do dir
+            cd(dir) do
+                d = pwd() # might resolve symlinks
+                @test isdir(d)
+                @test Base.Filesystem.samefile(d, ".")
+                @test isempty(readdir())
+                @test isempty(readdir(d))
+                @test isempty(readdir(join=true))
+                rm(d, recursive=true)
+                @test !ispath(d)
+                @test isempty(readdir())
+                @test_throws SystemError readdir(d)
+                @test_throws Base.IOError readdir(join=true)
+            end
         end
     end
 end


### PR DESCRIPTION
This is a pretty niche issue but it allows `readdir()` to work after the current working direcotory has been deleted, whereas when `join=true` you need a path which no longer exists, so `pwd()` fails and therefore `readdir(join=true)` also fails.

I can't find a way to get a current working directory that is both deleted and non-empty:
* if you create files first, then you can't delete the directory (unless you use `rm -r` in which case it deletes the file before deleting the directory)
* trying to create files after deleting the directory doesn't work either since all the ways I tried of creating files in a deleted directory failed.