### PR TITLE
pty_{master,slave} -> pt{m,s}

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -47,9 +47,9 @@ function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=60, debug::Bool
         return "Process output found:\n\"\"\"\n$str\n\"\"\""
     end
     out = IOBuffer()
-    with_fake_pty() do pty_slave, pty_master
-        p = run(detach(cmd), pty_slave, pty_slave, pty_slave, wait=false)
-        Base.close_stdio(pty_slave)
+    with_fake_pty() do pts, ptm
+        p = run(detach(cmd), pts, pts, pts, wait=false)
+        Base.close_stdio(pts)
 
         # Kill the process if it takes too long. Typically occurs when process is waiting
         # for input.
@@ -79,17 +79,17 @@ function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=60, debug::Bool
         end
 
         for (challenge, response) in challenges
-            write(out, readuntil(pty_master, challenge, keep=true))
-            if !isopen(pty_master)
+            write(out, readuntil(ptm, challenge, keep=true))
+            if !isopen(ptm)
                 error("Could not locate challenge: \"$challenge\". ",
                       format_output(out))
             end
-            write(pty_master, response)
+            write(ptm, response)
         end
 
-        # Capture output from process until `pty_slave` is closed
+        # Capture output from process until `pts` is closed
         try
-            write(out, pty_master)
+            write(out, ptm)
         catch ex
             if !(ex isa Base.IOError && ex.code == Base.UV_EIO)
                 rethrow() # ignore EIO from master after slave dies
@@ -97,7 +97,7 @@ function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=60, debug::Bool
         end
 
         status = fetch(timer)
-        close(pty_master)
+        close(ptm)
         if status != :success
             if status == :timeout
                 error("Process timed out possibly waiting for a response. ",

--- a/test/testhelpers/FakePTYs.jl
+++ b/test/testhelpers/FakePTYs.jl
@@ -16,25 +16,25 @@ function open_fake_pty()
         pid = string(getpid(), base=16, pad=16)
         pipename = """\\\\?\\pipe\\cygwin-$pid-pty10-abcdefg"""
         server = listen(pipename)
-        pty_slave = connect(pipename)
-        @assert ccall(:jl_ispty, Cint, (Ptr{Cvoid},), pty_slave.handle) == 1
-        pty_master = accept(server)
+        pts = connect(pipename)
+        @assert ccall(:jl_ispty, Cint, (Ptr{Cvoid},), pts.handle) == 1
+        ptm = accept(server)
         close(server)
         # extract just the file descriptor
-        fds = Libc.dup(Base._fd(pty_slave))
-        close(pty_slave)
-        pty_slave = fds
-        # convert pty_slave handle to a TTY
-        #fds = pty_slave.handle
-        #pty_slave.status = Base.StatusClosed
-        #pty_slave.handle = C_NULL
-        #pty_slave = Base.TTY(fds, Base.StatusOpen)
+        fds = Libc.dup(Base._fd(pts))
+        close(pts)
+        pts = fds
+        # convert pts handle to a TTY
+        #fds = pts.handle
+        #pts.status = Base.StatusClosed
+        #pts.handle = C_NULL
+        #pts = Base.TTY(fds, Base.StatusOpen)
     else
         O_RDWR = Base.Filesystem.JL_O_RDWR
         O_NOCTTY = Base.Filesystem.JL_O_NOCTTY
 
         fdm = ccall(:posix_openpt, Cint, (Cint,), O_RDWR | O_NOCTTY)
-        fdm == -1 && error("Failed to open pty_master")
+        fdm == -1 && error("Failed to open ptm")
         rc = ccall(:grantpt, Cint, (Cint,), fdm)
         rc != 0 && error("grantpt failed")
         rc = ccall(:unlockpt, Cint, (Cint,), fdm)
@@ -43,21 +43,21 @@ function open_fake_pty()
         fds = ccall(:open, Cint, (Ptr{UInt8}, Cint),
             ccall(:ptsname, Ptr{UInt8}, (Cint,), fdm), O_RDWR | O_NOCTTY)
 
-        pty_slave = RawFD(fds)
-        # pty_slave = fdio(fds, true)
-        # pty_slave = Base.Filesystem.File(RawFD(fds))
-        # pty_slave = Base.TTY(RawFD(fds); readable = false)
-        pty_master = Base.TTY(RawFD(fdm))
+            pts = RawFD(fds)
+        # pts = fdio(fds, true)
+        # pts = Base.Filesystem.File(RawFD(fds))
+        # pts = Base.TTY(RawFD(fds); readable = false)
+        ptm = Base.TTY(RawFD(fdm))
     end
-    return pty_slave, pty_master
+    return pts, ptm
 end
 
 function with_fake_pty(f)
-    pty_slave, pty_master = open_fake_pty()
+    pts, ptm = open_fake_pty()
     try
-        f(pty_slave, pty_master)
+        f(pts, ptm)
     finally
-        close(pty_master)
+        close(ptm)
     end
     nothing
 end


### PR DESCRIPTION
We decided to get rid of the master/slave terminology in Julia in #30058.
However, we decided to keep it for PTYs, where the terminology is imposed
upon us by POSIX (and thus changing it would be confusing for people who
might need to read up on the POSIX definitions of these concepts). It
was recently suggested to revisit this, by renaming to ptm and pts instead,
which also fit well (as the devies that the fds refer to are `/dev/ptmx`
and `/dev/pts` respectively), are googleable (`pty pts` will yield the
correct man page) and will probably need to remain even if POSIX
adjusts their terminology, since they're part of the ABI (presumably
they'll be backronymed to whatever terminology ends up winning).
This patch does this rename.