### PR TITLE
scope docs: fix more formatting issues

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -116,20 +116,19 @@ expression means based on where the assignment expression occurs and what `x` al
 that location:
 
 1. **Existing local:** If `x` is *already a local variable*, then the existing local `x` is
-assigned;
-
-2. **Hard scope:** If `x` is *not already a local variable* and assignment occurs inside of any hard
-scope construct (i.e. within a let block, function or macro body, comprehension, or generator), a new
-local named `x` is created in the scope of the assignment;
-
+   assigned;
+2. **Hard scope:** If `x` is *not already a local variable* and assignment occurs inside of any
+   hard scope construct (i.e. within a let block, function or macro body, comprehension, or
+   generator), a new local named `x` is created in the scope of the assignment;
 3. **Soft scope:** If `x` is *not already a local variable* and all of the scope constructs
-containing the assignment are soft scopes (loops, `try`/`catch` blocks, or `struct` blocks), the
-behavior depends on whether the global variable `x` is defined:
-  * if global `x` is **undefined**, a new local named `x` is created in the scope of the assignment;
-  * if global `x` is **defined**, the assignment is considered ambiguous:
-    * in non-interactive contexts (files, eval), an ambiguity warning is printed and a new local
-      is created;
-    * in interactive contexts (REPL, notebooks), the global variable `x` is assigned.
+   containing the assignment are soft scopes (loops, `try`/`catch` blocks, or `struct` blocks), the
+   behavior depends on whether the global variable `x` is defined:
+   * if global `x` is *undefined*, a new local named `x` is created in the scope of the
+     assignment;
+   * if global `x` is *defined*, the assignment is considered ambiguous:
+     * in *non-interactive* contexts (files, eval), an ambiguity warning is printed and a new
+       local is created;
+     * in *interactive* contexts (REPL, notebooks), the global variable `x` is assigned.
 
 You may note that in non-interactive contexts the hard and soft scope behaviors are identical except
 that a warning is printed when an implicitly local variable (i.e. not declared with `local x`)
@@ -442,7 +441,9 @@ As of Julia 1.5, this code works without the `global` annotation in interactive 
 REPL or Jupyter notebooks (just like Julia 0.6) and in files and other non-interactive contexts, it
 prints this very direct warning:
 
-> Assignment to `s` in soft scope is ambiguous because a global variable by the same name exists: `s` will be treated as a new local. Disambiguate by using `local s` to suppress this warning or `global s` to assign to the existing global variable.
+> Assignment to `s` in soft scope is ambiguous because a global variable by the same name exists:
+> `s` will be treated as a new local. Disambiguate by using `local s` to suppress this warning or
+> `global s` to assign to the existing global variable.
 
 This addresses both issues while preserving the "programming at scale" benefits of the 1.0 behavior:
 global variables have no spooky effect on the meaning of code that may be far away; in the REPL


### PR DESCRIPTION
Apparently our Markdown parsers is quite a bit stricter than GitHubs (and others).