### PR TITLE
Update regex.jl with missing `# Examples` headers. 

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -405,6 +405,7 @@ end
 Stores the given string `substr` as a `SubstitutionString`, for use in regular expression
 substitutions. Most commonly constructed using the [`@s_str`](@ref) macro.
 
+# Examples
 ```jldoctest
 julia> SubstitutionString("Hello \\\\g<name>, it's \\\\1")
 s"Hello \\\\g<name>, it's \\\\1"
@@ -440,6 +441,7 @@ Construct a substitution string, used for regular expression substitutions.  Wit
 string, sequences of the form `\\N` refer to the Nth capture group in the regex, and
 `\\g<groupname>` refers to a named capture group with name `groupname`.
 
+# Examples
 ```jldoctest
 julia> msg = "#Hello# from Julia";
 


### PR DESCRIPTION
Added missing `# Examples` headers to the jldoctests.