### PR TITLE
[WIP]  Trying to fix spawn-interpolation for macrocalls

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -388,6 +388,8 @@ function _lift_one_interp_helper(expr::Expr, in_quote_context, letargs)
         end
     elseif expr.head == :quote
         in_quote_context = true   # Don't try to lift $ directly out of quotes
+    elseif expr.head == :macrocall
+        return expr
     end
     for (i,e) in enumerate(expr.args)
         expr.args[i] = _lift_one_interp_helper(e, in_quote_context, letargs)

--- a/base/task.jl
+++ b/base/task.jl
@@ -386,10 +386,8 @@ function _lift_one_interp_helper(expr::Expr, in_quote_context, letargs)
             push!(letargs, :($(esc(newarg)) = $(esc(expr.args[1]))))
             return newarg  # Don't recurse into the lifted $() exprs
         end
-    elseif expr.head == :quote
+    elseif expr.head == :quote || expr.head == :macrocall
         in_quote_context = true   # Don't try to lift $ directly out of quotes
-    elseif expr.head == :macrocall
-        return expr
     end
     for (i,e) in enumerate(expr.args)
         expr.args[i] = _lift_one_interp_helper(e, in_quote_context, letargs)

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -781,19 +781,3 @@ end
     @test fetch(@async :($($a))) == a
     @test fetch(@async "$($a)") == "$a"
 end
-
-# errors inside @threads
-function _atthreads_with_error(a, err)
-    Threads.@threads for i in eachindex(a)
-        if err
-            error("failed")
-        end
-        a[i] = Threads.threadid()
-    end
-    a
-end
-@test_throws TaskFailedException _atthreads_with_error(zeros(nthreads()), true)
-let a = zeros(nthreads())
-    _atthreads_with_error(a, false)
-    @test a == [1:nthreads();]
-end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -781,3 +781,26 @@ end
     @test fetch(@async :($($a))) == a
     @test fetch(@async "$($a)") == "$a"
 end
+
+# Issue #34138
+@testset "spawn interpolation: macrocalls" begin
+    @testset "inner macrocalls" begin
+        x = 2
+        @test fetch(@async @eval 2+$x) == 4
+        @test fetch(@async @eval 2+$$x) == 4
+
+        x = [reshape(1:4, 2, 2);]
+        @test fetch(Threads.@spawn @. $exp(x)) == @. $exp(x)
+    end
+    @testset "outer macrocalls" begin
+        x = 2
+        @test @eval(fetch(@async 2+$x)) == 4
+        @test @eval(fetch(@async 2+$$x)) == 4
+
+        @test @eval(fetch(@async @eval 2+$x)) == 4
+        @test @eval(fetch(@async @eval 2+$$x)) == 4
+
+        x = [reshape(1:4, 2, 2);]
+        @test @eval(fetch(Threads.@spawn @. $exp(x))) == @. $exp(x)
+    end
+end


### PR DESCRIPTION
Expand macrocalls when parsing async early, before recursing to
interpolate `$` variables. This fixes inner macrocalls that themselves
operate on `$`, by giving them the chance to use up the `$` _if they
use them_, before allowing `@async` / `@spawn` to do the intepolation
themselves.

But this still doesn't seem to be working correctly, since "outer
macrocalls" still aren't working, e.g.:
```julia
julia> @eval fetch(@async 2+$$x)
ERROR: syntax: "$" expression outside quote
```