### PR TITLE
Fix findfirst with decreasing step range

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1773,7 +1773,8 @@ findfirst(testf::Function, A::Union{AbstractArray, AbstractString}) =
     findnext(testf, A, first(keys(A)))
 
 function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
-    first(r) <= p.x <= last(r) || return nothing
+    isempty(r) && return nothing
+    minimum(r) <= p.x <= maximum(r) || return nothing
     d = convert(S, p.x - first(r))
     iszero(d % step(r)) || return nothing
     return d ÷ step(r) + 1

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -306,6 +306,7 @@ end
         @test findfirst(==(10), 1:2:10) == nothing
         @test findfirst(==(11), 1:2:10) == nothing
         @test findfirst(==(-7), 1:-1:-10) == 9
+        @test findfirst(==(2),1:-1:2) == nothing
     end
     @testset "reverse" begin
         @test reverse(reverse(1:10)) == 1:10

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -305,6 +305,7 @@ end
         @test findfirst(==(7), 1:2:10) == 4
         @test findfirst(==(10), 1:2:10) == nothing
         @test findfirst(==(11), 1:2:10) == nothing
+        @test findfirst(==(-7), 1:-1:-10) == 9
     end
     @testset "reverse" begin
         @test reverse(reverse(1:10)) == 1:10


### PR DESCRIPTION
Fixes #33808 
`findfirst` assumed increasing step size for `StepRange`.