### PR TITLE
Reunify code for Base.include and MainInclude.include

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -363,32 +363,9 @@ end
 for m in methods(include)
     delete_method(m)
 end
-# These functions are duplicated in client.jl/include(::String) for
-# nicer stacktraces. Modifications here have to be backported there
 include(mod::Module, _path::AbstractString) = include(identity, mod, _path)
-function include(mapexpr::Function, mod::Module, _path::AbstractString)
-    path, prev = _include_dependency(mod, _path)
-    for callback in include_callbacks # to preserve order, must come before Core.include
-        invokelatest(callback, mod, path)
-    end
-    tls = task_local_storage()
-    tls[:SOURCE_PATH] = path
-    local result
-    try
-        # result = Core.include(mod, path)
-        if mapexpr === identity
-            result = ccall(:jl_load, Any, (Any, Cstring), mod, path)
-        else
-            result = ccall(:jl_load_rewrite, Any, (Any, Cstring, Any), mod, path, mapexpr)
-        end
-    finally
-        if prev === nothing
-            delete!(tls, :SOURCE_PATH)
-        else
-            tls[:SOURCE_PATH] = prev
-        end
-    end
-    return result
+function include(mapexpr::Function, mod::Module, path::AbstractString)
+    @_code_for_include(mapexpr, mod, path)
 end
 
 end_base_include = time_ns()


### PR DESCRIPTION
These are only duplicated for better stack traces, and are otherwise meant to be the same. However the code here has already started to diverge in several minor but confusing ways (#34595 etc) which is making a larger refactor related to https://github.com/JuliaLang/julia/pull/35243 more fiddly.

Factor the include bodies into a macro to improve this.

This also allows the bulk of the code to go in loading.jl which I find a little more natural.