### PR TITLE
Avoid OOB access of the line table during codegen.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6460,7 +6460,7 @@ static std::unique_ptr<Module> emit_function(
 
     if (do_coverage(mod_is_user_mod)) {
         coverageVisitLine(ctx, ctx.file, toplineno);
-        if (linetable.size() >= 1) {
+        if (linetable.size() >= 2) {
             // avoid double-counting the entry line
             const auto &info = linetable.at(1);
             if (info.file == ctx.file && info.line == toplineno && info.is_user_code == mod_is_user_mod)


### PR DESCRIPTION
Observed in https://github.com/JuliaGPU/CUDAnative.jl/pull/581, e.g. https://gitlab.com/JuliaGPU/CUDAnative.jl/-/jobs/457173436
Ref https://github.com/JuliaLang/julia/pull/34254