### PR TITLE
fix return type of `get!` on `IdDict`

### DIFF
--- a/test/dict.jl
+++ b/test/dict.jl
@@ -554,7 +554,8 @@ end
     @test delete!(d, "a") === d
     @test !haskey(d, "a")
     @test_throws ArgumentError get!(IdDict{Symbol,Any}(), 2, "b")
-
+    @test get!(IdDict{Int,Int}(), 1, 2.0) === 2
+    @test get!(()->2.0, IdDict{Int,Int}(), 1) === 2
 
     # sizehint! & rehash!
     d = IdDict()


### PR DESCRIPTION
`get!(::Dict, ...)` returns the value after it has been converted to the Dict's value type, but IdDict was returning it pre-conversion. I believe the Dict behavior is correct.