### PR TITLE
Darwin/ARM64: Fix throwing of synchronous memory exceptions

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -842,3 +842,15 @@ end
 @testset "fieldtypes Module" begin
     @test fieldtypes(Module) isa Tuple
 end
+
+# Test that read fault on a prot-none region does not incorrectly give
+# ReadOnlyMemoryEror, but rather crashes the program
+const MAP_ANONYMOUS_PRIVATE = Sys.isbsd() ? 0x1002 : 0x22
+let script = :(let ptr = Ptr{Cint}(ccall(:jl_mmap, Ptr{Cvoid},
+    (Ptr{Cvoid}, Csize_t, Cint, Cint, Cint, Int),
+    C_NULL, 16*1024, 0, $MAP_ANONYMOUS_PRIVATE, -1, 0)); try
+    unsafe_load(ptr)
+    catch e; println(e) end; end)
+    @test !success(`$(Base.julia_cmd()) -e $script`)
+end
+


### PR DESCRIPTION
Needs decoding of the ARM64 ESR register. Additionally, the Aarch64 ABI requires 16 byte aligned stack
pointers on function entry, so we can't push the return pointer there. Whether we need to construct a
stack frame instead will depend on the unwinder (which doesn't work yet), but I don't believe so,
since the ABI mandates a frame pointer.