### PR TITLE
Use typed-zero in sign() implementation

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -10,7 +10,7 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
              sum, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
-             hastypemax
+             sign, hastypemax
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -668,6 +668,11 @@ flipsign!(x::BigInt, y::Integer) = (signbit(y) && (x.size = -x.size); x)
 flipsign( x::BigInt, y::Integer) = signbit(y) ? -x : x
 flipsign( x::BigInt, y::BigInt)  = signbit(y) ? -x : x
 # above method to resolving ambiguities with flipsign(::T, ::T) where T<:Signed
+function sign(x::BigInt)
+    isneg(x) && return -one(x)
+    ispos(x) && return one(x)
+    return x
+end
 
 show(io::IO, x::BigInt) = print(io, string(x))
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -13,7 +13,7 @@ import
         nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show, float,
         sum, sqrt, string, print, trunc, precision, exp10, expm1,
         log1p,
-        eps, signbit, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
+        eps, signbit, sign, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh,
         cbrt, typemax, typemin, unsafe_trunc, floatmin, floatmax, rounding,
         setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero,
@@ -786,6 +786,11 @@ cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)
 <=(x::CdoubleMax, y::BigFloat) = !isnan(x) && !isnan(y) && cmp(y,x) >= 0
 
 signbit(x::BigFloat) = ccall((:mpfr_signbit, :libmpfr), Int32, (Ref{BigFloat},), x) != 0
+function sign(x::BigFloat)
+    c = cmp(x, 0)
+    (c == 0 || isnan(x)) && return x
+    return c < 0 ? -one(x) : one(x)
+end
 
 function precision(x::BigFloat)  # precision of an object of type BigFloat
     return ccall((:mpfr_get_prec, :libmpfr), Clong, (Ref{BigFloat},), x)

--- a/base/number.jl
+++ b/base/number.jl
@@ -114,9 +114,9 @@ signbit(x::Real) = x < 0
 
 Return zero if `x==0` and ``x/|x|`` otherwise (i.e., ±1 for real `x`).
 """
-sign(x::Number) = x == 0 ? x/abs(oneunit(x)) : x/abs(x)
-sign(x::Real) = ifelse(x < 0, oftype(one(x),-1), ifelse(x > 0, one(x), typeof(one(x))(x)))
-sign(x::Unsigned) = ifelse(x > 0, one(x), oftype(one(x),0))
+sign(x::Number) = iszero(x) ? x/abs(oneunit(x)) : x/abs(x)
+sign(x::Real) = ifelse(x < zero(x), oftype(one(x),-1), ifelse(x > zero(x), one(x), typeof(one(x))(x)))
+sign(x::Unsigned) = ifelse(x > zero(x), one(x), oftype(one(x),0))
 abs(x::Real) = ifelse(signbit(x), -x, x)
 
 """

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -78,6 +78,16 @@ end
         @test rem(BigInt(i), BigInt(j)) == rem(i,j)
     end
 end
+@testset "copysign / sign" begin
+    x = BigInt(1)
+    y = BigInt(-1)
+    @test copysign(x, y) == y
+    @test copysign(y, x) == x
+
+    @test sign(BigInt(-3)) == -1
+    @test sign(BigInt( 0)) == 0
+    @test sign(BigInt( 3)) == 1
+end
 
 @testset "Signed addition" begin
     @test a+Int8(1) == b

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -372,12 +372,18 @@ end
     end
 end
 
-@testset "copysign" begin
+@testset "copysign / sign" begin
     x = BigFloat(1)
     y = BigFloat(-1)
     @test copysign(x, y) == y
     @test copysign(y, x) == x
     @test copysign(1.0, BigFloat(NaN)) == 1.0
+
+    @test sign(BigFloat(-3.0)) == -1.0
+    @test sign(BigFloat( 3.0)) == 1.0
+    @test isequal(sign(BigFloat(-0.0)), BigFloat(-0.0))
+    @test isequal(sign(BigFloat( 0.0)), BigFloat( 0.0))
+    @test isnan(sign(BigFloat(NaN)))
 end
 @testset "isfinite / isinf / isnan" begin
     x = BigFloat(Inf)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -469,6 +469,12 @@ end
     @test sign(one(UInt)) == 1
     @test sign(zero(UInt)) == 0
 
+    isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
+    using .Main.Furlongs
+    x = Furlong(3.0)
+    @test sign(x) * x == x
+    @test sign(-x) * -x == x
+
     @test signbit(1) == 0
     @test signbit(0) == 0
     @test signbit(-1) == 1


### PR DESCRIPTION
This PR fixes #34914: 
```julia
# With PR
julia> @code_typed sign(2.0)
CodeInfo(
1 ─ %1 = Base.lt_float(x, 0.0)::Bool
│   %2 = Base.lt_float(0.0, x)::Bool
│   %3 = Base.ifelse(%2, 1.0, x)::Float64
│   %4 = Base.ifelse(%1, -1.0, %3)::Float64
└──      return %4
) => Float64

julia> @code_llvm debuginfo=:none sign(2.0)

define double @julia_sign_18479(double) {
top:
  %1 = fcmp uge double %0, 0.000000e+00
  %2 = fcmp ule double %0, 0.000000e+00
  %3 = select i1 %2, double %0, double 1.000000e+00
  %4 = select i1 %1, double %3, double -1.000000e+00
  ret double %4
}
```
Previously, the type mismatch in the comparisons meant that `sign(::Furlong)` from the test helper didn't work, so I've used that as a regression test.