### PR TITLE
Simplify llvmcall

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -954,24 +954,23 @@ In most cases, this simply results in a call to `convert(argtype, argvalue)`.
 kw"ccall"
 
 """
-    llvmcall(IR::String, ReturnType, (ArgumentType1, ...), ArgumentValue1, ...)
-    llvmcall((declarations::String, IR::String), ReturnType, (ArgumentType1, ...), ArgumentValue1, ...)
+    llvmcall(fun_ir::String, returntype, Tuple{argtype1, ...}, argvalue1, ...)
+    llvmcall((mod_ir::String, entry_fn::String), returntype, Tuple{argtype1, ...}, argvalue1, ...)
+    llvmcall((mod_bc::Vector{UInt8}, entry_fn::String), returntype, Tuple{argtype1, ...}, argvalue1, ...)
 
-Call LLVM IR string in the first argument. Similar to an LLVM function `define` block,
-arguments are available as consecutive unnamed SSA variables (%0, %1, etc.).
+Call the LLVM code provided in the first argument. There are several ways to specify this
+first argument:
 
-The optional declarations string contains external functions declarations that are
-necessary for llvm to compile the IR string. Multiple declarations can be passed in by
-separating them with line breaks.
+- as a literal string, representing function-level IR (similar to an LLVM `define` block),
+  with arguments are available as consecutive unnamed SSA variables (%0, %1, etc.);
+- as a 2-element tuple, containing a string of module IR and a string representing the name
+  of the entry-point function to call;
+- as a 2-element tuple, but with the module provided as an `Vector{UINt8}` with bitcode.
 
-Note that the argument type tuple must be a literal tuple, and not a tuple-valued
-variable or expression.
-
-Each `ArgumentValue` to `llvmcall` will be converted to the corresponding
-`ArgumentType`, by automatic insertion of calls to `unsafe_convert(ArgumentType,
-cconvert(ArgumentType, ArgumentValue))`. (See also the documentation for
-[`unsafe_convert`](@ref Base.unsafe_convert) and [`cconvert`](@ref Base.cconvert) for further details.)
-In most cases, this simply results in a call to `convert(ArgumentType, ArgumentValue)`.
+Note that contrary to `ccall`, the argument types must be specified as a tuple type, and not
+a tuple of types. All types, as well as the LLVM code, should be specified as literals, and
+not as variables or expressions (it may be necessary to use `@eval` to generate these
+literals).
 
 See `test/llvmcall.jl` for usage examples.
 """

--- a/src/Makefile
+++ b/src/Makefile
@@ -235,7 +235,7 @@ $(BUILDDIR)/init.o $(BUILDDIR)/init.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/interpreter.o $(BUILDDIR)/interpreter.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/jltypes.o $(BUILDDIR)/jltypes.dbg.obj: $(SRCDIR)/builtin_proto.h
-$(BUILDDIR)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/codegen_shared.h
+$(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/codegen_shared.h $(BUILDDIR)/julia_version.h
 $(BUILDDIR)/llvm-alloc-opt.o $(BUILDDIR)/llvm-alloc-opt.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-final-gc-lowering.o $(BUILDDIR)/llvm-final-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/llvm-gc-invariant-verifier.o $(BUILDDIR)/llvm-gc-invariant-verifier.dbg.obj: $(SRCDIR)/codegen_shared.h

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -2,6 +2,7 @@
 
 // --- the ccall, cglobal, and llvm intrinsics ---
 #include "llvm/Support/Path.h" // for llvm::sys::path
+#include <llvm/Linker/Linker.h>
 
 // somewhat unusual variable, in that aotcompile wants to get the address of this for a sanity check
 GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M)
@@ -649,195 +650,22 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
     return mark_julia_type(ctx, res, false, rt);
 }
 
-static Function *llvmcall_proto(Function *F, Module *M = nullptr)
-{
-    // Copy the declaration characteristics of the Function (not the body)
-    Function *NewF = Function::Create(F->getFunctionType(),
-                                      Function::ExternalLinkage,
-                                      F->getName(),
-                                      M);
+// --- code generator for llvmcall ---
 
-    // Declarations are not allowed to have personality routines, but
-    // copyAttributesFrom sets them anyway. Temporarily unset the personality
-    // routine from `F`, since copying it and then resetting is more expensive
-    // as well as introducing an extra use from this unowned function, which
-    // can cause crashes in the LLVMContext's global destructor.
-    llvm::Constant *OldPersonalityFn = nullptr;
-    if (F->hasPersonalityFn()) {
-        OldPersonalityFn = F->getPersonalityFn();
-        F->setPersonalityFn(nullptr);
-    }
-
-    // FunctionType does not include any attributes. Copy them over manually
-    // as codegen may make decisions based on the presence of certain attributes
-    NewF->copyAttributesFrom(F);
-
-    if (OldPersonalityFn)
-        F->setPersonalityFn(OldPersonalityFn);
-
-    // DLLImport only needs to be set for the shadow module
-    // it just gets annoying in the JIT
-    NewF->setDLLStorageClass(GlobalValue::DefaultStorageClass);
-
-    return NewF;
-}
-
-class FunctionMover final : public ValueMaterializer
-{
-public:
-    FunctionMover(llvm::Module *dest,llvm::Module *src) :
-        ValueMaterializer(), VMap(), destModule(dest), srcModule(src),
-        LazyFunctions(0)
-    {
-    }
-    ValueToValueMapTy VMap;
-    llvm::Module *destModule;
-    llvm::Module *srcModule;
-    std::vector<Function *> LazyFunctions;
-
-    Function *CloneFunctionProto(Function *F)
-    {
-        assert(!F->isDeclaration());
-        Function *NewF = Function::Create(F->getFunctionType(),
-                                          Function::ExternalLinkage,
-                                          F->getName(),
-                                          destModule);
-        LazyFunctions.push_back(F);
-        VMap[F] = NewF;
-        return NewF;
-    }
-
-    void CloneFunctionBody(Function *F)
-    {
-        Function *NewF = (Function*)(Value*)VMap[F];
-        assert(NewF != NULL);
-
-        Function::arg_iterator DestI = NewF->arg_begin();
-        for (Function::const_arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E; ++I) {
-            DestI->setName(I->getName());    // Copy the name over...
-            VMap[&*I] = &*(DestI++);        // Add mapping to VMap
-        }
-
-        SmallVector<ReturnInst*, 8> Returns;
-        llvm::CloneFunctionInto(NewF,F,VMap,true,Returns,"",NULL,NULL,this);
-        NewF->setComdat(nullptr);
-        NewF->setSection("");
-    }
-
-    Function *CloneFunction(Function *F)
-    {
-        Function *NewF = (llvm::Function*)MapValue(F,VMap,RF_None,NULL,this);
-        ResolveLazyFunctions();
-        return NewF;
-    }
-
-    void ResolveLazyFunctions()
-    {
-        while (!LazyFunctions.empty()) {
-            Function *F = LazyFunctions.back();
-            LazyFunctions.pop_back();
-
-            CloneFunctionBody(F);
-        }
-    }
-
-    Value *InjectFunctionProto(Function *F)
-    {
-        Function *NewF = destModule->getFunction(F->getName());
-        if (!NewF) {
-            NewF = llvmcall_proto(F);
-            NewF->setComdat(nullptr);
-            destModule->getFunctionList().push_back(NewF);
-        }
-        return NewF;
-    }
-
-    Value *materialize(Value *V) override
-    {
-        Function *F = dyn_cast<Function>(V);
-        if (F) {
-            if (isIntrinsicFunction(F)) {
-                auto Fcopy = destModule->getOrInsertFunction(F->getName(), F->getFunctionType());
-#if JL_LLVM_VERSION >= 90000
-                return Fcopy.getCallee();
-#else
-                return Fcopy;
-#endif
-            }
-            if (F->isDeclaration() || F->getParent() != destModule) {
-                if (F->getName().empty())
-                    return CloneFunctionProto(F);
-                Function *shadow = srcModule->getFunction(F->getName());
-                if (shadow != NULL && !shadow->isDeclaration()) {
-                    Function *oldF = destModule->getFunction(F->getName());
-                    if (oldF)
-                        return oldF;
-                    if (jl_ExecutionEngine->findSymbol(F->getName(), false))
-                        return InjectFunctionProto(F);
-                    return CloneFunctionProto(shadow);
-                }
-                else if (!F->isDeclaration()) {
-                    return CloneFunctionProto(F);
-                }
-            }
-            // Still a declaration and still in a different module
-            if (F->isDeclaration() && F->getParent() != destModule) {
-                // Create forward declaration in current module
-                return InjectFunctionProto(F);
-            }
-        }
-        else if (isa<GlobalVariable>(V)) {
-            GlobalVariable *GV = cast<GlobalVariable>(V);
-            assert(GV != NULL);
-            GlobalVariable *oldGV = destModule->getGlobalVariable(GV->getName());
-            if (oldGV != NULL)
-                return oldGV;
-            GlobalVariable *newGV = new GlobalVariable(*destModule,
-                GV->getType()->getElementType(),
-                GV->isConstant(),
-                GV->getLinkage(),
-                NULL,
-                GV->getName(),
-                NULL,
-                GV->getThreadLocalMode(),
-                GV->getType()->getPointerAddressSpace());
-            newGV->copyAttributesFrom(GV);
-            newGV->setComdat(nullptr);
-            if (GV->isDeclaration())
-                return newGV;
-            if (!GV->getName().empty()) {
-                uint64_t addr = jl_ExecutionEngine->getGlobalValueAddress(GV->getName());
-                if (addr != 0) {
-                    newGV->setExternallyInitialized(true);
-                    return newGV;
-                }
-            }
-            if (GV->hasInitializer()) {
-                Value *C = MapValue(GV->getInitializer(),VMap,RF_None,NULL,this);
-                newGV->setInitializer(cast<Constant>(C));
-            }
-            return newGV;
-        }
-        return NULL;
-    };
-};
-
-static Function *prepare_llvmcall(Module *M, Function *Callee)
-{
-    GlobalValue *local = M->getNamedValue(Callee->getName());
-    if (!local)
-        local = llvmcall_proto(Callee, M);
-    return cast<Function>(local);
-}
-
-
-// llvmcall(ir, (rettypes...), (argtypes...), args...)
 static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
 {
+    // parse and validate arguments
+    //
+    // two forms of llvmcall are supported:
+    // - llvmcall(ir, (rettypes...), (argtypes...), args...)
+    //   where `ir` represents IR that should be pasted in a function body
+    // - llvmcall((mod, fn), (rettypes...), (argtypes...), args...)
+    //   where `mod` represents the assembly of an entire LLVM module,
+    //   and `fn` the name of the function to call
     JL_NARGSV(llvmcall, 3);
-    jl_value_t *rt = NULL, *at = NULL, *ir = NULL, *decl = NULL;
+    jl_value_t *rt = NULL, *at = NULL, *ir = NULL, *entry = NULL;
     jl_value_t *ir_arg = args[1];
-    JL_GC_PUSH4(&ir, &rt, &at, &decl);
+    JL_GC_PUSH4(&ir, &rt, &at, &entry);
     if (jl_is_ssavalue(ir_arg))
         ir_arg = jl_arrayref((jl_array_t*)ctx.source->code, ((jl_ssavalue_t*)ir_arg)->id - 1);
     ir = try_eval(ctx, ir_arg, "error statically evaluating llvm IR argument");
@@ -856,25 +684,20 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     if (at == NULL)
         at = try_eval(ctx, args[3], "error statically evaluating llvmcall argument tuple");
     if (jl_is_tuple(ir)) {
-        // if the IR is a tuple, we expect (declarations, ir)
+        // if the IR is a tuple, we expect (mod, fn)
         if (jl_nfields(ir) != 2)
             jl_error("Tuple as first argument to llvmcall must have exactly two children");
-        decl = jl_fieldref(ir,0);
-        ir = jl_fieldref(ir,1);
-        if (!jl_is_string(decl))
-            jl_error("Declarations passed to llvmcall must be a string");
+        entry = jl_fieldref(ir, 1);
+        if (!jl_is_string(entry))
+            jl_error("Function name passed to llvmcall must be a string");
+        ir = jl_fieldref(ir, 0);
     }
-    bool isString = jl_is_string(ir);
-    bool isPtr = jl_is_cpointer(ir);
-    if (!isString && !isPtr) {
-        jl_error("IR passed to llvmcall must be a string or pointer to an LLVM Function");
+    if (!jl_is_string(ir)) {
+        jl_error("IR passed to llvmcall must be a string or a tuple of two strings");
     }
 
     JL_TYPECHK(llvmcall, type, rt);
     JL_TYPECHK(llvmcall, type, at);
-
-    std::string ir_string;
-    raw_string_ostream ir_stream(ir_string);
 
     // Generate arguments
     std::string arguments;
@@ -906,17 +729,21 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
         argvals[i] = llvm_type_rewrite(ctx, v, t, issigned);
     }
 
-    Function *f;
     bool retboxed;
     Type *rettype = julia_type_to_llvm(ctx, rtt, &retboxed);
-    if (isString) {
-        // Make sure to find a unique name
-        std::string ir_name;
-        while (true) {
-            raw_string_ostream(ir_name) << (ctx.f->getName().str()) << "u" << globalUnique++;
-            if (jl_Module->getFunction(ir_name) == NULL)
-                break;
-        }
+
+    // Make sure to find a unique name
+    std::string ir_name;
+    while (true) {
+        raw_string_ostream(ir_name) << (ctx.f->getName().str()) << "u" << globalUnique++;
+        if (jl_Module->getFunction(ir_name) == NULL)
+            break;
+    }
+
+    // generate a temporary module that contains our IR
+    std::unique_ptr<Module> Mod;
+    if (entry == NULL) {
+        // we only have function IR, which we should put in a function
 
         bool first = true;
         for (std::vector<Type *>::iterator it = argtypes.begin(); it != argtypes.end(); ++it) {
@@ -933,91 +760,77 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
         rettype->print(rtypename);
         std::map<uint64_t,std::string> localDecls;
 
-        if (decl != NULL) {
-            // parse string line by line
-            StringRef declarations(jl_string_data(decl), jl_string_len(decl));
-            while (!declarations.empty()) {
-                StringRef declstr;
-                std::tie(declstr, declarations) = declarations.split('\n');
-                // Find name of declaration by searching for '@'
-                size_t atpos = declstr.find('@') + 1;
-                // Find end of declaration by searching for '('
-                size_t bracepos = declstr.find('(', atpos);
-                // Declaration name is the string between @ and (
-                StringRef declname = declstr.substr(atpos, bracepos - atpos);
-
-                // Check if declaration already present in module
-                if (jl_Module->getNamedValue(declname) == NULL) {
-                    ir_stream << "; Declarations\n" << declstr << "\n";
-                }
-            }
-        }
+        std::string ir_string;
+        raw_string_ostream ir_stream(ir_string);
         ir_stream << "; Number of arguments: " << nargt << "\n"
         << "define "<<rtypename.str()<<" @\"" << ir_name << "\"("<<argstream.str()<<") {\n"
         << jl_string_data(ir) << "\n}";
-        SMDiagnostic Err = SMDiagnostic();
-        // Do not enable update debug info since it runs the verifier on the whole module
-        // and will error on the function we are currently emitting.
-        ModuleSummaryIndex index = ModuleSummaryIndex(true);
-        bool failed = parseAssemblyInto(MemoryBufferRef(ir_stream.str(), "llvmcall"),
-                                        jl_Module, &index, Err, nullptr,
-                                        /* UpdateDebugInfo */ false);
-        f = jl_Module->getFunction(ir_name);
-        if (failed) {
-            // try to get the module in a workable state again
-            if (f)
-                f->eraseFromParent();
 
+        SMDiagnostic Err = SMDiagnostic();
+        Mod = parseAssemblyString(ir_stream.str(), Err, jl_LLVMContext);
+        if (!Mod) {
             std::string message = "Failed to parse LLVM assembly: \n";
             raw_string_ostream stream(message);
             Err.print("", stream, true);
             emit_error(ctx, stream.str());
             return jl_cgval_t();
         }
+
+        Function *f = Mod->getFunction(ir_name);
+        f->addFnAttr(Attribute::AlwaysInline);
     }
     else {
-        assert(isPtr);
-        // Create Function skeleton
-        f = (llvm::Function*)jl_unbox_voidpointer(ir);
+        // we have the IR of an entire module, which we can parse directly
+
+        SMDiagnostic Err = SMDiagnostic();
+        Mod = parseAssemblyString(jl_string_data(ir), Err, jl_LLVMContext);
+        if (!Mod) {
+            std::string message = "Failed to parse LLVM assembly: \n";
+            raw_string_ostream stream(message);
+            Err.print("", stream, true);
+            emit_error(ctx, stream.str());
+            return jl_cgval_t();
+        }
+
+        Function *f = Mod->getFunction(jl_string_data(entry));
+        if (!f) {
+            emit_error(ctx, "Module IR does not contain specified entry function");
+            return jl_cgval_t();
+        }
+        f->setName(ir_name);
+
+        // verify the function type
         assert(!f->isDeclaration());
         assert(f->getReturnType() == rettype);
         int i = 0;
         for (std::vector<Type *>::iterator it = argtypes.begin();
             it != argtypes.end(); ++it, ++i)
             assert(*it == f->getFunctionType()->getParamType(i));
-
-        if (f->getParent() != jl_Module) {
-            FunctionMover mover(jl_Module, f->getParent());
-            f = mover.CloneFunction(f);
-        }
-
-        std::string message = "Malformed LLVM function: \n";
-        raw_string_ostream stream(message);
-        if (verifyFunction(*f, &stream)) {
-            emit_error(ctx, stream.str());
-            return jl_cgval_t();
-        }
     }
 
-    // Since we dumped all of f's dependencies into the active module,
-    // we cannot reasonably inline it, so leave it there and just emit
-    // a regular call
-    if (!isString) {
-        static int llvmcallnumbering = 0;
-        std::string name;
-        llvm::raw_string_ostream(name) << "jl_llvmcall" << llvmcallnumbering++;
-        f->setName(name);
-        f = prepare_llvmcall(jl_Module, llvmcall_proto(f));
-    }
-    else {
-        f->setLinkage(GlobalValue::LinkOnceODRLinkage);
+    // copy module properties that should always match
+    Mod->setTargetTriple(jl_Module->getTargetTriple());
+    Mod->setDataLayout(jl_Module->getDataLayout());
+
+    // verify the IR
+    Function *f = Mod->getFunction(ir_name);
+    assert(f);
+    std::string message = "Malformed LLVM function: \n";
+    raw_string_ostream stream(message);
+    if (verifyFunction(*f, &stream)) {
+        emit_error(ctx, stream.str());
+        return jl_cgval_t();
     }
 
+    if (Linker::linkModules(*jl_Module, std::move(Mod))) {
+        emit_error(ctx, "Failed to link LLVM bitcode");
+        return jl_cgval_t();
+    }
+
+    f = jl_Module->getFunction(ir_name);
+    assert(f);
     CallInst *inst = ctx.builder.CreateCall(f, ArrayRef<Value*>(&argvals[0], nargt));
-    if (isString) {
-        f->addFnAttr(Attribute::AlwaysInline);
-        inst->setAttributes(f->getAttributes());
-    }
+    f->setLinkage(GlobalVariable::PrivateLinkage);
 
     JL_GC_POP();
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -126,7 +126,7 @@ static jl_value_t *do_invoke(jl_value_t **args, size_t nargs, interpreter_state 
     JL_GC_PUSHARGS(argv, nargs - 1);
     size_t i;
     for (i = 1; i < nargs; i++)
-        argv[i - 1] = eval_value(args[i], s);
+        argv[i] = eval_value(args[i], s);
     jl_method_instance_t *meth = (jl_method_instance_t*)args[0];
     assert(jl_is_method_instance(meth));
     jl_value_t *result = jl_invoke(argv[1], &argv[2], nargs - 2, meth);

--- a/src/llvmcalltest.cpp
+++ b/src/llvmcalltest.cpp
@@ -7,15 +7,20 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/IRBuilder.h"
 
+#include "julia.h"
 #include "codegen_shared.h"
 
 using namespace llvm;
 
 extern "C" {
 
-JL_DLLEXPORT llvm::Function *MakeIdentityFunction(llvm::PointerType *AnyTy) {
+JL_DLLEXPORT const char *MakeIdentityFunction(jl_value_t* jl_AnyTy) {
+    LLVMContext Ctx;
+    PointerType *AnyTy = PointerType::get(StructType::get(Ctx), 0);
+    // FIXME: get AnyTy via jl_type_to_llvm(Ctx, jl_AnyTy)
+
     Type *TrackedTy = PointerType::get(AnyTy->getElementType(), AddressSpace::Tracked);
-    Module *M = new llvm::Module("shadow", AnyTy->getContext());
+    Module *M = new llvm::Module("shadow", Ctx);
     Function *F = Function::Create(
         FunctionType::get(
             TrackedTy, {TrackedTy}, false),
@@ -24,15 +29,21 @@ JL_DLLEXPORT llvm::Function *MakeIdentityFunction(llvm::PointerType *AnyTy) {
         M
     );
 
-    IRBuilder<> Builder(BasicBlock::Create(AnyTy->getContext(), "top", F));
+    IRBuilder<> Builder(BasicBlock::Create(Ctx, "top", F));
     Builder.CreateRet(&*F->arg_begin());
 
-    return F;
+    std::string buf;
+    raw_string_ostream os(buf);
+    M->print(os, NULL);
+    os.flush();
+    return strdup(buf.c_str());
 }
 
-JL_DLLEXPORT llvm::Function *MakeLoadGlobalFunction(llvm::PointerType *AnyTy) {
-    auto M = new Module("shadow", AnyTy->getContext());
-    auto intType = Type::getInt32Ty(AnyTy->getContext());
+JL_DLLEXPORT const char *MakeLoadGlobalFunction() {
+    LLVMContext Ctx;
+
+    auto M = new Module("shadow", Ctx);
+    auto intType = Type::getInt32Ty(Ctx);
     auto G = new GlobalVariable(
         *M,
         intType,
@@ -41,17 +52,21 @@ JL_DLLEXPORT llvm::Function *MakeLoadGlobalFunction(llvm::PointerType *AnyTy) {
         Constant::getNullValue(intType),
         "test_global_var");
 
-    auto resultType = Type::getInt64Ty(AnyTy->getContext());
+    auto resultType = Type::getInt64Ty(Ctx);
     auto F = Function::Create(
         FunctionType::get(resultType, {}, false),
         GlobalValue::ExternalLinkage,
         "load_global_var",
         M);
 
-    IRBuilder<> Builder(BasicBlock::Create(AnyTy->getContext(), "top", F));
+    IRBuilder<> Builder(BasicBlock::Create(Ctx, "top", F));
     Builder.CreateRet(Builder.CreatePtrToInt(G, resultType));
 
-    return F;
+    std::string buf;
+    raw_string_ostream os(buf);
+    M->print(os, NULL);
+    os.flush();
+    return strdup(buf.c_str());
 }
 
 }

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -80,10 +80,14 @@ end
 
 function declared_floor(x::Float64)
     llvmcall(
-        ("""declare double @llvm.floor.f64(double)""",
-         """%2 = call double @llvm.floor.f64(double %0)
-            ret double %2"""),
-    Float64, Tuple{Float64}, x)
+        ("""declare double @llvm.floor.f64(double)
+            define double @entry(double) #0 {
+            1:
+                %2 = call double @llvm.floor.f64(double %0)
+                ret double %2
+            }
+            attributes #0 = { alwaysinline }
+         """, "entry"), Float64, Tuple{Float64}, x)
 end
 @test declared_floor(4.2) ≈ 4.
 ir = sprint(code_llvm, declared_floor, Tuple{Float64})
@@ -91,67 +95,51 @@ ir = sprint(code_llvm, declared_floor, Tuple{Float64})
 
 function doubly_declared_floor(x::Float64)
     llvmcall(
-        ("""declare double @llvm.floor.f64(double)""",
-         """%2 = call double @llvm.floor.f64(double %0)
-            ret double %2"""),
-    Float64, Tuple{Float64}, x+1)-1
+        ("""declare double @llvm.floor.f64(double)
+            define double @entry(double) #0 {
+            1:
+                %2 = call double @llvm.floor.f64(double %0)
+                ret double %2
+            }
+            attributes #0 = { alwaysinline }
+         """, "entry"), Float64, Tuple{Float64}, x+1)-1
 end
 @test doubly_declared_floor(4.2) ≈ 4.
 
 function doubly_declared2_trunc(x::Float64)
     a = llvmcall(
-        ("""declare double @llvm.trunc.f64(double)""",
-         """%2 = call double @llvm.trunc.f64(double %0)
-            ret double %2"""),
-    Float64, Tuple{Float64}, x)
+        ("""declare double @llvm.trunc.f64(double)
+            define double @entry(double) #0 {
+            1:
+                %2 = call double @llvm.trunc.f64(double %0)
+                ret double %2
+            }
+            attributes #0 = { alwaysinline }
+         """, "entry"), Float64, Tuple{Float64}, x)
     b = llvmcall(
-        ("""declare double @llvm.trunc.f64(double)""",
-         """%2 = call double @llvm.trunc.f64(double %0)
-            ret double %2"""),
-    Float64, Tuple{Float64}, x+1)-1
+        ("""declare double @llvm.trunc.f64(double)
+            define double @entry(double) #0 {
+            1:
+                %2 = call double @llvm.trunc.f64(double %0)
+                ret double %2
+            }
+            attributes #0 = { alwaysinline }
+         """, "entry"), Float64, Tuple{Float64}, x+1)-1
     a + b
 end
 @test doubly_declared2_trunc(4.2) ≈ 8.
 
-# Test for single line
-function declared_ceil(x::Float64)
-    llvmcall(
-        ("declare double @llvm.ceil.f64(double)",
-         """%2 = call double @llvm.ceil.f64(double %0)
-            ret double %2"""),
-    Float64, Tuple{Float64}, x)
-end
-@test declared_ceil(4.2) ≈ 5.0
-
-# Test for multiple lines
-function ceilfloor(x::Float64)
-    llvmcall(
-        ("""declare double @llvm.ceil.f64(double)
-            declare double @llvm.floor.f64(double)""",
-         """%2 = call double @llvm.ceil.f64(double %0)
-            %3 = call double @llvm.floor.f64(double %2)
-            ret double %3"""),
-    Float64, Tuple{Float64}, x)
-end
-@test ceilfloor(7.4) ≈ 8.0
-
-# Test for proper declaration extraction
-function confuse_declname_parsing()
-    llvmcall(
-        ("""declare i64 addrspace(0)* @foobar()""",
-         """ret void"""),
-    Cvoid, Tuple{})
-end
-confuse_declname_parsing()
-
 # Test for proper mangling of external (C) functions
 function call_jl_errno()
     llvmcall(
-    (""" declare i32 @jl_errno()""",
-    """
-    %r = call i32 @jl_errno()
-    ret i32 %r
-    """),Int32,Tuple{})
+        ("""declare i32 @jl_errno()
+            define i32 @entry() #0 {
+            0:
+                %r = call i32 @jl_errno()
+                ret i32 %r
+            }
+            attributes #0 = { alwaysinline }
+         """, "entry"),Int32,Tuple{})
 end
 call_jl_errno()
 
@@ -168,11 +156,14 @@ module ObjLoadTest
     jl_the_callback(); didcall = false
     function do_the_call()
         llvmcall(
-        (""" declare void @jl_the_callback()""",
-        """
-        call void @jl_the_callback()
-        ret void
-        """),Cvoid,Tuple{})
+            ("""declare void @jl_the_callback()
+                define void @entry() #0 {
+                0:
+                    call void @jl_the_callback()
+                    ret void
+                }
+                attributes #0 = { alwaysinline }
+            """, "entry"),Cvoid,Tuple{})
     end
     do_the_call()
     @test didcall
@@ -198,11 +189,14 @@ module CcallableRetTypeTest
     end
     function do_the_call()
         llvmcall(
-        (""" declare double @jl_test_returns_float()""",
-        """
-        %1 = call double @jl_test_returns_float()
-        ret double %1
-        """),Float64,Tuple{})
+            ("""declare double @jl_test_returns_float()
+                define double @entry() #0 {
+                0:
+                    %1 = call double @jl_test_returns_float()
+                    ret double %1
+                }
+                attributes #0 = { alwaysinline }
+            """, "entry"),Float64,Tuple{})
     end
     @test do_the_call() === 42.0
 end
@@ -212,16 +206,10 @@ module LLVMCallFunctionTest
     using Base: llvmcall
     using Test
 
-    function julia_to_llvm(@nospecialize x)
-        isboxed = Ref{UInt8}()
-        ccall(:jl_type_to_llvm, Ptr{Cvoid}, (Any, Ref{UInt8}), x, isboxed)
-    end
-    const AnyTy = julia_to_llvm(Any)
-
     const libllvmcalltest = "libllvmcalltest"
-    const the_f = ccall((:MakeIdentityFunction, libllvmcalltest), Ptr{Cvoid}, (Ptr{Cvoid},), AnyTy)
+    const the_ir = unsafe_string(ccall((:MakeIdentityFunction, libllvmcalltest), Cstring, (Any,), Any))
 
-    @eval really_complicated_identity(x) = llvmcall($(the_f), Any, Tuple{Any}, x)
+    @eval really_complicated_identity(x) = llvmcall(($(the_ir), "identity"), Any, Tuple{Any}, x)
 
     mutable struct boxed_struct
     end
@@ -233,11 +221,11 @@ module LLVMCallFunctionTest
     # The names of these globals are the same, so if their linkages are overwritten, then the
     # linker will merge the globals. Consequently, we can test that linkage is preserved by testing
     # that the addresses of the globals differ. The next few lines of code do just that.
-    const the_other_f1 = ccall((:MakeLoadGlobalFunction, libllvmcalltest), Ptr{Cvoid}, (Ptr{Cvoid},), AnyTy)
-    const the_other_f2 = ccall((:MakeLoadGlobalFunction, libllvmcalltest), Ptr{Cvoid}, (Ptr{Cvoid},), AnyTy)
+    const the_other_ir1 = unsafe_string(ccall((:MakeLoadGlobalFunction, libllvmcalltest), Cstring, ()))
+    const the_other_ir2 = unsafe_string(ccall((:MakeLoadGlobalFunction, libllvmcalltest), Cstring, ()))
 
-    @eval global_value_address1() = llvmcall($(the_other_f1), Int64, Tuple{})
-    @eval global_value_address2() = llvmcall($(the_other_f2), Int64, Tuple{})
+    @eval global_value_address1() = llvmcall(($(the_other_ir1), "load_global_var"), Int64, Tuple{})
+    @eval global_value_address2() = llvmcall(($(the_other_ir2), "load_global_var"), Int64, Tuple{})
 
     @test global_value_address1() != global_value_address2()
 end

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -229,3 +229,7 @@ module LLVMCallFunctionTest
 
     @test global_value_address1() != global_value_address2()
 end
+
+# issue 34166
+f34166(x) = Base.llvmcall("ret i$(Sys.WORD_SIZE) %0", Int, (Int,), x)
+@test_throws ErrorException f34166(1)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -227,11 +227,13 @@ try
 
     @eval begin function ccallable_test()
         Base.llvmcall(
-        (""" declare i32 @f35014(i32)""",
-         """
-         %1 = call i32 @f35014(i32 3)
-         ret i32 %1
-         """), Cint, Tuple{})
+        ("""declare i32 @f35014(i32)
+            define i32 @entry() {
+            0:
+                %1 = call i32 @f35014(i32 3)
+                ret i32 %1
+            }""", "entry"
+        ), Cint, Tuple{})
     end
     @test ccallable_test() == 4
     end


### PR DESCRIPTION
This PR reworks and simplifies both the implementation and capabilities of `llvmcall`. Most importantly, it removes the ability to call `llvm::Function*` pointers (which was broken anyway since it is or will not be possible to work with Julia's LLVM context directly), and replaces it with the ability to pass an entire `llvm::Module` and the name of its entry point function as literal strings. It's a step towards https://github.com/vtjnash/julep/wiki/0002:-Enhanced-llvmcall, but should already remove most of the global state.

Since passing a module + function name is a superset of the hacky `(decl, ir)` syntax, I decided to remove that too and re-use the 2-element tuple syntax for passing a module and entry-point:

```julia
julia> using Base: llvmcall

julia> g(a,b) = Base.llvmcall(
           ("""define i64 @entry(i64, i64) #0 {
                 top:
                 %sum = add i64 %1, %0
                 ret i64 %sum
               }
               attributes #0 = { alwaysinline }""", "entry"), Int,
           Tuple{Int, Int}, a, b)
g (generic function with 1 method)

julia> @show g(1,2)
g(1, 2) = 3
3

julia> code_llvm(g, Tuple{Int,Int})
```
```llvm
define i64 @julia_g_927(i64, i64) {
top:
  %sum.i.i = add i64 %1, %0
  ret i64 %sum.i.i
}
```

The PR also switches from our own FunctionMover to LLVM's IR linker, which merges equivalent types. Together with https://github.com/JuliaLang/julia/pull/36482 (which removes the opaque `jl_value_t` that couldn't get linked like that), it enables generating IR in e.g. generated functions using a temporary LLVM context and returning that as IR to the JIT. That covers most of the use-cases for GPU compilers.

Building on that, IR is now also parsed into a temporary module, which should reduce the risk of the active module being left in a bad state when parsing invalid IR.

Finally, getting rid of the function pointers should make use of `llvmcall` by LLVM.jl (and thus the GPU compilers) precompilable, which should be a great thing for latency in the future (we haven't been able to precompile any GPU code because of it).

All this is pretty breaking, but `llvmcall` was not exported and deemed experimental.

Fixes https://github.com/JuliaLang/julia/pull/36482, https://github.com/JuliaLang/julia/issues/28121, https://github.com/JuliaLang/julia/issues/23925, https://github.com/JuliaLang/julia/issues/34166

@Keno Is this in any way compatible with Cxx.jl?
