### PR TITLE
[build] read uninstall from manifest

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -23,19 +23,14 @@ BUILDDIR := $(BUILDDIR)$(MAYBE_HOST)
 # additionally all targets should be listed in the getall target for easier off-line compilation
 # if you are adding a new target, it can help to copy an similar, existing target
 #
-# autoconf configure-driven scripts: llvm pcre unwind gmp mpfr patchelf libuv curl
+# autoconf configure-driven scripts: pcre unwind gmp mpfr patchelf libuv curl
 # custom Makefile rules: openlibm dsfmt suitesparse-wrapper suitesparse lapack openblas utf8proc objconv osxunwind libwhich
-# CMake libs: libgit2 libssh2 mbedtls
+# CMake libs: llvm libgit2 libssh2 mbedtls
 #
-# downloaded from git: llvm-svn, libuv, libopenlibm, utf8proc, libgit2, libssh2
-#
-# there are rules in this file with the . replaced by a %
-# this is some magic Makefile trick that tells make
-# that all targets with a % in them on that line will
-# be rebuilt in a single invocation
+# downloadable via git: llvm-svn, libuv, libopenlibm, utf8proc, libgit2, libssh2
 #
 # to debug 'define' rules, replace eval at the usage site with info or error
-#
+
 
 ## Overall configuration of which rules exist and should be run by default ##
 
@@ -162,7 +157,7 @@ ifneq ($(OS), WINNT)
 DEP_LIBS += libwhich
 endif
 
-DEP_LIBS_STAGED := $(filter-out suitesparse suitesparse-wrapper osxunwind,$(DEP_LIBS)) # unlist targets that have not been converted to use the staged-install
+DEP_LIBS_STAGED := $(filter-out suitesparse-wrapper osxunwind,$(DEP_LIBS)) # unlist targets that have not been converted to use the staged-install
 
 
 ## Common build target prefixes
@@ -176,7 +171,6 @@ check: $(addprefix check-, $(DEP_LIBS))
 fastcheck: $(addprefix fastcheck-, $(DEP_LIBS))
 stage: $(addprefix stage-, $(DEP_LIBS_STAGED))
 install: $(addprefix install-, $(DEP_LIBS))
-uninstall: $(addprefix uninstall-, $(DEP_LIBS_STAGED))
 cleanall: $(addprefix clean-, $(DEP_LIBS))
 distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)
@@ -202,3 +196,5 @@ include $(SRCDIR)/libgit2.mk
 include $(SRCDIR)/libwhich.mk
 include $(SRCDIR)/zlib.mk
 include $(SRCDIR)/p7zip.mk
+
+include $(SRCDIR)/tools/uninstallers.mk

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -554,7 +554,8 @@ check-llvm: $(LLVM_BUILDDIR_withtype)/build-checked
 
 ifeq ($(LLVM_VER),svn)
 update-llvm:
-	(cd $(LLVM_MONOSRC_DIR); git pull --ff-only)
+	cd $(LLVM_MONOSRC_DIR) && \
+		git pull --ff-only
 endif
 else # USE_BINARYBUILDER_LLVM
 LLVM_BB_URL_BASE := https://github.com/staticfloat/LLVMBuilder/releases/download/v$(LLVM_VER)+$(LLVM_BB_REL)

--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -1,3 +1,9 @@
+#$(call bb-install, \
+#    1 target, \               # name (lowercase)
+#    2 variable, \             # name (uppercase)
+#    3 gfortran, \             # signifies a GCC ABI (e.g. libgfortran version) dependency
+#    4 cxx11)                  # signifies a cxx11 ABI dependency
+
 # Auto-detect triplet once, create different versions that we use as defaults below for each BB install target
 # This is much more efficient than launching `gcc` and `python` once for each BB install target.
 BB_TRIPLET_GCCABI_CXXABI := $(shell python $(JULIAHOME)/contrib/normalize_triplet.py $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' )")
@@ -6,7 +12,6 @@ BB_TRIPLET_CXXABI := $(subst $(SPACE),-,$(filter-out gcc%,$(subst -,$(SPACE),$(B
 BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out gcc%,$(subst -,$(SPACE),$(BB_TRIPLET_GCCABI_CXXABI)))))
 
 define bb-install
-# $(3) signifies a GCC ABI (e.g. libgfortran version) dependency, $(4) signifies a cxx11 ABI dependency
 TRIPLET_VAR := BB_TRIPLET
 ifeq ($(3),true)
 TRIPLET_VAR := $$(TRIPLET_VAR)_GCCABI
@@ -26,20 +31,20 @@ $$(SRCCACHE)/$$($(2)_BB_BASENAME): | $$(SRCCACHE)
 
 stage-$(strip $1): $$(SRCCACHE)/$$($(2)_BB_BASENAME)
 install-$(strip $1): $$(build_prefix)/manifest/$(strip $1)
-uninstall-$(strip $1):
-	-rm $$(build_prefix)/manifest/$(strip $1)
-	-cd $$(build_prefix) && rm -dv -- $$$$($(TAR) -tzf $$(SRCCACHE)/$$($(2)_BB_BASENAME) --exclude './$$$$')
 
 reinstall-$(strip $1):
 	+$$(MAKE) uninstall-$(strip $1)
 	+$$(MAKE) stage-$(strip $1)
 	+$$(MAKE) install-$(strip $1)
 
+UNINSTALL_$(strip $1) := $$($(2)_BB_BASENAME:.tar.gz=) bb-uninstaller
+
 $$(build_prefix)/manifest/$(strip $1): $$(SRCCACHE)/$$($(2)_BB_BASENAME) | $(build_prefix)/manifest
+	-+[ ! -e $$@ ] || $$(MAKE) uninstall-$(strip $1)
 	$$(JLCHECKSUM) $$<
 	mkdir -p $$(build_prefix)
 	$(UNTAR) $$< -C $$(build_prefix)
-	echo $2 > $$@
+	echo '$$(UNINSTALL_$(strip $1))' > $$@
 
 clean-bb-download-$(1):
 	rm -f $$(SRCCACHE)/$$($(2)_BB_BASENAME)
@@ -61,4 +66,10 @@ ifeq ($$(lastword $$(subst -,$$(SPACE),$$(BB_TRIPLET_CXXABI))),cxx11)
 $$(error Attempting to use gcc4 $(2) tarball, but compiling with cxx11 string ABI; set "CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0" to avoid linker errors)
 endif
 endif
+endef
+
+define bb-uninstaller
+uninstall-$(strip $1):
+	-cd $$(build_prefix) && rm -fdv -- $$$$($$(TAR) -tzf $$(SRCCACHE)/$2.tar.gz --exclude './$$$$')
+	-rm $$(build_prefix)/manifest/$(strip $1)
 endef

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -144,9 +144,6 @@ endef
 define staged-install
 stage-$(strip $1): $$(build_staging)/$2.tgz
 install-$(strip $1): $$(build_prefix)/manifest/$(strip $1)
-uninstall-$(strip $1):
-	-rm $$(build_prefix)/manifest/$(strip $1)
-	-cd $$(build_prefix) && rm -dv -- $$$$($(TAR) -tzf $$(build_staging)/$2.tgz --exclude './$$$$')
 
 ifeq (exists, $$(shell [ -e $$(build_staging)/$2.tgz ] && echo exists ))
 # clean depends on uninstall only if the staged file exists
@@ -171,11 +168,20 @@ $$(build_staging)/$2.tgz: $$(BUILDDIR)/$2/build-compiled
 	rm -rf $$(build_staging)/$2
 	mv $$@.tmp $$@
 
+UNINSTALL_$(strip $1) := $2 staged-uninstaller
+
 $$(build_prefix)/manifest/$(strip $1): $$(build_staging)/$2.tgz | $(build_prefix)/manifest
+	-+[ ! -e $$@ ] || $$(MAKE) uninstall-$(strip $1)
 	mkdir -p $$(build_prefix)
 	$(UNTAR) $$< -C $$(build_prefix)
 	$6
-	echo $2 > $$@
+	echo '$$(UNINSTALL_$(strip $1))' > $$@
+endef
+
+define staged-uninstaller
+uninstall-$(strip $1):
+	-cd $$(build_prefix) && rm -fdv -- $$$$($$(TAR) -tzf $$(build_staging)/$2.tgz --exclude './$$$$')
+	-rm $$(build_prefix)/manifest/$(strip $1)
 endef
 
 
@@ -189,16 +195,11 @@ define symlink_install # (target-name, rel-from, abs-to)
 clean-$1: uninstall-$1
 install-$1: $$(build_prefix)/manifest/$1
 reinstall-$1: install-$1
-uninstall-$1:
-ifeq ($$(BUILD_OS), WINNT)
-	-cmd //C rmdir $$(call mingw_to_dos,$3/$1,cd $3 &&)
-else
-	-rm -r $3/$1
-endif
-	-rm $$(build_prefix)/manifest/$1
+
+UNINSTALL_$(strip $1) := $2 symlink-uninstaller $3
 
 $$(build_prefix)/manifest/$1: $$(BUILDDIR)/$2/build-compiled | $3 $$(build_prefix)/manifest
-	+[ ! \( -e $3/$1 -o -h $3/$1 \) ] || $$(MAKE) uninstall-$1
+	-+[ ! \( -e $3/$1 -o -h $3/$1 \) ] || $$(MAKE) uninstall-$1
 ifeq ($$(BUILD_OS), WINNT)
 	cmd //C mklink //J $$(call mingw_to_dos,$3/$1,cd $3 &&) $$(call mingw_to_dos,$$(BUILDDIR)/$2,)
 else ifneq (,$$(findstring CYGWIN,$$(BUILD_OS)))
@@ -208,7 +209,17 @@ else ifdef JULIA_VAGRANT_BUILD
 else
 	ln -sf $$(abspath $$(BUILDDIR)/$2) $3/$1
 endif
-	echo $2 > $$@
+	echo '$$(UNINSTALL_$(strip $1))' > $$@
+endef
+
+define symlink-uninstaller
+uninstall-$1:
+ifeq ($$(BUILD_OS), WINNT)
+	-cmd //C rmdir $$(call mingw_to_dos,$3/$1,cd $3 &&)
+else
+	-rm -r $3/$1
+endif
+	-rm $$(build_prefix)/manifest/$1
 endef
 
 

--- a/deps/tools/uninstallers.mk
+++ b/deps/tools/uninstallers.mk
@@ -1,0 +1,31 @@
+# include after all other files:
+# defines uninstallers and version-checks
+# based on the contents of the UNINSTALL_* variables and the manifest files
+
+install: version-check
+version-check: $(addprefix version-check-, $(DEP_LIBS_STAGED))
+uninstall: $(addprefix uninstall-, $(DEP_LIBS_STAGED))
+
+## read 'uninstall-*' definition from either the manifest or the current session
+define define-uninstaller
+MANIFEST_$1 := $$(shell [ -e $$(build_prefix)/manifest/$1 ] && cat $$(build_prefix)/manifest/$1)
+ifeq (undefined,$$(flavor $$(word 2,$$(MANIFEST_$1))))
+MANIFEST_$1 := $$(UNINSTALL_$1)
+endif
+UNINST_HOW_$1 := $$(word 2,$$(MANIFEST_$1))
+ifneq ($$(UNINST_HOW_$1),)
+UNINST_WHO_$1 := $$(firstword $$(MANIFEST_$1))
+UNINST_WHERE_$1 := $$(wordlist 3,99,$$(MANIFEST_$1))
+$$(eval $$(call $$(UNINST_HOW_$1),$1,$$(UNINST_WHO_$1),$$(UNINST_WHERE_$1)))
+endif
+endef
+$(foreach dep,$(DEP_LIBS_STAGED),$(eval $(call define-uninstaller,$(dep))))
+
+# for each subproject with a manifest, keep the user aware if something is not the expected version
+$(addprefix version-check-,$(DEP_LIBS_STAGED)) : version-check-% : install-%
+	@if [ ! -e $(build_prefix)/manifest/$* ] || ( \
+			[ "1" != "`wc -w $(build_prefix)/manifest/$* | cut -f 1 -d ' '`" ] && \
+			[ "$(UNINSTALL_$*)" != "`cat $(build_prefix)/manifest/$*`" ]) ; then \
+		echo "WARNING: using mismatched version for $$(cat $(build_prefix)/manifest/$*):" ; \
+		echo "  want $(UNINSTALL_$*)" ; \
+	fi

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -35,3 +35,6 @@ getall get: $(addprefix get-, $(STDLIBS_EXT))
 install: $(addprefix install-, $(STDLIBS_EXT)) $(STDLIBS_LINK_TARGETS)
 clean: $(addprefix clean-, $(STDLIBS_EXT)) $(CLEAN_TARGETS)
 distclean: $(addprefix distclean-, $(STDLIBS_EXT)) clean
+
+DEP_LIBS_STAGED := $(STDLIBS_EXT)
+include $(JULIAHOME)/deps/tools/uninstallers.mk


### PR DESCRIPTION
I wanted to be doing some testing and development work with switching LLVM versions. This helps us uninstall the right content more frequently, thus making the swap between versions cleaner and easier.

And this also lets us print a warning of the user's versions mismatch those in the repository (may be intentional, so we just print a warning so that the user is aware).

~~This is temporarily a bit noisy, but you can quickly silence it by doing a simple `make -C deps uninstall` or a more aggressive `rm -rf usr`.~~