### PR TITLE
Update the custom type broadcasting example

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -565,6 +565,7 @@ end
 find_aac(bc::Base.Broadcast.Broadcasted) = find_aac(bc.args)
 find_aac(args::Tuple) = find_aac(find_aac(args[1]), Base.tail(args))
 find_aac(x) = x
+find_aac(x::Base.Broadcast.Extruded) = x.x
 find_aac(::Tuple{}) = nothing
 find_aac(a::ArrayAndChar, rest) = a
 find_aac(::Any, rest) = find_aac(rest)

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -570,7 +570,7 @@ find_aac(::Tuple{}) = nothing
 find_aac(a::ArrayAndChar, rest) = a
 find_aac(::Any, rest) = find_aac(rest)
 # output
-find_aac (generic function with 6 methods)
+find_aac (generic function with 7 methods)
 ```
 
 From these definitions, one obtains the following behavior:


### PR DESCRIPTION
Without this method, the following code fails:
```
a = ArrayAndChar([1, 2, 3, 4], 'x')
tp = UInt64
func(x) = convert(tp, x)
d = func.(a)
```

Also, if someone knows more about broadcasting: 
- is it now a complete definition, or should some other methods be added?
- why, if one writes `func` as `func(x) = convert(UInt64, x)`, `Extruded` does not appear in the broadcast expression?