### PR TITLE
Fix #34316

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -630,7 +630,7 @@ hypot(x::Number, y::Number) = hypot(promote(x, y)...)
 hypot(x::Complex, y::Complex) = hypot(abs(x), abs(y))
 hypot(x::T, y::T) where {T<:Real} = hypot(float(x), float(y))
 function hypot(x::T, y::T) where {T<:Number}
-    #Return Inf if either or both imputs is Inf (Compliance with IEEE754)
+    # Return Inf if either or both inputs is Inf (Compliance with IEEE754)
     if isinf(x) || isinf(y)
         return T(Inf)
     end
@@ -639,7 +639,7 @@ function hypot(x::T, y::T) where {T<:Number}
 end
 
 function hypot(x::T, y::T) where T<:AbstractFloat
-    #Return Inf if either or both imputs is Inf (Compliance with IEEE754)
+    # Return Inf if either or both inputs is Inf (Compliance with IEEE754)
     if isinf(x) || isinf(y)
         return T(Inf)
     end

--- a/base/math.jl
+++ b/base/math.jl
@@ -630,12 +630,14 @@ hypot(x::Number, y::Number) = hypot(promote(x, y)...)
 hypot(x::Complex, y::Complex) = hypot(abs(x), abs(y))
 hypot(x::T, y::T) where {T<:Real} = hypot(float(x), float(y))
 function hypot(x::T, y::T) where {T<:Number}
-    # Return Inf if either or both inputs is Inf (Compliance with IEEE754)
-    if isinf(x) || isinf(y)
-        return T(Inf)
-    end
+    if !iszero(x)
+        z = y/x
+        z2 = z*z
 
-    !iszero(x) ? (z = y/x; abs(x) * sqrt(oneunit(z) + z*z)) : abs(y)
+        abs(x) * sqrt(oneunit(z2) + z2)
+    else
+        abs(y)
+    end
 end
 
 function hypot(x::T, y::T) where T<:AbstractFloat

--- a/base/math.jl
+++ b/base/math.jl
@@ -629,7 +629,15 @@ julia> hypot(3, 4im)
 hypot(x::Number, y::Number) = hypot(promote(x, y)...)
 hypot(x::Complex, y::Complex) = hypot(abs(x), abs(y))
 hypot(x::T, y::T) where {T<:Real} = hypot(float(x), float(y))
-hypot(x::T, y::T) where {T<:Number} = (z = y/x; abs(x) * sqrt(one(z) + z*z))
+function hypot(x::T, y::T) where {T<:Number}
+    #Return Inf if either or both imputs is Inf (Compliance with IEEE754)
+    if isinf(x) || isinf(y)
+        return T(Inf)
+    end
+
+    !iszero(x) ? (z = y/x; abs(x) * sqrt(oneunit(z) + z*z)) : abs(y)
+end
+
 function hypot(x::T, y::T) where T<:AbstractFloat
     #Return Inf if either or both imputs is Inf (Compliance with IEEE754)
     if isinf(x) || isinf(y)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1046,7 +1046,4 @@ end
     using .Main.Furlongs
     @test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)
     @test hypot(Furlong(3), Furlong(4)) == Furlong(5.0)
-    @test hypot(Furlong(NaN), Furlong(Inf)) == Furlong(Inf)
-    @test hypot(Furlong(Inf), Furlong(NaN)) == Furlong(Inf)
-    @test hypot(Furlong(Inf), Furlong(Inf)) == Furlong(Inf)
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1035,10 +1035,18 @@ end
     end
 end
 
-isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
-using .Main.Furlongs
-@test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)
-@test hypot(Furlong(3), Furlong(4)) == Furlong(5.0)
-@test hypot(Furlong(NaN), Furlong(Inf)) == Furlong(Inf)
-@test hypot(Furlong(Inf), Furlong(NaN)) == Furlong(Inf)
-@test hypot(Furlong(Inf), Furlong(Inf)) == Furlong(Inf)
+@testset "hypot" begin
+    @test hypot(0, 0) == 0.0
+    @test hypot(3, 4) == 5.0
+    @test hypot(NaN, Inf) == Inf
+    @test hypot(Inf, NaN) == Inf
+    @test hypot(Inf, Inf) == Inf
+
+    isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
+    using .Main.Furlongs
+    @test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)
+    @test hypot(Furlong(3), Furlong(4)) == Furlong(5.0)
+    @test hypot(Furlong(NaN), Furlong(Inf)) == Furlong(Inf)
+    @test hypot(Furlong(Inf), Furlong(NaN)) == Furlong(Inf)
+    @test hypot(Furlong(Inf), Furlong(Inf)) == Furlong(Inf)
+end

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -46,8 +46,8 @@ for f in (:real,:imag,:complex,:+,:-)
     @eval Base.$f(x::Furlong{p}) where {p} = Furlong{p}($f(x.val))
 end
 
-import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^, hypot
-for op in (:+, :-, :hypot)
+import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^
+for op in (:+, :-)
     @eval function $op(x::Furlong{p}, y::Furlong{p}) where {p}
         v = $op(x.val, y.val)
         Furlong{p}(v)


### PR DESCRIPTION
The differences between the proposed solution in https://github.com/JuliaLang/julia/issues/34771#issue-565766128 are

- use `oneunit` instead of `one` (see https://github.com/PainterQubits/Unitful.jl/issues/291)
- add a check for `isinf` in order to have a similar behavior with the unitless case. Should this be done more generally with something like the following?
```julia
function hypot(x, y)
    #Return Inf if either or both inputs is Inf
    if isinf(x) || isinf(y)
        return promote_type(typeof(x), typeof(y))(Inf)
    end

    hypot(x, y)
end
```
- remove the `hypot` definition from `Furlongs`. I looked at why the tests were passing with the previous definition of `hypot` and I discovered that the fallback was not actually tested because of the additional method.