### PR TITLE
test: fix pool size assumption

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -150,8 +150,8 @@ void gc_sweep_sysimg(void);
 static const int jl_gc_sizeclasses[] = {
 #ifdef _P64
     8,
-#elif MAX_ALIGN == 8
-    // ARM and PowerPC have max alignment of 8,
+#elif MAX_ALIGN > 4
+    // ARM and PowerPC have max alignment larger than pointer,
     // make sure allocation of size 8 has that alignment.
     4, 8,
 #else


### PR DESCRIPTION
On 32-bit, this object falls into the 12-byte pool, which does not exist
on some platforms (such as Win32). Query for which pool this will land
into and test the track-allocation result accordingly.