### PR TITLE
InteractiveUtils - Added support for PyCharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 
 /perf*
 .DS_Store
+.idea/*

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -69,6 +69,7 @@ already work:
 - notepad++
 - Visual Studio Code
 - open
+- pycharm
 
 # Example:
 
@@ -123,7 +124,7 @@ function define_default_editors()
     define_editor(["textmate", "mate", "kate"]) do cmd, path, line
         `$cmd $path -l $line`
     end
-    define_editor([r"\bsubl", r"\batom"]) do cmd, path, line
+    define_editor([r"\bsubl", r"\batom", "pycharm"]) do cmd, path, line
         `$cmd $path:$line`
     end
     define_editor("code") do cmd, path, line


### PR DESCRIPTION
PyCharm documentation for opening files, [here](https://www.jetbrains.com/help/pycharm/opening-files-from-command-line.html). I think the `alternative` is the more preferable way of opening files personally.