### PR TITLE
Fix attaching docstrings to where call syntax

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -534,6 +534,12 @@ function docm(source::LineNumberNode, mod::Module, meta, ex, define::Bool = true
     isexpr(x, [:function, :macro])  && !isexpr(x.args[1], :call) ? objectdoc(source, mod, meta, def, x) :
     isexpr(x, :call)                                   ? calldoc(source, mod, meta, x) :
 
+    # Parametric method "call" syntax (see #32960), i.e.
+    #
+    #   f(x::T) where {T}
+    #
+    isexpr(x, :where) && isexpr(x.args[1], :call) ? calldoc(source, mod, meta, x) :
+
     # Type definitions.
     #
     #   struct T ... end

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -366,13 +366,15 @@ end
 
 function calldoc(__source__, __module__, str, def::Expr)
     @nospecialize str
-    args = def.args[2:end]
+    args = callargs(def)
     if isempty(args) || all(validcall, args)
         objectdoc(__source__, __module__, str, nothing, def, signature(def))
     else
         docerror(def)
     end
 end
+callargs(ex::Expr) = isexpr(ex, :where) ? callargs(ex.args[1]) :
+    isexpr(ex, :call) ? ex.args[2:end] : error("Invalid expression to callargs: $ex")
 validcall(x) = isa(x, Symbol) || isexpr(x, (:(::), :..., :kw, :parameters))
 
 function moduledoc(__source__, __module__, meta, def, def′::Expr)
@@ -502,6 +504,12 @@ function docm(source::LineNumberNode, mod::Module, ex)
     end
 end
 
+# iscallexpr checks if an expression is a :call expression. The call expression may be
+# also part of a :where expression, so it unwraps the :where layers until it reaches the
+# "actual" expression
+iscallexpr(ex::Expr) = isexpr(ex, :where) ? iscallexpr(ex.args[1]) : isexpr(ex, :call)
+iscallexpr(ex) = false
+
 function docm(source::LineNumberNode, mod::Module, meta, ex, define::Bool = true)
     @nospecialize meta ex
     # Some documented expressions may be decorated with macro calls which obscure the actual
@@ -530,15 +538,14 @@ function docm(source::LineNumberNode, mod::Module, meta, ex, define::Bool = true
     #   function f end
     #   f(...)
     #
-    isexpr(x, FUNC_HEADS) && is_signature(x.args[1])   ? objectdoc(source, mod, meta, def, x, signature(x)) :
+    # Including if the "call" expression is wrapped in "where" expression(s) (#32960), i.e.
+    #
+    #   f(::T) where T
+    #   f(::T, ::U) where T where U
+    #
+    isexpr(x, FUNC_HEADS) && is_signature(x.args[1]) ? objectdoc(source, mod, meta, def, x, signature(x)) :
     isexpr(x, [:function, :macro])  && !isexpr(x.args[1], :call) ? objectdoc(source, mod, meta, def, x) :
-    isexpr(x, :call)                                   ? calldoc(source, mod, meta, x) :
-
-    # Parametric method "call" syntax (see #32960), i.e.
-    #
-    #   f(x::T) where {T}
-    #
-    isexpr(x, :where) && isexpr(x.args[1], :call) ? calldoc(source, mod, meta, x) :
+    iscallexpr(x) ? calldoc(source, mod, meta, x) :
 
     # Type definitions.
     #

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -153,6 +153,18 @@ t(::Int, ::Any)
 "t-3"
 t{S <: Integer}(::S)
 
+# Docstrings to parametric methods after definition using where syntax (#32960):
+tw(x::T) where T = nothing
+tw(x::T, y::U) where {T, U <: Integer} = nothing
+tw(x::T, y::U, z::V) where T where U <: Integer where V <: AbstractFloat = nothing
+
+"tw-1"
+tw(x::T) where T
+"tw-2"
+tw(x::T, y::U) where {T, U <: Integer}
+"tw-3"
+tw(x::T, y::U, z::V) where T where U <: Integer where V <: AbstractFloat
+
 "FieldDocs"
 mutable struct FieldDocs
     "one"


### PR DESCRIPTION
Fix #32960. I.e. that it would be possible to attach docstrings as follows:

```julia
"docstring"
sin(x::Vector{T}, ::T) where {T <: Integer}
```

---

The lookup (e.g. in `help>`) for the parametric methods is still a bit broken. E.g. if you have the following definitions:

```julia
"    tw(x::T) where T"
tw(x::T) where T = nothing
"    tw(x::T, y::U) where {T, U <: Integer}"
tw(x::T, y::U) where {T, U <: Integer} = nothing
"    tw(x::T, y::U, z::V) where T where U <: Integer where V <: AbstractFloat"
tw(x::T, y::U, z::V) where T where U <: Integer where V <: AbstractFloat = nothing
```

Looking up the single argument method does not work correctly for some reason:

```
help?> tw(0)
  tw(x::T) where T

  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  tw(x::T, y::U) where {T, U <: Integer}

  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  tw(x::T, y::U, z::V) where T where U <: Integer where V <: AbstractFloat

help?> tw(0,0)
  tw(x::T, y::U) where {T, U <: Integer}

help?> tw(0,0,0.0)
  tw(x::T, y::U, z::V) where T where U <: Integer where V <: AbstractFloat
```

But that is actually separate from the original issue.