### PR TITLE
Support `init` keyword in `maximum`/`minimum`

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -45,7 +45,7 @@ function mapfoldl_impl(f::F, op::OP, nt, itr) where {F,OP}
 end
 
 function foldl_impl(op::OP, nt, itr) where {OP}
-    v = _foldl_impl(op, get(nt, :init, _InitialValue()), itr)
+    v = _foldl_impl(op, nt, itr)
     v isa _InitialValue && return reduce_empty_iter(op, itr)
     return v
 end
@@ -157,7 +157,7 @@ Like [`mapreduce`](@ref), but with guaranteed left associativity, as in [`foldl`
 If provided, the keyword argument `init` will be used exactly once. In general, it will be
 necessary to provide `init` to work with empty collections.
 """
-mapfoldl(f, op, itr; kw...) = mapfoldl_impl(f, op, kw.data, itr)
+mapfoldl(f, op, itr; init=_InitialValue()) = mapfoldl_impl(f, op, init, itr)
 
 """
     foldl(op, itr; [init])
@@ -200,7 +200,7 @@ Like [`mapreduce`](@ref), but with guaranteed right associativity, as in [`foldr
 provided, the keyword argument `init` will be used exactly once. In general, it will be
 necessary to provide `init` to work with empty collections.
 """
-mapfoldr(f, op, itr; kw...) = mapfoldr_impl(f, op, kw.data, itr)
+mapfoldr(f, op, itr; init=_InitialValue()) = mapfoldr_impl(f, op, init, itr)
 
 
 """
@@ -606,35 +606,47 @@ function mapreduce_impl(f, op::Union{typeof(max), typeof(min)},
 end
 
 """
-    maximum(f, itr)
+    maximum(f, itr; [init])
 
 Returns the largest result of calling function `f` on each element of `itr`.
+If provided, `init` must be a neutral element for `max` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
 julia> maximum(length, ["Julion", "Julia", "Jule"])
 6
+
+julia> maximum(length, []; init=-1)
+-1
 ```
 """
-maximum(f, a) = mapreduce(f, max, a)
+maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
 
 """
-    minimum(f, itr)
+    minimum(f, itr; [init])
 
 Returns the smallest result of calling function `f` on each element of `itr`.
+If provided, `init` must be a neutral element for `min` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
 julia> minimum(length, ["Julion", "Julia", "Jule"])
 4
+
+julia> minimum(length, []; init=-1)
+-1
 ```
 """
-minimum(f, a) = mapreduce(f, min, a)
+minimum(f, a; kw...) = mapreduce(f, min, a; kw...)
 
 """
-    maximum(itr)
+    maximum(itr; [init])
 
 Returns the largest element in a collection.
+If provided, `init` must be a neutral element for `max` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
@@ -643,14 +655,24 @@ julia> maximum(-20.5:10)
 
 julia> maximum([1,2,3])
 3
+
+julia> maximum(())
+ERROR: ArgumentError: reducing over an empty collection is not allowed
+Stacktrace:
+[...]
+
+julia> maximum((); init=-1)
+-1
 ```
 """
-maximum(a) = mapreduce(identity, max, a)
+maximum(a; kw...) = mapreduce(identity, max, a; kw...)
 
 """
-    minimum(itr)
+    minimum(itr; [init])
 
 Returns the smallest element in a collection.
+If provided, `init` must be a neutral element for `min` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
@@ -659,9 +681,17 @@ julia> minimum(-20.5:10)
 
 julia> minimum([1,2,3])
 1
+
+julia> minimum([])
+ERROR: ArgumentError: reducing over an empty collection is not allowed
+Stacktrace:
+[...]
+
+julia> minimum([]; init=-1)
+-1
 ```
 """
-minimum(a) = mapreduce(identity, min, a)
+minimum(a; kw...) = mapreduce(identity, min, a; kw...)
 
 ## all & any
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -208,6 +208,9 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test_throws ArgumentError maximum(Int[])
 @test_throws ArgumentError minimum(Int[])
 
+@test maximum(Int[]; init=-1) == -1
+@test minimum(Int[]; init=-1) == -1
+
 @test maximum(5) == 5
 @test minimum(5) == 5
 @test extrema(5) == (5, 5)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -75,6 +75,11 @@ safe_minabs(A::Array{T}, region) where {T} = safe_mapslices(minimum, abs.(A), re
     @test @inferred(count(!, Breduc, dims=region)) ≈ safe_count(.!Breduc, region)
 end
 
+# Combining dims and init
+A = Array{Int}(undef, 0, 3)
+@test_throws ArgumentError maximum(A; dims=1)
+@test maximum(A; dims=1, init=-1) == reshape([-1,-1,-1], 1, 3)
+
 # Test reduction along first dimension; this is special-cased for
 # size(A, 1) >= 16
 Breduc = rand(64, 3)


### PR DESCRIPTION
We can supply `init` for general reductions, but `maximum` and `minimum` do not support this keyword. This PR allows them to do so:
```julia
julia> maximum([1,2,3])
3

julia> maximum(Int[])
ERROR: ArgumentError: reducing over an empty collection is not allowed
Stacktrace:
 [1] _empty_reduce_error() at ./reduce.jl:299
 [2] reduce_empty(::Function, ::Type{T} where T) at ./reduce.jl:309
⋮

julia> maximum(Int[]; init=-1)
-1
```

This was motivated by writing a blog post on invalidations (https://github.com/JuliaLang/www.julialang.org/pull/794), and together with some changes to Pkg to supply the `init` keyword it eliminates all of the `reduce_empty` invalidations from loading FixedPointNumbers (which extends `reduce_empty`).

It's worth noting one unfortunate fact: `init` has different meanings for `reduce(+, src)` than for `sum!(dest, src)`. In the former case, it's the value for seeding the result; in the latter, it's a boolean indicating whether to re-initialize `dest` to the sentinel value or to keep whatever result is already there. This PR might make the situation slightly worse by supporting more cases where the conflict becomes appreciable (`maximum` vs `maximum!`). This feels like something we should fix for Julia 2.0.

Closes #35733