### PR TITLE
fix _spawn_primitive to report error correctly

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -84,7 +84,7 @@ const SpawnIOs = Vector{Any} # convenience name for readability
         for io in stdio]
     handle = Libc.malloc(_sizeof_uv_process)
     disassociate_julia_struct(handle) # ensure that data field is set to C_NULL
-    error = ccall(:jl_spawn, Int32,
+    err = ccall(:jl_spawn, Int32,
               (Cstring, Ptr{Cstring}, Ptr{Cvoid}, Ptr{Cvoid},
                Ptr{Tuple{Cint, UInt}}, Int,
                UInt32, Ptr{Cstring}, Cstring, Ptr{Cvoid}),
@@ -94,9 +94,9 @@ const SpawnIOs = Vector{Any} # convenience name for readability
         cmd.env === nothing ? C_NULL : cmd.env,
         isempty(cmd.dir) ? C_NULL : cmd.dir,
         uv_jl_return_spawn::Ptr{Cvoid})
-    if error != 0
+    if err != 0
         ccall(:jl_forceclose_uv, Cvoid, (Ptr{Cvoid},), handle) # will call free on handle eventually
-        throw(_UVError("could not spawn " * repr(cmd), error))
+        throw(_UVError("could not spawn " * repr(cmd), err))
     end
     pp = Process(cmd, handle)
     associate_julia_struct(handle, pp)


### PR DESCRIPTION
Method `_spawn_primitive` in `process.jl` seems to be defining a local valiable that shadows the `error` method that it tries to use.
This renames the local variable to fix that.

Below are a few lines to simulate the condition.

Before:

```
julia> Base.rawhandle(s::String) = s

julia> Base._spawn_primitive("/tmp/xyx", `ls`, Any["abc"])
ERROR: UndefVarError: error not defined
Stacktrace:
 [1] _spawn_primitive(::String, ::Cmd, ::Array{Any,1}) at ./process.jl:79
 [2] top-level scope at REPL[2]:1
```

With this fix:

```
julia> Base.rawhandle(s::String) = s

julia> Base._spawn_primitive("/tmp/xyx", `ls`, Any["abc"])
ERROR: invalid spawn handle abc from abc
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] _spawn_primitive(::String, ::Cmd, ::Array{Any,1}) at ./process.jl:79
 [3] top-level scope at REPL[4]:1
```