### PR TITLE
threading: improve safety posture of modifying global bindings

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -33,9 +33,6 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 The following is a leaf lock (level 2), and only acquires level 1 locks (safepoint) internally:
 
 >   * typecache
-
-The following is a level 2 lock:
-
 >   * Module->lock
 
 The following is a level 3 lock, which can only acquire level 1 or level 2 locks internally:
@@ -48,9 +45,10 @@ The following is a level 4 lock, which can only recurse to acquire level 1, 2, o
 
 No Julia code may be called while holding a lock above this point.
 
-The following is a level 6 lock, which can only recurse to acquire locks at lower levels:
+The following are a level 6 lock, which can only recurse to acquire locks at lower levels:
 
 >   * codegen
+>   * jl_modules_mutex
 
 The following is an almost root lock (level end-1), meaning only the root look may be held when
 trying to acquire it:
@@ -93,6 +91,19 @@ The following locks are broken:
     > doesn't exist right now
     >
     > fix: create it
+
+  * Module->lock
+
+    > This is vulnerable to deadlocks since it can't be certain it is acquired in sequence.
+    > Some operations (such as `import_module`) are missing a lock.
+    >
+    > fix: replace with `jl_modules_mutex`?
+
+  * loading.jl: `require` and `register_root_module`
+
+    > This file potentially has numerous problems.
+    >
+    > fix: needs locks
 
 ## Shared Global Data Structures
 

--- a/src/atomics.h
+++ b/src/atomics.h
@@ -73,6 +73,8 @@
 // TODO: Maybe add jl_atomic_compare_exchange_weak for spin lock
 #  define jl_atomic_store(obj, val)                     \
     __atomic_store_n(obj, val, __ATOMIC_SEQ_CST)
+#  define jl_atomic_store_relaxed(obj, val)           \
+    __atomic_store_n(obj, val, __ATOMIC_RELAXED)
 #  if defined(__clang__) || defined(__ICC) || defined(__INTEL_COMPILER) || \
     !(defined(_CPU_X86_) || defined(_CPU_X86_64_))
 // ICC and Clang doesn't have this bug...
@@ -262,6 +264,10 @@ template<typename T, typename T2>
 static inline void jl_atomic_store_release(volatile T *obj, T2 val)
 {
     jl_signal_fence();
+    *obj = (T)val;
+}
+static inline void jl_atomic_store_relaxed(volatile T *obj, T2 val)
+{
     *obj = (T)val;
 }
 // atomic loads

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1692,7 +1692,6 @@ static jl_cgval_t emit_globalref(jl_codectx_t &ctx, jl_module_t *mod, jl_sym_t *
 {
     jl_binding_t *bnd = NULL;
     Value *bp = global_binding_pointer(ctx, mod, name, &bnd, false);
-    // TODO: refactor. this partially duplicates code in emit_var
     if (bnd && bnd->value != NULL) {
         if (bnd->constp) {
             return mark_julia_const(bnd->value);

--- a/src/init.c
+++ b/src/init.c
@@ -618,6 +618,8 @@ static void jl_set_io_wait(int v)
     ptls->io_wait = v;
 }
 
+extern jl_mutex_t jl_modules_mutex;
+
 void _julia_init(JL_IMAGE_SEARCH rel)
 {
     jl_init_timing();
@@ -628,6 +630,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     jl_safepoint_init();
     libsupport_init();
     htable_new(&jl_current_modules, 0);
+    JL_MUTEX_INIT(&jl_modules_mutex);
     ios_set_io_wait_func = jl_set_io_wait;
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),
                                     // best to call this first, since it also initializes libuv

--- a/src/julia.h
+++ b/src/julia.h
@@ -1472,13 +1472,9 @@ JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var) JL_NOTSA
 JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
-JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT,
-                                jl_sym_t *var,
-                                jl_value_t *val JL_ROOTED_ARGUMENT);
-JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT,
-                               jl_sym_t *var,
-                               jl_value_t *val JL_ROOTED_ARGUMENT);
-JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);
+JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
+JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
+JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b JL_ROOTING_ARGUMENT, jl_value_t *rhs JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b);
 JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);
 JL_DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);

--- a/src/module.c
+++ b/src/module.c
@@ -118,7 +118,7 @@ static jl_binding_t *new_binding(jl_sym_t *name)
 }
 
 // get binding for assignment
-JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var, int error)
+JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, int error)
 {
     JL_LOCK_NOGC(&m->lock);
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
@@ -567,24 +567,23 @@ JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    // In a release build, simply ignore conflicting assignments (for backwards compatibility).
-    // However, we want to start asserting that they do not occur, since that can cause `val`
-    // not to be rooted when the caller expected it to be.
-    assert(!bp->constp);
-    if (!bp->constp) {
-        bp->value = val;
-        jl_gc_wb(m, val);
-    }
+    JL_GC_PROMISE_ROOTED(bp);
+    jl_checked_assignment(bp, val);
 }
 
 JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    assert(!bp->constp);
-    if (jl_atomic_compare_exchange(&bp->constp, 0, 1) == 0) {
-        bp->value = val;
-        jl_gc_wb(m, val);
+    if (bp->value == NULL) {
+        if (jl_atomic_bool_compare_exchange(&bp->constp, 0, 1)) {
+            if (jl_atomic_bool_compare_exchange(&bp->value, NULL, val)) {
+                jl_gc_wb_binding(bp, val);
+                return;
+            }
+        }
     }
+    jl_errorf("invalid redefinition of constant %s",
+              jl_symbol_name(bp->name));
 }
 
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)
@@ -700,18 +699,22 @@ void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b)
 
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
 {
-    if (b->constp && b->value != NULL) {
-        if (!jl_egal(rhs, b->value)) {
-            if (jl_typeof(rhs) != jl_typeof(b->value) ||
-                jl_is_type(rhs) /*|| jl_is_function(rhs)*/ || jl_is_module(rhs)) {
-                jl_errorf("invalid redefinition of constant %s",
-                          jl_symbol_name(b->name));
-            }
-            jl_printf(JL_STDERR, "WARNING: redefinition of constant %s. This may fail, cause incorrect answers, or produce other errors.\n",
+    if (b->constp) {
+        jl_value_t *old = jl_atomic_compare_exchange(&b->value, NULL, rhs);
+        if (old == NULL) {
+            jl_gc_wb_binding(b, rhs);
+            return;
+        }
+        if (jl_egal(rhs, old))
+            return;
+        if (jl_typeof(rhs) != jl_typeof(old) || jl_is_type(rhs) || jl_is_module(rhs)) {
+            jl_errorf("invalid redefinition of constant %s",
                       jl_symbol_name(b->name));
         }
+        jl_printf(JL_STDERR, "WARNING: redefinition of constant %s. This may fail, cause incorrect answers, or produce other errors.\n",
+                  jl_symbol_name(b->name));
     }
-    b->value = rhs;
+    jl_atomic_store_relaxed(&b->value, rhs);
     jl_gc_wb_binding(b, rhs);
 }
 


### PR DESCRIPTION
Ensures that we are holding some lock (a new one) while mutating the
internal global `jl_current_modules` table.

While reading these binding values is not memory-safe to do
simultaneously (it may invent pointers from thin-air and segfault), this
commit ensures that a data conflict during the writes to them will
not corrupt the values written into memory.

This is some of the non-controversial content extracted from #35535. While it doesn't make particularly useful promises without the rest of that PR (docs here are updated accordingly), it is a much smaller semantic change.