### PR TITLE
fix printing of `'`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -994,7 +994,7 @@ end
 # * Print valid identifiers & operators literally; also macros names if allow_macroname=true
 # * Escape invalid identifiers with var"" syntax
 function show_sym(io::IO, sym; allow_macroname=false)
-    if isidentifier(sym) || (isoperator(sym) && sym !== :var"'")
+    if isidentifier(sym) || (isoperator(sym) && sym !== Symbol("'"))
         print(io, sym)
     elseif allow_macroname && (sym_str = string(sym); startswith(sym_str, '@'))
         print(io, '@')
@@ -1050,7 +1050,7 @@ end
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
-        if isidentifier(s) || (isoperator(value) && value !== :var"'")
+        if isidentifier(s) || (isoperator(value) && value !== Symbol("'"))
             print(io, ":")
             print(io, value)
         else

--- a/base/show.jl
+++ b/base/show.jl
@@ -994,7 +994,7 @@ end
 # * Print valid identifiers & operators literally; also macros names if allow_macroname=true
 # * Escape invalid identifiers with var"" syntax
 function show_sym(io::IO, sym; allow_macroname=false)
-    if isidentifier(sym) || isoperator(sym)
+    if isidentifier(sym) || (isoperator(sym) && sym !== :var"'")
         print(io, sym)
     elseif allow_macroname && (sym_str = string(sym); startswith(sym_str, '@'))
         print(io, '@')
@@ -1050,7 +1050,7 @@ end
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
-        if isidentifier(s) || isoperator(value)
+        if isidentifier(s) || (isoperator(value) && value !== :var"'")
             print(io, ":")
             print(io, value)
         else

--- a/test/show.jl
+++ b/test/show.jl
@@ -351,6 +351,10 @@ end
 @test sprint(show, :+) == ":+"
 @test sprint(show, :end) == ":end"
 
+# make sure :var"'" prints correctly
+@test sprint(show, Symbol("'")) == "Symbol(\"'\")"
+@test_repr "var\"'\" = 5"
+
 # issue #32408: Printing of names which are invalid identifiers
 # Invalid identifiers which need `var` quoting:
 @test sprint(show, Expr(:call, :foo, Symbol("##")))   == ":(foo(var\"##\"))"


### PR DESCRIPTION
`:var"'"` prints as `:'` and `:(2*var"'")` as `:(2')`, neither of which are parseable. Not the most elegant solution to just special case it, but this seemed the most logical to me.