### PR TITLE
Document that using `invoke` on external functions is not forward-compatible

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1381,6 +1381,13 @@ This method allows invoking a method other than the most specific matching metho
 when the behavior of a more general definition is explicitly needed (often as part of the
 implementation of a more specific method of the same function).
 
+Be careful when using `invoke` for functions that you don't write.  What definition is used
+for given `argtypes` is an implementation detail unless the function is explicitly states
+that calling with certain `argtypes` is a part of public API.  For example, the change
+between `f1` and `f2` in the example below is usually considered compatible because the
+change is invisible by the caller with a normal (non-`invoke`) call.  However, the change is
+visible if you use `invoke`.
+
 # Examples
 ```jldoctest
 julia> f(x::Real) = x^2;
@@ -1389,6 +1396,25 @@ julia> f(x::Integer) = 1 + invoke(f, Tuple{Real}, x);
 
 julia> f(2)
 5
+
+julia> f1(::Integer) = Integer
+       f1(::Real) = Real;
+
+julia> f2(x::Real) = _f2(x)
+       _f2(::Integer) = Integer
+       _f2(_) = Real;
+
+julia> f1(1)
+Integer
+
+julia> f2(1)
+Integer
+
+julia> invoke(f1, Tuple{Real}, 1)
+Real
+
+julia> invoke(f2, Tuple{Real}, 1)
+Integer
 ```
 """
 invoke


### PR DESCRIPTION
Motivated by #33684, I suggest to add the following notes to the docstring of `invoke`:

> Be careful when using `invoke` for functions that you don't write.  What definition is used for given `argtypes` is an implementation detail unless the function is explicitly states that calling with certain `argtypes` is a part of public API.  For example, the change between `f1` and `f2` in the example below is usually considered compatible because the change is invisible by the caller with a normal (non-`invoke`) call.  However, the change is visible if you use `invoke`.

> ```julia
> julia> f1(::Integer) = Integer
>        f1(::Real) = Real;
> 
> julia> f2(x::Real) = _f2(x)
>        _f2(::Integer) = Integer
>        _f2(_) = Real;
> 
> julia> f1(1)
> Integer
> 
> julia> f2(1)
> Integer
> 
> julia> invoke(f1, Tuple{Real}, 1)
> Real
> 
> julia> invoke(f2, Tuple{Real}, 1)
> Integer
> ```
