### PR TITLE
optimize more tuple splatting independent of length when possible

### DIFF
--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -222,6 +222,11 @@ end
 f_identity_splat(t) = (t...,)
 @test length(code_typed(f_identity_splat, (Tuple{Int,Int},))[1][1].code) == 1
 
+# splatting one tuple into (,) plus zero or more empties should reduce
+# this pattern appears for example in `fill_to_length`
+f_splat_with_empties(t) = (()..., t..., ()..., ()...)
+@test length(code_typed(f_splat_with_empties, (NTuple{200,UInt8},))[1][1].code) == 1
+
 # check that <: can be fully eliminated
 struct SomeArbitraryStruct; end
 function f_subtype()


### PR DESCRIPTION
For the heck of it, I tried to use `fill_to_length` to create a constant tuple (`Base.fill_to_length((),0x00,Val(160))`), and to my surprise the generated code still contained a call to `_apply_iterate`. That was because the tuple exceeds MAX_TUPLE_SPLAT. That limit should perhaps be higher for inlining than for inference, but this is also an easy case we can optimize anyway.