### PR TITLE
faster randn!(::MersenneTwister, ::Array{Float64})

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -154,6 +154,8 @@ Standard library changes
 
 #### Random
 
+* `randn!(::MersenneTwister, ::Array{Float64})` is faster, and as a result, for a given state of the RNG,
+  the corresponding generated numbers have changed ([#35078]).
 
 #### REPL
 

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -39,7 +39,7 @@ end
     n1 = div(n, 2)
     n2 = 2*n1
 
-    Random.seed!(1234321)
+    Random.seed!(12343)
 
     areal = randn(n,n)/2
     aimg  = randn(n,n)/2

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -4,7 +4,7 @@ module TestSymmetric
 
 using Test, LinearAlgebra, SparseArrays, Random
 
-Random.seed!(101)
+Random.seed!(1010)
 
 @testset "Pauli σ-matrices: $σ" for σ in map(Hermitian,
         Any[ [1 0; 0 1], [0 1; 1 0], [0 -im; im 0], [1 0; 0 -1] ])

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -35,9 +35,11 @@ julia> randn(rng, ComplexF32, (2, 3))
   0.611224+1.56403im   0.355204-0.365563im  0.0905552+1.31012im
 ```
 """
-@inline function randn(rng::AbstractRNG=default_rng())
+@inline randn(rng::AbstractRNG=default_rng()) = _randn(rng, rand(rng, UInt52Raw()))
+
+@inline function _randn(rng::AbstractRNG, r::UInt64)
     @inbounds begin
-        r = rand(rng, UInt52())
+        r &= 0x000fffffffffffff
         rabs = Int64(r>>1) # One bit for the sign
         idx = rabs & 0xFF
         x = ifelse(r % Bool, -rabs, rabs)*wi[idx+1]
@@ -95,9 +97,11 @@ julia> randexp(rng, 3, 3)
  0.695867  0.693292  0.643644
 ```
 """
-function randexp(rng::AbstractRNG=default_rng())
+randexp(rng::AbstractRNG=default_rng()) = _randexp(rng, rand(rng, UInt52Raw()))
+
+function _randexp(rng::AbstractRNG, ri::UInt64)
     @inbounds begin
-        ri = rand(rng, UInt52())
+        ri &= 0x000fffffffffffff
         idx = ri & 0xFF
         x = ri*we[idx+1]
         ri < ke[idx+1] && return x # 98.9% of the time we return here 1st try
@@ -162,6 +166,7 @@ function randexp! end
 
 for randfun in [:randn, :randexp]
     randfun! = Symbol(randfun, :!)
+    _randfun = Symbol(:_, randfun)
     @eval begin
         # scalars
         $randfun(rng::AbstractRNG, T::BitFloatType) = convert(T, $randfun(rng))
@@ -171,6 +176,21 @@ for randfun in [:randn, :randexp]
         function $randfun!(rng::AbstractRNG, A::AbstractArray{T}) where T
             for i in eachindex(A)
                 @inbounds A[i] = $randfun(rng, T)
+            end
+            A
+        end
+
+        # optimization for MersenneTwister, which randomizes natively Array{Float64}
+        function $randfun!(rng::MersenneTwister, A::Array{Float64})
+            if length(A) < 13
+                for i in eachindex(A)
+                    @inbounds A[i] = $randfun(rng, Float64)
+                end
+            else
+                rand!(rng, A, CloseOpen12())
+                for i in eachindex(A)
+                    @inbounds A[i] = $_randfun(rng, reinterpret(UInt64, A[i]))
+                end
             end
             A
         end


### PR DESCRIPTION
The main idea is that 
1. `randn()` essentially needs one random `Float64` value (a bit more in rare cases)
2. `rand!(rng::MersenneTwister, ::Array{Float})` is optimized, compared to calling `rand(rng, Float64)` in a loop

So for `randn!`, let's use this optimized version by filling the array with _uniform_ float values, and then do a second pass to transform them into normal values. The same applies to `randexp!` but with a smaller improvement.

There is a threshold on the length of the array between 10-20 below which this refined algorithm is less performant, so we switch the algorithm depending on that length. Here are the speed-ups on my machine:

| length     | 5    | 10   | 50   | 100  | 300  | 600  | 1 000 | 10 000 | 100 000 | 1 000 000 |
| ----------------- | ---- | ---  | ---  | ---  | ---  | ---  | ---   | ---    | ---     | ---       |
| randn!            | 0.88 | 1.04 | 1.57 | 1.70 | 1.81 | 1.89 | 1.92  | 1.94   | 1.92    | 1.85      |
| randexp!          | 0.87 | 1.14 | 1.27 | 1.37 | 1.37 | 1.34 | 1.42  | 1.39   | 1.37    | 1.31      |

So for small arrays there is small "speed-down".

As future work, it would be interesting to see if this also applies to some other `AbstractArray`s, and to other RNGs which have optimized array generation, in which case we could have a "trait" for enabling this improvement.