### PR TITLE
RFC: for the release, change tempfile cleanup default back to false

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,7 @@ New library functions
 
 * The `splitpath` function now accepts any `AbstractString` whereas previously it only accepted paths of type `String` ([#33012]).
 * The `tempname` function now takes an optional `parent::AbstractString` argument to give it a directory in which to attempt to produce a temporary path name ([#33090]).
-* The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `true`, which causes the process to try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
+* The `tempname` function now takes a `cleanup::Bool` keyword argument defaulting to `false` (may change in a future release), which causes the process to try to ensure that any file or directory at the path returned by `tempname` is deleted upon process exit ([#33090]).
 * The `readdir` function now takes a `join::Bool` keyword argument defaulting to `false`, which when set causes `readdir` to join its directory argument with each listed name ([#33113]).
 * `readdir` output is now guaranteed to be sorted. The `sort` keyword allows opting out of sorting to get names in OS-native order ([#33542]).
 * The new `only(x)` function returns the one-and-only element of a collection `x`, and throws an `ArgumentError` if `x` contains zero or multiple elements. ([#33129])


### PR DESCRIPTION
This seems to be exacerbating Windows CI problems such as #31810 and failing its own test. Disable it by default for this release (e.g. reverts 75cb00604e), so we can get this into the next RC, and explore fixes on master.