### PR TITLE
Fix codegen for getfield of homogeneous tuples

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -7140,3 +7140,10 @@ end
 struct SplatBadIterate; end
 Base.iterate(s::SplatBadIterate, args...) = ()
 @test_throws BoundsError (SplatBadIterate()...,)
+
+# Issue #34206/34207
+function mre34206(a)
+    b = ntuple(_ -> view(a, :), 1)[1]
+    b.offset1
+end
+@test mre34206([44]) == 0

--- a/test/core.jl
+++ b/test/core.jl
@@ -7143,7 +7143,12 @@ Base.iterate(s::SplatBadIterate, args...) = ()
 
 # Issue #34206/34207
 function mre34206(a)
-    b = ntuple(_ -> view(a, :), 1)[1]
+function mre34206(a, n)
+    va = view(a, :)
+    b = ntuple(_ -> va, n)::Tuple{Vararg{typeof(va)}}
+    return b[1].offset1
+end
+@test mre34206([44], 1) == 0
     b.offset1
 end
 @test mre34206([44]) == 0


### PR DESCRIPTION
This fastpath wasn't checking whether or not the element type
was inline allocated or not.

Fixes #34206
Fixes #34207