### PR TITLE
 Improve `fld` documentation following PR #17754 

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -89,7 +89,7 @@ julia> 6.0/0.1
 julia> 6.0/big(0.1)
 59.99999999999999666933092612453056361837965690217069245739573412231113406246995
 ```
-
+What is happening here is that the true value of the floating-point number written as `0.1` is slightly larger than the numerical value 1/10 while `6.0` represents the number 6 precisely. Therefore the true value of `6.0 / 0.1` is slightly less than 60. When doing division, this is rounded to precisely `60.0`, but `fld(6.0, 0.1)` always takes the floor or the true value, so the result is `59.0`.
 """
 fld(a, b) = div(a, b, RoundDown)
 

--- a/base/div.jl
+++ b/base/div.jl
@@ -80,6 +80,16 @@ See also: [`div`](@ref)
 julia> fld(7.3,5.5)
 1.0
 ```
+Because of floating-point rounding `fld(x,y)` can lead to an *alleged* violation of the fld(x,y) == x/y condition:
+```jldoctest
+julia> fld(6.0/0.1)
+59.0
+julia> 6.0/0.1
+60.0
+julia> 6.0/big(0.1)
+59.99999999999999666933092612453056361837965690217069245739573412231113406246995
+```
+
 """
 fld(a, b) = div(a, b, RoundDown)
 

--- a/base/div.jl
+++ b/base/div.jl
@@ -80,7 +80,8 @@ See also: [`div`](@ref)
 julia> fld(7.3,5.5)
 1.0
 ```
-Because `fld(x, y)` implements strictly correct floored rounding based on the true of floating-point numbers, unintuitive situations can arise. For example:
+Because `fld(x, y)` implements strictly correct floored rounding based on the true
+value of floating-point numbers, unintuitive situations can arise. For example:
 ```jldoctest
 julia> fld(6.0,0.1)
 59.0
@@ -89,7 +90,11 @@ julia> 6.0/0.1
 julia> 6.0/big(0.1)
 59.99999999999999666933092612453056361837965690217069245739573412231113406246995
 ```
-What is happening here is that the true value of the floating-point number written as `0.1` is slightly larger than the numerical value 1/10 while `6.0` represents the number 6 precisely. Therefore the true value of `6.0 / 0.1` is slightly less than 60. When doing division, this is rounded to precisely `60.0`, but `fld(6.0, 0.1)` always takes the floor or the true value, so the result is `59.0`.
+What is happening here is that the true value of the floating-point number written
+as `0.1` is slightly larger than the numerical value 1/10 while `6.0` represents
+the number 6 precisely. Therefore the true value of `6.0 / 0.1` is slightly less
+than 60. When doing division, this is rounded to precisely `60.0`, but
+`fld(6.0, 0.1)` always takes the floor or the true value, so the result is `59.0`.
 """
 fld(a, b) = div(a, b, RoundDown)
 

--- a/base/div.jl
+++ b/base/div.jl
@@ -80,7 +80,7 @@ See also: [`div`](@ref)
 julia> fld(7.3,5.5)
 1.0
 ```
-Because of floating-point rounding `fld(x,y)` can lead to an *alleged* violation of the `fld(x,y) == x/y` condition:
+Because `fld(x, y)` implements strictly correct floored rounding based on the true of floating-point numbers, unintuitive situations can arise. For example:
 ```jldoctest
 julia> fld(6.0,0.1)
 59.0

--- a/base/div.jl
+++ b/base/div.jl
@@ -80,9 +80,9 @@ See also: [`div`](@ref)
 julia> fld(7.3,5.5)
 1.0
 ```
-Because of floating-point rounding `fld(x,y)` can lead to an *alleged* violation of the fld(x,y) == x/y condition:
+Because of floating-point rounding `fld(x,y)` can lead to an *alleged* violation of the `fld(x,y) == x/y` condition:
 ```jldoctest
-julia> fld(6.0/0.1)
+julia> fld(6.0,0.1)
 59.0
 julia> 6.0/0.1
 60.0


### PR DESCRIPTION
Hi,
this is my first attempt to do a pull request - so if I did something wrong I would be happy to know how to do it better.

Following the discussion in [PR #17754](https://github.com/JuliaLang/julia/pull/17754), I think that it is of value to add an example to the documentation of `fld(x,y)` that warns the user that `x/y` might not be the expected result due to floating point rounding. 

I thus added an explicit example plus description in the `#Examples` section. (see below)

As to the workflow: I forked the repository, made changes in a branch and merged with my master. However, travis checks failed because I exceeded maximum run times. I nevertheless wanted to try this PR now to see if you agree in principle, and if so, how I can properly run checks that documentations compile.
