### PR TITLE
Overhaul of rounding for rational numbers

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -126,7 +126,6 @@ round(::Type{T}, x::AbstractFloat, r::RoundingMode) where {T<:Integer} = trunc(T
 # NOTE: this relies on the current keyword dispatch behaviour (#9498).
 function round(x::Real, r::RoundingMode=RoundNearest;
                digits::Union{Nothing,Integer}=nothing, sigdigits::Union{Nothing,Integer}=nothing, base::Union{Nothing,Integer}=nothing)
-    isfinite(x) || return x
     if digits === nothing
         if sigdigits === nothing
             if base === nothing
@@ -137,10 +136,12 @@ function round(x::Real, r::RoundingMode=RoundNearest;
                 # or throw(ArgumentError("`round` cannot use `base` argument without `digits` or `sigdigits` arguments."))
             end
         else
+            isfinite(x) || return float(x)
             _round_sigdigits(x, r, sigdigits, base === nothing ? 10 : base)
         end
     else
         if sigdigits === nothing
+            isfinite(x) || return float(x)
             _round_digits(x, r, digits, base === nothing ? 10 : base)
         else
             throw(ArgumentError("`round` cannot use both `digits` and `sigdigits` arguments."))

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -135,7 +135,7 @@ round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
     throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
 round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
 # to fix ambiguities
-round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
+round(::Type{T}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {T>:Missing,Tr} = round(nonmissingtype_checked(T), x, r)
 round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
 
 # Handle ceil, floor, and trunc separately as they have no RoundingMode argument

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -385,53 +385,19 @@ end
 trunc(::Type{T}, x::Rational) where {T} = convert(T,div(x.num,x.den))
 floor(::Type{T}, x::Rational) where {T} = convert(T,fld(x.num,x.den))
 ceil(::Type{T}, x::Rational) where {T} = convert(T,cld(x.num,x.den))
-round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T} = _round_rational(T, x, r)
-round(x::Rational, r::RoundingMode) = round(Rational, x, r)
 
-function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest}) where {T,Tr}
-    if denominator(x) == zero(Tr) && T <: Integer
-        throw(DivideError())
-    elseif denominator(x) == zero(Tr)
+round(x::Rational, r::RoundingMode) = round(typeof(x), x, r)
+
+function round(::Type{T}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {T,Tr}
+    if iszero(denominator(x))
+        T <: Integer && throw(DivideError())
         return convert(T, copysign(one(Tr)//zero(Tr), numerator(x)))
     end
-    q,r = divrem(numerator(x), denominator(x))
-    s = q
-    if abs(r) >= abs((denominator(x)-copysign(Tr(4), numerator(x))+one(Tr)+iseven(q))>>1 + copysign(Tr(2), numerator(x)))
-        s += copysign(one(Tr),numerator(x))
-    end
-    convert(T, s)
-end
-
-function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesAway}) where {T,Tr}
-    if denominator(x) == zero(Tr) && T <: Integer
-        throw(DivideError())
-    elseif denominator(x) == zero(Tr)
-        return convert(T, copysign(one(Tr)//zero(Tr), numerator(x)))
-    end
-    q,r = divrem(numerator(x), denominator(x))
-    s = q
-    if abs(r) >= abs((denominator(x)-copysign(Tr(4), numerator(x))+one(Tr))>>1 + copysign(Tr(2), numerator(x)))
-        s += copysign(one(Tr),numerator(x))
-    end
-    convert(T, s)
-end
-
-function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp}) where {T,Tr}
-    if denominator(x) == zero(Tr) && T <: Integer
-        throw(DivideError())
-    elseif denominator(x) == zero(Tr)
-        return convert(T, copysign(one(Tr)//zero(Tr), numerator(x)))
-    end
-    q,r = divrem(numerator(x), denominator(x))
-    s = q
-    if abs(r) >= abs((denominator(x)-copysign(Tr(4), numerator(x))+one(Tr)+(numerator(x)<0))>>1 + copysign(Tr(2), numerator(x)))
-        s += copysign(one(Tr),numerator(x))
-    end
-    convert(T, s)
+    convert(T, div(numerator(x), denominator(x), r))
 end
 
 function round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where T
-    if denominator(x) == false && (T <: Union{Integer, Bool})
+    if denominator(x) == false && (T <: Integer)
         throw(DivideError())
     end
     convert(T, x)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -389,8 +389,7 @@ ceil(::Type{T}, x::Rational) where {T} = round(T, x, RoundUp)
 round(x::Rational, r::RoundingMode=RoundNearest) = round(typeof(x), x, r)
 
 function round(::Type{T}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {T,Tr}
-    if iszero(denominator(x))
-        T <: Integer && throw(DivideError())
+    if iszero(denominator(x)) && !(T <: Integer)
         return convert(T, copysign(one(Tr)//zero(Tr), numerator(x)))
     end
     convert(T, div(numerator(x), denominator(x), r))

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -382,11 +382,11 @@ for (S, T) in ((Rational, Integer), (Integer, Rational), (Rational, Rational))
     end
 end
 
-trunc(::Type{T}, x::Rational) where {T} = convert(T,div(x.num,x.den))
-floor(::Type{T}, x::Rational) where {T} = convert(T,fld(x.num,x.den))
-ceil(::Type{T}, x::Rational) where {T} = convert(T,cld(x.num,x.den))
+trunc(::Type{T}, x::Rational) where {T} = round(T, x, RoundToZero)
+floor(::Type{T}, x::Rational) where {T} = round(T, x, RoundDown)
+ceil(::Type{T}, x::Rational) where {T} = round(T, x, RoundUp)
 
-round(x::Rational, r::RoundingMode) = round(typeof(x), x, r)
+round(x::Rational, r::RoundingMode=RoundNearest) = round(typeof(x), x, r)
 
 function round(::Type{T}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {T,Tr}
     if iszero(denominator(x))
@@ -402,11 +402,6 @@ function round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where 
     end
     convert(T, x)
 end
-
-trunc(x::Rational{T}) where {T} = Rational(trunc(T,x))
-floor(x::Rational{T}) where {T} = Rational(floor(T,x))
-ceil(x::Rational{T}) where {T} = Rational(ceil(T,x))
-round(x::Rational{T}) where {T} = Rational(round(T,x))
 
 function ^(x::Rational, n::Integer)
     n >= 0 ? power_by_squaring(x,n) : power_by_squaring(inv(x),-n)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -247,10 +247,47 @@ end
 end
 
 @testset "round" begin
-    @test round(11//2) == 6//1 # rounds to closest _even_ integer
-    @test round(-11//2) == -6//1 # rounds to closest _even_ integer
-    @test round(11//3) == 4//1 # rounds to closest _even_ integer
-    @test round(-11//3) == -4//1 # rounds to closest _even_ integer
+    @test round(11//2) == round(11//2, RoundNearest) == 6//1 # rounds to closest _even_ integer
+    @test round(-11//2) == round(-11//2, RoundNearest) == -6//1 # rounds to closest _even_ integer
+    @test round(13//2) == round(13//2, RoundNearest) == 6//1 # rounds to closest _even_ integer
+    @test round(-13//2) == round(-13//2, RoundNearest) == -6//1 # rounds to closest _even_ integer
+    @test round(11//3) == round(11//3, RoundNearest) == 4//1 # rounds to closest _even_ integer
+    @test round(-11//3) == round(-11//3, RoundNearest) == -4//1 # rounds to closest _even_ integer
+
+    @test round(11//2, RoundNearestTiesAway) == 6//1
+    @test round(-11//2, RoundNearestTiesAway) == -6//1
+    @test round(13//2, RoundNearestTiesAway) == 7//1
+    @test round(-13//2, RoundNearestTiesAway) == -7//1
+    @test round(11//3, RoundNearestTiesAway) == 4//1
+    @test round(-11//3, RoundNearestTiesAway) == -4//1
+
+    @test round(11//2, RoundNearestTiesUp) == 6//1
+    @test round(-11//2, RoundNearestTiesUp) == -5//1
+    @test round(13//2, RoundNearestTiesUp) == 7//1
+    @test round(-13//2, RoundNearestTiesUp) == -6//1
+    @test round(11//3, RoundNearestTiesUp) == 4//1
+    @test round(-11//3, RoundNearestTiesUp) == -4//1
+
+    @test round(11//2, RoundToZero) == 5//1
+    @test round(-11//2, RoundToZero) == -5//1
+    @test round(13//2, RoundToZero) == 6//1
+    @test round(-13//2, RoundToZero) == -6//1
+    @test round(11//3, RoundToZero) == 3//1
+    @test round(-11//3, RoundToZero) == -3//1
+
+    @test round(11//2, RoundUp) == 6//1
+    @test round(-11//2, RoundUp) == -5//1
+    @test round(13//2, RoundUp) == 7//1
+    @test round(-13//2, RoundUp) == -6//1
+    @test round(11//3, RoundUp) == 4//1
+    @test round(-11//3, RoundUp) == -3//1
+
+    @test round(11//2, RoundDown) == 5//1
+    @test round(-11//2, RoundDown) == -6//1
+    @test round(13//2, RoundDown) == 6//1
+    @test round(-13//2, RoundDown) == -7//1
+    @test round(11//3, RoundDown) == 3//1
+    @test round(-11//3, RoundDown) == -4//1
 
     for T in (Float16, Float32, Float64)
         @test round(T, true//false) === convert(T, Inf)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -333,6 +333,11 @@ end
         @test round(1//0, r) === 1//0
         @test round(-1//0, r) === -1//0
     end
+
+    @test @inferred(round(1//0, digits=1)) === Inf
+    @test @inferred(trunc(1//0, digits=2)) === Inf
+    @test @inferred(floor(-1//0, sigdigits=1)) === -Inf
+    @test @inferred(ceil(-1//0, sigdigits=2)) === -Inf
 end
 
 @testset "issue 1552" begin

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -268,37 +268,70 @@ end
     @test round(11//3, RoundNearestTiesUp) == 4//1
     @test round(-11//3, RoundNearestTiesUp) == -4//1
 
-    @test round(11//2, RoundToZero) == 5//1
-    @test round(-11//2, RoundToZero) == -5//1
-    @test round(13//2, RoundToZero) == 6//1
-    @test round(-13//2, RoundToZero) == -6//1
-    @test round(11//3, RoundToZero) == 3//1
-    @test round(-11//3, RoundToZero) == -3//1
+    @test trunc(11//2) == round(11//2, RoundToZero) == 5//1
+    @test trunc(-11//2) == round(-11//2, RoundToZero) == -5//1
+    @test trunc(13//2) == round(13//2, RoundToZero) == 6//1
+    @test trunc(-13//2) == round(-13//2, RoundToZero) == -6//1
+    @test trunc(11//3) == round(11//3, RoundToZero) == 3//1
+    @test trunc(-11//3) == round(-11//3, RoundToZero) == -3//1
 
-    @test round(11//2, RoundUp) == 6//1
-    @test round(-11//2, RoundUp) == -5//1
-    @test round(13//2, RoundUp) == 7//1
-    @test round(-13//2, RoundUp) == -6//1
-    @test round(11//3, RoundUp) == 4//1
-    @test round(-11//3, RoundUp) == -3//1
+    @test ceil(11//2) == round(11//2, RoundUp) == 6//1
+    @test ceil(-11//2) == round(-11//2, RoundUp) == -5//1
+    @test ceil(13//2) == round(13//2, RoundUp) == 7//1
+    @test ceil(-13//2) == round(-13//2, RoundUp) == -6//1
+    @test ceil(11//3) == round(11//3, RoundUp) == 4//1
+    @test ceil(-11//3) == round(-11//3, RoundUp) == -3//1
 
-    @test round(11//2, RoundDown) == 5//1
-    @test round(-11//2, RoundDown) == -6//1
-    @test round(13//2, RoundDown) == 6//1
-    @test round(-13//2, RoundDown) == -7//1
-    @test round(11//3, RoundDown) == 3//1
-    @test round(-11//3, RoundDown) == -4//1
+    @test floor(11//2) == round(11//2, RoundDown) == 5//1
+    @test floor(-11//2) == round(-11//2, RoundDown) == -6//1
+    @test floor(13//2) == round(13//2, RoundDown) == 6//1
+    @test floor(-13//2) == round(-13//2, RoundDown) == -7//1
+    @test floor(11//3) == round(11//3, RoundDown) == 3//1
+    @test floor(-11//3) == round(-11//3, RoundDown) == -4//1
 
     for T in (Float16, Float32, Float64)
         @test round(T, true//false) === convert(T, Inf)
         @test round(T, true//true) === one(T)
         @test round(T, false//true) === zero(T)
+        @test trunc(T, true//false) === convert(T, Inf)
+        @test trunc(T, true//true) === one(T)
+        @test trunc(T, false//true) === zero(T)
+        @test floor(T, true//false) === convert(T, Inf)
+        @test floor(T, true//true) === one(T)
+        @test floor(T, false//true) === zero(T)
+        @test ceil(T, true//false) === convert(T, Inf)
+        @test ceil(T, true//true) === one(T)
+        @test ceil(T, false//true) === zero(T)
     end
 
     for T in (Int8, Int16, Int32, Int64, Bool)
         @test_throws DivideError round(T, true//false)
         @test round(T, true//true) === one(T)
         @test round(T, false//true) === zero(T)
+        @test_throws DivideError trunc(T, true//false)
+        @test trunc(T, true//true) === one(T)
+        @test trunc(T, false//true) === zero(T)
+        @test_throws DivideError floor(T, true//false)
+        @test floor(T, true//true) === one(T)
+        @test floor(T, false//true) === zero(T)
+        @test_throws DivideError ceil(T, true//false)
+        @test ceil(T, true//true) === one(T)
+        @test ceil(T, false//true) === zero(T)
+    end
+
+    # issue 34657
+    @test round(1//0) === round(Rational, 1//0) === 1//0
+    @test trunc(1//0) === trunc(Rational, 1//0) === 1//0
+    @test floor(1//0) === floor(Rational, 1//0) === 1//0
+    @test ceil(1//0) === ceil(Rational, 1//0) === 1//0
+    @test round(-1//0) === round(Rational, -1//0) === -1//0
+    @test trunc(-1//0) === trunc(Rational, -1//0) === -1//0
+    @test floor(-1//0) === floor(Rational, -1//0) === -1//0
+    @test ceil(-1//0) === ceil(Rational, -1//0) === -1//0
+    for r = [RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp,
+             RoundToZero, RoundUp, RoundDown]
+        @test round(1//0, r) === 1//0
+        @test round(-1//0, r) === -1//0
     end
 end
 


### PR DESCRIPTION
Fix #34645.
Fix #34657.

In addition, this simplifies the implementation of `round` for `Rational`s by using the recently added `div(x, y, ::RoundingMode)`.
