### PR TITLE
Minor build system fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ else ifneq (,$(findstring $(OS),Linux FreeBSD))
 endif
 
 	# Overwrite JL_SYSTEM_IMAGE_PATH in julia library
-	if [ $(DARWIN_FRAMEWORK) == 0 ]; then \
+	if [ $(DARWIN_FRAMEWORK) = 0 ]; then \
 		RELEASE_TARGET=$(DESTDIR)$(libdir)/libjulia.$(SHLIB_EXT); \
 		DEBUG_TARGET=$(DESTDIR)$(libdir)/libjulia-debug.$(SHLIB_EXT); \
 	else \
@@ -405,7 +405,7 @@ endif
 		DEBUG_TARGET=$(DESTDIR)$(prefix)/$(framework_dylib)_debug; \
 	fi; \
 	$(call stringreplace,$${RELEASE_TARGET},sys.$(SHLIB_EXT)$$,$(private_libdir_rel)/sys.$(SHLIB_EXT)); \
-	if [ $(BUNDLE_DEBUG_LIBS) == 1 ]; then \
+	if [ $(BUNDLE_DEBUG_LIBS) = 1 ]; then \
 		$(call stringreplace,$${DEBUG_TARGET},sys-debug.$(SHLIB_EXT)$$,$(private_libdir_rel)/sys-debug.$(SHLIB_EXT)); \
 	fi;
 

--- a/Makefile
+++ b/Makefile
@@ -605,11 +605,11 @@ else
 LLVM_SIZE := $(build_depsbindir)/llvm-size$(EXE)
 endif
 build-stats:
-	@echo $(JULCOLOR)' ==> ./julia binary sizes'$(ENDCOLOR)
+	@printf $(JULCOLOR)' ==> ./julia binary sizes\n'$(ENDCOLOR)
 	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_libdir)/sys.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_bindir)/julia$(EXE)))
-	@echo $(JULCOLOR)' ==> ./julia launch speedtest'$(ENDCOLOR)
+	@printf $(JULCOLOR)' ==> ./julia launch speedtest\n'$(ENDCOLOR)
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')


### PR DESCRIPTION
1. When /bin/sh points to dash (or any other POSIX-compliant shell that doesn't support the non-standard `==`), running `if [ ... ]` statements containing `==` would quietly fail. Example:

```sh
# dash
$ if [ 0 == 0 ]; then echo hi; fi
dash: 1: [: 0: unexpected operator
$ echo $?
0
$ if [ 0 = 0 ]; then echo hi; fi
hi
```

2. Originally, when `make build-stats` was run, it printed something like
```sh
\033[34;1m ==> ./julia binary sizes\033[0m
[...]
```
to the terminal. Now prints text in color as expected.