### PR TITLE
Track a distinct compile cache for julia-debug.

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -633,7 +633,7 @@ end
 
 cache_file_entry(pkg::PkgId) = joinpath(
     "compiled",
-    "v$(VERSION.major).$(VERSION.minor)",
+    "v$(VERSION.major).$(VERSION.minor)" * (JLOptions().debug_level > 1 ? "-debug" : ""),
     pkg.uuid === nothing ? ""       : pkg.name),
     pkg.uuid === nothing ? pkg.name : package_slug(pkg.uuid)
 


### PR DESCRIPTION
Addresses #33668.