### PR TITLE
RFC: lower T[a b; c d] to typed_hvcat(T, Val((2, 2)), a, b, c, d)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1744,6 +1744,9 @@ function hvcat(nbc::Integer, as...)
     hvcat(ntuple(i->nbc, nbr), as...)
 end
 
+hvcat(::Val{rows}, values...) where {rows} = hvcat(rows, values...)
+typed_hvcat(T, ::Val{rows}, values...) where {rows} = typed_hvcat(T, rows, values...)
+
 """
     hvcat(rows::Tuple{Vararg{Int}}, values...)
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2339,7 +2339,7 @@
                                        (list x)))
                                  a)))
                   `(call (top hvcat)
-                         (tuple ,.(map length rows))
+                         (call (curly (top Val) (tuple ,.(map length rows))))
                          ,.(apply append rows)))
                 `(call (top vcat) ,@a))))))
 
@@ -2366,7 +2366,7 @@
                                    (list x)))
                              a)))
               `(call (top typed_hvcat) ,t
-                     (tuple ,.(map length rows))
+                     (call (curly (top Val) (tuple ,.(map length rows))))
                      ,.(apply append rows)))
             `(call (top typed_vcat) ,t ,@a)))))
 


### PR DESCRIPTION
Please tell me if this is a dumb idea, but I'm doing some shenanigans with `Base.typed_hvcat` in https://github.com/simeonschaub/CoolTensors.jl, where this significantly helps constant propagation and therefore type inference. This should be entirely non-breaking, because I added a fallback definition that falls back to calling the old methods. Is there reason to be concerned about latencies and invalidations here? From my qualitative testing, I didn't notice any difference and am inclined to say that this shouldn't make much of a difference for array constructors anyways, but perhaps it might be a good idea to add `@nospecialize` to the fallback methods?