### PR TITLE
fix #35295, typo in change to `clipboard` on linux

### DIFF
--- a/stdlib/InteractiveUtils/src/clipboard.jl
+++ b/stdlib/InteractiveUtils/src/clipboard.jl
@@ -67,7 +67,7 @@ elseif Sys.islinux() || Sys.KERNEL === :FreeBSD
     end
     function clipboard()
         c = clipboardcmd()
-        cmd = _clipboardcmds_paste[c]
+        cmd = _clipboard_paste[c]
         return read(pipeline(cmd, stderr=stderr), String)
     end
 


### PR DESCRIPTION
fix #35295

Obviously the problem here is that we're not running the test for this on linux. I'll try enabling it here to see if it works, or if we can get it working.