### PR TITLE
Inline and use a non-splatting combine_axes in broadcast

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -472,7 +472,7 @@ julia> Broadcast.combine_axes(1, 1, 1)
 """
 @inline combine_axes(A, B...) = broadcast_shape(axes(A), combine_axes(B...))
 @inline combine_axes(A, B) = broadcast_shape(axes(A), axes(B))
-@inline combine_axes(A) = axes(A)
+combine_axes(A) = axes(A)
 
 # shape (i.e., tuple-of-indices) inputs
 broadcast_shape(shape::Tuple) = shape

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -471,7 +471,7 @@ julia> Broadcast.combine_axes(1, 1, 1)
 ```
 """
 @inline combine_axes(A, B...) = broadcast_shape(axes(A), combine_axes(B...))
-@inline combine_axes(A, B) = broadcast_shape(broadcast_axes(A), broadcast_axes(B))
+@inline combine_axes(A, B) = broadcast_shape(axes(A), axes(B))
 @inline combine_axes(A) = axes(A)
 
 # shape (i.e., tuple-of-indices) inputs

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -471,7 +471,8 @@ julia> Broadcast.combine_axes(1, 1, 1)
 ```
 """
 @inline combine_axes(A, B...) = broadcast_shape(axes(A), combine_axes(B...))
-combine_axes(A) = axes(A)
+@inline combine_axes(A, B) = broadcast_shape(broadcast_axes(A), broadcast_axes(B))
+@inline combine_axes(A) = axes(A)
 
 # shape (i.e., tuple-of-indices) inputs
 broadcast_shape(shape::Tuple) = shape

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -857,3 +857,13 @@ end
 
 # 28680
 @test 1 .+ 1 .+  (1, 2) == (3, 4)
+
+# PR #35260 no allocations in simple broadcasts
+u = rand(100)
+k1 = similar(u)
+k2 = similar(u)
+k3 = similar(u)
+k4 = similar(u)
+f(a,b,c,d,e) = @. a = a + 1*(b+c+d+e)
+@allocated f(u,k1,k2,k3,k4)
+@test (@allocated f(u,k1,k2,k3,k4)) == 0


### PR DESCRIPTION
DifferentialEquations.jl has been carrying around a patch

https://github.com/SciML/DiffEqBase.jl/blob/master/src/diffeqfastbc.jl#L18

for awhile which stops allocations like https://discourse.julialang.org/t/strange-allocations-during-broadcasting/26605/5 due to lack of inlining and due to splatting. It would probably be good to upstream this?

@mbauman 