### PR TITLE
Fix incorrect caching of Julia-LLVM type mapping

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -693,7 +693,9 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, jl_unionall_t *ua, bool *isbox
 #endif
                 decl = StructType::get(jl_LLVMContext, latypes);
             }
-            jst->struct_decl = decl;
+            // don't use struct_decl cache for llvmcall
+            if (!llvmcall)
+                jst->struct_decl = decl;
             return decl;
         }
     }

--- a/test/llvmpasses/llvmcall.jl
+++ b/test/llvmpasses/llvmcall.jl
@@ -6,6 +6,7 @@
 include(joinpath("..", "testhelpers", "llvmpasses.jl"))
 
 @generated foo(x)=:(ccall("extern foo", llvmcall, $x, ($x,), x))
+bar(x) = ntuple(i -> VecElement{Float16}(x[i]), 2)
 
 # CHECK: call half @foo(half zeroext %{{[0-9]+}})
 emit(foo, Float16)
@@ -15,3 +16,6 @@ emit(foo, NTuple{2, Float16})
 
 # CHECK: call <2 x half> @foo(<2 x half> %{{[0-9]+}})
 emit(foo, NTuple{2, VecElement{Float16}})
+
+# CHECK: define <2 x i16> @julia_bar_{{[0-9]+}}([2 x i16]
+emit(bar, NTuple{2, Float16})


### PR DESCRIPTION
This is a follow-up of https://github.com/JuliaLang/julia/pull/33970.
I noticed an issue in the implementation: if you use a `Float16` with `llvmcall` calling convention, it is lowered to a `half`, as expected.
However, subsequent calls also use `half` (instead of `i16`), even if you don't use `llvmcall`.

This is a MWE:
```julia
julia> foo(x) = ccall("extern foo", llvmcall, NTuple{2, VecElement{Float16}}, (NTuple{2, Float16},), x)
foo (generic function with 1 method)

julia> bar(x) = ntuple(i -> VecElement{Float16}(x[i]), 2)
bar (generic function with 1 method)

julia> code_llvm(foo, (NTuple{2, Float16},))

;  @ REPL[1]:1 within `foo'
define <2 x i16> @julia_foo_17011([2 x i16] addrspace(11)* nocapture nonnull readonly dereferenceable(4)) {
top:
  %.elt = bitcast [2 x i16] addrspace(11)* %0 to half addrspace(11)*
  %.unpack = load half, half addrspace(11)* %.elt, align 2
  %1 = insertvalue [2 x half] undef, half %.unpack, 0
  %.elt1 = getelementptr inbounds [2 x i16], [2 x i16] addrspace(11)* %0, i64 0, i64 1
  %2 = bitcast i16 addrspace(11)* %.elt1 to half addrspace(11)*
  %.unpack2 = load half, half addrspace(11)* %2, align 2
  %3 = insertvalue [2 x half] %1, half %.unpack2, 1
  %4 = call <2 x half> @foo([2 x half] %3)
  %5 = bitcast <2 x half> %4 to <2 x i16>
  ret <2 x i16> %5
}

julia> code_llvm(bar, (NTuple{2, Float16},))

;  @ REPL[2]:1 within `bar'
define <2 x half> @julia_bar_17013([2 x half] addrspace(11)* nocapture nonnull readonly dereferenceable(4)) {
top:
; ┌ @ ntuple.jl:18 within `ntuple'
; │┌ @ REPL[2]:1 within `#7'
; ││┌ @ boot.jl:362 within `VecElement'
     %1 = getelementptr inbounds [2 x half], [2 x half] addrspace(11)* %0, i64 0, i64 0
     %2 = load half, half addrspace(11)* %1, align 2
; ││└
; ││┌ @ tuple.jl:24 within `getindex'
     %3 = getelementptr inbounds [2 x half], [2 x half] addrspace(11)* %0, i64 0, i64 1
; ││└
; ││┌ @ boot.jl:362 within `VecElement'
     %4 = load half, half addrspace(11)* %3, align 2
; │└└
   %5 = insertelement <2 x half> undef, half %2, i32 0
   %6 = insertelement <2 x half> %5, half %4, i32 1
; └
  ret <2 x half> %6
}
```

This is because the LLVM type is cached in the `struct_decl` field.

This PR solves the issue by splitting the `struct_decl` field in two: one in case `llvmcall` is used, and one in case it isn't.

// cc: @maleadt @vchuravy