### PR TITLE
spezialized conj of Transpose/Adjoint

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -281,3 +281,7 @@ pinv(v::TransposeAbsVec, tol::Real = 0) = pinv(conj(v.parent)).parent
 /(u::TransposeAbsVec, A::AbstractMatrix) = transpose(transpose(A) \ u.parent)
 /(u::AdjointAbsVec, A::Transpose{<:Any,<:AbstractMatrix}) = adjoint(conj(A.parent) \ u.parent) # technically should be adjoint(copy(adjoint(copy(A))) \ u.parent)
 /(u::TransposeAbsVec, A::Adjoint{<:Any,<:AbstractMatrix}) = transpose(conj(A.parent) \ u.parent) # technically should be transpose(copy(transpose(copy(A))) \ u.parent)
+
+## complex conjugate
+conj(A::Transpose) = adjoint(A.parent)
+conj(A::Adjoint) = transpose(A.parent)

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -520,6 +520,9 @@ end
             @test conj(conj(M)) === M
         end
     end
+    # test if `conj(transpose(::Hermitian))` is a no-op
+    hermitian = Hermitian([1 2+im; 2-im 3])
+    @test conj(transpose(hermitian)) === hermitian
 end
 
 end # module TestAdjointTranspose

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -513,17 +513,13 @@ end
                                                       complexmat, vec(complexmat),
                                                       nested, vec(nested),
                                                      )
-        t = transpose(i)
-        @test conj(t) isa Adjoint
-        @test conj(t) == conj(collect(t))
-        @test conj(conj(t)) === t
-
-        a = adjoint(i)
-        @test conj(a) isa Transpose
-        @test conj(a) == conj(collect(a))
-        @test conj(conj(a)) === a
+        for (t,type) in ((transpose, Adjoint), (adjoint, Transpose))
+            M = t(i)
+            @test conj(M) isa type
+            @test conj(M) == conj(collect(M))
+            @test conj(conj(M)) === M
+        end
     end
 end
-
 
 end # module TestAdjointTranspose

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -504,4 +504,26 @@ using .Main.OffsetArrays
     @test_throws BoundsError s[1, 4]
 end
 
+@testset "specialized conj of Adjoint/Transpose" begin
+    realmat = [1 2; 3 4]
+    complexmat = ComplexF64[1+im 2; 3 4-im]
+    nested = [[complexmat] [-complexmat]; [0complexmat] [3complexmat]]
+    @testset "AdjOrTrans{...,$(typeof(i))}" for i in (
+                                                      realmat, vec(realmat),
+                                                      complexmat, vec(complexmat),
+                                                      nested, vec(nested),
+                                                     )
+        t = transpose(i)
+        @test conj(t) isa Adjoint
+        @test conj(t) == conj(collect(t))
+        @test conj(conj(t)) === t
+
+        a = adjoint(i)
+        @test conj(a) isa Transpose
+        @test conj(a) == conj(collect(a))
+        @test conj(conj(a)) === a
+    end
+end
+
+
 end # module TestAdjointTranspose


### PR DESCRIPTION
I brought this up on Slack and it received quite positive feedback, so I put this together as a PR. The implementation is very minimal. Two things to maybe think about:
* For `AbstractArray{<:Real}`, `conj` is generally a no-op, this breaks this assumption. We still differentiate between `Adjoint` and `Transpose` for real matrices though, so I think this is fine.
* Do we want something similar for broadcasted `conj`? – Probably not worth it?

I am also not quite sure, how breaking one should consider this change. It will definitely break code, that relies on `conj` returning a copy here.