### PR TITLE
fix #33974, wrong integer types used in `jl_array_sizehint`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -933,8 +933,8 @@ STATIC_INLINE void jl_array_shrink(jl_array_t *a, size_t dec)
     if (a->flags.how == 0) return;
 
     size_t elsz = a->elsize;
-    int newbytes = (a->maxsize - dec) * a->elsize;
-    int oldnbytes = (a->maxsize) * a->elsize;
+    size_t newbytes = (a->maxsize - dec) * a->elsize;
+    size_t oldnbytes = (a->maxsize) * a->elsize;
     int isbitsunion = jl_array_isbitsunion(a);
     if (isbitsunion) {
         newbytes += a->maxsize - dec;
@@ -1107,7 +1107,7 @@ JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
 {
     size_t n = jl_array_nrows(a);
 
-    int min = a->offset + a->length;
+    size_t min = a->offset + a->length;
     sz = (sz < min) ? min : sz;
 
     if (sz <= a->maxsize) {

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2657,3 +2657,14 @@ end
     C = hcat(A, B)
     @test typeof(C) == Array{Array{Float64,2},2}
 end
+
+# issue #33974
+let n = 12000000, k = 257000000
+    # tests skipped since they use a lot of memory
+    @test_skip filter(x -> x[2] < 1.0, collect(enumerate(vcat(fill(0.5, n), fill(NaN, k)))))[end] == (n, 0.5)
+    @test_skip let v = collect(enumerate(vcat(fill(0.5, n), fill(NaN, k))))
+        resize!(v, n)
+        sizehint!(v, n)
+        v[end] == (n, 0.5)
+    end
+end


### PR DESCRIPTION
fix #33974

I used `@test_skip` here since they use a lot of memory. But if it's ok to allocate several GB I can enable them.