### PR TITLE
Return the first argument in `put!`

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -304,14 +304,19 @@ Append an item `v` to the channel `c`. Blocks if the channel is full.
 
 For unbuffered channels, blocks until a [`take!`](@ref) is performed by a different
 task.
+Return the first argument.
 
 !!! compat "Julia 1.1"
     `v` now gets converted to the channel's type with [`convert`](@ref) as `put!` is called.
+
+!!! compat "Julia 1.4"
+    `put!` now returns the channel `c`; older versions of Julia returned `v`.
 """
 function put!(c::Channel{T}, v) where T
     check_channel_state(c)
     v = convert(T, v)
-    return isbuffered(c) ? put_buffered(c, v) : put_unbuffered(c, v)
+    isbuffered(c) ? put_buffered(c, v) : put_unbuffered(c, v)
+    return c
 end
 
 function put_buffered(c::Channel, v)

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -19,7 +19,7 @@ end
 
     c = Channel(1)
     @test eltype(c) == Any
-    @test put!(c, 1) == 1
+    @test put!(c, 1) === c
     @test isready(c) == true
     @test take!(c) == 1
     @test isready(c) == false
@@ -35,7 +35,8 @@ end
 
     c = Channel{Int}(Inf)
     @test eltype(c) == Int
-    pvals = map(i->put!(c,i), 1:10^6)
+    pvals = 1:10^6
+    foldl(put!, pvals; init=c)
     tvals = Int[take!(c) for i in 1:10^6]
     @test pvals == tvals
 
@@ -162,7 +163,7 @@ using Distributed
 
     if N > 0
         for i in 1:5
-            @test put!(cs[i], 2) === 2
+            @test put!(cs[i], 2) === cs[i]
         end
     end
     for i in 1:5
@@ -457,8 +458,7 @@ let t = @async nothing
     @test_throws ErrorException("schedule: Task not runnable") schedule(t, nothing)
 end
 
-@testset "put!(c, v) -> c" begin
+@testset "push!(c, v) -> c" begin
     c = Channel(Inf)
-    @test put!(c, nothing) === c
     @test push!(c, nothing) === c
 end

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -456,3 +456,9 @@ let t = @async nothing
     wait(t)
     @test_throws ErrorException("schedule: Task not runnable") schedule(t, nothing)
 end
+
+@testset "put!(c, v) -> c" begin
+    c = Channel(Inf)
+    @test put!(c, nothing) === c
+    @test push!(c, nothing) === c
+end


### PR DESCRIPTION
`push!` usually returns the first argument ("container")

```julia
julia> push!([], 1)
1-element Array{Any,1}:
 1

julia> push!(Dict(), :a => 1)
Dict{Any,Any} with 1 entry:
  :a => 1

julia> push!(Set(), 1)
Set{Any} with 1 element:
  1
```

but not with channels

```julia
julia> push!(Channel(Inf), 1)
1
```

This PR fixes this inconsistency by tweaking `put!` such that `put!(c, _) === c`.  This automatically fixes `push!` as `push!` is just an alias of `put!`:

https://github.com/JuliaLang/julia/blob/2835347ff051f85997220dfe0dc152249763c6f4/base/channels.jl#L351

This also makes `put!(::Channel, _)` consistent with `put!(::RemoteChannel, _)`

https://github.com/JuliaLang/julia/blob/2835347ff051f85997220dfe0dc152249763c6f4/stdlib/Distributed/src/remotecall.jl#L584-L591
