### PR TITLE
Make finalizer warning for shredded SecretBuffer async

### DIFF
--- a/base/secretbuffer.jl
+++ b/base/secretbuffer.jl
@@ -166,7 +166,7 @@ function read(io::SecretBuffer, ::Type{UInt8})
 end
 
 function final_shred!(s::SecretBuffer)
-    !isshredded(s) && @warn("a SecretBuffer was `shred!`ed by the GC; use `shred!` manually after use to minimize exposure.")
+    !isshredded(s) && @async @warn("a SecretBuffer was `shred!`ed by the GC; use `shred!` manually after use to minimize exposure.")
     shred!(s)
 end
 


### PR DESCRIPTION
This avoids IO in the finalizer where it's invalid to task switch.

Fixes #33696 (CC @staticfloat) by following the advice from #25141.

Amusingly enough, this seems to be a case where the unstructured "fire and forget" nature of `@async` is useful, at least from an implementation perspective (not really a counter example to #33248 but at least an interesting edge case to consider)