### PR TITLE
Fix delete! for WeakKeyDict.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,8 @@ Standard library changes
 
 * `methods` now accepts passing a module (or a list thereof) to filter methods defined in it ([#33403]).
 
+* `delete!` on `WeakKeyDict`s now returns the `WeakKeyDict` itself instead of the underlying `Dict` used for implementation
+
 #### Libdl
 
 #### LinearAlgebra

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -105,7 +105,7 @@ function get!(default::Callable, wkh::WeakKeyDict{K}, key) where {K}
 end
 pop!(wkh::WeakKeyDict{K}, key) where {K} = lock(() -> pop!(wkh.ht, key), wkh)
 pop!(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> pop!(wkh.ht, key, default), wkh)
-delete!(wkh::WeakKeyDict, key) = lock(() -> delete!(wkh.ht, key), wkh)
+delete!(wkh::WeakKeyDict, key) = (lock(() -> delete!(wkh.ht, key), wkh); wkh)
 empty!(wkh::WeakKeyDict) = (lock(() -> empty!(wkh.ht), wkh); wkh)
 haskey(wkh::WeakKeyDict{K}, key) where {K} = lock(() -> haskey(wkh.ht, key), wkh)
 getindex(wkh::WeakKeyDict{K}, key) where {K} = lock(() -> getindex(wkh.ht, key), wkh)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -856,6 +856,7 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
 
     wkd = WeakKeyDict(A=>1)
     @test delete!(wkd, A) == empty(wkd)
+    @test delete!(wkd, A) === wkd
 
     # issue #26939
     d26939 = WeakKeyDict()


### PR DESCRIPTION
Relatively minor thing. Currently, `delete!` for `WeakKeyDict`s returns the underlying dict implementation rather than the `WeakKeyDict` like it's supposed to.

```julia
# Julia 1.3
julia> wkd = WeakKeyDict()
WeakKeyDict{Any,Any} with 0 entries

julia> delete!(wkd, "foo")
Dict{WeakRef,Any} with 0 entries
```