### PR TITLE
Fix: rem2pi for negative values greater than 2pi

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1001,7 +1001,7 @@ function rem2pi(x::Float64, ::RoundingMode{:ToZero})
     ax = abs(x)
     ax <= 2*Float64(pi,RoundDown) && return x
 
-    n,y = rem_pio2_kernel(x)
+    n,y = rem_pio2_kernel(ax)
 
     if iseven(n)
         if n & 2 == 2 # n % 4 == 2: add pi

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2507,6 +2507,14 @@ end
     @test rem2pi(T(-4), RoundNearest) ≈ 2pi-4
     @test rem2pi(T(-4), RoundDown)    ≈ 2pi-4
     @test rem2pi(T(-4), RoundUp)      == -4
+    @test rem2pi(T(8), RoundToZero)  ≈ 8-2pi
+    @test rem2pi(T(8), RoundNearest) ≈ 8-2pi
+    @test rem2pi(T(8), RoundDown)    ≈ 8-2pi
+    @test rem2pi(T(8), RoundUp)      ≈ 8-4pi
+    @test rem2pi(T(-8), RoundToZero)  ≈ -8+2pi
+    @test rem2pi(T(-8), RoundNearest) ≈ -8+2pi
+    @test rem2pi(T(-8), RoundDown)    ≈ -8+4pi
+    @test rem2pi(T(-8), RoundUp)      ≈ -8+2pi
 end
 
 import Base.^


### PR DESCRIPTION
Fix for #36232

We just need to pass absolute value to `rem_pio2_kernel`. 

The function `rem2pi(x::Float64, ::RoundingMode{:ToZero})` gives wrong answer for negative numbers. The tests cases were limited so it was missed.
```
julia> rem2pi(Float64(-8), RoundToZero)  
-4.566370614359173 # wrong answer
  
julia> rem2pi(BigFloat(-8), RoundToZero) # correct answer
-1.716814692820413523074713233440994231605661201249788358050110815384367187427604
```
Answer for rem2pi(8, RoundToZero) should be `-8 - 2pi*round(-8/(2π),RoundToZero)` which evaluates to -1.7168146928204138

The answer for rem2pi(Float64(-8), RoundToZero)  & rem2pi(BigFloat(-8), RoundToZero) are different because the definition for BigFloat fn is different.
https://github.com/JuliaLang/julia/blob/38f2c594c49cec46d38be6dd614a5592582a3016/base/mpfr.jl#L713
https://github.com/JuliaLang/julia/blob/38f2c594c49cec46d38be6dd614a5592582a3016/base/math.jl#L1000