### PR TITLE
Add a few hooks that make external AbstractInterpreters easier

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -46,6 +46,10 @@ mutable struct InferenceState
     # `max_valid`, to be used in inlining
     matching_methods_cache::IdDict{Any, Tuple{Any, UInt, UInt}}
 
+    # The interpreter that created this inference state. Not looked at by
+    # NativeInterpreter. But other interpreters may use this to detect cycles
+    interp::AbstractInterpreter
+
     # src is assumed to be a newly-allocated CodeInfo, that can be modified in-place to contain intermediate results
     function InferenceState(result::InferenceResult, src::CodeInfo,
                             cached::Bool, interp::AbstractInterpreter)
@@ -107,7 +111,8 @@ mutable struct InferenceState
             Vector{InferenceState}(), # callers_in_cycle
             #=parent=#nothing,
             cached, false, false, false,
-            IdDict{Any, Tuple{Any, UInt, UInt}}())
+            IdDict{Any, Tuple{Any, UInt, UInt}}(),
+            interp)
         result.result = frame
         cached && push!(get_inference_cache(interp), result)
         return frame

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -983,18 +983,22 @@ struct CodegenParams
 
     lookup::Ptr{Cvoid}
 
+    generic_context::Any
+
     function CodegenParams(; track_allocations::Bool=true, code_coverage::Bool=true,
                    static_alloc::Bool=true, prefer_specsig::Bool=false,
                    gnu_pubnames=true, debug_info_kind::Cint = default_debug_info_kind(),
                    module_setup=nothing, module_activation=nothing, raise_exception=nothing,
                    emit_function=nothing, emitted_function=nothing,
-                   lookup::Ptr{Cvoid}=cglobal(:jl_rettype_inferred))
+                   lookup::Ptr{Cvoid}=cglobal(:jl_rettype_inferred),
+                   generic_context = nothing)
         return new(
             Cint(track_allocations), Cint(code_coverage),
             Cint(static_alloc), Cint(prefer_specsig),
             Cint(gnu_pubnames), debug_info_kind,
             module_setup, module_activation, raise_exception,
-            emit_function, emitted_function, lookup)
+            emit_function, emitted_function, lookup,
+            generic_context)
     end
 end
 

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -24,6 +24,7 @@ DECLARE_BUILTIN(typeof);     DECLARE_BUILTIN(sizeof);
 DECLARE_BUILTIN(issubtype);  DECLARE_BUILTIN(isa);
 DECLARE_BUILTIN(_apply);     DECLARE_BUILTIN(_apply_pure);
 DECLARE_BUILTIN(_apply_latest); DECLARE_BUILTIN(_apply_iterate);
+DECLARE_BUILTIN(_invoke_codeinst);
 DECLARE_BUILTIN(isdefined);  DECLARE_BUILTIN(nfields);
 DECLARE_BUILTIN(tuple);      DECLARE_BUILTIN(svec);
 DECLARE_BUILTIN(getfield);   DECLARE_BUILTIN(setfield);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -669,6 +669,14 @@ JL_CALLABLE(jl_f__apply)
     return do_apply(F, args, nargs, NULL);
 }
 
+JL_CALLABLE(jl_f__invoke_codeinst)
+{
+    JL_NARGSV(_invoke_codeinst, 2);
+    JL_TYPECHK(_invoke_codeinst, code_instance, args[0]);
+    jl_code_instance_t *inst = (jl_code_instance_t*)args[0];
+    return inst->invoke(args[1], &args[2], nargs-2, inst);
+}
+
 // this is like `_apply`, but with quasi-exact checks to make sure it is pure
 JL_CALLABLE(jl_f__apply_pure)
 {
@@ -1523,6 +1531,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     jl_builtin_apply_type = add_builtin_func("apply_type", jl_f_apply_type);
     jl_builtin__apply = add_builtin_func("_apply", jl_f__apply);
     jl_builtin__apply_iterate = add_builtin_func("_apply_iterate", jl_f__apply_iterate);
+    jl_builtin__invoke_codeinst = add_builtin_func("_invoke_codeinst", jl_f__invoke_codeinst);
     jl_builtin__expr = add_builtin_func("_expr", jl_f__expr);
     jl_builtin_svec = add_builtin_func("svec", jl_f_svec);
     add_builtin_func("_apply_pure", jl_f__apply_pure);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -789,6 +789,7 @@ static const std::map<jl_fptr_args_t, JuliaFunction*> builtin_func_map = {
     { &jl_f__apply_iterate,     new JuliaFunction{"jl_f__apply_iterate", get_func_sig, get_func_attrs} },
     { &jl_f__apply_pure,        new JuliaFunction{"jl_f__apply_pure", get_func_sig, get_func_attrs} },
     { &jl_f__apply_latest,      new JuliaFunction{"jl_f__apply_latest", get_func_sig, get_func_attrs} },
+    { &jl_f__invoke_codeinst,     new JuliaFunction{"jl_f__invoke_codeinst", get_func_sig, get_func_attrs} },
     { &jl_f_throw,              new JuliaFunction{"jl_f_throw", get_func_sig, get_func_attrs} },
     { &jl_f_tuple,              jltuple_func },
     { &jl_f_svec,               new JuliaFunction{"jl_f_svec", get_func_sig, get_func_attrs} },

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -81,15 +81,16 @@ void jl_jit_strings(jl_codegen_params_t::SymMapGV &stringConstants)
     }
 }
 
-
 // this generates llvm code for the lambda info
 // and adds the result to the jitlayers
 // (and the shadow module),
 // and generates code for it
-static jl_callptr_t _jl_compile_codeinst(
+extern "C" {
+JL_DLLEXPORT jl_callptr_t jl_compile_codeinst(
         jl_code_instance_t *codeinst,
         jl_code_info_t *src,
-        size_t world)
+        size_t world,
+        const jl_cgparams_t *cg_params)
 {
     // TODO: Merge with jl_dump_compiles?
     static ios_t f_precompile;
@@ -111,6 +112,7 @@ static jl_callptr_t _jl_compile_codeinst(
     jl_codegen_params_t params;
     params.cache = true;
     params.world = world;
+    params.params = cg_params;
     std::map<jl_code_instance_t*, jl_compile_result_t> emitted;
     {
         JL_TIMING(CODEGEN);
@@ -217,6 +219,15 @@ static jl_callptr_t _jl_compile_codeinst(
         }
     }
     return fptr;
+}
+}
+
+static jl_callptr_t _jl_compile_codeinst(
+        jl_code_instance_t *codeinst,
+        jl_code_info_t *src,
+        size_t world)
+{
+    return jl_compile_codeinst(codeinst, src, world, &jl_default_cgparams);
 }
 
 void jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2100,6 +2100,10 @@ typedef struct {
 
     // Cache access. Default: jl_rettype_inferred.
     jl_codeinstance_lookup_t lookup;
+
+    // If not `nothing`, rewrite all generic calls to call
+    // generic_context(f, args...) instead of f(args...).
+    jl_value_t *generic_context;
 } jl_cgparams_t;
 extern JL_DLLEXPORT jl_cgparams_t jl_default_cgparams;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -78,7 +78,7 @@ static void *const _tags[] = {
          // some Core.Builtin Functions that we want to be able to reference:
          &jl_builtin_throw, &jl_builtin_is, &jl_builtin_typeof, &jl_builtin_sizeof,
          &jl_builtin_issubtype, &jl_builtin_isa, &jl_builtin_typeassert, &jl_builtin__apply,
-         &jl_builtin__apply_iterate,
+         &jl_builtin__apply_iterate, &jl_builtin__invoke_codeinst,
          &jl_builtin_isdefined, &jl_builtin_nfields, &jl_builtin_tuple, &jl_builtin_svec,
          &jl_builtin_getfield, &jl_builtin_setfield, &jl_builtin_fieldtype, &jl_builtin_arrayref,
          &jl_builtin_const_arrayref, &jl_builtin_arrayset, &jl_builtin_arraysize,
@@ -117,7 +117,9 @@ void *native_functions;
 // This is a manually constructed dual of the fvars array, which would be produced by codegen for Julia code, for C.
 static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_throw, &jl_f_is, &jl_f_typeof, &jl_f_issubtype, &jl_f_isa,
-    &jl_f_typeassert, &jl_f__apply, &jl_f__apply_iterate, &jl_f__apply_pure, &jl_f__apply_latest, &jl_f_isdefined,
+    &jl_f_typeassert, &jl_f__apply, &jl_f__apply_iterate, &jl_f__apply_pure, &jl_f__apply_latest,
+    &jl_f__invoke_codeinst,
+    &jl_f_isdefined,
     &jl_f_tuple, &jl_f_svec, &jl_f_intrinsic_call, &jl_f_invoke_kwsorter,
     &jl_f_getfield, &jl_f_setfield, &jl_f_fieldtype, &jl_f_nfields,
     &jl_f_arrayref, &jl_f_const_arrayref, &jl_f_arrayset, &jl_f_arraysize, &jl_f_apply_type,


### PR DESCRIPTION
Details, in the individual commit messages. I don't think these are necessarily the correct abstractions longterm, but they are quite useful for prototyping in the short term. With these hooks (and prior work on refactoring the caches), it's possible to have a completely external Julia compiler, complete with its own implementation of apply_generic that will use the correct interpreter for its analysis, while still running on the Julia execution engine.