### PR TITLE
faster replace on Dict and Set

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -683,3 +683,46 @@ function _replace!(new::Callable, res::AbstractArray, A::AbstractArray, count::I
     end
     res
 end
+
+### specialization for Dict / Set
+
+function _replace!(new::Callable, t::Dict{K,V}, A::Dict{K,V}, count::Int) where {K,V}
+    # we ignore A, which is supposed to be equal to the destination t,
+    # as it can generally be faster to just replace inline
+    count == 0 && return t
+    c = 0
+    news = Pair{K,V}[]
+    i = skip_deleted_floor!(t)
+    @inbounds while i != 0
+        k1, v1 = t.keys[i], t.vals[i]
+        x1 = Pair{K,V}(k1, v1)
+        x2 = new(x1)
+        if x1 !== x2
+            k2, v2 = first(x2), last(x2)
+            if isequal(k1, k2)
+                t.keys[i] = k2
+                t.vals[i] = v2
+                t.age += 1
+            else
+                _delete!(t, i)
+                push!(news, x2)
+            end
+            c += 1
+            c == count && break
+        end
+        i = i == typemax(Int) ? 0 : skip_deleted(t, i+1)
+    end
+    for n in news
+        push!(t, n)
+    end
+    t
+end
+
+function _replace!(new::Callable, t::Set{T}, ::Set{T}, count::Int) where {T}
+    _replace!(t.dict, t.dict, count) do kv
+        k = first(kv)
+        k2 = new(k)
+        k2 === k ? kv : k2 => nothing
+    end
+    t
+end


### PR DESCRIPTION
This optimizes `replace` and `replace!` functions on `Dict` (and `Set`) based on the internals. The most spectacular improvements is when dict elements are replaced with another element with the same key: then the old value can be overwritten directly, and the time taken by `replace` basically doesn't depend anymore on the number of replaced elements, just the length of the dict.
The following table shows examples of speed-up for different proportions of replaced elements: 

|                       | replace | replace! |
|-----------------------|---------|---------|
| 10% elements replaced |      2x |    2.5x |
|                   50% |      3x |      7x |
|                   90% |      5x |     14x |

When the keys change, the speedup seems to be generally between 30 and 40%. Not as nice, but still a modest improvement.