### PR TITLE
Improve error message for character literal

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2264,9 +2264,12 @@
                                                   b))
                                   (loop (read-char (ts:port s))))))
                      (let ((str (tostr #f b)))
-                       (if (= (string-length str) 1)
-                           (string.char str 0)
-                           (error "character literal contains multiple characters")))))))
+                       (let ((len (string-length str)))
+                         (if (= len 1)
+                             (string.char str 0)
+                             (if (= len 0)
+                                 (error "invalid empty character literal")
+                                 (error "character literal contains multiple characters")))))))))
 
           ;; symbol/expression quote
           ((eq? t ':)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2266,7 +2266,7 @@
                      (let ((str (tostr #f b)))
                        (if (= (string-length str) 1)
                            (string.char str 0)
-                           (error "invalid character literal")))))))
+                           (error "character literal contains multiple characters")))))))
 
           ;; symbol/expression quote
           ((eq? t ':)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1994,3 +1994,9 @@ end
     end
     pop = 1
 end == 1
+
+# issue #29982
+@test Meta.parse("'a'") == 'a'
+@test Meta.parse("'\U0061'") == 'a'
+test_parseerror("''", "invalid empty character literal")
+test_parseerror("'abc'", "character literal contains multiple characters")


### PR DESCRIPTION
Modified the error message emitted when character literal have 2 or more characters.
fixes #29982