### PR TITLE
RFC: Introduce Matrix^Matrix functionality

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -545,6 +545,22 @@ Base.:^(b::Number, A::AbstractMatrix) = exp!(log(b)*A)
 # method for ℯ to explicitly elide the log(b) multiplication
 Base.:^(::Irrational{:ℯ}, A::AbstractMatrix) = exp(A)
 
+function Base.:^(A::AbstractMatrix, B::AbstractMatrix)
+    nA1, nA2 = size(A)
+    nB1, nB2 = size(B)
+    if nA1!=nA2 || nB1!=nB2
+        throw(DimensionMismatch("matrices must be square"))
+    elseif nA1==1
+        return A[1,1]^B
+    elseif nB1==1
+        return A^B[1,1]
+    elseif nA1!=nB2
+        throw(DimensionMismatch("matrices must have same dimensionality"))
+    else
+        return exp(B*log(A))
+    end
+end
+
 ## Destructive matrix exponential using algorithm from Higham, 2008,
 ## "Functions of Matrices: Theory and Computation", SIAM
 function exp!(A::StridedMatrix{T}) where T<:BlasFloat

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -928,4 +928,13 @@ end
     @test exp(log(A2)) ≈ A2
 end
 
+@testset "Matrix^Matrix" begin
+    A = [ℯ 0; 0 ℯ]
+    B = [3 0; 0 3]
+    @test A^B ≈ A^3 ≈ ℯ^B
+    C = 2*ones(1,1)
+    @test C^B ≈ 2^B
+    @test A^C ≈ A^2
+end
+
 end # module TestDense


### PR DESCRIPTION
Given two matrices A and B, we can extend the scalar definition of exponentiation to state

`A^B = exp(B * log(A))`

provided A and B are square matrices of identical dimensionality.

