### PR TITLE
build: remove old mingw32 support macro [NFCI]

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -119,13 +119,13 @@ JL_DLLEXPORT void __stack_chk_fail()
 
 #ifdef _OS_WINDOWS_
 #if defined(_CPU_X86_64_)
-#if defined(_COMPILER_MINGW_)
+#if defined(_COMPILER_GCC_)
 extern void ___chkstk_ms(void);
 #else
 extern void __chkstk(void);
 #endif
 #else
-#if defined(_COMPILER_MINGW_)
+#if defined(_COMPILER_GCC_)
 #undef _alloca
 extern void _alloca(void);
 #else
@@ -7537,7 +7537,7 @@ static void init_julia_llvm_env(Module *m)
 #endif
 #ifndef FORCE_ELF
 #if defined(_CPU_X86_64_)
-#if defined(_COMPILER_MINGW_)
+#if defined(_COMPILER_GCC_)
     Function *chkstk_func = Function::Create(FunctionType::get(T_void, false),
             Function::ExternalLinkage, "___chkstk_ms", m);
     add_named_global(chkstk_func, &___chkstk_ms, /*dllimport*/false);
@@ -7547,7 +7547,7 @@ static void init_julia_llvm_env(Module *m)
     add_named_global(chkstk_func, &__chkstk, /*dllimport*/false);
 #endif
 #else
-#if defined(_COMPILER_MINGW_)
+#if defined(_COMPILER_GCC_)
     Function *chkstk_func = Function::Create(FunctionType::get(T_void, false),
             Function::ExternalLinkage, "_alloca", m);
     add_named_global(chkstk_func, &_alloca, /*dllimport*/false);

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -51,7 +51,7 @@
 extern "C" {
 #endif
 
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
 #include <malloc.h>
 JL_DLLEXPORT char * dirname(char *);
 #else

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -169,7 +169,7 @@ char *tostring(fl_context_t *fl_ctx, value_t v, const char *fname);
 /* error handling */
 #if defined(_OS_WINDOWS_)
 #define fl_jmp_buf jmp_buf
-#if defined(_COMPILER_MINGW_)
+#if defined(_COMPILER_GCC_)
 int __attribute__ ((__nothrow__,__returns_twice__)) (jl_setjmp)(jmp_buf _Buf);
 __declspec(noreturn) __attribute__ ((__nothrow__)) void (jl_longjmp)(jmp_buf _Buf, int _Value);
 #else

--- a/src/gc.h
+++ b/src/gc.h
@@ -367,9 +367,7 @@ unsigned ffs_u32(uint32_t bitvec) JL_NOTSAFEPOINT;
 #else
 STATIC_INLINE unsigned ffs_u32(uint32_t bitvec)
 {
-#if defined(_COMPILER_MINGW_)
-    return __builtin_ffs(bitvec) - 1;
-#elif defined(_COMPILER_MICROSOFT_)
+#if defined(_COMPILER_MICROSOFT_)
     unsigned long j;
     _BitScanForward(&j, bitvec);
     return j;

--- a/src/init.c
+++ b/src/init.c
@@ -13,7 +13,7 @@
 
 #include <errno.h>
 
-#if !defined(_OS_WINDOWS_) || defined(_COMPILER_MINGW_)
+#if !defined(_OS_WINDOWS_) || defined(_COMPILER_GCC_)
 #include <getopt.h>
 #endif
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -563,10 +563,10 @@ extern int vasprintf(char **str, const char *fmt, va_list ap);
 
 JL_DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
 {
-    char *str=NULL;
+    char *str = NULL;
     int c;
     va_list al;
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
     al = args;
 #else
     va_copy(al, args);

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -22,7 +22,7 @@ extern "C" {
 #include <fenv.h>
 #endif
 
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
 JL_DLLEXPORT char * __cdecl dirname(char *);
 #else
 #include <libgen.h>

--- a/src/julia.h
+++ b/src/julia.h
@@ -1783,7 +1783,7 @@ JL_DLLEXPORT size_t jl_excstack_state(void);
 JL_DLLEXPORT void jl_restore_excstack(size_t state);
 
 #if defined(_OS_WINDOWS_)
-#if defined(_COMPILER_MINGW_)
+#if defined(_COMPILER_GCC_)
 int __attribute__ ((__nothrow__,__returns_twice__)) (jl_setjmp)(jmp_buf _Buf);
 __declspec(noreturn) __attribute__ ((__nothrow__)) void (jl_longjmp)(jmp_buf _Buf, int _Value);
 #else

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -6,7 +6,7 @@
 #include "options.h"
 #include "locks.h"
 #include <uv.h>
-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+#if !defined(_WIN32)
 #include <unistd.h>
 #else
 #define sleep(x) Sleep(1000*x)

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -465,7 +465,7 @@ JL_DLLEXPORT jl_nullable_float32_t jl_try_substrtof(char *str, size_t offset, si
         bstr = newstr;
         pend = bstr+len;
     }
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
     float out = (float)jl_strtod_c(bstr, &p);
 #else
     float out = jl_strtof_c(bstr, &p);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -6,7 +6,7 @@
 
 // Copied from MINGW_FLOAT_H which may not be found due to a collision with the builtin gcc float.h
 // eventually we can probably integrate this into OpenLibm.
-#if defined(_COMPILER_MINGW_)
+#if defined(_COMPILER_GCC_)
 void __cdecl __MINGW_NOTHROW _fpreset (void);
 void __cdecl __MINGW_NOTHROW fpreset (void);
 #else

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
-#if !defined(_COMPILER_MINGW_)
+#if !defined(_COMPILER_GCC_)
 
 #define strtoull                                            _strtoui64
 #define strtoll                                             _strtoi64
@@ -42,7 +42,7 @@
 #define STDOUT_FILENO                                       1
 #define STDERR_FILENO                                       2
 
-#endif /* !_COMPILER_MINGW_ */
+#endif /* !_COMPILER_GCC_ */
 
 #endif /* _OS_WINDOWS_ */
 
@@ -114,7 +114,7 @@
 #  define STATIC_INLINE static inline
 #endif
 
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
 #  define NOINLINE __declspec(noinline)
 #  define NOINLINE_DECL(f) __declspec(noinline) f
 #else

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -16,7 +16,6 @@
  *          _COMPILER_GCC_
  *          _COMPILER_INTEL_
  *          _COMPILER_MICROSOFT_
- *          _COMPILER_MINGW_
  *      OS:
  *          _OS_FREEBSD_
  *          _OS_LINUX_
@@ -37,25 +36,14 @@
 *******************************************************************************/
 
 /*
- * Notes:
- *
- *  1. Checking for Intel's compiler should be done before checking for
+ * Note: Checking for Intel's compiler should be done before checking for
  * Microsoft's. On Windows Intel's compiler also defines _MSC_VER as the
- * acknoledgement of the fact that it is integrated with Visual Studio.
- *
- *  2. Checking for MinGW should be done before checking for GCC as MinGW
- * pretends to be GCC.
+ * acknowledgement of the fact that it is integrated with Visual Studio.
  */
 #if defined(__clang__)
 #define _COMPILER_CLANG_
-// Clang can also be used as a MinGW compiler
-#if defined(__MINGW32__)
-#define _COMPILER_MINGW_
-#endif
 #elif defined(__INTEL_COMPILER) || defined(__ICC)
 #define _COMPILER_INTEL_
-#elif defined(__MINGW32__)
-#define _COMPILER_MINGW_
 #elif defined(_MSC_VER)
 #define _COMPILER_MICROSOFT_
 #elif defined(__GNUC__)

--- a/src/sys.c
+++ b/src/sys.c
@@ -62,7 +62,7 @@
 extern "C" {
 #endif
 
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
 JL_DLLEXPORT char *dirname(char *);
 #else
 #include <libgen.h>
@@ -413,7 +413,7 @@ JL_DLLEXPORT uint64_t jl_hrtime(void)
 #ifdef __APPLE__
 #include <crt_externs.h>
 #else
-#if !defined(_OS_WINDOWS_) || defined(_COMPILER_MINGW_)
+#if !defined(_OS_WINDOWS_) || defined(_COMPILER_GCC_)
 extern char **environ;
 #endif
 #endif


### PR DESCRIPTION
Realized this while trying to track down why some warnings were appearing on the mingw-w64, despite us having disabled them for gcc.

We have not supported this compiler in many years (though its successor project, mingw-w64, also defined it). And it's a weird combination of compiler and platform specifics: the present uses were generally either using it instead of either the more appropriate GCC or WINDOWS.
