### PR TITLE
Consider terminal emacs in EDITOR_CALLBACKS before graphical

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -58,6 +58,7 @@ Note that many editors are already defined. All of the following commands should
 already work:
 
 - emacs
+- emacsclient
 - vim
 - nvim
 - nano
@@ -113,13 +114,14 @@ function define_default_editors()
     define_editor(r".*") do cmd, path, line
         `$cmd $path`
     end
+    define_editor([r"\bemacs", "gedit", r"\bgvim"]) do cmd, path, line
+        `$cmd +$line $path`
+    end
+    # Must check that emacs not running in -t/-nw before regex match for general emacs
     define_editor([
         "vim", "vi", "nvim", "mvim", "nano",
         r"\bemacs\b.*\s(-nw|--no-window-system)\b",
         r"\bemacsclient\b.\s*-(-?nw|t|-?tty)\b"], wait=true) do cmd, path, line
-        `$cmd +$line $path`
-    end
-    define_editor([r"\bemacs", "gedit", r"\bgvim"]) do cmd, path, line
         `$cmd +$line $path`
     end
     define_editor(["textmate", "mate", "kate"]) do cmd, path, line


### PR DESCRIPTION
Since the regex `r"\bemacs"` matches the cmd `emacs -nw`, the regex
`r"\bemacs\b.*\s(-nw|--no-window-system)\b"` should be considered in the
`EDITOR_CALLBACKS` list before it.

Without this change, when `JULIA_EDITOR="emacs -nw"`, julia tries to
open the editor with `run(...; wait=false)` which causes the error:

    emacs: standard input is not a tty

or for emacsclient:

    emacsclient: could not get terminal name
    emacsclient: error executing alternate editor ""

cc @rfourquet 