### PR TITLE
Fix multiplication of triangular matrix and sparse vector

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1489,7 +1489,9 @@ end
 
 # * and mul!
 
-function (*)(A::StridedMatrix{Ta}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
+const _StridedOrTriangularMatrix{T} = Union{StridedMatrix{T}, LowerTriangular{T}, UnitLowerTriangular{T}, UpperTriangular{T}, UnitUpperTriangular{T}}
+
+function (*)(A::_StridedOrTriangularMatrix{Ta}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
     require_one_based_indexing(A, x)
     m, n = size(A)
     length(x) == n || throw(DimensionMismatch())
@@ -1498,10 +1500,10 @@ function (*)(A::StridedMatrix{Ta}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
     mul!(y, A, x)
 end
 
-mul!(y::AbstractVector{Ty}, A::StridedMatrix, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
+mul!(y::AbstractVector{Ty}, A::_StridedOrTriangularMatrix, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
     mul!(y, A, x, true, false)
 
-function mul!(y::AbstractVector, A::StridedMatrix, x::AbstractSparseVector, α::Number, β::Number)
+function mul!(y::AbstractVector, A::_StridedOrTriangularMatrix, x::AbstractSparseVector, α::Number, β::Number)
     require_one_based_indexing(y, A, x)
     m, n = size(A)
     length(x) == n && length(y) == m || throw(DimensionMismatch())
@@ -1528,7 +1530,7 @@ end
 
 # * and mul!(C, transpose(A), B)
 
-function *(transA::Transpose{<:Any,<:StridedMatrix{Ta}}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
+function *(transA::Transpose{<:Any,<:_StridedOrTriangularMatrix{Ta}}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
     require_one_based_indexing(transA, x)
     m, n = size(transA)
     length(x) == n || throw(DimensionMismatch())
@@ -1537,10 +1539,10 @@ function *(transA::Transpose{<:Any,<:StridedMatrix{Ta}}, x::AbstractSparseVector
     mul!(y, transA, x)
 end
 
-mul!(y::AbstractVector{Ty}, transA::Transpose{<:Any,<:StridedMatrix}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
+mul!(y::AbstractVector{Ty}, transA::Transpose{<:Any,<:_StridedOrTriangularMatrix}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
     mul!(y, transA, x, true, false)
 
-function mul!(y::AbstractVector, transA::Transpose{<:Any,<:StridedMatrix}, x::AbstractSparseVector, α::Number, β::Number)
+function mul!(y::AbstractVector, transA::Transpose{<:Any,<:_StridedOrTriangularMatrix}, x::AbstractSparseVector, α::Number, β::Number)
     require_one_based_indexing(y, transA, x)
     m, n = size(transA)
     length(x) == n && length(y) == m || throw(DimensionMismatch())
@@ -1569,7 +1571,7 @@ end
 
 # * and mul!(C, adjoint(A), B)
 
-function *(adjA::Adjoint{<:Any,<:StridedMatrix{Ta}}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
+function *(adjA::Adjoint{<:Any,<:_StridedOrTriangularMatrix{Ta}}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
     require_one_based_indexing(adjA, x)
     m, n = size(adjA)
     length(x) == n || throw(DimensionMismatch())
@@ -1578,10 +1580,10 @@ function *(adjA::Adjoint{<:Any,<:StridedMatrix{Ta}}, x::AbstractSparseVector{Tx}
     mul!(y, adjA, x)
 end
 
-mul!(y::AbstractVector{Ty}, adjA::Adjoint{<:Any,<:StridedMatrix}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
+mul!(y::AbstractVector{Ty}, adjA::Adjoint{<:Any,<:_StridedOrTriangularMatrix}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
     mul!(y, adjA, x, true, false)
 
-function mul!(y::AbstractVector, adjA::Adjoint{<:Any,<:StridedMatrix}, x::AbstractSparseVector, α::Number, β::Number)
+function mul!(y::AbstractVector, adjA::Adjoint{<:Any,<:_StridedOrTriangularMatrix}, x::AbstractSparseVector, α::Number, β::Number)
     require_one_based_indexing(y, adjA, x)
     m, n = size(adjA)
     length(x) == n && length(y) == m || throw(DimensionMismatch())

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1086,6 +1086,45 @@ end
             @test isequal(ldiv!(transpose(mat), copy(zerospvec)), zerospvec)
         end
     end
+    @testset "Triangular and SparseVector multiplications" begin
+        n = 10
+        types = (Int, Float64, ComplexF64)
+        tritypes = (LowerTriangular, UnitUpperTriangular)
+        for ta in types
+            for tri in tritypes
+                if ta == Int
+                    T = tri(rand(1:9, n, n))
+                else
+                    T = tri(randn(ta, n, n))
+                end
+                for tb in types
+                    if tb == Int
+                        x = sparse(rand(0:4, 10))
+                    else
+                        x = sprandn(tb, n, 0.6)
+                    end
+                    @test T * x ≈ Array(T) * Array(x)
+                    @test T' * x ≈ Array(T)' * Array(x)
+                    @test transpose(T) * x ≈ transpose(Array(T)) * Array(x)
+                    @test x' * T ≈ Array(x)' * Array(T)
+                    @test x' * T' ≈ Array(x)' * Array(T)'
+                    @test x' * transpose(T) ≈ Array(x)' * transpose(Array(T))
+                end
+            end
+        end
+
+        # 0-dimensional case
+        x = sparse(zeros(0))
+        for tri in tritypes
+            T = tri(zeros(0, 0))
+            @test T*x == Array(T) * Array(x)
+            @test T' * x == Array(T)' * Array(x)
+            @test transpose(T) * x == transpose(Array(T)) * Array(x)
+            @test x' * T == Array(x)' * Array(T)
+            @test x' * T' == Array(x)' * Array(T)'
+            @test x' * transpose(T) == Array(x)' * transpose(Array(T))
+        end
+    end
 end
 
 @testset "fkeep!" begin

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1099,7 +1099,7 @@ end
                 end
                 for tb in types
                     if tb == Int
-                        x = sparse(rand(0:4, 10))
+                        x = sparse(rand(0:4, n))
                     else
                         x = sprandn(tb, n, 0.6)
                     end


### PR DESCRIPTION
This PR intends to enable multiplication between triangular matrices and sparse vectors, which is currently broken as mentioned in https://github.com/JuliaLang/julia/issues/30094#issuecomment-440175887.

The following examples work with the changes committed with this PR, but do not work in the current `master` branch:
```julia
julia> using LinearAlgebra

julia> using SparseArrays

julia> L = LowerTriangular(ones(Int, (3,3)));

julia> x = sparsevec([1, 3], [2.0, 3.0]);

julia> L*x
3-element Array{Float64,1}:
 2.0
 2.0
 5.0

julia> L'*x
3-element Array{Float64,1}:
 5.0
 3.0
 3.0

julia> transpose(L)*x
3-element Array{Float64,1}:
 5.0
 3.0
 3.0

julia> x'*L
1×3 Adjoint{Float64,Array{Float64,1}}:
 5.0  3.0  3.0

julia> x'*L'
1×3 Adjoint{Float64,Array{Float64,1}}:
 2.0  2.0  5.0

julia> x'*transpose(L)
1×3 Adjoint{Float64,Array{Float64,1}}:
 2.0  2.0  5.0
```