### PR TITLE
Add a default implementation of `length` using `iterate`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ Standard library changes
 ------------------------
 * The `nextprod` function now accepts tuples and other array types for its first argument ([#35791]).
 * The function `isapprox(x,y)` now accepts the `norm` keyword argument also for numeric (i.e., non-array) arguments `x` and `y` ([#35883]).
+* There is a default implementation of `length` for all iterables with `IteratorSize` of `SizeUnknown` (using simple iteration) ([#35947]).
 
 #### LinearAlgebra
 

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -97,6 +97,18 @@ IteratorSize(::Type{Any}) = SizeUnknown()
 
 haslength(iter) = IteratorSize(iter) isa Union{HasShape, HasLength}
 
+function length(iter)
+    if IteratorSize(iter) isa SizeUnknown
+        i = 0
+        for _ in iter
+            i += 1
+        end
+        return i
+    else
+        throw(MethodError(length, (iter,)))
+    end
+end
+
 abstract type IteratorEltype end
 struct EltypeUnknown <: IteratorEltype end
 struct HasEltype <: IteratorEltype end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -363,6 +363,7 @@ end
 @testset "skipmissing" begin
     x = skipmissing([1, 2, missing, 4])
     @test eltype(x) === Int
+    @test length(x) == 3
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
 


### PR DESCRIPTION
Here is an alternative to #35946.

For all iterables with `SizeUnknown` we default to using `iterate` to get the `length` when requested. Algorithms can still take care to check `IteratorSize` on unknown iterables in order to know if the function is *O*(1) or not.

The particular (new) behavior I am seeking is:

```julia
julia> (length ∘ skipmissing)([1, 2, missing, 4])
3
```

but I've had to write this defintion elsewhere before so I thought it made sense in `Base`. I also believe we should tie `length` to the `iterate` API, generically.