### PR TITLE
Commute union splitting and MethodTable identification

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2707,3 +2707,12 @@ f32699(a) = (id = a[1],).id
 g32699(a) = Tuple{a}
 @test Base.return_types(g32699, (Type{<:Integer},))[1] == Type{<:Tuple{Any}}
 @test Base.return_types(g32699, (Type,))[1] == Type{<:Tuple}
+
+# Inference precision of union-split calls
+function f_apply_union_split(fs, x)
+    i = rand(1:length(fs))
+    f = fs[i]
+    f(x)
+end
+
+@test Base.return_types(f_apply_union_split, Tuple{Tuple{typeof(sqrt), typeof(abs)}, Int64}) == Any[Union{Int64, Float64}]


### PR DESCRIPTION
This allows inference of calls where union-splitting the function would
lead to an acceptable answer, e.g. in
```
function randapply(fs, x)
  i = rand(1:length(fs))
  f = fs[i]
  f(x)
end
@code_warntype randapply((sqrt, abs), 3)
```

Previously this only worked if an extra function boundary was introduced,
which would cause union splitting on some non-first argument,
e.g.
```
function randapply2(fs, x)
  xs = map(f -> f(x), fs)
  rand(xs)
end
@code_warntype randapply((sqrt, abs), 3)
```
which currently infers fine.

This patch simply moves the identification of which MethodTable we
looked at into the union splitting logic. This seems to fix the
case of interest, and I don't see any correctness problems.

As requested by @zenna on slack.