### PR TITLE
Use function attribute "frame-pointer" instead of "no-frame-pointer-elim" on LLVM 8+

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -830,7 +830,11 @@ void jl_init_function(Function *F)
     F->setHasUWTable(); // force NeedsWinEH
 #endif
 #ifdef JL_DISABLE_FPO
+#if LLVM_VERSION_MAJOR >= 8
+    F->addFnAttr("frame-pointer", "all");
+#else
     F->addFnAttr("no-frame-pointer-elim", "true");
+#endif
 #endif
     // record the WIP name
     incomplete_fname.insert(F->getName());


### PR DESCRIPTION
LLVM 8 ([D56351](https://reviews.llvm.org/D56351)) introduced "frame-pointer" which was intended to replace
"no-frame-pointer-elim"/"no-frame-pointer-elim-non-leaf".

-----

In the LLVM monorepo, run `git show llvmorg-8.0.0:llvm/lib/CodeGen/TargetOptionsImpl.cpp` to verify that `"frame-pointer"` is available.