### PR TITLE
change default ios buffer size to 32k

### DIFF
--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -352,10 +352,13 @@ value_t fl_ioreaduntil(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     cv->len = n;
     if (dest.buf != data) {
         // outgrew initial space
-        cv->data = dest.buf;
+        size_t sz;
+        cv->data = ios_take_buffer(&dest, &sz);
         cv_autorelease(fl_ctx, cv);
     }
-    ((char*)cv->data)[n] = '\0';
+    else {
+        ((char*)cv->data)[n] = '\0';
+    }
     if (n == 0 && ios_eof(src))
         return fl_ctx->FL_EOF;
     return str;

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -1203,10 +1203,14 @@ int ios_vprintf(ios_t *s, const char *format, va_list args)
         char *start = s->buf + s->bpos;
         c = vsnprintf(start, avail, format, args);
         if (c < 0) {
+#if defined(_OS_WINDOWS_)
+            // on windows this can mean not enough space was available
+#else
             va_end(al);
             return c;
+#endif
         }
-        if (c < avail) {
+        else if (c < avail) {
             s->bpos += (size_t)c;
             _write_update_pos(s);
             // TODO: only works right if newline is at end

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -198,14 +198,12 @@ static char *_buf_realloc(ios_t *s, size_t sz)
 
     if (s->ownbuf && s->buf != &s->local[0]) {
         // if we own the buffer we're free to resize it
-        // always allocate 1 bigger in case user wants to add a NUL
-        // terminator after taking over the buffer
-        temp = (char*)LLT_REALLOC(s->buf, sz+1);
+        temp = (char*)LLT_REALLOC(s->buf, sz);
         if (temp == NULL)
             return NULL;
     }
     else {
-        temp = (char*)LLT_ALLOC(sz+1);
+        temp = (char*)LLT_ALLOC(sz);
         if (temp == NULL)
             return NULL;
         s->ownbuf = 1;
@@ -691,22 +689,24 @@ char *ios_take_buffer(ios_t *s, size_t *psize)
 
     ios_flush(s);
 
-    if (s->buf == &s->local[0]) {
+    if (s->buf == &s->local[0] || s->buf == NULL || (!s->ownbuf && s->size == s->maxsize)) {
         buf = (char*)LLT_ALLOC((size_t)s->size + 1);
         if (buf == NULL)
             return NULL;
         if (s->size)
             memcpy(buf, s->buf, (size_t)s->size);
     }
+    else if (s->size == s->maxsize) {
+        buf = (char*)LLT_REALLOC(s->buf, (size_t)s->size + 1);
+        if (buf == NULL)
+            return NULL;
+    }
     else {
-        if (s->buf == NULL)
-            buf = (char*)LLT_ALLOC((size_t)s->size + 1);
-        else
-            buf = s->buf;
+        buf = s->buf;
     }
     buf[s->size] = '\0';
 
-    *psize = s->size+1;  // buffer is actually 1 bigger for terminating NUL
+    *psize = s->size + 1;
 
     /* empty stream and reinitialize */
     _buf_init(s, s->bm);

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -95,7 +95,7 @@ JL_DLLEXPORT int ios_eof_blocking(ios_t *s);
 JL_DLLEXPORT int ios_flush(ios_t *s);
 JL_DLLEXPORT int ios_close(ios_t *s) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_isopen(ios_t *s);
-JL_DLLEXPORT char *ios_take_buffer(ios_t *s, size_t *psize);  // release buffer to caller
+JL_DLLEXPORT char *ios_take_buffer(ios_t *s, size_t *psize);  // nul terminate and release buffer to caller
 // set buffer space to use
 JL_DLLEXPORT int ios_setbuf(ios_t *s, char *buf, size_t size, int own) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_bufmode(ios_t *s, bufmode_t mode) JL_NOTSAFEPOINT;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -20,7 +20,7 @@ typedef enum { bm_none=UV_HANDLE_TYPE_MAX+1, bm_line, bm_block, bm_mem } bufmode
 typedef enum { bst_none, bst_rd, bst_wr } bufstate_t;
 
 #define IOS_INLSIZE 54
-#define IOS_BUFSIZE 131072
+#define IOS_BUFSIZE 32768
 
 #ifdef _P64
 #define ON_P64(x) x


### PR DESCRIPTION
fixes #34449

Also stop over-allocating ios_t buffer by 1 byte. This should make allocations more predictable if the buffer size becomes customizable.
