### PR TITLE
skip `Union{}` arguments to gc_preserve in codegen

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3820,7 +3820,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
         std::vector<Value*> vals;
         for (size_t i = 0; i < nargs; ++i) {
             const jl_cgval_t &ai = argv[i];
-            if (ai.constant)
+            if (ai.constant || ai.typ == jl_bottom_type)
                 continue;
             if (ai.isboxed) {
                 vals.push_back(ai.Vboxed);


### PR DESCRIPTION
Under some experimental changes to the compiler I sometimes see an assertion failure due to hitting this case. It may very well be that we're giving codegen invalid IR in those cases (I haven't been able to construct a test case that fails on master), but this change seems valid to me anyway.