### PR TITLE
add an extra inbounds in nextind to prevent a gc frame

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -144,7 +144,7 @@ end
     @inbounds l = codeunit(s, i)
     (l < 0x80) | (0xf8 ≤ l) && return i+1
     if l < 0xc0
-        i′ = thisind(s, i)
+        i′ = @inbounds thisind(s, i)
         return i′ < i ? nextind(s, i′) : i+1
     end
     # first continuation byte

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -145,7 +145,7 @@ end
     (l < 0x80) | (0xf8 ≤ l) && return i+1
     if l < 0xc0
         i′ = @inbounds thisind(s, i)
-        return i′ < i ? nextind(s, i′) : i+1
+        return i′ < i ? @inbounds(nextind(s, i′)) : i+1
     end
     # first continuation byte
     (i += 1) > n && return i


### PR DESCRIPTION
Unless I miss something, this should be safe since the `@boundscheck` in `thisind`

https://github.com/JuliaLang/julia/blob/8f512f3f6d5d69403be4b8179bd80ba64229e761/base/strings/string.jl#L123

 is identical to the `@boundscheck` we just did.


https://github.com/JuliaLang/julia/blob/8f512f3f6d5d69403be4b8179bd80ba64229e761/base/strings/string.jl#L143


This avoids a GC frame and reduces the code size quite a bit (for some form of measurement, reduces the number of SSA values from 108 to 46).