### PR TITLE
Typo fix: remove space before comma

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -232,7 +232,7 @@ end
     unique!(f, A::AbstractVector)
 
 Selects one value from `A` for each unique value produced by `f` applied to
-elements of `A` , then return the modified A.
+elements of `A`, then return the modified A.
 
 !!! compat "Julia 1.1"
     This method is available as of Julia 1.1.


### PR DESCRIPTION
`grep` gave me another typo similar to https://github.com/JuliaLang/julia/pull/36349