### PR TITLE
remove unused macros `__FILE_SYMBOL__` and `get!`

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -463,14 +463,6 @@ function get!(default::Callable, h::Dict{K,V}, key::K) where V where K
     return v
 end
 
-# NOTE: this macro is trivial, and should
-#       therefore not be exported as-is: it's for internal use only.
-macro get!(h, key0, default)
-    return quote
-        get!(()->$(esc(default)), $(esc(h)), $(esc(key0)))
-    end
-end
-
 
 function getindex(h::Dict{K,V}, key) where V where K
     index = ht_keyindex(h, key)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -797,11 +797,6 @@ macro __LINE__()
     return __source__.line
 end
 
-# Just for bootstrapping purposes below
-macro __FILE_SYMBOL__()
-    return Expr(:quote, __source__.file)
-end
-
 # Iteration
 """
     isdone(itr, state...) -> Union{Bool, Missing}

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -15,7 +15,7 @@ import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu, matprod
 
-import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
+import Base: acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     atan, atand, atanh, broadcast!, conj!, cos, cosc, cosd, cosh, cospi, cot,
     cotd, coth, count, csc, cscd, csch,
     exp10, exp2, findprev, findnext, floor, hash, argmin, inv,


### PR DESCRIPTION
I believe the first was only used in the deprecation code for the new iteration protocol. The second, IIRC, predates higher-order functions being fast and is no longer used anywhere.