### PR TITLE
add informative error message for `map!(f, array)`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2157,7 +2157,11 @@ julia> a
  6.0
 ```
 """
-map!(f::F, dest::AbstractArray, As::AbstractArray...) where {F} = map_n!(f, dest, As)
+function map!(f::F, dest::AbstractArray, As::AbstractArray...) where {F}
+    isempty(As) && throw(ArgumentError(
+        """map! requires at least one "source" argument"""))
+    map_n!(f, dest, As)
+end
 
 map(f) = f()
 map(f, iters...) = collect(Generator(f, iters...))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -755,6 +755,7 @@ test_ind2sub(TestAbstractArray)
 
 include("generic_map_tests.jl")
 generic_map_tests(map, map!)
+@test_throws ArgumentError map!(-, [1])
 
 test_UInt_indexing(TestAbstractArray)
 test_13315(TestAbstractArray)


### PR DESCRIPTION
For example:
```julia
julia>  map!(-, [1]) # master
ERROR: BoundsError: attempt to access ()
  at index [1]
Stacktrace:
[...]

julia>  map!(-, [1]) # PR
ERROR: ArgumentError: map! requires at least one "source" argument
Stacktrace:
[...]
```