### PR TITLE
Use NFD-normalized identifiers to match LaTeX hints

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -13,6 +13,8 @@ using Base: with_output_color
 
 using InteractiveUtils: subtypes
 
+using Unicode: normalize
+
 ## Help mode ##
 
 # This is split into helpmode and _helpmode to easier unittest _helpmode
@@ -326,6 +328,8 @@ function symbol_latex(s::String)
     return get(symbols_latex, s, "")
 end
 function repl_latex(io::IO, s::String)
+    # decompose NFC-normalized identifier to match tab-completion input
+    s = normalize(s, :NFD)
     latex = symbol_latex(s)
     if !isempty(latex)
         print(io, "\"")

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -985,6 +985,9 @@ end
 @test sprint(repl_latex, "√") == "\"√\" can be typed by \\sqrt<tab>\n\n"
 @test sprint(repl_latex, "x̂₂") == "\"x̂₂\" can be typed by x\\hat<tab>\\_2<tab>\n\n"
 
+# issue #36378 (\u1e8b and x\u307 are the fully composed and decomposed forms of ẋ, respectively)
+@test sprint(repl_latex, "\u1e8b") == "\"x\u307\" can be typed by x\\dot<tab>\n\n"
+
 # issue #15684
 begin
     """


### PR DESCRIPTION
This fixes #36378.