### PR TITLE
REPL: fix shift-selection when input doesn't fit terminal

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -480,7 +480,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
     return InputAreaState(cur_row, curs_row)
 end
 
-function highlight_region(lwrite::String, regstart::Int, regstop::Int, written::Int, slength::Int)
+function highlight_region(lwrite::AbstractString, regstart::Int, regstop::Int, written::Int, slength::Int)
     if written <= regstop <= written+slength
         i = thisind(lwrite, regstop-written)
         lwrite = lwrite[1:i] * Base.disable_text_style[:reverse] * lwrite[nextind(lwrite, i):end]


### PR DESCRIPTION
When input doesn't fit terminal, `chomp` is used on a `line::String`
variable, which is then sent to `highlight_region`, which accepted
only `String`, but `chomp` can return a `SubString`. So widen
`highlight_region` signature to `AbstractString`.

Fix #35621.