### PR TITLE
Remove some references to build time environment from sysimg

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -101,4 +101,9 @@ let
     empty!(LOAD_PATH)
     empty!(DEPOT_PATH)
 end
+
+@eval Sys begin
+    BINDIR = ""
+    STDLIB = ""
+end
 end

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -114,6 +114,12 @@ function __init__()
     global SC_CLK_TCK = ccall(:jl_SC_CLK_TCK, Clong, ())
     global CPU_NAME = ccall(:jl_get_cpu_name, Ref{String}, ())
     global JIT = ccall(:jl_get_JIT, Ref{String}, ())
+    __init_build()
+    nothing
+end
+# Populate the paths needed by sysimg compilation, e.g. `generate_precompile.jl`,
+# without pulling in anything unnecessary like `CPU_NAME`
+function __init_build()
     global BINDIR = ccall(:jl_get_julia_bindir, Any, ())::String
     vers = "v$(VERSION.major).$(VERSION.minor)"
     global STDLIB = abspath(BINDIR, "..", "share", "julia", "stdlib", vers)

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 if isempty(ARGS) || ARGS[1] !== "0"
+Sys.__init_build()
 # Prevent this from being put into the Main namespace
 @eval Module() begin
 if !isdefined(Base, :uv_eventloop)
@@ -209,6 +210,16 @@ function generate_precompile_statements()
 end
 
 generate_precompile_statements()
+
+# As a last step in system image generation,
+# remove some references to build time environment for a more reproducible build.
+@eval Base PROGRAM_FILE = ""
+@eval Sys begin
+    BINDIR = ""
+    STDLIB = ""
+end
+empty!(Base.ARGS)
+empty!(Core.ARGS)
 
 end # @eval
 end


### PR DESCRIPTION
All of these are always re-populated at load time and
does not need to be in sysimg.

Similar to #36536.

I'm also carrying more patches to remove all build time path in the binary for a more reprodicuble build as well as being much more friendly to gdb by default similar to the `-f*-prefix-map` GCC options. Those patches are much dirtier currently though....
