### PR TITLE
Sockets: reconsider how to define `bind` failure

### DIFF
--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -540,11 +540,14 @@ end
 
 function bind_client_port(sock::TCPSocket, iptype)
     bind_host = iptype(0)
-    if Sockets.bind(sock, bind_host, client_port[])
-        _addr, port = getsockname(sock)
-        client_port[] = port
+    while true
+        if Sockets.bind(sock, bind_host, client_port[])
+            _addr, port = getsockname(sock)
+            client_port[] = port
+            return sock
+        end
+        client_port[] = 0
     end
-    return sock
 end
 
 function connect_to_worker(host::AbstractString, port::Integer)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1673,6 +1673,8 @@ let (h, t) = Distributed.head_and_tail(Int[], 0)
     @test collect(t) == []
 end
 
+include("splitrange.jl")
+
 # Run topology tests last after removing all workers, since a given
 # cluster at any time only supports a single topology.
 rmprocs(workers())

--- a/stdlib/Distributed/test/runtests.jl
+++ b/stdlib/Distributed/test/runtests.jl
@@ -11,5 +11,4 @@ if !success(pipeline(cmd; stdout=stdout, stderr=stderr)) && ccall(:jl_running_on
     error("Distributed test failed, cmd : $cmd")
 end
 
-include("macros.jl")
 include("managers.jl")

--- a/stdlib/Distributed/test/splitrange.jl
+++ b/stdlib/Distributed/test/splitrange.jl
@@ -2,7 +2,6 @@ using Test
 using Distributed
 using Distributed: splitrange
 
-# testing function macros.jl:splitrange
 @test splitrange(1, 11, 1) == Array{UnitRange{Int64},1}([1:11])
 @test splitrange(0, 10, 1) == Array{UnitRange{Int64},1}([0:10])
 @test splitrange(-1, 9, 1) == Array{UnitRange{Int64},1}([-1:9])
@@ -26,11 +25,7 @@ const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
 using .Main.OffsetArrays
 
-oa=OffsetArray([-1,0], (-2,))
-@distributed for i in eachindex(oa)
-	@test i <= 0
+oa = OffsetArray([123, -345], (-2,))
+@sync @distributed for i in eachindex(oa)
+    @test i ∈ (-1, 0)
 end
-
-# testing macros.jl:...
-# ... yet to be implemented
-


### PR DESCRIPTION
This test was being run on the wrong cluster, leading to semi-frequent test failures that look like this on CI: https://build.julialang.org/#/builders/65/builds/8733

```
Distributed                        (3) |   226.48 |   0.18 |  0.1 |      74.51 |  1784.14
┌ Error: Error on 4 while connecting to peer 3, exiting
│   exception =
│    IOError: connect: connection refused (ECONNREFUSED)
│    Stacktrace:
│     [1] wait_connected(::Sockets.TCPSocket) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Sockets\src\Sockets.jl:523
│     [2] connect at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Sockets\src\Sockets.jl:558 [inlined]
│     [3] connect_to_worker(::String, ::UInt16) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\managers.jl:562
│     [4] connect_w2w(::Int32, ::WorkerConfig) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\managers.jl:510
│     [5] connect(::Distributed.DefaultClusterManager, ::Int32, ::WorkerConfig) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\managers.jl:442
│     [6] connect_to_peer(::Distributed.DefaultClusterManager, ::Int32, ::WorkerConfig) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:373
│     [7] (::Distributed.var"#117#119"{Int32,WorkerConfig})() at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:357
│     [8] exec_conn_func(::Distributed.Worker) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\cluster.jl:179
│     [9] exec_conn_func(::Int32) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\cluster.jl:173
│     [10] (::Distributed.var"#106#108"{Distributed.CallMsg{:call_fetch}})() at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:294
│     [11] run_work_thunk(::Distributed.var"#106#108"{Distributed.CallMsg{:call_fetch}}, ::Bool) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:79
│     [12] macro expansion at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:294 [inlined]
│     [13] (::Distributed.var"#105#107"{Distributed.CallMsg{:call_fetch},Distributed.MsgHeader,Sockets.TCPSocket})() at .\task.jl:358
└ @ Distributed D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:380
bitarray                           (4) |         failed at 2020-03-11T19:26:13.509
Worker 4 terminated.┌ Error: Fatal error on process 1
│   exception =
│    attempt to send to unknown socket
│    Stacktrace:
│     [1] error(::String) at .\error.jl:33
│     [2] send_msg_unknown(::TCPSocket, ::Distributed.MsgHeader, ::Distributed.ResultMsg) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\messages.jl:111
│     [3] send_msg_now(::TCPSocket, ::Distributed.MsgHeader, ::Distributed.ResultMsg) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\messages.jl:127
│     [4] deliver_result(::TCPSocket, ::Symbol, ::Distributed.RRID, ::RemoteException) at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:111
│     [5] macro expansion at D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:302 [inlined]
│     [6] (::Distributed.var"#105#107"{Distributed.CallMsg{:call_fetch},Distributed.MsgHeader,TCPSocket})() at .\task.jl:358
└ @ Distributed D:\buildbot\worker\package_win32\build\usr\share\julia\stdlib\v1.5\Distributed\src\process_messages.jl:115

Error in testset bitarray:
Error During Test at none:1
  Test threw exception
  Expression: bitarray
  ProcessExitedException(4)
```