### PR TITLE
Parseable `repr` for `undef`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-show(io::IO, ::UndefInitializer) = print(io, "array initializer with undefined values")
+function show(io::IO, ::MIME"text/plain", ::UndefInitializer)
+    print(io, "array initializer with undefined values")
+end
 
 # first a few multiline show functions for types defined before the MIME type:
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-function show(io::IO, ::MIME"text/plain", ::UndefInitializer)
-    print(io, "array initializer with undefined values")
+function show(io::IO, ::MIME"text/plain", u::UndefInitializer)
+    print(io, u, ": array initializer with undefined values")
 end
 
 # first a few multiline show functions for types defined before the MIME type:

--- a/test/show.jl
+++ b/test/show.jl
@@ -1541,6 +1541,13 @@ end
 Z = Array{Float64}(undef,0,0)
 @test eval(Meta.parse(repr(Z))) == Z
 
+@testset "show undef" begin
+    # issue  #33204 - Parseable `repr` for `undef`
+    @test eval(Meta.parse(repr(undef))) == undef == UndefInitializer()
+    @test showstr(undef) == "UndefInitializer()"
+    @test occursin("initializer with undefined values", replstr(undef))
+end
+
 # issue #31065, do not print parentheses for nested dot expressions
 @test sprint(Base.show_unquoted, :(foo.x.x)) == "foo.x.x"
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1546,6 +1546,13 @@ Z = Array{Float64}(undef,0,0)
     @test eval(Meta.parse(repr(undef))) == undef == UndefInitializer()
     @test showstr(undef) == "UndefInitializer()"
     @test occursin("initializer with undefined values", replstr(undef))
+
+    vec_undefined = Vector(undef, 2)
+    vec_initialisers = fill(undef, 2)
+    @test showstr(vec_undefined) == "Any[#undef, #undef]"
+    @test showstr(vec_initialisers) == "UndefInitializer[$undef, $undef]"
+    @test replstr(vec_undefined) == "2-element Array{Any,1}:\n #undef\n #undef"
+    @test replstr(vec_initialisers) == "2-element Array{UndefInitializer,1}:\n $undef\n $undef"
 end
 
 # issue #31065, do not print parentheses for nested dot expressions

--- a/test/show.jl
+++ b/test/show.jl
@@ -1545,6 +1545,7 @@ Z = Array{Float64}(undef,0,0)
     # issue  #33204 - Parseable `repr` for `undef`
     @test eval(Meta.parse(repr(undef))) == undef == UndefInitializer()
     @test showstr(undef) == "UndefInitializer()"
+    @test occursin(repr(undef), replstr(undef))
     @test occursin("initializer with undefined values", replstr(undef))
 
     vec_undefined = Vector(undef, 2)


### PR DESCRIPTION
- attempt to resolve #33204 
- ~WIP becuase not sure which tests will need updating~
- Allows us to keep the verbose printing in REPL (i've not changed this text, although we could if others see a benefit to that too) [EDIT: [updated below](https://github.com/JuliaLang/julia/pull/33211#issuecomment-530848285)]
```julia
julia> undef
array initializer with undefined values
```
- But gives us a parseable representation if requested (with `show`/`repr`) -- which is the motivation for the change
```julia
julia> repr(undef)
"UndefInitializer()"
```
- To me (others may disagree), a bonus is we get more familiar Julia syntax in the first case here, which helps to better distinguishes the two cases:
```julia
julia> fill(undef, 2)  # thing you probably don't want - Vector of Initializers
2-element Array{UndefInitializer,1}:
 UndefInitializer()
 UndefInitializer()

julia> Vector(undef, 2)  # thing you probably wanted - Vector of undefined values
2-element Array{Any,1}:
 #undef
 #undef
```
