### PR TITLE
Enable combined BroadcastStyle dispatch in materialize!

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -820,11 +820,16 @@ Take a lazy `Broadcasted` object and compute the result
 """
 @inline materialize(bc::Broadcasted) = copy(instantiate(bc))
 materialize(x) = x
-@inline function materialize!(dest, bc::Broadcasted{Style}) where {Style}
-    return copyto!(dest, instantiate(Broadcasted{Style}(bc.f, bc.args, axes(dest))))
-end
+
 @inline function materialize!(dest, x)
-    return copyto!(dest, instantiate(Broadcasted(identity, (x,), axes(dest))))
+    return materialize!(dest, instantiate(Broadcasted(identity, (x,), axes(dest))))
+end
+
+@inline function materialize!(dest, bc::Broadcasted{Style}) where {Style}
+    return materialize!(combine_styles(dest, bc), dest, bc)
+end
+@inline function materialize!(::BroadcastStyle, dest, bc::Broadcasted{Style}) where {Style}
+    return copyto!(dest, instantiate(Broadcasted{Style}(bc.f, bc.args, axes(dest))))
 end
 
 ## general `copy` methods


### PR DESCRIPTION
In-place broadcast (the `.=` syntax) now allows for custom implementations to dispatch on the
combined `BroadcastStyle` between the destination and the right-hand side for by implementing
`materialize!(::BroadcastStyle, dest, bc)`.

cc @vchuravy 