### PR TITLE
allow ± and ∓ as unary operators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ New language features
 * `⨟` is now parsed as a binary operator with times precedence. It can be entered in the REPL
   with `\bbsemi` followed by <kbd>TAB</kbd> ([#34722]).
 
+* `±` and `∓` are now unary operators as well, like `+` or `-`. Attention has to be paid in
+  macros and matrix constructors, which are whitespace sensitive, because expressions like
+  `[a ±b]` now get parsed as `[a ±(b)]` instead of `[±(a, b)]`. ([#34200])
+
 Language changes
 ----------------
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -102,12 +102,13 @@
                                       0))
 
 (define unary-ops (append! '(|<:| |>:|)
-                           (add-dots '(+ - ! ~ ¬ √ ∛ ∜ ⋆))))
+                           (add-dots '(+ - ! ~ ¬ √ ∛ ∜ ⋆ ± ∓))))
 
 (define unary-op? (Set unary-ops))
 
 ; operators that are both unary and binary
-(define unary-and-binary-ops '(+ - $ & ~ ⋆ |.+| |.-| |.⋆|))
+(define unary-and-binary-ops (append! '($ & ~)
+                                      (add-dots '(+ - ⋆ ± ∓))))
 
 (define unary-and-binary-op? (Set unary-and-binary-ops))
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -310,3 +310,8 @@ end
         @test isequal(parse(Float64, s), sign(v))
     end
 end
+
+@testset "unary ± and ∓" begin
+    @test Meta.parse("±x") == Expr(:call, :±, :x)
+    @test Meta.parse("∓x") == Expr(:call, :∓, :x)
+end


### PR DESCRIPTION
This came up on slack, that it would be nice to have `±` as an allowed unary operator. This PR also adds `∓`. <s>further plus-like operators, which looked enough like `+` and `-` to make sense in my mind, but I can also remove the weirder ones, if so desired</s>. Probably should have tests, but I'm not quite sure what to test here exactly.