### PR TITLE
make spawn faster by fixing the sync context check

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -350,7 +350,7 @@ macro async(expr)
     var = esc(sync_varname)
     quote
         local task = Task($thunk)
-        if $(Expr(:isdefined, var))
+        if $(Expr(:islocal, var))
             push!($var, task)
         end
         schedule(task)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -115,7 +115,7 @@ macro spawn(expr)
     quote
         local task = Task($thunk)
         task.sticky = false
-        if $(Expr(:isdefined, var))
+        if $(Expr(:islocal, var))
             push!($var, task)
         end
         schedule(task)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2495,6 +2495,10 @@
                                    (call (top setindex!) ,d ,var (quote ,v)))))
                           names)
                    ,d)))
+        ((eq? (car e) 'islocal)
+         (if (memq (var-kind (cadr e) scope) '(global none))
+             'false
+             'true))
         ((eq? (car e) 'lambda)
          (let* ((args (lam:vars e))
                 (body (resolve-scopes- (lam:body e) (make-scope e args '() '() sp '() scope))))

--- a/stdlib/Distributed/src/macros.jl
+++ b/stdlib/Distributed/src/macros.jl
@@ -48,7 +48,7 @@ macro spawn(expr)
     var = esc(Base.sync_varname)
     quote
         local ref = spawn_somewhere($thunk)
-        if $(Expr(:isdefined, var))
+        if $(Expr(:islocal, var))
             push!($var, ref)
         end
         ref
@@ -93,7 +93,7 @@ macro spawnat(p, expr)
     end
     quote
         local ref = $spawncall
-        if $(Expr(:isdefined, var))
+        if $(Expr(:islocal, var))
             push!($var, ref)
         end
         ref
@@ -346,7 +346,7 @@ macro distributed(args...)
         syncvar = esc(Base.sync_varname)
         return quote
             local ref = pfor($(make_pfor_body(var, body)), $(esc(r)))
-            if $(Expr(:isdefined, syncvar))
+            if $(Expr(:islocal, syncvar))
                 push!($syncvar, ref)
             end
             ref


### PR DESCRIPTION
I discovered that a lot of overhead in `@spawn` comes from the check for a surrounding `@sync` block. When there isn't one, we need to do an expensive global lookup. This is a hack to instead check whether a local variable with the given name exists. It brings my standard task overhead benchmark (`fib(31)` with 2 threads) from ~3.6 seconds to ~3 seconds.