### PR TITLE
randsubseq docstring: remove useless collect

### DIFF
--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -132,7 +132,10 @@ julia> rng = MersenneTwister(1234);
 
 julia> S = Int64[];
 
-julia> randsubseq!(rng, S, collect(1:8), 0.3);
+julia> randsubseq!(rng, S, 1:8, 0.3)
+2-element Array{Int64,1}:
+ 7
+ 8
 
 julia> S
 2-element Array{Int64,1}:
@@ -157,7 +160,7 @@ large.) Technically, this process is known as "Bernoulli sampling" of `A`.
 ```jldoctest
 julia> rng = MersenneTwister(1234);
 
-julia> randsubseq(rng, collect(1:8), 0.3)
+julia> randsubseq(rng, 1:8, 0.3)
 2-element Array{Int64,1}:
  7
  8


### PR DESCRIPTION
And show the result of `randsubseq!`.