### PR TITLE
Fix invalidations from novel Integer conversions

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -166,18 +166,19 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                       vdots::AbstractString = "\u22ee",
                       ddots::AbstractString = "  \u22f1  ",
                       hmod::Integer = 5, vmod::Integer = 5)
+    hmod, vmod = Int(hmod)::Int, Int(vmod)::Int
     if !(get(io, :limit, false)::Bool)
         screenheight = screenwidth = typemax(Int)
     else
-        sz = displaysize(io)
+        sz = displaysize(io)::Tuple{Int,Int}
         screenheight, screenwidth = sz[1] - 4, sz[2]
     end
-    screenwidth -= length(pre) + length(post)
-    presp = repeat(" ", length(pre))  # indent each row to match pre string
+    screenwidth -= length(pre)::Int + length(post)::Int
+    presp = repeat(" ", length(pre)::Int)  # indent each row to match pre string
     postsp = ""
     @assert textwidth(hdots) == textwidth(ddots)
-    sepsize = length(sep)
-    rowsA, colsA = UnitRange(axes(X,1)), UnitRange(axes(X,2))
+    sepsize = length(sep)::Int
+    rowsA, colsA = UnitRange{Int}(axes(X,1)), UnitRange{Int}(axes(X,2))
     m, n = length(rowsA), length(colsA)
     # To figure out alignments, only need to look at as many rows as could
     # fit down screen. If screen has at least as many rows as A, look at A.
@@ -204,14 +205,14 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                 if i != last(rowsA); println(io); end
             end
         else # rows fit down screen but cols don't, so need horizontal ellipsis
-            c = div(screenwidth-length(hdots)+1,2)+1  # what goes to right of ellipsis
+            c = div(screenwidth-length(hdots)::Int+1,2)+1  # what goes to right of ellipsis
             Ralign = reverse(alignment(io, X, rowsA, reverse(colsA), c, c, sepsize)) # alignments for right
-            c = screenwidth - sum(map(sum,Ralign)) - (length(Ralign)-1)*sepsize - length(hdots)
+            c = screenwidth - sum(map(sum,Ralign)) - (length(Ralign)-1)*sepsize - length(hdots)::Int
             Lalign = alignment(io, X, rowsA, colsA, c, c, sepsize) # alignments for left of ellipsis
             for i in rowsA
                 print(io, i == first(rowsA) ? pre : presp)
                 print_matrix_row(io, X,Lalign,i,colsA[1:length(Lalign)],sep)
-                print(io, (i - first(rowsA)) % hmod == 0 ? hdots : repeat(" ", length(hdots)))
+                print(io, (i - first(rowsA)) % hmod == 0 ? hdots : repeat(" ", length(hdots)::Int))
                 print_matrix_row(io, X, Ralign, i, (n - length(Ralign)) .+ colsA, sep)
                 print(io, i == last(rowsA) ? post : postsp)
                 if i != last(rowsA); println(io); end
@@ -231,15 +232,15 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                 end
             end
         else # neither rows nor cols fit, so use all 3 kinds of dots
-            c = div(screenwidth-length(hdots)+1,2)+1
+            c = div(screenwidth-length(hdots)::Int+1,2)+1
             Ralign = reverse(alignment(io, X, rowsA, reverse(colsA), c, c, sepsize))
-            c = screenwidth - sum(map(sum,Ralign)) - (length(Ralign)-1)*sepsize - length(hdots)
+            c = screenwidth - sum(map(sum,Ralign)) - (length(Ralign)-1)*sepsize - length(hdots)::Int
             Lalign = alignment(io, X, rowsA, colsA, c, c, sepsize)
             r = mod((length(Ralign)-n+1),vmod) # where to put dots on right half
             for i in rowsA
                 print(io, i == first(rowsA) ? pre : presp)
                 print_matrix_row(io, X,Lalign,i,colsA[1:length(Lalign)],sep)
-                print(io, (i - first(rowsA)) % hmod == 0 ? hdots : repeat(" ", length(hdots)))
+                print(io, (i - first(rowsA)) % hmod == 0 ? hdots : repeat(" ", length(hdots)::Int))
                 print_matrix_row(io, X,Ralign,i,(n-length(Ralign)).+colsA,sep)
                 print(io, i == last(rowsA) ? post : postsp)
                 if i != rowsA[end] || i == rowsA[halfheight]; println(io); end

--- a/base/int.jl
+++ b/base/int.jl
@@ -369,7 +369,7 @@ julia> count_ones(7)
 3
 ```
 """
-count_ones(x::BitInteger) = ctpop_int(x) % Int
+count_ones(x::BitInteger) = (ctpop_int(x) % Int)::Int
 
 """
     leading_zeros(x::Integer) -> Integer
@@ -382,7 +382,7 @@ julia> leading_zeros(Int32(1))
 31
 ```
 """
-leading_zeros(x::BitInteger) = ctlz_int(x) % Int
+leading_zeros(x::BitInteger) = (ctlz_int(x) % Int)::Int
 
 """
     trailing_zeros(x::Integer) -> Integer
@@ -395,7 +395,7 @@ julia> trailing_zeros(2)
 1
 ```
 """
-trailing_zeros(x::BitInteger) = cttz_int(x) % Int
+trailing_zeros(x::BitInteger) = (cttz_int(x) % Int)::Int
 
 """
     count_zeros(x::Integer) -> Integer

--- a/base/refvalue.jl
+++ b/base/refvalue.jl
@@ -22,12 +22,12 @@ function unsafe_convert(P::Type{Ptr{T}}, b::RefValue{T}) where T
         # which also ensures this returns same pointer as the one rooted in the `RefValue` object.
         p = pointerref(Ptr{Ptr{Cvoid}}(pointer_from_objref(b)), 1, Core.sizeof(Ptr{Cvoid}))
     end
-    return convert(P, p)
+    return convert(P, p)::Ptr{T}
 end
 function unsafe_convert(P::Type{Ptr{Any}}, b::RefValue{Any})
-    return convert(P, pointer_from_objref(b))
+    return convert(P, pointer_from_objref(b))::Ptr{Any}
 end
-unsafe_convert(::Type{Ptr{Cvoid}}, b::RefValue{T}) where {T} = convert(Ptr{Cvoid}, unsafe_convert(Ptr{T}, b))
+unsafe_convert(::Type{Ptr{Cvoid}}, b::RefValue{T}) where {T} = convert(Ptr{Cvoid}, unsafe_convert(Ptr{T}, b))::Ptr{Cvoid}
 
 getindex(b::RefValue) = b.x
 setindex!(b::RefValue, x) = (b.x = x; b)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -422,11 +422,11 @@ struct SubstitutionString{T<:AbstractString} <: AbstractString
     string::T
 end
 
-ncodeunits(s::SubstitutionString) = ncodeunits(s.string)
-codeunit(s::SubstitutionString) = codeunit(s.string)
-codeunit(s::SubstitutionString, i::Integer) = codeunit(s.string, i)
-isvalid(s::SubstitutionString, i::Integer) = isvalid(s.string, i)
-iterate(s::SubstitutionString, i::Integer...) = iterate(s.string, i...)
+ncodeunits(s::SubstitutionString) = ncodeunits(s.string)::Int
+codeunit(s::SubstitutionString) = codeunit(s.string)::Type{<:Union{UInt8, UInt16, UInt32}}
+codeunit(s::SubstitutionString, i::Integer) = codeunit(s.string, i)::Union{UInt8, UInt16, UInt32}
+isvalid(s::SubstitutionString, i::Integer) = isvalid(s.string, i)::Bool
+iterate(s::SubstitutionString, i::Integer...) = iterate(s.string, i...)::Union{Nothing,Tuple{AbstractChar,Int}}
 
 function show(io::IO, s::SubstitutionString)
     print(io, "s")

--- a/base/set.jl
+++ b/base/set.jl
@@ -264,7 +264,7 @@ function unique!(f, A::AbstractVector; seen::Union{Nothing,Set}=nothing)
         return A
     end
 
-    i = firstindex(A)
+    i = firstindex(A)::Int
     x = @inbounds A[i]
     y = f(x)
     if seen === nothing
@@ -291,7 +291,7 @@ function _unique!(f, A::AbstractVector, seen::Set, current::Integer, i::Integer)
         end
         i += 1
     end
-    return resize!(A, current - firstindex(A) + 1)::typeof(A)
+    return resize!(A, current - firstindex(A)::Int + 1)::typeof(A)
 end
 
 

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -8,6 +8,7 @@ const shell_special = "#{}()[]<>|&*?~;"
 function rstrip_shell(s::AbstractString)
     c_old = nothing
     for (i, c) in Iterators.reverse(pairs(s))
+        i::Int; c::AbstractChar
         ((c == '\\') && c_old == ' ') && return SubString(s, 1, i+1)
         isspace(c) || return SubString(s, 1, i)
         c_old = c
@@ -38,8 +39,8 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
         end
     end
     function consume_upto(s, i, j)
-        update_arg(s[i:prevind(s, j)])
-        something(peek(st), (lastindex(s)+1,'\0'))[1]
+        update_arg(s[i:prevind(s, j)::Int])
+        something(peek(st), (lastindex(s)::Int+1,'\0'))[1]
     end
     function append_arg()
         if isempty(arg); arg = Any["",]; end
@@ -48,6 +49,7 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
     end
 
     for (j, c) in st
+        j::Int; c::AbstractChar
         if !in_single_quotes && !in_double_quotes && isspace(c)
             i = consume_upto(s, i, j)
             append_arg()

--- a/base/show.jl
+++ b/base/show.jl
@@ -395,7 +395,7 @@ function _show_default(io::IO, @nospecialize(x))
     show(io, inferencebarrier(t))
     print(io, '(')
     nf = nfields(x)
-    nb = sizeof(x)
+    nb = sizeof(x)::Int
     if nf != 0 || nb == 0
         if !show_circular(io, x)
             recur_io = IOContext(io, Pair{Symbol,Any}(:SHOWN_SET, x),

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -174,10 +174,10 @@ julia> sizeof("∀")
 3
 ```
 """
-sizeof(s::AbstractString) = ncodeunits(s) * sizeof(codeunit(s))
+sizeof(s::AbstractString) = ncodeunits(s)::Int * sizeof(codeunit(s)::Type{<:Union{UInt8,UInt16,UInt32}})
 firstindex(s::AbstractString) = 1
-lastindex(s::AbstractString) = thisind(s, ncodeunits(s))
-isempty(s::AbstractString) = iszero(ncodeunits(s))
+lastindex(s::AbstractString) = thisind(s, ncodeunits(s)::Int)
+isempty(s::AbstractString) = iszero(ncodeunits(s)::Int)
 
 function getindex(s::AbstractString, i::Integer)
     @boundscheck checkbounds(s, i)
@@ -204,9 +204,9 @@ end
 ## bounds checking ##
 
 checkbounds(::Type{Bool}, s::AbstractString, i::Integer) =
-    1 ≤ i ≤ ncodeunits(s)
+    1 ≤ i ≤ ncodeunits(s)::Int
 checkbounds(::Type{Bool}, s::AbstractString, r::AbstractRange{<:Integer}) =
-    isempty(r) || (1 ≤ minimum(r) && maximum(r) ≤ ncodeunits(s))
+    isempty(r) || (1 ≤ minimum(r) && maximum(r) ≤ ncodeunits(s)::Int)
 checkbounds(::Type{Bool}, s::AbstractString, I::AbstractArray{<:Real}) =
     all(i -> checkbounds(Bool, s, i), I)
 checkbounds(::Type{Bool}, s::AbstractString, I::AbstractArray{<:Integer}) =
@@ -382,12 +382,12 @@ julia> length("jμΛIα")
 5
 ```
 """
-length(s::AbstractString) = @inbounds return length(s, 1, ncodeunits(s))
+length(s::AbstractString) = @inbounds return length(s, 1, ncodeunits(s)::Int)
 
 function length(s::AbstractString, i::Int, j::Int)
     @boundscheck begin
-        0 < i ≤ ncodeunits(s)+1 || throw(BoundsError(s, i))
-        0 ≤ j < ncodeunits(s)+1 || throw(BoundsError(s, j))
+        0 < i ≤ ncodeunits(s)::Int+1 || throw(BoundsError(s, i))
+        0 ≤ j < ncodeunits(s)::Int+1 || throw(BoundsError(s, j))
     end
     n = 0
     for k = i:j
@@ -434,7 +434,7 @@ ERROR: BoundsError: attempt to access 2-codeunit String at index [-1]
 thisind(s::AbstractString, i::Integer) = thisind(s, Int(i))
 
 function thisind(s::AbstractString, i::Int)
-    z = ncodeunits(s) + 1
+    z = ncodeunits(s)::Int + 1
     i == z && return i
     @boundscheck 0 ≤ i ≤ z || throw(BoundsError(s, i))
     @inbounds while 1 < i && !(isvalid(s, i)::Bool)
@@ -602,9 +602,9 @@ isascii(c::AbstractChar) = UInt32(c) < 0x80
 ## string map, filter ##
 
 function map(f, s::AbstractString)
-    out = StringVector(max(4, sizeof(s)÷sizeof(codeunit(s))))
+    out = StringVector(max(4, sizeof(s)::Int÷sizeof(codeunit(s)::Type{<:Union{UInt8,UInt16,UInt32}})))
     index = UInt(1)
-    for c in s
+    for c::AbstractChar in s
         c′ = f(c)
         isa(c′, AbstractChar) || throw(ArgumentError(
             "map(f, s::AbstractString) requires f to return AbstractChar; " *

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -343,11 +343,11 @@ julia> escape_string(string('\\u2135','\\0','0')) # \\0 would be ambiguous
 """
 function escape_string(io::IO, s::AbstractString, esc="")
     a = Iterators.Stateful(s)
-    for c in a
+    for c::AbstractChar in a
         if c in esc
             print(io, '\\', c)
         elseif isascii(c)
-            c == '\0'          ? print(io, escape_nul(peek(a))) :
+            c == '\0'          ? print(io, escape_nul(peek(a)::Union{AbstractChar,Nothing})) :
             c == '\e'          ? print(io, "\\e") :
             c == '\\'          ? print(io, "\\\\") :
             '\a' <= c <= '\r'  ? print(io, '\\', "abtnvfr"[Int(c)-6]) :
@@ -356,10 +356,10 @@ function escape_string(io::IO, s::AbstractString, esc="")
         elseif !isoverlong(c) && !ismalformed(c)
             isprint(c)         ? print(io, c) :
             c <= '\x7f'        ? print(io, "\\x", string(UInt32(c), base = 16, pad = 2)) :
-            c <= '\uffff'      ? print(io, "\\u", string(UInt32(c), base = 16, pad = need_full_hex(peek(a)) ? 4 : 2)) :
-                                 print(io, "\\U", string(UInt32(c), base = 16, pad = need_full_hex(peek(a)) ? 8 : 4))
+            c <= '\uffff'      ? print(io, "\\u", string(UInt32(c), base = 16, pad = need_full_hex(peek(a)::Union{AbstractChar,Nothing}) ? 4 : 2)) :
+                                 print(io, "\\U", string(UInt32(c), base = 16, pad = need_full_hex(peek(a)::Union{AbstractChar,Nothing}) ? 8 : 4))
         else # malformed or overlong
-            u = bswap(reinterpret(UInt32, c))
+            u = bswap(reinterpret(UInt32, c)::UInt32)
             while true
                 print(io, "\\x", string(u % UInt8, base = 16, pad = 2))
                 (u >>= 8) == 0 && break

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -144,14 +144,14 @@ function _searchindex(s::Union{AbstractString,ByteArray},
                       t::Union{AbstractString,AbstractChar,Int8,UInt8},
                       i::Integer)
     if isempty(t)
-        return 1 <= i <= nextind(s,lastindex(s)) ? i :
+        return 1 <= i <= nextind(s,lastindex(s))::Int ? i :
                throw(BoundsError(s, i))
     end
     t1, trest = Iterators.peel(t)
     while true
         i = findnext(isequal(t1),s,i)
         if i === nothing return 0 end
-        ii = nextind(s, i)
+        ii = nextind(s, i)::Int
         a = Iterators.Stateful(trest)
         matched = all(splat(==), zip(SubString(s, ii), a))
         (isempty(a) && matched) && return i
@@ -351,21 +351,21 @@ function _rsearchindex(s::AbstractString,
                        t::Union{AbstractString,AbstractChar,Int8,UInt8},
                        i::Integer)
     if isempty(t)
-        return 1 <= i <= nextind(s, lastindex(s)) ? i :
+        return 1 <= i <= nextind(s, lastindex(s))::Int ? i :
                throw(BoundsError(s, i))
     end
     t1, trest = Iterators.peel(Iterators.reverse(t))
     while true
         i = findprev(isequal(t1), s, i)
         i === nothing && return 0
-        ii = prevind(s, i)
+        ii = prevind(s, i)::Int
         a = Iterators.Stateful(trest)
         b = Iterators.Stateful(Iterators.reverse(
             pairs(SubString(s, 1, ii))))
         matched = all(splat(==), zip(a, (x[2] for x in b)))
         if matched && isempty(a)
             isempty(b) && return firstindex(s)
-            return nextind(s, popfirst!(b)[1])
+            return nextind(s, popfirst!(b)[1])::Int
         end
         i = ii
     end

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -44,8 +44,8 @@ end
     SubString(s.string, s.offset+i, s.offset+j)
 end
 
-SubString(s::AbstractString) = SubString(s, 1, lastindex(s))
-SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, lastindex(s))
+SubString(s::AbstractString) = SubString(s, 1, lastindex(s)::Int)
+SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, lastindex(s)::Int)
 
 @propagate_inbounds view(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)
 @propagate_inbounds maybeview(s::AbstractString, r::AbstractUnitRange{<:Integer}) = view(s, r)
@@ -62,7 +62,7 @@ function String(s::SubString{String})
 end
 
 ncodeunits(s::SubString) = s.ncodeunits
-codeunit(s::SubString) = codeunit(s.string)
+codeunit(s::SubString) = codeunit(s.string)::Type{<:Union{UInt8, UInt16, UInt32}}
 length(s::SubString) = length(s.string, s.offset+1, s.offset+s.ncodeunits)
 
 function codeunit(s::SubString, i::Integer)
@@ -75,7 +75,7 @@ function iterate(s::SubString, i::Integer=firstindex(s))
     @boundscheck checkbounds(s, i)
     y = iterate(s.string, s.offset + i)
     y === nothing && return nothing
-    c, i = y
+    c, i = y::Tuple{AbstractChar,Int}
     return c, i - s.offset
 end
 
@@ -87,7 +87,7 @@ end
 function isvalid(s::SubString, i::Integer)
     ib = true
     @boundscheck ib = checkbounds(Bool, s, i)
-    @inbounds return ib && isvalid(s.string, s.offset + i)
+    @inbounds return ib && isvalid(s.string, s.offset + i)::Bool
 end
 
 byte_string_classify(s::SubString{String}) =

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -256,7 +256,7 @@ julia> rstrip(a)
 """
 function rstrip(f, s::AbstractString)
     for (i, c) in Iterators.reverse(pairs(s))
-        f(c) || return @inbounds SubString(s, 1, i)
+        f(c::AbstractChar) || return @inbounds SubString(s, 1, i::Int)
     end
     SubString(s, 1, 0)
 end
@@ -389,26 +389,26 @@ function split(str::T, splitter::AbstractChar;
     _split(str, isequal(splitter), limit, keepempty, T <: SubString ? T[] : SubString{T}[])
 end
 
-function _split(str::AbstractString, splitter, limit::Integer, keepempty::Bool, strs::Array)
+function _split(str::AbstractString, splitter, limit::Integer, keepempty::Bool, strs::Vector)
     i = 1 # firstindex(str)
-    n = lastindex(str)
-    r = findfirst(splitter,str)
+    n = lastindex(str)::Int
+    r = findfirst(splitter,str)::Union{Nothing,Int,UnitRange{Int}}
     if !isnothing(r)
-        j, k = first(r), nextind(str,last(r))
+        j, k = first(r), nextind(str,last(r))::Int
         while 0 < j <= n && length(strs) != limit-1
             if i < k
                 if keepempty || i < j
-                    push!(strs, @inbounds SubString(str,i,prevind(str,j)))
+                    push!(strs, @inbounds SubString(str,i,prevind(str,j)::Int))
                 end
                 i = k
             end
-            (k <= j) && (k = nextind(str,j))
-            r = findnext(splitter,str,k)
+            (k <= j) && (k = nextind(str,j)::Int)
+            r = findnext(splitter,str,k)::Union{Nothing,Int,UnitRange{Int}}
             isnothing(r) && break
-            j, k = first(r), nextind(str,last(r))
+            j, k = first(r), nextind(str,last(r))::Int
         end
     end
-    if keepempty || i <= ncodeunits(str)
+    if keepempty || i <= ncodeunits(str)::Int
         push!(strs, @inbounds SubString(str,i))
     end
     return strs
@@ -464,13 +464,13 @@ function rsplit(str::T, splitter::AbstractChar;
 end
 
 function _rsplit(str::AbstractString, splitter, limit::Integer, keepempty::Bool, strs::Array)
-    n = lastindex(str)
-    r = something(findlast(splitter, str), 0)
+    n = lastindex(str)::Int
+    r = something(findlast(splitter, str)::Union{Nothing,Int,UnitRange{Int}}, 0)
     j, k = first(r), last(r)
     while j > 0 && k > 0 && length(strs) != limit-1
-        (keepempty || k < n) && pushfirst!(strs, @inbounds SubString(str,nextind(str,k),n))
-        n = prevind(str, j)
-        r = something(findprev(splitter,str,n), 0)
+        (keepempty || k < n) && pushfirst!(strs, @inbounds SubString(str,nextind(str,k)::Int,n))
+        n = prevind(str, j)::Int
+        r = something(findprev(splitter,str,n)::Union{Nothing,Int,UnitRange{Int}}, 0)
         j, k = first(r), last(r)
     end
     (keepempty || n > 0) && pushfirst!(strs, SubString(str,1,n))

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -443,7 +443,7 @@ function connect(manager::ClusterManager, pid::Int, config::WorkerConfig)
 
     # master connecting to workers
     if config.io !== nothing
-        (bind_addr, port) = read_worker_host_port(config.io)
+        (bind_addr, port::Int) = read_worker_host_port(config.io)
         pubhost = something(config.host, bind_addr)
         config.host = pubhost
         config.port = port
@@ -503,7 +503,7 @@ function connect(manager::ClusterManager, pid::Int, config::WorkerConfig)
 end
 
 function connect_w2w(pid::Int, config::WorkerConfig)
-    (rhost, rport) = notnothing(config.connect_at)
+    (rhost, rport) = notnothing(config.connect_at)::Tuple{AbstractString, Int}
     config.host = rhost
     config.port = rport
     (s, bind_addr) = connect_to_worker(rhost, rport)

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -106,7 +106,7 @@ function handle_message(logger::ConsoleLogger, level, message, _module, group, i
     # Generate a text representation of the message and all key value pairs,
     # split into lines.
     msglines = [(indent=0,msg=l) for l in split(chomp(string(message)), '\n')]
-    dsize = displaysize(logger.stream)
+    dsize = displaysize(logger.stream)::Tuple{Int,Int}
     if !isempty(kwargs)
         valbuf = IOBuffer()
         rows_per_value = max(1, dsize[1]÷(length(kwargs)+1))
@@ -127,9 +127,7 @@ function handle_message(logger::ConsoleLogger, level, message, _module, group, i
 
     # Format lines as text with appropriate indentation and with a box
     # decoration on the left.
-    color,prefix,suffix = logger.meta_formatter(level, _module, group, id, filepath, line)
-    color = convert(Symbol, color)::Symbol
-    prefix, suffix = convert(String, prefix)::String, convert(String, suffix)::String
+    color,prefix,suffix = logger.meta_formatter(level, _module, group, id, filepath, line)::Tuple{Union{Symbol,Int},String,String}
     minsuffixpad = 2
     buf = IOBuffer()
     iob = IOContext(buf, logger.stream)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1315,7 +1315,7 @@ end
 const wildcard = '\U10f7ff' # "Private Use" Char
 
 normalize_key(key::AbstractChar) = string(key)
-normalize_key(key::Integer) = normalize_key(Char(key))
+normalize_key(key::Union{Int,UInt8}) = normalize_key(Char(key))
 function normalize_key(key::AbstractString)
     wildcard in key && error("Matching '\U10f7ff' not supported.")
     buf = IOBuffer()
@@ -2029,9 +2029,9 @@ function commit_line(s)
     nothing
 end
 
-function bracketed_paste(s; tabwidth=options(s).tabwidth)
+function bracketed_paste(s; tabwidth::Int=options(s).tabwidth::Int)
     options(s).auto_indent_bracketed_paste = true
-    ps = state(s, mode(s))
+    ps = state(s, mode(s))::PromptState
     input = readuntil(ps.terminal, "\e[201~")
     input = replace(input, '\r' => '\n')
     if position(buffer(s)) == 0

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1587,11 +1587,11 @@ with string types besides the standard `String` type.
 struct GenericString <: AbstractString
     string::AbstractString
 end
-Base.ncodeunits(s::GenericString) = ncodeunits(s.string)
-Base.codeunit(s::GenericString) = codeunit(s.string)
-Base.codeunit(s::GenericString, i::Integer) = codeunit(s.string, i)
-Base.isvalid(s::GenericString, i::Integer) = isvalid(s.string, i)
-Base.iterate(s::GenericString, i::Integer=1) = iterate(s.string, i)
+Base.ncodeunits(s::GenericString) = ncodeunits(s.string)::Int
+Base.codeunit(s::GenericString) = codeunit(s.string)::Type{<:Union{UInt8, UInt16, UInt32}}
+Base.codeunit(s::GenericString, i::Integer) = codeunit(s.string, i)::Union{UInt8, UInt16, UInt32}
+Base.isvalid(s::GenericString, i::Integer) = isvalid(s.string, i)::Bool
+Base.iterate(s::GenericString, i::Integer=1) = iterate(s.string, i)::Union{Nothing,Tuple{AbstractChar,Int}}
 Base.reverse(s::GenericString) = GenericString(reverse(s.string))
 Base.reverse(s::SubString{GenericString}) =
     GenericString(typeof(s.string)(reverse(String(s))))


### PR DESCRIPTION
Defining

```julia
    struct MyInt <: Integer
        x::Int
    end
    (::Type{T})(x::MyInt) where T<:Integer = T(x.x)
```
triggers about 830 unique method invalidations. This fixes the majority of them, and most of the rest are nothing to worry about (they are in Core.Compiler, or run in the `normalize_keymap` phase of REPL initialization). One package that adds this kind of method is GeometryTypes, which is used by Plots. This PR, together with https://github.com/JuliaWeb/HTTP.jl/pull/549, fix the last "big" sources of invalidation from `using Plots`. Altogether there are "only" 440 invalidations left, many of which are probably unconcerning; when I started, my estimate (which is probably ballpark but not entirely comparable due to some changes in how I'm counting) was nearly 10-fold higher (see https://github.com/JuliaLang/www.julialang.org/pull/794/files).

EDIT: fun fact, the opposite case (#29166) was handled in #30830.

This PR by itself is not a huge effect, but for the record:

Just the predecessors of this PR (which is better than current `master`), including my customizations of #35877:
```julia
julia> @time using Plots; @time p = plot(rand(10)); @time display(p)
  5.339177 seconds (9.02 M allocations: 561.481 MiB, 4.25% gc time)
  1.910392 seconds (2.81 M allocations: 156.618 MiB, 1.55% gc time)
  4.631717 seconds (6.53 M allocations: 364.880 MiB, 1.48% gc time)
```

Adding this PR on top of the previous:
```julia
julia> @time using Plots; @time p = plot(rand(10)); @time display(p)
  4.853647 seconds (9.23 M allocations: 571.112 MiB, 3.34% gc time)
  1.898238 seconds (2.81 M allocations: 156.582 MiB, 3.03% gc time)
  4.382853 seconds (6.46 M allocations: 361.079 MiB, 1.48% gc time)
```

Compared to the timings I posted [here for master](https://github.com/JuliaLang/julia/pull/35877#issuecomment-649572533), this is almost 2s faster, so the cumulative effect is mounting (but also coming to its end, I don't expect much further progress just from fixing invalidations). There's still about 0.8s of precompilation, so getting more to precompile would add a little more benefit.

However, this specific PR should not be merged immediately. For most of my invalidation PRs, I think the improvements in inference can also be justified as improving code-quality. While that applies to some of this PR, a lot of it is just type-annotation, and one might really wish that most of those annotations aren't necessary. Consequently I've marked this RFC because it's worth asking whether there is a more systematic way to achieve the same benefits without all the annotation.