### PR TITLE
Move `realpath()` earlier in `cmdlineargs` test

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -600,6 +600,7 @@ end
 end
 
 mktempdir() do dir
+    dir = realpath(dir)
     # test parameters
     repo_url = "https://github.com/JuliaLang/Example.jl"
     cache_repo = joinpath(dir, "Example")

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -804,7 +804,7 @@ end
 if Sys.iswindows()
     tmp = tempname()
     touch(tmp)
-    path = dirname(tmp)
+    path = realpath(dirname(tmp))
     file = basename(tmp)
     temp_name = basename(path)
     cd(path) do

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -416,6 +416,9 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
 
     # test the program name remains constant
     mktempdir() do dir
+        # dir can be case-incorrect sometimes
+        dir = realpath(dir)
+
         a = joinpath(dir, "a.jl")
         b = joinpath(dir, "b.jl")
         c = joinpath(dir, ".julia", "config", "startup.jl")
@@ -439,19 +442,19 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
                 [a, a,
                  b, a]
             @test readsplit(`$exename -L $b -e 'exit(0)'`) ==
-                [realpath(b), ""]
+                [b, ""]
             @test readsplit(`$exename -L $b $a`) ==
-                [realpath(b), a,
+                [b, a,
                  a, a,
                  b, a]
             @test readsplit(`$exename --startup-file=yes -e 'exit(0)'`) ==
                 [c, ""]
             @test readsplit(`$exename --startup-file=yes -L $b -e 'exit(0)'`) ==
                 [c, "",
-                 realpath(b), ""]
+                 b, ""]
             @test readsplit(`$exename --startup-file=yes -L $b $a`) ==
                 [c, a,
-                 realpath(b), a,
+                 b, a,
                  a, a,
                  b, a]
         end


### PR DESCRIPTION
This should hopefully fix issues such as https://github.com/JuliaLang/julia/pull/34418#issuecomment-578275655