### PR TITLE
Make indexing into LinRange preserve eltype

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -727,12 +727,12 @@ function getindex(r::StepRangeLen{T}, s::OrdinalRange{<:Integer}) where {T}
     return StepRangeLen{T}(ref, r.step*step(s), length(s), offset)
 end
 
-function getindex(r::LinRange, s::OrdinalRange{<:Integer})
+function getindex(r::LinRange{T}, s::OrdinalRange{<:Integer}) where {T}
     @_inline_meta
     @boundscheck checkbounds(r, s)
     vfirst = unsafe_getindex(r, first(s))
     vlast  = unsafe_getindex(r, last(s))
-    return LinRange(vfirst, vlast, length(s))
+    return LinRange{T}(vfirst, vlast, length(s))
 end
 
 show(io::IO, r::AbstractRange) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1581,3 +1581,9 @@ end
     @test step(r) === 2
     @test collect(r) == ['a','c','e','g']
 end
+
+@testset "Return type of indexing with ranges" begin
+    for T = (Base.OneTo{Int}, UnitRange{Int}, StepRange{Int,Int}, StepRangeLen{Int}, LinRange{Int})
+        @test eltype(T(1:5)) === eltype(T(1:5)[1:2])
+    end
+end


### PR DESCRIPTION
Previously, indexing into a `LinRange{Int}` with another range would return a `LinRange{Float64}`. This PR fixes that.

Before:
```julia
julia> LinRange{Int}(1,5,5)
5-element LinRange{Int64}:
 1.0,2.0,3.0,4.0,5.0

julia> LinRange{Int}(1,5,5)[1:2]
2-element LinRange{Float64}:
 1.0,2.0
```

After:
```julia
julia> LinRange{Int}(1,5,5)
5-element LinRange{Int64}:
 1,2,3,4,5

julia> LinRange{Int}(1,5,5)[1:2]
2-element LinRange{Int64}:
 1,2
```

Note that this also affects the printing of `LinRange{Int}` because of the way `print_range` is implemented.