### PR TITLE
Preserve `eltype` of `LinRange` under `reverse` and `-`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -903,7 +903,10 @@ issubset(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) =
 -(r::OrdinalRange) = range(-first(r), step=-step(r), length=length(r))
 -(r::StepRangeLen{T,R,S}) where {T,R,S} =
     StepRangeLen{T,R,S}(-r.ref, -r.step, length(r), r.offset)
--(r::LinRange) = LinRange(-r.start, -r.stop, length(r))
+function -(r::LinRange)
+    start = -r.start
+    LinRange{typeof(start)}(start, -r.stop, length(r))
+end
 
 
 # promote eltype if at least one container wouldn't change, otherwise join container types.
@@ -1003,7 +1006,7 @@ function reverse(r::StepRangeLen)
     offset = isempty(r) ? r.offset : length(r)-r.offset+1
     StepRangeLen(r.ref, -r.step, length(r), offset)
 end
-reverse(r::LinRange)     = LinRange(r.stop, r.start, length(r))
+reverse(r::LinRange{T}) where {T} = LinRange{T}(r.stop, r.start, length(r))
 
 ## sorting ##
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1008,8 +1008,10 @@ end
     @test LinRange(0,3,4)/3 == LinRange(0,1,4)
     @test broadcast(-, 2, LinRange(0,3,4)) == LinRange(2,-1,4)
     @test broadcast(+, 2, LinRange(0,3,4)) == LinRange(2,5,4)
-    @test -LinRange(0,3,4) == LinRange(0,-3,4)
-    @test reverse(LinRange(0,3,4)) == LinRange(3,0,4)
+    @test -LinRange{Int}(0,3,4) === LinRange{Int}(0,-3,4)
+    @test -LinRange{Float64}(0.,3.,4) === LinRange{Float64}(-0.,-3.,4)
+    @test reverse(LinRange{Int}(0,3,4)) === LinRange{Int}(3,0,4)
+    @test reverse(LinRange{Float64}(0.,3.,4)) === LinRange{Float64}(3.,0.,4)
 end
 @testset "Issue #11245" begin
     io = IOBuffer()


### PR DESCRIPTION
Currently, `-` and `reverse` change the `eltype` of a `LinRange{<:Integer}`:
```julia
julia> r = LinRange{Int}(1, 5, 3)
3-element LinRange{Int64}:
 1,3,5

julia> -r
3-element LinRange{Float64}:
 -1.0,-3.0,-5.0

julia> reverse(r)
3-element LinRange{Float64}:
 5.0,3.0,1.0
```
This PR changes that. Note that `-(::LinRange{Bool})` now returns a `LinRange{Int}`.