### PR TITLE
Change getaddrinfo(host::AbstractString) to work with ipv6 localhost string "::1"

### DIFF
--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -126,15 +126,19 @@ getalladdrinfo(host::AbstractString) = getalladdrinfo(String(host))
 Gets the first IP address of the `host` of the specified `IPAddr` type.
 Uses the operating system's underlying getaddrinfo implementation, which may do a DNS lookup.
 """
-function getaddrinfo(host::String, T::Union{Type{<:IPAddr}, Nothing})
+function getaddrinfo(host::String, T::Type{<:IPAddr})
     addrs = getalladdrinfo(host)
-    if T isa Nothing && !isempty(addrs)
-        return addrs[1]
-    end
     for addr in addrs
         if addr isa T
             return addr
         end
+    end
+    throw(DNSError(host, UV_EAI_NONAME))
+end
+function getaddrinfo(host::String, ::Nothing)
+    addrs = getalladdrinfo(host)
+    if !isempty(addrs)
+        return addrs[1]
     end
     throw(DNSError(host, UV_EAI_NONAME))
 end

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -126,8 +126,11 @@ getalladdrinfo(host::AbstractString) = getalladdrinfo(String(host))
 Gets the first IP address of the `host` of the specified `IPAddr` type.
 Uses the operating system's underlying getaddrinfo implementation, which may do a DNS lookup.
 """
-function getaddrinfo(host::String, T::Type{<:IPAddr})
+function getaddrinfo(host::String, T::Union{Type{<:IPAddr}, Nothing})
     addrs = getalladdrinfo(host)
+    if T isa Nothing && !isempty(addrs)
+        return addrs[1]
+    end
     for addr in addrs
         if addr isa T
             return addr
@@ -136,7 +139,7 @@ function getaddrinfo(host::String, T::Type{<:IPAddr})
     throw(DNSError(host, UV_EAI_NONAME))
 end
 getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host), T)
-getaddrinfo(host::AbstractString) = getaddrinfo(String(host), IPv4)
+getaddrinfo(host::AbstractString) = getaddrinfo(String(host), nothing)
 
 function uv_getnameinfocb(req::Ptr{Cvoid}, status::Cint, hostname::Cstring, service::Cstring)
     data = uv_req_data(req)

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -135,15 +135,14 @@ function getaddrinfo(host::String, T::Type{<:IPAddr})
     end
     throw(DNSError(host, UV_EAI_NONAME))
 end
-function getaddrinfo(host::String, ::Nothing)
-    addrs = getalladdrinfo(host)
+getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host), T)
+function getaddrinfo(host::AbstractString)
+    addrs = getalladdrinfo(String(host))
     if !isempty(addrs)
         return addrs[1]
     end
     throw(DNSError(host, UV_EAI_NONAME))
 end
-getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host), T)
-getaddrinfo(host::AbstractString) = getaddrinfo(String(host), nothing)
 
 function uv_getnameinfocb(req::Ptr{Cvoid}, status::Cint, hostname::Cstring, service::Cstring)
     data = uv_req_data(req)

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -139,7 +139,7 @@ getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host),
 function getaddrinfo(host::AbstractString)
     addrs = getalladdrinfo(String(host))
     if !isempty(addrs)
-        return addrs[1]
+        return addrs[end]
     end
     throw(DNSError(host, UV_EAI_NONAME))
 end

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -139,7 +139,7 @@ getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host),
 function getaddrinfo(host::AbstractString)
     addrs = getalladdrinfo(String(host))
     if !isempty(addrs)
-        return addrs[end]
+        return addrs[begin]
     end
     throw(DNSError(host, UV_EAI_NONAME))
 end

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -257,10 +257,10 @@ end
 end
 
 # test connecting to a named port
-let localhost = getaddrinfo("localhost")
+let localhost = ip"127.0.0.1"
     global randport
     randport, server = listenany(localhost, defaultport)
-    @async connect("localhost", randport)
+    @async connect(localhost, randport)
     s1 = accept(server)
     @test_throws ErrorException("client TCPSocket is not in initialization state") accept(server, s1)
     @test_throws Base._UVError("listen", Base.UV_EADDRINUSE) listen(randport)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -218,6 +218,8 @@ end
 end
 
 @testset "getaddrinfo" begin
+    @test getaddrinfo("127.0.0.1") == ip"127.0.0.1"
+    @test getaddrinfo("::1") == ip"::1"
     let localhost = getnameinfo(ip"127.0.0.1")::String
         @test !isempty(localhost) && localhost != "127.0.0.1"
         @test !isempty(getalladdrinfo(localhost)::Vector{IPAddr})
@@ -227,8 +229,6 @@ end
         catch ex
             isa(ex, Sockets.DNSError) && ex.code == Base.UV_EAI_NONAME && ex.host == localhost
         end
-        @test getaddrinfo("127.0.0.1") == ip"127.0.0.1"
-        @test getaddrinfo("::1") == ip"::1"
     end
     @test_throws Sockets.DNSError getaddrinfo(".invalid")
     @test_throws ArgumentError getaddrinfo("localhost\0") # issue #10994

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -227,6 +227,8 @@ end
         catch ex
             isa(ex, Sockets.DNSError) && ex.code == Base.UV_EAI_NONAME && ex.host == localhost
         end
+        @test getaddrinfo("127.0.0.1") == ip"127.0.0.1"
+        @test getaddrinfo("::1") == ip"::1"
     end
     @test_throws Sockets.DNSError getaddrinfo(".invalid")
     @test_throws ArgumentError getaddrinfo("localhost\0") # issue #10994


### PR DESCRIPTION
# Description

Fixes #36000 .

The following would fail:
``` Julia
julia> using Sockets
julia> Sockets.connect("::1", 8080)
ERROR: DNSError: ::1, unknown node or service (EAI_NONAME)
Stacktrace:
 [1] getaddrinfo at /Users/ssikdar1/julia/usr/share/julia/stdlib/v1.6/Sockets/src/addrinfo.jl:136 [inlined]
 [2] getaddrinfo at /Users/ssikdar1/julia/usr/share/julia/stdlib/v1.6/Sockets/src/addrinfo.jl:139 [inlined]
 [3] connect!(::TCPSocket, ::String, ::Int64) at /Users/ssikdar1/julia/usr/share/julia/stdlib/v1.6/Sockets/src/Sockets.jl:553
 [4] connect at /Users/ssikdar1/julia/usr/share/julia/stdlib/v1.6/Sockets/src/Sockets.jl:559 [inlined]
 [5] connect(::String, ::Int64) at /Users/ssikdar1/julia/usr/share/julia/stdlib/v1.6/Sockets/src/Sockets.jl:545
 [6] top-level scope at REPL[2]:1
```

This is because Sockets.connect would call `ipaddr = getaddrinfo(host)`
Which defined here:

https://github.com/JuliaLang/julia/blob/575701248adc951038b9727e646230737e5b3c91/stdlib/Sockets/src/addrinfo.jl#L139

calls `getaddrinfo(String(host), IPv4)` with an IPv4 type. Since "::1" has no IPv4 type a DNS error is thrown here:
https://github.com/JuliaLang/julia/blob/575701248adc951038b9727e646230737e5b3c91/stdlib/Sockets/src/addrinfo.jl#L129-L137

Similarly `getaddrinfo("::1")` fails while `getaddrinfo("::1", IPv6)` works:
``` Julia
julia> getaddrinfo("::1")
ERROR: DNSError: ::1, unknown node or service (EAI_NONAME)
Stacktrace:
 [1] getaddrinfo at /Users/ssikdar1/julia/usr/share/julia/stdlib/v1.6/Sockets/src/addrinfo.jl:136 [inlined]
 [2] getaddrinfo(::String) at /Users/ssikdar1/julia/usr/share/julia/stdlib/v1.6/Sockets/src/addrinfo.jl:139
 [3] top-level scope at REPL[3]:1

julia> getaddrinfo("::1", IPv6)
ip"::1"
``` 

Change  returns the first entry from getalladdrinfo, otherwise throws a DNS error. 

# Testing

Tests added to `stdlib/Sockets/test/runtests.jl`

Manual testing of `getaddrinfo`

```Julia
julia> using Sockets

julia> getaddrinfo("::1")
ip"::1"

julia> getaddrinfo("127.0.0.1")
ip"127.0.0.1"
```

and after setting up an IPv6 server in python, using `Sockets.connect` to connect to it:
```Julia
julia> Sockets.connect("::1", 8080)
TCPSocket(RawFD(0x00000014) open, 0 bytes waiting)
```


