### PR TITLE
rm doc reference to non-existent diagm keyword arg

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -311,7 +311,7 @@ diagm_container(size, kv::Pair{<:Integer,<:BitVector}...) =
     diagm(m::Integer, n::Integer, v::AbstractVector)
 
 Construct a matrix with elements of the vector as diagonal elements.
-By default (if `size=nothing`), the matrix is square and its size is given by
+By default, the matrix is square and its size is given by
 `length(v)`, but a non-square size `m`×`n` can be specified
 by passing `m,n` as the first arguments.
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3469,7 +3469,7 @@ end
 
 Construct a sparse diagonal matrix from `Pair`s of vectors and diagonals.
 Each vector `kv.second` will be placed on the `kv.first` diagonal.  By
-default (if `size=nothing`), the matrix is square and its size is inferred
+default, the matrix is square and its size is inferred
 from `kv`, but a non-square size `m`×`n` (padded with zeros as needed)
 can be specified by passing `m,n` as the first arguments.
 


### PR DESCRIPTION
There was originally a `size` keyword argument in the implementation of this feature (#31654), which was removed before the feature was merged, but a reference to it was accidentally retained in the documentation.