### PR TITLE
Fix rem2pi for NaN

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1239,6 +1239,8 @@ julia> rem2pi(7pi/4, RoundDown)
 """
 function rem2pi end
 function rem2pi(x::Float64, ::RoundingMode{:Nearest})
+    isnan(x) && return NaN
+
     abs(x) < pi && return x
 
     n,y = rem_pio2_kernel(x)
@@ -1262,6 +1264,8 @@ function rem2pi(x::Float64, ::RoundingMode{:Nearest})
     end
 end
 function rem2pi(x::Float64, ::RoundingMode{:ToZero})
+    isnan(x) && return NaN
+
     ax = abs(x)
     ax <= 2*Float64(pi,RoundDown) && return x
 
@@ -1287,6 +1291,8 @@ function rem2pi(x::Float64, ::RoundingMode{:ToZero})
     copysign(z,x)
 end
 function rem2pi(x::Float64, ::RoundingMode{:Down})
+    isnan(x) && return NaN
+
     if x < pi4o2_h
         if x >= 0
             return x
@@ -1316,6 +1322,8 @@ function rem2pi(x::Float64, ::RoundingMode{:Down})
     end
 end
 function rem2pi(x::Float64, ::RoundingMode{:Up})
+    isnan(x) && return NaN
+
     if x > -pi4o2_h
         if x <= 0
             return x

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2675,6 +2675,13 @@ end
     @test rem2pi(T(-8), RoundUp)      ≈ -8+2pi
 end
 
+@testset "PR #36420 $T" for T in (Float16, Float32, Float64)
+    @test rem2pi(T(NaN), RoundToZero)  === T(NaN)
+    @test rem2pi(T(NaN), RoundNearest) === T(NaN)
+    @test rem2pi(T(NaN), RoundDown)    === T(NaN)
+    @test rem2pi(T(NaN), RoundUp)      === T(NaN)
+end
+
 import Base.^
 struct PR20530; end
 struct PR20889; x; end


### PR DESCRIPTION
Fix for #32888 

This will also fix the `mod2pi`. 

There was a discussion that Domain Error should be thrown or `NaN `should be returned. To be consistent with `rem` I returned `NaN`