### PR TITLE
using isapprox for floating point comparison

### DIFF
--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -213,7 +213,7 @@ d[5,1:2:4,8] .= 19
 AA = rand(4,2)
 A = @inferred(convert(SharedArray, AA))
 B = @inferred(convert(SharedArray, copy(AA')))
-@test B*A == AA'*AA
+@test B*A ≈ AA'*AA
 
 d=SharedArray{Int64,2}((10,10); init = D->fill!(D.loc_subarr_1d, myid()), pids=[id_me, id_other])
 d2 = map(x->1, d)


### PR DESCRIPTION
One way to fix https://github.com/JuliaLang/julia/issues/33580
Possibly due to mkl/julia handling the matrix product of the lazy `'` of AA and `copy(AA')` differently. Note that changing the test to `@test B*A == copy(AA')*AA` also works. Also leaving to the maintainers to decide whether to include this in 1.3 or not. Thanks!