### PR TITLE
Simpler printing for Iterators.Enumerate, Iterators.Zip, and SkipMissing

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -288,7 +288,7 @@ julia> b = ["e","d","b","c","a"]
  "a"
 
 julia> c = zip(a,b)
-Base.Iterators.Zip{Tuple{UnitRange{Int64},Array{String,1}}}((1:5, ["e", "d", "b", "c", "a"]))
+zip(1:5, ["e", "d", "b", "c", "a"])
 
 julia> length(c)
 5

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -196,7 +196,7 @@ of the input.
 # Examples
 ```jldoctest
 julia> x = skipmissing([1, missing, 2])
-Base.SkipMissing{Array{Union{Missing, Int64},1}}(Union{Missing, Int64}[1, missing, 2])
+skipmissing(Union{Missing, Int64}[1, missing, 2])
 
 julia> sum(x)
 3

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -259,6 +259,12 @@ keys(itr::SkipMissing) =
     v
 end
 
+function show(io::IO, s::SkipMissing)
+    print(io, "skipmissing(")
+    show(io, s.x)
+    print(io, ')')
+end
+
 # Optimized mapreduce implementation
 # The generic method is faster when !(eltype(A) >: Missing) since it does not need
 # additional loops to identify the two first non-missing values of each block

--- a/base/show.jl
+++ b/base/show.jl
@@ -2223,6 +2223,15 @@ function showarg(io::IO, r::ReinterpretArray{T}, toplevel) where {T}
     print(io, ')')
 end
 
+# printing iterators from Base.Iterators
+
+function show(io::IO, e::Iterators.Enumerate)
+    print(io, "enumerate(")
+    show(io, e.itr)
+    print(io, ')')
+end
+show(io::IO, z::Iterators.Zip) = show_delim_array(io, z.is, "zip(", ',', ')', false)
+
 # pretty printing for Iterators.Pairs
 function Base.showarg(io::IO, r::Iterators.Pairs{<:Integer, <:Any, <:Any, T}, toplevel) where T<:AbstractArray
     print(io, "pairs(IndexLinear(), ::", T, ")")

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -301,7 +301,7 @@ This convenience function returns an iterator which filters out `missing` values
 efficiently. It can therefore be used with any function which supports iterators
 ```jldoctest skipmissing; setup = :(using Statistics)
 julia> x = skipmissing([3, missing, 2, 1])
-Base.SkipMissing{Array{Union{Missing, Int64},1}}(Union{Missing, Int64}[3, missing, 2, 1])
+skipmissing(Union{Missing, Int64}[3, missing, 2, 1])
 
 julia> maximum(x)
 3

--- a/test/show.jl
+++ b/test/show.jl
@@ -2011,3 +2011,14 @@ end
 @test_repr "a[(bla;)]"
 @test_repr "a[(;;)]"
 @weak_test_repr "a[x -> f(x)]"
+
+@testset "Base.Iterators" begin
+    @test sprint(show, enumerate("test")) == "enumerate(\"test\")"
+    @test sprint(show, enumerate(1:5)) == "enumerate(1:5)"
+    @test sprint(show, enumerate([1,2,3])) == "enumerate([1, 2, 3])"
+    @test sprint(show, enumerate((1,1.0,'a'))) == "enumerate((1, 1.0, 'a'))"
+    @test sprint(show, zip()) == "zip()"
+    @test sprint(show, zip([1,2,3])) == "zip([1, 2, 3])"
+    @test sprint(show, zip(1:3, ('a','b','c'))) == "zip(1:3, ('a', 'b', 'c'))"
+    @test sprint(show, zip(1:3, ('a','b','c'), "abc")) == "zip(1:3, ('a', 'b', 'c'), \"abc\")"
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2022,3 +2022,10 @@ end
     @test sprint(show, zip(1:3, ('a','b','c'))) == "zip(1:3, ('a', 'b', 'c'))"
     @test sprint(show, zip(1:3, ('a','b','c'), "abc")) == "zip(1:3, ('a', 'b', 'c'), \"abc\")"
 end
+
+@testset "skipmissing" begin
+    @test sprint(show, skipmissing("test")) == "skipmissing(\"test\")"
+    @test sprint(show, skipmissing(1:5)) == "skipmissing(1:5)"
+    @test sprint(show, skipmissing([1,2,missing])) == "skipmissing(Union{Missing, Int64}[1, 2, missing])"
+    @test sprint(show, skipmissing((missing,1.0,'a'))) == "skipmissing((missing, 1.0, 'a'))"
+end


### PR DESCRIPTION
Fixes #33695.

This changes the printing of `Iterators.Enumerate` and `Iterators.Zip` so they are printed just as they are called:

Before:
```julia
julia> enumerate([1,2,3])
Base.Iterators.Enumerate{Array{Int64,1}}([1, 2, 3])

julia> zip([1,2,3], ('a', 'b', 'c'))
Base.Iterators.Zip{Tuple{Array{Int64,1},Tuple{Char,Char,Char}}}(([1, 2, 3], ('a', 'b', 'c')))
```
After:
```julia
julia> enumerate([1,2,3])
enumerate([1, 2, 3])

julia> zip([1,2,3], ('a', 'b', 'c'))
zip([1, 2, 3], ('a', 'b', 'c'))
```