### PR TITLE
add missing test for ones and zeros

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -501,15 +501,13 @@ for (fname, felt) in ((:zeros, :zero), (:ones, :one))
         $fname(dims::Tuple{Vararg{DimOrInd}}) = $fname(Float64, dims)
         $fname(::Type{T}, dims::NTuple{N, Union{Integer, OneTo}}) where {T,N} = $fname(T, map(to_dim, dims))
         function $fname(::Type{T}, dims::NTuple{N, Integer}) where {T,N}
-            init = $felt(T)
-            a = Array{typeof(init),N}(undef, dims)
-            fill!(a, init)
+            a = Array{T,N}(undef, dims)
+            fill!(a, $felt(T))
             return a
         end
         function $fname(::Type{T}, dims::Tuple{}) where {T}
-            init = $felt(T)
-            a = Array{typeof(init)}(undef)
-            fill!(a, init)
+            a = Array{T}(undef)
+            fill!(a, $felt(T))
             return a
         end
     end

--- a/base/array.jl
+++ b/base/array.jl
@@ -501,13 +501,15 @@ for (fname, felt) in ((:zeros, :zero), (:ones, :one))
         $fname(dims::Tuple{Vararg{DimOrInd}}) = $fname(Float64, dims)
         $fname(::Type{T}, dims::NTuple{N, Union{Integer, OneTo}}) where {T,N} = $fname(T, map(to_dim, dims))
         function $fname(::Type{T}, dims::NTuple{N, Integer}) where {T,N}
-            a = Array{T,N}(undef, dims)
-            fill!(a, $felt(T))
+            init = $felt(T)
+            a = Array{typeof(init),N}(undef, dims)
+            fill!(a, init)
             return a
         end
         function $fname(::Type{T}, dims::Tuple{}) where {T}
-            a = Array{T}(undef)
-            fill!(a, $felt(T))
+            init = $felt(T)
+            a = Array{typeof(init)}(undef)
+            fill!(a, init)
             return a
         end
     end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2504,10 +2504,6 @@ end
             @test_throws MethodError fname(T, [1.]) # issue #19265
             @test_throws MethodError fname(T, [1, 1]) # issue #19265
         end
-
-        for T in (AbstractFloat, Integer, Real, Number)
-            @test eltype(fname(T)) === typeof(felt(T))
-        end
     end
 end
 


### PR DESCRIPTION
I'm actually a little surprised that `eltype(ones(T)) === typeof(one(T))` not hold true for abstract types (e.g., `AbstractFloat`) given that `one(T)` is allowed, so here's one small patch that fixes this.

However, it's also a conflict that `eltype(ones(T)) != T`... so feedbacks are needed.

cc: @kimikage

---

Edit: 

Actually I'm not convinced about this change at all, with two :-1: here I think it's sufficient to just reverted the changes and simply adds some test cases for zeros and ones.