### PR TITLE
Add compact 3-arg show for Irrational

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -20,7 +20,11 @@ struct Irrational{sym} <: AbstractIrrational end
 show(io::IO, x::Irrational{sym}) where {sym} = print(io, sym)
 
 function show(io::IO, ::MIME"text/plain", x::Irrational{sym}) where {sym}
-    print(io, sym, " = ", string(float(x))[1:15], "...")
+    if get(io, :compact, false)
+        print(io, sym)
+    else
+        print(io, sym, " = ", string(float(x))[1:15], "...")
+    end
 end
 
 promote_rule(::Type{<:AbstractIrrational}, ::Type{Float16}) = Float16

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1078,6 +1078,12 @@ end
 
     @test sqrt(2) == 1.4142135623730951
 end
+@testset "Irrational printing" begin
+    @test sprint(show, "text/plain", π) == "π = 3.1415926535897..."
+    @test sprint(show, "text/plain", π, context=:compact => true) == "π"
+    @test sprint(show, π) == "π"
+
+end
 @testset "issue #6365" begin
     for T in (Float32, Float64)
         for i = 9007199254740992:9007199254740996


### PR DESCRIPTION
Due to the changes in #34387 any call to 3-arg show for `Irrational` (namely π) would result in the symbol and a truncated value being displayed. This PR allows for a compact option for the 3-arg show where only the symbol is shown.

Similar to: https://github.com/JuliaLang/julia/pull/34730