### PR TITLE
multiplication of sparse triangular matrices #35609 #35610 #35642

### DIFF
--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -185,7 +185,6 @@ const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti},SparseTriangular{Tv
 *(A::SparseOrTri, B::SparseColumnView) = spmatmulv(A, B)
 *(A::SparseOrTri, B::SparseVectorView) = spmatmulv(A, B)
 *(A::SparseMatrixCSCUnion, B::SparseMatrixCSCUnion) = spmatmul(A,B)
-*(A::SparseMatrixCSCUnion, B::SubArray{<:Any,1,<:AbstractSparseVector}) = spmatmulv(A, B)
 *(A::SparseTriangular, B::SparseMatrixCSCUnion) = spmatmul(A,B)
 *(A::SparseMatrixCSCUnion, B::SparseTriangular) = spmatmul(A,B)
 *(A::SparseTriangular, B::SparseTriangular) = spmatmul1(A,B)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -109,8 +109,15 @@ julia> nnz(A)
 ```
 """
 nnz(S::AbstractSparseMatrixCSC) = Int(getcolptr(S)[size(S, 2) + 1] - 1)
-nnz(S::ReshapedArray{T,1,<:AbstractSparseMatrixCSC}) where T = nnz(parent(S))
-count(pred, S::AbstractSparseMatrixCSC) = count(pred, nzvalview(S)) + pred(zero(eltype(S)))*(prod(size(S)) - nnz(S))
+nnz(S::ReshapedArray{<:Any,1,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
+nnz(S::UpperTriangular{<:Any,<:AbstractSparseMatrixCSC}) = nnz1(S)
+nnz(S::LowerTriangular{<:Any,<:AbstractSparseMatrixCSC}) = nnz1(S)
+nnz(S::SparseMatrixCSCView) = nnz1(S)
+nnz1(S) = sum(length.(nzrange.(Ref(S), axes(S, 2))))
+
+function count(pred, S::AbstractSparseMatrixCSC)
+    count(pred, nzvalview(S)) + pred(zero(eltype(S)))*(prod(size(S)) - nnz(S))
+end
 
 """
     nonzeros(A)
@@ -138,6 +145,8 @@ julia> nonzeros(A)
 """
 nonzeros(S::SparseMatrixCSC) = getfield(S, :nzval)
 nonzeros(S::SparseMatrixCSCView)  = nonzeros(S.parent)
+nonzeros(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
+nonzeros(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
 
 """
     rowvals(A::AbstractSparseMatrixCSC)
@@ -164,6 +173,8 @@ julia> rowvals(A)
 """
 rowvals(S::SparseMatrixCSC) = getfield(S, :rowval)
 rowvals(S::SparseMatrixCSCView) = rowvals(S.parent)
+rowvals(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
+rowvals(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
 
 """
     nzrange(A::AbstractSparseMatrixCSC, col::Integer)
@@ -186,6 +197,8 @@ column. In conjunction with [`nonzeros`](@ref) and
 """
 nzrange(S::AbstractSparseMatrixCSC, col::Integer) = getcolptr(S)[col]:(getcolptr(S)[col+1]-1)
 nzrange(S::SparseMatrixCSCView, col::Integer) = nzrange(S.parent, S.indices[2][col])
+nzrange(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangeup(S.data, i)
+nzrange(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangelo(S.data, i)
 
 function Base.show(io::IO, ::MIME"text/plain", S::AbstractSparseMatrixCSC)
     xnnz = nnz(S)

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -57,7 +57,9 @@ nnz(x::SparseVectorView) = nnz(x.parent)
 Give the range of indices to the structural nonzero values of a sparse vector.
 The column index `col` is ignored (assumed to be `1`).
 """
-nzrange(x::SparseVectorUnion, ::Integer) = 1:nnz(x)
+function nzrange(x::SparseVectorUnion, j::Integer)
+    j == 1 ? (1:nnz(x)) : throw(BoundsError(x, (":", j)))
+end
 
 nonzeros(x::SparseVector) = getfield(x, :nzval)
 function nonzeros(x::SparseColumnView)

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -32,15 +32,32 @@ SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
 
 # Define an alias for a view of a whole column of a SparseMatrixCSC. Many methods can be written for the
 # union of such a view and a SparseVector so we define an alias for such a union as well
-const SparseColumnView{T}  = SubArray{T,1,<:AbstractSparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
-const SparseVectorUnion{T} = Union{SparseVector{T}, SparseColumnView{T}}
-const AdjOrTransSparseVectorUnion{T} = LinearAlgebra.AdjOrTrans{T, <:SparseVectorUnion{T}}
+const SparseColumnView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
+const SparseVectorView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}}},false}
+const SparseVectorUnion{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
+const AdjOrTransSparseVectorUnion{Tv,Ti} = LinearAlgebra.AdjOrTrans{Tv, <:SparseVectorUnion{Tv,Ti}}
 
 ### Basic properties
 
 size(x::SparseVector)     = (getfield(x, :n),)
-nnz(x::SparseVector)      = length(nonzeros(x))
 count(f, x::SparseVector) = count(f, nonzeros(x)) + f(zero(eltype(x)))*(length(x) - nnz(x))
+
+# implement the nnz - nzrange - nonzeros - rowvals interface for sparse vectors
+
+nnz(x::SparseVector)      = length(nonzeros(x))
+function nnz(x::SparseColumnView)
+    rowidx, colidx = parentindices(x)
+    return length(nzrange(parent(x), colidx))
+end
+nnz(x::SparseVectorView) = nnz(x.parent)
+
+"""
+    nzrange(x::SparseVectorUnion, col)
+
+Give the range of indices to the structural nonzero values of a sparse vector.
+The column index `col` is ignored (assumed to be `1`).
+"""
+nzrange(x::SparseVectorUnion, ::Integer) = 1:nnz(x)
 
 nonzeros(x::SparseVector) = getfield(x, :nzval)
 function nonzeros(x::SparseColumnView)
@@ -49,6 +66,7 @@ function nonzeros(x::SparseColumnView)
     @inbounds y = view(nonzeros(A), nzrange(A, colidx))
     return y
 end
+nonzeros(x::SparseVectorView) = nonzeros(parent(x))
 
 nonzeroinds(x::SparseVector) = getfield(x, :nzind)
 function nonzeroinds(x::SparseColumnView)
@@ -57,12 +75,12 @@ function nonzeroinds(x::SparseColumnView)
     @inbounds y = view(rowvals(A), nzrange(A, colidx))
     return y
 end
+nonzeroinds(x::SparseVectorView) = nonzeroinds(parent(x))
+
+rowvals(x::SparseVectorUnion) = nonzeroinds(x)
 
 indtype(x::SparseColumnView) = indtype(parent(x))
-function nnz(x::SparseColumnView)
-    rowidx, colidx = parentindices(x)
-    return length(nzrange(parent(x), colidx))
-end
+indtype(x::SparseVectorView) = indtype(parent(x))
 
 ## similar
 #

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2970,4 +2970,50 @@ end
     @test typeof(Y) == typeof(A)
 end
 
+#testing the sparse matrix/vector access functions nnz, nzrange, rowvals, nonzeros
+@testset "generic sparse matrix access functions" begin
+    I = [1,3,4,5, 1,3,4,5, 1,3,4,5];
+    J = [4,4,4,4, 5,5,5,5, 6,6,6,6];
+    V = [14,34,44,54, 15,35,45,55, 16,36,46,56];
+    A = sparse(I, J, V, 9, 9);
+    AU = UpperTriangular(A)
+    AL = LowerTriangular(A)
+    b = SparseVector(9, I[1:4], V[1:4])
+    c = view(A, :, 5)
+    d = view(b, :)
+
+    @testset "nnz $n" for (n, M, nz) in (("A", A, 12), ("AU", AU, 11), ("AL", AL, 3),
+                                         ("b", b, 4), ("c", c, 4), ("d", d, 4))
+        @test nnz(M) == nz
+        @test_throws BoundsError nzrange(M, 0)
+        @test_throws BoundsError nzrange(M, size(M, 2) + 1)
+    end
+    @testset "nzrange(A, $i)" for (i, nzr) in ((1,1:0),(4,1:4),(5,5:8),(6,9:12),(9,13:12))
+        @test nzrange(A, i) == nzr
+    end
+    @testset "nzrange(AU, $i)" for (i, nzr) in ((2,1:0),(4,1:3),(5,5:8),(6,9:12),(8,13:12))
+        @test nzrange(AU, i) == nzr
+    end
+    @testset "nzrange(AL, $i)" for (i, nzr) in ((3,1:0),(4,3:4),(5,8:8),(6,13:12),(7,13:12))
+        @test nzrange(AL, i) == nzr
+    end
+    @test nzrange(b, 1) == 1:4
+    @test nzrange(c, 1) == 1:4
+    @test nzrange(d, 1) == 1:4
+
+    @test rowvals(A) == I
+    @test rowvals(AL) == I
+    @test rowvals(AL) == I
+    @test rowvals(b) == I[1:4]
+    @test rowvals(c) == I[5:8]
+    @test rowvals(d) == I[1:4]
+
+    @test nonzeros(A) == V
+    @test nonzeros(AU) == V
+    @test nonzeros(AL) == V
+    @test nonzeros(b) == V[1:4]
+    @test nonzeros(c) == V[5:8]
+    @test nonzeros(d) == V[1:4]
+end
+
 end # module

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2936,4 +2936,38 @@ end
     end
 end
 
+@testset "Multiplying with triangular sparse matrices #35609 #35610" begin
+    n = 10
+    A = sprand(n, n, 5/n)
+    U = UpperTriangular(A)
+    L = LowerTriangular(A)
+    AM = Matrix(A)
+    UM = Matrix(U)
+    LM = Matrix(L)
+    Y = A * U
+    @test Y == AM * UM
+    @test typeof(Y) == typeof(A)
+    Y = A * L
+    @test Y == AM * LM
+    @test typeof(Y) == typeof(A)
+    Y = U * A
+    @test Y == UM * AM
+    @test typeof(Y) == typeof(A)
+    Y = L * A
+    @test Y == LM * AM
+    @test typeof(Y) == typeof(A)
+    Y = U * U
+    @test Y == UM * UM
+    @test typeof(Y) == typeof(U)
+    Y = L * L
+    @test Y == LM * LM
+    @test typeof(Y) == typeof(L)
+    Y = L * U
+    @test Y == LM * UM
+    @test typeof(Y) == typeof(A)
+    Y = U * L
+    @test Y == UM * LM
+    @test typeof(Y) == typeof(A)
+end
+
 end # module

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2945,28 +2945,28 @@ end
     UM = Matrix(U)
     LM = Matrix(L)
     Y = A * U
-    @test Y == AM * UM
+    @test Y ≈ AM * UM
     @test typeof(Y) == typeof(A)
     Y = A * L
-    @test Y == AM * LM
+    @test Y ≈ AM * LM
     @test typeof(Y) == typeof(A)
     Y = U * A
-    @test Y == UM * AM
+    @test Y ≈ UM * AM
     @test typeof(Y) == typeof(A)
     Y = L * A
-    @test Y == LM * AM
+    @test Y ≈ LM * AM
     @test typeof(Y) == typeof(A)
     Y = U * U
-    @test Y == UM * UM
+    @test Y ≈ UM * UM
     @test typeof(Y) == typeof(U)
     Y = L * L
-    @test Y == LM * LM
+    @test Y ≈ LM * LM
     @test typeof(Y) == typeof(L)
     Y = L * U
-    @test Y == LM * UM
+    @test Y ≈ LM * UM
     @test typeof(Y) == typeof(A)
     Y = U * L
-    @test Y == UM * LM
+    @test Y ≈ UM * LM
     @test typeof(Y) == typeof(A)
 end
 

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1440,7 +1440,7 @@ end
     z = view(x, :)
     ty = typeof
     @testset "matvec multiplication $(ty(X)) * $(ty(v))" for X in (U, L), v in (x, y, z)
-        @test X * v == Matrix(X) * Vector(v)
+        @test X * v ≈ Matrix(X) * Vector(v)
         @test typeof(X * v) == typeof(x)
     end
 end

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1430,4 +1430,19 @@ end
     @test nonzeros(A) !== nonzeros(B)
 end
 
+@testset "multiplication of Triangular sparse matrices with sparse vectors #35642" begin
+    n = 10
+    A = sprand(n, n, 5/n)
+    U = UpperTriangular(A)
+    L = LowerTriangular(A)
+    x = sprand(n, 5/n)
+    y = view(A, :, 6)
+    z = view(x, :)
+    ty = typeof
+    @testset "matvec multiplication $(ty(X)) * $(ty(v))" for X in (U, L), v in (x, y, z)
+        @test X * v == Matrix(X) * Vector(v)
+        @test typeof(X * v) == typeof(x)
+    end
+end
+
 end # module


### PR DESCRIPTION
Fixes JuliaLang/julia#35609 
Fixes JuliaLang/LinearAlgebra.jl#719 
Fixes JuliaLang/LinearAlgebra.jl#721 
Multiplying a sparse triangular matrix with a sparse matrix now is possible.
The result type is a triangular sparse matrix or a sparse matrix.
Multiplying a sparse triangular matrix with a sparse vector now yields a sparse vector. 
