### PR TITLE
add supertypes(T) function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ New library features
 Standard library changes
 ------------------------
 * The `@timed` macro now returns a `NamedTuple` ([#34149])
+* New `supertypes(T)` function returns a tuple of all supertypes of `T` ([#34419]).
 
 #### LinearAlgebra
 * The BLAS submodule now supports the level-2 BLAS subroutine `hpmv!` ([#34211]).

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -6,6 +6,7 @@ InteractiveUtils.varinfo
 InteractiveUtils.versioninfo
 InteractiveUtils.methodswith
 InteractiveUtils.subtypes
+InteractiveUtils.supertypes
 InteractiveUtils.edit(::AbstractString, ::Integer)
 InteractiveUtils.edit(::Any)
 InteractiveUtils.@edit

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -3,7 +3,7 @@
 module InteractiveUtils
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
-    versioninfo, subtypes, @which, @edit, @less, @functionloc, @code_warntype,
+    versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
     @code_typed, @code_lowered, @code_llvm, @code_native, clipboard
 
 import Base.Docs.apropos
@@ -238,6 +238,24 @@ julia> subtypes(Integer)
 ```
 """
 subtypes(x::Type) = _subtypes_in(Base.loaded_modules_array(), x)
+
+"""
+    supertypes(T::Type)
+
+Return a tuple `(T, ..., Any)` of `T` and all its supertypes, in order of `<:`, terminated by `Any`.
+
+# Examples
+```jldoctest
+julia> supertypes(Int)
+(Int64, Signed, Integer, Real, Number, Any)
+```
+"""
+function supertypes(T::Type)
+    S = supertype(T)
+    # note: we return a tuple here, not an Array as for subtypes, because in
+    #       the future we could evaluate this function statically if desired.
+    return S === T ? (T,) : (T, supertypes(S)...)
+end
 
 # dumptype is for displaying abstract type hierarchies,
 # based on Jameson Nash's typetree.jl in https://github.com/JuliaArchive/Examples

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -242,7 +242,9 @@ subtypes(x::Type) = _subtypes_in(Base.loaded_modules_array(), x)
 """
     supertypes(T::Type)
 
-Return a tuple `(T, ..., Any)` of `T` and all its supertypes, in order of `<:`, terminated by `Any`.
+Return a tuple `(T, ..., Any)` of `T` and all its supertypes, as determined by
+successive calls to the the [`supertype`](@ref) function, listed in order of `<:`
+and terminated by `Any`.
 
 # Examples
 ```jldoctest

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -23,6 +23,12 @@ struct B20086{T,N} <: A20086{T,N} end
 @test subtypes(A20086{T,3} where T) == [B20086{T,3} where T]
 @test subtypes(A20086{Int,3}) == [B20086{Int,3}]
 
+# supertypes
+@test supertypes(B20086) == (B20086, A20086, Any)
+@test supertypes(B20086{Int}) == (B20086{Int}, A20086{Int}, Any)
+@test supertypes(B20086{Int,2}) == (B20086{Int,2}, A20086{Int,2}, Any)
+@test supertypes(Any) == (Any,)
+
 # code_warntype
 module WarnType
 using Test, Random, InteractiveUtils


### PR DESCRIPTION
Closes #34362, adding this function to InteractiveUtils along with `subtypes`.

Unlike `subtypes`, returns a tuple instead of an array, just in case we ever decide that we want this function to work statically (since it can). 