### PR TITLE
Version check for serialized data headers

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -708,7 +708,9 @@ function readheader(s::AbstractSerializer)
                  error("Unknown endianness flag in header")
     # Check protocol compatibility.
     endian_bom == ENDIAN_BOM  || error("Serialized byte order mismatch ($(repr(endian_bom)))")
-    wordsize   == sizeof(Int) || error("Serialized word size mismatch ($wordsize)")
+    # We don't check wordsize == sizeof(Int) here, as Int is encoded concretely
+    # as Int32 or Int64, which should be enough to correctly deserialize a range
+    # of data structures between Julia versions.
     if version > ser_version
         error("""Cannot read stream serialized with a newer version of Julia.
                  Got data version $version > current version $ser_version""")

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -557,8 +557,6 @@ end
     @test_throws(ErrorException("Unknown endianness flag in header"),
                  deserialize(corrupt_header(b, 5, 2)))
     other_wordsize = sizeof(Int) == 8 ? 4 : 8
-    @test_throws(ErrorException("Serialized word size mismatch ($other_wordsize)"),
-                 deserialize(corrupt_header(b, 5, UInt8((sizeof(Int) != 8)<<2))))
     other_endianness = bswap(ENDIAN_BOM)
     @test_throws(ErrorException("Serialized byte order mismatch ($(repr(other_endianness)))"),
                  deserialize(corrupt_header(b, 5, UInt8(ENDIAN_BOM != 0x01020304))))


### PR DESCRIPTION
Check that the serialization data format is compatible before attempting to read a serialized stream. New versions of Serialization are assumed to be able to read old serialized data, but attempting to read newer data with an older version of Serialization will fail with an error.

This code was written as part of an alternative solution to patching up `CodeInfo` serialization in #35371, but seems like it could be useful: it should prevent confusion if a newer julia versions somehow ends up sending data to older workers.