### PR TITLE
inserteach! of Vector into Vector

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1300,9 +1300,14 @@ function insert!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) wher
     elseif itemslen === 0
         return a
     end
-    sortindices = sortperm(indices) # sorts so the final index is correct
-    indices_sorted = indices[sortindices]
-    items_sorted = items[sortindices]
+    if issorted(indices) # based on the tests overhead/advantage is low
+        indices_sorted = indices
+        items_sorted = items
+    else
+        sort_indices = sortperm(indices) # sorts so the final index is correct
+        indices_sorted = indices[sort_indices]
+        items_sorted = items[sort_indices]
+    end
     _growat!.(Ref(a), indices_sorted, 1) # does bound check
     @inbounds for (index, item) in zip(indices_sorted, items_sorted)
         a[index] = item
@@ -1319,11 +1324,16 @@ function insert!(a::Array{T,1}, indices::AbstractRange{<:Integer}, items::Array{
     elseif itemslen === 0
         return a
     end
-    indicessorted = sort(indices) # sorting them is faster than indexing into them
-    sortindices = sortperm(indices) # sorts so the final index is correct
-    items_sorted = items[sortindices]
-    _growat!.(Ref(a), indicessorted, 1) # does bound check
-    @inbounds for (index, item) in zip(indicessorted, items_sorted)
+    if issorted(indices) # based on the tests overhead/advantage is low
+        indices_sorted = indices
+        items_sorted = items
+    else
+        indices_sorted = sort(indices) # sorting them is faster than indexing into them
+        sort_indices = sortperm(indices) # sorts so the final index is correct
+        items_sorted = items[sort_indices]
+    end
+    _growat!.(Ref(a), indices_sorted, 1) # does bound check
+    @inbounds for (index, item) in zip(indices_sorted, items_sorted)
         a[index] = item
     end
     return a

--- a/base/array.jl
+++ b/base/array.jl
@@ -1234,14 +1234,14 @@ julia> inserteach!([1, 2, 3], 2, [8, 9])
  3
 ```
 """
-function inserteach!(a::Vector, i::Integer, items::AbstractVector)
+function inserteach!(a::Vector, index::Integer, items::AbstractVector)
     m = length(items)
     if m === 0
         return a
     end
-    _growat!(a, i, m)  # does bound check
-    @inbounds for k = i:i+m-1
-        a[k] = items[k-i+1]
+    _growat!(a, index, m)  # does bound check
+    @inbounds for k = index:index+m-1
+        a[k] = items[k-index+1]
     end
     return a
 end
@@ -1263,7 +1263,7 @@ julia> inserteach!([1, 2, 3], 2:3, [8, 9])
  3
 ```
 
-Following example inserts `10, 9, and 8` at index `6 ,4, and 2` respectively
+Following example inserts `10, 9, and 8` at index `6, 4, and 2` respectively
 ```jldoctest
 julia> inserteach!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
 8-element Array{Int64,1}:

--- a/base/array.jl
+++ b/base/array.jl
@@ -1216,6 +1216,11 @@ function insert!(a::Array{T,1}, i::Integer, item) where T
     return a
 end
 
+function insert!(a::Array{T,1}, i::Integer, item::T) where T
+    _growat!(a, i, 1) # does bound check
+    @inbounds a[i] = item
+    return a
+end
 """
     deleteat!(a::Vector, i::Integer)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1216,12 +1216,6 @@ function insert!(a::Array{T,1}, i::Integer, item) where T
     return a
 end
 
-function insert!(a::Array{T,1}, i::Integer, item::T) where T
-    _growat!(a, i, 1) # does bound check
-    @inbounds a[i] = item
-    return a
-end
-
 """
     insert!(a::Vector, index::Integer, items::Vector)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1221,6 +1221,37 @@ function insert!(a::Array{T,1}, i::Integer, item::T) where T
     @inbounds a[i] = item
     return a
 end
+
+"""
+    insert!(a::Vector, index::Integer, items::Vector)
+
+Insert all of the elements of `items` into `a` at the given `index`. `index` is the index of first element of `items` in the resulting `a`.
+
+# Examples
+```jldoctest
+julia> insert!([6, 5, 4, 2, 1], 4, [8, 9, 9])
+8-element Array{Int64,1}:
+ 6
+ 5
+ 4
+ 8
+ 9
+ 9
+ 2
+ 1
+```
+"""
+function insert!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
+    m = length(items)
+    if m === 0
+        return a
+    end
+    _growat!(a, i, m)  # does bound check
+    @inbounds for k = i:i+m-1
+        a[k] = items[k-i+1]
+    end
+    return a
+end
 """
     deleteat!(a::Vector, i::Integer)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1234,7 +1234,7 @@ julia> inserteach!([1, 2, 3], 2, [8, 9])
  3
 ```
 """
-function inserteach!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
+function inserteach!(a::Vector, i::Integer, items::AbstractVector)
     m = length(items)
     if m === 0
         return a
@@ -1288,7 +1288,7 @@ julia> inserteach!([1, 2, 3], [true, false, true, false, false], [10, 9])
   3
 ```
 """
-function inserteach!(a::Array{T,1}, indices::Union{AbstractVector, AbstractRange{<:Integer}}, items::Array{T,1}) where {T}
+function inserteach!(a::Vector, indices::Union{AbstractVector, AbstractRange{<:Integer}}, items::AbstractVector)
     itemslen = length(items)
     indiceslen = length(indices)
     if itemslen !== indiceslen
@@ -1324,7 +1324,7 @@ function sort_indices_items(indices::AbstractRange{<:Integer}, items)
     return indices_sorted, items_sorted
 end
 
-function inserteach!(a::Array{T,1}, r::AbstractUnitRange{<:Integer}, items::Array{T,1}) where T
+function inserteach!(a::Vector, r::AbstractUnitRange{<:Integer}, items::AbstractVector)
     ilen = length(items)
     rlen = length(r)
     if ilen !== rlen
@@ -1334,7 +1334,7 @@ function inserteach!(a::Array{T,1}, r::AbstractUnitRange{<:Integer}, items::Arra
     end
 end
 
-function inserteach!(a::Array{T,1}, boolindices::AbstractVector{Bool}, items::Array{T,1}) where T
+function inserteach!(a::Vector, boolindices::AbstractVector{Bool}, items::AbstractVector)
     alen = length(a)
     itemslen = length(items)
     boolindiceslen = length(boolindices)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1310,7 +1310,26 @@ function insert!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) wher
     return a
 end
 
-function insert!(a::Array{T,1}, r::UnitRange{<:Integer}, items::Array{T,1}) where T
+
+function insert!(a::Array{T,1}, indices::AbstractRange{<:Integer}, items::Array{T,1}) where {T}
+    itemslen = length(items)
+    indiceslen = length(indices)
+    if itemslen !== indiceslen
+        throw(DimensionMismatch("Length of the indices and items should be the same"))
+    elseif itemslen === 0
+        return a
+    end
+    indicessorted = sort(indices) # sorting them is faster than indexing into them
+    sortindices = sortperm(indices) # sorts so the final index is correct
+    items_sorted = items[sortindices]
+    _growat!.(Ref(a), indicessorted, 1) # does bound check
+    @inbounds for (index, item) in zip(indicessorted, items_sorted)
+        a[index] = item
+    end
+    return a
+end
+
+function insert!(a::Array{T,1}, r::AbstractUnitRange{<:Integer}, items::Array{T,1}) where T
     ilen = length(items)
     rlen = length(r)
     if ilen !== rlen

--- a/base/array.jl
+++ b/base/array.jl
@@ -1229,16 +1229,13 @@ Insert all of the elements of `items` into `a` at the given `index`. `index` is 
 
 # Examples
 ```jldoctest
-julia> insert!([6, 5, 4, 2, 1], 4, [8, 9, 9])
-8-element Array{Int64,1}:
- 6
- 5
- 4
+julia> insert!([1, 2, 3], 2, [8, 9])
+5-element Array{Int64,1}:
+ 1
  8
  9
- 9
  2
- 1
+ 3
 ```
 """
 function insert!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
@@ -1261,14 +1258,13 @@ Insert all of the elements of `items` into `a` for the given `range` or `indices
 
 # Examples
 ```jldoctest
-julia> insert!([1, 2, 3, 4], 3:4, [8, 9])
-6-element Array{Int64,1}:
+julia> insert!([1, 2, 3], 2:3, [8, 9])
+5-element Array{Int64,1}:
  1
- 2
  8
  9
+ 2
  3
- 4
 ```
 
 Following example inserts `10, 9, and 8` at index `6 ,4, and 2` respectively

--- a/base/array.jl
+++ b/base/array.jl
@@ -1303,9 +1303,9 @@ function inserteach!(a::Vector, indices::Union{AbstractVector, AbstractRange{<:I
         # sorts so the final index is correct
         indices_sorted, items_sorted = sort_indices_items(indices, items)
     end
-    _growat!.(Ref(a), indices_sorted, 1) # does bound check
-    @inbounds for (index, item) in zip(indices_sorted, items_sorted)
-        a[index] = item
+    for (index, item) in zip(indices_sorted, items_sorted)
+        _growat!(a, index, 1) # TODO write a batch growat in C for speed-up
+        @inbounds a[index] = item
     end
     return a
 end
@@ -1348,9 +1348,9 @@ function inserteach!(a::Vector, boolindices::AbstractVector{Bool}, items::Abstra
     elseif itemslen === 0
         return a
     end
-    _growat!.(Ref(a), indices, 1) # does bound check
-    @inbounds for (index, item) in zip(indices, items)
-        a[index] = item
+    for (index, item) in zip(indices, items)
+        _growat!(a, index, 1) # TODO write a batch growat in C for speed-up
+        @inbounds a[index] = item
     end
     return a
 end

--- a/base/array.jl
+++ b/base/array.jl
@@ -1252,6 +1252,67 @@ function insert!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
     end
     return a
 end
+
+"""
+    insert!(a::Vector, range, items::Vector)
+    insert!(a::Vector, indices::Vector, items::Vector)
+
+Insert all of the elements of `items` into `a` for the given `range` or `indices`. `range` or `indices` are the resulting indices of elements of `items` in the `a`.
+
+# Examples
+```jldoctest
+julia> insert!([1, 2, 3, 4], 3:4, [8, 9])
+6-element Array{Int64,1}:
+ 1
+ 2
+ 8
+ 9
+ 3
+ 4
+```
+
+Following example inserts `10, 9, and 8` at index `6 ,4, and 2` respectively
+```jldoctest
+julia> insert!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
+8-element Array{Int64,1}:
+  1
+  8
+  2
+  9
+  3
+ 10
+  4
+  5
+```
+"""
+function insert!(a::Array{T1,1}, indices::T2, items::Array{T1,1}) where {T1} where {T2<:Union{Array{<:Integer,1}, OrdinalRange{<:Integer, <:Integer}}}
+    itemslen = length(items)
+    indiceslen = length(indices)
+    if itemslen !== indiceslen
+        throw(DimensionMismatch("Length of the indices and items should be the same"))
+    elseif itemslen === 0
+        return a
+    end
+    sortindices = sortperm(indices) # sorts so the final index is correct
+    indices_sorted = indices[sortindices]
+    items_sorted = items[sortindices]
+    _growat!.(Ref(a), indices_sorted, 1) # does bound check
+    @inbounds for (index, item) in zip(indices_sorted, items_sorted)
+        a[index] = item
+    end
+    return a
+end
+
+function insert!(a::Array{T,1}, r::UnitRange{<:Integer}, items::Array{T,1}) where T
+    ilen = length(items)
+    rlen = length(r)
+    if ilen !== rlen
+        throw(DimensionMismatch("Length of the range and items should be the same"))
+    else
+        return insert!(a, first(r), items)
+    end
+end
+
 """
     deleteat!(a::Vector, i::Integer)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1195,6 +1195,8 @@ end
 Insert an `item` into `a` at the given `index`. `index` is the index of `item` in
 the resulting `a`.
 
+See [`insert_elements!`](@ref) for inserting the elements of a vector into another vector.
+
 # Examples
 ```jldoctest
 julia> insert!([6, 5, 4, 2, 1], 4, 3)
@@ -1217,13 +1219,13 @@ function insert!(a::Array{T,1}, i::Integer, item) where T
 end
 
 """
-    insert!(a::Vector, index::Integer, items::Vector)
+    insert_elements!(a::Vector, index::Integer, items::Vector)
 
 Insert all of the elements of `items` into `a` at the given `index`. `index` is the index of first element of `items` in the resulting `a`.
 
 # Examples
 ```jldoctest
-julia> insert!([1, 2, 3], 2, [8, 9])
+julia> insert_elements!([1, 2, 3], 2, [8, 9])
 5-element Array{Int64,1}:
  1
  8
@@ -1232,7 +1234,7 @@ julia> insert!([1, 2, 3], 2, [8, 9])
  3
 ```
 """
-function insert!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
+function insert_elements!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
     m = length(items)
     if m === 0
         return a
@@ -1245,14 +1247,14 @@ function insert!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
 end
 
 """
-    insert!(a::Vector, range, items::Vector)
-    insert!(a::Vector, indices::Vector, items::Vector)
+    insert_elements!(a::Vector, range, items::Vector)
+    insert_elements!(a::Vector, indices::Vector, items::Vector)
 
 Insert all of the elements of `items` into `a` for the given `range` or `indices`. `range` or `indices` are the resulting indices of elements of `items` in the `a`.
 
 # Examples
 ```jldoctest
-julia> insert!([1, 2, 3], 2:3, [8, 9])
+julia> insert_elements!([1, 2, 3], 2:3, [8, 9])
 5-element Array{Int64,1}:
  1
  8
@@ -1263,7 +1265,7 @@ julia> insert!([1, 2, 3], 2:3, [8, 9])
 
 Following example inserts `10, 9, and 8` at index `6 ,4, and 2` respectively
 ```jldoctest
-julia> insert!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
+julia> insert_elements!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
 8-element Array{Int64,1}:
   1
   8
@@ -1277,7 +1279,7 @@ julia> insert!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
 
 It is possible to use boolean indices (each true shows insertion index):
 ```jldoctest
-julia> insert!([1, 2, 3], [true, false, true, false, false], [10, 9])
+julia> insert_elements!([1, 2, 3], [true, false, true, false, false], [10, 9])
 5-element Array{Int64,1}:
  10
   1
@@ -1286,7 +1288,7 @@ julia> insert!([1, 2, 3], [true, false, true, false, false], [10, 9])
   3
 ```
 """
-function insert!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) where {T}
+function insert_elements!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) where {T}
     itemslen = length(items)
     indiceslen = length(indices)
     if itemslen !== indiceslen
@@ -1310,7 +1312,7 @@ function insert!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) wher
 end
 
 
-function insert!(a::Array{T,1}, indices::AbstractRange{<:Integer}, items::Array{T,1}) where {T}
+function insert_elements!(a::Array{T,1}, indices::AbstractRange{<:Integer}, items::Array{T,1}) where {T}
     itemslen = length(items)
     indiceslen = length(indices)
     if itemslen !== indiceslen
@@ -1333,17 +1335,17 @@ function insert!(a::Array{T,1}, indices::AbstractRange{<:Integer}, items::Array{
     return a
 end
 
-function insert!(a::Array{T,1}, r::AbstractUnitRange{<:Integer}, items::Array{T,1}) where T
+function insert_elements!(a::Array{T,1}, r::AbstractUnitRange{<:Integer}, items::Array{T,1}) where T
     ilen = length(items)
     rlen = length(r)
     if ilen !== rlen
         throw(DimensionMismatch("Length of the range and items should be the same"))
     else
-        return insert!(a, first(r), items)
+        return insert_elements!(a, first(r), items)
     end
 end
 
-function insert!(a::Array{T,1}, boolindices::AbstractVector{Bool}, items::Array{T,1}) where T
+function insert_elements!(a::Array{T,1}, boolindices::AbstractVector{Bool}, items::Array{T,1}) where T
     alen = length(a)
     itemslen = length(items)
     boolindiceslen = length(boolindices)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1195,7 +1195,7 @@ end
 Insert an `item` into `a` at the given `index`. `index` is the index of `item` in
 the resulting `a`.
 
-See [`insert_elements!`](@ref) for inserting the elements of a vector into another vector.
+See [`inserteach!`](@ref) for inserting the elements of a vector into another vector.
 
 # Examples
 ```jldoctest
@@ -1219,13 +1219,13 @@ function insert!(a::Array{T,1}, i::Integer, item) where T
 end
 
 """
-    insert_elements!(a::Vector, index::Integer, items::Vector)
+    inserteach!(a::Vector, index::Integer, items::Vector)
 
 Insert all of the elements of `items` into `a` at the given `index`. `index` is the index of first element of `items` in the resulting `a`.
 
 # Examples
 ```jldoctest
-julia> insert_elements!([1, 2, 3], 2, [8, 9])
+julia> inserteach!([1, 2, 3], 2, [8, 9])
 5-element Array{Int64,1}:
  1
  8
@@ -1234,7 +1234,7 @@ julia> insert_elements!([1, 2, 3], 2, [8, 9])
  3
 ```
 """
-function insert_elements!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
+function inserteach!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T}
     m = length(items)
     if m === 0
         return a
@@ -1247,14 +1247,14 @@ function insert_elements!(a::Array{T,1}, i::Integer, items::Array{T,1}) where {T
 end
 
 """
-    insert_elements!(a::Vector, range, items::Vector)
-    insert_elements!(a::Vector, indices::Vector, items::Vector)
+    inserteach!(a::Vector, range, items::Vector)
+    inserteach!(a::Vector, indices::Vector, items::Vector)
 
 Insert all of the elements of `items` into `a` for the given `range` or `indices`. `range` or `indices` are the resulting indices of elements of `items` in the `a`.
 
 # Examples
 ```jldoctest
-julia> insert_elements!([1, 2, 3], 2:3, [8, 9])
+julia> inserteach!([1, 2, 3], 2:3, [8, 9])
 5-element Array{Int64,1}:
  1
  8
@@ -1265,7 +1265,7 @@ julia> insert_elements!([1, 2, 3], 2:3, [8, 9])
 
 Following example inserts `10, 9, and 8` at index `6 ,4, and 2` respectively
 ```jldoctest
-julia> insert_elements!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
+julia> inserteach!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
 8-element Array{Int64,1}:
   1
   8
@@ -1279,7 +1279,7 @@ julia> insert_elements!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8])
 
 It is possible to use boolean indices (each true shows insertion index):
 ```jldoctest
-julia> insert_elements!([1, 2, 3], [true, false, true, false, false], [10, 9])
+julia> inserteach!([1, 2, 3], [true, false, true, false, false], [10, 9])
 5-element Array{Int64,1}:
  10
   1
@@ -1288,7 +1288,7 @@ julia> insert_elements!([1, 2, 3], [true, false, true, false, false], [10, 9])
   3
 ```
 """
-function insert_elements!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) where {T}
+function inserteach!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) where {T}
     itemslen = length(items)
     indiceslen = length(indices)
     if itemslen !== indiceslen
@@ -1312,7 +1312,7 @@ function insert_elements!(a::Array{T,1}, indices::AbstractVector, items::Array{T
 end
 
 
-function insert_elements!(a::Array{T,1}, indices::AbstractRange{<:Integer}, items::Array{T,1}) where {T}
+function inserteach!(a::Array{T,1}, indices::AbstractRange{<:Integer}, items::Array{T,1}) where {T}
     itemslen = length(items)
     indiceslen = length(indices)
     if itemslen !== indiceslen
@@ -1335,17 +1335,17 @@ function insert_elements!(a::Array{T,1}, indices::AbstractRange{<:Integer}, item
     return a
 end
 
-function insert_elements!(a::Array{T,1}, r::AbstractUnitRange{<:Integer}, items::Array{T,1}) where T
+function inserteach!(a::Array{T,1}, r::AbstractUnitRange{<:Integer}, items::Array{T,1}) where T
     ilen = length(items)
     rlen = length(r)
     if ilen !== rlen
         throw(DimensionMismatch("Length of the range and items should be the same"))
     else
-        return insert_elements!(a, first(r), items)
+        return inserteach!(a, first(r), items)
     end
 end
 
-function insert_elements!(a::Array{T,1}, boolindices::AbstractVector{Bool}, items::Array{T,1}) where T
+function inserteach!(a::Array{T,1}, boolindices::AbstractVector{Bool}, items::Array{T,1}) where T
     alen = length(a)
     itemslen = length(items)
     boolindiceslen = length(boolindices)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1292,7 +1292,7 @@ julia> insert!([1, 2, 3], [true, false, true, false, false], [10, 9])
   3
 ```
 """
-function insert!(a::Array{T1,1}, indices::T2, items::Array{T1,1}) where {T1} where {T2<:Union{Array{<:Integer,1}, OrdinalRange{<:Integer, <:Integer}}}
+function insert!(a::Array{T,1}, indices::AbstractVector, items::Array{T,1}) where {T}
     itemslen = length(items)
     indiceslen = length(indices)
     if itemslen !== indiceslen

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -467,6 +467,7 @@ export
 # dequeues
     append!,
     insert!,
+    insert_elements!,
     pop!,
     prepend!,
     push!,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -467,7 +467,7 @@ export
 # dequeues
     append!,
     insert!,
-    insert_elements!,
+    inserteach!,
     pop!,
     prepend!,
     push!,

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -272,6 +272,7 @@ Base.pop!
 Base.pushfirst!
 Base.popfirst!
 Base.insert!
+Base.inserteach!
 Base.deleteat!
 Base.splice!
 Base.resize!

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -484,6 +484,17 @@ end
     # non-sorted indices vector
     @test inserteach!([1, 2, 3, 4, 5], [6, 5, 4], [10, 9, 8]) ==
     [1, 2, 3, 8, 9, 10, 4, 5]
+
+    # items of 0 length
+    @test Base.inserteach!([6, 5, 4, 2, 1], 4, []) == [6, 5, 4, 2, 1]
+    # items and indices of 0 length
+    @test Base.inserteach!([6, 5, 4, 2, 1], 4:3, []) == [6, 5, 4, 2, 1]
+    # items of 0 length and indices of any other length
+    @test_throws DimensionMismatch Base.inserteach!([6, 5, 4, 2, 1], 4:5, [])
+    # 0 index
+    @test_throws BoundsError Base.inserteach!([6, 5, 4, 2, 1], 0, [1, 2])
+    @test_throws BoundsError Base.inserteach!([6, 5, 4, 2, 1], 0:1, [1, 2])
+
 end
 @testset "concatenation" begin
     @test isequal([fill(1.,2,2)  fill(2.,2,1)], [1. 1 2; 1 1 2])

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -462,6 +462,10 @@ end
         @test vc == [v[1:(i-1)]; 5; v[i:end]]
     end
     @test_throws BoundsError insert!(v, 5, 5)
+
+    @test insert!([6, 5, 4, 2, 1], 4, [8, 9, 9]) === [6, 5, 4, 8, 9, 9, 2, 1]
+    @test_throws BoundsError insert!([6, 5, 4], 5, [8, 9])
+
 end
 @testset "concatenation" begin
     @test isequal([fill(1.,2,2)  fill(2.,2,1)], [1. 1 2; 1 1 2])

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -477,6 +477,13 @@ end
     @test insert!([1, 2, 3], [true, false, true, false, false], [10, 9]) == [10, 1, 9, 2, 3]
     @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false], [10, 9])
     @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false, true], [10, 9])
+
+    # sorted indices vector
+    @test insert!([1, 2, 3, 4, 5], [4, 5, 6], [10, 9, 8]) ==
+    [1, 2, 3, 10, 9, 8, 4, 5]
+    # non-sorted indices vector
+    @test insert!([1, 2, 3, 4, 5], [6, 5, 4], [10, 9, 8]) ==
+    [1, 2, 3, 8, 9, 10, 4, 5]
 end
 @testset "concatenation" begin
     @test isequal([fill(1.,2,2)  fill(2.,2,1)], [1. 1 2; 1 1 2])

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -463,26 +463,26 @@ end
     end
     @test_throws BoundsError insert!(v, 5, 5)
 
-    @test insert!([6, 5, 4, 2, 1], 4, [8, 9, 9]) == [6, 5, 4, 8, 9, 9, 2, 1]
-    @test_throws BoundsError insert!([6, 5, 4], 5, [8, 9])
+    @test insert_elements!([6, 5, 4, 2, 1], 4, [8, 9, 9]) == [6, 5, 4, 8, 9, 9, 2, 1]
+    @test_throws BoundsError insert_elements!([6, 5, 4], 5, [8, 9])
 
-    @test insert!([1, 2, 3, 4], 3:4, [8, 9]) == [1, 2, 8, 9, 3, 4]
-    @test_throws BoundsError insert!([6, 5, 4], 5:6, [8, 9])
-    @test_throws DimensionMismatch insert!([6, 5, 4], 4:6, [8, 9])
+    @test insert_elements!([1, 2, 3, 4], 3:4, [8, 9]) == [1, 2, 8, 9, 3, 4]
+    @test_throws BoundsError insert_elements!([6, 5, 4], 5:6, [8, 9])
+    @test_throws DimensionMismatch insert_elements!([6, 5, 4], 4:6, [8, 9])
 
-    @test insert!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8]) == [1, 8, 2, 9, 3, 10, 4, 5]
-    @test_throws BoundsError insert!([6, 5, 4], 6:-1:5, [8, 9])
-    @test_throws DimensionMismatch insert!([6, 5, 4], 5:-1:4, [8, 9, 9])
+    @test insert_elements!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8]) == [1, 8, 2, 9, 3, 10, 4, 5]
+    @test_throws BoundsError insert_elements!([6, 5, 4], 6:-1:5, [8, 9])
+    @test_throws DimensionMismatch insert_elements!([6, 5, 4], 5:-1:4, [8, 9, 9])
 
-    @test insert!([1, 2, 3], [true, false, true, false, false], [10, 9]) == [10, 1, 9, 2, 3]
-    @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false], [10, 9])
-    @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false, true], [10, 9])
+    @test insert_elements!([1, 2, 3], [true, false, true, false, false], [10, 9]) == [10, 1, 9, 2, 3]
+    @test_throws ArgumentError insert_elements!([1, 2, 3], [true, false, true, false], [10, 9])
+    @test_throws ArgumentError insert_elements!([1, 2, 3], [true, false, true, false, true], [10, 9])
 
     # sorted indices vector
-    @test insert!([1, 2, 3, 4, 5], [4, 5, 6], [10, 9, 8]) ==
+    @test insert_elements!([1, 2, 3, 4, 5], [4, 5, 6], [10, 9, 8]) ==
     [1, 2, 3, 10, 9, 8, 4, 5]
     # non-sorted indices vector
-    @test insert!([1, 2, 3, 4, 5], [6, 5, 4], [10, 9, 8]) ==
+    @test insert_elements!([1, 2, 3, 4, 5], [6, 5, 4], [10, 9, 8]) ==
     [1, 2, 3, 8, 9, 10, 4, 5]
 end
 @testset "concatenation" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -463,26 +463,26 @@ end
     end
     @test_throws BoundsError insert!(v, 5, 5)
 
-    @test insert_elements!([6, 5, 4, 2, 1], 4, [8, 9, 9]) == [6, 5, 4, 8, 9, 9, 2, 1]
-    @test_throws BoundsError insert_elements!([6, 5, 4], 5, [8, 9])
+    @test inserteach!([6, 5, 4, 2, 1], 4, [8, 9, 9]) == [6, 5, 4, 8, 9, 9, 2, 1]
+    @test_throws BoundsError inserteach!([6, 5, 4], 5, [8, 9])
 
-    @test insert_elements!([1, 2, 3, 4], 3:4, [8, 9]) == [1, 2, 8, 9, 3, 4]
-    @test_throws BoundsError insert_elements!([6, 5, 4], 5:6, [8, 9])
-    @test_throws DimensionMismatch insert_elements!([6, 5, 4], 4:6, [8, 9])
+    @test inserteach!([1, 2, 3, 4], 3:4, [8, 9]) == [1, 2, 8, 9, 3, 4]
+    @test_throws BoundsError inserteach!([6, 5, 4], 5:6, [8, 9])
+    @test_throws DimensionMismatch inserteach!([6, 5, 4], 4:6, [8, 9])
 
-    @test insert_elements!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8]) == [1, 8, 2, 9, 3, 10, 4, 5]
-    @test_throws BoundsError insert_elements!([6, 5, 4], 6:-1:5, [8, 9])
-    @test_throws DimensionMismatch insert_elements!([6, 5, 4], 5:-1:4, [8, 9, 9])
+    @test inserteach!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8]) == [1, 8, 2, 9, 3, 10, 4, 5]
+    @test_throws BoundsError inserteach!([6, 5, 4], 6:-1:5, [8, 9])
+    @test_throws DimensionMismatch inserteach!([6, 5, 4], 5:-1:4, [8, 9, 9])
 
-    @test insert_elements!([1, 2, 3], [true, false, true, false, false], [10, 9]) == [10, 1, 9, 2, 3]
-    @test_throws ArgumentError insert_elements!([1, 2, 3], [true, false, true, false], [10, 9])
-    @test_throws ArgumentError insert_elements!([1, 2, 3], [true, false, true, false, true], [10, 9])
+    @test inserteach!([1, 2, 3], [true, false, true, false, false], [10, 9]) == [10, 1, 9, 2, 3]
+    @test_throws ArgumentError inserteach!([1, 2, 3], [true, false, true, false], [10, 9])
+    @test_throws ArgumentError inserteach!([1, 2, 3], [true, false, true, false, true], [10, 9])
 
     # sorted indices vector
-    @test insert_elements!([1, 2, 3, 4, 5], [4, 5, 6], [10, 9, 8]) ==
+    @test inserteach!([1, 2, 3, 4, 5], [4, 5, 6], [10, 9, 8]) ==
     [1, 2, 3, 10, 9, 8, 4, 5]
     # non-sorted indices vector
-    @test insert_elements!([1, 2, 3, 4, 5], [6, 5, 4], [10, 9, 8]) ==
+    @test inserteach!([1, 2, 3, 4, 5], [6, 5, 4], [10, 9, 8]) ==
     [1, 2, 3, 8, 9, 10, 4, 5]
 end
 @testset "concatenation" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -474,6 +474,9 @@ end
     @test_throws BoundsError insert!([6, 5, 4], 6:-1:5, [8, 9])
     @test_throws DimensionMismatch insert!([6, 5, 4], 5:-1:4, [8, 9, 9])
 
+    @test insert!([1, 2, 3], [true, false, true, false, false], [10, 9]) ===  [10, 1, 9, 2, 3]
+    @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false], [10, 9])
+    @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false, true], [10, 9])
 end
 @testset "concatenation" begin
     @test isequal([fill(1.,2,2)  fill(2.,2,1)], [1. 1 2; 1 1 2])

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -466,6 +466,14 @@ end
     @test insert!([6, 5, 4, 2, 1], 4, [8, 9, 9]) === [6, 5, 4, 8, 9, 9, 2, 1]
     @test_throws BoundsError insert!([6, 5, 4], 5, [8, 9])
 
+    @test insert!([1, 2, 3, 4], 3:4, [8, 9]) === [1, 2, 8, 9, 3, 4]
+    @test_throws BoundsError insert!([6, 5, 4], 5:6, [8, 9])
+    @test_throws DimensionMismatch insert!([6, 5, 4], 4:6, [8, 9])
+
+    @test insert!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8]) ===  [1, 8, 2, 9, 3, 10, 4, 5]
+    @test_throws BoundsError insert!([6, 5, 4], 6:-1:5, [8, 9])
+    @test_throws DimensionMismatch insert!([6, 5, 4], 5:-1:4, [8, 9, 9])
+
 end
 @testset "concatenation" begin
     @test isequal([fill(1.,2,2)  fill(2.,2,1)], [1. 1 2; 1 1 2])

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -463,18 +463,18 @@ end
     end
     @test_throws BoundsError insert!(v, 5, 5)
 
-    @test insert!([6, 5, 4, 2, 1], 4, [8, 9, 9]) === [6, 5, 4, 8, 9, 9, 2, 1]
+    @test insert!([6, 5, 4, 2, 1], 4, [8, 9, 9]) == [6, 5, 4, 8, 9, 9, 2, 1]
     @test_throws BoundsError insert!([6, 5, 4], 5, [8, 9])
 
-    @test insert!([1, 2, 3, 4], 3:4, [8, 9]) === [1, 2, 8, 9, 3, 4]
+    @test insert!([1, 2, 3, 4], 3:4, [8, 9]) == [1, 2, 8, 9, 3, 4]
     @test_throws BoundsError insert!([6, 5, 4], 5:6, [8, 9])
     @test_throws DimensionMismatch insert!([6, 5, 4], 4:6, [8, 9])
 
-    @test insert!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8]) ===  [1, 8, 2, 9, 3, 10, 4, 5]
+    @test insert!([1, 2, 3, 4, 5], 6:-2:2, [10, 9, 8]) == [1, 8, 2, 9, 3, 10, 4, 5]
     @test_throws BoundsError insert!([6, 5, 4], 6:-1:5, [8, 9])
     @test_throws DimensionMismatch insert!([6, 5, 4], 5:-1:4, [8, 9, 9])
 
-    @test insert!([1, 2, 3], [true, false, true, false, false], [10, 9]) ===  [10, 1, 9, 2, 3]
+    @test insert!([1, 2, 3], [true, false, true, false, false], [10, 9]) == [10, 1, 9, 2, 3]
     @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false], [10, 9])
     @test_throws ArgumentError insert!([1, 2, 3], [true, false, true, false, true], [10, 9])
 end


### PR DESCRIPTION
## Changes
- inserteach! Vector into Vector at the given index
- inserteach! Vector into Vector for the given indices
- inserteach! Vector into Vector for the given range
<del>- inserteach! specialization for the items with the same type of Vector </del>

## What is remaining:
- Testing new algorithm for multi-index inserteach!

<del>

- Additional benchmark requested: https://github.com/JuliaLang/julia/pull/34635#issuecomment-589281419
- To avoid overlapping with `insert!` in some special cases, a new name for these methods should be chosen. I like <del> `insert_elements!`</del>  `inserteach!` (the most descriptive name IMO) <del>, and `thrust!` (compact name). </del> Let me know your suggestion. 

</del>

## Performance

Specialization is done for AbstractRanges, AbstractUnitRages, and AbstractBool.
To get the best algorithm for general AbstractVector, I tried 5 other alternatives, and what is given in the PR is the fastest:
<details>
  <summary>Spoiler</summary>

### Single Index
`inserteach!` is much faster than the others.
```julia
function inserteach!(a::Vector, index::Integer, items::AbstractVector)
    m = length(items)
    if m === 0
        return a
    end
    _growat!(a, index, m)  # does bound check
    @inbounds for k = index:index+m-1
        a[k] = items[k-index+1]
    end
    return a
end

function inserteach_singleindex_2!(a::Vector, index::Integer, items::AbstractVector)
    for (i, item) in enumerate(items)
        insert!(a, i-1+index, item)
    end
    return a
end

function inserteach_singleindex_3!(a::Vector, index::Integer, items::AbstractVector)
    sizehint!(a, length(items)+length(a))
    for (i, item) in enumerate(items)
        insert!(a, i-1+index, item)
    end
    return a
end
```
### Single-index result
```julia
a = [1, 2, 3, 4]
b = 3
c = [10, 9, 8]

using Test; @test inserteach!(copy(a), b, c) == inserteach_singleindex_2!(copy(a), b, c) == inserteach_singleindex_3!(copy(a), b ,c)

using BenchmarkTools
@btime inserteach!($copy(a), $b, $c)
  # 97.465 ns (2 allocations: 192 bytes)
@btime inserteach_singleindex_2!($copy(a), $b, $c)
  # 115.888 ns (2 allocations: 192 bytes)
@btime inserteach_singleindex_3!($copy(a), $b, $c)
  # 119.802 ns (2 allocations: 192 bytes)

vsize = 1000
d = rand(Float32, vsize)
e = 30
f = rand(Float32, vsize÷10)

@btime inserteach!($copy(d), $e, $f)
  # 880.000 ns (2 allocations: 11.94 KiB)
@btime inserteach_singleindex_2!($copy(d), $e, $f)
  # 2.678 μs (2 allocations: 11.94 KiB)
@btime inserteach_singleindex_3!($copy(d), $e, $f)
  # 2.862 μs (2 allocations: 11.94 KiB)

g = rand(vsize)
h = 30
i = rand(vsize÷10)
@btime inserteach!($copy(g), $h, $i)
  # 1.480 μs (2 allocations: 23.63 KiB)
@btime inserteach_singleindex_2!($copy(g), $h, $i)
  # 3.825 μs (2 allocations: 23.63 KiB)
@btime inserteach_singleindex_3!($copy(g), $h, $i)
  # 4.243 μs (2 allocations: 23.63 KiB)

```

### Multi-Index
For larger sizes `inserteach!` is a lot faster. `inserteach_multiindex7!` has a similar speed to `inserteach!` until a batch `growat!` is written in C

```julia
function inserteach!(a::Vector, indices::Union{AbstractVector, AbstractRange{<:Integer}}, items::AbstractVector)
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    if issorted(indices) # based on the tests overhead/advantage is low
        indices_sorted = indices
        items_sorted = items
    else
        # sorts so the final index is correct
        indices_sorted, items_sorted = sort_indices_items(indices, items)
    end
    # _growat!.(Ref(a), indices_sorted, 1) # does bound check
    for (index, item) in zip(indices_sorted, items_sorted)
         _growat!(a, index, 1)
        @inbounds a[index] = item
    end
    return a
end

function sort_indices_items(indices::AbstractVector, items)
    sort_indices = sortperm(indices)
    indices_sorted = indices[sort_indices]
    items_sorted = items[sort_indices]
    return indices_sorted, items_sorted
end
function inserteach_multiindex_2!(a::Vector{T}, indices::AbstractVector, items::AbstractVector) where T
# defines a new array, finds the 1:newlength indices that are not in the given indices (rest), then populates the new array based on that.
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    alen = length(a)
    v = Vector{T}(undef, alen+itemslen)
    # rest = filter(x -> !in(x, indices), 1:alen+itemslen)
    rest = .!in.(1:alen+itemslen, Ref(indices))
   @inbounds v[rest] = a
    v[indices] = items
    return v
end

function inserteach_multiindex_3!(a::Vector, indices::AbstractVector, items::AbstractVector)
# grows the array at the end for the length of indices, then finds the rest of the indices that are not part of given indices (rest), then populates the array based on the indices.
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    alen = length(a)
    _growat!(a, alen+1, indiceslen) # does bound check
    # rest = filter(x -> !in(x, indices), 1:alen+itemslen)
     rest = .!in.(1:alen+itemslen, Ref(indices))
    @inbounds begin
        a[rest] = a[1:alen]
        a[indices] = items
    end
    return a
end

function inserteach_multiindex_3_2!(a::Vector, indices::AbstractVector, items::AbstractVector)
# grows the array at the end for the length of indices, then finds the rest of the indices that are not part of given indices (rest), then populates the array based on the indices.
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    alen = length(a)
    b = copy(a)
    _growat!(a, alen+1, indiceslen) # does bound check
    # rest = filter(x -> !in(x, indices), 1:alen+itemslen)
     rest = .!in.(1:alen+itemslen, Ref(indices))
    @inbounds begin
        a[rest] = b
        a[indices] = items
    end
    return a
end

function inserteach_multiindex_4!(a::Vector{T}, indices::AbstractVector, items::AbstractVector) where T
# sorts the indices. Then in a loop populates the array based on the fact that an index of the new array is in the given indices. We need sort because `in` only gives true (not the index).
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    alen = length(a)
    v = Vector{T}(undef, alen+itemslen)
    if issorted(indices) # based on the tests overhead/advantage is low
        indices_sorted = indices
        items_sorted = items
    else
        # sorts so the final index is correct
        indices_sorted, items_sorted = sort_indices_items(indices, items)
    end
    kitem = 1
    ka=1
    @inbounds for k=1:alen+itemslen
        if k in indices_sorted
            v[k] = items_sorted[kitem]
            kitem+=1
        else
            v[k] = a[ka]
            ka+=1
        end
    end
    return v
end

function inserteach_multiindex_5!(a::Vector{T}, indices::AbstractVector, items::AbstractVector) where T
# In a loop populates the array based on the finded index of the new array is in the given indices.
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    alen = length(a)
    v = Vector{T}(undef, alen+itemslen)
    kitem = 1
    ka=1
    @inbounds for k=1:alen+itemslen
        kitem = findfirst(x -> x == k, indices)
        if isnothing(kitem)
            v[k] = a[ka]
            ka+=1
        else
            v[k] = items[kitem]
            kitem+=1
        end
    end
    return v
end

function inserteach_multiindex_6!(a::Vector{T}, indices::AbstractVector, items::AbstractVector) where T
# Similar to 6 but first checks `in` then uses `findfirst` only for the ones that already exist
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    alen = length(a)
    v = Vector{T}(undef, alen+itemslen)
    kitem = 1
    ka=1
    @inbounds for k=1:alen+itemslen
        if k in indices
            kitem = findfirst(x -> x == k, indices)
            v[k] = items[kitem]
            kitem+=1
        else
            v[k] = a[ka]
            ka+=1
        end
    end
    return v
end


function inserteach_multiindex_7!(a::Vector, indices::AbstractVector, items::AbstractVector)
# For loops around insert
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    if issorted(indices) # based on the tests overhead/advantage is low
        indices_sorted = indices
        items_sorted = items
    else
        # sorts so the final index is correct
        indices_sorted, items_sorted = sort_indices_items(indices, items)
    end
    for (index, item) in zip(indices_sorted, items_sorted)
        insert!(a, index, item)
    end
    return a
end

function inserteach_multiindex_8!(a::Vector, indices::AbstractVector, items::AbstractVector)
# For loops around insert with sizehint
    itemslen = length(items)
    indiceslen = length(indices)
    if itemslen !== indiceslen
        throw(DimensionMismatch("Length of the indices and items should be the same"))
    elseif itemslen === 0
        return a
    end
    if issorted(indices) # based on the tests overhead/advantage is low
        indices_sorted = indices
        items_sorted = items
    else
        # sorts so the final index is correct
        indices_sorted, items_sorted = sort_indices_items(indices, items)
    end
    sizehint!(a, length(items)+length(a))
    for (index, item) in zip(indices_sorted, items_sorted)
        insert!(a, index, item)
    end
    return a
end
```
### Multi-Index Result:
For small sizes inserteach5! and 6 are definitely faster
```julia
using BenchmarkTools

a = [1, 2, 3, 4]
b = collect(6:-2:2)
c = [10, 9, 8]

using Test;
@test inserteach_multiindex_8!(copy(a), b, c) == inserteach_multiindex_7!(copy(a), b, c) == inserteach_multiindex_6!(copy(a), b, c) == inserteach_multiindex_5!(copy(a), b, c) == inserteach_multiindex_4!(copy(a), b, c) == inserteach_multiindex_3!(copy(a), b, c) == inserteach_multiindex_2!(copy(a), b, c) == inserteach!(copy(a), b, c)

println("small set")

@btime inserteach!(copy($a), $b, $c)
  # 336.814 ns (8 allocations: 576 bytes)
@btime inserteach_multiindex_2!(copy($a), $b, $c)
  # 244.755 ns (5 allocations: 416 bytes)
  # 241.960 ns (11 allocations: 688 bytes)  # using filter instead of in
@btime inserteach_multiindex_3!(copy($a), $b, $c)
  # 272.378 ns (6 allocations: 464 bytes)
  # 257.534 ns (11 allocations: 720 bytes) # using filter instead of in
@btime inserteach_multiindex_3_2!(copy($a), $b, $c)
  # 272.810 ns (6 allocations: 464 bytes)
@btime inserteach_multiindex_4!(copy($a), $b, $c)
  # 321.397 ns (8 allocations: 640 bytes)
@btime inserteach_multiindex_5!(copy($a), $b, $c)
  # 85.020 ns (2 allocations: 256 bytes)
@btime inserteach_multiindex_6!(copy($a), $b, $c)
  # 88.223 ns (2 allocations: 256 bytes)
@btime inserteach_multiindex_7!(copy($a), $b, $c)
  # 337.900 ns (8 allocations: 576 bytes)
@btime inserteach_multiindex_8!(copy($a), $b, $c)
  # 348.843 ns (8 allocations: 576 bytes)

```
But for larger sizes inserteach! is a lot faster. `inserteach_multiindex7!` has a similar speed to `inserteach!` until a batch `growat!` is written in C
```julia
println("big set, with skips, falling, non-sorted")

vsize = 1000
d = rand(Float32, vsize)
e = collect(vsize:-10:1)
f = rand(Float32, vsize÷10)

@btime inserteach!(copy($d), $e, $f)
  # 5.480 μs (8 allocations: 14.22 KiB)
@btime inserteach_multiindex_2!(copy($d), $e, $f)
  # 55.400 μs (6 allocations: 12.97 KiB)
  # 58.800 μs (11 allocations: 33.55 KiB) # using filter instead of in
@btime inserteach_multiindex_3!(copy($d), $e, $f)
  # 57.999 μs (7 allocations: 20.47 KiB)
  # 59.501 μs (11 allocations: 48.41 KiB)  # using filter instead of in
@btime inserteach_multiindex_3_2!(copy($d), $e, $f)
  # 56.500 μs (7 allocations: 20.47 KiB)
@btime inserteach_multiindex_4!(copy($d), $e, $f)
  # 53.199 μs (8 allocations: 10.78 KiB)
@btime inserteach_multiindex_5!(copy($d), $e, $f)
  # 71.999 μs (2 allocations: 8.50 KiB)
@btime inserteach_multiindex_6!(copy($d), $e, $f)
  # 59.999 μs (2 allocations: 8.50 KiB)
@btime inserteach_multiindex_7!(copy($d), $e, $f)
  # 5.417 μs (8 allocations: 14.22 KiB)
@btime inserteach_multiindex_8!(copy($d), $e, $f)
  # 5.633 μs (8 allocations: 14.22 KiB)

```

For sorted array, it gets even faster:
```julia
println("big set, with skips, rising, sorted")

g = rand(vsize)
h = collect(1:10:vsize)
i = rand(vsize÷10)

@btime inserteach!(copy($g), $h, $i)
  # 7.100 μs (2 allocations: 23.63 KiB)
@btime inserteach_multiindex_2!(copy($g), $h, $i)
  # 55.700 μs (6 allocations: 21.16 KiB)
  # 58.699 μs (11 allocations: 33.55 KiB) # using filter instead of in
@btime inserteach_multiindex_3!(copy($g), $h, $i)
  # 58.201 μs (7 allocations: 36.03 KiB)
  # 59.700 μs (11 allocations: 48.41 KiB)  # using filter instead of in
@btime inserteach_multiindex_3_2!(copy($g), $h, $i)
  # 58.000 μs (7 allocations: 36.03 KiB)
@btime inserteach_multiindex_4!(copy($g), $h, $i)
  # 52.100 μs (2 allocations: 16.69 KiB)
@btime inserteach_multiindex_5!(copy($g), $h, $i)
  # 75.299 μs (2 allocations: 16.69 KiB)
@btime inserteach_multiindex_6!(copy($g), $h, $i)
  # 58.300 μs (2 allocations: 16.69 KiB)
@btime inserteach_multiindex_7!(copy($g), $h, $i)
  # 7.050 μs (2 allocations: 23.63 KiB)
@btime inserteach_multiindex_8!(copy($g), $h, $i)
  # 7.425 μs (2 allocations: 23.63 KiB)
```
</details>


## Application
It is an algorithm that can be used for a lot of different applications. I usually ended up writing my own `inserteach!`.

It allows running different algorithms with different goals independent of each other. Like doing some sort first. Then inserting some other array into our array, etc. 

As an example:
Imagine your Instagram feed being an array that its order is defined (sorted based on your interests). Then Instagram decides to insert ads for every 10 posts. You can do it using
```julia
sort!(posts) # based on interests
insert!(posts, 1:10:length(posts), ads)
```
or imagine you have a song (like an array) that you want to insert a drum crash every 4 bars. You can think of many other things. 


https://github.com/JuliaLang/julia/pull/34635#issuecomment-581754452 :
> From an algorithmic viewpoint, it's more efficient to do the batch insertion.
> 
> For arrays of length N and a number of (sorted!) insertion points M it's an O(N + M) algorithm to do the insertion in a batch and a single reallocation. This is opposed to an O(N*M) algorithm to iteratively insert! because you only need to move the existing elements once. (Not to mention insert! is mutating so iteratively inserting needs to keep track of how the insertion points change which is annoying.)