### PR TITLE
Fix multiplication of Triangular and Diagonal matrix

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -216,7 +216,8 @@ function lmul!(D::Diagonal, B::UnitUpperTriangular)
 end
 
 *(D::Adjoint{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(adjoint.(D.parent.diag) .* B.diag)
-*(A::Adjoint{<:Any,<:AbstractTriangular}, D::Diagonal) = rmul!(copy(A), D)
+*(A::Adjoint{<:Any,<:AbstractTriangular}, D::Diagonal) =
+    rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A), D)
 function *(adjA::Adjoint{<:Any,<:AbstractMatrix}, D::Diagonal)
     A = adjA.parent
     Ac = similar(A, promote_op(*, eltype(A), eltype(D.diag)), (size(A, 2), size(A, 1)))
@@ -225,7 +226,8 @@ function *(adjA::Adjoint{<:Any,<:AbstractMatrix}, D::Diagonal)
 end
 
 *(D::Transpose{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(transpose.(D.parent.diag) .* B.diag)
-*(A::Transpose{<:Any,<:AbstractTriangular}, D::Diagonal) = rmul!(copy(A), D)
+*(A::Transpose{<:Any,<:AbstractTriangular}, D::Diagonal) =
+    rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A), D)
 function *(transA::Transpose{<:Any,<:AbstractMatrix}, D::Diagonal)
     A = transA.parent
     At = similar(A, promote_op(*, eltype(A), eltype(D.diag)), (size(A, 2), size(A, 1)))
@@ -234,7 +236,8 @@ function *(transA::Transpose{<:Any,<:AbstractMatrix}, D::Diagonal)
 end
 
 *(D::Diagonal, B::Adjoint{<:Any,<:Diagonal}) = Diagonal(D.diag .* adjoint.(B.parent.diag))
-*(D::Diagonal, B::Adjoint{<:Any,<:AbstractTriangular}) = lmul!(D, collect(B))
+*(D::Diagonal, B::Adjoint{<:Any,<:AbstractTriangular}) =
+    lmul!(D, copyto!(similar(B, promote_op(*, eltype(B), eltype(D.diag))), B))
 *(D::Diagonal, adjQ::Adjoint{<:Any,<:Union{QRCompactWYQ,QRPackedQ}}) = (Q = adjQ.parent; rmul!(Array(D), adjoint(Q)))
 function *(D::Diagonal, adjA::Adjoint{<:Any,<:AbstractMatrix})
     A = adjA.parent
@@ -244,7 +247,8 @@ function *(D::Diagonal, adjA::Adjoint{<:Any,<:AbstractMatrix})
 end
 
 *(D::Diagonal, B::Transpose{<:Any,<:Diagonal}) = Diagonal(D.diag .* transpose.(B.parent.diag))
-*(D::Diagonal, B::Transpose{<:Any,<:AbstractTriangular}) = lmul!(D, copy(B))
+*(D::Diagonal, B::Transpose{<:Any,<:AbstractTriangular}) =
+    lmul!(D, copyto!(similar(B, promote_op(*, eltype(B), eltype(D.diag))), B))
 function *(D::Diagonal, transA::Transpose{<:Any,<:AbstractMatrix})
     A = transA.parent
     At = similar(A, promote_op(*, eltype(A), eltype(D.diag)), (size(A, 2), size(A, 1)))

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -162,8 +162,10 @@ end
 (*)(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag .* Db.diag)
 (*)(D::Diagonal, V::AbstractVector) = D.diag .* V
 
-(*)(A::AbstractTriangular, D::Diagonal) = rmul!(copy(A), D)
-(*)(D::Diagonal, B::AbstractTriangular) = lmul!(D, copy(B))
+(*)(A::AbstractTriangular, D::Diagonal) =
+    rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A), D)
+(*)(D::Diagonal, B::AbstractTriangular) =
+    lmul!(D, copyto!(similar(B, promote_op(*, eltype(B), eltype(D.diag))), B))
 
 (*)(A::AbstractMatrix, D::Diagonal) =
     rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag)), size(A)), A), D)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -50,19 +50,15 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
     end
 end
 
-for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
-          :UnitUpperTriangular)
-    @eval begin
-        adjtypes = Dict(
-            LowerTriangular => UpperTriangular,
-            UpperTriangular => LowerTriangular,
-            UnitLowerTriangular => UnitUpperTriangular,
-            UnitUpperTriangular => UnitLowerTriangular,
-        )
-        similar(A::Adjoint{TI,TV}, ::Type{T}) where{T,TI,TV<:$t} = adjtypes[$t](similar(parent(parent(A)), T))
-        similar(A::Transpose{TI,TV}, ::Type{T}) where{T,TI,TV<:$t} = adjtypes[$t](similar(parent(parent(A)), T))
-    end
-end
+similar(A::Union{Adjoint{Ti,Tv}, Transpose{Ti,Tv}}, ::Type{T}) where {T,Ti,Tv<:LowerTriangular} =
+    UpperTriangular(similar(parent(parent(A)), T))
+similar(A::Union{Adjoint{Ti,Tv}, Transpose{Ti,Tv}}, ::Type{T}) where {T,Ti,Tv<:UnitLowerTriangular} =
+    UnitUpperTriangular(similar(parent(parent(A)), T))
+similar(A::Union{Adjoint{Ti,Tv}, Transpose{Ti,Tv}}, ::Type{T}) where {T,Ti,Tv<:UpperTriangular} =
+    LowerTriangular(similar(parent(parent(A)), T))
+similar(A::Union{Adjoint{Ti,Tv}, Transpose{Ti,Tv}}, ::Type{T}) where {T,Ti,Tv<:UnitUpperTriangular} =
+    UnitLowerTriangular(similar(parent(parent(A)), T))
+
 
 LowerTriangular(U::UpperTriangular) = throw(ArgumentError(
     "cannot create a LowerTriangular matrix from an UpperTriangular input"))

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -50,6 +50,20 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
     end
 end
 
+for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
+          :UnitUpperTriangular)
+    @eval begin
+        adjtypes = Dict(
+            LowerTriangular => UpperTriangular,
+            UpperTriangular => LowerTriangular,
+            UnitLowerTriangular => UnitUpperTriangular,
+            UnitUpperTriangular => UnitLowerTriangular,
+        )
+        similar(A::Adjoint{TI,TV}, ::Type{T}) where{T,TI,TV<:$t} = adjtypes[$t](similar(parent(parent(A)), T))
+        similar(A::Transpose{TI,TV}, ::Type{T}) where{T,TI,TV<:$t} = adjtypes[$t](similar(parent(parent(A)), T))
+    end
+end
+
 LowerTriangular(U::UpperTriangular) = throw(ArgumentError(
     "cannot create a LowerTriangular matrix from an UpperTriangular input"))
 UpperTriangular(U::LowerTriangular) = throw(ArgumentError(

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -474,22 +474,22 @@ end
                 # Adjoint of Triangular * Diagonal
                 R = T' * D
                 @test R == Array(T)' * Array(D)
-                # @test isa(R, adjtype)
+                @test isa(R, adjtype)
 
                 # Diagonal * Adjoint of Triangular
                 R = D * T'
                 @test R == Array(D) * Array(T)'
-                # @test isa(R, adjtype)
+                @test isa(R, adjtype)
 
                 # Transpose of Triangular * Diagonal
                 R = transpose(T) * D
                 @test R == transpose(Array(T)) * Array(D)
-                # @test isa(R, adjtype)
+                @test isa(R, adjtype)
 
                 # Diagonal * Transpose of Triangular
                 R = D * transpose(T)
                 @test R == Array(D) * transpose(Array(T))
-                # @test isa(R, adjtype)
+                @test isa(R, adjtype)
             end
         end
     end

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -444,15 +444,6 @@ end
 @test Matrix(1.0I, 5, 5) \ Diagonal(fill(1.,5)) == Matrix(I, 5, 5)
 
 @testset "Triangular and Diagonal" begin
-    for T in (LowerTriangular(randn(5,5)), LinearAlgebra.UnitLowerTriangular(randn(5,5)))
-        D = Diagonal(randn(5))
-        @test T*D   == Array(T)*Array(D)
-        @test T'D   == Array(T)'*Array(D)
-        @test transpose(T)*D  == transpose(Array(T))*Array(D)
-        @test D*T'  == Array(D)*Array(T)'
-        @test D*transpose(T) == Array(D)*transpose(Array(T))
-        @test D*T   == Array(D)*Array(T)
-    end
     function _test_matrix(type)
         if type == Int
             return rand(1:9, 5, 5)
@@ -460,7 +451,7 @@ end
             return randn(type, 5, 5)
         end
     end
-    types = (Float32, Float64, Int, ComplexF64)
+    types = (Float64, Int, ComplexF64)
     for ta in types
         D = Diagonal(_test_matrix(ta))
         for tb in types
@@ -468,6 +459,8 @@ end
             Tmats = (LowerTriangular(B), UnitLowerTriangular(B), UpperTriangular(B), UnitUpperTriangular(B))
             restypes = (LowerTriangular, LowerTriangular, UpperTriangular, UpperTriangular)
             for (T, rtype) in zip(Tmats, restypes)
+                adjtype = (rtype == LowerTriangular) ? UpperTriangular : LowerTriangular
+
                 # Triangular * Diagonal
                 R = T * D
                 @test R == Array(T) * Array(D)
@@ -477,6 +470,26 @@ end
                 R = D * T
                 @test R == Array(D) * Array(T)
                 @test isa(R, rtype)
+
+                # Adjoint of Triangular * Diagonal
+                R = T' * D
+                @test R == Array(T)' * Array(D)
+                # @test isa(R, adjtype)
+
+                # Diagonal * Adjoint of Triangular
+                R = D * T'
+                @test R == Array(D) * Array(T)'
+                # @test isa(R, adjtype)
+
+                # Transpose of Triangular * Diagonal
+                R = transpose(T) * D
+                @test R == transpose(Array(T)) * Array(D)
+                # @test isa(R, adjtype)
+
+                # Diagonal * Transpose of Triangular
+                R = D * transpose(T)
+                @test R == Array(D) * transpose(Array(T))
+                # @test isa(R, adjtype)
             end
         end
     end

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -453,6 +453,33 @@ end
         @test D*transpose(T) == Array(D)*transpose(Array(T))
         @test D*T   == Array(D)*Array(T)
     end
+    function _test_matrix(type)
+        if type == Int
+            return rand(1:9, 5, 5)
+        else
+            return randn(type, 5, 5)
+        end
+    end
+    types = (Float32, Float64, Int, ComplexF64)
+    for ta in types
+        D = Diagonal(_test_matrix(ta))
+        for tb in types
+            B = _test_matrix(tb)
+            Tmats = (LowerTriangular(B), UnitLowerTriangular(B), UpperTriangular(B), UnitUpperTriangular(B))
+            restypes = (LowerTriangular, LowerTriangular, UpperTriangular, UpperTriangular)
+            for (T, rtype) in zip(Tmats, restypes)
+                # Triangular * Diagonal
+                R = T * D
+                @test R == Array(T) * Array(D)
+                @test isa(R, rtype)
+
+                # Diagonal * Triangular
+                R = D * T
+                @test R == Array(D) * Array(T)
+                @test isa(R, rtype)
+            end
+        end
+    end
 end
 
 let D1 = Diagonal(rand(5)), D2 = Diagonal(rand(5))


### PR DESCRIPTION
This PR intends to fix some examples from https://github.com/JuliaLang/julia/issues/30094#issuecomment-440175887, more precisely the multiplication of a triangular matrix with a diagonal matrix and vice versa.

There are more broken examples involving triangular and diagonal matrices, but I first wanted to check if this is done right.

Here are some examples that still need to be addressed:
```julia
julia> using LinearAlgebra

julia> D = Diagonal([0.5, 0.5, 0.5]);

julia> T = LowerTriangular(ones(Int, (3,3)));

julia> T'*D
ERROR: InexactError: Int64(0.5)
Stacktrace:
 [1] Int64 at ./float.jl:709 [inlined]
 [2] convert at ./number.jl:7 [inlined]
 [3] setindex! at ./array.jl:798 [inlined]
 [4] setindex! at ./multidimensional.jl:490 [inlined]
 [5] macro expansion at ./broadcast.jl:909 [inlined]
 [6] macro expansion at ./simdloop.jl:77 [inlined]
 [7] copyto! at ./broadcast.jl:908 [inlined]
 [8] copyto! at ./broadcast.jl:863 [inlined]
 [9] materialize! at ./broadcast.jl:822 [inlined]
 [10] rmul!(::Array{Int64,2}, ::Diagonal{Float64,Array{Float64,1}}) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:177
 [11] rmul! at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:187 [inlined]
 [12] *(::Adjoint{Int64,LowerTriangular{Int64,Array{Int64,2}}}, ::Diagonal{Float64,Array{Float64,1}}) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:219
 [13] top-level scope at REPL[4]:1

julia> transpose(T)*D
ERROR: InexactError: Int64(0.5)
Stacktrace:
 [1] Int64 at ./float.jl:709 [inlined]
 [2] convert at ./number.jl:7 [inlined]
 [3] setindex! at ./array.jl:798 [inlined]
 [4] setindex! at ./multidimensional.jl:490 [inlined]
 [5] macro expansion at ./broadcast.jl:909 [inlined]
 [6] macro expansion at ./simdloop.jl:77 [inlined]
 [7] copyto! at ./broadcast.jl:908 [inlined]
 [8] copyto! at ./broadcast.jl:863 [inlined]
 [9] materialize! at ./broadcast.jl:822 [inlined]
 [10] rmul!(::Array{Int64,2}, ::Diagonal{Float64,Array{Float64,1}}) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:177
 [11] rmul! at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:187 [inlined]
 [12] *(::Transpose{Int64,LowerTriangular{Int64,Array{Int64,2}}}, ::Diagonal{Float64,Array{Float64,1}}) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:228
 [13] top-level scope at REPL[5]:1

julia> D*T'
ERROR: InexactError: Int64(0.5)
Stacktrace:
 [1] Int64 at ./float.jl:709 [inlined]
 [2] convert at ./number.jl:7 [inlined]
 [3] setindex! at ./array.jl:798 [inlined]
 [4] setindex! at ./multidimensional.jl:490 [inlined]
 [5] macro expansion at ./broadcast.jl:909 [inlined]
 [6] macro expansion at ./simdloop.jl:77 [inlined]
 [7] copyto! at ./broadcast.jl:908 [inlined]
 [8] copyto! at ./broadcast.jl:863 [inlined]
 [9] materialize! at ./broadcast.jl:822 [inlined]
 [10] lmul!(::Diagonal{Float64,Array{Float64,1}}, ::Array{Int64,2}) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:183
 [11] *(::Diagonal{Float64,Array{Float64,1}}, ::Adjoint{Int64,LowerTriangular{Int64,Array{Int64,2}}}) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/diagonal.jl:237
 [12] top-level scope at REPL[6]:1

julia> D*transpose(T)
ERROR: InexactError: Int64(0.5)
Stacktrace:
 [1] Int64 at ./float.jl:709 [inlined]
 [2] convert at ./number.jl:7 [inlined]
 [3] setindex! at ./array.jl:798 [inlined]
 [4] setindex!(::UpperTriangular{Int64,Array{Int64,2}}, ::Float64, ::Int64, ::Int64) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/triangular.jl:229
 [5] macro expansion at ./abstractarray.jl:1104 [inlined]
 [6] macro expansion at ./simdloop.jl:77 [inlined]
 [7] copyto! at ./broadcast.jl:908 [inlined]
 [8] copyto!(::UpperTriangular{Int64,Array{Int64,2}}, ::Base.Broadcast.Broadcasted{LinearAlgebra.StructuredMatrixStyle{UpperTriangular{Int64,Array{Int64,2}}},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},typeof(*),Tuple{Array{Float64,1},UpperTriangular{Int64,Array{Int64,2}}}}) at /home/alex/Projects/github/goggle/julia/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/structuredbroadcast.jl:175
 [9] *(::Diagonal{Float64,Array{Float64,1}}, ::Transpose{Int64,LowerTriangular{Int64,Array{Int64,2}}}) at ./broadcast.jl:822
 [10] top-level scope at REPL[8]:1
```

And in this example, I think we should expect in both cases a `UpperTriangular` as a result, right?
```julia
julia> T = LowerTriangular(ones(Float64, (3,3)));

julia> T'*D
3×3 UpperTriangular{Float64,Array{Float64,2}}:
 0.5  0.5  0.5
  ⋅   0.5  0.5
  ⋅    ⋅   0.5

julia> D*T'
3×3 Array{Float64,2}:
 0.5  0.5  0.5
 0.0  0.5  0.5
 0.0  0.0  0.5
```