### PR TITLE
allow redirecting standard streams to `IOContext`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@ New library functions
 New library features
 --------------------
 
+* The `redirect_*` functions can now be called on `IOContext` objects.
 
 Standard library changes
 ------------------------

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1166,6 +1166,12 @@ for (x, writable, unix_fd, c_symbol) in
             $x = devnull
             return devnull
         end
+        function ($f)(io::IOContext)
+            io2, _dict = unwrapcontext(io)
+            ($f)(io2)
+            global $x = io
+            return io
+        end
     end
 end
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -252,6 +252,11 @@ end
         @test "Hello World\n" == read(fname, String)
         @test OLD_STDOUT === stdout
         rm(fname)
+
+        col = get(stdout, :color, false)
+        redirect_stdout(IOContext(stdout, :color=>!col))
+        @test get(stdout, :color, col) == !col
+        redirect_stdout(OLD_STDOUT)
     end
 end
 


### PR DESCRIPTION
This will be helpful for #36671, allowing a non-TTY stdout to be set to `:color=>true`.