### PR TITLE
add (un)signed(::Type{Bool}) method

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -70,6 +70,7 @@ julia> signed(UInt64)
 Int64
 ```
 """
+signed(::Type{Bool}) = Int
 signed(::Type{UInt8}) = Int8
 signed(::Type{UInt16}) = Int16
 signed(::Type{UInt32}) = Int32

--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -6,6 +6,7 @@ import Base: div, divrem, rem, unsigned
 using  Base: IndexLinear, IndexCartesian, tail
 export multiplicativeinverse
 
+unsigned(::Type{Bool}) = UInt
 unsigned(::Type{Int8}) = UInt8
 unsigned(::Type{Int16}) = UInt16
 unsigned(::Type{Int32}) = UInt32

--- a/test/int.jl
+++ b/test/int.jl
@@ -63,6 +63,7 @@ end
     @test signed(true) == 1
     @test unsigned(true) isa Unsigned
     @test unsigned(true) == unsigned(1)
+    @test signed(Bool) == Int
 end
 @testset "bswap" begin
     @test bswap(Int8(3)) == 3

--- a/test/int.jl
+++ b/test/int.jl
@@ -63,7 +63,11 @@ end
     @test signed(true) == 1
     @test unsigned(true) isa Unsigned
     @test unsigned(true) == unsigned(1)
+
     @test signed(Bool) == Int
+    @test signed(Bool) == typeof(signed(true))
+    @test unsigned(Bool) == UInt
+    @test unsigned(Bool) == typeof(unsigned(true))
 end
 @testset "bswap" begin
     @test bswap(Int8(3)) == 3


### PR DESCRIPTION
Since `signed(true)` already works and returns an `Int`, I think this was just an omission.