### PR TITLE
Remove address spaces during IR printing.

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -825,14 +825,6 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
         PM = new legacy::PassManager();
         addTargetPasses(PM, jl_TargetMachine);
         addOptimizationPasses(PM, jl_options.opt_level);
-        PM->add(createRemoveJuliaAddrspacesPass());
-    }
-
-    static legacy::PassManager *PM_minimal;
-    if (!PM_minimal) {
-        PM_minimal = new legacy::PassManager();
-        addTargetPasses(PM_minimal, jl_TargetMachine);
-        PM_minimal->add(createRemoveJuliaAddrspacesPass());
     }
 
     // get the source code for this function
@@ -874,8 +866,6 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
             // if compilation succeeded, prepare to return the result
             if (optimize)
                 PM->run(*m.get());
-            else
-                PM_minimal->run(*m.get());
             const std::string *fname;
             if (decls.functionObject == "jl_fptr_args" || decls.functionObject == "jl_fptr_sparam")
                 getwrapper = false;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -17,6 +17,8 @@
 #include <llvm/Target/TargetMachine.h>
 #include "julia_assert.h"
 
+using namespace llvm;
+
 extern "C" {
     extern int globalUnique;
 }


### PR DESCRIPTION
As suggested by @vtjnash:

```llvm
julia> @code_llvm debuginfo=:none [1]

define nonnull %jl_value_t* @julia_vect_845(i64) {
top:
  %1 = call %jl_value_t* inttoptr (i64 139641304421472 to %jl_value_t* (%jl_value_t*, i64)*)(%jl_value_t* inttoptr (i64 139641129450176 to %jl_value_t*), i64 1)
  %2 = bitcast %jl_value_t* %1 to i64**
  %3 = load i64*, i64** %2, align 8
  store i64 %0, i64* %3, align 8
  ret %jl_value_t* %1
}

julia> @code_llvm raw=true debuginfo=:none [1]

define nonnull %jl_value_t addrspace(10)* @julia_vect_912(i64) !dbg !5 {
top:
  %1 = call %jl_value_t addrspace(10)* inttoptr (i64 139641304421472 to %jl_value_t addrspace(10)* (%jl_value_t addrspace(10)*, i64)*)(%jl_value_t addrspace(10)* addrspacecast (%jl_value_t* inttoptr (i64 139641129450176 to %jl_value_t*) to %jl_value_t addrspace(10)*), i64 1), !dbg !7
  %2 = addrspacecast %jl_value_t addrspace(10)* %1 to %jl_value_t addrspace(11)*, !dbg !18
  %3 = bitcast %jl_value_t addrspace(11)* %2 to i64 addrspace(13)* addrspace(11)*, !dbg !18
  %4 = load i64 addrspace(13)*, i64 addrspace(13)* addrspace(11)* %3, align 8, !dbg !18, !tbaa !20, !nonnull !4
  store i64 %0, i64 addrspace(13)* %4, align 8, !dbg !18, !tbaa !25
  ret %jl_value_t addrspace(10)* %1, !dbg !17
}
```
