### PR TITLE
Optimize foldl/foreach for zip(arrays...), CartesianIndices, etc.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1925,8 +1925,7 @@ julia> foreach(x -> println(x^2), a)
 ```
 """
 foreach(f) = (f(); nothing)
-foreach(f, itr) = (for x in itr; f(x); end; nothing)
-foreach(f, itrs...) = (for z in zip(itrs...); f(z...); end; nothing)
+# actual implementations are in reduce.jl
 
 ## map over arrays ##
 

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -64,6 +64,7 @@ add_with_overflow(x::Bool, y::Bool) = (x+y, false)
 include("indices.jl")
 include("array.jl")
 include("abstractarray.jl")
+foreach(f, itr) = (for x in itr; f(x); end; nothing)
 
 # core structures
 include("bitarray.jl")

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -381,6 +381,16 @@ module IteratorsMD
     first(iter::CartesianIndices) = CartesianIndex(map(first, iter.indices))
     last(iter::CartesianIndices)  = CartesianIndex(map(last, iter.indices))
 
+    # Use nested for-loop in `foldl` as it is much faster than `iterate`:
+    @inline Base._foldl_impl(op::OP, init, CI::CartesianIndices) where {OP} =
+        Base._foldl_product(init, CI.indices) do acc, args...
+            Base.@_inline_meta
+            op(acc, CartesianIndex(args))
+        end
+
+    @inline Base._foldl_impl(op::OP, init, ::CartesianIndices{0}) where {OP} =
+        Base._foldl_impl(op, init, (CartesianIndex(),))
+
     # When used as indices themselves, CartesianIndices can simply become its tuple of ranges
     @inline to_indices(A, inds, I::Tuple{CartesianIndices, Vararg{Any}}) =
         to_indices(A, inds, (I[1].indices..., tail(I)...))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -381,7 +381,8 @@ module IteratorsMD
     first(iter::CartesianIndices) = CartesianIndex(map(first, iter.indices))
     last(iter::CartesianIndices)  = CartesianIndex(map(last, iter.indices))
 
-    # Use nested for-loop in `foldl` as it is much faster than `iterate`:
+    # Use nested for-loop in `foldl` to generate code that can be
+    # easily vectorized by LLVM:
     @inline Base._foldl_impl(op::OP, init, CI::CartesianIndices) where {OP} =
         Base._foldl_product(init, CI.indices) do acc, args...
             Base.@_inline_meta

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -49,7 +49,10 @@ function foldl_impl(op::OP, nt, itr) where {OP}
     return v
 end
 
-@inline function _foldl_impl(op::OP, init, itr) where {OP}
+@inline _foldl_impl(op::OP, init, itr) where {OP} =
+    _foldl_default(op, init, itr)
+
+@inline function _foldl_default(op::OP, init, itr) where {OP}
     # Unroll the while loop once; if init is known, the call to op may
     # be evaluated at compile time
     y = iterate(itr)
@@ -65,7 +68,7 @@ end
 
 @inline function _foldl_impl(op::OP, init, array::AbstractArray) where {OP}
     if IndexStyle(array) isa IndexLinear
-        return invoke(_foldl_impl, Tuple{Any,Any,Any}, op, init, array)
+        return _foldl_default(op, init, array)
     else
         return _foldl_impl(init, CartesianIndices(array)) do acc, I
             @_inline_meta

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -34,9 +34,9 @@ mul_prod(x::SmallSigned, y::SmallSigned) = Int(x) * Int(y)
 mul_prod(x::SmallUnsigned, y::SmallUnsigned) = UInt(x) * UInt(y)
 mul_prod(x::Real, y::Real)::Real = x * y
 
-## foldl && mapfoldl
-
 struct _InitialValue end
+
+## foldl && mapfoldl
 
 function mapfoldl_impl(f::F, op::OP, nt, itr) where {F,OP}
     op′, itr′ = _xfadjoint(BottomRF(op), Generator(f, itr))


### PR DESCRIPTION
This PR implements performance an optimization for `foldl` on `CartesianIndices` and `product` by executing them as nested loops rather than invoking their custom `iterate` function on a single loop.  From this optimization, we can easily add performance optimizations of other functions such as `foldl(_, zip(arrays...))` and `foreach(_, arrays...)`.  For more contexts, see https://github.com/JuliaLang/julia/issues/9080#issuecomment-595543681, https://github.com/JuliaLang/julia/issues/9080#issuecomment-596029746, and https://github.com/JuliaLang/julia/issues/15648#issuecomment-511048192.

As we already have iterators-to-transducers automatic conversions #33526, iterator comprehensions wrapping `product`, i.e., anything of the form

```julia
(f(x, y, z) for x in xs, y in ys, z in zs if p(x, y, z))
```

can automatically get some performance boost.

I think this PR also addresses issue #9080.

## Benchmarks (issue #9080)

```julia
using BenchmarkTools

function sumcart_manual(A::AbstractMatrix)
    s = 0.0
    @inbounds for j = 1:size(A,2), i = 1:size(A,1)
        s += A[i,j]
    end
    s
end

function sumcart_iter(A)
    s = 0.0
    @inbounds for I in CartesianIndices(size(A))
        s += A[I]
    end
    s
end

function sumcart_foldl(A)
    foldl(CartesianIndices(size(A)); init=0.0) do s, I
        @inbounds s + A[I]
    end
end

A = rand(10^4, 10^4);
@btime sumcart_manual($A);  # 126.509 ms (0 allocations: 0 bytes)
@btime sumcart_iter($A);    # 145.124 ms (0 allocations: 0 bytes)
@btime sumcart_foldl($A);   # 125.753 ms (0 allocations: 0 bytes)
```

## Some more benchmarks

```julia
using BenchmarkTools
suite = BenchmarkGroup()
suite["sum(x == y for x in xs, y in ys)"] = @benchmarkable sum(
    x == y for x in (1, 2, 3, 4, 5, 6, 7, 8), y in $(rand(1:50, 10^3))
)
suite["sum(x * y for (x, y) in zip(A, transpose(B)))"] = @benchmarkable sum(
    x * y for (x, y) in zip($(rand(100, 100)), transpose($(rand(100, 100))))
)
suite["copyto!(A, transpose(B))"] = @benchmarkable begin
    A = $(zeros(100, 100))
    B = transpose($(rand(100, 100)))
    foreach(eachindex(A, B)) do I
        @inbounds A[I] = B[I]
    end
end
```

Before (1.5.0-DEV.416):

```
  "sum(x * y for (x, y) in zip(A, transpose(B)))" => Trial(19.145 μs)
  "sum(x == y for x in xs, y in ys)" => Trial(5.190 μs)
  "copyto!(A, transpose(B))" => Trial(15.972 μs)
```

After:

```
  "sum(x * y for (x, y) in zip(A, transpose(B)))" => Trial(10.593 μs)
  "sum(x == y for x in xs, y in ys)" => Trial(616.000 ns)
  "copyto!(A, transpose(B))" => Trial(5.733 μs)
```
