### PR TITLE
Fix the use of time() in measuring performances (replace with time_ns())

### DIFF
--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -264,13 +264,14 @@ Returns :ok, :timed_out, or :error
 """
 function timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
     pollint > 0 || throw(ArgumentError("cannot set pollint to $pollint seconds"))
-    start = time()
+    start = time_ns()
+    nsecs = 1e9 * secs
     done = Channel(1)
     function timercb(aw)
         try
             if testcb()
                 put!(done, :ok)
-            elseif (time() - start) > secs
+            elseif (time_ns() - start) > nsecs
                 put!(done, :timed_out)
             end
         catch e

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -57,7 +57,7 @@ if Pkg !== nothing
 end
 
 function generate_precompile_statements()
-    start_time = time()
+    start_time = time_ns()
     debug_output = devnull # or stdout
 
     # Precompile a package
@@ -179,9 +179,9 @@ function generate_precompile_statements()
         end
 
         print(" $(length(statements)) generated in ")
-        tot_time = time() - start_time
-        Base.time_print(tot_time * 10^9)
-        print(" (overhead "); Base.time_print((tot_time - include_time) * 10^9); println(")")
+        tot_time = time_ns() - start_time
+        Base.time_print(tot_time)
+        print(" (overhead "); Base.time_print(tot_time - (include_time * 1e9)); println(")")
     end
 
     return

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -771,10 +771,10 @@ final value. The macro might look like this:
 ```julia
 macro time(ex)
     return quote
-        local t0 = time()
+        local t0 = time_ns()
         local val = $ex
-        local t1 = time()
-        println("elapsed time: ", t1-t0, " seconds")
+        local t1 = time_ns()
+        println("elapsed time: ", (t1-t0)/1e9, " seconds")
         val
     end
 end
@@ -857,10 +857,10 @@ macro time(expr)
     return :(timeit(() -> $(esc(expr))))
 end
 function timeit(f)
-    t0 = time()
+    t0 = time_ns()
     val = f()
-    t1 = time()
-    println("elapsed time: ", t1-t0, " seconds")
+    t1 = time_ns()
+    println("elapsed time: ", (t1-t0)/1e9, " seconds")
     return val
 end
 ```

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1023,7 +1023,7 @@ function _rmprocs(pids, waitfor)
         end
 
         start = time_ns()
-        while (time_ns() - start) < waitfor
+        while (time_ns() - start) < waitfor*1e9
             all(w -> w.state == W_TERMINATED, rmprocset) && break
             sleep(min(0.1, waitfor - (time_ns() - start)/1e9))
         end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -17,8 +17,8 @@ end
     init_data = Profile.len_data()
     while iter < n_tries && Profile.len_data() == init_data
         iter += 1
-        tend = time() + t
-        while time() < tend end
+        tend = time_ns() + 1e9 * t
+        while time_ns() < tend end
     end
 end
 

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -379,11 +379,11 @@ end
         end
 
         function wait_with_timeout(recvs)
-            TIMEOUT_VAL = 3  # seconds
-            t0 = time()
+            TIMEOUT_VAL = 3*1e9 # nanoseconds
+            t0 = time_ns()
             recvs_check = copy(recvs)
             while ((length(filter!(t->!istaskdone(t), recvs_check)) > 0)
-                  && (time() - t0 < TIMEOUT_VAL))
+                  && (time_ns() - t0 < TIMEOUT_VAL))
                 sleep(0.05)
             end
             length(recvs_check) > 0 && error("timeout")

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -32,12 +32,12 @@ macro check_bit_operation(ex)
     Expr(:call, :check_bitop_call, nothing, map(esc, ex.args)...)
 end
 
-let t0 = time()
+let t0 = time_ns()
     global timesofar
     function timesofar(str)
         return # no-op, comment to see timings
-        t1 = time()
-        println(str, ": ", t1-t0, " seconds")
+        t1 = time_ns()
+        println(str, ": ", (t1-t0)/1e9, " seconds")
         t0 = t1
     end
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -3,7 +3,7 @@
 #############################################
 # Create some temporary files & directories #
 #############################################
-starttime = time()
+starttime = time_ns() / 1e9
 pwd_ = pwd()
 dir = mktempdir()
 file = joinpath(dir, "afile.txt")
@@ -382,12 +382,14 @@ if Sys.iswindows()
 else
     @test filesize(dir) > 0
 end
-nowtime = time()
+# We need both: one to check passed time, one to comapare file's mtime()
+nowtime = time_ns() / 1e9
+nowwall = time()
 # Allow 10s skew in addition to the time it took us to actually execute this code
 let skew = 10 + (nowtime - starttime)
     mfile = mtime(file)
     mdir  = mtime(dir)
-    @test abs(nowtime - mfile) <= skew && abs(nowtime - mdir) <= skew && abs(mfile - mdir) <= skew
+    @test abs(nowwall - mfile) <= skew && abs(nowwall - mdir) <= skew && abs(mfile - mdir) <= skew
 end
 #@test Int(time()) >= Int(mtime(file)) >= Int(mtime(dir)) >= 0 # 1 second accuracy should be sufficient
 


### PR DESCRIPTION
time() is a wrapper for gettimeofday, which is affected by by discontinuous
jumps in the system time (e.g., if the system administrator manually changes the
system time), see `man gettimeofday`.  On the other hand, time_ns() is a wrapper
for libuv uv_hrtime that has no drift, whose manual page says "The primary use
is for measuring performance between intervals.".

Tentative fix for bug #34115