### PR TITLE
WIP/RFC: Run LinearAlgebra tests with --compile=min.

### DIFF
--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -26,7 +26,14 @@ if !@isdefined(testenv_defined)
         const test_exename = popfirst!(test_exeflags.exec)
     end
 
-    addprocs_with_testenv(X; kwargs...) = addprocs(X; exename=test_exename, exeflags=test_exeflags, kwargs...)
+    function addprocs_with_testenv(X; kwargs...)
+        if X > 1
+            [addprocs(X-1; exename=test_exename, exeflags=test_exeflags, kwargs...);
+             addprocs(1; exename=test_exename, exeflags=`$test_exeflags --compile=min`, kwargs...)]
+        else
+            addprocs(X; exename=test_exename, exeflags=test_exeflags, kwargs...)
+        end
+    end
 
     const curmod = @__MODULE__
     const curmod_name = fullname(curmod)


### PR DESCRIPTION
Implements https://github.com/JuliaLang/LinearAlgebra.jl/issues/690. Has the same effect as https://github.com/JuliaLang/julia/pull/34456, too. Current approach introduces some non-determinism (whether tests are executed on the `--compile=min` worker or not), so that may not be wanted. Unless that flag is supposed to be non-breaking, in which case this would add some coverage?