### PR TITLE
check dl===du in lu! for Tridiagonal; closes #35167

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -489,6 +489,9 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{Val{false}, Val{true}} = Val(true
     dl = A.dl
     d = A.d
     du = A.du
+    if dl === du
+        throw(ArgumentError("off-diagonals of `A` must not alias"))
+    end
     du2 = fill!(similar(d, n-2), 0)::V
 
     @inbounds begin

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -93,6 +93,12 @@ dimg  = randn(n)/2
         @test lud.L*lud.U ≈ Array(d)[lud.p,:]
         @test AbstractArray(lud) ≈ d
         @test Array(lud) ≈ d
+        if eltya != Int
+            dlu = convert.(eltya, [1, 1])
+            dia = convert.(eltya, [-2, -2, -2])
+            tri = Tridiagonal(dlu, dia, dlu)
+            @test_throws ArgumentError lu!(tri)
+        end
     end
     @testset for eltyb in (Float32, Float64, ComplexF32, ComplexF64, Int)
         b  = eltyb == Int ? rand(1:5, n, 2) :


### PR DESCRIPTION
I've added a check whether the lower and upper off-diagonals of a `Tridiagonal` matrix alias for the in-place LU factorization, closes JuliaLang/LinearAlgebra.jl#706.