### PR TITLE
SparseArrays: specialize zero(...) so result has nnz(...) = 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,10 @@ Standard library changes
 
 #### SparseArrays
 
+* The return value of `zero(x::AbstractSparseArray)` has no stored zeros anymore ([#31835]).
+  Previously, it would have stored zeros wherever `x` had them. This makes the operation
+  constant time instead of `O(<number of stored values>)`.
+
 #### Dates
 
 #### Statistics

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -10,7 +10,7 @@ using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
 using Base.Sort: Forward
 using LinearAlgebra
 
-import Base: +, -, *, \, /, &, |, xor, ==
+import Base: +, -, *, \, /, &, |, xor, ==, zero
 import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu, matprod
@@ -51,6 +51,8 @@ similar(B::Bidiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spze
 similar(D::Diagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
 similar(S::SymTridiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
 similar(M::Tridiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
+
+zero(a::AbstractSparseArray) = spzeros(eltype(a), size(a)...)
 
 const BiTriSym = Union{Bidiagonal,SymTridiagonal,Tridiagonal}
 function *(A::BiTriSym, B::BiTriSym)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -36,6 +36,7 @@ end
 @testset "issparse" begin
     @test issparse(sparse(fill(1,5,5)))
     @test !issparse(fill(1,5,5))
+    @test nnz(zero(sparse(fill(1,5,5)))) == 0
 end
 
 @testset "iszero specialization for SparseMatrixCSC" begin


### PR DESCRIPTION
This pull request fixes #31835.

Before this commit, the result of
```julia
zero(x::AbstractSparseArray)
```
is filled with stored zeros exactly where `x` has a stored value. That is a
wasteful artifact of the default fallback implementation for `AbstractArray`.
After this commit, we return a sparse array of the same dimensions as `x`
without any stored values.

This change is backwards incompatible where it relates to object identity.
Before this commit, for mutable objects, every stored zero has the same
identity. Example:

    julia> using SparseArrays

    julia> y = zero(BigInt[1,2,3]); y[1] === y[2]
    true

    julia> y = zero(sparse(BigInt[1,2,3])); y[1] === y[2]
    true

    julia> Base.zero(a::AbstractSparseArray) = spzeros(eltype(a), size(a)...)

    julia> y = zero(sparse(BigInt[1,2,3])); y[1] === y[2]
    false

But this behaviour should be classified as a performance bug and can therefore
be fixed in a minor (but not a patch) release.