### PR TITLE
support contiguous subarrays in isvalid(String, ...)

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -163,7 +163,7 @@ end
 
 ## checking UTF-8 & ACSII validity ##
 
-byte_string_classify(s::Union{String,Vector{UInt8}}) =
+byte_string_classify(s::Union{String,Vector{UInt8},FastContiguousSubArray{UInt8,1,Vector{UInt8}}}) =
     ccall(:u8_isvalid, Int32, (Ptr{UInt8}, Int), s, sizeof(s))
     # 0: neither valid ASCII nor UTF-8
     # 1: valid ASCII

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -169,7 +169,7 @@ byte_string_classify(s::Union{String,Vector{UInt8}}) =
     # 1: valid ASCII
     # 2: valid UTF-8
 
-isvalid(::Type{String}, s::Union{Vector{UInt8},String}) = byte_string_classify(s) ≠ 0
+isvalid(::Type{String}, s::Union{Vector{UInt8},FastContiguousSubArray{UInt8,1,Vector{UInt8}},String}) = byte_string_classify(s) ≠ 0
 isvalid(s::String) = isvalid(String, s)
 
 is_valid_continuation(c) = c & 0xc0 == 0x80

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -47,6 +47,9 @@ true
 julia> isvalid(Char, 0xd799)
 true
 ```
+
+!!! compat "Julia 1.6"
+    Support for subarray values was added in Julia 1.6.
 """
 isvalid(T,value)
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -33,7 +33,8 @@ isvalid(value)
 
 Returns `true` if the given value is valid for that type. Types currently can
 be either `AbstractChar` or `String`. Values for `AbstractChar` can be of type `AbstractChar` or [`UInt32`](@ref).
-Values for `String` can be of that type, or `Vector{UInt8}` or `SubString{String}`.
+Values for `String` can be of that type, `SubString{String}`, `Vector{UInt8}`,
+or a contiguous subarray thereof.
 
 # Examples
 ```jldoctest

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -575,7 +575,9 @@ end
     for (rng, flg) in ((0x00:0x9f, false), (0xa0:0xbf, true), (0xc0:0xff, false))
         for cont in rng
             @test isvalid(String, UInt8[0xe0, cont]) == false
-            @test isvalid(String, UInt8[0xe0, cont, 0x80]) == flg
+            bytes = UInt8[0xe0, cont, 0x80]
+            @test isvalid(String, bytes) == flg
+            @test isvalid(String, @view(bytes[1:end])) == flg # contiguous subarray support
         end
     end
     # Check three-byte sequences


### PR DESCRIPTION
I noticed in JuliaWeb/HTTP.jl#538 that `isvalid(String, x)` supports `x::Vector{UInt8}` but not subarrays thereof.   This PR makes it at least support contiguous subarrays.