### PR TITLE
src/codegen.cpp: fix segfault on `@code_native` with eltype (#34434)

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1685,7 +1685,7 @@ void *jl_get_llvmf_decl(jl_method_instance_t *mi, size_t world, bool getwrapper,
         // internal error
         return NULL;
 
-    const jl_llvm_functions_t &decls = codeinst->functionObjectsDecls;
+    jl_llvm_functions_t decls = codeinst->functionObjectsDecls;
     if (decls.functionObject == NULL && codeinst->invoke == jl_fptr_const_return && jl_is_method(mi->def.method)) {
         // normally we don't generate native code for these functions, so need an exception here
         // This leaks a bit of memory to cache native code that we'll never actually need
@@ -1699,6 +1699,7 @@ void *jl_get_llvmf_decl(jl_method_instance_t *mi, size_t world, bool getwrapper,
             if (codeinst == NULL)
                 // internal error
                 return NULL;
+            decls = codeinst->functionObjectsDecls;
         }
         JL_UNLOCK(&codegen_lock);
     }

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -440,3 +440,9 @@ end
 # buildbot path updating
 file, ln = functionloc(versioninfo, Tuple{})
 @test isfile(file)
+
+@testset "Issue #34434" begin
+    io = IOBuffer()
+    code_native(io, eltype, Tuple{Int})
+    @test occursin("eltype", String(take!(io)))
+end


### PR DESCRIPTION
Fixes #34434

According to git bisect:

8c445663547791e59f33f9e8d49b276332107614 is the first bad commit

```                                               
git bisect start                                                                                          
# bad: [c6da87ff4bc7a855e217856757ad3413cf6d1f79] Set VERSION to 1.2.0 (#32964)                           
git bisect bad c6da87ff4bc7a855e217856757ad3413cf6d1f79                                               
# good: [55e36cc308b66d3472990a06b2797f9f9154ea0a] Set VERSION to 1.1.1 (#31969)                      
git bisect good 55e36cc308b66d3472990a06b2797f9f9154ea0a                                                  
# good: [b55b85cd9952ce39246d1bcb6c4b0417ac457531] spawn/IO: supercharge the API (#30278)                 
git bisect good b55b85cd9952ce39246d1bcb6c4b0417ac457531                                                  
# good: [0b38dd0ac1ec977166e71fdee92d2ac5d1ee36fe] More xrefs for the meta docs                           
git bisect good 0b38dd0ac1ec977166e71fdee92d2ac5d1ee36fe                                                  
# bad: [a3997800b0b8d364c628d2a2ec8ae8e246b8f63f] Fix Int64 overrun potential in skip_deleted (#31452)    
git bisect bad a3997800b0b8d364c628d2a2ec8ae8e246b8f63f                                                   
# good: [a168bc8a8c73f6f6b536a40ced32df8c528a7b4b] Merge pull request #31324 from JuliaLang/vc/tuple_props
git bisect good a168bc8a8c73f6f6b536a40ced32df8c528a7b4b
# good: [672bf8bea7b01a1828fc21e6689c8d3fa5f46ea6] realpath buffer is a vector (#31433)
git bisect good 672bf8bea7b01a1828fc21e6689c8d3fa5f46ea6
# good: [c0b40d8530dc62cebc556e026ab5ae5409a7bd29] Merge pull request #31413 from JuliaLang/jn/nfc-1
git bisect good c0b40d8530dc62cebc556e026ab5ae5409a7bd29
# good: [11156024da041ea0060fd267f6acd8d83193b653] Fix #31396 (#31401)
git bisect good 11156024da041ea0060fd267f6acd8d83193b653
# good: [53d7fbfbd67607659e33b779b9c91668dff7ca71] Replaced `Any[...]` with `[...]` in example (#31526)
git bisect good 53d7fbfbd67607659e33b779b9c91668dff7ca71
# good: [9f125f90cdb823e5682868838eded05c394f1944] add test for #28762, at-inferred error (#31430)
git bisect good 9f125f90cdb823e5682868838eded05c394f1944
# bad: [8c445663547791e59f33f9e8d49b276332107614] internals: better representation for code (#31191)
git bisect bad 8c445663547791e59f33f9e8d49b276332107614
# good: [4b1230277ca50c70ee517578db1ec30483cf9ad9] add a nop conversion for some (#31536)
git bisect good 4b1230277ca50c70ee517578db1ec30483cf9ad9
# first bad commit: [8c445663547791e59f33f9e8d49b276332107614] internals: better representation for code (#31191)
```