### PR TITLE
fix stackoverflow in circshift!(x, y, (1.0,))

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1026,7 +1026,9 @@ See also [`circshift`](@ref).
     axes(dest) == inds || throw(ArgumentError("indices of src and dest must match (got $inds and $(axes(dest)))"))
     _circshift!(dest, (), src, (), inds, fill_to_length(shiftamt, 0, Val(N)))
 end
-circshift!(dest::AbstractArray, src, shiftamt) = circshift!(dest, src, (shiftamt...,))
+
+circshift!(dest::AbstractArray, src, shiftamt) =
+    circshift!(dest, src, map(Integer, (shiftamt...,)))
 
 # For each dimension, we copy the first half of src to the second half
 # of dest, and the second half of src to the first half of dest. This

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -733,6 +733,15 @@ end
     dst=similar(src)
     s=(1,2,3)
     @inferred Base.circshift!(dst,src,s)
+
+    src = [1 2 3; 4 5 6]
+    dst = similar(src)
+    @test circshift(src, (3, 2)) == [5 6 4; 2 3 1]
+    @test circshift(src, (3.0, 2.0)) == [5 6 4; 2 3 1]
+    res = circshift!(dst, src, (3, 2))
+    @test res === dst == [5 6 4; 2 3 1]
+    res = circshift!(dst, src, (3.0, 2.0))
+    @test res === dst == [5 6 4; 2 3 1]
 end
 
 @testset "circcopy" begin


### PR DESCRIPTION
Currently:
```julia
julia> y = rand(2, 3); circshift(y, (1.0,))
2×3 Matrix{Float64}:
 0.224088  0.726063  0.704152
 0.545146  0.442787  0.417946

julia> x = similar(y); circshift!(x, y, (1.0,))
ERROR: StackOverflowError:
```
An alternative fix would be to disallow non-`Integer`, but would be (minorly?) breaking.