### PR TITLE
doc: add example of using BigInt to avoid overflow

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -76,6 +76,9 @@ julia> parse(BigInt, "42")
 
 julia> big"313"
 313
+
+julia> BigInt(10)^19
+10000000000000000000
 ```
 """
 BigInt(x)


### PR DESCRIPTION
Added an example of a `BigInt` that would otherwise overflow.