### PR TITLE
Improve `show` for 0-dim array

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@ Standard library changes
 
 * Verbose `display` of `Char` (`text/plain` output) now shows the codepoint value in standard-conforming `"U+XXXX"` format ([#33291]).
 
+* Calling `show` or `repr` on 0-dimensional `AbstractArray`s now shows valid code for creating an equivalent 0-dimensional array, instead of only showing the contained value. ([#33206])
+
+
 #### Libdl
 
 #### LinearAlgebra

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@ Language changes
 
 * Calling `show` or `repr` on an `undef`/`UndefInitializer()` array initializer now shows valid Julia code ([#33211]).
 
+* Calling `show` or `repr` on a 0-dimensional `AbstractArray` now shows valid code for creating an equivalent 0-dimensional array, instead of only showing the contained value. ([#33206])
+
 Multi-threading changes
 -----------------------
 
@@ -37,8 +39,6 @@ Standard library changes
 * The methods of `mktemp` and `mktempdir` which take a function body to pass temporary paths to no longer throw errors if the path is already deleted when the function body returns ([#33091]).
 
 * Verbose `display` of `Char` (`text/plain` output) now shows the codepoint value in standard-conforming `"U+XXXX"` format ([#33291]).
-
-* Calling `show` or `repr` on 0-dimensional `AbstractArray`s now shows valid code for creating an equivalent 0-dimensional array, instead of only showing the contained value. ([#33206])
 
 
 #### Libdl

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -424,7 +424,7 @@ end
 
 ### 0-dimensional arrays -- see https://github.com/JuliaLang/julia/issues/31481
 function show_zero_dim(io::IO, X::AbstractArray{<:Any, 0})
-    val = isassigned(X) ? repr(X[]) : undef_ref_str
+    val = isassigned(X) ? repr(X[]; context=io) : undef_ref_str
     print(io, "fill($val)")
 end
 

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -422,10 +422,15 @@ function show(io::IO, X::AbstractArray)
         _show_nonempty(io, X, prefix)
 end
 
-### 0-dimensional arrays -- see https://github.com/JuliaLang/julia/issues/31481
-function show_zero_dim(io::IO, X::AbstractArray{<:Any, 0})
-    print(io, "fill(")
-    isassigned(X) ? show(io, X[]) : print(io, undef_ref_str)
+### 0-dimensional arrays (#31481)
+function show_zero_dim(io::IO, X::AbstractArray{T, 0}) where T
+    if isassigned(X)
+        print(io, "fill(")
+        show(io, X[])
+    else
+        print(io, "Array{$T,0}(")
+        show(io, undef)
+    end
     print(io, ")")
 end
 

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -424,8 +424,9 @@ end
 
 ### 0-dimensional arrays -- see https://github.com/JuliaLang/julia/issues/31481
 function show_zero_dim(io::IO, X::AbstractArray{<:Any, 0})
-    val = isassigned(X) ? repr(X[]; context=io) : undef_ref_str
-    print(io, "fill($val)")
+    print(io, "fill(")
+    isassigned(X) ? show(io, X[]) : print(io, undef_ref_str)
+    print(io, ")")
 end
 
 ### Vector arrays

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -424,7 +424,7 @@ end
 
 ### 0-dimensional arrays -- see https://github.com/JuliaLang/julia/issues/31481
 function show_zero_dim(io::IO, X::AbstractArray{<:Any, 0})
-    val = isassigned(X) ? repr(X[]) : repr(undef)
+    val = isassigned(X) ? repr(X[]) : undef_ref_str
     print(io, "fill($val)")
 end
 

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -423,6 +423,7 @@ function show(io::IO, X::AbstractArray)
 end
 
 ### 0-dimensional arrays (#31481)
+show_zero_dim(io::IO, X::BitArray{0}) = print(io, "BitArray(", Int(X[]), ")")
 function show_zero_dim(io::IO, X::AbstractArray{T, 0}) where T
     if isassigned(X)
         print(io, "fill(")

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -301,7 +301,7 @@ end
 # typeinfo agnostic
 # Note that this is for showing the content inside the array, and for `MIME"text/plain".
 # There are `show(::IO, ::A) where A<:AbstractArray` methods that don't use this
-# e.g. show_vector, show_zero_di, show_zero_dim
+# e.g. show_vector, show_zero_dim
 print_array(io::IO, X::AbstractArray{<:Any, 0}) =
     isassigned(X) ? show(io, X[]) : print(io, undef_ref_str)
 print_array(io::IO, X::AbstractVecOrMat) = print_matrix(io, X)
@@ -424,12 +424,9 @@ end
 
 ### 0-dimensional arrays -- see https://github.com/JuliaLang/julia/issues/31481
 function show_zero_dim(io::IO, X::AbstractArray{<:Any, 0})
-    # `"undef"` not `repr(undef)` because https://github.com/JuliaLang/julia/issues/33204
-    val = isassigned(X) ? repr(X[]) : "undef"
+    val = isassigned(X) ? repr(X[]) : repr(undef)
     print(io, "fill($val)")
 end
-# special case for when `isassigned(::AbstractArray{<:UndefInitializer}) == true`
-show_zero_dim(io::IO, X::AbstractArray{<:UndefInitializer, 0}) = print(io, "fill(undef)")
 
 ### Vector arrays
 

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -210,7 +210,7 @@ targets1 = ["0-dimensional $OAs_name.OffsetArray{Float64,0,Array{Float64,0}}:\n1
             "1×1 $OAs_name.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:2×3:3:\n 1.0",
             "1×1×1 $OAs_name.OffsetArray{Float64,3,Array{Float64,3}} with indices 2:2×3:3×4:4:\n[:, :, 4] =\n 1.0",
             "1×1×1×1 $OAs_name.OffsetArray{Float64,4,Array{Float64,4}} with indices 2:2×3:3×4:4×5:5:\n[:, :, 4, 5] =\n 1.0"]
-targets2 = ["(1.0, 1.0)",
+targets2 = ["(fill(1.0), fill(1.0))",
             "([1.0], [1.0])",
             "([1.0], [1.0])",
             "([1.0], [1.0])",

--- a/test/show.jl
+++ b/test/show.jl
@@ -1585,18 +1585,28 @@ end
 end
 
 @testset "0-dimensional Array. Issue #31481" begin
-    for x in (zeros(Int32), collect('b'), fill(nothing))
+    for x in (zeros(Int32), collect('b'), fill(nothing), BitArray(0))
         @test eval(Meta.parse(repr(x))) == x
     end
     @test showstr(zeros(Int32)) == "fill(0)"
     @test showstr(collect('b')) == "fill('b')"
     @test showstr(fill(nothing)) == "fill(nothing)"
-    @test showstr(fill(undef)) == "fill($undef)"
-    @test showstr(Array{Any, 0}(undef)) == "fill($(Base.undef_ref_str))"
+    @test showstr(BitArray(0)) == "fill(false)"
 
     @test replstr(zeros(Int32)) == "0-dimensional Array{Int32,0}:\n0"
     @test replstr(collect('b')) == "0-dimensional Array{Char,0}:\n'b'"
     @test replstr(fill(nothing)) == "0-dimensional Array{Nothing,0}:\nnothing"
+    @test replstr(BitArray(0)) == "0-dimensional BitArray{0}:\n0"
+
+    # UndefInitializer
+    @test showstr(fill(undef)) == "fill($undef)"
     @test replstr(fill(undef)) == "0-dimensional Array{UndefInitializer,0}:\n$undef"
-    @test replstr(Array{Any, 0}(undef)) == "0-dimensional Array{Any,0}:\n$(Base.undef_ref_str)"
+
+    # `#undef` values
+    @test showstr(Array{String, 0}(undef)) == "Array{String,0}($undef)"
+    @test replstr(Array{String, 0}(undef)) == "0-dimensional Array{String,0}:\n$(Base.undef_ref_str)"
+
+    # "undef" with isbits type
+    @test startswith(showstr(Array{Int32, 0}(undef)), "fill(")
+    @test startswith(replstr(Array{Int32, 0}(undef)), "0-dimensional Array{Int32,0}:\n")
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1592,11 +1592,11 @@ end
     @test showstr(collect('b')) == "fill('b')"
     @test showstr(fill(nothing)) == "fill(nothing)"
     @test showstr(fill(undef)) == "fill($undef)"
-    @test showstr(Array{Any, 0}(undef)) == "fill($undef)"
+    @test showstr(Array{Any, 0}(undef)) == "fill($(Base.undef_ref_str))"
 
     @test replstr(zeros(Int32)) == "0-dimensional Array{Int32,0}:\n0"
     @test replstr(collect('b')) == "0-dimensional Array{Char,0}:\n'b'"
     @test replstr(fill(nothing)) == "0-dimensional Array{Nothing,0}:\nnothing"
-    @test replstr(fill(undef)) == "0-dimensional Array{UndefInitializer,0}:\n$(repr(undef))"
+    @test replstr(fill(undef)) == "0-dimensional Array{UndefInitializer,0}:\n$undef"
     @test replstr(Array{Any, 0}(undef)) == "0-dimensional Array{Any,0}:\n$(Base.undef_ref_str)"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1585,18 +1585,18 @@ end
 end
 
 @testset "0-dimensional Array. Issue #31481" begin
-    for x in (zeros(Int32), collect('b'), fill(nothing), fill(undef))
+    for x in (zeros(Int32), collect('b'), fill(nothing))
         @test eval(Meta.parse(repr(x))) == x
     end
     @test showstr(zeros(Int32)) == "fill(0)"
     @test showstr(collect('b')) == "fill('b')"
     @test showstr(fill(nothing)) == "fill(nothing)"
-    @test showstr(fill(undef)) == "fill(undef)"
-    @test showstr(Array{Any, 0}(undef)) == "fill(undef)"
+    @test showstr(fill(undef)) == "fill($undef)"
+    @test showstr(Array{Any, 0}(undef)) == "fill($undef)"
 
     @test replstr(zeros(Int32)) == "0-dimensional Array{Int32,0}:\n0"
     @test replstr(collect('b')) == "0-dimensional Array{Char,0}:\n'b'"
     @test replstr(fill(nothing)) == "0-dimensional Array{Nothing,0}:\nnothing"
     @test replstr(fill(undef)) == "0-dimensional Array{UndefInitializer,0}:\n$(repr(undef))"
-    @test replstr(Array{Any, 0}(undef)) == "0-dimensional Array{Any,0}:\n#undef"
+    @test replstr(Array{Any, 0}(undef)) == "0-dimensional Array{Any,0}:\n$(Base.undef_ref_str)"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1583,3 +1583,20 @@ end
     @test sdastr(2, 2) == "[2, 3]"
     @test sdastr(3, 3) == "[3, 4, 5]"
 end
+
+@testset "0-dimensional Array. Issue #31481" begin
+    for x in (zeros(Int32), collect('b'), fill(nothing), fill(undef))
+        @test eval(Meta.parse(repr(x))) == x
+    end
+    @test showstr(zeros(Int32)) == "fill(0)"
+    @test showstr(collect('b')) == "fill('b')"
+    @test showstr(fill(nothing)) == "fill(nothing)"
+    @test showstr(fill(undef)) == "fill(undef)"
+    @test showstr(Array{Any, 0}(undef)) == "fill(undef)"
+
+    @test replstr(zeros(Int32)) == "0-dimensional Array{Int32,0}:\n0"
+    @test replstr(collect('b')) == "0-dimensional Array{Char,0}:\n'b'"
+    @test replstr(fill(nothing)) == "0-dimensional Array{Nothing,0}:\nnothing"
+    @test replstr(fill(undef)) == "0-dimensional Array{UndefInitializer,0}:\n$(repr(undef))"
+    @test replstr(Array{Any, 0}(undef)) == "0-dimensional Array{Any,0}:\n#undef"
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1591,7 +1591,7 @@ end
     @test showstr(zeros(Int32)) == "fill(0)"
     @test showstr(collect('b')) == "fill('b')"
     @test showstr(fill(nothing)) == "fill(nothing)"
-    @test showstr(BitArray(0)) == "fill(false)"
+    @test showstr(BitArray(0)) == "BitArray(0)"
 
     @test replstr(zeros(Int32)) == "0-dimensional Array{Int32,0}:\n0"
     @test replstr(collect('b')) == "0-dimensional Array{Char,0}:\n'b'"


### PR DESCRIPTION
- attempt to close #31481
- ~WIP: opening for comments / see if this is the right approach (printing is confusing...)~
- ~needs test~
- potentially needs news?

---

Before (on version 1.2.0):
```julia
# repl display
julia> a = zeros(Int)
0-dimensional Array{Int64,0}:
0

julia> b = collect('b')
0-dimensional Array{Char,0}:
'b'

julia> c = fill(undef)  
0-dimensional Array{UndefInitializer,0}:
array initializer with undefined values

# show
julia> show(a)
0
julia> show(b)
'b'
julia> show(c)
array initializer with undefined values

# repr
julia> repr(a)
"0"

julia> repr(b)
"'b'"

julia> repr(c)
"array initializer with undefined values"

# leads to confusing test output
julia> @test a == 0
Test Failed at REPL[8]:1
  Expression: a == 0
   Evaluated: 0 == 0
ERROR: There was an error during testing
```

this PR: [EDIT: [updated below](https://github.com/JuliaLang/julia/pull/33206#issuecomment-531181035)]
```julia
# repl display (unchanged)
julia> a = zeros(Int)
0-dimensional Array{Int64,0}:
0

julia> b = collect('b')
0-dimensional Array{Char,0}:
'b'

julia> c = fill(undef)
0-dimensional Array{UndefInitializer,0}:
array initializer with undefined values

# show
julia> show(a)
fill(0)
julia> show(b)
fill('b')
julia> show(c) # EDIT: changed below; now `fill(array initializer with undefined values)`
fill(undef)

# repr
julia> repr(a)
"fill(0)"

julia> repr(b)
"fill('b')"

julia> repr(c)  # EDIT: changed below; now `fill(array initializer with undefined values)`
"fill(undef)"

# clearer test output
julia> @test a == 0
Test Failed at REPL[21]:1
  Expression: a == 0
   Evaluated: fill(0) == 0
ERROR: There was an error during testing
```