### PR TITLE
Introduce skipuntil function and deprecate skipchars

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -208,3 +208,9 @@ macro get!(h, key0, default)
 end
 
 # END 1.5 deprecations
+
+# BEGIN 1.6 deprecations
+
+@deprecate skipchars(pred, io::IO; linecomment=nothing) skipuntil(!pred, io::IO; linecomment=linecomment)
+
+# END 1.6 deprecations

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -820,7 +820,6 @@ export
     seekend,
     seekstart,
     skip,
-    skipchars,
     skipuntil,
     take!,
     truncate,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -821,6 +821,7 @@ export
     seekstart,
     skip,
     skipchars,
+    skipuntil,
     take!,
     truncate,
     unmark,

--- a/base/io.jl
+++ b/base/io.jl
@@ -1070,38 +1070,6 @@ Commit all currently buffered writes to the given stream.
 flush(io::IO) = nothing
 
 """
-    skipchars(predicate, io::IO; linecomment=nothing)
-
-Advance the stream `io` such that the next-read character will be the first remaining for
-which `predicate` returns `false`. If the keyword argument `linecomment` is specified, all
-characters from that character until the start of the next line are ignored.
-
-# Examples
-```jldoctest
-julia> buf = IOBuffer("    text")
-IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=8, maxsize=Inf, ptr=1, mark=-1)
-
-julia> skipchars(isspace, buf)
-IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=8, maxsize=Inf, ptr=5, mark=-1)
-
-julia> String(readavailable(buf))
-"text"
-```
-"""
-function skipchars(predicate, io::IO; linecomment=nothing)
-    while !eof(io)
-        c = read(io, Char)
-        if c === linecomment
-            readline(io)
-        elseif !predicate(c)
-            skip(io, -ncodeunits(c))
-            break
-        end
-    end
-    return io
-end
-
-"""
     skipuntil(predicate, io::IO; linecomment=nothing)
 
 Advance `io` until `predicate(peek(c)) === true`.

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -43,7 +43,6 @@ Base.redirect_stdin
 Base.redirect_stdin(::Function, ::Any)
 Base.readchomp
 Base.truncate
-Base.skipchars
 Base.skipuntil
 Base.countlines
 Base.PipeBuffer

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -44,6 +44,7 @@ Base.redirect_stdin(::Function, ::Any)
 Base.readchomp
 Base.truncate
 Base.skipchars
+Base.skipuntil
 Base.countlines
 Base.PipeBuffer
 Base.readavailable

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1118,7 +1118,7 @@ end
 
 function edit_replace_word_right(buf::IOBuffer, replace::Function)
     # put the cursor at the beginning of the next word
-    skipchars(is_non_word_char, buf)
+    skipuntil(!is_non_word_char, buf)
     b = position(buf)
     char_move_word_right(buf)
     e = position(buf)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -300,6 +300,31 @@ end
     end
 end
 
+@testset "skipuntil" begin
+    io = IOBuffer("")
+    @test eof(skipuntil(isspace, io))
+
+    io = IOBuffer("   ")
+    @test eof(skipuntil(!isspace, io))
+
+    io = IOBuffer("#    \n     ")
+    @test eof(skipuntil(!isspace, io, linecomment='#'))
+
+    io = IOBuffer("      text")
+    skipuntil(!isspace, io)
+    @test String(readavailable(io)) == "text"
+
+    io = IOBuffer("   # comment \n    text")
+    skipuntil(!isspace, io, linecomment='#')
+    @test String(readavailable(io)) == "text"
+
+    for char in ['@','߷','࿊','𐋺']
+        io = IOBuffer("alphabeticalstuff$char")
+        @test !eof(skipuntil(!isletter, io))
+        @test read(io, Char) == char
+    end
+end
+
 @testset "Test constructor with a generic type argument." begin
     io = IOBuffer(maxsize=Int16(10))
     @test io isa IOBuffer

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -275,28 +275,30 @@ let io = IOBuffer()
     @test Base.buffer_writes(io) === io
 end
 
-@testset "skipchars" begin
-    io = IOBuffer("")
-    @test eof(skipchars(isspace, io))
+@static if Base.JLOptions().depwarn != 2
+    @testset "skipchars" begin
+        io = IOBuffer("")
+        @test eof(@test_deprecated(skipchars(isspace, io)))
 
-    io = IOBuffer("   ")
-    @test eof(skipchars(isspace, io))
+        io = IOBuffer("   ")
+        @test eof(@test_deprecated(skipchars(isspace, io)))
 
-    io = IOBuffer("#    \n     ")
-    @test eof(skipchars(isspace, io, linecomment='#'))
+        io = IOBuffer("#    \n     ")
+        @test eof(@test_deprecated(skipchars(isspace, io, linecomment='#')))
 
-    io = IOBuffer("      text")
-    skipchars(isspace, io)
-    @test String(readavailable(io)) == "text"
+        io = IOBuffer("      text")
+        @test_deprecated skipchars(isspace, io)
+        @test String(readavailable(io)) == "text"
 
-    io = IOBuffer("   # comment \n    text")
-    skipchars(isspace, io, linecomment='#')
-    @test String(readavailable(io)) == "text"
+        io = IOBuffer("   # comment \n    text")
+        @test_deprecated skipchars(isspace, io, linecomment='#')
+        @test String(readavailable(io)) == "text"
 
-    for char in ['@','߷','࿊','𐋺']
-        io = IOBuffer("alphabeticalstuff$char")
-        @test !eof(skipchars(isletter, io))
-        @test read(io, Char) == char
+        for char in ['@','߷','࿊','𐋺']
+            io = IOBuffer("alphabeticalstuff$char")
+            @test !eof(@test_deprecated(skipchars(isletter, io)))
+            @test read(io, Char) == char
+        end
     end
 end
 

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -1,40 +1,42 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-@testset "skipchars for IOStream" begin
-    mktemp() do path, file
-        function append_to_file(str)
-            mark(file)
-            print(file, str)
-            flush(file)
-            reset(file)
-        end
-        # test it doesn't error on eof
-        @test eof(skipchars(isspace, file))
+@static if Base.JLOptions().depwarn != 2
+    @testset "skipchars for IOStream" begin
+        mktemp() do path, file
+            function append_to_file(str)
+                mark(file)
+                print(file, str)
+                flush(file)
+                reset(file)
+            end
+            # test it doesn't error on eof
+            @test eof(@test_deprecated(skipchars(isspace, file)))
 
-        # test it correctly skips
-        append_to_file("    ")
-        @test eof(skipchars(isspace, file))
+            # test it correctly skips
+            append_to_file("    ")
+            @test eof(@test_deprecated(skipchars(isspace, file)))
 
-        # test it correctly detects comment lines
-        append_to_file("#    \n   ")
-        @test eof(skipchars(isspace, file, linecomment='#'))
+            # test it correctly detects comment lines
+            append_to_file("#    \n   ")
+            @test eof(@test_deprecated(skipchars(isspace, file, linecomment='#')))
 
-        # test it stops at the appropriate time
-        append_to_file("   not a space")
-        @test !eof(skipchars(isspace, file))
-        @test read(file, Char) == 'n'
+            # test it stops at the appropriate time
+            append_to_file("   not a space")
+            @test !eof(@test_deprecated(skipchars(isspace, file)))
+            @test read(file, Char) == 'n'
 
-        # test it correctly ignores the contents of comment lines
-        append_to_file("  #not a space \n   not a space")
-        @test !eof(skipchars(isspace, file, linecomment='#'))
-        @test read(file, Char) == 'n'
+            # test it correctly ignores the contents of comment lines
+            append_to_file("  #not a space \n   not a space")
+            @test !eof(@test_deprecated(skipchars(isspace, file, linecomment='#')))
+            @test read(file, Char) == 'n'
 
-        # test it correctly handles unicode
-        for (byte, char) in zip(1:4, ('@','߷','࿊','𐋺'))
-            append_to_file("abcdef$char")
-            @test ncodeunits(char) == byte
-            @test !eof(skipchars(isletter, file))
-            @test read(file, Char) == char
+            # test it correctly handles unicode
+            for (byte, char) in zip(1:4, ('@','߷','࿊','𐋺'))
+                append_to_file("abcdef$char")
+                @test ncodeunits(char) == byte
+                @test !eof(@test_deprecated(skipchars(isletter, file)))
+                @test read(file, Char) == char
+            end
         end
     end
 end


### PR DESCRIPTION
Closes #36132.

`skipuntil` illustrates the purpose of this function much more clearly
than `skipchars` and improves discoverability.

My only concern with this change is that the `skipuntil` name now
mirrors the `readuntil` name without providing a similar
interface:

1. `readuntil` only takes a `Char`/`Int`/`String` and finds
   the first occurrence of that rather than having the full flexibility
   of taking a predicate.
2. `readuntil` has a signature of `readuntil(io, searchedfor)` rather
   than `readuntil(searchedfor, io)`.
3. `readuntil` is inclusive rather than exclusive. It includes the
   object being searched for and leaves the stream position after that
   object whereas `skipuntil` leaves the stream position before.

Point 2 means that point 1 can't be easily addressed by adding a
predicate-accepting version of `readuntil` (unless we're willing to
forgo do-block notation). Should I add a keyword-argument to
`skipchars` to toggle it between inclusive/exclusive to resolve point
3?
 
This was originally part of #36158 and is broken out now since the change is separate. If both are to be merged, I'd like to update this PR to make use of the function introduced in #36158.