### PR TITLE
Base.runtests(): return nothing instead of the Process object

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -821,6 +821,7 @@ function runtests(tests = ["all"]; ncores = ceil(Int, Sys.CPU_THREADS / 2),
     try
         run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR::String,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))
+        nothing
     catch
         buf = PipeBuffer()
         Base.require(Base, :InteractiveUtils).versioninfo(buf)


### PR DESCRIPTION
The process is still printed on failure, but on success, this
seems quite unnecessary: a bunch of environment variables are
also printed as part of it, and this can easily take up more
than half a screen.
(For example, my "LS_COLORS" env var takes already 12 lines of screen estate, and is definitely noise). 

Maybe `show` for `Process` could be improved, but I can't see the usfulness of returning a `Process` from `runtests()`.
