### PR TITLE
Add clearer documentation for asynchronous I/O to the manual.

### DIFF
--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -314,6 +314,7 @@ ip"74.125.226.225"
 ```
 
 ## Asynchronous I/O
+
 All I/O operations exposed by [`Base.read`](@ref) and [`Base.write`](@ref) can be performed
 asynchronously through the use of [coroutines](@ref man-tasks). You can create a new coroutine to
 read from or write to a stream using the [`@async`](@ref) macro:
@@ -338,8 +339,8 @@ your program to block until all of the coroutines it wraps around have exited:
 julia> using Sockets
 
 julia> @sync for hostname in ("google.com", "github.com", "julialang.org")
-           conn = connect(hostname, 80)
            @async begin
+               conn = connect(hostname, 80)
                write(conn, "GET / HTTP/1.1\r\nHost:$(hostname)\r\n\r\n")
                readline(conn, keep=true)
                println("Finished connection to $(hostname)")

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -315,6 +315,7 @@ ip"74.125.226.225"
 
 ## Asynchronous I/O
 
+
 All I/O operations exposed by [`Base.read`](@ref) and [`Base.write`](@ref) can be performed
 asynchronously through the use of [coroutines](@ref man-tasks). You can create a new coroutine to
 read from or write to a stream using the [`@async`](@ref) macro:

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -312,3 +312,39 @@ resolution:
 julia> getaddrinfo("google.com")
 ip"74.125.226.225"
 ```
+
+## Asynchronous I/O
+All I/O operations exposed by [`Base.read`](@ref) and [`Base.write`](@ref) can be performed
+asynchronously through the use of [coroutines](@ref man-tasks). You can create a new coroutine to
+read from or write to a stream using the [`@async`](@ref) macro:
+
+```julia-repl
+julia> task = @async open("foo.txt", "w") do io
+           write(io, "Hello, World!")
+       end;
+
+julia> wait(task)
+
+julia> readlines("foo.txt")
+1-element Array{String,1}:
+ "Hello, World!"
+```
+
+It's common to run into situations where you want to perform multiple asynchronous operations
+concurrently and wait until they've all completed. You can use the [`@sync`](@ref) macro to cause
+your program to block until all of the coroutines it wraps around have exited:
+
+```julia-repl
+julia> @sync for filename in ("foo.txt", "bar.txt", "baz.txt")
+           @async open(filename, "w") do io
+               write(io, "My name is $(filename)")
+           end
+       end
+
+julia> for filename in ("foo.txt", "bar.txt", "baz.txt")
+           println(readlines(filename))
+       end
+["My name is foo.txt"]
+["My name is bar.txt"]
+["My name is baz.txt"]
+```

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -335,16 +335,17 @@ concurrently and wait until they've all completed. You can use the [`@sync`](@re
 your program to block until all of the coroutines it wraps around have exited:
 
 ```julia-repl
-julia> @sync for filename in ("foo.txt", "bar.txt", "baz.txt")
-           @async open(filename, "w") do io
-               write(io, "My name is $(filename)")
+julia> using Sockets
+
+julia> @sync for hostname in ("google.com", "github.com", "julialang.org")
+           conn = connect(hostname, 80)
+           @async begin
+               write(conn, "GET / HTTP/1.1\r\nHost:$(hostname)\r\n\r\n")
+               readline(conn, keep=true)
+               println("Finished connection to $(hostname)")
            end
        end
-
-julia> for filename in ("foo.txt", "bar.txt", "baz.txt")
-           println(readlines(filename))
-       end
-["My name is foo.txt"]
-["My name is bar.txt"]
-["My name is baz.txt"]
+Finished connection to google.com
+Finished connection to julialang.org
+Finished connection to github.com
 ```


### PR DESCRIPTION
There's heavy documentation for Tasks in the manual, but not a lot of reference to how they're used for asynchronous I/O operations. I don't think it's necessarily very clear to someone doing asynchronous I/O in Julia for the first time that

```julia
julia> f = open("foo.txt", "w");

julia> job = @async write(f, "Hello, world!");

julia> wait(job)
```

_actually_ runs asynchronously. One way to think about it is that in the following Python snippet

```python
import asyncio

async def myfun():
    with open("foo.txt", "w") as f:
        f.write("hello, world")

async def main():
    await myfun()

asyncio.run(main())
```

the `async` prefix doesn't actually cause `f.write(...)` to run asynchronously. At least as someone from a more Pythonic background, to me it's not clear in the manual that Julia's `@async` will really cause `Base.read` and `Base.write` to become asynchronous.

This addition to the documentation makes it a little clearer how `@async` works. I've added it to the bottom of the "Networking and Streams" page, which previously did not have much explicit reference to asynchronous I/O.