### PR TITLE
RFC: Define API invariance for keys, values, getindex and pairs

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -69,6 +69,16 @@ in(k, v::KeySet) = get(v.dict, k, secret_table_token) !== secret_table_token
 
 For an iterator or collection that has keys and values (e.g. arrays and dictionaries),
 return an iterator over the keys.
+
+# Implementation
+
+It is highly recommended that each `collection` that implements `keys`
+to satisfy the following relationship between [`values`](@ref) and
+[`getindex`](@ref):
+
+```julia
+isequal(collect(values(collection)), [collection[k] for k in keys(collection)])
+```
 """
 function keys end
 
@@ -130,6 +140,18 @@ values(a::AbstractDict) = ValueIterator(a)
 Return an iterator over `key => value` pairs for any
 collection that maps a set of keys to a set of values.
 This includes arrays, where the keys are the array indices.
+
+# Implementation
+
+It is highly recommended that each implementation of `pairs` satisfies
+the following relationships:
+
+```julia
+isequal(map(first, paris(collection)), keys(collection))
+isequal(map(last, paris(collection)), values(collection))
+```
+
+The fallback generic implementation satisfy this invariance.
 """
 pairs(collection) = Generator(=>, keys(collection), values(collection))
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -804,6 +804,11 @@ Dict{String,Int64} with 2 entries:
 julia> getindex(A, "a")
 1
 ```
+
+# Implementation
+
+Implementation of `getindex` should satisfy the invariance explained
+in [`keys`](@ref).
 """
 function getindex end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -758,6 +758,11 @@ julia> values([2])
 1-element Array{Int64,1}:
  2
 ```
+
+# Implementation
+
+Implementation of `values` should satisfy the invariance explained in
+[`keys`](@ref).
 """
 values(itr) = itr
 


### PR DESCRIPTION
There are discussions for extending `keys` #34678 and `pairs` #34851 API.  Rather than extending the implementation purely for convenience, I suggest to document the expected relationships between the functions.  This clarifies what to expect from these APIs without looking at each implementation.  Otherwise, it is difficult to use these functions in generic code.

Concretely, for `keys`, `values`, and `getindex` I suggest:

> It is highly recommended that each `collection` that implements `keys` to satisfy the following relationship between `values` and `getindex`:
>
> ```julia
> isequal(collect(values(collection)), [collection[k] for k in keys(collection)])
> ```

For `pairs`:

> It is highly recommended that each implementation of `pairs` satisfies the following relationships:
>
> ```julia
> isequal(map(first, paris(collection)), keys(collection))
> isequal(map(last, paris(collection)), values(collection))
> ```
>
> The fallback generic implementation satisfy this invariance.

Since it is a breaking change to impose more strict API requirements for already existing and used API, I only used a very loose phrasing "It is highly recommended."  It is up to discussion if upgrading this to "must" is a `minor change`.

close #34851