### PR TITLE
fix #34105, unescape triple-quoted strings after dedenting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,16 @@ Language changes
 
 * The syntax `(;)` (which was deprecated in v1.4) now creates an empty named tuple ([#30115]).
 
+* In triple-quoted string literals, whitespace stripping is now done before processing
+  escape sequences instead of after. For example, the syntax
+  ```
+  """
+    a\n b"""
+  ```
+  used to yield the string " a\nb", since the single space before `b` set the indent level.
+  Now the result is "a\n b", since the space before `b` is no longer considered to occur
+  at the start of a line. The old behavior is considered a bug ([#35001]).
+
 Multi-threading changes
 -----------------------
 

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -642,7 +642,7 @@ julia> """
 
 Trailing whitespace is left unaltered.
 
-Triple-quoted string literals can contain `"` symbols without escaping.
+Triple-quoted string literals can contain `"` characters without escaping.
 
 Note that line breaks in literal strings, whether single- or triple-quoted, result in a newline
 (LF) character `\n` in the string, even if your editor uses a carriage return `\r` (CR) or CRLF

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2051,15 +2051,19 @@
 (define (parse-raw-literal s delim)
   (car (parse-string-literal s delim #t)))
 
+(define (unescape-parsed-string-literal strs)
+  (map-at even? unescape-string strs))
+
 (define (parse-string-literal s delim raw)
   (let ((p (ts:port s)))
-    (if (eqv? (peek-char p) delim)
-        (if (eqv? (peek-char (take-char p)) delim)
-            (map-first strip-leading-newline
-                       (dedent-triplequoted-string
-                        (parse-string-literal- 2 (take-char p) s delim raw)))
-            (list ""))
-        (parse-string-literal- 0 p s delim raw))))
+    ((if raw identity unescape-parsed-string-literal)
+     (if (eqv? (peek-char p) delim)
+         (if (eqv? (peek-char (take-char p)) delim)
+             (map-first strip-leading-newline
+                        (dedent-triplequoted-string
+                         (parse-string-literal- 2 (take-char p) s delim raw)))
+             (list ""))
+         (parse-string-literal- 0 p s delim raw)))))
 
 (define (strip-leading-newline s)
   (let ((n (sizeof s)))
@@ -2163,11 +2167,6 @@
                    (else (error "invalid interpolation syntax")))))
           (else (error (string "invalid interpolation syntax: \"$" c "\""))))))
 
-(define (tostr raw io)
-  (if raw
-      (io.tostring! io)
-      (let ((str (unescape-string (io.tostring! io)))) str)))
-
 ;; raw = raw string literal
 ;; when raw is #t, unescape only \\ and delimiter
 ;; otherwise do full unescaping, and parse interpolations too
@@ -2180,7 +2179,7 @@
       ((eqv? c delim)
        (if (< quotes n)
            (loop (read-char p) b e (+ quotes 1))
-           (reverse (cons (tostr raw b) e))))
+           (reverse (cons (io.tostring! b) e))))
 
       ((= quotes 1)
        (if (not raw) (write-char #\\ b))
@@ -2220,7 +2219,7 @@
        (let ((ex (parse-interpolate s)))
          (loop (read-char p)
                (open-output-string)
-               (list* ex (tostr raw b) e)
+               (list* ex (io.tostring! b) e)
                0)))
 
       ; convert literal \r and \r\n in strings to \n (issue #11988)
@@ -2269,7 +2268,7 @@
                                       (write-char (not-eof-1 (read-char (ts:port s)))
                                                   b))
                                   (loop (read-char (ts:port s))))))
-                     (let ((str (tostr #f b)))
+                     (let ((str (unescape-string (io.tostring! b))))
                        (let ((len (string-length str)))
                          (if (= len 1)
                              (string.char str 0)

--- a/test/triplequote.jl
+++ b/test/triplequote.jl
@@ -52,7 +52,7 @@ s = "   p"
       """ == " $s$(nl)"
 @test """\t""" == "\t"
 @test """
-      \t""" == ""
+      \t""" == "\t"
 @test """
       foo
       \tbar""" == "foo$(nl)\tbar"
@@ -66,3 +66,10 @@ s = "   p"
 @test """
       $("\n      ")
       """ == "\n      $(nl)"
+
+# issue #34105
+let str = "   yoyo"
+    interp = """interpolate:\n$str
+    next line"""
+    @test interp == "interpolate:\n   yoyo\nnext line"
+end


### PR DESCRIPTION
It seems clear to me that triple-quoted strings should only specially handle whitespace that directly occurs in the source text, not including escape sequences. This also makes it easier to fix #34967, since if unescaping is done first then you get a UTF-8 error when we try to strip whitespace if you write invalid UTF-8 strings using escape sequences (which is allowed of course).
But, this could be breaking since it obviously changes the values of some string literals.

fix #34105