### PR TITLE
[WASM] load the sysimage from the executable

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -509,6 +509,16 @@ extern const int jl_tls_elf_support;
 void jl_init_threading(void);
 void jl_start_threads(void);
 
+// -- staticdata.c -- //
+extern char     *jl_sysimg_gvars_base;
+extern char     *jl_sysimg_fvars_base;
+extern int32_t  *jl_sysimg_gvars_offsets;
+extern int32_t  *jl_sysimg_fvars_offsets;
+extern void     *jl_dispatch_target_ids;
+extern int32_t  *jl_dispatch_reloc_slots;
+extern uint32_t *jl_dispatch_fvars_idxs;
+extern int32_t  *jl_dispatch_fvars_offsets;
+
 // Whether the GC is running
 extern char *jl_safepoint_pages;
 STATIC_INLINE int jl_addr_is_safepoint(uintptr_t addr)

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -257,7 +257,7 @@ bool LowerPTLS::runOnModule(Module &_M)
     T_pint8 = T_int8->getPointerTo();
     if (imaging_mode) {
         ptls_slot = create_aliased_global(T_ptls_getter, "jl_get_ptls_states_slot");
-        ptls_offset = create_aliased_global(T_size, "jl_tls_offset");
+        ptls_offset = create_aliased_global(T_size, "jl_tls_offset_idx");
     }
 
     for (auto it = ptls_getter->user_begin(); it != ptls_getter->user_end();) {

--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -1346,7 +1346,11 @@ jl_sysimg_fptrs_t jl_init_processor_sysimg(void *hdl)
 {
     if (!jit_targets.empty())
         jl_error("JIT targets already initialized");
-    return parse_sysimg(hdl, sysimg_init_cb);
+    if (hdl) {
+        return parse_sysimg(hdl, sysimg_init_cb);
+    } else {
+        return parse_static_sysimg(sysimg_init_cb);
+    }
 }
 
 std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags)

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -101,7 +101,11 @@ jl_sysimg_fptrs_t jl_init_processor_sysimg(void *hdl)
 {
     if (!jit_targets.empty())
         jl_error("JIT targets already initialized");
-    return parse_sysimg(hdl, sysimg_init_cb);
+    if (hdl) {
+        return parse_sysimg(hdl, sysimg_init_cb);
+    } else {
+        return parse_static_sysimg(sysimg_init_cb);
+    }
 }
 
 std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags)

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -872,7 +872,11 @@ jl_sysimg_fptrs_t jl_init_processor_sysimg(void *hdl)
 {
     if (!jit_targets.empty())
         jl_error("JIT targets already initialized");
-    return parse_sysimg(hdl, sysimg_init_cb);
+    if (hdl) {
+        return parse_sysimg(hdl, sysimg_init_cb);
+    } else {
+        return parse_static_sysimg(sysimg_init_cb);
+    }
 }
 
 std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -238,16 +238,22 @@ static void jl_load_sysimg_so(void)
 }
 
 const char jl_system_image_data[] __attribute__((weak));
-void *jl_sysimg_fvars[] __attribute__((weak));
-void *jl_sysimg_gvars[] __attribute__((weak));
-void *jl_sysimg_gvars_offsets[] __attribute__((weak));
-size_t jl_system_image_size __attribute__((weak)) = 0;
+size_t jl_system_image_size   __attribute__((weak)) = 0;
 
-void jl_load_sysimg_static() {
-    sysimg_fptrs.base = jl_sysimg_fvars;
-    sysimg_gvars_base = jl_sysimg_gvars;
-    sysimg_gvars_offsets = jl_sysimg_gvars_offsets;
-    sysimg_gvars_offsets += 1;
+char     *jl_sysimg_gvars_base      __attribute__((weak)) = NULL;
+char     *jl_sysimg_fvars_base      __attribute__((weak)) = NULL;
+int32_t  *jl_sysimg_gvars_offsets   __attribute__((weak)) = NULL;
+int32_t  *jl_sysimg_fvars_offsets   __attribute__((weak)) = NULL;
+void     *jl_dispatch_target_ids    __attribute__((weak)) = NULL;
+int32_t  *jl_dispatch_reloc_slots   __attribute__((weak)) = NULL;
+uint32_t *jl_dispatch_fvars_idxs    __attribute__((weak)) = NULL;
+int32_t  *jl_dispatch_fvars_offsets __attribute__((weak)) = NULL;
+
+void jl_load_sysimg_static(void) {
+#ifndef JL_NDEBUG
+    assert(jl_system_image_size > 0 && "load sysimg static despite 0 size");
+#endif
+    sysimg_fptrs = jl_init_processor_sysimg(NULL);
     jl_restore_system_image_data(jl_system_image_data, jl_system_image_size);
 }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -212,7 +212,7 @@ static void jl_load_sysimg_so(void)
         jl_dlsym(jl_sysimg_handle, "jl_get_ptls_states_slot", (void **)&tls_getter_slot, 1);
         *tls_getter_slot = (uintptr_t)jl_get_ptls_states_getter();
         size_t *tls_offset_idx;
-        jl_dlsym(jl_sysimg_handle, "jl_tls_offset", (void **)&tls_offset_idx, 1);
+        jl_dlsym(jl_sysimg_handle, "jl_tls_offset_idx", (void **)&tls_offset_idx, 1);
         *tls_offset_idx = (uintptr_t)(jl_tls_offset == -1 ? 0 : jl_tls_offset);
 
 #ifdef _OS_WINDOWS_
@@ -243,7 +243,6 @@ void *jl_sysimg_gvars[] __attribute__((weak));
 void *jl_sysimg_gvars_offsets[] __attribute__((weak));
 size_t jl_system_image_size __attribute__((weak)) = 0;
 
-#include <stdio.h>
 void jl_load_sysimg_static() {
     sysimg_fptrs.base = jl_sysimg_fvars;
     sysimg_gvars_base = jl_sysimg_gvars;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -247,6 +247,7 @@ void jl_load_sysimg_static() {
     sysimg_fptrs.base = jl_sysimg_fvars;
     sysimg_gvars_base = jl_sysimg_gvars;
     sysimg_gvars_offsets = jl_sysimg_gvars_offsets;
+    sysimg_gvars_offsets += 1;
     jl_restore_system_image_data(jl_system_image_data, jl_system_image_size);
 }
 


### PR DESCRIPTION
Allows linking the sysimage statically with a binary instead of loading
it through a shared library, currently does not support
multi-versioning.