### PR TITLE
Revert the accidentally breaking part of 33779

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1557,7 +1557,7 @@ function hcat(V::Vector{T}...) where T
             throw(DimensionMismatch("vectors must have same lengths"))
         end
     end
-    return T[ V[j][i] for i=1:length(V[1]), j=1:length(V) ]
+    return [ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]
 end
 
 function vcat(arrays::Vector{T}...) where T

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2650,3 +2650,10 @@ end
 
 # Throws ArgumentError for negative dimensions in Array
 @test_throws ArgumentError fill('a', -10)
+
+@testset "Issue 33919" begin
+    A = Array[rand(2, 3), rand(3, 1)]
+    B = Array[rand(2, 2), rand(1, 4)]
+    C = hcat(A, B)
+    @test typeof(C) == Array{Array{Float64,2},2}
+end


### PR DESCRIPTION
A one-line change introduced in #33779 seems to have inadvertently caused the regression noted in #33919. Reverting just that part should fix it.

Fixes #33919.