### PR TITLE
add setindex for named tuples

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -300,3 +300,27 @@ function structdiff(a::NamedTuple{an}, b::Union{NamedTuple{bn}, Type{NamedTuple{
         NamedTuple{names,types}(map(n->getfield(a, n), names))
     end
 end
+
+"""
+    setindex(nt::NamedTuple{names}, val::V, key::K) where {names, V, K}
+
+Constructs a new `NamedTuple` with the key `key` set to `val`.
+If `key` is already in the keys of `nt`, `val` replaces the old value.
+
+```jldoctest
+julia> nt = (a = 3,)
+(a = 3,)
+
+julia> setindex(nt, 33, :b)
+(a = 3, b = 33)
+
+julia> setindex(nt, 4, :a)
+(a = 4,)
+
+julia> setindex(nt, "a", :a)
+(a = "a",)
+```
+"""
+function setindex(nt::NamedTuple{names}, v::V, idx::Symbol) where {names, V, K}
+    merge(nt, ((idx, v),))
+end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -311,13 +311,13 @@ If `key` is already in the keys of `nt`, `val` replaces the old value.
 julia> nt = (a = 3,)
 (a = 3,)
 
-julia> setindex(nt, 33, :b)
+julia> Base.setindex(nt, 33, :b)
 (a = 3, b = 33)
 
-julia> setindex(nt, 4, :a)
+julia> Base.setindex(nt, 4, :a)
 (a = 4,)
 
-julia> setindex(nt, "a", :a)
+julia> Base.setindex(nt, "a", :a)
 (a = "a",)
 ```
 """

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -321,6 +321,6 @@ julia> Base.setindex(nt, "a", :a)
 (a = "a",)
 ```
 """
-function setindex(nt::NamedTuple{names}, v::V, idx::Symbol) where {names, V, K}
+function setindex(nt::NamedTuple, v, idx::Symbol)
     merge(nt, ((idx, v),))
 end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -322,5 +322,5 @@ julia> Base.setindex(nt, "a", :a)
 ```
 """
 function setindex(nt::NamedTuple, v, idx::Symbol)
-    merge(nt, ((idx, v),))
+    merge(nt, (; idx => v))
 end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -302,7 +302,7 @@ function structdiff(a::NamedTuple{an}, b::Union{NamedTuple{bn}, Type{NamedTuple{
 end
 
 """
-    setindex(nt::NamedTuple{names}, val::V, key::K) where {names, V, K}
+    setindex(nt::NamedTuple, val, key::Symbol)
 
 Constructs a new `NamedTuple` with the key `key` set to `val`.
 If `key` is already in the keys of `nt`, `val` replaces the old value.

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -267,3 +267,11 @@ let n = NamedTuple{(:T,), Tuple{Type{Float64}}}((Float64,))
     @test n isa NamedTuple{(:T,), Tuple{Type{Float64}}}
     @test n.T === Float64
 end
+
+# setindex
+let nt0 = NamedTuple(), nt1 = (a=33,), nt2 = (a=0, b=:v)
+    @test Base.setindex(nt0, 33, :a) == nt1
+    @test Base.setindex(Base.setindex(nt1, 0, :a), :v, :b) == nt2
+    @test Base.setindex(nt1, "value", :a) == (a="value",)
+    @test Base.setindex(nt1, "value", :a) isa NamedTuple{(:a,),<:Tuple{AbstractString}}
+end


### PR DESCRIPTION
Given that `Base.setindex` is now documented, I think it makes some sense to have it defined for `NamedTuple`s as well.
The implementation may be naive here and uses `merge(::NamedTuple, itr)`, given that the left argument re-writes member already present in the first argument