### PR TITLE
Have `copy(ci::CodeInfo)` also copy `ci.edges`.

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -67,8 +67,9 @@ function copy(c::CodeInfo)
     cnew.slotflags = copy(cnew.slotflags)
     cnew.codelocs  = copy(cnew.codelocs)
     cnew.linetable = copy(cnew.linetable)
-    cnew.ssaflags = copy(cnew.ssaflags)
-    ssavaluetypes = cnew.ssavaluetypes
+    cnew.ssaflags  = copy(cnew.ssaflags)
+    cnew.edges     = cnew.edges === nothing ? nothing : copy(cnew.edges)
+    ssavaluetypes  = cnew.ssavaluetypes
     ssavaluetypes isa Vector{Any} && (cnew.ssavaluetypes = copy(ssavaluetypes))
     return cnew
 end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -193,3 +193,13 @@ end
 let x = Bar17149()
     @test deepcopy(x) !== x
 end
+
+@testset "copying CodeInfo" begin
+    _testfunc() = nothing
+    ci,_ = code_typed(_testfunc, ())[1]
+    ci.edges = [_testfunc]
+
+    ci2 = copy(ci)
+    # Test that edges are not shared
+    @test ci2.edges !== ci.edges
+end


### PR DESCRIPTION
Before this commit, it was a shallow-copy, so the array was shared between the original ci and the copy.

CC: @vchuravy 

Came up in https://github.com/jrevels/Cassette.jl/pull/148