### PR TITLE
RFC: Add `Lockable{T, L<:AbstractLock}` struct

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@ Language changes
 
 Multi-threading changes
 -----------------------
-
+* There is a new struct `Lockable{T, L<:AbstractLock}` that makes it easy to bundle a resource and its lock together.
 
 Build system changes
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -656,6 +656,7 @@ export
     istaskfailed,
     lock,
     notify,
+    Lockable,
     ReentrantLock,
     schedule,
     task_local_storage,

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -210,17 +210,6 @@ function lock(f, l::Lockable)
     end
 end
 
-function trylock(f, l::Lockable)
-    if trylock(l.lock)
-        try
-            return f(l.value)
-        finally
-            unlock(l.lock)
-        end
-    end
-    return false
-end
-
 # implement the rest of the Lock interface on Lockable
 islocked(l::Lockable) = islocked(l.lock)
 lock(l::Lockable) = lock(l.lock)

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -164,6 +164,52 @@ function lock(f, l::AbstractLock)
     end
 end
 
+"""
+Lockable(value, lock = ReentrantLock())
+
+Creates a `Lockable` object that wraps `value` and
+associates it with the provided `lock`.
+
+!!! compat "Julia 1.5"
+    Requires at least Julia 1.5.
+"""
+struct Lockable{T, L<:AbstractLock}
+    value::T
+    lock::L
+end
+
+"""
+
+Lockable(value)
+
+Creates a `Lockable` object that wraps `value` and
+associates it with a newly created `ReentrantLock`.
+
+!!! compat "Julia 1.5"
+    Requires at least Julia 1.5.
+"""
+Lockable(value) = Lockable(value, ReentrantLock())
+
+"""
+    lock(f::Function, l::Lockable)
+
+Acquire the lock associated with `l`, execute `f` with the lock held,
+and release the lock when `f` returns. `f` will receive one positional
+argument: the value wrapped by `l`. If the lock is already locked by a
+different task/thread, wait for it to become available.
+
+When this function returns, the `lock` has been released, so the caller should
+not attempt to `unlock` it.
+
+!!! compat "Julia 1.5"
+    Requires at least Julia 1.5.
+"""
+function lock(f, l::Lockable)
+    lock(l.lock) do
+        f(l.value)
+    end
+end
+
 function trylock(f, l::AbstractLock)
     if trylock(l)
         try

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -210,6 +210,23 @@ function lock(f, l::Lockable)
     end
 end
 
+function trylock(f, l::Lockable)
+    if trylock(l.lock)
+        try
+            return f(l.value)
+        finally
+            unlock(l.lock)
+        end
+    end
+    return false
+end
+
+# implement the rest of the Lock interface on Lockable
+islocked(l::Lockable) = islocked(l.lock)
+lock(l::Lockable) = lock(l.lock)
+trylock(l::Lockable) = trylock(l.lock)
+unlock(l::Lockable) = unlock(l.lock)
+
 function trylock(f, l::AbstractLock)
     if trylock(l)
         try

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -108,6 +108,36 @@ let l = ReentrantLock()
     @test_throws ErrorException unlock(l)
 end
 
+# Lockable{T, L<:AbstractLock}
+let # test the constructor `Lockable(value, lock)`
+    lockable = Lockable(Dict("foo" => "hello"), ReentrantLock())
+    @test lockable.value["foo"] == "hello"
+    lock(lockable) do d
+        @test d["foo"] == "hello"
+    end
+    lock(lockable) do d
+        d["foo"] = "goodbye"
+    end
+    @test lockable.value["foo"] == "goodbye"
+    lock(lockable) do d
+        @test d["foo"] == "goodbye"
+    end
+end
+let # test the constructor `Lockable(value)`
+    lockable = Lockable(Dict("foo" => "hello"))
+    @test lockable.value["foo"] == "hello"
+    lock(lockable) do d
+        @test d["foo"] == "hello"
+    end
+    lock(lockable) do d
+        d["foo"] = "goodbye"
+    end
+    @test lockable.value["foo"] == "goodbye"
+    lock(lockable) do d
+        @test d["foo"] == "goodbye"
+    end
+end
+
 # task switching
 
 @noinline function f6597(c)


### PR DESCRIPTION
I find myself using this pattern a lot, so I'm curious if it would be worth adding to `Base`.

The basic idea is that there is some object that should only ever be accessed when its corresponding lock is held, so it makes sense to package the object and its lock together into a single object.

Here is the code that this PR adds to `base/lock.jl`:

```julia
struct Lockable{T, L<:AbstractLock}
    value::T
    lock::L
end

Lockable(value) = Lockable(value, ReentrantLock())

function lock(f, l::Lockable)
    lock(l.lock) do
        f(l.value)
    end
end
```

## Example usage:

```julia
julia> function foo(x::Lockable)
           lock(x) do value
               push!(value, value[end-1] + value[end])
           end
       end
foo (generic function with 1 method)

julia> bar = Lockable([1, 1], ReentrantLock())

julia> foo(bar)
3-element Array{Int64,1}:
 1
 1
 2

julia> foo(bar)
4-element Array{Int64,1}:
 1
 1
 2
 3

julia> foo(bar)
5-element Array{Int64,1}:
 1
 1
 2
 3
 5
```
