### PR TITLE
runtests: Print currently running tests when asked

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,6 +155,7 @@ cd(@__DIR__) do
     try
         # Monitor stdin and kill this task on ^C
         # but don't do this on Windows, because it may deadlock in the kernel
+        running_tests = Dict{String, DateTime}()
         if !Sys.iswindows() && isa(stdin, Base.TTY)
             t = current_task()
             stdin_monitor = @async begin
@@ -162,9 +163,16 @@ cd(@__DIR__) do
                 try
                     REPL.Terminals.raw!(term, true)
                     while true
-                        if read(term, Char) == '\x3'
+                        c = read(term, Char)
+                        if c == '\x3'
                             Base.throwto(t, InterruptException())
                             break
+                        elseif c == '?'
+                            println("Currently running: ")
+                            tests = sort(collect(running_tests), by=x->x[2])
+                            foreach(tests) do (test, date)
+                                println(test, " (running for ", round(now()-date, Minute), ")")
+                            end
                         end
                     end
                 catch e
@@ -180,6 +188,7 @@ cd(@__DIR__) do
                     push!(all_tasks, current_task())
                     while length(tests) > 0
                         test = popfirst!(tests)
+                        running_tests[test] = now()
                         local resp
                         wrkr = p
                         try
@@ -188,6 +197,7 @@ cd(@__DIR__) do
                             isa(e, InterruptException) && return
                             resp = Any[e]
                         end
+                        delete!(running_tests, test)
                         push!(results, (test, resp))
                         if resp[1] isa Exception
                             print_testworker_errored(test, wrkr)


### PR DESCRIPTION
With this patch, pressing '?' while the test are running will print
which tests are still running. Of course, you could just try to look
through the log to try to figure out which tests have started but not
yet finished, but that's pretty annoying to do. Being able to just ask
is much easier for the impatient developer.