### PR TITLE
Add documentation badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ Code coverage:
 [![coveralls][coveralls-img]](https://coveralls.io/r/JuliaLang/julia?branch=master)
 [![codecov][codecov-img]](https://codecov.io/github/JuliaLang/julia?branch=master)
 
+Documentation:
+[![version 1][docs-img]](https://docs.julialang.org)
+
 [travis-img]: https://img.shields.io/travis/JuliaLang/julia/master.svg?label=Linux+/+macOS
 [appveyor-img]: https://img.shields.io/appveyor/ci/JuliaLang/julia/master.svg?label=Windows
 [coveralls-img]: https://img.shields.io/coveralls/github/JuliaLang/julia/master.svg?label=coveralls
 [codecov-img]: https://img.shields.io/codecov/c/github/JuliaLang/julia/master.svg?label=codecov
+[docs-img]: https://img.shields.io/badge/docs-v1-blue.svg
 
 ## The Julia Language
 


### PR DESCRIPTION
- Seems helpful to me :) makes them nice and prominent
- ~gives direct access to the latest docs (which some people/I sometimes want), as well as the stable docs~
- of course the stable docs are already linked under Resources, but making docs even easier to find seems no bad thing (e.g. we already list coveralls code coverage there and with a badge)