### PR TITLE
Avoid potential buffer overflow/missing zero termination of string

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -190,7 +190,8 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
                     snprintf(relocated, PATHBUF, "%s%s", jl_options.julia_bindir, dl_path + 16);
                     len = len - 16 + strlen(jl_options.julia_bindir);
                 } else {
-                    strncpy(relocated, dl_path, len);
+                    strncpy(relocated, dl_path, PATHBUF);
+                    relocated[PATHBUF-1] = '\0';
                 }
                 for (i = 0; i < n_extensions; i++) {
                     const char *ext = extensions[i];

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -224,11 +224,6 @@ end
 
 # test DL_LOAD_PATH handling and @executable_path expansion
 mktempdir() do dir
-    # Skip these tests if the temporary directory is not on the same filesystem
-    # as the BINDIR, as in that case, a relative path will never work.
-    if Base.Filesystem.splitdrive(dir)[1] != Base.Filesystem.splitdrive(Sys.BINDIR)[1]
-        return
-    end
     # Create a `libdcalltest` in a directory that is not on our load path
     src_path = joinpath(private_libdir, "libccalltest.$(Libdl.dlext)")
     dst_path = joinpath(dir, "libdcalltest.$(Libdl.dlext)")
@@ -237,8 +232,8 @@ mktempdir() do dir
     # Add an absurdly long entry to the load path to verify it doesn't lead to a buffer overflow
     push!(Base.DL_LOAD_PATH, joinpath(dir, join(rand('a':'z', 10000))))
 
-    # Add this temporary directory to our load path, using `@executable_path` to do so.
-    push!(Base.DL_LOAD_PATH, joinpath("@executable_path", relpath(dir, Sys.BINDIR)))
+    # Add the temporary directors to load path by absolute path
+    push!(Base.DL_LOAD_PATH, dir)
 
     # Test that we can now open that file
     Libdl.dlopen("libdcalltest") do dl
@@ -252,10 +247,17 @@ mktempdir() do dir
         @test fptr == C_NULL
     end
 
-    # Now use the absolute path
+    # Skip these tests if the temporary directory is not on the same filesystem
+    # as the BINDIR, as in that case, a relative path will never work.
+    if Base.Filesystem.splitdrive(dir)[1] != Base.Filesystem.splitdrive(Sys.BINDIR)[1]
+        return
+    end
+
     empty!(Base.DL_LOAD_PATH)
     push!(Base.DL_LOAD_PATH, joinpath(dir, join(rand('a':'z', 10000))))
-    push!(Base.DL_LOAD_PATH, dir)
+
+    # Add this temporary directory to our load path, now using `@executable_path` to do so.
+    push!(Base.DL_LOAD_PATH, joinpath("@executable_path", relpath(dir, Sys.BINDIR)))
 
     # Test that we can now open that file
     Libdl.dlopen("libdcalltest") do dl

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -222,4 +222,27 @@ let dl = C_NULL
     @test_skip !Libdl.dlclose(dl)   # Syscall doesn't fail on Win32
 end
 
+# test @executable_path expansion
+mktempdir() do dir
+    # Create a `libdcalltest` in a directory that is not on our load path
+    src_path = joinpath(private_libdir, "libccalltest.$(Libdl.dlext)")
+    dst_path = joinpath(dir, "libdcalltest.$(Libdl.dlext)")
+    cp(src_path, dst_path)
+
+    # Add this temporary directory to our load path, using `@executable_path` to do so.
+    push!(Base.DL_LOAD_PATH, joinpath("@executable_path", relpath(dir, Sys.BINDIR)))
+
+    # Test that we can now open that file
+    Libdl.dlopen("libdcalltest") do dl
+        fptr = Libdl.dlsym(dl, :set_verbose)
+        @test fptr !== nothing
+        @test_throws ErrorException Libdl.dlsym(dl, :foo)
+
+        fptr = Libdl.dlsym_e(dl, :set_verbose)
+        @test fptr != C_NULL
+        fptr = Libdl.dlsym_e(dl, :foo)
+        @test fptr == C_NULL
+    end
+end
+
 end

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -222,15 +222,35 @@ let dl = C_NULL
     @test_skip !Libdl.dlclose(dl)   # Syscall doesn't fail on Win32
 end
 
-# test @executable_path expansion
+# test DL_LOAD_PATH handling and @executable_path expansion
 mktempdir() do dir
     # Create a `libdcalltest` in a directory that is not on our load path
     src_path = joinpath(private_libdir, "libccalltest.$(Libdl.dlext)")
     dst_path = joinpath(dir, "libdcalltest.$(Libdl.dlext)")
     cp(src_path, dst_path)
 
+    # Add an absurdly long entry to the load path to verify it doesn't lead to a buffer overflow
+    push!(Base.DL_LOAD_PATH, joinpath(dir, join(rand('a':'z', 10000))))
+
     # Add this temporary directory to our load path, using `@executable_path` to do so.
     push!(Base.DL_LOAD_PATH, joinpath("@executable_path", relpath(dir, Sys.BINDIR)))
+
+    # Test that we can now open that file
+    Libdl.dlopen("libdcalltest") do dl
+        fptr = Libdl.dlsym(dl, :set_verbose)
+        @test fptr !== nothing
+        @test_throws ErrorException Libdl.dlsym(dl, :foo)
+
+        fptr = Libdl.dlsym_e(dl, :set_verbose)
+        @test fptr != C_NULL
+        fptr = Libdl.dlsym_e(dl, :foo)
+        @test fptr == C_NULL
+    end
+
+    # Now use the absolute path
+    empty!(Base.DL_LOAD_PATH)
+    push!(Base.DL_LOAD_PATH, joinpath(dir, join(rand('a':'z', 10000))))
+    push!(Base.DL_LOAD_PATH, dir)
 
     # Test that we can now open that file
     Libdl.dlopen("libdcalltest") do dl

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -224,6 +224,11 @@ end
 
 # test DL_LOAD_PATH handling and @executable_path expansion
 mktempdir() do dir
+    # Skip these tests if the temporary directory is not on the same filesystem
+    # as the BINDIR, as in that case, a relative path will never work.
+    if Base.Filesystem.splitdrive(dir)[1] != Base.Filesystem.splitdrive(Sys.BINDIR)[1]
+        return
+    end
     # Create a `libdcalltest` in a directory that is not on our load path
     src_path = joinpath(private_libdir, "libccalltest.$(Libdl.dlext)")
     dst_path = joinpath(dir, "libdcalltest.$(Libdl.dlext)")


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/commit/00abaf8f5f0fac23e93e140172c10b11383a042f#r39659418. Replace a `strncpy(dest, src, strlen(src))` with `strncpy(dest, src,  DEST_SIZE); dest[DEST_SIZE-1]='\0'`. The old code could overflow the destination if the source was too long (not sure that could actually happen), defeating the purpose of `strncpy`. Further, it failed to put the terminating zero in the destination, relying on it being properly initialized.

I have no idea about the context here, but this code path isn't exercised at all when I do `make test`. Is that somehow system specific? Does CI cover this?