### PR TITLE
Eliminate most invalidations from loading FixedPointNumbers

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -3,6 +3,8 @@
 # promote Bool to any other numeric type
 promote_rule(::Type{Bool}, ::Type{T}) where {T<:Number} = T
 
+convert(::Type{Bool}, x::Bool) = x   # prevent invalidation
+
 typemin(::Type{Bool}) = false
 typemax(::Type{Bool}) = true
 

--- a/base/char.jl
+++ b/base/char.jl
@@ -49,6 +49,7 @@ Char
 (::Type{AbstractChar})(x::Number) = Char(x)
 (::Type{T})(x::AbstractChar) where {T<:Union{Number,AbstractChar}} = T(codepoint(x))
 (::Type{T})(x::T) where {T<:AbstractChar} = x
+AbstractChar(x::AbstractChar) = x
 
 """
     ncodeunits(c::Char) -> Int
@@ -179,6 +180,7 @@ convert(::Type{AbstractChar}, x::Number) = Char(x) # default to Char
 convert(::Type{T}, x::Number) where {T<:AbstractChar} = T(x)
 convert(::Type{T}, x::AbstractChar) where {T<:Number} = T(x)
 convert(::Type{T}, c::AbstractChar) where {T<:AbstractChar} = T(c)
+convert(::Type{AbstractChar}, c::AbstractChar) = c
 convert(::Type{T}, c::T) where {T<:AbstractChar} = c
 
 rem(x::AbstractChar, ::Type{T}) where {T<:Number} = rem(codepoint(x), T)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -174,6 +174,8 @@ convert(::Type{Type}, x::Type) = x # the ssair optimizer is strongly dependent o
                                    # in the absence of inlining-enabled
                                    # (due to fields typed as `Type`, which is generally a bad idea)
 
+Union{}(x::Union{}) = throw(MethodError(convert, (Union{}, x)))
+
 """
     @eval [mod,] ex
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -166,6 +166,7 @@ true
 """
 function convert end
 
+convert(::Type{Union{}}, x::Union{}) = throw(MethodError(convert, (Union{}, x)))
 convert(::Type{Union{}}, x) = throw(MethodError(convert, (Union{}, x)))
 convert(::Type{Any}, x) = x
 convert(::Type{T}, x::T) where {T} = x
@@ -447,6 +448,9 @@ Stacktrace:
 ```
 """
 sizeof(x) = Core.sizeof(x)
+# The next two methods prevent invalidation
+sizeof(::Type{Union{}}) = Core.sizeof(Union{})
+sizeof(::Type{T}) where T = Core.sizeof(T)
 
 # simple Array{Any} operations needed for bootstrap
 @eval setindex!(A::Array{Any}, @nospecialize(x), i::Int) = arrayset($(Expr(:boundscheck)), A, x, i)

--- a/base/number.jl
+++ b/base/number.jl
@@ -2,6 +2,10 @@
 
 ## generic operations on numbers ##
 
+# prevent invalidation
+Union{}(x::Number)                  = throw(MethodError(convert, (Union{}, x)))
+convert(::Type{Union{}}, x::Number) = throw(MethodError(convert, (Union{}, x)))
+
 # Numbers are convertible
 convert(::Type{T}, x::T)      where {T<:Number} = x
 convert(::Type{T}, x::Number) where {T<:Number} = T(x)
@@ -240,6 +244,9 @@ julia> zero(rand(2,2))
 """
 zero(x::Number) = oftype(x,0)
 zero(::Type{T}) where {T<:Number} = convert(T,0)
+# prevent invalidation
+zero(x::Union{})      = throw(MethodError(zero, (x,)))
+zero(::Type{Union{}}) = throw(MethodError(zero, (Union{},)))
 
 """
     one(x)
@@ -275,6 +282,9 @@ julia> import Dates; one(Dates.Day(1))
 """
 one(::Type{T}) where {T<:Number} = convert(T,1)
 one(x::T) where {T<:Number} = one(T)
+# prevent invalidation
+one(x::Union{})      = throw(MethodError(one, (x,)))
+one(::Type{Union{}}) = throw(MethodError(one, (Union{},)))
 # note that convert(T, 1) should throw an error if T is dimensionful,
 # so this fallback definition should be okay.
 
@@ -298,6 +308,9 @@ julia> import Dates; oneunit(Dates.Day)
 """
 oneunit(x::T) where {T} = T(one(x))
 oneunit(::Type{T}) where {T} = T(one(T))
+# prevent invalidation
+oneunit(x::Union{})      = throw(MethodError(oneunit, (x,)))
+oneunit(::Type{Union{}}) = throw(MethodError(oneunit, (Union{},)))
 
 """
     big(T::Type)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -306,25 +306,29 @@ with reduction `op` over an empty array with element type of `T`.
 
 If not defined, this will throw an `ArgumentError`.
 """
-reduce_empty(op, T) = _empty_reduce_error()
-reduce_empty(::typeof(+), T) = zero(T)
+reduce_empty(op, ::Type{T}) where T = _empty_reduce_error()
+reduce_empty(::typeof(+), ::Type{Union{}}) = _empty_reduce_error()   # avoid invalidation
+reduce_empty(::typeof(+), ::Type{T}) where T = zero(T)
 reduce_empty(::typeof(+), ::Type{Bool}) = zero(Int)
-reduce_empty(::typeof(*), T) = one(T)
+reduce_empty(::typeof(*), ::Type{Union{}}) = _empty_reduce_error()
+reduce_empty(::typeof(*), ::Type{T}) where T = one(T)
 reduce_empty(::typeof(*), ::Type{<:AbstractChar}) = ""
 reduce_empty(::typeof(&), ::Type{Bool}) = true
 reduce_empty(::typeof(|), ::Type{Bool}) = false
 
-reduce_empty(::typeof(add_sum), T) = reduce_empty(+, T)
+reduce_empty(::typeof(add_sum), ::Type{Union{}}) = _empty_reduce_error()
+reduce_empty(::typeof(add_sum), ::Type{T}) where T = reduce_empty(+, T)
 reduce_empty(::typeof(add_sum), ::Type{T}) where {T<:SmallSigned}  = zero(Int)
 reduce_empty(::typeof(add_sum), ::Type{T}) where {T<:SmallUnsigned} = zero(UInt)
-reduce_empty(::typeof(mul_prod), T) = reduce_empty(*, T)
+reduce_empty(::typeof(mul_prod), ::Type{Union{}}) = _empty_reduce_error()
+reduce_empty(::typeof(mul_prod), ::Type{T}) where T = reduce_empty(*, T)
 reduce_empty(::typeof(mul_prod), ::Type{T}) where {T<:SmallSigned}  = one(Int)
 reduce_empty(::typeof(mul_prod), ::Type{T}) where {T<:SmallUnsigned} = one(UInt)
 
-reduce_empty(op::BottomRF, T) = reduce_empty(op.rf, T)
-reduce_empty(op::MappingRF, T) = mapreduce_empty(op.f, op.rf, T)
-reduce_empty(op::FilteringRF, T) = reduce_empty(op.rf, T)
-reduce_empty(op::FlipArgs, T) = reduce_empty(op.f, T)
+reduce_empty(op::BottomRF, ::Type{T}) where T = reduce_empty(op.rf, T)
+reduce_empty(op::MappingRF, ::Type{T}) where T = mapreduce_empty(op.f, op.rf, T)
+reduce_empty(op::FilteringRF, ::Type{T}) where T = reduce_empty(op.rf, T)
+reduce_empty(op::FlipArgs, ::Type{T}) where T = reduce_empty(op.f, T)
 
 """
     Base.mapreduce_empty(f, op, T)
@@ -336,12 +340,12 @@ of `T`.
 If not defined, this will throw an `ArgumentError`.
 """
 mapreduce_empty(f, op, T) = _empty_reduce_error()
-mapreduce_empty(::typeof(identity), op, T) = reduce_empty(op, T)
-mapreduce_empty(::typeof(abs), op, T)      = abs(reduce_empty(op, T))
-mapreduce_empty(::typeof(abs2), op, T)     = abs2(reduce_empty(op, T))
+mapreduce_empty(::typeof(identity), op, ::Type{T}) where T = reduce_empty(op, T)
+mapreduce_empty(::typeof(abs), op, ::Type{T}) where T      = abs(reduce_empty(op, T))
+mapreduce_empty(::typeof(abs2), op, ::Type{T}) where T     = abs2(reduce_empty(op, T))
 
-mapreduce_empty(f::typeof(abs),  ::typeof(max), T) = abs(zero(T))
-mapreduce_empty(f::typeof(abs2), ::typeof(max), T) = abs2(zero(T))
+mapreduce_empty(::typeof(abs),  ::typeof(max), ::Type{T}) where T = abs(zero(T))
+mapreduce_empty(::typeof(abs2), ::typeof(max), ::Type{T}) where T = abs2(zero(T))
 
 # For backward compatibility:
 mapreduce_empty_iter(f, op, itr, ItrEltype) =


### PR DESCRIPTION
On master (or really, on #35714), loading FixedPointNumbers ("FPN") produces a `jl_debug_method_invalidation` log of nearly 600 lines. In conjunction with a couple of changes to FPN (below), this reduces it to 43, of which only 17 are actual `MethodInstance`s. Most of the remaining ones derive from invalidating `convert(Type{T<:Int64}, Int64) where {T<:Int64}`, which gets invalidated by
```julia
(::Type{X})(x::Number) where {X <: FixedPoint} = _convert(X, x)
```
I have not been successful in figuring out how to head that off short of `@eval`ing dedicated methods like `convert(::Type{Int64}, x::Int64) = x`.

Here's the FPN diff (EDIT: new and improved):

```diff
diff --git a/src/FixedPointNumbers.jl b/src/FixedPointNumbers.jl
index 160c133..3c3bd33 100644
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -48,7 +48,8 @@ rawtype(::Type{X}) where {T, X <: FixedPoint{T}} = T
 *(x::Real, ::Type{X}) where {X <: FixedPoint} = _convert(X, x)
 
 # constructor-style conversions
-(::Type{X})(x::Real) where {X <: FixedPoint} = _convert(X, x)
+(::Type{X})(x::X) where {X <: FixedPoint}      = x
+(::Type{X})(x::Number) where {X <: FixedPoint} = _convert(X, x)
 
 function (::Type{<:FixedPoint})(x::AbstractChar)
     throw(ArgumentError("FixedPoint (Fixed or Normed) cannot be constructed from a Char"))
@@ -97,7 +98,6 @@ one(::Type{X}) where {X <: FixedPoint} = oneunit(X)
 inv_rawone(x) = (@generated) ? (y = 1.0 / rawone(x); :($y)) : 1.0 / rawone(x)
 
 # traits
-sizeof(::Type{X}) where {X <: FixedPoint} = sizeof(rawtype(X))
 eps(::Type{X}) where {X <: FixedPoint} = X(oneunit(rawtype(X)), 0)
 typemax(::Type{T}) where {T <: FixedPoint} = T(typemax(rawtype(T)), 0)
 typemin(::Type{T}) where {T <: FixedPoint} = T(typemin(rawtype(T)), 0)
```
