### PR TITLE
Add a missing test for Hermitian

### DIFF
--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -481,6 +481,9 @@ end
         W[1,1] = 4
         @test W == T([4 -1; -1 1])
         @test_throws ArgumentError (W[1,2] = 2)
+        if T == Hermitian
+            @test_throws ArgumentError (W[2,2] = 3+4im)
+        end
 
         @test Y + I == T([2 -1; -1 2])
         @test Y - I == T([0 -1; -1 0])


### PR DESCRIPTION
Tests that an `ArgumentError` is thrown when one tries to set a diagonal element of a `Hermitian` to a non-real value.