### PR TITLE
in inference, disallow 3-element Unions if one elt is abstract

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -268,8 +268,11 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
     return true
 end
 
+union_count_abstract(x::Union) = union_count_abstract(x.a) + union_count_abstract(x.b)
+union_count_abstract(@nospecialize(x)) = !isdispatchelem(x)
+
 function issimpleenoughtype(@nospecialize t)
-    return unionlen(t) <= MAX_TYPEUNION_LENGTH && unioncomplexity(t) <= MAX_TYPEUNION_COMPLEXITY
+    return unionlen(t)+union_count_abstract(t) <= MAX_TYPEUNION_LENGTH && unioncomplexity(t) <= MAX_TYPEUNION_COMPLEXITY
 end
 
 # pick a wider type that contains both typea and typeb,

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -91,10 +91,10 @@ tmerge_test(Tuple{ComplexF64, ComplexF64, ComplexF32}, Tuple{Vararg{Union{Comple
     Tuple{Vararg{Complex}}, false)
 tmerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
     Tuple{Vararg{Complex}})
-@test Core.Compiler.tmerge(Tuple{}, Union{Int16, Nothing, Tuple{ComplexF32, ComplexF32}}) ==
-    Union{Int16, Nothing, Tuple{Vararg{ComplexF32}}}
-@test Core.Compiler.tmerge(Union{Int32, Nothing, Tuple{ComplexF32}}, Union{Int32, Nothing, Tuple{ComplexF32, ComplexF32}}) ==
-    Union{Int32, Nothing, Tuple{Vararg{ComplexF32}}}
+@test Core.Compiler.tmerge(Tuple{}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
+    Union{Nothing, Tuple{Vararg{ComplexF32}}}
+@test Core.Compiler.tmerge(Union{Nothing, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
+    Union{Nothing, Tuple{Vararg{ComplexF32}}}
 
 # issue 9770
 @noinline x9770() = false


### PR DESCRIPTION
Simpler alternative to #35904; just the type-widening part. With this we can still split `!` as follows:
```
julia> g(x) = !x

julia> code_typed(g,(Any,))
1-element Array{Any,1}:
 CodeInfo(
1 ─ %1  = (isa)(x, Missing)::Bool
└──       goto #3 if not %1
2 ─       goto #6
3 ─ %4  = (isa)(x, Bool)::Bool
└──       goto #5 if not %4
4 ─ %6  = π (x, Bool)
│   %7  = Base.not_int(%6)::Bool
└──       goto #6
5 ─ %9  = !x::Any
└──       goto #6
6 ┄ %11 = φ (#2 => $(QuoteNode(missing)), #4 => %7, #5 => %9)::Any
└──       return %11
) => Any
```
Those branches are potentially helpful, and the `!x::Any` avoids adding the method table backedge, so we still get most of the latency improvement.