### PR TITLE
RFC: Document that mapreduce(f, op, _) may exploit commutativity of op and purity of f

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -270,6 +270,10 @@ In general, it will be necessary to provide `init` to work with empty collection
 intermediate collection needs to be created. See documentation for [`reduce`](@ref) and
 [`map`](@ref).
 
+Known commutativity of the operation `op` such as `+` and `max` may be exploited in the
+implementation.  It means that the elements of `itr` may be accessed out of order and
+the order in which `f` is called is implementation-defined.
+
 !!! compat "Julia 1.2"
     `mapreduce` with multiple iterators requires Julia 1.2 or later.
 
@@ -439,6 +443,9 @@ The associativity of the reduction is implementation dependent. This means that 
 use non-associative operations like `-` because it is undefined whether `reduce(-,[1,2,3])`
 should be evaluated as `(1-2)-3` or `1-(2-3)`. Use [`foldl`](@ref) or
 [`foldr`](@ref) instead for guaranteed left or right associativity.
+
+Known commutativity of the operation `op` such as `+` and `max` may be exploited in the
+implementation.  It means that the elements of `itr` may be accessed out of order.
 
 Some operations accumulate error. Parallelism will be easier if the reduction can be
 executed in groups. Future versions of Julia might change the algorithm. Note that the

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -271,7 +271,7 @@ intermediate collection needs to be created. See documentation for [`reduce`](@r
 [`map`](@ref).
 
 Known commutativity of the operation `op` such as `+` and `max` may be exploited in the
-implementation.  It means that the elements of `itr` may be accessed out of order and
+implementation. This means that the elements of `itr` may be accessed out of order and
 the order in which `f` is called is implementation-defined.
 
 !!! compat "Julia 1.2"
@@ -445,7 +445,7 @@ should be evaluated as `(1-2)-3` or `1-(2-3)`. Use [`foldl`](@ref) or
 [`foldr`](@ref) instead for guaranteed left or right associativity.
 
 Known commutativity of the operation `op` such as `+` and `max` may be exploited in the
-implementation.  It means that the elements of `itr` may be accessed out of order.
+implementation. This means that the elements of `itr` may be accessed out of order.
 
 Some operations accumulate error. Parallelism will be easier if the reduction can be
 executed in groups. Future versions of Julia might change the algorithm. Note that the


### PR DESCRIPTION
Currently `reduce` etc. document that it may exploit associativity of the operator.  However, we already exploit commutativity of certain operations like `max`

https://github.com/JuliaLang/julia/blob/98a845f99541e6ece591a3c0528cdf400a39ff88/base/reduce.jl#L627-L630

Also, using `@simd` arguably requires this caveat.  So, I propose to document the current behavior.

If we do this, I think it makes sense to also require that `f` and `getindex(A, _)` for `mapreduce(f, op, A)` are reasonably pure and they may be called out of order.  Again, this is already assumed in `mapreduce(f, max, array)` since it runs over the array (up to) twice.

https://github.com/JuliaLang/julia/blob/98a845f99541e6ece591a3c0528cdf400a39ff88/base/reduce.jl#L642-L650

In particular, it means that it's possible to implement a more efficient `maximum(f, ::PermutedDimsArray)` etc.

close #36081
