### PR TITLE
add readline(::AbstractCmd)

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -320,6 +320,8 @@ function eachline(cmd::AbstractCmd; keep::Bool=false)
     return EachLine(out, keep=keep, ondone=ondone)::EachLine
 end
 
+readline(cmd::AbstractCmd; keep::Bool=false) = first(eachline(cmd, keep=keep))
+
 """
     open(command, mode::AbstractString, stdio=devnull)
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -670,6 +670,14 @@ end
 @test repr(Base.CmdRedirect(``, devnull, 1, true)) == "pipeline(``, stdout<Base.DevNull())"
 @test repr(Base.CmdRedirect(``, devnull, 11, true)) == "pipeline(``, 11<Base.DevNull())"
 
+@testset "readline" begin
+    @test readline(`$(printfcmd) '\n'`) == ""
+    @test readline(`$(printfcmd) 'foo\n'`) == "foo"
+    @test readline(`$(printfcmd) 'foo\nbar\n'`) == "foo"
+    @test readline(yescmd) == "y"
+    @test readline(pipeline(`$(printfcmd) 'foo\nbar\n'`, sortcmd)) == "bar"
+    @test_throws ArgumentError("collection must be non-empty") readline(`$(printfcmd) ''`)
+end
 
 # clean up busybox download
 if Sys.iswindows()
@@ -759,13 +767,4 @@ end
     # input : [A\ B\, C, D K]
     # output: "A\ B\\" C "D K"
     @test Base.shell_escape_winsomely("A\\ B\\", "C", "D K") == "\"A\\ B\\\\\" C \"D K\""
-end
-
-@testset "readline" begin
-    @test readline(`$(printfcmd) '\n'`) == ""
-    @test readline(`$(printfcmd) 'foo\n'`) == "foo"
-    @test readline(`$(printfcmd) 'foo\nbar\n'`) == "foo"
-    @test readline(yescmd) == "y"
-    @test readline(pipeline(`$(printfcmd) 'foo\nbar\n'`, sortcmd)) == "bar"
-    @test_throws ArgumentError("collection must be non-empty") readline(`$(printfcmd) ''`)
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -762,10 +762,10 @@ end
 end
 
 @testset "readline" begin
-    @test readline(echocmd) == ""
-    @test readline(`$(echocmd) foo`) == "foo"
-    @test readline(`$(echocmd) -e 'foo\nbar'`) == "foo"
+    @test readline(`$(printfcmd) '\n'`) == ""
+    @test readline(`$(printfcmd) 'foo\n'`) == "foo"
+    @test readline(`$(printfcmd) 'foo\nbar\n'`) == "foo"
     @test readline(yescmd) == "y"
-    @test readline(pipeline(`$(echocmd) -e 'foo\nbar'`, sortcmd)) == "bar"
-    @test_throws ArgumentError("collection must be non-empty") readline(`$(echocmd) -n`)
+    @test readline(pipeline(`$(printfcmd) 'foo\nbar\n'`, sortcmd)) == "bar"
+    @test_throws ArgumentError("collection must be non-empty") readline(`$(printfcmd) ''`)
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -760,3 +760,12 @@ end
     # output: "A\ B\\" C "D K"
     @test Base.shell_escape_winsomely("A\\ B\\", "C", "D K") == "\"A\\ B\\\\\" C \"D K\""
 end
+
+@testset "readline" begin
+    @test readline(echocmd) == ""
+    @test readline(`$(echocmd) foo`) == "foo"
+    @test readline(`$(echocmd) -e 'foo\nbar'`) == "foo"
+    @test readline(yescmd) == "y"
+    @test readline(pipeline(`$(echocmd) -e 'foo\nbar'`, sortcmd)) == "bar"
+    @test_throws ArgumentError("collection must be non-empty") readline(`$(echocmd) -n`)
+end


### PR DESCRIPTION
This adds the `readline(::AbstractCmd)` method in a trivial way, unless I miss something non-trivial. This closes #28975.