### PR TITLE
Fix mkpath error handling

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -228,7 +228,7 @@ function mkpath(path::AbstractString; mode::Integer = 0o777)
     catch err
         # If there is a problem with making the directory, but the directory
         # does in fact exist, then ignore the error. Else re-throw it.
-        if !isa(err, SystemError) || !isdir(path)
+        if !isa(err, IOError) || !isdir(path)
             rethrow()
         end
     end


### PR DESCRIPTION
The error thrown by `mkdir` when the directory already exists was changed in #33422.

Unfortunately, this is hard to test, though we came across it on a cluster with a shared file system.

cc: @jakebolewski @kpamnany 