### PR TITLE
Use `cache.julialang.org` to download `busybox.exe` at test time

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -20,7 +20,7 @@ sleepcmd = `sleep`
 lscmd = `ls`
 havebb = false
 if Sys.iswindows()
-    busybox = download("https://frippery.org/files/busybox/busybox.exe", joinpath(tempdir(), "busybox.exe"))
+    busybox = download("https://cache.julialang.org/https://frippery.org/files/busybox/busybox.exe", joinpath(tempdir(), "busybox.exe"))
     havebb = try # use busybox-w32 on windows, if available
         success(`$busybox`)
         true


### PR DESCRIPTION
This should hopefully fix the issues we've been having with downloading `busybox.exe` on the windows buildbots recently; I believe those IP addresses may have been blacklisted, as we successfully connect to the `frippery.org` server, but get an `HTTP 403` on 3/4 of the windows buildbots.  By using our own caching server we are better netizens both by not hitting someone else's server a bunch, but also by keeping our CI traffic datacenter-local!