### PR TITLE
Don't crash in _apply if the user writes a bad iterate method

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -602,9 +602,9 @@ JL_CALLABLE(jl_f__apply)
             jl_value_t *next = jl_apply_generic(jl_iterate_func, args, 1);
             while (next != jl_nothing) {
                 roots[stackalloc] = next;
-                jl_value_t *value = jl_fieldref(next, 0);
+                jl_value_t *value = jl_get_nth_field_checked(next, 0);
                 roots[stackalloc + 1] = value;
-                jl_value_t *state = jl_fieldref(next, 1);
+                jl_value_t *state = jl_get_nth_field_checked(next, 1);
                 roots[stackalloc] = state;
                 _grow_to(&roots[0], &newargs, &arg_heap, &n_alloc, n + precount + 1, extra);
                 JL_GC_ASSERT_LIVE(value);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1470,7 +1470,7 @@ JL_DLLEXPORT void JL_NORETURN jl_type_error(const char *fname,
                                             jl_value_t *got JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_type_error_rt(const char *fname,
                                                const char *context,
-                                               jl_value_t *ty,
+                                               jl_value_t *ty JL_MAYBE_UNROOTED,
                                                jl_value_t *got JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_undefined_var_error(jl_sym_t *var);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v,

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -112,7 +112,7 @@ JL_DLLEXPORT void JL_NORETURN jl_type_error_rt(const char *fname, const char *co
                                                jl_value_t *expected, jl_value_t *got)
 {
     jl_value_t *ctxt=NULL;
-    JL_GC_PUSH2(&ctxt, &got);
+    JL_GC_PUSH3(&ctxt, &expected, &got);
     ctxt = jl_pchar_to_string((char*)context, strlen(context));
     jl_value_t *ex = jl_new_struct(jl_typeerror_type, jl_symbol(fname), ctxt, expected, got);
     jl_throw(ex);

--- a/test/core.jl
+++ b/test/core.jl
@@ -7060,3 +7060,8 @@ function f32820(refs)
     x
 end
 @test f32820(Any[1,2]) == Any[1, 1]
+
+# Splatting with bad iterate
+struct SplatBadIterate; end
+Base.iterate(s::SplatBadIterate, args...) = ()
+@test_throws BoundsError (SplatBadIterate()...,)


### PR DESCRIPTION
Instead check that we indeed got a tuple of appropriate length back.

Not that I would ever write an incorrect `iterate` method.