### PR TITLE
fix table column alignment in html output

### DIFF
--- a/stdlib/Markdown/src/GitHub/table.jl
+++ b/stdlib/Markdown/src/GitHub/table.jl
@@ -65,8 +65,10 @@ function html(io::IO, md::Table)
     withtag(io, :table) do
         for (i, row) in enumerate(md.rows)
             withtag(io, :tr) do
-                for c in md.rows[i]
-                    withtag(io, i == 1 ? :th : :td) do
+                for (j, c) in enumerate(md.rows[i])
+                    alignment = md.align[j]
+                    alignment = alignment === :l ? "left" : alignment === :r ? "right" : "center"
+                     withtag(io, i == 1 ? :th : :td, ("align", alignment)) do
                         htmlinline(io, c)
                     end
                 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -510,6 +510,7 @@ let text =
     """,
     table = Markdown.parse(text)
     @test text == Markdown.plain(table)
+    @test Markdown.html(table) == """<table><tr><th align="left">Markdown</th><th align="center">Table</th><th align="right">Test</th></tr><tr><td align="left">foo</td><td align="center"><code>bar</code></td><td align="right"><em>baz</em></td></tr><tr><td align="left"><code>bar</code></td><td align="center">baz</td><td align="right"><em>foo</em></td></tr></table>\n"""
 end
 let text =
     """
@@ -519,6 +520,7 @@ let text =
     """,
     table = Markdown.parse(text)
     @test text == Markdown.plain(table)
+    @test Markdown.html(table) == """<table><tr><th align="left">a</th><th align="right">b</th></tr><tr><td align="left"><code>x | y</code></td><td align="right">2</td></tr></table>\n"""
 end
 
 # LaTeX extension


### PR DESCRIPTION
The html output of markdown tables doesn't correctly set the horizontal alignment. This PR fixes that.