### PR TITLE
Don't eagerly convert isabspath to String

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -79,9 +79,9 @@ end
 
 
 if Sys.iswindows()
-    isabspath(path::String) = occursin(path_absolute_re, path)
+    isabspath(path::AbstractString) = occursin(path_absolute_re, path)
 else
-    isabspath(path::String) = startswith(path, '/')
+    isabspath(path::AbstractString) = startswith(path, '/')
 end
 
 """
@@ -463,6 +463,6 @@ end
 relpath(path::AbstractString, startpath::AbstractString) =
     relpath(String(path), String(startpath))
 
-for f in (:isabspath, :isdirpath, :splitdir, :splitdrive, :splitext, :normpath, :abspath)
+for f in (:isdirpath, :splitdir, :splitdrive, :splitext, :normpath, :abspath)
     @eval $f(path::AbstractString) = $f(String(path))
 end


### PR DESCRIPTION
Testing both on linux and Windows. The abstract implementation is either just as good or faster (and on linux allocates fewer).  