### PR TITLE
Add test-revise-* Makefile targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,12 @@ If you need to restart your Julia session, just start at step 2 above.
 built and incorporate them automatically. You only need to rebuild
 Julia if you made code-changes that Revise cannot handle.
 
+For convenience, there are also `test-revise-*` targets for every `test-*`
+target that use Revise to load any modifications to Base into the current
+process before running the corresponding test. This can be useful as a shortcut
+on the command line (since tests aren't always designed to be run outside the
+runtest harness).
+
 ### Code Formatting Guidelines
 
 #### General Formatting Guidelines for Julia code contributions

--- a/Makefile
+++ b/Makefile
@@ -580,7 +580,12 @@ testall1: check-whitespace $(JULIA_BUILD_MODE)
 	@env JULIA_CPU_THREADS=1 $(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/test all JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
 
 test-%: check-whitespace $(JULIA_BUILD_MODE)
+	@([ $$(( $$(date +%s) - $$(date +%s -r $(build_private_libdir)/sys.$(SHLIB_EXT)) )) -le 100 ] && \
+		printf '\033[93m    HINT The system image was recently rebuilt. Are you aware of the test-revise-* targets? See CONTRIBUTING.md. \033[0m\n') || true
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/test $* JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
+
+test-revise-%:
+	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/test revise-$* JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
 
 # download target for some hardcoded windows dependencies
 .PHONY: win-extras wine_path

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,6 +25,10 @@ $(TESTS):
 	@cd $(SRCDIR) && \
 	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no ./runtests.jl $@)
 
+$(addprefix revise-, $(TESTS)):
+	@cd $(SRCDIR) && \
+    $(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no ./runtests.jl --revise $(subst revise-,,$@))
+
 embedding:
 	@$(MAKE) -C $(SRCDIR)/$@ check $(EMBEDDING_ARGS)
 

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -60,6 +60,7 @@ function choosetests(choices = [])
     tests = []
     skip_tests = []
     exit_on_error = false
+    use_revise = false
     seed = rand(RandomDevice(), UInt128)
 
     for (i, t) in enumerate(choices)
@@ -68,6 +69,8 @@ function choosetests(choices = [])
             break
         elseif t == "--exit-on-error"
             exit_on_error = true
+        elseif t == "--revise"
+            use_revise = true
         elseif startswith(t, "--seed=")
             seed = parse(UInt128, t[8:end])
         else
@@ -183,5 +186,5 @@ function choosetests(choices = [])
     # Filter out tests from the test groups in the stdlibs
     filter!(!in(skip_tests), tests)
 
-    tests, net_on, exit_on_error, seed
+    tests, net_on, exit_on_error, use_revise, seed
 end


### PR DESCRIPTION
These targets use Revise to load any modifications to base into the
process before running tests. This is very handy when editing Base
and wanting to run the appropriate tests as a sanity check but
without waiting 3 minutes for a whole system image rebuild. Of course
it was previously possible to do this through the REPL by doing the
3-4 steps manually, but I was generally too lazy too do that, so
here's the automatic option.

Also, if we detect that you just rebuilt your sysimage before the test- command is run, you get a friendly ad for the new functionality:
![Screen Shot 2019-10-26 at 12 49 33 AM](https://user-images.githubusercontent.com/1291671/67614511-0ef61080-f78c-11e9-8feb-464f66448a78.png)
