### PR TITLE
active project: get rid of the concept of a home project

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,13 @@ Compiler/Runtime improvements
 Command-line option changes
 ---------------------------
 
+* There is no longer a concept of "home project": starting `julia --project=dir`
+  is now exactly equivalent to starting `julia` and then doing `pkg> activate
+  $dir` and `julia --project` is exactly equivalent to doing that where
+  `dir = Base.current_project()`. In particular, this means that if you do
+  `pkg> activate` after starting `julia` with the `--project` option (or with
+  `JULIA_PROJECT` set) it will take you to the default active project, which is
+  `@v1.5` unless you have modified `LOAD_PATH`. ([#36434])
 
 Multi-threading changes
 -----------------------

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -394,6 +394,7 @@ function __init__()
     # initialize loading
     init_depot_path()
     init_load_path()
+    init_active_project()
     nothing
 end
 

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -101,7 +101,7 @@ function init_depot_path()
     end
 end
 
-## LOAD_PATH, HOME_PROJECT & ACTIVE_PROJECT ##
+## LOAD_PATH & ACTIVE_PROJECT ##
 
 # JULIA_LOAD_PATH: split on `:` (or `;` on Windows)
 # first empty entry is replaced with DEFAULT_LOAD_PATH, the rest are skipped
@@ -155,6 +155,7 @@ See also:
 [Code Loading](@ref Code-Loading).
 """
 const LOAD_PATH = copy(DEFAULT_LOAD_PATH)
+# HOME_PROJECT is no longer used, here just to avoid breaking things
 const HOME_PROJECT = Ref{Union{String,Nothing}}(nothing)
 const ACTIVE_PROJECT = Ref{Union{String,Nothing}}(nothing)
 
@@ -211,14 +212,17 @@ function init_load_path()
         paths = filter!(env -> env !== nothing,
             [env == "@." ? current_project() : env for env in DEFAULT_LOAD_PATH])
     end
+    append!(empty!(LOAD_PATH), paths)
+end
+
+function init_active_project()
     project = (JLOptions().project != C_NULL ?
         unsafe_string(Base.JLOptions().project) :
         get(ENV, "JULIA_PROJECT", nothing))
-    HOME_PROJECT[] =
+    ACTIVE_PROJECT[] =
         project === nothing ? nothing :
         project == "" ? nothing :
         project == "@." ? current_project() : abspath(expanduser(project))
-    append!(empty!(LOAD_PATH), paths)
 end
 
 ## load path expansion: turn LOAD_PATH entries into concrete paths ##
@@ -262,7 +266,7 @@ end
 load_path_expand(::Nothing) = nothing
 
 function active_project(search_load_path::Bool=true)
-    for project in (ACTIVE_PROJECT[], HOME_PROJECT[])
+    for project in (ACTIVE_PROJECT[],)
         project == "@" && continue
         project = load_path_expand(project)
         project === nothing && continue

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1194,7 +1194,7 @@ function load_path_setup_code(load_path::Bool=true)
         code *= """
         append!(empty!(Base.LOAD_PATH), $(repr(load_path)))
         ENV["JULIA_LOAD_PATH"] = $(repr(join(load_path, Sys.iswindows() ? ';' : ':')))
-        Base.HOME_PROJECT[] = Base.ACTIVE_PROJECT[] = nothing
+        Base.ACTIVE_PROJECT[] = nothing
         """
     end
     return code
@@ -1206,7 +1206,7 @@ function include_package_for_output(input::String, depot_path::Vector{String}, d
     append!(empty!(Base.DL_LOAD_PATH), dl_load_path)
     append!(empty!(Base.LOAD_PATH), load_path)
     ENV["JULIA_LOAD_PATH"] = join(load_path, Sys.iswindows() ? ';' : ':')
-    Base.HOME_PROJECT[] = Base.ACTIVE_PROJECT[] = nothing
+    Base.ACTIVE_PROJECT[] = nothing
     Base._track_dependencies[] = true
     append!(empty!(Base._concrete_dependencies), concrete_deps)
 

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -365,12 +365,9 @@ function report_bug(kind)
             mktempdir() do tmp
                 old_load_path = copy(LOAD_PATH)
                 push!(empty!(LOAD_PATH), joinpath(tmp, "Project.toml"))
-                old_home_project = Base.HOME_PROJECT[]
-                Base.HOME_PROJECT[] = nothing
                 Pkg.add(Pkg.PackageSpec(BugReportingId.name, BugReportingId.uuid))
                 BugReporting = Base.require(BugReportingId)
                 append!(empty!(LOAD_PATH), old_load_path)
-                Base.HOME_PROJECT[] = old_home_project
             end
         end
     else

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -183,12 +183,10 @@ end
 
 saved_load_path = copy(LOAD_PATH)
 saved_depot_path = copy(DEPOT_PATH)
-saved_home_project = Base.HOME_PROJECT[]
 saved_active_project = Base.ACTIVE_PROJECT[]
 
 push!(empty!(LOAD_PATH), "project")
 push!(empty!(DEPOT_PATH), "depot")
-Base.HOME_PROJECT[] = nothing
 Base.ACTIVE_PROJECT[] = nothing
 
 @test load_path() == [abspath("project","Project.toml")]
@@ -667,7 +665,6 @@ end
 
 append!(empty!(LOAD_PATH), saved_load_path)
 append!(empty!(DEPOT_PATH), saved_depot_path)
-Base.HOME_PROJECT[] = saved_home_project
 Base.ACTIVE_PROJECT[] = saved_active_project
 
 # issue #28190


### PR DESCRIPTION
This makes doing `julia --project` equivalent to activating the project that the current directory is in at Julia startup. What this means is that if you do `pkg> activate` instead of taking you back to whatever project was initially active, it will make it as if you had never activated a project in the first place.

I think the "home project" idea is more confusing than it's worth and I do actually quite often want to deactivate the current project and get access to whatever the fallback active project would be, i.e. `@v1.6`, so this simpler version of this seems not only easier to explain but also more useful.

cc @fredrikekre, @KristofferC 