### PR TITLE
Add file name to all top level line number nodes

### DIFF
--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -66,10 +66,7 @@
                            ;; for error, get most recent line number (#16720)
                            (lineno (if iserr (input-port-line io) lineno))
                            (next   (list* expr
-                                          ;; include filename in first line node
-                                          (if (null? exprs)
-                                              `(line ,lineno ,(symbol filename))
-                                              `(line ,lineno))
+                                          `(line ,lineno ,current-filename)
                                           exprs)))
                       (if iserr
                           (cons 'toplevel (reverse! next))


### PR DESCRIPTION
This allows julia code to more easily consume the output of `jl-parse-all` and is consistent with the way line number nodes have file name information in all non-toplevel constructs.

See various mentions in #34715, eg https://github.com/JuliaLang/julia/pull/34715/files#discussion_r383156452.