### PR TITLE
Fix link in docstring of `big()`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -460,7 +460,8 @@ promote_rule(::Type{BigInt}, ::Type{<:Integer}) = BigInt
     big(x)
 
 Convert a number to a maximum precision representation (typically [`BigInt`](@ref) or
-`BigFloat`). See [`BigFloat`](@ref) for information about some pitfalls with floating-point numbers.
+`BigFloat`). See [`BigFloat`](@ref BigFloat(::Any, rounding::RoundingMode)) for
+information about some pitfalls with floating-point numbers.
 """
 function big end
 


### PR DESCRIPTION
There are two `BigFloat` docstrings: for the type and for the method (constructor).
This changes the link target from the former to the latter.

https://docs.julialang.org/en/v1.6-dev/base/numbers/#Base.big