### PR TITLE
simplify @allocated macro

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -156,6 +156,7 @@ julia> @time begin
 """
 macro time(ex)
     quote
+        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
         local stats = gc_num()
         local elapsedtime = time_ns()
         local val = $(esc(ex))
@@ -189,6 +190,7 @@ malloc() calls:    1
 """
 macro timev(ex)
     quote
+        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
         local stats = gc_num()
         local elapsedtime = time_ns()
         local val = $(esc(ex))
@@ -214,9 +216,10 @@ julia> @elapsed sleep(0.3)
 """
 macro elapsed(ex)
     quote
+        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
         local t0 = time_ns()
-        local val = $(esc(ex))
-        (time_ns()-t0)/1e9
+        $(esc(ex))
+        (time_ns() - t0) / 1e9
     end
 end
 
@@ -280,6 +283,7 @@ julia> memallocs.total_time
 """
 macro timed(ex)
     quote
+        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
         local stats = gc_num()
         local elapsedtime = time_ns()
         local val = $(esc(ex))

--- a/base/util.jl
+++ b/base/util.jl
@@ -3,20 +3,20 @@
 
 # This type must be kept in sync with the C struct in src/gc.h
 struct GC_Num
-    allocd      ::Int64 # GC internal
-    deferred_alloc::Int64 # GC internal
-    freed       ::Int64 # GC internal
-    malloc      ::UInt64
-    realloc     ::UInt64
-    poolalloc   ::UInt64
-    bigalloc    ::UInt64
-    freecall    ::UInt64
-    total_time  ::UInt64
-    total_allocd::UInt64 # GC internal
-    since_sweep ::UInt64 # GC internal
-    collect     ::Csize_t # GC internal
-    pause       ::Cint
-    full_sweep  ::Cint
+    allocd          ::Int64 # GC internal
+    deferred_alloc  ::Int64 # GC internal
+    freed           ::Int64 # GC internal
+    malloc          ::Int64
+    realloc         ::Int64
+    poolalloc       ::Int64
+    bigalloc        ::Int64
+    freecall        ::Int64
+    total_time      ::Int64
+    total_allocd    ::Int64 # GC internal
+    since_sweep     ::Int64 # GC internal
+    collect         ::Csize_t # GC internal
+    pause           ::Cint
+    full_sweep      ::Cint
 end
 
 gc_num() = ccall(:jl_gc_num, GC_Num, ())
@@ -35,21 +35,21 @@ struct GC_Diff
 end
 
 gc_total_bytes(gc_num::GC_Num) =
-    (gc_num.allocd + gc_num.deferred_alloc + Int64(gc_num.total_allocd))
+    gc_num.allocd + gc_num.deferred_alloc + gc_num.total_allocd
 
 function GC_Diff(new::GC_Num, old::GC_Num)
     # logic from `src/gc.c:jl_gc_total_bytes`
     old_allocd = gc_total_bytes(old)
     new_allocd = gc_total_bytes(new)
     return GC_Diff(new_allocd - old_allocd,
-                   Int64(new.malloc       - old.malloc),
-                   Int64(new.realloc      - old.realloc),
-                   Int64(new.poolalloc    - old.poolalloc),
-                   Int64(new.bigalloc     - old.bigalloc),
-                   Int64(new.freecall     - old.freecall),
-                   Int64(new.total_time   - old.total_time),
-                   new.pause              - old.pause,
-                   new.full_sweep         - old.full_sweep)
+                   new.malloc       - old.malloc,
+                   new.realloc      - old.realloc,
+                   new.poolalloc    - old.poolalloc,
+                   new.bigalloc     - old.bigalloc,
+                   new.freecall     - old.freecall,
+                   new.total_time   - old.total_time,
+                   new.pause        - old.pause,
+                   new.full_sweep   - old.full_sweep)
 end
 
 function gc_alloc_count(diff::GC_Diff)

--- a/src/julia.h
+++ b/src/julia.h
@@ -749,9 +749,6 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT int jl_gc_enable(int on);
 JL_DLLEXPORT int jl_gc_is_enabled(void);
-JL_DLLEXPORT int64_t jl_gc_total_bytes(void);
-JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void);
-JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
 
 typedef enum {
     JL_GC_AUTO = 0,         // use heuristics to determine the collection type

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -319,6 +319,7 @@ JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz);
 
 JL_DLLEXPORT void JL_NORETURN jl_throw_out_of_memory_error(void);
 
+JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
 void jl_gc_sync_total_bytes(void);
 void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a) JL_NOTSAFEPOINT;
 void jl_gc_count_allocd(size_t sz) JL_NOTSAFEPOINT;

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1109,7 +1109,7 @@ function testset_beginend(args, tests, source)
             err isa InterruptException && rethrow()
             # something in the test block threw an error. Count that as an
             # error in this test set
-            record(ts, Error(:nontest_error, :(), err, Base.catch_stack(), $(QuoteNode(source))))
+            record(ts, Error(:nontest_error, Expr(:tuple), err, Base.catch_stack(), $(QuoteNode(source))))
         finally
             copy!(RNG, oldrng)
         end
@@ -1182,7 +1182,7 @@ function testset_forloop(args, testloop, source)
             err isa InterruptException && rethrow()
             # Something in the test block threw an error. Count that as an
             # error in this test set
-            record(ts, Error(:nontest_error, :(), err, Base.catch_stack(), $(QuoteNode(source))))
+            record(ts, Error(:nontest_error, Expr(:tuple), err, Base.catch_stack(), $(QuoteNode(source))))
         end
     end
     quote

--- a/test/core.jl
+++ b/test/core.jl
@@ -5019,13 +5019,15 @@ end
 # when calculating total allocation size.
 @noinline function f17255(n)
     GC.enable(false)
-    b0 = Base.gc_bytes()
+    b0 = Ref{Int64}(0)
+    b1 = Ref{Int64}(0)
+    Base.gc_bytes(b0)
     local a
     for i in 1:n
         a, t, allocd = @timed [Ref(1) for i in 1:1000]
         @test allocd > 0
-        b1 = Base.gc_bytes()
-        if b1 < b0
+        Base.gc_bytes(b1)
+        if b1[] < b0[]
             return false, a
         end
     end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -533,15 +533,15 @@ end
     B = OffsetArray(reshape(1:24, 4, 3, 2), -5, 6, -7)
     for R in (fill(0, -4:-1), fill(0, -4:-1, 7:7), fill(0, -4:-1, 7:7, -6:-6))
         @test @inferred(maximum!(R, B)) == reshape(maximum(B, dims=(2,3)), axes(R)) == reshape(21:24, axes(R))
-        @test @allocated(maximum!(R, B)) <= 400
+        @test @allocated(maximum!(R, B)) <= 800
         @test @inferred(minimum!(R, B)) == reshape(minimum(B, dims=(2,3)), axes(R)) == reshape(1:4, axes(R))
-        @test @allocated(minimum!(R, B)) <= 400
+        @test @allocated(minimum!(R, B)) <= 800
     end
     for R in (fill(0, -4:-4, 7:9), fill(0, -4:-4, 7:9, -6:-6))
         @test @inferred(maximum!(R, B)) == reshape(maximum(B, dims=(1,3)), axes(R)) == reshape(16:4:24, axes(R))
-        @test @allocated(maximum!(R, B)) <= 400
+        @test @allocated(maximum!(R, B)) <= 800
         @test @inferred(minimum!(R, B)) == reshape(minimum(B, dims=(1,3)), axes(R)) == reshape(1:4:9, axes(R))
-        @test @allocated(minimum!(R, B)) <= 400
+        @test @allocated(minimum!(R, B)) <= 800
     end
     @test_throws DimensionMismatch maximum!(fill(0, -4:-1, 7:7, -6:-6, 1:1), B)
     @test_throws DimensionMismatch minimum!(fill(0, -4:-1, 7:7, -6:-6, 1:1), B)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1490,8 +1490,6 @@ end
 end
 
 @testset "allocation of TwicePrecision call" begin
-    0:286.493442:360
-    0:286:360
     @test @allocated(0:286.493442:360) == 0
     @test @allocated(0:286:360) == 0
 end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1845,8 +1845,7 @@ end
 @testset "closure conversion in testsets" begin
     p = (2, 3, 4)
     @test p == (2, 3, 4)
-    identity(p)
-    allocs = @allocated identity(p)
+    allocs = (() -> @allocated identity(p))()
     @test allocs == 0
 end
 


### PR DESCRIPTION
There were a long list of gotchas in the `@allocated` macro to deal with problems that it couldn't actually solve. The simplified macro doesn't have those issues—and even solves some of the issues it was trying to address. This needed an adjustment to `@testset` to avoid it triggering the compiler heuristic that disables inference.