### PR TITLE
More invalidation fixes

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -159,6 +159,7 @@ macro enum(T, syms...)
         else
             throw(ArgumentError(string("invalid argument for Enum ", typename, ": ", s)))
         end
+        s = s::Symbol
         if !Base.isidentifier(s)
             throw(ArgumentError("invalid name for Enum $typename; \"$s\" is not a valid identifier"))
         end

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -29,7 +29,7 @@ Base.print(io::IO, x::Enum) = print(io, Symbol(x))
 
 function Base.show(io::IO, x::Enum)
     sym = Symbol(x)
-    if !get(io, :compact, false)
+    if !(get(io, :compact, false)::Bool)
         from = get(io, :module, Main)
         def = typeof(x).name.module
         if from === nothing || !Base.isvisible(sym, def, from)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1064,6 +1064,7 @@ _getindex(::IndexStyle, A::AbstractArray, I...) =
     error("getindex for $(typeof(A)) with types $(typeof(I)) is not supported")
 
 ## IndexLinear Scalar indexing: canonical method is one Int
+_getindex(::IndexLinear, A::AbstractVector, i::Int) = (@_propagate_inbounds_meta; getindex(A, i))  # ambiguity resolution in case packages specialize this (to be avoided if at all possible, but see Interpolations.jl)
 _getindex(::IndexLinear, A::AbstractArray, i::Int) = (@_propagate_inbounds_meta; getindex(A, i))
 function _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int,M}) where M
     @_inline_meta

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2150,6 +2150,8 @@ end
 # map on collections
 map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 
+mapany(f, itr) = map!(f, Vector{Any}(undef, length(itr)), itr)  # convenient for Expr.args
+
 # default to returning an Array for `map` on general iterators
 """
     map(f, c...) -> collection

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -166,7 +166,7 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                       vdots::AbstractString = "\u22ee",
                       ddots::AbstractString = "  \u22f1  ",
                       hmod::Integer = 5, vmod::Integer = 5)
-    if !get(io, :limit, false)
+    if !(get(io, :limit, false)::Bool)
         screenheight = screenwidth = typemax(Int)
     else
         sz = displaysize(io)

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -444,7 +444,7 @@ show(io::IO, c::Channel) = print(io, typeof(c), "(", c.sz_max, ")")
 
 function show(io::IO, ::MIME"text/plain", c::Channel)
     show(io, c)
-    if !get(io, :compact, false)
+    if !(get(io, :compact, false)::Bool)
         if !isopen(c)
             print(io, " (closed)")
         else

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -25,7 +25,7 @@ function show(io::IO, t::AbstractDict{K,V}) where V where K
     recur_io = IOContext(io, :SHOWN_SET => t,
                              :typeinfo => eltype(t))
 
-    limit::Bool = get(io, :limit, false)
+    limit = get(io, :limit, false)::Bool
     # show in a Julia-syntax-like form: Dict(k=>v, ...)
     print(io, typeinfo_prefix(io, t)[1])
     print(io, '(')

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -71,12 +71,13 @@ export doc
 
 const modules = Module[]
 const META    = gensym(:meta)
+const METAType = IdDict{Any,Any}
 
-meta(m::Module) = isdefined(m, META) ? getfield(m, META) : IdDict()
+meta(m::Module) = isdefined(m, META) ? getfield(m, META)::METAType : METAType()
 
 function initmeta(m::Module)
     if !isdefined(m, META)
-        Core.eval(m, :(const $META = $(IdDict())))
+        Core.eval(m, :(const $META = $(METAType())))
         push!(modules, m)
     end
     nothing
@@ -204,9 +205,9 @@ mutable struct MultiDoc
     "Ordered (via definition order) vector of object signatures."
     order::Vector{Type}
     "Documentation for each object. Keys are signatures."
-    docs::IdDict{Any,Any}
+    docs::METAType
 
-    MultiDoc() = new(Type[], IdDict())
+    MultiDoc() = new(Type[], METAType())
 end
 
 # Docstring registration.

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -265,7 +265,7 @@ function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
     if isempty(args)
         tag = sym
     else
-        tag = Expr(sym, args...)
+        tag = Expr(sym, args...)::Expr
     end
 
     inner = ex
@@ -277,7 +277,7 @@ function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
     if idx != 0
         push!(exargs[idx].args, tag)
     else
-        body::Expr = inner.args[2]
+        body = inner.args[2]::Expr
         pushfirst!(body.args, Expr(:meta, tag))
     end
     ex
@@ -333,7 +333,7 @@ end
 
 function findmeta(ex::Expr)
     if ex.head === :function || is_short_function_def(ex) || ex.head === :->
-        body::Expr = ex.args[2]
+        body = ex.args[2]::Expr
         body.head === :block || error(body, " is not a block expression")
         return findmeta_block(ex.args)
     end

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -118,7 +118,7 @@ function make_fastmath(expr::Expr)
             end
         end
     end
-    Expr(make_fastmath(expr.head), map(make_fastmath, expr.args)...)
+    Expr(make_fastmath(expr.head), Base.mapany(make_fastmath, expr.args)...)
 end
 function make_fastmath(symb::Symbol)
     fast_symb = get(fast_op, symb, :nothing)

--- a/base/io.jl
+++ b/base/io.jl
@@ -387,7 +387,7 @@ it is always safe to read one byte after seeing `eof` return `false`. `eof` will
 `false` as long as buffered data is still available, even if the remote end of a connection
 is closed.
 """
-eof(io::AbstractPipe) = eof(pipe_reader(io))
+eof(io::AbstractPipe) = eof(pipe_reader(io)::IO)::Bool
 reseteof(io::AbstractPipe) = reseteof(pipe_reader(io))
 
 

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -38,6 +38,8 @@ dup(src::RawFD, target::RawFD) = systemerror("dup", -1 ==
     ccall((@static Sys.iswindows() ? :_dup2 : :dup2), Int32,
                 (RawFD, RawFD), src, target))
 
+show(io::IO, fd::RawFD) = print(io, "RawFD(", bitcast(UInt32, fd), ')')  # avoids invalidation via show_default
+
 # Wrapper for an OS file descriptor (for Windows)
 if Sys.iswindows()
     primitive type WindowsRawSocket sizeof(Ptr) * 8 end # On Windows file descriptors are HANDLE's and 64-bit on 64-bit Windows

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -80,6 +80,7 @@ end
 
 _invoked_min_enabled_level(@nospecialize(logger)) = invoke(min_enabled_level, Tuple{typeof(logger)}, logger)
 
+_invoked_catch_exceptions(@nospecialize(logger)) = invoke(catch_exceptions, Tuple{typeof(logger)}, logger)
 
 """
     NullLogger()
@@ -349,7 +350,7 @@ end
 # Report an error in log message creation (or in the logger itself).
 @noinline function logging_error(logger, level, _module, group, id,
                                  filepath, line, @nospecialize(err))
-    if !catch_exceptions(logger)
+    if !_invoked_catch_exceptions(logger)
         rethrow(err)
     end
     try

--- a/base/range.jl
+++ b/base/range.jl
@@ -457,7 +457,6 @@ function print_range(io::IO, r::AbstractRange,
                      hdots::AbstractString = ",\u2026,") # horiz ellipsis
     # This function borrows from print_matrix() in show.jl
     # and should be called by show and display
-    limit = get(io, :limit, false)
     sz = displaysize(io)
     if !haskey(io, :compact)
         io = IOContext(io, :compact => true)

--- a/base/ryu/Ryu.jl
+++ b/base/ryu/Ryu.jl
@@ -109,7 +109,7 @@ function writeexp(x::T,
 end
 
 function Base.show(io::IO, x::T, forceuntyped::Bool=false, fromprint::Bool=false) where {T <: Base.IEEEFloat}
-    compact = get(io, :compact, false)
+    compact = get(io, :compact, false)::Bool
     buf = Base.StringVector(neededdigits(T))
     typed = !forceuntyped && !compact && get(io, :typeinfo, Any) != typeof(x)
     pos = writeshortest(buf, 1, x, false, false, true, -1,

--- a/base/show.jl
+++ b/base/show.jl
@@ -49,7 +49,7 @@ function show(io::IO, ::MIME"text/plain", iter::Union{KeySet,ValueIterator})
     summary(io, iter)
     isempty(iter) && return
     print(io, ". ", isa(iter,KeySet) ? "Keys" : "Values", ":")
-    limit::Bool = get(io, :limit, false)
+    limit = get(io, :limit, false)::Bool
     if limit
         sz = displaysize(io)
         rows, cols = sz[1] - 3, sz[2]
@@ -79,7 +79,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
     isempty(t) && return show(io, t)
     # show more descriptively, with one line per key/value pair
     recur_io = IOContext(io, :SHOWN_SET => t)
-    limit::Bool = get(io, :limit, false)
+    limit = get(io, :limit, false)::Bool
     if !haskey(io, :compact)
         recur_io = IOContext(recur_io, :compact => true)
     end
@@ -149,7 +149,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractSet{T}) where T
     isempty(t) && return show(io, t)
     # show more descriptively, with one line per value
     recur_io = IOContext(io, :SHOWN_SET => t)
-    limit::Bool = get(io, :limit, false)
+    limit = get(io, :limit, false)::Bool
 
     summary(io, t)
     isempty(t) && return
@@ -450,11 +450,11 @@ function show_function(io::IO, f::Function, compact::Bool)
     end
 end
 
-show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false))
+show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false)::Bool)
 print(io::IO, f::Function) = show_function(io, f, true)
 
 function show(io::IO, f::Core.IntrinsicFunction)
-    if !get(io, :compact, false)
+    if !(get(io, :compact, false)::Bool)
         print(io, "Core.Intrinsics.")
     end
     print(io, nameof(f))
@@ -564,7 +564,7 @@ function show_type_name(io::IO, tn::Core.TypeName)
     sym = (globfunc ? globname : tn.name)::Symbol
     globfunc && print(io, "typeof(")
     quo = false
-    if !get(io, :compact, false)
+    if !(get(io, :compact, false)::Bool)
         # Print module prefix unless type is visible from module passed to
         # IOContext If :module is not set, default to Main. nothing can be used
         # to force printing prefix
@@ -2129,7 +2129,7 @@ function alignment(io::IO, x::Pair)
         ctx = IOContext(io, :typeinfo => gettypeinfos(io, x)[1])
         left = length(sprint(show, x.first, context=ctx, sizehint=0))
         left += 2 * !isdelimited(ctx, x.first) # for parens around p.first
-        left += !get(io, :compact, false) # spaces are added around "=>"
+        left += !(get(io, :compact, false)::Bool) # spaces are added around "=>"
         (left+1, length(s)-left-1) # +1 for the "=" part of "=>"
     else
         (0, length(s)) # as for x::Any

--- a/base/show.jl
+++ b/base/show.jl
@@ -1198,7 +1198,7 @@ function show_import_path(io::IO, ex, quote_level)
             if i > 1 && ex.args[i-1] !== :(.)
                 print(io, '.')
             end
-            show_sym(io, ex.args[i], allow_macroname=(i==length(ex.args)))
+            show_sym(io, ex.args[i]::Symbol, allow_macroname=(i==length(ex.args)))
         end
     else
         show_unquoted(io, ex, 0, 0, quote_level)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -290,7 +290,7 @@ julia> cmp("b", "β")
 function cmp(a::AbstractString, b::AbstractString)
     a === b && return 0
     a, b = Iterators.Stateful(a), Iterators.Stateful(b)
-    for (c, d) in zip(a, b)
+    for (c::AbstractChar, d::AbstractChar) in zip(a, b)
         c ≠ d && return ifelse(c < d, -1, 1)
     end
     isempty(a) && return ifelse(isempty(b), 0, -1)

--- a/base/views.jl
+++ b/base/views.jl
@@ -148,10 +148,10 @@ function _views(ex::Expr)
         # but still use views for the args of the ref:
         lhs = ex.args[1]
         Expr(ex.head, Meta.isexpr(lhs, :ref) ?
-                      Expr(:ref, _views.(lhs.args)...) : _views(lhs),
+                      Expr(:ref, mapany(_views, lhs.args)...) : _views(lhs),
              _views(ex.args[2]))
     elseif ex.head === :ref
-        Expr(:call, maybeview, _views.(ex.args)...)
+        Expr(:call, maybeview, mapany(_views, ex.args)...)
     else
         h = string(ex.head)
         # don't use view on the lhs of an op-assignment a[i...] += ...
@@ -182,9 +182,9 @@ function _views(ex::Expr)
                  Expr(first(h) == '.' ? :(.=) : :(=), :($a[$(I...)]),
                       Expr(:call, Symbol(h[1:end-1]),
                            :($maybeview($a, $(I...))),
-                           _views.(ex.args[2:end])...)))
+                           mapany(_views, ex.args[2:end])...)))
         else
-            Expr(ex.head, _views.(ex.args)...)
+            Expr(ex.head, mapany(_views, ex.args)...)
         end
     end
 end

--- a/stdlib/Base64/src/decode.jl
+++ b/stdlib/Base64/src/decode.jl
@@ -123,7 +123,7 @@ function Base.readbytes!(pipe::Base64DecodePipe, data::AbstractVector{UInt8}, nb
     return filled
 end
 
-Base.eof(pipe::Base64DecodePipe) = isempty(pipe.rest) && eof(pipe.io)
+Base.eof(pipe::Base64DecodePipe) = isempty(pipe.rest) && eof(pipe.io)::Bool
 Base.close(pipe::Base64DecodePipe) = nothing
 
 # Decode data from (b1, b2, b3, b5, buffer, input) into (ptr, rest).

--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -102,11 +102,11 @@ end
 
 function Base.read!(io::IO, cred::GitCredential)
     # https://git-scm.com/docs/git-credential#IOFMT
-    while !eof(io)
-        key = readuntil(io, '=')
+    while !(eof(io)::Bool)
+        key::AbstractString = readuntil(io, '=')
         if key == "password"
             value = Base.SecretBuffer()
-            while !eof(io) && (c = read(io, UInt8)) != UInt8('\n')
+            while !(eof(io)::Bool) && (c = read(io, UInt8)) != UInt8('\n')
                 write(value, c)
             end
             seekstart(value)

--- a/stdlib/Markdown/src/Julia/interp.jl
+++ b/stdlib/Markdown/src/Julia/interp.jl
@@ -39,7 +39,7 @@ end
 
 toexpr(x) = x
 
-toexpr(xs::Vector{Any}) = Expr(:call, GlobalRef(Base,:getindex), Any, map(toexpr, xs)...)
+toexpr(xs::Vector{Any}) = Expr(:call, GlobalRef(Base,:getindex), Any, mapany(toexpr, xs)...)
 
 for T in Any[MD, Paragraph, Header, Link, Bold, Italic]
     @eval function toexpr(md::$T)

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -5,7 +5,7 @@ Tools for working with the Markdown file format. Mainly for documentation.
 """
 module Markdown
 
-import Base: show, ==, with_output_color
+import Base: show, ==, with_output_color, mapany
 using Base64: stringmime
 
 # Margin for printing in terminal.

--- a/stdlib/Markdown/src/parse/config.jl
+++ b/stdlib/Markdown/src/parse/config.jl
@@ -76,7 +76,7 @@ const flavors = Dict{Symbol, Config}()
 
 macro flavor(name, features)
     quote
-        const $(esc(name)) = config($(map(esc,features.args)...))
+        const $(esc(name)) = config($(mapany(esc,features.args)...))
         flavors[$(Expr(:quote, name))] = $(esc(name))
     end
 end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1161,7 +1161,7 @@ StreamREPL(stream::IO) = StreamREPL(stream, Base.text_colors[:green], Base.input
 run_repl(stream::IO) = run_repl(StreamREPL(stream))
 
 outstream(s::StreamREPL) = s.stream
-hascolor(s::StreamREPL) = get(s.stream, :color, false)
+hascolor(s::StreamREPL) = get(s.stream, :color, false)::Bool
 
 answer_color(r::LineEditREPL) = r.envcolors ? Base.answer_color() : r.answer_color
 answer_color(r::StreamREPL) = r.answer_color

--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -96,8 +96,8 @@ disable_bracketed_paste(t::TextTerminal) = nothing
 
 abstract type UnixTerminal <: TextTerminal end
 
-pipe_reader(t::UnixTerminal) = t.in_stream
-pipe_writer(t::UnixTerminal) = t.out_stream
+pipe_reader(t::UnixTerminal) = t.in_stream::IO
+pipe_writer(t::UnixTerminal) = t.out_stream::IO
 
 mutable struct TerminalBuffer <: UnixTerminal
     out_stream::IO

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -607,9 +607,9 @@ moduleusings(mod) = ccall(:jl_module_usings, Any, (Any,), mod)
 filtervalid(names) = filter(x->!occursin(r"#", x), map(string, names))
 
 accessible(mod::Module) =
-    [filter!(s -> !Base.isdeprecated(mod, s), names(mod, all = true, imported = true));
-     map(names, moduleusings(mod))...;
-     collect(keys(Base.Docs.keywords))] |> unique |> filtervalid
+    Symbol[filter!(s -> !Base.isdeprecated(mod, s), names(mod, all=true, imported=true));
+           map(names, moduleusings(mod))...;
+           collect(keys(Base.Docs.keywords))] |> unique |> filtervalid
 
 doc_completions(name) = fuzzysort(name, accessible(Main))
 doc_completions(name::Symbol) = doc_completions(string(name))

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -275,7 +275,7 @@ function _show_with_braille_patterns(io::IOContext, S::AbstractSparseMatrixCSC)
 end
 
 function Base.show(io::IOContext, S::AbstractSparseMatrixCSC)
-    if max(size(S)...) < 16 && !get(io, :compact, false)
+    if max(size(S)...) < 16 && !(get(io, :compact, false)::Bool)
         ioc = IOContext(io, :compact => true)
         println(ioc)
         Base.print_matrix(ioc, S)

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -854,7 +854,7 @@ function show(io::IOContext, x::AbstractSparseVector)
     if isempty(nzind)
         return show(io, MIME("text/plain"), x)
     end
-    limit::Bool = get(io, :limit, false)
+    limit = get(io, :limit, false)::Bool
     half_screen_rows = limit ? div(displaysize(io)[1] - 8, 2) : typemax(Int)
     pad = ndigits(n)
     if !haskey(io, :compact)


### PR DESCRIPTION
These fix a fair number of the Base invalidations in #35922. If all these seem fine it could be merged, but many do arise from partial inference, and if we implement some of the suggestions in that issue then the changes to the following may not be so urgent:

- ~`convert(::Type{T}, x::AbstractDict) where T<:AbstractDict`~
- `cmp(a::AbstractString, b::AbstractString)`

I doubt either of these would cause trouble, but I'm happy to drop those if Jeff or others think they are fixable by other means. To me, the rest seem like stuff we probably want.