### PR TITLE
Fix dot call in AST docs

### DIFF
--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -59,7 +59,7 @@ call. Finally, chains of comparisons have their own special expression structure
 | `a==b`      | `(call == a b)`           |
 | `1<i<=n`    | `(comparison 1 < i <= n)` |
 | `a.b`       | `(. a (quote b))`         |
-| `a.(b)`     | `(. a b)`                 |
+| `a.(b)`     | `(. a (tuple b))`         |
 
 ### Bracketed forms
 


### PR DESCRIPTION
It seems current documentation

https://github.com/JuliaLang/julia/blob/668341ea6c4eb48d7c550672a3c4c11838003dde/doc/src/devdocs/ast.md#L62

does not match with the implementation:

```lisp
> (julia-parse "a.(b)")
(|.| a (tuple b))
```

```julia
julia> :(a.(b)).args
2-element Array{Any,1}:
 :a
 :((b,))
```
