### PR TITLE
Use parent for similar(::PermutedDimsArray)

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -46,8 +46,10 @@ function PermutedDimsArray(data::AbstractArray{T,N}, perm) where {T,N}
 end
 
 Base.parent(A::PermutedDimsArray) = A.parent
-Base.size(A::PermutedDimsArray{T,N,perm}) where {T,N,perm}    = genperm(size(parent(A)),    perm)
+Base.size(A::PermutedDimsArray{T,N,perm}) where {T,N,perm} = genperm(size(parent(A)), perm)
 Base.axes(A::PermutedDimsArray{T,N,perm}) where {T,N,perm} = genperm(axes(parent(A)), perm)
+
+Base.similar(A::PermutedDimsArray, T::Type, dims::Base.Dims) = similar(parent(A), T, dims)
 
 Base.unsafe_convert(::Type{Ptr{T}}, A::PermutedDimsArray{T}) where {T} = Base.unsafe_convert(Ptr{T}, parent(A))
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -4,11 +4,9 @@
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
-using SparseArrays
+isdefined(Main, :TSlow) || @eval Main include("testhelpers/arrayindexingtypes.jl")
 
-if !isdefined(@__MODULE__, :T24Linear)
-     include("testhelpers/arrayindexingtypes.jl")
- end
+using SparseArrays
 
 using Random, LinearAlgebra
 using Dates

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3,7 +3,12 @@
 # Array test
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
+
 using SparseArrays
+
+if !isdefined(@__MODULE__, :T24Linear)
+     include("testhelpers/arrayindexingtypes.jl")
+ end
 
 using Random, LinearAlgebra
 using Dates
@@ -683,6 +688,13 @@ end
     y = [0, 0, 0, 0]
     copyto!(y, x)
     @test y == [1, 2, 3, 4]
+
+    # similar, https://github.com/JuliaLang/julia/pull/35304
+    x = PermutedDimsArray([1 2; 3 4], (2, 1))
+    @test similar(x, 3,3) isa Array
+    z = TSlow([1 2; 3 4])
+    x_slow = PermutedDimsArray(z, (2, 1))
+    @test similar(x_slow, 3,3) isa TSlow
 end
 
 @testset "circshift" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -4,7 +4,7 @@
 isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
 using .Main.OffsetArrays
 
-isdefined(Main, :TSlow) || @eval Main include("testhelpers/arrayindexingtypes.jl")
+isdefined(@__MODULE__, :T24Linear) || include("testhelpers/arrayindexingtypes.jl")
 
 using SparseArrays
 


### PR DESCRIPTION
This ensures that `similar` matches the underlying storage of a `PermutedDimsArray` wrapper, as happens e.g. for `Transpose`, views:
```julia
julia> using SparseArrays

julia> similar(transpose(sparse(ones(3,3))))
3×3 SparseMatrixCSC{Float64,Int64} with 0 stored entries

julia> similar(view(sparse(ones(3,3)), 1,:), 4,4)
4×4 SparseMatrixCSC{Float64,Int64} with 0 stored entries

julia> similar(PermutedDimsArray(sparse(ones(3,3)), (2,1)))
3×3 Array{Float64,2}:
 2.19322e-314  2.19306e-314  2.19306e-314
 0.0           0.0           0.0
 2.19307e-314  2.19307e-314  2.19307e-314
```
I'm not sure how to add a test for this, and don't see any in `test/subarray.jl` for views either. Can I load SparseArrays in the tests for Base?

Fixes https://github.com/JuliaGPU/CuArrays.jl/issues/658