### PR TITLE
interpret &(a,b) as a call expresion

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -115,7 +115,7 @@
 (define syntactic-operators
   (append! (add-dots '(= += -= *= /= //= |\\=| ^= ÷= %= <<= >>= >>>= |\|=| &= ⊻=))
            '(:= --> $= && |\|\|| |.| ... ->)))
-(define syntactic-unary-operators '($ & |::|))
+(define syntactic-unary-operators '($ |::|))
 
 (define syntactic-op? (Set syntactic-operators))
 (define syntactic-unary-op? (Set syntactic-unary-operators))

--- a/test/show.jl
+++ b/test/show.jl
@@ -34,9 +34,6 @@ end
 
 @test replstr(Meta.parse("mutable struct X end")) == ":(mutable struct X\n      #= none:1 =#\n  end)"
 @test replstr(Meta.parse("struct X end")) == ":(struct X\n      #= none:1 =#\n  end)"
-let s = "ccall(:f, Int, (Ptr{Cvoid},), &x)"
-    @test replstr(Meta.parse(s)) == ":($s)"
-end
 
 # recursive array printing
 # issue #10353

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -159,7 +159,6 @@ macro test999_str(args...); args; end
 
 @test parseall("a = &\nb") == Expr(:block, Expr(:(=), :a, :&), :b)
 @test parseall("a = \$\nb") == Expr(:block, Expr(:(=), :a, :$), :b)
-@test parseall(":(a = &\nb)") == Expr(:quote, Expr(:(=), :a, Expr(:&, :b)))
 @test parseall(":(a = \$\nb)") == Expr(:quote, Expr(:(=), :a, Expr(:$, :b)))
 
 # issue 11970
@@ -1084,9 +1083,6 @@ end
 @test_throws ParseError Meta.parse("x@time 2")
 @test_throws ParseError Meta.parse("@ time")
 
-# issue #7479
-@test Meta.lower(Main, Meta.parse("(true &&& false)")) == Expr(:error, "invalid syntax &false")
-
 # if an indexing expression becomes a cat expression, `end` is not special
 @test_throws ParseError Meta.parse("a[end end]")
 @test_throws ParseError Meta.parse("a[end;end]")
@@ -1656,9 +1652,6 @@ for i = 1:10
 end
 end
 @test M22314.i == 0
-
-# #6080
-@test Meta.lower(@__MODULE__, :(ccall(:a, Cvoid, (Cint,), &x))) == Expr(:error, "invalid syntax &x")
 
 @test_throws ParseError Meta.parse("x.'")
 @test_throws ParseError Meta.parse("0.+1")


### PR DESCRIPTION
closes #34693
I believe that & is included in this list by accident, but I'm not exactly sure.