### PR TITLE
Revert "add a test for big tuple conversion (#35736)"

### DIFF
--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -569,8 +569,3 @@ end
     @test_throws BoundsError (1,2.0)[0:1]
     @test_throws BoundsError (1,2.0)[0:0]
 end
-
-@testset "big tuple convert stackoverflow #31935" begin
-    t = (rand(1:typemax(UInt8), 1024)...,);
-    @test convert(NTuple{1024, UInt8}, t) isa NTuple{1024, UInt8}
-end


### PR DESCRIPTION
This reverts commit b72e191ea9ad98aee0e8f8fa4688491906316f50.

It looks like this can still stack overflow, e.g. https://build.julialang.org/#/builders/65/builds/10435