### PR TITLE
Fix regression in inlining of invoke

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -682,7 +682,7 @@ function analyze_method!(idx::Int, sig::Signature, @nospecialize(metharg), meths
     # Check if we intersect any of this method's ambiguities
     # TODO: We could split out the ambiguous case as another "union split" case.
     # For now, we just reject the method
-    if method.ambig !== nothing
+    if method.ambig !== nothing && invoke_data === nothing
         for entry::Core.TypeMapEntry in method.ambig
             if typeintersect(sig.atype, entry.sig) !== Bottom
                 return nothing

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test
+using Base.Meta
 
 """
 Helper to walk the AST and call a function on every node.
@@ -265,3 +266,12 @@ b30118(x...) = c30118(x)
 
 @test_throws MethodError c30118((Base.RefValue{Type{Int64}}(), Ref(Int64)))
 @test_throws MethodError b30118(Base.RefValue{Type{Int64}}(), Ref(Int64))
+
+# Issue #34900
+f34900(x::Int, y) = x
+f34900(x, y::Int) = y
+f34900(x::Int, y::Int) = invoke(f34900, Tuple{Int, Any}, x, y)
+let ci = code_typed(f34900, Tuple{Int, Int})[1].first
+    @test length(ci.code) == 1 && isexpr(ci.code[1], :return) &&
+        ci.code[1].args[1].id == 2
+end


### PR DESCRIPTION
When we added the check to prevent inlining through ambiguous methods,
we failed exclude this check for calls to `invoke` (which skip ambiguous
methods, since the method is explicitly selected). Fixes #34900.