### PR TITLE
Regex: enable support for partial matches

### DIFF
--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -159,6 +159,10 @@ function err_message(errno::Integer)
     return GC.@preserve buffer unsafe_string(pointer(buffer))
 end
 
+const NO_MATCH = 0
+const PARTIAL_MATCH = 1
+const FULL_MATCH = 2
+
 function exec(re, subject, offset, options, match_data)
     if !(subject isa Union{String,SubString{String}})
         subject = String(subject)
@@ -168,10 +172,12 @@ function exec(re, subject, offset, options, match_data)
                re, subject, ncodeunits(subject), offset, options, match_data, get_local_match_context())
     # rc == -1 means no match, -2 means partial match.
     rc < -2 && error("PCRE.exec error: $(err_message(rc))")
-    if rc == -2 && 0 != (options & (PCRE.PARTIAL_SOFT|PCRE.PARTIAL_HARD))
-        missing
+    if rc == -2
+        PARTIAL_MATCH
+    elseif rc == -1
+        NO_MATCH
     else
-        rc >= 0
+        FULL_MATCH
     end
 end
 

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -168,7 +168,11 @@ function exec(re, subject, offset, options, match_data)
                re, subject, ncodeunits(subject), offset, options, match_data, get_local_match_context())
     # rc == -1 means no match, -2 means partial match.
     rc < -2 && error("PCRE.exec error: $(err_message(rc))")
-    return rc >= 0
+    if rc == -2 && 0 != (options & (PCRE.PARTIAL_SOFT|PCRE.PARTIAL_HARD))
+        missing
+    else
+        rc >= 0
+    end
 end
 
 function exec_r(re, subject, offset, options)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -155,4 +155,36 @@
 
     # test that we can get the error message of negative error codes
     @test Base.PCRE.err_message(Base.PCRE.ERROR_NOMEMORY) isa String
+
+    @testset "partial matches" begin
+        for partial in [Base.PCRE.PARTIAL_SOFT, Base.PCRE.PARTIAL_HARD, UInt32(0)]
+            r = Regex("ab+", Base.DEFAULT_COMPILER_OPTS, Base.DEFAULT_MATCH_OPTS | partial)
+            @test occursin(r, "ab")
+            m = match(r, "ab")
+            @test m.partial == (partial == Base.PCRE.PARTIAL_HARD)
+            @test m.match == "ab"
+
+            m = match(r, "a")
+            if partial == 0
+                @test m === nothing
+            else
+                @test m.partial
+            end
+
+            em = collect(eachmatch(r, "abqab"))
+            @test em[1].partial == false
+            @test em[2].partial == (partial == Base.PCRE.PARTIAL_HARD)
+
+            em = collect(eachmatch(r, "abqa"))
+            @test em[1].partial == false
+            if partial == 0
+                @test length(em) == 1
+            else
+                @test em[2].partial
+            end
+
+            @test findnext(r, "abqab", 1) == 1:2
+            @test findnext(r, "abqab", 3) == 4:5
+        end
+    end
 end


### PR DESCRIPTION
String `str` is a partial match for regex `r` when `str` is a potential prefix of a match for `r`. See for example  https://www.pcre.org/current/doc/html/pcre2partial.html for a motivating example. Another example where I may need it is for #33617 
PCRE supports that, so it's easy to expose this functionality, only the API has to be decided.

There are two options for partial matches: `PCRE_PARTIAL_SOFT` and `PCRE_PARTIAL_HARD`. With the soft option, a full match is prefered over a partial one, the hard option is the opposite.

The proposed API here is:
- `Regex` constructor: add the `p` flag to mean `PCRE_PARTIAL_SOFT`, e.g. `r"abc"p`
- `match`: add a `partial` field to mean that the match was partial
- `eachmatch`: seems to work automatically (only the last element of the iterator can be partial), but we may forbid the presence of a partial flag 
- `findnext`: still needs to be updated, but I guess the choice of supporting partial matches should match that for `eachmatch`
- `occursin`/`startswith`: with the current implementation, `occursin(r, str)` returns missing if `str` is a partial match (implemenation detail leak). I don't find it so bad: if we consider that the string `str` is "incomplete" when a partial flag is passed, and there is a partial match, we can only conclude that the information needed to say whether there is a match (the yet unvavailable end of the string) is missing. Should this return `true` instead? (then we can't discriminate between a full & partial match).
- `endswith` fails with the "partial" options (incompatible options).