### PR TITLE
Revert some Date printings

### DIFF
--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -244,7 +244,7 @@ Date
       value: Int64 735264
 
 julia> t.instant
-Dates.UTInstant{Day}(Day(735264))
+Dates.UTInstant{Day}(735264 days)
 
 julia> Dates.value(t)
 735264
@@ -400,7 +400,7 @@ As a bonus, all period arithmetic objects work directly with ranges:
 
 ```jldoctest
 julia> dr = Date(2014,1,29):Day(1):Date(2014,2,3)
-Date(2014, 1, 29):Day(1):Date(2014, 2, 3)
+Date(2014, 1, 29):1 day:Date(2014, 2, 3)
 
 julia> collect(dr)
 6-element Array{Date,1}:
@@ -412,7 +412,7 @@ julia> collect(dr)
  Date(2014, 2, 3)
 
 julia> dr = Date(2014,1,29):Dates.Month(1):Date(2014,07,29)
-Date(2014, 1, 29):Month(1):Date(2014, 7, 29)
+Date(2014, 1, 29):1 month:Date(2014, 7, 29)
 
 julia> collect(dr)
 7-element Array{Date,1}:

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -400,29 +400,29 @@ As a bonus, all period arithmetic objects work directly with ranges:
 
 ```jldoctest
 julia> dr = Date(2014,1,29):Day(1):Date(2014,2,3)
-Date(2014, 1, 29):1 day:Date(2014, 2, 3)
+2014-01-29:1 day:2014-02-03
 
 julia> collect(dr)
 6-element Array{Date,1}:
- Date(2014, 1, 29)
- Date(2014, 1, 30)
- Date(2014, 1, 31)
- Date(2014, 2, 1)
- Date(2014, 2, 2)
- Date(2014, 2, 3)
+ 2014-01-29
+ 2014-01-30
+ 2014-01-31
+ 2014-02-01
+ 2014-02-02
+ 2014-02-03
 
 julia> dr = Date(2014,1,29):Dates.Month(1):Date(2014,07,29)
-Date(2014, 1, 29):1 month:Date(2014, 7, 29)
+2014-01-29:1 month:2014-07-29
 
 julia> collect(dr)
 7-element Array{Date,1}:
- Date(2014, 1, 29)
- Date(2014, 2, 28)
- Date(2014, 3, 29)
- Date(2014, 4, 29)
- Date(2014, 5, 29)
- Date(2014, 6, 29)
- Date(2014, 7, 29)
+ 2014-01-29
+ 2014-02-28
+ 2014-03-29
+ 2014-04-29
+ 2014-05-29
+ 2014-06-29
+ 2014-07-29
 ```
 
 ## Adjuster Functions
@@ -492,15 +492,14 @@ julia> filter(dr) do x
            Dates.dayofweekofmonth(x) == 2
        end
 8-element Array{Date,1}:
- Date(2014, 4, 8)
- Date(2014, 5, 13)
- Date(2014, 6, 10)
- Date(2014, 7, 8)
- Date(2014, 8, 12)
- Date(2014, 9, 9)
- Date(2014, 10, 14)
- Date(2014, 11, 11)
-
+ 2014-04-08
+ 2014-05-13
+ 2014-06-10
+ 2014-07-08
+ 2014-08-12
+ 2014-09-09
+ 2014-10-14
+ 2014-11-11
 ```
 
 Additional examples and tests are available in [`stdlib/Dates/test/adjusters.jl`](https://github.com/JuliaLang/julia/blob/master/stdlib/Dates/test/adjusters.jl).

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -579,14 +579,6 @@ end
 
 # show
 
-function Base.show(io::IO, p::P) where P <: Period
-    if get(io, :compact, false)
-        print(io, p)
-    else
-        print(io, P, '(', p.value, ')')
-    end
-end
-
 function Base.show(io::IO, dt::DateTime)
     if get(io, :compact, false)
         print(io, dt)
@@ -597,9 +589,9 @@ function Base.show(io::IO, dt::DateTime)
         s = second(dt)
         ms = millisecond(dt)
         if ms == 0
-            print(io, DateTime, "($y, $m, $d, $h, $mi, $s)")
+            print(io, "DateTime($y, $m, $d, $h, $mi, $s)")
         else
-            print(io, DateTime, "($y, $m, $d, $h, $mi, $s, $ms)")
+            print(io, "DateTime($y, $m, $d, $h, $mi, $s, $ms)")
         end
     end
 end
@@ -617,7 +609,7 @@ function Base.show(io::IO, dt::Date)
         print(io, dt)
     else
         y,m,d = yearmonthday(dt)
-        print(io, Date, "($y, $m, $d)")
+        print(io, "Date($y, $m, $d)")
     end
 end
 

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -580,40 +580,6 @@ end
 # show
 
 function Base.show(io::IO, dt::DateTime)
-    if get(io, :compact, false)
-        print(io, dt)
-    else
-        y,m,d = yearmonthday(dt)
-        h = hour(dt)
-        mi = minute(dt)
-        s = second(dt)
-        ms = millisecond(dt)
-        if ms == 0
-            print(io, "DateTime($y, $m, $d, $h, $mi, $s)")
-        else
-            print(io, "DateTime($y, $m, $d, $h, $mi, $s, $ms)")
-        end
-    end
-end
-
-function Base.show(io::IO, ::MIME"text/plain", dt::DateTime)
-    print(io, dt)
-end
-
-function Base.show(io::IO, ::MIME"text/plain", dt::Date)
-    print(io, dt)
-end
-
-function Base.show(io::IO, dt::Date)
-    if get(io, :compact, false)
-        print(io, dt)
-    else
-        y,m,d = yearmonthday(dt)
-        print(io, "Date($y, $m, $d)")
-    end
-end
-
-function Base.print(io::IO, dt::DateTime)
     if millisecond(dt) == 0
         format(io, dt, dateformat"YYYY-mm-dd\THH:MM:SS")
     else
@@ -621,7 +587,7 @@ function Base.print(io::IO, dt::DateTime)
     end
 end
 
-function Base.print(io::IO, dt::Date)
+function Base.show(io::IO, dt::Date)
     format(io, dt, dateformat"YYYY-mm-dd")
 end
 

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -45,8 +45,8 @@ for period in (:Year, :Month, :Week, :Day, :Hour, :Minute, :Second, :Millisecond
 end
 
 #Print/show/traits
-Base.print(io::IO, p::Period) = print(io, value(p), _units(p))
-Base.show(io::IO, ::MIME"text/plain", p::Period) = print(io, p)
+Base.string(x::Period) = string(value(x), _units(x))
+Base.show(io::IO,x::Period) = print(io, string(x))
 Base.zero(::Union{Type{P},P}) where {P<:Period} = P(0)
 Base.one(::Union{Type{P},P}) where {P<:Period} = 1  # see #16116
 Base.typemin(::Type{P}) where {P<:Period} = P(typemin(Int64))

--- a/stdlib/Dates/test/io.jl
+++ b/stdlib/Dates/test/io.jl
@@ -7,7 +7,7 @@ using Dates
 
 @testset "string/show representation of Date" begin
     @test string(Dates.Date(1, 1, 1)) == "0001-01-01" # January 1st, 1 AD/CE
-    @test sprint(show, Dates.Date(1, 1, 1)) == "Date(1, 1, 1)"
+    @test sprint(show, Dates.Date(1, 1, 1)) == "0001-01-01"
     @test string(Dates.Date(0, 12, 31)) == "0000-12-31" # December 31, 1 BC/BCE
     @test Dates.Date(1, 1, 1) - Dates.Date(0, 12, 31) == Dates.Day(1)
     @test Dates.Date(Dates.UTD(-306)) == Dates.Date(0, 2, 29)
@@ -16,7 +16,7 @@ using Dates
     @test string(Dates.Date(-1000000, 1, 1)) == "-1000000-01-01"
     @test string(Dates.Date(1000000, 1, 1)) == "1000000-01-01"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 1)) == "2000-01-01T00:00:00.001"
-    @test sprint(show, Dates.DateTime(2000, 1, 1, 0, 0, 0, 1)) == "DateTime(2000, 1, 1, 0, 0, 0, 1)"
+    @test sprint(show, Dates.DateTime(2000, 1, 1, 0, 0, 0, 1)) == "2000-01-01T00:00:00.001"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 2)) == "2000-01-01T00:00:00.002"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 500)) == "2000-01-01T00:00:00.5"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 998)) == "2000-01-01T00:00:00.998"

--- a/stdlib/Dates/test/io.jl
+++ b/stdlib/Dates/test/io.jl
@@ -5,61 +5,9 @@ module IOTests
 using Test
 using Dates
 
-@testset "string/show representation of Period" begin
-    @test string(Dates.Year(2018)) == "2018 years"
-    @test sprint(show, Dates.Year(2018)) == "Dates.Year(2018)"
-    @test sprint(print, Dates.Year(2018)) == "2018 years"
-    @test repr(Dates.Year(2018)) == "Dates.Year(2018)"
-
-    @test string(Dates.Month(12)) == "12 months"
-    @test sprint(show, Dates.Month(12)) == "Dates.Month(12)"
-    @test sprint(print, Dates.Month(12)) == "12 months"
-    @test repr(Dates.Month(12)) == "Dates.Month(12)"
-
-    @test string(Dates.Week(4)) == "4 weeks"
-    @test sprint(show, Dates.Week(4)) == "Dates.Week(4)"
-    @test sprint(print, Dates.Week(4)) == "4 weeks"
-    @test repr(Dates.Week(4)) == "Dates.Week(4)"
-
-    @test string(Dates.Day(12)) == "12 days"
-    @test sprint(show, Dates.Day(12)) == "Dates.Day(12)"
-    @test sprint(print,Dates.Day(12)) == "12 days"
-    @test repr(Dates.Day(12)) == "Dates.Day(12)"
-
-    @test string(Dates.Hour(12)) == "12 hours"
-    @test sprint(show, Dates.Hour(12)) == "Dates.Hour(12)"
-    @test sprint(print,Dates.Hour(12)) == "12 hours"
-    @test repr(Dates.Hour(12)) == "Dates.Hour(12)"
-
-    @test string(Dates.Minute(12)) == "12 minutes"
-    @test sprint(show, Dates.Minute(12)) == "Dates.Minute(12)"
-    @test sprint(print,Dates.Minute(12)) == "12 minutes"
-    @test repr(Dates.Minute(12)) == "Dates.Minute(12)"
-
-    @test string(Dates.Second(12)) == "12 seconds"
-    @test sprint(show, Dates.Second(12)) == "Dates.Second(12)"
-    @test sprint(print,Dates.Second(12)) == "12 seconds"
-    @test repr(Dates.Second(12)) == "Dates.Second(12)"
-
-    @test string(Dates.Millisecond(12)) == "12 milliseconds"
-    @test sprint(show, Dates.Millisecond(12)) == "Dates.Millisecond(12)"
-    @test sprint(print,Dates.Millisecond(12)) == "12 milliseconds"
-    @test repr(Dates.Millisecond(12)) == "Dates.Millisecond(12)"
-
-    @test string(Dates.Microsecond(12)) == "12 microseconds"
-    @test sprint(show, Dates.Microsecond(12)) == "Dates.Microsecond(12)"
-    @test sprint(print,Dates.Microsecond(12)) == "12 microseconds"
-    @test repr(Dates.Microsecond(12)) == "Dates.Microsecond(12)"
-
-    @test string(Dates.Nanosecond(12)) == "12 nanoseconds"
-    @test sprint(show, Dates.Nanosecond(12)) == "Dates.Nanosecond(12)"
-    @test sprint(print,Dates.Nanosecond(12)) == "12 nanoseconds"
-    @test repr(Dates.Nanosecond(12)) == "Dates.Nanosecond(12)"
-end
-
 @testset "string/show representation of Date" begin
     @test string(Dates.Date(1, 1, 1)) == "0001-01-01" # January 1st, 1 AD/CE
-    @test sprint(show, Dates.Date(1, 1, 1)) == "Dates.Date(1, 1, 1)"
+    @test sprint(show, Dates.Date(1, 1, 1)) == "Date(1, 1, 1)"
     @test string(Dates.Date(0, 12, 31)) == "0000-12-31" # December 31, 1 BC/BCE
     @test Dates.Date(1, 1, 1) - Dates.Date(0, 12, 31) == Dates.Day(1)
     @test Dates.Date(Dates.UTD(-306)) == Dates.Date(0, 2, 29)
@@ -68,7 +16,7 @@ end
     @test string(Dates.Date(-1000000, 1, 1)) == "-1000000-01-01"
     @test string(Dates.Date(1000000, 1, 1)) == "1000000-01-01"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 1)) == "2000-01-01T00:00:00.001"
-    @test sprint(show, Dates.DateTime(2000, 1, 1, 0, 0, 0, 1)) == "Dates.DateTime(2000, 1, 1, 0, 0, 0, 1)"
+    @test sprint(show, Dates.DateTime(2000, 1, 1, 0, 0, 0, 1)) == "DateTime(2000, 1, 1, 0, 0, 0, 1)"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 2)) == "2000-01-01T00:00:00.002"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 500)) == "2000-01-01T00:00:00.5"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 998)) == "2000-01-01T00:00:00.998"


### PR DESCRIPTION
These commits were reverted for release 1.2 and also now on release 1.3 since AFAIU they broke some test and we are not sure we want to commit to this printing.

It is a bit annoying and fragile to have stuff on master that we keep reverting for the releases. Therefore we should either decide to go with this or revert it on master aswell.

cc @nalimilan, @JeffBezanson 