### PR TITLE
Run ast_transforms with invokelatest

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -113,7 +113,7 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend)
             else
                 backend.in_eval = true
                 for xf in backend.ast_transforms
-                    ast = xf(ast)
+                    ast = Base.invokelatest(xf, ast)
                 end
                 value = Core.eval(Main, ast)
                 backend.in_eval = false

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1133,3 +1133,18 @@ fake_repl() do stdin_write, stdout_read, repl
     write(stdin_write, "\x15\x04")
     Base.wait(repltask)
 end
+
+# AST transformations (softscope, Revise, OhMyREPL, etc.)
+repl_channel = Channel(1)
+response_channel = Channel(1)
+backend = REPL.start_repl_backend(repl_channel, response_channel)
+put!(repl_channel, (:(1+1), false))
+reply = take!(response_channel)
+@test reply == (2, false)
+twice(ex) = Expr(:tuple, ex, ex)
+push!(backend.ast_transforms, twice)
+put!(repl_channel, (:(1+1), false))
+reply = take!(response_channel)
+@test reply == ((2, 2), false)
+put!(repl_channel, (nothing, -1))
+Base.wait(backend.backend_task)


### PR DESCRIPTION
The recently-introduced `ast_transforms` need to be run under `Base.invokelatest` if it is going to be useful in packages. Current master fails the test in the first commit; the second commit fixes it.

xref https://github.com/timholy/Revise.jl/pull/425.