### PR TITLE
Define `length(::SkipMissing)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ Standard library changes
 ------------------------
 * The `nextprod` function now accepts tuples and other array types for its first argument ([#35791]).
 * The function `isapprox(x,y)` now accepts the `norm` keyword argument also for numeric (i.e., non-array) arguments `x` and `y` ([#35883]).
+* `length` now supports `SkipMissing`-wrapped containers ([#35946]).
 
 #### LinearAlgebra
 

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -258,6 +258,13 @@ keys(itr::SkipMissing) =
     v === missing && throw(MissingException("the value at index $I is missing"))
     v
 end
+function length(itr::SkipMissing)
+    i = 0
+    for _ in itr
+        i += 1
+    end
+    return i
+end
 
 function show(io::IO, s::SkipMissing)
     print(io, "skipmissing(")

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -363,6 +363,7 @@ end
 @testset "skipmissing" begin
     x = skipmissing([1, 2, missing, 4])
     @test eltype(x) === Int
+    @test length(x) == 3
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
 


### PR DESCRIPTION
This adds a definition for the `length` of `SkipMissing`. Note that the `IteratorSize` trait remains available for algorithms to know that this function is not *O*(1).

In particular, it seems odd that I can do:

```julia
julia> (sum ∘ skipmissing)([1, 2, missing, 4])
7
```

but not:

```julia
julia> (length ∘ skipmissing)([1, 2, missing, 4])
ERROR: MethodError: no method matching length(::Base.SkipMissing{Array{Union{Missing, Int64},1}})
Closest candidates are:
  length(::Base.Iterators.Flatten{Tuple{}}) at iterators.jl:1061
  length(::BitSet) at bitset.jl:365
  length(::Base.EnvDict) at env.jl:132
  ...
Stacktrace:
 [1] (::Base.var"#62#63"{typeof(length),typeof(skipmissing)})(::Array{Union{Missing, Int64},1}) at ./operators.jl:877
 [2] top-level scope at REPL[2]:1
```

Now we have:

```julia
julia> (length ∘ skipmissing)([1, 2, missing, 4])
3
```