### PR TITLE
modulo when constructing Time values

### DIFF
--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -124,7 +124,7 @@ end
 """
 struct Time <: TimeType
     instant::Nanosecond
-    Time(instant::Nanosecond) = new(instant)
+    Time(instant::Nanosecond) = new(mod(instant, 86400000000000))
 end
 
 # Convert y,m,d to # of Rata Die days
@@ -397,11 +397,6 @@ Base.promote_rule(::Type{Date}, x::Type{DateTime}) = DateTime
 Base.isless(x::T, y::T) where {T<:TimeType} = isless(value(x), value(y))
 Base.isless(x::TimeType, y::TimeType) = isless(promote(x, y)...)
 (==)(x::T, y::T) where {T<:TimeType} = (==)(value(x), value(y))
-function ==(a::Time, b::Time)
-    return hour(a) == hour(b) && minute(a) == minute(b) &&
-        second(a) == second(b) && millisecond(a) == millisecond(b) &&
-        microsecond(a) == microsecond(b) && nanosecond(a) == nanosecond(b)
-end
 (==)(x::TimeType, y::TimeType) = (===)(promote(x, y)...)
 Base.min(x::AbstractTime) = x
 Base.max(x::AbstractTime) = x

--- a/stdlib/Dates/test/arithmetic.jl
+++ b/stdlib/Dates/test/arithmetic.jl
@@ -325,6 +325,15 @@ end
     @test t + Dates.Millisecond(1) == Dates.Time(0, 0, 0, 1)
     @test t + Dates.Microsecond(1) == Dates.Time(0, 0, 0, 0, 1)
     @test_throws MethodError t + Dates.Day(1)
+    @testset "Time-TimePeriod arithmetic inequalities" begin
+        t = Dates.Time(4, 20)
+        @test t - Dates.Nanosecond(1) < t
+        @test t + Dates.Nanosecond(1) > t
+        @test t + Dates.Hour(24) < typemax(Dates.Time)
+        @test t - Dates.Hour(24) > typemin(Dates.Time)
+        @test t + Dates.Hour(23) < t
+        @test t + Dates.Hour(25) > t
+    end
 end
 @testset "Month arithmetic and non-associativity" begin
     # Month arithmetic minimizes "edit distance", or number of changes


### PR DESCRIPTION
**Problems**

1. There is a bug in implementation of `Time` comparisons (currently `<` would simply compare underlying `Nanosecond`s ignoring modulo structure of `Time`)
```
julia> using Dates
julia> t = Time(4, 20);
julia> t + Hour(24)
04:20:00
julia> t + Hour(24) == t
true
julia> t + Hour(24) > t
true
```
2. `==` has a workaround for `Time` `value` being outside normal range of values - it individually compares `Hour`, `Minute`, etc. components. This is quite slow.

**Solution**
On approach would be to just fix equality and comparison. Another is to do all arithmetics modulo # nanoseconds in a day.

Or we can have constructor take modulo. Then `==` and `<` can fall back to default definitions. I think this is a) more extensible, b) makes sense performance-wise since comparisons (i.e. in filter/groupby) are very common (at least in my use cases).  