### PR TITLE
Add Unicode dependency to REPL

### DIFF
--- a/stdlib/REPL/Project.toml
+++ b/stdlib/REPL/Project.toml
@@ -5,6 +5,7 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This fixes the warning introduced in https://github.com/JuliaLang/julia/pull/36382.