### PR TITLE
Fix multiplication of bidiagonal and triangular matrix (fixes #30094)

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -586,7 +586,12 @@ function *(A::AbstractTriangular, B::Union{SymTridiagonal, Tridiagonal})
     A_mul_B_td!(zeros(TS, size(A)...), A, B)
 end
 
-function *(A::UpperTriangular, B::Bidiagonal)
+const UpperOrUnitUpperTriangular = Union{UpperTriangular, UnitUpperTriangular}
+const LowerOrUnitLowerTriangular = Union{LowerTriangular, UnitLowerTriangular}
+const AdjOrTransUpperOrUnitUpperTriangular = Union{Adjoint{<:Any, <:UpperOrUnitUpperTriangular}, Transpose{<:Any, <:UpperOrUnitUpperTriangular}}
+const AdjOrTransLowerOrUnitLowerTriangular = Union{Adjoint{<:Any, <:LowerOrUnitLowerTriangular}, Transpose{<:Any, <:LowerOrUnitLowerTriangular}}
+
+function *(A::UpperOrUnitUpperTriangular, B::Bidiagonal)
     TS = promote_op(matprod, eltype(A), eltype(B))
     if B.uplo == 'U'
         A_mul_B_td!(UpperTriangular(zeros(TS, size(A)...)), A, B)
@@ -595,10 +600,28 @@ function *(A::UpperTriangular, B::Bidiagonal)
     end
 end
 
-function *(A::LowerTriangular, B::Bidiagonal)
+function *(A::AdjOrTransUpperOrUnitUpperTriangular, B::Bidiagonal)
     TS = promote_op(matprod, eltype(A), eltype(B))
     if B.uplo == 'L'
         A_mul_B_td!(LowerTriangular(zeros(TS, size(A)...)), A, B)
+    else
+        A_mul_B_td!(zeros(TS, size(A)...), A, B)
+    end
+end
+
+function *(A::LowerOrUnitLowerTriangular, B::Bidiagonal)
+    TS = promote_op(matprod, eltype(A), eltype(B))
+    if B.uplo == 'L'
+        A_mul_B_td!(LowerTriangular(zeros(TS, size(A)...)), A, B)
+    else
+        A_mul_B_td!(zeros(TS, size(A)...), A, B)
+    end
+end
+
+function *(A::AdjOrTransLowerOrUnitLowerTriangular, B::Bidiagonal)
+    TS = promote_op(matprod, eltype(A), eltype(B))
+    if B.uplo == 'U'
+        A_mul_B_td!(UpperTriangular(zeros(TS, size(A)...)), A, B)
     else
         A_mul_B_td!(zeros(TS, size(A)...), A, B)
     end
@@ -609,7 +632,7 @@ function *(A::Union{SymTridiagonal, Tridiagonal}, B::AbstractTriangular)
     A_mul_B_td!(zeros(TS, size(A)...), A, B)
 end
 
-function *(A::Bidiagonal, B::UpperTriangular)
+function *(A::Bidiagonal, B::UpperOrUnitUpperTriangular)
     TS = promote_op(matprod, eltype(A), eltype(B))
     if A.uplo == 'U'
         A_mul_B_td!(UpperTriangular(zeros(TS, size(A)...)), A, B)
@@ -618,10 +641,28 @@ function *(A::Bidiagonal, B::UpperTriangular)
     end
 end
 
-function *(A::Bidiagonal, B::LowerTriangular)
+function *(A::Bidiagonal, B::AdjOrTransUpperOrUnitUpperTriangular)
     TS = promote_op(matprod, eltype(A), eltype(B))
     if A.uplo == 'L'
         A_mul_B_td!(LowerTriangular(zeros(TS, size(A)...)), A, B)
+    else
+        A_mul_B_td!(zeros(TS, size(A)...), A, B)
+    end
+end
+
+function *(A::Bidiagonal, B::LowerOrUnitLowerTriangular)
+    TS = promote_op(matprod, eltype(A), eltype(B))
+    if A.uplo == 'L'
+        A_mul_B_td!(LowerTriangular(zeros(TS, size(A)...)), A, B)
+    else
+        A_mul_B_td!(zeros(TS, size(A)...), A, B)
+    end
+end
+
+function *(A::Bidiagonal, B::AdjOrTransLowerOrUnitLowerTriangular)
+    TS = promote_op(matprod, eltype(A), eltype(B))
+    if A.uplo == 'U'
+        A_mul_B_td!(UpperTriangular(zeros(TS, size(A)...)), A, B)
     else
         A_mul_B_td!(zeros(TS, size(A)...), A, B)
     end

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -488,21 +488,10 @@ end
                 for B in (BU, BL)
                     MB = Matrix(B)
                     MT = Matrix(T)
-                    @test B * T ≈ MB * MT
-                    @test B * T' ≈ MB * MT'
-                    @test B * transpose(T) ≈ MB * transpose(MT)
-                    @test B' * T ≈ MB' * MT
-                    @test transpose(B) * T ≈ transpose(MB) * MT
-                    @test B' * T' ≈ MB' * MT'
-                    @test transpose(B) * transpose(T) ≈ transpose(MB) * transpose(MT)
-
-                    @test T * B ≈ MT * MB
-                    @test T * B' ≈ MT * MB'
-                    @test T * transpose(B) ≈ MT * transpose(MB)
-                    @test T' * B ≈ MT' * MB
-                    @test transpose(T) * B ≈ transpose(MT) * MB
-                    @test T' * B' ≈ MT' * MB'
-                    @test transpose(T) * transpose(B) ≈ transpose(MT) * transpose(MB)
+                    for transB in (identity, adjoint, transpose), transT in (identity, adjoint, transpose)
+                        @test transB(B) * transT(T) ≈ transB(MB) * transT(MT)
+                        @test transT(T) * transB(B) ≈ transT(MT) * transB(MB)
+                    end
                 end
             end
         end

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -468,4 +468,45 @@ end
     end
 end
 
+@testset "multiplication of bidiagonal and triangular matrix" begin
+    n = 5
+    for eltyB in (Int, ComplexF64)
+        if eltyB == Int
+            BU = Bidiagonal(rand(1:7, n), rand(1:7, n - 1), :U)
+            BL = Bidiagonal(rand(1:7, n), rand(1:7, n - 1), :L)
+        else
+            BU = Bidiagonal(randn(eltyB, n), randn(eltyB, n - 1), :U)
+            BL = Bidiagonal(randn(eltyB, n), randn(eltyB, n - 1), :L)
+        end
+        for eltyT in (Int, ComplexF64)
+            for TriT in (LowerTriangular, UnitLowerTriangular, UpperTriangular, UnitUpperTriangular)
+                if eltyT == Int
+                    T = TriT(rand(1:7, n, n))
+                else
+                    T = TriT(randn(eltyT, n, n))
+                end
+                for B in (BU, BL)
+                    MB = Matrix(B)
+                    MT = Matrix(T)
+                    @test B * T ≈ MB * MT
+                    @test B * T' ≈ MB * MT'
+                    @test B * transpose(T) ≈ MB * transpose(MT)
+                    @test B' * T ≈ MB' * MT
+                    @test transpose(B) * T ≈ transpose(MB) * MT
+                    @test B' * T' ≈ MB' * MT'
+                    @test transpose(B) * transpose(T) ≈ transpose(MB) * transpose(MT)
+
+                    @test T * B ≈ MT * MB
+                    @test T * B' ≈ MT * MB'
+                    @test T * transpose(B) ≈ MT * transpose(MB)
+                    @test T' * B ≈ MT' * MB
+                    @test transpose(T) * B ≈ transpose(MT) * MB
+                    @test T' * B' ≈ MT' * MB'
+                    @test transpose(T) * transpose(B) ≈ transpose(MT) * transpose(MB)
+                end
+            end
+        end
+    end
+end
+
 end # module TestBidiagonal


### PR DESCRIPTION
This PR intends to fix #30094.
Additionally, it also enables of multiplications `Bidiagonal * adjoint(Triangular)` and `Bidiagonal * transpose(Triangular)`, where `Triangular` can be any triangular matrix type (`LowerTriangular`, `UpperTriangular`, `UnitUpperTriangular`, `UnitLowerTriangular`).