### PR TITLE
Add note for non-Posix and Windows users.

### DIFF
--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -20,6 +20,13 @@ differs in several aspects from the behavior in various shells, Perl, or Ruby:
     interpolating variables and splitting on words as the shell would, respecting shell quoting syntax.
     The command is run as `julia`'s immediate child process, using `fork` and `exec` calls.
 
+
+!!! note
+    The following assumes a Posix environment as on Linux or MacOS.
+    On Windows, many similar commands, such as `echo` and `dir`, are not external programs and instead are built into the shell `cmd.exe` itself.
+    One option to run these commands is to invoke `cmd.exe`, for example `cmd /C echo hello`.
+    Alternatively Julia can be run inside a Posix environment such as Cygwin.
+
 Here's a simple example of running an external program:
 
 ```jldoctest


### PR DESCRIPTION
Examples in [docs for running external programs](https://docs.julialang.org/en/v1/manual/running-external-programs/index.html) fail for Windows users due to idiosyncrasies of the Windows shell. This commit adds a note explaining why ``run(`echo hello`)`` fails on windows and provides an alternative. This additional information should save new Windows users time when learning to use Julia to run shell commands. Partially addresses issue https://github.com/JuliaLang/julia/issues/23597.

