### PR TITLE
fix using non one-based indexing arrays in threads loops

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -43,7 +43,7 @@ function _threadsfor(iter,lbody)
                 len, rem = 1, 0
             end
             # compute this thread's iterations
-            f = 1 + ((tid-1) * len)
+            f = firstindex(r) + ((tid-1) * len)
             l = f + len - 1
             # distribute remaining iterations evenly
             if rem > 0
@@ -57,7 +57,7 @@ function _threadsfor(iter,lbody)
             end
             # run this thread's iterations
             for i = f:l
-                local $(esc(lidx)) = Base.unsafe_getindex(r,i)
+                local $(esc(lidx)) = @inbounds r[i]
                 $(esc(lbody))
             end
         end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/33394

```jl
julia> Threads.@threads for i in Base.IdentityUnitRange(-1:1)
                 println(i);
             end
1
-1
0
```

Also swaps out the `unsafe_getindex` call for an `@inbounds`.