### PR TITLE
A legendary tale of why we should make pmap default to using CachingPool

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@ New library features
 Standard library changes
 ------------------------
 
+* `pmap` now defaults to using a `CachingPool` ([#33892]).
+
 #### Package Manager
 
 #### LinearAlgebra

--- a/stdlib/Distributed/src/pmap.jl
+++ b/stdlib/Distributed/src/pmap.jl
@@ -40,8 +40,8 @@ For multiple collection arguments, apply `f` elementwise.
 Note that `f` must be made available to all worker processes; see
 [Code Availability and Loading Packages](@ref code-availability) for details.
 
-If a worker pool is not specified, all available workers, i.e., the default worker pool
-is used.
+If a worker pool is not specified all available workers will be used via a [`CachingPool`](@ref).
+
 
 By default, `pmap` distributes the computation over all specified workers. To use only the
 local process and distribute over tasks, specify `distributed=false`.
@@ -153,7 +153,7 @@ function pmap(f, p::AbstractWorkerPool, c; distributed=true, batch_size=1, on_er
 end
 
 pmap(f, p::AbstractWorkerPool, c1, c...; kwargs...) = pmap(a->f(a...), p, zip(c1, c...); kwargs...)
-pmap(f, c; kwargs...) = pmap(f, default_worker_pool(), c; kwargs...)
+pmap(f, c; kwargs...) = pmap(f, CachingPool(workers()), c; kwargs...)
 pmap(f, c1, c...; kwargs...) = pmap(a->f(a...), zip(c1, c...); kwargs...)
 
 function wrap_on_error(f, on_error; capture_data=false)


### PR DESCRIPTION
Once upon a time, there was a young julia user first getting started with parallelism.
And she found it fearsomely slow.
And so she did investigate, and she did illuminate upon her issue.
Her closures, they were being reserialized again and again.
And so this young woman, she openned an issue JuliaLang/julia#16345.
Lo and behold, a noble soul did come and resolve it,
by making the glorious `CachingPool()` in JuliaLang/julia#16808.

3 long years a later this julia user did bravely return to the world of parallism, with many battle worn scars.
and once more she did face the demon that is `pmap` over closures.
But to her folly, she felt no fear, for she believed the demon to be crippled and chained by the glorious `CachingPool`.
Fearlessly, she threw his closure over 2GB of data into the maw of the demon `pmap`.
But alas, alas indeed, she was wrong.
The demon remained unbound, and it slew her, and slew her again.
100 times did it slay her for 101 items was the user iterating upon. 
For the glorious chains of the the `CachingPool()` remains unused, left aside in the users tool chest, forgotten.