### PR TITLE
fix buggy rand(RandomDevice(), Bool)

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -25,6 +25,7 @@ else # !windows
     end
 
     rand(rd::RandomDevice, sp::SamplerBoolBitInteger) = read(getfile(rd), sp[])
+    rand(rd::RandomDevice, ::SamplerType{Bool}) = read(getfile(rd), UInt8) % Bool
 
     function getfile(rd::RandomDevice)
         devrandom = rd.unlimited ? DEV_URANDOM : DEV_RANDOM


### PR DESCRIPTION
The tests might seem overkill for this particular bug, but I was writing them for #33721, so they will still be useful. 

An alternative fix might be to define `read(s::IO, ::Type{Bool}) = read(s, UInt8) % Bool` instead of `read(s, UInt8) != 0`.
Both definitions coincide if `Bool`s are stored in "canonical binary representation", and the definition of `read` seems to leave the result unspecified for non-canonical `Bool`.

