### PR TITLE
Dispatch more cases to BLAS.gemm!

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -154,12 +154,12 @@ function (*)(A::AbstractMatrix, B::AbstractMatrix)
 end
 
 @inline function mul!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
-                      alpha′::Number, beta′::Number) where {T<:BlasFloat}
-    alpha, beta = promote(alpha′, beta′, zero(T))
+                      α::Number, β::Number) where {T<:BlasFloat}
+    alpha, beta = promote(α, β, zero(T))
     if alpha isa T && beta isa T
         return gemm_wrapper!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
     else
-        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha′, beta′))
+        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(α, β))
     end
 end
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -586,7 +586,7 @@ end
     A = rand(n, n)
     B = rand(n, n)
     C = zeros(n, n)
-    mul!(C, A, B, -1, 0)
+    mul!(C, A, B, -1 + 0im, 0)
     D = -A * B
     @test D ≈ C
 


### PR DESCRIPTION
This PR tweaks dispatch of `mul!` so that more combinations of types can use `BLAS.gemm!`.  Namely, alpha and beta does not have to be `BlasFloat` anymore.

After:

```julia
julia> n = 100
       A = rand(n, n)
       B = rand(n, n)
       C = zeros(n, n);

julia> @btime mul!($C, $B, $A, -1, 0);
  31.085 μs (0 allocations: 0 bytes)

julia> @btime mul!($C, $B, $A, -1.0, 0.0);
  31.228 μs (0 allocations: 0 bytes)
```

Before:

```julia
julia> @btime mul!($C, $B, $A, -1, 0);
  704.054 μs (69 allocations: 3.56 KiB)

julia> @btime mul!($C, $B, $A, -1.0, 0.0);
  31.068 μs (0 allocations: 0 bytes)
```

@fredrikekre pointed it out in https://github.com/JuliaLang/LinearAlgebra.jl/issues/663