### PR TITLE
gf: optimize jl_matching_methods for dispatch tuples

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5191,8 +5191,8 @@ static Function *jl_cfunction_object(jl_value_t *ff, jl_value_t *declrt, jl_tupl
     else {
         cache_l2 = jl_eqtable_get(jl_cfunction_list, ft, NULL);
         if (cache_l2) {
-            cache_l3 = jl_typemap_assoc_by_type(cache_l2, (jl_value_t*)argt, NULL,
-                /*subtype*/0, /*offs*/0, /*world*/1, /*max_world_mask*/0);
+            struct jl_typemap_assoc search = {(jl_value_t*)argt, 1, 0, NULL, 0, ~(size_t)0};
+            cache_l3 = jl_typemap_assoc_by_type(cache_l2, &search, /*offs*/0, /*subtype*/0);
             if (cache_l3) {
                 jl_svec_t *sf = (jl_svec_t*)cache_l3->func.value;
                 size_t i, l = jl_svec_len(sf);

--- a/src/dump.c
+++ b/src/dump.c
@@ -2282,6 +2282,7 @@ static size_t lowerbound_dependent_world_set(size_t world, arraylist_t *dependen
 }
 
 extern int JL_DEBUG_METHOD_INVALIDATION;
+extern jl_value_t *jl_matching_methods_including_deleted(jl_tupletype_t *types, size_t world);
 
 static void jl_insert_backedges(jl_array_t *list, arraylist_t *dependent_worlds)
 {
@@ -2307,12 +2308,11 @@ static void jl_insert_backedges(jl_array_t *list, arraylist_t *dependent_worlds)
                 sig = callee;
             }
             // verify that this backedge doesn't intersect with any new methods
-            size_t min_valid = 0;
-            size_t max_valid = ~(size_t)0;
-            jl_value_t *matches = jl_matching_methods((jl_tupletype_t*)sig, -1, 1, 0, &min_valid, &max_valid);
+            jl_value_t *matches = jl_matching_methods_including_deleted((jl_tupletype_t*)sig, jl_world_counter);
             if (matches == jl_false)
                 valid = 0;
             size_t k;
+            assert(!jl_is_method_instance(callee) || jl_array_len(matches) > 0);
             for (k = 0; valid && k < jl_array_len(matches); k++) {
                 jl_method_t *m = (jl_method_t*)jl_svecref(jl_array_ptr_ref(matches, k), 2);
                 int wasactive = (lowerbound_dependent_world_set(m->primary_world, dependent_worlds) == m->primary_world);
@@ -3123,8 +3123,8 @@ static jl_method_t *jl_lookup_method_worldset(jl_methtable_t *mt, jl_datatype_t 
     size_t world = jl_world_counter;
     jl_typemap_entry_t *entry;
     while (1) {
-        entry = jl_typemap_assoc_by_type(
-            mt->defs, (jl_value_t*)sig, NULL, /*subtype*/0, /*offs*/0, world, /*max_world_mask*/(~(size_t)0) >> 1);
+        struct jl_typemap_assoc search = {(jl_value_t*)sig, world, /*max_world_mask*/(~(size_t)0) >> 1, NULL, 0, ~(size_t)0};
+        entry = jl_typemap_assoc_by_type(mt->defs, &search, /*offs*/0, /*subtype*/0);
         assert(entry);
         jl_method_t *_new = (jl_method_t*)entry->func.value;
         world = lowerbound_dependent_world_set(_new->primary_world, dependent_worlds);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1034,10 +1034,22 @@ jl_typemap_entry_t *jl_typemap_insert(jl_typemap_t **cache,
                                       const struct jl_typemap_info *tparams,
                                       size_t min_world, size_t max_world);
 
+struct jl_typemap_assoc {
+    // inputs
+    jl_value_t *const types;
+    size_t const world;
+    size_t const max_world_mask;
+    // outputs
+    jl_svec_t *env; // subtype env (initialize to null to perform intersection without an environment)
+    size_t min_valid;
+    size_t max_valid;
+};
+
 jl_typemap_entry_t *jl_typemap_assoc_by_type(
         jl_typemap_t *ml_or_cache JL_PROPAGATES_ROOT,
-        jl_value_t *types, jl_svec_t **penv,
-        int8_t subtype, int8_t offs, size_t world, size_t max_world_mask);
+        struct jl_typemap_assoc *search,
+        int8_t offs, uint8_t subtype);
+
 jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t *arg1, jl_value_t **args, size_t n, int8_t offs, size_t world);
 jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t *arg1, jl_value_t **args, size_t n, size_t world);
 STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(
@@ -1062,9 +1074,9 @@ struct typemap_intersection_env;
 typedef int (*jl_typemap_intersection_visitor_fptr)(jl_typemap_entry_t *l, struct typemap_intersection_env *closure);
 struct typemap_intersection_env {
     // input values
-    jl_typemap_intersection_visitor_fptr fptr; // fptr to call on a match
-    jl_value_t *type; // type to match
-    jl_value_t *va; // the tparam0 for the vararg in type, if applicable (or NULL)
+    jl_typemap_intersection_visitor_fptr const fptr; // fptr to call on a match
+    jl_value_t *const type; // type to match
+    jl_value_t *const va; // the tparam0 for the vararg in type, if applicable (or NULL)
     // output values
     jl_value_t *ti; // intersection type
     jl_svec_t *env; // intersection env (initialize to null to perform intersection without an environment)


### PR DESCRIPTION
When the input type is a dispatch tuple, we know that a subtype lookup
is sufficient, so we can do a slightly more direct lookup and avoid
considering `Union{}`-declared methods as possible results.

This also fixes an issue with the special `jl_matching_methods` query
being done by `jl_insert_backedges`: we would set the `done` flag when a
method "fully covered" the result, even if that method was deleted.
Rather than continue to abuse the meaning of `world == 0` (which also
has performance implications), we add a specific flag for this case.