### PR TITLE
soft scope: fix doc tests

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -289,7 +289,7 @@ entered interactively, it behaves the same way it does in a function body. But i
 in a file, it  prints an ambiguity warning and throws an undefined variable error. Let's see it
 working in the REPL first:
 
-```jldoctest
+```
 julia> s = 0 # global
 0
 
@@ -317,7 +317,7 @@ The second fact is why execution of the loop changes the global value of `s` and
 why `t` is still undefined after the loop executes. Now, let's try evaluating this same code as
 though it were in a file instead:
 
-```jldoctest
+```
 julia> code = """
        s = 0 # global
        for i = 1:10


### PR DESCRIPTION
In the original PR, these were hidden by the fact that a stray leading space caused what was considered code and not to be messed up for the second half of this file. Then the PR that fixed it didn't have CI run (not sure why). This fixes the doc tests but ideally should be reverted once Documenter supports the new soft scope behavior correctly.