### PR TITLE
Make issparse handle nested wrappers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,7 +117,7 @@ Standard library changes
 
 * new `sizehint!(::SparseMatrixCSC, ::Integer)` method ([#30676]).
 * `cholesky()` now fully preserves the user-specified permutation. ([#40560])
-
+* `issparse` now applies consistently to all wrapper arrays, including nested, by checking `issparse` on the wrapped parent array ([#37644]).
 
 #### Dates
 

--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -50,17 +50,19 @@ julia> issparse(Array(sv))
 false
 ```
 """
-issparse(A::AbstractArray) = false
+function issparse(A::AbstractArray)
+    # Handle wrapper arrays: sparse if it is wrapping a sparse array.
+    # This gets compiled away during specialization.
+    p = parent(A)
+    if p === A
+        # have reached top of wrapping without finding a sparse array, assume it is not.
+        return false
+    else
+        return issparse(p)
+    end
+end
+issparse(A::DenseArray) = false
 issparse(S::AbstractSparseArray) = true
-issparse(S::LinearAlgebra.Adjoint{<:Any,<:AbstractSparseArray}) = true
-issparse(S::LinearAlgebra.Transpose{<:Any,<:AbstractSparseArray}) = true
-
-issparse(S::LinearAlgebra.Symmetric{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.Hermitian{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.LowerTriangular{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.UnitLowerTriangular{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.UpperTriangular{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.UnitUpperTriangular{<:Any,<:AbstractSparseMatrix}) = true
 
 indtype(S::AbstractSparseArray{<:Any,Ti}) where {Ti} = Ti
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2166,6 +2166,7 @@ end
     @test issparse(UpperTriangular(Array(m))) == false
     @test issparse(LinearAlgebra.UnitUpperTriangular(Array(m))) == false
     @test issparse(Base.ReshapedArray(m, (20, 5), ()))
+    @test issparse(@view m[1:3, :])
 
     # greater nesting
     @test issparse(Symmetric(UpperTriangular(m)))

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2165,6 +2165,11 @@ end
     @test issparse(LinearAlgebra.UnitLowerTriangular(Array(m))) == false
     @test issparse(UpperTriangular(Array(m))) == false
     @test issparse(LinearAlgebra.UnitUpperTriangular(Array(m))) == false
+    @test issparse(Base.ReshapedArray(m, (20, 5), ()))
+
+    # greater nesting
+    @test issparse(Symmetric(UpperTriangular(m)))
+    @test issparse(Symmetric(UpperTriangular(Array(m)))) == false
 end
 
 @testset "issparse for sparse vectors #34253" begin


### PR DESCRIPTION
Follow up to: https://github.com/JuliaLang/julia/pull/34266

Handles all the existing cases, plus:
 - arbitary nesting of wrappers
 - `SubArrays`
 - `Diagonal`


It all constant folds out:
```
julia> z = adjoint(transpose((1 + im) .*sprandn(5,5, 0.5)));

julia> @code_llvm issparse(z)

;  @ REPL[18]:2 within `issparse'
define i8 @julia_issparse_17287(%jl_value_t addrspace(10)* nonnull align 8 dereferenceable(8)) {
top:
;  @ REPL[18]:4 within `issparse'
  ret i8 1
}

julia> q = adjoint(transpose((1 + im) .*randn(5,5)));

julia> @code_llvm issparse(q)

;  @ REPL[18]:2 within `issparse'
define i8 @julia_issparse_17303(%jl_value_t addrspace(10)* nonnull align 8 dereferenceable(8)) {
top:
;  @ REPL[18]:4 within `issparse'
  ret i8 0
}
```