### PR TITLE
Mention LinRange in the range docstring

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -370,8 +370,8 @@ julia> LinRange(1.5, 5.5, 9)
  1.5,2.0,2.5,3.0,3.5,4.0,4.5,5.0,5.5
 ```
 
-Compared to [`range`](@ref), `LinRange` should have less overhead but deal with floating point errors
-less cleanly:
+Compared to [`range`](@ref), `LinRange` should have less overhead but won't try to correct
+for floating point errors:
 ```julia
 julia> collect(-0.1:0.1:0.3)
 5-element Array{Float64,1}:
@@ -383,11 +383,11 @@ julia> collect(-0.1:0.1:0.3)
 
 julia> collect(LinRange(-0.1, 0.3, 5))
 5-element Array{Float64,1}:
- -0.1                   
+ -0.1
  -1.3877787807814457e-17
-  0.09999999999999999   
-  0.19999999999999998   
-  0.3    
+  0.09999999999999999
+  0.19999999999999998
+  0.3
 ```
 """
 struct LinRange{T} <: AbstractRange{T}

--- a/base/range.jl
+++ b/base/range.jl
@@ -369,6 +369,26 @@ julia> LinRange(1.5, 5.5, 9)
 9-element LinRange{Float64}:
  1.5,2.0,2.5,3.0,3.5,4.0,4.5,5.0,5.5
 ```
+
+Compared to [`range`](@ref), `LinRange` should have less overhead but deal with floating point errors
+less cleanly:
+```julia
+julia> collect(-0.1:0.1:0.3)
+5-element Array{Float64,1}:
+ -0.1
+  0.0
+  0.1
+  0.2
+  0.3
+
+julia> collect(LinRange(-0.1, 0.3, 5))
+5-element Array{Float64,1}:
+ -0.1                   
+ -1.3877787807814457e-17
+  0.09999999999999999   
+  0.19999999999999998   
+  0.3    
+```
 """
 struct LinRange{T} <: AbstractRange{T}
     start::T

--- a/base/range.jl
+++ b/base/range.jl
@@ -374,7 +374,7 @@ julia> LinRange(1.5, 5.5, 9)
 Compared to [`range`](@ref), `LinRange` should have less overhead but won't try to correct
 for floating point errors:
 ```julia
-julia> collect(-0.1:0.1:0.3)
+julia> collect(range(-0.1, 0.3, length=5))
 5-element Array{Float64,1}:
  -0.1
   0.0

--- a/base/range.jl
+++ b/base/range.jl
@@ -59,6 +59,8 @@ automatically such that there are `length` linearly spaced elements in the range
 If `step` and `stop` are provided and `length` is not, the overall range length will be computed
 automatically such that the elements are `step` spaced.
 
+For a simpler linearly spaced range-like object with less overhead, see [`LinRange`](@ref).
+
 `stop` may be specified as either a positional or keyword argument.
 
 !!! compat "Julia 1.1"

--- a/base/range.jl
+++ b/base/range.jl
@@ -60,7 +60,7 @@ If `step` and `stop` are provided and `length` is not, the overall range length 
 automatically such that the elements are `step` spaced.
 
 Special care is taken to ensure intermediate values are computed rationally.
-For a simpler linearly spaced range-like object with less overhead, see [`LinRange`](@ref).
+To avoid this induced overhead, see the [`LinRange`](@ref) constructor.
 
 `stop` may be specified as either a positional or keyword argument.
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -59,7 +59,8 @@ automatically such that there are `length` linearly spaced elements in the range
 If `step` and `stop` are provided and `length` is not, the overall range length will be computed
 automatically such that the elements are `step` spaced.
 
-Special care is taken to ensure intermediate values are computed rationally.  For a simpler linearly spaced range-like object with less overhead, see [`LinRange`](@ref).
+Special care is taken to ensure intermediate values are computed rationally.
+For a simpler linearly spaced range-like object with less overhead, see [`LinRange`](@ref).
 
 `stop` may be specified as either a positional or keyword argument.
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -371,8 +371,8 @@ julia> LinRange(1.5, 5.5, 9)
  1.5,2.0,2.5,3.0,3.5,4.0,4.5,5.0,5.5
 ```
 
-Compared to [`range`](@ref), `LinRange` should have less overhead but won't try to correct
-for floating point errors:
+Compared to using [`range`](@ref), directly constructing a `LinRange` should
+have less overhead but won't try to correct for floating point errors:
 ```julia
 julia> collect(range(-0.1, 0.3, length=5))
 5-element Array{Float64,1}:

--- a/base/range.jl
+++ b/base/range.jl
@@ -59,7 +59,7 @@ automatically such that there are `length` linearly spaced elements in the range
 If `step` and `stop` are provided and `length` is not, the overall range length will be computed
 automatically such that the elements are `step` spaced.
 
-For a simpler linearly spaced range-like object with less overhead, see [`LinRange`](@ref).
+Special care is taken to ensure intermediate values are computed rationally.  For a simpler linearly spaced range-like object with less overhead, see [`LinRange`](@ref).
 
 `stop` may be specified as either a positional or keyword argument.
 


### PR DESCRIPTION
I was recently quite surprised by https://github.com/JuliaLang/julia/issues/35022, but it was pointed out to me that perhaps I should just use `LinRange` which did indeed solve my problem.

However, I had no expectation from the docs on `range` that it can't be run at compile time if the arguments are literals, and I also didn't know that `LinRange` seems to exist to solve this problem. Hence, I think it's a good idea to mention this somehow in the docstring. 

```julia
julia> foo1() = range(-1, 1, length=10000)
foo1 (generic function with 1 method)

julia> foo2() = LinRange(-1, 1, 10000)
foo2 (generic function with 1 method)

julia> @btime foo1();
  118.294 ns (0 allocations: 0 bytes)

julia> @btime foo2();
  0.029 ns (0 allocations: 0 bytes)
```