### PR TITLE
doc: empty function example to single line

### DIFF
--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -885,8 +885,7 @@ purpose of documentation or code readability. The syntax for this is an empty `f
 without a tuple of arguments:
 
 ```julia
-function emptyfunc
-end
+function emptyfunc end
 ```
 
 ## [Method design and the avoidance of ambiguities](@id man-method-design-ambiguities)


### PR DESCRIPTION
My feeling is that a one-liner is a more common (and preferred) style for declaring functions in Julia, so the manual should recommend that.