### PR TITLE
Fix race condition in test introduced in #33119 (oops).

### DIFF
--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -781,19 +781,3 @@ end
     @test fetch(@async :($($a))) == a
     @test fetch(@async "$($a)") == "$a"
 end
-
-# errors inside @threads
-function _atthreads_with_error(a, err)
-    Threads.@threads for i in eachindex(a)
-        if err
-            error("failed")
-        end
-        a[i] = Threads.threadid()
-    end
-    a
-end
-@test_throws TaskFailedException _atthreads_with_error(zeros(nthreads()), true)
-let a = zeros(nthreads())
-    _atthreads_with_error(a, false)
-    @test a == [1:nthreads();]
-end


### PR DESCRIPTION
Introduce synchronization (via a `Channel()`) to force spawned tasks to
run after the local variables are updated, showcasing the problem and
the solution with `$`-interpolation.

Fixes race condition in test introduced in #33119.

Fixes https://github.com/JuliaLang/julia/issues/34141.