### PR TITLE
fix bug in printing of block expressions in ref

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1584,7 +1584,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
                 show_unquoted(io, ex.args[i], ind, -1, quote_level)
             end
             if length(ex.args) < 2
-                print(isempty(ex.args) ? "nothing;)" : ";)")
+                print(io, isempty(ex.args) ? "nothing;)" : ";)")
             else
                 print(io, ')')
             end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1992,3 +1992,4 @@ end
 @weak_test_repr "a[begin, end, let x=1; (x+1;); end]"
 @test repr(Base.remove_linenums!(:(a[begin, end, let x=1; (x+1;); end]))) ==
         ":(a[begin, end, let x = 1\n          begin\n              x + 1\n          end\n      end])"
+@test_repr "a[(bla;)]"


### PR DESCRIPTION
This one really caught me by surprise while debugging another part of `show_unquoted`