### PR TITLE
normalize_triplet.py: Properly map libgfortran versions for GCC 10

### DIFF
--- a/contrib/normalize_triplet.py
+++ b/contrib/normalize_triplet.py
@@ -110,13 +110,14 @@ def p(x):
 if libgfortran_version == "blank_libgfortran":
     if len(sys.argv) >= 3:
         libgfortran_version = {
-            "4": "libgfortran3",
-            "5": "libgfortran3",
-            "6": "libgfortran3",
-            "7": "libgfortran4",
-            "8": "libgfortran5",
-            "9": "libgfortran5",
-        }[list(filter(lambda x: re.match("\d+\.\d+(\.\d+)?", x), sys.argv[2].split()))[-1][0]]
+            "4":  "libgfortran3",
+            "5":  "libgfortran3",
+            "6":  "libgfortran3",
+            "7":  "libgfortran4",
+            "8":  "libgfortran5",
+            "9":  "libgfortran5",
+            "10": "libgfortran5",
+        }[list(filter(lambda x: re.match("\d+\.\d+(\.\d+)?", x), sys.argv[2].split()))[-1].split('.')[0]]
 
 if cxx_abi == "blank_cxx_abi":
     if len(sys.argv) == 4:


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/35638