### PR TITLE
fix latest LLVM 11 compatibility issues

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -236,7 +236,9 @@ static GlobalVariable *emit_plt_thunk(
     SmallVector<Value*, 16> args;
     for (Function::arg_iterator arg = plt->arg_begin(), arg_e = plt->arg_end(); arg != arg_e; ++arg)
         args.push_back(&*arg);
-    CallInst *ret = irbuilder.CreateCall(ptr, ArrayRef<Value*>(args));
+    CallInst *ret = irbuilder.CreateCall(
+        cast<FunctionType>(ptr->getType()->getPointerElementType()),
+        ptr, ArrayRef<Value*>(args));
     ret->setAttributes(attrs);
     if (cc != CallingConv::C)
         ret->setCallingConv(cc);
@@ -1029,7 +1031,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
         std::stringstream name;
         name << "jl_llvmcall" << llvmcallnumbering++;
         f->setName(name.str());
-        f = cast<Function>(prepare_call(function_proto(f)));
+        f = cast<Function>(prepare_call(function_proto(f)).getCallee());
     }
     else {
         f->setLinkage(GlobalValue::LinkOnceODRLinkage);
@@ -1710,11 +1712,19 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
 
         ctx.builder.CreateMemCpy(
                 ctx.builder.CreateIntToPtr(destp, T_pint8),
+#if JL_LLVM_VERSION >= 110000
+                MaybeAlign(1),
+#else
                 1,
+#endif
                 ctx.builder.CreateIntToPtr(
                     emit_unbox(ctx, T_size, src, (jl_value_t*)jl_voidpointer_type),
                     T_pint8),
+#if JL_LLVM_VERSION >= 110000
+                MaybeAlign(0),
+#else
                 0,
+#endif
                 emit_unbox(ctx, T_size, n, (jl_value_t*)jl_ulong_type),
                 false);
         JL_GC_POP();

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -900,8 +900,13 @@ static void jl_dump_asm_internal(
             if (pass != 0 && nextLineAddr != (uint64_t)-1 && Index + Fptr + slide == nextLineAddr) {
                 if (di_ctx) {
                     std::string buf;
-                    DILineInfoSpecifier infoSpec(DILineInfoSpecifier::FileLineInfoKind::Default,
-                                                 DILineInfoSpecifier::FunctionNameKind::ShortName);
+                    DILineInfoSpecifier infoSpec(
+#if JL_LLVM_VERSION >= 110000
+                        DILineInfoSpecifier::FileLineInfoKind::RawValue,
+#else
+                        DILineInfoSpecifier::FileLineInfoKind::Default,
+#endif
+                        DILineInfoSpecifier::FunctionNameKind::ShortName);
                     DIInliningInfo dbg = di_ctx->getInliningInfoForAddress(makeAddress(Section, Index + Fptr + slide), infoSpec);
                     if (dbg.getNumberOfFrames()) {
                         dbgctx.emit_lineinfo(buf, dbg);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -418,7 +418,11 @@ void JuliaOJIT::DebugObjectRegistrar::registerObject(RTDyldObjHandleT H, const O
     // record all of the exported symbols defined in this object
     // in the primary hash table for the enclosing JIT
     for (auto &Symbol : Object->symbols()) {
-        auto Flags = Symbol.getFlags();
+#if JL_LLVM_VERSION >= 110000
+        uint32_t Flags = Symbol.getFlags().get();
+#else
+        uint32_t Flags = Symbol.getFlags();
+#endif
         if (Flags & object::BasicSymbolRef::SF_Undefined)
             continue;
         if (!(Flags & object::BasicSymbolRef::SF_Exported))

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -507,22 +507,26 @@ static std::pair<Value*,int> FindBaseValue(const State &S, Value *V, bool UseCac
             // so we don't need to lift these operations, but we do need to check if it's loaded and continue walking the base pointer
             if (II->getIntrinsicID() == Intrinsic::masked_load ||
                 II->getIntrinsicID() == Intrinsic::masked_gather) {
-                if (auto PtrT = dyn_cast<PointerType>(II->getType()->getVectorElementType())) {
-                    if (PtrT->getAddressSpace() == AddressSpace::Loaded) {
-                        assert(isa<UndefValue>(II->getOperand(3)) && "unimplemented");
-                        CurrentV = II->getOperand(0);
-                        if (II->getIntrinsicID() == Intrinsic::masked_load) {
-                            fld_idx = -1;
-                            if (!isSpecialPtr(CurrentV->getType())) {
-                                CurrentV = ConstantPointerNull::get(Type::getInt8PtrTy(V->getContext()));
-                            }
-                        } else {
-                            if (!isSpecialPtr(CurrentV->getType()->getVectorElementType())) {
-                                CurrentV = ConstantPointerNull::get(Type::getInt8PtrTy(V->getContext()));
+                if (auto VTy = dyn_cast<VectorType>(II->getType())) {
+                    if (auto PtrT = dyn_cast<PointerType>(VTy->getElementType())) {
+                        if (PtrT->getAddressSpace() == AddressSpace::Loaded) {
+                            assert(isa<UndefValue>(II->getOperand(3)) && "unimplemented");
+                            CurrentV = II->getOperand(0);
+                            if (II->getIntrinsicID() == Intrinsic::masked_load) {
                                 fld_idx = -1;
+                                if (!isSpecialPtr(CurrentV->getType())) {
+                                    CurrentV = ConstantPointerNull::get(Type::getInt8PtrTy(V->getContext()));
+                                }
+                            } else {
+                                if (auto VTy2 = dyn_cast<VectorType>(CurrentV->getType())) {
+                                    if (!isSpecialPtr(VTy2->getElementType())) {
+                                        CurrentV = ConstantPointerNull::get(Type::getInt8PtrTy(V->getContext()));
+                                        fld_idx = -1;
+                                    }
+                                }
                             }
+                            continue;
                         }
-                        continue;
                     }
                 }
                 // In general a load terminates a walk
@@ -625,8 +629,8 @@ void LateLowerGCFrame::LiftSelect(State &S, SelectInst *SI) {
     }
     std::vector<int> Numbers;
     unsigned NumRoots = 1;
-    if (isa<VectorType>(SI->getType()))
-        Numbers.resize(SI->getType()->getVectorNumElements(), -1);
+    if (auto VTy = dyn_cast<VectorType>(SI->getType()))
+        Numbers.resize(VTy->getNumElements(), -1);
     else
         assert(isa<PointerType>(SI->getType()) && "unimplemented");
     assert(!isTrackedValue(SI));
@@ -678,12 +682,14 @@ void LateLowerGCFrame::LiftSelect(State &S, SelectInst *SI) {
         else
             Numbers[i] = Number;
     }
-    if (isa<VectorType>(SI->getType()) && NumRoots != Numbers.size()) {
-        // broadcast the scalar root number to fill the vector
-        assert(NumRoots == 1);
-        int Number = Numbers[0];
-        Numbers.resize(0);
-        Numbers.resize(SI->getType()->getVectorNumElements(), Number);
+    if (auto VTy = dyn_cast<VectorType>(SI->getType())) {
+        if (NumRoots != Numbers.size()) {
+            // broadcast the scalar root number to fill the vector
+            assert(NumRoots == 1);
+            int Number = Numbers[0];
+            Numbers.resize(0);
+            Numbers.resize(VTy->getNumElements(), Number);
+        }
     }
     if (!isa<PointerType>(SI->getType()))
         S.AllCompositeNumbering[SI] = Numbers;
@@ -698,8 +704,8 @@ void LateLowerGCFrame::LiftPhi(State &S, PHINode *Phi) {
     SmallVector<PHINode *, 2> lifted;
     std::vector<int> Numbers;
     unsigned NumRoots = 1;
-    if (isa<VectorType>(Phi->getType())) {
-        NumRoots = Phi->getType()->getVectorNumElements();
+    if (auto VTy = dyn_cast<VectorType>(Phi->getType())) {
+        NumRoots = VTy->getNumElements();
         Numbers.resize(NumRoots);
     }
     else {
@@ -1333,17 +1339,19 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                     }
                     if (II->getIntrinsicID() == Intrinsic::masked_load ||
                         II->getIntrinsicID() == Intrinsic::masked_gather) {
-                        if (auto PtrT = dyn_cast<PointerType>(II->getType()->getVectorElementType())) {
-                            if (isSpecialPtr(PtrT)) {
-                                // LLVM sometimes tries to materialize these operations with undefined pointers in our non-integral address space.
-                                // Hopefully LLVM didn't already propagate that information and poison our users. Set those to NULL now.
-                                Value *passthru = II->getArgOperand(3);
-                                if (isa<UndefValue>(passthru)) {
-                                    II->setArgOperand(3, Constant::getNullValue(passthru->getType()));
-                                }
-                                if (PtrT->getAddressSpace() == AddressSpace::Loaded) {
-                                    // These are not real defs
-                                    continue;
+                        if (auto VTy = dyn_cast<VectorType>(II->getType())) {
+                            if (auto PtrT = dyn_cast<PointerType>(VTy->getElementType())) {
+                                if (isSpecialPtr(PtrT)) {
+                                    // LLVM sometimes tries to materialize these operations with undefined pointers in our non-integral address space.
+                                    // Hopefully LLVM didn't already propagate that information and poison our users. Set those to NULL now.
+                                    Value *passthru = II->getArgOperand(3);
+                                    if (isa<UndefValue>(passthru)) {
+                                        II->setArgOperand(3, Constant::getNullValue(passthru->getType()));
+                                    }
+                                    if (PtrT->getAddressSpace() == AddressSpace::Loaded) {
+                                        // These are not real defs
+                                        continue;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
- `CompositeType` class has been removed
- `FileLineInfoSpecifier::Default` has been renamed to `RawValue`

@vchuravy