### PR TITLE
fix a bug preventing inlining of getindex of const globals

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -280,7 +280,7 @@ intrinsic_effect_free_if_nothrow(f) = f === Intrinsics.pointerref || is_pure_int
 plus_saturate(x::Int, y::Int) = max(x, y, x+y)
 
 # known return type
-isknowntype(@nospecialize T) = (T === Union{}) || isconcretetype(T)
+isknowntype(@nospecialize T) = (T === Union{}) || isa(T, Const) || isconcretetype(widenconst(T))
 
 function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any}, params::Params)
     head = ex.head

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -282,3 +282,9 @@ end
     @test ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(@inline function f(x) x end)).source)
     @test !ccall(:jl_ast_flag_inlineable, Bool, (Any,), first(methods(function f(x) x end)).source)
 end
+
+const _a_global_array = [1]
+f_inline_global_getindex() = _a_global_array[1]
+let ci = code_typed(f_inline_global_getindex, Tuple{})[1].first
+    @test any(x->(isexpr(x, :call) && x.args[1] === GlobalRef(Base, :arrayref)), ci.code)
+end


### PR DESCRIPTION
For example

```
julia> const k = [1];

julia> f() = k[1];

julia> @code_typed f()
CodeInfo(
1 ─ %1 = invoke Base.getindex(Main.k::Array{Int64,1}, 1::Int64)::Int64
└──      return %1
) => Int64
```

Fixes https://github.com/JuliaLang/julia/issues/31460
