### PR TITLE
allow passing a module to methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,8 @@ Standard library changes
 * Sets are now displayed less compactly in the REPL, as a column of elements, like vectors
   and dictionaries ([#33300]).
 
+* `methods` now accepts passing a module (or a list thereof) to filter methods defined in it ([#33403]).
+
 #### Libdl
 
 #### LinearAlgebra

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -868,14 +868,19 @@ Return the method table for `f`.
 
 If `types` is specified, return an array of methods whose types match.
 If `module` is specified, return an array of methods defined in this module.
+A list of modules can also be specified as an array or tuple.
 """
-function methods(@nospecialize(f), @nospecialize(t), mod::Union{Module,Nothing}=nothing)
+function methods(@nospecialize(f), @nospecialize(t),
+                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}}}=()))
+    if mod isa Module
+        mod = (mod,)
+    end
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end
     t = to_tuple_type(t)
     world = typemax(UInt)
-    MethodList(Method[m[3] for m in _methods(f, t, -1, world) if mod === nothing || m[3].module == mod],
+    MethodList(Method[m[3] for m in _methods(f, t, -1, world) if isempty(mod) || m[3].module in mod],
                typeof(f).name.mt)
 end
 
@@ -890,7 +895,8 @@ function methods_including_ambiguous(@nospecialize(f), @nospecialize(t))
     return MethodList(Method[m[3] for m in ms], typeof(f).name.mt)
 end
 
-function methods(@nospecialize(f), mod::Union{Module,Nothing}=nothing)
+function methods(@nospecialize(f),
+                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}}}=()))
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -869,6 +869,9 @@ Return the method table for `f`.
 If `types` is specified, return an array of methods whose types match.
 If `module` is specified, return an array of methods defined in this module.
 A list of modules can also be specified as an array or tuple.
+
+!!! compat "Julia 1.4"
+    At least Julia 1.4 is required for specifying a module.
 """
 function methods(@nospecialize(f), @nospecialize(t),
                  @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}}}=()))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -874,7 +874,7 @@ A list of modules can also be specified as an array or tuple.
     At least Julia 1.4 is required for specifying a module.
 """
 function methods(@nospecialize(f), @nospecialize(t),
-                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}}}=()))
+                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}},Nothing}=nothing))
     if mod isa Module
         mod = (mod,)
     end
@@ -883,7 +883,7 @@ function methods(@nospecialize(f), @nospecialize(t),
     end
     t = to_tuple_type(t)
     world = typemax(UInt)
-    MethodList(Method[m[3] for m in _methods(f, t, -1, world) if isempty(mod) || m[3].module in mod],
+    MethodList(Method[m[3] for m in _methods(f, t, -1, world) if mod === nothing || m[3].module in mod],
                typeof(f).name.mt)
 end
 
@@ -899,7 +899,7 @@ function methods_including_ambiguous(@nospecialize(f), @nospecialize(t))
 end
 
 function methods(@nospecialize(f),
-                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}}}=()))
+                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}},Nothing}=nothing))
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -869,7 +869,7 @@ Return the method table for `f`.
 If `types` is specified, return an array of methods whose types match.
 If `module` is specified, return an array of methods defined in this module.
 """
-function methods(@nospecialize(f), @nospecialize(t), mod::Union{Module,Nothing})
+function methods(@nospecialize(f), @nospecialize(t), mod::Union{Module,Nothing}=nothing)
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -893,3 +893,30 @@ end
 @test nameof(:) === :Colon
 @test nameof(Core.Intrinsics.mul_int) === :mul_int
 @test nameof(Core.Intrinsics.arraylen) === :arraylen
+
+module TestMod33403
+f(x) = 1
+f(x::Int) = 2
+
+module Sub
+import ..TestMod33403: f
+f(x::Char) = 3
+end
+end
+
+@testset "methods with module" begin
+    using .TestMod33403: f
+    @test length(methods(f)) == 3
+    @test length(methods(f, (Int,))) == 1
+
+    @test length(methods(f, TestMod33403)) == 2
+    @test length(methods(f, (TestMod33403,))) == 2
+    @test length(methods(f, [TestMod33403])) == 2
+    @test length(methods(f, (Int,), TestMod33403)) == 1
+    @test length(methods(f, (Int,), (TestMod33403,))) == 1
+
+    @test length(methods(f, TestMod33403.Sub)) == 1
+    @test length(methods(f, (TestMod33403.Sub,))) == 1
+    @test length(methods(f, (Char,), TestMod33403.Sub)) == 1
+    @test length(methods(f, (Int,), TestMod33403.Sub)) == 0
+end


### PR DESCRIPTION
I often wish to see methods implemented by a specific module. Of course I can do `collect(Iterators.filter(x -> x.module == MyModule, methods(eltype)))` (`collect` is quite necessary as otherwise all the methods are printed, because the iterator itself is printed).
But it's cumbersome and I'm not even sure `method.module` is documented.

This PR implements the API `methods(f, [types], [module::Module])`, a possible added convenience could be to also allow passing a list of modules.
