### PR TITLE
Faster blockdiag for uniform input value-index types

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3318,7 +3318,7 @@ julia> blockdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
  ⋅  ⋅  ⋅  ⋅  4
 ```
 """
-blockdiag() = spzeros(Union{}, Int, 0, 0)
+blockdiag() = spzeros(promote_type(), Int, 0, 0)
 
 function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...) where {Tv, Ti <: Integer}
     _blockdiag(Tv, Ti, X...)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3318,6 +3318,8 @@ julia> blockdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
  ⋅  ⋅  ⋅  ⋅  4
 ```
 """
+blockdiag() = spzeros(0, 0)
+
 function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...) where {Tv, Ti <: Integer}
     blockdiag(Tv, Ti, X...)
 end

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3318,7 +3318,9 @@ julia> blockdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
  ⋅  ⋅  ⋅  ⋅  4
 ```
 """
-function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...=spzeros(0,0)) where {Tv, Ti <: Integer}
+blockdiag() = spzeros(Union{}, Int, 0, 0)
+
+function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...) where {Tv, Ti <: Integer}
     _blockdiag(Tv, Ti, X...)
 end
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3321,13 +3321,13 @@ julia> blockdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
 blockdiag() = spzeros(0, 0)
 
 function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...) where {Tv, Ti <: Integer}
-    blockdiag(Tv, Ti, X...)
+    _blockdiag(Tv, Ti, X...)
 end
 
 function blockdiag(X::AbstractSparseMatrixCSC...)
     Tv = promote_type(map(x->eltype(nonzeros(x)), X)...)
     Ti = isempty(X) ? Int : promote_type(map(x->eltype(rowvals(x)), X)...)
-    blockdiag(Tv, Ti, X...)
+    _blockdiag(Tv, Ti, X...)
 end
 
 function _blockdiag(::Type{Tv}, ::Type{Ti}, X::AbstractSparseMatrixCSC...) where {Tv, Ti <: Integer}

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3318,15 +3318,22 @@ julia> blockdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
  ⋅  ⋅  ⋅  ⋅  4
 ```
 """
+function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...) where {Tv, Ti <: Integer}
+    blockdiag(Tv, Ti, X...)
+end
+
 function blockdiag(X::AbstractSparseMatrixCSC...)
+    Tv = promote_type(map(x->eltype(nonzeros(x)), X)...)
+    Ti = isempty(X) ? Int : promote_type(map(x->eltype(rowvals(x)), X)...)
+    blockdiag(Tv, Ti, X...)
+end
+
+function blockdiag(::Type{Tv}, ::Type{Ti}, X::AbstractSparseMatrixCSC...) where {Tv, Ti <: Integer}
     num = length(X)
     mX = Int[ size(x, 1) for x in X ]
     nX = Int[ size(x, 2) for x in X ]
     m = sum(mX)
     n = sum(nX)
-
-    Tv = promote_type(map(x->eltype(nonzeros(x)), X)...)
-    Ti = isempty(X) ? Int : promote_type(map(x->eltype(rowvals(x)), X)...)
 
     colptr = Vector{Ti}(undef, n+1)
     nnzX = Int[ nnz(x) for x in X ]

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3330,7 +3330,7 @@ function blockdiag(X::AbstractSparseMatrixCSC...)
     blockdiag(Tv, Ti, X...)
 end
 
-function blockdiag(::Type{Tv}, ::Type{Ti}, X::AbstractSparseMatrixCSC...) where {Tv, Ti <: Integer}
+function _blockdiag(::Type{Tv}, ::Type{Ti}, X::AbstractSparseMatrixCSC...) where {Tv, Ti <: Integer}
     num = length(X)
     mX = Int[ size(x, 1) for x in X ]
     nX = Int[ size(x, 2) for x in X ]

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3318,15 +3318,13 @@ julia> blockdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
  ⋅  ⋅  ⋅  ⋅  4
 ```
 """
-blockdiag() = spzeros(0, 0)
-
-function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...) where {Tv, Ti <: Integer}
+function blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...=spzeros(0,0)) where {Tv, Ti <: Integer}
     _blockdiag(Tv, Ti, X...)
 end
 
 function blockdiag(X::AbstractSparseMatrixCSC...)
     Tv = promote_type(map(x->eltype(nonzeros(x)), X)...)
-    Ti = isempty(X) ? Int : promote_type(map(x->eltype(rowvals(x)), X)...)
+    Ti = promote_type(map(x->eltype(rowvals(x)), X)...)
     _blockdiag(Tv, Ti, X...)
 end
 


### PR DESCRIPTION
The current blockdiag implementation in SparseArrays uses type promotion to identify what types the values and index should be for the output SparseArray. 

This can be quite slow when the input to blockdiag is many small, sparse arrays (for the sake of example, over 2500+). If all the input sparse arrays have the same value and index types, then it's not necessary to compute them via type promotion and we can directly proceed to creating the new matrix.

This can provide significant speedups; for M generated with
```julia
M = [sprand(rand(15:50), rand(15:50), 0.02) for i in 1:2500]
``` 
and benchmarking the existing implementation with BenchmarkTools

```julia
@benchmark output = blockdiag(M...)
```

we get
```
BenchmarkTools.Trial: 
  memory estimate:  192.35 MiB
  allocs estimate:  37956
  --------------
  minimum time:     1.404 s (1.30% GC)
  median time:      1.434 s (1.31% GC)
  mean time:        1.438 s (1.24% GC)
  maximum time:     1.482 s (0.89% GC)
  --------------
  samples:          4
  evals/sample:     1
```
running the same benchmark, with same M, with the new implementation, we get a speedup of nearly 1000x

```julia
@benchmark output = blockdiag(M...)
```

```BenchmarkTools.Trial: 
  memory estimate:  3.00 MiB
  allocs estimate:  5019
  --------------
  minimum time:     1.072 ms (0.00% GC)
  median time:      1.162 ms (0.00% GC)
  mean time:        1.386 ms (11.86% GC)
  maximum time:     5.059 ms (60.41% GC)
  --------------
  samples:          3591
  evals/sample:     1
```

the current blockdiag implementation is hence split into 3 possible methods
```julia
blockdiag(X::AbstractSparseMatrixCSC...) # for the general case
blockdiag(X::AbstractSparseMatrixCSC{Tv, Ti}...) where {Tv, Ti <: Integer} # for increased speed when all input X have the same index and value types
blockdiag(::Type{Tv}, ::Type{Ti}, X::AbstractSparseMatrixCSC...) where {Tv, Ti <: Integer} # internally called by the two above methods, and available to the user when they're dealing with heterogenous inputs, and wish to specifiy the output index and value types manually for the increased speed benefits


