### PR TITLE
Test ordering of `GitConfigIter`

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -1969,7 +1969,12 @@ mktempdir() do dir
             end
 
             LibGit2.with(LibGit2.GitConfig(config_path, LibGit2.Consts.CONFIG_LEVEL_APP)) do cfg
-                @test length(collect(LibGit2.GitConfigIter(cfg, r"credential.*"))) == 3
+                iter = LibGit2.GitConfigIter(cfg, r"credential.*\.helper")
+                @test LibGit2.split_cfg_entry.(iter) == [
+                    ("credential", "", "helper", "!echo first"),
+                    ("credential", "https://mygithost", "helper", ""),
+                    ("credential", "", "helper", "!echo second"),
+                ]
 
                 expected = [
                     GitCredentialHelper(`echo first`),


### PR DESCRIPTION
Makes the test more specific which was helpful in trying to debug: https://github.com/JuliaLang/julia/issues/35640. Previously this was not done as `GitConfigIter` ordering was unreliable.