### PR TITLE
REPL: make edit_title_case (M-c) call titlecase

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1103,7 +1103,7 @@ function edit_lower_case(s)
 end
 function edit_title_case(s)
     set_action!(s, :edit_title_case)
-    return edit_replace_word_right(s, uppercasefirst)
+    return edit_replace_word_right(s, titlecase)
 end
 
 function edit_replace_word_right(s, replace::Function)

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -606,7 +606,7 @@ end
 
 @testset "change case on the right" begin
     local buf = IOBuffer()
-    edit_insert(buf, "aa bb CC")
+    edit_insert(buf, "aa bB CC")
     seekstart(buf)
     LineEdit.edit_upper_case(buf)
     LineEdit.edit_title_case(buf)


### PR DESCRIPTION
When edit_title_case was implemented, `uppercasefirst` (née `ucfirst`)
and `titlecase` were doing the same transformation on only one word.
But `titlecase` now transforms non-leading letters to lowercase,
which is more expected for the M-c keyboard combo, as it's the
standard readline behavior (I believe).

Edit: it's not just to copy readline, I also find `titlecase` more useful (in the REPL)!