### PR TITLE
Stop transpose(A) \ lu(B)' from overwriting A

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -432,11 +432,11 @@ end
 (/)(adjA::Adjoint{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU}) = adjoint(F.parent \ adjA.parent)
 function (/)(trA::Transpose{<:Any,<:AbstractVector}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, convert(AbstractVector{T}, conj(trA.parent))))
+    return adjoint(ldiv!(F.parent, convert(AbstractVector{T}, conj!(copy(trA.parent)))))
 end
 function (/)(trA::Transpose{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, convert(AbstractMatrix{T}, conj(trA.parent))))
+    return adjoint(ldiv!(F.parent, convert(AbstractMatrix{T}, conj!(copy(trA.parent)))))
 end
 
 function det(F::LU{T}) where T

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -432,11 +432,11 @@ end
 (/)(adjA::Adjoint{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU}) = adjoint(F.parent \ adjA.parent)
 function (/)(trA::Transpose{<:Any,<:AbstractVector}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, conj!(AbstractVector{T}(trA.parent))))
+    return adjoint(ldiv!(F.parent, conj!(copy_oftype(trA.parent, T))))
 end
 function (/)(trA::Transpose{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, conj!(AbstractMatrix{T}(trA.parent))))
+    return adjoint(ldiv!(F.parent, conj!(copy_oftype(trA.parent, T))))
 end
 
 function det(F::LU{T}) where T

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -432,11 +432,11 @@ end
 (/)(adjA::Adjoint{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU}) = adjoint(F.parent \ adjA.parent)
 function (/)(trA::Transpose{<:Any,<:AbstractVector}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, convert(AbstractVector{T}, conj!(copy(trA.parent)))))
+    return adjoint(ldiv!(F.parent, conj!(AbstractVector{T}(trA.parent))))
 end
 function (/)(trA::Transpose{<:Any,<:AbstractMatrix}, F::Adjoint{<:Any,<:LU})
     T = promote_type(eltype(trA), eltype(F))
-    return adjoint(ldiv!(F.parent, convert(AbstractMatrix{T}, conj!(copy(trA.parent)))))
+    return adjoint(ldiv!(F.parent, conj!(AbstractMatrix{T}(trA.parent))))
 end
 
 function det(F::LU{T}) where T

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -360,4 +360,17 @@ end
     end
 end
 
+@testset "transpose(A) / lu(B)' should not overwrite A (#36657)" begin
+    for elty in (Float16, Float64, ComplexF64)
+        A = randn(elty, 5, 5)
+        B = randn(elty, 5, 5)
+        C = copy(A)
+        a = randn(elty, 5)
+        c = copy(a)
+        @test transpose(A) / lu(B)' ≈ transpose(A) / B
+        @test transpose(a) / lu(B)' ≈ transpose(a) / B        
+        @test A == C
+        @test a == c
+    end
+end
 end # module TestLU

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -367,8 +367,8 @@ end
         C = copy(A)
         a = randn(elty, 5)
         c = copy(a)
-        @test transpose(A) / lu(B)' ≈ transpose(A) / B
-        @test transpose(a) / lu(B)' ≈ transpose(a) / B        
+        @test transpose(A) / lu(B)' ≈ transpose(A) / B'
+        @test transpose(a) / lu(B)' ≈ transpose(a) / B'
         @test A == C
         @test a == c
     end


### PR DESCRIPTION
This fixes the following bug I just found:
```julia
julia> A = randn(5,5)
5×5 Array{Float64,2}:
  0.485776   1.29655    0.0790172   0.66021   -1.49472
  0.971676  -1.01382    0.630476    0.479027  -0.843428
 -0.264609   0.392383   0.646729    0.510696   0.34913
 -0.795944  -2.47709   -1.81052    -1.0947    -0.30381
 -0.938873   2.16395   -1.33484    -0.745461   1.43709

julia> transpose(A) / lu(randn(5,5))' # should not change A
5×5 Adjoint{Float64,Array{Float64,2}}:
  14.36      11.9797   -7.32563    1.87016   -16.2731
 -18.4415   -13.7036   10.6455    -2.47396    19.9999
   8.0401     8.31723  -5.16714    2.13261    -9.637
   4.19849    3.9865   -1.98478    0.714778   -4.62445
  -5.36059   -2.60991   0.917052   0.290281    4.62547

julia> A # but does!
5×5 Array{Float64,2}:
  14.36     -18.4415    8.0401    4.19849   -5.36059
  11.9797   -13.7036    8.31723   3.9865    -2.60991
  -7.32563   10.6455   -5.16714  -1.98478    0.917052
   1.87016   -2.47396   2.13261   0.714778   0.290281
 -16.2731    19.9999   -9.637    -4.62445    4.62547
```
