### PR TITLE
Update latest stable Julia version in README to 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Julia. However, most users should use the most recent stable version
 of Julia. You can get this version by changing to the Julia directory
 and running:
 
-    git checkout v1.1.1
+    git checkout v1.2.0
 
 Now run `make` to build the `julia` executable.
 


### PR DESCRIPTION
Just noticed that this still mentioned 1.1.1 as the latest stable version.