### PR TITLE
fix showing methods with unicode gensymed variable names

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -13,7 +13,7 @@ function argtype_decl(env, n, sig::DataType, i::Int, nargs, isva::Bool) # -> (ar
     s = string(n)
     i = findfirst(isequal('#'), s)
     if i !== nothing
-        s = s[1:i-1]
+        s = s[1:prevind(s, i)]
     end
     if t === Any && !isempty(s)
         return s, ""

--- a/test/show.jl
+++ b/test/show.jl
@@ -1985,3 +1985,12 @@ end
     @test sprint(show, skipmissing([1,2,missing])) == "skipmissing(Union{Missing, $Int}[1, 2, missing])"
     @test sprint(show, skipmissing((missing,1.0,'a'))) == "skipmissing((missing, 1.0, 'a'))"
 end
+
+@testset "unicode in method table" begin
+    αsym = gensym(:α)
+    ℓsym = gensym(:ℓ)
+    eval(:(foo($αsym) = $αsym))
+    eval(:(bar($ℓsym) = $ℓsym))
+    @test contains(string(methods(foo)), "foo(α)")
+    @test contains(string(methods(bar)), "bar(ℓ)")
+end


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/31494