### PR TITLE
support random sampling of tuple types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -160,6 +160,7 @@ Standard library changes
   results table ([#38042]).
 * `@testset` now supports the option `verbose` to show the test result summary
   of the children even if they all pass ([#33755]).
+* `rand` now supports sampling of tuple types ([#35856]).
 
 #### LinearAlgebra
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -310,7 +310,8 @@ Pick a random element or array of random elements from the set of values specifi
 * a string (considered as a collection of characters), or
 * a type: the set of values to pick from is then equivalent to `typemin(S):typemax(S)` for
   integers (this is not applicable to [`BigInt`](@ref)), to ``[0, 1)`` for floating
-  point numbers and to ``[0, 1)+i[0, 1)`` for complex floating point numbers;
+  point numbers and to ``[0, 1)+i[0, 1)`` for complex floating point numbers; `Tuple` types
+  are sampled component-wise.
 
 `S` defaults to [`Float64`](@ref).
 When only one argument is passed besides the optional `rng` and is a `Tuple`, it is interpreted
@@ -319,6 +320,9 @@ as a collection of values (`S`) and not as `dims`.
 
 !!! compat "Julia 1.1"
     Support for `S` as a tuple requires at least Julia 1.1.
+
+!!! compat "Julia 1.6"
+    Support for `S` as a tuple type requires at least Julia 1.6.
 
 # Examples
 ```julia-repl

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -167,6 +167,15 @@ function rand(r::AbstractRNG, ::SamplerType{T}) where {T<:AbstractChar}
     (c < 0xd800) ? T(c) : T(c+0x800)
 end
 
+### random tuples
+
+@generated function rand(r::AbstractRNG, ::SamplerType{T}) where {T<:Tuple}
+    all(isa.(T.parameters, Type)) ||
+        throw(ArgumentError("tuple sampling requires types as parameters, got {$(join(T.parameters, ", "))}"))
+    a = (:( rand(r, $S) ) for S in T.parameters)
+    return :( ($(a...),) )
+end
+
 
 ## Generate random integer within a range
 

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -741,6 +741,14 @@ end
     end
 end
 
+@testset "rand(::Type{<:Tuple})" begin
+    @test_throws TypeError rand(Tuple)
+    @test rand(Tuple{}) == ()
+    @inferred rand(Tuple{Int32,Int64,Float64})
+    @inferred rand(NTuple{20,Int})
+    @test_throws ArgumentError rand(Tuple{1:2,3:4})
+end
+
 @testset "GLOBAL_RNG" begin
     local GLOBAL_RNG = Random.GLOBAL_RNG
     local LOCAL_RNG = Random.default_rng()


### PR DESCRIPTION
This allows e.g `rand(NTuple{5,Int})` to sample a tuple of 5 `Int`s.

The implementation simply assembles a tuple by calling `rand` on the
corresponding type parameters of the tuple type.
A generated function is used to ensure type stability.

Note that this is distinct from `rand(::Tuple)` to select a random element from a tuple.