### PR TITLE
fix #33329, printing and `nameof` of `IntrinsicFunction`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1149,6 +1149,11 @@ function nameof(f::Function)
     return mt.name
 end
 
+function nameof(f::Core.IntrinsicFunction)
+    name = ccall(:jl_intrinsic_name, Ptr{UInt8}, (Core.IntrinsicFunction,), f)
+    return ccall(:jl_symbol, Ref{Symbol}, (Ptr{UInt8},), name)
+end
+
 """
     parentmodule(f::Function) -> Module
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -24,7 +24,7 @@ function show(io::IO, ::MIME"text/plain", f::Function)
     ft = typeof(f)
     mt = ft.name.mt
     if isa(f, Core.IntrinsicFunction)
-        show(io, f)
+        print(io, f)
         id = Core.Intrinsics.bitcast(Int32, f)
         print(io, " (intrinsic function #$id)")
     elseif isa(f, Core.Builtin)
@@ -403,10 +403,14 @@ end
 show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false))
 print(io::IO, f::Function) = show_function(io, f, true)
 
-function show(io::IO, x::Core.IntrinsicFunction)
-    name = ccall(:jl_intrinsic_name, Cstring, (Core.IntrinsicFunction,), x)
-    print(io, unsafe_string(name))
+function show(io::IO, f::Core.IntrinsicFunction)
+    if !get(io, :compact, false)
+        print(io, "Core.Intrinsics.")
+    end
+    print(io, nameof(f))
 end
+
+print(io::IO, f::Core.IntrinsicFunction) = print(io, nameof(f))
 
 show(io::IO, ::Core.TypeofBottom) = print(io, "Union{}")
 show(io::IO, ::MIME"text/plain", ::Core.TypeofBottom) = print(io, "Union{}")

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -890,3 +890,5 @@ end
 
 @test nameof(Any) === :Any
 @test nameof(:) === :Colon
+@test nameof(Core.Intrinsics.mul_int) === :mul_int
+@test nameof(Core.Intrinsics.arraylen) === :arraylen

--- a/test/show.jl
+++ b/test/show.jl
@@ -1361,13 +1361,15 @@ end
 end
 
 @testset "Intrinsic printing" begin
-    @test sprint(show, Core.Intrinsics.arraylen) == "arraylen"
+    @test sprint(show, Core.Intrinsics.arraylen) == "Core.Intrinsics.arraylen"
+    @test repr(Core.Intrinsics.arraylen) == "Core.Intrinsics.arraylen"
     let io = IOBuffer()
         show(io, MIME"text/plain"(), Core.Intrinsics.arraylen)
         str = String(take!(io))
         @test occursin("arraylen", str)
         @test occursin("(intrinsic function", str)
     end
+    @test string(Core.Intrinsics.add_int) == "add_int"
 end
 
 @testset "repr(mime, x)" begin


### PR DESCRIPTION
fix #33329