### PR TITLE
Small typographical fixes to the manual

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -204,8 +204,8 @@ julia> function mycompare(a, b)::Cint
 mycompare (generic function with 1 method)
 ```
 
-``qsort`` expects a comparison function that return a C ``int``, so we annotate the return type
-to be ``Cint``.
+`qsort` expects a comparison function that return a C `int`, so we annotate the return type
+to be `Cint`.
 
 In order to pass this function to C, we obtain its address using the macro `@cfunction`:
 

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -457,7 +457,7 @@ M
 end
 ```
 
-Adds docstring `"..."` to the `Module``M`. Adding the docstring above the `Module` is the preferred
+Adds docstring `"..."` to the `Module` `M`. Adding the docstring above the `Module` is the preferred
 syntax, however both are equivalent.
 
 ```julia


### PR DESCRIPTION
This fixes two small issues in the manual:
* In the “Calling C and Fortran Code” section, replace some double backquotes by single backquotes to print names as code instead of LaTeX.
* In the “Documentation” section, add a space between two words.