### PR TITLE
Distributed, SHA tests: fix soft scope shadowing

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1557,7 +1557,7 @@ nprocs()>1 && rmprocs(workers())
 cluster_cookie("")
 
 for close_stdin in (true, false), stderr_to_stdout in (true, false)
-    npids = addprocs_with_testenv(RetainStdioTester(close_stdin,stderr_to_stdout))
+    local npids = addprocs_with_testenv(RetainStdioTester(close_stdin,stderr_to_stdout))
     @test remotecall_fetch(myid, npids[1]) == npids[1]
     @test close_stdin != remotecall_fetch(()->isopen(stdin), npids[1])
     @test stderr_to_stdout == remotecall_fetch(()->(stderr === stdout), npids[1])
@@ -1621,7 +1621,7 @@ a27933 = :_not_defined_27933
 
 # PR #28651
 for T in (UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64)
-    n = @distributed (+) for i in Base.OneTo(T(10))
+    local n = @distributed (+) for i in Base.OneTo(T(10))
         i
     end
     @test n == 55

--- a/stdlib/SHA/test/runtests.jl
+++ b/stdlib/SHA/test/runtests.jl
@@ -275,7 +275,7 @@ end
 # test error if eltype of input is not UInt8
 for f in sha_funcs
     global nerrors
-    data = UInt32[0x23467, 0x324775]
+    local data = UInt32[0x23467, 0x324775]
     try
         f(data)
     catch ex


### PR DESCRIPTION
Fix the "soft scope violations" found in https://github.com/JuliaLang/julia/pull/34469. Good change regardless.