### PR TITLE
codegen: on alignment incongruence, replace assert by jl_error

### DIFF
--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -119,3 +119,11 @@ for T in (Float64, Float32, Int64, Int32)
         @test b == result
     end
 end
+
+# Eventually, this should not raise an error at all; we're just testing that at least it doesn't abort.
+# see #34245 for details.
+let
+    foo() = ntuple(i -> Core.VecElement{Float64}(i), Val(8));
+    bar(a) = (a, foo())
+    @test_throws ErrorException bar(42.0)
+end


### PR DESCRIPTION
It is possible that LLVM and Julia disagree on the offsets of struct
fields. This has been observed in #32414 in cases like

    Tuple{Float64, NTuple{8, VecElement{Float64}}}

where LLVM wants to align the `vec` on 64 bytes (adding 56 bytes
of padding after the first `Float64`) but Julia refusing to
align like that because it can't guarantee that on the heap:

https://github.com/JuliaLang/julia/blob/c7e9d9f8ade647582c6635c8c9a587f2360af404/src/datatype.c#L453

There is no easy solution this I can see, but since this can be
triggered from pure Julia, the least we can do is not abort the program.

For this reason, this commit replaces the assert by jl_error.
To be able to give a sort-of meaningful error message, we return
a sentinel value from `convert_struct_offset` and generate
an error message in the caller.