### PR TITLE
Differentiate between copy_oftype(A, T) and convert(AbstractArray{T}, A) for structured arrays

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -464,4 +464,20 @@ function __init__()
     Base.at_disable_library_threading(() -> BLAS.set_num_threads(1))
 end
 
+
+# For testing purposes:
+# A wrapper type for arrays, which implements getindex but not setindex!
+# This type allows to test whether some methods preserve immutable arrays, e.g.,
+# after conversion.
+struct ImmutableArray{T,N,A<:AbstractArray} <: AbstractArray{T,N}
+    data::A
+end
+ImmutableArray(data::AbstractArray{T,N}) where {T,N} = ImmutableArray{T,N,typeof(data)}(data)
+Base.size(A::ImmutableArray) = size(A.data)
+Base.size(A::ImmutableArray, d) = size(A.data, d)
+Base.getindex(A::ImmutableArray, i...) = getindex(A.data, i...)
+AbstractArray{T}(A::ImmutableArray) where {T} = ImmutableArray(AbstractArray{T}(A.data))
+AbstractArray{T,N}(A::ImmutableArray{S,N}) where {S,T,N} = ImmutableArray(AbstractArray{T,N}(A.data))
+
+
 end # module LinearAlgebra

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -347,7 +347,7 @@ control over the factorization of `B`.
 rdiv!(A, B)
 
 copy_oftype(A::AbstractArray{T}, ::Type{T}) where {T} = copy(A)
-copy_oftype(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = convert(AbstractArray{S,N}, A)
+copy_oftype(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = copyto!(similar(A, S), A)
 
 include("adjtrans.jl")
 include("transpose.jl")

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -346,8 +346,22 @@ control over the factorization of `B`.
 """
 rdiv!(A, B)
 
+"""
+Copy array `A` and make sure the result has element type `T`.
+
+This method often preserves the structure of `A`. It does so if both `copy(A)`
+and the two-argument function `similar(A, T)` do.
+"""
 copy_oftype(A::AbstractArray{T}, ::Type{T}) where {T} = copy(A)
 copy_oftype(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = copyto!(similar(A, S), A)
+
+"""
+Copy array `A` and make sure the result has element type `T`.
+
+This method typically discards the structure of `A`. It does so if the
+three-argument function `similar(A, T, size(A))` does.
+"""
+copy_similar(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = copyto!(similar(A, S, size(A)), A)
 
 include("adjtrans.jl")
 include("transpose.jl")

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -465,19 +465,4 @@ function __init__()
 end
 
 
-# For testing purposes:
-# A wrapper type for arrays, which implements getindex but not setindex!
-# This type allows to test whether some methods preserve immutable arrays, e.g.,
-# after conversion.
-struct ImmutableArray{T,N,A<:AbstractArray} <: AbstractArray{T,N}
-    data::A
-end
-ImmutableArray(data::AbstractArray{T,N}) where {T,N} = ImmutableArray{T,N,typeof(data)}(data)
-Base.size(A::ImmutableArray) = size(A.data)
-Base.size(A::ImmutableArray, d) = size(A.data, d)
-Base.getindex(A::ImmutableArray, i...) = getindex(A.data, i...)
-AbstractArray{T}(A::ImmutableArray) where {T} = ImmutableArray(AbstractArray{T}(A.data))
-AbstractArray{T,N}(A::ImmutableArray{S,N}) where {S,T,N} = ImmutableArray(AbstractArray{T,N}(A.data))
-
-
 end # module LinearAlgebra

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -196,6 +196,10 @@ similar(A::AdjOrTrans) = similar(A.parent, eltype(A), axes(A))
 similar(A::AdjOrTrans, ::Type{T}) where {T} = similar(A.parent, T, axes(A))
 similar(A::AdjOrTrans, ::Type{T}, dims::Dims{N}) where {T,N} = similar(A.parent, T, dims)
 
+# mimick the style of similar for the AbstractMatrix{T} constructor:
+# for vectors we maintain the parent and wrapper type here, matrices use the default
+AbstractMatrix{T}(A::AdjOrTransAbsVec) where {T} = wrapperop(A)(AbstractVector{T}(A.parent))
+
 # sundry basic definitions
 parent(A::AdjOrTrans) = A.parent
 vec(v::TransposeAbsVec) = parent(v)

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -388,7 +388,7 @@ end
 # There is no fallback solver for Bunch-Kaufman so we'll have to promote to same element type
 function ldiv!(B::BunchKaufman{T}, R::StridedVecOrMat{S}) where {T,S}
     TS = promote_type(T,S)
-    return ldiv!(convert(BunchKaufman{TS}, B), copy_oftype(R, TS))
+    return ldiv!(convert(BunchKaufman{TS}, B), convert(AbstractArray{TS}, R))
 end
 
 function logabsdet(F::BunchKaufman)

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -388,7 +388,7 @@ end
 # There is no fallback solver for Bunch-Kaufman so we'll have to promote to same element type
 function ldiv!(B::BunchKaufman{T}, R::StridedVecOrMat{S}) where {T,S}
     TS = promote_type(T,S)
-    return ldiv!(convert(BunchKaufman{TS}, B), convert(AbstractArray{TS}, R))
+    return ldiv!(convert(BunchKaufman{TS}, B), copy_oftype(R, TS))
 end
 
 function logabsdet(F::BunchKaufman)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -178,14 +178,14 @@ end
 (*)(D::Diagonal, V::AbstractVector) = D.diag .* V
 
 (*)(A::AbstractTriangular, D::Diagonal) =
-    rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A), D)
+    rmul!(copy_oftype(A, promote_op(*, eltype(A), eltype(D.diag))), D)
 (*)(D::Diagonal, B::AbstractTriangular) =
-    lmul!(D, copyto!(similar(B, promote_op(*, eltype(B), eltype(D.diag))), B))
+    lmul!(D, copy_oftype(B, promote_op(*, eltype(B), eltype(D.diag))))
 
 (*)(A::AbstractMatrix, D::Diagonal) =
-    rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag)), size(A)), A), D)
+    rmul!(copy_similar(A, promote_op(*, eltype(A), eltype(D.diag))), D)
 (*)(D::Diagonal, A::AbstractMatrix) =
-    lmul!(D, copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag)), size(A)), A))
+    lmul!(D, copy_similar(A, promote_op(*, eltype(A), eltype(D.diag))))
 
 function rmul!(A::AbstractMatrix, D::Diagonal)
     require_one_based_indexing(A)
@@ -232,7 +232,7 @@ end
 
 *(D::Adjoint{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(adjoint.(D.parent.diag) .* B.diag)
 *(A::Adjoint{<:Any,<:AbstractTriangular}, D::Diagonal) =
-    rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A), D)
+    rmul!(copy_oftype(A, promote_op(*, eltype(A), eltype(D.diag))), D)
 function *(adjA::Adjoint{<:Any,<:AbstractMatrix}, D::Diagonal)
     A = adjA.parent
     Ac = similar(A, promote_op(*, eltype(A), eltype(D.diag)), (size(A, 2), size(A, 1)))
@@ -242,7 +242,7 @@ end
 
 *(D::Transpose{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(transpose.(D.parent.diag) .* B.diag)
 *(A::Transpose{<:Any,<:AbstractTriangular}, D::Diagonal) =
-    rmul!(copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A), D)
+    rmul!(copy_oftype(A, promote_op(*, eltype(A), eltype(D.diag))), D)
 function *(transA::Transpose{<:Any,<:AbstractMatrix}, D::Diagonal)
     A = transA.parent
     At = similar(A, promote_op(*, eltype(A), eltype(D.diag)), (size(A, 2), size(A, 1)))
@@ -252,7 +252,7 @@ end
 
 *(D::Diagonal, B::Adjoint{<:Any,<:Diagonal}) = Diagonal(D.diag .* adjoint.(B.parent.diag))
 *(D::Diagonal, B::Adjoint{<:Any,<:AbstractTriangular}) =
-    lmul!(D, copyto!(similar(B, promote_op(*, eltype(B), eltype(D.diag))), B))
+    lmul!(D, copy_oftype(B, promote_op(*, eltype(B), eltype(D.diag))))
 *(D::Diagonal, adjQ::Adjoint{<:Any,<:Union{QRCompactWYQ,QRPackedQ}}) = (Q = adjQ.parent; rmul!(Array(D), adjoint(Q)))
 function *(D::Diagonal, adjA::Adjoint{<:Any,<:AbstractMatrix})
     A = adjA.parent
@@ -263,7 +263,7 @@ end
 
 *(D::Diagonal, B::Transpose{<:Any,<:Diagonal}) = Diagonal(D.diag .* transpose.(B.parent.diag))
 *(D::Diagonal, B::Transpose{<:Any,<:AbstractTriangular}) =
-    lmul!(D, copyto!(similar(B, promote_op(*, eltype(B), eltype(D.diag))), B))
+    lmul!(D, copy_oftype(B, promote_op(*, eltype(B), eltype(D.diag))))
 function *(D::Diagonal, transA::Transpose{<:Any,<:AbstractMatrix})
     A = transA.parent
     At = similar(A, promote_op(*, eltype(A), eltype(D.diag)), (size(A, 2), size(A, 1)))

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -96,32 +96,28 @@ end
 function \(F::Factorization, B::AbstractVecOrMat)
     require_one_based_indexing(B)
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
-    BB = similar(B, TFB, size(B))
-    copyto!(BB, B)
+    BB = copy_similar(B, TFB)
     ldiv!(F, BB)
 end
 function \(adjF::Adjoint{<:Any,<:Factorization}, B::AbstractVecOrMat)
     require_one_based_indexing(B)
     F = adjF.parent
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
-    BB = similar(B, TFB, size(B))
-    copyto!(BB, B)
+    BB = copy_similar(B, TFB)
     ldiv!(adjoint(F), BB)
 end
 
 function /(B::AbstractMatrix, F::Factorization)
     require_one_based_indexing(B)
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
-    BB = similar(B, TFB, size(B))
-    copyto!(BB, B)
+    BB = copy_similar(B, TFB)
     rdiv!(BB, F)
 end
 function /(B::AbstractMatrix, adjF::Adjoint{<:Any,<:Factorization})
     require_one_based_indexing(B)
     F = adjF.parent
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
-    BB = similar(B, TFB, size(B))
-    copyto!(BB, B)
+    BB = copy_similar(B, TFB)
     rdiv!(BB, adjoint(F))
 end
 /(adjB::AdjointAbsVec, adjF::Adjoint{<:Any,<:Factorization}) = adjoint(adjF.parent \ adjB.parent)

--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -8,7 +8,7 @@ transpose(R::AbstractRotation) = error("transpose not implemented for $(typeof(R
 
 function (*)(R::AbstractRotation{T}, A::AbstractVecOrMat{S}) where {T,S}
     TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
-    lmul!(convert(AbstractRotation{TS}, R), TS == S ? copy(A) : convert(AbstractArray{TS}, A))
+    lmul!(convert(AbstractRotation{TS}, R), copy_oftype(A, TS))
 end
 (*)(A::AbstractVector, adjR::Adjoint{<:Any,<:AbstractRotation}) = _absvecormat_mul_adjrot(A, adjR)
 (*)(A::AbstractMatrix, adjR::Adjoint{<:Any,<:AbstractRotation}) = _absvecormat_mul_adjrot(A, adjR)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -60,6 +60,8 @@ parent(H::UpperHessenberg) = H.data
 similar(H::UpperHessenberg, ::Type{T}) where {T} = UpperHessenberg(similar(H.data, T))
 similar(H::UpperHessenberg, ::Type{T}, dims::Dims{N}) where {T,N} = similar(H.data, T, dims)
 
+AbstractMatrix{T}(H::UpperHessenberg) where {T} = UpperHessenberg(AbstractMatrix{T}(H.data))
+
 copy(H::UpperHessenberg) = UpperHessenberg(copy(H.data))
 real(H::UpperHessenberg{<:Real}) = H
 real(H::UpperHessenberg{<:Complex}) = UpperHessenberg(triu!(real(H.data),-1))

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -432,11 +432,12 @@ end
 (/)(adjA::Adjoint{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU}) = adjoint(F.parent \ adjA.parent)
 function (/)(trA::Transpose{<:Any,<:AbstractVector}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, convert(AbstractVector{T}, conj(trA.parent))))
+    # Make a copy here to avoid overwriting trA.parent if it is real, #35071
+    return adjoint(ldiv!(F.parent, copy_oftype(conj(trA.parent), T)))
 end
 function (/)(trA::Transpose{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, convert(AbstractMatrix{T}, conj(trA.parent))))
+    return adjoint(ldiv!(F.parent, copy_oftype(conj(trA.parent), T)))
 end
 
 function det(F::LU{T}) where T

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -378,8 +378,7 @@ true
 """
 function qr(A::AbstractMatrix{T}, arg...; kwargs...) where T
     require_one_based_indexing(A)
-    AA = similar(A, _qreltype(T), size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, _qreltype(T))
     return qr!(AA, arg...; kwargs...)
 end
 qr(x::Number) = qr(fill(x,1,1))
@@ -720,8 +719,7 @@ function *(A::StridedMatrix, adjB::Adjoint{<:Any,<:AbstractQ})
     TAB = promote_type(eltype(A),eltype(B))
     BB = convert(AbstractMatrix{TAB}, B)
     if size(A,2) == size(B.factors, 1)
-        AA = similar(A, TAB, size(A))
-        copyto!(AA, A)
+        AA = copy_similar(A, TAB)
         return rmul!(AA, adjoint(BB))
     elseif size(A,2) == size(B.factors,2)
         return rmul!([A zeros(TAB, size(A, 1), size(B.factors, 1) - size(B.factors, 2))], adjoint(BB))

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -674,7 +674,7 @@ eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Func
 function eigen(A::RealHermSymComplexHerm; sortby::Union{Function,Nothing}=nothing)
     T = eltype(A)
     S = eigtype(T)
-    eigen!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), sortby=sortby)
+    eigen!(copy_oftype(A, S), sortby=sortby)
 end
 
 eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, irange::UnitRange) = Eigen(LAPACK.syevr!('V', 'I', A.uplo, A.data, 0.0, 0.0, irange.start, irange.stop, -1.0)...)
@@ -699,7 +699,7 @@ The [`UnitRange`](@ref) `irange` specifies indices of the sorted eigenvalues to 
 function eigen(A::RealHermSymComplexHerm, irange::UnitRange)
     T = eltype(A)
     S = eigtype(T)
-    eigen!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), irange)
+    eigen!(copy_oftype(A, S), irange)
 end
 
 eigen!(A::RealHermSymComplexHerm{T,<:StridedMatrix}, vl::Real, vh::Real) where {T<:BlasReal} =
@@ -725,7 +725,7 @@ The following functions are available for `Eigen` objects: [`inv`](@ref), [`det`
 function eigen(A::RealHermSymComplexHerm, vl::Real, vh::Real)
     T = eltype(A)
     S = eigtype(T)
-    eigen!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), vl, vh)
+    eigen!(copy_oftype(A, S), vl, vh)
 end
 
 eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}) =
@@ -734,7 +734,7 @@ eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}) =
 function eigvals(A::RealHermSymComplexHerm)
     T = eltype(A)
     S = eigtype(T)
-    eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A))
+    eigvals!(copy_oftype(A, S))
 end
 
 """
@@ -775,7 +775,7 @@ julia> eigvals(A)
 function eigvals(A::RealHermSymComplexHerm, irange::UnitRange)
     T = eltype(A)
     S = eigtype(T)
-    eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), irange)
+    eigvals!(copy_oftype(A, S), irange)
 end
 
 """
@@ -815,7 +815,7 @@ julia> eigvals(A)
 function eigvals(A::RealHermSymComplexHerm, vl::Real, vh::Real)
     T = eltype(A)
     S = eigtype(T)
-    eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), vl, vh)
+    eigvals!(copy_oftype(A, S), vl, vh)
 end
 
 eigmax(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix}) = eigvals(A, size(A, 1):size(A, 1))[1]

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1809,32 +1809,28 @@ for (f, f2!) in ((:*, :lmul!), (:\, :ldiv!))
         function ($f)(A::LowerTriangular, B::LowerTriangular)
             TAB = typeof(($f)(zero(eltype(A)), zero(eltype(B))) +
                          ($f)(zero(eltype(A)), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             return LowerTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
         end
 
         function $(f)(A::UnitLowerTriangular, B::LowerTriangular)
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+             BB = copy_similar(B, TAB)
             return LowerTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
         end
 
         function ($f)(A::UpperTriangular, B::UpperTriangular)
             TAB = typeof(($f)(zero(eltype(A)), zero(eltype(B))) +
                          ($f)(zero(eltype(A)), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             return UpperTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
         end
 
         function ($f)(A::UnitUpperTriangular, B::UpperTriangular)
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             return UpperTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
         end
     end
@@ -1850,8 +1846,7 @@ for (ipop, op, xformtype, xformop) in (
             A = xformA.parent
             TAB = typeof(($op)($xformop(zero(eltype(A))), zero(eltype(B))) +
                          ($op)($xformop(zero(eltype(A))), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             return LowerTriangular(($ipop)($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
 
@@ -1859,8 +1854,7 @@ for (ipop, op, xformtype, xformop) in (
             A = xformA.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             return LowerTriangular($ipop($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
 
@@ -1868,8 +1862,7 @@ for (ipop, op, xformtype, xformop) in (
             A = xformA.parent
             TAB = typeof(($op)($xformop(zero(eltype(A))), zero(eltype(B))) +
                          ($op)($xformop(zero(eltype(A))), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             return UpperTriangular($ipop($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
 
@@ -1877,8 +1870,7 @@ for (ipop, op, xformtype, xformop) in (
             A = xformA.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             return UpperTriangular($ipop($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
     end
@@ -1887,29 +1879,25 @@ end
 function (/)(A::LowerTriangular, B::LowerTriangular)
     TAB = typeof((/)(zero(eltype(A)), zero(eltype(B))) +
                  (/)(zero(eltype(A)), zero(eltype(B))))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     return LowerTriangular(rdiv!(AA, convert(AbstractMatrix{TAB}, B)))
 end
 function (/)(A::LowerTriangular, B::UnitLowerTriangular)
     TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                  (*)(zero(eltype(A)), zero(eltype(B))))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     return LowerTriangular(rdiv!(AA, convert(AbstractMatrix{TAB}, B)))
 end
 function (/)(A::UpperTriangular, B::UpperTriangular)
     TAB = typeof((/)(zero(eltype(A)), zero(eltype(B))) +
                  (/)(zero(eltype(A)), zero(eltype(B))))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     return UpperTriangular(rdiv!(AA, convert(AbstractMatrix{TAB}, B)))
 end
 function (/)(A::UpperTriangular, B::UnitUpperTriangular)
     TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                  (*)(zero(eltype(A)), zero(eltype(B))))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     return UpperTriangular(rdiv!(AA, convert(AbstractMatrix{TAB}, B)))
 end
 
@@ -1923,8 +1911,7 @@ for (ipop, op, xformtype, xformop) in (
             B = xformB.parent
             TAB = typeof(($op)(zero(eltype(A)), $xformop(zero(eltype(B)))) +
                          ($op)(zero(eltype(A)), $xformop(zero(eltype(B)))))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             return LowerTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
 
@@ -1932,8 +1919,7 @@ for (ipop, op, xformtype, xformop) in (
             B = xformB.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             return LowerTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
 
@@ -1941,8 +1927,7 @@ for (ipop, op, xformtype, xformop) in (
             B = xformB.parent
             TAB = typeof(($op)(zero(eltype(A)), $xformop(zero(eltype(B)))) +
                          ($op)(zero(eltype(A)), $xformop(zero(eltype(B)))))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             return UpperTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
 
@@ -1950,8 +1935,7 @@ for (ipop, op, xformtype, xformop) in (
             B = xformB.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             return UpperTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
     end
@@ -1960,37 +1944,32 @@ end
 ## The general promotion methods
 function *(A::AbstractTriangular, B::AbstractTriangular)
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    BB = similar(B, TAB, size(B))
-    copyto!(BB, B)
+    BB = copy_similar(B, TAB)
     lmul!(convert(AbstractArray{TAB}, A), BB)
 end
 function *(adjA::Adjoint{<:Any,<:AbstractTriangular}, B::AbstractTriangular)
     A = adjA.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    BB = similar(B, TAB, size(B))
-    copyto!(BB, B)
+    BB = copy_similar(B, TAB)
     lmul!(adjoint(convert(AbstractArray{TAB}, A)), BB)
 end
 function *(transA::Transpose{<:Any,<:AbstractTriangular}, B::AbstractTriangular)
     A = transA.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    BB = similar(B, TAB, size(B))
-    copyto!(BB, B)
+    BB = copy_similar(B, TAB)
     lmul!(transpose(convert(AbstractArray{TAB}, A)), BB)
 end
 
 function *(A::AbstractTriangular, adjB::Adjoint{<:Any,<:AbstractTriangular})
     B = adjB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     rmul!(AA, adjoint(convert(AbstractArray{TAB}, B)))
 end
 function *(A::AbstractTriangular, transB::Transpose{<:Any,<:AbstractTriangular})
     B = transB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     rmul!(AA, transpose(convert(AbstractArray{TAB}, B)))
 end
 
@@ -2000,24 +1979,21 @@ for mat in (:AbstractVector, :AbstractMatrix)
         function *(A::AbstractTriangular, B::$mat)
             require_one_based_indexing(B)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             lmul!(convert(AbstractArray{TAB}, A), BB)
         end
         function *(adjA::Adjoint{<:Any,<:AbstractTriangular}, B::$mat)
             require_one_based_indexing(B)
             A = adjA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             lmul!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function *(transA::Transpose{<:Any,<:AbstractTriangular}, B::$mat)
             require_one_based_indexing(B)
             A = transA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             lmul!(transpose(convert(AbstractArray{TAB}, A)), BB)
         end
     end
@@ -2026,24 +2002,21 @@ for mat in (:AbstractVector, :AbstractMatrix)
         function \(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
             require_one_based_indexing(B)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             ldiv!(convert(AbstractArray{TAB}, A), BB)
         end
         function \(adjA::Adjoint{<:Any,<:Union{UnitUpperTriangular,UnitLowerTriangular}}, B::$mat)
             require_one_based_indexing(B)
             A = adjA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             ldiv!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function \(transA::Transpose{<:Any,<:Union{UnitUpperTriangular,UnitLowerTriangular}}, B::$mat)
             require_one_based_indexing(B)
             A = transA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             ldiv!(transpose(convert(AbstractArray{TAB}, A)), BB)
         end
     end
@@ -2052,24 +2025,21 @@ for mat in (:AbstractVector, :AbstractMatrix)
         function \(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
             require_one_based_indexing(B)
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             ldiv!(convert(AbstractArray{TAB}, A), BB)
         end
         function \(adjA::Adjoint{<:Any,<:Union{UpperTriangular,LowerTriangular}}, B::$mat)
             require_one_based_indexing(B)
             A = adjA.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             ldiv!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function \(transA::Transpose{<:Any,<:Union{UpperTriangular,LowerTriangular}}, B::$mat)
             require_one_based_indexing(B)
             A = transA.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
-            BB = similar(B, TAB, size(B))
-            copyto!(BB, B)
+            BB = copy_similar(B, TAB)
             ldiv!(transpose(convert(AbstractArray{TAB}, A)), BB)
         end
     end
@@ -2078,24 +2048,21 @@ for mat in (:AbstractVector, :AbstractMatrix)
         function /(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
             require_one_based_indexing(A)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             rdiv!(AA, convert(AbstractArray{TAB}, B))
         end
         function /(A::$mat, adjB::Adjoint{<:Any,<:Union{UnitUpperTriangular, UnitLowerTriangular}})
             require_one_based_indexing(A)
             B = adjB.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             rdiv!(AA, adjoint(convert(AbstractArray{TAB}, B)))
         end
         function /(A::$mat, transB::Transpose{<:Any,<:Union{UnitUpperTriangular, UnitLowerTriangular}})
             require_one_based_indexing(A)
             B = transB.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             rdiv!(AA, transpose(convert(AbstractArray{TAB}, B)))
         end
     end
@@ -2104,24 +2071,21 @@ for mat in (:AbstractVector, :AbstractMatrix)
         function /(A::$mat, B::Union{UpperTriangular,LowerTriangular})
             require_one_based_indexing(A)
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             rdiv!(AA, convert(AbstractArray{TAB}, B))
         end
         function /(A::$mat, adjB::Adjoint{<:Any,<:Union{UpperTriangular,LowerTriangular}})
             require_one_based_indexing(A)
             B = adjB.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             rdiv!(AA, adjoint(convert(AbstractArray{TAB}, B)))
         end
         function /(A::$mat, transB::Transpose{<:Any,<:Union{UpperTriangular,LowerTriangular}})
             require_one_based_indexing(A)
             B = transB.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
-            AA = similar(A, TAB, size(A))
-            copyto!(AA, A)
+            AA = copy_similar(A, TAB)
             rdiv!(AA, transpose(convert(AbstractArray{TAB}, B)))
         end
     end
@@ -2131,24 +2095,21 @@ end
 function *(A::AbstractMatrix, B::AbstractTriangular)
     require_one_based_indexing(A)
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     rmul!(AA, convert(AbstractArray{TAB}, B))
 end
 function *(A::AbstractMatrix, adjB::Adjoint{<:Any,<:AbstractTriangular})
     require_one_based_indexing(A)
     B = adjB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     rmul!(AA, adjoint(convert(AbstractArray{TAB}, B)))
 end
 function *(A::AbstractMatrix, transB::Transpose{<:Any,<:AbstractTriangular})
     require_one_based_indexing(A)
     B = transB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
-    AA = similar(A, TAB, size(A))
-    copyto!(AA, A)
+    AA = copy_similar(A, TAB)
     rmul!(AA, transpose(convert(AbstractArray{TAB}, B)))
 end
 # ambiguity resolution with definitions in linalg/rowvector.jl

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -31,6 +31,8 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
             Anew = convert(AbstractMatrix{T}, A.data)
             $t(Anew)
         end
+        AbstractMatrix{T}(A::$t) where {T} = $t{T}(A)
+
         Matrix(A::$t{T}) where {T} = Matrix{T}(A)
 
         size(A::$t, d) = size(A.data, d)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -159,6 +159,8 @@ similar(S::SymTridiagonal, ::Type{T}) where {T} = SymTridiagonal(similar(S.dv, T
 # The method below is moved to SparseArrays for now
 # similar(S::SymTridiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
 
+copyto!(dest::SymTridiagonal, src::SymTridiagonal) = (copyto!(dest.dv, src.dv); copyto!(dest.ev, src.ev); dest)
+
 #Elementary operations
 for func in (:conj, :copy, :real, :imag)
     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -239,9 +239,12 @@ end
     @test convert(Transpose{Float64,Matrix{Float64}}, Transpose(intmat))::Transpose{Float64,Matrix{Float64}} == Transpose(intmat)
 end
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
+using .Main.ImmutableArrays
+
 @testset "Adjoint and Transpose convert methods to AbstractArray" begin
     # tests corresponding to #34995
-    using LinearAlgebra: ImmutableArray
     intvec, intmat = [1, 2], [1 2 3; 4 5 6]
     statvec = ImmutableArray(intvec)
     statmat = ImmutableArray(intmat)

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -239,6 +239,23 @@ end
     @test convert(Transpose{Float64,Matrix{Float64}}, Transpose(intmat))::Transpose{Float64,Matrix{Float64}} == Transpose(intmat)
 end
 
+@testset "Adjoint and Transpose convert methods to AbstractArray" begin
+    # tests corresponding to #34995
+    using LinearAlgebra: ImmutableArray
+    intvec, intmat = [1, 2], [1 2 3; 4 5 6]
+    statvec = ImmutableArray(intvec)
+    statmat = ImmutableArray(intmat)
+
+    @test convert(AbstractArray{Float64}, Adjoint(statvec))::Adjoint{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Adjoint(statvec)
+    @test convert(AbstractArray{Float64}, Adjoint(statmat))::Array{Float64,2} == Adjoint(statmat)
+    @test convert(AbstractArray{Float64}, Transpose(statvec))::Transpose{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Transpose(statvec)
+    @test convert(AbstractArray{Float64}, Transpose(statmat))::Array{Float64,2} == Transpose(statmat)
+    @test convert(AbstractMatrix{Float64}, Adjoint(statvec))::Adjoint{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Adjoint(statvec)
+    @test convert(AbstractMatrix{Float64}, Adjoint(statmat))::Array{Float64,2} == Adjoint(statmat)
+    @test convert(AbstractMatrix{Float64}, Transpose(statvec))::Transpose{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Transpose(statvec)
+    @test convert(AbstractMatrix{Float64}, Transpose(statmat))::Array{Float64,2} == Transpose(statmat)
+end
+
 @testset "Adjoint and Transpose similar methods" begin
     intvec, intmat = [1, 2], [1 2 3; 4 5 6]
     # similar with no additional specifications, vector (rewrapping) semantics

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -588,9 +588,12 @@ Base.transpose(n::MyNotANumberType) = n
     @test transpose(copy(tB)) == B
 end
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
+using .Main.ImmutableArrays
+
 @testset "Conversion to AbstractArray" begin
     # tests corresponding to #34995
-    using LinearAlgebra: ImmutableArray
     dv = ImmutableArray([1, 2, 3, 4])
     ev = ImmutableArray([7, 8, 9])
     Bu = Bidiagonal(dv, ev, :U)

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -588,4 +588,18 @@ Base.transpose(n::MyNotANumberType) = n
     @test transpose(copy(tB)) == B
 end
 
+@testset "Conversion to AbstractArray" begin
+    # tests corresponding to #34995
+    using LinearAlgebra: ImmutableArray
+    dv = ImmutableArray([1, 2, 3, 4])
+    ev = ImmutableArray([7, 8, 9])
+    Bu = Bidiagonal(dv, ev, :U)
+    Bl = Bidiagonal(dv, ev, :L)
+
+    @test convert(AbstractArray{Float64}, Bu)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bu
+    @test convert(AbstractMatrix{Float64}, Bu)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bu
+    @test convert(AbstractArray{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
+    @test convert(AbstractMatrix{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
+end
+
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -717,4 +717,14 @@ end
     @test dot(zeros(Int32, 0), Diagonal(zeros(Int, 0)), zeros(Int16, 0)) === 0
 end
 
+@testset "Conversion to AbstractArray" begin
+    # tests corresponding to #34995
+    using LinearAlgebra: ImmutableArray
+    d = ImmutableArray([1, 2, 3, 4])
+    D = Diagonal(d)
+
+    @test convert(AbstractArray{Float64}, D)::Diagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == D
+    @test convert(AbstractMatrix{Float64}, D)::Diagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == D
+end
+
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -717,9 +717,12 @@ end
     @test dot(zeros(Int32, 0), Diagonal(zeros(Int, 0)), zeros(Int16, 0)) === 0
 end
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
+using .Main.ImmutableArrays
+
 @testset "Conversion to AbstractArray" begin
     # tests corresponding to #34995
-    using LinearAlgebra: ImmutableArray
     d = ImmutableArray([1, 2, 3, 4])
     D = Diagonal(d)
 

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -133,9 +133,12 @@ end
     @test Base.propertynames(F, true) == (:Q, :H, :μ, :τ, :factors, :uplo)
 end
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
+using .Main.ImmutableArrays
+
 @testset "Conversion to AbstractArray" begin
     # tests corresponding to #34995
-    using LinearAlgebra: ImmutableArray
     A = ImmutableArray([1 2 3; 4 5 6; 7 8 9])
     H = UpperHessenberg(A)
 

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -133,4 +133,14 @@ end
     @test Base.propertynames(F, true) == (:Q, :H, :μ, :τ, :factors, :uplo)
 end
 
+@testset "Conversion to AbstractArray" begin
+    # tests corresponding to #34995
+    using LinearAlgebra: ImmutableArray
+    A = ImmutableArray([1 2 3; 4 5 6; 7 8 9])
+    H = UpperHessenberg(A)
+
+    @test convert(AbstractArray{Float64}, H)::UpperHessenberg{Float64,ImmutableArray{Float64,2,Array{Float64,2}}} == H
+    @test convert(AbstractMatrix{Float64}, H)::UpperHessenberg{Float64,ImmutableArray{Float64,2,Array{Float64,2}}} == H
+end
+
 end # module TestHessenberg

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -340,6 +340,17 @@ end
     A = complex.(randn(2, 2), randn(2, 2))
     @test (A' / F') * B ≈ A'
     @test (transpose(A) / F') * B ≈ transpose(A)
+
+    # Issue #35071, check that the input is not overwritten for real input vector
+    at = transpose(randn(2))
+    atcopy = copy(at)
+    @test (at / F') * B ≈ at
+    @test at == atcopy
+
+    At = transpose(randn(2, 2))
+    Atcopy = copy(At)
+    @test (At / F') * B ≈ At
+    @test At == Atcopy
 end
 
 @testset "0x0 matrix" begin

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -540,9 +540,12 @@ end
     end
 end
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
+using .Main.ImmutableArrays
+
 @testset "Conversion to AbstractArray" begin
     # tests corresponding to #34995
-    using LinearAlgebra: ImmutableArray
     immutablemat = ImmutableArray([1 2 3; 4 5 6; 7 8 9])
     for SymType in (Symmetric, Hermitian)
         S = Float64

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -540,6 +540,22 @@ end
     end
 end
 
+@testset "Conversion to AbstractArray" begin
+    # tests corresponding to #34995
+    using LinearAlgebra: ImmutableArray
+    immutablemat = ImmutableArray([1 2 3; 4 5 6; 7 8 9])
+    for SymType in (Symmetric, Hermitian)
+        S = Float64
+        symmat = SymType(immutablemat)
+        @test convert(AbstractArray{S}, symmat).data isa ImmutableArray{S}
+        @test convert(AbstractMatrix{S}, symmat).data isa ImmutableArray{S}
+        @test AbstractArray{S}(symmat).data isa ImmutableArray{S}
+        @test AbstractMatrix{S}(symmat).data isa ImmutableArray{S}
+        @test convert(AbstractArray{S}, symmat) == symmat
+        @test convert(AbstractMatrix{S}, symmat) == symmat
+    end
+end
+
 @testset "#24572: eltype(A::HermOrSym) === eltype(parent(A))" begin
     A = rand(Float32, 3, 3)
     @test_throws TypeError Symmetric{Float64,Matrix{Float32}}(A, 'U')

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -605,6 +605,23 @@ end
     end
 end
 
+@testset "AbstractArray constructor should preserve underlying storage type" begin
+    # tests corresponding to #34995
+    using LinearAlgebra: ImmutableArray
+    local m = 4
+    local T, S = Float32, Float64
+    immutablemat = ImmutableArray(randn(T,m,m))
+    for TriType in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
+        trimat = TriType(immutablemat)
+        @test convert(AbstractArray{S}, trimat).data isa ImmutableArray{S}
+        @test convert(AbstractMatrix{S}, trimat).data isa ImmutableArray{S}
+        @test AbstractArray{S}(trimat).data isa ImmutableArray{S}
+        @test AbstractMatrix{S}(trimat).data isa ImmutableArray{S}
+        @test convert(AbstractArray{S}, trimat) == trimat
+        @test convert(AbstractMatrix{S}, trimat) == trimat
+    end
+end
+
 @testset "special printing of Lower/UpperTriangular" begin
     @test occursin(r"3×3 (LinearAlgebra\.)?LowerTriangular{Int64,Array{Int64,2}}:\n 2  ⋅  ⋅\n 2  2  ⋅\n 2  2  2",
                    sprint(show, MIME"text/plain"(), LowerTriangular(2ones(Int64,3,3))))

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -605,9 +605,11 @@ end
     end
 end
 
+isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
+using .Main.ImmutableArrays
+
 @testset "AbstractArray constructor should preserve underlying storage type" begin
     # tests corresponding to #34995
-    using LinearAlgebra: ImmutableArray
     local m = 4
     local T, S = Float32, Float64
     immutablemat = ImmutableArray(randn(T,m,m))

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -185,10 +185,8 @@ end
         @testset "similar, size, and copyto!" begin
             B = similar(A)
             @test size(B) == size(A)
-            if mat_type == Tridiagonal # doesn't work for SymTridiagonal yet
-                copyto!(B, A)
-                @test B == A
-            end
+            copyto!(B, A)
+            @test B == A
             @test isa(similar(A), mat_type{elty})
             @test isa(similar(A, Int), mat_type{Int})
             @test isa(similar(A, (3, 2)), SparseMatrixCSC)
@@ -553,6 +551,21 @@ end
 
     @test diag(T + 2I) == zero(d)
     @test diag(S + 2I) == zero(d)
+end
+
+@testset "Conversion to AbstractArray" begin
+    # tests corresponding to #34995
+    using LinearAlgebra: ImmutableArray
+    v1 = ImmutableArray([1, 2])
+    v2 = ImmutableArray([3, 4, 5])
+    v3 = ImmutableArray([6, 7])
+    T = Tridiagonal(v1, v2, v3)
+    Tsym = SymTridiagonal(v2, v1)
+
+    @test convert(AbstractArray{Float64}, T)::Tridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == T
+    @test convert(AbstractMatrix{Float64}, T)::Tridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == T
+    @test convert(AbstractArray{Float64}, Tsym)::SymTridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Tsym
+    @test convert(AbstractMatrix{Float64}, Tsym)::SymTridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Tsym
 end
 
 end # module TestTridiagonal

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -553,9 +553,12 @@ end
     @test diag(S + 2I) == zero(d)
 end
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
+using .Main.ImmutableArrays
+
 @testset "Conversion to AbstractArray" begin
     # tests corresponding to #34995
-    using LinearAlgebra: ImmutableArray
     v1 = ImmutableArray([1, 2])
     v2 = ImmutableArray([3, 4, 5])
     v3 = ImmutableArray([6, 7])

--- a/test/testhelpers/ImmutableArrays.jl
+++ b/test/testhelpers/ImmutableArrays.jl
@@ -1,0 +1,28 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# ImmutableArrays (arrays that implement getindex but not setindex!)
+
+# This test file defines an array wrapper that is immutable. It can be used to
+# test the action of methods on immutable arrays.
+
+module ImmutableArrays
+
+export ImmutableArray
+
+"An immutable wrapper type for arrays."
+struct ImmutableArray{T,N,A<:AbstractArray} <: AbstractArray{T,N}
+    data::A
+end
+
+ImmutableArray(data::AbstractArray{T,N}) where {T,N} = ImmutableArray{T,N,typeof(data)}(data)
+
+# Minimal AbstractArray interface
+Base.size(A::ImmutableArray) = size(A.data)
+Base.size(A::ImmutableArray, d) = size(A.data, d)
+Base.getindex(A::ImmutableArray, i...) = getindex(A.data, i...)
+
+# The immutable array remains immutable after conversion to AbstractArray
+AbstractArray{T}(A::ImmutableArray) where {T} = ImmutableArray(AbstractArray{T}(A.data))
+AbstractArray{T,N}(A::ImmutableArray{S,N}) where {S,T,N} = ImmutableArray(AbstractArray{T,N}(A.data))
+
+end


### PR DESCRIPTION
This pull request redefines the `copy_oftype` function in LinearAlgebra and it implements `convert(AbstractArray{T}, A)` differently for a small number of structured arrays. The motivation for this pull request has been described in JuliaLang/julia#34995. It also fixes JuliaLang/LinearAlgebra.jl#701.

The request is split into two commits.

The first commit has the following two major changes:
- ` copy_oftype(A, T)` is now implemented in terms of either `copy(A)` or `copyto!(similar(A, T), A)`. _It was already like that implicitly_. The function used to invoke `convert(AbstractArray{T}, A)`, which in turn called `AbstractArray{T}(A)`, which in most cases would call `copyto!(similar(A, T), A)`. The change makes the fallback explicit.
- `AbstractMatrix{T}(A)` is now implemented for all structured matrices in LinearAlgebra by invoking the `AbstractVector{T}` or `AbstractMatrix{T}` constructor on its underlying data. This was already the case for several arrays. After the first change, `AbstractMatrix{T}(A)` is no longer assumed to return something mutable.

It is difficult to illustrate with an example in Base, because the change is helpful for immutable arrays that support conversion to a different eltype. With the latest version of StaticArrays we have:
```julia
julia> using LinearAlgebra, StaticArrays

julia> convert(AbstractMatrix{Float64}, SA[1 2; 0 3])
2×2 SArray{Tuple{2,2},Float64,2,4} with indices SOneTo(2)×SOneTo(2):
 1.0  2.0
 0.0  3.0

julia> tri = UpperTriangular(SA[1 2; 0 3]);

julia> convert(AbstractMatrix{Float64}, tri)
2×2 UpperTriangular{Float64,SArray{Tuple{2,2},Float64,2,4}}:
 1.0  2.0
  ⋅   3.0
```
The point is that an immutable static matrix remains immutable after conversion to `AbstractMatrix{T}` (this is implemented in StaticArrays itself), and that the upper triangular matrix also remains immutable after conversion to `AbstractMatrix{T}` (this is implemented in the pull request). Previously, the conversion of the triangular matrix would surprisingly yield a mutable and less efficient `MArray` as the underlying data.

Design choices:
- I think it makes sense that `copyto!(similar(A, T), A)` should always work. This was not the case for the `SymTridiagonal` type (due to another issue which I'll come back to), so I've added a definition.
- `AbstractMatrix{T}(A)` mimicks what `similar(A, T)` does: it will preserve structure if `similar` preserves structure, and vice-versa. Thus, its application to a transposed vector is recursive, but its application to a transposed matrix is not.
- Should `AbstractMatrix{T}(A)` make a copy of `A` or not? It is clear that `convert(AbstractArray{T}, A)` is not expected to make a copy. The recursive implementation of `AbstractMatrix{T}(A)` in this pull request invokes the constructor on the underlying data, not the conversion, so the decision lies with the underlying data array and this pull request remains agnostic. I don't think the behaviour is uniform, but perhaps that is not such a big problem.

The second commit makes some more aggressive changes elsewhere in LinearAlgebra. It defines the new function `copy_similar` right after `copy_oftype`:
```julia
copy_similar(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = copyto!(similar(A, S, size(A)), A)
```
Typically, the three-argument call to similar discards the structure of `A`. The third argument is `size(A)` and it is subtly absent in the definition of `copy_oftype`. The result of `copy_similar` is used in many places to create a writable matrix without the structure of `A` which is suitable for an in-place algorithm. I've looked for this use-case and replaced all occurrences with a call to `copy_similar`. This hopefully improves the clarity of this subtle difference in the code, and also shortens some files (most changes are in triangular.jl). It is otherwise independent from the first commit.

On my machine the entire test suite passes with these changes, that is, it does not seem to affect any of the existing tests. I have yet to add tests for the specific things I've changed.

The code is actually shorter than all my explanations here and in JuliaLang/julia#34995 :-)
Do these changes look acceptable?