### PR TITLE
fix #35649, copy! on vectors with shared data

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -705,7 +705,15 @@ See also [`copyto!`](@ref).
     This method requires at least Julia 1.1. In Julia 1.0 this method
     is available from the `Future` standard library as `Future.copy!`.
 """
-copy!(dst::AbstractVector, src::AbstractVector) = append!(empty!(dst), src)
+function copy!(dst::AbstractVector, src::AbstractVector)
+    if length(dst) != length(src)
+        resize!(dst, length(src))
+    end
+    for i in eachindex(dst, src)
+        @inbounds dst[i] = src[i]
+    end
+    dst
+end
 
 function copy!(dst::AbstractArray, src::AbstractArray)
     axes(dst) == axes(src) || throw(ArgumentError(

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -878,6 +878,10 @@ end
             @test s === copy!(s, Vector(a)) == Vector(a)
             @test s === copy!(s, SparseVector(a)) == Vector(a)
         end
+        # issue #35649
+        s = [1, 2, 3, 4]
+        s2 = reshape(s, 2, 2) # shared data
+        @test s === copy!(s, 11:14) == 11:14
     end
     @testset "AbstractArray" begin
         @test_throws ArgumentError copy!(zeros(2, 3), zeros(3, 2))


### PR DESCRIPTION
This makes the following work as expected, by not trying to `resize!` when it's not necessary:
```julia
b = rand(4)
b2 = reshape(b, 2, 2)
copy!(b, rand(4)) 
```
But as a side effect, this also fixes another "bug", but this might be considered as a "minor change": after a call `copy!(a, b)`, `a == b` is supposed to hold, but currently this fails for offset arrays:
```julia
julia> a = OffsetArray([1, 2, 3], -2); copy!(a, 1:3); a == 1:3
false
```
This is because no check on axes was made on vectors (only on arrays with more dimensions). In this PR, `eachindex(a, b)` is used, and this `eachindex` call checks for compatible axes (meaning that `copy!(a, 1:3)` above will fail, when it was working before).
