### PR TITLE
Display argument that is duplicated in function calls

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -339,7 +339,7 @@
          (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x))
                       (llist-vars argl))))
      (if (has-dups (filter (lambda (x) (not (eq? x UNUSED))) anames))
-         (error "function argument names not unique"))
+         ((error (string "function argument names not unique " (cdr anames)))))
      (if (has-dups names)
          (error "function static parameter names not unique"))
      (if (any (lambda (x) (and (not (eq? x UNUSED)) (memq x names))) anames)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -336,8 +336,8 @@
                                    (append req opt vararg) rett)))))
    ;; no optional positional args
    (let* ((names (map car sparams))
-         (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x))(llist-vars argl)))
-         (unused_anames (filter (lambda (x) (not (eq? x UNUSED))) anames)))
+          (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x)) (llist-vars argl)))
+          (unused_anames (filter (lambda (x) (not (eq? x UNUSED))) anames)))
      (if (has-dups unused_anames)
          (error (string "function argument name not unique: \"" (car (has-dups unused_anames)) "\"")))
      (if (has-dups names)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -335,11 +335,12 @@
          (optional-positional-defs name sparams req opt dfl body
                                    (append req opt vararg) rett)))))
    ;; no optional positional args
-   (let ((names (map car sparams))
+   (let* ((names (map car sparams))
          (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x))
-                      (llist-vars argl))))
-     (if (has-dups (filter (lambda (x) (not (eq? x UNUSED))) anames))
-         ((error (string "function argument names not unique " (cdr anames)))))
+                      (llist-vars argl)))
+         (unused_anames (filter (lambda (x) (not (eq? x UNUSED))) anames)))
+     (if (has-dups unused_anames)
+         ((error (string "function argument name not unique: " (car (has-dups unused_anames))))))
      (if (has-dups names)
          (error "function static parameter names not unique"))
      (if (any (lambda (x) (and (not (eq? x UNUSED)) (memq x names))) anames)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -336,8 +336,7 @@
                                    (append req opt vararg) rett)))))
    ;; no optional positional args
    (let* ((names (map car sparams))
-         (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x))
-                      (llist-vars argl)))
+         (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x))(llist-vars argl)))
          (unused_anames (filter (lambda (x) (not (eq? x UNUSED))) anames)))
      (if (has-dups unused_anames)
          (error (string "function argument name not unique: " (car (has-dups unused_anames)))))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -339,7 +339,7 @@
          (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x))(llist-vars argl)))
          (unused_anames (filter (lambda (x) (not (eq? x UNUSED))) anames)))
      (if (has-dups unused_anames)
-         (error (string "function argument name not unique: " (car (has-dups unused_anames)))))
+         (error (string "function argument name not unique: \"" (car (has-dups unused_anames)) "\"")))
      (if (has-dups names)
          (error "function static parameter names not unique"))
      (if (any (lambda (x) (and (not (eq? x UNUSED)) (memq x names))) anames)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -340,7 +340,7 @@
                       (llist-vars argl)))
          (unused_anames (filter (lambda (x) (not (eq? x UNUSED))) anames)))
      (if (has-dups unused_anames)
-         ((error (string "function argument name not unique: " (car (has-dups unused_anames))))))
+         (error (string "function argument name not unique: " (car (has-dups unused_anames)))))
      (if (has-dups names)
          (error "function static parameter names not unique"))
      (if (any (lambda (x) (and (not (eq? x UNUSED)) (memq x names))) anames)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2192,7 +2192,7 @@ end
 
 # Syntax desugaring pass errors contain line numbers
 @test Meta.lower(@__MODULE__, Expr(:block, LineNumberNode(101, :some_file), :(f(x,x)=1))) ==
-    Expr(:error, "function argument names not unique around some_file:101")
+    Expr(:error, "function argument name not unique: \"x\" around some_file:101")
 
 # Ensure file names don't leak between `eval`s
 eval(LineNumberNode(11, :incorrect_file))


### PR DESCRIPTION
# Description
Fixes #34084

Now error message will also give the name of a variable duplicated in the function call.

# Testing
```
julia> foo !== foo = bar
ERROR: syntax: function argument name not unique: foo around REPL[1]:1
Stacktrace:
 [1] top-level scope at REPL[1]:1
```

```
julia> function lala(;  bar=3, bar=4, boo=5)
       end
ERROR: syntax: function argument name not unique: bar around REPL[2]:1
Stacktrace:
 [1] top-level scope at REPL[2]:1
```