### PR TITLE
Teach `jl_load_dynamic_library()` about `@executable_path` on all platforms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@ Compiler/Runtime improvements
 -----------------------------
 
 
+* All platforms can now use `@executable_path` within `jl_load_dynamic_library()`.
+  This allows executable-relative paths to be embedded within executables on all
+  platforms, not just MacOS, which the syntax is borrowed from. ([#35627])
+
 Command-line option changes
 ---------------------------
 

--- a/stdlib/Libdl/src/Libdl.jl
+++ b/stdlib/Libdl/src/Libdl.jl
@@ -99,6 +99,11 @@ between shared libraries.
 
 If the library cannot be found, this method throws an error, unless the keyword argument
 `throw_error` is set to `false`, in which case this method returns `nothing`.
+
+!!! note
+     From Julia 1.6 on, this method replaces paths starting with `@executable_path/` with
+     the path to the Julia executable, allowing for relocatable relative-path loads. In
+     Julia 1.5 and earlier, this only worked on macOS.
 """
 function dlopen end
 


### PR DESCRIPTION
It is useful for us to be able to hard-code a dynamic library's location
relative to that of the julia executable.  We repurpose the
`@executable_path` component from MacOS, allowing all platforms to
perform executable-relative binary loading (I'm looking at you, Windows).

This is useful for the Julia binary to be able to find libraries within artifacts in https://github.com/JuliaLang/julia/pull/35193