### PR TITLE
make setdiff not call `setdiff!` ?

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -212,7 +212,7 @@ julia> symdiff(unique([1,2,1]), unique([2, 1, 2]))
 ```
 """
 symdiff(s, sets...) = symdiff!(emptymutable(s, promote_eltype(s, sets...)), s, sets...)
-symdiff(s) = copy(s)
+symdiff(s) = union(s)
 
 """
     symdiff!(s::Union{AbstractSet,AbstractVector}, itrs...)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -212,7 +212,7 @@ julia> symdiff(unique([1,2,1]), unique([2, 1, 2]))
 ```
 """
 symdiff(s, sets...) = symdiff!(emptymutable(s, promote_eltype(s, sets...)), s, sets...)
-symdiff(s) = symdiff!(copy(s))
+symdiff(s) = copy(s)
 
 """
     symdiff!(s::Union{AbstractSet,AbstractVector}, itrs...)


### PR DESCRIPTION
Calling `setdiff!` on `copy(x)` seems like its not desirable.
