### PR TITLE
Link to "noteworthy differences" early in docs

### DIFF
--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -3,7 +3,7 @@
 Julia installation is straightforward, whether using precompiled binaries or compiling from source.
 Download and install Julia by following the instructions at [https://julialang.org/downloads/](https://julialang.org/downloads/).
 
-If you are coming to Julia from one of the following languages, then you should start by reading the section on noteworthy differences from [Matlab](@ref Noteworthy differences from MATLAB), [R](@ref Noteworthy differences from R), [Python](@ref Noteworthy differences from Python), [C/C++](@ref Noteworthy differences from C/C++) or [Common Lisp](@ref Noteworthy differences from Common Lisp). This will help you avoid some common pitfalls since Julia differs from those languages in many subtle ways.
+If you are coming to Julia from one of the following languages, then you should start by reading the section on noteworthy differences from [MATLAB](@ref Noteworthy-differences-from-MATLAB), [R](@ref Noteworthy-differences-from-R), [Python](@ref Noteworthy-differences-from-Python), [C/C++](@ref Noteworthy-differences-from-C/C) or [Common Lisp](@ref Noteworthy-differences-from-Common-Lisp). This will help you avoid some common pitfalls since Julia differs from those languages in many subtle ways.
 
 The easiest way to learn and experiment with Julia is by starting an interactive session (also
 known as a read-eval-print loop or "REPL") by double-clicking the Julia executable or running

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -3,6 +3,8 @@
 Julia installation is straightforward, whether using precompiled binaries or compiling from source.
 Download and install Julia by following the instructions at [https://julialang.org/downloads/](https://julialang.org/downloads/).
 
+If you are coming to Julia from one of the following languages, then you should start by reading the section on noteworthy differences from [Matlab](@ref Noteworthy differences from MATLAB), [R](@ref Noteworthy differences from R), [Python](@ref Noteworthy differences from Python), [C/C++](@ref Noteworthy differences from C/C++) or [Common Lisp](@ref Noteworthy differences from Common Lisp). This will help you avoid some common pitfalls since Julia differs from those languages in many subtle ways.
+
 The easiest way to learn and experiment with Julia is by starting an interactive session (also
 known as a read-eval-print loop or "REPL") by double-clicking the Julia executable or running
 `julia` from the command line:


### PR DESCRIPTION
It frequently happens that newcomers to Julia are tripped up by some aspect of the language, such as integer overflow, that is not present in their current favorite programming language. The list of noteworthy differences points out many of these pitfalls, so getting more people to read it can reduce user frustration.

[From discourse](https://discourse.julialang.org/t/the-speed-of-light-is-an-integer-why-should-we-care/40108/51?u=per).
