### PR TITLE
add keepat! (the opposite of deleteat!)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,8 @@ New library functions
 
 * Two argument methods `findmax(f, domain)`, `argmax(f, domain)` and the corresponding `min` versions ([#27613]).
 * `isunordered(x)` returns true if `x` is value that is normally unordered, such as `NaN` or `missing`.
+* New `keepat!(vector, inds)` function which is the inplace equivalent of `vector[inds]`
+  for a list `inds` of integers ([#36229]).
 * New macro `Base.@invokelatest f(args...; kwargs...)` provides a convenient way to call `Base.invokelatest(f, args...; kwargs...)` ([#37971])
 * New macro `Base.@invoke f(arg1::T1, arg2::T2; kwargs...)` provides an easier syntax to call `invoke(f, Tuple{T1,T2}; kwargs...)` ([#38438])
 * Two arguments method `lock(f, lck)` now accepts a `Channel` as the second argument. ([#39312])

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2579,7 +2579,9 @@ function keepat!(a::AbstractVector, inds)
     local prev
     i = firstindex(a)
     for k in inds
-        @isdefined(prev) && (prev < k || throw(ArgumentError("indices must be sorted")))
+        if @isdefined(prev)
+            prev < k || throw(ArgumentError("indices must be unique and sorted"))
+        end
         ak = a[k] # must happen even when i==k for bounds checking
         if i != k
             @inbounds a[i] = ak # k > i, so a[i] is inbounds

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2549,3 +2549,44 @@ function rest(a::AbstractArray{T}, state...) where {T}
     sizehint!(v, length(a))
     return foldl(push!, Iterators.rest(a, state...), init=v)
 end
+
+
+## keepat! ##
+
+"""
+    keepat!(a::AbstractVector, inds)
+
+Remove the items at all the indices which are not given by `inds`,
+and return the modified `a`.
+Items which are kept are shifted to fill the resulting gaps.
+
+`inds` can be either an iterator or a collection of sorted integer indices.
+See also [`deleteat!`](@ref).
+
+!!! compat "Julia 1.7"
+    This function is available as of Julia 1.7.
+
+# Examples
+```jldoctest
+julia> keepat!([6, 5, 4, 3, 2, 1], 1:2:5)
+3-element Array{Int64,1}:
+ 6
+ 4
+ 2
+```
+"""
+function keepat!(a::AbstractVector, inds)
+    isempty(inds) && return a
+    local prev
+    i = firstindex(a)
+    for k in inds
+        @isdefined(prev) && (prev <= k || throw(ArgumentError("indices must be sorted")))
+        if i != k
+            a[i] = a[k]
+        end
+        prev = k
+        i = nextind(a, i)
+    end
+    deleteat!(a, i:lastindex(a))
+    return a
+end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2560,7 +2560,7 @@ Remove the items at all the indices which are not given by `inds`,
 and return the modified `a`.
 Items which are kept are shifted to fill the resulting gaps.
 
-`inds` can be either an iterator or a collection of sorted integer indices.
+`inds` must be an iterator of sorted and unique integer indices.
 See also [`deleteat!`](@ref).
 
 !!! compat "Julia 1.7"
@@ -2576,13 +2576,13 @@ julia> keepat!([6, 5, 4, 3, 2, 1], 1:2:5)
 ```
 """
 function keepat!(a::AbstractVector, inds)
-    isempty(inds) && return a
     local prev
     i = firstindex(a)
     for k in inds
-        @isdefined(prev) && (prev <= k || throw(ArgumentError("indices must be sorted")))
+        @isdefined(prev) && (prev < k || throw(ArgumentError("indices must be sorted")))
+        ak = a[k] # must happen even when i==k for bounds checking
         if i != k
-            a[i] = a[k]
+            @inbounds a[i] = ak # k > i, so a[i] is inbounds
         end
         prev = k
         i = nextind(a, i)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1368,6 +1368,41 @@ function insert!(a::Array{T,1}, i::Integer, item) where T
 end
 
 """
+    keepat!(a::Vector, inds)
+
+Remove the items at all the indices which are not given by `inds`, and return the modified `a`.
+Items which are kept are shifted to fill the resulting gaps.
+
+`inds` can be either an iterator or a collection of sorted and unique integer indices.
+See also [`deleteat!`](@ref).
+
+# Examples
+```jldoctest
+julia> keepat!([6, 5, 4, 3, 2, 1], 1:2:5)
+3-element Array{Int64,1}:
+ 6
+ 4
+ 2
+```
+"""
+function keepat!(a::Vector, inds)
+    n = length(a)
+    l = 0
+    i = 1
+    for k in inds
+        1 <= k <= n || throw(BoundsError(a, k))
+        l < k || throw(ArgumentError("indices must be unique and sorted"))
+        if i != k
+            @inbounds a[i] = a[k]
+        end
+        l = k
+        i += 1
+    end
+    _deleteend!(a, n-i+1)
+    a
+end
+
+"""
     deleteat!(a::Vector, i::Integer)
 
 Remove the item at the given `i` and return the modified `a`. Subsequent items

--- a/base/array.jl
+++ b/base/array.jl
@@ -1385,21 +1385,20 @@ julia> keepat!([6, 5, 4, 3, 2, 1], 1:2:5)
  2
 ```
 """
-function keepat!(a::Vector, inds)
-    n = length(a)
-    l = 0
-    i = 1
+function keepat!(a::AbstractVector, inds)
+    isempty(inds) && return a
+    local prev
+    i = firstindex(a)
     for k in inds
-        1 <= k <= n || throw(BoundsError(a, k))
-        l < k || throw(ArgumentError("indices must be unique and sorted"))
+        @isdefined(prev) && (prev <= k || throw(ArgumentError("indices must be sorted")))
         if i != k
-            @inbounds a[i] = a[k]
+            a[i] = a[k]
         end
-        l = k
-        i += 1
+        prev = k
+        i = nextind(a, i)
     end
-    _deleteend!(a, n-i+1)
-    a
+    deleteat!(a, i:lastindex(a))
+    return a
 end
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -1368,40 +1368,6 @@ function insert!(a::Array{T,1}, i::Integer, item) where T
 end
 
 """
-    keepat!(a::Vector, inds)
-
-Remove the items at all the indices which are not given by `inds`, and return the modified `a`.
-Items which are kept are shifted to fill the resulting gaps.
-
-`inds` can be either an iterator or a collection of sorted and unique integer indices.
-See also [`deleteat!`](@ref).
-
-# Examples
-```jldoctest
-julia> keepat!([6, 5, 4, 3, 2, 1], 1:2:5)
-3-element Array{Int64,1}:
- 6
- 4
- 2
-```
-"""
-function keepat!(a::AbstractVector, inds)
-    isempty(inds) && return a
-    local prev
-    i = firstindex(a)
-    for k in inds
-        @isdefined(prev) && (prev <= k || throw(ArgumentError("indices must be sorted")))
-        if i != k
-            a[i] = a[k]
-        end
-        prev = k
-        i = nextind(a, i)
-    end
-    deleteat!(a, i:lastindex(a))
-    return a
-end
-
-"""
     deleteat!(a::Vector, i::Integer)
 
 Remove the item at the given `i` and return the modified `a`. Subsequent items

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -503,6 +503,7 @@ export
     count,
     delete!,
     deleteat!,
+    keepat!,
     eltype,
     empty!,
     empty,

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -273,6 +273,7 @@ Base.pushfirst!
 Base.popfirst!
 Base.insert!
 Base.deleteat!
+Base.keepat!
 Base.splice!
 Base.resize!
 Base.append!

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1298,3 +1298,24 @@ end
     @test @inferred(reduce(vcat, x_vecs)) == [5.0, 1.0, 2.0, 3.0]
     @test @inferred(reduce(vcat, ([10.0], [20.0], Bool[]))) == [10.0, 20.0]
 end
+
+@testset "keepat!" begin
+    a = [1:6;]
+    @test a === keepat!(a, 1:5)
+    @test a == 1:5
+    @test keepat!(a, [2, 4]) == [2, 4]
+    @test isempty(keepat!(a, []))
+
+    a = [1:6;]
+    @test_throws BoundsError keepat!(a, 1:10) # make sure this is not a no-op
+    @test_throws BoundsError keepat!(a, 2:10)
+    @test_throws ArgumentError keepat!(a, [2, 4, 3])
+
+    b = BitVector([1, 1, 1, 0, 0])
+    @test b === keepat!(b, 1:5)
+    @test b == [1, 1, 1, 0, 0]
+    @test keepat!(b, 2:4) == [1, 1, 0]
+    @test_throws BoundsError keepat!(a, -1:10)
+    @test_throws ArgumentError keepat!(a, [2, 1])
+    @test isempty(keepat!(a, []))
+end


### PR DESCRIPTION
It feels like I'm missing something, but I asked on slack and this functionality doesn't seem to exist yet in `Base`.
`keepat!(vector, indices)` deletes items at all indices of `vector` except those which are specified in `indices`.
In other words, after `keepat!(a, inds)`, `a` is equal to the array which would have been obtained by `a[inds]`.

I'm not sure about the name, it could be maybe `getindex!`, or the feature could be incorporated in `deleteat!` with a keyword.