### PR TITLE
Sharper field type for `NamedTuple`s with types in fields

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -132,7 +132,7 @@ function show(io::IO, t::NamedTuple)
     n = nfields(t)
     for i = 1:n
         # if field types aren't concrete, show full type
-        if typeof(getfield(t, i)) !== fieldtype(typeof(t), i)
+        if Core.safe_Typeof(getfield(t, i)) !== fieldtype(typeof(t), i)
             show(io, typeof(t))
             print(io, "(")
             show(io, Tuple(t))

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -302,3 +302,11 @@ let x = 1, y = 2
     @test Meta.lower(Main, Meta.parse("(; a.y, y)")) == Expr(:error, "field name \"y\" repeated in named tuple")
     @test (; a.y, x) === (y=2, x=1)
 end
+
+@testset "types in fields" begin
+    @test (a = Int,) isa NamedTuple{(:a,),Tuple{Type{Int}}}
+    @test (a = Int, b = :hello, c = Float64) isa
+          NamedTuple{(:a, :b, :c),Tuple{Type{Int},Symbol,Type{Float64}}}
+    @test (a = (Int,),) isa NamedTuple{(:a,),Tuple{Tuple{DataType}}}  # FIXME
+    @test (a = Vector.body,) isa NamedTuple{(:a,),Tuple{DataType}}
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1994,3 +1994,10 @@ end
     @test contains(string(methods(foo)), "foo(α)")
     @test contains(string(methods(bar)), "bar(ℓ)")
 end
+
+@testset "NamedTuple with types (#36614)" begin
+    @test showstr((a = Symbol,)) == "(a = Symbol,)"
+    @test showstr((a = Symbol, b = 1, c = String)) == "(a = Symbol, b = 1, c = String)"
+    @test showstr((a = Vector.body,)) == "(a = Array{T,1},)"
+    @test showstr((a = (Symbol,),)) == "(a = (Symbol,),)"
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2000,4 +2000,8 @@ end
     @test showstr((a = Symbol, b = 1, c = String)) == "(a = Symbol, b = 1, c = String)"
     @test showstr((a = Vector.body,)) == "(a = Array{T,1},)"
     @test showstr((a = (Symbol,),)) == "(a = (Symbol,),)"
+    @test showstr(NamedTuple{(:a,),Tuple{DataType}}((Symbol,))) ==
+          "NamedTuple{(:a,),Tuple{DataType}}((Symbol,))"
+    @test showstr(NamedTuple{(:a, :b),Tuple{Type{Symbol},DataType}}((Symbol, Symbol))) ==
+          "NamedTuple{(:a, :b),Tuple{Type{Symbol},DataType}}((Symbol, Symbol))"
 end


### PR DESCRIPTION
This PR tweaks the `NamedTuple{names}` constructor so that `namedtuple.field` is inferable when `field` is a type.

Before

```julia
julia> typeof((a=Int,))
NamedTuple{(:a,),Tuple{DataType}}
```

After

```julia
julia> typeof((a=Int,))
NamedTuple{(:a,),Tuple{Type{Int64}}}
```
