### PR TITLE
add push(::IO, pair...) and push(::ImmutableDict, pair...)

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -743,6 +743,15 @@ ImmutableDict(t::ImmutableDict{K,V}, KV::Pair, rest::Pair...) where {K,V} =
     ImmutableDict(ImmutableDict(t, KV), rest...)
 ImmutableDict(KV::Pair, rest::Pair...) = ImmutableDict(ImmutableDict(KV), rest...)
 
+"""
+    push(coll, items...)
+
+Create a new collection containing all the elements from `coll` (in the same order
+for ordered collections) plus the provided new `items` (inserted at the end
+for ordered collections).
+"""
+push(dict::ImmutableDict, KV::Pair...) = ImmutableDict(dict, KV...)
+
 function in(key_value::Pair, dict::ImmutableDict, valcmp=(==))
     key, value = key_value
     while isdefined(dict, :parent)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -475,6 +475,7 @@ export
     pop!,
     popat!,
     prepend!,
+    push,
     push!,
     resize!,
     popfirst!,

--- a/base/show.jl
+++ b/base/show.jl
@@ -217,7 +217,7 @@ print(io::IO, s::Symbol) = (write(io,s); nothing)
 `IOContext` provides a mechanism for passing output configuration settings among [`show`](@ref) methods.
 
 In short, it is an immutable dictionary that is a subclass of `IO`. It supports standard
-dictionary operations such as [`getindex`](@ref), and can also be used as an I/O stream.
+dictionary operations such as [`getindex`](@ref) and [`push`](@ref), and can also be used as an I/O stream.
 """
 struct IOContext{IO_t <: IO} <: AbstractPipe
     io::IO_t
@@ -323,6 +323,15 @@ short
 ```
 """
 IOContext(io::IO, KV::Pair, KVs::Pair...) = IOContext(IOContext(io, KV), KVs...)
+
+"""
+    push(io::IO, KV::Pair...)
+
+Create an `IOContext` that wraps a given stream, adding the specified `key=>value` pairs to
+the properties of that stream (note that `io` can itself be an `IOContext`).
+This is equivalent to [`IOContext(io, KV...)`](@ref).
+"""
+push(io::IO, KV::Pair...) = IOContext(io, KVs...)
 
 show(io::IO, ctx::IOContext) = (print(io, "IOContext("); show(io, ctx.io); print(io, ")"))
 

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -50,6 +50,7 @@ Base.readavailable
 Base.IOContext
 Base.IOContext(::IO, ::Pair)
 Base.IOContext(::IO, ::IOContext)
+Base.push(::IO, ::Pair)
 ```
 
 ## Text I/O

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -661,9 +661,13 @@ import Base.ImmutableDict
     v1 = "value1"
     v2 = "value2"
     d1 = ImmutableDict(d, k1 => v1)
+    @test d1 == push(d, k1 => v1)
     d2 = ImmutableDict(d1, k2 => v2)
     d3 = ImmutableDict(d2, k1 => v2)
     d4 = ImmutableDict(d3, k2 => v1)
+    d4′ = push(d, k1 => v1, k2 => v2, k1 => v2, k2 => v1)
+    @test d4 == d4′
+    @test typeof(d4) == typeof(d4′)
     dnan = ImmutableDict{String, Float64}(k2, NaN)
     dnum = ImmutableDict(dnan, k2 => 1)
 


### PR DESCRIPTION
This is part of #24836 with what seems to be the least controversial: this doesn't add a generic `push` implementation for mutable collections, and doesn't even implement specific implementation for specific containers, but just defines push on `ImmutableDict`, and on `IO`.

Both types are considered as immutable dictionaries, they support `get` and `getindex`, and it seems natural that they also support `push`ing.
Triage label was already applied to the other PR and removed, I'm not sure if it needs to be applied here.