### PR TITLE
Make `with_output_color` respect `have_color`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -69,7 +69,7 @@ text_colors
 
 function with_output_color(@nospecialize(f::Function), color::Union{Int, Symbol}, io::IO, args...; bold::Bool = false)
     buf = IOBuffer()
-    iscolor = get(io, :color, false)::Bool
+    iscolor = get_have_color()
     try f(IOContext(buf, io), args...)
     finally
         str = String(take!(buf))


### PR DESCRIPTION
Since v1.6 has to be the most colourful release yet, I thought it would be nice to have logging use colours in CI, which is currently never the case in GitHub Actions for example.

I'm not sure this is the right way to check whether the function should use colours since it ignores the stream, but I believe `iscolor` should be `true` when `--color=yes` is passed.  I figured I'd open a questionable PR to get the right answer :slightly_smiling_face: 