### PR TITLE
stop hard-exiting from generate_precompile when JULIA_PRECOMPILE=0

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -1,9 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-if !isempty(ARGS)
-    ARGS[1] == "0" && exit(0)
-end
-
+if isempty(ARGS) || ARGS[1] !== "0"
 # Prevent this from being put into the Main namespace
 @eval Module() begin
 if !isdefined(Base, :uv_eventloop)
@@ -180,3 +177,4 @@ end
 generate_precompile_statements()
 
 end # @eval
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/33182

Running `exit(0)` prevents the cleanup procedure in `include` to run which messes up the state of  `current_task().storage[:SOURCE_PATH]`.

@maleadt, could you try this out.