### PR TITLE
MethodError for missing `div` fallback

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -231,7 +231,15 @@ fld(x::T, y::T) where {T<:Real} = throw(MethodError(div, (x, y, RoundDown)))
 cld(x::T, y::T) where {T<:Real} = throw(MethodError(div, (x, y, RoundUp)))
 
 # Promotion
-div(x::Real, y::Real, r::RoundingMode) = div(promote(x, y)..., r)
+function div(x::Real, y::Real, r::RoundingMode)
+    typeof(x) === typeof(y) && throw(MethodError(div, (x, y, r)))
+    if r == RoundToZero
+        # For compat. Remove in 2.0.
+        div(promote(x, y)...)
+    else
+        div(promote(x, y)..., r)
+    end
+end
 
 # Integers
 # fld(x,y) == div(x,y) - ((x>=0) != (y>=0) && rem(x,y) != 0 ? 1 : 0)


### PR DESCRIPTION
also a better compatibility fallback to two-argument div for packages
that haven't upgraded yet.

Fixes #33651