### PR TITLE
Added rol/ror functions to Base (issue #11592)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ New library functions
 * `istaskfailed` is now documented and exported, like its siblings `istaskdone` and `istaskstarted` ([#32300]).
 * `RefArray` and `RefValue` objects now accept index `CartesianIndex()` in  `getindex` and `setindex!` ([#32653])
 * Added `sincosd(x)` to simultaneously compute the sine and cosine of `x`, where `x` is in degrees ([#30134]).
+* Added integer bitwise rotation functions `rol` and `ror` ([#33938]).
 
 Standard library changes
 ------------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -314,6 +314,8 @@ export
     reinterpret,
     rem,
     rem2pi,
+    rol,
+    ror,
     round,
     sec,
     secd,

--- a/base/int.jl
+++ b/base/int.jl
@@ -448,6 +448,45 @@ trailing_ones(x::Integer) = trailing_zeros(~x)
 >>>(x::BitInteger, y::Int) =
     ifelse(0 <= y, x >>> unsigned(y), x << unsigned(-y))
 
+# integer rotation
+"""
+    rol(x::Integer, s::Int) -> Integer
+
+Rotate the bits of `x` left by `s` steps.
+
+# Examples
+```jldoctest
+julia> rol(10, 2)
+40
+
+julia> rol(0x1a, 4)
+0xa1
+```
+"""
+function rol(x::BitInteger, s::Int)
+    mask = sizeof(x) << 3 - 1
+    return (x << (s & mask)) | (x >>> (-s & mask))
+end
+
+"""
+    ror(x::Integer, s::Int) -> Integer
+
+Rotate the bits of `x` right by `s` steps.
+
+# Examples
+```jldoctest
+julia> ror(10, 2)
+-9223372036854775806
+
+julia> ror(0x1a, 6)
+0x68
+```
+"""
+function ror(x::BitInteger, s::Int)
+    mask = sizeof(x) << 3 - 1
+    return (x >>> (s & mask)) | (x << (-s & mask))
+end
+
 for to in BitInteger_types, from in (BitInteger_types..., Bool)
     if !(to === from)
         if to.size < from.size


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/julia/issues/11592, it would be nice if there were efficient bitwise rotation functions for integers.

This PR adds `rol` and `ror` for Int8, Int16, Int32, Int64, Int128 and their unsigned counterparts. On my computer, for all types except the 128-bit ones, the function compiles down to a single rotate instruction. The native code for the 128-bit rotations are quite bad, but I don't know how to optimize that.