### PR TITLE
Show progress indicator when precompiling

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -196,10 +196,13 @@ function generate_precompile_statements()
             @assert n_succeeded > 1500
         end
 
-        print(" $(length(statements)) generated in ")
         tot_time = time_ns() - start_time
-        Base.time_print(tot_time)
-        print(" (overhead "); Base.time_print(tot_time - (include_time * 1e9)); println(")")
+        include_time *= 1e9
+        gen_time = tot_time - include_time
+        println("Precompilation complete. Summary:")
+        print("Total ─────── "); Base.time_print(tot_time); println()
+        print("Generation ── "); Base.time_print(gen_time);     print(" "); show(IOContext(stdout, :compact=>true), gen_time / tot_time * 100); println("%")
+        print("Execution ─── "); Base.time_print(include_time); print(" "); show(IOContext(stdout, :compact=>true), include_time / tot_time * 100); println("%")
     end
 
     return


### PR DESCRIPTION
Ref #35153, but for the sysimage.

Shows the progress while generating and executing precompilation statements.  Then prints them nicely to match that of base/sysimg.jl.

A preview:

```
[...]
Pkg  ────────────  8.360788 seconds
Test  ───────────  0.199837 seconds
REPL  ───────────  0.523738 seconds
Statistics  ─────  0.140444 seconds
Stdlibs total  ── 29.230955 seconds
Sysimage built. Summary:
Total ───────  49.196509 seconds
Base: ───────  19.965539 seconds 40.5832%
Stdlibs: ────  29.230955 seconds 59.4167%
    JULIA usr/lib/julia/sys-o.a
Generating precompile statements... 30/30
Executing precompile statements... 1883/1890
Precompilation complete. Summary:
Total ───────  82.776807 seconds
Generation ──  56.348977 seconds 68.0734%
Execution ───  26.427830 seconds 31.9266%
    LINK usr/lib/julia/sys.so
```
