### PR TITLE
generalize filter[!] docstring and add compat annotation for Tuple

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2363,10 +2363,13 @@ end
 ## Filter ##
 
 """
-    filter(f, a::AbstractArray)
+    filter(f, a)
 
-Return a copy of `a`, removing elements for which `f` is `false`.
+Return a copy of collection `a`, removing elements for which `f` is `false`.
 The function `f` is passed one argument.
+
+!!! compat "Julia 1.4"
+    Support for `a` as a tuple requires at least Julia 1.4.
 
 # Examples
 ```jldoctest
@@ -2412,9 +2415,9 @@ function filter(f, a::AbstractArray)
 end
 
 """
-    filter!(f, a::AbstractVector)
+    filter!(f, a)
 
-Update `a`, removing elements for which `f` is `false`.
+Update collection `a`, removing elements for which `f` is `false`.
 The function `f` is passed one argument.
 
 # Examples


### PR DESCRIPTION
The docstring for `filter(f, array)` was generic enough to be generally applicable (e.g. for `Set` and `Tuple`, which didn't have a corresponding docstring), so lift the type constraint from the signature.

`Filter(f, tuple)` was added in #32968.