### PR TITLE
Add sizehint! to Dict constructor

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -99,7 +99,10 @@ mutable struct Dict{K,V} <: AbstractDict{K,V}
 end
 function Dict{K,V}(kv) where V where K
     h = Dict{K,V}()
-    sizehint!(h, length(kv))
+    chklen = IteratorSize(kv)
+    if (chklen isa HasLength) || (chklen isa HasShape)
+        sizehint!(h, length(kv))
+    end
     for (k,v) in kv
         h[k] = v
     end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -99,6 +99,7 @@ mutable struct Dict{K,V} <: AbstractDict{K,V}
 end
 function Dict{K,V}(kv) where V where K
     h = Dict{K,V}()
+    sizehint!(h, length(kv))
     for (k,v) in kv
         h[k] = v
     end


### PR DESCRIPTION
The constructor `Dict{K,V}(kv)` does not provide a size hint, whereas the `Dict{K,V}(ps::Pair...)` constructor does. Is there any reason for this? I just tried benchmarking with and without `sizehint!` for `Dict{K,V}(kv)` and see an improvement when providing a size hint:

```julia
julia> using BenchmarkTools

julia> n = 1_000_000;

julia> kv = collect(zip(rand(n), rand(n)));

julia> @btime Dict{Float64,Float64}($kv);
  55.698 ms (54 allocations: 65.17 MiB)

julia> @eval Base begin
       function Dict{K,V}(kv) where V where K
           h = Dict{K,V}()
           sizehint!(h, length(kv))
           for (k,v) in kv
              h[k] = v
           end
           return h
       end
       end

julia> @btime Dict{Float64,Float64}($kv);
  40.509 ms (13 allocations: 51.00 MiB)
```

Closes #36334