### PR TITLE
Remove empty _str_sizehint definition

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -107,9 +107,6 @@ function sprint(f::Function, args...; context=nothing, sizehint::Integer=0)
     String(resize!(s.data, s.size))
 end
 
-# CategoricalArrays extends this
-function tostr_sizehint end
-
 function _str_sizehint(x)
     if x isa Float64
         return 20


### PR DESCRIPTION
CategoricalArrays will stop overloading this soon and this kind of hack is only appropriate for a backport anyway.

@Keno At https://github.com/JuliaLang/julia/pull/33757/files#r341886873 you mentioned there was some duplication, but I don't where. Was the PR changed after that comment?