### PR TITLE
Fix `div` docstring to describe division, after #33040

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -4,10 +4,11 @@
     div(x, y, r::RoundingMode=RoundToZero)
 
 The quotient from Euclidean division. Computes x/y, rounded to an integer according
-to the rounding mode `r`. In other words, the following quantity:
+to the rounding mode `r`. In other words, the quantity
 
     round(x/y,r)
 
+without any intermediate rounding.
 
 See also: [`fld`](@ref), [`cld`](@ref) which are special cases of this function
 

--- a/base/div.jl
+++ b/base/div.jl
@@ -3,12 +3,11 @@
 """
     div(x, y, r::RoundingMode=RoundToZero)
 
-Compute the remainder of `x` after integer division by `y`, with the quotient rounded
-according to the rounding mode `r`. In other words, the quantity
+The quotient from Euclidean division. Computes x/y, rounded to an integer according
+to the rounding mode `r`. In other words, the following quantity:
 
-    y*round(x/y,r)
+    round(x/y,r)
 
-without any intermediate rounding.
 
 See also: [`fld`](@ref), [`cld`](@ref) which are special cases of this function
 


### PR DESCRIPTION
It looks like in #33040 the `div` docstring was accidentally incorrectly copied from the `rem` docstring, so it currently describes the `rem` operation, not `div`.

This commit changes that docstring to correctly describe integer division with custom rounding.