### PR TITLE
avoid suggesting a method that will not work to resolve a method ambiguity

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -320,8 +320,14 @@ function showerror_ambiguous(io::IO, meth, f, args)
         sigfix = typeintersect(m.sig, sigfix)
     end
     if isa(unwrap_unionall(sigfix), DataType) && sigfix <: Tuple
-        print(io, "\nPossible fix, define\n  ")
-        Base.show_tuple_as_call(io, :function,  sigfix)
+        if all(m->morespecific(sigfix, m.sig), meth)
+            print(io, "\nPossible fix, define\n  ")
+            Base.show_tuple_as_call(io, :function,  sigfix)
+        else
+            println(io)
+            print(io, "To resolve the ambiguity, try making one of the methods more specific, or ")
+            print(io, "adding a new method more specific than any of the existing applicable methods.")
+        end
     end
     nothing
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -589,7 +589,9 @@ end
 Compute a type that contains the intersection of `T` and `S`. Usually this will be the
 smallest such type or one close to it.
 """
-typeintersect(@nospecialize(a),@nospecialize(b)) = (@_pure_meta; ccall(:jl_type_intersection, Any, (Any,Any), a, b))
+typeintersect(@nospecialize(a), @nospecialize(b)) = (@_pure_meta; ccall(:jl_type_intersection, Any, (Any, Any), a, b))
+
+morespecific(@nospecialize(a), @nospecialize(b)) = ccall(:jl_type_morespecific, Cint, (Any, Any), a, b) != 0
 
 """
     fieldoffset(type, i)


### PR DESCRIPTION
Example:
```
julia> f33789(x::I, ft::Function, use::Type{U}, ignore::Type{I}) where {U, I} = 0;

julia> f33789(x::U, ft::Function, use::Type{U}, ignore::Type{I}) where {U, I} = 1;

julia> f33789(1.0f0, identity, Number, Float32)
ERROR: MethodError: f33789(::Float32, ::typeof(identity), ::Type{Number}, ::Type{Float32}) is ambiguous. Candidates:
  f33789(x::I, ft::Function, use::Type{U}, ignore::Type{I}) where {U, I} in Main at REPL[1]:1
  f33789(x::U, ft::Function, use::Type{U}, ignore::Type{I}) where {U, I} in Main at REPL[2]:1
To resolve the ambiguity, try making one or more of the methods more specific, or adding a new method more specific than any of the existing applicable methods.
```
