### PR TITLE
Allow indexing into Tuple by another Tuple

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -23,6 +23,7 @@ size(@nospecialize(t::Tuple), d::Integer) = (d == 1) ? length(t) : throw(Argumen
 axes(@nospecialize t::Tuple) = (OneTo(length(t)),)
 @eval getindex(@nospecialize(t::Tuple), i::Int) = getfield(t, i, $(Expr(:boundscheck)))
 @eval getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
+getindex(t::Tuple, r::Tuple) = ([t[ri] for ri in r]...,)
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = ([t[ri] for ri in r]...,)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t, findall(b)) : throw(BoundsError(t, b))
 getindex(t::Tuple, c::Colon) = t


### PR DESCRIPTION
Seems like this behavior would be an added convenience.
Could also allow indexing into AbstractArray by Tuple. Indexing into Tuple by AbstractArray is already supported.
Wanted to get some feedback on whether there are any downsides to this feature before working on whatever other changes need to be made for this to be accepted.

``` jl
julia> t = tuple((10 .* (1:5))...)
(10, 20, 30, 40, 50)

julia> r = (2,4)
(2, 4)

julia> t[r]
(20, 40)
```

To try locally without incorporating this change:
``` jl
Base.getindex(t::Tuple, r::Tuple) = ([t[ri] for ri in r]...,)
```