### PR TITLE
give more information in StringIndexError

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -133,7 +133,7 @@ julia> isvalid(str, 2)
 false
 
 julia> str[2]
-ERROR: StringIndexError: invalid index [2], valid previous index [1] ('α'), valid next index [3] ('β')
+ERROR: StringIndexError: invalid index [2], valid nearby indices [1]=>'α', [3]=>'β'
 Stacktrace:
 [...]
 ```

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -133,7 +133,7 @@ julia> isvalid(str, 2)
 false
 
 julia> str[2]
-ERROR: StringIndexError("αβγdef", 2)
+ERROR: StringIndexError: invalid index [2], valid previous index [1] ('α'), valid next index [3] ('β')
 Stacktrace:
 [...]
 ```

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -11,6 +11,15 @@ struct StringIndexError <: Exception
 end
 @noinline string_index_err(s::AbstractString, i::Integer) =
     throw(StringIndexError(s, Int(i)))
+function Base.showerror(io::IO, exc::StringIndexError)
+    s = exc.string
+    i = thisind(s, exc.index)
+    print(io, "StringIndexError: ", "invalid index [$(exc.index)], valid previous index [$i] ('$(s[i])')")
+    inext = nextind(s, i)
+    if !(inext > ncodeunits(s))
+        print(io, ", valid next index [$(inext)] ('$(s[inext])')")
+    end
+end
 
 const ByteArray = Union{Vector{UInt8},Vector{Int8}}
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -13,11 +13,15 @@ end
     throw(StringIndexError(s, Int(i)))
 function Base.showerror(io::IO, exc::StringIndexError)
     s = exc.string
-    i = thisind(s, exc.index)
-    print(io, "StringIndexError: ", "invalid index [$(exc.index)], valid previous index [$i] ('$(s[i])')")
-    inext = nextind(s, i)
-    if !(inext > ncodeunits(s))
-        print(io, ", valid next index [$(inext)] ('$(s[inext])')")
+    print(io, "StringIndexError: ", "invalid index [$(exc.index)]")
+    if firstindex(s) <= exc.index <= ncodeunits(s)
+        iprev = thisind(s, exc.index)
+        inext = nextind(s, iprev)
+        if inext <= ncodeunits(s)
+            print(io, ", valid nearby indices [$iprev]=>'$(s[iprev])', [$inext]=>'$(s[inext])'")
+        else
+            print(io, ", valid nearby index [$iprev]=>'$(s[iprev])'")
+        end
     end
 end
 

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -281,12 +281,12 @@ julia> s[1]
 '∀': Unicode U+2200 (category Sm: Symbol, math)
 
 julia> s[2]
-ERROR: StringIndexError: invalid index [2], valid previous index [1] ('∀'), valid next index [4] (' ')
+ERROR: StringIndexError: invalid index [2], valid nearby indices [1]=>'∀', [4]=>' '
 Stacktrace:
 [...]
 
 julia> s[3]
-ERROR: StringIndexError: invalid index [3], valid previous index [1] ('∀'), valid next index [4] (' ')
+ERROR: StringIndexError: invalid index [3], valid nearby indices [1]=>'∀', [4]=>' '
 Stacktrace:
 [...]
 
@@ -306,7 +306,7 @@ julia> s[end-1]
 ' ': ASCII/Unicode U+0020 (category Zs: Separator, space)
 
 julia> s[end-2]
-ERROR: StringIndexError: invalid index [9], valid previous index [7] ('∃'), valid next index [10] (' ')
+ERROR: StringIndexError: invalid index [9], valid nearby indices [7]=>'∃', [10]=>' '
 Stacktrace:
 [...]
 
@@ -326,7 +326,7 @@ julia> s[1:1]
 "∀"
 
 julia> s[1:2]
-ERROR: StringIndexError: invalid index [2], valid previous index [1] ('∀'), valid next index [4] (' ')
+ERROR: StringIndexError: invalid index [2], valid nearby indices [1]=>'∀', [4]=>' '
 Stacktrace:
 [...]
 

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -281,11 +281,12 @@ julia> s[1]
 '∀': Unicode U+2200 (category Sm: Symbol, math)
 
 julia> s[2]
-ERROR: StringIndexError("∀ x ∃ y", 2)
+ERROR: StringIndexError: invalid index [2], valid previous index [1] ('∀'), valid next index [4] (' ')
+Stacktrace:
 [...]
 
 julia> s[3]
-ERROR: StringIndexError("∀ x ∃ y", 3)
+ERROR: StringIndexError: invalid index [3], valid previous index [1] ('∀'), valid next index [4] (' ')
 Stacktrace:
 [...]
 
@@ -305,7 +306,7 @@ julia> s[end-1]
 ' ': ASCII/Unicode U+0020 (category Zs: Separator, space)
 
 julia> s[end-2]
-ERROR: StringIndexError("∀ x ∃ y", 9)
+ERROR: StringIndexError: invalid index [9], valid previous index [7] ('∃'), valid next index [10] (' ')
 Stacktrace:
 [...]
 
@@ -325,7 +326,7 @@ julia> s[1:1]
 "∀"
 
 julia> s[1:2]
-ERROR: StringIndexError("∀ x ∃ y", 2)
+ERROR: StringIndexError: invalid index [2], valid previous index [1] ('∀'), valid next index [4] (' ')
 Stacktrace:
 [...]
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1074,3 +1074,12 @@ let x = SubString("ab", 1, 1)
     @test y === x
     chop("ab") === chop.(["ab"])[1]
 end
+
+@testset "show StringIndexError" begin
+    str = "abcdefghκijklmno"
+    e = StringIndexError(str, 10)
+    @test sprint(showerror, e) == "StringIndexError: invalid index [10], valid previous index [9] ('κ'), valid next index [11] ('i')"
+    str = "κ"
+    e = StringIndexError(str, 2)
+    @test sprint(showerror, e) == "StringIndexError: invalid index [2], valid previous index [1] ('κ')"
+end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1078,8 +1078,8 @@ end
 @testset "show StringIndexError" begin
     str = "abcdefghκijklmno"
     e = StringIndexError(str, 10)
-    @test sprint(showerror, e) == "StringIndexError: invalid index [10], valid previous index [9] ('κ'), valid next index [11] ('i')"
+    @test sprint(showerror, e) == "StringIndexError: invalid index [10], valid nearby indices [9]=>'κ', [11]=>'i'"
     str = "κ"
     e = StringIndexError(str, 2)
-    @test sprint(showerror, e) == "StringIndexError: invalid index [2], valid previous index [1] ('κ')"
+    @test sprint(showerror, e) == "StringIndexError: invalid index [2], valid nearby index [1]=>'κ'"
 end


### PR DESCRIPTION
Before

```jl
julia> str = "abcdefghκijklmno"
"abcdefghκijklmno"

julia> str[10]
ERROR: StringIndexError("abcdefghκijklmno", 10)
Stacktrace:
```

Now

```jl
julia> str = "abcdefghκijklmno"
"abcdefghκijklmno"

julia> str[10]
ERROR: StringIndexError: invalid index [10], valid previous index [9] ('κ'), valid next index [11] ('i')
```