### PR TITLE
Add keyword argument constant propogation to News

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Compiler/Runtime improvements
 * All platforms can now use `@executable_path` within `jl_load_dynamic_library()`.
   This allows executable-relative paths to be embedded within executables on all
   platforms, not just MacOS, which the syntax is borrowed from. ([#35627])
+* Constant propogation now occurs through keyword arguments ([#35976])
 
 Command-line option changes
 ---------------------------


### PR DESCRIPTION
I think https://github.com/JuliaLang/julia/pull/35976 is a pretty big deal since it makes all of SciML suddenly infer a lot better, and probably another big library that's splatting keyword arguments. So I added a note to the compiler/runtime improvements.