### PR TITLE
Unset TMPDIR before calling tempnam in tempname

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -547,7 +547,9 @@ else # !windows
 # Obtain a temporary filename.
 function tempname(parent::AbstractString=tempdir(); cleanup::Bool=true)
     isdir(parent) || throw(ArgumentError("$(repr(parent)) is not a directory"))
-    p = ccall(:tempnam, Cstring, (Cstring, Cstring), parent, temp_prefix)
+    p = withenv("TMPDIR" => nothing) do
+        ccall(:tempnam, Cstring, (Cstring, Cstring), parent, temp_prefix)
+    end
     systemerror(:tempnam, p == C_NULL)
     s = unsafe_string(p)
     Libc.free(p)

--- a/test/file.jl
+++ b/test/file.jl
@@ -72,6 +72,15 @@ end
     @test_throws ArgumentError tempname(randstring())
 end
 
+@testset "tempname with parent and TMPDIR" begin
+    withenv("TMPDIR" => tempdir()) do
+        mktempdir() do d
+            t = tempname(d)
+            @test dirname(t) == d
+        end
+    end
+end
+
 child_eval(code::String) = eval(Meta.parse(readchomp(`$(Base.julia_cmd()) -E $code`)))
 
 @testset "mktemp/dir basic cleanup" begin


### PR DESCRIPTION
`tempnam` consults the `TMPDIR` environment variable before its argument (see [man page](https://linux.die.net/man/3/tempnam)), so if it is set the function will suddenly and quietly ignore the `parent` argument.