### PR TITLE
mapexpr argument for include: transform each parsed expression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@ New library functions
   `merge!` are still available for backward compatibility ([#34296]).
 * The new `isdisjoint` function indicates whether two collections are disjoint ([#34427]).
 * Add function `ismutable` and deprecate `isimmutable` to check whether something is mutable.([#34652])
+* `include` now accepts an optional `mapexpr` first argument to transform the parsed
+  expressions before they are evaluated ([#34595]).
 
 New library features
 --------------------

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -366,7 +366,7 @@ end
 # These functions are duplicated in client.jl/include(::String) for
 # nicer stacktraces. Modifications here have to be backported there
 include(mod::Module, path::AbstractString) = include(mod, convert(String, path))
-function include(mod::Module, _path::String)
+function include(mod::Module, _path::String; mapexpr::Function=identity)
     path, prev = _include_dependency(mod, _path)
     for callback in include_callbacks # to preserve order, must come before Core.include
         invokelatest(callback, mod, path)
@@ -376,7 +376,7 @@ function include(mod::Module, _path::String)
     local result
     try
         # result = Core.include(mod, path)
-        result = ccall(:jl_load_, Any, (Any, Any), mod, path)
+        result = ccall(:jl_load_rewrite, Any, (Any, Cstring, Any), mod, path, mapexpr)
     finally
         if prev === nothing
             delete!(tls, :SOURCE_PATH)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -326,7 +326,7 @@ Nothing() = nothing
 # This should always be inlined
 getptls() = ccall(:jl_get_ptls_states, Ptr{Cvoid}, ())
 
-include(m::Module, fname::String) = ccall(:jl_load_, Any, (Any, Any), m, fname)
+include(m::Module, fname::String) = ccall(:jl_load_, Any, (Any, Any, Ptr{Cvoid}), m, fname, Ptr{Cvoid}(0))
 
 eval(m::Module, @nospecialize(e)) = ccall(:jl_toplevel_eval_in, Any, (Any, Any), m, e)
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -326,7 +326,7 @@ Nothing() = nothing
 # This should always be inlined
 getptls() = ccall(:jl_get_ptls_states, Ptr{Cvoid}, ())
 
-include(m::Module, fname::String) = ccall(:jl_load_, Any, (Any, Any, Ptr{Cvoid}), m, fname, Ptr{Cvoid}(0))
+include(m::Module, fname::String) = ccall(:jl_load_, Any, (Any, Any), m, fname)
 
 eval(m::Module, @nospecialize(e)) = ccall(:jl_toplevel_eval_in, Any, (Any, Any), m, e)
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -425,7 +425,7 @@ baremodule MainInclude
 using ..Base
 # We inline the definition of include from loading.jl/include_relative to get one-frame stacktraces.
 # include(fname::AbstractString) = Main.Base.include(Main, fname)
-function include(fname::AbstractString)
+function include(fname::AbstractString; mapexpr::Function=identity)
     mod = Main
     isa(fname, String) || (fname = Base.convert(String, fname)::String)
     path, prev = Base._include_dependency(mod, fname)
@@ -436,7 +436,7 @@ function include(fname::AbstractString)
     tls[:SOURCE_PATH] = path
     local result
     try
-        result = ccall(:jl_load_, Any, (Any, Any), mod, path)
+        result = ccall(:jl_load_rewrite, Any, (Any, Cstring, Any), mod, path, mapexpr)
     finally
         if prev === nothing
             Base.delete!(tls, :SOURCE_PATH)

--- a/base/client.jl
+++ b/base/client.jl
@@ -464,15 +464,19 @@ definition of `eval`, which evaluates expressions in that module.
 MainInclude.eval
 
 """
-    include(path::AbstractString)
+    include([mapexpr::Function,] path::AbstractString)
 
 Evaluate the contents of the input source file in the global scope of the containing module.
-Every module (except those defined with `baremodule`) has its own 1-argument
+Every module (except those defined with `baremodule`) has its own
 definition of `include`, which evaluates the file in that module.
 Returns the result of the last evaluated expression of the input file. During including,
 a task-local include path is set to the directory containing the file. Nested calls to
 `include` will search relative to that path. This function is typically used to load source
 interactively, or to combine files in packages that are broken into multiple source files.
+
+The optional first argument `mapexpr` can be used to transform the included code before
+it is evaluated: for each parsed expression `expr` in `path`, the `include` function
+actually evaluates `mapexpr(expr)`.  If it is omitted, `mapexpr` defaults to [`identity`](@ref).
 
 Use [`Base.include`](@ref) to evaluate a file into another module.
 """

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1077,13 +1077,19 @@ end
 
 Like [`include`](@ref), except reads code from the given string rather than from a file.
 """
-include_string(m::Module, txt::String, fname::String; mapexpr::Function=identity) =
-    ccall(:jl_load_rewrite_file_string, Any, (Ptr{UInt8}, Csize_t, Cstring, Any, Any),
-          txt, sizeof(txt), fname, m, mapexpr)
+function include_string(mapexpr::Function, m::Module, txt_::AbstractString, fname::AbstractString="string")
+    txt = String(txt_)
+    if mapexpr === identity
+        ccall(:jl_load_file_string, Any, (Ptr{UInt8}, Csize_t, Cstring, Any),
+            txt, sizeof(txt), String(fname), m)
+    else
+        ccall(:jl_load_rewrite_file_string, Any, (Ptr{UInt8}, Csize_t, Cstring, Any, Any),
+            txt, sizeof(txt), String(fname), m, mapexpr)
+    end
+end
 
-include_string(m::Module, txt::AbstractString, fname::AbstractString="string";
-               mapexpr::Function=identity) =
-    include_string(m, String(txt), String(fname); mapexpr=mapexpr)
+include_string(m::Module, txt::AbstractString, fname::AbstractString="string") =
+    include_string(identity, m, txt, fname)
 
 function source_path(default::Union{AbstractString,Nothing}="")
     s = current_task().storage

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1077,12 +1077,13 @@ end
 
 Like [`include`](@ref), except reads code from the given string rather than from a file.
 """
-include_string(m::Module, txt::String, fname::String) =
-    ccall(:jl_load_file_string, Any, (Ptr{UInt8}, Csize_t, Cstring, Any),
-          txt, sizeof(txt), fname, m)
+include_string(m::Module, txt::String, fname::String; mapexpr::Function=identity) =
+    ccall(:jl_load_rewrite_file_string, Any, (Ptr{UInt8}, Csize_t, Cstring, Any, Any),
+          txt, sizeof(txt), fname, m, mapexpr)
 
-include_string(m::Module, txt::AbstractString, fname::AbstractString="string") =
-    include_string(m, String(txt), String(fname))
+include_string(m::Module, txt::AbstractString, fname::AbstractString="string";
+               mapexpr::Function=identity) =
+    include_string(m, String(txt), String(fname); mapexpr=mapexpr)
 
 function source_path(default::Union{AbstractString,Nothing}="")
     s = current_task().storage

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -180,7 +180,8 @@
           (loc  (if (and (pair? loc) (eq? (car loc) 'line))
                     (list loc)
                     '()))
-          (x    (if (eq? name 'x) 'y 'x)))
+          (x    (if (eq? name 'x) 'y 'x))
+          (mex  (if (eq? name 'mapexpr) 'map_expr 'mapexpr)))
      `(block
        (= (call eval ,x)
           (block
@@ -189,7 +190,11 @@
        (= (call include ,x)
           (block
            ,@loc
-           (call (top include) ,name ,x)))))
+           (call (top include) ,name ,x)))
+       (= (call include (:: ,mex (top Function)) ,x)
+          (block
+           ,@loc
+           (call (top include) ,mex ,name ,x)))))
    'none 0))
 
 ; run whole frontend on a string. useful for testing.

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -452,7 +452,8 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
 jl_value_t *jl_eval_global_var(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *e);
 jl_value_t *jl_parse_eval_all(const char *fname,
                               const char *content, size_t contentlen,
-                              jl_module_t *inmodule);
+                              jl_module_t *inmodule,
+                              jl_value_t *mapexpr);
 jl_value_t *jl_interpret_toplevel_thunk(jl_module_t *m, jl_code_info_t *src);
 jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                           jl_code_info_t *src,

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -863,13 +863,18 @@ JL_DLLEXPORT jl_value_t *jl_infer_thunk(jl_code_info_t *thk, jl_module_t *m)
     return (jl_value_t*)jl_any_type;
 }
 
-JL_DLLEXPORT jl_value_t *jl_load(jl_module_t *module, const char *fname)
+JL_DLLEXPORT jl_value_t *jl_load_rewrite(jl_module_t *module, const char *fname, jl_value_t *mapexpr)
 {
     uv_stat_t stbuf;
     if (jl_stat(fname, (char*)&stbuf) != 0 || (stbuf.st_mode & S_IFMT) != S_IFREG) {
         jl_errorf("could not open file %s", fname);
     }
-    return jl_parse_eval_all(fname, NULL, 0, module);
+    return jl_parse_eval_all(fname, NULL, 0, module, mapexpr);
+}
+
+JL_DLLEXPORT jl_value_t *jl_load(jl_module_t *module, const char *fname)
+{
+    return jl_load_rewrite(module, fname, NULL);
 }
 
 // load from filename given as a String object


### PR DESCRIPTION
This PR adds an optional `mapexpr` ~~keyword~~ first argument to `include` and `include_string`, allowing you to specify a function that rewrites each expression after it is parsed.    I've needed this functionality several times, e.g. in SoftScope.jl and ChangePrecision.jl, and it is tricky implement manually in a way that preserves line-number information and other semantics of `include`.

Moreover, now that #33864 has merged, I would like to use the "official" `REPL.softscope!` function in IJulia instead of SoftScope.jl, or equivalently change `SoftScope.jl` to use this function on newer Julia releases.   With this PR, one can just pass `REPL.softscope!` to `include_string`.

To do:
- [x] Tests
- [x] Documentation
- [x] Benchmarking.  Invoking the identity transformation `x->x` adds a 2–3% overhead to `include_string` measured for `"nothing\n"^10000`,  but I eliminated this by optimizing the default case of `mapexpr === identity`.
