### PR TITLE
#34518 - rename isimmutable to ismutable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@ New library functions
   provide one-argument method that returns a closure.  The old methods of `merge` and
   `merge!` are still available for backward compatibility ([#34296]).
 * The new `isdisjoint` function indicates whether two collections are disjoint ([#34427]).
+* Add function `ismutable` and deprecate `isimmutable` to check whether something is mutable.([#34652])
 
 New library features
 --------------------

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -167,7 +167,7 @@ function const_prop_profitable(@nospecialize(arg))
             isconstType(b) && return true
             const_prop_profitable(b) && return true
         end
-    elseif !isa(arg, Const) || (isa(arg.val, Symbol) || isa(arg.val, Type) || (!isa(arg.val, String) && isimmutable(arg.val)))
+    elseif !isa(arg, Const) || (isa(arg.val, Symbol) || isa(arg.val, Type) || (!isa(arg.val, String) && !ismutable(arg.val)))
         # don't consider mutable values or Strings useful constants
         return true
     end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -380,7 +380,7 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
         elseif isa(leaf, Union{Argument, Expr})
             return nothing
         end
-        isimmutable(leaf) || return nothing
+        !ismutable(leaf) || return nothing
         isdefined(leaf, field) || return nothing
         val = getfield(leaf, field)
         is_inlineable_constant(val) || return nothing

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -288,7 +288,7 @@ function isdefined_tfunc(@nospecialize(args...))
                 return Const(true)
             elseif isa(arg1, Const)
                 arg1v = (arg1::Const).val
-                if isimmutable(arg1v) || isdefined(arg1v, idx) || (isa(arg1v, DataType) && is_dt_const_field(idx))
+                if !ismutable(arg1v) || isdefined(arg1v, idx) || (isa(arg1v, DataType) && is_dt_const_field(idx))
                     return Const(isdefined(arg1v, idx))
                 end
             end
@@ -722,7 +722,7 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
             if !(isa(nv,Symbol) || isa(nv,Int))
                 return Bottom
             end
-            if (isa(sv, SimpleVector) || isimmutable(sv)) && isdefined(sv, nv)
+            if (isa(sv, SimpleVector) || !ismutable(sv)) && isdefined(sv, nv)
                 return AbstractEvalConstant(getfield(sv, nv))
             end
         end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -209,6 +209,6 @@ julia> isimmutable([1,2])
 false
 ```
 """
-isimmutable(@nospecialize(x)) = (@_pure_meta; !typeof(x).mutable)
+isimmutable(@nospecialize(x)) = !ismutable(x)
 
 # END 1.5 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -190,3 +190,24 @@ MPFR.BigFloat(x::Real, prec::Int, rounding::RoundingMode) = BigFloat(x, rounding
 end
 
 # END 1.3 deprecations
+
+# BEGIN 1.5 deprecations
+"""
+    isimmutable(v) -> Bool
+
+Return `true` iff value `v` is immutable.  See [Mutable Composite Types](@ref)
+for a discussion of immutability. Note that this function works on values, so if you give it
+a type, it will tell you that a value of `DataType` is mutable.
+
+# Examples
+```jldoctest
+julia> isimmutable(1)
+true
+
+julia> isimmutable([1,2])
+false
+```
+"""
+isimmutable(@nospecialize(x)) = (@_pure_meta; !typeof(x).mutable)
+
+# END 1.5 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -195,7 +195,7 @@ end
 """
     isimmutable(v) -> Bool
 !!! warning
-    Consider using `!ismutable(v)` instead, as `isimmutable(v)` will be replaced by `!ismutable(v)` in a future release.
+    Consider using `!ismutable(v)` instead, as `isimmutable(v)` will be replaced by `!ismutable(v)` in a future release. (Since Julia 1.5)
 Return `true` iff value `v` is immutable.  See [Mutable Composite Types](@ref)
 for a discussion of immutability. Note that this function works on values, so if you give it
 a type, it will tell you that a value of `DataType` is mutable.

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -210,5 +210,6 @@ false
 ```
 """
 isimmutable(@nospecialize(x)) = !ismutable(x)
+export isimmutable
 
 # END 1.5 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -194,7 +194,8 @@ end
 # BEGIN 1.5 deprecations
 """
     isimmutable(v) -> Bool
-
+!!! warning
+    Consider using `!ismutable(v)` instead, as `isimmutable(v)` will be replaced by `!ismutable(v)` in a future release.
 Return `true` iff value `v` is immutable.  See [Mutable Composite Types](@ref)
 for a discussion of immutability. Note that this function works on values, so if you give it
 a type, it will tell you that a value of `DataType` is mutable.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -641,7 +641,6 @@ export
     identity,
     isbits,
     isequal,
-    isimmutable,
     ismutable,
     isless,
     ifelse,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -642,6 +642,7 @@ export
     isbits,
     isequal,
     isimmutable,
+    ismutable,
     isless,
     ifelse,
     objectid,

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -27,7 +27,7 @@ end
 ```
 """
 function finalizer(@nospecialize(f), @nospecialize(o))
-    if isimmutable(o)
+    if !ismutable(o)
         error("objects of type ", typeof(o), " cannot be finalized")
     end
     ccall(:jl_gc_add_finalizer_th, Cvoid, (Ptr{Cvoid}, Any, Any),
@@ -37,7 +37,7 @@ end
 
 function finalizer(f::Ptr{Cvoid}, o::T) where T
     @_inline_meta
-    if isimmutable(o)
+    if !ismutable(o)
         error("objects of type ", typeof(o), " cannot be finalized")
     end
     ccall(:jl_gc_add_ptr_finalizer, Cvoid, (Ptr{Cvoid}, Any, Ptr{Cvoid}),

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -402,27 +402,6 @@ function datatype_fielddesc_type(dt::DataType)
 end
 
 """
-    isimmutable(v) -> Bool
-
-Return `true` iff value `v` is immutable.  See [Mutable Composite Types](@ref)
-for a discussion of immutability. Note that this function works on values, so if you give it
-a type, it will tell you that a value of `DataType` is mutable.
-
-# Examples
-```jldoctest
-julia> isimmutable(1)
-true
-
-julia> isimmutable([1,2])
-false
-```
-"""
-function isimmutable(@nospecialize(x))
-    depwarn(" isimmutable is deprecated use ismutable instead ", :isimmutable)
-    return (@_pure_meta; !typeof(x).mutable)
-end
-
-"""
     ismutable(v) -> Bool
 
 Return `true` iff value `v` is mutable.  See [Mutable Composite Types](@ref)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -417,7 +417,28 @@ julia> isimmutable([1,2])
 false
 ```
 """
-isimmutable(@nospecialize(x)) = (@_pure_meta; !typeof(x).mutable)
+function isimmutable(@nospecialize(x))
+    depwarn(" isimmutable is deprecated use ismutable instead ", :isimmutable)
+    return (@_pure_meta; !typeof(x).mutable)
+end
+
+"""
+    ismutable(v) -> Bool
+
+Return `true` iff value `v` is mutable.  See [Mutable Composite Types](@ref)
+for a discussion of immutability. Note that this function works on values, so if you give it
+a type, it will tell you that a value of `DataType` is mutable.
+
+# Examples
+```jldoctest
+julia> ismutable(1)
+false
+
+julia> ismutable([1,2])
+true
+```
+"""
+ismutable(@nospecialize(x)) = (@_pure_meta; typeof(x).mutable)
 
 """
     isstructtype(T) -> Bool

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -159,6 +159,7 @@ Base.isdispatchtuple
 
 ```@docs
 Base.isimmutable
+Base.ismutable
 Base.isabstracttype
 Base.isprimitivetype
 Base.issingletontype

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -158,8 +158,8 @@ Base.isdispatchtuple
 ### Declared structure
 
 ```@docs
-Base.isimmutable
 Base.ismutable
+Base.isimmutable
 Base.isabstracttype
 Base.isprimitivetype
 Base.issingletontype

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -104,8 +104,8 @@ not_const = 1
 @test isconst(@__MODULE__, :not_const) == false
 @test isconst(@__MODULE__, :is_not_defined) == false
 
-@test isimmutable(1) == true
-@test isimmutable([]) == false
+@test ismutable(1) == false
+@test ismutable([]) == true
 
 ## find bindings tests
 @test ccall(:jl_get_module_of_binding, Any, (Any, Any), Base, :sin)==Base


### PR DESCRIPTION
PR for issue #34518. 
Created a `ismutable` in   `base/reflection.jl ` and added a `depwar` to `isimmutable`.

Result in REPL:
```
julia> isimmutable(1)
┌ Warning:  isimmutable is deprecated use ismutable instead 
│   caller = top-level scope at REPL[1]:1
└ @ Core REPL[1]:1
true

julia> ismutable(1)
false
```

Switched `isimmutable` to `ismutable` in other parts of the code. 

- [X] add `isimmutable`
- [X] replace `isimmutable` to `ismutable`
- [X] Add a few tests.
Didn't add any new tests but `test/reflection.jl` passed.
```
$ ./julia test/reflection.jl
Test Summary: |
issue #31687  | No tests
Test Summary:       | Pass  Total
methods with module |   11     11
```
- [X] Add a NEWS item.