### PR TITLE
Allow construction of 0x0 Tridiagonal matrix (fixes #26377)

### DIFF
--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -419,7 +419,7 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     function Tridiagonal{T,V}(dl, d, du) where {T,V<:AbstractVector{T}}
         require_one_based_indexing(dl, d, du)
         n = length(d)
-        if (length(dl) != n-1 || length(du) != n-1)
+        if (length(dl) != n-1 || length(du) != n-1) && !(length(d) == 0 && length(dl) == 0 && length(du) == 0)
             throw(ArgumentError(string("cannot construct Tridiagonal from incompatible ",
                 "lengths of subdiagonal, diagonal and superdiagonal: ",
                 "($(length(dl)), $(length(d)), $(length(du)))")))

--- a/stdlib/LinearAlgebra/test/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/test/bunchkaufman.jl
@@ -153,6 +153,22 @@ end
 
 @test_throws DomainError logdet(bunchkaufman([-1 -1; -1 1]))
 @test logabsdet(bunchkaufman([8 4; 4 2]; check = false))[1] == -Inf
-@test isa(bunchkaufman(Symmetric(ones(0,0))), BunchKaufman) # 0x0 matrix
+
+@testset "0x0 matrix" begin
+    for ul in (:U, :L)
+        B = bunchkaufman(Symmetric(ones(0, 0), ul))
+        @test isa(B, BunchKaufman)
+        @test B.D == Tridiagonal([], [], [])
+        @test B.P == ones(0, 0)
+        @test B.p == []
+        if ul == :U
+            @test B.U == UnitUpperTriangular(ones(0, 0))
+            @test_throws ArgumentError B.L
+        else
+            @test B.L == UnitLowerTriangular(ones(0, 0))
+            @test_throws ArgumentError B.U
+        end
+    end
+end
 
 end # module TestBunchKaufman

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -332,4 +332,13 @@ end
     @test (transpose(A) / F') * B ≈ transpose(A)
 end
 
+@testset "0x0 matrix" begin
+    A = ones(0, 0)
+    F = lu(A)
+    @test F.U == ones(0, 0)
+    @test F.L == ones(0, 0)
+    @test F.P == ones(0, 0)
+    @test F.p == []
+end
+
 end # module TestLU


### PR DESCRIPTION
This PR solves the last remaining issue of JuliaLang/LinearAlgebra.jl#508. Prior to this PR it was not possible to display a Bunch-Kaufmann decomposition of an empty matrix, because we could not construct empty tridiagonal matrices:
```julia
julia> bunchkaufman(ones(0,0))
BunchKaufman{Float64,Array{Float64,2}}
D factor:
Error showing value of type BunchKaufman{Float64,Array{Float64,2}}:
ERROR: ArgumentError: cannot construct Tridiagonal from incompatible lengths of subdiagonal, diagonal and superdiagonal: (0, 0, 0)
Stacktrace:
 [1] Type at /build/julia/src/julia-1.2.0/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/tridiag.jl:384 [inlined]
 [2] Type at /build/julia/src/julia-1.2.0/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/tridiag.jl:423 [inlined]
 [3] getproperty(::BunchKaufman{Float64,Array{Float64,2}}, ::Symbol) at /build/julia/src/julia-1.2.0/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/bunchkaufman.jl:231
 [4] show(::IOContext{REPL.Terminals.TTYTerminal}, ::MIME{Symbol("text/plain")}, ::BunchKaufman{Float64,Array{Float64,2}}) at /build/julia/src/julia-1.2.0/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/bunchkaufman.jl:260
 [5] #invokelatest#1 at ./essentials.jl:790 [inlined]
 [6] invokelatest at ./essentials.jl:789 [inlined]
 [7] print_response(::IO, ::Any, ::Bool, ::Bool, ::Any) at /build/julia/src/julia-1.2.0/usr/share/julia/stdlib/v1.2/REPL/src/REPL.jl:156
```

After this PR:
```julia
julia> bunchkaufman(ones(0,0))
BunchKaufman{Float64,Array{Float64,2}}
D factor:
0×0 Tridiagonal{Float64,Array{Float64,1}}
U factor:
0×0 UnitUpperTriangular{Float64,Array{Float64,2}}
permutation:
0-element Array{Int64,1}
```

Furthermore, I have added tests for LU and Bunch-Kaufmann decompositions of `0x0` matrices.

All the other mentioned issues in JuliaLang/LinearAlgebra.jl#508 seem to be solved:
```julia
julia> lu(ones(0,0))
LU{Float64,Array{Float64,2}}
L factor:
0×0 Array{Float64,2}
U factor:
0×0 Array{Float64,2}

julia> tril(ones(0,0), -1)
0×0 Array{Float64,2}

julia> tril(ones(0,0), 0)
0×0 Array{Float64,2}

julia> triu(ones(0,0), 1)
0×0 Array{Float64,2}

julia> triu(ones(0,0), 0)
0×0 Array{Float64,2}
```