### PR TITLE
Explain boundry cases for set_num_threads

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -108,7 +108,7 @@ openblas_get_config() = strip(unsafe_string(ccall((@blasfunc(openblas_get_config
     set_num_threads(n)
 
 Set the number of threads the BLAS library should use.
-If n <= 0 then will make no change.
+If `n <= 0` then the number of threads will not be changed.
 If n > number of CPU threads, then caps at the number of CPU threads.
 """
 function set_num_threads(n::Integer)

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -109,7 +109,7 @@ openblas_get_config() = strip(unsafe_string(ccall((@blasfunc(openblas_get_config
 
 Set the number of threads the BLAS library should use.
 If `n <= 0` then the number of threads will not be changed.
-If `n`  is greater than number of CPU threads, then the nuumber of BLAS threads wiol be set to the number of CPU threads.
+If `n`  is greater than number of CPU threads, then the number of BLAS threads will be set to the number of CPU threads.
 """
 function set_num_threads(n::Integer)
     blas = vendor()

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -109,7 +109,7 @@ openblas_get_config() = strip(unsafe_string(ccall((@blasfunc(openblas_get_config
 
 Set the number of threads the BLAS library should use.
 If `n <= 0` then the number of threads will not be changed.
-If n > number of CPU threads, then caps at the number of CPU threads.
+If `n`  is greater than number of CPU threads, then the nuumber of BLAS threads wiol be set to the number of CPU threads.
 """
 function set_num_threads(n::Integer)
     blas = vendor()

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -108,6 +108,8 @@ openblas_get_config() = strip(unsafe_string(ccall((@blasfunc(openblas_get_config
     set_num_threads(n)
 
 Set the number of threads the BLAS library should use.
+If n <= 0 then will make no change.
+If n > number of CPU threads, then caps at the number of CPU threads.
 """
 function set_num_threads(n::Integer)
     blas = vendor()


### PR DESCRIPTION
I wanted to know how to set number of BLAS threads to "All of them"
Looked at OpenBLAS source.
Answer is: `set_num_threads(typemax(Int))`

https://github.com/xianyi/OpenBLAS/blob/a387a23518b2794b7a9bdebdb7ca35943c50a912/driver/others/blas_server.c#L849-L917

