### PR TITLE
debug_method_invalidation: print the module-of-definition

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1487,6 +1487,21 @@ static void update_max_args(jl_methtable_t *mt, jl_value_t *type)
 
 JL_DLLEXPORT int jl_debug_method_invalidation = 0;
 
+static void show_method_instance_module(jl_method_instance_t *mi)
+{
+    jl_static_show(JL_STDOUT, (jl_value_t*)mi);
+    if (jl_is_method(mi->def.method)) {
+        jl_uv_puts(JL_STDOUT, " (in ", 5);
+        jl_static_show(JL_STDOUT, mi->def.method->module);
+        jl_uv_puts(JL_STDOUT, ")", 1);
+    }
+    else if (jl_is_module(mi->def.module)) {
+        jl_uv_puts(JL_STDOUT, " (toplevel thunk in ", 5);
+        jl_static_show(JL_STDOUT, mi->def.module);
+        jl_uv_puts(JL_STDOUT, ")", 1);
+    }
+}
+
 // recursively invalidate cached methods that had an edge to a replaced method
 static void invalidate_method_instance(jl_method_instance_t *replaced, size_t max_world, int depth)
 {
@@ -1494,7 +1509,7 @@ static void invalidate_method_instance(jl_method_instance_t *replaced, size_t ma
         int d0 = depth;
         while (d0-- > 0)
             jl_uv_puts(JL_STDOUT, " ", 1);
-        jl_static_show(JL_STDOUT, (jl_value_t*)replaced);
+        show_method_instance_module(replaced);
         jl_uv_puts(JL_STDOUT, "\n", 1);
     }
     if (!jl_is_method(replaced->def.method))
@@ -1624,7 +1639,7 @@ static int invalidate_mt_cache(jl_typemap_entry_t *oldentry, void *closure0)
         if (intersects) {
             if (jl_debug_method_invalidation) {
                 jl_uv_puts(JL_STDOUT, "-- ", 3);
-                jl_static_show(JL_STDOUT, (jl_value_t*)mi);
+                show_method_instance_module(mi);
                 jl_uv_puts(JL_STDOUT, "\n", 1);
             }
             oldentry->max_world = env->max_world;


### PR DESCRIPTION
This might be helpful as we consider writing tooling to help people analyze `MethodInstance` invalidations.