### PR TITLE
Windows - guidance for shell mode in the REPL

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -135,7 +135,23 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 shell> echo hello
 hello
 ```
+* Note for Windows users: Julia Shell mode does not expose windows shell commands.Hence, this will fail: 
+```julia-repl
+julia> ; # upon typing ;, the prompt changes (in place) to: shell>
+shell> dir
+ERROR: IOError: could not spawn `dir`: no such file or directory (ENOENT)
+Stacktrace!
+.......
+```
+However, you can get access to Power Shell like this:
+```julia-repl
+julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 
+shell> powershell
+Windows PowerShell
+Copyright (C) Microsoft Corporation. Tous droits réservés.
+PS C:\Users\elm>
+```
 ### Search modes
 
 In all of the above modes, the executed lines get saved to a history file, which can be searched.

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -135,15 +135,19 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 shell> echo hello
 hello
 ```
-* Note for Windows users: Julia Shell mode does not expose windows shell commands.Hence, this will fail: 
+!!! note
+    For Windows users, Julia's shell mode does not expose windows shell commands.
+    Hence, this will fail:
+
 ```julia-repl
 julia> ; # upon typing ;, the prompt changes (in place) to: shell>
+
 shell> dir
 ERROR: IOError: could not spawn `dir`: no such file or directory (ENOENT)
 Stacktrace!
 .......
 ```
-However, you can get access to Power Shell like this:
+However, you can get access to `PowerShell` like this:
 ```julia-repl
 julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 
@@ -152,6 +156,23 @@ Windows PowerShell
 Copyright (C) Microsoft Corporation. Tous droits réservés.
 PS C:\Users\elm>
 ```
+... and to `cmd.exe` like that (see the `dir` command):
+```julia-repl
+julia> ; # upon typing ;, the prompt changes (in place) to: shell>
+
+shell> cmd
+Microsoft Windows [version 10.0.17763.973]
+(c) 2018 Microsoft Corporation. Tous droits réservés.
+C:\Users\elm>dir
+ Le volume dans le lecteur C s’appelle Windows
+ Le numéro de série du volume est F62C-E199
+  Répertoire de C:\Users\elm
+
+29/01/2020  22:15    <DIR>          .
+29/01/2020  22:15    <DIR>          ..
+02/02/2020  08:06    <DIR>          .atom
+```
+
 ### Search modes
 
 In all of the above modes, the executed lines get saved to a history file, which can be searched.

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -153,7 +153,7 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 
 shell> powershell
 Windows PowerShell
-Copyright (C) Microsoft Corporation. Tous droits réservés.
+Copyright (C) Microsoft Corporation. All rights reserved.
 PS C:\Users\elm>
 ```
 ... and to `cmd.exe` like that (see the `dir` command):
@@ -162,11 +162,11 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 
 shell> cmd
 Microsoft Windows [version 10.0.17763.973]
-(c) 2018 Microsoft Corporation. Tous droits réservés.
+(c) 2018 Microsoft Corporation. All rights reserved.
 C:\Users\elm>dir
- Le volume dans le lecteur C s’appelle Windows
- Le numéro de série du volume est F62C-E199
-  Répertoire de C:\Users\elm
+ Volume in drive C has no label
+ Volume Serial Number is 1643-0CD7
+  Directory of C:\Users\elm
 
 29/01/2020  22:15    <DIR>          .
 29/01/2020  22:15    <DIR>          ..


### PR DESCRIPTION
Shell mode behavior is currently very non intuitive on Windows. It essentially does nothing a basic user (that would be me..) understands by shell mode (list directory, show environment variables etc) . So I clarified, and showed a way to fire up the two most common shells, `cmd.exe` and `powershell`. 