### PR TITLE
Make backtrace buffer handling more systematic

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -62,25 +62,39 @@ rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
 struct InterpreterIP
     code::Union{CodeInfo,Core.MethodInstance,Nothing}
     stmt::Csize_t
+    mod::Union{Module,Nothing}
 end
 
-# convert dual arrays (ips, interpreter_frames) to a single array of locations
+# convert dual arrays (raw bt buffer, array of GC managed values) to a single
+# array of locations
 function _reformat_bt(bt, bt2)
     ret = Vector{Union{InterpreterIP,Ptr{Cvoid}}}()
     i, j = 1, 1
     while i <= length(bt)
         ip = bt[i]::Ptr{Cvoid}
-        if UInt(ip) == (-1 % UInt)
-            # The next one is really a CodeInfo
-            push!(ret, InterpreterIP(
-                bt2[j],
-                bt[i+2]))
-            j += 1
-            i += 3
-        else
-            push!(ret, Ptr{Cvoid}(ip))
+        if UInt(ip) != (-1 % UInt) # See also jl_bt_is_native
+            # native frame
+            push!(ret, ip)
             i += 1
+            continue
         end
+        # Extended backtrace entry
+        entry_metadata = reinterpret(UInt, bt[i+1])
+        njlvalues =  entry_metadata & 0x7
+        nuintvals = (entry_metadata >> 3) & 0x7
+        tag       = (entry_metadata >> 6) & 0xf
+        header    =  entry_metadata >> 10
+        if tag == 1 # JL_BT_INTERP_FRAME_TAG
+            code = bt2[j]
+            mod = njlvalues == 2 ? bt2[j+1] : nothing
+            push!(ret, InterpreterIP(code, header, mod))
+        else
+            # Tags we don't know about are an error
+            throw(ArgumentError("Unexpected extended backtrace entry tag $tag at bt[$i]"))
+        end
+        # See jl_bt_entry_size
+        j += njlvalues
+        i += Int(2 + njlvalues + nuintvals)
     end
     ret
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -705,7 +705,7 @@ end
 function show(io::IO, ip::InterpreterIP)
     print(io, typeof(ip))
     if ip.code isa Core.CodeInfo
-        print(io, " in top-level CodeInfo at statement $(Int(ip.stmt))")
+        print(io, " in top-level CodeInfo for $(ip.mod) at statement $(Int(ip.stmt))")
     else
         print(io, " in $(ip.code) at statement $(Int(ip.stmt))")
     end

--- a/src/gc.h
+++ b/src/gc.h
@@ -153,9 +153,10 @@ typedef struct {
 
 // Exception stack data
 typedef struct {
-    jl_excstack_t *s;  // Stack of exceptions
-    size_t itr;        // Iterator into exception stack
-    size_t i;          // Iterator into backtrace data for exception
+    jl_excstack_t *s;   // Stack of exceptions
+    size_t itr;         // Iterator into exception stack
+    size_t bt_index;    // Current backtrace buffer entry index
+    size_t jlval_index; // Index into GC managed values for current bt entry
 } gc_mark_excstack_t;
 
 // Module bindings. This is also the beginning of module scanning.

--- a/src/julia.h
+++ b/src/julia.h
@@ -236,6 +236,13 @@ typedef struct _jl_llvm_functions_t {
 
 typedef struct _jl_method_instance_t jl_method_instance_t;
 
+typedef struct _jl_line_info_node_t {
+    jl_value_t *method;
+    jl_sym_t *file;
+    intptr_t line;
+    intptr_t inlined_at;
+} jl_line_info_node_t;
+
 // This type describes a single function body
 typedef struct _jl_code_info_t {
     // ssavalue-indexed arrays of properties:

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -156,6 +156,7 @@ typedef struct {
 } jl_gc_mark_cache_t;
 
 typedef struct _jl_excstack_t jl_excstack_t;
+struct _jl_bt_element_t;
 // This includes all the thread local states we care about for a thread.
 // Changes to TLS field types must be reflected in codegen.
 #define JL_MAX_BT_SIZE 80000
@@ -193,7 +194,7 @@ struct _jl_tls_states_t {
     // Temp storage for exception thrown in signal handler. Not rooted.
     struct _jl_value_t *sig_exception;
     // Temporary backtrace buffer. Scanned for gc roots when bt_size > 0.
-    uintptr_t *bt_data; // JL_MAX_BT_SIZE + 1 elements long
+    struct _jl_bt_element_t *bt_data; // JL_MAX_BT_SIZE + 1 elements long
     size_t bt_size;    // Size for backtrace in transit in bt_data
     // Atomically set by the sender, reset by the handler.
     volatile sig_atomic_t signal_request;

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -18,7 +18,7 @@ extern "C" {
 #include <threading.h>
 
 // Profiler control variables //
-static volatile intptr_t *bt_data_prof = NULL;
+static volatile jl_bt_element_t *bt_data_prof = NULL;
 static volatile size_t bt_size_max = 0;
 static volatile size_t bt_size_cur = 0;
 static volatile uint64_t nsecprof = 0;
@@ -221,7 +221,7 @@ void jl_show_sigill(void *_ctx)
 }
 
 // what to do on a critical error
-void jl_critical_error(int sig, bt_context_t *context, uintptr_t *bt_data, size_t *bt_size)
+void jl_critical_error(int sig, bt_context_t *context, jl_bt_element_t *bt_data, size_t *bt_size)
 {
     // This function is not allowed to reference any TLS variables.
     // We need to explicitly pass in the TLS buffer pointer when
@@ -230,10 +230,14 @@ void jl_critical_error(int sig, bt_context_t *context, uintptr_t *bt_data, size_
     if (sig)
         jl_safe_printf("\nsignal (%d): %s\n", sig, strsignal(sig));
     jl_safe_printf("in expression starting at %s:%d\n", jl_filename, jl_lineno);
-    if (context)
+    if (context) {
+        // Must avoid extended backtrace frames here unless we're sure bt_data
+        // is properly rooted.
         *bt_size = n = rec_backtrace_ctx(bt_data, JL_MAX_BT_SIZE, context, 0);
-    for (i = 0; i < n; i++)
-        jl_gdblookup(bt_data[i] - 1);
+    }
+    for (i = 0; i < n; i += jl_bt_entry_size(bt_data + i)) {
+        jl_print_bt_entry_codeloc(bt_data + i);
+    }
     gc_debug_print_status();
     gc_debug_critical_error();
 }
@@ -247,7 +251,7 @@ JL_DLLEXPORT int jl_profile_init(size_t maxsize, uint64_t delay_nsec)
     nsecprof = delay_nsec;
     if (bt_data_prof != NULL)
         free((void*)bt_data_prof);
-    bt_data_prof = (intptr_t*) calloc(maxsize, sizeof(intptr_t));
+    bt_data_prof = (jl_bt_element_t*) calloc(maxsize, sizeof(jl_bt_element_t));
     if (bt_data_prof == NULL && maxsize > 0)
         return -1;
     bt_size_cur = 0;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -448,10 +448,10 @@ void *mach_profile_listener(void *arg)
 
                 if (forceDwarf == 0) {
                     // Save the backtrace
-                    bt_size_cur += rec_backtrace_ctx((uintptr_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, 0);
+                    bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, 0);
                 }
                 else if (forceDwarf == 1) {
-                    bt_size_cur += rec_backtrace_ctx_dwarf((uintptr_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, 0);
+                    bt_size_cur += rec_backtrace_ctx_dwarf((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, 0);
                 }
                 else if (forceDwarf == -1) {
                     jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
@@ -459,11 +459,11 @@ void *mach_profile_listener(void *arg)
 
                 forceDwarf = -2;
 #else
-                bt_size_cur += rec_backtrace_ctx((uintptr_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, 0);
+                bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, 0);
 #endif
 
                 // Mark the end of this block with 0
-                bt_data_prof[bt_size_cur++] = 0;
+                bt_data_prof[bt_size_cur++].uintptr = 0;
 
                 // Reset the alarm
                 kern_return_t ret = clock_alarm(clk, TIME_RELATIVE, timerprof, profile_port);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -551,7 +551,7 @@ static void kqueue_signal(int *sigqueue, struct kevent *ev, int sig)
 
 static void *signal_listener(void *arg)
 {
-    static uintptr_t bt_data[JL_MAX_BT_SIZE + 1];
+    static jl_bt_element_t bt_data[JL_MAX_BT_SIZE + 1];
     static size_t bt_size = 0;
     sigset_t sset;
     int sig, critical, profile;
@@ -669,7 +669,7 @@ static void *signal_listener(void *arg)
                 bt_size += rec_backtrace_ctx(bt_data + bt_size,
                         JL_MAX_BT_SIZE / jl_n_threads - 1,
                         signal_context, 0);
-                bt_data[bt_size++] = 0;
+                bt_data[bt_size++].uintptr = 0;
             }
 
             // do backtrace for profiler
@@ -686,13 +686,13 @@ static void *signal_listener(void *arg)
                         jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
                     } else {
                         // Get backtrace data
-                        bt_size_cur += rec_backtrace_ctx((uintptr_t*)bt_data_prof + bt_size_cur,
+                        bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
                                 bt_size_max - bt_size_cur - 1, signal_context, 0);
                     }
                     ptls->safe_restore = old_buf;
 
                     // Mark the end of this block with 0
-                    bt_data_prof[bt_size_cur++] = 0;
+                    bt_data_prof[bt_size_cur++].uintptr = 0;
                 }
                 if (bt_size_cur >= bt_size_max - 1) {
                     // Buffer full: Delete the timer

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -297,7 +297,7 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
                 jl_safe_printf("UNKNOWN"); break;
         }
         jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-        jl_gdblookup((uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+        jl_print_native_codeloc(ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
         jl_critical_error(0, ExceptionInfo->ContextRecord,
                           ptls->bt_data, &ptls->bt_size);
@@ -344,10 +344,10 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     break;
                 }
                 // Get backtrace data
-                bt_size_cur += rec_backtrace_ctx((uintptr_t*)bt_data_prof + bt_size_cur,
+                bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
                     bt_size_max - bt_size_cur - 1, &ctxThread, 0);
                 // Mark the end of this block with 0
-                bt_data_prof[bt_size_cur] = 0;
+                bt_data_prof[bt_size_cur].uintptr = 0;
                 bt_size_cur++;
             }
             if ((DWORD)-1 == ResumeThread(hMainThread)) {

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -45,7 +45,7 @@ static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, uintpt
 //
 // jl_unw_stepn will return 1 if there are more frames to come. The number of
 // elements written to bt_data (and sp if non-NULL) are returned in bt_size.
-int jl_unw_stepn(bt_cursor_t *cursor, uintptr_t *bt_data, size_t *bt_size,
+int jl_unw_stepn(bt_cursor_t *cursor, jl_bt_element_t *bt_data, size_t *bt_size,
                  uintptr_t *sp, size_t maxsize, int skip, int add_interp_frames,
                  int from_signal_handler) JL_NOTSAFEPOINT
 {
@@ -117,17 +117,17 @@ int jl_unw_stepn(bt_cursor_t *cursor, uintptr_t *bt_data, size_t *bt_size,
                 // normal frame
                 call_ip -= 1;
             }
-            if (call_ip == JL_BT_INTERP_FRAME) {
+            if (call_ip == JL_BT_NON_PTR_ENTRY) {
                 // Never leave special marker in the bt data as it can corrupt the GC.
                 call_ip = 0;
             }
-            uintptr_t *bt_entry = bt_data + n;
+            jl_bt_element_t *bt_entry = bt_data + n;
             size_t entry_sz = 0;
             if (add_interp_frames && jl_is_enter_interpreter_frame(call_ip) &&
                 (entry_sz = jl_capture_interp_frame(bt_entry, thesp, thefp, maxsize-n)) != 0) {
                 n += entry_sz;
             } else {
-                *bt_entry = call_ip;
+                bt_entry->uintptr = call_ip;
                 n++;
             }
         }
@@ -149,7 +149,7 @@ int jl_unw_stepn(bt_cursor_t *cursor, uintptr_t *bt_data, size_t *bt_size,
     return need_more_space;
 }
 
-NOINLINE size_t rec_backtrace_ctx(uintptr_t *bt_data, size_t maxsize,
+NOINLINE size_t rec_backtrace_ctx(jl_bt_element_t *bt_data, size_t maxsize,
                                   bt_context_t *context, int add_interp_frames) JL_NOTSAFEPOINT
 {
     bt_cursor_t cursor;
@@ -165,7 +165,7 @@ NOINLINE size_t rec_backtrace_ctx(uintptr_t *bt_data, size_t maxsize,
 //
 // The first `skip` frames are omitted, in addition to omitting the frame from
 // `rec_backtrace` itself.
-NOINLINE size_t rec_backtrace(uintptr_t *bt_data, size_t maxsize, int skip)
+NOINLINE size_t rec_backtrace(jl_bt_element_t *bt_data, size_t maxsize, int skip)
 {
     bt_context_t context;
     memset(&context, 0, sizeof(context));
@@ -217,7 +217,7 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp, int skip)
                 jl_array_grow_end(sp, maxincr);
             }
             size_t size_incr = 0;
-            have_more_frames = jl_unw_stepn(&cursor, (uintptr_t*)jl_array_data(ip) + offset,
+            have_more_frames = jl_unw_stepn(&cursor, (jl_bt_element_t*)jl_array_data(ip) + offset,
                                             &size_incr, sp_ptr, maxincr, skip, 1, 0);
             skip = 0;
             offset += size_incr;
@@ -227,12 +227,18 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp, int skip)
             jl_array_del_end(sp, jl_array_len(sp) - offset);
 
         size_t n = 0;
+        jl_bt_element_t *bt_data = (jl_bt_element_t*)jl_array_data(ip);
         while (n < jl_array_len(ip)) {
-            if ((uintptr_t)jl_array_ptr_ref(ip, n) == JL_BT_INTERP_FRAME) {
-                jl_array_ptr_1d_push(bt2, jl_array_ptr_ref(ip, n+1));
-                n += 2;
+            jl_bt_element_t *bt_entry = bt_data + n;
+            if (!jl_bt_is_native(bt_entry)) {
+                size_t njlvals = jl_bt_num_jlvals(bt_entry);
+                for (size_t j = 0; j < njlvals; j++) {
+                    jl_value_t *v = jl_bt_entry_jlvalue(bt_entry, j);
+                    JL_GC_PROMISE_ROOTED(v);
+                    jl_array_ptr_1d_push(bt2, v);
+                }
             }
-            n++;
+            n += jl_bt_entry_size(bt_entry);
         }
     }
     jl_value_t *bt = returnsp ? (jl_value_t*)jl_svec(3, ip, bt2, sp) : (jl_value_t*)jl_svec(2, ip, bt2);
@@ -240,32 +246,37 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp, int skip)
     return bt;
 }
 
-// note: btout and bt2out must be GC roots
-void decode_backtrace(uintptr_t *bt_data, size_t bt_size,
-                      jl_array_t **btout, jl_array_t **bt2out)
+void decode_backtrace(jl_bt_element_t *bt_data, size_t bt_size,
+                      jl_array_t **btout JL_REQUIRE_ROOTED_SLOT,
+                      jl_array_t **bt2out JL_REQUIRE_ROOTED_SLOT)
 {
     jl_array_t *bt, *bt2;
     if (array_ptr_void_type == NULL) {
         array_ptr_void_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_voidpointer_type, jl_box_long(1));
     }
     bt = *btout = jl_alloc_array_1d(array_ptr_void_type, bt_size);
-    memcpy(bt->data, bt_data, bt_size * sizeof(void*));
+    static_assert(sizeof(jl_bt_element_t) == sizeof(void*),
+                  "jl_bt_element_t is presented as Ptr{Cvoid} on julia side");
+    memcpy(bt->data, bt_data, bt_size * sizeof(jl_bt_element_t));
     bt2 = *bt2out = jl_alloc_array_1d(jl_array_any_type, 0);
-    // Scan the stack for any interpreter frames
-    size_t n = 0;
-    while (n < bt_size) {
-        if (bt_data[n] == JL_BT_INTERP_FRAME) {
-            jl_array_ptr_1d_push(bt2, (jl_value_t*)bt_data[n+1]);
-            n += 2;
+    // Scan the backtrace buffer for any gc-managed values
+    for (size_t i = 0; i < bt_size; i += jl_bt_entry_size(bt_data + i)) {
+        jl_bt_element_t* bt_entry = bt_data + i;
+        if (jl_bt_is_native(bt_entry))
+            continue;
+        size_t njlvals = jl_bt_num_jlvals(bt_entry);
+        for (size_t j = 0; j < njlvals; j++) {
+            jl_value_t *v = jl_bt_entry_jlvalue(bt_entry, j);
+            JL_GC_PROMISE_ROOTED(v);
+            jl_array_ptr_1d_push(bt2, v);
         }
-        n++;
     }
 }
 
 JL_DLLEXPORT jl_value_t *jl_get_backtrace(void)
 {
     jl_excstack_t *s = jl_get_ptls_states()->current_task->excstack;
-    uintptr_t *bt_data = NULL;
+    jl_bt_element_t *bt_data = NULL;
     size_t bt_size = 0;
     if (s && s->top) {
         bt_data = jl_excstack_bt_data(s, s->top);
@@ -519,7 +530,7 @@ static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, uintpt
 }
 
 #ifdef LIBOSXUNWIND
-NOINLINE size_t rec_backtrace_ctx_dwarf(uintptr_t *bt_data, size_t maxsize,
+NOINLINE size_t rec_backtrace_ctx_dwarf(jl_bt_element_t *bt_data, size_t maxsize,
                                         bt_context_t *context, int add_interp_frames)
 {
     size_t bt_size = 0;
@@ -577,8 +588,22 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
     return rs;
 }
 
-//for looking up functions from gdb:
-JL_DLLEXPORT void jl_gdblookup(uintptr_t ip)
+void jl_safe_print_codeloc(const char* func_name, const char* file_name,
+                           int line, int inlined) JL_NOTSAFEPOINT
+{
+    const char *inlined_str = inlined ? " [inlined]" : "";
+    if (line != -1) {
+        jl_safe_printf("%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
+    }
+    else {
+        jl_safe_printf("%s at %s (unknown line)%s\n", func_name, file_name, inlined_str);
+    }
+}
+
+// Print function, file and line containing native instruction pointer `ip` by
+// looking up debug info. Prints multiple such frames when `ip` points to
+// inlined code.
+void jl_print_native_codeloc(uintptr_t ip) JL_NOTSAFEPOINT
 {
     // This function is not allowed to reference any TLS variables since
     // it can be called from an unmanaged thread on OSX.
@@ -593,15 +618,7 @@ JL_DLLEXPORT void jl_gdblookup(uintptr_t ip)
             jl_safe_printf("unknown function (ip: %p)\n", (void*)ip);
         }
         else {
-            const char *inlined = frame.inlined ? " [inlined]" : "";
-            if (frame.line != -1) {
-                jl_safe_printf("%s at %s:%" PRIuPTR "%s\n", frame.func_name,
-                    frame.file_name, (uintptr_t)frame.line, inlined);
-            }
-            else {
-                jl_safe_printf("%s at %s (unknown line)%s\n", frame.func_name,
-                    frame.file_name, inlined);
-            }
+            jl_safe_print_codeloc(frame.func_name, frame.file_name, frame.line, frame.inlined);
             free(frame.func_name);
             free(frame.file_name);
         }
@@ -609,22 +626,70 @@ JL_DLLEXPORT void jl_gdblookup(uintptr_t ip)
     free(frames);
 }
 
+// Print code location for backtrace buffer entry at *bt_entry
+void jl_print_bt_entry_codeloc(jl_bt_element_t *bt_entry) JL_NOTSAFEPOINT
+{
+    if (jl_bt_is_native(bt_entry)) {
+        jl_print_native_codeloc(bt_entry[0].uintptr);
+    }
+    else if (jl_bt_entry_tag(bt_entry) == JL_BT_INTERP_FRAME_TAG) {
+        size_t ip = jl_bt_entry_header(bt_entry);
+        jl_value_t *code = jl_bt_entry_jlvalue(bt_entry, 0);
+        if (jl_is_method_instance(code)) {
+            // When interpreting a method instance, need to unwrap to find the code info
+            code = ((jl_method_instance_t*)code)->uninferred;
+        }
+        if (jl_is_code_info(code)) {
+            jl_code_info_t *src = (jl_code_info_t*)code;
+            // See also the debug info handling in codegen.cpp.
+            // NB: debuginfoloc is 1-based!
+            intptr_t debuginfoloc = ((int32_t*)jl_array_data(src->codelocs))[ip];
+            while (debuginfoloc != 0) {
+                jl_line_info_node_t *locinfo = (jl_line_info_node_t*)
+                    jl_array_ptr_ref(src->linetable, debuginfoloc - 1);
+                assert(jl_typeis(locinfo, jl_lineinfonode_type));
+                jl_value_t *method = locinfo->method;
+                if (jl_is_method_instance(method)) {
+                    method = ((jl_method_instance_t*)method)->def.value;
+                    if (jl_is_method(method))
+                        method = (jl_value_t*)((jl_method_t*)method)->name;
+                }
+                const char *func_name = jl_is_symbol(method) ?
+                                        jl_symbol_name((jl_sym_t*)method) : "Unknown";
+                jl_safe_print_codeloc(func_name, jl_symbol_name(locinfo->file),
+                                      locinfo->line, locinfo->inlined_at);
+                debuginfoloc = locinfo->inlined_at;
+            }
+        }
+        else {
+            // If we're using this function something bad has already happened;
+            // be a bit defensive to avoid crashing while reporting the crash.
+            jl_safe_printf("No code info - unknown interpreter state!\n");
+        }
+    }
+    else {
+        jl_safe_printf("Non-native bt entry with tag and header bits 0x%" PRIxPTR "\n",
+                       bt_entry[1].uintptr);
+    }
+}
+
+//--------------------------------------------------
+// Tools for interactive debugging in gdb
+JL_DLLEXPORT void jl_gdblookup(void* ip)
+{
+    jl_print_native_codeloc((uintptr_t)ip);
+}
+
+// Print backtrace for current exception in catch block
 JL_DLLEXPORT void jlbacktrace(void) JL_NOTSAFEPOINT
 {
     jl_excstack_t *s = jl_get_ptls_states()->current_task->excstack;
     if (!s)
         return;
     size_t bt_size = jl_excstack_bt_size(s, s->top);
-    uintptr_t *bt_data = jl_excstack_bt_data(s, s->top);
-    for (size_t i = 0; i < bt_size; ) {
-        if (bt_data[i] == JL_BT_INTERP_FRAME) {
-            jl_safe_printf("Interpreter frame (ip: %d)\n", (int)bt_data[i+2]);
-            jl_static_show(JL_STDERR, (jl_value_t*)bt_data[i+1]);
-            i += 3;
-        } else {
-            jl_gdblookup(bt_data[i] - 1);
-            i += 1;
-        }
+    jl_bt_element_t *bt_data = jl_excstack_bt_data(s, s->top);
+    for (size_t i = 0; i < bt_size; i += jl_bt_entry_size(bt_data + i)) {
+        jl_print_bt_entry_codeloc(bt_data + i);
     }
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -518,7 +518,7 @@ JL_DLLEXPORT void jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED)
     if (!excstack || excstack->top == 0)
         jl_error("rethrow(exc) not allowed outside a catch block");
     // overwrite exception on top of stack. see jl_excstack_exception
-    jl_excstack_raw(excstack)[excstack->top-1] = (uintptr_t)e;
+    jl_excstack_raw(excstack)[excstack->top-1].jlvalue = e;
     JL_GC_PROMISE_ROOTED(e);
     throw_internal(NULL);
 }
@@ -673,7 +673,7 @@ STATIC_OR_JS void NOINLINE JL_NORETURN start_task(void)
     if (t->exception != jl_nothing) {
         record_backtrace(ptls, 0);
         jl_push_excstack(&t->excstack, t->exception,
-                          ptls->bt_data, ptls->bt_size);
+                         ptls->bt_data, ptls->bt_size);
         res = t->exception;
     }
     else {

--- a/src/threading.c
+++ b/src/threading.c
@@ -262,14 +262,15 @@ void jl_init_threadtls(int16_t tid)
                                     sizeof(size_t));
     }
     ptls->defer_signal = 0;
-    void *bt_data = malloc(sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
+    jl_bt_element_t *bt_data = (jl_bt_element_t*)
+        malloc(sizeof(jl_bt_element_t) * (JL_MAX_BT_SIZE + 1));
     if (bt_data == NULL) {
         jl_printf(JL_STDERR, "could not allocate backtrace buffer\n");
         gc_debug_critical_error();
         abort();
     }
-    memset(bt_data, 0, sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
-    ptls->bt_data = (uintptr_t*)bt_data;
+    memset(bt_data, 0, sizeof(jl_bt_element_t) * (JL_MAX_BT_SIZE + 1));
+    ptls->bt_data = bt_data;
     ptls->sig_exception = NULL;
     ptls->previous_exception = NULL;
 #ifdef _OS_WINDOWS_

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -255,6 +255,6 @@ let code = """
 
     bt_str = read(`$(Base.julia_cmd()) --startup-file=no --compile=min -e $code`, String)
     @test occursin("InterpreterIP in MethodInstance for foo", bt_str)
-    @test occursin("InterpreterIP in top-level CodeInfo", bt_str)
+    @test occursin("InterpreterIP in top-level CodeInfo for Main.A", bt_str)
 end
 


### PR DESCRIPTION
Increase expressibility of what can be stored in backtrace buffers, while ensuring that the GC can find roots without knowing about the detail.

To do this, introduce a new "extended backtrace entry" format which carries along the number of roots and other data in a bitpacked format. This allows the backtrace buffer to be traversed and the roots collected in a general way, without the GC knowing about interpreter frames. Use
this to add the module to InterperterIP so that the module of interpreted top level thunks can be known (this is infrastructure to help with #33065.)

In the future the extended entry format should allow us to be a lot more flexible with what can be stored in a backtrace. For example, we could
* Compress the backtrace cycles of runaway recursive functions so that stack overflows are much more likely to fit in the fixed-size bt_data array.
* Integrate external or other types of interpreter frames into the backtrace machinery.

## Implementation details

[Edit] To quote the code comments regarding the buffer format:

A backtrace buffer conceptually contains a stack of instruction pointers ordered from the inner-most frame to the outermost. We store them in a special raw format for two reasons:

  * Efficiency: Every `throw()` must populate the trace so it must be as efficient as possible.
  * Signal safety: For signal-based exceptions such as StackOverflowError the trace buffer needs to be filled from a signal handler where most operations are not allowed (including malloc) so we choose a flat preallocated buffer.

The raw buffer layout contains "frame entries" composed of one or several `jl_bt_element_t` values. From the point of view of the GC, an entry is either:

1. A single instruction pointer to native code, not GC-managed.
2. An "extended entry": a mixture of raw data and pointers to julia objects which must be treated as GC roots.

An extended entry `e` is made up of several `jl_bt_element_t` values:

* `e[0]  JL_BT_NON_PTR_ENTRY` - Special marker to distinguish extended entries
* `e[1]  tags               ` - A bit packed uintptr_t containing a tag and the number of GC- managed and non-managed values
* `e[2+j]                   ` - GC managed data
* `e[2+ngc+i]               ` - Non-GC-managed data

The format of `tags` is, from LSB to MSB:

* `0:2     ngc   ` - Number of GC-managed pointers for this frame entry
* `3:5     nptr  ` - Number of non-GC-managed buffer elements
* `6:9     tag   ` - Entry type
* `10:...  header` - Entry-specific header data
