### PR TITLE
Add Varargs feature for the Kronecker Tensor Product

### DIFF
--- a/stdlib/LinearAlgebra/test/kron.jl
+++ b/stdlib/LinearAlgebra/test/kron.jl
@@ -1,0 +1,8 @@
+using LinearAlgebra,Test
+@testset " issue ##### " begin
+	x = collect(0:50)
+	A = [ 0.1, x[1:5],reshape(x[1:6],2,3),reshape(x[1:6],1,6) ]
+	@test kron(A...) == kron(kron(kron(A[1],A[2]),A[3]),A[4])
+	A = A[[2,3,4,1]]
+	@test kron(A...) == kron(kron(kron(A[1],A[2]),A[3]),A[4])
+end


### PR DESCRIPTION
Add an efficient way of computing the Kronecker product of a set of matrices, vectors and/or integers.
