### PR TITLE
Add specialized * for Rational and Integer

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -280,7 +280,7 @@ function *(x::Rational, y::Rational)
     checked_mul(xn,yn) // checked_mul(xd,yd)
 end
 function *(x::Rational, y::Integer)
-    xd,yn = divgcd(x.den,y)
+    xd, yn = divgcd(x.den, y)
     checked_mul(x.num,yn) // xd
 end
 *(x::Integer, y::Rational) = *(y, x)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -279,6 +279,11 @@ function *(x::Rational, y::Rational)
     xd,yn = divgcd(x.den,y.num)
     checked_mul(xn,yn) // checked_mul(xd,yd)
 end
+function *(x::Rational, y::Integer)
+    xd,yn = divgcd(x.den,y)
+    checked_mul(x.num,yn) // xd
+end
+*(x::Integer, y::Rational) = *(y, x)
 /(x::Rational, y::Rational) = x//y
 /(x::Rational, y::Complex{<:Union{Integer,Rational}}) = x//y
 inv(x::Rational) = Rational(x.den, x.num)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -281,7 +281,7 @@ function *(x::Rational, y::Rational)
 end
 function *(x::Rational, y::Integer)
     xd, yn = divgcd(x.den, y)
-    checked_mul(x.num,yn) // xd
+    checked_mul(x.num, yn) // xd
 end
 *(x::Integer, y::Rational) = *(y, x)
 /(x::Rational, y::Rational) = x//y

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -414,11 +414,16 @@ end
         @test rem(q, i) == q - i*div(q, i)
         @test mod(q, i) == q - i*fld(q, i)
     end
+    @test 1//2 * 3 == 3//2
+    @test -3 * (1//2) == -3//2
 
     @test_throws OverflowError UInt(1)//2 - 1
     @test_throws OverflowError 1 - UInt(5)//2
     @test_throws OverflowError 1//typemax(Int64) + 1
     @test_throws OverflowError Int8(1) + Int8(5)//(Int8(127)-Int8(1))
+    @test_throws InexactError UInt(1)//2 * -1
+    @test_throws OverflowError typemax(Int64)//1 * 2
+    @test_throws OverflowError -1//1 * typemin(Int64)
 
     @test Int8(1) + Int8(4)//(Int8(127)-Int8(1)) == Int8(65) // Int8(63)
     @test -Int32(1) // typemax(Int32) - Int32(1) == typemin(Int32) // typemax(Int32)


### PR DESCRIPTION
Piggybacking off of #35444. Seeing that PR, I realized I have code that would be helped if multiplication got the same treatment. Trying following benchmark:

```julia
function mul_spec(x::Rational, y::Integer)
    xd,yn = Base.divgcd(x.den,y)
    Base.checked_mul(x.num,yn) // xd
end
mul_spec(x::Integer, y::Rational) = mul_spec(y, x)

function mk_rats(T, n)
    r = one(T):T(1000)
    Rational.(rand(r, n), rand(r, n))
end

function bench(f, rats)
    r = 1:length(rats)
    maximum(
        f(i, f(i2, f(f(rat, i2), i))).den
        for (rat, i, i2)
        in zip(rats, r, r .+ 1)
    )
end

n = 1_000
for T in (UInt, Int, BigInt)
    rats = mk_rats(T, n)
    @info "Type" T
    @btime bench($(*), $rats)
    @btime bench($mul_spec, $rats)
end
```
I see the following speedups:

```
┌ Info: Type
└   T = UInt64
  717.044 μs (2 allocations: 64 bytes)
  480.512 μs (2 allocations: 64 bytes)
┌ Info: Type
└   T = Int64
  753.683 μs (2 allocations: 64 bytes)
  485.841 μs (2 allocations: 64 bytes)
┌ Info: Type
└   T = BigInt
  4.653 ms (145006 allocations: 2.78 MiB)
  2.555 ms (80002 allocations: 1.53 MiB)
```

There's still a redundant `divgcd` in Rational's inner constructor.