### PR TITLE
refine method overwrite warning

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -521,10 +521,10 @@ void jl_compute_field_offsets(jl_datatype_t *st)
 
 static int is_anonfn_typename(char *name)
 {
-    if (name[0] != '#')
+    if (name[0] != '#' || name[1] == '#')
         return 0;
     char *other = strrchr(name, '#');
-    return (name[1] != '#' && other > &name[1] && is10digit(other[1]));
+    return other > &name[1] && is10digit(other[1]);
 }
 
 JL_DLLEXPORT jl_datatype_t *jl_new_datatype(

--- a/src/dump.c
+++ b/src/dump.c
@@ -2341,8 +2341,7 @@ static void jl_recache_types(void) JL_GC_DISABLED
     }
 }
 
-// repeatedly look up older methods until we come to one that existed
-// at the time this module was serialized (e.g. ignoring deletion)
+// look up a method from a previously deserialized dependent module
 static jl_method_t *jl_lookup_method(jl_methtable_t *mt, jl_datatype_t *sig, size_t world)
 {
     if (world < jl_main_module->primary_world)

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -60,7 +60,7 @@ RELBUILDROOT := $(call rel_path,$(JULIAHOME)/base,$(BUILDROOT)/base)/ # <-- make
 $(build_private_libdir)/corecompiler.ji: $(COMPILER_SRCS)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) -C "$(JULIA_CPU_TARGET)" --output-ji $(call cygpath_w,$@).tmp \
-		--startup-file=no -g0 -O0 compiler/compiler.jl)
+		--startup-file=no --warn-overwrite=yes -g0 -O0 compiler/compiler.jl)
 	@mv $@.tmp $@
 
 $(build_private_libdir)/sys.ji: $(build_private_libdir)/corecompiler.ji $(JULIAHOME)/VERSION $(BASE_SRCS) $(STDLIB_SRCS)


### PR DESCRIPTION
Always show the warning for anonymous functions, but update the verbiage
to give additional information. This warning can still be avoided by
explicitly calling delete_method first.

fixes #32635
fixes #35140
refs #15602