### PR TITLE
Fix diagm_container for types without zero

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -301,7 +301,9 @@ function diagm_size(size::Tuple{Int,Int}, kv::Pair{<:Integer,<:AbstractVector}..
 end
 function diagm_container(size, kv::Pair{<:Integer,<:AbstractVector}...)
     T = promote_type(map(x -> eltype(x.second), kv)...)
-    return zeros(T, diagm_size(size, kv...)...)
+    # For some type `T`, `zero(T)` is not a `T` and `zeros(T, ...)` fails.
+    U = promote_type(T, typeof(zero(T)))
+    return zeros(U, diagm_size(size, kv...)...)
 end
 diagm_container(size, kv::Pair{<:Integer,<:BitVector}...) =
     falses(diagm_size(size, kv...)...)

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -928,4 +928,15 @@ end
     @test exp(log(A2)) ≈ A2
 end
 
+struct TypeWithoutZero end
+Base.zero(::Type{TypeWithoutZero}) = TypeWithZero()
+struct TypeWithZero end
+Base.promote_rule(::Type{TypeWithoutZero}, ::Type{TypeWithZero}) = TypeWithZero
+Base.zero(::Type{<:Union{TypeWithoutZero, TypeWithZero}}) = TypeWithZero()
+Base.:+(x::TypeWithZero, ::TypeWithoutZero) = x
+
+@testset "diagm for type with no zero" begin
+    @test diagm(0 => [TypeWithoutZero()]) isa Matrix{TypeWithZero}
+end
+
 end # module TestDense


### PR DESCRIPTION
For some types, `T`, `zero(T) isa T` does not hold. This is the case for instance for `T = JuMP.VariableRef` for which `zero(T) isa AffExpr`. When the users call `diagm` with vectors of `VariableRef`, we should have a matrix of `AffExpr` but instead an error is thrown
```julia
MethodError: Cannot `convert` an object of type JuMP.AffExpr to an object of type JuMP.VariableRef
Closest candidates are:
  convert(::Type{T}, !Matched::T) where T at essentials.jl:171
```
because `diagm_container` calls `zeros(JuMP.VariableRef, ...)`.
I think it is fair for `zeros(JuMP.VariableRef, ...)` to error and it would not be consistent for it to return a matrix of `JuMP.AffExpr` so it seems the issue is that `diagm_container` calls `zeros(JuMP.VariableRef, ...)` hence the fix in this PR.

Note that if you try it with the latest version of JuMP, it currently works as we redefine `diagm_container` just for this case:
https://github.com/JuliaOpt/MutableArithmetics.jl/blob/407a8fdfb5ef1810f3785a88e490291d37b9fb03/src/dispatch.jl#L27-L31
but we'd rather have it fixed upstream as other types might benefit from it (e.g. polynomial variables from [MultivariatePolynomials](https://github.com/JuliaAlgebra/MultivariatePolynomials.jl)).

See https://github.com/JuliaOpt/MutableArithmetics.jl/issues/47 for more context.