### PR TITLE
Add note on the complexity of length for strings

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -346,14 +346,21 @@ isless(a::Symbol, b::Symbol) = cmp(a, b) < 0
     length(s::AbstractString) -> Int
     length(s::AbstractString, i::Integer, j::Integer) -> Int
 
-The number of characters in string `s` from indices `i` through `j`. This is
-computed as the number of code unit indices from `i` to `j` which are valid
-character indices. With only a single string argument, this computes the
-number of characters in the entire string. With `i` and `j` arguments it
+Return the number of characters in string `s` from indices `i` through `j`.
+
+This is computed as the number of code unit indices from `i` to `j` which are
+valid character indices. With only a single string argument, this computes
+the number of characters in the entire string. With `i` and `j` arguments it
 computes the number of indices between `i` and `j` inclusive that are valid
 indices in the string `s`. In addition to in-bounds values, `i` may take the
 out-of-bounds value `ncodeunits(s) + 1` and `j` may take the out-of-bounds
 value `0`.
+
+!!! note
+    The time complexity of this operation is linear in general. That is, it
+    will take the time proportional to the number of bytes or characters in
+    the string because it counts the value on the fly. This is in contrast to
+    the method for arrays, which is a constant-time operation.
 
 See also: [`isvalid`](@ref), [`ncodeunits`](@ref), [`lastindex`](@ref),
 [`thisind`](@ref), [`nextind`](@ref), [`prevind`](@ref)


### PR DESCRIPTION
I sometimes see people expect the `length` method for strings is a constant-time operation possibly becase it is so for arrays. So I think we should add a note on it to its docstring. I also tweaked the style to follow the current guideline of docstrings.