### PR TITLE
Distributed: add missing check on return code

### DIFF
--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -511,7 +511,7 @@ function connect_w2w(pid::Int, config::WorkerConfig)
     (s,s)
 end
 
-const client_port = Ref{Cushort}(0)
+const client_port = Ref{UInt16}(0)
 
 function socket_reuse_port(iptype)
     if ccall(:jl_has_so_reuseport, Int32, ()) == 1
@@ -523,6 +523,8 @@ function socket_reuse_port(iptype)
         bind_early && bind_client_port(sock, iptype)
         rc = ccall(:jl_tcp_reuseport, Int32, (Ptr{Cvoid},), sock.handle)
         if rc < 0
+            close(sock)
+
             # This is an issue only on systems with lots of client connections, hence delay the warning
             nworkers() > 128 && @warn "Error trying to reuse client port number, falling back to regular socket" maxlog=1
 
@@ -538,9 +540,10 @@ end
 
 function bind_client_port(sock::TCPSocket, iptype)
     bind_host = iptype(0)
-    Sockets.bind(sock, bind_host, client_port[])
-    _addr, port = getsockname(sock)
-    client_port[] = port
+    if Sockets.bind(sock, bind_host, client_port[])
+        _addr, port = getsockname(sock)
+        client_port[] = port
+    end
     return sock
 end
 

--- a/stdlib/Distributed/test/managers.jl
+++ b/stdlib/Distributed/test/managers.jl
@@ -15,13 +15,13 @@ using Distributed: parse_machine, bind_client_port, SSHManager, LocalManager
 @test_throws ArgumentError parse_machine("127.0.0.1:0")
 @test_throws ArgumentError parse_machine("127.0.0.1:65536")
 
-sock = bind_client_port(TCPSocket(), typeof(IPv4(0)))
-addr, port = getsockname(sock)
-@test addr == ip"0.0.0.0"
-
-sock = bind_client_port(TCPSocket(), typeof(IPv6(0)))
-addr, port = getsockname(sock)
-@test addr == ip"::"
+for ip in (IPv4(0), IPv6(0))
+    sock = TCPSocket()
+    @test bind_client_port(sock, typeof(ip)) === sock
+    addr, port = getsockname(sock)
+    @test addr === ip
+    @test port::UInt16 === Distributed.client_port[] != 0
+end
 
 @test occursin(r"^SSHManager\(machines=.*\)$",
                sprint((t,x) -> show(t, "text/plain", x), SSHManager("127.0.0.1")))


### PR DESCRIPTION
We were failing to check the return value, which meant we'd throw it on the subsequent line instead and self-destruct that worker.

This got lost when enabling on OSX in 0394f47f455defd5758dc7031266a0eb0adebc57