### PR TITLE
fix #36492, ensure output is limited even with basic REPLs

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -205,11 +205,11 @@ end
 
 function display(d::REPLDisplay, mime::MIME"text/plain", x)
     with_methodtable_hint(d.repl) do io
+        io = IOContext(io, :limit => true, :module => Main)
         get(io, :color, false) && write(io, answer_color(d.repl))
         if isdefined(d.repl, :options) && isdefined(d.repl.options, :iocontext)
             # this can override the :limit property set initially
-            io = foldl(IOContext, d.repl.options.iocontext,
-                       init=IOContext(io, :limit => true, :module => Main))
+            io = foldl(IOContext, d.repl.options.iocontext, init=io)
         end
         show(io, mime, x)
         println(io)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -888,6 +888,13 @@ let term = REPL.Terminals.TTYTerminal("dumb",IOBuffer("1+2\n"),IOContext(IOBuffe
     @test_throws KeyError term[:bar]
 end
 
+# Ensure even the dumb REPL elides content
+let term = REPL.Terminals.TTYTerminal("dumb",IOBuffer("zeros(1000)\n"),IOBuffer(),IOBuffer())
+    r = REPL.BasicREPL(term)
+    REPL.run_repl(r)
+    @test contains(String(take!(term.out_stream)), "⋮")
+end
+
 
 # a small module for alternative keymap tests
 module AltLE


### PR DESCRIPTION
This is simple enough; just unconditionally use an IOContext with `:limit=>true` and then allow the fancier REPLs to further customize.