### PR TITLE
Update operators.jl

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -27,7 +27,7 @@ false
 
 Supertype operator, equivalent to `T2 <: T1`.
 """
-const (>:)(@nospecialize(a), @nospecialize(b)) = (b <: a)
+(>:)(@nospecialize(a), @nospecialize(b)) = (b <: a)
 
 """
     supertype(T::DataType)


### PR DESCRIPTION
why need `const` for operator definition? `>:` is the only operator that has `const`