### PR TITLE
ml-matches: restore fast-path cache

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1838,7 +1838,7 @@ static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
         else {
             size_t j, k, l = jl_array_len(expected);
             for (k = 0; k < jl_array_len(matches); k++) {
-                jl_method_match_t *match = jl_array_ptr_ref(matches, k);
+                jl_method_match_t *match = (jl_method_match_t*)jl_array_ptr_ref(matches, k);
                 jl_method_t *m = match->method;
                 for (j = 0; j < l; j++) {
                     if (m == (jl_method_t*)jl_array_ptr_ref(expected, j))


### PR DESCRIPTION
In attempting to add one early-exit path, the cache update had gotten
lost for the other fast path.