### PR TITLE
digits docstring no need to allocate

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -737,7 +737,7 @@ bitstring(x::Union{Int128,UInt128})            = string(reinterpret(UInt128,x), 
 
 Return an array with element type `T` (default `Int`) of the digits of `n` in the given
 base, optionally padded with zeros to a specified size. More significant digits are at
-higher indices, such that `n == sum([digits[k]*base^(k-1) for k=1:length(digits)])`.
+higher indices, such that `n == sum(digits[k]*base^(k-1) for k=1:length(digits))`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
`sum` works without allocating => this speeds up the computation.
I'm not sure whether I should run Documenter locally or whether this is done via Travis/GitHub Actions