### PR TITLE
Define isempty for Ref to be always false even for undefined references

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -50,6 +50,7 @@ convert(::Type{Ref{T}}, x::Ref{T}) where {T} = x
 size(x::Ref) = ()
 axes(x::Ref) = ()
 length(x::Ref) = 1
+isempty(x::Ref) = false
 ndims(x::Ref) = 0
 ndims(::Type{<:Ref}) = 0
 iterate(r::Ref) = (r[], nothing)


### PR DESCRIPTION
Closes #34812 (`isempty` on uninitialized `Ref`) with the help of PR #35723 (document `isassigned` for `Ref`)

Currently, `length(x::Ref) = 1` while `isempty` will throw an error for undefined references. 

For an `AbstractArray`, `isempty` is only defined in terms of the array length and not its contents: `isempty(a::AbstractArray) = (length(a) == 0)`

To be consistent with this the behavior on an `AbstractArray`, I propose
```julia
isempty(x::Ref) = false
```

Contrary to #34812 I do not believe it would be consistent for `isempty` to refer to `isassigned` in any way since `isemtpy` only has to do with `length` and not assignment.

The status quo is as follows:
```julia
julia> A = Array{Function}(undef,1)
1-element Array{Function,1}:
 #undef

julia> isassigned(A)
false

julia> length(A)
1

julia> isempty(A)
false

julia> R = Ref{Function}()
Base.RefValue{Function}(#undef)

julia> isassigned(R)
false

julia> length(R)
1

julia> isempty(R)
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getproperty at ./Base.jl:33 [inlined]
 [2] getindex at ./refvalue.jl:32 [inlined]
 [3] iterate at ./refpointer.jl:55 [inlined]
 [4] isempty(::Base.RefValue{Function}) at ./essentials.jl:737
 [5] top-level scope at REPL[22]:1
```

After this change
```julia
julia> A = Array{Function}(undef,1)
1-element Array{Function,1}:
 #undef

julia> isassigned(A)
false

julia> length(A)
1

julia> isempty(A)
false

julia> R = Ref{Function}()
Base.RefValue{Function}(#undef)

julia> isassigned(R)
false

julia> length(R)
1

julia> isempty(R)
false
```