### PR TITLE
RFC: showarg: add AbstractArray specialization

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1954,6 +1954,11 @@ function showarg(io::IO, a::Array{Union{}}, toplevel)
 end
 
 # Container specializations
+function showarg(io::IO, a::AbstractArray{T, N}, toplevel) where {T, N}
+    toplevel || print(io, "::")
+    print(io, typeof(a).name, "{eltype=", T, ", ndims=", N, "}")
+    toplevel || print(io, "")
+end
 function showarg(io::IO, v::SubArray, toplevel)
     print(io, "view(")
     showarg(io, parent(v), false)


### PR DESCRIPTION
While watching someone do a interactive demo one day at https://www.meetup.com/julia-cajun, I felt this REPL printing just didn't feel quite right (see examples below). We've customized the show to highlight the most relevant information about the structure of the data, but weren't doing anything for for the types (by default). I thought this might give a much better summary read by showing just the AbstractArray API (T and N) instead of dumping the whole leaf type structure by default.

Vote below for your preference! Let's say 👍 for option (a), 😃 for option (b) and 👎 for keeping the status quo and not breaking the whole ecosystem of tests for `repr(::Array)`?

Current printing:
```
julia> using LinearAlgebra

julia> adjoint(view(Diagonal([1, 2]), :, :))
2×2 Adjoint{Int64,SubArray{Int64,2,Diagonal{Int64,Array{Int64,1}},Tuple{Base.Slice{Base.OneTo{Int64}},Base.Slice{Base.OneTo{Int64}}},false}}:
 1  0
 0  2

julia> view(Diagonal([1, 2]), :, :)
2×2 view(::Diagonal{Int64,Array{Int64,1}}, :, :) with eltype Int64:
 1  0
 0  2

julia> Diagonal([1, 2])
2×2 Diagonal{Int64,Array{Int64,1}}:
 1  ⋅
 ⋅  2

julia> [1 2]
1×2 Array{Int64,2}:
 1  2
```

Option (a):
```
julia> Revise.track(Base)

julia> adjoint(view(Diagonal([1, 2]), :, :))
2×2 Adjoint{eltype=Int64, ndims=2}:
 1  0
 0  2

julia> view(Diagonal([1, 2]), :, :)
2×2 view(::Diagonal{eltype=Int64, ndims=2}, :, :) with eltype Int64:
 1  0
 0  2

julia> Diagonal([1, 2])
2×2 Diagonal{eltype=Int64, ndims=2}:
 1  ⋅
 ⋅  2

julia> [1 2]
1×2 Array{eltype=Int64, ndims=2}:
 1  2
```

Option (b): same information, just with different formatting:
```
2×2 view(::(Diagonal with eltype Int64 in 2-d), :, :) with eltype Int64:
2×2 Adjoint with eltype Int64 in 2-d:
2×2 Diagonal with eltype Int64 in 2-d:
1×2 Array with eltype Int64 in 2-d:
```

Opening as draft, since I'd still need to go back and fix all of the doc-tests and a handful of show tests.