### PR TITLE
micro-optimize UUID(::AbstractString)

### DIFF
--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -37,7 +37,7 @@ let
     d = __convert_digit(_c, UInt32(16))
     d >= 16 && throw_malformed_uuid(s)
     u <<= 4
-    u |= d
+    u | d
 end
 
 global UUID

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -30,24 +30,45 @@ end
 
 UInt128(u::UUID) = u.value
 
-let groupings = [1:8; 10:13; 15:18; 20:23; 25:36]
-    global UUID
-    function UUID(s::AbstractString)
-        s = lowercase(s)
-
-        if !occursin(r"^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$", s)
-            throw(ArgumentError("Malformed UUID string: $(repr(s))"))
-        end
-
-        u = UInt128(0)
-        for i in groupings
-            u <<= 4
-            d = s[i] - '0'
-            u |= 0xf & (d - 39*(d > 9))
-        end
-        return UUID(u)
-    end
+let
+@noinline throw_malformed_uuid(s) = throw(ArgumentError("Malformed UUID string: $(repr(s))"))
+@inline function uuid_kernel(s, i, u)
+    _c = UInt32(@inbounds codeunit(s, i))
+    d = __convert_digit(_c, UInt32(16))
+    d >= 16 && throw_malformed_uuid(s)
+    u <<= 4
+    u |= d
 end
+
+global UUID
+function UUID(s::AbstractString)
+    u = UInt128(0)
+    ncodeunits(s) != 36 && throw_malformed_uuid(s)
+    for i in 1:8
+        u = uuid_kernel(s, i, u)
+    end
+    @inbounds codeunit(s, 9) == UInt8('-') || @goto error
+    for i in 10:13
+        u = uuid_kernel(s, i, u)
+    end
+    @inbounds codeunit(s, 14) == UInt8('-') || @goto error
+    for i in 15:18
+        u = uuid_kernel(s, i, u)
+    end
+    @inbounds codeunit(s, 19) == UInt8('-') || @goto error
+    for i in 20:23
+        u = uuid_kernel(s, i, u)
+    end
+    @inbounds codeunit(s, 24) == UInt8('-') || @goto error
+    for i in 25:36
+        u = uuid_kernel(s, i, u)
+    end
+    return Base.UUID(u)
+    @label error
+    throw_malformed_uuid(s)
+end
+end
+
 
 let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
     global string
@@ -55,10 +76,10 @@ let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
         u = u.value
         a = Base.StringVector(36)
         for i in groupings
-            a[i] = hex_chars[1 + u & 0xf]
+            @inbounds a[i] = hex_chars[1 + u & 0xf]
             u >>= 4
         end
-        a[24] = a[19] = a[14] = a[9] = '-'
+        @inbounds a[24] = a[19] = a[14] = a[9] = '-'
         return String(a)
     end
 end

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -62,3 +62,14 @@ u4 = uuid4()
 Random.seed!(Random.GLOBAL_RNG, 10)
 @test u1 != uuid1()
 @test u4 != uuid4()
+
+@test_throws ArgumentError UUID("22b4a8a1ae548-4eeb-9270-60426d66a48e")
+@test_throws ArgumentError UUID("22b4a8a1-e548a4eeb-9270-60426d66a48e")
+@test_throws ArgumentError UUID("22b4a8a1-e548-4eeba9270-60426d66a48e")
+@test_throws ArgumentError UUID("22b4a8a1-e548-4eeb-9270a60426d66a48e")
+str = "22b4a8a1-e548-4eeb-9270-60426d66a48e"
+@test UUID(uppercase(str)) == UUID(str)
+
+for r in rand(UInt128, 10^3)
+    @test UUID(r) == UUID(string(UUID(r)))
+end


### PR DESCRIPTION
I was profiling Pkg and saw some traces pointing to `UUID(::String)`. The current implementations allocates a brand new vector for `lowercase` (which I would guess is almost never needed) and it also does a regex call to check it the format of the string is ok. This speeds it up by a bit.

Setup:

```jl
julia> using UUIDs

julia>  a = uuid4() |> string

julia> uuid_strs = string.(UUID.(rand(UInt128, 10^6)));

julia> uuids = Vector{UUID}(undef, 10^6);
```

Master

``` 
julia> @btime UUID($a);
  319.275 ns (3 allocations: 224 bytes)

julia> @btime $uuids .= UUID.($uuid_strs)
  373.077 ms (3000000 allocations: 213.62 MiB)
```



PR
```
julia> @btime UUID($a);
  27.489 ns (0 allocations: 0 bytes)

julia> @btime $uuids .= UUID.($uuid_strs)
  111.078 ms (0 allocations: 0 bytes)
```