### PR TITLE
RFC: Prevent compilation with `Expr(:meta, :waitcompile, ex)`

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -62,6 +62,7 @@ jl_sym_t *throw_undef_if_not_sym; jl_sym_t *getfield_undefref_sym;
 jl_sym_t *gc_preserve_begin_sym; jl_sym_t *gc_preserve_end_sym;
 jl_sym_t *escape_sym;
 jl_sym_t *aliasscope_sym; jl_sym_t *popaliasscope_sym;
+jl_sym_t *waitcompile_sym;
 
 static uint8_t flisp_system_image[] = {
 #include <julia_flisp.boot.inc>
@@ -367,6 +368,7 @@ void jl_init_frontend(void)
     do_sym = jl_symbol("do");
     aliasscope_sym = jl_symbol("aliasscope");
     popaliasscope_sym = jl_symbol("popaliasscope");
+    waitcompile_sym = jl_symbol("waitcompile");
 }
 
 JL_DLLEXPORT void jl_lisp_prompt(void)

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -504,7 +504,13 @@ SECT_INTERP static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
     else if (head == boundscheck_sym) {
         return jl_true;
     }
-    else if (head == meta_sym || head == inbounds_sym || head == loopinfo_sym) {
+    else if (head == meta_sym) {
+        if (jl_expr_nargs(ex) == 2 && jl_exprarg(ex, 0) == (jl_value_t*)waitcompile_sym) {
+            return jl_toplevel_eval_flex(s->module, jl_exprarg(ex, 1), 0, 0);
+        }
+        return jl_nothing;
+    }
+    else if (head == inbounds_sym || head == loopinfo_sym) {
         return jl_nothing;
     }
     else if (head == gc_preserve_begin_sym || head == gc_preserve_end_sym) {
@@ -754,6 +760,9 @@ SECT_INTERP static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s
                     }
                     if (jl_expr_nargs(stmt) == 1 && jl_exprarg(stmt, 0) == (jl_value_t*)specialize_sym) {
                         jl_set_module_nospecialize(s->module, 0);
+                    }
+                    if (jl_expr_nargs(stmt) == 2 && jl_exprarg(stmt, 0) == (jl_value_t*)waitcompile_sym) {
+                        jl_toplevel_eval_flex(s->module, jl_exprarg(stmt, 1), 0, 0);
                     }
                 }
                 else {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1096,7 +1096,7 @@ extern jl_sym_t *colon_sym; extern jl_sym_t *hygienicscope_sym;
 extern jl_sym_t *throw_undef_if_not_sym; extern jl_sym_t *getfield_undefref_sym;
 extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
 extern jl_sym_t *failed_sym; extern jl_sym_t *done_sym; extern jl_sym_t *runnable_sym;
-extern jl_sym_t *escape_sym;
+extern jl_sym_t *escape_sym; extern jl_sym_t *waitcompile_sym;
 
 struct _jl_sysimg_fptrs_t;
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -335,6 +335,8 @@ static void expr_attributes(jl_value_t *v, int *has_intrinsics, int *has_defs)
             return;
         }
     }
+    else if (head == meta_sym && jl_exprarg(e, 0) == (jl_value_t*)waitcompile_sym)
+        return;
     int i;
     for (i = 0; i < jl_array_len(e->args); i++) {
         jl_value_t *a = jl_exprarg(e, i);

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -54,7 +54,8 @@ function choosetests(choices = [])
         "checked", "bitset", "floatfuncs", "precompile",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
-        "reinterpretarray", "syntax", "logging", "missing", "asyncmap", "atexit"
+        "reinterpretarray", "syntax", "logging", "missing", "asyncmap",
+        "atexit", "snoop"
     ]
 
     tests = []

--- a/test/snoop.jl
+++ b/test/snoop.jl
@@ -1,0 +1,96 @@
+module Snoop
+
+const __inf_logging__ = Tuple{Float64,Core.MethodInstance}[]
+
+function typeinf_ext_logged(linfo::Core.MethodInstance, params::Core.Compiler.Params)
+    tstart = time()
+    ret = Core.Compiler.typeinf_ext(linfo, params)
+    tstop = time()
+    push!(__inf_logging__, (tstop-tstart, linfo))
+    return ret
+end
+function typeinf_ext_logged(linfo::Core.MethodInstance, world::UInt)
+    tstart = time()
+    ret = Core.Compiler.typeinf_ext(linfo, world)
+    tstop = time()
+    push!(__inf_logging__, (tstop-tstart, linfo))
+    return ret
+end
+
+@noinline start_logging() = ccall(:jl_set_typeinf_func, Cvoid, (Any,), typeinf_ext_logged)
+@noinline stop_logging() = ccall(:jl_set_typeinf_func, Cvoid, (Any,), Core.Compiler.typeinf_ext)
+
+macro snoopi(cmd)
+    body = Expr(:meta, :waitcompile, cmd)
+    quote
+        empty!(__inf_logging__)
+        start_logging()
+        try
+            $(esc(body))
+        finally
+            stop_logging()
+        end
+        __inf_logging__
+    end
+end
+
+macro badsnoopi(cmd)
+    body = Expr(:meta, :waitcompile, cmd)
+    somecode = quote
+        ss = 0
+        for i = 1:5
+            global ss
+            ss += i
+        end
+    end
+    quote
+        empty!(__inf_logging__)
+        start_logging()
+        $(esc(somecode))
+        try
+            $(esc(body))
+        finally
+            stop_logging()
+        end
+        __inf_logging__
+    end
+end
+
+function __init__()
+    # typeinf_ext_logged must be compiled before it gets run
+    # We do this in __init__ to make sure it gets compiled to native code
+    # (the *.ji file stores only the inferred code)
+    precompile(typeinf_ext_logged, (Core.MethodInstance, Core.Compiler.Params))
+    precompile(typeinf_ext_logged, (Core.MethodInstance, UInt))
+    precompile(start_logging, ())
+    precompile(stop_logging, ())
+    nothing
+end
+
+end # Snoop
+
+ret2() = 2
+# A loop would normally force the entire body to be compiled, thus
+# failing to turn on inference-snooping before compilation.
+# Consequently this tests the :waitcompile mechanism.
+tinf = Snoop.@snoopi begin
+    s = 0
+    for i = 1:5
+        global s   # is this undesirable?
+        s += ret2()
+    end
+    s
+end
+@test last(tinf[1]).def == first(methods(ret2))
+
+ret3() = 3
+tinf = Snoop.@badsnoopi begin
+    s = 0
+    for i = 1:2
+        global s
+        s += ret3()
+    end
+    s
+end
+@test isempty(tinf)  # the loop forced it to compile before snooping was turned on
+@test ss == sum(1:5)


### PR DESCRIPTION
This PR gives some control over whether a block of code is run in the interpreter or compiled. Currently, expressions are [inspected](https://github.com/JuliaLang/julia/blob/6f690679cc8c04b4d3b5f4e840b19524840afa97/src/toplevel.c#L790-L815) for whether the block needs to be compiled; this PR allows one to wrap an expression in `Expr(:meta, :waitcompile, ex)` to defer the analysis of that block of expressions. Presuming the rest of the expression doesn't force compilation, then those wrapped expressions get re-analyzed on their own.

This is really directed at SnoopCompile, which turns on inference-snooping before running a user expression; currently, if the user-expression triggers the codegen path, then inference is performed *before* snooping is turned on and the user doesn't get the list of inferred methods that one might expect.

There are a couple of that may not be ideal about this (hence the RFC):
- I have some doubt that I've properly handled the situation in which *other* code in the expression (not wrapped in `Expr(:meta, :waitcompile, ex)` triggers the codegen path. The `@badsnoopi` test is intended to probe this case, and it seems to work, but I doubt I've caught the problems associated with this.
- Is it really right that this runs at toplevel? (see the comment in the `@snoopi` test)
