### PR TITLE
Add docstring for keys(::AbstractArray)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -98,6 +98,16 @@ axes1(iter) = OneTo(length(iter))
 unsafe_indices(A) = axes(A)
 unsafe_indices(r::AbstractRange) = (OneTo(unsafe_length(r)),) # Ranges use checked_sub for size
 
+"""
+    keys(a::AbstractArray)
+
+Return the tuple of valid indices for array `a`. This is equivalent to
+[`LinearIndices(a)`](@ref) for vectors, and to [`CartesianIndices(axes(a))`](@ref)
+for higher-dimensional arrays.
+
+This may not return the most efficient indices type to iterate over `a`:
+use [`eachindex`](@ref) instead for maximum performance.
+"""
 keys(a::AbstractArray) = CartesianIndices(axes(a))
 keys(a::AbstractVector) = LinearIndices(a)
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -101,12 +101,15 @@ unsafe_indices(r::AbstractRange) = (OneTo(unsafe_length(r)),) # Ranges use check
 """
     keys(a::AbstractArray)
 
-Return the tuple of valid indices for array `a`. This is equivalent to
-[`LinearIndices(a)`](@ref) for vectors, and to [`CartesianIndices(axes(a))`](@ref)
-for higher-dimensional arrays.
+Return an efficient array describing all valid indices for `a` arranged in the shape of `a` itself.
 
-This may not return the most efficient indices type to iterate over `a`:
-use [`eachindex`](@ref) instead for maximum performance.
+They keys of 1-dimensional arrays (vectors) are integers, whereas all other N-dimensional
+arrays use [`CartesianIndex`](@ref) to describe their locations.  Often the special array
+types [`LinearIndices`](@ref) and [`CartesianIndices`](@ref) are used to efficiently
+represent these arrays of integers and `CartesianIndex`es, respectively.
+
+Note that the `keys` of an array might not be the most efficient index type; for maximum
+performance use  [`eachindex`](@ref) instead.
 """
 keys(a::AbstractArray) = CartesianIndices(axes(a))
 keys(a::AbstractVector) = LinearIndices(a)

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -51,6 +51,7 @@ Base.size
 Base.axes(::Any)
 Base.axes(::AbstractArray, ::Any)
 Base.length(::AbstractArray)
+Base.keys(::AbstractArray)
 Base.eachindex
 Base.IndexStyle
 Base.IndexLinear


### PR DESCRIPTION
This is helpful for users, and it matters because some Base functions rely on `keys(::AbstractArray)` returning a collection of integer ranges (e.g. `hash`).

Cc: @bkamins 