### PR TITLE
Improve exception stack printing

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -872,7 +872,7 @@ function show_exception_stack(io::IO, stack::Vector)
     nexc = length(stack)
     for i = nexc:-1:1
         if nexc != i
-            printstyled(io, "caused by [exception ", i, "]\n", color=:light_black)
+            printstyled(io, "\ncaused by:\n", color=error_color())
         end
         exc, bt = stack[i]
         showerror(io, exc, bt, backtrace = bt!==nothing)

--- a/test/client.jl
+++ b/test/client.jl
@@ -11,7 +11,8 @@ end
 nested_error_pattern = r"""
     ERROR: DivideError: integer division error
     Stacktrace:.*
-    caused by \[exception 1\]
+
+    caused by:
     UndefVarError: __not_a_binding__ not defined
     Stacktrace:.*
     """s


### PR DESCRIPTION
The expanded stacktrace printing introduced in #36134 and the fact that
we no longer print errors in red (#36015) makes it harder to distinguish
distinct exceptions in the stack.

Add a newline for this, and print the "caused by" in dark red. Also remove
exception numbering, which was arguably not very helpful.

Arguably this (along with previous changes over time) fixes #31257.

Before:
![before](https://user-images.githubusercontent.com/601473/87148750-4f81c400-c2f2-11ea-8919-290780479b06.png)

After:
![after](https://user-images.githubusercontent.com/601473/87149213-2dd50c80-c2f3-11ea-8645-efe67ea58932.png)
