### PR TITLE
fix error for `global` declarations shadowing locals

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2249,3 +2249,23 @@ macro a35391(b)
     :(GC.@preserve ($(esc(b)),) )
 end
 @test @a35391(0) === (0,)
+
+# global declarations from the top level are not inherited by functions.
+# don't allow such a declaration to override an outer local, since it's not
+# clear what it should do.
+@test Meta.lower(Main, :(let
+                           x = 1
+                           let
+                             global x
+                           end
+                         end)) == Expr(:error, "`global x`: x is a local variable in its enclosing scope")
+# note: this `begin` block must be at the top level
+_temp_33553 = begin
+    global _x_this_remains_undefined
+    let
+        local _x_this_remains_undefined = 2
+        _x_this_remains_undefined
+    end
+end
+@test _temp_33553 == 2
+@test !@isdefined(_x_this_remains_undefined)


### PR DESCRIPTION
Extracted from #33553. We probably don't really need this error, but for now this makes reporting it more accurate.