### PR TITLE
Add a dash in the Windows installer path between the version number

### DIFF
--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -2,7 +2,7 @@
 #define AppNameLong AppName + " " + AppVersion
 #define AppMainExeName "bin\julia.exe"
 #define CurrentYear GetDateTimeString('yyyy', '', '')
-#define DirName AppName + " " + AppVersion
+#define DirName AppName + "-" + AppVersion
 
 
 [LangOptions]
@@ -110,7 +110,6 @@ Root: HKA; Subkey: "{code:GetEnvironmentKey}"; ValueType: expandsz; ValueName: "
 [Code]
 
 procedure InitializeWizard;
-
 begin
   WizardForm.Bevel.Visible := False;
   WizardForm.Bevel1.Visible := False;


### PR DESCRIPTION
Close https://github.com/JuliaLang/julia/issues/35720

It seems like the space is causing some people issues with 'non-standard' escaping that might be tricky in some configurations.