### PR TITLE
correct printing of empty block inside ref

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1590,7 +1590,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
                 show_unquoted(io, ex.args[i], ind, -1, quote_level)
             end
             if length(ex.args) < 2
-                print(io, isempty(ex.args) ? "nothing;)" : ";)")
+                print(io, isempty(ex.args) ? ";;)" : ";)")
             else
                 print(io, ')')
             end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1993,4 +1993,5 @@ end
 @test repr(Base.remove_linenums!(:(a[begin, end, let x=1; (x+1;); end]))) ==
         ":(a[begin, end, let x = 1\n          begin\n              x + 1\n          end\n      end])"
 @test_repr "a[(bla;)]"
+@test_repr "a[(;;)]"
 @weak_test_repr "a[x -> f(x)]"

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -172,6 +172,7 @@ macro test999_str(args...); args; end
 # blocks vs. tuples
 @test Meta.parse("()") == Expr(:tuple)
 @test_skip Meta.parse("(;)") == Expr(:tuple, Expr(:parameters))
+@test Meta.parse("(;;)") == Expr(:block)
 @test Meta.parse("(;;;;)") == Expr(:block)
 @test_throws ParseError Meta.parse("(,)")
 @test_throws ParseError Meta.parse("(;,)")


### PR DESCRIPTION
Another follow-up to #33946. If people are skeptical about the usage of `(;;)` for empty blocks here, we could also just print the ugly `$(Expr(:block))` instead. `(nothing;)` will do the same thing as `(;;)` most of the time, but parses completely differently and nothing stops users from assigning something different to `nothing`, so I don't think it makes sense to print it that way.