### PR TITLE
Fix dropped bytes when bulk reading from uv streams with oversized bufs

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -495,7 +495,7 @@ end
 function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, Int(recommended_size))
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
-    nb = length(buffer.data) - ptr + 1
+    nb = min(length(buffer.data), buffer.maxsize) - ptr + 1
     return (pointer(buffer.data, ptr), nb)
 end
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -596,3 +596,18 @@ end
     seekstart(io)
     @test_throws ErrorException read!(io, @view z[4:6])
 end
+
+# Bulk read from pipe
+let p = Pipe()
+    data = rand(UInt8, Base.SZ_UNBUFFERED_IO + 100)
+    Base.link_pipe!(p, reader_supports_async=true, writer_supports_async=true)
+    t = @async write(p.in, data)
+    @test read(p.out, UInt8) == data[1]
+    data_read = Vector{UInt8}(undef, 10*Base.SZ_UNBUFFERED_IO)
+    nread = readbytes!(p.out, data_read, Base.SZ_UNBUFFERED_IO + 50)
+    @test nread == Base.SZ_UNBUFFERED_IO + 50
+    @test data_read[1:nread] == data[2:nread+1]
+    @test read(p.out, 49) == data[end-48:end]
+    wait(t)
+    close(p)
+end


### PR DESCRIPTION
In readbytes!(s::UVStream, buf::AbstractVector{UInt8}, nb), we wrap `buf`
in a PipeBuffer of maxsize nb and swap it in as the main buffer for the
stream `s`. However, when we inform libuv of the size of the buffer,
we instead use the size of the underlying array, which can be larger.
In that case, we probably either drop bytes or override something that
the user did not want overriden.