### PR TITLE
[contrib/mac/app] Improve `renotarize_dmg.sh`

### DIFF
--- a/contrib/mac/app/renotarize_dmg.sh
+++ b/contrib/mac/app/renotarize_dmg.sh
@@ -12,8 +12,17 @@ if [[ -z "${APPLEID}" ]] || [[ -z "${APPLEID_PASSWORD}" ]]; then
     exit 1
 fi
 
+# Translate from `s3://` URL to `https://` url:
+URL="$1"
+if [[ "$URL" == s3://* ]]; then
+    # Chop off `s3://`
+    URL="${URL:5}"
+    # Split into bucket.s3.aws.com/path
+    URL="https://${URL%%/*}.s3.amazonaws.com/${URL#*/}"
+fi
+
 # Download .dmg
-curl -L "$1" -O
+curl -L "${URL}" -O
 
 # Unpack dmg into our `dmg` folder
 rm -rf dmg
@@ -27,6 +36,11 @@ cp -Ra /Volumes/Julia-* dmg
 DMG_NAME=$(basename "$1")
 APP_NAME=$(basename dmg/*.app)
 VOL_NAME=$(basename /Volumes/Julia-*)
+
+if [[ ! -d dmg/${APP_NAME} ]]; then
+    echo "ERORR: Unable to auto-detect APP_NAME, check dmg folder!" >&2
+    exit 1
+fi
 # Unmount everything again
 for j in /Volumes/Julia-*; do hdiutil detach "${j}"; done
 


### PR DESCRIPTION
Add more error checking, allow direct pasting in of `s3://` URLs

[skip ci]

**EDIT**: Apparently, the `[skip ci]` should go into the commit message, not the PR text field.  :P 