### PR TITLE
rename some uses of `ast` to `ir` where applicable [NFC]

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -237,13 +237,13 @@ function abstract_call_method_with_const_args(@nospecialize(rettype), @nospecial
     # decide if it's likely to be worthwhile
     if !force_inference
         code = inf_for_methodinstance(mi, sv.params.world)
-        declared_inline = isdefined(method, :source) && ccall(:jl_ast_flag_inlineable, Bool, (Any,), method.source)
+        declared_inline = isdefined(method, :source) && ccall(:jl_ir_flag_inlineable, Bool, (Any,), method.source)
         cache_inlineable = declared_inline
         if isdefined(code, :inferred) && !cache_inlineable
             cache_inf = code.inferred
             if !(cache_inf === nothing)
-                cache_src_inferred = ccall(:jl_ast_flag_inferred, Bool, (Any,), cache_inf)
-                cache_src_inlineable = ccall(:jl_ast_flag_inlineable, Bool, (Any,), cache_inf)
+                cache_src_inferred = ccall(:jl_ir_flag_inferred, Bool, (Any,), cache_inf)
+                cache_src_inlineable = ccall(:jl_ir_flag_inlineable, Bool, (Any,), cache_inf)
                 cache_inlineable = cache_src_inferred && cache_src_inlineable
             end
         end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -711,8 +711,8 @@ function analyze_method!(idx::Int, sig::Signature, @nospecialize(metharg), meths
         return spec_lambda(atype_unlimited, sv, invoke_data)
     end
 
-    src_inferred = ccall(:jl_ast_flag_inferred, Bool, (Any,), src)
-    src_inlineable = ccall(:jl_ast_flag_inlineable, Bool, (Any,), src)
+    src_inferred = ccall(:jl_ir_flag_inferred, Bool, (Any,), src)
+    src_inlineable = ccall(:jl_ir_flag_inlineable, Bool, (Any,), src)
 
     if !(src_inferred && src_inlineable)
         return spec_lambda(atype_unlimited, sv, invoke_data)
@@ -722,7 +722,7 @@ function analyze_method!(idx::Int, sig::Signature, @nospecialize(metharg), meths
     add_backedge!(mi, sv)
 
     if !isa(src, CodeInfo)
-        src = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), method, C_NULL, src::Vector{UInt8})::CodeInfo
+        src = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), method, C_NULL, src::Vector{UInt8})::CodeInfo
     end
 
     @timeit "inline IR inflation" begin

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -119,7 +119,7 @@ function cache_result(result::InferenceResult, min_valid::UInt, max_valid::UInt)
                     nslots = length(inferred_result.slotflags)
                     resize!(inferred_result.slottypes, nslots)
                     resize!(inferred_result.slotnames, nslots)
-                    inferred_result = ccall(:jl_compress_ast, Any, (Any, Any), def, inferred_result)
+                    inferred_result = ccall(:jl_compress_ir, Any, (Any, Any), def, inferred_result)
                 else
                     inferred_result = nothing
                 end
@@ -559,7 +559,7 @@ function typeinf_ext(mi::MethodInstance, params::Params)
                 return inf
             elseif isa(inf, Vector{UInt8})
                 i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
-                inf = _uncompressed_ast(code, inf)
+                inf = _uncompressed_ir(code, inf)
                 return inf
             end
         end

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -107,7 +107,7 @@ function retrieve_code_info(linfo::MethodInstance)
     if c === nothing && isdefined(m, :source)
         src = m.source
         if isa(src, Array{UInt8,1})
-            c = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, src)
+            c = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, src)
         else
             c = copy(src::CodeInfo)
         end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -811,7 +811,7 @@ function code_lowered(@nospecialize(f), @nospecialize(t=Tuple); generated::Bool=
                       "not leaf types, but the `generated` argument is `true`.")
             end
         end
-        code = uncompressed_ast(m.def::Method)
+        code = uncompressed_ir(m.def::Method)
         debuginfo === :none && remove_linenums!(code)
         return code
     end
@@ -943,12 +943,15 @@ function length(mt::Core.MethodTable)
 end
 isempty(mt::Core.MethodTable) = (mt.defs === nothing)
 
-uncompressed_ast(m::Method) = isdefined(m, :source) ? _uncompressed_ast(m, m.source) :
-                              isdefined(m, :generator) ? error("Method is @generated; try `code_lowered` instead.") :
-                              error("Code for this Method is not available.")
-_uncompressed_ast(m::Method, s::CodeInfo) = copy(s)
-_uncompressed_ast(m::Method, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, s)::CodeInfo
-_uncompressed_ast(ci::Core.CodeInstance, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Any, Any), ci.def.def::Method, ci, s)::CodeInfo
+uncompressed_ir(m::Method) = isdefined(m, :source) ? _uncompressed_ir(m, m.source) :
+                             isdefined(m, :generator) ? error("Method is @generated; try `code_lowered` instead.") :
+                             error("Code for this Method is not available.")
+_uncompressed_ir(m::Method, s::CodeInfo) = copy(s)
+_uncompressed_ir(m::Method, s::Array{UInt8,1}) = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, s)::CodeInfo
+_uncompressed_ir(ci::Core.CodeInstance, s::Array{UInt8,1}) = ccall(:jl_uncompress_ir, Any, (Any, Any, Any), ci.def.def::Method, ci, s)::CodeInfo
+# for backwards compat
+const uncompressed_ast = uncompressed_ir
+const _uncompressed_ast = _uncompressed_ir
 
 function method_instances(@nospecialize(f), @nospecialize(t), world::UInt = typemax(UInt))
     tt = signature_type(f, t)
@@ -993,7 +996,7 @@ struct CodegenParams
 end
 
 const SLOT_USED = 0x8
-ast_slotflag(@nospecialize(code), i) = ccall(:jl_ast_slotflag, UInt8, (Any, Csize_t), code, i - 1)
+ast_slotflag(@nospecialize(code), i) = ccall(:jl_ir_slotflag, UInt8, (Any, Csize_t), code, i - 1)
 
 """
     may_invoke_generator(method, atypes, sparams)
@@ -1031,7 +1034,7 @@ function may_invoke_generator(method::Method, @nospecialize(atypes), sparams::Si
     nsparams = length(sparams)
     isdefined(generator_method, :source) || return false
     code = generator_method.source
-    nslots = ccall(:jl_ast_nslots, Int, (Any,), code)
+    nslots = ccall(:jl_ir_nslots, Int, (Any,), code)
     at = unwrap_unionall(atypes)
     (nslots >= 1 + length(sparams) + length(at.parameters)) || return false
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -286,7 +286,7 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams)
                     if ((jl_value_t*)src == jl_nothing)
                         src = NULL;
                     if (src && jl_is_method(def))
-                        src = jl_uncompress_ast(def, codeinst, (jl_array_t*)src);
+                        src = jl_uncompress_ir(def, codeinst, (jl_array_t*)src);
                 }
                 if (src == NULL || !jl_is_code_info(src)) {
                     src = jl_type_infer(mi, params.world, 0);
@@ -792,7 +792,7 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
         jl_code_instance_t *codeinst = (jl_code_instance_t*)ci;
         src = (jl_code_info_t*)codeinst->inferred;
         if ((jl_value_t*)src != jl_nothing && !jl_is_code_info(src) && jl_is_method(mi->def.method))
-            src = jl_uncompress_ast(mi->def.method, codeinst, (jl_array_t*)src);
+            src = jl_uncompress_ir(mi->def.method, codeinst, (jl_array_t*)src);
         jlrettype = codeinst->rettype;
     }
     if (!src || (jl_value_t*)src == jl_nothing) {
@@ -802,7 +802,7 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
         else if (jl_is_method(mi->def.method)) {
             src = mi->def.method->generator ? jl_code_for_staged(mi) : (jl_code_info_t*)mi->def.method->source;
             if (src && !jl_is_code_info(src) && jl_is_method(mi->def.method))
-                src = jl_uncompress_ast(mi->def.method, NULL, (jl_array_t*)src);
+                src = jl_uncompress_ir(mi->def.method, NULL, (jl_array_t*)src);
         }
         // TODO: use mi->uninferred
     }

--- a/src/ast.c
+++ b/src/ast.c
@@ -598,7 +598,7 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
             e = cdr_(e);
         }
         if (sym == lambda_sym)
-            ex = (jl_value_t*)jl_new_code_info_from_ast((jl_expr_t*)ex);
+            ex = (jl_value_t*)jl_new_code_info_from_ir((jl_expr_t*)ex);
         JL_GC_POP();
         if (sym == list_sym)
             return (jl_value_t*)((jl_expr_t*)ex)->args;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6484,7 +6484,7 @@ jl_compile_result_t jl_emit_codeinst(
         src = (jl_code_info_t*)codeinst->inferred;
         jl_method_t *def = codeinst->def->def.method;
         if (src && (jl_value_t*)src != jl_nothing && jl_is_method(def))
-            src = jl_uncompress_ast(def, codeinst, (jl_array_t*)src);
+            src = jl_uncompress_ir(def, codeinst, (jl_array_t*)src);
         if (!src || !jl_is_code_info(src)) {
             JL_GC_POP();
             return jl_compile_result_t(); // failed
@@ -6526,17 +6526,17 @@ jl_compile_result_t jl_emit_codeinst(
                 // update the stored code
                 if (codeinst->inferred != (jl_value_t*)src) {
                     if (jl_is_method(def))
-                        src = (jl_code_info_t*)jl_compress_ast(def, src);
+                        src = (jl_code_info_t*)jl_compress_ir(def, src);
                     codeinst->inferred = (jl_value_t*)src;
                     jl_gc_wb(codeinst, src);
                 }
             }
             else if (// don't delete toplevel code
                      jl_is_method(def) &&
-                     // and there is something to delete (test this before calling jl_ast_flag_inlineable)
+                     // and there is something to delete (test this before calling jl_ir_flag_inlineable)
                      codeinst->inferred != jl_nothing &&
                      // don't delete inlineable code, unless it is constant
-                     (codeinst->invoke == jl_fptr_const_return || !jl_ast_flag_inlineable((jl_array_t*)codeinst->inferred)) &&
+                     (codeinst->invoke == jl_fptr_const_return || !jl_ir_flag_inlineable((jl_array_t*)codeinst->inferred)) &&
                      // don't delete code when generating a precompile file
                      !imaging_mode) {
                 // if not inlineable, code won't be needed again

--- a/src/gf.c
+++ b/src/gf.c
@@ -253,7 +253,7 @@ JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_method_instance_t *mi, size_t mi
     while (codeinst) {
         if (codeinst->min_world <= min_world && max_world <= codeinst->max_world) {
             jl_value_t *code = codeinst->inferred;
-            if (code && (code == jl_nothing || jl_ast_flag_inferred((jl_array_t*)code)))
+            if (code && (code == jl_nothing || jl_ir_flag_inferred((jl_array_t*)code)))
                 return (jl_value_t*)codeinst;
         }
         codeinst = codeinst->next;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -447,7 +447,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
 #endif
         return val;
     }
-    assert(!jl_is_phinode(e) && !jl_is_phicnode(e) && !jl_is_upsilonnode(e) && "malformed AST");
+    assert(!jl_is_phinode(e) && !jl_is_phicnode(e) && !jl_is_upsilonnode(e) && "malformed IR");
     if (!jl_is_expr(e))
         return e;
     jl_expr_t *ex = (jl_expr_t*)e;
@@ -655,7 +655,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
         jl_value_t *stmt = jl_array_ptr_ref(stmts, ip);
         assert(!jl_is_phinode(stmt));
         size_t next_ip = ip + 1;
-        assert(!jl_is_phinode(stmt) && !jl_is_phicnode(stmt) && "malformed AST");
+        assert(!jl_is_phinode(stmt) && !jl_is_phicnode(stmt) && "malformed IR");
         if (jl_is_gotonode(stmt)) {
             next_ip = jl_gotonode_label(stmt) - 1;
         }
@@ -842,7 +842,7 @@ jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *mi)
         }
         if (src && (jl_value_t*)src != jl_nothing) {
             JL_GC_PUSH1(&src);
-            src = jl_uncompress_ast(mi->def.method, NULL, (jl_array_t*)src);
+            src = jl_uncompress_ir(mi->def.method, NULL, (jl_array_t*)src);
             mi->uninferred = (jl_value_t*)src;
             jl_gc_wb(mi, src);
             JL_GC_POP();

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -222,7 +222,7 @@ jl_code_instance_t *jl_generate_fptr(jl_method_instance_t *mi JL_PROPAGATES_ROOT
         if ((jl_value_t*)src == jl_nothing)
             src = NULL;
         else if (jl_is_method(mi->def.method))
-            src = jl_uncompress_ast(mi->def.method, codeinst, (jl_array_t*)src);
+            src = jl_uncompress_ir(mi->def.method, codeinst, (jl_array_t*)src);
     }
     if (src == NULL && jl_is_method(mi->def.method) &&
              jl_symbol_name(mi->def.method->name)[0] != '@') {
@@ -272,7 +272,7 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
                 src = jl_code_for_staged(unspec->def);
             }
             if (src && (jl_value_t*)src != jl_nothing)
-                src = jl_uncompress_ast(def, NULL, (jl_array_t*)src);
+                src = jl_uncompress_ir(def, NULL, (jl_array_t*)src);
         }
         else {
             src = (jl_code_info_t*)unspec->def->uninferred;
@@ -315,7 +315,7 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
                         src = def->generator ? jl_code_for_staged(mi) : (jl_code_info_t*)def->source;
                     }
                     if (src && (jl_value_t*)src != jl_nothing)
-                        src = jl_uncompress_ast(mi->def.method, codeinst, (jl_array_t*)src);
+                        src = jl_uncompress_ir(mi->def.method, codeinst, (jl_array_t*)src);
                 }
                 fptr = (uintptr_t)codeinst->invoke;
                 specfptr = (uintptr_t)codeinst->specptr.fptr;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1647,13 +1647,14 @@ JL_DLLEXPORT void jl_register_newmeth_tracer(void (*callback)(jl_method_t *trace
 // AST access
 JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr JL_MAYBE_UNROOTED);
 
-JL_DLLEXPORT jl_array_t *jl_compress_ast(jl_method_t *m, jl_code_info_t *code);
-JL_DLLEXPORT jl_code_info_t *jl_uncompress_ast(jl_method_t *m, jl_code_instance_t *metadata, jl_array_t *data);
-JL_DLLEXPORT uint8_t jl_ast_flag_inferred(jl_array_t *data) JL_NOTSAFEPOINT;
-JL_DLLEXPORT uint8_t jl_ast_flag_inlineable(jl_array_t *data) JL_NOTSAFEPOINT;
-JL_DLLEXPORT uint8_t jl_ast_flag_pure(jl_array_t *data) JL_NOTSAFEPOINT;
-JL_DLLEXPORT ssize_t jl_ast_nslots(jl_array_t *data) JL_NOTSAFEPOINT;
-JL_DLLEXPORT uint8_t jl_ast_slotflag(jl_array_t *data, size_t i) JL_NOTSAFEPOINT;
+// IR representation
+JL_DLLEXPORT jl_array_t *jl_compress_ir(jl_method_t *m, jl_code_info_t *code);
+JL_DLLEXPORT jl_code_info_t *jl_uncompress_ir(jl_method_t *m, jl_code_instance_t *metadata, jl_array_t *data);
+JL_DLLEXPORT uint8_t jl_ir_flag_inferred(jl_array_t *data) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint8_t jl_ir_flag_inlineable(jl_array_t *data) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint8_t jl_ir_flag_pure(jl_array_t *data) JL_NOTSAFEPOINT;
+JL_DLLEXPORT ssize_t jl_ir_nslots(jl_array_t *data) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint8_t jl_ir_slotflag(jl_array_t *data, size_t i) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_compress_argnames(jl_array_t *syms);
 JL_DLLEXPORT jl_array_t *jl_uncompress_argnames(jl_value_t *syms);
 JL_DLLEXPORT jl_value_t *jl_uncompress_argname_n(jl_value_t *syms, size_t i);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -403,7 +403,7 @@ jl_method_instance_t *jl_get_unspecialized(jl_method_instance_t *method JL_PROPA
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
 jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *lam JL_PROPAGATES_ROOT);
 int jl_code_requires_compiler(jl_code_info_t *src);
-jl_code_info_t *jl_new_code_info_from_ast(jl_expr_t *ast);
+jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ast);
 JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void);
 
 jl_value_t *jl_argtype_with_function(jl_function_t *f, jl_value_t *types);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -326,8 +326,8 @@ static int precompile_enq_specialization_(jl_typemap_entry_t *l, void *closure)
         int do_compile = 0;
         if (codeinst->invoke != jl_fptr_const_return) {
             if (codeinst->inferred && codeinst->inferred != jl_nothing &&
-                jl_ast_flag_inferred((jl_array_t*)codeinst->inferred) &&
-                !jl_ast_flag_inlineable((jl_array_t*)codeinst->inferred)) {
+                jl_ir_flag_inferred((jl_array_t*)codeinst->inferred) &&
+                !jl_ir_flag_inlineable((jl_array_t*)codeinst->inferred)) {
                 do_compile = 1;
             }
             else if (codeinst->invoke != NULL) {

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1523,7 +1523,7 @@ function f24852_kernel_cinfo(fsig::Type)
     world = typemax(UInt) # FIXME
     sig, spvals, method = Base._methods_by_ftype(fsig, -1, world)[1]
     isdefined(method, :source) || return (nothing, :(f(x, y)))
-    code_info = Base.uncompressed_ast(method)
+    code_info = Base.uncompressed_ir(method)
     Meta.partially_inline!(code_info.code, Any[], sig, Any[spvals...], 1, 0, :propagate)
     if startswith(String(method.name), "f24852")
         for a in code_info.code

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -276,9 +276,9 @@ let ci = code_typed(f34900, Tuple{Int, Int})[1].first
         ci.code[1].args[1].id == 2
 end
 
-@testset "check jl_ast_flag_inlineable for inline macro" begin
-    @test ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(@inline x -> x)).source)
-    @test !ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods( x -> x)).source)
-    @test ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(@inline function f(x) x end)).source)
-    @test !ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(function f(x) x end)).source)
+@testset "check jl_ir_flag_inlineable for inline macro" begin
+    @test ccall(:jl_ir_flag_inlineable, Bool, (Any,), first(methods(@inline x -> x)).source)
+    @test !ccall(:jl_ir_flag_inlineable, Bool, (Any,), first(methods( x -> x)).source)
+    @test ccall(:jl_ir_flag_inlineable, Bool, (Any,), first(methods(@inline function f(x) x end)).source)
+    @test !ccall(:jl_ir_flag_inlineable, Bool, (Any,), first(methods(function f(x) x end)).source)
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -9,7 +9,7 @@ using Test
 module ReflectionTest
 using Test, Random
 
-function test_ast_reflection(freflect, f, types)
+function test_ir_reflection(freflect, f, types)
     @test !isempty(freflect(f, types))
     nothing
 end
@@ -39,8 +39,8 @@ function test_code_reflections(tester, freflect)
     test_code_reflection(freflect, muladd, Tuple{Float64, Float64, Float64}, tester)
 end
 
-test_code_reflections(test_ast_reflection, code_lowered)
-test_code_reflections(test_ast_reflection, code_typed)
+test_code_reflections(test_ir_reflection, code_lowered)
+test_code_reflections(test_ir_reflection, code_typed)
 
 end # module ReflectionTest
 
@@ -336,7 +336,7 @@ import InteractiveUtils.code_warntype
 
 used_dup_var_tested15714 = false
 used_unique_var_tested15714 = false
-function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types), must_used_vars)
+function test_typed_ir_printing(Base.@nospecialize(f), Base.@nospecialize(types), must_used_vars)
     src, rettype = code_typed(f, types, optimize=false)[1]
     dupnames = Set()
     slotnames = Set()
@@ -396,10 +396,10 @@ function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types
         @test must_used_checked[sym]
     end
 end
-test_typed_ast_printing(f15714, Tuple{Vector{Float32}},
-                        [:array_var15714,  :index_var15714])
-test_typed_ast_printing(g15714, Tuple{Vector{Float32}},
-                        [:array_var15714,  :index_var15714])
+test_typed_ir_printing(f15714, Tuple{Vector{Float32}},
+                       [:array_var15714,  :index_var15714])
+test_typed_ir_printing(g15714, Tuple{Vector{Float32}},
+                       [:array_var15714,  :index_var15714])
 #This test doesn't work with the new optimizer because we drop slotnames
 #We may want to test it against debug info eventually
 #@test used_dup_var_tested15715
@@ -626,7 +626,7 @@ let
     mtypes, msp, m = Base._methods_by_ftype(T22979, -1, world)[1]
     instance = Core.Compiler.specialize_method(m, mtypes, msp)
     cinfo_generated = Core.Compiler.get_staged(instance)
-    @test_throws ErrorException Base.uncompressed_ast(m)
+    @test_throws ErrorException Base.uncompressed_ir(m)
 
     test_similar_codeinfo(code_lowered(f22979, typeof(x22979))[1], cinfo_generated)
 

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -248,7 +248,7 @@ f22440kernel(::Type{T}) where {T<:AbstractFloat} = zero(T)
 
 @generated function f22440(y)
     sig, spvals, method = Base._methods_by_ftype(Tuple{typeof(f22440kernel),y}, -1, typemax(UInt))[1]
-    code_info = Base.uncompressed_ast(method)
+    code_info = Base.uncompressed_ir(method)
     Meta.partially_inline!(code_info.code, Any[], sig, Any[spvals...], 0, 0, :propagate)
     return code_info
 end
@@ -283,7 +283,7 @@ let a = Any[]
     @test f23168(a, 3) == (6, Int)
     @test a == [1, 6, 3]
     @test occursin(" + ", string(code_lowered(f23168, (Vector{Any},Int))))
-    @test occursin("2 * ", string(Base.uncompressed_ast(first(methods(f23168)))))
+    @test occursin("2 * ", string(Base.uncompressed_ir(first(methods(f23168)))))
     @test occursin("2 * ", string(code_lowered(f23168, (Vector{Any},Int), generated=false)))
     @test occursin("Base.add_int", string(code_typed(f23168, (Vector{Any},Int))))
 end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1509,7 +1509,7 @@ end
 # issue #27129
 f27129(x = 1) = (@Base._inline_meta; x)
 for meth in methods(f27129)
-    @test ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), meth, C_NULL, meth.source).inlineable
+    @test ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), meth, C_NULL, meth.source).inlineable
 end
 
 # issue #27710


### PR DESCRIPTION
We have several left-over places where the term "AST" is used but we really mean "IR".