### PR TITLE
Fix GPUCodegen by re-inferring deleted methods

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -250,9 +250,12 @@ static void makeSafeName(GlobalObject &G)
 
 
 // takes the running content that has collected in the shadow module and dump it to disk
-// this builds the object file portion of the sysimage files for fast startup
+// this builds the object file portion of the sysimage files for fast startup, and can
+// also be used be extern consumers like GPUCompiler.jl to obtain a module containing
+// all reachable & inferrrable functions. The `policy` flag switches between the defaul
+// mode `0` and the extern mode `1`.
 extern "C" JL_DLLEXPORT
-void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams)
+void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _policy)
 {
     jl_native_code_desc_t *data = new jl_native_code_desc_t;
     jl_codegen_params_t params;
@@ -263,11 +266,16 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams)
     JL_GC_PUSH1(&src);
     JL_LOCK(&codegen_lock);
 
+    CompilationPolicy policy = (CompilationPolicy) _policy;
+
     // compile all methods for the current world and type-inference world
     size_t compile_for[] = { jl_typeinf_world, jl_world_counter };
     for (int worlds = 0; worlds < 2; worlds++) {
         params.world = compile_for[worlds];
         if (!params.world)
+            continue;
+        // Don't emit methods for the typeinf_world with extern policy
+        if (policy == CompilationPolicy::Extern && params.world == jl_typeinf_world)
             continue;
         size_t i, l;
         for (i = 0, l = jl_array_len(methods); i < l; i++) {
@@ -304,8 +312,9 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams)
                 }
             }
         }
+
         // finally, make sure all referenced methods also get compiled or fixed up
-        jl_compile_workqueue(emitted, params);
+        jl_compile_workqueue(emitted, params, policy);
     }
     JL_GC_POP();
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -97,7 +97,7 @@ static jl_callptr_t _jl_compile_codeinst(
         jl_compile_result_t result = jl_emit_codeinst(codeinst, src, params);
         if (std::get<0>(result))
             emitted[codeinst] = std::move(result);
-        jl_compile_workqueue(emitted, params);
+        jl_compile_workqueue(emitted, params, CompilationPolicy::Default);
 
         jl_add_to_ee();
         StringMap<std::unique_ptr<Module>*> NewExports;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -75,9 +75,15 @@ jl_compile_result_t jl_emit_codeinst(
         jl_code_info_t *src,
         jl_codegen_params_t &params);
 
+enum CompilationPolicy {
+    Default = 0,
+    Extern = 1
+};
+
 void jl_compile_workqueue(
     std::map<jl_code_instance_t*, jl_compile_result_t> &emitted,
-    jl_codegen_params_t &params);
+    jl_codegen_params_t &params,
+    CompilationPolicy policy);
 
 Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tupletype_t *argt,
     jl_codegen_params_t &params);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -613,7 +613,7 @@ JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char*
 JL_DLLEXPORT jl_value_t *jl_dump_llvm_asm(void *F, const char* asm_variant, const char *debuginfo);
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir(void *f, char strip_ir_metadata, char dump_module, const char *debuginfo);
 
-void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams);
+void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int policy);
 void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         const char *sysimg_data, size_t sysimg_len);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -395,7 +395,7 @@ void *jl_precompile(int all)
             jl_array_ptr_1d_push(m2, (jl_value_t*)mi);
     }
     m = NULL;
-    void *native_code = jl_create_native(m2, jl_default_cgparams);
+    void *native_code = jl_create_native(m2, jl_default_cgparams, 0);
     JL_GC_POP();
     return native_code;
 }


### PR DESCRIPTION
Fixes #34993

In JIT compilation mode we [delete the inferred method](https://github.com/JuliaLang/julia/blob/8b010b5f1b33c0397f4019902163cc013ea59a7f/src/codegen.cpp#L6597) after emitting it. Normally AOT mode doesn't run concurrently with JIT mode, but GPUCodegen does concurrently and
we have stricter requirements since we need to collect all code reachable from the kernel. 

This adds a second policy to `jl_create_native` in which upon encountering a deleted method we re-infer it as needed. 