### PR TITLE
ldiv!(::QR, ::StridedVector) should return the modified argument

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -847,7 +847,10 @@ function ldiv!(A::QR{T}, B::StridedMatrix{T}) where T
     end
     return B
 end
-ldiv!(A::QR, B::StridedVector) = ldiv!(A, reshape(B, length(B), 1))[:]
+function ldiv!(A::QR, B::StridedVector)
+    ldiv!(A, reshape(B, length(B), 1))
+    B
+end
 function ldiv!(A::QRPivoted, b::StridedVector)
     ldiv!(QR(A.factors,A.τ), b)
     b[1:size(A.factors, 2)] = view(b, 1:size(A.factors, 2))[invperm(A.jpvt)]


### PR DESCRIPTION
`ldiv!(A::QR, B::StridedVector)` was making an unneccessary copy, rather than just returning the argument `B`.