### PR TITLE
In open(f, ...), call flush before calling `close`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -296,6 +296,7 @@ function open(f::Function, args...; kwargs...)
     io = open(args...; kwargs...)
     try
         f(io)
+        flush(io)
     finally
         close(io)
     end

--- a/base/io.jl
+++ b/base/io.jl
@@ -295,8 +295,9 @@ julia> rm("myfile.txt")
 function open(f::Function, args...; kwargs...)
     io = open(args...; kwargs...)
     try
-        f(io)
+        v = f(io)
         flush(io)
+        return v
     finally
         close(io)
     end


### PR DESCRIPTION
In #35217, I noticed that if we call `close` on an IOStream, but the device
that has the underlying file is full, we silently truncate the file without
error. To remidy that, introduce an explicit flush call before closing the
file. This should either succeed and reflect the changes on disk, or fail
and throw an appropriate error.