### PR TITLE
Add passthrough of non-Markdown docs in document trimming

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -108,6 +108,8 @@ function Markdown.term(io::IO, msg::Message, columns)
     printstyled(io, msg.msg; msg.fmt...)
 end
 
+trimdocs(doc, brief::Bool) = doc
+
 function trimdocs(md::Markdown.MD, brief::Bool)
     brief || return md
     md, trimmed = _trimdocs(md, brief)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1093,13 +1093,31 @@ Short docs
 Long docs
 """
 f() = nothing
+@doc text"""
+    f_plain()
+
+Plain text docs
+"""
+f_plain() = nothing
+@doc html"""
+<h1><code>f_html()</code></h1>
+<p>HTML docs.</p>
+"""
+f_html() = nothing
 end # module BriefExtended
+
 buf = IOBuffer()
 md = Base.eval(REPL._helpmode(buf, "$(@__MODULE__).BriefExtended.f"))
 @test length(md.content) == 2 && isa(md.content[2], REPL.Message)
 buf = IOBuffer()
 md = Base.eval(REPL._helpmode(buf, "?$(@__MODULE__).BriefExtended.f"))
 @test length(md.content) == 1 && length(md.content[1].content[1].content) == 4
+buf = IOBuffer()
+txt = Base.eval(REPL._helpmode(buf, "$(@__MODULE__).BriefExtended.f_plain"))
+@test !isempty(sprint(show, txt))
+buf = IOBuffer()
+html = Base.eval(REPL._helpmode(buf, "$(@__MODULE__).BriefExtended.f_html"))
+@test !isempty(sprint(show, html))
 
 # PR #27562
 fake_repl() do stdin_write, stdout_read, repl


### PR DESCRIPTION
The new extended docs feature added in #34226 defined how to trim [Julia's standard] Markdown docs. This breaks the docs retrieved in `PyPlot` since it just forwards through the original Python docs as plain-text (wrapped in `Base.Docs.Text`), and there's no appropriate `trimdocs()` method for that case. There is a fallback definition of the internal `_trimdocs()`, though, so it appears the restriction to specifically `trimdocs(::Markdown.MD, ::Bool)` may have been a mistake, and loosening the type on the first argument fixes the issue.

I've tested this fix on master, but it should be noted that the new v1.5 beta throws the same error when using PyPlot, so this PR should probably be backported (if accepted).

```julia
julia> using PyPlot                                                                                                                                                                                                
                                                                                                                                                                                                                   
help?> plot                                                                                                                                                                                                        
search: plot plot3D plotfile plot_date plot_trisurf plot_surface plot_wireframe triplot subplot boxplot

ERROR: MethodError: no method matching trimdocs(::Text{PyPlot.var"#1#2"{Tuple{PyPlot.LazyHelp}}}, ::Bool)
Closest candidates are:                             
  trimdocs(::Markdown.MD, ::Bool) at /home/justin/devel/ext/julia/usr/share/julia/stdlib/v1.6/REPL/src/docview.jl:111
Stacktrace:                                         
 [1] top-level scope at /home/justin/devel/ext/julia/usr/share/julia/stdlib/v1.6/REPL/src/docview.jl:366

julia> using REPL; Revise.track(REPL)

help?> plot                                         
search: plot plot3D plotfile plot_date plot_trisurf plot_surface plot_wireframe triplot subplot boxplot subplots matplotlib subplot_tool subplot2grid subplots_adjust get_plot_commands stackplot eventplot

Plot y versus x as lines and/or markers.

Call signatures::

    plot([x], y, [fmt], *, data=None, **kwargs)
    plot([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
[...]
```