### PR TITLE
speed up llvmcall unique name generation

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -881,7 +881,6 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     }
     if (at == NULL)
         at = try_eval(ctx, args[3], "error statically evaluating llvmcall argument tuple");
-    int i = 1;
     if (jl_is_tuple(ir)) {
         // if the IR is a tuple, we expect (declarations, ir)
         if (jl_nfields(ir) != 2)
@@ -940,7 +939,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
         std::string ir_name;
         while (true) {
             std::stringstream name;
-            name << (ctx.f->getName().str()) << "u" << i++;
+            name << (ctx.f->getName().str()) << "u" << globalUnique++;
             ir_name = name.str();
             if (jl_Module->getFunction(ir_name) == NULL)
                 break;


### PR DESCRIPTION
This speeds up codegen of functions that use many duplicate llvmcalls, such as in LoopVectorization/SIMDPirates. From issue #35131

For me this takes the time to run the LoopVectorization tests from 5'40" to 5'15" (note this is a somewhat slow machine).