### PR TITLE
Improve printing of BoundsError with colon

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -110,6 +110,11 @@ function show_error_hints(io, ex, args...)
     end
 end
 
+index_string(x::Any) = string(x)
+index_string(x::Slice) = index_string(x.indices)
+index_string(x::OneTo) = "1:" * string(x.stop)
+index_string(x::Colon) = ":"
+
 function showerror(io::IO, ex::BoundsError)
     print(io, "BoundsError")
     if isdefined(ex, :a)
@@ -121,7 +126,7 @@ function showerror(io::IO, ex::BoundsError)
             if isa(ex.i, AbstractRange)
                 print(io, ex.i)
             else
-                join(io, ex.i, ", ")
+                join(io, index_string.(ex.i), ", ")
             end
             print(io, ']')
         end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -110,10 +110,12 @@ function show_error_hints(io, ex, args...)
     end
 end
 
-index_string(x::Any) = string(x)
-index_string(x::Slice) = index_string(x.indices)
-index_string(x::OneTo) = "1:" * string(x.stop)
-index_string(x::Colon) = ":"
+show_index(io::IO, x::Any) = show(io, x)
+show_index(io::IO, x::Slice) = show_index(io, x.indices)
+show_index(io::IO, x::LogicalIndex) = show_index(io, x.mask)
+show_index(io::IO, x::OneTo) = print(io, "1:", x.stop)
+show_index(io::IO, x::Colon) = print(io, ':')
+
 
 function showerror(io::IO, ex::BoundsError)
     print(io, "BoundsError")
@@ -123,10 +125,15 @@ function showerror(io::IO, ex::BoundsError)
         if isdefined(ex, :i)
             !isa(ex.a, AbstractArray) && print(io, "\n ")
             print(io, " at index [")
-            if isa(ex.i, AbstractRange)
+            if ex.i isa AbstractRange
                 print(io, ex.i)
+            elseif ex.i isa AbstractString
+                show(io, ex.i)
             else
-                join(io, index_string.(ex.i), ", ")
+                for (i, x) in enumerate(ex.i)
+                    i > 1 && print(io, ", ")
+                    show_index(io, x)
+                end
             end
             print(io, ']')
         end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2740,3 +2740,19 @@ let n = 12000000, k = 257000000
         v[end] == (n, 0.5)
     end
 end
+
+@testset "BoundsError printing" begin
+    x = rand(2, 2)
+    @test_throws BoundsError x[10, :]
+    err = try x[10, :]; catch err; err; end
+    b = IOBuffer()
+    showerror(b, err)
+    @test String(take!(b)) ==
+        "BoundsError: attempt to access 2×2 Array{Float64,2} at index [10, 1:2]"
+
+    # Also test : directly for custom types for which it may appear as-is
+    err = BoundsError(x, (10, :))
+    showerror(b, err)
+    @test String(take!(b)) ==
+        "BoundsError: attempt to access 2×2 Array{Float64,2} at index [10, :]"
+end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2743,16 +2743,32 @@ end
 
 @testset "BoundsError printing" begin
     x = rand(2, 2)
-    @test_throws BoundsError x[10, :]
+
     err = try x[10, :]; catch err; err; end
     b = IOBuffer()
     showerror(b, err)
     @test String(take!(b)) ==
         "BoundsError: attempt to access 2×2 Array{Float64,2} at index [10, 1:2]"
 
+    err = try x[10, trues(2)]; catch err; err; end
+    b = IOBuffer()
+    showerror(b, err)
+    @test String(take!(b)) ==
+        "BoundsError: attempt to access 2×2 Array{Float64,2} at index [10, Bool[1, 1]]"
+
     # Also test : directly for custom types for which it may appear as-is
     err = BoundsError(x, (10, :))
     showerror(b, err)
     @test String(take!(b)) ==
         "BoundsError: attempt to access 2×2 Array{Float64,2} at index [10, :]"
+
+    err = BoundsError(x, "bad index")
+    showerror(b, err)
+    @test String(take!(b)) ==
+        "BoundsError: attempt to access 2×2 Array{Float64,2} at index [\"bad index\"]"
+
+    err = BoundsError(x, (10, "bad index"))
+    showerror(b, err)
+    @test String(take!(b)) ==
+        "BoundsError: attempt to access 2×2 Array{Float64,2} at index [10, \"bad index\"]"
 end


### PR DESCRIPTION
Avoid exposing implementation details like `Base.Slice(Base.OneTo(n))` and print `:` instead of `Colon()`.

Before:
```julia
julia> rand(2, 2)[1:10, :]
ERROR: BoundsError: attempt to access 2×2 Array{Float64,2} at index [1:10, Base.Slice(Base.OneTo(2))]
```

After:
```julia
julia> rand(2, 2)[1:10, :]
ERROR: BoundsError: attempt to access 2×2 Array{Float64,2} at index [1:10, 1:2]
```

A more "radical" approach would be to implement `print` for `Slice`, `OneTo` and `Colon` so that it avoids details, and call it from `showerror`. What do you think?