### PR TITLE
Document customizable binary operators

### DIFF
--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -186,10 +186,15 @@ For example
 defines the `⊗` (otimes) function to be the Kronecker product,
 and one can call it as binary operator using infix syntax:
 ```C = A ⊗ B```
-as well as with the usual postfix syntax
+as well as with the usual prefix syntax
 ```C = ⊗(A,B)```.
 
 Other characters that support such extensions include
 \odot `⊙`
 and
 \oplus `⊕`
+
+The complete list is here:
+https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm#L29
+and looks like this:
+`* / ÷ % & ⋅ ∘ × |\\| ∩ ∧ ⊗ ⊘ ⊙ ⊚ ⊛ ⊠ ⊡ ⊓ ∗ ∙ ∤ ⅋ ≀ ⊼ ⋄ ⋆ ⋇ ⋉ ⋊ ⋋ ⋌ ⋏ ⋒ ⟑ ⦸ ⦼ ⦾ ⦿ ⧶ ⧷ ⨇ ⨰ ⨱ ⨲ ⨳ ⨴ ⨵ ⨶ ⨷ ⨸ ⨻ ⨼ ⨽ ⩀ ⩃ ⩄ ⩋ ⩍ ⩎ ⩑ ⩓ ⩕ ⩘ ⩚ ⩜ ⩞ ⩟ ⩠ ⫛ ⊍ ▷ ⨝ ⟕ ⟖ ⟗`

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -194,7 +194,11 @@ Other characters that support such extensions include
 and
 \oplus `⊕`
 
-The complete list is here:
-https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm#L29
-and looks like this:
+The complete list is in the parser code:
+https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm
+
+Those that are parsed like `*` (in terms of precedence) include
 `* / ÷ % & ⋅ ∘ × |\\| ∩ ∧ ⊗ ⊘ ⊙ ⊚ ⊛ ⊠ ⊡ ⊓ ∗ ∙ ∤ ⅋ ≀ ⊼ ⋄ ⋆ ⋇ ⋉ ⋊ ⋋ ⋌ ⋏ ⋒ ⟑ ⦸ ⦼ ⦾ ⦿ ⧶ ⧷ ⨇ ⨰ ⨱ ⨲ ⨳ ⨴ ⨵ ⨶ ⨷ ⨸ ⨻ ⨼ ⨽ ⩀ ⩃ ⩄ ⩋ ⩍ ⩎ ⩑ ⩓ ⩕ ⩘ ⩚ ⩜ ⩞ ⩟ ⩠ ⫛ ⊍ ▷ ⨝ ⟕ ⟖ ⟗`
+and those that are parsed like `+` include
+`+ - |\|| ⊕ ⊖ ⊞ ⊟ |++| ∪ ∨ ⊔ ± ∓ ∔ ∸ ≏ ⊎ ⊻ ⊽ ⋎ ⋓ ⧺ ⧻ ⨈ ⨢ ⨣ ⨤ ⨥ ⨦ ⨧ ⨨ ⨩ ⨪ ⨫ ⨬ ⨭ ⨮ ⨹ ⨺ ⩁ ⩂ ⩅ ⩊ ⩌ ⩏ ⩐ ⩒ ⩔ ⩖ ⩗ ⩛ ⩝ ⩡ ⩢ ⩣`
+There are many others that are related to arrows, comparisons, and powers.

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -176,3 +176,20 @@ Base.widemul
 Base.Math.@evalpoly
 Base.FastMath.@fastmath
 ```
+
+## Customizable binary operators
+
+Some unicode characters can be used to define new binary operators
+that support infix notation.
+For example
+```⊗(x,y) = kron(x,y)```
+defines the `⊗` (otimes) function to be the Kronecker product,
+and one can call it as binary operator using infix syntax:
+```C = A ⊗ B```
+as well as with the usual postfix syntax
+```C = ⊗(A,B)```.
+
+Other characters that support such extensions include
+\odot `⊙`
+and
+\oplus `⊕`


### PR DESCRIPTION
I learned indirectly through comments on a PR that \otimes and \oplus and \odot can be extended as binary operators yet I cannot find this fact anywhere in the documentation.  Search the docs for `oplus` yields nothing.
Somewhere there must be a list of which characters can be extended this way and it should be documented in the manual.
This PR is an attempt to get that ball rolling!