### PR TITLE
Support Factorization \ UniformScaling

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -210,6 +210,7 @@ end
     rmul!(inv(A), J.λ)
 \(J::UniformScaling, A::AbstractVecOrMat) = J.λ == 0 ? throw(SingularException(1)) : J.λ\A
 \(A::AbstractMatrix, J::UniformScaling) = rmul!(inv(A), J.λ)
+\(F::Factorization, J::UniformScaling) = F \ J(size(F,1))
 
 \(x::Number, J::UniformScaling) = UniformScaling(x\J.λ)
 

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -345,4 +345,37 @@ end
     @test dot([x], λ*I, [y]) ≈ dot(x, λ, y) ≈ dot(x, λ*y)
 end
 
+@testset "Factorization solutions" begin
+    J = complex(randn(),randn()) * I
+    qrp = A -> qr(A, Val(true))
+
+    # thin matrices
+    X = randn(3,2)
+    Z = pinv(X)
+    for fac in (qr,qrp,svd)
+        F = fac(X)
+        @test @inferred(F \ I) ≈ Z
+        @test @inferred(F \ J) ≈ Z * J
+    end
+
+    # square matrices
+    X = randn(3,3)
+    X = X'X + rand()I # make positive definite for cholesky
+    Z = pinv(X)
+    for fac in (bunchkaufman,cholesky,lu,qr,qrp,svd)
+        F = fac(X)
+        @test @inferred(F \ I) ≈ Z
+        @test @inferred(F \ J) ≈ Z * J
+    end
+
+    # fat matrices - only rank-revealing variants
+    X = randn(2,3)
+    Z = pinv(X)
+    for fac in (qrp,svd)
+        F = fac(X)
+        @test @inferred(F \ I) ≈ Z
+        @test @inferred(F \ J) ≈ Z * J
+    end
+end
+
 end # module TestUniformscaling


### PR DESCRIPTION
This fills in the ability to solve a factorized matrix system of equations with respect to a `UniformScaling` object. Neither `Factorization <: AbstractMatrix` nor `UniformScaling <: AbstractMatrix`, so neither type's current methods apply.