### PR TITLE
Don't load startup.jl when building docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ julia-debug julia-release : julia-% : julia-sysimg-% julia-symlink julia-libccal
 debug release : % : julia-%
 
 docs: julia-sysimg-$(JULIA_BUILD_MODE)
-	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/doc JULIA_EXECUTABLE='$(call spawn,$(JULIA_EXECUTABLE_$(JULIA_BUILD_MODE)))'
+	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/doc JULIA_EXECUTABLE='$(call spawn,$(JULIA_EXECUTABLE_$(JULIA_BUILD_MODE))) --startup-file=no'
 
 check-whitespace:
 ifneq ($(NO_GIT), 1)


### PR DESCRIPTION
Currently, when you run `make docs`, it will also load your `startup.jl`. `doc/Makefile` actually already sets `--startup-file=no`:

https://github.com/JuliaLang/julia/blob/e36fe95a639c6956aa39367bef8e727b174e52b2/doc/Makefile#L10

But this gets lost when we pass `JULIA_EXECUTABLE` in the main `Makefile. Hence this change.

Alternatively, we could also solve this in `doc/Makefile` by always explicitly setting `--startup-file=no` there, even if `JULIA_EXECUTABLE` is overridden. E.g.:

```make
JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
JULIA_COMMAND := $(JULIA_EXECUTABLE) --startup-file=no --color=yes

# ...

html: deps
	$(JULIA_COMMAND) $(call cygpath_w,$(SRCDIR)/make.jl) $(DOCUMENTER_OPTIONS)

# ...
```

Happy to update the PR if you think the alternative would be better.