### PR TITLE
Define g ⨟ f = f ∘ g

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -193,6 +193,7 @@ export
     :,
     =>,
     ∘,
+    ⨟,
 
 # scalar math
     @evalpoly,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -833,6 +833,7 @@ entered in the Julia REPL (and most editors, appropriately configured) by typing
 Function composition also works in prefix form: `∘(f, g)` is the same as `f ∘ g`.
 The prefix form supports composition of multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
 and splatting `∘(fs...)` for composing an iterable collection of functions.
+See also [`⨟`](@ref) for composition in the reversed order.
 
 !!! compat "Julia 1.4"
     Multiple function composition requires at least Julia 1.4.
@@ -863,6 +864,24 @@ function ∘ end
 ∘(f) = f
 ∘(f, g) = (x...)->f(g(x...))
 ∘(f, g, h...) = ∘(f ∘ g, h...)
+
+"""
+    g ⨟ f
+
+Compose functions in the "opposite order": i.e. `(g ⨟ f)(args...)` means `f(g(args...))`.
+Composition `g ⨟ f` is defined as [`f ∘ g`](@ref ∘).
+
+!!! compat "Julia 1.5"
+    Opposite composition `⨟` requires at least Julia 1.5.
+
+# Examples
+```jldoctest
+julia> 1 |> (x -> 2x) ⨟ string
+"2"
+```
+"""
+function ⨟ end
+⨟(fs...) = ∘(reverse(fs)...)
 
 """
     !f::Function

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -233,6 +233,7 @@ Base.invokelatest
 new
 Base.:(|>)
 Base.:(∘)
+Base.:(⨟)
 ```
 
 ## Syntax

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -133,6 +133,11 @@ Base.promote_rule(::Type{T19714}, ::Type{Int}) = T19714
     @test ∘(FreeMagma(1), FreeMagma(2)) === FreeMagma((1,2))
     @test ∘(FreeMagma(1), FreeMagma(2), FreeMagma(3)) === FreeMagma(((1,2), 3))
     @test ∘(FreeMagma(1), FreeMagma(2), FreeMagma(3), FreeMagma(4)) === FreeMagma((((1,2), 3), 4))
+
+    @test ⨟(FreeMagma(1)) === FreeMagma(1)
+    @test ⨟(FreeMagma(1), FreeMagma(2)) === FreeMagma((2,1))
+    @test ⨟(FreeMagma(1), FreeMagma(2), FreeMagma(3)) === FreeMagma(((3,2), 1))
+    @test ⨟(FreeMagma(1), FreeMagma(2), FreeMagma(3), FreeMagma(4)) === FreeMagma((((4,3), 2), 1))
 end
 
 @testset "function negation" begin


### PR DESCRIPTION
This PR adds a simple definition `⨟(fs...) = ∘(reverse(fs)...)` to the new operator added in #34722.  This is useful for abstracting out pipelined operations like `x |> f |> g |> h` as `f ⨟ g ⨟ h`. For example:

```julia
mapping(f) = xs -> Base.Generator(f, xs)
filtering(f) = xs -> Iterators.filter(f, xs)
partitioning(n) = xs -> Iterators.partition(xs, n)
using Base.Iterators: flatten

# Iterator-to-iterator transformation to do some normalization and filtering
# with sliding window (a toy example):
ixf = partitioning(10) ⨟
    mapping(x -> (x , mean(x))) ⨟
    filtering(((_, m),) -> m > 0) ⨟
    mapping(((x, m),) -> x ./ m) ⨟
    flatten

collect(ixf(randn(100)))
```

cc @jw3126 @schlichtanders @ararslan
