### PR TITLE
change uuid to use  Random.RandomDevice() instead of Random.default_rng()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,9 @@ Standard library changes
 #### Distributed
 
 
+#### UUIDs
+* Change `uuid1` and `uuid4` to use `Random.RandomDevice()` as default random number generator ([#35872]).
+
 Deprecated or removed
 ---------------------
 

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -48,10 +48,10 @@ julia> rng = MersenneTwister(1234);
 
 julia> uuid1(rng)
 UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
+```
 
 !!! compat "Julia 1.6"
     The default rng has been changed to use Random.RandomDevice as of Julia 1.6
-```
 """
 function uuid1(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)
@@ -88,10 +88,9 @@ julia> rng = MersenneTwister(1234);
 
 julia> uuid4(rng)
 UUID("196f2941-2d58-45ba-9f13-43a2532b2fa8")
-
+```
 !!! compat "Julia 1.6"
     The default rng has been changed to use Random.RandomDevice as of Julia 1.6
-```
 """
 function uuid4(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -50,7 +50,7 @@ julia> uuid1(rng)
 UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
 ```
 """
-function uuid1(rng::AbstractRNG=Random.default_rng())
+function uuid1(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)
 
     # mask off clock sequence and node
@@ -87,7 +87,7 @@ julia> uuid4(rng)
 UUID("196f2941-2d58-45ba-9f13-43a2532b2fa8")
 ```
 """
-function uuid4(rng::AbstractRNG=Random.default_rng())
+function uuid4(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)
     u &= 0xffffffffffff0fff3fffffffffffffff
     u |= 0x00000000000040008000000000000000

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -36,11 +36,20 @@ const namespace_oid  = UUID(0x6ba7b8129dad11d180b400c04fd430c8) # 6ba7b812-9dad-
 const namespace_x500 = UUID(0x6ba7b8149dad11d180b400c04fd430c8) # 6ba7b814-9dad-11d1-80b4-00c04fd430c8
 
 """
-    uuid1([rng::AbstractRNG=Random.RandomDevice()]) -> UUID
+    uuid1([rng::AbstractRNG]) -> UUID
 
 Generates a version 1 (time-based) universally unique identifier (UUID), as specified
 by RFC 4122. Note that the Node ID is randomly generated (does not identify the host)
 according to section 4.5 of the RFC.
+
+The default rng used by `uuid1` is not `GLOBAL_RNG` and every invocation of `uuid1()` without
+an argument should be expected to return a unique identifier. Importantly, the outputs of
+`uuid1` do not repeat even when `Random.seed!(seed)` is called. Currently (as of Julia 1.6),
+`uuid1` uses `Random.RandomDevice` as the default rng. However, this is an implementation
+detail that may change in the future.
+
+!!! compat "Julia 1.6"
+    The output of `uuid1` does not dependent on `GLOBAL_RNG` as of Julia 1.6.
 
 # Examples
 ```jldoctest; filter = r"[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}"
@@ -49,9 +58,6 @@ julia> rng = MersenneTwister(1234);
 julia> uuid1(rng)
 UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
 ```
-
-!!! compat "Julia 1.6"
-    The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 """
 function uuid1(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)
@@ -77,10 +83,19 @@ function uuid1(rng::AbstractRNG=Random.RandomDevice())
 end
 
 """
-    uuid4([rng::AbstractRNG=Random.RandomDevice()]) -> UUID
+    uuid4([rng::AbstractRNG]) -> UUID
 
 Generates a version 4 (random or pseudo-random) universally unique identifier (UUID),
 as specified by RFC 4122.
+
+The default rng used by `uuid4` is not `GLOBAL_RNG` and every invocation of `uuid4()` without
+an argument should be expected to return a unique identifier. Importantly, the outputs of
+`uuid4` do not repeat even when `Random.seed!(seed)` is called. Currently (as of Julia 1.6),
+`uuid4` uses `Random.RandomDevice` as the default rng. However, this is an implementation
+detail that may change in the future.
+
+!!! compat "Julia 1.6"
+    The output of `uuid4` does not dependent on `GLOBAL_RNG` as of Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -89,8 +104,6 @@ julia> rng = MersenneTwister(1234);
 julia> uuid4(rng)
 UUID("196f2941-2d58-45ba-9f13-43a2532b2fa8")
 ```
-!!! compat "Julia 1.6"
-    The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 """
 function uuid4(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -49,7 +49,7 @@ an argument should be expected to return a unique identifier. Importantly, the o
 detail that may change in the future.
 
 !!! compat "Julia 1.6"
-    The output of `uuid1` does not dependent on `GLOBAL_RNG` as of Julia 1.6.
+    The output of `uuid1` does not depend on `GLOBAL_RNG` as of Julia 1.6.
 
 # Examples
 ```jldoctest; filter = r"[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}"

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -35,6 +35,8 @@ const namespace_url  = UUID(0x6ba7b8119dad11d180b400c04fd430c8) # 6ba7b811-9dad-
 const namespace_oid  = UUID(0x6ba7b8129dad11d180b400c04fd430c8) # 6ba7b812-9dad-11d1-80b4-00c04fd430c8
 const namespace_x500 = UUID(0x6ba7b8149dad11d180b400c04fd430c8) # 6ba7b814-9dad-11d1-80b4-00c04fd430c8
 
+uuid_rng = Random.RandomDevice()
+
 """
     uuid1([rng::AbstractRNG=Random.RandomDevice()]) -> UUID
 
@@ -53,7 +55,7 @@ UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
 !!! compat "Julia 1.6"
     The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 """
-function uuid1(rng::AbstractRNG=Random.RandomDevice())
+function uuid1(rng::AbstractRNG=uuid_rng)
     u = rand(rng, UInt128)
 
     # mask off clock sequence and node
@@ -92,7 +94,7 @@ UUID("196f2941-2d58-45ba-9f13-43a2532b2fa8")
 !!! compat "Julia 1.6"
     The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 """
-function uuid4(rng::AbstractRNG=Random.RandomDevice())
+function uuid4(rng::AbstractRNG=uuid_rng)
     u = rand(rng, UInt128)
     u &= 0xffffffffffff0fff3fffffffffffffff
     u |= 0x00000000000040008000000000000000

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -95,7 +95,7 @@ an argument should be expected to return a unique identifier. Importantly, the o
 detail that may change in the future.
 
 !!! compat "Julia 1.6"
-    The output of `uuid4` does not dependent on `GLOBAL_RNG` as of Julia 1.6.
+    The output of `uuid4` does not depend on `GLOBAL_RNG` as of Julia 1.6.
 
 # Examples
 ```jldoctest

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -48,6 +48,9 @@ julia> rng = MersenneTwister(1234);
 
 julia> uuid1(rng)
 UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
+
+!!! compat "Julia 1.6"
+    The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 ```
 """
 function uuid1(rng::AbstractRNG=Random.RandomDevice())
@@ -85,6 +88,9 @@ julia> rng = MersenneTwister(1234);
 
 julia> uuid4(rng)
 UUID("196f2941-2d58-45ba-9f13-43a2532b2fa8")
+
+!!! compat "Julia 1.6"
+    The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 ```
 """
 function uuid4(rng::AbstractRNG=Random.RandomDevice())

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -36,7 +36,7 @@ const namespace_oid  = UUID(0x6ba7b8129dad11d180b400c04fd430c8) # 6ba7b812-9dad-
 const namespace_x500 = UUID(0x6ba7b8149dad11d180b400c04fd430c8) # 6ba7b814-9dad-11d1-80b4-00c04fd430c8
 
 """
-    uuid1([rng::AbstractRNG=GLOBAL_RNG]) -> UUID
+    uuid1([rng::AbstractRNG=Random.RandomDevice()]) -> UUID
 
 Generates a version 1 (time-based) universally unique identifier (UUID), as specified
 by RFC 4122. Note that the Node ID is randomly generated (does not identify the host)
@@ -74,7 +74,7 @@ function uuid1(rng::AbstractRNG=Random.RandomDevice())
 end
 
 """
-    uuid4([rng::AbstractRNG=GLOBAL_RNG]) -> UUID
+    uuid4([rng::AbstractRNG=Random.RandomDevice()]) -> UUID
 
 Generates a version 4 (random or pseudo-random) universally unique identifier (UUID),
 as specified by RFC 4122.

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -35,8 +35,6 @@ const namespace_url  = UUID(0x6ba7b8119dad11d180b400c04fd430c8) # 6ba7b811-9dad-
 const namespace_oid  = UUID(0x6ba7b8129dad11d180b400c04fd430c8) # 6ba7b812-9dad-11d1-80b4-00c04fd430c8
 const namespace_x500 = UUID(0x6ba7b8149dad11d180b400c04fd430c8) # 6ba7b814-9dad-11d1-80b4-00c04fd430c8
 
-uuid_rng = Random.RandomDevice()
-
 """
     uuid1([rng::AbstractRNG=Random.RandomDevice()]) -> UUID
 
@@ -55,7 +53,7 @@ UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
 !!! compat "Julia 1.6"
     The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 """
-function uuid1(rng::AbstractRNG=uuid_rng)
+function uuid1(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)
 
     # mask off clock sequence and node
@@ -94,7 +92,7 @@ UUID("196f2941-2d58-45ba-9f13-43a2532b2fa8")
 !!! compat "Julia 1.6"
     The default rng has been changed to use Random.RandomDevice as of Julia 1.6
 """
-function uuid4(rng::AbstractRNG=uuid_rng)
+function uuid4(rng::AbstractRNG=Random.RandomDevice())
     u = rand(rng, UInt128)
     u &= 0xffffffffffff0fff3fffffffffffffff
     u |= 0x00000000000040008000000000000000

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -54,3 +54,11 @@ for (init_uuid, next_uuid) in standard_namespace_uuids
     result = uuid5(init_uuid, "julia")
     @test next_uuid == result
 end
+
+# Issue 35860
+Random.seed!(Random.GLOBAL_RNG, 10)
+u1 = uuid1()
+u4 = uuid4()
+Random.seed!(Random.GLOBAL_RNG, 10)
+@test u1 != uuid1()
+@test u4 != uuid4()


### PR DESCRIPTION
# Description
Fixes #35860 

Change `Random.default_rng()`  in the UUID functions to `Random.RandomDevice()`

# Testing

Ran `$ ./julia stdlib/UUIDs/test/runtests.jl `  with no issues