### PR TITLE
provide non-aliasing constructors for sparse arrays

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -402,6 +402,21 @@ function SparseMatrixCSC{Tv,Ti}(S::AbstractSparseMatrixCSC) where {Tv,Ti}
     eltypeTvnzval = convert(Vector{Tv}, nonzeros(S))
     return SparseMatrixCSC(size(S, 1), size(S, 2), eltypeTicolptr, eltypeTirowval, eltypeTvnzval)
 end
+
+function convert(::Type{SparseMatrixCSC}, S::AbstractSparseMatrixCSC)
+    convert(SparseMatrixCSC{eltype(nonzeros(S)),eltype(rowvals(S))}, S)
+end
+function convert(::Type{SparseMatrixCSC{Tv}}, S::AbstractSparseMatrixCSC) where Tv
+    convert(SparseMatrixCSC{Tv,eltype(rowvals(S))}, S)
+end
+function convert(::Type{T}, S::AbstractSparseMatrixCSC) where {Ti,Tv,T<:SparseMatrixCSC{Tv,Ti}}
+    S isa T && return S
+    eltypeTicolptr = Vector{Ti}(getcolptr(S))
+    eltypeTirowval = Vector{Ti}(rowvals(S))
+    eltypeTvnzval = Vector{Tv}(nonzeros(S))
+    T(size(S, 1), size(S, 2), eltypeTicolptr, eltypeTirowval, eltypeTvnzval)
+end
+
 # converting from other matrix types to SparseMatrixCSC (also see sparse())
 SparseMatrixCSC(M::Matrix) = sparse(M)
 function SparseMatrixCSC(T::Tridiagonal{Tv}) where Tv

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -397,24 +397,10 @@ SparseMatrixCSC{Tv}(S::AbstractSparseMatrixCSC{Tv}) where {Tv} = copy(S)
 SparseMatrixCSC{Tv}(S::AbstractSparseMatrixCSC) where {Tv} = SparseMatrixCSC{Tv,eltype(getcolptr(S))}(S)
 SparseMatrixCSC{Tv,Ti}(S::AbstractSparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = copy(S)
 function SparseMatrixCSC{Tv,Ti}(S::AbstractSparseMatrixCSC) where {Tv,Ti}
-    eltypeTicolptr = convert(Vector{Ti}, getcolptr(S))
-    eltypeTirowval = convert(Vector{Ti}, rowvals(S))
-    eltypeTvnzval = convert(Vector{Tv}, nonzeros(S))
-    return SparseMatrixCSC(size(S, 1), size(S, 2), eltypeTicolptr, eltypeTirowval, eltypeTvnzval)
-end
-
-function convert(::Type{SparseMatrixCSC}, S::AbstractSparseMatrixCSC)
-    convert(SparseMatrixCSC{eltype(nonzeros(S)),eltype(rowvals(S))}, S)
-end
-function convert(::Type{SparseMatrixCSC{Tv}}, S::AbstractSparseMatrixCSC) where Tv
-    convert(SparseMatrixCSC{Tv,eltype(rowvals(S))}, S)
-end
-function convert(::Type{T}, S::AbstractSparseMatrixCSC) where {Ti,Tv,T<:SparseMatrixCSC{Tv,Ti}}
-    S isa T && return S
     eltypeTicolptr = Vector{Ti}(getcolptr(S))
     eltypeTirowval = Vector{Ti}(rowvals(S))
     eltypeTvnzval = Vector{Tv}(nonzeros(S))
-    T(size(S, 1), size(S, 2), eltypeTicolptr, eltypeTirowval, eltypeTvnzval)
+    return SparseMatrixCSC(size(S, 1), size(S, 2), eltypeTicolptr, eltypeTirowval, eltypeTvnzval)
 end
 
 # converting from other matrix types to SparseMatrixCSC (also see sparse())

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -427,7 +427,7 @@ SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(
 function SparseVector{Tv,Ti}(s::SparseVector) where {Tv,Ti}
     copyind = Vector{Ti}(nonzeroinds(s))
     copynz = Vector{Tv}(nonzeros(s))
-    SparseVector{Tv,Ti}(length(s::SparseVector), copyind, copynz)
+    SparseVector{Tv,Ti}(length(s), copyind, copynz)
 end
 
 # convert between different types of SparseVector

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -432,6 +432,12 @@ SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti} =
     SparseVector{Tv,Ti}(length(s::SparseVector), nonzeroinds(s), convert(Vector{Tv}, nonzeros(s)))
 
 convert(T::Type{<:SparseVector}, m::AbstractVector) = m isa T ? m : T(m)
+convert(::Type{SparseVector}, s::AbstractSparseVector) = convert(SparseVector{eltype(nonzeros(s)),eltype(nonzeroinds(s))}, s)
+convert(::Type{SparseVector{Tv}}, s::AbstractSparseVector) where Tv = convert(SparseVector{Tv,eltype(nonzeroinds(s))}, s)
+function convert(T::Type{SparseVector{Tv,Ti}}, s::AbstractSparseVector) where {Tv,Ti<:Integer}
+    s isa T && return s
+    T(length(s), Vector{Ti}(nonzeroinds(s)), Vector{Tv}(nonzeros(s)))
+end
 
 convert(T::Type{<:SparseVector}, m::AbstractSparseMatrixCSC) = T(m)
 convert(T::Type{<:AbstractSparseMatrixCSC}, v::SparseVector) = T(v)

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -428,17 +428,13 @@ SparseVector{Tv,Ti}(s::SparseVector{Tv,Ti}) where {Tv,Ti} = s
 SparseVector{Tv,Ti}(s::SparseVector) where {Tv,Ti} =
     SparseVector{Tv,Ti}(length(s::SparseVector), convert(Vector{Ti}, nonzeroinds(s)), convert(Vector{Tv}, nonzeros(s)))
 
-SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti} =
-    SparseVector{Tv,Ti}(length(s::SparseVector), nonzeroinds(s), convert(Vector{Tv}, nonzeros(s)))
-
-convert(T::Type{<:SparseVector}, m::AbstractVector) = m isa T ? m : T(m)
-convert(::Type{SparseVector}, s::AbstractSparseVector) = convert(SparseVector{eltype(nonzeros(s)),eltype(nonzeroinds(s))}, s)
-convert(::Type{SparseVector{Tv}}, s::AbstractSparseVector) where Tv = convert(SparseVector{Tv,eltype(nonzeroinds(s))}, s)
-function convert(T::Type{SparseVector{Tv,Ti}}, s::AbstractSparseVector) where {Tv,Ti<:Integer}
-    s isa T && return s
-    T(length(s), Vector{Ti}(nonzeroinds(s)), Vector{Tv}(nonzeros(s)))
+function SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti}
+    copyind = Vector{Ti}(nonzeroinds(s))
+    copynz = Vector{Tv}(nonzeros(s))
+    SparseVector{Tv,Ti}(length(s::SparseVector), copyind, copynz)
 end
 
+convert(T::Type{<:SparseVector}, m::AbstractVector) = m isa T ? m : T(m)
 convert(T::Type{<:SparseVector}, m::AbstractSparseMatrixCSC) = T(m)
 convert(T::Type{<:AbstractSparseMatrixCSC}, v::SparseVector) = T(v)
 

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -421,19 +421,16 @@ SparseVector{Tv}(s::AbstractVector{Tv}) where {Tv} = SparseVector{Tv,Int}(s)
 
 SparseVector(s::AbstractVector{Tv}) where {Tv} = SparseVector{Tv,Int}(s)
 
-
-# convert between different types of SparseVector
-SparseVector{Tv}(s::SparseVector{Tv}) where {Tv} = s
-SparseVector{Tv,Ti}(s::SparseVector{Tv,Ti}) where {Tv,Ti} = s
-SparseVector{Tv,Ti}(s::SparseVector) where {Tv,Ti} =
-    SparseVector{Tv,Ti}(length(s::SparseVector), convert(Vector{Ti}, nonzeroinds(s)), convert(Vector{Tv}, nonzeros(s)))
-
-function SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti}
+# copy-constructors
+SparseVector(s::SparseVector{Tv,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(s)
+SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(s)
+function SparseVector{Tv,Ti}(s::SparseVector) where {Tv,Ti}
     copyind = Vector{Ti}(nonzeroinds(s))
     copynz = Vector{Tv}(nonzeros(s))
     SparseVector{Tv,Ti}(length(s::SparseVector), copyind, copynz)
 end
 
+# convert between different types of SparseVector
 convert(T::Type{<:SparseVector}, m::AbstractVector) = m isa T ? m : T(m)
 convert(T::Type{<:SparseVector}, m::AbstractSparseMatrixCSC) = T(m)
 convert(T::Type{<:AbstractSparseMatrixCSC}, v::SparseVector) = T(v)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2834,4 +2834,16 @@ end
     @test reshape(crA, 20, 10) == A
 end
 
+@testset "avoid aliasing of fields during convert $T (issue #34630)" for T in
+    (SparseMatrixCSC{Float64}, SparseMatrixCSC{Float64,Int16})
+
+    A = sparse([1 1; 1 0])
+    B = convert(SparseMatrixCSC{Float64}, A)
+    @test A == B
+    A[2,2] = 1
+    @test getcolptr(A) !== getcolptr(B)
+    @test rowvals(A) !== rowvals(B)
+    @test nonzeros(A) !== nonzeros(B)
+end
+
 end # module

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2834,13 +2834,14 @@ end
     @test reshape(crA, 20, 10) == A
 end
 
-@testset "avoid aliasing of fields during convert $T (issue #34630)" for T in
-    (SparseMatrixCSC{Float64}, SparseMatrixCSC{Float64,Int16})
+@testset "avoid aliasing of fields during constructing $T (issue #34630)" for T in
+    (SparseMatrixCSC, SparseMatrixCSC{Float64}, SparseMatrixCSC{Float64,Int16})
 
     A = sparse([1 1; 1 0])
-    B = convert(SparseMatrixCSC{Float64}, A)
+    B = T(A)
     @test A == B
     A[2,2] = 1
+    @test A != B
     @test getcolptr(A) !== getcolptr(B)
     @test rowvals(A) !== rowvals(B)
     @test nonzeros(A) !== nonzeros(B)

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1408,13 +1408,14 @@ end
     @test nnz(scv) == nnz(A[:, 1])
 end
 
-@testset "avoid aliasing of fields during convert $T (issue #34630)" for T in
-    (SparseVector{Float64},SparseVector{Float64,Int16})
+@testset "avoid aliasing of fields during constructing $T (issue #34630)" for T in
+    (SparseVector, SparseVector{Float64}, SparseVector{Float64,Int16})
 
     A = sparse([1; 0])
-    B = convert(SparseVector{Float64}, A)
+    B = T(A)
     @test A == B
     A[2] = 1
+    @test A != B
     @test nonzeroinds(A) !== nonzeroinds(B)
     @test nonzeros(A) !== nonzeros(B)
 end

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1408,4 +1408,15 @@ end
     @test nnz(scv) == nnz(A[:, 1])
 end
 
+@testset "avoid aliasing of fields during convert $T (issue #34630)" for T in
+    (SparseVector{Float64},SparseVector{Float64,Int16})
+
+    A = sparse([1; 0])
+    B = convert(SparseVector{Float64}, A)
+    @test A == B
+    A[2] = 1
+    @test nonzeroinds(A) !== nonzeroinds(B)
+    @test nonzeros(A) !== nonzeros(B)
+end
+
 end # module


### PR DESCRIPTION
This fixes #34630, which ~~does not touch~~ makes copy sparse constructors.