### PR TITLE
FileWatching,test: remove max timeout

### DIFF
--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -719,7 +719,7 @@ function watch_folder(s::String, timeout_s::Real=-1)
     end
     if timeout_s >= 0 && !isready(fm.notify)
         if timeout_s <= 0.010
-            # for very small timeouts, we can just sleep for the timeout-interval
+            # for very small timeouts, we can just sleep for the whole timeout-interval
             (timeout_s == 0) ? yield() : sleep(timeout_s)
             if !isready(fm.notify)
                 return "" => FileEvent() # timeout

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -30,20 +30,14 @@ end
 function pfd_tst_reads(idx, intvl)
     global ready += 1
     wait(ready_c)
-    t_elapsed = @elapsed begin
-        start_evt2 = Condition()
-        evt2 = @async (notify(start_evt2); poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false))
-        wait(start_evt2); yield() # make sure the async poll_fd is pumping events
-        evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false)
-    end
+    start_evt2 = Condition()
+    evt2 = @async (notify(start_evt2); poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false))
+    wait(start_evt2); yield() # make sure the async poll_fd is pumping events
+    evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false)
     @test !evt.timedout
     @test evt.readable
     @test !evt.writable
     @test evt === fetch(evt2)
-
-    # println("Expected ", intvl, ", actual ", t_elapsed, ", diff ", t_elapsed - intvl)
-    # Disabled since this assertion fails randomly, notably on build VMs (issue #12824)
-    # @test t_elapsed <= (intvl + 1)
 
     dout = zeros(UInt8, 1)
     @static if Sys.iswindows()
@@ -58,22 +52,15 @@ end
 function pfd_tst_timeout(idx, intvl)
     global ready += 1
     wait(ready_c)
-    t_elapsed = @elapsed begin
-        start_evt2 = Condition()
-        evt2 = @async (notify(start_evt2); poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false))
-        wait(start_evt2); yield() # make sure the async poll_fd is pumping events
-        evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false)
-        @test evt.timedout
-        @test !evt.readable
-        @test !evt.writable
-        @test evt === fetch(evt2)
-    end
-
-    # Disabled since these assertions fail randomly, notably on build VMs (issue #12824)
-    # @test intvl <= t_elapsed
-    # @test t_elapsed <= (intvl + 1)
+    start_evt2 = Condition()
+    evt2 = @async (notify(start_evt2); poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false))
+    wait(start_evt2); yield() # make sure the async poll_fd is pumping events
+    evt = poll_fd(pipe_fds[idx][1], intvl; readable=true, writable=false)
+    @test evt.timedout
+    @test !evt.readable
+    @test !evt.writable
+    @test evt === fetch(evt2)
 end
-
 
 # Odd numbers trigger reads, even numbers timeout
 for (i, intvl) in enumerate(intvls)
@@ -176,24 +163,24 @@ file = joinpath(dir, "afile.txt")
 # initialize a watch_folder instance and create afile.txt
 function test_init_afile()
     @test isempty(FileWatching.watched_folders)
-    @test @elapsed(@test(watch_folder(dir, 0) == ("" => FileWatching.FileEvent()))) <= 2
+    @test(watch_folder(dir, 0) == ("" => FileWatching.FileEvent()))
     @test @elapsed(@test(watch_folder(dir, 0) == ("" => FileWatching.FileEvent()))) <= 0.5
     @test length(FileWatching.watched_folders) == 1
     @test unwatch_folder(dir) === nothing
     @test isempty(FileWatching.watched_folders)
-    @test 0.001 <= @elapsed(@test(watch_folder(dir, 0.004) == ("" => FileWatching.FileEvent()))) <= 2
-    @test 0.001 <= @elapsed(@test(watch_folder(dir, 0.004) == ("" => FileWatching.FileEvent()))) <= 0.5
+    @test 0.002 <= @elapsed(@test(watch_folder(dir, 0.004) == ("" => FileWatching.FileEvent())))
+    @test 0.002 <= @elapsed(@test(watch_folder(dir, 0.004) == ("" => FileWatching.FileEvent()))) <= 0.5
     @test unwatch_folder(dir) === nothing
-    @test 0.9 <= @elapsed(@test(watch_folder(dir, 1) == ("" => FileWatching.FileEvent()))) <= 4
-    @test 0.9 <= @elapsed(@test(watch_folder(dir, 1) == ("" => FileWatching.FileEvent()))) <= 1.5
+    @test 0.99 <= @elapsed(@test(watch_folder(dir, 1) == ("" => FileWatching.FileEvent())))
+    @test 0.99 <= @elapsed(@test(watch_folder(dir, 1) == ("" => FileWatching.FileEvent())))
     # like touch, but lets the operating system update the timestamp
     # for greater precision on some platforms (windows)
     @test close(open(file, "w")) === nothing
-    @test @elapsed(@test(watch_folder(dir) == (F_PATH => FileWatching.FileEvent(FileWatching.UV_RENAME)))) <= 0.5
+    @test(watch_folder(dir) == (F_PATH => FileWatching.FileEvent(FileWatching.UV_RENAME)))
     @test close(open(file, "w")) === nothing
     sleep(3)
     let c
-        @test @elapsed(c = watch_folder(dir, 0)) <= 0.5
+        c = watch_folder(dir, 0)
         if F_GETPATH
             @test c.first == F_PATH
             @test c.second.changed ⊻ c.second.renamed
@@ -205,8 +192,8 @@ function test_init_afile()
         end
     end
     @test unwatch_folder(dir) === nothing
-    @test @elapsed(@test(watch_folder(dir, 0) == ("" => FileWatching.FileEvent()))) <= 0.5
-    @test 0.9 <= @elapsed(@test(watch_folder(dir, 1) == ("" => FileWatching.FileEvent()))) <= 1.5
+    @test(watch_folder(dir, 0) == ("" => FileWatching.FileEvent()))
+    @test 0.9 <= @elapsed(@test(watch_folder(dir, 1) == ("" => FileWatching.FileEvent())))
     @test length(FileWatching.watched_folders) == 1
     nothing
 end
@@ -384,8 +371,8 @@ mv(file * "~", file)
 let changes = []
     while true
         let c
-            timeout = Sys.iswindows() ? 0.1 : 0.0
-            @test @elapsed(c = watch_folder(dir, timeout)) < 0.5
+            Sys.iswindows() && sleep(0.1)
+            @test @elapsed(c = watch_folder(dir, 0.0)) < 0.5
             push!(changes, c)
             (c.second::FileWatching.FileEvent).timedout && break
         end


### PR DESCRIPTION
This has been pretty flaky on CI systems, and isn't really required of the tests.

fix #33311