### PR TITLE
gf lookup: avoid creating unintended specializations and cache misses

### DIFF
--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -84,8 +84,10 @@ struct NotFound end
 
 const NOT_FOUND = NotFound()
 
-const CompilerTypes = Union{Type, MaybeUndef, Const, Conditional, NotFound, PartialStruct}
+const CompilerTypes = Union{MaybeUndef, Const, Conditional, NotFound, PartialStruct}
 ==(x::CompilerTypes, y::CompilerTypes) = x === y
+==(x::Type, y::CompilerTypes) = false
+==(x::CompilerTypes, y::Type) = false
 
 #################
 # lattice logic #

--- a/base/show.jl
+++ b/base/show.jl
@@ -2492,11 +2492,11 @@ type, indicating that any recursed calls are not at the top level.
 Printing the parent as `::Array{Float64,3}` is the fallback (non-toplevel)
 behavior, because no specialized method for `Array` has been defined.
 """
-function showarg(io::IO, ::Type{T}, toplevel) where {T}
+function showarg(io::IO, T::Type, toplevel)
     toplevel || print(io, "::")
     print(io, "Type{", T, "}")
 end
-function showarg(io::IO, x, toplevel)
+function showarg(io::IO, @nospecialize(x), toplevel)
     toplevel || print(io, "::")
     print(io, typeof(x))
 end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -36,7 +36,7 @@ _Agen(A, i1, i2, i3, i4, i5, i6) = [A[j1,j2,j3,j4,j5,j6] for j1 in i1, j2 in i2,
 
 function replace_colon(A::AbstractArray, I)
     Iout = Vector{Any}(undef, length(I))
-    I == (:,) && return (1:length(A),)
+    I === (:,) && return (1:length(A),)
     for d = 1:length(I)
         Iout[d] = isa(I[d], Colon) ? (1:size(A,d)) : I[d]
     end


### PR DESCRIPTION
The typemap code was forgetting to handle the case where the user needed
to look for something complicated (like AbstractVec{Float64}) in the
method table cache (such as for ==).

edit: fixes #36669