### PR TITLE
Add NamedTuple pair constructor

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -518,6 +518,7 @@ export
     mergewith!,
     merge,
     mergewith,
+    namedtuple,
     pairs,
     reduce,
     setdiff!,

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -85,18 +85,17 @@ end
 NamedTuple{names, T}(itr) where {names, T <: Tuple} = NamedTuple{names, T}(T(itr))
 NamedTuple{names}(itr) where {names} = NamedTuple{names}(Tuple(itr))
 
-function NamedTuple(args::Pair{Symbol,<:Any}...)
+end # if Base
+
+function namedtuple(args::Pair{Symbol,<:Any}...)
     if @generated
         types = Tuple{(arg.types[2] for arg in args)...}
         names = Expr(:tuple, Any[ :(args[$i][1]) for i in eachindex(args) ]...)
         Expr(:new, :(NamedTuple{$names, $types}), Any[ :(args[$i][2]) for i in eachindex(args) ]...)
     else
-        names = Tuple(n for (n, v) in args)
-        NamedTuple{names}(Tuple(v for (n, v) in args))
+        (; args...)
     end
 end
-
-end # if Base
 
 length(t::NamedTuple) = nfields(t)
 iterate(t::NamedTuple, iter=1) = iter > nfields(t) ? nothing : (getfield(t, iter), iter + 1)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -85,6 +85,17 @@ end
 NamedTuple{names, T}(itr) where {names, T <: Tuple} = NamedTuple{names, T}(T(itr))
 NamedTuple{names}(itr) where {names} = NamedTuple{names}(Tuple(itr))
 
+function NamedTuple(args::Pair{Symbol,<:Any}...)
+    if @generated
+        types = Tuple{(arg.types[2] for arg in args)...}
+        names = Expr(:tuple, Any[ :(args[$i][1]) for i in eachindex(args) ]...)
+        Expr(:new, :(NamedTuple{$names, $types}), Any[ :(args[$i][2]) for i in eachindex(args) ]...)
+    else
+        names = Tuple(n for (n, v) in args)
+        NamedTuple{names}(Tuple(v for (n, v) in args))
+    end
+end
+
 end # if Base
 
 length(t::NamedTuple) = nfields(t)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -276,3 +276,7 @@ let nt0 = NamedTuple(), nt1 = (a=33,), nt2 = (a=0, b=:v)
     @test Base.setindex(nt1, "value", :a) == (a="value",)
     @test Base.setindex(nt1, "value", :a) isa NamedTuple{(:a,),<:Tuple{AbstractString}}
 end
+
+# Pair constructor
+@test NamedTuple(:a => 1, :b => 2.0) === (a=1, b=2.0)
+@test_throws MethodError NamedTuple("a" => 1, "b" => 2.0)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -278,5 +278,5 @@ let nt0 = NamedTuple(), nt1 = (a=33,), nt2 = (a=0, b=:v)
 end
 
 # Pair constructor
-@test NamedTuple(:a => 1, :b => 2.0) === (a=1, b=2.0)
-@test_throws MethodError NamedTuple("a" => 1, "b" => 2.0)
+@test namedtuple(:a => 1, :b => 2.0) === (a=1, b=2.0) === (; :a => 1, :b => 2.0)
+@test_throws MethodError namedtuple("a" => 1, "b" => 2.0)


### PR DESCRIPTION
Adds an alternative way to create a `NamedTuple`:
```julia
julia> NamedTuple(:a => 1, :b => 2.0)
(a = 1, b = 2.0)
```
It may be more sensible to call this `namedtuple` to mirror the `tuple` interface.