### PR TITLE
Enable tty, vt sequences on Windows  

### DIFF
--- a/src/support/libsupportinit.c
+++ b/src/support/libsupportinit.c
@@ -12,9 +12,7 @@ static int isInitialized = 0;
 void libsupport_init(void)
 {
     if (!isInitialized) {
-#ifdef _OS_WINDOWS_
-        SetConsoleCP(1252); // ANSI Latin1; Western European (Windows)
-#endif
+
         setlocale(LC_ALL, ""); // set to user locale
         setlocale(LC_NUMERIC, "C"); // use locale-independent numeric formats
 

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1277,7 +1277,7 @@ end
 # not leave the console mode in a corrupt state.
 if Sys.iswindows()
 function _console_mode()
-    hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11) # STD_OUTPUT_HANDLE
+    hOutput = ccall(:GetStdHandle, stdcall, Int32, (Int32,), -11) # STD_OUTPUT_HANDLE
     dwMode = Ref{UInt32}(0)
     ccall(:GetConsoleMode, Int32, (Int32, Ptr{Nothing}), hOutput, dwMode)
     dwMode[]
@@ -1286,8 +1286,8 @@ const default_console_mode = _console_mode()
 function _reset_console_mode()
     mode = _console_mode()
     if mode !== default_console_mode
-        hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11) # STD_OUTPUT_HANDLE
-        ccall(:SetConsoleMode, Int32, (Int32, Int32), hOutput, default_console_mode)
+        hOutput = ccall(:GetStdHandle, stdcall, Int32, (Int32,), -11) # STD_OUTPUT_HANDLE
+        ccall(:SetConsoleMode, stdcall, Int32, (Int32, Int32), hOutput, default_console_mode)
         nothing
     end
 end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1275,10 +1275,10 @@ end
 # On Windows, when launching external processes, we cannot control what assumption they make on the
 # console mode. We thus forcibly reset the console mode at the start of the prompt to ensure they do
 # not leave the console mode in a corrupt state.
-# FIXME: when pseudo-tty are used for child processes
+# FIXME: remove when pseudo-tty are implemented for child processes
 if Sys.iswindows()
 function _console_mode()
-    hOutput = ccall(:GetStdHandle, stdcall, Ptr{Cvoid}, (UInt32,), unsafe_trunc(UInt32,-11)) # STD_OUTPUT_HANDLE
+    hOutput = ccall(:GetStdHandle, stdcall, Ptr{Cvoid}, (UInt32,), -11 % UInt32) # STD_OUTPUT_HANDLE
     dwMode = Ref{UInt32}()
     ccall(:GetConsoleMode, stdcall, Int32, (Ref{Cvoid}, Ref{UInt32}), hOutput, dwMode)
     return dwMode[]
@@ -1295,7 +1295,7 @@ end
 function _reset_console_mode()
     mode = _console_mode()
     if mode !== get_default_console_mode()
-        hOutput = ccall(:GetStdHandle, stdcall, Ptr{Cvoid}, (UInt32,), unsafe_trunc(UInt32,-11)) # STD_OUTPUT_HANDLE
+        hOutput = ccall(:GetStdHandle, stdcall, Ptr{Cvoid}, (UInt32,), -11 % UInt32) # STD_OUTPUT_HANDLE
         ccall(:SetConsoleMode, stdcall, Int32, (Ptr{Cvoid}, UInt32), hOutput, default_console_mode_ref[])
     end
     nothing

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1284,11 +1284,10 @@ function _console_mode()
 end
 const default_console_mode = _console_mode()
 function _reset_console_mode()
-    if _console_mode() !== default_console_mode
-        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x004
-        newMode = default_console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    mode = _console_mode()
+    if mode !== default_console_mode
         hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11)
-        ccall(:SetConsoleMode, Int32, (Int32, Int32), hOutput, newMode)
+        ccall(:SetConsoleMode, Int32, (Int32, Int32), hOutput, default_console_mode)
         nothing
     end
 end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1284,11 +1284,13 @@ function _console_mode()
 end
 const default_console_mode = _console_mode()
 function _reset_console_mode()
-    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x004
-    newMode = default_console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING
-    hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11)
-    ccall(:SetConsoleMode, Int32, (Int32, Int32), hOutput, newMode)
-    nothing
+    if _console_mode() !== default_console_mode
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x004
+        newMode = default_console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11)
+        ccall(:SetConsoleMode, Int32, (Int32, Int32), hOutput, newMode)
+        nothing
+    end
 end
 end
 

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1277,7 +1277,7 @@ end
 # not leave the console mode in a corrupt state.
 if Sys.iswindows()
 function _console_mode()
-    hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11)
+    hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11) # STD_OUTPUT_HANDLE
     dwMode = Ref{UInt32}(0)
     ccall(:GetConsoleMode, Int32, (Int32, Ptr{Nothing}), hOutput, dwMode)
     dwMode[]
@@ -1286,7 +1286,7 @@ const default_console_mode = _console_mode()
 function _reset_console_mode()
     mode = _console_mode()
     if mode !== default_console_mode
-        hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11)
+        hOutput = ccall(:GetStdHandle, Int32, (Int32,), -11) # STD_OUTPUT_HANDLE
         ccall(:SetConsoleMode, Int32, (Int32, Int32), hOutput, default_console_mode)
         nothing
     end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1279,7 +1279,7 @@ if Sys.iswindows()
 function _console_mode()
     hOutput = ccall(:GetStdHandle, stdcall, Int32, (Int32,), -11) # STD_OUTPUT_HANDLE
     dwMode = Ref{UInt32}(0)
-    ccall(:GetConsoleMode, Int32, (Int32, Ptr{Nothing}), hOutput, dwMode)
+    ccall(:GetConsoleMode, stdcall, Int32, (Int32, Ptr{Nothing}), hOutput, dwMode)
     dwMode[]
 end
 const default_console_mode = _console_mode()


### PR DESCRIPTION
Enable tty, vt sequences on Windows.

Ultimately, we can't control what external processes assume on the console mode when launched within Julia. With the shared console mode that Julia utilizes, this is problematic and the terminal can be left in a corrupted state. As a result, it's safest to *reset the mode* before each prompt to ensure we enter back into the original console state.
In particular, this fixes problems like that in https://github.com/JuliaLang/julia/issues/26894#issuecomment-383901827.

Currently Julia has disabled vt support, as this can  help enhance compatibility. Note, however, we can  corrupt the terminal state even under the current status quo, which uniformly disables  vt support, and this can be demonstrated through examples. Disabling tty support, has been an annoyance on Windows and has lead to a lot of comments on how the Windows Julia terminal experience is crippled and that this is unfixable since Microsoft has not improved the terminal experience, leading to discussion on other terminal emulators such as mintty. In fact, I think  we can support a quality terminal experience on Windows if we carefully enable features that support an improved REPL experience.

This PR in tandem with https://github.com/JuliaLang/libuv/pull/11  enables tty support on Windows. 


Here's an example of Julia with these patches using the Windows Terminal:
![image](https://user-images.githubusercontent.com/4319522/87067723-70f38a80-c1e2-11ea-8597-10e27ee7e982.png)


For those that want to try out this PR built with the updated libuv fork that enables tty support on Windows, here's a x86-64 windows installer you can play around with: https://1drv.ms/u/s!AvuMkGVjog3NuaQswzrzMyFP8XlVNw?e=qbv749

 


closes https://github.com/JuliaLang/julia/issues/31491