### PR TITLE
Fix assignment to 0-dim array indexed by CartesianIndices{0}

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -381,12 +381,12 @@ module IteratorsMD
     first(iter::CartesianIndices) = CartesianIndex(map(first, iter.indices))
     last(iter::CartesianIndices)  = CartesianIndex(map(last, iter.indices))
 
-    # Collapse trailing CartesianIndices{0} elements to a single instance. (Also
-    # maintains at least one for 0-dimensional indexed assignment.)
-    @inline to_indices(A, inds, I::Tuple{CartesianIndices{0},Vararg{CartesianIndices{0}}}) = (first(I),)
     # When used as indices themselves, CartesianIndices can simply become its tuple of ranges
     @inline to_indices(A, inds, I::Tuple{CartesianIndices, Vararg{Any}}) =
         to_indices(A, inds, (I[1].indices..., tail(I)...))
+    # but preserve CartesianIndices{0} as they consume a dimension.
+    @inline to_indices(A, inds, I::Tuple{CartesianIndices{0},Vararg{Any}}) =
+        (first(I), to_indices(A, inds, tail(I))...)
 
     @inline function in(i::CartesianIndex{N}, r::CartesianIndices{N}) where {N}
         _in(true, i.I, first(r).I, last(r).I)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -381,6 +381,9 @@ module IteratorsMD
     first(iter::CartesianIndices) = CartesianIndex(map(first, iter.indices))
     last(iter::CartesianIndices)  = CartesianIndex(map(last, iter.indices))
 
+    # Collapse trailing CartesianIndices{0} elements to a single instance. (Also
+    # maintains at least one for 0-dimensional indexed assignment.)
+    @inline to_indices(A, inds, I::Tuple{CartesianIndices{0},Vararg{CartesianIndices{0}}}) = (first(I),)
     # When used as indices themselves, CartesianIndices can simply become its tuple of ranges
     @inline to_indices(A, inds, I::Tuple{CartesianIndices, Vararg{Any}}) =
         to_indices(A, inds, (I[1].indices..., tail(I)...))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2684,6 +2684,24 @@ end
     end
     @test !checkbounds(Bool, rand(3,3,3), :, CartesianIndex(0,0):CartesianIndex(1,1))
     @test !checkbounds(Bool, rand(3,3,3), CartesianIndex(0,0):CartesianIndex(1,1), :)
+
+    CI0 = CartesianIndices(())
+    # 0-dimensional
+    @test setindex!(fill(0.0), fill(1.0), CI0) == fill(1.0)
+    @test setindex!(fill(0.0), fill(1.0), CI0, CI0) == fill(1.0)
+    @test setindex!(fill(0.0), fill(1.0), :, CI0) == fill(1.0)
+    @test setindex!(fill(0.0), fill(1.0), CI0, :) == fill(1.0)
+    @test setindex!(fill(0.0), fill(1.0), :, CI0, CI0) == fill(1.0)
+    @test setindex!(fill(0.0), fill(1.0), CI0, :, CI0) == fill(1.0)
+    @test setindex!(fill(0.0), fill(1.0), CI0, CI0, :) == fill(1.0)
+    @test setindex!(fill(fill(0.0)), fill(fill(1.0)), CI0) == fill(fill(1.0))
+    # 1-dimensional
+    @test setindex!(zeros(2), ones(2), :, CI0) == ones(2)
+    @test setindex!(zeros(2), ones(2), CI0, :) == ones(2)
+    @test setindex!(zeros(2), ones(2), :, CI0, CI0) == ones(2)
+    @test setindex!(zeros(2), ones(2), CI0, :, CI0) == ones(2)
+    @test setindex!(zeros(2), ones(2), CI0, CI0, :) == ones(2)
+    @test setindex!([fill(0.0)], fill(1.0), 1) == [fill(1.0)]
 end
 
 # Throws ArgumentError for negative dimensions in Array

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2702,6 +2702,12 @@ end
     @test setindex!(zeros(2), ones(2), CI0, :, CI0) == ones(2)
     @test setindex!(zeros(2), ones(2), CI0, CI0, :) == ones(2)
     @test setindex!([fill(0.0)], fill(1.0), 1) == [fill(1.0)]
+    # 0-dimensional assigment into ≥1-dimensional arrays
+    @test setindex!(zeros(2), fill(1.0), 1, CI0) == [1.0, 0.0]
+    @test setindex!(zeros(2), fill(1.0), CI0, 1) == [1.0, 0.0]
+    @test setindex!(zeros(2,2), fill(1.0), 1, 1, CI0) == [1.0 0.0; 0.0 0.0]
+    @test setindex!(zeros(2,2), fill(1.0), 1, CI0, 1) == [1.0 0.0; 0.0 0.0]
+    @test setindex!(zeros(2,2), fill(1.0), CI0, 1, 1) == [1.0 0.0; 0.0 0.0]
 end
 
 # Throws ArgumentError for negative dimensions in Array


### PR DESCRIPTION
The change in PR #31214 replaced `CartesianIndices` in the indexing tuple with their constituent ranges. This broke assignment to 0-dimensional arrays which have been indexed by a `CartesianIndices{0}`, e.g.
```julia
julia> A = fill(0.0);

julia> I = CartesianIndices(size(A));

julia> x = fill!(similar(A), 1.0);

# On v1.3
julia> A[I] = x
0-dimensional Array{Float64,0}:
1.0

# On master
julia> A[I] = x
ERROR: MethodError: Cannot `convert` an object of type Array{Float64,0} to an object of type Float64
...
```

This is because previously the `CartesianIndices{0}` (hereafter `CI0`) was preserved through the call to `to_indices()`:
```julia
# On v1.3
julia> to_indices(A, (I,))
(CartesianIndex(),)

julia> to_indices(A, (I,I))
(CartesianIndex(), CartesianIndex())

julia> to_indices(A, (I,I,I))
(CartesianIndex(), CartesianIndex(), CartesianIndex())
```
but now the empty tuple is returned instead:
```julia
# On master
julia> to_indices(A, (I,))
()

julia> to_indices(A, (I,I))
()

julia> to_indices(A, (I,I,I))
()
```
and that changes which internal implementation of `setindex!` is dispatched to.

This PR fixes the issue by tweaking the tuple reduction performed by `to_indices()`. The result is that
during the tuple reduction, a case where only [trailing] `CI0`s remain is shortcut and returns just a single `CI0` index.

With this PR:
```julia
julia> A[I] = x
0-dimensional Array{Float64,0}:
1.0

julia> to_indices(A, (I,))
(fill(CartesianIndex()),)

julia> to_indices(A, (I,I))
(fill(CartesianIndex()),)

julia> to_indices(A, (I,I,I))
(fill(CartesianIndex()),)
```

The one thing I couldn't figure out is how to avoid an unnecessary trailing `CI0` if a concrete index precedes it — (my attempts lead to `to_indices()` method ambiguities) — but there's always at most a single unnecessary trailing `CI0`.

```julia
julia> B = [1.0]
1-element Array{Float64,1}:
 1.0

julia> to_indices(B, (1, I))
(1, fill(CartesianIndex()))

julia> to_indices(B, (1, I, I))
(1, fill(CartesianIndex()))

julia> to_indices(B, (I, 1, I))
(1, fill(CartesianIndex()))

julia> to_indices(B, (I, I, 1, I))
(1, fill(CartesianIndex()))

julia> to_indices(B, (I, I, I, 1))
(1,)
```