### PR TITLE
leaf-types cache for ml-matches

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -176,7 +176,7 @@ function showerror(io::IO, ex::InexactError)
     Experimental.show_error_hints(io, ex)
 end
 
-typesof(args...) = Tuple{Any[ Core.Typeof(a) for a in args ]...}
+typesof(@nospecialize args...) = Tuple{Any[ Core.Typeof(args[i]) for i in 1:length(args) ]...}
 
 function print_with_compare(io::IO, @nospecialize(a::DataType), @nospecialize(b::DataType), color::Symbol)
     if a.name === b.name

--- a/src/ast.c
+++ b/src/ast.c
@@ -962,7 +962,7 @@ static jl_value_t *jl_invoke_julia_macro(jl_array_t *args, jl_module_t *inmodule
     jl_value_t *result;
     JL_TRY {
         margs[0] = jl_toplevel_eval(*ctx, margs[0]);
-        jl_method_instance_t *mfunc = jl_method_lookup(margs, nargs, 1, world);
+        jl_method_instance_t *mfunc = jl_method_lookup(margs, nargs, world);
         JL_GC_PROMISE_ROOTED(mfunc);
         if (mfunc == NULL) {
             jl_method_error(margs[0], &margs[1], nargs, world);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -990,8 +990,7 @@ JL_CALLABLE(jl_f_applicable)
 {
     JL_NARGSV(applicable, 1);
     size_t world = jl_get_ptls_states()->world_age;
-    return jl_method_lookup(args, nargs, 1, world) != NULL ?
-        jl_true : jl_false;
+    return jl_method_lookup(args, nargs, world) != NULL ? jl_true : jl_false;
 }
 
 JL_CALLABLE(jl_f_invoke)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -49,6 +49,7 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
     mt->name = jl_demangle_typename(name);
     mt->module = module;
     mt->defs = jl_nothing;
+    mt->leafcache = (jl_array_t*)jl_an_empty_vec_any;
     mt->cache = jl_nothing;
     mt->max_args = 0;
     mt->kwsorter = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -2237,9 +2237,6 @@ STATIC_INLINE jl_value_t *verify_type(jl_value_t *v) JL_NOTSAFEPOINT
 }
 #endif
 
-jl_datatype_t *jl_lookup_cache_type_(jl_datatype_t *type);
-void jl_cache_type_(jl_datatype_t *type);
-
 static jl_datatype_t *jl_recache_type(jl_datatype_t *dt) JL_GC_DISABLED
 {
     jl_datatype_t *t; // the type after unique'ing

--- a/src/gf.c
+++ b/src/gf.c
@@ -418,11 +418,11 @@ static void foreach_mtable_in_module(
         jl_module_t *m,
         void (*visit)(jl_methtable_t *mt, void *env),
         void *env,
-        jl_array_t *visited)
+        jl_array_t **visited)
 {
     size_t i;
     void **table = m->bindings.table;
-    jl_eqtable_put(visited, (jl_value_t*)m, jl_true, NULL);
+    *visited = jl_eqtable_put(*visited, (jl_value_t*)m, jl_true, NULL);
     for (i = 1; i < m->bindings.size; i += 2) {
         if (table[i] != HT_NOTFOUND) {
             jl_binding_t *b = (jl_binding_t*)table[i];
@@ -440,7 +440,7 @@ static void foreach_mtable_in_module(
                 else if (jl_is_module(v)) {
                     jl_module_t *child = (jl_module_t*)v;
                     if (child != m && child->parent == m && child->name == b->name &&
-                        !jl_eqtable_get(visited, v, NULL)) {
+                        !jl_eqtable_get(*visited, v, NULL)) {
                         // this is the original/primary binding for the submodule
                         foreach_mtable_in_module(child, visit, env, visited);
                     }
@@ -463,11 +463,11 @@ void jl_foreach_reachable_mtable(void (*visit)(jl_methtable_t *mt, void *env), v
             jl_module_t *m = (jl_module_t*)jl_array_ptr_ref(mod_array, i);
             assert(jl_is_module(m));
             if (!jl_eqtable_get(visited, (jl_value_t*)m, NULL))
-                foreach_mtable_in_module(m, visit, env, visited);
+                foreach_mtable_in_module(m, visit, env, &visited);
         }
     }
     else {
-        foreach_mtable_in_module(jl_main_module, visit, env, visited);
+        foreach_mtable_in_module(jl_main_module, visit, env, &visited);
     }
     JL_GC_POP();
 }

--- a/src/iddict.c
+++ b/src/iddict.c
@@ -37,7 +37,11 @@ static int jl_table_assign_bp(jl_array_t **pa, jl_value_t *key, jl_value_t *val)
     jl_array_t *a = *pa;
     size_t orig, index, iter, empty_slot;
     size_t newsz, sz = hash_size(a);
-    assert(sz >= 1);
+    if (sz == 0) {
+        a = jl_alloc_vec_any(HT_N_INLINE);
+        sz = hash_size(a);
+        *pa = a;
+    }
     size_t maxprobe = max_probe(sz);
     void **tab = (void **)a->data;
 
@@ -108,7 +112,8 @@ static int jl_table_assign_bp(jl_array_t **pa, jl_value_t *key, jl_value_t *val)
 jl_value_t **jl_table_peek_bp(jl_array_t *a, jl_value_t *key) JL_NOTSAFEPOINT
 {
     size_t sz = hash_size(a);
-    assert(sz >= 1);
+    if (sz == 0)
+        return NULL;
     size_t maxprobe = max_probe(sz);
     void **tab = (void **)a->data;
     uint_t hv = keyhash(key);

--- a/src/init.c
+++ b/src/init.c
@@ -721,7 +721,6 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     else {
         jl_init_types();
         jl_init_codegen();
-        jl_an_empty_vec_any = (jl_value_t*)jl_alloc_vec_any(0); // used internally
     }
 
     jl_init_tasks();

--- a/src/julia.h
+++ b/src/julia.h
@@ -537,6 +537,7 @@ typedef struct _jl_methtable_t {
     JL_DATA_TYPE
     jl_sym_t *name; // sometimes a hack used by serialization to handle kwsorter
     jl_typemap_t *defs;
+    jl_array_t *leafcache;
     jl_typemap_t *cache;
     intptr_t max_args;  // max # of non-vararg arguments in a signature
     jl_value_t *kwsorter;  // keyword argument sorter function

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -462,6 +462,8 @@ jl_datatype_t *jl_new_uninitialized_datatype(void);
 void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable);
 jl_datatype_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}
 jl_value_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n);
+jl_datatype_t *jl_lookup_cache_type_(jl_datatype_t *type);
+void jl_cache_type_(jl_datatype_t *type);
 void jl_assign_bits(void *dest, jl_value_t *bits) JL_NOTSAFEPOINT;
 void set_nth_field(jl_datatype_t *st, void *v, size_t i, jl_value_t *rhs) JL_NOTSAFEPOINT;
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n);
@@ -482,7 +484,7 @@ int jl_is_toplevel_only_expr(jl_value_t *e) JL_NOTSAFEPOINT;
 jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr, jl_module_t *inmodule);
 void jl_linenumber_to_lineinfo(jl_code_info_t *ci, jl_value_t *name);
 
-jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, int cache, size_t world);
+jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world);
 jl_value_t *jl_gf_invoke(jl_value_t *types, jl_value_t *f, jl_value_t **args, size_t nargs);
 jl_method_instance_t *jl_lookup_generic(jl_value_t **args, uint32_t nargs, uint32_t callsite, size_t world) JL_ALWAYS_LEAFTYPE;
 JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int include_ambiguous,
@@ -1048,13 +1050,12 @@ struct jl_typemap_info {
     jl_datatype_t **jl_contains; // the type that is being put in this
 };
 
-jl_typemap_entry_t *jl_typemap_insert(jl_typemap_t **cache,
-                                      jl_value_t *parent JL_PROPAGATES_ROOT,
-                                      jl_tupletype_t *type,
-                                      jl_tupletype_t *simpletype, jl_svec_t *guardsigs,
-                                      jl_value_t *newvalue, int8_t offs,
-                                      const struct jl_typemap_info *tparams,
-                                      size_t min_world, size_t max_world);
+void jl_typemap_insert(jl_typemap_t **cache, jl_value_t *parent,
+        jl_typemap_entry_t *newrec, int8_t offs,
+        const struct jl_typemap_info *tparams);
+jl_typemap_entry_t *jl_typemap_alloc(
+        jl_tupletype_t *type, jl_tupletype_t *simpletype, jl_svec_t *guardsigs,
+        jl_value_t *newvalue, size_t min_world, size_t max_world);
 
 struct jl_typemap_assoc {
     // inputs

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -314,12 +314,6 @@ static void jl_compile_all_defs(void)
     JL_GC_POP();
 }
 
-static int precompile_enq_all_cache__(jl_typemap_entry_t *l, void *closure)
-{
-    jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)l->func.linfo);
-    return 1;
-}
-
 static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closure)
 {
     assert(jl_is_method_instance(mi));
@@ -370,7 +364,6 @@ static int precompile_enq_all_specializations__(jl_typemap_entry_t *def, void *c
 static void precompile_enq_all_specializations_(jl_methtable_t *mt, void *env)
 {
     jl_typemap_visitor(mt->defs, precompile_enq_all_specializations__, env);
-    jl_typemap_visitor(mt->cache, precompile_enq_all_cache__, env);
 }
 
 void jl_compile_now(jl_method_instance_t *mi);

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -395,7 +395,7 @@ end
 # Returns the return type. example: get_type(:(Base.strip("", ' ')), Main) returns (String, true)
 function try_get_type(sym::Expr, fn::Module)
     val, found = get_value(sym, fn)
-    found && return Base.typesof(val).parameters[1], found
+    found && return Core.Typeof(val), found
     if sym.head === :call
         # getfield call is special cased as the evaluation of getfield provides good type information,
         # is inexpensive and it is also performed in the complete_symbol function.
@@ -403,7 +403,7 @@ function try_get_type(sym::Expr, fn::Module)
         if isa(a1,GlobalRef) && isconst(a1.mod,a1.name) && isdefined(a1.mod,a1.name) &&
             eval(a1) === Core.getfield
             val, found = get_value_getfield(sym, Main)
-            return found ? Base.typesof(val).parameters[1] : Any, found
+            return found ? Core.Typeof(val) : Any, found
         end
         return get_type_call(sym)
     elseif sym.head === :thunk
@@ -430,7 +430,7 @@ end
 
 function get_type(sym, fn::Module)
     val, found = get_value(sym, fn)
-    return found ? Base.typesof(val).parameters[1] : Any, found
+    return found ? Core.Typeof(val) : Any, found
 end
 
 # Method completion on function call expression that look like :(max(1))

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -390,6 +390,7 @@ end
         t = Timer(0) do t
             tc[] += 1
         end
+        Libc.systemsleep(0.005)
         @test isopen(t)
         Base.process_events()
         @test !isopen(t)
@@ -402,6 +403,7 @@ end
         t = Timer(0) do t
             tc[] += 1
         end
+        Libc.systemsleep(0.005)
         @test isopen(t)
         close(t)
         @test !isopen(t)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -507,7 +507,6 @@ f18888() = nothing
 let
     world = Core.Compiler.get_world_counter()
     m = first(methods(f18888, Tuple{}))
-    @test isempty(m.specializations)
     ft = typeof(f18888)
 
     code_typed(f18888, Tuple{}; optimize=false)


### PR DESCRIPTION
When we do a `methods` lookup and get back a single result, it's very easy for us to cache that information, since we essentially already have the data-structure for it (TypeMapEntry). This lets us shave off a bit of time on micro-benchmarks by putting this information into a hash table instead of a tree (which is still used to handle the general case):
```
julia> @btime methods(+, (Int, Int))
master:  3.322 μs (21 allocations: 912 bytes)
PR:      2.069 μs (18 allocations: 784 bytes)

julia> @btime Base._methods_by_ftype(Tuple{typeof(+), Int, Int}, -1, typemax(UInt64))
master:  1.496 μs (7 allocations: 464 bytes)
PR:      0.175 μs (4 allocations: 336 bytes)
```