### PR TITLE
temp cleanup: broaden try-catch block

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -480,15 +480,16 @@ end
 function temp_cleanup_purge(all::Bool=true)
     need_gc = Sys.iswindows()
     for (path, asap) in TEMP_CLEANUP
-        if (all || asap) && ispath(path)
-            need_gc && GC.gc(true)
-            need_gc = false
-            try rm(path, recursive=true, force=true)
-            catch ex
-                @warn "temp cleanup" _group=:file exception=(ex, catch_backtrace())
+        try
+            if (all || asap) && ispath(path)
+                need_gc && GC.gc(true)
+                need_gc = false
+                rm(path, recursive=true, force=true)
             end
+            !ispath(path) && delete!(TEMP_CLEANUP, path)
+        catch ex
+            @warn "temp cleanup" _group=:file exception=(ex, catch_backtrace())
         end
-        !ispath(path) && delete!(TEMP_CLEANUP, path)
     end
 end
 


### PR DESCRIPTION
In case even asking `ispath` causes problems (which apparently, it can).