### PR TITLE
Generic `isfinite` method

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -537,20 +537,6 @@ isnan(x::AbstractFloat) = (x != x)::Bool
 isnan(x::Float16) = reinterpret(UInt16,x)&0x7fff > 0x7c00
 isnan(x::Real) = false
 
-"""
-    isfinite(f) -> Bool
-
-Test whether a number is finite.
-
-# Examples
-```jldoctest
-julia> isfinite(5)
-true
-
-julia> isfinite(NaN32)
-false
-```
-"""
 isfinite(x::AbstractFloat) = x - x == 0
 isfinite(x::Float16) = reinterpret(UInt16,x)&0x7c00 != 0x7c00
 isfinite(x::Real) = decompose(x)[3] != 0

--- a/base/number.jl
+++ b/base/number.jl
@@ -135,6 +135,22 @@ julia> abs2(-3)
 abs2(x::Real) = x*x
 
 """
+    isfinite(f) -> Bool
+
+Test whether a number is finite.
+
+# Examples
+```jldoctest
+julia> isfinite(5)
+true
+
+julia> isfinite(NaN32)
+false
+```
+"""
+isfinite(x) = iszero(x - x)
+
+"""
     flipsign(x, y)
 
 Return `x` with its sign flipped if `y` is negative. For example `abs(x) = flipsign(x,x)`.

--- a/base/number.jl
+++ b/base/number.jl
@@ -59,6 +59,22 @@ true
 """
 isone(x) = x == one(x) # fallback method
 
+"""
+    isfinite(f) -> Bool
+
+Test whether a number is finite.
+
+# Examples
+```jldoctest
+julia> isfinite(5)
+true
+
+julia> isfinite(NaN32)
+false
+```
+"""
+isfinite(x::Number) = iszero(x - x)
+
 size(x::Number) = ()
 size(x::Number, d::Integer) = d < 1 ? throw(BoundsError()) : 1
 axes(x::Number) = ()
@@ -133,22 +149,6 @@ julia> abs2(-3)
 ```
 """
 abs2(x::Real) = x*x
-
-"""
-    isfinite(f) -> Bool
-
-Test whether a number is finite.
-
-# Examples
-```jldoctest
-julia> isfinite(5)
-true
-
-julia> isfinite(NaN32)
-false
-```
-"""
-isfinite(x) = iszero(x - x)
 
 """
     flipsign(x, y)

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -54,6 +54,7 @@ Base.zero(::Union{Type{P},P}) where {P<:Period} = P(0)
 Base.one(::Union{Type{P},P}) where {P<:Period} = 1  # see #16116
 Base.typemin(::Type{P}) where {P<:Period} = P(typemin(Int64))
 Base.typemax(::Type{P}) where {P<:Period} = P(typemax(Int64))
+Base.isfinite(::Union{Type{P}, P}) where {P<:Period} = true
 
 # Default values (as used by TimeTypes)
 """

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -30,6 +30,7 @@ using Test
     @test sign(t) == sign(t2) == 1
     @test sign(-t) == sign(-t2) == -1
     @test sign(Dates.Year(0)) == 0
+    @test isfinite(t) == true
 end
 @testset "div/mod/gcd/lcm/rem" begin
     @test Dates.Year(10) % Dates.Year(4) == Dates.Year(2)

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -30,7 +30,6 @@ using Test
     @test sign(t) == sign(t2) == 1
     @test sign(-t) == sign(-t2) == -1
     @test sign(Dates.Year(0)) == 0
-    @test isfinite(t) == true
 end
 @testset "div/mod/gcd/lcm/rem" begin
     @test Dates.Year(10) % Dates.Year(4) == Dates.Year(2)
@@ -227,6 +226,8 @@ end
     @test Dates.string(Dates.Year(1)) == "1 year"
     @test Dates.string(Dates.Year(-1)) == "-1 year"
     @test Dates.string(Dates.Year(2)) == "2 years"
+    @test isfinite(Dates.Year)
+    @test isfinite(Dates.Year(0))
     @test zero(Dates.Year) == Dates.Year(0)
     @test zero(Dates.Year(10)) == Dates.Year(0)
     @test zero(Dates.Month) == Dates.Month(0)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2704,3 +2704,11 @@ end
     @test all(m -> m.file == Symbol("deprecated.jl"),
         collect(methods(T))[findall(R -> !(R<:T), Base.return_types(T))])
 end
+
+@testset "generic isfinite" begin
+    @test isfinite('a') == true
+
+    @test invoke(isfinite, Tuple{Any}, 0.0) == true
+    @test invoke(isfinite, Tuple{Any}, NaN) == false
+    @test invoke(isfinite, Tuple{Any}, Inf) == false
+end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2706,9 +2706,7 @@ end
 end
 
 @testset "generic isfinite" begin
-    @test isfinite('a') == true
-
-    @test invoke(isfinite, Tuple{Any}, 0.0) == true
-    @test invoke(isfinite, Tuple{Any}, NaN) == false
-    @test invoke(isfinite, Tuple{Any}, Inf) == false
+    @test invoke(isfinite, Tuple{Number}, 0.0) == true
+    @test invoke(isfinite, Tuple{Number}, NaN) == false
+    @test invoke(isfinite, Tuple{Number}, Inf) == false
 end


### PR DESCRIPTION
Implements a generic `isfinite` method which should work for any type supporting subtraction and `iszero`. My motivation behind the change is that I was writing some generic code which needed `isfinite` to work with `Char` and `Period` instances.