### PR TITLE
Add `exclusive` flag to open() keywords (issue #33947)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@ New library functions
 * The new `only(x)` function returns the one-and-only element of a collection `x`, and throws an `ArgumentError` if `x` contains zero or multiple elements. ([#33129])
 * `takewhile` and `dropwhile` have been added to the Iterators submodule ([#33437]).
 * There is a now an `evalpoly` (generated) function meant to take the role of the `@evalpoly` macro. The function is just as efficient as the macro while giving added flexibility, so it should be preferred over `@evalpoly`. `evalpoly` takes a list of coefficients as a tuple, so where one might write `@evalpoly(x, p1, p2, p3)` one would instead write `evalpoly(x, (p1, p2, p3))`.
+* The keyword version of `open` now takes keyword argument `exclusive` to ensure that the call creates the file ([#33949]).
 
 Standard library changes
 ------------------------

--- a/base/io.jl
+++ b/base/io.jl
@@ -243,11 +243,12 @@ Compute the `read`, `write`, `create`, `truncate`, `append` flag value for
 a given set of keyword arguments to [`open`](@ref) a [`NamedTuple`](@ref).
 """
 function open_flags(;
-    read     :: Union{Bool,Nothing} = nothing,
-    write    :: Union{Bool,Nothing} = nothing,
-    create   :: Union{Bool,Nothing} = nothing,
-    truncate :: Union{Bool,Nothing} = nothing,
-    append   :: Union{Bool,Nothing} = nothing,
+    read      :: Union{Bool,Nothing} = nothing,
+    write     :: Union{Bool,Nothing} = nothing,
+    create    :: Union{Bool,Nothing} = nothing,
+    truncate  :: Union{Bool,Nothing} = nothing,
+    append    :: Union{Bool,Nothing} = nothing,
+    exclusive :: Union{Bool,Nothing} = nothing,
 )
     if write === true && read !== true && append !== true
         create   === nothing && (create   = true)
@@ -259,11 +260,12 @@ function open_flags(;
         create === nothing && (create = true)
     end
 
-    write    === nothing && (write    = false)
-    read     === nothing && (read     = !write)
-    create   === nothing && (create   = false)
-    truncate === nothing && (truncate = false)
-    append   === nothing && (append   = false)
+    write     === nothing && (write     = false)
+    read      === nothing && (read      = !write)
+    create    === nothing && (create    = false)
+    truncate  === nothing && (truncate  = false)
+    append    === nothing && (append    = false)
+    exclusive === nothing && (exclusive = false)
 
     return (
         read = read,
@@ -271,6 +273,7 @@ function open_flags(;
         create = create,
         truncate = truncate,
         append = append,
+        exclusive = exclusive,
     )
 end
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1313,7 +1313,7 @@ jl_code_instance_t *jl_compile_linfo(jl_method_instance_t *mi, jl_code_info_t *s
                 if (!strncmp(t, "stderr", 6))
                     s_precompile = JL_STDERR;
                 else {
-                    if (ios_file(&f_precompile, t, 1, 1, 1, 1) == NULL)
+                    if (ios_file(&f_precompile, t, 1, 1, 1, 1, 0) == NULL)
                         jl_errorf("cannot open precompile statement file \"%s\" for writing", t);
                     s_precompile = (JL_STREAM*) &f_precompile;
                 }

--- a/src/dump.c
+++ b/src/dump.c
@@ -2856,7 +2856,7 @@ JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
                 const char *depstr = jl_string_data(dep);
                 if (!depstr[0])
                     continue;
-                ios_t *srctp = ios_file(&srctext, depstr, 1, 0, 0, 0);
+                ios_t *srctp = ios_file(&srctext, depstr, 1, 0, 0, 0, 0);
                 if (!srctp) {
                     jl_printf(JL_STDERR, "WARNING: could not cache source text for \"%s\".\n",
                               jl_string_data(dep));
@@ -3256,7 +3256,7 @@ JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t
 JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname, jl_array_t *mod_array)
 {
     ios_t f;
-    if (ios_file(&f, fname, 1, 0, 0, 0) == NULL) {
+    if (ios_file(&f, fname, 1, 0, 0, 0, 0) == NULL) {
         return jl_get_exceptionf(jl_errorexception_type,
             "Cache file \"%s\" not found.\n", fname);
     }

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -426,7 +426,7 @@ struct _fl_context_t {
     int SCR_WIDTH;
     int HPOS, VPOS;
 
-    value_t iostreamsym, rdsym, wrsym, apsym, crsym, truncsym;
+    value_t iostreamsym, rdsym, wrsym, apsym, crsym, truncsym, exclsym;
     value_t instrsym, outstrsym;
     fltype_t *iostreamtype;
 

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -77,19 +77,20 @@ value_t fl_file(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     if (nargs < 1)
         argcount(fl_ctx, "file", nargs, 1);
-    int i, r=0, w=0, c=0, t=0, a=0;
+    int i, r=0, w=0, c=0, t=0, a=0, e=0;
     for(i=1; i < (int)nargs; i++) {
         if      (args[i] == fl_ctx->wrsym)    w = 1;
         else if (args[i] == fl_ctx->apsym)    { a = 1; w = 1; }
         else if (args[i] == fl_ctx->crsym)    { c = 1; w = 1; }
         else if (args[i] == fl_ctx->truncsym) { t = 1; w = 1; }
         else if (args[i] == fl_ctx->rdsym)    r = 1;
+        else if (args[i] == fl_ctx->exclsym)  e = 1;
     }
     if ((r|w|c|t|a) == 0) r = 1;  // default to reading
     value_t f = cvalue(fl_ctx, fl_ctx->iostreamtype, sizeof(ios_t));
     char *fname = tostring(fl_ctx, args[0], "file");
     ios_t *s = value2c(ios_t*, f);
-    if (ios_file(s, fname, r, w, c, t) == NULL)
+    if (ios_file(s, fname, r, w, c, t, e) == NULL)
         lerrorf(fl_ctx, fl_ctx->IOError, "file: could not open \"%s\"", fname);
     if (a) ios_seek_end(s);
     return f;
@@ -445,6 +446,7 @@ void iostream_init(fl_context_t *fl_ctx)
     fl_ctx->apsym = symbol(fl_ctx, ":append");
     fl_ctx->crsym = symbol(fl_ctx, ":create");
     fl_ctx->truncsym = symbol(fl_ctx, ":truncate");
+    fl_ctx->exclsym = symbol(fl_ctx, ":exclusive");
     fl_ctx->instrsym = symbol(fl_ctx, "*input-stream*");
     fl_ctx->outstrsym = symbol(fl_ctx, "*output-stream*");
     fl_ctx->iostreamtype = define_opaque_type(fl_ctx->iostreamsym, sizeof(ios_t),

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -81,7 +81,7 @@ void jl_write_compiler_output(void)
             }
             else {
                 ios_t f;
-                if (ios_file(&f, jl_options.outputji, 1, 1, 1, 1) == NULL)
+                if (ios_file(&f, jl_options.outputji, 1, 1, 1, 1, 0) == NULL)
                     jl_errorf("cannot open system image file \"%s\" for writing", jl_options.outputji);
                 ios_write(&f, (const char*)s->buf, (size_t)s->size);
                 ios_close(&f);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1396,7 +1396,7 @@ JL_DLLEXPORT size_t ios_write_direct(ios_t *dest, ios_t *src);
 JL_DLLEXPORT void jl_save_system_image(const char *fname)
 {
     ios_t f;
-    if (ios_file(&f, fname, 1, 1, 1, 1) == NULL) {
+    if (ios_file(&f, fname, 1, 1, 1, 1, 0) == NULL) {
         jl_errorf("cannot open system image file \"%s\" for writing", fname);
     }
     JL_SIGATOMIC_BEGIN();
@@ -1573,7 +1573,7 @@ JL_DLLEXPORT void jl_restore_system_image(const char *fname)
     }
     else {
         ios_t f;
-        if (ios_file(&f, fname, 1, 0, 0, 0) == NULL)
+        if (ios_file(&f, fname, 1, 0, 0, 0, 0) == NULL)
             jl_errorf("System image file \"%s\" not found.", fname);
         ios_bufmode(&f, bm_none);
         JL_SIGATOMIC_BEGIN();

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -902,7 +902,7 @@ static int open_cloexec(const char *path, int flags, mode_t mode)
 }
 #endif
 
-ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc)
+ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc, int excl)
 {
     int flags;
     int fd;
@@ -911,6 +911,7 @@ ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int tru
         goto open_file_err;
     flags = wr ? (rd ? O_RDWR : O_WRONLY) : O_RDONLY;
     if (create) flags |= O_CREAT;
+    if (create && excl) flags |= O_EXCL;
     if (trunc)  flags |= O_TRUNC;
 #if defined(_OS_WINDOWS_)
     size_t wlen = MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -111,7 +111,7 @@ JL_DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 
 /* stream creation */
 JL_DLLEXPORT
-ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc) JL_NOTSAFEPOINT;
+ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc, int excl) JL_NOTSAFEPOINT;
 JL_DLLEXPORT ios_t *ios_mkstemp(ios_t *f, char *fname);
 JL_DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize) JL_NOTSAFEPOINT;
 ios_t *ios_str(ios_t *s, char *str);

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -82,7 +82,7 @@ end
     end
 end
 
-@test Base.open_flags(read=false, write=true, append=false) == (read=false, write=true, create=true, truncate=true, append=false)
+@test Base.open_flags(read=false, write=true, append=false) == (read=false, write=true, create=true, truncate=true, append=false, exclusive=false)
 
 @testset "issue #30978" begin
     mktemp() do path, io
@@ -107,5 +107,11 @@ end
         y = zeros(UInt8, 101)
         open(f -> readbytes!(f, y, 102, all=false), path)
         @test y == [x; 0]
+    end
+end
+
+@testset "exclusive flag" begin
+    mktemp() do path, io
+        @test_throws SystemError open(path, create=true, exclusive=true)
     end
 end


### PR DESCRIPTION
Fixes: #33947

```julia
julia> open("/tmp/aaaaa"; create = true, write = true) do f
       write(f, "aaa")
       end
3

julia> open("/tmp/aaaaa"; create = true, write = true, exclusive = true) do f
       write(f, "aaa")
       end
ERROR: SystemError: opening file "/tmp/aaaaa": File exists
Stacktrace:
 [1] systemerror(::String, ::Int32; extrainfo::Nothing) at ./error.jl:168
 [2] #systemerror#44 at ./error.jl:167 [inlined]
 [3] systemerror at ./error.jl:167 [inlined]
 [4] open(::String; read::Nothing, write::Bool, create::Bool, truncate::Nothing, append::Nothing, exclusive::Bool) at ./iostream.jl:257
 [5] open(::var"#11#12", ::String; kwargs::Base.Iterators.Pairs{Symbol,Bool,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:create, :write, :exclusive),Tuple{Bool,Bool,Bool}}}) at ./io.jl:299
 [6] top-level scope at REPL[4]:1
```