### PR TITLE
fix some cases of diagonal subtyping when a var also appears invariantly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@ New language features
 Language changes
 ----------------
 
+* Converting arbitrary tuples to `NTuple`, e.g. `convert(NTuple, (1, ""))` now gives an error,
+  where it used to be incorrectly allowed. This is because `NTuple` refers only to homogeneous
+  tuples (this meaning has not changed) ([#34272]).
 
 Multi-threading changes
 -----------------------

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -333,9 +333,7 @@ convert(T::Type{Tuple{Vararg{V}}}, x::Tuple) where {V} =
 #convert(_::Type{Tuple{Vararg{S, N}}},
 #        x::Tuple{Vararg{Any, N}}) where
 #       {S, N} = cnvt_all(S, x...)
-# TODO: These currently can't be used since
-#   Type{NTuple} <: (Type{Tuple{Vararg{S}}} where S) is true
-#   even though the value S doesn't exist
+# TODO: These are similar to the methods we currently use but cnvt_all might work better:
 #convert(_::Type{Tuple{Vararg{S}}},
 #        x::Tuple{Any, Vararg{Any}}) where
 #       {S} = cnvt_all(S, x...)

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -403,16 +403,37 @@ f(nothing, 2.0)
 These examples are telling us something: when `x` is `nothing::Nothing`, there are no
 extra constraints on `y`.
 It is as if the method signature had `y::Any`.
-This means that whether a variable is diagonal is not a static property based on
-where it appears in a type.
-Rather, it depends on where a variable appears when the subtyping algorithm *uses* it.
-When `x` has type `Nothing`, we don't need to use the `T` in `Union{Nothing,T}`, so `T`
-does not "occur".
 Indeed, we have the following type equivalence:
 
 ```julia
 (Tuple{Union{Nothing,T},T} where T) == Union{Tuple{Nothing,Any}, Tuple{T,T} where T}
 ```
+
+The general rule is: a concrete variable in covariant position acts like it's
+not concrete if the subtyping algorithm only *uses* it once.
+When `x` has type `Nothing`, we don't need to use the `T` in `Union{Nothing,T}`;
+we only use it in the second slot.
+This arises naturally from the observation that in `Tuple{T} where T` restricting
+`T` to concrete types makes no difference; the type is equal to `Tuple{Any}` either way.
+
+However, appearing in *invariant* position disqualifies a variable from being concrete
+whether that appearance of the variable is used or not.
+Otherwise types can behave differently depending on which other types
+they are compared to, making subtyping not transitive. For example, consider
+
+Tuple{Int,Int8,Vector{Integer}} <: Tuple{T,T,Vector{Union{Integer,T}}} where T
+
+If the `T` inside the Union is ignored, then `T` is concrete and the answer is "false"
+since the first two types aren't the same.
+But consider instead
+
+Tuple{Int,Int8,Vector{Any}} <: Tuple{T,T,Vector{Union{Integer,T}}} where T
+
+Now we cannot ignore the `T` in the Union (we must have T == Any), so `T` is not
+concrete and the answer is "true".
+That would make the concreteness of `T` depend on the other type, which is not
+acceptable since a type must have a clear meaning on its own.
+Therefore the appearance of `T` inside `Vector` is considered in both cases.
 
 ## Subtyping diagonal variables
 

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -136,6 +136,35 @@ function test_diagonal()
     @test  issub(Tuple{Tuple{T, T}} where T>:Int, Tuple{Tuple{T, T} where T>:Int})
     @test  issub(Vector{Tuple{T, T} where Number<:T<:Number},
                  Vector{Tuple{Number, Number}})
+
+    @test !issub(Type{Tuple{T,Any} where T},   Type{Tuple{T,T}} where T)
+    @test !issub(Type{Tuple{T,Any,T} where T}, Type{Tuple{T,T,T}} where T)
+    @test_broken issub(Type{Tuple{T} where T},       Type{Tuple{T}} where T)
+    @test_broken issub(Ref{Tuple{T} where T},        Ref{Tuple{T}} where T)
+    @test !issub(Type{Tuple{T,T} where T},     Type{Tuple{T,T}} where T)
+    @test !issub(Type{Tuple{T,T,T} where T},   Type{Tuple{T,T,T}} where T)
+    @test  isequal_type(Ref{Tuple{T, T} where Int<:T<:Int},
+                        Ref{Tuple{S, S}} where Int<:S<:Int)
+
+    let A = Tuple{Int,Int8,Vector{Integer}},
+        B = Tuple{T,T,Vector{T}} where T>:Integer,
+        C = Tuple{T,T,Vector{Union{Integer,T}}} where T
+        @test A <: B
+        @test B == C
+        @test A <: C
+        @test Tuple{Int,Int8,Vector{Any}} <: C
+    end
+
+    # #26108
+    @test !issub((Tuple{T, T, Array{T, 1}} where T), Tuple{T, T, Any} where T)
+
+    # #26716
+    @test !issub((Union{Tuple{Int,Bool}, Tuple{P,Bool}} where P), Tuple{Union{T,Int}, T} where T)
+
+    @test issub_strict(Tuple{Ref{Tuple{N,N}}, Ref{N}} where N,
+                       Tuple{Ref{Tuple{N1,N1}}, Ref{N2}} where {N1, N2})
+    @test !issub(Tuple{Type{Tuple{Vararg{T}} where T <: Integer}, Tuple{Float64, Int}},
+                 Tuple{Type{Tuple{Vararg{T}}}, Tuple{Vararg{T}}} where T)
 end
 
 # level 3: UnionAll
@@ -881,7 +910,9 @@ function test_intersection()
     # since TypeofBottom is a singleton we can deduce its intersection with Type{...}
     @testintersect(Core.TypeofBottom, (Type{T} where T<:Tuple), Type{Union{}})
 
-    @testintersect((Type{Tuple{Vararg{T}}} where T), Type{Tuple}, Bottom)
+    # since this T is inside the invariant ctor Type{}, we allow T == Any here
+    @testintersect((Type{Tuple{Vararg{T}}} where T), Type{Tuple}, Type{Tuple})
+
     @testintersect(Tuple{Type{S}, Tuple{Any, Vararg{Any}}} where S<:Tuple{Any, Vararg{Any}},
                    Tuple{Type{T}, T} where T,
                    Tuple{Type{S},S} where S<:Tuple{Any,Vararg{Any,N} where N})
@@ -1005,6 +1036,13 @@ function test_intersection()
     @testintersect(Type{<:Array},
                    Type{AbstractArray{T}} where T,
                    Bottom)
+
+    @testintersect(Tuple{Type{Tuple{Vararg{Integer}}}, Tuple},
+                   Tuple{Type{Tuple{Vararg{V}}}, Tuple{Vararg{V}}} where {V},
+                   Tuple{Type{Tuple{Vararg{Integer,N} where N}},Tuple{Vararg{Integer,N} where N}})
+    @testintersect(Tuple{Type{Tuple{Vararg{Union{Int,Symbol}}}}, Tuple},
+                   Tuple{Type{Tuple{Vararg{V}}}, Tuple{Vararg{V}}} where {V},
+                   Tuple{Type{Tuple{Vararg{Union{Int,Symbol},N} where N}},Tuple{Vararg{Union{Int,Symbol},N} where N}})
 end
 
 function test_intersection_properties()
@@ -1475,12 +1513,19 @@ let U = Tuple{Union{LT, LT1},Union{R, R1},Int} where LT1<:R1 where R1<:Tuple{Int
 end
 
 # issue #31082 and #30741
-@testintersect(Tuple{T, Ref{T}, T} where T,
-               Tuple{Ref{S}, S, S} where S,
-               Union{})
+@test typeintersect(Tuple{T, Ref{T}, T} where T,
+                    Tuple{Ref{S}, S, S} where S) != Union{}
 @testintersect(Tuple{Pair{B,C},Union{C,Pair{B,C}},Union{B,Real}} where {B,C},
                Tuple{Pair{B,C},C,C} where {B,C},
                Tuple{Pair{B,C},C,C} where C<:Union{Real, B} where B)
+f31082(::Pair{B, C}, ::Union{C, Pair{B, C}}, ::Union{B, Real}) where {B, C} = 0
+f31082(::Pair{B, C}, ::C, ::C) where {B, C} = 1
+@test f31082(""=>1, 2, 3) == 1
+@test f31082(""=>1, 2, "") == 0
+@test f31082(""=>1, 2, 3.0) == 0
+@test f31082(Pair{Any,Any}(1,2), 1, 2) == 1
+@test f31082(Pair{Any,Any}(1,2), Pair{Any,Any}(1,2), 2) == 1
+@test f31082(Pair{Any,Any}(1,2), 1=>2, 2.0) == 1
 
 # issue #31115
 @testintersect(Tuple{Ref{Z} where Z<:(Ref{Y} where Y<:Tuple{<:B}), Int} where B,


### PR DESCRIPTION
This is a part of #31833 that seems to be pretty non-breaking.

fix #26108, fix #26716