### PR TITLE
jl_special_vector_alignment: Remove work-around for old LLVM versions

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -191,18 +191,6 @@ unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *t)
 {
     if (!jl_is_vecelement_type(t))
         return 0;
-    // LLVM 3.7 and 3.8 either crash or generate wrong code for many
-    // SIMD vector sizes N. It seems the rule is that N can have at
-    // most 2 non-zero bits. (This is true at least for N<=100.) See
-    // also <https://llvm.org/bugs/show_bug.cgi?id=27708>.
-    size_t mask = nfields;
-    // See e.g.
-    // <https://graphics.stanford.edu/%7Eseander/bithacks.html> for an
-    // explanation of this bit-counting algorithm.
-    mask &= mask-1;             // clear least-significant 1 if present
-    mask &= mask-1;             // clear another 1
-    if (mask)
-        return 0;               // nfields has more than two 1s
     assert(jl_datatype_nfields(t)==1);
     jl_value_t *ty = jl_field_type((jl_datatype_t*)t, 0);
     if (!jl_is_primitivetype(ty))

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -105,12 +105,6 @@ end
 # Test various SIMD Vectors with known good sizes
 for T in (Float64, Float32, Int64, Int32)
     for N in 1:36
-        # For some vectortypes Julia emits llvm arrays instead of vectors
-        if N %  7 == 0 || N % 11 == 0 || N % 13 == 0 || N % 15 == 0 ||
-           N % 19 == 0 || N % 23 == 0 || N % 25 == 0 || N % 27 == 0 ||
-           N % 29 == 0 || N % 31 == 0
-            continue
-        end
         a = ntuple(i->VecElement(T(i)), N)
         result = ntuple(i-> VecElement(T(i+i)), N)
         b = vecadd(a, a)


### PR DESCRIPTION
LLVM <= 3.8 segfaults when LLVM SIMD vectors are not powers of 2 (or a sum
of 2 different powers of 2). This LLVM bug was corrected in 2017 (see
<https://bugs.llvm.org/show_bug.cgi?id=27708>). This change removes this
work-around, finally allowing arbitrary SIMD vector lengths in Julia.

This changes Julia's ABI for SIMD types. All SIMD types are now represented
as SIMD vectors in LLVM. The work-around represented some SIMD types as
LLVM arrays instead to avoid the LLVM segfault. I don't think that SIMD
vector lengths that are not a power of 2 were in widespread use, if at all.