### PR TITLE
Allow external CodeInstances to be added to the execution engine

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -81,15 +81,16 @@ void jl_jit_strings(jl_codegen_params_t::SymMapGV &stringConstants)
     }
 }
 
-
 // this generates llvm code for the lambda info
 // and adds the result to the jitlayers
 // (and the shadow module),
 // and generates code for it
-static jl_callptr_t _jl_compile_codeinst(
+extern "C" {
+JL_DLLEXPORT jl_callptr_t jl_compile_codeinst(
         jl_code_instance_t *codeinst,
         jl_code_info_t *src,
-        size_t world)
+        size_t world,
+        const jl_cgparams_t *cg_params)
 {
     // TODO: Merge with jl_dump_compiles?
     static ios_t f_precompile;
@@ -111,6 +112,7 @@ static jl_callptr_t _jl_compile_codeinst(
     jl_codegen_params_t params;
     params.cache = true;
     params.world = world;
+    params.params = cg_params;
     std::map<jl_code_instance_t*, jl_compile_result_t> emitted;
     {
         JL_TIMING(CODEGEN);
@@ -217,6 +219,15 @@ static jl_callptr_t _jl_compile_codeinst(
         }
     }
     return fptr;
+}
+}
+
+static jl_callptr_t _jl_compile_codeinst(
+        jl_code_instance_t *codeinst,
+        jl_code_info_t *src,
+        size_t world)
+{
+    return jl_compile_codeinst(codeinst, src, world, &jl_default_cgparams);
 }
 
 void jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params);


### PR DESCRIPTION
As of #35831, we've had the ability to cache CodeInstances in an
external cache and to replace that cache during jl_generate_native
(e.g. for GPU compilation). This extends the same capability to
CodeInstances to be added to the execution engine.