### PR TITLE
fix order of multiplication in axpy! docstring

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -422,7 +422,7 @@ asum(x::Union{AbstractVector,DenseArray}) = GC.@preserve x asum(length(x), point
 """
     axpy!(a, X, Y)
 
-Overwrite `Y` with `a*X + Y`, where `a` is a scalar. Return `Y`.
+Overwrite `Y` with `X*a + Y`, where `a` is a scalar. Return `Y`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This doesn't matter for BLAS, but it's the only docstring we have, and therefore handles the generic case as well, in which we multiply from the right. Consistently with `axpby!`.