### PR TITLE
fix isapprox on ranges with equal step

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1628,7 +1628,20 @@ promote_leaf_eltypes(x::Union{AbstractArray,Tuple}) = mapreduce(promote_leaf_elt
 # isapprox: approximate equality of arrays [like isapprox(Number,Number)]
 # Supports nested arrays; e.g., for `a = [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]]`
 # `a ≈ a` is `true`.
-function isapprox(x::AbstractArray, y::AbstractArray;
+function isapprox(x::AbstractArray, y::AbstractArray; kw...)
+    isapprox_generic_arrays(x,y;kw...)
+end
+function isapprox(x::AbstractRange, y::AbstractRange; kw...)
+    # x - y can throw an error, if their step is equal
+    # but generic version computes norm(x-y)
+    if step(x) == step(y)
+        isapprox(collect(x), y; kw...)
+    else
+        isapprox_generic_arrays(x,y; kw...)
+    end
+end
+
+function isapprox_generic_arrays(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -486,4 +486,14 @@ end
     @test condskeel(A) ≈ condskeel(A, [8,8,8])
 end
 
+@testset "isapprox on ranges" begin
+    @test 1:10 ≈ 1:10
+    @test 1:10 ≈ Float64.(1:10)
+    @test 1:10 ≈ (1:10) .+ sqrt(eps(Float64))
+    @test !(1:10 ≈ 2:11)
+    @test 1:0 ≈ 2:1
+    @test 1:10 ≈ collect(1:10)
+    @test collect(1:10) ≈ 1:10
+end
+
 end # module TestGeneric


### PR DESCRIPTION
This fixes the following  corner case:
```julia
julia> isapprox(1:3, 1:3)
ERROR: ArgumentError: step cannot be zero
Stacktrace:
 [1] steprange_last(::Int64, ::Int64, ::Int64) at ./range.jl:215
 [2] StepRange at ./range.jl:205 [inlined]
 [3] _rangestyle at ./range.jl:118 [inlined]
 [4] _range at ./range.jl:116 [inlined]
 [5] #range#43 at ./range.jl:91 [inlined]
 [6] -(::UnitRange{Int64}, ::UnitRange{Int64}) at ./range.jl:1059
 [7] isapprox(::UnitRange{Int64}, ::UnitRange{Int64}; atol::Int64, rtol::Int64, nans::Bool, norm::typeof(LinearAlgebra.norm)) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/generic.jl:1635
 [8] isapprox(::UnitRange{Int64}, ::UnitRange{Int64}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/generic.jl:1635
 [9] top-level scope at REPL[1]:1
```