### PR TITLE
Revert "Use norm instead of abs in generic lu factorization (#34575)"

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -140,9 +140,9 @@ function generic_lufact!(A::StridedMatrix{T}, ::Val{Pivot} = Val(true);
             # find index max
             kp = k
             if Pivot
-                amax = norm(zero(T))
+                amax = abs(zero(T))
                 for i = k:m
-                    absi = norm(A[i,k])
+                    absi = abs(A[i,k])
                     if absi > amax
                         kp = i
                         amax = absi

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -365,8 +365,6 @@ LinearAlgebra.Transpose(a::ModInt{n}) where {n} = transpose(a)
 
     # Needed for pivoting:
     Base.abs(a::ModInt{n}) where {n} = a
-    LinearAlgebra.norm(a::ModInt{n}) where {n} = a
-
     Base.:<(a::ModInt{n}, b::ModInt{n}) where {n} = a.k < b.k
 
     @test A*(lu(A, Val(true))\b) == b


### PR DESCRIPTION
This reverts commit ecc0c434fae2438c05093b0fb1443b21c5463825.

Closes https://github.com/JuliaLang/LinearAlgebra.jl/issues/734. See the discussion there and in the linked issues.