### PR TITLE
fix 1d/2d array method error message with unsupported keyword arg

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -316,7 +316,7 @@ function showerror(io::IO, ex::MethodError)
             hasrows |= isrow
             push!(vec_args, isrow ? vec(arg) : arg)
         end
-        if hasrows && applicable(f, vec_args...)
+        if hasrows && applicable(f, vec_args...) && isempty(kwargs)
             print(io, "\n\nYou might have used a 2d row vector where a 1d column vector was required.",
                       "\nNote the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].",
                       "\nYou can convert to a column vector with the vec() function.")

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -753,7 +753,7 @@ end
 # 1d/2d error shouldn't appear in unsupported keywords arg #36325
 let err = nothing
     try
-        identity([1,1]; bad_kwards = :julia)
+        identity([1 1]; bad_kwards = :julia)
     catch err
         err_str = sprint(showerror, err)
         @test !occursin("2d", err_str)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -750,3 +750,12 @@ end
     @test contains(bt_str, "@ $m.B.C")
     @test contains(bt_str, "@ $m.B.D")
 end
+# 1d/2d error shouldn't appear in unsupported keywords arg #36325
+let err = nothing
+    try
+        identity([1,1]; bad_kwards = :julia)
+    catch err
+        err_str = sprint(showerror, err)
+        @test !occursin("2d", err_str)
+    end
+end


### PR DESCRIPTION
based on #36321