### PR TITLE
Support git credential helper resetting

### DIFF
--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -222,21 +222,11 @@ function credential_helpers(cfg::GitConfig, cred::GitCredential)
         ismatch(url, cred) || continue
 
         # An empty credential.helper resets the list to empty
-        isempty(value) && empty!(helpers)
-
-        # Due to a bug in libgit2 iteration we may read credential helpers out of order.
-        # See: https://github.com/libgit2/libgit2/issues/4361
-        #
-        # Typically the ordering doesn't matter but does in this particular case. Disabling
-        # credential helpers avoids potential issues with using the wrong credentials or
-        # writing credentials to the wrong helper.
         if isempty(value)
-            @warn """Resetting the helper list is currently unsupported:
-                     ignoring all git credential helpers""" maxlog=1
-            return GitCredentialHelper[]
+            empty!(helpers)
+        else
+            Base.push!(helpers, parse(GitCredentialHelper, value))
         end
-
-        Base.push!(helpers, parse(GitCredentialHelper, value))
     end
 
     return helpers

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -1980,9 +1980,7 @@ mktempdir() do dir
                 mygit_cred = GitCredential("https", "mygithost")
 
                 @test LibGit2.credential_helpers(cfg, github_cred) == expected
-
-                println(stderr, "The following 'Resetting the helper list...' warning is expected:")
-                @test_broken LibGit2.credential_helpers(cfg, mygit_cred) == expected[2]
+                @test LibGit2.credential_helpers(cfg, mygit_cred) == expected[2:2]
 
                 Base.shred!(github_cred)
                 Base.shred!(mygit_cred)


### PR DESCRIPTION
Due to libgit2 fixing an [issue with iterator ordering](https://github.com/libgit2/libgit2/issues/4361) and Julia now [updating to a libgit2](https://github.com/JuliaLang/julia/pull/32806) release including that fix we now remove this fail safe.