### PR TITLE
micro-optimize iterate on string

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -176,9 +176,9 @@ is_valid_continuation(c) = c & 0xc0 == 0x80
 
 ## required core functionality ##
 
-@propagate_inbounds function iterate(s::String, i::Int=firstindex(s))
-    i > ncodeunits(s) && return nothing
-    b = codeunit(s, i)
+@inline function iterate(s::String, i::Int=firstindex(s))
+    (i % UInt) - 1 < ncodeunits(s) || return nothing
+    b = @inbounds codeunit(s, i)
     u = UInt32(b) << 24
     between(b, 0x80, 0xf7) || return reinterpret(Char, u), i+1
     return iterate_continued(s, i, u)


### PR DESCRIPTION
This uses the same trick as the array code for checking the valid range with one branch:

https://github.com/JuliaLang/julia/blob/755df8e43e84ec858900e5adaf88c3eaca766043/base/array.jl#L775

This now returns `nothing` for e.g `iterate("foo", 0)` (just like for `Array`) so we know that we are in range for the `codeunit` call and can use `@inbounds` there. This means that `iterate` no longer throws which gets rid of quite a lot of code (like the GC frame).

The new code is

```
julia> @code_llvm debuginfo=:none optimize=true iterate("foo", 1)

define { %jl_value_t*, i8 } @julia_iterate_154([16 x i8]* noalias nocapture align 8 dereferenceable(16), %jl_value_t* nonnull, i64) {
top:
  %3 = alloca { i32, i64 }, align 8
  %4 = add i64 %2, -1
  %5 = bitcast %jl_value_t* %1 to i64*
  %6 = load i64, i64* %5, align 8
  %7 = icmp uge i64 %4, %6
  %8 = icmp slt i64 %6, 0
  %9 = or i1 %8, %7
  br i1 %9, label %L61, label %L27

L27:                                              ; preds = %top
  %10 = bitcast %jl_value_t* %1 to i8*
  %11 = getelementptr i8, i8* %10, i64 8
  %12 = getelementptr i8, i8* %11, i64 %4
  %13 = load i8, i8* %12, align 1
  %14 = zext i8 %13 to i32
  %15 = shl nuw i32 %14, 24
  %16 = icmp ult i8 %13, -8
  %.lobit = lshr i8 %13, 7
  %17 = zext i1 %16 to i8
  %18 = and i8 %.lobit, %17
  %19 = icmp eq i8 %18, 0
  br i1 %19, label %L57, label %L54

L54:                                              ; preds = %L27
  call void @j_iterate_continued_155({ i32, i64 }* noalias nocapture nonnull sret %3, %jl_value_t* nonnull %1, i64 %2, i32 %15)
  %20 = bitcast { i32, i64 }* %3 to i8*
  %21 = getelementptr inbounds [16 x i8], [16 x i8]* %0, i64 0, i64 0
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 8 %21, i8* nonnull align 8 %20, i64 16, i1 false)
  br label %L61

L57:                                              ; preds = %L27
  %22 = add i64 %2, 1
  %.sroa.0.0..sroa_cast = bitcast [16 x i8]* %0 to i32*
  store i32 %15, i32* %.sroa.0.0..sroa_cast, align 8
  %.sroa.27.0..sroa_idx8 = getelementptr inbounds [16 x i8], [16 x i8]* %0, i64 0, i64 8
  %.sroa.27.0..sroa_cast = bitcast i8* %.sroa.27.0..sroa_idx8 to i64*
  store i64 %22, i64* %.sroa.27.0..sroa_cast, align 8
  br label %L61

L61:                                              ; preds = %L57, %L54, %top
  %merge = phi { %jl_value_t*, i8 } [ { %jl_value_t* null, i8 1 }, %top ], [ { %jl_value_t* null, i8 2 }, %L54 ], [ { %jl_value_t* null, i8 2 }, %L57 ]
  ret { %jl_value_t*, i8 } %merge
}
````

while the old code is

```
julia> @code_llvm debuginfo=:none optimize=true iterate("foo", 1)

define { %jl_value_t addrspace(10)*, i8 } @julia_iterate_12089([16 x i8]* noalias nocapture align 8 dereferenceable(16), %jl_value_t addrspace(10)* nonnull, i64) {
top:
  %gcframe = alloca %jl_value_t addrspace(10)*, i32 3, align 16
  %3 = bitcast %jl_value_t addrspace(10)** %gcframe to i8*
  call void @llvm.memset.p0i8.i32(i8* align 16 %3, i8 0, i32 24, i1 false)
  %4 = alloca { i32, i64 }, align 8
  %5 = call %jl_value_t*** inttoptr (i64 4312865216 to %jl_value_t*** ()*)() #3
  %6 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 0
  %7 = bitcast %jl_value_t addrspace(10)** %6 to i64*
  store i64 4, i64* %7
  %8 = getelementptr %jl_value_t**, %jl_value_t*** %5, i32 0
  %9 = load %jl_value_t**, %jl_value_t*** %8
  %10 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 1
  %11 = bitcast %jl_value_t addrspace(10)** %10 to %jl_value_t***
  store %jl_value_t** %9, %jl_value_t*** %11
  %12 = bitcast %jl_value_t*** %8 to %jl_value_t addrspace(10)***
  store %jl_value_t addrspace(10)** %gcframe, %jl_value_t addrspace(10)*** %12
  %13 = bitcast %jl_value_t addrspace(10)* %1 to i64 addrspace(10)*
  %14 = load i64, i64 addrspace(10)* %13, align 8
  %15 = icmp slt i64 %14, %2
  br i1 %15, label %L5, label %L7

L5:                                               ; preds = %top, %L51, %L48
  %merge = phi { %jl_value_t addrspace(10)*, i8 } [ { %jl_value_t addrspace(10)* addrspacecast (%jl_value_t* null to %jl_value_t addrspace(10)*), i8 1 }, %top ], [ { %jl_value_t addrspace(10)* addrspacecast (%jl_value_t* null to %jl_value_t addrspace(10)*), i8 2 }, %L48 ], [ { %jl_value_t addrspace(10)* addrspacecast (%jl_value_t* null to %jl_value_t addrspace(10)*), i8 2 }, %L51 ]
  %16 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 1
  %17 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %16
  %18 = getelementptr %jl_value_t**, %jl_value_t*** %5, i32 0
  %19 = bitcast %jl_value_t*** %18 to %jl_value_t addrspace(10)**
  store %jl_value_t addrspace(10)* %17, %jl_value_t addrspace(10)** %19
  ret { %jl_value_t addrspace(10)*, i8 } %merge

L7:                                               ; preds = %top
  %20 = icmp slt i64 %2, 1
  br i1 %20, label %L17, label %L21

L17:                                              ; preds = %L7
  %21 = call nonnull %jl_value_t addrspace(10)* @julia_BoundsError_16412(%jl_value_t addrspace(10)* addrspacecast (%jl_value_t* inttoptr (i64 4397596960 to %jl_value_t*) to %jl_value_t addrspace(10)*), %jl_value_t addrspace(10)* nonnull %1, i64 %2)
  %22 = addrspacecast %jl_value_t addrspace(10)* %21 to %jl_value_t addrspace(12)*
  %23 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 2
  store %jl_value_t addrspace(10)* %21, %jl_value_t addrspace(10)** %23
  call void @jl_throw(%jl_value_t addrspace(12)* %22)
  unreachable

L21:                                              ; preds = %L7
  %24 = addrspacecast %jl_value_t addrspace(10)* %1 to %jl_value_t addrspace(11)*
  %25 = addrspacecast %jl_value_t addrspace(11)* %24 to %jl_value_t*
  %26 = bitcast %jl_value_t* %25 to i8*
  %27 = getelementptr i8, i8* %26, i64 8
  %28 = add i64 %2, -1
  %29 = getelementptr i8, i8* %27, i64 %28
  %30 = load i8, i8* %29, align 1
  %31 = zext i8 %30 to i32
  %32 = shl nuw i32 %31, 24
  %33 = icmp ult i8 %30, -8
  %.lobit = lshr i8 %30, 7
  %34 = zext i1 %33 to i8
  %35 = and i8 %.lobit, %34
  %36 = icmp eq i8 %35, 0
  br i1 %36, label %L51, label %L48

L48:                                              ; preds = %L21
  call void @julia_iterate_continued_12091({ i32, i64 }* noalias nocapture nonnull sret %4, %jl_value_t addrspace(10)* nonnull %1, i64 %2, i32 %32)
  %37 = bitcast { i32, i64 }* %4 to i8*
  %38 = getelementptr inbounds [16 x i8], [16 x i8]* %0, i64 0, i64 0
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 8 %38, i8* align 8 %37, i64 16, i1 false)
  br label %L5

L51:                                              ; preds = %L21
  %39 = add i64 %2, 1
  %.sroa.0.0..sroa_cast = bitcast [16 x i8]* %0 to i32*
  store i32 %32, i32* %.sroa.0.0..sroa_cast, align 8
  %.sroa.27.0..sroa_idx8 = getelementptr inbounds [16 x i8], [16 x i8]* %0, i64 0, i64 8
  %.sroa.27.0..sroa_cast = bitcast i8* %.sroa.27.0..sroa_idx8 to i64*
  store i64 %39, i64* %.sroa.27.0..sroa_cast, align 8
  br label %L5
}
```