### PR TITLE
allow `redirect_std*` to `devnull` (#36136)

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1098,6 +1098,12 @@ for (x, writable, unix_fd, c_symbol) in
             ($f)($(writable ? :write : :read))
             return (read, write)
         end
+        function ($f)(::DevNull)
+            nulldev = @static Sys.iswindows() ? "NUL" : "/dev/null"
+            handle = open(nulldev, write=$writable)
+            $(_f)(handle)
+            return handle
+        end
     end
 end
 
@@ -1115,7 +1121,7 @@ elsewhere.
 If called with the optional `stream` argument, then returns `stream` itself.
 
 !!! note
-    `stream` must be a `TTY`, a `Pipe`, or a socket.
+    `stream` must be a `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
 """
 redirect_stdout
 
@@ -1125,7 +1131,7 @@ redirect_stdout
 Like [`redirect_stdout`](@ref), but for [`stderr`](@ref).
 
 !!! note
-    `stream` must be a `TTY`, a `Pipe`, or a socket.
+    `stream` must be a `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
 """
 redirect_stderr
 
@@ -1137,7 +1143,7 @@ Note that the order of the return tuple is still `(rd, wr)`,
 i.e. data to be read from [`stdin`](@ref) may be written to `wr`.
 
 !!! note
-    `stream` must be a `TTY`, a `Pipe`, or a socket.
+    `stream` must be a `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
 """
 redirect_stdin
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1099,6 +1099,7 @@ for (x, writable, unix_fd, c_symbol) in
             return (read, write)
         end
         function ($f)(::DevNull)
+            global $x
             nulldev = @static Sys.iswindows() ? "NUL" : "/dev/null"
             handle = open(nulldev, write=$writable)
             $(_f)(handle)
@@ -1123,7 +1124,7 @@ elsewhere.
 If called with the optional `stream` argument, then returns `stream` itself.
 
 !!! note
-    `stream` must be a `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
+    `stream` must be an `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
 """
 redirect_stdout
 
@@ -1133,7 +1134,7 @@ redirect_stdout
 Like [`redirect_stdout`](@ref), but for [`stderr`](@ref).
 
 !!! note
-    `stream` must be a `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
+    `stream` must be an `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
 """
 redirect_stderr
 
@@ -1145,7 +1146,7 @@ Note that the order of the return tuple is still `(rd, wr)`,
 i.e. data to be read from [`stdin`](@ref) may be written to `wr`.
 
 !!! note
-    `stream` must be a `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
+    `stream` must be an `IOStream`, a `TTY`, a `Pipe`, a socket, or `devnull`.
 """
 redirect_stdin
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -259,7 +259,13 @@ end
 @testset "redirect to devnull" begin
     @test redirect_stdout(devnull) do; println("Hello") end === nothing
     @test redirect_stderr(devnull) do; println(stderr, "Hello") end === nothing
-    @test redirect_stdin(devnull) do; read(stdin, String) end == ""
+    # stdin is unavailable on the workers. Run test on master.
+    ret = Core.eval(Main, quote
+                remotecall_fetch(1) do
+                    redirect_stdin(devnull) do; read(stdin, String) end
+                end
+            end)
+    @test ret == ""
 end
 
 # Test that redirecting an IOStream does not crash the process

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -255,6 +255,13 @@ end
     end
 end
 
+# issue #36136
+@testset "redirect to devnull" begin
+    @test redirect_stdout(devnull) do; println("Hello") end === nothing
+    @test redirect_stderr(devnull) do; println(stderr, "Hello") end === nothing
+    @test redirect_stdin(devnull) do; read(stdin, String) end == ""
+end
+
 # Test that redirecting an IOStream does not crash the process
 let fname = tempname(), p
     cmd = """


### PR DESCRIPTION
solves #36136 partially. 

The methods `redirect_std*(io::Base.DevNull)` have been added. They redirect to `"/dev/null"` on non-windows systems and to `"NUL"` elsewhere.
This allows to call for example `redirect_stdout(f, devnull)` to supress all output to `stdout` produced in function call `f()`.
The first argument `f` is still restricted to `::Function`.