### PR TITLE
WIP Divert sum(Vector{Bool}) to mapreduce from count.

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -19,6 +19,7 @@ The reduction operator used in `sum`. The main difference from [`+`](@ref) is th
 integers are promoted to `Int`/`UInt`.
 """
 add_sum(x, y) = x + y
+add_sum(x::Bool, y::Bool) = Int(x) + Int(y)
 add_sum(x::SmallSigned, y::SmallSigned) = Int(x) + Int(y)
 add_sum(x::SmallUnsigned, y::SmallUnsigned) = UInt(x) + UInt(y)
 add_sum(x::Real, y::Real)::Real = x + y
@@ -498,7 +499,6 @@ julia> sum(1:20)
 ```
 """
 sum(a) = sum(identity, a)
-sum(a::AbstractArray{Bool}) = count(a)
 
 ## prod
 """


### PR DESCRIPTION
This PR starts with https://discourse.julialang.org/t/sum-array-bool-1-vs-sum-array-int8-1/31353.  

Given ```b = rand(Bool, 10000); i = Int8.(b)```, the performance of  ```sum(b)``` and ```sum(i)``` should be the same, because they both add up bytes in contiguous memory, but they aren't.  Following Stevengj's suggestion, this commit changes two lines in ```base/reduce.jl``` to redirect the implementation of ```sum(Vector{Bool})``` into the same ```mapreduce``` path that ```sum(Vector{Int8})``` takes.  The altered code computes the sums correctly, but they still perform differently.  

I'd like to figure out what prevents the compiler from recognizing that ```sum(Vector{Bool})``` should match the same code generation path that ```sum(Vector{Int8})``` takes.
