### PR TITLE
Recommend to check package name if not found by require

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -892,6 +892,7 @@ function require(into::Module, mod::Symbol)
             - If you have $(where.name) checked out for development and have
               added $mod as a dependency but haven't updated your primary
               environment's manifest file, try `Pkg.resolve()`.
+            - Check the imported package name for typos.
             - Otherwise you may need to report an issue with $(where.name)"""
 
             uuidkey = identify_package(PkgId(string(into)), String(mod))


### PR DESCRIPTION
When package dependencies are being loaded, if the package is not found there is an error message containing a recommendation to run `Pkg.resolve()`, or report an issue. This error message also appears in the simple case when the package name is misspelled. I just lost some time with that, and I think pointing that out in the message might be helpful.