### PR TITLE
tempdir: error on non-directory result

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -480,7 +480,7 @@ function tempdir()
         rc = ccall(:uv_os_tmpdir, Cint, (Ptr{UInt8}, Ptr{Csize_t}), buf, sz)
         if rc == 0
             resize!(buf, sz[])
-            return String(buf)
+            break
         elseif rc == Base.UV_ENOBUFS
             resize!(buf, sz[] - 1)  # space for null-terminator implied by StringVector
         else
@@ -513,6 +513,11 @@ function prepare_for_deletion(path::AbstractString)
             catch; end
         end
     end
+    p = String(buf)
+    s = stat(p)
+    ispath(s) || error("tempdir path does not exist: $p")
+    isdir(s) || error("tempdir path is not a directory: $p")
+    return p
 end
 
 const TEMP_CLEANUP_MIN = Ref(1024)


### PR DESCRIPTION
Potential more graceful handling of https://github.com/JuliaLang/julia/issues/33382. I thought about creating the directory if it doesn't exist, but that seems aa bit questionable. Probably better to let the user know about the situation in a clear way so they can mitigate it. An even better improvement would be if we could tell them which environment variable to look at. I tried setting `TEMP` in the environment on macOS but it didn't seem to have any effect on the result.