### PR TITLE
Sys.detectwsl()

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -31,7 +31,8 @@ export BINDIR,
        iswindows,
        isjsvm,
        isexecutable,
-       which
+       which,
+       detectwsl
 
 import ..Base: show
 
@@ -411,7 +412,18 @@ including e.g. a WebAssembly JavaScript embedding in a web browser.
 """
 isjsvm(os::Symbol) = (os === :Emscripten)
 
-for f in (:isunix, :islinux, :isbsd, :isapple, :iswindows, :isfreebsd, :isopenbsd, :isnetbsd, :isdragonfly, :isjsvm)
+"""
+    Sys.detectwsl([os])
+
+Runtime Predicate for testing if Julia is running inside WSL.
+"""
+function detectwsl(os::Symbol)
+    islinux(os) &&
+    isfile("/proc/sys/kernel/osrelease") &&
+    contains(read("/proc/sys/kernel/osrelease", String), r"Microsoft|WSL"i)
+end
+
+for f in (:detectwsl, :isunix, :islinux, :isbsd, :isapple, :iswindows, :isfreebsd, :isopenbsd, :isnetbsd, :isdragonfly, :isjsvm)
     @eval $f() = $(getfield(@__MODULE__, f)(KERNEL))
 end
 

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -28,6 +28,11 @@
     else
         @test Sys.windows_version() >= v"1.0.0-"
     end
+
+    @test !Sys.detectwsl(:Windows)
+    if !Sys.islinux()
+        @test !Sys.detectwsl()
+    end
 end
 
 @testset "@static" begin


### PR DESCRIPTION
Tries to solve #36354 

Since it will be a runtime function I did it with Julia itself.

I looked into libuv docs and there is no wrapper function to get proc-version since Its too system specific and libuv abstracts it.

Looking at https://github.com/microsoft/WSL/issues/4071 and [javascript/wsl](https://github.com/sindresorhus/is-wsl/blob/master/index.js) seems that we can only find it from version information

If its not the correct way then please give me some pointers in the correct direction. 