### PR TITLE
add BLAS.get_num_threads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@ Standard library changes
 #### LinearAlgebra
 * New method `LinearAlgebra.issuccess(::CholeskyPivoted)` for checking whether pivoted Cholesky factorization was successful ([#36002]).
 * `UniformScaling` can now be indexed into using ranges to return dense matrices and vectors ([#24359]).
+* New function `LinearAlgebra.BLAS.get_num_threads()` for getting the number of BLAS threads. ([#36360])
 
 #### Markdown
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -144,7 +144,7 @@ function get_num_threads()
         s = get(ENV, key, "")
         nt = Base.tryparse(Cint, s)
         if nt === nothing
-            @warn "Failed to read environment variable $key"
+            @warn "Failed to read environment variable $key" maxlog=1
         else
             return nt
         end

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -122,10 +122,26 @@ end
     set_num_threads(::Nothing)
 
 Set the number of threads the BLAS library should use equal to `n::Integer`.
-If `nothing` is passed to this function, julia tries to figure out the optimial number of threads.
-The exact heuristic is an implementation detail.
 
-On exotic variants of `BLAS` this function can fail.
+Also accepts `nothing`, in which case julia tries to guess the default number of threads.
+Passing `nothing` is discouraged and mainly exists for the following reason:
+
+On exotic variants of BLAS, `nothing` may be returned by `get_num_threads()`.
+Thus on exotic variants of BLAS, the following pattern may fail to set the number of threads:
+
+```julia
+old = get_num_threads()
+set_num_threads(1)
+@threads for i in 1:10
+    # single-threaded BLAS calls
+end
+set_num_threads(old)
+```
+Because `set_num_threads` accepts `nothing`, this code can still run
+on exotic variants of BLAS without error. Warnings will be raised instead.
+
+!!! compat "Julia 1.6"
+    `set_num_threads(::Nothing)` requires at least Julia 1.6.
 """
 set_num_threads(n)::Nothing = _set_num_threads(n)
 
@@ -162,6 +178,9 @@ end
 Get the number of threads the BLAS library is using.
 
 On exotic variants of `BLAS` this function can fail, which is indicated by returning `nothing`.
+
+!!! compat "Julia 1.6"
+    `get_num_threads` requires at least Julia 1.6.
 """
 get_num_threads(;_blas=guess_vendor())::Union{Int, Nothing} = _get_num_threads()
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -127,7 +127,9 @@ The exact heuristic is an implementation detail.
 
 On exotic variants of `BLAS` this function can fail.
 """
-function set_num_threads(n::Integer; _blas=guess_vendor())::Nothing
+set_num_threads(n)::Nothing = _set_num_threads(n)
+
+function _set_num_threads(n::Integer; _blas = guess_vendor())
     if _blas === :openblas || _blas == :openblas64
         return ccall((@blasfunc(openblas_set_num_threads), libblas), Cvoid, (Cint,), n)
     elseif _blas === :mkl

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -127,7 +127,7 @@ The exact heuristic is an implementation detail.
 
 On exotic variants of `BLAS` this function can fail.
 """
-function set_num_threads(n::Integer, _blas=guess_vendor())::Nothing
+function set_num_threads(n::Integer; _blas=guess_vendor())::Nothing
     if _blas === :openblas || _blas == :openblas64
         return ccall((@blasfunc(openblas_set_num_threads), libblas), Cvoid, (Cint,), n)
     elseif _blas === :mkl
@@ -145,13 +145,13 @@ end
 
 _tryparse_env_int(key) = tryparse(Int, get(ENV, key, ""))
 
-function set_num_threads(::Nothing, _blas=guess_vendor())
+function set_num_threads(::Nothing; _blas=guess_vendor())
     n = something(
         _tryparse_env_int("OPENBLAS_NUM_THREADS"),
         _tryparse_env_int("OMP_NUM_THREADS"),
         max(1, Sys.CPU_THREADS ÷ 2),
     )
-    set_num_threads(n, _blas)
+    set_num_threads(n; _blas)
 end
 
 """
@@ -161,7 +161,7 @@ Get the number of threads the BLAS library is using.
 
 On exotic variants of `BLAS` this function can fail, which is indicated by returning `nothing`.
 """
-function get_num_threads(_blas=guess_vendor())::Union{Int, Nothing}
+function get_num_threads(;_blas=guess_vendor())::Union{Int, Nothing}
     if _blas === :openblas || _blas === :openblas64
         return Int(ccall((@blasfunc(openblas_get_num_threads), libblas), Cint, ()))
     elseif _blas === :mkl

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -122,7 +122,7 @@ function set_num_threads(n::Integer)
         # OSX BLAS looks at an environment variable
         ENV["VECLIB_MAXIMUM_THREADS"] = n
     else
-        @warn "Failed to set number of BLAS threads."
+        @warn "Failed to set number of BLAS threads." maxlog=1
     end
 
     return nothing

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -163,7 +163,9 @@ Get the number of threads the BLAS library is using.
 
 On exotic variants of `BLAS` this function can fail, which is indicated by returning `nothing`.
 """
-function get_num_threads(;_blas=guess_vendor())::Union{Int, Nothing}
+get_num_threads(;_blas=guess_vendor())::Union{Int, Nothing} = _get_num_threads()
+
+function _get_num_threads(; _blas = guess_vendor())::Union{Int, Nothing}
     if _blas === :openblas || _blas === :openblas64
         return Int(ccall((@blasfunc(openblas_get_num_threads), libblas), Cint, ()))
     elseif _blas === :mkl

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -133,8 +133,14 @@ function set_num_threads(n::Integer)
     return nothing
 end
 
+_tryparse_env_cint(key) = tryparse(Cint, get(ENV, key, ""))
+
 function set_num_threads(::Nothing)
-    n = max(1, Sys.CPU_THREADS ÷ 2)
+    n = something(
+        _tryparse_env_cint("OPENBLAS_NUM_THREADS"),
+        _tryparse_env_cint("OMP_NUM_THREADS"),
+        max(1, Sys.CPU_THREADS ÷ 2),
+    )
     set_num_threads(n)
 end
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -153,7 +153,7 @@ function _set_num_threads(::Nothing; _blas = guess_vendor())
         _tryparse_env_int("OMP_NUM_THREADS"),
         max(1, Sys.CPU_THREADS ÷ 2),
     )
-    set_num_threads(n; _blas)
+    _set_num_threads(n; _blas)
 end
 
 """

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -136,8 +136,8 @@ _tryparse_env_int(key) = tryparse(Int, get(ENV, key, ""))
 
 function set_num_threads(::Nothing)
     n = something(
-        _tryparse_env_cint("OPENBLAS_NUM_THREADS"),
-        _tryparse_env_cint("OMP_NUM_THREADS"),
+        _tryparse_env_int("OPENBLAS_NUM_THREADS"),
+        _tryparse_env_int("OMP_NUM_THREADS"),
         max(1, Sys.CPU_THREADS ÷ 2),
     )
     set_num_threads(n)

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -132,7 +132,7 @@ function set_num_threads(n::Integer)::Nothing
     return nothing
 end
 
-_tryparse_env_cint(key) = tryparse(Cint, get(ENV, key, ""))
+_tryparse_env_int(key) = tryparse(Int, get(ENV, key, ""))
 
 function set_num_threads(::Nothing)
     n = something(

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -147,7 +147,7 @@ end
 
 _tryparse_env_int(key) = tryparse(Int, get(ENV, key, ""))
 
-function set_num_threads(::Nothing; _blas=guess_vendor())
+function _set_num_threads(::Nothing; _blas = guess_vendor())
     n = something(
         _tryparse_env_int("OPENBLAS_NUM_THREADS"),
         _tryparse_env_int("OMP_NUM_THREADS"),

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -110,7 +110,7 @@ function guess_vendor()
     # like determine_vendor, but guesses blas in some cases
     # where determine_vendor returns :unknown
     ret = vendor()
-    if Sys.isapple() && (ret == :unknown )
+    if Sys.isapple() && (ret == :unknown)
         ret = :osxblas
     end
     ret

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -162,7 +162,7 @@ function get_num_threads()
         end
     end
     ret = nothing
-    @warn "Could not get number of BLAS threads. Returning $ret instead." maxlog=1
+    @warn "Could not get number of BLAS threads. Returning `$ret` instead." maxlog=1
     return ret
 end
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -138,7 +138,7 @@ function get_num_threads()
     if blas === :openblas || blas === :openblas64
         return ccall((@blasfunc(openblas_get_num_threads), libblas), Cint, ())
     elseif blas == :mkl
-        return ccall((:MKL_Get_Max_Num_Threads, libblas), Cint, ())
+        return ccall((:mkl_get_max_threads, libblas), Cint, ())
     elseif Sys.isapple()
         return Base.parse(Cint, ENV["VECLIB_MAXIMUM_THREADS"])
     else

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -151,7 +151,7 @@ Get the number of threads the BLAS library is using.
 On exotic variants of `BLAS` this function can fail, which is indicated by returning `nothing`.
 """
 function get_num_threads()::Union{Int, Nothing}
-    blas = LinearAlgebra.BLAS.vendor()
+    blas = vendor()
     if blas === :openblas || blas === :openblas64
         return Int(ccall((@blasfunc(openblas_get_num_threads), libblas), Cint, ()))
     elseif blas == :mkl

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -139,11 +139,11 @@ function get_num_threads()
         return ccall((@blasfunc(openblas_get_num_threads), libblas), Cint, ())
     elseif blas == :mkl
         return ccall((:mkl_get_max_threads, libblas), Cint, ())
-    elseif Sys.isapple()
-        return Base.parse(Cint, ENV["VECLIB_MAXIMUM_THREADS"])
-    else
-        error("Unknown BLAS") # better error? return nothing
     end
+    @static if Sys.isapple()
+        return Base.parse(Cint, ENV["VECLIB_MAXIMUM_THREADS"])
+    end
+    error("Unknown BLAS") # better error? return nothing?
 end
 
 const _testmat = [1.0 0.0; 0.0 -1.0]

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -158,8 +158,7 @@ function get_num_threads()::Union{Int, Nothing}
         return Int(ccall((:mkl_get_max_threads, libblas), Cint, ()))
     elseif Sys.isapple()
         key = "VECLIB_MAXIMUM_THREADS"
-        s = get(ENV, key, "")
-        nt = Base.tryparse(Int, s)
+        nt = _tryparse_env_int(key)
         if nt === nothing
             @warn "Failed to read environment variable $key" maxlog=1
         else

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -149,7 +149,7 @@ function get_num_threads()
             return nt
         end
     end
-    @warn "Could not get number of BLAS threads. Returning Sys.CPU_THREADS instead."
+    @warn "Could not get number of BLAS threads. Returning Sys.CPU_THREADS instead." maxlog=1
     return Sys.CPU_THREADS
 end
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -167,9 +167,8 @@ function get_num_threads()
             return nt
         end
     end
-    ret = nothing
-    @warn "Could not get number of BLAS threads. Returning `$ret` instead." maxlog=1
-    return ret
+    @warn "Could not get number of BLAS threads. Returning `nothing` instead." maxlog=1
+    return nothing
 end
 
 const _testmat = [1.0 0.0; 0.0 -1.0]

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -562,6 +562,7 @@ end
     BLAS.set_num_threads(default)
     @test BLAS.get_num_threads() === default
 
+    @test_logs (:warn,) match_mode=:any BLAS._set_num_threads(1, _blas=:unknown)
     if BLAS.guess_vendor() !== :osxblas
         # test osxblas which is not covered by CI
         withenv() do

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -555,19 +555,19 @@ end
 
 @testset "get_set_num_threads" begin
     default = BLAS.get_num_threads()
-    @test default isa Integer
+    @test default isa Int
     @test default > 0
     BLAS.set_num_threads(1)
-    @test BLAS.get_num_threads() == 1
+    @test BLAS.get_num_threads() === 1
     BLAS.set_num_threads(default)
-    @test BLAS.get_num_threads() == default
+    @test BLAS.get_num_threads() === default
 
     if BLAS.guess_vendor() !== :osxblas
         # test osxblas which is not covered by CI
-        BLAS.set_num_threads(1, :osxblas)
-        @test BLAS.get_num_threads(:osxblas) === 1
-        BLAS.set_num_threads(2, :osxblas)
-        @test BLAS.get_num_threads(:osxblas) === 2
+        BLAS.set_num_threads(1, _blas=:osxblas)
+        @test BLAS.get_num_threads(_blas=:osxblas) === 1
+        BLAS.set_num_threads(2, _blas=:osxblas)
+        @test BLAS.get_num_threads(_blas=:osxblas) === 2
     end
 end
 

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -561,6 +561,14 @@ end
     @test BLAS.get_num_threads() == 1
     BLAS.set_num_threads(default)
     @test BLAS.get_num_threads() == default
+
+    if BLAS.guess_vendor() !== :osxblas
+        # test osxblas which is not covered by CI
+        BLAS.set_num_threads(1, :osxblas)
+        @test BLAS.get_num_threads(:osxblas) === 1
+        BLAS.set_num_threads(2, :osxblas)
+        @test BLAS.get_num_threads(:osxblas) === 2
+    end
 end
 
 end # module TestBLAS

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -553,4 +553,15 @@ Base.stride(A::WrappedArray, i::Int) = stride(A.A, i)
     end
 end
 
+@testset "get_set_num_threads" begin
+    default = BLAS.get_num_threads()
+    @test default isa Integer
+    @test default > 0
+    new = rand(1:10)
+    BLAS.set_num_threads(net)
+    @test BLAS.get_num_threads() == new
+    BLAS.set_num_threads(default)
+    @test BLAS.get_num_threads() == default
+end
+
 end # module TestBLAS

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -558,7 +558,7 @@ end
     @test default isa Integer
     @test default > 0
     new = rand(1:10)
-    BLAS.set_num_threads(net)
+    BLAS.set_num_threads(new)
     @test BLAS.get_num_threads() == new
     BLAS.set_num_threads(default)
     @test BLAS.get_num_threads() == default

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -564,10 +564,22 @@ end
 
     if BLAS.guess_vendor() !== :osxblas
         # test osxblas which is not covered by CI
-        BLAS.set_num_threads(1, _blas=:osxblas)
-        @test BLAS.get_num_threads(_blas=:osxblas) === 1
-        BLAS.set_num_threads(2, _blas=:osxblas)
-        @test BLAS.get_num_threads(_blas=:osxblas) === 2
+        withenv() do
+            @test_logs (:warn,) match_mode=:any BLAS._set_num_threads(1, _blas=:osxblas)
+            @test @test_logs(
+                (:warn,),
+                (:warn,),
+                match_mode=:any,
+                BLAS._get_num_threads(_blas=:osxblas),
+            ) === 1
+            @test_logs (:warn,) match_mode=:any BLAS._set_num_threads(2, _blas=:osxblas)
+            @test @test_logs(
+                (:warn,),
+                (:warn,),
+                match_mode=:any,
+                BLAS._get_num_threads(_blas=:osxblas),
+            ) === 2
+        end
     end
 end
 

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -565,21 +565,17 @@ end
     @test_logs (:warn,) match_mode=:any BLAS._set_num_threads(1, _blas=:unknown)
     if BLAS.guess_vendor() !== :osxblas
         # test osxblas which is not covered by CI
-        withenv() do
-            @test_logs (:warn,) match_mode=:any BLAS._set_num_threads(1, _blas=:osxblas)
+        withenv("VECLIB_MAXIMUM_THREADS" => nothing) do
             @test @test_logs(
                 (:warn,),
                 (:warn,),
                 match_mode=:any,
                 BLAS._get_num_threads(_blas=:osxblas),
-            ) === 1
-            @test_logs (:warn,) match_mode=:any BLAS._set_num_threads(2, _blas=:osxblas)
-            @test @test_logs(
-                (:warn,),
-                (:warn,),
-                match_mode=:any,
-                BLAS._get_num_threads(_blas=:osxblas),
-            ) === 2
+            ) === nothing
+            @test_logs BLAS._set_num_threads(1, _blas=:osxblas)
+            @test @test_logs(BLAS._get_num_threads(_blas=:osxblas)) === 1
+            @test_logs BLAS._set_num_threads(2, _blas=:osxblas)
+            @test @test_logs(BLAS._get_num_threads(_blas=:osxblas)) === 2
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -557,7 +557,7 @@ end
     default = BLAS.get_num_threads()
     @test default isa Integer
     @test default > 0
-    new = rand(1:10)
+    new=rand(1:Sys.CPU_THREADS)
     BLAS.set_num_threads(new)
     @test BLAS.get_num_threads() == new
     BLAS.set_num_threads(default)

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -557,9 +557,8 @@ end
     default = BLAS.get_num_threads()
     @test default isa Integer
     @test default > 0
-    new=rand(1:Sys.CPU_THREADS)
-    BLAS.set_num_threads(new)
-    @test BLAS.get_num_threads() == new
+    BLAS.set_num_threads(1)
+    @test BLAS.get_num_threads() == 1
     BLAS.set_num_threads(default)
     @test BLAS.get_num_threads() == default
 end


### PR DESCRIPTION
From slack, also came up [on discourse](https://discourse.julialang.org/t/how-to-get-number-of-current-blas-threads/32090)