### PR TITLE
handle `GlobalRef` in getfield elim pass

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -370,6 +370,13 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
             end
         elseif isa(leaf, QuoteNode)
             leaf = leaf.value
+        elseif isa(leaf, GlobalRef)
+            mod, name = leaf.mod, leaf.name
+            if isdefined(mod, name) && isconst(mod, name)
+                leaf = getfield(mod, name)
+            else
+                return nothing
+            end
         elseif isa(leaf, Union{Argument, Expr})
             return nothing
         end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -290,3 +290,8 @@ end
 let K = rand(2,2)
     @test test_29253(K) == 2
 end
+
+# check getfield elim handling of GlobalRef
+const _some_coeffs = (1,[2],3,4)
+splat_from_globalref(x) = (x, _some_coeffs...,)
+@test splat_from_globalref(0) == (0, 1, [2], 3, 4)


### PR DESCRIPTION
This fixes this odd failure in ODE.jl:
```
ERROR: LoadError: MethodError: no method matching size(::Symbol, ::Int64)
Closest candidates are:
  size(!Matched::BitArray{1}, ::Integer) at bitarray.jl:81
  size(!Matched::Tuple, ::Integer) at tuple.jl:22
  size(!Matched::Number, ::Integer) at number.jl:63
  ...
Stacktrace:
 [1] oderosenbrock(::var"#3#4", ::Float64, ::Array{Float64,1}, ::Float64, ::Symbol, ::Array{Float64,2}, ::Array{Float64,2}; jacobian::Nothing, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/jeff/.julia/packages/ODE/OyDLv/src/ODE.jl:386
 [2] #ode4s_s#27 at /home/jeff/.julia/packages/ODE/OyDLv/src/ODE.jl:432 [inlined]
 [3] ode4s_s(::Function, ::Float64, ::Array{Float64,1}) at /home/jeff/.julia/packages/ODE/OyDLv/src/ODE.jl:432
```

The getfield elim pass was treating a `GlobalRef` as literal data and fetching the Symbol out of it. That was exposed by #32437, which allowed inlining the resulting Symbol constant.