### PR TITLE
add a test that error can be inferred to bottom

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2989,3 +2989,6 @@ f38888() = S38888(Base.inferencebarrier(3))
 @test f38888() isa S38888
 g38888() = S38888(Base.inferencebarrier(3), nothing)
 @test g38888() isa S38888
+
+f_inf_error_bottom(x::Vector) = isempty(x) ? error(x[1]) : x
+Core.Compiler.return_type(f_inf_error_bottom, Tuple{Vector{Any}}) == Vector{Any}

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2991,4 +2991,4 @@ g38888() = S38888(Base.inferencebarrier(3), nothing)
 @test g38888() isa S38888
 
 f_inf_error_bottom(x::Vector) = isempty(x) ? error(x[1]) : x
-Core.Compiler.return_type(f_inf_error_bottom, Tuple{Vector{Any}}) == Vector{Any}
+@test Core.Compiler.return_type(f_inf_error_bottom, Tuple{Vector{Any}}) == Vector{Any}


### PR DESCRIPTION
Test that we don't break https://github.com/JuliaLang/julia/blob/ddf7ce9a595b0c84fbed1a42e8c987a9fdcddaac/base/compiler/params.jl#L20-L21 in Base + stdlibs at least.

Ref https://github.com/JuliaLang/Pkg.jl/pull/1817

Maybe this shouldn't be a generic method if it has these constraints?