### PR TITLE
Add fast isodd for BigInt

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -10,7 +10,7 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
              sum, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
-             sign, hastypemax
+             sign, hastypemax, isodd
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -341,6 +341,8 @@ function rem(x::BigInt, ::Type{T}) where T<:Union{Base.BitUnsigned,Base.BitSigne
 end
 
 rem(x::Integer, ::Type{BigInt}) = BigInt(x)
+
+isodd(x::BigInt) = MPZ.tstbit(x, 0)
 
 function (::Type{T})(x::BigInt) where T<:Base.BitUnsigned
     if sizeof(T) < sizeof(Limb)

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -412,6 +412,9 @@ end
 # Issue #24298
 @test mod(BigInt(6), UInt(5)) == mod(6, 5)
 
+@test iseven(zero(BigInt))
+@test isodd(BigInt(typemax(UInt)))
+
 @testset "cmp has values in [-1, 0, 1], issue #28780" begin
     # _rand produces values whose log2 is better distributed than rand
     _rand(::Type{BigInt}, n=1000) = let x = big(2)^rand(1:rand(1:n))


### PR DESCRIPTION
Simpy use `MPZ.tstbit` instead of falling back to the generic `isodd` which has to allocate `BigInt(2)` and then call `rem`.
The speedup is between 20x for very small BigInts, and beyond 1000x for very large BigInts:
```julia
julia> a = zero(BigInt);

julia> @btime isodd($a);  # Using the current implementation
  79.233 ns (4 allocations: 80 bytes)

julia> @btime Base.GMP.MPZ.tstbit($a, 0); # What this PR uses
  3.164 ns (0 allocations: 0 bytes)

julia> a = BigInt(typemax(Int))^12345;

julia> @btime isodd($a);
  36.271 μs (5 allocations: 95.04 KiB)

julia> @btime Base.GMP.MPZ.tstbit($a, 0);
  3.827 ns (0 allocations: 0 bytes)
```