### PR TITLE
Fix equality for one-element ranges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -741,14 +741,29 @@ show(io::IO, r::AbstractRange) = print(io, repr(first(r)), ':', repr(step(r)), '
 show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
 show(io::IO, r::OneTo) = print(io, "Base.OneTo(", r.stop, ")")
 
-==(r::T, s::T) where {T<:AbstractRange} =
-    (isempty(r) & isempty(s)) | ((first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s)))
-==(r::OrdinalRange, s::OrdinalRange) =
-    (isempty(r) & isempty(s)) | ((first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s)))
+function ==(r::T, s::T) where {T<:AbstractRange}
+    isempty(r) && return isempty(s)
+    _has_length_one(r) && return _has_length_one(s) & (first(r) == first(s))
+    (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))
+end
+
+function ==(r::OrdinalRange, s::OrdinalRange)
+    isempty(r) && return isempty(s)
+    _has_length_one(r) && return _has_length_one(s) & (first(r) == first(s))
+    (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))
+end
+
 ==(r::T, s::T) where {T<:Union{StepRangeLen,LinRange}} =
     (isempty(r) & isempty(s)) | ((first(r) == first(s)) & (length(r) == length(s)) & (last(r) == last(s)))
-==(r::Union{StepRange{T},StepRangeLen{T,T}}, s::Union{StepRange{T},StepRangeLen{T,T}}) where {T} =
-    (isempty(r) & isempty(s)) | ((first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s)))
+
+function ==(r::Union{StepRange{T},StepRangeLen{T,T}}, s::Union{StepRange{T},StepRangeLen{T,T}}) where {T}
+    isempty(r) && return isempty(s)
+    _has_length_one(r) && return _has_length_one(s) & (first(r) == first(s))
+    (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))
+end
+
+_has_length_one(r::OrdinalRange) = first(r) == last(r)
+_has_length_one(r::AbstractRange) = isone(length(r))
 
 function ==(r::AbstractRange, s::AbstractRange)
     lr = length(r)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -819,7 +819,9 @@ end
                        0.0:0.1:1.0, map(Float32,0.0:0.1:1.0),map(Float32,LinRange(0.0, 1.0, 11)),
                        1.0:eps():1.0 .+ 10eps(), 9007199254740990.:1.0:9007199254740994,
                        range(0, stop=1, length=20), map(Float32, range(0, stop=1, length=20)),
-                       3:2, 5:-2:7, range(0.0, step=2.0, length=0), 3//2:3//2:0//1, LinRange(2,3,0)]
+                       3:2, 5:-2:7, range(0.0, step=2.0, length=0), 3//2:3//2:0//1, LinRange(2,3,0),
+                       Base.OneTo(1), 1:1, 1:-3:1, 1//1:1//3:1//1, range(1.0, step=2.5, length=1),
+                       LinRange(1,1,1), LinRange(1,1,2)]
     for r in Rs
         local r
         ar = Vector(r)


### PR DESCRIPTION
#32348 made zero-element ranges compare equal, but some types of *one-element* ranges do still not compare equal if their `step` is different (cf. https://github.com/JuliaLang/julia/issues/29421#issuecomment-635838603, thanks to @ti-s for pointing this out). This PR fixes that.

As discussed in #29421, this should be backported to 1.5. Should this be mentioned in the NEWS.md/HISTORY.md item for #32348?