### PR TITLE
Clang doesn't have mminimal-toc

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -128,7 +128,9 @@ endif # LLDB_DISABLE_PYTHON
 endif # BUILD_LLDB
 
 ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
+ifeq (${USECLANG},0)
 LLVM_CXXFLAGS += -mminimal-toc
+endif
 endif
 
 ifeq ($(LLVM_SANITIZE),1)


### PR DESCRIPTION
Fix our build options for Clang on PPC