### PR TITLE
fix #33367, defining enums is slow

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -189,7 +189,7 @@ macro enum(T, syms...)
         Enums.namemap(::Type{$(esc(typename))}) = $(esc(namemap))
         Base.typemin(x::Type{$(esc(typename))}) = $(esc(typename))($lo)
         Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)
-        let insts = ntuple(i->$(esc(typename))($values[i]), $(length(values)))
+        let insts = (Any[ $(esc(typename))(v) for v in $values ]...,)
             Base.instances(::Type{$(esc(typename))}) = insts
         end
     end


### PR DESCRIPTION
Each definition used a new closure and call to `ntuple`, which is not necessary since the code only runs at load time.

For me the example in the issue goes from about 10 seconds to about 1 second.

fix #33367 