### PR TITLE
fix unsigned(::Ptr) and signed(::Ptr)

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -160,5 +160,5 @@ isless(x::Ptr{T}, y::Ptr{T}) where {T} = x < y
 -(x::Ptr, y::Integer) = oftype(x, sub_ptr(UInt(x), (y % UInt) % UInt))
 +(x::Integer, y::Ptr) = y + x
 
-unsigned(x::Ptr) = convert(Unsigned, x)
-signed(x::Ptr) = convert(Signed, x)
+unsigned(x::Ptr) = UInt(x)
+signed(x::Ptr) = Int(x)

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -159,3 +159,6 @@ isless(x::Ptr{T}, y::Ptr{T}) where {T} = x < y
 +(x::Ptr, y::Integer) = oftype(x, add_ptr(UInt(x), (y % UInt) % UInt))
 -(x::Ptr, y::Integer) = oftype(x, sub_ptr(UInt(x), (y % UInt) % UInt))
 +(x::Integer, y::Ptr) = y + x
+
+unsigned(x::Ptr) = convert(Unsigned, x)
+signed(x::Ptr) = convert(Signed, x)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -793,6 +793,16 @@ end
 # Pointer 0-arg constructor
 @test Ptr{Cvoid}() == C_NULL
 
+@testset "Pointer to unsigned/signed integer" begin
+    # assuming UInt and Ptr have the same size
+    @assert sizeof(UInt) == sizeof(Ptr{Nothing})
+    uint = UInt(0x12345678)
+    sint = signed(uint)
+    ptr = reinterpret(Ptr{Nothing}, uint)
+    @test unsigned(ptr) === uint
+    @test signed(ptr) === sint
+end
+
 # Finalizer with immutable should throw
 @test_throws ErrorException finalizer(x->nothing, 1)
 @test_throws ErrorException finalizer(C_NULL, 1)


### PR DESCRIPTION
Since #34287, `unsigned(::Ptr)` and `signed(::Ptr)` haven't worked as expected.

```
# Julia 1.3
julia> p = pointer("foo");

julia> unsigned(p)
0x00007f81b5598bd8

julia> signed(p)
140195070053336

# Julia 1.4-rc2 and master
julia> unsigned(p)
ERROR: MethodError: no method matching zero(::Ptr{UInt8})
Closest candidates are:
  zero(::Type{Missing}) at missing.jl:103
  zero(::Type{LibGit2.GitHash}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/LibGit2/src/oid.jl:220
  zero(::Type{Pkg.Resolve.VersionWeight}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Pkg/src/Resolve/versionweights.jl:15
  ...
Stacktrace:
 [1] unsigned(::Ptr{UInt8}) at ./int.jl:158
 [2] top-level scope at REPL[2]:1

julia> signed(p)
ERROR: MethodError: no method matching zero(::Ptr{UInt8})
Closest candidates are:
  zero(::Type{Missing}) at missing.jl:103
  zero(::Type{LibGit2.GitHash}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/LibGit2/src/oid.jl:220
  zero(::Type{Pkg.Resolve.VersionWeight}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Pkg/src/Resolve/versionweights.jl:15
  ...
Stacktrace:
 [1] signed(::Ptr{UInt8}) at ./int.jl:167
 [2] top-level scope at REPL[3]:1
```

This causes an actual package breakage such as https://github.com/JuliaLang/julia/pull/34287#issuecomment-573027796 (cf. https://github.com/bicycle1885/EzXML.jl/pull/125).

A possible (perhaps smarter) solution would be adding `zero(::Ptr)` but it is technically a new feature and so I think it is not a good time to introduce it since Julia 1.4 RC2 is already out.