### PR TITLE
Test copy for ReshapedArray of SparseMatrixCSC

### DIFF
--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2823,4 +2823,11 @@ end
     @test adjoint(B)*adjoint(complex.(A)) ≈ adjoint(Array(B)) * adjoint(Array(complex.(A)))
 end
 
+@testset "copy a ReshapedArray of SparseMatrixCSC" begin
+    A = sprand(20, 10, 0.2)
+    rA = reshape(A, 10, 20)
+    crA = copy(rA)
+    @test reshape(crA, 20, 10) == A
+end
+
 end # module


### PR DESCRIPTION
Seems [uncovered](https://codecov.io/gh/JuliaLang/julia/src/4254045d215275bd84bb83993e293ac818977b43/stdlib/SparseArrays/src/sparsematrix.jl#L285). Checked with `@which` and this should call the right method.