### PR TITLE
LibGit2: add resolve_url to RemoteCallbacksStruct for LibGit2 0.99.0

### DIFF
--- a/stdlib/LibGit2/src/error.jl
+++ b/stdlib/LibGit2/src/error.jl
@@ -58,7 +58,12 @@ export GitError
              Callback,
              CherryPick,
              Describe,
-             Rebase)
+             Rebase,
+             Filesystem,
+             Patch,
+             WorkTree,
+             SHA1,
+             HTTP)
 
 struct ErrorStruct
     message::Ptr{UInt8}

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -223,6 +223,9 @@ end
     push_negotiation::Ptr{Cvoid}       = C_NULL
     transport::Ptr{Cvoid}              = C_NULL
     payload::Ptr{Cvoid}                = C_NULL
+    @static if LibGit2.VERSION >= v"0.99.0"
+        resolve_url::Ptr{Cvoid}        = C_NULL
+    end
 end
 
 """

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -3048,7 +3048,7 @@ mktempdir() do dir
                             deserialize(f)
                         end
                         @test err.code == LibGit2.Error.ERROR
-                        @test lowercase(err.msg) == lowercase("invalid Content-Type: text/plain")
+                        @test occursin(r"invalid content-type: '?text/plain'?"i, err.msg)
                     end
 
                     # OpenSSL s_server should still be running


### PR DESCRIPTION
Upstream commit https://github.com/libgit2/libgit2/commit/59647e1ad095f80112918971b7bbe05adfaf8c3c ("remote: add callback to resolve URLs before connecting") introduced a new callback `resolve_url` in LibGit2 0.99.0. Even though it is not currently used in Julia, it needs to be accounted for to get the correct size for `FetchOptionsStruct`. An incorrectly aligned `FetchOptionsStruct` leads to error messages like "invalid version 0 on git_proxy_options" when trying to use the latest LibGit2 version.

Fixes: GH-35043
Fixes: [FS#65540](https://bugs.archlinux.org/task/65540)