### PR TITLE
REPL: fix bug when all the input buffer can't be printed

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -405,8 +405,15 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
     while moreinput
         line = readline(buf, keep=true)
         moreinput = endswith(line, "\n")
+        if rows == 1 && line_pos <= sizeof(line) - moreinput
+            # we special case rows == 1, as otherwise by the time the cursor is seen to
+            # be in the current line, it's too late to chop the '\n' away
+            lastline = true
+            curs_row = 1
+            curs_pos = lindent + line_pos
+        end
         if moreinput && lastline # we want to print only one "visual" line, so
-            line = line[1:end-1] # don't include the trailing "\n"
+            line = chomp(line)   # don't include the trailing "\n"
         end
         # We need to deal with on-screen characters, so use textwidth to compute occupied columns
         llength = textwidth(line)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -375,11 +375,13 @@ refresh_multi_line(s::ModeState; kw...) = refresh_multi_line(terminal(s), s; kw.
 refresh_multi_line(termbuf::TerminalBuffer, s::ModeState; kw...) = refresh_multi_line(termbuf, terminal(s), s; kw...)
 refresh_multi_line(termbuf::TerminalBuffer, term, s::ModeState; kw...) = (@assert term == terminal(s); refresh_multi_line(termbuf,s; kw...))
 
-function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf::IOBuffer, state::InputAreaState, prompt = "";
+function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf::IOBuffer,
+                            state::InputAreaState, prompt = "";
                             indent = 0, region_active = false)
     _clear_input_area(termbuf, state)
 
     cols = width(terminal)
+    rows = height(terminal)
     curs_row = -1 # relative to prompt (1-based)
     curs_pos = -1 # 1-based column position of the cursor
     cur_row = 0   # count of the number of rows
@@ -395,16 +397,24 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
     # Now go through the buffer line by line
     seek(buf, 0)
     moreinput = true # add a blank line if there is a trailing newline on the last line
+    lastline = false # indicates when to stop printing lines, even when there are potentially
+                     # more (for the case where rows is too small to print everything)
+                     # Note: when there are too many lines for rows, we still print the first lines
+                     # even if they are going to not be visible in the end: for simplicity, but
+                     # also because it does the 'right thing' when the window is resized
     while moreinput
-        l = readline(buf, keep=true)
-        moreinput = endswith(l, "\n")
+        line = readline(buf, keep=true)
+        moreinput = endswith(line, "\n")
+        if moreinput && lastline # we want to print only one "visual" line, so
+            line = line[1:end-1] # don't include the trailing "\n"
+        end
         # We need to deal with on-screen characters, so use textwidth to compute occupied columns
-        llength = textwidth(l)
-        slength = sizeof(l)
+        llength = textwidth(line)
+        slength = sizeof(line)
         cur_row += 1
         # lwrite: what will be written to termbuf
-        lwrite = region_active ? highlight_region(l, regstart, regstop, written, slength) :
-                                 l
+        lwrite = region_active ? highlight_region(line, regstart, regstop, written, slength) :
+                                 line
         written += slength
         cmove_col(termbuf, lindent + 1)
         write(termbuf, lwrite)
@@ -414,7 +424,9 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
             line_pos -= slength # '\n' gets an extra pos
             # in this case, we haven't yet written the cursor position
             if line_pos < 0 || !moreinput
-                num_chars = (line_pos >= 0 ? llength : textwidth(l[1:prevind(l, line_pos + slength + 1)]))
+                num_chars = line_pos >= 0 ?
+                                llength :
+                                textwidth(line[1:prevind(line, line_pos + slength + 1)])
                 curs_row, curs_pos = divrem(lindent + num_chars - 1, cols)
                 curs_row += cur_row
                 curs_pos += 1
@@ -434,6 +446,12 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
         end
         cur_row += div(max(lindent + llength + miscountnl - 1, 0), cols)
         lindent = indent < 0 ? lindent : indent
+
+        lastline && break
+        if curs_row >= 0 && cur_row + 1 >= rows &&             # when too many lines,
+                            cur_row - curs_row + 1 >= rows ÷ 2 # center the cursor
+            lastline = true
+        end
     end
     seek(buf, buf_pos)
 


### PR DESCRIPTION
When the input buffer contained too many lines, it was
still possible to edit it, but blindly for the n invisible
lines: indeed, the first n lines where never shown even
when the cursor was moved in their region.
Fix that, by centering the cursor in the available space
when all the lines can't be shown at the same time.
Other strategies are possible, some nicer, but this is
probably the simplest, by far, as it is "stateless": it
doesn't need to remember what happened during the last
refresh or to know what event triggered the refresh.

Fixes #24049.
This is an embarassingly simple 10 lines patch, when compared to the time it took me to come up with :sweat_smile: We could eventually improve the behavior, for example to implement what IPython does, i.e. don't change the visible region when the cursor movement doesn't force to unhide a line. But this would be a feature request rather than a long standing bug.