### PR TITLE
Update build dependencies

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -144,7 +144,7 @@ Notes for various architectures:
 Building Julia requires that the following software be installed:
 
 - **[GNU make]**                — building dependencies.
-- **[gcc & g++][gcc]** (>= 4.7) or **[Clang][clang]** (>= 3.1, Xcode 4.3.3 on macOS) — compiling and linking C, C++.
+- **[gcc & g++][gcc]** (>= 5.1) or **[Clang][clang]** (>= 3.5, >= 6.0 for Apple Clang) — compiling and linking C, C++.
 - **[libatomic][gcc]**          — provided by **[gcc]** and needed to support atomic operations.
 - **[python]** (>=2.7)          — needed to build LLVM.
 - **[gfortran]**                — compiling and linking Fortran libraries.
@@ -155,6 +155,7 @@ Building Julia requires that the following software be installed:
 - **[patch]**                   — for modifying source code.
 - **[cmake]** (>= 3.4.3)        — needed to build `libgit2`.
 - **[pkg-config]**              — needed to build `libgit2` correctly, especially for proxy support.
+- **[powershell]** (>= 3.0)     — necessary only on Windows.
 
 On Debian-based distributions (e.g. Ubuntu), you can easily install them with `apt-get`:
 ```
@@ -164,25 +165,26 @@ sudo apt-get install build-essential libatomic1 python gfortran perl wget m4 cma
 Julia uses the following external libraries, which are automatically
 downloaded (or in a few cases, included in the Julia source
 repository) and then compiled from source the first time you run
-`make`:
+`make`. The specific version numbers of these libraries that Julia 
+uses are listed in [`deps/Versions.make`](https://github.com/JuliaLang/julia/blob/master/deps/Versions.make):
 
 - **[LLVM]** (9.0 + [patches](https://github.com/JuliaLang/julia/tree/master/deps/patches)) — compiler infrastructure (see [note below](#llvm)).
 - **[FemtoLisp]**            — packaged with Julia source, and used to implement the compiler front-end.
 - **[libuv]**  (custom fork) — portable, high-performance event-based I/O library.
 - **[OpenLibm]**             — portable libm library containing elementary math functions.
 - **[DSFMT]**                — fast Mersenne Twister pseudorandom number generator library.
-- **[OpenBLAS]**             — fast, open, and maintained [basic linear algebra subprograms (BLAS)](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) library, based on [Kazushige Goto's](https://en.wikipedia.org/wiki/Kazushige_Goto) famous [GotoBLAS](https://www.tacc.utexas.edu/research-development/tacc-software/gotoblas2) (see [note below](#blas-and-lapack)).
-- **[LAPACK]** (>= 3.5)      — library of linear algebra routines for solving systems of simultaneous linear equations, least-squares solutions of linear systems of equations, eigenvalue problems, and singular value problems.
+- **[OpenBLAS]**             — fast, open, and maintained [basic linear algebra subprograms (BLAS)]
+- **[LAPACK]**               — library of linear algebra routines for solving systems of simultaneous linear equations, least-squares solutions of linear systems of equations, eigenvalue problems, and singular value problems.
 - **[MKL]** (optional)       – OpenBLAS and LAPACK may be replaced by Intel's MKL library.
-- **[SuiteSparse]** (>= 4.1) — library of linear algebra routines for sparse matrices.
-- **[PCRE]** (>= 10.00)      — Perl-compatible regular expressions library.
-- **[GMP]** (>= 5.0)         — GNU multiple precision arithmetic library, needed for `BigInt` support.
-- **[MPFR]** (>= 4.0)        — GNU multiple precision floating point library, needed for arbitrary precision floating point (`BigFloat`) support.
-- **[libgit2]** (>= 0.23)    — Git linkable library, used by Julia's package manager.
-- **[curl]** (>= 7.50)       — libcurl provides download and proxy support for Julia's package manager.
-- **[libssh2]** (>= 1.7)     — library for SSH transport, used by libgit2 for packages with SSH remotes.
-- **[mbedtls]** (>= 2.2)     — library used for cryptography and transport layer security, used by libssh2
-- **[utf8proc]** (>= 2.1)    — a library for processing UTF-8 encoded Unicode strings.
+- **[SuiteSparse]**          — library of linear algebra routines for sparse matrices.
+- **[PCRE]**                 — Perl-compatible regular expressions library.
+- **[GMP]**                  — GNU multiple precision arithmetic library, needed for `BigInt` support.
+- **[MPFR]**                 — GNU multiple precision floating point library, needed for arbitrary precision floating point (`BigFloat`) support.
+- **[libgit2]**              — Git linkable library, used by Julia's package manager.
+- **[curl]**                 — libcurl provides download and proxy support for Julia's package manager.
+- **[libssh2]**              — library for SSH transport, used by libgit2 for packages with SSH remotes.
+- **[mbedtls]**              — library used for cryptography and transport layer security, used by libssh2
+- **[utf8proc]**             — a library for processing UTF-8 encoded Unicode strings.
 - **[libosxunwind]**         — fork of [libunwind], a library that determines the call-chain of a program.
 
 [GNU make]:     https://www.gnu.org/software/make
@@ -217,6 +219,7 @@ repository) and then compiled from source the first time you run
 [libssh2]:      https://www.libssh2.org
 [mbedtls]:      https://tls.mbed.org/
 [pkg-config]:   https://www.freedesktop.org/wiki/Software/pkg-config/
+[powershell]:   https://docs.microsoft.com/en-us/powershell/scripting/wmf/overview
 
 ## Build dependencies
 


### PR DESCRIPTION
C/C++ compiler based on LLVM recommendation: https://llvm.org/docs/GettingStarted.html#host-c-toolchain-both-compiler-and-standard-library
Powershell based on: https://julialang.org/downloads/platform/#windows

Remove version numbers for the libraries in deps since they are quite out of date, and change frequently. Instead point to Versions.make.

[ci skip]