### PR TITLE
fix `hasfield` for unionall-wrapped DataTypes

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -668,7 +668,7 @@ function fieldindex(T::DataType, name::Symbol, err::Bool=true)
     return Int(ccall(:jl_field_index, Cint, (Any, Any, Cint), T, name, err)+1)
 end
 
-fieldindex(t::UnionAll, name::Symbol, err::Bool=true) = fieldindex(unwrap_unionall(t), name, err)
+fieldindex(t::UnionAll, name::Symbol, err::Bool=true) = fieldindex(something(argument_datatype(t)), name, err)
 
 argument_datatype(@nospecialize t) = ccall(:jl_argument_datatype, Any, (Any,), t)
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -668,6 +668,8 @@ function fieldindex(T::DataType, name::Symbol, err::Bool=true)
     return Int(ccall(:jl_field_index, Cint, (Any, Any, Cint), T, name, err)+1)
 end
 
+fieldindex(t::UnionAll, name::Symbol, err::Bool=true) = fieldindex(unwrap_unionall(t), name, err)
+
 argument_datatype(@nospecialize t) = ccall(:jl_argument_datatype, Any, (Any,), t)
 
 """

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -225,6 +225,8 @@ tlayout = TLayout(5,7,11)
 @test fieldnames(TLayout) == (:x, :y, :z) == Base.propertynames(tlayout)
 @test hasfield(TLayout, :y)
 @test !hasfield(TLayout, :a)
+@test hasfield(Complex, :re)
+@test !hasfield(Complex, :qxq)
 @test hasproperty(tlayout, :x)
 @test !hasproperty(tlayout, :p)
 @test [(fieldoffset(TLayout,i), fieldname(TLayout,i), fieldtype(TLayout,i)) for i = 1:fieldcount(TLayout)] ==


### PR DESCRIPTION
Other similar functions like fieldname and fieldnames work, so this should too.