### PR TITLE
track-allocation: charge entry cost to caller

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2789,9 +2789,13 @@ JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void)
     return newtb - oldtb;
 }
 
-void jl_gc_sync_total_bytes(void)
+JL_DLLEXPORT int64_t jl_gc_sync_total_bytes(int64_t offset)
 {
-    jl_gc_get_total_bytes(&last_gc_total_bytes);
+    int64_t oldtb = last_gc_total_bytes;
+    int64_t newtb;
+    jl_gc_get_total_bytes(&newtb);
+    last_gc_total_bytes = newtb - offset;
+    return newtb - oldtb;
 }
 
 JL_DLLEXPORT int64_t jl_gc_live_bytes(void)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -315,7 +315,7 @@ JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz);
 JL_DLLEXPORT void JL_NORETURN jl_throw_out_of_memory_error(void);
 
 JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
-void jl_gc_sync_total_bytes(void);
+JL_DLLEXPORT int64_t jl_gc_sync_total_bytes(int64_t offset);
 void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a) JL_NOTSAFEPOINT;
 void jl_gc_count_allocd(size_t sz) JL_NOTSAFEPOINT;
 void jl_gc_run_all_finalizers(jl_ptls_t ptls);

--- a/test/testhelpers/allocation_file.jl
+++ b/test/testhelpers/allocation_file.jl
@@ -1,0 +1,8 @@
+g(x) = x + 123456
+function f(x)
+    []
+    Base.invokelatest(g, 0)
+    Base.invokelatest(g, x)
+    []
+end
+f(1.23)


### PR DESCRIPTION
This effectively makes two related changes:
1. Completely removes one-time costs of runtime functions (aka "warmup costs") from being charged to the user's code. This was already being partly subtracted in some cases (depending on whether we hit a malloc record point) resulting in both over- and under- reporting of the user's allocations. However, theoretically these costs are implementation details that the user doesn't specifically care about, and should thus be charged against the internal allocation budget instead. (This implements #19981 and should make `Profile.clear_malloc_data()` less necessary, and just get the desired answer on the first pass). In the future, we can continue to sharpen this if people report cases I've missed. We can also even create a bin to put these in so that they continue to be reported, but just charged against the correct cause.
2. Adjust where entry point costs are charged against. Previously we charged the callee for any setup costs incurred by the caller. That sometimes wasn't too bad, but other times would result in very large numbers being added the the first instruction in the user's function. Now, we'll charge those against the caller, so you won't see that happen anymore. Instead those costs should now show up on the line of code that actually incurred them.