### PR TITLE
nicer constructor for ImmutableDict

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -749,6 +749,7 @@ Create a new entry in the Immutable Dictionary for the key => value pair
 ImmutableDict
 ImmutableDict(KV::Pair{K,V}) where {K,V} = ImmutableDict{K,V}(KV[1], KV[2])
 ImmutableDict(t::ImmutableDict{K,V}, KV::Pair) where {K,V} = ImmutableDict{K,V}(t, KV[1], KV[2])
+ImmutableDict(KV::Pair, rest::Pair...) = ImmutableDict(ImmutableDict(rest...), KV)
 
 function in(key_value::Pair, dict::ImmutableDict, valcmp=(==))
     key, value = key_value

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -709,6 +709,11 @@ import Base.ImmutableDict
 
     @test_throws KeyError d[k1]
     @test_throws KeyError d1["key2"]
+
+    v = [k1 => v1, k2 => v2]
+    d5 = ImmutableDict(v...)
+    @test d5 == d2
+    @test collect(d5) == v
 end
 
 @testset "filtering" begin


### PR DESCRIPTION
It's currently quite cumbersome to construct ImmutableDicts with multiple entries. This PR allows constructing ImmutableDicts by pairs in the same way as regular Dicts. If people approve, I can add some docs.