### PR TITLE
Recommend to use tuples to scalarize items in broadcast expressions

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -18,6 +18,17 @@ converted to a native pointer to the data it references.
 
 There is no invalid (NULL) `Ref` in Julia, but a `C_NULL` instance of `Ptr` can be passed to
 a `ccall` Ref argument.
+
+# Use in broadcasting
+`Ref` is sometimes used in broadcasting in order to treat the referenced values as a scalar:
+
+```jldoctest
+julia> isa.(Ref([1,2,3]), [Array, Dict, Int])
+3-element BitArray{1}:
+ 1
+ 0
+ 0
+```
 """
 Ref
 

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -18,17 +18,6 @@ converted to a native pointer to the data it references.
 
 There is no invalid (NULL) `Ref` in Julia, but a `C_NULL` instance of `Ptr` can be passed to
 a `ccall` Ref argument.
-
-# Use in broadcasting
-
-Broadcasting with `Ref(x)` treats `x` as a scalar:
-```jldoctest
-julia> isa.(Ref([1,2,3]), [Array, Dict, Int])
-3-element BitArray{1}:
- 1
- 0
- 0
-```
 """
 Ref
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -945,6 +945,16 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
  "3. Third"
 ```
 
+Sometimes, you have a non-scalar object like an array that you wish to treat as a scalar in a particular
+broadcast expression. This is best done by wrapping that item in a [`Tuple`](@ref)
+```jldoctest
+julia> ([1, 2, 3], [4, 5, 6]) .+ ([1, 2, 3],)
+([2, 4, 6], [5, 7, 9])
+
+julia> ([1, 2, 3], [4, 5, 6]) .+ tuple([1, 2, 3])
+([2, 4, 6], [5, 7, 9])
+```
+
 ## Implementation
 
 The base array type in Julia is the abstract type [`AbstractArray{T,N}`](@ref). It is parameterized by

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -945,8 +945,9 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
  "3. Third"
 ```
 
-Sometimes, you have a non-scalar object like an array that you don't wish to broadcast into in a particular
-broadcast expression. This is best done by wrapping that item in a [`Tuple`](@ref)
+Sometimes, you want a container (like an array) that would normally participate in broadcast to be "protected" 
+from broadcast's behavior of iterating over all of its elements. By placing it inside another container 
+(like a single element [`Tuple`](@ref)) broadcast will treat it as a single value.
 ```jldoctest
 julia> ([1, 2, 3], [4, 5, 6]) .+ ([1, 2, 3],)
 ([2, 4, 6], [5, 7, 9])

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -933,7 +933,7 @@ julia> convert.(Float32, [1, 2])
  1.0
  2.0
 
-julia> ceil.((UInt8,), [1.2 3.4; 5.6 6.7])
+julia> ceil.(UInt8, [1.2 3.4; 5.6 6.7])
 2×2 Array{UInt8,2}:
  0x02  0x04
  0x06  0x07

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -945,7 +945,7 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
  "3. Third"
 ```
 
-Sometimes, you have a non-scalar object like an array that you wish to treat as a scalar in a particular
+Sometimes, you have a non-scalar object like an array that you don't wish to broadcast into in a particular
 broadcast expression. This is best done by wrapping that item in a [`Tuple`](@ref)
 ```jldoctest
 julia> ([1, 2, 3], [4, 5, 6]) .+ ([1, 2, 3],)

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -945,8 +945,8 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
  "3. Third"
 ```
 
-Sometimes, you want a container (like an array) that would normally participate in broadcast to be "protected" 
-from broadcast's behavior of iterating over all of its elements. By placing it inside another container 
+Sometimes, you want a container (like an array) that would normally participate in broadcast to be "protected"
+from broadcast's behavior of iterating over all of its elements. By placing it inside another container
 (like a single element [`Tuple`](@ref)) broadcast will treat it as a single value.
 ```jldoctest
 julia> ([1, 2, 3], [4, 5, 6]) .+ ([1, 2, 3],)


### PR DESCRIPTION
There's a lot of conflicting advice out there on what one should do in order to treat a given object as a scalar in a broadcast expression. Perhaps the most common practice is to use `Ref`, but this is arguably not the intended use of `Ref` and can be less performant than `tuple` because `Ref` (currently) blocks constant propagation. For a contrived example:
```julia
julia> using StaticArrays, BenchmarkTools

julia> us = (SA[1,2,3], SA[4,5,6]); v = SA[7,8,9]
3-element SArray{Tuple{3},Int64,1,3} with indices SOneTo(3):
 7
 8
 9

julia> @btime $us .+ Ref($v)
  2.839 ns (0 allocations: 0 bytes)
([8, 10, 12], [11, 13, 15])

julia> @btime $us .+ ($v,)
  0.020 ns (0 allocations: 0 bytes)
([8, 10, 12], [11, 13, 15])
```
This difference is perhaps inconsequential currently, but in a future where Julia is better able to reason about non-mutated arrays it could become more important, so I think it's better to recommend a more future-proof style. Of course, one could say that in that future `Ref` might also play better with constant prop, but I think that may be undesirable because `Ref` is often used for explicitly blocking constant prop, i.e. in benchmarking. 

____________________

I also modified an example that wrote `ceil.((UInt8,), [1.2 3.4; 5.6 6.7])` to instead say `ceil.(UInt8, [1.2 3.4; 5.6 6.7])` because there is no reason to wrap `UInt8` in a tuple since it is already a broadcast scalar. 