### PR TITLE
Make the at-threads a no-op if nthreads()==0

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -19,6 +19,8 @@ on `threadid()`.
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 
 function _threadsfor(iter,lbody)
+    nthreads()==1 && return esc(Expr(:for, iter, lbody)) # do nothing if there are not threads
+
     lidx = iter.args[1]         # index
     range = iter.args[2]
     quote


### PR DESCRIPTION
In one of my codes (an MCMC sampler) I saw an overhead of using the `Threads.@threads` macro even though julia was started with `nthreads()==1`.  I'm not sure whether this is expected (trying to reproduce on simple cases, I saw no performance impact).  For my test-case this works, but I have no idea on whether this is ok.