### PR TITLE
give an error for EOF before complete input to the stream REPL

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -687,6 +687,17 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
     end
 end
 
+# incomplete inputs to stream REPL
+let exename = `$(Base.julia_cmd()) --startup-file=no`
+    in = Pipe(); out = Pipe(); err = Pipe()
+    proc = run(pipeline(exename, stdin = in, stdout = out, stderr = err), wait=false)
+    write(in, "f(\n")
+    close(in)
+    close(err.in)
+    txt = readline(err)
+    @test startswith(txt, "ERROR: syntax: incomplete")
+end
+
 # Issue #29855
 for yn in ("no", "yes")
     exename = `$(Base.julia_cmd()) --inline=no --startup-file=no --inline=$yn`

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -341,18 +341,6 @@ test_parseerror("0x1.0p", "invalid numeric constant \"0x1.0\"")
            @X19861
            """)::Expr) == 23341
 
-# test parse_input_line for a streaming IO input
-let b = IOBuffer("""
-                 let x = x
-                     x
-                 end
-                 f()
-                 """)
-    @test Base.parse_input_line(b).args[end] == Expr(:let, Expr(:(=), :x, :x), Expr(:block, LineNumberNode(2, :none), :x))
-    @test Base.parse_input_line(b).args[end] == Expr(:call, :f)
-    @test Base.parse_input_line(b) === nothing
-end
-
 # issue #15763
 test_parseerror("if\nfalse\nend", "missing condition in \"if\" at none:1")
 test_parseerror("if false\nelseif\nend", "missing condition in \"elseif\" at none:2")


### PR DESCRIPTION
I wanted to rearrange this code, and found that (yes, arguably due to the implicit `nothing` return) it currently fails to give an error if the input is incomplete:
```
jeff@gurren:~/src/julia$ cat | ../julia-1.5/julia/julia 
f(
jeff@gurren:~/src/julia$ 
```
With this PR:
```
jeff@gurren:~/src/julia$ cat | ./julia
f(
ERROR: syntax: incomplete: premature end of input
Stacktrace:
 [1] top-level scope at none:1
```
(on Ctl-D being pressed of course).

One question is whether the process should exit with code 1 in this case. It currently doesn't, since it's acting like a REPL and dealing with each input individually, followed by simply exiting the session.