### PR TITLE
Force full collection in SharedArrays tests

### DIFF
--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -145,9 +145,9 @@ finalize(S)
 
 # call gc 3 times to avoid unlink: operation not permitted (EPERM) on Windows
 S = nothing
-@everywhere GC.gc()
-@everywhere GC.gc()
-@everywhere GC.gc()
+@everywhere GC.gc(true)
+@everywhere GC.gc(true)
+@everywhere GC.gc(true)
 rm(fn); rm(fn2); rm(fn3)
 
 ### Utility functions
@@ -288,7 +288,7 @@ let
     id = a1.id
     aorig = nothing
     a1 = remotecall_fetch(fill!, id_other, a1, 1.0)
-    GC.gc(); GC.gc()
+    GC.gc(true); GC.gc(true)
     a1 = remotecall_fetch(fill!, id_other, a1, 1.0)
     @test haskey(SharedArrays.sa_refs, id)
     finalize(a1)


### PR DESCRIPTION
Fixes the same CI failure as https://github.com/JuliaLang/julia/pull/34336,
but hopefully should be immediately mergeable without objection about what
the interface is.