### PR TITLE
better fix for #33337; revert #33353

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1680,3 +1680,5 @@ c32703(::Type{<:Str{C}}, str::Str{C}) where {C<:CSE} = str
 # issue #33337
 @test !issub(Tuple{Type{T}, T} where T<:NTuple{30, Union{Nothing, Ref}},
              Tuple{Type{Tuple{Vararg{V, N} where N}}, Tuple{Vararg{V, N} where N}} where V)
+@test  issub(Tuple{Type{Any}, NTuple{4,Union{Int,Nothing}}},
+             Tuple{Type{V}, Tuple{Vararg{V, N} where N}} where V)


### PR DESCRIPTION
As @vtjnash pointed out, #33353 was not quite correct. This adds a test for that plus a different fix that's more general and hopefully correct as well.