### PR TITLE
outline length assert in default_rng(tid)

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -295,7 +295,7 @@ seed!(seed::Union{Integer,Vector{UInt32}}) = seed!(default_rng(), seed)
 const THREAD_RNGs = MersenneTwister[]
 @inline default_rng() = default_rng(Threads.threadid())
 @noinline function default_rng(tid::Int)
-    @assert 0 < tid <= length(THREAD_RNGs)
+    0 < tid <= length(THREAD_RNGs) || _rng_length_assert()
     if @inbounds isassigned(THREAD_RNGs, tid)
         @inbounds MT = THREAD_RNGs[tid]
     else
@@ -304,6 +304,8 @@ const THREAD_RNGs = MersenneTwister[]
     end
     return MT
 end
+@noinline _rng_length_assert() =  @assert false "0 < tid <= length(THREAD_RNGs)"
+
 function __init__()
     resize!(empty!(THREAD_RNGs), Threads.nthreads()) # ensures that we didn't save a bad object
 end


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/issues/34216

Benchmark

```jl
# export JULIA_NUM_THREADS=4
using BenchmarkTools, Random, Base.Threads

function par_pi(n::Int)
    hits = zeros(Int, nthreads())
    @threads for i in 1:n
        x, y = rand(), rand()
        hits[threadid()] += (x^2 + y^2 <= 1)
    end

    4.0 * sum(hits) / n
end
@btime par_pi(10_000_000)
```

master:

```
168.895 ms (24 allocations: 2.83 KiB)
```

PR:

```
 83.366 ms (24 allocations: 2.83 KiB)
```