### PR TITLE
[RFC/WIP] Handle :compact context in 3-arg show for arrays

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -334,7 +334,7 @@ function show(io::IO, ::MIME"text/plain", X::AbstractArray)
     show_circular(io, X) && return
 
     # 1) compute new IOContext
-    if !haskey(io, :compact)
+    if !haskey(io, :compact) && length(axes(X, 2)) > 1
         io = IOContext(io, :compact => true)
     end
     if get(io, :limit, false) && eltype(X) === Method

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -334,7 +334,7 @@ function show(io::IO, ::MIME"text/plain", X::AbstractArray)
     show_circular(io, X) && return
 
     # 1) compute new IOContext
-    if !haskey(io, :compact) && length(axes(X, 2)) > 1
+    if !haskey(io, :compact)
         io = IOContext(io, :compact => true)
     end
     if get(io, :limit, false) && eltype(X) === Method

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -320,6 +320,13 @@ print_array(io::IO, X::AbstractArray) = show_nd(io, X, print_matrix, true)
 # typeinfo aware
 # implements: show(io::IO, ::MIME"text/plain", X::AbstractArray)
 function show(io::IO, ::MIME"text/plain", X::AbstractArray)
+    # -1) handle arrays-in-array (recursive call)
+    if get(io, :compact, false) === true
+        # Using `show` of method with the most abstract type to avoid infinite recursion.
+        invoke(show, Tuple{IO,AbstractArray}, io, X)
+        return
+    end
+
     # 0) show summary before setting :compact
     summary(io, X)
     isempty(X) && return


### PR DESCRIPTION
Edit: now this PR fixes only `permutedims([Int[], Int[]])` case https://github.com/JuliaLang/julia/pull/34733#issuecomment-588513011

---

<strike>Before:

```
julia> [Int[]]
1-element Array{Array{Int64,1},1}:
 0-element Array{Int64,1}
```

After:

```
julia> [Int[]]
1-element Array{Array{Int64,1},1}:
 []
```
</strike>

<strike>I'm sending this as a WIP</strike> I was meant to send this as a WIP PR before fixing the tests as I don't know if the core devs think this is the way to go.

fix (a related bug of) #34659