### PR TITLE
Document getfield(value, i::Int)

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1544,9 +1544,10 @@ tuple
 
 """
     getfield(value, name::Symbol)
+    getfield(value, i::Int)
 
-Extract a named field from a `value` of composite type.
-See also [`getproperty`](@ref Base.getproperty).
+Extract a field from a composite `value` by a name or a position.
+See also [`getproperty`](@ref Base.getproperty) and [`fieldnames`](@ref).
 
 # Examples
 ```jldoctest
@@ -1557,6 +1558,9 @@ julia> getfield(a, :num)
 1
 
 julia> a.num
+1
+
+julia> getfield(a, 1)
 1
 ```
 """

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1546,7 +1546,7 @@ tuple
     getfield(value, name::Symbol)
     getfield(value, i::Int)
 
-Extract a field from a composite `value` by a name or a position.
+Extract a field from a composite `value` by name or position.
 See also [`getproperty`](@ref Base.getproperty) and [`fieldnames`](@ref).
 
 # Examples


### PR DESCRIPTION
Is `getfield(value, i::Int)` an official API? It would be nice to mention it in the documentation if so.