### PR TITLE
add some type info to Base to avoid excess recursion in inference

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1190,13 +1190,13 @@ mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !_i
 mightalias(x, y) = false
 
 _isdisjoint(as::Tuple{}, bs::Tuple{}) = true
-_isdisjoint(as::Tuple{}, bs::Tuple{Any}) = true
+_isdisjoint(as::Tuple{}, bs::Tuple{UInt}) = true
 _isdisjoint(as::Tuple{}, bs::Tuple) = true
-_isdisjoint(as::Tuple{Any}, bs::Tuple{}) = true
-_isdisjoint(as::Tuple{Any}, bs::Tuple{Any}) = as[1] != bs[1]
-_isdisjoint(as::Tuple{Any}, bs::Tuple) = !(as[1] in bs)
+_isdisjoint(as::Tuple{UInt}, bs::Tuple{}) = true
+_isdisjoint(as::Tuple{UInt}, bs::Tuple{UInt}) = as[1] != bs[1]
+_isdisjoint(as::Tuple{UInt}, bs::Tuple) = !(as[1] in bs)
 _isdisjoint(as::Tuple, bs::Tuple{}) = true
-_isdisjoint(as::Tuple, bs::Tuple{Any}) = !(bs[1] in as)
+_isdisjoint(as::Tuple, bs::Tuple{UInt}) = !(bs[1] in as)
 _isdisjoint(as::Tuple, bs::Tuple) = !(as[1] in bs) && _isdisjoint(tail(as), bs)
 
 """

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -555,7 +555,7 @@ Base.@propagate_inbounds _newindex(ax::Tuple{}, I::Tuple{}) = ()
 @inline function _newindexer(indsA::Tuple)
     ind1 = indsA[1]
     keep, Idefault = _newindexer(tail(indsA))
-    (Base.length(ind1)!=1, keep...), (first(ind1), Idefault...)
+    (Base.length(ind1)::Integer != 1, keep...), (first(ind1), Idefault...)
 end
 
 @inline function Base.getindex(bc::Broadcasted, I::Union{Integer,CartesianIndex})

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -64,7 +64,7 @@ Core.NamedTuple
 if nameof(@__MODULE__) === :Base
 
 @eval function NamedTuple{names,T}(args::Tuple) where {names, T <: Tuple}
-    if length(args) != length(names)
+    if length(args) != length(names::Tuple)
         throw(ArgumentError("Wrong number of arguments to named tuple constructor."))
     end
     # Note T(args) might not return something of type T; e.g.
@@ -251,8 +251,8 @@ julia> merge((a=1, b=2, c=3), [:b=>4, :d=>5])
 function merge(a::NamedTuple, itr)
     names = Symbol[]
     vals = Any[]
-    inds = IdDict()
-    for (k,v) in itr
+    inds = IdDict{Symbol,Int}()
+    for (k::Symbol, v) in itr
         oldind = get(inds, k, 0)
         if oldind > 0
             vals[oldind] = v

--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -55,12 +55,13 @@ ntuple(f, ::Val{3}) = (@_inline_meta; (f(1), f(2), f(3)))
     end
 end
 
-@inline function fill_to_length(t::Tuple, val, ::Val{N}) where {N}
+@inline function fill_to_length(t::Tuple, val, ::Val{_N}) where {_N}
     M = length(t)
+    N = _N::Int
     M > N && throw(ArgumentError("input tuple of length $M, requested $N"))
     if @generated
         quote
-            (t..., $(fill(:val, N-length(t.parameters))...))
+            (t..., $(fill(:val, (_N::Int) - length(t.parameters))...))
         end
     else
         (t..., fill(val, N-M)...)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -147,7 +147,7 @@ function fieldname(t::DataType, i::Integer)
         throw(ArgumentError("type does not have definite field names"))
     end
     names = _fieldnames(t)
-    n_fields = length(names)
+    n_fields = length(names)::Int
     field_label = n_fields == 1 ? "field" : "fields"
     i > n_fields && throw(ArgumentError("Cannot access field $i since type $t only has $n_fields $field_label."))
     i < 1 && throw(ArgumentError("Field numbers must be positive integers. $i is invalid."))

--- a/base/show.jl
+++ b/base/show.jl
@@ -523,7 +523,7 @@ end
 function show_datatype(io::IO, x::DataType)
     istuple = x.name === Tuple.name
     if (!isempty(x.parameters) || istuple) && x !== Tuple
-        n = length(x.parameters)
+        n = length(x.parameters)::Int
 
         # Print homogeneous tuples with more than 3 elements compactly as NTuple{N, T}
         if istuple && n > 3 && all(i -> (x.parameters[1] === i), x.parameters)


### PR DESCRIPTION
Fixes #33336.

This addresses some commonly-occurring cases where having too little type info makes inference see a lot of recursion in Base that is not actually possible.

Of course, this is not satisfying, since these are empirically determined (*). @vtjnash & I would also like to make inference's cycle handling smarter, but that will be a longer project.

Needs review from @mbauman : Are the dataid arguments to `_isdisjoint` indeed always `UInt`? And is it safe to assume that the length of an index in broadcast is an `Integer`?

(*) Methodology is as follows:
Apply this patch:
```
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -245,6 +245,10 @@ function add_mt_backedge!(mt::Core.MethodTable, @nospecialize(typ), caller::Infe
 end
 
 function poison_callstack(infstate::InferenceState, topmost::InferenceState, poison_topmost::Bool)
+    if trace_inf[1]
+        print_callstack(infstate)
+        println()
+    end
```

(you will also need to add `const trace_inf = [false]` somewhere. Set `Core.Compiler.trace_inf[]=true` just before running the problematic call. In the output, look for calls from simple "innocent" Base functions that lead into package code or big nests of code like broadcast, that they should not be able to touch. For example:
```
#broadcastMD#59(Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, typeof(MDDatasets.broadcastMD), MDDatasets.CastType2{Number, 1, Number, 2}, typeof(Base.:(>)), Int64, MDDatasets.DataHR{T2} where T2)  [limited]
broadcastMD(MDDatasets.CastType2{Number, 1, Number, 2}, typeof(Base.:(>)), Int64, MDDatasets.DataHR{T2}) where {T2}  [limited]
>(Int64, MDDatasets.DataMD)  [limited]
fill_to_length(Tuple{Integer, Vararg{Any, N} where N}, Int64, Base.Val{_A} where _A)  [limited]
(::Type{Base.IteratorsMD.CartesianIndex{_A}})(Tuple{Integer, Vararg{Any, N} where N})  [limited]
```

There, `fill_to_length`, a low-level tuple utility, led to inference of `>(Int64, MDDatasets.DataMD)` which then calls broadcast, etc. That can be patched up by declaring the second argument to `>` in `fill_to_length` as `Int` (which it will always be, but inference can't tell).