### PR TITLE
Add compat entry for @deprecated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,7 +74,8 @@ Command-line option changes
 ---------------------------
 
 * Deprecation warnings are no longer shown by default. i.e. if the `--depwarn=...` flag is
-  not passed it defaults to `--depwarn=no`. ([#35362]).
+  not passed it defaults to `--depwarn=no`. The warnings are printed from tests run by
+  `Pkg.test()`. ([#35362]).
 
 * Color now defaults to on when stdout and stderr are TTYs ([#34347])
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -21,6 +21,10 @@ The first argument `old` is the signature of the deprecated method, the second o
 `new` is the call which replaces it. `@deprecate` exports `old` unless the optional
 third argument is `false`.
 
+!!! compat "Julia 1.5"
+    As of Julia 1.5, functions defined by `@deprecate` do not print warning inside normal
+    `julia` program as the defualt value of `--depwarn` option is `no`.
+
 # Examples
 ```jldoctest
 julia> @deprecate old(x) new(x)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -23,7 +23,8 @@ third argument is `false`.
 
 !!! compat "Julia 1.5"
     As of Julia 1.5, functions defined by `@deprecate` do not print warning inside normal
-    `julia` program as the defualt value of `--depwarn` option is `no`.
+    `julia` program as the defualt value of `--depwarn` option is `no`.  The warnings
+    are printed from tests run by `Pkg.test()`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
I think #35362 should have included the compat annotation and clarified the behavior of `@deprecated`.

https://github.com/JuliaLang/Pkg.jl/pull/1763 needs to be approved before this PR can be merged.
