### PR TITLE
Fix zero(::Type{TwicePrecision}) for dimensionful quantities

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -257,7 +257,10 @@ big(x::TwicePrecision) = big(x.hi) + big(x.lo)
 
 -(x::TwicePrecision) = TwicePrecision(-x.hi, -x.lo)
 
-zero(::Type{TwicePrecision{T}}) where {T} = TwicePrecision{T}(0, 0)
+function zero(::Type{TwicePrecision{T}}) where {T}
+    z = zero(T)
+    TwicePrecision{T}(z, z)
+end
 
 # Arithmetic
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -193,6 +193,7 @@ end
     @test_throws ErrorException("Int is incommensurate with PhysQuantity") x*2   # not a MethodError for convert
     @test x.hi/2 === PhysQuantity{1}(2.0)
     @test_throws ErrorException("Int is incommensurate with PhysQuantity") x/2
+    @test zero(typeof(x)) === Base.TwicePrecision(PhysQuantity{1}(0.0))
 end
 @testset "ranges" begin
     @test size(10:1:0) == (0,)


### PR DESCRIPTION
Fixes #36080 (and thus should be backported to 1.5).