### PR TITLE
[contrib/mac/app]: Add renotarization script

### DIFF
--- a/contrib/mac/app/renotarize_dmg.sh
+++ b/contrib/mac/app/renotarize_dmg.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# We need a URL
+if [[ -z "$1" ]]; then
+    echo "Usage: $0 <julia DMG url>" >&2
+    exit 1
+fi
+
+# You need to define these in your environment
+if [[ -z "${APPLEID}" ]] || [[ -z "${APPLEID_PASSWORD}" ]]; then
+    echo "You must define APPLEID and APPLEID_PASSWORD in your environment!" >&2
+    exit 1
+fi
+
+# Download .dmg
+curl -L "$1" -O
+
+# Unpack dmg into our `dmg` folder
+rm -rf dmg
+
+# Copy app over to our `dmg` folder
+for j in /Volumes/Julia-*; do hdiutil detach "${j}"; done
+hdiutil mount "$(basename "$1")"
+cp -Ra /Volumes/Julia-* dmg
+
+# Override some important Makefile variables
+DMG_NAME=$(basename "$1")
+APP_NAME=$(basename dmg/*.app)
+VOL_NAME=$(basename /Volumes/Julia-*)
+# Unmount everything again
+for j in /Volumes/Julia-*; do hdiutil detach "${j}"; done
+
+# Run notarization
+make notarize "DMG_NAME=${DMG_NAME}" "APP_NAME=${APP_NAME}" "VOL_NAME=${VOL_NAME}"


### PR DESCRIPTION
This makes renotarizing any modern release of Julia as easy as running `renotarize_dmg.sh <url>`, provided you have the necessary environment variables defined.  Note that I don't think this will work on older versions of Julia, as we didn't codesign with the proper flags before 1.3.X; so those actually require a rebuild and it's a more in-depth process.