### PR TITLE
allow constant propagation to break call cycles in inference

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -129,7 +129,8 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
     end
     # try constant propagation if only 1 method is inferred to non-Bottom
     # this is in preparation for inlining, or improving the return result
-    if nonbot > 0 && seen == napplicable && !edgecycle && isa(rettype, Type) && InferenceParams(interp).ipo_constant_propagation
+    is_unused = call_result_unused(sv)
+    if nonbot > 0 && seen == napplicable && (!edgecycle || !is_unused) && isa(rettype, Type) && InferenceParams(interp).ipo_constant_propagation
         # if there's a possibility we could constant-propagate a better result
         # (hopefully without doing too much work), try to do that now
         # TODO: it feels like this could be better integrated into abstract_call_method / typeinf_edge
@@ -139,7 +140,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             rettype = const_rettype
         end
     end
-    if call_result_unused(sv) && !(rettype === Bottom)
+    if is_unused && !(rettype === Bottom)
         # We're mainly only here because the optimizer might want this code,
         # but we ourselves locally don't typically care about it locally
         # (beyond checking if it always throws).
@@ -268,7 +269,8 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter, @nosp
         typeinf(interp, frame) || return Any
     end
     result = inf_result.result
-    isa(result, InferenceState) && return Any # TODO: unexpected, is this recursive constant inference?
+    # if constant inference hits a cycle, just bail out
+    isa(result, InferenceState) && return Any
     add_backedge!(inf_result.linfo, sv)
     return result
 end


### PR DESCRIPTION
This fixes the inference issue encountered by #35904. Currently we avoid constant propagation if there are cycles, but it appears to work if we just try constant prop and only use the result if it ends up breaking the cycle. It's possible something more might be needed here though.