### PR TITLE
Improve `eps` documentation for `TimeType`s

### DIFF
--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -374,17 +374,32 @@ calendar(dt::DateTime) = ISOCalendar
 calendar(dt::Date) = ISOCalendar
 
 """
-    eps(::DateTime) -> Millisecond
-    eps(::Date) -> Day
-    eps(::Time) -> Nanosecond
+    eps(::Type{DateTime}) -> Millisecond
+    eps(::Type{Date}) -> Day
+    eps(::Type{Time}) -> Nanosecond
+    eps(::TimeType) -> Period
 
-Returns `Millisecond(1)` for `DateTime` values, `Day(1)` for `Date` values, and `Nanosecond(1)` for `Time` values.
+Return the smallest unit value supported by the `TimeType`.
+
+# Examples
+```jldoctest
+julia> eps(DateTime)
+1 millsecond
+
+julia> eps(Date)
+1 day
+
+julia> eps(Time)
+1 nanosecond
+```
 """
-Base.eps
+Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, TimeType})
 
-Base.eps(dt::DateTime) = Millisecond(1)
-Base.eps(dt::Date) = Day(1)
-Base.eps(t::Time) = Nanosecond(1)
+Base.eps(::Type{DateTime}) = Millisecond(1)
+Base.eps(::Type{Date}) = Day(1)
+Base.eps(::Type{Time}) = Nanosecond(1)
+Base.eps(::T) where T <: TimeType = eps(T)::Period
+
 
 Base.typemax(::Union{DateTime, Type{DateTime}}) = DateTime(146138512, 12, 31, 23, 59, 59)
 Base.typemin(::Union{DateTime, Type{DateTime}}) = DateTime(-146138511, 1, 1, 0, 0, 0)

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -181,6 +181,9 @@ c = Dates.Time(0)
 @testset "DateTime traits" begin
     @test Dates.calendar(a) == Dates.ISOCalendar
     @test Dates.calendar(b) == Dates.ISOCalendar
+    @test eps(DateTime) == Dates.Millisecond(1)
+    @test eps(Date) == Dates.Day(1)
+    @test eps(Time) == Dates.Nanosecond(1)
     @test eps(a) == Dates.Millisecond(1)
     @test eps(b) == Dates.Day(1)
     @test eps(c) == Dates.Nanosecond(1)


### PR DESCRIPTION
Also now supports calling `eps` with `TimeType` types.