### PR TITLE
devdocs: add instructions for running the parser without full re-build

### DIFF
--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -71,6 +71,14 @@ which handles tokenizing Julia code and turning it into an AST, and [`julia-synt
 which handles transforming complex AST representations into simpler, "lowered" AST representations
 which are more suitable for analysis and execution.
 
+If you want to test the parser without re-building Julia in its entirety, you can run the frontend
+on its own as follows:
+
+    $ cd src
+    $ flisp/flisp
+    > (load "jlfrontend.scm")
+    > (jl-parse-file "<filename>")
+
 ## [Macro Expansion](@id dev-macro-expansion)
 
 When [`eval()`](@ref) encounters a macro, it expands that AST node before attempting to evaluate


### PR DESCRIPTION
It is possible to just run the parser in `flisp` and that doesn't need re-building the rest of Julia. Adding that to the documentation.

This was useful to me when working on #32071 and might be useful for others as well. This patch is part of that branch but it's independently useful as well, so that's why I'm submitting it separately.