### PR TITLE
replace mantissa with significand in docstring

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -579,7 +579,7 @@ hash(x::Float32, h::UInt) = hash(Float64(x), h)
     precision(num::AbstractFloat)
 
 Get the precision of a floating point number, as defined by the effective number of bits in
-the mantissa.
+the significand.
 """
 function precision end
 


### PR DESCRIPTION
The word "significand" is more frequently used in the docs and the function names than "mantissa" and I think we should stick to a single word for consistency, at least places visible to users.