### PR TITLE
Fix issue #35206: PermutedDimsArray, wrong results on strides method

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -62,13 +62,16 @@ Base.pointer(A::PermutedDimsArray, i::Integer) = throw(ArgumentError("pointer(A,
     (1,t[1].*c_strides(Base.tail(t))...)
 end
 
+@inline function c_strides(t::NTuple{1,Int})
+    1
+end
+
 @inline function c_strides(t::NTuple{0,Int})
     1
 end
 
 function Base.strides(A::PermutedDimsArray{T,N,perm}) where {T,N,perm}
-    strides_trail=c_strides(size(A))
-    ntuple(i->strides_trail[i],Val(N))
+    c_strides(size(A))
 end
 
 @inline function Base.getindex(A::PermutedDimsArray{T,N,perm,iperm}, I::Vararg{Int,N}) where {T,N,perm,iperm}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -661,9 +661,9 @@ end
     cp = PermutedDimsArray(c, (3,2,1))
     @test pointer(cp) == pointer(c)
     @test_throws ArgumentError pointer(cp, 2)
-    @test strides(cp) == (9,3,1)
+    @test strides(cp) == (1, 2, 6)
     ap = PermutedDimsArray(Array(a), (2,1,3))
-    @test strides(ap) == (3,1,12)
+    @test strides(ap) == (1, 4, 12)
 
     for A in [rand(1,2,3,4),rand(2,2,2,2),rand(5,6,5,6),rand(1,1,1,1)]
         perm = randperm(4)


### PR DESCRIPTION
this PR is meant as a solution to
https://github.com/JuliaLang/julia/issues/35206

before PR:
```julia
A=rand(10,100,300);
B=PermutedDimsArray(A,(3,2,1));
@show strides(A) #### strides(A) = (1, 10, 1000)
@show strides(B) #### strides(B) = (1000, 10, 1) ### WRONG (supposedly)
@show strides(collect(B)) #### strides(collect(B)) = (1, 300, 30000) ## CORRECT
```

after PR:

```julia
A=rand(10,100,300);
B=PermutedDimsArray(A,(3,2,1));
@show strides(A) #### strides(A) = (1, 10, 1000)
@show strides(B) #### strides(B) = (1, 300, 30000) ## CORRECT
@show strides(collect(B)) #### strides(collect(B)) = (1, 300, 30000) ## CORRECT
```


@timholy the original method is yours i think, if i got something wrong, apologies