### PR TITLE
fix #36104, hack to allow accessing incomplete struct via dot syntax

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -741,6 +741,14 @@ Unsigned(x::Union{Float32, Float64, Bool}) = UInt(x)
 Integer(x::Integer) = x
 Integer(x::Union{Float32, Float64}) = Int(x)
 
+# During definition of struct type `B`, if an `A.B` expression refers to
+# the eventual global name of the struct, then return the partially-initialized
+# type object.
+# TODO: remove. This is a shim for backwards compatibility.
+function struct_name_shim(@nospecialize(x), name::Symbol, mod::Module, @nospecialize(t))
+    return x === mod ? t : getfield(x, name)
+end
+
 # Binding for the julia parser, called as
 #
 #    Core._parse(text, filename, offset, options)

--- a/src/utils.scm
+++ b/src/utils.scm
@@ -48,6 +48,13 @@
                 (any (lambda (y) (expr-contains-p p y filt))
                      (cdr expr))))))
 
+(define (expr-replace p expr repl)
+  (cond ((p expr) (repl expr))
+        ((and (pair? expr) (not (quoted? expr)))
+         (cons (car expr)
+               (map (lambda (x) (expr-replace p x repl)) (cdr expr))))
+        (else expr)))
+
 ;; find all subexprs satisfying `p`, applying `key` to each one
 (define (expr-find-all p expr key (filt (lambda (x) #t)))
   (if (filt expr)

--- a/test/core.jl
+++ b/test/core.jl
@@ -7221,3 +7221,11 @@ struct AVL35416{K,V}
     avl:: Union{Nothing,Node35416{AVL35416{K,V},<:K,<:V}}
 end
 @test AVL35416(Node35416{AVL35416{Integer,AbstractString},Int,String}()) isa AVL35416{Integer,AbstractString}
+
+# issue #36104
+module M36104
+struct T36104
+    v::Vector{M36104.T36104}
+end
+end
+@test fieldtypes(M36104.T36104) == (Vector{M36104.T36104},)


### PR DESCRIPTION
This isn't perfect, but hopefully it will be good enough to catch all practical cases. In 1.6 we should officially deprecate accessing an incomplete struct via its global binding.

fix #36104