### PR TITLE
Remove spurious warnings with g++-7.4.0

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -884,7 +884,6 @@ JL_CALLABLE(jl_f_fieldtype)
         nargs -= 1;
     }
     JL_NARGS(fieldtype, 2, 2);
-    jl_datatype_t *st = (jl_datatype_t*)args[0];
     return get_fieldtype(args[0], args[1], 1);
 }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2016,7 +2016,7 @@ static Value *emit_array_nd_index(
     for (size_t k = 0; k < nidxs; k++) {
         idxs[k] = emit_unbox(ctx, T_size, argv[k], (jl_value_t*)jl_long_type); // type asserted by caller
     }
-    Value *ii;
+    Value *ii = NULL;
     for (size_t k = 0; k < nidxs; k++) {
         ii = ctx.builder.CreateSub(idxs[k], ConstantInt::get(T_size, 1));
         i = ctx.builder.CreateAdd(i, ctx.builder.CreateMul(ii, stride));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3538,7 +3538,7 @@ static jl_cgval_t emit_global(jl_codectx_t &ctx, jl_sym_t *sym)
 
 static jl_cgval_t emit_isdefined(jl_codectx_t &ctx, jl_value_t *sym)
 {
-    Value *isnull;
+    Value *isnull = NULL;
     if (jl_is_slot(sym)) {
         size_t sl = jl_slot_number(sym) - 1;
         jl_varinfo_t &vi = ctx.slots[sl];
@@ -3655,7 +3655,7 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
     }
     if (vi.boxroot != NULL) {
         Instruction *boxed = ctx.builder.CreateLoad(T_prjlvalue, vi.boxroot, vi.isVolatile);
-        Value *box_isnull;
+        Value *box_isnull = NULL;
         if (vi.usedUndef)
             box_isnull = ctx.builder.CreateICmpNE(boxed, maybe_decay_untracked(V_null));
         maybe_mark_load_dereferenceable(boxed, vi.usedUndef || vi.pTIndex, typ);
@@ -5298,7 +5298,7 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
     size_t nfargs = ftype->getNumParams();
     Value **args = (Value**) alloca(nfargs * sizeof(Value*));
     unsigned idx = 0;
-    AllocaInst *result;
+    AllocaInst *result = NULL;
     switch (f.cc) {
     case jl_returninfo_t::Boxed:
     case jl_returninfo_t::Register:
@@ -6499,7 +6499,7 @@ static std::unique_ptr<Module> emit_function(
             }
 
             Value *isboxed_union = NULL;
-            Value *retval;
+            Value *retval = NULL;
             Value *sret = has_sret ? f->arg_begin() : NULL;
             Type *retty = f->getReturnType();
             switch (returninfo.cc) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -370,6 +370,7 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM)
             cantFail(std::move(Err), "resolveSymbol failed");
           })),
     ObjectLayer(
+        AcknowledgeORCv1Deprecation,
         ES,
         [this](RTDyldObjHandleT) {
                       ObjLayerT::Resources result;
@@ -380,6 +381,7 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM)
         std::ref(registrar)
         ),
     CompileLayer(
+            AcknowledgeORCv1Deprecation,
             ObjectLayer,
             CompilerT(this)
         )


### PR DESCRIPTION
* Unused variable
* Potentially uninitialized pointers
* Acknowledge LLVM ORCJIT v1 deprecations