### PR TITLE
Improving sort performance by handling AbstractVector and rev=true by counting sort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -728,14 +728,13 @@ end
 # sort! for vectors of few unique integers
 function sort_int_range!(x::AbstractVector{<:Integer}, rangelen, minval, maybereverse)
     offs = 1 - minval
-    n = length(x)
 
     where = fill(0, rangelen)
-    @inbounds for i = 1:n
+    @inbounds for i = eachindex(x)
         where[x[i] + offs] += 1
     end
 
-    idx = 1
+    idx = firstindex(x)
     @inbounds for i = maybereverse(1:rangelen)
         lastidx = idx + where[i] - 1
         val = i-offs

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -711,7 +711,7 @@ function sort!(v::AbstractVector;
                rev::Union{Bool,Nothing}=nothing,
                order::Ordering=Forward)
     ordr = ord(lt,by,rev,order)
-    if ordr === Forward && isa(v,Vector) && eltype(v)<:Integer
+    if ordr === Forward && eltype(v)<:Integer
         n = length(v)
         if n > 1
             min, max = extrema(v)
@@ -726,7 +726,7 @@ function sort!(v::AbstractVector;
 end
 
 # sort! for vectors of few unique integers
-function sort_int_range!(x::Vector{<:Integer}, rangelen, minval)
+function sort_int_range!(x::AbstractVector{<:Integer}, rangelen, minval)
     offs = 1 - minval
     n = length(x)
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -6,6 +6,9 @@ using Base.Order
 using Random
 using Test
 
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
+
 @testset "Order" begin
     @test Forward == ForwardOrdering()
     @test ReverseOrdering(Forward) == ReverseOrdering() == Reverse
@@ -508,6 +511,10 @@ end
 
     a = view([9:-1:0;], :)::SubArray
     Base.Sort.sort_int_range!(a, 10, 0, identity)  # test it supports non-Vector
+    @test issorted(a)
+
+    a = OffsetArray([9:-1:0;], -5)
+    Base.Sort.sort_int_range!(a, 10, 0, identity)
     @test issorted(a)
 end
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -507,7 +507,7 @@ end
     @test issorted(a)
 
     a = view([9:-1:0;], :)::SubArray
-    Base.Sort.sort_int_range!(a, 10, 0)  # test it supports non-Vector
+    Base.Sort.sort_int_range!(a, 10, 0, identity)  # test it supports non-Vector
     @test issorted(a)
 end
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -501,4 +501,14 @@ end
     @test isequal(a, [8,6,7,NaN,5,3,0,9])
 end
 
+@testset "sort!(::AbstractVector{<:Integer}) with short int range" begin
+    a = view([9:-1:0;], :)::SubArray
+    sort!(a)
+    @test issorted(a)
+
+    a = view([9:-1:0;], :)::SubArray
+    Base.Sort.sort_int_range!(a, 10, 0)  # test it supports non-Vector
+    @test issorted(a)
+end
+
 end


### PR DESCRIPTION
Currently, sorting integers with small range in a `SubArray` is slower than the same case with a `Vector`:

```julia
julia> xs = rand(0:9, 1000);

julia> @btime sort!(xs) setup=(xs = $(copy(xs)); copyto!(xs, $xs));
  1.559 μs (1 allocation: 160 bytes)

julia> @btime sort!(xs) setup=(xs = view($(copy(xs)), :); copyto!(xs, $xs));
  5.136 μs (0 allocations: 0 bytes)
```

First commit "fixes" it:

```julia
julia> @btime sort!(xs) setup=(xs = view($(copy(xs)), :); copyto!(xs, $xs));
  2.745 μs (1 allocation: 160 bytes)
```

It's not as fast as the `Vector` case but I think it's mostly due to non-optimized `extrema`:

```julia
julia> @btime extrema(xs);
  194.520 ns (1 allocation: 32 bytes)

julia> @btime extrema(view(xs, :));
  988.615 ns (2 allocations: 80 bytes)
```

In the second commit, I tweaked the counting sort a bit to handle `rev = true` case:

Before:

```julia
julia> @btime sort!(xs; rev=true) setup=(xs = $(copy(xs)); copyto!(xs, $xs));
  5.754 μs (0 allocations: 0 bytes)
```

After:

```julia
julia> @btime sort!(xs; rev=true) setup=(xs = $(copy(xs)); copyto!(xs, $xs));
  1.670 μs (1 allocation: 160 bytes)
```
