### PR TITLE
Always optimize Float.([32 64]) exponentiation by.(-1:3)

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -896,8 +896,22 @@ end
     end
     z
 end
-@inline ^(x::Float64, y::Integer) = ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, Float64(y))
-@inline ^(x::Float32, y::Integer) = ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, Float32(y))
+@inline function ^(x::Float64, y::Integer)
+    y == -1 && return inv(x)
+    y == 0 && return one(x)
+    y == 1 && return x
+    y == 2 && return x*x
+    y == 3 && return x*x*x
+    ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, Float64(y))
+end
+@inline function ^(x::Float32, y::Integer)
+    y == -1 && return inv(x)
+    y == 0 && return one(x)
+    y == 1 && return x
+    y == 2 && return x*x
+    y == 3 && return x*x*x
+    ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, Float32(y))
+end
 @inline ^(x::Float16, y::Integer) = Float16(Float32(x) ^ y)
 @inline literal_pow(::typeof(^), x::Float16, ::Val{p}) where {p} = Float16(literal_pow(^,Float32(x),Val(p)))
 


### PR DESCRIPTION
We perform these optimizations in the literal pow case, and LLVM does it when we happen to propagate constants for it, so I'd contend that they're just as worthwhile to do in the non-literal case. Calling LLVM's pow intrinsic takes ~16ns on my computer; adding these quick exits get compiled down to a simple switch statement that seems to add ~0.5ns in the cases where we don't hit the quick exits. In exchange, we get consistent numbers everywhere, they're better numbers at that (they're closer to the real answer), and these small common powers become essentially free.

(This was a hairy yak found over in #32762)

Edit: I should note I checked the other `methods(^, (Base.HWNumber, Integer))` to see if anyone else needed changing to match the `literal_pow` optimization; they all fell back the generic power by squaring which gets this right or were otherwise not applicable.