### PR TITLE
Fix deadlock in windows profiler

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -721,6 +721,7 @@ typedef struct {
 
 // Might be called from unmanaged thread
 uint64_t jl_getUnwindInfo(uint64_t dwBase);
+uint64_t jl_trygetUnwindInfo(uint64_t dwBase);
 #ifdef _OS_WINDOWS_
 #include <dbghelp.h>
 JL_DLLEXPORT EXCEPTION_DISPOSITION __julia_personality(
@@ -757,7 +758,7 @@ size_t rec_backtrace(jl_bt_element_t *bt_data, size_t maxsize, int skip) JL_NOTS
 // Record backtrace from a signal handler. `ctx` is the context of the code
 // which was asynchronously interrupted.
 size_t rec_backtrace_ctx(jl_bt_element_t *bt_data, size_t maxsize, bt_context_t *ctx,
-                         jl_gcframe_t *pgcstack) JL_NOTSAFEPOINT;
+                         jl_gcframe_t *pgcstack, int lockless) JL_NOTSAFEPOINT;
 #ifdef LIBOSXUNWIND
 size_t rec_backtrace_ctx_dwarf(jl_bt_element_t *bt_data, size_t maxsize, bt_context_t *ctx, jl_gcframe_t *pgcstack) JL_NOTSAFEPOINT;
 #endif

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -233,7 +233,7 @@ void jl_critical_error(int sig, bt_context_t *context, jl_bt_element_t *bt_data,
     if (context) {
         // Must avoid extended backtrace frames here unless we're sure bt_data
         // is properly rooted.
-        *bt_size = n = rec_backtrace_ctx(bt_data, JL_MAX_BT_SIZE, context, NULL);
+        *bt_size = n = rec_backtrace_ctx(bt_data, JL_MAX_BT_SIZE, context, NULL, 1);
     }
     for (i = 0; i < n; i += jl_bt_entry_size(bt_data + i)) {
         jl_print_bt_entry_codeloc(bt_data + i);

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -142,7 +142,7 @@ static void jl_throw_in_thread(int tid, mach_port_t thread, jl_value_t *exceptio
     if (!ptls2->safe_restore) {
         assert(exception);
         ptls2->bt_size = rec_backtrace_ctx(ptls2->bt_data, JL_MAX_BT_SIZE,
-                                           (bt_context_t*)&state, ptls2->pgcstack);
+                                           (bt_context_t*)&state, ptls2->pgcstack, 0);
         ptls2->sig_exception = exception;
     }
     jl_call_in_state(ptls2, &state, &jl_sig_throw);
@@ -448,7 +448,7 @@ void *mach_profile_listener(void *arg)
 
                 if (forceDwarf == 0) {
                     // Save the backtrace
-                    bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
+                    bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL, 1);
                 }
                 else if (forceDwarf == 1) {
                     bt_size_cur += rec_backtrace_ctx_dwarf((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -176,7 +176,7 @@ static void jl_throw_in_ctx(jl_ptls_t ptls, jl_value_t *e, int sig, void *sigctx
 {
     if (!ptls->safe_restore)
         ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE,
-                                          jl_to_bt_context(sigctx), ptls->pgcstack);
+                                          jl_to_bt_context(sigctx), ptls->pgcstack, 0);
     ptls->sig_exception = e;
     jl_call_in_ctx(ptls, &jl_sig_throw, sig, sigctx);
 }
@@ -670,7 +670,7 @@ static void *signal_listener(void *arg)
             if (critical) {
                 bt_size += rec_backtrace_ctx(bt_data + bt_size,
                         JL_MAX_BT_SIZE / jl_n_threads - 1,
-                        signal_context, NULL);
+                        signal_context, NULL, 1);
                 bt_data[bt_size++].uintptr = 0;
             }
 
@@ -689,7 +689,7 @@ static void *signal_listener(void *arg)
                     } else {
                         // Get backtrace data
                         bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
-                                bt_size_max - bt_size_cur - 1, signal_context, NULL);
+                                bt_size_max - bt_size_cur - 1, signal_context, NULL, 1);
                     }
                     ptls->safe_restore = old_buf;
 

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -104,7 +104,7 @@ static void JL_NORETURN start_backtrace_fiber(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     // collect the backtrace
-    ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, error_ctx, ptls->pgcstack);
+    ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, error_ctx, ptls->pgcstack, 0);
     // switch back to the execution fiber
     jl_setcontext(&error_return_fiber);
     abort();
@@ -130,7 +130,7 @@ void jl_throw_in_ctx(jl_value_t *excpt, PCONTEXT ctxThread)
         assert(excpt != NULL);
         ptls->bt_size = 0;
         if (excpt != jl_stackovf_exception) {
-            ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, ctxThread, ptls->pgcstack);
+            ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, ctxThread, ptls->pgcstack, 0);
         }
         else if (have_backtrace_fiber) {
             error_ctx = ctxThread;
@@ -345,7 +345,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                 }
                 // Get backtrace data
                 bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
-                    bt_size_max - bt_size_cur - 1, &ctxThread, NULL);
+                    bt_size_max - bt_size_cur - 1, &ctxThread, NULL, 1);
                 // Mark the end of this block with 0
                 bt_data_prof[bt_size_cur].uintptr = 0;
                 bt_size_cur++;


### PR DESCRIPTION
The deadlock here happens when the main thread is trying to register
a new JIT object while the profiler is triggered. The main thread
will acquire the objectmap lock and then get suspended. Then the profiler
thread will attempt to stackwalk, but in order to do that effectively,
it needs to look at the object map to find the unwind info for the function
on the stack. We don't have the same problem on linux because the main
thread runs the backtracing. On linux and mac the registration process
works differently and on linux at least the backtracing happens on a
different thread so we may not have this problem. However, #13294 says
that it is also a problem on OS X. We should keep an eye out for it.
For the moment, just try to fix this by terminating the stack unwind
when we fail to acquire the lock. That's not ideal, because it reduces
the quality of the profiler info, but only in situations where we would
previous deadlock. This entire code needs a rewrite, but for now, I'm
just hoping to get CI to stopping deadlocking on us.