### PR TITLE
add `hypot` fallback for 2 Numbers of the same type

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -613,6 +613,7 @@ julia> hypot(3, 4im)
 hypot(x::Number, y::Number) = hypot(promote(x, y)...)
 hypot(x::Complex, y::Complex) = hypot(abs(x), abs(y))
 hypot(x::T, y::T) where {T<:Real} = hypot(float(x), float(y))
+hypot(x::T, y::T) where {T<:Number} = (z = y/x; abs(x) * sqrt(one(z) + z*z))
 function hypot(x::T, y::T) where T<:AbstractFloat
     #Return Inf if either or both imputs is Inf (Compliance with IEEE754)
     if isinf(x) || isinf(y)


### PR DESCRIPTION
#33224 broke `hypot` with Unitful.jl. There used to be a method for this. The weird thing is, in the current state it works if you pass 3 arguments to `hypot` but not 2, so we should probably add this.