### PR TITLE
Add a line continuation digraph `\#`

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2221,3 +2221,9 @@ end
 h35201(x; k=1) = (x, k)
 f35201(c) = h35201((;c...), k=true)
 @test f35201(Dict(:a=>1,:b=>3)) === ((a=1,b=3), true)
+
+# Line contination: issues #18612 and #27533
+@test Meta.parse("[1 \\#\n 2]") == Expr(:hcat, 1, 2)
+@test Meta.parse("@f \\#\n a") == Expr(:macrocall, Symbol("@f"), LineNumberNode(1, :none), :a)
+@test Meta.isexpr(Meta.parse("@f \\#"), :incomplete)
+@test_throws ParseError("Cannot start block comment after \\#") Meta.parse("x \\#=")


### PR DESCRIPTION
Closes #18612 and #27533 by providing a two-character combination (`\#`) for line continuation.

This is based on the suggestions proposed in https://github.com/JuliaLang/julia/pull/29273#issuecomment-429228868. Modifying the implementation to use the alternative suggested character combinations (e.g. `.#`) is fairly trivial. Anything after `\#` on the same line is treated as a comment. This should largely play well with existing syntax highlighting.

Use cases:
- Applying macros to function definitions

        @foo \#
        function bar()
            ...
        end

- Breaking long macro calls

        @info "A message which could be rather long" \#
              a="something more"                     \#
              b="another thing"

- Newlines in long matrix literals:

        A = [1 2 3 4 5 \#
             6 7 8 9 10]

    (Note about the matrix literals: I agree that having huge chunks of data in your code is not a great idea. But with 16 digit numbers, even 4 or 5 columns is enough to justify a line break. These kinds of matrix literals are encountered very commonly in numerical applications, e.g. Butcher tableaux for Runge-Kutta methods).

Note: technically, `\#` is already valid syntax, so this would break something like
```
A\#
b
```
which parses as `A\b`. I think this usage is extremely rare (this should be checked with PkgEval), and the original functionality can be restored quite easily by adding a space (`A\ #`).
