### PR TITLE
Inference of circcopy and circshift

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1060,7 +1060,7 @@ circshift!(dest::AbstractArray, src, shiftamt) = circshift!(dest, src, (shiftamt
 #       _circshift!(dest, src, ("second half of dim1", "second half of dim2")) --> copyto!
 @inline function _circshift!(dest, rdest, src, rsrc,
                              inds::Tuple{AbstractUnitRange,Vararg{Any}},
-                             shiftamt::Tuple{Integer,Vararg{Any}})
+                             shiftamt::Tuple{Integer,Vararg{Any}})::typeof(dest)
     ind1, d = inds[1], shiftamt[1]
     s = mod(d, length(ind1))
     sf, sl = first(ind1)+s, last(ind1)-s
@@ -1120,7 +1120,7 @@ end
 
 # This uses the same strategy described above for _circshift!
 @inline function _circcopy!(dest, rdest, indsdest::Tuple{AbstractUnitRange,Vararg{Any}},
-                            src,  rsrc,  indssrc::Tuple{AbstractUnitRange,Vararg{Any}})
+                            src,  rsrc,  indssrc::Tuple{AbstractUnitRange,Vararg{Any}})::typeof(dest)
     indd1, inds1 = indsdest[1], indssrc[1]
     l = length(indd1)
     s = mod(first(inds1)-first(indd1), l)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -705,13 +705,13 @@ end
     src=rand(3,4,5)
     dst=similar(src)
     s=(1,2,3)
-    @inferred circshift!(dst,src,s)
+    @inferred Base.circshift!(dst,src,s)
 end
 
 @testset "circcopy" begin
     src=rand(3,4,5)
     dst=similar(src)
-    @inferred circcopy!(dst,src)
+    @inferred Base.circcopy!(dst,src)
 end
 # unique across dim
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -702,6 +702,10 @@ end
     @test_throws ArgumentError Base.circshift!(a, a, 1)
     b = copy(a)
     @test Base.circshift!(b, a, 1) == [5,1,2,3,4]
+    src=rand(3,4,5)
+    dst=similar(src)
+    s=(1,2,3)
+    @inferred circshift!(dst,src,s)
 end
 
 # unique across dim

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -708,6 +708,11 @@ end
     @inferred circshift!(dst,src,s)
 end
 
+@testset "circcopy" begin
+    src=rand(3,4,5)
+    dst=similar(src)
+    @inferred circcopy!(dst,src)
+end
 # unique across dim
 
 # With hash collisions

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -701,7 +701,7 @@ end
     a = [1:5;]
     @test_throws ArgumentError Base.circshift!(a, a, 1)
     b = copy(a)
-    @test Base.circshift!(b, a, 1) == [5,1,2,3,4]
+    @test @inferred(Base.circshift!(b, a, 1) == [5,1,2,3,4])
     src=rand(3,4,5)
     dst=similar(src)
     s=(1,2,3)


### PR DESCRIPTION
Hello,

Locally, this fixes https://github.com/JuliaLang/julia/issues/35396 and fixes https://github.com/JuliaLang/julia/issues/35248. I guess the recursive function definition is not inferring and the type assertion helps. It prevents the type instability to propagate further.

This is an easy/lazy fix, please feel free to close if this is not appropriate or suggest a better fix :)

Cheers!