### PR TITLE
bugfix in PCRE.jit_compile

### DIFF
--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -129,7 +129,7 @@ function jit_compile(regex::Ptr{Cvoid})
                   (Ptr{Cvoid}, UInt32), regex, JIT_COMPLETE) % UInt32
     errno == 0 && return true
     errno == ERROR_JIT_BADOPTION && return false
-    error("PCRE JIT error: $(err_message(errno))")
+    error("PCRE JIT error: $(err_message(errno % Int32))")
 end
 
 free_match_data(match_data) =


### PR DESCRIPTION
This fixes a bug in the error handling of `PCRE.jit_compile` apparently introduced in Julia 1.2 by #30542 (cc @Keno): in order to compare to the `UInt32` error constants in `pcre_h.jl` it casts the error code to `UInt32`, but in order to pass to `err_message(err)` it needs to cast back to `Int32` in order to avoid conversion errors on the `ccall` of the latter function.

In particular, I noticed this in a test failure for PyCall, where the stacktrace was:
```
ERROR: LoadError: LoadError: LoadError: InexactError: check_top_bit(Int32, 4294967248)
Stacktrace:
 [1] throw_inexacterror(::Symbol, ::Type{Int32}, ::UInt32) at ./boot.jl:557
 [2] check_top_bit at ./boot.jl:571 [inlined]
 [3] toInt32 at ./boot.jl:620 [inlined]
 [4] Int32 at ./boot.jl:706 [inlined]
 [5] convert at ./number.jl:7 [inlined]
 [6] cconvert at ./essentials.jl:388 [inlined]
 [7] err_message(::UInt32) at ./pcre.jl:149
 [8] jit_compile at ./pcre.jl:132 [inlined]
 [9] compile(::Regex) at ./regex.jl:73
 [10] #occursin#377 at ./regex.jl:172 [inlined]
 [11] occursin at ./regex.jl:172 [inlined]
 [12] isslurp(::Symbol) at /Users/travis/.julia/packages/MacroTools/X77lQ/src/match/match.jl:39
 [13] allbindings(::Symbol, ::Array{Any,1}) at /Users/travis/.julia/packages/MacroTools/X77lQ/src/match/macro.jl:5
 [14] (::MacroTools.var"#1#2"{Array{Any,1}})(::Symbol) at /Users/travis/.julia/packages/MacroTools/X77lQ/src/match/macro.jl:10
 [15] iterate at ./generator.jl:47 [inlined]
 [16] _collect(::Array{Any,1}, ::Base.Generator{Array{Any,1},MacroTools.var"#1#2"{Array{Any,1}}}, ::Base.EltypeUnknown, ::Base.HasShape{1}) at ./array.jl:679
 [17] collect_similar(::Array{Any,1}, ::Base.Generator{Array{Any,1},MacroTools.var"#1#2"{Array{Any,1}}}) at ./array.jl:608
 [18] map(::Function, ::Array{Any,1}) at ./abstractarray.jl:2090
 [19] allbindings(::Expr, ::Array{Any,1}) at /Users/travis/.julia/packages/MacroTools/X77lQ/src/match/macro.jl:7
 [20] allbindings(::Expr) at /Users/travis/.julia/packages/MacroTools/X77lQ/src/match/macro.jl:14
 [21] @capture(::LineNumberNode, ::Module, ::Any, ::Any) at /Users/travis/.julia/packages/MacroTools/X77lQ/src/match/macro.jl:68
 [22] include(::Function, ::Module, ::String) at ./Base.jl:382
 [23] include at ./Base.jl:370 [inlined]
 [24] include(::String) at /Users/travis/build/JuliaPy/PyCall.jl/src/PyCall.jl:1
 [25] top-level scope at /Users/travis/build/JuliaPy/PyCall.jl/src/PyCall.jl:199
 [26] include(::Function, ::Module, ::String) at ./Base.jl:382
 [27] include(::Module, ::String) at ./Base.jl:370
 [28] top-level scope at none:2
 [29] eval at ./boot.jl:331 [inlined]
 [30] eval(::Expr) at ./client.jl:467
 [31] top-level scope at ./none:3
in expression starting at /Users/travis/build/JuliaPy/PyCall.jl/src/pyclass.jl:45
in expression starting at /Users/travis/build/JuliaPy/PyCall.jl/src/pyclass.jl:44
in expression starting at /Users/travis/build/JuliaPy/PyCall.jl/src/PyCall.jl:199
```
Here, it was throwing an error on trying to convert `UInt32(4294967248) == 0xffffffd0` to `Int32` in the `ccall` (when compiling `occursin(r"[^_]__$", string(s)` [from MacroTools.jl](https://github.com/MikeInnes/MacroTools.jl/blob/0cf0f7c69399e97ece5253d86096f18e279d33f2/src/match/match.jl#L39)).  This corresponds to an error code of `0xffffffd0 % Int32 == -48 == PCRE2_ERROR_NOMEMORY`.