### PR TITLE
A collection of ! invalidation fixes

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1135,6 +1135,7 @@ end
 
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int, quote_level::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
+        value = value::Symbol
         s = string(value)
         if isidentifier(s) || (isoperator(value) && value !== Symbol("'"))
             print(io, ":")
@@ -1144,6 +1145,7 @@ function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, pre
         end
     else
         if isa(value,Expr) && value.head === :block
+            value = value::Expr
             show_block(IOContext(io, beginsym=>false), "quote", value, indent, quote_level)
             print(io, "end")
         else

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -320,7 +320,7 @@ function isopen(x::Union{LibuvStream, LibuvServer})
     if x.status == StatusUninit || x.status == StatusInit
         throw(ArgumentError("$x is not initialized"))
     end
-    return x.status != StatusClosed && x.status != StatusEOF
+    return x.status::Int != StatusClosed && x.status::Int != StatusEOF
 end
 
 function check_open(x::Union{LibuvStream, LibuvServer})
@@ -395,7 +395,7 @@ function close(stream::Union{LibuvStream, LibuvServer})
         stream.status = StatusClosing
     elseif isopen(stream) || stream.status == StatusEOF
         should_wait = uv_handle_data(stream) != C_NULL
-        if stream.status != StatusClosing
+        if stream.status::Int != StatusClosing
             ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), stream.handle)
             stream.status = StatusClosing
         end
@@ -410,7 +410,7 @@ function uvfinalize(uv::Union{LibuvStream, LibuvServer})
     iolock_begin()
     if uv.handle != C_NULL
         disassociate_julia_struct(uv.handle) # not going to call the usual close hooks
-        if uv.status != StatusUninit
+        if uv.status::Int != StatusUninit
             close(uv)
         else
             Libc.free(uv.handle)
@@ -524,7 +524,7 @@ function uv_alloc_buf(handle::Ptr{Cvoid}, size::Csize_t, buf::Ptr{Cvoid})
     stream = unsafe_pointer_to_objref(hd)::LibuvStream
 
     local data::Ptr{Cvoid}, newsize::Csize_t
-    if stream.status != StatusActive
+    if stream.status::Int != StatusActive
         data = C_NULL
         newsize = 0
     else
@@ -557,7 +557,7 @@ function uv_readcb(handle::Ptr{Cvoid}, nread::Cssize_t, buf::Ptr{Cvoid})
                     if isa(stream, TTY)
                         stream.status = StatusEOF # libuv called uv_stop_reading already
                         notify(stream.cond)
-                    elseif stream.status != StatusClosing
+                    elseif stream.status::Int != StatusClosing
                         # begin shutdown of the stream
                         ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), stream.handle)
                         stream.status = StatusClosing
@@ -667,7 +667,7 @@ show(io::IO, stream::Pipe) = print(io,
 
 function open_pipe!(p::PipeEndpoint, handle::OS_HANDLE)
     iolock_begin()
-    if p.status != StatusInit
+    if p.status::Int != StatusInit
         error("pipe is already in use or has been closed")
     end
     err = ccall(:uv_pipe_open, Int32, (Ptr{Cvoid}, OS_HANDLE), p.handle, handle)
@@ -1061,7 +1061,7 @@ _fd(x::Union{OS_HANDLE, RawFD}) = x
 
 function _fd(x::Union{LibuvStream, LibuvServer})
     fd = Ref{OS_HANDLE}(INVALID_OS_HANDLE)
-    if x.status != StatusUninit && x.status != StatusClosed
+    if x.status::Int != StatusUninit && x.status::Int != StatusClosed
         err = ccall(:uv_fileno, Int32, (Ptr{Cvoid}, Ptr{OS_HANDLE}), x.handle, fd)
         # handle errors by returning INVALID_OS_HANDLE
     end

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -421,7 +421,7 @@ function thisind(s::AbstractString, i::Int)
     z = ncodeunits(s) + 1
     i == z && return i
     @boundscheck 0 ≤ i ≤ z || throw(BoundsError(s, i))
-    @inbounds while 1 < i && !isvalid(s, i)
+    @inbounds while 1 < i && !(isvalid(s, i)::Bool)
         i -= 1
     end
     return i

--- a/base/util.jl
+++ b/base/util.jl
@@ -68,7 +68,7 @@ text_colors
 
 function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args...; bold::Bool = false)
     buf = IOBuffer()
-    iscolor = get(io, :color, false)
+    iscolor = get(io, :color, false)::Bool
     try f(IOContext(buf, io), args...)
     finally
         str = String(take!(buf))

--- a/base/version.jl
+++ b/base/version.jl
@@ -154,7 +154,7 @@ function ident_cmp(
     B::Tuple{Vararg{Union{Integer,String}}},
 )
     for (a, b) in zip(A, B)
-       c = ident_cmp(a,b)
+       c = ident_cmp(a,b)::Int
        (c != 0) && return c
     end
     length(A) < length(B) ? -1 :

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -128,6 +128,8 @@ function handle_message(logger::ConsoleLogger, level, message, _module, group, i
     # Format lines as text with appropriate indentation and with a box
     # decoration on the left.
     color,prefix,suffix = logger.meta_formatter(level, _module, group, id, filepath, line)
+    color = convert(Symbol, color)::Symbol
+    prefix, suffix = convert(String, prefix)::String, convert(String, suffix)::String
     minsuffixpad = 2
     buf = IOBuffer()
     iob = IOContext(buf, logger.stream)
@@ -161,4 +163,3 @@ function handle_message(logger::ConsoleLogger, level, message, _module, group, i
     write(logger.stream, take!(buf))
     nothing
 end
-


### PR DESCRIPTION
On master,
```julia
struct Not end
Base.:!(::Not) = true
```
results in more than 2600 invalidated MethodInstances. On this branch, it's less than 1500. Far from fixed, but a lot better.

