### PR TITLE
enable regex-filtering of testsets based on their descriptions

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1095,26 +1095,33 @@ function testset_beginend(args, tests, source)
         # this empty loop is here to force the block to be compiled,
         # which is needed for backtrace scrubbing to work correctly.
         while false; end
-        push_testset(ts)
-        # we reproduce the logic of guardseed, but this function
-        # cannot be used as it changes slightly the semantic of @testset,
-        # by wrapping the body in a function
-        local RNG = default_rng()
-        oldrng = copy(RNG)
-        try
-            # RNG is re-seeded with its own seed to ease reproduce a failed test
-            Random.seed!(RNG.seed)
-            $(esc(tests))
-        catch err
-            err isa InterruptException && rethrow()
-            # something in the test block threw an error. Count that as an
-            # error in this test set
-            record(ts, Error(:nontest_error, :(), err, Base.catch_stack(), $(QuoteNode(source))))
-        finally
-            copy!(RNG, oldrng)
+
+        rx = get(ENV, "JULIA_TESTSET_REGEX", nothing)
+        depths = get(ENV, "JULIA_TESTSET_DEPTHS", "1")
+        depths = parse.(Int, split(depths, ',')) .- 1
+
+        if get_testset_depth() ∉ depths || rx === nothing || occursin(Regex(rx), $desc)
+            push_testset(ts)
+            # we reproduce the logic of guardseed, but this function
+            # cannot be used as it changes slightly the semantic of @testset,
+            # by wrapping the body in a function
+            local RNG = default_rng()
+            oldrng = copy(RNG)
+            try
+                # RNG is re-seeded with its own seed to ease reproduce a failed test
+                Random.seed!(RNG.seed)
+                $(esc(tests))
+            catch err
+                err isa InterruptException && rethrow()
+                # something in the test block threw an error. Count that as an
+                # error in this test set
+                record(ts, Error(:nontest_error, :(), err, Base.catch_stack(), $(QuoteNode(source))))
+            finally
+                copy!(RNG, oldrng)
+            end
+            pop_testset()
+            finish(ts)
         end
-        pop_testset()
-        finish(ts)
     end
     # preserve outer location if possible
     if tests isa Expr && tests.head === :block && !isempty(tests.args) && tests.args[1] isa LineNumberNode
@@ -1166,23 +1173,24 @@ function testset_forloop(args, testloop, source)
         _check_testset($testsettype, $(QuoteNode(testsettype.args[1])))
         # Trick to handle `break` and `continue` in the test code before
         # they can be handled properly by `finally` lowering.
-        if !first_iteration
-            pop_testset()
-            push!(arr, finish(ts))
-            # it's 1000 times faster to copy from tmprng rather than calling Random.seed!
-            copy!(RNG, tmprng)
-
-        end
-        ts = $(testsettype)($desc; $options...)
-        push_testset(ts)
-        first_iteration = false
-        try
-            $(esc(tests))
-        catch err
-            err isa InterruptException && rethrow()
-            # Something in the test block threw an error. Count that as an
-            # error in this test set
-            record(ts, Error(:nontest_error, :(), err, Base.catch_stack(), $(QuoteNode(source))))
+        if rx === nothing || occursin(rx, $desc)
+            if !first_iteration
+                pop_testset()
+                push!(arr, finish(ts))
+                # it's 1000 times faster to copy from tmprng rather than calling Random.seed!
+                copy!(RNG, tmprng)
+            end
+            ts = $(testsettype)($desc; $options...)
+            push_testset(ts)
+            first_iteration = false
+            try
+                $(esc(tests))
+            catch err
+                err isa InterruptException && rethrow()
+                # Something in the test block threw an error. Count that as an
+                # error in this test set
+                record(ts, Error(:nontest_error, :(), err, Base.catch_stack(), $(QuoteNode(source))))
+            end
         end
     end
     quote
@@ -1193,6 +1201,15 @@ function testset_forloop(args, testloop, source)
         local oldrng = copy(RNG)
         Random.seed!(RNG.seed)
         local tmprng = copy(RNG)
+        local rx = get(ENV, "JULIA_TESTSET_REGEX", nothing)
+        local depths = get(ENV, "JULIA_TESTSET_DEPTHS", "1")
+        if get_testset_depth()+1 ∉ parse.(Int, split(depths, ','))
+            rx = nothing
+        end
+        if rx !== nothing
+            rx = Regex(rx)
+        end
+
         try
             $(Expr(:for, Expr(:block, [esc(v) for v in loopvars]...), blk))
         finally


### PR DESCRIPTION
The current solutions (that I know of) to run only a certain subset (typically of size one) of testsets in a project, consist either to comment out portions of the test files, or to copy-paste the testset at the REPL (which often doesn't work seamlessly, as you have to replicate the state in the REPL, e.g. define global variables, functions (like `replshow()` in Julia's "test/show.jl" file) etc.

This is not ideal, and filtering run testsets based on their description would go a long way to simplify this process, in many cases at least.   

This PR uses a `"JULIA_TESTSET_REGEX"` environment variable: if set, only testsets matching this regex are run (note that this can be used to exclude certain patterns, with "negative lookahead" regexes). Usually, only toplevel testsets should be filtered, otherwise, filtering in only the following tests for example would be complicated:
```julia
@testset "integers" begin
    @testset "addition" begin
        @test 1 + 1 == 2
    end
    # more sub-testsets ...
end
# needs a regex like r"integers|addition| ...", but how to not catch "addition" from `@testset "floats"` ?
```

There is a catch: in the Julia repo for example, tests in a file are implicitly wrapped in a testset. So in this case, you only want the filtering to happen for testsets at nesting level 2 (toplevel is 1). So there is an other environment variable which contains a comma-separated list of levels (depths) at which filtering must happen, `"JULIA_TESTSET_DEPTHS"` , defaulting to "1".
(The name `"JULIA_TESTSET_DEPTHS"` is far from ideal, suggestions welcome).