### PR TITLE
Tuple constructors for one-element containers

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -235,6 +235,9 @@ if nameof(@__MODULE__) === :Base
 
 (::Type{T})(x::Tuple) where {T<:Tuple} = convert(T, x)  # still use `convert` for tuples
 
+Tuple(x::Ref) = tuple(getindex(x))  # faster than iterator for one element
+Tuple(x::Array{T,0}) where {T} = tuple(getindex(x))
+
 (::Type{T})(itr) where {T<:Tuple} = _totuple(T, itr)
 
 _totuple(::Type{Tuple{}}, itr, s...) = ()
@@ -266,11 +269,6 @@ _totuple(::Type{Tuple{Vararg{E}}}, itr, s...) where {E} = (collect(E, Iterators.
 _totuple(::Type{Tuple}, itr, s...) = (collect(Iterators.rest(itr,s...))...,)
 
 end
-
-## construction with one element ##
-
-Tuple(x::Ref) = tuple(getindex(x))
-Tuple(x::Array{T,0}) where {T} = tuple(getindex(x))
 
 ## comparison ##
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -267,6 +267,11 @@ _totuple(::Type{Tuple}, itr, s...) = (collect(Iterators.rest(itr,s...))...,)
 
 end
 
+## construction with one element ##
+
+Tuple(x::Ref) = tuple(getindex(x))
+Tuple(x::Array{T,0}) where {T} = tuple(getindex(x))
+
 ## comparison ##
 
 isequal(t1::Tuple, t2::Tuple) = (length(t1) == length(t2)) && _isequal(t1, t2)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -89,6 +89,13 @@ end
 
     # issue #28915
     @test convert(Union{Tuple{}, Tuple{Int}}, (1,)) === (1,)
+
+    @testset "one-element containers" begin
+        r = Ref(3)
+        @test (3,) === @inferred Tuple(r)
+        z = Array{Float64,0}(undef); z[] = 3.0
+        @test (3.0,) === @inferred Tuple(z)
+    end
 end
 
 @testset "size" begin


### PR DESCRIPTION
Currently `Tuple(Ref(99))` works via iterators and takes `184.490 ns (2 allocations: 112 bytes)`, this PR adds a shortcut to make it faster: `1.122 ns (0 allocations: 0 bytes)`. 

There's some chance it ought to add a method to something like `_totuple(T, itr)` instead?