### PR TITLE
Don't promote to float in norm(::Number).

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -621,31 +621,31 @@ end
 """
     norm(x::Number, p::Real=2)
 
-For numbers, return ``\\left( |x|^p \\right)^{1/p}``.
+For numbers, return ``abs(x)`` when ``p>0``. When `p==0`, return one if ``x!=0`` otherwise return zero.
 
 # Examples
 ```jldoctest
 julia> norm(2, 1)
-2.0
+2
 
 julia> norm(-2, 1)
-2.0
+2
 
 julia> norm(2, 2)
-2.0
+2
 
 julia> norm(-2, 2)
-2.0
+2
 
 julia> norm(2, Inf)
-2.0
+2
 
 julia> norm(-2, Inf)
-2.0
+2
 ```
 """
 @inline function norm(x::Number, p::Real=2)
-    afx = abs(float(x))
+    afx = abs(x)
     if p == 0
         if x == 0
             return zero(afx)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -334,8 +334,8 @@ end
     @test [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]] ≈ [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]]
 end
 
-# Minimal modulo number type - but not subtyping Number
-struct ModInt{n}
+# Minimal modulo number type
+struct ModInt{n} <: Number
     k
     ModInt{n}(k) where {n} = new(mod(k,n))
     ModInt{n}(k::ModInt{n}) where {n} = k
@@ -356,20 +356,16 @@ Base.adjoint(a::ModInt{n}) where {n} = ModInt{n}(conj(a))
 Base.transpose(a::ModInt{n}) where {n} = a  # see Issue 20978
 LinearAlgebra.Adjoint(a::ModInt{n}) where {n} = adjoint(a)
 LinearAlgebra.Transpose(a::ModInt{n}) where {n} = transpose(a)
+# Needed for pivoting:
+Base.abs(a::ModInt{n}) where {n} = a
+Base.:<(a::ModInt{n}, b::ModInt{n}) where {n} = a.k < b.k
 
 @testset "Issue 22042" begin
     A = [ModInt{2}(1) ModInt{2}(0); ModInt{2}(1) ModInt{2}(1)]
     b = [ModInt{2}(1), ModInt{2}(0)]
 
     @test A*(lu(A, Val(false))\b) == b
-
-    # Needed for pivoting:
-    Base.abs(a::ModInt{n}) where {n} = a
-    LinearAlgebra.norm(a::ModInt{n}) where {n} = a
-
-    Base.:<(a::ModInt{n}, b::ModInt{n}) where {n} = a.k < b.k
-
-    @test A*(lu(A, Val(true))\b) == b
+    @test A*(lu(A, Val(true)) \b) == b
 end
 
 @testset "Issue 18742" begin


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#734. See https://github.com/JuliaLang/LinearAlgebra.jl/issues/431, https://github.com/JuliaLang/julia/pull/22146, and https://github.com/JuliaLang/LinearAlgebra.jl/issues/693 for discussions of the generic LU.

I decided to make `ModInt{n}` and subtype of `Number` the tests such that it actually hits the `norm(::Number)` fallback. The `Number` abstract type assumes almost no structure so I think it should be fine for any number like thing to be a subtype of `Number`.