### PR TITLE
show: differentiate TypeName and wrapper when printing

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -45,7 +45,7 @@ struct ValueIterator{T<:AbstractDict}
 end
 
 function summary(io::IO, iter::T) where {T<:Union{KeySet,ValueIterator}}
-    print(io, T.name, " for a ")
+    print(io, T.name.name, " for a ")
     summary(io, iter.dict)
 end
 
@@ -558,7 +558,7 @@ Dict{Symbol,Int64} with 2 entries:
   :b => 2
 
 julia> map!(v -> v-1, values(d))
-Base.ValueIterator for a Dict{Symbol,Int64} with 2 entries. Values:
+ValueIterator for a Dict{Symbol,Int64} with 2 entries. Values:
   0
   1
 ```

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -516,9 +516,9 @@ function typeinfo_prefix(io::IO, X)
 
     if X isa AbstractDict
         if eltype_X == eltype_ctx
-            string(typeof(X).name), false
+            sprint(show_type_name, typeof(X).name), false
         elseif !isempty(X) && typeinfo_implicit(keytype(X)) && typeinfo_implicit(valtype(X))
-            string(typeof(X).name), true
+            sprint(show_type_name, typeof(X).name), true
         else
             string(typeof(X)), false
         end
@@ -529,7 +529,7 @@ function typeinfo_prefix(io::IO, X)
         elseif !isempty(X) && typeinfo_implicit(eltype_X)
             "", true
         elseif print_without_params(eltype_X)
-            string(unwrap_unionall(eltype_X).name), false # Print "Array" rather than "Array{T,N}"
+            sprint(show_type_name, unwrap_unionall(eltype_X).name), false # Print "Array" rather than "Array{T,N}"
         else
             string(eltype_X), false
         end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -750,7 +750,7 @@ of a general iterator are normally considered its "values".
 julia> d = Dict("a"=>1, "b"=>2);
 
 julia> values(d)
-Base.ValueIterator for a Dict{String,Int64} with 2 entries. Values:
+ValueIterator for a Dict{String,Int64} with 2 entries. Values:
   2
   1
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -499,7 +499,7 @@ function show(io::IO, @nospecialize(x::Type))
         show_datatype(io, x)
         return
     elseif x isa Union
-        if x.a isa DataType && Core.Compiler.typename(x.a) === Core.Compiler.typename(DenseArray)
+        if x.a isa DataType && x.a.name === typename(DenseArray)
             T, N = x.a.parameters
             if x == StridedArray{T,N}
                 print(io, "StridedArray")
@@ -522,7 +522,7 @@ function show(io::IO, @nospecialize(x::Type))
     x::UnionAll
 
     if print_without_params(x)
-        return show(io, unwrap_unionall(x).name)
+        return show_type_name(io, unwrap_unionall(x).name)
     end
 
     if x.var.name === :_ || io_has_tvar_name(io, x.var.name, x)
@@ -593,6 +593,7 @@ function show_type_name(io::IO, tn::Core.TypeName)
     show_sym(io, sym)
     quo      && print(io, ")")
     globfunc && print(io, ")")
+    nothing
 end
 
 function show_datatype(io::IO, x::DataType)
@@ -647,7 +648,9 @@ macro show(exs...)
 end
 
 function show(io::IO, tn::Core.TypeName)
+    print(io, "typename(")
     show_type_name(io, tn)
+    print(io, ")")
 end
 
 show(io::IO, ::Nothing) = print(io, "nothing")

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -813,6 +813,11 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, " where ");
         n += jl_static_show_x(out, (jl_value_t*)ua->var, depth->prev);
     }
+    else if (vt == jl_typename_type) {
+        n += jl_printf(out, "typename(");
+        n += jl_static_show_x(out, jl_unwrap_unionall(((jl_typename_t*)v)->wrapper), depth);
+        n += jl_printf(out, ")");
+    }
     else if (vt == jl_tvar_type) {
         // show type-var bounds only if they aren't going to be printed by UnionAll later
         jl_tvar_t *var = (jl_tvar_t*)v;

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1062,20 +1062,20 @@ end
     @test String(take!(buf)) == "Base.ImmutableDict{$Int,$Int} with 1 entry: …"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeySet for a Base.ImmutableDict{$Int,$Int} with 1 entry. Keys: …"
+        "KeySet for a Base.ImmutableDict{$Int,$Int} with 1 entry. Keys: …"
 
     io = IOContext(io, :displaysize => (5, 80))
     show(io, MIME"text/plain"(), d)
     @test String(take!(buf)) == "Base.ImmutableDict{$Int,$Int} with 1 entry:\n  1 => 2"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeySet for a Base.ImmutableDict{$Int,$Int} with 1 entry. Keys:\n  1"
+        "KeySet for a Base.ImmutableDict{$Int,$Int} with 1 entry. Keys:\n  1"
     d = Base.ImmutableDict(d, 3=>4)
     show(io, MIME"text/plain"(), d)
     @test String(take!(buf)) == "Base.ImmutableDict{$Int,$Int} with 2 entries:\n  ⋮ => ⋮"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeySet for a Base.ImmutableDict{$Int,$Int} with 2 entries. Keys:\n  ⋮"
+        "KeySet for a Base.ImmutableDict{$Int,$Int} with 2 entries. Keys:\n  ⋮"
 
     io = IOContext(io, :displaysize => (6, 80))
     show(io, MIME"text/plain"(), d)
@@ -1083,14 +1083,14 @@ end
         "Base.ImmutableDict{$Int,$Int} with 2 entries:\n  3 => 4\n  1 => 2"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeySet for a Base.ImmutableDict{$Int,$Int} with 2 entries. Keys:\n  3\n  1"
+        "KeySet for a Base.ImmutableDict{$Int,$Int} with 2 entries. Keys:\n  3\n  1"
     d = Base.ImmutableDict(d, 5=>6)
     show(io, MIME"text/plain"(), d)
     @test String(take!(buf)) ==
         "Base.ImmutableDict{$Int,$Int} with 3 entries:\n  5 => 6\n  ⋮ => ⋮"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeySet for a Base.ImmutableDict{$Int,$Int} with 3 entries. Keys:\n  5\n  ⋮"
+        "KeySet for a Base.ImmutableDict{$Int,$Int} with 3 entries. Keys:\n  5\n  ⋮"
 end
 
 @testset "copy!" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -616,6 +616,8 @@ end
 @test_repr "Array{<:Real}"
 @test_repr "Array{>:Real}"
 
+@test repr(Base.typename(Array)) == "typename(Array)"
+
 let oldout = stdout, olderr = stderr
     local rdout, wrout, rderr, wrerr, out, err, rd, wr, io
     try


### PR DESCRIPTION
Currently we print a TypeName identically to the wrapper object Type it is pointed from. This prints them slightly differently, to help distinguish which one you have.