### PR TITLE
Clarify BLAS.asum docstring for complex arrays

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -423,7 +423,11 @@ nrm2(x::Union{AbstractVector,DenseArray}) = nrm2(length(x), x, stride1(x))
 """
     asum(n, X, incx)
 
-Sum of the absolute values of the first `n` elements of array `X` with stride `incx`.
+Sum of the magnitudes of the first `n` elements of array `X` with stride `incx`.
+
+For a real array, the magnitude is the absolute value. For a complex array, the
+magnitude is the sum of the absolute value of the real part and the absolute value
+of the imaginary part.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The `BLAS.asum` docstring claims it computes the sum of the absolute values of the elements of the array. However, for complex arrays, it actually does something different. This PR clarifies the docstring.