### PR TITLE
RFC: add a command line option to print out method invalidations to stderr or a file

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -28,6 +28,7 @@ struct JLOptions
     can_inline::Int8
     polly::Int8
     trace_compile::Ptr{UInt8}
+    trace_method_invalidations::Ptr{UInt8}
     fast_math::Int8
     worker::Int8
     cookie::Ptr{UInt8}

--- a/src/dump.c
+++ b/src/dump.c
@@ -2294,8 +2294,6 @@ static void jl_insert_methods(jl_array_t *list)
     }
 }
 
-extern int jl_debug_method_invalidation;
-
 // verify that these edges intersect with the same methods as before
 static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
 {
@@ -2386,9 +2384,11 @@ static void jl_insert_backedges(jl_array_t *list, jl_array_t *targets)
             }
         }
         else {
-            if (jl_debug_method_invalidation) {
-                jl_static_show(JL_STDOUT, (jl_value_t*)caller);
-                jl_uv_puts(JL_STDOUT, "<<<\n", 4);
+            if (jl_options.trace_method_invalidations != NULL) {
+                jl_static_show(jl_s_method_invalidated, (jl_value_t*)caller);
+                jl_uv_puts(jl_s_method_invalidated, "<<<\n", 4);
+                if (jl_s_method_invalidated != JL_STDERR)
+                    ios_flush(&jl_f_method_invalidated);
             }
         }
     }

--- a/src/init.c
+++ b/src/init.c
@@ -612,6 +612,24 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
     }
 }
 
+ios_t jl_f_method_invalidated;
+JL_STREAM* jl_s_method_invalidated;
+static void jl_init_method_invalidated_streams(void) {
+    if (jl_options.trace_method_invalidations != NULL) {
+        if (jl_s_method_invalidated == NULL) {
+            const char* t = jl_options.trace_method_invalidations;
+            if (!strncmp(t, "stderr", 6))
+                jl_s_method_invalidated = JL_STDERR;
+            else {
+                if (ios_file(&jl_f_method_invalidated, t, 1, 1, 1, 1) == NULL)
+                    jl_errorf("cannot open method invalidation file \"%s\" for writing", t);
+                jl_s_method_invalidated = (JL_STREAM*) &jl_f_method_invalidated;
+            }
+        }
+    }
+}
+
+
 static void jl_set_io_wait(int v)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
@@ -774,6 +792,8 @@ void _julia_init(JL_IMAGE_SEARCH rel)
         }
         JL_GC_POP();
     }
+
+    jl_init_method_invalidated_streams();
 
     if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
         jl_install_sigint_handler();

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -58,6 +58,7 @@ jl_options_t jl_options = { 0,    // quiet
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly
                             NULL, // trace_compile
+                            NULL, // trace_method_invalidations
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
                             NULL, // cookie
@@ -161,8 +162,10 @@ static const char opts_hidden[]  =
     " --output-bc name          Generate LLVM bitcode (.bc)\n"
     " --output-asm name         Generate an assembly file (.s)\n"
     " --output-incremental=no   Generate an incremental output file (rather than complete)\n"
-    " --trace-compile={stdout,stderr}\n"
+    " --trace-compile={name,stderr}\n"
     "                           Print precompile statements for methods compiled during execution.\n\n"
+    " --trace-method-invalidations={name,stderr}\n"
+    "                           Print method invalidations.\n\n"
 ;
 
 JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
@@ -183,6 +186,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_inline,
            opt_polly,
            opt_trace_compile,
+           opt_trace_method_invalidations,
            opt_math_mode,
            opt_worker,
            opt_bind_to,
@@ -244,6 +248,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "inline",          required_argument, 0, opt_inline },
         { "polly",           required_argument, 0, opt_polly },
         { "trace-compile",   required_argument, 0, opt_trace_compile },
+        { "trace-method-invalidations", required_argument, 0, opt_trace_method_invalidations },
         { "math-mode",       required_argument, 0, opt_math_mode },
         { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
@@ -615,6 +620,11 @@ restart_switch:
          case opt_trace_compile:
             jl_options.trace_compile = strdup(optarg);
             if (!jl_options.trace_compile)
+                jl_errorf("fatal error: failed to allocate memory: %s", strerror(errno));
+            break;
+        case opt_trace_method_invalidations:
+            jl_options.trace_method_invalidations = strdup(optarg);
+            if (!jl_options.trace_method_invalidations)
                 jl_errorf("fatal error: failed to allocate memory: %s", strerror(errno));
             break;
         case opt_math_mode:

--- a/src/julia.h
+++ b/src/julia.h
@@ -1921,6 +1921,7 @@ typedef struct {
     int8_t can_inline;
     int8_t polly;
     const char *trace_compile;
+    const char *trace_method_invalidations;
     int8_t fast_math;
     int8_t worker;
     const char *cookie;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -905,6 +905,10 @@ JL_DLLEXPORT jl_value_t *jl_get_cfunction_trampoline(
     jl_unionall_t *env, jl_value_t **vals);
 
 
+// Method invalidation debug output
+extern ios_t jl_f_method_invalidated;
+extern JL_STREAM* jl_s_method_invalidated;
+
 // Windows only
 #define JL_EXE_LIBNAME ((const char*)1)
 #define JL_DL_LIBNAME ((const char*)2)


### PR DESCRIPTION
This makes it work the same as `--trace-compile`.

```jl
❯ ./julia --trace-method-invalidations=stderr -e 'f() = 1; f(); f() = 2'
-- f()


❯ ./julia --trace-method-invalidations=invalidations.txt -e 'f() = 1; f(); f() = 2'
❯ cat invalidations.txt
-- f()
```

It is harder to toggle this in a running session now though so maybe this API isn't the best. Perhaps it is better to be able to scope a block of code to write the invalidations to a file.

cc @timholy, could potentially be used in https://github.com/timholy/SnoopCompile.jl/issues/77.

Also, I don't know much about how things are structured in the code here so I just put stuff a bit randomly...