### PR TITLE
Documentation: Mention `Vararg{Any, N}` in the "Performance Tips" section of the manual

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -534,6 +534,11 @@ but this will:
 g_vararg(x::Vararg{Int, N}) where {N} = tuple(x...)
 ```
 
+This will also specialize, and is useful when the arguments are not all of the same type:
+```julia
+h_vararg(x::Vararg{<:Any, N}) where {N} = tuple(x...)
+```
+
 Note that [`@code_typed`](@ref) and friends will always show you specialized code, even if Julia
 would not normally specialize that method call. You need to check the
 [method internals](@ref ast-lowered-method) if you want to see whether specializations are generated

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -536,7 +536,7 @@ g_vararg(x::Vararg{Int, N}) where {N} = tuple(x...)
 
 This will also specialize, and is useful when the arguments are not all of the same type:
 ```julia
-h_vararg(x::Vararg{<:Any, N}) where {N} = tuple(x...)
+h_vararg(x::Vararg{Any, N}) where {N} = tuple(x...)
 ```
 
 Note that [`@code_typed`](@ref) and friends will always show you specialized code, even if Julia

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -534,7 +534,7 @@ but this will:
 g_vararg(x::Vararg{Int, N}) where {N} = tuple(x...)
 ```
 
-This will also specialize, and is useful when the arguments are not all of the same type:
+One only needs to introduce a single type parameter to force specialization, even if the other types are unconstrained. For example, this will also specialize, and is useful when the arguments are not all of the same type:
 ```julia
 h_vararg(x::Vararg{Any, N}) where {N} = tuple(x...)
 ```


### PR DESCRIPTION
This pull request adds two lines to the "Performance Tips" section of the manual to explain that `Vararg{Any, N}` can be used to force specialization on varargs.

I'm not sure if this should be `Vararg{<:Any, N}` or `Vararg{Any, N}`. They both seem to force specialization, so I'm not sure if there is any difference between the two.

Hat tip to @tkf for showing me that this works.