### PR TITLE
Follow up to docstring changes in  #35427

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -22,9 +22,9 @@ The first argument `old` is the signature of the deprecated method, the second o
 third argument is `false`.
 
 !!! compat "Julia 1.5"
-    As of Julia 1.5, functions defined by `@deprecate` do not print warning inside normal
-    `julia` program as the defualt value of `--depwarn` option is `no`.  The warnings
-    are printed from tests run by `Pkg.test()`.
+    As of Julia 1.5, functions defined by `@deprecate` do not print warning when `julia`
+    run without the `--depwarn=yes` flag set, as the default value of `--depwarn` option
+    is `no`.  The warnings are printed from tests run by `Pkg.test()`.
 
 # Examples
 ```jldoctest

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -23,7 +23,7 @@ third argument is `false`.
 
 !!! compat "Julia 1.5"
     As of Julia 1.5, functions defined by `@deprecate` do not print warning when `julia`
-    run without the `--depwarn=yes` flag set, as the default value of `--depwarn` option
+    is run without the `--depwarn=yes` flag set, as the default value of `--depwarn` option
     is `no`.  The warnings are printed from tests run by `Pkg.test()`.
 
 # Examples


### PR DESCRIPTION
in #35427 I noticed that `default` was spelt as `defualt` 
when I was editting it, I also thought we could avoid saying `normal `julia` program` and be more explict.