### PR TITLE
adding sort=true keyword to readdir() according to #24626

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@ New library functions
 * The `tempname` function now takes an optional `parent::AbstractString` argument to give it a directory in which to attempt to produce a temporary path name ([#33090]).
 * The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `true`, which causes the process to try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
 * The `readdir` function now takes a `join::Bool` keyword argument defaulting to `false`, which when set causes `readdir` to join its directory argument with each listed name ([#33113]).
+* `readdir` output is now guaranteed to be sorted. The `sort` keyword allows opting out of sorting to get names in OS-native order ([#33542]).
 * The new `only(x)` function returns the one-and-only element of a collection `x`, and throws an `ArgumentError` if `x` contains zero or multiple elements. ([#33129])
 * `takewhile` and `dropwhile` have been added to the Iterators submodule ([#33437]).
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -1277,6 +1277,20 @@ cd(dirwalk) do
 end
 rm(dirwalk, recursive=true)
 
+###################
+#     readdir     #
+###################
+@testset "readdir is sorted" begin
+    mktempdir() do dir
+        cd(dir) do
+            for k in 1:10
+                touch(randstring())
+            end
+            @test issorted(readdir())
+        end
+    end
+end
+
 ############
 # Clean up #
 ############


### PR DESCRIPTION
Resurrection of https://github.com/JuliaLang/julia/pull/24675 in light of the recent massive scientific software failure due to different OSes sorting files in different orders in Python:

https://twitter.com/bmarwell/status/1181821143835201536

Let's do better.