### PR TITLE
Enforce runtime-dispatch with atsign-invoke

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,10 @@ Build system changes
 New library functions
 ---------------------
 
+* A new `Base.@invoke f(args...)` makes it easier to achieve
+  runtime-dispatch without union-splitting on the types of
+  `args...`. This can be useful to prevent invalidation of
+  partially-specified code when new methods of dependencies are added.
 
 New library features
 --------------------

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -199,7 +199,13 @@ julia> "foo" ≠ "foo"
 false
 ```
 """
-!=(x, y) = !(x == y)
+function !=(x, y)
+    cmp = x == y
+    isa(cmp, Bool) && return !cmp
+    isa(cmp, Missing) && return !cmp
+    # Due to bootstrap we can't yet make use of `@invoke`
+    return invoke(!, Tuple{typeof(cmp)}, cmp)
+end
 const ≠ = !=
 
 """

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -933,6 +933,23 @@ function visit(f, d::Core.TypeMapEntry)
     end
     nothing
 end
+function visit(f, d::SimpleVector)
+    for i = 1:length(d)
+        if isassigned(d, i)
+            f(d[i])
+        end
+    end
+end
+function visit(f, d::Core.MethodInstance)
+    if isdefined(d, :cache)
+        ci = d.cache
+        f(ci)
+        while isdefined(ci, :next)
+            ci = ci.next
+            f(ci)
+        end
+    end
+end
 
 function length(mt::Core.MethodTable)
     n = 0

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -254,6 +254,7 @@ Base.@inline
 Base.@noinline
 Base.@nospecialize
 Base.@specialize
+Base.@invoke
 Base.gensym
 Base.@gensym
 var"name"


### PR DESCRIPTION
This is a tool to prevent invalidations due to partial specialization. For example,
```julia
!=(x, y) = @invoke !(x == y)
```

or, if you want to "manually union-split" known cases,

```julia
function !=(x, y)
    cmp = x == y
    isa(cmp, Bool) && return !cmp
    isa(cmp, Missing) && return !cmp
    return @invoke !cmp
end
```

This only affects cases where the types of `x` and `y` cannot be concretely inferred.