### PR TITLE
use CodeGenOpt::None at optlevel<2, Default at 2, and Aggressive at >2

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7451,7 +7451,9 @@ extern "C" void jl_init_llvm(void)
 #ifdef DISABLE_OPT
         CodeGenOpt::None;
 #else
-        (jl_options.opt_level == 0 ? CodeGenOpt::None : CodeGenOpt::Aggressive);
+        (jl_options.opt_level < 2 ? CodeGenOpt::None :
+         jl_options.opt_level == 2 ? CodeGenOpt::Default :
+         CodeGenOpt::Aggressive);
 #endif
     jl_TargetMachine = TheTarget->createTargetMachine(
             TheTriple.getTriple(), TheCPU, FeaturesStr,


### PR DESCRIPTION
This provides a little bit of speedup. I don't fully understand what these flags mean, but it seems to make sense to use `Default` at the default optimization level. Anyway I'm curious to see what the benchmarks say.

The difference in compile time between None and Default is quite large, with a much smaller difference between Default and Aggressive (which I assume is why we were using Aggressive most of the time). In fact using None for -O1 is even faster than using FastISel, so we might want to consider dropping FastISel entirely.

@nanosoldier `runbenchmarks(ALL, vs=":master")`