### PR TITLE
change intersect order to reduce time

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -169,9 +169,9 @@ end
 intersect(s) = union(s)
 function intersect(s::AbstractSet, itr)
     if haslength(itr) && hasfastin(itr) && length(s) < length(itr)
-        return mapfilter(_in(itr), push!, s, emptymutable(s))
+        return mapfilter(∈(itr), push!, s, emptymutable(s))
     else
-        return mapfilter(_in(s), push!, itr, emptymutable(s))
+        return mapfilter(∈(s), push!, itr, emptymutable(s))
     end
 end
 

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -149,7 +149,8 @@ function intersect(s::AbstractSet, itr, itrs...)
     # determine if swap order is useful and viable
     if length(s)>50 && haslength(itr) && all(map(haslength, itrs))
         itrs_lengths = map(length, itrs)
-        min_length = minimum(itrs_lengths)
+        min_idx = argmin(itrs_lengths)
+        min_length = itrs_lengths[min_idx]
         # do nothing if s is longer than the rest or itr is already the shortest
         if length(itr) > min_length >= length(s)
             min_idx = argmin(itrs_lengths)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -153,7 +153,7 @@ function intersect(s::AbstractSet, itr, itrs...)
         min_length = itrs_lengths[min_idx]
         # do nothing if s is longer than the rest or itr is already the shortest
         if length(itr) > min_length >= length(s)
-            new_itrs = (itrs[1:min_idx-1]..., itr, itrs[min_idx+1:end]...)
+            new_itrs = setindex(itrs, itr, min_idx)
             return intersect(s, itrs[min_idx], new_itrs...)
         end
     end

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -11,30 +11,36 @@ copy!(dst::AbstractSet, src::AbstractSet) = union!(empty!(dst), src)
     union(s, itrs...)
     ∪(s, itrs...)
 
-Construct the union of sets. Maintain order with arrays.
+Construct an object containing all distinct elements from all of the arguments.
 
-See also: [`intersect`](@ref), [`isdisjoint`](@ref), [`vcat`](@ref), [`Iterators.flatten`](@ref).
+The first argument controls what kind of container is returned.
+If this is an array, it maintains the order in which elements first appear.
+
+Unicode `∪` can be typed by writing `\\cup` then pressing tab in the Julia REPL, and in many editors.
+This is an infix operator, allowing `s ∪ itr`.
+
+See also [`unique`](@ref), [`intersect`](@ref), [`isdisjoint`](@ref), [`vcat`](@ref), [`Iterators.flatten`](@ref).
 
 # Examples
 ```jldoctest
-julia> union([1, 2], [3, 4])
-4-element Vector{Int64}:
+julia> union([1, 2], [3])
+3-element Vector{Int64}:
  1
  2
  3
- 4
 
-julia> union([1, 2], [2, 4])
-3-element Vector{Int64}:
- 1
- 2
- 4
+julia> union([4 2 3 4 4], 1:3, 3.0)
+4-element Vector{Float64}:
+ 4.0
+ 2.0
+ 3.0
+ 1.0
 
-julia> union([4, 2], 1:2)
-3-element Vector{Int64}:
- 4
- 2
- 1
+julia> (0, 0.0) ∪ (-0.0, NaN)
+3-element Vector{Real}:
+   0
+  -0.0
+ NaN
 
 julia> union(Set([1, 2]), 2:3)
 Set{Int64} with 3 elements:
@@ -53,14 +59,14 @@ const ∪ = union
 """
     union!(s::Union{AbstractSet,AbstractVector}, itrs...)
 
-Construct the union of passed in sets and overwrite `s` with the result.
+Construct the [`union`](@ref) of passed in sets and overwrite `s` with the result.
 Maintain order with arrays.
 
 # Examples
 ```jldoctest
-julia> a = Set([1, 3, 4, 5]);
+julia> a = Set([3, 4, 5]);
 
-julia> union!(a, 1:2:8);
+julia> union!(a, 1:2:7);
 
 julia> a
 Set{Int64} with 5 elements:
@@ -102,10 +108,15 @@ end
     intersect(s, itrs...)
     ∩(s, itrs...)
 
-Construct the intersection of sets.
-Maintain order with arrays.
+Construct the set containing those elements which appear in all of the arguments.
 
-See also: [`setdiff`](@ref), [`isdisjoint`](@ref), [`issubset`](@ref Base.issubset), [`issetequal`](@ref).
+The first argument controls what kind of container is returned.
+If this is an array, it maintains the order in which elements first appear.
+
+Unicode `∩` can be typed by writing `\\cap` then pressing tab in the Julia REPL, and in many editors.
+This is an infix operator, allowing `s ∩ itr`.
+
+See also [`setdiff`](@ref), [`isdisjoint`](@ref), [`issubset`](@ref Base.issubset), [`issetequal`](@ref).
 
 !!! compat "Julia 1.8"
     As of Julia 1.8 intersect returns a result with the eltype of the
@@ -117,14 +128,21 @@ julia> intersect([1, 2, 3], [3, 4, 5])
 1-element Vector{Int64}:
  3
 
-julia> intersect([1, 4, 4, 5, 6], [4, 6, 6, 7, 8])
+julia> intersect([1, 4, 4, 5, 6], [6, 4, 6, 7, 8])
 2-element Vector{Int64}:
  4
  6
 
-julia> intersect(Set([1, 2]), BitSet([2, 3]))
-Set{Int64} with 1 element:
-  2
+julia> intersect(1:16, 7:99)
+7:16
+
+julia> (0, 0.0) ∩ (-0.0, 0)
+1-element Vector{Real}:
+ 0
+
+julia> intersect(Set([1, 2]), BitSet([2, 3]), 1.0:10.0)
+Set{Float64} with 1 element:
+  2.0
 ```
 """
 function intersect(s::AbstractSet, itr, itrs...)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -156,13 +156,11 @@ function intersect(s::AbstractSet, itr, itrs...)
     return intersect!(out, itrs...)
 end
 intersect(s) = union(s)
-function intersect(s::AbstractSet, itr) 
-    if haslength(itr) && hasfastin(itr)
-        if length(s) > length(itr) 
-            return mapfilter(_in(s), push!, itr, emptymutable(s)) 
-        else
-            return mapfilter(_in(itr), push!, s, emptymutable(s))
-        end
+function intersect(s::AbstractSet, itr)
+    if haslength(itr) && hasfastin(itr) && length(s) < length(itr)
+        return mapfilter(_in(itr), push!, s, emptymutable(s))
+    else
+        return mapfilter(_in(s), push!, itr, emptymutable(s))
     end
 end
 

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -147,10 +147,11 @@ Set{Float64} with 1 element:
 """
 function intersect(s::AbstractSet, itr, itrs...)
     # determine if swap order is useful and viable
-    if haslength(itr) && all(haslength, itrs)
+    if length(s)>50 && haslength(itr) && all(haslength.(itrs))
         itrs_lengths = length.(itrs)
-        # do nothing if itr is already the shortest
-        if length(itr) > minimum(itrs_lengths)
+        min_length = minimum(itrs_lengths)
+        # do nothing if s is longer than the rest or itr is already the shortest
+        if length(itr) > min_length >= length(s)
             min_idx = argmin(itrs_lengths)
             new_itrs = (itrs[1:min_idx-1]..., itr, itrs[min_idx+1:end]...)
             return intersect(s, itrs[min_idx], new_itrs...)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -153,7 +153,6 @@ function intersect(s::AbstractSet, itr, itrs...)
         min_length = itrs_lengths[min_idx]
         # do nothing if s is longer than the rest or itr is already the shortest
         if length(itr) > min_length >= length(s)
-            min_idx = argmin(itrs_lengths)
             new_itrs = (itrs[1:min_idx-1]..., itr, itrs[min_idx+1:end]...)
             return intersect(s, itrs[min_idx], new_itrs...)
         end

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -147,7 +147,7 @@ Set{Float64} with 1 element:
 """
 function intersect(s::AbstractSet, itr, itrs...)
     # determine if swap order is useful and viable
-    if length(s)>50 && haslength(itr) && all(haslength.(itrs))
+    if length(s)>50 && haslength(itr) && all(map(haslength, itrs))
         itrs_lengths = length.(itrs)
         min_length = minimum(itrs_lengths)
         # do nothing if s is longer than the rest or itr is already the shortest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -146,6 +146,16 @@ Set{Float64} with 1 element:
 ```
 """
 function intersect(s::AbstractSet, itr, itrs...)
+    # determine if swap order is useful and viable
+    if haslength(itr) && all(haslength, itrs)
+        itrs_lengths = length.(itrs)
+        # do nothing if itr is already the shortest
+        if length(itr) > minimum(itrs_lengths)
+            min_idx = argmin(itrs_lengths)
+            new_itrs = (itrs[1:min_idx-1]..., itr, itrs[min_idx+1:end]...)
+            return intersect(s, itrs[min_idx], new_itrs...)
+        end
+    end
     T = promote_eltype(s, itr, itrs...)
     if T == promote_eltype(s, itr)
         out = intersect(s, itr)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -146,10 +146,9 @@ Set{Float64} with 1 element:
 ```
 """
 function intersect(s::AbstractSet, itr, itrs...)
+    # heuristics to try to `intersect` with the shortest Set on the left
     if length(s)>50 && haslength(itr) && all(haslength, itrs)
-        itrs_lengths = map(length, itrs)
-        min_idx = argmin(itrs_lengths)
-        min_length = itrs_lengths[min_idx]
+        min_length, min_idx = findmin(length, itrs)
         if length(itr) > min_length
             new_itrs = setindex(itrs, itr, min_idx)
             return intersect(s, itrs[min_idx], new_itrs...)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -156,7 +156,15 @@ function intersect(s::AbstractSet, itr, itrs...)
     return intersect!(out, itrs...)
 end
 intersect(s) = union(s)
-intersect(s::AbstractSet, itr) = mapfilter(in(s), push!, itr, emptymutable(s, promote_eltype(s, itr)))
+function intersect(s::AbstractSet, itr) 
+    if haslength(itr) && hasfastin(itr)
+        if length(s) > length(itr) 
+            return mapfilter(_in(s), push!, itr, emptymutable(s)) 
+        else
+            return mapfilter(_in(itr), push!, s, emptymutable(s))
+        end
+    end
+end
 
 const ∩ = intersect
 

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -148,7 +148,7 @@ Set{Float64} with 1 element:
 function intersect(s::AbstractSet, itr, itrs...)
     # determine if swap order is useful and viable
     if length(s)>50 && haslength(itr) && all(map(haslength, itrs))
-        itrs_lengths = length.(itrs)
+        itrs_lengths = map(length, itrs)
         min_length = minimum(itrs_lengths)
         # do nothing if s is longer than the rest or itr is already the shortest
         if length(itr) > min_length >= length(s)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -147,7 +147,7 @@ Set{Float64} with 1 element:
 """
 function intersect(s::AbstractSet, itr, itrs...)
     # determine if swap order is useful and viable
-    if length(s)>50 && haslength(itr) && all(map(haslength, itrs))
+    if length(s)>50 && haslength(itr) && all(haslength, itrs)
         itrs_lengths = map(length, itrs)
         min_idx = argmin(itrs_lengths)
         min_length = itrs_lengths[min_idx]

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -242,8 +242,9 @@ end
         s = S([1,2]) ∩ S([3,4])
         @test s == S()
         s = intersect(S([5,6,7,8]), S([7,8,9]))
+        slong = S(collect(3:63))
         # test #36339 length/order short-cut
-        @test s == intersect(S([7,8,9]), S([5,6,7,8]))
+        @test intersect(S([5,6,7,8]), slong) == intersect(slong, S([5,6,7,8]))
         @test s == S([7,8])
         @test intersect(S([2,3,1]), S([4,2,3]), S([5,4,3,2])) == S([2,3])
         let s1 = S([1,2,3])

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -242,6 +242,8 @@ end
         s = S([1,2]) ∩ S([3,4])
         @test s == S()
         s = intersect(S([5,6,7,8]), S([7,8,9]))
+        # test #36339 length/order short-cut
+        @test s == intersect(S([7,8,9]), S([5,6,7,8]))
         @test s == S([7,8])
         @test intersect(S([2,3,1]), S([4,2,3]), S([5,4,3,2])) == S([2,3])
         let s1 = S([1,2,3])


### PR DESCRIPTION
based on #36335

Before:
```
julia> @btime intersect($t, $s);
  42.603 μs (17 allocations: 49.56 KiB)

julia> @btime intersect($s, $t);
  317.603 μs (17 allocations: 49.56 KiB)
```

After:
```
julia> @btime intersect($t, $s);
  53.400 μs (17 allocations: 49.56 KiB)

julia> @btime intersect($s, $t);
  53.687 μs (17 allocations: 49.56 KiB)
```