### PR TITLE
1017 -> 1000

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -418,7 +418,7 @@ julia> function f()
 f (generic function with 1 method)
 
 julia> f() # the correct result is 1000
-1017
+1000
 
 julia> function g()
            a = zeros(1000)


### PR DESCRIPTION
"Side effects and mutable function arguments". I've just run f() several times. I was fortunate to obtain necessary "1000" instead of "1017".