### PR TITLE
Fix Ctrl+Q for stack traces

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -538,15 +538,6 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
     end
 end
 
-function show_trace_entry(io, frame, n; prefix = "")
-    if haskey(io, :last_shown_line_infos)
-        push!(io[:last_shown_line_infos], (string(frame.file), frame.line))
-    end
-    print(io, "\n", prefix)
-    show(io, frame, full_path=true)
-    n > 1 && print(io, " (repeats ", n, " times)")
-end
-
 # In case the line numbers in the source code have changed since the code was compiled,
 # allow packages to set a callback function that corrects them.
 # (Used by Revise and perhaps other packages.)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -759,7 +759,7 @@ end
 
 function show_backtrace(io::IO, t::Vector)
     if haskey(io, :last_shown_line_infos)
-        resize!(io[:last_shown_line_infos], 0)
+        empty!(io[:last_shown_line_infos])
     end
 
     # t is a pre-processed backtrace (ref #12856)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -708,8 +708,8 @@ function print_stackframe(io, i, frame, n, digit_align_width, modulecolor)
 
     # Used by the REPL to make it possible to open
     # the location of a stackframe/method in the editor.
-    if haskey(io, :LAST_SHOWN_LINE_INFOS)
-        push!(io[:LAST_SHOWN_LINE_INFOS], (string(frame.file), frame.line))
+    if haskey(io, :last_shown_line_infos)
+        push!(io[:last_shown_line_infos], (string(frame.file), frame.line))
     end
 
     inlined = getfield(frame, :inlined)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -538,6 +538,15 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
     end
 end
 
+function show_trace_entry(io, frame, n; prefix = "")
+    if haskey(io, :last_shown_line_infos)
+        push!(io[:last_shown_line_infos], (string(frame.file), frame.line))
+    end
+    print(io, "\n", prefix)
+    show(io, frame, full_path=true)
+    n > 1 && print(io, " (repeats ", n, " times)")
+end
+
 # In case the line numbers in the source code have changed since the code was compiled,
 # allow packages to set a callback function that corrects them.
 # (Used by Revise and perhaps other packages.)
@@ -749,8 +758,8 @@ end
 
 
 function show_backtrace(io::IO, t::Vector)
-    if haskey(io, :LAST_SHOWN_LINE_INFOS)
-        resize!(io[:LAST_SHOWN_LINE_INFOS], 0)
+    if haskey(io, :last_shown_line_infos)
+        resize!(io[:last_shown_line_infos], 0)
     end
 
     # t is a pre-processed backtrace (ref #12856)

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -240,9 +240,9 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
     end
     n = rest = 0
     local last
-    LAST_SHOWN_LINE_INFOS = get(io, :LAST_SHOWN_LINE_INFOS, Tuple{String,Int}[])
+    last_shown_line_infos = get(io, :last_shown_line_infos, Tuple{String,Int}[])
 
-    resize!(LAST_SHOWN_LINE_INFOS, 0)
+    resize!(last_shown_line_infos, 0)
     for meth in ms
         if max==-1 || n<max
             n += 1
@@ -250,7 +250,7 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
             print(io, "[$n] ")
             show(io, meth)
             file, line = updated_methodloc(meth)
-            push!(LAST_SHOWN_LINE_INFOS, (string(file), line))
+            push!(last_shown_line_infos, (string(file), line))
         else
             rest += 1
             last = meth
@@ -374,8 +374,8 @@ show(io::IO, mime::MIME"text/html", mt::Core.MethodTable) = show(io, mime, Metho
 
 # pretty-printing of AbstractVector{Method}
 function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
-    LAST_SHOWN_LINE_INFOS = get(io, :LAST_SHOWN_LINE_INFOS, Tuple{String,Int}[])
-    resize!(LAST_SHOWN_LINE_INFOS, 0)
+    last_shown_line_infos = get(io, :last_shown_line_infos, Tuple{String,Int}[])
+    resize!(last_shown_line_infos, 0)
     first = true
     for (i, m) in enumerate(mt)
         first || println(io)
@@ -383,7 +383,7 @@ function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
         print(io, "[$(i)] ")
         show(io, m)
         file, line = updated_methodloc(m)
-        push!(LAST_SHOWN_LINE_INFOS, (string(file), line))
+        push!(last_shown_line_infos, (string(file), line))
     end
 end
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -240,9 +240,10 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
     end
     n = rest = 0
     local last
-    last_shown_line_infos = get(io, :last_shown_line_infos, Tuple{String,Int}[])
 
-    resize!(last_shown_line_infos, 0)
+    last_shown_line_infos = get(io, :last_shown_line_infos, nothing)
+    last_shown_line_infos === nothing || empty!(last_shown_line_infos)
+
     for meth in ms
         if max==-1 || n<max
             n += 1
@@ -250,7 +251,9 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
             print(io, "[$n] ")
             show(io, meth)
             file, line = updated_methodloc(meth)
-            push!(last_shown_line_infos, (string(file), line))
+            if last_shown_line_infos !== nothing
+                push!(last_shown_line_infos, (string(file), line))
+            end
         else
             rest += 1
             last = meth
@@ -374,8 +377,8 @@ show(io::IO, mime::MIME"text/html", mt::Core.MethodTable) = show(io, mime, Metho
 
 # pretty-printing of AbstractVector{Method}
 function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
-    last_shown_line_infos = get(io, :last_shown_line_infos, Tuple{String,Int}[])
-    resize!(last_shown_line_infos, 0)
+    last_shown_line_infos = get(io, :last_shown_line_infos, nothing)
+    last_shown_line_infos === nothing || empty!(last_shown_line_infos)
     first = true
     for (i, m) in enumerate(mt)
         first || println(io)
@@ -383,7 +386,9 @@ function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
         print(io, "[$(i)] ")
         show(io, m)
         file, line = updated_methodloc(m)
-        push!(last_shown_line_infos, (string(file), line))
+        if last_shown_line_infos !== nothing
+            push!(last_shown_line_infos, (string(file), line))
+        end
     end
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -212,21 +212,8 @@ function display(d::REPLDisplay, mime::MIME"text/plain", x)
                    init=IOContext(io, :limit => true, :module => Main))
     end
 
-    infos = Tuple{String,Int}[]
-    io = IOContext(io, :LAST_SHOWN_LINE_INFOS => infos)
-
     show(io, mime, x)
     println(io)
-
-    if !isempty(infos)
-        d.repl.last_shown_line_infos = infos
-        println(
-            io,
-            "\nTo edit a specific method, type the corresponding number into the " *
-            "REPL and press Ctrl+Q",
-        )
-    end
-
     nothing
 end
 display(d::REPLDisplay, x) = display(d, MIME("text/plain"), x)
@@ -234,7 +221,16 @@ display(d::REPLDisplay, x) = display(d, MIME("text/plain"), x)
 function print_response(repl::AbstractREPL, @nospecialize(response), show_value::Bool, have_color::Bool)
     repl.waserror = response[2]
     io = IOContext(outstream(repl), :module => Main)
+
     print_response(io, response, show_value, have_color, specialdisplay(repl))
+
+    if repl isa LineEditREPL && !isempty(repl.last_shown_line_infos)
+        println(
+            io,
+            "\nTo edit a specific method, type the corresponding number into the " *
+            "REPL and press Ctrl+Q",
+        )
+    end
     nothing
 end
 function print_response(errio::IO, @nospecialize(response), show_value::Bool, have_color::Bool, specialdisplay=nothing)
@@ -451,7 +447,11 @@ mutable struct LineEditREPL <: AbstractREPL
         new(t,hascolor,prompt_color,input_color,answer_color,shell_color,help_color,history_file,in_shell,
             in_help,envcolors,false,nothing, Options(), nothing, Tuple{String,Int}[])
 end
-outstream(r::LineEditREPL) = r.t
+function outstream(r::LineEditREPL)
+    linfos = r.last_shown_line_infos
+    empty!(linfos)
+    IOContext(r.t, :LAST_SHOWN_LINE_INFOS => linfos)
+end
 specialdisplay(r::LineEditREPL) = r.specialdisplay
 specialdisplay(r::AbstractREPL) = nothing
 terminal(r::LineEditREPL) = r.t

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -486,7 +486,7 @@ end
 
 with_methodtable_hint(f, repl) = f(outstream(repl))
 function with_methodtable_hint(f, repl::LineEditREPL)
-    io = IOContext(outstream(repl), :LAST_SHOWN_LINE_INFOS => linfos)
+    io = IOContext(outstream(repl), :last_shown_line_infos => linfos)
     f(io)
     if !isempty(linfos)
         repl.last_shown_line_infos = linfos

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -486,6 +486,7 @@ end
 
 with_methodtable_hint(f, repl) = f(outstream(repl))
 function with_methodtable_hint(f, repl::LineEditREPL)
+    linfos = Tuple{String,Int}[]
     io = IOContext(outstream(repl), :last_shown_line_infos => linfos)
     f(io)
     if !isempty(linfos)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1247,13 +1247,12 @@ end
 
 @testset "last shown line infos" begin
     out_stream = IOBuffer()
-    term = REPL.TTYTerminal("dumb", IOBuffer(), out_stream, IOBuffer());
-    repl = REPL.LineEditREPL(term, false);
-    repl.specialdisplay = REPL.REPLDisplay(repl);
+    term = REPL.TTYTerminal("dumb", IOBuffer(), out_stream, IOBuffer())
+    repl = REPL.LineEditREPL(term, false)
+    repl.specialdisplay = REPL.REPLDisplay(repl)
 
     REPL.print_response(repl, (methods(+), false), true, false)
     seekstart(out_stream)
-    #dump(collect(eachline(out_stream)))
     @test count(
         contains(
             "To edit a specific method, type the corresponding number into the REPL and " *
@@ -1261,13 +1260,13 @@ end
         ),
         eachline(out_stream),
     ) == 1
-
     take!(out_stream)
+
     err = ErrorException("Foo")
     bt = try
         @throw_with_linenumbernode(err)()
-    catch e
-        Base.catch_stack
+    catch
+        Base.catch_stack()
     end
 
     repl.backendref = REPL.REPLBackendRef(Channel(1), Channel(1))

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -110,7 +110,7 @@ end
 
 let s = "using REP"
     c, r = test_complete(s)
-    @test count(isequal("REPL"), c) == 1
+    @test count(isequal("REPL"), c) == 2
     # issue #30234
     @test !Base.isbindingresolved(Main, :tanh)
 end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -110,7 +110,7 @@ end
 
 let s = "using REP"
     c, r = test_complete(s)
-    @test count(isequal("REPL"), c) == 2
+    @test count(isequal("REPL"), c) == 1
     # issue #30234
     @test !Base.isbindingresolved(Main, :tanh)
 end


### PR DESCRIPTION
This should be a more general fix than #36341. It currently silently gets stuck while generating precompile statements on my machine, but not sure if that's reproducible.

close #36340