### PR TITLE
speedup BitSet iteration (by 2x or 3x)

### DIFF
--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -341,13 +341,12 @@ filter!(f, s::BitSet) = unsafe_filter!(f, s)
 @inline in(n::Integer, s::BitSet) = _is_convertible_Int(n) ? in(Int(n), s) : false
 
 function iterate(s::BitSet, (word, idx) = (CHK0, 0))
-    while (b = trailing_zeros(word)) == 64 # word == 0
+    while word == 0
         idx == length(s.bits) && return nothing
         idx += 1
         word = @inbounds s.bits[idx]
     end
-    word ⊻= one(UInt64) << (b % UInt) # cancel bit b for next iteration
-    b + (idx - 1 + s.offset) << 6, (word, idx)
+    trailing_zeros(word) + (idx - 1 + s.offset) << 6, (_blsr(word), idx)
 end
 
 @noinline _throw_bitset_notempty_error() =

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -340,10 +340,14 @@ filter!(f, s::BitSet) = unsafe_filter!(f, s)
 @inline in(n::Int, s::BitSet) = _bits_getindex(s.bits, n, s.offset)
 @inline in(n::Integer, s::BitSet) = _is_convertible_Int(n) ? in(Int(n), s) : false
 
-function iterate(s::BitSet, idx=0)
-   idx = _bits_findnext(s.bits, idx)
-   idx == -1 && return nothing
-   (idx + intoffset(s), idx+1)
+function iterate(s::BitSet, (word, idx) = (CHK0, 0))
+    while (b = trailing_zeros(word)) == 64 # word == 0
+        idx == length(s.bits) && return nothing
+        idx += 1
+        word = @inbounds s.bits[idx]
+    end
+    word ⊻= one(UInt64) << (b % UInt) # cancel bit b for next iteration
+    b + (idx - 1 + s.offset) << 6, (word, idx)
 end
 
 @noinline _throw_bitset_notempty_error() =


### PR DESCRIPTION
Cf. https://discourse.julialang.org/t/iterate-and-intersect-on-bitset-vs-int/30345/5 for motivation.

A shorter (stupid) benchmark:
```julia
b1 = BitSet(1:1000)
b2 = BitSet(rand(1:1000, 500))
b3 = BitSet(rand(1:1000, 100))

function findval(set, x)
    for v in set
        if v == x
            return true
        end
    end
    false
end
```
Master:
```julia
julia> for b = (b1, b2, b3)
           @btime findval($b, 1001)
       end
  6.939 μs (0 allocations: 0 bytes)
  3.025 μs (0 allocations: 0 bytes)
  660.325 ns (0 allocations: 0 bytes)
```
PR:
```julia
julia> for b = (b1, b2, b3)
           @btime findval($b, 1001)
       end
  2.602 μs (0 allocations: 0 bytes)
  1.140 μs (0 allocations: 0 bytes)
  225.121 ns (0 allocations: 0 bytes)
```
EDIT: PR with `_blsr`:
```julia
julia> for b = (b1, b2, b3)
           @btime findval($b, 1001)
       end
  1.071 μs (0 allocations: 0 bytes)
  499.384 ns (0 allocations: 0 bytes)
  110.638 ns (0 allocations: 0 bytes)
```

~~This is a speedup of about 2.6x for `b1` and `b2`, and almost 3x for `b3`.~~
This is a speedup of about 6x. 