### PR TITLE
Correct doc for \U escape sequence under Base/Strings/unescape_string

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -382,7 +382,8 @@ The following escape sequences are recognised:
  - Escaped backslash (`\\\\`)
  - Escaped double-quote (`\\\"`)
  - Standard C escape sequences (`\\a`, `\\b`, `\\t`, `\\n`, `\\v`, `\\f`, `\\r`, `\\e`)
- - Unicode code points (`\\u` or `\\U` prefixes with 1-4 trailing hex digits)
+ - Unicode BMP code points (`\\u` with 1-4 trailing hex digits)
+ - All Unicode code points (`\\U` with 1-8 trailing hex digits; max value = 0010ffff)
  - Hex bytes (`\\x` with 1-2 trailing hex digits)
  - Octal bytes (`\\` with 1-3 trailing octal digits)
 


### PR DESCRIPTION
The `\U` escape sequence, which can take 1 - 8 hex digits, was presented as a duplicate of the `\u` escape sequence, which can only take 1 - 4 hex digits. I separated `\u` from `\U` so it would be easier to clarify the distinction between them. Also, added "max value" for `\U` since unlike `\x`, octal, and `\u` sequences, the max value for `\U` is _not_ the max of all 8 hex digits (i.e. `ffffffff` ).