### PR TITLE
Fix incorrect version number in docstrings

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -991,7 +991,7 @@ that directory will be recursively changed.
 Return `path`.
 
 !!! note
-     Prior to Julia 1.5, this did not correctly manipulate filesystem ACLs
+     Prior to Julia 1.6, this did not correctly manipulate filesystem ACLs
      on Windows, therefore it would only set read-only bits on files.  It
      now is able to manipulate ACLs.
 """

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -440,9 +440,9 @@ const WINDOWS_VISTA_VER = v"6.0"
 Return `true` if the given `path` has executable permissions.
 
 !!! note
-    Prior to Julia 1.5, this did not correctly interrogate filesystem
+    Prior to Julia 1.6, this did not correctly interrogate filesystem
     ACLs on Windows, therefore it would return `true` for any
-    file.  From Julia 1.5 on, it correctly determines whether the
+    file.  From Julia 1.6 on, it correctly determines whether the
     file is marked as executable or not.
 """
 function isexecutable(path::String)


### PR DESCRIPTION
I just merged a PR that was prepared before 1.5 was branched; the docstrings should instead note that the functionality is only available starting in 1.6.