### PR TITLE
RFC: Add weights argument to sum

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -380,6 +380,7 @@ include("bitarray.jl")
 include("ldlt.jl")
 include("schur.jl")
 include("structuredbroadcast.jl")
+include("wsum.jl")
 include("deprecated.jl")
 
 const ⋅ = dot

--- a/stdlib/LinearAlgebra/src/wsum.jl
+++ b/stdlib/LinearAlgebra/src/wsum.jl
@@ -1,0 +1,94 @@
+# Optimized method for weighted sum with BlasReal
+# dot cannot be used for other types as it uses + rather than add_sum for accumulation,
+# and therefore does not return the correct type
+Base._sum(A::AbstractArray{T}, dims::Colon, w::AbstractArray{T}) where {T<:BlasReal} =
+    dot(vec(A), vec(w))
+
+# Optimized methods for weighted sum over dimensions with BlasReal
+# (generic method is defined in base/reducedim.jl)
+#
+#  _wsum! is specialized for following cases:
+#     (a) A is a dense matrix with eltype <: BlasReal: we call gemv!
+#         The internal function that implements this is _wsum2_blas!
+#
+#     (b) A is a contiguous array with eltype <: BlasReal:
+#         dim == 1: treat A like a matrix of size (d1, d2 x ... x dN)
+#         dim == N: treat A like a matrix of size (d1 x ... x d(N-1), dN)
+#         otherwise: decompose A into multiple pages, and apply _wsum2_blas!
+#         for each
+#         The internal function that implements this is _wsumN!
+#
+#     (c) A is a general dense array with eltype <: BlasReal:
+#         dim <= 2: delegate to (a) and (b)
+#         otherwise, decompose A into multiple pages
+#         The internal function that implements this is _wsumN!
+
+function _wsum2_blas!(R::StridedVector{T}, A::StridedMatrix{T}, w::StridedVector{T},
+                      dim::Int, init::Bool) where T<:BlasReal
+    beta = ifelse(init, zero(T), one(T))
+    trans = dim == 1 ? 'T' : 'N'
+    BLAS.gemv!(trans, one(T), A, w, beta, R)
+    return R
+end
+
+function _wsumN!(R::StridedArray{T}, A::StridedArray{T,N}, w::StridedVector{T},
+                 dim::Int, init::Bool) where {T<:BlasReal,N}
+    if dim == 1
+        m = size(A, 1)
+        n = div(length(A), m)
+        _wsum2_blas!(view(R,:), reshape(A, (m, n)), w, 1, init)
+    elseif dim == N
+        n = size(A, N)
+        m = div(length(A), n)
+        _wsum2_blas!(view(R,:), reshape(A, (m, n)), w, 2, init)
+    else # 1 < dim < N
+        m = 1
+        for i = 1:dim-1
+            m *= size(A, i)
+        end
+        n = size(A, dim)
+        k = 1
+        for i = dim+1:N
+            k *= size(A, i)
+        end
+        Av = reshape(A, (m, n, k))
+        Rv = reshape(R, (m, k))
+        for i = 1:k
+            _wsum2_blas!(view(Rv,:,i), view(Av,:,:,i), w, 2, init)
+        end
+    end
+    return R
+end
+
+function _wsumN!(R::StridedArray{T}, A::DenseArray{T,N}, w::StridedVector{T},
+                 dim::Int, init::Bool) where {T<:BlasReal,N}
+    @assert N >= 3
+    if dim <= 2
+        m = size(A, 1)
+        n = size(A, 2)
+        npages = 1
+        for i = 3:N
+            npages *= size(A, i)
+        end
+        rlen = ifelse(dim == 1, n, m)
+        Rv = reshape(R, (rlen, npages))
+        for i = 1:npages
+            _wsum2_blas!(view(Rv,:,i), view(A,:,:,i), w, dim, init)
+        end
+    else
+        Base._wsum_general!(R, A, w, dim, init)
+    end
+    return R
+end
+
+Base._wsum!(R::StridedArray{T}, A::DenseMatrix{T}, w::StridedVector{T},
+            dim::Int, init::Bool) where {T<:BlasReal} =
+    _wsum2_blas!(view(R,:), A, w, dim, init)
+
+Base._wsum!(R::StridedArray{T}, A::DenseArray{T}, w::StridedVector{T},
+            dim::Int, init::Bool) where {T<:BlasReal} =
+    _wsumN!(R, A, w, dim, init)
+
+Base._wsum!(R::StridedVector{T}, A::DenseArray{T}, w::StridedVector{T},
+            dim::Int, init::Bool) where {T<:BlasReal} =
+    Base._wsum1!(R, A, w, init)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -533,3 +533,38 @@ x = [j^2 for j in i]
 i = Base.Slice(0:0)
 x = [j+7 for j in i]
 @test sum(x) == 7
+
+@testset "weighted sum" begin
+    wts = ([1.4, 2.5, 10.1], [1.4f0, 2.5f0, 10.1f0], [0.0, 2.3, 5.6],
+           [NaN, 2.3, 5.6], [Inf, 2.3, 5.6],
+           [2, 1, 3], Int8[1, 2, 3], [1, 1, 1])
+    for a in (rand(3), rand(Int, 3), rand(Int8, 3))
+        for w in wts
+            res = @inferred sum(a, weights=w)
+            expected = sum(a.*w)
+            if isfinite(res)
+                @test res ≈ expected
+            else
+                @test isequal(res, expected)
+            end
+            @test typeof(res) == typeof(expected)
+        end
+    end
+    for a in (rand(3, 5), rand(Float32, 3, 5), rand(Int, 3, 5), rand(Int8, 3, 5))
+        for w in wts
+            wr = repeat(w, outer=(1, 5))
+            res = @inferred sum(a, weights=wr)
+            expected = sum(a.*wr)
+            if isfinite(res)
+                @test res ≈ expected
+            else
+                @test isequal(res, expected)
+            end
+            @test typeof(res) == typeof(expected)
+        end
+    end
+
+    @test_throws ArgumentError sum(exp, [1], weights=[1])
+    @test_throws ArgumentError sum!(exp, [0 0], [1 2], weights=[1, 10])
+    @test_throws ArgumentError sum!([0 0], [1 2], weights=[1 10])
+end


### PR DESCRIPTION
This will be consistent with the `weights` argument to be added to similar functions in Statistics. Since that code is needed notably to computed the weighted `mean` in Statistics, I figured it is better to make it public rather than only defining internal helpers for `mean`.

This is based on code from StatsBase, of which one part needs to live in LinearAlgebra since it depends on BLAS and `dot`.

Extracted from https://github.com/JuliaLang/julia/pull/31395.