### PR TITLE
Added missing parentheses in reduced_index error message string interpolation

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -8,7 +8,7 @@ reduced_index(i::Union{Slice, IdentityUnitRange}) = oftype(i, first(i):first(i))
 reduced_index(i::AbstractUnitRange) =
     throw(ArgumentError(
 """
-No method is implemented for reducing index range of type $typeof(i). Please implement
+No method is implemented for reducing index range of type $(typeof(i)). Please implement
 reduced_index for this index type or report this as an issue.
 """
     ))


### PR DESCRIPTION
The call to `typeof` in the string interpolation for an error message in `reduced_index` was not enclosed in parentheses. I ran a simple script (see below) to find similar errors in base and stdlib, the script gives lots of false positives but I have not identified any more errors of this kind in the codebase.

``` julia
function find_all_functions_in_interpolations(expr::Expr, ln, collector, modules)
    # inspired by:
    # https://stackoverflow.com/questions/58898978/getting-the-whole-ast-of-the-file-complex-code
    # https://github.com/chakravala/SyntaxTree.jl/blob/0400d8094d/src/SyntaxTree.jl#L50-L71
    if expr.head == :string
        for part in expr.args
            if part isa Symbol
                for mod in modules
                    if isdefined(mod, part)
                        ms = methods(Base.eval(mod, part))
                        # CF: methodshow.jl: show_method_list_header
                        mt = ms.mt
                        if !isempty(ms) || (mt.module === Core && mt.defs === nothing && mt.cache !== nothing)
                            push!(collector, (ln, part))
                        end
                    end
                end
            end
        end
    elseif expr.head == :using
        push!(modules, Module(expr.args[1].head))
    else
        for a in expr.args
            ln = find_all_functions_in_interpolations(a, ln, collector, modules)
        end
    end
    return ln
end
find_all_functions_in_interpolations(newln::LineNumberNode, ln, collector, modules) = newln.line
find_all_functions_in_interpolations(a, ln, collector, modules) = ln

for (root, dirs, files) in walkdir(".")
    for file in files
        if endswith(file, ".jl")
            path = joinpath(root, file)
            try
                code = read(joinpath(root, file), String)
                lines = split(code, '\n')
                expr = Meta.parse("begin $code end")
                collector = Tuple{Int64, Symbol}[]
                endln = find_all_functions_in_interpolations(expr, 1, collector, [Base])
                for (ln, sym) in collector
                    println("$path: $ln, $sym")
                end
            catch e
                println("$path: ERROR: $e")
            end
        end
    end
end
```