### PR TITLE
Revert "fix #6645, 8-byte alignment of Float64 on 32-bit"

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -600,7 +600,8 @@ JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i)
         ((jl_value_t**)a->data)[i] = NULL;
 }
 
-// at this size and bigger, allocate resized array data with malloc
+// at this size and bigger, allocate resized array data with malloc directly
+// instead of managing them separately as gc objects
 #define MALLOC_THRESH 1048576
 
 // Resize the buffer to a max size of `newlen`
@@ -652,13 +653,7 @@ static int NOINLINE array_resize_buffer(jl_array_t *a, size_t newlen)
     }
     else {
         newbuf = 1;
-        if (
-#ifdef _P64
-            nbytes >= MALLOC_THRESH
-#else
-            elsz > 4
-#endif
-            ) {
+        if (nbytes >= MALLOC_THRESH) {
             a->data = jl_gc_managed_malloc(nbytes);
             jl_gc_track_malloced_array(ptls, a);
             a->flags.how = 2;


### PR DESCRIPTION
This workaround should no longer be needed.