### PR TITLE
simplify generated code for iterate on codeunits

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -731,7 +731,7 @@ size(s::CodeUnits) = (length(s),)
 elsize(s::CodeUnits{T}) where {T} = sizeof(T)
 @propagate_inbounds getindex(s::CodeUnits, i::Int) = codeunit(s.s, i)
 IndexStyle(::Type{<:CodeUnits}) = IndexLinear()
-@inline iterate(s::CodeUnits, i=1) = (@_inline_meta; (i % UInt) - 1 < length(s) ? (@inbounds s[i], i + 1) : nothing)
+@inline iterate(s::CodeUnits, i=1) = (i % UInt) - 1 < length(s) ? (@inbounds s[i], i + 1) : nothing
 
 
 write(io::IO, s::CodeUnits) = write(io, s.s)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -731,7 +731,8 @@ size(s::CodeUnits) = (length(s),)
 elsize(s::CodeUnits{T}) where {T} = sizeof(T)
 @propagate_inbounds getindex(s::CodeUnits, i::Int) = codeunit(s.s, i)
 IndexStyle(::Type{<:CodeUnits}) = IndexLinear()
-iterate(s::CodeUnits, i=1) = (@_propagate_inbounds_meta; i == length(s)+1 ? nothing : (s[i], i+1))
+@inline iterate(s::CodeUnits, i=1) = (@_inline_meta; (i % UInt) - 1 < length(s) ? (@inbounds s[i], i + 1) : nothing)
+
 
 write(io::IO, s::CodeUnits) = write(io, s.s)
 


### PR DESCRIPTION
One step towards fixing https://github.com/JuliaLang/julia/issues/30632. Makes the function noexcept but still doesn't vectorize in https://github.com/JuliaLang/julia/issues/30632 like `Array` does though (not that that matters much, I'm just using it as a smoke test to see that the abstractions are seen through).