### PR TITLE
Inference annotations that can be read by an external tool

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -79,7 +79,6 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
     return true
 end
 
-
 function CodeInstance(result::InferenceResult, min_valid::UInt, max_valid::UInt,
                       may_compress=true, allow_discard_tree=true)
     inferred_result = result.src

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -17,7 +17,6 @@ All AbstractInterpreters are expected to provide at least the following methods:
 """
 abstract type AbstractInterpreter; end
 
-
 """
     InferenceResult
 
@@ -189,6 +188,13 @@ lock_mi_inference(ni::NativeInterpreter, mi::MethodInstance) = (mi.inInference =
     See lock_mi_inference
 """
 unlock_mi_inference(ni::NativeInterpreter, mi::MethodInstance) = (mi.inInference = false; nothing)
+
+"""
+Emit an analysis remark during inference for the current line (`sv.pc`). These annotations are ignored
+by the native interpreter, but can be used by external tooling to annotate
+inference results.
+"""
+add_remark!(ni::NativeInterpreter, sv, s) = nothing
 
 may_optimize(ni::NativeInterpreter) = true
 may_compress(ni::NativeInterpreter) = true

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -189,3 +189,7 @@ lock_mi_inference(ni::NativeInterpreter, mi::MethodInstance) = (mi.inInference =
     See lock_mi_inference
 """
 unlock_mi_inference(ni::NativeInterpreter, mi::MethodInstance) = (mi.inInference = false; nothing)
+
+may_optimize(ni::NativeInterpreter) = true
+may_compress(ni::NativeInterpreter) = true
+may_discard_trees(ni::NativeInterpreter) = true


### PR DESCRIPTION
This builds on top of #35831, letting inference emit a custom message
whenever it gives up on infering something. These messages are intended
to be displayed by external tools, either to debug what inference is doing
(e.g. for Cthulhu) or, if an external compiler needs to disallow certain
kinds of missing information (e.g. no dynamic dispatch on GPUs), can be
used to improve diagnostics. This is mostly a proof of concept, I think
these messages/hooks need to be a bit richer for a full solution, though
I think this can be already useful if we hook up something like Cthulhu.
As a proof of concept, I hacked up a 10 line function that reads these messagse.
It works something like the following:

```
function bar()
    sin = eval(:sin)
    sin(1)
end
foo() = bar()
```

```
julia> Compiler3.analyze_static(Tuple{typeof(foo)})
In function: bar()
ERROR: The called function was unknown
1| function bar()
2|     sin = eval(:sin)
=>     sin(1)
4| end

[1] In foo()
```

The reason this needs to sit on top of #35831 is that it needs to run
with a completely fresh cache, which #35831 provides the primitives for.
Otherwise, while you could still get the annotations out, that would
only work the first time something is inferred anywhere in the system.
With a fresh cache, everything is analyzed again, and any messages like
these that are opted in to can be collected.

cc @vchuravy for Cthulhu, @maleadt @jpsamaroo for GPU-related concerns