### PR TITLE
Update mod2pi docstring

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -987,9 +987,10 @@ numerically exact `2π`, and is therefore not exactly the same as `mod(x,2π)`, 
 compute the modulus of `x` relative to division by the floating-point number `2π`.
 
 !!! note
-    Depending on how your machine represents floats, `2π` may be less than the numerically
-    exact value used in this calculation. So in certain applications `mod2pi(2π)` will not
-    return 0. See [`rem2pi`](@ref) for more refined control of this behavior.
+    Depending on the format of the input value, the closest representable value to 2π may
+    be less than 2π. For example, the expression `mod2pi(2π)` will not return `0`, because
+    the intermediate value of `2*π` is a `Float64` and `2*Float64(π) < 2*big(π)`. See
+    [`rem2pi`](@ref) for more refined control of this behavior.
 
 # Examples
 ```jldoctest

--- a/base/math.jl
+++ b/base/math.jl
@@ -986,6 +986,11 @@ This function computes a floating point representation of the modulus after divi
 numerically exact `2π`, and is therefore not exactly the same as `mod(x,2π)`, which would
 compute the modulus of `x` relative to division by the floating-point number `2π`.
 
+!!! note
+    Depending on how your machine represents floats, `2π` may be less than the numerically
+    exact value used in this calculation. So in certain applications `mod2pi(2π)` will not
+    return 0. See [`rem2pi`](@ref) for more refined control of this behavior.
+
 # Examples
 ```jldoctest
 julia> mod2pi(9*pi/4)


### PR DESCRIPTION
Updating the mod2pi docstring with a note that explains why `mod2pi(2pi)` may not return 0 and directing users to `rem2pi` for more refined control.