### PR TITLE
typemap: attempt split on typenames also

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -924,6 +924,18 @@ function visit(f, mc::Core.TypeMapLevel)
             isassigned(e, i) && visit(f, e[i])
         end
     end
+    if mc.tname !== nothing
+        e = mc.tname::Vector{Any}
+        for i in 2:2:length(e)
+            isassigned(e, i) && visit(f, e[i])
+        end
+    end
+    if mc.name1 !== nothing
+        e = mc.name1::Vector{Any}
+        for i in 2:2:length(e)
+            isassigned(e, i) && visit(f, e[i])
+        end
+    end
     mc.list !== nothing && visit(f, mc.list)
     mc.any !== nothing && visit(f, mc.any)
     nothing

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1153,7 +1153,7 @@ static inline jl_cgval_t ghostValue(jl_value_t *typ)
         return jl_cgval_t(); // Undef{}
     if (typ == (jl_value_t*)jl_typeofbottom_type) {
         // normalize TypeofBottom to Type{Union{}}
-        typ = (jl_value_t*)jl_wrap_Type(jl_bottom_type);
+        typ = (jl_value_t*)jl_typeofbottom_type->super;
     }
     if (jl_is_type_type(typ)) {
         // replace T::Type{T} with T, by assuming that T must be a leaftype of some sort

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -55,7 +55,7 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
     mt->kwsorter = NULL;
     mt->backedges = NULL;
     JL_MUTEX_INIT(&mt->writelock);
-    mt->offs = 1;
+    mt->offs = 0;
     mt->frozen = 0;
     return mt;
 }
@@ -569,8 +569,8 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
             // as an optimization
             tn->mt = jl_new_method_table(name, module);
             jl_gc_wb(tn, tn->mt);
-            if (jl_svec_len(parameters) > 0)
-                tn->mt->offs = 0;
+            if (jl_svec_len(parameters) == 0 && !abstract)
+                tn->mt->offs = 1;
         }
         else {
             // Everything else, gets to use the unified table

--- a/src/dump.c
+++ b/src/dump.c
@@ -771,22 +771,6 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
             }
             return;
         }
-        if (t == jl_typemap_level_type) {
-            // perform some compression on the typemap levels
-            // (which will need to be rehashed during deserialization anyhow)
-            jl_typemap_level_t *node = (jl_typemap_level_t*)v;
-            assert( // make sure this type has the expected ordering and layout
-                offsetof(jl_typemap_level_t, arg1) == 0 * sizeof(jl_value_t*) &&
-                offsetof(jl_typemap_level_t, targ) == 1 * sizeof(jl_value_t*) &&
-                offsetof(jl_typemap_level_t, linear) == 2 * sizeof(jl_value_t*) &&
-                offsetof(jl_typemap_level_t, any) == 3 * sizeof(jl_value_t*) &&
-                sizeof(jl_typemap_level_t) == 4 * sizeof(jl_value_t*));
-            jl_serialize_value(s, node->arg1);
-            jl_serialize_value(s, node->targ);
-            jl_serialize_value(s, node->linear);
-            jl_serialize_value(s, node->any);
-            return;
-        }
 
         char *data = (char*)jl_data_ptr(v);
         size_t i, j, np = t->layout->npointers;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1873,7 +1873,6 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_any_type->super = jl_any_type;
     jl_nonfunction_mt = jl_any_type->name->mt;
     jl_any_type->name->mt = NULL;
-    jl_nonfunction_mt->offs = 0;
 
     jl_type_type = (jl_unionall_t*)jl_new_abstracttype((jl_value_t*)jl_symbol("Type"), core, jl_any_type, jl_emptysvec);
     jl_type_typename = ((jl_datatype_t*)jl_type_type)->name;
@@ -2091,17 +2090,21 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_typemap_level_type =
         jl_new_datatype(jl_symbol("TypeMapLevel"), core, jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(4,
+                        jl_perm_symsvec(6,
                             "arg1",
                             "targ",
+                            "name1",
+                            "tname",
                             "list",
                             "any"),
-                        jl_svec(4,
+                        jl_svec(6,
+                            jl_any_type,
+                            jl_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type),
-                        0, 1, 4);
+                        0, 1, 6);
 
     jl_typemap_entry_type =
         jl_new_datatype(jl_symbol("TypeMapEntry"), core, jl_any_type, jl_emptysvec,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1038,7 +1038,7 @@ void jl_mach_gc_end(void);
 
 typedef uint_t (*smallintset_hash)(size_t val, jl_svec_t *data);
 typedef int (*smallintset_eq)(size_t val, const void *key, jl_svec_t *data, uint_t hv);
-ssize_t jl_smallintset_lookup(jl_array_t *cache JL_PROPAGATES_ROOT, smallintset_eq eq, const void *key, jl_svec_t *data, uint_t hv);
+ssize_t jl_smallintset_lookup(jl_array_t *cache, smallintset_eq eq, const void *key, jl_svec_t *data, uint_t hv);
 void jl_smallintset_insert(jl_array_t **pcache, jl_value_t *parent, smallintset_hash hash, size_t val, jl_svec_t *data);
 
 // -- typemap.c -- //

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -664,6 +664,10 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
             n += jl_static_show_x(out, li->uninferred, depth);
         }
     }
+    else if (vt == jl_typename_type) {
+        n += jl_static_show_x(out, jl_unwrap_unionall(((jl_typename_t*)v)->wrapper), depth);
+        n += jl_printf(out, ".name");
+    }
     else if (vt == jl_simplevector_type) {
         n += jl_show_svec(out, (jl_svec_t*)v, "svec", "(", ")");
     }

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -375,7 +375,7 @@ int jl_typemap_intersection_visitor(jl_typemap_t *map, int offs,
             }
             if (cache->targ != (jl_array_t*)jl_an_empty_vec_any) {
                 jl_value_t *typetype = jl_is_type_type(ty) ? jl_tparam0(ty) : NULL;
-                if (typetype) {
+                if (typetype && !jl_has_free_typevars(typetype)) {
                     if (is_cache_leaf(typetype)) {
                         // direct lookup of leaf types
                         jl_typemap_t *ml = mtcache_hash_lookup(cache->targ, typetype);

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -171,6 +171,10 @@ try
               const layout2 = Any[Ptr{Int8}(0), Ptr{Int16}(1), Ptr{Int32}(-1)]
               const layout3 = collect(x.match for x in eachmatch(r"..", "abcdefghijk"))::Vector{SubString{String}}
 
+              # create a backedge that includes Type{Union{}}, to ensure lookup can handle that
+              call_bottom() = show(stdout::IO, Union{})
+              Core.Compiler.return_type(call_bottom, ())
+
               # check that @ccallable works from precompiled modules
               Base.@ccallable Cint f35014(x::Cint) = x+Cint(1)
           end


### PR DESCRIPTION
This is a recreation of https://github.com/JuliaLang/julia/pull/16418, now working due to many changes in the meantime! In measurements, it appears to successfully shave significant time off `require` calls:
```
$ time ./usr/bin/julia -e 'using DataFrames'
user 0m1.192s => 0m0.887s

$ time ./usr/bin/julia -e 'using Plots'
user 0m3.240s => 0m2.056s

$ time ./usr/bin/julia -e 'using ApproxFun
user 0m21.551s => 0m11.953s
```