### PR TITLE
Fix obsolete builtins list in devdocs/function

### DIFF
--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -103,30 +103,27 @@ The "builtin" functions, defined in the `Core` module, are:
 
 ```@eval
 
-lines(words) = begin
-    io = IOBuffer()
-    linelen = 0
-    for word in words
-        if linelen+length(word) > 80
-            print(io, '\n', word)
-            linelen = length(word)
-        elseif linelen == 0
-            print(io, word);
-            linelen += length(word)
-        else
-            print(io, ' ', word);
-            linelen += length(word)+1
-        end
+ws = [string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin]
+io = IOBuffer()
+
+print(io, "```\n")
+n = 0
+for w in ws
+    if n+length(w) > 80
+        print(io, '\n', w)
+        n = length(w)
+    elseif n == 0
+        print(io, w);
+        n += length(w)
+    else
+        print(io, ' ', w);
+        n += length(w)+1
     end
-    String(take!(io))
 end
-
-
+print(io, "\n```")
 
 import Markdown
-fs = [string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin]
-x = Markdown.parse("```\n$(lines(fs))\n```")
-
+x = Markdown.parse(String(take!(io)))
 
 ```
 

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -103,7 +103,6 @@ The "builtin" functions, defined in the `Core` module, are:
 
 ```@eval
 
-
 function lines(words)
     io = IOBuffer()
     n = 0
@@ -121,7 +120,6 @@ function lines(words)
     end
     String(take!(io))
 end
-
 
 import Markdown
 

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -103,28 +103,32 @@ The "builtin" functions, defined in the `Core` module, are:
 
 ```@eval
 
-ws = [string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin]
-io = IOBuffer()
 
-print(io, "```\n")
-n = 0
-for w in ws
-    if n+length(w) > 80
-        print(io, '\n', w)
-        n = length(w)
-    elseif n == 0
-        print(io, w);
-        n += length(w)
-    else
-        print(io, ' ', w);
-        n += length(w)+1
+function lines(words)
+    io = IOBuffer()
+    n = 0
+    for w in words
+        if n+length(w) > 80
+            print(io, '\n', w)
+            n = length(w)
+        elseif n == 0
+            print(io, w);
+            n += length(w)
+        else
+            print(io, ' ', w);
+            n += length(w)+1
+        end
     end
+    String(take!(io))
 end
-print(io, "\n```")
+
 
 import Markdown
-x = Markdown.parse(String(take!(io)))
 
+[string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin] |>
+    lines |>
+    s ->  "```\n$s\n```" |>
+    Markdown.parse
 ```
 
 These are all singleton objects whose types are subtypes of `Builtin`, which is a subtype of

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -101,10 +101,8 @@ currently share a method table via special arrangement.
 
 The "builtin" functions, defined in the `Core` module, are:
 
-```
-=== typeof sizeof <: isa typeassert throw tuple getfield setfield! fieldtype
-nfields isdefined arrayref arrayset arraysize applicable invoke apply_type _apply
-_expr svec
+```@eval
+[n for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin]
 ```
 
 These are all singleton objects whose types are subtypes of `Builtin`, which is a subtype of

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -102,7 +102,32 @@ currently share a method table via special arrangement.
 The "builtin" functions, defined in the `Core` module, are:
 
 ```@eval
-[n for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin]
+
+lines(words) = begin
+    io = IOBuffer()
+    linelen = 0
+    for word in words
+        if linelen+length(word) > 80
+            print(io, '\n', word)
+            linelen = length(word)
+        elseif linelen == 0
+            print(io, word);
+            linelen += length(word)
+        else
+            print(io, ' ', word);
+            linelen += length(word)+1
+        end
+    end
+    String(take!(io))
+end
+
+
+
+import Markdown
+fs = [string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin]
+x = Markdown.parse("```$(lines(fs))\n```")
+
+
 ```
 
 These are all singleton objects whose types are subtypes of `Builtin`, which is a subtype of

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -125,7 +125,7 @@ end
 
 import Markdown
 fs = [string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin]
-x = Markdown.parse("```$(lines(fs))\n```")
+x = Markdown.parse("```\n$(lines(fs))\n```")
 
 
 ```


### PR DESCRIPTION
WAS

```julia
ns_str = """
=== typeof sizeof <: isa typeassert throw tuple getfield setfield! fieldtype
nfields isdefined arrayref arrayset arraysize applicable invoke apply_type _apply
_expr svec
"""
```

BUT

```julia
ns = ns_str |> strip |> split |> s -> map(Symbol,s)
ns2 = [n for n in names(Core) if getfield(Core,n) isa Core.Builtin] # 15 without private
ns2 = [n for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin] # 29 with private

@test setdiff(ns2, ns) == [ :_apply_latest, :_apply_pure, :_typevar, :const_arrayref, :getproperty, :ifelse, :setproperty!] # with private
```