### PR TITLE
Improve sentence in the Performance Tips section

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1013,11 +1013,9 @@ julia> @time f.(x);
 
 That is, `fdot(x)` is ten times faster and allocates 1/6 the
 memory of `f(x)`, because each `*` and `+` operation in `f(x)` allocates
-a new temporary array and executes in a separate loop. (Of course,
-if you just do `f.(x)` then it is as fast as `fdot(x)` in this
-example, but in many contexts it is more convenient to just sprinkle
-some dots in your expressions rather than defining a separate function
-for each vectorized operation.)
+a new temporary array and executes in a separate loop. 
+Note also that, while `f.(x)` is as fast as `fdot(x)` in the above example, in general defining a separate function will lead to improved performance. Nevertheless, in many contexts it is more convenient to just sprinkle some dots in your expressions rather than defining a separate function for each vectorized operation.
+
 
 ## [Consider using views for slices](@id man-performance-views)
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1013,11 +1013,9 @@ julia> @time f.(x);
 
 That is, `fdot(x)` is ten times faster and allocates 1/6 the
 memory of `f(x)`, because each `*` and `+` operation in `f(x)` allocates
-a new temporary array and executes in a separate loop. (Of course,
-if you just do `f.(x)` then it is as fast as `fdot(x)` in this
-example, but in many contexts it is more convenient to just sprinkle
-some dots in your expressions rather than defining a separate function
-for each vectorized operation.)
+a new temporary array and executes in a separate loop.
+Note also that, while `f.(x)` is as fast as `fdot(x)` in the above example, in general defining a separate function will lead to improved performance. Nevertheless, in many contexts it is more convenient to just sprinkle some dots in your expressions rather than defining a separate function for each vectorized operation.
+
 
 ## [Consider using views for slices](@id man-performance-views)
 


### PR DESCRIPTION
This commit improves an ambiguous sentence in the [Performance Tips](https://docs.julialang.org/en/v1/manual/performance-tips/) page.

In the section [Access arrays in memory order, along columns](https://docs.julialang.org/en/v1/manual/performance-tips/#More-dots:-Fuse-vectorized-operations-1), there is the final sentence
> (Of course, if you just do `f.(x)` then it is as fast as `fdot(x)` in this example, but in many contexts it is more convenient to just sprinkle some dots in your expressions rather than defining a separate function for each vectorized operation.)

This is a bit confusing.  What we want to say is that
- using the dot notation is faster in the given example, but in general it will not be the case,
- even though in general the dot notation is not the most performant approach, in several contexts it is more convenient.