### PR TITLE
add a summary for AbstractString

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -419,11 +419,11 @@ julia> thisind("α", 3)
 3
 
 julia> thisind("α", 4)
-ERROR: BoundsError: attempt to access String at index [4]
+ERROR: BoundsError: attempt to access 2-codeunit String at index [4]
 [...]
 
 julia> thisind("α", -1)
-ERROR: BoundsError: attempt to access String at index [-1]
+ERROR: BoundsError: attempt to access 2-codeunit String at index [-1]
 [...]
 ```
 """
@@ -473,7 +473,7 @@ julia> prevind("α", 1)
 0
 
 julia> prevind("α", 0)
-ERROR: BoundsError: attempt to access String at index [0]
+ERROR: BoundsError: attempt to access 2-codeunit String at index [0]
 [...]
 
 julia> prevind("α", 2, 2)
@@ -532,7 +532,7 @@ julia> nextind("α", 1)
 3
 
 julia> nextind("α", 3)
-ERROR: BoundsError: attempt to access String at index [3]
+ERROR: BoundsError: attempt to access 2-codeunit String at index [3]
 [...]
 
 julia> nextind("α", 0, 2)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -229,6 +229,12 @@ Symbol(x...) = Symbol(string(x...))
 convert(::Type{T}, s::T) where {T<:AbstractString} = s
 convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)
 
+## summary ##
+
+function summary(io::IO, s::AbstractString)
+    print(io, ncodeunits(s), "-codeunit ", typeof(s))
+end
+
 ## string & character concatenation ##
 
 """

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -232,7 +232,8 @@ convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)
 ## summary ##
 
 function summary(io::IO, s::AbstractString)
-    print(io, ncodeunits(s), "-codeunit ", typeof(s))
+    prefix = isempty(s) ? "empty" : string(ncodeunits(s), "-codeunit")
+    print(io, prefix, " ", typeof(s))
 end
 
 ## string & character concatenation ##

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -205,11 +205,11 @@ Using an index less than `begin` (`1`) or greater than `end` raises an error:
 
 ```jldoctest helloworldstring
 julia> str[begin-1]
-ERROR: BoundsError: attempt to access String at index [0]
+ERROR: BoundsError: attempt to access 14-codeunit String at index [0]
 [...]
 
 julia> str[end+1]
-ERROR: BoundsError: attempt to access String at index [15]
+ERROR: BoundsError: attempt to access 14-codeunit String at index [15]
 [...]
 ```
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1085,3 +1085,8 @@ end
     e = StringIndexError(str, 2)
     @test sprint(showerror, e) == "StringIndexError: invalid index [2], valid nearby index [1]=>'κ'"
 end
+
+@testset "summary" begin
+    @test sprint(summary, "foα") == "4-codeunit String"
+    @test sprint(summary, SubString("foα", 2)) == "3-codeunit SubString{String}"
+end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1089,4 +1089,5 @@ end
 @testset "summary" begin
     @test sprint(summary, "foα") == "4-codeunit String"
     @test sprint(summary, SubString("foα", 2)) == "3-codeunit SubString{String}"
+    @test sprint(summary, "") == "empty String"
 end


### PR DESCRIPTION
A bit more useful than the current printing for e.g. BoundsError. Now it is:

```
julia> "foo"[5]
ERROR: BoundsError: attempt to access 3-codeunit String at index [5]
```