### PR TITLE
Allow single option with REPL.TerminalMenus

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -610,6 +610,7 @@ Aside from the overall `charset` option, for `RadioMenu` the configurable option
  - `cursor::Char='>'|'→'`: character to use for cursor
  - `up_arrow::Char='^'|'↑'`: character to use for up arrow
  - `down_arrow::Char='v'|'↓'`: character to use for down arrow
+ - `updown_arrow::Char='I'|'↕'`: character to use for up/down arrow in one-line page
  - `scroll_wrap::Bool=false`: optionally wrap-around at the beginning/end of a menu
  - `ctrl_c_interrupt::Bool=true`: If `false`, return empty on ^C, if `true` throw InterruptException() on ^C
 

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -256,7 +256,8 @@ end
 function move_down!(m::AbstractMenu, cursor::Int, lastoption::Int=numoptions(m))
     if cursor < lastoption
         cursor += 1 # move selection down
-        if m.pagesize + m.pageoffset <= cursor
+        pagepos = m.pagesize + m.pageoffset
+        if pagepos <= cursor && pagepos < lastoption
             m.pageoffset += 1 # scroll page down
         end
     elseif scroll_wrap(m)

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -369,7 +369,7 @@ down_arrow(c::Config) = c.down_arrow
 down_arrow(::AbstractMenu) = CONFIG[:down_arrow]
 
 updown_arrow(m::ConfiguredMenu) = updown_arrow(m.config)
-updown_arrow(m::AbstractConfig) = updown_arrow(c.config)
+updown_arrow(c::AbstractConfig) = updown_arrow(c.config)
 updown_arrow(c::Config) = c.updown_arrow
 updown_arrow(::AbstractMenu) = CONFIG[:updown_arrow]
 

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -315,9 +315,14 @@ function printmenu(out, m::AbstractMenu, cursoridx::Int; oldstate=nothing, init:
         # clearline
         print(buf, "\x1b[2K")
 
-        if i == firstline && m.pageoffset > 0
+        upscrollable = i == firstline && m.pageoffset > 0
+        downscrollable = i == lastline && i != lastoption
+
+        if upscrollable && downscrollable
+            print_arrow(buf, m, updown_arrow(m))
+        elseif upscrollable
             print_arrow(buf, m, up_arrow(m))
-        elseif i == lastline && i != lastoption
+        elseif downscrollable
             print_arrow(buf, m, down_arrow(m))
         else
             print_arrow(buf, m, ' ')
@@ -362,6 +367,11 @@ down_arrow(m::ConfiguredMenu) = down_arrow(m.config)
 down_arrow(c::AbstractConfig) = down_arrow(c.config)
 down_arrow(c::Config) = c.down_arrow
 down_arrow(::AbstractMenu) = CONFIG[:down_arrow]
+
+updown_arrow(m::ConfiguredMenu) = updown_arrow(m.config)
+updown_arrow(m::AbstractConfig) = updown_arrow(c.config)
+updown_arrow(c::Config) = c.updown_arrow
+updown_arrow(::AbstractMenu) = CONFIG[:updown_arrow]
 
 print_arrow(buf, ::ConfiguredMenu, c::Char) = print(buf, c)
 print_arrow(buf, ::AbstractMenu, c::Char) = print(buf, c)

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -319,13 +319,13 @@ function printmenu(out, m::AbstractMenu, cursoridx::Int; oldstate=nothing, init:
         downscrollable = i == lastline && i != lastoption
 
         if upscrollable && downscrollable
-            print_arrow(buf, m, updown_arrow(m))
+            print(buf, updown_arrow(m))
         elseif upscrollable
-            print_arrow(buf, m, up_arrow(m))
+            print(buf, up_arrow(m))
         elseif downscrollable
-            print_arrow(buf, m, down_arrow(m))
+            print(buf, down_arrow(m))
         else
-            print_arrow(buf, m, ' ')
+            print(buf, ' ')
         end
 
         printcursor(buf, m, i == cursoridx)
@@ -372,9 +372,6 @@ updown_arrow(m::ConfiguredMenu) = updown_arrow(m.config)
 updown_arrow(c::AbstractConfig) = updown_arrow(c.config)
 updown_arrow(c::Config) = c.updown_arrow
 updown_arrow(::AbstractMenu) = CONFIG[:updown_arrow]
-
-print_arrow(buf, ::ConfiguredMenu, c::Char) = print(buf, c)
-print_arrow(buf, ::AbstractMenu, c::Char) = print(buf, c)
 
 printcursor(buf, m::ConfiguredMenu, iscursor::Bool) = print(buf, iscursor ? cursor(m.config) : ' ', ' ')
 cursor(c::AbstractConfig) = cursor(c.config)

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -320,9 +320,10 @@ function printmenu(out, m::AbstractMenu, cursoridx::Int; oldstate=nothing, init:
         elseif i == lastline && i != lastoption
             print_arrow(buf, m, down_arrow(m))
         else
-            printcursor(buf, m, i == cursoridx)
+            print_arrow(buf, m, ' ')
         end
 
+        printcursor(buf, m, i == cursoridx)
         writeline(buf, m, i, i == cursoridx)
 
         (firstline == lastline || i != lastline) && print(buf, "\r\n")
@@ -362,10 +363,10 @@ down_arrow(c::AbstractConfig) = down_arrow(c.config)
 down_arrow(c::Config) = c.down_arrow
 down_arrow(::AbstractMenu) = CONFIG[:down_arrow]
 
-print_arrow(buf, ::ConfiguredMenu, c::Char) = print(buf, c, "  ")
+print_arrow(buf, ::ConfiguredMenu, c::Char) = print(buf, c)
 print_arrow(buf, ::AbstractMenu, c::Char) = print(buf, c)
 
-printcursor(buf, m::ConfiguredMenu, iscursor::Bool) = print(buf, ' ', iscursor ? cursor(m.config) : ' ', ' ')
+printcursor(buf, m::ConfiguredMenu, iscursor::Bool) = print(buf, iscursor ? cursor(m.config) : ' ', ' ')
 cursor(c::AbstractConfig) = cursor(c.config)
 cursor(c::Config) = c.cursor
-printcursor(buf, ::AbstractMenu, ::Bool) = print(buf, ' ')   # `writeLine` is expected to do the printing (get from CONFIG[:cursor])
+printcursor(buf, ::AbstractMenu, ::Bool) = nothing   # `writeLine` is expected to do the printing (get from CONFIG[:cursor])

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -256,7 +256,7 @@ end
 function move_down!(m::AbstractMenu, cursor::Int, lastoption::Int=numoptions(m))
     if cursor < lastoption
         cursor += 1 # move selection down
-        if m.pagesize + m.pageoffset <= cursor < lastoption
+        if m.pagesize + m.pageoffset <= cursor
             m.pageoffset += 1 # scroll page down
         end
     elseif scroll_wrap(m)

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -325,7 +325,7 @@ function printmenu(out, m::AbstractMenu, cursoridx::Int; oldstate=nothing, init:
 
         writeline(buf, m, i, i == cursoridx)
 
-        i != lastline && print(buf, "\r\n")
+        (firstline == lastline || i != lastline) && print(buf, "\r\n")
     end
 
     newstate = lastline-firstline  # final line doesn't have `\n`

--- a/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
@@ -53,14 +53,14 @@ were selected by the user.
 Any additional keyword arguments will be passed to [`TerminalMenus.MultiSelectConfig`](@ref).
 """
 function MultiSelectMenu(options::Array{String,1}; pagesize::Int=10, selected=Int[], warn::Bool=true, kwargs...)
-    length(options) < 2 && error("MultiSelectMenu must have at least two options")
+    length(options) < 1 && error("MultiSelectMenu must have at least one option")
 
     # if pagesize is -1, use automatic paging
     pagesize = pagesize == -1 ? length(options) : pagesize
     # pagesize shouldn't be bigger than options
     pagesize = min(length(options), pagesize)
     # after other checks, pagesize must be greater than 2
-    pagesize < 2 && error("pagesize must be >= 2")
+    pagesize < 1 && error("pagesize must be >= 1")
 
     pageoffset = 0
     _selected = Set{Int}()

--- a/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
@@ -44,14 +44,14 @@ user.
 Any additional keyword arguments will be passed to [`TerminalMenus.Config`](@ref).
 """
 function RadioMenu(options::Array{String,1}; pagesize::Int=10, warn::Bool=true, kwargs...)
-    length(options) < 2 && error("RadioMenu must have at least two options")
+    length(options) < 1 && error("RadioMenu must have at least one option")
 
     # if pagesize is -1, use automatic paging
     pagesize = pagesize == -1 ? length(options) : pagesize
     # pagesize shouldn't be bigger than options
     pagesize = min(length(options), pagesize)
-    # after other checks, pagesize must be greater than 2
-    pagesize < 2 && error("pagesize must be >= 2")
+    # after other checks, pagesize must be greater than 1
+    pagesize < 1 && error("pagesize must be >= 1")
 
     pageoffset = 0
     selected = -1 # none

--- a/stdlib/REPL/src/TerminalMenus/config.jl
+++ b/stdlib/REPL/src/TerminalMenus/config.jl
@@ -6,6 +6,7 @@ struct Config <: AbstractConfig
     cursor::Char
     up_arrow::Char
     down_arrow::Char
+    updown_arrow::Char
     scroll_wrap::Bool
     ctrl_c_interrupt::Bool
 end
@@ -46,6 +47,7 @@ function Config(;
                 cursor::Char = '\0',
                 up_arrow::Char = '\0',
                 down_arrow::Char = '\0',
+                updown_arrow::Char = '\0',
                 scroll_wrap::Bool = false,
                 ctrl_c_interrupt::Bool = true)
     charset === :ascii || charset === :unicode ||
@@ -59,7 +61,10 @@ function Config(;
     if down_arrow == '\0'
         down_arrow = charset === :ascii ? 'v' : '↓'
     end
-    return Config(cursor, up_arrow, down_arrow, scroll_wrap, ctrl_c_interrupt)
+    if updown_arrow == '\0'
+        updown_arrow = charset === :ascii ? 'I' : '↕'
+    end
+    return Config(cursor, up_arrow, down_arrow, updown_arrow, scroll_wrap, ctrl_c_interrupt)
 end
 
 """
@@ -133,6 +138,7 @@ function config(;charset::Symbol = :na,
                 cursor::Char = '\0',
                 up_arrow::Char = '\0',
                 down_arrow::Char = '\0',
+                updown_arrow::Char = '\0',
                 checked::String = "",
                 unchecked::String = "",
                 supress_output::Union{Nothing, Bool}=nothing,   # typo was documented, unfortunately
@@ -142,12 +148,14 @@ function config(;charset::Symbol = :na,
         cursor     = '>'
         up_arrow   = '^'
         down_arrow = 'v'
+        updown_arrow = 'I'
         checked    = "[X]"
         unchecked  = "[ ]"
     elseif charset === :unicode
         cursor     = '→'
         up_arrow   = '↑'
         down_arrow = '↓'
+        updown_arrow = '↕'
         checked    = "✓"
         unchecked  = "⬚"
     elseif charset === :na
@@ -162,6 +170,7 @@ function config(;charset::Symbol = :na,
     cursor     != '\0' && (CONFIG[:cursor]     = cursor)
     up_arrow   != '\0' && (CONFIG[:up_arrow]   = up_arrow)
     down_arrow != '\0' && (CONFIG[:down_arrow] = down_arrow)
+    updown_arrow != '\0' && (CONFIG[:updown_arrow] = updown_arrow)
     checked    != ""   && (CONFIG[:checked]    = checked)
     unchecked  != ""   && (CONFIG[:unchecked]  = unchecked)
     supress_output isa Bool   && (CONFIG[:supress_output] = supress_output)

--- a/stdlib/REPL/test/TerminalMenus/legacytests/old_multiselect_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/legacytests/old_multiselect_menu.jl
@@ -5,10 +5,6 @@
 # Check to make sure types are imported properly
 @test MultiSelectMenu <: TerminalMenus.AbstractMenu
 
-# Invalid Menu Params
-@test_throws ErrorException MultiSelectMenu(["one"], warn=false)
-@test_throws ErrorException MultiSelectMenu(["one", "two", "three"], pagesize=1, warn=false)
-
 # Constructor
 @test MultiSelectMenu(["one", "two", "three"], warn=false).pagesize == 3
 @test MultiSelectMenu(string.(1:30), pagesize=-1, warn=false).pagesize == 30
@@ -37,3 +33,5 @@ TerminalMenus.writeLine(buf, multi_menu, 1, true)
 # Test SDTIN
 multi_menu = MultiSelectMenu(string.(1:10), warn=false)
 @test simulate_input(Set([1,2]), multi_menu, :enter, :down, :enter, 'd')
+multi_menu = MultiSelectMenu(["single option"], warn=false)
+@test simulate_input(Set([1]), multi_menu, :up, :up, :down, :enter, 'd')

--- a/stdlib/REPL/test/TerminalMenus/legacytests/old_radio_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/legacytests/old_radio_menu.jl
@@ -5,10 +5,6 @@
 # Check to make sure types are imported properly
 @test RadioMenu <: TerminalMenus.AbstractMenu
 
-# Invalid Menu Params
-@test_throws ErrorException RadioMenu(["one"], warn=false)
-@test_throws ErrorException RadioMenu(["one", "two", "three"], pagesize=1, warn=false)
-
 # Constructor
 @test RadioMenu(["one", "two", "three"], warn=false).pagesize == 3
 @test RadioMenu(string.(1:30), pagesize=-1, warn=false).pagesize == 30
@@ -40,3 +36,7 @@ TerminalMenus.writeLine(buf, radio_menu, 1, true)
 # Test using stdin
 radio_menu = RadioMenu(string.(1:10), warn=false)
 @test simulate_input(3, radio_menu, :down, :down, :enter)
+radio_menu = RadioMenu(["single option"], warn=false)
+@test simulate_input(1, radio_menu, :up, :up, :down, :up, :enter)
+radio_menu = RadioMenu(string.(1:3), pagesize=1, warn=false)
+@test simulate_input(3, radio_menu, :down, :down, :down, :down, :enter)

--- a/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
@@ -6,10 +6,6 @@
 # Check to make sure types are imported properly
 @test MultiSelectMenu{TerminalMenus.MultiSelectConfig} <: TerminalMenus.ConfiguredMenu  # TODO Julia 2.0: delete parameter
 
-# Invalid Menu Params
-@test_throws ErrorException MultiSelectMenu(["one"], charset=:ascii)
-@test_throws ErrorException MultiSelectMenu(["one", "two", "three"], pagesize=1, charset=:ascii)
-
 # Constructor
 @test MultiSelectMenu(["one", "two", "three"], charset=:ascii).pagesize == 3
 @test MultiSelectMenu(string.(1:30), pagesize=-1, charset=:ascii).pagesize == 30
@@ -57,3 +53,5 @@ end
 # Test SDTIN
 multi_menu = MultiSelectMenu(string.(1:10), charset=:ascii)
 @test simulate_input(Set([1,2]), multi_menu, :enter, :down, :enter, 'd')
+multi_menu = MultiSelectMenu(["single option"])
+@test simulate_input(Set([1]), multi_menu, :up, :up, :down, :enter, 'd')

--- a/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
@@ -53,5 +53,5 @@ end
 # Test SDTIN
 multi_menu = MultiSelectMenu(string.(1:10), charset=:ascii)
 @test simulate_input(Set([1,2]), multi_menu, :enter, :down, :enter, 'd')
-multi_menu = MultiSelectMenu(["single option"])
+multi_menu = MultiSelectMenu(["single option"], charset=:ascii)
 @test simulate_input(Set([1]), multi_menu, :up, :up, :down, :enter, 'd')

--- a/stdlib/REPL/test/TerminalMenus/radio_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/radio_menu.jl
@@ -38,7 +38,7 @@ end
 # Test using stdin
 radio_menu = RadioMenu(string.(1:10); charset=:ascii)
 @test simulate_input(3, radio_menu, :down, :down, :enter)
-radio_menu = RadioMenu(["single option"])
+radio_menu = RadioMenu(["single option"], charset=:ascii)
 @test simulate_input(1, radio_menu, :up, :up, :down, :up, :enter)
-radio_menu = RadioMenu(string.(1:3), pagesize=1)
+radio_menu = RadioMenu(string.(1:3), pagesize=1, charset=:ascii)
 @test simulate_input(3, radio_menu, :down, :down, :down, :down, :enter)

--- a/stdlib/REPL/test/TerminalMenus/radio_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/radio_menu.jl
@@ -6,10 +6,6 @@
 # Check to make sure types are imported properly
 @test RadioMenu{TerminalMenus.Config} <: TerminalMenus.ConfiguredMenu  # TODO Julia 2.0: delete parameter
 
-# Invalid Menu Params
-@test_throws ErrorException RadioMenu(["one"]; charset=:ascii)
-@test_throws ErrorException RadioMenu(["one", "two", "three"], pagesize=1, charset=:ascii)
-
 # Constructor
 @test RadioMenu(["one", "two", "three"]; charset=:ascii).pagesize == 3
 @test RadioMenu(string.(1:30), pagesize=-1, charset=:ascii).pagesize == 30
@@ -42,3 +38,7 @@ end
 # Test using stdin
 radio_menu = RadioMenu(string.(1:10); charset=:ascii)
 @test simulate_input(3, radio_menu, :down, :down, :enter)
+radio_menu = RadioMenu(["single option"])
+@test simulate_input(1, radio_menu, :up, :up, :down, :up, :enter)
+radio_menu = RadioMenu(string.(1:3), pagesize=1)
+@test simulate_input(3, radio_menu, :down, :down, :down, :down, :enter)


### PR DESCRIPTION
As briefly [mentioned](https://github.com/JuliaLang/julia/pull/35915#issuecomment-638316817) in the recent API change of REPL.TerminalMenus (#35915), single choice menu (nick-paul/TerminalMenus.jl#20) is a feature implemented in the original repo then somehow missed a chance to be part of the stdlib.

The first half of this PR is mostly identical to the above patch with small changes. Basically it relaxes minimum value of pagesize to 1 instead of 2. A notable thing added to this PR was to fix the condition for page offset update in `move_down!()` to ensure proper scrolling when there is only one line in the page (pagesize=1). The recently changed code for this function has a slightly different condition than to what was originally implemented ([old](https://github.com/nick-paul/TerminalMenus.jl/blob/809727726d6b8a27865fe6e9da953bc40891239a/src/AbstractMenu.jl#L110) vs [new](https://github.com/JuliaLang/julia/blob/35c1f87176fecab5a8e8077fb3a62275363a5aa5/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl#L259)).

The remaining part is not directly related to the single choice menu, but to improve handling of pagesize=1 which is now inevitably open to multiple options if users insist on using it. A main issue is that the current scrolling arrow can be only placed for one direction, but now we may end up with a single line with multiple options that can be scrolled to either direction.

For this, the logic in `printcursor()` to print out empty space when no arrow presents is now taken over by `print_arrow()`. `updown_arrow()` provides an additional symbol for the new arrow (`I` in ASCII, `↕` in Unicode by default). Then `printcursor()` is always called for each line regardless of existence of arrows.