### PR TITLE
Track a distinct compile cache for julia-debug.

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -646,7 +646,7 @@ end
 
 cache_file_entry(pkg::PkgId) = joinpath(
     "compiled",
-    "v$(VERSION.major).$(VERSION.minor)",
+    "v$(VERSION.major).$(VERSION.minor)" * (ccall(:jl_is_debugbuild, Cint, ()) > 0 ? "-debug" : ""),
     pkg.uuid === nothing ? ""       : pkg.name),
     pkg.uuid === nothing ? pkg.name : package_slug(pkg.uuid)
 


### PR DESCRIPTION
Addresses #33668.

#29914 was recently merged, which itself may keep `julia` and `julia-debug` from stepping on each other's precompilation, but it still seems natural to me to distinguish between the caches for regular and debug julia at the same level in which we distinguish between julia versions.

Was: #33669