### PR TITLE
Implement stdout option for --trace-compile

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -173,6 +173,8 @@ static jl_callptr_t _jl_compile_codeinst(
                 const char* t = jl_options.trace_compile;
                 if (!strncmp(t, "stderr", 6))
                     s_precompile = JL_STDERR;
+                else if(!strncmp(t, "stdout", 6))
+                    s_precompile = JL_STDOUT;
                 else {
                     if (ios_file(&f_precompile, t, 1, 1, 1, 1) == NULL)
                         jl_errorf("cannot open precompile statement file \"%s\" for writing", t);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -173,8 +173,6 @@ static jl_callptr_t _jl_compile_codeinst(
                 const char* t = jl_options.trace_compile;
                 if (!strncmp(t, "stderr", 6))
                     s_precompile = JL_STDERR;
-                else if(!strncmp(t, "stdout", 6))
-                    s_precompile = JL_STDOUT;
                 else {
                     if (ios_file(&f_precompile, t, 1, 1, 1, 1) == NULL)
                         jl_errorf("cannot open precompile statement file \"%s\" for writing", t);

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -161,8 +161,8 @@ static const char opts_hidden[]  =
     " --output-bc name          Generate LLVM bitcode (.bc)\n"
     " --output-asm name         Generate an assembly file (.s)\n"
     " --output-incremental=no   Generate an incremental output file (rather than complete)\n"
-    " --trace-compile={stdout,stderr,name}\n"
-    "                           Print precompile statements for methods compiled during execution or save to a file (.jl)\n\n"
+    " --trace-compile={stderr,name}\n"
+    "                           Print precompile statements for methods compiled during execution or save to a path\n\n"
 ;
 
 JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -161,8 +161,8 @@ static const char opts_hidden[]  =
     " --output-bc name          Generate LLVM bitcode (.bc)\n"
     " --output-asm name         Generate an assembly file (.s)\n"
     " --output-incremental=no   Generate an incremental output file (rather than complete)\n"
-    " --trace-compile={stdout,stderr}\n"
-    "                           Print precompile statements for methods compiled during execution.\n\n"
+    " --trace-compile={stdout,stderr,name}\n"
+    "                           Print precompile statements for methods compiled during execution or save to a file (.jl)\n\n"
 ;
 
 JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)


### PR DESCRIPTION
The command line option `--trace-compile` supposedly supports `stdout` as a valid option according to `--help-hidden`. Currently, using `--trace-compile=stdout` would result in precompile statements being written to an ordinary file called "stdout".

This commit implements `--trace-compile=stdout` such that the precompile statements are written to standard output stream rather than a file.
```
$ ./julia --help-hidden
julia [switches] -- [programfile] [args...]
...
 --trace-compile={stdout,stderr}
                           Print precompile statements for methods compiled during execution.
```