### PR TITLE
Incorporate an add to PATH option in Windows Inno Setup installer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,10 @@ Multi-threading changes
 Build system changes
 --------------------
 
+* Windows Installer now has the option to 'Add Julia to Path'. To unselect this option
+  from the commandline simply remove the tasks you do not want to be installed: e.g.
+  `./julia-installer.exe /TASKS="desktopicon,startmenu,addtopath"`, adds a desktop
+  icon, a startmenu group icon, and adds Julia to system PATH.
 
 New library functions
 ---------------------

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -73,15 +73,20 @@ SetupIconFile={#RepoDir}\contrib\windows\julia.ico
 UninstallDisplayName={#AppNameLong}
 UninstallDisplayIcon={app}\{#AppMainExeName}
 UninstallFilesDir={app}\uninstall
+ChangesEnvironment=true
 
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
+[CustomMessages]
+AdditionalIcons=Icons:
+Other=%nOther:
 
 [Tasks]
-Name: "desktopicon"; Description: "Create a Desktop shortcut"
-Name: "startmenu"; Description: "Create a Start Menu entry"
+Name: "desktopicon"; Description: "Create a Desktop shortcut"; GroupDescription: "{cm:AdditionalIcons}";
+Name: "startmenu"; Description: "Create a Start Menu entry"; GroupDescription: "{cm:AdditionalIcons}";
+Name: "addtopath"; Description: "Add {#AppName} to PATH"; GroupDescription: "{cm:Other}"; Flags: unchecked;
 
 
 [Files]
@@ -89,8 +94,8 @@ Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs 
 
 
 [Icons]
-Name: "{autostartmenu}\{#AppNameLong}"; Filename: "{app}\{#AppMainExeName}"; WorkingDir: "{%USERPROFILE}"; Tasks: startmenu
 Name: "{autodesktop}\{#AppNameLong}"; Filename: "{app}\{#AppMainExeName}"; WorkingDir: "{%USERPROFILE}"; Tasks: desktopicon
+Name: "{autostartmenu}\{#AppNameLong}"; Filename: "{app}\{#AppMainExeName}"; WorkingDir: "{%USERPROFILE}"; Tasks: startmenu
 
 
 [Run]
@@ -99,9 +104,13 @@ Filename: "{app}"; Description: "Open {#AppName} directory"; Flags: nowait posti
 Filename: "https://docs.julialang.org"; Description: "Open documentation"; Flags: nowait postinstall skipifsilent unchecked shellexec
 
 
+[Registry]
+Root: HKA; Subkey: "{code:GetEnvironmentKey}"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\bin"; Tasks: addtopath; Check: NeedsAddPath(ExpandConstant('{app}\bin'))
+
 [Code]
 
 procedure InitializeWizard;
+
 begin
   WizardForm.Bevel.Visible := False;
   WizardForm.Bevel1.Visible := False;
@@ -129,4 +138,74 @@ begin
   UninstallProgressForm.Color := clWhite;
   UninstallProgressForm.Bevel.Visible := False;
   UninstallProgressForm.Bevel1.Visible := False;
+end;
+
+function GetEnvironmentKey(Param: string): string;
+begin
+  if IsAdminInstallMode then
+    Result := 'System\CurrentControlSet\Control\Session Manager\Environment'
+  else
+    Result := 'Environment';
+end;
+
+// https://stackoverflow.com/a/23838239/261019
+procedure Explode(var Dest: TArrayOfString; Text: String; Separator: String);
+var
+  i, p: Integer;
+begin
+  i := 0;
+  repeat
+    SetArrayLength(Dest, i+1);
+    p := Pos(Separator,Text);
+    if p > 0 then begin
+      Dest[i] := Copy(Text, 1, p-1);
+      Text := Copy(Text, p + Length(Separator), Length(Text));
+      i := i + 1;
+    end else begin
+      Dest[i] := Text;
+      Text := '';
+    end;
+  until Length(Text)=0;
+end;
+
+// https://stackoverflow.com/questions/3304463/how-do-i-modify-the-path-environment-variable-when-running-an-inno-setup-install
+function NeedsAddPath(Param: string): boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKA, GetEnvironmentKey(''), 'Path', OrigPath)
+  then begin
+    Result := True;
+    exit;
+  end;
+  Result := Pos(';' + Param + ';', ';' + OrigPath + ';') = 0;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  Path: string;
+  ExePath: string;
+  Parts: TArrayOfString;
+  NewPath: string;
+  i: Integer;
+begin
+  if not CurUninstallStep = usUninstall then begin
+    exit;
+  end;
+  if not RegQueryStringValue(HKA, GetEnvironmentKey(''), 'Path', Path)
+  then begin
+    exit;
+  end;
+  NewPath := '';
+  ExePath := ExpandConstant('{app}\bin')
+  Explode(Parts, Path, ';');
+  for i:=0 to GetArrayLength(Parts)-1 do begin
+    if CompareText(Parts[i], ExePath) <> 0 then begin
+      NewPath := NewPath + Parts[i];
+      if i < GetArrayLength(Parts) - 1 then begin
+        NewPath := NewPath + ';';
+      end;
+    end;
+  end;
+  RegWriteExpandStringValue(HKA, GetEnvironmentKey(''), 'Path', NewPath);
 end;


### PR DESCRIPTION
This adds an **unchecked by default option** to add the Julia bin directory to path on Windows for the installer.

The code handles adding the bin to path and also automatically removes the path upon uninstallation. 

![image](https://user-images.githubusercontent.com/4319522/86369420-69653c00-bc4c-11ea-8433-0bc8927d49ac.png)


Part of:  https://github.com/JuliaLang/julia/issues/34495