### PR TITLE
remove SinkingPass from pass pipeline

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -213,7 +213,6 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
 
     // Run instcombine after redundancy elimination to exploit opportunities
     // opened up by them.
-    PM->add(createSinkingPass()); ////////////// ****
 #if JL_LLVM_VERSION < 70000
     // This pass is a subset of InstructionCombiningPass in LLVM 7
     // and therefore not required.


### PR DESCRIPTION
SinkingPass is not used by Clang and seems to be only used
as part of the AMDGPU pipeline (after the CFGStructurizer).

I have seen examples where it creates substantial worse code,
especially for the NVPTX, where it clusters loads and moves arithmetic
operations far away, causing a much higher register usage.

The pass was added by @jeffbezanson in abdbbb7ddaca2029438e7bc1843e495721810ba6
a long time ago :) 

cc: @lcw