### PR TITLE
Fix ASAN-enabled build

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -641,7 +641,7 @@ else
 SANITIZE_OPTS := -fsanitize=address -mllvm -asan-stack=0
 SANITIZE_LDFLAGS := -fsanitize=address
 endif
-JCXXFLAGS += $(SANITIZE_OPTS) -DNDEBUG
+JCXXFLAGS += $(SANITIZE_OPTS)
 JCFLAGS += $(SANITIZE_OPTS)
 JLDFLAGS += $(SANITIZE_LDFLAGS)
 endif

--- a/Make.inc
+++ b/Make.inc
@@ -641,7 +641,7 @@ else
 SANITIZE_OPTS := -fsanitize=address -mllvm -asan-stack=0
 SANITIZE_LDFLAGS := -fsanitize=address
 endif
-JCXXFLAGS += $(SANITIZE_OPTS)
+JCXXFLAGS += $(SANITIZE_OPTS) -DNDEBUG
 JCFLAGS += $(SANITIZE_OPTS)
 JLDFLAGS += $(SANITIZE_LDFLAGS)
 endif

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -22,7 +22,7 @@
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Vectorize.h>
 #if defined(JL_ASAN_ENABLED)
-#include <llvm/Transforms/Instrumentation.h>
+#include <llvm/Transforms/Instrumentation/AddressSanitizer.h>
 #endif
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>


### PR DESCRIPTION
I have no idea if it is the right fix (esp. `NDEBUG`) but this is what I needed to do to build `julia` with ASAN #35341. I'm sending a patch just in case it's an OK fix.

With this patch, I can run build `julia` with: `ASAN_OPTIONS=detect_leaks=0:allow_user_segv_handler=1 make CC=$PWD/usr/tools/clang CXX=$PWD/usr/tools/clang LLVM_CONFIG=$PWD/usr/tools/llvm-config USECLANG=1 SANITIZE=1`

cc @vchuravy @maleadt @Keno

close #35338
