### PR TITLE
Make kron(a,b) preserve Adjoint-ness

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -221,6 +221,7 @@ similar(A::AdjOrTrans, ::Type{T}, dims::Dims{N}) where {T,N} = similar(A.parent,
 # sundry basic definitions
 parent(A::AdjOrTrans) = A.parent
 vec(v::TransposeAbsVec) = parent(v)
+vec(v::AdjointAbsVec{<:Real}) = parent(v)
 
 ### concatenation
 # preserve Adjoint/Transpose wrapper around vectors

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -401,6 +401,9 @@ kron(a::AbstractVector, b::AbstractVector) = vec(kron(reshape(a ,length(a), 1), 
 kron(a::AbstractMatrix, b::AbstractVector) = kron(a, reshape(b, length(b), 1))
 kron(a::AbstractVector, b::AbstractMatrix) = kron(reshape(a, length(a), 1), b)
 
+kron(a::AdjointAbsVec, b::AdjointAbsVec) = adjoint(kron(parent(a), parent(b)))
+kron(a::AdjOrTransAbsVec, b::AdjOrTransAbsVec) = transpose(kron(vec(a), vec(b)))
+
 # Matrix power
 (^)(A::AbstractMatrix, p::Integer) = p < 0 ? power_by_squaring(inv(A), -p) : power_by_squaring(A, p)
 function (^)(A::AbstractMatrix{T}, p::Integer) where T<:Integer

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -341,11 +341,12 @@ end
 
 Kronecker tensor product of two vectors or two matrices.
 
-For vectors v and w, the Kronecker product is related to the outer product by
-`kron(v,w) == vec(w*transpose(v))` or
-`w*transpose(v) == reshape(kron(v,w), (length(w), length(v)))`.
+For real vectors `v` and `w`, the Kronecker product is related to the outer product by
+`kron(v,w) == vec(w * transpose(v))` or
+`w * transpose(v) == reshape(kron(v,w), (length(w), length(v)))`.
 Note how the ordering of `v` and `w` differs on the left and right
 of these expressions (due to column-major storage).
+For complex vectors, the outer product `w * v'` also differs by conjugation of `v`.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -401,8 +401,8 @@ kron(a::AbstractVector, b::AbstractVector) = vec(kron(reshape(a ,length(a), 1), 
 kron(a::AbstractMatrix, b::AbstractVector) = kron(a, reshape(b, length(b), 1))
 kron(a::AbstractVector, b::AbstractMatrix) = kron(reshape(a, length(a), 1), b)
 
-kron(a::AdjointAbsVec, b::AdjointAbsVec) = adjoint(kron(parent(a), parent(b)))
-kron(a::AdjOrTransAbsVec, b::AdjOrTransAbsVec) = transpose(kron(vec(a), vec(b)))
+kron(a::AdjointAbsVec, b::AdjointAbsVec) = adjoint(kron(adjoint(a), adjoint(b)))
+kron(a::AdjOrTransAbsVec, b::AdjOrTransAbsVec) = transpose(kron(transpose(a), transpose(b)))
 
 # Matrix power
 (^)(A::AbstractMatrix, p::Integer) = p < 0 ? power_by_squaring(inv(A), -p) : power_by_squaring(A, p)

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -271,7 +271,7 @@ end
 
 @testset "Adjoint and Transpose vector vec methods" begin
     intvec = [1, 2]
-    @test vec(Adjoint(intvec)) == intvec
+    @test vec(Adjoint(intvec)) === intvec
     @test vec(Transpose(intvec)) === intvec
     cvec = [1 + 1im]
     @test vec(cvec')[1] == cvec[1]'

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -396,11 +396,14 @@ end
 end
 
 @testset "kron adjoint" begin
-    a = [1, 2, 3]
-    b = [4, 5, 6]
+    a = [1+im, 2, 3]
+    b = [4, 5, 6+7im]
     @test kron(a', b') isa Adjoint
+    @test kron(a', b') == kron(a, b)'
     @test kron(transpose(a), b') isa Transpose
+    @test kron(transpose(a), b') == kron(permutedims(a), collect(b'))
     @test kron(transpose(a), transpose(b)) isa Transpose
+    @test kron(transpose(a), transpose(b)) == transpose(kron(a, b))
 end
 
 @testset "issue #4796" begin

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -395,6 +395,14 @@ end
     @test kron(b',2) == [8 10 12]
 end
 
+@testset "kron adjoint" begin
+    a = [1, 2, 3]
+    b = [4, 5, 6]
+    @test kron(a', b') isa Adjoint
+    @test kron(transpose(a), b') isa Transpose
+    @test kron(transpose(a), transpose(b)) isa Transpose
+end
+
 @testset "issue #4796" begin
     dim=2
     S=zeros(Complex,dim,dim)


### PR DESCRIPTION
This makes `kron` of two `Adjoint` vectors return the same type, and solves the following important obstacle to world peace:
```julia
A = rand(3,3); B = rand(3,3); 
v = rand(3); w = rand(3);
C = rand(5,9);

# Then these are equal, kron commutes with *
C * (kron(A,B) * kron(v,w))
C * kron(A*v, B*w)

# But these are not:
C * (kron(v,w)' * kron(A,B))' # 5-element Array
C * kron(v'*A, w'*B)'         # 5×1 Array

# Because this a 1×9 matrix, not an Adjoint:
kron(v', w')
```
It also adjusts the docstring of `kron` so as not to suggest that it's closely related to an outer product in general, but only for real vectors (as discussed more than once in #35150). 

And it makes `vec(v') === v` for real vectors; this was already true for `vec(transpose(v))`, and was used in making this work before I had a better idea. (I can remove this if someone wishes to be very strict about orthogonal PRs.)