### PR TITLE
Generate an error for closure cfunctions on unsupported platforms.

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -47,7 +47,7 @@ Note that the argument type tuple must be a literal tuple, and not a tuple-value
 (although it can include a splat expression). And that these arguments will be evaluated in global scope
 during compile-time (not deferred until runtime).
 Adding a '\\\$' in front of the function argument changes this to instead create a runtime closure
-over the local variable `callable`.
+over the local variable `callable` (this is not supported on all architectures).
 
 See [manual section on ccall and cfunction usage](@ref Calling-C-and-Fortran-Code).
 

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -945,6 +945,10 @@ function qsort(a::Vector{T}, cmp) where T
 end
 ```
 
+!!! note
+    Closure [`@cfunction`](@ref) rely on LLVM trampolines, which are not available on all
+    platforms (for example ARM and PowerPC).
+
 
 ## Closing a Library
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5084,6 +5084,12 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
     }
 
     bool nest = (!fexpr_rt.constant || unionall_env);
+#if defined(_CPU_AARCH64_) || defined(_CPU_ARM_) || defined(_CPU_PPC64_)
+    if (nest) {
+        emit_error(ctx, "cfunction: closures are not supported on this platform");
+        return jl_cgval_t();
+    }
+#endif
     Value *F = gen_cfun_wrapper(
             jl_Module,
             sig, fexpr_rt.constant,

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -27,6 +27,7 @@
  *      CPU/Architecture:
  *          _CPU_X86_
  *          _CPU_X86_64_
+ *          _CPU_AARCH64_
  *          _CPU_ARM_
  *          _CPU_WASM_
  */

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -6,6 +6,9 @@ using InteractiveUtils: code_llvm
 
 import Libdl
 
+# for cfunction_closure
+include("testenv.jl")
+
 const libccalltest = "libccalltest"
 
 const verbose = false
@@ -791,6 +794,8 @@ end
 ## cfunction roundtrip
 
 verbose && Libc.flush_cstdio()
+
+if cfunction_closure
 verbose && println("Testing cfunction closures: ")
 
 # helper Type for testing that constructors work
@@ -972,6 +977,12 @@ for (t, v) in ((Complex{Int32}, :ci32), (Complex{Int64}, :ci64),
             @test_throws TypeError ccall(cf, Any, (Ref{Any},), $v)
         end
     end
+end
+
+else
+
+@test_broken "cfunction: no support for closures on this platform"
+
 end
 
 # issue 13031

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -32,4 +32,8 @@ if !@isdefined(testenv_defined)
     const curmod_name = fullname(curmod)
     const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
     const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+
+    # platforms that support cfunction with closures
+    # (requires LLVM back-end support for trampoline intrinsics)
+    const cfunction_closure = Sys.ARCH === :x86_64 || Sys.ARCH === :i686
 end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -4,6 +4,9 @@ using Test
 using Base.Threads
 using Base.Threads: SpinLock
 
+# for cfunction_closure
+include("testenv.jl")
+
 # threading constructs
 
 let a = zeros(Int, 2 * nthreads())
@@ -460,10 +463,12 @@ function test_thread_cfunction()
     end
     @test sum(ok) == 10000
 end
-if nthreads() == 1
-    test_thread_cfunction()
-else
-    @test_broken "cfunction trampoline code not thread-safe"
+if cfunction_closure
+    if nthreads() == 1
+        test_thread_cfunction()
+    else
+        @test_broken "cfunction trampoline code not thread-safe"
+    end
 end
 
 # Compare the two ways of checking if threading is enabled.


### PR DESCRIPTION
Work around the fatal errors on ARM and PPC (https://github.com/JuliaLang/julia/issues/27174 and https://github.com/JuliaLang/julia/issues/32154) when compiling closure cfunctions, because that blocks nightlies from getting generated. The LLVM PPC back-end does seem to support trampolines though, so we could probably fix that if somebody cares.