### PR TITLE
docs: more direct links to sections in peformance tips

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -310,7 +310,7 @@ inner functions used elsewhere in the language, variables from the enclosing sco
 "captured" in the inner function.  For example, `sum(p[i] - q[i] for i=1:n)`
 captures the three variables `p`, `q` and `n` from the enclosing scope.
 Captured variables can present performance challenges; see
-[performance tips](@ref man-performance-tips).
+[performance tips](@ref man-performance-captured).
 
 
 Ranges in generators and comprehensions can depend on previous ranges by writing multiple `for`
@@ -974,8 +974,8 @@ the length of the tuple returned by [`size`](@ref). For more details on defining
 `AbstractArray` implementations, see the [array interface guide in the interfaces chapter](@ref man-interface-array).
 
 `DenseArray` is an abstract subtype of `AbstractArray` intended to include all arrays where
-elements are stored contiguously in column-major order (see additional notes in
-[Performance Tips](@ref man-performance-tips)). The [`Array`](@ref) type is a specific instance
+elements are stored contiguously in column-major order (see [additional notes in
+Performance Tips](@ref man-performance-column-major)). The [`Array`](@ref) type is a specific instance
 of `DenseArray`;  [`Vector`](@ref) and [`Matrix`](@ref) are aliases for the 1-d and 2-d cases.
 Very few operations are implemented specifically for `Array` beyond those that are required
 for all `AbstractArray`s; much of the array library is implemented in a generic

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -677,7 +677,7 @@ the arguments of the user function are initialized.
 A `do` block, like any other inner function, can "capture" variables from its
 enclosing scope. For example, the variable `data` in the above example of
 `open...do` is captured from the outer scope. Captured variables
-can create performance challenges as discussed in [performance tips](@ref man-performance-tips).
+can create performance challenges as discussed in [performance tips](@ref man-performance-captured).
 
 ## Function composition and piping
 

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -210,7 +210,7 @@ For users coming to Julia from R, these are some noteworthy differences:
     to continue is to wrap it in parentheses.
   * Julia arrays are column major (Fortran ordered) whereas NumPy arrays are row major (C-ordered)
     by default. To get optimal performance when looping over arrays, the order of the loops should
-    be reversed in Julia relative to NumPy (see relevant section of [Performance Tips](@ref man-performance-tips)).
+    be reversed in Julia relative to NumPy (see [relevant section of Performance Tips](@ref man-performance-column-major)).
   * Julia's updating operators (e.g. `+=`, `-=`, ...) are *not in-place* whereas NumPy's are. This
     means `A = [1, 1]; B = A; B += [3, 3]` doesn't change values in `A`, it rather rebinds the name `B`
     to the result of the right-hand side `B = B + 3`, which is a new array. For in-place operation, use `B .+= 3`
@@ -236,7 +236,7 @@ For users coming to Julia from R, these are some noteworthy differences:
     which rebinds the left-hand side to the result of the right-hand side expression.
   * Julia arrays are column major (Fortran ordered) whereas C/C++ arrays are row major ordered by
     default. To get optimal performance when looping over arrays, the order of the loops should be
-    reversed in Julia relative to C/C++ (see relevant section of [Performance Tips](@ref man-performance-tips)).
+    reversed in Julia relative to C/C++ (see [relevant section of Performance Tips](@ref man-performance-column-major)).
   * Julia values are not copied when assigned or passed to a function. If a function modifies an array, the changes
     will be visible in the caller.
   * In Julia, whitespace is significant, unlike C/C++, so care must be taken when adding/removing

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -151,7 +151,7 @@ the performance of your code:
   * `@code_warntype` generates a representation of your code that can be helpful in finding expressions
     that result in type uncertainty. See [`@code_warntype`](@ref) below.
 
-## Avoid containers with abstract type parameters
+## [Avoid containers with abstract type parameters](@id man-performance-abstract-container)
 
 When working with parameterized types, including arrays, it is best to avoid parameterizing with
 abstract types where possible.
@@ -674,7 +674,7 @@ or the [`fill!`](@ref) function, which we could have used instead of writing our
 Functions like `strange_twos` occur when dealing with data of uncertain type, for example data
 loaded from an input file that might contain either integers, floats, strings, or something else.
 
-## Types with values-as-parameters
+## [Types with values-as-parameters](@id man-performance-value-type)
 
 Let's say you want to create an `N`-dimensional array that has size 3 along each axis. Such arrays
 can be created like this:
@@ -811,7 +811,7 @@ or thousands of variants compiled for it. Each of these increases the size of th
 code, the length of internal lists of methods, etc. Excess enthusiasm for values-as-parameters
 can easily waste enormous resources.
 
-## Access arrays in memory order, along columns
+## [Access arrays in memory order, along columns](@id man-performance-column-major)
 
 Multidimensional arrays in Julia are stored in column-major order. This means that arrays are
 stacked one column at a time. This can be verified using the `vec` function or the syntax `[:]`

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -232,7 +232,7 @@ has full control over whether the default or more specific method is used.
 An important point to note is that there is no loss in performance if the programmer relies on
 a function whose arguments are abstract types, because it is recompiled for each tuple of argument
 concrete types with which it is invoked. (There may be a performance issue, however, in the case
-of function arguments that are containers of abstract types; see [Performance Tips](@ref man-performance-tips).)
+of function arguments that are containers of abstract types; see [Performance Tips](@ref man-performance-abstract-container).)
 
 ## Primitive Types
 
@@ -1408,6 +1408,6 @@ a *type*, i.e., use `foo(Val(:bar))` rather than `foo(Val{:bar})`.
 It's worth noting that it's extremely easy to mis-use parametric "value" types, including `Val`;
 in unfavorable cases, you can easily end up making the performance of your code much *worse*.
  In particular, you would never want to write actual code as illustrated above.  For more information
-about the proper (and improper) uses of `Val`, please read the more extensive discussion in [the performance tips](@ref man-performance-tips).
+about the proper (and improper) uses of `Val`, please read [the more extensive discussion in the performance tips](@ref man-performance-value-type).
 
 [^1]: "Small" is defined by the `MAX_UNION_SPLITTING` constant, which is currently set to 4.

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -259,8 +259,8 @@ julia> counter()
 See also the closures in the examples in the next two sections. A variable,
 such as `x` in the first example and `state` in the second, that is inherited
 from the enclosing scope by the inner function is sometimes called a
-*captured* variable. Captured variables can present performance challenges
-discussed in [performance tips](@ref man-performance-tips).
+*captured* variable. Captured variables can present [performance challenges
+discussed in performance tips](@ref man-performance-captured).
 
 The distinction between inheriting global scope and nesting local scope
 can lead to some slight differences between functions


### PR DESCRIPTION
This PR modifies the links to the performance tips' header so that they point to a specific section, when it's clear within the original context. Then readers no longer need to search the relevant sections in performance tips after a jump.