### PR TITLE
Return `HasEltype` only for homogenous non-empty tuples

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -646,6 +646,12 @@ if isdefined(Core, :Compiler)
         return quote
             if $I isa Generator && ($I).f isa Type
                 ($I).f
+            elseif $I isa Tuple
+                if isempty($I) || length($I) > 16
+                    Any
+                else
+                    mapreduce(typeof, typejoin, $I; init=Union{})
+                end
             else
                 Core.Compiler.return_type(first, Tuple{typeof($I)})
             end

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -126,3 +126,6 @@ IteratorEltype(::Type) = HasEltype()  # HasEltype is the default
 IteratorEltype(::Type{Generator{I,T}}) where {I,T} = EltypeUnknown()
 
 IteratorEltype(::Type{Any}) = EltypeUnknown()
+
+IteratorEltype(::Type{<:Tuple}) = EltypeUnknown()
+IteratorEltype(::Type{Tuple{T,Vararg{T}}}) where {T} = HasEltype()


### PR DESCRIPTION
Inspired by #35803, https://github.com/JuliaLang/Statistics.jl/pull/36, but seems like it might be worth trying on its own now that we're in the 1.6 cycle. Surprisingly little broke even without the `@default_eltype` change, let's see what that fixes/messes up!

If this does OK we might want a PkgEval run just to figure out what consequences a change like this might have.