### PR TITLE
Backports for Julia 1.4 RC 1

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -53,15 +53,15 @@ module GC
     GC.gc()
     GC.gc(full::Bool)
 
-Perform garbage collection. The argument `full` determines the kind of collection: A full
-collection scans all objects, while an incremental collection only scans so-called young
-objects and is much quicker. If called without an argument, heuristics are used to determine
-which type of collection is needed.
+Perform garbage collection. The argument `full` determines the kind of
+collection: A full collection (default) sweeps all objects, which makes the
+next GC scan much slower, while an incremental collection may only sweep
+so-called young objects.
 
 !!! warning
     Excessive use will likely lead to poor performance.
 """
-gc() = ccall(:jl_gc_collect, Cvoid, (Cint,), 0)
+gc() = ccall(:jl_gc_collect, Cvoid, (Cint,), 1)
 gc(full::Bool) = ccall(:jl_gc_collect, Cvoid, (Cint,), full ? 1 : 2)
 
 """

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -49,9 +49,13 @@ Module with garbage collection utilities.
 """
 module GC
 
+# mirrored from julia.h
+const GC_AUTO = 0
+const GC_FULL = 1
+const GC_INCREMENTAL = 2
+
 """
-    GC.gc()
-    GC.gc(full::Bool)
+    GC.gc([full=true])
 
 Perform garbage collection. The argument `full` determines the kind of
 collection: A full collection (default) sweeps all objects, which makes the
@@ -61,8 +65,8 @@ so-called young objects.
 !!! warning
     Excessive use will likely lead to poor performance.
 """
-gc() = ccall(:jl_gc_collect, Cvoid, (Cint,), 1)
-gc(full::Bool) = ccall(:jl_gc_collect, Cvoid, (Cint,), full ? 1 : 2)
+gc(full::Bool=true) =
+    ccall(:jl_gc_collect, Cvoid, (Cint,), full ? GC_FULL : GC_INCREMENTAL)
 
 """
     GC.enable(on::Bool)

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -398,6 +398,6 @@ rand(::Type{Float64}) = rand(UInt32) * 2.0^-32
 
 Interface to the C `srand(seed)` function.
 """
-srand(seed=floor(time())) = ccall(:srand, Cvoid, (Cuint,), seed)
+srand(seed=floor(Int, time()) % Cuint) = ccall(:srand, Cvoid, (Cuint,), seed)
 
 end # module

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -273,7 +273,8 @@
 
 ;; predicates and accessors
 
-(define (quoted? e) (memq (car e) '(quote top core globalref outerref line break inert meta)))
+(define (quoted? e)
+  (memq (car e) '(quote top core globalref outerref line break inert meta inbounds loopinfo)))
 (define (quotify e) `',e)
 (define (unquote e)
   (if (and (pair? e) (memq (car e) '(quote inert)))

--- a/src/dump.c
+++ b/src/dump.c
@@ -403,7 +403,10 @@ static void jl_serialize_datatype(jl_serializer_state *s, jl_datatype_t *dt) JL_
             uint32_t np = dt->layout->npointers;
             size_t fieldsize = jl_fielddesc_size(dt->layout->fielddesc_type);
             ios_write(s->s, (const char*)dt->layout, sizeof(*dt->layout));
-            ios_write(s->s, (const char*)(dt->layout + 1), nf * fieldsize + (np << dt->layout->fielddesc_type));
+            size_t fldsize = nf * fieldsize;
+            if (dt->layout->first_ptr != -1)
+                fldsize += np << dt->layout->fielddesc_type;
+            ios_write(s->s, (const char*)(dt->layout + 1), fldsize);
         }
     }
 
@@ -1484,11 +1487,14 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
             uint32_t np = buffer.npointers;
             uint8_t fielddesc_type = buffer.fielddesc_type;
             size_t fielddesc_size = nf > 0 ? jl_fielddesc_size(fielddesc_type) : 0;
+            size_t fldsize = nf * fielddesc_size;
+            if (buffer.first_ptr != -1)
+                fldsize += np << fielddesc_type;
             jl_datatype_layout_t *layout = (jl_datatype_layout_t*)jl_gc_perm_alloc(
-                    sizeof(jl_datatype_layout_t) + nf * fielddesc_size + (np << fielddesc_type),
+                    sizeof(jl_datatype_layout_t) + fldsize,
                     0, 4, 0);
             *layout = buffer;
-            ios_read(s->s, (char*)(layout + 1), nf * fielddesc_size + (np << fielddesc_type));
+            ios_read(s->s, (char*)(layout + 1), fldsize);
             dt->layout = layout;
         }
     }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -290,7 +290,7 @@ jl_value_t *jl_permbox32(jl_datatype_t *t, int32_t x);
 jl_value_t *jl_permbox64(jl_datatype_t *t, int64_t x);
 jl_svec_t *jl_perm_symsvec(size_t n, ...);
 
-#if !defined(__clang_analyzer__) // this sizeof(__VA_ARGS__) trick can't be computed until C11, but only the analyzer seems to care
+#if !defined(__clang_analyzer__) && !defined(JL_ASAN_ENABLED) // this sizeof(__VA_ARGS__) trick can't be computed until C11, but that only matters to Clang in some situations
 #ifdef __GNUC__
 #define jl_perm_symsvec(n, ...) \
     (jl_perm_symsvec)(__extension__({                                         \

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -871,7 +871,9 @@ static void jl_write_values(jl_serializer_state *s)
                     size_t np = dt->layout->npointers;
                     size_t fieldsize = jl_fielddesc_size(dt->layout->fielddesc_type);
                     char *flddesc = (char*)dt->layout;
-                    size_t fldsize = sizeof(jl_datatype_layout_t) + nf * fieldsize + (np << dt->layout->fielddesc_type);
+                    size_t fldsize = sizeof(jl_datatype_layout_t) + nf * fieldsize;
+                    if (dt->layout->first_ptr != -1)
+                        fldsize += np << dt->layout->fielddesc_type;
                     uintptr_t layout = LLT_ALIGN(ios_pos(s->const_data), sizeof(void*));
                     write_padding(s->const_data, layout - ios_pos(s->const_data)); // realign stream
                     newdt->layout = NULL; // relocation offset

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1971,3 +1971,11 @@ end
 # issue #33987
 f33987(args::(Vararg{Any, N} where N); kwargs...) = args
 @test f33987(1,2,3) === (1,2,3)
+
+@test @eval let
+    (z,)->begin
+        $(Expr(:inbounds, true))
+        $(Expr(:inbounds, :pop))
+    end
+    pop = 1
+end == 1


### PR DESCRIPTION
Backported PRs:
- [x] #34336 - revert breaking change to GC.gc()
- [x] #34401 - Clean-up the GC.gc interface.
- [x] #34442 - base/libc.jl: fix crash when run before epoch
- [x] #34389 - ASAN fixes
- [x] #34397 - mark `inbounds` and `loopinfo` as quoted during lowering

Non-merged PRs with backport label:
- [ ] #34402 - Make testall target work with JULIA_BUILD_MODE=debug again.
- [ ] #34391 - track-allocation: charge entry cost to caller