### PR TITLE
Revert "Simpler printing for Iterators.Enumerate, Iterators.Zip, and SkipMissing"

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -288,7 +288,7 @@ julia> b = ["e","d","b","c","a"]
  "a"
 
 julia> c = zip(a,b)
-zip(1:5, ["e", "d", "b", "c", "a"])
+Base.Iterators.Zip{Tuple{UnitRange{Int64},Array{String,1}}}((1:5, ["e", "d", "b", "c", "a"]))
 
 julia> length(c)
 5

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -196,7 +196,7 @@ of the input.
 # Examples
 ```jldoctest
 julia> x = skipmissing([1, missing, 2])
-skipmissing(Union{Missing, Int64}[1, missing, 2])
+Base.SkipMissing{Array{Union{Missing, Int64},1}}(Union{Missing, Int64}[1, missing, 2])
 
 julia> sum(x)
 3
@@ -257,12 +257,6 @@ keys(itr::SkipMissing) =
     v = itr.x[I...]
     v === missing && throw(MissingException("the value at index $I is missing"))
     v
-end
-
-function show(io::IO, s::SkipMissing)
-    print(io, "skipmissing(")
-    show(io, s.x)
-    print(io, ')')
 end
 
 # Optimized mapreduce implementation

--- a/base/show.jl
+++ b/base/show.jl
@@ -2223,15 +2223,6 @@ function showarg(io::IO, r::ReinterpretArray{T}, toplevel) where {T}
     print(io, ')')
 end
 
-# printing iterators from Base.Iterators
-
-function show(io::IO, e::Iterators.Enumerate)
-    print(io, "enumerate(")
-    show(io, e.itr)
-    print(io, ')')
-end
-show(io::IO, z::Iterators.Zip) = show_delim_array(io, z.is, "zip(", ',', ')', false)
-
 # pretty printing for Iterators.Pairs
 function Base.showarg(io::IO, r::Iterators.Pairs{<:Integer, <:Any, <:Any, T}, toplevel) where T<:AbstractArray
     print(io, "pairs(IndexLinear(), ::", T, ")")

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -301,7 +301,7 @@ This convenience function returns an iterator which filters out `missing` values
 efficiently. It can therefore be used with any function which supports iterators
 ```jldoctest skipmissing; setup = :(using Statistics)
 julia> x = skipmissing([3, missing, 2, 1])
-skipmissing(Union{Missing, Int64}[3, missing, 2, 1])
+Base.SkipMissing{Array{Union{Missing, Int64},1}}(Union{Missing, Int64}[3, missing, 2, 1])
 
 julia> maximum(x)
 3

--- a/test/show.jl
+++ b/test/show.jl
@@ -2011,21 +2011,3 @@ end
 @test_repr "a[(bla;)]"
 @test_repr "a[(;;)]"
 @weak_test_repr "a[x -> f(x)]"
-
-@testset "Base.Iterators" begin
-    @test sprint(show, enumerate("test")) == "enumerate(\"test\")"
-    @test sprint(show, enumerate(1:5)) == "enumerate(1:5)"
-    @test sprint(show, enumerate([1,2,3])) == "enumerate([1, 2, 3])"
-    @test sprint(show, enumerate((1,1.0,'a'))) == "enumerate((1, 1.0, 'a'))"
-    @test sprint(show, zip()) == "zip()"
-    @test sprint(show, zip([1,2,3])) == "zip([1, 2, 3])"
-    @test sprint(show, zip(1:3, ('a','b','c'))) == "zip(1:3, ('a', 'b', 'c'))"
-    @test sprint(show, zip(1:3, ('a','b','c'), "abc")) == "zip(1:3, ('a', 'b', 'c'), \"abc\")"
-end
-
-@testset "skipmissing" begin
-    @test sprint(show, skipmissing("test")) == "skipmissing(\"test\")"
-    @test sprint(show, skipmissing(1:5)) == "skipmissing(1:5)"
-    @test sprint(show, skipmissing([1,2,missing])) == "skipmissing(Union{Missing, Int64}[1, 2, missing])"
-    @test sprint(show, skipmissing((missing,1.0,'a'))) == "skipmissing((missing, 1.0, 'a'))"
-end


### PR DESCRIPTION
Reverts JuliaLang/julia#35389.

This commit fails 32 bit CI. Once this revert goes through, feel free to submit a fixed PR.