### PR TITLE
Modified _searchindex for findnext to work like findprev (for small integers) (#33100)

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -185,7 +185,8 @@ function _searchindex(s::ByteArray, t::ByteArray, i::Integer)
     end
 
     w = m - n
-    if w < 0 || i - 1 > w
+    i = i > 0 ? i-1 : 0
+    if w < 0 || i > w
         return 0
     end
 
@@ -199,7 +200,6 @@ function _searchindex(s::ByteArray, t::ByteArray, i::Integer)
         end
     end
 
-    i -= 1
     while i <= w
         if _nthbyte(s,i+n) == tlast
             # check candidate

--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -194,7 +194,7 @@ modules, such as `Pkg`, or module roots (see [`Base.moduleroot`](@ref)). To
 enable all debug logging, use the special value `all`.
 
 To turn debug logging on from the REPL, set `ENV["JULIA_DEBUG"]` to the
-name of the module of interest. Functions defined in the REPL belong to 
+name of the module of interest. Functions defined in the REPL belong to
 module `Main`; logging for them can be enabled like this:
 ```julia-repl
 julia> foo() = @debug "foo"


### PR DESCRIPTION
Hi!

This fix is proposed for the issue "findnext() does not give BoundsErrors for small negative indices #33100". This is my first time sending a pr to Julia, so please let me know if findnext() should not follow the behavior seen in findprev().

julia> s = "kitten"
"kitten"

julia> findprev(s, s, length(s)+1)
1:6

julia> findprev(s, s, typemax(Int64))
1:6

findprev() gives 1:6 for the example for i>length(s). findnext() will give the same for i<=1.

julia> findnext(s, s, 0)
1:6

julia> findnext(s, s, 1)
1:6

julia> findnext(s, s, 2)

julia> findnext(s, s, -1)
1:6

julia> findnext(s, s, -100)
1:6

julia> findnext(s, s, typemin(Int64))
1:6
 