### PR TITLE
Fix minimum and maximum in the presence of missing values

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -573,10 +573,11 @@ function mapreduce_impl(f, op::Union{typeof(max), typeof(min)},
     simdstop  = start + chunk_len - 4
     while simdstop <= last - 3
         # short circuit in case of NaN
-        v1 == v1 || return v1
-        v2 == v2 || return v2
-        v3 == v3 || return v3
-        v4 == v4 || return v4
+        # === true is there to ignore missing
+        (v1 == v1) === true || return v1
+        (v2 == v2) === true || return v2
+        (v3 == v3) === true || return v3
+        (v4 == v4) === true || return v4
         @inbounds for i in start:4:simdstop
             v1 = _fast(op, v1, f(A[i+0]))
             v2 = _fast(op, v2, f(A[i+1]))

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -572,8 +572,7 @@ function mapreduce_impl(f, op::Union{typeof(max), typeof(min)},
     start = first + 1
     simdstop  = start + chunk_len - 4
     while simdstop <= last - 3
-        # short circuit in case of NaN
-        # === true is there to ignore missing
+        # short circuit in case of NaN or missing
         (v1 == v1) === true || return v1
         (v2 == v2) === true || return v2
         (v3 == v3) === true || return v3

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -338,6 +338,18 @@ A = circshift(reshape(1:24,2,3,4), (0,1,1))
 @test size(extrema(A,dims=(1,2,3))) == size(maximum(A,dims=(1,2,3)))
 @test extrema(x->div(x, 2), A, dims=(2,3)) == reshape([(0,11),(1,12)],2,1,1)
 
+@testset "maximum/minimum/extrema with missing values" begin
+    for x in (Vector{Union{Int,Missing}}(missing, 10),
+              Vector{Union{Int,Missing}}(missing, 257))
+        @test maximum(x) === minimum(x) === missing
+        @test extrema(x) === (missing, missing)
+        fill!(x, 1)
+        x[1] = missing
+        @test maximum(x) === minimum(x) === missing
+        @test extrema(x) === (missing, missing)
+    end
+end
+
 # any & all
 
 @test @inferred any([]) == false


### PR DESCRIPTION
Another, possibly cleaner way of fixing this would be to add an `isnan(::Number) = false` fallback, and do `x isa Number && isnan(x)`. That would make the code a bit clearer and could be useful for others. Currently we would have to do `x isa Union{Real, Complex} && isnan(x)` since there are the only types for which we define `isnan` methods -- but that approach wouldn't work for custom complex types.

Similar to https://github.com/JuliaLang/julia/pull/35323 (but simpler to fix).