### PR TITLE
Fix RoundNearest rem for Rational's

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -64,10 +64,11 @@ without any intermediate rounding.
 rem(x, y, r::RoundingMode)
 
 # TODO: Make these primitive and have the two-argument version call these
-rem(x, y, ::RoundingMode{:ToZero}) = rem(x,y)
-rem(x, y, ::RoundingMode{:Down}) = mod(x,y)
-rem(x, y, ::RoundingMode{:Up}) = mod(x,-y)
-rem(x, y, r::RoundingMode{:Nearest}) = divrem(x, y, r)[2]
+rem(x, y, ::RoundingMode{:ToZero}) = rem(x, y)
+rem(x, y, ::RoundingMode{:Down}) = mod(x, y)
+rem(x, y, ::RoundingMode{:Up}) = mod(x, -y)
+rem(x, y, r::RoundingMode{:Nearest}) = x - y*div(x, y, r)
+rem(x::Integer, y::Integer, r::RoundingMode{:Nearest}) = divrem(x, y, r)[2]
 
 """
     fld(x, y)
@@ -118,7 +119,7 @@ julia> divrem(7,3)
 """
 divrem(x, y) = divrem(x, y, RoundToZero)
 function divrem(a, b, r::RoundingMode)
-    if r == RoundToZero
+    if r === RoundToZero
         # For compat. Remove in 2.0.
         (div(a, b), rem(a, b))
     elseif r === RoundDown
@@ -208,7 +209,7 @@ end
 function div(x::Integer, y::Integer, rnd::Union{typeof(RoundNearest),
                                               typeof(RoundNearestTiesAway),
                                               typeof(RoundNearestTiesUp)})
-    divrem(x,y,rnd)[1]
+    divrem(x, y, rnd)[1]
 end
 
 # For bootstrapping purposes, we define div for integers directly. Provide the
@@ -246,7 +247,7 @@ cld(x::T, y::T) where {T<:Real} = throw(MethodError(div, (x, y, RoundUp)))
 # Promotion
 function div(x::Real, y::Real, r::RoundingMode)
     typeof(x) === typeof(y) && throw(MethodError(div, (x, y, r)))
-    if r == RoundToZero
+    if r === RoundToZero
         # For compat. Remove in 2.0.
         div(promote(x, y)...)
     else

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2476,10 +2476,10 @@ end
         @test rem(T(n), T(-5), RoundNearest) == rem(float(n), -5.0, RoundNearest) == r
         @test rem(T(-n), T(-5), RoundNearest) == rem(float(-n), -5.0, RoundNearest) == -r
         @test rem(T(-n), T(5), RoundNearest) == rem(float(-n), 5.0, RoundNearest) == -r
-        @test rem(T(n), T(5), RoundNearest) == rem(T(n)//1, T(5)//1, RoundNearest)
-        @test rem(T(-n), T(5), RoundNearest) == rem(T(-n)//1, T(5)//1, RoundNearest)
-        @test rem(T(n), T(-5), RoundNearest) == rem(T(n)//1, T(-5)//1, RoundNearest)
-        @test rem(T(-n), T(-5), RoundNearest) == rem(T(-n)//1, T(-5)//1, RoundNearest)
+        @test rem(T(n), T(5), RoundNearest) == rem(T(n)//T(1), T(5)//T(1), RoundNearest)
+        @test rem(T(-n), T(5), RoundNearest) == rem(T(-n)//T(1), T(5)//T(1), RoundNearest)
+        @test rem(T(n), T(-5), RoundNearest) == rem(T(n)//T(1), T(-5)//T(1), RoundNearest)
+        @test rem(T(-n), T(-5), RoundNearest) == rem(T(-n)//T(1), T(-5)//T(1), RoundNearest)
     end
 end
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2473,6 +2473,7 @@ end
 @testset "rem for $T RoundNearest" for T in (Int8, Int16, Int32, Int64, Int128)
     for (n, r) in zip(3:7, -2:2)
         @test rem(T(n), T(5), RoundNearest) == rem(float(n), 5.0, RoundNearest) == r
+        @test rem(T(n), T(5), RoundNearest) == rem(T(n)//1, T(5)//1, RoundNearest)
     end
 end
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2473,7 +2473,13 @@ end
 @testset "rem for $T RoundNearest" for T in (Int8, Int16, Int32, Int64, Int128)
     for (n, r) in zip(3:7, -2:2)
         @test rem(T(n), T(5), RoundNearest) == rem(float(n), 5.0, RoundNearest) == r
+        @test rem(T(n), T(-5), RoundNearest) == rem(float(n), -5.0, RoundNearest) == r
+        @test rem(T(-n), T(-5), RoundNearest) == rem(float(-n), -5.0, RoundNearest) == -r
+        @test rem(T(-n), T(5), RoundNearest) == rem(float(-n), 5.0, RoundNearest) == -r
         @test rem(T(n), T(5), RoundNearest) == rem(T(n)//1, T(5)//1, RoundNearest)
+        @test rem(T(-n), T(5), RoundNearest) == rem(T(-n)//1, T(5)//1, RoundNearest)
+        @test rem(T(n), T(-5), RoundNearest) == rem(T(n)//1, T(-5)//1, RoundNearest)
+        @test rem(T(-n), T(-5), RoundNearest) == rem(T(-n)//1, T(-5)//1, RoundNearest)
     end
 end
 


### PR DESCRIPTION
... and use `===` for type comparison.

I used the opportunity to polish the code at a few places.

Fixes the issue brought up in https://github.com/JuliaLang/julia/pull/35034#issuecomment-599035929 by @sostock.