### PR TITLE
Strip non-integral address space from datalayout after GC lowering

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,8 @@ SRCS += codegen llvm-ptls
 RUNTIME_SRCS += jitlayers aotcompile debuginfo disasm llvm-simdloop llvm-muladd \
 	llvm-final-gc-lowering llvm-pass-helpers llvm-late-gc-lowering \
 	llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces \
-	llvm-multiversioning llvm-alloc-opt cgmemmgr llvm-api llvm-remove-addrspaces
+	llvm-multiversioning llvm-alloc-opt cgmemmgr llvm-api llvm-remove-addrspaces \
+	llvm-remove-ni
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -632,6 +632,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
             PM->add(createFinalLowerGCPass());
             PM->add(createLowerPTLSPass(dump_native));
         }
+        PM->add(createRemoveNIPass());
         PM->add(createLowerSimdLoopPass()); // Annotate loop marked with "loopinfo" as LLVM parallel loop
         if (dump_native)
             PM->add(createMultiVersioningPass());
@@ -754,6 +755,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
         // Clean up write barrier and ptls lowering
         PM->add(createCFGSimplificationPass());
     }
+    PM->add(createRemoveNIPass());
     PM->add(createCombineMulAddPass());
     PM->add(createDivRemPairsPass());
 #if defined(JL_ASAN_ENABLED)

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -237,6 +237,7 @@ Pass *createLowerExcHandlersPass();
 Pass *createGCInvariantVerifierPass(bool Strong);
 Pass *createPropagateJuliaAddrspaces();
 Pass *createRemoveJuliaAddrspacesPass();
+Pass *createRemoveNIPass();
 Pass *createMultiVersioningPass();
 Pass *createAllocOptPass();
 // Whether the Function is an llvm or julia intrinsic.

--- a/src/llvm-remove-ni.cpp
+++ b/src/llvm-remove-ni.cpp
@@ -1,0 +1,49 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "llvm-version.h"
+
+#include <llvm/IR/Module.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Support/Debug.h>
+
+#define DEBUG_TYPE "remove_ni"
+
+using namespace llvm;
+
+namespace {
+
+struct RemoveNIPass : public ModulePass {
+    static char ID;
+    RemoveNIPass() : ModulePass(ID) {};
+
+    bool runOnModule(Module &M)
+    {
+        auto dlstr = M.getDataLayoutStr();
+        auto nistart = dlstr.find("-ni:");
+        if (nistart == std::string::npos)
+            return false;
+        auto len = dlstr.size();
+        auto niend = nistart + 1;
+        for (; niend < len; niend++) {
+            if (dlstr[niend] == '-') {
+                break;
+            }
+        }
+        dlstr.erase(nistart, niend - nistart);
+        M.setDataLayout(dlstr);
+        return true;
+    }
+};
+
+char RemoveNIPass::ID = 0;
+static RegisterPass<RemoveNIPass>
+        Y("RemoveNI",
+          "Remove non-integral address space.",
+          false,
+          false);
+}
+
+Pass *createRemoveNIPass()
+{
+    return new RemoveNIPass();
+}


### PR DESCRIPTION
This allows LLVM codegen passes to insert `inttoptr` and `ptrtoint` as it wish,
and avoids hitting any illegal ones in those passes.

Fix #36062
