### PR TITLE
Build all the targets we build in SuiteSparse artifacts:

### DIFF
--- a/deps/suitesparse.mk
+++ b/deps/suitesparse.mk
@@ -16,8 +16,8 @@ CHOLMOD_CONFIG += -DNPARTITION
 
 ifneq ($(USE_BINARYBUILDER_SUITESPARSE), 1)
 
-SUITESPARSE_PROJECTS := AMD CAMD CCOLAMD COLAMD CHOLMOD UMFPACK SPQR
-SUITESPARSE_LIBS := $(addsuffix .*$(SHLIB_EXT)*,suitesparseconfig amd camd ccolamd colamd cholmod umfpack spqr)
+SUITESPARSE_PROJECTS := AMD BTF CAMD CCOLAMD COLAMD CHOLMOD LDL KLU UMFPACK RBio SPQR
+SUITESPARSE_LIBS := $(addsuffix .*$(SHLIB_EXT)*,suitesparseconfig amd btf camd ccolamd colamd cholmod klu umfpack rbio spqr)
 
 SUITE_SPARSE_LIB := $(LDFLAGS) -L"$(abspath $(BUILDDIR))/SuiteSparse-$(SUITESPARSE_VER)/lib"
 ifeq ($(OS), Darwin)


### PR DESCRIPTION
https://github.com/JuliaPackaging/Yggdrasil/blob/master/S/SuiteSparse%405/build_tarballs.jl

The artifacts SuiteSparse build does quite a bit more. This at least builds all the same libraries, but does not link against metis (which is only used if found, but keeps the same API). Essentially this should not be used for anything except for development.