### PR TITLE
Pass force=true option to rename in case of loading failure in compilecache

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -890,12 +890,11 @@ function unlink(p::AbstractString)
 end
 
 # For move command
-function rename(src::AbstractString, dst::AbstractString)
+function rename(src::AbstractString, dst::AbstractString; force::Bool=false)
     err = ccall(:jl_fs_rename, Int32, (Cstring, Cstring), src, dst)
     # on error, default to cp && rm
     if err < 0
-        # force: is already done in the mv function
-        cp(src, dst; force=false, follow_symlinks=false)
+        cp(src, dst; force=force, follow_symlinks=false)
         rm(src; recursive=true)
     end
     nothing

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1338,7 +1338,7 @@ function compilecache(pkg::PkgId, path::String)
             chmod(tmppath, filemode(path) & 0o777)
 
             # this is atomic according to POSIX:
-            rename(tmppath, cachefile)
+            rename(tmppath, cachefile; force=true)
             return cachefile
         end
     finally


### PR DESCRIPTION
This fixes https://github.com/JuliaLang/julia/issues/36621 for me

What's happening is that the rename via `jl_fs_rename` fails and then we have a `cp` failure since `force=true` is not passed. 


