### PR TITLE
Use trait `RangeStepStyle` for `findfirst(isequal, ...)`, and adjust it for `StepRange{Char,Int}`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2517,7 +2517,7 @@ function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::Abst
     return i1 + oftype(i1, p.x - first(r))
 end
 
-findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
+function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
     RangeStepStyle(r) isa RangeStepRegular || return _findfirst(p, r)
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing

--- a/base/array.jl
+++ b/base/array.jl
@@ -2492,7 +2492,9 @@ julia> findfirst(iseven, A)
 CartesianIndex(2, 1)
 ```
 """
-function findfirst(testf::Function, A)
+findfirst(testf::Function, A) = _findfirst(testf, A)
+
+function _findfirst(testf::Function, A)
     for (i, a) in pairs(A)
         testf(a) && return i
     end
@@ -2515,10 +2517,12 @@ function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::Abst
     return i1 + oftype(i1, p.x - first(r))
 end
 
-function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
-    if RangeStepStyle(r) !== RangeStepRegular()
-        return invoke(findfirst, Tuple{Function,Any}, p, r)
-    end
+findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S} =
+    _findfirst(p, RangeStepStyle(r), r)
+
+_findfirst(p, ::RangeStepStyle, r) = _findfirst(p, r)
+
+function _findfirst(p::Union{Fix2{typeof(isequal)},Fix2{typeof(==)}}, ::RangeStepRegular, r::StepRange{T,S}) where {T,S}
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing
     d = p.x - first(r)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2517,7 +2517,7 @@ function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::Abst
     return i1 + oftype(i1, p.x - first(r))
 end
 
-findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S} =
+findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
     RangeStepStyle(r) isa RangeStepRegular || return _findfirst(p, r)
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing

--- a/base/array.jl
+++ b/base/array.jl
@@ -2463,6 +2463,9 @@ Return `nothing` if there is no such element.
 Indices or keys are of the same type as those returned by [`keys(A)`](@ref)
 and [`pairs(A)`](@ref).
 
+A faster method is used for `findfirst(isequal(x), A)` when
+`RangeStepStyle(A) === RangeStepRegular()`.
+
 # Examples
 ```jldoctest
 julia> A = [1, 4, 2, 2]
@@ -2513,6 +2516,9 @@ function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::Abst
 end
 
 function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
+    if RangeStepStyle(r) !== RangeStepRegular()
+        return invoke(findfirst, Tuple{Function,Any}, p, r)
+    end
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing
     d = p.x - first(r)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2463,8 +2463,8 @@ Return `nothing` if there is no such element.
 Indices or keys are of the same type as those returned by [`keys(A)`](@ref)
 and [`pairs(A)`](@ref).
 
-A faster method is used for `findfirst(isequal(x), A)` when
-`RangeStepStyle(A) === RangeStepRegular()`.
+An optimized method is used for `findfirst(isequal(x), A)` when `A` is a range and
+`Base.RangeStepStyle(A) === Base.RangeStepRegular()`.
 
 # Examples
 ```jldoctest
@@ -2518,11 +2518,7 @@ function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::Abst
 end
 
 findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S} =
-    _findfirst(p, RangeStepStyle(r), r)
-
-_findfirst(p, ::RangeStepStyle, r) = _findfirst(p, r)
-
-function _findfirst(p::Union{Fix2{typeof(isequal)},Fix2{typeof(==)}}, ::RangeStepRegular, r::StepRange{T,S}) where {T,S}
+    RangeStepStyle(r) isa RangeStepRegular || return _findfirst(p, r)
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing
     d = p.x - first(r)

--- a/base/range.jl
+++ b/base/range.jl
@@ -392,6 +392,8 @@ steprange_last_empty(start, step, stop) = stop
 StepRange{T}(start, step::S, stop) where {T,S} = StepRange{T,S}(start, step, stop)
 StepRange(start::T, step::S, stop::T) where {T,S} = StepRange{T,S}(start, step, stop)
 
+RangeStepStyle(::Type{<:StepRange{<:Any,<:Integer}}) = RangeStepRegular()
+
 """
     UnitRange{T<:Real}
 
@@ -534,6 +536,8 @@ StepRangeLen(ref::R, step::S, len::Integer, offset::Integer = 1) where {R,S} =
     StepRangeLen{typeof(ref+zero(step)),R,S,promote_type(Int,typeof(len))}(ref, step, len, offset)
 StepRangeLen{T}(ref::R, step::S, len::Integer, offset::Integer = 1) where {T,R,S} =
     StepRangeLen{T,R,S,promote_type(Int,typeof(len))}(ref, step, len, offset)
+
+RangeStepStyle(::Type{<:StepRangeLen{<:Any,<:Any,<:Integer}}) = RangeStepRegular()
 
 ## range with computed step
 

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -43,15 +43,14 @@ define the following method:
 ```julia
 Base.RangeStepStyle(::Type{<:AbstractRange{<:T}}) = Base.RangeStepRegular()
 ```
-This will allow [`hash`](@ref) to use an O(1) algorithm for `AbstractRange{T}`
-objects instead of the default O(N) algorithm (with N the length of the range).
-
 In some cases, whether the step will be regular depends not only on the
 element type `T`, but also on the type of the step `S`. In that case, more
 specific methods should be defined:
 ```julia
 Base.RangeStepStyle(::Type{<:OrdinalRange{<:T, <:S}}) = Base.RangeStepRegular()
 ```
+It is expected that intervals between elements can be converted to type `S`,
+and that `div` and `rem` are defined for this type.
 
 By default, all range types are assumed to be `RangeStepIrregular`, except
 ranges with an element type which is a subtype of `Integer`.

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -55,6 +55,8 @@ Base.RangeStepStyle(::Type{<:OrdinalRange{<:T, <:S}}) = Base.RangeStepRegular()
 
 By default, all range types are assumed to be `RangeStepIrregular`, except
 ranges with an element type which is a subtype of `Integer`.
+The module `Dates` also defines ranges whose step is a `FixedPeriod` to be regular,
+for example steps of a `Day(1)` but not `Month(1)`.
 """
 abstract type RangeStepStyle end
 struct RangeStepRegular   <: RangeStepStyle end # range with regular step

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -611,4 +611,14 @@ end
     @test_throws OverflowError StepRange(dmin, Day(1), dmax)
 end
 
+# https://github.com/JuliaLang/julia/issues/35203
+yr = Date(1852):Year(4):Date(1940)
+@test Base.RangeStepStyle(yr) === Base.RangeStepIrregular()
+y21 = yr[21+1]
+@test findfirst(isequal(y21), yr) == findfirst(isequal(y21), collect(yr))
+mr = Date(1998,8,7):Month(1):Date(2001,9,11)
+@test Base.RangeStepStyle(mr) === Base.RangeStepIrregular()
+m36 = mr[36+1]
+@test findfirst(isequal(m36), mr) == findfirst(isequal(m36), collect(mr))
+
 end  # RangesTest module

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -582,6 +582,25 @@ a = Dates.Time(23, 1, 1)
       hash([Date("2018-1-03"), Date("2018-1-04"), Date("2018-1-05")]) ==
       hash(Date("2018-1-03"):Day(1):Date("2018-1-05"))
 
+@testset "months are irregular steps -- issue 35203" begin
+    yr = Date(1852):Year(4):Date(1940)
+    @test Base.RangeStepStyle(yr) === Base.RangeStepIrregular()
+    y21 = yr[21+1]
+    @test findfirst(isequal(y21), yr) == findfirst(isequal(y21), collect(yr))
+    mr = Date(1998,8,7):Month(1):Date(2001,9,11)
+    @test Base.RangeStepStyle(mr) === Base.RangeStepIrregular()
+    m36 = mr[36+1]
+    @test findfirst(isequal(m36), mr) == findfirst(isequal(m36), collect(mr))
+    # but days etc. are regular
+    dr = Date(2020,03,27):Day(1):Date(2021,03,21)
+    @test Base.RangeStepStyle(dr) === Base.RangeStepRegular()
+    aday = rand(dr)
+    i1fast = findfirst(isequal(aday), dr)
+    i1slow = findfirst(d -> d==aday, dr)
+    @test i1fast == i1slow
+    @test dr[i1fast] == aday
+end
+
 @testset "range overflow" begin
     # DateTime ranges interactions with overflow. If not handled correctly `Dates.len` could
     # infinite loop

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2581,6 +2581,7 @@ let r = Ptr{Cvoid}(20):-UInt(2):Ptr{Cvoid}(10)
     @test last(r) === Ptr{Cvoid}(10)
 end
 
+<<<<<<< HEAD
 # test behavior of wrap-around and promotion of empty ranges (#35711)
 @test length(range(0, length=UInt(0))) === UInt(0)
 @test isempty(range(0, length=UInt(0)))
@@ -2859,4 +2860,13 @@ const EXAMPLE_RANGES = AbstractRange[
     for a in EXAMPLE_RANGES, b in EXAMPLE_RANGES
         @test try cmp(a, b) catch e; e end == try cmp(collect(a), collect(b)) catch e; e end
     end
+end
+
+@testset "Char ranges are regular" begin
+    r = 'a':'z'
+    r2 = 'α':2:'ω'
+    r3 = StepRangeLen('a',3,10)
+    @test Base.RangeStepStyle(r) === RangeStepRegular()
+    @test Base.RangeStepStyle(r2) === RangeStepRegular()
+    @test Base.RangeStepStyle(r3) === RangeStepRegular()
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2581,7 +2581,6 @@ let r = Ptr{Cvoid}(20):-UInt(2):Ptr{Cvoid}(10)
     @test last(r) === Ptr{Cvoid}(10)
 end
 
-<<<<<<< HEAD
 # test behavior of wrap-around and promotion of empty ranges (#35711)
 @test length(range(0, length=UInt(0))) === UInt(0)
 @test isempty(range(0, length=UInt(0)))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2866,7 +2866,7 @@ end
     r = 'a':'z'
     r2 = 'α':2:'ω'
     r3 = StepRangeLen('a',3,10)
-    @test Base.RangeStepStyle(r) === RangeStepRegular()
-    @test Base.RangeStepStyle(r2) === RangeStepRegular()
-    @test Base.RangeStepStyle(r3) === RangeStepRegular()
+    @test Base.RangeStepStyle(r) === Base.RangeStepRegular()
+    @test Base.RangeStepStyle(r2) === Base.RangeStepRegular()
+    @test Base.RangeStepStyle(r3) === Base.RangeStepRegular()
 end


### PR DESCRIPTION
Fixes #35203, and closes #35278 which is a different solution. This `findfirst` method was added in #30778. 

Edit, 2021: another PR #35278 special-cased some dates to avoid the fast method. New PR #40552 instead restricts it to only numbers. This PR uses an existing trait, which I believe correctly marks the distinction between regular and irregular dates, and marks unknown cases `RangeStepIrregular`, including many floating point ranges.

Earlier:

I'm not completely sure about things like 
```
RangeStepStyle(::Type{<:StepRangeLen{<:Any,<:Any,<:Integer}}) = RangeStepRegular()
```
and how
```
Date(2019):Month(1):Date(2021) isa StepRange
```
fits with "The step between each element is constant" here. So someone who does understand should check that this isn't wrong. 