### PR TITLE
Rewording related to disability

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2260,7 +2260,7 @@ function hash(A::AbstractArray, h::UInt)
     # hashes will often subsequently be compared by equality -- and equality between arrays
     # works elementwise forwards and is short-circuiting. This means that a collision
     # between arrays that differ by elements at the beginning is cheaper than one where the
-    # difference is towards the end. Furthermore, blindly choosing log(N) entries from a
+    # difference is towards the end. Furthermore, naively choosing log(N) entries from a
     # sparse array will likely only choose the same element repeatedly (zero in this case).
 
     # To achieve this, we work backwards, starting by hashing the last element of the

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2260,7 +2260,7 @@ function hash(A::AbstractArray, h::UInt)
     # hashes will often subsequently be compared by equality -- and equality between arrays
     # works elementwise forwards and is short-circuiting. This means that a collision
     # between arrays that differ by elements at the beginning is cheaper than one where the
-    # difference is towards the end. Furthermore, naively choosing log(N) entries from a
+    # difference is towards the end. Furthermore, choosing `log(N)` arbitrary entries from a
     # sparse array will likely only choose the same element repeatedly (zero in this case).
 
     # To achieve this, we work backwards, starting by hashing the last element of the

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -113,7 +113,7 @@ julia> Base.length(S::Squares) = S.count
 ```
 
 Now, when we ask Julia to [`collect`](@ref) all the elements into an array it can preallocate a `Vector{Int}`
-of the right size instead of blindly [`push!`](@ref)ing each element into a `Vector{Any}`:
+of the right size instead of naively [`push!`](@ref)ing each element into a `Vector{Any}`:
 
 ```jldoctest squaretype
 julia> collect(Squares(4))

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -906,7 +906,7 @@ f(x::Int, y::Int) = 3
 ```
 
 This is often the right strategy; however, there are circumstances
-where following this advice carelessly can be counterproductive. In
+where following this advice mindlessly can be counterproductive. In
 particular, the more methods a generic function has, the more
 possibilities there are for ambiguities. When your method hierarchies
 get more complicated than this simple example, it can be worth your

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -906,7 +906,7 @@ f(x::Int, y::Int) = 3
 ```
 
 This is often the right strategy; however, there are circumstances
-where following this advice blindly can be counterproductive. In
+where following this advice carelessly can be counterproductive. In
 particular, the more methods a generic function has, the more
 possibilities there are for ambiguities. When your method hierarchies
 get more complicated than this simple example, it can be worth your


### PR DESCRIPTION
I believe these small changes to be worthwhile. I believe there are some appropriate figurative uses of "blind" (e.g. https://www.realsocialskills.org/blog/blind-spot-is-not-a-disability-analogy), but I don't think the uses in this PR are like that.