### PR TITLE
Support `do` block with `@code_...` macros

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -51,11 +51,6 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
                 return Expr(:call, fcn, f,
                             Expr(:call, typesof, map(esc, ex0.args)...))
             end
-        elseif ex0.head === :do && Meta.isexpr(get(ex0.args, 1, nothing), :call)
-            f = ex0.args[1].args[1]
-            args = [[ex0.args[2]]; ex0.args[1].args[2:end]]
-            return Expr(:call, fcn, esc(f), Expr(:call, typesof, map(esc, args)...),
-                        kws...)
         else
             for (head, f) in (:ref => Base.getindex, :hcat => Base.hcat, :(.) => Base.getproperty, :vect => Base.vect, Symbol("'") => Base.adjoint, :typed_hcat => Base.typed_hcat, :string => string)
                 if ex0.head === head

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -51,6 +51,11 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
                 return Expr(:call, fcn, f,
                             Expr(:call, typesof, map(esc, ex0.args)...))
             end
+        elseif ex0.head === :do && Meta.isexpr(get(ex0.args, 1, nothing), :call)
+            f = ex0.args[1].args[1]
+            args = [[ex0.args[2]]; ex0.args[1].args[2:end]]
+            return Expr(:call, fcn, esc(f), Expr(:call, typesof, map(esc, args)...),
+                        kws...)
         else
             for (head, f) in (:ref => Base.getindex, :hcat => Base.hcat, :(.) => Base.getproperty, :vect => Base.vect, Symbol("'") => Base.adjoint, :typed_hcat => Base.typed_hcat, :string => string)
                 if ex0.head === head

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -90,6 +90,9 @@ Base.getproperty(t::T1234321, ::Symbol) = "foo"
 Base.setproperty!(t::T1234321, ::Symbol, ::Symbol) = "foo"
 @test (@code_typed T1234321(1).f = :foo).second == String
 
+# Make sure `do` block works with `@code_...` macros
+@test (@code_typed map(1:1) do x; x; end).second == Vector{Int}
+
 module ImportIntrinsics15819
 # Make sure changing the lookup path of an intrinsic doesn't break
 # the heuristic for type instability warning.

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -92,6 +92,7 @@ Base.setproperty!(t::T1234321, ::Symbol, ::Symbol) = "foo"
 
 # Make sure `do` block works with `@code_...` macros
 @test (@code_typed map(1:1) do x; x; end).second == Vector{Int}
+@test (@code_typed open(`cat`; read=true) do _; 1; end).second == Int
 
 module ImportIntrinsics15819
 # Make sure changing the lookup path of an intrinsic doesn't break


### PR DESCRIPTION
This PR makes invocations like `@code_typed map(1:1) do x; x; end` work.