### PR TITLE
indent formulae on terminal

### DIFF
--- a/stdlib/Markdown/src/IPython/IPython.jl
+++ b/stdlib/Markdown/src/IPython/IPython.jl
@@ -30,6 +30,3 @@ latex(io::IO, tex::LaTeX) =
 
 latexinline(io::IO, tex::LaTeX) =
     print(io, '$', tex.formula, '$')
-
-term(io::IO, tex::LaTeX, cols) = printstyled(io, tex.formula, color=:magenta)
-terminline(io::IO, tex::LaTeX) = printstyled(io, tex.formula, color=:magenta)

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -24,8 +24,7 @@ include("render/plain.jl")
 include("render/html.jl")
 include("render/latex.jl")
 include("render/rst.jl")
-
-include(joinpath("render", "terminal", "render.jl"))
+include("render/terminal/render.jl")
 
 export @md_str, @doc_str
 

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -110,6 +110,10 @@ function term(io::IO, md::Code, columns)
     end
 end
 
+function term(io::IO, tex::LaTeX, columns)
+    printstyled(io, ' '^margin, tex.formula, color=:magenta)
+end
+
 term(io::IO, br::LineBreak, columns) = nothing # line breaks already printed between subsequent elements
 
 function term(io::IO, br::HorizontalRule, columns)
@@ -160,6 +164,10 @@ end
 
 function terminline(io::IO, code::Code)
     printstyled(io, code.code, color=:cyan)
+end
+
+function terminline(io::IO, tex::LaTeX)
+    printstyled(io, tex.formula, color=:magenta)
 end
 
 terminline(io::IO, x) = show(io, MIME"text/plain"(), x)

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -232,6 +232,13 @@ World""" |> plain == "Hello\n\n---\n\nWorld\n"
 @test sprint(term, md"[x](@ref something)") == "  x"
 @test sprint(term, md"![x](https://julialang.org)") == "  (Image: x)"
 
+# math (LaTeX)
+@test sprint(term, md"""
+```math
+A = Q R
+```
+""") == "  A = Q R"
+
 # enumeration is normalized
 let doc = Markdown.parse(
         """


### PR DESCRIPTION
I found LaTeX formulae are not indented in the same way as other components:
```
julia> using LinearAlgebra

help?> qr
search: qr qr! QR QRPivoted sqrt isqrt QuickSort PartialQuickSort

  qr(A, pivot=Val(false); blocksize) -> F

  Compute the QR factorization of the matrix A: an orthogonal (or unitary if A is complex-valued) matrix Q, and an upper
  triangular matrix R such that

A = Q R

  The returned object F stores the factorization in a packed format:
```

This fixes it and adds minor refactoring.