### PR TITLE
Convert Base.alignment examples to jldoctests

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2100,18 +2100,27 @@ end
 """
 `alignment(io, X)` returns a tuple (left,right) showing how many characters are
 needed on either side of an alignment feature such as a decimal point.
+
+# Examples
+```jldoctest
+julia> Base.alignment(stdout, 42)
+(2, 0)
+
+julia> Base.alignment(stdout, 4.23)
+(1, 3)
+
+julia> Base.alignment(stdout, 1 + 10im)
+(3, 5)
+```
 """
 alignment(io::IO, x::Any) = (0, length(sprint(show, x, context=io, sizehint=0)))
 alignment(io::IO, x::Number) = (length(sprint(show, x, context=io, sizehint=0)), 0)
-"`alignment(stdout, 42)` yields (2, 0)"
 alignment(io::IO, x::Integer) = (length(sprint(show, x, context=io, sizehint=0)), 0)
-"`alignment(stdout, 4.23)` yields (1, 3) for `4` and `.23`"
 function alignment(io::IO, x::Real)
     m = match(r"^(.*?)((?:[\.eEfF].*)?)$", sprint(show, x, context=io, sizehint=0))
     m === nothing ? (length(sprint(show, x, context=io, sizehint=0)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
-"`alignment(stdout, 1 + 10im)` yields (3, 5) for `1 +` and `_10im` (plus sign on left, space on right)"
 function alignment(io::IO, x::Complex)
     m = match(r"^(.*[^ef][\+\-])(.*)$", sprint(show, x, context=io, sizehint=0))
     m === nothing ? (length(sprint(show, x, context=io, sizehint=0)), 0) :


### PR DESCRIPTION
Closes #35672.

It seems that comments are not supported in jldoctests (see below).
I'm not sure what is the best way to keep the original comments?
```
Evaluated output:
  (3, 5)
Expected output:
  (3, 5) # for `1 +` and `_10im` (plus sign on left, space on right)"
```