### PR TITLE
Add option --compile=min to Julia man page.

### DIFF
--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -130,7 +130,7 @@ Enable or disable color text
 Load or save history
 
 .TP
---compile={yes|no|all}
+--compile={yes|no|all|min}
 Enable or disable compiler, or request exhaustive compilation
 
 .TP


### PR DESCRIPTION
Add option `--compile=min` to Julia man page that is present in `julia --help-hidden`.