### PR TITLE
REPL: implement "insert last word from previous history entry"

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -174,6 +174,7 @@ to do so), or pressing Esc and then the key.
 | `^Q`                | Write a number in REPL and press `^Q` to open editor at corresponding stackframe or method                 |
 | `meta-Left Arrow`   | indent the current line on the left                                                                        |
 | `meta-Right Arrow`  | indent the current line on the right                                                                       |
+| `meta-.`            | insert last word from previous history entry                                                               |
 
 
 ### Customizing keybindings

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1942,6 +1942,25 @@ function move_line_end(buf::IOBuffer)
     nothing
 end
 
+edit_insert_last_word(s::MIState) =
+    edit_insert(s, get_last_word(IOBuffer(mode(s).hist.history[end])))
+
+function get_last_word(buf::IOBuffer)
+    move_line_end(buf)
+    char_move_word_left(buf)
+    posbeg = position(buf)
+    char_move_word_right(buf)
+    posend = position(buf)
+    buf = take!(buf)
+    word = String(buf[posbeg+1:posend])
+    rest = String(buf[posend+1:end])
+    lp, rp, lb, rb = count.(.==(('(', ')', '[', ']')), rest)
+    special = any(in.(('\'', '"', '`'), rest))
+    !special && lp == rp && lb == rb ?
+        word *= rest :
+        word
+end
+
 function commit_line(s)
     cancel_beep(s)
     move_input_end(s)
@@ -2080,6 +2099,7 @@ AnyDict(
     "\eOc" => "\ef",
     # Meta Enter
     "\e\r" => (s,o...)->edit_insert_newline(s),
+    "\e." =>  (s,o...)->edit_insert_last_word(s),
     "\e\n" => "\e\r",
     "^_" => (s,o...)->edit_undo!(s),
     "\e_" => (s,o...)->edit_redo!(s),

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -878,5 +878,20 @@ end
     buf.mark = 0
     seek(buf, 1)
     @test transform!(transpose_lines_down_reg!, buf) == ("l2\nl3\nl1", 4, 3)
+end
 
+@testset "edit_insert_last_word" begin
+    get_last_word(str::String) = LineEdit.get_last_word(IOBuffer(str))
+    @test get_last_word("1+2") == "2"
+    @test get_last_word("1+23") == "23"
+    @test get_last_word("1+2") == "2"
+    @test get_last_word(""" "a" * "b" """) == "b"
+    @test get_last_word(""" "a" * 'b' """) == "b"
+    @test get_last_word(""" "a" * `b` """) == "b"
+    @test get_last_word("g()") == "g()"
+    @test get_last_word("g(1, 2)") == "2"
+    @test get_last_word("g(1, f())") == "f"
+    @test get_last_word("a[1]") == "1"
+    @test get_last_word("a[b[]]") == "b"
+    @test get_last_word("a[]") == "a[]"
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -415,6 +415,11 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         s = LineEdit.init_state(repl.t, repl.interface)
         LineEdit.edit_insert(s, "wip")
 
+        # LineEdit functions related to history
+        LineEdit.edit_insert_last_word(s)
+        @test buffercontents(LineEdit.buffer(s)) == "wip2"
+        LineEdit.edit_backspace(s) # remove the "2"
+
         # Test that navigating history skips invalid modes
         # (in both directions)
         LineEdit.history_prev(s, hp)


### PR DESCRIPTION
Bind this shell-like feature to the usual "meta-.".

For example, if the previous input was `julia> 1 + 2`, then <Alt-.> (or <meta-.>) will insert `2` in the current input.

It's not necessary clear what the "last word" should mean. I think that in shells this command considers space-separated words, and also IPython. But the problem is that if the last input is e.g. `f(a, b)`, then the last word is `b)`, which is not very useful. So here I use a slightly different heuristic: go to the end of line, then one word backward (position reaches "before b"), then one word forward (position is between "b" and ")"). Call `word` what we have jumped around till now (`b`) and `rest` what is between current position and the en of line (`)`). If `rest` contains a balanced number of parenthesis and brackets, and doesn't contain special characters (``` ` ```, `"`, `'` for now), then return `word * rest`, otherwise `word`. In this example, this would return `b`, and with `1+f()` it would return `f()`. 

But most of the time when I try to reach out to this shortcut, it's for simple things which are unambiguous, like when I do for example `pkg> up MyPackage` and then `pkg> st <Alt-.>`, or `using <Alt-.>`, where `<Alt-.>` would insert `MyPackage`. Or for example `using Random` followed by `<M-.>.seed!()`.

This implements the last missing feature from #8447.