### PR TITLE
add per-module optimization level

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@ New language features
 
 * Support for Unicode 13.0.0 (via utf8proc 2.5) ([#35282]).
 
+* The compiler optimization level can now be set per-module using the experimental macro
+  `Base.Experimental.@optlevel n`. For code that is not performance-critical, setting
+  this to 0 or 1 can provide significant latency improvements ([#34896]).
+
 Language changes
 ----------------
 

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -100,5 +100,20 @@ macro sync(block)
     end
 end
 
+"""
+    Experimental.@optlevel n::Int
+
+Set the optimization level (equivalent to the `-O` command line argument)
+for code in the current module. Submodules inherit the setting of their
+parent module.
+
+Supported values are 0, 1, 2, and 3.
+
+The effective optimization level is the minimum of that specified on the
+command line and in per-module settings.
+"""
+macro optlevel(n::Int)
+    return Expr(:meta, :optlevel, n)
+end
 
 end

--- a/src/ast.c
+++ b/src/ast.c
@@ -62,6 +62,7 @@ jl_sym_t *throw_undef_if_not_sym; jl_sym_t *getfield_undefref_sym;
 jl_sym_t *gc_preserve_begin_sym; jl_sym_t *gc_preserve_end_sym;
 jl_sym_t *coverageeffect_sym; jl_sym_t *escape_sym;
 jl_sym_t *aliasscope_sym; jl_sym_t *popaliasscope_sym;
+jl_sym_t *optlevel_sym;
 
 static uint8_t flisp_system_image[] = {
 #include <julia_flisp.boot.inc>
@@ -380,6 +381,7 @@ void jl_init_frontend(void)
     isdefined_sym = jl_symbol("isdefined");
     nospecialize_sym = jl_symbol("nospecialize");
     specialize_sym = jl_symbol("specialize");
+    optlevel_sym = jl_symbol("optlevel");
     macrocall_sym = jl_symbol("macrocall");
     escape_sym = jl_symbol("escape");
     hygienicscope_sym = jl_symbol("hygienic-scope");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5242,6 +5242,14 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
 #ifdef JL_DEBUG_BUILD
     f->addFnAttr(Attribute::StackProtectStrong);
 #endif
+
+    // add the optimization level specified for this module, if any
+    int optlevel = jl_get_module_optlevel(ctx.module);
+    if (optlevel >= 0 && optlevel <= 3) {
+        static const char* const optLevelStrings[] = { "0", "1", "2", "3" };
+        f->addFnAttr("julia-optimization-level", optLevelStrings[optlevel]);
+    }
+
     ctx.f = f;
 
     // Step 4b. determine debug info signature and other type info for locals
@@ -7464,14 +7472,7 @@ extern "C" void jl_init_llvm(void)
 #else
         None;
 #endif
-    auto optlevel =
-#ifdef DISABLE_OPT
-        CodeGenOpt::None;
-#else
-        (jl_options.opt_level < 2 ? CodeGenOpt::None :
-         jl_options.opt_level == 2 ? CodeGenOpt::Default :
-         CodeGenOpt::Aggressive);
-#endif
+    auto optlevel = CodeGenOptLevelFor(jl_options.opt_level);
     jl_TargetMachine = TheTarget->createTargetMachine(
             TheTriple.getTriple(), TheCPU, FeaturesStr,
             options,

--- a/src/dump.c
+++ b/src/dump.c
@@ -479,6 +479,7 @@ static void jl_serialize_module(jl_serializer_state *s, jl_module_t *m)
     write_uint64(s->s, m->build_id);
     write_int32(s->s, m->counter);
     write_int32(s->s, m->nospecialize);
+    write_int32(s->s, m->optlevel);
 }
 
 static int is_ir_node(jl_value_t *v)
@@ -1883,6 +1884,7 @@ static jl_value_t *jl_deserialize_value_module(jl_serializer_state *s) JL_GC_DIS
     m->build_id = read_uint64(s->s);
     m->counter = read_int32(s->s);
     m->nospecialize = read_int32(s->s);
+    m->optlevel = read_int32(s->s);
     m->primary_world = jl_world_counter;
     return (jl_value_t*)m;
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -798,6 +798,12 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                     if (jl_expr_nargs(stmt) == 1 && jl_exprarg(stmt, 0) == (jl_value_t*)specialize_sym) {
                         jl_set_module_nospecialize(s->module, 0);
                     }
+                    if (jl_expr_nargs(stmt) == 2 && jl_exprarg(stmt, 0) == (jl_value_t*)optlevel_sym) {
+                        if (jl_is_long(jl_exprarg(stmt, 1))) {
+                            int n = jl_unbox_long(jl_exprarg(stmt, 1));
+                            jl_set_module_optlevel(s->module, n);
+                        }
+                    }
                 }
                 else {
                     eval_stmt_value(stmt, s);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -212,7 +212,10 @@ private:
     // object fits in its entirety
     SmallVector<char, 4096> ObjBufferSV;
     raw_svector_ostream ObjStream;
-    legacy::PassManager PM;
+    legacy::PassManager PM0;  // per-optlevel pass managers
+    legacy::PassManager PM1;
+    legacy::PassManager PM2;
+    legacy::PassManager PM3;
     MCContext *Ctx;
     std::shared_ptr<RTDyldMemoryManager> MemMgr;
     DebugObjectRegistrar registrar;
@@ -243,3 +246,5 @@ static inline bool isIntrinsicFunction(Function *F)
 {
     return F->isIntrinsic() || F->getName().startswith("julia.");
 }
+
+CodeGenOpt::Level CodeGenOptLevelFor(int optlevel);

--- a/src/julia.h
+++ b/src/julia.h
@@ -495,6 +495,7 @@ typedef struct _jl_module_t {
     size_t primary_world;
     uint32_t counter;
     int32_t nospecialize;  // global bit flags: initialization for new methods
+    int32_t optlevel;
     uint8_t istopmod;
     jl_mutex_t lock;
 } jl_module_t;
@@ -1454,6 +1455,8 @@ extern JL_DLLEXPORT jl_module_t *jl_base_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_top_module JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on);
+JL_DLLEXPORT void jl_set_module_optlevel(jl_module_t *self, int lvl);
+JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m);
 // get binding for reading
 JL_DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
 JL_DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1162,6 +1162,7 @@ extern jl_sym_t *throw_undef_if_not_sym; extern jl_sym_t *getfield_undefref_sym;
 extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
 extern jl_sym_t *failed_sym; extern jl_sym_t *done_sym; extern jl_sym_t *runnable_sym;
 extern jl_sym_t *coverageeffect_sym; extern jl_sym_t *escape_sym;
+extern jl_sym_t *optlevel_sym;
 
 struct _jl_sysimg_fptrs_t;
 

--- a/src/module.c
+++ b/src/module.c
@@ -35,6 +35,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     m->primary_world = 0;
     m->counter = 1;
     m->nospecialize = 0;
+    m->optlevel = -1;
     JL_MUTEX_INIT(&m->lock);
     htable_new(&m->bindings, 0);
     arraylist_new(&m->usings, 0);
@@ -70,6 +71,21 @@ JL_DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports)
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on)
 {
     self->nospecialize = (on ? -1 : 0);
+}
+
+JL_DLLEXPORT void jl_set_module_optlevel(jl_module_t *self, int lvl)
+{
+    self->optlevel = lvl;
+}
+
+JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m)
+{
+    int lvl = m->optlevel;
+    while (lvl == -1 && m->parent != m && m != jl_base_module) {
+        m = m->parent;
+        lvl = m->optlevel;
+    }
+    return lvl;
 }
 
 JL_DLLEXPORT void jl_set_istopmod(jl_module_t *self, uint8_t isprimary)

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -2,6 +2,8 @@
 
 module InteractiveUtils
 
+Base.Experimental.@optlevel 1
+
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
     @code_typed, @code_lowered, @code_llvm, @code_native, clipboard

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -13,6 +13,8 @@ Run Evaluate Print Loop (REPL)
 """
 module REPL
 
+Base.Experimental.@optlevel 1
+
 using Base.Meta, Sockets
 import InteractiveUtils
 


### PR DESCRIPTION
Time for `display(plot(rand(10)))` on Plots master, baseline:
```
 25.938760 seconds (18.25 M allocations: 899.022 MiB, 1.74% gc time)
```
On this branch, adding `Base.@optlevel 0` to Plots.jl:
```
 20.341163 seconds (18.26 M allocations: 899.217 MiB, 2.30% gc time)
```
