### PR TITLE
fix #34286, regression in `methods` with empty tuple of types

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -868,14 +868,14 @@ end
 Return the method table for `f`.
 
 If `types` is specified, return an array of methods whose types match.
-If `module` is specified, return an array of methods defined in this module.
-A list of modules can also be specified as an array or tuple.
+If `module` is specified, return an array of methods defined in that module.
+A list of modules can also be specified as an array.
 
 !!! compat "Julia 1.4"
     At least Julia 1.4 is required for specifying a module.
 """
 function methods(@nospecialize(f), @nospecialize(t),
-                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}},Nothing}=nothing))
+                 @nospecialize(mod::Union{Module,AbstractArray{Module},Nothing}=nothing))
     if mod isa Module
         mod = (mod,)
     end
@@ -900,7 +900,7 @@ function methods_including_ambiguous(@nospecialize(f), @nospecialize(t))
 end
 
 function methods(@nospecialize(f),
-                 @nospecialize(mod::Union{Module,AbstractArray{Module},Tuple{Vararg{Module}},Nothing}=nothing))
+                 @nospecialize(mod::Union{Module,AbstractArray{Module},Nothing}=nothing))
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -897,6 +897,7 @@ end
 module TestMod33403
 f(x) = 1
 f(x::Int) = 2
+g() = 3
 
 module Sub
 import ..TestMod33403: f
@@ -905,18 +906,19 @@ end
 end
 
 @testset "methods with module" begin
-    using .TestMod33403: f
+    using .TestMod33403: f, g
     @test length(methods(f)) == 3
     @test length(methods(f, (Int,))) == 1
 
     @test length(methods(f, TestMod33403)) == 2
-    @test length(methods(f, (TestMod33403,))) == 2
     @test length(methods(f, [TestMod33403])) == 2
     @test length(methods(f, (Int,), TestMod33403)) == 1
-    @test length(methods(f, (Int,), (TestMod33403,))) == 1
+    @test length(methods(f, (Int,), [TestMod33403])) == 1
 
     @test length(methods(f, TestMod33403.Sub)) == 1
-    @test length(methods(f, (TestMod33403.Sub,))) == 1
+    @test length(methods(f, [TestMod33403.Sub])) == 1
     @test length(methods(f, (Char,), TestMod33403.Sub)) == 1
     @test length(methods(f, (Int,), TestMod33403.Sub)) == 0
+
+    @test length(methods(g, ())) == 1
 end


### PR DESCRIPTION
The new feature accepting a tuple of modules intercepted this case by accident. This seems like the simplest way to fix it unless there is some compelling reason to accept a tuple of modules. If so, we could possibly change this to a keyword argument.