### PR TITLE
Use unchecked conversion in bitcounting operations. NFC.

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -337,7 +337,7 @@ julia> count_ones(7)
 3
 ```
 """
-count_ones(x::BitInteger) = Int(ctpop_int(x))
+count_ones(x::BitInteger) = ctpop_int(x) % Int
 
 """
     leading_zeros(x::Integer) -> Integer
@@ -350,7 +350,7 @@ julia> leading_zeros(Int32(1))
 31
 ```
 """
-leading_zeros(x::BitInteger) = Int(ctlz_int(x))
+leading_zeros(x::BitInteger) = ctlz_int(x) % Int
 
 """
     trailing_zeros(x::Integer) -> Integer
@@ -363,7 +363,7 @@ julia> trailing_zeros(2)
 1
 ```
 """
-trailing_zeros(x::BitInteger) = Int(cttz_int(x))
+trailing_zeros(x::BitInteger) = cttz_int(x) % Int
 
 """
     count_zeros(x::Integer) -> Integer


### PR DESCRIPTION
LLVM's intrinsics for bitcounting return an integer of the same size as
the input integer. On the julia side, we then trunc back to `Int` (since
we're guaranteed that the answers will always be at most `log2(x)`). However,
the code was calling for a checked conversion, rather than an unchecked one.
This doesn't matter too much as LLVM does know about the result range of these
intrinsics, but it made me sad to generate all these error checks in the first
place, so use the unchecked variants instead.