### PR TITLE
Fix links in the manual

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -317,7 +317,7 @@ variants, one can also supply the "raw" data in the requested MIME type by passi
 application/postscript) or `x::Vector{UInt8}` (for binary MIME types).
 
 To customize how instances of a type are displayed, overload [`show`](@ref) rather than `display`,
-as explained in the manual section on [custom pretty-printing](@id man-custom-pretty-printing).
+as explained in the manual section on [custom pretty-printing](@ref man-custom-pretty-printing).
 """
 function display(@nospecialize x)
     for i = length(displays):-1:1

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -825,4 +825,4 @@ case the `finally` block will run after `catch` has handled the error.
 
 Tasks are a control flow feature that allows computations to be suspended and resumed in a flexible
 manner. We mention them here only for completeness; for a full discussion see
-[Asynchronous Programming](@id man-asynchronous).
+[Asynchronous Programming](@ref man-asynchronous).


### PR DESCRIPTION
Fix a couple of broken links in the manual. I am unable to track these four:

```
┌ Warning: invalid local link: unresolved path in base/arrays.md
│   link.text =
│    1-element Array{Any,1}:
│     Markdown.Code("", "^")
│   link.url = "math.html#Base.:^-Tuple{Number,Number}"
└ @ Documenter.Writers.HTMLWriter ~/julia/doc/deps/packages/Documenter/QQWIJ/src/Writers/HTMLWriter.jl:1676
┌ Warning: invalid local link: unresolved path in base/arrays.md
│   link.text =
│    1-element Array{Any,1}:
│     Markdown.Code("", "c^r")
│   link.url = "math.html#Base.:^-Tuple{Number,Number}"
└ @ Documenter.Writers.HTMLWriter ~/julia/doc/deps/packages/Documenter/QQWIJ/src/Writers/HTMLWriter.jl:1676
┌ Warning: invalid local link: unresolved path in base/base.md
│   link.text =
│    1-element Array{Any,1}:
│     Markdown.Code("", "one")
│   link.url = "../base/numbers.html#Base.one"
└ @ Documenter.Writers.HTMLWriter ~/julia/doc/deps/packages/Documenter/QQWIJ/src/Writers/HTMLWriter.jl:1676
┌ Warning: invalid local link: unresolved path in base/base.md
│   link.text =
│    1-element Array{Any,1}:
│     Markdown.Code("", "Float64")
│   link.url = "../base/numbers.html#Core.Float64"
└ @ Documenter.Writers.HTMLWriter ~/julia/doc/deps/packages/Documenter/QQWIJ/src/Writers/HTMLWriter.jl:1676
```