### PR TITLE
deleteat! : check bounds for the first passed index

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1353,7 +1353,7 @@ function _deleteat!(a::Vector, inds, dltd=Nowhere())
     y = iterate(inds)
     y === nothing && return a
     (p, s) = y
-    1 <= p <= n || throw(BoundsError(a, p))
+    checkbounds(a, p)
     push!(dltd, @inbounds a[p])
     q = p+1
     while true

--- a/base/array.jl
+++ b/base/array.jl
@@ -1352,9 +1352,9 @@ function _deleteat!(a::Vector, inds, dltd=Nowhere())
     n = length(a)
     y = iterate(inds)
     y === nothing && return a
-    n == 0 && throw(BoundsError(a, inds))
     (p, s) = y
-    p <= n && push!(dltd, @inbounds a[p])
+    1 <= p <= n || throw(BoundsError(a, p))
+    push!(dltd, @inbounds a[p])
     q = p+1
     while true
         y = iterate(inds, s)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1446,11 +1446,15 @@ end
     @test deleteat!(a, [1,3,5,7:10...]) == [2,4,6]
     @test_throws BoundsError deleteat!(a, 13)
     @test_throws BoundsError deleteat!(a, [1,13])
-    @test_throws ArgumentError deleteat!(a, [5,3])
+    @test_throws ArgumentError deleteat!(a, [3,2]) # not sorted
     @test_throws BoundsError deleteat!(a, 5:20)
     @test_throws BoundsError deleteat!(a, Bool[])
     @test_throws BoundsError deleteat!(a, [true])
     @test_throws BoundsError deleteat!(a, falses(11))
+    @test_throws BoundsError deleteat!(a, [0])
+    @test_throws BoundsError deleteat!(a, [4])
+    @test_throws BoundsError deleteat!(a, [5])
+    @test_throws BoundsError deleteat!(a, [5, 3])
 
     @test_throws BoundsError deleteat!([], 1)
     @test_throws BoundsError deleteat!([], [1])


### PR DESCRIPTION
All other indices are bound-checked.
Currently, the behavior looks like:
```julia
julia> deleteat!([1:1000;], [-100])

signal (11): Segmentation fault
[...]

julia>  deleteat!(BigInt[0], [0])
free(): invalid next size (normal)

signal (6): Aborted
[...]

julia> deleteat!(BigInt[0], [-100])
ERROR: UndefRefError: access to undefined reference
[...]

julia> deleteat!([0], [0])
Int64[]

julia> deleteat!([0], [2])
1-element Array{Int64,1}:
 0

julia> deleteat!([0], [3])
ERROR: InexactError: check_top_bit(UInt64, -1)
[...]
```
With this commit, all these expressions throw a `BoundsError`.