### PR TITLE
Remove Iterators.reverse(::Tuple) specialization

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -98,7 +98,6 @@ reverse(G::Generator) = Generator(G.f, reverse(G.iter))
 reverse(r::Reverse) = r.itr
 reverse(x::Union{Number,AbstractChar}) = x
 reverse(p::Pair) = Base.reverse(p) # copying pairs is cheap
-reverse(xs::Tuple) = Base.reverse(xs) # allows inference in mapfoldr and similar
 
 iterate(r::Reverse{<:Tuple}, i::Int = length(r.itr)) = i < 1 ? nothing : (r.itr[i], i-1)
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -178,8 +178,11 @@ foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)
 
 function mapfoldr_impl(f, op, nt, itr)
     op′, itr′ = _xfadjoint(BottomRF(FlipArgs(op)), Generator(f, itr))
-    return foldl_impl(op′, nt, Iterators.reverse(itr′))
+    return foldl_impl(op′, nt, _reverse(itr′))
 end
+
+_reverse(itr) = Iterators.reverse(itr)
+_reverse(itr::Tuple) = reverse(itr)  #33235
 
 struct FlipArgs{F}
     f::F


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/34691#issuecomment-584912856, @JeffBezanson was pointing out that it is desirable to have good support for large tuples:

> Large tuples do exist, and we'd like to support them better if possible. So it's really not obvious to me that `zip` should be eager for tuples.

_If_ we follow this principle, I think it's ideal if none of the iterator transformation APIs from `Iterators` special-case `Tuple`s.  So I suggest to revert #33235 (making `Iterators.reverse(::Tuple)` eager) and solve the original problem differently.  I think it's a safe option anyway as it makes this part of the API identical to the latest released version (1.3).

(Side note: `pairs` already supports `NamedTuple` and `Tuple` for some times so I guess it's not desirable to remove it.)

Requesting a tag: `backport 1.4`
