### PR TITLE
RFC: in Core.show, make printing of Method/MethodInstance more precise

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -649,20 +649,14 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     }
     else if (vt == jl_method_type) {
         jl_method_t *m = (jl_method_t*)v;
-        n += jl_static_show_x(out, (jl_value_t*)m->module, depth);
-        n += jl_printf(out, ".%s(...)", jl_symbol_name(m->name));
+        n += jl_static_show_func_sig(out, m->sig);
     }
     else if (vt == jl_method_instance_type) {
         jl_method_instance_t *li = (jl_method_instance_t*)v;
         if (jl_is_method(li->def.method)) {
-            if (li->specTypes) {
-                n += jl_static_show_func_sig(out, li->specTypes);
-            }
-            else {
-                jl_method_t *m = li->def.method;
-                n += jl_static_show_x(out, (jl_value_t*)m->module, depth);
-                n += jl_printf(out, ".%s(?)", jl_symbol_name(m->name));
-            }
+            n += jl_static_show_func_sig(out, li->specTypes);
+            n += jl_printf(out, " from ");
+            n += jl_static_show_func_sig(out, li->def.method->sig);
         }
         else {
             n += jl_static_show_x(out, (jl_value_t*)li->def.module, depth);


### PR DESCRIPTION
```
julia> Core.println(which(+, (Int32, Int64)).specializations[1])
+(UInt64, Int64)

julia> Core.println(which(+, (Int32, Int64)))
Base.+(...)
```
==>
```
julia> Core.println(which(+, (Int32, Int64)).specializations[1])
+(UInt64, Int64) from +(Integer, Integer)
```

I don't expect any concerns for the RFC tag, since this is mostly just an internal thing, but I do think it's useful here to be verbose. Primarily where someone might see this is in gdb-debugging while looking at IR, since these show up in `:invoke` statements:
```
julia> code_typed(IOBuffer, ()) |> Core.println
Array{Any, (1,)}[Base.Pair{Core.CodeInfo, DataType}(first=Core.CodeInfo(code=Array{Any, (2,)}[
  Expr(:invoke, #IOBuffer#327(Bool, Bool, Nothing, Bool, Int64, Nothing, Type{Base.GenericIOBuffer{Array{UInt8, 1}}}) from #IOBuffer#327(Union{Nothing, Bool}, Union{Nothing, Bool}, Union{Nothing, Bool}, Union{Nothing, Bool}, Integer, Union{Nothing, Integer}, Type{Base.GenericIOBuffer{Array{UInt8, 1}}}), Base.:(#IOBuffer#327), true, true, Base.nothing, true, 9223372036854775807, Base.nothing, Core.Argument(n=1)),
...
```