### PR TITLE
improve error message for using **

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -234,7 +234,7 @@
 
 (define (read-operator port c)
   (if (and (eqv? c #\*) (eqv? (peek-char port) #\*))
-      (error "If you were trying to raise a number to a power, you should use \"^\" instead of \"**\".\n If you used \"**\" in some other context, you did something wrong. This is invalid syntax."))
+      (error "For exponentiation, use \"^\" instead of \"**\".\n For splatting, use \"x...\" instead of \"**x\"."))
   (if (or (eof-object? (peek-char port)) (not (op-or-sufchar? (peek-char port))))
       (symbol (string c)) ; 1-char operator
       (let ((str (let loop ((str (string c))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -234,7 +234,7 @@
 
 (define (read-operator port c)
   (if (and (eqv? c #\*) (eqv? (peek-char port) #\*))
-      (error "For exponentiation, use \"^\" instead of \"**\".\n For splatting, use \"x...\" instead of \"**x\"."))
+      (error "use \"x^y\" instead of \"x**y\" for exponentiation, and \"x...\" instead of \"**x\ for splatting."))
   (if (or (eof-object? (peek-char port)) (not (op-or-sufchar? (peek-char port))))
       (symbol (string c)) ; 1-char operator
       (let ((str (let loop ((str (string c))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -234,7 +234,7 @@
 
 (define (read-operator port c)
   (if (and (eqv? c #\*) (eqv? (peek-char port) #\*))
-      (error "use \"x^y\" instead of \"x**y\" for exponentiation, and \"x...\" instead of \"**x\ for splatting."))
+      (error "use \"x^y\" instead of \"x**y\" for exponentiation, and \"x...\" instead of \"**x\" for splatting."))
   (if (or (eof-object? (peek-char port)) (not (op-or-sufchar? (peek-char port))))
       (symbol (string c)) ; 1-char operator
       (let ((str (let loop ((str (string c))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -234,7 +234,7 @@
 
 (define (read-operator port c)
   (if (and (eqv? c #\*) (eqv? (peek-char port) #\*))
-      (error "use \"^\" instead of \"**\""))
+      (error "If you were trying to raise a number to a power, you should use \"^\" instead of \"**\".\n If you used \"**\" in some other context, you did something wrong. This is invalid syntax."))
   (if (or (eof-object? (peek-char port)) (not (op-or-sufchar? (peek-char port))))
       (symbol (string c)) ; 1-char operator
       (let ((str (let loop ((str (string c))


### PR DESCRIPTION
based on https://discourse.julialang.org/t/syntax-use-instead-of-and-syntax-is-not-a-unary-operator/34258/5, it seems that while well intentioned, this error message might be causing more confusion than it fixes. I took a stab at addressing it, but I think possibly the better change would be to parse `**` as an operator, and then we could define specific methods that threw better error messages. Specifically, `a**b` should have the error, but if we see `**a`, we should instead be telling people to use splatting, as that is more likely what they were trying to do.