### PR TITLE
Rework broken-precompilation warning

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -836,6 +836,7 @@ jl_value_t *jl_parse_eval_all(const char *fname,
     jl_ptls_t ptls = jl_get_ptls_states();
     if (ptls->in_pure_callback)
         jl_error("cannot use include inside a generated function");
+    jl_check_open_for(inmodule, "include");
     jl_ast_context_t *ctx = jl_ast_ctx_enter();
     fl_context_t *fl_ctx = &ctx->fl;
     value_t f, ast, expression;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -470,6 +470,7 @@ void jl_init_main_module(void);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 jl_array_t *jl_get_loaded_modules(void);
 
+void jl_check_open_for(jl_module_t *m, const char* funcname);
 jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded);
 
 jl_value_t *jl_eval_global_var(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *e);


### PR DESCRIPTION
This allows me to use `Core.eval()` for replacing parts of `jl_parse_eval_all` with Julia code (part of #35243) by splitting out the warning separately. It also allows us to use the normal logging system and Base infrastructure to format the warning more nicely, including the stacktrace and pretty printing of the expression.

For bootstrap I've copied @vtjnash's bootstrap trick where `include` methods are deleted and redefined. Does this seem ok for use with `eval`? I'm unsure whether it can leave unwanted traces of the old methods in the sysimg, as I don't fully understand the world age and code caching infrastructure.