### PR TITLE
Support for fine-grained selection of the GC collection type.

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -49,15 +49,29 @@ Module with garbage collection utilities.
 """
 module GC
 
-"""
-    GC.gc()
+# @enum-like structure
+struct CollectionType
+    x::Int
+end
+Base.cconvert(::Type{Cint}, collection::CollectionType) = Cint(collection.x)
 
-Perform garbage collection.
+const Auto          = CollectionType(0)
+const Full          = CollectionType(1)
+const Incremental   = CollectionType(2)
+
+"""
+    GC.gc(full::Bool=true)
+    GC.gc(collection::CollectionType)
+
+Perform garbage collection. The argument `full` determines whether a full, but more costly
+collection is performed. Otherwise, heuristics are used to determine which type of
+collection is needed. For exact control, pass an argument of type `CollectionType`.
 
 !!! warning
     Excessive use will likely lead to poor performance.
 """
-gc(full::Bool=true) = ccall(:jl_gc_collect, Cvoid, (Int32,), full)
+gc(full::Bool=true) = ccall(:jl_gc_collect, Cvoid, (Cint,), full)
+gc(collection::CollectionType) = ccall(:jl_gc_collect, Cvoid, (Cint,), collection)
 
 """
     GC.enable(on::Bool)

--- a/src/julia.h
+++ b/src/julia.h
@@ -746,7 +746,13 @@ JL_DLLEXPORT int64_t jl_gc_total_bytes(void);
 JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void);
 JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
 
-JL_DLLEXPORT void jl_gc_collect(int);
+typedef enum {
+    JL_GC_AUTO = 0,         // use heuristics to determine the collection type
+    JL_GC_FULL = 1,         // force a full collection
+    JL_GC_INCREMENTAL = 2,  // force an incremental collection
+} jl_gc_collection_t;
+
+JL_DLLEXPORT void jl_gc_collect(jl_gc_collection_t);
 
 JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
 JL_DLLEXPORT void jl_finalize(jl_value_t *o);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1269,8 +1269,8 @@ static void jl_cleanup_serializer2(void);
 
 static void jl_save_system_image_to_stream(ios_t *f)
 {
-    jl_gc_collect(1); // full
-    jl_gc_collect(0); // incremental (sweep finalizers)
+    jl_gc_collect(JL_GC_FULL);
+    jl_gc_collect(JL_GC_INCREMENTAL);   // sweep finalizers
     JL_TIMING(SYSIMG_DUMP);
     int en = jl_gc_enable(0);
     jl_init_serializer2(1);

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -758,3 +758,12 @@ end
 # Finalizer with immutable should throw
 @test_throws ErrorException finalizer(x->nothing, 1)
 @test_throws ErrorException finalizer(C_NULL, 1)
+
+
+@testset "GC utilities" begin
+    GC.gc()
+    GC.gc(true); GC.gc(false)
+    GC.gc(GC.Auto); GC.gc(GC.Full); GC.gc(GC.Incremental)
+
+    GC.safepoint()
+end


### PR DESCRIPTION
This makes it possible to force an incremental collection, ignoring full collection heuristics.

**Motivation**: from the GPU allocator, we routinely call into the Julia GC to free GPU buffer objects. If GPU memory pressure is high, we do this quite regularly (e.g. twice a second). An incremental collection is often enough to free up sufficient GPU memory, and this initially takes about 40~50ms (for a Flux model I'm profiling), but after a while the collection time drops off a cliff to about 500ms for all calls to `gc(false)`. This is due to the GC heuristics forcing a full collection since the incremental ones "fail" to collect enough memory (GPU buffer objects are tiny, and do not reflect actual GPU memory freed).

This PR adds the (non-breaking) ability to force an incremental collection, ignoring all heuristics.

TODO:
- [x] tests
- [x] Julia API