### PR TITLE
Fix evalpoly docstring

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -101,7 +101,7 @@ end
 """
     evalpoly(x, p)
 
-Evaluate the polynomial ``\\sum_k p[k] x^{k-1}`` for the coefficients `p[1]`, `p[2]`, ...;
+Evaluate the polynomial ``\\sum_k x^{k-1} p[k]`` for the coefficients `p[1]`, `p[2]`, ...;
 that is, the coefficients are given in ascending order by power of `x`.
 Loops are unrolled at compile time if the number of coefficients is statically known, i.e.
 when `p` is a `Tuple`.
@@ -210,7 +210,7 @@ end
 """
     @evalpoly(z, c...)
 
-Evaluate the polynomial ``\\sum_k c[k] z^{k-1}`` for the coefficients `c[1]`, `c[2]`, ...;
+Evaluate the polynomial ``\\sum_k z^{k-1} c[k]`` for the coefficients `c[1]`, `c[2]`, ...;
 that is, the coefficients are given in ascending order by power of `z`.  This macro expands
 to efficient inline code that uses either Horner's method or, for complex `z`, a more
 efficient Goertzel-like algorithm.


### PR DESCRIPTION
The equation in the `evalpoly` docstring is fine for scalar polynomials but out of order for matrix polynomials with matrix coefficients.
It gives the order as `\sum_k p[k] x^{k-1}`, but the code actually evaluates `\sum_k x^{k-1} p[k]`.
The docstring for `@horner` uses the correct order.

An example:

```julia
julia> x = [1 2; 3 4];

julia> p1 = [3 4; 5 6];

julia> p = [p1, 2p1, 3p1];

julia> evalpoly(x, p)
2×2 Array{Int64,2}:
 242  300
 528  654

julia> p[1] + p[2] * x + p[3] * x^2 # what the equation claims evalpoly does
2×2 Array{Int64,2}:
 276  402
 426  620

julia> p[1] + x * p[2] + x^2 * p[3] # how the polynomial is actually evaluated
2×2 Array{Int64,2}:
 242  300
 528  654
```