### PR TITLE
Update inference devdoc

### DIFF
--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -13,9 +13,16 @@ posts
 
 You can start a Julia session, edit `compiler/*.jl` (for example to
 insert `print` statements), and then replace `Core.Compiler` in your
-running session by navigating to `base/compiler` and executing
-`include("compiler.jl")`. This trick typically leads to much faster
+running session by navigating to `base` and executing
+`include("compiler/compiler.jl")`. This trick typically leads to much faster
 development than if you rebuild Julia for each change.
+
+Alternatively, you can use the [Revise.jl](https://github.com/timholy/Revise.jl)
+package to track the compiler changes by using the the command
+`Revise.track(Core.Compiler)` at the beginning of your Julia session. As
+explained in the [Revise documentation](https://timholy.github.io/Revise.jl/stable/),
+the modifications to the compiler will be reflected when the modified files
+are saved.
 
 A convenient entry point into inference is `typeinf_code`. Here's a
 demo running inference on `convert(Int, UInt(1))`:
@@ -28,11 +35,11 @@ m = first(mths)
 
 # Create variables needed to call `typeinf_code`
 params = Core.Compiler.Params(typemax(UInt))  # parameter is the world age,
-                                                        #   typemax(UInt) -> most recent
+                                              # typemax(UInt) -> most recent
 sparams = Core.svec()      # this particular method doesn't have type-parameters
 optimize = true            # run all inference optimizations
-cached = false             # force inference to happen (do not use cached results)
-Core.Compiler.typeinf_code(m, atypes, sparams, optimize, cached, params)
+types = Tuple{typeof(convert), atypes.parameters...} # Tuple{typeof(convert), Type{Int}, UInt}
+Core.Compiler.typeinf_code(m, types, sparams, optimize, params)
 ```
 
 If your debugging adventures require a `MethodInstance`, you can look it up by


### PR DESCRIPTION
This PR updates the developer's documentation for the compiler reloading trick, and the use of `typeinf_code`. I hope this is indeed what was intended.