### PR TITLE
mark `inbounds` and `loopinfo` as quoted during lowering

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -273,7 +273,8 @@
 
 ;; predicates and accessors
 
-(define (quoted? e) (memq (car e) '(quote top core globalref outerref line break inert meta)))
+(define (quoted? e)
+  (memq (car e) '(quote top core globalref outerref line break inert meta inbounds loopinfo)))
 (define (quotify e) `',e)
 (define (unquote e)
   (if (and (pair? e) (memq (car e) '(quote inert)))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1986,3 +1986,11 @@ i0xb23hG = @id_for_kwarg let x = 1
 end
 @test i0xb23hG() == 2
 @test i0xb23hG(x=10) == 10
+
+@test @eval let
+    (z,)->begin
+        $(Expr(:inbounds, true))
+        $(Expr(:inbounds, :pop))
+    end
+    pop = 1
+end == 1


### PR DESCRIPTION
This fixes errors that can happen when a variable called `pop` and inbounds expressions coexist.