### PR TITLE
Fix MacOS Notarization

### DIFF
--- a/contrib/mac/app/Entitlements.plist
+++ b/contrib/mac/app/Entitlements.plist
@@ -4,5 +4,19 @@
 <dict>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.debugger</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -51,7 +51,12 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	tar zxf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
 	if [ -n "$$MACOS_CODESIGN_IDENTITY" ]; then \
 	    echo "Codesigning with identity $$MACOS_CODESIGN_IDENTITY"; \
-		codesign -s "$$MACOS_CODESIGN_IDENTITY" --option=runtime --entitlements Entitlements.plist -v --deep $@; \
+		MACHO_FILES=$$(find "$@" -type f -perm -755 | cut -d: -f1); \
+		for f in $${MACHO_FILES}; do \
+			echo "Codesigning $${f}..."; \
+			codesign -s "$$MACOS_CODESIGN_IDENTITY" --option=runtime --entitlements Entitlements.plist -vvv --timestamp --deep --force "$${f}"; \
+		done; \
+		codesign -s "$$MACOS_CODESIGN_IDENTITY" --option=runtime --entitlements Entitlements.plist -vvv --timestamp --deep --force "$@"; \
 	else \
 		true; \
 	fi
@@ -62,7 +67,7 @@ ifneq ($(filter root,$(ROOTFILES)),)
 	@echo "We have to use sudo here to clean out folders owned by root.  You may be asked for your password"
 	sudo rm -rf dmg *.dmg notarize-*.xml
 else
-	rm -rf dmg *.dmg
+	rm -rf dmg *.dmg notarize-*.xml
 endif
 
 notarize-upload-$(DMG_NAME).xml: $(DMG_NAME)

--- a/contrib/mac/app/notarize_check.sh
+++ b/contrib/mac/app/notarize_check.sh
@@ -33,6 +33,10 @@ function wait_until_completed()
             echo -n "."
             sleep 10
             continue
+        elif [[ ${STATUS} == "invalid" ]]; then
+            echo "invalid!  Looks like something got borked:"
+            /usr/libexec/PlistBuddy -c "print notarization-info:LogFileURL" "${PLIST_FILE}" 2>/dev/null
+            exit 1
         else
             echo "Notarization failed with status ${STATUS}"
             exit 1


### PR DESCRIPTION
We need to individually sign each Mach-O file independently, otherwise notarization bails.  Note that you must sign the overall `.app` after each individual file is signed.

I've also added more Entitlements. I've gone for a "gentle shotgun" approach, turning on everything that I think we could reasonably want.  I wait expectantly for someone to complain that they need Location access turned on for some package.  ;)