### PR TITLE
Fix #34414: remove legacy doc content [skip ci]

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -384,19 +384,6 @@ to point to different objects.
 Where required, mutable composite objects can be declared with the keyword [`mutable struct`](@ref), to be
 discussed in the next section.
 
-Immutable composite types with no fields are singletons; there can be only one instance of such types:
-
-```jldoctest
-julia> struct NoFields
-       end
-
-julia> NoFields() === NoFields()
-true
-```
-
-The [`===`](@ref) function confirms that the "two" constructed instances of `NoFields` are actually one
-and the same. Singleton types are described in further detail [below](@ref man-singleton-types).
-
 There is much more to say about how instances of composite types are created, but that discussion
 depends on both [Parametric Types](@ref) and on [Methods](@ref), and is sufficiently important
 to be addressed in its own section: [Constructors](@ref man-constructors).


### PR DESCRIPTION
Remove the paragraphs saying "Immutable composite types with no fields are singletons".

Previously, `MutableNoFields() === MutableNoFields()`, but this was changed in #25854. When that got changed, the existing docs was tweaked to say that the struct had to be immutable(#25862) . However, there is no longer anything specific about it having no fields. The docs about singletons can thus just be removed since they are not special anymore.