### PR TITLE
fix ImmutableDict(pairs...) constructor

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -739,6 +739,8 @@ Create a new entry in the `ImmutableDict` for a `key => value` pair
 ImmutableDict
 ImmutableDict(KV::Pair{K,V}) where {K,V} = ImmutableDict{K,V}(KV[1], KV[2])
 ImmutableDict(t::ImmutableDict{K,V}, KV::Pair) where {K,V} = ImmutableDict{K,V}(t, KV[1], KV[2])
+ImmutableDict(t::ImmutableDict{K,V}, KV::Pair, rest::Pair...) where {K,V} =
+    ImmutableDict(ImmutableDict(t, KV), rest...)
 ImmutableDict(KV::Pair, rest::Pair...) = ImmutableDict(ImmutableDict(KV), rest...)
 
 function in(key_value::Pair, dict::ImmutableDict, valcmp=(==))

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -723,7 +723,9 @@ import Base.ImmutableDict
     d5 = ImmutableDict(v...)
     @test d5 == d2
     @test reverse(collect(d5)) == v
-    @test ImmutableDict(:a => 1, :a => 2)[:a] == 2
+    d6 = ImmutableDict(:a => 1, :b => 3, :a => 2)
+    @test d6[:a] == 2
+    @test d6[:b] == 3
 
     @test !haskey(ImmutableDict(-0.0=>1), 0.0)
 end


### PR DESCRIPTION
It could only handle a couple of pairs, e.g.
`ImmutableDict(1=>1, 2=>2, 3=>3)` would throw.

The fix is implemented by adding the
`ImmutableDict(t::ImmutableDict, pairs...)` constructor,
which generalizes `ImmutableDict(t::ImmutableDict, pair)`
(with some similarity to how `push!` accepts multiple items
to be pushed).