### PR TITLE
Emit structs as LLVM structures

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -733,8 +733,10 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, jl_
         else if (isarray && !type_is_ghost(lasttype)) {
             if (isTuple && isvector && jl_special_vector_alignment(ntypes, jlasttype) != 0)
                 struct_decl = VectorType::get(lasttype, ntypes);
-            else
+            else if (isTuple)
                 struct_decl = ArrayType::get(lasttype, ntypes);
+            else
+                struct_decl = StructType::get(jl_LLVMContext, latypes);
         }
         else {
 #if 0 // stress-test code that tries to assume julia-index == llvm-index

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -733,7 +733,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, jl_
         else if (isarray && !type_is_ghost(lasttype)) {
             if (isTuple && isvector && jl_special_vector_alignment(ntypes, jlasttype) != 0)
                 struct_decl = VectorType::get(lasttype, ntypes);
-            else if (isTuple)
+            else if (isTuple || !llvmcall)
                 struct_decl = ArrayType::get(lasttype, ntypes);
             else
                 struct_decl = StructType::get(jl_LLVMContext, latypes);

--- a/test/llvmpasses/llvmcall.jl
+++ b/test/llvmpasses/llvmcall.jl
@@ -5,6 +5,11 @@
 
 include(joinpath("..", "testhelpers", "llvmpasses.jl"))
 
+struct Foo
+    x::Int32
+    y::Int32
+end
+
 @generated foo(x)=:(ccall("extern foo", llvmcall, $x, ($x,), x))
 bar(x) = ntuple(i -> VecElement{Float16}(x[i]), 2)
 
@@ -19,6 +24,9 @@ emit(foo, NTuple{2, VecElement{Float16}})
 
 # CHECK: call i8 addrspace(3)* @foo(i8 addrspace(3)* %{{[0-9]+}})
 emit(foo, Core.AddrSpacePtr{Float32, 3})
+
+# CHECK: call { i32, i32 } @foo({ i32, i32 } %{{[0-9]+}})
+emit(foo, Foo)
 
 # CHECK: define <2 x i16> @julia_bar_{{[0-9]+}}([2 x i16]
 emit(bar, NTuple{2, Float16})


### PR DESCRIPTION
AFAICT, there is no way to call LLVM intrinsics with structure arguments/return values with `ccall`.
This PR changes the LLVM representation of Julia structs to LLVM structures (instead of LLVM arrays).

// cc: @maleadt 