### PR TITLE
allow `where` syntax in constructor definitions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ Julia v1.6 Release Notes
 New language features
 ---------------------
 
+* Types written with `where` syntax can now be used to define constructors, e.g.
+  `(Foo{T} where T)(x) = ...`.
 
 Language changes
 ----------------

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1111,7 +1111,7 @@
                             (and (not (any kwarg? argl)) (not (and (pair? argl)
                                                                    (pair? (car argl))
                                                                    (eq? (caar argl) 'parameters))))))
-                  (name    (if (or (decl? name) (and (pair? name) (eq? (car name) 'curly)))
+                  (name    (if (or (decl? name) (and (pair? name) (memq (car name) '(curly where))))
                                #f name)))
              (expand-forms
               (method-def-expr name sparams argl body rett))))

--- a/test/core.jl
+++ b/test/core.jl
@@ -4708,6 +4708,11 @@ let ft = Base.datatype_fieldtypes
     @test !isdefined(ft(B12238.body.body)[1], :instance)  # has free type vars
 end
 
+# `where` syntax in constructor definitions
+(A12238{T} where T<:Real)(x) = 0
+@test A12238{<:Real}(0) == 0
+@test_throws MethodError A12238{<:Integer}(0)
+
 # issue #16315
 let a = Any[]
     @noinline f() = a[end]


### PR DESCRIPTION
This is kind of an oversight; we might as well allow it since `Foo{<:T}(x) = ...` already works. This removes the need to use `Type{T}` for the called object, except when `T` is a typevar (we could maybe consider allowing that too). This also allows us to use more concise syntax when printing method signatures.