### PR TITLE
document that delete! can accept a non-present key

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -631,7 +631,7 @@ end
 """
     delete!(collection, key)
 
-Delete the mapping for the given key in a collection, and return the collection.
+Delete the mapping for the given key in a collection, if any, and return the collection.
 
 # Examples
 ```jldoctest
@@ -641,6 +641,10 @@ Dict{String,Int64} with 2 entries:
   "a" => 1
 
 julia> delete!(d, "b")
+Dict{String,Int64} with 1 entry:
+  "a" => 1
+
+julia> delete!(d, "b") # d is left unchanged
 Dict{String,Int64} with 1 entry:
   "a" => 1
 ```


### PR DESCRIPTION
From the docstring, it was not clear what happens with `delete!(d, k)` if `d[k]` doesn't exist. 
Suggestions for better wording welcome.
Also, in some cases, when `typeof(k) != keytype(d)`, an exception will be thrown, for example `delete!(BitSet(), "a")` (`MethodError` in this case). Should this also be mentioned in the docstring?
