### PR TITLE
make `ccallable` work with system images and precompilation

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -482,8 +482,8 @@ function exit_on_sigint(on::Bool)
     ccall(:jl_exit_on_sigint, Cvoid, (Cint,), on)
 end
 
-function ccallable(f::Function, rt::Type, argt::Type, name::Union{AbstractString,Symbol}=string(f))
-    ccall(:jl_extern_c, Cvoid, (Any, Any, Any, Cstring), f, rt, argt, name)
+function _ccallable(rt::Type, sigt::Type)
+    ccall(:jl_extern_c, Cvoid, (Any, Any), rt, sigt)
 end
 
 function expand_ccallable(rt, def)
@@ -499,17 +499,22 @@ function expand_ccallable(rt, def)
             error("@ccallable requires a return type")
         end
         if sig.head === :call
-            name = sig.args[1]
+            f = sig.args[1]
+            if isa(f,Expr) && f.head === :(::)
+                f = f.args[end]
+            else
+                f = :(typeof($f))
+            end
             at = map(sig.args[2:end]) do a
                 if isa(a,Expr) && a.head === :(::)
-                    a.args[2]
+                    a.args[end]
                 else
                     :Any
                 end
             end
             return quote
                 $(esc(def))
-                ccallable($(esc(name)), $(esc(rt)), $(Expr(:curly, :Tuple, map(esc, at)...)), $(string(name)))
+                _ccallable($(esc(rt)), $(Expr(:curly, :Tuple, esc(f), map(esc, at)...)))
             end
         end
     end

--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -66,5 +66,3 @@ JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION(void)
 {
     return 0;
 }
-
-jl_array_t *jl_cfunction_list;

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -274,7 +274,7 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams)
             // each item in this list is either a MethodInstance indicating something
             // to compile, or an svec(rettype, sig) describing a C-callable alias to create.
             jl_value_t *item = jl_array_ptr_ref(methods, i);
-            if (jl_is_simplevector(item)) {
+            if (jl_is_simplevector(item) && worlds == 1) {
                 jl_compile_extern_c(shadow_output, &params, NULL, jl_svecref(item, 0), jl_svecref(item, 1));
                 continue;
             }

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -271,7 +271,14 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams)
             continue;
         size_t i, l;
         for (i = 0, l = jl_array_len(methods); i < l; i++) {
-            mi = (jl_method_instance_t*)jl_array_ptr_ref(methods, i);
+            // each item in this list is either a MethodInstance indicating something
+            // to compile, or an svec(rettype, sig) describing a C-callable alias to create.
+            jl_value_t *item = jl_array_ptr_ref(methods, i);
+            if (jl_is_simplevector(item)) {
+                jl_compile_extern_c(shadow_output, &params, NULL, jl_svecref(item, 0), jl_svecref(item, 1));
+                continue;
+            }
+            mi = (jl_method_instance_t*)item;
             src = NULL;
             // if this method is generally visible to the current compilation world,
             // and this is either the primary world, or not applicable in the primary world

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -774,6 +774,13 @@ static Type *julia_struct_to_llvm(jl_codectx_t &ctx, jl_value_t *jt, jl_unionall
     return _julia_struct_to_llvm(&ctx.emission_context, jt, ua, isboxed);
 }
 
+bool jl_type_mappable_to_c(jl_value_t *ty)
+{
+    jl_codegen_params_t params;
+    bool toboxed;
+    return _julia_struct_to_llvm(&params, ty, NULL, &toboxed) != NULL;
+}
+
 static bool is_datatype_all_pointers(jl_datatype_t *dt)
 {
     size_t i, l = jl_datatype_nfields(dt);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4014,8 +4014,8 @@ static void emit_cfunc_invalidate(
 
 static Function* gen_cfun_wrapper(
     Module *into, jl_codegen_params_t &params,
-    const function_sig_t &sig, jl_value_t *ff,
-    jl_typemap_entry_t *sf, jl_value_t *declrt, jl_method_instance_t *lam,
+    const function_sig_t &sig, jl_value_t *ff, const char *aliasname,
+    jl_value_t *declrt, jl_method_instance_t *lam,
     jl_unionall_t *unionall_env, jl_svec_t *sparam_vals, jl_array_t **closure_types)
 {
     // Generate a c-callable wrapper
@@ -4027,12 +4027,11 @@ static Function* gen_cfun_wrapper(
     jl_value_t *astrt = (jl_value_t*)jl_any_type;
     void *callptr = NULL;
     int calltype = 0;
-    // infer it first, if necessary
-    // FIXME! pretend this is OK
-    if (lam)
+    if (aliasname)
+        name = aliasname;
+    else if (lam)
         name = jl_symbol_name(lam->def.method->name);
     if (lam && params.cache) {
-        // if (!into)
         // TODO: this isn't ideal to be unconditionally calling type inference (and compile) from here
         codeinst = jl_compile_method_internal(lam, world);
         assert(codeinst->invoke);
@@ -4086,20 +4085,6 @@ static Function* gen_cfun_wrapper(
     cw->setAttributes(attributes);
     jl_init_function(cw);
     Function *cw_proto = into ? cw : function_proto(cw);
-    // Save the Function object reference
-    if (sf) {
-        jl_value_t *oldsf = sf->func.value;
-        size_t i, oldlen = jl_svec_len(oldsf);
-        jl_value_t *newsf = (jl_value_t*)jl_alloc_svec(oldlen + 2);
-        JL_GC_PUSH1(&newsf);
-        jl_svecset(newsf, 0, sig.rt);
-        jl_svecset(newsf, 1, jl_box_voidpointer((void*)cw_proto));
-        for (i = 0; i < oldlen; i++)
-            jl_svecset(newsf, i + 2, jl_svecref(oldsf, i));
-        sf->func.value = newsf;
-        jl_gc_wb(sf, sf->func.value);
-        JL_GC_POP();
-    }
 
     jl_codectx_t ctx(jl_LLVMContext, params);
     ctx.f = cw;
@@ -4515,6 +4500,10 @@ static Function* gen_cfun_wrapper(
         cw_proto = into ? cw_make : function_proto(cw_make);
     }
 
+    if (aliasname) {
+        GlobalAlias::create(cw->getType()->getElementType(), cw->getType()->getAddressSpace(),
+                            GlobalValue::ExternalLinkage, aliasname, cw, M);
+    }
     if (!into)
         jl_finalize_module(std::unique_ptr<Module>(M));
 
@@ -4628,8 +4617,8 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
     jl_method_instance_t *lam = sigt ? jl_get_specialization1((jl_tupletype_t*)sigt, world, &min_valid, &max_valid, 0) : NULL;
     Value *F = gen_cfun_wrapper(
             jl_Module, ctx.emission_context,
-            sig, fexpr_rt.constant,
-            NULL, declrt, lam,
+            sig, fexpr_rt.constant, NULL,
+            declrt, lam,
             unionall_env, sparam_vals, &closure_types);
     bool outboxed;
     if (nest) {
@@ -4689,116 +4678,54 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
     return mark_julia_type(ctx, F, outboxed, output_type);
 }
 
-const struct jl_typemap_info cfunction_cache = {
-    1, (jl_datatype_t**)&jl_array_any_type
-};
-
-jl_array_t *jl_cfunction_list;
-
-Function *jl_cfunction_object(jl_function_t *ff, jl_value_t *declrt, jl_tupletype_t *argt,
-                              jl_codegen_params_t &params)
+// do codegen to create a C-callable alias/wrapper, or if sysimg_handle is set,
+// restore one from a loaded system image.
+Function *jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params)
 {
-    // Assumes the codegen lock is acquired. The caller is responsible for that.
-    jl_ptls_t ptls = jl_get_ptls_states();
-    if (ptls->in_pure_callback)
-        jl_error("cfunction cannot be used in a generated function");
-
-    // validate and unpack the arguments
-    JL_TYPECHK(cfunction, type, declrt);
-    if (!jl_is_tuple_type(argt)) // the C API requires that argt Tuple type actually be an svec
-        jl_type_error("cfunction", (jl_value_t*)jl_anytuple_type_type, (jl_value_t*)argt);
-    // trampolines are not supported here:
-    // check that f is a guaranteed singleton type
-    jl_value_t *ft = jl_typeof(ff);
-    if (((jl_datatype_t*)ft)->instance != ff)
-        jl_error("cfunction: use `@cfunction` to make closures");
-
-    // check the cache structure
-    // this has three levels (for the 3 parameters above)
-    // first split on `ft` using a simple eqtable
-    // then use the typemap to split on argt
-    // and finally, pick declrt from the pair-list
-    jl_typemap_t *cache_l2 = NULL;
-    jl_typemap_entry_t *cache_l3 = NULL;
-    if (!jl_cfunction_list) {
-        jl_cfunction_list = jl_alloc_vec_any(16);
-    }
-    else {
-        cache_l2 = jl_eqtable_get(jl_cfunction_list, ft, NULL);
-        if (cache_l2) {
-            struct jl_typemap_assoc search = {(jl_value_t*)argt, 1, NULL, 0, ~(size_t)0};
-            cache_l3 = jl_typemap_assoc_by_type(cache_l2, &search, /*offs*/0, /*subtype*/0);
-            if (cache_l3) {
-                jl_svec_t *sf = (jl_svec_t*)cache_l3->func.value;
-                size_t i, l = jl_svec_len(sf);
-                for (i = 0; i < l; i += 2) {
-                    jl_value_t *ti = jl_svecref(sf, i);
-                    if (jl_egal(ti, declrt)) {
-                        return (Function*)jl_unbox_voidpointer(jl_svecref(sf, i + 1));
-                    }
-                }
-            }
-        }
-    }
-
-    if (cache_l3 == NULL) {
-        jl_typemap_t *insert = cache_l2;
-        if (!insert)
-            insert = jl_nothing;
-        cache_l3 = jl_typemap_insert(&insert, (jl_value_t*)insert, (jl_tupletype_t*)argt,
-            NULL, jl_emptysvec, (jl_value_t*)jl_emptysvec, /*offs*/0, &cfunction_cache, 1, ~(size_t)0);
-        if (insert != cache_l2)
-            jl_cfunction_list = jl_eqtable_put(jl_cfunction_list, ft, insert, NULL);
-    }
-
-    // compute / validate return type
+    jl_datatype_t *ft = (jl_datatype_t*)jl_tparam0(sigt);
+    jl_value_t *ff = ft->instance;
+    assert(ff);
+    const char *name = jl_symbol_name(ft->name->mt->name);
     jl_value_t *crt = declrt;
     if (jl_is_abstract_ref_type(declrt)) {
         declrt = jl_tparam0(declrt);
-        if (jl_is_typevar(declrt))
-            jl_error("cfunction: return type Ref should have an element type, not Ref{<:T}");
-        if (declrt == (jl_value_t*)jl_any_type)
-            jl_error("cfunction: return type Ref{Any} is invalid. Use Any or Ptr{Any} instead.");
         crt = (jl_value_t*)jl_any_type;
     }
     bool toboxed;
     Type *lcrt = _julia_struct_to_llvm(&params, crt, NULL, &toboxed);
-    if (lcrt == NULL)
-        jl_error("cfunction: return type doesn't correspond to a C type");
-    else if (toboxed)
+    if (toboxed)
         lcrt = T_prjlvalue;
-
-    // compute / validate method signature
-    jl_value_t *sigt = NULL; // dispatch sig: type signature (argt) with Ref{} annotations removed and ft added
-    JL_GC_PUSH1(&sigt);
-    size_t i, nargs = jl_nparams(argt);
-    sigt = (jl_value_t*)jl_alloc_svec(nargs + 1);
-    jl_svecset(sigt, 0, ft);
-    for (i = 0; i < nargs; i++) {
-        jl_value_t *ati = jl_tparam(argt, i);
-        if (jl_is_abstract_ref_type(ati)) {
-            ati = jl_tparam0(ati);
-            if (jl_is_typevar(ati))
-                jl_error("cfunction: argument type Ref should have an element type, not Ref{<:T}");
-        }
-        if (jl_is_pointer(ati) && jl_is_typevar(jl_tparam0(ati)))
-            jl_error("cfunction: argument type Ptr should have an element type, Ptr{<:T}");
-        jl_svecset(sigt, i + 1, ati);
+    size_t nargs = jl_nparams(sigt)-1;
+    jl_svec_t *argtypes = NULL;
+    JL_GC_PUSH1(&argtypes);
+    argtypes = jl_alloc_svec(nargs);
+    for (size_t i = 0; i < nargs; i++) {
+        jl_svecset(argtypes, i, jl_tparam(sigt, i+1));
     }
-    sigt = (jl_value_t*)jl_apply_tuple_type((jl_svec_t*)sigt);
-
-    // emit cfunction (trampoline)
     jl_value_t *err;
     { // scope block for sig
         function_sig_t sig("cfunction", lcrt, crt, toboxed,
-                           argt->parameters, NULL, false, CallingConv::C, false, &params);
+                           argtypes, NULL, false, CallingConv::C, false, &params);
         if (sig.err_msg.empty()) {
             size_t world = jl_world_counter;
             size_t min_valid = 0;
             size_t max_valid = ~(size_t)0;
-            // try to look up this function for direct invoking
-            jl_method_instance_t *lam = jl_get_specialization1((jl_tupletype_t*)sigt, world, &min_valid, &max_valid, 0);
-            Function *F = gen_cfun_wrapper(NULL, params, sig, ff, cache_l3, declrt, lam, NULL, NULL, NULL);
+            Function *F = NULL;
+            if (sysimg_handle) {
+                // restore a ccallable from the system image
+                void *addr;
+                int found = jl_dlsym(sysimg_handle, name, &addr, 0);
+                if (found) {
+                    FunctionType *ftype = sig.functype();
+                    F = Function::Create(ftype, GlobalVariable::ExternalLinkage,
+                                         name, shadow_output);
+                    add_named_global(F, addr);
+                }
+            }
+            else {
+                jl_method_instance_t *lam = jl_get_specialization1((jl_tupletype_t*)sigt, world, &min_valid, &max_valid, 0);
+                F = gen_cfun_wrapper((Module*)llvmmod, params, sig, ff, name, declrt, lam, NULL, NULL, NULL);
+            }
             JL_GC_POP();
             return F;
         }

--- a/src/gc.c
+++ b/src/gc.c
@@ -2672,8 +2672,6 @@ static void mark_roots(jl_gc_mark_cache_t *gc_cache, jl_gc_mark_sp_t *sp)
             gc_mark_queue_obj(gc_cache, sp, jl_current_modules.table[i]);
         }
     }
-    if (jl_cfunction_list != NULL)
-        gc_mark_queue_obj(gc_cache, sp, jl_cfunction_list);
     gc_mark_queue_obj(gc_cache, sp, jl_anytuple_type_type);
     for (size_t i = 0; i < N_CALL_CACHE; i++)
         if (call_cache[i])

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2117,7 +2117,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(23,
+                        jl_perm_symsvec(24,
                             "name",
                             "module",
                             "file",
@@ -2134,6 +2134,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             "unspecialized",
                             "generator",
                             "roots",
+                            "ccallable",
                             "invokes",
                             "nargs",
                             "called",
@@ -2141,7 +2142,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             "nkw",
                             "isva",
                             "pure"),
-                        jl_svec(23,
+                        jl_svec(24,
                             jl_symbol_type,
                             jl_module_type,
                             jl_symbol_type,
@@ -2158,6 +2159,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_any_type, // jl_method_instance_type
                             jl_any_type,
                             jl_array_any_type,
+                            jl_simplevector_type,
                             jl_any_type,
                             jl_int32_type,
                             jl_int32_type,

--- a/src/julia.h
+++ b/src/julia.h
@@ -298,6 +298,7 @@ typedef struct _jl_method_t {
     struct _jl_method_instance_t *unspecialized;  // unspecialized executable method instance, or null
     jl_value_t *generator;  // executable code-generating function if available
     jl_array_t *roots;  // pointers in generated code (shared to reduce memory), or null
+    jl_svec_t *ccallable; // svec(rettype, sig) if a ccallable entry point is requested for this
 
     // cache of specializations of this method for invoke(), i.e.
     // cases where this method was called even though it was not necessarily

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -507,7 +507,7 @@ void jl_module_run_initializer(jl_module_t *m);
 jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var) JL_NOTSAFEPOINT;
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
-extern jl_array_t *jl_cfunction_list JL_GLOBALLY_ROOTED;
+JL_DLLEXPORT void jl_compile_extern_c(void *llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
 
 #ifdef JL_USE_INTEL_JITEVENTS
 extern char jl_using_intel_jitevents;

--- a/src/method.c
+++ b/src/method.c
@@ -592,6 +592,7 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     m->ambig = jl_nothing;
     m->resorted = jl_nothing;
     m->roots = NULL;
+    m->ccallable = NULL;
     m->module = module;
     m->source = NULL;
     m->unspecialized = NULL;

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -362,6 +362,8 @@ static int precompile_enq_all_specializations__(jl_typemap_entry_t *def, void *c
                 precompile_enq_specialization_(mi, closure);
         }
     }
+    if (m->ccallable)
+        jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)m->ccallable);
     return 1;
 }
 
@@ -386,13 +388,21 @@ void *jl_precompile(int all)
     jl_foreach_reachable_mtable(precompile_enq_all_specializations_, m);
     m2 = jl_alloc_vec_any(0);
     for (size_t i = 0; i < jl_array_len(m); i++) {
-        mi = (jl_method_instance_t*)jl_array_ptr_ref(m, i);
-        size_t min_world = 0;
-        size_t max_world = ~(size_t)0;
-        if (!jl_isa_compileable_sig((jl_tupletype_t*)mi->specTypes, mi->def.method))
-            mi = jl_get_specialization1((jl_tupletype_t*)mi->specTypes, jl_world_counter, &min_world, &max_world, 0);
-        if (mi)
-            jl_array_ptr_1d_push(m2, (jl_value_t*)mi);
+        jl_value_t *item = jl_array_ptr_ref(m, i);
+        if (jl_is_method_instance(item)) {
+            mi = (jl_method_instance_t*)item;
+            size_t min_world = 0;
+            size_t max_world = ~(size_t)0;
+            if (!jl_isa_compileable_sig((jl_tupletype_t*)mi->specTypes, mi->def.method))
+                mi = jl_get_specialization1((jl_tupletype_t*)mi->specTypes, jl_world_counter, &min_world, &max_world, 0);
+            if (mi)
+                jl_array_ptr_1d_push(m2, (jl_value_t*)mi);
+        }
+        else {
+            assert(jl_is_simplevector(item));
+            assert(jl_svec_len(item) == 2);
+            jl_array_ptr_1d_push(m2, item);
+        }
     }
     m = NULL;
     void *native_code = jl_create_native(m2, jl_default_cgparams);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -105,6 +105,9 @@ static arraylist_t builtin_typenames;
 // during deserialization later
 static arraylist_t reinit_list;
 
+// @ccallable entry points to install
+static arraylist_t ccallable_list;
+
 // hash of definitions for predefined function pointers
 static htable_t fptr_to_id;
 void *native_functions;
@@ -784,6 +787,10 @@ static void jl_write_values(jl_serializer_state *s)
 
             if (jl_is_method(v)) {
                 write_padding(s->s, sizeof(jl_method_t) - tot);
+                if (((jl_method_t*)v)->ccallable) {
+                    arraylist_push(&ccallable_list, (void*)item);
+                    arraylist_push(&ccallable_list, (void*)3);
+                }
             }
             else if (jl_is_code_instance(v)) {
                 jl_code_instance_t *m = (jl_code_instance_t*)v;
@@ -1209,18 +1216,18 @@ static void jl_update_all_gvars(jl_serializer_state *s)
 }
 
 
-static void jl_finalize_serializer(jl_serializer_state *s)
+static void jl_finalize_serializer(jl_serializer_state *s, arraylist_t *list)
 {
     size_t i, l;
 
     // record list of reinitialization functions
-    l = reinit_list.len;
+    l = list->len;
     for (i = 0; i < l; i += 2) {
-        size_t item = (size_t)reinit_list.items[i];
+        size_t item = (size_t)list->items[i];
         size_t reloc_offset = (size_t)layout_table.items[item];
         assert(reloc_offset != 0);
         write_uint32(s->s, (uint32_t)reloc_offset);
-        write_uint32(s->s, (uint32_t)((uintptr_t)reinit_list.items[i + 1]));
+        write_uint32(s->s, (uint32_t)((uintptr_t)list->items[i + 1]));
     }
     write_uint32(s->s, 0);
 }
@@ -1257,6 +1264,11 @@ static void jl_reinit_item(jl_value_t *v, int how)
                 memcpy(newitems, mod->usings.items, mod->usings.len * sizeof(void*));
                 mod->usings.items = newitems;
             }
+            break;
+        }
+        case 3: { // install ccallable entry point in JIT
+            jl_svec_t *sv = ((jl_method_t*)v)->ccallable;
+            jl_compile_extern_c(NULL, NULL, jl_sysimg_handle, jl_svecref(sv, 0), jl_svecref(sv, 1));
             break;
         }
         default:
@@ -1320,6 +1332,7 @@ static void jl_save_system_image_to_stream(ios_t *f)
     jl_init_serializer2(1);
     htable_reset(&backref_table, 250000);
     arraylist_new(&reinit_list, 0);
+    arraylist_new(&ccallable_list, 0);
     backref_table_numel = 0;
     ios_t sysimg, const_data, symbols, relocs, gvar_record, fptr_record;
     ios_mem(&sysimg,     1000000);
@@ -1425,11 +1438,13 @@ static void jl_save_system_image_to_stream(ios_t *f)
         write_uint32(f, jl_get_gs_ctr());
         write_uint32(f, jl_world_counter);
         write_uint32(f, jl_typeinf_world);
-        jl_finalize_serializer(&s);
+        jl_finalize_serializer(&s, &reinit_list);
+        jl_finalize_serializer(&s, &ccallable_list);
     }
 
     arraylist_free(&layout_table);
     arraylist_free(&reinit_list);
+    arraylist_free(&ccallable_list);
     arraylist_free(&s.relocs_list);
     arraylist_free(&s.gctags_list);
     jl_cleanup_serializer2();
@@ -1577,6 +1592,7 @@ static void jl_restore_system_image_from_stream(ios_t *f)
     s.s = NULL;
 
     s.s = f;
+    // reinit items except ccallables
     jl_finalize_deserializer(&s);
     s.s = NULL;
 
@@ -1601,6 +1617,10 @@ static void jl_restore_system_image_from_stream(ios_t *f)
     s.s = &sysimg;
     jl_init_codegen();
     jl_update_all_fptrs(&s); // fptr relocs and registration
+    // reinit ccallables, which require codegen to be initialized
+    s.s = f;
+    jl_finalize_deserializer(&s);
+
     ios_close(&fptr_record);
     ios_close(&sysimg);
     s.s = NULL;


### PR DESCRIPTION
fixes #35014

The approach I took is to add a field to `Method` storing the needed return type and signature if a C entry point is requested for that method. `jl_compile_extern_c` is called to inform the JIT during loading, or after loading a .ji or system image. The signatures are also added to the data passed to `jl_create_native` to tell it to include aliases in the system image.

A possible simplification is to require the argument types to be specific enough to be specialized. Currently, we allow `@ccallable f(x::Any) = ...`, in which case we need to generate a wrapper accepting any value and doing dynamic dispatch. If we required specific types, e.g. `f(x::Cint)`, then every ccallable would be associated with a single MethodInstance, and we'd just generate the alias whenever the instance is compiled.

It's not clear whether this feature is needed in the JIT, or just system images (i.e. only when you want to link a C program with direct calls against sys.so). The JIT case takes a bunch of the code here.

A separate problem to fix in the near future is that I believe ccallable and possibly also cfunction are always using jl_apply_generic when compiled into a system image, since `gen_cfun_wrapper` doesn't use the new mechanism for looking up call targets (there is already a TODO comment about the recursive compilation done there).
