### PR TITLE
RFC: LLVM intrinsic and interface for assuming a condition

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -262,7 +262,8 @@ function is_pure_intrinsic_infer(f::IntrinsicFunction)
              f === Intrinsics.llvmcall ||   # this one is never effect-free
              f === Intrinsics.arraylen ||   # this one is volatile
              f === Intrinsics.sqrt_llvm ||  # this one may differ at runtime (by a few ulps)
-             f === Intrinsics.cglobal)  # cglobal lookup answer changes at runtime
+             f === Intrinsics.cglobal ||  # cglobal lookup answer changes at runtime
+             f === Intrinsics.assume_llvm)
 end
 
 # whether `f` is effect free if nothrow

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -192,6 +192,7 @@ cglobal_tfunc(@nospecialize(fptr)) = Ptr{Cvoid}
 cglobal_tfunc(@nospecialize(fptr), @nospecialize(t)) = (isType(t) ? Ptr{t.parameters[1]} : Ptr)
 cglobal_tfunc(@nospecialize(fptr), t::Const) = (isa(t.val, Type) ? Ptr{t.val} : Ptr)
 add_tfunc(Core.Intrinsics.cglobal, 1, 2, cglobal_tfunc, 5)
+add_tfunc(assume_llvm, 1, 1, (@nospecialize(x)) -> Nothing, 0)
 
 function ifelse_tfunc(@nospecialize(cnd), @nospecialize(x), @nospecialize(y))
     if isa(cnd, Const)

--- a/base/util.jl
+++ b/base/util.jl
@@ -795,6 +795,15 @@ function _kwdef!(blk, params_args, call_args)
     blk
 end
 
+"""
+    Base.assume(cond::Bool)
+
+Assume that a condition `cond` always hold. This information may be used by the compiler for
+optimization purposes.
+"""
+assume(cond::Bool) = Core.Intrinsics.assume_llvm(cond)
+
+
 # testing
 
 """

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -937,6 +937,15 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         return mark_julia_type(ctx, ans, false, x.typ);
     }
 
+    case assume_llvm: {
+        const jl_cgval_t &x = argv[0];
+        if (x.typ != (jl_value_t*)jl_bool_type)
+            return emit_runtime_call(ctx, f, argv, nargs);
+        Value *assumeintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::assume);
+        ctx.builder.CreateCall(assumeintr, x.V);
+        return ghostValue(jl_void_type);
+    }
+
     default: {
         assert(nargs >= 1 && "invalid nargs for intrinsic call");
         const jl_cgval_t &xinfo = argv[0];

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -88,6 +88,7 @@
     ADD_I(trunc_llvm, 1) \
     ADD_I(rint_llvm, 1) \
     ADD_I(sqrt_llvm, 1) \
+    ADD_I(assume_llvm, 1) \
     /*  pointer access */ \
     ADD_I(pointerref, 3) \
     ADD_I(pointerset, 4) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -855,6 +855,8 @@ JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);
 
 JL_DLLEXPORT uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v) JL_NOTSAFEPOINT;
 
+JL_DLLEXPORT jl_value_t *jl_assume_llvm(jl_value_t *cond);
+
 // -- synchronization utilities -- //
 
 extern jl_mutex_t typecache_lock;

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -915,6 +915,13 @@ un_fintrinsic(trunc_float,trunc_llvm)
 un_fintrinsic(rint_float,rint_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm)
 
+JL_DLLEXPORT jl_value_t *jl_assume_llvm(jl_value_t *cond)
+{
+    JL_TYPECHK(assume_llvm, bool, cond);
+    // TODO: evaluate cond and check if true?
+    return jl_nothing;
+}
+
 JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a)
 {
     JL_TYPECHK(arraylen, array, a);


### PR DESCRIPTION
Motivation: get rid of an unthrowable exception path in a GPU kernel:

```julia
julia> foo(i) = cld(42, i)
foo (generic function with 1 method)

julia> @code_llvm debuginfo=:none foo(1)
```
```llvm
define i64 @julia_foo_12290(i64) {
top:
  %1 = icmp eq i64 %0, 0
  br i1 %1, label %fail, label %pass

fail:                                             ; preds = %top
  call void @jl_throw(%jl_value_t addrspace(12)* addrspacecast (%jl_value_t* inttoptr (i64 140194520974688 to %jl_value_t*) to %jl_value_t addrspace(12)*))
  unreachable

pass:                                             ; preds = %top
  %2 = sdiv i64 42, %0
  %3 = icmp sgt i64 %0, 0
  %4 = mul i64 %2, %0
  %5 = icmp ne i64 %4, 42
  %6 = and i1 %3, %5
  %7 = zext i1 %6 to i64
  %8 = add i64 %2, %7
  ret i64 %8
}
```
```julia
julia> foo(i) = (Base.assume(i > 0); cld(42, i))
foo (generic function with 1 method)

julia> @code_llvm debuginfo=:none foo(1)
```
```llvm
define i64 @julia_foo_12303(i64) {
pass:
  %1 = icmp sgt i64 %0, 0
  call void @llvm.assume(i1 %1)
  %2 = udiv i64 42, %0
  %3 = mul i64 %2, %0
  %4 = icmp ne i64 %3, 42
  %5 = zext i1 %4 to i64
  %6 = add nuw nsw i64 %2, %5
  ret i64 %6
}
```

For now, `Base.assume` just calls the LLVM intrinsic, but that could change and, e.g., feed into the Julia IR and optimizer instead.

TODO: tests.