### PR TITLE
Add `inv(::AbstractQ)`

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -467,6 +467,8 @@ Base.propertynames(F::QRPivoted, private::Bool=false) =
 
 abstract type AbstractQ{T} <: AbstractMatrix{T} end
 
+inv(Q::AbstractQ) = Q'
+
 """
     QRPackedQ <: AbstractMatrix
 

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -300,7 +300,7 @@ end
 @testset "inv(::AbstractQ)" begin
     for T in (Float64, ComplexF64)
         Q = qr(randn(T,5,5)).Q
-        @test inv(Q) == Q'
+        @test inv(Q) === Q'
     end
 end
 

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -297,4 +297,11 @@ end
     end
 end
 
+@testset "inv(::AbstractQ)" begin
+    for T in (Float64, ComplexF64)
+        Q = qr(randn(T,5,5)).Q
+        @test inv(Q) == Q'
+    end
+end
+
 end # module TestQR


### PR DESCRIPTION
This PR fixes this behaviour:
```julia
julia> inv(qr(randn(5,5)).Q)
ERROR: MethodError: no method matching factorize(::LinearAlgebra.QRCompactWYQ{Float64,Array{Float64,2}})
Closest candidates are:
  factorize(::Union{DenseArray{T,2}, Base.ReinterpretArray{T,2,S,A} where S where A<:Union{SubArray{T,N,A,I,true} where I<:Union{Tuple{Vararg{Real,N} where N}, Tuple{AbstractUnitRange,Vararg{Any,N} where N}} where A<:DenseArray where N where T, DenseArray}, Base.ReshapedArray{T,2,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:Union{Base.ReinterpretArray{T,N,S,A} where S where A<:Union{SubArray{T,N,A,I,true} where I<:Union{Tuple{Vararg{Real,N} where N}, Tuple{AbstractUnitRange,Vararg{Any,N} where N}} where A<:DenseArray where N where T, DenseArray} where N where T, SubArray{T,N,A,I,true} where I<:Union{Tuple{Vararg{Real,N} where N}, Tuple{AbstractUnitRange,Vararg{Any,N} where N}} where A<:DenseArray where N where T, DenseArray}, SubArray{T,2,A,I,L} where L where I<:Tuple{Vararg{Union{Int64, AbstractRange{Int64}, Base.AbstractCartesianIndex},N} where N} where A<:Union{Base.ReinterpretArray{T,N,S,A} where S where A<:Union{SubArray{T,N,A,I,true} where I<:Union{Tuple{Vararg{Real,N} where N}, Tuple{AbstractUnitRange,Vararg{Any,N} where N}} where A<:DenseArray where N where T, DenseArray} where N where T, Base.ReshapedArray{T,N,A,MI} where MI<:Tuple{Vararg{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64},N} where N} where A<:Union{Base.ReinterpretArray{T,N,S,A} where S where A<:Union{SubArray{T,N,A,I,true} where I<:Union{Tuple{Vararg{Real,N} where N}, Tuple{AbstractUnitRange,Vararg{Any,N} where N}} where A<:DenseArray where N where T, DenseArray} where N where T, SubArray{T,N,A,I,true} where I<:Union{Tuple{Vararg{Real,N} where N}, Tuple{AbstractUnitRange,Vararg{Any,N} where N}} where A<:DenseArray where N where T, DenseArray} where N where T, DenseArray}}) where T at /Users/solver/Projects/julia-1.4/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/dense.jl:1197
  factorize(::Adjoint) at /Users/solver/Projects/julia-1.4/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/dense.jl:1272
  factorize(::Transpose) at /Users/solver/Projects/julia-1.4/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/dense.jl:1273
  ...
Stacktrace:
 [1] inv(::LinearAlgebra.QRCompactWYQ{Float64,Array{Float64,2}}) at /Users/solver/Projects/julia-1.4/usr/share/julia/stdlib/v1.4/LinearAlgebra/src/generic.jl:1047
 [2] top-level scope at REPL[5]:1
```