### PR TITLE
fix broadcasted assignment for scalar cartesian indexing

### DIFF
--- a/base/views.jl
+++ b/base/views.jl
@@ -131,7 +131,7 @@ end
 # (while remaining equivalent to getindex for scalar indices and non-array types)
 @propagate_inbounds maybeview(A, args...) = getindex(A, args...)
 @propagate_inbounds maybeview(A::AbstractArray, args...) = view(A, args...)
-@propagate_inbounds maybeview(A::AbstractArray, args::Union{Number,CartesianIndex}...) = getindex(A, args...)
+@propagate_inbounds maybeview(A::AbstractArray, args::Union{Number,AbstractCartesianIndex}...) = getindex(A, args...)
 @propagate_inbounds maybeview(A) = getindex(A)
 @propagate_inbounds maybeview(A::AbstractArray) = getindex(A)
 

--- a/base/views.jl
+++ b/base/views.jl
@@ -131,7 +131,7 @@ end
 # (while remaining equivalent to getindex for scalar indices and non-array types)
 @propagate_inbounds maybeview(A, args...) = getindex(A, args...)
 @propagate_inbounds maybeview(A::AbstractArray, args...) = view(A, args...)
-@propagate_inbounds maybeview(A::AbstractArray, args::Number...) = getindex(A, args...)
+@propagate_inbounds maybeview(A::AbstractArray, args::Union{Number,CartesianIndex}...) = getindex(A, args...)
 @propagate_inbounds maybeview(A) = getindex(A)
 @propagate_inbounds maybeview(A::AbstractArray) = getindex(A)
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -310,9 +310,13 @@ let x = [1:4;], y = x
     @. x[2:end] = 1:3    # @. should convert to .=
     @test y === x == [0,1,2,3]
 end
-let a = [[4, 5], [6, 7]]
+let a = [[4, 5], [6, 7]], b = reshape(a, 1, 2)
     a[1] .= 3
     @test a == [[3, 3], [6, 7]]
+    a[CartesianIndex(1)] .= 4
+    @test a == [[4, 4], [6, 7]]
+    b[1, CartesianIndex(1)] .= 5
+    @test a == [[5, 5], [6, 7]]
 end
 let d = Dict(:foo => [1,3,7], (3,4) => [5,9])
     d[:foo] .+= 2


### PR DESCRIPTION
When broadcasting left-hand side indexing is turned into a dotview.
For scalar indexing this should be equivalent to a `getindex`, but up
until this patch the `CartesianIndex` would not be treated as such.

This fixes e.g. broadcasting like `a[CartesianIndex(1)] .= 1` for a nested
array `a`.