### PR TITLE
RFC: Give MethodMatch its own type

### DIFF
--- a/base/compiler/bootstrap.jl
+++ b/base/compiler/bootstrap.jl
@@ -23,13 +23,13 @@ let fs = Any[typeinf_ext, typeinf, typeinf_edge, pure_eval_call, run_passes],
     for f in fs
         for m in _methods_by_ftype(Tuple{typeof(f), Vararg{Any}}, 10, typemax(UInt))
             # remove any TypeVars from the intersection
-            typ = Any[m[1].parameters...]
+            typ = Any[m.spec_types.parameters...]
             for i = 1:length(typ)
                 if isa(typ[i], TypeVar)
                     typ[i] = typ[i].ub
                 end
             end
-            typeinf_type(interp, m[3], Tuple{typ...}, m[2])
+            typeinf_type(interp, m.method, Tuple{typ...}, m.sparams)
         end
     end
 end

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -5,7 +5,8 @@ getfield(getfield(Main, :Core), :eval)(getfield(Main, :Core), :(baremodule Compi
 using Core.Intrinsics, Core.IR
 
 import Core: print, println, show, write, unsafe_write, stdout, stderr,
-             _apply, _apply_iterate, svec, apply_type, Builtin, IntrinsicFunction, MethodInstance, CodeInstance
+             _apply, _apply_iterate, svec, apply_type, Builtin, IntrinsicFunction,
+             MethodInstance, CodeInstance, MethodMatch
 
 const getproperty = Core.getfield
 const setproperty! = Core.setfield!

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1080,15 +1080,15 @@ function analyze_single_call!(ir::IRCode, todo::Vector{Any}, idx::Int, @nospecia
             continue
         elseif length(meth) == 1 && only_method !== false
             if only_method === nothing
-                only_method = meth[1][3]
-            elseif only_method !== meth[1][3]
+                only_method = meth[1].method
+            elseif only_method !== meth[1].method
                 only_method = false
             end
         else
             only_method = false
         end
         for match in meth::Vector{Any}
-            (metharg, methsp, method) = (match[1]::Type, match[2]::SimpleVector, match[3]::Method)
+            (metharg, methsp, method) = (match.spec_types, match.sparams, match.method)
             signature_union = Union{signature_union, metharg}
             if !isdispatchtuple(metharg)
                 fully_covered = false
@@ -1119,7 +1119,7 @@ function analyze_single_call!(ir::IRCode, todo::Vector{Any}, idx::Int, @nospecia
                 sig.atype, method.sig)::SimpleVector
         else
             @assert length(meth) == 1
-            (metharg, methsp, method) = (meth[1][1]::Type, meth[1][2]::SimpleVector, meth[1][3]::Method)
+            (metharg, methsp, method) = (meth[1].spec_types, meth[1].sparams, meth[1].method)
         end
         fully_covered = true
         case = analyze_method!(idx, sig, metharg, methsp, method,

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -683,8 +683,8 @@ function _return_type(interp::AbstractInterpreter, @nospecialize(f), @nospeciali
             rt = widenconst(rt)
         end
     else
-        for m in _methods(f, t, -1, get_world_counter(interp))
-            ty = typeinf_type(interp, m[3], m[1], m[2])
+        for match in _methods(f, t, -1, get_world_counter(interp))
+            ty = typeinf_type(interp, match.method, match.spec_types, match.sparams)
             ty === nothing && return Any
             rt = tmerge(rt, ty)
             rt === Any && break

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -128,6 +128,10 @@ function specialize_method(method::Method, @nospecialize(atypes), sparams::Simpl
     return ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), method, atypes, sparams)
 end
 
+function specialize_method(match::MethodMatch, preexisting::Bool=false)
+    return specialize_method(match.method, match.spec_types, match.sparams, preexisting)
+end
+
 # This function is used for computing alternate limit heuristics
 function method_for_inference_heuristics(method::Method, @nospecialize(sig), sparams::SimpleVector)
     if isdefined(method, :generator) && method.generator.expand_early && may_invoke_generator(method, sig, sparams)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -208,3 +208,15 @@ macro get!(h, key0, default)
 end
 
 # END 1.5 deprecations
+
+# BEGIN 1.6 deprecations
+
+# These changed from SimpleVector to `MethodMatch`. These definitions emulate
+# being a SimpleVector to ease transition for packages that make explicit
+# use of (internal) APIs that return raw method matches.
+iterate(match::Core.MethodMatch, field::Int=1) =
+    field > nfields(match) ? nothing : (getfield(match, field), field+1)
+getindex(match::Core.MethodMatch, field::Int) =
+    getfield(match, field)
+
+# END 1.6 deprecations

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1583,6 +1583,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Argument", (jl_value_t*)jl_argument_type);
     add_builtin("Const", (jl_value_t*)jl_const_type);
     add_builtin("PartialStruct", (jl_value_t*)jl_partial_struct_type);
+    add_builtin("MethodMatch", (jl_value_t*)jl_method_match_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);
     add_builtin("Builtin", (jl_value_t*)jl_builtin_type);

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -767,6 +767,7 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.endswith_lower("jl_excstack_t") ||
                    Name.endswith_lower("jl_task_t") ||
                    Name.endswith_lower("jl_uniontype_t") ||
+                   Name.endswith_lower("jl_method_match_t") ||
                    // Probably not technically true for these, but let's allow
                    // it
                    Name.endswith_lower("typemap_intersection_env") ||

--- a/src/dump.c
+++ b/src/dump.c
@@ -976,7 +976,8 @@ static void jl_collect_backedges(jl_array_t *s, jl_array_t *t)
                         }
                         size_t k;
                         for (k = 0; k < jl_array_len(matches); k++) {
-                            jl_array_ptr_set(matches, k, jl_svecref(jl_array_ptr_ref(matches, k), 2));
+                            jl_method_match_t *match = (jl_method_match_t *)jl_array_ptr_ref(matches, k);
+                            jl_array_ptr_set(matches, k, match->method);
                         }
                         jl_array_ptr_1d_push(t, callee);
                         jl_array_ptr_1d_push(t, matches);
@@ -1837,7 +1838,8 @@ static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
         else {
             size_t j, k, l = jl_array_len(expected);
             for (k = 0; k < jl_array_len(matches); k++) {
-                jl_method_t *m = (jl_method_t*)jl_svecref(jl_array_ptr_ref(matches, k), 2);
+                jl_method_match_t *match = jl_array_ptr_ref(matches, k);
+                jl_method_t *m = match->method;
                 for (j = 0; j < l; j++) {
                     if (m == (jl_method_t*)jl_array_ptr_ref(expected, j))
                         break;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1045,8 +1045,8 @@ static jl_method_instance_t *cache_method(
             int unmatched_tvars = 0;
             size_t i, l = jl_array_len(temp);
             for (i = 0; i < l; i++) {
-                jl_value_t *m = jl_array_ptr_ref(temp, i);
-                jl_value_t *env = jl_svecref(m, 1);
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(temp, i);
+                jl_svec_t *env = matc->sparams;
                 int k, l;
                 for (k = 0, l = jl_svec_len(env); k < l; k++) {
                     if (jl_is_typevar(jl_svecref(env, k))) {
@@ -1063,7 +1063,7 @@ static jl_method_instance_t *cache_method(
                     cache_with_orig = 1;
                     break;
                 }
-                if (((jl_method_t*)jl_svecref(m, 2)) != definition) {
+                if (matc->method != definition) {
                     guards++;
                 }
             }
@@ -1076,13 +1076,13 @@ static jl_method_instance_t *cache_method(
             temp3 = (jl_value_t*)guardsigs;
             guards = 0;
             for (i = 0, l = jl_array_len(temp); i < l; i++) {
-                jl_value_t *m = jl_array_ptr_ref(temp, i);
-                jl_method_t *other = (jl_method_t*)jl_svecref(m, 2);
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(temp, i);
+                jl_method_t *other = matc->method;
                 if (other != definition) {
-                    jl_svecset(guardsigs, guards, (jl_tupletype_t*)jl_svecref(m, 0));
+                    jl_svecset(guardsigs, guards, matc->spec_types);
                     guards++;
                     // alternative approach: insert sentinel entry
-                    //jl_typemap_insert(cache, parent, (jl_tupletype_t*)jl_svecref(m, 0),
+                    //jl_typemap_insert(cache, parent, (jl_tupletype_t*)matc->spec_types,
                     //        NULL, jl_emptysvec, /*guard*/NULL, jl_cachearg_offset(mt), &lambda_cache, other->min_world, other->max_world);
                 }
             }
@@ -1165,7 +1165,7 @@ static jl_method_instance_t *cache_method(
     return newmeth;
 }
 
-static jl_value_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world, size_t *min_valid, size_t *max_valid);
+static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world, size_t *min_valid, size_t *max_valid);
 
 static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt, size_t world)
 {
@@ -1185,12 +1185,12 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype
 
     size_t min_valid = 0;
     size_t max_valid = ~(size_t)0;
-    jl_value_t *matc = _gf_invoke_lookup((jl_value_t*)tt, world, &min_valid, &max_valid);
+    jl_method_match_t *matc = _gf_invoke_lookup((jl_value_t*)tt, world, &min_valid, &max_valid);
     jl_method_instance_t *nf = NULL;
     if (matc) {
         JL_GC_PUSH1(&matc);
-        jl_method_t *m = (jl_method_t*)jl_svecref(matc, 2);
-        jl_svec_t *env = (jl_svec_t*)jl_svecref(matc, 1);
+        jl_method_t *m = matc->method;
+        jl_svec_t *env = matc->sparams;
         nf = cache_method(mt, &mt->cache, (jl_value_t*)mt, tt, m, world, min_valid, max_valid, env);
         JL_GC_POP();
     }
@@ -1950,10 +1950,10 @@ jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types JL_PROPAGATES
     jl_tupletype_t *tt = NULL;
     jl_svec_t *newparams = NULL;
     JL_GC_PUSH3(&matches, &tt, &newparams);
-    jl_svec_t *match = (jl_svec_t*)jl_array_ptr_ref(matches, 0);
-    jl_method_t *m = (jl_method_t*)jl_svecref(match, 2);
-    jl_svec_t *env = (jl_svec_t*)jl_svecref(match, 1);
-    jl_tupletype_t *ti = (jl_tupletype_t*)jl_svecref(match, 0);
+    jl_method_match_t *match = (jl_method_match_t*)jl_array_ptr_ref(matches, 0);
+    jl_method_t *m = match->method;
+    jl_svec_t *env = match->sparams;
+    jl_tupletype_t *ti = match->spec_types;
     jl_method_instance_t *nf = NULL;
     if (jl_is_datatype(ti)) {
         jl_methtable_t *mt = jl_method_table_for((jl_value_t*)ti);
@@ -2317,7 +2317,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint
     return _jl_invoke(F, args, nargs, mfunc, world);
 }
 
-static jl_value_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world, size_t *min_valid, size_t *max_valid)
+static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world, size_t *min_valid, size_t *max_valid)
 {
     jl_value_t *unw = jl_unwrap_unionall((jl_value_t*)types);
     if (jl_is_tuple_type(unw) && jl_tparam0(unw) == jl_bottom_type)
@@ -2329,7 +2329,7 @@ static jl_value_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_
     jl_value_t *matches = ml_matches(mt, 0, (jl_tupletype_t*)types, 1, 0, 0, world, 1, min_valid, max_valid, &ambig);
     if (matches == jl_false || jl_array_len(matches) != 1)
         return NULL;
-    jl_value_t *matc = jl_array_ptr_ref(matches, 0);
+    jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(matches, 0);
     return matc;
 }
 
@@ -2338,10 +2338,10 @@ JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types, size_t world)
     // XXX: return min/max world
     size_t min_valid = 0;
     size_t max_valid = ~(size_t)0;
-    jl_value_t *matc = _gf_invoke_lookup(types, world, &min_valid, &max_valid);
+    jl_method_match_t *matc = _gf_invoke_lookup(types, world, &min_valid, &max_valid);
     if (matc == NULL)
         return jl_nothing;
-    return jl_svecref(matc, 2);
+    return (jl_value_t*)matc->method;
 }
 
 static jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);
@@ -2522,12 +2522,29 @@ struct ml_matches_env {
     size_t world;
     int lim;
     // results:
-    jl_value_t *t; // array of svec(argtypes, params, Method, fully-covers)
+    jl_value_t *t; // array of method matches
     size_t min_valid;
     size_t max_valid;
     // temporary:
-    jl_svec_t *matc; // current working svec
+    jl_method_match_t *matc; // current working method match
 };
+
+enum SIGNATURE_FULLY_COVERS {
+    NOT_FULLY_COVERS = 0,
+    FULLY_COVERS = 1,
+    SENTINEL    = 2,
+};
+
+static jl_method_match_t *make_method_match(jl_tupletype_t *spec_types, jl_svec_t *sparams, jl_method_t *method, enum SIGNATURE_FULLY_COVERS fully_covers)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_method_match_t *match = (jl_method_match_t*)jl_gc_alloc(ptls, sizeof(jl_method_match_t), jl_method_match_type);
+    match->spec_types = spec_types;
+    match->sparams = sparams;
+    match->method = method;
+    match->fully_covers = fully_covers;
+    return match;
+}
 
 static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersection_env *closure0)
 {
@@ -2559,7 +2576,9 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
             return 0;
         closure->lim--;
     }
-    closure->matc = jl_svec(4, closure->match.ti, closure->match.env, meth, closure->match.issubty ? jl_true : jl_false);
+    closure->matc = make_method_match((jl_tupletype_t*)closure->match.ti,
+        closure->match.env, meth,
+        closure->match.issubty ? FULLY_COVERS : NOT_FULLY_COVERS);
     size_t len = jl_array_len(closure->t);
     if (len == 0) {
         closure->t = (jl_value_t*)jl_alloc_vec_any(1);
@@ -2629,7 +2648,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
                 // this just calls jl_subtype_env (since we know that `type <: meth->sig` by transitivity)
                 env.match.ti = jl_type_intersection_env((jl_value_t*)type, (jl_value_t*)meth->sig, &env.match.env);
             }
-            env.matc = jl_svec(4, env.match.ti, env.match.env, meth, jl_true);
+            env.matc = make_method_match((jl_tupletype_t*)env.match.ti,
+                env.match.env, meth, FULLY_COVERS);
             env.t = (jl_value_t*)jl_alloc_vec_any(1);
             jl_array_ptr_set(env.t, 0, env.matc);
             if (*min_valid < entry->min_world)
@@ -2654,7 +2674,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
                 // this just calls jl_subtype_env (since we know that `type <: meth->sig` by transitivity)
                 env.match.ti = jl_type_intersection_env((jl_value_t*)type, (jl_value_t*)meth->sig, &env.match.env);
             }
-            env.matc = jl_svec(4, env.match.ti, env.match.env, meth, jl_true);
+            env.matc = make_method_match((jl_tupletype_t*)env.match.ti,
+                env.match.env, meth, FULLY_COVERS);
             env.t = (jl_value_t*)jl_alloc_vec_any(1);
             jl_array_ptr_set(env.t, 0, env.matc);
             *min_valid = entry->min_world;
@@ -2676,12 +2697,12 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         // first try to pre-process the results to find the most specific result that fully covers the input
         // (since we can do this in linear time, and the rest is O(n^2)
         //   - first see if this might even be profitable, given the requested output we need to compute
-        jl_svec_t *minmax = NULL;
+        jl_method_match_t *minmax = NULL;
         int minmax_ambig = 0;
         int all_subtypes = 1;
         for (i = 0; i < len; i++) {
-            jl_svec_t *matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
-            if (jl_svecref(matc, 3) != jl_true) {
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+            if (matc->fully_covers != FULLY_COVERS) {
                 all_subtypes = 0;
                 break;
             }
@@ -2692,11 +2713,11 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
             //     finding the minmax now, if we still need to examine all
             //     methods for ambiguities later.)
             for (i = 0; i < len; i++) {
-                jl_svec_t *matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
-                if (jl_svecref(matc, 3) == jl_true) {
-                    jl_method_t *m = (jl_method_t*)jl_svecref(matc, 2);
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+                if (matc->fully_covers == FULLY_COVERS) {
+                    jl_method_t *m = matc->method;
                     if (minmax != NULL) {
-                        jl_method_t *minmaxm = (jl_method_t*)jl_svecref(minmax, 2);
+                        jl_method_t *minmaxm = minmax->method;
                         if (jl_type_morespecific((jl_value_t*)minmaxm->sig, (jl_value_t*)m->sig))
                             continue;
                     }
@@ -2706,12 +2727,12 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
             //   - then see if it dominated all of the other choices
             if (minmax != NULL) {
                 for (i = 0; i < len; i++) {
-                    jl_svec_t *matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
+                    jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
                     if (matc == minmax)
                         break;
-                    if (jl_svecref(matc, 3) == jl_true) {
-                        jl_method_t *m = (jl_method_t*)jl_svecref(matc, 2);
-                        jl_method_t *minmaxm = (jl_method_t*)jl_svecref(minmax, 2);
+                    if (matc->fully_covers == FULLY_COVERS) {
+                        jl_method_t *m = matc->method;
+                        jl_method_t *minmaxm = minmax->method;
                         if (!jl_type_morespecific((jl_value_t*)minmaxm->sig, (jl_value_t*)m->sig)) {
                             minmax_ambig = 1;
                             *has_ambiguity = 1;
@@ -2725,14 +2746,14 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
             //   - it may even dominate some choices that are not subtypes!
             //     move those into the subtype group, where we're filter them out shortly after
             if (!all_subtypes && minmax) {
-                jl_method_t *minmaxm = (jl_method_t*)jl_svecref(minmax, 2);
+                jl_method_t *minmaxm = minmax->method;
                 all_subtypes = 1;
                 for (i = 0; i < len; i++) {
-                    jl_svec_t *matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
-                    if (jl_svecref(matc, 3) != jl_true) {
-                        jl_method_t *m = (jl_method_t*)jl_svecref(matc, 2);
+                    jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+                    if (matc->fully_covers != FULLY_COVERS) {
+                        jl_method_t *m = matc->method;
                         if (jl_type_morespecific((jl_value_t*)minmaxm->sig, (jl_value_t*)m->sig))
-                            jl_svecset(matc, 3, jl_nothing); // put a sentinel value here for sorting
+                            matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
                         else
                             all_subtypes = 0;
                     }
@@ -2763,16 +2784,16 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         // if we have a minmax method, we ignore anything less specific
         // we'll clean that up next
         for (i = 1; i < len; i++) {
-            env.matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
-            jl_method_t *m = (jl_method_t*)jl_svecref(env.matc, 2);
-            int subt = jl_svecref(env.matc, 3) != jl_false;
+            env.matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+            jl_method_t *m = env.matc->method;
+            int subt = env.matc->fully_covers != NOT_FULLY_COVERS;
             if (minmax != NULL && subt) {
                 continue; // already the biggest
             }
             for (j = 0; j < i; j++) {
-                jl_value_t *matc2 = jl_array_ptr_ref(env.t, i - j - 1);
-                jl_method_t *m2 = (jl_method_t*)jl_svecref(matc2, 2);
-                int subt2 = jl_svecref(matc2, 3) != jl_false;
+                jl_method_match_t *matc2 = (jl_method_match_t *)jl_array_ptr_ref(env.t, i - j - 1);
+                jl_method_t *m2 = matc2->method;
+                int subt2 = matc2->fully_covers != NOT_FULLY_COVERS;
                 if (!subt2 && subt)
                     break;
                 if (subt == subt2)
@@ -2789,17 +2810,17 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         // check for that now
         if (!minmax) {
             for (i = 0; i < len; i++) {
-                jl_svec_t *matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
-                if (jl_svecref(matc, 3) == jl_true)
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+                if (matc->fully_covers == FULLY_COVERS)
                     break;
             }
             for (; i > 0; i--) {
-                env.matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i - 1);
-                jl_method_t *m = (jl_method_t*)jl_svecref(env.matc, 2);
+                env.matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i - 1);
+                jl_method_t *m = env.matc->method;
                 for (j = i; j < len; j++) {
-                    jl_svec_t *matc2 = (jl_svec_t*)jl_array_ptr_ref(env.t, j);
-                    jl_method_t *m2 = (jl_method_t*)jl_svecref(matc2, 2);
-                    if (jl_svecref(matc2, 3) != jl_true)
+                    jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);
+                    jl_method_t *m2 = matc2->method;
+                    if (matc2->fully_covers != FULLY_COVERS)
                         break;
                     if (!jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig))
                         break;
@@ -2807,7 +2828,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
                 }
                 if (j == i)
                     break;
-                jl_svecset(env.matc, 3, jl_nothing); // leave behind a sentinel value here for clarity
+                env.matc->fully_covers = SENTINEL;
                 jl_array_ptr_set(env.t, j - 1, env.matc);
             }
         }
@@ -2816,8 +2837,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         // since we had a minmax method, now may now be able to cleanup some of our sort result
         if (minmax_ambig && !include_ambiguous) {
             for (i = 0; i < len; i++) {
-                jl_svec_t *matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
-                if (jl_svecref(matc, 3) != jl_false) {
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+                if (matc->fully_covers != NOT_FULLY_COVERS) {
                     skip[i] = 1;
                 }
             }
@@ -2825,8 +2846,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         else if (minmax != NULL) {
             assert(all_subtypes || !include_ambiguous);
             for (i = 0; i < len; i++) {
-                jl_svec_t *matc = (jl_svec_t*)jl_array_ptr_ref(env.t, i);
-                if (minmax != matc && jl_svecref(matc, 3) != jl_false) {
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+                if (minmax != matc && matc->fully_covers != NOT_FULLY_COVERS) {
                     skip[i] = 1;
                 }
             }
@@ -2840,19 +2861,19 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         int ndisjoint = 0;
         for (i = 0; i < len; i++) {
             // can't use skip[i] here, since we still need to make sure the minmax dominates
-            jl_value_t *matc = jl_array_ptr_ref(env.t, i);
-            jl_method_t *m = (jl_method_t*)jl_svecref(matc, 2);
-            int subt = jl_svecref(matc, 3) == jl_true; // jl_subtype((jl_value_t*)type, (jl_value_t*)m->sig)
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+            jl_method_t *m = matc->method;
+            int subt = matc->fully_covers == FULLY_COVERS; // jl_subtype((jl_value_t*)type, (jl_value_t*)m->sig)
             ambig_groupid[i] = i;
             int disjoint = 1;
             for (j = i; j > 0; j--) {
-                jl_value_t *matc2 = jl_array_ptr_ref(env.t, j - 1);
-                jl_method_t *m2 = (jl_method_t*)jl_svecref(matc2, 2);
-                int subt2 = jl_svecref(matc2, 3) == jl_true; // jl_subtype((jl_value_t*)type, (jl_value_t*)m2->sig)
+                jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(env.t, j - 1);
+                jl_method_t *m2 = matc2->method;
+                int subt2 = matc2->fully_covers == FULLY_COVERS; // jl_subtype((jl_value_t*)type, (jl_value_t*)m2->sig)
                 if (skip[j - 1]) {
                     // if there was a minmax method, we can just pretend these are all in the same group
                     // they're all together but unsorted in the list, since we'll drop them all later anyways
-                    assert(jl_svecref(matc2, 3) != jl_false);
+                    assert(matc2->fully_covers != NOT_FULLY_COVERS);
                     disjoint = 0;
                     ambig_groupid[i] = j - 1; // ambiguity covering range [i:j)
                 }
@@ -2896,8 +2917,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         }
         // always remove matches after the first subtype, now that we've sorted the list for ambiguities
         for (i = 0; i < len; i++) {
-            jl_value_t *matc = jl_array_ptr_ref(env.t, i);
-            if (jl_svecref(matc, 3) == jl_true) { // jl_subtype((jl_value_t*)type, (jl_value_t*)m->sig)
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+            if (matc->fully_covers == FULLY_COVERS) { // jl_subtype((jl_value_t*)type, (jl_value_t*)m->sig)
                 uint32_t agid = ambig_groupid[i];
                 while (i < len && agid == ambig_groupid[i])
                     i++; // keep ambiguous ones
@@ -2910,15 +2931,15 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
             for (i = 0; i < len; i++) {
                 if (skip[i])
                     continue;
-                jl_value_t *matc = jl_array_ptr_ref(env.t, i);
-                jl_method_t *m = (jl_method_t*)jl_svecref(matc, 2);
-                jl_value_t *ti = jl_svecref(matc, 0);
-                if (jl_svecref(matc, 3) == jl_true)
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+                jl_method_t *m = matc->method;
+                jl_tupletype_t *ti = matc->spec_types;
+                if (matc->fully_covers == FULLY_COVERS)
                     break; // remaining matches are ambiguous or already skipped
                 for (j = 0; j < i; j++) {
-                    jl_value_t *matc2 = jl_array_ptr_ref(env.t, j);
-                    jl_method_t *m2 = (jl_method_t*)jl_svecref(matc2, 2);
-                    if (jl_subtype(ti, m2->sig)) {
+                    jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);
+                    jl_method_t *m2 = matc2->method;
+                    if (jl_subtype((jl_value_t*)ti, m2->sig)) {
                         if (ambig_groupid[i] != ambig_groupid[j]) {
                             skip[i] = 1;
                             break;
@@ -2957,21 +2978,21 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
                 if (skip[i])
                     continue;
                 uint32_t agid = ambig_groupid[i];
-                jl_value_t *matc = jl_array_ptr_ref(env.t, i);
-                jl_method_t *m = (jl_method_t*)jl_svecref(matc, 2);
-                jl_value_t *ti = jl_svecref(matc, 0);
-                int subt = jl_svecref(matc, 3) == jl_true; // jl_subtype((jl_value_t*)type, (jl_value_t*)m->sig)
+                jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
+                jl_method_t *m = matc->method;
+                jl_tupletype_t *ti = matc->spec_types;
+                int subt = matc->fully_covers == FULLY_COVERS; // jl_subtype((jl_value_t*)type, (jl_value_t*)m->sig)
                 char ambig1 = 0;
                 for (j = agid; j < len && ambig_groupid[j] == agid; j++) {
                     if (j == i)
                         continue;
-                    jl_value_t *matc2 = jl_array_ptr_ref(env.t, j);
-                    jl_method_t *m2 = (jl_method_t*)jl_svecref(matc2, 2);
-                    int subt2 = jl_svecref(matc2, 3) == jl_true; // jl_subtype((jl_value_t*)type, (jl_value_t*)m2->sig)
+                    jl_method_match_t *matc2 = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);
+                    jl_method_t *m2 = matc2->method;
+                    int subt2 = matc2->fully_covers == FULLY_COVERS; // jl_subtype((jl_value_t*)type, (jl_value_t*)m2->sig)
                     // if their intersection contributes to the ambiguity cycle
-                    if (subt || subt2 || !jl_has_empty_intersection(ti, m2->sig)) {
+                    if (subt || subt2 || !jl_has_empty_intersection((jl_value_t*)ti, m2->sig)) {
                         // and the contribution of m is ambiguous with the portion of the cycle from m2
-                        if (subt2 || jl_subtype(ti, m2->sig)) {
+                        if (subt2 || jl_subtype((jl_value_t*)ti, m2->sig)) {
                             // but they aren't themselves simply ordered (here
                             // we don't consider that a third method might be
                             // disrupting that ordering and just consider them
@@ -2994,12 +3015,12 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         }
         // cleanup array to remove skipped entries
         for (i = 0, j = 0; i < len; i++) {
-            jl_value_t *matc = jl_array_ptr_ref(env.t, i);
+            jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
             if (!skip[i]) {
                 jl_array_ptr_set(env.t, j++, matc);
                 // remove our sentinel entry markers
-                if (jl_svecref(matc, 3) == jl_nothing)
-                    jl_svecset(matc, 3, jl_false);
+                if (matc->fully_covers == SENTINEL)
+                    matc->fully_covers = NOT_FULLY_COVERS;
             }
         }
         if (j != len)
@@ -3008,9 +3029,9 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
     }
     if (cache_result && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result parameter keeps this from being recursive
         if (len == 1 && !*has_ambiguity) {
-            env.matc = (jl_svec_t*)jl_array_ptr_ref(env.t, 0);
-            jl_method_t *meth = (jl_method_t*)jl_svecref(env.matc, 2);
-            jl_svec_t *tpenv = (jl_svec_t*)jl_svecref(env.matc, 1);
+            env.matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, 0);
+            jl_method_t *meth = env.matc->method;
+            jl_svec_t *tpenv = env.matc->sparams;
             cache_method(mt, &mt->cache, (jl_value_t*)mt, type, meth, world, env.min_valid, env.max_valid, tpenv);
         }
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -37,6 +37,7 @@ jl_datatype_t *jl_typedslot_type;
 jl_datatype_t *jl_argument_type;
 jl_datatype_t *jl_const_type;
 jl_datatype_t *jl_partial_struct_type;
+jl_datatype_t *jl_method_match_type;
 jl_datatype_t *jl_simplevector_type;
 jl_typename_t *jl_tuple_typename;
 jl_datatype_t *jl_anytuple_type;
@@ -2398,6 +2399,11 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_partial_struct_type = jl_new_datatype(jl_symbol("PartialStruct"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(2, "typ", "fields"),
                                        jl_svec2(jl_any_type, jl_array_any_type), 0, 0, 2);
+
+    jl_method_match_type = jl_new_datatype(jl_symbol("MethodMatch"), core, jl_any_type, jl_emptysvec,
+                                       jl_perm_symsvec(4, "spec_types", "sparams", "method", "fully_covers"),
+                                       jl_svec(4, jl_type_type, jl_simplevector_type, jl_method_type, jl_bool_type), 0, 0, 4);
+
 
     // all Kinds share the Type method table (not the nonfunction one)
     jl_unionall_type->name->mt = jl_uniontype_type->name->mt = jl_datatype_type->name->mt =

--- a/src/julia.h
+++ b/src/julia.h
@@ -559,6 +559,16 @@ typedef struct {
     jl_array_t *args;
 } jl_expr_t;
 
+typedef struct {
+    JL_DATA_TYPE
+    jl_tupletype_t *spec_types;
+    jl_svec_t *sparams;
+    jl_method_t *method;
+    // A bool on the julia side, but can be temporarily 0x2 as a sentinel
+    // during construction.
+    uint8_t fully_covers;
+} jl_method_match_t;
+
 // constants and type objects -------------------------------------------------
 
 // kinds
@@ -581,6 +591,7 @@ extern JL_DLLEXPORT jl_datatype_t *jl_typedslot_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_const_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_partial_struct_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_method_match_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_simplevector_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_tuple_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_vecelement_typename JL_GLOBALLY_ROOTED;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -40,7 +40,7 @@ static void *const _tags[] = {
          &jl_module_type, &jl_tvar_type, &jl_method_instance_type, &jl_method_type, &jl_code_instance_type,
          &jl_linenumbernode_type, &jl_lineinfonode_type,
          &jl_gotonode_type, &jl_quotenode_type, &jl_gotoifnot_type, &jl_argument_type, &jl_returnnode_type,
-         &jl_const_type, &jl_partial_struct_type,
+         &jl_const_type, &jl_partial_struct_type, &jl_method_match_type,
          &jl_pinode_type, &jl_phinode_type, &jl_phicnode_type, &jl_upsilonnode_type,
          &jl_type_type, &jl_bottom_type, &jl_ref_type, &jl_pointer_type, &jl_llvmpointer_type,
          &jl_vararg_type, &jl_abstractarray_type,

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -384,12 +384,12 @@ function get_type_call(expr::Expr)
     end
     # use _methods_by_ftype as the function is supplied as a type
     world = Base.get_world_counter()
-    mt = Base._methods_by_ftype(Tuple{ft, args...}, -1, world)
-    length(mt) == 1 || return (Any, false)
-    m = first(mt)
+    matches = Base._methods_by_ftype(Tuple{ft, args...}, -1, world)
+    length(matches) == 1 || return (Any, false)
+    match = first(matches)
     # Typeinference
     interp = Core.Compiler.NativeInterpreter()
-    return_type = Core.Compiler.typeinf_type(interp, m[3], m[1], m[2])
+    return_type = Core.Compiler.typeinf_type(interp, match.method, match.spec_types, match.sparams)
     return_type === nothing && return (Any, false)
     return (return_type, true)
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1441,9 +1441,9 @@ function detect_ambiguities(mods...;
                 mt = Base.MethodList(f.name.mt)
                 for m in mt
                     ambig = Int32[0]
-                    for m2 in Base._methods_by_ftype(m.sig, -1, typemax(UInt), true, UInt[typemin(UInt)], UInt[typemax(UInt)], ambig)
+                    for match2 in Base._methods_by_ftype(m.sig, -1, typemax(UInt), true, UInt[typemin(UInt)], UInt[typemax(UInt)], ambig)
                         ambig[1] == 0 && break
-                        m2 = m2[3]
+                        m2 = match2.method
                         if Base.isambiguous(m, m2, ambiguous_bottom=ambiguous_bottom)
                             push!(ambs, sortdefs(m, m2))
                         end
@@ -1465,9 +1465,9 @@ function detect_ambiguities(mods...;
         for m in mt
             if is_in_mods(m.module)
                 ambig = Int32[0]
-                for m2 in Base._methods_by_ftype(m.sig, -1, typemax(UInt), true, UInt[typemin(UInt)], UInt[typemax(UInt)], ambig)
+                for match2 in Base._methods_by_ftype(m.sig, -1, typemax(UInt), true, UInt[typemin(UInt)], UInt[typemax(UInt)], ambig)
                     ambig[1] == 0 && break
-                    m2 = m2[3]
+                    m2 = match2.method
                     if Base.isambiguous(m, m2, ambiguous_bottom=ambiguous_bottom)
                         push!(ambs, sortdefs(m, m2))
                     end

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -73,8 +73,9 @@ module MiniCassette
         tt = Tuple{f, args...}
         mthds = _methods_by_ftype(tt, -1, typemax(UInt))
         @assert length(mthds) == 1
-        mtypes, msp, m = mthds[1]
-        mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), m, mtypes, msp)
+        match = mthds[1]
+        mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance},
+            (Any, Any, Any), match.method, match.spec_types, match.sparams)
         # Unsupported in this mini-cassette
         @assert !mi.def.isva
         code_info = retrieve_code_info(mi)
@@ -83,7 +84,7 @@ module MiniCassette
         if isdefined(code_info, :edges)
             code_info.edges = MethodInstance[mi]
         end
-        transform!(code_info, length(args), msp)
+        transform!(code_info, length(args), match.sparams)
         code_info
     end
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1553,11 +1553,11 @@ f24852_kernel(x, y::Number) = f24852_kernel3(x, (y,))
 
 function f24852_kernel_cinfo(fsig::Type)
     world = typemax(UInt) # FIXME
-    sig, spvals, method = Base._methods_by_ftype(fsig, -1, world)[1]
-    isdefined(method, :source) || return (nothing, :(f(x, y)))
-    code_info = Base.uncompressed_ir(method)
-    Meta.partially_inline!(code_info.code, Any[], sig, Any[spvals...], 1, 0, :propagate)
-    if startswith(String(method.name), "f24852")
+    match = Base._methods_by_ftype(fsig, -1, world)[1]
+    isdefined(match.method, :source) || return (nothing, :(f(x, y)))
+    code_info = Base.uncompressed_ir(match.method)
+    Meta.partially_inline!(code_info.code, Any[], match.spec_types, Any[match.sparams...], 1, 0, :propagate)
+    if startswith(String(match.method.name), "f24852")
         for a in code_info.code
             if a isa Expr && a.head == :(=)
                 a = a.args[2]
@@ -1569,7 +1569,7 @@ function f24852_kernel_cinfo(fsig::Type)
     end
     pushfirst!(code_info.slotnames, Symbol("#self#"))
     pushfirst!(code_info.slotflags, 0x00)
-    return method, code_info
+    return match.method, code_info
 end
 
 function f24852_gen_cinfo_uninflated(X, Y, _, f, x, y)

--- a/test/compiler/validation.jl
+++ b/test/compiler/validation.jl
@@ -20,8 +20,8 @@ end
 
 msig = Tuple{typeof(f22938),Int,Int,Int,Int}
 world = typemax(UInt)
-_, msp, m = Base._methods_by_ftype(msig, -1, world)[]
-mi = Core.Compiler.specialize_method(m, msig, msp, false)
+match = Base._methods_by_ftype(msig, -1, world)[]
+mi = Core.Compiler.specialize_method(match, false)
 c0 = Core.Compiler.retrieve_code_info(mi)
 
 @test isempty(Core.Compiler.validate_code(mi))

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -629,10 +629,10 @@ let
     x22979 = (1, 2.0, 3.0 + im)
     T22979 = Tuple{typeof(f22979), typeof.(x22979)...}
     world = Core.Compiler.get_world_counter()
-    mtypes, msp, m = Base._methods_by_ftype(T22979, -1, world)[1]
-    instance = Core.Compiler.specialize_method(m, mtypes, msp)
+    match = Base._methods_by_ftype(T22979, -1, world)[1]
+    instance = Core.Compiler.specialize_method(match)
     cinfo_generated = Core.Compiler.get_staged(instance)
-    @test_throws ErrorException Base.uncompressed_ir(m)
+    @test_throws ErrorException Base.uncompressed_ir(match.method)
 
     test_similar_codeinfo(code_lowered(f22979, typeof(x22979))[1], cinfo_generated)
 

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -247,9 +247,9 @@ f22440kernel(::Type{T}) where {T} = one(T)
 f22440kernel(::Type{T}) where {T<:AbstractFloat} = zero(T)
 
 @generated function f22440(y)
-    sig, spvals, method = Base._methods_by_ftype(Tuple{typeof(f22440kernel),y}, -1, typemax(UInt))[1]
-    code_info = Base.uncompressed_ir(method)
-    Meta.partially_inline!(code_info.code, Any[], sig, Any[spvals...], 0, 0, :propagate)
+    match = Base._methods_by_ftype(Tuple{typeof(f22440kernel),y}, -1, typemax(UInt))[1]
+    code_info = Base.uncompressed_ir(match.method)
+    Meta.partially_inline!(code_info.code, Any[], match.spec_types, Any[match.sparams...], 0, 0, :propagate)
     return code_info
 end
 


### PR DESCRIPTION
Every time I see any code dealing with the svecs we get back from
the method match code, I think that it shouldn't really be an svec:
1. It's always the same length
2. Basically every use of it typeasserts the field type
3. Every use of it needs the same magic numbers to access the fields.

All put together this should just be a type. This basically does that,
but there's a few things missing, so before I go finish it, I figured,
I'd make sure that there isn't some reason not to do this.

TODO:
1. (deprecated) getindex/iterate for `MethodMatch` to avoid breaking packages that use the internal API
2. Make the bitfield a uint8_t for compatibility with compiler that use a different layout
3. Double check the gf.c changes. I think I fatfingered one of the mappings.

Doesn't need extensive review in this state, since it isn't done,
just a quick yay/nay on the direction.