### PR TITLE
Add Release Notes back to the html version of the documentation

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -155,15 +155,17 @@ const PAGES = [
     "Manual" => ["index.md", Manual...],
     "Base" => BaseDocs,
     "Standard Library" => StdlibDocs,
-    "Developer Documentation" => DevDocs
+    "Developer Documentation" => DevDocs,
+    hide("NEWS.md"),
 ]
 else
 const PAGES = [
     "Julia Documentation" => "index.md",
+    hide("NEWS.md"),
     "Manual" => Manual,
     "Base" => BaseDocs,
     "Standard Library" => StdlibDocs,
-    "Developer Documentation" => DevDocs
+    "Developer Documentation" => DevDocs,
 ]
 end
 


### PR DESCRIPTION
Adding them back to the PDF version as well, but now they are at the end rather than in the beginning.