### PR TITLE
Convert range type in `reduced_index`

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -20,7 +20,7 @@ reduced_indices0(a::AbstractArray, region) = reduced_indices0(axes(a), region)
 function reduced_indices(inds::Indices{N}, d::Int) where N
     d < 1 && throw(ArgumentError("dimension must be ≥ 1, got $d"))
     if d == 1
-        return (reduced_index(inds[1]), tail(inds)...)
+        return (reduced_index(inds[1]), tail(inds)...)::typeof(inds)
     elseif 1 < d <= N
         return tuple(inds[1:d-1]..., oftype(inds[d], reduced_index(inds[d])), inds[d+1:N]...)::typeof(inds)
     else
@@ -34,7 +34,7 @@ function reduced_indices0(inds::Indices{N}, d::Int) where N
         ind = inds[d]
         rd = isempty(ind) ? ind : reduced_index(inds[d])
         if d == 1
-            return (rd, tail(inds)...)
+            return (rd, tail(inds)...)::typeof(inds)
         else
             return tuple(inds[1:d-1]..., oftype(inds[d], rd), inds[d+1:N]...)::typeof(inds)
         end

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -4,7 +4,7 @@
 
 # for reductions that expand 0 dims to 1
 reduced_index(i::OneTo) = OneTo(1)
-reduced_index(i::Union{Slice, IdentityUnitRange}) = first(i):first(i)
+reduced_index(i::Union{Slice, IdentityUnitRange}) = oftype(i, first(i):first(i))
 reduced_index(i::AbstractUnitRange) =
     throw(ArgumentError(
 """

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -440,6 +440,14 @@ I = findall(!iszero, z)
 @test std(A_3_3, dims=2) == OffsetArray(reshape([3,3,3], (3,1)), A_3_3.offsets)
 @test sum(OffsetArray(fill(1,3000), -1000)) == 3000
 
+# https://github.com/JuliaArrays/OffsetArrays.jl/issues/92
+A92 = OffsetArray(reshape(1:27, 3, 3, 3), -2, -2, -2)
+B92 = view(A92, :, :, -1:0)
+@test axes(B92) == (-1:1, -1:1, 1:2)
+@test sum(B92, dims=(2,3)) == OffsetArray(reshape([51,57,63], Val(3)), -2, -2, 0)
+B92 = view(A92, :, :, Base.IdentityUnitRange(-1:0))
+@test sum(B92, dims=(2,3)) == OffsetArray(reshape([51,57,63], Val(3)), -2, -2, -2)
+
 @test norm(v) ≈ norm(parent(v))
 @test norm(A) ≈ norm(parent(A))
 @test dot(v, v) ≈ dot(v0, v0)


### PR DESCRIPTION
**BACKPORTING NOTE**: consensus is to backport the first commit but not the second.

The `reduced_indices` and `reduced_indices0` methods *sometimes* assert that the return axes type is the same as the input. Consequently, the implementation of `reduced_index` had better return a range of the same type as the input.

This corrects the error in https://github.com/JuliaArrays/OffsetArrays.jl/issues/92. I'll put a workaround in OffsetArrays.jl too.

The second commit consistently asserts type-equality in `reduced_indices`. This is a bit more aggressive, and if we backport it's possible we should backport the first but not the second. The potential problem is that it makes these methods more fragile in cases where `reduced_index` is broken. IMO, this is a good thing because it increases the odds that errors will be caught early. Moreover, it ensures that the return type is inferrable in cases where the reduction is over the first dimension but constant-propagation fails to detect this. However, for the LTS release this should be tested for trouble.