### PR TITLE
add length function to Enum

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -115,6 +115,13 @@ To list all the instances of an enum use `instances`, e.g.
 julia> instances(Fruit)
 (apple, orange, kiwi)
 ```
+
+To get the number of instances of an enum use `length`, e.g.
+
+```jldoctest fruitenum
+julia> length(Fruit)
+3
+```
 """
 macro enum(T, syms...)
     if isempty(syms)
@@ -193,6 +200,7 @@ macro enum(T, syms...)
         Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)
         let insts = (Any[ $(esc(typename))(v) for v in $values ]...,)
             Base.instances(::Type{$(esc(typename))}) = insts
+            Base.length(::Type{$(esc(typename))}) = length(insts)
         end
     end
     if isa(typename, Symbol)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -46,6 +46,7 @@ using Main.MacroCalls
 @test Bool(orange) == true
 @test_throws InexactError Bool(kiwi)
 @test instances(Fruit) == (apple, orange, kiwi)
+@test length(Fruit) == 3
 
 f(x::Fruit) = "hey, I'm a Fruit"
 @test f(apple) == "hey, I'm a Fruit"
@@ -97,6 +98,7 @@ end
 @test Test3.size == 1
 @test UInt8(_one_Test3) === 0x01
 @test length(instances(Test3)) == 3
+@test length(Test3) == 3
 
 @enum Test4::UInt16 _one_Test4=0x01 _two_Test4=0x0002 _three_Test4=0x03
 @test Test4.size == 2


### PR DESCRIPTION
Adds a `length` function that you can call like `length(Fruit)`.

It's equivalent to `length(instances(YourEnum))`.

```
julia> @enum Fruit apple=1 orange=2 kiwi=3
julia> length(Fruit)
3
```

I was motivated by the `len(YourEnum)` from Python. [Example of someone looking for this](https://discourse.julialang.org/t/the-length-of-a-enum-object-in-julia/19865/3)


*Please let me know if I made any mistakes in the documentation/testing*