### PR TITLE
Add .clang-format file (take 3)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,118 @@
+Language: Cpp
+Standard: Cpp11
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Stroustrup
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializersBeforeComma: false
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: false
+ColumnLimit: 92
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^(<|"(llvm|llvm-c|clang|clang-c)/)'
+    Priority:        2
+  - Regex:           '^<.*'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 8
+UseCRLF: true
+UseTab: Never
+ForEachMacros:
+  - JL_TRY
+  - JL_CATCH
+StatementMacros:
+  - bi_fintrinsic
+  - bi_iintrinsic_fast
+  - bi_intrinsic_ctype
+  - bool_fintrinsic
+  - bool_iintrinsic_fast
+  - bool_intrinsic_ctype
+  - checked_intrinsic_ctype
+  - cvt_iintrinsic
+  - fpiseq_n
+  - fpislt_n
+  - ter_fintrinsic
+  - ter_intrinsic_ctype
+  - un_fintrinsic
+  - un_fintrinsic_withtype
+  - un_iintrinsic_ctype
+  - uu_iintrinsic_ctype


### PR DESCRIPTION
Following https://github.com/JuliaLang/julia/pull/15591 and https://github.com/JuliaLang/julia/pull/22660, I now took the mechanical approach of generating a clang-format rule file based on the existing codebase using [clang-format-infer](https://github.com/jbapple-cloudera/clang-format-infer). Comparing `git diff --stat` against https://github.com/JuliaLang/julia/pull/22660, this goes from 38037 insertions(+) 24659 deletions(-) to 25550 insertions(+) 22371 deletions(-), so matches our codebase a fair bit more closely.

This PR is just to add a formatting rule file, not to format the entire codebase. We should think about how to do so separately (in one go, leaving out certain badle-formatted sections, or rather incrementally on every commit, using `git clang-format` or maybe even a bot, etc). The formatting commit is here to inspect the diff.