### PR TITLE
Export jl_debug_method_invalidation.

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -2285,7 +2285,7 @@ static void jl_insert_methods(jl_array_t *list)
     }
 }
 
-extern int JL_DEBUG_METHOD_INVALIDATION;
+extern int jl_debug_method_invalidation;
 
 // verify that these edges intersect with the same methods as before
 static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
@@ -2377,7 +2377,7 @@ static void jl_insert_backedges(jl_array_t *list, jl_array_t *targets)
             }
         }
         else {
-            if (JL_DEBUG_METHOD_INVALIDATION) {
+            if (jl_debug_method_invalidation) {
                 jl_static_show(JL_STDOUT, (jl_value_t*)caller);
                 jl_uv_puts(JL_STDOUT, "<<<\n", 4);
             }

--- a/src/gf.c
+++ b/src/gf.c
@@ -1489,12 +1489,12 @@ static void update_max_args(jl_methtable_t *mt, jl_value_t *type)
         mt->max_args = na;
 }
 
-int JL_DEBUG_METHOD_INVALIDATION = 0;
+JL_DLLEXPORT int jl_debug_method_invalidation = 0;
 
 // recursively invalidate cached methods that had an edge to a replaced method
 static void invalidate_method_instance(jl_method_instance_t *replaced, size_t max_world, int depth)
 {
-    if (JL_DEBUG_METHOD_INVALIDATION) {
+    if (jl_debug_method_invalidation) {
         int d0 = depth;
         while (d0-- > 0)
             jl_uv_puts(JL_STDOUT, " ", 1);
@@ -1626,7 +1626,7 @@ static int invalidate_mt_cache(jl_typemap_entry_t *oldentry, void *closure0)
             }
         }
         if (intersects) {
-            if (JL_DEBUG_METHOD_INVALIDATION) {
+            if (jl_debug_method_invalidation) {
                 jl_uv_puts(JL_STDOUT, "-- ", 4);
                 jl_static_show(JL_STDOUT, (jl_value_t*)mi);
                 jl_uv_puts(JL_STDOUT, "\n", 1);
@@ -1776,7 +1776,7 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
             }
         }
     }
-    if (invalidated && JL_DEBUG_METHOD_INVALIDATION) {
+    if (invalidated && jl_debug_method_invalidation) {
         jl_uv_puts(JL_STDOUT, ">> ", 3);
         jl_static_show(JL_STDOUT, (jl_value_t*)method);
         jl_uv_puts(JL_STDOUT, " ", 1);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1627,7 +1627,7 @@ static int invalidate_mt_cache(jl_typemap_entry_t *oldentry, void *closure0)
         }
         if (intersects) {
             if (jl_debug_method_invalidation) {
-                jl_uv_puts(JL_STDOUT, "-- ", 4);
+                jl_uv_puts(JL_STDOUT, "-- ", 3);
                 jl_static_show(JL_STDOUT, (jl_value_t*)mi);
                 jl_uv_puts(JL_STDOUT, "\n", 1);
             }


### PR DESCRIPTION
Seems useful, ref https://github.com/JuliaLang/julia/pull/35714

```julia
julia> f() = 1
f (generic function with 1 method)

julia> f()
1

julia> f() = 2
f (generic function with 1 method)

julia> f()
2

julia> unsafe_store!(cglobal(:jl_debug_method_invalidation, Cint), 1)
Ptr{Int32} @0x00007ff48d312260

julia> f() = 3
-- f()
f (generic function with 1 method)

julia> f()
3

```