### PR TITLE
Report LLVM timings and statistics during teardown.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -57,12 +57,14 @@
 // support
 #include <llvm/ADT/SmallBitVector.h>
 #include <llvm/ADT/Optional.h>
+#include <llvm/ADT/Statistic.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/FormattedStream.h>
 #include <llvm/Support/SourceMgr.h> // for llvmcall
 #include <llvm/Transforms/Utils/Cloning.h> // for llvmcall inlining
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/IR/Verifier.h> // for llvmcall validation
+#include <llvm/IR/PassTimingInfo.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 
 // C API
@@ -7596,6 +7598,13 @@ extern "C" void jl_init_codegen(void)
     UBOX_F(ssavalue,size);
 
     jl_init_intrinsic_functions_codegen(m);
+}
+
+extern "C" void jl_teardown_codegen()
+{
+    // output LLVM timings and statistics
+    reportAndResetTimings();
+    PrintStatistics();
 }
 
 // the rest of this file are convenience functions

--- a/src/init.c
+++ b/src/init.c
@@ -299,6 +299,8 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
 #ifdef ENABLE_TIMINGS
     jl_print_timings();
 #endif
+
+    jl_teardown_codegen();
 }
 
 static void post_boot_hooks(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -539,6 +539,8 @@ void jl_init_uv(void);
 void jl_init_debuginfo(void);
 void jl_init_thread_heap(jl_ptls_t ptls);
 
+void jl_teardown_codegen(void);
+
 void _julia_init(JL_IMAGE_SEARCH rel);
 
 void jl_set_base_ctx(char *__stk);


### PR DESCRIPTION
```
$ JULIA_LLVM_ARGS='-stats' ./julia -e 'exit()'
===-------------------------------------------------------------------------===
                          ... Statistics Collected ...
===-------------------------------------------------------------------------===

 1736 asm-printer           - Number of machine instrs printed
...
   16 x86-vzeroupper        - Number of vzeroupper instructions inserted
```

```
$ JULIA_LLVM_ARGS='-time-passes' ./julia -e 'exit()'
===-------------------------------------------------------------------------===
                      ... Pass execution timing report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 0.1629 seconds (0.1270 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.0261 ( 23.2%)   0.0121 ( 23.9%)   0.0382 ( 23.4%)   0.0305 ( 24.0%)  X86 DAG->DAG Instruction Selection
...
   0.1123 (100.0%)   0.0506 (100.0%)   0.1629 (100.0%)   0.1270 (100.0%)  Total
```

Does not affect execution time of `julia -e 'exit()'`