### PR TITLE
Remove unnecessary use of ans keyword from manual

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -71,7 +71,7 @@ julia> t = ccall(:clock, Int32, ())
 julia> t
 2292761
 
-julia> typeof(ans)
+julia> typeof(t)
 Int32
 ```
 

--- a/doc/src/manual/complex-and-rational-numbers.md
+++ b/doc/src/manual/complex-and-rational-numbers.md
@@ -269,10 +269,10 @@ Constructing infinite rational values is acceptable:
 julia> 5//0
 1//0
 
-julia> -3//0
+julia> x = -3//0
 -1//0
 
-julia> typeof(ans)
+julia> typeof(x)
 Rational{Int64}
 ```
 

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -360,10 +360,10 @@ and then delegates construction to the general constructor for the case where bo
 successfully creates a point of type `Point{Float64}`:
 
 ```jldoctest parametric2
-julia> Point(1,2.5)
+julia> p = Point(1,2.5)
 Point{Float64}(1.0, 2.5)
 
-julia> typeof(ans)
+julia> typeof(p)
 Point{Float64}
 ```
 

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -60,16 +60,16 @@ julia> x = 12
 julia> typeof(x)
 Int64
 
-julia> convert(UInt8, x)
+julia> xu = convert(UInt8, x)
 0x0c
 
-julia> typeof(ans)
+julia> typeof(xu)
 UInt8
 
-julia> convert(AbstractFloat, x)
+julia> xf = convert(AbstractFloat, x)
 12.0
 
-julia> typeof(ans)
+julia> typeof(xf)
 Float64
 
 julia> a = Any[1 2 3; 4 5 6]
@@ -271,10 +271,10 @@ Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 This allows calls like the following to work:
 
 ```jldoctest
-julia> Rational(Int8(15),Int32(-5))
+julia> x = Rational(Int8(15),Int32(-5))
 -3//1
 
-julia> typeof(ans)
+julia> typeof(x)
 Rational{Int32}
 ```
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -410,16 +410,16 @@ is bounded and wraps around at either end so that adding, subtracting and multip
 can overflow or underflow, leading to some results that can be unsettling at first:
 
 ```jldoctest
-julia> typemax(Int)
+julia> m = typemax(Int)
 9223372036854775807
 
-julia> ans+1
+julia> m+1
 -9223372036854775808
 
-julia> -ans
+julia> -m
 -9223372036854775808
 
-julia> 2*ans
+julia> 2*m
 0
 ```
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -410,16 +410,16 @@ is bounded and wraps around at either end so that adding, subtracting and multip
 can overflow or underflow, leading to some results that can be unsettling at first:
 
 ```jldoctest
-julia> m = typemax(Int)
+julia> x = typemax(Int)
 9223372036854775807
 
-julia> m+1
+julia> y = x+1
 -9223372036854775808
 
-julia> -m
+julia> z = -y
 -9223372036854775808
 
-julia> 2*m
+julia> 2*z
 0
 ```
 

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -21,7 +21,9 @@ To exit the interactive session, type `CTRL-D` (press the Control/`^` key togeth
 `exit()`. When run in interactive mode, `julia` displays a banner and prompts the user for input.
 Once the user has entered a complete expression, such as `1 + 2`, and hits enter, the interactive
 session evaluates the expression and shows its value. If an expression is entered into an interactive
-session with a trailing semicolon, its value is not shown.
+session with a trailing semicolon, its value is not shown. The variable `ans` is bound to the
+value of the last evaluated expression whether it is shown or not. The `ans` variable is only
+bound in interactive sessions, not when Julia code is run in other ways.
 
 To evaluate expressions written in a source file `file.jl`, write `include("file.jl")`.
 

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -14,16 +14,14 @@ io = IOBuffer()
 Base.banner(io)
 banner = String(take!(io))
 import Markdown
-Markdown.parse("```\n\$ julia\n\n$(banner)\njulia> 1 + 2\n3\n\njulia> ans\n3\n```")
+Markdown.parse("```\n\$ julia\n\n$(banner)\njulia> 1 + 2\n3\n```")
 ```
 
 To exit the interactive session, type `CTRL-D` (press the Control/`^` key together with the `d` key), or type
 `exit()`. When run in interactive mode, `julia` displays a banner and prompts the user for input.
 Once the user has entered a complete expression, such as `1 + 2`, and hits enter, the interactive
 session evaluates the expression and shows its value. If an expression is entered into an interactive
-session with a trailing semicolon, its value is not shown. The variable `ans` is bound to the
-value of the last evaluated expression whether it is shown or not. The `ans` variable is only
-bound in interactive sessions, not when Julia code is run in other ways.
+session with a trailing semicolon, its value is not shown.
 
 To evaluate expressions written in a source file `file.jl`, write `include("file.jl")`.
 

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -14,7 +14,7 @@ io = IOBuffer()
 Base.banner(io)
 banner = String(take!(io))
 import Markdown
-Markdown.parse("```\n\$ julia\n\n$(banner)\njulia> 1 + 2\n3\n```")
+Markdown.parse("```\n\$ julia\n\n$(banner)\njulia> 1 + 2\n3\n\njulia> ans\n3\n```")
 ```
 
 To exit the interactive session, type `CTRL-D` (press the Control/`^` key together with the `d` key), or type

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -113,34 +113,34 @@ Unsigned integers are input and output using the `0x` prefix and hexadecimal (ba
 determined by the number of hex digits used:
 
 ```jldoctest
-julia> 0x1
+julia> x = 0x1
 0x01
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt8
 
-julia> 0x123
+julia> x = 0x123
 0x0123
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt16
 
-julia> 0x1234567
+julia> x = 0x1234567
 0x01234567
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt32
 
-julia> 0x123456789abcdef
+julia> x = 0x123456789abcdef
 0x0123456789abcdef
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt64
 
-julia> 0x11112222333344445555666677778888
+julia> x = 0x11112222333344445555666677778888
 0x11112222333344445555666677778888
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt128
 ```
 
@@ -148,28 +148,25 @@ This behavior is based on the observation that when one uses unsigned hex litera
 values, one typically is using them to represent a fixed numeric byte sequence, rather than just
 an integer value.
 
-Recall that the variable [`ans`](@ref) is set to the value of the last expression evaluated in
-an interactive session. This does not occur when Julia code is run in other ways.
-
 Binary and octal literals are also supported:
 
 ```jldoctest
-julia> 0b10
+julia> x = 0b10
 0x02
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt8
 
-julia> 0o010
+julia> x = 0o010
 0x08
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt8
 
-julia> 0x00000000000000001111222233334444
+julia> x = 0x00000000000000001111222233334444
 0x00000000000000001111222233334444
 
-julia> typeof(ans)
+julia> typeof(x)
 UInt128
 ```
 
@@ -289,10 +286,10 @@ The above results are all [`Float64`](@ref) values. Literal [`Float32`](@ref) va
 entered by writing an `f` in place of `e`:
 
 ```jldoctest
-julia> 0.5f0
+julia> x = 0.5f0
 0.5f0
 
-julia> typeof(ans)
+julia> typeof(x)
 Float32
 
 julia> 2.5f-4
@@ -302,10 +299,10 @@ julia> 2.5f-4
 Values can be converted to [`Float32`](@ref) easily:
 
 ```jldoctest
-julia> Float32(-1.5)
+julia> x = Float32(-1.5)
 -1.5f0
 
-julia> typeof(ans)
+julia> typeof(x)
 Float32
 ```
 
@@ -319,10 +316,10 @@ julia> 0x1p0
 julia> 0x1.8p3
 12.0
 
-julia> 0x.4p-1
+julia> x = 0x.4p-1
 0.125
 
-julia> typeof(ans)
+julia> typeof(x)
 Float64
 ```
 

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -105,10 +105,10 @@ an [interned string](https://en.wikipedia.org/wiki/String_interning) used as one
 of expressions:
 
 ```jldoctest
-julia> :foo
+julia> s = :foo
 :foo
 
-julia> typeof(ans)
+julia> typeof(s)
 Symbol
 ```
 
@@ -354,10 +354,10 @@ Given an expression object, one can cause Julia to evaluate (execute) it at glob
 [`eval`](@ref):
 
 ```jldoctest interp1
-julia> :(1 + 2)
+julia> ex1 = :(1 + 2)
 :(1 + 2)
 
-julia> eval(ans)
+julia> eval(ex1)
 3
 
 julia> ex = :(a + b)

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -51,24 +51,24 @@ other subtypes of `AbstractChar`, e.g. to optimize operations for other
 input and shown:
 
 ```jldoctest
-julia> 'x'
+julia> c = 'x'
 'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 
-julia> typeof(ans)
+julia> typeof(c)
 Char
 ```
 
 You can easily convert a `Char` to its integer value, i.e. code point:
 
 ```jldoctest
-julia> Int('x')
+julia> c = Int('x')
 120
 
-julia> typeof(ans)
+julia> typeof(c)
 Int64
 ```
 
-On 32-bit architectures, [`typeof(ans)`](@ref) will be [`Int32`](@ref). You can convert an
+On 32-bit architectures, [`typeof(c)`](@ref) will be [`Int32`](@ref). You can convert an
 integer value back to a `Char` just as easily:
 
 ```jldoctest
@@ -756,10 +756,10 @@ using non-standard string literals prefixed with various identifiers beginning w
 basic regular expression literal without any options turned on just uses `r"..."`:
 
 ```jldoctest
-julia> r"^\s*(?:#|$)"
+julia> re = r"^\s*(?:#|$)"
 r"^\s*(?:#|$)"
 
-julia> typeof(ans)
+julia> typeof(re)
 Regex
 ```
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -90,10 +90,10 @@ julia> function foo()
        end
 foo (generic function with 1 method)
 
-julia> foo()
+julia> x = foo()
 100
 
-julia> typeof(ans)
+julia> typeof(x)
 Int8
 ```
 
@@ -667,10 +667,10 @@ Since the type `Point{Float64}` is a concrete type equivalent to `Point` declare
 in place of `T`, it can be applied as a constructor accordingly:
 
 ```jldoctest pointtype
-julia> Point{Float64}(1.0, 2.0)
+julia> p = Point{Float64}(1.0, 2.0)
 Point{Float64}(1.0, 2.0)
 
-julia> typeof(ans)
+julia> typeof(p)
 Point{Float64}
 ```
 
@@ -695,16 +695,16 @@ that reason, you can also apply `Point` itself as a constructor, provided that t
 of the parameter type `T` is unambiguous:
 
 ```jldoctest pointtype
-julia> Point(1.0,2.0)
+julia> p1 = Point(1.0,2.0)
 Point{Float64}(1.0, 2.0)
 
-julia> typeof(ans)
+julia> typeof(p1)
 Point{Float64}
 
-julia> Point(1,2)
+julia> p2 = Point(1,2)
 Point{Int64}(1, 2)
 
-julia> typeof(ans)
+julia> typeof(p2)
 Point{Int64}
 ```
 


### PR DESCRIPTION
The `ans` keyword adds to the cognitive load for new users reading the
manual, potentially distracting their focus from the examples. This
commit replaces non essential uses of `ans` in the manual with clear
variable assignments.

Thanks @fredrikekre for the [suggestion and encouragement on Slack](https://julialang.slack.com/archives/C69DZ83C6/p1591540869043200).
For context, I'm a new user coming from R and Python.
While reading the string docs, I went down a short rabbit hole with `ans`:

> Where did this `ans` come from?
> There must have been some hidden assignment that happened somewhere, maybe in a hidden block in the docs that they       forgot to show.
> (Looks up docs), ah, `ans` is a keyword.
> What are the semantics?
> Will it write over my variable `ans`?
> Yes, that's too bad, some people like to use ans as a variable name
> ... (and so on) 

I did read the [Getting Started](https://docs.julialang.org/en/v1/manual/getting-started/), but a couple days later when I returned to the docs I forgot about `ans`. `ans` strikes me as a convenience, not a core feature of the language. Why make something potentially confusing the first thing that a new user sees in the manual?

For the integers and floating point numbers, continually reassigning the variable `x` with objects of different types reinforces that Julia is dynamically typed, which is a core feature of the language.

It seems that the doctests are failing locally on my Mac with the `typemax(Int)` example in the FAQ. I'm not sure it's related to my changes?