### PR TITLE
fix #34343, missing type prefix in display of some nested containers

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -428,7 +428,9 @@ function show(io::IO, X::AbstractArray)
     ndims(X) == 0 && return show_zero_dim(io, X)
     ndims(X) == 1 && return show_vector(io, X)
     prefix, implicit = typeinfo_prefix(io, X)
-    io = IOContext(io, :typeinfo => eltype(X), :typeinfo_implicit => implicit)
+    if !implicit
+        io = IOContext(io, :typeinfo => eltype(X))
+    end
     isempty(X) ?
         _show_empty(io, X) :
         _show_nonempty(io, X, prefix)
@@ -456,7 +458,9 @@ function show_vector(io::IO, v, opn='[', cls=']')
     prefix, implicit = typeinfo_prefix(io, v)
     print(io, prefix)
     # directly or indirectly, the context now knows about eltype(v)
-    io = IOContext(io, :typeinfo => eltype(v), :typeinfo_implicit => implicit)
+    if !implicit
+        io = IOContext(io, :typeinfo => eltype(v))
+    end
     limited = get(io, :limit, false)
 
     if limited && length(v) > 20
@@ -498,7 +502,6 @@ end
 # X not constrained, can be any iterable (cf. show_vector)
 function typeinfo_prefix(io::IO, X)
     typeinfo = get(io, :typeinfo, Any)::Type
-    implicit = get(io, :typeinfo_implicit, false)::Bool
 
     if !(X isa typeinfo)
         typeinfo = Any
@@ -509,15 +512,17 @@ function typeinfo_prefix(io::IO, X)
     eltype_X = eltype(X)
 
     if X isa AbstractDict
-        if eltype_X == eltype_ctx || (!isempty(X) && typeinfo_implicit(keytype(X)) && typeinfo_implicit(valtype(X)))
+        if eltype_X == eltype_ctx
             string(typeof(X).name), false
+        elseif !isempty(X) && typeinfo_implicit(keytype(X)) && typeinfo_implicit(valtype(X))
+            string(typeof(X).name), true
         else
             string(typeof(X)), false
         end
     else
         # Types hard-coded here are those which are created by default for a given syntax
-        if !(isempty(X) && implicit) && eltype_X == eltype_ctx
-            "", implicit
+        if eltype_X == eltype_ctx
+            "", false
         elseif !isempty(X) && typeinfo_implicit(eltype_X)
             "", true
         elseif print_without_params(eltype_X)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -27,7 +27,7 @@ function show(io::IO, t::AbstractDict{K,V}) where V where K
 
     limit::Bool = get(io, :limit, false)
     # show in a Julia-syntax-like form: Dict(k=>v, ...)
-    print(io, typeinfo_prefix(io, t))
+    print(io, typeinfo_prefix(io, t)[1])
     print(io, '(')
     if !isempty(t) && !show_circular(io, t)
         first = true

--- a/test/show.jl
+++ b/test/show.jl
@@ -1672,6 +1672,10 @@ end
     @test replstr(Vector[Any[1]]) == "1-element Array{Array{T,1} where T,1}:\n Any[1]"
     @test replstr(AbstractDict{Integer,Integer}[Dict{Integer,Integer}(1=>2)]) ==
         "1-element Array{AbstractDict{Integer,Integer},1}:\n Dict(1 => 2)"
+
+    # issue #34343
+    @test showstr([[1], Int[]]) == "[[1], $Int[]]"
+    @test showstr([Dict(1=>1), Dict{Int,Int}()]) == "[Dict(1 => 1), Dict{$Int,$Int}()]"
 end
 
 @testset "#14684: `display` should print associative types in full" begin


### PR DESCRIPTION
This currently only fixes the arrays, and no tests, but wanted first feedback on the approach.
Arrays are now printed this way:
```julia
julia> [Int[]] # no change here, the context gives all the type info
1-element Array{Array{Int64,1},1}:
 []

julia> show([Int[]]) # was `[[]]` before
[Int64[]]

julia> show([Int[1]]) # no change here, the 1 gives the type info
[[1]]
```
(Note: `[Int[]]` displays currently differently on master, cf. #34659).

Two different strategies:
1) Have an `:typeinfo_implicit` `IOContext` attribute tracking whether we "know" the current `:typeinfo` type because it was printed, or because it can be inferred from the content of the container. In the latter case, this can depend on the elements of the container being themselves non-empty containers, so if they turn out to be empty, we have then to print some type information for them (when `:typeinfo_implicit` is true). This is the 1st commit.
2) "if a container decides not to print a type prefix, it should then not set :typeinfo" (quoting [Jeff](https://github.com/JuliaLang/julia/pull/34354#issuecomment-573830284)). This is 2nd commit.

I'm not sure yet of the implications of both ideas, but think I prefer 2) for simplicity, which we can always amend if things don't go well (I'm just a little less sure that tests will even pass with 2)).