### PR TITLE
Define machinery so that Some can be used for broadcast

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ New language features
 * The compiler optimization level can now be set per-module using the experimental macro
   `Base.Experimental.@optlevel n`. For code that is not performance-critical, setting
   this to 0 or 1 can provide significant latency improvements ([#34896]).
+* `Some`containers now support broadcast as zero dimensional immutable containers. `Some(x)`
+  should be preferred to `Ref(x)` when you wish to exempt `x` from broadcasting ([#35778]).
 
 Language changes
 ----------------

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -193,6 +193,8 @@ include("broadcast.jl")
 using .Broadcast
 using .Broadcast: broadcasted, broadcasted_kwsyntax, materialize, materialize!
 
+include("somebroadcast.jl")
+
 # missing values
 include("missing.jl")
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -668,8 +668,8 @@ julia> Broadcast.broadcastable([1,2,3]) # like `identity` since arrays already s
  2
  3
 
-julia> Broadcast.broadcastable(Int) # Types don't support axes, indexing, or iteration but are commonly used as scalars
-Some(Int)
+julia> Broadcast.broadcastable(Int64) # Types don't support axes, indexing, or iteration but are commonly used as scalars
+Some(Int64)
 
 julia> Broadcast.broadcastable("hello") # Strings break convention of matching iteration and act like a scalar instead
 Some("hello")

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -669,10 +669,10 @@ julia> Broadcast.broadcastable([1,2,3]) # like `identity` since arrays already s
  3
 
 julia> Broadcast.broadcastable(Int) # Types don't support axes, indexing, or iteration but are commonly used as scalars
-Base.RefValue{Type{Int64}}(Int64)
+Some(Int)
 
 julia> Broadcast.broadcastable("hello") # Strings break convention of matching iteration and act like a scalar instead
-Base.RefValue{String}("hello")
+Some("hello")
 ```
 """
 broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex,Pair}) = Some(x)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -675,8 +675,8 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex,Pair}) = Ref(x)
-broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
+broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex,Pair}) = Some(x)
+broadcastable(::Type{T}) where {T} = Some{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables
 broadcastable(x) = collect(x)

--- a/base/some.jl
+++ b/base/some.jl
@@ -97,23 +97,3 @@ something() = throw(ArgumentError("No value arguments present"))
 something(x::Nothing, y...) = something(y...)
 something(x::Some, y...) = x.value
 something(x::Any, y...) = x
-
-#Methods for broadcast
-getindex(s::Some) = s.value
-getindex(s::Some, ::CartesianIndex{0}) = s.value
-
-iterate(s::Some) = (s.value, nothing)
-iterate( ::Some, s) = nothing
-
-ndims(::Some) = 0
-ndims(::Type{<:Some}) = 0
-
-length(::Some) = 1
-size(::Some) = ()
-axes(::Some) = ()
-
-IteratorSize(::Type{<:Some}) = HasShape{0}()
-broadcastable(s::Some) = s
-
-eltype(::Some{T})       where {T} = T
-eltype(::Type{Some{T}}) where {T} = T

--- a/base/some.jl
+++ b/base/some.jl
@@ -6,6 +6,8 @@
 A wrapper type used in `Union{Some{T}, Nothing}` to distinguish between the absence
 of a value ([`nothing`](@ref)) and the presence of a `nothing` value (i.e. `Some(nothing)`).
 
+`Some` is also used in broadcasting to treat it's enclosed value as a scalar.
+
 Use [`something`](@ref) to access the value wrapped by a `Some` object.
 """
 struct Some{T}
@@ -95,3 +97,23 @@ something() = throw(ArgumentError("No value arguments present"))
 something(x::Nothing, y...) = something(y...)
 something(x::Some, y...) = x.value
 something(x::Any, y...) = x
+
+#Methods for broadcast
+Base.getindex(s::Some) = s.value
+Base.getindex(s::Some, ::CartesianIndex{0}) = s.value
+
+Base.iterate(s::Some) = (s.value, nothing)
+Base.iterate( ::Some, s) = nothing
+
+Base.ndims(::Some) = 0
+Base.ndims(::Type{<:Some}) = 0
+
+Base.length(::Some) = 1
+Base.size(::Some) = ()
+Base.axes(::Some) = ()
+
+Base.IteratorSize(::Type{<:Some}) = Base.HasShape{0}()
+Base.broadcastable(s::Some) = s
+
+Base.eltype(::Some{T})       where {T} = T
+Base.eltype(::Type{Some{T}}) where {T} = T

--- a/base/some.jl
+++ b/base/some.jl
@@ -99,21 +99,21 @@ something(x::Some, y...) = x.value
 something(x::Any, y...) = x
 
 #Methods for broadcast
-Base.getindex(s::Some) = s.value
-Base.getindex(s::Some, ::CartesianIndex{0}) = s.value
+getindex(s::Some) = s.value
+getindex(s::Some, ::CartesianIndex{0}) = s.value
 
-Base.iterate(s::Some) = (s.value, nothing)
-Base.iterate( ::Some, s) = nothing
+iterate(s::Some) = (s.value, nothing)
+iterate( ::Some, s) = nothing
 
-Base.ndims(::Some) = 0
-Base.ndims(::Type{<:Some}) = 0
+ndims(::Some) = 0
+ndims(::Type{<:Some}) = 0
 
-Base.length(::Some) = 1
-Base.size(::Some) = ()
-Base.axes(::Some) = ()
+length(::Some) = 1
+size(::Some) = ()
+axes(::Some) = ()
 
-Base.IteratorSize(::Type{<:Some}) = Base.HasShape{0}()
-Base.broadcastable(s::Some) = s
+IteratorSize(::Type{<:Some}) = Base.HasShape{0}()
+broadcastable(s::Some) = s
 
-Base.eltype(::Some{T})       where {T} = T
-Base.eltype(::Type{Some{T}}) where {T} = T
+eltype(::Some{T})       where {T} = T
+eltype(::Type{Some{T}}) where {T} = T

--- a/base/some.jl
+++ b/base/some.jl
@@ -6,7 +6,7 @@
 A wrapper type used in `Union{Some{T}, Nothing}` to distinguish between the absence
 of a value ([`nothing`](@ref)) and the presence of a `nothing` value (i.e. `Some(nothing)`).
 
-`Some` is also used in broadcasting to treat it's enclosed value as a scalar.
+`Some` is also used in broadcasting to treat its enclosed value as a scalar.
 
 Use [`something`](@ref) to access the value wrapped by a `Some` object.
 """

--- a/base/some.jl
+++ b/base/some.jl
@@ -112,7 +112,7 @@ length(::Some) = 1
 size(::Some) = ()
 axes(::Some) = ()
 
-IteratorSize(::Type{<:Some}) = Base.HasShape{0}()
+IteratorSize(::Type{<:Some}) = HasShape{0}()
 broadcastable(s::Some) = s
 
 eltype(::Some{T})       where {T} = T

--- a/base/somebroadcast.jl
+++ b/base/somebroadcast.jl
@@ -1,0 +1,19 @@
+#Methods some Some can broadcast
+getindex(s::Some) = s.value
+getindex(s::Some, ::CartesianIndex{0}) = s.value
+
+iterate(s::Some) = (s.value, nothing)
+iterate( ::Some, s) = nothing
+
+ndims(::Some) = 0
+ndims(::Type{<:Some}) = 0
+
+length(::Some) = 1
+size(::Some) = ()
+axes(::Some) = ()
+
+IteratorSize(::Type{<:Some}) = HasShape{0}()
+broadcastable(s::Some) = s
+
+eltype(::Some{T})       where {T} = T
+eltype(::Type{Some{T}}) where {T} = T

--- a/base/somebroadcast.jl
+++ b/base/somebroadcast.jl
@@ -13,7 +13,7 @@ size(::Some) = ()
 axes(::Some) = ()
 
 IteratorSize(::Type{<:Some}) = HasShape{0}()
-broadcastable(s::Some) = s
+Broadcast.broadcastable(s::Some) = s
 
 eltype(::Some{T})       where {T} = T
 eltype(::Type{Some{T}}) where {T} = T

--- a/base/somebroadcast.jl
+++ b/base/somebroadcast.jl
@@ -15,5 +15,4 @@ axes(::Some) = ()
 IteratorSize(::Type{<:Some}) = HasShape{0}()
 Broadcast.broadcastable(s::Some) = s
 
-eltype(::Some{T})       where {T} = T
 eltype(::Type{Some{T}}) where {T} = T

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -947,12 +947,9 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
 
 Sometimes, you want a container (like an array) that would normally participate in broadcast to be "protected"
 from broadcast's behavior of iterating over all of its elements. By placing it inside another container
-(like a single element [`Tuple`](@ref)) broadcast will treat it as a single value.
+(we recommend [`Some`](@ref)), broadcast will treat it as a single value.
 ```jldoctest
-julia> ([1, 2, 3], [4, 5, 6]) .+ ([1, 2, 3],)
-([2, 4, 6], [5, 7, 9])
-
-julia> ([1, 2, 3], [4, 5, 6]) .+ tuple([1, 2, 3])
+julia> ([1, 2, 3], [4, 5, 6]) .+ Some([1, 2, 3])
 ([2, 4, 6], [5, 7, 9])
 ```
 

--- a/test/some.jl
+++ b/test/some.jl
@@ -98,3 +98,14 @@ using Base: notnothing
 # isnothing()
 @test !isnothing(1)
 @test isnothing(nothing)
+
+#Eltype
+@test eltype(Some{Int}) == Int
+@test eltype(Some(1)) == Int
+
+# Broadcast with Some
+@testset "Some Broadcast" begin
+    @test Some(1) .+ 1 == 2
+    @test Some([1, 2]) .+ [[1, 2,], [3, 4]] == [[2, 4], [4, 6]]
+    @test isa.(Some([1,2,3]), [Array, Dict, Int]) == [true, false, false]
+end


### PR DESCRIPTION
As mentioned in https://github.com/JuliaLang/julia/pull/35675, `Some` may be a good candidate to use basically like an immutable version of `Ref` in broadcast expressions. This makes `Some` a zero dimensional container that knows how to broadcast efficiently.

I figure it might be better to discuss the merits of this idea here rather than clogging up that PR. Another candidate brought up in that thread is to create a new singleton type `Only`. 

I think if we can make `Some` work for this without breaking anything, it would be preferable to creating yet another singleton type, but I'm wary that there could be hitherto unforeseen negative consequences to adding this behaviour to `Some`. Perhaps someone is relying on `eltype(Some(1)) == Any`

Closes https://github.com/JuliaLang/julia/issues/18379