### PR TITLE
fix #32678, error due to Ptr constant in `_reformat_bt`

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -70,7 +70,7 @@ function _reformat_bt(bt, bt2)
     i, j = 1, 1
     while i <= length(bt)
         ip = bt[i]::Ptr{Cvoid}
-        if ip == Ptr{Cvoid}(-1%UInt)
+        if UInt(ip) == (-1 % UInt)
             # The next one is really a CodeInfo
             push!(ret, InterpreterIP(
                 bt2[j],
@@ -95,8 +95,8 @@ function backtrace()
     # skip frame for backtrace(). Note that for this to work properly,
     # backtrace() itself must not be interpreted nor inlined.
     skip = 1
-    bt1, bt2 = ccall(:jl_backtrace_from_here, Any, (Cint,Cint), false, skip)
-    _reformat_bt(bt1, bt2)
+    bt1, bt2 = ccall(:jl_backtrace_from_here, Ref{SimpleVector}, (Cint, Cint), false, skip)
+    return _reformat_bt(bt1::Vector{Ptr{Cvoid}}, bt2::Vector{Any})
 end
 
 """
@@ -105,10 +105,8 @@ end
 Get the backtrace of the current exception, for use within `catch` blocks.
 """
 function catch_backtrace()
-    bt = Ref{Any}(nothing)
-    bt2 = Ref{Any}(nothing)
-    ccall(:jl_get_backtrace, Cvoid, (Ref{Any}, Ref{Any}), bt, bt2)
-    return _reformat_bt(bt[], bt2[])
+    bt, bt2 = ccall(:jl_get_backtrace, Ref{SimpleVector}, ())
+    return _reformat_bt(bt::Vector{Ptr{Cvoid}}, bt2::Vector{Any})
 end
 
 """

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -646,7 +646,7 @@ size_t rec_backtrace_ctx(uintptr_t *bt_data, size_t maxsize, bt_context_t *ctx,
 #ifdef LIBOSXUNWIND
 size_t rec_backtrace_ctx_dwarf(uintptr_t *bt_data, size_t maxsize, bt_context_t *ctx, int add_interp_frames) JL_NOTSAFEPOINT;
 #endif
-JL_DLLEXPORT void jl_get_backtrace(jl_array_t **bt, jl_array_t **bt2);
+JL_DLLEXPORT jl_value_t *jl_get_backtrace(void);
 void jl_critical_error(int sig, bt_context_t *context, uintptr_t *bt_data, size_t *bt_size);
 JL_DLLEXPORT void jl_raise_debugger(void);
 int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT;


### PR DESCRIPTION
Also change `jl_get_backtrace` to return a pair of values instead of mutating. This seems to have been missing a write barrier, plus `jl_backtrace_from_here` is very similar and already returns a pair, so might as well make them match.

fix #32678