### PR TITLE
fix #36116, diff(::AbstractRange) returns an Array

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -848,9 +848,9 @@ function diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
 
     return view(a, r1...) .- view(a, r0...)
 end
-function diff(r::AbstractRange; dims::Integer=1)
+function diff(r::AbstractRange{T}; dims::Integer=1) where {T}
     dims == 1 || throw(ArgumentError("dimension $dims out of range (1:$N)"))
-    return [@inbounds r[i+1] - r[i] for i in firstindex(r):lastindex(r)-1]
+    return T[@inbounds r[i+1] - r[i] for i in firstindex(r):lastindex(r)-1]
 end
 
 ### from abstractarray.jl

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -848,6 +848,10 @@ function diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
 
     return view(a, r1...) .- view(a, r0...)
 end
+function diff(r::AbstractRange; dims::Integer=1)
+    dims == 1 || throw(ArgumentError("dimension $dims out of range (1:$N)"))
+    return [@inbounds r[i+1] - r[i] for i in firstindex(r):lastindex(r)-1]
+end
 
 ### from abstractarray.jl
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -849,7 +849,7 @@ function diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
     return view(a, r1...) .- view(a, r0...)
 end
 function diff(r::AbstractRange{T}; dims::Integer=1) where {T}
-    dims == 1 || throw(ArgumentError("dimension $dims out of range (1:$N)"))
+    dims == 1 || throw(ArgumentError("dimension $dims out of range (1:1)"))
     return T[@inbounds r[i+1] - r[i] for i in firstindex(r):lastindex(r)-1]
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1607,6 +1607,15 @@ end
     @test collect(r) == ['a','c','e','g']
 end
 
+@testset "diff of ranges, #36116" begin
+    for r in (0:2, 0:1:2, 0.0:1.0:2.0, LinRange(0,2,3))
+        @test diff(r) == diff(collect(r)) == fill(1, 2)
+    end
+    for r in (0:2:5, 0.1:0.1:2.0, LinRange(0,2,33))
+        @test diff(r) == diff(collect(r)) == [r[i+1] - r[i] for i in 1:length(r)-1]
+    end
+end
+
 @testset "Return type of indexing with ranges" begin
     for T = (Base.OneTo{Int}, UnitRange{Int}, StepRange{Int,Int}, StepRangeLen{Int}, LinRange{Int})
         @test eltype(T(1:5)) === eltype(T(1:5)[1:2])

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1610,6 +1610,7 @@ end
 @testset "diff of ranges, #36116" begin
     for r in (0:2, 0:1:2, 0.0:1.0:2.0, LinRange(0,2,3))
         @test diff(r) == diff(collect(r)) == fill(1, 2)
+        @test_throws ArgumentError diff(r, dims=2)
     end
     for r in (0:2:5, 0.1:0.1:2.0, LinRange(0,2,33))
         @test diff(r) == diff(collect(r)) == [r[i+1] - r[i] for i in 1:length(r)-1]


### PR DESCRIPTION
It's oh so tempting to simply define `diff(r::AbstractRange) = fill(step(r), length(r)-1)`, (or even a `Fill`), but this preserves the behavior that we had on 1.4 and before — and is arguably what folks want. It's not the repeated theoretical step, but the realized sequential differences of the generated elements.