### PR TITLE
Add `lock(f, lock)` docstring to `lock`.

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -145,6 +145,16 @@ function relockall(rl::ReentrantLock, n::Int)
     return
 end
 
+"""
+    lock(f::Function, lock)
+
+Acquire the `lock`, execute `f` with the `lock` held, and release the `lock` when `f`
+returns. If the lock is already locked by a different task/thread, wait for it to become
+available.
+
+When this function returns, the `lock` has been released, so the caller should
+not attempt to `unlock` it.
+"""
 function lock(f, l::AbstractLock)
     lock(l)
     try


### PR DESCRIPTION
Currently the `lock(l) do ; ... end` method is not documented, and so is not discoverable.