### PR TITLE
Use safer computation of midpoint in sorting (fixes #33977)

### DIFF
--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -475,6 +475,19 @@ v = OffsetArray(rand(8), (-2,))
 @test sortslices(A, dims=2) == OffsetArray(sortslices(parent(A), dims=2), A.offsets)
 @test sort(A, dims=1) == OffsetArray(sort(parent(A), dims=1), A.offsets)
 @test sort(A, dims=2) == OffsetArray(sort(parent(A), dims=2), A.offsets)
+# Issue #33977
+soa = OffsetArray([2,2,3], -2)
+@test searchsorted(soa, 1) == -1:-2
+@test searchsortedfirst(soa, 1) == -1
+@test searchsortedlast(soa, 1) == -2
+@test first(sort!(soa; alg=QuickSort)) == 2
+@test first(sort!(soa; alg=MergeSort)) == 2
+soa = OffsetArray([2,2,3], typemax(Int)-4)
+@test searchsorted(soa, 1) == typemax(Int)-3:typemax(Int)-4
+@test searchsortedfirst(soa, 2) == typemax(Int) - 3
+@test searchsortedlast(soa, 2) == typemax(Int) - 2
+@test first(sort!(soa; alg=QuickSort)) == 2
+@test first(sort!(soa; alg=MergeSort)) == 2
 
 @test mapslices(sort, A, dims=1) == OffsetArray(mapslices(sort, parent(A), dims=1), A.offsets)
 @test mapslices(sort, A, dims=2) == OffsetArray(mapslices(sort, parent(A), dims=2), A.offsets)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -11,6 +11,21 @@ using Test
     @test ReverseOrdering(Forward) == ReverseOrdering() == Reverse
 end
 
+@testset "midpoint" begin
+    @test Base.Sort.midpoint(1, 3) === 2
+    @test Base.Sort.midpoint(2, 4) === 3
+    @test 2 <= Base.Sort.midpoint(1, 4) <= 3
+    @test Base.Sort.midpoint(-3, -1) === -2
+    @test Base.Sort.midpoint(-4, -2) === -3
+    @test -3 <= Base.Sort.midpoint(-4, -1) <= -2
+    @test Base.Sort.midpoint(-1, 1) ===  0
+    @test -1 <= Base.Sort.midpoint(-2, 1) <= 0
+    @test 0 <= Base.Sort.midpoint(-1, 2) <= 1
+    @test Base.Sort.midpoint(-2, 2) ===  0
+    @test Base.Sort.midpoint(typemax(Int)-2, typemax(Int)) === typemax(Int)-1
+    @test Base.Sort.midpoint(typemin(Int), typemin(Int)+2) === typemin(Int)+1
+    @test -1 <= Base.Sort.midpoint(typemin(Int), typemax(Int)) <= 0
+end
 
 @testset "sort" begin
     @test sort([2,3,1]) == [1,2,3] == sort([2,3,1]; order=Forward)


### PR DESCRIPTION
Fixes #33977

I've tested that `÷2` is as fast as a shift locally, but let's see what nanosoldier says:
@nanosoldier `runbenchmarks(ALL, vs=":master")`
