### PR TITLE
Force `clang`-based platforms to choose a cxx ABI

### DIFF
--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -6,7 +6,7 @@
 
 # Auto-detect triplet once, create different versions that we use as defaults below for each BB install target
 # This is much more efficient than launching `gcc` and `python` once for each BB install target.
-BB_TRIPLET_GCCABI_CXXABI := $(shell python $(JULIAHOME)/contrib/normalize_triplet.py $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' )")
+BB_TRIPLET_GCCABI_CXXABI := $(shell python $(JULIAHOME)/contrib/normalize_triplet.py $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(or $(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' ),1)")
 BB_TRIPLET_GCCABI := $(subst $(SPACE),-,$(filter-out cxx%,$(subst -,$(SPACE),$(BB_TRIPLET_GCCABI_CXXABI))))
 BB_TRIPLET_CXXABI := $(subst $(SPACE),-,$(filter-out gcc%,$(subst -,$(SPACE),$(BB_TRIPLET_GCCABI_CXXABI))))
 BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out gcc%,$(subst -,$(SPACE),$(BB_TRIPLET_GCCABI_CXXABI)))))


### PR DESCRIPTION
MacOS and FreeBSD are `clang` based, and so don't typically care about
our cxxstring ABI versioning, but we still build them because it is
_possible_ to use `g++` with `libstdc++` on MacOS and FreeBSD, so we
still need to build the two versions.  For the typical case, however,
the julia that is built by `clang` won't care which one you use, and so
this ensures that we just download the `cxx11` one by default.