### PR TITLE
fix dead-lock in WeakKeyDict

### DIFF
--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -6,7 +6,7 @@
     WeakKeyDict([itr])
 
 `WeakKeyDict()` constructs a hash table where the keys are weak
-references to objects, and thus may be garbage collected even when
+references to objects which may be garbage collected even when
 referenced in a hash table.
 
 See [`Dict`](@ref) for further help.  Note, unlike [`Dict`](@ref),

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -126,7 +126,11 @@ end
 function iterate(t::WeakKeyDict{K,V}, state) where V where K
     gc_token = first(state)
     y = iterate(t.ht, tail(state)...)
-    y === nothing && return nothing
+    if y === nothing
+        gc_token[] = true
+        finalize(gc_token)
+        return nothing
+    end
     wkv, i = y
     kv = Pair{K,V}(wkv[1].value::K, wkv[2])
     return (kv, (gc_token, i))


### PR DESCRIPTION
In Julia version v1.3.0-rc4 and v1.4.0-DEV.427 the following commands give a dead-lock:

    x = WeakKeyDict(:a => 4)
    push!(x, :b => 2)

It is caused by a `lock` in `iterate(t::WeakKeyDict{K,V}) ..` where the finalizer with `unlock` never gets called. The WeakKeyDict normally uses another task than the REPL; now when the terminal prints the wkd object, it uses the REPL task for the iterate! method and doesn't unlock it. Next time the WeakKeyDict does something, the object lock is 'locked_by' another task and the dict has to wait  (forever...).

I'm not sure about my fix. I supposed that the iterate! methods should be protected but I don't understand the 'no keys will be deleted' remark. Please review. I would have a branch with nicely formatted log messages upon interest. Also I can add tests when it is clear how the fix will look like.