### PR TITLE
Fix type-instability of ∘ and Some when wrapping types

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -893,8 +893,6 @@ function show(io::IO, c::ComposedFunction)
     show(io, c.g)
 end
 
-show(io::IO, ::MIME"text/plain", c::ComposedFunction) = show(io, c)
-
 """
     !f::Function
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -873,9 +873,27 @@ julia> ∘(fs...)(3)
 ```
 """
 function ∘ end
+
+struct ComposedFunction{F,G} <: Function
+    f::F
+    g::G
+    ComposedFunction{F, G}(f, g) where {F, G} = new{F, G}(f, g)
+    ComposedFunction(f, g) = new{Core.Typeof(f),Core.Typeof(g)}(f, g)
+end
+
+(c::ComposedFunction)(x...) = c.f(c.g(x...))
+
 ∘(f) = f
-∘(f, g) = (x...)->f(g(x...))
+∘(f, g) = ComposedFunction(f, g)
 ∘(f, g, h...) = ∘(f ∘ g, h...)
+
+function show(io::IO, c::ComposedFunction)
+    show(io, c.f)
+    print(io, " ∘ ")
+    show(io, c.g)
+end
+
+show(io::IO, ::MIME"text/plain", c::ComposedFunction) = show(io, c)
 
 """
     !f::Function

--- a/base/show.jl
+++ b/base/show.jl
@@ -44,6 +44,8 @@ function show(io::IO, ::MIME"text/plain", f::Function)
     end
 end
 
+show(io::IO, ::MIME"text/plain", c::ComposedFunction) = show(io, c)
+
 function show(io::IO, ::MIME"text/plain", iter::Union{KeySet,ValueIterator})
     isempty(iter) && get(io, :compact, false) && return show(io, iter)
     summary(io, iter)

--- a/base/some.jl
+++ b/base/some.jl
@@ -12,6 +12,8 @@ struct Some{T}
     value::T
 end
 
+Some(::Type{T}) where {T} = Some{Type{T}}(T)
+
 promote_rule(::Type{Some{T}}, ::Type{Some{S}}) where {T, S<:T} = Some{T}
 
 nonnothingtype(::Type{T}) where {T} = Core.Compiler.typesubtract(T, Nothing)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -134,7 +134,7 @@ Base.promote_rule(::Type{T19714}, ::Type{Int}) = T19714
     @test ∘(FreeMagma(1), FreeMagma(2), FreeMagma(3)) === FreeMagma(((1,2), 3))
     @test ∘(FreeMagma(1), FreeMagma(2), FreeMagma(3), FreeMagma(4)) === FreeMagma((((1,2), 3), 4))
 
-    @test fieldtypes(typeof(Float64 ∘ Int)) == (Type{Float64}, Type{Int64})
+    @test fieldtypes(typeof(Float64 ∘ Int)) == (Type{Float64}, Type{Int})
 end
 
 @testset "function negation" begin

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -133,6 +133,8 @@ Base.promote_rule(::Type{T19714}, ::Type{Int}) = T19714
     @test ∘(FreeMagma(1), FreeMagma(2)) === FreeMagma((1,2))
     @test ∘(FreeMagma(1), FreeMagma(2), FreeMagma(3)) === FreeMagma(((1,2), 3))
     @test ∘(FreeMagma(1), FreeMagma(2), FreeMagma(3), FreeMagma(4)) === FreeMagma((((1,2), 3), 4))
+
+    @test fieldtypes(typeof(Float64 ∘ Int)) == (Type{Float64}, Type{Int64})
 end
 
 @testset "function negation" begin

--- a/test/some.jl
+++ b/test/some.jl
@@ -98,3 +98,6 @@ using Base: notnothing
 # isnothing()
 @test !isnothing(1)
 @test isnothing(nothing)
+
+# type stability
+@test fieldtype(typeof(Some(Int)), 1) === Type{Int}


### PR DESCRIPTION
It looks fixing type instability of closure is hard (#35970). So, can we add a workaround for cases like `Float64 ∘ first`?

fix #34849

---

I also added a similar fix for `Some`

Before

```
julia> typeof(Float64 ∘ first)
Base.var"#62#63"{DataType,typeof(first)}

julia> typeof(Some(Int))
Some{DataType}
```

After

```
julia> typeof(Float64 ∘ first)
Base.ComposedFunction{Type{Float64},typeof(first)}

julia> typeof(Some(Int))
Some{Type{Int64}}
```
