### PR TITLE
BigInt printf fixes

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -942,10 +942,9 @@ function decode_0ct(x::BigInt, digits)
     pt = Base.ndigits0z(x, 8) + 1
     length(digits) < pt+1 && resize!(digits, pt+1)
     neg && (x.size = -x.size)
-    p = convert(Ptr{UInt8}, digits) + 1
-    GMP.MPZ.get_str!(p, 8, x)
+    GMP.MPZ.get_str!(pointer(digits, 2), 8, x)
     neg && (x.size = -x.size)
-    return neg, Int32(pt), Int32(pt)
+    return Int32(pt), Int32(pt), neg
 end
 
 ### decoding functions directly used by printf generated code ###
@@ -1059,13 +1058,15 @@ function ini_dec(x::BigInt, n::Int, digits)
     end
     d = Base.ndigits0z(x)
     if d <= n
-        info = decode_dec(x)
-        d == n && return info
-        p = convert(Ptr{Cvoid}, digits) + info[2]
-        ccall(:memset, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Csize_t), p, '0', n - info[2])
-        return info
+        len,pt,neg = decode_dec(x, digits)
+        if d < n
+            ccall(:memset, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Csize_t), pointer(digits, pt+1), '0', n - pt)
+        end
+        return (len,pt,neg)
+    else
+        _,_,neg = decode_dec(round(BigInt,x/big(10)^(d-n)), digits)
+        return (n, d, neg)
     end
-    return (n, d, decode_dec(round(BigInt,x/big(10)^(d-n)))[3])
 end
 
 

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -39,11 +39,10 @@ for (fmt, val) in (("%i", "42"),
                    ("%20a","            0x2.ap+4"),
                    ("%-20a","0x2.ap+4            "),
                    ("%f", "42.000000"),
-                   ("%g", "42")),
+                   ("%g", "42"),
+                   ("%e", "4.200000e+01")),
      num in (UInt16(42), UInt32(42), UInt64(42), UInt128(42),
               Int16(42), Int32(42), Int64(42), Int128(42), big"42")
-            #big"42" causes stack overflow on %a ; gh #14409
-    num isa BigInt && fmt in ["%a", "%#o", "%g"] && continue
     @test @eval(@sprintf($fmt, $num) == $val)
 end
 


### PR DESCRIPTION
Relative and octal printing used incorrect arguments. Fixes #36031.

Same as ddc65bb898486acd113640aa1af42f7e6a8ec02f which was accidentally pushed to master, and reverted in adf6d521afd125f2de12a3209b342148d78981c2.