### PR TITLE
Allow non-Function callables to be used in count(f, itr)

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -840,7 +840,7 @@ end
 
 ## count
 
-_bool(f::Function) = x->f(x)::Bool
+_bool(f) = x->f(x)::Bool
 
 """
     count(p, itr) -> Integer

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -468,6 +468,11 @@ end
 @test count(!iszero, Int[1]) == 1
 @test count(!iszero, [1, 0, 2, 0, 3, 0, 4]) == 4
 
+struct NonFunctionIsZero end
+(::NonFunctionIsZero)(x) = iszero(x)
+@test count(NonFunctionIsZero(), []) == 0
+@test count(NonFunctionIsZero(), [0]) == 1
+@test count(NonFunctionIsZero(), [1]) == 0
 
 ## cumsum, cummin, cummax
 


### PR DESCRIPTION
Currently, all predicate functions are wrapped with

https://github.com/JuliaLang/julia/blob/98e678fd9806856a4c0a12f711e1ee397994deeb/base/reduce.jl#L843

The signature `::Function` is overly restrictive because everything is (potentially) callable.

With this patch, following works

```julia
julia> struct NonFunctionIsZero end

julia> (::NonFunctionIsZero)(x) = iszero(x)

julia> count(NonFunctionIsZero(), [])
0
```

Since this worked in Julia 1.0 and 1.4, I'm marking this as a bugfix.
