### PR TITLE
Fix #32980

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,6 @@ endif
 	mkdir -p $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/
 	$(INSTALL_F) $(JULIAHOME)/contrib/julia.svg $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/
 	-touch -c $(DESTDIR)$(datarootdir)/icons/hicolor/
-	-gtk-update-icon-cache --ignore-theme-index $(DESTDIR)$(datarootdir)/icons/hicolor/
 	mkdir -p $(DESTDIR)$(datarootdir)/applications/
 	$(INSTALL_F) $(JULIAHOME)/contrib/julia.desktop $(DESTDIR)$(datarootdir)/applications/
 	# Install appdata file


### PR DESCRIPTION
This was introduced in: e2821f594c5e9b2ec0fa1603f4e90628d2e40cd7

Package managers track which package owns a file, and if the
icon-theme.cache is owned by Julia, the package manager will get
confused when that file already exists on the system or when another
process overwrites it.

It's the DE's job to update that cache.

Fixes #32980.