### PR TITLE
[WIP] allow sorting Dict/Set values in show

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -79,11 +79,21 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
     if !haskey(io, :compact)
         recur_io = IOContext(recur_io, :compact => true)
     end
+    sorted = get(io, :sorted, false)
 
     summary(io, t)
     isempty(t) && return
     print(io, ":")
     show_circular(io, t) && return
+
+    if sorted
+        try # sorting fails when elements are not comparable, collect can fail too
+            t = sort!(collect(t))
+        catch
+            sorted = false
+        end
+    end
+
     if limit
         sz = displaysize(io)
         rows, cols = sz[1] - 3, sz[2]


### PR DESCRIPTION
It can clearly be convenient to have a dict or set printed in sorted order, but doing so by default would give the wrong idea about the order of iteration. Cf. e.g. #7153 for some discussion. But wouldn't it be great to have an opt-in way? With this PR together with #29249, you can!
```julia
julia> Base.active_repl.options.iocontext[:sorted] = true;

julia> Dict(i => i^2 for i=1:10)
Dict{Int64,Int64} with 10 entries:
  1  => 1
  2  => 4
  3  => 9
  4  => 16
  5  => 25
  6  => 36
  7  => 49
  8  => 64
  9  => 81
  10 => 100
```
Needs to be updated for other `show` methods, and for `Set`, but I wanted to check first whether this has a chance before putting more work.