### PR TITLE
Rename AddrSpacePtr

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -144,9 +144,13 @@ setindex!(b::RefArray, x) = (b.x[b.i] = x; b)
 ###
 
 """
-    AddrSpacePtr{T, AS}
+    LLVMPtr{T, AS}
 
-When passed as a `ccall` argument with the `llvmcall` calling convention, an `AddrSpacePtr` will be converted to an LLVM pointer type with the correct address space.
-This type is mainly used to ensure Julia's codegen uses the correct address space when calling LLVM intrinsics.
+A pointer type that more closely resembles LLVM semantics: It includes the pointer address
+space, and will be passed as an actual pointer instead of an integer.
+
+This type is mainly used to interface with code that has strict requirements about pointers,
+e.g., intrinsics that are selected based on the address space, or back-ends that require
+pointers to be identifiable by their types.
 """
-Core.AddrSpacePtr
+Core.LLVMPtr

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1570,7 +1570,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("CodeInfo", (jl_value_t*)jl_code_info_type);
     add_builtin("Ref", (jl_value_t*)jl_ref_type);
     add_builtin("Ptr", (jl_value_t*)jl_pointer_type);
-    add_builtin("AddrSpacePtr", (jl_value_t*)jl_addrspace_pointer_type);
+    add_builtin("LLVMPtr", (jl_value_t*)jl_llvmpointer_type);
     add_builtin("Task", (jl_value_t*)jl_task_type);
 
     add_builtin("AbstractArray", (jl_value_t*)jl_abstractarray_type);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1185,7 +1185,7 @@ std::string generate_func_sig(const char *fname)
             t = T_pint8;
             isboxed = false;
         }
-        else if (llvmcall && jl_is_addrspace_ptr_type(tti)) {
+        else if (llvmcall && jl_is_llvmpointer_type(tti)) {
             t = bitstype_to_llvm(tti, true);
             tti = (jl_value_t*)jl_voidpointer_type;
             isboxed = false;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -590,7 +590,7 @@ static Type *bitstype_to_llvm(jl_value_t *bt, bool llvmcall = false)
         return T_float32;
     if (bt == (jl_value_t*)jl_float64_type)
         return T_float64;
-    if (jl_is_addrspace_ptr_type(bt)) {
+    if (jl_is_llvmpointer_type(bt)) {
         jl_value_t *as_param = jl_tparam1(bt);
         int as;
         if (jl_is_int32(as_param))

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -591,16 +591,14 @@ static Type *bitstype_to_llvm(jl_value_t *bt, bool llvmcall = false)
     if (bt == (jl_value_t*)jl_float64_type)
         return T_float64;
     if (jl_is_addrspace_ptr_type(bt)) {
-        int as = 0;
-
-        jl_datatype_t *typ = (jl_datatype_t*)bt;
-        jl_value_t *as_param = jl_svecref(typ->parameters, 1);
-
+        jl_value_t *as_param = jl_tparam1(bt);
+        int as;
         if (jl_is_int32(as_param))
             as = jl_unbox_int32(as_param);
         else if (jl_is_int64(as_param))
             as = jl_unbox_int64(as_param);
-
+        else
+            jl_error("invalid pointer address space");
         return PointerType::get(T_int8, as);
     }
     int nb = jl_datatype_size(bt);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -119,8 +119,8 @@ jl_datatype_t *jl_lineinfonode_type;
 jl_unionall_t *jl_ref_type;
 jl_unionall_t *jl_pointer_type;
 jl_typename_t *jl_pointer_typename;
-jl_unionall_t *jl_addrspace_pointer_type;
-jl_typename_t *jl_addrspace_pointer_typename;
+jl_unionall_t *jl_llvmpointer_type;
+jl_typename_t *jl_llvmpointer_typename;
 jl_datatype_t *jl_void_type; // deprecated
 jl_datatype_t *jl_nothing_type;
 jl_datatype_t *jl_voidpointer_type;
@@ -2238,14 +2238,14 @@ void jl_init_types(void) JL_GC_DISABLED
                              sizeof(void*)*8)->name->wrapper;
     jl_pointer_typename = ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_pointer_type))->name;
 
-    // AddrSpacePtr{T, AS} where {T, AS}
+    // LLVMPtr{T, AS} where {T, AS}
     tv = jl_svec2(tvar("T"), tvar("AS"));
     jl_svec_t *tv_base = jl_svec1(tvar("T"));
-    jl_addrspace_pointer_type = (jl_unionall_t*)
-        jl_new_primitivetype((jl_value_t*)jl_symbol("AddrSpacePtr"), core,
+    jl_llvmpointer_type = (jl_unionall_t*)
+        jl_new_primitivetype((jl_value_t*)jl_symbol("LLVMPtr"), core,
                              (jl_datatype_t*)jl_apply_type((jl_value_t*)jl_ref_type, jl_svec_data(tv_base), 1), tv,
                              sizeof(void*)*8)->name->wrapper;
-    jl_addrspace_pointer_typename = ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_addrspace_pointer_type))->name;
+    jl_llvmpointer_typename = ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_llvmpointer_type))->name;
 
     // Type{T} where T<:Tuple
     tttvar = jl_new_typevar(jl_symbol("T"),

--- a/src/julia.h
+++ b/src/julia.h
@@ -636,10 +636,10 @@ extern JL_DLLEXPORT jl_datatype_t *jl_signed_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_voidpointer_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_uint8pointer_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_pointer_type JL_GLOBALLY_ROOTED;
-extern JL_DLLEXPORT jl_unionall_t *jl_addrspace_pointer_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_unionall_t *jl_llvmpointer_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_ref_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_pointer_typename JL_GLOBALLY_ROOTED;
-extern JL_DLLEXPORT jl_typename_t *jl_addrspace_pointer_typename JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_typename_t *jl_llvmpointer_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_namedtuple_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_namedtuple_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_task_type JL_GLOBALLY_ROOTED;
@@ -1090,6 +1090,7 @@ static inline int jl_is_layout_opaque(const jl_datatype_layout_t *l) JL_NOTSAFEP
 #define jl_is_cpointer(v)    jl_is_cpointer_type(jl_typeof(v))
 #define jl_is_pointer(v)     jl_is_cpointer_type(jl_typeof(v))
 #define jl_is_uint8pointer(v)jl_typeis(v,jl_uint8pointer_type)
+#define jl_is_llvmpointer(v) jl_typeis(v,jl_llvmpointer_type)
 #define jl_is_intrinsic(v)   jl_typeis(v,jl_intrinsic_type)
 #define jl_array_isbitsunion(a) (!(((jl_array_t*)(a))->flags.ptrarray) && jl_is_uniontype(jl_tparam0(jl_typeof(a))))
 
@@ -1154,10 +1155,10 @@ STATIC_INLINE int jl_is_cpointer_type(jl_value_t *t) JL_NOTSAFEPOINT
             ((jl_datatype_t*)(t))->name == ((jl_datatype_t*)jl_pointer_type->body)->name);
 }
 
-STATIC_INLINE int jl_is_addrspace_ptr_type(jl_value_t *t) JL_NOTSAFEPOINT
+STATIC_INLINE int jl_is_llvmpointer_type(jl_value_t *t) JL_NOTSAFEPOINT
 {
     return (jl_is_datatype(t) &&
-            ((jl_datatype_t*)(t))->name == jl_addrspace_pointer_typename);
+            ((jl_datatype_t*)(t))->name == jl_llvmpointer_typename);
 }
 
 STATIC_INLINE int jl_is_abstract_ref_type(jl_value_t *t) JL_NOTSAFEPOINT

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -41,7 +41,7 @@ static void *const _tags[] = {
          &jl_linenumbernode_type, &jl_lineinfonode_type,
          &jl_gotonode_type, &jl_quotenode_type,
          &jl_pinode_type, &jl_phinode_type, &jl_phicnode_type, &jl_upsilonnode_type,
-         &jl_type_type, &jl_bottom_type, &jl_ref_type, &jl_pointer_type, &jl_addrspace_pointer_type,
+         &jl_type_type, &jl_bottom_type, &jl_ref_type, &jl_pointer_type, &jl_llvmpointer_type,
          &jl_vararg_type, &jl_abstractarray_type,
          &jl_densearray_type, &jl_nothing_type, &jl_function_type, &jl_typeofbottom_type,
          &jl_unionall_type, &jl_typename_type, &jl_builtin_type, &jl_code_info_type,
@@ -57,7 +57,7 @@ static void *const _tags[] = {
          &jl_float16_type, &jl_float32_type, &jl_float64_type, &jl_floatingpoint_type,
          &jl_number_type, &jl_signed_type,
          // special typenames
-         &jl_tuple_typename, &jl_pointer_typename, &jl_addrspace_pointer_typename, &jl_array_typename, &jl_type_typename,
+         &jl_tuple_typename, &jl_pointer_typename, &jl_llvmpointer_typename, &jl_array_typename, &jl_type_typename,
          &jl_vararg_typename, &jl_namedtuple_typename,
          &jl_vecelement_typename,
          // special exceptions

--- a/test/llvmpasses/llvmcall.jl
+++ b/test/llvmpasses/llvmcall.jl
@@ -23,7 +23,7 @@ emit(foo, NTuple{2, Float16})
 emit(foo, NTuple{2, VecElement{Float16}})
 
 # CHECK: call i8 addrspace(3)* @foo(i8 addrspace(3)* %{{[0-9]+}})
-emit(foo, Core.AddrSpacePtr{Float32, 3})
+emit(foo, Core.LLVMPtr{Float32, 3})
 
 # CHECK: call { i32, i32 } @foo({ i32, i32 } %{{[0-9]+}})
 emit(foo, Foo)


### PR DESCRIPTION
This PR started as a rework of AddrSpacePtr, [adding support for it to `pointerset` and `pointerref`](https://github.com/JuliaLang/julia/commit/60cddd7e82523f17ace4071065521a212a897da4), but while doing so I realized that (1) it isn't a good fit for Base (e.g. what to do at run-time with non-generic address spaces), and (2) AddrSpacePtr doesn't accurately reflect what this type does: These pointers are lowered to IR in a way that more closely resembles the underlying LLVM pointers:

```julia
julia> foo(x) = x
foo (generic function with 1 method)

julia> @code_llvm foo(C_NULL)

;  @ REPL[1]:1 within `foo'
define i64 @julia_foo_726(i64) {
top:
  ret i64 %0
}

julia> @code_llvm foo(reinterpret(Core.LLVMPtr{Nothing,0}, C_NULL))

;  @ REPL[1]:1 within `foo'
define i8* @julia_foo_817(i8*) {
top:
  ret i8* %0
}
```

i.e. more than just adding address space information, so it seems better to call it `LLVMPtr`.

I also considered [lowering them to non-opaque types](https://github.com/JuliaLang/julia/commit/7f67ef0997d1be13df4a44d5ff69910fdc63a545), i.e. `i64*` in the above example, but LLVM itself seems to be moving away from that it seems better not do. (Linked changes don't fully work)

PR also adds an ugly error when using invalid address space typevars -- no way to cleanly emit an error from there.

Open question: [add support for `pointerset`/`pointerref` with `LLVMPtr`s](https://github.com/JuliaLang/julia/commit/60cddd7e82523f17ace4071065521a212a897da4), or keep these intrinsics in e.g. LLVM.jl? They currently live in CUDA.jl: https://github.com/JuliaGPU/CUDA.jl/blob/3af3e3104cc7baae2408598220395eff078e3f28/src/device/pointer.jl#L114-L180

Marked for backport so that we don't have the old name in any release.

cc @thomasfaingnaert