### PR TITLE
Add missing `image_file_specified` field in `Base.JLOptions`

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -42,6 +42,7 @@ struct JLOptions
     outputji::Ptr{UInt8}
     output_code_coverage::Ptr{UInt8}
     incremental::Int8
+    image_file_specified::Int8
     warn_scope::Int8
 end
 


### PR DESCRIPTION
It's a good thing the `warn_scope` option isn't consumed by Julia-side code and is instead used by the C code that isn't sensitive to this.