### PR TITLE
improve performance of complex number parsing

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -309,7 +309,17 @@ function tryparse_internal(::Type{Complex{T}}, s::Union{String,SubString{String}
     end
 
     # find trailing im/i/j
-    iᵢ = something(findprev(in(('m','i','j')), s, e), 0)
+    iᵢ = 0
+    # findprev with a predicate function is quite slow,
+    # use three separate calls to findprev with a char instead
+    for c in ('j', 'i', 'm')
+        local i = findprev(c, s, e)
+        if i !== nothing
+            iᵢ = i
+            break
+        end
+    end
+
     if iᵢ > 0 && s[iᵢ] == 'm' # im
         iᵢ -= 1
         if s[iᵢ] != 'i'


### PR DESCRIPTION
```jl
using DelimitedFiles
A = randn(Complex{Float64},300,50)
writedlm("A.csv",A,',')
@time readdlm("A.csv",',',Complex{Float64},'\n')
```

Before:

```
  9.316321 seconds (293.64 k allocations: 3.262 GiB, 3.35% gc time)
```

After

```
  0.558150 seconds (18.06 k allocations: 1.130 MiB)
```

It is still very slow but hey.

Ref https://github.com/JuliaLang/julia/issues/35721

The super slowness came from the generic `findprev` which needs to allocate a brand new string to for the reversal:

https://github.com/JuliaLang/julia/blob/bb2aa52abd72ee64ad6a41e36959fc62560b37ac/base/strings/search.jl#L346