### PR TITLE
Improve inferrability of stream IO

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -333,8 +333,27 @@ function open(f::Function, args...; kwargs...)
     end
 end
 
-# Generic wrappers around other IO objects
+"""
+    AbstractPipe
+
+`AbstractPipe` is the abstract supertype for IO pipes that provide for communication between processes.
+
+If `pipe isa AbstractPipe`, it must obey the following interface:
+
+- `pipe.in` or `pipe.in_stream`, if present, must be of type `IO` and be used to provide input to the pipe
+- `pipe.out` or `pipe.out_stream`, if present, must be of type `IO` and be used for output from the pipe
+- `pipe.err` or `pipe.err_stream`, if present, must be of type `IO` and be used for writing errors from the pipe
+"""
 abstract type AbstractPipe <: IO end
+
+function getproperty(pipe::AbstractPipe, name::Symbol)
+    if name === :in || name === :in_stream || name === :out || name === :out_stream ||
+       name === :err || name === :err_stream
+        return getfield(pipe, name)::IO
+    end
+    return getfield(pipe, name)
+end
+
 function pipe_reader end
 function pipe_writer end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -340,7 +340,7 @@ getindex(io::IO, key) = throw(KeyError(key))
 get(io::IOContext, key, default) = get(io.dict, key, default)
 get(io::IO, key, default) = default
 
-displaysize(io::IOContext) = haskey(io, :displaysize) ? io[:displaysize] : displaysize(io.io)
+displaysize(io::IOContext) = haskey(io, :displaysize) ? io[:displaysize]::Tuple{Int,Int} : displaysize(io.io)
 
 show_circular(io::IO, @nospecialize(x)) = false
 function show_circular(io::IOContext, @nospecialize(x))

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -378,7 +378,7 @@ function isopen(x::Union{LibuvStream, LibuvServer})
     if x.status == StatusUninit || x.status == StatusInit
         throw(ArgumentError("$x is not initialized"))
     end
-    return x.status::Int != StatusClosed && x.status::Int != StatusEOF
+    return x.status != StatusClosed && x.status != StatusEOF
 end
 
 function check_open(x::Union{LibuvStream, LibuvServer})
@@ -453,7 +453,7 @@ function close(stream::Union{LibuvStream, LibuvServer})
         stream.status = StatusClosing
     elseif isopen(stream) || stream.status == StatusEOF
         should_wait = uv_handle_data(stream) != C_NULL
-        if stream.status::Int != StatusClosing
+        if stream.status != StatusClosing
             ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), stream.handle)
             stream.status = StatusClosing
         end
@@ -468,7 +468,7 @@ function uvfinalize(uv::Union{LibuvStream, LibuvServer})
     iolock_begin()
     if uv.handle != C_NULL
         disassociate_julia_struct(uv.handle) # not going to call the usual close hooks
-        if uv.status::Int != StatusUninit
+        if uv.status != StatusUninit
             close(uv)
         else
             Libc.free(uv.handle)
@@ -582,7 +582,7 @@ function uv_alloc_buf(handle::Ptr{Cvoid}, size::Csize_t, buf::Ptr{Cvoid})
     stream = unsafe_pointer_to_objref(hd)::LibuvStream
 
     local data::Ptr{Cvoid}, newsize::Csize_t
-    if stream.status::Int != StatusActive
+    if stream.status != StatusActive
         data = C_NULL
         newsize = 0
     else
@@ -615,7 +615,7 @@ function uv_readcb(handle::Ptr{Cvoid}, nread::Cssize_t, buf::Ptr{Cvoid})
                     if isa(stream, TTY)
                         stream.status = StatusEOF # libuv called uv_stop_reading already
                         notify(stream.cond)
-                    elseif stream.status::Int != StatusClosing
+                    elseif stream.status != StatusClosing
                         # begin shutdown of the stream
                         ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), stream.handle)
                         stream.status = StatusClosing
@@ -725,7 +725,7 @@ show(io::IO, stream::Pipe) = print(io,
 
 function open_pipe!(p::PipeEndpoint, handle::OS_HANDLE)
     iolock_begin()
-    if p.status::Int != StatusInit
+    if p.status != StatusInit
         error("pipe is already in use or has been closed")
     end
     err = ccall(:uv_pipe_open, Int32, (Ptr{Cvoid}, OS_HANDLE), p.handle, handle)
@@ -1119,7 +1119,7 @@ _fd(x::Union{OS_HANDLE, RawFD}) = x
 
 function _fd(x::Union{LibuvStream, LibuvServer})
     fd = Ref{OS_HANDLE}(INVALID_OS_HANDLE)
-    if x.status::Int != StatusUninit && x.status::Int != StatusClosed
+    if x.status != StatusUninit && x.status != StatusClosed
         err = ccall(:uv_fileno, Int32, (Ptr{Cvoid}, Ptr{OS_HANDLE}), x.handle, fd)
         # handle errors by returning INVALID_OS_HANDLE
     end

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -13,9 +13,67 @@ end
 
 ## types ##
 abstract type IOServer end
+"""
+    LibuvServer
+
+An abstract type for IOServers handled by libuv.
+
+If `server isa LibuvServer`, it must obey the following interface:
+
+- `server.handle` must be a `Ptr{Cvoid}`
+- `server.status` must be an `Int`
+- `server.cond` must be a `GenericCondition`
+"""
 abstract type LibuvServer <: IOServer end
+
+function getproperty(server::LibuvServer, name::Symbol)
+    if name === :handle
+        return getfield(server, :handle)::Ptr{Cvoid}
+    elseif name === :status
+        return getfield(server, :status)::Int
+    elseif name === :cond
+        return getfield(server, :cond)::GenericCondition
+    else
+        return getfield(server, name)
+    end
+end
+
+"""
+    LibuvStream
+
+An abstract type for IO streams handled by libuv.
+
+If`stream isa LibuvStream`, it must obey the following interface:
+
+- `stream.handle`, if present, must be a `Ptr{Cvoid}`
+- `stream.status`, if present, must be an `Int`
+- `stream.buffer`, if present, must be an `IOBuffer`
+- `stream.sendbuf`, if present, must be a `Union{Nothing,IOBuffer}`
+- `stream.cond`, if present, must be a `GenericCondition`
+- `stream.lock`, if present, must be an `AbstractLock`
+- `stream.throttle`, if present, must be an `Int`
+"""
 abstract type LibuvStream <: IO end
 
+function getproperty(stream::LibuvStream, name::Symbol)
+    if name === :handle
+        return getfield(stream, :handle)::Ptr{Cvoid}
+    elseif name === :status
+        return getfield(stream, :status)::Int
+    elseif name === :buffer
+        return getfield(stream, :buffer)::IOBuffer
+    elseif name === :sendbuf
+        return getfield(stream, :sendbuf)::Union{Nothing,IOBuffer}
+    elseif name === :cond
+        return getfield(stream, :cond)::GenericCondition
+    elseif name === :lock
+        return getfield(stream, :lock)::AbstractLock
+    elseif name === :throttle
+        return getfield(stream, :throttle)::Int
+    else
+        return getfield(stream, name)
+    end
+end
 
 # IO
 # +- GenericIOBuffer{T<:AbstractArray{UInt8,1}} (not exported)


### PR DESCRIPTION
A lot of IO subtypes wrap other IO objects, and the field type declaration is typically abstract (e.g., `::IO` or `::LibuvStream`). This leads to widespread inference problems, because it's not possible for inference to know what `io.io.status` will return, even if it knows that `io.io::LibuvStream`.

To fix this, this PR defines a formal interface for three abstract types (`LibuvStream`, `LibuvServer`, and `AbstractPipe`) by specializing `getproperty` for them and adding name-specific type assertions. Since these types are unexported, it should not be considered a breaking change to specify that certain fields must have certain types.

This change makes most functions in `base/stream.jl` pretty well-inferred, which is a substantial change from where we are now.