### PR TITLE
fix #36270: 3-arg `dot` missing in documentation page

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -317,6 +317,7 @@ LinearAlgebra.SingularException
 LinearAlgebra.PosDefException
 LinearAlgebra.ZeroPivotException
 LinearAlgebra.dot
+LinearAlgebra.dot(::Any, ::Any, ::Any)
 LinearAlgebra.cross
 LinearAlgebra.factorize
 LinearAlgebra.Diagonal


### PR DESCRIPTION
Fix #36270