### PR TITLE
add documentation for findnz w/ SparseVector

### DIFF
--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -103,7 +103,7 @@ function findprev(f::Function, v::AbstractSparseArray, i)
 end
 
 """
-    findnz(A)
+    findnz(A::SparseMatrix)
 
 Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of the stored
 ("structurally non-zero") values in sparse matrix `A`, and `V` is a vector of the values.

--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -103,7 +103,7 @@ function findprev(f::Function, v::AbstractSparseArray, i)
 end
 
 """
-    findnz(A::SparseMatrix)
+    findnz(A::SparseMatrixCSC)
 
 Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of the stored
 ("structurally non-zero") values in sparse matrix `A`, and `V` is a vector of the values.

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -732,6 +732,25 @@ end
 findall(p::Base.Fix2{typeof(in)}, x::SparseVector{<:Any,Ti}) where {Ti} =
     invoke(findall, Tuple{Base.Fix2{typeof(in)}, AbstractArray}, p, x)
 
+"""
+    findnz(x)
+
+Return a tuple `(I, V)`  where `I` is the indices of the stored ("structurally non-zero")
+values in sparse vector `x` and `V` is a vector of the values.
+
+# Examples
+```jldoctest
+julia> x = sparsevec([1 2 0; 0 0 3; 0 4 0])
+9-element SparseVector{Int64,Int64} with 4 stored entries:
+  [1]  =  1
+  [4]  =  2
+  [6]  =  4
+  [8]  =  3
+
+julia> findnz(x)
+([1, 4, 6, 8], [1, 2, 4, 3])
+```
+"""
 function findnz(x::SparseVector{Tv,Ti}) where {Tv,Ti}
     numnz = nnz(x)
 

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -733,7 +733,7 @@ findall(p::Base.Fix2{typeof(in)}, x::SparseVector{<:Any,Ti}) where {Ti} =
     invoke(findall, Tuple{Base.Fix2{typeof(in)}, AbstractArray}, p, x)
 
 """
-    findnz(x)
+    findnz(x::SparseVector)
 
 Return a tuple `(I, V)`  where `I` is the indices of the stored ("structurally non-zero")
 values in sparse vector `x` and `V` is a vector of the values.


### PR DESCRIPTION
# Description

Fixes #35880 . 
Adds a docstring for the function `findnz(x::SparseVector{Tv,Ti})` using language based on the 
docstring for `findnz(A)`:
https://github.com/JuliaLang/julia/blob/479097cf8c5a7675689cb069568d6b1077df8ba7/stdlib/SparseArrays/src/abstractsparse.jl#L105-L121

# Testing

Added a jldoctest in the docstring.