### PR TITLE
fix printing of LineNumberNode in block within ref

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1580,7 +1580,13 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             print(io, '(')
             ind = indent + indent_width
             for i = 1:length(ex.args)
-                i > 1 && print(io, ";\n", ' '^ind)
+                if i > 1
+                    # if there was only a comment before the first semicolon, the expression would get parsed as a NamedTuple
+                    if !(i == 2 && ex.args[1] isa LineNumberNode)
+                        print(io, ';')
+                    end
+                    print(io, "\n", ' '^ind)
+                end
                 show_unquoted(io, ex.args[i], ind, -1, quote_level)
             end
             if length(ex.args) < 2

--- a/test/show.jl
+++ b/test/show.jl
@@ -1993,3 +1993,4 @@ end
 @test repr(Base.remove_linenums!(:(a[begin, end, let x=1; (x+1;); end]))) ==
         ":(a[begin, end, let x = 1\n          begin\n              x + 1\n          end\n      end])"
 @test_repr "a[(bla;)]"
+@weak_test_repr "a[x -> f(x)]"


### PR DESCRIPTION
This was brought up [on discourse](https://discourse.julialang.org/t/julia-v1-4-0-rc1-is-now-available/33715/13?u=simeonschaub). #34503 is needed for the tests to pass, so this currently also contains these commits.