### PR TITLE
alternative fix for mul!

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -20,22 +20,29 @@ julia> MulAddMul(12, 34)(56, 78) == 56 * 12 + 78 * 34
 true
 ```
 """
-struct MulAddMul{ais1, bis0, TA, TB}
+struct MulAddMul{TA, TB}
     alpha::TA
     beta::TB
+    ais1::Bool
+    bis0::Bool
 end
 
 MulAddMul(alpha::TA, beta::TB) where {TA, TB} =
-    MulAddMul{isone(alpha), iszero(beta), TA, TB}(alpha, beta)
+    MulAddMul{TA, TB}(alpha, beta, isone(alpha), iszero(beta))
 
 MulAddMul() = MulAddMul(true, false)
 
-@inline (::MulAddMul{true})(x) = x
-@inline (p::MulAddMul{false})(x) = x * p.alpha
-@inline (::MulAddMul{true, true})(x, _) = x
-@inline (p::MulAddMul{false, true})(x, _) = x * p.alpha
-@inline (p::MulAddMul{true, false})(x, y) = x + y * p.beta
-@inline (p::MulAddMul{false, false})(x, y) = x * p.alpha + y * p.beta
+
+@inline (p::MulAddMul)(x) = p.ais1 ? x : x * p.alpha
+
+@inline function (p::MulAddMul)(x, y)
+    x_mul_a = p.ais1 ? x : x * p.alpha
+    if p.bis0
+        return x_mul_a
+    else
+        return x_mul_a + y * p.beta
+    end
+end
 
 """
     _modify!(_add::MulAddMul, x, C, idx)
@@ -59,14 +66,13 @@ julia> C
  123.0
 ```
 """
-@inline @propagate_inbounds function _modify!(p::MulAddMul{ais1, bis0},
-                                              x, C, idx′) where {ais1, bis0}
+@inline @propagate_inbounds function _modify!(p::MulAddMul, x, C, idx′)
     # `idx′` may be an integer, a tuple of integer, or a `CartesianIndex`.
     #  Let `CartesianIndex` constructor normalize them so that it can be
     # used uniformly.  It also acts as a workaround for performance penalty
     # of splatting a number (#29114):
     idx = CartesianIndex(idx′)
-    if bis0
+    if p.bis0
         C[idx] = p(x)
     else
         C[idx] = p(x, C[idx])


### PR DESCRIPTION
Currently, the `MulAddMul` is implemented as a callable structure for calculating a short-circuit version of `x * a + y * b` depending on whether a is 1 or b is 0. The short-circuit is implemented with "[value types](https://docs.julialang.org/en/v1/manual/types/#"Value-types"-1)" on a pair of Booleans (ais1, bis0). This may lead to a performance regression on master, possibly due to constant propagation, details at https://github.com/JuliaLang/LinearAlgebra.jl/issues/684

This is an alternative way to fix https://github.com/JuliaLang/LinearAlgebra.jl/issues/684 by implementing the short-circuit callable structure `MulAddMul` differently, where the short-circuiting is done in the function body rather than depending on the dispatch system for the value type (ais1, bis0). The 3-argument `mul!` here might be a bit slower compared with 1.3.1 (~7-10 ns on my testings), not sure how to improve, but this might be less brittle than constant propagation?

test script:
```
using LinearAlgebra
using BenchmarkTools

ndim = 3
al = .5;
bt = .7im;

m1 = rand(ComplexF64,ndim,ndim);
m2 = rand(ComplexF64,ndim,ndim);
ou = rand(ComplexF64,ndim,ndim);

@btime mul!($ou, $m1, $m2);
@btime mul!($ou, $m1, $m2, $al, $bt);
@btime mul!($ou, $m1, $m2, .5, .7im);
```


on 1.3.1:
Julia Version 1.3.1
Commit 2d5741174c* (2019-12-30 21:36 UTC)

>   35.637 ns (0 allocations: 0 bytes)
>   350.521 ns (3 allocations: 112 bytes)
>   54.422 ns (0 allocations: 0 bytes)


on master:
Julia Version 1.5.0-DEV.71
Commit 15d693b0ec (2020-01-15 18:13 UTC)

>   397.612 ns (1 allocation: 16 bytes)
>   369.288 ns (3 allocations: 80 bytes)
>   371.888 ns (3 allocations: 80 bytes)

this PR:
Julia Version 1.5.0-DEV.72
Commit 20f2720891 (2020-01-15 20:16 UTC)

>   45.862 ns (0 allocations: 0 bytes)
>   59.554 ns (0 allocations: 0 bytes)
>   61.749 ns (0 allocations: 0 bytes)