### PR TITLE
Revise-test: make sure all workers load Revise

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -46,4 +46,16 @@ end
 # looking in . messes things up badly
 filter!(x->x!=".", LOAD_PATH)
 
+# Support for Revise
+function revise_trackall()
+    Revise.track(Core.Compiler)
+    Revise.track(Base)
+    for (id, mod) in Base.loaded_modules
+        if id.name in STDLIBS
+            Revise.track(mod)
+        end
+    end
+    Revise.revise()
+end
+
 nothing # File is loaded via a remotecall to "include". Ensure it returns "nothing".


### PR DESCRIPTION
This fixes the errors
```julia
julia> Base.runtests(["REPL", "cartesian"]; revise=true)
ERROR: LoadError: On worker 2:
UndefVarError: Revise not defined
```

and then later

```julia
julia> Base.runtests(["REPL", "cartesian"]; revise=true)
ERROR: LoadError: On worker 2:
UndefVarError: STDLIBS not defined
```