### PR TITLE
fix #33338, race condition in triggering method compilation

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1444,8 +1444,10 @@ void jl_generate_fptr(jl_code_instance_t *output)
                     break;
                 ucache = ucache->next;
             }
-            if (codeinst->invoke)
+            if (codeinst->invoke) {
+                JL_UNLOCK(&codegen_lock);
                 return;
+            }
             if (ucache != NULL) {
                 codeinst->specptr = ucache->specptr;
                 codeinst->rettype_const = ucache->rettype_const;


### PR DESCRIPTION
This might be too heavy-handed, but I'll put it up as an RFC. It looks like it was possible for `mi->inInference` and/or `in_inference` to be set by some threads, causing other threads to return `NULL` from `jl_type_infer`.

@fredrikekre See if this fixes it for you.

There was also a random missing unlock.