### PR TITLE
de-duplicate strings in serialization

### DIFF
--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -582,3 +582,11 @@ let d = IdDict([1] => 2, [3] => 4), io = IOBuffer()
     @test Dict(d) == Dict(ds)
     @test all([k in keys(ds) for k in keys(ds)])
 end
+
+# issue #35030, shared references to Strings
+let s = join(rand('a':'z', 1024)), io = IOBuffer()
+    serialize(io, (s, s))
+    seekstart(io)
+    s2 = deserialize(io)
+    @test Base.summarysize(s2) < 2*sizeof(s)
+end


### PR DESCRIPTION
fixes #35030

- Follows the usual backwards compatibility rule (new versions can read old files, but old versions can't necessarily read new files)
- I opted to do this by adding a tag that can be used in general to add optional backreferences for any type that one might want to de-duplicate

There are two design choices:
- Do we try to de-duplicate all strings (which this PR does), or save the exact reference topology we have in memory?
- Do we use a size cutoff (this PR uses 7), or apply this to all strings? Some datasets do have large numbers of non-unique small strings.