### PR TITLE
fix #34180, check domain of `precision` in BigFloat ctor

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -109,6 +109,7 @@ mutable struct BigFloat <: AbstractFloat
     end
 
     function BigFloat(; precision::Integer=DEFAULT_PRECISION[])
+        precision < 1 && throw(DomainError(precision, "`precision` cannot be less than 1."))
         nb = ccall((:mpfr_custom_get_size,:libmpfr), Csize_t, (Clong,), precision)
         nb = (nb + Core.sizeof(Limb) - 1) ÷ Core.sizeof(Limb) # align to number of Limb allocations required for this
         #d = Vector{Limb}(undef, nb)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -487,6 +487,9 @@ end
     x = BigFloat(12)
     @test precision(x) == old_precision
     @test_throws DomainError setprecision(1)
+    @test_throws DomainError BigFloat(1, precision = 0)
+    @test_throws DomainError BigFloat(big(1.1), precision = 0)
+    @test_throws DomainError BigFloat(2.5, precision = -900)
     # issue 15659
     @test (setprecision(53) do; big(1/3); end) < 1//3
 end


### PR DESCRIPTION
`setprecision` requires >= 2, but 1 seems to work so I allowed that here.

fix #34180