### PR TITLE
remove unused @get! macro

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -463,15 +463,6 @@ function get!(default::Callable, h::Dict{K,V}, key::K) where V where K
     return v
 end
 
-# NOTE: this macro is trivial, and should
-#       therefore not be exported as-is: it's for internal use only.
-macro get!(h, key0, default)
-    return quote
-        get!(()->$(esc(default)), $(esc(h)), $(esc(key0)))
-    end
-end
-
-
 function getindex(h::Dict{K,V}, key) where V where K
     index = ht_keyindex(h, key)
     @inbounds return (index < 0) ? throw(KeyError(key)) : h.vals[index]::V

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -15,7 +15,7 @@ import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu, matprod
 
-import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
+import Base: acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     atan, atand, atanh, broadcast!, conj!, cos, cosc, cosd, cosh, cospi, cot,
     cotd, coth, count, csc, cscd, csch,
     exp10, exp2, findprev, findnext, floor, hash, argmin, inv,


### PR DESCRIPTION
I found this macro definition while working on #34621, which is never used in the current codebase.  Perhaps a leftover of refactoring? Since it is not exported and is annotated as internal-use only, I think we can safely remove it without breaking user's code.