### PR TITLE
Markdown.plain: \ => \\

### DIFF
--- a/stdlib/Markdown/src/render/plain.jl
+++ b/stdlib/Markdown/src/render/plain.jl
@@ -113,7 +113,7 @@ plaininline(io::IO, link::Link) = plaininline(io, "[", link.text, "](", link.url
 
 plaininline(io::IO, md::Image) = plaininline(io, "![", md.alt, "](", md.url, ")")
 
-plaininline(io::IO, s::AbstractString) = print(io, s)
+plaininline(io::IO, s::AbstractString) = print(io, replace(s, '\\' => "\\\\"))
 
 plaininline(io::IO, md::Bold) = plaininline(io, "**", md.text, "**")
 

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1138,3 +1138,5 @@ let m = Markdown.parse("---"), io = IOBuffer()
     show(io, "text/latex", m)
     @test String(take!(io)) == "\\rule{\\textwidth}{1pt}\n"
 end
+
+sprint(show, md"\\") == "\\\\\n"


### PR DESCRIPTION
I'm not 100% sure but I think that `Markdown.plain` needs to escape backslashes for round-trip-ability