### PR TITLE
sigwait: ignore errno except on Darwin

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -600,6 +600,7 @@ static void *signal_listener(void *arg)
         if (sigwait(&sset, &sig)) {
             sig = SIGABRT; // this branch can't occur, unless we had stack memory corruption of sset
         }
+#ifdef _OS_DARWIN_
         else if (!sig || errno == EINTR) {
             // This should never happen, but it has been observed to occur
             // when this thread gets used to handle run a signal handler (without SA_RESTART).
@@ -612,6 +613,7 @@ static void *signal_listener(void *arg)
             // So signals really do seem to always just be lose-lose.
             continue;
         }
+#endif
 #ifndef HAVE_MACH
 #  ifdef HAVE_ITIMER
         profile = (sig == SIGPROF);


### PR DESCRIPTION
I am observing this value get set to EINTR sometimes on Linux. It is not
generally supposed to do that (though not prohibited either). That is
causing us to sometimes drop signals (usually SIGINT). Since we just
need this code for Darwin (ref #17626, #22041, #20174), we can remove
this from everywhere else.