### PR TITLE
fix #35771, `global a` as repl input

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -104,6 +104,8 @@ function softscope(@nospecialize ex)
             return ex′
         elseif h in (:meta, :import, :using, :export, :module, :error, :incomplete, :thunk)
             return ex
+        elseif h === :global && all(x->isa(x, Symbol), ex.args)
+            return ex
         else
             return Expr(:block, Expr(:softscope, true), ex)
         end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1146,6 +1146,18 @@ fake_repl() do stdin_write, stdout_read, repl
     Base.wait(repltask)
 end
 
+# issue #35771
+fake_repl() do stdin_write, stdout_read, repl
+    repltask = @async begin
+        REPL.run_repl(repl)
+    end
+    write(stdin_write, "global x\n")
+    readline(stdout_read)
+    @test !occursin("ERROR", readline(stdout_read))
+    write(stdin_write, '\x04')
+    Base.wait(repltask)
+end
+
 
 fake_repl() do stdin_write, stdout_read, repl
     repltask = @async begin


### PR DESCRIPTION
fix #35771