### PR TITLE
fix docstrings of floatmin and floatmax

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -750,17 +750,30 @@ end
 end
 
 """
-    floatmin(T)
+    floatmin([T])
 
-The smallest in absolute value non-subnormal value representable by the given
-floating-point DataType `T`.
+Return the smallest positive normal number representable by the floating-point
+type `T` (`T = Float64` by default).
+
+# Examples
+```jldoctest
+julia> floatmin(Float16)
+Float16(6.104e-5)
+
+julia> floatmin(Float32)
+1.1754944f-38
+
+julia> floatmin()
+2.2250738585072014e-308
+```
 """
 floatmin(x::T) where {T<:AbstractFloat} = floatmin(T)
 
 """
-    floatmax(T)
+    floatmax([T])
 
-The highest finite value representable by the given floating-point DataType `T`.
+Return the largest finite number representable by the floating-point type `T`
+(`T = Float64` by default).
 
 # Examples
 ```jldoctest
@@ -769,6 +782,9 @@ Float16(6.55e4)
 
 julia> floatmax(Float32)
 3.4028235f38
+
+julia> floatmax()
+1.7976931348623157e308
 ```
 """
 floatmax(x::T) where {T<:AbstractFloat} = floatmax(T)

--- a/base/float.jl
+++ b/base/float.jl
@@ -750,7 +750,7 @@ end
 end
 
 """
-    floatmin([T])
+    floatmin(T = Float64)
 
 Return the smallest positive normal number representable by the floating-point
 type `T` (`T = Float64` by default).

--- a/base/float.jl
+++ b/base/float.jl
@@ -753,7 +753,7 @@ end
     floatmin(T = Float64)
 
 Return the smallest positive normal number representable by the floating-point
-type `T` (`T = Float64` by default).
+type `T`.
 
 # Examples
 ```jldoctest
@@ -770,10 +770,9 @@ julia> floatmin()
 floatmin(x::T) where {T<:AbstractFloat} = floatmin(T)
 
 """
-    floatmax([T])
+    floatmax(T = Float64)
 
-Return the largest finite number representable by the floating-point type `T`
-(`T = Float64` by default).
+Return the largest finite number representable by the floating-point type `T`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The current docstring of `floatmin` says:
>  The smallest in absolute value non-subnormal value representable by the given floating-point DataType T.

If we literally interpret this sentence, the returned value would be zero, because zero is not a subnormal number with the minimum absolute value. So I changed it as "the smallest positive normal number". 

Also, the style does not follow the standard guideline of docstrings. So I fixed it as well and made the docstrings of `floatmin` and `floatmax` more symmetric.