### PR TITLE
WIP/RFC: add 2-argument `get` returning `Union{Nothing,Some}`

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -500,6 +500,16 @@ function hash(a::AbstractDict, h::UInt)
     hash(hv, h)
 end
 
+function get(default::Callable, d::AbstractDict, key)
+    val = get(d, key)
+    val === nothing ? default() : something(val)
+end
+
+function get(d::AbstractDict, key, default)
+    val = get(d, key)
+    val === nothing ? default : something(val)
+end
+
 function getindex(t::AbstractDict, key)
     v = get(t, key, secret_table_token)
     if v === secret_table_token

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -66,6 +66,7 @@ include("array.jl")
 include("abstractarray.jl")
 
 # core structures
+include("some.jl")
 include("bitarray.jl")
 include("bitset.jl")
 include("abstractdict.jl")

--- a/base/env.jl
+++ b/base/env.jl
@@ -78,6 +78,7 @@ const ENV = EnvDict()
 
 getindex(::EnvDict, k::AbstractString) = access_env(k->throw(KeyError(k)), k)
 get(::EnvDict, k::AbstractString, def) = access_env(k->def, k)
+get(::EnvDict, k::AbstractString) = (v = get(ENV, k, nothing); v === nothing ? v : Some(v))
 get(f::Callable, ::EnvDict, k::AbstractString) = access_env(k->f(), k)
 in(k::AbstractString, ::KeySet{String, EnvDict}) = _hasenv(k)
 pop!(::EnvDict, k::AbstractString) = (v = ENV[k]; _unsetenv(k); v)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -249,8 +249,7 @@ keys(v::Pairs) = v.itr
 values(v::Pairs) = v.data
 getindex(v::Pairs, key) = v.data[key]
 setindex!(v::Pairs, value, key) = (v.data[key] = value; v)
-get(v::Pairs, key, default) = get(v.data, key, default)
-get(f::Base.Callable, v::Pairs, key) = get(f, v.data, key)
+get(v::Pairs, key) = get(v.data, key)
 
 # zip
 

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -86,14 +86,22 @@ end
 
 function getkey(wkh::WeakKeyDict{K}, kk, default) where K
     return lock(wkh) do
-        k = getkey(wkh.ht, kk, secret_table_token)
-        k === secret_table_token && return default
-        return k.value::K
+        k = getkey(wkh.ht, kk)
+        k === nothing && return default
+        return something(k).value::K
+    end
+end
+
+function getkey(wkh::WeakKeyDict{K}, kk) where K
+    return lock(wkh) do
+        k = getkey(wkh.ht, kk)
+        k === nothing && return nothing
+        return Some(something(k).value::K)
     end
 end
 
 map!(f,iter::ValueIterator{<:WeakKeyDict})= map!(f, values(iter.dict.ht))
-get(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> get(wkh.ht, key, default), wkh)
+get(wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get(wkh.ht, key), wkh)
 get(default::Callable, wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get(default, wkh.ht, key), wkh)
 function get!(wkh::WeakKeyDict{K}, key, default) where {K}
     !isa(key, K) && throw(ArgumentError("$(limitrepr(key)) is not a valid key for type $K"))

--- a/src/iddict.c
+++ b/src/iddict.c
@@ -159,6 +159,17 @@ jl_value_t *jl_eqtable_get(jl_array_t *h, jl_value_t *key, jl_value_t *deflt)
 }
 
 JL_DLLEXPORT
+jl_value_t *jl_eqtable_get1(jl_array_t *h, jl_value_t *key, int *found)
+{
+    void **bp = jl_table_peek_bp(h, key);
+    if (found)
+        *found = (bp != NULL);
+    if (bp == NULL)
+        return jl_nothing;
+    return (jl_value_t *)*bp;
+}
+
+JL_DLLEXPORT
 jl_value_t *jl_eqtable_pop(jl_array_t *h, jl_value_t *key, jl_value_t *deflt, int *found)
 {
     void **bp = jl_table_peek_bp(h, key);


### PR DESCRIPTION
This form is a bit more general, and would eventually allow us to eliminate the loathsome `secret_table_token`.

Obviously incomplete; we should first discuss whether we want this.