### PR TITLE
More efficient isempty(::AbstractString)

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -157,6 +157,7 @@ julia> sizeof("∀")
 sizeof(s::AbstractString) = ncodeunits(s) * sizeof(codeunit(s))
 firstindex(s::AbstractString) = 1
 lastindex(s::AbstractString) = thisind(s, ncodeunits(s))
+isempty(s::AbstractString) = iszero(ncodeunits(s))
 
 function getindex(s::AbstractString, i::Integer)
     @boundscheck checkbounds(s, i)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -20,6 +20,11 @@ using Random
     @test s == "ab"
 
     @test isempty(string())
+    @test !isempty("abc")
+    @test !isempty("∀∃")
+    @test !isempty(GenericString("∀∃"))
+    @test isempty(GenericString(""))
+    @test !isempty(GenericString("abc"))
     @test eltype(GenericString) == Char
     @test firstindex("abc") == 1
     @test cmp("ab","abc") == -1


### PR DESCRIPTION
Instead of defaulting to the generic `isempty` method, which tries to iterate over the string, now simply checks if there are 0 codeunits.