### PR TITLE
Clarify that Julia requires LLVM 9+

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -166,7 +166,7 @@ downloaded (or in a few cases, included in the Julia source
 repository) and then compiled from source the first time you run
 `make`:
 
-- **[LLVM]** (6.0 + [patches](https://github.com/JuliaLang/julia/tree/master/deps/patches)) — compiler infrastructure (see [note below](#llvm)).
+- **[LLVM]** (9.0 + [patches](https://github.com/JuliaLang/julia/tree/master/deps/patches)) — compiler infrastructure (see [note below](#llvm)).
 - **[FemtoLisp]**            — packaged with Julia source, and used to implement the compiler front-end.
 - **[libuv]**  (custom fork) — portable, high-performance event-based I/O library.
 - **[OpenLibm]**             — portable libm library containing elementary math functions.


### PR DESCRIPTION
close #35339

@vchuravy Re https://github.com/JuliaLang/julia/issues/35339#issuecomment-607541369: does it make sense to mention that LLVM 9+ is required here?