### PR TITLE
doc multi-threading: link to 2019's blog post

### DIFF
--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -1,5 +1,8 @@
 # [Multi-Threading](@id man-multithreading)
 
+Visit this [blog post](https://julialang.org/blog/2019/07/multithreading/) for a presentation
+of Julia multi-threading features.
+
 ## Starting Julia with multiple threads
 
 By default, Julia starts up with a single thread of execution. This can be verified by using the


### PR DESCRIPTION
The current documentation on multi-threading in the manual is underwhelming, e.g. `Threads.@spawn`, while having a docstring, is not explained in the manual section of the documentation (it is first mentioned in the "Caveats" paragraph, as if the reader was supposed to know what it is). 
The https://julialang.org/blog/2019/07/multithreading/ blog post seems like a far better entry point for understanding multi-threading in Julia, so let's link it from the doc (at least until it improves).