### PR TITLE
Fix pretty printing of timings when building Julia with no stdlibs

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -49,7 +49,7 @@ let
             :Statistics,
         ]
 
-    maxlen = maximum(textwidth.(string.(stdlibs)))
+    maxlen = reduce(max, textwidth.(string.(stdlibs)); init=0)
 
     print_time = (mod, t) -> (print(rpad(string(mod) * "  ", maxlen + 3, "─")); Base.time_print(t * 10^9); println())
     print_time(Base, (Base.end_base_include - Base.start_base_include) * 10^(-9))


### PR DESCRIPTION
PackageCompiler can filter out stdlibs so it can be empty, and this line fails when reducing over empty collection.