### PR TITLE
support abs2 for Dates.Period

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -99,6 +99,7 @@ end
 # intfuncs
 Base.gcdx(a::T, b::T) where {T<:Period} = ((g, x, y) = gcdx(value(a), value(b)); return T(g), x, y)
 Base.abs(a::T) where {T<:Period} = T(abs(value(a)))
+Base.abs2(a::T) where {T<:Period} = T(abs2(value(a)))
 Base.sign(x::Period) = sign(value(x))
 
 periodisless(::Period,::Year)        = true

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -27,6 +27,7 @@ using Test
     @test mod.([t, t, t, t, t], Dates.Year(2)) == ([t, t, t, t, t])
     @test [t, t, t] / t2 == [0.5, 0.5, 0.5]
     @test abs(-t) == t
+    @test abs2(-t2) == Dates.Year(4)
     @test sign(t) == sign(t2) == 1
     @test sign(-t) == sign(-t2) == -1
     @test sign(Dates.Year(0)) == 0


### PR DESCRIPTION
Seems like an omission, since `abs` is defined. Currently gives a `MethodError`.

Came up in https://github.com/mcabbott/AxisKeys.jl/pull/11
