### PR TITLE
jl_debug_method_invalidation: return a list of instances

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -2294,7 +2294,7 @@ static void jl_insert_methods(jl_array_t *list)
     }
 }
 
-extern int jl_debug_method_invalidation;
+extern jl_array_t *_jl_debug_method_invalidation JL_GLOBALLY_ROOTED;
 
 // verify that these edges intersect with the same methods as before
 static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
@@ -2348,7 +2348,8 @@ static void jl_insert_backedges(jl_array_t *list, jl_array_t *targets)
     // map(enable, ((list[i] => targets[list[i + 1] .* 2]) for i in 1:2:length(list) if all(valids[list[i + 1]])))
     size_t i, l = jl_array_len(list);
     jl_array_t *valids = NULL;
-    JL_GC_PUSH1(&valids);
+    jl_value_t *loctag = NULL;
+    JL_GC_PUSH2(&valids, &loctag);
     jl_verify_edges(targets, &valids);
     for (i = 0; i < l; i += 2) {
         jl_method_instance_t *caller = (jl_method_instance_t*)jl_array_ptr_ref(list, i);
@@ -2386,9 +2387,11 @@ static void jl_insert_backedges(jl_array_t *list, jl_array_t *targets)
             }
         }
         else {
-            if (jl_debug_method_invalidation) {
-                jl_static_show(JL_STDOUT, (jl_value_t*)caller);
-                jl_uv_puts(JL_STDOUT, "<<<\n", 4);
+            if (_jl_debug_method_invalidation) {
+                jl_array_ptr_1d_push(_jl_debug_method_invalidation, (jl_value_t*)caller);
+                loctag = jl_cstr_to_string("insert_backedges");
+                jl_gc_wb(_jl_debug_method_invalidation, loctag);
+                jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
             }
         }
     }


### PR DESCRIPTION
Rather than print information about method invalidations, this allows us to store the `MethodInstance`s themselves. The reason I think this is attractive is that analyzing the reason for invalidations sometimes benefits from type intersection, and it will be easier to perform that kind of analysis if we don't have to try to reconstruct the type from its repr.

You can see a WIP analysis in SnoopCompile here: https://github.com/timholy/SnoopCompile.jl/blob/teh/invalidations/src/invalidations.jl

The biggest negative here is that this gets in the way of some potential debug information, e.g., if Julia crashes or doesn't get through bootstrap. So this isn't without some loss, CC @vtjnash. Nevertheless I think method invalidation is rarely an issue in such cases, so perhaps it's a loss we can live with.

There are some "competing" PRs, I'll list them as being closed by this one (should we choose to go this way):
Closes #35745
Closes #35747

CC @ianshmean 