### PR TITLE
On Windows use tempname for mktemp

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -50,6 +50,18 @@ end
 
 using Random
 
+@testset "that temp names are actually unique" begin
+    temps = [tempname(cleanup=false) for _ = 1:100]
+    @test allunique(temps)
+    temps = map(1:100) do _
+        path, io = mktemp(cleanup=false)
+        close(io)
+        rm(path, force=true)
+        return path
+    end
+    @test allunique(temps)
+end
+
 @testset "tempname with parent" begin
     t = tempname()
     @test dirname(t) == tempdir()


### PR DESCRIPTION
On top of  https://github.com/JuliaLang/julia/pull/33785

From https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamea

> Due to the algorithm used to generate file names, GetTempFileName can perform poorly when creating a large number of files with the same prefix. In such cases, it is recommended that you construct unique file names based on GUIDs.

Here we simply use `tempname` which uses GUIDs to generate  unique file name,  as recommended.  Whether this actually addresses 'can perform poorly when creating a large number of files' is kinda tangential since we prefix   `jl_` in `tempname`. This I think more importantly addresses the uniqueness issue, since the UIUD's generated should be unique and there is a lower probability to clash.
