### PR TITLE
Mention how to get the basetype of an enum

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -106,7 +106,8 @@ end
 
 `BaseType`, which defaults to [`Int32`](@ref), must be a primitive subtype of `Integer`.
 Member values can be converted between the enum type and `BaseType`. `read` and `write`
-perform these conversions automatically.
+perform these conversions automatically. In case, the default `BaseType` is not used,
+the `Base.Enums.basetype(EnumName)` function returns the `BaseType` for `EnumName`.
 
 To list all the instances of an enum use `instances`, e.g.
 

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -106,8 +106,8 @@ end
 
 `BaseType`, which defaults to [`Int32`](@ref), must be a primitive subtype of `Integer`.
 Member values can be converted between the enum type and `BaseType`. `read` and `write`
-perform these conversions automatically. In case, the default `BaseType` is not used,
-the `Base.Enums.basetype(EnumName)` function returns the `BaseType` for `EnumName`.
+perform these conversions automatically. In case the enum is created with a non-default
+`BaseType`, `Integer(value1)` will return the integer `value1` with the type `BaseType`.
 
 To list all the instances of an enum use `instances`, e.g.
 


### PR DESCRIPTION
I feel this is sufficient to address #28778, since it is a non-standard case. The type conversion with Integer() is not specific to enums - and not necessary.