### PR TITLE
fix tab completion not erroring after dot after undefined macro

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -418,6 +418,7 @@ function get_type(sym::Expr, fn::Module)
     # try to analyze nests of calls. if this fails, try using the expanded form.
     val, found = try_get_type(sym, fn)
     found && return val, found
+    sym.head == :macrocall && return (Any, false)
     return try_get_type(Meta.lower(fn, sym), fn)
 end
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1013,3 +1013,8 @@ let s = "prevind(\"θ\",1,"
     @test r == 1:7
     @test s[r] == "prevind"
 end
+
+let s = "@undefmacro_27184.",
+    c, _ = test_complete(s)
+    @test isempty(c)
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/27184

Edit: Wasn't that easy apparently.