### PR TITLE
Profile,test: avoid profiling compiler time

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -22,6 +22,7 @@ end
     end
 end
 
+busywait(0, 0) # compile
 @profile busywait(1, 20)
 
 let r = Profile.retrieve()


### PR DESCRIPTION
ref #33312. not really a fix, but might help clarify it?