### PR TITLE
Add hook in inference recursion resolution for external AbstractInter…

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -46,6 +46,10 @@ mutable struct InferenceState
     # `max_valid`, to be used in inlining
     matching_methods_cache::IdDict{Any, Tuple{Any, UInt, UInt}}
 
+    # The interpreter that created this inference state. Not looked at by
+    # NativeInterpreter. But other interpreters may use this to detect cycles
+    interp::AbstractInterpreter
+
     # src is assumed to be a newly-allocated CodeInfo, that can be modified in-place to contain intermediate results
     function InferenceState(result::InferenceResult, src::CodeInfo,
                             cached::Bool, interp::AbstractInterpreter)
@@ -107,7 +111,8 @@ mutable struct InferenceState
             Vector{InferenceState}(), # callers_in_cycle
             #=parent=#nothing,
             cached, false, false, false,
-            IdDict{Any, Tuple{Any, UInt, UInt}}())
+            IdDict{Any, Tuple{Any, UInt, UInt}}(),
+            interp)
         result.result = frame
         cached && push!(get_inference_cache(interp), result)
         return frame


### PR DESCRIPTION
…preter

This extends hookability to the same-frame comparison in inference's
recursion cycle detection. The case I ran into that made this necessary
is a recursive, nested AD transform. In this case, inference must detect
if two frames have different orders of derivatives (e.g. the primitive
for `-`, again calls `-`; the external interpreter makes sure that
inference results for these end up in different caches).