### PR TITLE
Remove unused MinGW compiler macro.

### DIFF
--- a/src/timing.h
+++ b/src/timing.h
@@ -29,8 +29,6 @@ void jl_timing_block_stop(jl_timing_block_t *cur_block);
 #define HAVE_TIMING_SUPPORT
 #elif defined(_COMPILER_GCC_)
 #define HAVE_TIMING_SUPPORT
-#elif defined(_COMPILER_MINGW_)
-#define HAVE_TIMING_SUPPORT
 #endif
 
 #ifndef HAVE_TIMING_SUPPORT


### PR DESCRIPTION
ref https://github.com/JuliaLang/julia/pull/34376#discussion_r372258075
ci skip because this code is not enabled on CI anyway.