### PR TITLE
parser error for invalid `:` after imports

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1580,9 +1580,9 @@
                     (let ((ex (parse-comma-separated s (lambda (s)
                                                          (parse-import s word)))))
                       (if (eq? (peek-token s) ':)
-                          (error (string "unexpected \":\" in \"" word "\" syntax\n"
-                                         "Last import needs to be a separate \"" word
-                                         "\" statement"))
+                          (error (string "\":\" in \"" word "\" syntax can only be used "
+                                         "when importing a single module. "
+                                         "Split imports into multiple lines."))
                           ex)))))
     (if from
         `(,word (|:| ,first ,@rest))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1578,11 +1578,12 @@
          (rest  (if done
                     '()
                     (let ((ex (parse-comma-separated s (lambda (s)
-                           (parse-import s word)))))
+                                                         (parse-import s word)))))
                       (if (eq? (peek-token s) ':)
-                        (error (string "unexpected \":\" in \"" word "\" syntax"
-                                 "\nLast import needs to be a separate \"" word "\" statement"))
-                        ex)))))
+                          (error (string "unexpected \":\" in \"" word "\" syntax\n"
+                                         "Last import needs to be a separate \"" word
+                                         "\" statement"))
+                          ex)))))
     (if from
         `(,word (|:| ,first ,@rest))
         (list* word first rest))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1577,8 +1577,12 @@
                       (else #t)))
          (rest  (if done
                     '()
-                    (parse-comma-separated s (lambda (s)
-                                               (parse-import s word))))))
+                    (let ((ex (parse-comma-separated s (lambda (s)
+                           (parse-import s word)))))
+                      (if (eq? (peek-token s) ':)
+                        (error (string "unexpected \":\" in \"" word "\" syntax"
+                                 "\nLast import needs to be a separate \"" word "\" statement"))
+                        ex)))))
     (if from
         `(,word (|:| ,first ,@rest))
         (list* word first rest))))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -383,8 +383,8 @@ end
 
         err = Expr(
             :error,
-            "unexpected \":\" in \"$imprt\" syntax\n" *
-            "Last import needs to be a separate \"$imprt\" statement"
+            "\":\" in \"$imprt\" syntax can only be used when importing a single module. " *
+            "Split imports into multiple lines."
         )
         ex = Meta.parse("$imprt A, B: x, y", raise=false)
         @test ex == err

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -375,3 +375,21 @@ end
     @test :(@foo{bar}[baz]) == :((@foo{bar})[baz])
     @test :(@foo{bar} + baz) == :((@foo{bar}) + baz)
 end
+
+@testset "issue #34650" begin
+    for imprt in [:using, :import]
+        @test Meta.isexpr(Meta.parse("$imprt A, B"), imprt)
+        @test Meta.isexpr(Meta.parse("$imprt A: x, y, z"), imprt)
+
+        err = Expr(
+            :error,
+            "unexpected \":\" in \"$imprt\" syntax\n" *
+            "Last import needs to be a separate \"$imprt\" statement"
+        )
+        ex = Meta.parse("$imprt A, B: x, y", raise=false)
+        @test ex == err
+
+        ex = Meta.parse("$imprt A: x, B: y", raise=false)
+        @test ex == err
+    end
+end


### PR DESCRIPTION
I wasn't quite sure, whether this should throw during parsing or lowering. I chose to have it throw during parsing, because I can't really see a situation, where the current parsing of expressions like `using A, B: x` as `(:)((using A, B;), x)` would be useful and we might eventually want to support this syntax and make this behave like users would expect it to.

Fix #34650