### PR TITLE
[RFC] support multiple s=>r Pairs in strings replace method

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -538,7 +538,7 @@ end
     c
 end
 
-function replace(str::AbstractString, subs::Pair...; count::Int=typemax(Int))
+function replace(str::ST, subs::Pair...; count::Int=typemax(Int)) where ST<:AbstractString
     @inbounds(count > 0 && for si in eachindex(subs)
         s,r=subs[si]
         R=rangify(findfirst(s,str))

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -553,6 +553,18 @@ function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
     str
 end
 
+function replace(s::String,mapping::Pair{Char,Char}...)
+    d=Dict{Char,Char}()
+    for (from,to) in mapping
+        d[from]=to
+    end
+    @inline function transform(input)
+        haskey(d,input) && return @inbounds d[input]
+        input
+    end
+    String(transform.(c for c in s))
+end
+
 # hex <-> bytes conversion
 
 """

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -537,7 +537,7 @@ function tuple_replace(str::String,count::Int, subs::Pair...)
         T=tuple_replace(str[(last(R)+1):end],count,subs...)
         return (H...,replace(M,s=>r),T...)
     end
-    (str,)
+    (str,) #test
 end
 
 function replace(str::String, subs::Pair...; count::Int=typemax(Int))

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -553,13 +553,18 @@ function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
     str
 end
 
-function replace(s::String,mapping::Pair{Char,Char}...)
+function replace(str::String, mapping::Pair{Char,Char}...; count::Integer=typemax(Int))
     d=Dict(mapping...)
-    @inline function transform(input)
-        haskey(d,input) && return @inbounds d[input]
-        input
+    buf = IOBuffer()
+    for c in str
+        if count>0 && haskey(d,c)
+            count-=1
+            print(buf,@inbounds d[c])
+        else
+            print(buf, c)
+        end
     end
-    String(transform.(c for c in s))
+    String(take!(buf))
 end
 
 # hex <-> bytes conversion

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -526,22 +526,31 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 
 # TODO: allow transform as the first argument to replace?
 
-function tuple_replace(str::String,count::Int, subs::Pair...)
-    count > 0 && for (s,r) in subs
-        R=findfirst(s,str)
-        isnothing(R) && continue
-        count -= 1
-        H=tuple_replace(str[begin:(first(R)-1)],count,subs...)
-        M=String(str[R]*"")
-        length(H)>1 && (count -= 1)
-        T=tuple_replace(str[(last(R)+1):end],count,subs...)
-        return (H...,replace(M,s=>r),T...)
-    end
-    (str,)
+@inline function rangify(c::T) where T<:AbstractRange
+    c
 end
 
-function replace(str::String, subs::Pair...; count::Int=typemax(Int))
-    *(tuple_replace(str, count, subs...)...)
+@inline function rangify(c::T) where T<:Integer
+    c:c
+end
+
+@inline function rangify(c::Nothing)
+    c
+end
+
+function replace(str::AbstractString, subs::Pair...; count::Int=typemax(Int))
+    @inbounds(count > 0 && for si in eachindex(subs)
+        s,r=subs[si]
+        R=rangify(findfirst(s,str))
+        isnothing(R) && continue
+        i,j=first(R),last(R)
+        count -= 1
+        H=replace(str[begin:(i-1)], subs[(si+1):end]..., count=count)
+        length(H)>1 && (count -= 1)
+        T=replace(str[(j+1):end], subs..., count=count)
+        return H*replace(str[R],s=>r)*T
+    end)
+    str
 end
 
 # hex <-> bytes conversion

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -538,7 +538,7 @@ end
     c
 end
 
-function replace(str::ST, subs::Pair...; count::Int=typemax(Int)) where ST<:AbstractString
+function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
     @inbounds(count > 0 && for si in eachindex(subs)
         s,r=subs[si]
         R=rangify(findfirst(s,str))

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -553,7 +553,7 @@ function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
     str
 end
 
-function replace(str::String, mapping::Pair{Char,Char}...; count::Integer=typemax(Int))
+function replace(str::String, mapping::Pair{Char}...; count::Integer=typemax(Int))
     d=Dict(mapping...)
     buf = IOBuffer()
     for c in str

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -526,57 +526,49 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 
 # TODO: allow transform as the first argument to replace?
 
-@inline function rangify(c::T) where T<:AbstractRange
-    c
-end
-
-@inline function rangify(c::T) where T<:Integer
-    c:c
-end
-
-@inline function rangify(c::Nothing)
-    c
-end
+@inline rangify(c::T) where T<:AbstractRange = c
+@inline rangify(c::T) where T<:Integer = c:c
+@inline rangify(c::Nothing) = c
 
 function multi_replace(str::String,count::Integer,subs::NTuple{N,Pair}) where N
     sh=floor(Int,1.2sizeof(str))
     @inbounds(count > 0 && for si in 1:N
-        s,r=subs[si]
+        s,r = subs[si]
         R=rangify(findfirst(s,str))
         isnothing(R) && continue
-        buf=IOBuffer(sizehint=sh)
-        i,j=first(R),last(R)
-        H,n=multi_replace(str[begin:(i-1)],count, subs[(si+1):end])
-        count-=n
-        totrepl=n
+        buf = IOBuffer(sizehint = sh)
+        i,j = first(R),last(R)
+        H,n = multi_replace(str[begin:(i - 1)], count, subs[(si + 1):end])
+        count -= n
+        totrepl = n
         print(buf,H)
-        if count>0
+        if count > 0
             print(buf,replace(str[R],s=>r))
-            count-=1
-            totrepl+=1
+            count -= 1
+            totrepl += 1
         else
             print(buf,str[R])
         end
-        T,n=multi_replace(str[(j+1):end],count, subs)
-        totrepl+=n
+        T,n=multi_replace(str[(j + 1):end], count, subs)
+        totrepl += n
         print(buf,T)
-        return String(take!(buf)),totrepl
+        return String(take!(buf)), totrepl
     end)
-    str,0
+    str, 0
 end
 
 function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
-    multi_replace(str,count,subs)[1]
+    multi_replace(str, count, subs)[1]
 end
 
 const _ReplaceCharToTS=Pair{Char,B} where {B<:Union{AbstractChar,AbstractString,Number}}
 function replace(str::String,mapping::_ReplaceCharToTS...;count::Integer = typemax(Int))
     d=Dict(mapping...)
-    sizestr=sizeof(str)
+    sizestr = sizeof(str)
     buf = IOBuffer(sizehint=sizestr+sizestr>>1)
     for c in str
-        if count>0 && haskey(d,c)
-            count-=1
+        if count > 0 && haskey(d,c)
+            count -= 1
             print(buf,@inbounds d[c])
         else
             print(buf, c)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -553,9 +553,11 @@ function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
     str
 end
 
-function replace(str::String, mapping::Pair{Char}...; count::Integer=typemax(Int))
+const _ReplaceCharToTS=Pair{Char,B} where {B<:Union{AbstractChar,AbstractString,Number}}
+function replace(str::String,mapping::_ReplaceCharToTS...;count::Integer = typemax(Int))
     d=Dict(mapping...)
-    buf = IOBuffer()
+    sizestr=sizeof(str)
+    buf = IOBuffer(sizehint=sizestr+sizestr>>1)
     for c in str
         if count>0 && haskey(d,c)
             count-=1

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -526,6 +526,24 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 
 # TODO: allow transform as the first argument to replace?
 
+function tuple_replace(str::String,count::Int, subs::Pair...)
+    count > 0 && for (s,r) in subs
+        R=findfirst(s,str)
+        isnothing(R) && continue
+        count -= 1
+        H=tuple_replace(str[begin:(first(R)-1)],count,subs...)
+        M=String(str[R]*"")
+        length(H)>1 && (count -= 1)
+        T=tuple_replace(str[(last(R)+1):end],count,subs...)
+        return (H...,replace(M,s=>r),T...)
+    end
+    (str,)
+end
+
+function replace(str::String, subs::Pair...; count::Int=typemax(Int))
+    *(tuple_replace(str, count, subs...)...)
+end
+
 # hex <-> bytes conversion
 
 """

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -526,6 +526,65 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 
 # TODO: allow transform as the first argument to replace?
 
+@inline function rangify(c::T) where T<:AbstractRange
+    c
+end
+
+@inline function rangify(c::T) where T<:Integer
+    c:c
+end
+
+@inline function rangify(c::Nothing)
+    c
+end
+
+function multi_replace(str::String,count::Integer,subs::NTuple{N,Pair}) where N
+    sh=floor(Int,1.2sizeof(str))
+    @inbounds(count > 0 && for si in 1:N
+        s,r=subs[si]
+        R=rangify(findfirst(s,str))
+        isnothing(R) && continue
+        buf=IOBuffer(sizehint=sh)
+        i,j=first(R),last(R)
+        H,n=multi_replace(str[begin:(i-1)],count, subs[(si+1):end])
+        count-=n
+        totrepl=n
+        print(buf,H)
+        if count>0
+            print(buf,replace(str[R],s=>r))
+            count-=1
+            totrepl+=1
+        else
+            print(buf,str[R])
+        end
+        T,n=multi_replace(str[(j+1):end],count, subs)
+        totrepl+=n
+        print(buf,T)
+        return String(take!(buf)),totrepl
+    end)
+    str,0
+end
+
+function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
+    multi_replace(str,count,subs)[1]
+end
+
+const _ReplaceCharToTS=Pair{Char,B} where {B<:Union{AbstractChar,AbstractString,Number}}
+function replace(str::String,mapping::_ReplaceCharToTS...;count::Integer = typemax(Int))
+    d=Dict(mapping...)
+    sizestr=sizeof(str)
+    buf = IOBuffer(sizehint=sizestr+sizestr>>1)
+    for c in str
+        if count>0 && haskey(d,c)
+            count-=1
+            print(buf,@inbounds d[c])
+        else
+            print(buf, c)
+        end
+    end
+    String(take!(buf))
+end
+
 # hex <-> bytes conversion
 
 """

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -537,7 +537,7 @@ function tuple_replace(str::String,count::Int, subs::Pair...)
         T=tuple_replace(str[(last(R)+1):end],count,subs...)
         return (H...,replace(M,s=>r),T...)
     end
-    (str,) #test
+    (str,)
 end
 
 function replace(str::String, subs::Pair...; count::Int=typemax(Int))

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -554,10 +554,7 @@ function replace(str::String, subs::Pair...; count::Integer=typemax(Int))
 end
 
 function replace(s::String,mapping::Pair{Char,Char}...)
-    d=Dict{Char,Char}()
-    for (from,to) in mapping
-        d[from]=to
-    end
+    d=Dict(mapping...)
     @inline function transform(input)
         haskey(d,input) && return @inbounds d[input]
         input

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -300,7 +300,7 @@ end
     # PR 35414
     @test replace("foobarbaz","oo"=>"zz","ar"=>"zz","z"=>"m") == "fzzbzzbam"
     substmp=["z"=>"m","oo"=>"zz","ar"=>"zz"]
-    for perm in [[1,2,3],[2,1,3],[3,2,1],[2,3,1]]
+    for perm in [[1,2,3],[2,1,3],[3,2,1],[2,3,1],[1,3,2],[3,1,2]]
         @test replace("foobarbaz",substmp[perm]...) == "fzzbzzbam"
         @test replace("foobarbaz",substmp[perm]...,count=2) == "fzzbzzbaz"
         @test replace("foobarbaz",substmp[perm]...,count=1) == "fzzbarbaz"

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -299,8 +299,12 @@ end
 
     # PR 35414
     @test replace("foobarbaz","oo"=>"zz","ar"=>"zz","z"=>"m") == "fzzbzzbam"
-    @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz") == "fzzbzzbam"
-    @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz",count=2) == "fzzbarbam"
+    substmp=["z"=>"m","oo"=>"zz","ar"=>"zz"]
+    for perm in [[1,2,3],[2,1,3],[3,2,1],[2,3,1]]
+        @test replace("foobarbaz",substmp[perm]...) == "fzzbzzbam"
+        @test replace("foobarbaz",substmp[perm]...,count=2) == "fzzbzzbaz"
+        @test replace("foobarbaz",substmp[perm]...,count=1) == "fzzbarbaz"
+    end
     @test replace("foobarbaz","z"=>"m",r"a.*a"=>uppercase) == "foobARBAm"
     @test replace("foobarbaz",'o'=>'z','a'=>'q','z'=>'m') == "fzzbqrbqm"
 end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -297,6 +297,11 @@ end
     @test replace("a", in("a") => typeof) == "Char"
     @test replace("a", ['a'] => typeof) == "Char"
 
+    # PR 35414
+    @test replace("foobarbaz","oo"=>"zz","ar"=>"zz","z"=>"m") == "fzzbzzbam"
+    @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz") == "fzzbzzbam"
+    @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz",count=2) == "fzzbarbam"
+    @test replace("foobarbaz","z"=>"m",r"a.*a"=>uppercase) == "foobARBAm"
 end
 
 @testset "chomp/chop" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -297,6 +297,16 @@ end
     @test replace("a", in("a") => typeof) == "Char"
     @test replace("a", ['a'] => typeof) == "Char"
 
+    # PR 35414
+    @test replace("foobarbaz","oo"=>"zz","ar"=>"zz","z"=>"m") == "fzzbzzbam"
+    substmp=["z"=>"m","oo"=>"zz","ar"=>"zz"]
+    for perm in [[1,2,3],[2,1,3],[3,2,1],[2,3,1],[1,3,2],[3,1,2]]
+        @test replace("foobarbaz",substmp[perm]...) == "fzzbzzbam"
+        @test replace("foobarbaz",substmp[perm]...,count=2) == "fzzbzzbaz"
+        @test replace("foobarbaz",substmp[perm]...,count=1) == "fzzbarbaz"
+    end
+    @test replace("foobarbaz","z"=>"m",r"a.*a"=>uppercase) == "foobARBAm"
+    @test replace("foobarbaz",'o'=>'z','a'=>'q','z'=>'m') == "fzzbqrbqm"
 end
 
 @testset "chomp/chop" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -302,6 +302,7 @@ end
     @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz") == "fzzbzzbam"
     @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz",count=2) == "fzzbarbam"
     @test replace("foobarbaz","z"=>"m",r"a.*a"=>uppercase) == "foobARBAm"
+    @test replace("foobarbaz",'o'=>'z','a'=>'q','z'=>'m') == "fzzbqrbqm"
 end
 
 @testset "chomp/chop" begin


### PR DESCRIPTION
Stab @ addressing https://github.com/JuliaLang/julia/issues/35327

semantics respected:
```julia
    @test replace("foobarbaz","oo"=>"zz","ar"=>"zz","z"=>"m") == "fzzbzzbam"
    @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz") == "fzzbzzbam"
    @test replace("foobarbaz","z"=>"m","oo"=>"zz","ar"=>"zz",count=2) == "fzzbzzbaz"
    @test replace("foobarbaz","z"=>"m",r"a.*a"=>uppercase) == "foobARBAm"
    @test replace("foobarbaz",'o'=>'z','a'=>'q','z'=>'m') == "fzzbqrbqm"
```

edit 9 apr: added fast specialization for Char=>Char mappings
edit 10 apr: generalized  fast specialization for Char=>? mappings using IOBuffer


