### PR TITLE
fix docstrings for & and |

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -254,7 +254,7 @@ false
 (~)(x::BitInteger)             = not_int(x)
 
 """
-    &(x, y)
+    x & y
 
 Bitwise and. Implements [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic),
 returning [`missing`](@ref) if one operand is `missing` and the other is `true`.
@@ -277,7 +277,7 @@ false
 (&)(x::T, y::T) where {T<:BitInteger} = and_int(x, y)
 
 """
-    |(x, y)
+    x | y
 
 Bitwise or. Implements [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic),
 returning [`missing`](@ref) if one operand is `missing` and the other is `false`.


### PR DESCRIPTION
The header of the docstring for `&` and `|` suggest a call syntax that is invalid (either needs `()`s, or be infix). This is a trivial fix for that.

Issue noted here:

https://discourse.julialang.org/t/ampersand-operator-not-consistent-with-help/34266