### PR TITLE
Show full stacktrace when Channel Task throws

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -228,15 +228,16 @@ false
 ```jldoctest
 julia> c = Channel(0);
 
-julia> task = @async (put!(c,1);error("foo"));
+julia> task = @async (put!(c, 1); error("foo"));
 
-julia> bind(c,task);
+julia> bind(c, task);
 
 julia> take!(c)
 1
 
-julia> put!(c,1);
-ERROR: foo
+julia> put!(c, 1);
+ERROR: TaskFailedException:
+foo
 Stacktrace:
 [...]
 ```

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -281,7 +281,7 @@ function close_chnl_on_taskdone(t::Task, c::Channel)
         if istaskfailed(t)
             excp = task_result(t)
             if excp isa Exception
-                close(c, excp)
+                close(c, TaskFailedException(t))
                 return
             end
         end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1298,7 +1298,7 @@ cd(dirwalk) do
     @test files == ["file1", "file2"]
 
     rm(joinpath("sub_dir1"), recursive=true)
-    @test_throws SystemError take!(chnl_error) # throws an error because sub_dir1 do not exist
+    @test_throws TaskFailedException take!(chnl_error) # throws an error because sub_dir1 do not exist
 
     root, dirs, files = take!(chnl_noerror)
     @test root == "."

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -138,7 +138,7 @@ f265(::Int) = 1
 h265() = true
 loc_h265 = "$(@__FILE__):$(@__LINE__() - 1)"
 @test h265()
-@test_throws MethodError put_n_take!(h265, ())
+@test_throws TaskFailedException(t265) put_n_take!(h265, ())
 @test_throws TaskFailedException(t265) fetch(t265)
 @test istaskdone(t265)
 let ex = t265.exception


### PR DESCRIPTION
Not sure if this counts as a feature or a bug-fix. This was a major
pain-point for a user on gitter which seemed an easy fix once I
understood the system.

This reuses the machinery that gives good stacktraces when a user
calls `wait` on a `Task`. Since `bind` internally uses `_wait2`, this
machinery is bypassed currently.

Currently, julia throws an uninformative stacktrace in this situation:

```julia
julia> c = Channel(_ -> error("foo"))
Channel{Any}(sz_max:0,sz_curr:0)

julia> for i in c end
ERROR: foo
Stacktrace:
 [1] iterate(::Channel{Any}) at ./channels.jl:459
 [2] top-level scope at ./REPL[2]:1
```

With this change, the stacktrace is much more informative:

```julia
julia> for i in c end
ERROR: TaskFailedException:
foo
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] (::var"#1#2")(::Channel{Any}) at ./REPL[4]:1
 [3] (::Base.var"#652#653"{var"#1#2",Channel{Any}})() at ./channels.jl:129
Stacktrace:
 [1] check_channel_state at ./channels.jl:167 [inlined]
 [2] take_unbuffered(::Channel{Any}) at ./channels.jl:405
 [3] take! at ./channels.jl:383 [inlined]
 [4] iterate(::Channel{Any}, ::Nothing) at ./channels.jl:449
 [5] iterate(::Channel{Any}) at ./channels.jl:448
 [6] top-level scope at ./REPL[5]:1
```