### PR TITLE
Satisfy TODO in Complex muladd

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -278,8 +278,8 @@ inv(z::Complex{<:Integer}) = inv(float(z))
                                     real(z) * imag(w) + imag(z) * real(w))
 
 muladd(z::Complex, w::Complex, x::Complex) =
-    Complex(muladd(real(z), real(w), real(x)) - imag(z)*imag(w), # TODO: use mulsub given #15985
-            muladd(real(z), imag(w), muladd(imag(z), real(w), imag(x))))
+    Complex(muladd(real(z), real(w), -muladd(imag(z), imag(w), -real(x))),
+            muladd(real(z), imag(w),  muladd(imag(z), real(w),  imag(x))))
 
 # handle Bool and Complex{Bool}
 # avoid type signature ambiguity warnings
@@ -326,7 +326,7 @@ muladd(z::Complex, x::Real, w::Complex) =
     Complex(muladd(real(z),x,real(w)), muladd(imag(z),x,imag(w)))
 muladd(x::Real, y::Real, z::Complex) = Complex(muladd(x,y,real(z)), imag(z))
 muladd(z::Complex, w::Complex, x::Real) =
-    Complex(muladd(real(z), real(w), x) - imag(z)*imag(w), # TODO: use mulsub given #15985
+    Complex(muladd(real(z), real(w), -muladd(imag(z), imag(w), -x)),
             muladd(real(z), imag(w), imag(z) * real(w)))
 
 /(a::R, z::S) where {R<:Real,S<:Complex} = (T = promote_type(R,S); a*inv(T(z)))


### PR DESCRIPTION
This PR has reduced in scope/changed goals. The original message is shown below, but the purpose now is to simply satisfy an old TODO in the definition of `muladd` for `Complex` arguments that mentions a "future" `mulsub` function. The `mulsub` function was never added (see #15985), and modern LLVM's optimizations are sufficient to take a sequence of `muladd` and negations and turn it into the corresponding fused multiply-subtract where appropriate.

---
PR #15980 defined `muladd` for `Complex` (and various combinations of mixed `Complex`-`Real`) arguments. It seems the same could (should?) be done for `fma` as well.

The original TODO comments concerning a future `mulsub` no longer apply since LLVM appears to be capable of reconstructing the fused multiply-subtract, as already mentioned recently in https://github.com/JuliaLang/julia/pull/35562#issuecomment-618605790:
```julia
julia> code_native(fma, Tuple{ComplexF64, ComplexF64, ComplexF64}, debuginfo=:none)
        .text
        vmovsd  8(%rsi), %xmm1          # xmm1 = mem[0],zero
        vmovsd  8(%rdx), %xmm3          # xmm3 = mem[0],zero
        vmovsd  (%rcx), %xmm4           # xmm4 = mem[0],zero
        vmovsd  (%rsi), %xmm0           # xmm0 = mem[0],zero
        vmovsd  (%rdx), %xmm2           # xmm2 = mem[0],zero
        movq    %rdi, %rax
        vfmsub231sd     %xmm3, %xmm1, %xmm4 # xmm4 = (xmm1 * xmm3) - xmm4
        vfmsub231sd     %xmm2, %xmm0, %xmm4 # xmm4 = (xmm0 * xmm2) - xmm4
        vfmadd213sd     8(%rcx), %xmm1, %xmm2 # xmm2 = (xmm1 * xmm2) + mem
        vmovsd  %xmm4, (%rdi)
        vfmadd231sd     %xmm3, %xmm0, %xmm2 # xmm2 = (xmm0 * xmm3) + xmm2
        vmovsd  %xmm2, 8(%rdi)
        retq
        nopl    (%rax,%rax)
```

---

For a motivating reason, I've been working on an algorithm where `fma` on real inputs is necessary for maintaining as much numerical accuracy as possible, but the mathematical function is technically defined over the complex domain as well. Without appropriate definitions of `fma` for `Complex`, the algorithm currently fails for complex arguments (or requires an extra type-based branch to fall back to `muladd`, which would give divergent answers when the complex input is located on the real axis).