### PR TITLE
define `keys` for `Base.Generator`

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -51,6 +51,7 @@ length(g::Generator) = length(g.iter)
 size(g::Generator) = size(g.iter)
 axes(g::Generator) = axes(g.iter)
 ndims(g::Generator) = ndims(g.iter)
+keys(g::Generator) = OneTo(length(g))
 
 
 ## iterator traits

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -220,5 +220,5 @@ let (:)(a,b) = (i for i in Base.:(:)(1,10) if i%2==0)
     @test Int8[ i for i = 1:2 ] == [2,4,6,8,10]
 end
 
-@test keys((sin(x) for x in 0.0:0.5:9.9) == 1:20
+@test keys(sin(x) for x in 0.0:0.5:9.9) == 1:20
 

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -219,3 +219,6 @@ end
 let (:)(a,b) = (i for i in Base.:(:)(1,10) if i%2==0)
     @test Int8[ i for i = 1:2 ] == [2,4,6,8,10]
 end
+
+@test keys((sin(x) for x in 0.0:0.5:9.9) == 1:20
+


### PR DESCRIPTION
IMO `findmin(sin(x) for x in 0:10)` should return same as `findmin([sin(x) for x in 0:10])`,
without allocating. Currently the first call throws a `MethodError`.

This PR inserts `key(::Base.Generator)` in order to achieve that.
As a consequence also `pairs(::Generator)`, `findmin(::Genearator)`, `findmax(::Generator)` are working as expected.

```
julia> @btime findmin(sin(x) for x = 1:10^6)
  21.901 ms (0 allocations: 0 bytes)
(-0.9999999999848337, 52174)

julia> @btime findmin([sin(x) for x = 1:10^6])
  25.945 ms (2 allocations: 7.63 MiB)
(-0.9999999999848337, 52174)
```