### PR TITLE
add compat annotation for map!(f, values(dict)) (from #31223)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -340,6 +340,7 @@ New library functions
 * Added `Base.hasproperty` and `Base.hasfield` ([#28850]).
 * One argument `!=(x)`, `>(x)`, `>=(x)`, `<(x)`, `<=(x)` have been added, returning partially-applied
   versions of the functions, similar to the existing `==(x)` and `isequal(x)` methods ([#30915]).
+* The new `map!(f, values(::AbstractDict))` method allows to modify in-place values of a dictionary ([#31223]).
 
 Standard library changes
 ------------------------

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -560,6 +560,9 @@ Modifies `dict` by transforming each value from `val` to `f(val)`.
 Note that the type of `dict` cannot be changed: if `f(val)` is not an instance of the value type
 of `dict` then it will be converted to the value type if possible and otherwise raise an error.
 
+!!! compat "Julia 1.2"
+    `map!(f, values(dict::AbstractDict))` requires Julia 1.2 or later.
+
 # Examples
 ```jldoctest
 julia> d = Dict(:a => 1, :b => 2)


### PR DESCRIPTION
This also didn't get a NEWS.md item, but this was for Julia 1.2... shall we add news now?