### PR TITLE
mention locking in docstring for `Threads.Condition`

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -203,6 +203,22 @@ end
 
     A thread-safe version of [`Base.Condition`](@ref).
 
+    To call [`wait`](@ref) or [`notify`](@ref) on a `Threads.Condition`, you must first call
+    [`lock`](@ref) on it. When `wait` is called, the lock is atomically released during
+    blocking, and will be reacquired before `wait` returns. Therefore idiomatic use
+    of a `Threads.Condition` `c` looks like the following:
+
+    ```
+    lock(c)
+    try
+        while !thing_we_are_waiting_for
+            wait(c)
+        end
+    finally
+        unlock(c)
+    end
+    ```
+
     !!! compat "Julia 1.2"
         This functionality requires at least Julia 1.2.
     """
@@ -213,7 +229,7 @@ end
 
     The caller must be holding the [`lock`](@ref) that owns `c` before calling this method.
     The calling task will be blocked until some other task wakes it,
-    usually by calling [`notify`](@ref)` on the same Condition object.
+    usually by calling [`notify`](@ref) on the same Condition object.
     The lock will be atomically released when blocking (even if it was locked recursively),
     and will be reacquired before returning.
     """


### PR DESCRIPTION
fixes #34351