### PR TITLE
Fix abstract_type args error in devdocs/ast

### DIFF
--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -384,7 +384,7 @@ These symbols appear in the `head` field of [`Expr`](@ref)s in lowered form.
   * `abstract_type`
 
     A 3-argument expression that defines a new abstract type. The
-    arguments are the same as the first three arguments of
+    arguments are the same as arguments 1, 2, and 4 of
     `struct_type` expressions.
 
   * `primitive_type`


### PR DESCRIPTION
No fieldnames args in abstract, but a super arg. so 
> ~arguments are the same as the first three arguments of~

is replaced by

> arguments are the same as arguments 1, 2, and 4 of

See

```scheme
(define (abstract-type-def-expr name params super)
  (receive
   (params bounds) (sparam-name-bounds params)
   `(block
     (global ,name) (const ,name)
     (scope-block
      (block
       ,@(map (lambda (v) `(local ,v)) params)
       ,@(map (lambda (n v) (make-assignment n (bounds-to-TypeVar v #t))) params bounds)
       (abstract_type ,name (call (core svec) ,@params) ,super))))))
```
@ https://github.com/JuliaLang/julia/blob/v1.2.0/src/julia-syntax.scm#L880-L889

and


```lisp
         (struct_type ,name (call (core svec) ,@params)
                      (call (core svec) ,@(map quotify field-names))
                      ,super (call (core svec) ,@field-types) ,mut ,min-initialized)))
```
https://github.com/JuliaLang/julia/blob/v1.2.0/src/julia-syntax.scm#L848-L850

--
For fun

```julia
function evaluate_abstracttype(@nospecialize(recurse), frame, node)
    name, mod = structname(frame, node)
    params = lookup_or_eval(recurse, frame, node.args[2])::SimpleVector
    supertype = lookup_or_eval(recurse, frame, node.args[3])::Type
    Core.eval(mod, Expr(:abstract_type, name, params, supertype))
    VERSION < v"1.2.0-DEV.239" && set_structtype_const(mod, name)
end
```

https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/master/src/interpret.jl#L314-L320