### PR TITLE
Include Iterators.peel in the API docs

### DIFF
--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -16,4 +16,5 @@ Base.Iterators.partition
 Base.Iterators.filter
 Base.Iterators.reverse
 Base.Iterators.only
+Base.Iterators.peel
 ```


### PR DESCRIPTION
We just accidentally remade this function (albeit with a better error message) in IterTools because this was not in the API docs.