### PR TITLE
Eliminate erroneous quoting on `${PATCHELF}`

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -940,7 +940,7 @@ endif
 # explicitly tell it to use this large page size so that when we rewrite rpaths and
 # such, we don't accidentally create incorrectly-aligned sections in our ELF files.
 ifneq (,$(filter $(ARCH),aarch64 powerpc64le))
-PATCHELF += --page-size=65536
+PATCHELF += --page-size 65536
 endif
 
 # Use ILP64 BLAS interface when building openblas from source on 64-bit architectures

--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -36,7 +36,7 @@ find_shlib()
     lib_path="$1"
     if [ -f "$lib_path" ]; then
         if [ "$UNAME" = "Linux" ]; then
-            "${PATCHELF}" --print-needed "$lib_path" | grep $2 | xargs
+            ${PATCHELF} --print-needed "$lib_path" | grep $2 | xargs
         else # $UNAME is "Darwin", we only have two options, see above
             otool -L "$lib_path" | grep $2 | cut -d' ' -f1 | xargs
         fi

--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -8,7 +8,7 @@ PATCHELF=${PATCHELF:-patchelf}
 # If we're invoked with "--verbose", create a `debug` function that prints stuff out
 if [ "$1" = "--verbose" ] || [ "$1" = "-v" ]; then
 shift 1
-debug() { echo "$*"; }
+debug() { echo "$*" >&2; }
 else
 debug() { :; }
 fi


### PR DESCRIPTION
This only manifests on platforms like `aarch64` and `ppc64le` because we
force extra arguments to `PATCHELF` in these cases which didn't interact
well with these well-meaning quotes.