### PR TITLE
Fix broken links in docstring of `repeat`

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -686,7 +686,7 @@ reverseind(s::AbstractString, i::Integer) = thisind(s, ncodeunits(s)-i+1)
 
 Repeat a string `r` times. This can be written as `s^r`.
 
-See also: [`^`](@ref)
+See also: [`^`](@ref :^(::Union{AbstractString, AbstractChar}, ::Integer))
 
 # Examples
 ```jldoctest

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -321,7 +321,8 @@ end
 """
     repeat(c::AbstractChar, r::Integer) -> String
 
-Repeat a character `r` times. This can equivalently be accomplished by calling [`c^r`](@ref ^).
+Repeat a character `r` times. This can equivalently be accomplished by calling
+[`c^r`](@ref :^(::Union{AbstractString, AbstractChar}, ::Integer)).
 
 # Examples
 ```jldoctest

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -7,7 +7,7 @@ Base.codepoint
 Base.length(::AbstractString)
 Base.sizeof(::AbstractString)
 Base.:*(::Union{AbstractChar, AbstractString}, ::Union{AbstractChar, AbstractString}...)
-Base.:^(::AbstractString, ::Integer)
+Base.:^(::Union{AbstractString, AbstractChar}, ::Integer)
 Base.string
 Base.repeat(::AbstractString, ::Integer)
 Base.repeat(::AbstractChar, ::Integer)


### PR DESCRIPTION
This changes the link targets of `^` parseable and more specific.

This fixes the problem in the first half of https://github.com/JuliaLang/julia/pull/35693#issue-412313318. These four seem like a problem with Documenter.jl (cf. https://github.com/JuliaDocs/Documenter.jl/issues/505) (or Julia). 

**Edit:**
The `^` without signatures should refer to
`base/math/#Base.:^-Tuple{Number,Number}`
but in "base/foo.md", the relative URL is resolved into:
`../math/#Base.:^-Tuple{Number,Number}` in "base/punctuation.md",
`math/#Base.:^-Tuple{Number,Number}` in "base/arrays.md".

In any case, the `math/#Base.:^` is not a suitable reference for `^` in the docstring of `repeat`. This is the reason for fixing only the first half.