### PR TITLE
make REPL ast transforms instance-specific

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -66,20 +66,28 @@ mutable struct REPLBackend
     response_channel::Channel
     "flag indicating the state of this backend"
     in_eval::Bool
+    "transformation functions to apply before evaluating expressions"
+    ast_transforms::Vector{Any}
     "current backend task"
     backend_task::Task
 
-    REPLBackend(repl_channel, response_channel, in_eval) =
-        new(repl_channel, response_channel, in_eval)
+    REPLBackend(repl_channel, response_channel, in_eval, ast_transforms=copy(repl_ast_transforms)) =
+        new(repl_channel, response_channel, in_eval, ast_transforms)
 end
 
-function softscope!(ex)
+"""
+    softscope(ex)
+
+Return a modified version of the parsed expression `ex` that uses
+the REPL's "soft" scoping rules for global syntax blocks.
+"""
+function softscope(@nospecialize ex)
     if ex isa Expr
         h = ex.head
         if h === :toplevel
-            for i = 1:length(ex.args)
-                ex.args[i] = softscope!(ex.args[i])
-            end
+            ex′ = Expr(h)
+            map!(softscope, resize!(ex′.args, length(ex.args)), ex.args)
+            return ex′
         elseif h in (:meta, :import, :using, :export, :module, :error, :incomplete, :thunk)
             return ex
         else
@@ -89,7 +97,10 @@ function softscope!(ex)
     return ex
 end
 
-const repl_ast_transforms = Any[softscope!]
+# Temporary alias until Documenter updates
+const softscope! = softscope
+
+const repl_ast_transforms = Any[softscope] # defaults for new REPL backends
 
 function eval_user_input(@nospecialize(ast), backend::REPLBackend)
     lasterr = nothing
@@ -101,7 +112,7 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend)
                 put!(backend.response_channel, (lasterr,true))
             else
                 backend.in_eval = true
-                for xf in repl_ast_transforms
+                for xf in backend.ast_transforms
                     ast = xf(ast)
                 end
                 value = Core.eval(Main, ast)


### PR DESCRIPTION
As suggested [here](https://github.com/JuliaLang/julia/pull/33864#discussion_r371343045), this makes the REPL ast transformation list specific to a `REPLBackend` instance, though there is a global array of defaults for new instances.

This PR also changes `REPL.softscope!` to `REPL.sofscope`.  There doesn't seem to be a big advantage to having this function mutating, and the non-mutating version is easier to use safely.  (In particular, though passing the mutating version to the new `include` function in #34595 is safe because the AST expressions are temporary, that would require us to document this property of `include` which is bothersome.)