### PR TITLE
fix error thrown by `filesize(::IOStream)`

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -221,7 +221,10 @@ end
 
 function filesize(s::IOStream)
     sz = @_lock_ios s ccall(:ios_filesize, Int64, (Ptr{Cvoid},), s.ios)
-    systemerror("filesize", sz == -1)
+    if sz == -1
+        err = Libc.errno()
+        throw(IOError(string("filesize: ", Libc.strerror(err), " for ", s.name), err))
+    end
     return sz
 end
 

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -548,8 +548,6 @@ int64_t ios_pos(ios_t *s)
 
 int64_t ios_filesize(ios_t *s)
 {
-    if (s->fd == -1)
-        return -1;
     int64_t fdpos = s->fpos;
     if (fdpos == (int64_t)-1) {
         fdpos = lseek(s->fd, 0, SEEK_CUR);


### PR DESCRIPTION
An Mmap test was expecting this, plus there was a case that errno wasn't set in ios.c. This must have been caused by #35925, but that PR (and I believe, some since then) passed CI so I'm not sure what's going on.