### PR TITLE
Make argument in `download` to AbstractString

### DIFF
--- a/base/download.jl
+++ b/base/download.jl
@@ -48,7 +48,7 @@ end
 
 const DOWNLOAD_HOOKS = Callable[]
 
-function download_url(url::String)
+function download_url(url::AbstractString)
     for hook in DOWNLOAD_HOOKS
         url = String(hook(url)::AbstractString)
     end


### PR DESCRIPTION
from `download_url(url::String)` to `download_url(url::AbstractString)`

fixes `ERROR: MethodError: no method matching download_url(::SubString{String})`