### PR TITLE
Profile: add line number correction (Revise)

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -196,9 +196,16 @@ function retrieve()
 end
 
 function getdict(data::Vector{UInt})
+    # Lookup is expensive, so do it only once per ip.
+    udata = unique(data)
     dict = LineInfoDict()
-    for ip in data
-        get!(() -> lookup(convert(Ptr{Cvoid}, ip)), dict, UInt64(ip))
+    for ip in udata
+        st = lookup(convert(Ptr{Cvoid}, ip))
+        # To correct line numbers for moving code, put it in the form expected by
+        # Base.update_stackframes_callback[]
+        stn = map(x->(x, 1), st)
+        try Base.invokelatest(Base.update_stackframes_callback[], stn) catch end
+        dict[UInt64(ip)] = map(first, stn)
     end
     return dict
 end


### PR DESCRIPTION
This ensures that Profiling will report the current line number in interactively-modified code.

It looks like #28328 failed to include a test, so I also added that here.