### PR TITLE
Implement RefField <: Ref{T}

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -665,6 +665,7 @@ julia> Base.fieldindex(Foo, :z, false)
 ```
 """
 function fieldindex(T::DataType, name::Symbol, err::Bool=true)
+    @_pure_meta
     return Int(ccall(:jl_field_index, Cint, (Any, Any, Cint), T, name, err)+1)
 end
 

--- a/base/refvalue.jl
+++ b/base/refvalue.jl
@@ -11,7 +11,7 @@ RefValue(x::T) where {T} = RefValue{T}(x)
 isassigned(x::RefValue) = isdefined(x, :x)
 
 function unsafe_convert(P::Type{Ptr{T}}, b::RefValue{T}) where T
-    if allocatedinline(T)
+    if allocatedinline(T) || T === Any
         p = pointer_from_objref(b)
     elseif isconcretetype(T) && T.mutable
         p = pointer_from_objref(b.x)
@@ -23,9 +23,6 @@ function unsafe_convert(P::Type{Ptr{T}}, b::RefValue{T}) where T
         p = pointerref(Ptr{Ptr{Cvoid}}(pointer_from_objref(b)), 1, Core.sizeof(Ptr{Cvoid}))
     end
     return convert(P, p)
-end
-function unsafe_convert(P::Type{Ptr{Any}}, b::RefValue{Any})
-    return convert(P, pointer_from_objref(b))
 end
 unsafe_convert(::Type{Ptr{Cvoid}}, b::RefValue{T}) where {T} = convert(Ptr{Cvoid}, unsafe_convert(Ptr{T}, b))
 

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1581,6 +1581,67 @@ let
     @test dest[] == (7,8,9)
 end
 
+using Base: RefField
+struct ManyFields
+    a::Bool
+    b::Int64
+    c::Any
+    d::Integer
+    e::Complex{BigFloat}
+end
+mutable struct ManyFields2
+    a::Bool
+    b::Int64
+    c::Any
+    d::Integer
+    e::Complex{BigFloat}
+end
+@testset "RefField" begin
+    mf = ManyFields(true, 1021, "hello", 5432, 1im)
+    a  = RefField(mf, :a)
+    b  = RefField(mf, :b)
+    c  = RefField(mf, :c)
+    d  = RefField(mf, :d)
+    e  = RefField(mf, :e)
+    @test a[] === true
+    @test b[] === 1021
+    @test c[] === "hello"
+    @test d[] === 5432
+    @test e[] == 1im
+    a_ptr = Base.unsafe_convert(Ptr{ManyFields}, a.x)
+    b_ptr = Base.unsafe_convert(Ptr{ManyFields}, b.x) + 8
+    c_ptr = Base.unsafe_convert(Ptr{ManyFields}, c.x) + 16
+    d_ptr = Base.unsafe_convert(Ptr{ManyFields}, d.x) + 24
+    e_ptr = Base.unsafe_convert(Ptr{ManyFields}, e.x) + 32
+    @test Base.unsafe_convert(Ptr{Bool}, a) == a_ptr
+    @test Base.unsafe_convert(Ptr{Int64}, b) == b_ptr
+    @test Base.unsafe_convert(Ptr{Any}, c) == c_ptr
+    @test Base.unsafe_convert(Ptr{Integer}, d) == unsafe_load(Ptr{Ptr{Integer}}(d_ptr))
+    @test Base.unsafe_convert(Ptr{Complex{BigFloat}}, e) == unsafe_load(Ptr{Ptr{Integer}}(e_ptr))
+end
+@testset "RefField" begin
+    mf = ManyFields2(true, 1021, "hello", 5432, 1im)
+    a  = RefField(mf, :a)
+    b  = RefField(mf, :b)
+    c  = RefField(mf, :c)
+    d  = RefField(mf, :d)
+    e  = RefField(mf, :e)
+    @test a[] === true
+    @test b[] === 1021
+    @test c[] === "hello"
+    @test d[] === 5432
+    @test e[] == 1im
+    a_ptr = Base.unsafe_convert(Ptr{ManyFields2}, a.x)
+    b_ptr = Base.unsafe_convert(Ptr{ManyFields2}, b.x) + 8
+    c_ptr = Base.unsafe_convert(Ptr{ManyFields2}, c.x) + 16
+    d_ptr = Base.unsafe_convert(Ptr{ManyFields2}, d.x) + 24
+    e_ptr = Base.unsafe_convert(Ptr{ManyFields2}, e.x) + 32
+    @test Base.unsafe_convert(Ptr{Bool}, a) == a_ptr
+    @test Base.unsafe_convert(Ptr{Int64}, b) == b_ptr
+    @test Base.unsafe_convert(Ptr{Any}, c) == c_ptr
+    @test Base.unsafe_convert(Ptr{Integer}, d) == unsafe_load(Ptr{Ptr{Integer}}(d_ptr))
+    @test Base.unsafe_convert(Ptr{Complex{BigFloat}}, e) == unsafe_load(Ptr{Ptr{Integer}}(e_ptr))
+end
 
 # @ccall macro
 using Base: ccall_macro_parse, ccall_macro_lower


### PR DESCRIPTION
Allows describing a GetElementPointer operation on a field of an object,
complementary to the existing ones for RefValue and RefArray.