### PR TITLE
remove more global state from codegen

### DIFF
--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -27,7 +27,6 @@ JL_DLLEXPORT size_t jl_LLVMDisasmInstruction(void *DC, uint8_t *Bytes, uint64_t 
 int32_t jl_assign_functionID(const char *fname) UNAVAILABLE
 
 void jl_init_codegen(void) { }
-void jl_fptr_to_llvm(void *fptr, jl_method_instance_t *lam, int specsig) { }
 
 int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline)
 {

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -536,7 +536,7 @@ void jl_dump_native(void *native_code,
 
         // reflect the address of the jl_RTLD_DEFAULT_handle variable
         // back to the caller, so that we can check for consistency issues
-        GlobalValue *jlRTLD_DEFAULT_var = data->M->getNamedValue("jl_RTLD_DEFAULT_handle");
+        GlobalValue *jlRTLD_DEFAULT_var = jl_emit_RTLD_DEFAULT_var(data->M.get());
         addComdat(new GlobalVariable(*data->M,
                                      jlRTLD_DEFAULT_var->getType(),
                                      true,

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -3,93 +3,42 @@
 // --- the ccall, cglobal, and llvm intrinsics ---
 #include "llvm/Support/Path.h" // for llvm::sys::path
 
-// Map from symbol name (in a certain library) to its GV in sysimg and the
-// DL handle address in the current session.
-typedef StringMap<GlobalVariable*> SymMapGV;
-static StringMap<std::pair<GlobalVariable*,SymMapGV>> libMapGV;
-#ifdef _OS_WINDOWS_
-static SymMapGV symMapExe;
-static SymMapGV symMapDl;
-#endif
-static SymMapGV symMapDefault;
-
-template<typename Func>
-struct LazyModule {
-    Func func;
-    Module *m;
-    template<typename Func2>
-    LazyModule(Func2 &&func)
-        : func(std::forward<Func2>(func)),
-          m(nullptr)
-    {}
-    Module *get()
-    {
-        if (!m)
-            m = func();
-        return m;
-    }
-    Module &operator*()
-    {
-        return *get();
-    }
-};
-
-template<typename Func>
-static LazyModule<typename std::remove_reference<Func>::type>
-lazyModule(Func &&func)
-{
-    return LazyModule<typename std::remove_reference<Func>::type>(
-        std::forward<Func>(func));
-}
-
-
-void copy_to_shadow(GlobalVariable *gv)
-{
-    // hack: make a copy of all globals in the shadow_output
-    if (!imaging_mode)
-        return;
-    GlobalVariable *shadowvar = global_proto(gv, shadow_output);
-    shadowvar->setInitializer(gv->getInitializer());
-    shadowvar->setLinkage(GlobalVariable::InternalLinkage);
-}
-
 // Find or create the GVs for the library and symbol lookup.
 // Return `runtime_lib` (whether the library name is a string)
 // The `lib` and `sym` GV returned may not be in the current module.
-template<typename MT>
-static bool runtime_sym_gvs(const char *f_lib, const char *f_name, MT &&M,
+static bool runtime_sym_gvs(jl_codegen_params_t &emission_context, const char *f_lib, const char *f_name,
                             GlobalVariable *&lib, GlobalVariable *&sym)
 {
+    Module *M = emission_context.shared_module(jl_LLVMContext);
     bool runtime_lib = false;
     GlobalVariable *libptrgv;
-    SymMapGV *symMap;
+    jl_codegen_params_t::SymMapGV *symMap;
 #ifdef _OS_WINDOWS_
     if ((intptr_t)f_lib == 1) {
         libptrgv = jlexe_var;
-        symMap = &symMapExe;
+        symMap = &emission_context.symMapExe;
     }
     else if ((intptr_t)f_lib == 2) {
         libptrgv = jldll_var;
-        symMap = &symMapDl;
+        symMap = &emission_context.symMapDl;
     }
     else
 #endif
     if (f_lib == NULL) {
         libptrgv = jlRTLD_DEFAULT_var;
-        symMap = &symMapDefault;
+        symMap = &emission_context.symMapDefault;
     }
     else {
         std::string name = "ccalllib_";
         name += llvm::sys::path::filename(f_lib);
         name += std::to_string(globalUnique++);
         runtime_lib = true;
-        auto &libgv = libMapGV[f_lib];
+        auto &libgv = emission_context.libMapGV[f_lib];
         if (libgv.first == NULL) {
             libptrgv = new GlobalVariable(*M, T_pint8, false,
                                           GlobalVariable::ExternalLinkage,
                                           Constant::getNullValue(T_pint8), name);
-            copy_to_shadow(libptrgv);
-            libgv.first = global_proto(libptrgv);
+            libgv.first = libptrgv;
         }
         else {
             libptrgv = libgv.first;
@@ -108,8 +57,6 @@ static bool runtime_sym_gvs(const char *f_lib, const char *f_name, MT &&M,
         llvmgv = new GlobalVariable(*M, T_pvoidfunc, false,
                                     GlobalVariable::ExternalLinkage,
                                     Constant::getNullValue(T_pvoidfunc), name);
-        copy_to_shadow(llvmgv);
-        llvmgv = global_proto(llvmgv);
     }
 
     lib = libptrgv;
@@ -118,6 +65,7 @@ static bool runtime_sym_gvs(const char *f_lib, const char *f_name, MT &&M,
 }
 
 static Value *runtime_sym_lookup(
+        jl_codegen_params_t &emission_context,
         IRBuilder<> &irbuilder,
         PointerType *funcptype, const char *f_lib,
         const char *f_name, Function *f,
@@ -154,14 +102,14 @@ static Value *runtime_sym_lookup(
     irbuilder.SetInsertPoint(dlsym_lookup);
     Value *libname;
     if (runtime_lib) {
-        libname = stringConstPtr(irbuilder, f_lib);
+        libname = stringConstPtr(emission_context, irbuilder, f_lib);
     }
     else {
         // f_lib is actually one of the special sentinel values
         libname = ConstantExpr::getIntToPtr(ConstantInt::get(T_size, (uintptr_t)f_lib), T_pint8);
     }
     Value *llvmf = irbuilder.CreateCall(prepare_call_in(jl_builderModule(irbuilder), jldlsym_func),
-            { libname, stringConstPtr(irbuilder, f_name), libptrgv });
+            { libname, stringConstPtr(emission_context, irbuilder, f_name), libptrgv });
     auto store = irbuilder.CreateAlignedStore(llvmf, llvmgv, sizeof(void*));
     store->setAtomic(AtomicOrdering::Release);
     irbuilder.CreateBr(ccall_bb);
@@ -181,35 +129,22 @@ static Value *runtime_sym_lookup(
 {
     GlobalVariable *libptrgv;
     GlobalVariable *llvmgv;
-    bool runtime_lib = runtime_sym_gvs(f_lib, f_name, f->getParent(),
-                                       libptrgv, llvmgv);
-    libptrgv = prepare_global(libptrgv);
-    llvmgv = prepare_global(llvmgv);
-    return runtime_sym_lookup(ctx.builder, funcptype, f_lib, f_name, f, libptrgv, llvmgv,
-                              runtime_lib);
+    bool runtime_lib = runtime_sym_gvs(ctx.emission_context, f_lib, f_name, libptrgv, llvmgv);
+    libptrgv = prepare_global_in(jl_Module, libptrgv);
+    llvmgv = prepare_global_in(jl_Module, llvmgv);
+    return runtime_sym_lookup(ctx.emission_context, ctx.builder, funcptype, f_lib, f_name, f, libptrgv, llvmgv, runtime_lib);
 }
-
-// Map from distinct callee's to its GOT entry.
-// In principle the attribute, function type and calling convention
-// don't need to be part of the key but it seems impossible to forward
-// all the arguments without writing assembly directly.
-// This doesn't matter too much in reality since a single function is usually
-// not called with multiple signatures.
-static DenseMap<AttributeList,
-                std::map<std::tuple<GlobalVariable*,FunctionType*,
-                                    CallingConv::ID>,GlobalVariable*>> allPltMap;
-
-void jl_add_to_shadow(Module *m);
 
 // Emit a "PLT" entry that will be lazily initialized
 // when being called the first time.
 static GlobalVariable *emit_plt_thunk(
-        Module *M, FunctionType *functype,
-        const AttributeList &attrs,
+        jl_codegen_params_t &emission_context,
+        FunctionType *functype, const AttributeList &attrs,
         CallingConv::ID cc, const char *f_lib, const char *f_name,
         GlobalVariable *libptrgv, GlobalVariable *llvmgv,
         bool runtime_lib)
 {
+    Module *M = emission_context.shared_module(jl_LLVMContext);
     PointerType *funcptype = PointerType::get(functype, 0);
     libptrgv = prepare_global_in(M, libptrgv);
     llvmgv = prepare_global_in(M, llvmgv);
@@ -229,7 +164,7 @@ static GlobalVariable *emit_plt_thunk(
                                              ConstantExpr::getBitCast(plt, T_pvoidfunc), gname);
     BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", plt);
     IRBuilder<> irbuilder(b0);
-    Value *ptr = runtime_sym_lookup(irbuilder, funcptype, f_lib, f_name, plt, libptrgv,
+    Value *ptr = runtime_sym_lookup(emission_context, irbuilder, funcptype, f_lib, f_name, plt, libptrgv,
                                     llvmgv, runtime_lib);
     auto store = irbuilder.CreateAlignedStore(irbuilder.CreateBitCast(ptr, T_pvoidfunc), got, sizeof(void*));
     store->setAtomic(AtomicOrdering::Release);
@@ -265,23 +200,14 @@ static GlobalVariable *emit_plt_thunk(
     }
     irbuilder.ClearInsertionPoint();
 
-    got = global_proto(got); // exchange got for the permanent global before jl_finalize_module destroys it
-    jl_add_to_shadow(M);
-    jl_finalize_module(std::unique_ptr<Module>(M));
-
-    auto shadowgot =
-        cast<GlobalVariable>(shadow_output->getNamedValue(gname));
-    auto shadowplt = cast<Function>(shadow_output->getNamedValue(fname));
-    shadowgot->setInitializer(ConstantExpr::getBitCast(shadowplt,
-                                                       T_pvoidfunc));
     return got;
 }
 
 static Value *emit_plt(
         jl_codectx_t &ctx,
         FunctionType *functype,
-       const AttributeList &attrs,
-       CallingConv::ID cc, const char *f_lib, const char *f_name)
+        const AttributeList &attrs,
+        CallingConv::ID cc, const char *f_lib, const char *f_name)
 {
     assert(imaging_mode);
     // Don't do this for vararg functions so that the `musttail` is only
@@ -289,26 +215,17 @@ static Value *emit_plt(
     assert(!functype->isVarArg());
     GlobalVariable *libptrgv;
     GlobalVariable *llvmgv;
-    auto LM = lazyModule([&] {
-            Module *m = new Module(f_name, jl_LLVMContext);
-            jl_setup_module(m);
-            return m;
-        });
-    bool runtime_lib = runtime_sym_gvs(f_lib, f_name, LM, libptrgv, llvmgv);
+    bool runtime_lib = runtime_sym_gvs(ctx.emission_context, f_lib, f_name, libptrgv, llvmgv);
     PointerType *funcptype = PointerType::get(functype, 0);
 
-    auto &pltMap = allPltMap[attrs];
+    auto &pltMap = ctx.emission_context.allPltMap[attrs];
     auto key = std::make_tuple(llvmgv, functype, cc);
-    GlobalVariable *&shadowgot = pltMap[key];
-    if (!shadowgot) {
-        shadowgot = emit_plt_thunk(LM.get(), functype, attrs, cc, f_lib, f_name, libptrgv, llvmgv, runtime_lib);
+    GlobalVariable *&sharedgot = pltMap[key];
+    if (!sharedgot) {
+        sharedgot = emit_plt_thunk(ctx.emission_context,
+                functype, attrs, cc, f_lib, f_name, libptrgv, llvmgv, runtime_lib);
     }
-    else {
-        // `runtime_sym_gvs` shouldn't have created anything in a new module
-        // if it returns a GV that already exists.
-        assert(!LM.m);
-    }
-    GlobalVariable *got = prepare_global(shadowgot);
+    GlobalVariable *got = prepare_global_in(jl_Module, sharedgot);
     LoadInst *got_val = ctx.builder.CreateAlignedLoad(got, sizeof(void*));
     // See comment in `runtime_sym_lookup` above. This in principle needs a
     // consume ordering too. This is even less likely to cause issues though

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -156,6 +156,7 @@ TargetMachine *jl_TargetMachine;
 static DataLayout &jl_data_layout = *(new DataLayout(""));
 #define jl_Module ctx.f->getParent()
 #define jl_builderModule(builder) (builder).GetInsertBlock()->getParent()->getParent()
+#define prepare_call(Callee) prepare_call_in(jl_Module, (Callee))
 
 // types
 static Type *T_jlvalue;
@@ -272,88 +273,542 @@ static bool is_uniquerep_Type(jl_value_t *t)
     return jl_is_type_type(t) && type_has_unique_rep(jl_tparam0(t));
 }
 
+class jl_codectx_t;
+struct JuliaVariable {
+public:
+    StringLiteral name;
+    bool isconst;
+    Type *(*_type)(LLVMContext &C);
+
+    JuliaVariable(const JuliaVariable&) = delete;
+    JuliaVariable(const JuliaVariable&&) = delete;
+    GlobalVariable *realize(Module *m) {
+        if (GlobalValue *V = m->getNamedValue(name))
+            return cast<GlobalVariable>(V);
+        return new GlobalVariable(*m, _type(m->getContext()),
+                isconst, GlobalVariable::ExternalLinkage,
+                NULL, name);
+    }
+    GlobalVariable *realize(jl_codectx_t &ctx);
+};
+static inline void add_named_global(JuliaVariable *name, void *addr)
+{
+    add_named_global(name->name, addr);
+}
+
+struct JuliaFunction {
+public:
+    StringLiteral name;
+    FunctionType *(*_type)(LLVMContext &C);
+    AttributeList (*_attrs)(LLVMContext &C);
+
+    JuliaFunction(const JuliaFunction&) = delete;
+    JuliaFunction(const JuliaFunction&&) = delete;
+    Function *realize(Module *m) {
+        if (GlobalValue *V = m->getNamedValue(name))
+            return cast<Function>(V);
+        Function *F = Function::Create(_type(m->getContext()),
+                         Function::ExternalLinkage,
+                         name, m);
+        if (_attrs)
+            F->setAttributes(_attrs(m->getContext()));
+        return F;
+    }
+    Function *realize(jl_codectx_t &ctx);
+};
+template<typename T>
+static inline void add_named_global(JuliaFunction *name, T *addr)
+{
+    // cast through integer to avoid c++ pedantic warning about casting between
+    // data and code pointers
+    add_named_global(name->name, (void*)(uintptr_t)addr);
+}
+template<typename T>
+static inline void add_named_global(StringRef name, T *addr)
+{
+    // cast through integer to avoid c++ pedantic warning about casting between
+    // data and code pointers
+    add_named_global(name, (void*)(uintptr_t)addr);
+}
+
+AttributeSet Attributes(LLVMContext &C, std::initializer_list<Attribute::AttrKind> attrkinds)
+{
+    SmallVector<Attribute, 8> attrs(attrkinds.size());
+    for (size_t i = 0; i < attrkinds.size(); i++)
+        attrs[i] = Attribute::get(C, attrkinds.begin()[i]);
+    return AttributeSet::get(C, makeArrayRef(attrs));
+}
+
+static Type *get_pjlvalue(LLVMContext &C) { return T_pjlvalue; }
+
+static FunctionType *get_func_sig(LLVMContext &C) { return jl_func_sig; }
+
+static AttributeList get_func_attrs(LLVMContext &C)
+{
+    return AttributeList::get(C,
+            AttributeSet::get(C, makeArrayRef({Thunk})),
+            Attributes(C, {Attribute::NonNull}),
+            None);
+}
+
+static AttributeList get_attrs_noreturn(LLVMContext &C)
+{
+    return AttributeList::get(C,
+                Attributes(C, {Attribute::NoReturn}),
+                AttributeSet(),
+                None);
+}
+
+static AttributeList get_attrs_sext(LLVMContext &C)
+{
+    return AttributeList::get(C,
+                AttributeSet(),
+                AttributeSet(),
+                {Attributes(C, {Attribute::SExt})});
+}
+
+static AttributeList get_attrs_zext(LLVMContext &C)
+{
+    return AttributeList::get(C,
+                AttributeSet(),
+                AttributeSet(),
+                {Attributes(C, {Attribute::ZExt})});
+}
+
+
 // global vars
-static GlobalVariable *jlRTLD_DEFAULT_var;
+static const auto jlRTLD_DEFAULT_var = new JuliaVariable{
+    "jl_RTLD_DEFAULT_handle",
+    true,
+    [](LLVMContext &C) { return T_pint8; },
+};
 #ifdef _OS_WINDOWS_
-static GlobalVariable *jlexe_var;
-static GlobalVariable *jldll_var;
+static const auto jlexe_var = new JuliaVariable{
+    "jl_exe_handle",
+    true,
+    [](LLVMContext &C) { return T_pint8; },
+};
+static const auto jldll_var = new JuliaVariable{
+    "jl_dl_handle",
+    true,
+    [](LLVMContext &C) { return T_pint8; },
+};
 #endif //_OS_WINDOWS_
 
-static Function *jltls_states_func;
+static const auto jlstack_chk_guard_var = new JuliaVariable{
+    "__stack_chk_guard",
+    true,
+    get_pjlvalue,
+};
+
+static const auto jlgetworld_global = new JuliaVariable{
+    "jl_world_counter",
+    false,
+    [](LLVMContext &C) { return (Type*)T_size; },
+};
+
+static const auto jltls_states_func = new JuliaFunction{
+    "julia.ptls_states",
+    [](LLVMContext &C) { return FunctionType::get(PointerType::get(T_ppjlvalue, 0), false); },
+};
+
 
 // important functions
-static Function *jlnew_func;
-static Function *jlsplatnew_func;
-static Function *jlthrow_func;
-static Function *jlerror_func;
-static Function *jltypeerror_func;
-static Function *jlundefvarerror_func;
-static Function *jlboundserror_func;
-static Function *jluboundserror_func;
-static Function *jlvboundserror_func;
-static Function *jlboundserrorv_func;
-static Function *jlcheckassign_func;
-static Function *jldeclareconst_func;
-static Function *jlgetbindingorerror_func;
-static Function *jlboundp_func;
-static Function *jltopeval_func;
-static Function *jlcopyast_func;
-static Function *jltuple_func;
-static Function *jlnsvec_func;
-static Function *jlapplygeneric_func;
-static Function *jlinvoke_func;
-static Function *jlgetfield_func;
-static Function *jlmethod_func;
-static Function *jlgenericfunction_func;
-static Function *jlenter_func;
-static Function *jl_current_exception_func;
-static Function *jlleave_func;
-static Function *jl_restore_excstack_func;
-static Function *jl_excstack_state_func;
-static Function *jlegal_func;
-static Function *jl_alloc_obj_func;
-static Function *jl_newbits_func;
-static Function *jl_typeof_func;
-static Function *jl_loopinfo_marker_func;
-static Function *jl_write_barrier_func;
-static Function *jlisa_func;
-static Function *jlsubtype_func;
-static Function *jlapplytype_func;
-static Function *jl_object_id__func;
-static Function *setjmp_func;
-static Function *memcmp_func;
-static Function *box_int8_func;
-static Function *box_uint8_func;
-static Function *box_int16_func;
-static Function *box_uint16_func;
-static Function *box_int32_func;
-static Function *box_char_func;
-static Function *box_uint32_func;
-static Function *box_int64_func;
-static Function *box_uint64_func;
-static Function *box_float32_func;
-static Function *box_float64_func;
-static Function *box_ssavalue_func;
-static Function *expect_func;
-static Function *jldlsym_func;
-static Function *jltypeassert_func;
-//static Function *jlgetnthfield_func;
-static Function *jlgetnthfieldchecked_func;
-//static Function *jlsetnthfield_func;
-static Function *jlgetcfunctiontrampoline_func;
-static Function *diff_gc_total_bytes_func;
-static Function *sync_gc_total_bytes_func;
-static Function *jlarray_data_owner_func;
-static GlobalVariable *jlgetworld_global;
+// Symbols are not gc-tracked, but we'll treat them as callee rooted anyway,
+// because they may come from a gc-rooted location
+static const auto jlnew_func = new JuliaFunction{
+    "jl_new_structv",
+    get_func_sig,
+    get_func_attrs,
+};
+static const auto jlsplatnew_func = new JuliaFunction{
+    "jl_new_structt",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+            {T_prjlvalue, T_prjlvalue}, false); },
+    get_func_attrs,
+};
+static const auto jlthrow_func = new JuliaFunction{
+    "jl_throw",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
+    get_attrs_noreturn,
+};
+static const auto jlerror_func = new JuliaFunction{
+    "jl_error",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_pint8}, false); },
+    get_attrs_noreturn,
+};
+static const auto jltypeerror_func = new JuliaFunction{
+    "jl_type_error",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_pint8, T_prjlvalue, PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
+    get_attrs_noreturn,
+};
+static const auto jlundefvarerror_func = new JuliaFunction{
+    "jl_undefined_var_error",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
+    get_attrs_noreturn,
+};
+static const auto jlboundserrorv_func = new JuliaFunction{
+    "jl_bounds_error_ints",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted), T_psize, T_size}, false); },
+    get_attrs_noreturn,
+};
+static const auto jlboundserror_func = new JuliaFunction{
+    "jl_bounds_error_int",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted), T_size}, false); },
+    get_attrs_noreturn,
+};
+static const auto jlvboundserror_func = new JuliaFunction{
+    "jl_bounds_error_tuple_int",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_pprjlvalue, T_size, T_size}, false); },
+    get_attrs_noreturn,
+};
+static const auto jluboundserror_func = new JuliaFunction{
+    "jl_bounds_error_unboxed_int",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {PointerType::get(T_int8, AddressSpace::Derived), T_pjlvalue, T_size}, false); },
+    get_attrs_noreturn,
+};
+static const auto jlcheckassign_func = new JuliaFunction{
+    "jl_checked_assignment",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_pjlvalue, PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
+};
+static const auto jldeclareconst_func = new JuliaFunction{
+    "jl_declare_constant",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_pjlvalue}, false); },
+};
+static const auto jlgetbindingorerror_func = new JuliaFunction{
+    "jl_get_binding_or_error",
+    [](LLVMContext &C) { return FunctionType::get(T_pjlvalue,
+                {T_pjlvalue, T_pjlvalue}, false); },
+};
+static const auto jlboundp_func = new JuliaFunction{
+    "jl_boundp",
+    [](LLVMContext &C) { return FunctionType::get(T_int32,
+                {T_pjlvalue, T_pjlvalue}, false); },
+};
+static const auto jltopeval_func = new JuliaFunction{
+    "jl_toplevel_eval",
+    [](LLVMContext &C) { return FunctionType::get(T_pjlvalue,
+                {T_pjlvalue, T_pjlvalue}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet(),
+            Attributes(C, {Attribute::NonNull}),
+            None); },
+};
+static const auto jlcopyast_func = new JuliaFunction{
+    "jl_copy_ast",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+                {T_prjlvalue}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet(),
+            Attributes(C, {Attribute::NonNull}),
+            None); },
+};
+//static const auto jlnsvec_func = new JuliaFunction{
+//    "jl_svec",
+//    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+//                {T_size}, true); },
+//    [](LLVMContext &C) { return AttributeList::get(C,
+//            AttributeSet(),
+//            Attributes(C, {Attribute::NonNull}),
+//            None); },
+//};
+static const auto jlapplygeneric_func = new JuliaFunction{
+    "jl_apply_generic",
+    get_func_sig,
+    get_func_attrs,
+};
+static const auto jlinvoke_func = new JuliaFunction{
+    "jl_invoke",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+                {T_prjlvalue, T_pprjlvalue, T_uint32, T_prjlvalue}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet(),
+            Attributes(C, {Attribute::NonNull}),
+            {AttributeSet(),
+             Attributes(C, {Attribute::ReadOnly, Attribute::NoCapture})}); },
+};
+static const auto jlmethod_func = new JuliaFunction{
+    "jl_method_def",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+                {T_prjlvalue, T_prjlvalue, T_pjlvalue}, false); },
+};
+static const auto jlgenericfunction_func = new JuliaFunction{
+    "jl_generic_function_def",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+                {T_pjlvalue, T_pjlvalue, T_pprjlvalue, T_pjlvalue, T_pjlvalue}, false); },
+};
+static const auto jlenter_func = new JuliaFunction{
+    "jl_enter_handler",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_pint8}, false); },
+};
+static const auto jl_current_exception_func = new JuliaFunction{
+    "jl_current_exception",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue, false); },
+};
+static const auto jlleave_func = new JuliaFunction{
+    "jl_pop_handler",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_int32}, false); },
+};
+static const auto jl_restore_excstack_func = new JuliaFunction{
+    "jl_restore_excstack",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_size}, false); },
+};
+static const auto jl_excstack_state_func = new JuliaFunction{
+    "jl_excstack_state",
+    [](LLVMContext &C) { return FunctionType::get(T_size, false); },
+};
+static const auto jlegal_func = new JuliaFunction{
+    "jl_egal",
+    [](LLVMContext &C) {
+        Type *T = PointerType::get(T_jlvalue, AddressSpace::CalleeRooted);
+        return FunctionType::get(T_int32, {T, T}, false); },
+};
+static const auto jl_alloc_obj_func = new JuliaFunction{
+    "julia.gc_alloc_obj",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+                {T_pint8, T_size, T_prjlvalue}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet::get(C, makeArrayRef({Attribute::getWithAllocSizeArgs(C, 1, None)})), // returns %1 bytes
+            Attributes(C, {Attribute::NoAlias, Attribute::NonNull}),
+            None); },
+};
+static const auto jl_newbits_func = new JuliaFunction{
+    "jl_new_bits",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+                {T_prjlvalue, T_pint8}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet(),
+            Attributes(C, {Attribute::NoAlias, Attribute::NonNull}),
+            None); },
+};
+static const auto jl_typeof_func = new JuliaFunction{
+    "julia.typeof",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+                {T_prjlvalue}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            Attributes(C, {Attribute::ReadOnly, Attribute::NoUnwind, Attribute::ArgMemOnly, Attribute::NoRecurse}),
+            Attributes(C, {Attribute::NonNull}),
+            None); },
+};
+static const auto jl_loopinfo_marker_func = new JuliaFunction{
+    "julia.loopinfo_marker",
+    [](LLVMContext &C) { return FunctionType::get(T_void, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            Attributes(C, {Attribute::ReadOnly, Attribute::NoRecurse, Attribute::InaccessibleMemOnly}),
+            AttributeSet(),
+            None); },
+};
+static const auto jl_write_barrier_func = new JuliaFunction{
+    "julia.write_barrier",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_prjlvalue}, true); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            Attributes(C, {Attribute::NoUnwind, Attribute::NoRecurse, Attribute::InaccessibleMemOnly}),
+            AttributeSet(),
+            None); },
+};
+static const auto jlisa_func = new JuliaFunction{
+    "jl_isa",
+    [](LLVMContext &C) { return FunctionType::get(T_int32,
+            {T_prjlvalue, T_prjlvalue}, false); },
+};
+
+static const auto jlsubtype_func = new JuliaFunction{
+    "jl_subtype",
+    [](LLVMContext &C) { return FunctionType::get(T_int32,
+            {T_prjlvalue, T_prjlvalue}, false); },
+};
+static const auto jlapplytype_func = new JuliaFunction{
+    "jl_instantiate_type_in_env",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+            {T_pjlvalue, T_pjlvalue, T_pprjlvalue}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet(),
+            Attributes(C, {Attribute::NonNull}),
+            None); },
+};
+static const auto jl_object_id__func = new JuliaFunction{
+    "jl_object_id_",
+    [](LLVMContext &C) { return FunctionType::get(T_size,
+            {T_prjlvalue, PointerType::get(T_int8, AddressSpace::Derived)}, false); },
+};
+static const auto setjmp_func = new JuliaFunction{
+    jl_setjmp_name,
+    [](LLVMContext &C) { return FunctionType::get(T_int32,
+            {T_pint8,
+#ifndef _OS_WINDOWS_
+            T_int32,
+#endif
+            }, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            Attributes(C, {Attribute::ReturnsTwice}),
+            AttributeSet(),
+            None); },
+};
+static const auto memcmp_func = new JuliaFunction{
+    "memcmp",
+    [](LLVMContext &C) { return FunctionType::get(T_int32,
+            {T_pint8, T_pint8, T_size}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            Attributes(C, {Attribute::ReadOnly, Attribute::NoUnwind, Attribute::ArgMemOnly}),
+            AttributeSet(),
+            None); },
+    // TODO: inferLibFuncAttributes(*memcmp_func, TLI);
+};
+static const auto jldlsym_func = new JuliaFunction{
+    "jl_load_and_lookup",
+    [](LLVMContext &C) { return FunctionType::get(T_pvoidfunc,
+            {T_pint8, T_pint8, PointerType::get(T_pint8, 0)}, false); },
+};
+static const auto jltypeassert_func = new JuliaFunction{
+    "jl_typeassert",
+    [](LLVMContext &C) { return FunctionType::get(T_void,
+            {T_prjlvalue, T_prjlvalue}, false); },
+};
+static const auto jlgetnthfieldchecked_func = new JuliaFunction{
+    "jl_get_nth_field_checked",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+            {T_prjlvalue, T_size}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet(),
+            Attributes(C, {Attribute::NonNull}),
+            None); },
+};
+static const auto jlgetcfunctiontrampoline_func = new JuliaFunction{
+    "jl_get_cfunction_trampoline",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+            {
+                T_prjlvalue, // f (object)
+                T_pjlvalue, // result
+                T_pint8, // cache
+                T_pjlvalue, // fill
+                FunctionType::get(T_pint8, { T_pint8, T_ppjlvalue }, false)->getPointerTo(), // trampoline
+                T_pjlvalue, // env
+                T_pprjlvalue, // vals
+            }, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet(),
+            Attributes(C, {Attribute::NonNull}),
+            None); },
+};
+static const auto diff_gc_total_bytes_func = new JuliaFunction{
+    "jl_gc_diff_total_bytes",
+    [](LLVMContext &C) { return FunctionType::get(T_int64, false); },
+};
+static const auto sync_gc_total_bytes_func = new JuliaFunction{
+    "jl_gc_sync_total_bytes",
+    [](LLVMContext &C) { return FunctionType::get(T_int64,
+            {T_int64}, false); },
+};
+static const auto jlarray_data_owner_func = new JuliaFunction{
+    "jl_array_data_owner",
+    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
+            {T_prjlvalue}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            Attributes(C, {Attribute::ReadOnly, Attribute::NoUnwind}),
+            Attributes(C, {Attribute::NonNull}),
+            None); },
+};
+#define BOX_FUNC(ct,rt,at,attrs)                                              \
+static const auto box_##ct##_func = new JuliaFunction{                        \
+    "jl_box_"#ct,                                                             \
+    [](LLVMContext &C) { return FunctionType::get(rt,                         \
+            {at}, false); },                                                  \
+    attrs,                                                                    \
+}
+BOX_FUNC(int8, T_pjlvalue, T_int8, get_attrs_sext);
+BOX_FUNC(uint8, T_pjlvalue, T_int8, get_attrs_zext);
+BOX_FUNC(int16, T_prjlvalue, T_int16, get_attrs_sext);
+BOX_FUNC(uint16, T_prjlvalue, T_int16, get_attrs_zext);
+BOX_FUNC(int32, T_prjlvalue, T_int32, get_attrs_sext);
+BOX_FUNC(uint32, T_prjlvalue, T_int32, get_attrs_zext);
+BOX_FUNC(int64, T_prjlvalue, T_int64, get_attrs_sext);
+BOX_FUNC(uint64, T_prjlvalue, T_int64, get_attrs_zext);
+BOX_FUNC(char, T_prjlvalue, T_char, get_attrs_zext);
+BOX_FUNC(float32, T_prjlvalue, T_float32, nullptr);
+BOX_FUNC(float64, T_prjlvalue, T_float64, nullptr);
+BOX_FUNC(ssavalue, T_prjlvalue, T_size, nullptr);
+#undef BOX_FUNC
+
 
 // placeholder functions
-static Function *gcroot_flush_func;
-static Function *gc_preserve_begin_func;
-static Function *gc_preserve_end_func;
-static Function *except_enter_func;
-static Function *pointer_from_objref_func;
+static const auto gcroot_flush_func = new JuliaFunction{
+    "julia.gcroot_flush",
+    [](LLVMContext &C) { return FunctionType::get(T_void, false); },
+};
+static const auto gc_preserve_begin_func = new JuliaFunction{
+    "llvm.julia.gc_preserve_begin",
+    [](LLVMContext &C) { return FunctionType::get(Type::getTokenTy(C), true); },
+};
+static const auto gc_preserve_end_func = new JuliaFunction {
+    "llvm.julia.gc_preserve_end",
+    [](LLVMContext &C) { return FunctionType::get(T_void, {Type::getTokenTy(C)}, false); },
+};
+static const auto except_enter_func = new JuliaFunction{
+    "julia.except_enter",
+    [](LLVMContext &C) { return FunctionType::get(T_int32, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet::get(C, makeArrayRef({Attribute::get(C, Attribute::ReturnsTwice)})),
+            AttributeSet(),
+            None); },
+};
+static const auto pointer_from_objref_func = new JuliaFunction{
+    "julia.pointer_from_objref",
+    [](LLVMContext &C) { return FunctionType::get(T_pjlvalue,
+            {PointerType::get(T_jlvalue, AddressSpace::Derived)}, false); },
+    [](LLVMContext &C) { return AttributeList::get(C,
+            AttributeSet::get(C, makeArrayRef({Attribute::get(C, Attribute::ReadNone), Attribute::get(C, Attribute::NoUnwind)})),
+            AttributeSet(),
+            None); },
+};
 
-static std::map<jl_fptr_args_t, Function*> builtin_func_map;
+static const auto jltuple_func = new JuliaFunction{"jl_f_tuple", get_func_sig, get_func_attrs};
+static const auto jlgetfield_func = new JuliaFunction{"jl_f_getfield", get_func_sig, get_func_attrs};
+static const std::map<jl_fptr_args_t, JuliaFunction*> builtin_func_map = {
+    { &jl_f_is,                 new JuliaFunction{"jl_f_is", get_func_sig, get_func_attrs} },
+    { &jl_f_typeof,             new JuliaFunction{"jl_f_typeof", get_func_sig, get_func_attrs} },
+    { &jl_f_sizeof,             new JuliaFunction{"jl_f_sizeof", get_func_sig, get_func_attrs} },
+    { &jl_f_issubtype,          new JuliaFunction{"jl_f_issubtype", get_func_sig, get_func_attrs} },
+    { &jl_f_isa,                new JuliaFunction{"jl_f_isa", get_func_sig, get_func_attrs} },
+    { &jl_f_typeassert,         new JuliaFunction{"jl_f_typeassert", get_func_sig, get_func_attrs} },
+    { &jl_f_ifelse,             new JuliaFunction{"jl_f_ifelse", get_func_sig, get_func_attrs} },
+    { &jl_f__apply,             new JuliaFunction{"jl_f__apply", get_func_sig, get_func_attrs} },
+    { &jl_f__apply_iterate,     new JuliaFunction{"jl_f__apply_iterate", get_func_sig, get_func_attrs} },
+    { &jl_f__apply_pure,        new JuliaFunction{"jl_f__apply_pure", get_func_sig, get_func_attrs} },
+    { &jl_f__apply_latest,      new JuliaFunction{"jl_f__apply_latest", get_func_sig, get_func_attrs} },
+    { &jl_f_throw,              new JuliaFunction{"jl_f_throw", get_func_sig, get_func_attrs} },
+    { &jl_f_tuple,              jltuple_func },
+    { &jl_f_svec,               new JuliaFunction{"jl_f_svec", get_func_sig, get_func_attrs} },
+    { &jl_f_applicable,         new JuliaFunction{"jl_f_applicable", get_func_sig, get_func_attrs} },
+    { &jl_f_invoke,             new JuliaFunction{"jl_f_invoke", get_func_sig, get_func_attrs} },
+    { &jl_f_invoke_kwsorter,    new JuliaFunction{"jl_f_invoke_kwsorter", get_func_sig, get_func_attrs} },
+    { &jl_f_isdefined,          new JuliaFunction{"jl_f_isdefined", get_func_sig, get_func_attrs} },
+    { &jl_f_getfield,           jlgetfield_func },
+    { &jl_f_setfield,           new JuliaFunction{"jl_f_setfield", get_func_sig, get_func_attrs} },
+    { &jl_f_fieldtype,          new JuliaFunction{"jl_f_fieldtype", get_func_sig, get_func_attrs} },
+    { &jl_f_nfields,            new JuliaFunction{"jl_f_nfields", get_func_sig, get_func_attrs} },
+    { &jl_f__expr,              new JuliaFunction{"jl_f__expr", get_func_sig, get_func_attrs} },
+    { &jl_f__typevar,           new JuliaFunction{"jl_f__typevar", get_func_sig, get_func_attrs} },
+    { &jl_f_arrayref,           new JuliaFunction{"jl_f_arrayref", get_func_sig, get_func_attrs} },
+    { &jl_f_const_arrayref,     new JuliaFunction{"jl_f_const_arrayref", get_func_sig, get_func_attrs} },
+    { &jl_f_arrayset,           new JuliaFunction{"jl_f_arrayset", get_func_sig, get_func_attrs} },
+    { &jl_f_arraysize,          new JuliaFunction{"jl_f_arraysize", get_func_sig, get_func_attrs} },
+    { &jl_f_apply_type,         new JuliaFunction{"jl_f_apply_type", get_func_sig, get_func_attrs} },
+};
+
 
 // --- code generation ---
 extern "C" {
@@ -590,6 +1045,10 @@ public:
     }
 };
 
+GlobalVariable *JuliaVariable::realize(jl_codectx_t &ctx) {
+    return realize(jl_Module);
+}
+
 static Type *julia_type_to_llvm(jl_codectx_t &ctx, jl_value_t *jt, bool *isboxed = NULL);
 static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, StringRef name, jl_value_t *sig, jl_value_t *jlrettype);
 static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval = -1);
@@ -600,12 +1059,44 @@ static jl_cgval_t emit_sparam(jl_codectx_t &ctx, size_t i);
 static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const std::string &msg);
 static void allocate_gc_frame(jl_codectx_t &ctx, BasicBlock *b0);
 static void CreateTrap(IRBuilder<> &irbuilder);
-static CallInst *emit_jlcall(jl_codectx_t &ctx, Value *theFptr, Value *theF,
+static CallInst *emit_jlcall(jl_codectx_t &ctx, Function *theFptr, Value *theF,
+                             jl_cgval_t *args, size_t nargs, CallingConv::ID cc);
+static CallInst *emit_jlcall(jl_codectx_t &ctx, JuliaFunction *theFptr, Value *theF,
                              jl_cgval_t *args, size_t nargs, CallingConv::ID cc);
 
 static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p);
 static GlobalVariable *prepare_global_in(Module *M, GlobalVariable *G);
 static Instruction *tbaa_decorate(MDNode *md, Instruction *load_or_store);
+
+static GlobalVariable *prepare_global_in(Module *M, JuliaVariable *G)
+{
+    return G->realize(M);
+}
+
+static Function *prepare_call_in(Module *M, JuliaFunction *G)
+{
+    return G->realize(M);
+}
+
+static inline GlobalVariable *prepare_global_in(Module *M, GlobalVariable *G)
+{
+    if (G->getParent() == M)
+        return G;
+    GlobalValue *local = M->getNamedValue(G->getName());
+    if (!local) {
+        // Copy the GlobalVariable, but without the initializer, so it becomes a declaration
+        GlobalVariable *proto = new GlobalVariable(*M, G->getType()->getElementType(),
+                G->isConstant(), GlobalVariable::ExternalLinkage,
+                nullptr, G->getName(), nullptr, G->getThreadLocalMode());
+        proto->copyAttributesFrom(G);
+        // DLLImport only needs to be set for the shadow module
+        // it just gets annoying in the JIT
+        proto->setDLLStorageClass(GlobalValue::DefaultStorageClass);
+        return proto;
+    }
+    return cast<GlobalVariable>(local);
+}
+
 
 // --- convenience functions for tagging llvm values with julia types ---
 
@@ -2611,7 +3102,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     return false;
 }
 
-static CallInst *emit_jlcall(jl_codectx_t &ctx, Value *theFptr, Value *theF,
+static CallInst *emit_jlcall(jl_codectx_t &ctx, Function *theFptr, Value *theF,
                              jl_cgval_t *argv, size_t nargs, CallingConv::ID cc)
 {
     // emit arguments
@@ -2628,11 +3119,16 @@ static CallInst *emit_jlcall(jl_codectx_t &ctx, Value *theFptr, Value *theF,
     }
     FunctionType *FTy = FunctionType::get(T_prjlvalue, argsT, false);
     CallInst *result = ctx.builder.CreateCall(FTy,
-        ctx.builder.CreateBitCast(prepare_call(theFptr).getCallee(), FTy->getPointerTo()),
+        ctx.builder.CreateBitCast(theFptr, FTy->getPointerTo()),
         theArgs);
     add_return_attr(result, Attribute::NonNull);
     result->setCallingConv(cc);
     return result;
+}
+static CallInst *emit_jlcall(jl_codectx_t &ctx, JuliaFunction *theFptr, Value *theF,
+                             jl_cgval_t *argv, size_t nargs, CallingConv::ID cc)
+{
+    return emit_jlcall(ctx, prepare_call(theFptr), theF, argv, nargs, cc);
 }
 
 
@@ -2755,16 +3251,13 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, jl_method_instance_
 static jl_cgval_t emit_call_specfun_boxed(jl_codectx_t &ctx, StringRef specFunctionObject,
                                           jl_cgval_t *argv, size_t nargs, jl_value_t *inferred_retty)
 {
-    auto theFptr = jl_Module->getOrInsertFunction(specFunctionObject, jl_func_sig)
+    auto theFptr = cast<Function>(jl_Module->getOrInsertFunction(specFunctionObject, jl_func_sig)
 #if JL_LLVM_VERSION >= 90000
-                .getCallee();
-#else
-                ;
+                .getCallee()
 #endif
-    if (auto F = dyn_cast<Function>(theFptr->stripPointerCasts())) {
-        add_return_attr(F, Attribute::NonNull);
-        F->addFnAttr(Thunk);
-    }
+            );
+    add_return_attr(theFptr, Attribute::NonNull);
+    theFptr->addFnAttr(Thunk);
     Value *ret = emit_jlcall(ctx, theFptr, nullptr, argv, nargs, JLCALL_F_CC);
     return mark_julia_type(ctx, ret, true, inferred_retty);
 }
@@ -2850,7 +3343,7 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
         }
     }
     if (!handled) {
-        Value *r = emit_jlcall(ctx, prepare_call(jlinvoke_func).getCallee(), boxed(ctx, lival), argv, nargs, JLCALL_F2_CC);
+        Value *r = emit_jlcall(ctx, jlinvoke_func, boxed(ctx, lival), argv, nargs, JLCALL_F2_CC);
         result = mark_julia_type(ctx, r, true, rt);
     }
     if (result.typ == jl_bottom_type)
@@ -2888,10 +3381,9 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
         }
 
         // special case for known builtin not handled by emit_builtin_call
-        std::map<jl_fptr_args_t, Function*>::iterator it = builtin_func_map.find(jl_get_builtin_fptr(f.constant));
+        auto it = builtin_func_map.find(jl_get_builtin_fptr(f.constant));
         if (it != builtin_func_map.end()) {
-            Value *theFptr = it->second;
-            Value *ret = emit_jlcall(ctx, theFptr, maybe_decay_untracked(V_null), &argv[1], nargs - 1, JLCALL_F_CC);
+            Value *ret = emit_jlcall(ctx, it->second, maybe_decay_untracked(V_null), &argv[1], nargs - 1, JLCALL_F_CC);
             return mark_julia_type(ctx, ret, true, rt);
         }
     }
@@ -3909,11 +4401,15 @@ static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Module *M, jl_cod
     ctx.f = f; // for jl_Module
     BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", f);
     ctx.builder.SetInsertPoint(b0);
-    FunctionCallee theFunc;
+    Function *theFunc;
     Value *theFarg;
     if (codeinst->invoke != NULL) {
         StringRef theFptrName = jl_ExecutionEngine->getFunctionAtAddress((uintptr_t)codeinst->invoke, codeinst);
-        theFunc = M->getOrInsertFunction(theFptrName, jlinvoke_func->getFunctionType());
+        theFunc = cast<Function>(M->getOrInsertFunction(theFptrName, jlinvoke_func->_type(jl_LLVMContext))
+#if JL_LLVM_VERSION >= 90000
+                .getCallee()
+#endif
+                );
         theFarg = literal_pointer_val(ctx, (jl_value_t*)codeinst);
     }
     else {
@@ -3923,7 +4419,7 @@ static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Module *M, jl_cod
     theFarg = maybe_decay_untracked(theFarg);
     auto args = f->arg_begin();
     CallInst *r = ctx.builder.CreateCall(theFunc, { &*args, &*++args, &*++args, theFarg });
-    r->setAttributes(cast<Function>(theFunc.getCallee())->getAttributes());
+    r->setAttributes(theFunc->getAttributes());
     ctx.builder.CreateRet(r);
     return f;
 }
@@ -3933,7 +4429,7 @@ static void emit_cfunc_invalidate(
         jl_value_t *calltype, jl_value_t *rettype,
         size_t nargs,
         jl_codegen_params_t &params,
-        Function *target=jlapplygeneric_func)
+        Function *target)
 {
     jl_codectx_t ctx(jl_LLVMContext, params);
     ctx.f = gf_thunk;
@@ -4020,6 +4516,16 @@ static void emit_cfunc_invalidate(
         break;
     }
     }
+}
+
+static void emit_cfunc_invalidate(
+        Function *gf_thunk, jl_returninfo_t::CallingConv cc, unsigned return_roots,
+        jl_value_t *calltype, jl_value_t *rettype,
+        size_t nargs,
+        jl_codegen_params_t &params)
+{
+    emit_cfunc_invalidate(gf_thunk, cc, return_roots, calltype, rettype, nargs, params,
+        prepare_call_in(gf_thunk->getParent(), jlapplygeneric_func));
 }
 
 static Function* gen_cfun_wrapper(
@@ -4328,7 +4834,7 @@ static Function* gen_cfun_wrapper(
             ctx.builder.CreateBr(b_after);
             ctx.builder.SetInsertPoint(b_generic);
         }
-        Value *ret = emit_jlcall(ctx, prepare_call(jlapplygeneric_func).getCallee(), NULL, inputargs, nargs + 1, JLCALL_F_CC);
+        Value *ret = emit_jlcall(ctx, jlapplygeneric_func, NULL, inputargs, nargs + 1, JLCALL_F_CC);
         if (age_ok) {
             ctx.builder.CreateBr(b_after);
             ctx.builder.SetInsertPoint(b_after);
@@ -4718,12 +5224,8 @@ void jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t *declr
                 // restore a ccallable from the system image
                 void *addr;
                 int found = jl_dlsym(sysimg_handle, name, &addr, 0);
-                if (found) {
-                    FunctionType *ftype = sig.functype();
-                    Function *F = Function::Create(ftype, GlobalVariable::ExternalLinkage, name);
-                    add_named_global(F, addr);
-                    delete F;
-                }
+                if (found)
+                    add_named_global(name, addr);
             }
             else {
                 jl_method_instance_t *lam = jl_get_specialization1((jl_tupletype_t*)sigt, world, &min_valid, &max_valid, 0);
@@ -5624,7 +6126,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                 emit_varinfo_assign(ctx, vi, tuple);
             }
             else {
-                restTuple = emit_jlcall(ctx, prepare_call(jltuple_func).getCallee(), maybe_decay_untracked(V_null),
+                restTuple = emit_jlcall(ctx, jltuple_func, maybe_decay_untracked(V_null),
                     vargs, ctx.nvargs, JLCALL_F_CC);
                 jl_cgval_t tuple = mark_julia_type(ctx, restTuple, true, vi.value.typ);
                 emit_varinfo_assign(ctx, vi, tuple);
@@ -5632,14 +6134,15 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
         }
         else {
             // restarg = jl_f_tuple(NULL, &args[nreq], nargs - nreq)
+            Function *F = prepare_call(jltuple_func);
             restTuple =
-                ctx.builder.CreateCall(prepare_call(jltuple_func),
+                ctx.builder.CreateCall(F,
                         { maybe_decay_untracked(V_null),
                           ctx.builder.CreateInBoundsGEP(T_prjlvalue, argArray,
                                   ConstantInt::get(T_size, nreq - 1)),
                           ctx.builder.CreateSub(argCount,
                                   ConstantInt::get(T_int32, nreq - 1)) });
-            restTuple->setAttributes(jltuple_func->getAttributes());
+            restTuple->setAttributes(F->getAttributes());
             ctx.builder.CreateStore(restTuple, vi.boxroot);
         }
     }
@@ -6652,32 +7155,19 @@ std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *parent=null
     return std::make_pair(n, scalar);
 }
 
-static GlobalVariable *global_to_llvm(const std::string &cname, void *addr, Module *m)
+std::vector<std::pair<jl_value_t**, JuliaVariable*>> gv_for_global;
+static void global_jlvalue_to_llvm(JuliaVariable *var, jl_value_t **addr)
 {
-    GlobalVariable *gv =
-        new GlobalVariable(*m, T_pjlvalue, true,
-                           GlobalVariable::ExternalLinkage, NULL, cname);
-    add_named_global(gv, addr);
-    return gv;
+    gv_for_global.push_back(std::make_pair(addr, var));
 }
-llvm::SmallVector<std::pair<jl_value_t**, GlobalVariable*>, 16> gv_for_global;
-static GlobalVariable *global_jlvalue_to_llvm(const std::string &cname, jl_value_t **addr, Module *m)
+static JuliaVariable *julia_const_gv(jl_value_t *val)
 {
-    GlobalVariable *gv = global_to_llvm(cname, (void*)addr, m);
-    gv_for_global.push_back(std::make_pair(addr, gv));
-    return gv;
-}
-static GlobalVariable *julia_const_gv(jl_value_t *val)
-{
-    for (auto& kv : gv_for_global) {
+    for (auto &kv : gv_for_global) {
         if (*kv.first == val)
             return kv.second;
     }
     return nullptr;
 }
-
-// TODO: delete this
-extern "C" void jl_fptr_to_llvm(void *fptr, jl_code_instance_t *lam, int specsig) { }
 
 static void init_julia_llvm_meta(void)
 {
@@ -6706,15 +7196,6 @@ static void init_julia_llvm_meta(void)
     tbaa_arrayselbyte = tbaa_make_child("jtbaa_arrayselbyte", tbaa_array_scalar).first;
 
     Thunk = Attribute::get(jl_LLVMContext, "thunk");
-}
-
-static Function *jlcall_func_to_llvm(const std::string &cname, jl_fptr_args_t addr, Module *m)
-{
-    Function *f = Function::Create(jl_func_sig, Function::ExternalLinkage, cname, m);
-    add_return_attr(f, Attribute::NonNull);
-    f->addFnAttr(Thunk);
-    add_named_global(f, addr);
-    return f;
 }
 
 static void init_julia_llvm_env(Module *m)
@@ -6749,8 +7230,6 @@ static void init_julia_llvm_env(Module *m)
     T_float128 = Type::getFP128Ty(jl_LLVMContext);
     T_void = Type::getVoidTy(jl_LLVMContext);
     T_pvoidfunc = FunctionType::get(T_void, /*isVarArg*/false)->getPointerTo();
-
-    auto T_pint8_derived = PointerType::get(T_int8, AddressSpace::Derived);
 
     // add needed base debugging definitions to our LLVM environment
     DIBuilder dbuilder(*m);
@@ -6818,556 +7297,104 @@ static void init_julia_llvm_env(Module *m)
     jl_array_llvmt =
         StructType::create(jl_LLVMContext, makeArrayRef(vaelts), "jl_array_t");
     jl_parray_llvmt = PointerType::get(jl_array_llvmt, 0);
+}
 
-    global_to_llvm("__stack_chk_guard", (void*)&__stack_chk_guard, m);
-    Function *jl__stack_chk_fail =
-        Function::Create(FunctionType::get(T_void, false),
-                         Function::ExternalLinkage,
-                         "__stack_chk_fail", m);
-    jl__stack_chk_fail->setDoesNotReturn();
-    add_named_global(jl__stack_chk_fail, &__stack_chk_fail);
-
-    global_jlvalue_to_llvm("jl_true", &jl_true, m);
-    global_jlvalue_to_llvm("jl_false", &jl_false, m);
-    global_jlvalue_to_llvm("jl_emptysvec", (jl_value_t**)&jl_emptysvec, m);
-    global_jlvalue_to_llvm("jl_emptytuple", &jl_emptytuple, m);
-    global_jlvalue_to_llvm("jl_diverror_exception", &jl_diverror_exception, m);
-    global_jlvalue_to_llvm("jl_undefref_exception", &jl_undefref_exception, m);
-
-    jlRTLD_DEFAULT_var =
-        new GlobalVariable(*m, T_pint8,
-                           true, GlobalVariable::ExternalLinkage,
-                           NULL, "jl_RTLD_DEFAULT_handle");
+static void init_jit_functions(void)
+{
+    add_named_global(jlstack_chk_guard_var, &__stack_chk_guard);
     add_named_global(jlRTLD_DEFAULT_var, &jl_RTLD_DEFAULT_handle);
 #ifdef _OS_WINDOWS_
-    jlexe_var =
-        new GlobalVariable(*m, T_pint8,
-                           true, GlobalVariable::ExternalLinkage,
-                           NULL, "jl_exe_handle");
     add_named_global(jlexe_var, &jl_exe_handle);
-    jldll_var =
-        new GlobalVariable(*m, T_pint8,
-                           true, GlobalVariable::ExternalLinkage,
-                           NULL, "jl_dl_handle");
     add_named_global(jldll_var, &jl_dl_handle);
 #endif
-
-    jltls_states_func = Function::Create(FunctionType::get(PointerType::get(T_ppjlvalue, 0), false),
-                                         Function::ExternalLinkage, "julia.ptls_states");
-    add_named_global(jltls_states_func, (void*)NULL, /*dllimport*/false);
-
-    std::vector<Type*> args1(0);
-    args1.push_back(T_pint8);
-    jlerror_func =
-        Function::Create(FunctionType::get(T_void, args1, false),
-                         Function::ExternalLinkage,
-                         "jl_error", m);
-    jlerror_func->setDoesNotReturn();
+    global_jlvalue_to_llvm(new JuliaVariable{"jl_true", true, get_pjlvalue}, &jl_true);
+    global_jlvalue_to_llvm(new JuliaVariable{"jl_false", true, get_pjlvalue}, &jl_false);
+    global_jlvalue_to_llvm(new JuliaVariable{"jl_emptysvec", true, get_pjlvalue}, (jl_value_t**)&jl_emptysvec);
+    global_jlvalue_to_llvm(new JuliaVariable{"jl_emptytuple", true, get_pjlvalue}, &jl_emptytuple);
+    global_jlvalue_to_llvm(new JuliaVariable{"jl_diverror_exception", true, get_pjlvalue}, &jl_diverror_exception);
+    global_jlvalue_to_llvm(new JuliaVariable{"jl_undefref_exception", true, get_pjlvalue}, &jl_undefref_exception);
+    add_named_global(jlgetworld_global, &jl_world_counter);
+    add_named_global("__stack_chk_fail", &__stack_chk_fail);
+    add_named_global(jltls_states_func, (void*)NULL);
     add_named_global(jlerror_func, &jl_error);
-
-    std::vector<Type*> args1_(0);
-    args1_.push_back(PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
-    jlthrow_func =
-        Function::Create(FunctionType::get(T_void, args1_, false),
-                         Function::ExternalLinkage,
-                         "jl_throw", m);
-    jlthrow_func->setDoesNotReturn();
     add_named_global(jlthrow_func, &jl_throw);
-
-    // Symbols are not gc-tracked, but we'll treat them as callee rooted anyway,
-    // because they may come from a gc-rooted location
-    jlundefvarerror_func =
-        Function::Create(FunctionType::get(T_void, args1_, false),
-                         Function::ExternalLinkage,
-                         "jl_undefined_var_error", m);
-    jlundefvarerror_func->setDoesNotReturn();
     add_named_global(jlundefvarerror_func, &jl_undefined_var_error);
-
-    std::vector<Type*> args2_boundserrorv(0);
-    args2_boundserrorv.push_back(PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
-    args2_boundserrorv.push_back(T_psize);
-    args2_boundserrorv.push_back(T_size);
-    jlboundserrorv_func =
-        Function::Create(FunctionType::get(T_void, args2_boundserrorv, false),
-                         Function::ExternalLinkage,
-                         "jl_bounds_error_ints", m);
-    jlboundserrorv_func->setDoesNotReturn();
     add_named_global(jlboundserrorv_func, &jl_bounds_error_ints);
-
-    std::vector<Type*> args2_boundserror(0);
-    args2_boundserror.push_back(PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
-    args2_boundserror.push_back(T_size);
-    jlboundserror_func =
-        Function::Create(FunctionType::get(T_void, args2_boundserror, false),
-                         Function::ExternalLinkage,
-                         "jl_bounds_error_int", m);
-    jlboundserror_func->setDoesNotReturn();
     add_named_global(jlboundserror_func, &jl_bounds_error_int);
-
-    std::vector<Type*> args3_vboundserror(0);
-    args3_vboundserror.push_back(T_pprjlvalue);
-    args3_vboundserror.push_back(T_size);
-    args3_vboundserror.push_back(T_size);
-    jlvboundserror_func =
-        Function::Create(FunctionType::get(T_void, args3_vboundserror, false),
-                         Function::ExternalLinkage,
-                         "jl_bounds_error_tuple_int", m);
-    jlvboundserror_func->setDoesNotReturn();
     add_named_global(jlvboundserror_func, &jl_bounds_error_tuple_int);
-
-    std::vector<Type*> args3_uboundserror(0);
-    args3_uboundserror.push_back(T_pint8_derived);
-    args3_uboundserror.push_back(T_pjlvalue);
-    args3_uboundserror.push_back(T_size);
-    jluboundserror_func =
-        Function::Create(FunctionType::get(T_void, args3_uboundserror, false),
-                         Function::ExternalLinkage,
-                         "jl_bounds_error_unboxed_int", m);
-    jluboundserror_func->setDoesNotReturn();
     add_named_global(jluboundserror_func, &jl_bounds_error_unboxed_int);
-
-    jlnew_func =
-        Function::Create(jl_func_sig, Function::ExternalLinkage,
-                         "jl_new_structv", m);
-    add_return_attr(jlnew_func, Attribute::NonNull);
-    jlnew_func->addFnAttr(Thunk);
     add_named_global(jlnew_func, &jl_new_structv);
-
-    std::vector<Type *> args_2rptrs_(0);
-    args_2rptrs_.push_back(T_prjlvalue);
-    args_2rptrs_.push_back(T_prjlvalue);
-    jlsplatnew_func =
-        Function::Create(FunctionType::get(T_prjlvalue, args_2rptrs_, false),
-                         Function::ExternalLinkage,
-                         "jl_new_structt", m);
-    add_return_attr(jlsplatnew_func, Attribute::NonNull);
-    jlsplatnew_func->addFnAttr(Thunk);
     add_named_global(jlsplatnew_func, &jl_new_structt);
-
-    std::vector<Type*> args2(0);
-    args2.push_back(T_pint8);
-#ifndef _OS_WINDOWS_
-    args2.push_back(T_int32);
-#endif
-    setjmp_func =
-        Function::Create(FunctionType::get(T_int32, args2, false),
-                         Function::ExternalLinkage, jl_setjmp_name, m);
-    setjmp_func->addFnAttr(Attribute::ReturnsTwice);
     add_named_global(setjmp_func, &jl_setjmp_f);
-
-    std::vector<Type*> args_memcmp(0);
-    args_memcmp.push_back(T_pint8);
-    args_memcmp.push_back(T_pint8);
-    args_memcmp.push_back(T_size);
-    memcmp_func =
-        Function::Create(FunctionType::get(T_int32, args_memcmp, false),
-                         Function::ExternalLinkage, "memcmp", m);
-    memcmp_func->addFnAttr(Attribute::ReadOnly);
-    memcmp_func->addFnAttr(Attribute::NoUnwind);
-    memcmp_func->addFnAttr(Attribute::ArgMemOnly);
     add_named_global(memcmp_func, &memcmp);
-    // TODO: inferLibFuncAttributes(*memcmp_func, TLI);
-
-    std::vector<Type*> te_args(0);
-    te_args.push_back(T_pint8);
-    te_args.push_back(T_prjlvalue);
-    te_args.push_back(PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
-    jltypeerror_func =
-        Function::Create(FunctionType::get(T_void, te_args, false),
-                         Function::ExternalLinkage,
-                         "jl_type_error", m);
-    jltypeerror_func->setDoesNotReturn();
     add_named_global(jltypeerror_func, &jl_type_error);
-
-    std::vector<Type *> args_2ptrs(0);
-    args_2ptrs.push_back(T_pjlvalue);
-    args_2ptrs.push_back(PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
-    jlcheckassign_func =
-        Function::Create(FunctionType::get(T_void, args_2ptrs, false),
-                         Function::ExternalLinkage,
-                         "jl_checked_assignment", m);
     add_named_global(jlcheckassign_func, &jl_checked_assignment);
-
-    std::vector<Type *> args_1binding(0);
-    args_1binding.push_back(T_pjlvalue);
-    jldeclareconst_func =
-        Function::Create(FunctionType::get(T_void, args_1binding, false),
-                         Function::ExternalLinkage,
-                         "jl_declare_constant", m);
     add_named_global(jldeclareconst_func, &jl_declare_constant);
-
-    std::vector<Type *> args_2ptrs_(0);
-    args_2ptrs_.push_back(T_pjlvalue);
-    args_2ptrs_.push_back(T_pjlvalue);
-    jlgetbindingorerror_func =
-        Function::Create(FunctionType::get(T_pjlvalue, args_2ptrs_, false),
-                         Function::ExternalLinkage,
-                         "jl_get_binding_or_error", m);
     add_named_global(jlgetbindingorerror_func, &jl_get_binding_or_error);
-
-    jlboundp_func =
-        Function::Create(FunctionType::get(T_int32, args_2ptrs_, false),
-                         Function::ExternalLinkage,
-                         "jl_boundp", m);
     add_named_global(jlboundp_func, &jl_boundp);
-
-    builtin_func_map[jl_f_is] = jlcall_func_to_llvm("jl_f_is", &jl_f_is, m);
-    builtin_func_map[jl_f_typeof] = jlcall_func_to_llvm("jl_f_typeof", &jl_f_typeof, m);
-    builtin_func_map[jl_f_sizeof] = jlcall_func_to_llvm("jl_f_sizeof", &jl_f_sizeof, m);
-    builtin_func_map[jl_f_issubtype] = jlcall_func_to_llvm("jl_f_issubtype", &jl_f_issubtype, m);
-    builtin_func_map[jl_f_isa] = jlcall_func_to_llvm("jl_f_isa", &jl_f_isa, m);
-    builtin_func_map[jl_f_typeassert] = jlcall_func_to_llvm("jl_f_typeassert", &jl_f_typeassert, m);
-    builtin_func_map[jl_f_ifelse] = jlcall_func_to_llvm("jl_f_ifelse", &jl_f_ifelse, m);
-    builtin_func_map[jl_f__apply] = jlcall_func_to_llvm("jl_f__apply", &jl_f__apply, m);
-    builtin_func_map[jl_f__apply_iterate] = jlcall_func_to_llvm("jl_f__apply_iterate", &jl_f__apply_iterate, m);
-    builtin_func_map[jl_f__apply_pure] = jlcall_func_to_llvm("jl_f__apply_pure", &jl_f__apply_pure, m);
-    builtin_func_map[jl_f__apply_latest] = jlcall_func_to_llvm("jl_f__apply_latest", &jl_f__apply_latest, m);
-    builtin_func_map[jl_f_throw] = jlcall_func_to_llvm("jl_f_throw", &jl_f_throw, m);
-    builtin_func_map[jl_f_tuple] = jlcall_func_to_llvm("jl_f_tuple", &jl_f_tuple, m);
-    builtin_func_map[jl_f_svec] = jlcall_func_to_llvm("jl_f_svec", &jl_f_svec, m);
-    builtin_func_map[jl_f_applicable] = jlcall_func_to_llvm("jl_f_applicable", &jl_f_applicable, m);
-    builtin_func_map[jl_f_invoke] = jlcall_func_to_llvm("jl_f_invoke", &jl_f_invoke, m);
-    builtin_func_map[jl_f_invoke_kwsorter] = jlcall_func_to_llvm("jl_f_invoke_kwsorter", &jl_f_invoke_kwsorter, m);
-    builtin_func_map[jl_f_isdefined] = jlcall_func_to_llvm("jl_f_isdefined", &jl_f_isdefined, m);
-    builtin_func_map[jl_f_getfield] = jlcall_func_to_llvm("jl_f_getfield", &jl_f_getfield, m);
-    builtin_func_map[jl_f_setfield] = jlcall_func_to_llvm("jl_f_setfield", &jl_f_setfield, m);
-    builtin_func_map[jl_f_fieldtype] = jlcall_func_to_llvm("jl_f_fieldtype", &jl_f_fieldtype, m);
-    builtin_func_map[jl_f_nfields] = jlcall_func_to_llvm("jl_f_nfields", &jl_f_nfields, m);
-    builtin_func_map[jl_f__expr] = jlcall_func_to_llvm("jl_f__expr", &jl_f__expr, m);
-    builtin_func_map[jl_f__typevar] = jlcall_func_to_llvm("jl_f__typevar", &jl_f__typevar, m);
-    builtin_func_map[jl_f_arrayref] = jlcall_func_to_llvm("jl_f_arrayref", &jl_f_arrayref, m);
-    builtin_func_map[jl_f_const_arrayref] = jlcall_func_to_llvm("jl_f_const_arrayref", &jl_f_arrayref, m);
-    builtin_func_map[jl_f_arrayset] = jlcall_func_to_llvm("jl_f_arrayset", &jl_f_arrayset, m);
-    builtin_func_map[jl_f_arraysize] = jlcall_func_to_llvm("jl_f_arraysize", &jl_f_arraysize, m);
-    builtin_func_map[jl_f_apply_type] = jlcall_func_to_llvm("jl_f_apply_type", &jl_f_apply_type, m);
-    jltuple_func = builtin_func_map[jl_f_tuple];
-    jlgetfield_func = builtin_func_map[jl_f_getfield];
-
-    jlapplygeneric_func = Function::Create(jl_func_sig,
-                                           Function::ExternalLinkage,
-                                           "jl_apply_generic", m);
-    add_return_attr(jlapplygeneric_func, Attribute::NonNull);
-    jlapplygeneric_func->addFnAttr(Thunk);
+    for (auto it : builtin_func_map)
+        add_named_global(it.second, it.first);
     add_named_global(jlapplygeneric_func, &jl_apply_generic);
-
-    std::vector<Type*> invokeargs(0);
-    invokeargs.push_back(T_prjlvalue);
-    invokeargs.push_back(T_pprjlvalue);
-    invokeargs.push_back(T_uint32);
-    invokeargs.push_back(T_prjlvalue);
-    jlinvoke_func = Function::Create(FunctionType::get(T_prjlvalue, invokeargs, false),
-                                     Function::ExternalLinkage,
-                                     "jl_invoke", m);
-    add_return_attr(jlinvoke_func, Attribute::NonNull);
-    jlinvoke_func->addAttribute(2, Attribute::ReadOnly);
-    jlinvoke_func->addAttribute(2, Attribute::NoCapture);
     add_named_global(jlinvoke_func, &jl_invoke);
-
-    std::vector<Type *> exp_args(0);
-    exp_args.push_back(T_int1);
-    expect_func = Intrinsic::getDeclaration(m, Intrinsic::expect, exp_args);
-
-    std::vector<Type*> args_topeval(0);
-    args_topeval.push_back(T_pjlvalue);
-    args_topeval.push_back(T_pjlvalue);
-    jltopeval_func =
-        Function::Create(FunctionType::get(T_pjlvalue, args_topeval, false),
-                         Function::ExternalLinkage,
-                         "jl_toplevel_eval", m);
-    add_return_attr(jltopeval_func, Attribute::NonNull);
     add_named_global(jltopeval_func, &jl_toplevel_eval);
-
-    std::vector<Type*> args_copyast(0);
-    args_copyast.push_back(T_prjlvalue);
-    jlcopyast_func =
-        Function::Create(FunctionType::get(T_prjlvalue, args_copyast, false),
-                         Function::ExternalLinkage,
-                         "jl_copy_ast", m);
-    add_return_attr(jlcopyast_func, Attribute::NonNull);
     add_named_global(jlcopyast_func, &jl_copy_ast);
-
-    std::vector<Type*> args5(0);
-    args5.push_back(T_size);
-    jlnsvec_func =
-        Function::Create(FunctionType::get(T_pjlvalue, args5, true),
-                         Function::ExternalLinkage,
-                         "jl_svec", m);
-    add_return_attr(jlnsvec_func, Attribute::NonNull);
-    add_named_global(jlnsvec_func, &jl_svec);
-
-    std::vector<Type*> mdargs(0);
-    mdargs.push_back(T_prjlvalue);
-    mdargs.push_back(T_prjlvalue);
-    mdargs.push_back(T_pjlvalue);
-    jlmethod_func =
-        Function::Create(FunctionType::get(T_void, mdargs, false),
-                         Function::ExternalLinkage,
-                         "jl_method_def", m);
+    //add_named_global(jlnsvec_func, &jl_svec);
     add_named_global(jlmethod_func, &jl_method_def);
-
-    std::vector<Type*> funcdefargs(0);
-    funcdefargs.push_back(T_pjlvalue);
-    funcdefargs.push_back(T_pjlvalue);
-    funcdefargs.push_back(T_pprjlvalue);
-    funcdefargs.push_back(T_pjlvalue);
-    funcdefargs.push_back(T_pjlvalue);
-    jlgenericfunction_func =
-        Function::Create(FunctionType::get(T_prjlvalue, funcdefargs, false),
-                         Function::ExternalLinkage,
-                         "jl_generic_function_def", m);
     add_named_global(jlgenericfunction_func, &jl_generic_function_def);
-
-    std::vector<Type*> ehargs(0);
-    ehargs.push_back(T_pint8);
-    jlenter_func =
-        Function::Create(FunctionType::get(T_void, ehargs, false),
-                         Function::ExternalLinkage,
-                         "jl_enter_handler", m);
     add_named_global(jlenter_func, &jl_enter_handler);
-
-    jl_current_exception_func =
-        Function::Create(FunctionType::get(T_prjlvalue, false),
-                         Function::ExternalLinkage,
-                         "jl_current_exception", m);
     add_named_global(jl_current_exception_func, &jl_current_exception);
+    add_named_global(jlleave_func, &jl_pop_handler);
+    add_named_global(jl_restore_excstack_func, &jl_restore_excstack);
+    add_named_global(jl_excstack_state_func, &jl_excstack_state);
+    add_named_global(jlegal_func, &jl_egal);
+    add_named_global(jlisa_func, &jl_isa);
+    add_named_global(jlsubtype_func, &jl_subtype);
+    add_named_global(jltypeassert_func, &jl_typeassert);
+    add_named_global(jlapplytype_func, &jl_instantiate_type_in_env);
+    add_named_global(jl_object_id__func, &jl_object_id_);
+    add_named_global(jl_alloc_obj_func, (void*)NULL);
+    add_named_global(jl_newbits_func, (void*)jl_new_bits);
+    add_named_global(jl_loopinfo_marker_func, (void*)NULL);
+    add_named_global(jl_typeof_func, (void*)NULL);
+    add_named_global(jl_write_barrier_func, (void*)NULL);
+    add_named_global(jldlsym_func, &jl_load_and_lookup);
+    add_named_global(jlgetcfunctiontrampoline_func, &jl_get_cfunction_trampoline);
+    add_named_global(jlgetnthfieldchecked_func, &jl_get_nth_field_checked);
+    add_named_global(diff_gc_total_bytes_func, &jl_gc_diff_total_bytes);
+    add_named_global(sync_gc_total_bytes_func, &jl_gc_sync_total_bytes);
+    add_named_global(jlarray_data_owner_func, &jl_array_data_owner);
+    add_named_global(gcroot_flush_func, (void*)NULL);
+    add_named_global(gc_preserve_begin_func, (void*)NULL);
+    add_named_global(gc_preserve_end_func, (void*)NULL);
+    add_named_global(pointer_from_objref_func, (void*)NULL);
+    add_named_global(except_enter_func, (void*)NULL);
 
 #ifdef _OS_WINDOWS_
 #ifndef FORCE_ELF
 #if defined(_CPU_X86_64_)
 #if defined(_COMPILER_GCC_)
-    Function *chkstk_func = Function::Create(FunctionType::get(T_void, false),
-            Function::ExternalLinkage, "___chkstk_ms", m);
-    add_named_global(chkstk_func, &___chkstk_ms, /*dllimport*/false);
+    add_named_global("___chkstk_ms", &___chkstk_ms);
 #else
-    Function *chkstk_func = Function::Create(FunctionType::get(T_void, false),
-            Function::ExternalLinkage, "__chkstk", m);
-    add_named_global(chkstk_func, &__chkstk, /*dllimport*/false);
+    add_named_global("__chkstk", &__chkstk);
 #endif
 #else
 #if defined(_COMPILER_GCC_)
-    Function *chkstk_func = Function::Create(FunctionType::get(T_void, false),
-            Function::ExternalLinkage, "_alloca", m);
-    add_named_global(chkstk_func, &_alloca, /*dllimport*/false);
+    add_named_global("_alloca", &_alloca);
 #else
-    Function *chkstk_func = Function::Create(FunctionType::get(T_void, false),
-            Function::ExternalLinkage, "_chkstk", m);
-    add_named_global(chkstk_func, &_chkstk, /*dllimport*/false);
+    add_named_global("_chkstk", &_chkstk);
 #endif
 #endif
 #endif
 #endif
 
-    std::vector<Type*> lhargs(0);
-    lhargs.push_back(T_int32);
-    jlleave_func =
-        Function::Create(FunctionType::get(T_void, lhargs, false),
-                         Function::ExternalLinkage,
-                         "jl_pop_handler", m);
-    add_named_global(jlleave_func, &jl_pop_handler);
-
-    jl_restore_excstack_func =
-        Function::Create(FunctionType::get(T_void, T_size, false),
-                         Function::ExternalLinkage,
-                         "jl_restore_excstack", m);
-    add_named_global(jl_restore_excstack_func, &jl_restore_excstack);
-
-    jl_excstack_state_func =
-        Function::Create(FunctionType::get(T_size, false),
-                         Function::ExternalLinkage,
-                         "jl_excstack_state", m);
-    add_named_global(jl_excstack_state_func, &jl_excstack_state);
-
-    std::vector<Type *> args_2vals_callee_rooted(0);
-    args_2vals_callee_rooted.push_back(PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
-    args_2vals_callee_rooted.push_back(PointerType::get(T_jlvalue, AddressSpace::CalleeRooted));
-    jlegal_func =
-        Function::Create(FunctionType::get(T_int32, args_2vals_callee_rooted, false),
-                         Function::ExternalLinkage,
-                         "jl_egal", m);
-    add_named_global(jlegal_func, &jl_egal);
-
-    std::vector<Type *> args_2vals_tracked(0);
-    args_2vals_tracked.push_back(T_prjlvalue);
-    args_2vals_tracked.push_back(T_prjlvalue);
-    jlisa_func =
-        Function::Create(FunctionType::get(T_int32, args_2vals_tracked, false),
-                         Function::ExternalLinkage,
-                         "jl_isa", m);
-    add_named_global(jlisa_func, &jl_isa);
-
-    jlsubtype_func =
-        Function::Create(FunctionType::get(T_int32, args_2vals_tracked, false),
-                         Function::ExternalLinkage,
-                         "jl_subtype", m);
-    add_named_global(jlsubtype_func, &jl_subtype);
-
-    jltypeassert_func = Function::Create(FunctionType::get(T_void, args_2vals_tracked, false),
-                                        Function::ExternalLinkage,
-                                        "jl_typeassert", m);
-    add_named_global(jltypeassert_func, &jl_typeassert);
-
-    std::vector<Type *> applytype_args(0);
-    applytype_args.push_back(T_pjlvalue);
-    applytype_args.push_back(T_pjlvalue);
-    applytype_args.push_back(T_pprjlvalue);
-    jlapplytype_func =
-        Function::Create(FunctionType::get(T_prjlvalue, applytype_args, false),
-                         Function::ExternalLinkage,
-                         "jl_instantiate_type_in_env", m);
-    add_return_attr(jlapplytype_func, Attribute::NonNull);
-    add_named_global(jlapplytype_func, &jl_instantiate_type_in_env);
-
-    std::vector<Type *> objectid__args(0);
-    objectid__args.push_back(T_prjlvalue);
-    objectid__args.push_back(T_pint8_derived);
-    jl_object_id__func =
-        Function::Create(FunctionType::get(T_size, objectid__args, false),
-                         Function::ExternalLinkage,
-                         "jl_object_id_", m);
-    add_named_global(jl_object_id__func, &jl_object_id_);
-
-    std::vector<Type*> gc_alloc_args(0);
-    gc_alloc_args.push_back(T_pint8);
-    gc_alloc_args.push_back(T_size);
-    gc_alloc_args.push_back(T_prjlvalue);
-    jl_alloc_obj_func = Function::Create(FunctionType::get(T_prjlvalue, gc_alloc_args, false),
-                                         Function::ExternalLinkage,
-                                         "julia.gc_alloc_obj");
-    add_return_attr(jl_alloc_obj_func, Attribute::NoAlias);
-    add_return_attr(jl_alloc_obj_func, Attribute::NonNull);
-    jl_alloc_obj_func->addFnAttr(Attribute::getWithAllocSizeArgs(jl_LLVMContext, 1, None)); // returns %1 bytes
-    add_named_global(jl_alloc_obj_func, (void*)NULL, /*dllimport*/false);
-
-    std::vector<Type*> newbits_args(0);
-    newbits_args.push_back(T_prjlvalue);
-    newbits_args.push_back(T_pint8);
-    jl_newbits_func = Function::Create(FunctionType::get(T_prjlvalue, newbits_args, false),
-                                         Function::ExternalLinkage,
-                                         "jl_new_bits");
-    add_return_attr(jl_newbits_func, Attribute::NoAlias);
-    add_return_attr(jl_newbits_func, Attribute::NonNull);
-    add_named_global(jl_newbits_func, (void*)jl_new_bits);
-
-    jl_loopinfo_marker_func = Function::Create(FunctionType::get(T_void, {}, false),
-                                               Function::ExternalLinkage,
-                                               "julia.loopinfo_marker");
-    jl_loopinfo_marker_func->addFnAttr(Attribute::NoUnwind);
-    jl_loopinfo_marker_func->addFnAttr(Attribute::NoRecurse);
-    jl_loopinfo_marker_func->addFnAttr(Attribute::InaccessibleMemOnly);
-
-    jl_typeof_func = Function::Create(FunctionType::get(T_prjlvalue, {T_prjlvalue}, false),
-                                      Function::ExternalLinkage,
-                                      "julia.typeof");
-    jl_typeof_func->addFnAttr(Attribute::ReadOnly);
-    jl_typeof_func->addFnAttr(Attribute::NoUnwind);
-    jl_typeof_func->addFnAttr(Attribute::ArgMemOnly);
-    jl_typeof_func->addFnAttr(Attribute::NoRecurse);
-    add_return_attr(jl_typeof_func, Attribute::NonNull);
-    add_named_global(jl_typeof_func, (void*)NULL, /*dllimport*/false);
-
-    jl_write_barrier_func = Function::Create(FunctionType::get(T_void, {T_prjlvalue,}, true),
-                                             Function::ExternalLinkage,
-                                             "julia.write_barrier");
-    jl_write_barrier_func->addFnAttr(Attribute::InaccessibleMemOnly);
-    jl_write_barrier_func->addFnAttr(Attribute::NoUnwind);
-    jl_write_barrier_func->addFnAttr(Attribute::NoRecurse);
-    add_named_global(jl_write_barrier_func, (void*)NULL, /*dllimport*/false);
-
-    std::vector<Type *> dlsym_args(0);
-    dlsym_args.push_back(T_pint8);
-    dlsym_args.push_back(T_pint8);
-    dlsym_args.push_back(PointerType::get(T_pint8,0));
-    jldlsym_func =
-        Function::Create(FunctionType::get(T_pvoidfunc, dlsym_args, false),
-                         Function::ExternalLinkage,
-                         "jl_load_and_lookup", m);
-    add_named_global(jldlsym_func, &jl_load_and_lookup);
-
-    std::vector<Type *> getcfunctiontrampoline_args(0);
-    getcfunctiontrampoline_args.push_back(T_prjlvalue); // f (object)
-    getcfunctiontrampoline_args.push_back(T_pjlvalue); // result
-    getcfunctiontrampoline_args.push_back(T_pint8); // cache
-    getcfunctiontrampoline_args.push_back(T_pjlvalue); // fill
-    getcfunctiontrampoline_args.push_back(FunctionType::get(T_pint8, { T_pint8, T_ppjlvalue }, false)->getPointerTo()); // trampoline
-    getcfunctiontrampoline_args.push_back(T_pjlvalue); // env
-    getcfunctiontrampoline_args.push_back(T_pprjlvalue); // vals
-    jlgetcfunctiontrampoline_func =
-        Function::Create(FunctionType::get(T_prjlvalue, getcfunctiontrampoline_args, false),
-                         Function::ExternalLinkage,
-                         "jl_get_cfunction_trampoline", m);
-    add_return_attr(jlgetcfunctiontrampoline_func, Attribute::NonNull);
-    add_named_global(jlgetcfunctiontrampoline_func, &jl_get_cfunction_trampoline);
-
-    std::vector<Type *> getnthfld_args(0);
-    getnthfld_args.push_back(T_prjlvalue);
-    getnthfld_args.push_back(T_size);
-    jlgetnthfieldchecked_func =
-        Function::Create(FunctionType::get(T_prjlvalue, getnthfld_args, false),
-                         Function::ExternalLinkage,
-                         "jl_get_nth_field_checked", m);
-    add_return_attr(jlgetnthfieldchecked_func, Attribute::NonNull);
-    add_named_global(jlgetnthfieldchecked_func, &jl_get_nth_field_checked);
-
-    diff_gc_total_bytes_func =
-        Function::Create(FunctionType::get(T_int64, false),
-                         Function::ExternalLinkage,
-                         "jl_gc_diff_total_bytes", m);
-    add_named_global(diff_gc_total_bytes_func, &jl_gc_diff_total_bytes);
-
-    sync_gc_total_bytes_func =
-        Function::Create(FunctionType::get(T_int64, {T_int64}, false),
-                         Function::ExternalLinkage,
-                         "jl_gc_sync_total_bytes", m);
-    add_named_global(sync_gc_total_bytes_func, &jl_gc_sync_total_bytes);
-
-
-    std::vector<Type*> array_owner_args(0);
-    array_owner_args.push_back(T_prjlvalue);
-    jlarray_data_owner_func =
-        Function::Create(FunctionType::get(T_prjlvalue, array_owner_args, false),
-                         Function::ExternalLinkage,
-                         "jl_array_data_owner", m);
-    jlarray_data_owner_func->addFnAttr(Attribute::ReadOnly);
-    jlarray_data_owner_func->addFnAttr(Attribute::NoUnwind);
-    add_return_attr(jlarray_data_owner_func, Attribute::NonNull);
-    add_named_global(jlarray_data_owner_func, &jl_array_data_owner);
-
-    gcroot_flush_func = Function::Create(FunctionType::get(T_void, false),
-                                         Function::ExternalLinkage,
-                                         "julia.gcroot_flush");
-    add_named_global(gcroot_flush_func, (void*)NULL, /*dllimport*/false);
-
-    gc_preserve_begin_func = Function::Create(FunctionType::get(Type::getTokenTy(jl_LLVMContext),
-                                         ArrayRef<Type*>(), true),
-                                         Function::ExternalLinkage,
-                                         "llvm.julia.gc_preserve_begin");
-    add_named_global(gc_preserve_begin_func, (void*)NULL, /*dllimport*/false);
-
-    gc_preserve_end_func = Function::Create(FunctionType::get(T_void,
-                                        ArrayRef<Type*>(Type::getTokenTy(jl_LLVMContext)), false),
-                                        Function::ExternalLinkage,
-                                        "llvm.julia.gc_preserve_end");
-    add_named_global(gc_preserve_end_func, (void*)NULL, /*dllimport*/false);
-
-    pointer_from_objref_func = Function::Create(FunctionType::get(T_pjlvalue,
-                                         ArrayRef<Type*>(PointerType::get(T_jlvalue, AddressSpace::Derived)), false),
-                                         Function::ExternalLinkage,
-                                         "julia.pointer_from_objref");
-    pointer_from_objref_func->addFnAttr(Attribute::ReadNone);
-    pointer_from_objref_func->addFnAttr(Attribute::NoUnwind);
-    add_named_global(pointer_from_objref_func, (void*)NULL, /*dllimport*/false);
-
-    except_enter_func = Function::Create(FunctionType::get(T_int32, false),
-                                         Function::ExternalLinkage,
-                                         "julia.except_enter");
-    except_enter_func->addFnAttr(Attribute::ReturnsTwice);
-    add_named_global(except_enter_func, (void*)NULL, /*dllimport*/false);
-
-    jlgetworld_global =
-        new GlobalVariable(*m, T_size,
-                           false, GlobalVariable::ExternalLinkage,
-                           NULL, "jl_world_counter");
-    add_named_global(jlgetworld_global, &jl_world_counter);
+#define BOX_F(ct) add_named_global("jl_box_"#ct, &jl_box_##ct);
+    BOX_F(int8); BOX_F(uint8);
+    BOX_F(int16); BOX_F(uint16);
+    BOX_F(int32); BOX_F(uint32);
+    BOX_F(int64); BOX_F(uint64);
+    BOX_F(float32); BOX_F(float64);
+    BOX_F(char); BOX_F(ssavalue);
+#undef BOX_F
 }
 
 extern "C" void jl_init_llvm(void)
@@ -7527,19 +7554,13 @@ extern "C" void jl_init_codegen(void)
     jl_init_llvm();
     // Now that the execution engine exists, initialize all modules
     jl_init_jit();
+    init_jit_functions();
+
     Module *m = new Module("julia", jl_LLVMContext);
     jl_setup_module(m);
     init_julia_llvm_env(m);
 
-    SBOX_F_PERM(int8,int8); UBOX_F_PERM(uint8,uint8);
-    SBOX_F(int16,int16); UBOX_F(uint16,uint16);
-    SBOX_F(int32,int32); UBOX_F(uint32,uint32);
-    SBOX_F(int64,int64); UBOX_F(uint64,uint64);
-    BOX_F(float32,float32,T_prjlvalue); BOX_F(float64,float64,T_prjlvalue);
-    UBOX_F(char,char);
-    UBOX_F(ssavalue,size);
-
-    jl_init_intrinsic_functions_codegen(m);
+    jl_init_intrinsic_functions_codegen();
 }
 
 extern "C" void jl_teardown_codegen()

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -21,13 +21,13 @@ extern "C" {
     extern int globalUnique;
 }
 extern TargetMachine *jl_TargetMachine;
-extern Module *shadow_output;
 extern bool imaging_mode;
 
 void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM);
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool lower_intrinsics=true, bool dump_native=false);
 void jl_finalize_module(std::unique_ptr<Module>  m);
 void jl_merge_module(Module *dest, std::unique_ptr<Module> src);
+Module *jl_create_llvm_module(StringRef name);
 
 typedef struct _jl_llvm_functions_t {
     std::string functionObject;     // jlcall llvm Function name
@@ -53,11 +53,36 @@ typedef std::vector<std::tuple<jl_code_instance_t*, jl_returninfo_t::CallingConv
 typedef std::tuple<std::unique_ptr<Module>, jl_llvm_functions_t> jl_compile_result_t;
 
 typedef struct {
+    typedef StringMap<GlobalVariable*> SymMapGV;
     // outputs
     jl_codegen_call_targets_t workqueue;
     std::map<void*, GlobalVariable*> globals;
     std::map<jl_datatype_t*, DIType*> ditypes;
     std::map<jl_datatype_t*, Type*> llvmtypes;
+    SymMapGV stringConstants;
+    // Map from symbol name (in a certain library) to its GV in sysimg and the
+    // DL handle address in the current session.
+    StringMap<std::pair<GlobalVariable*,SymMapGV>> libMapGV;
+#ifdef _OS_WINDOWS_
+    SymMapGV symMapExe;
+    SymMapGV symMapDl;
+#endif
+    SymMapGV symMapDefault;
+    // Map from distinct callee's to its GOT entry.
+    // In principle the attribute, function type and calling convention
+    // don't need to be part of the key but it seems impossible to forward
+    // all the arguments without writing assembly directly.
+    // This doesn't matter too much in reality since a single function is usually
+    // not called with multiple signatures.
+    DenseMap<AttributeList, std::map<
+        std::tuple<GlobalVariable*, FunctionType*, CallingConv::ID>,
+        GlobalVariable*>> allPltMap;
+    Module *_shared_module = NULL;
+    Module *shared_module(LLVMContext &context) {
+        if (!_shared_module)
+            _shared_module = jl_create_llvm_module("globals");
+        return _shared_module;
+    }
     // inputs
     size_t world = 0;
     const jl_cgparams_t *params = &jl_default_cgparams;
@@ -88,29 +113,21 @@ void jl_compile_workqueue(
 Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tupletype_t *argt,
     jl_codegen_params_t &params);
 
-// Connect Modules via prototypes, each owned by module `M`
-static inline GlobalVariable *global_proto(GlobalVariable *G, Module *M = NULL)
-{
-    // Copy the GlobalVariable, but without the initializer, so it becomes a declaration
-    GlobalVariable *proto = new GlobalVariable(G->getType()->getElementType(),
-            G->isConstant(), GlobalVariable::ExternalLinkage,
-            NULL, G->getName(),  G->getThreadLocalMode());
-    proto->copyAttributesFrom(G);
-    // DLLImport only needs to be set for the shadow module
-    // it just gets annoying in the JIT
-    proto->setDLLStorageClass(GlobalValue::DefaultStorageClass);
-    if (M)
-        M->getGlobalList().push_back(proto);
-    return proto;
-}
-
 static inline GlobalVariable *prepare_global_in(Module *M, GlobalVariable *G)
 {
     if (G->getParent() == M)
         return G;
     GlobalValue *local = M->getNamedValue(G->getName());
     if (!local) {
-        local = global_proto(G, M);
+        // Copy the GlobalVariable, but without the initializer, so it becomes a declaration
+        GlobalVariable *proto = new GlobalVariable(*M, G->getType()->getElementType(),
+                G->isConstant(), GlobalVariable::ExternalLinkage,
+                nullptr, G->getName(), nullptr, G->getThreadLocalMode());
+        proto->copyAttributesFrom(G);
+        // DLLImport only needs to be set for the shadow module
+        // it just gets annoying in the JIT
+        proto->setDLLStorageClass(GlobalValue::DefaultStorageClass);
+        return proto;
     }
     return cast<GlobalVariable>(local);
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -28,6 +28,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool lowe
 void jl_finalize_module(std::unique_ptr<Module>  m);
 void jl_merge_module(Module *dest, std::unique_ptr<Module> src);
 Module *jl_create_llvm_module(StringRef name);
+GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M);
 
 typedef struct _jl_llvm_functions_t {
     std::string functionObject;     // jlcall llvm Function name
@@ -113,33 +114,7 @@ void jl_compile_workqueue(
 Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tupletype_t *argt,
     jl_codegen_params_t &params);
 
-static inline GlobalVariable *prepare_global_in(Module *M, GlobalVariable *G)
-{
-    if (G->getParent() == M)
-        return G;
-    GlobalValue *local = M->getNamedValue(G->getName());
-    if (!local) {
-        // Copy the GlobalVariable, but without the initializer, so it becomes a declaration
-        GlobalVariable *proto = new GlobalVariable(*M, G->getType()->getElementType(),
-                G->isConstant(), GlobalVariable::ExternalLinkage,
-                nullptr, G->getName(), nullptr, G->getThreadLocalMode());
-        proto->copyAttributesFrom(G);
-        // DLLImport only needs to be set for the shadow module
-        // it just gets annoying in the JIT
-        proto->setDLLStorageClass(GlobalValue::DefaultStorageClass);
-        return proto;
-    }
-    return cast<GlobalVariable>(local);
-}
-
-void add_named_global(GlobalObject *gv, void *addr, bool dllimport);
-template<typename T>
-static inline void add_named_global(GlobalObject *gv, T *addr, bool dllimport = true)
-{
-    // cast through integer to avoid c++ pedantic warning about casting between
-    // data and code pointers
-    add_named_global(gv, (void*)(uintptr_t)addr, dllimport);
-}
+void add_named_global(StringRef name, void *addr);
 
 static inline Constant *literal_static_pointer_val(const void *p, Type *T)
 {
@@ -212,7 +187,6 @@ public:
                          const object::ObjectFile &Obj,
                          const RuntimeDyld::LoadedObjectInfo &LoadedObjectInfo);
     void addGlobalMapping(StringRef Name, uint64_t Addr);
-    void addGlobalMapping(const GlobalValue *GV, void *Addr);
     void *getPointerToGlobalIfAvailable(StringRef S);
     void *getPointerToGlobalIfAvailable(const GlobalValue *GV);
     void addModule(std::unique_ptr<Module> M);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -636,7 +636,6 @@ JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, 
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_value_t *caller);
 
 uint32_t jl_module_next_counter(jl_module_t *m);
-void jl_fptr_to_llvm(void *fptr, jl_code_instance_t *codeinst, int spec_abi);
 jl_tupletype_t *arg_type_tuple(jl_value_t *arg1, jl_value_t **args, size_t nargs);
 
 int jl_has_meta(jl_array_t *body, jl_sym_t *sym);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1189,7 +1189,6 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
             else {
                 codeinst->invoke = (jl_callptr_t)fptr;
             }
-            jl_fptr_to_llvm(fptr, codeinst, specfunc);
         }
     }
     jl_register_fptrs(sysimage_base, &fvars, linfos, sysimg_fvars_max);


### PR DESCRIPTION
Annoyed by https://build.julialang.org/#/builders/48/builds/527, I decided to spend some time removing more global state from codegen and wrapping it into our jl_codegen_params_t context.

While we still have some work to do to remove the global use of many Type objects, and to remove the global counter (we'll need to figure out a different mechanism when merging modules to identify unique values), this is another step in that direction.