### PR TITLE
fix #36196, failure to give `expected "end"` error in parser

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -662,16 +662,13 @@
                    (first? #t)
                    (t (peek-token s)))
           (if (not (memv t ops))
-              (begin
-                (if (not (or (eof-object? t) (eqv? t #\newline) (closer? t)))
-                    (error (string "extra token \"" t "\" after end of expression")))
-                (if (or (null? ex) (pair? (cdr ex)) (not first?))
-                    ;; () => (head)
-                    ;; (ex2 ex1) => (head ex1 ex2)
-                    ;; (ex1) if operator appeared => (head ex1) (handles "x;")
-                    (cons head (reverse! ex))
-                    ;; (ex1) => ex1
-                    (car ex)))
+              (if (or (null? ex) (pair? (cdr ex)) (not first?))
+                  ;; () => (head)
+                  ;; (ex2 ex1) => (head ex1 ex2)
+                  ;; (ex1) if operator appeared => (head ex1) (handles "x;")
+                  (cons head (reverse! ex))
+                  ;; (ex1) => ex1
+                  (car ex))
               (begin (take-token s)
                      ;; allow input to end with the operator, as in a;b;
                      (if (or (eof-object? (peek-token s))
@@ -1270,15 +1267,18 @@
 
 (define (expect-end s word)
   (let ((t (peek-token s)))
-    (cond ((eq? t 'end) (take-token s))
-          ((eof-object? t)
-           (error (string "incomplete: \"" word "\" at " ; NOTE: changing this may affect code in base/client.jl
-                          current-filename ":" expect-end-current-line
-                          " requires end")))
-          (else
-           (error (string "\"" word "\" at "
-                          current-filename ":" expect-end-current-line
-                          " expected \"end\", got \"" t "\""))))))
+    (if (eq? t 'end)
+        (take-token s)
+        (expect-end-error t word))))
+
+(define (expect-end-error t word)
+  (if (eof-object? t)
+      (error (string "incomplete: \"" word "\" at " ; NOTE: changing this may affect code in base/client.jl
+                     current-filename ":" expect-end-current-line
+                     " requires end"))
+      (error (string "\"" word "\" at "
+                     current-filename ":" expect-end-current-line
+                     " expected \"end\", got \"" t "\""))))
 
 (define (parse-subtype-spec s)
   (parse-comparison s))
@@ -1469,10 +1469,10 @@
                              (expect-end (take-lineendings s) "primitive type"))))))
 
        ((try)
-        (let ((try-block (if (memq (require-token s) '(catch finally))
+        (let ((try-block (if (memq (peek-token s) '(catch finally))
                              '(block)
                              (parse-block s))))
-          (let loop ((nxt    (require-token s))
+          (let loop ((nxt    (peek-token s))
                      (catchb #f)
                      (catchv #f)
                      (finalb #f))
@@ -1519,7 +1519,7 @@
                       catchb
                       catchv
                       fb)))
-             (else    (error (string "unexpected \"" nxt "\"")))))))
+             (else (expect-end-error nxt 'try))))))
        ((return)          (let ((t (peek-token s)))
                             (if (or (eqv? t #\newline) (closing-token? t))
                                 (list 'return '(null))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2264,3 +2264,7 @@ x = let var"'"(x) = 2x
     3'
 end
 @test x == 6
+
+# issue #36196
+@test_throws ParseError("\"for\" at none:1 expected \"end\", got \")\"") Meta.parse("(for i=1; println())")
+@test_throws ParseError("\"try\" at none:1 expected \"end\", got \")\"") Meta.parse("(try i=1; println())")


### PR DESCRIPTION
It looks like we already had better error handling implemented for this, but it was blocked by what seems to be just a wrong error message from `parse-block`.