### PR TITLE
timing.c needs to include `julia_internal.h` for `cycleclock`

### DIFF
--- a/src/timing.c
+++ b/src/timing.c
@@ -2,6 +2,7 @@
 
 #include <inttypes.h>
 #include "julia.h"
+#include "julia_internal.h"
 #include "options.h"
 #include "stdio.h"
 


### PR DESCRIPTION
The function was moved by 65b8e7ed72541d1dd5bc1f4dcabc5245e1dba718