### PR TITLE
clarify error message for constant redefinition

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -630,7 +630,7 @@ julia> const y = 1.0
 1.0
 
 julia> y = 2.0
-WARNING: redefining constant y
+WARNING: redefinition of constant y. This may fail, cause incorrect answers, or produce other errors.
 2.0
 ```
 * if an assignment would not result in the change of variable value no message is given:
@@ -669,7 +669,7 @@ julia> const a = [1]
  1
 
 julia> a = [1]
-WARNING: redefining constant a
+WARNING: redefinition of constant a. This may fail, cause incorrect answers, or produce other errors.
 1-element Array{Int64,1}:
  1
 ```
@@ -690,7 +690,7 @@ julia> f()
 1
 
 julia> x = 2
-WARNING: redefining constant x
+WARNING: redefinition of constant x. This may fail, cause incorrect answers, or produce other errors.
 2
 
 julia> f()

--- a/src/module.c
+++ b/src/module.c
@@ -707,7 +707,7 @@ JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
                 jl_errorf("invalid redefinition of constant %s",
                           jl_symbol_name(b->name));
             }
-            jl_printf(JL_STDERR, "WARNING: redefining constant %s\n",
+            jl_printf(JL_STDERR, "WARNING: redefinition of constant %s. This may fail, cause incorrect answers, or produce other errors.\n",
                       jl_symbol_name(b->name));
         }
     }


### PR DESCRIPTION
Before it sounded like a linter message (the description was that this was a gentle notice), now it should be clearer that this warning means Julia may now be partially dysfunctional.

Closes #28689