### PR TITLE
Ensure string-hashing is defined before it gets used

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -75,3 +75,13 @@ else
     hash(x::Expr, h::UInt) = hash(x.args, hash(x.head, h + 0x96d26dc6))
     hash(x::QuoteNode, h::UInt) = hash(x.value, h + 0x469d72af)
 end
+
+## hashing strings ##
+
+const memhash = UInt === UInt64 ? :memhash_seed : :memhash32_seed
+const memhash_seed = UInt === UInt64 ? 0x71e729fd56419c81 : 0x56419c81
+
+function hash(s::String, h::UInt)
+    h += memhash_seed
+    ccall(memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), s, sizeof(s), h % UInt32) + h
+end

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -230,14 +230,3 @@ end
 ## hashing Float16s ##
 
 hash(x::Float16, h::UInt) = hash(Float64(x), h)
-
-## hashing strings ##
-
-const memhash = UInt === UInt64 ? :memhash_seed : :memhash32_seed
-const memhash_seed = UInt === UInt64 ? 0x71e729fd56419c81 : 0x56419c81
-
-function hash(s::Union{String,SubString{String}}, h::UInt)
-    h += memhash_seed
-    ccall(memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), s, sizeof(s), h % UInt32) + h
-end
-hash(s::AbstractString, h::UInt) = hash(String(s), h)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -347,6 +347,10 @@ cmp(a::Symbol, b::Symbol) = Int(sign(ccall(:strcmp, Int32, (Cstring, Cstring), a
 
 isless(a::Symbol, b::Symbol) = cmp(a, b) < 0
 
+# hashing
+
+hash(s::AbstractString, h::UInt) = hash(String(s), h)
+
 ## character index arithmetic ##
 
 """

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -122,6 +122,11 @@ end
 pointer(x::SubString{String}) = pointer(x.string) + x.offset
 pointer(x::SubString{String}, i::Integer) = pointer(x.string) + x.offset + (i-1)
 
+function hash(s::SubString{String}, h::UInt)
+    h += memhash_seed
+    ccall(memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), s, sizeof(s), h % UInt32) + h
+end
+
 """
     reverse(s::AbstractString) -> AbstractString
 


### PR DESCRIPTION
An analysis of invalidations during bootstrap (https://github.com/JuliaLang/julia/issues/36391#issuecomment-648470785) revealed that `log_record_id` calls `hash` on strings, and in principle it is used before the specialized `hash(::String)` methods are defined, and thus defaulting to the [fallback](https://github.com/JuliaLang/julia/blob/6cd329c371c1db3d9876bc337e82e274e50420e8/base/hashing.jl#L23). Since the new methods change the value of the computed hash, this could cause subtle bugs. It seems safer to define the hash methods as early as possible.