### PR TITLE
base/libc.jl: fix crash when run before epoch

### DIFF
--- a/base/libc.jl
+++ b/base/libc.jl
@@ -398,6 +398,6 @@ rand(::Type{Float64}) = rand(UInt32) * 2.0^-32
 
 Interface to the C `srand(seed)` function.
 """
-srand(seed=floor(time())) = ccall(:srand, Cvoid, (Cuint,), seed)
+srand(seed=floor(Int, time()) % Cuint) = ccall(:srand, Cvoid, (Cuint,), seed)
 
 end # module


### PR DESCRIPTION
Fixes #34056

This makes sure Libc.srand() does what srand() in C would do if supplied with a negative value.

```sh
$ faketime -f "1969-01-01 00:00:00" ./julia -e 'println([ccall(:rand, Cint, ()) for _ in 1:4])'
Int32[1569920243, 1857134397, 196762781, 1154924542]
```

Matches the output in C:
```sh
$ cc x.c &&  faketime -f "1969-01-01 00:00:00" ./a.out
seed 4263449296:        1569920243 1857134397 196762781 1154924542 
seed 4263449296:        1569920243 1857134397 196762781 1154924542
```

```c
#include <limits.h>
#include <stdio.h>
#include <stdlib.h>
#include <time.h>

void showrand(unsigned int seed) {
  srand(seed);
  printf("seed %u:\t", seed);
  for (int i = 0; i < 4; i++) {
    printf("%i ", rand());
  }
  printf("\n");
}

int main() {
  long int t1 = time(NULL);
  long int t2 = UINT_MAX + t1 + 1; // t1 is negative

  showrand(t1);
  showrand(t2);
  return 0;
}
```