### PR TITLE
Fix `$(PYTHON)` paths for native windows executable or cygwin

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1018,7 +1018,7 @@ PYTHON_SYSTEM := $(shell $(PYTHON) -c 'from __future__ import print_function; im
 # If we're running on Cygwin, but using a native-windows Python, we need to use cygpath -w
 ifneq ($(and $(filter $(PYTHON_SYSTEM),Windows),$(findstring CYGWIN,$(BUILD_OS))),)
 define invoke_python
-$(PYTHON) "$$(shell cygpath -w "$(1)")"
+$(PYTHON) "$$(cygpath -w "$(1)")"
 endef
 else
 define invoke_python

--- a/Make.inc
+++ b/Make.inc
@@ -1018,7 +1018,7 @@ PYTHON_SYSTEM := $(shell $(PYTHON) -c 'from __future__ import print_function; im
 # If we're running on Cygwin, but using a native-windows Python, we need to use cygpath -w
 ifneq ($(and $(filter $(PYTHON_SYSTEM),Windows),$(findstring CYGWIN,$(BUILD_OS))),)
 define invoke_python
-$(PYTHON) "$(shell cygpath -w "$(1)")"
+$(PYTHON) "$$(shell cygpath -w "$(1)")"
 endef
 else
 define invoke_python

--- a/Make.inc
+++ b/Make.inc
@@ -1014,7 +1014,7 @@ endif
 # about version, generally, so just find something that works:
 PYTHON := $(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)
 PYTHON_SYSTEM := $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())'
-ifneq ($(filter $(call lowercase,$(PYTHON_SYSTEM)),cygwin),)
+ifneq ($(filter $(PYTHON_SYSTEM),CYGWIN),)
 define invoke_python
 "$(PYTHON)" "$(call cygpath_w,$(1))"
 endef

--- a/Make.inc
+++ b/Make.inc
@@ -1012,15 +1012,15 @@ endif
 
 # We need python for things like BB triplet recognition.  We don't really care
 # about version, generally, so just find something that works:
-PYTHON := $(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)
-PYTHON_SYSTEM := $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())'
+PYTHON := "$(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)"
+PYTHON_SYSTEM := $(shell $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())')
 ifneq ($(filter $(PYTHON_SYSTEM),CYGWIN),)
 define invoke_python
-"$(PYTHON)" "$(call cygpath_w,$(1))"
+$(PYTHON) "$(call cygpath_w,$(1))"
 endef
 else
 define invoke_python
-"$(PYTHON)" "$(1)"
+$(PYTHON) "$(1)"
 endef
 endif
 

--- a/Make.inc
+++ b/Make.inc
@@ -1014,9 +1014,11 @@ endif
 # about version, generally, so just find something that works:
 PYTHON := "$(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)"
 PYTHON_SYSTEM := $(shell $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())')
-ifneq ($(filter $(PYTHON_SYSTEM),Windows),)
+
+# If we're running on Cygwin, but using a native-windows Python, we need to use cygpath -w
+ifneq ($(and $(filter $(PYTHON_SYSTEM),Windows),$(findstring CYGWIN,$(BUILD_OS))),)
 define invoke_python
-$(PYTHON) "$(call cygpath_w,$(1))"
+$(PYTHON) "$(shell cygpath -w "$(1)")"
 endef
 else
 define invoke_python

--- a/Make.inc
+++ b/Make.inc
@@ -1014,7 +1014,7 @@ endif
 # about version, generally, so just find something that works:
 PYTHON := "$(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)"
 PYTHON_SYSTEM := $(shell $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())')
-ifneq ($(filter $(PYTHON_SYSTEM),CYGWIN),)
+ifneq ($(filter $(PYTHON_SYSTEM),Windows),)
 define invoke_python
 $(PYTHON) "$(call cygpath_w,$(1))"
 endef

--- a/Make.inc
+++ b/Make.inc
@@ -1013,13 +1013,23 @@ endif
 # We need python for things like BB triplet recognition.  We don't really care
 # about version, generally, so just find something that works:
 PYTHON := $(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)
+PYTHON_SYSTEM := $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())'
+ifneq ($(filter $(call lowercase,$(PYTHON_SYSTEM)),cygwin),)
+define invoke_python
+$(PYTHON) $(call cygpath_w,$(1))
+endef
+else
+define invoke_python
+$(PYTHON) $(1)
+endef
+endif
 
 # BinaryBuilder options.  We default to "on" for all the projects listed in BB_PROJECTS,
 # but only if contrib/normalize_triplet.py works for our requested triplet.
-ifeq ($(shell $(PYTHON) $(JULIAHOME)/contrib/normalize_triplet.py $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) >/dev/null 2>/dev/null; echo $$?),0)
+ifeq ($(shell $(call invoke_python,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) >/dev/null 2>/dev/null; echo $$?),0)
 USE_BINARYBUILDER ?= 1
 else
-ifneq ($(shell $(PYTHON) $(JULIAHOME)/contrib/normalize_triplet.py x86_64-linux-gnu),x86_64-linux-gnu)
+ifneq ($(shell $(call invoke_python,$(JULIAHOME)/contrib/normalize_triplet.py) x86_64-linux-gnu),x86_64-linux-gnu)
 $(warning normalize_triplet.py appears to be non-functional (used python interpreter "$(PYTHON)"), so BinaryBuilder disabled)
 endif
 USE_BINARYBUILDER ?= 0

--- a/Make.inc
+++ b/Make.inc
@@ -1016,11 +1016,11 @@ PYTHON := $(shell which python 2>/dev/null || which python3 2>/dev/null || which
 PYTHON_SYSTEM := $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())'
 ifneq ($(filter $(call lowercase,$(PYTHON_SYSTEM)),cygwin),)
 define invoke_python
-$(PYTHON) $(call cygpath_w,$(1))
+"$(PYTHON)" "$(call cygpath_w,$(1))"
 endef
 else
 define invoke_python
-$(PYTHON) $(1)
+"$(PYTHON)" "$(1)"
 endef
 endif
 

--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -5,7 +5,7 @@
 #    4 cxx11)                  # signifies a cxx11 ABI dependency
 
 # Auto-detect triplet once, create different versions that we use as defaults below for each BB install target
-BB_TRIPLET_LIBGFORTRAN_CXXABI := $(shell $(PYTHON) $(JULIAHOME)/contrib/normalize_triplet.py $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(or $(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' ),1)")
+BB_TRIPLET_LIBGFORTRAN_CXXABI := $(shell $(call invoke_python,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(or $(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' ),1)")
 BB_TRIPLET_LIBGFORTRAN := $(subst $(SPACE),-,$(filter-out cxx%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI))))
 BB_TRIPLET_CXXABI := $(subst $(SPACE),-,$(filter-out libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI))))
 BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI)))))


### PR DESCRIPTION
We auto-detect by inspecting the output of `platform.system()`