### PR TITLE
Fix ImmutableDict(:a => 1, :a => 2)[:a]

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -742,7 +742,7 @@ Create a new entry in the `ImmutableDict` for a `key => value` pair
 ImmutableDict
 ImmutableDict(KV::Pair{K,V}) where {K,V} = ImmutableDict{K,V}(KV[1], KV[2])
 ImmutableDict(t::ImmutableDict{K,V}, KV::Pair) where {K,V} = ImmutableDict{K,V}(t, KV[1], KV[2])
-ImmutableDict(KV::Pair, rest::Pair...) = ImmutableDict(ImmutableDict(rest...), KV)
+ImmutableDict(KV::Pair, rest::Pair...) = ImmutableDict(ImmutableDict(KV), rest...)
 
 function in(key_value::Pair, dict::ImmutableDict, valcmp=(==))
     key, value = key_value

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -722,7 +722,8 @@ import Base.ImmutableDict
     v = [k1 => v1, k2 => v2]
     d5 = ImmutableDict(v...)
     @test d5 == d2
-    @test collect(d5) == v
+    @test reverse(collect(d5)) == v
+    @test ImmutableDict(:a => 1, :a => 2)[:a] == 2
 
     @test !haskey(ImmutableDict(-0.0=>1), 0.0)
 end


### PR DESCRIPTION
Currently, the behavior of `Dict(pairs...)` and
`Base.ImmutableDict(pairs...)` are different:

    julia> Dict(:a => 1, :a => 2)[:a]
    2

    julia> Base.ImmutableDict(:a => 1, :a => 2)[:a]
    1

This PR fixes the latter to return 2.

cc @simeonschaub 

As I think this is a bug fix and this feature did not exist in 1.4, I add the backport label.