### PR TITLE
Add @inline for do blocks

### DIFF
--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -281,4 +281,6 @@ end
     @test !ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods( x -> x)).source)
     @test ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(@inline function f(x) x end)).source)
     @test !ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(function f(x) x end)).source)
+    @test ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(@inline identity() do x; x end)).source)
+    @test !ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(identity() do x; x end)).source)
 end

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -96,7 +96,7 @@ end
 for m in [:foo1, :foo2, :foo3, :foo4, :foo5]
     @test popmeta!(multi_meta, m)[1]
 end
-@test Base.findmeta(multi_meta.args)[1] == 0
+@test Base.findmeta_block(multi_meta.args)[1] == 0
 
 # Test that pushmeta! can push across other macros,
 # in the case multiple pushmeta!-based macros are combined


### PR DESCRIPTION
This PR makes `@inline` work with `do` blocks.  This is very useful for writing high-performance code with higher-order functions such as `foreach`, `foldl`, and `reduce`.