### PR TITLE
Make view of a string return a substring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,7 +44,7 @@ Standard library changes
 * The `nextprod` function now accepts tuples and other array types for its first argument ([#35791]).
 * The function `isapprox(x,y)` now accepts the `norm` keyword argument also for numeric (i.e., non-array) arguments `x` and `y` ([#35883]).
 * `view`, `@view`, and `@views` now work on `AbstractString`s, returning a `SubString` when appropriate ([#35879]).
-* All `AbstractUnitRange{<:Integer}`s now work with `SubString`, `view`,`@view` and `@views` on strings ([#35879]).
+* All `AbstractUnitRange{<:Integer}`s now work with `SubString`, `view`, `@view` and `@views` on strings ([#35879]).
 
 #### LinearAlgebra
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ Standard library changes
 ------------------------
 * The `nextprod` function now accepts tuples and other array types for its first argument ([#35791]).
 * The function `isapprox(x,y)` now accepts the `norm` keyword argument also for numeric (i.e., non-array) arguments `x` and `y` ([#35883]).
+* `view`, `@view`, and `@views` now work on `AbstractString`s, returning a `SubString` when appropriate ([#35879]).
 
 #### LinearAlgebra
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@ Standard library changes
 * The `nextprod` function now accepts tuples and other array types for its first argument ([#35791]).
 * The function `isapprox(x,y)` now accepts the `norm` keyword argument also for numeric (i.e., non-array) arguments `x` and `y` ([#35883]).
 * `view`, `@view`, and `@views` now work on `AbstractString`s, returning a `SubString` when appropriate ([#35879]).
+* All `AbstractUnitRange{<:Integer}`s now work with `SubString`, `view`,`@view` and `@views` on strings ([#35879]).
 
 #### LinearAlgebra
 

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -47,7 +47,6 @@ end
 SubString(s::AbstractString) = SubString(s, 1, lastindex(s))
 SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, lastindex(s))
 
-
 @propagate_inbounds view(s::AbstractString, r) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::UnitRange{<:Integer}) = view(s, r)
 @propagate_inbounds maybeview(s::AbstractString, args...) = getindex(s, args...)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -47,6 +47,11 @@ end
 SubString(s::AbstractString) = SubString(s, 1, lastindex(s))
 SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, lastindex(s))
 
+
+@propagate_inbounds view(s::AbstractString, r) = SubString(s, r)
+@propagate_inbounds maybeview(s::AbstractString, r::UnitRange{<:Integer}) = view(s, r)
+@propagate_inbounds maybeview(s::AbstractString, args...) = getindex(s, args...)
+
 convert(::Type{SubString{S}}, s::AbstractString) where {S<:AbstractString} =
     SubString(convert(S, s))
 convert(::Type{T}, s::T) where {T<:SubString} = s

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -37,7 +37,7 @@ end
 
 @propagate_inbounds SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
 @propagate_inbounds SubString(s::AbstractString, i::Integer, j::Integer=lastindex(s)) = SubString(s, Int(i), Int(j))
-@propagate_inbounds SubString(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, first(r), last(r))
+@propagate_inbounds SubString(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, first(r), last(r))
 
 @propagate_inbounds function SubString(s::SubString, i::Int, j::Int)
     @boundscheck i ≤ j && checkbounds(s, i:j)
@@ -47,8 +47,8 @@ end
 SubString(s::AbstractString) = SubString(s, 1, lastindex(s))
 SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, lastindex(s))
 
-@propagate_inbounds view(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, r)
-@propagate_inbounds maybeview(s::AbstractString, r::UnitRange{<:Integer}) = view(s, r)
+@propagate_inbounds view(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)
+@propagate_inbounds maybeview(s::AbstractString, r::AbstractUnitRange{<:Integer}) = view(s, r)
 @propagate_inbounds maybeview(s::AbstractString, args...) = getindex(s, args...)
 
 convert(::Type{SubString{S}}, s::AbstractString) where {S<:AbstractString} =

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -47,7 +47,7 @@ end
 SubString(s::AbstractString) = SubString(s, 1, lastindex(s))
 SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, lastindex(s))
 
-@propagate_inbounds view(s::AbstractString, r) = SubString(s, r)
+@propagate_inbounds view(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::UnitRange{<:Integer}) = view(s, r)
 @propagate_inbounds maybeview(s::AbstractString, args...) = getindex(s, args...)
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -166,6 +166,22 @@ end
     @test endswith(z)(z)
 end
 
+@testset "SubStrings and Views" begin
+    x = "abcdefg"
+    @test SubString(x, 2:4) == "bcd"
+    @test view(x, 2:4) == "bcd"
+    @test view(x, 2:4) isa SubString
+    @test (@view x[4:end]) == "defg"
+    @test (@view x[4:end]) isa SubString
+
+    # We don't (at present) make non-contiguous SubStrings with views
+    @test_throws MethodError (@view x[[1,3,5]]) == "ace"
+    @test (@views (x[[1,3,5]])) isa String
+
+    @test (@views (x[1], x[1:2], x[[1,4]])) isa Tuple{Char, SubString, String}
+end
+
+
 @testset "filter specialization on String issue #32460" begin
      @test filter(x -> x ∉ ['작', 'Ï', 'z', 'ξ'],
                   GenericString("J'étais n작작é pour plaiÏre à toute âξme un peu fière")) ==

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -168,22 +168,32 @@ end
 
 @testset "SubStrings and Views" begin
     x = "abcdefg"
-    @test SubString(x, 2:4) == "bcd"
-    @test view(x, 2:4) == "bcd"
-    @test view(x, 2:4) isa SubString
-    @test (@view x[4:end]) == "defg"
-    @test (@view x[4:end]) isa SubString
+    @testset "basic unit range" begin
+        @test SubString(x, 2:4) == "bcd"
+        @test view(x, 2:4) == "bcd"
+        @test view(x, 2:4) isa SubString
+        @test (@view x[4:end]) == "defg"
+        @test (@view x[4:end]) isa SubString
+    end
 
-    # We don't (at present) make non-contiguous SubStrings with views
-    @test_throws MethodError (@view x[[1,3,5]])
-    @test (@views (x[[1,3,5]])) isa String
+    @testset "other AbstractUnitRanges" begin
+        @test SubString(x, Base.OneTo(3)) == "abc"
+        @test view(x, Base.OneTo(4)) == "abcd"
+        @test view(x, Base.OneTo(4)) isa SubString
+    end
 
-    # We don't (at present) make single character SubStrings with views
-    @test_throws MethodError (@view x[3])
-    @test (@views (x[3])) isa Char
+    @testset "views but not view" begin
+        # We don't (at present) make non-contiguous SubStrings with views
+        @test_throws MethodError (@view x[[1,3,5]])
+        @test (@views (x[[1,3,5]])) isa String
 
-    @test (@views (x[3], x[1:2], x[[1,4]])) isa Tuple{Char, SubString, String}
-    @test (@views (x[3], x[1:2], x[[1,4]])) == ('c', "ab", "ad")
+        # We don't (at present) make single character SubStrings with views
+        @test_throws MethodError (@view x[3])
+        @test (@views (x[3])) isa Char
+
+        @test (@views (x[3], x[1:2], x[[1,4]])) isa Tuple{Char, SubString, String}
+        @test (@views (x[3], x[1:2], x[[1,4]])) == ('c', "ab", "ad")
+    end
 end
 
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -183,6 +183,7 @@ end
     @test (@views (x[3])) isa Char
 
     @test (@views (x[3], x[1:2], x[[1,4]])) isa Tuple{Char, SubString, String}
+    @test (@views (x[3], x[1:2], x[[1,4]])) == ('c', "ab", "ad")
 end
 
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -175,10 +175,14 @@ end
     @test (@view x[4:end]) isa SubString
 
     # We don't (at present) make non-contiguous SubStrings with views
-    @test_throws MethodError (@view x[[1,3,5]]) == "ace"
+    @test_throws MethodError (@view x[[1,3,5]])
     @test (@views (x[[1,3,5]])) isa String
 
-    @test (@views (x[1], x[1:2], x[[1,4]])) isa Tuple{Char, SubString, String}
+    # We don't (at present) make single character SubStrings with views
+    @test_throws MethodError (@view x[3])
+    @test (@views (x[3])) isa Char
+
+    @test (@views (x[3], x[1:2], x[[1,4]])) isa Tuple{Char, SubString, String}
 end
 
 


### PR DESCRIPTION
the [docs say](https://docs.julialang.org/en/v1/manual/strings/)
 
> Range indexing makes a copy of the selected part of the original string. Alternatively, it is possible to create a **view** into a string using the type SubString, …

(emph, mine)

but without this PR `@view "abcd"[2:3]` just `MethodError`s