### PR TITLE
Generalize `Base.show_default` 

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -358,7 +358,14 @@ unsafe_length(S::Slice) = unsafe_length(S.indices)
 getindex(S::Slice, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::Slice, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::Slice, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
-show(io::IO, r::Slice) = show_default(io, r; f_type = t -> t.name)
+
+function show(io::IO, r::Slice)
+    show(io, typeof(r).name)
+    print(io, "(")
+    show_fields(io, r)
+    print(io, ")")
+end
+
 iterate(S::Slice, s...) = iterate(S.indices, s...)
 
 
@@ -389,7 +396,14 @@ unsafe_length(S::IdentityUnitRange) = unsafe_length(S.indices)
 getindex(S::IdentityUnitRange, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::IdentityUnitRange, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
-show(io::IO, r::IdentityUnitRange) = show_default(io, r; f_type = t -> t.name)
+
+function show(io::IO, r::IdentityUnitRange)
+    show(io, typeof(r).name)
+    print(io, "(")
+    show_fields(io, r)
+    print(io, ")")
+end
+
 iterate(S::IdentityUnitRange, s...) = iterate(S.indices, s...)
 
 """

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -358,7 +358,7 @@ unsafe_length(S::Slice) = unsafe_length(S.indices)
 getindex(S::Slice, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::Slice, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::Slice, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
-show(io::IO, r::Slice) = print(io, "Base.Slice(", r.indices, ")")
+show(io::IO, r::Slice) = show_default(io, r; f_type = t -> t.name)
 iterate(S::Slice, s...) = iterate(S.indices, s...)
 
 
@@ -389,7 +389,7 @@ unsafe_length(S::IdentityUnitRange) = unsafe_length(S.indices)
 getindex(S::IdentityUnitRange, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::IdentityUnitRange, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
-show(io::IO, r::IdentityUnitRange) = print(io, "Base.IdentityUnitRange(", r.indices, ")")
+show(io::IO, r::IdentityUnitRange) = show_default(io, r; f_type = t -> t.name)
 iterate(S::IdentityUnitRange, s...) = iterate(S.indices, s...)
 
 """

--- a/base/range.jl
+++ b/base/range.jl
@@ -739,7 +739,7 @@ end
 
 show(io::IO, r::AbstractRange) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
 show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
-show(io::IO, r::OneTo) = print(io, "Base.OneTo(", r.stop, ")")
+show(io::IO, r::OneTo) = show_default(io, r; f_type = t -> t.name)
 
 function ==(r::T, s::T) where {T<:AbstractRange}
     isempty(r) && return isempty(s)

--- a/base/range.jl
+++ b/base/range.jl
@@ -739,7 +739,13 @@ end
 
 show(io::IO, r::AbstractRange) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
 show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
-show(io::IO, r::OneTo) = show_default(io, r; f_type = t -> t.name)
+
+function show(io::IO, r::OneTo)
+    show(io, typeof(r).name)
+    print(io, "(")
+    show_fields(io, r)
+    print(io, ")")
+end
 
 function ==(r::T, s::T) where {T<:AbstractRange}
     isempty(r) && return isempty(s)

--- a/base/show.jl
+++ b/base/show.jl
@@ -388,17 +388,17 @@ show(io::IO, @nospecialize(x)) = show_default(io, x)
 show(x) = show(stdout::IO, x)
 
 # avoid inferring show_default on the type of `x`
-show_default(io::IO, @nospecialize(x); f_type=identity) = _show_default(io, inferencebarrier(x), inferencebarrier(f_type))
+show_default(io::IO, @nospecialize(x)) = _show_default(io, inferencebarrier(x))
 
-function _show_default(io::IO, @nospecialize(x), @nospecialize(f_type))
+function _show_default(io::IO, @nospecialize(x))
     t = typeof(x)
-    show(io, inferencebarrier(f_type(t)))
+    show(io, inferencebarrier(t))
     print(io, '(')
-    _show_default_body(io, x)
+    show_fields(io, x)
     print(io, ')')
 end
 
-function _show_default_body(io::IO, @nospecialize(x))
+function show_fields(io::IO, @nospecialize(x))
     t = typeof(x)
     nf = nfields(x)
     nb = sizeof(x)

--- a/base/show.jl
+++ b/base/show.jl
@@ -593,6 +593,7 @@ function show_type_name(io::IO, tn::Core.TypeName)
     show_sym(io, sym)
     quo      && print(io, ")")
     globfunc && print(io, ")")
+    nothing
 end
 
 function show_datatype(io::IO, x::DataType)

--- a/base/show.jl
+++ b/base/show.jl
@@ -388,12 +388,18 @@ show(io::IO, @nospecialize(x)) = show_default(io, x)
 show(x) = show(stdout::IO, x)
 
 # avoid inferring show_default on the type of `x`
-show_default(io::IO, @nospecialize(x)) = _show_default(io, inferencebarrier(x))
+show_default(io::IO, @nospecialize(x); f_type=identity) = _show_default(io, inferencebarrier(x), inferencebarrier(f_type))
 
-function _show_default(io::IO, @nospecialize(x))
+function _show_default(io::IO, @nospecialize(x), @nospecialize(f_type))
     t = typeof(x)
-    show(io, inferencebarrier(t))
+    show(io, inferencebarrier(f_type(t)))
     print(io, '(')
+    _show_default_body(io, x)
+    print(io, ')')
+end
+
+function _show_default_body(io::IO, @nospecialize(x))
+    t = typeof(x)
     nf = nfields(x)
     nb = sizeof(x)
     if nf != 0 || nb == 0
@@ -422,7 +428,6 @@ function _show_default(io::IO, @nospecialize(x))
             end
         end
     end
-    print(io,')')
 end
 
 # Check if a particular symbol is exported from a standard library module

--- a/test/show.jl
+++ b/test/show.jl
@@ -1983,3 +1983,8 @@ end
     @test sprint(show, skipmissing([1,2,missing])) == "skipmissing(Union{Missing, $Int}[1, 2, missing])"
     @test sprint(show, skipmissing((missing,1.0,'a'))) == "skipmissing((missing, 1.0, 'a'))"
 end
+
+@testset "show_fields" begin
+    @test sprint(Base.show_fields, (:a, :b)) == ":a, :b"
+    @test sprint(Base.show_fields, (a=:a, b=:b)) == ":a, :b"
+end


### PR DESCRIPTION
Summary of behavior:

```julia
julia> struct Foo{T}
       x::T
       end

julia> Foo(Base.OneTo(3))
Foo{Base.OneTo{Int64}}(Base.OneTo(3))

julia> using Base: OneTo

julia> Foo(Base.OneTo(3))
Foo{OneTo{Int64}}(OneTo(3))

julia> Base.show(io::IO, f::Foo) = Base.show_default(io, f; f_type=t -> t.name)

julia> Foo(Base.OneTo(3))
Foo(OneTo(3))
```


See #36263 

This needs to look better than requiring the anonymous function. The reason I didn't just use a flag is because I thought there might be a good way to selectively print some type parameters and not other. For example, for a type like

```julia
struct Bar{S, T}
    x::S
end
```
one might desire to print it as `Bar{_, 2}(Base.OneTo(3))` instead of
`Bar(Base.OneTo(3))` or `Bar{Base.OneTo{Int64}, 2}(Base.OneTo(3))`

This also needs tests. Question: how should I test the following behavior:

```julia
julia> Foo(Base.OneTo(3))
Foo{Base.OneTo{Int64}}(Base.OneTo(3))

julia> using Base: OneTo

julia> Foo(Base.OneTo(3))
Foo{OneTo{Int64}}(OneTo(3))
```
