### PR TITLE
Patch REPL documentation for symbols ending with '='

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -208,7 +208,7 @@ function lookup_doc(ex)
     end
     if isa(ex, Symbol) && Base.isoperator(ex)
         str = string(ex)
-        if endswith(str, "=")
+        if endswith(str, "=") && Base.operator_precedence(ex) == Base.prec_assignment
             op = str[1:end-1]
             return Markdown.parse("`x $op= y` is a synonym for `x = x $op y`")
         elseif startswith(str, ".")

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1043,8 +1043,13 @@ for line in ["′", "abstract", "type"]
         sprint(show, help_result(line)::Union{Markdown.MD,Nothing}))
 end
 
+# PR 35154
 @test occursin("|=", sprint(show, help_result("|=")))
 @test occursin("broadcast", sprint(show, help_result(".=")))
+
+# PR 35277
+@test occursin("identical", sprint(show, help_result("===")))
+@test occursin("broadcast", sprint(show, help_result(".<=")))
 
 # Issue #25930
 


### PR DESCRIPTION
Hi there!

While randomly idling in the REPL, I was amazed to discover that:
```
help?> ==
search: == === !==

  x == y is a synonym for x = x = y

help?> <=
search: <=

  x <= y is a synonym for x = x < y

help?> .<=
search:

  x .<= y is a synonym for x = x .< y
```
This was good fun! But after an instant of dreadful uncertainty, I decided it could not be right, so here is a PR to reestablish the truth.

I believe this was unintentionally introduced in #35154. If it is intentional, let me know and I will simply re-read the entire Julia manual to make sense of things...

By the way the fix is not very nice to the eye, if there is a way get all the comparison operators in one place I would gladly use that instead.