### PR TITLE
Provide a clearer error for at-threads for a, b

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -90,7 +90,11 @@ macro threads(args...)
         throw(ArgumentError("need an expression argument to @threads"))
     end
     if ex.head === :for
-        return _threadsfor(ex.args[1], ex.args[2])
+        if ex.args[1] isa Expr && ex.args[1].head === :(=)
+            return _threadsfor(ex.args[1], ex.args[2])
+        else
+            throw(ArgumentError("nested outer loops are not currently supported by @threads"))
+        end
     else
         throw(ArgumentError("unrecognized argument to @threads"))
     end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -705,3 +705,10 @@ let a = zeros(nthreads())
     _atthreads_with_error(a, false)
     @test a == [1:nthreads();]
 end
+
+try
+    @macroexpand @threads(for i = 1:10, j = 1:10; end)
+catch ex
+    @test ex isa LoadError
+    @test ex.error isa ArgumentError
+end


### PR DESCRIPTION
Currently, nested loops specified as `for i = 1:2, j = 1:2` fail when passed to `@threads`, since the macro assumes the expression is a single `for` loop. This change just provides a more explicit error message in this case.