### PR TITLE
sparse linalg docs

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -156,6 +156,7 @@ end
 # A few standard libraries need more than just the module itself in the DocTestSetup.
 # This overwrites the existing ones from above though, hence the warn=false.
 DocMeta.setdocmeta!(SparseArrays, :DocTestSetup, :(using SparseArrays, LinearAlgebra), recursive=true, warn=false)
+DocMeta.setdocmeta!(SuiteSparse, :DocTestSetup, :(using SparseArrays, LinearAlgebra, SuiteSparse), recursive=true, warn=false)
 DocMeta.setdocmeta!(UUIDs, :DocTestSetup, :(using UUIDs, Random), recursive=true, warn=false)
 DocMeta.setdocmeta!(Pkg, :DocTestSetup, :(using Pkg, Pkg.Artifacts), recursive=true, warn=false)
 DocMeta.setdocmeta!(Pkg.BinaryPlatforms, :DocTestSetup, :(using Pkg, Pkg.BinaryPlatforms), recursive=true, warn=false)

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -1,7 +1,7 @@
-# Linear Algebra
+# [Linear Algebra](@id man-linalg)
 
 ```@meta
-DocTestSetup = :(using LinearAlgebra)
+DocTestSetup = :(using LinearAlgebra, SparseArrays, SuiteSparse)
 ```
 
 In addition to (and as part of) its support for multi-dimensional arrays, Julia provides native implementations
@@ -306,12 +306,9 @@ of the Linear Algebra documentation.
 | `Schur`            | [Schur decomposition](https://en.wikipedia.org/wiki/Schur_decomposition)                                       |
 | `GeneralizedSchur` | [Generalized Schur decomposition](https://en.wikipedia.org/wiki/Schur_decomposition#Generalized_Schur_decomposition) |
 
-
-
 ## Standard functions
 
-Linear algebra functions in Julia are largely implemented by calling functions from [LAPACK](http://www.netlib.org/lapack/).
- Sparse factorizations call functions from [SuiteSparse](http://faculty.cse.tamu.edu/davis/suitesparse.html).
+Linear algebra functions in Julia are largely implemented by calling functions from [LAPACK](http://www.netlib.org/lapack/). Sparse matrix factorizations call functions from [SuiteSparse](http://suitesparse.com). Other sparse solvers are available as Julia packages.
 
 ```@docs
 Base.:*(::AbstractMatrix, ::AbstractMatrix)

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -222,7 +222,7 @@ end
 
 ### for StridedMatrices, check that matrix is symmetric/Hermitian
 """
-    cholesky!(A, Val(false); check = true) -> Cholesky
+    cholesky!(A::StridedMatrix, Val(false); check = true) -> Cholesky
 
 The same as [`cholesky`](@ref), but saves space by overwriting the input `A`,
 instead of creating a copy. An [`InexactError`](@ref) exception is thrown if
@@ -269,7 +269,7 @@ cholesky!(A::RealHermSymComplexHerm{<:Real}, ::Val{true}; tol = 0.0, check::Bool
 
 ### for StridedMatrices, check that matrix is symmetric/Hermitian
 """
-    cholesky!(A, Val(true); tol = 0.0, check = true) -> CholeskyPivoted
+    cholesky!(A::StridedMatrix, Val(true); tol = 0.0, check = true) -> CholeskyPivoted
 
 The same as [`cholesky`](@ref), but saves space by overwriting the input `A`,
 instead of creating a copy. An [`InexactError`](@ref) exception is thrown if the

--- a/stdlib/SuiteSparse/docs/src/index.md
+++ b/stdlib/SuiteSparse/docs/src/index.md
@@ -1,5 +1,9 @@
 # Sparse Linear Algebra
 
+```@meta
+DocTestSetup = :(using LinearAlgebra, SparseArrays, SuiteSparse)
+```
+
 Sparse matrix solvers call functions from [SuiteSparse](http://suitesparse.com). The following factorizations are available:
 
 | Type                              | Description                                   |
@@ -22,4 +26,9 @@ SuiteSparse.CHOLMOD.lowrankupdate!
 SuiteSparse.CHOLMOD.lowrankdowndate
 SuiteSparse.CHOLMOD.lowrankdowndate!
 SuiteSparse.CHOLMOD.lowrankupdowndate!
+```
+
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/SuiteSparse/docs/src/index.md
+++ b/stdlib/SuiteSparse/docs/src/index.md
@@ -1,0 +1,25 @@
+# Sparse Linear Algebra
+
+Sparse matrix solvers call functions from [SuiteSparse](http://suitesparse.com). The following factorizations are available:
+
+| Type                              | Description                                   |
+|:--------------------------------- |:--------------------------------------------- |
+| `SuiteSparse.CHOLMOD.Factor`      | Cholesky factorization                        |
+| `SuiteSparse.UMFPACK.UmfpackLU`   | LU factorization                              |
+| `SuiteSparse.SPQR.QRSparse`       | QR factorization                              |
+
+Other solvers such as [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl/) are as external packages. [Arpack.jl](https://julialinearalgebra.github.io/Arpack.jl/stable/) provides `eigs` and `svds` for iterative solution of eigensystems and singular value decompositions.
+
+These factorizations are described in the [`Linear Algebra`](@ref man-linalg) section of the manual:
+1. [`cholesky`](@ref)
+2. [`ldlt`](@ref)
+3. [`lu`](@ref)
+4. [`qr`](@ref)
+
+```@docs
+SuiteSparse.CHOLMOD.lowrankupdate
+SuiteSparse.CHOLMOD.lowrankupdate!
+SuiteSparse.CHOLMOD.lowrankdowndate
+SuiteSparse.CHOLMOD.lowrankdowndate!
+SuiteSparse.CHOLMOD.lowrankupdowndate!
+```

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -1310,7 +1310,7 @@ function cholesky!(F::Factor{Tv}, A::Sparse{Tv};
 end
 
 """
-    cholesky!(F::Factor, A; shift = 0.0, check = true) -> CHOLMOD.Factor
+    cholesky!(F::CHOLMOD.Factor, A::SparseMatrixCSC; shift = 0.0, check = true) -> CHOLMOD.Factor
 
 Compute the Cholesky (``LL'``) factorization of `A`, reusing the symbolic
 factorization `F`. `A` must be a [`SparseMatrixCSC`](@ref) or a [`Symmetric`](@ref)/
@@ -1349,7 +1349,7 @@ function cholesky(A::Sparse; shift::Real=0.0, check::Bool = true,
 end
 
 """
-    cholesky(A; shift = 0.0, check = true, perm = nothing) -> CHOLMOD.Factor
+    cholesky(A::SparseMatrixCSC; shift = 0.0, check = true, perm = nothing) -> CHOLMOD.Factor
 
 Compute the Cholesky factorization of a sparse positive definite matrix `A`.
 `A` must be a [`SparseMatrixCSC`](@ref) or a [`Symmetric`](@ref)/[`Hermitian`](@ref)
@@ -1474,7 +1474,7 @@ function ldlt!(F::Factor{Tv}, A::Sparse{Tv};
 end
 
 """
-    ldlt!(F::Factor, A; shift = 0.0, check = true) -> CHOLMOD.Factor
+    ldlt!(F::CHOLMOD.Factor, A::SparseMatrixCSC; shift = 0.0, check = true) -> CHOLMOD.Factor
 
 Compute the ``LDL'`` factorization of `A`, reusing the symbolic factorization `F`.
 `A` must be a [`SparseMatrixCSC`](@ref) or a [`Symmetric`](@ref)/[`Hermitian`](@ref)
@@ -1518,7 +1518,7 @@ function ldlt(A::Sparse; shift::Real=0.0, check::Bool = true,
 end
 
 """
-    ldlt(A; shift = 0.0, check = true, perm=nothing) -> CHOLMOD.Factor
+    ldlt(A::SparseMatrixCSC; shift = 0.0, check = true, perm=nothing) -> CHOLMOD.Factor
 
 Compute the ``LDL'`` factorization of a sparse matrix `A`.
 `A` must be a [`SparseMatrixCSC`](@ref) or a [`Symmetric`](@ref)/[`Hermitian`](@ref)
@@ -1564,14 +1564,14 @@ ldlt(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}},
 ## Rank updates
 
 """
-    lowrankupdowndate!(F::Factor, C::Sparse, update::Cint)
+    lowrankupdowndate!(F::CHOLMOD.Factor, C::Sparse, update::Cint)
 
 Update an `LDLt` or `LLt` Factorization `F` of `A` to a factorization of `A ± C*C'`.
 
 If sparsity preserving factorization is used, i.e. `L*L' == P*A*P'` then the new
 factor will be `L*L' == P*A*P' + C'*C`
 
-update: `Cint(1)` for `A + CC'`, `Cint(0)` for `A - CC'`
+`update`: `Cint(1)` for `A + CC'`, `Cint(0)` for `A - CC'`
 """
 function lowrankupdowndate!(F::Factor{Tv}, C::Sparse{Tv}, update::Cint) where Tv<:VTypes
     lF = unsafe_load(pointer(F))
@@ -1590,7 +1590,7 @@ lowrank_reorder(V::AbstractArray,p) = Sparse(sparse(V[p,:]))
 lowrank_reorder(V::AbstractSparseArray,p) = Sparse(V[p,:])
 
 """
-    lowrankupdate!(F::Factor, C)
+    lowrankupdate!(F::CHOLMOD.Factor, C::AbstractArray)
 
 Update an `LDLt` or `LLt` Factorization `F` of `A` to a factorization of `A + C*C'`.
 
@@ -1605,7 +1605,7 @@ function lowrankupdate!(F::Factor{Tv}, V::AbstractArray{Tv}) where Tv<:VTypes
 end
 
 """
-    lowrankdowndate!(F::Factor, C)
+    lowrankdowndate!(F::CHOLMOD.Factor, C::AbstractArray)
 
 Update an `LDLt` or `LLt` Factorization `F` of `A` to a factorization of `A - C*C'`.
 
@@ -1620,7 +1620,7 @@ function lowrankdowndate!(F::Factor{Tv}, V::AbstractArray{Tv}) where Tv<:VTypes
 end
 
 """
-    lowrankupdate(F::Factor, C) -> FF::Factor
+    lowrankupdate(F::CHOLMOD.Factor, C::AbstractArray) -> FF::CHOLMOD.Factor
 
 Get an `LDLt` Factorization of `A + C*C'` given an `LDLt` or `LLt` factorization `F` of `A`.
 
@@ -1632,7 +1632,7 @@ lowrankupdate(F::Factor{Tv}, V::AbstractArray{Tv}) where {Tv<:VTypes} =
     lowrankupdate!(copy(F), V)
 
 """
-    lowrankupdate(F::Factor, C) -> FF::Factor
+    lowrankupdate(F::CHOLMOD.Factor, C::AbstractArray) -> FF::CHOLMOD.Factor
 
 Get an `LDLt` Factorization of `A + C*C'` given an `LDLt` or `LLt` factorization `F` of `A`.
 

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -1415,8 +1415,8 @@ true
 
 julia> P = sparse(1:3, C.p, ones(3))
 3×3 SparseMatrixCSC{Float64,Int64} with 3 stored entries:
- ⋅    ⋅   1.0
- ⋅   1.0   ⋅
+  ⋅    ⋅   1.0
+  ⋅   1.0   ⋅
  1.0   ⋅    ⋅
 
 julia> P' * L * L' * P ≈ A

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -149,7 +149,7 @@ _default_tol(A::SparseMatrixCSC) =
     20*sum(size(A))*eps(real(eltype(A)))*maximum(norm(view(A, :, i)) for i in 1:size(A, 2))
 
 """
-    qr(A) -> QRSparse
+    qr(A::SparseMatrixCSC; tol=_default_tol(A), ordering=ORDERING_DEFAULT) -> QRSparse
 
 Compute the `QR` factorization of a sparse matrix `A`. Fill-reducing row and column permutations
 are used such that `F.R = F.Q'*A[F.prow,F.pcol]`. The main application of this type is to

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -171,9 +171,9 @@ julia> A = sparse([1,2,3,4], [1,1,2,2], [1.0,1.0,1.0,1.0])
   ⋅   1.0
 
 julia> qr(A)
-Base.SparseArrays.SPQR.QRSparse{Float64,Int64}
+SuiteSparse.SPQR.QRSparse{Float64,Int64}
 Q factor:
-4×4 Base.SparseArrays.SPQR.QRSparseQ{Float64,Int64}:
+4×4 SuiteSparse.SPQR.QRSparseQ{Float64,Int64}:
  -0.707107   0.0        0.0       -0.707107
   0.0       -0.707107  -0.707107   0.0
   0.0       -0.707107   0.707107   0.0
@@ -302,7 +302,7 @@ Extract factors of a QRSparse factorization. Possible values of `d` are
 julia> F = qr(sparse([1,3,2,3,4], [1,1,2,3,4], [1.0,2.0,3.0,4.0,5.0]));
 
 julia> F.Q
-4×4 Base.SparseArrays.SPQR.QRSparseQ{Float64,Int64}:
+4×4 SuiteSparse.SPQR.QRSparseQ{Float64,Int64}:
  1.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0
  0.0  0.0  1.0  0.0


### PR DESCRIPTION
I've incorporated the documentation of the sparse factorizations in the linear algebra section of the manual. The sparse factorizations will now show along with the dense and special counterparts in the manual.

Fix JuliaLang/LinearAlgebra.jl#724