### PR TITLE
lower header level to make the content be rendered as one chapter

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -199,7 +199,7 @@ section of the standard library reference.
 | [`sprandn(m,n,d)`](@ref)   | [`randn(m,n)`](@ref)   | Creates a *m*-by-*n* random matrix (of density *d*) with iid non-zero elements distributed according to the standard normal (Gaussian) distribution.                  |
 | [`sprandn(rng,m,n,d)`](@ref) | [`randn(rng,m,n)`](@ref) | Creates a *m*-by-*n* random matrix (of density *d*) with iid non-zero elements generated with the `rng` random number generator                                   |
 
-# [Sparse Arrays](@id stdlib-sparse-arrays)
+## [Sparse Arrays](@id stdlib-sparse-arrays)
 
 ```@docs
 SparseArrays.AbstractSparseArray


### PR DESCRIPTION
Is it OK if we lower the level of the last header so that this document will be rendered as one chapter in the PDF version rather than two separate chapters?