### PR TITLE
Array fixes for non-power-of-2 sized elements

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -156,6 +156,9 @@ static inline jl_array_t *_new_array(jl_value_t *atype, uint32_t ndims, size_t *
         elsz = sizeof(void*);
         al = elsz;
     }
+    else {
+        elsz = LLT_ALIGN(elsz, al);
+    }
 
     return _new_array_(atype, ndims, dims, isunboxed, isunion, elsz);
 }
@@ -207,7 +210,7 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
     int isboxed = !jl_islayout_inline(eltype, &elsz, &align);
     assert(isboxed == data->flags.ptrarray);
     if (!isboxed) {
-        a->elsize = elsz;
+        a->elsize = LLT_ALIGN(elsz, align);
         jl_value_t *ownerty = jl_typeof(owner);
         size_t oldelsz = 0, oldalign = 0;
         if (ownerty == (jl_value_t*)jl_string_type) {
@@ -323,7 +326,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
 #ifdef STORE_ARRAY_LEN
     a->length = nel;
 #endif
-    a->elsize = elsz;
+    a->elsize = LLT_ALIGN(elsz, align);
     a->flags.ptrarray = !isunboxed;
     a->flags.ndims = 1;
     a->flags.isshared = 1;
@@ -389,7 +392,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
 #ifdef STORE_ARRAY_LEN
     a->length = nel;
 #endif
-    a->elsize = elsz;
+    a->elsize = LLT_ALIGN(elsz, align);
     a->flags.ptrarray = !isunboxed;
     a->flags.ndims = ndims;
     a->offset = 0;

--- a/src/julia.h
+++ b/src/julia.h
@@ -173,7 +173,7 @@ JL_EXTENSION typedef struct {
     size_t length;
 #endif
     jl_array_flags_t flags;
-    uint16_t elsize;
+    uint16_t elsize;  // element size including alignment (dim 1 memory stride)
     uint32_t offset;  // for 1-d only. does not need to get big.
     size_t nrows;
     union {

--- a/test/core.jl
+++ b/test/core.jl
@@ -6461,6 +6461,31 @@ let A=[0, missing], B=[missing, 0], C=Vector{Union{Int, Missing}}(undef, 6)
     @test isequal(C, [0, missing, missing, missing, 0, missing])
 end
 
+# non-power-of-2 element sizes, issue #26026
+primitive type TypeWith24Bits 24 end
+TypeWith24Bits(x::UInt32) = Core.Intrinsics.trunc_int(TypeWith24Bits, x)
+let x = TypeWith24Bits(0x112233), y = TypeWith24Bits(0x445566), z = TypeWith24Bits(0x778899)
+    a = [x, x]
+    Core.arrayset(true, a, y, 2)
+    @test a == [x, y]
+    a[2] = z
+    @test a == [x, z]
+    @test pointer(a, 2) - pointer(a, 1) == 4
+
+    b = [(x, x), (x, x)]
+    Core.arrayset(true, b, (x, y), 2)
+    @test b == [(x, x), (x, y)]
+    b[2] = (y, z)
+    @test b == [(x, x), (y, z)]
+
+    V = Vector{TypeWith24Bits}(undef, 1000)
+    p = Ptr{UInt8}(pointer(V))
+    for i = 1:sizeof(V)
+        unsafe_store!(p, i % UInt8, i)
+    end
+    @test V[1:4] == [TypeWith24Bits(0x030201), TypeWith24Bits(0x070605), TypeWith24Bits(0x0b0a09), TypeWith24Bits(0x0f0e0d)]
+end
+
 # issue #29718
 function f29718()
     nt = NamedTuple{(:a, :b, :c, :d, :e, :f,),


### PR DESCRIPTION
Before:
```
julia> primitive type TypeWith24Bits 24 end

julia> x = Core.Intrinsics.trunc_int(TypeWith24Bits, 0x112233); a = [x,x];

julia> Core.arrayset(true, a, x, 2)
2-element Array{TypeWith24Bits,1}:
 TypeWith24Bits(0x112233)
 TypeWith24Bits(0x111122)
```

After: works.

Fixes https://github.com/JuliaComputing/JuliaDB.jl/issues/287#issuecomment-507281028