### PR TITLE
Add documentation to the sized identity matrix

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -337,6 +337,7 @@ LinearAlgebra.UnitUpperTriangular
 LinearAlgebra.UpperHessenberg
 LinearAlgebra.UniformScaling
 LinearAlgebra.I
+(LinearAlgebra.I::LinearAlgebra.UniformScaling)(::Integer)
 LinearAlgebra.Factorization
 LinearAlgebra.LU
 LinearAlgebra.lu

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -337,7 +337,7 @@ LinearAlgebra.UnitUpperTriangular
 LinearAlgebra.UpperHessenberg
 LinearAlgebra.UniformScaling
 LinearAlgebra.I
-(::LinearAlgebra.UniformScaling)(::Integer)
+LinearAlgebra.(::LinearAlgebra.UniformScaling)(::Integer)
 LinearAlgebra.Factorization
 LinearAlgebra.LU
 LinearAlgebra.lu

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -337,7 +337,7 @@ LinearAlgebra.UnitUpperTriangular
 LinearAlgebra.UpperHessenberg
 LinearAlgebra.UniformScaling
 LinearAlgebra.I
-(LinearAlgebra.I::LinearAlgebra.UniformScaling)(::Integer)
+(::LinearAlgebra.UniformScaling)(::Integer)
 LinearAlgebra.Factorization
 LinearAlgebra.LU
 LinearAlgebra.lu

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -337,7 +337,7 @@ LinearAlgebra.UnitUpperTriangular
 LinearAlgebra.UpperHessenberg
 LinearAlgebra.UniformScaling
 LinearAlgebra.I
-LinearAlgebra.(::LinearAlgebra.UniformScaling)(::Integer)
+LinearAlgebra.UniformScaling(::Integer)
 LinearAlgebra.Factorization
 LinearAlgebra.LU
 LinearAlgebra.lu


### PR DESCRIPTION
As proposed [on discourse](https://discourse.julialang.org/t/linear-algebra-tricks/38618/10?u=roble), I would like to add this to improve the documentation. 