### PR TITLE
Recommend against using the form rethrow(e) in docs

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -43,10 +43,18 @@ function error(s::Vararg{Any,N}) where {N}
 end
 
 """
-    rethrow([e])
+    rethrow()
 
-Throw an object without changing the current exception backtrace. The default argument is
-the current exception (if called within a `catch` block).
+Rethrow the current exception from within a `catch` block. The rethrown
+exception will continue propagation as if it had not been caught.
+
+!!! note
+    The alternative form `rethrow(e)` allows you to associate an alternative
+    exception object `e` with the current backtrace. However this misrepresents
+    the program state at the time of the error so you're encouraged to instead
+    throw a new exception using `throw(e)`. In Julia 1.1 and above, using
+    `throw(e)` will preserve the root cause exception on the stack, as
+    described in [`catch_stack`](@ref).
 """
 rethrow() = ccall(:jl_rethrow, Bottom, ())
 rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)


### PR DESCRIPTION
This form misrepresents what the program state was at the error site, and is largely obsoleted by the catch_stack functionality.

See also https://github.com/JuliaLang/julia/issues/29792