### PR TITLE
RFC: IteratorSize(::Type{<:AbstractString}) = SizeUnknown()

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -148,6 +148,7 @@ See also: [`getindex`](@ref), [`checkbounds`](@ref)
 
 ## basic generic definitions ##
 
+IteratorSize(::Type{<:AbstractString}) = SizeUnknown() # length is not O(1)
 eltype(::Type{<:AbstractString}) = Char # some string types may use another AbstractChar
 
 """
@@ -545,6 +546,7 @@ struct EachStringIndex{T<:AbstractString}
 end
 keys(s::AbstractString) = EachStringIndex(s)
 
+IteratorSize(::Type{<:EachStringIndex}) = SizeUnknown()
 length(e::EachStringIndex) = length(e.s)
 first(::EachStringIndex) = 1
 last(e::EachStringIndex) = lastindex(e.s)
@@ -715,6 +717,7 @@ size(s::CodeUnits) = (length(s),)
 elsize(s::CodeUnits{T}) where {T} = sizeof(T)
 @propagate_inbounds getindex(s::CodeUnits, i::Int) = codeunit(s.s, i)
 IndexStyle(::Type{<:CodeUnits}) = IndexLinear()
+IteratorSize(::Type{<:CodeUnits}) = SizeUnknown()
 iterate(s::CodeUnits, i=1) = (@_propagate_inbounds_meta; i == length(s)+1 ? nothing : (s[i], i+1))
 
 write(io::IO, s::CodeUnits) = write(io, s.s)


### PR DESCRIPTION
Currently, `IteratorSize` on `AbstractString` is `HasLength` due to the generic fallback:

```
julia> @which Base.IteratorSize(String)
Base.IteratorSize(::Type) in Base at generator.jl:91
```

Since `length` on strings is not O(1), it may be better to return `SizeUnknown()` from string-related iterators.  But I don't do much string processing so I'm not sure if this is the best choice.  What do you think?  Is it a reasonable change?
