### PR TITLE
Add a command line flag to create an rr recording

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -196,6 +196,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_compiled_modules,
            opt_machine_file,
            opt_project,
+           opt_bug_report
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:it:p:O:g:";
     static const struct option longopts[] = {
@@ -211,6 +212,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "eval",            required_argument, 0, 'e' },
         { "print",           required_argument, 0, 'E' },
         { "load",            required_argument, 0, 'L' },
+        { "bug-report",      required_argument, 0, opt_bug_report },
         { "sysimage",        required_argument, 0, 'J' },
         { "sysimage-native-code", required_argument, 0, opt_sysimage_native_code },
         { "compiled-modules",    required_argument, 0, opt_compiled_modules },
@@ -341,11 +343,12 @@ restart_switch:
         case 'e': // eval
         case 'E': // print
         case 'L': // load
+        case opt_bug_report: // bug
         {
             size_t sz = strlen(optarg) + 1;
             char *arg = (char*)malloc_s(sz + 1);
             const char **newcmds;
-            arg[0] = c;
+            arg[0] = c == opt_bug_report ? 'B' : c;
             memcpy(arg + 1, optarg, sz);
             newcmds = (const char**)realloc_s(cmds, (ncmds + 2) * sizeof(char*));
             cmds = newcmds;


### PR DESCRIPTION
Recently I've been asking people to send me rr recordings whenever
they encounter bugs, since it really streamlines the bug fixing process
(in particular, it cuts out the whole "get it to reproduce and capture
it in rr" part of the process). However, the process so far is not quite
trivial. You have to get rr from somewhere (in a version that isn't broken
for latest julia), you have to remember to pack it and then you have
to find a place to upload it. I put together a package
(https://github.com/JuliaLang/BugReporting.jl [1]) that takes care of all of these
steps, but the convenience isn't quite 100% yet. That's what this PR is
supposed to address. It adds `--bug=` command line flag that internally
loads up the BugReporting, but passes through all the command line
options, environment, etc. The idea is that to create a bug report
you just do all the things you usually do, but instead of launching
`julia`, you launch `julia --bug`. This should also work if you are
launching Julia from within a script, etc.

Demo: https://asciinema.org/a/JFdoGT2wlxBE7uyzM1ZjwgSA5

[1] Note: Not yet registered, I'm waiting for a few dependency bumps to go through.