### PR TITLE
clarify error handling during task switches

### DIFF
--- a/test/channels.jl
+++ b/test/channels.jl
@@ -455,4 +455,5 @@ end
 let t = @async nothing
     wait(t)
     @test_throws ErrorException("schedule: Task not runnable") schedule(t, nothing)
+    @test_throws ErrorException("yield: Task not runnable") yield(t)
 end


### PR DESCRIPTION
The goal of this is to separate the cases (1) where we're switching to a queued task obeying scheduler invariants, vs. (2) the user asks to switch to an arbitrary task, in which case we need more error checking. To that end, this factors out `unsafe_schedule`, `unsafe_wait`, and `unsafe_yieldto` from error checking.

Another goal is to avoid needing to catch exceptions and re-queue tasks. If we're trying to block at a program point where it's not allowed, an error should be thrown early. If we're trying to switch to an invalid task, then either the error should have been caught when that task was queued, or there is a bug in the scheduler.