### PR TITLE
add a dummy method to ! to get rid of its Union splitting

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -391,6 +391,12 @@ function include(mapexpr::Function, mod::Module, _path::AbstractString)
     return result
 end
 
+# Hack: add a method to Base.! to prevent union splitting
+struct _NEG_UNION_SPLITTING_BLOCKER
+end
+!(::_NEG_UNION_SPLITTING_BLOCKER) = "foo"
+
+
 end_base_include = time_ns()
 
 if is_primary_base_module

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2592,4 +2592,4 @@ end
 # Test that we do not union split ! based on the number of methods
 # because that leads to excessive invalidations if a package
 # defines an additional method for !
-Core.Compiler.return_type(x -> !(x[]), Tuple{Ref{Any}}) == Any
+@test Core.Compiler.return_type(x -> !(x[]), Tuple{Ref{Any}}) == Any

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2588,3 +2588,8 @@ f() = _foldl_iter(step, (Missing[],), [0.0], 1)
 end
 @test Core.Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}) == Tuple{Int}
 @test Base.return_types(Issue35566.f) == [Val{:expected}]
+
+# Test that we do not union split ! based on the number of methods
+# because that leads to excessive invalidations if a package
+# defines an additional method for !
+Core.Compiler.return_type(x -> !(x[]), Tuple{Ref{Any}}) == Any


### PR DESCRIPTION
Removes 4000 lines of invalidations when loading SIMD.jl...

Before

```
julia> Core.Compiler.return_type(x -> !(x[]), Tuple{Ref{Any}})
Union{Missing, Bool, Base.var"#64#65"{_A} where _A}
```

After

```
julia> Core.Compiler.return_type(x -> !(x[]), Tuple{Ref{Any}})
Any
```

Maybe not a 100% serious PR...