### PR TITLE
Add specialized +, -, rem and mod for Rational and Integer

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -263,6 +263,14 @@ for (op,chop) in ((:+,:checked_add), (:-,:checked_sub),
             xd, yd = divgcd(x.den, y.den)
             Rational(($chop)(checked_mul(x.num,yd), checked_mul(y.num,xd)), checked_mul(x.den,yd))
         end
+
+        function ($op)(x::Rational, y::Integer)
+            Rational(($chop)(x.num, checked_mul(x.den, y)), x.den)
+        end
+
+        function ($op)(y::Integer, x::Rational)
+            Rational(($chop)(checked_mul(x.den, y), x.num), x.den)
+        end
     end
 end
 
@@ -479,4 +487,3 @@ function gcdx(x::Rational, y::Rational)
     end
     c, a, b
 end
-

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -405,3 +405,22 @@ end
     @test gcd([5, 2, 1//2]) == 1//2
 end
 
+@testset "Binary operations with Integer" begin
+    @test 1//2 - 1 == -1//2
+    @test -1//2 + 1 == 1//2
+    @test 1 - 1//2 == 1//2
+    @test 1 + 1//2 == 3//2
+    for q in (19//3, -4//5), i in (6, -7)
+        @test rem(q, i) == q - i*div(q, i)
+        @test mod(q, i) == q - i*fld(q, i)
+    end
+
+    @test_throws OverflowError UInt(1)//2 - 1
+    @test_throws OverflowError 1 - UInt(5)//2
+    @test_throws OverflowError 1//typemax(Int64) + 1
+    @test_throws OverflowError Int8(1) + Int8(5)//(Int8(127)-Int8(1))
+
+    @test Int8(1) + Int8(4)//(Int8(127)-Int8(1)) == Int8(65) // Int8(63)
+    @test -Int32(1) // typemax(Int32) - Int32(1) == typemin(Int32) // typemax(Int32)
+    @test 1 // (typemax(Int128) + BigInt(1)) - 2 == (1 + BigInt(2)*typemin(Int128)) // (BigInt(1) + typemax(Int128))
+end


### PR DESCRIPTION
Currently, calling either `+`, `-`, `rem` or `mod` with one Rational and one Integer argument defaults to promoting the Integer to a Rational and then performing the computation. This is a bit wasteful since Integers are more structured than Rationals (namely, their denominator is known to be 1).

This PR adds the required specializations. As you can see from the commit, all four functions actually share the same underlying code pattern so the addition is quite terse. I also added tests for these binary operations with Integers, but they only check correction, not performance.

A silly benchmark to show the improvement:
```julia
julia> function foo(::Type{T}) where T<:Integer
           x = Rational{T}(1, 100)
           n = T(10000)
           k = one(T)
           return maximum(i-((i+((x+i)-i))-x) for i in k:n)
       end
foo (generic function with 3 methods)

julia> @btime foo(Int)
  2.443 ms (0 allocations: 0 bytes)  # Currently
  1.137 ms (0 allocations: 0 bytes)  # This PR
0//1

julia> @btime foo(UInt)
  2.263 ms (0 allocations: 0 bytes)  # Currently
  1.049 ms (0 allocations: 0 bytes)  # This PR
0x0000000000000000//0x0000000000000001

julia> @btime foo(BigInt)
  49.909 ms (1640020 allocations: 31.13 MiB)  # Currently
  20.211 ms (800012 allocations: 15.56 MiB)    # This PR
0//1
```