### PR TITLE
Eagerly return a tuple from zip of tuples

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -390,7 +390,12 @@ _zip_iterator_eltype(::Type{Tuple{}}) = HasEltype()
 
 reverse(z::Zip) = Zip(map(reverse, z.is))
 
-zip(tuples::NTuple{N,Any}...) where {N} = ntuple(i -> map(t -> t[i], tuples), N)
+# Not using `zip(tuples::NTuple{N,Any}...)` to avoid having unbound
+# type parameter.
+function zip(x::NTuple{N,Any}, xs::NTuple{N,Any}...) where {N}
+    tuples = (x, xs...)
+    return ntuple(i -> map(t -> t[i], tuples), N)
+end
 
 # filter
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -390,6 +390,8 @@ _zip_iterator_eltype(::Type{Tuple{}}) = HasEltype()
 
 reverse(z::Zip) = Zip(map(reverse, z.is))
 
+zip(tuples::NTuple{N,Any}...) where {N} = ntuple(i -> map(t -> t[i], tuples), N)
+
 # filter
 
 struct Filter{F,I}

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -480,3 +480,10 @@ end
 
 # tuple_type_tail on non-normalized vararg tuple
 @test Base.tuple_type_tail(Tuple{Vararg{T, 3}} where T<:Real) == Tuple{Vararg{T, 2}} where T<:Real
+
+@testset "zip" begin
+    @test zip((1, 2, 3), (4, 5, 6), (7, 8, 9), (10, 11, 12)) ==
+        ((1, 4, 7, 10), (2, 5, 8, 11), (3, 6, 9, 12))
+    tuples = ntuple(i -> ntuple(j -> Val((i, j)), 10), 5)
+    @test collect(@inferred(zip(tuples...))) == collect(zip(collect.(tuples)...))
+end


### PR DESCRIPTION
Can we have `zip(tuples...)` return a tuple?  I think this is compatible with some methods in `Iterators` that eagerly compute results. See #33235 for similar discussion on `Iterators.reverse(x::Tuple) :: Tuple`.