### PR TITLE
include ClearStacktrace.jl in Base

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -609,7 +609,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
     try invokelatest(update_stackframes_callback[], displayed_stackframes) catch end
 
     println(io, "\nStacktrace:")
-    ndigits = length(digits(length(t)))
+    ndigits_max = ndigits(length(t))
 
     modulecolorcycler = Iterators.Stateful(Iterators.cycle(STACKTRACE_MODULECOLORS))
 
@@ -632,7 +632,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
         inlined = getfield(frame, :inlined)
 
         push!(LAST_SHOWN_LINE_INFOS, (file, line))
-        print_frame(io, frame_counter, func, inlined, modul, file, line, sigtypes, varnames, ndigits, modulecolor)
+        print_frame(io, frame_counter, func, inlined, modul, file, line, sigtypes, varnames, ndigits_max, modulecolor)
         
         if i < length(displayed_stackframes)
             println(io)
@@ -714,7 +714,7 @@ stacktrace_linebreaks()::Bool = parse(Bool, get(ENV, "JULIA_STACKTRACE_LINEBREAK
 function print_trace(io::IO, trace; print_linebreaks::Bool)
 
     n = length(trace)
-    ndigits = length(digits(n))
+    ndigits_max = ndigits(n)
 
     modulecolordict = Dict("" => :default)
     modulecolorcycler = Iterators.Stateful(Iterators.cycle(STACKTRACE_MODULECOLORS))
@@ -735,7 +735,7 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
         inlined = getfield(frame, :inlined)
 
         push!(LAST_SHOWN_LINE_INFOS, (file, line))
-        print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, ndigits, modulecolor)
+        print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, ndigits_max, modulecolor)
         if i < n
             println(io)
             print_linebreaks && println(io)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -609,7 +609,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
     try invokelatest(update_stackframes_callback[], displayed_stackframes) catch end
 
     println(io, "\nStacktrace:")
-    numstr_width = length(digits(length(t))) + 2
+    ndigits = length(digits(length(t)))
 
     modulecolorcycler = Iterators.cycle(STACKTRACE_MODULECOLORS)
 
@@ -627,7 +627,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
         print_frame(io, frame_counter, getfunc(frame), getfield(frame, :inlined), getmodule(frame),
             getfile(frame, STACKTRACE_EXPAND_BASE_PATHS, STACKTRACE_CONTRACT_USER_DIR),
             getline(frame), getsigtypes(frame), getvarnames(frame),
-            numstr_width, modulecolor)
+            ndigits, modulecolor)
         
         if i < length(displayed_stackframes)
             println(io)
@@ -706,7 +706,6 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
 
     n = length(trace)
     ndigits = length(digits(n))
-    length_numstr = ndigits + 2
 
     modulecolordict = Dict("" => :default)
     modulecolorcycler = Iterators.cycle(STACKTRACE_MODULECOLORS)
@@ -726,7 +725,7 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
         sigtypes = getsigtypes(frame)
         inlined = getfield(frame, :inlined)
 
-        print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, length_numstr, modulecolor)
+        print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, ndigits, modulecolor)
         if i < n
             println(io)
             print_linebreaks && println(io)
@@ -735,10 +734,10 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
 end
 
 function print_frame(io, i, func, inlined, modul, file, line, stypes,
-    vnames, length_numstr, modulecolor)
+    vnames, width_digits, modulecolor)
 
     # frame number
-    print(io, lpad("[" * string(i) * "]", length_numstr))
+    print(io, lpad("[" * string(i) * "]", width_digits + 2))
     print(io, " ")
     
     # function name
@@ -763,7 +762,7 @@ function print_frame(io, i, func, inlined, modul, file, line, stypes,
     println(io)
     
     # @
-    printstyled(io, " " ^ (length_numstr - 1) * "@ ", color = :light_black)
+    printstyled(io, " " ^ (width_digits + 1) * "@ ", color = :light_black)
 
     # module
     if !isempty(modul)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -624,10 +624,15 @@ function show_reduced_backtrace(io::IO, t::Vector)
         end
         modulecolor = modulecolordict[modul]
         
-        print_frame(io, frame_counter, getfunc(frame), getfield(frame, :inlined), getmodule(frame),
-            getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir()),
-            getline(frame), getsigtypes(frame), getvarnames(frame),
-            ndigits, modulecolor)
+        file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
+        line = getline(frame)
+        varnames = getvarnames(frame)
+        func = getfunc(frame)
+        sigtypes = getsigtypes(frame)
+        inlined = getfield(frame, :inlined)
+
+        push!(LAST_SHOWN_LINE_INFOS, (file, line))
+        print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, ndigits, modulecolor)
         
         if i < length(displayed_stackframes)
             println(io)
@@ -820,19 +825,6 @@ function show_backtrace(io::IO, t::Vector)
     print_trace(io, t; print_linebreaks = stacktrace_linebreaks())
 end
 
-# I think this is not needed anymore?
-
-# function show_backtrace(io::IO, t::Vector{Any})
-#     # t is a pre-processed backtrace (ref #12856)
-#     if length(t) < BIG_STACKTRACE_SIZE
-#         try invokelatest(update_stackframes_callback[], t) catch end
-#         for entry in t
-#             show_trace_entry(io, entry...)
-#         end
-#     else
-#         show_reduced_backtrace(io, t, false)
-#     end
-# end
 
 function is_kw_sorter_name(name::Symbol)
     sn = string(name)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -819,10 +819,10 @@ function show_backtrace(io::IO, t::Vector)
 
     println(io, "\nStacktrace:")
 
-    # process_backtrace returns a Tuple{Frame, Int}
+    # process_backtrace returns a Vector{Tuple{Frame, Int}}
     frames = first.(filtered)
 
-    print_trace(io, t; print_linebreaks = stacktrace_linebreaks())
+    print_trace(io, frames; print_linebreaks = stacktrace_linebreaks())
 end
 
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -552,7 +552,7 @@ const update_stackframes_callback = Ref{Function}(identity)
 function replaceuserpath(str)
     str = replace(str, homedir() => "~")
     # seems to be necessary for some paths with small letter drive c:// etc
-    replace(str, lowercasefirst(homedir()) => "~")
+    str = replace(str, lowercasefirst(homedir()) => "~")
     return str
 end
 
@@ -562,7 +562,7 @@ const STACKTRACE_MODULECOLORS = [:light_blue, :light_yellow,
 stacktrace_expand_basepaths()::Bool =
     tryparse(Bool, get(ENV, "JULIA_STACKTRACE_EXPAND_BASEPATHS", "false")) === true
 stacktrace_contract_userdir()::Bool =
-    tryparse(Bool, get(ENV, "JULIA_STACKTRACE_CONTRACT_USERDIR", "true")) === true
+    tryparse(Bool, get(ENV, "JULIA_STACKTRACE_CONTRACT_HOMEDIR", "true")) === true
 stacktrace_linebreaks()::Bool =
     tryparse(Bool, get(ENV, "JULIA_STACKTRACE_LINEBREAKS", "false")) === true
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -752,7 +752,13 @@ function show_backtrace(io::IO, t::Vector)
     if haskey(io, :LAST_SHOWN_LINE_INFOS)
         resize!(io[:LAST_SHOWN_LINE_INFOS], 0)
     end
-    filtered = process_backtrace(t)
+
+    # t is a pre-processed backtrace (ref #12856)
+    if t isa Vector{Any}
+        filtered = t
+    else
+        filtered = process_backtrace(t)
+    end
     isempty(filtered) && return
 
     if length(filtered) == 1 && StackTraces.is_top_level_frame(filtered[1][1])

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -538,15 +538,6 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
     end
 end
 
-function show_trace_entry(io, frame, n; prefix = "")
-    if haskey(io, :LAST_SHOWN_LINE_INFOS)
-        push!(io[:LAST_SHOWN_LINE_INFOS], (string(frame.file), frame.line))
-    end
-    print(io, "\n", prefix)
-    show(io, frame, full_path=true)
-    n > 1 && print(io, " (repeats ", n, " times)")
-end
-
 # In case the line numbers in the source code have changed since the code was compiled,
 # allow packages to set a callback function that corrects them.
 # (Used by Revise and perhaps other packages.)
@@ -719,8 +710,11 @@ function print_frame(io, i, frame, width_digits, modulecolordict, modulecolorcyc
     file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
     line = getline(frame)
 
-    # add file and line info for accessing frame locations from the repl
-    push!(LAST_SHOWN_LINE_INFOS, (file, line))
+    # Used by the REPL to make it possible to open
+    # the location of a stackframe/method in the editor.
+    if haskey(io, :LAST_SHOWN_LINE_INFOS)
+        push!(io[:LAST_SHOWN_LINE_INFOS], (string(frame.file), frame.line))
+    end
 
     variable_names = getvarnames(frame)
     func = getfunc(frame)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -632,7 +632,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
         inlined = getfield(frame, :inlined)
 
         push!(LAST_SHOWN_LINE_INFOS, (file, line))
-        print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, ndigits, modulecolor)
+        print_frame(io, frame_counter, func, inlined, modul, file, line, sigtypes, varnames, ndigits, modulecolor)
         
         if i < length(displayed_stackframes)
             println(io)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -729,6 +729,7 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
         sigtypes = getsigtypes(frame)
         inlined = getfield(frame, :inlined)
 
+        push!(LAST_SHOWN_LINE_INFOS, (file, line))
         print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, ndigits, modulecolor)
         if i < n
             println(io)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -733,8 +733,8 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
     end
 end
 
-function print_frame(io, i, func, inlined, modul, file, line, stypes,
-    vnames, width_digits, modulecolor)
+function print_frame(io, i, func, inlined, modul, file, line, specialization_types,
+    variable_names, width_digits, modulecolor)
 
     # frame number
     print(io, lpad("[" * string(i) * "]", width_digits + 2))
@@ -743,11 +743,11 @@ function print_frame(io, i, func, inlined, modul, file, line, stypes,
     # function name
     printstyled(io, func, bold = true)
    
-    if !isempty(vnames)
+    if !isempty(variable_names)
         # type signature
         printstyled(io, "(", color = :light_black)
 
-        for (i, (stype, varname)) in enumerate(zip(stypes, vnames))
+        for (i, (stype, varname)) in enumerate(zip(specialization_types, variable_names))
             if i > 1
                 printstyled(io, ", ", color = :light_black)
             end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -610,7 +610,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
     for i in 1:length(displayed_stackframes)
         (frame, n) = displayed_stackframes[i]
 
-        print_frame(io, frame_counter, frame, ndigits_max, modulecolordict, modulecolorcycler)
+        print_stackframe(io, frame_counter, frame, ndigits_max, modulecolordict, modulecolorcycler)
         
         if i < length(displayed_stackframes)
             println(io)
@@ -689,7 +689,7 @@ stacktrace_contract_userdir()::Bool = parse(Bool,
     get(ENV, "JULIA_STACKTRACE_CONTRACT_USERDIR", "true"))
 stacktrace_linebreaks()::Bool = parse(Bool, get(ENV, "JULIA_STACKTRACE_LINEBREAKS", "true"))
 
-function print_trace(io::IO, trace; print_linebreaks::Bool)
+function show_full_backtrace(io::IO, trace; print_linebreaks::Bool)
 
     n = length(trace)
     ndigits_max = ndigits(n)
@@ -702,7 +702,7 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
 
     for (i, frame) in enumerate(trace)
 
-        print_frame(io, i, frame, ndigits_max, modulecolordict, modulecolorcycler)
+        print_stackframe(io, i, frame, ndigits_max, modulecolordict, modulecolorcycler)
         if i < n
             println(io)
             print_linebreaks && println(io)
@@ -711,13 +711,13 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
 end
 
 """
-    print_frame(io, i, frame, digit_align_width, modulecolordict::Dict, modulecolorcycler)
+    print_stackframe(io, i, frame, digit_align_width, modulecolordict::Dict, modulecolorcycler)
 
 Print a stack frame where the module color is determined by looking up the parent module in
 `modulecolordict`. If the module does not have a color, yet, a new one can be drawn
 from `modulecolorcycler`.
 """
-function print_frame(io, i, frame, digit_align_width, modulecolordict, modulecolorcycler)
+function print_stackframe(io, i, frame, digit_align_width, modulecolordict, modulecolorcycler)
     modul = getmodule(frame)
     parentmodule = split(modul, ".")[1]
     if !haskey(modulecolordict, parentmodule)
@@ -725,15 +725,15 @@ function print_frame(io, i, frame, digit_align_width, modulecolordict, modulecol
     end
     modulecolor = modulecolordict[parentmodule]
 
-    print_frame(io, i, frame, digit_align_width, modulecolor)
+    print_stackframe(io, i, frame, digit_align_width, modulecolor)
 end
 
 """
-    print_frame(io, i, frame, digit_align_width, modulecolordict::Dict, modulecolorcycler)
+    print_stackframe(io, i, frame, digit_align_width, modulecolordict::Dict, modulecolorcycler)
 
 Print a stack frame where the module color is set manually with `modulecolor`.
 """
-function print_frame(io, i, frame, digit_align_width, modulecolor)
+function print_stackframe(io, i, frame, digit_align_width, modulecolor)
 
     file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
     line = getline(frame)
@@ -824,7 +824,7 @@ function show_backtrace(io::IO, t::Vector)
     # process_backtrace returns a Vector{Tuple{Frame, Int}}
     frames = first.(filtered)
 
-    print_trace(io, frames; print_linebreaks = stacktrace_linebreaks())
+    show_full_backtrace(io, frames; print_linebreaks = stacktrace_linebreaks())
 end
 
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -625,13 +625,13 @@ function show_reduced_backtrace(io::IO, t::Vector)
         modulecolor = modulecolordict[modul]
         
         print_frame(io, frame_counter, getfunc(frame), getfield(frame, :inlined), getmodule(frame),
-            getfile(frame, STACKTRACE_EXPAND_BASE_PATHS, STACKTRACE_CONTRACT_USER_DIR),
+            getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir()),
             getline(frame), getsigtypes(frame), getvarnames(frame),
             ndigits, modulecolor)
         
         if i < length(displayed_stackframes)
             println(io)
-            STACKTRACE_LINEBREAKS && println(io)
+            stacktrace_linebreaks() && println(io)
         end
 
         while repeated_cycle[1][1] == i # never empty because of the initial (0,0,0)
@@ -641,17 +641,12 @@ function show_reduced_backtrace(io::IO, t::Vector)
             printstyled(io,
                 "--- the last ", cycle_length, " lines are repeated ",
                   repetitions, " more time", repetitions>1 ? "s" : "", " ---\n", color = :light_black)
-            STACKTRACE_LINEBREAKS && println(io)
+            stacktrace_linebreaks() && println(io)
             frame_counter += cycle_length * repetitions
         end
         frame_counter += 1
     end
 end
-
-const STACKTRACE_MODULECOLORS = [:light_blue, :light_yellow, :light_red, :light_green,:light_magenta, :light_cyan, :blue, :yellow, :red, :green, :magenta, :cyan]
-const STACKTRACE_EXPAND_BASE_PATHS = true
-const STACKTRACE_CONTRACT_USER_DIR = true
-const STACKTRACE_LINEBREAKS = true
 
 function expandbasepath(str)
 
@@ -702,6 +697,15 @@ function getvarnames(frame)
     end
 end
 
+const STACKTRACE_MODULECOLORS = [:light_blue, :light_yellow, :light_red,
+        :light_green,:light_magenta, :light_cyan,
+        :blue, :yellow, :red, :green, :magenta, :cyan]
+stacktrace_expand_basepaths()::Bool = parse(Bool,
+    get(ENV, "JULIA_STACKTRACE_EXPAND_BASEPATHS", "true"))
+stacktrace_contract_userdir()::Bool = parse(Bool,
+    get(ENV, "JULIA_STACKTRACE_CONTRACT_USERDIR", "true"))
+stacktrace_linebreaks()::Bool = parse(Bool, get(ENV, "JULIA_STACKTRACE_LINEBREAKS", "true"))
+
 function print_trace(io::IO, trace; print_linebreaks::Bool)
 
     n = length(trace)
@@ -718,7 +722,7 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
         end
         modulecolor = modulecolordict[modul]
 
-        file = getfile(frame, STACKTRACE_EXPAND_BASE_PATHS, STACKTRACE_CONTRACT_USER_DIR)
+        file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
         line = getline(frame)
         varnames = getvarnames(frame)
         func = getfunc(frame)
@@ -812,7 +816,7 @@ function show_backtrace(io::IO, t::Vector)
     # process_backtrace returns a Tuple{Frame, Int}
     frames = first.(filtered)
 
-    print_trace(io, t; print_linebreaks = STACKTRACE_LINEBREAKS)
+    print_trace(io, t; print_linebreaks = stacktrace_linebreaks())
 end
 
 # I think this is not needed anymore?

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -703,8 +703,11 @@ function show_reduced_backtrace(io::IO, t::Vector)
             popfirst!(repeated_cycle)
             printstyled(io,
                 "--- the last ", cycle_length, " lines are repeated ",
-                  repetitions, " more time", repetitions>1 ? "s" : "", " ---\n", color = :light_black)
-            stacktrace_linebreaks() && println(io)
+                  repetitions, " more time", repetitions>1 ? "s" : "", " ---", color = :light_black)
+            if i < length(displayed_stackframes)
+                println(io)
+                stacktrace_linebreaks() && println(io)
+            end
             frame_counter += cycle_length * repetitions
         end
         frame_counter += 1

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -585,18 +585,33 @@ function getfile(frame, expandbase::Bool, contractuser::Bool)
 end
 getfunc(frame) = string(frame.func)
 getmodule(frame) = try; string(frame.linfo.def.module) catch; "" end
-getsigtypes(frame) = try;  frame.linfo.specTypes.parameters[2:end] catch; "" end
 getmethod(frame) = try;  frame.linfo.def catch; nothing end
-function getvarnames(frame)
-    m = getmethod(frame)
-    if isnothing(m)
-        []
-    else
-        tv, decls, file, line = arg_decl_parts(m)
-        # this is a list of tuples (variable name, variable type)
-        # we take only the variable names
-        first.(decls[2:end])
+
+function getarguments(frame)
+
+    meth = getmethod(frame)
+    if isnothing(meth)
+        return (([], []), ([], []))
     end
+
+    tv, decls, file, line = arg_decl_parts(meth)
+    # this is a list of tuples (variable name, variable type)
+    # we take only the variable names
+    varnames = first.(decls)[2:end]
+    sigtypes = frame.linfo.specTypes.parameters[2:end]
+
+    n_keywords = meth.nkw
+    keyword_offset = 1
+    # if there are no keywords, the positional arguments start immediately
+    # if there are keywords, there is another argument between keywords and positional args (the original function of the keyword shim)
+    positional_offset = keyword_offset + n_keywords + (n_keywords > 0 ? 1 : 0)
+    varnames_keywords = varnames[keyword_offset:n_keywords]
+    varnames_positional = varnames[positional_offset:end]
+
+    sigtypes_keywords = sigtypes[keyword_offset:n_keywords]
+    sigtypes_positional = sigtypes[positional_offset:end]
+
+    ((varnames_positional, varnames_keywords), (sigtypes_positional, sigtypes_keywords))
 end
 
 const STACKTRACE_MODULECOLORS = [:light_blue, :light_yellow, :light_red,
@@ -748,9 +763,7 @@ function print_stackframe(io, i, frame, digit_align_width, modulecolor)
         push!(io[:LAST_SHOWN_LINE_INFOS], (string(frame.file), frame.line))
     end
 
-    variable_names = getvarnames(frame)
     func = getfunc(frame)
-    specialization_types = getsigtypes(frame)
     inlined = getfield(frame, :inlined)
     modul = getmodule(frame)
 
@@ -761,11 +774,27 @@ function print_stackframe(io, i, frame, digit_align_width, modulecolor)
     # function name
     printstyled(io, func, bold = true)
    
-    if !isempty(variable_names)
-        # type signature
+
+    (varnames_positional, varnames_kw), (sigtypes_positional, sigtypes_kw) = getarguments(frame)
+
+    if !(isempty(varnames_positional) && isempty(varnames_kw))
+
         printstyled(io, "(", color = :light_black)
 
-        for (i, (stype, varname)) in enumerate(zip(specialization_types, variable_names))
+        for (i, (stype, varname)) in enumerate(zip(sigtypes_positional, varnames_positional))
+            if i > 1
+                printstyled(io, ", ", color = :light_black)
+            end
+            printstyled(io, string(varname), color = :light_black, bold = true)
+            printstyled(io, "::")
+            printstyled(io, string(stype), color = :light_black)
+        end
+
+        if !isempty(varnames_kw)
+            print(io, "; ")
+        end
+
+        for (i, (stype, varname)) in enumerate(zip(sigtypes_kw, varnames_kw))
             if i > 1
                 printstyled(io, ", ", color = :light_black)
             end
@@ -778,7 +807,7 @@ function print_stackframe(io, i, frame, digit_align_width, modulecolor)
     end
 
     println(io)
-    
+
     # @
     printstyled(io, " " ^ (digit_align_width + 1) * "@ ", color = :light_black)
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -620,7 +620,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
 
         modul = getmodule(frame)
         if !haskey(modulecolordict, modul)
-            modulecolordict[modul] = popfirst!(modulecolorcycler)[1]
+            modulecolordict[modul] = popfirst!(modulecolorcycler)
         end
         modulecolor = modulecolordict[modul]
         

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -597,7 +597,9 @@ function show_reduced_backtrace(io::IO, t::Vector)
 
     try invokelatest(update_stackframes_callback[], displayed_stackframes) catch end
 
-    println(io, "\nStacktrace:")
+    println(io, "\n--- STACKTRACE ---")
+    stacktrace_linebreaks() && println(io)
+
     ndigits_max = ndigits(length(t))
 
     modulecolordict = Dict("" => :default)
@@ -694,6 +696,9 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
 
     modulecolordict = Dict("" => :default)
     modulecolorcycler = Iterators.Stateful(Iterators.cycle(STACKTRACE_MODULECOLORS))
+
+    println(io, "\n--- STACKTRACE ---")
+    stacktrace_linebreaks() && println(io)
 
     for (i, frame) in enumerate(trace)
 
@@ -815,8 +820,6 @@ function show_backtrace(io::IO, t::Vector)
         show_reduced_backtrace(IOContext(io, :backtrace => true), filtered)
         return
     end
-
-    println(io, "\nStacktrace:")
 
     # process_backtrace returns a Vector{Tuple{Frame, Int}}
     frames = first.(filtered)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -611,7 +611,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
     println(io, "\nStacktrace:")
     ndigits = length(digits(length(t)))
 
-    modulecolorcycler = Iterators.cycle(STACKTRACE_MODULECOLORS)
+    modulecolorcycler = Iterators.Stateful(Iterators.cycle(STACKTRACE_MODULECOLORS))
 
     push!(repeated_cycle, (0,0,0)) # repeated_cycle is never empty
     frame_counter = 1
@@ -620,7 +620,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
 
         modul = getmodule(frame)
         if !haskey(modulecolordict, modul)
-            modulecolordict[modul] = iterate(modulecolorcycler)[1]
+            modulecolordict[modul] = popfirst!(modulecolorcycler)[1]
         end
         modulecolor = modulecolordict[modul]
         
@@ -717,13 +717,13 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
     ndigits = length(digits(n))
 
     modulecolordict = Dict("" => :default)
-    modulecolorcycler = Iterators.cycle(STACKTRACE_MODULECOLORS)
+    modulecolorcycler = Iterators.Stateful(Iterators.cycle(STACKTRACE_MODULECOLORS))
 
     for (i, frame) in enumerate(trace)
 
         modul = getmodule(frame)
         if !haskey(modulecolordict, modul)
-            modulecolordict[modul] = iterate(modulecolorcycler)[1]
+            modulecolordict[modul] = popfirst!(modulecolorcycler)
         end
         modulecolor = modulecolordict[modul]
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -566,8 +566,6 @@ function show_reduced_backtrace(io::IO, t::Vector)
     such that hash(t[i-1]) == h, ie the list of positions in which the
     frame appears just before. =#
 
-    modulecolordict = Dict("" => :default)
-
     displayed_stackframes = []
     repeated_cycle = Tuple{Int,Int,Int}[]
     # First:  line to introuce the "cycle repetition" message
@@ -611,6 +609,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
     println(io, "\nStacktrace:")
     ndigits_max = ndigits(length(t))
 
+    modulecolordict = Dict("" => :default)
     modulecolorcycler = Iterators.Stateful(Iterators.cycle(STACKTRACE_MODULECOLORS))
 
     push!(repeated_cycle, (0,0,0)) # repeated_cycle is never empty
@@ -618,21 +617,7 @@ function show_reduced_backtrace(io::IO, t::Vector)
     for i in 1:length(displayed_stackframes)
         (frame, n) = displayed_stackframes[i]
 
-        modul = getmodule(frame)
-        if !haskey(modulecolordict, modul)
-            modulecolordict[modul] = popfirst!(modulecolorcycler)
-        end
-        modulecolor = modulecolordict[modul]
-        
-        file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
-        line = getline(frame)
-        varnames = getvarnames(frame)
-        func = getfunc(frame)
-        sigtypes = getsigtypes(frame)
-        inlined = getfield(frame, :inlined)
-
-        push!(LAST_SHOWN_LINE_INFOS, (file, line))
-        print_frame(io, frame_counter, func, inlined, modul, file, line, sigtypes, varnames, ndigits_max, modulecolor)
+        print_frame(io, frame_counter, frame, ndigits_max, modulecolordict, modulecolorcycler)
         
         if i < length(displayed_stackframes)
             println(io)
@@ -721,21 +706,7 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
 
     for (i, frame) in enumerate(trace)
 
-        modul = getmodule(frame)
-        if !haskey(modulecolordict, modul)
-            modulecolordict[modul] = popfirst!(modulecolorcycler)
-        end
-        modulecolor = modulecolordict[modul]
-
-        file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
-        line = getline(frame)
-        varnames = getvarnames(frame)
-        func = getfunc(frame)
-        sigtypes = getsigtypes(frame)
-        inlined = getfield(frame, :inlined)
-
-        push!(LAST_SHOWN_LINE_INFOS, (file, line))
-        print_frame(io, i, func, inlined, modul, file, line, sigtypes, varnames, ndigits_max, modulecolor)
+        print_frame(io, i, frame, ndigits_max, modulecolordict, modulecolorcycler)
         if i < n
             println(io)
             print_linebreaks && println(io)
@@ -743,8 +714,23 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
     end
 end
 
-function print_frame(io, i, func, inlined, modul, file, line, specialization_types,
-    variable_names, width_digits, modulecolor)
+function print_frame(io, i, frame, width_digits, modulecolordict, modulecolorcycler)
+
+    file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
+    line = getline(frame)
+
+    # add file and line info for accessing frame locations from the repl
+    push!(LAST_SHOWN_LINE_INFOS, (file, line))
+
+    variable_names = getvarnames(frame)
+    func = getfunc(frame)
+    specialization_types = getsigtypes(frame)
+    inlined = getfield(frame, :inlined)
+    modul = getmodule(frame)
+    if !haskey(modulecolordict, modul)
+        modulecolordict[modul] = popfirst!(modulecolorcycler)
+    end
+    modulecolor = modulecolordict[modul]
 
     # frame number
     print(io, lpad("[" * string(i) * "]", width_digits + 2))

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -705,7 +705,30 @@ function print_trace(io::IO, trace; print_linebreaks::Bool)
     end
 end
 
-function print_frame(io, i, frame, width_digits, modulecolordict, modulecolorcycler)
+"""
+    print_frame(io, i, frame, digit_align_width, modulecolordict::Dict, modulecolorcycler)
+
+Print a stack frame where the module color is determined by looking up the parent module in
+`modulecolordict`. If the module does not have a color, yet, a new one can be drawn
+from `modulecolorcycler`.
+"""
+function print_frame(io, i, frame, digit_align_width, modulecolordict, modulecolorcycler)
+    modul = getmodule(frame)
+    parentmodule = split(modul, ".")[1]
+    if !haskey(modulecolordict, parentmodule)
+        modulecolordict[parentmodule] = popfirst!(modulecolorcycler)
+    end
+    modulecolor = modulecolordict[parentmodule]
+
+    print_frame(io, i, frame, digit_align_width, modulecolor)
+end
+
+"""
+    print_frame(io, i, frame, digit_align_width, modulecolordict::Dict, modulecolorcycler)
+
+Print a stack frame where the module color is set manually with `modulecolor`.
+"""
+function print_frame(io, i, frame, digit_align_width, modulecolor)
 
     file = getfile(frame, stacktrace_expand_basepaths(), stacktrace_contract_userdir())
     line = getline(frame)
@@ -721,13 +744,9 @@ function print_frame(io, i, frame, width_digits, modulecolordict, modulecolorcyc
     specialization_types = getsigtypes(frame)
     inlined = getfield(frame, :inlined)
     modul = getmodule(frame)
-    if !haskey(modulecolordict, modul)
-        modulecolordict[modul] = popfirst!(modulecolorcycler)
-    end
-    modulecolor = modulecolordict[modul]
 
     # frame number
-    print(io, lpad("[" * string(i) * "]", width_digits + 2))
+    print(io, lpad("[" * string(i) * "]", digit_align_width + 2))
     print(io, " ")
     
     # function name
@@ -752,7 +771,7 @@ function print_frame(io, i, frame, width_digits, modulecolordict, modulecolorcyc
     println(io)
     
     # @
-    printstyled(io, " " ^ (width_digits + 1) * "@ ", color = :light_black)
+    printstyled(io, " " ^ (digit_align_width + 1) * "@ ", color = :light_black)
 
     # module
     if !isempty(modul)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -648,7 +648,7 @@ end
 function find_source_file(path::AbstractString)
     (isabspath(path) || isfile(path)) && return path
     base_path = joinpath(Sys.BINDIR::String, DATAROOTDIR, "julia", "base", path)
-    return isfile(base_path) ? base_path : nothing
+    return isfile(base_path) ? normpath(base_path) : nothing
 end
 
 cache_file_entry(pkg::PkgId) = joinpath(

--- a/base/show.jl
+++ b/base/show.jl
@@ -1787,7 +1787,7 @@ function show_signature_function(io::IO, @nospecialize(ft), demangle=false, farg
     nothing
 end
 
-function printstacktrace(io, s...; color, bold=false)
+function print_within_stacktrace(io, s...; color, bold=false)
     if get(io, :backtrace, false)::Bool
         printstyled(io, s...; color, bold)
     else
@@ -1810,16 +1810,16 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwa
     sig = sig.parameters
     show_signature_function(env_io, sig[1], demangle)
     first = true
-    printstacktrace(io, "(", color=:light_black)
+    print_within_stacktrace(io, "(", color=:light_black)
     show_argnames = argnames !== nothing && length(argnames) == length(sig)
     for i = 2:length(sig)  # fixme (iter): `eachindex` with offset?
         first || print(io, ", ")
         first = false
         if show_argnames
-            printstacktrace(io, argnames[i]; bold=true, color=:light_black)
+            print_within_stacktrace(io, argnames[i]; bold=true, color=:light_black)
         end
         print(io, "::")
-        printstacktrace(env_io, sig[i]; color=:light_black)
+        print_within_stacktrace(env_io, sig[i]; color=:light_black)
     end
     if kwargs !== nothing
         print(io, "; ")
@@ -1827,12 +1827,12 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwa
         for (k, t) in kwargs
             first || print(io, ", ")
             first = false
-            printstacktrace(io, k; bold=true, color=:light_black)
+            print_within_stacktrace(io, k; bold=true, color=:light_black)
             print(io, "::")
-            printstacktrace(io, t; color=:light_black)
+            print_within_stacktrace(io, t; color=:light_black)
         end
     end
-    printstacktrace(io, ")", color=:light_black)
+    print_within_stacktrace(io, ")", color=:light_black)
     show_method_params(io, tv)
     nothing
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1787,11 +1787,17 @@ function show_signature_function(io::IO, @nospecialize(ft), demangle=false, farg
     nothing
 end
 
-function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing)
+function printstacktrace(io, s...; color, bold=false)
+    if get(io, :backtrace, false)::Bool
+        printstyled(io, s...; color, bold)
+    else
+        print(io, s...)
+    end
+end
+function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing, argnames=nothing)
     # print a method signature tuple for a lambda definition
-    color = get(io, :color, false) && get(io, :backtrace, false) ? stackframe_function_color() : :nothing
     if sig === Tuple
-        printstyled(io, demangle ? demangle_function_name(name) : name, "(...)", color=color)
+        print(io, demangle ? demangle_function_name(name) : name, "(...)")
         return
     end
     tv = Any[]
@@ -1802,16 +1808,18 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwa
         sig = sig.body
     end
     sig = sig.parameters
-    with_output_color(color, env_io) do io
-        show_signature_function(io, sig[1], demangle)
-    end
+    show_signature_function(env_io, sig[1], demangle)
     first = true
-    print_style = get(io, :color, false) && get(io, :backtrace, false) ? :bold : :nothing
-    printstyled(io, "(", color=print_style)
+    printstacktrace(io, "(", color=:light_black)
+    show_argnames = argnames !== nothing && length(argnames) == length(sig)
     for i = 2:length(sig)  # fixme (iter): `eachindex` with offset?
         first || print(io, ", ")
         first = false
-        print(env_io, "::", sig[i])
+        if show_argnames
+            printstacktrace(io, argnames[i]; bold=true, color=:light_black)
+        end
+        print(io, "::")
+        printstacktrace(env_io, sig[i]; color=:light_black)
     end
     if kwargs !== nothing
         print(io, "; ")
@@ -1819,11 +1827,12 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwa
         for (k, t) in kwargs
             first || print(io, ", ")
             first = false
-            print(io, k, "::")
-            show(io, t)
+            printstacktrace(io, k; bold=true, color=:light_black)
+            print(io, "::")
+            printstacktrace(io, t; color=:light_black)
         end
     end
-    printstyled(io, ")", color=print_style)
+    printstacktrace(io, ")", color=:light_black)
     show_method_params(io, tv)
     nothing
 end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -216,30 +216,28 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         elseif frame.func === top_level_scope_sym
             print(io, "top-level scope")
         else
-            color = get(io, :color, false) && get(io, :backtrace, false) ?
-                        Base.stackframe_function_color() :
-                        :nothing
-            printstyled(io, Base.demangle_function_name(string(frame.func)), color=color)
+            print(io, Base.demangle_function_name(string(frame.func)))
         end
     elseif frame.linfo isa MethodInstance
         def = frame.linfo.def
         if isa(def, Method)
             sig = frame.linfo.specTypes
+            argnames = Base.method_argnames(def)
             if def.nkw > 0
                 # rearrange call kw_impl(kw_args..., func, pos_args...) to func(pos_args...)
                 kwarg_types = Any[ fieldtype(sig, i) for i = 2:(1+def.nkw) ]
                 uw = Base.unwrap_unionall(sig)
                 pos_sig = Base.rewrap_unionall(Tuple{uw.parameters[(def.nkw+2):end]...}, sig)
-                kwnames = Base.method_argnames(def)[2:(def.nkw+1)]
+                kwnames = argnames[2:(def.nkw+1)]
                 for i = 1:length(kwnames)
                     str = string(kwnames[i])
                     if endswith(str, "...")
                         kwnames[i] = Symbol(str[1:end-3])
                     end
                 end
-                Base.show_tuple_as_call(io, def.name, pos_sig, true, zip(kwnames, kwarg_types))
+                Base.show_tuple_as_call(io, def.name, pos_sig, true, zip(kwnames, kwarg_types), argnames[def.nkw+2:end])
             else
-                Base.show_tuple_as_call(io, def.name, sig, true)
+                Base.show_tuple_as_call(io, def.name, sig, true, nothing, argnames)
             end
         else
             Base.show(io, frame.linfo)
@@ -249,18 +247,16 @@ function show_spec_linfo(io::IO, frame::StackFrame)
     end
 end
 
-function show(io::IO, frame::StackFrame; full_path::Bool=false)
+function show(io::IO, frame::StackFrame)
     show_spec_linfo(io, frame)
     if frame.file !== empty_sym
-        file_info = full_path ? string(frame.file) : basename(string(frame.file))
+        file_info = basename(string(frame.file))
         print(io, " at ")
-        Base.with_output_color(get(io, :color, false) && get(io, :backtrace, false) ? Base.stackframe_lineinfo_color() : :nothing, io) do io
-            print(io, file_info, ":")
-            if frame.line >= 0
-                print(io, frame.line)
-            else
-                print(io, "?")
-            end
+        print(io, file_info, ":")
+        if frame.line >= 0
+            print(io, frame.line)
+        else
+            print(io, "?")
         end
     end
     if frame.inlined

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -245,16 +245,6 @@ should have at the terminal.
 The formatting `Base.answer_color()` (default: normal, `"\033[0m"`) that output
 should have at the terminal.
 
-### `JULIA_STACKFRAME_LINEINFO_COLOR`
-
-The formatting `Base.stackframe_lineinfo_color()` (default: bold, `"\033[1m"`)
-that line info should have during a stack trace at the terminal.
-
-### `JULIA_STACKFRAME_FUNCTION_COLOR`
-
-The formatting `Base.stackframe_function_color()` (default: bold, `"\033[1m"`)
-that function calls should have during a stack trace at the terminal.
-
 ## Debugging and profiling
 
 ### `JULIA_DEBUG`

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -201,7 +201,7 @@ end
     │   exception =
     │    DivideError: integer division error
     │    Stacktrace:
-    │     [1] func1()""")
+    │      [1] func1()""")
 
 
     @testset "Limiting large data structures" begin

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -201,7 +201,7 @@ end
     │   exception =
     │    DivideError: integer division error
     │    Stacktrace:
-    │     [1] func1() at""")
+    │     [1] func1()""")
 
 
     @testset "Limiting large data structures" begin

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -194,8 +194,8 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=false)) do stdin_wr
         @test occursin("shell> ", s) # check for the echo of the prompt
         @test occursin("'", s) # check for the echo of the input
         s = readuntil(stdout_read, "\n\n")
-        @test startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n [1] ") ||
-              startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n [1] ")
+        @test startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n  [1] ") ||
+              startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n  [1] ")
     end
 
     # issue #27293

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -731,11 +731,11 @@ end
 # Test backtrace printing
 module B
     module C
-        f(x; y=2) = error()
+        f(x; y=2.0) = error()
     end
     module D
         import ..C: f
-        g() = f(2; y=3)
+        g() = f(2.0; y=3.0)
     end
 end
 
@@ -746,7 +746,7 @@ end
     end
     bt_str = sprint(Base.show_backtrace, bt)
     m = @__MODULE__
-    @test contains(bt_str, "f(x::Int64; y::Int64)")
+    @test contains(bt_str, "f(x::Float64; y::Float64)")
     @test contains(bt_str, "@ $m.B.C")
     @test contains(bt_str, "@ $m.B.D")
 end

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -177,17 +177,17 @@ let bt
     catch
         bt = stacktrace(catch_backtrace())
     end
-    @test any(s->startswith(string(s), "f33065(::Float32; b::Float64, a::String)"), bt)
+    @test any(s->startswith(string(s), "f33065(x::Float32; b::Float64, a::String)"), bt)
     try
         f33065(0.0f0, b=:x)
     catch
         bt = stacktrace(catch_backtrace())
     end
-    @test any(s->startswith(string(s), "f33065(::Float32; b::Symbol, a::String)"), bt)
+    @test any(s->startswith(string(s), "f33065(x::Float32; b::Symbol, a::String)"), bt)
     try
         f33065(0.0f0, 0.0f0, z=0)
     catch
         bt = stacktrace(catch_backtrace())
     end
-    @test any(s->startswith(string(s), "f33065(::Float32, ::Float32; b::Float64, a::String, c::"), bt)
+    @test any(s->startswith(string(s), "f33065(x::Float32, y::Float32; b::Float64, a::String, c::"), bt)
 end


### PR DESCRIPTION
cf. issue #36026

The base functionality works. I added handling of stackoverflow traces, too.

I have not dealt with any tests, yet. Also, somebody in the know should check if my methods of retrieving different parts of information about each frame are valid.

I am also checking for three boolean ENV variables in the code, to make printing a bit more customizable. They are:

```
JULIA_STACKTRACE_EXPAND_BASEPATHS
JULIA_STACKTRACE_CONTRACT_USERDIR
JULIA_STACKTRACE_LINEBREAKS
```