### PR TITLE
add more about docblocks

### DIFF
--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -1,5 +1,3 @@
-
-
 # Markdown
 
 This section describes Julia's markdown syntax, which is enabled by the

--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -1,3 +1,5 @@
+
+
 # Markdown
 
 This section describes Julia's markdown syntax, which is enabled by the
@@ -364,12 +366,38 @@ They can be defined using the following `!!!` syntax:
     This warning admonition has a custom title: `"Beware!"`.
 ```
 
-The type of the admonition can be any word, but some types produce special styling,
+The type of the admonition can be any lowercase word, but some types produce special styling,
 namely (in order of decreasing severity): `danger`, `warning`, `info`/`note`, and `tip`.
 
 A custom title for the box can be provided as a string (in double quotes) after the admonition type.
-If no title text is specified after the admonition type, then the title used will be the type of the block,
-i.e. `"Note"` in the case of the `note` admonition.
+If no title text is specified after the admonition type, then for the default blocks mentions above
+the title used will be the type of the block, i.e. `"Note"` in the case of the `note` admonition.
+
+If you would like to define your own block, for example a `terminology`  block
+used like so:
+```
+!!! terminology julia vs Julia
+    Strictly speaking, Julia refers to the language,
+    and julia the standard implementation.
+```
+
+Then you can overwrite the default (grey) styling to (for example) yellow,
+with the word `Terminology` in the title, by adding the CSS:
+
+```
+div.admonition.terminology div.admonition-title:before {
+  content: "Terminology: ";
+  font-family: 'Lato', 'Helvetica Neue', Arial, sans-serif;
+  font-weight: bold;
+}
+div.admonition.terminology div.admonition-title {
+  background-color: #FFEC8B;
+}
+
+div.admonition.terminology div.admonition-text {
+  background-color: #FFFEDD;
+}
+```
 
 Admonitions, like most other toplevel elements, can contain other toplevel elements.
 

--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -364,7 +364,7 @@ They can be defined using the following `!!!` syntax:
     This warning admonition has a custom title: `"Beware!"`.
 ```
 
-The type of the admonition can be any lowercase word, but some types produce special styling,
+The type of the admonition can be any word made up of only lowercase Latin characters (a-z), but some types produce special styling,
 namely (in order of decreasing severity): `danger`, `warning`, `info`, `note`, and `tip`.
 
 A custom title for the box can be provided as a string (in double quotes) after the admonition type.

--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -374,7 +374,7 @@ the title used will be the type of the block, i.e. `"Note"` in the case of the `
 If you would like to define your own block, for example a `terminology`  block
 used like so:
 ```
-!!! terminology julia vs Julia
+!!! terminology "julia vs Julia"
     Strictly speaking, Julia refers to the language,
     and julia the standard implementation.
 ```

--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -365,11 +365,12 @@ They can be defined using the following `!!!` syntax:
 ```
 
 The type of the admonition can be any lowercase word, but some types produce special styling,
-namely (in order of decreasing severity): `danger`, `warning`, `info`/`note`, and `tip`.
+namely (in order of decreasing severity): `danger`, `warning`, `info`, `note`, and `tip`.
 
 A custom title for the box can be provided as a string (in double quotes) after the admonition type.
-If no title text is specified after the admonition type, then for the default blocks mentions above
-the title used will be the type of the block, i.e. `"Note"` in the case of the `note` admonition.
+For that standard types (`danger`, `warning`... etc_, if no title text is specified after the
+admonition type, then the type title used will be the type of the block.
+E.g. `"Note"` in the case of the `note` admonition.
 
 If you would like to define your own block, for example a `terminology`  block
 used like so:
@@ -377,24 +378,6 @@ used like so:
 !!! terminology "julia vs Julia"
     Strictly speaking, Julia refers to the language,
     and julia the standard implementation.
-```
-
-Then you can overwrite the default (grey) styling to (for example) yellow,
-with the word `Terminology` in the title, by adding the CSS:
-
-```
-div.admonition.terminology div.admonition-title:before {
-  content: "Terminology: ";
-  font-family: 'Lato', 'Helvetica Neue', Arial, sans-serif;
-  font-weight: bold;
-}
-div.admonition.terminology div.admonition-title {
-  background-color: #FFEC8B;
-}
-
-div.admonition.terminology div.admonition-text {
-  background-color: #FFFEDD;
-}
 ```
 
 Admonitions, like most other toplevel elements, can contain other toplevel elements.


### PR DESCRIPTION
docs that:
 - must be lower-case
 - title is only used for default blocks
 - how to customize