### PR TITLE
Add `haskey(::RegexMatch, ::Symbol)` to test for named capture groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,7 @@ Standard library changes
 * `first` and `last` functions now accept an integer as second argument to get that many
   leading or trailing elements of any iterable ([#34868]).
 * `intersect` on `CartesianIndices` now returns `CartesianIndices` instead of `Vector{<:CartesianIndex}` ([#36643]).
+* `RegexMatch` objects can now be probed for whether a named capture group exists within it through `haskey()` ([#36717]).
 
 #### LinearAlgebra
 * New method `LinearAlgebra.issuccess(::CholeskyPivoted)` for checking whether pivoted Cholesky factorization was successful ([#36002]).

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -194,7 +194,6 @@ end
 function substring_number_from_name(re, name)
     n = ccall((:pcre2_substring_number_from_name_8, PCRE_LIB), Cint,
                (Ptr{Cvoid}, Cstring), re, name)
-    n < 0 && error("PCRE error: $(err_message(n))")
     return Int(n)
 end
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -167,6 +167,11 @@ function getindex(m::RegexMatch, name::Symbol)
     m[idx]
 end
 getindex(m::RegexMatch, name::AbstractString) = m[Symbol(name)]
+function haskey(m::RegexMatch, name::Symbol)
+    idx = PCRE.substring_number_from_name(m.regex.regex, name)
+    return idx > 0
+end
+haskey(m::RegexMatch, name::AbstractString) = haskey(m, Symbol(name))
 
 function occursin(r::Regex, s::AbstractString; offset::Integer=0)
     compile(r)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -66,6 +66,9 @@
 
     # Named subpatterns
     let m = match(r"(?<a>.)(.)(?<b>.)", "xyz")
+        @test haskey(m, :a)
+        @test haskey(m, "b")
+        @test !haskey(m, "foo")
         @test (m[:a], m[2], m["b"]) == ("x", "y", "z")
         @test sprint(show, m) == "RegexMatch(\"xyz\", a=\"x\", 2=\"y\", b=\"z\")"
     end


### PR DESCRIPTION
Currently, the only way to test for a named capture group within
`RegexMatch` is to attempt to index into it and catch the error after it
fails; this adds a way to probe for a given key.