### PR TITLE
Alternate fix for introspection macros with getproperty

### DIFF
--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -325,6 +325,13 @@ B33163(x) = x
 @test_throws ErrorException (@functionloc Base.nothing)
 @test (@code_typed (3//4).num)[2] == Int
 
+struct A14637
+    x
+end
+a14637 = A14637(0)
+@test (@which a14637.x).name == :getproperty
+@test (@functionloc a14637.x)[2] isa Integer
+
 # Issue #28615
 @test_throws ErrorException (@which [1, 2] .+ [3, 4])
 @test (@code_typed optimize=true max.([1,7], UInt.([4])))[2] == Vector{UInt}


### PR DESCRIPTION
This supersedes #35895. Likewise, it fixes `@which` so that the two following behaviors work:
```julia
julia> @which Base.nothing
Core

julia> x = LinearAlgebra.lu(rand(Int, 3, 3));

julia> @which x.factors
getproperty(F::LU{T,var"#s825"} where var"#s825"<:(StridedArray{T, 2} where T), d::Symbol) where T in LinearAlgebra at /home/liozou/julia/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/lu.jl:305
```

Additionally, the other non-`code_...` introspection macros (`@edit`, `@functionloc` and `@less`) now work as well for the second case and point to the appropriate `getproperty` methods: for instance
```julia
julia> @functionloc x.factors
("/home/liozou/julia/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/lu.jl", 305)
```

However, and that's the only difference with #35895, these macros throw an error when used on a fully qualified symbol: for instance
```julia
julia> @edit Base.isabstracttype
ERROR: expression is not a function call
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at /home/liozou/julia/stdlib/InteractiveUtils/src/macros.jl:74
```

I think this is a better behavior than that proposed in #35895 where it would point to `getproperty(x::Module, f::Symbol)`, which seems more confusing than helpful to me.