### PR TITLE
Default to not showing deprecation warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,13 @@ Language changes
 
 * The line number of function definitions is now added by the parser as an
   additional `LineNumberNode` at the start of each function body ([#35138]).
+  
+Command-line option changes
+---------------------------
+
+* Deprecation warnings are no longer shown by default. i.e. if the `--depwarn=...` flag is
+  not passed it defaults to `--depwarn=no`. ([#35362]).
+   
 
 * Color now defaults to on when stdout and stderr are TTYs ([#34347])
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,7 +66,7 @@ Language changes
   used to yield the string " a\nb", since the single space before `b` set the indent level.
   Now the result is "a\n b", since the space before `b` is no longer considered to occur
   at the start of a line. The old behavior is considered a bug ([#35001]).
-  
+
 * The line number of function definitions is now added by the parser as an
   additional `LineNumberNode` at the start of each function body ([#35138]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,16 +66,15 @@ Language changes
   used to yield the string " a\nb", since the single space before `b` set the indent level.
   Now the result is "a\n b", since the space before `b` is no longer considered to occur
   at the start of a line. The old behavior is considered a bug ([#35001]).
-
+  
 * The line number of function definitions is now added by the parser as an
   additional `LineNumberNode` at the start of each function body ([#35138]).
-  
+
 Command-line option changes
 ---------------------------
 
 * Deprecation warnings are no longer shown by default. i.e. if the `--depwarn=...` flag is
   not passed it defaults to `--depwarn=no`. ([#35362]).
-   
 
 * Color now defaults to on when stdout and stderr are TTYs ([#34347])
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -139,12 +139,12 @@ function julia_cmd(julia=joinpath(Sys.BINDIR::String, julia_exename()))
                   end
         isempty(compile) || push!(addflags, "--compile=$compile")
     end
-    let depwarn = if opts.depwarn == 0
-                      "no"
+    let depwarn = if opts.depwarn == 1
+                      "yes"
                   elseif opts.depwarn == 2
                       "error"
                   else
-                      "" # default = "yes"
+                      "" # default = "no"
                   end
         isempty(depwarn) || push!(addflags, "--depwarn=$depwarn")
     end

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -52,7 +52,7 @@ jl_options_t jl_options = { 0,    // quiet
                             1,    // debug_level [release build]
 #endif
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
-                            JL_OPTIONS_DEPWARN_ON,    // deprecation warning
+                            JL_OPTIONS_DEPWARN_OFF,    // deprecation warning
                             0,    // method overwrite warning
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -655,8 +655,8 @@ end
 include("testenv.jl")
 
 
-let flags = Cmd(replace.(test_exeflags, r"^--depwarn=.*" => "--depwarn=yes"))
-    local cmd = `$test_exename $flags deprecation_exec.jl`
+let flags = Cmd(filter(a->!occursin("depwarn", a), collect(test_exeflags)))
+    local cmd = `$test_exename $flags --depwarn=yes deprecation_exec.jl`
 
     if !success(pipeline(cmd; stdout=stdout, stderr=stderr))
         error("Deprecation test failed, cmd : $cmd")

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -654,7 +654,8 @@ end
 
 include("testenv.jl")
 
-let flags = Cmd(filter(a->!occursin("depwarn", a), collect(test_exeflags)))
+
+let flags = Cmd(replace.(test_exeflags, r"^--depwarn=.*" => "--depwarn=yes"))
     local cmd = `$test_exename $flags deprecation_exec.jl`
 
     if !success(pipeline(cmd; stdout=stdout, stderr=stderr))


### PR DESCRIPTION
All julia packages  follow SemVer.
That means that that adding a deprecation is nonbreaking,
and removing the thing you deprecated is breaking.

As such consider if I was a package author. Where my package's current release is v1.x.
consider if I am renaming `foo(args...)` to the new `generalized_foo(true, args....)` in v1.5.0
That means I will not bne removing the old `foo` function til v2.0.0

People using my package have Compat set as `="^1"`
there is nothing wrong with them continuing to use the `foo` function forever, as long as they do not want to use v2 of my package.
Indeed there is some advantages to continuing using `foo` since if they want to swap to `generalized_foo`, they need to restrict their compat to `="^1.5"`, which might break compatibility with another package they are using with that might have restricted  my package to `="~1.1"` (idk why, maybe they need everything auditted)

People get really frustrated about deprecation warnings, even to the exent of [making PRs to remove them](https://github.com/JuliaCollections/DataStructures.jl/pull/603).
**And not unreasonably so** -- their code works fine, why are they getting spammed with this warning message? A warning message that makes there code much slower infact.
And there code is going to keep working fine since they have the compat bounds set.

One option is to hold off all deprecation warning until the last release before v2.0.0,
say v1.9.0.
However, that just delays the problem.
Even once v2 is out, I don't want to force people to upgrade, if v1, still works fine then that is great.
So I don't want them to do `up` with there compat still set to `="^1"`, and for them toi get the 1.9 release added, and then get spammed with deprecation warnings.
They should be able to upgrade at there own pace, when they are ready.


I personally just set `--depwarn=no` all the time, except when specifically wanting the warnings because I am upgrading on of my dependencies.
and I think everyone else should to.
Thus this PR to change the default

 cc @mlubin @sbromberger 