### PR TITLE
Linux: Remove `--nodetach` option for `xsel` copy.

### DIFF
--- a/stdlib/InteractiveUtils/src/clipboard.jl
+++ b/stdlib/InteractiveUtils/src/clipboard.jl
@@ -34,7 +34,7 @@ elseif Sys.islinux() || Sys.KERNEL === :FreeBSD
     _clipboardcmd = nothing
     const _clipboard_copy = Dict(
             :xsel  => Sys.islinux() ?
-                `xsel --nodetach --input --clipboard` :
+                `xsel --input --clipboard` :
                 `xsel -c`,
             :xclip => `xclip -silent -in -selection clipboard`,
         )


### PR DESCRIPTION
The `--nodetach` option causes `clipboard(x)` to hang indefinitely on (all which I have tried) linux systems. Removing this option fixes `clipboard(x)`, but briefly spawns a child process. Since `clipboard(x)` is designed for interactive use, this shouldn't be an issue.

This addresses issue #14510.