### PR TITLE
Replace LinearAlgebra._iszero by Base.iszero

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -104,9 +104,7 @@ function isstructurepreserving(::typeof(Base.literal_pow), ::Ref{typeof(^)}, ::S
 end
 isstructurepreserving(f, args...) = false
 
-_iszero(n::Number) = iszero(n)
-_iszero(x) = x == 0
-fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && _iszero(v))
+fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && iszero(v))
 # Like sparse matrices, we assume that the zero-preservation property of a broadcasted
 # expression is stable.  We can test the zero-preservability by applying the function
 # in cases where all other arguments are known scalars against a zero from the structured

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -205,4 +205,22 @@ end
     @test typeof(tmp) <: Tridiagonal
 
 end
+
+struct Zero end
+Base.iszero(::Zero) = true
+Base.zero(::Type{Zero}) = Zero()
+@testset "PR #36193" begin
+    z = Zero()
+    Z = [z z
+         z z]
+    zz = [z, z]
+    U = UpperTriangular(Z)
+    L = LowerTriangular(Z)
+    D = Diagonal(zz)
+    for a in [U, L, D]
+        @test identity.(a) isa typeof(a)
+        @test map(identity, a) isa typeof(a)
+    end
+end
+
 end


### PR DESCRIPTION
For an object `x::X` that is not a `Number`, before this PR, either `Base.(:==)(::X, ::Int)` is defined or it redirects to `===` and returns `false` which means that the structure is silently not preserved.
With the current PR, either `Base.iszero` is defined (or `Base.zero` and `Base.(:==)(::X, ::X)`) or it throws a `MethodError` because `==(::X, ::X)` is not defined (note that `Base.zero` is used by `fzero` so it has to be implemented anyway).
It quite natural to implement `Base.iszero` for most object while the comparison with `Int` does not always make sense and it does not seem appropriate to require objects to implement comparison with integers while we only need to be able to check whether it is zero or to be able to compare the object with another object of the same type.
Before this PR:
```julia
julia> struct Zero end

julia> x = [Zero(), Zero()];

julia> Base.zero(::Union{Zero, Type{Zero}}) = Zero()

julia> d = Diagonal(x);

julia> identity.(d)
ERROR: MethodError: no method matching zero(::Type{Zero})
Closest candidates are:
  zero(::Type{LibGit2.GitHash}) at /home/blegat/git/julia-master/usr/share/julia/stdlib/v1.6/LibGit2/src/oid.jl:220
  zero(::Type{Dates.Time}) at /home/blegat/git/julia-master/usr/share/julia/stdlib/v1.6/Dates/src/types.jl:406
  zero(::Type{Dates.Date}) at /home/blegat/git/julia-master/usr/share/julia/stdlib/v1.6/Dates/src/types.jl:405
  ...
Stacktrace:
 [1] fzero(::Diagonal{Zero,Array{Zero,1}}) at /home/blegat/git/julia-master/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/structuredbroadcast.jl:108

julia> Base.zero(::Union{Zero, Type{Zero}}) = Zero()

julia> identity.(d)
2×2 Array{Zero,2}:
 Zero()  Zero()
 Zero()  Zero()
```
After this PR, the only difference is the last line which is:
```julia
julia> identity.(d)
2×2 Diagonal{Zero,Array{Zero,1}}:
 Zero()    ⋅   
   ⋅     Zero()
```