### PR TITLE
codegen: improve our argument annotations

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -676,6 +676,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createLowerSimdLoopPass()); // Annotate loop marked with "loopinfo" as LLVM parallel loop
     PM->add(createLICMPass());
     PM->add(createLoopUnswitchPass());
+    PM->add(createLICMPass());
     // Subsequent passes not stripping metadata from terminator
     PM->add(createInstSimplifyLegacyPass());
     PM->add(createIndVarSimplifyPass());


### PR DESCRIPTION
Reflect that immutable struct parameters are readonly by the time LLVM
can see them, even passed inside boxes.