### PR TITLE
Fix segfault on ill-formed module Expr

### DIFF
--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -112,7 +112,8 @@ jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     assert(ex->head == module_sym);
-    if (jl_array_len(ex->args) != 3 || !jl_is_expr(jl_exprarg(ex, 2))) {
+    if (jl_array_len(ex->args) != 3 || !jl_is_expr(jl_exprarg(ex, 2)) ||
+        !jl_array_len(((jl_expr_t *)(jl_exprarg(ex, 2)))->args)) {
         jl_error("syntax: malformed module expression");
     }
     int std_imports = (jl_exprarg(ex, 0) == jl_true);

--- a/test/core.jl
+++ b/test/core.jl
@@ -7198,3 +7198,6 @@ struct NFANode34126
 end
 
 @test repr(NFANode34126()) == "$NFANode34126(Tuple{Nothing,$NFANode34126}[])"
+
+# Issue #34544
+@test_throws ErrorException eval(Expr(:module, true, :bar, Expr(:foo)))


### PR DESCRIPTION
Fixes #34544

The original issue seemed to be more about module Expr whose third argument was an Expr with an empty `args`, so I added a check for this specific case.