### PR TITLE
Annotating ^(HWNumber,Int) with @pure

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -220,6 +220,7 @@ end
 
 ^(x::T, p::T) where {T<:Integer} = power_by_squaring(x,p)
 ^(x::Number, p::Integer)  = power_by_squaring(x,p)
+Base.@pure ^(x::HWNumber,p::Int) = power_by_squaring(x,p)
 
 # x^p for any literal integer p is lowered to Base.literal_pow(^, x, Val(p))
 # to enable compile-time optimizations specialized to p.


### PR DESCRIPTION
Since literal_pow does not always kick in for higher exponents, it is relatively easy to accidentally insert a full function call to power_by_squaring in a tight loop when one intended to have a constant literal there.

Proposing to add a pure method to ^ for the integer & float types with concise literals, in order to make an expression like 10^5 get lowered to 100000 by constant propagation.