### PR TITLE
Change first example for sparse arrays

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -50,15 +50,17 @@ matrix. [`dropzeros`](@ref), and the in-place [`dropzeros!`](@ref), can be used 
 remove stored zeros from the sparse matrix.
 
 ```jldoctest
-julia> A = sparse([1, 2, 3], [1, 2, 3], [0, 2, 0])
-3×3 SparseMatrixCSC{Int64,Int64} with 3 stored entries:
+julia> A = sparse([1, 1, 2, 3], [1, 3, 2, 3], [0, 1, 2, 0])
+3×3 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
   [1, 1]  =  0
   [2, 2]  =  2
+  [1, 3]  =  1
   [3, 3]  =  0
 
 julia> dropzeros(A)
-3×3 SparseMatrixCSC{Int64,Int64} with 1 stored entry:
+3×3 SparseMatrixCSC{Int64,Int64} with 2 stored entries:
   [2, 2]  =  2
+  [1, 3]  =  1
 ```
 
 ## Sparse Vector Storage


### PR DESCRIPTION
Currently, the first example in the [SparseArrays docs](https://docs.julialang.org/en/v1/stdlib/SparseArrays/index.html) is the following:

```julia
julia> A = sparse([1, 2, 3], [1, 2, 3], [0, 2, 0])
3×3 SparseMatrixCSC{Int64,Int64} with 3 stored entries:
  [1, 1]  =  0
  [2, 2]  =  2
  [3, 3]  =  0

julia> dropzeros(A)
3×3 SparseMatrixCSC{Int64,Int64} with 1 stored entry:
  [2, 2]  =  2
```

This example is shown before the COO format is explained (and it needs to use COO as it deals with explicitly setting zero values). If a user scans this page superficially - e.g. when looking for a quick example that shows how to initialize a sparse matrix -, they might be inclined to think that the function
```julia
sparse([1, 2, 3], [1, 2, 3], [0, 2, 0])
```
creates a 3x3 matrix of the values listed in the arrays and that way confuse it with
```julia
sparse([1 2 3; 1 2 3; 0 2 0])
```
(The latter syntax is also there on the page, coming from the docstring of [`findnz`](https://github.com/JuliaLang/julia/blob/cb76f2a0e7f2e13a2d1c500df5fe9d30d73dc82f/stdlib/SparseArrays/src/abstractsparse.jl#L103-L122)).

I have been confused by this multiple times when I forgot the syntax and visited the Sparse Arrays documentation page to refresh my memory. To mitigate this, this PR proposes a simple change and adds an additional non-zero entry, which hopefully makes the docs a bit more instructive.