### PR TITLE
add better implementations for generic findprev findnext for AbstractString

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -130,9 +130,9 @@ function findnext(testf::Function, s::AbstractString, i::Integer)
     1 ≤ i ≤ z || throw(BoundsError(s, i))
     @inbounds i == z || isvalid(s, i) || string_index_err(s, i)
     e = lastindex(s)
-    @inbounds while i <= e
-        testf(s[i]) && return i
-        i = nextind(s, i)
+    while i <= e
+        testf(@inbounds s[i]) && return i
+        i = @inbounds nextind(s, i)
     end
     return nothing
 end
@@ -340,9 +340,9 @@ function findprev(testf::Function, s::AbstractString, i::Integer)
     0 ≤ i ≤ z || throw(BoundsError(s, i))
     i == z && return nothing
     @inbounds i == 0 || isvalid(s, i) || string_index_err(s, i)
-    @inbounds while i >= 1
-        testf(s[i]) && return i
-        i = prevind(s, i)
+    while i >= 1
+        testf(@inbounds s[i]) && return i
+        i = @inbounds prevind(s, i)
     end
     return nothing
 end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -127,15 +127,16 @@ findfirst(ch::AbstractChar, string::AbstractString) = findfirst(==(ch), string)
 function findnext(testf::Function, s::AbstractString, i::Integer)
     i = Int(i)
     z = ncodeunits(s) + 1
-    1 ≤ i ≤ z || throw(BoundsError(s, i))
+    1 ≤ i ≤ z || throw(BoundsError(s, i))
     @inbounds i == z || isvalid(s, i) || string_index_err(s, i)
-    for (j, d) in pairs(SubString(s, i))
-        if testf(d)
-            return i + j - 1
-        end
+    e = lastindex(s)
+    @inbounds while i <= e
+        testf(s[i]) && return i
+        i = nextind(s, i)
     end
     return nothing
 end
+
 
 in(c::AbstractChar, s::AbstractString) = (findfirst(isequal(c),s)!==nothing)
 
@@ -334,18 +335,16 @@ findlast(ch::AbstractChar, string::AbstractString) = findlast(==(ch), string)
 
 # AbstractString implementation of the generic findprev interface
 function findprev(testf::Function, s::AbstractString, i::Integer)
-    if i < 1
-        return i == 0 ? nothing : throw(BoundsError(s, i))
+    i = Int(i)
+    z = ncodeunits(s) + 1
+    0 ≤ i ≤ z || throw(BoundsError(s, i))
+    i == z && return nothing
+    @inbounds i == 0 || isvalid(s, i) || string_index_err(s, i)
+    @inbounds while i >= 1
+        testf(s[i]) && return i
+        i = prevind(s, i)
     end
-    n = ncodeunits(s)
-    if i > n
-        return i == n+1 ? nothing : throw(BoundsError(s, i))
-    end
-    # r[reverseind(r,i)] == reverse(r)[i] == s[i]
-    # s[reverseind(s,j)] == reverse(s)[j] == r[j]
-    r = reverse(s)
-    j = findnext(testf, r, reverseind(r, i))
-    j === nothing ? nothing : reverseind(s, j)
+    return nothing
 end
 
 function _rsearchindex(s::AbstractString,


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/35727#issuecomment-623499860

```jl
using DelimitedFiles
A = randn(Complex{Float64},300,50)
writedlm("A.csv",A,',')
@time readdlm("A.csv",',',Complex{Float64},'\n')
```


Before:
```
  9.316321 seconds (293.64 k allocations: 3.262 GiB, 3.35% gc time)
```

After

```
 0.013526 seconds (30.09 k allocations: 1.882 MiB)
```
Fixes #35721.