### PR TITLE
llvm: address v11-dev compatibility issues

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -525,7 +525,7 @@ struct jl_returninfo_t {
     unsigned return_roots;
 };
 
-static jl_returninfo_t get_specsig_function(Module *M, const std::string &name, jl_value_t *sig, jl_value_t *jlrettype);
+static jl_returninfo_t get_specsig_function(Module *M, StringRef name, jl_value_t *sig, jl_value_t *jlrettype);
 
 // information about the context of a piece of code: its enclosing
 // function and module, and visible local variables and labels.
@@ -1840,7 +1840,7 @@ static void write_log_data(logdata_t &logData, const char *extension)
     base = base + "/../share/julia/base/";
     logdata_t::iterator it = logData.begin();
     for (; it != logData.end(); it++) {
-        std::string filename = it->first();
+        std::string filename(it->first());
         std::vector<logdata_block*> &values = it->second;
         if (!values.empty()) {
             if (!isabspath(filename.c_str()))
@@ -1898,12 +1898,10 @@ static void write_lcov_data(logdata_t &logData, const std::string &outfile)
     //base = base + "/../share/julia/base/";
     logdata_t::iterator it = logData.begin();
     for (; it != logData.end(); it++) {
-        const std::string &filename = it->first();
+        StringRef filename = it->first();
         const std::vector<logdata_block*> &values = it->second;
         if (!values.empty()) {
-            //if (!isabspath(filename.c_str()))
-            //    filename = base + filename;
-            outf << "SF:" << filename << '\n';
+            outf << "SF:" << filename.str() << '\n';
             size_t n_covered = 0;
             size_t n_instrumented = 0;
             size_t lno = 0;
@@ -5420,7 +5418,7 @@ static bool uses_specsig(jl_value_t *sig, size_t nreq, jl_value_t *rettype, bool
     return false; // jlcall sig won't require any box allocations
 }
 
-static jl_returninfo_t get_specsig_function(Module *M, const std::string &name, jl_value_t *sig, jl_value_t *jlrettype)
+static jl_returninfo_t get_specsig_function(Module *M, StringRef name, jl_value_t *sig, jl_value_t *jlrettype)
 {
     jl_returninfo_t props = {};
     SmallVector<Type*, 8> fsig;

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -74,7 +74,7 @@ struct ObjectInfo {
 // so that when we see it get emitted, we can add a link back to the linfo
 // that it came from (providing name, type signature, file info, etc.)
 static StringMap<jl_code_instance_t*> ncode_in_flight;
-static std::string mangle(const std::string &Name, const DataLayout &DL)
+static std::string mangle(StringRef Name, const DataLayout &DL)
 {
     std::string MangledName;
     {
@@ -945,7 +945,7 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
         if (objpath.empty()) {
             // Fall back to simple path relative to the dynamic library.
             size_t sep = fname.rfind('/');
-            debuginfopath = fname;
+            debuginfopath = fname.str();
             debuginfopath += ".dSYM/Contents/Resources/DWARF/";
             debuginfopath += fname.substr(sep + 1);
             objpath = debuginfopath;
@@ -977,12 +977,12 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
                 // that can be ignored.
                 ignoreError(DebugInfo);
                 if (fname.substr(sep + 1) != info.filename) {
-                    debuginfopath = fname.substr(0, sep + 1);
+                    debuginfopath = fname.substr(0, sep + 1).str();
                     debuginfopath += info.filename;
                     DebugInfo = openDebugInfo(debuginfopath, info);
                 }
                 if (!DebugInfo) {
-                    debuginfopath = fname.substr(0, sep + 1);
+                    debuginfopath = fname.substr(0, sep + 1).str();
                     debuginfopath += ".debug/";
                     debuginfopath += info.filename;
                     ignoreError(DebugInfo);

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -334,8 +334,8 @@ void LineNumberAnnotatedWriter::emitFunctionAnnot(
     if (FuncLoc) {
         std::vector<DILineInfo> DIvec(1);
         DILineInfo &DI = DIvec.back();
-        DI.FunctionName = FuncLoc->getName();
-        DI.FileName = FuncLoc->getFilename();
+        DI.FunctionName = FuncLoc->getName().str();
+        DI.FileName = FuncLoc->getFilename().str();
         DI.Line = FuncLoc->getLine();
         LinePrinter.emit_lineinfo(Out, DIvec);
     }
@@ -358,8 +358,8 @@ void LineNumberAnnotatedWriter::emitInstructionAnnot(
             DILineInfo &DI = DIvec.back();
             DIScope *scope = NewInstrLoc->getScope();
             if (scope)
-                DI.FunctionName = scope->getName();
-            DI.FileName = NewInstrLoc->getFilename();
+                DI.FunctionName = scope->getName().str();
+            DI.FileName = NewInstrLoc->getFilename().str();
             DI.Line = NewInstrLoc->getLine();
             NewInstrLoc = NewInstrLoc->getInlinedAt();
         } while (NewInstrLoc);
@@ -655,7 +655,7 @@ const char *SymbolTable::lookupSymbolName(uint64_t addr)
             }
         }
         else {
-            Sym->second = local_name;
+            Sym->second = local_name.str();
         }
     }
     return Sym->second.empty() ? NULL : Sym->second.c_str();

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -315,7 +315,7 @@ void JuliaOJIT::DebugObjectRegistrar::registerObject(RTDyldObjHandleT H, const O
         auto NameOrError = Symbol.getName();
         assert(NameOrError);
         auto Name = NameOrError.get();
-        auto Sym = JIT.CompileLayer.findSymbolIn(H, Name, true);
+        auto Sym = JIT.CompileLayer.findSymbolIn(H, Name.str(), true);
         assert(Sym);
         // note: calling getAddress here eagerly finalizes H
         // as an alternative, we could store the JITSymbol instead
@@ -351,7 +351,7 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
                                  "The module's content was printed above. Please file a bug report");
     }
 
-    return ObjBuffer;
+    return CompilerResultT(std::move(ObjBuffer));
 }
 
 JuliaOJIT::JuliaOJIT(TargetMachine &TM)
@@ -363,7 +363,7 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM)
     ES(),
     SymbolResolver(llvm::orc::createLegacyLookupResolver(
           ES,
-          [this](const std::string& name) -> llvm::JITSymbol {
+          [this](StringRef name) -> llvm::JITSymbol {
             return this->resolveSymbol(name);
           },
           [](llvm::Error Err) {
@@ -462,7 +462,7 @@ void JuliaOJIT::removeModule(ModuleHandleT H)
     (void)CompileLayer.removeModule(H);
 }
 
-JL_JITSymbol JuliaOJIT::findSymbol(const std::string &Name, bool ExportedSymbolsOnly)
+JL_JITSymbol JuliaOJIT::findSymbol(StringRef Name, bool ExportedSymbolsOnly)
 {
     void *Addr = nullptr;
     if (ExportedSymbolsOnly) {
@@ -475,12 +475,12 @@ JL_JITSymbol JuliaOJIT::findSymbol(const std::string &Name, bool ExportedSymbols
     return JL_JITSymbol((uintptr_t)Addr, JITSymbolFlags::Exported);
 }
 
-JL_JITSymbol JuliaOJIT::findUnmangledSymbol(const std::string Name)
+JL_JITSymbol JuliaOJIT::findUnmangledSymbol(StringRef Name)
 {
     return findSymbol(getMangledName(Name), true);
 }
 
-JL_JITSymbol JuliaOJIT::resolveSymbol(const std::string& Name)
+JL_JITSymbol JuliaOJIT::resolveSymbol(StringRef Name)
 {
     // Step 0: ObjectLinkingLayer has checked whether it is in the current module
     // Step 1: See if it's something known to the ExecutionEngine
@@ -490,29 +490,29 @@ JL_JITSymbol JuliaOJIT::resolveSymbol(const std::string& Name)
         return Sym;
     }
     // Step 2: Search the program symbols
-    if (uint64_t addr = SectionMemoryManager::getSymbolAddressInProcess(Name))
+    if (uint64_t addr = SectionMemoryManager::getSymbolAddressInProcess(Name.str()))
         return JL_SymbolInfo(addr, JITSymbolFlags::Exported);
 #if defined(_OS_LINUX_) || defined(_OS_WINDOWS_) || defined(_OS_FREEBSD_)
-    if (uint64_t addr = resolve_atomic(Name.c_str()))
+    if (uint64_t addr = resolve_atomic(Name.str().c_str()))
         return JL_SymbolInfo(addr, JITSymbolFlags::Exported);
 #endif
     // Return failure code
     return JL_SymbolInfo(nullptr);
 }
 
-uint64_t JuliaOJIT::getGlobalValueAddress(const std::string &Name)
+uint64_t JuliaOJIT::getGlobalValueAddress(StringRef Name)
 {
     auto addr = findSymbol(getMangledName(Name), false).getAddress();
     return addr ? addr.get() : 0;
 }
 
-uint64_t JuliaOJIT::getFunctionAddress(const std::string &Name)
+uint64_t JuliaOJIT::getFunctionAddress(StringRef Name)
 {
     auto addr = findSymbol(getMangledName(Name), false).getAddress();
     return addr ? addr.get() : 0;
 }
 
-Function *JuliaOJIT::FindFunctionNamed(const std::string &Name)
+Function *JuliaOJIT::FindFunctionNamed(StringRef Name)
 {
     return shadow_output->getFunction(Name);
 }
@@ -542,11 +542,11 @@ const Triple& JuliaOJIT::getTargetTriple() const
     return TM.getTargetTriple();
 }
 
-std::string JuliaOJIT::getMangledName(const std::string &Name)
+std::string JuliaOJIT::getMangledName(StringRef Name)
 {
     SmallString<128> FullName;
     Mangler::getNameWithPrefix(FullName, Name, DL);
-    return FullName.str();
+    return FullName.str().str();
 }
 
 std::string JuliaOJIT::getMangledName(const GlobalValue *GV)
@@ -707,7 +707,7 @@ void jl_finalize_function(StringRef F)
     }
 }
 
-static void jl_finalize_function(const std::string &F, Module *collector)
+static void jl_finalize_function(StringRef F, Module *collector)
 {
     std::unique_ptr<Module> m(module_for_fname.lookup(F));
     if (m) {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -87,7 +87,11 @@ typedef JITSymbol JL_JITSymbol;
 typedef JITSymbol JL_SymbolInfo;
 
 using RTDyldObjHandleT = orc::VModuleKey;
+#if JL_LLVM_VERSION >= 110000
+using CompilerResultT = Expected<orc::LegacyRTDyldObjectLinkingLayerBase::ObjectPtr>;
+#else
 using CompilerResultT = std::unique_ptr<llvm::MemoryBuffer>;
+#endif
 
 class JuliaOJIT {
     // Custom object emission notification handler for the JuliaOJIT
@@ -132,16 +136,16 @@ public:
     void *getPointerToGlobalIfAvailable(const GlobalValue *GV);
     void addModule(std::unique_ptr<Module> M);
     void removeModule(ModuleHandleT H);
-    JL_JITSymbol findSymbol(const std::string &Name, bool ExportedSymbolsOnly);
-    JL_JITSymbol findUnmangledSymbol(const std::string Name);
-    JL_JITSymbol resolveSymbol(const std::string& Name);
-    uint64_t getGlobalValueAddress(const std::string &Name);
-    uint64_t getFunctionAddress(const std::string &Name);
-    Function *FindFunctionNamed(const std::string &Name);
+    JL_JITSymbol findSymbol(StringRef Name, bool ExportedSymbolsOnly);
+    JL_JITSymbol findUnmangledSymbol(StringRef ame);
+    JL_JITSymbol resolveSymbol(StringRef Name);
+    uint64_t getGlobalValueAddress(StringRef Name);
+    uint64_t getFunctionAddress(StringRef Name);
+    Function *FindFunctionNamed(StringRef Name);
     const DataLayout& getDataLayout() const;
     const Triple& getTargetTriple() const;
 private:
-    std::string getMangledName(const std::string &Name);
+    std::string getMangledName(StringRef Name);
     std::string getMangledName(const GlobalValue *GV);
 
     TargetMachine &TM;

--- a/src/llvm-api.cpp
+++ b/src/llvm-api.cpp
@@ -8,6 +8,7 @@
 // They are not to be considered a stable API, and will be removed
 // when better package build systems are available
 
+#include "llvm-version.h"
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>
 
@@ -25,7 +26,6 @@
 #include <llvm/Transforms/IPO.h>
 
 #include "julia.h"
-#include "llvm-version.h"
 
 using namespace llvm::legacy;
 

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -1,5 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include "llvm-version.h"
+
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -9,7 +11,6 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 
-#include "llvm-version.h"
 #include "codegen_shared.h"
 #include "julia.h"
 #include "julia_internal.h"

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -3,6 +3,8 @@
 // This LLVM pass verifies invariants required for correct GC root placement.
 // See the devdocs for a description of these invariants.
 
+#include "llvm-version.h"
+
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>
 
@@ -24,7 +26,6 @@
 #include <llvm/Pass.h>
 #include <llvm/Support/Debug.h>
 
-#include "llvm-version.h"
 #include "codegen_shared.h"
 #include "julia.h"
 

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1,5 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include "llvm-version.h"
+
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>
 
@@ -24,8 +26,6 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
-
-#include "llvm-version.h"
 
 #if JL_LLVM_VERSION >= 100000
 #include <llvm/InitializePasses.h>

--- a/src/llvm-lower-handlers.cpp
+++ b/src/llvm-lower-handlers.cpp
@@ -1,5 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include "llvm-version.h"
+
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>
 
@@ -15,7 +17,6 @@
 #include <llvm/Pass.h>
 #include <llvm/Support/Debug.h>
 
-#include "llvm-version.h"
 #include "julia.h"
 #include "julia_assert.h"
 

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -7,7 +7,6 @@
 // LLVM pass to clone function for different archs
 
 #include "llvm-version.h"
-#include "support/dtypes.h"
 
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>
@@ -29,6 +28,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 #include "processor.h"
+#include "support/dtypes.h"
 
 #include <map>
 #include <memory>
@@ -625,7 +625,7 @@ void CloneCtx::add_features(Function *F, StringRef name, StringRef features, uin
 {
     auto attr = F->getFnAttribute("target-features");
     if (attr.isStringAttribute()) {
-        std::string new_features = attr.getValueAsString();
+        std::string new_features(attr.getValueAsString());
         new_features += ",";
         new_features += features;
         F->addFnAttr("target-features", new_features);

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -5,6 +5,8 @@
 // lowering and final GC intrinsic lowering passes. See the corresponding header
 // for docs.
 
+#include "llvm-version.h"
+
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
@@ -12,7 +14,6 @@
 
 #include <iostream>
 
-#include "llvm-version.h"
 #include "codegen_shared.h"
 #include "julia_assert.h"
 #include "llvm-pass-helpers.h"

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -15,3 +15,5 @@
 #if JL_LLVM_VERSION < 100000
 #define Align(a) (a)
 #endif
+
+#define LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING 0

--- a/src/llvmcalltest.cpp
+++ b/src/llvmcalltest.cpp
@@ -1,7 +1,8 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#include "../src/support/platform.h"
-#include "../src/support/dtypes.h"
+#include "llvm-version.h"
+#include "support/platform.h"
+#include "support/dtypes.h"
 
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/IRBuilder.h"


### PR DESCRIPTION
LLVM is unabashedly creating more nuisance renaming changes than covered here (https://groups.google.com/forum/#!topic/llvm-dev/DZRKP9qriZU), so the last known good commit is e252293d0629066225228596a9ef9d397513eb99. But this is a start towards staying functional.