### PR TITLE
Accessors for current_task, safe_restore in TLS

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -2078,6 +2078,11 @@ typedef struct {
 #define jl_current_task (jl_get_ptls_states()->current_task)
 #define jl_root_task (jl_get_ptls_states()->root_task)
 
+JL_DLLEXPORT jl_value_t *jl_get_current_task(void);
+
+JL_DLLEXPORT jl_jmp_buf *jl_get_safe_restore(void);
+JL_DLLEXPORT void jl_set_safe_restore(jl_jmp_buf *);
+
 // codegen interface ----------------------------------------------------------
 // The root propagation here doesn't have to be literal, but callers should
 // ensure that the return value outlives the MethodInstance

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1021,7 +1021,6 @@ JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);
 
 JL_DLLEXPORT uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v) JL_NOTSAFEPOINT;
-JL_DLLEXPORT jl_value_t *jl_get_current_task(void);
 JL_DLLEXPORT void jl_set_next_task(jl_task_t *task);
 
 // -- synchronization utilities -- //

--- a/src/task.c
+++ b/src/task.c
@@ -612,6 +612,18 @@ JL_DLLEXPORT jl_value_t *jl_get_current_task(void)
     return (jl_value_t*)ptls->current_task;
 }
 
+JL_DLLEXPORT jl_jmp_buf *jl_get_safe_restore(void)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    return (jl_value_t*)ptls->safe_restore;
+}
+
+JL_DLLEXPORT void jl_set_safe_restore(jl_jmp_buf *sr)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    ptls->safe_restore = sr;
+}
+
 #ifdef JL_HAVE_ASYNCIFY
 JL_DLLEXPORT jl_ucontext_t *task_ctx_ptr(jl_task_t *t)
 {


### PR DESCRIPTION
In code which may be compiled against one Julia version but then gets loaded
in another (e.g. due to an update), it is problematic to directly access
members of jl_ptls_t, as this structure frequently changes between Julia
versions

The accessor function `jl_get_current_task` and `jl_get_root_task` avoid this.

Note that macros `jl_current_task` and `jl_root_task` exist, but since those
are compiled into the code which includes `julia.h`, they do not deal with
the situation described above.

No alternatives seem to exist for `jl_get_safe_restore` and `jl_set_safe_restore`.

Motivation: the integration of [GAP](https://www.gap-system.org) with Julia by changing GAP to use the Julia GC so far works quite well (see also [GAP.jl](https://github.com/oscar-system/GAP.jl)) but unfortunately GAP has to be recompiled when the Julia version changes. This is because GAP kernel code expects the GC to perform stack scanning; and for that it needs to know whether the current task is the root task, and also to catch hard errors (segfaults) triggered by reading beyond the bounds of a stack into a guard page. (Note that we try very hard to *not* run into this, *but* for the main thread, this apparently cannot be avoided 100%). To cope with this, we need to recompile GAP against every new Julia version; unfortunately an upgrade to Julia does not necessarily trigger updates to installed packages, so this is trick to get right. See also https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/511

A lot of this could be sidestepped if were able to make a `GAP_jll`. Alas, there are several stumbling stones... This PR tries to remove several of them.  We need ...
- `safe_restore` to catch exceptions caused by access to guard pages;
- the `root_task` to check whether the current task is the root task (so an API to test whether a given task is the root task, a la `jl_is_roottask(task *t)` or even `jl_is_currenttask_root` or so would be sufficient to our needs; 
- the `current_task`so that we can e.g. call `jl_task_stack_buffer` on it.

I am completely open to changes here; e.g. better names, better places where to put the new code, etc.; perhaps you also have alternate ideas how to structure this.

If this ever gets merged (after revisions etc.), can I request that this be backported to 1.5? Then we'd only have to make two GAP_jll: one for Julia 1.3 and 1.4 (no TLS layout between them), and one for 1.5+. (that said, wI'll survive if it doesn't get into 1.5 anymore, of course)


If there are any questions, @rbehrends and me will try our best to address them.