### PR TITLE
Prevent `OverflowError` when multiplying empty sparse matrix and its adjoint (fixes #33365)

### DIFF
--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -1224,11 +1224,12 @@ function *(A::Sparse{Tv}, adjB::Adjoint{Tv,Sparse{Tv}}) where Tv<:VRealTypes
     ## A->stype == 0 (storage of upper and lower parts). If necessary
     ## the matrix A is first converted to stype == 0
     s = unsafe_load(pointer(A))
+    fset = s.ncol == 0 ? SuiteSparse_long[] : SuiteSparse_long[0:s.ncol-1;]
     if s.stype != 0
         aa1 = copy(A, 0, 1)
-        return aat(aa1, SuiteSparse_long[0:s.ncol-1;], 1)
+        return aat(aa1, fset, 1)
     else
-        return aat(A, SuiteSparse_long[0:s.ncol-1;], 1)
+        return aat(A, fset, 1)
     end
 end
 

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -855,3 +855,15 @@ end
         @test !issuccess(ldlt!(F, M; check = false))
     end
 end
+
+@testset "Issue #33365" begin
+    A = Sparse(spzeros(0, 0))
+    @test A * A' == A
+    @test A' * A == A
+    B = Sparse(spzeros(0, 4))
+    @test B * B' == Sparse(spzeros(0, 0))
+    @test B' * B == Sparse(spzeros(4, 4))
+    C = Sparse(spzeros(3, 0))
+    @test C * C' == Sparse(spzeros(3, 3))
+    @test C' * C == Sparse(spzeros(0, 0))
+end


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#668.