### PR TITLE
Improve REPL printing of UmfpackLU

### DIFF
--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -190,9 +190,18 @@ function size(F::UmfpackLU, dim::Integer)
     end
 end
 
-function show(io::IO, F::UmfpackLU)
-    print(io, "UMFPACK LU Factorization of a $(size(F)) sparse matrix")
-    F.numeric != C_NULL && print(io, '\n', F.numeric)
+function show(io::IO, mime::MIME{Symbol("text/plain")}, F::UmfpackLU)
+    if F.numeric != C_NULL
+        if issuccess(F)
+            summary(io, F); println(io)
+            println(io, "L factor:")
+            show(io, mime, F.L)
+            println(io, "\nU factor:")
+            show(io, mime, F.U)
+        else
+            print(io, "Failed factorization of type $(typeof(F))")
+        end
+    end
 end
 
 function deserialize(s::AbstractSerializer, t::Type{UmfpackLU{Tv,Ti}}) where {Tv,Ti}

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -190,3 +190,19 @@ using LinearAlgebra: Adjoint, Transpose, SingularException
     end
 
 end
+
+@testset "REPL printing of UmfpackLU" begin
+    # regular matrix
+    A = sparse([1, 2], [1, 2], Float64[1.0, 1.0])
+    F = lu(A)
+    facstring = sprint((t, s) -> show(t, "text/plain", s), F)
+    lstring = sprint((t, s) -> show(t, "text/plain", s), F.L)
+    ustring = sprint((t, s) -> show(t, "text/plain", s), F.U)
+    @test facstring == "$(summary(F))\nL factor:\n$lstring\nU factor:\n$ustring"
+
+    # singular matrix
+    B = sparse(zeros(Float64, 2, 2))
+    F = lu(B; check=false)
+    facstring = sprint((t, s) -> show(t, "text/plain", s), F)
+    @test facstring == "Failed factorization of type $(summary(F))"
+end


### PR DESCRIPTION
This PR addresses another issue from JuliaLang/LinearAlgebra.jl#485.

Consider this code:
```julia
using LinearAlgebra
using SparseArrays
A = sparse([1, 2], [1, 2], Float64[1.0, 1.0])
F = lu(A)
```

Prior to this PR, the LU factorization looked like this:
```julia
julia> F
UMFPACK LU Factorization of a (2, 2) sparse matrix
Ptr{Nothing} @0x0000557483015a10
```

Now it is shown in the same manner as the LU factorization of a dense matrix:
```julia
julia> F
SuiteSparse.UMFPACK.UmfpackLU{Float64,Int64}
L factor:
2×2 SparseMatrixCSC{Float64,Int64} with 2 stored entries:
  [1, 1]  =  1.0
  [2, 2]  =  1.0
U factor:
2×2 SparseMatrixCSC{Float64,Int64} with 2 stored entries:
  [1, 1]  =  1.0
  [2, 2]  =  1.0
```