### PR TITLE
Add eltype for RemoteChannel

### DIFF
--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+import Base: eltype
+
 abstract type AbstractRemoteRef end
 
 """
@@ -118,6 +120,8 @@ function RemoteChannel(f::Function, pid::Integer=myid())
         RemoteChannel{typeof(rv.c)}(myid(), rrid)
     end
 end
+
+Base.eltype(::Type{RemoteChannel{T}}) where {T} = eltype(T)
 
 hash(r::AbstractRemoteRef, h::UInt) = hash(r.whence, hash(r.id, h))
 ==(r::AbstractRemoteRef, s::AbstractRemoteRef) = (r.whence==s.whence && r.id==s.id)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -834,6 +834,7 @@ remote_do(fut->put!(fut, myid()), id_other, f)
 
 # Github issue #29932
 rc_unbuffered = RemoteChannel(()->Channel{Vector{Float64}}(0))
+@test eltype(rc_unbuffered) == Vector{Float64}
 
 @async begin
     # Trigger direct write (no buffering) of largish array


### PR DESCRIPTION
so that is behaves more in line with `Base.Channel`. Before:

```
julia> r = RemoteChannel(() -> Channel{Bool}(1))
RemoteChannel{Channel{Bool}}(1, 1, 4)

julia> eltype(r)
Any
```

After:
```
julia> eltype(r)
Bool
```