### PR TITLE
Add Base.Experimental.ReservedStyle: Allow constructing Broadcasted of dictionaries and named tuples

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1282,7 +1282,7 @@ struct ReservedCollection{T}
     value::T
 end
 
-get(r::ReservedCollection) = r.value
+Base.get(r::ReservedCollection) = r.value
 
 broadcastable(x::Union{AbstractDict,NamedTuple}) = ReservedCollection(x)
 BroadcastStyle(::Type{<:ReservedCollection}) = ReservedStyle()

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1300,6 +1300,7 @@ julia> aspairs.(tuple.(Dict(:a => 1), Dict(:b => 2)))
 struct ReservedStyle <: BroadcastStyle end
 
 BroadcastStyle(s::ReservedStyle, ::BroadcastStyle) = s
+BroadcastStyle(::ReservedStyle, s::Unknown) = s
 instantiate(bc::Broadcasted{ReservedStyle}) = bc
 
 copy(::Broadcasted{ReservedStyle}) =

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1303,11 +1303,12 @@ BroadcastStyle(s::ReservedStyle, ::BroadcastStyle) = s
 BroadcastStyle(::ReservedStyle, s::Unknown) = s
 instantiate(bc::Broadcasted{ReservedStyle}) = bc
 
-copy(::Broadcasted{ReservedStyle}) =
+_reserved_style_error() =
     throw(ArgumentError("broadcasting over dictionaries and `NamedTuple`s is reserved"))
 
-materialize!(_, ::Broadcasted{ReservedStyle}) =
-    throw(ArgumentError("broadcasting over dictionaries and `NamedTuple`s is reserved"))
+copy(::Broadcasted{ReservedStyle}) = _reserved_style_error()
+copyto!(_, ::Broadcasted{ReservedStyle}) = _reserved_style_error()
+copyto!(::AbstractArray, ::Broadcasted{ReservedStyle}) = _reserved_style_error()
 
 BroadcastStyle(::Type{<:AbstractDict}) = ReservedStyle()
 BroadcastStyle(::Type{<:NamedTuple}) = ReservedStyle()

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1283,6 +1283,8 @@ struct ReservedCollection{T}
 end
 
 Base.get(r::ReservedCollection) = r.value
+axes(::ReservedCollection) = _reserved_style_error()
+Base.ndims(::Type{<:ReservedCollection}) = _reserved_style_error()
 
 broadcastable(x::Union{AbstractDict,NamedTuple}) = ReservedCollection(x)
 BroadcastStyle(::Type{<:ReservedCollection}) = ReservedStyle()

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -677,7 +677,7 @@ Base.RefValue{String}("hello")
 """
 broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex,Pair}) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
-broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted,AbstractDict, NamedTuple}) = x
+broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables
 broadcastable(x) = collect(x)
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1300,7 +1300,7 @@ julia> aspairs.(tuple.(Dict(:a => 1), Dict(:b => 2)))
 struct ReservedStyle <: BroadcastStyle end
 
 BroadcastStyle(s::ReservedStyle, ::BroadcastStyle) = s
-BroadcastStyle(::ReservedStyle, s::Unknown) = s
+BroadcastStyle(s::ReservedStyle, ::Unknown) = s
 instantiate(bc::Broadcasted{ReservedStyle}) = bc
 
 _reserved_style_error() =

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1266,40 +1266,6 @@ end
 
 ## Reserved broadcasting
 
-"""
-    Experimental.ReservedStyle
-
-`ReservedStyle` is a broadcasting style for collections without an
-implementation of broadcasting.  This is currently used for
-dictionaries and `NamedTuple`s.
-
-These collections are wrapped in [`ReservedCollection`](@ref) and
-stored in `args` property of `Broadcasted`, to avoid accidentally used
-in broadcasting implementations that are not aware of `ReservedStyle`.
-The dictionaries and `NamedTuple`s wrapped in `ReservedCollection` can
-be unwrapped by `get(::ReservedCollection)`.
-
-!!! warning
-    A different broadcast style may be assigned to the collections with
-    `ReservedStyle` in the future.
-
-# Examples
-```jldoctest
-julia> using Base.Experimental: ReservedStyle, ReservedCollection
-       using Base.Broadcast: Broadcasted, broadcasted
-
-julia> function aspairs end;
-
-julia> function Broadcast.broadcasted(::typeof(aspairs), bc::Broadcasted{<:ReservedStyle})
-           args = map(a -> a isa ReservedCollection ? get(a) : a , bc.args)
-           broadcasted(bc.f, collect.(pairs.(args))...)
-       end;
-
-julia> aspairs.(tuple.(Dict(:a => 1), Dict(:b => 2)))
-1-element Array{Tuple{Pair{Symbol,Int64},Pair{Symbol,Int64}},1}:
- (:a => 1, :b => 2)
-```
-"""
 struct ReservedStyle <: BroadcastStyle end
 
 BroadcastStyle(s::ReservedStyle, ::BroadcastStyle) = s
@@ -1312,15 +1278,6 @@ _reserved_style_error() =
 copy(::Broadcasted{ReservedStyle}) = _reserved_style_error()
 materialize!(::ReservedStyle, _, ::Broadcasted{ReservedStyle}) = _reserved_style_error()
 
-"""
-    Experimental.ReservedCollection(collection)
-
-`ReservedCollection` wraps a `collection` that does not support
-broadcasting.  A custom broadcasting implementations can obtain
-wrapped `collection` by `get(::ReservedCollection)`.
-
-See also [`ReservedStyle`](@ref).
-"""
 struct ReservedCollection{T}
     value::T
 end

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1307,8 +1307,7 @@ _reserved_style_error() =
     throw(ArgumentError("broadcasting over dictionaries and `NamedTuple`s is reserved"))
 
 copy(::Broadcasted{ReservedStyle}) = _reserved_style_error()
-copyto!(_, ::Broadcasted{ReservedStyle}) = _reserved_style_error()
-copyto!(::AbstractArray, ::Broadcasted{ReservedStyle}) = _reserved_style_error()
+materialize!(::ReservedStyle, _, ::Broadcasted{ReservedStyle}) = _reserved_style_error()
 
 BroadcastStyle(::Type{<:AbstractDict}) = ReservedStyle()
 BroadcastStyle(::Type{<:NamedTuple}) = ReservedStyle()

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -11,8 +11,9 @@ module Experimental
 
 using Base: Threads, sync_varname
 
-# Not using `using` so that tab completion shows `ReservedStyle`:
+# Not using `using` so that tab completion shows them:
 const ReservedStyle = Base.Broadcast.ReservedStyle
+const ReservedCollection = Base.Broadcast.ReservedCollection
 
 """
     Const(A::Array)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -11,10 +11,6 @@ module Experimental
 
 using Base: Threads, sync_varname
 
-# Not using `using` so that tab completion shows them:
-const ReservedStyle = Base.Broadcast.ReservedStyle
-const ReservedCollection = Base.Broadcast.ReservedCollection
-
 """
     Const(A::Array)
 
@@ -215,5 +211,52 @@ function show_error_hints(io, ex, args...)
         end
     end
 end
+
+"""
+    Experimental.ReservedStyle
+
+`ReservedStyle` is a broadcasting style for collections without an
+implementation of broadcasting.  This is currently used for
+dictionaries and `NamedTuple`s.
+
+These collections are wrapped in [`ReservedCollection`](@ref) and
+stored in `args` property of `Broadcasted`, to avoid accidentally used
+in broadcasting implementations that are not aware of `ReservedStyle`.
+The dictionaries and `NamedTuple`s wrapped in `ReservedCollection` can
+be unwrapped by `get(::ReservedCollection)`.
+
+!!! warning
+    A different broadcast style may be assigned to the collections with
+    `ReservedStyle` in the future.
+
+# Examples
+```jldoctest
+julia> using Base.Experimental: ReservedStyle, ReservedCollection
+       using Base.Broadcast: Broadcasted, broadcasted
+
+julia> function aspairs end;
+
+julia> function Broadcast.broadcasted(::typeof(aspairs), bc::Broadcasted{<:ReservedStyle})
+           args = map(a -> a isa ReservedCollection ? get(a) : a , bc.args)
+           broadcasted(bc.f, collect.(pairs.(args))...)
+       end;
+
+julia> aspairs.(tuple.(Dict(:a => 1), Dict(:b => 2)))
+1-element Array{Tuple{Pair{Symbol,Int64},Pair{Symbol,Int64}},1}:
+ (:a => 1, :b => 2)
+```
+"""
+const ReservedStyle = Base.Broadcast.ReservedStyle
+
+"""
+    Experimental.ReservedCollection(collection)
+
+`ReservedCollection` wraps a `collection` that does not support
+broadcasting.  A custom broadcasting implementations can obtain
+wrapped `collection` by `get(::ReservedCollection)`.
+
+See also [`ReservedStyle`](@ref).
+"""
+const ReservedCollection = Base.Broadcast.ReservedCollection
 
 end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -11,6 +11,9 @@ module Experimental
 
 using Base: Threads, sync_varname
 
+# Not using `using` so that tab completion shows `ReservedStyle`:
+const ReservedStyle = Base.Broadcast.ReservedStyle
+
 """
     Const(A::Array)
 

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -80,6 +80,7 @@ Base.Broadcast.AbstractArrayStyle
 Base.Broadcast.ArrayStyle
 Base.Broadcast.DefaultArrayStyle
 Base.Experimental.ReservedStyle
+Base.Experimental.ReservedCollection
 Base.Broadcast.broadcastable
 Base.Broadcast.combine_axes
 Base.Broadcast.combine_styles

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -79,6 +79,7 @@ Base.BroadcastStyle
 Base.Broadcast.AbstractArrayStyle
 Base.Broadcast.ArrayStyle
 Base.Broadcast.DefaultArrayStyle
+Base.Experimental.ReservedStyle
 Base.Broadcast.broadcastable
 Base.Broadcast.combine_axes
 Base.Broadcast.combine_styles

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test, Random
-using Base.Broadcast: BroadcastStyle, ReservedStyle, broadcasted
+using Base.Broadcast: BroadcastStyle, ReservedStyle, ReservedCollection, broadcasted
 
 module TestBroadcastInternals
 
@@ -617,10 +617,9 @@ end
 
 @testset "ReservedStyle" begin
     dict = Dict()
-    @test Broadcast.broadcastable(dict) === dict
+    @test Broadcast.broadcastable(dict) === ReservedCollection(dict)
     nt = (a=1,)
-    @test Broadcast.broadcastable(nt) === nt
-    @test Broadcast.broadcastable(nt) === nt
+    @test Broadcast.broadcastable(nt) === ReservedCollection(nt)
     @test BroadcastStyle(typeof(broadcasted(+, dict))) isa ReservedStyle
     @test BroadcastStyle(typeof(broadcasted(+, nt))) isa ReservedStyle
     @test BroadcastStyle(typeof(broadcasted(+, dict, []))) isa ReservedStyle

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -618,8 +618,10 @@ end
 @testset "ReservedStyle" begin
     dict = Dict()
     @test Broadcast.broadcastable(dict) === ReservedCollection(dict)
+    @test get(Broadcast.broadcastable(dict)) === dict
     nt = (a=1,)
     @test Broadcast.broadcastable(nt) === ReservedCollection(nt)
+    @test get(Broadcast.broadcastable(nt)) === nt
     @test BroadcastStyle(typeof(broadcasted(+, dict))) isa ReservedStyle
     @test BroadcastStyle(typeof(broadcasted(+, nt))) isa ReservedStyle
     @test BroadcastStyle(typeof(broadcasted(+, dict, []))) isa ReservedStyle

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -607,6 +607,11 @@ end
     @test_throws ArgumentError [] .= NamedTuple()
     @test_throws ArgumentError Dict() .= Dict()
     @test_throws ArgumentError Dict() .= NamedTuple()
+    @test_throws ArgumentError axes(ReservedCollection(Dict()))
+    @test_throws ArgumentError axes(ReservedCollection(NamedTuple()))
+    @test_throws ArgumentError ndims(ReservedCollection)
+    @test_throws ArgumentError ndims(typeof(ReservedCollection(Dict())))
+    @test_throws ArgumentError ndims(typeof(ReservedCollection(NamedTuple())))
     @test_throws MethodError broadcast(identity, Base)
 
     @test broadcast(identity, Iterators.filter(iseven, 1:10)) == 2:2:10


### PR DESCRIPTION
This PR lets people _construct_ `Broadcasted`s through the dot-call syntax with dictionaries and named tuples.  This will allow people to experiment with broadcasting with dictionaries and named tuple outside `Base` (see https://github.com/JuliaLang/julia/issues/25904#issuecomment-533309070 for more about the motivation).  Here is a toy example from the docstring:

```julia
julia> using Base.Experimental: ReservedStyle
       using Base.Broadcast: Broadcasted, broadcasted

julia> function aspairs end;

julia> function Broadcast.broadcasted(::typeof(aspairs), bc::Broadcasted{<:ReservedStyle})
           broadcasted(bc.f, collect.(pairs.(bc.args))...)
       end;

julia> aspairs.(tuple.(Dict(:a => 1), Dict(:b => 2)))
1-element Array{Tuple{Pair{Symbol,Int64},Pair{Symbol,Int64}},1}:
 (:a => 1, :b => 2)
```

Note that broadcasting with dictionaries and named tuples still throws the same exception:

```julia
julia> Dict() .+ NamedTuple()
ERROR: ArgumentError: broadcasting over dictionaries and `NamedTuple`s is reserved
Stacktrace:
 [1] copy(::Base.Broadcast.Broadcasted{Base.Broadcast.ReservedStyle,Nothing,typeof(+),Tuple{Dict{Any,Any},NamedTuple{(),Tuple{}}}}) at /home/takafumi/repos/watch/julia/base/broadcast.jl:1305
 [2] materialize(::Base.Broadcast.Broadcasted{Base.Broadcast.ReservedStyle,Nothing,typeof(+),Tuple{Dict{Any,Any},NamedTuple{(),Tuple{}}}}) at /home/takafumi/repos/watch/julia/base/broadcast.jl:836
```

However, this is done at the late materialization stage rather than in `broadcastable` (which is before constructing the `Broadcasted` object).
