### PR TITLE
Run FD stress test in separate process

### DIFF
--- a/test/stress_fd_exec.jl
+++ b/test/stress_fd_exec.jl
@@ -1,0 +1,22 @@
+using Test
+let ps = Pipe[]
+    ulimit_n = tryparse(Int, readchomp(`sh -c 'ulimit -n'`))
+    try
+        for i = 1:100*something(ulimit_n, 1000)
+            p = Pipe()
+            Base.link_pipe!(p)
+            push!(ps, p)
+        end
+        if ulimit_n === nothing
+            @warn "`ulimit -n` is set to unlimited, fd exhaustion cannot be tested"
+            @test_broken false
+        else
+            @test false
+        end
+    catch ex
+        isa(ex, Base.IOError) || rethrow()
+        @test ex.code in (Base.UV_EMFILE, Base.UV_ENFILE)
+    finally
+        foreach(close, ps)
+    end
+end


### PR DESCRIPTION
As noted in #35011, the `stress` test is likely causing ENOMEM
errors in unrelated processes on FreeBSD as it's causing kernel
resource exhaustion. This fixes that by running that test with
a low FD ulimit (100). Should fix #23143. Closes #35011.