### PR TITLE
faster rand!(::MersenneTwister, ::Array{Bool})

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -182,9 +182,12 @@ Standard library changes
 * `randn!(::MersenneTwister, ::Array{Float64})` is faster, and as a result, for a given state of the RNG,
   the corresponding generated numbers have changed ([#35078]).
 
+* `rand!(::MersenneTwister, ::Array{Bool})` is faster, and as a result, for a given state of the RNG,
+  the corresponding generated numbers have changed ([#33721]).
+
 * A new faster algorithm ("nearly division less") is used for generating random numbers
-  within a range ([#29240]).
-  As a result, the streams of generated numbers is changed.
+  within a range ([#29240]). As a result, the streams of generated numbers are changed
+  (for ranges, like in `rand(1:9)`, and for collections in general, like in `rand([1, 2, 3])`).
   Also, for performance, the undocumented property that, given a seed and `a, b` of type `Int`,
   `rand(a:b)` produces the same stream on 32 and 64 bits architectures, is dropped.
 

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -586,8 +586,10 @@ function rand!(r::MersenneTwister, A::UnsafeView{UInt128}, ::SamplerType{UInt128
 end
 
 for T in BitInteger_types
-    @eval rand!(r::MersenneTwister, A::Array{$T}, sp::SamplerType{$T}) =
-        (GC.@preserve A rand!(r, UnsafeView(pointer(A), length(A)), sp); A)
+    @eval function rand!(r::MersenneTwister, A::Array{$T}, sp::SamplerType{$T})
+        GC.@preserve A rand!(r, UnsafeView(pointer(A), length(A)), sp)
+        A
+    end
 
     T == UInt128 && continue
 
@@ -601,6 +603,17 @@ for T in BitInteger_types
         A
     end
 end
+
+
+#### arrays of Bool
+
+function rand!(r::MersenneTwister, A::Array{Bool}, sp::SamplerType{Bool})
+    GC.@preserve A rand!(r,
+                         UnsafeView(Ptr{UInt8}(pointer(A)), length(A)),
+                         SamplerType{UInt8}())
+    A
+end
+
 
 ### randjump
 


### PR DESCRIPTION
This uses the same optimizations as for other bits types,
and gives equivalent performance as for `UInt8` (at least
7x to 9x speedup in few tested cases).

This *seems* to work, but I'm not sure whether it's valid to write arbitrary bit patterns at the memory pointed to by `pointer(b::Array{Bool})`.