### PR TITLE
fix codegen for getfield of homogeneous tuples

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2903,8 +2903,11 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                                 emit_datatype_nfields(ctx, emit_typeof_boxed(ctx, obj)),
                                 jl_true);
                         }
+                        bool isboxed = !jl_datatype_isinlinealloc(jt);
                         Value *ptr = maybe_decay_tracked(data_pointer(ctx, obj));
-                        *ret = typed_load(ctx, ptr, vidx, jt, obj.tbaa, nullptr, false);
+                        *ret = typed_load(ctx, ptr, vidx,
+                                isboxed ? (jl_value_t*)jl_any_type : jt,
+                                obj.tbaa, nullptr, false);
                         return true;
                     }
                 }

--- a/test/core.jl
+++ b/test/core.jl
@@ -7156,3 +7156,11 @@ struct B33954
 end
 @test_broken isbitstype(Tuple{B33954})
 @test_broken isbitstype(B33954)
+
+# Issue #34206/34207
+function mre34206(a, n)
+    va = view(a, :)
+    b = ntuple(_ -> va, n)::Tuple{Vararg{typeof(va)}}
+    return b[1].offset1
+end
+@test mre34206([44], 1) == 0


### PR DESCRIPTION
This is an alternative to #34208. Uses the same method as the `typed_load` call for `arrayref`.

fix #34206, fix #34207
