### PR TITLE
remove error when calling fieldtype on a Module

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -885,8 +885,6 @@ JL_CALLABLE(jl_f_fieldtype)
     }
     JL_NARGS(fieldtype, 2, 2);
     jl_datatype_t *st = (jl_datatype_t*)args[0];
-    if (st == jl_module_type)
-        jl_error("cannot assign variables in other modules");
     return get_fieldtype(args[0], args[1], 1);
 }
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -804,3 +804,7 @@ end
 
     GC.safepoint()
 end
+
+@testset "fieldtypes Module" begin
+    @test fieldtypes(Module) isa Tuple
+end


### PR DESCRIPTION
This was added in https://github.com/JuliaLang/julia/commit/8f08a1f8bf11628e0dff8ad1a76923e2de9e99e6 to fix https://github.com/JuliaLang/julia/issues/13021 but it doesn't seem to be needed anymore.

Fixes https://github.com/JuliaLang/julia/issues/33347.