### PR TITLE
[DO NOT MERGE] make sinpi/cospi return Int

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -927,8 +927,8 @@ function sincospi(x::T) where T<:Rational
     end
 end
 
-sinpi(x::Integer) = x >= 0 ? zero(float(x)) : -zero(float(x))
-cospi(x::Integer) = isodd(x) ? -one(float(x)) : one(float(x))
+sinpi(x::T) where {T<:Integer} = zero(signed(T))
+cospi(x::T) where {T<:Integer} = isodd(x) ? -one(signed(T)) : one(signed(T))
 sincospi(x::Integer) = (sinpi(x), cospi(x))
 sinpi(x::Real) = sinpi(float(x))
 cospi(x::Real) = cospi(float(x))


### PR DESCRIPTION
ref #35820. There was some discussion on Slack about how breaking this change would be, so could someone with permission trigger PkgEval on this? I think it would be good to get a better understanding of how much code actually relies on the specific return type. Of course, this won't catch performance regressions, e.g. due to dispatching on `generic_matmul` instead of BLAS, so we might still want to be careful, even if PkgEval is successful.