### PR TITLE
Document one-argument version of Unicode.normalize

### DIFF
--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -8,8 +8,9 @@ export graphemes
     Unicode.normalize(s::AbstractString; kwargs...)
     Unicode.normalize(s::AbstractString, normalform::Symbol)
 
-Normalize the string `s`. By default, canonical composition is performed without ensuring
-Unicode versioning stability (equivalent to passing `compose=true`).
+Normalize the string `s`. By default, canonical composition (`compose=true`) is performed without ensuring
+Unicode versioning stability (`compat=false`), which produces the shortest possible equivalent string
+but may introduce composition characters not present in earlier Unicode versions.
 
 Alternatively, one of the four "normal forms" of the Unicode standard can be specified:
 `normalform` can be `:NFC`, `:NFD`, `:NFKC`, or `:NFKD`.  Normal forms C
@@ -39,7 +40,7 @@ options (which all default to `false` except for `compose`) are specified:
   spaces; newlines are also converted to spaces unless a newline-conversion flag was
   specified
 * `rejectna=true`: throw an error if unassigned code points are found
-* `stable=true`: enforce Unicode Versioning Stability
+* `stable=true`: enforce Unicode versioning stability (never introduce characters missing from earlier Unicode versions)
 
 For example, NFKC corresponds to the options `compose=true, compat=true, stable=true`.
 

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -5,10 +5,14 @@ module Unicode
 export graphemes
 
 """
+    Unicode.normalize(s::AbstractString; kwargs...)
     Unicode.normalize(s::AbstractString, normalform::Symbol)
 
-Normalize the string `s` according to one of the four "normal forms" of the Unicode
-standard: `normalform` can be `:NFC`, `:NFD`, `:NFKC`, or `:NFKD`.  Normal forms C
+Normalize the string `s`. By default, canonical composition is performed without ensuring
+Unicode versioning stability (equivalent to passing `compose=true`).
+
+Alternatively, one of the four "normal forms" of the Unicode standard can be specified:
+`normalform` can be `:NFC`, `:NFD`, `:NFKC`, or `:NFKD`.  Normal forms C
 (canonical composition) and D (canonical decomposition) convert different visually identical
 representations of the same abstract string into a single canonical form, with form C being
 more compact.  Normal forms KC and KD additionally canonicalize "compatibility equivalents":
@@ -41,6 +45,9 @@ For example, NFKC corresponds to the options `compose=true, compat=true, stable=
 
 # Examples
 ```jldoctest
+julia> "é" == Unicode.normalize("é") #LHS: Unicode U+00e9, RHS: U+0065 & U+0065
+true
+
 julia> "μ" == Unicode.normalize("µ", compat=true) #LHS: Unicode U+03bc, RHS: Unicode U+00b5
 true
 

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -5,7 +5,7 @@ module Unicode
 export graphemes
 
 """
-    Unicode.normalize(s::AbstractString; kwargs...)
+    Unicode.normalize(s::AbstractString; keywords...)
     Unicode.normalize(s::AbstractString, normalform::Symbol)
 
 Normalize the string `s`. By default, canonical composition (`compose=true`) is performed without ensuring
@@ -46,7 +46,7 @@ For example, NFKC corresponds to the options `compose=true, compat=true, stable=
 
 # Examples
 ```jldoctest
-julia> "é" == Unicode.normalize("é") #LHS: Unicode U+00e9, RHS: U+0065 & U+0065
+julia> "é" == Unicode.normalize("é") #LHS: Unicode U+00e9, RHS: U+0065 & U+0301
 true
 
 julia> "μ" == Unicode.normalize("µ", compat=true) #LHS: Unicode U+03bc, RHS: Unicode U+00b5


### PR DESCRIPTION
I'm not sure why the default is `compose=true, stable=false`, which sounds a bit scary when documenting...