### PR TITLE
Support setting MCPU during Make, for ARM

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -686,7 +686,7 @@ override ARCH := $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
 else
 ifneq ($(XC_HOST),)
 XC_HOST := $(ARCH)$(shell echo $(XC_HOST) | sed "s/[^-]*\(.*\)$$/\1/")
-ifneq (,$(filter ,$(findstring arm, $(ARCH)) $(findstring aarch64, $(ARCH))))
+ifneq ($(findstring arm, $(ARCH))$(findstring aarch64, $(ARCH)),)
 MCPU := $(subst _,-,$(ARCH)) # Arm prefers MCPU over MARCH
 else
 MARCH := $(subst _,-,$(ARCH))
@@ -819,14 +819,12 @@ OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
 endif
 
-do_step =
 # Set MARCH-specific flags
 ifneq ($(MARCH),)
 CC += -march=$(MARCH)
 CXX += -march=$(MARCH)
 FC += -march=$(MARCH)
 JULIA_CPU_TARGET ?= $(MARCH)
-do_step = yes
 endif
 
 # Set MCPU-specific flags
@@ -835,10 +833,9 @@ CC += -mcpu=$(MCPU)
 CXX += -mcpu=$(MCPU)
 FC += -mcpu=$(MCPU)
 JULIA_CPU_TARGET ?= $(MCPU)
-do_step = yes
 endif
 
-ifdef do_step
+ifneq ($(MARCH)$(MCPU),)
 ifeq ($(OS),Darwin)
 # on Darwin, the standalone `as` program doesn't know
 # how to handle AVX instructions, but it does know how

--- a/Make.inc
+++ b/Make.inc
@@ -686,7 +686,11 @@ override ARCH := $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
 else
 ifneq ($(XC_HOST),)
 XC_HOST := $(ARCH)$(shell echo $(XC_HOST) | sed "s/[^-]*\(.*\)$$/\1/")
+ifneq ($(findstring arm, $(ARCH)),)
 MARCH := $(subst _,-,$(ARCH))
+else
+MCPU := $(subst _,-,$(ARCH)) # Arm prefers MCPU over MARCH
+endif
 else # insert ARCH into HOST
 XC_HOST := $(ARCH)$(shell echo $(BUILD_MACHINE) | sed "s/[^-]*\(.*\)$$/\1/")
 endif
@@ -815,12 +819,26 @@ OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
 endif
 
+do_step =
 # Set MARCH-specific flags
 ifneq ($(MARCH),)
 CC += -march=$(MARCH)
 CXX += -march=$(MARCH)
 FC += -march=$(MARCH)
 JULIA_CPU_TARGET ?= $(MARCH)
+do_step = yes
+endif
+
+# Set MCPU-specific flags
+ifneq ($(MCPU),)
+CC += -mcpu=$(MCPU)
+CXX += -mcpu=$(MCPU)
+FC += -mcpu=$(MCPU)
+JULIA_CPU_TARGET ?= $(MCPU)
+do_step = yes
+endif
+
+ifdef do_step
 ifeq ($(OS),Darwin)
 # on Darwin, the standalone `as` program doesn't know
 # how to handle AVX instructions, but it does know how

--- a/Make.inc
+++ b/Make.inc
@@ -686,10 +686,10 @@ override ARCH := $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
 else
 ifneq ($(XC_HOST),)
 XC_HOST := $(ARCH)$(shell echo $(XC_HOST) | sed "s/[^-]*\(.*\)$$/\1/")
-ifneq ($(findstring arm, $(ARCH)),)
-MARCH := $(subst _,-,$(ARCH))
-else
+ifneq (,$(filter ,$(findstring arm, $(ARCH)) $(findstring aarch64, $(ARCH))))
 MCPU := $(subst _,-,$(ARCH)) # Arm prefers MCPU over MARCH
+else
+MARCH := $(subst _,-,$(ARCH))
 endif
 else # insert ARCH into HOST
 XC_HOST := $(ARCH)$(shell echo $(BUILD_MACHINE) | sed "s/[^-]*\(.*\)$$/\1/")

--- a/doc/build/arm.md
+++ b/doc/build/arm.md
@@ -50,7 +50,7 @@ CPU target by adding the following to `Make.user`:
 ```JULIA_CPU_TARGET=cortex-a7```
 
 Depending on the exact compiler and distribution, there might be a build failure
-due to unsupported inline assembly. In that case, add `MARCH=armv7-a` to
+due to unsupported inline assembly. In that case, add `MCPU=armv7-a` to
 `Make.user`.
 
 ## AArch64 (ARMv8)
@@ -65,7 +65,7 @@ Julia has been successfully built on the following ARMv8 devices:
 Compilation on `ARMv8-A` requires that `Make.user` is configured as follows:
 
 ```
-MARCH=armv8-a
+MCPU=armv8-a
 ```
 
 ### nVidia Jetson TX2


### PR DESCRIPTION
As is outlined in https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu

> In short, you cannot support both x86 and Arm with exactly the same compiler flags.  You must use -mcpu for Arm and -march for x86.

I also opened up https://github.com/JuliaCI/julia-buildbot/pull/149 to switch arm builds to mcpu, before realizing I needed to also adjust the Make file here