### PR TITLE
fix doctests for devdocs inlinable computation

### DIFF
--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -109,11 +109,26 @@ cst = map(cost, ci.code)
 
 # output
 
-5-element Array{Int64,1}:
+31-element Array{Int64,1}:
   0
   0
  20
- 20
+  4
+  1
+  1
+  1
+  0
+  0
+  0
+  ⋮
+  0
+  0
+  0
+  0
+  1
+  0
+  0
+  0
   0
 ```
 


### PR DESCRIPTION
Probably changed in https://github.com/JuliaLang/julia/pull/31626.