### PR TITLE
Partly revert "Reduce consequences of method invalidation for Dict and Set"

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -378,10 +378,6 @@ end
 
 function setindex!(h::Dict{K,V}, v0, key::K) where V where K
     v = convert(V, v0)
-    setindex!(h, v, key)
-end
-
-function setindex!(h::Dict{K,V}, v::V, key::K) where V where K
     index = ht_keyindex2!(h, key)
 
     if index > 0


### PR DESCRIPTION
This small change had a very significant impact on build times and sysimg size. It must be because it forces us to specialize on all value types.

master:
```
Base  ─────────── 44.928756 seconds
Total ─────── 110.037750 seconds 
Generating precompile statements... 1977 generated in 156.256105 seconds (overhead 106.552134 seconds)
-rwxr-xr-x 1 jeff jeff 157101656 May  5 19:32 sys.so
```

with the commit reverted:
```
Base  ─────────── 39.333038 seconds
Total ───────  95.018324 seconds 
Generating precompile statements... 1754 generated in 147.468238 seconds (overhead 101.685924 seconds)
-rwxr-xr-x 1 jeff jeff 149454696 May  5 19:40 sys.so
```

The Dict `setindex!` method seems to be the vast majority of it; the new copymutable method is probably ok.

@timholy Could you check how much impact this has on the latencies you were testing?
