### PR TITLE
Reorder self-referential types checking to prevent inline allocation

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -5924,6 +5924,14 @@ let x = UnionFieldInlineStruct(1, 3.14)
     @test CInlineUnion[end] == x
 end
 
+# issue 33709
+struct A33709
+    a::Union{Nothing,A33709}
+end
+let a33709 = A33709(A33709(nothing))
+    @test isnothing(a33709.a.a)
+end
+
 # issue 31583
 a31583 = "a"
 f31583() = a31583 === "a"


### PR DESCRIPTION
Fixes #33709 

I added a small test right after those for #32448 but I can move, change or remove it if someone has a preference about it.