### PR TITLE
Separate stage for windows exe installer and build tarballs on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,16 +465,15 @@ endif
 ifeq ($(OS), Darwin)
 	-cat $(JULIAHOME)/contrib/mac/startup.jl >> $(DESTDIR)$(prefix)/etc/julia/startup.jl
 endif
-
 ifeq ($(OS), WINNT)
 	cd $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
+endif
+	cd $(BUILDROOT) && $(TAR) zcvf $(JULIA_BINARYDIST_FILENAME).tar.gz julia-$(JULIA_COMMIT)
 
+exe:
 	# run Inno Setup to compile installer; /O flag specifies where to place installer and /F flag the installer name
 	$(call spawn,$(JULIAHOME)/dist-extras/inno/iscc.exe /DAppVersion=$(JULIA_VERSION) /DAppSourceFiles="$(call cygpath_w,$(BUILDROOT)/julia-$(JULIA_COMMIT))" /DAppHomeFiles="$(call cygpath_w,$(JULIAHOME))" /F"$(JULIA_BINARYDIST_FILENAME)" /O"$(call cygpath_w,$(BUILDROOT))"  $(call cygpath_w,$(JULIAHOME)/contrib/windows/build-installer.iss))
 	chmod a+x "$(BUILDROOT)/$(JULIA_BINARYDIST_FILENAME).exe"
-else
-	cd $(BUILDROOT) && $(TAR) zcvf $(JULIA_BINARYDIST_FILENAME).tar.gz julia-$(JULIA_COMMIT)
-endif
 
 app:
 	$(MAKE) -C contrib/mac/app

--- a/doc/build/windows.md
+++ b/doc/build/windows.md
@@ -196,6 +196,7 @@ make -j4 win-extras julia-ui-release
 export WINEDEBUG=-all # suppress wine fixme's
 # this last step may need to be run interactively
 make -j4 binary-dist
+make -j4 exe
 SCRIPT
 
 Vagrant.configure("2") do |config|
@@ -235,7 +236,7 @@ Then run the build:
  2. `echo override XC_HOST = i686-w64-mingw32 >> Make.user`
  3. `make`
  4. `make win-extras` (Necessary before running `make binary-dist`)
- 5. `make binary-dist`
+ 5. `make binary-dist` then `make exe` to create the Windows installer.
  6. move the `julia-*.exe` installer to the target machine
 
 If you are building for 64-bit windows, the steps are essentially the same.
@@ -267,8 +268,7 @@ just run `vagrant up` from that folder.
 Compiling using one of the options above creates a basic Julia build, but not some
 extra components that are included if you run the full Julia binary installer.
 If you need these components, the easiest way to get them is to build the installer
-yourself using ```make win-extras``` followed by ```make binary-dist```, and then
-running the resulting installer.
+yourself using ```make win-extras``` followed by ```make binary-dist``` and ```make exe```. Then running the resulting installer.
 
 
 ## Windows Build Debugging


### PR DESCRIPTION
Two changes:
1. Build tarballs on Windows platforms, as is done for the other supported platforms.
2. Separate out the windows  exe installer into a new stage