### PR TITLE
Remove `init` from `count!` docstring

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -390,11 +390,10 @@ count(A::AbstractArrayOrBroadcasted; dims=:) = count(identity, A, dims=dims)
 count(f, A::AbstractArrayOrBroadcasted; dims=:) = mapreduce(_bool(f), add_sum, A, dims=dims, init=0)
 
 """
-    count!([f=identity,] r, A; init=true)
+    count!([f=identity,] r, A)
 
 Count the number of elements in `A` for which `f` returns `true` over the
 singleton dimensions of `r`, writing the result into `r` in-place.
-If `init` is `true`, values in `r` are initialized to zero.
 
 !!! compat "Julia 1.5"
     inplace `count!` was added in Julia 1.5.


### PR DESCRIPTION
To prepare for renaming keyword argument `init` for in-place multi-dimensional reducers #36266, it'd be better to avoid increasing the user of `init` in Julia 1.5 phase.  So, maybe it makes sense to "downgrade" the status of `init` for `count!` to the same level as the one for `sum!` etc.