### PR TITLE
Add takewhile, dropwhile to iterators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@ New library functions
 * The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `true`, which causes the process to try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
 * The `readdir` function now takes a `join::Bool` keyword argument defaulting to `false`, which when set causes `readdir` to join its directory argument with each listed name ([#33113]).
 * The new `only(x)` function returns the one-and-only element of a collection `x`, and throws an `ArgumentError` if `x` contains zero or multiple elements. ([#33129])
-* takewhile and dropwhile have been added to the Iterators submodule ([#33437]).
+* `takewhile` and `dropwhile` have been added to the Iterators submodule ([#33437]).
 
 
 Standard library changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ New library functions
 * The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `true`, which causes the process to try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
 * The `readdir` function now takes a `join::Bool` keyword argument defaulting to `false`, which when set causes `readdir` to join its directory argument with each listed name ([#33113]).
 * The new `only(x)` function returns the one-and-only element of a collection `x`, and throws an `ArgumentError` if `x` contains zero or multiple elements. ([#33129])
+* takewhile and dropwhile have been added to the Iterators submodule ([#33437]).
 
 
 Standard library changes

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -711,7 +711,7 @@ An iterator that drops element from `iter` as long as predicate `pred` is true,
 afterwards, returns every element.
 
 !!! compat "Julia 1.3"
-     This function requires at least Julia 1.3.
+    This function requires at least Julia 1.3.
 
 # Examples
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -680,23 +680,17 @@ end
 
 dropwhile(pred,itr) = DropWhile(pred,itr)
 
-function iterate(ibl::DropWhile,itr...)
-    if isempty(itr)
-        # one could use Iterators.filter with Iterators.Stateful
-        # but filter erases last elem state and
-        # stateful did not revert propertly due to nextvalstate/taken machinery
-        y = iterate(ibl.xs)
-        while y !== nothing
-            ibl.pred(y[1]) || break
-            y = iterate(ibl.xs,y[2])
-        end
-        y
-    else
-        iterate(ibl.xs, itr...)
+iterate(ibl::DropWhile,itr) = iterate(ibl.xs, itr)
+function iterate(ibl::DropWhile)
+    y = iterate(ibl.xs)
+    while y !== nothing
+        ibl.pred(y[1]) || break
+        y = iterate(ibl.xs,y[2])
     end
+    y
 end
 
-IteratorSize(::Type{DropWhile{I,P}}) where {I,P} = SizeUnknown()
+IteratorSize(::Type{<:DropWhile}) = SizeUnknown()
 eltype(::Type{DropWhile{I,P}}) where {I,P} = eltype(I)
 IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = IteratorEltype(I)
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -679,8 +679,8 @@ struct DropWhile{I,P<:Function}
 end
 
 dropwhile(pred,itr) = DropWhile(itr,pred)
-function iterate(ibl::DropWhile{I,P},itr=nothing) where {I,P}
-    (fltd,itr) = itr===nothing ? (false,()) : itr
+function iterate(ibl::DropWhile,itr...)
+    (fltd,itr) = isempty(itr) ? (false,()) : itr[1]
 
     y = fltd ?
         iterate(ibl.xs, itr...) :
@@ -689,7 +689,7 @@ function iterate(ibl::DropWhile{I,P},itr=nothing) where {I,P}
     y !== nothing ? (y[1],(true,y[2])) : nothing
 end
 
-IteratorSize(::Type{<:DropWhile}) = SizeUnknown()
+IteratorSize(::Type{DropWhile}) = SizeUnknown()
 eltype(::Type{DropWhile{I,P}}) where {I,P} = eltype(I)
 IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = IteratorEltype(I)
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -663,8 +663,8 @@ end
 An iterator that generates element from `iter` as long as predicate `pred` is true,
 afterwards, drops every element.
 
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
+!!! compat "Julia 1.4"
+    This function requires at least Julia 1.4.
 
 # Examples
 
@@ -710,8 +710,8 @@ end
 An iterator that drops element from `iter` as long as predicate `pred` is true,
 afterwards, returns every element.
 
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
+!!! compat "Julia 1.4"
+    This function requires at least Julia 1.4.
 
 # Examples
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -659,14 +659,14 @@ end
 
 takewhile(pred,xs) = TakeWhile(xs,pred)
 
-function iterate(ibl::TakeWhile{I,P},itr...) where {I,P}
+function iterate(ibl::TakeWhile, itr...)
     y = iterate(ibl.xs,itr...)
     y === nothing && return nothing
     ibl.pred(y[1]) || return nothing
     y
 end
 
-IteratorSize(ibl::TakeWhile{I,P}) where {I,P} = SizeUnknown()
+IteratorSize(::Type{<:TakeWhile}) = SizeUnknown()
 eltype(::Type{TakeWhile{I,P}}) where {I,P} = eltype(I)
 IteratorEltype(::Type{TakeWhile{I,P}}) where {I,P} = IteratorEltype(I)
 
@@ -689,7 +689,7 @@ function iterate(ibl::DropWhile{I,P},itr=nothing) where {I,P}
     y !== nothing ? (y[1],(true,y[2])) : nothing
 end
 
-IteratorSize(ibl::DropWhile{I,P}) where {I,P} = SizeUnknown()
+IteratorSize(::Type{<:DropWhile}) = SizeUnknown()
 eltype(::Type{DropWhile{I,P}}) where {I,P} = eltype(I)
 IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = IteratorEltype(I)
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -673,27 +673,25 @@ IteratorEltype(::Type{TakeWhile{I,P}}) where {I,P} = IteratorEltype(I)
 
 # dropwhile
 
-dropwhile(pred::Function,itr) = DropWhile(itr,pred)
-mutable struct DropWhile{I}
+struct DropWhile{I,P<:Function}
     xs::I
-    pred
-    fltd::Bool
-    DropWhile(xs::I,pred) where {I} = new{I}(xs,pred,false)
+    pred::P
 end
 
-function iterate(ibl::DropWhile{I},itr...) where {I}
-    if ibl.fltd
-        iterate(ibl.xs, itr...)
-    else
-        y = iterate(Iterators.filter(!ibl.pred, ibl.xs),itr...)
-        ibl.fltd = true
-        y
-    end
+dropwhile(pred,itr) = DropWhile(itr,pred)
+function iterate(ibl::DropWhile{I,P},itr=nothing) where {I,P}
+    (fltd,itr) = itr===nothing ? (false,()) : itr
+
+    y = fltd ?
+        iterate(ibl.xs, itr...) :
+        iterate(Iterators.filter(!ibl.pred, ibl.xs),itr...)
+
+    y !== nothing ? (y[1],(true,y[2])) : nothing
 end
 
-IteratorSize(ibl::DropWhile{I}) where {I} = SizeUnknown()
-eltype(::Type{DropWhile{I}}) where {I} = eltype(I)
-IteratorEltype(::Type{DropWhile{I}}) where {I} = IteratorEltype(I)
+IteratorSize(ibl::DropWhile{I,P}) where {I,P} = SizeUnknown()
+eltype(::Type{DropWhile{I,P}}) where {I,P} = eltype(I)
+IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = IteratorEltype(I)
 
 
 # Cycle an iterator forever

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -658,7 +658,7 @@ struct TakeWhile{I}
     pred
 end
 
-iterate(ibl::TakeWhile{I},itr...) where {I} = begin
+function iterate(ibl::TakeWhile{I},itr...) where {I}
     y = iterate(ibl.xs,itr...)
     y === nothing && return nothing
     ibl.pred(y[1]) || return nothing
@@ -680,7 +680,7 @@ mutable struct DropWhile{I}
     DropWhile(xs::I,pred) where {I} = new{I}(xs,pred,false)
 end
 
-iterate(ibl::DropWhile{I},itr...) where {I} = begin
+function iterate(ibl::DropWhile{I},itr...) where {I}
     if ibl.fltd
         iterate(ibl.xs, itr...)
     else

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -22,7 +22,7 @@ import .Base:
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek
 
-export enumerate, zip, rest, countfrom, take, drop, cycle, repeated, product, flatten, partition
+export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, partition
 
 tail_if_any(::Tuple{}) = ()
 tail_if_any(x::Tuple) = tail(x)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -671,16 +671,16 @@ afterwards, drops every element.
 ```jldoctest
 julia> s = collect(1:5)
 5-element Array{Int64,1}:
-  1
-  2
-  3
-  4
-  5
+ 1
+ 2
+ 3
+ 4
+ 5
 
 julia> collect(Iterators.takewhile(<(3),s))
 2-element Array{Int64,1}:
-  1
-  2
+ 1
+ 2
 ```
 """
 takewhile(pred,xs) = TakeWhile(pred,xs)
@@ -718,17 +718,17 @@ afterwards, returns every element.
 ```jldoctest
 julia> s = collect(1:5)
 5-element Array{Int64,1}:
-  1
-  2
-  3
-  4
-  5
+ 1
+ 2
+ 3
+ 4
+ 5
 
 julia> collect(Iterators.dropwhile(<(3),s))
 3-element Array{Int64,1}:
-  3
-  4
-  5
+ 3
+ 4
+ 5
 ```
 """
 dropwhile(pred,itr) = DropWhile(pred,itr)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -674,12 +674,12 @@ Base.IteratorEltype(::Type{TakeWhile{I,P}}) where {I,P} = Base.IteratorEltype(I)
 # dropwhile
 
 struct DropWhile{I,P<:Function}
-    xs::I
     pred::P
+    xs::I
 end
 
-dropwhile(pred,itr) = DropWhile(itr,pred)
-function iterate(ibl::DropWhile,itr...)
+dropwhile(pred,itr) = DropWhile(pred,itr)
+function Base.iterate(ibl::DropWhile,itr...)
     (fltd,itr) = isempty(itr) ? (false,()) : itr[1]
 
     y = fltd ?
@@ -689,9 +689,9 @@ function iterate(ibl::DropWhile,itr...)
     y !== nothing ? (y[1],(true,y[2])) : nothing
 end
 
-IteratorSize(::Type{DropWhile}) = SizeUnknown()
-eltype(::Type{DropWhile{I,P}}) where {I,P} = eltype(I)
-IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = IteratorEltype(I)
+Base.IteratorSize(::Type{DropWhile{I,P}}) where {I,P} = Base.SizeUnknown()
+Base.eltype(::Type{DropWhile{I,P}}) where {I,P} = Base.eltype(I)
+Base.IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = Base.IteratorEltype(I)
 
 
 # Cycle an iterator forever

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -657,6 +657,32 @@ struct TakeWhile{I,P<:Function}
     xs::I
 end
 
+"""
+    takewhile(pred, iter)
+
+An iterator that generates element from `iter` as long as predicate `pred` is true,
+afterwards, drops every element.
+
+!!! compat "Julia 1.3"
+     This function requires at least Julia 1.3.
+
+# Examples
+
+```jldoctest
+julia> s = collect(1:5)
+5-element Array{Int64,1}:
+  1
+  2
+  3
+  4
+  5
+
+julia> collect(Iterators.takewhile(<(3),s))
+2-element Array{Int64,1}:
+  1
+  2
+```
+"""
 takewhile(pred,xs) = TakeWhile(pred,xs)
 
 function iterate(ibl::TakeWhile, itr...)
@@ -678,6 +704,33 @@ struct DropWhile{I,P<:Function}
     xs::I
 end
 
+"""
+    dropwhile(pred, iter)
+
+An iterator that drops element from `iter` as long as predicate `pred` is true,
+afterwards, returns every element.
+
+!!! compat "Julia 1.3"
+     This function requires at least Julia 1.3.
+
+# Examples
+
+```jldoctest
+julia> s = collect(1:5)
+5-element Array{Int64,1}:
+  1
+  2
+  3
+  4
+  5
+
+julia> collect(Iterators.dropwhile(<(3),s))
+3-element Array{Int64,1}:
+  3
+  4
+  5
+```
+"""
 dropwhile(pred,itr) = DropWhile(pred,itr)
 
 iterate(ibl::DropWhile,itr) = iterate(ibl.xs, itr)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -652,22 +652,23 @@ isdone(it::Drop, state) = isdone(it.xs, state)
 
 # takewhile
 
-takewhile(pred::Function,xs) = TakeWhile(xs,pred)
-struct TakeWhile{I}
+struct TakeWhile{I,P<:Function}
     xs::I
-    pred
+    pred::P
 end
 
-function iterate(ibl::TakeWhile{I},itr...) where {I}
+takewhile(pred,xs) = TakeWhile(xs,pred)
+
+function iterate(ibl::TakeWhile{I,P},itr...) where {I,P}
     y = iterate(ibl.xs,itr...)
     y === nothing && return nothing
     ibl.pred(y[1]) || return nothing
     y
 end
 
-IteratorSize(ibl::TakeWhile{I}) where {I} = SizeUnknown()
-eltype(::Type{TakeWhile{I}}) where {I} = eltype(I)
-IteratorEltype(::Type{TakeWhile{I}}) where {I} = IteratorEltype(I)
+IteratorSize(ibl::TakeWhile{I,P}) where {I,P} = SizeUnknown()
+eltype(::Type{TakeWhile{I,P}}) where {I,P} = eltype(I)
+IteratorEltype(::Type{TakeWhile{I,P}}) where {I,P} = IteratorEltype(I)
 
 
 # dropwhile

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -653,22 +653,22 @@ isdone(it::Drop, state) = isdone(it.xs, state)
 # takewhile
 
 struct TakeWhile{I,P<:Function}
-    xs::I
     pred::P
+    xs::I
 end
 
-takewhile(pred,xs) = TakeWhile(xs,pred)
+takewhile(pred,xs) = TakeWhile(pred,xs)
 
-function iterate(ibl::TakeWhile, itr...)
+function Base.iterate(ibl::TakeWhile, itr...)
     y = iterate(ibl.xs,itr...)
     y === nothing && return nothing
     ibl.pred(y[1]) || return nothing
     y
 end
 
-IteratorSize(::Type{<:TakeWhile}) = SizeUnknown()
-eltype(::Type{TakeWhile{I,P}}) where {I,P} = eltype(I)
-IteratorEltype(::Type{TakeWhile{I,P}}) where {I,P} = IteratorEltype(I)
+Base.IteratorSize(::Type{<:TakeWhile}) = Base.SizeUnknown()
+Base.eltype(::Type{TakeWhile{I,P}}) where {I,P} = Base.eltype(I)
+Base.IteratorEltype(::Type{TakeWhile{I,P}}) where {I,P} = Base.IteratorEltype(I)
 
 
 # dropwhile

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -664,7 +664,7 @@ An iterator that generates element from `iter` as long as predicate `pred` is tr
 afterwards, drops every element.
 
 !!! compat "Julia 1.3"
-     This function requires at least Julia 1.3.
+    This function requires at least Julia 1.3.
 
 # Examples
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -151,7 +151,7 @@ end
 
 # takewhile
 # --------
-@testset "takewhile" begin
+@testset begin
     @test collect(takewhile(<(4),1:10)) == [1,2,3]
     @test collect(takewhile(<(4),Iterators.countfrom(1))) == [1,2,3]
     @test collect(takewhile(<(4),5:10)) == []
@@ -162,7 +162,7 @@ end
 
 # dropwhile
 # --------
-@testset "dropwhile" begin
+@testset begin
     @test collect(dropwhile(<(4), 1:10)) == 4:10
     @test collect(dropwhile(<(4), 1:10)) isa Vector{Int}
     @test isempty(dropwhile(<(4), []))

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -152,12 +152,12 @@ end
 # takewhile
 # --------
 @testset "takewhile" begin
-    @test takewhile(x -> x<4,1:10) |> collect == [1,2,3]
+    @test collect(takewhile(x -> x<4,1:10)) == [1,2,3]
     @test takewhile(x -> x<4,Iterators.countfrom(1)) |> collect == [1,2,3]
     @test takewhile(x -> x<4,5:10) |> collect == []
-    @test takewhile(x -> true,5:10) |> collect == 5:10 |> collect
+    @test collect(takewhile(x -> true,5:10)) == 5:10
     @test takewhile(isodd,[1,1,2,3]) |> collect == [1,1]
-    @test takewhile(<(3),[1,1,2,3]) |> s->takewhile(<(2),s) |> collect == [1,1]
+    @test collect(takewhile(<(2), takewhile(<(3), [1,1,2,3]))) == [1,1]
 end
 
 
@@ -166,7 +166,7 @@ end
 @testset "dropwhile" begin
     @test dropwhile(x -> x<4, 1:10) |> collect == 4:10 |> collect
     @test (dropwhile(x -> x<4, 1:10) |> collect) isa Vector{Int}
-    @test dropwhile(x -> x<4, []) |> collect == [] |> collect
+    @test collect(dropwhile(x -> x<4, [])) == []
     @test dropwhile(_ -> false,1:3) |> collect == 1:3 |> collect
     @test dropwhile(_ -> true, 1:3) |> isempty
     @test dropwhile(isodd,[1,1,2,3]) |> collect == [2,3]

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -149,6 +149,30 @@ for xs in Any["abc", [1, 2, 3]]
     @test take(drop(take(xs, 3), 1), 1) === take(drop(xs, 1), 1)
 end
 
+# takewhile
+# --------
+@testset "takewhile" begin
+    @test takewhile(x -> x<4,1:10) |> collect == [1,2,3]
+    @test takewhile(x -> x<4,Iterators.countfrom(1)) |> collect == [1,2,3]
+    @test takewhile(x -> x<4,5:10) |> collect == []
+    @test takewhile(x -> true,5:10) |> collect == 5:10 |> collect
+    @test takewhile(isodd,[1,1,2,3]) |> collect == [1,1]
+    @test takewhile(<(3),[1,1,2,3]) |> s->takewhile(<(2),s) |> collect == [1,1]
+end
+
+
+# dropwhile
+# --------
+@testset "dropwhile" begin
+    @test dropwhile(x -> x<4, 1:10) |> collect == 4:10 |> collect
+    @test (dropwhile(x -> x<4, 1:10) |> collect) isa Vector{Int}
+    @test dropwhile(x -> x<4, []) |> collect == [] |> collect
+    @test dropwhile(_ -> false,1:3) |> collect == 1:3 |> collect
+    @test dropwhile(_ -> true, 1:3) |> isempty
+    @test dropwhile(isodd,[1,1,2,3]) |> collect == [2,3]
+    @test dropwhile(isodd,[1,1,2,3]) |> s->dropwhile(iseven,s) |> collect == [3]
+end
+
 # cycle
 # -----
 let i = 0

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -164,14 +164,15 @@ end
 # dropwhile
 # --------
 @testset "dropwhile" begin
-    @test dropwhile(x -> x<4, 1:10) |> collect == 4:10 |> collect
-    @test (dropwhile(x -> x<4, 1:10) |> collect) isa Vector{Int}
-    @test collect(dropwhile(x -> x<4, [])) == []
-    @test dropwhile(_ -> false,1:3) |> collect == 1:3 |> collect
-    @test dropwhile(_ -> true, 1:3) |> isempty
-    @test dropwhile(isodd,[1,1,2,3]) |> collect == [2,3]
+    @test collect(dropwhile(<(4), 1:10)) == 4:10
+    @test collect(dropwhile(<(4), 1:10)) isa Vector{Int}
+    @test isempty(dropwhile(<(4), []))
+    @test collect(dropwhile(_->false,1:3)) == 1:3
+    @test isempty(dropwhile(_->true, 1:3))
+    @test collect(dropwhile(isodd,[1,1,2,3])) == [2,3]
     @test dropwhile(isodd,[1,1,2,3]) |> s->dropwhile(iseven,s) |> collect == [3]
 end
+
 
 # cycle
 # -----

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -152,11 +152,11 @@ end
 # takewhile
 # --------
 @testset "takewhile" begin
-    @test collect(takewhile(x -> x<4,1:10)) == [1,2,3]
-    @test takewhile(x -> x<4,Iterators.countfrom(1)) |> collect == [1,2,3]
-    @test takewhile(x -> x<4,5:10) |> collect == []
-    @test collect(takewhile(x -> true,5:10)) == 5:10
-    @test takewhile(isodd,[1,1,2,3]) |> collect == [1,1]
+    @test collect(takewhile(<(4),1:10)) == [1,2,3]
+    @test collect(takewhile(<(4),Iterators.countfrom(1))) == [1,2,3]
+    @test collect(takewhile(<(4),5:10)) == []
+    @test collect(takewhile(_->true,5:10)) == 5:10
+    @test collect(takewhile(isodd,[1,1,2,3])) == [1,1]
     @test collect(takewhile(<(2), takewhile(<(3), [1,1,2,3]))) == [1,1]
 end
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -160,7 +160,6 @@ end
     @test collect(takewhile(<(2), takewhile(<(3), [1,1,2,3]))) == [1,1]
 end
 
-
 # dropwhile
 # --------
 @testset "dropwhile" begin
@@ -170,9 +169,8 @@ end
     @test collect(dropwhile(_->false,1:3)) == 1:3
     @test isempty(dropwhile(_->true, 1:3))
     @test collect(dropwhile(isodd,[1,1,2,3])) == [2,3]
-    @test dropwhile(isodd,[1,1,2,3]) |> s->dropwhile(iseven,s) |> collect == [3]
+    @test collect(dropwhile(iseven,dropwhile(isodd,[1,1,2,3]))) == [3]
 end
-
 
 # cycle
 # -----


### PR DESCRIPTION
Constating that python, ruby, rust, elixir all offer takewhile, dropwhile

| language | take while| drop while |
|---|---|---|
| python | [takewhile](https://docs.python.org/3.7/library/itertools.html#itertools.takewhile) | [dropwhile](https://docs.python.org/3.7/library/itertools.html#itertools.dropwhile) |
| ruby | [take_while](https://ruby-doc.org/core-2.6.4/Enumerable.html#method-i-take_while) | [drop_while](https://ruby-doc.org/core-2.6.4/Enumerable.html#method-i-drop_while) |
| rust | [take_while](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.take_while) | [skip_while](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.skip_while) |
| elixir | [take_while](https://hexdocs.pm/elixir/Enum.html#take_while/2) | [drop_while](https://hexdocs.pm/elixir/Enum.html#drop_while/2) |

And also dotnet, java, scala !

I think Julia should have them too.

IterTools.jl, and rust have been consulted.