### PR TITLE
WIP Generalize Fix1 and Fix2

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -83,11 +83,19 @@ include("traits.jl")
 include("range.jl")
 include("error.jl")
 
+# Some type
+include("some.jl")
+
 # core numeric operations & types
 include("bool.jl")
 include("number.jl")
 include("int.jl")
 include("operators.jl")
+
+# The following definitions are not in `operators.jl` so they are not seen by bootstrapping (`compiler.jl`)
+getproperty(f::Fix1, s::Symbol) = s === :x ? getx(f) : getfield(f, s)
+getproperty(f::Fix2, s::Symbol) = s === :x ? getx(f) : getfield(f, s)
+
 include("pointer.jl")
 include("refvalue.jl")
 include("refpointer.jl")
@@ -149,8 +157,6 @@ end
 include("multimedia.jl")
 using .Multimedia
 
-# Some type
-include("some.jl")
 
 include("dict.jl")
 include("abstractset.jl")

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -40,6 +40,9 @@ include("range.jl")
 include("expr.jl")
 include("error.jl")
 
+# Some type
+include("some.jl")
+
 # core numeric operations & types
 include("bool.jl")
 include("number.jl")

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -964,7 +964,7 @@ _interleave(firstbind::Some{T}, tailbind::Tuple, args::Tuple) where T = (
 _interleave(firstbind::T, tailbind::Tuple, args::Tuple) where T = (
   firstbind, interleave(tailbind, args)...)
 
-struct Bind{F, A}
+struct Bind{F, A} <: Function
   f::F
   a::A
 end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -949,7 +949,6 @@ end
 (f::Fix2)(y) = f.f(y, f.x)
 =#
 
-
 interleave(bind::Tuple{}, args::Tuple{}) = ()
 interleave(bind::Tuple{}, args::Tuple) = error("more args than positions")
 interleave(bind, args) = _interleave(first(bind), tail(bind), args)
@@ -974,20 +973,13 @@ function (c::Bind)(args...)
   c.f(interleave(c.a, args)...)
 end
 
-c = Bind(==, (3, nothing))
-isnothing2 = Bind(===, (Some(nothing), nothing))
-
 const Fix1{F, X} =  Bind{F, Tuple{Some{X}, Nothing}}
 const Fix2{F, X} =  Bind{F, Tuple{Nothing, Some{X}}}
 Fix1(f, x) = Bind(f, (Some(x), nothing))
 Fix2(f, x) = Bind(f, (nothing, Some(x)))
 
-Base.getproperty(f::Fix1, s::Symbol) = s === :x ? something(f.a[1]) : getfield(f, s)
-Base.getproperty(f::Fix2, s::Symbol) = s === :x ? something(f.a[2]) : getfield(f, s)
-
-
-
-
+getx(f::Fix1) = something(f.a[1])
+getx(f::Fix2) = something(f.a[2])
 
 
 """

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -913,6 +913,7 @@ julia> filter(!isletter, str)
 """
 !(f::Function) = (x...)->!f(x...)
 
+#=
 """
     Fix1(f, x)
 
@@ -946,6 +947,48 @@ struct Fix2{F,T} <: Function
 end
 
 (f::Fix2)(y) = f.f(y, f.x)
+=#
+
+
+interleave(bind::Tuple{}, args::Tuple{}) = ()
+interleave(bind::Tuple{}, args::Tuple) = error("more args than positions")
+interleave(bind, args) = _interleave(first(bind), tail(bind), args)
+
+# `nothing` indicates a position to be bound
+_interleave(firstbind::Nothing, tailbind::Tuple, args::Tuple) = (
+  first(args), interleave(tailbind, tail(args))...)
+
+# allow escaping of e.g. `nothing`
+_interleave(firstbind::Some{T}, tailbind::Tuple, args::Tuple) where T = (
+  something(firstbind), interleave(tailbind, args)...)
+
+_interleave(firstbind::T, tailbind::Tuple, args::Tuple) where T = (
+  firstbind, interleave(tailbind, args)...)
+
+struct Bind{F, A}
+  f::F
+  a::A
+end
+
+function (c::Bind)(args...)
+  c.f(interleave(c.a, args)...)
+end
+
+c = Bind(==, (3, nothing))
+isnothing2 = Bind(===, (Some(nothing), nothing))
+
+const Fix1{F, X} =  Bind{F, Tuple{Some{X}, Nothing}}
+const Fix2{F, X} =  Bind{F, Tuple{Nothing, Some{X}}}
+Fix1(f, x) = Bind(f, (Some(x), nothing))
+Fix2(f, x) = Bind(f, (nothing, Some(x)))
+
+Base.getproperty(f::Fix1, s::Symbol) = s === :x ? something(f.a[1]) : getfield(f, s)
+Base.getproperty(f::Fix2, s::Symbol) = s === :x ? something(f.a[2]) : getfield(f, s)
+
+
+
+
+
 
 """
     isequal(x)

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -9,7 +9,7 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
         throw(BoundsError(s, i))
     end
     @inbounds isvalid(s, i) || string_index_err(s, i)
-    c = pred.x
+    c = getx(pred)
     c ≤ '\x7f' && return nothing_sentinel(_search(s, c % UInt8, i))
     while true
         i = _search(s, first_utf8_byte(c), i)
@@ -20,10 +20,10 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
 end
 
 findfirst(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray) =
-    nothing_sentinel(_search(a, pred.x))
+    nothing_sentinel(_search(a, getx(pred)))
 
 findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray, i::Integer) =
-    nothing_sentinel(_search(a, pred.x, i))
+    nothing_sentinel(_search(a, getx(pred), i))
 
 function _search(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = 1)
     if i < 1
@@ -48,7 +48,7 @@ end
 
 function findprev(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar},
                   s::String, i::Integer)
-    c = pred.x
+    c = getx(pred)
     c ≤ '\x7f' && return nothing_sentinel(_rsearch(s, c % UInt8, i))
     b = first_utf8_byte(c)
     while true
@@ -60,10 +60,10 @@ function findprev(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
 end
 
 findlast(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray) =
-    nothing_sentinel(_rsearch(a, pred.x))
+    nothing_sentinel(_rsearch(a, getx(pred)))
 
 findprev(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray, i::Integer) =
-    nothing_sentinel(_rsearch(a, pred.x, i))
+    nothing_sentinel(_rsearch(a, getx(pred), i))
 
 function _rsearch(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = sizeof(a))
     if i < 1


### PR DESCRIPTION
I have wanted a generalized version of Fix1 and Fix2 that allows binding any pattern of positional arguments. I think something like the implementation in this PR should be a drop-in replacement.

But I'm having trouble trying it out because I am getting an error during compilation

```
[...]
multidimensional.jl
permuteddimsarray.jl
broadcast.jl
missing.jl
version.jl
error during bootstrap:

jl_method_error_bare at /home/ggoretkin/repos/julia/src/gf.c:1842
jl_method_error at /home/ggoretkin/repos/julia/src/gf.c:1860
jl_lookup_generic_ at /home/ggoretkin/repos/julia/src/gf.c:2384 [inlined]
jl_apply_generic at /home/ggoretkin/repos/julia/src/gf.c:2405
in at ./strings/search.jl:141
∉ at ./operators.jl:1123
show_type_name at ./show.jl:567
show_datatype at ./show.jl:620
show at ./show.jl:499
_jl_invoke at /home/ggoretkin/repos/julia/src/gf.c:2242 [inlined]
jl_apply_generic at /home/ggoretkin/repos/julia/src/gf.c:2409
_show_default at ./show.jl:395
show_default at ./show.jl:391 [inlined]
show at ./show.jl:386
print at ./strings/io.jl:35
unknown function (ip: 0x7f8ba8cb9642)
_jl_invoke at /home/ggoretkin/repos/julia/src/gf.c:2242 [inlined]
jl_apply_generic at /home/ggoretkin/repos/julia/src/gf.c:2409
print_to_string at ./strings/io.jl:135
string at ./strings/io.jl:174
unknown function (ip: 0x7f8ba8cb9412)
_jl_invoke at /home/ggoretkin/repos/julia/src/gf.c:2242 [inlined]
jl_apply_generic at /home/ggoretkin/repos/julia/src/gf.c:2409
jl_apply at /home/ggoretkin/repos/julia/src/julia.h:1701 [inlined]
do_call at /home/ggoretkin/repos/julia/src/interpreter.c:117
eval_value at /home/ggoretkin/repos/julia/src/interpreter.c:206
eval_stmt_value at /home/ggoretkin/repos/julia/src/interpreter.c:157 [inlined]
eval_body at /home/ggoretkin/repos/julia/src/interpreter.c:566
jl_interpret_toplevel_thunk at /home/ggoretkin/repos/julia/src/interpreter.c:660
top-level scope at version.jl:236
jl_toplevel_eval_flex at /home/ggoretkin/repos/julia/src/toplevel.c:840
jl_parse_eval_all at /home/ggoretkin/repos/julia/src/toplevel.c:957
jl_load_ at /home/ggoretkin/repos/julia/src/toplevel.c:1004
include at ./boot.jl:329 [inlined]
include at ./Base.jl:15
include at ./Base.jl:17
_jl_invoke at /home/ggoretkin/repos/julia/src/gf.c:2225 [inlined]
jl_apply_generic at /home/ggoretkin/repos/julia/src/gf.c:2409
jl_apply at /home/ggoretkin/repos/julia/src/julia.h:1701 [inlined]
do_call at /home/ggoretkin/repos/julia/src/interpreter.c:117
eval_value at /home/ggoretkin/repos/julia/src/interpreter.c:206
eval_stmt_value at /home/ggoretkin/repos/julia/src/interpreter.c:157 [inlined]
eval_body at /home/ggoretkin/repos/julia/src/interpreter.c:566
jl_interpret_toplevel_thunk at /home/ggoretkin/repos/julia/src/interpreter.c:660
top-level scope at Base.jl:206
jl_toplevel_eval_flex at /home/ggoretkin/repos/julia/src/toplevel.c:840
jl_eval_module_expr at /home/ggoretkin/repos/julia/src/toplevel.c:197
jl_toplevel_eval_flex at /home/ggoretkin/repos/julia/src/toplevel.c:666
jl_parse_eval_all at /home/ggoretkin/repos/julia/src/toplevel.c:957
jl_load_ at /home/ggoretkin/repos/julia/src/toplevel.c:1004
include at ./boot.jl:329
_jl_invoke at /home/ggoretkin/repos/julia/src/gf.c:2242 [inlined]
jl_apply_generic at /home/ggoretkin/repos/julia/src/gf.c:2409
jl_apply at /home/ggoretkin/repos/julia/src/julia.h:1701 [inlined]
do_call at /home/ggoretkin/repos/julia/src/interpreter.c:117
eval_value at /home/ggoretkin/repos/julia/src/interpreter.c:206
eval_stmt_value at /home/ggoretkin/repos/julia/src/interpreter.c:157 [inlined]
eval_body at /home/ggoretkin/repos/julia/src/interpreter.c:566
jl_interpret_toplevel_thunk at /home/ggoretkin/repos/julia/src/interpreter.c:660
top-level scope at sysimg.jl:3
jl_toplevel_eval_flex at /home/ggoretkin/repos/julia/src/toplevel.c:840
jl_parse_eval_all at /home/ggoretkin/repos/julia/src/toplevel.c:957
jl_load_ at /home/ggoretkin/repos/julia/src/toplevel.c:1004
jl_load at /home/ggoretkin/repos/julia/src/toplevel.c:1017
exec_program at /home/ggoretkin/repos/julia/ui/repl.c:45
true_main at /home/ggoretkin/repos/julia/ui/repl.c:118
main at /home/ggoretkin/repos/julia/ui/repl.c:227
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
_start at /home/ggoretkin/repos/julia/usr/bin/julia (unknown line)
```

I tried allowing `pred.x` by defining the `getproperty` method, but I got a different error during compilation: "cannot add methods to a builtin function". Perhaps `getproperty` during bootstrapping and `getproperty` in the runtime are different. That is fine, since the occurances of e.g. `pred.x` in `Base` can be fixed, and the `getproperty` method can be used for a deprecation cycle.