### PR TITLE
Add rounding modes to round for rationals

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -401,9 +401,32 @@ ceil(::Type{T}, x::Rational) where {T} = _round_rational(T, x, RoundUp)
 round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T} = _round_rational(T, x, r)
 round(x::Rational, r::RoundingMode) = round(Rational, x, r)
 
-_round_rational(::Type{T}, x::Rational, ::RoundingMode{:ToZero}) where {T} = convert(T,div(x.num,x.den))
-_round_rational(::Type{T}, x::Rational, ::RoundingMode{:Down}) where {T} = convert(T,fld(x.num,x.den))
-_round_rational(::Type{T}, x::Rational, ::RoundingMode{:Up}) where {T} = convert(T,cld(x.num,x.den))
+function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:ToZero}) where {T,Tr}
+    if denominator(x) == zero(Tr) && T <: Integer
+        throw(DivideError())
+    elseif denominator(x) == zero(Tr)
+        return convert(T, copysign(one(Tr)//zero(Tr), numerator(x)))
+    end
+    convert(T,div(x.num,x.den))
+end
+
+function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Down}) where {T,Tr}
+    if denominator(x) == zero(Tr) && T <: Integer
+        throw(DivideError())
+    elseif denominator(x) == zero(Tr)
+        return convert(T, copysign(one(Tr)//zero(Tr), numerator(x)))
+    end
+    convert(T,fld(x.num,x.den))
+end
+
+function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Up}) where {T,Tr}
+    if denominator(x) == zero(Tr) && T <: Integer
+        throw(DivideError())
+    elseif denominator(x) == zero(Tr)
+        return convert(T, copysign(one(Tr)//zero(Tr), numerator(x)))
+    end
+    convert(T,cld(x.num,x.den))
+end
 
 function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest}) where {T,Tr}
     if denominator(x) == zero(Tr) && T <: Integer

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -395,11 +395,15 @@ for (S, T) in ((Rational, Integer), (Integer, Rational), (Rational, Rational))
     end
 end
 
-trunc(::Type{T}, x::Rational) where {T} = convert(T,div(x.num,x.den))
-floor(::Type{T}, x::Rational) where {T} = convert(T,fld(x.num,x.den))
-ceil(::Type{T}, x::Rational) where {T} = convert(T,cld(x.num,x.den))
+trunc(::Type{T}, x::Rational) where {T} = _round_rational(T, x, RoundToZero)
+floor(::Type{T}, x::Rational) where {T} = _round_rational(T, x, RoundDown)
+ceil(::Type{T}, x::Rational) where {T} = _round_rational(T, x, RoundUp)
 round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T} = _round_rational(T, x, r)
 round(x::Rational, r::RoundingMode) = round(Rational, x, r)
+
+_round_rational(::Type{T}, x::Rational, ::RoundingMode{:ToZero}) where {T} = convert(T,div(x.num,x.den))
+_round_rational(::Type{T}, x::Rational, ::RoundingMode{:Down}) where {T} = convert(T,fld(x.num,x.den))
+_round_rational(::Type{T}, x::Rational, ::RoundingMode{:Up}) where {T} = convert(T,cld(x.num,x.den))
 
 function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest}) where {T,Tr}
     if denominator(x) == zero(Tr) && T <: Integer

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -194,6 +194,12 @@ end
         @test round(Tf, -almost_half, RoundNearestTiesUp) == 0.0
         @test round(Tf,  almost_half, RoundNearestTiesAway) == 0.0
         @test round(Tf, -almost_half, RoundNearestTiesAway) == 0.0
+        @test round(Tf,  almost_half, RoundUp) == 1.0
+        @test round(Tf, -almost_half, RoundUp) == 0.0
+        @test round(Tf,  almost_half, RoundDown) == 0.0
+        @test round(Tf, -almost_half, RoundDown) == -1.0
+        @test round(Tf,  almost_half, RoundToZero) == 0.0
+        @test round(Tf, -almost_half, RoundToZero) == 0.0
 
         @test round( exactly_half) == 0//1 # rounds to closest _even_ integer
         @test round(-exactly_half) == 0//1 # rounds to closest _even_ integer
@@ -201,6 +207,12 @@ end
         @test round(Tf, -exactly_half, RoundNearestTiesUp) == 0.0
         @test round(Tf,  exactly_half, RoundNearestTiesAway) == 1.0
         @test round(Tf, -exactly_half, RoundNearestTiesAway) == -1.0
+        @test round(Tf,  exactly_half, RoundUp) == 1.0
+        @test round(Tf, -exactly_half, RoundUp) == 0.0
+        @test round(Tf,  exactly_half, RoundDown) == 0.0
+        @test round(Tf, -exactly_half, RoundDown) == -1.0
+        @test round(Tf,  exactly_half, RoundToZero) == 0.0
+        @test round(Tf, -exactly_half, RoundToZero) == 0.0
 
 
         @test round(over_half) == 1//1
@@ -209,11 +221,23 @@ end
         @test round(Tf,  over_half, RoundNearestTiesAway) == 1.0
         @test round(Tf, -over_half, RoundNearestTiesUp) == -1.0
         @test round(Tf, -over_half, RoundNearestTiesAway) == -1.0
+        @test round(Tf,  over_half, RoundUp) == 1.0
+        @test round(Tf, -over_half, RoundUp) == 0.0
+        @test round(Tf,  over_half, RoundDown) == 0.0
+        @test round(Tf, -over_half, RoundDown) == -1.0
+        @test round(Tf,  over_half, RoundToZero) == 0.0
+        @test round(Tf, -over_half, RoundToZero) == 0.0
 
         @test round(Tf, 11//2, RoundNearestTiesUp) == 6.0
         @test round(Tf, -11//2, RoundNearestTiesUp) == -5.0
         @test round(Tf, 11//2, RoundNearestTiesAway) == 6.0
         @test round(Tf, -11//2, RoundNearestTiesAway) == -6.0
+        @test round(Tf, 11//2, RoundUp) == 6.0
+        @test round(Tf, -11//2, RoundUp) == -5.0
+        @test round(Tf, 11//2, RoundDown) == 5.0
+        @test round(Tf, -11//2, RoundDown) == -6.0
+        @test round(Tf, 11//2, RoundToZero) == 5.0
+        @test round(Tf, -11//2, RoundToZero) == -5.0
 
         @test round(Tf, Ti(-1)//zero(Ti)) == -Inf
         @test round(Tf, one(1)//zero(Ti)) == Inf
@@ -221,10 +245,19 @@ end
         @test round(Tf, one(1)//zero(Ti), RoundNearestTiesUp) == Inf
         @test round(Tf, Ti(-1)//zero(Ti), RoundNearestTiesAway) == -Inf
         @test round(Tf, one(1)//zero(Ti), RoundNearestTiesAway) == Inf
+        @test round(Tf, Ti(-1)//zero(Ti), RoundUp) == -Inf
+        @test round(Tf, one(1)//zero(Ti), RoundUp) == Inf
+        @test round(Tf, Ti(-1)//zero(Ti), RoundDown) == -Inf
+        @test round(Tf, one(1)//zero(Ti), RoundDown) == Inf
+        @test round(Tf, Ti(-1)//zero(Ti), RoundToZero) == -Inf
+        @test round(Tf, one(1)//zero(Ti), RoundToZero) == Inf
 
         @test round(Tf, zero(Ti)//one(Ti)) == 0
         @test round(Tf, zero(Ti)//one(Ti), RoundNearestTiesUp) == 0
         @test round(Tf, zero(Ti)//one(Ti), RoundNearestTiesAway) == 0
+        @test round(Tf, zero(Ti)//one(Ti), RoundUp) == 0
+        @test round(Tf, zero(Ti)//one(Ti), RoundDown) == 0
+        @test round(Tf, zero(Ti)//one(Ti), RoundToZero) == 0
     end
 end
 @testset "show and Rationals" begin


### PR DESCRIPTION
Add modes `RoundDown`, `RoundUp`, and `RoundToZero` to
`round(::Rational, ::RoundingMode)` and `round(T, ::Rational, ::RoundingMode)`.