### PR TITLE
ensure user-structs get the correct method table

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -487,16 +487,16 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
     }
     else {
         tn = jl_new_typename_in((jl_sym_t*)name, module);
-        if (super == jl_function_type || super == jl_builtin_type || jl_symbol_name(name)[0] == '#') {
-            // Callable objects (including compiler-generated closures) get independent method tables
-            // as an optimization
+        if (super == jl_function_type || super == jl_builtin_type) {
+            // Anything Julia detects as declared as a Callable objects (including compiler-generated closures)
+            // should get independent method tables, as a performance optimization
             tn->mt = jl_new_method_table(name, module);
             jl_gc_wb(tn, tn->mt);
             if (jl_svec_len(parameters) > 0)
                 tn->mt->offs = 0;
         }
         else {
-            // Everything else, gets to use the unified table
+            // Everything else, must use the unified table
             tn->mt = jl_nonfunction_mt;
         }
     }

--- a/test/core.jl
+++ b/test/core.jl
@@ -2404,6 +2404,12 @@ for f in (:(Core.arrayref), :((::typeof(Core.arrayref))), :((::Core.IntrinsicFun
     @test_throws ErrorException("cannot add methods to a builtin function") @eval $f() = 1
 end
 
+# issue #33370: make sure user types get the right method table
+let gs = gensym()
+    @eval struct $gs <: Core.Number; end
+    @test eval(gs).name.mt === Symbol.name.mt
+end
+
 # issue #8798
 let
     npy_typestrs = Dict("b1"=>Bool,


### PR DESCRIPTION
Use a different mechanism to detect front-end generated temporaries which should be reliable
instead of a hack.

fix #33370