### PR TITLE
use simpler copy algorithm for small BitArrays in broadcasting

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -916,6 +916,7 @@ end
 @inline function copyto!(dest::BitArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
     ischunkedbroadcast(dest, bc) && return chunkedcopyto!(dest, bc)
+    length(dest) < 256 && return invoke(copyto!, Tuple{AbstractArray, Broadcasted{Nothing}}, dest, bc)
     tmp = Vector{Bool}(undef, bitcache_size)
     destc = dest.chunks
     ind = cind = 1


### PR DESCRIPTION
Fixes #33516 

```jl
julia> a = [1;2;3];

julia> u(a) = b = a .== 1;

julia> @time u(a);
  0.000006 seconds (6 allocations: 288 bytes)
```

Threshold found with

```jl
function opt(n)
           a = collect(1:n)
           bc =  Base.broadcasted(Main.:(==), a, 1)
           s = similar(bc, Bool)
           bc = convert(Base.Broadcast.Broadcasted{Nothing}, bc)
           @btime copyto!($s, $bc)
           @btime invoke(copyto!, Tuple{AbstractArray, Base.Broadcast.Broadcasted{Nothing}}, $s, $bc)
end
```