### PR TITLE
tighten signature of (complex mat) x (real vec)

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -69,7 +69,7 @@ end
 for elty in (Float32,Float64)
     @eval begin
         @inline function mul!(y::StridedVector{Complex{$elty}}, A::StridedVecOrMat{Complex{$elty}}, x::StridedVector{$elty},
-                              alpha::Number, beta::Number)
+                              alpha::Real, beta::Real)
             Afl = reinterpret($elty, A)
             yfl = reinterpret($elty, y)
             mul!(yfl, Afl, x, alpha, beta)
@@ -329,7 +329,7 @@ end
 for elty in (Float32,Float64)
     @eval begin
         @inline function mul!(C::StridedMatrix{Complex{$elty}}, A::StridedVecOrMat{Complex{$elty}}, transB::Transpose{<:Any,<:StridedVecOrMat{$elty}},
-                         alpha::Number, beta::Number)
+                         alpha::Real, beta::Real)
             Afl = reinterpret($elty, A)
             Cfl = reinterpret($elty, C)
             mul!(Cfl, Afl, transB, alpha, beta)


### PR DESCRIPTION
Closes JuliaLang/LinearAlgebra.jl#655 (again).

Indeed, in JuliaLang/julia#33743 I relaxed the signature by too much. Now, it is consistent with the corresponding mat-mat-mul function (as modified in JuliaLang/julia#33229), that reinterpret the complex matrix as real. Now, if alpha or beta are not real (as was the case in the failing tests), some other `mul!` method is the first to be called, which decides on whether to use BLAS or not.

I found a similar issue with the complexMatrix * transpose(realMatrix) function. ~~I went by the assumption that all this reinterpretation stuff makes sense only if for the reinterpreted real matrices BLAS gets called. So I added code that would check whether this is the case, and otherwise fall back to generic mul. This specializes again a change in JuliaLang/julia#33229.~~ I think the reinterpret should make sense even if the generic mul gets called.