### PR TITLE
add a subtyping fast path for tuple of Unions <: Vararg

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1049,6 +1049,10 @@ loop: // while (i <= lx) {
             yi = jl_tparam0(jl_unwrap_unionall(env->vty));
             if (!env->vvx && yi == (jl_value_t*)jl_any_type)
                 goto done;  // if y ends in `Vararg{Any}` skip checking everything
+            // var T in Vararg{T} is diagonal; an abstract type can't be a subtype of it,
+            // so avoid exponential blowup when xi is a Union.
+            if (jl_is_typevar(yi) && jl_is_uniontype(xi) && !jl_has_free_typevars(xi))
+                return 0;
         }
         if (xi == env->lastx &&
             ((yi == env->lasty && !jl_has_free_typevars(xi) && !jl_has_free_typevars(yi)) ||

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1676,3 +1676,7 @@ c32703(::Type{<:Str{C}}, str::Str{C}) where {C<:CSE} = str
 @testintersect(Tuple{Pair{Int, DataType}, Any},
                Tuple{Pair{A, B} where B<:Type, Int} where A,
                Tuple{Pair{Int, DataType}, Int})
+
+# issue #33337
+@test !issub(Tuple{Type{T}, T} where T<:NTuple{30, Union{Nothing, Ref}},
+             Tuple{Type{Tuple{Vararg{V, N} where N}}, Tuple{Vararg{V, N} where N}} where V)


### PR DESCRIPTION
fixes #33337

Replacement for #33345 that improves subtyping instead of reverting.