### PR TITLE
Add ASCII alias `compose` of `∘`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,6 @@ New language features
 
 * `import` now allows quoted symbols, e.g. `import Base.:+` ([#33158]).
 
-* Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
-and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).
-
-* Function composition `∘` now has an ASCII alias `compose` ([#33573]).
-
 Language changes
 ----------------
 
@@ -38,6 +33,9 @@ New library functions
 * `readdir` output is now guaranteed to be sorted. The `sort` keyword allows opting out of sorting to get names in OS-native order ([#33542]).
 * The new `only(x)` function returns the one-and-only element of a collection `x`, and throws an `ArgumentError` if `x` contains zero or multiple elements. ([#33129])
 * `takewhile` and `dropwhile` have been added to the Iterators submodule ([#33437]).
+* Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
+  and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).
+* Function composition `∘` now has an ASCII alias `compose` ([#33573]).
 
 
 Standard library changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ New language features
 * Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
 and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).
 
-* Function composition `∘` now has an ASCII alias `compose`.
+* Function composition `∘` now has an ASCII alias `compose` ([#33573]).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ New language features
 * Function composition now supports multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
 and splatting `∘(fs...)` for composing an iterable collection of functions ([#33568]).
 
+* Function composition `∘` now has an ASCII alias `compose`.
+
 Language changes
 ----------------
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -763,6 +763,7 @@ export
 # misc
     atexit,
     atreplinit,
+    compose,
     exit,
     ntuple,
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -853,8 +853,8 @@ julia> fs = [
 julia> ∘(fs...)(3)
 3.0
 
-julia> ∘(fs...) === compose(fs...)
-true
+julia> compose(fs...)(3)
+3.0
 ```
 """
 ∘(f, g) = (x...)->f(g(x...))

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -823,6 +823,7 @@ julia> [1:5;] |> x->x.^2 |> sum |> inv
 
 """
     f ∘ g
+    compose(f, g)
 
 Compose functions: i.e. `(f ∘ g)(args...)` means `f(g(args...))`. The `∘` symbol can be
 entered in the Julia REPL (and most editors, appropriately configured) by typing `\\circ<tab>`.
@@ -832,7 +833,7 @@ The prefix form supports composition of multiple functions: `∘(f, g, h) = f �
 and splatting `∘(fs...)` for composing an iterable collection of functions.
 
 !!!compat "Julia 1.4"
-    Multiple function composition requires at least Julia 1.4.
+    Multiple function composition and ASCII alias `compose` require at least Julia 1.4.
 
 # Examples
 ```jldoctest
@@ -851,10 +852,14 @@ julia> fs = [
 
 julia> ∘(fs...)(3)
 3.0
+
+julia> ∘(fs...) === compose(fs...)
+true
 ```
 """
 ∘(f, g) = (x...)->f(g(x...))
 ∘(f, g, h...) = ∘(f ∘ g, h...)
+const compose = ∘
 
 """
     !f::Function

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -111,6 +111,7 @@ Base.promote_rule(::Type{T19714}, ::Type{Int}) = T19714
     @test ∘(x -> x-2, x -> x-3, x -> x+5)(7) == 7
     fs = [x -> x[1:2], uppercase, lowercase]
     @test ∘(fs...)("ABC") == "AB"
+    @test ∘(fs...) === compose(fs...)
 end
 @testset "function negation" begin
     str = randstring(20)


### PR DESCRIPTION
There are quite a few cases where composition becomes/can be used as fundamental API in Julia:

* Lenses as implemented in [Setfield.jl](https://jw3126.github.io/Setfield.jl/latest/#Base.:%E2%88%98-Tuple{Lens,Lens})
* Transducers as implemented in [Transducers.jl](https://github.com/tkf/Transducers.jl)
* Iterator transforms as implemented in, e.g., [Query.jl](https://github.com/queryverse/Query.jl)

However, the composition operator `∘` is only exposed by a non-ASCII name.  This is not an ideal situation because the common practice in Julia is to provide ASCII-based API even when non-ASCII names are the primary API.  An easy solution implemented in this PR is to define `const compose = ∘` in `Base`.
