### PR TITLE
Remove a duplicated "`" in docs of abstractsparse.jl

### DIFF
--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -13,7 +13,7 @@ abstract type AbstractSparseArray{Tv,Ti,N} <: AbstractArray{Tv,N} end
     AbstractSparseVector{Tv,Ti}
 
 Supertype for one-dimensional sparse arrays (or array-like types) with elements
-of type `Tv` and index type `Ti`. Alias for `AbstractSparseArray{Tv,Ti,1}``.
+of type `Tv` and index type `Ti`. Alias for `AbstractSparseArray{Tv,Ti,1}`.
 """
 const AbstractSparseVector{Tv,Ti} = AbstractSparseArray{Tv,Ti,1}
 """


### PR DESCRIPTION
Before this change, it looks like
![image](https://user-images.githubusercontent.com/25192197/66889208-8c14cf00-efaf-11e9-950b-735bddeb7d4b.png)
