### PR TITLE
fix for `step(::StepRangeLen)` with units

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -424,6 +424,9 @@ function (:)(start::T, step::T, stop::T) where T<:Union{Float16,Float32,Float64}
     steprangelen_hp(T, start, step, 0, len, 1)
 end
 
+step(r::StepRangeLen{T,TwicePrecision{T},TwicePrecision{T}}) where {T<:AbstractFloat} = T(r.step)
+step(r::StepRangeLen{T,TwicePrecision{T},TwicePrecision{T}}) where {T} = T(r.step)
+
 function _range(a::T, st::T, ::Nothing, len::Integer) where T<:Union{Float16,Float32,Float64}
     start_n, start_d = rat(a)
     step_n, step_d = rat(st)


### PR DESCRIPTION
Fixes: https://github.com/JuliaLang/julia/issues/33882#issuecomment-579520703

I tried to concoct a test for this using Furlongs, but it's not meaningful, since Unitful adds a *bunch* of extra overloads to make Unitful ranges use `TwicePrecision{Quantity{...}}`, while by default unit-ish or ordinal types will just not use TwicePrecision.