### PR TITLE
method overwrite warning

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -54,7 +54,7 @@ jl_options_t jl_options = { 0,    // quiet
 #endif
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
                             JL_OPTIONS_DEPWARN_OFF,    // deprecation warning
-                            0,    // method overwrite warning
+                            JL_OPTIONS_WARN_OVERWRITE_ON,    // method overwrite warning
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly
                             NULL, // trace_compile
@@ -663,4 +663,10 @@ restart_switch:
 JL_DLLEXPORT ssize_t jl_sizeof_jl_options(void)
 {
     return sizeof(jl_options_t);
+}
+
+
+JL_DLLEXPORT void jl_options_flip_warn_overwrite(void)
+{
+    jl_options.warn_overwrite ^= 1;
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1960,6 +1960,7 @@ typedef struct {
 
 extern JL_DLLEXPORT jl_options_t jl_options;
 JL_DLLEXPORT ssize_t jl_sizeof_jl_options(void);
+JL_DLLEXPORT void jl_options_flip_warn_overwrite(void);
 
 // Parse an argc/argv pair to extract general julia options, passing back out
 // any arguments that should be passed on to the script.


### PR DESCRIPTION
Re: https://github.com/JuliaLang/julia/issues/15602 and https://github.com/JuliaLang/julia/issues/36037 (possibly others)

Currently, expressions like
```
function myfun(n::Int)
     if n < 3
        println("branch 1")
        doit() = 3
     else
        println("branch 1")
        doit() = 5
     end 
end
```

and

```
function do_test()
    function innerfunc()
        println(stderr, "innerfunc")
    end
    println(stderr, "pre-innerfunc")
    innerfunc()
    println(stderr, "post-innerfunc")

    # Overwrite innerfunc
    innerfunc() = nothing
    println("innerfunc is now overwritten")
end

do_test()
```

would "silently" overwrite the function, such that e.g. with the 1st example, `a = myfun(1)` would print `branch 1` but  `a()` returns `5` since method is silently overwritten, making such scenarios a bit difficult to debug. 

A long-term solution could be to error in such cases, meanwhile, this PR set the default setting to warn about such overwrites, and add a function to flip the warning setting (and a convenience macro) to temporarily disable the warning when such overwrite is intentional.

Example:
```
julia> f(x) = 1
 f (generic function with 1 method)
julia> f(x) = x
WARNING: Method definition f(Any) in module Main at REPL[1]:1 overwritten at REPL[2]:1.
 f (generic function with 1 method)
julia> Base.@overwrite f(x) = x * 3
 f (generic function with 1 method)
julia> f(1)
 3
```
