### PR TITLE
Automatically up-convert eltype in SPQR

### DIFF
--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -154,7 +154,7 @@ solve least squares or underdetermined problems with [`\\`](@ref). The function 
     `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of SuiteSparse.
     As this library only supports sparse matrices with [`Float64`](@ref) or
     `ComplexF64` elements, as of Julia v1.4 `qr` converts `A` into a copy that is
-     of type `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
+    of type `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 
 # Examples
 ```jldoctest

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -143,35 +143,18 @@ Matrix{T}(Q::QRSparseQ) where {T} = lmul!(Q, Matrix{T}(I, size(Q, 1), min(size(Q
 _default_tol(A::SparseMatrixCSC) =
     20*sum(size(A))*eps(real(eltype(A)))*maximum(norm(view(A, :, i)) for i in 1:size(A, 2))
 
-function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol = _default_tol(A)) where {Tv <: CHOLMOD.VTypes}
-    R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
-    E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
-    H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
-    HPinv = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
-    HTau  = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)
-
-    # SPQR doesn't accept symmetric matrices so we explicitly set the stype
-    r, p, hpinv = _qr!(ORDERING_DEFAULT, tol, 0, 0, Sparse(A, 0),
-        C_NULL, C_NULL, C_NULL, C_NULL,
-        R, E, H, HPinv, HTau)
-
-    R_ = SparseMatrixCSC(Sparse(R[]))
-    return QRSparse(SparseMatrixCSC(Sparse(H[])),
-                    vec(Array(CHOLMOD.Dense(HTau[]))),
-                    SparseMatrixCSC(min(size(A)...),
-                                    size(R_, 2),
-                                    getcolptr(R_),
-                                    rowvals(R_),
-                                    nonzeros(R_)),
-                    p, hpinv)
-end
-
 """
     qr(A) -> QRSparse
 
 Compute the `QR` factorization of a sparse matrix `A`. Fill-reducing row and column permutations
 are used such that `F.R = F.Q'*A[F.prow,F.pcol]`. The main application of this type is to
 solve least squares or underdetermined problems with [`\\`](@ref). The function calls the C library SPQR.
+
+!!! note
+    `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of SuiteSparse.
+    As this library only supports sparse matrices with [`Float64`](@ref) or
+    `ComplexF64` elements, `qr` converts `A` into a copy that is of type
+    `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 
 # Examples
 ```jldoctest
@@ -206,7 +189,43 @@ Column permutation:
  2
 ```
 """
-LinearAlgebra.qr(A::SparseMatrixCSC; tol = _default_tol(A)) = qr(A, Val{true}, tol = tol)
+function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A)) where {Tv <: CHOLMOD.VTypes}
+    R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
+    E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
+    H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
+    HPinv = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
+    HTau  = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)
+
+    # SPQR doesn't accept symmetric matrices so we explicitly set the stype
+    r, p, hpinv = _qr!(ORDERING_DEFAULT, tol, 0, 0, Sparse(A, 0),
+        C_NULL, C_NULL, C_NULL, C_NULL,
+        R, E, H, HPinv, HTau)
+
+    R_ = SparseMatrixCSC(Sparse(R[]))
+    return QRSparse(SparseMatrixCSC(Sparse(H[])),
+                    vec(Array(CHOLMOD.Dense(HTau[]))),
+                    SparseMatrixCSC(min(size(A)...),
+                                    size(R_, 2),
+                                    getcolptr(R_),
+                                    rowvals(R_),
+                                    nonzeros(R_)),
+                    p, hpinv)
+end
+LinearAlgebra.qr(A::SparseMatrixCSC{<:Union{Float16,Float32}}; tol=_default_tol(A)) =
+    qr(convert(SparseMatrixCSC{Float64}, A); tol=tol)
+LinearAlgebra.qr(A::SparseMatrixCSC{<:Union{ComplexF16,ComplexF32}}; tol=_default_tol(A)) =
+    qr(convert(SparseMatrixCSC{ComplexF64}, A); tol=tol)
+LinearAlgebra.qr(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}};
+   tol=_default_tol(A)) where {T<:AbstractFloat} =
+    throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",
+    "Try qr(convert(SparseMatrixCSC{Float64/ComplexF64,Int}, A)) for ",
+    "sparse floating point QR using SPQR or qr(Array(A)) for generic ",
+    "dense QR.")))
+LinearAlgebra.qr(A::SparseMatrixCSC; tol=_default_tol(A)) = qr(float(A); tol=tol)
+# function LinearAlgebra.qr(A::SparseMatrixCSC; tol=_default_tol(A))
+#     error("QR factorization of sparse matrices supports only Float64 and "*
+#             "Complex{Float64} eltypes")
+# end
 
 function LinearAlgebra.lmul!(Q::QRSparseQ, A::StridedVecOrMat)
     if size(A, 1) != size(Q, 1)

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -153,8 +153,8 @@ solve least squares or underdetermined problems with [`\\`](@ref). The function 
 !!! note
     `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of SuiteSparse.
     As this library only supports sparse matrices with [`Float64`](@ref) or
-    `ComplexF64` elements, `qr` converts `A` into a copy that is of type
-    `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
+    `ComplexF64` elements, as of Julia v1.4 `qr` converts `A` into a copy that is
+     of type `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 
 # Examples
 ```jldoctest
@@ -222,10 +222,6 @@ LinearAlgebra.qr(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}};
     "sparse floating point QR using SPQR or qr(Array(A)) for generic ",
     "dense QR.")))
 LinearAlgebra.qr(A::SparseMatrixCSC; tol=_default_tol(A)) = qr(float(A); tol=tol)
-# function LinearAlgebra.qr(A::SparseMatrixCSC; tol=_default_tol(A))
-#     error("QR factorization of sparse matrices supports only Float64 and "*
-#             "Complex{Float64} eltypes")
-# end
 
 function LinearAlgebra.lmul!(Q::QRSparseQ, A::StridedVecOrMat)
     if size(A, 1) != size(Q, 1)


### PR DESCRIPTION
This intends to close JuliaLang/LinearAlgebra.jl#673, one way or another.

I realized that we do up-convert in the other two sparse factorizations, UMFPACK and CHOLMOD, and this is clearly documented. So one option is to do the same with SPQR. Another option that we discussed over at JuliaLang/LinearAlgebra.jl#673 is to throw an error message.

The previous line below the docstring was calling a non-existent method, so I moved the main workhorse below the docstring, adapted the conversion functions from UMFPACK, and added a "!!! note" (maybe it should be a compat annotation?).