### PR TITLE
update register_error_hint example

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -57,7 +57,7 @@ julia> module Hinter
        only_int(x::Int)      = 1
        any_number(x::Number) = 2
 
-       function __init__()
+       function register_hints()
            register_error_hint(MethodError) do io, exc, argtypes, kwargs
                if exc.f == only_int
                     # Color is not necessary, this is just to show it's possible.
@@ -66,6 +66,7 @@ julia> module Hinter
                end
            end
        end
+       __init__() = register_hints()
 
        end
 ```


### PR DESCRIPTION
When used in practice, the previous `register_error_hint ` example introduced in #35094 is buggy during precompilation of downstream packages, this PR updates the example code so that others don't run into the same issue.

An example: https://github.com/JuliaGraphics/ColorTypes.jl/pull/178 and a fix(https://github.com/JuliaGraphics/ColorTypes.jl/pull/182) for that.

```julia
julia> using Colors
[ Info: Precompiling Colors [5ae59095-9a9b-59fe-a467-6f913c188581]
ERROR: LoadError: InitError: Evaluation into the closed module `ColorTypes` breaks incremental compilation because the side effects will not be permanent. This is likely due to some other module mutating `ColorTypes` with `include` during precompilation - don't do this.
Stacktrace:
 [1] include(::Function, ::Module, ::String) at ./Base.jl:382
 [2] include at ./Base.jl:370 [inlined]
 [3] include at /Users/jc/.julia/packages/ColorTypes/c4EXw/src/ColorTypes.jl:1 [inlined]
 [4] __init__() at /Users/jc/.julia/packages/ColorTypes/c4EXw/src/ColorTypes.jl:89
 [5] _include_from_serialized(::String, ::Array{Any,1}) at ./loading.jl:697
 [6] _require_search_from_serialized(::Base.PkgId, ::String) at ./loading.jl:781
 [7] _require(::Base.PkgId) at ./loading.jl:1006
 [8] require(::Base.PkgId) at ./loading.jl:927
 [9] require(::Module, ::Symbol) at ./loading.jl:922
 [10] include(::Function, ::Module, ::String) at ./Base.jl:382
 [11] include(::Module, ::String) at ./Base.jl:370
 [12] top-level scope at none:2
 [13] eval at ./boot.jl:331 [inlined]
 [14] eval(::Expr) at ./client.jl:452
 [15] top-level scope at ./none:3
```

cc: @timholy 