### PR TITLE
Clean up printing of testset start

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@
 
 using Test
 using Distributed
+using Dates
 import REPL
 using Printf: @sprintf
 
@@ -103,6 +104,17 @@ cd(@__DIR__) do
             printstyled(lpad(alloc_str, alloc_align, " "), " | ", color=:white)
             rss_str = @sprintf("%5.2f", resp[6] / 2^20)
             printstyled(lpad(rss_str, rss_align, " "), "\n", color=:white)
+        finally
+            unlock(print_lock)
+        end
+    end
+
+    global print_testworker_started = (name, wrkr)->begin
+    lock(print_lock)
+        try
+            printstyled(name, color=:white)
+            printstyled(lpad("($wrkr)", name_align - length(name) + 1, " "), " |",
+                " "^elapsed_align, "started at $(now())\n", color=:white)
         finally
             unlock(print_lock)
         end

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -15,7 +15,9 @@ function runtests(name, path, isolate=true; seed=nothing)
             m = Main
         end
         @eval(m, using Test, Random)
-        println("running testset ", name, "...")
+        let id = myid()
+            wait(@spawnat 1 print_testworker_started(name, id))
+        end
         ex = quote
             @timed @testset $"$name" begin
                 # Random.seed!(nothing) will fail


### PR DESCRIPTION
This has bothered me for a while, but looks like it didn't bother
anyone else enough to clean it up, so here I go :). Printing when
a test starts is useful when looking through logs because you can
correlate errors on a given worker with the specific test it was
running. However, it doesn't have to be so ugly and break the nice
regular formatting of the rest of the test.

Before:
```
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
      From worker 3:	running testset int...
      From worker 2:	running testset math...
int        (3) |     9.51 |   0.21 |  2.2 |     507.51 |   232.42
math       (2) |    81.06 |   0.75 |  0.9 |    3391.19 |   323.18

Test Summary: |    Pass    Total
  Overall     | 1637318  1637318
    SUCCESS
```
After:
```
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
int        (3) |        started at 2019-09-27T18:35:02.761
math       (2) |        started at 2019-09-27T18:35:02.883
int        (3) |    11.91 |   0.28 |  2.4 |     723.85 |   278.07
math       (2) |    40.51 |   0.87 |  2.1 |    3287.85 |   325.49

Test Summary: |    Pass    Total
  Overall     | 2030534  2030534
    SUCCESS
```