### PR TITLE
Fixed @test return value on Error (#31495)

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -731,9 +731,9 @@ end
 
 # Records nothing, and throws an error immediately whenever a Fail or
 # Error occurs. Takes no action in the event of a Pass or Broken result
-record(ts::FallbackTestSet, t::Union{Pass,Broken}) = t
-function record(ts::FallbackTestSet, t::Union{Fail,Error})
-    println(t)
+record(ts::FallbackTestSet, res::Union{Pass,Broken}) = res
+function record(ts::FallbackTestSet, res::Union{Fail,Error})
+    println(res)
     throw(FallbackTestSetException("There was an error during testing"))
 end
 # We don't need to do anything as we don't record anything
@@ -757,34 +757,33 @@ end
 DefaultTestSet(desc) = DefaultTestSet(desc, [], 0, false)
 
 # For a broken result, simply store the result
-record(ts::DefaultTestSet, t::Broken) = (push!(ts.results, t); t)
+record(ts::DefaultTestSet, res::Broken) = (push!(ts.results, res); res)
 # For a passed result, do not store the result since it uses a lot of memory
-record(ts::DefaultTestSet, t::Pass) = (ts.n_passed += 1; t)
+record(ts::DefaultTestSet, res::Pass) = (ts.n_passed += 1; res)
 
 # For the other result types, immediately print the error message
 # but do not terminate. Print a backtrace.
-function record(ts::DefaultTestSet, t::Union{Fail, Error})
+function record(ts::DefaultTestSet, res::Union{Fail, Error})
     if myid() == 1
         printstyled(ts.description, ": ", color=:white)
         # don't print for interrupted tests
-        if !(t isa Error) || t.test_type !== :test_interrupted
-            print(t)
-            # don't print the backtrace for Errors because it gets printed in the show
-            # method
-            if !isa(t, Error)
+        if !(res isa Error) || res.test_type !== :test_interrupted
+            print(res)
+            if !isa(res, Error) # if not gets printed in the show method
                 Base.show_backtrace(stdout, scrub_backtrace(backtrace()))
             end
             println()
         end
     end
-    push!(ts.results, t)
-    t, isa(t, Error) || backtrace()
+    push!(ts.results, res)
+    isa(res, Error) || backtrace()
+    return res
 end
 
 # When a DefaultTestSet finishes, it records itself to its parent
 # testset, if there is one. This allows for recursive printing of
 # the results at the end of the tests
-record(ts::DefaultTestSet, t::AbstractTestSet) = push!(ts.results, t)
+record(ts::DefaultTestSet, res::AbstractTestSet) = push!(ts.results, res)
 
 @specialize
 

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -233,6 +233,7 @@ let fails = @testset NoThrowTestSet begin
     end
 end
 
+
 let errors = @testset NoThrowTestSet begin
         # 1 - Error - unexpected pass
         @test_broken true
@@ -252,6 +253,22 @@ let errors = @testset NoThrowTestSet begin
     let str = sprint(show, errors[2])
         @test occursin("Expression: ==(1, 1:2...)", str)
         @test occursin("MethodError: no method matching ==(::$Int, ::$Int, ::$Int)", str)
+    end
+end
+
+let retval_tests = @testset NoThrowTestSet begin
+        ts = Test.DefaultTestSet("Mock for testing retval of record(::DefaultTestSet, ::T <: Result) methods")
+        pass_mock = Test.Pass(:test, 1, 2, LineNumberNode(0, "A Pass Mock"))
+        @test Test.record(ts, pass_mock) isa Test.Pass
+        error_mock = Test.Error(:test, 1, 2, 3, LineNumberNode(0, "An Error Mock"))
+        @test Test.record(ts, error_mock) isa Test.Error
+        fail_mock = Test.Fail(:test, 1, 2, 3, LineNumberNode(0, "A Fail Mock"))
+        @test Test.record(ts, fail_mock) isa Test.Fail
+        broken_mock = Test.Broken(:test, LineNumberNode(0, "A Broken Mock"))
+        @test Test.record(ts, broken_mock) isa Test.Broken
+    end
+    for retval_test in retval_tests
+        @test retval_test isa Test.Pass
     end
 end
 

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -233,7 +233,6 @@ let fails = @testset NoThrowTestSet begin
     end
 end
 
-
 let errors = @testset NoThrowTestSet begin
         # 1 - Error - unexpected pass
         @test_broken true


### PR DESCRIPTION
This is directly mergeable and closes the bug #31495 by copying the two-liner proposed there by @tpapp , thus I do not feel comfortable prefixing RFC.

But this is also my first contribution as a [boy scout](https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) and it would be great to get some feedback, especially because adding the missing tests was nontrivial and is not without issues:

- I was only able to create the missing tests for `record(::DefaultTestSet, ::T <: Result)` methods, but not for `@test` itself.
- Awkward output is printed, as seen here:

![Screenshot from 2020-07-01 16-01-03](https://user-images.githubusercontent.com/3518347/86252977-2eafc500-bbb4-11ea-8fa7-d9ba08662419.png)

I think this is acceptable when a test system tests itself, but I would be happy to fix it. I just don't know how to start.
