### PR TITLE
RFC: make `getindex(::AbstractRange, i)` specific to `StepRange`

### DIFF
--- a/base/compiler/ssair/basicblock.jl
+++ b/base/compiler/ssair/basicblock.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-Like UnitRange{Int}, but can handle the `last` field, being temporarily
-< first (this can happen during compacting)
+Like UnitRange{Int}, but can handle the `last` field being temporarily
+< first (this can happen during compacting) with normalizing it
 """
 struct StmtRange <: AbstractUnitRange{Int}
     start::Int
@@ -14,6 +14,17 @@ last(r::StmtRange) = r.stop
 iterate(r::StmtRange, state=0) = (last(r) - first(r) < state) ? nothing : (first(r) + state, state + 1)
 
 StmtRange(range::UnitRange{Int}) = StmtRange(first(range), last(range))
+
+function getindex(v::StmtRange, i::Int)
+    @inline
+    #i isa Bool && throw(ArgumentError("invalid index: $i of type Bool"))
+    val = v.start + (i - 1)
+    @boundscheck let _in_unit_range = i > 0 && val <= v.stop && val >= v.start
+        _in_unit_range || throw_boundserror(v, i)
+    end
+    val
+end
+
 
 struct BasicBlock
     stmts::StmtRange


### PR DESCRIPTION
I'm not an expert in the range code at this point, but it seemed odd to me that `getindex(::AbstractRange, ::Integer)` was defined. Based on what happens if you remove it, it seems this is only needed for `StepRange`; all other ranges (AFAIK) have their own methods. Is that correct or is this needed for some other reason?

It also looked to me like the scope of its boundscheck block needed to be bigger.
