### PR TITLE
Clarified matrix column order example in performance-tips.md

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -778,7 +778,7 @@ adopted by C and Python (`numpy`) among other languages. Remembering the orderin
 have significant performance effects when looping over arrays. A rule of thumb to keep in mind
 is that with column-major arrays, the first index changes most rapidly. Essentially this means
 that looping will be faster if the inner-most loop index is the first to appear in a slice expression.
-Keep in mind that accessing an array with `:` is a loop.
+Keep in mind that indexing an array with `:` is an implicit loop that iteratively accesses all elements within a particular dimension; it can be faster to extract columns than rows, for example.
 
 Consider the following contrived example. Imagine we wanted to write a function that accepts a
 [`Vector`](@ref) and returns a square [`Matrix`](@ref) with either the rows or the columns filled with copies

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -777,7 +777,8 @@ name a few). The alternative to column-major ordering is row-major ordering, whi
 adopted by C and Python (`numpy`) among other languages. Remembering the ordering of arrays can
 have significant performance effects when looping over arrays. A rule of thumb to keep in mind
 is that with column-major arrays, the first index changes most rapidly. Essentially this means
-that looping will be faster if the inner-most loop index is the first to appear in a slice expression. Keep in mind that accessing an array with `:` is a loop.
+that looping will be faster if the inner-most loop index is the first to appear in a slice expression.
+Keep in mind that accessing an array with `:` is a loop.
 
 Consider the following contrived example. Imagine we wanted to write a function that accepts a
 [`Vector`](@ref) and returns a square [`Matrix`](@ref) with either the rows or the columns filled with copies

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -777,7 +777,7 @@ name a few). The alternative to column-major ordering is row-major ordering, whi
 adopted by C and Python (`numpy`) among other languages. Remembering the ordering of arrays can
 have significant performance effects when looping over arrays. A rule of thumb to keep in mind
 is that with column-major arrays, the first index changes most rapidly. Essentially this means
-that looping will be faster if the inner-most loop index is the first to appear in a slice expression.
+that looping will be faster if the inner-most loop index is the first to appear in a slice expression. Keep in mind that accessing an array with `:` is a loop.
 
 Consider the following contrived example. Imagine we wanted to write a function that accepts a
 [`Vector`](@ref) and returns a square [`Matrix`](@ref) with either the rows or the columns filled with copies


### PR DESCRIPTION
Makes clear to newcomers that accessing an array with `:` is specifying a loop.

(Nuked my old fork trying to fix an issue, so restoring PR #29894 based on my new fork, with changes.)