### PR TITLE
Fix off-by-one dayofquarter() in leap years

### DIFF
--- a/stdlib/Dates/src/query.jl
+++ b/stdlib/Dates/src/query.jl
@@ -652,11 +652,14 @@ Return the quarter that `dt` resides in. Range of value is 1:4.
 """
 quarterofyear(dt::TimeType) = quarter(dt)
 
-const QUARTERDAYS = (0, 90, 181, 273)
+const QUARTERDAYS = (0, 31, 59, 0, 30, 61, 0, 31, 62, 0, 31, 61)
 
 """
     dayofquarter(dt::TimeType) -> Int
 
 Return the day of the current quarter of `dt`. Range of value is 1:92.
 """
-dayofquarter(dt::TimeType) = dayofyear(dt) - QUARTERDAYS[quarterofyear(dt)]
+function dayofquarter(dt::TimeType)
+    (y, m, d) = yearmonthday(dt)
+    return QUARTERDAYS[m] + d + (m == 3 && isleapyear(y))
+end

--- a/stdlib/Dates/test/query.jl
+++ b/stdlib/Dates/test/query.jl
@@ -194,22 +194,25 @@ end
     @test Dates.quarterofyear(Dates.DateTime(2000, 12, 31)) == 4
 end
 @testset "dayofquarter" begin
-    @test Dates.dayofquarter(Dates.Date(2014, 1, 1)) == 1
-    @test Dates.dayofquarter(Dates.Date(2014, 4, 1)) == 1
-    @test Dates.dayofquarter(Dates.Date(2014, 7, 1)) == 1
-    @test Dates.dayofquarter(Dates.Date(2014, 10, 1)) == 1
-    @test Dates.dayofquarter(Dates.Date(2014, 3, 31)) == 90
-    @test Dates.dayofquarter(Dates.Date(2014, 6, 30)) == 91
-    @test Dates.dayofquarter(Dates.Date(2014, 9, 30)) == 92
-    @test Dates.dayofquarter(Dates.Date(2014, 12, 31)) == 92
-    @test Dates.dayofquarter(Dates.DateTime(2014, 1, 1)) == 1
-    @test Dates.dayofquarter(Dates.DateTime(2014, 4, 1)) == 1
-    @test Dates.dayofquarter(Dates.DateTime(2014, 7, 1)) == 1
-    @test Dates.dayofquarter(Dates.DateTime(2014, 10, 1)) == 1
-    @test Dates.dayofquarter(Dates.DateTime(2014, 3, 31)) == 90
-    @test Dates.dayofquarter(Dates.DateTime(2014, 6, 30)) == 91
-    @test Dates.dayofquarter(Dates.DateTime(2014, 9, 30)) == 92
-    @test Dates.dayofquarter(Dates.DateTime(2014, 12, 31)) == 92
+    # Non-leap and leap year
+    for y in (2014, 2020)
+        @test Dates.dayofquarter(Dates.Date(y, 1, 1)) == 1
+        @test Dates.dayofquarter(Dates.Date(y, 4, 1)) == 1
+        @test Dates.dayofquarter(Dates.Date(y, 7, 1)) == 1
+        @test Dates.dayofquarter(Dates.Date(y, 10, 1)) == 1
+        @test Dates.dayofquarter(Dates.Date(y, 3, 31)) == 90 + isleapyear(y)
+        @test Dates.dayofquarter(Dates.Date(y, 6, 30)) == 91
+        @test Dates.dayofquarter(Dates.Date(y, 9, 30)) == 92
+        @test Dates.dayofquarter(Dates.Date(y, 12, 31)) == 92
+        @test Dates.dayofquarter(Dates.DateTime(y, 1, 1)) == 1
+        @test Dates.dayofquarter(Dates.DateTime(y, 4, 1)) == 1
+        @test Dates.dayofquarter(Dates.DateTime(y, 7, 1)) == 1
+        @test Dates.dayofquarter(Dates.DateTime(y, 10, 1)) == 1
+        @test Dates.dayofquarter(Dates.DateTime(y, 3, 31)) == 90 + isleapyear(y)
+        @test Dates.dayofquarter(Dates.DateTime(y, 6, 30)) == 91
+        @test Dates.dayofquarter(Dates.DateTime(y, 9, 30)) == 92
+        @test Dates.dayofquarter(Dates.DateTime(y, 12, 31)) == 92
+    end
 end
 
 end


### PR DESCRIPTION
`dayofquarter()` is off by one for leap years when `month > 3`.
Before:
```julia
julia> dayofquarter(Date(2019,4,1))
1
julia> dayofquarter(Date(2020,4,1))
2
```
After:
```julia
julia> dayofquarter(Date(2019,4,1))
1
julia> dayofquarter(Date(2020,4,1))
1
```