### PR TITLE
Fix correctness issues in sizeof tfunc

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -211,11 +211,9 @@ julia> Base.bitsunionsize(Union{Float64, UInt8, Int128})
 ```
 """
 function bitsunionsize(u::Union)
-    sz = Ref{Csize_t}(0)
-    algn = Ref{Csize_t}(0)
-    isunboxed = ccall(:jl_islayout_inline, Cint, (Any, Ptr{Csize_t}, Ptr{Csize_t}), u, sz, algn)
-    @assert isunboxed != Cint(0)
-    return sz[]
+    isinline, sz, _ = uniontype_layout(u)
+    @assert isinline
+    return sz
 end
 
 length(a::Array) = arraylen(a)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -347,15 +347,19 @@ function datatype_alignment(dt::DataType)
     return Int(alignment)
 end
 
+function uniontype_layout(T::Type)
+    sz = RefValue{Csize_t}(0)
+    algn = RefValue{Csize_t}(0)
+    isinline = ccall(:jl_islayout_inline, Cint, (Any, Ptr{Csize_t}, Ptr{Csize_t}), T, sz, algn) != 0
+    (isinline, sz[], algn[])
+end
+
 # amount of total space taken by T when stored in a container
 function aligned_sizeof(T::Type)
     @_pure_meta
     if isbitsunion(T)
-        sz = Ref{Csize_t}(0)
-        algn = Ref{Csize_t}(0)
-        ccall(:jl_islayout_inline, Cint, (Any, Ptr{Csize_t}, Ptr{Csize_t}), T, sz, algn)
-        al = algn[]
-        return (sz[] + al - 1) & -al
+        _, sz, al = uniontype_layout(T)
+        return (sz + al - 1) & -al
     elseif allocatedinline(T)
         al = datatype_alignment(T)
         return (Core.sizeof(T) + al - 1) & -al
@@ -380,6 +384,19 @@ function datatype_haspadding(dt::DataType)
     flags = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).flags
     return flags & 1 == 1
 end
+
+"""
+    Base.datatype_nfields(dt::DataType) -> Bool
+
+Return the number of fields known to this datatype's layout.
+Can be called on any `isconcretetype`.
+"""
+function datatype_nfields(dt::DataType)
+    @_pure_meta
+    dt.layout == C_NULL && throw(UndefRefError())
+    return unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).nfields
+end
+
 
 """
     Base.datatype_pointerfree(dt::DataType) -> Bool

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3039,21 +3039,6 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             *ret = mark_julia_type(ctx, ctx.builder.CreateMul(len, elsize), false, jl_long_type);
             return true;
         }
-        if (jl_is_type_type((jl_value_t*)sty) && !jl_is_typevar(jl_tparam0(sty))) {
-            sty = (jl_datatype_t*)jl_tparam0(sty);
-        }
-        if (jl_is_datatype(sty) && sty != jl_symbol_type &&
-                sty->name != jl_array_typename &&
-                sty != jl_simplevector_type && sty != jl_string_type &&
-                // exclude DataType, since each DataType has its own size, not sizeof(DataType).
-                // this is issue #8798
-                sty != jl_datatype_type) {
-            if (jl_is_concrete_type((jl_value_t*)sty) ||
-                    (jl_field_names(sty) == jl_emptysvec && jl_datatype_size(sty) > 0)) {
-                *ret = mark_julia_type(ctx, ConstantInt::get(T_size, jl_datatype_size(sty)), false, jl_long_type);
-                return true;
-            }
-        }
     }
 
     else if (f == jl_builtin_apply_type && nargs > 0) {


### PR DESCRIPTION
The `Core.sizeof` function can take either a value or a type,
which can be a bit confusing in the tfunc, because the tfunc
operates on the types of the values passed to the builtin.
In particular, we were incorrectly returning Const(16) (on 64bit)
for sizeof_tfunc(UnionAll), because it was treating it the asme
as `sizeof_tfunc(Const(UnionAll))`. Try to clean that up as well
as fixing a similar confusion in the nothrow version of this
function. Lastly, we had a similar fast path in codegen, which
would try to inline the actual size for a constant datatype argument.
For codegen, just rm that whole code path, since it should have no
more information than inference and figuring it out in inference
exposes strictly more optimization opportunities.

Fixes #36710