### PR TITLE
Added doc to RNG about changing between versions

### DIFF
--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -26,6 +26,9 @@ unbounded integers, the interval must be specified (e.g. `rand(big.(1:6))`).
 Additionally, normal and exponential distributions are implemented for some `AbstractFloat` and
 `Complex` types, see [`randn`](@ref) and [`randexp`](@ref) for details.
 
+!!! warn
+    Because the precise way in which random numbers are generated is considered an implementation detail, bug fixes and speed improvements may change the stream of numbers that are generated after a version change. Relying on a specific seed or generated stream of numbers during unit testing is thus discouraged - consider testing properties of the methods in question instead.
+
 ## Random numbers module
 ```@docs
 Random.Random


### PR DESCRIPTION
This PR is based on a few people asking about why their tests failed following a minor version change (as far as I can tell, [this one](https://github.com/JuliaLang/julia/pull/30494)). Notably on discourse following 0.6 -> 0.7 ([here](https://discourse.julialang.org/t/unit-tests-for-packages-that-use-random-number-generation-that-are-robust-to-version-changes/14477)) and because of the linked PR the [tests](https://github.com/EcoJulia/SpatialEcology.jl/blob/master/test/ComMatrix_test.jl#L31-L33) in SpatialEcology.jl also failed.

Relying on a specific stream of generated numbers using any of the interfaces of Random is imo bad form and should be avoided if possible, so a warning would be useful.

