### PR TITLE
Fix compat docstring

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -834,7 +834,7 @@ Function composition also works in prefix form: `∘(f, g)` is the same as `f �
 The prefix form supports composition of multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
 and splatting `∘(fs...)` for composing an iterable collection of functions.
 
-!!!compat "Julia 1.4"
+!!! compat "Julia 1.4"
     Multiple function composition requires at least Julia 1.4.
 
 # Examples


### PR DESCRIPTION
https://docs.julialang.org/en/latest/base/base/#Base.:%E2%88%98 docstring is not rendered correctly ATM:

![image](https://user-images.githubusercontent.com/29282/68603699-ada59100-045d-11ea-9913-52ce5cebdc16.png)

I think this PR fixes it.