### PR TITLE
Update comment still refering to [pty_]{master,slave}

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -92,7 +92,7 @@ function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=60, debug::Bool
             write(out, ptm)
         catch ex
             if !(ex isa Base.IOError && ex.code == Base.UV_EIO)
-                rethrow() # ignore EIO from master after slave dies
+                rethrow() # ignore EIO from `ptm` after `pts` dies
             end
         end
 


### PR DESCRIPTION
Follow up to https://github.com/JuliaLang/julia/pull/36315/
this comment got missed in the renaming as it was missing the `pty_` prefix

This is the last use of the word `slave` in our codebase