### PR TITLE
Fix source build of p7zip on FreeBSD

### DIFF
--- a/deps/p7zip.mk
+++ b/deps/p7zip.mk
@@ -23,7 +23,11 @@ $(BUILDDIR)/p7zip-$(P7ZIP_VER)/p7zip-15-Enhanced-encryption-strength.patch-appli
 	cd $(dir $@) && patch -p4 -f < $(SRCDIR)/patches/p7zip-15-Enhanced-encryption-strength.patch
 	echo 1 > $@
 
-$(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-configured: $(BUILDDIR)/p7zip-$(P7ZIP_VER)/p7zip-15-Enhanced-encryption-strength.patch-applied
+$(BUILDDIR)/p7zip-$(P7ZIP_VER)/p7zip-Windows_ErrorMsg.patch-applied: $(BUILDDIR)/p7zip-$(P7ZIP_VER)/p7zip-15-Enhanced-encryption-strength.patch-applied
+	cd $(dir $@) && patch -p0 -f < $(SRCDIR)/patches/p7zip-Windows_ErrorMsg.patch
+	echo 1 > $@
+
+$(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-configured: $(BUILDDIR)/p7zip-$(P7ZIP_VER)/p7zip-Windows_ErrorMsg.patch-applied
 $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-compiled: $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-configured
 	$(MAKE) -C $(dir $<) $(MAKE_COMMON) CC="$(CC)" CXX="$(CXX)" 7za
 	echo 1 > $@

--- a/deps/patches/p7zip-Windows_ErrorMsg.patch
+++ b/deps/patches/p7zip-Windows_ErrorMsg.patch
@@ -1,0 +1,33 @@
+This fixes the build with Clang 6.0:
+
+ ../../../../CPP/Windows/ErrorMsg.cpp:24:10: error: case value evaluates to -2147024809, which cannot be narrowed to type 'DWORD' (aka  'unsigned int') [-Wc++11-narrowing]
+     case E_INVALIDARG          : txt = "E_INVALIDARG"; break ;
+          ^
+ ../../../../CPP/Common/MyWindows.h:89:22: note: expanded from macro 'E_INVALIDARG'
+ #define E_INVALIDARG ((HRESULT)0x80070057L)
+                      ^
+
+The HRESULT cast in the macro causes the value to be read as signed int.
+--- CPP/Windows/ErrorMsg.cpp.orig	2015-01-18 18:20:28 UTC
++++ CPP/Windows/ErrorMsg.cpp
+@@ -15,13 +15,13 @@ UString MyFormatMessage(DWORD errorCode)
+ 
+   switch(errorCode) {
+     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+-    case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+-    case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;
+-    case E_ABORT               : txt = "E_ABORT"; break ;
+-    case E_FAIL                : txt = "E_FAIL"; break ;
+-    case STG_E_INVALIDFUNCTION : txt = "STG_E_INVALIDFUNCTION"; break ;
+-    case E_OUTOFMEMORY         : txt = "E_OUTOFMEMORY"; break ;
+-    case E_INVALIDARG          : txt = "E_INVALIDARG"; break ;
++    case (DWORD)(E_NOTIMPL)             : txt = "E_NOTIMPL"; break ;
++    case (DWORD)(E_NOINTERFACE)         : txt = "E_NOINTERFACE"; break ;
++    case (DWORD)(E_ABORT)               : txt = "E_ABORT"; break ;
++    case (DWORD)(E_FAIL)                : txt = "E_FAIL"; break ;
++    case (DWORD)(STG_E_INVALIDFUNCTION) : txt = "STG_E_INVALIDFUNCTION"; break ;
++    case (DWORD)(E_OUTOFMEMORY)         : txt = "E_OUTOFMEMORY"; break ;
++    case (DWORD)(E_INVALIDARG)          : txt = "E_INVALIDARG"; break ;
+     case ERROR_DIRECTORY          : txt = "Error Directory"; break ;
+     default:
+       txt = strerror(errorCode);


### PR DESCRIPTION
Adds a patch from the FreeBSD Ports Collection to fix #33430. I've applied the patch conditional on FreeBSD but it seems like it could be fine to apply to the others.

Marking for backport to 1.3 since the change that broke this was also marked for 1.3.