### PR TITLE
fix #27429, propagate include path in `at-everywhere`

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1702,6 +1702,12 @@ let e
     @test sprint(showerror, e) isa String
 end
 
+# issue #27429, propagate relative `include` path to workers
+@everywhere include("includefile.jl")
+for p in procs()
+    @test @fetchfrom(p, i27429) == 27429
+end
+
 include("splitrange.jl")
 
 # Run topology tests last after removing all workers, since a given

--- a/stdlib/Distributed/test/includefile.jl
+++ b/stdlib/Distributed/test/includefile.jl
@@ -1,0 +1,3 @@
+# this is used to test that relative include paths work on other processes
+
+i27429 = 27429


### PR DESCRIPTION
This is a bit ad-hoc but I think it's worth it. Definitely a noticeable bump in user-friendliness.

fix #27429
