### PR TITLE
Better stacktraces for `ccall` libraries that do not exist

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -663,22 +663,18 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
         }
         else {
             void *symaddr;
-            if (!jl_dlsym(jl_get_library(sym.f_lib), sym.f_name, &symaddr, 0)) {
-                std::stringstream msg;
-                msg << "cglobal: could not find symbol ";
-                msg << sym.f_name;
-                if (sym.f_lib != NULL) {
-#ifdef _OS_WINDOWS_
-                    assert(sym.f_lib != JL_EXE_LIBNAME && sym.f_lib != JL_DL_LIBNAME);
-#endif
-                    msg << " in library ";
-                    msg << sym.f_lib;
-                }
-                emit_error(ctx, msg.str());
+
+            void* libsym = jl_get_library_(sym.f_lib, 0);
+            if (!libsym || !jl_dlsym(libsym, sym.f_name, &symaddr, 0)) {
+                // Error mode, either the library or the symbol couldn't be find during compiletime.
+                // Fallback to a runtime symbol lookup.
+                res = runtime_sym_lookup(ctx, cast<PointerType>(T_pint8), sym.f_lib, sym.f_name, ctx.f);
+                res = ctx.builder.CreatePtrToInt(res, lrt);
+            } else {
+                // since we aren't saving this code, there's no sense in
+                // putting anything complicated here: just JIT the address of the cglobal
+                res = ConstantInt::get(lrt, (uint64_t)symaddr);
             }
-            // since we aren't saving this code, there's no sense in
-            // putting anything complicated here: just JIT the address of the cglobal
-            res = ConstantInt::get(lrt, (uint64_t)symaddr);
         }
     }
 
@@ -1877,23 +1873,17 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         }
         else {
             void *symaddr;
-            if (!jl_dlsym(jl_get_library(symarg.f_lib), symarg.f_name, &symaddr, 0)) {
-                std::stringstream msg;
-                msg << "ccall: could not find function ";
-                msg << symarg.f_name;
-                if (symarg.f_lib != NULL) {
-#ifdef _OS_WINDOWS_
-                    assert(symarg.f_lib != JL_EXE_LIBNAME && symarg.f_lib != JL_DL_LIBNAME);
-#endif
-                    msg << " in library ";
-                    msg << symarg.f_lib;
-                }
-                emit_error(ctx, msg.str());
-                return jl_cgval_t();
+
+            void* libsym = jl_get_library_(symarg.f_lib, 0);
+            if (!libsym || !jl_dlsym(libsym, symarg.f_name, &symaddr, 0)) {
+                // either the library or the symbol could not be found, place a runtime
+                // lookup here instead.
+                llvmf = runtime_sym_lookup(ctx, funcptype, symarg.f_lib, symarg.f_name, ctx.f);
+            } else {
+                // since we aren't saving this code, there's no sense in
+                // putting anything complicated here: just JIT the function address
+                llvmf = literal_static_pointer_val(ctx, symaddr, funcptype);
             }
-            // since we aren't saving this code, there's no sense in
-            // putting anything complicated here: just JIT the function address
-            llvmf = literal_static_pointer_val(ctx, symaddr, funcptype);
         }
     }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -861,7 +861,8 @@ extern void *jl_crtdll_handle;
 extern void *jl_winsock_handle;
 #endif
 
-void *jl_get_library(const char *f_lib);
+void *jl_get_library_(const char *f_lib, int throw_err);
+#define jl_get_library(f_lib) jl_get_library_(f_lib, 1)
 JL_DLLEXPORT void *jl_load_and_lookup(const char *f_lib, const char *f_name,
                                       void **hnd);
 JL_DLLEXPORT jl_value_t *jl_get_cfunction_trampoline(

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -27,7 +27,7 @@ using namespace llvm;
 static std::map<std::string, void*> libMap;
 static jl_mutex_t libmap_lock;
 extern "C"
-void *jl_get_library(const char *f_lib)
+void *jl_get_library_(const char *f_lib, int throw_err)
 {
     void *hnd;
 #ifdef _OS_WINDOWS_
@@ -47,7 +47,7 @@ void *jl_get_library(const char *f_lib)
     if (hnd != NULL)
         return hnd;
     // We might run this concurrently on two threads but it doesn't matter.
-    hnd = jl_load_dynamic_library(f_lib, JL_RTLD_DEFAULT, 1);
+    hnd = jl_load_dynamic_library(f_lib, JL_RTLD_DEFAULT, throw_err);
     if (hnd != NULL)
         jl_atomic_store_release(map_slot, hnd);
     return hnd;


### PR DESCRIPTION
After:
```
julia> f() = ccall((:time, "doesnotexit"), Int, ())
f (generic function with 1 method)

julia> h() = f()
h (generic function with 1 method)

julia> h()
ERROR: ccall: could not load library
 in library doesnotexit
Stacktrace:
 [1] f at ./REPL[1]:1 [inlined]
 [2] h() at ./REPL[2]:1
 [3] top-level scope at REPL[3]:1
```

Before:
```
julia> f() = ccall((:time, "doesnotexit"), Int, ())
f (generic function with 1 method)

julia> h() = f()
h (generic function with 1 method)

julia> h()
ERROR: error compiling h: could not load library "doesnotexit"
doesnotexit.so: cannot open shared object file: No such file or directory
Stacktrace:
 [1] top-level scope at REPL[3]:1
caused by [exception 1]
could not load library "doesnotexit"
doesnotexit.so: cannot open shared object file: No such file or directory
Stacktrace:
 [1] top-level scope at REPL[3]:1

julia> g() = h()
g (generic function with 1 method)

julia> g()
ERROR: error compiling g: could not load library "doesnotexit"
doesnotexit.so: cannot open shared object file: No such file or directory
Stacktrace:
 [1] top-level scope at REPL[5]:1
caused by [exception 1]
could not load library "doesnotexit"
doesnotexit.so: cannot open shared object file: No such file or directory
Stacktrace:
 [1] top-level scope at REPL[5]:1
```

Currently we lose the ability to report why the library couldn't be opened.

cc: @maleadt @simonbyrne 