### PR TITLE
Allow the the REPL backend to run on the root Task

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -380,7 +380,8 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_fil
             # REPLDisplay
             pushdisplay(REPL.REPLDisplay(active_repl))
             _atreplinit(active_repl)
-            REPL.run_repl(active_repl, backend->(global active_repl_backend = backend))
+            backend_on_root_task = get(ENV,"JULIA_ROOT_REPL","") in ("1","yes")
+            REPL.run_repl(active_repl, backend->(global active_repl_backend = backend), backend_on_current_task=backend_on_root_task)
         end
     else
         # otherwise provide a simple fallback

--- a/base/client.jl
+++ b/base/client.jl
@@ -380,8 +380,7 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_fil
             # REPLDisplay
             pushdisplay(REPL.REPLDisplay(active_repl))
             _atreplinit(active_repl)
-            backend_on_root_task = get(ENV,"JULIA_ROOT_REPL","") in ("1","yes")
-            REPL.run_repl(active_repl, backend->(global active_repl_backend = backend), backend_on_current_task=backend_on_root_task)
+            REPL.run_repl(active_repl, backend->(global active_repl_backend = backend))
         end
     else
         # otherwise provide a simple fallback

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -234,7 +234,7 @@ struct REPLBackendRef
     response_channel::Channel
 end
 
-function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); backend_on_current_task = false)
+function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); backend_on_current_task = true)
     repl_channel = Channel(1)
     response_channel = Channel(1)
     if backend_on_current_task

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -138,7 +138,8 @@ end
 function start_repl_backend(repl_channel::Channel, response_channel::Channel)
     # Maintain legacy behavior of asynchronous backend
     backend = REPLBackend(repl_channel, response_channel, false)
-    @async start_repl_backend(backend)
+    # Assignment will be made twice, but will be immediately available
+    backend.backend_task = @async start_repl_backend(backend)
     return backend
 end
 function start_repl_backend(backend::REPLBackend,  @nospecialize(consumer = x -> nothing))
@@ -247,8 +248,8 @@ function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); ba
     backend = REPLBackend()
     backend_ref = REPLBackendRef(backend)
     if backend_on_current_task
-        frontend_task = @async run_frontend(repl, backend_ref)
-        backend = start_repl_backend(backend,consumer)
+        @async run_frontend(repl, backend_ref)
+        start_repl_backend(backend,consumer)
     else
         @async start_repl_backend(backend,consumer)
         run_frontend(repl, backend_ref)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -241,7 +241,11 @@ function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); ba
         backend = REPLBackend(repl_channel, response_channel, false)
         backend.backend_task = Base.current_task()
         consumer(backend)
-        frontend_task = @async run_frontend(repl, REPLBackendRef(repl_channel, response_channel))
+        frontend_task = @async begin
+            run_frontend(repl, REPLBackendRef(repl_channel, response_channel))
+            # Explicitly stop the backend REPL
+            put!(repl_channel,(nothing,-1))
+        end
         repl_backend_loop(backend)
     else
         backend = start_repl_backend(repl_channel, response_channel)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -243,7 +243,7 @@ struct REPLBackendRef
 end
 REPLBackendRef(backend::REPLBackend) = REPLBackendRef(backend.repl_channel,backend.response_channel)
 
-function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); backend_on_current_task = true)
+function run_repl(repl::AbstractREPL, @nospecialize(consumer = x -> nothing); backend_on_current_task::Bool = true)
     backend = REPLBackend()
     backend_ref = REPLBackendRef(backend)
     if backend_on_current_task

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1170,10 +1170,6 @@ backend = REPL.REPLBackend()
 frontend_task = @async begin
     try
         @testset "AST Transformations Async" begin
-            put!(backend.repl_channel,
-                 (:(Base.roottask === Base.current_task()),false))
-            reply = take!(backend.response_channel)
-            @test reply == (true, false)
             put!(backend.repl_channel, (:(1+1), false))
             reply = take!(backend.response_channel)
             @test reply == (2, false)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1150,16 +1150,44 @@ fake_repl() do stdin_write, stdout_read, repl
 end
 
 # AST transformations (softscope, Revise, OhMyREPL, etc.)
-repl_channel = Channel(1)
-response_channel = Channel(1)
-backend = REPL.start_repl_backend(repl_channel, response_channel)
-put!(repl_channel, (:(1+1), false))
-reply = take!(response_channel)
-@test reply == (2, false)
-twice(ex) = Expr(:tuple, ex, ex)
-push!(backend.ast_transforms, twice)
-put!(repl_channel, (:(1+1), false))
-reply = take!(response_channel)
-@test reply == ((2, 2), false)
-put!(repl_channel, (nothing, -1))
-Base.wait(backend.backend_task)
+@testset "AST Transformation" begin
+    backend = REPL.REPLBackend()
+    @async REPL.start_repl_backend(backend)
+    put!(backend.repl_channel, (:(1+1), false))
+    reply = take!(backend.response_channel)
+    @test reply == (2, false)
+    twice(ex) = Expr(:tuple, ex, ex)
+    push!(backend.ast_transforms, twice)
+    put!(backend.repl_channel, (:(1+1), false))
+    reply = take!(backend.response_channel)
+    @test reply == ((2, 2), false)
+    put!(backend.repl_channel, (nothing, -1))
+    Base.wait(backend.backend_task)
+end
+
+
+backend = REPL.REPLBackend()
+frontend_task = @async begin
+    try
+        @testset "AST Transformations Async" begin
+            put!(backend.repl_channel,
+                 (:(Base.roottask === Base.current_task()),false))
+            reply = take!(backend.response_channel)
+            @test reply == (true, false)
+            put!(backend.repl_channel, (:(1+1), false))
+            reply = take!(backend.response_channel)
+            @test reply == (2, false)
+            twice(ex) = Expr(:tuple, ex, ex)
+            push!(backend.ast_transforms, twice)
+            put!(backend.repl_channel, (:(1+1), false))
+            reply = take!(backend.response_channel)
+            @test reply == ((2, 2), false)
+        end
+    catch e
+        Base.rethrow(e)
+    finally
+        put!(backend.repl_channel, (nothing, -1))
+    end
+end
+REPL.start_repl_backend(backend)
+Base.wait(frontend_task)


### PR DESCRIPTION
This change allows the REPL backend to run on the root `Task` rather than running using `@async` on a new `Task` as done in `REPL.start_repl_backend`. When the change is activated by setting the environmental variable `JULIA_ROOT_REPL=1`, the statement `Base.roottask === Base.current_task()` will evaluate to `true` in the REPL.

Use of the environmental variable `JULIA_ROOT_REPL` is mainly meant to permit evaluation and testing in the near term. Movement of the backend REPL loop to `REPL.repl_backend_loop` and the addition of `backend_on_current_task` keyword argument to `REPL.run_repl` also facilitates running the REPL backend on the root Task by an outside package.

JavaCall is a package for interoperability with the Java Virtual Machine that could benefit from a REPL backend running on the root Task. Currently `JULIA_COPY_STACKS=1` is required for JavaCall.jl to function properly on Mac and Linux. On the Windows operating system, `JULIA_COPY_STACKS=1` is not needed for JavaCall and may create more issues. This approach avoids the performance degradation involved in enabling `JULIA_COPY_STACKS=1`. If the REPL backend were run on the root `Task`, then `JULIA_COPY_STACKS=1` would not be required to run JavaCall on the REPL.

The status quo results in a segmentation fault on Linux run trying to run JavaCall:
```julia
$ ./julia --banner=no
julia> versioninfo()
Julia Version 1.5.0-DEV.422
Commit de4f8211b9* (2020-03-08 21:42 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: AMD FX(tm)-8350 Eight-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, bdver1)

julia> import Pkg; Pkg.status()
     Status `~/.julia/environments/v1.5/Project.toml`
   494afd89 JavaCall v0.7.3

julia> using JavaCall; JavaCall.init()
┌ Warning: JavaCall needs the environment variable `JULIA_COPY_STACKS` to be `1` or `yes`.
│ Calling the JVM may result in undefined behavior.
└ @ JavaCall ~/.julia/packages/JavaCall/0wJQZ/src/JavaCall.jl:38
Segmentation fault (core dumped)
```

With `JULIA_ROOT_REPL = 1` and the REPL backend running on the root `Task`, a segmentation fault does not occur and JavaCall functions perfectly. `JULIA_COPY_STACKS` does not need to be enabled here for JavaCall to function.
```julia
$ JULIA_ROOT_REPL=1 ./julia --banner=no
julia> versioninfo()
Julia Version 1.5.0-DEV.422
Commit de4f8211b9* (2020-03-08 21:42 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: AMD FX(tm)-8350 Eight-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, bdver1)
Environment:
  JULIA_ROOT_REPL = 1

julia> import Pkg; Pkg.status()
     Status `~/.julia/environments/v1.5/Project.toml`
   494afd89 JavaCall v0.7.3

julia> using JavaCall; JavaCall.init()
┌ Warning: JavaCall needs the environment variable `JULIA_COPY_STACKS` to be `1` or `yes`.
│ Calling the JVM may result in undefined behavior.
└ @ JavaCall ~/.julia/packages/JavaCall/0wJQZ/src/JavaCall.jl:38

julia> jlm = @jimport java.lang.Math
JavaObject{Symbol("java.lang.Math")}

julia> jcall(jlm, "sin", jdouble, (jdouble,), pi/2)
1.0

julia> jcall(jlm, "sin", jdouble, (jdouble,), pi/4)
0.7071067811865475
```

Further thoughts:
1. Perhaps running the REPL backend on the root `Task` should be the default behavior. I am not aware of a situation that actually requires the backend to run under `@async` on a non-root `Task`
2. This approach may allow Julia to drop the need for `JULIA_COPY_STACKS`, simplifying the code base.
3. Packages like JavaCall could enable functions that need to be executed from the root `Task` to be called on non-root `Tasks` through a similar `Channel` based system. Java is fully capable of asynchronous multithreaded behavior on its own.