### PR TITLE
added specialized implementation of `string(::Symbol)`

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -173,6 +173,8 @@ julia> string("a", 1, true)
 """
 string(xs...) = print_to_string(xs...)
 
+string(s::Symbol) = unsafe_string(unsafe_convert(Ptr{UInt8}, s))
+
 # note: print uses an encoding determined by `io` (defaults to UTF-8), whereas
 #       write uses an encoding determined by `s` (UTF-8 for `String`)
 print(io::IO, s::AbstractString) = for c in s; print(io, c); end

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -173,7 +173,7 @@ julia> string("a", 1, true)
 """
 string(xs...) = print_to_string(xs...)
 
-string(s::Symbol) = unsafe_string(unsafe_convert(Ptr{UInt8}, s))
+string(a::Symbol) = String(a)
 
 # note: print uses an encoding determined by `io` (defaults to UTF-8), whereas
 #       write uses an encoding determined by `s` (UTF-8 for `String`)


### PR DESCRIPTION
We can see the following performance improvement, when converting `Symbol` to `String`:

```
julia> @btime ssstring(:abs);
  20.785 ns (1 allocation: 32 bytes)
julia> @btime string(:abs);
  62.264 ns (3 allocations: 160 bytes)

julia> a = Symbol(String(rand(UInt8('a'):UInt8('z'), 100)));
julia> @btime string(a);
  196.648 ns (4 allocations: 288 bytes)
julia> @btime ssstring(a);
  26.303 ns (1 allocation: 128 bytes)
```