### PR TITLE
Add LLVM patches for NVPTX WMMA fixes

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -460,6 +460,9 @@ $(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-8.0-D66401-mingw-reloc)) # remove for 9.0
 $(eval $(call LLVM_PATCH,llvm7-revert-D44485))
 $(eval $(call LLVM_PATCH,llvm-8.0-D63688-wasm-isLocal)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm-8.0-D55758-tablegen-cond)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm-8.0-D59389-refactor-wmma)) # remove for 9.0
+$(eval $(call LLVM_PATCH,llvm-8.0-D59393-mma-ptx63-fix)) # remove for 9.0
 endif # LLVM_VER 8.0
 
 ifeq ($(LLVM_VER_SHORT),9.0)

--- a/deps/patches/llvm-8.0-D55758-tablegen-cond.patch
+++ b/deps/patches/llvm-8.0-D55758-tablegen-cond.patch
@@ -1,0 +1,794 @@
+From 95135c5a18ee14ca091d3513cc7801521d4eb204 Mon Sep 17 00:00:00 2001
+From: Javed Absar <javed.absar@arm.com>
+Date: Fri, 25 Jan 2019 10:25:25 +0000
+Subject: [PATCH] [TblGen] Extend !if semantics through new feature !cond
+
+This patch extends TableGen language with !cond operator.
+Instead of embedding !if inside !if which can get cumbersome,
+one can now use !cond.
+Below is an example to convert an integer 'x' into a string:
+
+    !cond(!lt(x,0) : "Negative",
+          !eq(x,0) : "Zero",
+          !eq(x,1) : "One,
+          1        : "MoreThanOne")
+
+Reviewed By: hfinkel, simon_tatham, greened
+Differential Revision: https://reviews.llvm.org/D55758
+
+llvm-svn: 352185
+---
+ docs/TableGen/LangIntro.rst          |  14 +++
+ docs/TableGen/LangRef.rst            |  10 +-
+ include/llvm/TableGen/Record.h       |  78 ++++++++++++++++
+ lib/TableGen/Record.cpp              | 131 +++++++++++++++++++++++++++
+ lib/TableGen/TGLexer.cpp             |   1 +
+ lib/TableGen/TGLexer.h               |   2 +-
+ lib/TableGen/TGParser.cpp            |  90 ++++++++++++++++++
+ lib/TableGen/TGParser.h              |   1 +
+ test/TableGen/cond-bitlist.td        |  27 ++++++
+ test/TableGen/cond-default.td        |  11 +++
+ test/TableGen/cond-empty-list-arg.td |   8 ++
+ test/TableGen/cond-inheritance.td    |  22 +++++
+ test/TableGen/cond-let.td            |  36 ++++++++
+ test/TableGen/cond-list.td           |  38 ++++++++
+ test/TableGen/cond-subclass.td       |  27 ++++++
+ test/TableGen/cond-type.td           |  11 +++
+ test/TableGen/cond-usage.td          |  29 ++++++
+ test/TableGen/condsbit.td            |  15 +++
+ 18 files changed, 549 insertions(+), 2 deletions(-)
+ create mode 100644 llvm/test/TableGen/cond-bitlist.td
+ create mode 100644 llvm/test/TableGen/cond-default.td
+ create mode 100644 llvm/test/TableGen/cond-empty-list-arg.td
+ create mode 100644 llvm/test/TableGen/cond-inheritance.td
+ create mode 100644 llvm/test/TableGen/cond-let.td
+ create mode 100644 llvm/test/TableGen/cond-list.td
+ create mode 100644 llvm/test/TableGen/cond-subclass.td
+ create mode 100644 llvm/test/TableGen/cond-type.td
+ create mode 100644 llvm/test/TableGen/cond-usage.td
+ create mode 100644 llvm/test/TableGen/condsbit.td
+
+diff --git a/docs/TableGen/LangIntro.rst b/docs/TableGen/LangIntro.rst
+index ea46550ffc0..390f941f0ca 100644
+--- a/docs/TableGen/LangIntro.rst
++++ b/docs/TableGen/LangIntro.rst
+@@ -258,6 +258,20 @@ supported include:
+ ``!if(a,b,c)``
+   'b' if the result of 'int' or 'bit' operator 'a' is nonzero, 'c' otherwise.
+ 
++``!cond(condition_1 : val1, condition_2 : val2, ..., condition_n : valn)``
++    Instead of embedding !if inside !if which can get cumbersome,
++    one can use !cond. !cond returns 'val1' if the result of 'int' or 'bit'
++    operator 'condition1' is nonzero. Otherwise, it checks 'condition2'.
++    If 'condition2' is nonzero, returns 'val2', and so on.
++    If all conditions are zero, it reports an error.
++
++    Below is an example to convert an integer 'x' into a string:
++
++    !cond(!lt(x,0) : "Negative",
++          !eq(x,0) : "Zero",
++          !eq(x,1) : "One,
++          1        : "MoreThanOne")
++
+ ``!eq(a,b)``
+     'bit 1' if string a is equal to string b, 0 otherwise.  This only operates
+     on string, int and bit objects.  Use !cast<string> to compare other types of
+diff --git a/docs/TableGen/LangRef.rst b/docs/TableGen/LangRef.rst
+index 2efee12ec9d..a3dbf363151 100644
+--- a/docs/TableGen/LangRef.rst
++++ b/docs/TableGen/LangRef.rst
+@@ -102,6 +102,12 @@ wide variety of meanings:
+                :!isa    !dag     !le      !lt        !ge
+                :!gt     !ne
+ 
++TableGen also has !cond operator that needs a slightly different
++syntax compared to other "bang operators":
++
++.. productionlist::
++   CondOperator: !cond
++
+ 
+ Syntax
+ ======
+@@ -140,7 +146,7 @@ considered to define the class if any of the following is true:
+ #. The :token:`Body` in the :token:`ObjectBody` is present and is not empty.
+ #. The :token:`BaseClassList` in the :token:`ObjectBody` is present.
+ 
+-You can declare an empty class by giving and empty :token:`TemplateArgList`
++You can declare an empty class by giving an empty :token:`TemplateArgList`
+ and an empty :token:`ObjectBody`. This can serve as a restricted form of
+ forward declaration: note that records deriving from the forward-declared
+ class will inherit no fields from it since the record expansion is done
+@@ -315,6 +321,8 @@ The initial :token:`DagArg` is called the "operator" of the dag.
+ 
+ .. productionlist::
+    SimpleValue: `BangOperator` ["<" `Type` ">"] "(" `ValueListNE` ")"
++              :| `CondOperator` "(" `CondVal` ("," `CondVal`)* ")"
++   CondVal: `Value` ":" `Value`
+ 
+ Bodies
+ ------
+diff --git a/include/llvm/TableGen/Record.h b/include/llvm/TableGen/Record.h
+index e022bc82b4e..3ca67ec72bd 100644
+--- a/include/llvm/TableGen/Record.h
++++ b/include/llvm/TableGen/Record.h
+@@ -316,6 +316,7 @@ protected:
+     IK_TernOpInit,
+     IK_UnOpInit,
+     IK_LastOpInit,
++    IK_CondOpInit,
+     IK_FoldOpInit,
+     IK_IsAOpInit,
+     IK_StringInit,
+@@ -912,6 +913,83 @@ public:
+   std::string getAsString() const override;
+ };
+ 
++/// !cond(condition_1: value1, ... , condition_n: value)
++/// Selects the first value for which condition is true.
++/// Otherwise reports an error.
++class CondOpInit final : public TypedInit, public FoldingSetNode,
++                      public TrailingObjects<CondOpInit, Init *> {
++  unsigned NumConds;
++  RecTy *ValType;
++
++  CondOpInit(unsigned NC, RecTy *Type)
++    : TypedInit(IK_CondOpInit, Type),
++      NumConds(NC), ValType(Type) {}
++
++  size_t numTrailingObjects(OverloadToken<Init *>) const {
++    return 2*NumConds;
++  }
++
++public:
++  CondOpInit(const CondOpInit &) = delete;
++  CondOpInit &operator=(const CondOpInit &) = delete;
++
++  static bool classof(const Init *I) {
++    return I->getKind() == IK_CondOpInit;
++  }
++
++  static CondOpInit *get(ArrayRef<Init*> C, ArrayRef<Init*> V,
++                        RecTy *Type);
++
++  void Profile(FoldingSetNodeID &ID) const;
++
++  RecTy *getValType() const { return ValType; }
++
++  unsigned getNumConds() const { return NumConds; }
++
++  Init *getCond(unsigned Num) const {
++    assert(Num < NumConds && "Condition number out of range!");
++    return getTrailingObjects<Init *>()[Num];
++  }
++
++  Init *getVal(unsigned Num) const {
++    assert(Num < NumConds && "Val number out of range!");
++    return getTrailingObjects<Init *>()[Num+NumConds];
++  }
++
++  ArrayRef<Init *> getConds() const {
++    return makeArrayRef(getTrailingObjects<Init *>(), NumConds);
++  }
++
++  ArrayRef<Init *> getVals() const {
++    return makeArrayRef(getTrailingObjects<Init *>()+NumConds, NumConds);
++  }
++
++  Init *Fold(Record *CurRec) const;
++
++  Init *resolveReferences(Resolver &R) const override;
++
++  bool isConcrete() const override;
++  bool isComplete() const override;
++  std::string getAsString() const override;
++
++  using const_case_iterator = SmallVectorImpl<Init*>::const_iterator;
++  using const_val_iterator = SmallVectorImpl<Init*>::const_iterator;
++
++  inline const_case_iterator  arg_begin() const { return getConds().begin(); }
++  inline const_case_iterator  arg_end  () const { return getConds().end(); }
++
++  inline size_t              case_size () const { return NumConds; }
++  inline bool                case_empty() const { return NumConds == 0; }
++
++  inline const_val_iterator name_begin() const { return getVals().begin();}
++  inline const_val_iterator name_end  () const { return getVals().end(); }
++
++  inline size_t              val_size () const { return NumConds; }
++  inline bool                val_empty() const { return NumConds == 0; }
++
++  Init *getBit(unsigned Bit) const override;
++};
++
+ /// !foldl (a, b, expr, start, lst) - Fold over a list.
+ class FoldOpInit : public TypedInit, public FoldingSetNode {
+ private:
+diff --git a/lib/TableGen/Record.cpp b/lib/TableGen/Record.cpp
+index cf1685a2e8c..26ffe761b66 100644
+--- a/lib/TableGen/Record.cpp
++++ b/lib/TableGen/Record.cpp
+@@ -1694,6 +1694,137 @@ Init *FieldInit::Fold(Record *CurRec) const {
+   return const_cast<FieldInit *>(this);
+ }
+ 
++static void ProfileCondOpInit(FoldingSetNodeID &ID,
++                             ArrayRef<Init *> CondRange,
++                             ArrayRef<Init *> ValRange,
++                             const RecTy *ValType) {
++  assert(CondRange.size() == ValRange.size() &&
++         "Number of conditions and values must match!");
++  ID.AddPointer(ValType);
++  ArrayRef<Init *>::iterator Case = CondRange.begin();
++  ArrayRef<Init *>::iterator Val = ValRange.begin();
++
++  while (Case != CondRange.end()) {
++    ID.AddPointer(*Case++);
++    ID.AddPointer(*Val++);
++  }
++}
++
++void CondOpInit::Profile(FoldingSetNodeID &ID) const {
++  ProfileCondOpInit(ID,
++      makeArrayRef(getTrailingObjects<Init *>(), NumConds),
++      makeArrayRef(getTrailingObjects<Init *>() + NumConds, NumConds),
++      ValType);
++}
++
++CondOpInit *
++CondOpInit::get(ArrayRef<Init *> CondRange,
++                ArrayRef<Init *> ValRange, RecTy *Ty) {
++  assert(CondRange.size() == ValRange.size() &&
++         "Number of conditions and values must match!");
++
++  static FoldingSet<CondOpInit> ThePool;
++  FoldingSetNodeID ID;
++  ProfileCondOpInit(ID, CondRange, ValRange, Ty);
++
++  void *IP = nullptr;
++  if (CondOpInit *I = ThePool.FindNodeOrInsertPos(ID, IP))
++    return I;
++
++  void *Mem = Allocator.Allocate(totalSizeToAlloc<Init *>(2*CondRange.size()),
++                                 alignof(BitsInit));
++  CondOpInit *I = new(Mem) CondOpInit(CondRange.size(), Ty);
++
++  std::uninitialized_copy(CondRange.begin(), CondRange.end(),
++                          I->getTrailingObjects<Init *>());
++  std::uninitialized_copy(ValRange.begin(), ValRange.end(),
++                          I->getTrailingObjects<Init *>()+CondRange.size());
++  ThePool.InsertNode(I, IP);
++  return I;
++}
++
++Init *CondOpInit::resolveReferences(Resolver &R) const {
++  SmallVector<Init*, 4> NewConds;
++  bool Changed = false;
++  for (const Init *Case : getConds()) {
++    Init *NewCase = Case->resolveReferences(R);
++    NewConds.push_back(NewCase);
++    Changed |= NewCase != Case;
++  }
++
++  SmallVector<Init*, 4> NewVals;
++  for (const Init *Val : getVals()) {
++    Init *NewVal = Val->resolveReferences(R);
++    NewVals.push_back(NewVal);
++    Changed |= NewVal != Val;
++  }
++
++  if (Changed)
++    return (CondOpInit::get(NewConds, NewVals,
++            getValType()))->Fold(R.getCurrentRecord());
++
++  return const_cast<CondOpInit *>(this);
++}
++
++Init *CondOpInit::Fold(Record *CurRec) const {
++  for ( unsigned i = 0; i < NumConds; ++i) {
++    Init *Cond = getCond(i);
++    Init *Val = getVal(i);
++
++    if (IntInit *CondI = dyn_cast_or_null<IntInit>(
++            Cond->convertInitializerTo(IntRecTy::get()))) {
++      if (CondI->getValue())
++        return Val->convertInitializerTo(getValType());
++    } else
++     return const_cast<CondOpInit *>(this);
++  }
++
++  PrintFatalError(CurRec->getLoc(),
++                  CurRec->getName() +
++                  " does not have any true condition in:" +
++                  this->getAsString());
++  return nullptr;
++}
++
++bool CondOpInit::isConcrete() const {
++  for (const Init *Case : getConds())
++    if (!Case->isConcrete())
++      return false;
++
++  for (const Init *Val : getVals())
++    if (!Val->isConcrete())
++      return false;
++
++  return true;
++}
++
++bool CondOpInit::isComplete() const {
++  for (const Init *Case : getConds())
++    if (!Case->isComplete())
++      return false;
++
++  for (const Init *Val : getVals())
++    if (!Val->isConcrete())
++      return false;
++
++  return true;
++}
++
++std::string CondOpInit::getAsString() const {
++  std::string Result = "!cond(";
++  for (unsigned i = 0; i < getNumConds(); i++) {
++    Result += getCond(i)->getAsString() + ": ";
++    Result += getVal(i)->getAsString();
++    if (i != getNumConds()-1)
++      Result += ", ";
++  }
++  return Result + ")";
++}
++
++Init *CondOpInit::getBit(unsigned Bit) const {
++  return VarBitInit::get(const_cast<CondOpInit *>(this), Bit);
++}
++
+ static void ProfileDagInit(FoldingSetNodeID &ID, Init *V, StringInit *VN,
+                            ArrayRef<Init *> ArgRange,
+                            ArrayRef<StringInit *> NameRange) {
+diff --git a/lib/TableGen/TGLexer.cpp b/lib/TableGen/TGLexer.cpp
+index 16aeee56107..f733cc3c134 100644
+--- a/lib/TableGen/TGLexer.cpp
++++ b/lib/TableGen/TGLexer.cpp
+@@ -545,6 +545,7 @@ tgtok::TokKind TGLexer::LexExclaim() {
+     .Case("ge", tgtok::XGe)
+     .Case("gt", tgtok::XGt)
+     .Case("if", tgtok::XIf)
++    .Case("cond", tgtok::XCond)
+     .Case("isa", tgtok::XIsA)
+     .Case("head", tgtok::XHead)
+     .Case("tail", tgtok::XTail)
+diff --git a/lib/TableGen/TGLexer.h b/lib/TableGen/TGLexer.h
+index e9980b36b97..9bdb01cf3dd 100644
+--- a/lib/TableGen/TGLexer.h
++++ b/lib/TableGen/TGLexer.h
+@@ -51,7 +51,7 @@ namespace tgtok {
+ 
+     // !keywords.
+     XConcat, XADD, XAND, XOR, XSRA, XSRL, XSHL, XListConcat, XStrConcat, XCast,
+-    XSubst, XForEach, XFoldl, XHead, XTail, XSize, XEmpty, XIf, XEq, XIsA, XDag,
++    XSubst, XForEach, XFoldl, XHead, XTail, XSize, XEmpty, XIf, XCond, XEq, XIsA, XDag,
+     XNe, XLe, XLt, XGe, XGt,
+ 
+     // Integer value.
+diff --git a/lib/TableGen/TGParser.cpp b/lib/TableGen/TGParser.cpp
+index 1d1f3603c83..200190acd59 100644
+--- a/lib/TableGen/TGParser.cpp
++++ b/lib/TableGen/TGParser.cpp
+@@ -1445,6 +1445,9 @@ Init *TGParser::ParseOperation(Record *CurRec, RecTy *ItemType) {
+     return (TernOpInit::get(Code, LHS, MHS, RHS, Type))->Fold(CurRec);
+   }
+ 
++  case tgtok::XCond:
++    return ParseOperationCond(CurRec, ItemType);
++
+   case tgtok::XFoldl: {
+     // Value ::= !foldl '(' Id ',' Id ',' Value ',' Value ',' Value ')'
+     Lex.Lex(); // eat the operation
+@@ -1603,6 +1606,91 @@ RecTy *TGParser::ParseOperatorType() {
+   return Type;
+ }
+ 
++Init *TGParser::ParseOperationCond(Record *CurRec, RecTy *ItemType) {
++  Lex.Lex();  // eat the operation 'cond'
++
++  if (Lex.getCode() != tgtok::l_paren) {
++     TokError("expected '(' after !cond operator");
++     return nullptr;
++  }
++  Lex.Lex();  // eat the '('
++
++  // Parse through '[Case: Val,]+'
++  SmallVector<Init *, 4> Case;
++  SmallVector<Init *, 4> Val;
++  while (true) {
++    if (Lex.getCode() == tgtok::r_paren) {
++      Lex.Lex(); // eat the ')'
++      break;
++    }
++
++    Init *V = ParseValue(CurRec);
++    if (!V)
++      return nullptr;
++    Case.push_back(V);
++
++    if (Lex.getCode() != tgtok::colon) {
++      TokError("expected ':'  following a condition in !cond operator");
++      return nullptr;
++    }
++    Lex.Lex(); // eat the ':'
++
++    V = ParseValue(CurRec, ItemType);
++    if (!V)
++      return nullptr;
++    Val.push_back(V);
++
++    if (Lex.getCode() == tgtok::r_paren) {
++      Lex.Lex(); // eat the ')'
++      break;
++    }
++
++    if (Lex.getCode() != tgtok::comma) {
++      TokError("expected ',' or ')' following a value in !cond operator");
++      return nullptr;
++    }
++    Lex.Lex();  // eat the ','
++  }
++
++  if (Case.size() < 1) {
++    TokError("there should be at least 1 'condition : value' in the !cond operator");
++    return nullptr;
++  }
++
++  // resolve type
++  RecTy *Type = nullptr;
++  for (Init *V : Val) {
++    RecTy *VTy = nullptr;
++    if (TypedInit *Vt = dyn_cast<TypedInit>(V))
++      VTy = Vt->getType();
++    if (BitsInit *Vbits = dyn_cast<BitsInit>(V))
++      VTy = BitsRecTy::get(Vbits->getNumBits());
++    if (isa<BitInit>(V))
++      VTy = BitRecTy::get();
++
++    if (Type == nullptr) {
++      if (!isa<UnsetInit>(V))
++        Type = VTy;
++    } else {
++      if (!isa<UnsetInit>(V)) {
++        RecTy *RType = resolveTypes(Type, VTy);
++        if (!RType) {
++          TokError(Twine("inconsistent types '") + Type->getAsString() +
++                         "' and '" + VTy->getAsString() + "' for !cond");
++          return nullptr;
++        }
++        Type = RType;
++      }
++    }
++  }
++
++  if (!Type) {
++    TokError("could not determine type for !cond from its arguments");
++    return nullptr;
++  }
++  return CondOpInit::get(Case, Val, Type)->Fold(CurRec);
++}
++
+ /// ParseSimpleValue - Parse a tblgen value.  This returns null on error.
+ ///
+ ///   SimpleValue ::= IDValue
+@@ -1621,6 +1709,7 @@ RecTy *TGParser::ParseOperatorType() {
+ ///   SimpleValue ::= SRLTOK '(' Value ',' Value ')'
+ ///   SimpleValue ::= LISTCONCATTOK '(' Value ',' Value ')'
+ ///   SimpleValue ::= STRCONCATTOK '(' Value ',' Value ')'
++///   SimpleValue ::= COND '(' [Value ':' Value,]+ ')'
+ ///
+ Init *TGParser::ParseSimpleValue(Record *CurRec, RecTy *ItemType,
+                                  IDParseMode Mode) {
+@@ -1933,6 +2022,7 @@ Init *TGParser::ParseSimpleValue(Record *CurRec, RecTy *ItemType,
+   case tgtok::XListConcat:
+   case tgtok::XStrConcat:   // Value ::= !binop '(' Value ',' Value ')'
+   case tgtok::XIf:
++  case tgtok::XCond:
+   case tgtok::XFoldl:
+   case tgtok::XForEach:
+   case tgtok::XSubst: {  // Value ::= !ternop '(' Value ',' Value ',' Value ')'
+diff --git a/lib/TableGen/TGParser.h b/lib/TableGen/TGParser.h
+index e3849043513..215b9dad770 100644
+--- a/lib/TableGen/TGParser.h
++++ b/lib/TableGen/TGParser.h
+@@ -194,6 +194,7 @@ private:  // Parser methods.
+   bool ParseRangePiece(SmallVectorImpl<unsigned> &Ranges);
+   RecTy *ParseType();
+   Init *ParseOperation(Record *CurRec, RecTy *ItemType);
++  Init *ParseOperationCond(Record *CurRec, RecTy *ItemType);
+   RecTy *ParseOperatorType();
+   Init *ParseObjectName(MultiClass *CurMultiClass);
+   Record *ParseClassID();
+diff --git a/test/TableGen/cond-bitlist.td b/test/TableGen/cond-bitlist.td
+new file mode 100644
+index 00000000000..bce615838df
+--- /dev/null
++++ b/test/TableGen/cond-bitlist.td
+@@ -0,0 +1,27 @@
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++class S<int s> {
++  bits<2> val = !cond(!eq(s, 8):  {0, 0},
++                      !eq(s, 16): 0b01,
++                      !eq(s, 32): 2,
++                      !eq(s, 64): {1, 1},
++                              1 : ?);
++}
++
++def D8  : S<8>;
++def D16 : S<16>;
++def D32 : S<32>;
++def D64 : S<64>;
++def D128: S<128>;
++// CHECK: def D128
++// CHECK-NEXT: bits<2> val = { ?, ? };
++// CHECK: def D16
++// CHECK-NEXT: bits<2> val = { 0, 1 };
++// CHECK: def D32
++// CHECK-NEXT: bits<2> val = { 1, 0 };
++// CHECK: def D64
++// CHECK-NEXT: bits<2> val = { 1, 1 };
++// CHECK: def D8
++// CHECK-NEXT: bits<2> val = { 0, 0 };
++
+diff --git a/test/TableGen/cond-default.td b/test/TableGen/cond-default.td
+new file mode 100644
+index 00000000000..816bf10676f
+--- /dev/null
++++ b/test/TableGen/cond-default.td
+@@ -0,0 +1,11 @@
++// Check that not specifying a valid condition results in error
++
++// RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
++// XFAIL: vg_leak
++
++class C<int x> {
++  string s  = !cond(!lt(x,0) : "negative", !gt(x,0) : "positive");
++}
++
++def Zero : C<0>;
++//CHECK: error: Zero does not have any true condition in:!cond(0: "negative", 0: "positive")
+diff --git a/test/TableGen/cond-empty-list-arg.td b/test/TableGen/cond-empty-list-arg.td
+new file mode 100644
+index 00000000000..5f4ccade169
+--- /dev/null
++++ b/test/TableGen/cond-empty-list-arg.td
+@@ -0,0 +1,8 @@
++// RUN: llvm-tblgen %s
++// XFAIL: vg_leak
++
++class C<bit cond> {
++  bit true = 1;
++  list<int> X = !cond(cond: [1, 2, 3], true : []);
++  list<int> Y = !cond(cond: [], true : [4, 5, 6]);
++}
+diff --git a/test/TableGen/cond-inheritance.td b/test/TableGen/cond-inheritance.td
+new file mode 100644
+index 00000000000..4b4abdf72f3
+--- /dev/null
++++ b/test/TableGen/cond-inheritance.td
+@@ -0,0 +1,22 @@
++// Make sure !cond gets propagated across multiple layers of inheritance.
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++class getInt<int c> {
++  int ret = !cond(c: 0, 1 : 1);
++}
++
++class I1<int c> {
++  int i = getInt<c>.ret;
++}
++
++class I2<int c> : I1<c>;
++
++def DI1: I1<1>;
++// CHECK: def DI1 {     // I1
++// CHECK-NEXT: int i = 0;
++
++// CHECK: def DI2 {     // I1 I2
++// CHECK-NEXT: int i = 0;
++def DI2: I2<1>;
++
+diff --git a/test/TableGen/cond-let.td b/test/TableGen/cond-let.td
+new file mode 100644
+index 00000000000..044878f2ab8
+--- /dev/null
++++ b/test/TableGen/cond-let.td
+@@ -0,0 +1,36 @@
++// Check support for `!cond' operator as part of a `let' statement.
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++
++class C<bits<3> x, bits<4> y, bit z> {
++  bits<16> n;
++
++  let n{11}  = !cond(y{3}: 1,
++                     y{2}: x{0},
++                     y{1}: x{1},
++                     y{0}: x{2},
++                     {1} :?);
++  let n{10-9}= !cond(x{2}: y{3-2},
++                     x{1}: y{2-1},
++                     x{1}: y{1-0},
++                     {1} : ?);
++  let n{8-6} = !cond(x{2}: 0b010,  1 : 0b110);
++  let n{5-4} = !cond(x{1}: y{3-2}, 1 :  {0, 1});
++  let n{3-0} = !cond(x{0}: y{3-0}, 1 : {z, y{2}, y{1}, y{0}});
++}
++
++
++def C1 : C<{1, 0, 1}, {0, 1, 0, 1}, 0>;
++def C2 : C<{0, 1, 0}, {1, 0, 1, 0}, 1>;
++def C3 : C<{0, 0, 0}, {1, 0, 1, 0}, 0>;
++def C4 : C<{0, 0, 0}, {0, 0, 0, 0}, 0>;
++
++// CHECK: def C1
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1 };
++// CHECK: def C2
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0 };
++// CHECK: def C3
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, 1, ?, ?, 1, 1, 0, 0, 1, 0, 0, 1, 0 };
++// CHECK: def C4
++// CHECK-NEXT: bits<16> n = { ?, ?, ?, ?, ?, ?, ?, 1, 1, 0, 0, 1, 0, 0, 0, 0 };
+diff --git a/test/TableGen/cond-list.td b/test/TableGen/cond-list.td
+new file mode 100644
+index 00000000000..aa013cea4e1
+--- /dev/null
++++ b/test/TableGen/cond-list.td
+@@ -0,0 +1,38 @@
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++
++class A<list<list<int>> vals> {
++  list<int> first = vals[0];
++  list<int> rest  = !cond(!empty(!tail(vals)): vals[0],
++                          1                 : vals[1]);
++}
++
++def A_OneEl : A<[[1,2,3]]>;
++// CHECK:      def A_OneEl {  // A
++// CHECK-NEXT: list<int> first = [1, 2, 3];
++// CHECK-NEXT: list<int> rest = [1, 2, 3];
++// CHECK-NEXT: }
++
++def A_TwoEl : A<[[1,2,3], [4,5,6]]>;
++// CHECK:      def A_TwoEl { // A
++// CHECK-NEXT: list<int> first = [1, 2, 3];
++// CHECK-NEXT: list<int> rest = [4, 5, 6];
++// CHECK-NEXT: }
++
++
++class B<list<int> v> {
++  list<int> vals = v;
++}
++class BB<list<list<int>> vals> : B<!cond(!empty(!tail(vals)): vals[0],  1 : vals[1])>;
++class BBB<list<list<int>> vals> : BB<vals>;
++
++def B_OneEl : BBB<[[1,2,3]]>;
++// CHECK:      def B_OneEl { //  B BB BBB
++// CHECK-NEXT: list<int> vals = [1, 2, 3];
++// CHECK-NEXT: }
++
++def B_TwoEl : BBB<[[1,2,3],[4,5,6]]>;
++// CHECK:      def B_TwoEl { // B BB BBB
++// CHECK-NEXT: list<int> vals = [4, 5, 6];
++// CHECK-NEXT: }
+diff --git a/test/TableGen/cond-subclass.td b/test/TableGen/cond-subclass.td
+new file mode 100644
+index 00000000000..9f6f6e2cb8c
+--- /dev/null
++++ b/test/TableGen/cond-subclass.td
+@@ -0,0 +1,27 @@
++// Check that !cond with operands of different subtypes can
++// initialize a supertype variable.
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++class E<int dummy> {}
++class E1<int dummy> : E<dummy> {}
++class E2<int dummy> : E<dummy> {}
++
++class EX<int cc, E1 b, E2 c> {
++  E x = !cond(cc: b, 1 : c);
++}
++
++def E1d : E1<0>;
++def E2d : E2<0>;
++
++def EXd1 : EX<1, E1d, E2d>;
++def EXd2 : EX<0, E1d, E2d>;
++
++// CHECK: def EXd1 {
++// CHECK:   E x = E1d;
++// CHECK: }
++//
++// CHECK: def EXd2 {
++// CHECK:   E x = E2d;
++// CHECK: }
++
+diff --git a/test/TableGen/cond-type.td b/test/TableGen/cond-type.td
+new file mode 100644
+index 00000000000..fd2a3cc52b7
+--- /dev/null
++++ b/test/TableGen/cond-type.td
+@@ -0,0 +1,11 @@
++// RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
++// XFAIL: vg_leak
++
++class A<int dummy> {}
++class B<int dummy> : A<dummy> {}
++class C<int dummy> : A<dummy> {}
++
++// CHECK: Value 'x' of type 'C' is incompatible with initializer '{{.*}}' of type 'A'
++class X<int cc, B b, C c> {
++  C x = !cond(cc: b, 1 : c);
++}
+diff --git a/test/TableGen/cond-usage.td b/test/TableGen/cond-usage.td
+new file mode 100644
+index 00000000000..055fd6d7c69
+--- /dev/null
++++ b/test/TableGen/cond-usage.td
+@@ -0,0 +1,29 @@
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++
++// Check that !cond picks the first true value
++// CHECK:       class A
++// CHECK-NEXT:  string S = !cond(!eq(A:x, 10): "ten", !eq(A:x, 11): "eleven", !eq(A:x, 10): "TEN", !gt(A:x, 9): "MoreThanNine", 1: "unknown"); 
++// CHECK: B1
++// CHECK-NEXT: string S = "unknown"
++// CHECK: B10
++// CHECK-NEXT: string S = "ten";
++// CHECK: def B11
++// CHECK-NEXT: string S = "eleven";
++// CHECK: def B12
++// CHECK-NEXT:  string S = "MoreThanNine";
++// CHECK: def B9
++// CHECK-NEXT: string S = "unknown"
++
++class A<int x> {
++  string S = !cond(!eq(x,10) : "ten",
++                   !eq(x,11) : "eleven",
++                   !eq(x,10) : "TEN",
++                   !gt(x,9) : "MoreThanNine",
++                   !eq(1,1) : "unknown");
++}
++def B1  : A<1>;
++def B9  : A<9>;
++def B10 : A<10>;
++def B11 : A<11>;
++def B12 : A<12>;
+diff --git a/test/TableGen/condsbit.td b/test/TableGen/condsbit.td
+new file mode 100644
+index 00000000000..e08ac97f68b
+--- /dev/null
++++ b/test/TableGen/condsbit.td
+@@ -0,0 +1,15 @@
++// check that !cond works well with bit conditional values
++// RUN: llvm-tblgen %s | FileCheck %s
++// XFAIL: vg_leak
++// CHECK: a = 6
++// CHECK: a = 5
++
++class A<bit b = 1> {
++  bit true = 1;
++  int a = !cond(b: 5, true : 6);
++  bit c = !cond(b: 0, true : 1);
++  bits<1> d = !cond(b: 0, true : 1);
++}
++
++def X : A<0>;
++def Y : A;
+-- 
+2.17.1
+

--- a/deps/patches/llvm-8.0-D59389-refactor-wmma.patch
+++ b/deps/patches/llvm-8.0-D59389-refactor-wmma.patch
@@ -1,0 +1,899 @@
+From e9737bf498597707d084398b9485676dc7421644 Mon Sep 17 00:00:00 2001
+From: Artem Belevich <tra@google.com>
+Date: Thu, 25 Apr 2019 22:27:35 +0000
+Subject: [PATCH] [NVPTX] Refactor generation of MMA intrinsics and
+ instructions. NFC.
+
+Generalized constructions of 'fragments' of MMA operations to provide
+common primitives for construction of the ops. This will make it easier
+to add new variants of the instructions that operate on integer types.
+
+Use nested foreach loops which makes it possible to better control
+naming of the intrinsics.
+
+This patch does not affect LLVM's output, so there are no test changes.
+
+Differential Revision: https://reviews.llvm.org/D59389
+
+llvm-svn: 359245
+---
+ include/llvm/IR/IntrinsicsNVVM.td   | 258 ++++++--------
+ lib/Target/NVPTX/NVPTXIntrinsics.td | 512 ++++++++++------------------
+ 2 files changed, 295 insertions(+), 475 deletions(-)
+
+diff --git a/include/llvm/IR/IntrinsicsNVVM.td b/include/llvm/IR/IntrinsicsNVVM.td
+index 7f694f68969..e30a27613a6 100644
+--- a/include/llvm/IR/IntrinsicsNVVM.td
++++ b/include/llvm/IR/IntrinsicsNVVM.td
+@@ -38,6 +38,69 @@ def llvm_anyi64ptr_ty     : LLVMAnyPointerType<llvm_i64_ty>;     // (space)i64*
+ // MISC
+ //
+ 
++// Helper class for construction of n-element list<LLVMtype> [t,t,...,t]
++class RepLLVMType<int N, LLVMType T> {
++  list<LLVMType> ret = !if(N, !listconcat(RepLLVMType<!add(N,-1), T>.ret, [T]), []);
++}
++
++// Helper class that represents a 'fragment' of an NVPTX *MMA instruction.
++// Geom: m<M>n<N>k<K>. E.g. m8n32k16
++// Frag: [abcd]
++// PtxEltType: PTX type for the element.
++class WMMA_REGS<string Geom, string Frag, string PtxEltType> {
++  string geom = Geom;
++  string frag = Frag;
++  string ptx_elt_type = PtxEltType;
++  string ft = frag#":"#ptx_elt_type;
++  list<LLVMType> regs = !cond(
++    // fp16 -> fp16/fp32 @  m16n16k16/m8n32k16/m32n8k16
++    // All currently supported geometries use the same fragment format,
++    // so we only need to consider {fragment, type}.
++    !eq(ft,"a:f16") : RepLLVMType<8, llvm_v2f16_ty>.ret,
++    !eq(ft,"b:f16") : RepLLVMType<8, llvm_v2f16_ty>.ret,
++    !eq(ft,"c:f16") : RepLLVMType<4, llvm_v2f16_ty>.ret,
++    !eq(ft,"d:f16") : RepLLVMType<4, llvm_v2f16_ty>.ret,
++    !eq(ft,"c:f32") : RepLLVMType<8, llvm_float_ty>.ret,
++    !eq(ft,"d:f32") : RepLLVMType<8, llvm_float_ty>.ret);
++}
++
++class WMMA_NAME_LDST<string Op, WMMA_REGS Frag, string Layout, int WithStride> {
++  string intr = "llvm.nvvm.wmma."
++                # Frag.geom
++                # "." # Op
++                # "." # Frag.frag
++                # "." # Layout
++                # !if(WithStride, ".stride", "")
++                # "." # Frag.ptx_elt_type
++                ;
++  // TODO(tra): record name should ideally use the same field order as the intrinsic.
++  // E.g. string record = !subst("llvm", "int",
++  //                      !subst(".", "_", llvm));
++  string record = "int_nvvm_wmma_"
++                # Frag.geom
++                # "_" # Op
++                # "_" # Frag.frag
++                # "_" # Frag.ptx_elt_type
++                # "_" # Layout
++                # !if(WithStride, "_stride", "");
++}
++
++class WMMA_NAME_MMA<string ALayout, string BLayout,
++                    WMMA_REGS C, WMMA_REGS D,
++                    int Satfinite> {
++  string llvm = "llvm.nvvm.wmma."
++                # C.geom
++                # ".mma"
++                # "." # ALayout
++                # "." # BLayout
++                # "." # D.ptx_elt_type  // Intrinsic encodes 'd' first.
++                # "." # C.ptx_elt_type
++                # !if(Satfinite, ".satfinite", "");
++
++  string record = !subst(".", "_",
++                  !subst("llvm.", "int_", llvm));
++}
++
+ let TargetPrefix = "nvvm" in {
+   def int_nvvm_prmt : GCCBuiltin<"__nvvm_prmt">,
+       Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
+@@ -3882,166 +3945,69 @@ def int_nvvm_match_all_sync_i64p :
+ //
+ // WMMA instructions
+ //
+-
+ // WMMA.LOAD
+-class NVVM_WMMA_LD_GALSTS<string Geometry, string Abc, string Layout,
+-                          string Type, LLVMType regty, int WithStride>
+-  : Intrinsic<!if(!eq(Abc#Type,"cf16"),
+-                  [regty, regty, regty, regty],
+-                  [regty, regty, regty, regty,
+-                   regty, regty, regty, regty]),
++class NVVM_WMMA_LD<WMMA_REGS Frag, string Layout, int WithStride>
++  : Intrinsic<Frag.regs,
+               !if(WithStride, [llvm_anyptr_ty, llvm_i32_ty], [llvm_anyptr_ty]),
+               [IntrReadMem, IntrArgMemOnly, ReadOnly<0>, NoCapture<0>],
+-              "llvm.nvvm.wmma."
+-                # Geometry
+-                # ".load"
+-                # "." # Abc
+-                # "." # Layout
+-                # !if(WithStride, ".stride", "")
+-                # "." # Type>;
+-
+-multiclass NVVM_WMMA_LD_GALT<string Geometry, string Abc, string Layout,
+-                             string Type, LLVMType regty> {
+-  def _stride: NVVM_WMMA_LD_GALSTS<Geometry, Abc, Layout, Type, regty, 1>;
+-  def NAME   : NVVM_WMMA_LD_GALSTS<Geometry, Abc, Layout, Type, regty, 0>;
+-}
+-
+-multiclass NVVM_WMMA_LD_GAT<string Geometry, string Abc,
+-                           string Type, LLVMType regty> {
+-  defm _row: NVVM_WMMA_LD_GALT<Geometry, Abc, "row", Type, regty>;
+-  defm _col: NVVM_WMMA_LD_GALT<Geometry, Abc, "col", Type, regty>;
+-}
+-
+-multiclass NVVM_WMMA_LD_G<string Geometry> {
+-  defm _a_f16: NVVM_WMMA_LD_GAT<Geometry, "a", "f16", llvm_v2f16_ty>;
+-  defm _b_f16: NVVM_WMMA_LD_GAT<Geometry, "b", "f16", llvm_v2f16_ty>;
+-  defm _c_f16: NVVM_WMMA_LD_GAT<Geometry, "c", "f16", llvm_v2f16_ty>;
+-  defm _c_f32: NVVM_WMMA_LD_GAT<Geometry, "c", "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_LD {
+-  defm _m32n8k16_load: NVVM_WMMA_LD_G<"m32n8k16">;
+-  defm _m16n16k16_load: NVVM_WMMA_LD_G<"m16n16k16">;
+-  defm _m8n32k16_load: NVVM_WMMA_LD_G<"m8n32k16">;
+-}
+-
+-defm int_nvvm_wmma: NVVM_WMMA_LD;
++              WMMA_NAME_LDST<"load", Frag, Layout, WithStride>.intr>;
+ 
+ // WMMA.STORE.D
+-class NVVM_WMMA_STD_GLSTS<string Geometry, string Layout,
+-                          string Type, LLVMType regty, int WithStride,
+-                          // This is only used to create a typed empty array we
+-                          // need to pass to !if below.
+-                          list<LLVMType>Empty=[]>
++class NVVM_WMMA_ST<WMMA_REGS Frag, string Layout, int WithStride>
+   : Intrinsic<[],
+               !listconcat(
+                 [llvm_anyptr_ty],
+-                !if(!eq(Type,"f16"),
+-                    [regty, regty, regty, regty],
+-                    [regty, regty, regty, regty,
+-                     regty, regty, regty, regty]),
+-                !if(WithStride, [llvm_i32_ty], Empty)),
++                Frag.regs,
++                !if(WithStride, [llvm_i32_ty], [])),
+               [IntrWriteMem, IntrArgMemOnly, WriteOnly<0>, NoCapture<0>],
+-              "llvm.nvvm.wmma."
+-                   # Geometry
+-                   # ".store.d"
+-                   # "." # Layout
+-                   # !if(WithStride, ".stride", "")
+-                   # "." # Type>;
+-
+-multiclass NVVM_WMMA_STD_GLT<string Geometry, string Layout,
+-                             string Type, LLVMType regty> {
+-  def _stride: NVVM_WMMA_STD_GLSTS<Geometry, Layout, Type, regty, 1>;
+-  def NAME:    NVVM_WMMA_STD_GLSTS<Geometry, Layout, Type, regty, 0>;
+-}
+-
+-multiclass NVVM_WMMA_STD_GT<string Geometry, string Type, LLVMType regty> {
+-  defm _row: NVVM_WMMA_STD_GLT<Geometry, "row", Type, regty>;
+-  defm _col: NVVM_WMMA_STD_GLT<Geometry, "col", Type, regty>;
+-}
+-multiclass NVVM_WMMA_STD_G<string Geometry> {
+-  defm _d_f16: NVVM_WMMA_STD_GT<Geometry, "f16", llvm_v2f16_ty>;
+-  defm _d_f32: NVVM_WMMA_STD_GT<Geometry, "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_STD {
+-  defm _m32n8k16_store:  NVVM_WMMA_STD_G<"m32n8k16">;
+-  defm _m16n16k16_store: NVVM_WMMA_STD_G<"m16n16k16">;
+-  defm _m8n32k16_store:  NVVM_WMMA_STD_G<"m8n32k16">;
++              WMMA_NAME_LDST<"store", Frag, Layout, WithStride>.intr>;
++
++// Create all load/store variants 
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout = ["row", "col"] in {
++    foreach stride = [0, 1] in {
++      foreach frag = [WMMA_REGS<geom, "a", "f16">,
++                      WMMA_REGS<geom, "b", "f16">,
++                      WMMA_REGS<geom, "c", "f16">,
++                      WMMA_REGS<geom, "c", "f32">] in {
++          def WMMA_NAME_LDST<"load", frag, layout, stride>.record
++             : NVVM_WMMA_LD<frag, layout, stride>;
++      }
++      foreach frag = [WMMA_REGS<geom, "d", "f16">,
++                      WMMA_REGS<geom, "d", "f32">] in {
++          def WMMA_NAME_LDST<"store", frag, layout, stride>.record
++             : NVVM_WMMA_ST<frag, layout, stride>;
++      }
++    }
++  }
+ }
+ 
+-defm int_nvvm_wmma: NVVM_WMMA_STD;
+-
+ // WMMA.MMA
+-class NVVM_WMMA_MMA_GABDCS<string Geometry,
+-                           string ALayout, string BLayout,
+-                           string DType, LLVMType d_regty,
+-                           string CType, LLVMType c_regty,
+-                           string Satfinite = "">
+-  : Intrinsic<!if(!eq(DType,"f16"),
+-                      [d_regty, d_regty, d_regty, d_regty],
+-                      [d_regty, d_regty, d_regty, d_regty,
+-                       d_regty, d_regty, d_regty, d_regty]),
++class NVVM_WMMA_MMA<string ALayout, string BLayout,
++                    WMMA_REGS C, WMMA_REGS D, int Satfinite>
++  : Intrinsic<D.regs,
+               !listconcat(
+-                [// A
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty,
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty,
+-                // B
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty,
+-                llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty, llvm_v2f16_ty],
+-                !if(!eq(CType,"f16"),
+-                      [c_regty, c_regty, c_regty, c_regty],
+-                      [c_regty, c_regty, c_regty, c_regty,
+-                       c_regty, c_regty, c_regty, c_regty])),
++                WMMA_REGS<C.geom, "a", "f16">.regs,
++                WMMA_REGS<C.geom, "b", "f16">.regs,
++                C.regs),
+               [IntrNoMem],
+-              "llvm.nvvm.wmma."
+-                # Geometry
+-                # ".mma"
+-                # "." # ALayout
+-                # "." # BLayout
+-                # "." # DType
+-                # "." # CType
+-                # Satfinite> {
+-}
+-
+-multiclass NVVM_WMMA_MMA_GABDC<string Geometry, string ALayout, string BLayout,
+-                               string DType, LLVMType d_regty,
+-                               string CType, LLVMType c_regty> {
+-  def NAME : NVVM_WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                  DType, d_regty, CType, c_regty>;
+-  def _satfinite: NVVM_WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                       DType, d_regty, CType, c_regty,".satfinite">;
+-}
+-
+-multiclass NVVM_WMMA_MMA_GABD<string Geometry, string ALayout, string BLayout,
+-                              string DType, LLVMType d_regty> {
+-  defm _f16: NVVM_WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_regty,
+-                                "f16", llvm_v2f16_ty>;
+-  defm _f32: NVVM_WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_regty,
+-                                "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_MMA_GAB<string Geometry, string ALayout, string BLayout> {
+-  defm _f16: NVVM_WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f16", llvm_v2f16_ty>;
+-  defm _f32: NVVM_WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f32", llvm_float_ty>;
+-}
+-
+-multiclass NVVM_WMMA_MMA_GA<string Geometry, string ALayout> {
+-  defm _col: NVVM_WMMA_MMA_GAB<Geometry, ALayout, "col">;
+-  defm _row: NVVM_WMMA_MMA_GAB<Geometry, ALayout, "row">;
+-}
+-
+-multiclass NVVM_WMMA_MMA_G<string Geometry> {
+-  defm _col: NVVM_WMMA_MMA_GA<Geometry, "col">;
+-  defm _row: NVVM_WMMA_MMA_GA<Geometry, "row">;
+-}
+-
+-multiclass NVVM_WMMA_MMA {
+-  defm _m32n8k16_mma : NVVM_WMMA_MMA_G<"m32n8k16">;
+-  defm _m16n16k16_mma : NVVM_WMMA_MMA_G<"m16n16k16">;
+-  defm _m8n32k16_mma : NVVM_WMMA_MMA_G<"m8n32k16">;
++              WMMA_NAME_MMA<ALayout, BLayout, C, D, Satfinite>.llvm>;
++
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout_a = ["row", "col"] in {
++    foreach layout_b = ["row", "col"] in {
++      foreach frag_c = [WMMA_REGS<geom, "c", "f16">,
++                        WMMA_REGS<geom, "c", "f32">] in {
++        foreach frag_d = [WMMA_REGS<geom, "d", "f16">,
++                          WMMA_REGS<geom, "d", "f32">] in {
++          foreach satf = [0, 1] in {
++            def WMMA_NAME_MMA<layout_a, layout_b, frag_c, frag_d, satf>.record
++             : NVVM_WMMA_MMA<layout_a, layout_b, frag_c, frag_d, satf>;
++          }
++        }
++      }
++    }
++  }
+ }
+ 
+-defm int_nvvm_wmma : NVVM_WMMA_MMA;
+-
+ } // let TargetPrefix = "nvvm"
+diff --git a/lib/Target/NVPTX/NVPTXIntrinsics.td b/lib/Target/NVPTX/NVPTXIntrinsics.td
+index 47dcdcf6e0b..b9a67ba5ed3 100644
+--- a/lib/Target/NVPTX/NVPTXIntrinsics.td
++++ b/lib/Target/NVPTX/NVPTXIntrinsics.td
+@@ -27,7 +27,17 @@ def immDouble1 : PatLeaf<(fpimm), [{
+     return (d==1.0);
+ }]>;
+ 
+-
++def AS_match {
++  code generic = [{
++   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
++  }];
++  code shared = [{
++   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
++  }];
++  code global = [{
++   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
++  }];
++}
+ 
+ //-----------------------------------
+ // Synchronization and shuffle functions
+@@ -1007,17 +1017,11 @@ def INT_FNS_iii : INT_FNS_MBO<(ins    i32imm:$mask,    i32imm:$base,    i32imm:$
+ //-----------------------------------
+ 
+ class ATOMIC_GLOBAL_CHK <dag ops, dag frag>
+- : PatFrag<ops, frag, [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
+-}]>;
++ : PatFrag<ops, frag, AS_match.global>;
+ class ATOMIC_SHARED_CHK <dag ops, dag frag>
+- : PatFrag<ops, frag, [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
+-}]>;
++ : PatFrag<ops, frag, AS_match.shared>;
+ class ATOMIC_GENERIC_CHK <dag ops, dag frag>
+- : PatFrag<ops, frag, [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
+-}]>;
++ : PatFrag<ops, frag, AS_match.generic>;
+ 
+ multiclass F_ATOMIC_2_imp<NVPTXRegClass ptrclass, NVPTXRegClass regclass,
+   string SpaceStr, string TypeStr, string OpcStr, PatFrag IntOp,
+@@ -7381,36 +7385,60 @@ def INT_PTX_SREG_WARPSIZE :
+     NVPTXInst<(outs Int32Regs:$dst), (ins), "mov.u32 \t$dst, WARP_SZ;",
+               [(set Int32Regs:$dst, (int_nvvm_read_ptx_sreg_warpsize))]>;
+ 
+-//
+-// wmma.load.[a|b|c].sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+-//
+-
+ class EmptyNVPTXInst : NVPTXInst<(outs), (ins), "?", []>;
++// Generates list of n sequential register names.
++class RegSeq<int n, string prefix> {
++  list<string> ret = !if(n, !listconcat(RegSeq<!add(n,-1), prefix>.ret,
++                                        [prefix # !add(n, -1)]),
++                            []);
++}
+ 
+-class WMMA_LOAD_GALSTOS<string Geometry, string Abc, string Layout,
+-                        string Space, string Type, NVPTXRegClass regclass,
+-                        DAGOperand SrcOp, bit WithStride>
+-  : EmptyNVPTXInst,
+-    Requires<[!if(!eq(Geometry, "m16n16k16"),
+-                  hasPTX60,
+-                  hasPTX61),
+-              hasSM70]> {
+-  // Pattern (created by WMMA_LOAD_INTR_HELPER below) that matches the intrinsic
+-  // for this function.
+-  PatFrag IntrMatcher = !cast<PatFrag>("INT_WMMA_"
+-                                       # Geometry # "_load_"
+-                                       # !subst("c", "c_" # Type, Abc)
+-                                       # "_" # Layout
+-                                       # !subst(".", "_", Space)
+-                                       # !if(WithStride,"_stride", "")
+-                                       # "_Intr");
+-  dag OutsR03 = (outs regclass:$r0, regclass:$r1, regclass:$r2, regclass:$r3);
+-  dag OutsR47 = (outs regclass:$r4, regclass:$r5, regclass:$r6, regclass:$r7);
+-  dag Outs = !if(!eq(Abc#Type,"cf16"), OutsR03, !con(OutsR03, OutsR47));
+-
+-  dag StrideArg = !if(WithStride, (ins Int32Regs:$ldm), (ins));
+-  dag Ins = !con((ins SrcOp:$src), StrideArg);
++// Helper class that represents a 'fragment' of an NVPTX *MMA instruction.
++// In addition to target-independent fields provided by WMMA_REGS, it adds
++// the fields commonly used to implement specific PTX instruction -- register
++// types and names, constraints, parts of assembly, etc.
++class WMMA_REGINFO<string Geom, string Frag, string PtxEltType>
++      : WMMA_REGS<Geom, Frag, PtxEltType> {
++  // NVPTX register types used to carry fragment data.
++  NVPTXRegClass regclass = !cond(
++    !eq(PtxEltType, "f16") : Float16x2Regs,
++    !eq(PtxEltType, "f32") : Float32Regs);
++
++  // Instruction input/output arguments for the fragment.
++  list<NVPTXRegClass> ptx_regs = !foreach(tmp, regs, regclass);
++
++  // List of register names for the fragment -- ["ra0", "ra1",...]
++  list<string> reg_names = RegSeq<!size(ptx_regs), "r"#frag>.ret;
++  // Generates "{{$r0, $r1,.... $rN-1}}" for use in asm string construction.
++  string regstring = "{{$" # !head(reg_names)
++                           # !foldl("", !tail(reg_names), a, b,
++                                    !strconcat(a, ", $", b))
++                     # "}}";
++
++  // Predicates for particular fragment variant. Technically those are
++  // per-instruction predicates, but currently all fragments that can be used in
++  // a given instruction are subject to the same constraints, so an instruction
++  // can use predicates from any of its fragments. If/when this is no
++  // longer the case, we can concat all per-fragment predicates to enforce that
++  // all fragments of the instruction are viable.
++  list<Predicate> Predicates = !cond(
++    // fp16 -> fp16/fp32 @ m16n16k16
++    !and(!eq(Geom, "m16n16k16"),
++         !or(!eq(PtxEltType, "f16"),
++             !eq(PtxEltType, "f32"))) : [hasSM70, hasPTX60],
++
++    // fp16 -> fp16/fp32 @ m8n32k16/m32n8k16
++    !and(!or(!eq(Geom, "m8n32k16"),
++             !eq(Geom, "m32n8k16")),
++         !or(!eq(PtxEltType, "f16"),
++             !eq(PtxEltType, "f32"))) : [hasSM70, hasPTX61]);
++
++  // template DAGs for instruction inputs/output.
++  dag Outs = !dag(outs, ptx_regs, reg_names);
++  dag Ins = !dag(ins, ptx_regs, reg_names);
++}
+ 
++class BuildPattern<dag Outs, PatFrag IntrMatcher, dag Ins> {
+   // Build a dag pattern that matches the intrinsic call.
+   // We want a dag that looks like this:
+   // (set <output args>, (intrinsic <input arguments>)) where input and
+@@ -7431,277 +7459,127 @@ class WMMA_LOAD_GALSTOS<string Geometry, string Abc, string Layout,
+                               !subst(ins, IntrMatcher, tmp)))));
+   // Finally, consatenate both parts together. !con() requires both dags to have
+   // the same operator, so we wrap PatArgs in a (set ...) dag.
+-  let Pattern = [!con(PatOuts, (set PatArgs))];
+-  let OutOperandList = Outs;
+-  let InOperandList = Ins;
+-  let AsmString = "wmma.load."
+-                  # Abc
+-                  # ".sync"
+-                  # "." # Layout
+-                  # "." # Geometry
+-                  # Space
+-                  # "." # Type # " \t"
+-                  # !if(!eq(Abc#Type, "cf16"),
+-                        "{{$r0, $r1, $r2, $r3}}",
+-                        "{{$r0, $r1, $r2, $r3, $r4, $r5, $r6, $r7}}")
+-                  # ", [$src]"
+-                  # !if(WithStride, ", $ldm", "")
+-                  # ";";
++  dag ret = !con(PatOuts, (set PatArgs));
+ }
+ 
+-class WMMA_LOAD_INTR_HELPER<string Geometry, string Abc, string Layout,
+-                            string Space, string Type, bit WithStride>
++//
++// wmma.load.[a|b|c].sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
++//
++
++class WMMA_LOAD_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
++                            bit WithStride>
+                            : PatFrag <(ops),(ops)> {
+   // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>("int_nvvm_wmma"
+-                                    # "_" # Geometry # "_load_"
+-                                    # Abc # "_" # Type # "_" # Layout
+-                                    # !if(WithStride,"_stride", ""));
+-  code match_generic = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
+-  }];
+-  code match_shared = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
+-  }];
+-  code match_global = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
+-  }];
+-
++  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"load", Frag, Layout,
++                                                   WithStride>.record);
+   let Operands = !if(WithStride, (ops node:$src, node:$ldm), (ops node:$src));
+   let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !if(!eq(Space, ".shared"), match_shared,
+-                      !if(!eq(Space, ".global"), match_global, match_generic));
+-}
+-
+-multiclass WMMA_LOAD_GALSTS<string Geometry, string Abc, string Layout,
+-                            string Space, string Type, NVPTXRegClass regclass,
+-                            bit WithStride> {
+-  def _avar:  WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                imem, WithStride>;
+-  def _areg: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                Int32Regs, WithStride>;
+-  def _areg64: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                Int64Regs, WithStride>;
+-  def _ari: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                MEMri, WithStride>;
+-  def _ari64: WMMA_LOAD_GALSTOS<Geometry, Abc, Layout, Space, Type, regclass,
+-                                MEMri64, WithStride>;
++  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
++                            !eq(Space, ".global"): AS_match.global,
++                            1: AS_match.generic);
+ }
+ 
+-multiclass WMMA_LOAD_GALSTSh<string Geometry, string Abc, string Layout,
+-                             string Space, string Type, NVPTXRegClass regclass,
+-                             bit WithStride> {
+-  // Define a PatFrag that matches appropriate intrinsic that loads from the
+-  // given address space.
+-  def _Intr:  WMMA_LOAD_INTR_HELPER<Geometry, Abc, Layout, Space, Type,
+-                                    WithStride>;
+-  defm NAME:  WMMA_LOAD_GALSTS<Geometry, Abc, Layout, Space, Type, regclass,
+-                               WithStride>;
+-}
+-
+-multiclass WMMA_LOAD_GALST<string Geometry, string Abc, string Layout,
+-                           string Space, string Type, NVPTXRegClass regclass> {
+-  defm _stride: WMMA_LOAD_GALSTSh<Geometry, Abc, Layout, Space, Type, regclass, 1>;
+-  defm NAME:    WMMA_LOAD_GALSTSh<Geometry, Abc, Layout, Space, Type, regclass, 0>;
+-}
+-
+-multiclass WMMA_LOAD_GALT<string Geometry, string Abc, string Layout,
+-                          string Type, NVPTXRegClass regclass> {
+-  defm _global: WMMA_LOAD_GALST<Geometry, Abc, Layout, ".global",
+-                                Type, regclass>;
+-  defm _shared: WMMA_LOAD_GALST<Geometry, Abc, Layout, ".shared",
+-                                Type, regclass>;
+-  defm NAME:    WMMA_LOAD_GALST<Geometry, Abc, Layout,        "",
+-                                Type, regclass>;
+-}
+-
+-multiclass WMMA_LOAD_GAT<string Geometry, string Abc,
+-                         string Type, NVPTXRegClass regclass> {
+-  defm _row: WMMA_LOAD_GALT<Geometry, Abc, "row", Type, regclass>;
+-  defm _col: WMMA_LOAD_GALT<Geometry, Abc, "col", Type, regclass>;
+-}
++class WMMA_LOAD<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
++                DAGOperand SrcOp>
++  : EmptyNVPTXInst,
++    Requires<Frag.Predicates> {
++  // Pattern that matches the intrinsic for this instruction variant.
++  PatFrag IntrMatcher = WMMA_LOAD_INTR_HELPER<Frag, Layout, Space, WithStride>;
++  dag Ins = !con((ins SrcOp:$src), !if(WithStride, (ins Int32Regs:$ldm), (ins)));
+ 
+-multiclass WMMA_LOAD_G<string Geometry> {
+-  defm _load_a: WMMA_LOAD_GAT<Geometry, "a", "f16", Float16x2Regs>;
+-  defm _load_b: WMMA_LOAD_GAT<Geometry, "b", "f16", Float16x2Regs>;
+-  defm _load_c_f16: WMMA_LOAD_GAT<Geometry, "c", "f16", Float16x2Regs>;
+-  defm _load_c_f32: WMMA_LOAD_GAT<Geometry, "c", "f32", Float32Regs>;
++  let Pattern = [BuildPattern<Frag.Outs, IntrMatcher, Ins>.ret];
++  let OutOperandList = Frag.Outs;
++  let InOperandList = Ins;
++  let AsmString = "wmma.load."
++                  # Frag.frag
++                  # ".sync"
++                  # "." # Layout
++                  # "." # Frag.geom
++                  # Space
++                  # "." # Frag.ptx_elt_type # " \t"
++                  # Frag.regstring
++                  # ", [$src]"
++                  # !if(WithStride, ", $ldm", "")
++                  # ";";
+ }
+ 
+-defm INT_WMMA_m32n8k16: WMMA_LOAD_G<"m32n8k16">;
+-defm INT_WMMA_m16n16k16: WMMA_LOAD_G<"m16n16k16">;
+-defm INT_WMMA_m8n32k16: WMMA_LOAD_G<"m8n32k16">;
+-
+ //
+ // wmma.store.d.sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+ //
+-class WMMA_STORE_D_GLSTSO<string Geometry, string Layout, string Space,
+-                          string Type, NVPTXRegClass regclass,
+-                          bit WithStride, DAGOperand DstOp>
++class WMMA_STORE_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
++                             bit WithStride>
++                            : PatFrag <(ops),(ops)> {
++  // Intrinsic that matches this instruction.
++  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"store", Frag, Layout,
++                                                   WithStride>.record);
++  let Operands = !con((ops node:$dst),
++                      !dag(ops, !foreach(tmp, Frag.regs, node), Frag.reg_names),
++                      !if(WithStride, (ops node:$ldm), (ops)));
++  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
++  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
++                            !eq(Space, ".global"): AS_match.global,
++                            1: AS_match.generic);
++}
++
++class WMMA_STORE<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
++                 DAGOperand DstOp>
+   : EmptyNVPTXInst,
+-    Requires<[!if(!eq(Geometry, "m16n16k16"),
+-                  hasPTX60,
+-                  hasPTX61),
+-              hasSM70]> {
+-  PatFrag IntrMatcher = !cast<PatFrag>("INT_WMMA"
+-                                       # "_" # Geometry # "_store_d"
+-                                       # "_" # Type
+-                                       # "_" # Layout
+-                                       # !subst(".", "_", Space)
+-                                       # !if(WithStride,"_stride", "")
+-                                       # "_Intr");
+-  dag InsR03 = (ins DstOp:$src, regclass:$r0, regclass:$r1,
+-                                regclass:$r2, regclass:$r3);
+-  dag InsR47 = (ins regclass:$r4, regclass:$r5,
+-                    regclass:$r6, regclass:$r7);
+-  dag InsR = !if(!eq(Type,"f16"), InsR03, !con(InsR03, InsR47));
+-  dag StrideArg = !if(WithStride, (ins Int32Regs:$ldm), (ins));
+-  dag Ins = !con(InsR, StrideArg);
+-
+-  // Construct the pattern to match corresponding intrinsic call. See the
+-  // details in the comments in WMMA_LOAD_ALSTOS.
+-  dag PatArgs = !foreach(tmp, Ins,
+-                              !subst(imem, ADDRvar,
+-                              !subst(MEMri64, ADDRri64,
+-                              !subst(MEMri, ADDRri,
+-                              !subst(ins, IntrMatcher, tmp)))));
+-  let Pattern = [PatArgs];
++    Requires<Frag.Predicates> {
++  PatFrag IntrMatcher = WMMA_STORE_INTR_HELPER<Frag, Layout, Space, WithStride>;
++  dag Ins = !con((ins DstOp:$src),
++                 Frag.Ins,
++                 !if(WithStride, (ins Int32Regs:$ldm), (ins)));
++  let Pattern = [BuildPattern<(set), IntrMatcher, Ins>.ret];
+   let OutOperandList = (outs);
+   let InOperandList = Ins;
+   let AsmString = "wmma.store.d.sync."
+                   # Layout
+-                  # "." # Geometry
++                  # "." # Frag.geom
+                   # Space
+-                  # "." # Type
++                  # "." # Frag.ptx_elt_type
+                   # " \t[$src],"
+-                  # !if(!eq(Type,"f16"),
+-                        "{{$r0, $r1, $r2, $r3}}",
+-                        "{{$r0, $r1, $r2, $r3, $r4, $r5, $r6, $r7}}")
++                  # Frag.regstring
+                   # !if(WithStride, ", $ldm", "")
+                   # ";";
+-
+ }
+ 
+-class WMMA_STORE_INTR_HELPER<string Geometry, string Layout, string Space,
+-                             string Type, bit WithStride>
+-                            : PatFrag <(ops),(ops)> {
+-  // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>("int_nvvm_wmma_"
+-                                    # Geometry
+-                                    # "_store_d"
+-                                    # "_" # Type
+-                                    # "_" # Layout
+-                                    # !if(WithStride, "_stride", ""));
+-  code match_generic = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GENERIC);
+-  }];
+-  code match_shared = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_SHARED);
+-  }];
+-  code match_global = [{
+-   return ChkMemSDNodeAddressSpace(N, llvm::ADDRESS_SPACE_GLOBAL);
+-  }];
+-
+-  dag Args = !if(!eq(Type,"f16"),
+-                 (ops node:$dst, node:$r0, node:$r1, node:$r2, node:$r3),
+-                 (ops node:$dst, node:$r0, node:$r1, node:$r2, node:$r3,
+-                                 node:$r4, node:$r5, node:$r6, node:$r7));
+-  dag StrideArg = !if(WithStride, (ops node:$ldm), (ops));
+-  let Operands = !con(Args, StrideArg);
+-  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !if(!eq(Space, ".shared"), match_shared,
+-                      !if(!eq(Space, ".global"), match_global, match_generic));
+-}
+-
+-multiclass WMMA_STORE_D_GLSTS<string Geometry, string Layout, string Space,
+-                              string Type, NVPTXRegClass regclass,
+-                              bit WithStride> {
+-  def _avar:   WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, imem>;
+-  def _areg:   WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, Int32Regs>;
+-  def _areg64: WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, Int64Regs>;
+-  def _ari:    WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, MEMri>;
+-  def _ari64:  WMMA_STORE_D_GLSTSO<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride, MEMri64>;
+-}
+-
+-multiclass WMMA_STORE_D_GLSTSh<string Geometry, string Layout, string Space,
+-                               string Type, NVPTXRegClass regclass,
+-                               bit WithStride> {
+-  // Define a PatFrag that matches appropriate intrinsic that loads from the
+-  // given address space.
+-  def _Intr:    WMMA_STORE_INTR_HELPER<Geometry, Layout, Space, Type,
+-                                       WithStride>;
+-  defm NAME:    WMMA_STORE_D_GLSTS<Geometry, Layout, Space, Type, regclass,
+-                                   WithStride>;
+-}
+-
+-multiclass WMMA_STORE_D_GLST<string Geometry, string Layout, string Space,
+-                             string Type, NVPTXRegClass regclass > {
+-  defm _stride: WMMA_STORE_D_GLSTSh<Geometry, Layout, Space, Type, regclass, 1>;
+-  defm NAME:    WMMA_STORE_D_GLSTSh<Geometry, Layout, Space, Type, regclass, 0>;
+-}
+-
+-multiclass WMMA_STORE_D_GLT<string Geometry, string Layout,
+-                           string Type, NVPTXRegClass regclass> {
+-  defm _global: WMMA_STORE_D_GLST<Geometry, Layout, ".global", Type, regclass>;
+-  defm _shared: WMMA_STORE_D_GLST<Geometry, Layout, ".shared", Type, regclass>;
+-  defm NAME:    WMMA_STORE_D_GLST<Geometry, Layout,        "", Type, regclass>;
+-}
+-
+-multiclass WMMA_STORE_D_GT<string Geometry, string Type,
+-                           NVPTXRegClass regclass> {
+-  defm _row:    WMMA_STORE_D_GLT<Geometry, "row", Type, regclass>;
+-  defm _col:    WMMA_STORE_D_GLT<Geometry, "col", Type, regclass>;
+-}
+-
+-multiclass WMMA_STORE_D_G<string Geometry> {
+-  defm _store_d_f16: WMMA_STORE_D_GT<Geometry, "f16", Float16x2Regs>;
+-  defm _store_d_f32: WMMA_STORE_D_GT<Geometry, "f32", Float32Regs>;
+-}
+-
+-defm INT_WMMA_m32n8k16: WMMA_STORE_D_G<"m32n8k16">;
+-defm INT_WMMA_m16n16k16: WMMA_STORE_D_G<"m16n16k16">;
+-defm INT_WMMA_m8n32k16: WMMA_STORE_D_G<"m8n32k16">;
++// Create all load/store variants
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout = ["row", "col"] in {
++    foreach stride = [0, 1] in {
++      foreach space = [".global", ".shared", ""] in {
++        foreach addr = [imem, Int32Regs, Int64Regs, MEMri, MEMri64] in {
++          foreach frag = [WMMA_REGINFO<geom, "a", "f16">,
++                          WMMA_REGINFO<geom, "b", "f16">,
++                          WMMA_REGINFO<geom, "c", "f16">,
++                          WMMA_REGINFO<geom, "c", "f32">] in {
++              def : WMMA_LOAD<frag, layout, space, stride, addr>;
++          }
++          foreach frag = [WMMA_REGINFO<geom, "d", "f16">,
++                          WMMA_REGINFO<geom, "d", "f32">] in {
++              def : WMMA_STORE<frag, layout, space, stride, addr>;
++          }
++        } // addr
++      } // space
++    } // stride
++  } // layout
++} // geom
+ 
+ // WMMA.MMA
+-class WMMA_MMA_GABDCS<string Geometry, string ALayout, string BLayout,
+-                     string DType, NVPTXRegClass d_reg,
+-                     string CType, NVPTXRegClass c_reg,
+-                     NVPTXRegClass ab_reg,
+-                     string Satfinite = "">
++class WMMA_MMA<WMMA_REGINFO FragA, WMMA_REGINFO FragB,
++               WMMA_REGINFO FragC, WMMA_REGINFO FragD,
++               string ALayout, string BLayout, int Satfinite>
+   : EmptyNVPTXInst,
+-    Requires<[!if(!eq(Geometry, "m16n16k16"),
+-                  hasPTX60,
+-                  hasPTX61),
+-              hasSM70]> {
+-  Intrinsic Intr = !cast<Intrinsic>("int_nvvm_wmma_"
+-                                    # Geometry
+-                                    # "_mma"
+-                                    # "_" # ALayout
+-                                    # "_" # BLayout
+-                                    # "_" # DType
+-                                    # "_" # CType
+-                                    # !subst(".", "_", Satfinite));
+-  dag Outs = !if(!eq(DType,"f16"),
+-                 (outs d_reg:$d0, d_reg:$d1, d_reg:$d2, d_reg:$d3),
+-                 (outs d_reg:$d0, d_reg:$d1, d_reg:$d2, d_reg:$d3,
+-                       d_reg:$d4, d_reg:$d5, d_reg:$d6, d_reg:$d7));
+-  dag InsExtraCArgs = !if(!eq(CType,"f16"),
+-                          (ins),
+-                          (ins c_reg:$c4,  c_reg:$c5,  c_reg:$c6,  c_reg:$c7));
+-  dag Ins = !con((ins ab_reg:$a0, ab_reg:$a1, ab_reg:$a2, ab_reg:$a3,
+-                      ab_reg:$a4, ab_reg:$a5, ab_reg:$a6, ab_reg:$a7,
+-                      ab_reg:$b0, ab_reg:$b1, ab_reg:$b2, ab_reg:$b3,
+-                      ab_reg:$b4, ab_reg:$b5, ab_reg:$b6, ab_reg:$b7,
+-                      c_reg:$c0,  c_reg:$c1,  c_reg:$c2,  c_reg:$c3),
+-                  InsExtraCArgs);
+-
+-  // Construct the pattern to match corresponding intrinsic call. See the
+-  // details in the comments in WMMA_LOAD_ALSTOS.
++    Requires<FragC.Predicates> {
++  //Intrinsic Intr = int_nvvm_suld_1d_v4i32_zero;
++  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_MMA<ALayout, BLayout, FragC, FragD, Satfinite>.record);
++  dag Outs = FragD.Outs;
++  dag Ins = !con(FragA.Ins,
++                 FragB.Ins,
++                 FragC.Ins);
++
++  // Construct the pattern to match corresponding intrinsic call.
++  // mma does not load/store anything, so we don't need complex operand matching here.
+   dag PatOuts = !foreach(tmp, Outs, !subst(outs, set, tmp));
+   dag PatArgs = !foreach(tmp, Ins, !subst(ins, Intr, tmp));
+   let Pattern = [!con(PatOuts, (set PatArgs))];
+@@ -7710,54 +7588,30 @@ class WMMA_MMA_GABDCS<string Geometry, string ALayout, string BLayout,
+   let AsmString = "wmma.mma.sync."
+                   # ALayout
+                   # "." # BLayout
+-                  # "." # Geometry
+-                  # "." # DType
+-                  # "." # CType
+-                  # Satfinite # "\n\t\t"
+-                  # !if(!eq(DType,"f16"),
+-                        "{{$d0, $d1, $d2, $d3}}, \n\t\t",
+-                        "{{$d0, $d1, $d2, $d3, $d4, $d5, $d6, $d7}},\n\t\t")
+-                  # "{{$a0, $a1, $a2, $a3, $a4, $a5, $a6, $a7}},\n\t\t"
+-                  # "{{$b0, $b1, $b2, $b3, $b4, $b5, $b6, $b7}},\n\t\t"
+-                  # !if(!eq(CType,"f16"),
+-                        "{{$c0, $c1, $c2, $c3}};",
+-                        "{{$c0, $c1, $c2, $c3, $c4, $c5, $c6, $c7}};");
+-}
+-
+-multiclass WMMA_MMA_GABDC<string Geometry, string ALayout, string BLayout,
+-                         string DType, NVPTXRegClass d_reg,
+-                         string CType, NVPTXRegClass c_reg> {
+-  def _satfinite: WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                 DType, d_reg, CType, c_reg,
+-                                 Float16x2Regs, ".satfinite">;
+-  def NAME:       WMMA_MMA_GABDCS<Geometry, ALayout, BLayout,
+-                                 DType, d_reg, CType, c_reg,
+-                                 Float16x2Regs>;
+-}
+-
+-multiclass WMMA_MMA_GABD<string Geometry, string ALayout, string BLayout,
+-                        string DType, NVPTXRegClass d_reg> {
+-  defm _f16: WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_reg,
+-                            "f16", Float16x2Regs>;
+-  defm _f32: WMMA_MMA_GABDC<Geometry, ALayout, BLayout, DType, d_reg,
+-                            "f32", Float32Regs>;
+-}
+-
+-multiclass WMMA_MMA_GAB<string Geometry, string ALayout, string BLayout> {
+-  defm _f16: WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f16", Float16x2Regs>;
+-  defm _f32: WMMA_MMA_GABD<Geometry, ALayout, BLayout, "f32", Float32Regs>;
+-}
+-
+-multiclass WMMA_MMA_GA<string Geometry, string ALayout> {
+-  defm _col: WMMA_MMA_GAB<Geometry, ALayout, "col">;
+-  defm _row: WMMA_MMA_GAB<Geometry, ALayout, "row">;
+-}
+-
+-multiclass WMMA_MMA_G<string Geometry> {
+-  defm _col: WMMA_MMA_GA<Geometry, "col">;
+-  defm _row: WMMA_MMA_GA<Geometry, "row">;
++                  # "." # FragA.geom
++                  # "." # FragD.ptx_elt_type
++                  # "." # FragC.ptx_elt_type
++                  # !if(Satfinite, ".satfinite", "") # "\n\t\t"
++                  # FragD.regstring # ",\n\t\t"
++                  # FragA.regstring # ",\n\t\t"
++                  # FragB.regstring # ",\n\t\t"
++                  # FragC.regstring # ";";
+ }
+ 
+-defm INT_WMMA_MMA_m32n8k16 : WMMA_MMA_G<"m32n8k16">;
+-defm INT_WMMA_MMA_m16n16k16 : WMMA_MMA_G<"m16n16k16">;
+-defm INT_WMMA_MMA_m8n32k16 : WMMA_MMA_G<"m8n32k16">;
++foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++  foreach layout_a = ["row", "col"] in {
++    foreach layout_b = ["row", "col"] in {
++      foreach frag_c = [WMMA_REGINFO<geom, "c", "f16">,
++                        WMMA_REGINFO<geom, "c", "f32">] in {
++        foreach frag_d = [WMMA_REGINFO<geom, "d", "f16">,
++                          WMMA_REGINFO<geom, "d", "f32">] in {
++          foreach satf = [0, 1] in {
++            def : WMMA_MMA<WMMA_REGINFO<geom, "a", "f16">,
++                           WMMA_REGINFO<geom, "b", "f16">,
++                           frag_c, frag_d, layout_a, layout_b, satf>;
++          } // satf
++        } // frag_d
++      } // frag_c
++    } // layout_b
++  } // layout_a
++} // geom
+-- 
+2.17.1
+

--- a/deps/patches/llvm-8.0-D59393-mma-ptx63-fix.patch
+++ b/deps/patches/llvm-8.0-D59393-mma-ptx63-fix.patch
@@ -1,0 +1,510 @@
+From be924be7f9e699775fe7690d4b421bebfed73aa9 Mon Sep 17 00:00:00 2001
+From: Artem Belevich <tra@google.com>
+Date: Thu, 25 Apr 2019 22:27:46 +0000
+Subject: [PATCH] [NVPTX] generate correct MMA instruction mnemonics with
+ PTX63+.
+
+PTX 6.3 requires using ".aligned" in the MMA instruction names.
+In order to generate correct name, now we pass current
+PTX version to each instruction as an extra constant operand
+and InstPrinter adjusts its output accordingly.
+
+Differential Revision: https://reviews.llvm.org/D59393
+
+llvm-svn: 359246
+---
+ .../NVPTX/InstPrinter/NVPTXInstPrinter.cpp    |  14 +
+ .../NVPTX/InstPrinter/NVPTXInstPrinter.h      |   2 +
+ lib/Target/NVPTX/NVPTXInstrInfo.td            |   4 +
+ lib/Target/NVPTX/NVPTXIntrinsics.td           | 279 ++++++++++--------
+ test/CodeGen/NVPTX/wmma.py                    |  17 +-
+ 5 files changed, 184 insertions(+), 132 deletions(-)
+
+diff --git a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp
+index b774fe169d7..6fb577d5499 100644
+--- a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp
++++ b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.cpp
+@@ -270,6 +270,20 @@ void NVPTXInstPrinter::printLdStCode(const MCInst *MI, int OpNum,
+     llvm_unreachable("Empty Modifier");
+ }
+ 
++void NVPTXInstPrinter::printMmaCode(const MCInst *MI, int OpNum, raw_ostream &O,
++                                    const char *Modifier) {
++  const MCOperand &MO = MI->getOperand(OpNum);
++  int Imm = (int)MO.getImm();
++  if (Modifier == nullptr || strcmp(Modifier, "version") == 0) {
++    O << Imm; // Just print out PTX version
++  } else if (strcmp(Modifier, "aligned") == 0) {
++    // PTX63 requires '.aligned' in the name of the instruction.
++    if (Imm >= 63)
++      O << ".aligned";
++  } else
++    llvm_unreachable("Unknown Modifier");
++}
++
+ void NVPTXInstPrinter::printMemOperand(const MCInst *MI, int OpNum,
+                                        raw_ostream &O, const char *Modifier) {
+   printOperand(MI, OpNum, O);
+diff --git a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h
+index f0f223aa057..588439137f9 100644
+--- a/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h
++++ b/lib/Target/NVPTX/InstPrinter/NVPTXInstPrinter.h
+@@ -41,6 +41,8 @@ public:
+                     const char *Modifier = nullptr);
+   void printLdStCode(const MCInst *MI, int OpNum,
+                      raw_ostream &O, const char *Modifier = nullptr);
++  void printMmaCode(const MCInst *MI, int OpNum, raw_ostream &O,
++                    const char *Modifier = nullptr);
+   void printMemOperand(const MCInst *MI, int OpNum,
+                        raw_ostream &O, const char *Modifier = nullptr);
+   void printProtoIdent(const MCInst *MI, int OpNum,
+diff --git a/lib/Target/NVPTX/NVPTXInstrInfo.td b/lib/Target/NVPTX/NVPTXInstrInfo.td
+index 02a40b9f526..603d3212395 100644
+--- a/lib/Target/NVPTX/NVPTXInstrInfo.td
++++ b/lib/Target/NVPTX/NVPTXInstrInfo.td
+@@ -1549,6 +1549,10 @@ def LdStCode : Operand<i32> {
+   let PrintMethod = "printLdStCode";
+ }
+ 
++def MmaCode : Operand<i32> {
++  let PrintMethod = "printMmaCode";
++}
++
+ def SDTWrapper : SDTypeProfile<1, 1, [SDTCisSameAs<0, 1>, SDTCisPtrTy<0>]>;
+ def Wrapper    : SDNode<"NVPTXISD::Wrapper", SDTWrapper>;
+ 
+diff --git a/lib/Target/NVPTX/NVPTXIntrinsics.td b/lib/Target/NVPTX/NVPTXIntrinsics.td
+index b9a67ba5ed3..5cd534914f7 100644
+--- a/lib/Target/NVPTX/NVPTXIntrinsics.td
++++ b/lib/Target/NVPTX/NVPTXIntrinsics.td
+@@ -39,6 +39,24 @@ def AS_match {
+   }];
+ }
+ 
++// A node that will be replaced with the current PTX version.
++class PTX {
++  SDNodeXForm PTXVerXform = SDNodeXForm<imm, [{
++    return getI32Imm(Subtarget->getPTXVersion(), SDLoc(N));
++  }]>;
++  // (i32 0) will be XForm'ed to the currently used PTX version.
++  dag version = (PTXVerXform (i32 0));
++}
++def ptx : PTX;
++
++// Generates list of n sequential register names.
++// E.g. RegNames<3,"r">.ret -> ["r0", "r1", "r2" ]
++class RegSeq<int n, string prefix> {
++  list<string> ret = !if(n, !listconcat(RegSeq<!add(n,-1), prefix>.ret,
++                                        [prefix # !add(n, -1)]),
++                            []);
++}
++
+ //-----------------------------------
+ // Synchronization and shuffle functions
+ //-----------------------------------
+@@ -7385,14 +7403,6 @@ def INT_PTX_SREG_WARPSIZE :
+     NVPTXInst<(outs Int32Regs:$dst), (ins), "mov.u32 \t$dst, WARP_SZ;",
+               [(set Int32Regs:$dst, (int_nvvm_read_ptx_sreg_warpsize))]>;
+ 
+-class EmptyNVPTXInst : NVPTXInst<(outs), (ins), "?", []>;
+-// Generates list of n sequential register names.
+-class RegSeq<int n, string prefix> {
+-  list<string> ret = !if(n, !listconcat(RegSeq<!add(n,-1), prefix>.ret,
+-                                        [prefix # !add(n, -1)]),
+-                            []);
+-}
+-
+ // Helper class that represents a 'fragment' of an NVPTX *MMA instruction.
+ // In addition to target-independent fields provided by WMMA_REGS, it adds
+ // the fields commonly used to implement specific PTX instruction -- register
+@@ -7409,6 +7419,7 @@ class WMMA_REGINFO<string Geom, string Frag, string PtxEltType>
+ 
+   // List of register names for the fragment -- ["ra0", "ra1",...]
+   list<string> reg_names = RegSeq<!size(ptx_regs), "r"#frag>.ret;
++
+   // Generates "{{$r0, $r1,.... $rN-1}}" for use in asm string construction.
+   string regstring = "{{$" # !head(reg_names)
+                            # !foldl("", !tail(reg_names), a, b,
+@@ -7438,61 +7449,65 @@ class WMMA_REGINFO<string Geom, string Frag, string PtxEltType>
+   dag Ins = !dag(ins, ptx_regs, reg_names);
+ }
+ 
+-class BuildPattern<dag Outs, PatFrag IntrMatcher, dag Ins> {
++// Convert dag of arguments into a dag to match given intrinsic.
++class BuildPatternI<Intrinsic Intr, dag Ins> {
++  // Build a dag pattern that matches the intrinsic call.
++  dag ret = !foreach(tmp, Ins,
++                          !subst(imem, ADDRvar,
++                          !subst(MEMri64, ADDRri64,
++                          !subst(MEMri, ADDRri,
++                          !subst(ins, Intr, tmp)))));
++}
++
++// Same as above, but uses PatFrag instead of an Intrinsic.
++class BuildPatternPF<PatFrag Intr, dag Ins> {
+   // Build a dag pattern that matches the intrinsic call.
+-  // We want a dag that looks like this:
+-  // (set <output args>, (intrinsic <input arguments>)) where input and
+-  // output arguments are named patterns that would match corresponding
+-  // input/output arguments of the instruction.
+-  //
+-  // First we construct (set <output arguments>) from instruction's outs dag by
+-  // replacing dag operator 'outs' with 'set'.
+-  dag PatOuts = !foreach(tmp, Outs, !subst(outs, set, tmp));
+-  // Similarly, construct (intrinsic <input arguments>) sub-dag from
+-  // instruction's input arguments, only now we also need to replace operands
+-  // with patterns that would match them and the operator 'ins' with the
+-  // intrinsic.
+-  dag PatArgs = !foreach(tmp, Ins,
+-                              !subst(imem, ADDRvar,
+-                              !subst(MEMri64, ADDRri64,
+-                              !subst(MEMri, ADDRri,
+-                              !subst(ins, IntrMatcher, tmp)))));
+-  // Finally, consatenate both parts together. !con() requires both dags to have
+-  // the same operator, so we wrap PatArgs in a (set ...) dag.
+-  dag ret = !con(PatOuts, (set PatArgs));
++  dag ret = !foreach(tmp, Ins,
++                          !subst(imem, ADDRvar,
++                          !subst(MEMri64, ADDRri64,
++                          !subst(MEMri, ADDRri,
++                          !subst(ins, Intr, tmp)))));
++}
++
++// Common WMMA-related fields used for building patterns for all MMA instructions.
++class WMMA_INSTR<string _Intr, list<dag> _Args>
++  : NVPTXInst<(outs), (ins), "?", []> {
++  Intrinsic Intr = !cast<Intrinsic>(_Intr);
++  // Concatenate all arguments into a single dag.
++  dag Args = !foldl((ins), _Args, a, b, !con(a,b));
++  // Pre-build the pattern to match (intrinsic arg0, arg1, ...).
++  dag IntrinsicPattern = BuildPatternI<!cast<Intrinsic>(Intr), Args>.ret;
+ }
+ 
+ //
+ // wmma.load.[a|b|c].sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+ //
+ 
+-class WMMA_LOAD_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
+-                            bit WithStride>
+-                           : PatFrag <(ops),(ops)> {
+-  // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"load", Frag, Layout,
+-                                                   WithStride>.record);
+-  let Operands = !if(WithStride, (ops node:$src, node:$ldm), (ops node:$src));
+-  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
+-                            !eq(Space, ".global"): AS_match.global,
+-                            1: AS_match.generic);
+-}
+-
+ class WMMA_LOAD<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
+                 DAGOperand SrcOp>
+-  : EmptyNVPTXInst,
++  : WMMA_INSTR<WMMA_NAME_LDST<"load", Frag, Layout, WithStride>.record,
++                              [!con((ins SrcOp:$src),
++                                    !if(WithStride, (ins Int32Regs:$ldm), (ins)))]>,
+     Requires<Frag.Predicates> {
+-  // Pattern that matches the intrinsic for this instruction variant.
+-  PatFrag IntrMatcher = WMMA_LOAD_INTR_HELPER<Frag, Layout, Space, WithStride>;
+-  dag Ins = !con((ins SrcOp:$src), !if(WithStride, (ins Int32Regs:$ldm), (ins)));
++  // Load/store intrinsics are overloaded on pointer's address space.
++  // To match the right intrinsic, we need to build AS-constrained PatFrag.
++  // Operands is a dag equivalent in shape to Args, but using (ops node:$name, .....).
++  dag PFOperands = !if(WithStride, (ops node:$src, node:$ldm), (ops node:$src));
++  // Build PatFrag that only matches particular address space.
++  PatFrag IntrFrag = PatFrag<PFOperands,
++                             !foreach(tmp, PFOperands, !subst(ops, Intr, tmp)),
++                             !cond(!eq(Space, ".shared"): AS_match.shared,
++                                   !eq(Space, ".global"): AS_match.global,
++                                   1: AS_match.generic)>;
++  // Build AS-constrained pattern.
++  let IntrinsicPattern = BuildPatternPF<IntrFrag, Args>.ret;
+ 
+-  let Pattern = [BuildPattern<Frag.Outs, IntrMatcher, Ins>.ret];
+   let OutOperandList = Frag.Outs;
+-  let InOperandList = Ins;
++  let InOperandList = !con(Args, (ins MmaCode:$ptx));
+   let AsmString = "wmma.load."
+                   # Frag.frag
+                   # ".sync"
++                  # "${ptx:aligned}"
+                   # "." # Layout
+                   # "." # Frag.geom
+                   # Space
+@@ -7506,87 +7521,79 @@ class WMMA_LOAD<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
+ //
+ // wmma.store.d.sync.[row|col].m16n16k16[|.global|.shared].[f16|f32]
+ //
+-class WMMA_STORE_INTR_HELPER<WMMA_REGINFO Frag, string Layout, string Space,
+-                             bit WithStride>
+-                            : PatFrag <(ops),(ops)> {
+-  // Intrinsic that matches this instruction.
+-  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_LDST<"store", Frag, Layout,
+-                                                   WithStride>.record);
+-  let Operands = !con((ops node:$dst),
+-                      !dag(ops, !foreach(tmp, Frag.regs, node), Frag.reg_names),
+-                      !if(WithStride, (ops node:$ldm), (ops)));
+-  let Fragments = [!foreach(tmp, Operands, !subst(ops, Intr, tmp))];
+-  let PredicateCode = !cond(!eq(Space, ".shared"): AS_match.shared,
+-                            !eq(Space, ".global"): AS_match.global,
+-                            1: AS_match.generic);
+-}
+-
+-class WMMA_STORE<WMMA_REGINFO Frag, string Layout, string Space, bit WithStride,
+-                 DAGOperand DstOp>
+-  : EmptyNVPTXInst,
++class WMMA_STORE_D<WMMA_REGINFO Frag, string Layout, string Space,
++                   bit WithStride, DAGOperand DstOp>
++  : WMMA_INSTR<WMMA_NAME_LDST<"store", Frag, Layout, WithStride>.record,
++               [!con((ins DstOp:$dst),
++                     Frag.Ins,
++                     !if(WithStride, (ins Int32Regs:$ldm), (ins)))]>,
+     Requires<Frag.Predicates> {
+-  PatFrag IntrMatcher = WMMA_STORE_INTR_HELPER<Frag, Layout, Space, WithStride>;
+-  dag Ins = !con((ins DstOp:$src),
+-                 Frag.Ins,
+-                 !if(WithStride, (ins Int32Regs:$ldm), (ins)));
+-  let Pattern = [BuildPattern<(set), IntrMatcher, Ins>.ret];
++
++  // Load/store intrinsics are overloaded on pointer's address space.
++  // To match the right intrinsic, we need to build AS-constrained PatFrag.
++  // Operands is a dag equivalent in shape to Args, but using (ops node:$name, .....).
++  dag PFOperands = !con((ops node:$dst),
++                        !dag(ops, !foreach(tmp, Frag.regs, node), Frag.reg_names),
++                        !if(WithStride, (ops node:$ldm), (ops)));
++  // Build PatFrag that only matches particular address space.
++  PatFrag IntrFrag = PatFrag<PFOperands,
++                             !foreach(tmp, PFOperands, !subst(ops, Intr, tmp)),
++                             !cond(!eq(Space, ".shared"): AS_match.shared,
++                                   !eq(Space, ".global"): AS_match.global,
++                                   1: AS_match.generic)>;
++  // Build AS-constrained pattern.
++  let IntrinsicPattern = BuildPatternPF<IntrFrag, Args>.ret;
++
++  let InOperandList  = !con(Args, (ins MmaCode:$ptx));
+   let OutOperandList = (outs);
+-  let InOperandList = Ins;
+-  let AsmString = "wmma.store.d.sync."
+-                  # Layout
++  let AsmString = "wmma.store.d.sync"
++                  # "${ptx:aligned}"
++                  # "." # Layout
+                   # "." # Frag.geom
+                   # Space
+                   # "." # Frag.ptx_elt_type
+-                  # " \t[$src],"
++                  # " \t[$dst],"
+                   # Frag.regstring
+                   # !if(WithStride, ", $ldm", "")
+                   # ";";
+ }
+ 
+ // Create all load/store variants
+-foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
+-  foreach layout = ["row", "col"] in {
+-    foreach stride = [0, 1] in {
+-      foreach space = [".global", ".shared", ""] in {
+-        foreach addr = [imem, Int32Regs, Int64Regs, MEMri, MEMri64] in {
+-          foreach frag = [WMMA_REGINFO<geom, "a", "f16">,
+-                          WMMA_REGINFO<geom, "b", "f16">,
+-                          WMMA_REGINFO<geom, "c", "f16">,
+-                          WMMA_REGINFO<geom, "c", "f32">] in {
+-              def : WMMA_LOAD<frag, layout, space, stride, addr>;
+-          }
+-          foreach frag = [WMMA_REGINFO<geom, "d", "f16">,
+-                          WMMA_REGINFO<geom, "d", "f32">] in {
+-              def : WMMA_STORE<frag, layout, space, stride, addr>;
+-          }
+-        } // addr
+-      } // space
+-    } // stride
+-  } // layout
+-} // geom
++defset list<WMMA_INSTR> MMA_LDSTs  = {
++  foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++    foreach layout = ["row", "col"] in {
++      foreach stride = [0, 1] in {
++        foreach space = [".global", ".shared", ""] in {
++          foreach addr = [imem, Int32Regs, Int64Regs, MEMri, MEMri64] in {
++            foreach frag = [WMMA_REGINFO<geom, "a", "f16">,
++                            WMMA_REGINFO<geom, "b", "f16">,
++                            WMMA_REGINFO<geom, "c", "f16">,
++                            WMMA_REGINFO<geom, "c", "f32">] in {
++                def : WMMA_LOAD<frag, layout, space, stride, addr>;
++            }
++            foreach frag = [WMMA_REGINFO<geom, "d", "f16">,
++                            WMMA_REGINFO<geom, "d", "f32">] in {
++                def : WMMA_STORE_D<frag, layout, space, stride, addr>;
++            }
++          } // addr
++        } // space
++      } // stride
++    } // layout
++  } // geom
++} // defset
+ 
+ // WMMA.MMA
+ class WMMA_MMA<WMMA_REGINFO FragA, WMMA_REGINFO FragB,
+                WMMA_REGINFO FragC, WMMA_REGINFO FragD,
+                string ALayout, string BLayout, int Satfinite>
+-  : EmptyNVPTXInst,
++  : WMMA_INSTR<WMMA_NAME_MMA<ALayout, BLayout, FragC, FragD, Satfinite>.record,
++                             [FragA.Ins, FragB.Ins, FragC.Ins]>,
+     Requires<FragC.Predicates> {
+-  //Intrinsic Intr = int_nvvm_suld_1d_v4i32_zero;
+-  Intrinsic Intr = !cast<Intrinsic>(WMMA_NAME_MMA<ALayout, BLayout, FragC, FragD, Satfinite>.record);
+-  dag Outs = FragD.Outs;
+-  dag Ins = !con(FragA.Ins,
+-                 FragB.Ins,
+-                 FragC.Ins);
+-
+-  // Construct the pattern to match corresponding intrinsic call.
+-  // mma does not load/store anything, so we don't need complex operand matching here.
+-  dag PatOuts = !foreach(tmp, Outs, !subst(outs, set, tmp));
+-  dag PatArgs = !foreach(tmp, Ins, !subst(ins, Intr, tmp));
+-  let Pattern = [!con(PatOuts, (set PatArgs))];
+-  let OutOperandList = Outs;
+-  let InOperandList  = Ins;
+-  let AsmString = "wmma.mma.sync."
+-                  # ALayout
++  let OutOperandList = FragD.Outs;
++  let InOperandList  = !con(Args, (ins MmaCode:$ptx));
++  let AsmString = "wmma.mma.sync"
++                  # "${ptx:aligned}"
++                  # "." # ALayout
+                   # "." # BLayout
+                   # "." # FragA.geom
+                   # "." # FragD.ptx_elt_type
+@@ -7598,20 +7605,34 @@ class WMMA_MMA<WMMA_REGINFO FragA, WMMA_REGINFO FragB,
+                   # FragC.regstring # ";";
+ }
+ 
+-foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
+-  foreach layout_a = ["row", "col"] in {
+-    foreach layout_b = ["row", "col"] in {
+-      foreach frag_c = [WMMA_REGINFO<geom, "c", "f16">,
+-                        WMMA_REGINFO<geom, "c", "f32">] in {
+-        foreach frag_d = [WMMA_REGINFO<geom, "d", "f16">,
+-                          WMMA_REGINFO<geom, "d", "f32">] in {
+-          foreach satf = [0, 1] in {
+-            def : WMMA_MMA<WMMA_REGINFO<geom, "a", "f16">,
+-                           WMMA_REGINFO<geom, "b", "f16">,
+-                           frag_c, frag_d, layout_a, layout_b, satf>;
+-          } // satf
+-        } // frag_d
+-      } // frag_c
+-    } // layout_b
+-  } // layout_a
+-} // geom
++defset list<WMMA_INSTR> MMAs  = {
++  foreach geom = ["m16n16k16", "m32n8k16", "m8n32k16" ] in {
++    foreach layout_a = ["row", "col"] in {
++      foreach layout_b = ["row", "col"] in {
++        foreach frag_c = [WMMA_REGINFO<geom, "c", "f16">,
++                          WMMA_REGINFO<geom, "c", "f32">] in {
++          foreach frag_d = [WMMA_REGINFO<geom, "d", "f16">,
++                            WMMA_REGINFO<geom, "d", "f32">] in {
++            foreach satf = [0, 1] in {
++              def : WMMA_MMA<WMMA_REGINFO<geom, "a", "f16">,
++                             WMMA_REGINFO<geom, "b", "f16">,
++                             frag_c, frag_d, layout_a, layout_b, satf>;
++            } // satf
++          } // frag_d
++        } // frag_c
++      } // layout_b
++    } // layout_a
++  } // geom
++} // defset
++
++// Constructing non-flat DAGs is still a pain. I can't !subst a dag node with a
++// dag, so the ptx.version must be appended *after* foreach replaces 'ins' with
++// the instruction record.
++class WMMA_PAT<WMMA_INSTR wi>
++      : Pat<wi.IntrinsicPattern,
++            !con(!foreach(tmp, wi.Args, !subst(ins, wi, tmp)),
++                 (wi ptx.version))>;
++
++// Build intrinsic->instruction patterns for all MMA instructions.
++foreach mma = !listconcat(MMAs, MMA_LDSTs) in
++  def : WMMA_PAT<mma>;
+diff --git a/test/CodeGen/NVPTX/wmma.py b/test/CodeGen/NVPTX/wmma.py
+index 14bbfd7df09..72d189ca050 100644
+--- a/test/CodeGen/NVPTX/wmma.py
++++ b/test/CodeGen/NVPTX/wmma.py
+@@ -3,9 +3,12 @@
+ 
+ # RUN: python %s > %t.ll
+ # RUN: llc < %t.ll -march=nvptx64 -mcpu=sm_70 -mattr=+ptx61 | FileCheck %t.ll
++# RUN: python %s --ptx=63 > %t-ptx63.ll
++# RUN: llc < %t-ptx63.ll -march=nvptx64 -mcpu=sm_70 -mattr=+ptx63 | FileCheck %t-ptx63.ll
+ 
+ from __future__ import print_function
+ 
++import argparse
+ from itertools import product
+ from string import Template
+ 
+@@ -64,7 +67,7 @@ define ${ret_ty} @test_${function}_o(i8 ${as}* %src ${extra_args}) {
+ }
+ """
+   intrinsic_template = "llvm.nvvm.wmma.${geom}.load.${abc}.${layout}${stride}.${itype}.${pspace}"
+-  instruction_template = "wmma.load.${abc}.sync.${layout}.${geom}${space}.${itype}"
++  instruction_template = "wmma.load.${abc}.sync${aligned}.${layout}.${geom}${space}.${itype}"
+ 
+   for geom, abc, layout, space, stride, itype in product(
+       known_geoms,
+@@ -76,6 +79,7 @@ define ${ret_ty} @test_${function}_o(i8 ${as}* %src ${extra_args}) {
+ 
+     params = {
+         "abc" : abc,
++        "aligned" : ".aligned" if ptx_version >= 63 else "",
+         "layout" : layout,
+         "space" : space,
+         "stride" : stride,
+@@ -135,7 +139,7 @@ define void @test_${function}_o(i8 ${as}* %src, ${args}${extra_args}) {
+ }
+ """
+   intrinsic_template = "llvm.nvvm.wmma.${geom}.store.${abc}.${layout}${stride}.${itype}.${pspace}"
+-  instruction_template = "wmma.store.${abc}.sync.${layout}.${geom}${space}.${itype}"
++  instruction_template = "wmma.store.${abc}.sync${aligned}.${layout}.${geom}${space}.${itype}"
+ 
+   for geom, abc, layout, space, stride, itype in product(
+       known_geoms,
+@@ -147,6 +151,7 @@ define void @test_${function}_o(i8 ${as}* %src, ${args}${extra_args}) {
+ 
+     params = {
+         "abc" : abc,
++        "aligned" : ".aligned" if ptx_version >= 63 else "",
+         "layout" : layout,
+         "space" : space,
+         "stride" : stride,
+@@ -191,7 +196,7 @@ define ${ret_ty} @test_${function}(
+ }
+ """
+   intrinsic_template = "llvm.nvvm.wmma.${geom}.mma.${alayout}.${blayout}.${dtype}.${ctype}${satf}"
+-  instruction_template = "wmma.mma.sync.${alayout}.${blayout}.${geom}.${dtype}.${ctype}${satf}"
++  instruction_template = "wmma.mma.sync${aligned}.${alayout}.${blayout}.${geom}.${dtype}.${ctype}${satf}"
+ 
+   for geom, alayout, blayout, ctype, dtype, satf in product(
+       known_geoms,
+@@ -202,6 +207,7 @@ define ${ret_ty} @test_${function}(
+       [".satfinite", ""]):
+ 
+     params = {
++        "aligned" : ".aligned" if ptx_version >= 63 else "",
+         "alayout" : alayout,
+         "blayout" : blayout,
+         "ctype" : ctype,
+@@ -230,4 +236,9 @@ def main():
+   gen_wmma_store_tests()
+   gen_wmma_mma_tests()
+ 
++parser = argparse.ArgumentParser()
++parser.add_argument('--ptx', type=int, default=60)
++args = parser.parse_args()
++ptx_version = args.ptx
++
+ main()
+-- 
+2.17.1
+


### PR DESCRIPTION
In PTX 6.3 and higher, the WMMA PTX instructions require a `.aligned` in their mnemonic.
This was changed in https://reviews.llvm.org/rL359246, but unfortunately this didn't get in LLVM 8.0.1.
This PR ports that change, along with two other commits it depends on:
- https://reviews.llvm.org/rL359245 which refactors the tablegen which generates MMA intrinsics
- https://reviews.llvm.org/rL352185 which adds the `!cond` function to tablegen (needed because it is used by https://reviews.llvm.org/rL359246)

I bundled all three in one PR, but if you'd like me to split it up in three PRs, let me know.
Also, I can rewrite `rL359246` using `!if` instead of `cond!`, if you want to avoid merging https://reviews.llvm.org/rL352185.