### PR TITLE
use ReturnNode, GotoIfNot, and Argument more consistently in IR

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -103,6 +103,15 @@
 #    label::Int
 #end
 
+#struct GotoIfNot
+#    cond::Any
+#    dest::Int
+#end
+
+#struct ReturnNode
+#    val::Any
+#end
+
 #struct PiNode
 #    val
 #    typ
@@ -368,6 +377,10 @@ _new(:GotoNode, :Int)
 _new(:NewvarNode, :SlotNumber)
 _new(:QuoteNode, :Any)
 _new(:SSAValue, :Int)
+_new(:Argument, :Int)
+_new(:ReturnNode, :Any)
+eval(Core, :(ReturnNode() = $(Expr(:new, :ReturnNode)))) # unassigned val indicates unreachable
+eval(Core, :(GotoIfNot(@nospecialize(cond), dest::Int) = $(Expr(:new, :GotoIfNot, :cond, :dest))))
 eval(Core, :(LineNumberNode(l::Int) = $(Expr(:new, :LineNumberNode, :l, nothing))))
 eval(Core, :(LineNumberNode(l::Int, @nospecialize(f)) = $(Expr(:new, :LineNumberNode, :l, :f))))
 LineNumberNode(l::Int, f::String) = LineNumberNode(l, Symbol(f))
@@ -453,12 +466,12 @@ Symbol(s::Symbol) = s
 
 # module providing the IR object model
 module IR
-export CodeInfo, MethodInstance, CodeInstance, GotoNode,
-    NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot,
+export CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnNode,
+    NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot, Argument,
     PiNode, PhiNode, PhiCNode, UpsilonNode, LineInfoNode
 
-import Core: CodeInfo, MethodInstance, CodeInstance, GotoNode,
-    NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot,
+import Core: CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnNode,
+    NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot, Argument,
     PiNode, PhiNode, PhiCNode, UpsilonNode, LineInfoNode
 
 end

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1174,13 +1174,13 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                 changes[sn] = VarState(Bottom, true)
             elseif isa(stmt, GotoNode)
                 pc´ = (stmt::GotoNode).label
-            elseif hd === :gotoifnot
-                condt = abstract_eval(interp, stmt.args[1], s[pc], frame)
+            elseif isa(stmt, GotoIfNot)
+                condt = abstract_eval(interp, stmt.cond, s[pc], frame)
                 if condt === Bottom
                     break
                 end
                 condval = maybe_extract_const_bool(condt)
-                l = stmt.args[2]::Int
+                l = stmt.dest::Int
                 # constant conditions
                 if condval === true
                 elseif condval === false
@@ -1207,9 +1207,9 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                         s[l] = newstate_else
                     end
                 end
-            elseif hd === :return
+            elseif isa(stmt, ReturnNode)
                 pc´ = n + 1
-                rt = widenconditional(abstract_eval(interp, stmt.args[1], s[pc], frame))
+                rt = widenconditional(abstract_eval(interp, stmt.val, s[pc], frame))
                 if !isa(rt, Const) && !isa(rt, Type) && !isa(rt, PartialStruct)
                     # only propagate information we know we can store
                     # and is valid inter-procedurally

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -339,12 +339,6 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
         # prevent inlining.
         extyp = line == -1 ? Any : src.ssavaluetypes[line]
         return extyp === Union{} ? 0 : 20
-    elseif head === :return
-        a = ex.args[1]
-        if a isa Expr
-            return statement_cost(a, -1, src, sptypes, slottypes, params)
-        end
-        return 0
     elseif head === :(=)
         if ex.args[1] isa GlobalRef
             cost = 20
@@ -364,12 +358,6 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
         # since these aren't usually performance-sensitive functions,
         # and llvm is more likely to miscompile them when these functions get large
         return typemax(Int)
-    elseif head === :gotoifnot
-        target = ex.args[2]::Int
-        # loops are generally always expensive
-        # but assume that forward jumps are already counted for from
-        # summing the cost of the not-taken branch
-        return target < line ? 40 : 0
     end
     return 0
 end
@@ -386,6 +374,8 @@ function inline_worthy(body::Array{Any,1}, src::CodeInfo, sptypes::Vector{Any}, 
             # but assume that forward jumps are already counted for from
             # summing the cost of the not-taken branch
             thiscost = stmt.label < line ? 40 : 0
+        elseif stmt isa GotoIfNot
+            thiscost = stmt.dest < line ? 40 : 0
         else
             continue
         end
@@ -423,20 +413,23 @@ function renumber_ir_elements!(body::Vector{Any}, ssachangemap::Vector{Int}, lab
         el = body[i]
         if isa(el, GotoNode)
             body[i] = GotoNode(el.label + labelchangemap[el.label])
+        elseif isa(el, GotoIfNot)
+            cond = el.cond
+            if isa(cond, SSAValue)
+                cond = SSAValue(cond.id + ssachangemap[cond.id])
+            end
+            body[i] = GotoIfNot(cond, el.dest + labelchangemap[el.dest])
+        elseif isa(el, ReturnNode)
+            if isdefined(el, :val) && isa(el.val, SSAValue)
+                body[i] = ReturnNode(SSAValue(el.val.id + ssachangemap[el.val.id]))
+            end
         elseif isa(el, SSAValue)
             body[i] = SSAValue(el.id + ssachangemap[el.id])
         elseif isa(el, Expr)
             if el.head === :(=) && el.args[2] isa Expr
                 el = el.args[2]::Expr
             end
-            if el.head === :gotoifnot
-                cond = el.args[1]
-                if isa(cond, SSAValue)
-                    el.args[1] = SSAValue(cond.id + ssachangemap[cond.id])
-                end
-                tgt = el.args[2]::Int
-                el.args[2] = tgt + labelchangemap[tgt]
-            elseif el.head === :enter
+            if el.head === :enter
                 tgt = el.args[1]::Int
                 el.args[1] = tgt + labelchangemap[tgt]
             elseif !is_meta_expr_head(el.head)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -141,7 +141,7 @@ end
 
 function should_print_ssa_type(@nospecialize node)
     if isa(node, Expr)
-        return !(node.head in (:gc_preserve_begin, :gc_preserve_end, :meta, :return, :enter, :leave))
+        return !(node.head in (:gc_preserve_begin, :gc_preserve_end, :meta, :enter, :leave))
     end
     return !isa(node, PiNode)   && !isa(node, GotoIfNot) &&
            !isa(node, GotoNode) && !isa(node, ReturnNode) &&
@@ -722,9 +722,7 @@ function show_ir_stmt(io::IO, code::CodeInfo, idx::Int, line_info_preprinter, li
     print(io, inlining_indent, " ")
     # convert statement index to labels, as expected by print_stmt
     if stmt isa Expr
-        if stmt.head === :gotoifnot && length(stmt.args) == 2 && stmt.args[2] isa Int
-            stmt = GotoIfNot(stmt.args[1], block_for_inst(cfg, stmt.args[2]::Int))
-        elseif stmt.head === :enter && length(stmt.args) == 1 && stmt.args[1] isa Int
+        if stmt.head === :enter && length(stmt.args) == 1 && stmt.args[1] isa Int
             stmt = Expr(:enter, block_for_inst(cfg, stmt.args[1]::Int))
         end
     elseif isa(stmt, GotoIfNot)

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -43,7 +43,6 @@ function lift_defuse(cfg::CFG, defuse)
     end
 end
 
-@inline slot_id(s) = isa(s, SlotNumber) ? (s::SlotNumber).id : (s::TypedSlot).id
 function scan_slot_def_use(nargs::Int, ci::CodeInfo, code::Vector{Any})
     nslots = length(ci.slotflags)
     result = SlotInfo[SlotInfo() for i = 1:nslots]
@@ -821,7 +820,7 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, domtree::DomTree, defuse, narg
         elseif isexpr(stmt, :enter)
             new_code[idx] = Expr(:enter, block_for_inst(cfg, stmt.args[1]))
             ssavalmap[idx] = SSAValue(idx) # Slot to store token for pop_exception
-        elseif isexpr(stmt, :leave) || isexpr(stmt, :(=)) || isexpr(stmt, :return) ||
+        elseif isexpr(stmt, :leave) || isexpr(stmt, :(=)) || isa(stmt, ReturnNode) ||
             isexpr(stmt, :meta) || isa(stmt, NewvarNode)
             new_code[idx] = stmt
         else

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -166,7 +166,9 @@ function argextype(@nospecialize(x), src, sptypes::Vector{Any}, slottypes::Vecto
     elseif isa(x, SSAValue)
         return abstract_eval_ssavalue(x::SSAValue, src)
     elseif isa(x, Argument)
-        return isa(src, IncrementalCompact) ? src.ir.argtypes[x.n] : src.argtypes[x.n]
+        return isa(src, IncrementalCompact) ? src.ir.argtypes[x.n] :
+            isa(src, IRCode) ? src.argtypes[x.n] :
+            slottypes[x.n]
     elseif isa(x, QuoteNode)
         return AbstractEvalConstant((x::QuoteNode).value)
     elseif isa(x, GlobalRef)
@@ -188,6 +190,11 @@ function find_ssavalue_uses(body::Vector{Any}, nvals::Int)
     uses = BitSet[ BitSet() for i = 1:nvals ]
     for line in 1:length(body)
         e = body[line]
+        if isa(e, ReturnNode)
+            e = e.val
+        elseif isa(e, GotoIfNot)
+            e = e.cond
+        end
         if isa(e, SSAValue)
             push!(uses[e.id], line)
         elseif isa(e, Expr)
@@ -213,7 +220,8 @@ function find_ssavalue_uses(e::Expr, uses::Vector{BitSet}, line::Int)
 end
 
 # using a function to ensure we can infer this
-@inline slot_id(s) = isa(s, SlotNumber) ? (s::SlotNumber).id : (s::TypedSlot).id
+@inline slot_id(s) = isa(s, SlotNumber) ? (s::SlotNumber).id :
+    isa(s, Argument) ? (s::Argument).n : (s::TypedSlot).id
 
 ###########
 # options #

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -5,15 +5,12 @@ const VALID_EXPR_HEADS = IdDict{Any,Any}(
     :call => 1:typemax(Int),
     :invoke => 2:typemax(Int),
     :static_parameter => 1:1,
-    :gotoifnot => 2:2,
     :(&) => 1:1,
     :(=) => 2:2,
     :method => 1:4,
     :const => 1:1,
     :new => 1:typemax(Int),
     :splatnew => 2:2,
-    :return => 1:1,
-    :unreachable => 0:0,
     :the_exception => 0:0,
     :enter => 1:1,
     :leave => 1:1,
@@ -39,7 +36,7 @@ const INVALID_EXPR_HEAD = "invalid expression head"
 const INVALID_EXPR_NARGS = "invalid number of expression args"
 const INVALID_LVALUE = "invalid LHS value"
 const INVALID_RVALUE = "invalid RHS value"
-const INVALID_RETURN = "invalid argument to :return"
+const INVALID_RETURN = "invalid argument to return"
 const INVALID_CALL_ARG = "invalid :call argument"
 const EMPTY_SLOTNAMES = "slotnames field is empty"
 const SLOTFLAGS_MISMATCH = "length(slotnames) < length(slotflags)"
@@ -130,22 +127,12 @@ function validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo, is_top_
                 end
                 validate_val!(lhs)
                 validate_val!(rhs)
-            elseif head === :gotoifnot
-                if !is_valid_argument(x.args[1])
-                    push!(errors, InvalidCodeError(INVALID_CALL_ARG, x.args[1]))
-                end
-                validate_val!(x.args[1])
-            elseif head === :return
-                if !is_valid_return(x.args[1])
-                    push!(errors, InvalidCodeError(INVALID_RETURN, x.args[1]))
-                end
-                validate_val!(x.args[1])
             elseif head === :call || head === :invoke || head === :gc_preserve_end || head === :meta ||
                 head === :inbounds || head === :foreigncall || head === :cfunction ||
                 head === :const || head === :enter || head === :leave || head === :pop_exception ||
                 head === :method || head === :global || head === :static_parameter ||
                 head === :new || head === :splatnew || head === :thunk || head === :loopinfo ||
-                head === :throw_undef_if_not || head === :unreachable || head === :code_coverage_effect
+                head === :throw_undef_if_not || head === :code_coverage_effect
                 validate_val!(x)
             else
                 # TODO: nothing is actually in statement position anymore
@@ -153,8 +140,21 @@ function validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo, is_top_
             end
         elseif isa(x, NewvarNode)
         elseif isa(x, GotoNode)
+        elseif isa(x, GotoIfNot)
+            if !is_valid_argument(x.cond)
+                push!(errors, InvalidCodeError(INVALID_CALL_ARG, x.cond))
+            end
+            validate_val!(x.cond)
+        elseif isa(x, ReturnNode)
+            if isdefined(x, :val)
+                if !is_valid_return(x.val)
+                    push!(errors, InvalidCodeError(INVALID_RETURN, x.val))
+                end
+                validate_val!(x.val)
+            end
         elseif x === nothing
         elseif isa(x, SlotNumber)
+        elseif isa(x, Argument)
         elseif isa(x, GlobalRef)
         elseif isa(x, LineNumberNode)
         elseif isa(x, PiNode)
@@ -213,7 +213,7 @@ validate_code(args...) = validate_code!(Vector{InvalidCodeError}(), args...)
 is_valid_lvalue(@nospecialize(x)) = isa(x, Slot) || isa(x, GlobalRef)
 
 function is_valid_argument(@nospecialize(x))
-    if isa(x, Slot) || isa(x, SSAValue) || isa(x, GlobalRef) || isa(x, QuoteNode) ||
+    if isa(x, Slot) || isa(x, Argument) || isa(x, SSAValue) || isa(x, GlobalRef) || isa(x, QuoteNode) ||
         (isa(x,Expr) && (x.head in (:static_parameter, :boundscheck))) ||
         isa(x, Number) || isa(x, AbstractString) || isa(x, AbstractChar) || isa(x, Tuple) ||
         isa(x, Type) || isa(x, Core.Box) || isa(x, Module) || x === nothing

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -247,7 +247,7 @@ types exist in lowered form:
     Has a node type indicated by the `head` field, and an `args` field which is a `Vector{Any}` of
     subexpressions.
     While almost every part of a surface AST is represented by an `Expr`, the IR uses only a
-    limited number of `Expr`s, mostly for calls, conditional branches (`gotoifnot`), and returns.
+    limited number of `Expr`s, mostly for calls and some top-level-only forms.
 
   * `Slot`
 
@@ -258,6 +258,11 @@ types exist in lowered form:
     Slots that require per-use type annotations are represented with `TypedSlot`, which has a `typ`
     field.
 
+  * `Argument`
+
+    The same as `SlotNumber`, but appears only post-optimization. Indicates that the
+    referenced slot is an argument of the enclosing function.
+
   * `CodeInfo`
 
     Wraps the IR of a group of statements. Its `code` field is an array of expressions to execute.
@@ -266,6 +271,16 @@ types exist in lowered form:
 
     Unconditional branch. The argument is the branch target, represented as an index in
     the code array to jump to.
+
+  * `GotoIfNot`
+
+    Conditional branch. If the `cond` field evaluates to false, goes to the index identified
+    by the `dest` field.
+
+  * `ReturnNode`
+
+    Returns its argument (the `val` field) as the value of the enclosing function.
+    If the `val` field is undefined, then this represents an unreachable statement.
 
   * `QuoteNode`
 
@@ -304,10 +319,6 @@ These symbols appear in the `head` field of [`Expr`](@ref)s in lowered form.
   * `static_parameter`
 
     Reference a static parameter by index.
-
-  * `gotoifnot`
-
-    Conditional branch. If `args[1]` is false, goes to the index identified in `args[2]`.
 
   * `=`
 
@@ -414,10 +425,6 @@ These symbols appear in the `head` field of [`Expr`](@ref)s in lowered form.
 
     Similar to `new`, except field values are passed as a single tuple. Works similarly to
     `Base.splat(new)` if `new` were a first-class function, hence the name.
-
-  * `return`
-
-    Returns its argument as the value of the enclosing function.
 
   * `isdefined`
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -34,7 +34,7 @@ jl_sym_t *export_sym;  jl_sym_t *import_sym;
 jl_sym_t *toplevel_sym; jl_sym_t *quote_sym;
 jl_sym_t *line_sym;    jl_sym_t *jl_incomplete_sym;
 jl_sym_t *goto_sym;    jl_sym_t *goto_ifnot_sym;
-jl_sym_t *return_sym;  jl_sym_t *unreachable_sym;
+jl_sym_t *return_sym;
 jl_sym_t *lambda_sym;  jl_sym_t *assign_sym;
 jl_sym_t *globalref_sym; jl_sym_t *do_sym;
 jl_sym_t *method_sym;  jl_sym_t *core_sym;
@@ -344,7 +344,6 @@ void jl_init_common_symbols(void)
     goto_sym = jl_symbol("goto");
     goto_ifnot_sym = jl_symbol("gotoifnot");
     return_sym = jl_symbol("return");
-    unreachable_sym = jl_symbol("unreachable");
     lambda_sym = jl_symbol("lambda");
     module_sym = jl_symbol("module");
     export_sym = jl_symbol("export");
@@ -555,10 +554,15 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
             JL_GC_POP();
             return temp;
         }
-        JL_GC_PUSH1(&ex);
+        JL_GC_PUSH2(&ex, &temp);
         if (sym == goto_sym) {
             ex = scm_to_julia_(fl_ctx, car_(e), mod);
             temp = jl_new_struct(jl_gotonode_type, ex);
+        }
+        else if (sym == goto_ifnot_sym) {
+            ex = scm_to_julia_(fl_ctx, car_(e), mod);
+            temp = scm_to_julia(fl_ctx, car_(cdr_(e)), mod);
+            temp = jl_new_struct(jl_gotoifnot_type, ex, temp);
         }
         else if (sym == newvar_sym) {
             ex = scm_to_julia_(fl_ctx, car_(e), mod);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1562,6 +1562,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Slot", (jl_value_t*)jl_abstractslot_type);
     add_builtin("SlotNumber", (jl_value_t*)jl_slotnumber_type);
     add_builtin("TypedSlot", (jl_value_t*)jl_typedslot_type);
+    add_builtin("Argument", (jl_value_t*)jl_argument_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);
     add_builtin("Builtin", (jl_value_t*)jl_builtin_type);
@@ -1580,6 +1581,8 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("LineNumberNode", (jl_value_t*)jl_linenumbernode_type);
     add_builtin("LineInfoNode", (jl_value_t*)jl_lineinfonode_type);
     add_builtin("GotoNode", (jl_value_t*)jl_gotonode_type);
+    add_builtin("GotoIfNot", (jl_value_t*)jl_gotoifnot_type);
+    add_builtin("ReturnNode", (jl_value_t*)jl_returnnode_type);
     add_builtin("PiNode", (jl_value_t*)jl_pinode_type);
     add_builtin("PhiNode", (jl_value_t*)jl_phinode_type);
     add_builtin("PhiCNode", (jl_value_t*)jl_phicnode_type);

--- a/src/dump.c
+++ b/src/dump.c
@@ -2573,7 +2573,7 @@ void jl_init_serializer(void)
 
     void *vals[] = { jl_emptysvec, jl_emptytuple, jl_false, jl_true, jl_nothing, jl_any_type,
                      call_sym, invoke_sym, goto_ifnot_sym, return_sym, jl_symbol("tuple"),
-                     unreachable_sym, jl_an_empty_string, jl_an_empty_vec_any,
+                     jl_an_empty_string, jl_an_empty_vec_any,
 
                      // empirical list of very common symbols
                      #include "common_symbols1.inc"
@@ -2585,7 +2585,6 @@ void jl_init_serializer(void)
                      jl_box_int32(12), jl_box_int32(13), jl_box_int32(14),
                      jl_box_int32(15), jl_box_int32(16), jl_box_int32(17),
                      jl_box_int32(18), jl_box_int32(19), jl_box_int32(20),
-                     jl_box_int32(21),
 
                      jl_box_int64(0), jl_box_int64(1), jl_box_int64(2),
                      jl_box_int64(3), jl_box_int64(4), jl_box_int64(5),
@@ -2594,7 +2593,7 @@ void jl_init_serializer(void)
                      jl_box_int64(12), jl_box_int64(13), jl_box_int64(14),
                      jl_box_int64(15), jl_box_int64(16), jl_box_int64(17),
                      jl_box_int64(18), jl_box_int64(19), jl_box_int64(20),
-                     jl_box_int64(21), jl_box_int64(22),
+                     jl_box_int64(21),
 
                      jl_bool_type, jl_linenumbernode_type, jl_pinode_type,
                      jl_upsilonnode_type, jl_type_type, jl_bottom_type, jl_ref_type,
@@ -2644,6 +2643,9 @@ void jl_init_serializer(void)
     deser_tag[TAG_UNIONALL] = (jl_value_t*)jl_unionall_type;
     deser_tag[TAG_GOTONODE] = (jl_value_t*)jl_gotonode_type;
     deser_tag[TAG_QUOTENODE] = (jl_value_t*)jl_quotenode_type;
+    deser_tag[TAG_GOTOIFNOT] = (jl_value_t*)jl_gotoifnot_type;
+    deser_tag[TAG_RETURNNODE] = (jl_value_t*)jl_returnnode_type;
+    deser_tag[TAG_ARGUMENT] = (jl_value_t*)jl_argument_type;
 
     intptr_t i = 0;
     while (vals[i] != NULL) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -34,6 +34,7 @@ jl_datatype_t *jl_ssavalue_type;
 jl_datatype_t *jl_abstractslot_type;
 jl_datatype_t *jl_slotnumber_type;
 jl_datatype_t *jl_typedslot_type;
+jl_datatype_t *jl_argument_type;
 jl_datatype_t *jl_simplevector_type;
 jl_typename_t *jl_tuple_typename;
 jl_datatype_t *jl_anytuple_type;
@@ -93,6 +94,8 @@ jl_datatype_t *jl_expr_type;
 jl_datatype_t *jl_globalref_type;
 jl_datatype_t *jl_linenumbernode_type;
 jl_datatype_t *jl_gotonode_type;
+jl_datatype_t *jl_gotoifnot_type;
+jl_datatype_t *jl_returnnode_type;
 jl_datatype_t *jl_pinode_type;
 jl_datatype_t *jl_phinode_type;
 jl_datatype_t *jl_phicnode_type;
@@ -2066,6 +2069,10 @@ void jl_init_types(void) JL_GC_DISABLED
                                         jl_perm_symsvec(2, "id", "typ"),
                                         jl_svec(2, jl_long_type, jl_any_type), 0, 0, 2);
 
+    jl_argument_type = jl_new_datatype(jl_symbol("Argument"), core, jl_any_type, jl_emptysvec,
+                                       jl_perm_symsvec(1, "n"),
+                                       jl_svec1(jl_long_type), 0, 0, 1);
+
     jl_init_int32_int64_cache();
 
     jl_bool_type = NULL;
@@ -2180,6 +2187,16 @@ void jl_init_types(void) JL_GC_DISABLED
         jl_new_datatype(jl_symbol("GotoNode"), core, jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(1, "label"),
                         jl_svec(1, jl_long_type), 0, 0, 1);
+
+    jl_gotoifnot_type =
+        jl_new_datatype(jl_symbol("GotoIfNot"), core, jl_any_type, jl_emptysvec,
+                        jl_perm_symsvec(2, "cond", "dest"),
+                        jl_svec(2, jl_any_type, jl_long_type), 0, 0, 2);
+
+    jl_returnnode_type =
+        jl_new_datatype(jl_symbol("ReturnNode"), core, jl_any_type, jl_emptysvec,
+                        jl_perm_symsvec(1, "val"),
+                        jl_svec(1, jl_any_type), 0, 0, 0);
 
     jl_pinode_type =
         jl_new_datatype(jl_symbol("PiNode"), core, jl_any_type, jl_emptysvec,
@@ -2488,13 +2505,6 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_compute_field_offsets(jl_uniontype_type);
     jl_compute_field_offsets(jl_tvar_type);
     jl_compute_field_offsets(jl_methtable_type);
-    jl_compute_field_offsets(jl_expr_type);
-    jl_compute_field_offsets(jl_linenumbernode_type);
-    jl_compute_field_offsets(jl_lineinfonode_type);
-    jl_compute_field_offsets(jl_gotonode_type);
-    jl_compute_field_offsets(jl_quotenode_type);
-    jl_compute_field_offsets(jl_pinode_type);
-    jl_compute_field_offsets(jl_phinode_type);
     jl_compute_field_offsets(jl_module_type);
     jl_compute_field_offsets(jl_method_instance_type);
     jl_compute_field_offsets(jl_code_instance_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -572,6 +572,7 @@ extern JL_DLLEXPORT jl_datatype_t *jl_ssavalue_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_abstractslot_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_slotnumber_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_typedslot_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_simplevector_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_tuple_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_vecelement_typename JL_GLOBALLY_ROOTED;
@@ -652,6 +653,8 @@ extern JL_DLLEXPORT jl_datatype_t *jl_expr_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_globalref_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_linenumbernode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_gotonode_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_gotoifnot_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_returnnode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_phinode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_pinode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_phicnode_type JL_GLOBALLY_ROOTED;
@@ -917,9 +920,12 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x) JL_NOTSAFEPO
 #define jl_slot_number(x) (((intptr_t*)(x))[0])
 #define jl_typedslot_get_type(x) (((jl_value_t**)(x))[1])
 #define jl_gotonode_label(x) (((intptr_t*)(x))[0])
+#define jl_gotoifnot_cond(x) (((jl_value_t**)(x))[0])
+#define jl_gotoifnot_label(x) (((intptr_t*)(x))[1])
 #define jl_globalref_mod(s) (*(jl_module_t**)(s))
 #define jl_globalref_name(s) (((jl_sym_t**)(s))[1])
 #define jl_quotenode_value(x) (((jl_value_t**)x)[0])
+#define jl_returnnode_value(x) (((jl_value_t**)x)[0])
 
 #define jl_nparams(t)  jl_svec_len(((jl_datatype_t*)(t))->parameters)
 #define jl_tparam0(t)  jl_svecref(((jl_datatype_t*)(t))->parameters, 0)
@@ -1072,6 +1078,9 @@ static inline int jl_is_layout_opaque(const jl_datatype_layout_t *l) JL_NOTSAFEP
 #define jl_is_expr(v)        jl_typeis(v,jl_expr_type)
 #define jl_is_globalref(v)   jl_typeis(v,jl_globalref_type)
 #define jl_is_gotonode(v)    jl_typeis(v,jl_gotonode_type)
+#define jl_is_gotoifnot(v)   jl_typeis(v,jl_gotoifnot_type)
+#define jl_is_returnnode(v)  jl_typeis(v,jl_returnnode_type)
+#define jl_is_argument(v)    jl_typeis(v,jl_argument_type)
 #define jl_is_pinode(v)      jl_typeis(v,jl_pinode_type)
 #define jl_is_phinode(v)     jl_typeis(v,jl_phinode_type)
 #define jl_is_phicnode(v)    jl_typeis(v,jl_phicnode_type)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1141,7 +1141,7 @@ extern jl_sym_t *export_sym;  extern jl_sym_t *import_sym;
 extern jl_sym_t *toplevel_sym; extern jl_sym_t *quote_sym;
 extern jl_sym_t *line_sym;    extern jl_sym_t *jl_incomplete_sym;
 extern jl_sym_t *goto_sym;    extern jl_sym_t *goto_ifnot_sym;
-extern jl_sym_t *return_sym;  extern jl_sym_t *unreachable_sym;
+extern jl_sym_t *return_sym;
 extern jl_sym_t *lambda_sym;  extern jl_sym_t *assign_sym;
 extern jl_sym_t *globalref_sym; extern jl_sym_t *do_sym;
 extern jl_sym_t *method_sym;  extern jl_sym_t *core_sym;

--- a/src/method.c
+++ b/src/method.c
@@ -28,6 +28,23 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
             return expr;
         return jl_module_globalref(module, (jl_sym_t*)expr);
     }
+    else if (jl_is_returnnode(expr)) {
+        jl_value_t *val = resolve_globals(jl_returnnode_value(expr), module, sparam_vals, binding_effects, eager_resolve);
+        JL_GC_PUSH1(&val);
+        expr = jl_new_struct(jl_returnnode_type, val);
+        JL_GC_POP();
+        return expr;
+    }
+    else if (jl_is_gotoifnot(expr)) {
+        jl_value_t *cond = resolve_globals(jl_gotoifnot_cond(expr), module, sparam_vals, binding_effects, eager_resolve);
+        intptr_t label = jl_gotoifnot_label(expr);
+        JL_GC_PUSH1(&cond);
+        expr = jl_new_struct_uninit(jl_gotoifnot_type);
+        set_nth_field(jl_gotoifnot_type, expr, 0, cond);
+        jl_gotoifnot_label(expr) = label;
+        JL_GC_POP();
+        return expr;
+    }
     else if (jl_is_expr(expr)) {
         jl_expr_t *e = (jl_expr_t*)expr;
         if (e->head == global_sym && binding_effects) {
@@ -244,6 +261,9 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
                 bd[j] = jl_nothing;
             else
                 jl_array_del_end(meta, na - ins);
+        }
+        else if (jl_is_expr(st) && ((jl_expr_t*)st)->head == return_sym) {
+            jl_array_ptr_set(body, j, jl_new_struct(jl_returnnode_type, jl_exprarg(st, 0)));
         }
     }
     jl_array_t *vinfo = (jl_array_t*)jl_exprarg(ir, 1);
@@ -513,7 +533,7 @@ static void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
                 size_t j;
                 for (j = 1; j < nargs; j++) {
                     jl_value_t *aj = jl_exprarg(st, j);
-                    if (!jl_is_slot(aj))
+                    if (!jl_is_slot(aj) && !jl_is_argument(aj))
                         continue;
                     int sn = (int)jl_slot_number(aj) - 2;
                     if (sn < 0) // @nospecialize on self is valid but currently ignored

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -59,8 +59,11 @@ extern "C" {
 #define TAG_GOTONODE           51
 #define TAG_QUOTENODE          52
 #define TAG_GENERAL            53
+#define TAG_GOTOIFNOT          54
+#define TAG_RETURNNODE         55
+#define TAG_ARGUMENT           56
 
-#define LAST_TAG 53
+#define LAST_TAG 56
 
 #define write_uint8(s, n) ios_putc((n), (s))
 #define read_uint8(s) ((uint8_t)ios_getc(s))

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -39,7 +39,7 @@ static void *const _tags[] = {
          &jl_expr_type, &jl_globalref_type, &jl_string_type,
          &jl_module_type, &jl_tvar_type, &jl_method_instance_type, &jl_method_type, &jl_code_instance_type,
          &jl_linenumbernode_type, &jl_lineinfonode_type,
-         &jl_gotonode_type, &jl_quotenode_type,
+         &jl_gotonode_type, &jl_quotenode_type, &jl_gotoifnot_type, &jl_argument_type, &jl_returnnode_type,
          &jl_pinode_type, &jl_phinode_type, &jl_phicnode_type, &jl_upsilonnode_type,
          &jl_type_type, &jl_bottom_type, &jl_ref_type, &jl_pointer_type, &jl_llvmpointer_type,
          &jl_vararg_type, &jl_abstractarray_type,

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -395,11 +395,9 @@ static void body_attributes(jl_array_t *body, int *has_intrinsics, int *has_defs
                 if (jl_gotonode_label(stmt) <= i)
                     *has_loops = 1;
             }
-            else if (jl_is_expr(stmt)) {
-                if (((jl_expr_t*)stmt)->head == goto_ifnot_sym) {
-                    if (jl_unbox_long(jl_exprarg(stmt,1)) <= i)
-                        *has_loops = 1;
-                }
+            else if (jl_is_gotoifnot(stmt)) {
+                if (jl_gotoifnot_label(stmt) <= i)
+                    *has_loops = 1;
             }
         }
         expr_attributes(stmt, has_intrinsics, has_defs);

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -276,7 +276,7 @@ let m = which(f_broken_code, ())
    let src = Base.uncompressed_ast(m)
        src.code = Any[
            Expr(:meta, :noinline)
-           Expr(:return, Expr(:invalid))
+           Core.ReturnNode(Expr(:invalid))
        ]
        m.source = src
    end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -2,6 +2,7 @@
 
 using Test
 using Base.Meta
+using Core: ReturnNode
 
 """
 Helper to walk the AST and call a function on every node.
@@ -87,11 +88,11 @@ end
 @inline Base.getindex(v::s21074, i::Integer) = v.x[i]
 @eval f21074() = $(s21074((1,2))).x[1]
 let (src, _) = code_typed(f21074, ())[1]
-    @test src.code[end] == Expr(:return, 1)
+    @test src.code[end] == ReturnNode(1)
 end
 @eval g21074() = $(s21074((1,2)))[1]
 let (src, _) = code_typed(g21074, ())[1]
-    @test src.code[end] == Expr(:return, 1)
+    @test src.code[end] == ReturnNode(1)
 end
 
 # issue #21311
@@ -235,7 +236,7 @@ function f_subtype()
 end
 let code = code_typed(f_subtype, Tuple{})[1][1].code
     @test length(code) == 1
-    @test code[1] == Expr(:return, false)
+    @test code[1] == ReturnNode(false)
 end
 
 # check that pointerref gets deleted if unused
@@ -261,7 +262,7 @@ function foo_apply_apply_type_svec()
     Core.apply_type(A..., B.types...)
 end
 let ci = code_typed(foo_apply_apply_type_svec, Tuple{})[1].first
-    @test length(ci.code) == 1 && ci.code[1] == Expr(:return, NTuple{3, Float32})
+    @test length(ci.code) == 1 && ci.code[1] == ReturnNode(NTuple{3, Float32})
 end
 
 # The that inlining doesn't drop ambiguity errors (#30118)
@@ -277,8 +278,8 @@ f34900(x::Int, y) = x
 f34900(x, y::Int) = y
 f34900(x::Int, y::Int) = invoke(f34900, Tuple{Int, Any}, x, y)
 let ci = code_typed(f34900, Tuple{Int, Int})[1].first
-    @test length(ci.code) == 1 && isexpr(ci.code[1], :return) &&
-        ci.code[1].args[1].id == 2
+    @test length(ci.code) == 1 && isa(ci.code[1], ReturnNode) &&
+        ci.code[1].val.n == 2
 end
 
 @testset "check jl_ir_flag_inlineable for inline macro" begin

--- a/test/compiler/interpreter_exec.jl
+++ b/test/compiler/interpreter_exec.jl
@@ -2,6 +2,7 @@
 
 # tests that interpreter matches codegen
 using Test
+using Core: GotoIfNot, ReturnNode
 
 # test that interpreter correctly handles PhiNodes (#29262)
 let m = Meta.@lower 1 + 1
@@ -12,11 +13,11 @@ let m = Meta.@lower 1 + 1
         QuoteNode(:a),
         QuoteNode(:b),
         GlobalRef(@__MODULE__, :test29262),
-        Expr(:gotoifnot, Core.SSAValue(3), 6),
+        GotoIfNot(Core.SSAValue(3), 6),
         # block 2
         Core.PhiNode(Any[4], Any[Core.SSAValue(1)]),
         Core.PhiNode(Any[4, 5], Any[Core.SSAValue(2), Core.SSAValue(5)]),
-        Expr(:return, Core.SSAValue(6)),
+        ReturnNode(Core.SSAValue(6)),
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = Any[ Any for _ = 1:nstmts ]
@@ -51,12 +52,12 @@ let m = Meta.@lower 1 + 1
         Core.PhiNode(Any[], Any[]), # NULL, NULL
         Core.PhiNode(Any[17, 8], Any[Core.SSAValue(2), Core.SSAValue(8)]), # NULL, :c, [:b]
         Core.PhiNode(Any[], Any[]), # NULL, NULL
-        Expr(:gotoifnot, Core.SSAValue(5), 5),
+        GotoIfNot(Core.SSAValue(5), 5),
         # block 4
-        Expr(:gotoifnot, Core.SSAValue(10), 9),
+        GotoIfNot(Core.SSAValue(10), 9),
         # block 5
         Expr(:call, GlobalRef(Core, :tuple), Core.SSAValue(6), Core.SSAValue(7), Core.SSAValue(8), Core.SSAValue(14)),
-        Expr(:return, Core.SSAValue(18)),
+        ReturnNode(Core.SSAValue(18)),
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = Any[ Any for _ = 1:nstmts ]
@@ -83,7 +84,7 @@ let m = Meta.@lower 1 + 1
         Core.UpsilonNode(),
         Core.UpsilonNode(),
         Core.UpsilonNode(Core.SSAValue(2)),
-        Expr(:gotoifnot, Core.SSAValue(3), 10),
+        GotoIfNot(Core.SSAValue(3), 10),
         # block 4
         Core.UpsilonNode(Core.SSAValue(1)),
         # block 5
@@ -93,7 +94,7 @@ let m = Meta.@lower 1 + 1
         Core.PhiCNode(Any[Core.SSAValue(6)]), # NULL
         Expr(:leave, 1),
         # block 7
-        Expr(:return, Core.SSAValue(11)),
+        ReturnNode(Core.SSAValue(11)),
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = Any[ Any for _ = 1:nstmts ]

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -2,7 +2,7 @@
 
 using Test
 using Base.Meta
-using Core: PhiNode, SSAValue, GotoNode, PiNode, QuoteNode
+using Core: PhiNode, SSAValue, GotoNode, PiNode, QuoteNode, ReturnNode, GotoIfNot
 
 # Tests for domsort
 
@@ -13,20 +13,20 @@ let m = Meta.@lower 1 + 1
     src.code = Any[
         # block 1
         Expr(:call, :opaque),
-        Expr(:gotoifnot, Core.SSAValue(1), 10),
+        GotoIfNot(Core.SSAValue(1), 10),
         # block 2
         Core.PhiNode(Any[8], Any[Core.SSAValue(7)]), # <- This phi must not get replaced by %7
         Core.PhiNode(Any[2, 8], Any[true, false]),
-        Expr(:gotoifnot, Core.SSAValue(1), 7),
+        GotoIfNot(Core.SSAValue(1), 7),
         # block 3
         Expr(:call, :+, Core.SSAValue(3), 1),
         # block 4
         Core.PhiNode(Any[5, 6], Any[0, Core.SSAValue(6)]),
         Expr(:call, >, Core.SSAValue(7), 10),
-        Expr(:gotoifnot, Core.SSAValue(8), 3),
+        GotoIfNot(Core.SSAValue(8), 3),
         # block 5
         Core.PhiNode(Any[2, 8], Any[0, Core.SSAValue(7)]),
-        Expr(:return, Core.SSAValue(10)),
+        ReturnNode(Core.SSAValue(10)),
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = nstmts
@@ -49,11 +49,11 @@ let m = Meta.@lower 1 + 1
     N = 2^15
     for i in 1:2:N
         push!(code, Expr(:call, :opaque))
-        push!(code, Expr(:gotoifnot, Core.SSAValue(i), N+2)) # skip one block
+        push!(code, GotoIfNot(Core.SSAValue(i), N+2)) # skip one block
     end
     # all goto here
     push!(code, Expr(:call, :opaque))
-    push!(code, Expr(:return))
+    push!(code, ReturnNode(nothing))
     src.code = code
 
     nstmts = length(src.code)
@@ -136,7 +136,7 @@ struct FooPartial
     f_partial(x) = new(x, 2).x
 end
 let ci = code_typed(f_partial, Tuple{Float64})[1].first
-    @test length(ci.code) == 1 && isexpr(ci.code[1], :return)
+    @test length(ci.code) == 1 && isa(ci.code[1], ReturnNode)
 end
 
 # A SSAValue after the compaction line
@@ -147,9 +147,9 @@ let m = Meta.@lower 1 + 1
         # block 1
         nothing,
         # block 2
-        PhiNode(Any[1, 7], Any[Core.SlotNumber(2), SSAValue(9)]),
+        PhiNode(Any[1, 7], Any[Core.Argument(2), SSAValue(9)]),
         Expr(:call, isa, SSAValue(2), UnionAll),
-        Expr(:gotoifnot, Core.SSAValue(3), 11),
+        GotoIfNot(Core.SSAValue(3), 11),
         # block 3
         nothing,
         nothing,
@@ -160,7 +160,7 @@ let m = Meta.@lower 1 + 1
                      # the phinode here
         GotoNode(2),
         # block 5
-        Expr(:return, Core.SSAValue(2)),
+        ReturnNode(Core.SSAValue(2)),
     ]
     src.ssavaluetypes = Any[
         Nothing,
@@ -214,7 +214,7 @@ let m = Meta.@lower 1 + 1
         Core.Compiler.GotoNode(5),
         Core.Compiler.GotoNode(6),
         Core.Compiler.GotoNode(7),
-        Expr(:return, 2)
+        ReturnNode(2)
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = nstmts
@@ -235,14 +235,14 @@ let m = Meta.@lower 1 + 1
     src.code = Any[
         Core.Compiler.GotoIfNot(Core.Compiler.Argument(2), 3),
         Core.Compiler.GotoNode(4),
-        Expr(:return, 1),
+        ReturnNode(1),
         Core.Compiler.GotoNode(5),
         Core.Compiler.GotoIfNot(Core.Compiler.Argument(2), 7),
         # This fall through block of the previous GotoIfNot
         # must be moved up along with it, when we merge it
         # into the goto 4 block.
-        Expr(:return, 2),
-        Expr(:return, 3)
+        ReturnNode(2),
+        ReturnNode(3)
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = nstmts

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -5,11 +5,11 @@ const Compiler = Core.Compiler
 
 # TODO: this test is broken
 #let code = Any[
-#        Expr(:gotoifnot, SlotNumber(2), 4),
+#        GotoIfNot(SlotNumber(2), 4),
 #        Expr(:(=), SlotNumber(3), 2),
 #        # Test a SlotNumber as a value of a PhiNode
 #        PhiNode(Any[2,3], Any[1, SlotNumber(3)]),
-#        Expr(:return, SSAValue(3))
+#        ReturnNode(SSAValue(3))
 #    ]
 #
 #    ci = eval(Expr(:new, CodeInfo,

--- a/test/compiler/validation.jl
+++ b/test/compiler/validation.jl
@@ -50,12 +50,12 @@ end
     c.code[1] = Expr(:(=), SlotNumber(2), GotoNode(1))
     c.code[2] = Expr(:(=), SlotNumber(2), LineNumberNode(2))
     i = 2
-    for h in (:gotoifnot, :line, :const, :meta)
+    for h in (:line, :const, :meta)
         c.code[i+=1] = Expr(:(=), SlotNumber(2), Expr(h))
     end
     errors = Core.Compiler.validate_code(c)
-    @test length(errors) == 6
-    @test count(e.kind === Core.Compiler.INVALID_RVALUE for e in errors) == 6
+    @test length(errors) == 5
+    @test count(e.kind === Core.Compiler.INVALID_RVALUE for e in errors) == 5
 end
 
 @testset "INVALID_CALL_ARG" begin
@@ -64,12 +64,12 @@ end
     c.code[2] = Expr(:call, GlobalRef(Base,:-), Expr(:call, GlobalRef(Base,:sin), GotoNode(2)), 3)
     c.code[3] = Expr(:call, LineNumberNode(2))
     i = 3
-    for h in (:gotoifnot, :line, :const, :meta)
+    for h in (:line, :const, :meta)
         c.code[i+=1] = Expr(:call, GlobalRef(@__MODULE__,:f), Expr(h))
     end
     errors = Core.Compiler.validate_code(c)
-    @test length(errors) == 7
-    @test count(e.kind === Core.Compiler.INVALID_CALL_ARG for e in errors) == 7
+    @test length(errors) == 6
+    @test count(e.kind === Core.Compiler.INVALID_CALL_ARG for e in errors) == 6
 end
 
 @testset "EMPTY_SLOTNAMES" begin

--- a/test/core.jl
+++ b/test/core.jl
@@ -7138,7 +7138,7 @@ let code = code_lowered(FieldConvert)[1].code
     @test code[8] == Expr(:call, GlobalRef(Core, :fieldtype), Core.SSAValue(1), 5)
     @test code[9] == Expr(:call, GlobalRef(Base, :convert), Core.SSAValue(8), Core.SlotNumber(6))
     @test code[10] == Expr(:new, Core.SSAValue(1), Core.SSAValue(3), Core.SSAValue(5), Core.SlotNumber(4), Core.SSAValue(7), Core.SSAValue(9))
-    @test code[11] == Expr(:return, Core.SSAValue(10))
+    @test code[11] == Core.ReturnNode(Core.SSAValue(10))
  end
 
 # Issue #32820

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -678,8 +678,8 @@ function count_meta_loc(exprs)
     return push_count
 end
 
-function is_return_ssavalue(ex::Expr)
-    ex.head === :return && isa(ex.args[1], Core.SSAValue)
+function is_return_ssavalue(ex)
+    ex isa Core.ReturnNode && ex.val isa Core.SSAValue
 end
 
 function is_pop_loc(ex::Expr)


### PR DESCRIPTION
These are more efficient representations, and I would like to make the optimizer IR and codegen/inference IR more similar, reducing the amount of conversion needed. Seems to make the compiler a hair faster too.

- Always uses ReturnNode and GotoIfNot within IR (AST/macros unaffected)
- Inference still uses Slots but codegen can understand Argument, removing a conversion step

I also plan to replace `:unreachable` Exprs with `ReturnNode()`. Do we still like the ReturnNode-with-undefined-field approach, or should we add a singleton type for this?
