### PR TITLE
edit(): allow specifying the column for some editors

### DIFF
--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1506,11 +1506,10 @@ fake_repl() do stdin_write, stdout_read, repl
     end
     repl.interface = REPL.setup_interface(repl)
     s = LineEdit.init_state(repl.t, repl.interface)
-    LineEdit.edit_insert(s, "1234")
-    @show buffercontents(LineEdit.buffer(s))
-    input_f = function(filename, line)
-        write(filename, "123456\n")
+    LineEdit.edit_insert(s, "1234αβ")
+    input_f = function(filename, line, column)
+        write(filename, "1234αβ56γ\n")
     end
     LineEdit.edit_input(s, input_f)
-    @test buffercontents(LineEdit.buffer(s)) == "123456"
+    @test buffercontents(LineEdit.buffer(s)) == "1234αβ56γ"
 end


### PR DESCRIPTION
This will be useful for #33759 if that gets included. For this use case, it would not be useful to print a warning if the editor can't be opened at a specifed column, so I didn't add a `column_unsupported` variable similar to `line_unsupported`. Alternatively, a keyword could be passed to specify whether we want a warning in these cases.