### PR TITLE
allow multiplying empty matrices when zero() is undefined

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -708,7 +708,10 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
     if size(C,1) != mA || size(C,2) != nB
         throw(DimensionMismatch("result C has dimensions $(size(C)), needs ($mA,$nB)"))
     end
-    if isempty(A) || isempty(B) || iszero(_add.alpha)
+    if isempty(A) || isempty(B)
+        return C
+    end
+    if iszero(_add.alpha)
         return _rmul_or_fill!(C, _add.beta)
     end
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -597,4 +597,13 @@ end
     @test D ≈ C
 end
 
+@testset "multiplication of empty matrices without calling zero" begin
+    r, c = rand(0:9, 2)
+    A = collect(Number, rand(r, c))
+    B = rand(c, 0)
+    C = A * B
+    @test size(C) == (r, 0)
+    @test_throws MethodError zero(eltype(C))
+end
+
 end # module TestMatmul


### PR DESCRIPTION
Multiplying non-empty matrices whose eltype doesn't have `zero` works, but non-empty ones:
```julia
julia> collect(Number, rand(2, 2)) * rand(2, 2)
2×2 Array{Any,2}:
 0.206836  0.360325
 0.400471  0.486588

julia> collect(Number, rand(2, 2)) * rand(2, 0)
ERROR: MethodError: no method matching zero(::Type{Any})
[...]
```
I don't know this part of the codebase, it just seemed quite easy to fix, but please feel free to close this and open a more appropriate fix.