### PR TITLE
Install `7z.dll` to `libexec` instead of `bin`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,9 @@ endif
 ifeq ($(OS),WINNT)
 	-$(INSTALL_M) $(filter-out $(build_bindir)/libjulia-debug.dll,$(wildcard $(build_bindir)/*.dll)) $(DESTDIR)$(bindir)/
 	-$(INSTALL_M) $(build_libdir)/libjulia.dll.a $(DESTDIR)$(libdir)/
+
+	# We have a single exception; we want 7z.dll to live in libexec, not bin, so that 7z.exe can find it.
+	-mv $(DESTDIR)$(bindir)/7z.dll $(DESTDIR)$(libexecdir)/
 ifeq ($(BUNDLE_DEBUG_LIBS),1)
 	-$(INSTALL_M) $(build_bindir)/libjulia-debug.dll $(DESTDIR)$(bindir)/
 	-$(INSTALL_M) $(build_libdir)/libjulia-debug.dll.a $(DESTDIR)$(libdir)/


### PR DESCRIPTION
This is required for `7z.exe` to load properly.  I believe this was not
caught in previous testing because if the `bin` folder is on the `PATH`,
this is not necessary, however we definitely cannot rely on that.