### PR TITLE
zero and one for irrational numbers

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -136,6 +136,15 @@ hash(x::Irrational, h::UInt) = 3*objectid(x) - h
 
 widen(::Type{T}) where {T<:Irrational} = T
 
+zero(::AbstractIrrational) = false
+zero(::Type{<:AbstractIrrational}) = false
+
+one(::AbstractIrrational) = true
+one(::Type{<:AbstractIrrational}) = true
+
+oneunit(T::Type{<:AbstractIrrational}) = throw(ArgumentError("The number one cannot be of type $T"))
+oneunit(x::T) where {T <: AbstractIrrational} = oneunit(T)
+
 -(x::AbstractIrrational) = -Float64(x)
 for op in Symbol[:+, :-, :*, :/, :^]
     @eval $op(x::AbstractIrrational, y::AbstractIrrational) = $op(Float64(x),Float64(y))

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -142,9 +142,6 @@ zero(::Type{<:AbstractIrrational}) = false
 one(::AbstractIrrational) = true
 one(::Type{<:AbstractIrrational}) = true
 
-oneunit(T::Type{<:AbstractIrrational}) = throw(ArgumentError("The number one cannot be of type $T"))
-oneunit(x::T) where {T <: AbstractIrrational} = oneunit(T)
-
 -(x::AbstractIrrational) = -Float64(x)
 for op in Symbol[:+, :-, :*, :/, :^]
     @eval $op(x::AbstractIrrational, y::AbstractIrrational) = $op(Float64(x),Float64(y))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1035,6 +1035,15 @@ end
     @test !(1 > NaN)
 end
 
+@testset "Irrational zero, one and oneunit" begin
+	@test one(pi) === true
+	@test zero(pi) === false
+	@test one(typeof(pi)) === true
+	@test zero(typeof(pi)) === false
+	@test_throws ArgumentError oneunit(pi)
+	@test_throws ArgumentError oneunit(typeof(pi))
+end
+
 @testset "Irrationals compared with Irrationals" begin
     for i in (π, ℯ, γ, catalan)
         for j in (π, ℯ, γ, catalan)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1035,13 +1035,11 @@ end
     @test !(1 > NaN)
 end
 
-@testset "Irrational zero, one and oneunit" begin
+@testset "Irrational zero and one" begin
     @test one(pi) === true
     @test zero(pi) === false
     @test one(typeof(pi)) === true
     @test zero(typeof(pi)) === false
-    @test_throws ArgumentError oneunit(pi)
-    @test_throws ArgumentError oneunit(typeof(pi))
 end
 
 @testset "Irrationals compared with Irrationals" begin

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1036,12 +1036,12 @@ end
 end
 
 @testset "Irrational zero, one and oneunit" begin
-	@test one(pi) === true
-	@test zero(pi) === false
-	@test one(typeof(pi)) === true
-	@test zero(typeof(pi)) === false
-	@test_throws ArgumentError oneunit(pi)
-	@test_throws ArgumentError oneunit(typeof(pi))
+    @test one(pi) === true
+    @test zero(pi) === false
+    @test one(typeof(pi)) === true
+    @test zero(typeof(pi)) === false
+    @test_throws ArgumentError oneunit(pi)
+    @test_throws ArgumentError oneunit(typeof(pi))
 end
 
 @testset "Irrationals compared with Irrationals" begin


### PR DESCRIPTION
This PR takes a fraction of https://github.com/JuliaLang/julia/pull/32117 and implements `zero`, `one` and ~`oneunit` (throws)~ for irrational numbers.