### PR TITLE
Casting low-rank CholeskyPivoted to Matrix

### DIFF
--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -396,7 +396,8 @@ Array(C::Cholesky) = Matrix(C)
 
 function AbstractMatrix(F::CholeskyPivoted)
     ip = invperm(F.p)
-    (F.L * F.U)[ip,ip]
+    U = F.U[1:F.rank,ip]
+    U'U
 end
 AbstractArray(F::CholeskyPivoted) = AbstractMatrix(F)
 Matrix(F::CholeskyPivoted) = Array(AbstractArray(F))

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -395,11 +395,10 @@ end
 @testset "issue #33704, casting low-rank CholeskyPivoted to Matrix" begin
     T = Float64
     n = 8
-    tol = 1e-8
     A = randn(T, (n,1))
     B = A*A'
-    C = cholesky(B, Val(true), tol = tol, check=false)
-    @test maximum(abs, B-Matrix(C)) < tol
+    C = cholesky(B, Val(true), check=false)
+    @test B ≈ Matrix(C)
 end
 
 end # module TestCholesky

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -392,4 +392,14 @@ end
 
 end
 
+@testset "issue #33704, casting low-rank CholeskyPivoted to Matrix" begin
+    T = Float64
+    n = 8
+    tol = 1e-8
+    A = randn(T, (n,1))
+    B = A*A'
+    C = cholesky(B, Val(true), tol = tol, check=false)
+    @test maximum(abs, B-Matrix(C)) < tol
+end
+
 end # module TestCholesky

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -393,10 +393,8 @@ end
 end
 
 @testset "issue #33704, casting low-rank CholeskyPivoted to Matrix" begin
-    T = Float64
-    n = 8
-    A = randn(T, (n,1))
-    B = A*A'
+    A = randn(1,8)
+    B = A'A
     C = cholesky(B, Val(true), check=false)
     @test B ≈ Matrix(C)
 end


### PR DESCRIPTION
I created and closed a pull request for this already, because I accidentally force pushed to my branch during the time the PR was open. I apologize for the duplicate. 

Fixes JuliaLang/LinearAlgebra.jl#680.