### PR TITLE
Fix some invalidations during Julia's bootstrap

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -129,6 +129,7 @@ include("abstractarraymath.jl")
 include("arraymath.jl")
 
 # SIMD loops
+@pure sizeof(s::String) = Core.sizeof(s)  # needed by gensym as called from simdloop
 include("simdloop.jl")
 using .SimdLoop
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1047,6 +1047,9 @@ function getindex(A::AbstractArray, I...)
     error_if_canonical_getindex(IndexStyle(A), A, I...)
     _getindex(IndexStyle(A), A, to_indices(A, I)...)
 end
+# To avoid invalidations from multidimensional.jl: getindex(A::Array, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...)
+getindex(A::Array, i1::Integer, I::Integer...) = A[to_indices(A, (i1, I...))...]
+
 function unsafe_getindex(A::AbstractArray, I...)
     @_inline_meta
     @inbounds r = getindex(A, I...)
@@ -2150,7 +2153,7 @@ end
 # map on collections
 map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 
-mapany(f, itr) = map!(f, Vector{Any}(undef, length(itr)), itr)  # convenient for Expr.args
+mapany(f, itr) = map!(f, Vector{Any}(undef, length(itr)::Int), itr)  # convenient for Expr.args
 
 # default to returning an Array for `map` on general iterators
 """

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -96,7 +96,7 @@ function signature!(tv, expr::Expr)
             push!(sig.args[end].args, argtype(arg))
         end
         if isexpr(expr.args[1], :curly) && isempty(tv)
-            append!(tv, mapany(tvar, expr.args[1].args[2:end]))
+            append!(tv, mapany(tvar, (expr.args[1]::Expr).args[2:end]))
         end
         for i = length(tv):-1:1
             push!(sig.args, :(Tuple{$(tv[i].args[1])}))

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -172,6 +172,8 @@ convert(::Type{T}, x::T) where {T} = x
 convert(::Type{Type}, x::Type) = x # the ssair optimizer is strongly dependent on this method existing to avoid over-specialization
                                    # in the absence of inlining-enabled
                                    # (due to fields typed as `Type`, which is generally a bad idea)
+# These end up being called during bootstrap and then would be invalidated if not for the following:
+convert(::Type{String}, x::String) = x
 
 """
     @eval [mod,] ex

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -320,6 +320,10 @@ not all index types are guaranteed to propagate to `Base.to_index`.
 """
 to_indices(A, I::Tuple) = (@_inline_meta; to_indices(A, axes(A), I))
 to_indices(A, I::Tuple{Any}) = (@_inline_meta; to_indices(A, (eachindex(IndexLinear(), A),), I))
+# In simple cases, we know that we don't need to use axes(A), optimize those.
+# Having this here avoids invalidations from multidimensional.jl: to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex}}})
+to_indices(A, I::Tuple{}) = ()
+to_indices(A, I::Tuple{Vararg{Integer}}) = (@_inline_meta; to_indices(A, (), I))
 to_indices(A, inds, ::Tuple{}) = ()
 to_indices(A, inds, I::Tuple{Any, Vararg{Any}}) =
     (@_inline_meta; (to_index(A, I[1]), to_indices(A, _maybetail(inds), tail(I))...))

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -266,6 +266,9 @@ function active_project(search_load_path::Bool=true)
         project == "@" && continue
         project = load_path_expand(project)
         project === nothing && continue
+        # while this seems well-inferred, nevertheless without the type annotation below
+        # there are backedges here from abspath(::AbstractString, ::String)
+        project = project::String
         if !isfile_casesensitive(project) && basename(project) ∉ project_names
             project = abspath(project, "Project.toml")
         end

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -155,7 +155,7 @@ function _parse_string(text::AbstractString, filename::AbstractString,
     if index < 1 || index > ncodeunits(text) + 1
         throw(BoundsError(text, index))
     end
-    ex, offset = Core._parse(text, filename, index-1, options)
+    ex, offset::Int = Core._parse(text, filename, index-1, options)
     ex, offset+1
 end
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -701,7 +701,6 @@ ensure_indexable(I::Tuple{}) = ()
 
 # In simple cases, we know that we don't need to use axes(A). Optimize those
 # until Julia gets smart enough to elide the call on its own:
-to_indices(A, I::Tuple{}) = ()
 @inline to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex}}}) = to_indices(A, (), I)
 # But some index types require more context spanning multiple indices
 # CartesianIndexes are simple; they just splat out

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -17,7 +17,7 @@ end
 
 function shell_parse(str::AbstractString, interpolate::Bool=true;
                      special::AbstractString="")
-    s::SubString = SubString(str, firstindex(str))
+    s = SubString(str, firstindex(str))
     s = rstrip_shell(lstrip(s))
 
     # N.B.: This is used by REPLCompletions
@@ -37,9 +37,9 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
             push!(arg, x)
         end
     end
-    function consume_upto(j)
+    function consume_upto(s, i, j)
         update_arg(s[i:prevind(s, j)])
-        i = something(peek(st), (lastindex(s)+1,'\0'))[1]
+        something(peek(st), (lastindex(s)+1,'\0'))[1]
     end
     function append_arg()
         if isempty(arg); arg = Any["",]; end
@@ -49,7 +49,7 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
 
     for (j, c) in st
         if !in_single_quotes && !in_double_quotes && isspace(c)
-            consume_upto(j)
+            i = consume_upto(s, i, j)
             append_arg()
             while !isempty(st)
                 # We've made sure above that we don't end in whitespace,
@@ -59,7 +59,7 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
                 popfirst!(st)
             end
         elseif interpolate && !in_single_quotes && c == '$'
-            consume_upto(j)
+            i = consume_upto(s, i, j)
             isempty(st) && error("\$ right before end of command")
             stpos, c = popfirst!(st)
             isspace(c) && error("space not allowed right after \$")
@@ -79,21 +79,21 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
         else
             if !in_double_quotes && c == '\''
                 in_single_quotes = !in_single_quotes
-                consume_upto(j)
+                i = consume_upto(s, i, j)
             elseif !in_single_quotes && c == '"'
                 in_double_quotes = !in_double_quotes
-                consume_upto(j)
+                i = consume_upto(s, i, j)
             elseif c == '\\'
                 if in_double_quotes
                     isempty(st) && error("unterminated double quote")
                     k, c′ = peek(st)
                     if c′ == '"' || c′ == '$' || c′ == '\\'
-                        consume_upto(j)
+                        i = consume_upto(s, i, j)
                         _ = popfirst!(st)
                     end
                 elseif !in_single_quotes
                     isempty(st) && error("dangling backslash")
-                    consume_upto(j)
+                    i = consume_upto(s, i, j)
                     _ = popfirst!(st)
                 end
             elseif !in_single_quotes && !in_double_quotes && c in special

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -26,7 +26,7 @@ function check_body!(x::Expr)
     if x.head === :break || x.head === :continue
         throw(SimdError("$(x.head) is not allowed inside a @simd loop body"))
     elseif x.head === :macrocall && x.args[1] === Symbol("@goto")
-        throw(SimdError("$(x.args[1]) is not allowed inside a @simd loop body"))
+        throw(SimdError("@goto is not allowed inside a @simd loop body"))
     end
     for arg in x.args
         check_body!(arg)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -95,7 +95,6 @@ pointer(s::String) = unsafe_convert(Ptr{UInt8}, s)
 pointer(s::String, i::Integer) = pointer(s)+(i-1)
 
 @pure ncodeunits(s::String) = Core.sizeof(s)
-@pure sizeof(s::String) = Core.sizeof(s)
 codeunit(s::String) = UInt8
 
 @inline function codeunit(s::String, i::Integer)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -224,7 +224,7 @@ julia> lstrip(a)
 """
 function lstrip(f, s::AbstractString)
     e = lastindex(s)
-    for (i, c) in pairs(s)
+    for (i::Int, c::AbstractChar) in pairs(s)
         !f(c) && return @inbounds SubString(s, i, e)
     end
     SubString(s, e+1, e)

--- a/base/util.jl
+++ b/base/util.jl
@@ -66,7 +66,7 @@ Printing with the color `:nothing` will print the string without modifications.
 """
 text_colors
 
-function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args...; bold::Bool = false)
+function with_output_color(@nospecialize(f::Function), color::Union{Int, Symbol}, io::IO, args...; bold::Bool = false)
     buf = IOBuffer()
     iscolor = get(io, :color, false)::Bool
     try f(IOContext(buf, io), args...)


### PR DESCRIPTION
This cuts the total number of invalidations that occur during Julia's build process approximately in half. It may knock about 2% off Julia's build time, though that's about in the noise so I am not sure. Here was one run on `master`:
```
Sysimage built. Summary:
Total ───────  52.165692 seconds 
Base: ───────  21.758738 seconds 41.7108%
Stdlibs: ────  30.406945 seconds 58.2892%
    JULIA usr/lib/julia/sys-o.a
Generating precompile statements... 30/30
Executing precompile statements... 1870/1877
Precompilation complete. Summary:
Total ───────  84.620999 seconds
Generation ──  58.195211 seconds 68.7716%
Execution ───  26.425789 seconds 31.2284%
```
and here were two runs on this(*caveat: also using #35877) branch:
```
Sysimage built. Summary:
Total ───────  50.963781 seconds 
Base: ───────  20.885574 seconds 40.9812%
Stdlibs: ────  30.078193 seconds 59.0188%
    JULIA usr/lib/julia/sys-o.a
Generating precompile statements... 30/30
Executing precompile statements... 1858/1865
Precompilation complete. Summary:
Total ───────  85.445948 seconds
Generation ──  59.581762 seconds 69.7304%
Execution ───  25.864185 seconds 30.2696%

Sysimage built. Summary:
Total ───────  49.995934 seconds 
Base: ───────  20.612026 seconds 41.2274%
Stdlibs: ────  29.383900 seconds 58.7726%
    JULIA usr/lib/julia/sys-o.a
Generating precompile statements... 30/30
Executing precompile statements... 1858/1865
Precompilation complete. Summary:
Total ───────  85.556325 seconds
Generation ──  59.087194 seconds 69.0623%
Execution ───  26.469131 seconds 30.9377%
```

Interestingly, both were about a second longer on generating the precompile statements, reducing or eliminating the total advantage. I don't know whether that's systematic. (With fewer to build, you might expect it to be faster, maybe?)

The remaining invalidations fit a couple of patterns:
- lots of invalidations from loading `reducedim.jl`, which specialize methods already in active use from `reduce.jl`
- lots of `promote_rule` invalidations due to specializing the fallbacks. None of these have large cascades of consequences, however.
- a couple of invalidations, one with a consequence of quite a few `MethodInstances` (~80? I don't really remember), from code that *might* call a function before it has any methods defined (result: they mt-invalidate themselves):
  + `with_output_color` gets used by the `show` method in `cmd.jl` which gets used by Base.FileRedirect via the logging framework
  + `fill!` isn't defined until well after its first potential use by `show(io::IO, x::Type)`, via the `vcat` call


While trying to understand the `with_output_color` phenomenon I added a `@nospecialize`, this is a bonus but it seems reasonable.

I'm happy to back out some of these if folks prefer, just let me know. I was basically going down the list, but none of these are game-changing so we can afford to drop some.