### PR TITLE
Fix broken show method for Base.LogicalIndex

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -631,7 +631,7 @@ LogicalIndex(mask::AbstractArray{Bool, N}) where {N} = LogicalIndex{CartesianInd
 size(L::LogicalIndex) = (L.sum,)
 length(L::LogicalIndex) = L.sum
 collect(L::LogicalIndex) = [i for i in L]
-show(io::IO, r::LogicalIndex) = print(io, "Base.LogicalIndex(", r.mask, ")")
+show(io::IO, r::LogicalIndex) = print(io,collect(r))
 print_array(io::IO, X::LogicalIndex) = print_array(io, collect(X))
 # Iteration over LogicalIndex is very performance-critical, but it also must
 # support arbitrary AbstractArray{Bool}s with both Int and CartesianIndex.

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -632,6 +632,7 @@ size(L::LogicalIndex) = (L.sum,)
 length(L::LogicalIndex) = L.sum
 collect(L::LogicalIndex) = [i for i in L]
 show(io::IO, r::LogicalIndex) = print(io, "Base.LogicalIndex(", r.mask, ")")
+print_array(io::IO, X::LogicalIndex) = print_array(io, collect(X))
 # Iteration over LogicalIndex is very performance-critical, but it also must
 # support arbitrary AbstractArray{Bool}s with both Int and CartesianIndex.
 # Thus the iteration state contains an index iterator and its state. We also


### PR DESCRIPTION
Fixes #34364 
`julia> show(stdout, "text/plain", Base.LogicalIndex([true]))` now shows the following output
` 1-element Base.LogicalIndex{Int64,Array{Bool,1}}:
 1`
Output is similar to that of collect method on LogicalIndex as suggested by @stevengj
In my opinion this is the appropriate change required.
Defined `print_array(io,X::LogicalIndex) = print_array(io,collect(X))`