### PR TITLE
optimize replace! on arrays

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -627,11 +627,15 @@ function _replace!(new::Callable, res::AbstractArray, A::AbstractArray, count::I
     if count >= length(A) # simpler loop allows for SIMD
         if res === A # for optimization only
             for i in eachindex(A)
-                @inbounds A[i] = new(A[i])
+                @inbounds Ai = A[i]
+                y = new(Ai)
+                @inbounds A[i] = y
             end
         else
             for i in eachindex(A)
-                @inbounds res[i] = new(A[i])
+                @inbounds Ai = A[i]
+                y = new(Ai)
+                @inbounds res[i] = y
             end
         end
     else

--- a/base/set.jl
+++ b/base/set.jl
@@ -625,10 +625,14 @@ end
 function _replace!(new::Callable, res::AbstractArray, A::AbstractArray, count::Int)
     c = 0
     if count >= length(A) # simpler loop allows for SIMD
-        for i in eachindex(A)
-            @inbounds Ai = A[i]
-            y = new(Ai)
-            @inbounds res[i] = y
+        if res === A # for optimization only
+            for i in eachindex(A)
+                @inbounds A[i] = new(A[i])
+            end
+        else
+            for i in eachindex(A)
+                @inbounds res[i] = new(A[i])
+            end
         end
     else
         for i in eachindex(A)


### PR DESCRIPTION
There is an unexpected inefficiency currently, e.g.:
```julia
julia> x = rand(100);
                          
julia> @btime $x .*= -1;
  27.912 ns (0 allocations: 0 bytes)

julia> @btime replace!(-, $x);
  96.327 ns (0 allocations: 0 bytes)

julia> @btime replace(-, $x);
  67.359 ns (1 allocation: 896 bytes)
```
So `replace!(-, x)` is 3 to 4 times slower than what seems to be possible (like done with `x .*= -1`), and `replace(-, x)` being faster is a clear sign something goes wrong (on Julia 1.0.5, it's slower though).

The problem is that in the main loop of `replace!`, there is something like `dst[i] = new(src[i])` (where `new == -` in the above example), and by replacing this by `src[i] = new(src[i])` when `src === dst` we get back the almost optimal performance:
```julia
julia> @btime replace!(-, $x);
  29.348 ns (0 allocations: 0 bytes)
```
I don't know if the "compiler" can reasonably easily be made to optimize itself this pattern, in which case take this PR as an issue.