### PR TITLE
change helpdoc so using a works

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -37,6 +37,8 @@ function _helpmode(io::IO, line::AbstractString)
             # Docs for keywords must be treated separately since trying to parse a single
             # keyword such as `function` would throw a parse error due to the missing `end`.
             Symbol(line)
+        elseif isexpr(x, (:using, :import))
+            x.head
         else
             # Retrieving docs for macros requires us to make a distinction between the text
             # `@macroname` and `@macroname()`. These both parse the same, but are used by

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1027,9 +1027,11 @@ for (line, expr) in Pair[
     "while       " => :while, # keyword, trailing spaces should be stripped.
     "0"            => 0,
     "\"...\""      => "...",
-    "r\"...\""     => Expr(:macrocall, Symbol("@r_str"), LineNumberNode(1, :none), "...")
+    "r\"...\""     => Expr(:macrocall, Symbol("@r_str"), LineNumberNode(1, :none), "..."),
+    "using Foo"    => :using,
+    "import Foo"   => :import,
     ]
-    #@test REPL._helpmode(line) == Expr(:macrocall, Expr(:., Expr(:., :Base, QuoteNode(:Docs)), QuoteNode(Symbol("@repl"))), LineNumberNode(119, doc_util_path), stdout, expr)
+    @test REPL._helpmode(line).args[4] == expr
     buf = IOBuffer()
     @test Base.eval(REPL._helpmode(buf, line)) isa Union{Markdown.MD,Nothing}
 end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -982,8 +982,6 @@ let x = Binding(Main, :⊕)
     @test Meta.parse(string(x)) == :(⊕)
 end
 
-doc_util_path = Symbol(joinpath("docs", "utils.jl"))
-
 @test sprint(repl_latex, "√") == "\"√\" can be typed by \\sqrt<tab>\n\n"
 @test sprint(repl_latex, "x̂₂") == "\"x̂₂\" can be typed by x\\hat<tab>\\_2<tab>\n\n"
 


### PR DESCRIPTION
For issue #34713 

https://github.com/JuliaLang/julia/blob/a211abcdfacc05cb93c15774a59ce8961c16dac4/stdlib/REPL/src/docview.jl#L34-L47

Here for `using 1`, `Meta.parse`  determines x is:
```
x = :($(Expr(:error, "invalid \"using\" statement: expected identifier")))
typeof(x) = Expr
```
as a result `expr` is 
```
expr = Symbol("using 1")
typeof(expr) = Symbol
```

while for `using a` , `Meta.parse` can parse the string without an error:
```
x = :(using a)
typeof(x) = Expr
``` 
and `expr` is 

```
expr = :(using a)
typeof(expr) = Expr
```
The difference in types leads to two different code paths. This is why one has a useful documentation, the other an exception.

This change quickly checks the input line. If it splits and the first token contains `using` just make `expr` a `Symbol` ( same type used when `using 1` is called).

With this both `using 1` and `using a` can have similar outputs:

```
help?> using a
search: using SubString include_string unsafe_string unescape_string SubstitutionString

Couldn't find using a
Perhaps you meant using or asin
  No documentation found.

  Binding using a does not exist.

help?> using 1
search: using SubString include_string unsafe_string unescape_string SubstitutionString

Couldn't find using 1
Perhaps you meant using or asin
  No documentation found.

  Binding using 1 does not exist.

julia> 
```