### PR TITLE
Add broadcasting examples to `in` and `∉` docstrings.

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1083,11 +1083,10 @@ You may also negate the `in` by doing `!(a in b)` which is logically similar to 
 
 When broadcasting with `in.(items, collection)` or `items .∈ collection`, both
 `item` and `collection` are broadcasted over, which is often not what is intended.
-For example, if both arguments are vectors, the result is a vector indicating whether
-each value in collection `items` is `in` the value at the corresponding position
-in `collection`.
-To get a vector indicating whether each value in `items` is in `collection`,
-wrap `collection` in a tuple or a `Ref` like this:
+For example, if both arguments are vectors (and the dimensions match), the result is
+a vector indicating whether each value in collection `items` is `in` the value at the
+corresponding position in `collection`. To get a vector indicating whether each value
+in `items` is in `collection`, wrap `collection` in a tuple or a `Ref` like this:
 `in.(items, Ref(collection))` or `items .∈ Ref(collection)`.
 
 # Examples
@@ -1138,8 +1137,13 @@ in, ∋
 
 Negation of `∈` and `∋`, i.e. checks that `item` is not in `collection`.
 
-When broadcasting with `∉`, the collection will be broadcasted over unless the
-collection is wrapped in a tuple or a `Ref`.
+When broadcasting with `items .∉ collection`, both `item` and `collection` are
+broadcasted over, which is often not what is intended. For example, if both arguments
+are vectors (and the dimensions match), the result is a vector indicating whether
+each value in collection `items` is not in the value at the corresponding position
+in `collection`. To get a vector indicating whether each value in `items` is not in
+`collection`, wrap `collection` in a tuple or a `Ref` like this:
+`items .∉ Ref(collection)`.
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1109,6 +1109,16 @@ true
 
 julia> !(19 in a)
 false
+
+julia> [1, 2] .∈ [2, 3]
+2-element BitArray{1}:
+ 0
+ 0
+
+julia> [1, 2] .∈ ([2, 3],)
+2-element BitArray{1}:
+ 0
+ 1
 ```
 """
 in, ∋
@@ -1126,6 +1136,16 @@ true
 
 julia> 1 ∉ 1:3
 false
+
+julia> [1, 2] .∉ [2, 3]
+2-element BitArray{1}:
+ 1
+ 1
+
+julia> [1, 2] .∉ ([2, 3],)
+2-element BitArray{1}:
+ 1
+ 0
 ```
 """
 ∉, ∌

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1081,6 +1081,9 @@ is always a `Bool` and never `missing`.
 To determine whether an item is not in a given collection, see [`:∉`](@ref).
 You may also negate the `in` by doing `!(a in b)` which is logically similar to "not in".
 
+When broadcasting with `in` or `∈`, the collection will be broadcasted over unless the
+collection is wrapped in a tuple or a `Ref`.
+
 # Examples
 ```jldoctest
 julia> a = 1:3:20
@@ -1128,6 +1131,9 @@ in, ∋
     ∌(collection, item) -> Bool
 
 Negation of `∈` and `∋`, i.e. checks that `item` is not in `collection`.
+
+When broadcasting with `∉`, the collection will be broadcasted over unless the
+collection is wrapped in a tuple or a `Ref`.
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1081,8 +1081,14 @@ is always a `Bool` and never `missing`.
 To determine whether an item is not in a given collection, see [`:∉`](@ref).
 You may also negate the `in` by doing `!(a in b)` which is logically similar to "not in".
 
-When broadcasting with `in` or `∈`, the collection will be broadcasted over unless the
-collection is wrapped in a tuple or a `Ref`.
+When broadcasting with `in.(items, collection)` or `items .∈ collection`, both
+`item` and `collection` are broadcasted over, which is often not what is intended.
+For example, if both arguments are vectors, the result is a vector indicating whether
+each value in collection `items` is `in` the value at the corresponding position
+in `collection`.
+To get a vector indicating whether each value in `items` is in `collection`,
+wrap `collection` in a tuple or a `Ref` like this:
+`in.(items, Ref(collection))` or `items .∈ Ref(collection)`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This PR adds examples to the `in` and `∉` docstrings that show how to use those infix operators in broadcasting expressions where the collection on the right side is intended to be treated as scalar. I've included one example with the right side enclosed in a tuple and one without the tuple to demonstrate the difference between the two, since the latter is also valid syntax that could easily be confused with the right-side-as-a-scalar behavior.