### PR TITLE
fix #36732: printing of single-entry matrix

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -433,6 +433,23 @@ _show_empty(io, X::AbstractArray) = summary(io, X)
 function show(io::IO, X::AbstractArray)
     ndims(X) == 0 && return show_zero_dim(io, X)
     ndims(X) == 1 && return show_vector(io, X)
+    # [x] parses as a vector, so we need to special-case 1x1 matrices
+    if ndims(X) == 2 && length(X) == 1
+        print(io, "fill(")
+        show(io, only(X))
+        ax = axes(X)
+        if all(a -> a isa OneTo, ax)
+            print(io, ", 1, 1)")
+        else
+            print(io, ", ")
+            show(io, ax[1])
+            print(io, ", ")
+            show(io, ax[2])
+            print(io, ")")
+        end
+        return
+    end
+
     prefix, implicit = typeinfo_prefix(io, X)
     if !implicit
         io = IOContext(io, :typeinfo => eltype(X))

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -223,7 +223,7 @@ targets1 = ["0-dimensional $OAs_name.OffsetArray{Float64,0,Array{Float64,0}}:\n1
             "1×1×1×1 $OAs_name.OffsetArray{Float64,4,Array{Float64,4}} with indices 2:2×3:3×4:4×5:5:\n[:, :, 4, 5] =\n 1.0"]
 targets2 = ["(fill(1.0), fill(1.0))",
             "([1.0], [1.0])",
-            "([1.0], [1.0])",
+            "(fill(1.0, Base.IdentityUnitRange(2:2), Base.IdentityUnitRange(3:3)), fill(1.0, Base.IdentityUnitRange(2:2), Base.IdentityUnitRange(3:3)))",
             "([1.0], [1.0])",
             "([1.0], [1.0])"]
 @testset "printing of OffsetArray with n=$n" for n = 0:4

--- a/test/show.jl
+++ b/test/show.jl
@@ -1994,3 +1994,17 @@ end
     @test contains(string(methods(foo)), "foo(α)")
     @test contains(string(methods(bar)), "bar(ℓ)")
 end
+
+struct OffsetMatrix{T} <: AbstractMatrix{T}
+    val::T
+    axes
+end
+Base.size(::OffsetMatrix) = (1, 1)
+Base.axes(m::OffsetMatrix) = m.axes
+Base.getindex(m::OffsetMatrix, i::Int, j::Int) = m.val
+
+@testset "show single-entry matrix (#36732)" begin
+    @test sprint(show, fill(42, 1, 1), context=:compact=>true) == "fill(42, 1, 1)"
+    m = OffsetMatrix(9.8, (3:3, 7:7))
+    @test sprint(show, m, context=:compact=>true) == "fill(9.8, 3:3, 7:7)"
+end


### PR DESCRIPTION
I find it a bit odd, that we currently print every `AbstractMatrix` as if it were just a `Matrix`, but that's definitely a separate discussion. I tried to at least respect the `axes` of the matrix when printed as `fill(...)`, but if people deem that unnecessary, I could also just remove that.
fixes #36732