### PR TITLE
[backport #35274] fix #35272, searchsorted(3:-1:1, 2.5, rev=true)

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -253,7 +253,11 @@ function searchsortedlast(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderin
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
-        clamp( fld(floor(Integer, x) - first(a), step(a)) + 1, 0, length(a))
+        if o isa ForwardOrdering
+            clamp( fld(floor(Integer, x) - first(a), step(a)) + 1, 0, length(a))
+        else
+            clamp( fld(ceil(Integer, x) - first(a), step(a)) + 1, 0, length(a))
+        end
     end
 end
 
@@ -262,7 +266,11 @@ function searchsortedfirst(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderi
     if step(a) == 0
         lt(o, first(a), x) ? length(a)+1 : 1
     else
-        clamp(-fld(floor(Integer, -x) + first(a), step(a)) + 1, 1, length(a) + 1)
+        if o isa ForwardOrdering
+            clamp(-fld(floor(Integer, -x) + first(a), step(a)) + 1, 1, length(a) + 1)
+        else
+            clamp(-fld(ceil(Integer, -x) + first(a), step(a)) + 1, 1, length(a) + 1)
+        end
     end
 end
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -138,6 +138,17 @@ end
         @test searchsortedlast(500:1.0:600, -1.0e20) == 0
         @test searchsortedlast(500:1.0:600, 1.0e20) == 101
     end
+    @testset "issue #35272" begin
+        for v0 = (3:-1:1, 3.0:-1.0:1.0), v = (v0, collect(v0))
+            @test searchsorted(v, 3, rev=true) == 1:1
+            @test searchsorted(v, 3.0, rev=true) == 1:1
+            @test searchsorted(v, 2.5, rev=true) == 2:1
+            @test searchsorted(v, 2, rev=true) == 2:2
+            @test searchsorted(v, 1.2, rev=true) == 3:2
+            @test searchsorted(v, 1, rev=true) == 3:3
+            @test searchsorted(v, 0.1, rev=true) == 4:3
+        end
+    end
 end
 # exercise the codepath in searchsorted* methods for ranges that check for zero step range
 struct ConstantRange{T} <: AbstractRange{T}


### PR DESCRIPTION
cc @KristofferC 