### PR TITLE
no longer color the exception-provided error message red

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -86,9 +86,7 @@ end
 
 function showerror(io::IO, ex, bt; backtrace=true)
     try
-        with_output_color(get(io, :color, false) ? error_color() : :nothing, io) do io
-            showerror(io, ex)
-        end
+        showerror(io, ex)
     finally
         backtrace && show_backtrace(io, bt)
     end


### PR DESCRIPTION
This doesn't compose well with exceptions trying to provide colors in their error messages.

Fixes https://github.com/JuliaLang/julia/issues/36015