### PR TITLE
fix doc syntax of @ macroexpand

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -119,10 +119,11 @@ Return equivalent expression with all macros removed (expanded).
 There are differences between `@macroexpand` and [`macroexpand`](@ref).
 
 * While [`macroexpand`](@ref) takes a keyword argument `recursive`, `@macroexpand`
-is always recursive. For a non recursive macro version, see [`@macroexpand1`](@ref).
+  is always recursive. For a non recursive macro version, see [`@macroexpand1`](@ref).
 
 * While [`macroexpand`](@ref) has an explicit `module` argument, `@macroexpand` always
-expands with respect to the module in which it is called.
+  expands with respect to the module in which it is called.
+
 This is best seen in the following example:
 ```julia-repl
 julia> module M


### PR DESCRIPTION
fixes doc string of `@macroexpand`

[Before](https://docs.julialang.org/en/v1/base/base/#Base.@macroexpand):
![image](https://user-images.githubusercontent.com/40514306/72251455-482e7600-3641-11ea-8f57-0647b6dd0b12.png)

After:
![image](https://user-images.githubusercontent.com/40514306/72251547-64321780-3641-11ea-8726-d3704cc5c1b3.png)
