### PR TITLE
codegen: fix bad declaration of memcmp stdlib function signature

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1390,9 +1390,9 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         if (jl_is_long(argi_root))
             continue;
         jl_cgval_t arg_root = emit_expr(ctx, argi_root);
-        if (arg_root.Vboxed || arg_root.V) {
-            gc_uses.push_back(arg_root.Vboxed ? arg_root.Vboxed : arg_root.V);
-        }
+        Value *gc_root = get_gc_root_for(arg_root);
+        if (gc_root)
+            gc_uses.push_back(gc_root);
     }
 
     jl_unionall_t *unionall = (jl_is_method(ctx.linfo->def.method) && jl_is_unionall(ctx.linfo->def.method->sig))
@@ -1487,8 +1487,9 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         if (!retboxed) {
             return mark_or_box_ccall_result(
                     ctx,
-                    emit_pointer_from_objref(ctx,
-                        emit_bitcast(ctx, ary, T_prjlvalue)),
+                    ctx.builder.CreatePtrToInt(
+                        emit_pointer_from_objref(ctx, emit_bitcast(ctx, ary, T_prjlvalue)),
+                        T_size),
                     retboxed, rt, unionall, static_rt);
         }
         else {
@@ -1496,7 +1497,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                     ctx,
                     ctx.builder.CreateAddrSpaceCast(
                         ctx.builder.CreateIntToPtr(ary, T_pjlvalue),
-                        T_prjlvalue), // TODO: this addrspace cast is invalid (implies that the value is rooted elsewhere)
+                        T_prjlvalue), // WARNING: this addrspace cast necessarily implies that the value is rooted elsewhere!
                     retboxed, rt, unionall, static_rt);
         }
     }
@@ -1647,7 +1648,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
     else if (is_libjulia_func(jl_string_ptr)) {
         assert(lrt == T_size);
         assert(!isVa && !llvmcall && nccallargs == 1);
-        Value *obj = emit_pointer_from_objref(ctx, boxed(ctx, argv[0]));
+        Value *obj = ctx.builder.CreatePtrToInt(emit_pointer_from_objref(ctx, boxed(ctx, argv[0])), T_size);
         Value *strp = ctx.builder.CreateAdd(obj, ConstantInt::get(T_size, sizeof(void*)));
         JL_GC_POP();
         return mark_or_box_ccall_result(ctx, strp, retboxed, rt, unionall, static_rt);
@@ -1662,7 +1663,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                 ctx.builder.CreateIntToPtr(destp, T_pint8),
                 1,
                 ctx.builder.CreateIntToPtr(
-                    emit_unbox(ctx, T_size, src, (jl_value_t*)jl_voidpointer_type), T_pint8),
+                    emit_unbox(ctx, T_size, src, (jl_value_t*)jl_voidpointer_type),
+                    T_pint8),
                 0,
                 emit_unbox(ctx, T_size, n, (jl_value_t*)jl_ulong_type),
                 false);
@@ -1789,7 +1791,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                                    literal_pointer_val(ctx, (jl_value_t*)rt));
             sretboxed = true;
             gc_uses.push_back(result);
-            argvals[0] = ctx.builder.CreateIntToPtr(emit_pointer_from_objref(ctx, result), fargt_sig.at(0));
+            argvals[0] = ctx.builder.CreateBitCast(emit_pointer_from_objref(ctx, result), fargt_sig.at(0));
         }
     }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -253,24 +253,34 @@ static DIType *julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxe
     return (llvm::DIType*)jdt->ditype;
 }
 
-static Value *emit_pointer_from_objref_internal(jl_codectx_t &ctx, Value *V)
-{
-    CallInst *Call = ctx.builder.CreateCall(prepare_call(pointer_from_objref_func), V);
-    Call->addAttribute(AttributeList::FunctionIndex, Attribute::ReadNone);
-    return Call;
-}
-
 static Value *emit_pointer_from_objref(jl_codectx_t &ctx, Value *V)
 {
     unsigned AS = cast<PointerType>(V->getType())->getAddressSpace();
     if (AS != AddressSpace::Tracked && AS != AddressSpace::Derived)
-        return ctx.builder.CreatePtrToInt(V, T_size);
-    V = ctx.builder.CreateBitCast(decay_derived(V),
-            PointerType::get(T_jlvalue, AddressSpace::Derived));
+        return V;
+    V = decay_derived(V);
+    Type *T = PointerType::get(T_jlvalue, AddressSpace::Derived);
+    if (V->getType() != T)
+        V = ctx.builder.CreateBitCast(V, T);
+    CallInst *Call = ctx.builder.CreateCall(prepare_call(pointer_from_objref_func), V);
+    Call->setAttributes(pointer_from_objref_func->getAttributes());
+    return Call;
+}
 
-    return ctx.builder.CreatePtrToInt(
-        emit_pointer_from_objref_internal(ctx, V),
-        T_size);
+static Value *get_gc_root_for(const jl_cgval_t &x)
+{
+    if (x.Vboxed)
+        return x.Vboxed;
+    if (x.ispointer() && !x.constant) {
+        assert(x.V);
+        if (PointerType *T = dyn_cast<PointerType>(x.V->getType())) {
+            if (T->getAddressSpace() == AddressSpace::Tracked ||
+                T->getAddressSpace() == AddressSpace::Derived) {
+                return x.V;
+            }
+        }
+    }
+    return nullptr;
 }
 
 // --- emitting pointers directly into code ---
@@ -1896,7 +1906,7 @@ static Value *emit_arrayptr(jl_codectx_t &ctx, const jl_cgval_t &tinfo, bool isb
 static Value *emit_unsafe_arrayptr(jl_codectx_t &ctx, const jl_cgval_t &tinfo, bool isboxed = false)
 {
     Value *t = boxed(ctx, tinfo);
-    t = emit_pointer_from_objref_internal(ctx, decay_derived(t));
+    t = emit_pointer_from_objref(ctx, decay_derived(t));
     return emit_arrayptr_internal(ctx, tinfo, t, 0, isboxed);
 }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -654,7 +654,7 @@ static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
         // unsafe_store to Ptr{Any} is allowed to implicitly drop GC roots.
         thePtr = emit_unbox(ctx, T_psize, e, e.typ);
         Instruction *store = ctx.builder.CreateAlignedStore(
-          emit_pointer_from_objref(ctx, boxed(ctx, x)),
+          ctx.builder.CreatePtrToInt(emit_pointer_from_objref(ctx, boxed(ctx, x)), T_size),
             ctx.builder.CreateGEP(T_size, thePtr, im1), align_nb);
         tbaa_decorate(tbaa_data, store);
     }


### PR DESCRIPTION
We were lying to LLVM, and it now catches that in the verifier. Stop
lying to LLVM so that it will again be happy to generate good code for
us (e.g. optimizing this to bcmp).

Aside: the code we emit for the failing test was quite bad. Also, it's worthwhile taking a look at how we handle a slight variation on the original test:
```
julia> struct LargeStruct
           x::NTuple{1024,Int8}
           LargeStruct() = new()
       end
julia> const large_struct = LargeStruct()
julia> @noinline create_large_struct() = Base.inferencebarrier(large_struct)
julia> function compare_large_struct(a)
           a = a::LargeStruct
           b = create_large_struct()::LargeStruct
           GC.gc() # compare with and without this barrier
           return a === b
       end
julia> code_llvm(compare_large_struct, Tuple{Any}, optimize=false)
julia> code_llvm(compare_large_struct, Tuple{Any}, optimize=true)
```