### PR TITLE
BUGFIX: provide enough space when converting adjoint of triangular sparse matrix to sparse

### DIFF
--- a/stdlib/SparseArrays/src/sparseconvert.jl
+++ b/stdlib/SparseArrays/src/sparseconvert.jl
@@ -183,9 +183,10 @@ function _sparsem(A::AbstractTriangularSparse{Tv}) where Tv
     Ti = eltype(rowval)
     fnzrange = A isa Union{UpperTriangular,UnitUpperTriangular} ? nzrangeup : nzrangelo
     unit = A isa Union{UnitUpperTriangular,UnitLowerTriangular}
+    nz = nnz(S) + n * unit
     newcolptr = Vector{Ti}(undef, n+1)
-    newrowval = Vector{Ti}(undef, nnz(S))
-    newnzval = Vector{Tv}(undef, nnz(S))
+    newrowval = Vector{Ti}(undef, nz)
+    newnzval = Vector{Tv}(undef, nz)
     newcolptr[1] = 1
     uplo = fnzrange == nzrangeup
     newk = 1
@@ -233,7 +234,7 @@ function _sparsem(taA::Union{Transpose{Tv,<:AbstractTriangularSparse},
     uplo = A isa Union{UpperTriangular,UnitUpperTriangular}
 
     newcolptr = Vector{Ti}(undef, n+1)
-    fill!(newcolptr, 1unit)
+    fill!(newcolptr, unit)
     newcolptr[1] = 1
     @inbounds for j = 1:n
         for k = fnzrange(A, j)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2693,6 +2693,9 @@ end
     @test sparse([1,2,3,4,5]') == SparseMatrixCSC([1 2 3 4 5])
     @test sparse(UpperTriangular(A')) == UpperTriangular(B')
     @test sparse(Adjoint(UpperTriangular(A'))) == Adjoint(UpperTriangular(B'))
+    @test sparse(UnitUpperTriangular(spzeros(5,5))) == I
+    deepwrap(A) = (Adjoint(LowerTriangular(view(Symmetric(A), 5:7, 4:6))))
+    @test sparse(deepwrap(A)) == Matrix(deepwrap(B))
 end
 
 @testset "unary operations on matrices where length(nzval)>nnz" begin


### PR DESCRIPTION
Fixes #34123.

The internal buffers of `SparseMatrixCSC` are to small in length.

The error is in all releases starting form 1.2 in `stdlib/SparseArrays`.
It initiates a segmentation violation, if the program is not started with `julia --check-bounds=yes`.

