### PR TITLE
Use inefficient `findfirst` method for `StepRange{..., Year}`

### DIFF
--- a/stdlib/Dates/src/ranges.jl
+++ b/stdlib/Dates/src/ranges.jl
@@ -65,3 +65,11 @@ Base.iterate(r::StepRange{<:TimeType}, (l, i)) = l <= i ? nothing : (r.start + r
 # Combinations of types and periods for which the range step is regular
 Base.RangeStepStyle(::Type{<:OrdinalRange{<:TimeType, <:FixedPeriod}}) =
     Base.RangeStepRegular()
+
+# Avoid special method added in https://github.com/JuliaLang/julia/pull/30778
+function findfirst(testf::Union{Fix2{typeof(isequal)},Fix2{typeof(==)}}, A::StepRange{<:TimeType, <:OtherPeriod})
+    for (i, a) in pairs(A)
+        testf(a) && return i
+    end
+    return nothing
+end

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -582,4 +582,12 @@ a = Dates.Time(23, 1, 1)
       hash([Date("2018-1-03"), Date("2018-1-04"), Date("2018-1-05")]) ==
       hash(Date("2018-1-03"):Day(1):Date("2018-1-05"))
 
+# https://github.com/JuliaLang/julia/issues/35203
+yr = Date(1852):Year(4):Date(1940)
+y21 = yr[21+1]
+@test findfirst(isequal(y21), yr) == findfirst(isequal(y21), collect(yr))
+mr = Date(1998,8,7):Month(1):Date(2001,9,11)
+m36 = mr[36+1]
+@test findfirst(isequal(m36), mr) == findfirst(isequal(m36), collect(mr))
+
 end


### PR DESCRIPTION
Fixes #35203, by avoiding the method added in #30778 for ranges of step Month or Year. 

The alternative would be to add a check of `Base.RangeStepStyle` to #30778. That seems tidier but it sounds like nothing else is using this trait, e.g. #30501. It seems wrong for some ranges too, like `Base.RangeStepStyle('a':'z’) == Base.RangeStepIrregular()`. 