### PR TITLE
Add Base.FixKwargs (a la Base.Fix1) for more introspectable broadcasts

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1242,31 +1242,8 @@ macro __dot__(x)
     esc(__dot__(x))
 end
 
-"""
-    Base.Broadcast.FixKwargs{F,K} <: Function
-
-An instance `c` of `FixKwargs` is a function that takes positional
-arguments.  `c(args...)` is equivalent to `c.f(args...; c.kwargs...)`.
-
-The callables of type `FixKwargs` are created when function calls with
-keyword arguments are used in the dot-call syntax.  The dot-call
-sub-expression `f.(args...; kwargs...)` is lowered to a form that is
-equivalent to `broadcasted(FixKwargs(f, kwargs), args...)`.
-
-# Properties
-- `f::F`: a callable
-- `kwargs::K`: the keyword arguments passed to `f`
-"""
-struct FixKwargs{F,K} <: Function
-    f::F
-    kwargs::K
-end
-
-FixKwargs(::Type{T}, kwargs::K) where {T,K} = FixKwargs{Type{T},K}(T, kwargs)
-
-(f::FixKwargs)(args...) = f.f(args...; f.kwargs...)
-
-@inline broadcasted_kwsyntax(f, args...; kwargs...) = broadcasted(FixKwargs(f, kwargs), args...)
+@inline broadcasted_kwsyntax(f, args...; kwargs...) =
+    broadcasted(Base.FixKwargs(f, kwargs), args...)
 @inline function broadcasted(f, args...)
     args′ = map(broadcastable, args)
     broadcasted(combine_styles(args′...), f, args′...)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -948,6 +948,33 @@ end
 (f::Fix2)(y) = f.f(y, f.x)
 
 """
+    Base.FixKwargs(f; kwargs...)
+    Base.FixKwargs(f, kwargs)
+
+A type representing a partially-applied version of the keyword argument function
+`f`, with all keyword arguments fixed to those passed. In other words,
+`FixKwargs(f; kwargs...)` behaves similarly to `(args...) -> f(args...; kwargs...)`.
+
+The callables of type `FixKwargs` are created when function calls with
+keyword arguments are used in the dot-call syntax.  The dot-call
+sub-expression `f.(args...; kwargs...)` is lowered to a form that is
+equivalent to `broadcasted(FixKwargs(f, kwargs), args...)`.
+
+# Properties
+- `f::F`: a callable
+- `kwargs::K`: the keyword arguments passed to `f`
+"""
+struct FixKwargs{F,K} <: Function
+    f::F
+    kwargs::K
+end
+
+FixKwargs(::Type{T}, kwargs::K) where {T,K} = FixKwargs{Type{T},K}(T, kwargs)
+FixKwargs(f; kwargs...) = FixKwargs(f, kwargs)
+
+(f::FixKwargs)(args...) = f.f(args...; f.kwargs...)
+
+"""
     isequal(x)
 
 Create a function that compares its argument to `x` using [`isequal`](@ref), i.e.

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -261,7 +261,7 @@ Broadcast.materialize(x::LazyBC) = x.value
 @testset "FixKwargs" begin
     function f end
     bc = lazybc.(f.(1, 2, a = 3, b = 4))
-    @test bc.f isa Base.Broadcast.FixKwargs
+    @test bc.f isa Base.FixKwargs
     @test bc.f.f === f
     @test (; bc.f.kwargs...) === (a = 3, b = 4)
     @test bc.args == (1, 2)


### PR DESCRIPTION
This PR adds `Base.Broadcast.FixKwargs` which can be used to match and destructure dot-calls with keyword arguments.  I think this is useful to have this as a public API.

## Examples

### Toy example

```julia
julia> using LazyArrays

julia> function f end
f (generic function with 0 methods)

julia> bc = @~ f.(1, 2; a = 3, b = 4);

julia> bc.f
(::Base.Broadcast.FixKwargs{typeof(f),Base.Iterators.Pairs{Symbol,Int64,Tuple{Symbol,Symbol},NamedTuple{(:a, :b),Tuple{Int64,Int64}}}}) (generic function with 1 method)

julia> bc.f.f === f
true

julia> (; bc.f.kwargs...)
(a = 3, b = 4)

julia> bc.args
(1, 2)
```

### Example: keyword argument broadcasting

Keyword argument broadcasting https://github.com/JuliaLang/julia/issues/34737 can be implemented by users based on public API:

```julia
using Base.Broadcast: Broadcasted, FixKwargs, broadcastable

function withkwcall end
Broadcast.broadcasted(::typeof(withkwcall), x) = _fuse_kwcalls(x)

_fuse_kwcalls(x) = x
_fuse_kwcalls(bc::Broadcasted{Style}) where {Style} =
    _fuse_kwcalls(Broadcasted{Style}, bc.f, bc.args, bc.axes)

_fuse_kwcalls(BC, f, args, axes) = BC(f, map(_fuse_kwcalls, args), axes)
_fuse_kwcalls(BC, f::FixKwargs, args, axes) = BC(
    FlatKWCall{propertynames((; f.kwargs...))}(f.f),
    (map(_fuse_kwcalls, Tuple((; f.kwargs...)))..., map(_fuse_kwcalls, args)...),
    axes,
)

struct FlatKWCall{names,T} <: Function
    f::T
end
FlatKWCall{names}(f::T) where {names,T} = FlatKWCall{names,T}(f)

function (f::FlatKWCall{names})(args...) where {names}
    kw = NamedTuple{names}(args[1:length(names)])
    pos = args[length(names):end]
    return f.f(pos...; kw...)
end
```

```julia
julia> using LazyArrays

julia> f(args...; kwargs...) = (map(=>, 1:length(args), args)..., pairs(kwargs)...)
f (generic function with 1 method)

julia> withkwcall.(f.(1, [2], a = (@~ [1, 2] .+ 1), b = 3))
2-element Array{Tuple{Pair{Int64,Int64},Pair{Int64,Int64},Pair{Int64,Int64},Pair{Symbol,Int64},Pair{Symbol,Int64}},1}:
 (1 => 3, 2 => 1, 3 => 2, :a => 2, :b => 3)
 (1 => 3, 2 => 1, 3 => 2, :a => 3, :b => 3)
```

## Type stability

While I'm at it, this PR also solves the problem with closures capturing types https://github.com/JuliaLang/julia/issues/23618.  Before this PR, this test failed

https://github.com/JuliaLang/julia/blob/2290c4b64dcda05a568f8994483301c13bb3184d/test/broadcast.jl#L270-L276

and it now passes in this PR.
