### PR TITLE
Define what is and is not covered by SemVer for Julia itself (Base Julia and stdlibs)

### DIFF
--- a/doc/src/manual/semver_promise.md
+++ b/doc/src/manual/semver_promise.md
@@ -1,0 +1,36 @@
+# The Julia Language API and SemVer
+
+This pages documents the finer details of how Julia follows the [SemVer 2.0 specification](https://semver.org/).
+
+In particular it lists things that are *not* covered by SemVer and may change without tagging a **major** release.
+
+For brevity, in the following sections the following defintions appply:
+ - **API Items**: Functions, Macros, Types, Modules and Constants
+ - **Standard Libraries**: Base, Core, as well as the other packages included in a julia install by default, such as Pkg, Statistics, LinearAlgebra etc.
+ 
+
+The following are excluded:
+ - _API Items_ that are not exported
+      - For example: `Pkg.installed` is not exported and is removed in Julia v1.4
+ - _API Items_ that are marked _experimental_ in their release notes or documentation.
+      - For example: the `Base.Threading` module introduced in julia v0.4 was maked experimental until julia v1.3; and thus could have been removed at any time.
+ - The type of exception that might be thrown by a particular method or action.
+      - For example: `run(`failingcommand`) changed in 1.2 to throw a `ProcessFailedException` rather than an `ErrorException`.
+ - Whether or not an exception is thrown at all. I.e. behavour can be improved to make less things errors:
+      - For example in julia 1.0 `print(nothing)` errored, but in 1.3 it works.
+ - The exact set of exported _API Items_: more things may be exported expanding the API
+      - For example julia v1.1 added `eachcol`.
+
+ 
+Further understand that according to SemVer 2: bugs, such as when a functions behavour disagrees with the documentation, my be removed in any release.
+This also includes when a breaking change was mistakenly added, a patch release can revert it.
+
+
+The following things *are* covered by the SemVer garentee (many other things also, but these might catch you by surprise):
+ - 
+ - 
+ 
+ 
+## TODO CLassify these:
+  - The serialization format used by `Base.serialize`; except when dealing with stored values that are of types that were allowed to be changed.
+  - The stream of random numbers given by the default random number generator for a given seed.

--- a/doc/src/manual/semver_promise.md
+++ b/doc/src/manual/semver_promise.md
@@ -31,6 +31,8 @@ The following things *are* covered by the SemVer garentee (many other things als
  - 
  
  
-## TODO CLassify these:
+## TODO Classify these:
   - The serialization format used by `Base.serialize`; except when dealing with stored values that are of types that were allowed to be changed.
   - The stream of random numbers given by the default random number generator for a given seed.
+  - Behavour after reassigning a constant
+  - Behavour while engaging in type-piracy


### PR DESCRIPTION
We really should document this.
I figured I would start and people who know more could push directly to my branch.

[TensorFlow has a good one of these pages in its docs](https://www.tensorflow.org/guide/versions)

We could almost take these directly:


> 
> Floating point numerical details: The specific floating point values computed by ops may change at any time. Users should rely only on approximate accuracy and numerical stability, not on the specific bits computed. Changes to numerical formulas in minor and patch releases should result in comparable or improved accuracy, with the caveat that in machine learning improved accuracy of specific formulas may result in decreased accuracy for the overall system.
> 
> Random numbers: The specific random numbers computed by the random ops may change at any time. Users should rely only on approximately correct distributions and statistical strength, not the specific bits computed. However, we will make changes to random bits rarely (or perhaps never) for patch releases. We will, of course, document all such changes.
> 
> Bugs: We reserve the right to make backwards incompatible behavior (though not API) changes if the current implementation is clearly broken, that is, if it contradicts the documentation or if a well-known and well-defined intended behavior is not properly implemented due to a bug. For example, if an optimizer claims to implement a well-known optimization algorithm but does not match that algorithm due to a bug, then we will fix the optimizer. Our fix may break code relying on the wrong behavior for convergence. We will note such changes in the release notes.
> 
> Error behavior: We may replace errors with non-error behavior. For instance, we may change a function to compute a result instead or raising an error, even if that error is documented. We also reserve the right to change the text of error messages. In addition, the type of an error may change unless the exception type for a specific error condition is specified in the documentation