### PR TITLE
Fix #36531 - Error in abstract_iteration

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2660,3 +2660,8 @@ function symcmp36230(vec)
     return false
 end
 @test Base.return_types(symcmp36230, (Vector{Any},)) == Any[Bool]
+
+# Issue #36531, double varargs in abstract_iteration
+f36531(args...) = tuple((args...)...)
+@test @inferred(f36531(1,2,3)) == (1,2,3)
+@test code_typed(f36531, Tuple{Vararg{Int}}) isa Vector


### PR DESCRIPTION
The issue here is passing a `Vargarg` to `precise_container_type`, which
doesn't really make sense. Instead, we need to have the caller unwrap
the vararg, request the precise container type of the inner type and
then re-wrap the answer in a vararg.