### PR TITLE
fix diagonal Cholesky factorization and return Diagonal Cholesky factor

### DIFF
--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -411,7 +411,6 @@ size(C::Union{Cholesky, CholeskyPivoted}, d::Integer) = size(C.factors, d)
 function getproperty(C::Cholesky, d::Symbol)
     Cfactors = getfield(C, :factors)
     Cuplo    = getfield(C, :uplo)
-    info     = getfield(C, :info)
     if d == :U
         return UpperTriangular(Cuplo === char_uplo(d) ? Cfactors : copy(Cfactors'))
     elseif d == :L

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -672,6 +672,15 @@ end
 cholesky(A::Diagonal, ::Val{false} = Val(false); check::Bool = true) =
     cholesky!(cholcopy(A), Val(false); check = check)
 
+function getproperty(C::Cholesky{<:Any,<:Diagonal}, d::Symbol)
+    Cfactors = getfield(C, :factors)
+    if d in (:U, :L, :UL)
+        return Cfactors
+    else
+        return getfield(C, d)
+    end
+end
+
 Base._sum(A::Diagonal, ::Colon) = sum(A.diag)
 
 function logabsdet(A::Diagonal)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -654,11 +654,9 @@ end
 
 function cholesky!(A::Diagonal, ::Val{false} = Val(false); check::Bool = true)
     info = 0
-    diagonal = A.diag
-    for i in axes(diagonal, 1)
-        d = diagonal[i]
-        if !(d == 0 || (isreal(d) && d < 0))
-            diagonal[i] = √d
+    for (i, di) in enumerate(A.diag)
+        if isreal(di) && real(di) > 0
+            A.diag[i] = √di
         elseif check
             throw(PosDefException(i))
         else

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -336,9 +336,10 @@ end
     d = abs.(randn(3)) .+ 0.1
     D = Diagonal(d)
     CD = cholesky(D)
+    CM = cholesky(Matrix(D))
     @test CD isa Cholesky{Float64}
-    @test CD.U isa UpperTriangular{Float64}
-    @test CD.U == Diagonal(.√d)
+    @test CD.U == Diagonal(.√d) == CM.U
+    @test D ≈ CD.L * CD.U
     @test CD.info == 0
 
     # real, failing
@@ -347,13 +348,12 @@ end
     @test Dnpd.info == 2
 
     # complex
-    d = cis.(rand(3) .* 2*π)
-    d .*= abs.(randn(3) .+ 0.1)
-    D = Diagonal(d)
+    D = complex(D)
     CD = cholesky(D)
+    CM = cholesky(Matrix(D))
     @test CD isa Cholesky{Complex{Float64}}
-    @test CD.U isa UpperTriangular{Complex{Float64}}
-    @test CD.U == Diagonal(.√d)
+    @test CD.U == Diagonal(.√d) == CM.U
+    @test D ≈ CD.L * CD.U
     @test CD.info == 0
 
     # complex, failing


### PR DESCRIPTION
This addresses partially JuliaLang/LinearAlgebra.jl#556.

I didn't fully get @andreasnoack's https://github.com/JuliaLang/LinearAlgebra.jl/issues/556, but I thought I'll get started and then see. So this PR makes getting the factors of a Cholesky factorization of a `Diagonal` matrix return a `Diagonal`, and not a `Triangular{<:Diagonal}` or something like that. So this should work now:
```julia
using LinearAlgebra; A = cholesky(inv(Diagonal([1.0, 4.0]))).L; A*A' ≈ inv(Diagonal([1.0, 4.0]))
```
@tpapp 

~~The commit message might be wrong, I messed it up with another PR.~~ 😇  Fixed.