### PR TITLE
don't save implicit imports into Main

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -82,24 +82,24 @@ empty!(LOAD_PATH)
 @eval Base creating_sysimg = false
 Base.init_load_path() # want to be able to find external packages in userimg.jl
 
-let
-tot_time_userimg = @elapsed (Base.isfile("userimg.jl") && Base.include(Main, "userimg.jl"))
-
-
-tot_time_base = (Base.end_base_include - Base.start_base_include) * 10.0^(-9)
-tot_time = tot_time_base + Base.tot_time_stdlib[] + tot_time_userimg
-
-println("Sysimage built. Summary:")
-print("Total ─────── "); Base.time_print(tot_time               * 10^9); print(" \n");
-print("Base: ─────── "); Base.time_print(tot_time_base          * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_base          / tot_time) * 100); println("%")
-print("Stdlibs: ──── "); Base.time_print(Base.tot_time_stdlib[] * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (Base.tot_time_stdlib[] / tot_time) * 100); println("%")
-if isfile("userimg.jl")
-print("Userimg: ──── "); Base.time_print(tot_time_userimg       * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_userimg       / tot_time) * 100); println("%")
-end
-end
-
-empty!(LOAD_PATH)
-empty!(DEPOT_PATH)
-
 # Set up Main module
 import Base.MainInclude: eval, include
+
+Base.@eval Base let
+    ccall(:jl_clear_implicit_imports, Cvoid, (Any,), Main)
+    tot_time_userimg = @elapsed (isfile("userimg.jl") && include(Main, "userimg.jl"))
+
+    tot_time_base = (end_base_include - start_base_include) * 10.0^(-9)
+    tot_time = tot_time_base + tot_time_stdlib[] + tot_time_userimg
+
+    println("Sysimage built. Summary:")
+    print("Total ─────── "); time_print(tot_time               * 10^9); print(" \n");
+    print("Base: ─────── "); time_print(tot_time_base          * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_base          / tot_time) * 100); println("%")
+    print("Stdlibs: ──── "); time_print(tot_time_stdlib[] * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_stdlib[] / tot_time) * 100); println("%")
+    if isfile("userimg.jl")
+    print("Userimg: ──── "); time_print(tot_time_userimg       * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_userimg       / tot_time) * 100); println("%")
+    end
+end
+
+Base.empty!(LOAD_PATH)
+Base.empty!(DEPOT_PATH)


### PR DESCRIPTION
This rolls back a small part of #34828. The problem is that the code in sysimg.jl uses various bindings from Base, and if those stay around it prevents you from importing things with the same name in a new julia session.

Caused https://github.com/rofinn/FilePathsBase.jl/pull/75#issuecomment-611310616
