### PR TITLE
Respect memory constraints during init.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3206,7 +3206,11 @@ void jl_gc_init(void)
 
 #ifdef _P64
     // on a big memory machine, set max_collect_interval to totalmem / ncores / 2
-    size_t maxmem = uv_get_total_memory() / jl_cpu_threads() / 2;
+    uint64_t total_mem = uv_get_total_memory();
+    uint64_t constrained_mem = uv_get_constrained_memory();
+    if (constrained_mem > 0 && constrained_mem < total_mem)
+        total_mem = constrained_mem;
+    size_t maxmem = total_mem / jl_cpu_threads() / 2;
     if (maxmem > max_collect_interval)
         max_collect_interval = maxmem;
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -640,6 +640,9 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
     jl_page_size = jl_getpagesize();
     uint64_t total_mem = uv_get_total_memory();
+    uint64_t constrained_mem = uv_get_constrained_memory();
+    if (constrained_mem > 0 && constrained_mem < total_mem)
+        total_mem = constrained_mem;
     if (total_mem >= (size_t)-1) {
         total_mem = (size_t)-1;
     }


### PR DESCRIPTION
I'm not sure https://github.com/JuliaLang/julia/issues/24617 should have been closed, as `uv_get_total_memory` doesn't change when running with, e.g., `docker run --memory 3G`. Instead, libuv now has `uv_get_contrained_memory`, which we should probably respect when initializing the heap.

I think this is the cause for some GPU CI issues, where docker kills the process once we exceed the memory limit (i.e. we don't get a nice OOM error). That happens often, I assume because the GC doesn't know about the actual memory limit.

Like https://github.com/nodejs/node/pull/27508