### PR TITLE
Mention that `string(message)` is used for formatting log messages

### DIFF
--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -73,7 +73,7 @@ automatically extracted. Let's examine the user-defined data first:
 * The *message*  is an object describing the event. By convention
   `AbstractString`s passed as messages are assumed to be in markdown format.
   Other types will be displayed using `print(io, obj)` or `string(obj)` for
-  text-based logger and possibly `show(io,mime,obj)` for other multimedia
+  text-based output and possibly `show(io,mime,obj)` for other multimedia
   displays used in the installed logger.
 * Optional *key--value pairs* allow arbitrary data to be attached to each event.
   Some keys have conventional meaning that can affect the way an event is
@@ -309,4 +309,3 @@ Logging.NullLogger
 Logging.ConsoleLogger
 Logging.SimpleLogger
 ```
-

--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -72,8 +72,9 @@ automatically extracted. Let's examine the user-defined data first:
 
 * The *message*  is an object describing the event. By convention
   `AbstractString`s passed as messages are assumed to be in markdown format.
-  Other types will be displayed using `show(io,mime,obj)` according to the
-  display capabilities of the installed logger.
+  Other types will be displayed using `print(io, obj)` or `string(obj)` for
+  text-based logger and possibly `show(io,mime,obj)` for other multimedia
+  displays used in the installed logger.
 * Optional *key--value pairs* allow arbitrary data to be attached to each event.
   Some keys have conventional meaning that can affect the way an event is
   interpreted (see [`@logmsg`](@ref)).


### PR DESCRIPTION
As discussed in https://github.com/JunoLab/ProgressLogging.jl/pull/13#discussion_r371113550

cc @c42f 