### PR TITLE
Change llvmcall ABI representation for Float16

### DIFF
--- a/test/llvmpasses/llvmcall.jl
+++ b/test/llvmpasses/llvmcall.jl
@@ -1,0 +1,17 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t
+# RUN: cat %t/* | FileCheck %s
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+@generated foo(x)=:(ccall("extern foo", llvmcall, $x, ($x,), x))
+
+# CHECK: call half @foo(half zeroext %{{[0-9]+}})
+emit(foo, Float16)
+
+# CHECK: call [2 x half] @foo([2 x half] %{{[0-9]+}})
+emit(foo, NTuple{2, Float16})
+
+# CHECK: call <2 x half> @foo(<2 x half> %{{[0-9]+}})
+emit(foo, NTuple{2, VecElement{Float16}})


### PR DESCRIPTION
When wrapping LLVM intrinsics using `ccall(..., llvmcall, ...)`, `Float16`s are represented as LLVM's `i16` instead of `half`.
This PR changes the representation to `half`, but only for the llvmcall calling convention.
As such, this shouldn't break anything.

Example:
```julia
for T = [Float16, NTuple{2, Float16}, NTuple{2, VecElement{Float16}}]
    @eval foo(x) = ccall("extern foo", llvmcall, $T, ($T,), x)
    code_llvm(foo, Tuple{T})
end
```

Before patch:
```llvm
;  @ REPL[1]:2 within `foo'
define i16 @julia_foo_17018(i16) {
top:
  %1 = call i16 @foo(i16 zeroext %0)
  ret i16 %1
}

;  @ REPL[1]:2 within `foo'
define [2 x i16] @julia_foo_17020([2 x i16] addrspace(11)* nocapture nonnull readonly dereferenceable(4)) {
top:
  %.elt = getelementptr inbounds [2 x i16], [2 x i16] addrspace(11)* %0, i64 0, i64 0
  %.unpack = load i16, i16 addrspace(11)* %.elt, align 2
  %1 = insertvalue [2 x i16] undef, i16 %.unpack, 0
  %.elt3 = getelementptr inbounds [2 x i16], [2 x i16] addrspace(11)* %0, i64 0, i64 1
  %.unpack4 = load i16, i16 addrspace(11)* %.elt3, align 2
  %2 = insertvalue [2 x i16] %1, i16 %.unpack4, 1
  %3 = call [2 x i16] @foo([2 x i16] %2)
  ret [2 x i16] %3
}

;  @ REPL[1]:2 within `foo'
define <2 x i16> @julia_foo_17021(<2 x i16>) {
top:
  %1 = call <2 x i16> @foo(<2 x i16> %0)
  ret <2 x i16> %1
}
```

After patch:
```llvm
;  @ REPL[1]:2 within `foo'
define i16 @julia_foo_16991(i16) {
top:
  %1 = bitcast i16 %0 to half
  %2 = call half @foo(half zeroext %1)
  %3 = bitcast half %2 to i16
  ret i16 %3
}

;  @ REPL[1]:2 within `foo'
define [2 x i16] @julia_foo_16993([2 x i16] addrspace(11)* nocapture nonnull readonly dereferenceable(4)) {
top:
  %.elt = bitcast [2 x i16] addrspace(11)* %0 to half addrspace(11)*
  %.unpack = load half, half addrspace(11)* %.elt, align 2
  %1 = insertvalue [2 x half] undef, half %.unpack, 0
  %.elt3 = getelementptr inbounds [2 x i16], [2 x i16] addrspace(11)* %0, i64 0, i64 1
  %2 = bitcast i16 addrspace(11)* %.elt3 to half addrspace(11)*
  %.unpack4 = load half, half addrspace(11)* %2, align 2
  %3 = insertvalue [2 x half] %1, half %.unpack4, 1
  %4 = call [2 x half] @foo([2 x half] %3)
  %.fca.0.extract = extractvalue [2 x half] %4, 0
  %5 = bitcast half %.fca.0.extract to i16
  %.fca.1.extract = extractvalue [2 x half] %4, 1
  %6 = bitcast half %.fca.1.extract to i16
  %.fca.0.insert = insertvalue [2 x i16] undef, i16 %5, 0
  %.fca.1.insert = insertvalue [2 x i16] %.fca.0.insert, i16 %6, 1
  ret [2 x i16] %.fca.1.insert
}

;  @ REPL[1]:2 within `foo'
define <2 x i16> @julia_foo_16994(<2 x i16>) {
top:
  %1 = bitcast <2 x i16> %0 to <2 x half>
  %2 = call <2 x half> @foo(<2 x half> %1)
  %3 = bitcast <2 x half> %2 to <2 x i16>
  ret <2 x i16> %3
}
```

// cc @maleadt 