### PR TITLE
Add "_invoke_codeinst" builtin

### DIFF
--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -24,6 +24,7 @@ DECLARE_BUILTIN(typeof);     DECLARE_BUILTIN(sizeof);
 DECLARE_BUILTIN(issubtype);  DECLARE_BUILTIN(isa);
 DECLARE_BUILTIN(_apply);     DECLARE_BUILTIN(_apply_pure);
 DECLARE_BUILTIN(_apply_latest); DECLARE_BUILTIN(_apply_iterate);
+DECLARE_BUILTIN(_invoke_codeinst);
 DECLARE_BUILTIN(isdefined);  DECLARE_BUILTIN(nfields);
 DECLARE_BUILTIN(tuple);      DECLARE_BUILTIN(svec);
 DECLARE_BUILTIN(getfield);   DECLARE_BUILTIN(setfield);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -669,6 +669,14 @@ JL_CALLABLE(jl_f__apply)
     return do_apply(F, args, nargs, NULL);
 }
 
+JL_CALLABLE(jl_f__invoke_codeinst)
+{
+    JL_NARGSV(_invoke_codeinst, 2);
+    JL_TYPECHK(_invoke_codeinst, code_instance, args[0]);
+    jl_code_instance_t *inst = (jl_code_instance_t*)args[0];
+    return inst->invoke(args[1], &args[2], nargs-2, inst);
+}
+
 // this is like `_apply`, but with quasi-exact checks to make sure it is pure
 JL_CALLABLE(jl_f__apply_pure)
 {
@@ -1523,6 +1531,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     jl_builtin_apply_type = add_builtin_func("apply_type", jl_f_apply_type);
     jl_builtin__apply = add_builtin_func("_apply", jl_f__apply);
     jl_builtin__apply_iterate = add_builtin_func("_apply_iterate", jl_f__apply_iterate);
+    jl_builtin__invoke_codeinst = add_builtin_func("_invoke_codeinst", jl_f__invoke_codeinst);
     jl_builtin__expr = add_builtin_func("_expr", jl_f__expr);
     jl_builtin_svec = add_builtin_func("svec", jl_f_svec);
     add_builtin_func("_apply_pure", jl_f__apply_pure);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -789,6 +789,7 @@ static const std::map<jl_fptr_args_t, JuliaFunction*> builtin_func_map = {
     { &jl_f__apply_iterate,     new JuliaFunction{"jl_f__apply_iterate", get_func_sig, get_func_attrs} },
     { &jl_f__apply_pure,        new JuliaFunction{"jl_f__apply_pure", get_func_sig, get_func_attrs} },
     { &jl_f__apply_latest,      new JuliaFunction{"jl_f__apply_latest", get_func_sig, get_func_attrs} },
+    { &jl_f__invoke_codeinst,     new JuliaFunction{"jl_f__invoke_codeinst", get_func_sig, get_func_attrs} },
     { &jl_f_throw,              new JuliaFunction{"jl_f_throw", get_func_sig, get_func_attrs} },
     { &jl_f_tuple,              jltuple_func },
     { &jl_f_svec,               new JuliaFunction{"jl_f_svec", get_func_sig, get_func_attrs} },

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -78,7 +78,7 @@ static void *const _tags[] = {
          // some Core.Builtin Functions that we want to be able to reference:
          &jl_builtin_throw, &jl_builtin_is, &jl_builtin_typeof, &jl_builtin_sizeof,
          &jl_builtin_issubtype, &jl_builtin_isa, &jl_builtin_typeassert, &jl_builtin__apply,
-         &jl_builtin__apply_iterate,
+         &jl_builtin__apply_iterate, &jl_builtin__invoke_codeinst,
          &jl_builtin_isdefined, &jl_builtin_nfields, &jl_builtin_tuple, &jl_builtin_svec,
          &jl_builtin_getfield, &jl_builtin_setfield, &jl_builtin_fieldtype, &jl_builtin_arrayref,
          &jl_builtin_const_arrayref, &jl_builtin_arrayset, &jl_builtin_arraysize,
@@ -117,7 +117,9 @@ void *native_functions;
 // This is a manually constructed dual of the fvars array, which would be produced by codegen for Julia code, for C.
 static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_throw, &jl_f_is, &jl_f_typeof, &jl_f_issubtype, &jl_f_isa,
-    &jl_f_typeassert, &jl_f__apply, &jl_f__apply_iterate, &jl_f__apply_pure, &jl_f__apply_latest, &jl_f_isdefined,
+    &jl_f_typeassert, &jl_f__apply, &jl_f__apply_iterate, &jl_f__apply_pure, &jl_f__apply_latest,
+    &jl_f__invoke_codeinst,
+    &jl_f_isdefined,
     &jl_f_tuple, &jl_f_svec, &jl_f_intrinsic_call, &jl_f_invoke_kwsorter,
     &jl_f_getfield, &jl_f_setfield, &jl_f_fieldtype, &jl_f_nfields,
     &jl_f_arrayref, &jl_f_const_arrayref, &jl_f_arrayset, &jl_f_arraysize, &jl_f_apply_type,


### PR DESCRIPTION
This builtin is a low-level mechanism to execute a specific codeinst.
Higher-level invokers need to make sure that any world-age limits
are observed.