### PR TITLE
gf: improve ordering of operations based on performance estimates

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1513,6 +1513,11 @@ jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np)
     return (jl_datatype_t*)inst_datatype_inner(jl_anytuple_type, NULL, p, np, 1, NULL, NULL);
 }
 
+jl_tupletype_t *jl_lookup_arg_tuple_type(jl_value_t *arg1, jl_value_t **args, size_t nargs, int leaf)
+{
+    return (jl_datatype_t*)lookup_typevalue(jl_tuple_typename, arg1, args, nargs, leaf);
+}
+
 jl_tupletype_t *jl_inst_arg_tuple_type(jl_value_t *arg1, jl_value_t **args, size_t nargs, int leaf)
 {
     jl_tupletype_t *tt = (jl_datatype_t*)lookup_typevalue(jl_tuple_typename, arg1, args, nargs, leaf);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -444,6 +444,7 @@ int jl_has_concrete_subtype(jl_value_t *typ);
 jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np) JL_ALWAYS_LEAFTYPE;
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p) JL_ALWAYS_LEAFTYPE;
 jl_tupletype_t *jl_inst_arg_tuple_type(jl_value_t *arg1, jl_value_t **args, size_t nargs, int leaf);
+jl_tupletype_t *jl_lookup_arg_tuple_type(jl_value_t *arg1 JL_PROPAGATES_ROOT, jl_value_t **args, size_t nargs, int leaf);
 JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
 jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED;
 jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, int *issubty);


### PR DESCRIPTION
In the last commit (#36166), I didn't expect NamedTuple to hammer our
performance, but was starting to notice performance problems with trying
to call constructors. It's somewhat violating our best-practices in two
common cases (both the constructor and structdiff functions are
dispatching on non-leaf types instead of values). That was putting a lot
of strain on the cache, and so it forms a good test case. Keeping those
cases out of the cache, and searching the cache in a more suitable order
(significant mainly for constructors because there are always so many of
them), offsets that--and seems to probably make us faster overall as a
bonus because of that effect!

Here's what I was measuring that was highlighting this issue:
```
julia> @btime methods(==, (Int64, Int64)) 
   1.248 μs (18 allocations: 784 bytes) # before PR
  32.553 μs (18 allocations: 784 bytes) # master now
   1.310 μs (18 allocations: 784 bytes) # this PR
```