### PR TITLE
fix `var"true"` and `var"false"`

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -478,13 +478,8 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
             return (jl_value_t*)jl_box_int32((int32_t)i64);
 #endif
     }
-    if (issymbol(e)) {
-        if (e == jl_ast_ctx(fl_ctx)->true_sym)
-            return jl_true;
-        else if (e == jl_ast_ctx(fl_ctx)->false_sym)
-            return jl_false;
+    if (issymbol(e))
         return (jl_value_t*)scmsym_to_julia(fl_ctx, e);
-    }
     if (fl_isstring(fl_ctx, e))
         return jl_pchar_to_string((char*)cvalue_data(e), cvalue_len(e));
     if (iscons(e) || e == fl_ctx->NIL) {
@@ -501,6 +496,10 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
                 return jl_box_slotnumber(numval(car_(cdr_(e))));
             else if (hd == jl_ast_ctx(fl_ctx)->null_sym && llength(e) == 1)
                 return jl_nothing;
+            else if (hd == jl_ast_ctx(fl_ctx)->true_sym && llength(e) == 1)
+                return jl_true;
+            else if (hd == jl_ast_ctx(fl_ctx)->false_sym && llength(e) == 1)
+                return jl_false;
         }
         if (issymbol(hd))
             sym = scmsym_to_julia(fl_ctx, hd);
@@ -643,9 +642,9 @@ static int julia_to_scm_noalloc1(fl_context_t *fl_ctx, jl_value_t *v, value_t *r
     else if (jl_is_symbol(v))
         *retval = symbol(fl_ctx, jl_symbol_name((jl_sym_t*)v));
     else if (v == jl_true)
-        *retval = jl_ast_ctx(fl_ctx)->true_sym;
+        *retval = fl_cons(fl_ctx, jl_ast_ctx(fl_ctx)->true_sym, fl_ctx->NIL);
     else if (v == jl_false)
-        *retval = jl_ast_ctx(fl_ctx)->false_sym;
+        *retval = fl_cons(fl_ctx, jl_ast_ctx(fl_ctx)->false_sym, fl_ctx->NIL);
     else if (v == jl_nothing)
         *retval = fl_cons(fl_ctx, jl_ast_ctx(fl_ctx)->null_sym, fl_ctx->NIL);
     else

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -111,8 +111,7 @@
   (and (pair? e)
        (or (memq (car e) '(toplevel line module import using export
                                     error incomplete))
-           (and (memq (car e) '(global const)) (every symbol? (cdr e))
-                (every (lambda (x) (not (memq x '(true false)))) (cdr e))))))
+           (and (memq (car e) '(global const)) (every symbol? (cdr e))))))
 
 (define *in-expand* #f)
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -334,7 +334,7 @@
                                                            (cons 'list (map car sparams)))
                                                       ,(if (null? loc) 0 (cadr loc))
                                                       (inert ,(if (null? loc) 'none (caddr loc)))
-                                                      false)))))
+                                                      (false))))))
                              (list gf))
                            '()))
             (types (llist-types argl))
@@ -443,7 +443,7 @@
                                      (string (current-julia-module-counter)))))))
       ;; this is a hack: nest these statements inside a call so they get closure
       ;; converted together, allowing all needed types to be defined before any methods.
-      `(call (core ifelse) false false (block
+      `(call (core ifelse) (false) (false) (block
         ;; forward-declare function so its type can occur in the signature of the inner method below
         ,@(if (or (symbol? name) (globalref? name)) `((method ,name)) '())
 
@@ -742,7 +742,7 @@
                    (if (call (top ult_int) ,(length field-names) ,nf)
                        (call (core throw) (call (top ArgumentError)
                                                 ,(string "new: too many arguments (expected " (length field-names) ")"))))
-                   (new ,tn ,@(map (lambda (fld fty) (field-convert fld fty `(call (core getfield) ,argt ,(+ fld 1) false)))
+                   (new ,tn ,@(map (lambda (fld fty) (field-convert fld fty `(call (core getfield) ,argt ,(+ fld 1) (false))))
                                    (iota (length field-names)) (list-head field-types (length field-names))))))))
           (else
             `(block
@@ -1241,13 +1241,13 @@
            (let ((finalb (cadddr (cdr e))))
              (expand-forms
               `(tryfinally
-                ,(if (not (eq? catchb 'false))
+                ,(if (not (equal? catchb '(false)))
                      `(try ,tryb ,var ,catchb)
                      `(scope-block ,tryb))
                 (scope-block ,finalb)))))
           ((length= e 4)
            (expand-forms
-            (if (and (symbol-like? var) (not (eq? var 'false)))
+            (if (symbol-like? var)
                 `(trycatch (scope-block ,tryb)
                            (scope-block
                             (block (= ,var (the_exception))
@@ -1520,18 +1520,18 @@
   (let ((e (cdr (flatten-ex '&& e))))
     (let loop ((tail e))
       (if (null? tail)
-          'true
+          '(true)
           (if (null? (cdr tail))
               (car tail)
               `(if ,(car tail)
                    ,(loop (cdr tail))
-                   false))))))
+                   (false)))))))
 
 (define (expand-or e)
   (let ((e (cdr (flatten-ex '|\|\|| e))))
     (let loop ((tail e))
       (if (null? tail)
-          'false
+          '(false)
           (if (null? (cdr tail))
               (car tail)
               (if (symbol-like? (car tail))
@@ -1816,7 +1816,7 @@
       `(= ,lhs ,rhs)))
 
 (define (expand-forms e)
-  (if (or (atom? e) (memq (car e) '(quote inert top core globalref outerref line module toplevel ssavalue null meta using import export)))
+  (if (or (atom? e) (memq (car e) '(quote inert top core globalref outerref line module toplevel ssavalue null true false meta using import export)))
       e
       (let ((ex (get expand-table (car e) #f)))
         (if ex
@@ -2330,7 +2330,7 @@
     (define (construct-loops itrs iv)
       (if (null? itrs)
           `(block (= ,oneresult ,expr)
-                  (inbounds true)
+                  (inbounds (true))
                   (if ,szunk
                       (call (top push!) ,result ,oneresult)
                       (call (top setindex!) ,result ,oneresult ,idx))
@@ -2497,8 +2497,8 @@
                    ,d)))
         ((eq? (car e) 'islocal)
          (if (memq (var-kind (cadr e) scope) '(global none))
-             'false
-             'true))
+             '(false)
+             '(true)))
         ((eq? (car e) 'lambda)
          (let* ((args (lam:vars e))
                 (body (resolve-scopes- (lam:body e) (make-scope e args '() '() sp '() scope))))
@@ -2594,7 +2594,7 @@
 
 ;; compute set of variables referenced in a lambda but not bound by it
 (define (free-vars- e tab)
-  (cond ((or (eq? e 'true) (eq? e 'false) (eq? e UNUSED) (underscore-symbol? e)) tab)
+  (cond ((or (eq? e UNUSED) (underscore-symbol? e)) tab)
         ((symbol? e) (put! tab e #t))
         ((and (pair? e) (eq? (car e) 'outerref)) tab)
         ((and (pair? e) (eq? (car e) 'break-block)) (free-vars- (caddr e) tab))
@@ -2752,7 +2752,7 @@ f(x) = yt(x)
                (struct_type ,name (call (core svec) ,@P)
                             (call (core svec) ,@(map quotify fields))
                             ,super
-                            (call (core svec) ,@types) false ,(length fields))
+                            (call (core svec) ,@types) (false) ,(length fields))
                (return (null))))))))
 
 (define (type-for-closure name fields super)
@@ -2763,7 +2763,7 @@ f(x) = yt(x)
                                 (call (core svec) ,@(map quotify fields))
                                 ,super
                                 (call (core svec) ,@(map (lambda (v) '(core Box)) fields))
-                                false ,(length fields))
+                                (false) ,(length fields))
                    (return (null)))))))
 
 
@@ -2779,7 +2779,7 @@ f(x) = yt(x)
 ;          (struct_type ,name (call (core svec) ,@P)
 ;                       (call (core svec) ,@(map quotify fields))
 ;                       ,super
-;                       (call (core svec) ,@types) false ,(length fields)))))
+;                       (call (core svec) ,@types) (false) ,(length fields)))))
 
 ;; ... and without parameters
 ;(define (type-for-closure name fields super)
@@ -2789,7 +2789,7 @@ f(x) = yt(x)
 ;                 (call (core svec) ,@(map quotify fields))
 ;                 ,super
 ;                 (call (core svec) ,@(map (lambda (v) 'Any) fields))
-;                 false ,(length fields))))
+;                 (false) ,(length fields))))
 
 
 (define (vinfo:not-capt vi)
@@ -2978,7 +2978,7 @@ f(x) = yt(x)
          meta inbounds boundscheck loopinfo decl aliasscope popaliasscope
          struct_type abstract_type primitive_type thunk with-static-parameters
          global globalref outerref const-if-global
-         const null ssavalue isdefined toplevel module lambda error
+         const null true false ssavalue isdefined toplevel module lambda error
          gc_preserve_begin gc_preserve_end import using export)))
 
 (define (local-in? s lam)
@@ -3165,7 +3165,7 @@ f(x) = yt(x)
        ((atom? e) e)
        (else
         (case (car e)
-          ((quote top core globalref outerref line break inert module toplevel null meta) e)
+          ((quote top core globalref outerref line break inert module toplevel null true false meta) e)
           ((=)
            (let ((var (cadr e))
                  (rhs (cl-convert (caddr e) fname lam namemap defined toplevel interp)))
@@ -3199,7 +3199,7 @@ f(x) = yt(x)
                                           `($ (call (core QuoteNode) ,sym))
                                           `(call (core getfield) ,fname (inert ,sym)))))
                           `(call (core isdefined) ,access (inert contents)))
-                        'true))
+                        '(true)))
                    (vi
                     (if (and (vinfo:asgn vi) (vinfo:capt vi))
                         `(call (core isdefined) ,sym (inert contents))
@@ -3646,7 +3646,7 @@ f(x) = yt(x)
     ;; `tail` means we are in tail position, where a value needs to be `return`ed
     ;; from the current function.
     (define (compile e break-labels value tail (linearize-args #t))
-      (if (or (not (pair? e)) (memq (car e) '(null ssavalue quote inert top core copyast the_exception $
+      (if (or (not (pair? e)) (memq (car e) '(null true false ssavalue quote inert top core copyast the_exception $
                                                    globalref outerref cdecl stdcall fastcall thiscall llvmcall)))
           (let ((e1 (if (and arg-map (symbol? e))
                         (get arg-map e e)
@@ -3658,7 +3658,6 @@ f(x) = yt(x)
                 (error (string "all-underscore identifier used as rvalue" (format-loc current-loc))))
             (cond (tail  (emit-return e1))
                   (value e1)
-                  ((or (eq? e1 'true) (eq? e1 'false)) #f)
                   ((symbol? e1) (emit e1) #f)  ;; keep symbols for undefined-var checking
                   ((and (pair? e1) (eq? (car e1) 'outerref)) (emit e1) #f)  ;; keep globals for undefined-var checking
                   ((and (pair? e1) (eq? (car e1) 'globalref)) (emit e1) #f) ;; keep globals for undefined-var checking
@@ -3942,7 +3941,7 @@ f(x) = yt(x)
                                  (let ((l  (make-ssavalue)))
                                    (emit `(= ,l ,(compile lam break-labels #t #f)))
                                    l))))
-                   (emit `(method ,(or (cadr e) 'false) ,sig ,lam))
+                   (emit `(method ,(or (cadr e) '(false)) ,sig ,lam))
                    (if value (compile '(null) break-labels value tail)))
                  (cond (tail  (emit-return e))
                        (value e)

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -15,9 +15,9 @@
               (loop (cdr lst) (cons nxt out)))))))
 
 (define (julia-bq-expand- x d)
-  (cond ((or (eq? x 'true) (eq? x 'false))  x)
-        ((or (symbol? x) (ssavalue? x))     (list 'inert x))
+  (cond ((or (symbol? x) (ssavalue? x))     (list 'inert x))
         ((atom? x)  x)
+        ((memq (car x) '(true false)) x)
         ((and (= d 0) (eq? (car x) '$))
          (if (length= x 2)
              (if (vararg? (cadr x))
@@ -206,8 +206,7 @@
 
 ;; get the name from a function formal argument expression, allowing `(escape x)`
 (define (try-arg-name v)
-  (cond ((and (symbol? v) (not (eq? v 'true)) (not (eq? v 'false)))
-         (list v))
+  (cond ((symbol? v) (list v))
         ((atom? v) '())
         (else
          (case (car v)
@@ -315,7 +314,7 @@
    m parent-scope inarg))
 
 (define (resolve-expansion-vars- e env m parent-scope inarg)
-  (cond ((or (eq? e 'true) (eq? e 'false) (eq? e 'end) (eq? e 'ccall) (eq? e 'cglobal))
+  (cond ((or (eq? e 'end) (eq? e 'ccall) (eq? e 'cglobal))
          e)
         ((symbol? e)
          (let ((a (assq e env)))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1389,7 +1389,7 @@ end
 # Module name cannot be a reserved word.
 @test_throws ParseError Meta.parse("module module end")
 
-@test Meta.lower(@__MODULE__, :(global true)) == Expr(:error, "invalid identifier name \"true\"")
+@test Meta.lower(@__MODULE__, :(global true)) == Expr(:error, "invalid syntax in \"global\" declaration")
 @test Meta.lower(@__MODULE__, :(let ccall end)) == Expr(:error, "invalid identifier name \"ccall\"")
 @test Meta.lower(@__MODULE__, :(cglobal = 0)) == Expr(:error, "invalid assignment location \"cglobal\"")
 
@@ -1920,7 +1920,9 @@ end
 @test Meta.parse(":a..:b") == Expr(:call, :(..), QuoteNode(:a), QuoteNode(:b))
 
 # Non-standard identifiers (PR #32408)
-@test Meta.parse("var\"#\"") == Symbol("#")
+@test Meta.parse("var\"#\"") === Symbol("#")
+@test Meta.parse("var\"true\"") === Symbol("true")
+@test Meta.parse("var\"false\"") === Symbol("false")
 @test_throws ParseError Meta.parse("var\"#\"x") # Reject string macro-like suffix
 @test_throws ParseError Meta.parse("var \"#\"")
 @test_throws ParseError Meta.parse("var\"for\" i = 1:10; end")


### PR DESCRIPTION
This is a bit silly but it might as well work.

This changes the internal representation of booleans in the front end to `(true)` and `(false)` to make them easier to distinguish from identifiers. Arguably, it makes the code easier to work with anyway.