### PR TITLE
Allow packages to provide custom hints for Exceptions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,8 @@ New language features
 * Packages can now provide custom hints for specific `MethodError`s to
   help guide users. `push!` a pattern-matching function `hint(f,
   argtypes, kwargs)`, returning a message string in case of a match
-  and `nothing` otherwise, to `Base.methoderror_hints`. ([#35094])
+  and `nothing` otherwise, to `Base.methoderror_hints`.
+  See `?Base.methoderror_hints` for more information. ([#35094])
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,11 @@ New language features
   macros and matrix constructors, which are whitespace sensitive, because expressions like
   `[a ±b]` now get parsed as `[a ±(b)]` instead of `[±(a, b)]`. ([#34200])
 
+* Packages can now provide custom hints for specific `MethodError`s to
+  help guide users. `push!` a pattern-matching function `hint(f,
+  argtypes, kwargs)`, returning a message string in case of a match
+  and `nothing` otherwise, to `Base.methoderror_hints`. ([#35094])
+
 Language changes
 ----------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,11 +11,9 @@ New language features
   macros and matrix constructors, which are whitespace sensitive, because expressions like
   `[a ±b]` now get parsed as `[a ±(b)]` instead of `[±(a, b)]`. ([#34200])
 
-* Packages can now provide custom hints for specific `MethodError`s to
-  help guide users. `push!` a pattern-matching function `hint(f,
-  argtypes, kwargs)`, returning a message string in case of a match
-  and `nothing` otherwise, to `Base.methoderror_hints`.
-  See `?Base.methoderror_hints` for more information. ([#35094])
+* Packages can now provide custom hints to help users resolve errors by using the
+  `register_error_hint` function. Packages that define custom exception types
+  can support hints by calling `show_error_hints` from their `showerror` method. ([#35094])
 
 Language changes
 ----------------

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -222,6 +222,9 @@ specific `MethodError`s with `push!(Base.methoderror_hints, hintmessage)`, where
         end
         return nothing    # use `nothing` to indicate that f, arg_types, kwargs didn't match
     end
+
+!!! compat "Julia 1.5"
+    Custom MethodError hints are available as of Julia 1.5.
 """
 const methoderror_hints = []
 # Note: Base should not use `methoderror_hints`, it should inline

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -60,12 +60,8 @@ julia> module Hinter
        function __init__()
            register_error_hint(MethodError) do io, exc, argtypes, kwargs
                if exc.f == only_int
-                   if get(io, :color, false)
-                       print(io, "\nDid you mean to call ")
-                       printstyled(io, "`any_number`?", color=:light_magenta)
-                   else
-                       print(io, "\nDid you mean to call `any_number`?")
-                   end
+                    print(io, "\nDid you mean to call ")
+                    printstyled(io, "`any_number`?", color=:light_magenta)
                end
            end
        end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -223,6 +223,9 @@ specific `MethodError`s with `push!(Base.methoderror_hints, hintmessage)`, where
         return nothing    # use `nothing` to indicate that f, arg_types, kwargs didn't match
     end
 
+Packages should perform the `push!` onto `Base.methoderror_hints` from
+their `__init__` function.
+
 !!! compat "Julia 1.5"
     Custom MethodError hints are available as of Julia 1.5.
 """

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -215,13 +215,15 @@ Packages can provide hints about appropriate corrective actions for
 specific `MethodError`s with `push!(Base.methoderror_hints, hintmessage)`, where
 `hintmessage` should be a function like
 
-    function hintmessage(f, arg_types, kwargs)
-        # Test to see whether the call matches the specific pattern for this message
-        if f === myfunc && length(arg_types) == 1 && arg_types[1] <: SomeType
-            return "`myfunc(::SomeType)` is not defined, did you mean to call `otherfunc`?"
-        end
-        return nothing    # use `nothing` to indicate that f, arg_types, kwargs didn't match
+```julia
+function hintmessage(f, arg_types, kwargs)
+    # Test to see whether the call matches the specific pattern for this message
+    if f === myfunc && length(arg_types) == 1 && arg_types[1] <: SomeType
+        return "`myfunc(::SomeType)` is not defined, did you mean to call `otherfunc`?"
     end
+    return nothing    # use `nothing` to indicate that f, arg_types, kwargs didn't match
+end
+```
 
 Packages should perform the `push!` onto `Base.methoderror_hints` from
 their `__init__` function.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -695,8 +695,10 @@ export
     backtrace,
     catch_backtrace,
     error,
+    register_error_hint,
     rethrow,
     retry,
+    show_error_hints,
     systemerror,
 
 # stack traces

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -334,6 +334,8 @@ Base.backtrace
 Base.catch_backtrace
 Base.catch_stack
 Base.@assert
+Base.register_error_hint
+Base.show_error_hints
 Base.ArgumentError
 Base.AssertionError
 Core.BoundsError

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -608,6 +608,19 @@ let err_str
 end
 pop!(Base._hint_handlers[MethodError])  # order is undefined, don't copy this
 
+function busted_hint(io, exc, notarg)  # wrong number of args
+    print(io, "\nI don't have a hint for you, sorry")
+end
+@test register_error_hint(busted_hint, DomainError) === nothing
+try
+    sqrt(-2)
+catch ex
+    io = IOBuffer()
+    @test_logs (:error, "Hint-handler busted_hint for DomainError in $(@__MODULE__) caused an error") showerror(io, ex)
+end
+pop!(Base._hint_handlers[DomainError])  # order is undefined, don't copy this
+
+
 # issue #28442
 @testset "Long stacktrace printing" begin
     f28442(c) = g28442(c + 1)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -588,16 +588,16 @@ end
 
 # Custom hints
 struct HasNoOne end
-function recommend_oneunit(f, arg_types, kwargs)
-    if f === Base.one && length(arg_types) == 1 && arg_types[1] === HasNoOne
+function recommend_oneunit(io, ex, arg_types, kwargs)
+    if ex.f === Base.one && length(arg_types) == 1 && arg_types[1] === HasNoOne
         if isempty(kwargs)
-            return "HasNoOne does not support `one`; did you mean `oneunit`?"
+            print(io, "\nHasNoOne does not support `one`; did you mean `oneunit`?")
         else
-            return "`one` doesn't take keyword arguments, that would be silly"
+            print(io, "\n`one` doesn't take keyword arguments, that would be silly")
         end
     end
 end
-push!(Base.methoderror_hints, recommend_oneunit)
+@test register_error_hint(recommend_oneunit, MethodError) === nothing
 let err_str
     err_str = @except_str one(HasNoOne()) MethodError
     @test occursin(r"MethodError: no method matching one\(::.*HasNoOne\)", err_str)
@@ -606,7 +606,7 @@ let err_str
     @test occursin(r"MethodError: no method matching one\(::.*HasNoOne; value=2\)", err_str)
     @test occursin("`one` doesn't take keyword arguments, that would be silly", err_str)
 end
-pop!(Base.methoderror_hints)
+pop!(Base._hint_handlers[MethodError])  # order is undefined, don't copy this
 
 # issue #28442
 @testset "Long stacktrace printing" begin


### PR DESCRIPTION
Package authors may be able to predict likely user errors, and it can be nice to create an informative hint. For MethodErrors, we've done this repeatedly for Base; this PR makes it possible for packages to get in on the fun.

The procedure is described in the docstring for ~~Base.methoderror_hints~~`register_error_hint`.
