### PR TITLE
Update parallel-computing.md

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -341,8 +341,8 @@ julia> old_is
 4-element Array{Float64,1}:
  0.0
  1.0
- 7.0
  3.0
+ 6.0
 
 julia> ids
 4-element Array{Float64,1}:


### PR DESCRIPTION
I got a different result on my system when i ran the following codeblock
```julia-repl
julia> i = Threads.Atomic{Int}(0);

julia> ids = zeros(4);

julia> old_is = zeros(4);

julia> Threads.@threads for id in 1:4
           old_is[id] = Threads.atomic_add!(i, id)
           ids[id] = id
       end
```
The result gotten in the julia manual is
``` julia-repl
julia> old_is
4-element Array{Float64,1}:
 0.0
 1.0
 7.0
 3.0
````
While on my system i got
```julia-repl
julia> ids
4-element Array{Float64,1}:
 0.0
 1.0
 3.0
 6.0
````
