### PR TITLE
Add zero for TimeType

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -167,7 +167,7 @@ Standard library changes
 
 #### Dates
 * The `eps` function now accepts `TimeType` types ([#31487]).
-* The `zero` function now accepts `TimeType` types.
+* The `zero` function now accepts `TimeType` types ([#35554]).
 
 
 #### Statistics

--- a/NEWS.md
+++ b/NEWS.md
@@ -167,6 +167,8 @@ Standard library changes
 
 #### Dates
 * The `eps` function now accepts `TimeType` types ([#31487]).
+* The `zero` function now accepts `TimeType` types.
+
 
 #### Statistics
 

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -401,6 +401,12 @@ Base.eps(::Type{Time}) = Nanosecond(1)
 Base.eps(::T) where T <: TimeType = eps(T)::Period
 
 
+Base.zero(::Type{DateTime}) = Millisecond(0)
+Base.zero(::Type{Date}) = Day(0)
+Base.zero(::Type{Time}) = Nanosecond(0)
+Base.zero(::T) where T <: TimeType = zero(T)::Period
+
+
 Base.typemax(::Union{DateTime, Type{DateTime}}) = DateTime(146138512, 12, 31, 23, 59, 59)
 Base.typemin(::Union{DateTime, Type{DateTime}}) = DateTime(-146138511, 1, 1, 0, 0, 0)
 Base.typemax(::Union{Date, Type{Date}}) = Date(252522163911149, 12, 31)

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -400,7 +400,7 @@ Base.eps(::Type{Date}) = Day(1)
 Base.eps(::Type{Time}) = Nanosecond(1)
 Base.eps(::T) where T <: TimeType = eps(T)::Period
 
-
+# zero returns dt::T - dt::T
 Base.zero(::Type{DateTime}) = Millisecond(0)
 Base.zero(::Type{Date}) = Day(0)
 Base.zero(::Type{Time}) = Nanosecond(0)

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -187,6 +187,12 @@ c = Dates.Time(0)
     @test eps(a) == Dates.Millisecond(1)
     @test eps(b) == Dates.Day(1)
     @test eps(c) == Dates.Nanosecond(1)
+    @test zero(DateTime) == Dates.Millisecond(0)
+    @test zero(Date) == Dates.Day(0)
+    @test zero(Time) == Dates.Nanosecond(0)
+    @test zero(a) == Dates.Millisecond(0)
+    @test zero(b) == Dates.Day(0)
+    @test zero(c) == Dates.Nanosecond(0)
     @test string(typemax(Dates.DateTime)) == "146138512-12-31T23:59:59"
     @test string(typemin(Dates.DateTime)) == "-146138511-01-01T00:00:00"
     @test typemax(Dates.DateTime) - typemin(Dates.DateTime) == Dates.Millisecond(9223372017043199000)


### PR DESCRIPTION
According to docs, zero "gets the additive identity element for the type of x (x can also specify the
type itself).". Defining this method allows one to get the type of `dt::T - dt::T` in a generic way.