### PR TITLE
a vector is always == to itself, even when containing missing

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1776,6 +1776,7 @@ end
 isless(A::AbstractVector, B::AbstractVector) = cmp(A, B) < 0
 
 function (==)(A::AbstractArray, B::AbstractArray)
+    A === B && return true
     if axes(A) != axes(B)
         return false
     end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -70,6 +70,7 @@ in which case `missing` is returned
 ([three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic)).
 For collections, `missing` is returned if at least one of the operands contains
 a `missing` value and all non-missing values are equal.
+An exception is when both operands are the same object.
 Use [`isequal`](@ref) or [`===`](@ref) to always get a `Bool` result.
 
 # Implementation

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -98,7 +98,13 @@ using Dates
     @test Array(a) !== a
     @test Array{eltype(a)}(a) !== a
     @test Vector(a) !== a
+
+    # missing
+    a = [missing]
+    @test ismissing(a == [missing])
+    @test a == a
 end
+
 @testset "reshaping SubArrays" begin
     a = Array(reshape(1:5, 1, 5))
     @testset "linearfast" begin

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -275,6 +275,8 @@ end
     @test Dict(NaN=>1) == Dict(NaN=>1)
     @test isequal(Dict(NaN=>1), Dict(NaN=>1))
 
+    d = Dict(1=>missing)
+    @test d == d
     @test ismissing(Dict(1=>missing) == Dict(1=>missing))
     @test isequal(Dict(1=>missing), Dict(1=>missing))
 


### PR DESCRIPTION
This tries to fix the following inconsistency:
```julia
julia> v = [missing]; (v == v, v == [missing])
(missing, missing)

julia> d = Dict(0=>missing); (d == d, d == Dict(0=>missing))
(true, missing)
```
The docstring for `==` says 
> For collections, missing is returned if at least one of the operands contains a missing value and all
  non-missing values are equal.

Which would suggest `d == d` should be `missing`. But another point of vue would suggest that `v == v` should be `true`, as well expressed by @oxinabox:
> But we know the `missing`s the two d in d == d are the same.
> Because those are the same reference.
> We are not comparing two different forms with unfilled boxes, we are comparing a form to itself.
> No matter what the answer for the missing on the left is, it will certainly be the same for the missing on the right

This PR makes `(v == v) == true`. But this raises the quesion for some immutable types: what should `(missing,) == (missing,)` be? we don't know if both tuples have been created from the same source or not...

cc. @nalimilan 
(apologies if this was already discussed to death and consciously decided upon the current behavior)