### PR TITLE
Add file and line number reporting for some lowering errors

### DIFF
--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -94,7 +94,7 @@
   (let ((ex0 (julia-expand-macroscope e)))
     (if (toplevel-only-expr? ex0)
         ex0
-        (let* ((ex (julia-expand0 ex0))
+        (let* ((ex (julia-expand0 ex0 file line))
                (th (julia-expand1
                     `(lambda () ()
                              (scope-block

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -115,7 +115,7 @@
                                    (cons (decl-var (cadar binds)) vars)))
                             ((eventually-call? (cadar binds))
                              ;; f()=c
-                             (let ((asgn (cadr (julia-expand0 (car binds)))))
+                             (let ((asgn (cadr (julia-expand0 (car binds) 'none 0))))
                                (loop (cdr binds)
                                      (cons (cadr asgn) vars))))
                             ((and (pair? (cadar binds))

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -829,6 +829,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex)
         jl_error("eval cannot be used in a generated function");
     jl_value_t *v = NULL;
     int last_lineno = jl_lineno;
+    const char *last_filename = jl_filename;
     if (jl_options.incremental && jl_generating_output()) {
         if (!ptrhash_has(&jl_current_modules, (void*)m)) {
             if (m != jl_main_module) { // TODO: this was grand-fathered in
@@ -843,9 +844,11 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex)
     }
     JL_CATCH {
         jl_lineno = last_lineno;
+        jl_filename = last_filename;
         jl_rethrow();
     }
     jl_lineno = last_lineno;
+    jl_filename = last_filename;
     assert(v);
     return v;
 }

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2189,6 +2189,12 @@ end
 @test Meta.lower(@__MODULE__, Expr(:block, LineNumberNode(101, :some_file), :(f(x,x)=1))) ==
     Expr(:error, "function argument names not unique around some_file:101")
 
+# Ensure file names don't leak between `eval`s
+eval(LineNumberNode(11, :incorrect_file))
+let exc = try eval(:(f(x,x)=1)) catch e ; e ; end
+    @test !occursin("incorrect_file", exc.msg)
+end
+
 # issue #34967
 @test_throws LoadError("string", 2, ErrorException("syntax: invalid UTF-8 sequence")) include_string(@__MODULE__,
                                       "x34967 = 1\n# Halloa\xf5b\nx34967 = 2")

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1459,7 +1459,10 @@ end
 @test c27964(8) == (8, 2)
 
 # issue #26739
-@test_throws ErrorException("syntax: invalid syntax \"sin.[1]\"") Core.eval(@__MODULE__, :(sin.[1]))
+let exc = try Core.eval(@__MODULE__, :(sin.[1])) catch exc ; exc end
+    @test exc isa ErrorException
+    @test startswith(exc.msg, "syntax: invalid syntax \"sin.[1]\"")
+end
 
 # issue #26873
 f26873 = 0
@@ -2181,6 +2184,10 @@ end
         @test ex == err
     end
 end
+
+# Syntax desugaring pass errors contain line numbers
+@test Meta.lower(@__MODULE__, Expr(:block, LineNumberNode(101, :some_file), :(f(x,x)=1))) ==
+    Expr(:error, "function argument names not unique around some_file:101")
 
 # issue #34967
 @test_throws LoadError("string", 2, ErrorException("syntax: invalid UTF-8 sequence")) include_string(@__MODULE__,


### PR DESCRIPTION
As part of looking into https://github.com/JuliaLang/julia/issues/34820 I added file and line number reporting for desugaring errors and cleaned up some problems with `jl_filename` leaking between `eval`s. I thought these could be useful in their own right (independent of finishing the fix for `functionloc`).

The approach using the dynamically scoped `*current-desugar-loc*` seemed to be the least disruptive way of making this work in lowering.

Fixes #35128