### PR TITLE
Document that true==1 and false==0

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1431,7 +1431,22 @@ Unsigned
 """
     Bool <: Integer
 
-Boolean type, containing the values `true` (`== 1`) and `false` (`== 0`) .
+Boolean type, containing the values `true` and `false`.
+Note that `Bool` is kind of number and `false` is numerically
+equal to `0` and `true` is numerically equal to `1`.
+Moreover, `false` and acts as a multiplicative "strong zero":
+
+    julia> false == 0
+    true
+
+    julia> true == 1
+    true
+
+    julia> 0 * NaN
+    NaN
+
+    julia> false * NaN
+    0.0
 """
 Bool
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1432,9 +1432,10 @@ Unsigned
     Bool <: Integer
 
 Boolean type, containing the values `true` and `false`.
-Note that `Bool` is kind of number and `false` is numerically
+
+`Bool` is a kind of number: `false` is numerically
 equal to `0` and `true` is numerically equal to `1`.
-Moreover, `false` and acts as a multiplicative "strong zero":
+Moreover, `false` acts as a multiplicative "strong zero":
 
     julia> false == 0
     true

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1437,17 +1437,19 @@ Boolean type, containing the values `true` and `false`.
 equal to `0` and `true` is numerically equal to `1`.
 Moreover, `false` acts as a multiplicative "strong zero":
 
-    julia> false == 0
-    true
+```jldoctest
+julia> false == 0
+true
 
-    julia> true == 1
-    true
+julia> true == 1
+true
 
-    julia> 0 * NaN
-    NaN
+julia> 0 * NaN
+NaN
 
-    julia> false * NaN
-    0.0
+julia> false * NaN
+0.0
+```
 """
 Bool
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1431,7 +1431,7 @@ Unsigned
 """
     Bool <: Integer
 
-Boolean type, containing the values `true` and `false`.
+Boolean type, containing the values `true` (`== 1`) and `false` (`== 0`) .
 """
 Bool
 


### PR DESCRIPTION
Was missing from the docstring for `Bool`.