### PR TITLE
REPL: allow editing current input in editor (via Meta-e)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,9 @@ Standard library changes
 
 #### REPL
 
+* `Meta-e` now opens the current input in an editor. The content (if modified) will be
+  executed upon existing the editor.
+
 #### SparseArrays
 
 #### Dates

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -270,9 +270,10 @@ to do so), or pressing Esc and then the key.
 | `meta-l`            | Change the next word to lowercase                                                                          |
 | `^/`, `^_`          | Undo previous editing action                                                                               |
 | `^Q`                | Write a number in REPL and press `^Q` to open editor at corresponding stackframe or method                 |
-| `meta-Left Arrow`   | indent the current line on the left                                                                        |
-| `meta-Right Arrow`  | indent the current line on the right                                                                       |
-| `meta-.`            | insert last word from previous history entry                                                               |
+| `meta-Left Arrow`   | Indent the current line on the left                                                                        |
+| `meta-Right Arrow`  | Indent the current line on the right                                                                       |
+| `meta-.`            | Insert last word from previous history entry                                                               |
+| `meta-e`            | Edit the current input in an editor                                                                        |
 
 ### Customizing keybindings
 

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1314,7 +1314,7 @@ function guess_current_mode_name(s)
 end
 
 # edit current input in editor
-function edit_input(s)
+function edit_input(s, f = (filename, line) -> InteractiveUtils.edit(filename, line))
     mode_name = guess_current_mode_name(s)
     filename = tempname()
     if mode_name == :julia
@@ -1327,7 +1327,7 @@ function edit_input(s)
     str = String(take!(buf))
     line = 1 + count(==(_newline), view(str, 1:pos))
     write(filename, str)
-    InteractiveUtils.edit(filename, line)
+    f(filename, line)
     str_mod = readchomp(filename)
     rm(filename)
     if str != str_mod # something was changed, run the input

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -59,7 +59,8 @@ import ..LineEdit:
     terminal,
     MIState,
     PromptState,
-    TextInterface
+    TextInterface,
+    mode_idx
 
 include("REPLCompletions.jl")
 using .REPLCompletions
@@ -599,14 +600,6 @@ function hist_from_file(hp::REPLHistoryProvider, path::String)
     end
     hp.start_idx = length(hp.history)
     return hp
-end
-
-function mode_idx(hist::REPLHistoryProvider, mode::TextInterface)
-    c = :julia
-    for (k,v) in hist.mode_mapping
-        isequal(v, mode) && (c = k)
-    end
-    return c
 end
 
 function add_history(hist::REPLHistoryProvider, s::PromptState)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1499,3 +1499,18 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         @test buffercontents(LineEdit.buffer(s)) == "xyz = 2"
     end
 end
+
+fake_repl() do stdin_write, stdout_read, repl
+    repltask = @async begin
+        REPL.run_repl(repl)
+    end
+    repl.interface = REPL.setup_interface(repl)
+    s = LineEdit.init_state(repl.t, repl.interface)
+    LineEdit.edit_insert(s, "1234")
+    @show buffercontents(LineEdit.buffer(s))
+    input_f = function(filename, line)
+        write(filename, "123456\n")
+    end
+    LineEdit.edit_input(s, input_f)
+    @test buffercontents(LineEdit.buffer(s)) == "123456"
+end


### PR DESCRIPTION
The REPL editing features are decent, but as the multi-line input grows, it can be convenient to quicly jump to your favorite editor... let's make this feature available trough Meta-e. 

In the current state, we open a temporary file with the REPL's current input, call `edit()` on this file, and then load the REPL input buffer with its new content. If the file has been modified, we execute directly the code, otherwise we assume that the user changed her mind and we restore the input buffer as it was before the call to `edit()`. Suggestions welcome for this particular behavior (*).

It's easy to try this feature out without having to recompile Julia, by putting the three new functions in your startup.jl file, together with
```julia
import REPL, InteractiveUtils
using REPL.LineEdit: buffer, _newline, refresh_line, commit_line
```
And adding the keybinding, e.g.
```julia
atreplinit() do repl
    repl.options =
        REPL.Options(extra_keymap =
                     Dict("\ee" => (s,o...) -> edit_input(s)))
end
```

(*) This is currently implemented with a call to `ctime`, but might be more safe by comparing the content of the buffers before/after. For some reason, there is a little bug: if the first time the feature is used, the file is not updated, the input is still executed; but this doesn't happen when I put the new functions in my startup.jl file and run master (as described above).