### PR TITLE
fix REPL test for completions

### DIFF
--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -549,8 +549,10 @@ let
     @test !occursin("where T at sysimg.jl", sprint(showerror, method_error))
 
     # Test that tab-completion will not show the 'default' sysimg.jl method.
-    for method_string in REPL.REPLCompletions.complete_methods(:(EnclosingModule.AbstractTypeNoConstructors()))
-        @test !startswith(method_string, "(::Type{T})(arg) where T in Base at sysimg.jl")
+    completions = REPL.REPLCompletions.complete_methods(:(EnclosingModule.AbstractTypeNoConstructors()), @__MODULE__)
+    @test !isempty(completions)
+    for method_string in completions
+        @test !startswith(REPL.REPLCompletions.completion_text(method_string), "(::Type{T})(arg) where T in Base at sysimg.jl")
     end
 end
 


### PR DESCRIPTION
I was really confused when this test failed when I pasted it into the REPL on any Julia version I tried. Turns out that the `complete_methods` call here returns an empty array so the test just does nothing. This PR passes in the current module so that the `complete_methods` call can find it and also fixes the test-bug in that we need to call `completion_text` on the returned value.

This test looks really brittle to changes in printing...