### PR TITLE
Fix and test PCRE error message getter.

### DIFF
--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -147,7 +147,7 @@ free_match_context(context) =
 function err_message(errno)
     buffer = Vector{UInt8}(undef, 256)
     ccall((:pcre2_get_error_message_8, PCRE_LIB), Cvoid,
-          (Int32, Ptr{UInt8}, Csize_t), errno, buffer, sizeof(buffer))
+          (UInt32, Ptr{UInt8}, Csize_t), errno, buffer, sizeof(buffer))
     GC.@preserve buffer unsafe_string(pointer(buffer))
 end
 

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -139,4 +139,7 @@
     # Test that PCRE throws the correct kind of error
     # TODO: Uncomment this once the corresponding change has propagated to CI
     #@test_throws ErrorException Base.PCRE.info(C_NULL, Base.PCRE.INFO_NAMECOUNT, UInt32)
+
+    # test that we can get the error message of negative error codes
+    @test Base.PCRE.err_message(Base.PCRE.ERROR_NOMEMORY) isa String
 end


### PR DESCRIPTION
Encountered the following in an OOM situation:

```
ERROR: LoadError: LoadError: InexactError: check_top_bit(Int32, 4294967248)
Stacktrace:
 [1] throw_inexacterror(::Symbol, ::Type{Int32}, ::UInt32) at ./boot.jl:557
 [2] check_top_bit at ./boot.jl:571 [inlined]
 [3] toInt32 at ./boot.jl:620 [inlined]
 [4] Int32 at ./boot.jl:706 [inlined]
 [5] convert at ./number.jl:7 [inlined]
 [6] cconvert at ./essentials.jl:388 [inlined]
 [7] err_message(::UInt32) at ./pcre.jl:149
 [8] jit_compile at ./pcre.jl:132 [inlined]
 [9] compile(::Regex) at ./regex.jl:73
 [10] #occursin#377 at ./regex.jl:172 [inlined]
 [11] occursin at ./regex.jl:172 [inlined]
 [12] (::Base.var"#723#724"{Base.UUID,String})(::IOStream) at ./loading.jl:538
 [13] open(::Base.var"#723#724"{Base.UUID,String}, ::String; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:323
 [14] open at ./io.jl:321 [inlined]
 [15] explicit_manifest_deps_get at ./loading.jl:524 [inlined]
 [16] manifest_deps_get(::String, ::Base.PkgId, ::String) at ./loading.jl:345
 [17] identify_package(::Base.PkgId, ::String) at ./loading.jl:215
 [18] stale_cachefile(::String, ::String) at ./loading.jl:1470
 [19] _require_search_from_serialized(::Base.PkgId, ::String) at ./loading.jl:757
 [20] _tryrequire_from_serialized(::Base.PkgId, ::UInt64, ::Nothing) at ./loading.jl:712
 [21] _require_from_serialized(::String) at ./loading.jl:743
 [22] _require(::Base.PkgId) at ./loading.jl:1039
 [23] require(::Base.PkgId) at ./loading.jl:927
 [24] require(::Module, ::Symbol) at ./loading.jl:922
 [25] include(::Function, ::Module, ::String) at ./Base.jl:382
 [26] include at ./Base.jl:370 [inlined]
 [27] include(::String) at /Users/travis/build/JuliaGPU/GPUCompiler.jl/src/GPUCompiler.jl:1
 [28] top-level scope at /Users/travis/build/JuliaGPU/GPUCompiler.jl/src/GPUCompiler.jl:41
 [29] include(::Function, ::Module, ::String) at ./Base.jl:382
 [30] include(::Module, ::String) at ./Base.jl:370
 [31] top-level scope at none:2
 [32] eval at ./boot.jl:331 [inlined]
 [33] eval(::Expr) at ./client.jl:467
 [34] top-level scope at ./none:3
```