### PR TITLE
use ssh multiplexing to create SSH workers with tunneling

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1700,13 +1700,12 @@ requirements for the inbuilt `LocalManager` and `SSHManager`:
     via `sshflags`, for example ```sshflags=`-i <keyfile>` ```.
 
     Internally, SSH multiplexing is used to create a tunnel between the master and workers. If you have
-    been configured SSH multiplexing on your own and the connection has already been established,
-    forwarding is set by using the existing connection (`-O forward` option in ssh). This is beneficial
-    if your servers require password authentication; you can avoid authentication in Julia by logging
-    in to the server ahead of `addprocs`. Even if you do not explicitly configure SSH multiplexing,
-    Julia will use multiplexing to reduce the number of authentication. The control socket will be
-    located at `~/.ssh/julia-%r@%h:%p` during the session unless the existing multiplexing connection
-    is used.
+    configured SSH multiplexing on your own and the connection has already been established, forwarding
+    is set by using the existing connection (`-O forward` option in ssh). This is beneficial if your
+    servers require password authentication; you can avoid authentication in Julia by logging in to the
+    server ahead of `addprocs`. Even if you do not explicitly configure SSH multiplexing, Julia will
+    use multiplexing to reduce the number of authentication. The control socket will be located at
+    `~/.ssh/julia-%r@%h:%p` during the session unless the existing multiplexing connection is used.
 
     In an all-to-all topology (the default), all workers connect to each other via plain TCP sockets.
     The security policy on the cluster nodes must thus ensure free connectivity between workers for

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1699,6 +1699,15 @@ requirements for the inbuilt `LocalManager` and `SSHManager`:
     authenticated via public key infrastructure (PKI). Authentication credentials can be supplied
     via `sshflags`, for example ```sshflags=`-i <keyfile>` ```.
 
+    Internally, SSH multiplexing is used to create a tunnel between the master and workers. If you have
+    been configured SSH multiplexing on your own and the connection has already been established,
+    forwarding is set by using the existing connection (`-O forward` option in ssh). This is beneficial
+    if your servers require password authentication; you can avoid authentication in Julia by logging
+    in to the server ahead of `addprocs`. Even if you do not explicitly configure SSH multiplexing,
+    Julia will use multiplexing to reduce the number of authentication. The control socket will be
+    located at `~/.ssh/julia-%r@%h:%p` during the session unless the existing multiplexing connection
+    is used.
+
     In an all-to-all topology (the default), all workers connect to each other via plain TCP sockets.
     The security policy on the cluster nodes must thus ensure free connectivity between workers for
     the ephemeral port range (varies by OS).

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1699,20 +1699,22 @@ requirements for the inbuilt `LocalManager` and `SSHManager`:
     authenticated via public key infrastructure (PKI). Authentication credentials can be supplied
     via `sshflags`, for example ```sshflags=`-i <keyfile>` ```.
 
-    Internally, SSH multiplexing is used to create a tunnel between the master and workers. If you have
-    configured SSH multiplexing on your own and the connection has already been established, forwarding
-    is set by using the existing connection (`-O forward` option in ssh). This is beneficial if your
-    servers require password authentication; you can avoid authentication in Julia by logging in to the
-    server ahead of `addprocs`. Even if you do not explicitly configure SSH multiplexing, Julia will
-    use multiplexing to reduce the number of authentication. The control socket will be located at
-    `~/.ssh/julia-%r@%h:%p` during the session unless the existing multiplexing connection is used.
-
     In an all-to-all topology (the default), all workers connect to each other via plain TCP sockets.
     The security policy on the cluster nodes must thus ensure free connectivity between workers for
     the ephemeral port range (varies by OS).
 
     Securing and encrypting all worker-worker traffic (via SSH) or encrypting individual messages
     can be done via a custom `ClusterManager`.
+
+  * If you specify `multiplex=true` as an option to `addprocs`, SSH multiplexing is used to create
+    a tunnel between the master and workers. If you have configured SSH multiplexing on your own and
+    the connection has already been established, SSH multiplexing is used regardless of `multiplex`
+    option. If multiplexing is enabled, forwarding is set by using the existing connection
+    (`-O forward` option in ssh). This is beneficial if your servers require password authentication;
+    you can avoid authentication in Julia by logging in to the server ahead of `addprocs`. The control
+    socket will be located at `~/.ssh/julia-%r@%h:%p` during the session unless the existing multiplexing
+    connection is used. Note that bandwidth may be limited if you create multiple processes on a node
+    and enable multiplexing, because in that case processes share a single multiplexing TCP connection.
 
 ### [Cluster Cookie](@id man-cluster-cookie)
 

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -28,6 +28,7 @@ The `userdata` field is used to store information for each worker by external ma
 
 Some fields are used by `SSHManager` and similar managers:
   * `tunnel` -- `true` (use tunneling), `false` (do not use tunneling), or [`nothing`](@ref) (use default for the manager)
+  * `multiplex` -- `true` (use SSH multiplexing for tunneling) or `false`
   * `forward` -- the forwarding option used for `-L` option of ssh
   * `bind_addr` -- the address on the remote host to bind to
   * `sshflags` -- flags to use in establishing the SSH connection
@@ -59,6 +60,7 @@ mutable struct WorkerConfig
 
     # SSHManager / SSH tunnel connections to workers
     tunnel::Union{Bool, Nothing}
+    multiplex::Union{Bool, Nothing}
     forward::Union{AbstractString, Nothing}
     bind_addr::Union{AbstractString, Nothing}
     sshflags::Union{Cmd, Nothing}
@@ -551,7 +553,7 @@ function launch_n_additional_processes(manager, frompid, fromconfig, cnt, launch
             (bind_addr, port) = address
 
             wconfig = WorkerConfig()
-            for x in [:host, :tunnel, :sshflags, :exeflags, :exename, :enable_threaded_blas]
+            for x in [:host, :tunnel, :multiplex, :sshflags, :exeflags, :exename, :enable_threaded_blas]
                 Base.setproperty!(wconfig, x, Base.getproperty(fromconfig, x))
             end
             wconfig.bind_addr = bind_addr

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -28,6 +28,7 @@ The `userdata` field is used to store information for each worker by external ma
 
 Some fields are used by `SSHManager` and similar managers:
   * `tunnel` -- `true` (use tunneling), `false` (do not use tunneling), or [`nothing`](@ref) (use default for the manager)
+  * `forward` -- the forwarding option used for `-L` option of ssh
   * `bind_addr` -- the address on the remote host to bind to
   * `sshflags` -- flags to use in establishing the SSH connection
   * `max_parallel` -- the maximum number of workers to connect to in parallel on the host
@@ -58,6 +59,7 @@ mutable struct WorkerConfig
 
     # SSHManager / SSH tunnel connections to workers
     tunnel::Union{Bool, Nothing}
+    forward::Union{AbstractString, Nothing}
     bind_addr::Union{AbstractString, Nothing}
     sshflags::Union{Cmd, Nothing}
     max_parallel::Union{Int, Nothing}

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -432,7 +432,7 @@ function connect(manager::ClusterManager, pid::Int, config::WorkerConfig)
         sshflags = notnothing(config.sshflags)
         acquire(sem)
         try
-            (s, bind_addr, forward) = connect_to_worker(pubhost, bind_addr, port, user, sshflags)
+            (s, bind_addr, forward) = connect_to_worker_with_tunnel(pubhost, bind_addr, port, user, sshflags)
             config.forward = forward
         finally
             release(sem)
@@ -519,7 +519,7 @@ function connect_to_worker(host::AbstractString, port::Integer)
 end
 
 
-function connect_to_worker(host::AbstractString, bind_addr::AbstractString, port::Integer, tunnel_user::AbstractString, sshflags)
+function connect_to_worker_with_tunnel(host::AbstractString, bind_addr::AbstractString, port::Integer, tunnel_user::AbstractString, sshflags)
     localport = ssh_tunnel(tunnel_user, host, bind_addr, UInt16(port), sshflags)
     s = connect("localhost", localport)
     forward = "$localport:$bind_addr:$port"

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -718,7 +718,10 @@ if Sys.isunix() # aka have ssh
     print("\nssh addprocs with tunnel\n")
     new_pids = addprocs_with_testenv([("localhost", num_workers)]; tunnel=true, sshflags=sshflags)
     @test length(new_pids) == num_workers
+    controlpath = joinpath(homedir(), ".ssh", "julia-$(ENV["USER"])@localhost:22")
+    @test issocket(controlpath)
     test_n_remove_pids(new_pids)
+    @test :ok == timedwait(()->!issocket(controlpath), 10.0; pollint=0.5)
 
     print("\nAll supported formats for hostname\n")
     h1 = "localhost"

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -718,6 +718,11 @@ if Sys.isunix() # aka have ssh
     print("\nssh addprocs with tunnel\n")
     new_pids = addprocs_with_testenv([("localhost", num_workers)]; tunnel=true, sshflags=sshflags)
     @test length(new_pids) == num_workers
+    test_n_remove_pids(new_pids)
+
+    print("\nssh addprocs with tunnel (SSH multiplexing)\n")
+    new_pids = addprocs_with_testenv([("localhost", num_workers)]; tunnel=true, multiplex=true, sshflags=sshflags)
+    @test length(new_pids) == num_workers
     controlpath = joinpath(homedir(), ".ssh", "julia-$(ENV["USER"])@localhost:22")
     @test issocket(controlpath)
     test_n_remove_pids(new_pids)


### PR DESCRIPTION
The current implementation of `Distributed.addprocs` with `tunnel=true` had problems:
- If a multiplexing process had been already launched, the creation of new ssh workers hung.
- It required two separate connections, which needed two times of authentication.

These problems can be solved by using ssh multiplexing.
I modified the code to use ssh multiplexing when `tunnel` is true, and it has some advantages to the current one:

- The ssh commands got much simpler
    - by using control commands (`-O` options) of ssh
- Reuse a multiplexing session if it has already been established outside of Julia.
    - which reduces overhead and avoids authentication at each run