### PR TITLE
cross-reference ntoh and hton from bswap docs

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -321,6 +321,8 @@ xor(x::T, y::T) where {T<:BitInteger} = xor_int(x, y)
 
 Reverse the byte order of `n`.
 
+(See also [`ntoh`](@ref) and [`hton`](@ref) to convert between the current native byte order and big-endian order.)
+
 # Examples
 ```jldoctest
 julia> a = bswap(0x10203040)


### PR DESCRIPTION
Rationale: many people using `bswap` probably actually want `ntoh` or `hton`.

(e.g. [on discourse](https://discourse.julialang.org/t/how-to-read-big-endian-data/29132) today.)