### PR TITLE
remove `Ref` allocation on task switch

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2645,6 +2645,8 @@ static void jl_gc_queue_thread_local(jl_gc_mark_cache_t *gc_cache, jl_gc_mark_sp
 {
     gc_mark_queue_obj(gc_cache, sp, ptls2->current_task);
     gc_mark_queue_obj(gc_cache, sp, ptls2->root_task);
+    if (ptls2->next_task)
+        gc_mark_queue_obj(gc_cache, sp, ptls2->next_task);
     if (ptls2->previous_exception)
         gc_mark_queue_obj(gc_cache, sp, ptls2->previous_exception);
 }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1011,6 +1011,7 @@ JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);
 
 JL_DLLEXPORT uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_get_current_task(void);
+JL_DLLEXPORT void jl_set_next_task(jl_task_t *task);
 
 // -- synchronization utilities -- //
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -185,6 +185,7 @@ struct _jl_tls_states_t {
     uv_cond_t wake_signal;
     volatile sig_atomic_t defer_signal;
     struct _jl_task_t *current_task;
+    struct _jl_task_t *next_task;
 #ifdef MIGRATE_TASKS
     struct _jl_task_t *previous_task;
 #endif

--- a/src/threading.c
+++ b/src/threading.c
@@ -285,6 +285,7 @@ void jl_init_threadtls(int16_t tid)
     ptls->bt_data = bt_data;
     ptls->sig_exception = NULL;
     ptls->previous_exception = NULL;
+    ptls->next_task = NULL;
 #ifdef _OS_WINDOWS_
     ptls->needs_resetstkoflw = 0;
 #endif


### PR DESCRIPTION
pfib(31) before:
```
  3.180960 seconds (14.34 M allocations: 1.512 GiB, 28.57% gc time)
```
after:
```
  2.835908 seconds (10.89 M allocations: 1.461 GiB, 21.35% gc time)
```

The times are pretty variable, and the GC is doing a good job here, but reducing the allocation workload here is surely worth it.

(also needs #35589 to get this result)
