### PR TITLE
REPL prefix search: add ^x "pass through" key

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2218,6 +2218,7 @@ const prefix_history_keymap = merge!(
             match_input(map, s, IOBuffer(c))(s, keymap_data(ps, mode(s)))
         end,
         # match escape sequences for pass through
+        "^x*" => "*",
         "\e*" => "*",
         "\e[*" => "*",
         "\eO*"  => "*",

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -332,6 +332,13 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=false)) do stdin_wr
     @test endswith(s2, " 0x321\r\e[13C|||") # should have a space (from Meta-rightarrow) and not
                                             # have a spurious C before ||| (the one here is not spurious!)
 
+    # "pass through" for ^x^x
+    write(stdin_write, "\x030x4321\n") # \x03 == ^c
+    readuntil(stdout_read, "0x4321")
+    write(stdin_write, "\e[A\x18\x18||\x18\x18||||") # uparrow, ^x^x||^x^x||||
+    s3 = readuntil(stdout_read, "||||", keep=true)
+    @test endswith(s3, "||0x4321\r\e[15C||||")
+
     # Delete line (^U) and close REPL (^D)
     write(stdin_write, "\x15\x04")
     Base.wait(repltask)


### PR DESCRIPTION
This fix the following bug:

1. press "Ctrl-P" to go to previous history entry, through "prefix history search"
2. "^x"

Then the Julia session is exited ("^x" is a prefix keyboard shortcut, e.g. "^x^x" does "exchange-mark-and-cursor").
This PR is a very similar to #33805. 

This is not a complete solution: if you have a 3-key combo as a keyboard shortcut, e.g. "^x^lb", then the session will again terminate. Then we could add ` "^x**" => "*",` as a "pass-through", but
1. the problem is not solved for bigger n-keys combos
2. "^x^x" doesn't work well anymore: after pressing "^x^x", the REPL first waits for a third key before processing, which is not wanted.

So let's assume 3+-key combos are not used very much.
I'm really looking forward to fixing this "pass through" problem in a general way...