### PR TITLE
Allow indexing of `SparseMatrixCSC` by array of `CartesianIndex`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -156,7 +156,7 @@ module IteratorsMD
         return I
     end
 
-    Base._ind2sub(t::AbstractArray, ind::CartesianIndex) = Tuple(ind)
+    Base._ind2sub(t::Tuple, ind::CartesianIndex) = Tuple(ind)
 
     # Iteration over the elements of CartesianIndex cannot be supported until its length can be inferred,
     # see #23719

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -156,6 +156,8 @@ module IteratorsMD
         return I
     end
 
+    Base._ind2sub(t, ind::CartesianIndex) = Tuple(ind)
+
     # Iteration over the elements of CartesianIndex cannot be supported until its length can be inferred,
     # see #23719
     Base.iterate(::CartesianIndex) =

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -156,7 +156,7 @@ module IteratorsMD
         return I
     end
 
-    Base._ind2sub(t, ind::CartesianIndex) = Tuple(ind)
+    Base._ind2sub(t::AbstractArray, ind::CartesianIndex) = Tuple(ind)
 
     # Iteration over the elements of CartesianIndex cannot be supported until its length can be inferred,
     # see #23719

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -675,12 +675,9 @@ function getindex(A::AbstractSparseMatrixCSC{Tv,Ti}, I::AbstractVector) where {T
     rowvalB = Vector{Ti}(undef, nnzB)
     nzvalB = Vector{Tv}(undef, nnzB)
 
-    _rowcol(t::Tuple, ind) = Base._ind2sub(t, ind)
-    _rowcol(t::Tuple, ind::CartesianIndex) = (ind[1], ind[2])
-
     idxB = 1
     for i in 1:n
-        row,col = _rowcol(szA, I[i])
+        row,col = Base._ind2sub(szA, I[i])
         for r in colptrA[col]:(colptrA[col+1]-1)
             @inbounds if rowvalA[r] == row
                 if idxB <= nnzB

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -870,6 +870,21 @@ end
         end
     end
 
+    # indexing by array of CartesianIndex (issue #30981)
+    S = sprand(10, 10, 0.4)
+    inds_sparse = S[findall(S .> 0.2)]
+    M = Matrix(S)
+    inds_dense = M[findall(M .> 0.2)]
+    @test Array(inds_sparse) == inds_dense
+    inds_out = Array([CartesianIndex(1, 1), CartesianIndex(0, 1)])
+    @test_throws BoundsError S[inds_out]
+    pop!(inds_out); push!(inds_out, CartesianIndex(1, 0))
+    @test_throws BoundsError S[inds_out]
+    pop!(inds_out); push!(inds_out, CartesianIndex(11, 1))
+    @test_throws BoundsError S[inds_out]
+    pop!(inds_out); push!(inds_out, CartesianIndex(1, 11))
+    @test_throws BoundsError S[inds_out]
+
     # workaround issue #7197: comment out let-block
     #let S = SparseMatrixCSC(3, 3, UInt8[1,1,1,1], UInt8[], Int64[])
     S1290 = SparseMatrixCSC(3, 3, UInt8[1,1,1,1], UInt8[], Int64[])


### PR DESCRIPTION
This PR intends to fix https://github.com/JuliaLang/julia/issues/30981.

I'm not sure if using these nested function definitions `_rowcol` is the right way to do it. If not, let me know what I should do instead.