### PR TITLE
Corrections to `timedwait` methods

### DIFF
--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -255,14 +255,14 @@ function Timer(cb::Function, timeout::Real; interval::Real=0.0)
 end
 
 """
-    timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
+    timedwait(testcb::Function, secs::Real; pollint::Real=0.1)
 
 Waits until `testcb` returns `true` or for `secs` seconds, whichever is earlier.
 `testcb` is polled every `pollint` seconds.
 
 Returns :ok, :timed_out, or :error
 """
-function timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
+function timedwait(testcb::Function, secs::Real; pollint::Real=0.1)
     pollint > 0 || throw(ArgumentError("cannot set pollint to $pollint seconds"))
     start = time_ns()
     nsecs = 1e9 * secs

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -255,24 +255,24 @@ function Timer(cb::Function, timeout::Real; interval::Real=0.0)
 end
 
 """
-    timedwait(testcb::Function, secs::Real; pollint::Real=0.1)
+    timedwait(testcb::Function, timeout::Real; pollint::Real=0.1)
 
-Waits until `testcb` returns `true` or for `secs` seconds, whichever is earlier.
-`testcb` is polled every `pollint` seconds. The minimum duration for `secs` and `pollint` is
-1 millisecond or `0.001`.
+Waits until `testcb` returns `true` or for `timeout` seconds, whichever is earlier.
+`testcb` is polled every `pollint` seconds. The minimum duration for `timeout` and `pollint`
+is 1 millisecond or `0.001`.
 
 Returns :ok or :timed_out
 """
-function timedwait(testcb::Function, secs::Real; pollint::Real=0.1)
+function timedwait(testcb::Function, timeout::Real; pollint::Real=0.1)
     pollint >= 1e-3 || throw(ArgumentError("pollint must be ≥ 1 millisecond"))
     start = time_ns()
-    nsecs = 1e9 * secs
+    ns_timeout = 1e9 * timeout
     done = Channel(1)
     function timercb(aw)
         try
             if testcb()
                 put!(done, (:ok, nothing))
-            elseif (time_ns() - start) > nsecs
+            elseif (time_ns() - start) > ns_timeout
                 put!(done, (:timed_out, nothing))
             end
         catch e

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -258,12 +258,13 @@ end
     timedwait(testcb::Function, secs::Real; pollint::Real=0.1)
 
 Waits until `testcb` returns `true` or for `secs` seconds, whichever is earlier.
-`testcb` is polled every `pollint` seconds.
+`testcb` is polled every `pollint` seconds. The minimum duration for `secs` and `pollint` is
+1 millisecond or `0.001`.
 
 Returns :ok, :timed_out, or :error
 """
 function timedwait(testcb::Function, secs::Real; pollint::Real=0.1)
-    pollint > 0 || throw(ArgumentError("cannot set pollint to $pollint seconds"))
+    pollint >= 1e-3 || throw(ArgumentError("pollint must be ≥ 1 millisecond"))
     start = time_ns()
     nsecs = 1e9 * secs
     done = Channel(1)

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -420,11 +420,15 @@ Base.hash(x::Time, h::UInt) =
     hash(hour(x), hash(minute(x), hash(second(x),
         hash(millisecond(x), hash(microsecond(x), hash(nanosecond(x), h))))))
 
-import Base: sleep, Timer, timedwait
-sleep(time::Period) = sleep(toms(time) / 1000)
-Timer(time::Period; interval::Period = Second(0)) =
-    Timer(toms(time) / 1000, interval = toms(interval) / 1000)
-timedwait(testcb::Function, time::Period) = timedwait(testcb, toms(time) / 1000)
+Base.sleep(duration::Period) = sleep(toms(duration) / 1000)
+
+function Base.Timer(delay::Period; interval::Period=Second(0))
+    Timer(toms(delay) / 1000, interval=toms(interval) / 1000)
+end
+
+function Base.timedwait(testcb::Function, timeout::Period)
+    timedwait(testcb, toms(timeout) / 1000)
+end
 
 Base.OrderStyle(::Type{<:AbstractTime}) = Base.Ordered()
 Base.ArithmeticStyle(::Type{<:AbstractTime}) = Base.ArithmeticWraps()

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -426,8 +426,8 @@ function Base.Timer(delay::Period; interval::Period=Second(0))
     Timer(toms(delay) / 1000, interval=toms(interval) / 1000)
 end
 
-function Base.timedwait(testcb::Function, timeout::Period)
-    timedwait(testcb, toms(timeout) / 1000)
+function Base.timedwait(testcb::Function, timeout::Period; pollint::Period=Millisecond(100))
+    timedwait(testcb, toms(timeout) / 1000, pollint=toms(pollint) / 1000)
 end
 
 Base.OrderStyle(::Type{<:AbstractTime}) = Base.Ordered()

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -266,4 +266,8 @@ end
 
 end
 
+@testset "timedwait" begin
+    @test timedwait(() -> false, Second(0); pollint=Millisecond(1)) === :timed_out
+end
+
 end

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -252,6 +252,19 @@ using Distributed
     end
 end
 
+@testset "timedwait" begin
+    @test timedwait(() -> true, 0) === :ok
+    @test timedwait(() -> false, 0) === :timed_out
+    @test_broken timedwait(() -> error("callback failed"), 0) === :error
+    @test_throws ArgumentError timedwait(() -> true, 0; pollint=0)
+
+    duration = @elapsed timedwait(() -> false, 1)  # Using default pollint of 0.1
+    @test duration ≈ 1 atol=0.4
+
+    duration = @elapsed timedwait(() -> false, 0; pollint=1)
+    @test duration ≈ 1 atol=0.4
+end
+
 @testset "timedwait on multiple channels" begin
     @Experimental.sync begin
         rr1 = Channel(1)

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -255,11 +255,36 @@ end
 @testset "timedwait" begin
     @test timedwait(() -> true, 0) === :ok
     @test timedwait(() -> false, 0) === :timed_out
-    @test_broken timedwait(() -> error("callback failed"), 0) === :error
     @test_throws ArgumentError timedwait(() -> true, 0; pollint=0)
 
     # Allowing a smaller positive `pollint` results in `timewait` hanging
     @test_throws ArgumentError timedwait(() -> true, 0, pollint=1e-4)
+
+    # Callback passed in raises an exception
+    failure_cb = function (fail_on_call=1)
+        i = 0
+        function ()
+            i += 1
+            i >= fail_on_call && error("callback failed")
+            return false
+        end
+    end
+
+    try
+        timedwait(failure_cb(1), 0)
+        @test false
+    catch e
+        @test e isa CapturedException
+        @test e.ex isa ErrorException
+    end
+
+    try
+        timedwait(failure_cb(2), 0)
+        @test false
+    catch e
+        @test e isa CapturedException
+        @test e.ex isa ErrorException
+    end
 
     duration = @elapsed timedwait(() -> false, 1)  # Using default pollint of 0.1
     @test duration ≈ 1 atol=0.4

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -258,6 +258,9 @@ end
     @test_broken timedwait(() -> error("callback failed"), 0) === :error
     @test_throws ArgumentError timedwait(() -> true, 0; pollint=0)
 
+    # Allowing a smaller positive `pollint` results in `timewait` hanging
+    @test_throws ArgumentError timedwait(() -> true, 0, pollint=1e-4)
+
     duration = @elapsed timedwait(() -> false, 1)  # Using default pollint of 0.1
     @test duration ≈ 1 atol=0.4
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -252,7 +252,6 @@ using Distributed
     end
 end
 
-using Dates
 @testset "timedwait on multiple channels" begin
     @Experimental.sync begin
         rr1 = Channel(1)
@@ -262,13 +261,13 @@ using Dates
         callback() = all(map(isready, [rr1, rr2, rr3]))
         # precompile functions which will be tested for execution time
         @test !callback()
-        @test timedwait(callback, 0.0) === :timed_out
+        @test timedwait(callback, 0) === :timed_out
 
         @async begin sleep(0.5); put!(rr1, :ok) end
         @async begin sleep(1.0); put!(rr2, :ok) end
         @async begin sleep(2.0); put!(rr3, :ok) end
 
-        et = @elapsed timedwait(callback, Dates.Second(1))
+        et = @elapsed timedwait(callback, 1)
 
         # assuming that 0.5 seconds is a good enough buffer on a typical modern CPU
         try


### PR DESCRIPTION
Mainly I wanted to update the `timedwait` function to be able to take `Real` instead of just `Float64`. During this process I found that the `timedwait` method which takes `Period` was missing the `pollint` keyword and I made some adjustments there as well.

The `timedwait` function currently doesn't have any tests so I'll probably also do that as part of this PR.