### PR TITLE
restrict last(v::AbstractArray, n::Integer) to AbstractVector

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -410,7 +410,7 @@ Float64[]
 """
 last(itr, n::Integer) = reverse!(collect(Iterators.take(Iterators.reverse(itr), n)))
 # Faster method for arrays
-function last(v::AbstractArray, n::Integer)
+function last(v::AbstractVector, n::Integer)
     n < 0 && throw(ArgumentError("Number of elements must be nonnegative"))
     @inbounds v[max(begin, end - n + 1):end]
 end


### PR DESCRIPTION
As explained in my comment in #34868, we should be consistent here.

… in general, this optimization only seems to make sense for arrays with linear indexing, but it's easiest to just use AbstractVector here and rely on the `Iterators.reverse` fallback for other cases.

cc @giordano 