### PR TITLE
Fix offset when widening collections

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -696,7 +696,8 @@ end
 function setindex_widen_up_to(dest::AbstractArray{T}, el, i) where T
     @_inline_meta
     new = similar(dest, promote_typejoin(T, typeof(el)))
-    copyto!(new, firstindex(new), dest, firstindex(dest), i-1)
+    f = first(LinearIndices(dest))
+    copyto!(new, first(LinearIndices(new)), dest, f, i-f)
     @inbounds new[i] = el
     return new
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -231,76 +231,9 @@ mutable struct TestAbstractArray end
 
 ## Tests for the abstract array interfaces with minimally defined array types
 
-# A custom linear fast array type with 24 elements that doesn't rely upon Array storage
-mutable struct T24Linear{T,N,dims} <: AbstractArray{T,N}
-    v1::T;  v2::T;  v3::T;  v4::T;  v5::T;  v6::T;  v7::T;  v8::T
-    v9::T;  v10::T; v11::T; v12::T; v13::T; v14::T; v15::T; v16::T
-    v17::T; v18::T; v19::T; v20::T; v21::T; v22::T; v23::T; v24::T
-    T24Linear{T,N,d}() where {T,N,d} =
-        (prod(d) == 24 || throw(DimensionMismatch("T24Linear must have 24 elements")); new())
-    function T24Linear{T,N,d}(v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,
-                              v13,v14,v15,v16,v17,v18,v19,v20,v21,v22,v23,v24) where {T,N,d}
-        prod(d) == 24 || throw(DimensionMismatch("T24Linear must have 24 elements"))
-        new(v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,v17,v18,v19,v20,v21,v22,v23,v24)
-    end
+if !isdefined(@__MODULE__, :T24Linear)
+    include("testhelpers/arrayindexingtypes.jl")
 end
-
-T24Linear(::Type{T}, dims::Int...) where T = T24Linear(T, dims)
-T24Linear(::Type{T}, dims::NTuple{N,Int}) where {T,N} = T24Linear{T,N,dims}()
-
-T24Linear(     X::AbstractArray{T,N}) where {T,N  } = T24Linear{T,N}(X)
-T24Linear{T  }(X::AbstractArray{_,N}) where {T,N,_} = T24Linear{T,N}(X)
-T24Linear{T,N}(X::AbstractArray     ) where {T,N  } = T24Linear{T,N,size(X)}(X...)
-
-Base.size(::T24Linear{T,N,dims}) where {T,N,dims} = dims
-import Base: IndexLinear
-Base.IndexStyle(::Type{A}) where {A<:T24Linear} = IndexLinear()
-Base.getindex(A::T24Linear, i::Int) = getfield(A, i)
-Base.setindex!(A::T24Linear{T}, v, i::Int) where {T} = setfield!(A, i, convert(T, v))
-
-# A custom linear slow sparse-like array that relies upon Dict for its storage
-struct TSlow{T,N} <: AbstractArray{T,N}
-    data::Dict{NTuple{N,Int}, T}
-    dims::NTuple{N,Int}
-end
-TSlow(::Type{T}, dims::Int...) where {T} = TSlow(T, dims)
-TSlow(::Type{T}, dims::NTuple{N,Int}) where {T,N} = TSlow{T,N}(Dict{NTuple{N,Int}, T}(), dims)
-
-TSlow{T,N}(X::TSlow{T,N})         where {T,N  } = X
-TSlow(     X::AbstractArray{T,N}) where {T,N  } = TSlow{T,N}(X)
-TSlow{T  }(X::AbstractArray{_,N}) where {T,N,_} = TSlow{T,N}(X)
-TSlow{T,N}(X::AbstractArray     ) where {T,N  } = begin
-    A = TSlow(T, size(X))
-    for I in CartesianIndices(size(X))
-        A[I.I...] = X[I.I...]
-    end
-    A
-end
-
-Base.size(A::TSlow) = A.dims
-Base.similar(A::TSlow, ::Type{T}, dims::Dims) where {T} = TSlow(T, dims)
-import Base: IndexCartesian
-Base.IndexStyle(::Type{A}) where {A<:TSlow} = IndexCartesian()
-# Until #11242 is merged, we need to define each dimension independently
-Base.getindex(A::TSlow{T,0}) where {T} = get(A.data, (), zero(T))
-Base.getindex(A::TSlow{T,1}, i1::Int) where {T} = get(A.data, (i1,), zero(T))
-Base.getindex(A::TSlow{T,2}, i1::Int, i2::Int) where {T} = get(A.data, (i1,i2), zero(T))
-Base.getindex(A::TSlow{T,3}, i1::Int, i2::Int, i3::Int) where {T} =
-    get(A.data, (i1,i2,i3), zero(T))
-Base.getindex(A::TSlow{T,4}, i1::Int, i2::Int, i3::Int, i4::Int) where {T} =
-    get(A.data, (i1,i2,i3,i4), zero(T))
-Base.getindex(A::TSlow{T,5}, i1::Int, i2::Int, i3::Int, i4::Int, i5::Int) where {T} =
-    get(A.data, (i1,i2,i3,i4,i5), zero(T))
-
-Base.setindex!(A::TSlow{T,0}, v) where {T} = (A.data[()] = v)
-Base.setindex!(A::TSlow{T,1}, v, i1::Int) where {T} = (A.data[(i1,)] = v)
-Base.setindex!(A::TSlow{T,2}, v, i1::Int, i2::Int) where {T} = (A.data[(i1,i2)] = v)
-Base.setindex!(A::TSlow{T,3}, v, i1::Int, i2::Int, i3::Int) where {T} =
-    (A.data[(i1,i2,i3)] = v)
-Base.setindex!(A::TSlow{T,4}, v, i1::Int, i2::Int, i3::Int, i4::Int) where {T} =
-    (A.data[(i1,i2,i3,i4)] = v)
-Base.setindex!(A::TSlow{T,5}, v, i1::Int, i2::Int, i3::Int, i4::Int, i5::Int) where {T} =
-    (A.data[(i1,i2,i3,i4,i5)] = v)
 
 const can_inline = Base.JLOptions().can_inline != 0
 function test_scalar_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where T

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -9,6 +9,10 @@ using Statistics
 
 const OAs_name = join(fullname(OffsetArrays), ".")
 
+if !isdefined(@__MODULE__, :T24Linear)
+    include("testhelpers/arrayindexingtypes.jl")
+end
+
 let
 # Basics
 v0 = rand(4)
@@ -336,6 +340,9 @@ am = map(identity, a)
 @test isequal(map(!, OffsetArray([true,missing],2)), OffsetArray([false, missing], 2))
 @test isequal(map(!, OffsetArray([true missing; false true], 2, -1)), OffsetArray([false missing; true false], 2, -1))
 P = view([true missing; false true; true false], 1:2:3, :)
+@test IndexStyle(P) === IndexCartesian()
+@test isequal(map(!, OffsetArray(P, 2, -1)), OffsetArray(map(!, P), 2, -1))
+P = TSlow([true missing; false true])
 @test IndexStyle(P) === IndexCartesian()
 @test isequal(map(!, OffsetArray(P, 2, -1)), OffsetArray(map(!, P), 2, -1))
 

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -332,6 +332,13 @@ am = map(identity, a)
 @test isa(am, OffsetArray)
 @test am == a
 
+# https://github.com/JuliaArrays/OffsetArrays.jl/issues/106
+@test isequal(map(!, OffsetArray([true,missing],2)), OffsetArray([false, missing], 2))
+@test isequal(map(!, OffsetArray([true missing; false true], 2, -1)), OffsetArray([false missing; true false], 2, -1))
+P = view([true missing; false true; true false], 1:2:3, :)
+@test IndexStyle(P) === IndexCartesian()
+@test isequal(map(!, OffsetArray(P, 2, -1)), OffsetArray(map(!, P), 2, -1))
+
 # dropdims
 a0 = rand(1,1,8,8,1)
 a = OffsetArray(a0, (-1,2,3,4,5))

--- a/test/testhelpers/arrayindexingtypes.jl
+++ b/test/testhelpers/arrayindexingtypes.jl
@@ -1,0 +1,54 @@
+## Tests for the abstract array interfaces and operations with arrays
+## with different indexing rules
+
+# A custom linear fast array type with 24 elements that doesn't rely upon Array storage
+mutable struct T24Linear{T,N,dims} <: AbstractArray{T,N}
+    v1::T;  v2::T;  v3::T;  v4::T;  v5::T;  v6::T;  v7::T;  v8::T
+    v9::T;  v10::T; v11::T; v12::T; v13::T; v14::T; v15::T; v16::T
+    v17::T; v18::T; v19::T; v20::T; v21::T; v22::T; v23::T; v24::T
+    T24Linear{T,N,d}() where {T,N,d} =
+        (prod(d) == 24 || throw(DimensionMismatch("T24Linear must have 24 elements")); new())
+    function T24Linear{T,N,d}(v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,
+                              v13,v14,v15,v16,v17,v18,v19,v20,v21,v22,v23,v24) where {T,N,d}
+        prod(d) == 24 || throw(DimensionMismatch("T24Linear must have 24 elements"))
+        new(v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,v17,v18,v19,v20,v21,v22,v23,v24)
+    end
+end
+
+T24Linear(::Type{T}, dims::Int...) where T = T24Linear(T, dims)
+T24Linear(::Type{T}, dims::NTuple{N,Int}) where {T,N} = T24Linear{T,N,dims}()
+
+T24Linear(     X::AbstractArray{T,N}) where {T,N  } = T24Linear{T,N}(X)
+T24Linear{T  }(X::AbstractArray{_,N}) where {T,N,_} = T24Linear{T,N}(X)
+T24Linear{T,N}(X::AbstractArray     ) where {T,N  } = T24Linear{T,N,size(X)}(X...)
+
+Base.size(::T24Linear{T,N,dims}) where {T,N,dims} = dims
+import Base: IndexLinear
+Base.IndexStyle(::Type{A}) where {A<:T24Linear} = IndexLinear()
+Base.getindex(A::T24Linear, i::Int) = getfield(A, i)
+Base.setindex!(A::T24Linear{T}, v, i::Int) where {T} = setfield!(A, i, convert(T, v))
+
+# A custom linear slow sparse-like array that relies upon Dict for its storage
+struct TSlow{T,N} <: AbstractArray{T,N}
+    data::Dict{NTuple{N,Int}, T}
+    dims::NTuple{N,Int}
+end
+TSlow(::Type{T}, dims::Int...) where {T} = TSlow(T, dims)
+TSlow(::Type{T}, dims::NTuple{N,Int}) where {T,N} = TSlow{T,N}(Dict{NTuple{N,Int}, T}(), dims)
+
+TSlow{T,N}(X::TSlow{T,N})         where {T,N  } = X
+TSlow(     X::AbstractArray{T,N}) where {T,N  } = TSlow{T,N}(X)
+TSlow{T  }(X::AbstractArray{_,N}) where {T,N,_} = TSlow{T,N}(X)
+TSlow{T,N}(X::AbstractArray     ) where {T,N  } = begin
+    A = TSlow(T, size(X))
+    for I in CartesianIndices(X)
+        A[Tuple(I)...] = X[Tuple(I)...]
+    end
+    A
+end
+
+Base.size(A::TSlow) = A.dims
+Base.similar(A::TSlow, ::Type{T}, dims::Dims) where {T} = TSlow(T, dims)
+Base.IndexStyle(::Type{A}) where {A<:TSlow} = IndexCartesian()
+Base.getindex(A::TSlow{T,N}, i::Vararg{Int,N}) where {T,N} = get(A.data, i, zero(T))
+Base.setindex!(A::TSlow{T,N}, v, i::Vararg{Int,N}) where {T,N} = (A.data[i] = v)


### PR DESCRIPTION
The final argument of `copyto!` is a count; subtracting 1 from the current index works only if indexing starts at 1. This also explicitly uses `LinearIndices` just as occurs in [upstream callers](https://github.com/JuliaLang/julia/blob/b637cb786a644979f6ad2752e11206d08c8ce683/base/array.jl#L686).
