### PR TITLE
Introduce `StructuredMatrixStyle{Matrix}` (fixes #33397)

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -45,6 +45,12 @@ Broadcast.BroadcastStyle(::StructuredMatrixStyle{<:Union{LowerTriangular,UnitLow
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{<:Union{UpperTriangular,UnitUpperTriangular}}, ::StructuredMatrixStyle{<:Union{LowerTriangular,UnitLowerTriangular}}) =
     StructuredMatrixStyle{Matrix}()
 
+# Make sure that `StructuredMatrixStyle{<:Matrix}` doesn't ever end up falling
+# through and give back `DefaultArrayStyle{2}`
+Broadcast.BroadcastStyle(T::StructuredMatrixStyle{<:Matrix}, ::StructuredMatrixStyle) = T
+Broadcast.BroadcastStyle(::StructuredMatrixStyle, T::StructuredMatrixStyle{<:Matrix}) = T
+Broadcast.BroadcastStyle(T::StructuredMatrixStyle{<:Matrix}, ::StructuredMatrixStyle{<:Matrix}) = T
+
 # All other combinations fall back to the default style
 Broadcast.BroadcastStyle(::StructuredMatrixStyle, ::StructuredMatrixStyle) = DefaultArrayStyle{2}()
 

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -8,7 +8,7 @@ struct StructuredMatrixStyle{T} <: Broadcast.AbstractArrayStyle{2} end
 StructuredMatrixStyle{T}(::Val{2}) where {T} = StructuredMatrixStyle{T}()
 StructuredMatrixStyle{T}(::Val{N}) where {T,N} = Broadcast.DefaultArrayStyle{N}()
 
-const StructuredMatrix = Union{Matrix,Diagonal,Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UnitLowerTriangular,UpperTriangular,UnitUpperTriangular}
+const StructuredMatrix = Union{Diagonal,Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UnitLowerTriangular,UpperTriangular,UnitUpperTriangular}
 Broadcast.BroadcastStyle(::Type{T}) where {T<:StructuredMatrix} = StructuredMatrixStyle{T}()
 
 # Promotion of broadcasts between structured matrices. This is slightly unusual
@@ -93,7 +93,7 @@ fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && _iszero(v))
 # Very conservatively only allow Numbers and Types in this speculative zero-test pass
 fzero(x::Number) = x
 fzero(::Type{T}) where T = T
-fzero(S::Union{Diagonal,Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UnitLowerTriangular,UpperTriangular,UnitUpperTriangular}) = zero(eltype(S))
+fzero(S::StructuredMatrix) = zero(eltype(S))
 fzero(x) = missing
 function fzero(bc::Broadcast.Broadcasted)
     args = map(fzero, bc.args)

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -14,7 +14,8 @@ using Test, LinearAlgebra
     T = Tridiagonal(rand(N - 1), rand(N), rand(N - 1))
     U = UpperTriangular(rand(N,N))
     L = LowerTriangular(rand(N,N))
-    structuredarrays = (D, B, T, U, L)
+    M = Matrix(rand(N,N))
+    structuredarrays = (D, B, T, U, L, M)
     fstructuredarrays = map(Array, structuredarrays)
     for (X, fX) in zip(structuredarrays, fstructuredarrays)
         @test (Q = broadcast(sin, X); typeof(Q) == typeof(X) && Q == broadcast(sin, fX))
@@ -56,6 +57,7 @@ end
     T = Tridiagonal(rand(N - 1), rand(N), rand(N - 1))
     ◣ = LowerTriangular(rand(N,N))
     ◥ = UpperTriangular(rand(N,N))
+    M = Matrix(rand(N,N))
 
     @test broadcast!(sin, copy(D), D) == Diagonal(sin.(D))
     @test broadcast!(sin, copy(Bu), Bu) == Bidiagonal(sin.(Bu), :U)
@@ -63,12 +65,14 @@ end
     @test broadcast!(sin, copy(T), T) == Tridiagonal(sin.(T))
     @test broadcast!(sin, copy(◣), ◣) == LowerTriangular(sin.(◣))
     @test broadcast!(sin, copy(◥), ◥) == UpperTriangular(sin.(◥))
+    @test broadcast!(sin, copy(M), M) == Matrix(sin.(M))
     @test broadcast!(*, copy(D), D, A) == Diagonal(broadcast(*, D, A))
     @test broadcast!(*, copy(Bu), Bu, A) == Bidiagonal(broadcast(*, Bu, A), :U)
     @test broadcast!(*, copy(Bl), Bl, A) == Bidiagonal(broadcast(*, Bl, A), :L)
     @test broadcast!(*, copy(T), T, A) == Tridiagonal(broadcast(*, T, A))
     @test broadcast!(*, copy(◣), ◣, A) == LowerTriangular(broadcast(*, ◣, A))
     @test broadcast!(*, copy(◥), ◥, A) == UpperTriangular(broadcast(*, ◥, A))
+    @test broadcast!(*, copy(M), M, A) == Matrix(broadcast(*, M, A))
 
     @test_throws ArgumentError broadcast!(cos, copy(D), D) == Diagonal(sin.(D))
     @test_throws ArgumentError broadcast!(cos, copy(Bu), Bu) == Bidiagonal(sin.(Bu), :U)
@@ -93,7 +97,8 @@ end
     T = Tridiagonal(rand(N - 1), rand(N), rand(N - 1))
     U = UpperTriangular(rand(N,N))
     L = LowerTriangular(rand(N,N))
-    structuredarrays = (D, B, T, U, L)
+    M = Matrix(rand(N,N))
+    structuredarrays = (M, D, B, T, U, L)
     fstructuredarrays = map(Array, structuredarrays)
     for (X, fX) in zip(structuredarrays, fstructuredarrays)
         @test (Q = map(sin, X); typeof(Q) == typeof(X) && Q == map(sin, fX))
@@ -123,4 +128,18 @@ end
     end
 end
 
+@testset "Issue #33397" begin
+    N = 5
+    U = UpperTriangular(rand(N, N))
+    L = LowerTriangular(rand(N, N))
+    UnitU = UnitUpperTriangular(rand(N, N))
+    UnitL = UnitLowerTriangular(rand(N, N))
+    D = Diagonal(rand(N))
+    @test U .+ L .+ D == U + L + D
+    @test L .+ U .+ D == L + U + D
+    @test UnitU .+ UnitL .+ D == UnitU + UnitL + D
+    @test UnitL .+ UnitU .+ D == UnitL + UnitU + D
+    @test U .+ UnitL .+ D == U + UnitL + D
+    @test L .+ UnitU .+ D == L + UnitU + D
+end
 end

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -141,5 +141,9 @@ end
     @test UnitL .+ UnitU .+ D == UnitL + UnitU + D
     @test U .+ UnitL .+ D == U + UnitL + D
     @test L .+ UnitU .+ D == L + UnitU + D
+    @test L .+ U .+ L .+ U == L + U + L + U
+    @test U .+ L .+ U .+ L == U + L + U + L
+    @test L .+ UnitL .+ UnitU .+ U .+ D == L + UnitL + UnitU + U + D
+    @test L .+ U .+ D .+ D .+ D .+ D == L + U + D + D + D + D
 end
 end


### PR DESCRIPTION
As discussed in #33397, I have added a new structured matrix style type `StructuredMatrixStyle{Matrix}` to solve the issue.

Unfortunately, this introduced a new bug:
```julia
julia> using LinearAlgebra

julia> D = Diagonal(rand(2));

julia> M = rand(2,2);

julia> map(+, D, M, D)
2×2 Array{Float64,2}:
 1.7611    0.190262
 0.611437  1.32978
```
The `map` method suddenly returned a `Diagonal` matrix. That's the reason why I had to exclude the new type from the `fzero(S::StructuredMatrix)` method.