### PR TITLE
Define convert for UniformScaling

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -119,6 +119,8 @@ function show(io::IO, ::MIME"text/plain", J::UniformScaling)
 end
 copy(J::UniformScaling) = UniformScaling(J.λ)
 
+Base.convert(::Type{UniformScaling{T}}, J::UniformScaling) where {T} = UniformScaling(convert(T, J.λ))
+
 conj(J::UniformScaling) = UniformScaling(conj(J.λ))
 real(J::UniformScaling) = UniformScaling(real(J.λ))
 imag(J::UniformScaling) = UniformScaling(imag(J.λ))

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -23,6 +23,7 @@ Random.seed!(123)
     @test sparse(3I,4,5) == sparse(1:4, 1:4, 3, 4, 5)
     @test sparse(3I,5,4) == sparse(1:4, 1:4, 3, 5, 4)
     @test opnorm(UniformScaling(1+im)) ≈ sqrt(2)
+    @test convert(UniformScaling{Float64}, 2I) === 2.0I
 end
 
 @testset "getindex" begin


### PR DESCRIPTION
Before this PR:
```julia
julia> convert(UniformScaling{Float64}, 2I)
ERROR: MethodError: Cannot `convert` an object of type 
  UniformScaling{Int64} to an object of type 
  UniformScaling{Float64}
Closest candidates are:
  convert(::Type{T}, ::T) where T at essentials.jl:171
  UniformScaling{T}(::Any) where T<:Number at /home/blegat/git/julia-master/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/uniformscaling.jl:40
Stacktrace:
 [1] top-level scope at REPL[2]:1
```
After this PR:
```julia
julia> convert(UniformScaling{Float64}, 2I)
UniformScaling{Float64}
2.0*I
```