### PR TITLE
Make RegexMatch iterable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@ Standard library changes
   `keep` that are to be kept as they are. ([#38597]).
 * `getindex` can now be used on `NamedTuple`s with multiple values ([#38878])
 * `keys(::RegexMatch)` is now defined to return the capture's keys, by name if named, or by index if not ([#37299]).
+* `RegexMatch` now iterate to give their captures. ([#34355]).
 
 #### Package Manager
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -166,7 +166,7 @@ function show(io::IO, m::RegexMatch)
         for (i, capture_name) in enumerate(capture_keys)
             print(io, capture_name, "=")
             show(io, m.captures[i])
-            if i < length(m.captures)
+            if i < length(m)
                 print(io, ", ")
             end
         end
@@ -189,6 +189,10 @@ function haskey(m::RegexMatch, name::Symbol)
     return idx > 0
 end
 haskey(m::RegexMatch, name::AbstractString) = haskey(m, Symbol(name))
+
+iterate(m::RegexMatch, args...) = iterate(m.captures, args...)
+length(m::RegexMatch) = length(m.captures)
+eltype(m::RegexMatch) = eltype(m.captures)
 
 function occursin(r::Regex, s::AbstractString; offset::Integer=0)
     compile(r)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -167,6 +167,24 @@
         @test r"this|that"^2 == r"(?:this|that){2}"
     end
 
+    @testset "iterate" begin
+        m = match(r"(.) test (.+)", "a test 123")
+        @test first(m) == "a"
+        @test collect(m) == ["a", "123"]
+        for (i, capture) in enumerate(m)
+            i == 1 && @test capture == "a"
+            i == 2 && @test capture == "123"
+        end
+    end
+
+    @testset "Destructuring dispatch" begin
+        handle(::Nothing) = "not found"
+        handle((capture,)::RegexMatch) = "found $capture"
+
+        @test handle(match(r"a (\d)", "xyz")) == "not found"
+        @test handle(match(r"a (\d)", "a 1")) == "found 1"
+    end
+
     # Test that PCRE throws the correct kind of error
     # TODO: Uncomment this once the corresponding change has propagated to CI
     #@test_throws ErrorException Base.PCRE.info(C_NULL, Base.PCRE.INFO_NAMECOUNT, UInt32)


### PR DESCRIPTION
Look at the tests.
Isn't this a nice feature?

In general its weird to define `getindex` without matching `iterate`.