### PR TITLE
Check axes in Array(::AbstractArray) (fixes #36220)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -940,6 +940,12 @@ function copyto!(B::AbstractVecOrMat{R}, ir_dest::AbstractRange{Int}, jr_dest::A
     return B
 end
 
+function copyto_axcheck!(dest, src)
+    @noinline checkaxs(axd, axs) = axd == axs || throw(DimensionMismatch("axes must agree, got $axd and $axs"))
+
+    checkaxs(axes(dest), axes(src))
+    copyto!(dest, src)
+end
 
 """
     copymutable(a)

--- a/base/array.jl
+++ b/base/array.jl
@@ -561,8 +561,8 @@ promote_rule(a::Type{Array{T,n}}, b::Type{Array{S,n}}) where {T,n,S} = el_same(p
 
 if nameof(@__MODULE__) === :Base  # avoid method overwrite
 # constructors should make copies
-Array{T,N}(x::AbstractArray{S,N})         where {T,N,S} = copyto!(Array{T,N}(undef, size(x)), x)
-AbstractArray{T,N}(A::AbstractArray{S,N}) where {T,N,S} = copyto!(similar(A,T), A)
+Array{T,N}(x::AbstractArray{S,N})         where {T,N,S} = copyto_axcheck!(Array{T,N}(undef, size(x)), x)
+AbstractArray{T,N}(A::AbstractArray{S,N}) where {T,N,S} = copyto_axcheck!(similar(A,T), A)
 end
 
 ## copying iterators to containers

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -111,10 +111,12 @@ end
 
 for a in vals
     a isa AbstractArray || continue
-    if keys(a) == keys(Array(a))
-        @test hash(a) == hash(Array(a)) == hash(Array{Any}(a))
+    aa  = copyto!(Array{eltype(a)}(undef, size(a)), a)
+    aaa = copyto!(Array{Any}(undef, size(a)), a)
+    if keys(a) == keys(aa)
+        @test hash(a) == hash(aa) == hash(aaa)
     else
-        @test hash(a) == hash(OffsetArray(Array(a), (first.(axes(a)).-1)...)) == hash(OffsetArray(Array{Any}(a), (first.(axes(a)).-1)...))
+        @test hash(a) == hash(OffsetArray(aa, (first.(axes(a)).-1)...)) == hash(OffsetArray(aaa, (first.(axes(a)).-1)...))
     end
 end
 

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -21,6 +21,7 @@ h = OffsetArray([-1,1,-2,2,0], (-3,))
 @test axes(v) == (-2:1,)
 @test size(v) == (4,)
 @test size(v, 1) == 4
+@test_throws DimensionMismatch Array(v)
 
 A0 = [1 3; 2 4]
 A = OffsetArray(A0, (-1,2))                   # IndexLinear


### PR DESCRIPTION
Now, `Array(A::AbstractArray)` checks to make sure that `A` has axes starting at 1. It's not entirely clear whether this check should be done by `Array(A)` or `convert(Array, A)`, but the more conservative option is to avoid changing behavior, and this is how it works on 1.4 (indirectly via the `copyto!` bug).

EDIT: Fixes #36220