### PR TITLE
RFC: Per-project sysimage

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -83,7 +83,9 @@ static const char opts[]  =
     " --help-hidden             Uncommon options not shown by `-h`\n\n"
 
     // startup options
-    " --project[={<dir>|@.}]    Set <dir> as the home project/environment\n"
+    " --project[={<dir>|@.}]    Set <dir> as the home project/environment.\n"
+    "                           If a text file `<dir>/.julia/sysimage.path` exist, its content\n"
+    "                           is used as the default value of of --sysimage.\n"
     " -J, --sysimage <file>     Start up with the given system image file\n"
     " -H, --home <dir>          Set location of `julia` executable\n"
     " --startup-file={yes|no}   Load `~/.julia/config/startup.jl`\n"


### PR DESCRIPTION
With this patch, you can do

```
(@v1.x) pkg> activate .

julia> Base.set_sysimage_path("PATH/TO/sys.so")

julia> exit()

$ julia --project=.  # implicitly use -J=PATH/TO/sys.so
```

To use `julia` with project-specific system image.

### Implementation/design

Given `--project=$projectdir`, `julia` binary tries to read the text file `$projectdir/.julia/sysimages/$slug.path` and use its content as the default `--sysimage` argument.  The `$slug` is computed from the path of `julia` binary.  This way, it is safe to use multiple `julia` binaries with the same project.

(Edit: it was pointed out that including `VERSION` in `slug` as well might be a better idea https://github.com/JuliaLang/Pkg.jl/issues/2008#issuecomment-687847827)

This PR does not store the system image directly at `$projectdir/.julia/sysimages/$slug.$dlext` because the system image is rather large and it is nice to be able to use the same system image in multiple projects without copying the image file itself.  Furthermore, it may make sense to distribute pre-compiled system image using the artifacts mechanism.  It then is desirable to load system image directly from artifacts datastore rather than in `$projectdir/.julia/sysimages`.  Note that symbolic link is not a good option for supporting Windows.

@staticfloat suggested to use triplet instead of `$slug` https://github.com/JuliaLang/julia/issues/33973#issuecomment-601505588 but this means to re-implement triplet detection in C. Furthermore, I don't think it is enough for supporting other variations of `julia` (e.g., debug build, different versions). Hashing the path of `julia` binary seems to be a simple robust solution.

---

If the design is good, I can add some tests.  Also, since I'm not a C programmer, I may be doing something stupid.  Let me know if there is a better way to implement this.
