### PR TITLE
WIP: Allow convert and reinterpret for Arrays of unions with missing/nothing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -85,10 +85,10 @@ for Cs in ((:Missing,), (:Nothing,), (:Missing, :Nothing))
         ) where {N} where {T<:Q} where Q
 
         all(x->x isa T, xs) || throw(ArgumentError("cannot convert $(eltype(xs)) to $T"))
-        if isbitstype(T) &&
+        if isbitstype(T) && T===Q
             reinterpret(T, xs)
         else
-            T[x for x in xs]
+            Q[x for x in xs]
         end
     end
     ==#


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/26681 and #31152

Right now convert kind of breaks the compiler and i am not sure why.
Debugging that is pending, so right now it is commented out so i could run the `reinterpet` tests

Writing this is made harder by https://github.com/JuliaLang/julia/issues/36185