### PR TITLE
Restrict `signed(x) = reinterpret(...)` to BitIntegers.

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -137,9 +137,6 @@ abs(x::Signed) = flipsign(x,x)
 
 ~(n::Integer) = -n-1
 
-unsigned(x::BitSigned) = reinterpret(typeof(convert(Unsigned, zero(x))), x)
-unsigned(x::Bool) = convert(Unsigned, x)
-
 """
     unsigned(x) -> Unsigned
 
@@ -159,7 +156,7 @@ julia> signed(unsigned(-2))
 ```
 """
 unsigned(x) = convert(Unsigned, x)
-signed(x::Unsigned) = reinterpret(typeof(convert(Signed, zero(x))), x)
+unsigned(x::BitSigned) = reinterpret(typeof(convert(Unsigned, zero(x))), x)
 
 """
     signed(x)
@@ -168,6 +165,7 @@ Convert a number to a signed integer. If the argument is unsigned, it is reinter
 signed without checking for overflow.
 """
 signed(x) = convert(Signed, x)
+signed(x::BitUnsigned) = reinterpret(typeof(convert(Signed, zero(x))), x)
 
 div(x::BitSigned, y::Unsigned) = flipsign(signed(div(unsigned(abs(x)), y)), x)
 div(x::Unsigned, y::BitSigned) = unsigned(flipsign(signed(div(x, unsigned(abs(y)))), y))


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/30473

This is a minor PR, but it fixes an inconsistency in Base that was brought up in #30473 and was blocking the merge of https://github.com/JuliaLang/julia/pull/30445#discussion_r243427894. :)

I also reordered the definitions to clean them up a bit. :)
(Note that I also deleted the extra method for unsigned(x::Bool) because it's already covered by the default `unsigned(x) = convert(Unsigned, x)` (since `Bool <: Base.BitSigned) == false`), and it was a redundant copy/paste. ☺️)

---------

This commit restricts the `reinterpret` implementation of `signed(x)`
to only apply to `Base.BitInteger`s. This brings its behavior in-line
with `unsigned(x)`.

Previously, although `unsigned(x)` did restrict the `reinterpret`
implementation to only apply to `Base.BitInteger`s, `signed(x)` by
default called `reinterpret(Signed, x)` for any type `T <: Unsigned`.

This of course wouldn't work for `BigInt`, which is presumably why
`unsigned(x)` was restricted (since `BigInt <: Signed` but not `BigInt
<: BitInteger`), but although _Base_ contains no non-BitInteger types in
`Unsigned` (besides `Bool`), of course users _could_ create such types,
so this should be restricted symmetrically.

Below is an example of the previous, unexpected broken behavior (curtesy @timholy):
```julia
struct WeirdUnsigned <: Unsigned
    msg::String
    val::UInt16
end
WeirdUnsigned(x::Int) = WeirdUnsigned("missing", UInt16(x))
Base.Signed(x::WeirdUnsigned) = signed(x.val)
```
```julia
julia> signed(WeirdUnsigned(4))
ERROR: bitcast: expected primitive type value for second argument
Stacktrace:
 [1] reinterpret at ./essentials.jl:417 [inlined]
 [2] signed(::WeirdUnsigned) at ./int.jl:162
 [3] top-level scope at REPL[20]:1
```

Whereas after this commit, this works as expected, calling the `Signed`
constructor:
```julia
julia> signed(WeirdUnsigned(4))
4

julia> typeof(signed(WeirdUnsigned(4)))
Int16
```

-------------------

This should be a non-breaking change. If there exist any `primitive
type` implementations that were relying on the reinterpret
implementation, they may see a slight performance regression, as this
will by default now call `Signed(x::T)`, instead of
`reinterpret(typeof(Signed(x)), x)` -- so they may want to manually
define the reinterpret implemention themselves.


CC: @JeffreySarnoff, @timholy 