### PR TITLE
Fix: lastindex for Numbers

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -68,7 +68,9 @@ ndims(x::Number) = 0
 ndims(::Type{<:Number}) = 0
 length(x::Number) = 1
 firstindex(x::Number) = 1
+firstindex(x::Number, ::Int) = 1
 lastindex(x::Number) = 1
+lastindex(x::Number, ::Int) = 1
 IteratorSize(::Type{<:Number}) = HasShape{0}()
 keys(::Number) = OneTo(1)
 

--- a/base/number.jl
+++ b/base/number.jl
@@ -68,9 +68,9 @@ ndims(x::Number) = 0
 ndims(::Type{<:Number}) = 0
 length(x::Number) = 1
 firstindex(x::Number) = 1
-firstindex(x::Number, ::Int) = 1
+firstindex(x::Number, d::Int) = d < 1 ? throw(BoundsError()) : 1
 lastindex(x::Number) = 1
-lastindex(x::Number, ::Int) = 1
+lastindex(x::Number, d::Int) = d < 1 ? throw(BoundsError()) : 1
 IteratorSize(::Type{<:Number}) = HasShape{0}()
 keys(::Number) = OneTo(1)
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2405,6 +2405,7 @@ end
     @test_throws BoundsError firstindex(1,0)
     @test lastindex(1) == 1
     @test lastindex(1, 1) == 1
+    @test 1[end,end] == 1
     @test_throws BoundsError lastindex(1,0)
     @test eltype(Integer) == Integer
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2401,7 +2401,11 @@ end
     @test size(1) == ()
     @test length(1) == 1
     @test firstindex(1) == 1
+    @test firstindex(1, 1) == 1
+    @test_throws BoundsError firstindex(1,0)
     @test lastindex(1) == 1
+    @test lastindex(1, 1) == 1
+    @test_throws BoundsError lastindex(1,0)
     @test eltype(Integer) == Integer
 end
 


### PR DESCRIPTION
Fixes: #36311 
Added a method to `lastindex` to handel 1[end,end] for consistency.
Also added similar function to `firstindex`