### PR TITLE
Reexport the LLVM context.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -147,7 +147,7 @@ extern JITEventListener *CreateJuliaJITEventListener();
 bool imaging_mode = false;
 
 // shared llvm state
-static LLVMContext &jl_LLVMContext = *(new LLVMContext());
+JL_DLLEXPORT LLVMContext &jl_LLVMContext = *(new LLVMContext());
 TargetMachine *jl_TargetMachine;
 Module *shadow_output;
 static DataLayout &jl_data_layout = *(new DataLayout(""));


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/25984#discussion_r167396607

Although aotcompile has an accessor for the context of a native object, LLVM.jl currently needs it earlier during generated function expansion. Future work should give us a way to return IR to the compiler differently, e.g. [this julep](https://github.com/vtjnash/julep/wiki/0002:-Enhanced-llvmcall#support-for-generated-llvmcall). In the meantime, reexport the context since it's global anyway.