### PR TITLE
fix #33675, unpredictable `summarysize` on isbitsunion arrays

### DIFF
--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -125,7 +125,7 @@ function (ss::SummarySize)(obj::Array)
             dsize += length(obj)
         end
         size += dsize
-        if !isbitstype(eltype(obj)) && !isempty(obj)
+        if !isempty(obj) && !Base.allocatedinline(eltype(obj))
             push!(ss.frontier_x, obj)
             push!(ss.frontier_i, 1)
         end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -206,6 +206,11 @@ end
 @test summarysize(Vector{Nothing}(undef, 16)) == summarysize(Vector{Nothing}(undef, 32))
 @test summarysize(S32881()) == sizeof(Int)
 
+# issue #33675
+let vec = vcat(missing, ones(100000))
+    @test length(unique(summarysize(vec) for i = 1:20)) == 1
+end
+
 # issue #13021
 let ex = try
     Main.x13021 = 0


### PR DESCRIPTION
fix #33675