### PR TITLE
Change TypeVars in UnionAlls to print as var"" syntax

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1820,16 +1820,16 @@ function show(io::IO, tv::TypeVar)
     lb, ub = tv.lb, tv.ub
     if !in_env && lb !== Bottom
         if ub === Any
-            write(io, tv.name)
+            show_unquoted(io, tv.name)
             print(io, ">:")
             show_bound(io, lb)
         else
             show_bound(io, lb)
             print(io, "<:")
-            write(io, tv.name)
+            show_unquoted(io, tv.name)
         end
     else
-        write(io, tv.name)
+        show_unquoted(io, tv.name)
     end
     if !in_env && ub !== Any
         print(io, "<:")


### PR DESCRIPTION
This changes unnamed type variables to print as valid syntax, via the `var""` printing macro introduced in #32408, as part of addressing #34887.

For example, this makes `Vector{<:Bool}` print as a valid, syntactic expression:
```julia
julia> Vector{<:Bool}
Array{var"#s46",1} where var"#s46"<:Bool
```

I'm not totally in love with this approach, since it makes the types much more verbose, but it's a good first step towards resolving #34887. I don't feel confident enough to delve into the type creation to change the type variable's actual name when instantiating the UnionAll to be a valid identifier, as proposed in #34887.