### PR TITLE
Refactor compiler method lookup interface

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -100,9 +100,11 @@ include("compiler/types.jl")
 include("compiler/utilities.jl")
 include("compiler/validation.jl")
 
+include("compiler/cicache.jl")
+include("compiler/methodtable.jl")
+
 include("compiler/inferenceresult.jl")
 include("compiler/inferencestate.jl")
-include("compiler/cicache.jl")
 
 include("compiler/typeutils.jl")
 include("compiler/typelimits.jl")

--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -1,0 +1,93 @@
+abstract type MethodTableView; end
+
+struct MethodLookupResult
+    # Really Vector{Core.MethodMatch}, but it's easier to represent this as
+    # and work with Vector{Any} on the C side.
+    matches::Vector{Any}
+    valid_worlds::WorldRange
+    ambig::Bool
+end
+length(result::MethodLookupResult) = length(result.matches)
+function iterate(result::MethodLookupResult, args...)
+    r = iterate(result.matches, args...)
+    r === nothing && return nothing
+    match, state = r
+    return (match::MethodMatch, state)
+end
+getindex(result::MethodLookupResult, idx::Int) = getindex(result.matches, idx)::MethodMatch
+
+"""
+    struct InternalMethodTable <: MethodTableView
+
+A struct representing the state of the internal method table at a
+particular world age.
+"""
+struct InternalMethodTable <: MethodTableView
+    world::UInt
+end
+
+"""
+    struct CachedMethodTable <: MethodTableView
+
+Overlays another method table view with an additional local fast path cache that
+can respond to repeated, identical queries faster than the original method table.
+"""
+struct CachedMethodTable{T} <: MethodTableView
+    cache::IdDict{Any, Union{Missing, MethodLookupResult}}
+    table::T
+end
+CachedMethodTable(table::T) where T =
+    CachedMethodTable{T}(IdDict{Any, Union{Missing, MethodLookupResult}}(),
+        table)
+
+"""
+    findall(sig::Type{<:Tuple}, view::MethodTableView; limit=typemax(Int))
+
+Find all methods in the given method table `view` that are applicable to the
+given signature `sig`. If no applicable methods are found, an empty result is
+returned. If the number of applicable methods exeeded the specified limit,
+`missing` is returned.
+"""
+function findall(@nospecialize(sig::Type{<:Tuple}), table::InternalMethodTable; limit::Int=typemax(Int))
+    _min_val = RefValue{UInt}(typemin(UInt))
+    _max_val = RefValue{UInt}(typemax(UInt))
+    _ambig = RefValue{Int32}(0)
+    ms = _methods_by_ftype(sig, limit, table.world, false, _min_val, _max_val, _ambig)
+    if ms === false
+        return missing
+    end
+    return MethodLookupResult(ms::Vector{Any}, WorldRange(_min_val[], _max_val[]), _ambig[] != 0)
+end
+
+function findall(@nospecialize(sig::Type{<:Tuple}), table::CachedMethodTable; limit::Int=typemax(Int))
+    box = Core.Box(sig)
+    return get!(table.cache, sig) do
+        findall(box.contents, table.table; limit=limit)
+    end
+end
+
+"""
+    findsup(sig::Type{<:Tuple}, view::MethodTableView)::Union{Tuple{MethodMatch, WorldRange}, Nothing}
+
+Find the (unique) method `m` such that `sig <: m.sig`, while being more
+specific than any other method with the same property. In other words, find
+the method which is the least upper bound (supremum) under the specificity/subtype
+relation of the queried `signature`. If `sig` is concrete, this is equivalent to
+asking for the method that will be called given arguments whose types match the
+given signature. This query is also used to implement `invoke`.
+
+Such a method `m` need not exist. It is possible that no method is an
+upper bound of `sig`, or it is possible that among the upper bounds, there
+is no least element. In both cases `nothing` is returned.
+"""
+function findsup(@nospecialize(sig::Type{<:Tuple}), table::InternalMethodTable)
+    min_valid = RefValue{UInt}(typemin(UInt))
+    max_valid = RefValue{UInt}(typemax(UInt))
+    result = ccall(:jl_gf_invoke_lookup_worlds, Any, (Any, UInt, Ptr{Csize_t}, Ptr{Csize_t}),
+                   sig, table.world, min_valid, max_valid)::Union{Method, Nothing}
+    result === nothing && return nothing
+    (result, WorldRange(min_valid[], max_valid[]))
+end
+
+# This query is not cached
+findsup(sig::Type{<:Tuple}, table::CachedMethodTable) = findsup(sig, table.table)

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -7,12 +7,11 @@ to re-consult the method table. This info is illegal on any statement that is
 not a call to a generic function.
 """
 struct MethodMatchInfo
-    applicable::Any
-    ambig::Bool
+    results::Union{Missing, MethodLookupResult}
 end
 
 """
-    struct MethodMatchInfo
+    struct UnionSplitInfo
 
 If inference decides to partition the method search space by splitting unions,
 it will issue a method lookup query for each such partition. This info indicates

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -23,8 +23,7 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
     # collect results for the new expanded frame
     results = InferenceResult[ frames[i].result for i in 1:length(frames) ]
     # empty!(frames)
-    min_valid = frame.min_valid
-    max_valid = frame.max_valid
+    valid_worlds = frame.valid_worlds
     cached = frame.cached
     if cached || frame.parent !== nothing
         for caller in results
@@ -46,27 +45,21 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
                 else
                     caller.src = nothing
                 end
-                if min_valid < opt.min_valid
-                    min_valid = opt.min_valid
-                end
-                if max_valid > opt.max_valid
-                    max_valid = opt.max_valid
-                end
+                valid_worlds = intersect(valid_worlds, opt.valid_worlds)
             end
         end
     end
-    if max_valid == get_world_counter()
-        max_valid = typemax(UInt)
+    if last(valid_worlds) == get_world_counter()
+        valid_worlds = WorldRange(first(valid_worlds), typemax(UInt))
     end
     for caller in frames
-        caller.min_valid = min_valid
-        caller.max_valid = max_valid
-        caller.src.min_world = min_valid
-        caller.src.max_world = max_valid
+        caller.valid_worlds = valid_worlds
+        caller.src.min_world = first(valid_worlds)
+        caller.src.max_world = last(valid_worlds)
         if cached
-            cache_result!(interp, caller.result, min_valid, max_valid)
+            cache_result!(interp, caller.result, valid_worlds)
         end
-        if max_valid == typemax(UInt)
+        if last(valid_worlds) == typemax(UInt)
             # if we aren't cached, we don't need this edge
             # but our caller might, so let's just make it anyways
             for caller in frames
@@ -79,7 +72,7 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
     return true
 end
 
-function CodeInstance(result::InferenceResult, min_valid::UInt, max_valid::UInt,
+function CodeInstance(result::InferenceResult, valid_worlds::WorldRange,
                       may_compress=true, allow_discard_tree=true)
     inferred_result = result.src
     local const_flags::Int32
@@ -126,7 +119,7 @@ function CodeInstance(result::InferenceResult, min_valid::UInt, max_valid::UInt,
     end
     return CodeInstance(result.linfo,
         widenconst(result.result), rettype_const, inferred_result,
-        const_flags, min_valid, max_valid)
+        const_flags, first(valid_worlds), last(valid_worlds))
 end
 
 # For the NativeInterpreter, we don't need to do an actual cache query to know
@@ -140,17 +133,17 @@ already_inferred_quick_test(interp::AbstractInterpreter, mi::MethodInstance) =
 
 # inference completed on `me`
 # update the MethodInstance
-function cache_result!(interp::AbstractInterpreter, result::InferenceResult, min_valid::UInt, max_valid::UInt)
+function cache_result!(interp::AbstractInterpreter, result::InferenceResult, valid_worlds::WorldRange)
     # check if the existing linfo metadata is also sufficient to describe the current inference result
     # to decide if it is worth caching this
     already_inferred = already_inferred_quick_test(interp, result.linfo)
-    if !already_inferred && haskey(WorldView(code_cache(interp), min_valid, max_valid), result.linfo)
+    if !already_inferred && haskey(WorldView(code_cache(interp), valid_worlds), result.linfo)
         already_inferred = true
     end
 
     # TODO: also don't store inferred code if we've previously decided to interpret this function
     if !already_inferred
-        code_cache(interp)[result.linfo] = CodeInstance(result, min_valid, max_valid,
+        code_cache(interp)[result.linfo] = CodeInstance(result, valid_worlds,
             may_compress(interp), may_discard_trees(interp))
     end
     unlock_mi_inference(interp, result.linfo)
@@ -495,7 +488,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     mi = specialize_method(method, atypes, sparams)::MethodInstance
     code = get(code_cache(interp), mi, nothing)
     if code isa CodeInstance # return existing rettype if the code is already inferred
-        update_valid_age!(min_world(code), max_world(code), caller)
+        update_valid_age!(caller, WorldRange(min_world(code), max_world(code)))
         if isdefined(code, :rettype_const)
             if isa(code.rettype_const, Vector{Any}) && !(Vector{Any} <: code.rettype)
                 return PartialStruct(code.rettype, code.rettype_const), mi

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -202,3 +202,5 @@ add_remark!(ni::NativeInterpreter, sv, s) = nothing
 may_optimize(ni::NativeInterpreter) = true
 may_compress(ni::NativeInterpreter) = true
 may_discard_trees(ni::NativeInterpreter) = true
+
+method_table(ai::AbstractInterpreter) = InternalMethodTable(get_world_counter(ai))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -866,6 +866,9 @@ end
 function _methods_by_ftype(@nospecialize(t), lim::Int, world::UInt, ambig::Bool, min::Array{UInt,1}, max::Array{UInt,1}, has_ambig::Array{Int32,1})
     return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}, Ptr{Int32}), t, lim, ambig, world, min, max, has_ambig)::Union{Array{Any,1}, Bool}
 end
+function _methods_by_ftype(@nospecialize(t), lim::Int, world::UInt, ambig::Bool, min::Ref{UInt}, max::Ref{UInt}, has_ambig::Ref{Int32})
+    return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}, Ptr{Int32}), t, lim, ambig, world, min, max, has_ambig)::Union{Array{Any,1}, Bool}
+end
 
 # high-level, more convenient method lookup functions
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -2335,12 +2335,19 @@ static jl_method_match_t *_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT
 
 JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types, size_t world)
 {
-    // XXX: return min/max world
+    // Deprecated: Use jl_gf_invoke_lookup_worlds for future development
     size_t min_valid = 0;
     size_t max_valid = ~(size_t)0;
     jl_method_match_t *matc = _gf_invoke_lookup(types, world, &min_valid, &max_valid);
     if (matc == NULL)
         return jl_nothing;
+    return (jl_value_t*)matc->method;
+}
+
+
+JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, size_t world, size_t *min_world, size_t *max_world)
+{
+    jl_method_match_t *matc = _gf_invoke_lookup(types, world, min_world, max_world);
     return (jl_value_t*)matc->method;
 }
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1486,8 +1486,8 @@ let linfo = get_linfo(Base.convert, Tuple{Type{Int64}, Int32}),
     @test opt.src.ssavaluetypes isa Vector{Any}
     @test !opt.src.inferred
     @test opt.mod === Base
-    @test opt.max_valid === Core.Compiler.get_world_counter()
-    @test opt.min_valid === Core.Compiler.min_world(opt.src) === UInt(1)
+    @test opt.valid_worlds.max_world === Core.Compiler.get_world_counter()
+    @test opt.valid_worlds.min_world === Core.Compiler.min_world(opt.src) === UInt(1)
     @test opt.nargs == 3
 end
 


### PR DESCRIPTION
The primary motivation here is to clean up the notion of
"looking up a method in the method table" into a single
object that can be passed around. At the moment, it's
all a bit murky, with fairly large state objects being
passed around everywhere and implicit accesses to the
global environment. In my AD use case, I need to be a
bit careful to make sure the various inference and
optimization steps are looking things up in the correct
tables/caches, so being very explicit about where things
need to be looked up is quite helpful.

In particular, I would like to clean up the optimizer, to
not require the big `OptimizationState` which is currently
a bit of a mix of things that go into IRCode and information
needed for method lookup/edge tracking. That isn't part of
this PR, but will build on top of it.

More generally, with a bunch of the recent compiler work,
I've been trying to define more crisp boundaries between
the various components of the system, giving them clearer
interfaces, and at least a little bit of documentation.
The compiler is a very powerful bit of technology, but I
think people having been avoiding it, because the code
looks a bit scary. I'm hoping some of these cleanups will
make it easier for people to understand what's going on.
Here in particular, I'm using `findall(sig, table)` as
the predicate for method lookup. The idea being that
people familiar with the `findall(predicate, collection)`
idiom from regular julia will have a good intuitive
understanding of what's happening (a collection is searched
for a predicate), an array of matches is returned, etc.
Of course, it's not a perfect fit, but I think these
kinds of mental aids can be helpful in making it easier
for people to read compiler code (similar to how #35831
used `getindex` as the verb for cache lookup). While
I was at it, I also cleaned up the use of out-parameters
which leaked through too much of the underlying C API
and replaced them by a proper struct of results.