### PR TITLE
Improve docstrings of IEEE floating point types

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1557,12 +1557,22 @@ julia> false * NaN
 """
 Bool
 
+# IEEE 754 standard
+binary = Dict(
+    16 => Dict(:sign => 1, :exp => 5, :frac => 10),
+    32 => Dict(:sign => 1, :exp => 8, :frac => 23),
+    64 => Dict(:sign => 1, :exp => 11, :frac => 52),
+)
+
 for bit in (16, 32, 64)
+    b = binary[bit]
     @eval begin
         """
             Float$($bit) <: AbstractFloat
 
-        $($bit)-bit floating point number type.
+        $($bit)-bit floating point number type (IEEE 754 standard).
+
+        Binary format: $($b[:sign]) sign, $($b[:exp]) exponent, $($b[:frac]) fraction bits.
         """
         $(Symbol("Float", bit))
     end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1557,22 +1557,14 @@ julia> false * NaN
 """
 Bool
 
-# IEEE 754 standard
-binary = Dict(
-    16 => Dict(:sign => 1, :exp => 5, :frac => 10),
-    32 => Dict(:sign => 1, :exp => 8, :frac => 23),
-    64 => Dict(:sign => 1, :exp => 11, :frac => 52),
-)
-
-for bit in (16, 32, 64)
-    b = binary[bit]
+for (bit, sign, exp, frac) in ((16, 1, 5, 10), (32, 1, 8, 23), (64, 1, 11, 52))
     @eval begin
         """
             Float$($bit) <: AbstractFloat
 
         $($bit)-bit floating point number type (IEEE 754 standard).
 
-        Binary format: $($b[:sign]) sign, $($b[:exp]) exponent, $($b[:frac]) fraction bits.
+        Binary format: $($sign) sign, $($exp) exponent, $($frac) fraction bits.
         """
         $(Symbol("Float", bit))
     end


### PR DESCRIPTION
As suggested by @dpsanders in #34833, this PR improves the docstrings of `Float16`, `Float32`. and `Float64`. Specifically, we

* mention that the types are IEEE 754 standard compatible
* describe their binary format

I went with "fraction" instead of "mantissa", mainly because this is how [wikipedia](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) calls it.

Closes #34833