### PR TITLE
fix #34924, don't import `LOAD_PATH` into Main by default

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -99,7 +99,7 @@ Base.@eval Base let
     if isfile("userimg.jl")
     print("Userimg: ──── "); time_print(tot_time_userimg       * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_userimg       / tot_time) * 100); println("%")
     end
-end
 
-Base.empty!(LOAD_PATH)
-Base.empty!(DEPOT_PATH)
+    empty!(LOAD_PATH)
+    empty!(DEPOT_PATH)
+end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -141,6 +141,8 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
     # --eval --interactive (replaced --post-boot)
     @test  success(`$exename -i -e "exit(0)"`)
     @test !success(`$exename -i -e "exit(1)"`)
+    # issue #34924
+    @test  success(`$exename -e 'const LOAD_PATH=1'`)
 
     # --print
     @test read(`$exename -E "1+1"`, String) == "2\n"


### PR DESCRIPTION
fix #34924
I don't see how the implicated commit apparently broke this in the original issue. But #34828 definitely broke it in a different way, and with this patch it now works for me.