### PR TITLE
Add scaffolding for notarization on macOS

### DIFF
--- a/contrib/mac/app/.gitignore
+++ b/contrib/mac/app/.gitignore
@@ -1,3 +1,4 @@
 julia/
 dmg/
 *.dmg
+notarize-*.xml

--- a/contrib/mac/app/Entitlements.plist
+++ b/contrib/mac/app/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
+</plist>

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -17,7 +17,7 @@ APP_NAME:=Julia-$(JULIA_VERSION_MAJOR_MINOR).app
 VOL_NAME:=Julia-$(JULIA_VERSION_OPT_COMMIT)
 
 APP_ID:=org.julialang.launcherapp
-APP_COPYRIGHT:=© 2016 The Julia Project
+APP_COPYRIGHT:=© $(shell date '+%Y') The Julia Project
 
 
 all: clean $(DMG_NAME)
@@ -51,7 +51,7 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	tar zxf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
 	if [ -n "$$MACOS_CODESIGN_IDENTITY" ]; then \
 	    echo "Codesigning with identity $$MACOS_CODESIGN_IDENTITY"; \
-		codesign -s "$$MACOS_CODESIGN_IDENTITY" -v --deep $@; \
+		codesign -s "$$MACOS_CODESIGN_IDENTITY" --option=runtime --entitlements Entitlements.plist -v --deep $@; \
 	else \
 		true; \
 	fi
@@ -60,9 +60,35 @@ ROOTFILES := $(shell ls -ld dmg/*.app *.dmg 2> /dev/null | awk '{print $$3}')
 clean:
 ifneq ($(filter root,$(ROOTFILES)),)
 	@echo "We have to use sudo here to clean out folders owned by root.  You may be asked for your password"
-	sudo rm -rf dmg *.dmg
+	sudo rm -rf dmg *.dmg notarize-*.xml
 else
 	rm -rf dmg *.dmg
 endif
 
-.PHONY: clean all
+notarize-upload-$(DMG_NAME).xml: $(DMG_NAME)
+	@# Upload the `.dmg` for notarization
+	xcrun altool --notarize-app --primary-bundle-id org.julialang.launcherapp --username "$$APPLEID" --password "$$APPLEID_PASSWORD" -itc_provider A427R7F42H --file "$(DMG_NAME)" --output-format xml > "$@"
+	@# Sleep for a few seconds so that we don't immediately error out when we request the UUID from Apple
+	@sleep 5
+
+
+notarize-check: notarize-upload-$(DMG_NAME).xml
+	@# We wait in a while loop for notarization to complete
+	./notarize_check.sh "$<"
+
+# This is the top-level notarization target.  Note that this is still a somewhat manual
+# process; things can go wrong, and so if it fails, you may need to inspect the `.xml`
+# files to see what went wrong, but in general you can just run `make notarize` and it
+# should upload, notarize, staple, and re-package the .dmg for you.
+# Note that for this to work, you need to have exported `APPLEID`, `APPLEID_PASSWORD`
+# and `MACOS_CODESIGN_IDENTITY` to have signed the `.app` in the first place.
+notarize: notarize-check
+	@# Delete old .dmg file
+	rm -f $(DMG_NAME)
+	@# Staple the .app
+	xcrun stapler staple dmg/$(APP_NAME)
+	@# re-build the .dmg
+	$(MAKE) $(DMG_NAME)
+
+
+.PHONY: clean all notarize-upload notarize-check

--- a/contrib/mac/app/notarize_check.sh
+++ b/contrib/mac/app/notarize_check.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Note that you need to have exported `APPLEID` and `APPLEID_PASSWORD` for this to work.
+
+# Get the UUID from a notarization-upload*.xml file
+function extract_uuid()
+{
+    PLIST_FILE="$1"
+
+    SED_PATTERN='.*([[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}).*'
+    /usr/libexec/PlistBuddy -c "print notarization-upload:RequestUUID" "${PLIST_FILE}" 2>/dev/null
+    if [[ $? != 0 ]]; then
+        sed -n -E "s/${SED_PATTERN}/\1/p" "${PLIST_FILE}" 2>/dev/null | head -1
+    fi
+}
+
+# Continually probe and ask if Apple is done notarizing our precious binary bits
+function wait_until_completed()
+{
+    UUID="$1"
+    PLIST_FILE="$2"
+    echo "Waiting until UUID ${UUID} is done processing...."
+
+    while true; do
+        xcrun altool --notarization-info "${UUID}" --username "${APPLEID}" --password "${APPLEID_PASSWORD}" --output-format xml > "${PLIST_FILE}"
+        STATUS=$(/usr/libexec/PlistBuddy -c "print notarization-info:Status" "${PLIST_FILE}" 2>/dev/null)
+
+        # Process loop exit conditions
+        if [[ ${STATUS} == "success" ]]; then
+            echo "Notarization finished"
+            return 0
+        elif [[ ${STATUS} == "in progress" ]]; then
+            echo -n "."
+            sleep 10
+            continue
+        else
+            echo "Notarization failed with status ${STATUS}"
+            exit 1
+        fi
+    done
+}
+
+if [[ "$#" != 1 ]]; then
+    echo "Usage: $0 notarize-upload-<suffix>.xml"
+    exit 1
+fi
+
+# Get input parameters
+UPLOAD_PLIST_FILE="$1"
+SUFFIX="${UPLOAD_PLIST_FILE#"notarize-upload-"}"
+SUFFIX="${SUFFIX%".xml"}"
+
+# Extract UUID from uploaded plist file
+UUID=$(extract_uuid "${UPLOAD_PLIST_FILE}")
+if [[ -z "${UUID}" ]]; then
+    echo "ERROR: Could not extract UUID value from ${UPLOAD_PLIST_FILE}" >&2
+    exit 1
+fi
+
+# Wait until the UUID is done processing
+wait_until_completed "${UUID}" "notarize-check-${SUFFIX}.xml"


### PR DESCRIPTION
This adds some Makefile and `bash` tools to aid in notarizing macOS apps.  None of this is run automatically; the process is still too manual to be done automatically, but this at least makes it very easy for a human to supervise.