### PR TITLE
deleteat!(::BitVector, inds) : check bounds for the first passed index

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -967,11 +967,11 @@ function deleteat!(B::BitVector, inds)
     n = new_l = length(B)
     y = iterate(inds)
     y === nothing && return B
-    n == 0 && throw(BoundsError(B, inds))
 
     Bc = B.chunks
 
     (p, s) = y
+    checkbounds(B, p)
     q = p+1
     new_l -= 1
     y = iterate(inds, s)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -666,6 +666,8 @@ timesofar("indexing")
     b1 = bitrand(v1)
     @test_throws ArgumentError deleteat!(b1, [1, 1, 2])
     @test_throws BoundsError deleteat!(b1, [1, length(b1)+1])
+    @test_throws BoundsError deleteat!(b1, [length(b1)+rand(1:100)])
+    @test_throws BoundsError deleteat!(bitrand(1), [-1, 0, 1])
 
     @test_throws BoundsError deleteat!(BitVector(), 1)
     @test_throws BoundsError deleteat!(BitVector(), [1])


### PR DESCRIPTION
Similar to #36231, a discourse post about this method just prompted me to check whether this also needed fixing, it does:
```
julia> deleteat!(trues(1), [2])
0-element BitArray{1}

julia> deleteat!(trues(1), [-1, 0, 1])
0-element BitArray{1}:

julia> deleteat!(trues(1), [-1, 1]) # this one correctly throws for some reason
ERROR: BoundsError: attempt to access 1-element Array{UInt64,1} at index [0]
[...]
```
