### PR TITLE
improve `instanceof_tfunc` to take declared parameter bounds into account

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -78,7 +78,13 @@ function instanceof_tfunc(@nospecialize(t))
     elseif isa(t, UnionAll)
         t′ = unwrap_unionall(t)
         t′′, isexact = instanceof_tfunc(t′)
-        return rewrap_unionall(t′′, t), isexact
+        tr = rewrap_unionall(t′′, t)
+        if t′′ isa DataType && !has_free_typevars(tr)
+            # a real instance must be within the declared bounds of the type,
+            # so we can intersect with the original wrapper.
+            tr = typeintersect(tr, t′′.name.wrapper)
+        end
+        return tr, isexact
     elseif isa(t, Union)
         ta, isexact_a = instanceof_tfunc(t.a)
         tb, isexact_b = instanceof_tfunc(t.b)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2442,3 +2442,6 @@ f31974(n::Int) = f31974(1:n)
 # This query hangs if type inference improperly attempts to const prop
 # call cycles.
 @test code_typed(f31974, Tuple{Int}) !== nothing
+
+f_overly_abstract_complex() = Complex(Ref{Number}(1)[])
+@test Base.return_types(f_overly_abstract_complex, Tuple{}) == [Complex]


### PR DESCRIPTION
This fixes the following inference performance issue identified by @andreasnoack :
```
julia> using DataFrames

julia> @time cumsum(rand(2, 2), dims=1);
 59.742860 seconds (72.02 M allocations: 4.530 GiB, 2.89% gc time)
```
(except on master it's even worse)

What happened here was that a type got inferred as `CartesianIndices{A,B} where {A,B}` --- there are no limits on A and B even though the type has some declared bounds. That in turn caused us to infer into methods that actually could not be applicable, because we thought `iterate(::CartesianIndices)` might not cover every case. That led to a lot of recursion that made it very hard to infer a lot of code.

It's a bit lucky that this ends up being enough to fix it. Does not help #33336.