### PR TITLE
[WASM branch] Better JS FFI

### DIFF
--- a/base/jsobject.jl
+++ b/base/jsobject.jl
@@ -3,12 +3,13 @@ module JS
 using .Base.Meta
 import .Base: convert
 
-export @jscall
+export @js, JSObject
 
 abstract type JSBoxed end
 primitive type JSObject <: JSBoxed 32 end
 primitive type JSString <: JSBoxed 32 end
 primitive type JSSymbol <: JSBoxed 32 end
+primitive type JSFunction <: JSBoxed 32 end
 struct JSUndefined; end
 struct JSNull; end
 
@@ -19,8 +20,29 @@ const null = JSNull.instance
 
 const JSAny = Union{JSBoxed, Float64, JSUndefined, JSNull}
 
-macro jscall(expr)
-    isexpr(expr, :call) || error("@jscall argument must be a call")
+function parse_braces_expr(expr)
+    @assert isexpr(expr, :braces)
+    ret = Expr(:block)
+    s = gensym()
+    push!(ret.args, :($s = $JSObject()))
+    for arg in expr.args
+        isexpr(arg, :call) || return :(error("Unrecognized expression `$(arg.head)`"))
+        (arg.args[1] === Symbol(":")) || return :(error("Expected `:`, got $(arg.args[1])"))
+        length(arg.args) == 3 || return :(error("Excessive `:`"))
+        isa(arg.args[2], Symbol) || return :(error("Expected symbol, got $(arg.args[2])"))
+        val = arg.args[3]
+        if isexpr(val, :braces)
+            val = parse_braces_expr(val)
+        else
+            val = esc(val)
+        end
+        push!(ret.args, :(setproperty!($s, $(quot(arg.args[2])), $val)))
+    end
+    push!(ret.args, s)
+    ret
+end
+
+function parse_call_expr(expr)
     target_expr = expr.args[1]
     if isa(target_expr, Symbol)
         target = QuoteNode(target_expr)
@@ -37,25 +59,42 @@ macro jscall(expr)
     converted_args = Symbol[]
     for a in expr.args[2:end]
         x = gensym()
-        push!(b.args, :($x = jsconvert($(esc(a)))))
+        if isexpr(a, :braces)
+            a = parse_braces_expr(a)
+        else
+            a = :(jsconvert($(esc(a))))
+        end
+        push!(b.args, :($x = $a))
         push!(converted_args, x)
     end
-    atypes = [JSAny for _ in converted_args]
+    atypes = [:JSAny for _ in converted_args]
     quote
         $b
-        $(Expr(:foreigncall, target, JSAny, Core.svec(atypes...), length(atypes), QuoteNode(:jscall),
+        $(Expr(:foreigncall, target, :JSAny, Core.svec(atypes...), length(atypes), QuoteNode(:jscall),
             length(atypes), converted_args...))
     end
 end
 
-jsconvert(x) = convert(JSAny, x)
-
-function getproperty(this::JSObject, sym::Symbol)
-    @jscall Reflect.get(this, sym)
+macro js(expr)
+    if isexpr(expr, :call)
+        return parse_call_expr(expr)
+    elseif isexpr(expr, :braces)
+        return parse_braces_expr(expr)
+    else
+        return :(error("Invalid expression for @js macro $(expr.head)"))
+    end
 end
 
-function setproperty!(this::JSObject, sym::Symbol, val)
-    @jscall Reflect.set(this, sym, val)
+jsnew(f::JSFunction, args::JSObject) = @js Reflect.construct(f, args)
+
+jsconvert(x) = convert(JSAny, x)
+
+function Base.getproperty(this::JSObject, sym::Symbol)
+    @js Reflect.get(this, sym)
+end
+
+function Base.setproperty!(this::JSObject, sym::Symbol, val)
+    @js Reflect.set(this, sym, val)
 end
 
 # Yes, we're converting a pointer to Float64 here, but at least in
@@ -63,12 +102,28 @@ end
 # undo this conversion.
 jsconvert(x::Ptr) = convert(JSNumber, convert(UInt32, x))
 jsconvert(x::AbstractString) = convert(JSString, x)
+jsconvert(x::Symbol) = jsconvert(string(x))
 
 function convert(::Type{JSString}, x::String)
     @GC.preserve x begin
         ptr = pointer(x)
-        @jscall UTF8ToString(ptr)
+        @js UTF8ToString(ptr)
     end
 end
+
+global Object = nothing
+global EmptyArray = nothing
+function __init__()
+    global Object, EmptyArray
+    # TODO: Without the eval, this gets codegen'ed into the system image,
+    # where we don't yet support this calling convention.
+    Core.eval(JS, quote
+        @js Module.initialize_jscall_runtime()
+        Object = @js eval("Object")
+        EmptyArray = @js Array(0.0)
+    end)
+end
+
+JSObject() = jsnew(Object, EmptyArray)::JSObject
 
 end

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -386,6 +386,8 @@ jl_sym_t *get_sym_or_global_if_const(jl_value_t *arg)
         if (!jl_is_symbol(jl_quotenode_value(arg)))
             return NULL;
         return (jl_sym_t*)jl_quotenode_value(arg);
+    } else {
+        return NULL;
     }
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -316,6 +316,11 @@ static void expr_attributes(jl_value_t *v, int *has_intrinsics, int *has_defs)
     else if (head == foreigncall_sym) {
         jl_sym_t *fname = NULL, *libname = NULL;
         jl_foreigncall_get_syms(jl_exprarg(e, 0), &fname, &libname);
+        jl_sym_t *cc = *(jl_value_t**)jl_exprarg(e, 3);
+        if (cc == jl_symbol("jscall")) {
+            // jscall is always interpretable
+            return;
+        }
         if (fname == NULL || !jl_foreigncall_interpretable(fname, libname))
             *has_intrinsics = 1;
         return;


### PR DESCRIPTION
[N.B.: This is targeted to the wasm branch]

@vchuravy is working on anyref codegen and was asking for some testcases, which this provides (if the `Core.eval` in the `__init__` method is commented out, it tries to codegen a `jscall` which obviously fails at the moment).

This improves the JS FFI a bit to make it able to better handle some
practical cases of interest, as well as fixing some bugs. In particular
the `@jscall` macro has been renamed to `@js` and now supports on the fly
construction of JavaScript objects, using a JS-like syntax, e.g.
```julia
obj = @js {some: "value", hello: "world"}
@js console.log(obj)
```

An example where this is useful is e.g. in making a HTTP request using
fetch:
```julia
@js fetch("https://github.com", {mode: "no-cors"})
```