### PR TITLE
Support `init` keyword in `sum`/`prod`/`maximum`/`minimum`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,7 @@ Standard library changes
 * The function `isapprox(x,y)` now accepts the `norm` keyword argument also for numeric (i.e., non-array) arguments `x` and `y` ([#35883]).
 * `view`, `@view`, and `@views` now work on `AbstractString`s, returning a `SubString` when appropriate ([#35879]).
 * All `AbstractUnitRange{<:Integer}`s now work with `SubString`, `view`, `@view` and `@views` on strings ([#35879]).
-* `sum`, `prod`, `maximum`, and `minimum` now supports `init` keyword argument ([#36188], [#35839]).
+* `sum`, `prod`, `maximum`, and `minimum` now support `init` keyword argument ([#36188], [#35839]).
 
 #### LinearAlgebra
 * New method `LinearAlgebra.issuccess(::CholeskyPivoted)` for checking whether pivoted Cholesky factorization was successful ([#36002]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@ Standard library changes
 * The function `isapprox(x,y)` now accepts the `norm` keyword argument also for numeric (i.e., non-array) arguments `x` and `y` ([#35883]).
 * `view`, `@view`, and `@views` now work on `AbstractString`s, returning a `SubString` when appropriate ([#35879]).
 * All `AbstractUnitRange{<:Integer}`s now work with `SubString`, `view`, `@view` and `@views` on strings ([#35879]).
+* `sum`, `prod`, `maximum`, and `minimum` now supports `init` keyword argument ([#36188], [#35839]).
 
 #### LinearAlgebra
 * New method `LinearAlgebra.issuccess(::CholeskyPivoted)` for checking whether pivoted Cholesky factorization was successful ([#36002]).

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -470,9 +470,9 @@ The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
 
-The value returned for empty `itr` can be specified by `init` which must be the
-additive identity.  It is unspecified whether `init` is used for non-empty
-collections.
+The value returned for empty `itr` can be specified by `init`. It must be
+the additive identity (i.e. zero) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -642,8 +642,9 @@ end
     maximum(f, itr; [init])
 
 Returns the largest result of calling function `f` on each element of `itr`.
-If provided, `init` must be a neutral element for `max` that will be returned
-for empty collections.
+
+If provided, `init` must be a neutral element for `max` (i.e. which is less
+than any other element) that will be returned for empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -646,6 +646,9 @@ Returns the largest result of calling function `f` on each element of `itr`.
 If provided, `init` must be a neutral element for `max` that will be returned
 for empty collections.
 
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
+
 # Examples
 ```jldoctest
 julia> maximum(length, ["Julion", "Julia", "Jule"])
@@ -663,6 +666,9 @@ maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
 Returns the smallest result of calling function `f` on each element of `itr`.
 If provided, `init` must be a neutral element for `min` that will be returned
 for empty collections.
+
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
 
 # Examples
 ```jldoctest

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -649,8 +649,10 @@ end
 
 Returns the largest result of calling function `f` on each element of `itr`.
 
-If provided, `init` must be a neutral element for `max` (i.e. which is less
-than or equal to any other element) that will be returned for empty collections.
+The value returned for empty `itr` can be specified by `init`. It must be the
+a neutral element for `max` (i.e. which is less than or equal to any
+other element) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -660,8 +662,8 @@ than or equal to any other element) that will be returned for empty collections.
 julia> maximum(length, ["Julion", "Julia", "Jule"])
 6
 
-julia> maximum(length, []; init=-1)
--1
+julia> maximum(length, []; init=-Inf)
+-Inf
 ```
 """
 maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
@@ -671,8 +673,10 @@ maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
 
 Returns the smallest result of calling function `f` on each element of `itr`.
 
-If provided, `init` must be a neutral element for `min` (i.e. which is greater
-than or equal to any other element) that will be returned for empty collections.
+The value returned for empty `itr` can be specified by `init`. It must be the
+a neutral element for `min` (i.e. which is greater than or equal to any
+other element) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -693,8 +697,10 @@ minimum(f, a; kw...) = mapreduce(f, min, a; kw...)
 
 Returns the largest element in a collection.
 
-If provided, `init` must be a neutral element for `max` (i.e. which is less
-than or equal to any other element) that will be returned for empty collections.
+The value returned for empty `itr` can be specified by `init`. It must be the
+a neutral element for `max` (i.e. which is less than or equal to any
+other element) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -712,8 +718,8 @@ ERROR: ArgumentError: reducing over an empty collection is not allowed
 Stacktrace:
 [...]
 
-julia> maximum((); init=-1)
--1
+julia> maximum((); init=-Inf)
+-Inf
 ```
 """
 maximum(a; kw...) = mapreduce(identity, max, a; kw...)
@@ -723,8 +729,10 @@ maximum(a; kw...) = mapreduce(identity, max, a; kw...)
 
 Returns the smallest element in a collection.
 
-If provided, `init` must be a neutral element for `min` (i.e. which is greater
-than or equal to any other element) that will be returned for empty collections.
+The value returned for empty `itr` can be specified by `init`. It must be the
+a neutral element for `min` (i.e. which is greater than or equal to any
+other element) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -45,7 +45,7 @@ function mapfoldl_impl(f::F, op::OP, nt, itr) where {F,OP}
 end
 
 function foldl_impl(op::OP, nt, itr) where {OP}
-    v = _foldl_impl(op, get(nt, :init, _InitialValue()), itr)
+    v = _foldl_impl(op, nt, itr)
     v isa _InitialValue && return reduce_empty_iter(op, itr)
     return v
 end
@@ -157,7 +157,7 @@ Like [`mapreduce`](@ref), but with guaranteed left associativity, as in [`foldl`
 If provided, the keyword argument `init` will be used exactly once. In general, it will be
 necessary to provide `init` to work with empty collections.
 """
-mapfoldl(f, op, itr; kw...) = mapfoldl_impl(f, op, kw.data, itr)
+mapfoldl(f, op, itr; init=_InitialValue()) = mapfoldl_impl(f, op, init, itr)
 
 """
     foldl(op, itr; [init])
@@ -200,7 +200,7 @@ Like [`mapreduce`](@ref), but with guaranteed right associativity, as in [`foldr
 provided, the keyword argument `init` will be used exactly once. In general, it will be
 necessary to provide `init` to work with empty collections.
 """
-mapfoldr(f, op, itr; kw...) = mapfoldr_impl(f, op, kw.data, itr)
+mapfoldr(f, op, itr; init=_InitialValue()) = mapfoldr_impl(f, op, init, itr)
 
 
 """
@@ -606,35 +606,47 @@ function mapreduce_impl(f, op::Union{typeof(max), typeof(min)},
 end
 
 """
-    maximum(f, itr)
+    maximum(f, itr; [init])
 
 Returns the largest result of calling function `f` on each element of `itr`.
+If provided, `init` must be a neutral element for `max` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
 julia> maximum(length, ["Julion", "Julia", "Jule"])
 6
+
+julia> maximum(length, []; init=-1)
+-1
 ```
 """
-maximum(f, a) = mapreduce(f, max, a)
+maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
 
 """
-    minimum(f, itr)
+    minimum(f, itr; [init])
 
 Returns the smallest result of calling function `f` on each element of `itr`.
+If provided, `init` must be a neutral element for `min` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
 julia> minimum(length, ["Julion", "Julia", "Jule"])
 4
+
+julia> minimum(length, []; init=-1)
+-1
 ```
 """
-minimum(f, a) = mapreduce(f, min, a)
+minimum(f, a; kw...) = mapreduce(f, min, a; kw...)
 
 """
-    maximum(itr)
+    maximum(itr; [init])
 
 Returns the largest element in a collection.
+If provided, `init` must be a neutral element for `max` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
@@ -643,14 +655,24 @@ julia> maximum(-20.5:10)
 
 julia> maximum([1,2,3])
 3
+
+julia> maximum(())
+ERROR: ArgumentError: reducing over an empty collection is not allowed
+Stacktrace:
+[...]
+
+julia> maximum((); init=-1)
+-1
 ```
 """
-maximum(a) = mapreduce(identity, max, a)
+maximum(a; kw...) = mapreduce(identity, max, a; kw...)
 
 """
-    minimum(itr)
+    minimum(itr; [init])
 
 Returns the smallest element in a collection.
+If provided, `init` must be a neutral element for `min` that will be returned
+for empty collections.
 
 # Examples
 ```jldoctest
@@ -659,9 +681,17 @@ julia> minimum(-20.5:10)
 
 julia> minimum([1,2,3])
 1
+
+julia> minimum([])
+ERROR: ArgumentError: reducing over an empty collection is not allowed
+Stacktrace:
+[...]
+
+julia> minimum([]; init=-1)
+-1
 ```
 """
-minimum(a) = mapreduce(identity, min, a)
+minimum(a; kw...) = mapreduce(identity, min, a; kw...)
 
 ## all & any
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -692,8 +692,12 @@ minimum(f, a; kw...) = mapreduce(f, min, a; kw...)
     maximum(itr; [init])
 
 Returns the largest element in a collection.
-If provided, `init` must be a neutral element for `max` that will be returned
-for empty collections.
+
+If provided, `init` must be a neutral element for `max` (i.e. which is less
+than or equal to any other element) that will be returned for empty collections.
+
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
 
 # Examples
 ```jldoctest
@@ -718,8 +722,12 @@ maximum(a; kw...) = mapreduce(identity, max, a; kw...)
     minimum(itr; [init])
 
 Returns the smallest element in a collection.
-If provided, `init` must be a neutral element for `min` that will be returned
-for empty collections.
+
+If provided, `init` must be a neutral element for `min` (i.e. which is greater
+than or equal to any other element) that will be returned for empty collections.
+
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
 
 # Examples
 ```jldoctest

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -665,7 +665,7 @@ julia> maximum(length, ["Julion", "Julia", "Jule"])
 julia> maximum(length, []; init=-1)
 -1
 
-julia> maximum(tanh, Real[]; init=-1.0)
+julia> maximum(tanh, Real[]; init=-1.0)  # good, since output of tanh is >= -1
 -1.0
 ```
 """
@@ -692,7 +692,7 @@ julia> minimum(length, ["Julion", "Julia", "Jule"])
 julia> minimum(length, []; init=typemax(Int64))
 9223372036854775807
 
-julia> minimum(tanh, Real[]; init=1.0)
+julia> minimum(tanh, Real[]; init=1.0)  # good, since output of tanh is <= 1
 1.0
 ```
 """

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -520,6 +520,9 @@ for non-empty collections.
 ```jldoctest
 julia> sum(1:20)
 210
+
+julia> sum(1:20; init = 0.0)
+210.0
 ```
 """
 sum(a; kw...) = sum(identity, a; kw...)
@@ -569,8 +572,11 @@ for non-empty collections.
 
 # Examples
 ```jldoctest
-julia> prod(1:20)
-2432902008176640000
+julia> prod(1:5)
+120
+
+julia> prod(1:5; init = 1.0)
+120.0
 ```
 """
 prod(a; kw...) = mapreduce(identity, mul_prod, a; kw...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -686,8 +686,8 @@ for non-empty collections.
 julia> minimum(length, ["Julion", "Julia", "Jule"])
 4
 
-julia> minimum(length, []; init=Inf)
-Inf
+julia> minimum(length, []; init=typemax(Int64))
+9223372036854775807
 ```
 """
 minimum(f, a; kw...) = mapreduce(f, min, a; kw...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -664,6 +664,9 @@ julia> maximum(length, ["Julion", "Julia", "Jule"])
 
 julia> maximum(length, []; init=-1)
 -1
+
+julia> maximum(tanh, Real[]; init=-1.0)
+-1.0
 ```
 """
 maximum(f, a; kw...) = mapreduce(f, max, a; kw...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -688,6 +688,9 @@ julia> minimum(length, ["Julion", "Julia", "Jule"])
 
 julia> minimum(length, []; init=typemax(Int64))
 9223372036854775807
+
+julia> minimum(tanh, Real[]; init=1.0)
+1.0
 ```
 """
 minimum(f, a; kw...) = mapreduce(f, min, a; kw...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -523,9 +523,8 @@ julia> sum(1:20)
 ```
 """
 sum(a; kw...) = sum(identity, a; kw...)
-sum(a::AbstractArray{Bool}; kw...) = count(a)
-# Note: It is OK to ignore `init` to `sum(::AbstractArray{Bool})`
-# because it is unspecified if the value of `init` is used or not.
+sum(a::AbstractArray{Bool}; kw...) =
+    kw === NamedTuple() ? count(a) : reduce(add_sum, a; kw...)
 
 ## prod
 """

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -665,7 +665,7 @@ julia> maximum(length, ["Julion", "Julia", "Jule"])
 julia> maximum(length, []; init=-1)
 -1
 
-julia> maximum(tanh, Real[]; init=-1.0)  # good, since output of tanh is >= -1
+julia> maximum(sin, Real[]; init=-1.0)  # good, since output of sin is >= -1
 -1.0
 ```
 """
@@ -692,7 +692,7 @@ julia> minimum(length, ["Julion", "Julia", "Jule"])
 julia> minimum(length, []; init=typemax(Int64))
 9223372036854775807
 
-julia> minimum(tanh, Real[]; init=1.0)  # good, since output of tanh is <= 1
+julia> minimum(sin, Real[]; init=1.0)  # good, since output of sin is <= 1
 1.0
 ```
 """

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -649,7 +649,7 @@ end
 
 Returns the largest result of calling function `f` on each element of `itr`.
 
-The value returned for empty `itr` can be specified by `init`. It must be the
+The value returned for empty `itr` can be specified by `init`. It must be
 a neutral element for `max` (i.e. which is less than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.
@@ -676,7 +676,7 @@ maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
 
 Returns the smallest result of calling function `f` on each element of `itr`.
 
-The value returned for empty `itr` can be specified by `init`. It must be the
+The value returned for empty `itr` can be specified by `init`. It must be
 a neutral element for `min` (i.e. which is greater than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.
@@ -703,7 +703,7 @@ minimum(f, a; kw...) = mapreduce(f, min, a; kw...)
 
 Returns the largest element in a collection.
 
-The value returned for empty `itr` can be specified by `init`. It must be the
+The value returned for empty `itr` can be specified by `init`. It must be
 a neutral element for `max` (i.e. which is less than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.
@@ -735,7 +735,7 @@ maximum(a; kw...) = mapreduce(identity, max, a; kw...)
 
 Returns the smallest element in a collection.
 
-The value returned for empty `itr` can be specified by `init`. It must be the
+The value returned for empty `itr` can be specified by `init`. It must be
 a neutral element for `min` (i.e. which is greater than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -462,13 +462,20 @@ reduce(op, a::Number) = a  # Do we want this?
 ## sum
 
 """
-    sum(f, itr)
+    sum(f, itr; init)
 
 Sum the results of calling function `f` on each element of `itr`.
 
 The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
+
+The value returned for empty `itr` can be specified by `init` which must be the
+additive identity.  It is unspecified whether `init` is used for non-empty
+collections.
+
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
 
 # Examples
 ```jldoctest
@@ -491,10 +498,10 @@ In the former case, the integers are widened to system word size and therefore
 the result is 128. In the latter case, no such widening happens and integer
 overflow results in -128.
 """
-sum(f, a) = mapreduce(f, add_sum, a)
+sum(f, a; kw...) = mapreduce(f, add_sum, a; kw...)
 
 """
-    sum(itr)
+    sum(itr; init)
 
 Returns the sum of all elements in a collection.
 
@@ -502,18 +509,27 @@ The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
 
+The value returned for empty `itr` can be specified by `init` which must be the
+additive identity.  It is unspecified whether `init` is used for non-empty
+collections.
+
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
+
 # Examples
 ```jldoctest
 julia> sum(1:20)
 210
 ```
 """
-sum(a) = sum(identity, a)
-sum(a::AbstractArray{Bool}) = count(a)
+sum(a; kw...) = sum(identity, a; kw...)
+sum(a::AbstractArray{Bool}; kw...) = count(a)
+# Note: It is OK to ignore `init` to `sum(::AbstractArray{Bool})`
+# because it is unspecified if the value of `init` is used or not.
 
 ## prod
 """
-    prod(f, itr)
+    prod(f, itr; init)
 
 Returns the product of `f` applied to each element of `itr`.
 
@@ -521,16 +537,23 @@ The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
 
+The value returned for empty `itr` can be specified by `init` which must be the
+multiplicative identity.  It is unspecified whether `init` is used for non-empty
+collections.
+
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
+
 # Examples
 ```jldoctest
 julia> prod(abs2, [2; 3; 4])
 576
 ```
 """
-prod(f, a) = mapreduce(f, mul_prod, a)
+prod(f, a; kw...) = mapreduce(f, mul_prod, a; kw...)
 
 """
-    prod(itr)
+    prod(itr; init)
 
 Returns the product of all elements of a collection.
 
@@ -538,13 +561,20 @@ The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
 
+The value returned for empty `itr` can be specified by `init` which must be the
+multiplicative identity.  It is unspecified whether `init` is used for non-empty
+collections.
+
+!!! compat "Julia 1.6"
+    Keyword argument `init` requires Julia 1.6 or later.
+
 # Examples
 ```jldoctest
 julia> prod(1:20)
 2432902008176640000
 ```
 """
-prod(a) = mapreduce(identity, mul_prod, a)
+prod(a; kw...) = mapreduce(identity, mul_prod, a; kw...)
 
 ## maximum & minimum
 _fast(::typeof(min),x,y) = min(x,y)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -509,9 +509,9 @@ The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
 
-The value returned for empty `itr` can be specified by `init` which must be the
-additive identity.  It is unspecified whether `init` is used for non-empty
-collections.
+The value returned for empty `itr` can be specified by `init`. It must be
+the additive identity (i.e. zero) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -536,9 +536,9 @@ The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
 
-The value returned for empty `itr` can be specified by `init` which must be the
-multiplicative identity.  It is unspecified whether `init` is used for non-empty
-collections.
+The value returned for empty `itr` can be specified by `init`. It must be the
+multiplicative identity (i.e. one) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -560,9 +560,9 @@ The return type is `Int` for signed integers of less than system word size, and
 `UInt` for unsigned integers of less than system word size.  For all other
 arguments, a common return type is found to which all arguments are promoted.
 
-The value returned for empty `itr` can be specified by `init` which must be the
-multiplicative identity.  It is unspecified whether `init` is used for non-empty
-collections.
+The value returned for empty `itr` can be specified by `init`. It must be the
+multiplicative identity (i.e. one) as it is unspecified whether `init` is used
+for non-empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -644,7 +644,7 @@ end
 Returns the largest result of calling function `f` on each element of `itr`.
 
 If provided, `init` must be a neutral element for `max` (i.e. which is less
-than any other element) that will be returned for empty collections.
+than or equal to any other element) that will be returned for empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.
@@ -664,8 +664,9 @@ maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
     minimum(f, itr; [init])
 
 Returns the smallest result of calling function `f` on each element of `itr`.
-If provided, `init` must be a neutral element for `min` that will be returned
-for empty collections.
+
+If provided, `init` must be a neutral element for `min` (i.e. which is greater
+than or equal to any other element) that will be returned for empty collections.
 
 !!! compat "Julia 1.6"
     Keyword argument `init` requires Julia 1.6 or later.

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -682,8 +682,8 @@ than or equal to any other element) that will be returned for empty collections.
 julia> minimum(length, ["Julion", "Julia", "Jule"])
 4
 
-julia> minimum(length, []; init=-1)
--1
+julia> minimum(length, []; init=Inf)
+Inf
 ```
 """
 minimum(f, a; kw...) = mapreduce(f, min, a; kw...)
@@ -742,8 +742,8 @@ ERROR: ArgumentError: reducing over an empty collection is not allowed
 Stacktrace:
 [...]
 
-julia> minimum([]; init=-1)
--1
+julia> minimum([]; init=Inf)
+Inf
 ```
 """
 minimum(a; kw...) = mapreduce(identity, min, a; kw...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -662,8 +662,8 @@ for non-empty collections.
 julia> maximum(length, ["Julion", "Julia", "Jule"])
 6
 
-julia> maximum(length, []; init=-Inf)
--Inf
+julia> maximum(length, []; init=-1)
+-1
 ```
 """
 maximum(f, a; kw...) = mapreduce(f, max, a; kw...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -524,7 +524,7 @@ julia> sum(1:20)
 """
 sum(a; kw...) = sum(identity, a; kw...)
 sum(a::AbstractArray{Bool}; kw...) =
-    kw === NamedTuple() ? count(a) : reduce(add_sum, a; kw...)
+    kw.data === NamedTuple() ? count(a) : reduce(add_sum, a; kw...)
 
 ## prod
 """

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -462,7 +462,7 @@ reduce(op, a::Number) = a  # Do we want this?
 ## sum
 
 """
-    sum(f, itr; init)
+    sum(f, itr; [init])
 
 Sum the results of calling function `f` on each element of `itr`.
 
@@ -501,7 +501,7 @@ overflow results in -128.
 sum(f, a; kw...) = mapreduce(f, add_sum, a; kw...)
 
 """
-    sum(itr; init)
+    sum(itr; [init])
 
 Returns the sum of all elements in a collection.
 
@@ -529,7 +529,7 @@ sum(a::AbstractArray{Bool}; kw...) = count(a)
 
 ## prod
 """
-    prod(f, itr; init)
+    prod(f, itr; [init])
 
 Returns the product of `f` applied to each element of `itr`.
 
@@ -553,7 +553,7 @@ julia> prod(abs2, [2; 3; 4])
 prod(f, a; kw...) = mapreduce(f, mul_prod, a; kw...)
 
 """
-    prod(itr; init)
+    prod(itr; [init])
 
 Returns the product of all elements of a collection.
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1218,9 +1218,9 @@ See also [`applicable`](@ref).
 julia> hasmethod(length, Tuple{Array})
 true
 
-julia> f(; orange) = orange;
+julia> f(; oranges=0) = oranges;
 
-julia> hasmethod(f, Tuple{}, (:orange,))
+julia> hasmethod(f, Tuple{}, (:oranges,))
 true
 
 julia> hasmethod(f, Tuple{}, (:apples, :bananas))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1218,10 +1218,12 @@ See also [`applicable`](@ref).
 julia> hasmethod(length, Tuple{Array})
 true
 
-julia> hasmethod(sum, Tuple{Function, Array}, (:dims,))
+julia> f(; orange) = orange;
+
+julia> hasmethod(f, Tuple{}, (:orange,))
 true
 
-julia> hasmethod(sum, Tuple{Function, Array}, (:apples, :bananas))
+julia> hasmethod(f, Tuple{}, (:apples, :bananas))
 false
 
 julia> g(; xs...) = 4;

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -186,6 +186,8 @@ end
         @test sum(nothing, Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
               zeros(typeof(init), 1, 2, 0)
     end
+    # Note: We are using `nothing` in place of the callable to make
+    # sure that it's not actually called.
 end
 
 # check sum(abs, ...) for support of empty collections
@@ -226,6 +228,8 @@ end
         @test prod(nothing, Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
               ones(typeof(init), 1, 2, 0)
     end
+    # Note: We are using `nothing` in place of the callable to make
+    # sure that it's not actually called.
 end
 
 # check type-stability

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -208,6 +208,9 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test_throws ArgumentError maximum(Int[])
 @test_throws ArgumentError minimum(Int[])
 
+@test maximum(Int[]; init=-1) == -1
+@test minimum(Int[]; init=-1) == -1
+
 @test maximum(5) == 5
 @test minimum(5) == 5
 @test extrema(5) == (5, 5)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -176,18 +176,17 @@ end
 @test typeof(sum(Int8[])) == typeof(sum(Int8[1])) == typeof(sum(Int8[1 7]))
 
 @testset "`sum` of empty collections with `init`" begin
+    function noncallable end  # should not be called
     @testset for init in [0, 0.0]
         @test sum([]; init = init) === init
         @test sum((x for x in [123] if false); init = init) === init
-        @test sum(nothing, []; init = init) === init
-        @test sum(nothing, (x for x in [123] if false); init = init) === init
+        @test sum(noncallable, []; init = init) === init
+        @test sum(noncallable, (x for x in [123] if false); init = init) === init
         @test sum(Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
               zeros(typeof(init), 1, 2, 0)
-        @test sum(nothing, Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
+        @test sum(noncallable, Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
               zeros(typeof(init), 1, 2, 0)
     end
-    # Note: We are using `nothing` in place of the callable to make
-    # sure that it's not actually called.
 end
 
 # check sum(abs, ...) for support of empty collections
@@ -218,18 +217,17 @@ end
 @test typeof(prod(Array(trues(10)))) == Bool
 
 @testset "`prod` of empty collections with `init`" begin
+    function noncallable end  # should not be called
     @testset for init in [1, 1.0, ""]
         @test prod([]; init = init) === init
         @test prod((x for x in [123] if false); init = init) === init
-        @test prod(nothing, []; init = init) === init
-        @test prod(nothing, (x for x in [123] if false); init = init) === init
+        @test prod(noncallable, []; init = init) === init
+        @test prod(noncallable, (x for x in [123] if false); init = init) === init
         @test prod(Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
               ones(typeof(init), 1, 2, 0)
-        @test prod(nothing, Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
+        @test prod(noncallable, Array{Any,3}(undef, 3, 2, 0); dims = 1, init = init) ==ₜ
               ones(typeof(init), 1, 2, 0)
     end
-    # Note: We are using `nothing` in place of the callable to make
-    # sure that it's not actually called.
 end
 
 # check type-stability

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -75,6 +75,11 @@ safe_minabs(A::Array{T}, region) where {T} = safe_mapslices(minimum, abs.(A), re
     @test @inferred(count(!, Breduc, dims=region)) ≈ safe_count(.!Breduc, region)
 end
 
+# Combining dims and init
+A = Array{Int}(undef, 0, 3)
+@test_throws ArgumentError maximum(A; dims=1)
+@test maximum(A; dims=1, init=-1) == reshape([-1,-1,-1], 1, 3)
+
 # Test reduction along first dimension; this is special-cased for
 # size(A, 1) >= 16
 Breduc = rand(64, 3)


### PR DESCRIPTION
This PR extends/finalizes @timholy's #35839. It adds `init` kwarg also to `sum` and `prod`.

close #35839
