### PR TITLE
fix #34824, improve various cases of showing method signatures

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -260,12 +260,9 @@ function showerror(io::IO, ex::MethodError)
                 isdefined(ft.name.module, name) &&
                 ft == typeof(getfield(ft.name.module, name))
             f_is_function = true
-            print(io, "no method matching ", name)
-        elseif isa(f, Type)
-            print(io, "no method matching ", f)
-        else
-            print(io, "no method matching (::", ft, ")")
         end
+        print(io, "no method matching ")
+        show_signature_function(io, isa(f, Type) ? Type{f} : typeof(f))
         print(io, "(")
         for (i, typ) in enumerate(arg_types_param)
             print(io, "::", typ)
@@ -339,7 +336,9 @@ striptype(::Type{T}) where {T} = T
 striptype(::Any) = nothing
 
 function showerror_ambiguous(io::IO, meth, f, args)
-    print(io, "MethodError: ", f, "(")
+    print(io, "MethodError: ")
+    show_signature_function(io, isa(f, Type) ? Type{f} : typeof(f))
+    print(io, "(")
     p = args.parameters
     for (i,a) in enumerate(p)
         print(io, "::", a)
@@ -415,9 +414,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                 # function itself doesn't match
                 continue
             else
-                # TODO: use the methodshow logic here
-                use_constructor_syntax = isa(func, Type)
-                print(iob, use_constructor_syntax ? func : typeof(func).name.mt.name)
+                show_signature_function(iob, s1)
             end
             print(iob, "(")
             t_i = copy(arg_types_param)

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -48,7 +48,7 @@ function method_argnames(m::Method)
     return argnames[1:m.nargs]
 end
 
-function arg_decl_parts(m::Method)
+function arg_decl_parts(m::Method, html=false)
     tv = Any[]
     sig = m.sig
     while isa(sig, UnionAll)
@@ -65,6 +65,8 @@ function arg_decl_parts(m::Method)
         end
         decls = Tuple{String,String}[argtype_decl(show_env, argnames[i], sig, i, m.nargs, m.isva)
                     for i = 1:m.nargs]
+        decls[1] = ("", sprint(show_signature_function, sig.parameters[1], false, decls[1][1], html,
+                               context = show_env))
     else
         decls = Tuple{String,String}[("", "") for i = 1:length(sig.parameters::SimpleVector)]
     end
@@ -180,30 +182,12 @@ end
 function show(io::IO, m::Method)
     tv, decls, file, line = arg_decl_parts(m)
     sig = unwrap_unionall(m.sig)
-    ft0 = sig.parameters[1]
-    ft = unwrap_unionall(ft0)
-    d1 = decls[1]
     if sig === Tuple
         # Builtin
         print(io, m.name, "(...) in ", m.module)
         return
     end
-    if ft <: Function && isa(ft, DataType) &&
-            isdefined(ft.name.module, ft.name.mt.name) &&
-                # TODO: more accurate test? (tn.name === "#" name)
-            ft0 === typeof(getfield(ft.name.module, ft.name.mt.name))
-        print(io, ft.name.mt.name)
-    elseif isa(ft, DataType) && ft.name === Type.body.name
-        f = ft.parameters[1]
-        if isa(f, DataType) && isempty(f.parameters)
-            print(io, f)
-        else
-            print(io, "(", d1[1], "::", d1[2], ")")
-        end
-    else
-        print(io, "(", d1[1], "::", d1[2], ")")
-    end
-    print(io, "(")
+    print(io, decls[1][2], "(")
     join(io, String[isempty(d[2]) ? d[1] : d[1]*"::"*d[2] for d in decls[2:end]],
                  ", ", ", ")
     kwargs = kwarg_decl(m)
@@ -338,31 +322,14 @@ function url(m::Method)
 end
 
 function show(io::IO, ::MIME"text/html", m::Method)
-    tv, decls, file, line = arg_decl_parts(m)
+    tv, decls, file, line = arg_decl_parts(m, true)
     sig = unwrap_unionall(m.sig)
-    ft0 = sig.parameters[1]
-    ft = unwrap_unionall(ft0)
-    d1 = decls[1]
     if sig === Tuple
         # Builtin
         print(io, m.name, "(...) in ", m.module)
         return
     end
-    if ft <: Function && isa(ft, DataType) &&
-            isdefined(ft.name.module, ft.name.mt.name) &&
-            ft0 === typeof(getfield(ft.name.module, ft.name.mt.name))
-        print(io, ft.name.mt.name)
-    elseif isa(ft, DataType) && ft.name === Type.body.name
-        f = ft.parameters[1]
-        if isa(f, DataType) && isempty(f.parameters)
-            print(io, f)
-        else
-            print(io, "(", d1[1], "::<b>", d1[2], "</b>)")
-        end
-    else
-        print(io, "(", d1[1], "::<b>", d1[2], "</b>)")
-    end
-    print(io, "(")
+    print(io, decls[1][2], "(")
     join(io, String[isempty(d[2]) ? d[1] : d[1]*"::<b>"*d[2]*"</b>"
                       for d in decls[2:end]], ", ", ", ")
     kwargs = kwarg_decl(m)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1764,6 +1764,7 @@ function show_signature_function(io::IO, @nospecialize(ft), demangle=false, farg
             print(io, "($fargname::", ft, ")")
         end
     end
+    nothing
 end
 
 function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1742,6 +1742,30 @@ function demangle_function_name(name::AbstractString)
     return name
 end
 
+# show the called object in a signature, given its type `ft`
+# `io` should contain the UnionAll env of the signature
+function show_signature_function(io::IO, @nospecialize(ft), demangle=false, fargname="", html=false)
+    uw = unwrap_unionall(ft)
+    if ft <: Function && isa(uw, DataType) && isempty(uw.parameters) &&
+        isdefined(uw.name.module, uw.name.mt.name) &&
+        ft == typeof(getfield(uw.name.module, uw.name.mt.name))
+        print(io, (demangle ? demangle_function_name : identity)(uw.name.mt.name))
+    elseif isa(ft, DataType) && ft.name === Type.body.name &&
+        (f = ft.parameters[1]; !isa(f, TypeVar))
+        uwf = unwrap_unionall(f)
+        parens = isa(f, UnionAll) && !(isa(uwf, DataType) && f === uwf.name.wrapper)
+        parens && print(io, "(")
+        show(io, f)
+        parens && print(io, ")")
+    else
+        if html
+            print(io, "($fargname::<b>", ft, "</b>)")
+        else
+            print(io, "($fargname::", ft, ")")
+        end
+    end
+end
+
 function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing)
     # print a method signature tuple for a lambda definition
     color = get(io, :color, false) && get(io, :backtrace, false) ? stackframe_function_color() : :nothing
@@ -1758,18 +1782,7 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwa
     end
     sig = sig.parameters
     with_output_color(color, env_io) do io
-        ft = sig[1]
-        uw = unwrap_unionall(ft)
-        if ft <: Function && isa(uw,DataType) && isempty(uw.parameters) &&
-                isdefined(uw.name.module, uw.name.mt.name) &&
-                ft == typeof(getfield(uw.name.module, uw.name.mt.name))
-            print(io, (demangle ? demangle_function_name : identity)(uw.name.mt.name))
-        elseif isa(ft, DataType) && ft.name === Type.body.name && !Core.Compiler.has_free_typevars(ft)
-            f = ft.parameters[1]
-            print(io, f)
-        else
-            print(io, "(::", ft, ")")
-        end
+        show_signature_function(io, sig[1], demangle)
     end
     first = true
     print_style = get(io, :color, false) && get(io, :backtrace, false) ? :bold : :nothing

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -74,7 +74,7 @@ Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, 1)))
 # matches the implicit constructor -> convert method
 Base.show_method_candidates(buf, Base.MethodError(Tuple{}, (1, 1, 1)))
 let mc = String(take!(buf))
-    @test occursin("\nClosest candidates are:\n  Tuple{}", mc)
+    @test occursin("\nClosest candidates are:\n  (::Type{T})", mc)
     @test !occursin(cfile, mc)
 end
 
@@ -124,10 +124,13 @@ PR16155line2 = @__LINE__() + 1
 (::Type{T})(arg::Any) where {T<:PR16155} = "replace call-to-convert method from sysimg"
 
 Base.show_method_candidates(buf, MethodError(PR16155,(1.0, 2.0, Int64(3))))
-@test String(take!(buf)) == "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(!Matched::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2"
+@test String(take!(buf)) == "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(!Matched::Int64, ::Any)$cfile$PR16155line\n  (::Type{T})(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2"
 
 Base.show_method_candidates(buf, MethodError(PR16155,(Int64(3), 2.0, Int64(3))))
-@test String(take!(buf)) == "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2"
+@test String(take!(buf)) == "\nClosest candidates are:\n  $(curmod_prefix)PR16155(::Int64, ::Any)$cfile$PR16155line\n  $(curmod_prefix)PR16155(::Any, ::Any)$cfile$PR16155line\n  (::Type{T})(::Any) where T<:$(curmod_prefix)PR16155$cfile$PR16155line2"
+
+Base.show_method_candidates(buf, MethodError(Complex{T} where T<:Integer, (1.2,)))
+@test startswith(String(take!(buf)), "\nClosest candidates are:\n  (::Type{T})(::T) where T<:Number")
 
 c6line = @__LINE__
 method_c6(; x=1) = x
@@ -396,6 +399,9 @@ EightBitTypeT{T}() where {T} = throw(ErrorException("6"))
 (::EightBitTypeT)() = throw(ErrorException("7"))
 (::FunctionLike)() = throw(ErrorException("8"))
 
+struct StructWithUnionAllMethodDefs{T}
+end
+(::Type{StructWithUnionAllMethodDefs{T} where T<:Integer})(x) = x
 
 let err_str,
     i = reinterpret(EightBitType, 0x54),
@@ -412,15 +418,19 @@ let err_str,
     @test sprint(show, which(reinterpret(EightBitType, 0x54), Tuple{})) ==
         "(::$(curmod_prefix)EightBitType)() in $curmod_str at $sp:$(method_defs_lineno + 3)"
     @test sprint(show, which(EightBitTypeT, Tuple{})) ==
-        "(::Type{$(curmod_prefix)EightBitTypeT})() in $curmod_str at $sp:$(method_defs_lineno + 4)"
+        "$(curmod_prefix)EightBitTypeT() in $curmod_str at $sp:$(method_defs_lineno + 4)"
     @test sprint(show, which(EightBitTypeT{Int32}, Tuple{})) ==
-        "(::Type{$(curmod_prefix)EightBitTypeT{T}})() where T in $curmod_str at $sp:$(method_defs_lineno + 5)"
+        "$(curmod_prefix)EightBitTypeT{T}() where T in $curmod_str at $sp:$(method_defs_lineno + 5)"
     @test sprint(show, which(reinterpret(EightBitTypeT{Int32}, 0x54), Tuple{})) ==
         "(::$(curmod_prefix)EightBitTypeT)() in $curmod_str at $sp:$(method_defs_lineno + 6)"
+    @test startswith(sprint(show, which(Complex{Int}, Tuple{Int})),
+                     "Complex{T}(")
     @test startswith(sprint(show, which(getfield(Base, Symbol("@doc")), Tuple{LineNumberNode, Module, Vararg{Any}})),
                      "@doc(__source__::LineNumberNode, __module__::Module, x...) in Core at boot.jl:")
     @test startswith(sprint(show, which(FunctionLike(), Tuple{})),
                      "(::$(curmod_prefix)FunctionLike)() in $curmod_str at $sp:$(method_defs_lineno + 7)")
+    @test startswith(sprint(show, which(StructWithUnionAllMethodDefs{<:Integer}, (Any,))),
+                     "($(curmod_prefix)StructWithUnionAllMethodDefs{T} where T<:Integer)(x)")
     @test repr("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 1 method)"
     @test repr("text/plain", Core.arraysize) == "arraysize (built-in function)"
 


### PR DESCRIPTION
The code for this was duplicated several times (more than 3, depending how you count), with all sorts of problems. Here are some examples.

Before:
```
julia> methods(Complex)
# 7 methods for type constructor:
[1] (::Type{Complex})(x::Real) in Base at complex.jl:16
...

julia> methods(Complex{Int})
# 7 methods for type constructor:
[1] (::Type{Complex{T}})(x::AbstractIrrational) where T<:Real in Base at irrationals.jl:34
...

julia> (Complex{T} where T<:Integer)(1.2)
ERROR: MethodError: no method matching Complex{T} where T<:Integer(::Float64)
Closest candidates are:
  Complex{T} where T<:Integer(::T) where T<:Number at boot.jl:715

julia> (::Union{Nothing,Int})(::Nothing) = nothing

julia> nothing("")
ERROR: MethodError: no method matching (::Nothing)(::String)
Closest candidates are:
  Any(::Nothing) at REPL[6]:1
```

After:
```
julia> methods(Complex)
# 7 methods for type constructor:
[1] Complex(x::Real) in Base at complex.jl:16
...

julia> methods(Complex{Int})
# 7 methods for type constructor:
[1] Complex{T}(x::AbstractIrrational) where T<:Real in Base at irrationals.jl:47
...

julia> (Complex{T} where T<:Integer)(1.2)
ERROR: MethodError: no method matching (Complex{T} where T<:Integer)(::Float64)
Closest candidates are:
  (::Type{T})(::T) where T<:Number at boot.jl:715

julia> (::Union{Nothing,Int})(::Nothing) = nothing

julia> nothing("")
ERROR: MethodError: no method matching (::Nothing)(::String)
Closest candidates are:
  (::Union{Nothing, Int64})(::Nothing) at REPL[1]:1
```

Fixes #34824. Replaces #35311.

Discussion questions:
- I decided to print methods on unionalls as `(Foo{T} where T)(x)` even though that is not currently valid input syntax. With #35861 it would be, so I think it's ok.
- The "closest candidates" printing used to show the *called* type in the head of each signature, instead of the type from the definition (see third example above). That was probably intentional and I can see a case for it, but I think it's confusing because it looks like it's showing definitions that don't actually exist. I think we should show the same thing that e.g. `methods(t)` shows.
