### PR TITLE
fix #36230, more efficient lowering of `if` with a chain of `&&`

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -347,9 +347,9 @@ function findmeta_block(exargs, argsmatch=args->true)
     for i = 1:length(exargs)
         a = exargs[i]
         if isa(a, Expr)
-            if (a::Expr).head === :meta && argsmatch((a::Expr).args)
+            if a.head === :meta && argsmatch(a.args)
                 return i, exargs
-            elseif (a::Expr).head === :block
+            elseif a.head === :block
                 idx, exa = findmeta_block(a.args, argsmatch)
                 if idx != 0
                     return idx, exa

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -62,8 +62,9 @@ true
 ```
 """
 isexpr(@nospecialize(ex), head::Symbol) = isa(ex, Expr) && ex.head === head
-isexpr(@nospecialize(ex), heads::Union{Set,Vector,Tuple}) = isa(ex, Expr) && in(ex.head, heads)
-isexpr(@nospecialize(ex), heads, n::Int) = isexpr(ex, heads) && length((ex::Expr).args) == n
+isexpr(@nospecialize(ex), heads) = isa(ex, Expr) && in(ex.head, heads)
+isexpr(@nospecialize(ex), head::Symbol, n::Int) = isa(ex, Expr) && ex.head === head && length(ex.args) == n
+isexpr(@nospecialize(ex), heads, n::Int) = isa(ex, Expr) && in(ex.head, heads) && length(ex.args) == n
 
 """
     Meta.show_sexpr([io::IO,], ex)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2650,3 +2650,13 @@ end
 f(n) = depth(n, 1)
 end
 @test Base.return_types(TestConstPropRecursion.f, (TestConstPropRecursion.Node,)) == Any[Int]
+
+# issue #36230, keeping implications of all conditions in a && chain
+function symcmp36230(vec)
+    a, b = vec[1], vec[2]
+    if isa(a, Symbol) && isa(b, Symbol)
+        return a == b
+    end
+    return false
+end
+@test Base.return_types(symcmp36230, (Vector{Any},)) == Any[Bool]


### PR DESCRIPTION
This lowers `if a && b && ...` to just a series of conditional branches instead of introducing a temporary slot, allowing inference's branch condition propagation to work effectively. Does not fix the `if isexpr(...) && ...` case though; that is really pretty far out of reach for now.

fix #36230