### PR TITLE
Views with reshaped range indices are linear and strided

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -52,7 +52,7 @@ StridedFastContiguousSubArray{T,N,A<:DenseArray} = FastContiguousSubArray{T,N,A}
 StridedReinterpretArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray}} = ReinterpretArray{T,N,S,A} where S
 StridedReshapedArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray,StridedReinterpretArray}} = ReshapedArray{T,N,A}
 StridedSubArray{T,N,A<:Union{DenseArray,StridedReshapedArray,StridedReinterpretArray},
-    I<:Tuple{Vararg{Union{RangeIndex, AbstractCartesianIndex}}}} = SubArray{T,N,A,I}
+    I<:Tuple{Vararg{Union{RangeIndex, ReshapedUnitRange, AbstractCartesianIndex}}}} = SubArray{T,N,A,I}
 StridedArray{T,N} = Union{DenseArray{T,N}, StridedSubArray{T,N}, StridedReshapedArray{T,N}, StridedReinterpretArray{T,N}}
 StridedVector{T} = Union{DenseArray{T,1}, StridedSubArray{T,1}, StridedReshapedArray{T,1}, StridedReinterpretArray{T,1}}
 StridedMatrix{T} = Union{DenseArray{T,2}, StridedSubArray{T,2}, StridedReshapedArray{T,2}, StridedReinterpretArray{T,2}}

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -288,6 +288,6 @@ compute_stride1(s, inds, I::Tuple{ReshapedRange, Vararg{Any}}) = s*step(I[1].par
 compute_offset1(parent::AbstractVector, stride1::Integer, I::Tuple{ReshapedRange}) =
     (@_inline_meta; first(I[1]) - first(axes1(I[1]))*stride1)
 substrides(strds::NTuple{N,Int}, I::Tuple{ReshapedUnitRange, Vararg{Any}}) where N =
-    (size_to_strides(strds, size(I[1]))..., substrides(tail(strds), tail(I))...)
-unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{Union{RangeIndex,ReshapedUnitRange,CartesianIndex}}}}) where {T,N,P} =
+    (size_to_strides(strds[1], size(I[1])...)..., substrides(tail(strds), tail(I))...)
+unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{Union{RangeIndex,ReshapedUnitRange}}}}) where {T,N,P} =
     unsafe_convert(Ptr{T}, V.parent) + (first_index(V)-1)*sizeof(T)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -279,3 +279,15 @@ setindex!(A::ReshapedRange, val, index::ReshapedIndex) = _rs_setindex!_err()
 @noinline _rs_setindex!_err() = error("indexed assignment fails for a reshaped range; consider calling collect")
 
 unsafe_convert(::Type{Ptr{T}}, a::ReshapedArray{T}) where {T} = unsafe_convert(Ptr{T}, parent(a))
+
+# Add a few handy specializations to further speed up views of reshaped ranges
+const ReshapedUnitRange{T,N,A<:AbstractUnitRange} = ReshapedArray{T,N,A,Tuple{}}
+viewindexing(I::Tuple{Slice, ReshapedUnitRange, Vararg{ScalarIndex}}) = IndexLinear()
+viewindexing(I::Tuple{ReshapedRange, Vararg{ScalarIndex}}) = IndexLinear()
+compute_stride1(s, inds, I::Tuple{ReshapedRange, Vararg{Any}}) = s*step(I[1].parent)
+compute_offset1(parent::AbstractVector, stride1::Integer, I::Tuple{ReshapedRange}) =
+    (@_inline_meta; first(I[1]) - first(axes1(I[1]))*stride1)
+substrides(strds::NTuple{N,Int}, I::Tuple{ReshapedUnitRange, Vararg{Any}}) where N =
+    (size_to_strides(strds, size(I[1]))..., substrides(tail(strds), tail(I))...)
+unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{Union{RangeIndex,ReshapedUnitRange,CartesianIndex}}}}) where {T,N,P} =
+    unsafe_convert(Ptr{T}, V.parent) + (first_index(V)-1)*sizeof(T)

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -96,43 +96,24 @@ single_stride_dim(@nospecialize(A)) = single_stride_dim(copy_to_array(A))
 function test_cartesian(@nospecialize(A), @nospecialize(B))
     isgood = true
     for (IA, IB) in zip(CartesianIndices(A), CartesianIndices(B))
-        if A[IA] != B[IB]
-            @show IA IB A[IA] B[IB]
-            isgood = false
-            break
-        end
+        @test A[IA] == B[IB]
         if A isa StridedArray
             v1 = GC.@preserve A unsafe_load(pointer(A.parent, sum((0,(strides(A) .* (IA.I .- 1))...))+Base.first_index(A)))
-            isgood = (v1 == B[IB])
+            @test v1 == B[IB]
         end
-
-    end
-    if !isgood
-        @show A
-        @show B
-        error("Mismatch")
     end
 end
 
 function test_linear(@nospecialize(A), @nospecialize(B))
-    length(A) == length(B) || error("length mismatch")
+    @test length(A) == length(B)
     isgood = true
     for (iA, iB) in zip(1:length(A), 1:length(B))
-        if A[iA] != B[iB]
-            isgood = false
-            break
-        end
+        @test A[iA] == B[iB]
         if A isa StridedArray
             v1 = GC.@preserve A unsafe_load(pointer(A, iA))
             v2 = Ref(A, iA)[]
-            isgood = (v1 == v2 == B[iB])
+            @test v1 == v2 == B[iB]
         end
-    end
-    if !isgood
-        @show A
-        @show A.indices
-        @show B
-        error("Mismatch")
     end
 end
 
@@ -145,15 +126,7 @@ function _test_mixed(@nospecialize(A), @nospecialize(B))
     n = size(A, 2)
     isgood = true
     for J in CartesianIndices(size(A)[2:end]), i in 1:m
-        if A[i,J] != B[i,J]
-            isgood = false
-            break
-        end
-    end
-    if !isgood
-        @show A
-        @show B
-        error("Mismatch")
+        @test A[i,J] == B[i,J]
     end
     nothing
 end
@@ -231,15 +204,7 @@ function runsubarraytests(@nospecialize(A), I...)
             Cdim += 1
         end
     end
-    local S
-    try
-        S = view(A, I...)
-    catch
-        @show typeof(A)
-        @show A.indices
-        @show I
-        rethrow()
-    end
+    S = view(A, I...)
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
@@ -313,188 +278,197 @@ oindex = (:, 6, 3:7, reshape([12]), [8,4,6,12,5,7], [3:7 1:5 2:6 4:8 5:9], resha
 _ndims(::AbstractArray{T,N}) where {T,N} = N
 _ndims(x) = 1
 
-@time if testfull
+if testfull
     let B = copy(reshape(1:13^3, 13, 13, 13))
-        for o3 in oindex, o2 in oindex, o1 in oindex
+        @testset "full tests: ($o1,$o2,$o3)" for o3 in oindex, o2 in oindex, o1 in oindex
             viewB = view(B, o1, o2, o3)
             runviews(viewB, index5, index25, index125)
         end
     end
 end
 
-@time if true # !testfull
-    let B = copy(reshape(1:13^3, 13, 13, 13))
-        for oind in ((:,:,:),
-                     (:,:,6),
-                     (:,6,:),
-                     (6,:,:),
-                     (:,3:7,:),
-                     (3:7,:,:),
-                     (3:7,6,:),
-                     (3:7,6,0x6),
-                     (6,UInt(3):UInt(7),3:7),
-                     (13:-2:1,:,:),
-                     ([8,4,6,12,5,7],:,3:7),
-                     (6,CartesianIndex.(6,[8,4,6,12,5,7])),
-                     (CartesianIndex(13,6),[8,4,6,12,5,7]),
-                     (1,:,view(1:13,[9,12,4,13,1])),
-                     (2,:,reshape(2:11,2,5)),
-                     (2,:,reshape(2:2:13,2,3)),
-                     (3,reshape(2:11,5,2),4),
-                     (3,reshape(2:2:13,3,2),4),
-                     (view(1:13,[9,12,4,13,1]),2:6,4),
-                     ([1:5 2:6 3:7 4:8 5:9], :, 3))
-            runsubarraytests(B, oind...)
-            viewB = view(B, oind...)
-            runviews(viewB, index5, index25, index125)
-        end
+let B = copy(reshape(1:13^3, 13, 13, 13))
+    @testset "spot checks: $oind" for oind in ((:,:,:),
+                 (:,:,6),
+                 (:,6,:),
+                 (6,:,:),
+                 (:,3:7,:),
+                 (3:7,:,:),
+                 (3:7,6,:),
+                 (3:7,6,0x6),
+                 (6,UInt(3):UInt(7),3:7),
+                 (13:-2:1,:,:),
+                 ([8,4,6,12,5,7],:,3:7),
+                 (6,CartesianIndex.(6,[8,4,6,12,5,7])),
+                 (CartesianIndex(13,6),[8,4,6,12,5,7]),
+                 (1,:,view(1:13,[9,12,4,13,1])),
+                 (2,:,reshape(2:11,2,5)),
+                 (2,:,reshape(2:2:13,2,3)),
+                 (3,reshape(2:11,5,2),4),
+                 (3,reshape(2:2:13,3,2),4),
+                 (view(1:13,[9,12,4,13,1]),2:6,4),
+                 ([1:5 2:6 3:7 4:8 5:9], :, 3))
+        runsubarraytests(B, oind...)
+        viewB = view(B, oind...)
+        runviews(viewB, index5, index25, index125)
     end
 end
 
-# issue #11289
-x11289 = randn(5,5)
-@test isempty(view(x11289, Int[], :))
-@test isempty(view(x11289, [2,5], Int[]))
-@test isempty(view(x11289, Int[], 2))
-
 ####### "Classical" tests #######
 
-# Tests where non-trailing dimensions are preserved
-A = copy(reshape(1:120, 3, 5, 8))
-sA = view(A, 2:2, 1:5, :)
-@test @inferred(strides(sA)) == (1, 3, 15)
-@test parent(sA) == A
-@test parentindices(sA) == (2:2, 1:5, Base.Slice(1:8))
-@test size(sA) == (1, 5, 8)
-@test axes(sA) === (Base.OneTo(1), Base.OneTo(5), Base.OneTo(8))
-@test sA[1, 2, 1:8][:] == [5:15:120;]
-sA[2:5:end] .= -1
-@test all(sA[2:5:end] .== -1)
-@test all(A[5:15:120] .== -1)
-@test @inferred(strides(sA)) == (1,3,15)
-@test stride(sA,3) == 15
-@test stride(sA,4) == 120
-test_bounds(sA)
-sA = view(A, 1:3, 1:5, 5)
-sA[1:3,1:5] .= -2
-@test all(A[:,:,5] .== -2)
-fill!(sA, -3)
-@test all(A[:,:,5] .== -3)
-sA[:] .= 4
-@test all(A[:,:,5] .== 4)
-@test @inferred(strides(sA)) == (1,3)
-test_bounds(sA)
-sA = view(A, 1:3, 3:3, 2:5)
-@test size(sA) == (3,1,4)
-@test axes(sA) === (Base.OneTo(3), Base.OneTo(1), Base.OneTo(4))
-@test sA == A[1:3,3:3,2:5]
-@test sA[:] == A[1:3,3,2:5][:]
-test_bounds(sA)
-sA = view(A, 1:2:3, 1:3:5, 1:2:8)
-@test @inferred(strides(sA)) == (2,9,30)
-@test sA[:] == A[1:2:3, 1:3:5, 1:2:8][:]
-# issue #8807
-@test view(view([1:5;], 1:5), 1:5) == [1:5;]
-# Test with mixed types
-@test sA[:, Int16[1,2], big(2)] == [31 40; 33 42]
-test_bounds(sA)
-sA = view(A, 1:1, 1:5, [1 3; 4 2])
-@test ndims(sA) == 4
-@test axes(sA) === (Base.OneTo(1), Base.OneTo(5), Base.OneTo(2), Base.OneTo(2))
-sA = view(A, 1:2, 3, [1 3; 4 2])
-@test ndims(sA) == 3
-@test axes(sA) === (Base.OneTo(2), Base.OneTo(2), Base.OneTo(2))
+@testset "non-trailing dimensions" begin
+    A = copy(reshape(1:120, 3, 5, 8))
+    sA = view(A, 2:2, 1:5, :)
+    @test @inferred(strides(sA)) == (1, 3, 15)
+    @test parent(sA) == A
+    @test parentindices(sA) == (2:2, 1:5, Base.Slice(1:8))
+    @test size(sA) == (1, 5, 8)
+    @test axes(sA) === (Base.OneTo(1), Base.OneTo(5), Base.OneTo(8))
+    @test sA[1, 2, 1:8][:] == [5:15:120;]
+    sA[2:5:end] .= -1
+    @test all(sA[2:5:end] .== -1)
+    @test all(A[5:15:120] .== -1)
+    @test @inferred(strides(sA)) == (1,3,15)
+    @test stride(sA,3) == 15
+    @test stride(sA,4) == 120
+    test_bounds(sA)
+    sA = view(A, 1:3, 1:5, 5)
+    sA[1:3,1:5] .= -2
+    @test all(A[:,:,5] .== -2)
+    fill!(sA, -3)
+    @test all(A[:,:,5] .== -3)
+    sA[:] .= 4
+    @test all(A[:,:,5] .== 4)
+    @test @inferred(strides(sA)) == (1,3)
+    test_bounds(sA)
+    sA = view(A, 1:3, 3:3, 2:5)
+    @test size(sA) == (3,1,4)
+    @test axes(sA) === (Base.OneTo(3), Base.OneTo(1), Base.OneTo(4))
+    @test sA == A[1:3,3:3,2:5]
+    @test sA[:] == A[1:3,3,2:5][:]
+    test_bounds(sA)
+    sA = view(A, 1:2:3, 1:3:5, 1:2:8)
+    @test @inferred(strides(sA)) == (2,9,30)
+    @test sA[:] == A[1:2:3, 1:3:5, 1:2:8][:]
+    # issue #8807
+    @test view(view([1:5;], 1:5), 1:5) == [1:5;]
+    # Test with mixed types
+    @test sA[:, Int16[1,2], big(2)] == [31 40; 33 42]
+    test_bounds(sA)
+    sA = view(A, 1:1, 1:5, [1 3; 4 2])
+    @test ndims(sA) == 4
+    @test axes(sA) === (Base.OneTo(1), Base.OneTo(5), Base.OneTo(2), Base.OneTo(2))
+    sA = view(A, 1:2, 3, [1 3; 4 2])
+    @test ndims(sA) == 3
+    @test axes(sA) === (Base.OneTo(2), Base.OneTo(2), Base.OneTo(2))
+end
 
-# logical indexing #4763
-A = view([1:10;], 5:8)
-@test A[A.<7] == view(A, A.<7) == [5, 6]
-@test Base.unsafe_getindex(A, A.<7) == [5, 6]
-B = reshape(1:16, 4, 4)
-sB = view(B, 2:3, 2:3)
-@test sB[sB.>8] == view(sB, sB.>8) == [10, 11]
-@test Base.unsafe_getindex(sB, sB.>8) == [10, 11]
+@testset "logical indexing #4763" begin
+    A = view([1:10;], 5:8)
+    @test A[A.<7] == view(A, A.<7) == [5, 6]
+    @test Base.unsafe_getindex(A, A.<7) == [5, 6]
+    B = reshape(1:16, 4, 4)
+    sB = view(B, 2:3, 2:3)
+    @test sB[sB.>8] == view(sB, sB.>8) == [10, 11]
+    @test Base.unsafe_getindex(sB, sB.>8) == [10, 11]
+end
 
-# Tests where dimensions are dropped
-A = copy(reshape(1:120, 3, 5, 8))
-sA = view(A, 2, :, 1:8)
-@test parent(sA) == A
-@test parentindices(sA) == (2, Base.Slice(1:5), 1:8)
-@test size(sA) == (5, 8)
-@test axes(sA) === (Base.OneTo(5), Base.OneTo(8))
-@test @inferred(strides(sA)) == (3,15)
-@test sA[2, 1:8][:] == [5:15:120;]
-@test sA[:,1] == [2:3:14;]
-@test sA[2:5:end] == [5:15:110;]
-sA[2:5:end] .= -1
-@test all(sA[2:5:end] .== -1)
-@test all(A[5:15:120] .== -1)
-test_bounds(sA)
-sA = view(A, 1:3, 1:5, 5)
-@test size(sA) == (3,5)
-@test axes(sA) === (Base.OneTo(3),Base.OneTo(5))
-@test @inferred(strides(sA)) == (1,3)
-test_bounds(sA)
-sA = view(A, 1:2:3, 3, 1:2:8)
-@test size(sA) == (2,4)
-@test axes(sA) === (Base.OneTo(2), Base.OneTo(4))
-@test @inferred(strides(sA)) == (2,30)
-@test sA[:] == A[sA.indices...][:]
-test_bounds(sA)
+@testset "with dropped dimensions" begin
+    A = copy(reshape(1:120, 3, 5, 8))
+    sA = view(A, 2, :, 1:8)
+    @test parent(sA) == A
+    @test parentindices(sA) == (2, Base.Slice(1:5), 1:8)
+    @test size(sA) == (5, 8)
+    @test axes(sA) === (Base.OneTo(5), Base.OneTo(8))
+    @test @inferred(strides(sA)) == (3,15)
+    @test sA[2, 1:8][:] == [5:15:120;]
+    @test sA[:,1] == [2:3:14;]
+    @test sA[2:5:end] == [5:15:110;]
+    sA[2:5:end] .= -1
+    @test all(sA[2:5:end] .== -1)
+    @test all(A[5:15:120] .== -1)
+    test_bounds(sA)
+    sA = view(A, 1:3, 1:5, 5)
+    @test size(sA) == (3,5)
+    @test axes(sA) === (Base.OneTo(3),Base.OneTo(5))
+    @test @inferred(strides(sA)) == (1,3)
+    test_bounds(sA)
+    sA = view(A, 1:2:3, 3, 1:2:8)
+    @test size(sA) == (2,4)
+    @test axes(sA) === (Base.OneTo(2), Base.OneTo(4))
+    @test @inferred(strides(sA)) == (2,30)
+    @test sA[:] == A[sA.indices...][:]
+    test_bounds(sA)
+end
 
-let a = [5:8;]
+@testset "parent" begin
+    a = [5:8;]
     @test parent(a) == a
     @test parentindices(a) == (1:4,)
 end
 
-# issue #6218 - logical indexing
-A = rand(2, 2, 3)
-msk = fill(true, 2, 2)
-msk[2,1] = false
-sA = view(A, :, :, 1)
-sA[msk] .= 1.0
-@test sA[msk] == fill(1, count(msk))
+@testset "issue #11289" begin
+    x11289 = randn(5,5)
+    @test isempty(view(x11289, Int[], :))
+    @test isempty(view(x11289, [2,5], Int[]))
+    @test isempty(view(x11289, Int[], 2))
+end
 
-# bounds checking upon construction; see #4044, #10296
-@test_throws BoundsError view(1:10, 8:11)
-A = reshape(1:20, 5, 4)
-sA = view(A, 1:2, 1:3)
-@test_throws BoundsError view(sA, 1:3, 1:3)
-@test_throws BoundsError view(sA, 1:2, 1:4)
-view(sA, 1:2, 1:2)
-@test_throws BoundsError view(A, 17:23)
-view(A, 17:20)
 
-# Linear indexing by one multidimensional array:
-A = reshape(1:120, 3, 5, 8)
-sA = view(A, :, :, :)
-@test sA[[72 17; 107 117]] == [72 17; 107 117]
-@test sA[[99 38 119 14 76 81]] == [99 38 119 14 76 81]
-@test sA[[fill(1, (2, 2, 2)); fill(2, (2, 2, 2))]] == [fill(1, (2, 2, 2)); fill(2, (2, 2, 2))]
-sA = view(A, 1:2, 2:3, 3:4)
-@test sA[(1:8)'] == [34 35 37 38 49 50 52 53]
-@test sA[[1 2 4 4; 6 1 1 4]] == [34 35 38 38; 50 34 34 38]
+@testset "issue #6218 - logical indexing" begin
+    A = rand(2, 2, 3)
+    msk = fill(true, 2, 2)
+    msk[2,1] = false
+    sA = view(A, :, :, 1)
+    sA[msk] .= 1.0
+    @test sA[msk] == fill(1, count(msk))
+end
 
-# issue #11871
-let a = fill(1., (2,2)),
+@testset "bounds checking upon construction; see #4044, #10296" begin
+    @test_throws BoundsError view(1:10, 8:11)
+    A = reshape(1:20, 5, 4)
+    sA = view(A, 1:2, 1:3)
+    @test_throws BoundsError view(sA, 1:3, 1:3)
+    @test_throws BoundsError view(sA, 1:2, 1:4)
+    view(sA, 1:2, 1:2)
+    @test_throws BoundsError view(A, 17:23)
+    view(A, 17:20)
+end
+
+@testset "Linear indexing by one multidimensional array" begin
+    A = reshape(1:120, 3, 5, 8)
+    sA = view(A, :, :, :)
+    @test sA[[72 17; 107 117]] == [72 17; 107 117]
+    @test sA[[99 38 119 14 76 81]] == [99 38 119 14 76 81]
+    @test sA[[fill(1, (2, 2, 2)); fill(2, (2, 2, 2))]] == [fill(1, (2, 2, 2)); fill(2, (2, 2, 2))]
+    sA = view(A, 1:2, 2:3, 3:4)
+    @test sA[(1:8)'] == [34 35 37 38 49 50 52 53]
+    @test sA[[1 2 4 4; 6 1 1 4]] == [34 35 38 38; 50 34 34 38]
+end
+
+@testset "issue #11871" begin
+    a = fill(1., (2,2))
     b = view(a, 1:2, 1:2)
     b[2] = 2
     @test b[2] === 2.0
 end
 
-# issue #15138
-let a = [1,2,3],
+@testset "issue #15138" begin
+    a = [1,2,3]
     b = view(a, UInt(1):UInt(2))
     @test b == view(a, UInt(1):UInt(2)) == view(view(a, :), UInt(1):UInt(2)) == [1,2]
 end
 
-let A = reshape(1:4, 2, 2),
+@testset "unsigned index" begin
+    A = reshape(1:4, 2, 2)
     B = view(A, :, :)
     @test parent(B) === A
     @test parent(view(B, 0x1, :)) === parent(view(B, 0x1, :)) === A
 end
 
-# issue #15168
-let A = rand(10), sA = view(copy(A), :)
+@testset "issue #15168" begin
+    A = rand(10)
+    sA = view(copy(A), :)
     @test sA[Int16(1)] === sA[Int32(1)] === sA[Int64(1)] === A[1]
     permute!(sA, Vector{Int16}(1:10))
     @test A == sA
@@ -504,90 +478,88 @@ end
 @test Array(view(view(reshape(1:13^3, 13, 13, 13), 3:7, 6:6, :), 1:2:5, :, 1:2:5)) ==
     cat([68,70,72],[406,408,410],[744,746,748]; dims=3)
 
-# tests @view (and replace_ref_begin_end!)
+@testset "@view (and replace_ref_begin_end!)" begin
+    @test_throws ArgumentError(
+        "Invalid use of @view macro: argument must be a reference expression A[...]."
+    ) var"@view"(LineNumberNode(@__LINE__), @__MODULE__, 1)
 
-@test_throws ArgumentError(
-    "Invalid use of @view macro: argument must be a reference expression A[...]."
-) var"@view"(LineNumberNode(@__LINE__), @__MODULE__, 1)
+    X = reshape(1:24,2,3,4)
+    Y = 4:-1:1
 
-X = reshape(1:24,2,3,4)
-Y = 4:-1:1
+    @test isa(@view(X[1:3]), SubArray)
 
-@test isa(@view(X[1:3]), SubArray)
+    @test X[begin:end] == @.(@view X[begin:end]) # test compatibility of @. and @view
+    @test X[begin:end-3] == @view X[begin:end-3]
+    @test X[1:end,2,begin+1] == @view X[1:end,2,begin+1]
+    @test X[begin,1:end-2,1] == @view X[begin,1:end-2,1]
+    @test X[begin,begin+1,begin:end-2] == @view X[begin,begin+1,begin:end-2]
+    @test X[begin,2,Y[2:end]] == @view X[begin,2,Y[2:end]]
+    @test X[begin:end,2,Y[begin+1:end]] == @view X[begin:end,2,Y[begin+1:end]]
 
-@test X[begin:end] == @.(@view X[begin:end]) # test compatibility of @. and @view
-@test X[begin:end-3] == @view X[begin:end-3]
-@test X[1:end,2,begin+1] == @view X[1:end,2,begin+1]
-@test X[begin,1:end-2,1] == @view X[begin,1:end-2,1]
-@test X[begin,begin+1,begin:end-2] == @view X[begin,begin+1,begin:end-2]
-@test X[begin,2,Y[2:end]] == @view X[begin,2,Y[2:end]]
-@test X[begin:end,2,Y[begin+1:end]] == @view X[begin:end,2,Y[begin+1:end]]
+    u = (1,2:3)
+    @test X[u...,begin+1:end] == @view X[u...,begin+1:end]
+    @test X[(1,)...,(2,)...,2:end] == @view X[(1,)...,(2,)...,2:end]
 
-u = (1,2:3)
-@test X[u...,begin+1:end] == @view X[u...,begin+1:end]
-@test X[(1,)...,(2,)...,2:end] == @view X[(1,)...,(2,)...,2:end]
+    # test macro hygiene
+    let size=(x,y)-> error("should not happen"), Base=nothing
+        @test X[1:end,2,2] == @view X[1:end,2,2]
+    end
 
-# test macro hygiene
-let size=(x,y)-> error("should not happen"), Base=nothing
-    @test X[1:end,2,2] == @view X[1:end,2,2]
+    # test that side effects occur only once
+    let foo = [X]
+        @test X[2:end-1] == @view (push!(foo,X)[1])[2:end-1]
+        @test foo == [X, X]
+    end
+
+    # test @views macro
+    @views let f!(x) = x[begin:end-1] .+= x[begin+1:end].^2
+        x = [1,2,3,4]
+        f!(x)
+        @test x == [5,11,19,4]
+        @test x[1:3] isa SubArray
+        @test x[2] === 11
+        @test Dict((1:3) => 4)[1:3] === 4
+        x[1:2] .= 0
+        @test x == [0,0,19,4]
+        x[1:2] .= 5:6
+        @test x == [5,6,19,4]
+        f!(x[3:end])
+        @test x == [5,6,35,4]
+        x[Y[2:3]] .= 7:8
+        @test x == [5,8,7,4]
+        x[(3,)..., ()...] += 3
+        @test x == [5,8,10,4]
+        i = Int[]
+        # test that lhs expressions in update operations are evaluated only once:
+        x[push!(i,4)[1]] += 5
+        @test x == [5,8,10,9] && i == [4]
+        x[push!(i,3)[end]] += 2
+        @test x == [5,8,12,9] && i == [4,3]
+        @. x[3:end] = 0       # make sure @. works with end expressions in @views
+        @test x == [5,8,0,0]
+    end
+    @views @test isa(X[1:3], SubArray)
+    @test X[begin:end] == @views X[begin:end]
+    @test X[begin:end-3] == @views X[begin:end-3]
+    @test X[1:end,2,begin+1] == @views X[1:end,2,begin+1]
+    @test X[begin,2,1:end-2] == @views X[begin,2,1:end-2]
+    @test X[begin,2,Y[2:end]] == @views X[begin,2,Y[2:end]]
+    @test X[begin:end,2,Y[begin+1:end]] == @views X[begin:end,2,Y[begin+1:end]]
+    @test X[u...,begin+1:end] == @views X[u...,begin+1:end]
+    @test X[(1,)...,(2,)...,2:end] == @views X[(1,)...,(2,)...,2:end]
+
+    # @views for zero dimensional arrays
+    A = Array{Int, 0}(undef)
+    A[] = 2
+    @test (@views A[]) == 2
+
+    # test macro hygiene
+    let size=(x,y)-> error("should not happen"), Base=nothing
+        @test X[1:end,2,2] == @views X[1:end,2,2]
+    end
 end
 
-# test that side effects occur only once
-let foo = [X]
-    @test X[2:end-1] == @view (push!(foo,X)[1])[2:end-1]
-    @test foo == [X, X]
-end
-
-# test @views macro
-@views let f!(x) = x[begin:end-1] .+= x[begin+1:end].^2
-    x = [1,2,3,4]
-    f!(x)
-    @test x == [5,11,19,4]
-    @test x[1:3] isa SubArray
-    @test x[2] === 11
-    @test Dict((1:3) => 4)[1:3] === 4
-    x[1:2] .= 0
-    @test x == [0,0,19,4]
-    x[1:2] .= 5:6
-    @test x == [5,6,19,4]
-    f!(x[3:end])
-    @test x == [5,6,35,4]
-    x[Y[2:3]] .= 7:8
-    @test x == [5,8,7,4]
-    x[(3,)..., ()...] += 3
-    @test x == [5,8,10,4]
-    i = Int[]
-    # test that lhs expressions in update operations are evaluated only once:
-    x[push!(i,4)[1]] += 5
-    @test x == [5,8,10,9] && i == [4]
-    x[push!(i,3)[end]] += 2
-    @test x == [5,8,12,9] && i == [4,3]
-    @. x[3:end] = 0       # make sure @. works with end expressions in @views
-    @test x == [5,8,0,0]
-end
-@views @test isa(X[1:3], SubArray)
-@test X[begin:end] == @views X[begin:end]
-@test X[begin:end-3] == @views X[begin:end-3]
-@test X[1:end,2,begin+1] == @views X[1:end,2,begin+1]
-@test X[begin,2,1:end-2] == @views X[begin,2,1:end-2]
-@test X[begin,2,Y[2:end]] == @views X[begin,2,Y[2:end]]
-@test X[begin:end,2,Y[begin+1:end]] == @views X[begin:end,2,Y[begin+1:end]]
-@test X[u...,begin+1:end] == @views X[u...,begin+1:end]
-@test X[(1,)...,(2,)...,2:end] == @views X[(1,)...,(2,)...,2:end]
-
-# @views for zero dimensional arrays
-A = Array{Int, 0}(undef)
-A[] = 2
-@test (@views A[]) == 2
-
-# test macro hygiene
-let size=(x,y)-> error("should not happen"), Base=nothing
-    @test X[1:end,2,2] == @views X[1:end,2,2]
-end
-
-# issue #18034
-# ensure that it is possible to create an isbits, IndexLinear view of an immutable Array
-let
+@testset "issue #18034: an isbits, IndexLinear view of an immutable Array" begin
     struct ImmutableTestArray{T, N} <: Base.DenseArray{T, N}
     end
     Base.size(::Union{ImmutableTestArray, Type{ImmutableTestArray}}) = (0, 0)
@@ -597,49 +569,52 @@ let
     @test isbits(view(a, :, :))
 end
 
-# ref issue #17351
-@test @inferred(reverse(view([1 2; 3 4], :, 1), dims=1)) == [3, 1]
-
-let
+@testset "inference; issue #17351, #25321" begin
+    @test @inferred(reverse(view([1 2; 3 4], :, 1), dims=1)) == [3, 1]
     s = view(reshape(1:6, 2, 3), 1:2, 1:2)
     @test @inferred(s[2,2,1]) === 4
+
+    A = rand(5,5,5,5)
+    V = view(A, 1:1 ,:, 1:3, :)
+    @test @inferred(strides(V)) == (1, 5, 25, 125)
 end
 
-# issue #18581: slices with OneTo axes can be linear
-let
+@testset "issue #18581: slices with OneTo axes can be linear" begin
     A18581 = rand(5, 5)
     B18581 = view(A18581, :, axes(A18581,2))
     @test IndexStyle(B18581) === IndexLinear()
 end
 
-@test sizeof(view(zeros(UInt8, 10), 1:4)) == 4
-@test sizeof(view(zeros(UInt8, 10), 1:3)) == 3
-@test sizeof(view(zeros(Float64, 10, 10), 1:3, 2:6)) == 120
-
-# PR #25321
-# checks that issue in type inference is resolved
-A = rand(5,5,5,5)
-V = view(A, 1:1 ,:, 1:3, :)
-@test @inferred(strides(V)) == (1, 5, 25, 125)
-
-# Issue #26263 — ensure that unaliascopy properly trims the array
-A = rand(5,5,5,5)
-V = view(A, 2:5, :, 2:5, 1:2:5)
-@test @inferred(Base.unaliascopy(V)) == V == A[2:5, :, 2:5, 1:2:5]
-@test @inferred(sum(Base.unaliascopy(V))) ≈ sum(V) ≈ sum(A[2:5, :, 2:5, 1:2:5])
-
-# issue #27632
-function _test_27632(A)
-    for J in CartesianIndices(size(A)[2:end])
-        A[1, J]
-    end
-    nothing
+@testset "sizeof" begin
+    @test sizeof(view(zeros(UInt8, 10), 1:4)) == 4
+    @test sizeof(view(zeros(UInt8, 10), 1:3)) == 3
+    @test sizeof(view(zeros(Float64, 10, 10), 1:3, 2:6)) == 120
 end
-# check that this doesn't crash
-_test_27632(view(ones(Int64, (1, 1, 1)), 1, 1, 1))
 
-# issue #29608 - views of single values can be considered contiguous
-@test Base.iscontiguous(view(ones(1), 1))
+
+@testset "unaliascopy trimming; Issue #26263" begin
+    A = rand(5,5,5,5)
+    V = view(A, 2:5, :, 2:5, 1:2:5)
+    @test @inferred(Base.unaliascopy(V)) == V == A[2:5, :, 2:5, 1:2:5]
+    @test @inferred(sum(Base.unaliascopy(V))) ≈ sum(V) ≈ sum(A[2:5, :, 2:5, 1:2:5])
+end
+
+@testset "issue #27632" begin
+    function _test_27632(A)
+        for J in CartesianIndices(size(A)[2:end])
+            A[1, J]
+        end
+        nothing
+    end
+    # check that this doesn't crash
+    @test _test_27632(view(ones(Int64, (1, 1, 1)), 1, 1, 1)) === nothing
+end
+
+@testset "issue #29608; contiguousness" begin
+    @test Base.iscontiguous(view(ones(1), 1))
+    @test Base.iscontiguous(view(ones(10), 1:10))
+    @test Base.iscontiguous(view(ones(10), :))
+end
 
 import InteractiveUtils
 @testset "blas-enabled reshaped indices" begin


### PR DESCRIPTION
This came up in a DiffEq task, wherein a matrix is stored as a subset of the parameters vector — and thus to be used, it must be reshaped/subsetted before doing a matmul.  This patch gives such a view access to the blassy goodness.  The exemplar case looks something like this:

```julia
p = rand(300)
M = view(p, reshape(2:241, 60, 4))
v = rand(4)
@benchmark $M*$v
```

Before, this took nearly 200ns.  With this patch we hit BLAS and are down to 100ns.  Interestingly, this introduces a bifurcation where it's possible for view to be linear but not strided... but fortunately we've been pretty strict on keeping those two attributes distinct even though they previously were 100% overlapping.

I made sure the SubArray tests passed with JULIA_TESTFULL and while I was there I testsetified the test/subarray.jl file (as a separate and independent commit).

cc: @ChrisRackauckas.