### PR TITLE
Increment header level of TerminalMenus section in REPL docs.

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -450,11 +450,11 @@ ENV["JULIA_WARN_COLOR"] = :yellow
 ENV["JULIA_INFO_COLOR"] = :cyan
 ```
 
-# TerminalMenus
+## TerminalMenus
 
 TerminalMenus is a submodule of the Julia REPL and enables small, low-profile interactive menus in the terminal.
 
-## Examples
+### Examples
 
 ```julia
 import REPL
@@ -465,7 +465,7 @@ options = ["apple", "orange", "grape", "strawberry",
 
 ```
 
-### RadioMenu
+#### RadioMenu
 
 The RadioMenu allows the user to select one option from the list. The `request`
 function displays the interactive menu and returns the index of the selected
@@ -501,7 +501,7 @@ v  peach
 Your favorite fruit is blueberry!
 ```
 
-### MultiSelectMenu
+#### MultiSelectMenu
 
 The MultiSelectMenu allows users to select many choices from a list.
 
@@ -542,12 +542,12 @@ You like the following fruits:
   - peach
 ```
 
-## Customization / Configuration
+### Customization / Configuration
 
 All interface customization is done through the keyword only
 `TerminalMenus.config()` function.
 
-### Arguments
+#### Arguments
 
  - `charset::Symbol=:na`: ui characters to use (`:ascii` or `:unicode`); overridden by other arguments
  - `cursor::Char='>'|'→'`: character to use for cursor
@@ -559,7 +559,7 @@ All interface customization is done through the keyword only
  - `supress_output::Bool=false`: For testing. If true, menu will not be printed to console.
  - `ctrl_c_interrupt::Bool=true`: If `false`, return empty on ^C, if `true` throw InterruptException() on ^C
 
-### Examples
+#### Examples
 
 ```julia
 julia> menu = MultiSelectMenu(options, pagesize=5);
@@ -597,7 +597,7 @@ Set([4, 2])
 
 ```
 
-# References
+## References
 
 ```@docs
 Base.atreplinit


### PR DESCRIPTION
This section has a level one header (one `#`), which I think is supposed to only be for the page title. It makes the TOC in the sidebar behave somewhat strangely.

I've incremented the level of all headers in this section. Unfortunately I wasn't able to get `make docs` to work, but the changes are pretty simple.