### PR TITLE
Semantic Versioning block in Contributions.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,11 +64,21 @@ For developers who need to wrap C libraries so that they can be called from Juli
 
 ### Semantic Versioning and Package Compatibility Across Releases
 
-When tagging a new release of your package you should follow [Semantic Versioning (SemVar)](https://semver.org/). Given a version number of the form MAJOR.MINOR.PATCH, increment the:
+When tagging a new release of your package you should follow [Semantic Versioning (SemVar)](https://semver.org/). Given a version number of the form MAJOR.MINOR.PATCH with MAJOR >= 1, increment the:
 
 * MAJOR version when you make incompatible API changes,
 * MINOR version when you add functionality in a backwards compatible manner, and
 * PATCH version when you make backwards compatible bug fixes.
+
+For packages in an early stage with version numbers 0.MINOR.PATCH, for example 0.6.2, MINOR takes over the role of MAJOR and should therefore only be increased when introducing incompatible API changes.
+
+Examples:
+
+* 0.4.2 -> 0.4.3 (non-breaking)
+* 0.4.2 -> 0.5.0 (breaking)
+* 1.2.3 -> 1.3.0 (non-breaking)
+* 1.3.0 -> 1.3.1 (non breaking)
+* 1.9.2 -> 2.0.0 (breaking)
 
 Semantic Versioning is a great way to indicate to users of your package whether they should expect API breaking changes when switching to a new version. Note that Julia itself respects Semantic Versioning as well. This means that your package will be compatible with all newer Julia releases with the same MAJOR version.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,13 +64,17 @@ For developers who need to wrap C libraries so that they can be called from Juli
 
 ### Semantic Versioning and Package Compatibility Across Releases
 
-When tagging a new release of your package you should follow [Semantic Versioning (SemVar)](https://semver.org/). Given a version number of the form MAJOR.MINOR.PATCH with MAJOR >= 1, increment the:
+When tagging a new release of your package you should follow
+[Semantic Versioning (SemVar)](https://semver.org/). Given a version number
+of the form MAJOR.MINOR.PATCH with MAJOR >= 1, increment the:
 
 * MAJOR version when you make incompatible API changes,
 * MINOR version when you add functionality in a backwards compatible manner, and
 * PATCH version when you make backwards compatible bug fixes.
 
-For packages in an early stage with version numbers 0.MINOR.PATCH, for example 0.6.2, MINOR takes over the role of MAJOR and should therefore only be increased when introducing incompatible API changes.
+For packages in an early stage with version numbers 0.MINOR.PATCH, for example
+0.6.2, MINOR takes over the role of MAJOR and should therefore only be increased
+when introducing incompatible API changes.
 
 Examples:
 
@@ -80,9 +84,17 @@ Examples:
 * 1.3.0 -> 1.3.1 (non breaking)
 * 1.9.2 -> 2.0.0 (breaking)
 
-Semantic Versioning is a great way to indicate to users of your package whether they should expect API breaking changes when switching to a new version. Note that Julia itself respects Semantic Versioning as well. This means that your package will be compatible with all newer Julia releases with the same MAJOR version.
+Semantic Versioning is a great way to indicate to users of your package whether
+they should expect API breaking changes when switching to a new version.
+Note that Julia itself respects Semantic Versioning as well. This means that
+your package will be compatible with all newer Julia releases with the same
+MAJOR version.
 
-However, sometimes you might want to maintain compatibility across breaking Julia releases or use features from a certain MINOR version in a different, older MINOR version of Julia. To that end, use [`Compat.jl`](https://github.com/JuliaLang/Compat.jl). For more information see [this guide](https://github.com/JuliaLang/Compat.jl/#tagging-the-correct-minimum-version-of-compat).
+However, sometimes you might want to maintain compatibility across breaking
+Julia releases or use features from a certain MINOR version in a different,
+older MINOR version of Julia. To that end, use
+[`Compat.jl`](https://github.com/JuliaLang/Compat.jl). For more information see
+[this guide](https://github.com/JuliaLang/Compat.jl/#tagging-the-correct-minimum-version-of-compat).
 
 ### Writing tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Julia has a built-in [package manager](https://julialang.github.io/Pkg.jl/v1/) b
 
 For developers who need to wrap C libraries so that they can be called from Julia, the [Clang.jl](https://github.com/ihnorton/Clang.jl) package can help generate the wrappers automatically from the C header files.
 
-### Semantic Versioning
+### Semantic Versioning and Package Compatibility Across Releases
 
 When tagging a new release of your package you should follow [Semantic Versioning (SemVar)](https://semver.org/). Given a version number of the form MAJOR.MINOR.PATCH, increment the:
 
@@ -70,9 +70,9 @@ When tagging a new release of your package you should follow [Semantic Versionin
 * MINOR version when you add functionality in a backwards compatible manner, and
 * PATCH version when you make backwards compatible bug fixes.
 
-Semantic Versioning is a great way to indicate to users of your package whether they should expect API breaking changes when switching to a new version.
+Semantic Versioning is a great way to indicate to users of your package whether they should expect API breaking changes when switching to a new version. Note that Julia itself respects Semantic Versioning as well. This means that your package will be compatible with all newer Julia releases with the same MAJOR version.
 
-Note that Julia itself respects Semantic Versioning as well. This means that your package will be compatible with all newer Julia releases with the same MAJOR version.
+However, sometimes you might want to maintain compatibility across breaking Julia releases or use features from a certain MINOR version in a different, older MINOR version of Julia. To that end, use [`Compat.jl`](https://github.com/JuliaLang/Compat.jl). For more information see [this guide](https://github.com/JuliaLang/Compat.jl/#tagging-the-correct-minimum-version-of-compat).
 
 ### Writing tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,46 +56,6 @@ A useful bug report filed as a GitHub issue provides information about how to re
 
 ## Submitting contributions
 
-### Contributing a Julia package
-
-Julia has a built-in [package manager](https://julialang.github.io/Pkg.jl/v1/) based on `git`. A number of [packages](https://pkg.julialang.org) across many domains are already available for Julia. Developers are encouraged to provide their libraries as a Julia package. The manual provides instructions on [creating Julia packages](https://julialang.github.io/Pkg.jl/v1/creating-packages/).
-
-For developers who need to wrap C libraries so that they can be called from Julia, the [Clang.jl](https://github.com/ihnorton/Clang.jl) package can help generate the wrappers automatically from the C header files.
-
-### Semantic Versioning and Package Compatibility Across Releases
-
-When tagging a new release of your package you should follow
-[Semantic Versioning (SemVer)](https://semver.org/). Given a version number
-of the form MAJOR.MINOR.PATCH with MAJOR >= 1, increment the:
-
-* MAJOR version when you make incompatible API changes,
-* MINOR version when you add functionality in a backwards compatible manner, and
-* PATCH version when you make backwards compatible bug fixes.
-
-For packages in an early stage with version numbers 0.MINOR.PATCH, for example
-0.6.2, MINOR takes over the role of MAJOR and should therefore only be increased
-when introducing incompatible API changes.
-
-Examples:
-
-* 0.4.2 -> 0.4.3 (non-breaking)
-* 0.4.2 -> 0.5.0 (breaking)
-* 1.2.3 -> 1.3.0 (non-breaking)
-* 1.3.0 -> 1.3.1 (non breaking)
-* 1.9.2 -> 2.0.0 (breaking)
-
-Semantic Versioning is a great way to indicate to users of your package whether
-they should expect API breaking changes when switching to a new version.
-Note that Julia itself respects Semantic Versioning as well. This means that
-your package will be compatible with all newer Julia releases with the same
-MAJOR version.
-
-However, sometimes you might want to maintain compatibility across breaking
-Julia releases or use features from a certain MINOR version in a different,
-older MINOR version of Julia. To that end, use
-[`Compat.jl`](https://github.com/JuliaLang/Compat.jl). For more information see
-[this guide](https://github.com/JuliaLang/Compat.jl/#tagging-the-correct-minimum-version-of-compat).
-
 ### Writing tests
 
 There are never enough tests. Track [code coverage at Coveralls](https://coveralls.io/r/JuliaLang/julia), and help improve it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ For developers who need to wrap C libraries so that they can be called from Juli
 ### Semantic Versioning and Package Compatibility Across Releases
 
 When tagging a new release of your package you should follow
-[Semantic Versioning (SemVar)](https://semver.org/). Given a version number
+[Semantic Versioning (SemVer)](https://semver.org/). Given a version number
 of the form MAJOR.MINOR.PATCH with MAJOR >= 1, increment the:
 
 * MAJOR version when you make incompatible API changes,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,21 +62,17 @@ Julia has a built-in [package manager](https://julialang.github.io/Pkg.jl/v1/) b
 
 For developers who need to wrap C libraries so that they can be called from Julia, the [Clang.jl](https://github.com/ihnorton/Clang.jl) package can help generate the wrappers automatically from the C header files.
 
-### Package Compatibility Across Releases
+### Semantic Versioning
 
-Sometimes, you might find that while your package works
-on the current release, it might not work on the upcoming release or nightly.
-This is due to the fact that some Julia functions (after some discussion)
-could be deprecated or removed altogether. This may cause your package to break or
-throw a number of deprecation warnings on usage. Therefore it is highly recommended
-to port your package to latest Julia release.
+When tagging a new release of your package you should follow [Semantic Versioning (SemVar)](https://semver.org/). Given a version number of the form MAJOR.MINOR.PATCH, increment the:
 
-However, porting a package to the latest release may cause the package to break on
-earlier Julia releases. To maintain compatibility across releases, use
-[`Compat.jl`](https://github.com/JuliaLang/Compat.jl). Find the fix for your package
-from the README, and specify the minimum version of Compat that provides the fix
-in your REQUIRE file. To find the correct minimum version, refer to
-[this guide](https://github.com/JuliaLang/Compat.jl/#tagging-the-correct-minimum-version-of-compat).
+* MAJOR version when you make incompatible API changes,
+* MINOR version when you add functionality in a backwards compatible manner, and
+* PATCH version when you make backwards compatible bug fixes.
+
+Semantic Versioning is a great way to indicate to users of your package whether they should expect API breaking changes when switching to a new version.
+
+Note that Julia itself respects Semantic Versioning as well. This means that your package will be compatible with all newer Julia releases with the same MAJOR version.
 
 ### Writing tests
 


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/julia/issues/31685 some time ago, this PR updates the old "Package Compatibility Across Releases" section in contributions.md from 0.x times, where every Julia release was breaking.

It introduces a short block about Semantic Versioning and reduces the mention of Compat.jl to a minimum.

Closes #31685.