### PR TITLE
Small fix for lineedit tests

### DIFF
--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -246,7 +246,7 @@ for i = 1:6
     @test position(buf) == i
 end
 @test eof(buf)
-for i = 5:0
+for i = 5:-1:0
     LineEdit.edit_move_left(buf)
     @test position(buf) == i
 end


### PR DESCRIPTION
Previously, some tests were not executed because a range was not constructed properly. This PR fixes that.