### PR TITLE
Added note to use exeflags to load environment.

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -769,7 +769,8 @@ It is automatically made available on the worker processes.
 
 Note that workers do not run a `~/.julia/config/startup.jl` startup script, nor do they synchronize
 their global state (such as global variables, new method definitions, and loaded modules) with any
-of the other running processes.
+of the other running processes. You may use `addprocs(exeflags="--project")` to initialize a worker with
+a particular environment.
 
 Other types of clusters can be supported by writing your own custom `ClusterManager`, as described
 below in the [ClusterManagers](@ref) section.

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -770,7 +770,7 @@ It is automatically made available on the worker processes.
 Note that workers do not run a `~/.julia/config/startup.jl` startup script, nor do they synchronize
 their global state (such as global variables, new method definitions, and loaded modules) with any
 of the other running processes. You may use `addprocs(exeflags="--project")` to initialize a worker with
-a particular environment.
+a particular environment, and then `@everywhere using <modulename>` or `@everywhere include("file.jl")`.
 
 Other types of clusters can be supported by writing your own custom `ClusterManager`, as described
 below in the [ClusterManagers](@ref) section.


### PR DESCRIPTION
Based on discussion here: https://discourse.julialang.org/t/code-loading-with-workers-and-modules/30064/2

I believe the added note is helpful because a partial solution can now be found immediately after the limitation is described. Assuming I understand right.