### PR TITLE
add `@threads static` to aid thread API evolution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,9 @@ Command-line option changes
 
 Multi-threading changes
 -----------------------
+* `@threads` now allows an optional schedule argument. Use `@threads :static ...` to
+  ensure that the same schedule will be used as in past versions; the default schedule
+  is likely to change in the future.
 
 
 Build system changes

--- a/src/threading.c
+++ b/src/threading.c
@@ -481,6 +481,11 @@ void jl_start_threads(void)
 
 unsigned volatile _threadedregion; // HACK: keep track of whether it is safe to do IO
 
+JL_DLLEXPORT int jl_in_threaded_region(void)
+{
+    return _threadedregion != 0;
+}
+
 JL_DLLEXPORT void jl_enter_threaded_region(void)
 {
     _threadedregion += 1;

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -729,6 +729,17 @@ let a = zeros(nthreads())
     @test a == [1:nthreads();]
 end
 
+# static schedule
+function _atthreads_static_schedule()
+    ids = zeros(Int, nthreads())
+    Threads.@threads :static for i = 1:nthreads()
+        ids[i] = Threads.threadid()
+    end
+    return ids
+end
+@test _atthreads_static_schedule() == [1:nthreads();]
+@test_throws TaskFailedException @threads for i = 1:1; _atthreads_static_schedule(); end
+
 try
     @macroexpand @threads(for i = 1:10, j = 1:10; end)
 catch ex


### PR DESCRIPTION
Looking into stabilizing the thread API in 1.5, I think one major likely future change is the schedule used by `@threads`. Eventually we want it to spawn un-pinned tasks (and possibly more tasks than threads), yet we know some code is already using it in a way that assumes the current schedule. I think a good approach is to allow `@threads static` now, so that code depending on the schedule can be future-proofed, and then in a later version we can change the default schedule.