### PR TITLE
Dispatch even more to BLAS

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -449,8 +449,8 @@ end
     A
 end
 
-promote_unless_bool(α::Number, ::Type{T}) where {T<:Number} = first(promote(α, zero(T)))
-promote_unless_bool(α::Bool, ::Type{T}) where {T<:Number} = α
+# promote_unless_bool(α::Number, ::Type{T}) where {T<:Number} = first(promote(α, zero(T)))
+# promote_unless_bool(α::Bool, ::Type{T}) where {T<:Number} = α
 
 function gemv!(y::StridedVector{T}, tA::AbstractChar, A::StridedVecOrMat{T}, x::StridedVector{T},
                α::Number=true, β::Number=false) where {T<:BlasFloat}
@@ -467,8 +467,10 @@ function gemv!(y::StridedVector{T}, tA::AbstractChar, A::StridedVecOrMat{T}, x::
     if nA == 0
         return _rmul_or_fill!(y, β)
     end
-    alpha = promote_unless_bool(α, T)
-    beta = promote_unless_bool(β, T)
+
+    # alpha = promote_unless_bool(α, T)
+    # beta = promote_unless_bool(β, T)
+    alpha, beta = promote(α, β, zero(T))
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T} && stride(A, 1) == 1 && stride(A, 2) >= size(A, 1)
         return BLAS.gemv!(tA, alpha, A, x, beta, y)
     else
@@ -499,8 +501,9 @@ function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat
         return matmul3x3!(C, tA, tAt, A, A, MulAddMul(α, β))
     end
 
-    alpha = promote_unless_bool(α, T)
-    beta = promote_unless_bool(β, T)
+    # alpha = promote_unless_bool(α, T)
+    # beta = promote_unless_bool(β, T)
+    alpha, beta = promote(α, β, zero(T))
     if (alpha isa Union{Bool,T} &&
         beta isa Union{Bool,T} &&
         stride(A, 1) == stride(C, 1) == 1 &&
@@ -537,8 +540,9 @@ function herk_wrapper!(C::Union{StridedMatrix{T}, StridedMatrix{Complex{T}}}, tA
     # Result array does not need to be initialized as long as beta==0
     #    C = Matrix{T}(undef, mA, mA)
 
-    alpha = promote_unless_bool(α, T)
-    beta = promote_unless_bool(β, T)
+    # alpha = promote_unless_bool(α, T)
+    # beta = promote_unless_bool(β, T)
+    alpha, beta = promote(α, β, zero(T))
     if (alpha isa Union{Bool,T} &&
         beta isa Union{Bool,T} &&
         stride(A, 1) == stride(C, 1) == 1 &&
@@ -586,8 +590,9 @@ function gemm_wrapper!(C::StridedVecOrMat{T}, tA::AbstractChar, tB::AbstractChar
         return matmul3x3!(C, tA, tB, A, B, MulAddMul(α, β))
     end
 
-    alpha = promote_unless_bool(α, T)
-    beta = promote_unless_bool(β, T)
+    # alpha = promote_unless_bool(α, T)
+    # beta = promote_unless_bool(β, T)
+    alpha, beta = promote(α, β, zero(T))
     if (alpha isa Union{Bool,T} &&
         beta isa Union{Bool,T} &&
         stride(A, 1) == stride(B, 1) == stride(C, 1) == 1 &&

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -63,15 +63,15 @@ end
 (*)(a::AbstractVector, B::AbstractMatrix) = reshape(a,length(a),1)*B
 
 @inline mul!(y::StridedVector{T}, A::StridedVecOrMat{T}, x::StridedVector{T},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat} =
+             alpha::Number, beta::Number) where {T<:BlasFloat} =
     gemv!(y, 'N', A, x, alpha, beta)
 # Complex matrix times real vector. Reinterpret the matrix as a real matrix and do real matvec compuation.
 for elty in (Float32,Float64)
     @eval begin
         @inline function mul!(y::StridedVector{Complex{$elty}}, A::StridedVecOrMat{Complex{$elty}}, x::StridedVector{$elty},
-                              alpha::Union{$elty, Bool}, beta::Union{$elty, Bool})
-            Afl = reinterpret($elty,A)
-            yfl = reinterpret($elty,y)
+                              alpha::Number, beta::Number)
+            Afl = reinterpret($elty, A)
+            yfl = reinterpret($elty, y)
             mul!(yfl, Afl, x, alpha, beta)
             return y
         end
@@ -92,7 +92,7 @@ function *(transA::Transpose{<:Any,<:AbstractMatrix{T}}, x::AbstractVector{S}) w
     mul!(similar(x,TS,size(A,2)), transpose(A), x)
 end
 @inline function mul!(y::StridedVector{T}, transA::Transpose{<:Any,<:StridedVecOrMat{T}}, x::StridedVector{T},
-                      alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat}
+                      alpha::Number, beta::Number) where {T<:BlasFloat}
     A = transA.parent
     return gemv!(y, 'T', A, x, alpha, beta)
 end
@@ -114,12 +114,12 @@ function *(adjA::Adjoint{<:Any,<:AbstractMatrix{T}}, x::AbstractVector{S}) where
 end
 
 @inline function mul!(y::StridedVector{T}, adjA::Adjoint{<:Any,<:StridedVecOrMat{T}}, x::StridedVector{T},
-                      alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasReal}
+                      alpha::Number, beta::Number) where {T<:BlasReal}
     A = adjA.parent
     return mul!(y, transpose(A), x, alpha, beta)
 end
 @inline function mul!(y::StridedVector{T}, adjA::Adjoint{<:Any,<:StridedVecOrMat{T}}, x::StridedVector{T},
-                      alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasComplex}
+                      alpha::Number, beta::Number) where {T<:BlasComplex}
     A = adjA.parent
     return gemv!(y, 'C', A, x, alpha, beta)
 end
@@ -165,13 +165,8 @@ function (*)(A::StridedMatrix{<:BlasComplex}, B::StridedMatrix{<:BlasComplex})
 end
 
 @inline function mul!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
-                      α::Number, β::Number) where {T<:BlasFloat}
-    alpha, beta = promote(α, β, zero(T))
-    if alpha isa T && beta isa T
-        return gemm_wrapper!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
-    else
-        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(α, β))
-    end
+                      alpha::Number, beta::Number) where {T<:BlasFloat}
+    return gemm_wrapper!(C, 'N', 'N', A, B, alpha, beta)
 end
 # Complex Matrix times real matrix: We use that it is generally faster to reinterpret the
 # first matrix as a real matrix and carry out real matrix matrix multiply
@@ -307,12 +302,12 @@ julia> lmul!(F.Q, B)
 lmul!(A, B)
 
 @inline function mul!(C::StridedMatrix{T}, transA::Transpose{<:Any,<:StridedVecOrMat{T}}, B::StridedVecOrMat{T},
-                 alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat}
+                 alpha::Number, beta::Number) where {T<:BlasFloat}
     A = transA.parent
     if A===B
-        return syrk_wrapper!(C, 'T', A, MulAddMul(alpha, beta))
+        return syrk_wrapper!(C, 'T', A, alpha, beta)
     else
-        return gemm_wrapper!(C, 'T', 'N', A, B, MulAddMul(alpha, beta))
+        return gemm_wrapper!(C, 'T', 'N', A, B, alpha, beta)
     end
 end
 @inline function mul!(C::AbstractMatrix, transA::Transpose{<:Any,<:AbstractVecOrMat}, B::AbstractVecOrMat,
@@ -322,19 +317,19 @@ end
 end
 
 @inline function mul!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, transB::Transpose{<:Any,<:StridedVecOrMat{T}},
-                 alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat}
+                 alpha::Number, beta::Number) where {T<:BlasFloat}
     B = transB.parent
     if A===B
-        return syrk_wrapper!(C, 'N', A, MulAddMul(alpha, beta))
+        return syrk_wrapper!(C, 'N', A, alpha, beta)
     else
-        return gemm_wrapper!(C, 'N', 'T', A, B, MulAddMul(alpha, beta))
+        return gemm_wrapper!(C, 'N', 'T', A, B, alpha, beta)
     end
 end
 # Complex matrix times transposed real matrix. Reinterpret the first matrix to real for efficiency.
 for elty in (Float32,Float64)
     @eval begin
         @inline function mul!(C::StridedMatrix{Complex{$elty}}, A::StridedVecOrMat{Complex{$elty}}, transB::Transpose{<:Any,<:StridedVecOrMat{$elty}},
-                         alpha::Union{$elty, Bool}, beta::Union{$elty, Bool})
+                         alpha::Number, beta::Number)
             Afl = reinterpret($elty, A)
             Cfl = reinterpret($elty, C)
             mul!(Cfl, Afl, transB, alpha, beta)
@@ -354,7 +349,7 @@ end
                  alpha::Number, beta::Number) where {T<:BlasFloat}
     A = transA.parent
     B = transB.parent
-    return gemm_wrapper!(C, 'T', 'T', A, B, MulAddMul(alpha, beta))
+    return gemm_wrapper!(C, 'T', 'T', A, B, alpha, beta)
 end
 @inline function mul!(C::AbstractMatrix, transA::Transpose{<:Any,<:AbstractVecOrMat}, transB::Transpose{<:Any,<:AbstractVecOrMat},
                  alpha::Number, beta::Number)
@@ -364,10 +359,10 @@ end
 end
 
 @inline function mul!(C::StridedMatrix{T}, transA::Transpose{<:Any,<:StridedVecOrMat{T}}, transB::Adjoint{<:Any,<:StridedVecOrMat{T}},
-                 alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat}
+                 alpha::Number, beta::Number) where {T<:BlasFloat}
     A = transA.parent
     B = transB.parent
-    return gemm_wrapper!(C, 'T', 'C', A, B, MulAddMul(alpha, beta))
+    return gemm_wrapper!(C, 'T', 'C', A, B, alpha, beta)
 end
 @inline function mul!(C::AbstractMatrix, transA::Transpose{<:Any,<:AbstractVecOrMat}, transB::Adjoint{<:Any,<:AbstractVecOrMat},
                  alpha::Number, beta::Number)
@@ -377,17 +372,17 @@ end
 end
 
 @inline function mul!(C::StridedMatrix{T}, adjA::Adjoint{<:Any,<:StridedVecOrMat{T}}, B::StridedVecOrMat{T},
-                 alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasReal}
+                 alpha::Real, beta::Real) where {T<:BlasReal}
     A = adjA.parent
     return mul!(C, transpose(A), B, alpha, beta)
 end
 @inline function mul!(C::StridedMatrix{T}, adjA::Adjoint{<:Any,<:StridedVecOrMat{T}}, B::StridedVecOrMat{T},
-                 alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasComplex}
+                 alpha::Number, beta::Number) where {T<:BlasComplex}
     A = adjA.parent
     if A===B
-        return herk_wrapper!(C, 'C', A, MulAddMul(alpha, beta))
+        return herk_wrapper!(C, 'C', A, alpha, beta)
     else
-        return gemm_wrapper!(C, 'C', 'N', A, B, MulAddMul(alpha, beta))
+        return gemm_wrapper!(C, 'C', 'N', A, B, alpha, beta)
     end
 end
 @inline function mul!(C::AbstractMatrix, adjA::Adjoint{<:Any,<:AbstractVecOrMat}, B::AbstractVecOrMat,
@@ -402,12 +397,12 @@ end
     return mul!(C, A, transpose(B), alpha, beta)
 end
 @inline function mul!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, adjB::Adjoint{<:Any,<:StridedVecOrMat{T}},
-                 alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasComplex}
+                 alpha::Number, beta::Number) where {T<:BlasComplex}
     B = adjB.parent
     if A === B
-        return herk_wrapper!(C, 'N', A, MulAddMul(alpha, beta))
+        return herk_wrapper!(C, 'N', A, alpha, beta)
     else
-        return gemm_wrapper!(C, 'N', 'C', A, B, MulAddMul(alpha, beta))
+        return gemm_wrapper!(C, 'N', 'C', A, B, alpha, beta)
     end
 end
 @inline function mul!(C::AbstractMatrix, A::AbstractVecOrMat, adjB::Adjoint{<:Any,<:AbstractVecOrMat},
@@ -417,10 +412,10 @@ end
 end
 
 @inline function mul!(C::StridedMatrix{T}, adjA::Adjoint{<:Any,<:StridedVecOrMat{T}}, adjB::Adjoint{<:Any,<:StridedVecOrMat{T}},
-                 alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat}
+                 alpha::Number, beta::Number) where {T<:BlasFloat}
     A = adjA.parent
     B = adjB.parent
-    return gemm_wrapper!(C, 'C', 'C', A, B, MulAddMul(alpha, beta))
+    return gemm_wrapper!(C, 'C', 'C', A, B, alpha, beta)
 end
 @inline function mul!(C::AbstractMatrix, adjA::Adjoint{<:Any,<:AbstractVecOrMat}, adjB::Adjoint{<:Any,<:AbstractVecOrMat},
                  alpha::Number, beta::Number)
@@ -454,8 +449,11 @@ end
     A
 end
 
+promote_unless_bool(α::Number, ::Type{T}) where {T<:Number} = first(promote(α, zero(T)))
+promote_unless_bool(α::Bool, ::Type) = α
+
 function gemv!(y::StridedVector{T}, tA::AbstractChar, A::StridedVecOrMat{T}, x::StridedVector{T},
-               alpha::Union{T, Bool} = true, beta::Union{T, Bool} = false) where T<:BlasFloat
+               α::Number=true, β::Number=false) where {T<:BlasFloat}
     mA, nA = lapack_size(tA, A)
     if nA != length(x)
         throw(DimensionMismatch("second dimension of A, $nA, does not match length of x, $(length(x))"))
@@ -467,16 +465,19 @@ function gemv!(y::StridedVector{T}, tA::AbstractChar, A::StridedVecOrMat{T}, x::
         return y
     end
     if nA == 0
-        return _rmul_or_fill!(y, beta)
+        return _rmul_or_fill!(y, β)
     end
-    if stride(A, 1) == 1 && stride(A, 2) >= size(A, 1)
+    alpha = promote_unless_bool(α, T)
+    beta = promote_unless_bool(β, T)
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T} && stride(A, 1) == 1 && stride(A, 2) >= size(A, 1)
         return BLAS.gemv!(tA, alpha, A, x, beta, y)
+    else
+        return generic_matvecmul!(y, tA, A, x, MulAddMul(α, β))
     end
-    return generic_matvecmul!(y, tA, A, x, MulAddMul(alpha, beta))
 end
 
 function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat{T},
-                       _add::MulAddMul = MulAddMul()) where T<:BlasFloat
+                       α::Number=true, β::Number=false) where {T<:BlasFloat}
     nC = checksquare(C)
     if tA == 'T'
         (nA, mA) = size(A,1), size(A,2)
@@ -488,24 +489,30 @@ function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat
     if nC != mA
         throw(DimensionMismatch("output matrix has size: $(nC), but should have size $(mA)"))
     end
-    if mA == 0 || nA == 0 || iszero(_add.alpha)
-        return _rmul_or_fill!(C, _add.beta)
+    if mA == 0 || nA == 0 || iszero(α)
+        return _rmul_or_fill!(C, β)
     end
     if mA == 2 && nA == 2
-        return matmul2x2!(C, tA, tAt, A, A, _add)
+        return matmul2x2!(C, tA, tAt, A, A, MulAddMul(α, β))
     end
     if mA == 3 && nA == 3
-        return matmul3x3!(C, tA, tAt, A, A, _add)
+        return matmul3x3!(C, tA, tAt, A, A, MulAddMul(α, β))
     end
 
-    if stride(A, 1) == stride(C, 1) == 1 && stride(A, 2) >= size(A, 1) && stride(C, 2) >= size(C, 1)
-        return copytri!(BLAS.syrk!('U', tA, _add.alpha, A, _add.beta, C), 'U')
+    alpha = promote_unless_bool(α, T)
+    beta = promote_unless_bool(β, T)
+    if (alpha isa Union{Bool,T} &&
+        beta isa Union{Bool,T} &&
+        stride(A, 1) == stride(C, 1) == 1 &&
+        stride(A, 2) >= size(A, 1) &&
+        stride(C, 2) >= size(C, 1))
+        return copytri!(BLAS.syrk!('U', tA, alpha, A, beta, C), 'U')
     end
-    return generic_matmatmul!(C, tA, tAt, A, A, _add)
+    return generic_matmatmul!(C, tA, tAt, A, A, MulAddMul(α, β))
 end
 
 function herk_wrapper!(C::Union{StridedMatrix{T}, StridedMatrix{Complex{T}}}, tA::AbstractChar, A::Union{StridedVecOrMat{T}, StridedVecOrMat{Complex{T}}},
-                       _add::MulAddMul = MulAddMul()) where T<:BlasReal
+                       α::Number=true, β::Number=false) where {T<:BlasReal}
     nC = checksquare(C)
     if tA == 'C'
         (nA, mA) = size(A,1), size(A,2)
@@ -518,27 +525,33 @@ function herk_wrapper!(C::Union{StridedMatrix{T}, StridedMatrix{Complex{T}}}, tA
         throw(DimensionMismatch("output matrix has size: $(nC), but should have size $(mA)"))
     end
     if mA == 0 || nA == 0
-        return _rmul_or_fill!(C, _add.beta)
+        return _rmul_or_fill!(C, β)
     end
     if mA == 2 && nA == 2
-        return matmul2x2!(C, tA, tAt, A, A, _add)
+        return matmul2x2!(C, tA, tAt, A, A, MulAddMul(α, β))
     end
     if mA == 3 && nA == 3
-        return matmul3x3!(C, tA, tAt, A, A, _add)
+        return matmul3x3!(C, tA, tAt, A, A, MulAddMul(α, β))
     end
 
     # Result array does not need to be initialized as long as beta==0
     #    C = Matrix{T}(undef, mA, mA)
 
-    if stride(A, 1) == stride(C, 1) == 1 && stride(A, 2) >= size(A, 1) && stride(C, 2) >= size(C, 1)
-        return copytri!(BLAS.herk!('U', tA, _add.alpha, A, _add.beta, C), 'U', true)
+    alpha = promote_unless_bool(α, T)
+    beta = promote_unless_bool(β, T)
+    if (alpha isa Union{Bool,T} &&
+        beta isa Union{Bool,T} &&
+        stride(A, 1) == stride(C, 1) == 1 &&
+        stride(A, 2) >= size(A, 1) &&
+        stride(C, 2) >= size(C, 1))
+        return copytri!(BLAS.herk!('U', tA, alpha, A, beta, C), 'U', true)
     end
-    return generic_matmatmul!(C, tA, tAt, A, A, _add)
+    return generic_matmatmul!(C, tA, tAt, A, A, MulAddMul(α, β))
 end
 
 function gemm_wrapper(tA::AbstractChar, tB::AbstractChar,
                       A::StridedVecOrMat{T},
-                      B::StridedVecOrMat{T}) where T<:BlasFloat
+                      B::StridedVecOrMat{T}) where {T<:BlasFloat}
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
     C = similar(B, T, mA, nB)
@@ -547,7 +560,7 @@ end
 
 function gemm_wrapper!(C::StridedVecOrMat{T}, tA::AbstractChar, tB::AbstractChar,
                        A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
-                       _add::MulAddMul = MulAddMul()) where T<:BlasFloat
+                       α::Number=true, β::Number=false) where {T<:BlasFloat}
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
 
@@ -559,24 +572,31 @@ function gemm_wrapper!(C::StridedVecOrMat{T}, tA::AbstractChar, tB::AbstractChar
         throw(ArgumentError("output matrix must not be aliased with input matrix"))
     end
 
-    if mA == 0 || nA == 0 || nB == 0 || iszero(_add.alpha)
+    if mA == 0 || nA == 0 || nB == 0 || iszero(α)
         if size(C) != (mA, nB)
             throw(DimensionMismatch("C has dimensions $(size(C)), should have ($mA,$nB)"))
         end
-        return _rmul_or_fill!(C, _add.beta)
+        return _rmul_or_fill!(C, β)
     end
 
     if mA == 2 && nA == 2 && nB == 2
-        return matmul2x2!(C, tA, tB, A, B, _add)
+        return matmul2x2!(C, tA, tB, A, B, MulAddMul(α, β))
     end
     if mA == 3 && nA == 3 && nB == 3
-        return matmul3x3!(C, tA, tB, A, B, _add)
+        return matmul3x3!(C, tA, tB, A, B, MulAddMul(α, β))
     end
 
-    if stride(A, 1) == stride(B, 1) == stride(C, 1) == 1 && stride(A, 2) >= size(A, 1) && stride(B, 2) >= size(B, 1) && stride(C, 2) >= size(C, 1)
-        return BLAS.gemm!(tA, tB, _add.alpha, A, B, _add.beta, C)
+    alpha = promote_unless_bool(α, T)
+    beta = promote_unless_bool(β, T)
+    if (alpha isa Union{Bool,T} &&
+        beta isa Union{Bool,T} &&
+        stride(A, 1) == stride(B, 1) == stride(C, 1) == 1 &&
+        stride(A, 2) >= size(A, 1) &&
+        stride(B, 2) >= size(B, 1) &&
+        stride(C, 2) >= size(C, 1))
+        return BLAS.gemm!(tA, tB, alpha, A, B, beta, C)
     end
-    generic_matmatmul!(C, tA, tB, A, B, _add)
+    generic_matmatmul!(C, tA, tB, A, B, MulAddMul(α, β))
 end
 
 # blas.jl defines matmul for floats; other integer and mixed precision
@@ -687,7 +707,7 @@ const Bbuf = [Vector{UInt8}(undef, tilebufsize)]
 const Cbuf = [Vector{UInt8}(undef, tilebufsize)]
 
 function generic_matmatmul!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
-                            _add::MulAddMul = MulAddMul())
+                            _add::MulAddMul=MulAddMul())
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
     mC, nC = size(C)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -450,7 +450,7 @@ end
 end
 
 promote_unless_bool(α::Number, ::Type{T}) where {T<:Number} = first(promote(α, zero(T)))
-promote_unless_bool(α::Bool, ::Type) = α
+promote_unless_bool(α::Bool, ::Type{T}) where {T<:Number} = α
 
 function gemv!(y::StridedVector{T}, tA::AbstractChar, A::StridedVecOrMat{T}, x::StridedVector{T},
                α::Number=true, β::Number=false) where {T<:BlasFloat}

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -542,8 +542,8 @@ end
         return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
     end
 end
-@inline mul!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix},
-             α::Number, β::Number) where {T<:BlasComplex} =
+@inline function mul!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix},
+             α::Number, β::Number) where {T<:BlasComplex}
     alpha, beta = promote(α, β, zero(T))
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
         return BLAS.hemm!('R', B.uplo, alpha, B.data, A, beta, C)

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -469,34 +469,88 @@ for f in (:+, :-)
 end
 
 ## Matvec
-@inline mul!(y::StridedVector{T}, A::Symmetric{T,<:StridedMatrix}, x::StridedVector{T},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat} =
-    BLAS.symv!(A.uplo, alpha, A.data, x, beta, y)
-@inline mul!(y::StridedVector{T}, A::Hermitian{T,<:StridedMatrix}, x::StridedVector{T},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasReal} =
-    BLAS.symv!(A.uplo, alpha, A.data, x, beta, y)
-@inline mul!(y::StridedVector{T}, A::Hermitian{T,<:StridedMatrix}, x::StridedVector{T},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasComplex} =
-    BLAS.hemv!(A.uplo, alpha, A.data, x, beta, y)
+@inline function mul!(y::StridedVector{T}, A::Symmetric{T,<:StridedMatrix}, x::StridedVector{T},
+             α::Number, β::Number) where {T<:BlasFloat}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.symv!(A.uplo, alpha, A.data, x, beta, y)
+    else
+        return generic_matvecmul!(y, 'N', A, x, MulAddMul(α, β))
+    end
+end
+@inline function mul!(y::StridedVector{T}, A::Hermitian{T,<:StridedMatrix}, x::StridedVector{T},
+             α::Number, β::Number) where {T<:BlasReal}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.symv!(A.uplo, alpha, A.data, x, beta, y)
+    else
+        return generic_matvecmul!(y, 'N', A, x, MulAddMul(α, β))
+    end
+end
+@inline function mul!(y::StridedVector{T}, A::Hermitian{T,<:StridedMatrix}, x::StridedVector{T},
+             α::Number, β::Number) where {T<:BlasComplex}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.hemv!(A.uplo, alpha, A.data, x, beta, y)
+    else
+        return generic_matvecmul!(y, 'N', A, x, MulAddMul(α, β))
+    end
+end
 ## Matmat
-@inline mul!(C::StridedMatrix{T}, A::Symmetric{T,<:StridedMatrix}, B::StridedMatrix{T},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat} =
-    BLAS.symm!('L', A.uplo, alpha, A.data, B, beta, C)
-@inline mul!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Symmetric{T,<:StridedMatrix},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasFloat} =
-    BLAS.symm!('R', B.uplo, alpha, B.data, A, beta, C)
-@inline mul!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{T},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasReal} =
-    BLAS.symm!('L', A.uplo, alpha, A.data, B, beta, C)
+@inline function mul!(C::StridedMatrix{T}, A::Symmetric{T,<:StridedMatrix}, B::StridedMatrix{T},
+             α::Number, β::Number) where {T<:BlasFloat}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.symm!('L', A.uplo, alpha, A.data, B, beta, C)
+    else
+        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
+    end
+end
+@inline function mul!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Symmetric{T,<:StridedMatrix},
+             α::Number, β::Number) where {T<:BlasFloat}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.symm!('R', B.uplo, alpha, B.data, A, beta, C)
+    else
+        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
+    end
+end
+@inline function mul!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{T},
+             α::Number, β::Number) where {T<:BlasReal}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.symm!('L', A.uplo, alpha, A.data, B, beta, C)
+    else
+        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
+    end
+end
+@inline function mul!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix},
+             α::Number, β::Number) where {T<:BlasReal}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.symm!('R', B.uplo, alpha, B.data, A, beta, C)
+    else
+        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
+    end
+end
+@inline function mul!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{T},
+             α::Number, β::Number) where {T<:BlasComplex}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.hemm!('L', A.uplo, alpha, A.data, B, beta, C)
+    else
+        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
+    end
+end
 @inline mul!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasReal} =
-    BLAS.symm!('R', B.uplo, alpha, B.data, A, beta, C)
-@inline mul!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{T},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasComplex} =
-    BLAS.hemm!('L', A.uplo, alpha, A.data, B, beta, C)
-@inline mul!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix},
-             alpha::Union{T, Bool}, beta::Union{T, Bool}) where {T<:BlasComplex} =
-    BLAS.hemm!('R', B.uplo, alpha, B.data, A, beta, C)
+             α::Number, β::Number) where {T<:BlasComplex} =
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return BLAS.hemm!('R', B.uplo, alpha, B.data, A, beta, C)
+    else
+        return generic_matmatmul!(C, 'N', 'N', A, B, MulAddMul(alpha, beta))
+    end
+end
 
 *(A::HermOrSym, B::HermOrSym) = A * copyto!(similar(parent(B)), B)
 


### PR DESCRIPTION
This addresses an issue raised in https://github.com/JuliaLang/julia/pull/29634#issuecomment-547922743, by applying the methodology of JuliaLang/julia#33229 to the entire `matmul.jl`, (edit: and fixes an issue in the `syrk_wrapper!`). ~~One drawback, just as in JuliaLang/julia#33229, is that also `Bool` parameters are promoted to the numeric type of the matrices, which is unnecessary for `BLAS.gemv!` and `BLAS.gemm!`. We can think about how to work around that, perhaps by working on the types only and introduce some more `if` branches, but I guess avoiding the generic fallback in some more cases is already a significant improvement.~~