### PR TITLE
fixup-libgfortran: Bail out if libgfortran can't be found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ endef
 ifeq (,$(findstring $(OS),FreeBSD WINNT))
 julia-base: $(build_libdir)/libgfortran*.$(SHLIB_EXT)*
 $(build_libdir)/libgfortran*.$(SHLIB_EXT)*: | $(build_libdir) julia-deps
-	-$(CUSTOM_LD_LIBRARY_PATH) PATH="$(PATH):$(build_depsbindir)" PATCHELF="$(PATCHELF)" $(JULIAHOME)/contrib/fixup-libgfortran.sh --verbose $(build_libdir)
+	-$(CUSTOM_LD_LIBRARY_PATH) PATH="$(PATH):$(build_depsbindir)" PATCHELF="$(PATCHELF)" FC="$(FC)" $(JULIAHOME)/contrib/fixup-libgfortran.sh --verbose $(build_libdir)
 JL_PRIVATE_LIBS-0 += libgfortran libgcc_s libquadmath
 endif
 

--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -63,6 +63,7 @@ for lib in lapack blas openblas; do
         # Find the paths to the libraries we're interested in.  These are almost
         # always within the same directory, but we like to be general.
         LIBGFORTRAN_PATH="$(find_shlib "$private_libname" libgfortran)"
+        if [ -z "$LIBGFORTRAN_PATH" ]; then continue; fi
 
         # Take the directories, add them onto LIBGFORTRAN_DIRS, which we use to
         # search for these libraries in the future.  If there is no directory, try
@@ -79,10 +80,14 @@ for lib in lapack blas openblas; do
         LIBGCC_PATH="$(find_shlib "${LIBGFORTRAN_DIR}/${LIBGFORTRAN_SONAME}" libgcc_s)"
         LIBQUADMATH_PATH="$(find_shlib "${LIBGFORTRAN_DIR}/${LIBGFORTRAN_SONAME}" libquadmath)"
 
-        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(find_shlib_dir $LIBGCC_PATH)"
-        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(find_shlib_dir $LIBQUADMATH_PATH)"
-        LIBGCC_SONAMES="$LIBGCC_SONAMES $(basename "$LIBGCC_PATH")"
-        LIBQUADMATH_SONAMES="$LIBQUADMATH_SONAMES $(basename "$LIBQUADMATH_PATH")"
+        if [ ! -z "$LIBGCC_PATH" ]; then
+            LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(find_shlib_dir $LIBGCC_PATH)"
+            LIBGCC_SONAMES="$LIBGCC_SONAMES $(basename "$LIBGCC_PATH")"
+        fi
+        if [ ! -z "$LIBQUADMATH_PATH" ]; then
+            LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(find_shlib_dir $LIBQUADMATH_PATH)"
+            LIBQUADMATH_SONAMES="$LIBQUADMATH_SONAMES $(basename "$LIBQUADMATH_PATH")"
+        fi
     done
 done
 


### PR DESCRIPTION
Previously if the library was not found, we would try to look for
the directory of an empty file, which ironicall does something almost
sensible:
```
$ gfortran -print-file-name=
/usr/lib/gcc/x86_64-linux-gnu/9/
```
Unfortunately, we then `dirname` the directory, stripping the last path
component. Often this is harmless, but on some systems, the 32bit path
is e.g. `/usr/lib/gcc/x86_64-linux-gnu/9/32/`, which can cause the
64 bit path to be copied instead of the 32 bit path. This is of course
only an issue if the appropriate runtime libraries are missing, but an
arch mismatch error is harder to debug than a missing libraries error
(as well as it being of course incorrect to copy the 64 bit libraries
to our build directory). This fixes fixup-libgfortran to no try and
look for the directory of an empty libname.