### PR TITLE
refactor the (number) parsing code

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -15,7 +15,7 @@ import
         eps, signbit, sign, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, lerpi,
         cbrt, typemax, typemin, unsafe_trunc, floatmin, floatmax, rounding,
-        setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero,
+        setrounding, maxintfloat, widen, significand, frexp, iszero,
         isone, big, _string_n, decompose
 
 import ..Rounding: rounding_raw, setrounding_raw
@@ -244,7 +244,11 @@ function BigFloat(x::Rational, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::I
     end
 end
 
-function tryparse(::Type{BigFloat}, s::AbstractString; base::Integer=0, precision::Integer=DEFAULT_PRECISION[], rounding::MPFRRoundingMode=ROUNDING_MODE[])
+function Base.parse(::Type{BigFloat}, s::AbstractString; base::Integer=0, precision::Integer=DEFAULT_PRECISION[], rounding::MPFRRoundingMode=ROUNDING_MODE[])
+    result = tryparse(BigFloat, s; base, precision, rounding)
+    result === nothing ? Base.throw_parse_failure(BigFloat, s) : result
+end
+function Base.tryparse(::Type{BigFloat}, s::AbstractString; base::Integer=0, precision::Integer=DEFAULT_PRECISION[], rounding::MPFRRoundingMode=ROUNDING_MODE[])
     !isempty(s) && isspace(s[end]) && return tryparse(BigFloat, rstrip(s), base = base)
     z = BigFloat(precision=precision)
     err = ccall((:mpfr_set_str, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Int32, MPFRRoundingMode), z, s, base, rounding)


### PR DESCRIPTION
While looking at the parsing code I noticed that quite a lot of it took three arguments, a`AbstractString`, `startpos`,  `endpos`. This is almost the definition of a `SubString` so that is completely redundant (it is possible the parsing code was written before `SubString` existed.

Therefore I eliminated these three arguments for one `AbstractString` instead and replaced the places that called this with non-default positions with `SubString`.  This actually has some performance benefit since you are not calling `lastindex` unnecessarily. 

There was also quite a lot of inconsistencies in how the parsing errors were printed between different types. Most of this was because the throws were inlined into the body itself so I factored most of this out into functions that throw.

In addition, I had quite a hard time following the dispatch logic in the parsing code. There are an awful lot of `tryparse_internal` overloads and figuring out how things are called is non-trivial. I changed it so that there is now one section for integer parsing, one for float parsing and one for complex parsing, and these sections are more or less independent of each other with a pretty obvious dispatch chain.

Also, different parts of Base (and stdlibs) reached into the internals of the parsing code (directly calling `tryparse_internal`. These now try to just implement the `parse` interface (mostly) independent of the internals of the now new module `Base.Parse`.

In the end, it seems this refactor gave some performance benefits (10%) but that wasn't really the goal.

```jl
julia> strs = string.(rand(-10^4:10^4, 10^7));
```

PR:

```jl
julia> @time parse.(Int, strs);
  0.319752 seconds (5 allocations: 76.294 MiB)
``` 

master:

```jl
julia> @time parse.(Int, strs);
  0.343541 seconds (5 allocations: 76.294 MiB)
``` 

