### PR TITLE
exclude types with free variables from `type_morespecific`

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3847,6 +3847,8 @@ JL_DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b)
 {
     if (obviously_disjoint(a, b, 1))
         return 0;
+    if (jl_has_free_typevars(a) || jl_has_free_typevars(b))
+        return 0;
     if (jl_subtype(b, a))
         return 0;
     if (jl_subtype(a, b))


### PR DESCRIPTION
After loading packages like Unitful and StaticArrays that overload `show(io::IO, ::Type{<:T})` for some `T` a case like this basically hangs:
```
julia> struct X{A,B,C,D,E,F,G,H,I,J,K,L} end

julia> show(stdout, Union{Tuple{A}, Tuple{B}, Tuple{C}, Tuple{D}, Tuple{E}, Tuple{F}, Tuple{G}, Tuple{H}, Tuple{I}, Tuple{J}, Tuple{K}, Tuple{L}, Tuple{X{A,B,C,D,E,F,G,H,I,J,K,L}}} where {A,B,C,D,E,F,G,H,I,J,K,L})
```
Those definitions cause us to add dispatch cache entries with free variables, which then drives method sorting a bit crazy. This is definitely not a comprehensive solution, but it seems to fix this specific case.