### PR TITLE
Backport GC Extensions to Julia 1.0

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ endif
 # headers are used for dependency tracking, while public headers will be part of the dist
 UV_HEADERS :=
 HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h tls.h locks.h atomics.h julia_internal.h options.h timing.h)
-PUBLIC_HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h tls.h locks.h atomics.h)
+PUBLIC_HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h tls.h locks.h atomics.h julia_gcext.h)
 ifeq ($(USE_SYSTEM_LIBUV),0)
 UV_HEADERS += uv.h
 UV_HEADERS += uv/*.h

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -11,6 +11,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 #include "julia_assert.h"
+#include "julia_gcext.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -521,6 +522,34 @@ JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *
     bt->isbitstype = bt->isinlinealloc = (parameters == jl_emptysvec);
     bt->size = nbytes;
     bt->layout = jl_get_layout(0, alignm, 0, NULL);
+    bt->instance = NULL;
+    return bt;
+}
+
+JL_DLLEXPORT jl_datatype_t * jl_new_foreign_type(jl_sym_t *name,
+                                                 jl_module_t *module,
+                                                 jl_datatype_t *super,
+                                                 jl_markfunc_t markfunc,
+                                                 jl_sweepfunc_t sweepfunc,
+                                                 int haspointers,
+                                                 int large)
+{
+    jl_datatype_t *bt = jl_new_datatype(name, module, super,
+      jl_emptysvec, jl_emptysvec, jl_emptysvec, 0, 1, 0);
+    bt->size = large ? GC_MAX_SZCLASS+1 : 0;
+    jl_datatype_layout_t *layout = (jl_datatype_layout_t *)
+      jl_gc_perm_alloc(sizeof(jl_datatype_layout_t) + sizeof(jl_fielddescdyn_t),
+        0, 4, 0);
+    layout->nfields = 0;
+    layout->alignment = sizeof(void *);
+    layout->haspadding = 1;
+    layout->npointers = haspointers;
+    layout->fielddesc_type = 3;
+    jl_fielddescdyn_t * desc =
+      (jl_fielddescdyn_t *) ((char *)layout + sizeof(*layout));
+    desc->markfunc = markfunc;
+    desc->sweepfunc = sweepfunc;
+    bt->layout = layout;
     bt->instance = NULL;
     return bt;
 }

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -200,7 +200,7 @@ static void gc_verify_track(jl_ptls_t ptls)
 {
     jl_gc_mark_cache_t *gc_cache = &ptls->gc_cache;
     do {
-        gc_mark_sp_t sp;
+        jl_gc_mark_sp_t sp;
         gc_mark_sp_init(gc_cache, &sp);
         arraylist_push(&lostval_parents_done, lostval);
         jl_printf(JL_STDERR, "Now looking for %p =======\n", lostval);
@@ -247,7 +247,7 @@ static void gc_verify_track(jl_ptls_t ptls)
 void gc_verify(jl_ptls_t ptls)
 {
     jl_gc_mark_cache_t *gc_cache = &ptls->gc_cache;
-    gc_mark_sp_t sp;
+    jl_gc_mark_sp_t sp;
     gc_mark_sp_init(gc_cache, &sp);
     lostval = NULL;
     lostval_parents.len = 0;
@@ -1242,7 +1242,7 @@ int gc_slot_to_arrayidx(void *obj, void *_slot)
 
 // Print a backtrace from the bottom (start) of the mark stack up to `sp`
 // `pc_offset` will be added to `sp` for convenience in the debugger.
-NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, gc_mark_sp_t sp, int pc_offset)
+NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, jl_gc_mark_sp_t sp, int pc_offset)
 {
     jl_jmp_buf *old_buf = ptls->safe_restore;
     jl_jmp_buf buf;

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -21,19 +21,6 @@ extern "C" {
 
 static int block_pg_cnt = DEFAULT_BLOCK_PG_ALLOC;
 static size_t current_pg_count = 0;
-static int support_conservative_scans = 0;
-static jl_mutex_t conservative_scan_lock;
-
-JL_DLLEXPORT void jl_gc_enable_conservative_gc_support(void)
-{
-    JL_LOCK_NOGC(&conservative_scan_lock);
-    if (!support_conservative_scans) {
-        extern int jl_gc_cleanup_pages;
-        jl_gc_cleanup_pages = 1;
-    }
-    support_conservative_scans = 1;
-    JL_UNLOCK_NOGC(&conservative_scan_lock);
-}
 
 void jl_gc_init_page(void)
 {
@@ -259,8 +246,6 @@ have_free_page:
 #ifdef _OS_WINDOWS_
     VirtualAlloc(info.meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
 #endif
-    if (support_conservative_scans)
-        memset(info.meta->data, 0, GC_PAGE_SZ);
     current_pg_count++;
     gc_final_count_page(current_pg_count);
     JL_UNLOCK_NOGC(&gc_perm_lock);

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -21,6 +21,19 @@ extern "C" {
 
 static int block_pg_cnt = DEFAULT_BLOCK_PG_ALLOC;
 static size_t current_pg_count = 0;
+static int support_conservative_scans = 0;
+static jl_mutex_t conservative_scan_lock;
+
+JL_DLLEXPORT void jl_gc_enable_conservative_gc_support(void)
+{
+    JL_LOCK_NOGC(&conservative_scan_lock);
+    if (!support_conservative_scans) {
+        extern int jl_gc_cleanup_pages;
+        jl_gc_cleanup_pages = 1;
+    }
+    support_conservative_scans = 1;
+    JL_UNLOCK_NOGC(&conservative_scan_lock);
+}
 
 void jl_gc_init_page(void)
 {
@@ -246,6 +259,8 @@ have_free_page:
 #ifdef _OS_WINDOWS_
     VirtualAlloc(info.meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
 #endif
+    if (support_conservative_scans)
+        memset(info.meta->data, 0, GC_PAGE_SZ);
     current_pg_count++;
     gc_final_count_page(current_pg_count);
     JL_UNLOCK_NOGC(&gc_perm_lock);

--- a/src/gc.c
+++ b/src/gc.c
@@ -2302,7 +2302,8 @@ mark: {
             if (gc_cblist_task_scanner) {
                 export_gc_state(ptls, &sp);
                 gc_invoke_callbacks(jl_gc_cb_task_scanner_t,
-                    gc_cblist_task_scanner, (ta, ta == ptls2->root_task));
+                    gc_cblist_task_scanner,
+                    (ta, ptls2 != NULL && ta == ptls2->root_task));
                 import_gc_state(ptls, &sp);
             }
             if (stkbuf) {

--- a/src/gc.h
+++ b/src/gc.h
@@ -80,7 +80,7 @@ typedef struct {
     jl_gc_mark_data_t *data; // Current stack address for the data (up growing)
     void **pc_start; // Cached value of `gc_cache->pc_stack`
     void **pc_end; // Cached value of `gc_cache->pc_stack_end`
-} gc_mark_sp_t;
+} jl_gc_mark_sp_t;
 
 enum {
     GC_MARK_L_marked_obj,
@@ -190,7 +190,7 @@ union _jl_gc_mark_data {
 // Pop a data struct from the mark data stack (i.e. decrease the stack pointer)
 // This should be used after dispatch and therefore the pc stack pointer is already popped from
 // the stack.
-STATIC_INLINE void *gc_pop_markdata_(gc_mark_sp_t *sp, size_t size)
+STATIC_INLINE void *gc_pop_markdata_(jl_gc_mark_sp_t *sp, size_t size)
 {
     jl_gc_mark_data_t *data = (jl_gc_mark_data_t *)(((char*)sp->data) - size);
     sp->data = data;
@@ -201,7 +201,7 @@ STATIC_INLINE void *gc_pop_markdata_(gc_mark_sp_t *sp, size_t size)
 // Re-push a frame to the mark stack (both data and pc)
 // The data and pc are expected to be on the stack (or updated in place) already.
 // Mainly useful to pause the current scanning in order to scan an new object.
-STATIC_INLINE void *gc_repush_markdata_(gc_mark_sp_t *sp, size_t size)
+STATIC_INLINE void *gc_repush_markdata_(jl_gc_mark_sp_t *sp, size_t size)
 {
     jl_gc_mark_data_t *data = sp->data;
     sp->pc++;
@@ -479,7 +479,7 @@ STATIC_INLINE void gc_big_object_link(bigval_t *hdr, bigval_t **list)
     *list = hdr;
 }
 
-STATIC_INLINE void gc_mark_sp_init(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp)
+STATIC_INLINE void gc_mark_sp_init(jl_gc_mark_cache_t *gc_cache, jl_gc_mark_sp_t *sp)
 {
     sp->pc = gc_cache->pc_stack;
     sp->data = gc_cache->data_stack;
@@ -487,10 +487,10 @@ STATIC_INLINE void gc_mark_sp_init(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *s
     sp->pc_end = gc_cache->pc_stack_end;
 }
 
-void gc_mark_queue_all_roots(jl_ptls_t ptls, gc_mark_sp_t *sp);
-void gc_mark_queue_finlist(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp,
+void gc_mark_queue_all_roots(jl_ptls_t ptls, jl_gc_mark_sp_t *sp);
+void gc_mark_queue_finlist(jl_gc_mark_cache_t *gc_cache, jl_gc_mark_sp_t *sp,
                            arraylist_t *list, size_t start);
-void gc_mark_loop(jl_ptls_t ptls, gc_mark_sp_t sp);
+void gc_mark_loop(jl_ptls_t ptls, jl_gc_mark_sp_t sp);
 void gc_debug_init(void);
 
 extern void *gc_mark_label_addrs[_GC_MARK_L_MAX];
@@ -615,7 +615,7 @@ extern int gc_verifying;
 #endif
 int gc_slot_to_fieldidx(void *_obj, void *slot);
 int gc_slot_to_arrayidx(void *_obj, void *begin);
-NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, gc_mark_sp_t sp, int pc_offset);
+NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, jl_gc_mark_sp_t sp, int pc_offset);
 
 #ifdef GC_DEBUG_ENV
 JL_DLLEXPORT extern jl_gc_debug_env_t jl_gc_debug_env;

--- a/src/gc.h
+++ b/src/gc.h
@@ -75,13 +75,6 @@ typedef struct {
     int         full_sweep;
 } jl_gc_num_t;
 
-typedef struct {
-    void **pc; // Current stack address for the pc (up growing)
-    jl_gc_mark_data_t *data; // Current stack address for the data (up growing)
-    void **pc_start; // Cached value of `gc_cache->pc_stack`
-    void **pc_end; // Cached value of `gc_cache->pc_stack_end`
-} jl_gc_mark_sp_t;
-
 enum {
     GC_MARK_L_marked_obj,
     GC_MARK_L_scan_only,

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -114,4 +114,11 @@ JL_DLLEXPORT int jl_gc_conservative_gc_support_enabled(void);
 // jl_typeof(obj) is an actual type object.
 JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
 
+// Return a non-null pointer to the start of the stack area if the task
+// has an associated stack buffer. In that case, *size will also contain
+// the size of that stack buffer upon return. Also, if task is a thread's
+// current task, that thread's id will be stored in *tid; otherwise,
+// *tid will be set to -1.
+JL_DLLEXPORT void *jl_task_stack_buffer(jl_task_t *task, size_t *size, int *tid);
+
 #endif // _JULIA_GCEXT_H

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -5,10 +5,17 @@
 
 // Callbacks that allow C code to hook into the GC.
 
+// Marking callbacks for global roots and tasks, respectively. These,
+// along with custom mark functions must not alter the GC state except
+// through calling jl_gc_mark_queue_obj() and jl_gc_mark_queue_objarray().
 typedef void (*jl_gc_cb_root_scanner_t)(int full);
 typedef void (*jl_gc_cb_task_scanner_t)(jl_task_t *task, int full);
+
+// Callbacks that are invoked before and after a collection.
 typedef void (*jl_gc_cb_pre_gc_t)(int full);
 typedef void (*jl_gc_cb_post_gc_t)(int full);
+
+// Callbacks to track external object allocations.
 typedef void (*jl_gc_cb_notify_external_alloc_t)(void *addr, size_t size);
 typedef void (*jl_gc_cb_notify_external_free_t)(void *addr);
 

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -43,10 +43,6 @@ JL_DLLEXPORT jl_datatype_t *jl_new_foreign_type(
 JL_DLLEXPORT size_t jl_gc_max_internal_obj_size(void);
 JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void);
 
-// Returns the base address of a memory block, assuming it
-// is stored in a julia memory pool. Return NULL otherwise.
-JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
-
 // Field layout descriptor for custom types that do
 // not fit Julia layout conventions. This is associated with
 // jl_datatype_t instances where fielddesc_type == 3.
@@ -56,11 +52,59 @@ typedef struct {
     jl_sweepfunc_t sweepfunc;
 } jl_fielddescdyn_t;
 
+// Allocate an object with a foreign type.
 JL_DLLEXPORT void *jl_gc_alloc_typed(jl_ptls_t ptls, size_t sz, void *ty);
+// Queue an object or array of objects for scanning by the garbage collector.
+// These functions must only be called from within a root scanner callback
+// or from within a custom mark function.
 JL_DLLEXPORT int jl_gc_mark_queue_obj(jl_ptls_t ptls, jl_value_t *obj);
 JL_DLLEXPORT void jl_gc_mark_queue_objarray(jl_ptls_t ptls, jl_value_t *parent,
     jl_value_t **objs, size_t nobjs);
 
+// Calling this function on an object of a foreign type will cause the
+// sweep function to be called during garbage collection. This function
+// must be called at most once per object. If not enabled for an object,
+// the sweep function will not be called. Normally, this should happen
+// right after allocating such an object.
 JL_DLLEXPORT void jl_gc_schedule_foreign_sweepfunc(jl_ptls_t ptls, jl_value_t * bj);
+
+// CAUTION: The following functions enable support for conservative
+// marking. Conservative marking will treat any machine word that points
+// to an object (potentially including its interior) as a valid
+// reference, regardless of whether it actually is one or just an
+// integer that happens to match an actual address.
+//
+// This is a sharp tool and should only be used as a measure of last
+// resort. The user should be familiar with the risk of memory leaks
+// (especially on 32-bit machines) if used inappropriately and how
+// optimizing compilers can hide references from conservative stack
+// scanning. In particular, arrays must be kept explicitly visible to
+// the GC (by using JL_GC_PUSH1(), storing them in a location marked by
+// the Julia GC, etc.) while their contents are being accessed. The
+// reason is that array contents aren't marked separately, so if the
+// object itself is not visible to the GC, neither are the contents.
+
+// Enable support for conservative scanning. The function returns
+// whether support was already enabled. The function may implicitly
+// trigger a full garbage collection to properly update all internal
+// data structures.
+JL_DLLEXPORT int jl_gc_enable_conservative_gc_support(void);
+
+// This function returns whether support for conservative scanning has
+// been enabled. The return values are the same as for
+// jl_gc_enable_conservative_gc_support().
+JL_DLLEXPORT int jl_gc_conservative_gc_support_enabled(void);
+
+// Returns the base address of a memory block, assuming it is stored in
+// a julia memory pool. Return NULL otherwise.
+//
+// NOTE: This will only work for internal pool allocations. For external
+// allocations, the user must track allocations using the notification
+// callbacks above and verify that they are valid objects. Note that
+// external allocations may not all be valid objects and that for those,
+// the user *must* validate that they have a proper type, i.e. that
+// jl_typeof(obj) is an actual type object.
+JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
+
 
 #endif // _JULIA_GCEXT_H

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -7,9 +7,13 @@
 // a corresponding type with the same name, but in all lowercase,
 // and with a "_t" suffix.
 
+typedef void (*jl_gc_cb_root_scanner_t)(int full);
+typedef void (*jl_gc_cb_task_scanner_t)(jl_task_t *task, int full);
 typedef void (*jl_gc_cb_pre_gc_t)(int full);
 typedef void (*jl_gc_cb_post_gc_t)(int full);
 
+JL_DLLEXPORT void jl_gc_set_cb_root_scanner(jl_gc_cb_root_scanner_t cb, int enable);
+JL_DLLEXPORT void jl_gc_set_cb_task_scanner(jl_gc_cb_task_scanner_t cb, int enable);
 JL_DLLEXPORT void jl_gc_set_cb_pre_gc(jl_gc_cb_pre_gc_t cb, int enable);
 JL_DLLEXPORT void jl_gc_set_cb_post_gc(jl_gc_cb_post_gc_t cb, int enable);
 

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -11,11 +11,17 @@ typedef void (*jl_gc_cb_root_scanner_t)(int full);
 typedef void (*jl_gc_cb_task_scanner_t)(jl_task_t *task, int full);
 typedef void (*jl_gc_cb_pre_gc_t)(int full);
 typedef void (*jl_gc_cb_post_gc_t)(int full);
+typedef void (*jl_gc_cb_notify_external_alloc_t)(void *addr, size_t size);
+typedef void (*jl_gc_cb_notify_external_free_t)(void *addr);
 
 JL_DLLEXPORT void jl_gc_set_cb_root_scanner(jl_gc_cb_root_scanner_t cb, int enable);
 JL_DLLEXPORT void jl_gc_set_cb_task_scanner(jl_gc_cb_task_scanner_t cb, int enable);
 JL_DLLEXPORT void jl_gc_set_cb_pre_gc(jl_gc_cb_pre_gc_t cb, int enable);
 JL_DLLEXPORT void jl_gc_set_cb_post_gc(jl_gc_cb_post_gc_t cb, int enable);
+JL_DLLEXPORT void jl_gc_set_cb_notify_external_alloc(jl_gc_cb_notify_external_alloc_t cb,
+        int enable);
+JL_DLLEXPORT void jl_gc_set_cb_notify_external_free(jl_gc_cb_notify_external_free_t cb,
+        int enable);
 
 // Types for mark and sweep functions.
 // We make the cache and sp parameters opaque so that the internals
@@ -33,6 +39,31 @@ JL_DLLEXPORT jl_datatype_t *jl_new_foreign_type(
         jl_sweepfunc_t sweepfunc,
         int haspointers,
         int large);
+
+JL_DLLEXPORT size_t jl_gc_max_internal_obj_size(void);
+JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void);
+
+// The following function must be called to enable support for
+// conservative scanning, i.e. if you wish to use
+// `jl_gc_internal_obj_base_ptr()` or `jl_gc_is_internal_obj_alloc()`.
+// It has to be called before calling `jl_init()`.
+JL_DLLEXPORT void jl_gc_enable_conservative_gc_support(void);
+
+// The following function tests whether conservative scanning has
+// been enabled.
+JL_DLLEXPORT int jl_gc_conservative_scanning_enabled(void);
+
+// Returns the base address of a memory block, assuming it
+// is stored in a julia memory pool. Return NULL otherwise.
+JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
+
+// Returns 1 if the argument points to actual memory that contains
+// or may contain an internal Julia object or 0 if it doesn't.
+//
+// Furthermore, on success the tag will either be valid tag if p refers
+// to a live object or point to an address that isn't one if it is
+// invalid.
+JL_DLLEXPORT int jl_gc_is_internal_obj_alloc(jl_value_t *p);
 
 // Field layout descriptor for custom types that do
 // not fit Julia layout conventions. This is associated with

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -3,9 +3,7 @@
 
 // requires including "julia.h" beforehand.
 
-// Kinds of callbacks. For each kind of callback, there must be
-// a corresponding type with the same name, but in all lowercase,
-// and with a "_t" suffix.
+// Callbacks that allow C code to hook into the GC.
 
 typedef void (*jl_gc_cb_root_scanner_t)(int full);
 typedef void (*jl_gc_cb_task_scanner_t)(jl_task_t *task, int full);
@@ -23,9 +21,7 @@ JL_DLLEXPORT void jl_gc_set_cb_notify_external_alloc(jl_gc_cb_notify_external_al
 JL_DLLEXPORT void jl_gc_set_cb_notify_external_free(jl_gc_cb_notify_external_free_t cb,
         int enable);
 
-// Types for mark and sweep functions.
-// We make the cache and sp parameters opaque so that the internals
-// do not get exposed.
+// Types for custom mark and sweep functions.
 typedef uintptr_t (*jl_markfunc_t)(jl_ptls_t, jl_value_t *obj);
 typedef void (*jl_sweepfunc_t)(jl_value_t *obj);
 
@@ -52,8 +48,9 @@ typedef struct {
     jl_sweepfunc_t sweepfunc;
 } jl_fielddescdyn_t;
 
-// Allocate an object with a foreign type.
+// Allocate an object of a foreign type.
 JL_DLLEXPORT void *jl_gc_alloc_typed(jl_ptls_t ptls, size_t sz, void *ty);
+
 // Queue an object or array of objects for scanning by the garbage collector.
 // These functions must only be called from within a root scanner callback
 // or from within a custom mark function.
@@ -61,22 +58,25 @@ JL_DLLEXPORT int jl_gc_mark_queue_obj(jl_ptls_t ptls, jl_value_t *obj);
 JL_DLLEXPORT void jl_gc_mark_queue_objarray(jl_ptls_t ptls, jl_value_t *parent,
     jl_value_t **objs, size_t nobjs);
 
-// Calling this function on an object of a foreign type will cause the
-// sweep function to be called during garbage collection. This function
-// must be called at most once per object. If not enabled for an object,
-// the sweep function will not be called. Normally, this should happen
-// right after allocating such an object.
+// Sweep functions will not automatically be called for objects of
+// foreign types, as that may not always be desired. Only calling
+// jl_gc_schedule_foreign_sweepfunc() on an object of a foreign type
+// will result in the custome sweep function actually being called.
+// This must be done at most once per object and should usually be
+// done right after allocating the object.
 JL_DLLEXPORT void jl_gc_schedule_foreign_sweepfunc(jl_ptls_t ptls, jl_value_t * bj);
 
-// CAUTION: The following functions enable support for conservative
-// marking. Conservative marking will treat any machine word that points
-// to an object (potentially including its interior) as a valid
-// reference, regardless of whether it actually is one or just an
-// integer that happens to match an actual address.
-//
-// This is a sharp tool and should only be used as a measure of last
-// resort. The user should be familiar with the risk of memory leaks
-// (especially on 32-bit machines) if used inappropriately and how
+// The following functions enable support for conservative marking. This
+// functionality allows the user to determine if a machine word can be
+// interpreted as a pointer to an object (including the interior of an
+// object). It can be used to, for example, scan foreign stack frames or
+// data structures with an unknown layout. It is called conservative
+// marking, because it can lead to false positives, as non-pointer data
+// can mistakenly be interpreted as a pointer to a Julia object.
+
+// CAUTION: This is a sharp tool and should only be used as a measure of
+// last resort. The user should be familiar with the risk of memory
+// leaks (especially on 32-bit machines) if used inappropriately and how
 // optimizing compilers can hide references from conservative stack
 // scanning. In particular, arrays must be kept explicitly visible to
 // the GC (by using JL_GC_PUSH1(), storing them in a location marked by
@@ -84,7 +84,7 @@ JL_DLLEXPORT void jl_gc_schedule_foreign_sweepfunc(jl_ptls_t ptls, jl_value_t * 
 // reason is that array contents aren't marked separately, so if the
 // object itself is not visible to the GC, neither are the contents.
 
-// Enable support for conservative scanning. The function returns
+// Enable support for conservative marking. The function returns
 // whether support was already enabled. The function may implicitly
 // trigger a full garbage collection to properly update all internal
 // data structures.
@@ -96,7 +96,8 @@ JL_DLLEXPORT int jl_gc_enable_conservative_gc_support(void);
 JL_DLLEXPORT int jl_gc_conservative_gc_support_enabled(void);
 
 // Returns the base address of a memory block, assuming it is stored in
-// a julia memory pool. Return NULL otherwise.
+// a julia memory pool. Return NULL otherwise. Conservative support
+// *must* have been enabled for this to work reliably.
 //
 // NOTE: This will only work for internal pool allocations. For external
 // allocations, the user must track allocations using the notification
@@ -105,6 +106,5 @@ JL_DLLEXPORT int jl_gc_conservative_gc_support_enabled(void);
 // the user *must* validate that they have a proper type, i.e. that
 // jl_typeof(obj) is an actual type object.
 JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
-
 
 #endif // _JULIA_GCEXT_H

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -13,5 +13,37 @@ typedef void (*jl_gc_cb_post_gc_t)(int full);
 JL_DLLEXPORT void jl_gc_set_cb_pre_gc(jl_gc_cb_pre_gc_t cb, int enable);
 JL_DLLEXPORT void jl_gc_set_cb_post_gc(jl_gc_cb_post_gc_t cb, int enable);
 
+// Types for mark and sweep functions.
+// We make the cache and sp parameters opaque so that the internals
+// do not get exposed.
+typedef uintptr_t (*jl_markfunc_t)(jl_ptls_t, jl_value_t *obj);
+typedef void (*jl_sweepfunc_t)(jl_value_t *obj);
+
+// Function to create a new foreign type with custom
+// mark and sweep functions.
+JL_DLLEXPORT jl_datatype_t *jl_new_foreign_type(
+        jl_sym_t *name,
+        jl_module_t *module,
+        jl_datatype_t *super,
+        jl_markfunc_t markfunc,
+        jl_sweepfunc_t sweepfunc,
+        int haspointers,
+        int large);
+
+// Field layout descriptor for custom types that do
+// not fit Julia layout conventions. This is associated with
+// jl_datatype_t instances where fielddesc_type == 3.
+
+typedef struct {
+    jl_markfunc_t markfunc;
+    jl_sweepfunc_t sweepfunc;
+} jl_fielddescdyn_t;
+
+JL_DLLEXPORT void *jl_gc_alloc_typed(jl_ptls_t ptls, size_t sz, void *ty);
+JL_DLLEXPORT int jl_gc_mark_queue_obj(jl_ptls_t ptls, jl_value_t *obj);
+JL_DLLEXPORT void jl_gc_mark_queue_objarray(jl_ptls_t ptls, jl_value_t *parent,
+    jl_value_t **objs, size_t nobjs);
+
+JL_DLLEXPORT void jl_gc_schedule_foreign_sweepfunc(jl_ptls_t ptls, jl_value_t * bj);
 
 #endif // _JULIA_GCEXT_H

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -1,0 +1,17 @@
+#ifndef JL_GCEXT_H
+#define JL_GCEXT_H
+
+// requires including "julia.h" beforehand.
+
+// Kinds of callbacks. For each kind of callback, there must be
+// a corresponding type with the same name, but in all lowercase,
+// and with a "_t" suffix.
+
+typedef void (*jl_gc_cb_pre_gc_t)(int full);
+typedef void (*jl_gc_cb_post_gc_t)(int full);
+
+JL_DLLEXPORT void jl_gc_set_cb_pre_gc(jl_gc_cb_pre_gc_t cb, int enable);
+JL_DLLEXPORT void jl_gc_set_cb_post_gc(jl_gc_cb_post_gc_t cb, int enable);
+
+
+#endif // _JULIA_GCEXT_H

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -43,27 +43,9 @@ JL_DLLEXPORT jl_datatype_t *jl_new_foreign_type(
 JL_DLLEXPORT size_t jl_gc_max_internal_obj_size(void);
 JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void);
 
-// The following function must be called to enable support for
-// conservative scanning, i.e. if you wish to use
-// `jl_gc_internal_obj_base_ptr()` or `jl_gc_is_internal_obj_alloc()`.
-// It has to be called before calling `jl_init()`.
-JL_DLLEXPORT void jl_gc_enable_conservative_gc_support(void);
-
-// The following function tests whether conservative scanning has
-// been enabled.
-JL_DLLEXPORT int jl_gc_conservative_scanning_enabled(void);
-
 // Returns the base address of a memory block, assuming it
 // is stored in a julia memory pool. Return NULL otherwise.
 JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
-
-// Returns 1 if the argument points to actual memory that contains
-// or may contain an internal Julia object or 0 if it doesn't.
-//
-// Furthermore, on success the tag will either be valid tag if p refers
-// to a live object or point to an address that isn't one if it is
-// invalid.
-JL_DLLEXPORT int jl_gc_is_internal_obj_alloc(jl_value_t *p);
 
 // Field layout descriptor for custom types that do
 // not fit Julia layout conventions. This is associated with

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -289,7 +289,9 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty);
 #  define jl_gc_alloc(ptls, sz, ty) jl_gc_alloc_(ptls, sz, ty)
 #endif
 
-#define jl_buff_tag ((uintptr_t)0x4eade000)
+// jl_buff_tag must be a multiple of GC_PAGE_SZ so that it can't be
+// confused for an actual type reference.
+#define jl_buff_tag ((uintptr_t)0x4eadc000)
 typedef void jl_gc_tracked_buffer_t; // For the benefit of the static analyzer
 STATIC_INLINE jl_gc_tracked_buffer_t *jl_gc_alloc_buf(jl_ptls_t ptls, size_t sz)
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -289,7 +289,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty);
 #  define jl_gc_alloc(ptls, sz, ty) jl_gc_alloc_(ptls, sz, ty)
 #endif
 
-#define jl_buff_tag ((uintptr_t)0x4eade800)
+#define jl_buff_tag ((uintptr_t)0x4eade000)
 typedef void jl_gc_tracked_buffer_t; // For the benefit of the static analyzer
 STATIC_INLINE jl_gc_tracked_buffer_t *jl_gc_alloc_buf(jl_ptls_t ptls, size_t sz)
 {

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -58,6 +58,14 @@ typedef struct {
 // Cache of thread local change to global metadata during GC
 // This is sync'd after marking.
 typedef union _jl_gc_mark_data jl_gc_mark_data_t;
+
+typedef struct {
+    void **pc; // Current stack address for the pc (up growing)
+    jl_gc_mark_data_t *data; // Current stack address for the data (up growing)
+    void **pc_start; // Cached value of `gc_cache->pc_stack`
+    void **pc_end; // Cached value of `gc_cache->pc_stack_end`
+} jl_gc_mark_sp_t;
+
 typedef struct {
     // thread local increment of `perm_scanned_bytes`
     size_t perm_scanned_bytes;
@@ -132,7 +140,7 @@ struct _jl_tls_states_t {
     arraylist_t finalizers;
     jl_gc_mark_cache_t gc_cache;
     arraylist_t sweep_objs;
-    void *last_gc_mark_sp;
+    jl_gc_mark_sp_t gc_mark_sp;
 };
 
 // Update codegen version in `ccall.cpp` after changing either `pause` or `wake`

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -131,6 +131,8 @@ struct _jl_tls_states_t {
     int finalizers_inhibited;
     arraylist_t finalizers;
     jl_gc_mark_cache_t gc_cache;
+    arraylist_t sweep_objs;
+    void *last_gc_mark_sp;
 };
 
 // Update codegen version in `ccall.cpp` after changing either `pause` or `wake`

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,6 +16,8 @@ TESTS = all stdlib $(TESTGROUPS) \
 
 EMBEDDING_ARGS := "JULIA=$(JULIA_EXECUTABLE)" "BIN=$(SRCDIR)/embedding" "CC=$(CC)"
 
+GCEXT_ARGS := "JULIA=$(JULIA_EXECUTABLE)" "BIN=$(SRCDIR)/gcext" "CC=$(CC)"
+
 default: all
 
 $(TESTS):
@@ -25,7 +27,11 @@ $(TESTS):
 embedding:
 	@$(MAKE) -C $(SRCDIR)/$@ check $(EMBEDDING_ARGS)
 
+gcext:
+	@$(MAKE) -C $(SRCDIR)/$@ check $(GCEXT_ARGS)
+
 clean:
 	@$(MAKE) -C embedding $@ $(EMBEDDING_ARGS)
+	@$(MAKE) -C gcext $@ $(GCEXT_ARGS)
 
-.PHONY: $(TESTS) embedding clean
+.PHONY: $(TESTS) embedding gcext clean

--- a/test/gcext/.gitignore
+++ b/test/gcext/.gitignore
@@ -1,0 +1,2 @@
+/gcext
+/gcext-debug

--- a/test/gcext/LocalTest.jl
+++ b/test/gcext/LocalTest.jl
@@ -1,0 +1,85 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module LocalTest
+  const Stack = Main.TestGCExt.Stack
+  function make()
+    ccall(:stk_make, Stack, ())
+  end
+  function push(stack :: Stack, val :: String)
+    ccall(:stk_push, Nothing, (Stack, String), stack, val)
+  end
+  function top(stack :: Stack)
+    return ccall(:stk_top, String, (Stack,), stack)
+  end
+  function pop(stack :: Stack)
+    return ccall(:stk_pop, String, (Stack,), stack)
+  end
+  function size(stack :: Stack)
+    return ccall(:stk_size, UInt, (Stack,), stack)
+  end
+  function empty(stack :: Stack)
+    return size(stack) == 0
+  end
+  function blob(stack :: Stack)
+    return ccall(:stk_blob, Any, (Stack,), stack)
+  end
+  function gc_counter_full()
+    return ccall(:get_gc_counter, UInt, (Cint,), 1)
+  end
+  function gc_counter_inc()
+    return ccall(:get_gc_counter, UInt, (Cint,), 0)
+  end
+  function gc_counter()
+    return gc_counter_full() + gc_counter_inc()
+  end
+  function num_obj_sweeps()
+    return ccall(:get_obj_sweeps, UInt, ())
+  end
+  function get_aux_root(n :: Int)
+    return ccall(:get_aux_root, String, (UInt,), n)
+  end
+  function set_aux_root(n :: Int, x :: String)
+    return ccall(:set_aux_root, Nothing, (UInt, String), n, x)
+  end
+  function internal_obj_scan(p :: Any)
+    if ccall(:internal_obj_scan, Cint, (Any,), p) == 0
+      global internal_obj_scan_failures += 1
+    end
+  end
+
+  global internal_obj_scan_failures = 0
+  for i in 0:1000
+    set_aux_root(i, string(i))
+  end
+  function test()
+    local stack = make()
+    for i in 1:100000
+      push(stack, string(i, base=2))
+      internal_obj_scan(top(stack))
+    end
+    for i in 1:1000
+      local stack2 = make()
+      internal_obj_scan(stack2)
+      internal_obj_scan(blob(stack2))
+      while !empty(stack)
+	push(stack2, pop(stack))
+      end
+      stack = stack2
+      if i % 100 == 0
+	GC.gc()
+      end
+    end
+  end
+  global corrupted_roots = 0
+  for i in 0:1000
+    if get_aux_root(i) != string(i)
+      global corrupted_roots += 1
+    end
+  end
+  @time test()
+  print(gc_counter_full(), " full collections.\n")
+  print(gc_counter_inc(), " partial collections.\n")
+  print(num_obj_sweeps(), " object sweeps.\n")
+  print(internal_obj_scan_failures, " internal object scan failures.\n")
+  print(corrupted_roots, " corrupted auxiliary roots.\n")
+end

--- a/test/gcext/LocalTest.jl
+++ b/test/gcext/LocalTest.jl
@@ -1,85 +1,102 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module LocalTest
-  const Stack = Main.TestGCExt.Stack
-  function make()
-    ccall(:stk_make, Stack, ())
-  end
-  function push(stack :: Stack, val :: String)
-    ccall(:stk_push, Nothing, (Stack, String), stack, val)
-  end
-  function top(stack :: Stack)
-    return ccall(:stk_top, String, (Stack,), stack)
-  end
-  function pop(stack :: Stack)
-    return ccall(:stk_pop, String, (Stack,), stack)
-  end
-  function size(stack :: Stack)
-    return ccall(:stk_size, UInt, (Stack,), stack)
-  end
-  function empty(stack :: Stack)
-    return size(stack) == 0
-  end
-  function blob(stack :: Stack)
-    return ccall(:stk_blob, Any, (Stack,), stack)
-  end
-  function gc_counter_full()
-    return ccall(:get_gc_counter, UInt, (Cint,), 1)
-  end
-  function gc_counter_inc()
-    return ccall(:get_gc_counter, UInt, (Cint,), 0)
-  end
-  function gc_counter()
-    return gc_counter_full() + gc_counter_inc()
-  end
-  function num_obj_sweeps()
-    return ccall(:get_obj_sweeps, UInt, ())
-  end
-  function get_aux_root(n :: Int)
-    return ccall(:get_aux_root, String, (UInt,), n)
-  end
-  function set_aux_root(n :: Int, x :: String)
-    return ccall(:set_aux_root, Nothing, (UInt, String), n, x)
-  end
-  function internal_obj_scan(p :: Any)
-    if ccall(:internal_obj_scan, Cint, (Any,), p) == 0
-      global internal_obj_scan_failures += 1
-    end
-  end
+const Stack = Main.TestGCExt.Stack
 
-  global internal_obj_scan_failures = 0
-  for i in 0:1000
+function make()
+    ccall(:stk_make, Stack, ())
+end
+
+function push(stack :: Stack, val :: String)
+    ccall(:stk_push, Nothing, (Stack, String), stack, val)
+end
+
+function top(stack :: Stack)
+    return ccall(:stk_top, String, (Stack,), stack)
+end
+
+function pop(stack :: Stack)
+    return ccall(:stk_pop, String, (Stack,), stack)
+end
+
+function size(stack :: Stack)
+    return ccall(:stk_size, UInt, (Stack,), stack)
+end
+
+function empty(stack :: Stack)
+    return size(stack) == 0
+end
+
+function blob(stack :: Stack)
+    return ccall(:stk_blob, Any, (Stack,), stack)
+end
+
+function gc_counter_full()
+    return ccall(:get_gc_counter, UInt, (Cint,), 1)
+end
+
+function gc_counter_inc()
+    return ccall(:get_gc_counter, UInt, (Cint,), 0)
+end
+
+function gc_counter()
+    return gc_counter_full() + gc_counter_inc()
+end
+
+function num_obj_sweeps()
+    return ccall(:get_obj_sweeps, UInt, ())
+end
+
+function get_aux_root(n :: Int)
+    return ccall(:get_aux_root, String, (UInt,), n)
+end
+
+function set_aux_root(n :: Int, x :: String)
+    return ccall(:set_aux_root, Nothing, (UInt, String), n, x)
+end
+
+function internal_obj_scan(p :: Any)
+    if ccall(:internal_obj_scan, Cint, (Any,), p) == 0
+        global internal_obj_scan_failures += 1
+    end
+end
+
+global internal_obj_scan_failures = 0
+
+for i in 0:1000
     set_aux_root(i, string(i))
-  end
-  function test()
+end
+
+function test()
     local stack = make()
     for i in 1:100000
-      push(stack, string(i, base=2))
-      internal_obj_scan(top(stack))
+        push(stack, string(i, base=2))
+        internal_obj_scan(top(stack))
     end
     for i in 1:1000
-      local stack2 = make()
-      internal_obj_scan(stack2)
-      internal_obj_scan(blob(stack2))
-      while !empty(stack)
-	push(stack2, pop(stack))
-      end
-      stack = stack2
-      if i % 100 == 0
-	GC.gc()
-      end
+        local stack2 = make()
+        internal_obj_scan(stack2)
+        internal_obj_scan(blob(stack2))
+        while !empty(stack)
+            push(stack2, pop(stack))
+        end
+        stack = stack2
+        if i % 100 == 0
+            GC.gc()
+        end
     end
-  end
-  global corrupted_roots = 0
-  for i in 0:1000
-    if get_aux_root(i) != string(i)
-      global corrupted_roots += 1
-    end
-  end
-  @time test()
-  print(gc_counter_full(), " full collections.\n")
-  print(gc_counter_inc(), " partial collections.\n")
-  print(num_obj_sweeps(), " object sweeps.\n")
-  print(internal_obj_scan_failures, " internal object scan failures.\n")
-  print(corrupted_roots, " corrupted auxiliary roots.\n")
 end
+
+@time test()
+
+global corrupted_roots = 0
+for i in 0:1000
+    if get_aux_root(i) != string(i)
+        global corrupted_roots += 1
+    end
+end
+
+print(gc_counter_full(), " full collections.\n")
+print(gc_counter_inc(), " partial collections.\n")
+print(num_obj_sweeps(), " object sweeps.\n")
+print(internal_obj_scan_failures, " internal object scan failures.\n")
+print(corrupted_roots, " corrupted auxiliary roots.\n")

--- a/test/gcext/Makefile
+++ b/test/gcext/Makefile
@@ -1,0 +1,60 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# This Makefile template requires the following variables to be set
+# in the environment or on the command-line:
+#   JULIA: path to julia[.exe] executable
+#   BIN:   binary build directory
+
+ifndef JULIA
+  $(error "Please pass JULIA=[path of target julia binary], or set as environment variable!")
+endif
+ifndef BIN
+  $(error "Please pass BIN=[path of build directory], or set as environment variable!")
+endif
+
+#=============================================================================
+# this source directory where gcext.c is located
+SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+# get the executable suffix, if any
+EXE := $(suffix $(abspath $(JULIA)))
+
+# get compiler and linker flags. (see: `contrib/julia-config.jl`)
+JULIA_CONFIG := $(JULIA) -e 'include(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "julia-config.jl"))' --
+CPPFLAGS_ADD :=
+CFLAGS_ADD = $(shell $(JULIA_CONFIG) --cflags)
+LDFLAGS_ADD = -lm $(shell $(JULIA_CONFIG) --ldflags --ldlibs)
+
+DEBUGFLAGS += -g
+
+#=============================================================================
+
+release: $(BIN)/gcext$(EXE)
+debug:   $(BIN)/gcext-debug$(EXE)
+
+$(BIN)/gcext$(EXE): $(SRCDIR)/gcext.c
+	$(CC) $^ -o $@ $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) $(LDFLAGS_ADD) $(LDFLAGS)
+
+$(BIN)/gcext-debug$(EXE): $(SRCDIR)/gcext.c
+	$(CC) $^ -o $@ $(CPPFLAGS_ADD) $(CPPFLAGS) $(CFLAGS_ADD) $(CFLAGS) $(LDFLAGS_ADD) $(LDFLAGS) $(DEBUGFLAGS)
+
+ifneq ($(abspath $(BIN)),$(abspath $(SRCDIR)))
+# for demonstration purposes, our demo code is also installed
+# in $BIN, although this would likely not be typical
+$(BIN)/LocalModule.jl: $(SRCDIR)/LocalModule.jl
+	cp $< $@
+endif
+
+check: $(BIN)/gcext$(EXE) $(BIN)/LocalTest.jl
+	$(JULIA) --depwarn=error $(SRCDIR)/gcext-test.jl $<
+	@echo SUCCESS
+
+clean:
+	-rm -f $(BIN)/gcext-debug$(EXE) $(BIN)/gcext$(EXE)
+
+.PHONY: release debug clean check
+
+# Makefile debugging trick:
+# call print-VARIABLE to see the runtime value of any variable
+print-%:
+	@echo '$*=$($*)'

--- a/test/gcext/gcext-test.jl
+++ b/test/gcext/gcext-test.jl
@@ -11,10 +11,10 @@ end
 function checknum(s, rx, cond)
     m = match(rx, s)
     if m === nothing
-	return false
+        return false
     else
         num = m[1]
-	return cond(parse(UInt, num))
+        return cond(parse(UInt, num))
     end
 end
 

--- a/test/gcext/gcext-test.jl
+++ b/test/gcext/gcext-test.jl
@@ -1,0 +1,42 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# tests the output of the embedding example is correct
+using Test
+
+if Sys.iswindows()
+    # libjulia needs to be in the same directory as the embedding executable or in path
+    ENV["PATH"] = string(Sys.BINDIR, ";", ENV["PATH"])
+end
+
+function checknum(s, rx, cond)
+    m = match(rx, s)
+    if m === nothing
+	return false
+    else
+        num = m[1]
+	return cond(parse(UInt, num))
+    end
+end
+
+@test length(ARGS) == 1
+@testset "gcext example" begin
+    out = Pipe()
+    err = Pipe()
+    p = run(pipeline(Cmd(ARGS), stdin=devnull, stdout=out, stderr=err), wait=false)
+    close(out.in)
+    close(err.in)
+    out_task = @async readlines(out)
+    err_task = @async readlines(err)
+    # @test success(p)
+    errlines = fetch(err_task)
+    lines = fetch(out_task)
+    @test length(errlines) == 0
+    @test length(lines) == 6
+    @test checknum(lines[2], r"([0-9]+) full collections", n -> n >= 10)
+    @test checknum(lines[3], r"([0-9]+) partial collections", n -> n > 0)
+    @test checknum(lines[4], r"([0-9]+) object sweeps", n -> n > 0)
+    @test checknum(lines[5], r"([0-9]+) internal object scan failures",
+        n -> n == 0)
+    @test checknum(lines[6], r"([0-9]+) corrupted auxiliary roots",
+        n -> n == 0)
+end

--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -1,0 +1,616 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include <stddef.h>
+#include <stdio.h>
+
+#include "julia.h"
+#include "julia_gcext.h"
+
+// Comparing pointers in C without triggering undefined behavior
+// can be difficult. As the GC already assumes that the memory
+// range goes from 0 to 2^k-1 (region tables), we simply convert
+// to uintptr_t and compare those.
+
+static inline int cmp_ptr(void *p, void *q)
+{
+    uintptr_t paddr = (uintptr_t)p;
+    uintptr_t qaddr = (uintptr_t)q;
+    if (paddr < qaddr)
+        return -1;
+    else if (paddr > qaddr)
+        return 1;
+    else
+        return 0;
+}
+
+static inline int lt_ptr(void *a, void *b)
+{
+    return (uintptr_t)a < (uintptr_t)b;
+}
+
+#if 0
+static inline int gt_ptr(void * a, void * b)
+{
+    return (uintptr_t)a > (uintptr_t)b;
+}
+
+static inline void *max_ptr(void *a, void *b)
+{
+    if ((uintptr_t) a > (uintptr_t) b)
+        return a;
+    else
+        return b;
+}
+
+static inline void *min_ptr(void *a, void *b)
+{
+    if ((uintptr_t) a < (uintptr_t) b)
+        return a;
+    else
+        return b;
+}
+#endif
+
+/* align pointer to full word if mis-aligned */
+static inline void *align_ptr(void *p)
+{
+    uintptr_t u = (uintptr_t)p;
+    u &= ~(sizeof(p) - 1);
+    return (void *)u;
+}
+
+// We use treaps -- a form of balanced trees -- to be able to
+// find allocations based on their address.
+
+typedef struct treap_t {
+    struct treap_t *left, *right;
+    size_t prio;
+    void *addr;
+    size_t size;
+} treap_t;
+
+static treap_t *treap_free_list;
+
+treap_t *alloc_treap(void)
+{
+    treap_t *result;
+    if (treap_free_list) {
+        result = treap_free_list;
+        treap_free_list = treap_free_list->right;
+    }
+    else
+        result = malloc(sizeof(treap_t));
+    result->left = NULL;
+    result->right = NULL;
+    result->addr = NULL;
+    result->size = 0;
+    return result;
+}
+
+void free_treap(treap_t *t)
+{
+    t->right = treap_free_list;
+    treap_free_list = t;
+}
+
+static inline int test_bigval_range(treap_t *node, void *p)
+{
+    char *l = node->addr;
+    char *r = l + node->size;
+    if (lt_ptr(p, l))
+        return -1;
+    if (!lt_ptr(p, r))
+        return 1;
+    return 0;
+}
+
+#define L(t) ((t)->left)
+#define R(t) ((t)->right)
+
+static inline void treap_rot_right(treap_t **treap)
+{
+    /*       t                 l       */
+    /*     /   \             /   \     */
+    /*    l     r    -->    a     t    */
+    /*   / \                     / \   */
+    /*  a   b                   b   r  */
+    treap_t *t = *treap;
+    treap_t *l = L(t);
+    treap_t *a = L(l);
+    treap_t *b = R(l);
+    L(l) = a;
+    R(l) = t;
+    L(t) = b;
+    *treap = l;
+}
+
+static inline void treap_rot_left(treap_t **treap)
+{
+    /*     t                   r       */
+    /*   /   \               /   \     */
+    /*  l     r    -->      t     b    */
+    /*       / \           / \         */
+    /*      a   b         l   a        */
+    treap_t *t = *treap;
+    treap_t *r = R(t);
+    treap_t *a = L(r);
+    treap_t *b = R(r);
+    L(r) = t;
+    R(r) = b;
+    R(t) = a;
+    *treap = r;
+}
+
+static treap_t *treap_find(treap_t *treap, void *p)
+{
+    while (treap) {
+        int c = test_bigval_range(treap, p);
+        if (c == 0)
+            return treap;
+        else if (c < 0)
+            treap = L(treap);
+        else
+            treap = R(treap);
+    }
+    return NULL;
+}
+
+static void treap_insert(treap_t **treap, treap_t *val)
+{
+    treap_t *t = *treap;
+    if (t == NULL) {
+        L(val) = NULL;
+        R(val) = NULL;
+        *treap = val;
+    }
+    else {
+        int c = cmp_ptr(val->addr, t->addr);
+        if (c < 0) {
+            treap_insert(&L(t), val);
+            if (L(t)->prio > t->prio) {
+                treap_rot_right(treap);
+            }
+        }
+        else if (c > 0) {
+            treap_insert(&R(t), val);
+            if (R(t)->prio > t->prio) {
+                treap_rot_left(treap);
+            }
+        }
+    }
+}
+
+static void treap_delete_node(treap_t **treap)
+{
+    for (;;) {
+        treap_t *t = *treap;
+        if (L(t) == NULL) {
+            *treap = R(t);
+            free_treap(t);
+            break;
+        }
+        else if (R(t) == NULL) {
+            *treap = L(t);
+            free_treap(t);
+            break;
+        }
+        else {
+            if (L(t)->prio > R(t)->prio) {
+                treap_rot_right(treap);
+                treap = &R(*treap);
+            }
+            else {
+                treap_rot_left(treap);
+                treap = &L(*treap);
+            }
+        }
+    }
+}
+
+static int treap_delete(treap_t **treap, void *addr)
+{
+    while (*treap != NULL) {
+        int c = cmp_ptr(addr, (*treap)->addr);
+        if (c == 0) {
+            treap_delete_node(treap);
+            return 1;
+        }
+        else if (c < 0) {
+            treap = &L(*treap);
+        }
+        else {
+            treap = &R(*treap);
+        }
+    }
+    return 0;
+}
+
+static uint64_t xorshift_rng_state = 1;
+
+static uint64_t xorshift_rng(void)
+{
+    uint64_t x = xorshift_rng_state;
+    x = x ^ (x >> 12);
+    x = x ^ (x << 25);
+    x = x ^ (x >> 27);
+    xorshift_rng_state = x;
+    return x * (uint64_t)0x2545F4914F6CDD1DUL;
+}
+
+static treap_t *bigvals;
+static size_t bigval_startoffset;
+
+// Hooks to allocate and free external objects (bigval_t's).
+
+void alloc_bigval(void *addr, size_t size)
+{
+    treap_t *node = alloc_treap();
+    node->addr = addr;
+    node->size = size;
+    node->prio = xorshift_rng();
+    treap_insert(&bigvals, node);
+}
+
+void free_bigval(void *p)
+{
+    if (p) {
+        treap_delete(&bigvals, p);
+    }
+}
+
+// Auxiliary roots. These serve no special purpose, except
+// allowing us to verify that root scanning works.
+
+#define NAUXROOTS 1024
+static jl_value_t *aux_roots[NAUXROOTS];
+JL_DLLEXPORT size_t gc_counter_full, gc_counter_inc;
+
+JL_DLLEXPORT jl_value_t *get_aux_root(size_t n)
+{
+    if (n >= NAUXROOTS)
+        jl_error("get_aux_root: index out of range");
+    return aux_roots[n];
+}
+
+JL_DLLEXPORT void set_aux_root(size_t n, jl_value_t *val)
+{
+    if (n >= NAUXROOTS)
+        jl_error("set_aux_root: index out of range");
+    aux_roots[n] = val;
+}
+
+JL_DLLEXPORT size_t get_gc_counter(int full)
+{
+    if (full)
+        return gc_counter_full;
+    else
+        return gc_counter_inc;
+}
+
+static size_t obj_sweeps = 0;
+
+JL_DLLEXPORT size_t get_obj_sweeps()
+{
+    return obj_sweeps;
+}
+
+typedef struct {
+    size_t size;
+    size_t capacity;
+    jl_value_t *data[1];
+} dynstack_t;
+
+static jl_datatype_t *datatype_stack_internal;
+static jl_datatype_t *datatype_stack_external;
+static jl_datatype_t *datatype_stack;
+static jl_ptls_t ptls;
+
+static size_t gc_alloc_size(jl_value_t *val)
+{
+    size_t size;
+    if (jl_typeis(val, datatype_stack))
+        size = sizeof(jl_value_t *);
+    else if (jl_typeis(val, datatype_stack_internal) || jl_typeis(val, datatype_stack_external))
+        size = offsetof(dynstack_t, data) +
+                ((dynstack_t *)val)->capacity * sizeof(jl_value_t *);
+    else if (jl_typeis(val, jl_string_type)) {
+        size = jl_string_len(val) + sizeof(size_t) + 1;
+        // Round up to whole word size
+        if (size % sizeof(void *) != 0)
+            size += sizeof(void *) - size % sizeof(void *);
+    }
+    else
+        size = 0;
+    return size;
+}
+
+JL_DLLEXPORT int internal_obj_scan(jl_value_t *val)
+{
+    if (jl_gc_is_internal_obj_alloc(val)) {
+        if (jl_gc_internal_obj_base_ptr(val) != val)
+            return 0;
+        size_t size = gc_alloc_size(val);
+        char *addr = (char *)val;
+        for (size_t i = 0; i <= size; i++) {
+            if (jl_gc_internal_obj_base_ptr(addr + i) != val)
+                return 0;
+        }
+        return 1;
+    }
+    else {
+        treap_t *node = treap_find(bigvals, val);
+        if (!node)
+            return 0;
+        char *addr = node->addr;
+        if ((jl_value_t *)addr != val)
+            return 0;
+        size_t size = node->size;
+        for (size_t i = 0; i <= size; i++) {
+            if (treap_find(bigvals, addr + i) != node)
+                return 0;
+        }
+        return 1;
+    }
+}
+
+dynstack_t *allocate_stack_mem(size_t capacity)
+{
+    size_t size = offsetof(dynstack_t, data) + capacity * sizeof(jl_value_t *);
+    jl_datatype_t *type = datatype_stack_internal;
+    if (size > jl_gc_max_internal_obj_size())
+        type = datatype_stack_external;
+    dynstack_t *result = (dynstack_t *)jl_gc_alloc_typed(ptls, size, type);
+    result->size = 0;
+    result->capacity = capacity;
+    return result;
+}
+
+void check_stack(const char *name, jl_value_t *p)
+{
+    if (jl_typeis(p, datatype_stack))
+        return;
+    jl_type_error(name, (jl_value_t *)datatype_stack, p);
+}
+
+void check_stack_notempty(const char *name, jl_value_t *p)
+{
+    check_stack(name, p);
+    dynstack_t *stk = *(dynstack_t **)p;
+    if (stk->size == 0)
+        jl_errorf("%s: dynstack_t empty", name);
+}
+
+// Stacks use double indirection in order to be resizable.
+// The outer object is a single word containing a pointer to
+// a `dynstack_t`, which can contain a variable number of
+// Julia objects; the `capacity` field denotes the number of objects
+// that can be stored without resizing storage, the `size` field
+// denotes the actual number of objects. GC scanning should ignore
+// any storage past those.
+
+// Create a new stack object
+
+JL_DLLEXPORT jl_value_t *stk_make()
+{
+    jl_value_t *hdr =
+            jl_gc_alloc_typed(ptls, sizeof(jl_value_t *), datatype_stack);
+    JL_GC_PUSH1(hdr);
+    *(dynstack_t **)hdr = NULL;
+    dynstack_t *stk = allocate_stack_mem(8);
+    *(dynstack_t **)hdr = stk;
+    jl_gc_schedule_foreign_sweepfunc(ptls, (jl_value_t *)(stk));
+    JL_GC_POP();
+    return hdr;
+}
+
+// Return a pointer to the inner `dynstack_t` struct.
+
+JL_DLLEXPORT jl_value_t *stk_blob(jl_value_t *s)
+{
+    return (jl_value_t *)(*(dynstack_t **)s);
+}
+
+// Push `v` on `s`.
+
+JL_DLLEXPORT void stk_push(jl_value_t *s, jl_value_t *v)
+{
+    check_stack("push", s);
+    dynstack_t *stk = *(dynstack_t **)s;
+    if (stk->size < stk->capacity) {
+        stk->data[stk->size++] = v;
+        jl_gc_wb((jl_value_t *)stk, v);
+    }
+    else {
+        dynstack_t *newstk = allocate_stack_mem(stk->capacity * 3 / 2 + 1);
+        newstk->size = stk->size;
+        memcpy(newstk->data, stk->data, sizeof(jl_value_t *) * stk->size);
+        *(dynstack_t **)s = newstk;
+        newstk->data[newstk->size++] = v;
+        jl_gc_schedule_foreign_sweepfunc(ptls, (jl_value_t *)(newstk));
+        jl_gc_wb_back((jl_value_t *)newstk);
+        jl_gc_wb(s, (jl_value_t *)newstk);
+    }
+}
+
+// Return top value from `s`. Raise error if not empty.
+
+JL_DLLEXPORT jl_value_t *stk_top(jl_value_t *s)
+{
+    check_stack_notempty("top", s);
+    dynstack_t *stk = *(dynstack_t **)s;
+    return stk->data[stk->size - 1];
+}
+
+// Pop a value from `s` and return it. Raise error if not empty.
+
+JL_DLLEXPORT jl_value_t *stk_pop(jl_value_t *s)
+{
+    check_stack_notempty("pop", s);
+    dynstack_t *stk = *(dynstack_t **)s;
+    stk->size--;
+    return stk->data[stk->size];
+}
+
+// Number of objects on the stack.
+
+JL_DLLEXPORT size_t stk_size(jl_value_t *s)
+{
+    check_stack("empty", s);
+    dynstack_t *stk = *(dynstack_t **)s;
+    return stk->size;
+}
+
+static jl_module_t *module;
+
+// Mark auxiliary roots.
+
+void root_scanner(int full)
+{
+    for (int i = 0; i < NAUXROOTS; i++) {
+        if (aux_roots[i])
+            jl_gc_mark_queue_obj(ptls, aux_roots[i]);
+    }
+}
+
+// Hooks to run before and after GC.
+//
+// As a simple example, we only track counters for full
+// and partial collections.
+
+void pre_gc_func(int full)
+{
+    if (full)
+        gc_counter_full++;
+    else
+        gc_counter_inc++;
+}
+
+void post_gc_func(int full) {}
+
+// Mark the outer stack object (containing only a pointer to the data).
+
+uintptr_t mark_stack(jl_ptls_t ptls, jl_value_t *p)
+{
+    if (!*(void **)p)
+        return 0;
+    return jl_gc_mark_queue_obj(ptls, *(jl_value_t **)p) != 0;
+}
+
+// Mark the actual stack data.
+// This is used both for `StackData` and `StackDataLarge`.
+
+uintptr_t mark_stack_data(jl_ptls_t ptls, jl_value_t *p)
+{
+    dynstack_t *stk = (dynstack_t *)p;
+    // Alternate between two marking approaches for testing so
+    // that we test both.
+    if (gc_counter_full & 1) {
+        jl_gc_mark_queue_objarray(ptls, p, stk->data, stk->size);
+        return 0;
+    }
+    else {
+      uintptr_t n = 0;
+      for (size_t i = 0; i < stk->size; i++) {
+          if (jl_gc_mark_queue_obj(ptls, stk->data[i]))
+              n++;
+      }
+      return n;
+    }
+}
+
+void sweep_stack_data(jl_value_t *p)
+{
+    obj_sweeps++;
+    dynstack_t *stk = (dynstack_t *)p;
+    if (stk->size > stk->capacity)
+        jl_error("internal error during sweeping");
+}
+
+// Safely execute Julia code
+
+jl_value_t *checked_eval_string(const char *code)
+{
+    jl_value_t *result = jl_eval_string(code);
+    if (jl_exception_occurred()) {
+        // none of these allocate, so a gc-root (JL_GC_PUSH) is not necessary
+        jl_call2(
+                jl_get_function(jl_base_module, "showerror"),
+                jl_stderr_obj(),
+                jl_exception_occurred());
+        jl_printf(jl_stderr_stream(), "\n");
+        jl_atexit_hook(1);
+        exit(1);
+    }
+    assert(result && "Missing return value but no exception occurred!");
+    return result;
+}
+
+void abort_with_error(int full)
+{
+    abort();
+}
+
+int main()
+{
+    // Install callbacks. This should happen before `jl_init()` and
+    // before any GC is called.
+
+    jl_gc_set_cb_notify_external_alloc(alloc_bigval, 1);
+    jl_gc_set_cb_notify_external_free(free_bigval, 1);
+
+    jl_gc_enable_conservative_gc_support();
+    jl_init();
+    ptls = jl_get_ptls_states();
+    jl_gc_set_cb_root_scanner(root_scanner, 1);
+    jl_gc_set_cb_pre_gc(pre_gc_func, 1);
+    jl_gc_set_cb_post_gc(post_gc_func, 1);
+    // Test that deregistration works
+    jl_gc_set_cb_root_scanner(abort_with_error, 1);
+    jl_gc_set_cb_root_scanner(abort_with_error, 0);
+    // Create module to store types in.
+    module = jl_new_module(jl_symbol("TestGCExt"));
+    module->parent = jl_main_module;
+    jl_set_const(jl_main_module, jl_symbol("TestGCExt"), (jl_value_t *)module);
+    // Define Julia types for our stack implementation.
+    datatype_stack = jl_new_foreign_type(
+            jl_symbol("Stack"), module, jl_any_type, mark_stack, NULL, 1, 0);
+    jl_set_const(module, jl_symbol("Stack"), (jl_value_t *)datatype_stack);
+    datatype_stack_internal = jl_new_foreign_type(
+            jl_symbol("StackData"),
+            module,
+            jl_any_type,
+            mark_stack_data,
+            sweep_stack_data,
+            1,
+            0);
+    jl_set_const(
+            module,
+            jl_symbol("StackData"),
+            (jl_value_t *)datatype_stack_internal);
+    datatype_stack_external = jl_new_foreign_type(
+            jl_symbol("StackDataLarge"),
+            module,
+            jl_any_type,
+            mark_stack_data,
+            sweep_stack_data,
+            1,
+            1);
+    jl_set_const(
+            module,
+            jl_symbol("StackDataLarge"),
+            (jl_value_t *)datatype_stack_external);
+    // Remember the offset of external objects
+    bigval_startoffset = jl_gc_external_obj_hdr_size();
+    // Run the actual tests
+    checked_eval_string(
+            "let dir = dirname(unsafe_string(Base.JLOptions().julia_bin))\n"
+            // disable the package manager
+            "    ENV[\"JULIA_PKGDIR\"] = joinpath(dir, \"disabled\")\n"
+            // locate files relative to the "embedding" executable
+            "    stdlib = filter(env -> startswith(Base.find_package(Base, "
+            "\"Distributed\"), env), Base.load_path())[end]\n"
+            "    push!(empty!(LOAD_PATH), dir, stdlib)\n"
+            "end");
+
+    checked_eval_string("import LocalTest");
+}

--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -326,9 +326,7 @@ static size_t gc_alloc_size(jl_value_t *val)
 
 JL_DLLEXPORT int internal_obj_scan(jl_value_t *val)
 {
-    if (jl_gc_is_internal_obj_alloc(val)) {
-        if (jl_gc_internal_obj_base_ptr(val) != val)
-            return 0;
+    if (jl_gc_internal_obj_base_ptr(val) == val) {
         size_t size = gc_alloc_size(val);
         char *addr = (char *)val;
         for (size_t i = 0; i <= size; i++) {
@@ -558,7 +556,6 @@ int main()
     jl_gc_set_cb_notify_external_alloc(alloc_bigval, 1);
     jl_gc_set_cb_notify_external_free(free_bigval, 1);
 
-    jl_gc_enable_conservative_gc_support();
     jl_init();
     ptls = jl_get_ptls_states();
     jl_gc_set_cb_root_scanner(root_scanner, 1);


### PR DESCRIPTION
This PR backports PR #28368 and #32088 by @rbehrends to the `release-1.0` branch. The first PR contains extensions for the Julia GC to make used by the [OSCAR project](https://oscar.computeralgebra.de) (CC @wbhart @fieker) resp. the [GAP.jl](https://github.com/oscar-system/GAP.jl) package which integrates [GAP](https://www.gap-system.org) and Julia.

We realize that this might be controversial, and fully expect a discussion about this, but we wanted to at least try to get this in, as it would be really nice if people could use OSCAR with the Julia LTS releases.

I just discovered the rules for patch releases posted at https://discourse.julialang.org/t/proposed-release-process-and-schedule/15623, and those say that patch releases " ... should only contain bug fixes, low-risk performance improvements, and documentation updates". That does not fit with this PR (it adds an internal feature!), so perhaps that already is enough for you to reject it.... :-(. Anyway, I figured it can't hurt to at least try and ask...


To this end, note that this PR here is a super quick backport, which has ZERO testing right now -- of course that ought to change, but I before I waste time on that, I wanted to find out whether there is any chance at all for this being merged. If there is, we'll go over it carefully and test extensively. Also, I'd be happy to squash this down into a single commit, or do anything else you may require for backports.