### PR TITLE
Test suite tweaks for rr

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -45,6 +45,7 @@ struct JLOptions
     image_file_specified::Int8
     warn_scope::Int8
     image_codegen::Int8
+    rr_detach::Int8
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -75,6 +75,7 @@ jl_options_t jl_options = { 0,    // quiet
                             0, // image_file_specified
                             JL_OPTIONS_WARN_SCOPE_ON,  // ambiguous scope warning
                             0, // image-codegen
+                            0, // rr-detach
 };
 
 static const char usage[] = "julia [switches] -- [programfile] [args...]\n";
@@ -203,6 +204,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_project,
            opt_bug_report,
            opt_image_codegen,
+           opt_rr_detach,
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:it:p:O:g:";
     static const struct option longopts[] = {
@@ -254,6 +256,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "bind-to",         required_argument, 0, opt_bind_to },
         { "lisp",            no_argument,       0, 1 },
         { "image-codegen",   no_argument,       0, opt_image_codegen },
+        { "rr-detach",       no_argument,       0, opt_rr_detach },
         { 0, 0, 0, 0 }
     };
 
@@ -654,6 +657,9 @@ restart_switch:
             break;
         case opt_image_codegen:
             jl_options.image_codegen = 1;
+            break;
+        case opt_rr_detach:
+            jl_options.rr_detach = 1;
             break;
         default:
             jl_errorf("julia: unhandled option -- %c\n"

--- a/src/julia.h
+++ b/src/julia.h
@@ -1957,6 +1957,7 @@ typedef struct {
     int8_t image_file_specified;
     int8_t warn_scope;
     int8_t image_codegen;
+    int8_t rr_detach;
 } jl_options_t;
 
 extern JL_DLLEXPORT jl_options_t jl_options;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -83,6 +83,8 @@ void JL_UV_LOCK(void);
 extern "C" {
 #endif
 
+int jl_running_under_rr(int recheck);
+
 //--------------------------------------------------
 // timers
 // Returns time in nanosec

--- a/src/partr.c
+++ b/src/partr.c
@@ -274,14 +274,14 @@ JL_DLLEXPORT int jl_enqueue_task(jl_task_t *task)
 }
 
 
-static int running_under_rr(void)
+int jl_running_under_rr(int recheck)
 {
 #ifdef _OS_LINUX_
 #define RR_CALL_BASE 1000
 #define SYS_rrcall_check_presence (RR_CALL_BASE + 8)
     static int checked_running_under_rr = 0;
     static int is_running_under_rr = 0;
-    if (!checked_running_under_rr) {
+    if (!checked_running_under_rr || recheck) {
         int ret = syscall(SYS_rrcall_check_presence, 0, 0, 0, 0, 0, 0);
         if (ret == -1) {
             // Should always be ENOSYS, but who knows what people do for
@@ -311,7 +311,7 @@ static int sleep_check_after_threshold(uint64_t *start_cycles)
      * scheduling logic from switching to other threads. Just don't bother
      * trying to wait here
      */
-    if (running_under_rr())
+    if (jl_running_under_rr(0))
         return 1;
     if (!(*start_cycles)) {
         *start_cycles = jl_hrtime();

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -23,8 +23,14 @@ for i in 1:n
     end
     Ctype = Sys.iswindows() ? Ptr{Cvoid} : Cint
     FDmax = Sys.iswindows() ? 0x7fff : (n + 60) # expectations on reasonable values
-    @test 0 <= Int(Base.cconvert(Ctype, pipe_fds[i][1])) <= FDmax
-    @test 0 <= Int(Base.cconvert(Ctype, pipe_fds[i][2])) <= FDmax
+    fd_in_limits =
+        0 <= Int(Base.cconvert(Ctype, pipe_fds[i][1])) <= FDmax &&
+        0 <= Int(Base.cconvert(Ctype, pipe_fds[i][2])) <= FDmax
+    # Dump out what file descriptors are open for easier debugging of failure modes
+    if !fd_in_limits && Sys.islinux()
+        run(`ls -la /proc/$(getpid())/fd`)
+    end
+    @test fd_in_limits
 end
 
 function pfd_tst_reads(idx, intvl)

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -3,7 +3,9 @@
 using Test, Distributed, SharedArrays, Random
 include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
 
-addprocs_with_testenv(4)
+# These processes explicitly want to share memory, we can't have
+# them in separate rr sessions
+addprocs_with_testenv(4; rr_allowed=false)
 @test nprocs() == 5
 
 @everywhere using Test, SharedArrays

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -26,7 +26,16 @@ if !@isdefined(testenv_defined)
         const test_exename = popfirst!(test_exeflags.exec)
     end
 
-    addprocs_with_testenv(X; kwargs...) = addprocs(X; exename=test_exename, exeflags=test_exeflags, kwargs...)
+    if haskey(ENV, "JULIA_RR")
+        const rr_exename = `$(Base.shell_split(ENV["JULIA_RR"]))`
+    else
+        const rr_exename = ``
+    end
+
+    function addprocs_with_testenv(X; rr_allowed=true, kwargs...)
+        exename = rr_allowed ? `$rr_exename $test_exename` : test_exename
+        addprocs(X; exename=exename, exeflags=test_exeflags, kwargs...)
+    end
 
     const curmod = @__MODULE__
     const curmod_name = fullname(curmod)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -1,8 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+using Test
+
 let cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads_exec.jl`
     for test_nthreads in (1, 2, 4, 4) # run once to try single-threaded mode, then try a couple times to trigger bad races
-        run(pipeline(setenv(cmd, "JULIA_NUM_THREADS" => test_nthreads), stdout = stdout, stderr = stderr))
+        new_env = copy(ENV)
+        new_env["JULIA_NUM_THREADS"] = string(test_nthreads)
+        run(pipeline(setenv(cmd, new_env), stdout = stdout, stderr = stderr))
     end
 end
 

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -11,10 +11,17 @@ let cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads_exec.jl
 end
 
 # issue #34415 - make sure external affinity settings work
-if Sys.islinux() && Sys.CPU_THREADS > 1 && Sys.which("taskset") !== nothing
-    run_with_affinity(spec) = readchomp(`taskset -c $spec $(Base.julia_cmd()) -e "run(\`taskset -p \$(getpid())\`)"`)
-    @test endswith(run_with_affinity("1"), "2")
-    @test endswith(run_with_affinity("0,1"), "3")
+
+if Sys.islinux()
+    const SYS_rrcall_check_presence = 1008
+    running_under_rr() = 0 == ccall(:syscall, Int,
+        (Int, Int, Int, Int, Int, Int, Int),
+        SYS_rrcall_check_presence, 0, 0, 0, 0, 0, 0)
+    if Sys.CPU_THREADS > 1 && Sys.which("taskset") !== nothing && !running_under_rr()
+        run_with_affinity(spec) = readchomp(`taskset -c $spec $(Base.julia_cmd()) -e "run(\`taskset -p \$(getpid())\`)"`)
+        @test endswith(run_with_affinity("1"), "2")
+        @test endswith(run_with_affinity("0,1"), "3")
+    end
 end
 
 # issue #34769


### PR DESCRIPTION
threads: Pass through environment to thread_exec (for LD_PRELOAD for rr)
FileWatching: If the fds we allocated were to high, dump out what all those other fds were up to