### PR TITLE
Add parens to |> docstring

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -901,6 +901,7 @@ widen(x::Type{T}) where {T} = throw(MethodError(widen, (T,)))
     |>(x, f)
 
 Applies a function to the preceding argument. This allows for easy function chaining.
+When used with anonymous functions, parentheses are typically required around the definition to get the intended chain.
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -905,7 +905,7 @@ When used with anonymous functions, parentheses are typically required around th
 
 # Examples
 ```jldoctest
-julia> [1:5;] |> (x->x.^2) |> sum |> inv
+julia> [1:5;] .|> (x -> x^2) |> sum |> inv
 0.01818181818181818
 ```
 """


### PR DESCRIPTION
It is a common misunderstanding that
`data |> x -> f(x) |> g`
parses to
`data |> (x -> f(x)) |> g`
when it actually parses to
` data |> x -> (f(x) |> g)`
due to `|>` operator precedence. This can lead to unexpected behavior when using broadcasted pipelining. Using the docstring example with a broadcasted pipeline operator:
```julia
julia> [1:5;] .|> x->x^2 |> sum |> inv
5-element Array{Float64,1}:
 1.0 
 0.25
 0.1111111111111111
 0.0625
 0.04

julia> [1:5;] .|> (x->x^2) |> sum |> inv
0.01818181818181818
```
Having an anonymous function without enclosing parentheses in the docstring for `|>` may promote this misunderstanding.