### PR TITLE
(DO NOT MERGE) don't allow identifiers to start with Lm (Letter, modifier)

### DIFF
--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -59,7 +59,7 @@ value_t fl_skipws(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 static int is_wc_cat_id_start(uint32_t wc, utf8proc_category_t cat)
 {
     return (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LL ||
-            cat == UTF8PROC_CATEGORY_LT || cat == UTF8PROC_CATEGORY_LM ||
+            cat == UTF8PROC_CATEGORY_LT ||
             cat == UTF8PROC_CATEGORY_LO || cat == UTF8PROC_CATEGORY_NL ||
             cat == UTF8PROC_CATEGORY_SC ||  // allow currency symbols
             // other symbols, but not arrows
@@ -133,7 +133,7 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
     if (cat == UTF8PROC_CATEGORY_MN || cat == UTF8PROC_CATEGORY_MC ||
         cat == UTF8PROC_CATEGORY_ND || cat == UTF8PROC_CATEGORY_PC ||
         cat == UTF8PROC_CATEGORY_SK || cat == UTF8PROC_CATEGORY_ME ||
-        cat == UTF8PROC_CATEGORY_NO ||
+        cat == UTF8PROC_CATEGORY_NO || cat == UTF8PROC_CATEGORY_LM ||
         // primes (single, double, triple, their reverses, and quadruple)
         (wc >= 0x2032 && wc <= 0x2037) || (wc == 0x2057))
         return 1;

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1057,7 +1057,7 @@ for bad in ('=', '$', ':', "||", "&&", "->", "<:")
 end
 @test Base.operator_precedence(:+̂) == Base.operator_precedence(:+)
 
-@test_broken Meta.parse("(x)ᵀ") == Expr(:call, :*, :x, :ᵀ)
+@test_broken Meta.parse("(x)ᵀ") == Expr(:call, :*, :x, Meta.parse("ᵀ"))
 
 # issue #19351
 # adding return type decl should not affect parse of function body

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1057,7 +1057,7 @@ for bad in ('=', '$', ':', "||", "&&", "->", "<:")
 end
 @test Base.operator_precedence(:+̂) == Base.operator_precedence(:+)
 
-@test Meta.parse("(x)ᵀ") == Expr(:call, :*, :x, :ᵀ)
+@test_broken Meta.parse("(x)ᵀ") == Expr(:call, :*, :x, :ᵀ)
 
 # issue #19351
 # adding return type decl should not affect parse of function body


### PR DESCRIPTION
As discussed in #28441, #28494, and #34507, it is a bit awkward that identifiers can *start* with a category-Lm (Letter, modifier) character (such as a superscript).    This PR is an experiment to see how breaking it would be to change that.  (You can still have Lm characters in identifiers, just not as the first character.)

(Breaks #24567.)

Can we please run PkgEval on this PR?