### PR TITLE
Improve precision of abstract_iteration

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2674,3 +2674,7 @@ partial_return_1(x) = (x, 1)
 partial_return_2(x) = Val{partial_return_1(x)[2]}
 
 @test Base.return_types(partial_return_2, (Int,)) == Any[Type{Val{1}}]
+
+# Precision of abstract_iteration
+f_splat(x) = (x...,)
+@test Base.return_types(f_splat, (Pair{Int,Int},)) == Any[Tuple{Int, Int}]


### PR DESCRIPTION
Currently abstract iteration works fine for length-1 iterators, but
fails over for other small length iterators, such as Pair{Int, Int},
or common patterns where `iterate` iterates over the fields of a
small struct. Other examples include StaticVectors and constant
iterators, which should all now unroll properly up to the
MAX_TUPLE_SPLAT limit. That said, MAX_TUPLE_SPLAT is quite high
at the moment, but because abstract_iteration isn't very precise,
it's unlikely to be limiting. With this increase in precision,
we may find that MAX_TUPLE_SPLAT is too high and we should lower it.

Also note that while this is a nice improvement, performance is still
not great, since we currently can't inline these apply calls. However,
fixing that is in progress in a parallel PR and with both changes
put together, the performance improvement of splatting of small
iterators is quite sizeable.