### PR TITLE
Generalize `rand` for `OffsetArrays` e.g. `rand(Bool, 0:2)`

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -14,7 +14,7 @@ using .DSFMT
 using Base.GMP.MPZ
 using Base.GMP: Limb
 
-using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing
+using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing, DimOrInd, DimsOrInds
 
 import Base: copymutable, copy, copy!, ==, hash, convert,
              rand, randn
@@ -276,17 +276,17 @@ end
 rand(r::AbstractRNG, dims::Integer...) = rand(r, Float64, Dims(dims))
 rand(                dims::Integer...) = rand(Float64, Dims(dims))
 
-rand(r::AbstractRNG, X, dims::Dims)  = rand!(r, Array{gentype(X)}(undef, dims), X)
-rand(                X, dims::Dims)  = rand(default_rng(), X, dims)
+rand(r::AbstractRNG, X, dims::DimsOrInds)  = rand!(r, similar(Array{gentype(X)}, dims), X)
+rand(                X, dims::DimsOrInds)  = rand(default_rng(), X, dims)
 
 rand(r::AbstractRNG, X, d::Integer, dims::Integer...) = rand(r, X, Dims((d, dims...)))
 rand(                X, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...)))
 # note: the above methods would trigger an ambiguity warning if d was not separated out:
-# rand(r, ()) would match both this method and rand(r, dims::Dims)
+# rand(r, ()) would match both this method and rand(r, dims::DimsOrInds)
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
 
-rand(r::AbstractRNG, ::Type{X}, dims::Dims) where {X} = rand!(r, Array{X}(undef, dims), X)
-rand(                ::Type{X}, dims::Dims) where {X} = rand(default_rng(), X, dims)
+rand(r::AbstractRNG, ::Type{X}, dims::DimsOrInds) where {X} = rand!(r, similar(Array{X}, dims), X)
+rand(                ::Type{X}, dims::DimsOrInds) where {X} = rand(default_rng(), X, dims)
 
 rand(r::AbstractRNG, ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(r, X, Dims((d, dims...)))
 rand(                ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(X, Dims((d, dims...)))

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -252,7 +252,7 @@ rand(rng::AbstractRNG, ::UniformT{T}) where {T} = rand(rng, T)
 
 rand(rng::AbstractRNG, X)                                           = rand(rng, Sampler(rng, X, Val(1)))
 # this is needed to disambiguate
-rand(rng::AbstractRNG, X::Dims)                                     = rand(rng, Sampler(rng, X, Val(1)))
+rand(rng::AbstractRNG, X::DimsOrInds)                                     = rand(rng, Sampler(rng, X, Val(1)))
 rand(rng::AbstractRNG=default_rng(), ::Type{X}=Float64) where {X} = rand(rng, Sampler(rng, X, Val(1)))::X
 
 rand(X)                   = rand(default_rng(), X)
@@ -273,14 +273,14 @@ function rand!(rng::AbstractRNG, A::AbstractArray{T}, sp::Sampler) where T
     A
 end
 
-rand(r::AbstractRNG, dims::Integer...) = rand(r, Float64, Dims(dims))
-rand(                dims::Integer...) = rand(Float64, Dims(dims))
+rand(r::AbstractRNG, dims::DimOrInd...) = rand(r, Float64, DimsOrInds(dims))
+rand(                dims::DimOrInd...) = rand(Float64, DimsOrInds(dims))
 
 rand(r::AbstractRNG, X, dims::DimsOrInds)  = rand!(r, similar(Array{gentype(X)}, dims), X)
 rand(                X, dims::DimsOrInds)  = rand(default_rng(), X, dims)
 
-rand(r::AbstractRNG, X, d::Integer, dims::Integer...) = rand(r, X, Dims((d, dims...)))
-rand(                X, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...)))
+rand(r::AbstractRNG, X, d::DimOrInd, dims::DimOrInd...) = rand(r, X, DimsOrInds((d, dims...)))
+rand(                X, d::DimOrInd, dims::DimOrInd...) = rand(X, DimsOrInds((d, dims...)))
 # note: the above methods would trigger an ambiguity warning if d was not separated out:
 # rand(r, ()) would match both this method and rand(r, dims::DimsOrInds)
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
@@ -288,9 +288,15 @@ rand(                X, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...
 rand(r::AbstractRNG, ::Type{X}, dims::DimsOrInds) where {X} = rand!(r, similar(Array{X}, dims), X)
 rand(                ::Type{X}, dims::DimsOrInds) where {X} = rand(default_rng(), X, dims)
 
-rand(r::AbstractRNG, ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(r, X, Dims((d, dims...)))
-rand(                ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(X, Dims((d, dims...)))
+rand(r::AbstractRNG, ::Type{X}, d::DimOrInd, dims::DimOrInd...) where {X} = rand(r, X, DimsOrInds((d, dims...)))
+rand(                ::Type{X}, d::DimOrInd, dims::DimOrInd...) where {X} = rand(X, DimsOrInds((d, dims...)))
 
+# edge cases
+rand(rng::AbstractRNG, domain::AbstractUnitRange) = rand(rng, Sampler(rng, domain, Val(1)))
+rand(                  domain::AbstractUnitRange) = rand(default_rng(), domain)
+
+rand(rng::AbstractRNG, domain::AbstractUnitRange, dims::DimOrInd...) = rand(rng, domain, dims)
+rand(                  domain::AbstractUnitRange, dims::DimOrInd...) = rand(default_rng(), domain, dims)
 
 include("RNGs.jl")
 include("generation.jl")

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -815,4 +815,15 @@ isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH),
     @test axes(rand(Bool, Base.OneTo(3))) === (Base.OneTo(3), )
     @test axes(rand(Bool, 3)) === (Base.OneTo(3), )
     @test axes(rand(Bool, 0:2)) == (0:2, )
+
+    # axes splatted
+    @test axes(rand(Bool, Base.OneTo(3), Base.OneTo(3))) === (Base.OneTo(3), Base.OneTo(3))
+    @test axes(rand(Bool, Base.OneTo(3), 3)) === (Base.OneTo(3), Base.OneTo(3))
+    @test axes(rand(Bool, 0:2, 0:2)) == (0:2, 0:2)
+
+    # edge cases
+    @test rand(3) isa Array{Float64, 1}
+    @test rand(1:3) isa Integer
+    @test rand(1:3, 1:3) isa OffsetArrays.OffsetArray
+    @test axes(rand(1:3, 10)) === (Base.OneTo(10),)
 end

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -825,6 +825,6 @@ isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH),
     @test rand(3) isa Array{Float64, 1}
     @test rand(1:3) isa Integer
     @test rand(1:3, 1:4) isa OffsetArrays.OffsetArray
-    @test axes(rand(1:3, 1:4)) === (1:4, )
+    @test axes(rand(1:3, 1:4)) === (Base.IdentityUnitRange(1:4), )
     @test axes(rand(1:3, 10)) === (Base.OneTo(10),)
 end

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -801,3 +801,18 @@ end
 @testset "RNGs broadcast as scalars: T" for T in (MersenneTwister, RandomDevice)
     @test length.(rand.(T(), 1:3)) == 1:3
 end
+
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
+
+@testset "OffsetArrays" begin
+    # axes as tuple
+    @test axes(rand(Bool, (Base.OneTo(3), Base.OneTo(3)))) === (Base.OneTo(3), Base.OneTo(3))
+    @test axes(rand(Bool, (Base.OneTo(3), 3))) === (Base.OneTo(3), Base.OneTo(3))
+    @test axes(rand(Bool, (0:2, 0:2))) == (0:2, 0:2)
+
+    # 1D axes
+    @test axes(rand(Bool, Base.OneTo(3))) === (Base.OneTo(3), )
+    @test axes(rand(Bool, 3)) === (Base.OneTo(3), )
+    @test axes(rand(Bool, 0:2)) == (0:2, )
+end

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -824,6 +824,7 @@ isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH),
     # edge cases
     @test rand(3) isa Array{Float64, 1}
     @test rand(1:3) isa Integer
-    @test rand(1:3, 1:3) isa OffsetArrays.OffsetArray
+    @test rand(1:3, 1:4) isa OffsetArrays.OffsetArray
+    @test axes(rand(1:3, 1:4)) === (1:4, )
     @test axes(rand(1:3, 10)) === (Base.OneTo(10),)
 end


### PR DESCRIPTION
Address https://github.com/JuliaLang/julia/issues/36557
I think it might make sense to consider allowing

1. just `rand(Bool, (0:2,))`
2. also `rand(Bool, 0:2)`
3. furthermore `rand(Bool, 0:2, 0:2)`

1 is the most conservative change, and I can peel off a commit to revert to that situation.

