### PR TITLE
Include Threads.foreach in documentation

### DIFF
--- a/doc/src/base/multi-threading.md
+++ b/doc/src/base/multi-threading.md
@@ -2,6 +2,7 @@
 
 ```@docs
 Base.Threads.@threads
+Base.Threads.foreach
 Base.Threads.@spawn
 Base.Threads.threadid
 Base.Threads.nthreads


### PR DESCRIPTION
It's something we missed in #34543.

cc @jrevels
