### PR TITLE
fix #33789, ambiguity with imprecise intersection

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1179,13 +1179,13 @@ static int check_ambiguous_visitor(jl_typemap_entry_t *oldentry, struct typemap_
         if (closure->after)
             reorder = 1;
     }
-    else if (jl_type_morespecific_no_subtype((jl_value_t*)type, (jl_value_t*)sig)) {
+    else if (jl_type_morespecific_no_subtype_with_intersection((jl_value_t*)type, (jl_value_t*)sig, isect)) {
         // new entry is more specific
         if (!closure->after)
             reorder = 1;
         shadowed = 1;
     }
-    else if (jl_type_morespecific_no_subtype((jl_value_t*)sig, (jl_value_t*)type)) {
+    else if (jl_type_morespecific_no_subtype_with_intersection((jl_value_t*)sig, (jl_value_t*)type, isect)) {
         // old entry is more specific
         if (closure->after)
             reorder = 1;
@@ -1336,7 +1336,7 @@ static int check_disabled_ambiguous_visitor(jl_typemap_entry_t *oldentry, struct
         if (jl_types_equal(type, isect2)) {
             jl_method_t *beforem = before->func.method;
             jl_method_t *afterm = oldentry->func.method;
-            int msp = jl_type_morespecific((jl_value_t*)sig, (jl_value_t*)before->sig);
+            int msp = jl_type_morespecific_with_intersection((jl_value_t*)sig, (jl_value_t*)before->sig, isect2);
             if (msp) {
                 if ((jl_value_t*)beforem->resorted == jl_nothing) {
                     beforem->resorted = (jl_value_t*)jl_alloc_vec_any(0);
@@ -1344,7 +1344,7 @@ static int check_disabled_ambiguous_visitor(jl_typemap_entry_t *oldentry, struct
                 }
                 jl_array_ptr_1d_push((jl_array_t*)beforem->resorted, (jl_value_t*)oldentry);
             }
-            else if (!jl_type_morespecific((jl_value_t*)before->sig, (jl_value_t*)sig)) {
+            else if (!jl_type_morespecific_with_intersection((jl_value_t*)before->sig, (jl_value_t*)sig, isect2)) {
                 if ((jl_value_t*)beforem->ambig == jl_nothing) {
                     beforem->ambig = (jl_value_t*)jl_alloc_vec_any(0);
                     jl_gc_wb(beforem, beforem->ambig);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -420,6 +420,8 @@ jl_value_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t **p
 int jl_subtype_matching(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
 // specificity comparison assuming !(a <: b) and !(b <: a)
 JL_DLLEXPORT int jl_type_morespecific_no_subtype(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT int jl_type_morespecific_with_intersection(jl_value_t *a, jl_value_t *b, jl_value_t *isect);
+JL_DLLEXPORT int jl_type_morespecific_no_subtype_with_intersection(jl_value_t *a, jl_value_t *b, jl_value_t *isect);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
 JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals);
 jl_value_t *jl_substitute_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val);

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -1074,8 +1074,7 @@ static void jl_typemap_list_insert_sorted(
         if (!l->isleafsig) { // quickly ignore all of the leafsig entries (these were handled by caller)
             if (jl_type_morespecific((jl_value_t*)newrec->sig, (jl_value_t*)l->sig)) {
                 if (l->simplesig == (void*)jl_nothing ||
-                    newrec->simplesig != (void*)jl_nothing ||
-                    !jl_types_equal((jl_value_t*)l->sig, (jl_value_t*)newrec->sig)) {
+                    newrec->simplesig != (void*)jl_nothing) {
                     // might need to insert multiple entries for a lookup differing only by their simplesig
                     // when simplesig contains a kind
                     // TODO: make this test more correct or figure out a better way to compute this

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -328,4 +328,9 @@ end
     @test Base.has_bottom_parameter(Ref{<:Union{}})
 end
 
+# issue #33789
+f33789(x::I, ft::Function, use::Type{U}, ignore::Type{I}) where {U, I} = 0
+f33789(x::U, ft::Function, use::Type{U}, ignore::Type{I}) where {U, I} = 1
+@test f33789(1.0f0, identity, Number, Float32) in (0, 1)
+
 nothing # don't return a module from the remote include


### PR DESCRIPTION
This is an unfortunate case where methods are ambiguous, but intersection is not precise enough to determine exactly why. In such a case it's arguably nicer to just pick a method than to give a frustrating error telling you to define a method that already exists. I suppose another option is to detect that when printing the error, and issue an apology instead of a useless suggestion :)

This is a possible fix; will need review from @vtjnash. We do have the option of doing nothing here though, since this seems to be a real ambiguity.

fix #33789. Should be backported to 1.3 if deemed OK.