### PR TITLE
bundle the generated precompilation file with julia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /julia-*
 /source-dist.tmp
 /source-dist.tmp1
+/contrib/precompile.jl
 
 *.exe
 *.dll

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -57,6 +57,7 @@ if Pkg !== nothing
 end
 
 function generate_precompile_statements()
+    rm(joinpath(@__DIR__, "precompile.jl"); force=true)
     start_time = time()
     debug_output = devnull # or stdout
 
@@ -177,6 +178,7 @@ function generate_precompile_statements()
             # comment out if debugging script
             @assert n_succeeded > 3500
         end
+        cp(precompile_file, joinpath(@__DIR__, "precompile.jl"))
 
         print(" $(length(statements)) generated in ")
         tot_time = time() - start_time

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -80,6 +80,7 @@ $$(build_private_libdir)/sys$1-o.a $$(build_private_libdir)/sys$1-bc.a : $$(buil
 		false; \
 	fi )
 	@mv $$@.tmp $$@
+	mv $$(call cygpath_w,$$(JULIAHOME)/contrib/precompile.jl) $(build_datarootdir)/julia/precompile.jl
 .SECONDARY: $$(build_private_libdir)/sys$1-o.a $(build_private_libdir)/sys$1-bc.a # request Make to keep these files around
 endef
 $(eval $(call sysimg_builder,,-O3,$(JULIA_EXECUTABLE_release)))


### PR DESCRIPTION
This could be useful for people that won't to compile a non-incremental version of the sysimage (e.g. for https://github.com/JuliaComputing/MKL.jl).

cc @andreasnoack 