### PR TITLE
turn Method.specializations into a simpler table+list like the TypeName.cache

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -126,12 +126,9 @@ end
 # get a handle to the unique specialization object representing a particular instantiation of a call
 function specialize_method(method::Method, @nospecialize(atypes), sparams::SimpleVector, preexisting::Bool=false)
     if preexisting
-        if method.specializations !== nothing
-            # check cached specializations
-            # for an existing result stored there
-            return ccall(:jl_specializations_lookup, Any, (Any, Any), method, atypes)
-        end
-        return nothing
+        # check cached specializations
+        # for an existing result stored there
+        return ccall(:jl_specializations_lookup, Any, (Any, Any), method, atypes)
     end
     return ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), method, atypes, sparams)
 end

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ FLAGS += -I$(LOCALBASE)/include
 endif
 
 RUNTIME_SRCS := \
-	jltypes gf typemap ast builtins module interpreter symbol \
+	jltypes gf typemap smallintset ast builtins module interpreter symbol \
 	dlload sys init task array dump staticdata toplevel jl_uv datatype \
 	simplevector runtime_intrinsics precompile \
 	threading partr stackwalk gc gc-debug gc-pages gc-stacks method \

--- a/src/dump.c
+++ b/src/dump.c
@@ -851,6 +851,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         assert((jl_value_t*)mt != jl_nothing);
         external_mt = !module_in_worklist(mt->module);
         jl_serialize_value(s, m->specializations);
+        jl_serialize_value(s, m->speckeyset);
         jl_serialize_value(s, (jl_value_t*)m->name);
         jl_serialize_value(s, (jl_value_t*)m->file);
         write_int32(s->s, m->line);
@@ -1149,14 +1150,6 @@ static void collect_backedges(jl_method_instance_t *callee) JL_GC_DISABLED
 }
 
 
-static int jl_collect_backedges_to_mod(jl_typemap_entry_t *ml, void *closure) JL_GC_DISABLED
-{
-    (void)(jl_array_t*)closure;
-    jl_method_instance_t *callee = ml->func.linfo;
-    collect_backedges(callee);
-    return 1;
-}
-
 static int jl_collect_methcache_from_mod(jl_typemap_entry_t *ml, void *closure) JL_GC_DISABLED
 {
     jl_array_t *s = (jl_array_t*)closure;
@@ -1166,7 +1159,13 @@ static int jl_collect_methcache_from_mod(jl_typemap_entry_t *ml, void *closure) 
         jl_array_ptr_1d_push(s, (jl_value_t*)ml->simplesig);
     }
     else {
-        jl_typemap_visitor(m->specializations, jl_collect_backedges_to_mod, closure);
+        jl_svec_t *specializations = m->specializations;
+        size_t i, l = jl_svec_len(specializations);
+        for (i = 0; i < l; i++) {
+            jl_method_instance_t *callee = (jl_method_instance_t*)jl_svecref(specializations, i);
+            if (callee != NULL)
+                collect_backedges(callee);
+        }
     }
     return 1;
 }
@@ -1719,8 +1718,10 @@ static jl_value_t *jl_deserialize_value_method(jl_serializer_state *s, jl_value_
         arraylist_push(&flagref_list, (void*)pos);
         return (jl_value_t*)m;
     }
-    m->specializations = jl_deserialize_value(s, (jl_value_t**)&m->specializations);
+    m->specializations = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&m->specializations);
     jl_gc_wb(m, m->specializations);
+    m->speckeyset = (jl_array_t*)jl_deserialize_value(s, (jl_value_t**)&m->speckeyset);
+    jl_gc_wb(m, m->speckeyset);
     m->name = (jl_sym_t*)jl_deserialize_value(s, NULL);
     jl_gc_wb(m, m->name);
     m->file = (jl_sym_t*)jl_deserialize_value(s, NULL);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1042,6 +1042,8 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable)
                  (((jl_datatype_t*)p)->name == jl_type_typename && !((jl_datatype_t*)p)->hasfreetypevars));
         }
     }
+    if (dt->name == jl_type_typename)
+        cacheable = 0; // the cache for Type ignores parameter normalization, so it can't be used as a regular hash
     dt->hash = typekey_hash(dt->name, jl_svec_data(dt->parameters), l, cacheable);
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2123,7 +2123,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(22,
+                        jl_perm_symsvec(23,
                             "name",
                             "module",
                             "file",
@@ -2134,6 +2134,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             "ambig",
                             "resorted",
                             "specializations",
+                            "speckeyset",
                             "slot_syms",
                             "source",
                             "unspecialized",
@@ -2146,7 +2147,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             "nkw",
                             "isva",
                             "pure"),
-                        jl_svec(22,
+                        jl_svec(23,
                             jl_symbol_type,
                             jl_module_type,
                             jl_symbol_type,
@@ -2156,7 +2157,8 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_type_type,
                             jl_any_type, // Union{Vector, Nothing}
                             jl_any_type, // Union{Vector, Nothing}
-                            jl_any_type, // TypeMap
+                            jl_simplevector_type,
+                            jl_array_type,
                             jl_string_type,
                             jl_any_type,
                             jl_any_type, // jl_method_instance_type
@@ -2169,7 +2171,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_int32_type,
                             jl_bool_type,
                             jl_bool_type),
-                        0, 1, 11);
+                        0, 1, 12);
 
     jl_method_instance_type =
         jl_new_datatype(jl_symbol("MethodInstance"), core,
@@ -2334,7 +2336,7 @@ void jl_init_types(void) JL_GC_DISABLED
 #endif
     jl_svecset(jl_methtable_type->types, 9, jl_uint8_type);
     jl_svecset(jl_methtable_type->types, 10, jl_uint8_type);
-    jl_svecset(jl_method_type->types, 12, jl_method_instance_type);
+    jl_svecset(jl_method_type->types, 13, jl_method_instance_type);
     jl_svecset(jl_method_instance_type->types, 5, jl_code_instance_type);
     jl_svecset(jl_code_instance_type->types, 8, jl_voidpointer_type);
     jl_svecset(jl_code_instance_type->types, 9, jl_voidpointer_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1004,6 +1004,8 @@ static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
 
 static unsigned typekey_hash(jl_typename_t *tn, jl_value_t **key, size_t n, int nofail) JL_NOTSAFEPOINT
 {
+    if (tn == jl_type_typename && key[0] == jl_bottom_type)
+        return jl_typeofbottom_type->hash;
     size_t j;
     unsigned hash = 3;
     int failed = nofail;

--- a/src/julia.h
+++ b/src/julia.h
@@ -290,7 +290,8 @@ typedef struct _jl_method_t {
     jl_value_t *resorted;
 
     // table of all jl_method_instance_t specializations we have
-    jl_typemap_t *specializations;
+    jl_svec_t *specializations; // allocated as [hashable, ..., NULL, linear, ....]
+    jl_array_t *speckeyset; // index lookup by hash into specializations
 
     jl_value_t *slot_syms; // compacted list of slot names (String)
     jl_value_t *source;  // original code template (jl_code_info_t, but may be compressed), null for builtins

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1021,6 +1021,13 @@ extern jl_mutex_t safepoint_lock;
 void jl_mach_gc_end(void);
 #endif
 
+// -- smallintset.c -- //
+
+typedef uint_t (*smallintset_hash)(size_t val, jl_svec_t *data);
+typedef int (*smallintset_eq)(size_t val, const void *key, jl_svec_t *data, uint_t hv);
+ssize_t jl_smallintset_lookup(jl_array_t *cache JL_PROPAGATES_ROOT, smallintset_eq eq, const void *key, jl_svec_t *data, uint_t hv);
+void jl_smallintset_insert(jl_array_t **pcache, jl_value_t *parent, smallintset_hash hash, size_t val, jl_svec_t *data);
+
 // -- typemap.c -- //
 
 // a descriptor of a jl_typemap_t that gets

--- a/src/method.c
+++ b/src/method.c
@@ -591,7 +591,8 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_method_t *m =
         (jl_method_t*)jl_gc_alloc(ptls, sizeof(jl_method_t), jl_method_type);
-    m->specializations = jl_nothing;
+    m->specializations = jl_emptysvec;
+    m->speckeyset = (jl_array_t*)jl_an_empty_vec_any;
     m->sig = NULL;
     m->slot_syms = NULL;
     m->ambig = jl_nothing;

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -317,9 +317,8 @@ static int precompile_enq_all_cache__(jl_typemap_entry_t *l, void *closure)
     return 1;
 }
 
-static int precompile_enq_specialization_(jl_typemap_entry_t *l, void *closure)
+static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closure)
 {
-    jl_method_instance_t *mi = l->func.linfo;
     assert(jl_is_method_instance(mi));
     jl_code_instance_t *codeinst = mi->cache;
     while (codeinst) {
@@ -352,7 +351,13 @@ static int precompile_enq_all_specializations__(jl_typemap_entry_t *def, void *c
         jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);
     }
     else {
-        jl_typemap_visitor(def->func.method->specializations, precompile_enq_specialization_, closure);
+        jl_svec_t *specializations = def->func.method->specializations;
+        size_t i, l = jl_svec_len(specializations);
+        for (i = 0; i < l; i++) {
+            jl_method_instance_t *mi = (jl_method_instance_t*)jl_svecref(specializations, i);
+            if (mi != NULL)
+                precompile_enq_specialization_(mi, closure);
+        }
     }
     return 1;
 }

--- a/src/smallintset.c
+++ b/src/smallintset.c
@@ -1,0 +1,193 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include <stdlib.h>
+#include <string.h>
+#include "julia.h"
+#include "julia_internal.h"
+#ifndef _OS_WINDOWS_
+#include <unistd.h>
+#endif
+#include "julia_assert.h"
+
+// compute empirical max-probe for a given size
+#define max_probe(size) ((size) <= 1024 ? 16 : (size) >> 6)
+#define h2index(hv, sz) (size_t)((hv) & ((sz)-1))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline size_t jl_intref(const jl_array_t *arr, size_t idx) JL_NOTSAFEPOINT
+{
+    jl_value_t *el = jl_tparam0(jl_typeof(arr));
+    if (el == (jl_value_t*)jl_uint8_type)
+        return ((uint8_t*)jl_array_data(arr))[idx];
+    else if (el == (jl_value_t*)jl_uint16_type)
+        return ((uint16_t*)jl_array_data(arr))[idx];
+    else if (el == (jl_value_t*)jl_uint32_type)
+        return ((uint32_t*)jl_array_data(arr))[idx];
+    else
+        abort();
+}
+
+static inline void jl_intset(const jl_array_t *arr, size_t idx, size_t val) JL_NOTSAFEPOINT
+{
+    jl_value_t *el = jl_tparam0(jl_typeof(arr));
+    if (el == (jl_value_t*)jl_uint8_type)
+        ((uint8_t*)jl_array_data(arr))[idx] = val;
+    else if (el == (jl_value_t*)jl_uint16_type)
+        ((uint16_t*)jl_array_data(arr))[idx] = val;
+    else if (el == (jl_value_t*)jl_uint32_type)
+        ((uint32_t*)jl_array_data(arr))[idx] = val;
+    else
+        abort();
+}
+
+static inline size_t jl_max_int(const jl_array_t *arr)
+{
+    jl_value_t *el = jl_tparam0(jl_typeof(arr));
+    if (el == (jl_value_t*)jl_uint8_type)
+        return 0xFF;
+    else if (el == (jl_value_t*)jl_uint16_type)
+        return 0xFFFF;
+    else if (el == (jl_value_t*)jl_uint32_type)
+        return 0xFFFFFFFF;
+    else if (el == (jl_value_t*)jl_any_type)
+        return 0;
+    else
+        abort();
+}
+
+static jl_array_t *jl_alloc_int_1d(size_t np, size_t len)
+{
+    jl_value_t *ty;
+    if (np < 0xFF) {
+        ty = jl_array_uint8_type;
+     }
+    else if (np < 0xFFFF) {
+        static jl_value_t *int16 JL_ALWAYS_LEAFTYPE = NULL;
+        if (int16 == NULL)
+            int16 = jl_apply_array_type((jl_value_t*)jl_uint16_type, 1);
+        ty = int16;
+    }
+    else {
+        assert(np < 0x7FFFFFFF);
+        static jl_value_t *int32 JL_ALWAYS_LEAFTYPE = NULL;
+        if (int32 == NULL)
+            int32 = jl_apply_array_type((jl_value_t*)jl_uint32_type, 1);
+        ty = int32;
+    }
+    jl_array_t *a = jl_alloc_array_1d(ty, len);
+    memset(a->data, 0, len * a->elsize);
+    return a;
+}
+
+ssize_t jl_smallintset_lookup(jl_array_t *cache, smallintset_eq eq, const void *key, jl_svec_t *data, uint_t hv)
+{
+    size_t sz = jl_array_len(cache);
+    if (sz == 0)
+        return -1;
+    JL_GC_PUSH1(&cache);
+    size_t maxprobe = max_probe(sz);
+    size_t index = h2index(hv, sz);
+    size_t orig = index;
+    size_t iter = 0;
+    do {
+        size_t val1 = jl_intref(cache, index);
+        if (val1 == 0) {
+            JL_GC_POP();
+            return -1;
+        }
+        if (eq(val1 - 1, key, data, hv)) {
+            JL_GC_POP();
+            return val1 - 1;
+        }
+        index = (index + 1) & (sz - 1);
+        iter++;
+    } while (iter <= maxprobe && index != orig);
+    JL_GC_POP();
+    return -1;
+}
+
+static int smallintset_insert_(jl_array_t *a, uint_t hv, size_t val1)
+{
+    size_t sz = jl_array_len(a);
+    if (sz <= 1)
+        return 0;
+    size_t orig, index, iter;
+    iter = 0;
+    index = h2index(hv, sz);
+    orig = index;
+    size_t maxprobe = max_probe(sz);
+    do {
+        if (jl_intref(a, index) == 0) {
+            jl_intset(a, index, val1);
+            return 1;
+        }
+        index = (index + 1) & (sz - 1);
+        iter++;
+    } while (iter <= maxprobe && index != orig);
+    return 0;
+}
+
+static void smallintset_rehash(jl_array_t **cache, jl_value_t *parent, smallintset_hash hash, jl_svec_t *data, size_t newsz, size_t np);
+
+void jl_smallintset_insert(jl_array_t **cache, jl_value_t *parent, smallintset_hash hash, size_t val, jl_svec_t *data)
+{
+    if (val + 1 >  jl_max_int(*cache))
+        smallintset_rehash(cache, parent, hash, data, jl_array_len(*cache), val + 1);
+    while (1) {
+        if (smallintset_insert_(*cache, hash(val, data), val + 1))
+            return;
+
+        /* table full */
+        /* rehash to grow and retry the insert */
+        /* it's important to grow the table really fast; otherwise we waste */
+        /* lots of time rehashing all the keys over and over. */
+        size_t newsz;
+        size_t sz = jl_array_len(*cache);
+        if (sz < HT_N_INLINE)
+            newsz = HT_N_INLINE;
+        else if (sz >= (1 << 19) || (sz <= (1 << 8)))
+            newsz = sz << 1;
+        else
+            newsz = sz << 2;
+        smallintset_rehash(cache, parent, hash, data, newsz, 0);
+    }
+}
+
+static void smallintset_rehash(jl_array_t **cache, jl_value_t *parent, smallintset_hash hash, jl_svec_t *data, size_t newsz, size_t np)
+{
+    jl_array_t *a = *cache;
+    size_t sz = jl_array_len(a);
+    size_t i;
+    for (i = 0; i < sz; i += 1) {
+        size_t val = jl_intref(a, i);
+        if (val > np)
+            np = val;
+    }
+    while (1) {
+        jl_array_t *newa = jl_alloc_int_1d(np, newsz);
+        JL_GC_PUSH1(&newa);
+        for (i = 0; i < sz; i += 1) {
+            size_t val1 = jl_intref(a, i);
+            if (val1 != 0) {
+                if (!smallintset_insert_(newa, hash(val1 - 1, data), val1)) {
+                    break;
+                }
+            }
+        }
+        JL_GC_POP();
+        if (i == sz) {
+            *cache = newa;
+            jl_gc_wb(parent, newa);
+            return;
+        }
+        newsz <<= 1;
+    }
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -506,11 +506,11 @@ f18888() = nothing
 let
     world = Core.Compiler.get_world_counter()
     m = first(methods(f18888, Tuple{}))
-    @test m.specializations === nothing
+    @test isempty(m.specializations)
     ft = typeof(f18888)
 
     code_typed(f18888, Tuple{}; optimize=false)
-    @test m.specializations isa Core.TypeMapEntry  # uncached, but creates the specializations entry
+    @test !isempty(m.specializations) # uncached, but creates the specializations entry
     mi = Core.Compiler.specialize_method(m, Tuple{ft}, Core.svec())
     @test Core.Compiler.inf_for_methodinstance(mi, world) === nothing
     @test !isdefined(mi, :cache)


### PR DESCRIPTION
Some numbers:

Not a huge affect on speed, afaik, but pretty good on system image saving space:
126 MB => 123 MB measured

30_086 methods in the system (Base + stdlib)

the tuple pair here is (count of hash table, count of linear list)
mean number of specializations: (1.70, 0.39)
total number of specializations: (51_284, 11_743) => 81% hashable
max number of specializations: (1_166, 304)

```
julia> histogram(filter(!iszero, r), bins=40, xscale=log10)
                    ┌                                        ┐ 
   [   0.0,   50.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 9492   
   [  50.0,  100.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 85                       
   [ 100.0,  150.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇ 30                          
   [ 150.0,  200.0) ┤▇▇▇▇▇▇▇▇▇▇▇ 17                            
   [ 200.0,  250.0) ┤▇▇▇▇▇▇▇ 6                                 
   [ 250.0,  300.0) ┤▇▇▇▇▇▇▇ 6                                 
   [ 300.0,  350.0) ┤▇▇▇▇▇ 4                                   
   [ 350.0,  400.0) ┤▇▇▇▇ 3                                    
   [ 400.0,  450.0) ┤ 0                                        
   [ 450.0,  500.0) ┤ 0                                        
   [ 500.0,  550.0) ┤▇▇▇ 2                                     
   [ 550.0,  600.0) ┤ 0                                        
   [ 600.0,  650.0) ┤ 1                                        
   [ 650.0,  700.0) ┤ 0                                        
   [ 700.0,  750.0) ┤ 0                                        
   [ 750.0,  800.0) ┤ 1                                        
   [ 800.0,  850.0) ┤ 0                                        
   [ 850.0,  900.0) ┤ 1                                        
   [ 900.0,  950.0) ┤ 0                                        
   [ 950.0, 1000.0) ┤ 1                                        
   [1000.0, 1050.0) ┤ 0                                        
   [1050.0, 1100.0) ┤ 0                                        
   [1100.0, 1150.0) ┤ 0                                        
   [1150.0, 1200.0) ┤ 1                                        
                    └                                        ┘ 
                                Frequency [log10]
```

```
julia> histogram(filter(!iszero, l), bins=10, xscale=log10)
                  ┌                                        ┐ 
   [  0.0,  50.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 2349   
   [ 50.0, 100.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 22                         
   [100.0, 150.0) ┤▇▇▇▇▇▇▇▇ 6                                
   [150.0, 200.0) ┤▇▇▇ 2                                     
   [200.0, 250.0) ┤▇▇▇ 2                                     
   [250.0, 300.0) ┤ 0                                        
   [300.0, 350.0) ┤ 1                                        
                  └                                        ┘ 
                              Frequency [log10]
```

Most frequently specialized methods in table (over 100), with counts:
```
102 push!(a::Array{T,1}, item) where T in Base at array.jl:911
102 throw_boundserror(A, I) in Base at abstractarray.jl:537
105 rehash!(h::Dict{K,V}, newsz) where {K, V} in Base at dict.jl:175
106 getindex(t::Tuple, i::Int64) in Core.Compiler at tuple.jl:24
106 promote_type(::Type{T}, ::Type{T}) where T in Base at promotion.jl:212
107 (::Type{LinearIndices})(A::Union{Core.SimpleVector, AbstractArray}) in Base at indices.jl:453
107 isslotempty(h::Dict, i::Int64) in Base at dict.jl:170
107 isslotmissing(h::Dict, i::Int64) in Base at dict.jl:172
108 _array_for(::Type{T}, itr, ::Base.HasShape{N}) where {T, N} in Base at array.jl:656
108 isslotfilled(h::Dict, i::Int64) in Base at dict.jl:171
108 promote_type(::Type{T}, ::Type{Union{}}) where T in Base at promotion.jl:213
108 resize!(a::Array{T,1} where T, nl::Integer) in Base at array.jl:1060
110 !=(x, y) in Base at operators.jl:193
112 _deleteend!(a::Array{T,1} where T, delta::Integer) in Base at array.jl:878
115 (::Type{Dict{K,V}})() where {K, V} in Base at dict.jl:89
118 (::Type{Array{T,1}})(::UndefInitializer, d::Tuple{Int64}) where T in Core at boot.jl:414
125 #sprint#352(context, sizehint::Integer, ::typeof(sprint), f::Function, args...) in Base at strings/io.jl:101
125 eachindex(::IndexLinear, A::AbstractArray{T,1} where T) in Base at abstractarray.jl:267
125 eltype(x) in Base at array.jl:125
126 collect_to!(dest::AbstractArray{T,N} where N, itr, offs, st) where T in Base at array.jl:707
129 (::Type{Base.Broadcast.Broadcasted{Style,Axes,F,Args} where Args<:Tuple where F where Axes})(f::F, args::Args, axes) where {Style, F, Args<:Tuple} in Base.Broadcast at broadcast.jl:179
132 (::Type{Base.Broadcast.Broadcasted{Style,Axes,F,Args}})(f, args, axes) where {Style<:Union{Nothing, Base.Broadcast.BroadcastStyle}, Axes, F, Args<:Tuple} in Base.Broadcast at broadcast.jl:170
132 collect_to_with_first!(dest::AbstractArray, v1, itr, st) in Base at array.jl:686
132 ht_keyindex2!(h::Dict{K,V}, key) where {K, V} in Base at dict.jl:304
133 convert(::Type{Any}, x) in Core at boot.jl:393
137 first(itr) in Base at abstractarray.jl:341
140 axes1(A::AbstractArray) in Base at abstractarray.jl:95
142 ht_keyindex(h::Dict{K,V}, key) where {K, V} in Base at dict.jl:279
146 _growend!(a::Array{T,1} where T, delta::Integer) in Base at array.jl:869
146 isequal(x, y) in Base at operators.jl:123
152 Base.IteratorSize(x) in Base at generator.jl:90
152 convert(::Type{T}, a::AbstractArray) where T<:Array in Base at array.jl:532
155 size(a::Array{T,1} where T) in Base at array.jl:155
160 promote_rule(::Type{var"#s69"} where var"#s69", ::Type{var"#s68"} where var"#s68") in Base at promotion.jl:235
172 convert(::Type{T}, x::T) where T<:Tuple{Any,Vararg{Any,N} where N} in Base at essentials.jl:309
174 convert(::Type{Any}, x) in Base at essentials.jl:170
175 axes(A) in Base at abstractarray.jl:74
179 print(io::IO, xs...) in Base at strings/io.jl:43
180 (::Type{Pair})(a, b) in Base at pair.jl:15
180 BoundsError(a, i) in Core at boot.jl:244
191 ==(x, y) in Base at operators.jl:83
192 getindex(A::Array, i1::Int64) in Base at array.jl:786
193 _setindex!(h::Dict, v, key, index) in Base at dict.jl:354
193 length(a::Array) in Base at array.jl:221
193 promote_result(::Type{var"#s69"} where var"#s69", ::Type{var"#s68"} where var"#s68", ::Type{T}, ::Type{S}) where {T, S} in Base at promotion.jl:237
198 (::Type{Base.Generator{I,F}})(f, iter) where {I, F} in Base at generator.jl:32
198 getproperty(x::Type, f::Symbol) in Base at Base.jl:28
200 tail(x::Tuple) in Base at essentials.jl:205
207 setindex!(h::Dict{K,V}, v0, key::K) where {K, V} in Base at dict.jl:380
208 (::Type{Base.Generator})(f::F, iter::I) where {I, F} in Base at generator.jl:32
213 argtail(x, rest...) in Base at essentials.jl:189
234 (::Type{Array{T,1}})(::UndefInitializer, m::Int64) where T in Core at boot.jl:405
242 promote_type(::Type{T}, ::Type{S}) where {T, S} in Base at promotion.jl:217
276 isempty(x::Tuple) in Base at tuple.jl:383
283 indexed_iterate(t::Tuple, i::Int64) in Base at tuple.jl:81
283 indexed_iterate(t::Tuple, i::Int64, state) in Base at tuple.jl:81
290 getindex(t::NamedTuple, i::Symbol) in Base at namedtuple.jl:97
295 haskey(nt::NamedTuple, key::Union{Integer, Symbol}) in Base at namedtuple.jl:272
299 string(xs...) in Base at strings/io.jl:174
300 print_to_string(xs...) in Base at strings/io.jl:125
301 (::Type{NamedTuple{names,T}})(args::T) where {names, T<:Tuple} in Core at boot.jl:550
321 structdiff(a::NamedTuple{an,T} where T<:Tuple, b::Union{Type{NamedTuple{bn,T} where T<:Tuple}, NamedTuple{bn,T} where T<:Tuple}) where {an, bn} in Base at namedtuple.jl:294
342 (::Type{NamedTuple{names,T} where T<:Tuple})(args::Tuple) where names in Core at boot.jl:546
354 iterate(g::Base.Generator, s...) in Base at generator.jl:43
355 setindex!(A::Array{T,N} where N, x, i1::Int64) where T in Base at array.jl:824
387 (::Type{Pair{A,B}})(a, b) where {A, B} in Base at pair.jl:7
543 iterate(t::Tuple) in Base at tuple.jl:60
543 iterate(t::Tuple, i::Int64) in Base at tuple.jl:60
632 length(t::Tuple) in Base at tuple.jl:19
779 convert(::Type{T}, x::T) where T in Base at essentials.jl:171
859 setproperty!(x, f::Symbol, v) in Base at Base.jl:34
973 getindex(t::Tuple, i::Int64) in Base at tuple.jl:24
1166 getproperty(x, f::Symbol) in Base at Base.jl:33
```

Most frequently specialized methods in linear list (over 50), with counts:
```
50 (::Type{T})(x::Tuple) where T<:Tuple in Base at tuple.jl:225
52 (::Type{Base.Broadcast.Broadcasted{Style,Axes,F,Args}})(f, args, axes) where {Style<:Union{Nothing, Base.Broadcast.BroadcastStyle}, Axes, F, Args<:Tuple} in Base.Broadcast at broadcast.jl:170
53 (::Type{Base.Generator})(f::F, iter::I) where {I, F} in Base at generator.jl:32
54 setindex!(h::Dict{K,V}, v0, key::K) where {K, V} in Base at dict.jl:380
59 collect_to_with_first!(dest::AbstractArray, v1, itr, st) in Base at array.jl:686
62 isempty(x::Tuple) in Base at tuple.jl:383
63 argtail(x, rest...) in Base at essentials.jl:189
63 collect_to!(dest::AbstractArray{T,N} where N, itr, offs, st) where T in Base at array.jl:707
66 structdiff(a::NamedTuple{an,T} where T<:Tuple, b::Union{Type{NamedTuple{bn,T} where T<:Tuple}, NamedTuple{bn,T} where T<:Tuple}) where {an, bn} in Base at namedtuple.jl:294
67 tail(x::Tuple) in Base at essentials.jl:205
69 (::Type{Base.Generator{I,F}})(f, iter) where {I, F} in Base at generator.jl:32
70 checkbounds(A::AbstractArray, I...) in Base at abstractarray.jl:501
70 throw_boundserror(A, I) in Base at abstractarray.jl:537
74 (::Type{NamedTuple{names,T}})(args::T) where {names, T<:Tuple} in Core at boot.jl:550
74 (::Type{NamedTuple{names,T}})(args::Tuple) where {names, T<:Tuple} in Base at namedtuple.jl:69
75 iterate(g::Base.Generator, s...) in Base at generator.jl:43
77 to_indices(A, inds, I::Tuple{Any,Vararg{Any,N} where N}) in Base at indices.jl:324
79 BoundsError(a, i) in Core at boot.jl:244
80 string(xs...) in Base at strings/io.jl:174
84 print(io::IO, xs...) in Base at strings/io.jl:43
86 setindex!(A::Array{T,N} where N, x, i1::Int64) where T in Base at array.jl:824
92 print_to_string(xs...) in Base at strings/io.jl:125
106 promote_rule(::Type{var"#s69"} where var"#s69", ::Type{var"#s68"} where var"#s68") in Base at promotion.jl:235
115 promote_result(::Type{T}, ::Type{S}, ::Type{Union{}}, ::Type{Union{}}) where {T, S} in Base at promotion.jl:240
118 promote_type(::Type{T}, ::Type{S}) where {T, S} in Base at promotion.jl:217
118 setproperty!(x, f::Symbol, v) in Base at Base.jl:34
137 promote_result(::Type{var"#s69"} where var"#s69", ::Type{var"#s68"} where var"#s68", ::Type{T}, ::Type{S}) where {T, S} in Base at promotion.jl:237
144 promote_typeof(x, xs...) in Base at promotion.jl:262
182 iterate(t::Tuple) in Base at tuple.jl:60
182 iterate(t::Tuple, i::Int64) in Base at tuple.jl:60
211 getproperty(x, f::Symbol) in Base at Base.jl:33
236 length(t::Tuple) in Base at tuple.jl:19
304 getindex(t::Tuple, i::Int64) in Base at tuple.jl:24
```


via:
```julia
julia> Base.visit(f, @nospecialize x) = nothing
julia> function Base.visit(f, m::Module)
                         for x in names(m, all=true)
                           isdefined(m, x) || continue
                           x = Base.unwrap_unionall(getfield(m, x))
                           x isa Module && x !== m && parentmodule(x) === m && Base.visit(f, x)
                           x isa DataType  || continue
                           x.name.module === m || continue
                           (!isdefined(x.name, :mt) || x.name.mt === DataType.name.mt || x.name.mt === Symbol.name.mt) && continue
                           Base.visit(f, x.name.mt.defs)
                         end
                         m === Core && Base.visit(f, DataType.name.mt.defs)
                         m === Core && Base.visit(f, Symbol.name.mt.defs)
                     end
julia> ms = [:Base64, :CRC32c, :Dates, :DelimitedFiles, :Distributed, :FileWatching, :Future, :InteractiveUtils, :LibGit2, :Libdl, :LinearAlgebra, :Logging, :Markdown, :Mmap, :Pkg, :Printf, :Profile, :REPL, :Random, :SHA, :Serialization, :SharedArrays, :Sockets, :SparseArrays, :Statistics, :SuiteSparse, :Test, :UUIDs, :Unicode, :Pkg, :Base, :Core]
julia> for m in ms
              @eval import $m
              Base.visit(getfield(Main, m)) do l::Method
       a = sum(i -> isassigned(l.specializations, i), 0:length(l.specializations))
       b = sum(i -> isassigned(l.linearspecializations, i), 0:length(l.linearspecializations))
       println(a, '\t', b)
                nothing
              end
              end
```