### PR TITLE
Remove checked conversions in two more cases. NFC.

### DIFF
--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -8,7 +8,7 @@ integer. If a `maxsignif` argument is provided, then `b < maxsignif`.
     U = uinttype(T)
     uf = reinterpret(U, f)
     m = uf & significand_mask(T)
-    e = Int((uf & exponent_mask(T)) >> significand_bits(T))
+    e = ((uf & exponent_mask(T)) >> significand_bits(T)) % Int
 
     ## Step 1
     #  mf * 2^ef == f

--- a/base/special/rem_pio2.jl
+++ b/base/special/rem_pio2.jl
@@ -138,7 +138,8 @@ function paynehanek(x::Float64)
     X = (u & significand_mask(Float64)) | (one(UInt64) << significand_bits(Float64))
     # Get k from formula above
     # k = exponent(x)-52
-    k = Int((u & exponent_mask(Float64)) >> significand_bits(Float64)) - exponent_bias(Float64) - significand_bits(Float64)
+    raw_exponent = ((u & exponent_mask(Float64)) >> significand_bits(Float64)) % Int
+    k = raw_exponent - exponent_bias(Float64) - significand_bits(Float64)
 
     # 2. Let α = 1/2π, then:
     #


### PR DESCRIPTION
Like #34398, but in a different place. I also realized there was a good reason to
do this beside personal preference: Once we start tracking nothrow more closely (to
optimize try/catch, etc.), we we'll want to make sure not to emit error paths that the
julia optimizer itself can't eliminate.