### PR TITLE
Support the PCRE Regex PARTIAL_{HARD,SOFT} opts.

### DIFF
--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -157,7 +157,9 @@ function exec(re, subject, offset, options, match_data)
                re, subject, sizeof(subject), offset, options, match_data, get_local_match_context())
     # rc == -1 means no match, -2 means partial match.
     rc < -2 && error("PCRE.exec error: $(err_message(rc))")
-    rc >= 0
+    (rc >= 0 ||
+        # Allow partial matches if they were requested in the options.
+        ((options & PARTIAL_HARD != 0 || options & PARTIAL_SOFT != 0) && rc == -2))
 end
 
 function exec_r(re, subject, offset, options)


### PR DESCRIPTION
Make `exec` aware of the `PARTIAL_HARD` and `PARTIAL_SOFT` flags set on a `Regex` object.

This allows `match()` to return partial matches if they are requested by the user in the Regex options. Currently we are ignoring these options, since partial matches are returned as a `-2` status code, and we are not currently checking for that.

------

Partial Regex matches are often used for interactive validation of UI fields (e.g. in a web page):
 - You could have a regex describing the format of the field you expect, which you check for a (partial) match as the user types, so you can catch as soon as they have entered something that is invalid (because no completion of it will satisfy the regex), and underline the text in red (or something).
-  For example, something like this:
    ```julia
    if (partial_match(r"\d\d/\d\d/\d\d\d\d", input) == nothing) throw("input must be a \"dd/mm/yyyy\" string") end
    ```

-------

I didn't include a convenience function for _constructing_ a partial regex, which maybe we should also include in this PR?
Right now we're constructing them in our code like this:
```
partial(str::AbstractString) = Regex(str, Base.DEFAULT_COMPILER_OPTS,
    Base.DEFAULT_MATCH_OPTS | Base.PCRE.PARTIAL_HARD)
```

But it might make sense to add a flag to the `r""` macro, in the same style as the `m`/`i` flags? I couldn't find any equivalent such flags online -- where is the inspiration for those one-letter flags taken from?

Or this could be done in follow-up PRs.