### PR TITLE
#34234 normalize(a) for multidimensional arrays 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,7 @@ Standard library changes
 
 #### LinearAlgebra
 * The BLAS submodule now supports the level-2 BLAS subroutine `hpmv!` ([#34211]).
-* `normalize` now supports multidimensional arrays ([#34234])
+* `normalize` now supports multidimensional arrays ([#34239])
 
 #### Markdown
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@ Standard library changes
 
 
 #### LinearAlgebra
-
+* `normalize` now supports multidimensional arrays ([#34234])
 
 #### Markdown
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1639,7 +1639,7 @@ julia> c = normalize(a, 1)
 julia> norm(c, 1)
 1.0
 
-julia> a = [[1 2 4] ; [1 2 4]]
+julia> a = [1 2 4 ; 1 2 4]
 2×3 Array{Int64,2}:
  1  2  4
  1  2  4

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1582,18 +1582,18 @@ function isapprox(x::AbstractArray, y::AbstractArray;
 end
 
 """
-    normalize!(v::AbstractVector, p::Real=2)
+    normalize!(a::AbstractArray, p::Real=2)
 
-Normalize the vector `v` in-place so that its `p`-norm equals unity,
-i.e. `norm(v, p) == 1`.
+Normalize the array `a` in-place so that its `p`-norm equals unity,
+i.e. `norm(a, p) == 1`.
 See also [`normalize`](@ref) and [`norm`](@ref).
 """
-function normalize!(v::AbstractVector, p::Real=2)
-    nrm = norm(v, p)
-    __normalize!(v, nrm)
+function normalize!(a::AbstractArray, p::Real=2)
+    nrm = norm(a, p)
+    __normalize!(a, nrm)
 end
 
-@inline function __normalize!(v::AbstractVector, nrm::AbstractFloat)
+@inline function __normalize!(v::AbstractArray, nrm::AbstractFloat)
     # The largest positive floating point number whose inverse is less than infinity
     δ = inv(prevfloat(typemax(nrm)))
 
@@ -1611,10 +1611,10 @@ end
 end
 
 """
-    normalize(v::AbstractVector, p::Real=2)
+    normalize(a::AbstractArray, p::Real=2)
 
-Normalize the vector `v` so that its `p`-norm equals unity,
-i.e. `norm(v, p) == 1`.
+Normalize the array `a` so that its `p`-norm equals unity,
+i.e. `norm(a, p) == 1`.
 See also [`normalize!`](@ref) and [`norm`](@ref).
 
 # Examples
@@ -1638,15 +1638,29 @@ julia> c = normalize(a, 1)
 
 julia> norm(c, 1)
 1.0
+
+julia> a = [[1 2 4] ; [1 2 4]]
+2×3 Array{Int64,2}:
+ 1  2  4
+ 1  2  4
+
+julia> norm(a)
+6.48074069840786
+
+julia> normalize(a)
+2×3 Array{Float64,2}:
+ 0.154303  0.308607  0.617213
+ 0.154303  0.308607  0.617213
+
 ```
 """
-function normalize(v::AbstractVector, p::Real = 2)
-    nrm = norm(v, p)
-    if !isempty(v)
-        vv = copy_oftype(v, typeof(v[1]/nrm))
-        return __normalize!(vv, nrm)
+function normalize(a::AbstractArray, p::Real = 2)
+    nrm = norm(a, p)
+    if !isempty(a)
+        aa = copy_oftype(a, typeof(first(a)/nrm))
+        return __normalize!(aa, nrm)
     else
-        T = typeof(zero(eltype(v))/nrm)
+        T = typeof(zero(eltype(a))/nrm)
         return T[]
     end
 end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1593,21 +1593,21 @@ function normalize!(a::AbstractArray, p::Real=2)
     __normalize!(a, nrm)
 end
 
-@inline function __normalize!(v::AbstractArray, nrm::AbstractFloat)
+@inline function __normalize!(a::AbstractArray, nrm::AbstractFloat)
     # The largest positive floating point number whose inverse is less than infinity
     δ = inv(prevfloat(typemax(nrm)))
 
     if nrm ≥ δ # Safe to multiply with inverse
         invnrm = inv(nrm)
-        rmul!(v, invnrm)
+        rmul!(a, invnrm)
 
     else # scale elements to avoid overflow
         εδ = eps(one(nrm))/δ
-        rmul!(v, εδ)
-        rmul!(v, inv(nrm*εδ))
+        rmul!(a, εδ)
+        rmul!(a, inv(nrm*εδ))
     end
 
-    v
+    a
 end
 
 """

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -254,28 +254,13 @@ end
 end
 
 @testset "normalize for multidimensional arrays" begin
-    function test_arr(arr)
+
+    for arr in ([1.0 2.0 3.0; 4.0 5.0 6.0], OffsetArray([-1,0], (-2,)))
         @test normalize(arr) == normalize!(copy(arr))
         @test size(normalize(arr)) == size(arr)
+        @test axes(normalize(arr)) == axes(arr)
         @test vec(normalize(arr)) == normalize(vec(arr))
     end
-
-    arr = [ 1.0 0.0; 0.0 1.0 ]
-    test_arr(arr)
-
-    arr = [
-            [1.0 0.0 0.0];
-            [0.0 1.0 0.0]
-         ]
-    test_arr(arr)
-
-    arr = randn(2,3)
-    test_arr(arr)
-
-    A = OffsetArray([-1,0], (-2,))
-    Arsc = reshape(A, :, 1)
-    Arsc[1,1] = 5
-    test_arr(A)
 end
 
 @testset "Issue #30466" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -248,6 +248,18 @@ end
     end
 end
 
+@testset "normalize for multidimensional arrays" begin
+    arr = [ [1.0 0.0]; [0.0 1.0] ]
+    @test normalize(arr) == normalize!(copy(arr))
+    
+    arr = [
+            [1.0 0.0 0.0]; 
+            [0.0 1.0 0.0]
+         ]
+    @test normalize(arr) == normalize!(copy(arr))
+    
+end
+
 @testset "Issue #30466" begin
     @test norm([typemin(Int), typemin(Int)], Inf) == -float(typemin(Int))
     @test norm([typemin(Int), typemin(Int)], 1) == -2float(typemin(Int))

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -5,8 +5,13 @@ module TestGeneric
 using Test, LinearAlgebra, Random
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+
 isdefined(Main, :Quaternions) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Quaternions.jl"))
 using .Main.Quaternions
+
+isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
+using .Main.OffsetArrays
+
 
 Random.seed!(123)
 
@@ -249,15 +254,28 @@ end
 end
 
 @testset "normalize for multidimensional arrays" begin
-    arr = [ [1.0 0.0]; [0.0 1.0] ]
-    @test normalize(arr) == normalize!(copy(arr))
+    function test_arr(arr)
+        @test normalize(arr) == normalize!(copy(arr))
+        @test size(normalize(arr)) == size(arr)
+        @test vec(normalize(arr)) == normalize(vec(arr))
+    end
+
+    arr = [ 1.0 0.0; 0.0 1.0 ]
+    test_arr(arr)
 
     arr = [
             [1.0 0.0 0.0];
             [0.0 1.0 0.0]
          ]
-    @test normalize(arr) == normalize!(copy(arr))
+    test_arr(arr)
 
+    arr = randn(2,3)
+    test_arr(arr)
+
+    A = OffsetArray([-1,0], (-2,))
+    Arsc = reshape(A, :, 1)
+    Arsc[1,1] = 5
+    test_arr(A)
 end
 
 @testset "Issue #30466" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -255,7 +255,14 @@ end
 
 @testset "normalize for multidimensional arrays" begin
 
-    for arr in ([1.0 2.0 3.0; 4.0 5.0 6.0], OffsetArray([-1,0], (-2,)))
+    for arr in (
+        fill(10.0, ()),  # 0 dim
+        [1.0],           # 1 dim
+        [1.0 2.0 3.0; 4.0 5.0 6.0], # 2-dim
+        rand(1,2,3),                # higher dims
+        rand(1,2,3,4),
+        OffsetArray([-1,0], (-2,))  # no index 1
+    )
         @test normalize(arr) == normalize!(copy(arr))
         @test size(normalize(arr)) == size(arr)
         @test axes(normalize(arr)) == axes(arr)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -261,6 +261,8 @@ end
         @test axes(normalize(arr)) == axes(arr)
         @test vec(normalize(arr)) == normalize(vec(arr))
     end
+
+    @test typeof(normalize([1 2 3; 4 5 6])) == Array{Float64,2}
 end
 
 @testset "Issue #30466" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -251,13 +251,13 @@ end
 @testset "normalize for multidimensional arrays" begin
     arr = [ [1.0 0.0]; [0.0 1.0] ]
     @test normalize(arr) == normalize!(copy(arr))
-    
+
     arr = [
-            [1.0 0.0 0.0]; 
+            [1.0 0.0 0.0];
             [0.0 1.0 0.0]
          ]
     @test normalize(arr) == normalize!(copy(arr))
-    
+
 end
 
 @testset "Issue #30466" begin


### PR DESCRIPTION
PR to try and resolve issue JuliaLang/LinearAlgebra.jl#688

- [X]  Change the type signatures and documentation from AbstractVector to AbstractArray
- [x] Change this line from v[1] to first(v). (This is a bug anyway, since v[1] is wrong for non 1-based arrays.)
- [X] Change the documentation to refer to "array" rather than "vector" and use a rather than v. (changed docstrings)
- [X] Add a few tests. (not sure if i need more?)
- [X] Add a NEWS item.

Testing: 
added unit test to ` stdlib/LinearAlgebra/test/generic.jl`
ran ` ./julia stdlib/LinearAlgebra/test/generic.jl` with no errors.

```
...
Test Summary:                         | Pass  Total
normalize for multidimensional arrays |    2      2
...
```

Testing in the shell:

```
julia> using LinearAlgebra;

julia> arr = [ [1.0 0.0]; [0.0 1.0] ]
2×2 Array{Float64,2}:
 1.0  0.0
 0.0  1.0

julia> @show arr
arr = [1.0 0.0; 0.0 1.0]
2×2 Array{Float64,2}:
 1.0  0.0
 0.0  1.0

julia> @show normalize(arr)
normalize(arr) = [0.7071067811865475 0.0; 0.0 0.7071067811865475]
2×2 Array{Float64,2}:
 0.707107  0.0
 0.0       0.707107

julia> @show normalize!(copy(arr))
normalize!(copy(arr)) = [0.7071067811865475 0.0; 0.0 0.7071067811865475]
2×2 Array{Float64,2}:
 0.707107  0.0
 0.0       0.707107

julia> @show normalize(arr) == normalize!(copy(arr))
normalize(arr) == normalize!(copy(arr)) = true
true

julia> arr = [[1.0 0.0 0.0]; [0.0 1.0 0.0]]
2×3 Array{Float64,2}:
 1.0  0.0  0.0
 0.0  1.0  0.0

julia> @show normalize(arr) == normalize!(copy(arr))
normalize(arr) == normalize!(copy(arr)) = true
true

julia> a = [1,0,0]
3-element Array{Int64,1}:
 1
 0
 0

julia> @show normalize(a) == normalize!(copy(a))
normalize(a) == normalize!(copy(a)) = true
true
```

   