### PR TITLE
Include llvm-version.h first to avoid compiler warnings.

### DIFF
--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -1,5 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include "llvm-version.h"
+
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>
 
@@ -21,7 +23,6 @@
 #include <llvm/Pass.h>
 #include <llvm/Support/Debug.h>
 
-#include "llvm-version.h"
 #include "codegen_shared.h"
 #include "julia.h"
 


### PR DESCRIPTION
```
In file included from /home/tim/Julia/julia/src/llvm-propagate-addrspaces.cpp:6:
In file included from /home/tim/Julia/julia/build/sanitize/usr/include/llvm/ADT/SmallPtrSet.h:17:
In file included from /home/tim/Julia/julia/build/sanitize/usr/include/llvm/ADT/EpochTracker.h:18:
/home/tim/Julia/julia/build/sanitize/usr/include/llvm/Config/abi-breaking.h:23:6: warning: 'LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING' is not defined, evaluates to 0 [-Wundef]
#if !LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
     ^
1 warning generated.
```