### PR TITLE
fix #36527, skipped marking of some items in excstack

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2230,6 +2230,7 @@ excstack: {
                         goto mark;
                     }
                 }
+                jlval_index = 0;
             }
             // The exception comes last - mark it
             new_obj = jl_excstack_exception(excstack, itr);

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -367,3 +367,19 @@ end
         exc
     end == ErrorException("rethrow(exc) not allowed outside a catch block")
 end
+
+# issue #36527
+function f36527()
+    caught = false
+    🏡 = Core.eval(Main, :(module asdf36527 end))
+    try
+        Core.eval(🏡, :(include_string($🏡, "@assert z36527 == 10")))
+    catch ex
+        GC.gc()
+        catch_backtrace()
+        caught = true
+    end
+    return caught
+end
+
+@test f36527()


### PR DESCRIPTION
When moving to the next group of julia values in a trace the counter was not reset, so we didn't mark values after the first group.

fix #36527