### PR TITLE
Changed display of throw_eachindex_mismatch (issue #32890)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -212,7 +212,7 @@ eachindex(itrs...) = keys(itrs...)
 eachindex(A::AbstractVector) = (@_inline_meta(); axes1(A))
 
 @noinline function throw_eachindex_mismatch(::IndexLinear, A...)
-    throw(DimensionMismatch("all inputs to eachindex must have the same indices, got $(join(LinearIndices.(A), ", ", " and "))"))
+    throw(DimensionMismatch("all inputs to eachindex must have the same indices, got $(join(eachindex.(A), ", ", " and "))"))
 end
 @noinline function throw_eachindex_mismatch(::IndexCartesian, A...)
     throw(DimensionMismatch("all inputs to eachindex must have the same axes, got $(join(axes.(A), ", ", " and "))"))


### PR DESCRIPTION
Changed the display of throw_eachindex_mismatch. See issue #32890 .

Before:
```
julia> eachindex(rand(49), rand(50))
ERROR: DimensionMismatch("all inputs to eachindex must have the same indices, got [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49] and [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50]")
Stacktrace:
 [1] throw_eachindex_mismatch(::IndexLinear, ::Array{Float64,1}, ::Vararg{Array{Float64,1},N} where N) at ./abstractarray.jl:215
 [2] eachindex at ./abstractarray.jl:272 [inlined]
 [3] eachindex(::Array{Float64,1}, ::Array{Float64,1}) at ./abstractarray.jl:261
 [4] top-level scope at REPL[2]:1
```
After:
```
julia> eachindex(rand(49), rand(50))
ERROR: DimensionMismatch("all inputs to eachindex must have the same indices, got Base.OneTo(49) and Base.OneTo(50)")
Stacktrace:
 [1] throw_eachindex_mismatch(::IndexLinear, ::Array{Float64,1}, ::Vararg{Array{Float64,1},N} where N) at ./abstractarray.jl:215
 [2] eachindex at ./abstractarray.jl:272 [inlined]
 [3] eachindex(::Array{Float64,1}, ::Array{Float64,1}) at ./abstractarray.jl:261
 [4] top-level scope at REPL[1]:1
```