### PR TITLE
Darwin/ARM64: Set default mcpu target

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -777,6 +777,11 @@ ifeq ($(ARCH),amd64)
 override ARCH := x86_64
 endif
 
+# We map arm64 (Apple spelling) to aarch64 to avoid having to deal with both spellings everywhere
+ifeq ($(ARCH),arm64)
+override ARCH := aarch64
+endif
+
 ifeq ($(ARCH),i386)
 BINARY:=32
 ISX86:=1
@@ -853,6 +858,10 @@ endif
 ifneq (,$(findstring aarch64,$(ARCH)))
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
+ifeq ($(OS),Darwin)
+# Apple Chips are all at least A12Z
+MCPU:=apple-a12
+endif
 endif
 
 # Set MARCH-specific flags


### PR DESCRIPTION
And unconditionally require the CRC32 extension on this platform.
All current and future chips should have it.