### PR TITLE
RFC: Make `Base.manifest_names` a Vector instead of a Tuple

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -300,7 +300,7 @@ end
 ## generic project & manifest API ##
 
 const project_names = ("JuliaProject.toml", "Project.toml")
-const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
+const manifest_names = ["JuliaManifest.toml", "Manifest.toml"]
 
 # classify the LOAD_PATH entry to be one of:
 #  - `false`: nonexistant / nothing to see here


### PR DESCRIPTION
This would allow you to use custom names for your manifest files by doing something like:
```julia
pushfirst!(Base.manifest_names, "CustomManifestName.toml"
```

I'm curious what the performance impact of this would be. Would it be possible for someone with the appropriate permissions to trigger a Nanosoldier run on this PR? 