### PR TITLE
Small fix in nonmissingtype documentation

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -34,7 +34,7 @@ Any
 ```
 
 !!! compat "Julia 1.3"
-  This function is exported as of Julia 1.3.
+    This function is exported as of Julia 1.3.
 """
 nonmissingtype(::Type{T}) where {T} = Core.Compiler.typesubtract(T, Missing)
 


### PR DESCRIPTION
This corrects the markdown string of the `nonmissingtype` documentation to include the message `This function is exported as of Julia 1.3.` inside the admonition block.