### PR TITLE
Help mode documentation for ternary operator

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -24,7 +24,7 @@ For help on a specific function or macro, type `?` followed
 by its name, e.g. `?cos`, or `?@time`, and press enter.
 Type `;` to enter shell mode, `]` to enter package mode.
 """
-kw"help", kw"?", kw"Julia", kw"julia", kw""
+kw"help", kw"Julia", kw"julia", kw""
 
 """
     using
@@ -643,6 +643,28 @@ evaluated. The `elseif` and `else` blocks are optional, and as many `elseif` blo
 desired can be used.
 """
 kw"if", kw"elseif", kw"else"
+
+"""
+    a ? b : c
+
+Short form for conditionals; read "if `a`, evaluate `b` otherwise evaluate `c`".
+Also known as the [ternary operator](https://en.wikipedia.org/wiki/%3F:).
+
+This syntax is equivalent to `if a; b else c end`, but is often used to
+emphasize the value `b`-or-`c` which is being used as part of a larger
+expression, rather than the side effects that evaluating `b` or `c` may have.
+
+See the manual section on [control flow](@ref man-conditional-evaluation) for more details.
+
+# Examples
+```
+julia> x = 1; y = 2;
+
+julia> println(x > y ? "x is larger" : "y is larger")
+y is larger
+```
+"""
+kw"?", kw"?:"
 
 """
     for

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -85,6 +85,7 @@ where
 ...
 ;
 =
+?:
 ```
 
 ## Standard Modules

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -23,7 +23,8 @@ const extended_help_on = Ref{Any}(nothing)
 
 function _helpmode(io::IO, line::AbstractString)
     line = strip(line)
-    if startswith(line, '?')
+    ternary_operator_help = (line == "?" || line == "?:")
+    if startswith(line, '?') && !ternary_operator_help
         line = line[2:end]
         extended_help_on[] = line
         brief = false


### PR DESCRIPTION
Fixes #35636

Here I've stolen the single `?` as an alias for displaying the introduction text, as the intro text already has multiple other ways to show it (including simply pressing Return while in help mode).

I've also tried out something unusual which is linking to the manual documentation which describes this syntax in more detail. (Obviously we should have a better way to create such links without direct URLs, but for now I think this is the only way to do it?)