### PR TITLE
set default max_methods to 3

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -154,7 +154,7 @@ end
 size(a::Array, d::Integer) = arraysize(a, convert(Int, d))
 size(a::Vector) = (arraysize(a,1),)
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))
-size(a::Array{<:Any,N}) where {N} = (@_inline_meta; ntuple(M -> size(a, M), Val(N)))
+size(a::Array{<:Any,N}) where {N} = (@_inline_meta; ntuple(M -> size(a, M), Val(N))::Dims)
 
 asize_from(a::Array, n) = n > ndims(a) ? () : (arraysize(a,n), asize_from(a, n+1)...)
 

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -391,7 +391,20 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
                         widen = tuplemerge(unwrap_unionall(ti)::DataType, unwrap_unionall(tj)::DataType)
                         widen = rewrap_unionall(rewrap_unionall(widen, ti), tj)
                     else
-                        widen = typenames[i].wrapper
+                        wr = typenames[i].wrapper
+                        uw = unwrap_unionall(wr)::DataType
+                        ui = unwrap_unionall(ti)::DataType
+                        uj = unwrap_unionall(tj)::DataType
+                        merged = wr
+                        for k = 1:length(uw.parameters)
+                            ui_k = ui.parameters[k]
+                            if ui_k === uj.parameters[k] && !has_free_typevars(ui_k)
+                                merged = merged{ui_k}
+                            else
+                                merged = merged{uw.parameters[k]}
+                            end
+                        end
+                        widen = rewrap_unionall(merged, wr)
                     end
                     types[i] = Union{}
                     typenames[i] = Any.name

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -58,7 +58,7 @@ struct OptimizationParams
             inline_cost_threshold::Int = 100,
             inline_nonleaf_penalty::Int = 1000,
             inline_tupleret_bonus::Int = 400,
-            max_methods::Int = 4,
+            max_methods::Int = 3,
             tuple_splat::Int = 32,
             union_splitting::Int = 4,
         )
@@ -107,7 +107,7 @@ struct InferenceParams
     function InferenceParams(;
             ipo_constant_propagation::Bool = true,
             aggressive_constant_propagation::Bool = false,
-            max_methods::Int = 4,
+            max_methods::Int = 3,
             union_splitting::Int = 4,
             apply_union_enum::Int = 8,
             tupletype_depth::Int = 3,

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -253,7 +253,7 @@ rand(rng::AbstractRNG, ::UniformT{T}) where {T} = rand(rng, T)
 rand(rng::AbstractRNG, X)                                           = rand(rng, Sampler(rng, X, Val(1)))
 # this is needed to disambiguate
 rand(rng::AbstractRNG, X::Dims)                                     = rand(rng, Sampler(rng, X, Val(1)))
-rand(rng::AbstractRNG=default_rng(), ::Type{X}=Float64) where {X} = rand(rng, Sampler(rng, X, Val(1)))
+rand(rng::AbstractRNG=default_rng(), ::Type{X}=Float64) where {X} = rand(rng, Sampler(rng, X, Val(1)))::X
 
 rand(X)                   = rand(default_rng(), X)
 rand(::Type{X}) where {X} = rand(default_rng(), X)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -95,6 +95,7 @@ tmerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
 @test Core.Compiler.tmerge(Union{Nothing, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
+@test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Vector{Bool})) == Vector
 
 # issue 9770
 @noinline x9770() = false

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -275,11 +275,12 @@ applyf35855(Any[1])
 wany3 = worlds(instance(applyf35855, (Vector{Any},)))
 src3 = code_typed(applyf35855, (Vector{Any},))[1]
 @test (wany3 == wany2) == equal(src3, src2)   # don't invalidate unless you also change the code
-f35855(::AbstractVector) = 4         # next test would pass if this were ::Vector{Int}
+f35855(::AbstractVector) = 4
 applyf35855(Any[1])
 wany4 = worlds(instance(applyf35855, (Vector{Any},)))
 src4 = code_typed(applyf35855, (Vector{Any},))[1]
-@test_broken (wany4 == wany3) == equal(src4, src3)
+# this passes when max_methods == 3, fails when set to 4
+@test (wany4 == wany3) == equal(src4, src3)
 f35855(::Dict) = 5
 applyf35855(Any[1])
 wany5 = worlds(instance(applyf35855, (Vector{Any},)))
@@ -290,6 +291,18 @@ applyf35855(Any[1])
 wany6 = worlds(instance(applyf35855, (Vector{Any},)))
 src6 = code_typed(applyf35855, (Vector{Any},))[1]
 @test (wany6 == wany5) == equal(src6, src5)
+
+applyf35855_2(c) = f35855_2(c[1])
+f35855_2(::Int) = 1
+f35855_2(::Float64) = 2
+applyf35855_2(Any[1])
+wany3 = worlds(instance(applyf35855_2, (Vector{Any},)))
+src3 = code_typed(applyf35855_2, (Vector{Any},))[1]
+f35855_2(::AbstractVector) = 4         # next test would pass if this were ::Vector{Int}
+applyf35855_2(Any[1])
+wany4 = worlds(instance(applyf35855_2, (Vector{Any},)))
+src4 = code_typed(applyf35855_2, (Vector{Any},))[1]
+@test_broken (wany4 == wany3) == equal(src4, src3)
 
 ## ambiguities do not trigger invalidation
 using Printf


### PR DESCRIPTION
Until we settle on a generally-better algorithm (which may not exist), this is a good way to get some free performance. I'm curious to find out what PkgEval says.

Here are some numbers. Baseline from master (note my environment also includes https://github.com/JuliaPlots/PlotUtils.jl/pull/96):
```
Base  ─────────── 38.462095 seconds
Stdlibs: ────  54.332004 seconds 58.551%
-rw-r--r-- 1 jeff jeff  12831441 Jun  8 19:59 corecompiler.ji
-rwxr-xr-x 1 jeff jeff 151354656 Jun  8 20:07 sys.so
julia> @time using Plots
[ Info: Precompiling Plots [91a5bcdd-55d7-5caf-9e0b-520d859cae80]
144.572065 seconds (9.39 M allocations: 534.732 MiB, 0.14% gc time)

julia> @time display(plot(rand(10)))
 11.177675 seconds (11.11 M allocations: 574.409 MiB, 1.57% gc time)

julia> @time using SIMD
[ Info: Precompiling SIMD [fdea26ae-647d-5447-a871-4b548cad5224]
  2.551328 seconds (2.15 M allocations: 110.859 MiB, 0.87% gc time)

julia> @time display(plot(rand(10)))
  9.076342 seconds (20.95 M allocations: 1.047 GiB, 6.05% gc time)
```

This PR:
```
Base  ─────────── 36.959470 seconds
Stdlibs: ────  51.727160 seconds 58.3257%
-rw-r--r-- 1 jeff jeff  12750431 Jun  8 21:34 corecompiler.ji
-rwxr-xr-x 1 jeff jeff 145160120 Jun  8 21:41 sys.so
julia> @time using Plots
[ Info: Precompiling Plots [91a5bcdd-55d7-5caf-9e0b-520d859cae80]
125.626309 seconds (7.76 M allocations: 445.493 MiB, 0.10% gc time)

julia> @time display(plot(rand(10)))
 10.892562 seconds (10.28 M allocations: 530.079 MiB, 2.52% gc time)

julia> @time using SIMD
[ Info: Precompiling SIMD [fdea26ae-647d-5447-a871-4b548cad5224]
  1.415139 seconds (285.21 k allocations: 18.519 MiB)

julia> @time display(plot(rand(10)))
  0.409602 seconds (982.29 k allocations: 49.991 MiB, 2.96% gc time)
```

The last item is clearly volatile; there are probably just a few critical backedges that this plus #36200 manage to cut.
