### PR TITLE
New `readdir` features: `lazy` and `filetypes`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,10 @@ Library changes
   tasks mutating the dictionary or set ([#44534]).
 * Predicate function negation `!f` now returns a composed function `(!) ∘ f` instead of an anonymous function ([#44752]).
 * `RoundFromZero` now works for non-`BigFloat` types ([#41246]).
+* `Base.Filesystem._readdir` implements the directory traversal from `readdir`, except instead
+  of accumulating a `Vector{String}`, it takes a function to process each entry. This enables
+  limited-memory traversal. The function is also given a filetype, and it's possible to avoid
+  copying filename strings if unnecessary.
 
 
 Standard library changes

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -5,6 +5,7 @@ Base.Filesystem.pwd
 Base.Filesystem.cd(::AbstractString)
 Base.Filesystem.cd(::Function)
 Base.Filesystem.readdir
+Base.Filesystem._readdir
 Base.Filesystem.walkdir
 Base.Filesystem.mkdir
 Base.Filesystem.mkpath


### PR DESCRIPTION
The original libuv readdir one day became scandir, what is today the basis for Julia's `readdir`. The way that function works means all directory contents must be held in memory and sorted before processing. By utilizing the new readdir function in libuv we can instead process directory contents in a streaming fashion. This patch implements a `lazyreaddir` method to do this, delivering the directory contents trough a `Channel`.