### PR TITLE
Use norm instead of abs in generic lu factorization

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -140,9 +140,9 @@ function generic_lufact!(A::StridedMatrix{T}, ::Val{Pivot} = Val(true);
             # find index max
             kp = k
             if Pivot
-                amax = abs(zero(T))
+                amax = norm(zero(T))
                 for i = k:m
-                    absi = abs(A[i,k])
+                    absi = norm(A[i,k])
                     if absi > amax
                         kp = i
                         amax = absi

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -346,6 +346,8 @@ LinearAlgebra.Transpose(a::ModInt{n}) where {n} = transpose(a)
 
     # Needed for pivoting:
     Base.abs(a::ModInt{n}) where {n} = a
+    LinearAlgebra.norm(a::ModInt{n}) where {n} = a
+
     Base.:<(a::ModInt{n}, b::ModInt{n}) where {n} = a.k < b.k
 
     @test A*(lu(A, Val(true))\b) == b


### PR DESCRIPTION
Use norm instead of abs in generic lu factorization as discussed in JuliaLang/LinearAlgebra.jl#693. The factorisation then works also with tensors represented by matrices with elements which are matrix like.