### PR TITLE
Avoid overspecialization of the SparseMatrixCSC * Diagonal product

### DIFF
--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1359,7 +1359,7 @@ function copyinds!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC)
 end
 
 # multiply by diagonal matrix as vector
-function mul!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, D::Diagonal{T, <:Vector}) where T
+function mul!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, D::Diagonal{T, <:AbstractVector}) where T
     m, n = size(A)
     b    = D.diag
     (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
@@ -1373,7 +1373,7 @@ function mul!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, D::Diagona
     C
 end
 
-function mul!(C::AbstractSparseMatrixCSC, D::Diagonal{T, <:Vector}, A::AbstractSparseMatrixCSC) where T
+function mul!(C::AbstractSparseMatrixCSC, D::Diagonal{T, <:AbstractVector}, A::AbstractSparseMatrixCSC) where T
     m, n = size(A)
     b    = D.diag
     (m==length(b) && size(A)==size(C)) || throw(DimensionMismatch())

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1359,7 +1359,7 @@ function copyinds!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC)
 end
 
 # multiply by diagonal matrix as vector
-function mul!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, D::Diagonal{T, <:AbstractVector}) where T
+function mul!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, D::Diagonal)
     m, n = size(A)
     b    = D.diag
     (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
@@ -1373,7 +1373,7 @@ function mul!(C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, D::Diagona
     C
 end
 
-function mul!(C::AbstractSparseMatrixCSC, D::Diagonal{T, <:AbstractVector}, A::AbstractSparseMatrixCSC) where T
+function mul!(C::AbstractSparseMatrixCSC, D::Diagonal, A::AbstractSparseMatrixCSC)
     m, n = size(A)
     b    = D.diag
     (m==length(b) && size(A)==size(C)) || throw(DimensionMismatch())


### PR DESCRIPTION
A recent [thread on discourse](https://discourse.julialang.org/t/potential-performance-regression-wrt-0-6-products-involving-diagonal-matrices-much-slower-than-with-general-sparse-matrices/29005?u=ffevotte) describes a use case where the product between a `SparseMatrixCSC` and a `Diagonal` matrix falls back to a generic, dense algorithm. This of course entails very significant losses in performance.

It looks like in this case, the problem comes from the [relevant `mul!` methods](https://github.com/JuliaLang/julia/blob/34d2b87b65b1643b1055b10aa5ea7d2bdbcf6cd2/stdlib/SparseArrays/src/linalg.jl#L1362-L1389) being overly specialized because they accept only `Diagonal{T, <:Vector}` operands. I think this could safely be generalized to `Diagonal{T, <:AbstractVector}` operands, and this is what this PR proposes.

Below is a test case illustrating the performance issues:
```julia
using SparseArrays
using LinearAlgebra
using BenchmarkTools

nrows = 1000
spmat1 = sparse(1.0*I,nrows, nrows);
spmat2 = sparse(1.0*I,nrows, nrows);
diagmat = Diagonal(diag(spmat2));
@btime $spmat1*$diagmat;
@btime $spmat1*$spmat2;
```

yielding (on my machine and for the current `master` branch):
```julia
julia> @btime $spmat1*$diagmat;
  1.145 s (11 allocations: 24.27 KiB)

julia> @btime $spmat1*$spmat2;
  21.097 μs (8 allocations: 61.13 KiB)
```

and with the current PR:
```julia
julia> @btime $spmat1*$diagmat;
  46.593 μs (5 allocations: 23.94 KiB)

julia> @btime $spmat1*$spmat2;
  20.650 μs (8 allocations: 61.13 KiB)
```

<br/>

I'm not sure where to go from here. This is "only" a performance issue, so I'm not sure how to formalize its resolution with a test case in order to avoid potential, future regressions. I also don't think it needs any further documentation. But this is my first PR and I may very well be missing something here; please do not hesitate to tell me if there is anything I could do to improve this PR.

Thanks!