### PR TITLE
Canonicalize IR to disallow throwing GlobalRef in value position

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -168,6 +168,8 @@ function fixemup!(cond, rename, ir::IRCode, ci::CodeInfo, idx::Int, @nospecializ
                 return nothing
             end
             op[] = x
+        elseif isa(val, GlobalRef) && !isdefined(val.mod, val.name)
+            op[] = NewSSAValue(insert_node!(ir, idx, Any, val).id - length(ir.stmts))
         end
     end
     return urs[]


### PR DESCRIPTION
In anticipation of making the SSA IR more of an interface
that packages can use to implement custom compiler transformation,
I'd like to do some cleanup first. The is the first of the items
on my list: Disallowing GlobalRef in value position if it could
potentially throw (because the binding doesn't exist yet).

This is done as part of SSA conversion, because we don't know
whether a binding will exist during parsing/lowering and we
don't modify the IR at all between lowering and the end of
type inference, so doing it during SSA conversion is the first
possible opportunity.

The reason to do this is to simplify transformation passes that
want to replace calls with sequences of other instructions. By
moving those GlobalRef that could potentially throw into statement
position, the order of argument evaluation does not matter (this
isn't quite true yet due to static parameters, but I'd like to
fix that in a separate commit). I think that's a desirable property
to simplify the life os pass authors.