### PR TITLE
Add efficient `findfirst` methods for `UnitRange`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1791,6 +1791,12 @@ end
 findfirst(testf::Function, A::Union{AbstractArray, AbstractString}) =
     findnext(testf, A, first(keys(A)))
 
+findfirst(p::Union{Fix2{typeof(isequal),Int},Fix2{typeof(==),Int}}, r::OneTo{Int}) =
+    1 <= p.x <= r.stop ? p.x : nothing
+
+findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::AbstractUnitRange) where {T<:Integer} =
+    first(r) <= p.x <= last(r) ? 1+Int(p.x - first(r)) : nothing
+
 function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -301,6 +301,12 @@ end
         end
     end
     @testset "findfirst" begin
+        @test findfirst(isequal(3), Base.OneTo(10)) == 3
+        @test findfirst(==(0), Base.OneTo(10)) == nothing
+        @test findfirst(==(11), Base.OneTo(10)) == nothing
+        @test findfirst(==(4), Int16(3):Int16(7)) === Int(2)
+        @test findfirst(==(2), Int16(3):Int16(7)) == nothing
+        @test findfirst(isequal(8), 3:7) == nothing
         @test findfirst(isequal(7), 1:2:10) == 4
         @test findfirst(==(7), 1:2:10) == 4
         @test findfirst(==(10), 1:2:10) == nothing


### PR DESCRIPTION
This is like #30778 but for unit ranges. Before & after:
```
@btime findfirst(isequal(500), Base.OneTo(1_000))  # 285.704 ns 
@btime _findfirst(isequal(500), Base.OneTo(1_000)) # 0.029 ns

@btime findfirst(isequal(500), -10^6:10^6)     # 1.114 ms
@btime _findfirst(isequal(500), $(-10^6:10^6)) # 0.029 ns
```