### PR TITLE
Fix segfault on throwing during startup

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -470,6 +470,9 @@ void JL_NORETURN throw_internal(jl_value_t *exception JL_MAYBE_UNROOTED)
     ptls->io_wait = 0;
     if (ptls->safe_restore)
         jl_longjmp(*ptls->safe_restore, 1);
+    // During startup
+    if (!ptls->current_task)
+        jl_no_exc_handler(exception);
     JL_GC_PUSH1(&exception);
     jl_gc_unsafe_enter(ptls);
     if (exception) {


### PR DESCRIPTION
This happens, for example, for invalid CPU name.

Fixes #34063