### PR TITLE
Fix maybe-bug in sparsevec, more tests

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -813,7 +813,7 @@ function getindex(x::AbstractSparseVector{Tv,Ti}, I::AbstractUnitRange) where {T
 end
 
 getindex(x::AbstractSparseVector, I::AbstractVector{Bool}) = x[findall(I)]
-getindex(x::AbstractSparseVector, I::AbstractArray{Bool}) = x[findall(I)]
+getindex(x::AbstractSparseVector, I::AbstractArray{Bool}) = x[LinearIndices(I)[findall(I)]]
 @inline function getindex(x::AbstractSparseVector{Tv,Ti}, I::AbstractVector) where {Tv,Ti}
     # SparseMatrixCSC has a nicely optimized routine for this; punt
     S = SparseMatrixCSC(length(x::SparseVector), 1, Ti[1,length(nonzeroinds(x))+1], nonzeroinds(x), nonzeros(x))

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -174,6 +174,7 @@ end
             @test sprand(r1, 100, .9) == sprand(r2, 100, .9)
             @test sprandn(r1, 100, .9) == sprandn(r2, 100, .9)
             @test sprand(r1, Bool, 100, .9) == sprand(r2,  Bool, 100, .9)
+            @test sprandn(r1, Float16, 100, .9) == sprandn(r2,  Float16, 100, .9)
         end
 
         # test sprand with function inputs
@@ -249,6 +250,14 @@ end
             @test isa(r, SparseVector{Float64,Int})
             @test all(!iszero, nonzeros(r))
             @test Array(r) == Array(x)[bI]
+            bI = falses(length(x), 1) # AbstractArray rather than AbstractVector
+            bI[I, 1] .= true
+            r = x[bI]
+            @test isa(r, SparseVector{Float64,Int})
+            @test all(!iszero, nonzeros(r))
+            bIv = falses(length(x))
+            bIv[I] .= true
+            @test Array(r) == Array(x)[bIv]
         end
     end
 end


### PR DESCRIPTION
With the old version of this `getindex`:

```
julia> bI = falses(length(x), 1)
10×1 BitArray{2}:
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0

julia> bI[I] .= true
5-element view(::BitArray{1}, [9, 9, 6, 9, 8]) with eltype Bool:
 1
 1
 1
 1
 1

julia> r = x[bI]
ERROR: MethodError: no method matching isless(::CartesianIndex{2}, ::Int64)
Closest candidates are:
  isless(::Missing, ::Any) at missing.jl:87
  isless(::AbstractFloat, ::Real) at operators.jl:158
  isless(::Real, ::Real) at operators.jl:346
  ...
Stacktrace:
 [1] <(::CartesianIndex{2}, ::Int64) at ./operators.jl:268
 [2] getindex(::SparseMatrixCSC{Float64,Int64}, ::Array{CartesianIndex{2},1}, ::Array{Int64,1}) at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsematrix.jl:2377
 [3] getindex at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsevector.jl:544 [inlined]
 [4] getindex at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsevector.jl:820 [inlined]
 [5] getindex(::SparseVector{Float64,Int64}, ::BitArray{2}) at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsevector.jl:816
 [6] top-level scope at REPL[8]:1

julia> bI[I, 1] .= true
5-element view(::BitArray{2}, [9, 9, 6, 9, 8], 1) with eltype Bool:
 1
 1
 1
 1
 1

julia> r = x[bI]
ERROR: MethodError: no method matching isless(::CartesianIndex{2}, ::Int64)
Closest candidates are:
  isless(::Missing, ::Any) at missing.jl:87
  isless(::AbstractFloat, ::Real) at operators.jl:158
  isless(::Real, ::Real) at operators.jl:346
  ...
Stacktrace:
 [1] <(::CartesianIndex{2}, ::Int64) at ./operators.jl:268
 [2] getindex(::SparseMatrixCSC{Float64,Int64}, ::Array{CartesianIndex{2},1}, ::Array{Int64,1}) at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsematrix.jl:2377
 [3] getindex at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsevector.jl:544 [inlined]
 [4] getindex at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsevector.jl:820 [inlined]
 [5] getindex(::SparseVector{Float64,Int64}, ::BitArray{2}) at /Users/khyatt/julia/master/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsevector.jl:816
 [6] top-level scope at REPL[10]:1
```

Now it works ... hopefully this is the intended behavior.