### PR TITLE
Move Const/PartialStruct to Core

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -399,9 +399,9 @@ eval(Core, :(CodeInstance(mi::MethodInstance, @nospecialize(rettype), @nospecial
                           min_world::UInt, max_world::UInt) =
                 ccall(:jl_new_codeinst, Ref{CodeInstance}, (Any, Any, Any, Any, Int32, UInt, UInt),
                     mi, rettype, inferred_const, inferred, const_flags, min_world, max_world)))
-eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, Const, :v, false))))
-eval(Core, :(Const(@nospecialize(v), actual::Bool) = $(Expr(:new, Const, :v, :actual))))
-eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, PartialStruct, :typ, :fields))))
+eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, :Const, :v, false))))
+eval(Core, :(Const(@nospecialize(v), actual::Bool) = $(Expr(:new, :Const, :v, :actual))))
+eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))))
 
 Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool), name, std_imports)
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -399,6 +399,9 @@ eval(Core, :(CodeInstance(mi::MethodInstance, @nospecialize(rettype), @nospecial
                           min_world::UInt, max_world::UInt) =
                 ccall(:jl_new_codeinst, Ref{CodeInstance}, (Any, Any, Any, Any, Int32, UInt, UInt),
                     mi, rettype, inferred_const, inferred, const_flags, min_world, max_world)))
+eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, Const, :v, false))))
+eval(Core, :(Const(@nospecialize(v), actual::Bool) = $(Expr(:new, Const, :v, :actual))))
+eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, PartialStruct, :typ, :fields))))
 
 Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool), name, std_imports)
 
@@ -468,11 +471,13 @@ Symbol(s::Symbol) = s
 module IR
 export CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnNode,
     NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot, Argument,
-    PiNode, PhiNode, PhiCNode, UpsilonNode, LineInfoNode
+    PiNode, PhiNode, PhiCNode, UpsilonNode, LineInfoNode,
+    Const, PartialStruct
 
 import Core: CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnNode,
     NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot, Argument,
-    PiNode, PhiNode, PhiCNode, UpsilonNode, LineInfoNode
+    PiNode, PhiNode, PhiCNode, UpsilonNode, LineInfoNode,
+    Const, PartialStruct
 
 end
 

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -4,13 +4,23 @@
 # structs/constants #
 #####################
 
-# The type of a value might be constant
-struct Const
-    val
-    actual::Bool  # if true, we obtained `val` by actually calling a @pure function
-    Const(@nospecialize(v)) = new(v, false)
-    Const(@nospecialize(v), a::Bool) = new(v, a)
-end
+# N.B.: Const/PartialStruct are defined in Core, to allow them to be used
+# inside the global code cache.
+#
+# # The type of a value might be constant
+# struct Const
+#     val
+#     actual::Bool  # if true, we obtained `val` by actually calling a @pure function
+#     Const(@nospecialize(v)) = new(v, false)
+#     Const(@nospecialize(v), a::Bool) = new(v, a)
+# end
+#
+# struct PartialStruct
+#     typ
+#     fields::Vector{Any} # elements are other type lattice members
+# end
+import Core: Const, PartialStruct
+
 
 # The type of this value might be Bool.
 # However, to enable a limited amount of back-propagagation,
@@ -68,11 +78,6 @@ struct StateUpdate
     var::Union{Slot,SSAValue}
     vtype::VarState
     state::VarTable
-end
-
-struct PartialStruct
-    typ
-    fields::Vector{Any} # elements are other type lattice members
 end
 
 struct NotFound end

--- a/doc/src/devdocs/ssair.md
+++ b/doc/src/devdocs/ssair.md
@@ -143,7 +143,7 @@ The corresponding IR (with irrelevant types stripped) is:
 └──       $(Expr(:unreachable))::Union{}
 4 ┄ %13 = φᶜ (%3, %6, %9)::Bool
 │   %14 = φᶜ (%4, %7, %10)::Core.Compiler.MaybeUndef(Int64)
-│   %15 = φᶜ (%5)::Core.Compiler.Const(1, false)
+│   %15 = φᶜ (%5)::Core.Const(1, false)
 └──       $(Expr(:leave, 1))
 5 ─       $(Expr(:pop_exception, :(%2)))::Any
 │         $(Expr(:throw_undef_if_not, :y, :(%13)))::Any

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1432,7 +1432,7 @@ julia> function f(x)
 
 julia> @code_warntype f(3.2)
 Variables
-  #self#::Core.Compiler.Const(f, false)
+  #self#::Core.Const(f, false)
   x::Float64
   y::UNION{FLOAT64, INT64}
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1581,6 +1581,8 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("SlotNumber", (jl_value_t*)jl_slotnumber_type);
     add_builtin("TypedSlot", (jl_value_t*)jl_typedslot_type);
     add_builtin("Argument", (jl_value_t*)jl_argument_type);
+    add_builtin("Const", (jl_value_t*)jl_const_type);
+    add_builtin("PartialStruct", (jl_value_t*)jl_partial_struct_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);
     add_builtin("Builtin", (jl_value_t*)jl_builtin_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -35,6 +35,8 @@ jl_datatype_t *jl_abstractslot_type;
 jl_datatype_t *jl_slotnumber_type;
 jl_datatype_t *jl_typedslot_type;
 jl_datatype_t *jl_argument_type;
+jl_datatype_t *jl_const_type;
+jl_datatype_t *jl_partial_struct_type;
 jl_datatype_t *jl_simplevector_type;
 jl_typename_t *jl_tuple_typename;
 jl_datatype_t *jl_anytuple_type;
@@ -2378,6 +2380,14 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_any_type, jl_any_type), // fptrs
                         0, 1, 1);
     jl_svecset(jl_code_instance_type->types, 1, jl_code_instance_type);
+
+    jl_const_type = jl_new_datatype(jl_symbol("Const"), core, jl_any_type, jl_emptysvec,
+                                       jl_perm_symsvec(2, "val", "actual"),
+                                       jl_svec2(jl_any_type, jl_bool_type), 0, 0, 2);
+
+    jl_partial_struct_type = jl_new_datatype(jl_symbol("PartialStruct"), core, jl_any_type, jl_emptysvec,
+                                       jl_perm_symsvec(2, "typ", "fields"),
+                                       jl_svec2(jl_any_type, jl_array_any_type), 0, 0, 2);
 
     // all Kinds share the Type method table (not the nonfunction one)
     jl_unionall_type->name->mt = jl_uniontype_type->name->mt = jl_datatype_type->name->mt =

--- a/src/julia.h
+++ b/src/julia.h
@@ -570,6 +570,8 @@ extern JL_DLLEXPORT jl_datatype_t *jl_abstractslot_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_slotnumber_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_typedslot_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_const_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_partial_struct_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_simplevector_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_tuple_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_vecelement_typename JL_GLOBALLY_ROOTED;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -40,6 +40,7 @@ static void *const _tags[] = {
          &jl_module_type, &jl_tvar_type, &jl_method_instance_type, &jl_method_type, &jl_code_instance_type,
          &jl_linenumbernode_type, &jl_lineinfonode_type,
          &jl_gotonode_type, &jl_quotenode_type, &jl_gotoifnot_type, &jl_argument_type, &jl_returnnode_type,
+         &jl_const_type, &jl_partial_struct_type,
          &jl_pinode_type, &jl_phinode_type, &jl_phicnode_type, &jl_upsilonnode_type,
          &jl_type_type, &jl_bottom_type, &jl_ref_type, &jl_pointer_type, &jl_llvmpointer_type,
          &jl_vararg_type, &jl_abstractarray_type,

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1322,7 +1322,7 @@ Int64
 
 julia> @code_warntype f(2)
 Variables
-  #self#::Core.Compiler.Const(f, false)
+  #self#::Core.Const(f, false)
   a::Int64
 
 Body::UNION{FLOAT64, INT64}


### PR DESCRIPTION
The change in #36521 proposes to make PartialStruct legal in the
global code cache. However, `@vtjnash` points out that since
these structs are currently defined in `Core.Compiler`, this
would make loading a second copy of inference impossible. However,
loading a second copy of inference is desirable for development,
so we generally put any type that can appear in the global cache
into `Core` to make this possible. As such we have two options
here:
1. Change the representation of PartialStruct to only use objects
already in Core
2. Move Const/PartialStruct into Core

I originally thought that option 1 would be preferable, since I
though that the only meaningful information that could appear
in a PartialStruct field would be a Const or a nested PartialStruct.
However, I forgot that it sometimes also contains Type{...} or elements
of the type lattice more precise than what the widened type prescribes.
As such, building PartialStruct out of solely types defined in Core
would have gotten a bit messy, and it's much simpler just to move
both of these to Core themselves. `@JeffBezanson` also points out
that we may eventually want to look at these in codegen, so define
them in C while we're at it.