### PR TITLE
Faster Rationals by avoiding unnecessary divgcd

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -319,9 +319,7 @@ function *(y::Integer, x::Rational)
 end
 /(x::Rational, y::Union{Rational, Integer, Complex{<:Union{Integer,Rational}}}) = x//y
 /(x::Union{Integer, Complex{<:Union{Integer,Rational}}}, y::Rational) = x//y
-function inv(x::Rational{T}) where T
-    checked_den(x.den, x.num)
-end
+inv(x::Rational{T}) where {T} = checked_den(x.den, x.num)
 
 fma(x::Rational, y::Rational, z::Rational) = x*y+z
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -12,9 +12,9 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer; checked::Bool) where T<:Integer
         if checked
-            num == den == zero(T) && __throw_rational_argerror_zero(T)
+            iszero(den) && iszero(num) && __throw_rational_argerror_zero(T)
             num, den = divgcd(num, den)
-            num, den = checking_den(num, den)
+            num, den = checking_den(T(num), T(den))
         end
         return new{T}(num, den)
     end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -10,11 +10,11 @@ struct Rational{T<:Integer} <: Real
     num::T
     den::T
 
-    function Rational{T}(num::Integer, den::Integer; checked::Bool=true) where T<:Integer
+    function Rational{T}(num::Integer, den::Integer; checked::Bool) where T<:Integer
         if checked
             num == den == zero(T) && __throw_rational_argerror_zero(T)
             num, den = divgcd(num, den)
-            num, den = _checked_den(num, den)
+            num, den = checking_den(num, den)
         end
         return new{T}(num, den)
     end
@@ -22,7 +22,7 @@ end
 @noinline __throw_rational_argerror_zero(T) = throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
 @noinline __throw_rational_argerror_typemin(T) = throw(ArgumentError("invalid rational: denominator can't be typemin($T)"))
 
-function _checked_den(num::T, den::T) where T<:Integer
+function checking_den(num::T, den::T) where T<:Integer
     if signbit(den)
         den = -den
         signbit(den) && __throw_rational_argerror_typemin(T)
@@ -32,9 +32,13 @@ function _checked_den(num::T, den::T) where T<:Integer
 end
 
 function checked_den(num::T, den::T) where T<:Integer
-    Rational{T}(_checked_den(num, den)...; checked=false)
+    Rational{T}(checking_den(num, den)...; checked=false)
 end
 checked_den(num::Integer, den::Integer) = checked_den(promote(num, den)...)
+
+function Rational{T}(num::Integer, den::Integer) where T<:Integer
+    Rational{T}(num, den; checked=true)
+end
 
 function Rational(n::T, d::T; checked=true) where T<:Integer
     Rational{T}(n, d; checked)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -29,6 +29,7 @@ using Test
     @test_throws OverflowError (1//2)^63
     @test inv((1+typemin(Int))//typemax(Int)) == -1
     @test_throws ArgumentError inv(typemin(Int)//typemax(Int))
+    @test_throws ArgumentError Rational(0x1, typemin(Int32))
 
     @test @inferred(rationalize(Int, 3.0, 0.0)) === 3//1
     @test @inferred(rationalize(Int, 3.0, 0)) === 3//1
@@ -41,6 +42,11 @@ using Test
     @test_throws ArgumentError 0 // 0
     @test -2 // typemin(Int) == -1 // (typemin(Int) >> 1)
     @test 2 // typemin(Int) == 1 // (typemin(Int) >> 1)
+
+    @test_throws InexactError Rational(UInt(1), typemin(Int32))
+    @test iszero(Rational{Int}(UInt(0), 1))
+    @test Rational{BigInt}(UInt(1), Int(-1)) == -1
+    @test_broken Rational{Int64}(UInt(1), typemin(Int32)) == Int64(1) // Int64(typemin(Int32))
 
     for a = -5:5, b = -5:5
         if a == b == 0; continue; end

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -17,6 +17,7 @@ using Test
     @test 5//0 == 1//0
     @test -1//0 == -1//0
     @test -7//0 == -1//0
+    @test  (-1//2) // (-2//5) == 5//4
 
     @test_throws OverflowError -(0x01//0x0f)
     @test_throws OverflowError -(typemin(Int)//1)
@@ -26,9 +27,12 @@ using Test
     @test (typemax(Int)//1) / (typemax(Int)//1) == 1
     @test (1//typemax(Int)) / (1//typemax(Int)) == 1
     @test_throws OverflowError (1//2)^63
+    @test inv((1+typemin(Int))//typemax(Int)) == -1
+    @test_throws ArgumentError inv(typemin(Int)//typemax(Int))
 
     @test @inferred(rationalize(Int, 3.0, 0.0)) === 3//1
     @test @inferred(rationalize(Int, 3.0, 0)) === 3//1
+    @test_throws OverflowError rationalize(UInt, -2.0)
     @test_throws ArgumentError rationalize(Int, big(3.0), -1.)
     # issue 26823
     @test_throws InexactError rationalize(Int, NaN)
@@ -119,6 +123,8 @@ end
         @test typemax(Rational{T}) == one(T)//zero(T)
         @test widen(Rational{T}) == Rational{widen(T)}
     end
+
+    @test iszero(typemin(Rational{UInt}))
 
     @test Rational(Float32(rand_int)) == Rational(rand_int)
 
@@ -548,6 +554,8 @@ end
     end
     @test 1//2 * 3 == 3//2
     @test -3 * (1//2) == -3//2
+    @test (6//5) // -3 == -2//5
+    @test -4 // (-6//5) == 10//3
 
     @test_throws OverflowError UInt(1)//2 - 1
     @test_throws OverflowError 1 - UInt(5)//2


### PR DESCRIPTION
This PR prevents `divgcd` from being unnecessarily computed when creating a `Rational` with numerators and denominators that are known to be coprime. This is entirely non-breaking.

Addresses #11522

## The history

> I think if we really wanted to tweak performance of rationals, one way would be to have an option to not perform the gcd in the constructor when it isn't required, e.g. for Rational(::Int) or after a multiplication or division. (@simonbyrne)
> That seems like it would be an improvement. I guess that would require having a way of constructing Rational values, bypassing the gcd. (@StefanKarpinski)

(#8672)

## The implementation

~I add two constructors to `Rational` that take the numerator, the denominator, and either `Val(false)` or `Val(true)`. The original constructor is left unchanged (that would be breaking).~

~The two new constructors do not reduce the fraction to its irreducible form. Since the `Rational` infrastructure relies on that fact however, using any of these two new constructors to create an ill-formed rational (one whose numerator and denominator are not coprime) results in undefined behaviour. I did not document the new constructors for this very reason, but if you believe they should be exported alongside the warning I can add some documentation.~

~The difference between the two constructors is that the one with `Val(true)` performs no check whatsoever, whereas the one with `Val(false)` still checks whether the denominator is negative and errors if it is equal to `typemin(T)` (to conform to #32569).~

~EDIT: see discussion below. Intermediate version with `unsafe_rational` at https://github.com/JuliaLang/julia/pull/35492#issuecomment-615132277. Current version with keyword arguments at https://github.com/JuliaLang/julia/pull/35492#issuecomment-617939475. Other propositions: https://github.com/JuliaLang/julia/pull/35492#issuecomment-617922722 and https://github.com/JuliaLang/julia/pull/35492#issuecomment-617997997~

EDIT: See current state of the PR at https://github.com/JuliaLang/julia/pull/35492#issuecomment-622527564. This PR is non-breaking and does not add any new export.

The new constructor is used to remove some unnecessary checks in the existing code of `rational.jl`.


The idea for the implementation comes from @JeffreySarnoff's [FastRationals.jl.](https://github.com/JeffreySarnoff/FastRationals.jl) But this PR does not provide any additional speed from relaxing the constraint that the numerator and denominator should be coprime.

## The silly benchmark

EDIT: For more serious benchmarking work, see https://github.com/JuliaLang/julia/pull/35492#issuecomment-623480983

I am using the exact same function as in #35444. This shows the new improvement compared to current master (on which #35444 has been merged).
```julia
julia> function foo(::Type{T}) where T<:Integer
           x = Rational{T}(1, 100)
           n = T(10000)
           k = one(T)
           return maximum(i-((i+((x+i)-i))-x) for i in k:n)
       end
foo (generic function with 3 methods)

julia> @btime foo(Int);
  1.147 ms (0 allocations: 0 bytes)   # Currently
  442.850 μs (0 allocations: 0 bytes) # This PR

julia> @btime foo(UInt);
  1.113 ms (0 allocations: 0 bytes)   # Currently
  311.702 μs (0 allocations: 0 bytes) # This PR

julia> @btime foo(BigInt);
  20.428 ms (800012 allocations: 15.56 MiB) # Currently
  12.896 ms (540012 allocations: 10.38 MiB) # This PR
```

## The bonus

This PR also incidentally fixes (what I believe to be) two bugs:
- `rationalize(T, x)` with `T<:Unsigned` and `x<0` used to yield `one(T)//zero(T)` aka infinity. It now errors with `OverflowError: cannot negate unsigned number`.
- `typemin(Rational{T})` with `T<:Unsigned` used to be `one(T)//zero(T)` (infinity again), it is now `zero(T)//one(T)`.