### PR TITLE
Allow passing NTuple{N,T} as Ref{T}/Ptr{T} to ccall

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@ New library features
 --------------------
 * Function composition now works also on one argument `∘(f) = f` (#34251)
 
+* `Ref{NTuple{N,T}}` can be passed to `Ptr{T}`/`Ref{T}` `ccall` signatures ([#34199])
+
 
 Standard library changes
 ------------------------

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -126,6 +126,16 @@ cconvert(::Type{Ref{P}}, a::Array{<:Ptr}) where {P<:Ptr} = a
 cconvert(::Type{Ptr{P}}, a::Array) where {P<:Union{Ptr,Cwstring,Cstring}} = Ref{P}(a)
 cconvert(::Type{Ref{P}}, a::Array) where {P<:Union{Ptr,Cwstring,Cstring}} = Ref{P}(a)
 
+# pass NTuple{N,T} as Ptr{T}/Ref{T}
+cconvert(::Type{Ref{T}}, t::NTuple{N,T}) where {N,T} = Ref{NTuple{N,T}}(t)
+cconvert(::Type{Ref{T}}, r::Ref{NTuple{N,T}}) where {N,T} = r
+unsafe_convert(::Type{Ref{T}}, r::Ref{NTuple{N,T}}) where {N,T} =
+    convert(Ptr{T}, unsafe_convert(Ptr{NTuple{N,T}}, r))
+unsafe_convert(::Type{Ptr{T}}, r::Ref{NTuple{N,T}}) where {N,T} =
+    convert(Ptr{T}, unsafe_convert(Ptr{NTuple{N,T}}, r))
+unsafe_convert(::Type{Ptr{T}}, r::Ptr{NTuple{N,T}}) where {N,T} =
+    convert(Ptr{T}, r)
+
 ###
 
 getindex(b::RefArray) = b.x[b.i]

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1557,3 +1557,20 @@ ERROR: could not load library "does_not_exist"
 does_not_exist.so: cannot open shared object file: No such file or directory
 """)
 @test !isfile(o_file)
+
+# pass NTuple{N,T} as Ptr{T}/Ref{T}
+let
+    dest = Ref((0,0,0))
+
+    src  = Ref((1,2,3))
+    ccall(:memcpy, Ptr{Cvoid}, (Ptr{Int}, Ptr{Int}, Csize_t), dest, src, 3*sizeof(Int))
+    @test dest[] == (1,2,3)
+
+    src  = Ref((4,5,6))
+    ccall(:memcpy, Ptr{Cvoid}, (Ref{Int}, Ref{Int}, Csize_t), dest, src, 3*sizeof(Int))
+    @test dest[] == (4,5,6)
+
+    src  = (7,8,9)
+    ccall(:memcpy, Ptr{Cvoid}, (Ref{Int}, Ref{Int}, Csize_t), dest, src, 3*sizeof(Int))
+    @test dest[] == (7,8,9)
+end


### PR DESCRIPTION
This makes it convenient when working with APIs that use small arrays.

Based on discussion on Slack with @vtjnash and [Discourse comment](https://discourse.julialang.org/t/ccall-with-pointer-argument-to-array-of-custom-type-via-an-ntuple-of-immutables/1048/2) by @yuyichao 
