### PR TITLE
faster & type stable `invperm` and `isperm` for tuples shorter that 16 elements

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -263,12 +263,16 @@ function invperm(p::Union{Tuple{},Tuple{Int},Tuple{Int,Int}})
     p  # in dimensions 0-2, every permutation is its own inverse
 end
 
-function invperm(P::NTuple{N,Int}) where N
-    ntuple(Val(N)) do i
-        for j in eachindex(P)
-            P[j]==i && return Int(j)
+function invperm(P::NTuple{N}) where N
+    valn = Val(N)
+    ntuple(valn) do i
+        s = Base.afoldl(nothing, ntuple(identity, valn)...) do s, j
+            s !== nothing && return s
+            P[j]==i && return j
+            nothing
         end
-        throw(ArgumentError("argument is not a permutation"))
+        s === nothing && throw(ArgumentError("argument is not a permutation"))
+        s
     end
 end
 

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -36,6 +36,15 @@ end
 
 # Basic functions for working with permutations
 
+function _isperm(A)
+    n = length(A)
+    used = falses(n)
+    for a in A
+        (0 < a <= n) && (used[a] ⊻= true) || return false
+    end
+    true
+end
+
 """
     isperm(v) -> Bool
 
@@ -50,16 +59,6 @@ julia> isperm([1; 3])
 false
 ```
 """
-
-function _isperm(A)
-    n = length(A)
-    used = falses(n)
-    for a in A
-        (0 < a <= n) && (used[a] ⊻= true) || return false
-    end
-    true
-end
-
 isperm(A) = _isperm(A)
 
 function isperm(P::NTuple{N,Int}) where N

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -60,12 +60,17 @@ function isperm(A)
 end
 
 function isperm(P::NTuple{N,T}) where {N,T}
-    all(ntuple(Val(N)) do i
+    for i in eachindex(P)
+        flag=true
         for j in eachindex(P)
-            P[j]==i && return true
+            if P[j]==i
+                flag=false
+                break
+            end 
         end
-        return false
-    end)
+        flag && return false
+    end
+    return true
 end
 
 isperm(p::Tuple{}) = true

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -50,7 +50,8 @@ julia> isperm([1; 3])
 false
 ```
 """
-function isperm(A)
+
+function _isperm(A)
     n = length(A)
     used = falses(n)
     for a in A
@@ -59,7 +60,12 @@ function isperm(A)
     true
 end
 
+isperm(A) = _isperm(A)
+
 function isperm(P::NTuple{N,T}) where {N,T}
+    if N>21 # if N above 21 other algorithm is faster
+        return _isperm(P)
+    end
     for i in eachindex(P)
         flag=true
         for j in eachindex(P)

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -244,11 +244,11 @@ function invperm(p::Union{Tuple{},Tuple{Int},Tuple{Int,Int}})
 end
 
 function invperm(P::NTuple{N,T}) where {N,T}
-    isperm(P) || throw(ArgumentError("argument is not a permutation"))
     ntuple(Val(N)) do i
         for j in P
             @inbounds P[j]==i && return j
         end
+        throw(ArgumentError("argument is not a permutation"))
         return first(P) # DO NOT REMOVE: necessary for type stable code_gen
     end
 end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -81,8 +81,8 @@ isperm(p::Tuple{}) = true
 isperm(p::Tuple{Int}) = p[1] == 1
 isperm(p::Tuple{Int,Int}) = ((p[1] == 1) & (p[2] == 2)) | ((p[1] == 2) & (p[2] == 1))
 
-function isperm(P::NTuple{N,Integer}) where {N}
-    valn = Val(N)
+function isperm(P::Tuple)
+    valn = Val(length(P))
     _foldoneto(true, valn) do b,i
         s = _foldoneto(false, valn) do s, j
             s || P[j]==i
@@ -273,8 +273,8 @@ function invperm(p::Union{Tuple{},Tuple{Int},Tuple{Int,Int}})
     p  # in dimensions 0-2, every permutation is its own inverse
 end
 
-function invperm(P::NTuple{N,Integer}) where {N}
-    valn = Val(N)
+function invperm(P::Tuple)
+    valn = Val(length(P))
     ntuple(valn) do i
         s = _foldoneto(nothing, valn) do s, j
             s !== nothing && return s

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -286,7 +286,7 @@ function invperm(P::Tuple)
     end
 end
 
-invperm(P::Any16) = Tuple(invperm(collect(P)))
+invperm(P::Any16) = Tuple(invperm(collect(P)))::typeof(P)
 
 #XXX This function should be moved to Combinatorics.jl but is currently used by Base.DSP.
 """

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -62,7 +62,7 @@ end
 
 isperm(A) = _isperm(A)
 
-function isperm(P::NTuple{N,T}) where {N,T}
+function isperm(P::NTuple{N,Int}) where N
     if N>21 # if N above 21 other algorithm is faster
         return _isperm(P)
     end
@@ -263,10 +263,10 @@ function invperm(p::Union{Tuple{},Tuple{Int},Tuple{Int,Int}})
     p  # in dimensions 0-2, every permutation is its own inverse
 end
 
-function invperm(P::NTuple{N,T}) where {N,T}
+function invperm(P::NTuple{N,Int}) where N
     ntuple(Val(N)) do i
         for j in eachindex(P)
-            P[j]==i && return T(j)
+            P[j]==i && return Int(j)
         end
         throw(ArgumentError("argument is not a permutation"))
     end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -66,7 +66,9 @@ julia> isperm([1; 3])
 false
 ```
 """
-function isperm(A)
+isperm(A) = _isperm(A)
+
+function _isperm(A)
     n = length(A)
     used = falses(n)
     for a in A
@@ -88,6 +90,8 @@ function isperm(P::NTuple{N,Integer}) where {N}
         b&s
     end
 end
+
+isperm(P::Any16) = _isperm(P)
 
 # swap columns i and j of a, in-place
 function swapcols!(a::AbstractMatrix, i, j)
@@ -281,6 +285,8 @@ function invperm(P::NTuple{N,Integer}) where {N}
         s
     end
 end
+
+invperm(P::Any16) = Tuple(invperm(collect(P)))
 
 #XXX This function should be moved to Combinatorics.jl but is currently used by Base.DSP.
 """

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -59,6 +59,15 @@ function isperm(A)
     true
 end
 
+function isperm(P::NTuple{N,T}) where {N,T}
+    all(ntuple(Val(N)) do i
+        for j in eachindex(P)
+            @inbounds P[j]==i && return true
+        end
+        return false
+    end)
+end
+
 isperm(p::Tuple{}) = true
 isperm(p::Tuple{Int}) = p[1] == 1
 isperm(p::Tuple{Int,Int}) = ((p[1] == 1) & (p[2] == 2)) | ((p[1] == 2) & (p[2] == 1))
@@ -245,8 +254,8 @@ end
 
 function invperm(P::NTuple{N,T}) where {N,T}
     ntuple(Val(N)) do i
-        for j in P
-            @inbounds P[j]==i && return j
+        for j in eachindex(P)
+            @inbounds P[j]==i && return T(j)
         end
         throw(ArgumentError("argument is not a permutation"))
     end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -62,7 +62,7 @@ end
 function isperm(P::NTuple{N,T}) where {N,T}
     all(ntuple(Val(N)) do i
         for j in eachindex(P)
-            @inbounds P[j]==i && return true
+            P[j]==i && return true
         end
         return false
     end)
@@ -255,7 +255,7 @@ end
 function invperm(P::NTuple{N,T}) where {N,T}
     ntuple(Val(N)) do i
         for j in eachindex(P)
-            @inbounds P[j]==i && return T(j)
+            P[j]==i && return T(j)
         end
         throw(ArgumentError("argument is not a permutation"))
     end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -242,7 +242,16 @@ function invperm(p::Union{Tuple{},Tuple{Int},Tuple{Int,Int}})
     isperm(p) || throw(ArgumentError("argument is not a permutation"))
     p  # in dimensions 0-2, every permutation is its own inverse
 end
-invperm(a::Tuple) = (invperm([a...])...,)
+
+function invperm(P::NTuple{N,T}) where {N,T}
+    isperm(p) || throw(ArgumentError("argument is not a permutation"))
+    ntuple(Val(N)) do i
+        for j in P
+            @inbounds P[j]==i && return j
+        end
+        return zero(T) #
+    end
+end
 
 #XXX This function should be moved to Combinatorics.jl but is currently used by Base.DSP.
 """

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -244,12 +244,12 @@ function invperm(p::Union{Tuple{},Tuple{Int},Tuple{Int,Int}})
 end
 
 function invperm(P::NTuple{N,T}) where {N,T}
-    isperm(p) || throw(ArgumentError("argument is not a permutation"))
+    isperm(P) || throw(ArgumentError("argument is not a permutation"))
     ntuple(Val(N)) do i
         for j in P
             @inbounds P[j]==i && return j
         end
-        return zero(T) #
+        return first(P) # DO NOT REMOVE: necessary for type stable code_gen
     end
 end
 

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -286,7 +286,7 @@ function invperm(P::Tuple)
     end
 end
 
-invperm(P::Any16) = Tuple(invperm(collect(P)))::typeof(P)
+invperm(P::Any16) = Tuple(invperm(collect(P)))
 
 #XXX This function should be moved to Combinatorics.jl but is currently used by Base.DSP.
 """

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -83,9 +83,7 @@ function isperm(P::NTuple{N,Integer}) where {N}
     valn = Val(N)
     _foldoneto(true, valn) do b,i
         s = _foldoneto(false, valn) do s, j
-            s && return s
-            P[j]==i && return true
-            false
+            s || P[j]==i
         end
         b&s
     end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -249,7 +249,6 @@ function invperm(P::NTuple{N,T}) where {N,T}
             @inbounds P[j]==i && return j
         end
         throw(ArgumentError("argument is not a permutation"))
-        return first(P) # DO NOT REMOVE: necessary for type stable code_gen
     end
 end
 

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -72,7 +72,7 @@ function isperm(P::NTuple{N,T}) where {N,T}
             if P[j]==i
                 flag=false
                 break
-            end 
+            end
         end
         flag && return false
     end

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -34,7 +34,7 @@ end
     @test invperm((1,2)) == (1,2)
     @test invperm((2,1)) == (2,1)
     @test_throws ArgumentError invperm((1,3))
-    
+
     push!(p, 1)
     @test !isperm(p)
 
@@ -45,7 +45,7 @@ end
     let ai = 2:-1:1
         @test invpermute!(permute!([1, 2], ai), ai) == [1, 2]
     end
-    
+
     # PR 35234
     for N in 3:1:20
         A=randcycle(N)

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -34,7 +34,7 @@ end
     @test invperm((1,2)) == (1,2)
     @test invperm((2,1)) == (2,1)
     @test_throws ArgumentError invperm((1,3))
-
+    
     push!(p, 1)
     @test !isperm(p)
 
@@ -44,6 +44,17 @@ end
     # PR 12785
     let ai = 2:-1:1
         @test invpermute!(permute!([1, 2], ai), ai) == [1, 2]
+    end
+    
+    # PR 35234
+    for N in 3:1:20
+        A=randcycle(N)
+        T=Tuple(A)
+        K=Tuple(A.-1)
+        @test A[collect(invperm(T))] == 1:N
+        @test_throws ArgumentError invperm(K)
+        @test isperm(T) == true
+        @test isperm(K) == false
     end
 end
 


### PR DESCRIPTION
#### Regarding speed
small simple benchmarking code
```julia
using Random
using BenchmarkTools

function fast_invperm(P::NTuple{N,T}) where {N,T}
    isperm(P) || throw(ArgumentError("argument is not a permutation"))
    ntuple(Val(N)) do i
        for j in P
            @inbounds P[j]==i && return j
        end
        return first(P) # DO NOT REMOVE: necessary for type stable code_gen
    end
end

function time_impl()
    for N in 3:10:50
        T=(shuffle(1:N)...,)
        @show @benchmark invperm($T)
        @show @benchmark fast_invperm($T)
    end
end

time_impl()
```

results:

```
#= ....108 =# @benchmark(invperm($(Expr(:$, :T)))) = Trial(253.927 ns)
#= ....109 =# @benchmark(fast_invperm($(Expr(:$, :T)))) = Trial(41.746 ns)
#= ....108 =# @benchmark(invperm($(Expr(:$, :T)))) = Trial(450.132 ns)
#= ....109 =# @benchmark(fast_invperm($(Expr(:$, :T)))) = Trial(90.729 ns)
#= ....108 =# @benchmark(invperm($(Expr(:$, :T)))) = Trial(637.290 ns)
#= ....109 =# @benchmark(fast_invperm($(Expr(:$, :T)))) = Trial(194.659 ns)
#= ....108 =# @benchmark(invperm($(Expr(:$, :T)))) = Trial(1.296 μs)
#= ....109 =# @benchmark(fast_invperm($(Expr(:$, :T)))) = Trial(303.951 ns)
#= ....108 =# @benchmark(invperm($(Expr(:$, :T)))) = Trial(1.612 μs)
#= ....109 =# @benchmark(fast_invperm($(Expr(:$, :T)))) = Trial(475.883 ns)
```


#### Regarding type stability
```julia
@code_warntype invperm((1,3,2))
Variables
  #self#::Core.Compiler.Const(invperm, false)
  a::Tuple{Int64,Int64,Int64}

Body::Tuple{Vararg{Int64,N} where N}
1 ─ %1 = Core._apply_iterate(Base.iterate, Base.vect, a)::Array{Int64,1}
│   %2 = Base.invperm(%1)::Array{Int64,1}
│   %3 = Core._apply_iterate(Base.iterate, Core.tuple, %2)::Tuple{Vararg{Int64,N} where N}
└──      return %3
```


```julia
@code_warntype fast_invperm((1,3,2))

Variables
  #self#::Core.Compiler.Const(fast_invperm, false)
  P::Tuple{Int64,Int64,Int64}
  #9::var"#9#10"{Tuple{Int64,Int64,Int64}}

Body::Tuple{Int64,Int64,Int64}
1 ─       Core.NewvarNode(:(#9))
│   %2  = Main.isperm(P)::Bool
└──       goto #3 if not %2
2 ─       goto #4
3 ─ %5  = Main.ArgumentError("argument is not a permutation")::ArgumentError
└──       Main.throw(%5)
4 ┄ %7  = Main.:(var"#9#10")::Core.Compiler.Const(var"#9#10", false)
│   %8  = Core.typeof(P)::Core.Compiler.Const(Tuple{Int64,Int64,Int64}, false)
│   %9  = Core.apply_type(%7, %8)::Core.Compiler.Const(var"#9#10"{Tuple{Int64,Int64,Int64}}, false)
│         (#9 = %new(%9, P))
│   %11 = #9::var"#9#10"{Tuple{Int64,Int64,Int64}}
│   %12 = Main.Val($(Expr(:static_parameter, 1)))::Core.Compiler.Const(Val{3}(), true)
│   %13 = Main.ntuple(%11, %12)::Tuple{Int64,Int64,Int64}
└──       return %13

```

