### PR TITLE
test sprintf %p using real pointers

### DIFF
--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -51,9 +51,13 @@ end
 if Sys.WORD_SIZE == 64
     @test (@sprintf "%20p" 0) == "  0x0000000000000000"
     @test (@sprintf "%-20p" 0) == "0x0000000000000000  "
+    @test (@sprintf "%20p" C_NULL) == "  0x0000000000000000"
+    @test (@sprintf "%-20p" C_NULL) == "0x0000000000000000  "
 elseif Sys.WORD_SIZE == 32
     @test (@sprintf "%20p" 0) == "          0x00000000"
     @test (@sprintf "%-20p" 0) == "0x00000000          "
+    @test (@sprintf "%20p" C_NULL) == "          0x00000000"
+    @test (@sprintf "%-20p" C_NULL) == "0x00000000          "
 else
     @test false
 end


### PR DESCRIPTION
I discovered that `@sprintf "%p"` is not tested using real pointers while working on #34941. Since pointers are not integers, we need to test them in addition to integers. Please merge this only after #34941 or CI will fail.