### PR TITLE
Shuffle LinearAlgebra tests to the front of the test queue

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,13 @@ move_to_node1("stress")
 # since it starts a lot of workers and can easily exceed the maximum memory
 limited_worker_rss && move_to_node1("Distributed")
 
+# Shuffle LinearAlgebra tests to the front, because they take a while, so we might
+# as well get them all started early.
+linalg_test_ids = findall(x->occursin("LinearAlgebra", x), tests)
+linalg_tests = tests[linalg_test_ids]
+deleteat!(tests, linalg_test_ids)
+prepend!(tests, linalg_tests)
+
 import LinearAlgebra
 cd(@__DIR__) do
     n = 1


### PR DESCRIPTION
They take much longer than the rest of the tests, so if they're
run at the end, they often determine the length of the entire test
run. Instead, try running them at the start while there's still
plenty of work to be done. Hopefully this will reduce overall duration
of CI tests. If this doesn't work out as planned, we can try a more
fine grained strategy to load balancing (e.g. by checking in a table
of approximate runtimes and sorting according to that).