### PR TITLE
Add a link from Base.Docs to section on documentation

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -6,7 +6,7 @@
 The `Docs` module provides the `@doc` macro which can be used to set and retrieve
 documentation metadata for Julia objects.
 
-Please see the manual section on documentation for more
+Please see the manual section on [documentation](@ref man-documentation) for more
 information.
 """
 module Docs

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -1,7 +1,7 @@
-# Documentation
+# [Documentation](@id man-documentation)
 
 Julia enables package developers and users to document functions, types and other objects easily
-via a built-in documentation system since Julia 0.4.
+via a built-in documentation system.
 
 The basic syntax is simple: any string appearing at the toplevel right before an object
 (function, macro, type or instance) will be interpreted as documenting it (these are called


### PR DESCRIPTION
When saying "Please see the manual section on documentation", actually
provide a link.

Also drop a reference to Julia 0.4 (it probably made sense at some point,
but now it just is mildly confusing).