### PR TITLE
Use relative links in doc/build/README.md

### DIFF
--- a/doc/build/README.md
+++ b/doc/build/README.md
@@ -7,19 +7,19 @@
 
 This directory contains various details related to building Julia:
 
-* [Detailed build instructions](https://github.com/JuliaLang/julia/blob/master/doc/build/build.md)
+* [Detailed build instructions](build.md)
 
 Notes for various OSes:
 
-* [Linux](https://github.com/JuliaLang/julia/blob/master/doc/build/linux.md)
-* [macOS](https://github.com/JuliaLang/julia/blob/master/doc/build/macos.md)
-* [Windows](https://github.com/JuliaLang/julia/blob/master/doc/build/windows.md)
-* [FreeBSD](https://github.com/JuliaLang/julia/blob/master/doc/build/freebsd.md)
+* [Linux](linux.md)
+* [macOS](macos.md)
+* [Windows](windows.md)
+* [FreeBSD](freebsd.md)
 
 Notes for various architectures:
 
-* [ARM](https://github.com/JuliaLang/julia/blob/master/doc/build/arm.md)
+* [ARM](arm.md)
 
 Notes for building Julia for distribution:
 
-* [Distribution Notes](https://github.com/JuliaLang/julia/blob/master/doc/build/distributing.md)
+* [Distribution Notes](distributing.md)


### PR DESCRIPTION
This is so that you wouldn't change branches on GitHub when clicking on the links in this file.

cc @ViralBShah in case the current behaviour is intentional (ref #31858).