### PR TITLE
Recommend overloading 3-arg show; explain :compact handling

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -94,9 +94,10 @@ your images to be displayed on any PNG-capable `AbstractDisplay` (such as IJulia
 to `import Base.show` in order to add new methods to the built-in Julia function
 `show`.
 
-The default MIME type is `MIME"text/plain"`. There is a fallback definition for `text/plain`
-output that calls `show` with 2 arguments. Therefore, this case should be handled by
-defining a 2-argument `show(io::IO, x::MyType)` method.
+To customize how an object of type `T` is shown in text-based outputs, it is highly recommended
+to overload `show(::IO, ::MIME"text/plain", ::T)` rather than [`show(::IO, ::T)`](@ref show).
+Container types should call `show(io, MIME"text/plain"(), x)` for elements `x`
+instead of `show(io, x)` with [`IOContext`](@ref) of `:compact => true`.
 
 Technically, the `MIME"mime"` macro defines a singleton type for the given `mime` string,
 which allows us to exploit Julia's dispatch mechanisms in determining how to display objects

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -94,10 +94,12 @@ your images to be displayed on any PNG-capable `AbstractDisplay` (such as IJulia
 to `import Base.show` in order to add new methods to the built-in Julia function
 `show`.
 
-To customize how an object of type `T` is shown in text-based outputs, it is highly recommended
-to overload `show(::IO, ::MIME"text/plain", ::T)` rather than [`show(::IO, ::T)`](@ref show).
-Container types should call `show(io, MIME"text/plain"(), x)` for elements `x`
-instead of `show(io, x)` with [`IOContext`](@ref) of `:compact => true`.
+To customize human-readable text output for objects of type `T`, it is highly recommended
+to overload `show(::IO, ::MIME"text/plain", ::T)` rather than [`show(::IO, ::T)`](@ref show)
+which is primarily used for parseable text output.  When implementing the method
+`show(::IO, ::MIME"text/plain", ::T)` for container types, it should call
+`show(io, MIME"text/plain"(), x)` for elements `x` instead of `show(io, x)` with
+[`IOContext`](@ref) of `:compact => true` from its implementation
 
 Technically, the `MIME"mime"` macro defines a singleton type for the given `mime` string,
 which allows us to exploit Julia's dispatch mechanisms in determining how to display objects

--- a/base/show.jl
+++ b/base/show.jl
@@ -357,13 +357,13 @@ Write an informative text representation of a value to the current output stream
 should overload `show(io::IO, x)` where the first argument is a stream. The representation used
 by `show` generally includes Julia-specific formatting and type information.
 
-[`repr`](@ref) returns the output of `show` as a string.
+[`repr`](@ref) returns the output of `show` as a string.  Therefore, `show(::IO, ::T)` is
+expected to print parseable Julia code.
 
-To customize how an object of type `T` is shown in text-based outputs, it is highly recommended
-to overload `show(::IO, ::MIME"text/plain", ::T)` rather than `show(::IO, ::T)` as the latter
-is generally expected to print a valid Julia code.  To customize how objects of type `T` stored
-in containers are shown, check `:compact` [`IOContext`](@ref) rather than implementing the
-method `show(::IO, ::T)`.
+To customize human-readable text output for objects of type `T`, it is highly recommended
+to overload `show(::IO, ::MIME"text/plain", ::T)` rather than `show(::IO, ::T)`.  To customize
+how objects of type `T` stored in containers are shown, check `:compact` [`IOContext`](@ref)
+rather than implementing the method `show(::IO, ::T)`.
 
 See also [`print`](@ref), which writes un-decorated representations.
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -359,6 +359,12 @@ by `show` generally includes Julia-specific formatting and type information.
 
 [`repr`](@ref) returns the output of `show` as a string.
 
+To customize how an object of type `T` is shown in text-based outputs, it is highly recommended
+to overload `show(::IO, ::MIME"text/plain", ::T)` rather than `show(::IO, ::T)` as the latter
+is generally expected to print a valid Julia code.  To customize how objects of type `T` stored
+in containers are shown, check `:compact` [`IOContext`](@ref) rather than implementing the
+method `show(::IO, ::T)`.
+
 See also [`print`](@ref), which writes un-decorated representations.
 
 # Examples


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/julia/issues/30901#issuecomment-573450132 and implemented in #34387, it is now recommended to overload 3-arg `show` to customize the text output for humans.  This PR updates the docstring to recommend 3-arg `show` instead of 2-arg `show` and clarifies the role of `:compact` context for printing containers.