### PR TITLE
more DEPOT_PATH docs

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -71,7 +71,7 @@ environment variable if set.
 ## DEPOT_PATH contents
 
 Each entry in `DEPOT_PATH` is a path to a directory which contains subdirectories used by Julia for various purposes.
-of whats typically found there:
+Here is an overview of some of the subdirectories that may exist in a depot:
 
 * `clones`: Contains full clones of package repos. Maintained by `Pkg.jl` and used as a cache.
 * `compiled`: Contains precompiled `*.ji` files for packages. Maintained by Julia.

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -70,7 +70,7 @@ environment variable if set.
 
 ## DEPOT_PATH contents
 
-The directory in `DEPOT_PATH` contains a set of subdirectories, used for different purposes. Here is an overview
+Each entry in `DEPOT_PATH` is a path to a directory which contains subdirectories used by Julia for various purposes.
 of whats typically found there:
 
 * `clones`: Contains full clones of package repos. Maintained by `Pkg.jl` and used as a cache.

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -74,16 +74,12 @@ The directory in `DEPOT_PATH` contains a set of subdirectories, used for differe
 of whats typically found there:
 
 * `clones`: Contains full clones of package repos. Maintained by `Pkg.jl` and used as a cache.
-* `compiled`: Contains precompiled `*.ji` files for packages. Maintained by `Pkg.jl`.
+* `compiled`: Contains precompiled `*.ji` files for packages. Maintained by Julia.
 * `dev`: Default directory for `Pkg.develop`. Maintained by `Pkg.jl` and the user.
-* `environments`: Default package environments. For instance the global environment for a specific julia version. Maintained by `Pkg.jl`
-* `logs`: Contains logs of `Pkg` and `REPL` operations. Maintained by `Pkg.jl` and `Julia`. CHECK WHO ELSE LOGS HERE?
-* `packages`: Contains packages, some of which were explicitly installed and some which are implicit dependencies. Maintained by `Pkg.jl`
-* `registries`: Contains package registries. By default only `General`. Maintained by `Pkg.jl`
-
-Certain packages, also create and populate other subdirectories. For instance:
-* `conda`: Maintained by `Conda.jl`
-* `prefs`: Maintained by `IJulia.jl`
+* `environments`: Default package environments. For instance the global environment for a specific julia version. Maintained by `Pkg.jl`.
+* `logs`: Contains logs of `Pkg` and `REPL` operations. Maintained by `Pkg.jl` and `Julia`.
+* `packages`: Contains packages, some of which were explicitly installed and some which are implicit dependencies. Maintained by `Pkg.jl`.
+* `registries`: Contains package registries. By default only `General`. Maintained by `Pkg.jl`.
 
 See also:
 [`JULIA_DEPOT_PATH`](@ref JULIA_DEPOT_PATH), and

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -68,6 +68,23 @@ registries, packages, etc. installed and managed by system administrators.
 `DEPOT_PATH` is populated based on the [`JULIA_DEPOT_PATH`](@ref JULIA_DEPOT_PATH)
 environment variable if set.
 
+## DEPOT_PATH contents
+
+The directory in `DEPOT_PATH` contains a set of subdirectories, used for different purposes. Here is an overview
+of whats typically found there:
+
+* `clones`: Contains full clones of package repos. Maintained by `Pkg.jl` and used as a cache.
+* `compiled`: Contains precompiled `*.ji` files for packages. Maintained by `Pkg.jl`.
+* `dev`: Default directory for `Pkg.develop`. Maintained by `Pkg.jl` and the user.
+* `environments`: Default package environments. For instance the global environment for a specific julia version. Maintained by `Pkg.jl`
+* `logs`: Contains logs of `Pkg` and `REPL` operations. Maintained by `Pkg.jl` and `Julia`. CHECK WHO ELSE LOGS HERE?
+* `packages`: Contains packages, some of which were explicitly installed and some which are implicit dependencies. Maintained by `Pkg.jl`
+* `registries`: Contains package registries. By default only `General`. Maintained by `Pkg.jl`
+
+Certain packages, also create and populate other subdirectories. For instance:
+* `conda`: Maintained by `Conda.jl`
+* `prefs`: Maintained by `IJulia.jl`
+
 See also:
 [`JULIA_DEPOT_PATH`](@ref JULIA_DEPOT_PATH), and
 [Code Loading](@ref Code-Loading).


### PR DESCRIPTION
From https://discourse.julialang.org/t/high-view-description-of-the-folders-in-julia/20506/2
I need a little guidance here. I feel like the `DEPOT_PATH` docstring is not the ideal place to explain this. Any better location where this info could live?
