### PR TITLE
Fix type instability of closures capturing types

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -445,6 +445,16 @@ function Symbol(a::Array{UInt8,1})
 end
 Symbol(s::Symbol) = s
 
+# for closures
+function _typeof_prefer_singleton(@nospecialize x)
+    if x isa DataType
+        if x.layout === Ptr{Nothing}(0)  # we don't have C_NULL yet
+            return DataType
+        end
+    end
+    return Typeof(x)
+end
+
 # module providing the IR object model
 module IR
 export CodeInfo, MethodInstance, CodeInstance, GotoNode,

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3567,7 +3567,7 @@ f(x) = yt(x)
                                     (filter identity (map (lambda (v ve)
                                                             (if (is-var-boxed? v lam)
                                                                 #f
-                                                                `(call (core typeof) ,ve)))
+                                                                `(call (core _typeof_prefer_singleton) ,ve)))
                                                           capt-vars var-exprs)))))
                            `(new ,(if (null? P)
                                       type-name

--- a/test/core.jl
+++ b/test/core.jl
@@ -611,6 +611,10 @@ end
 @test foo21900 == 10
 @test bar21900 == 11
 
+let f = x -> g -> g(x)
+    @test fieldtype(typeof(f(Int)), 1) === Type{Int}
+end
+
 # ? syntax
 @test (true ? 1 : false ? 2 : 3) == 1
 


### PR DESCRIPTION
(trying to) fix #23618

This patch "works" in the sense that closures behave as expected in the "bare" `julia`:

```julia
$ usr/bin/julia --sysimage usr/lib/julia/corecompiler.ji
WARNING: Base._start not defined, falling back to economy mode repl.

julia> f = x -> g -> g(x)
getfield(Main, Symbol("#1#3"))()

julia> typeof(f(Int))  # this takes ~10 seconds
getfield(Main, Symbol("#2#4")){Type{Int64}}

julia> f(Int)(f(1))
1
```

Note that the output of the second statement would be `getfield(Main, Symbol("#2#4")){DataType}` in current `master`.  In this branch, it captures a `Type{Int64}` instead of a `DataType`.

However, `make` never finishes:

```
...
Sysimage built. Summary:
Total ─────── 352.542854 seconds
Base: ─────── 147.912140 seconds 41.9558%
Stdlibs: ──── 204.630686 seconds 58.0442%
    JULIA usr/lib/julia/sys-o.a
Generating precompile statements... 34405 generated in 6878.302163 seconds (overhead 5869.884857 seconds)
^C
signal (2): Interrupt
```

It ran for hours and consumed more than 12 GiB RAM so I just interrupted the compile.

@JeffBezanson @vtjnash Is there any way to make this work (or fix #23618 in any way)?
