### PR TITLE
Fix `realpath()` assumptions in REPL test suite

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -49,17 +49,9 @@ function repl_cmd(cmd, out)
                 if !haskey(ENV, "OLDPWD")
                     error("cd: OLDPWD not set")
                 end
-                cd(ENV["OLDPWD"])
-            else
-                @static if !Sys.iswindows()
-                    # TODO: this is a rather expensive way to copy a string, remove?
-                    # If it's intended to simulate `cd`, it should instead be doing
-                    # more nearly `cd $dir && printf %s \$PWD` (with appropriate quoting),
-                    # since shell `cd` does more than just `echo` the result.
-                    dir = read(`$shell -c "printf '%s' $(shell_escape_posixly(dir))"`, String)
-                end
-                cd(dir)
+                dir = ENV["OLDPWD"]
             end
+            cd(dir)
         else
             cd()
         end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -112,38 +112,38 @@ fake_repl() do stdin_write, stdout_read, repl
         readuntil(stdout_read, "shell> ")
         write(stdin_write, "cd $(escape_string(tmpdir))\n")
         readuntil(stdout_read, "cd $(escape_string(tmpdir))")
-        readuntil(stdout_read, realpath(tmpdir))
+        readuntil(stdout_read, escape_string(tmpdir))
         readuntil(stdout_read, "\n")
         readuntil(stdout_read, "\n")
-        @test pwd() == realpath(tmpdir)
+        @test realpath(pwd()) == realpath(tmpdir)
 
         # Test using `cd` to move to the home directory
         write(stdin_write, ";")
         readuntil(stdout_read, "shell> ")
         write(stdin_write, "cd\n")
-        readuntil(stdout_read, realpath(homedir()))
+        readuntil(stdout_read, homedir())
         readuntil(stdout_read, "\n")
         readuntil(stdout_read, "\n")
-        @test pwd() == realpath(homedir())
+        @test realpath(pwd()) == realpath(homedir())
 
         # Test using `-` to jump backward to tmpdir
         write(stdin_write, ";")
         readuntil(stdout_read, "shell> ")
         write(stdin_write, "cd -\n")
-        readuntil(stdout_read, tmpdir)
+        readuntil(stdout_read, escape_string(tmpdir))
         readuntil(stdout_read, "\n")
         readuntil(stdout_read, "\n")
-        @test pwd() == realpath(tmpdir)
+        @test realpath(pwd()) == realpath(tmpdir)
 
         # Test using `~` in `cd` commands
         if !Sys.iswindows()
             write(stdin_write, ";")
             readuntil(stdout_read, "shell> ")
             write(stdin_write, "cd ~\n")
-            readuntil(stdout_read, realpath(homedir()))
+            readuntil(stdout_read, homedir())
             readuntil(stdout_read, "\n")
             readuntil(stdout_read, "\n")
-            @test pwd() == realpath(homedir())
+            @test realpath(pwd()) == realpath(homedir())
         end
         cd(origpwd)
     end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -107,45 +107,52 @@ fake_repl() do stdin_write, stdout_read, repl
     # Test cd feature in shell mode.
     origpwd = pwd()
     mktempdir() do tmpdir
-        # Test `cd`'ing to an absolute path
-        write(stdin_write, ";")
-        readuntil(stdout_read, "shell> ")
-        write(stdin_write, "cd $(escape_string(tmpdir))\n")
-        readuntil(stdout_read, "cd $(escape_string(tmpdir))")
-        readuntil(stdout_read, escape_string(tmpdir))
-        readuntil(stdout_read, "\n")
-        readuntil(stdout_read, "\n")
-        @test realpath(pwd()) == realpath(tmpdir)
+        try
+            samefile = Base.Filesystem.samefile
+            tmpdir_pwd = cd(pwd, tmpdir)
+            homedir_pwd = cd(pwd, homedir())
 
-        # Test using `cd` to move to the home directory
-        write(stdin_write, ";")
-        readuntil(stdout_read, "shell> ")
-        write(stdin_write, "cd\n")
-        readuntil(stdout_read, homedir())
-        readuntil(stdout_read, "\n")
-        readuntil(stdout_read, "\n")
-        @test realpath(pwd()) == realpath(homedir())
-
-        # Test using `-` to jump backward to tmpdir
-        write(stdin_write, ";")
-        readuntil(stdout_read, "shell> ")
-        write(stdin_write, "cd -\n")
-        readuntil(stdout_read, escape_string(tmpdir))
-        readuntil(stdout_read, "\n")
-        readuntil(stdout_read, "\n")
-        @test realpath(pwd()) == realpath(tmpdir)
-
-        # Test using `~` in `cd` commands
-        if !Sys.iswindows()
+            # Test `cd`'ing to an absolute path
             write(stdin_write, ";")
             readuntil(stdout_read, "shell> ")
-            write(stdin_write, "cd ~\n")
-            readuntil(stdout_read, homedir())
+            write(stdin_write, "cd $(escape_string(tmpdir))\n")
+            readuntil(stdout_read, "cd $(escape_string(tmpdir))")
+            readuntil(stdout_read, tmpdir_pwd)
             readuntil(stdout_read, "\n")
             readuntil(stdout_read, "\n")
-            @test realpath(pwd()) == realpath(homedir())
+            @test samefile(".", tmpdir)
+
+            # Test using `cd` to move to the home directory
+            write(stdin_write, ";")
+            readuntil(stdout_read, "shell> ")
+            write(stdin_write, "cd\n")
+            readuntil(stdout_read, homedir_pwd)
+            readuntil(stdout_read, "\n")
+            readuntil(stdout_read, "\n")
+            @test samefile(".", homedir_pwd)
+
+            # Test using `-` to jump backward to tmpdir
+            write(stdin_write, ";")
+            readuntil(stdout_read, "shell> ")
+            write(stdin_write, "cd -\n")
+            readuntil(stdout_read, tmpdir_pwd)
+            readuntil(stdout_read, "\n")
+            readuntil(stdout_read, "\n")
+            @test samefile(".", tmpdir)
+
+            # Test using `~` (Base.expanduser) in `cd` commands
+            if !Sys.iswindows()
+                write(stdin_write, ";")
+                readuntil(stdout_read, "shell> ")
+                write(stdin_write, "cd ~\n")
+                readuntil(stdout_read, homedir_pwd)
+                readuntil(stdout_read, "\n")
+                readuntil(stdout_read, "\n")
+                @test samefile(".", homedir_pwd)
+            end
+        finally
+            cd(origpwd)
         end
-        cd(origpwd)
     end
 
     # issue #20482


### PR DESCRIPTION
On non-case-sensitive platforms, it is possible for `cd` and `pwd()` to
return values that are different from what `realpath()` of the same
would give back.  Therefore, we must adjust our tests to be more robust
against this variation.

This should hopefully fix some of the testing hangs on Windows