### PR TITLE
REPL: allow switching contextual module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,7 +98,7 @@ Standard library changes
   executed upon existing the editor.
 
 * The contextual module which is active at the REPL can be changed (it is `Main` by default),
-  via the `activate_module` function ([#33872]).
+  via the `REPL.activate` function or via a keybinding ([#33872]).
 
 #### SparseArrays
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,9 @@ Standard library changes
 * `Meta-e` now opens the current input in an editor. The content (if modified) will be
   executed upon existing the editor.
 
+* The contextual module which is active at the REPL can be changed (it is `Main` by default),
+  via the `activate_module` function ([#33872]).
+
 #### SparseArrays
 
 #### Dates

--- a/NEWS.md
+++ b/NEWS.md
@@ -98,7 +98,8 @@ Standard library changes
   executed upon existing the editor.
 
 * The contextual module which is active at the REPL can be changed (it is `Main` by default),
-  via the `REPL.activate` function or via a keybinding ([#33872]).
+  via the `REPL.activate(::Module)` function or via typing the module in the REPL and pressing
+  the keybinding Alt-m ([#33872]).
 
 #### SparseArrays
 

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -36,7 +36,7 @@ Base.print(io::IO, x::Enum) = print(io, _symbol(x))
 function Base.show(io::IO, x::Enum)
     sym = _symbol(x)
     if !(get(io, :compact, false)::Bool)
-        from = get(io, :module, Base.get_active_module())
+        from = get(io, :module, Base.active_module())
         def = typeof(x).name.module
         if from === nothing || !Base.isvisible(sym, def, from)
             show(io, def)

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -36,7 +36,7 @@ Base.print(io::IO, x::Enum) = print(io, _symbol(x))
 function Base.show(io::IO, x::Enum)
     sym = _symbol(x)
     if !(get(io, :compact, false)::Bool)
-        from = get(io, :module, Main)
+        from = get(io, :module, Base.get_active_module())
         def = typeof(x).name.module
         if from === nothing || !Base.isvisible(sym, def, from)
             show(io, def)

--- a/base/client.jl
+++ b/base/client.jl
@@ -465,6 +465,17 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_fil
     nothing
 end
 
+"""
+    activate_module(mod::Module=Main)
+
+Set `mod` as the default contextual module in the REPL,
+both for evaluating expressions and printing them.
+"""
+function activate_module(mod::Module=Main)
+    active_repl.mistate.active_module = mod
+    nothing
+end
+
 # MainInclude exists to hide Main.include and eval from `names(Main)`.
 baremodule MainInclude
 using ..Base

--- a/base/client.jl
+++ b/base/client.jl
@@ -379,11 +379,7 @@ const REPL_MODULE_REF = Ref{Module}()
 
 function load_InteractiveUtils(mod::Module=Main)
     # load interactive-only libraries
-    if isdefined(mod, :InteractiveUtils)
-        # InteractiveUtils is only `import`ed (like in REPL)
-        Core.eval(mod, :(using .InteractiveUtils))
-        return InteractiveUtils
-    else
+    if !isdefined(mod, :InteractiveUtils)
         try
             let InteractiveUtils = require(PkgId(UUID(0xb77e0a4c_d291_57a0_90e8_8db25a27a240), "InteractiveUtils"))
                 Core.eval(mod, :(const InteractiveUtils = $InteractiveUtils))

--- a/base/client.jl
+++ b/base/client.jl
@@ -379,7 +379,11 @@ const REPL_MODULE_REF = Ref{Module}()
 
 function load_InteractiveUtils(mod::Module=Main)
     # load interactive-only libraries
-    if !isdefined(mod, :InteractiveUtils)
+    if isdefined(mod, :InteractiveUtils)
+        # InteractiveUtils is only `import`ed (like in REPL)
+        Core.eval(mod, :(using .InteractiveUtils))
+        return InteractiveUtils
+    else
         try
             let InteractiveUtils = require(PkgId(UUID(0xb77e0a4c_d291_57a0_90e8_8db25a27a240), "InteractiveUtils"))
                 Core.eval(mod, :(const InteractiveUtils = $InteractiveUtils))

--- a/base/client.jl
+++ b/base/client.jl
@@ -465,17 +465,6 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_fil
     nothing
 end
 
-"""
-    activate_module(mod::Module=Main)
-
-Set `mod` as the default contextual module in the REPL,
-both for evaluating expressions and printing them.
-"""
-function activate_module(mod::Module=Main)
-    active_repl.mistate.active_module = mod
-    nothing
-end
-
 # MainInclude exists to hide Main.include and eval from `names(Main)`.
 baremodule MainInclude
 using ..Base

--- a/base/client.jl
+++ b/base/client.jl
@@ -377,21 +377,21 @@ _atreplinit(repl) = invokelatest(__atreplinit, repl)
 # The REPL stdlib hooks into Base using this Ref
 const REPL_MODULE_REF = Ref{Module}()
 
-function load_InteractiveUtils()
+function load_InteractiveUtils(mod::Module=Main)
     # load interactive-only libraries
-    if !isdefined(Main, :InteractiveUtils)
+    if !isdefined(mod, :InteractiveUtils)
         try
             let InteractiveUtils = require(PkgId(UUID(0xb77e0a4c_d291_57a0_90e8_8db25a27a240), "InteractiveUtils"))
-                Core.eval(Main, :(const InteractiveUtils = $InteractiveUtils))
-                Core.eval(Main, :(using .InteractiveUtils))
+                Core.eval(mod, :(const InteractiveUtils = $InteractiveUtils))
+                Core.eval(mod, :(using .InteractiveUtils))
                 return InteractiveUtils
             end
         catch ex
-            @warn "Failed to import InteractiveUtils into module Main" exception=(ex, catch_backtrace())
+            @warn "Failed to import InteractiveUtils into module $mod" exception=(ex, catch_backtrace())
         end
         return nothing
     end
-    return getfield(Main, :InteractiveUtils)
+    return getfield(mod, :InteractiveUtils)
 end
 
 # run the requested sort of evaluation loop on stdio

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -238,7 +238,7 @@ function doc!(__module__::Module, b::Binding, str::DocStr, @nospecialize sig = U
         # that over-writing a docstring *may* have been accidental.  The warning
         # is suppressed for symbols in Main (or current active module),
         # for interactive use (#23011).
-        __module__ === Base.get_active_module() ||
+        __module__ === Base.active_module() ||
             @warn "Replacing docs for `$b :: $sig` in module `$(__module__)`"
     else
         # The ordering of docstrings for each Binding is defined by the order in which they

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -236,8 +236,10 @@ function doc!(__module__::Module, b::Binding, str::DocStr, @nospecialize sig = U
     if haskey(m.docs, sig)
         # We allow for docstrings to be updated, but print a warning since it is possible
         # that over-writing a docstring *may* have been accidental.  The warning
-        # is suppressed for symbols in Main, for interactive use (#23011).
-        __module__ === Main || @warn "Replacing docs for `$b :: $sig` in module `$(__module__)`"
+        # is suppressed for symbols in Main (or current active module),
+        # for interactive use (#23011).
+        __module__ === Base.get_active_module() ||
+            @warn "Replacing docs for `$b :: $sig` in module `$(__module__)`"
     else
         # The ordering of docstrings for each Binding is defined by the order in which they
         # are initially added. Replacing a specific docstring does not change it's ordering.

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -33,7 +33,7 @@ macro var(x)
 end
 
 function Base.show(io::IO, b::Binding)
-    if b.mod === Base.get_active_module()
+    if b.mod === Base.active_module()
         print(io, b.var)
     else
         print(io, b.mod, '.', Base.isoperator(b.var) ? ":" : "", b.var)

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -33,7 +33,7 @@ macro var(x)
 end
 
 function Base.show(io::IO, b::Binding)
-    if b.mod === Main
+    if b.mod === Base.get_active_module()
         print(io, b.var)
     else
         print(io, b.mod, '.', Base.isoperator(b.var) ? ":" : "", b.var)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -805,6 +805,7 @@ export
 # misc
     atexit,
     atreplinit,
+    activate_module,
     exit,
     ntuple,
     Splat,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -805,7 +805,6 @@ export
 # misc
     atexit,
     atreplinit,
-    activate_module,
     exit,
     ntuple,
     Splat,

--- a/base/show.jl
+++ b/base/show.jl
@@ -482,17 +482,17 @@ function _show_default(io::IO, @nospecialize(x))
     print(io,')')
 end
 
-get_active_module() = isdefined(Base, :active_repl) && isdefined(Base.active_repl, :mistate) ?
-    Base.active_repl.mistate.active_module :
-    Main
+active_module() = isdefined(Base, :active_repl) && isdefined(Base.active_repl, :mistate) ?
+                      Base.active_repl.mistate.active_module :
+                      Main
 
 # Check if a particular symbol is exported from a standard library module
 function is_exported_from_stdlib(name::Symbol, mod::Module)
     !isdefined(mod, name) && return false
     orig = getfield(mod, name)
     while !(mod === Base || mod === Core)
+        activemod = active_module()
         parent = parentmodule(mod)
-        activemod = get_active_module()
         if mod === activemod || mod === parent || parent === activemod
             return false
         end
@@ -708,7 +708,7 @@ function show_typealias(io::IO, name::GlobalRef, x::Type, env::SimpleVector, whe
         # Print module prefix unless alias is visible from module passed to
         # IOContext. If :module is not set, default to Main (or current active module).
         # nothing can be used to force printing prefix.
-        from = get(io, :module, get_active_module())
+        from = get(io, :module, active_module())
         if (from === nothing || !isvisible(name.name, name.mod, from))
             show(io, name.mod)
             print(io, ".")
@@ -1024,7 +1024,7 @@ function show_type_name(io::IO, tn::Core.TypeName)
         # Print module prefix unless type is visible from module passed to
         # IOContext If :module is not set, default to Main (or current active module).
         # nothing can be used to force printing prefix
-        from = get(io, :module, get_active_module())
+        from = get(io, :module, active_module())
         if isdefined(tn, :module) && (from === nothing || !isvisible(sym, tn.module, from))
             show(io, tn.module)
             print(io, ".")
@@ -2778,9 +2778,9 @@ MyStruct
 ```
 """
 function dump(arg; maxdepth=DUMP_DEFAULT_MAXDEPTH)
-    # this is typically used interactively, so default to being in Main
-    mod = get(stdout, :module, get_active_module())
-    dump(IOContext(stdout, :limit => true, :module => mod), arg; maxdepth=maxdepth)
+    # this is typically used interactively, so default to being in Main (or current active module)
+    mod = get(stdout, :module, active_module())
+    dump(IOContext(stdout::IO, :limit => true, :module => mod), arg; maxdepth=maxdepth)
 end
 
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -482,7 +482,7 @@ function _show_default(io::IO, @nospecialize(x))
     print(io,')')
 end
 
-active_module() = isdefined(Base, :active_repl) && isdefined(Base.active_repl, :mistate) && Base.active_repl.mistate !== nothing ?
+active_module()::Module = isdefined(Base, :active_repl) && isdefined(Base.active_repl, :mistate) && Base.active_repl.mistate !== nothing ?
                       Base.active_repl.mistate.active_module :
                       Main
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -482,7 +482,7 @@ function _show_default(io::IO, @nospecialize(x))
     print(io,')')
 end
 
-active_module() = isdefined(Base, :active_repl) && isdefined(Base.active_repl, :mistate) ?
+active_module() = isdefined(Base, :active_repl) && isdefined(Base.active_repl, :mistate) && Base.active_repl.mistate !== nothing ?
                       Base.active_repl.mistate.active_module :
                       Main
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -511,7 +511,7 @@ function show_function(io::IO, f::Function, compact::Bool, fallback::Function)
         print(io, mt.name)
     elseif isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
         getfield(mt.module, mt.name) === f
-        mod = get_active_module()
+        mod = active_module()
         if is_exported_from_stdlib(mt.name, mt.module) || mt.module === mod
             show_sym(io, mt.name)
         else

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -34,7 +34,7 @@ The memory consumption estimate is an approximate lower bound on the size of the
 - `sortby` : the column to sort results by. Options are `:name` (default), `:size`, and `:summary`.
 - `minsize` : only includes objects with size at least `minsize` bytes. Defaults to `0`.
 """
-function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name, recursive::Bool = false, minsize::Int=0)
+function varinfo(m::Module=Base.active_module(), pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name, recursive::Bool = false, minsize::Int=0)
     sortby in (:name, :size, :summary) || throw(ArgumentError("Unrecognized `sortby` value `:$sortby`. Possible options are `:name`, `:size`, and `:summary`"))
     rows = Vector{Any}[]
     workqueue = [(m, ""),]
@@ -45,7 +45,7 @@ function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported
                 continue
             end
             value = getfield(m2, v)
-            isbuiltin = value === Base || value === Main || value === Core
+            isbuiltin = value === Base || value === Base.active_module() || value === Core
             if recursive && !isbuiltin && isa(value, Module) && value !== m2 && nameof(value) === v && parentmodule(value) === m2
                 push!(workqueue, (value, "$prep$v."))
             end
@@ -75,7 +75,7 @@ function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported
 
     return Markdown.MD(Any[Markdown.Table(map(r->r[1:3], rows), Symbol[:l, :r, :l])])
 end
-varinfo(pat::Regex) = varinfo(get_active_module(), pat)
+varinfo(pat::Regex) = varinfo(Base.active_module(), pat)
 
 """
     versioninfo(io::IO=stdout; verbose::Bool=false)

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -75,7 +75,7 @@ function varinfo(m::Module=Base.active_module(), pattern::Regex=r""; all::Bool =
 
     return Markdown.MD(Any[Markdown.Table(map(r->r[1:3], rows), Symbol[:l, :r, :l])])
 end
-varinfo(pat::Regex) = varinfo(Base.active_module(), pat)
+varinfo(pat::Regex; kwargs...) = varinfo(Base.active_module(), pat; kwargs...)
 
 """
     versioninfo(io::IO=stdout; verbose::Bool=false)

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -75,7 +75,7 @@ function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported
 
     return Markdown.MD(Any[Markdown.Table(map(r->r[1:3], rows), Symbol[:l, :r, :l])])
 end
-varinfo(pat::Regex; kwargs...) = varinfo(Main, pat, kwargs...)
+varinfo(pat::Regex) = varinfo(get_active_module(), pat)
 
 """
     versioninfo(io::IO=stdout; verbose::Bool=false)

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -567,9 +567,10 @@ julia> @__MODULE__
 Main
 ```
 
-It is possible to change this contextual module via the `REPL.activate(m)` where `m` is a `Module` or by typing the
-module in the REPL and pressing the keybinding Alt-m (the cursor must be on
-the module name). The active module is shown in the prompt:
+It is possible to change this contextual module via the function
+`REPL.activate(m)` where `m` is a `Module` or by typing the module in the REPL
+and pressing the keybinding Alt-m (the cursor must be on the module name). The
+active module is shown in the prompt:
 
 ```julia-repl
 julia> using REPL
@@ -594,8 +595,9 @@ julia> Core<Alt-m> # using the keybinding to change module
 julia>
 ```
 
-Function that take an optional module argument often defaults to the REPL context module. As an example, calling `varinfo()` will show the
-variables of the current active module:
+Functions that take an optional module argument often defaults to the REPL
+context module. As an example, calling `varinfo()` will show the variables of
+the current active module:
 
 ```julia-repl
 julia> module CustomMod

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -557,6 +557,63 @@ ENV["JULIA_WARN_COLOR"] = :yellow
 ENV["JULIA_INFO_COLOR"] = :cyan
 ```
 
+
+## Changing the contextual module which is active at the REPL
+
+When entering expressions at the REPL, they are by default evaluated in the `Main` module;
+
+```julia-repl
+julia> @__MODULE__
+Main
+```
+
+It is possible to change this contextual module via the `REPL.activate(m)` where `m` is a `Module` or by typing the
+module in the REPL and pressing the keybinding Alt-m (the cursor must be on
+the module name). The active module is shown in the prompt:
+
+```julia-repl
+julia> using REPL
+
+julia> REPL.activate(Base)
+
+(Base) julia> @__MODULE__
+Base
+
+(Base) julia> using REPL # Need to load REPL into Base module to use it
+
+(Base) julia> REPL.activate(Main)
+
+julia>
+
+julia> Core<Alt-m> # using the keybinding to change module
+
+(Core) julia>
+
+(Core) julia> Main<Alt-m> # going back to Main via keybinding
+
+julia>
+```
+
+Function that take an optional module argument often defaults to the REPL context module. As an example, calling `varinfo()` will show the
+variables of the current active module:
+
+```julia-repl
+julia> module CustomMod
+           export var, f
+           var = 1
+           f(x) = x^2
+       end;
+
+julia> REPL.activate(CustomMod)
+
+(Main.CustomMod) julia> varinfo()
+  name         size summary
+  ––––––––– ––––––– ––––––––––––––––––––––––––––––––––
+  CustomMod         Module
+  f         0 bytes f (generic function with 1 method)
+  var       8 bytes Int64
+```
+
 ## TerminalMenus
 
 TerminalMenus is a submodule of the Julia REPL and enables small, low-profile interactive menus in the terminal.
@@ -718,28 +775,6 @@ Types that are derived from `TerminalMenus.ConfiguredMenu` configure the menu op
 
 Prior to Julia 1.6, and still supported throughout Julia 1.x, one can also configure menus by calling
 `TerminalMenus.config()`.
-
-## Changing the contextual module which is active at the REPL
-
-When entering expressions at the REPL, they are by default evaluated in the `Main` module.
-It is possible to change this contextual module via the `REPL.activate` function:
-
-```julia
-julia> <(0)
-(::Base.Fix2{typeof(<), Int64}) (generic function with 1 method)
-
-julia> import REPL; REPL.activate(Base)
-
-Base> <(0) # note `Fix2` is printed without the "Base." prefix
-(::Fix2{typeof(<), Int64}) (generic function with 1 method)
-
-Base> struct X end; parentmodule(X)
-Base
-```
-
-It is also possible to activate a module by typing the name of the module and
-using the `meta-mm` (`meta-m` followed by `m`) keybinding (the cursor must be on
-the name).
 
 ## References
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -747,7 +747,6 @@ the name).
 
 ```@docs
 Base.atreplinit
-Base.activate_module
 ```
 
 ### TerminalMenus

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -722,13 +722,13 @@ Prior to Julia 1.6, and still supported throughout Julia 1.x, one can also confi
 ## Changing the contextual module which is active at the REPL
 
 When entering expressions at the REPL, they are by default evaluated in the `Main` module.
-It is possible to change this contextual module via the `activate_module` function:
+It is possible to change this contextual module via the `REPL.activate` function:
 
 ```julia
 julia> <(0)
 (::Base.Fix2{typeof(<), Int64}) (generic function with 1 method)
 
-julia> activate_module(Base)
+julia> import REPL; REPL.activate(Base)
 
 Base> <(0) # note `Fix2` is printed without the "Base." prefix
 (::Fix2{typeof(<), Int64}) (generic function with 1 method)
@@ -736,6 +736,10 @@ Base> <(0) # note `Fix2` is printed without the "Base." prefix
 Base> struct X end; parentmodule(X)
 Base
 ```
+
+It is also possible to activate a module by typing the name of the module and
+using the `meta-mm` (`meta-m` followed by `m`) keybinding (the cursor must be on
+the name).
 
 ## References
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -719,12 +719,31 @@ Types that are derived from `TerminalMenus.ConfiguredMenu` configure the menu op
 Prior to Julia 1.6, and still supported throughout Julia 1.x, one can also configure menus by calling
 `TerminalMenus.config()`.
 
+## Changing the contextual module which is active at the REPL
+
+When entering expressions at the REPL, they are by default evaluated in the `Main` module.
+It is possible to change this contextual module via the `activate_module` function:
+
+```julia
+julia> <(0)
+(::Base.Fix2{typeof(<), Int64}) (generic function with 1 method)
+
+julia> activate_module(Base)
+
+Base> <(0) # note `Fix2` is printed without the "Base." prefix
+(::Fix2{typeof(<), Int64}) (generic function with 1 method)
+
+Base> struct X end; parentmodule(X)
+Base
+```
+
 ## References
 
 ### REPL
 
 ```@docs
 Base.atreplinit
+Base.activate_module
 ```
 
 ### TerminalMenus

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -63,6 +63,7 @@ show(io::IO, x::Prompt) = show(io, string("Prompt(\"", prompt_string(x.prompt), 
 
 mutable struct MIState
     interface::ModalInterface
+    active_module::Module
     current_mode::TextInterface
     aborted::Bool
     mode_state::IdDict{TextInterface,ModeState}
@@ -74,7 +75,7 @@ mutable struct MIState
     current_action::Symbol
 end
 
-MIState(i, c, a, m) = MIState(i, c, a, m, String[], 0, Char[], 0, :none, :none)
+MIState(i, mod, c, a, m) = MIState(i, mod, c, a, m, String[], 0, Char[], 0, :none, :none)
 
 const BufferLike = Union{MIState,ModeState,IOBuffer}
 const State = Union{MIState,ModeState}
@@ -175,7 +176,10 @@ struct EmptyHistoryProvider <: HistoryProvider end
 
 reset_state(::EmptyHistoryProvider) = nothing
 
-complete_line(c::EmptyCompletionProvider, s) = String[], "", true
+complete_line(c::EmptyCompletionProvider, s, mod) = String[], "", true
+
+# for Pkg which specializes complete_line with only 2 arguments
+complete_line(c::CompletionProvider, s, ::Module) = complete_line(c, s)
 
 terminal(s::IO) = s
 terminal(s::PromptState) = s.terminal
@@ -343,7 +347,7 @@ end
 # Prompt Completions
 function complete_line(s::MIState)
     set_action!(s, :complete_line)
-    if complete_line(state(s), s.key_repeats)
+    if complete_line(state(s), s.key_repeats, s.active_module)
         return refresh_line(s)
     else
         beep(s)
@@ -351,8 +355,8 @@ function complete_line(s::MIState)
     end
 end
 
-function complete_line(s::PromptState, repeats::Int)
-    completions, partial, should_complete = complete_line(s.p.complete, s)::Tuple{Vector{String},String,Bool}
+function complete_line(s::PromptState, repeats::Int, mod::Module)
+    completions, partial, should_complete = complete_line(s.p.complete, s, mod)::Tuple{Vector{String},String,Bool}
     isempty(completions) && return false
     if !should_complete
         # should_complete is false for cases where we only want to show
@@ -1962,8 +1966,8 @@ setmodifiers!(p::Prompt, m::Modifiers) = setmodifiers!(p.complete, m)
 setmodifiers!(c) = nothing
 
 # Search Mode completions
-function complete_line(s::SearchState, repeats)
-    completions, partial, should_complete = complete_line(s.histprompt.complete, s)
+function complete_line(s::SearchState, repeats, mod::Module)
+    completions, partial, should_complete = complete_line(s.histprompt.complete, s, mod)
     # For now only allow exact completions in search mode
     if length(completions) == 1
         prev_pos = position(s)
@@ -2537,7 +2541,7 @@ init_state(terminal, prompt::Prompt) =
                 #=indent(spaces)=# -1, Threads.SpinLock(), 0.0, -Inf, nothing)
 
 function init_state(terminal, m::ModalInterface)
-    s = MIState(m, m.modes[1], false, IdDict{Any,Any}())
+    s = MIState(m, Main, m.modes[1], false, IdDict{Any,Any}())
     for mode in m.modes
         s.mode_state[mode] = init_state(terminal, mode)
     end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1384,7 +1384,7 @@ function activate_module(s::MIState)
     try
         mod = Base.Core.eval(Base.active_module(), Base.Meta.parse(word))
         REPL.activate(mod)
-        Base.Core.eval(mod, :(using InteractiveUtils))
+        Base.load_InteractiveUtils(mod)
         refresh_line(s)
     catch
         beep(s)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1384,7 +1384,7 @@ function activate_module(s::MIState)
         mod = Base.Core.eval(Base.active_module(), Base.Meta.parse(word))
         REPL.activate(mod)
         Base.load_InteractiveUtils(mod)
-        refresh_line(s)
+        edit_clear(s)
     catch
         beep(s)
     end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1383,7 +1383,6 @@ function activate_module(s::MIState)
     try
         mod = Base.Core.eval(Base.active_module(), Base.Meta.parse(word))
         REPL.activate(mod)
-        Base.load_InteractiveUtils(mod)
         edit_clear(s)
     catch
         beep(s)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2432,7 +2432,7 @@ AnyDict(
     "\el" => (s::MIState,o...)->edit_lower_case(s),
     "\ec" => (s::MIState,o...)->edit_title_case(s),
     "\ee" => (s::MIState,o...) -> edit_input(s),
-    "\emm" => (s::MIState, o...) -> activate_module(s)
+    "\em" => (s::MIState, o...) -> activate_module(s)
 )
 
 const history_keymap = AnyDict(

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -176,9 +176,10 @@ struct EmptyHistoryProvider <: HistoryProvider end
 
 reset_state(::EmptyHistoryProvider) = nothing
 
-complete_line(c::EmptyCompletionProvider, s, mod) = String[], "", true
+complete_line(c::EmptyCompletionProvider, s) = String[], "", true
 
-# for Pkg which specializes complete_line with only 2 arguments
+# complete_line can be specialized for only two arguments, when the active module
+# doesn't matter (e.g. Pkg does this)
 complete_line(c::CompletionProvider, s, ::Module) = complete_line(c, s)
 
 terminal(s::IO) = s

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2431,11 +2431,8 @@ AnyDict(
     "\eu" => (s::MIState,o...)->edit_upper_case(s),
     "\el" => (s::MIState,o...)->edit_lower_case(s),
     "\ec" => (s::MIState,o...)->edit_title_case(s),
-<<<<<<< HEAD
     "\ee" => (s::MIState,o...) -> edit_input(s),
-=======
     "\emm" => (s::MIState, o...) -> activate_module(s)
->>>>>>> 88db0e9418 (use a keybinding to activate modules and delete Base.activate_module)
 )
 
 const history_keymap = AnyDict(

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2473,6 +2473,7 @@ const prefix_history_keymap = merge!(
         end,
         # match escape sequences for pass through
         "^x*" => "*",
+        "\em*" => "*",
         "\e*" => "*",
         "\e[*" => "*",
         "\eO*"  => "*",

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1302,7 +1302,6 @@ _edit_indent(buf::IOBuffer, b::Int, num::Int) =
     num >= 0 ? edit_splice!(buf, b => b, ' '^num, rigid_mark=false) :
                edit_splice!(buf, b => (b - num))
 
-<<<<<<< HEAD
 function mode_idx(hist::HistoryProvider, mode::TextInterface)
     c = :julia
     for (k,v) in hist.mode_mapping

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1382,8 +1382,9 @@ function activate_module(s::MIState)
     word = current_word_with_dots(s);
     isempty(word) && return beep(s)
     try
-        REPL.activate(Base.Core.eval(Base.active_module(),
-                                     Base.Meta.parse(word)))
+        mod = Base.Core.eval(Base.active_module(), Base.Meta.parse(word))
+        REPL.activate(mod)
+        Base.Core.eval(mod, :(using InteractiveUtils))
         refresh_line(s)
     catch
         beep(s)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -496,6 +496,16 @@ active_module(::AbstractREPL) = Main
 active_module(d::REPLDisplay) = active_module(d.repl)
 
 setmodifiers!(c::REPLCompletionProvider, m::LineEdit.Modifiers) = c.modifiers = m
+"""
+    activate(mod::Module=Main)
+
+Set `mod` as the default contextual module in the REPL,
+both for evaluating expressions and printing them.
+"""
+function activate(mod::Module=Main)
+    Base.active_repl.mistate.active_module = mod
+    nothing
+end
 
 beforecursor(buf::IOBuffer) = String(buf.data[1:buf.ptr-1])
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -491,7 +491,7 @@ REPLCompletionProvider() = REPLCompletionProvider(LineEdit.Modifiers())
 mutable struct ShellCompletionProvider <: CompletionProvider end
 struct LatexCompletions <: CompletionProvider end
 
-active_module(repl::LineEditREPL) = repl.mistate.active_module
+active_module(repl::LineEditREPL) = repl.mistate === nothing ? Main : repl.mistate.active_module
 active_module(::AbstractREPL) = Main
 active_module(d::REPLDisplay) = active_module(d.repl)
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -927,13 +927,9 @@ enable_promptpaste(v::Bool) = JL_PROMPT_PASTE[] = v
 function contextual_prompt(repl::LineEditREPL, prompt::Union{String,Function})
     function ()
         mod = active_module(repl)
-        if prompt == JULIA_PROMPT
-            mod == Main ? prompt : string(mod, "> ")
-        else
-            prefix = mod == Main ? "" : string('(', mod, ") ")
-            pr = prompt isa String ? prompt : prompt()
-            prefix * pr
-        end
+        prefix = mod == Main ? "" : string('(', mod, ") ")
+        pr = prompt isa String ? prompt : prompt()
+        prefix * pr
     end
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -517,7 +517,7 @@ function complete_line(c::REPLCompletionProvider, s::PromptState, mod::Module)
     return unique!(map(completion_text, ret)), partial[range], should_complete
 end
 
-function complete_line(c::ShellCompletionProvider, s::PromptState, ::Module)
+function complete_line(c::ShellCompletionProvider, s::PromptState)
     # First parse everything up to the current position
     partial = beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
@@ -525,7 +525,7 @@ function complete_line(c::ShellCompletionProvider, s::PromptState, ::Module)
     return unique!(map(completion_text, ret)), partial[range], should_complete
 end
 
-function complete_line(c::LatexCompletions, s, ::Module)
+function complete_line(c::LatexCompletions, s)
     partial = beforecursor(LineEdit.buffer(s))
     full = LineEdit.input_string(s)::String
     ret, range, should_complete = bslash_completions(full, lastindex(partial))[2]
@@ -926,10 +926,14 @@ enable_promptpaste(v::Bool) = JL_PROMPT_PASTE[] = v
 
 function contextual_prompt(repl::LineEditREPL, prompt::Union{String,Function})
     function ()
-        mod = repl.mistate.active_module
-        prefix = mod == Main ? "" : string('(', mod, ") ")
-        pr = prompt isa String ? prompt : prompt()
-        prefix * pr
+        mod = active_module(repl)
+        if prompt == JULIA_PROMPT
+            mod == Main ? prompt : string(mod, "> ")
+        else
+            prefix = mod == Main ? "" : string('(', mod, ") ")
+            pr = prompt isa String ? prompt : prompt()
+            prefix * pr
+        end
     end
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -504,6 +504,7 @@ both for evaluating expressions and printing them.
 """
 function activate(mod::Module=Main)
     Base.active_repl.mistate.active_module = mod
+    Base.load_InteractiveUtils(mod)
     nothing
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -221,7 +221,7 @@ end
 
 """
     start_repl_backend(backend::REPLBackend)
-p
+
     Call directly to run backend loop on current Task.
     Use @async for run backend on new Task.
 

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -20,8 +20,8 @@ using Unicode: normalize
 ## Help mode ##
 
 # This is split into helpmode and _helpmode to easier unittest _helpmode
-helpmode(io::IO, line::AbstractString, mod::Module) = :($REPL.insert_hlines($io, $(REPL._helpmode(io, line, mod))))
-helpmode(line::AbstractString, mod::Module) = helpmode(stdout, line, mod)
+helpmode(io::IO, line::AbstractString, mod::Module=Main) = :($REPL.insert_hlines($io, $(REPL._helpmode(io, line, mod))))
+helpmode(line::AbstractString, mod::Module=Main) = helpmode(stdout, line, mod)
 
 const extended_help_on = Ref{Any}(nothing)
 

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -478,8 +478,8 @@ function repl(io::IO, s::Symbol; brief::Bool=true, mod::Module=Main)
 end
 isregex(x) = isexpr(x, :macrocall, 3) && x.args[1] === Symbol("@r_str") && !isempty(x.args[3])
 
-repl(io::IO, ex::Expr; brief::Bool=true, mod::Module=Main) = isregex(ex) ? :(apropos($io, $ex, $mod)) : _repl(ex, brief)
-repl(io::IO, str::AbstractString; brief::Bool=true, mod::Module=Main) = :(apropos($io, $str, $mod))
+repl(io::IO, ex::Expr; brief::Bool=true, mod::Module=Main) = isregex(ex) ? :(apropos($io, $ex)) : _repl(ex, brief)
+repl(io::IO, str::AbstractString; brief::Bool=true, mod::Module=Main) = :(apropos($io, $str))
 repl(io::IO, other; brief::Bool=true, mod::Module=Main) = esc(:(@doc $other))
 #repl(io::IO, other) = lookup_doc(other) # TODO
 

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -66,7 +66,7 @@ function _helpmode(io::IO, line::AbstractString, mod::Module=Main)
     # so that the resulting expressions are evaluated in the Base.Docs namespace
     :($REPL.@repl $io $expr $brief $mod)
 end
-_helpmode(line::AbstractString) = _helpmode(stdout, line)
+_helpmode(line::AbstractString, mod::Module=Main) = _helpmode(stdout, line, mod)
 
 # Print vertical lines along each docstring if there are multiple docs
 function insert_hlines(io::IO, docs)
@@ -375,7 +375,9 @@ function repl_search(io::IO, s::Union{Symbol,String}, mod::Module)
     printmatches(io, s, map(quote_spaces, doc_completions(s, mod)), cols = _displaysize(io)[2] - length(pre))
     println(io, "\n")
 end
-repl_search(s) = repl_search(stdout, s, mod)
+
+# TODO: document where this is used
+repl_search(s, mod::Module) = repl_search(stdout, s, mod)
 
 function repl_corrections(io::IO, s, mod::Module)
     print(io, "Couldn't find ")
@@ -707,7 +709,8 @@ function print_correction(io::IO, word::String, mod::Module)
     return
 end
 
-print_correction(word) = print_correction(stdout, word, Main)
+# TODO: document where this is used
+print_correction(word, mod::Module) = print_correction(stdout, word, mod)
 
 # Completion data
 
@@ -722,7 +725,7 @@ accessible(mod::Module) =
            collect(keys(Base.Docs.keywords))] |> unique |> filtervalid
 
 function doc_completions(name, mod::Module=Main)
-    res = fuzzysort(name, accessible(Main))
+    res = fuzzysort(name, accessible(mod))
 
     # to insert an entry like `raw""` for `"@raw_str"` in `res`
     ms = match.(r"^@(.*?)_str$", res)
@@ -734,7 +737,7 @@ function doc_completions(name, mod::Module=Main)
     end
     res
 end
-doc_completions(name::Symbol) = doc_completions(string(name))
+doc_completions(name::Symbol) = doc_completions(string(name), mod)
 
 
 # Searching and apropos

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -20,12 +20,12 @@ using Unicode: normalize
 ## Help mode ##
 
 # This is split into helpmode and _helpmode to easier unittest _helpmode
-helpmode(io::IO, line::AbstractString) = :($REPL.insert_hlines($io, $(REPL._helpmode(io, line))))
-helpmode(line::AbstractString) = helpmode(stdout, line)
+helpmode(io::IO, line::AbstractString, mod::Module) = :($REPL.insert_hlines($io, $(REPL._helpmode(io, line, mod))))
+helpmode(line::AbstractString, mod::Module) = helpmode(stdout, line, mod)
 
 const extended_help_on = Ref{Any}(nothing)
 
-function _helpmode(io::IO, line::AbstractString)
+function _helpmode(io::IO, line::AbstractString, mod::Module=Main)
     line = strip(line)
     ternary_operator_help = (line == "?" || line == "?:")
     if startswith(line, '?') && !ternary_operator_help
@@ -64,7 +64,7 @@ function _helpmode(io::IO, line::AbstractString)
         end
     # the following must call repl(io, expr) via the @repl macro
     # so that the resulting expressions are evaluated in the Base.Docs namespace
-    :($REPL.@repl $io $expr $brief)
+    :($REPL.@repl $io $expr $brief $mod)
 end
 _helpmode(line::AbstractString) = _helpmode(stdout, line)
 
@@ -369,21 +369,21 @@ end
 
 quote_spaces(x) = any(isspace, x) ? "'" * x * "'" : x
 
-function repl_search(io::IO, s::Union{Symbol,String})
+function repl_search(io::IO, s::Union{Symbol,String}, mod::Module)
     pre = "search:"
     print(io, pre)
-    printmatches(io, s, map(quote_spaces, doc_completions(s)), cols = _displaysize(io)[2] - length(pre))
+    printmatches(io, s, map(quote_spaces, doc_completions(s, mod)), cols = _displaysize(io)[2] - length(pre))
     println(io, "\n")
 end
-repl_search(s) = repl_search(stdout, s)
+repl_search(s) = repl_search(stdout, s, mod)
 
-function repl_corrections(io::IO, s)
+function repl_corrections(io::IO, s, mod::Module)
     print(io, "Couldn't find ")
     quot = any(isspace, s) ? "'" : ""
     print(io, quot)
     printstyled(io, s, color=:cyan)
     print(io, quot, '\n')
-    print_correction(io, s)
+    print_correction(io, s, mod)
 end
 repl_corrections(s) = repl_corrections(stdout, s)
 
@@ -460,27 +460,28 @@ function repl_latex(io::IO, s0::String)
 end
 repl_latex(s::String) = repl_latex(stdout, s)
 
-macro repl(ex, brief::Bool=false) repl(ex; brief=brief) end
-macro repl(io, ex, brief) repl(io, ex; brief=brief) end
+macro repl(ex, brief::Bool=false, mod::Module=Main) repl(ex; brief, mod) end
+macro repl(io, ex, brief, mod) repl(io, ex; brief, mod) end
 
-function repl(io::IO, s::Symbol; brief::Bool=true)
+function repl(io::IO, s::Symbol; brief::Bool=true, mod::Module=Main)
     str = string(s)
     quote
         repl_latex($io, $str)
-        repl_search($io, $str)
-        $(if !isdefined(Main, s) && !haskey(keywords, s) && !Base.isoperator(s)
-               :(repl_corrections($io, $str))
+        repl_search($io, $str, $mod)
+        $(if !isdefined(mod, s) && !haskey(keywords, s) && !Base.isoperator(s)
+               :(repl_corrections($io, $str, $mod))
           end)
         $(_repl(s, brief))
     end
 end
 isregex(x) = isexpr(x, :macrocall, 3) && x.args[1] === Symbol("@r_str") && !isempty(x.args[3])
-repl(io::IO, ex::Expr; brief::Bool=true) = isregex(ex) ? :(apropos($io, $ex)) : _repl(ex, brief)
-repl(io::IO, str::AbstractString; brief::Bool=true) = :(apropos($io, $str))
-repl(io::IO, other; brief::Bool=true) = esc(:(@doc $other))
+
+repl(io::IO, ex::Expr; brief::Bool=true, mod::Module=Main) = isregex(ex) ? :(apropos($io, $ex, $mod)) : _repl(ex, brief)
+repl(io::IO, str::AbstractString; brief::Bool=true, mod::Module=Main) = :(apropos($io, $str, $mod))
+repl(io::IO, other; brief::Bool=true, mod::Module=Main) = esc(:(@doc $other))
 #repl(io::IO, other) = lookup_doc(other) # TODO
 
-repl(x; brief::Bool=true) = repl(stdout, x; brief=brief)
+repl(x; brief::Bool=true, mod::Module=Main) = repl(stdout, x; brief, mod)
 
 function _repl(x, brief::Bool=true)
     if isexpr(x, :call)
@@ -697,8 +698,8 @@ end
 
 print_joined_cols(args...; cols::Int = _displaysize(stdout)[2]) = print_joined_cols(stdout, args...; cols=cols)
 
-function print_correction(io::IO, word::String)
-    cors = map(quote_spaces, levsort(word, accessible(Main)))
+function print_correction(io::IO, word::String, mod::Module)
+    cors = map(quote_spaces, levsort(word, accessible(mod)))
     pre = "Perhaps you meant "
     print(io, pre)
     print_joined_cols(io, cors, ", ", " or "; cols = _displaysize(io)[2] - length(pre))
@@ -706,7 +707,7 @@ function print_correction(io::IO, word::String)
     return
 end
 
-print_correction(word) = print_correction(stdout, word)
+print_correction(word) = print_correction(stdout, word, Main)
 
 # Completion data
 
@@ -720,7 +721,7 @@ accessible(mod::Module) =
            map(names, moduleusings(mod))...;
            collect(keys(Base.Docs.keywords))] |> unique |> filtervalid
 
-function doc_completions(name)
+function doc_completions(name, mod::Module=Main)
     res = fuzzysort(name, accessible(Main))
 
     # to insert an entry like `raw""` for `"@raw_str"` in `res`

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1114,7 +1114,7 @@ fake_repl() do stdin_write, stdout_read, repl
 
     repl.mistate.active_module = Base # simulate activate_module(Base)
     write(stdin_write, "(456, Base.Fix2)\n")
-    @test occursin("Base> ", split(readline(stdout_read), "Base.Fix2")[2])
+    @test occursin("(Base) julia> ", split(readline(stdout_read), "Base.Fix2")[2])
     # ".Base" prefix not shown here
     @test occursin("(456, Fix2)", readline(stdout_read))
     readline(stdout_read)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -478,6 +478,7 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
 
         # Some manual setup
         s = LineEdit.init_state(repl.t, repl.interface)
+        repl.mistate = s
         LineEdit.edit_insert(s, "wip")
 
         # LineEdit functions related to history
@@ -1096,7 +1097,34 @@ fake_repl() do stdin_write, stdout_read, repl
     Base.wait(repltask)
 end
 
-help_result(line) = Base.eval(REPL._helpmode(IOBuffer(), line))
+# test activate_module
+fake_repl() do stdin_write, stdout_read, repl
+    repl.history_file = false
+    repl.interface = REPL.setup_interface(repl)
+    repl.mistate = LineEdit.init_state(repl.t, repl.interface)
+
+    repltask = @async begin
+        REPL.run_repl(repl)
+    end
+
+    write(stdin_write, "(123, Base.Fix1)\n")
+    @test occursin("julia> ", split(readline(stdout_read), "Base.Fix1")[2])
+    @test occursin("(123, Base.Fix1)", readline(stdout_read))
+    readline(stdout_read)
+
+    repl.mistate.active_module = Base # simulate activate_module(Base)
+    write(stdin_write, "(456, Base.Fix2)\n")
+    @test occursin("Base> ", split(readline(stdout_read), "Base.Fix2")[2])
+    # ".Base" prefix not shown here
+    @test occursin("(456, Fix2)", readline(stdout_read))
+    readline(stdout_read)
+
+    # Close REPL ^D
+    write(stdin_write, '\x04')
+    Base.wait(repltask)
+end
+
+help_result(line, mod::Module=Base) = mod.eval(REPL._helpmode(IOBuffer(), line))
 
 # Docs.helpmode tests: we test whether the correct expressions are being generated here,
 # rather than complete integration with Julia's REPL mode system.
@@ -1139,6 +1167,13 @@ end
 
 # Issue #40563
 @test occursin("does not exist", sprint(show, help_result("..")))
+# test that helpmode is sensitive to contextual module
+@test occursin("No documentation found", sprint(show, help_result("Fix2", Main)))
+@test occursin("A type representing a partially-applied version", # exact string may change
+               sprint(show, help_result("Base.Fix2", Main)))
+@test occursin("A type representing a partially-applied version", # exact string may change
+               sprint(show, help_result("Fix2", Base)))
+
 
 # Issue #25930
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -7,7 +7,7 @@ using REPL
     @testset "Check symbols previously not shown by REPL.doc_completions()" begin
     symbols = ["?","=","[]","[","]","{}","{","}",";","","'","&&","||","julia","Julia","new","@var_str"]
         for i in symbols
-            @test i ∈ REPL.doc_completions(i)
+            @test i ∈ REPL.doc_completions(i, Main)
         end
     end
 let ex = quote


### PR DESCRIPTION
`Main` remains the default module in which REPL expressions
are `eval`ed, but it's possible to switch to a module `Mod` via
`activate_module(Mod)`. The default prompt then indicates this,
e.g. `(Mod) julia> `.

When not using `Revise`, this can be quite useful to work on a module (e.g. a workflow is redefine function `f` from a module, but first a bunch of `import Mod: ...` and/or `using Mod: ...` have to be typed for internal functions/constants used in `f`. With this change, copy-pasting the function from the module definitions into the REPL works out of the box).