### PR TITLE
Fix non-uniformity in nothrow queries with PartialTypeVar

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -997,7 +997,7 @@ function apply_type_nothrow(argtypes::Array{Any, 1}, @nospecialize(rt))
     for i = 2:length(argtypes)
         isa(u, UnionAll) || return false
         ai = widenconditional(argtypes[i])
-        if ai === TypeVar
+        if ai ⊑ TypeVar
             # We don't know anything about the bounds of this typevar, but as
             # long as the UnionAll is not constrained, that's ok.
             if !(u.var.lb === Union{} && u.var.ub === Any)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -168,6 +168,8 @@ function ⊑(@nospecialize(a), @nospecialize(b))
             return a.instance === b.val
         end
         return false
+    elseif isa(a, PartialTypeVar) && b === TypeVar
+        return true
     elseif !(isa(a, Type) || isa(a, TypeVar)) ||
            !(isa(b, Type) || isa(b, TypeVar))
         return a === b

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2456,3 +2456,11 @@ const DenseIdx = Union{IntRange,Integer}
 @inline foo_26724(result, r::IntRange, I::DenseIdx...) =
     foo_26724((result..., length(r)), I...)
 @test @inferred(foo_26724((), 1:4, 1:5, 1:6)) === (4, 5, 6)
+
+# Non uniformity in expresions with PartialTypeVar
+@test Core.Compiler.:⊑(Core.Compiler.PartialTypeVar(TypeVar(:N), true, true), TypeVar)
+let N = TypeVar(:N)
+    @test Core.Compiler.apply_type_nothrow([Core.Compiler.Const(NTuple),
+        Core.Compiler.PartialTypeVar(N, true, true),
+        Core.Compiler.Const(Any)], Type{Tuple{Vararg{Any,N}}})
+end


### PR DESCRIPTION
We were missing a case in the lattice operation for
⊑(::PartialTypeVar, ::Type{TypeVar}) causing non-uniformity for
various nothrow queries. Additionally `apply_type_nothrow` was
using `===` rather than `⊑`, causing additional problems there
even after the fix.