### PR TITLE
Fix `sizeof` for non-Array subarrays

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -64,7 +64,8 @@ size(V::SubArray) = (@_inline_meta; map(n->Int(unsafe_length(n)), axes(V)))
 
 similar(V::SubArray, T::Type, dims::Dims) = similar(V.parent, T, dims)
 
-sizeof(V::SubArray) = length(V) * elsize(V.parent)
+sizeof(V::SubArray) = length(V) * sizeof(eltype(V))
+sizeof(V::SubArray{<:Any,<:Any,<:Array}) = length(V) * elsize(V.parent)
 
 copy(V::SubArray) = V.parent[V.indices...]
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -601,6 +601,10 @@ end
     arrayOfUInt48 = [a, b, c];
 
     @test sizeof(view(arrayOfUInt48, 1:2)) == 16
+
+    @test sizeof(view(Diagonal(zeros(UInt8, 10)), 1:4)) == 4
+    @test sizeof(view(Diagonal(zeros(UInt8, 10)), 1:3)) == 3
+    @test sizeof(view(Diagonal(zeros(Float64, 10)), 1:3, 2:6)) == 120
 end
 
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Test, Random
+using Test, Random, LinearAlgebra
 
 ######## Utilities ###########
 


### PR DESCRIPTION
Not all `AbstractArray`s define elsize.  Cf. #35900, #36714.