### PR TITLE
Fix Base.show for SSHManager and LocalManager

### DIFF
--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -366,7 +366,7 @@ function addprocs(np::Integer; restrict=true, kwargs...)
     addprocs(LocalManager(np, restrict); kwargs...)
 end
 
-Base.show(io::IO, manager::LocalManager) = println(io, "LocalManager()")
+Base.show(io::IO, manager::LocalManager) = print(io, "LocalManager()")
 
 function launch(manager::LocalManager, params::Dict, launched::Array, c::Condition)
     dir = params[:dir]

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -144,7 +144,7 @@ function launch(manager::SSHManager, params::Dict, launched::Array, launch_ntfy:
 end
 
 
-show(io::IO, manager::SSHManager) = println(io, "SSHManager(machines=", manager.machines, ")")
+Base.show(io::IO, manager::SSHManager) = println(io, "SSHManager(machines=", manager.machines, ")")
 
 
 function parse_machine(machine::AbstractString)
@@ -366,7 +366,7 @@ function addprocs(np::Integer; restrict=true, kwargs...)
     addprocs(LocalManager(np, restrict); kwargs...)
 end
 
-show(io::IO, manager::LocalManager) = println(io, "LocalManager()")
+Base.show(io::IO, manager::LocalManager) = println(io, "LocalManager()")
 
 function launch(manager::LocalManager, params::Dict, launched::Array, c::Condition)
     dir = params[:dir]

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -144,7 +144,7 @@ function launch(manager::SSHManager, params::Dict, launched::Array, launch_ntfy:
 end
 
 
-Base.show(io::IO, manager::SSHManager) = println(io, "SSHManager(machines=", manager.machines, ")")
+Base.show(io::IO, manager::SSHManager) = print(io, "SSHManager(machines=", manager.machines, ")")
 
 
 function parse_machine(machine::AbstractString)

--- a/stdlib/Distributed/test/managers.jl
+++ b/stdlib/Distributed/test/managers.jl
@@ -23,5 +23,5 @@ sock = bind_client_port(TCPSocket(), typeof(IPv6(0)))
 addr, port = getsockname(sock)
 @test addr == ip"::"
 
-@test sprint((t,x) -> show(t, "text/plain", x), SSHManager("127.0.0.1")) == "SSHManager(machines=Dict{Any,Any}('.' => 3,'0' => 2,'1' => 2,'2' => 1,'7' => 1))\n"
+@test sprint((t,x) -> show(t, "text/plain", x), SSHManager("127.0.0.1")) == "SSHManager(machines=Dict{Any,Any}('.' => 3,'0' => 2,'1' => 2,'2' => 1,'7' => 1))"
 @test sprint((t,x) -> show(t, "text/plain", x), LocalManager(1, true)) == "LocalManager()\n"

--- a/stdlib/Distributed/test/managers.jl
+++ b/stdlib/Distributed/test/managers.jl
@@ -1,7 +1,7 @@
 using Test
 using Distributed
 using Sockets
-using Distributed: parse_machine, bind_client_port
+using Distributed: parse_machine, bind_client_port, SSHManager, LocalManager
 
 @test parse_machine("127.0.0.1") == ("127.0.0.1", nothing)
 @test parse_machine("127.0.0.1:80") == ("127.0.0.1", 80)
@@ -22,3 +22,6 @@ addr, port = getsockname(sock)
 sock = bind_client_port(TCPSocket(), typeof(IPv6(0)))
 addr, port = getsockname(sock)
 @test addr == ip"::"
+
+@test sprint((t,x) -> show(t, "text/plain", x), SSHManager("127.0.0.1")) == "SSHManager(machines=Dict{Any,Any}('.' => 3,'0' => 2,'1' => 2,'2' => 1,'7' => 1))\n"
+@test sprint((t,x) -> show(t, "text/plain", x), LocalManager(1, true)) == "LocalManager()\n"

--- a/stdlib/Distributed/test/managers.jl
+++ b/stdlib/Distributed/test/managers.jl
@@ -24,4 +24,4 @@ addr, port = getsockname(sock)
 @test addr == ip"::"
 
 @test sprint((t,x) -> show(t, "text/plain", x), SSHManager("127.0.0.1")) == "SSHManager(machines=Dict{Any,Any}('.' => 3,'0' => 2,'1' => 2,'2' => 1,'7' => 1))"
-@test sprint((t,x) -> show(t, "text/plain", x), LocalManager(1, true)) == "LocalManager()\n"
+@test sprint((t,x) -> show(t, "text/plain", x), LocalManager(1, true)) == "LocalManager()"

--- a/stdlib/Distributed/test/managers.jl
+++ b/stdlib/Distributed/test/managers.jl
@@ -23,5 +23,6 @@ sock = bind_client_port(TCPSocket(), typeof(IPv6(0)))
 addr, port = getsockname(sock)
 @test addr == ip"::"
 
-@test sprint((t,x) -> show(t, "text/plain", x), SSHManager("127.0.0.1")) == "SSHManager(machines=Dict{Any,Any}('.' => 3,'0' => 2,'1' => 2,'2' => 1,'7' => 1))"
+@test occursin(r"^SSHManager\(machines=.*\)$",
+               sprint((t,x) -> show(t, "text/plain", x), SSHManager("127.0.0.1")))
 @test sprint((t,x) -> show(t, "text/plain", x), LocalManager(1, true)) == "LocalManager()"


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/34933.

This PR makes the current `show` methods in `Distributed` for `LocalManager` and `SSHManager` extend `Base.show` (seems to have been a mistake before). Also added two tests to check that they actually get called now.

Closes #34933