### PR TITLE
Revert "Added test for dumptype with a Concrete and Abstract type."

### DIFF
--- a/stdlib/InteractiveUtils/Project.toml
+++ b/stdlib/InteractiveUtils/Project.toml
@@ -5,8 +5,8 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [extras]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
 test = ["Test", "Random"]

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -452,16 +452,3 @@ file, ln = functionloc(versioninfo, Tuple{})
     code_native(io, eltype, Tuple{Int})
     @test occursin("eltype", String(take!(io)))
 end
-
-using InteractiveUtils: dumptype
-@testset "dumptype" begin
-	io = IOBuffer()
-	n = 1
-	indent = ""
-	dumptype(io, UInt8, n, indent)
-	# should only be UInt8 because it is a concrete type.
-	@test String(take!(io)) == "UInt8"
-	dumptype(io, Exception, n, indent)
-	# will print many because Exception is abstract, but should have TypeError.
-	@test occursin("TypeError", String(take!(io)))
-end


### PR DESCRIPTION
I don't have time at the moment to look into the actual test failure, but obviously we need to get CI back, so this reverts JuliaLang/julia#34764. If somebody else comes up with a proper fix first, obviously merge that instead.