### PR TITLE
REPL: make DictCompletion context module aware

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -518,7 +518,7 @@ function bslash_completions(string, pos)::Tuple{Bool, Completions}
     return (false, (Completion[], 0:-1, false))
 end
 
-function dict_identifier_key(str,tag)
+function dict_identifier_key(str, tag, context_module = Main)
     if tag === :string
         str_close = str*"\""
     elseif tag === :cmd
@@ -529,7 +529,7 @@ function dict_identifier_key(str,tag)
 
     frange, end_of_identifier = find_start_brace(str_close, c_start='[', c_end=']')
     isempty(frange) && return (nothing, nothing, nothing)
-    obj = Main
+    obj = context_module
     for name in split(str[frange[1]:end_of_identifier], '.')
         Base.isidentifier(name) || return (nothing, nothing, nothing)
         sym = Symbol(name)
@@ -581,7 +581,7 @@ function completions(string, pos, context_module=Main)::Completions
     inc_tag = Base.incomplete_tag(Meta.parse(partial, raise=false, depwarn=false))
 
     # if completing a key in a Dict
-    identifier, partial_key, loc = dict_identifier_key(partial,inc_tag)
+    identifier, partial_key, loc = dict_identifier_key(partial, inc_tag, context_module)
     if identifier !== nothing
         matches = find_dict_matches(identifier, partial_key)
         length(matches)==1 && (lastindex(string) <= pos || string[nextind(string,pos)] != ']') && (matches[1]*=']')

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1061,3 +1061,8 @@ let s = "typeof(+)."
     c, r = test_complete_context(s)
     @test length(c) == length(fieldnames(DataType))
 end
+
+let s = "test_dict[\"ab"
+    c, r = test_complete_context(s)
+    @test c == Any["\"abc\"", "\"abcd\""]
+end


### PR DESCRIPTION
Makes `DictCompletion`s aware of a context-module.

Certain tools (like Juno, Debugger.jl etc) use `REPLCompletions` in a way that completions are generated in a context of a module other than `Main`, and can benefit from this change.
Not breaking at all, since `context_module` defaults to `Main`.