### PR TITLE
Add compact 3-arg show for `AbstractChar`

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -295,6 +295,7 @@ end
 
 function show(io::IO, ::MIME"text/plain", c::T) where {T<:AbstractChar}
     show(io, c)
+    get(io, :compact, false) && return
     if !ismalformed(c)
         print(io, ": ")
         if isoverlong(c)

--- a/test/char.jl
+++ b/test/char.jl
@@ -185,6 +185,7 @@ end
 
 @testset "sprint, repr" begin
     @test sprint(show, "text/plain", '$') == "'\$': ASCII/Unicode U+0024 (category Sc: Symbol, currency)"
+    @test sprint(show, "text/plain", '$', context=:compact => true) == "'\$'"
     @test repr('$') == "'\$'"
 end
 


### PR DESCRIPTION
Due to the changes in https://github.com/JuliaLang/julia/pull/34387 any call to 3-arg show for `Char` would always result in Unicode category information being displayed. This PR allows for a compact option for the 3-arg show.