### PR TITLE
add build-system support for MLIR

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -306,6 +306,9 @@ USE_POLLY := 0
 USE_POLLY_OPENMP := 0  # Enable OpenMP code-generation
 USE_POLLY_ACC := 0     # Enable GPU code-generation
 
+# Options to use MLIR
+USE_MLIR := 0
+
 # Cross-compile
 #XC_HOST := i686-w64-mingw32
 #XC_HOST := x86_64-w64-mingw32

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -17,6 +17,15 @@ endif
 endif
 endif
 
+ifeq ($(USE_MLIR),1)
+ifeq ($(USE_SYSTEM_LLVM),0)
+ifneq ($(LLVM_VER),svn)
+$(error USE_MLIR=1 requires LLVM_VER=svn)
+endif
+endif
+endif
+
+
 # for Monorepo
 LLVM_ENABLE_PROJECTS :=
 ifeq ($(BUILD_LLVM_CLANG), 1)
@@ -27,6 +36,9 @@ LLVM_ENABLE_PROJECTS := $(LLVM_ENABLE_PROJECTS);polly
 endif
 ifeq ($(BUILD_LLDB), 1)
 LLVM_ENABLE_PROJECTS := $(LLVM_ENABLE_PROJECTS);lldb
+endif
+ifeq ($(USE_MLIR), 1)
+LLVM_ENABLE_PROJECTS := $(LLVM_ENABLE_PROJECTS);mlir
 endif
 
 include $(SRCDIR)/llvm-options.mk


### PR DESCRIPTION
Allows to build MLIR when compiling LLVM 11+