### PR TITLE
Adds method to `find_aac` broadcasting example

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -565,6 +565,7 @@ end
 find_aac(bc::Base.Broadcast.Broadcasted) = find_aac(bc.args)
 find_aac(args::Tuple) = find_aac(find_aac(args[1]), Base.tail(args))
 find_aac(x) = x
+find_aac(::Tuple{}) = nothing
 find_aac(a::ArrayAndChar, rest) = a
 find_aac(::Any, rest) = find_aac(rest)
 # output


### PR DESCRIPTION
Without this additional method the `find_aac` fails with a `BoundsError` if one of the branches of the broadcast tree doesn't contain what you're looking for, because it tries to index into an empty tuple.

MWE:

```julia
a = ArrayAndChar(rand(5), 'c')

rand(5) .* 2 .+ a
```