### PR TITLE
fix a typo in docstring for readavailable

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -69,7 +69,7 @@ function bytesavailable end
     readavailable(stream)
 
 Read all available data on the stream, blocking the task only if no data is available. The
-result is a `Vector{UInt8,1}`.
+result is a `Vector{UInt8}`.
 """
 function readavailable end
 


### PR DESCRIPTION
`Vector{UInt8,1}` is not a valid type