### PR TITLE
RFC: optimizer: add Instruction/InstructionStream abstraction

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -7,8 +7,8 @@ using Core.Intrinsics, Core.IR
 import Core: print, println, show, write, unsafe_write, stdout, stderr,
              _apply, _apply_iterate, svec, apply_type, Builtin, IntrinsicFunction, MethodInstance, CodeInstance
 
-const getproperty = getfield
-const setproperty! = setfield!
+const getproperty = Core.getfield
+const setproperty! = Core.setfield!
 
 ccall(:jl_set_istopmod, Cvoid, (Any, Bool), Compiler, false)
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -186,8 +186,9 @@ function optimize(opt::OptimizationState, params::OptimizationParams, @nospecial
         if length(ir.stmts) < 10
             proven_pure = true
             for i in 1:length(ir.stmts)
-                stmt = ir.stmts[i]
-                if stmt_affects_purity(stmt, ir) && !stmt_effect_free(stmt, ir.types[i], ir, ir.sptypes)
+                node = ir.stmts[i]
+                stmt = node[:inst]
+                if stmt_affects_purity(stmt, ir) && !stmt_effect_free(stmt, node[:type], ir, ir.sptypes)
                     proven_pure = false
                     break
                 end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -53,7 +53,6 @@ struct CFG
     index::Vector{Int} # map from instruction => basic-block number
                        # TODO: make this O(1) instead of O(log(n_blocks))?
 end
-copy(c::CFG) = CFG(BasicBlock[copy(b) for b in c.blocks], copy(c.index))
 
 function block_for_inst(index::Vector{Int}, inst::Int)
     return searchsortedfirst(index, inst, lt=(<=))
@@ -191,59 +190,127 @@ function first_insert_for_bb(code, cfg::CFG, block::Int)
     end
 end
 
-struct NewNode
+# SSA-indexed nodes
+struct InstructionStream
+    inst::Vector{Any}
+    type::Vector{Any}
+    line::Vector{Int32}
+    flag::Vector{UInt8}
+end
+function InstructionStream(len::Int)
+    insts = Array{Any}(undef, len)
+    types = Array{Any}(undef, len)
+    lines = fill(Int32(0), len)
+    flags = fill(0x00, len)
+    return InstructionStream(insts, types, lines, flags)
+end
+InstructionStream() = InstructionStream(0)
+length(is::InstructionStream) = length(is.inst)
+isempty(is::InstructionStream) = isempty(is.inst)
+function add!(is::InstructionStream)
+    ninst = length(is) + 1
+    resize!(is.inst, ninst)
+    resize!(is.type, ninst)
+    resize!(is.line, ninst)
+    resize!(is.flag, ninst)
+    return ninst
+end
+#function copy(is::InstructionStream) # unused
+#    return InstructionStream(
+#        copy_exprargs(is.insts),
+#        copy(is.types),
+#        copy(is.lines),
+#        copy(is.flags))
+#end
+function resize!(stmts::InstructionStream, len)
+    old_length = length(stmts)
+    resize!(stmts.inst, len)
+    resize!(stmts.type, len)
+    resize!(stmts.line, len)
+    resize!(stmts.flag, len)
+    for i in (old_length + 1):len
+        stmts.line[i] = 0
+        stmts.flag[i] = 0x00
+    end
+    return stmts
+end
+
+
+struct Instruction
+    data::InstructionStream
+    idx::Int
+end
+Instruction(is::InstructionStream) = Instruction(is, add!(is))
+
+@inline function getindex(node::Instruction, fld::Symbol)
+    isdefined(node, fld) && return getfield(node, fld)
+    return getfield(getfield(node, :data), fld)[getfield(node, :idx)]
+end
+@inline function setindex!(node::Instruction, @nospecialize(val), fld::Symbol)
+    getfield(getfield(node, :data), fld)[getfield(node, :idx)] = val
+    return node
+end
+
+@inline getindex(is::InstructionStream, idx::Int) = Instruction(is, idx)
+function setindex!(is::InstructionStream, newval::Instruction, idx::Int)
+    is.inst[idx] = newval[:inst]
+    is.type[idx] = newval[:type]
+    is.line[idx] = newval[:line]
+    is.flag[idx] = newval[:flag]
+    return is
+end
+function setindex!(node::Instruction, newval::Instruction)
+    node.data[node.idx] = newval
+    return node
+end
+
+struct NewNodeInfo
     # Insertion position (interpretation depends on which array this is in)
     pos::Int
     # Place the new instruction after this instruction (but in the same BB if this is an implicit terminator)
     attach_after::Bool
-    # The type of the instruction to insert
-    typ::Any
-    # The node itself
-    node::Any
-    # The index into the line number table of this entry
-    line::Int32
-
-    NewNode(pos::Int, attach_after::Bool, @nospecialize(typ), @nospecialize(node), line::Int32) =
-        new(pos, attach_after, typ, node, line)
+end
+struct NewNodeStream
+    stmts::InstructionStream
+    info::Vector{NewNodeInfo}
+end
+NewNodeStream(len::Int=0) = NewNodeStream(InstructionStream(len), fill(NewNodeInfo(0, false), len))
+length(new::NewNodeStream) = length(new.stmts)
+isempty(new::NewNodeStream) = isempty(new.stmts)
+function add!(new::NewNodeStream, pos::Int, attach_after::Bool)
+    push!(new.info, NewNodeInfo(pos, attach_after))
+    return Instruction(new.stmts)
 end
 
 struct IRCode
-    stmts::Vector{Any}
-    types::Vector{Any}
-    lines::Vector{Int32}
-    flags::Vector{UInt8}
+    stmts::InstructionStream
     argtypes::Vector{Any}
     sptypes::Vector{Any}
     linetable::Vector{LineInfoNode}
     cfg::CFG
-    new_nodes::Vector{NewNode}
+    new_nodes::NewNodeStream
     meta::Vector{Any}
 
-    function IRCode(stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int32}, flags::Vector{UInt8},
-            cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Any},
-            sptypes::Vector{Any})
-        return new(stmts, types, lines, flags, argtypes, sptypes, linetable, cfg, NewNode[], meta)
+    function IRCode(stmts::InstructionStream, cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Any}, sptypes::Vector{Any})
+        return new(stmts, argtypes, sptypes, linetable, cfg, NewNodeStream(), meta)
     end
-    function IRCode(ir::IRCode, stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int32}, flags::Vector{UInt8},
-            cfg::CFG, new_nodes::Vector{NewNode})
-        return new(stmts, types, lines, flags, ir.argtypes, ir.sptypes, ir.linetable, cfg, new_nodes, ir.meta)
+    function IRCode(ir::IRCode, stmts::InstructionStream, cfg::CFG, new_nodes::NewNodeStream)
+        return new(stmts, ir.argtypes, ir.sptypes, ir.linetable, cfg, new_nodes, ir.meta)
     end
 end
-copy(code::IRCode) = IRCode(code, copy_exprargs(code.stmts), copy(code.types),
-    copy(code.lines), copy(code.flags), copy(code.cfg), copy(code.new_nodes))
 
 function getindex(x::IRCode, s::SSAValue)
     if s.id <= length(x.stmts)
-        return x.stmts[s.id]
+        return x.stmts[s.id][:inst]
     else
-        return x.new_nodes[s.id - length(x.stmts)].node
+        return x.new_nodes.stmts[s.id - length(x.stmts)][:inst]
     end
 end
 
 function setindex!(x::IRCode, @nospecialize(repl), s::SSAValue)
     @assert s.id <= length(x.stmts)
-    x.stmts[s.id] = repl
-    nothing
+    x.stmts[s.id][:inst] = repl
+    return x
 end
 
 
@@ -442,9 +509,10 @@ function foreachssa(f, @nospecialize(stmt))
 end
 
 function insert_node!(ir::IRCode, pos::Int, @nospecialize(typ), @nospecialize(val), attach_after::Bool=false)
-    line = ir.lines[pos]
-    push!(ir.new_nodes, NewNode(pos, attach_after, typ, val, line))
-    return SSAValue(length(ir.stmts) + length(ir.new_nodes))
+    line = ir.stmts[pos][:line]
+    node = add!(ir.new_nodes, pos, attach_after)
+    node[:inst], node[:type], node[:line], node[:flag] = val, typ, line, 0x00
+    return SSAValue(length(ir.stmts) + node.idx)
 end
 
 # For bootstrapping
@@ -459,23 +527,19 @@ end
 
 mutable struct IncrementalCompact
     ir::IRCode
-    result::Vector{Any}
-    result_types::Vector{Any}
-    result_lines::Vector{Int32}
-    result_flags::Vector{UInt8}
+    result::InstructionStream
     result_bbs::Vector{BasicBlock}
     ssa_rename::Vector{Any}
     bb_rename_pred::Vector{Int}
     bb_rename_succ::Vector{Int}
     used_ssas::Vector{Int}
     late_fixup::Vector{Int}
-    # This could be Stateful, but bootstrapping doesn't like that
     perm::Vector{Int}
     new_nodes_idx::Int
     # This supports insertion while compacting
-    new_new_nodes::Vector{NewNode}  # New nodes that were before the compaction point at insertion time
+    new_new_nodes::NewNodeStream  # New nodes that were before the compaction point at insertion time
     # TODO: Switch these two to a min-heap of some sort
-    pending_nodes::Vector{NewNode}  # New nodes that were after the compaction point at insertion time
+    pending_nodes::NewNodeStream  # New nodes that were after the compaction point at insertion time
     pending_perm::Vector{Int}
     # State
     idx::Int
@@ -485,13 +549,12 @@ mutable struct IncrementalCompact
     cfg_transforms_enabled::Bool
     fold_constant_branches::Bool
     function IncrementalCompact(code::IRCode, allow_cfg_transforms::Bool=false)
-        # Sort by position with attach after nodes affter regular ones
-        perm = my_sortperm(Int[(code.new_nodes[i].pos*2 + Int(code.new_nodes[i].attach_after)) for i in 1:length(code.new_nodes)])
+        # Sort by position with attach after nodes after regular ones
+        perm = my_sortperm(Int[let new_node = code.new_nodes.info[i]
+            (new_node.pos * 2 + Int(new_node.attach_after))
+            end for i in 1:length(code.new_nodes)])
         new_len = length(code.stmts) + length(code.new_nodes)
-        result = Array{Any}(undef, new_len)
-        result_types = Array{Any}(undef, new_len)
-        result_lines = fill(Int32(0), new_len)
-        result_flags = fill(0x00, new_len)
+        result = InstructionStream(new_len)
         used_ssas = fill(0, new_len)
         blocks = code.cfg.blocks
         if allow_cfg_transforms
@@ -517,9 +580,11 @@ mutable struct IncrementalCompact
                 # Dead blocks get removed from the predecessor list
                 filter!(x->x !== -1, preds)
                 # Rename succs
-                for j = 1:length(succs); succs[j] = bb_rename[succs[j]]; end
+                for j = 1:length(succs)
+                    succs[j] = bb_rename[succs[j]]
+                end
             end
-            let blocks=blocks
+            let blocks = blocks
                 result_bbs = BasicBlock[blocks[i] for i = 1:length(blocks) if bb_rename[i] != -1]
             end
         else
@@ -528,26 +593,26 @@ mutable struct IncrementalCompact
         end
         ssa_rename = Any[SSAValue(i) for i = 1:new_len]
         late_fixup = Vector{Int}()
-        new_new_nodes = NewNode[]
-        pending_nodes = NewNode[]
+        new_new_nodes = NewNodeStream()
+        pending_nodes = NewNodeStream()
         pending_perm = Int[]
-        return new(code, result, result_types, result_lines, result_flags, result_bbs, ssa_rename, bb_rename, bb_rename, used_ssas, late_fixup, perm, 1,
+        return new(code, result, result_bbs, ssa_rename, bb_rename, bb_rename, used_ssas, late_fixup, perm, 1,
             new_new_nodes, pending_nodes, pending_perm,
             1, 1, 1, false, allow_cfg_transforms, allow_cfg_transforms)
     end
 
     # For inlining
     function IncrementalCompact(parent::IncrementalCompact, code::IRCode, result_offset)
-        perm = my_sortperm(Int[code.new_nodes[i].pos for i in 1:length(code.new_nodes)])
+        perm = my_sortperm(Int[code.new_nodes.info[i].pos for i in 1:length(code.new_nodes)])
         new_len = length(code.stmts) + length(code.new_nodes)
         ssa_rename = Any[SSAValue(i) for i = 1:new_len]
         used_ssas = fill(0, new_len)
         late_fixup = Vector{Int}()
         bb_rename = Vector{Int}()
-        new_new_nodes = NewNode[]
-        pending_nodes = NewNode[]
+        new_new_nodes = NewNodeStream()
+        pending_nodes = NewNodeStream()
         pending_perm = Int[]
-        return new(code, parent.result, parent.result_types, parent.result_lines, parent.result_flags,
+        return new(code, parent.result,
             parent.result_bbs, ssa_rename, bb_rename, bb_rename, parent.used_ssas,
             late_fixup, perm, 1,
             new_new_nodes, pending_nodes, pending_perm,
@@ -555,39 +620,39 @@ mutable struct IncrementalCompact
     end
 end
 
-struct TypesView
-    ir::Union{IRCode, IncrementalCompact}
+struct TypesView{T}
+    ir::T # ::Union{IRCode, IncrementalCompact}
 end
 types(ir::Union{IRCode, IncrementalCompact}) = TypesView(ir)
 
 function getindex(compact::IncrementalCompact, idx::Int)
     if idx < compact.result_idx
-        return compact.result[idx]
+        return compact.result[idx][:inst]
     else
-        return compact.ir.stmts[idx]
+        return compact.ir.stmts[idx][:inst]
     end
 end
 
 function getindex(compact::IncrementalCompact, ssa::SSAValue)
     @assert ssa.id < compact.result_idx
-    return compact.result[ssa.id]
+    return compact.result[ssa.id][:inst]
 end
 
 function getindex(compact::IncrementalCompact, ssa::OldSSAValue)
     id = ssa.id
     if id <= length(compact.ir.stmts)
-        return compact.ir.stmts[id]
+        return compact.ir.stmts[id][:inst]
     end
     id -= length(compact.ir.stmts)
     if id <= length(compact.ir.new_nodes)
-        return compact.ir.new_nodes[id].node
+        return compact.ir.new_nodes.stmts[id][:inst]
     end
     id -= length(compact.ir.new_nodes)
-    return compact.pending_nodes[id].node
+    return compact.pending_nodes.stmts[id][:inst]
 end
 
 function getindex(compact::IncrementalCompact, ssa::NewSSAValue)
-    return compact.new_new_nodes[ssa.id].node
+    return compact.new_new_nodes.stmts[ssa.id][:inst]
 end
 
 function count_added_node!(compact::IncrementalCompact, @nospecialize(v))
@@ -607,22 +672,26 @@ function count_added_node!(compact::IncrementalCompact, @nospecialize(v))
     needs_late_fixup
 end
 
-function resort_pending!(compact)
-    sort!(compact.pending_perm, DEFAULT_STABLE, Order.By(x->compact.pending_nodes[x].pos, Order.Forward))
+function add_pending!(compact::IncrementalCompact, pos::Int, attach_after::Bool)
+    node = add!(compact.pending_nodes, pos, attach_after)
+    # TODO: switch this to `l = length(pending_nodes); splice!(pending_perm, searchsorted(pending_perm, l), l)`
+    push!(compact.pending_perm, length(compact.pending_nodes))
+    sort!(compact.pending_perm, DEFAULT_STABLE, Order.By(x->compact.pending_nodes.info[x].pos, Order.Forward))
+    return node
 end
 
 function insert_node!(compact::IncrementalCompact, before, @nospecialize(typ), @nospecialize(val), attach_after::Bool=false)
     if isa(before, SSAValue)
         if before.id < compact.result_idx
             count_added_node!(compact, val)
-            line = compact.result_lines[before.id]
-            push!(compact.new_new_nodes, NewNode(before.id, attach_after, typ, val, line))
-            return NewSSAValue(length(compact.new_new_nodes))
+            line = compact.result[before.id][:line]
+            node = add!(compact.new_new_nodes, before.id, attach_after)
+            node[:inst], node[:type], node[:line] = val, typ, line
+            return NewSSAValue(node.idx)
         else
-            line = compact.ir.lines[before.id]
-            push!(compact.pending_nodes, NewNode(before.id, attach_after, typ, val, line))
-            push!(compact.pending_perm, length(compact.pending_nodes))
-            resort_pending!(compact)
+            line = compact.ir.stmts[before.id][:line]
+            node = add_pending!(compact, before.id, attach_after)
+            node[:inst], node[:type], node[:line] = val, typ, line
             os = OldSSAValue(length(compact.ir.stmts) + length(compact.ir.new_nodes) + length(compact.pending_nodes))
             push!(compact.ssa_rename, os)
             push!(compact.used_ssas, 0)
@@ -632,127 +701,117 @@ function insert_node!(compact::IncrementalCompact, before, @nospecialize(typ), @
         pos = before.id
         if pos > length(compact.ir.stmts)
             #@assert attach_after
-            entry = compact.pending_nodes[pos - length(compact.ir.stmts) - length(compact.ir.new_nodes)]
-            pos, attach_after = entry.pos, entry.attach_after
+            info = compact.pending_nodes.info[pos - length(compact.ir.stmts) - length(compact.ir.new_nodes)]
+            pos, attach_after = info.pos, info.attach_after
         end
-        line = compact.ir.lines[pos]
-        push!(compact.pending_nodes, NewNode(pos, attach_after, typ, val, line))
-        push!(compact.pending_perm, length(compact.pending_nodes))
-        resort_pending!(compact)
+        line = compact.ir.stmts[pos][:line]
+        node = add_pending!(compact, pos, attach_after)
+        node[:inst], node[:type], node[:line] = val, typ, line
         os = OldSSAValue(length(compact.ir.stmts) + length(compact.ir.new_nodes) + length(compact.pending_nodes))
         push!(compact.ssa_rename, os)
         push!(compact.used_ssas, 0)
         return os
     elseif isa(before, NewSSAValue)
-        before_entry = compact.new_new_nodes[before.id]
-        push!(compact.new_new_nodes, NewNode(before_entry.pos, attach_after, typ, val, before_entry.line))
-        return NewSSAValue(length(compact.new_new_nodes))
+        before_entry = compact.new_new_nodes.info[before.id]
+        line = compact.new_new_nodes.stmts[before.id][:line]
+        new_entry = add!(compact.new_new_nodes, before_entry.pos, attach_after)
+        new_entry[:inst], new_entry[:type], new_entry[:line] = val, typ, line
+        return NewSSAValue(new_entry.idx)
     else
         error("Unsupported")
     end
 end
 
-function append_node!(ir, @nospecialize(typ), @nospecialize(node), line)
-    push!(ir.stmts, node)
-    push!(ir.types, typ)
-    push!(ir.lines, line)
-    push!(ir.flags, 0)
-    last_bb = ir.cfg.blocks[end]
-    ir.cfg.blocks[end] = BasicBlock(first(last_bb.stmts):length(ir.stmts),
-        last_bb.preds,
-        last_bb.succs)
-    return SSAValue(length(ir.stmts))
-end
-
 function insert_node_here!(compact::IncrementalCompact, @nospecialize(val), @nospecialize(typ), ltable_idx::Int32, reverse_affinity::Bool=false)
-    if compact.result_idx > length(compact.result)
-        @assert compact.result_idx == length(compact.result) + 1
-        resize!(compact, compact.result_idx)
-    end
     refinish = false
-    if compact.result_idx == first(compact.result_bbs[compact.active_result_bb].stmts) && reverse_affinity
+    result_idx = compact.result_idx
+    if result_idx == first(compact.result_bbs[compact.active_result_bb].stmts) && reverse_affinity
         compact.active_result_bb -= 1
         refinish = true
     end
-    compact.result[compact.result_idx] = val
-    compact.result_types[compact.result_idx] = typ
-    compact.result_lines[compact.result_idx] = ltable_idx
-    compact.result_flags[compact.result_idx] = 0x00
-    if count_added_node!(compact, val)
-        push!(compact.late_fixup, compact.result_idx)
+    if result_idx > length(compact.result)
+        @assert result_idx == length(compact.result) + 1
+        resize!(compact, result_idx)
     end
-    ret = SSAValue(compact.result_idx)
-    compact.result_idx += 1
+    node = compact.result[result_idx]
+    node[:inst], node[:type], node[:line], node[:flag] = val, typ, ltable_idx, 0x00
+    if count_added_node!(compact, val)
+        push!(compact.late_fixup, result_idx)
+    end
+    compact.result_idx = result_idx + 1
+    inst = SSAValue(result_idx)
     refinish && finish_current_bb!(compact, 0)
-    ret
+    return inst
 end
 
 function getindex(view::TypesView, v::OldSSAValue)
     id = v.id
-    if id <= length(view.ir.ir.types)
-        return view.ir.ir.types[id]
+    ir = view.ir.ir
+    stmts = ir.stmts
+    if id <= length(stmts)
+        return stmts[id][:type]
     end
-    id -= length(view.ir.ir.types)
-    if id <= length(view.ir.ir.new_nodes)
-        return view.ir.ir.new_nodes[id].typ
+    id -= length(stmts)
+    if id <= length(ir.new_nodes)
+        return ir.new_nodes.stmts[id][:type]
     end
-    id -= length(view.ir.ir.new_nodes)
-    return view.ir.pending_nodes[id].typ
+    id -= length(ir.new_nodes)
+    return view.ir.pending_nodes.stmts[id][:type]
 end
 
 function setindex!(compact::IncrementalCompact, @nospecialize(v), idx::SSAValue)
     @assert idx.id < compact.result_idx
-    (compact.result[idx.id] === v) && return
+    (compact.result[idx.id][:inst] === v) && return
     # Kill count for current uses
-    for ops in userefs(compact.result[idx.id])
+    for ops in userefs(compact.result[idx.id][:inst])
         val = ops[]
         if isa(val, SSAValue)
             @assert compact.used_ssas[val.id] >= 1
             compact.used_ssas[val.id] -= 1
         end
     end
-    compact.result[idx.id] = v
+    compact.result[idx.id][:inst] = v
     # Add count for new use
     if count_added_node!(compact, v)
         push!(compact.late_fixup, idx.id)
     end
+    return compact
 end
 
 function setindex!(compact::IncrementalCompact, @nospecialize(v), idx::Int)
     if idx < compact.result_idx
         compact[SSAValue(idx)] = v
     else
-        compact.ir.stmts[idx] = v
+        compact.ir.stmts[idx][:inst] = v
     end
-    return nothing
+    return compact
 end
 
-function getindex(view::TypesView, idx)
-    isa(idx, SSAValue) && (idx = idx.id)
+getindex(view::TypesView, idx::SSAValue) = getindex(view, idx.id)
+function getindex(view::TypesView, idx::Int)
     if isa(view.ir, IncrementalCompact) && idx < view.ir.result_idx
-        return view.ir.result_types[idx]
+        return view.ir.result[idx][:type]
     elseif isa(view.ir, IncrementalCompact) && view.ir.renamed_new_nodes
-        if idx <= length(view.ir.result_types)
-            return view.ir.result_types[idx]
+        if idx <= length(view.ir.result)
+            return view.ir.result[idx][:type]
         else
-            return view.ir.new_new_nodes[idx - length(view.ir.result_types)].typ
+            return view.ir.new_new_nodes.stmts[idx - length(view.ir.result)][:type]
         end
     else
         ir = isa(view.ir, IncrementalCompact) ? view.ir.ir : view.ir
-        if idx <= length(ir.types)
-            return ir.types[idx]
+        if idx <= length(ir.stmts)
+            return ir.stmts[idx][:type]
         else
-            return ir.new_nodes[idx - length(ir.types)].typ
+            return ir.new_nodes.stmts[idx - length(ir.stmts)][:type]
         end
     end
 end
 
 function getindex(view::TypesView, idx::NewSSAValue)
     if isa(view.ir, IncrementalCompact)
-        compact = view.ir
-        compact.new_new_nodes[idx.id].typ
+        return view.ir.new_new_nodes.stmts[idx.id][:type]
     else
-        view.ir.new_nodes[idx.id].typ
+        return view.ir.new_nodes.stmts[idx.id][:type]
     end
 end
 
@@ -853,16 +912,16 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
             # Kill all statements in the block
             stmts = compact.result_bbs[compact.bb_rename_succ[to]].stmts
             for stmt in stmts
-                compact.result[stmt] = nothing
+                compact.result[stmt][:inst] = nothing
             end
-            compact.result[last(stmts)] = ReturnNode()
+            compact.result[last(stmts)][:inst] = ReturnNode()
         end
     else
         # We need to remove this edge from any phi nodes
         if to < active_bb
             idx = first(compact.result_bbs[compact.bb_rename_succ[to]].stmts)
             while idx < length(compact.result)
-                stmt = compact.result[idx]
+                stmt = compact.result[idx][:inst]
                 stmt === nothing && continue
                 isa(stmt, PhiNode) || break
                 i = findfirst(x-> x === compact.bb_rename_pred[from], stmt.edges)
@@ -888,37 +947,39 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
     nothing
 end
 
-function process_node!(compact::IncrementalCompact, result::Vector{Any},
-        result_idx::Int, ssa_rename::Vector{Any},
-        late_fixup::Vector{Int}, used_ssas::Vector{Int}, @nospecialize(stmt),
-        idx::Int, processed_idx::Int, active_bb::Int, do_rename_ssa::Bool)
+function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instruction, idx::Int, processed_idx::Int, active_bb::Int, do_rename_ssa::Bool)
+    stmt = inst[:inst]
+    result = compact.result
+    ssa_rename = compact.ssa_rename
+    late_fixup = compact.late_fixup
+    used_ssas = compact.used_ssas
     ssa_rename[idx] = SSAValue(result_idx)
     if stmt === nothing
         ssa_rename[idx] = stmt
     elseif isa(stmt, OldSSAValue)
         ssa_rename[idx] = ssa_rename[stmt.id]
     elseif isa(stmt, GotoNode) && compact.cfg_transforms_enabled
-        result[result_idx] = GotoNode(compact.bb_rename_succ[stmt.label])
+        result[result_idx][:inst] = GotoNode(compact.bb_rename_succ[stmt.label])
         result_idx += 1
     elseif isa(stmt, GlobalRef) || isa(stmt, GotoNode)
-        result[result_idx] = stmt
+        result[result_idx][:inst] = stmt
         result_idx += 1
     elseif isa(stmt, GotoIfNot) && compact.cfg_transforms_enabled
         stmt = renumber_ssa2!(stmt, ssa_rename, used_ssas, late_fixup, result_idx, do_rename_ssa)::GotoIfNot
-        result[result_idx] = stmt
+        result[result_idx][:inst] = stmt
         cond = stmt.cond
         if isa(cond, Bool) && compact.fold_constant_branches
             if cond
-                result[result_idx] = nothing
+                result[result_idx][:inst] = nothing
                 kill_edge!(compact, active_bb, active_bb, stmt.dest)
                 # Don't increment result_idx => Drop this statement
             else
-                result[result_idx] = GotoNode(compact.bb_rename_succ[stmt.dest])
+                result[result_idx][:inst] = GotoNode(compact.bb_rename_succ[stmt.dest])
                 kill_edge!(compact, active_bb, active_bb, active_bb+1)
                 result_idx += 1
             end
         else
-            result[result_idx] = GotoIfNot(cond, compact.bb_rename_succ[stmt.dest])
+            result[result_idx][:inst] = GotoIfNot(cond, compact.bb_rename_succ[stmt.dest])
             result_idx += 1
         end
     elseif isa(stmt, Expr)
@@ -926,7 +987,7 @@ function process_node!(compact::IncrementalCompact, result::Vector{Any},
         if compact.cfg_transforms_enabled && isexpr(stmt, :enter)
             stmt.args[1] = compact.bb_rename_succ[stmt.args[1]::Int]
         end
-        result[result_idx] = stmt
+        result[result_idx][:inst] = stmt
         result_idx += 1
     elseif isa(stmt, PiNode)
         # As an optimization, we eliminate any trivial pinodes. For performance, we use ===
@@ -935,7 +996,7 @@ function process_node!(compact::IncrementalCompact, result::Vector{Any},
         stmt = renumber_ssa2!(stmt, ssa_rename, used_ssas, late_fixup, result_idx, do_rename_ssa)::PiNode
         pi_val = stmt.val
         if isa(pi_val, SSAValue)
-            if stmt.typ === compact.result_types[pi_val.id]
+            if stmt.typ === compact.result[pi_val.id][:type]
                 ssa_rename[idx] = pi_val
                 return result_idx
             end
@@ -946,10 +1007,10 @@ function process_node!(compact::IncrementalCompact, result::Vector{Any},
                 return result_idx
             end
         end
-        result[result_idx] = stmt
+        result[result_idx][:inst] = stmt
         result_idx += 1
     elseif isa(stmt, ReturnNode) || isa(stmt, UpsilonNode) || isa(stmt, GotoIfNot)
-        result[result_idx] = renumber_ssa2!(stmt, ssa_rename, used_ssas, late_fixup, result_idx, do_rename_ssa)
+        result[result_idx][:inst] = renumber_ssa2!(stmt, ssa_rename, used_ssas, late_fixup, result_idx, do_rename_ssa)
         result_idx += 1
     elseif isa(stmt, PhiNode)
         values = process_phinode_values(stmt.values, late_fixup, processed_idx, result_idx, ssa_rename, used_ssas, do_rename_ssa)
@@ -961,11 +1022,11 @@ function process_node!(compact::IncrementalCompact, result::Vector{Any},
             ssa_rename[idx] = values[1]
         else
             edges = compact.cfg_transforms_enabled ? map!(i->compact.bb_rename_pred[i], stmt.edges, stmt.edges) : stmt.edges
-            result[result_idx] = PhiNode(edges, values)
+            result[result_idx][:inst] = PhiNode(edges, values)
             result_idx += 1
         end
     elseif isa(stmt, PhiCNode)
-        result[result_idx] = PhiCNode(process_phinode_values(stmt.values, late_fixup, processed_idx, result_idx, ssa_rename, used_ssas, do_rename_ssa))
+        result[result_idx][:inst] = PhiCNode(process_phinode_values(stmt.values, late_fixup, processed_idx, result_idx, ssa_rename, used_ssas, do_rename_ssa))
         result_idx += 1
     elseif isa(stmt, SSAValue)
         # identity assign, replace uses of this ssa value with its result
@@ -980,26 +1041,17 @@ function process_node!(compact::IncrementalCompact, result::Vector{Any},
     return result_idx
 end
 
-function process_node!(compact::IncrementalCompact, result_idx::Int, @nospecialize(stmt), idx::Int, processed_idx::Int, active_bb::Int, do_rename_ssa::Bool)
-    return process_node!(compact, compact.result, result_idx, compact.ssa_rename,
-        compact.late_fixup, compact.used_ssas, stmt, idx, processed_idx, active_bb,
-        do_rename_ssa)
-end
-
 function resize!(compact::IncrementalCompact, nnewnodes)
     old_length = length(compact.result)
     resize!(compact.result, nnewnodes)
-    resize!(compact.result_types, nnewnodes)
-    resize!(compact.result_lines, nnewnodes)
-    resize!(compact.result_flags, nnewnodes)
     resize!(compact.used_ssas, nnewnodes)
-    for i in (old_length+1):nnewnodes
+    for i in (old_length + 1):nnewnodes
         compact.used_ssas[i] = 0
     end
-    nothing
+    return compact
 end
 
-function finish_current_bb!(compact, active_bb, old_result_idx=compact.result_idx, unreachable=false)
+function finish_current_bb!(compact::IncrementalCompact, active_bb, old_result_idx=compact.result_idx, unreachable=false)
     if compact.active_result_bb > length(compact.result_bbs)
         #@assert compact.bb_rename[active_bb] == -1
         return true
@@ -1011,15 +1063,12 @@ function finish_current_bb!(compact, active_bb, old_result_idx=compact.result_id
     if !compact.cfg_transforms_enabled || active_bb == 0 || active_bb > length(compact.bb_rename_succ) || compact.bb_rename_succ[active_bb] != -1
         if compact.result_idx == first(bb.stmts)
             length(compact.result) < old_result_idx && resize!(compact, old_result_idx)
+            node = compact.result[old_result_idx]
             if unreachable
-                compact.result[old_result_idx] = ReturnNode()
-                compact.result_types[old_result_idx] = Union{}
+                node[:inst], node[:type], node[:line] = ReturnNode(), Union{}, 0
             else
-                compact.result[old_result_idx] = nothing
-                compact.result_types[old_result_idx] = Nothing
+                node[:inst], node[:type], node[:line] = nothing, Nothing, 0
             end
-            compact.result_lines[old_result_idx] = 0
-            compact.result_flags[old_result_idx] = 0x00
             compact.result_idx = old_result_idx + 1
         elseif compact.cfg_transforms_enabled && compact.result_idx - 1 == first(bb.stmts)
             # Optimization: If this BB consists of only a branch, eliminate this bb
@@ -1039,25 +1088,25 @@ end
 
 function attach_after_stmt_after(compact::IncrementalCompact, idx::Int)
     compact.new_nodes_idx > length(compact.perm) && return false
-    entry = compact.ir.new_nodes[compact.perm[compact.new_nodes_idx]]
-    entry.pos == idx && entry.attach_after
+    entry = compact.ir.new_nodes.info[compact.perm[compact.new_nodes_idx]]
+    return entry.pos == idx && entry.attach_after
 end
 
-function process_newnode!(compact, new_idx, new_node_entry, idx, active_bb, do_rename_ssa)
+function process_newnode!(compact::IncrementalCompact, new_idx::Int, new_node_entry::Instruction, new_node_info::NewNodeInfo, idx::Int, active_bb::Int, do_rename_ssa::Bool)
     old_result_idx = compact.result_idx
     bb = compact.ir.cfg.blocks[active_bb]
-    compact.result_types[old_result_idx] = new_node_entry.typ
-    compact.result_lines[old_result_idx] = new_node_entry.line
-    result_idx = process_node!(compact, old_result_idx, new_node_entry.node, new_idx, idx - 1, active_bb, do_rename_ssa)
+    node = compact.result[old_result_idx]
+    node[] = new_node_entry
+    result_idx = process_node!(compact, old_result_idx, node, new_idx, idx - 1, active_bb, do_rename_ssa)
     compact.result_idx = result_idx
     # If this instruction has reverse affinity and we were at the end of a basic block,
     # finish it now.
-    if new_node_entry.attach_after && idx == last(bb.stmts)+1 && !attach_after_stmt_after(compact, idx-1)
+    if new_node_info.attach_after && idx == last(bb.stmts)+1 && !attach_after_stmt_after(compact, idx-1)
         active_bb += 1
         finish_current_bb!(compact, active_bb, old_result_idx)
     end
     (old_result_idx == result_idx) && return iterate(compact, (idx, active_bb))
-    return Pair{Int, Any}(old_result_idx, compact.result[old_result_idx]), (idx, active_bb)
+    return Pair{Int, Any}(old_result_idx, compact.result[old_result_idx][:inst]), (idx, active_bb)
 end
 
 struct CompactPeekIterator
@@ -1065,28 +1114,30 @@ struct CompactPeekIterator
     start_idx::Int
 end
 
-entry_at_idx(entry, idx) = entry.attach_after ? entry.pos == idx - 1 : entry.pos == idx
-function iterate(it::CompactPeekIterator, (idx, aidx, bidx)::NTuple{3, Int}=(it.start_idx,it.compact.new_nodes_idx,1))
+entry_at_idx(entry::NewNodeInfo, idx::Int) = entry.attach_after ? entry.pos == idx - 1 : entry.pos == idx
+function iterate(it::CompactPeekIterator, (idx, aidx, bidx)::NTuple{3, Int}=(it.start_idx, it.compact.new_nodes_idx, 1))
     # TODO: Take advantage of the fact that these arrays are sorted
+    # TODO: this return value design is horrible
     compact = it.compact
     if compact.new_nodes_idx <= length(compact.perm)
+        new_nodes = compact.ir.new_nodes
         for eidx in aidx:length(compact.perm)
-            if entry_at_idx(compact.ir.new_nodes[compact.perm[eidx]], idx)
-                entry = compact.ir.new_nodes[compact.perm[eidx]]
-                return (entry.node, (idx, eidx+1, bidx))
+            if entry_at_idx(new_nodes.info[compact.perm[eidx]], idx)
+                entry = new_nodes.stmts[compact.perm[eidx]]
+                return (entry[:inst], (idx, eidx+1, bidx))
             end
         end
     end
     if !isempty(compact.pending_perm)
         for eidx in bidx:length(compact.pending_perm)
-            if entry_at_idx(compact.pending_nodes[compact.pending_perm[eidx]], idx)
-                entry = compact.pending_nodes[compact.compact.pending_perm[eidx]]
-                return (entry.node, (idx, aidx, eidx+1))
+            if entry_at_idx(compact.pending_nodes.info[compact.pending_perm[eidx]], idx)
+                entry = compact.pending_nodes.stmts[compact.pending_perm[eidx]]
+                return (entry[:inst], (idx, aidx, eidx+1))
             end
         end
     end
     idx > length(compact.ir.stmts) && return nothing
-    return (compact.ir.stmts[idx], (idx + 1, aidx, bidx))
+    return (compact.ir.stmts[idx][:inst], (idx + 1, aidx, bidx))
 end
 
 function iterate(compact::IncrementalCompact, (idx, active_bb)::Tuple{Int, Int}=(compact.idx, 1))
@@ -1106,15 +1157,15 @@ function iterate(compact::IncrementalCompact, (idx, active_bb)::Tuple{Int, Int}=
         compact.idx = last(bb.stmts)
         # Pop any remaining insertion nodes
         while compact.new_nodes_idx <= length(compact.perm)
-            entry = compact.ir.new_nodes[compact.perm[compact.new_nodes_idx]]
+            entry = compact.ir.new_nodes.info[compact.perm[compact.new_nodes_idx]]
             if !(entry.attach_after ? entry.pos <= compact.idx - 1 : entry.pos <= compact.idx)
                 break
             end
             compact.new_nodes_idx += 1
         end
         while !isempty(compact.pending_perm)
-            entry = compact.pending_nodes[compact.pending_perm[1]];
-            if !(entry.attach_after ? entry.pos <= compact.idx - 1 : entry.pos <= compact.idx)
+            info = compact.pending_nodes.info[compact.pending_perm[1]];
+            if !(info.attach_after ? info.pos <= compact.idx - 1 : info.pos <= compact.idx)
                 break
             end
             popfirst!(compact.pending_perm)
@@ -1124,32 +1175,32 @@ function iterate(compact::IncrementalCompact, (idx, active_bb)::Tuple{Int, Int}=
         if finish_current_bb!(compact, active_bb, old_result_idx, true)
             return iterate(compact, (compact.idx, active_bb + 1))
         else
-            return Pair{Int, Any}(old_result_idx, compact.result[old_result_idx]), (compact.idx, active_bb + 1)
+            return Pair{Int, Any}(old_result_idx, compact.result[old_result_idx][:inst]), (compact.idx, active_bb + 1)
         end
     end
     if compact.new_nodes_idx <= length(compact.perm) &&
-        (entry =  compact.ir.new_nodes[compact.perm[compact.new_nodes_idx]];
-         entry.attach_after ? entry.pos == idx - 1 : entry.pos == idx)
+        (info = compact.ir.new_nodes.info[compact.perm[compact.new_nodes_idx]];
+         info.attach_after ? info.pos == idx - 1 : info.pos == idx)
         new_idx = compact.perm[compact.new_nodes_idx]
         compact.new_nodes_idx += 1
-        new_node_entry = compact.ir.new_nodes[new_idx]
+        new_node_entry = compact.ir.new_nodes.stmts[new_idx]
+        new_node_info = compact.ir.new_nodes.info[new_idx]
         new_idx += length(compact.ir.stmts)
-        return process_newnode!(compact, new_idx, new_node_entry, idx, active_bb, true)
+        return process_newnode!(compact, new_idx, new_node_entry, new_node_info, idx, active_bb, true)
     elseif !isempty(compact.pending_perm) &&
-        (entry = compact.pending_nodes[compact.pending_perm[1]];
-         entry.attach_after ? entry.pos == idx - 1 : entry.pos == idx)
+        (info = compact.pending_nodes.info[compact.pending_perm[1]];
+         info.attach_after ? info.pos == idx - 1 : info.pos == idx)
         new_idx = popfirst!(compact.pending_perm)
-        new_node_entry = compact.pending_nodes[new_idx]
+        new_node_entry = compact.pending_nodes.stmts[new_idx]
+        new_node_info = compact.pending_nodes.info[new_idx]
         new_idx += length(compact.ir.stmts) + length(compact.ir.new_nodes)
-        return process_newnode!(compact, new_idx, new_node_entry, idx, active_bb, false)
+        return process_newnode!(compact, new_idx, new_node_entry, new_node_info, idx, active_bb, false)
     end
     # This will get overwritten in future iterations if
     # result_idx is not, incremented, but that's ok and expected
-    compact.result_types[old_result_idx] = compact.ir.types[idx]
-    compact.result_lines[old_result_idx] = compact.ir.lines[idx]
-    compact.result_flags[old_result_idx] = compact.ir.flags[idx]
+    compact.result[old_result_idx] = compact.ir.stmts[idx]
     result_idx = process_node!(compact, old_result_idx, compact.ir.stmts[idx], idx, idx, active_bb, true)
-    stmt_if_any = old_result_idx == result_idx ? nothing : compact.result[old_result_idx]
+    stmt_if_any = old_result_idx == result_idx ? nothing : compact.result[old_result_idx][:inst]
     compact.result_idx = result_idx
     if idx == last(bb.stmts) && !attach_after_stmt_after(compact, idx)
         finish_current_bb!(compact, active_bb, old_result_idx)
@@ -1160,19 +1211,17 @@ function iterate(compact::IncrementalCompact, (idx, active_bb)::Tuple{Int, Int}=
         idx += 1
         @goto restart
     end
-    if !isassigned(compact.result, old_result_idx)
-        @assert false
-    end
-    return Pair{Int, Any}(old_result_idx, compact.result[old_result_idx]), (compact.idx, active_bb)
+    @assert isassigned(compact.result.inst, old_result_idx)
+    return Pair{Int, Any}(old_result_idx, compact.result[old_result_idx][:inst]), (compact.idx, active_bb)
 end
 
 function maybe_erase_unused!(extra_worklist, compact, idx, callback = x->nothing)
-    stmt = compact.result[idx]
+    stmt = compact.result[idx][:inst]
     stmt === nothing && return false
     if compact_exprtype(compact, SSAValue(idx)) === Bottom
         effect_free = false
     else
-        effect_free = stmt_effect_free(stmt, compact.result_types[idx], compact, compact.ir.sptypes)
+        effect_free = stmt_effect_free(stmt, compact.result[idx][:type], compact, compact.ir.sptypes)
     end
     if effect_free
         for ops in userefs(stmt)
@@ -1189,7 +1238,7 @@ function maybe_erase_unused!(extra_worklist, compact, idx, callback = x->nothing
                 callback(val)
             end
         end
-        compact.result[idx] = nothing
+        compact.result[idx][:inst] = nothing
         return true
     end
     return false
@@ -1238,17 +1287,16 @@ end
 
 function just_fixup!(compact::IncrementalCompact)
     for idx in compact.late_fixup
-        stmt = compact.result[idx]
+        stmt = compact.result[idx][:inst]
         new_stmt = fixup_node(compact, stmt)
-        (stmt !== new_stmt) && (compact.result[idx] = new_stmt)
+        (stmt === new_stmt) || (compact.result[idx][:inst] = new_stmt)
     end
     for idx in 1:length(compact.new_new_nodes)
-        node = compact.new_new_nodes[idx]
-        new_stmt = fixup_node(compact, node.node)
-        if node.node !== new_stmt
-            compact.new_new_nodes[idx] = NewNode(
-                node.pos, node.attach_after, node.typ,
-                new_stmt, node.line)
+        node = compact.new_new_nodes.stmts[idx]
+        stmt = node[:inst]
+        new_stmt = fixup_node(compact, stmt)
+        if new_stmt !== stmt
+            node[:inst] = new_stmt
         end
     end
 end
@@ -1268,10 +1316,7 @@ end
 
 function non_dce_finish!(compact::IncrementalCompact)
     result_idx = compact.result_idx
-    resize!(compact.result, result_idx-1)
-    resize!(compact.result_types, result_idx-1)
-    resize!(compact.result_lines, result_idx-1)
-    resize!(compact.result_flags, result_idx-1)
+    resize!(compact.result, result_idx - 1)
     just_fixup!(compact)
     bb = compact.result_bbs[end]
     compact.result_bbs[end] = BasicBlock(bb,
@@ -1289,13 +1334,13 @@ end
 function complete(compact::IncrementalCompact)
     result_bbs = resize!(compact.result_bbs, compact.active_result_bb-1)
     cfg = CFG(result_bbs, Int[first(result_bbs[i].stmts) for i in 2:length(result_bbs)])
-    return IRCode(compact.ir, compact.result, compact.result_types, compact.result_lines, compact.result_flags, cfg, compact.new_new_nodes)
+    return IRCode(compact.ir, compact.result, cfg, compact.new_new_nodes)
 end
 
-function compact!(code::IRCode, allow_cfg_transforms=false)
+function compact!(code::IRCode, allow_cfg_transforms::Bool=false)
     compact = IncrementalCompact(code, allow_cfg_transforms)
     # Just run through the iterator without any processing
-    foreach(x -> nothing, compact) # x isa Pair{Int, Any}
+    for _ in compact; end # _ isa Pair{Int, Any}
     return finish(compact)
 end
 

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -116,35 +116,34 @@ end
 
 function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSAValue=#), pi_callback=(pi, idx)->false)
     while true
-        if isa(defssa, OldSSAValue) && already_inserted(compact, defssa)
-            rename = compact.ssa_rename[defssa.id]
-            if isa(rename, AnySSAValue)
-                defssa = rename
-                continue
+        if isa(defssa, OldSSAValue)
+            if already_inserted(compact, defssa)
+                rename = compact.ssa_rename[defssa.id]
+                if isa(rename, AnySSAValue)
+                    defssa = rename
+                    continue
+                end
+                return rename
             end
-            return rename
         end
         def = compact[defssa]
         if isa(def, PiNode)
             if pi_callback(def, defssa)
                 return defssa
             end
-            if isa(def.val, SSAValue)
-                if is_old(compact, defssa)
-                    defssa = OldSSAValue(def.val.id)
-                else
-                    defssa = def.val
-                end
+            def = def.val
+            if isa(def, SSAValue)
+                is_old(compact, defssa) && (def = OldSSAValue(def.id))
             else
-                return def.val
+                return def
             end
+            defssa = def
         elseif isa(def, AnySSAValue)
             pi_callback(def, defssa)
-            if isa(def, SSAValue) && is_old(compact, defssa)
-                defssa = OldSSAValue(def.id)
-            else
-                defssa = def
+            if isa(def, SSAValue)
+                is_old(compact, defssa) && (def = OldSSAValue(def.id))
             end
+            defssa = def
         elseif isa(def, Union{PhiNode, PhiCNode, Expr, GlobalRef})
             return defssa
         else
@@ -565,8 +564,9 @@ function getfield_elim_pass!(ir::IRCode, domtree::DomTree)
             # that's defined not to return its value to make life easier
             # for the backend.
             pi = insert_node_here!(compact,
-                PiNode(stmt.args[2], compact.result_types[idx]), compact.result_types[idx],
-                compact.result_lines[idx], true)
+                PiNode(stmt.args[2], compact.result[idx][:type]),
+                compact.result[idx][:type],
+                compact.result[idx][:line], true)
             compact.ssa_rename[compact.idx-1] = pi
             continue
         elseif is_known_call(stmt, (===), compact)
@@ -738,7 +738,7 @@ function getfield_elim_pass!(ir::IRCode, domtree::DomTree)
         # Find the type for this allocation
         defexpr = ir[SSAValue(idx)]
         isexpr(defexpr, :new) || continue
-        typ = ir.types[idx]
+        typ = ir.stmts[idx][:type]
         if isa(typ, UnionAll)
             typ = unwrap_unionall(typ)
         end
@@ -834,11 +834,12 @@ function getfield_elim_pass!(ir::IRCode, domtree::DomTree)
     ir
 end
 
-function adce_erase!(phi_uses, extra_worklist, compact, idx)
-    if isa(compact.result[idx], PhiNode)
-        maybe_erase_unused!(extra_worklist, compact, idx, val->phi_uses[val.id]-=1)
+function adce_erase!(phi_uses::Vector{Int}, extra_worklist::Vector{Int}, compact::IncrementalCompact, idx::Int)
+    # return whether this made a change
+    if isa(compact.result[idx][:inst], PhiNode)
+        return maybe_erase_unused!(extra_worklist, compact, idx, val -> phi_uses[val.id] -= 1)
     else
-        maybe_erase_unused!(extra_worklist, compact, idx)
+        return maybe_erase_unused!(extra_worklist, compact, idx)
     end
 end
 
@@ -857,7 +858,7 @@ function mark_phi_cycles(compact::IncrementalCompact, safe_phis::BitSet, phi::In
     while !isempty(worklist)
         phi = pop!(worklist)
         push!(safe_phis, phi)
-        for ur in userefs(compact.result[phi])
+        for ur in userefs(compact.result[phi][:inst])
             val = ur[]
             isa(val, SSAValue) || continue
             isa(compact[val], PhiNode) || continue
@@ -878,7 +879,7 @@ function adce_pass!(ir::IRCode)
     end
     non_dce_finish!(compact)
     for phi in all_phis
-        count_uses(compact.result[phi]::PhiNode, phi_uses)
+        count_uses(compact.result[phi][:inst]::PhiNode, phi_uses)
     end
     # Perform simple DCE for unused values
     extra_worklist = Int[]
@@ -919,7 +920,9 @@ function type_lift_pass!(ir::IRCode)
     type_ctx_uses = Vector{Vector{Int}}[]
     has_non_type_ctx_uses = IdSet{Int}()
     lifted_undef = IdDict{Int, Any}()
-    for (idx, stmt) in pairs(ir.stmts)
+    insts = ir.stmts
+    for idx in 1:length(insts)
+        stmt = insts[idx][:inst]
         stmt isa Expr || continue
         if (stmt.head === :isdefined || stmt.head === :undefcheck)
             val = (stmt.head === :isdefined) ? stmt.args[1] : stmt.args[2]
@@ -927,26 +930,26 @@ function type_lift_pass!(ir::IRCode)
             # node (or an UpsilonNode() argument to a PhiC node),
             # so lift all these nodes that have maybe undef values
             processed = IdDict{Int, Union{SSAValue, Bool}}()
-            while isa(val, SSAValue) && isa(ir.stmts[val.id], PiNode)
-                val = ir.stmts[val.id].val
+            while isa(val, SSAValue) && isa(insts[val.id][:inst], PiNode)
+                val = (insts[val.id][:inst]::PiNode).val
             end
-            if !isa(val, SSAValue) || (!isa(ir.stmts[val.id], PhiNode) && !isa(ir.stmts[val.id], PhiCNode))
+            if !isa(val, SSAValue) || (!isa(insts[val.id][:inst], PhiNode) && !isa(insts[val.id][:inst], PhiCNode))
                 (isa(val, GlobalRef) || isexpr(val, :static_parameter)) && continue
                 if stmt.head === :undefcheck
-                    ir.stmts[idx] = nothing
+                    insts[idx][:inst] = nothing
                 else
-                    ir.stmts[idx] = true
+                    insts[idx][:inst] = true
                 end
                 continue
             end
             stmt_id = val.id
             worklist = Tuple{Int, Int, SSAValue, Int}[(stmt_id, 0, SSAValue(0), 0)]
-            def = ir.stmts[stmt_id]
+            def = insts[stmt_id][:inst]
             if !haskey(lifted_undef, stmt_id)
                 first = true
                 while !isempty(worklist)
                     item, w_up_id, which, use = pop!(worklist)
-                    def = ir.stmts[item]
+                    def = insts[item][:inst]
                     if isa(def, PhiNode)
                         edges = copy(def.edges)
                         values = Vector{Any}(undef, length(edges))
@@ -969,24 +972,25 @@ function type_lift_pass!(ir::IRCode)
                         else
                             up_id = id = def.values[i].id
                             @label restart
-                            if !isa(ir.types[id], MaybeUndef)
+                            if !isa(ir.stmts[id][:type], MaybeUndef)
                                 val = true
                             else
-                                if isa(ir.stmts[id], UpsilonNode)
-                                    up = ir.stmts[id]
-                                    if !isdefined(up, :val)
+                                node = insts[id][:inst]
+                                if isa(node, UpsilonNode)
+                                    if !isdefined(node, :val)
                                         val = false
-                                    elseif !isa(up.val, SSAValue)
+                                    elseif !isa(node.val, SSAValue)
                                         val = true
                                     else
-                                        id = up.val.id
+                                        id = node.val.id
                                         @goto restart
                                     end
                                 else
-                                    while isa(ir.stmts[id], PiNode)
-                                        id = ir.stmts[id].val.id
+                                    while isa(node, PiNode)
+                                        id = node.val.id
+                                        node = insts[id][:inst]
                                     end
-                                    if isa(ir.stmts[id], Union{PhiNode, PhiCNode})
+                                    if isa(node, Union{PhiNode, PhiCNode})
                                         if haskey(processed, id)
                                             val = processed[id]
                                         else
@@ -1011,15 +1015,15 @@ function type_lift_pass!(ir::IRCode)
                             phi.values[use] = new_phi
                         else
                             phi = phi::PhiCNode
-                            ir[which].values[use] = insert_node!(ir, w_up_id, Bool, UpsilonNode(new_phi))
+                            phi.values[use] = insert_node!(ir, w_up_id, Bool, UpsilonNode(new_phi))
                         end
                     end
                 end
             end
             if stmt.head === :isdefined
-                ir.stmts[idx] = lifted_undef[stmt_id]
+                insts[idx][:inst] = lifted_undef[stmt_id]
             else
-                ir.stmts[idx] = Expr(:throw_undef_if_not, stmt.args[1], lifted_undef[stmt_id])
+                insts[idx][:inst] = Expr(:throw_undef_if_not, stmt.args[1], lifted_undef[stmt_id])
             end
         end
     end
@@ -1064,7 +1068,7 @@ function cfg_simplify!(ir::IRCode)
             while merged_succ[curr] != 0
                 curr = merged_succ[curr]
             end
-            terminator = ir.stmts[ir.cfg.blocks[curr].stmts[end]]
+            terminator = ir.stmts[ir.cfg.blocks[curr].stmts[end]][:inst]
             if isa(terminator, GotoNode) || isa(terminator, ReturnNode)
                 break
             end
@@ -1097,50 +1101,55 @@ function cfg_simplify!(ir::IRCode)
     for i = 1:length(result_bbs_lengths)
         bb_starts[i+1] = bb_starts[i] + result_bbs_lengths[i]
     end
-    # Look at the original successor
-    function compute_succs(i)
-        orig_bb = result_bbs[i]
-        while merged_succ[orig_bb] != 0
-            orig_bb = merged_succ[orig_bb]
-        end
-        map(i->bb_rename_succ[i], bbs[orig_bb].succs)
-    end
-
-    function compute_preds(i)
-        orig_bb = result_bbs[i]
-        preds = bbs[orig_bb].preds
-        map(preds) do pred
-            while merge_into[pred] != 0
-                pred = merge_into[pred]
+    # Figure out the pred and succ lists for each basic block in our merged result
+    cresult_bbs = let result_bbs = result_bbs,
+                      merged_succ = merged_succ,
+                      merge_into = merge_into,
+                      bbs = bbs,
+                      bb_rename_succ = bb_rename_succ
+            function compute_succs(i)
+                # Look at the original successor
+                orig_bb = result_bbs[i]
+                while merged_succ[orig_bb] != 0
+                    orig_bb = merged_succ[orig_bb]
+                end
+                newsuccs = map(i->bb_rename_succ[i], bbs[orig_bb].succs)
+                return newsuccs
             end
-            bb_rename_succ[pred]
+            function compute_preds(i)
+                orig_bb = result_bbs[i]
+                preds = bbs[orig_bb].preds
+                newpreds = map(preds) do pred
+                    while merge_into[pred] != 0
+                        pred = merge_into[pred]
+                    end
+                    bb_rename_succ[pred]
+                end
+                return newpreds
+            end
+            BasicBlock[BasicBlock(
+                StmtRange(bb_starts[i], i + 1 > length(bb_starts) ? length(compact.result) : bb_starts[i + 1] - 1),
+                compute_preds(i), compute_succs(i)) for i = 1:length(result_bbs)]
         end
-    end
-    cresult_bbs = BasicBlock[BasicBlock(
-        StmtRange(bb_starts[i], i+1 > length(bb_starts) ? length(compact.result) : bb_starts[i+1]-1),
-        compute_preds(i), compute_succs(i)) for i = 1:length(result_bbs)]
     compact = IncrementalCompact(ir, true)
-    # We're messing with the CFG. We don't want compaction to do
-    # so independently
+    # Run instruction compaction to produce the result,
+    # but we're messing with the CFG
+    # so we don't want compaction to do so independently
     compact.fold_constant_branches = false
     compact.bb_rename_succ = bb_rename_succ
     compact.bb_rename_pred = bb_rename_pred
     compact.result_bbs = cresult_bbs
-    result_idx = 1
     for (idx, orig_bb) in enumerate(result_bbs)
         ms = orig_bb
         while ms != 0
             for i in bbs[ms].stmts
-                stmt = ir.stmts[i]
-                compact.result[compact.result_idx] = nothing
-                compact.result_types[compact.result_idx] = ir.types[i]
-                compact.result_lines[compact.result_idx] = ir.lines[i]
-                compact.result_flags[compact.result_idx] = ir.flags[i]
-                # If we merged a basic block, we need remove the trailing GotoNode (if any)
-                if isa(stmt, GotoNode) && merged_succ[ms] != 0
-                    # Do nothing
+                node = ir.stmts[i]
+                compact.result[compact.result_idx] = node
+                if isa(node[:inst], GotoNode) && merged_succ[ms] != 0
+                    # If we merged a basic block, we need remove the trailing GotoNode (if any)
+                    compact.result[compact.result_idx][:inst] = nothing
                 else
-                    process_node!(compact, compact.result_idx, stmt, i, i, ms, true)
+                    process_node!(compact, compact.result_idx, node, i, i, ms, true)
                 end
                 # We always increase the result index to ensure a predicatable
                 # placement of the resulting nodes.

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -234,7 +234,7 @@ to catch up and print the intermediate scopes. Which scope is printed is indicat
 by the indentation of the method name and by an increased thickness of the appropriate
 line for the scope.
 """
-function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
+function compute_ir_line_annotations(code::IRCode)
     loc_annotations = String[]
     loc_methods = String[]
     loc_lineno = String[]
@@ -243,20 +243,12 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
     last_lineno = 0
     last_stack = []
     last_printed_depth = 0
-    stmts = (code isa IRCode ? code.stmts : code.code)
     linetable = code.linetable
-    lines = (code isa IRCode ? code.lines : code.codelocs)
-    for idx in eachindex(stmts)
+    lines = code.stmts.line
+    for idx in 1:length(lines)
         buf = IOBuffer()
-        # N.B.: The line array length not matching is invalid,
-        # but let's be robust here
-        if idx > length(lines)
-            line = Int32(0)
-            print(buf, "!")
-        else
-            line = lines[idx]
-            print(buf, "│")
-        end
+        line = lines[idx]
+        print(buf, "│")
         depth = compute_inlining_depth(linetable, line)
         iline = line
         lineno = 0
@@ -343,7 +335,7 @@ function DILineInfoPrinter(linetable::Vector, showtypes::Bool=false)
         collapse = showtypes ? false : true
         indent_all = true
         # convert lineidx to a vector
-        if lineidx < 0
+        if lineidx == typemin(Int32)
             # sentinel value: reset internal (and external) state
             pops = indent("└")
             if !isempty(pops)
@@ -508,23 +500,26 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
     cols = displaysize(io)[2]
     used = BitSet()
     stmts = code.stmts
-    types = code.types
+    isempty(stmts) && return # unlikely, but avoid errors from reducing over empty sets
     cfg = code.cfg
     max_bb_idx_size = length(string(length(cfg.blocks)))
-    for stmt in stmts
-        scan_ssa_use!(push!, used, stmt)
-    end
+    new_nodes = code.new_nodes.stmts
+    new_nodes_info = code.new_nodes.info
     bb_idx = 1
-    new_nodes = code.new_nodes
-    if any(i -> !isassigned(code.new_nodes, i), 1:length(code.new_nodes))
+    for stmt in stmts
+        scan_ssa_use!(push!, used, stmt[:inst])
+    end
+    if any(i -> !isassigned(new_nodes.inst, i), 1:length(new_nodes))
         printstyled(io, "ERROR: New node array has unset entry\n", color=:red)
-        new_nodes = new_nodes[filter(i -> isassigned(code.new_nodes, i), 1:length(code.new_nodes))]
+        new_nodes_perm = filter(i -> isassigned(new_nodes.inst, i), 1:length(new_nodes))
+    else
+        new_nodes_perm = collect(1:length(new_nodes))
     end
-    for nn in new_nodes
-        scan_ssa_use!(push!, used, nn.node)
+    for nn in new_nodes_perm
+        scan_ssa_use!(push!, used, new_nodes[nn][:inst])
     end
-    perm = sortperm(new_nodes, by = x->x.pos)
-    new_nodes_perm = Iterators.Stateful(perm)
+    sort!(new_nodes_perm, by = x -> (x = new_nodes_info[x]; (x.pos, x.attach_after)))
+    perm_idx = 1
 
     if isempty(used)
         maxlength_idx = 0
@@ -538,10 +533,10 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         max_lineno_width = maximum(length(str) for str in loc_lineno)
         max_method_width = maximum(length(str) for str in loc_methods)
     end
-    max_depth = maximum(compute_inlining_depth(code.linetable, line) for line in code.lines)
+    max_depth = maximum(compute_inlining_depth(code.linetable, stmts[i][:line]) for i in 1:length(stmts.line))
     last_stack = []
-    for idx in eachindex(stmts)
-        if !isassigned(stmts, idx)
+    for idx in 1:length(stmts)
+        if !isassigned(stmts.inst, idx)
             # This is invalid, but do something useful rather
             # than erroring, to make debugging easier
             printstyled(io, "#UNDEF\n", color=:red)
@@ -570,7 +565,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         end
         # Print linetable information
         if verbose_linetable
-            stack = compute_loc_stack(code.linetable, code.lines[idx])
+            stack = compute_loc_stack(code.linetable, stmt[:line])
             # We need to print any stack frames that did not exist in the last stack
             ndepth = max(1, length(stack))
             rail = string(" "^(max_depth+1-ndepth), "│"^ndepth)
@@ -581,7 +576,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
                     printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
                     print(io, bb_guard_rail)
                     ssa_guard = " "^(maxlength_idx + 4 + (i - 1))
-                    entry_label = "$(ssa_guard)$(method_name(entry)) at $(entry.file):$(entry.line) "
+                    entry_label = "$(ssa_guard)$(method_name(entry)) at $(entry.file):$(entry[:line]) "
                     hline = string("─"^(start_column-length(entry_label)-length(bb_guard_rail)+max_depth-i), "┐")
                     printstyled(io, string(entry_label, hline), "\n"; color=:light_black)
                     bb_guard_rail = bb_guard_rail_cont
@@ -590,9 +585,17 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
             printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
             last_stack = stack
         else
-            annotation = loc_annotations[idx]
-            loc_method = loc_methods[idx]
-            lineno = loc_lineno[idx]
+            if idx <= length(loc_annotations)
+                # N.B.: The line array length not matching is invalid,
+                # but let's be robust here
+                annotation = loc_annotations[idx]
+                loc_method = loc_methods[idx]
+                lineno = loc_lineno[idx]
+            else
+                annotation = "!"
+                loc_method = ""
+                lineno = ""
+            end
             # Print location information right aligned. If the line below is too long, it'll overwrite this,
             # but that's what we want.
             if get(io, :color, false)
@@ -609,10 +612,12 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         end
         floop = true
         # print new nodes first in the right position
-        while !isempty(new_nodes_perm) && new_nodes[Iterators.peek(new_nodes_perm)].pos == idx
-            node_idx = popfirst!(new_nodes_perm)
-            new_node = new_nodes[node_idx]
-            node_idx += length(stmts)
+        while perm_idx <= length(new_nodes_perm)
+            node_idx = new_nodes_perm[perm_idx]
+            if new_nodes_info[node_idx].pos != idx
+                break
+            end
+            perm_idx += 1
             if !floop && !verbose_linetable
                 print(io, " "^(max_lineno_width + 1))
             end
@@ -625,12 +630,16 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
             end
             print_sep = true
             floop = false
-            show_type = should_print_ssa_type(new_node.node)
+            new_node = new_nodes[node_idx]
+            node_idx += length(stmts)
+            show_type = should_print_ssa_type(new_node[:inst])
             with_output_color(:green, io) do io′
-                print_stmt(io′, node_idx, new_node.node, used, maxlength_idx, false, show_type)
+                print_stmt(io′, node_idx, new_node[:inst], used, maxlength_idx, false, show_type)
             end
-            if show_type
-                expr_type_printer(io, new_node.typ, node_idx in used)
+            if !isassigned(stmts.type, idx) # try to be robust against errors
+                printstyled(io, "::#UNDEF", color=:red)
+            elseif show_type
+                expr_type_printer(io, new_node[:type], node_idx in used)
             end
             println(io)
         end
@@ -649,14 +658,12 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         if idx == last(bbrange)
             bb_idx += 1
         end
-        show_type = should_print_ssa_type(stmt)
-        print_stmt(io, idx, stmt, used, maxlength_idx, true, show_type)
-        if !isassigned(types, idx)
-            # This is an error, but can happen if passes don't update their type information
+        show_type = should_print_ssa_type(stmt[:inst])
+        print_stmt(io, idx, stmt[:inst], used, maxlength_idx, true, show_type)
+        if !isassigned(stmts.type, idx) # try to be robust against errors
             printstyled(io, "::#UNDEF", color=:red)
         elseif show_type
-            typ = types[idx]
-            expr_type_printer(io, typ, idx in used)
+            expr_type_printer(io, stmt[:type], idx in used)
         end
         println(io)
     end
@@ -753,7 +760,7 @@ function show_ir(io::IO, code::CodeInfo, line_info_preprinter=DILineInfoPrinter(
     end
     bb_idx = 1
 
-    for idx in eachindex(code.code)
+    for idx in 1:length(stmts)
         bb_idx = show_ir_stmt(ioctx, code, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
     end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1894,6 +1894,10 @@ module IRShow
     Base.size(r::Compiler.StmtRange) = Compiler.size(r)
     Base.first(r::Compiler.StmtRange) = Compiler.first(r)
     Base.last(r::Compiler.StmtRange) = Compiler.last(r)
+    Base.length(is::Compiler.InstructionStream) = Compiler.length(is)
+    Base.iterate(is::Compiler.InstructionStream, st::Int=1) = (st <= Compiler.length(is)) ? (is[st], st + 1) : nothing
+    Base.getindex(is::Compiler.InstructionStream, idx::Int) = Compiler.getindex(is, idx)
+    Base.getindex(node::Compiler.Instruction, fld::Symbol) = Compiler.getindex(node, fld)
     include("compiler/ssair/show.jl")
 
     const __debuginfo = Dict{Symbol, Any}(

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -37,7 +37,8 @@ let m = Meta.@lower 1 + 1
     domtree = Core.Compiler.construct_domtree(ir.cfg)
     ir = Core.Compiler.domsort_ssa!(ir, domtree)
     Core.Compiler.verify_ir(ir)
-    @test isa(ir.stmts[3], Core.PhiNode) && length(ir.stmts[3].edges) == 1
+    phi = ir.stmts.inst[3]
+    @test isa(phi, Core.PhiNode) && length(phi.edges) == 1
 end
 
 # test that we don't stack-overflow in SNCA with large functions.
@@ -224,7 +225,7 @@ let m = Meta.@lower 1 + 1
     ir = Core.Compiler.cfg_simplify!(ir)
     Core.Compiler.verify_ir(ir)
     ir = Core.Compiler.compact!(ir)
-    @test length(ir.cfg.blocks) == 1 && length(ir.stmts) == 1
+    @test length(ir.cfg.blocks) == 1 && Core.Compiler.length(ir.stmts) == 1
 end
 
 let m = Meta.@lower 1 + 1
@@ -252,7 +253,7 @@ let m = Meta.@lower 1 + 1
     ir = Core.Compiler.cfg_simplify!(ir)
     Core.Compiler.verify_ir(ir)
     @test length(ir.cfg.blocks) == 5
-    ret_2 = ir.stmts[ir.cfg.blocks[3].stmts[end]]
+    ret_2 = ir.stmts.inst[ir.cfg.blocks[3].stmts[end]]
     @test isa(ret_2, Core.Compiler.ReturnNode) && ret_2.val == 2
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1778,8 +1778,8 @@ let src = code_typed(my_fun28173, (Int,), debuginfo=:source)[1][1]
     @test isempty(pop!(lines1))
     Core.Compiler.insert_node!(ir, 1, Val{1}, QuoteNode(1), false)
     Core.Compiler.insert_node!(ir, 1, Val{2}, QuoteNode(2), true)
-    Core.Compiler.insert_node!(ir, length(ir.stmts), Val{3}, QuoteNode(3), false)
-    Core.Compiler.insert_node!(ir, length(ir.stmts), Val{4}, QuoteNode(4), true)
+    Core.Compiler.insert_node!(ir, length(ir.stmts.inst), Val{3}, QuoteNode(3), false)
+    Core.Compiler.insert_node!(ir, length(ir.stmts.inst), Val{4}, QuoteNode(4), true)
     lines2 = split(repr(ir), '\n')
     @test isempty(pop!(lines2))
     @test popfirst!(lines2) == "2  1 ──       $(QuoteNode(1))"
@@ -1806,7 +1806,7 @@ end
 # with as unnamed "!" BB.
 let src = code_typed(gcd, (Int, Int), debuginfo=:source)[1][1]
     ir = Core.Compiler.inflate_ir(src)
-    push!(ir.stmts, Core.Compiler.ReturnNode())
+    push!(ir.stmts.inst, Core.Compiler.ReturnNode())
     lines = split(sprint(show, ir), '\n')
     @test isempty(pop!(lines))
     @test pop!(lines) == "   ! ──       unreachable::#UNDEF"


### PR DESCRIPTION
This is an attempt to broaden and refine the generality of the AnySSAValue abstraction to a concrete Instruction struct. This lets us make aggregate statements about a node as:
```
result[nidx][] = ir.stmts[idx]
```
instead of writing it out individually as we do now:
```
result_types[nidx] = ir.types[idx]
result_ltable[nidx] = ir.lines[idx]
result_flags[nidx] = ir.flags[idx]
```

It also means we would want to (over time) alter the API from doing conjoined operations on the new index and the old fissioned values:
```
insert_node!(ircode::IRCode, newidx, @nospecialize ir.inst[idx], @nospecialize ir.types[idx], ir.lines[idx])
```
into separate operations on the index and the content:
```
newnode = insert_node!(ircode, newidx)
newnode[] = ir.stmts[idx]
```
such that in the future manual tracking of `nidx` goes away almost entirely, and the first example just reads as `result[] = old` (while nidx is still available as a field of result). But that is mostly left as future work here.

(and yes, this is nearly precisely opposite of LLVM, which first makes the clone, then inserts it—but is also more alike to LLVM that the operations are now more separable)
(when I first wrote this ~6 months ago, I checked that the compiler seemed to generally optimize this away, since we don't yet have stack-allocated immutables. I haven't looked into that again after rebasing this PR over more than 1000 commits before making this PR however to make sure something hadn't changed.)