### PR TITLE
show failed Tasks using the same style as `TaskFailedException`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -202,7 +202,7 @@ function show(io::IO, ::MIME"text/plain", t::Task)
     show(io, t)
     if t.state === :failed
         println(io)
-        showerror(io, CapturedException(t.result, t.backtrace))
+        show_task_exception(io, t)
     end
 end
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -67,17 +67,19 @@ struct TaskFailedException <: Exception
 end
 
 function showerror(io::IO, ex::TaskFailedException)
-    stacks = []
-    while isa(ex.task.exception, TaskFailedException)
-        pushfirst!(stacks, ex.task.backtrace)
-        ex = ex.task.exception
-    end
     println(io, "TaskFailedException:")
-    showerror(io, ex.task.exception, ex.task.backtrace)
-    if !isempty(stacks)
-        for bt in stacks
-            show_backtrace(io, bt)
-        end
+    show_task_exception(io, ex.task)
+end
+
+function show_task_exception(io::IO, t::Task)
+    stacks = []
+    while isa(t.exception, TaskFailedException)
+        pushfirst!(stacks, t.backtrace)
+        t = t.exception.task
+    end
+    showerror(io, t.exception, t.backtrace)
+    for bt in stacks
+        show_backtrace(io, bt)
     end
 end
 


### PR DESCRIPTION
It doesn't really make sense to construct a `CapturedException` just to show a Task.