### PR TITLE
Fix introspection macros for getproperty

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -69,9 +69,15 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
                 fully_qualified_symbol &= ex1 isa Symbol
                 if fully_qualified_symbol
                     if string(fcn) == "which"
-                        return quote $(fcn)($(esc(ex0.args[1])), $(ex0.args[2])) end
-                    else
-                        return Expr(:call, :error, "expression is not a function call or symbol")
+                        return quote
+                            local arg1 = $(esc(ex0.args[1]))
+                            if isa(arg1, Module)
+                                $(fcn)(arg1, $(ex0.args[2]))
+                            else
+                                local args = typesof($(map(esc, ex0.args)...))
+                                $(fcn)(Base.getproperty, args)
+                            end
+                        end
                     end
                 elseif ex0.args[2] isa Expr
                     return Expr(:call, :error, "dot expressions are not lowered to "

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -322,8 +322,14 @@ B33163(x) = x
 
 # Issue #14637
 @test (@which Base.Base.Base.nothing) == Core
-@test_throws ErrorException (@functionloc Base.nothing)
+@test (@functionloc Base.nothing)[2] isa Integer
 @test (@code_typed (3//4).num)[2] == Int
+
+struct A14637
+    x
+end
+a14637 = A14637(0)
+@test (@which a14637.x).name == :getproperty
 
 # Issue #28615
 @test_throws ErrorException (@which [1, 2] .+ [3, 4])


### PR DESCRIPTION
Non-`@code_` introspection macros currently fail on calls to `getproperty` with the dot syntax. The reason is that `@which` should not answer the same thing depending on whether it's a call to `getproperty` with a module or not, i.e. the two following behaviors are expected:
```julia
julia> @which Base.nothing
Core

julia> x = LinearAlgebra.lu(rand(Int, 3, 3));

julia> @which x.factors
getproperty(F::LU{T,var"#s825"} where var"#s825"<:(StridedArray{T, 2} where T), d::Symbol) where T in LinearAlgebra at /home/liozou/julia/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/lu.jl:305
```

This is something I overlooked in #35522. And currently the second case fails:
```julia
julia> @which x.factors
ERROR: expected tuple type
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] to_tuple_type(::Any) at ./reflection.jl:764
 [3] which(::Any, ::Any) at ./reflection.jl:1133
 [4] top-level scope at /home/liozou/julia/usr/share/julia/stdlib/v1.6/InteractiveUtils/src/macros.jl:72
```

This PR fixes that. It unfortunately breaks a test that I had intentionally put in #35522. The reasoning was that the two different calls with the dot syntax were ambiguous, so we have to error in the latter case. But actually the two calls are not ambiguous: we simply have to check whether the left-hand side of the dot is a module or not, which cannot be done at macro expansion but can certainly be done runtime.

Anyway, bottom line is:
- `@which` now differentiates between `SomeModule.x` and `foo.bar` (where `foo` is not a module) and now works in both cases (instead of only the first)
- `@less`, `@edit`, `@functionloc` don't fail anymore on calls to `getproperty` with the dot syntax.