### PR TITLE
add filesystem tests to try to increase coverage

### DIFF
--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -21,14 +21,15 @@ mktempdir() do dir
 
   # test filesystem futime
   file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
-  Base.Filesystem.futime(file, 1.0, 1.0)
+  Base.Filesystem.futime(file, 1.0, 2.0)
+  @test Base.Filesystem.stat(file).mtime == 2.0
   close(file)
 
   # test filesystem readbytes!
   file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
-  res = zeros(UInt8,20*4)
+  res = ones(UInt8, 80)
   Base.Filesystem.readbytes!(file, res)
-  res[1] == 0x31
+  @test res == UInt8[text..., (i > 20 for i in (length(text) + 1):length(res))...]
   close(file)
 
 end

--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -1,0 +1,34 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+mktempdir() do dir
+
+  # Create test file
+  filename = joinpath(dir, "file.txt")
+  text = "123456"
+  write(filename, text)
+
+  # test filesystem truncate (shorten)
+  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+  Base.Filesystem.truncate(file, 2)
+  @test length(read(file)) == 2
+  close(file)
+
+  # test filesystem truncate (lengthen)
+  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+  Base.Filesystem.truncate(file, 20)
+  @test length(read(file)) == 20
+  close(file)
+
+  # test filesystem futime
+  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+  Base.Filesystem.futime(file, 1.0, 1.0)
+  close(file)
+
+  # test filesystem readbytes!
+  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+  res = zeros(UInt8,20*4)
+  Base.Filesystem.readbytes!(file, res)
+  res[1] == 0x31
+  close(file)
+
+end


### PR DESCRIPTION
When looking around, I couldn't help but notice some functions in base/filesystem.jl didn't seem to have [test coverage](https://coveralls.io/builds/28847289/source?filename=base/filesystem.jl).

I'm almost certain that, as is, these aren't particularly good or effective tests, but I thought it was a reasonable starting place. I'm certainly willing to edit with feedback.