### PR TITLE
[GCChecker] teach it how to deal with more complex expressions

### DIFF
--- a/src/atomics.h
+++ b/src/atomics.h
@@ -68,8 +68,6 @@
     __sync_bool_compare_and_swap(obj, expected, desired)
 #  define jl_atomic_exchange(obj, desired)              \
     __atomic_exchange_n(obj, desired, __ATOMIC_SEQ_CST)
-#  define jl_atomic_exchange_generic(obj, desired, orig)\
-    __atomic_exchange(obj, desired, orig, __ATOMIC_SEQ_CST)
 #  define jl_atomic_exchange_relaxed(obj, desired)      \
     __atomic_exchange_n(obj, desired, __ATOMIC_RELAXED)
 // TODO: Maybe add jl_atomic_compare_exchange_weak for spin lock
@@ -123,7 +121,6 @@ jl_atomic_fetch_add(T *obj, T2 arg)
 {
     return (T)_InterlockedExchangeAdd64((volatile __int64*)obj, (__int64)arg);
 }
-// TODO: jl_atomic_exchange_generic
 #define jl_atomic_fetch_add_relaxed(obj, arg) jl_atomic_fetch_add(obj, arg)
 
 // and
@@ -285,5 +282,42 @@ static inline T jl_atomic_load_acquire(volatile T *obj)
 #else
 #  error "No atomic operations supported."
 #endif
+
+#ifdef __clang_analyzer__
+// for the purposes of the analyzer, we can turn these into non-atomic expressions with similar properties
+
+#undef jl_atomic_exchange
+#undef jl_atomic_exchange_relaxed
+#define jl_atomic_exchange(obj, desired) \
+    (__extension__({ \
+            __typeof__((obj)) p = (obj); \
+            __typeof__(*p) temp = *p; \
+            *p = desired; \
+            temp; \
+        }))
+#define jl_atomic_exchange_relaxed jl_atomic_exchange
+
+#undef jl_atomic_compare_exchange
+#define jl_atomic_compare_exchange(obj, expected, desired) ((expected), jl_atomic_exchange((obj), (desired)))
+
+#undef jl_atomic_bool_compare_exchange
+#define jl_atomic_bool_compare_exchange(obj, expected, desired) ((expected) == jl_atomic_exchange((obj), (desired)))
+
+#undef jl_atomic_store
+#undef jl_atomic_store_release
+#undef jl_atomic_store_relaxed
+#define jl_atomic_store(obj, val)         (*(obj) = (val))
+#define jl_atomic_store_release(obj, val) (*(obj) = (val))
+#define jl_atomic_store_relaxed(obj, val) (*(obj) = (val))
+
+#undef jl_atomic_load
+#undef jl_atomic_load_acquire
+#undef jl_atomic_load_relaxed
+#define jl_atomic_load(obj)         (*(obj))
+#define jl_atomic_load_acquire(obj) (*(obj))
+#define jl_atomic_load_relaxed(obj) (*(obj))
+
+#endif
+
 
 #endif // JL_ATOMICS_H

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -479,6 +479,7 @@ void STATIC_INLINE _grow_to(jl_value_t **root, jl_value_t ***oldargs, jl_svec_t 
     if (extra)
         // grow by an extra 50% if newalloc is still only a guess
         newalloc += oldalloc / 2 + 16;
+    JL_GC_PROMISE_ROOTED(*oldargs);
     jl_svec_t *newheap = _copy_to(newalloc, *oldargs, oldalloc);
     *root = (jl_value_t*)newheap;
     *arg_heap = newheap;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -556,9 +556,13 @@ static jl_value_t *do_apply(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl
     else {
         // put arguments on the heap if there are too many
         newargs = NULL;
-        n_alloc = 0;
-        assert(precount > 0); // let optimizer know this won't overflow
-        _grow_to(&roots[0], &newargs, &arg_heap, &n_alloc, precount, extra);
+        n_alloc = precount;
+        if (extra)
+            // grow by an extra 50% if newalloc is still only a guess
+            n_alloc += n_alloc / 2 + 16;
+        arg_heap = jl_alloc_svec(n_alloc);
+        roots[0] = (jl_value_t*)arg_heap;
+        newargs = jl_svec_data(arg_heap);
     }
     newargs[0] = f;
     precount -= 1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -120,7 +120,6 @@ JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m J
             ssize_t idx = jl_smallintset_lookup(speckeyset, speccache_eq, type, specializations, hv);
             if (idx != -1) {
                 jl_method_instance_t *mi = (jl_method_instance_t*)jl_svecref(specializations, idx);
-                JL_GC_PROMISE_ROOTED(mi); // clang-sa doesn't understand jl_atomic_load_relaxed
                 if (locked)
                     JL_UNLOCK(&m->writelock);
                 return mi;
@@ -131,7 +130,6 @@ JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m J
             JL_GC_PUSH1(&specializations); // clang-sa doesn't realize this loop uses specializations
             for (i = cl; i > 0; i--) {
                 jl_method_instance_t *mi = jl_atomic_load_relaxed(&data[i - 1]);
-                JL_GC_PROMISE_ROOTED(mi); // clang-sa doesn't understand jl_atomic_load_relaxed
                 if (mi == NULL)
                     break;
                 if (jl_types_equal(mi->specTypes, type)) {
@@ -153,7 +151,6 @@ JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m J
                 jl_method_instance_t **data = (jl_method_instance_t**)jl_svec_data(specializations);
                 for (i = 0; i < cl; i++) {
                     jl_method_instance_t *mi = jl_atomic_load_relaxed(&data[i]);
-                    JL_GC_PROMISE_ROOTED(mi); // clang-sa doesn't understand jl_atomic_load_relaxed
                     if (mi == NULL)
                         break;
                     assert(!jl_types_equal(mi->specTypes, type));
@@ -172,7 +169,6 @@ JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m J
                            (char*)jl_svec_data(specializations) + sizeof(void*) * i,
                            sizeof(void*) * (cl - i));
                 jl_atomic_store_release(&m->specializations, nc);
-                JL_GC_PROMISE_ROOTED(nc); // clang-sa doesn't understand jl_atomic_store_release
                 jl_gc_wb(m, nc);
                 specializations = nc;
                 if (!hv)

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1152,9 +1152,12 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
     }
 
     param = (param == 0 ? 1 : param);
-    env.lastx = env.lasty=NULL;
-    env.vtx = env.vty=NULL;
-    return subtype_tuple_tail(&env, 0, e, param);
+    env.lastx = env.lasty = NULL;
+    env.vtx = env.vty = NULL;
+    JL_GC_PUSH2(&env.vtx, &env.vty);
+    int ans = subtype_tuple_tail(&env, 0, e, param);
+    JL_GC_POP();
+    return ans;
 }
 
 static int subtype_naked_vararg(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, int param)


### PR DESCRIPTION
This helps the GCChecker deal with the atomics macros (by translating them to their equivalent non-atomic operation), and causes it to discover what appears to be true missing root in subtyping. (The first two commits could be pulled out and landed on master separately.)