### PR TITLE
handle lack of uv_os_get_passwd

### DIFF
--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -136,18 +136,21 @@ std::string jl_format_filename(StringRef output_pattern)
     for (auto c : output_pattern) {
         if (special) {
             if (!got_pwd && (c == 'i' || c == 'd' || c == 'u')) {
-                uv_os_get_passwd(&pwd);
-                got_pwd = true;
+                int r = uv_os_get_passwd(&pwd);
+                if (r == 0)
+                    got_pwd = true;
             }
             switch (c) {
             case 'p':
                 outfile << jl_getpid();
                 break;
             case 'd':
-                outfile << pwd.homedir;
+                if (got_pwd)
+                    outfile << pwd.homedir;
                 break;
             case 'i':
-                outfile << pwd.uid;
+                if (got_pwd)
+                    outfile << pwd.uid;
                 break;
             case 'l':
             case 'L':
@@ -163,7 +166,8 @@ std::string jl_format_filename(StringRef output_pattern)
 #endif
                 break;
             case 'u':
-                outfile << pwd.username;
+                if (got_pwd)
+                    outfile << pwd.username;
                 break;
             default:
                 outfile << c;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -34,7 +34,13 @@ end
 let
     fn = format_filename("a%d %p %i %L %l %u z")
     hd = withenv("HOME" => nothing) do
-        homedir()
+        # get the homedir, as reported by uv_os_get_passwd, as used by jl_format_filename
+        try
+            homedir()
+        catch ex
+            (ex isa Base.IOError && ex.code == Base.UV_ENOENT) || rethrow(ex)
+            ""
+        end
     end
     @test startswith(fn, "a$hd ")
     @test endswith(fn, " z")
@@ -48,13 +54,17 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
     # tests for handling of ENV errors
     let v = writereadpipeline("println(\"REPL: \", @which(less), @isdefined(InteractiveUtils))",
                 setenv(`$exename -i -E 'empty!(LOAD_PATH); @isdefined InteractiveUtils'`,
-                    "JULIA_LOAD_PATH"=>"", "JULIA_DEPOT_PATH"=>""))
+                    "JULIA_LOAD_PATH" => "",
+                    "JULIA_DEPOT_PATH" => "",
+                    "HOME" => homedir()))
         @test v[1] == "false\nREPL: InteractiveUtilstrue\n"
         @test v[2]
     end
     let v = writereadpipeline("println(\"REPL: \", InteractiveUtils)",
                 setenv(`$exename -i -e 'const InteractiveUtils = 3'`,
-                    "JULIA_LOAD_PATH"=>";;;:::", "JULIA_DEPOT_PATH"=>";;;:::"))
+                    "JULIA_LOAD_PATH" => ";;;:::",
+                    "JULIA_DEPOT_PATH" => ";;;:::",
+                    "HOME" => homedir()))
         # TODO: ideally, `@which`, etc. would still work, but Julia can't handle `using $InterativeUtils`
         @test v[1] == "REPL: 3\n"
         @test v[2]
@@ -71,13 +81,13 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
     end
     real_threads = string(ccall(:jl_cpu_threads, Int32, ()))
     for nc in ("0", "-2", "x", "2x", " ", "")
-        v = readchomperrors(setenv(`$exename -i -E 'Sys.CPU_THREADS'`, "JULIA_CPU_THREADS" => nc))
+        v = readchomperrors(setenv(`$exename -i -E 'Sys.CPU_THREADS'`, "JULIA_CPU_THREADS" => nc, "HOME" => homedir()))
         @test v[1]
         @test v[2] == real_threads
         @test v[3] == "WARNING: couldn't parse `JULIA_CPU_THREADS` environment variable. Defaulting Sys.CPU_THREADS to $real_threads."
     end
     for nc in ("1", " 1 ", " +1 ", " 0x1 ")
-        v = readchomperrors(setenv(`$exename -i -E 'Sys.CPU_THREADS'`, "JULIA_CPU_THREADS" => nc))
+        v = readchomperrors(setenv(`$exename -i -E 'Sys.CPU_THREADS'`, "JULIA_CPU_THREADS" => nc, "HOME" => homedir()))
         @test v[1]
         @test v[2] == "1"
         @test isempty(v[3])
@@ -101,7 +111,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
     if !Sys.iswindows()
         expanded = abspath(expanduser("~/foo"))
         @test occursin(expanded, readchomp(`$exename --project='~/foo' -E 'Base.active_project()'`))
-        @test occursin(expanded, readchomp(setenv(`$exename -E 'Base.active_project()'`, "JULIA_PROJECT"=>"~/foo")))
+        @test occursin(expanded, readchomp(setenv(`$exename -E 'Base.active_project()'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir())))
     end
 
     # --quiet, --banner


### PR DESCRIPTION
Ran into this problem on an unusual machine configuration (sssd PAM running x86 binaries on an amd64 OS) where Julia was failing to run the cmdlinearg tests (which I needed to run to check my PR). Turned out that getpwuid_r was unavailable for the current user. Working around that by checking return value and ensuring HOME is set in these tests. Note, Julia may still fail other tests (notably, the `path` test for the homedir functionality), and is broken at startup with the following error:
```
$ env -u HOME ./usr/bin/julia
fatal: error thrown and no exception handler available.
#<null>
uv_error at ./libuv.jl:97 [inlined]
uv_error at ./libuv.jl:96 [inlined]
homedir at ./path.jl:75
append_default_depot_path! at ./initdefs.jl:78
init_depot_path at ./initdefs.jl:100
__init__ at ./Base.jl:411
jfptr___init___13626 at /data/vtjnash/julia/build-x86/usr/lib/julia/sys.so (unknown line)
_jl_invoke at /data/vtjnash/julia/src/gf.c:2144 [inlined]
jl_apply_generic at /data/vtjnash/julia/src/gf.c:2328
jl_apply at /data/vtjnash/julia/src/julia.h:1692 [inlined]
jl_module_run_initializer at /data/vtjnash/julia/src/toplevel.c:74
_julia_init at /data/vtjnash/julia/src/init.c:800
julia_init__threading at /data/vtjnash/julia/src/task.c:248
main at /data/vtjnash/julia/ui/repl.c:211
__libc_start_main at /lib/i386-linux-gnu/libc.so.6 (unknown line)
_start at ./usr/bin/julia (unknown line)
```