### PR TITLE
remove obsolete parentdims

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -408,21 +408,3 @@ function _indices_sub(i1::AbstractArray, I...)
     @_inline_meta
     (unsafe_indices(i1)..., _indices_sub(I...)...)
 end
-
-## Compatibility
-# deprecate?
-function parentdims(s::SubArray)
-    nd = ndims(s)
-    dimindex = Vector{Int}(undef, nd)
-    sp = strides(s.parent)
-    sv = strides(s)
-    j = 1
-    for i = 1:ndims(s.parent)
-        r = s.indices[i]
-        if j <= nd && (isa(r,AbstractRange) ? sp[i]*step(r) : sp[i]) == sv[j]
-            dimindex[j] = i
-            j += 1
-        end
-    end
-    dimindex
-end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -351,7 +351,6 @@ sA = view(A, 2:2, 1:5, :)
 @test @inferred(strides(sA)) == (1, 3, 15)
 @test parent(sA) == A
 @test parentindices(sA) == (2:2, 1:5, Base.Slice(1:8))
-@test Base.parentdims(sA) == [1:3;]
 @test size(sA) == (1, 5, 8)
 @test axes(sA) === (Base.OneTo(1), Base.OneTo(5), Base.OneTo(8))
 @test sA[1, 2, 1:8][:] == [5:15:120;]
@@ -363,7 +362,6 @@ sA[2:5:end] .= -1
 @test stride(sA,4) == 120
 test_bounds(sA)
 sA = view(A, 1:3, 1:5, 5)
-@test Base.parentdims(sA) == [1:2;]
 sA[1:3,1:5] .= -2
 @test all(A[:,:,5] .== -2)
 fill!(sA, -3)
@@ -373,14 +371,12 @@ sA[:] .= 4
 @test @inferred(strides(sA)) == (1,3)
 test_bounds(sA)
 sA = view(A, 1:3, 3:3, 2:5)
-@test Base.parentdims(sA) == [1:3;]
 @test size(sA) == (3,1,4)
 @test axes(sA) === (Base.OneTo(3), Base.OneTo(1), Base.OneTo(4))
 @test sA == A[1:3,3:3,2:5]
 @test sA[:] == A[1:3,3,2:5][:]
 test_bounds(sA)
 sA = view(A, 1:2:3, 1:3:5, 1:2:8)
-@test Base.parentdims(sA) == [1:3;]
 @test @inferred(strides(sA)) == (2,9,30)
 @test sA[:] == A[1:2:3, 1:3:5, 1:2:8][:]
 # issue #8807
@@ -409,7 +405,6 @@ A = copy(reshape(1:120, 3, 5, 8))
 sA = view(A, 2, :, 1:8)
 @test parent(sA) == A
 @test parentindices(sA) == (2, Base.Slice(1:5), 1:8)
-@test Base.parentdims(sA) == [2:3;]
 @test size(sA) == (5, 8)
 @test axes(sA) === (Base.OneTo(5), Base.OneTo(8))
 @test @inferred(strides(sA)) == (3,15)
@@ -421,13 +416,11 @@ sA[2:5:end] .= -1
 @test all(A[5:15:120] .== -1)
 test_bounds(sA)
 sA = view(A, 1:3, 1:5, 5)
-@test Base.parentdims(sA) == [1:2;]
 @test size(sA) == (3,5)
 @test axes(sA) === (Base.OneTo(3),Base.OneTo(5))
 @test @inferred(strides(sA)) == (1,3)
 test_bounds(sA)
 sA = view(A, 1:2:3, 3, 1:2:8)
-@test Base.parentdims(sA) == [1,3]
 @test size(sA) == (2,4)
 @test axes(sA) === (Base.OneTo(2), Base.OneTo(4))
 @test @inferred(strides(sA)) == (2,30)


### PR DESCRIPTION
Addresses issue #34951 

Remove function `parentdims` from `subarrays.jl` and the test file. 
