### PR TITLE
Use haslength to check for HasShape and HasLength traits

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -124,8 +124,7 @@ function verify_ntasks(iterable, ntasks)
     end
 
     if ntasks == 0
-        chklen = IteratorSize(iterable)
-        if (chklen isa HasLength) || (chklen isa HasShape)
+        if haslength(iterable)
             ntasks = max(1,min(100, length(iterable)))
         else
             ntasks = 100

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -99,10 +99,7 @@ mutable struct Dict{K,V} <: AbstractDict{K,V}
 end
 function Dict{K,V}(kv) where V where K
     h = Dict{K,V}()
-    chklen = IteratorSize(kv)
-    if (chklen isa HasLength) || (chklen isa HasShape)
-        sizehint!(h, length(kv))
-    end
+    haslength(kv) && sizehint!(h, length(kv))
     for (k,v) in kv
         h[k] = v
     end


### PR DESCRIPTION
@garborg drew my attention to `haslength` in #35254. Here, I tidy up two `HasShape` and `HasLength` trait checks with `haslength`