### PR TITLE
fix `readavailable` for `IOStream` and improve its docstring

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -68,8 +68,13 @@ function bytesavailable end
 """
     readavailable(stream)
 
-Read all available data on the stream, blocking the task only if no data is available. The
-result is a `Vector{UInt8}`.
+Read available buffered data from a stream. Actual I/O is performed only if no
+data has already been buffered. The result is a `Vector{UInt8}`.
+
+!!! warning
+    The amount of data returned is implementation-dependent; for example it can
+depend on the internal choice of buffer size. Other functions such as [`read`](@ref)
+should generally be used instead.
 """
 function readavailable end
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -379,6 +379,10 @@ bytesavailable(s::IOStream) = @_lock_ios s ccall(:jl_nb_available, Int32, (Ptr{C
 function readavailable(s::IOStream)
     lock(s.lock)
     nb = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
+    if nb == 0
+        ccall(:ios_fillbuf, Cssize_t, (Ptr{Cvoid},), s.ios)
+        nb = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
+    end
     a = Vector{UInt8}(undef, nb)
     nr = ccall(:ios_readall, Csize_t, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), s, a, nb)
     if nr != nb

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -120,3 +120,13 @@ end
         @test peek(file) == 0x4c
     end
 end
+
+@testset "issue #36004" begin
+    f = tempname()
+    open(f, "w") do io
+        write(io, "test")
+    end
+    open(f, "r") do io
+        @test length(readavailable(io)) > 0
+    end
+end


### PR DESCRIPTION
fix #36004, fix #16821