### PR TITLE
Revert "`fixup-libgfortran.sh`: Use `patchelf` instead of parsing `ldd` output"

### DIFF
--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -36,7 +36,7 @@ find_shlib()
     lib_path="$1"
     if [ -f "$lib_path" ]; then
         if [ "$UNAME" = "Linux" ]; then
-            "${PATCHELF}" --print-needed "$lib_path" | grep $2 | xargs
+            ldd "$lib_path" | grep $2 | grep -v "not found" | cut -d' ' -f3 | xargs
         else # $UNAME is "Darwin", we only have two options, see above
             otool -L "$lib_path" | grep $2 | cut -d' ' -f1 | xargs
         fi
@@ -50,7 +50,7 @@ find_shlib_dir()
     # only get something like `@rpath/libgfortran.5.dylib` when inspecting the
     # libraries.  We can, as a last resort, ask `$FC` directly what the full
     # filepath for this library is, but only if we don't have a direct path to it:
-    if [ $(dirname "$1") = "@rpath" ] || [ $(dirname "$1") = "." ]; then
+    if [ $(dirname "$1") = "@rpath" ]; then
         dirname "$($FC -print-file-name="$(basename "$1")" 2>/dev/null)"
     else
         dirname "$1" 2>/dev/null
@@ -62,25 +62,19 @@ for lib in lapack blas openblas; do
     for private_libname in ${private_libdir}/lib$lib*.$SHLIB_EXT*; do
         # Find the paths to the libraries we're interested in.  These are almost
         # always within the same directory, but we like to be general.
-        LIBGFORTRAN_PATH="$(find_shlib "$private_libname" libgfortran)"
+        LIBGFORTRAN_PATH=$(find_shlib "$private_libname" libgfortran)
+        LIBGCC_PATH=$(find_shlib "$private_libname" libgcc_s)
+        LIBQUADMATH_PATH=$(find_shlib "$private_libname" libquadmath)
 
         # Take the directories, add them onto LIBGFORTRAN_DIRS, which we use to
         # search for these libraries in the future.  If there is no directory, try
         # asking `$FC` where such a file could be found.
-        LIBGFORTRAN_DIR="$(find_shlib_dir "$LIBGFORTRAN_PATH")"
-        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $LIBGFORTRAN_DIR"
-
-        # Save the SONAME
-        LIBGFORTRAN_SONAME="$(basename "$LIBGFORTRAN_PATH")"
-        LIBGFORTRAN_SONAMES="$LIBGFORTRAN_SONAMES $LIBGFORTRAN_SONAME"
-
-
-        # Now that we've (maybe) found a libgfortran, ask _it_ for things like libgcc_s and libquadmath:
-        LIBGCC_PATH="$(find_shlib "${LIBGFORTRAN_DIR}/${LIBGFORTRAN_SONAME}" libgcc_s)"
-        LIBQUADMATH_PATH="$(find_shlib "${LIBGFORTRAN_DIR}/${LIBGFORTRAN_SONAME}" libquadmath)"
-
+        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(find_shlib_dir $LIBGFORTRAN_PATH)"
         LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(find_shlib_dir $LIBGCC_PATH)"
         LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(find_shlib_dir $LIBQUADMATH_PATH)"
+
+        # Save the SONAMES
+        LIBGFORTRAN_SONAMES="$LIBGFORTRAN_SONAMES $(basename "$LIBGFORTRAN_PATH")"
         LIBGCC_SONAMES="$LIBGCC_SONAMES $(basename "$LIBGCC_PATH")"
         LIBQUADMATH_SONAMES="$LIBQUADMATH_SONAMES $(basename "$LIBQUADMATH_PATH")"
     done


### PR DESCRIPTION
This reverts https://github.com/JuliaLang/julia/pull/34155, which breaks the ARM/AArch64 binaries:

```
WARNING: Error during initialization of module LinearAlgebra:
ErrorException("could not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directory")
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
WARNING: Error during initialization of module LinearAlgebra:
ErrorException("could not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directory")
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
WARNING: Error during initialization of module LinearAlgebraWARNING: Error during initialization of module LinearAlgebraWARNING: Error during initialization of module LinearAlgebra:
:
:
ErrorException(ErrorException(ErrorException("""could not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directorycould not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directorycould not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directory""")))
WARNING: Error during initialization of module LinearAlgebra:
ErrorException("could not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directory")
WARNING: Error during initialization of module LinearAlgebraWARNING: Error during initialization of module LinearAlgebra:
:
ErrorException(ErrorException(""could not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directorycould not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directory""))
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
��� Error: Error during initialization of module CHOLMOD
���   exception =
���    could not load library "libcholmod"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] dlopen(::String, ::UInt32; throw_error::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109
���     [2] dlopen at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Libdl/src/Libdl.jl:109 [inlined] (repeats 2 times)
���     [3] __init__() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:90
��� @ SuiteSparse.CHOLMOD /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/SuiteSparse/src/cholmod.jl:177
��� Warning: a hook from a library to disable threading failed:
���   exception =
���    could not load library "libopenblas"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] set_num_threads at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/blas.jl:115 [inlined]
���     [2] (::LinearAlgebra.var"#199#200")() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:448
���     [3] disable_library_threading() at ./initdefs.jl:343
���     [4] handle_msg(::Distributed.JoinPGRPMsg, ::Distributed.MsgHeader, ::Sockets.TCPSocket, ::Sockets.TCPSocket, ::VersionNumber) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:343
���     [5] message_handler_loop(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:173
���     [6] process_tcp_streams(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:142
���     [7] (::Distributed.var"#97#98"{Sockets.TCPSocket,Sockets.TCPSocket,Bool})() at ./task.jl:358
��� @ Base initdefs.jl:345
��� Warning: a hook from a library to disable threading failed:
���   exception =
���    could not load library "libopenblas"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] set_num_threads at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/blas.jl:115 [inlined]
���     [2] (::LinearAlgebra.var"#199#200")() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:448
���     [3] disable_library_threading() at ./initdefs.jl:343
���     [4] handle_msg(::Distributed.JoinPGRPMsg, ::Distributed.MsgHeader, ::Sockets.TCPSocket, ::Sockets.TCPSocket, ::VersionNumber) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:343
���     [5] message_handler_loop(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:173
���     [6] process_tcp_streams(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:142
���     [7] (::Distributed.var"#97#98"{Sockets.TCPSocket,Sockets.TCPSocket,Bool})() at ./task.jl:358
��� @ Base initdefs.jl:345
��� Warning: a hook from a library to disable threading failed:
���   exception =
���    could not load library "libopenblas"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] set_num_threads at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/blas.jl:115 [inlined]
���     [2] (::LinearAlgebra.var"#199#200")() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:448
���     [3] disable_library_threading() at ./initdefs.jl:343
���     [4] handle_msg(::Distributed.JoinPGRPMsg, ::Distributed.MsgHeader, ::Sockets.TCPSocket, ::Sockets.TCPSocket, ::VersionNumber) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:343
���     [5] message_handler_loop(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:173
���     [6] process_tcp_streams(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:142
���     [7] (::Distributed.var"#97#98"{Sockets.TCPSocket,Sockets.TCPSocket,Bool})() at ./task.jl:358
��� @ Base initdefs.jl:345
��� Warning: a hook from a library to disable threading failed:
���   exception =
���    could not load library "libopenblas"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] set_num_threads at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/blas.jl:115 [inlined]
���     [2] (::LinearAlgebra.var"#199#200")() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:448
���     [3] disable_library_threading() at ./initdefs.jl:343
���     [4] handle_msg(::Distributed.JoinPGRPMsg, ::Distributed.MsgHeader, ::Sockets.TCPSocket, ::Sockets.TCPSocket, ::VersionNumber) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:343
���     [5] message_handler_loop(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:173
���     [6] process_tcp_streams(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:142
���     [7] (::Distributed.var"#97#98"{Sockets.TCPSocket,Sockets.TCPSocket,Bool})() at ./task.jl:358
��� @ Base initdefs.jl:345
��� Warning: a hook from a library to disable threading failed:
���   exception =
���    could not load library "libopenblas"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] set_num_threads at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/blas.jl:115 [inlined]
���     [2] (::LinearAlgebra.var"#199#200")() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:448
���     [3] disable_library_threading() at ./initdefs.jl:343
���     [4] handle_msg(::Distributed.JoinPGRPMsg, ::Distributed.MsgHeader, ::Sockets.TCPSocket, ::Sockets.TCPSocket, ::VersionNumber) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:343
���     [5] message_handler_loop(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:173
���     [6] process_tcp_streams(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:142
���     [7] (::Distributed.var"#97#98"{Sockets.TCPSocket,Sockets.TCPSocket,Bool})() at ./task.jl:358
��� @ Base initdefs.jl:345
��� Warning: a hook from a library to disable threading failed:
���   exception =
���    could not load library "libopenblas"
���    libgfortran.so.4: cannot open shared object file: No such file or directory
���    Stacktrace:
���     [1] set_num_threads at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/blas.jl:115 [inlined]
���     [2] (::LinearAlgebra.var"#199#200")() at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:448
���     [3] disable_library_threading() at ./initdefs.jl:343
���     [4] handle_msg(::Distributed.JoinPGRPMsg, ::Distributed.MsgHeader, ::Sockets.TCPSocket, ::Sockets.TCPSocket, ::VersionNumber) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:343
���     [5] message_handler_loop(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:173
���     [6] process_tcp_streams(::Sockets.TCPSocket, ::Sockets.TCPSocket, ::Bool) at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/Distributed/src/process_messages.jl:142
���     [7] (::Distributed.var"#97#98"{Sockets.TCPSocket,Sockets.TCPSocket,Bool})() at ./task.jl:358
��� @ Base initdefs.jl:345
ERROR: LoadError: could not load library "libopenblas"
libgfortran.so.4: cannot open shared object file: No such file or directory
Stacktrace:
 [1] set_num_threads at /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/blas.jl:115 [inlined]
 [2] (::var"#44#53")() at /buildworker/worker/tester_linuxaarch64/build/share/julia/test/runtests.jl:72
 [3] cd(::var"#44#53", ::String) at ./file.jl:104
 [4] top-level scope at /buildworker/worker/tester_linuxaarch64/build/share/julia/test/runtests.jl:67
 [5] include(::Module, ::String) at ./Base.jl:377
 [6] exec_options(::Base.JLOptions) at ./client.jl:288
 [7] _start() at ./client.jl:484
```

Although I can't replicate on my AArch64 box, there is an obvious difference:

```
tim@xavier /tmp$ ldd working/bin/julia
        linux-vdso.so.1 (0x0000007f7fe55000)
        libjulia.so.1 => /tmp/working/bin/../lib/libjulia.so.1 (0x0000007f7f80f000)
        libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000007f7f7e8000)
        librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000007f7f7d1000)
        libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000007f7f7a5000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000007f7f64c000)
        libLLVM-8.so => /tmp/working/bin/../lib/julia/libLLVM-8.so (0x0000007f7cffb000)
        libstdc++.so.6 => /tmp/working/bin/../lib/julia/libstdc++.so.6 (0x0000007f7ce69000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000007f7cdaf000)
        libgcc_s.so.1 => /tmp/working/bin/../lib/julia/libgcc_s.so.1 (0x0000007f7cd8b000)
        /lib/ld-linux-aarch64.so.1 (0x0000007f7fe2a000)
tim@xavier /tmp$ ldd broken/bin/julia
        linux-vdso.so.1 (0x0000007fa47c3000)
        libjulia.so.1 => /tmp/broken/bin/../lib/libjulia.so.1 (0x0000007fa417d000)
        libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000007fa4156000)
        librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000007fa413f000)
        libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000007fa4113000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000007fa3fba000)
        libLLVM-8.so => /tmp/broken/bin/../lib/julia/libLLVM-8.so (0x0000007fa1969000)
        libstdc++.so.6 => /tmp/broken/bin/../lib/julia/libstdc++.so.6 (0x0000007fa17d7000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000007fa171d000)
        libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000007fa16f9000)
        /lib/ld-linux-aarch64.so.1 (0x0000007fa4798000)
```

Notice `libgcc_s.so.1`, which isn't present in the tarball post https://github.com/JuliaLang/julia/pull/34155.