### PR TITLE
add compat annotation to NamedTuple macro docs

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -350,6 +350,9 @@ julia> @NamedTuple begin
        end
 NamedTuple{(:a, :b),Tuple{Float64,String}}
 ```
+
+!!! compat "Julia 1.5"
+    This macro is available as of Julia 1.5.
 """
 macro NamedTuple(ex)
     Meta.isexpr(ex, :braces) || Meta.isexpr(ex, :block) ||


### PR DESCRIPTION
(Missing from #34548.)