### PR TITLE
propagate errors from `flush` within `close`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,8 @@ Standard library changes
   order from `order` is used to compare the values of `by(element)`. In the latter case,
   any order different from `Forward` or `Reverse` will raise an error about the
   ambiguity.
+* `close` on a file (`IOStream`) can now throw an exception if an error occurs when trying
+  to flush buffered data to disk ([#35303]).
 
 #### LinearAlgebra
 * The BLAS submodule now supports the level-2 BLAS subroutine `hpmv!` ([#34211]).

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -648,17 +648,21 @@ int ios_flush(ios_t *s)
     return 0;
 }
 
-void ios_close(ios_t *s)
+int ios_close(ios_t *s)
 {
-    ios_flush(s);
-    if (s->fd != -1 && s->ownfd)
-        close(s->fd);
+    int err = ios_flush(s);
+    if (s->fd != -1 && s->ownfd) {
+        int err2 = close(s->fd);
+        if (err2 != 0)
+            err = err2;
+    }
     s->fd = -1;
     if (s->buf!=NULL && s->ownbuf && s->buf!=&s->local[0]) {
         LLT_FREE(s->buf);
     }
     s->buf = NULL;
     s->size = s->maxsize = s->bpos = 0;
+    return err;
 }
 
 int ios_isopen(ios_t *s)

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -93,7 +93,7 @@ JL_DLLEXPORT int ios_trunc(ios_t *s, size_t size) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_eof(ios_t *s);
 JL_DLLEXPORT int ios_eof_blocking(ios_t *s);
 JL_DLLEXPORT int ios_flush(ios_t *s);
-JL_DLLEXPORT void ios_close(ios_t *s);
+JL_DLLEXPORT int ios_close(ios_t *s);
 JL_DLLEXPORT int ios_isopen(ios_t *s);
 JL_DLLEXPORT char *ios_take_buffer(ios_t *s, size_t *psize);  // release buffer to caller
 // set buffer space to use


### PR DESCRIPTION
Alternative to #35303.