### PR TITLE
Fix obsolete builtins list in devdocs/function (dup/rebase of #33680)

### DIFF
--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -120,7 +120,8 @@ function lines(words)
     String(take!(io))
 end
 import Markdown
-[string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin] |>
+[string(n) for n in names(Core;all=true)
+    if getfield(Core,n) isa Core.Builtin && nameof(getfield(Core,n)) === n] |>
     lines |>
     s ->  "```\n$s\n```" |>
     Markdown.parse

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -101,10 +101,29 @@ currently share a method table via special arrangement.
 
 The "builtin" functions, defined in the `Core` module, are:
 
-```
-=== typeof sizeof <: isa typeassert throw tuple getfield setfield! fieldtype
-nfields isdefined arrayref arrayset arraysize applicable invoke apply_type _apply
-_expr svec
+```@eval
+function lines(words)
+    io = IOBuffer()
+    n = 0
+    for w in words
+        if n+length(w) > 80
+            print(io, '\n', w)
+            n = length(w)
+        elseif n == 0
+            print(io, w);
+            n += length(w)
+        else
+            print(io, ' ', w);
+            n += length(w)+1
+        end
+    end
+    String(take!(io))
+end
+import Markdown
+[string(n) for n in names(Core;all=true) if getfield(Core,n) isa Core.Builtin] |>
+    lines |>
+    s ->  "```\n$s\n```" |>
+    Markdown.parse
 ```
 
 These are all singleton objects whose types are subtypes of `Builtin`, which is a subtype of


### PR DESCRIPTION
Fix obsolete builtins list in devdocs/function with dyn code in doc

Actually a dup of #33680 Rather a dup for rebasing
*i get wind of unfixable errors may be due to obsolescence of the main codebase since proposal*