### PR TITLE
SPQR: allow user-selected ordering

### DIFF
--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -17,6 +17,9 @@ const ORDERING_METIS   = Int32(6) # metis(A'*A)
 const ORDERING_DEFAULT = Int32(7) # SuiteSparseQR default ordering
 const ORDERING_BEST    = Int32(8) # try COLAMD, AMD, and METIS; pick best
 const ORDERING_BESTAMD = Int32(9) # try COLAMD and AMD; pick best#
+const ORDERINGS = [ORDERING_FIXED, ORDERING_NATURAL, ORDERING_COLAMD, ORDERING_CHOLMOD,
+                   ORDERING_AMD, ORDERING_METIS, ORDERING_DEFAULT, ORDERING_BEST,
+                   ORDERING_BESTAMD]
 
 # Let [m n] = size of the matrix after pruning singletons.  The default
 # ordering strategy is to use COLAMD if m <= 2*n.  Otherwise, AMD(A'A) is
@@ -39,6 +42,8 @@ function _qr!(ordering::Integer, tol::Real, econ::Integer, getCTX::Integer,
         H::Union{Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}        , Ptr{Cvoid}} = C_NULL,
         HPinv::Union{Ref{Ptr{CHOLMOD.SuiteSparse_long}}, Ptr{Cvoid}} = C_NULL,
         HTau::Union{Ref{Ptr{CHOLMOD.C_Dense{Tv}}}      , Ptr{Cvoid}} = C_NULL) where {Tv<:CHOLMOD.VTypes}
+
+    ordering ∈ ORDERINGS || error("unknown ordering $ordering")
 
     AA   = unsafe_load(pointer(A))
     m, n = AA.nrow, AA.ncol
@@ -189,7 +194,7 @@ Column permutation:
  2
 ```
 """
-function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A)) where {Tv <: CHOLMOD.VTypes}
+function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Tv <: CHOLMOD.VTypes}
     R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
     E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
     H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
@@ -197,7 +202,7 @@ function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A)) where {Tv
     HTau  = Ref{Ptr{CHOLMOD.C_Dense{Tv}}}(C_NULL)
 
     # SPQR doesn't accept symmetric matrices so we explicitly set the stype
-    r, p, hpinv = _qr!(ORDERING_DEFAULT, tol, 0, 0, Sparse(A, 0),
+    r, p, hpinv = _qr!(ordering, tol, 0, 0, Sparse(A, 0),
         C_NULL, C_NULL, C_NULL, C_NULL,
         R, E, H, HPinv, HTau)
 
@@ -419,6 +424,10 @@ function _ldiv_basic(F::QRSparse, B::StridedVecOrMat)
                         view(X0, Base.OneTo(rnk), :))
 
     # Apply right permutation and extract solution from X
+    # NB: cpiv == [] if SPQR was called with ORDERING_FIXED
+    if length(F.cpiv) == 0
+      return getindex(X, ntuple(i -> i == 1 ? (1:size(F,2)) : :, Val(ndims(B)))...)
+    end
     return getindex(X, ntuple(i -> i == 1 ? invperm(F.cpiv) : :, Val(ndims(B)))...)
 end
 


### PR DESCRIPTION
This PR adds the `ordering` kwarg to `qr()` for sparse matrices (which calls SuiteSparseQR) so the user can select one of the orderings exposed by SPQR.
The default value of `ordering` is `ORDERING_DEFAULT` so that the default behavior is unchanged.

A little care must be taken when returning from `_ldiv_basic` because if `ordering == ORDERING_FIXED`, SPQR returns an empty column permutation (to indicate that no permutation occurred). ~~I tried writing the `return` statement so it's more readable but got errors in the threaded SuiteSparse tests.~~

I added tests for over- and under-determined problems.

@andreasnoack 