### PR TITLE
Check index vector length in partialsortperm!(); clarify documentation

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -790,17 +790,19 @@ partialsortperm(v::AbstractVector, k::Union{Integer,OrdinalRange}; kwargs...) =
     partialsortperm!(ix, v, k; by=<transform>, lt=<comparison>, rev=false, initialized=false)
 
 Like [`partialsortperm`](@ref), but accepts a preallocated index vector `ix` the same size as
-`v`.
+`v`, which is used to store (a permutation of) the indices of `v`. 
 
-If the index vector `ix` is initialized with the indices of `v`, `initialized` should be set to
+If the index vector `ix` is initialized with the indices of `v` (or a permutation thereof), `initialized` should be set to
 `true`.
 
 If `initialized` is `false` (the default), then `ix` is initialized to contain the indices of `v`.
 
-If `initialized` is `true`, but `ix` does not contain the indices of `v`, the behavior is undefined.
+If `initialized` is `true`, but `ix` does not contain (a permutation of) the indices of `v`, the behavior of
+`partialsortperm!` is undefined.
 
 (Typically, the indices of `v` will be `1:length(v)`, although if `v` has an alternative array type
-with non-one-based indices, such as an `OffsetArray`, `ix` must have the same indices.)
+with non-one-based indices, such as an `OffsetArray`, `ix` must also be an `OffsetArray` with the same
+indices, and the contents of `ix` must be these same indices, or a permutation thereof.)
 
 Upon return, `ix` is guaranteed to have the indices `k` in their sorted positions, such that
 `v[partialsortperm!(ix, v, k)] == partialsort!(v, k)`

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -789,9 +789,42 @@ partialsortperm(v::AbstractVector, k::Union{Integer,OrdinalRange}; kwargs...) =
 """
     partialsortperm!(ix, v, k; by=<transform>, lt=<comparison>, rev=false, initialized=false)
 
-Like [`partialsortperm`](@ref), but accepts a preallocated index vector `ix`. If `initialized` is `false`
-(the default), `ix` is initialized to contain the values `1:length(ix)`.
-"""
+Like [`partialsortperm`](@ref), but accepts a preallocated index vector `ix` the same size as
+`v`.
+
+If the index vector `ix` is initialized with the indices of `v`, `initialized` should be set to
+`true`.
+
+If `initialized` is `false` (the default), then `ix` is initialized to contain the indices of `v`.
+
+If `initialized` is `true`, but `ix` does not contain the indices of `v`, the behavior is undefined.
+
+(Typically, the indices of `v` will be `1:length(ix)`, although if `v` has an alternative array type
+with non-one-based indices, such as an `OffsetArray`, `ix` must have the same indices.)
+
+Upon return, `ix` is guaranteed to have the indices `k` in their sorted positions, such that
+`v[partialsortperm!(ix, v, k)] == partialsort!(v, k)`
+
+The return value is the `k`th element of `ix` if `k` is an Integer, or view into `ix` if `k` is
+a range.
+
+# Examples
+```julia-repl
+julia> v = [3, 1, 2, 1];
+
+julia> ix = Vector{Int}(undef, 4);
+
+julia> partialsortperm!(ix, v, 1)
+2
+
+julia> ix = [1:4...];
+
+julia> partialsortperm!(ix, v, 2:3, initialized=true)
+2-element view(::Array{Int64,1}, 2:3) with eltype Int64:
+ 4
+ 3
+
+ """
 function partialsortperm!(ix::AbstractVector{<:Integer}, v::AbstractVector,
                           k::Union{Int, OrdinalRange};
                           lt::Function=isless,
@@ -799,6 +832,10 @@ function partialsortperm!(ix::AbstractVector{<:Integer}, v::AbstractVector,
                           rev::Union{Bool,Nothing}=nothing,
                           order::Ordering=Forward,
                           initialized::Bool=false)
+    if axes(ix,1) != axes(v,1)
+        throw(ArgumentError("The index vector is used as a workspace and must have the " *
+                            "same length/indices as the source vector, $(axes(ix,1)) != $(axes(v,1))"))
+    end
     if !initialized
         @inbounds for i = axes(ix,1)
             ix[i] = i
@@ -897,7 +934,7 @@ function sortperm!(x::AbstractVector{<:Integer}, v::AbstractVector;
                    order::Ordering=Forward,
                    initialized::Bool=false)
     if axes(x,1) != axes(v,1)
-        throw(ArgumentError("index vector must have the same indices as the source vector, $(axes(x,1)) != $(axes(v,1))"))
+        throw(ArgumentError("index vector must have the same length/indices as the source vector, $(axes(x,1)) != $(axes(v,1))"))
     end
     if !initialized
         @inbounds for i = axes(v,1)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -825,7 +825,7 @@ julia> partialsortperm!(ix, v, 2:3, initialized=true)
 2-element view(::Array{Int64,1}, 2:3) with eltype Int64:
  4
  3
-
+```
  """
 function partialsortperm!(ix::AbstractVector{<:Integer}, v::AbstractVector,
                           k::Union{Int, OrdinalRange};

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -817,7 +817,7 @@ julia> ix = Vector{Int}(undef, 4);
 julia> partialsortperm!(ix, v, 1)
 2
 
-julia> ix = [1:4...];
+julia> ix = [1:4;];
 
 julia> partialsortperm!(ix, v, 2:3, initialized=true)
 2-element view(::Array{Int64,1}, 2:3) with eltype Int64:

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -802,12 +802,12 @@ If `initialized` is `true`, but `ix` does not contain (a permutation of) the ind
 
 (Typically, the indices of `v` will be `1:length(v)`, although if `v` has an alternative array type
 with non-one-based indices, such as an `OffsetArray`, `ix` must also be an `OffsetArray` with the same
-indices, and the contents of `ix` must be these same indices, or a permutation thereof.)
+indices, and must contain as values (a permutation of) these same indices.)
 
 Upon return, `ix` is guaranteed to have the indices `k` in their sorted positions, such that
 `v[partialsortperm!(ix, v, k)] == partialsort!(v, k)`
 
-The return value is the `k`th element of `ix` if `k` is an Integer, or view into `ix` if `k` is
+The return value is the `k`th element of `ix` if `k` is an integer, or view into `ix` if `k` is
 a range.
 
 # Examples

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -805,7 +805,11 @@ with non-one-based indices, such as an `OffsetArray`, `ix` must also be an `Offs
 indices, and must contain as values (a permutation of) these same indices.)
 
 Upon return, `ix` is guaranteed to have the indices `k` in their sorted positions, such that
-`v[partialsortperm!(ix, v, k)] == partialsort!(v, k)`
+
+```julia
+partialsortperm!(ix, v, k);
+v[ix[k]] == partialsort(v, k)
+```
 
 The return value is the `k`th element of `ix` if `k` is an integer, or view into `ix` if `k` is
 a range.

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -811,7 +811,7 @@ The return value is the `k`th element of `ix` if `k` is an integer, or view into
 a range.
 
 # Examples
-```julia-repl
+```jldoctest
 julia> v = [3, 1, 2, 1];
 
 julia> ix = Vector{Int}(undef, 4);

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -799,7 +799,7 @@ If `initialized` is `false` (the default), then `ix` is initialized to contain t
 
 If `initialized` is `true`, but `ix` does not contain the indices of `v`, the behavior is undefined.
 
-(Typically, the indices of `v` will be `1:length(ix)`, although if `v` has an alternative array type
+(Typically, the indices of `v` will be `1:length(v)`, although if `v` has an alternative array type
 with non-one-based indices, such as an `OffsetArray`, `ix` must have the same indices.)
 
 Upon return, `ix` is guaranteed to have the indices `k` in their sorted positions, such that

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -790,7 +790,7 @@ partialsortperm(v::AbstractVector, k::Union{Integer,OrdinalRange}; kwargs...) =
     partialsortperm!(ix, v, k; by=<transform>, lt=<comparison>, rev=false, initialized=false)
 
 Like [`partialsortperm`](@ref), but accepts a preallocated index vector `ix` the same size as
-`v`, which is used to store (a permutation of) the indices of `v`. 
+`v`, which is used to store (a permutation of) the indices of `v`.
 
 If the index vector `ix` is initialized with the indices of `v` (or a permutation thereof), `initialized` should be set to
 `true`.

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -33,6 +33,7 @@ let a=[1:10;]
         @test partialsortperm(a, r, rev=true) == (11 .- [r;])
     end
 end
+@test_throws ArgumentError partialsortperm!([1,2], [2,3,1], 1:2)
 @test sum(randperm(6)) == 21
 
 @testset "searchsorted" begin


### PR DESCRIPTION
* Check that index vector has the same axes as the source vector
* Clarify documentation and add doc-tests

Fixes #33184