### PR TITLE
RFC: NamedTuple macro for easier type construction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@ New library functions
 New library features
 --------------------
 * Function composition now works also on one argument `∘(f) = f` (#34251)
-* `@NamedTuple{key1::Type1, ...}` macro for convenient `NamedTuple` declarations.
+* `@NamedTuple{key1::Type1, ...}` macro for convenient `NamedTuple` declarations ([#34548]).
 
 
 Standard library changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ New library functions
 New library features
 --------------------
 * Function composition now works also on one argument `∘(f) = f` (#34251)
+* `@NamedTuple{key1::Type1, ...}` macro for convenient `NamedTuple` declarations.
 
 
 Standard library changes

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -940,6 +940,7 @@ export
     @s_str,    # regex substitution string
     @v_str,    # version number
     @raw_str,  # raw string with no interpolation/unescaping
+    @NamedTuple,
 
     # documentation
     @text_str,

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -337,18 +337,18 @@ If the `::Type` declaration is omitted, it is taken to be `Any`.   The `begin ..
 declarations to be split across multiple lines (similar to a `struct` declaration), but is otherwise
 equivalent.
 
-For example, the tuple `(a=3, b="hello")` has a type `NamedTuple{(:a, :b),Tuple{Int64,String}}`, which
+For example, the tuple `(a=3.1, b="hello")` has a type `NamedTuple{(:a, :b),Tuple{Float64,String}}`, which
 can also be declared via `@NamedTuple` as:
 
 ```jldoctest
-julia> @NamedTuple{a::Int, b::String}
-NamedTuple{(:a, :b),Tuple{Int64,String}}
+julia> @NamedTuple{a::Float64, b::String}
+NamedTuple{(:a, :b),Tuple{Float64,String}}
 
 julia> @NamedTuple begin
-           a::Int
+           a::Float64
            b::String
        end
-NamedTuple{(:a, :b),Tuple{Int64,String}}
+NamedTuple{(:a, :b),Tuple{Float64,String}}
 ```
 """
 macro NamedTuple(ex)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -358,6 +358,6 @@ macro NamedTuple(ex)
     all(e -> e isa Symbol || Meta.isexpr(e, :(::)), decls) ||
         throw(ArgumentError("@NamedTuple must contain a sequence of name or name::type expressions"))
     vars = [QuoteNode(e isa Symbol ? e : e.args[1]) for e in decls]
-    types = [e isa Symbol ? :Any : e.args[2] for e in decls]
+    types = [esc(e isa Symbol ? :Any : e.args[2]) for e in decls]
     return :(NamedTuple{($(vars...),), Tuple{$(types...)}})
 end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -17,6 +17,8 @@ using [`values`](@ref).
     Iteration over `NamedTuple`s produces the *values* without the names. (See example
     below.) To iterate over the name-value pairs, use the [`pairs`](@ref) function.
 
+The [`@NamedTuple`](@ref) macro can be used for conveniently declaring `NamedTuple` types.
+
 # Examples
 ```jldoctest
 julia> x = (a=1, b=2)
@@ -323,4 +325,39 @@ julia> Base.setindex(nt, "a", :a)
 """
 function setindex(nt::NamedTuple, v, idx::Symbol)
     merge(nt, (; idx => v))
+end
+
+"""
+    @NamedTuple{key1::Type1, key2::Type2, ...}
+    @NamedTuple begin key1::Type1; key2::Type2; ...; end
+
+This macro gives a more convenient syntax for declaring `NamedTuple` types. It returns a `NamedTuple`
+type with the given keys and types, equivalent to `NamedTuple{(:key1, :key2, ...), Tuple{Type1,Type2,...}}`.
+If the `::Type` declaration is omitted, it is taken to be `Any`.   The `begin ... end` form allows the
+declarations to be split across multiple lines (similar to a `struct` declaration), but is otherwise
+equivalent.
+
+For example, the tuple `(a=3, b="hello")` has a type `NamedTuple{(:a, :b),Tuple{Int64,String}}`, which
+can also be declared via `@NamedTuple` as:
+
+```jldoctest
+julia> @NamedTuple{a::Int, b::String}
+NamedTuple{(:a, :b),Tuple{Int64,String}}
+
+julia> @NamedTuple begin
+           a::Int
+           b::String
+       end
+NamedTuple{(:a, :b),Tuple{Int64,String}}
+```
+"""
+macro NamedTuple(ex)
+    Meta.isexpr(ex, :braces) || Meta.isexpr(ex, :block) ||
+        throw(ArgumentError("@NamedTuple expects {...} or begin...end"))
+    decls = filter(e -> !(e isa LineNumberNode), ex.args)
+    all(e -> e isa Symbol || Meta.isexpr(e, :(::)), decls) ||
+        throw(ArgumentError("@NamedTuple must contain a sequence of name or name::type expressions"))
+    vars = [QuoteNode(e isa Symbol ? e : e.args[1]) for e in decls]
+    types = [e isa Symbol ? :Any : e.args[2] for e in decls]
+    return :(NamedTuple{($(vars...),), Tuple{$(types...)}})
 end

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -207,6 +207,7 @@ Union{}
 Core.UnionAll
 Core.Tuple
 Core.NamedTuple
+Base.@NamedTuple
 Base.Val
 Core.Vararg
 Core.Nothing

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -923,12 +923,26 @@ julia> typeof((a=1,b="hello"))
 NamedTuple{(:a, :b),Tuple{Int64,String}}
 ```
 
+The [`@NamedTuple`](@ref) macro provides a more convenient `struct`-like syntax for declaring
+`NamedTuple` types via `key::Type` declarations, where an omitted `::Type` corresponds to `::Any`.
+
+```jldoctest
+julia> @NamedTuple{a::Int, b::String}
+NamedTuple{(:a, :b),Tuple{Int64,String}}
+
+julia> @NamedTuple begin
+           a::Int
+           b::String
+       end
+NamedTuple{(:a, :b),Tuple{Int64,String}}
+```
+
 A `NamedTuple` type can be used as a constructor, accepting a single tuple argument.
 The constructed `NamedTuple` type can be either a concrete type, with both parameters specified,
 or a type that specifies only field names:
 
 ```jldoctest
-julia> NamedTuple{(:a, :b),Tuple{Float32, String}}((1,""))
+julia> @NamedTuple{a::Float32,b::String}((1,""))
 (a = 1.0f0, b = "")
 
 julia> NamedTuple{(:a, :b)}((1,""))

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -285,6 +285,6 @@ end
             b::String
         end
     @test @NamedTuple{a::Int, b} === NamedTuple{(:a, :b),Tuple{Int64,Any}}
-    @test_throws Exception @NamedTuple{a::Int, b, 3}
-    @test_throws Exception @NamedTuple(a::Int, b)
+    @test_throws LoadError include_string(Main, "@NamedTuple{a::Int, b, 3}")
+    @test_throws LoadError include_string(Main, "@NamedTuple(a::Int, b)")
 end

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -284,7 +284,7 @@ end
             a::Int
             b::String
         end
-    @test @NamedTuple{a::Int, b} === NamedTuple{(:a, :b),Tuple{Int64,Any}}
+    @test @NamedTuple{a::Int, b} === NamedTuple{(:a, :b),Tuple{Int,Any}}
     @test_throws LoadError include_string(Main, "@NamedTuple{a::Int, b, 3}")
     @test_throws LoadError include_string(Main, "@NamedTuple(a::Int, b)")
 end

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -276,3 +276,15 @@ let nt0 = NamedTuple(), nt1 = (a=33,), nt2 = (a=0, b=:v)
     @test Base.setindex(nt1, "value", :a) == (a="value",)
     @test Base.setindex(nt1, "value", :a) isa NamedTuple{(:a,),<:Tuple{AbstractString}}
 end
+
+# @NamedTuple
+@testset "@NamedTuple" begin
+    @test @NamedTuple{a::Int, b::String} === NamedTuple{(:a, :b),Tuple{Int64,String}} ===
+        @NamedTuple begin
+            a::Int
+            b::String
+        end
+    @test @NamedTuple{a::Int, b} === NamedTuple{(:a, :b),Tuple{Int64,Any}}
+    @test_throws Exception @NamedTuple{a::Int, b, 3}
+    @test_throws Exception @NamedTuple(a::Int, b)
+end

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -279,7 +279,7 @@ end
 
 # @NamedTuple
 @testset "@NamedTuple" begin
-    @test @NamedTuple{a::Int, b::String} === NamedTuple{(:a, :b),Tuple{Int64,String}} ===
+    @test @NamedTuple{a::Int, b::String} === NamedTuple{(:a, :b),Tuple{Int,String}} ===
         @NamedTuple begin
             a::Int
             b::String


### PR DESCRIPTION
Following #34498, #34505, and [a recent discourse discussion](https://discourse.julialang.org/t/anonymous-nested-struct/33723/9), this PR defines (and exports) a macro `@NamedTuple` that provides a more convenient `struct`-like syntax for defining `NamedTuple` types:
```jl
julia> @NamedTuple{a::Int, b::String}
NamedTuple{(:a, :b),Tuple{Int64,String}}

julia> @NamedTuple begin
           a::Int
           b::String
       end
NamedTuple{(:a, :b),Tuple{Int64,String}}
```
If a `::Type` is not specified, it is treated as `::Any` (similar to a `struct`).   ~~This will only be useful if #34547 is resolved, however.  (Alternatively, the PR could be changed to require a type specifier for all keys.)~~  Abstractly typed fields of `NamedTuple` work fine.