### PR TITLE
Documentation changes for option "--compile=min".

### DIFF
--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -130,8 +130,8 @@ Enable or disable color text
 Load or save history
 
 .TP
---compile={yes|no|all}
-Enable or disable compiler, or request exhaustive compilation
+--compile={yes|no|all|min}
+Enable or disable compiler, or request exhaustive or minimal compilation
 
 .TP
 -C, --cpu-target=<target>

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -149,7 +149,7 @@ static const char opts[]  =
 
 static const char opts_hidden[]  =
     // code generation options
-    " --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation\n"
+    " --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive or minimal compilation\n"
 
     // compiler output options
     " --output-o name           Generate an object file (including system image data)\n"


### PR DESCRIPTION
Add option "--compile=min" to Julia man page and add "minimal" to description of option "--compile=min" in Julia hidden options.