### PR TITLE
macOS codesigning: only attempt if `$MACOS_CODESIGN_IDENTITY` is set

### DIFF
--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -49,7 +49,12 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	-mkdir -p $@/Contents/Resources/julia
 	make -C $(JULIAHOME) binary-dist
 	tar zxf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
-	-codesign -s "AFB379C0B4CBD9DB9A762797FC2AB5460A2B0DBE" --deep $@
+	if [ -n "$$MACOS_CODESIGN_IDENTITY" ]; then \
+	    echo "Codesigning with identity $$MACOS_CODESIGN_IDENTITY"; \
+		codesign -s "$$MACOS_CODESIGN_IDENTITY" -v --deep $@; \
+	else \
+		true; \
+	fi
 
 ROOTFILES := $(shell ls -ld dmg/*.app *.dmg 2> /dev/null | awk '{print $$3}')
 clean:


### PR DESCRIPTION
This has the following advantages:

* It allows our buildbots to pass in which code signing identity they
want to use (rather than having the identity hash hardcoded in our build
system)

* It stops blindly attempting to codesign on random user's machines

* It causes codesign failure to stop the build