### PR TITLE
Reduce estimated cost of `not_int` to zero

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -143,7 +143,7 @@ add_tfunc(rem_float_fast, 2, 2, math_tfunc, 10)
 add_tfunc(and_int, 2, 2, math_tfunc, 1)
 add_tfunc(or_int, 2, 2, math_tfunc, 1)
 add_tfunc(xor_int, 2, 2, math_tfunc, 1)
-add_tfunc(not_int, 1, 1, math_tfunc, 1)
+add_tfunc(not_int, 1, 1, math_tfunc, 0) # usually used as not_int(::Bool) to negate a condition
 add_tfunc(shl_int, 2, 2, math_tfunc, 1)
 add_tfunc(lshr_int, 2, 2, math_tfunc, 1)
 add_tfunc(ashr_int, 2, 2, math_tfunc, 1)

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -101,7 +101,7 @@ Each statement gets analyzed for its total cost in a function called
 where `f` is your function and `tt` is the Tuple-type of the arguments:
 
 ```jldoctest
-# A demo on `fill(3.5, (2, 3))
+# A demo on `fill(3.5, (2, 3))`
 f = fill
 tt = Tuple{Float64, Tuple{Int,Int}}
 # Create the objects we need to interact with the compiler
@@ -132,7 +132,7 @@ cst = map(cost, ci.code)
   0
   0
   0
-  1
+  0
   0
   0
   0


### PR DESCRIPTION
This reduces the estimated cost of `not_int` to zero for more reasonable inlining. (Fixes #35697)
This change is not a perfect solution, but has little side-effects on the existing cost model.