### PR TITLE
Export the codegen lock.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7547,6 +7547,16 @@ extern "C" void jl_teardown_codegen()
     PrintStatistics();
 }
 
+JL_DLLEXPORT void jl_codegenlock_begin(void)
+{
+    JL_LOCK(&codegen_lock);
+}
+
+JL_DLLEXPORT void jl_codegenlock_end(void)
+{
+    JL_UNLOCK(&codegen_lock);
+}
+
 // the rest of this file are convenience functions
 // that are exported for assisting with debugging from gdb
 extern "C" void jl_dump_llvm_value(void *v)


### PR DESCRIPTION
I couldn't find an exported accessor (@vtjnash?), so added one similar to `jl_iolock_{begin,end}`. No urgent need for this, but GPU back-ends have been running into threading-related segfaults (https://github.com/JuliaGPU/GPUCompiler.jl/issues/21) so I wanted to get this in for 1.5.