### PR TITLE
`_apply_in_world` builtin

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -742,8 +742,7 @@ of [`invokelatest`](@ref).
     This is because precompilation generates a "parallel universe" where the
     world age refers to system state unrelated to the main Julia session.
 """
-function invoke_in_world(world::Integer, @nospecialize(f), @nospecialize args...; kwargs...)
-    world = convert(UInt, world)
+function invoke_in_world(world::UInt, @nospecialize(f), @nospecialize args...; kwargs...)
     if isempty(kwargs)
         return Core._apply_in_world(world, f, args)
     end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -716,6 +716,41 @@ function invokelatest(@nospecialize(f), @nospecialize args...; kwargs...)
     Core._apply_latest(inner)
 end
 
+"""
+    invoke_in_world(world, f, args...; kwargs...)
+
+Call `f(args...; kwargs...)` in a fixed world age, `world`.
+
+This is useful for infrastructure running in the user's Julia session which is
+not part of the user's program. For example, things related to the REPL, editor
+support libraries, etc. In these cases it can be useful to prevent unwanted
+method invalidation and recompilation latency, and to prevent the user from
+breaking supporting infrastructure by mistake.
+
+The current world age can be queried using [`Base.get_world_counter()`](@ref)
+and stored for later use within the lifetime of the current Julia session, or
+when serializing and reloading the system image.
+
+Technically, `invoke_in_world` will prevent any function called by `f` from
+being extended by the user during their Julia session. That is, generic
+function method tables seen by `f` (and any functions it calls) will be frozen
+as they existed at the given `world` age. In a sense, this is like the opposite
+of [`invokelatest`](@ref).
+
+!!! note
+    It is not valid to store world ages obtained in precompilation for later use.
+    This is because precompilation generates a "parallel universe" where the
+    world age refers to system state unrelated to the main Julia session.
+"""
+function invoke_in_world(world::Integer, @nospecialize(f), @nospecialize args...; kwargs...)
+    world = convert(UInt, world)
+    if isempty(kwargs)
+        return Core._apply_in_world(world, f, args)
+    end
+    inner() = f(args...; kwargs...)
+    Core._apply_in_world(world, inner)
+end
+
 # TODO: possibly make this an intrinsic
 inferencebarrier(@nospecialize(x)) = Ref{Any}(x)[]
 

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -24,6 +24,7 @@ DECLARE_BUILTIN(typeof);     DECLARE_BUILTIN(sizeof);
 DECLARE_BUILTIN(issubtype);  DECLARE_BUILTIN(isa);
 DECLARE_BUILTIN(_apply);     DECLARE_BUILTIN(_apply_pure);
 DECLARE_BUILTIN(_apply_latest); DECLARE_BUILTIN(_apply_iterate);
+DECLARE_BUILTIN(_apply_in_world);
 DECLARE_BUILTIN(isdefined);  DECLARE_BUILTIN(nfields);
 DECLARE_BUILTIN(tuple);      DECLARE_BUILTIN(svec);
 DECLARE_BUILTIN(getfield);   DECLARE_BUILTIN(setfield);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -707,6 +707,24 @@ JL_CALLABLE(jl_f__apply_latest)
     return ret;
 }
 
+// Like `_apply`, but runs in the specified world.
+// If world > jl_world_counter, run in the latest world.
+JL_CALLABLE(jl_f__apply_in_world)
+{
+    JL_NARGSV(_apply_in_world, 2);
+    jl_ptls_t ptls = jl_get_ptls_states();
+    size_t last_age = ptls->world_age;
+    JL_TYPECHK(_apply_in_world, ulong, args[0]);
+    size_t world = jl_unbox_ulong(args[0]);
+    world = world <= jl_world_counter ? world : jl_world_counter;
+    if (!ptls->in_pure_callback) {
+        ptls->world_age = world;
+    }
+    jl_value_t *ret = do_apply(NULL, args+1, nargs-1, NULL);
+    ptls->world_age = last_age;
+    return ret;
+}
+
 // tuples ---------------------------------------------------------------------
 
 JL_CALLABLE(jl_f_tuple)
@@ -1527,6 +1545,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     jl_builtin_svec = add_builtin_func("svec", jl_f_svec);
     add_builtin_func("_apply_pure", jl_f__apply_pure);
     add_builtin_func("_apply_latest", jl_f__apply_latest);
+    add_builtin_func("_apply_in_world", jl_f__apply_in_world);
     add_builtin_func("_typevar", jl_f__typevar);
     add_builtin_func("_structtype", jl_f__structtype);
     add_builtin_func("_abstracttype", jl_f__abstracttype);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -786,6 +786,7 @@ static const std::map<jl_fptr_args_t, JuliaFunction*> builtin_func_map = {
     { &jl_f__apply_iterate,     new JuliaFunction{"jl_f__apply_iterate", get_func_sig, get_func_attrs} },
     { &jl_f__apply_pure,        new JuliaFunction{"jl_f__apply_pure", get_func_sig, get_func_attrs} },
     { &jl_f__apply_latest,      new JuliaFunction{"jl_f__apply_latest", get_func_sig, get_func_attrs} },
+    { &jl_f__apply_in_world,    new JuliaFunction{"jl_f__apply_in_world", get_func_sig, get_func_attrs} },
     { &jl_f_throw,              new JuliaFunction{"jl_f_throw", get_func_sig, get_func_attrs} },
     { &jl_f_tuple,              jltuple_func },
     { &jl_f_svec,               new JuliaFunction{"jl_f_svec", get_func_sig, get_func_attrs} },

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -117,7 +117,8 @@ void *native_functions;
 // This is a manually constructed dual of the fvars array, which would be produced by codegen for Julia code, for C.
 static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_throw, &jl_f_is, &jl_f_typeof, &jl_f_issubtype, &jl_f_isa,
-    &jl_f_typeassert, &jl_f__apply, &jl_f__apply_iterate, &jl_f__apply_pure, &jl_f__apply_latest, &jl_f_isdefined,
+    &jl_f_typeassert, &jl_f__apply, &jl_f__apply_iterate, &jl_f__apply_pure,
+    &jl_f__apply_latest, &jl_f__apply_in_world, &jl_f_isdefined,
     &jl_f_tuple, &jl_f_svec, &jl_f_intrinsic_call, &jl_f_invoke_kwsorter,
     &jl_f_getfield, &jl_f_setfield, &jl_f_fieldtype, &jl_f_nfields,
     &jl_f_arrayref, &jl_f_const_arrayref, &jl_f_arrayset, &jl_f_arraysize, &jl_f_apply_type,

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -324,3 +324,17 @@ w = worlds(mi)
 abstract type Colorant35855 end
 Base.convert(::Type{C}, c) where C<:Colorant35855 = false
 @test_broken worlds(mi) == w
+
+# invoke_in_world
+f_inworld(x) = "world one; x=$x"
+g_inworld(x; y) = "world one; x=$x, y=$y"
+wc_aiw1 = get_world_counter()
+# redefine f_inworld, g_inworld, and check that we can invoke both versions
+f_inworld(x) = "world two; x=$x"
+g_inworld(x; y) = "world two; x=$x, y=$y"
+wc_aiw2 = get_world_counter()
+@test Base.invoke_in_world(wc_aiw1, f_inworld, 2) == "world one; x=2"
+@test Base.invoke_in_world(wc_aiw2, f_inworld, 2) == "world two; x=2"
+@test Base.invoke_in_world(wc_aiw1, g_inworld, 2, y=3) == "world one; x=2, y=3"
+@test Base.invoke_in_world(wc_aiw2, g_inworld, 2, y=3) == "world two; x=2, y=3"
+


### PR DESCRIPTION
This implements a new builtin `Core._apply_in_world` to allow Julia code to be run in a frozen world age (when combined with `Base.get_world_counter()`).

This is more general than `Core._apply_latest`, so we could remove `_apply_latest` (or replace with a simple shim which calls `_apply_in_world` with `world=typemax(UInt)`) if people think that's a good idea.

### Motivation

The original motivation for this was to have a way to freeze the world age of Julia code implementing the Julia parser - see note at https://github.com/JuliaLang/julia/pull/35243#issuecomment-623044749.

Using a fixed world should be beneficial for infrastructure code which runs in a user's julia process, but which is otherwise not expected to be modified by the user. There's two benefits:
* Users can't accidentally break the basic infrastructure of the language. For example, breaking the Julia parser breaks pretty much everything in the REPL. Likewise, breaking Revise pretty much breaks the user's session.
* Method invalidation for infrastructure packages like Pkg will not slow down the user experience when the user loads `$random_package` into their session.

Note that world age is dynamically scoped, so fixed world would only apply when package code is entered through an `_apply_in_world` shim. Therefore devs of packages which choose to use this for deployment can still use a Revise-based workflow for developing their packages.

### Possible usage scenarios

* When replacing the flisp parser with CSTParser, I'd like to use this to ensure user mistakes don't take down the whole session.
* Revise.jl is basic infrastructure but method invalidation slows down load time. @timholy has recently fixed this through heroic efforts, but using a fixed world may be a lot easier and more future proof.  Same considerations likely apply to JuliaInterpreter/JuliaDebugger.
* Pkg also suffers from method invalidation so this may be of interest for the `pkg>` REPL mode, https://github.com/JuliaLang/Pkg.jl/issues/1816
* Any in-process infrastructure for code editor support, etc, may also benefit from this

### Questions / TODO

As public API, I've considered a callable `ApplyInWorld` function wrapper (and maybe an API `Base.freeze_world(f)` to create it) which would capture a function and `Base.get_world_counter()`. There might be other options though? I considered making inference understand the builtin so that the ApplyInWorld shim could be inferred, but in discussions with @Keno and @vtjnash, it seemed there were difficulties with this. For one, Jameson thought capturing the world age in the type parameters of `ApplyInWorld` would break subtyping in some way. For two, I was hoping this would help solve the problem that GeneralizedGenerated.jl solves, but Keno says that's not the case because inference can fundamentally only see older world ages. Actually I'm still a little confused by this because the newer world methods would be part of the global state so in principle accessible during compilation of an older world; but perhaps it just breaks fundamental inference invariants I don't understand yet.

A few todos:

* [x] Consider the public API.
* [x] ~~Replace `_apply_latest` builtin with this~~ Reverted to avoid an extra allocation
* [x] As I understand it, the world age isn't unique in precompilation. What complexities does this cause? Does it prevent `ApplyInWorld` wrappers from being saved during precompilation? (Edit: yes)
* [x] In general, is it safe to capture the world age `UInt` or does this create an implicit dependency on old methods which may be removed from internal caches? Do we need to lift this implicit dependency into an explicit one? (Edit: Should be ok?)

@vtjnash I'd greatly value your input on subtleties I might have missed, especially on the last two questions above.