### PR TITLE
remove unnecessary newline when printing BoundsError

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -42,7 +42,6 @@ function showerror(io::IO, ex::BoundsError)
         print(io, ": attempt to access ")
         summary(io, ex.a)
         if isdefined(ex, :i)
-            !isa(ex.a, AbstractArray) && print(io, "\n ")
             print(io, " at index [")
             if ex.i isa AbstractRange
                 print(io, ex.i)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -412,13 +412,11 @@ julia> thisind("α", 3)
 3
 
 julia> thisind("α", 4)
-ERROR: BoundsError: attempt to access String
-  at index [4]
+ERROR: BoundsError: attempt to access String at index [4]
 [...]
 
 julia> thisind("α", -1)
-ERROR: BoundsError: attempt to access String
-  at index [-1]
+ERROR: BoundsError: attempt to access String at index [-1]
 [...]
 ```
 """
@@ -468,8 +466,7 @@ julia> prevind("α", 1)
 0
 
 julia> prevind("α", 0)
-ERROR: BoundsError: attempt to access String
-  at index [0]
+ERROR: BoundsError: attempt to access String at index [0]
 [...]
 
 julia> prevind("α", 2, 2)
@@ -528,8 +525,7 @@ julia> nextind("α", 1)
 3
 
 julia> nextind("α", 3)
-ERROR: BoundsError: attempt to access String
-  at index [3]
+ERROR: BoundsError: attempt to access String at index [3]
 [...]
 
 julia> nextind("α", 0, 2)

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -205,13 +205,11 @@ Using an index less than `begin` (`1`) or greater than `end` raises an error:
 
 ```jldoctest helloworldstring
 julia> str[begin-1]
-ERROR: BoundsError: attempt to access String
-  at index [0]
+ERROR: BoundsError: attempt to access String at index [0]
 [...]
 
 julia> str[end+1]
-ERROR: BoundsError: attempt to access String
-  at index [15]
+ERROR: BoundsError: attempt to access String at index [15]
 [...]
 ```
 

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -291,7 +291,7 @@ let undefvar
     @test occursin("DomainError with [0.0 -1.0 …", err_str)
 
     err_str = @except_str (1, 2, 3)[4] BoundsError
-    @test err_str == "BoundsError: attempt to access (1, 2, 3)\n  at index [4]"
+    @test err_str == "BoundsError: attempt to access (1, 2, 3) at index [4]"
 
     err_str = @except_str [5, 4, 3][-2, 1] BoundsError
     @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [-2, 1]"
@@ -299,7 +299,7 @@ let undefvar
     @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [1:5]"
 
     err_str = @except_str Bounded(2)[3] BoundsError
-    @test err_str == "BoundsError: attempt to access 2-size Bounded\n  at index [3]"
+    @test err_str == "BoundsError: attempt to access 2-size Bounded at index [3]"
 
     err_str = @except_str 0::Bool TypeError
     @test err_str == "TypeError: non-boolean ($Int) used in boolean context"


### PR DESCRIPTION
I guess this was there because previously we didn't use `summary` when printing the value. It doesn't really make sense now anymore.