### PR TITLE
define hasmissing

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -685,6 +685,7 @@ export
     something,
     isnothing,
     nonmissingtype,
+    hasmissing
 
 # time
     sleep,

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -264,6 +264,7 @@ end
 
 Checks if itr has missing values.
 """
+hasmissing(x::Base.SkipMissing) = false
 hasmissing(itr) = ~(collect(skipmissing(itr)) == collect(itr))
 
 # Optimized mapreduce implementation

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -259,6 +259,13 @@ keys(itr::SkipMissing) =
     v
 end
 
+"""
+    hasmissing(itr)
+
+Checks if itr has missing values.
+"""
+hasmissing(itr) = ~(collect(skipmissing(itr)) == collect(itr))
+
 # Optimized mapreduce implementation
 # The generic method is faster when !(eltype(A) >: Missing) since it does not need
 # additional loops to identify the two first non-missing values of each block

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -264,8 +264,8 @@ end
 
 Checks if itr has missing values.
 """
+hasmissing(itr) = any(ismissing, itr)
 hasmissing(x::Base.SkipMissing) = false
-hasmissing(itr) = ~(collect(skipmissing(itr)) == collect(itr))
 
 # Optimized mapreduce implementation
 # The generic method is faster when !(eltype(A) >: Missing) since it does not need

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -266,6 +266,7 @@ Checks if itr has missing values.
 """
 hasmissing(itr) = any(ismissing, itr)
 hasmissing(x::Base.SkipMissing) = false
+hasmissing(::AbstractArray{<:Number}) = false
 
 # Optimized mapreduce implementation
 # The generic method is faster when !(eltype(A) >: Missing) since it does not need

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -266,7 +266,6 @@ Checks if itr has missing values.
 """
 hasmissing(itr) = any(ismissing, itr)
 hasmissing(x::Base.SkipMissing) = false
-hasmissing(::AbstractArray{<:Number}) = false
 
 # Optimized mapreduce implementation
 # The generic method is faster when !(eltype(A) >: Missing) since it does not need

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -527,3 +527,10 @@ mutable struct Obj; x; end
     @test ismissing(wref[1] == missing)
     @test ismissing(missing == wref[1])
 end
+
+@testset "hasmissing" begin
+    @test hasmissing([1, 2, 3, 4]) == false
+    @test hasmissing([1, 2, 3, missing, 5]) == true
+    @test hasmissing(skipmissing(skipmissing([1, 2, 3, 4]))) == false
+    @test hasmissing(skipmissing([1, 2, missing, 4])) == false
+end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -531,6 +531,5 @@ end
 @testset "hasmissing" begin
     @test hasmissing([1, 2, 3, 4]) == false
     @test hasmissing([1, 2, 3, missing, 5]) == true
-    @test hasmissing(skipmissing(skipmissing([1, 2, 3, 4]))) == false
     @test hasmissing(skipmissing([1, 2, missing, 4])) == false
 end


### PR DESCRIPTION
Defines a function `hasmissing` to test if a collection or iterator has missing values. 

This is something I've had to define myself in a few projects. I think it would be useful. 

```
"""
    hasmissing(itr)

Checks if itr has missing values.
"""
hasmissing(itr) = any(ismissing, itr)
hasmissing(x::Base.SkipMissing) = false
```

```
@testset "hasmissing" begin
    @test hasmissing([1, 2, 3, 4]) == false
    @test hasmissing([1, 2, 3, missing, 5]) == true
    @test hasmissing(skipmissing([1, 2, missing, 4])) == false
end
```