### PR TITLE
fix #36391, ensure anything `precompile`d ends up in output

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -662,6 +662,8 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         int flags = validate << 0;
         if (codeinst->invoke == jl_fptr_const_return)
             flags |= 1 << 2;
+        if (codeinst->precompile)
+            flags |= 1 << 3;
         write_uint8(s->s, flags);
         jl_serialize_value(s, (jl_value_t*)codeinst->def);
         if (validate || codeinst->min_world == 0) {
@@ -1494,6 +1496,8 @@ static jl_value_t *jl_deserialize_value_code_instance(jl_serializer_state *s, jl
     jl_gc_wb(codeinst, codeinst->rettype);
     if (constret)
         codeinst->invoke = jl_fptr_const_return;
+    if ((flags >> 3) & 1)
+        codeinst->precompile = 1;
     codeinst->next = (jl_code_instance_t*)jl_deserialize_value(s, (jl_value_t**)&codeinst->next);
     jl_gc_wb(codeinst, codeinst->next);
     if (validate)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2356,7 +2356,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_code_instance_type =
         jl_new_datatype(jl_symbol("CodeInstance"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(10,
+                        jl_perm_symsvec(11,
                             "def",
                             "next",
                             "min_world",
@@ -2366,8 +2366,8 @@ void jl_init_types(void) JL_GC_DISABLED
                             "inferred",
                             //"edges",
                             //"absolute_max",
-                            "isspecsig", "invoke", "specptr"), // function object decls
-                        jl_svec(10,
+                            "isspecsig", "precompile", "invoke", "specptr"), // function object decls
+                        jl_svec(11,
                             jl_method_instance_type,
                             jl_any_type,
                             jl_ulong_type,
@@ -2377,6 +2377,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_any_type,
                             //jl_any_type,
                             //jl_bool_type,
+                            jl_bool_type,
                             jl_bool_type,
                             jl_any_type, jl_any_type), // fptrs
                         0, 1, 1);
@@ -2498,8 +2499,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_methtable_type->types, 11, jl_uint8_type);
     jl_svecset(jl_method_type->types, 13, jl_method_instance_type);
     jl_svecset(jl_method_instance_type->types, 5, jl_code_instance_type);
-    jl_svecset(jl_code_instance_type->types, 8, jl_voidpointer_type);
     jl_svecset(jl_code_instance_type->types, 9, jl_voidpointer_type);
+    jl_svecset(jl_code_instance_type->types, 10, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -355,6 +355,7 @@ typedef struct _jl_code_instance_t {
 
     // compilation state cache
     uint8_t isspecsig; // if specptr is a specialized function signature for specTypes->rettype
+    uint8_t precompile;  // if set, this will be added to the output system image
     jl_callptr_t invoke; // jlcall entry point
     jl_generic_specptr_t specptr; // private data for `jlcall entry point`
 } jl_code_instance_t;

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -326,7 +326,7 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
                 !jl_ir_flag_inlineable((jl_array_t*)codeinst->inferred)) {
                 do_compile = 1;
             }
-            else if (codeinst->invoke != NULL) {
+            else if (codeinst->invoke != NULL || codeinst->precompile) {
                 do_compile = 1;
             }
         }


### PR DESCRIPTION
This adds a bit to `CodeInstance` to keep track of what we execute or call `precompile` on, to ensure it ends up in the output if we are generating a system image. Fixes #36391, and has some other latency benefits, e.g. the time to precompile Plots goes from 132 seconds to 125.