### PR TITLE
hypot scaling constant folding

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -659,7 +659,7 @@ function hypot(x::T, y::T) where T<:AbstractFloat
     end
 
     # Operands do not vary widely
-    scale = eps(sqrt(floatmin(T)))  #Rescaling constant
+    scale = eps(T)*sqrt(floatmin(T))  #Rescaling constant
     if ax > sqrt(floatmax(T)/2)
         ax = ax*scale
         ay = ay*scale


### PR DESCRIPTION
The scaling constant in `hypot` wasn't being constant folded. Partly fixes #36353.