### PR TITLE
implement LibuvStream interface for BufferStream

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -23,7 +23,6 @@ abstract type LibuvStream <: IO end
 # .  +- Pipe
 # .  +- Process (not exported)
 # .  +- ProcessChain (not exported)
-# +- BufferStream
 # +- DevNull (not exported)
 # +- Filesystem.File
 # +- LibuvStream (not exported)
@@ -31,6 +30,7 @@ abstract type LibuvStream <: IO end
 # .  +- TCPSocket
 # .  +- TTY (not exported)
 # .  +- UDPSocket
+# .  +- BufferStream (FIXME: 2.0)
 # +- IOBuffer = Base.GenericIOBuffer{Array{UInt8,1}}
 # +- IOStream
 
@@ -1202,11 +1202,12 @@ end
 mutable struct BufferStream <: LibuvStream
     buffer::IOBuffer
     cond::Threads.Condition
+    readerror::Any
     is_open::Bool
     buffer_writes::Bool
     lock::ReentrantLock # advisory lock
 
-    BufferStream() = new(PipeBuffer(), Threads.Condition(), true, false, ReentrantLock())
+    BufferStream() = new(PipeBuffer(), Threads.Condition(), nothing, true, false, ReentrantLock())
 end
 
 isopen(s::BufferStream) = s.is_open

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -254,6 +254,18 @@ end
     @test close(bstream) === nothing
     @test eof(bstream)
     @test bytesavailable(bstream) == 0
+    flag = Ref{Bool}(false)
+    event = Base.Event()
+    bstream = Base.BufferStream()
+    task = @async begin
+        notify(event)
+        read(bstream, 16)
+        flag[] = true
+    end
+    wait(event)
+    write(bstream, rand(UInt8, 16))
+    wait(task)
+    @test flag[] == true
 end
 
 @test flush(IOBuffer()) === nothing # should be a no-op


### PR DESCRIPTION
It is noted as a non-OS stream, but has also been a subtype
of LibuvStream since forever. #32309 did not add the `readerror`
field.

It might be better to decouple `BufferStream` from the `LibuvStream`
interface, but I decided to be conservative. Are changes in the type-hierarchy
backportable?