### PR TITLE
turn deprecations into hard errors

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -424,22 +424,9 @@ Dict{Int64,String} with 1 entry:
 function filter(f, d::AbstractDict)
     # don't just do filter!(f, copy(d)): avoid making a whole copy of d
     df = empty(d)
-    try
-        for pair in d
-            if f(pair)
-                df[pair.first] = pair.second
-            end
-        end
-    catch e
-        if isa(e, MethodError) && e.f === f
-            depwarn("In `filter(f, dict)`, `f` is now passed a single pair instead of two arguments.", :filter)
-            for (k, v) in d
-                if f(k, v)
-                    df[k] = v
-                end
-            end
-        else
-            rethrow()
+    for pair in d
+        if f(pair)
+            df[pair.first] = pair.second
         end
     end
     return df

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1064,17 +1064,6 @@ function func_for_method_checked(m::Method, @nospecialize(types), sparams::Simpl
     return m
 end
 
-function func_for_method_checked(m::Method, @nospecialize(types))
-    depwarn("The two argument form of `func_for_method_checked` is deprecated. Pass sparams in addition.",
-            :func_for_method_checked)
-    if isdefined(m, :generator) && !isdispatchtuple(types)
-        error("cannot call @generated function `", m, "` ",
-              "with abstract argument types: ", types)
-    end
-    return m
-end
-
-
 """
     code_typed(f, types; optimize=true, debuginfo=:default)
 

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -15,13 +15,6 @@ function rstrip_shell(s::AbstractString)
     SubString(s, 1, 0)
 end
 
-
-# needs to be factored out so depwarn only warns once
-# when removed, also need to update shell_escape for a Cmd to pass shell_special
-# and may want to use it in the test for #10120 (currently the implementation is essentially copied there)
-@noinline warn_shell_special(str,special) =
-    depwarn("Parsing command \"$str\". Special characters \"$special\" should now be quoted in commands", :warn_shell_special)
-
 function shell_parse(str::AbstractString, interpolate::Bool=true;
                      special::AbstractString="")
     s::SubString = SubString(str, firstindex(str))
@@ -104,7 +97,7 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
                     _ = popfirst!(st)
                 end
             elseif !in_single_quotes && !in_double_quotes && c in special
-                warn_shell_special(str,special) # noinline depwarn
+                error("parsing command `$str`: special characters \"$special\" must be quoted in commands")
             end
         end
     end


### PR DESCRIPTION
Kind of crucial part of https://github.com/JuliaLang/julia/pull/35362. Previously deprecated features in Base are now errors. If we had released a version without doing this, then we wouldn't have been allowed to change these behaviors in following versions.