### PR TITLE
add findall(char, str) and count(char, str)

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -372,6 +372,8 @@ function findall(t::Union{AbstractString,Regex}, s::AbstractString; overlap::Boo
     return found
 end
 
+findall(ch::AbstractChar, s::AbstractString) = findall(==(ch), s)
+
 """
     count(
         pattern::Union{AbstractString,Regex},
@@ -398,6 +400,8 @@ function count(t::Union{AbstractString,Regex}, s::AbstractString; overlap::Bool=
     end
     return n
 end
+
+count(ch::AbstractChar, s::AbstractString) = count(==(ch), s)
 
 """
     SubstitutionString(substr)

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -381,4 +381,11 @@ s_18109 = "fooα🐨βcd3"
     @test findall("αβ", "blαh blαβ blαββy") == findall("αβ", "blαh blαβ blαββy", overlap=true) == [9:11, 16:18]
     @test findall("aa", "aaaaaa") == [1:2, 3:4, 5:6]
     @test findall("aa", "aaaaaa", overlap=true) == [1:2, 2:3, 3:4, 4:5, 5:6]
+
+    @test findall('z', "language") == Int[]
+    @test findall('l', "language") == [1]
+    @test findall('a', "language") == [2, 6]
+    @test count('z', "language") == 0
+    @test count('l', "language") == 1
+    @test count('a', "language") == 2
 end


### PR DESCRIPTION
Since `findfirst(char, string)` works, why don't we add `findall(char, string)` and `count(char, string)`?