### PR TITLE
Enable color output whenever stdout is TTY

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,9 +51,8 @@ Language changes
   used to yield the string " a\nb", since the single space before `b` set the indent level.
   Now the result is "a\n b", since the space before `b` is no longer considered to occur
   at the start of a line. The old behavior is considered a bug ([#35001]).
-  
-* Color now defaults to on when stdout and stderr are TTYs ([#34347])
 
+* Color now defaults to on when stdout and stderr are TTYs ([#34347])
 
 Multi-threading changes
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@ Language changes
   used to yield the string " a\nb", since the single space before `b` set the indent level.
   Now the result is "a\n b", since the space before `b` is no longer considered to occur
   at the start of a line. The old behavior is considered a bug ([#35001]).
+  
+* Color now defaults to on when stdout and stderr are TTYs ([#34347])
 
 
 Multi-threading changes

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -241,6 +241,7 @@ include("filesystem.jl")
 using .Filesystem
 include("cmd.jl")
 include("process.jl")
+include("ttyhascolor.jl")
 include("grisu/grisu.jl")
 include("secretbuffer.jl")
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -493,7 +493,7 @@ function _start()
         invokelatest(display_error, catch_stack())
         exit(1)
     end
-    if is_interactive && have_color
+    if is_interactive && have_color === true
         print(color_normal)
     end
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -112,7 +112,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
     have_color = get(stdout, :color, false)
     while true
         try
-            if have_color === true
+            if have_color
                 print(color_normal)
             end
             if lasterr !== nothing
@@ -124,7 +124,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
                 value = Core.eval(Main, ast)
                 ccall(:jl_set_global, Cvoid, (Any, Any, Any), Main, :ans, value)
                 if !(value === nothing) && show_value
-                    if have_color === true
+                    if have_color
                         print(answer_color())
                     end
                     try

--- a/base/client.jl
+++ b/base/client.jl
@@ -112,7 +112,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
     have_color = get(stdout, :color, false)
     while true
         try
-            if have_color
+            if have_color === true
                 print(color_normal)
             end
             if lasterr !== nothing
@@ -124,7 +124,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
                 value = Core.eval(Main, ast)
                 ccall(:jl_set_global, Cvoid, (Any, Any, Any), Main, :ans, value)
                 if !(value === nothing) && show_value
-                    if have_color
+                    if have_color === true
                         print(answer_color())
                     end
                     try
@@ -493,7 +493,7 @@ function _start()
         invokelatest(display_error, catch_stack())
         exit(1)
     end
-    if is_interactive && have_color
+    if is_interactive && have_color === true
         print(color_normal)
     end
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -223,6 +223,11 @@ function exec_options(opts)
     global have_color     = (opts.color == 1) # --color=on
     global is_interactive = (opts.isinteractive != 0)
 
+    #check if stdout is TTY and color is not set manually
+    if isa(stdout, TTY) && !color_set
+        global have_color = true
+    end
+
     # pre-process command line argument list
     arg_is_program = !isempty(ARGS)
     repl = !arg_is_program

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1169,10 +1169,11 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
             eval(Meta.parse(code))
         end
         """
+
     io = open(pipeline(`$(julia_cmd()) -O0
                        --output-ji $output --output-incremental=yes
                        --startup-file=no --history-file=no --warn-overwrite=yes
-                       --color=$(have_color ? "yes" : "no")
+                       --color=$(have_color === true ? "yes" : "no")
                        --eval $code_object`, stderr=stderr),
               "w", stdout)
     in = io.in

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -485,29 +485,6 @@ function displaysize(io::TTY)
     return h, w
 end
 
-function ttyhascolor()
-    term_type = get(ENV, "TERM","")
-    startswith(term_type, "xterm") && return true
-    try
-        @static if Sys.KERNEL === :FreeBSD
-            return success("tput AF 0")
-        else
-            return success("tput setaf 0")
-        end
-    catch
-        return false
-    end
-end
-function get_have_color()
-    global have_color
-    have_color === nothing && (have_color = ttyhascolor())
-    return have_color::Bool
-end
-in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === get_have_color()
-haskey(::TTY, key::Symbol) = key === :color
-getindex(::TTY, key::Symbol) = key === :color ? get_have_color() : throw(KeyError(key))
-get(::TTY, key::Symbol, default) = key === :color ? get_have_color() : default
-
 ### Libuv callbacks ###
 
 ## BUFFER ##

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -485,10 +485,28 @@ function displaysize(io::TTY)
     return h, w
 end
 
-in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === have_color
+function ttyhascolor()
+    term_type = get(ENV, "TERM","")
+    startswith(term_type, "xterm") && return true
+    try
+        @static if Sys.KERNEL === :FreeBSD
+            return success("tput AF 0")
+        else
+            return success("tput setaf 0")
+        end
+    catch
+        return false
+    end
+end
+function get_have_color()
+    global have_color
+    have_color === nothing && (have_color = ttyhascolor())
+    return have_color::Bool
+end
+in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === get_have_color()
 haskey(::TTY, key::Symbol) = key === :color
-getindex(::TTY, key::Symbol) = key === :color ? have_color : throw(KeyError(key))
-get(::TTY, key::Symbol, default) = key === :color ? have_color : default
+getindex(::TTY, key::Symbol) = key === :color ? get_have_color() : throw(KeyError(key))
+get(::TTY, key::Symbol, default) = key === :color ? get_have_color() : default
 
 ### Libuv callbacks ###
 

--- a/base/ttyhascolor.jl
+++ b/base/ttyhascolor.jl
@@ -1,0 +1,24 @@
+function ttyhascolor()
+    term_type = get(ENV, "TERM","")
+    startswith(term_type, "xterm") && return true
+    try
+        @static if Sys.KERNEL === :FreeBSD
+            return success(`tput AF 0`)
+        else
+            return success(`tput setaf 0`)
+        end
+    catch e
+        return false
+    end
+end
+function get_have_color()
+    global have_color
+    have_color === nothing && (have_color = ttyhascolor())
+    return have_color
+end
+in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === get_have_color()
+haskey(::TTY, key::Symbol) = key === :color
+getindex(::TTY, key::Symbol) = key === :color ? get_have_color() : throw(KeyError(key))
+get(::TTY, key::Symbol, default) = key === :color ? get_have_color() : default
+
+

--- a/base/ttyhascolor.jl
+++ b/base/ttyhascolor.jl
@@ -1,24 +1,25 @@
-function ttyhascolor()
-    term_type = get(ENV, "TERM","")
-    startswith(term_type, "xterm") && return true
-    try
-        @static if Sys.KERNEL === :FreeBSD
-            return success(`tput AF 0`)
-        else
-            return success(`tput setaf 0`)
+if Sys.iswindows()
+    ttyhascolor(term_type = nothing) = true
+else
+    function ttyhascolor(term_type = get(ENV, "TERM", ""))
+        startswith(term_type, "xterm") && return true
+        try
+            @static if Sys.KERNEL === :FreeBSD
+                return success(`tput AF 0`)
+            else
+                return success(`tput setaf 0`)
+            end
+        catch e
+            return false
         end
-    catch e
-        return false
     end
 end
 function get_have_color()
     global have_color
     have_color === nothing && (have_color = ttyhascolor())
-    return have_color
+    return have_color::Bool
 end
 in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === get_have_color()
 haskey(::TTY, key::Symbol) = key === :color
 getindex(::TTY, key::Symbol) = key === :color ? get_have_color() : throw(KeyError(key))
 get(::TTY, key::Symbol, default) = key === :color ? get_have_color() : default
-
-

--- a/base/ttyhascolor.jl
+++ b/base/ttyhascolor.jl
@@ -14,7 +14,7 @@ end
 function get_have_color()
     global have_color
     have_color === nothing && (have_color = ttyhascolor())
-    return have_color
+    return have_color::Bool
 end
 in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === get_have_color()
 haskey(::TTY, key::Symbol) = key === :color

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1168,17 +1168,17 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     dopushdisplay = !in(d,Base.Multimedia.displays)
     dopushdisplay && pushdisplay(d)
     while !eof(repl.stream)
-        if have_color
+        if have_color === true
             print(repl.stream,repl.prompt_color)
         end
         print(repl.stream, "julia> ")
-        if have_color
+        if have_color === true
             print(repl.stream, input_color(repl))
         end
         line = readline(repl.stream, keep=true)
         if !isempty(line)
             ast = Base.parse_input_line(line)
-            if have_color
+            if have_color === true
                 print(repl.stream, Base.color_normal)
             end
             response = eval_with_backend(ast, backend)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1168,17 +1168,17 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     dopushdisplay = !in(d,Base.Multimedia.displays)
     dopushdisplay && pushdisplay(d)
     while !eof(repl.stream)
-        if have_color === true
+        if have_color
             print(repl.stream,repl.prompt_color)
         end
         print(repl.stream, "julia> ")
-        if have_color === true
+        if have_color
             print(repl.stream, input_color(repl))
         end
         line = readline(repl.stream, keep=true)
         if !isempty(line)
             ast = Base.parse_input_line(line)
-            if have_color === true
+            if have_color
                 print(repl.stream, Base.color_normal)
             end
             response = eval_with_backend(ast, backend)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1162,7 +1162,7 @@ function ends_with_semicolon(line::AbstractString)
 end
 
 function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
-    have_color = Base.have_color
+    have_color = get(repl.stream, :color, false)
     Base.banner(repl.stream)
     d = REPLDisplay(repl)
     dopushdisplay = !in(d,Base.Multimedia.displays)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -248,6 +248,7 @@ mutable struct BasicREPL <: AbstractREPL
 end
 
 outstream(r::BasicREPL) = r.terminal
+hascolor(r::BasicREPL) = hascolor(r.terminal)
 
 function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
     d = REPLDisplay(repl)
@@ -374,13 +375,14 @@ mutable struct LineEditREPL <: AbstractREPL
     interface::ModalInterface
     backendref::REPLBackendRef
     LineEditREPL(t,hascolor,prompt_color,input_color,answer_color,shell_color,help_color,history_file,in_shell,in_help,envcolors) =
-        new(t,true,prompt_color,input_color,answer_color,shell_color,help_color,history_file,in_shell,
+        new(t,hascolor,prompt_color,input_color,answer_color,shell_color,help_color,history_file,in_shell,
             in_help,envcolors,false,nothing, Options(), nothing)
 end
 outstream(r::LineEditREPL) = r.t
 specialdisplay(r::LineEditREPL) = r.specialdisplay
 specialdisplay(r::AbstractREPL) = nothing
 terminal(r::LineEditREPL) = r.t
+hascolor(r::LineEditREPL) = r.hascolor
 
 LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) =
     LineEditREPL(t, hascolor,
@@ -759,7 +761,7 @@ function respond(f, repl, main; pass_empty = false, suppress_on_semicolon = true
                 response = (catch_stack(), true)
             end
             hide_output = suppress_on_semicolon && ends_with_semicolon(line)
-            print_response(repl, response, !hide_output, Base.have_color)
+            print_response(repl, response, !hide_output, hascolor(repl))
         end
         prepare_next(repl)
         reset_state(s)
@@ -906,7 +908,7 @@ function setup_interface(
             end
             hist_from_file(hp, f, hist_path)
         catch
-            print_response(repl, (catch_stack(),true), true, Base.have_color)
+            print_response(repl, (catch_stack(),true), true, hascolor(repl))
             println(outstream(repl))
             @info "Disabling history file for this session"
             repl.history_file = false
@@ -1104,6 +1106,7 @@ StreamREPL(stream::IO) = StreamREPL(stream, Base.text_colors[:green], Base.input
 run_repl(stream::IO) = run_repl(StreamREPL(stream))
 
 outstream(s::StreamREPL) = s.stream
+hascolor(s::StreamREPL) = get(s.stream, :color, false)
 
 answer_color(r::LineEditREPL) = r.envcolors ? Base.answer_color() : r.answer_color
 answer_color(r::StreamREPL) = r.answer_color
@@ -1162,7 +1165,7 @@ function ends_with_semicolon(line::AbstractString)
 end
 
 function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
-    have_color = get(repl.stream, :color, false)
+    have_color = hascolor(repl)
     Base.banner(repl.stream)
     d = REPLDisplay(repl)
     dopushdisplay = !in(d,Base.Multimedia.displays)

--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -152,22 +152,7 @@ beep(t::UnixTerminal) = write(t.err_stream,"\x7")
 
 Base.displaysize(t::UnixTerminal) = displaysize(t.out_stream)
 
-if Sys.iswindows()
-    hascolor(t::TTYTerminal) = true
-else
-    function hascolor(t::TTYTerminal)
-        startswith(t.term_type, "xterm") && return true
-        try
-            @static if Sys.KERNEL === :FreeBSD
-                return success(`tput AF 0`)
-            else
-                return success(`tput setaf 0`)
-            end
-        catch
-            return false
-        end
-    end
-end
+hascolor(t::TTYTerminal) = Base.ttyhascolor(t.term_type)
 
 # use cached value of have_color
 Base.in(key_value::Pair, t::TTYTerminal) = in(key_value, pipe_writer(t))

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -51,7 +51,10 @@ function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_
     repl.options = options
 
     hard_kill = kill_timer(900) # Your debugging session starts now. You have 15 minutes. Go.
+    @eval Base old_have_color = have_color
+    @eval Base have_color = false
     f(input.in, output.out, repl)
+    @eval Base have_color = old_have_color
     t = @async begin
         close(input.in)
         close(output.in)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -47,14 +47,11 @@ function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_
     Base.link_pipe!(output, reader_supports_async=true, writer_supports_async=true)
     Base.link_pipe!(err, reader_supports_async=true, writer_supports_async=true)
 
-    repl = REPL.LineEditREPL(FakeTerminal(input.out, output.in, err.in), true)
+    repl = REPL.LineEditREPL(FakeTerminal(input.out, output.in, err.in, options.hascolor), options.hascolor)
     repl.options = options
 
     hard_kill = kill_timer(900) # Your debugging session starts now. You have 15 minutes. Go.
-    @eval Base old_have_color = have_color
-    @eval Base have_color = false
     f(input.in, output.out, repl)
-    @eval Base have_color = old_have_color
     t = @async begin
         close(input.in)
         close(output.in)
@@ -93,7 +90,7 @@ end
 # in the mix. If verification needs to be done, keep it to the bare minimum. Basically
 # this should make sure nothing crashes without depending on how exactly the control
 # characters are being used.
-fake_repl() do stdin_write, stdout_read, repl
+fake_repl(options = REPL.Options(confirm_exit=false,hascolor=false)) do stdin_write, stdout_read, repl
     repl.specialdisplay = REPL.REPLDisplay(repl)
     repl.history_file = false
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -51,7 +51,10 @@ function fake_repl(@nospecialize(f); options::REPL.Options=REPL.Options(confirm_
     repl.options = options
 
     hard_kill = kill_timer(900) # Your debugging session starts now. You have 15 minutes. Go.
+    # @eval Base old_have_color = have_color
+    # @eval Base have_color = false
     f(input.in, output.out, repl)
+    # @eval Base have_color = old_have_color
     t = @async begin
         close(input.in)
         close(output.in)


### PR DESCRIPTION
Fixes #34317 . Made a check if STDOUT is a TTY and color is not set explicitly by the user , then set global variable have_color to true.
In my opinion , there should be separate have_color variable for STDOUT and STDERR, since we can have separate TTY for STDOUT and STDERR