### PR TITLE
Add a test for `pkgdir`: submodule located in a subdirectory

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -284,7 +284,8 @@ module NotPkgModule; end
 
     @testset "pkgdir" begin
         @test pkgdir(Foo) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
-        @test pkgdir(Foo.SubFoo) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
+        @test pkgdir(Foo.SubFoo1) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
+        @test pkgdir(Foo.SubFoo2) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
         @test pkgdir(NotPkgModule) === nothing
     end
 

--- a/test/project/deps/Foo1/src/Foo.jl
+++ b/test/project/deps/Foo1/src/Foo.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Foo
-include("SubFoo.jl")
+include("SubFoo1.jl")
+include(joinpath("subdir", "SubFoo2.jl"))
 import Bar, Baz, Qux
 this = "Foo1"
 which = "path"

--- a/test/project/deps/Foo1/src/SubFoo1.jl
+++ b/test/project/deps/Foo1/src/SubFoo1.jl
@@ -1,5 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module SubFoo
-thissub = "Foo1.SubFoo"
+module SubFoo1
+thissub = "Foo1.SubFoo1"
 end

--- a/test/project/deps/Foo1/src/subdir/SubFoo2.jl
+++ b/test/project/deps/Foo1/src/subdir/SubFoo2.jl
@@ -1,0 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module SubFoo2
+thissub = "Foo1.SubFoo2"
+end


### PR DESCRIPTION
Currently, there is a test for `pkgdir(Foo.SubFoo)`, where the source file that defines `SubFoo` is located in the same directory as the source file that defines `Foo`.

This pull request adds an additional test for `pkgdir(Foo.SubFoo2)`, where the source file that defines `SubFoo2` is NOT located in the same directory as the source file that defines `Foo`.

The basic idea is that we want to make sure `pkgdir` works correctly even if you give it a submodule that has been defined in a subdirectory.

cc: @ianshmean 