### PR TITLE
in(p::Pair, a::AbstractDict, valcmp) bug sort.  swapped valcmp arguments

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -19,7 +19,7 @@ haskey(d::AbstractDict, k) = in(k, keys(d))
 function in(p::Pair, a::AbstractDict, valcmp=(==))
     v = get(a,p[1],secret_table_token)
     if v !== secret_table_token
-        return valcmp(v, p[2])
+        return valcmp(p[2], v)
     end
     return false
 end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1072,3 +1072,11 @@ end
         @test testdict[:b] == 1
     end
 end
+
+@testset "in(Pair, AbstractDict, valcmp='a comparison operator')" begin
+    testdict = Dict(:a=>1, :b=>3)
+    @test in(:a=>2, testdict, >)
+    @test !in(:a=>0, testdict, >)
+    @test in(:b=>2, testdict, <)
+    @test !in(:b=>4, testdict, <)
+end


### PR DESCRIPTION
AsbstractDict 'in'  valcmp arguments are swapped compared to the ImmutableDict version.

There are tests for ImmutableDict, but not AbstractDict.    PR makes Abstract Dict behave the same as ImmutableDict  and adds same tests to verify    