### PR TITLE
Add partially evaluated methods ===(x), !==(x), and isa(T)

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -806,7 +806,7 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, fargs::U
         end
     elseif (rt === Bool || (isa(rt, Const) && isa(rt.val, Bool))) && isa(fargs, Vector{Any})
         # perform very limited back-propagation of type information for `is` and `isa`
-        if f === isa
+        if f === isa && la == 3
             a = ssa_def_slot(fargs[2], sv)
             if isa(a, Slot)
                 aty = widenconst(argtypes[2])
@@ -825,7 +825,7 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, fargs::U
                     end
                 end
             end
-        elseif f === (===)
+        elseif f === (===) && la == 3
             a = ssa_def_slot(fargs[2], sv)
             b = ssa_def_slot(fargs[3], sv)
             aty = argtypes[2]

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -570,6 +570,7 @@ function getfield_elim_pass!(ir::IRCode, domtree::DomTree)
             compact.ssa_rename[compact.idx-1] = pi
             continue
         elseif is_known_call(stmt, (===), compact)
+            length(stmt.args) == 3 || continue
             c1 = compact_exprtype(compact, stmt.args[2])
             c2 = compact_exprtype(compact, stmt.args[3])
             if !(isa(c1, Const) || isa(c2, Const))

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1577,6 +1577,17 @@ Integer
 invoke
 
 """
+    ===(x)
+
+Create a function that compares its argument to `x` using [`===`](@ref), i.e.
+a function equivalent to `y -> y == x`.
+
+!!! compat "Julia 1.6"
+    The partially applied form `===(x)` requires Julia 1.6 or later.
+"""
+===(x)
+
+"""
     isa(x, type) -> Bool
 
 Determine whether `x` is of the given `type`. Can also be used as an infix operator, e.g.
@@ -1600,7 +1611,24 @@ julia> 1 isa Number
 true
 ```
 """
-isa
+isa(x, T)
+
+"""
+    isa(type)
+
+Create a function that compares its argument to `x` using [`isa`](@ref), i.e.
+a function equivalent to `type -> x isa type`.
+
+!!! compat "Julia 1.6"
+    The partially applied form `isa(type)` requires Julia 1.6 or later.
+
+# Examples
+```jldoctest
+julia> isa(Int)(1)
+true
+```
+"""
+isa(T)
 
 """
     DivideError()

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -986,6 +986,15 @@ used to implement specialized methods.
 """
 !=(x) = Fix2(!=, x)
 
+"""
+    !==(x)
+
+Create a function that compares its argument to `x` using [`!==`](@ref), i.e.
+a function equivalent to `y -> y !== x`.
+
+!!! compat "Julia 1.6"
+    This functionality requires at least Julia 1.6.
+"""
 !==(x) = Fix2(!==, x)
 
 """

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -925,7 +925,9 @@ struct Fix1{F,T} <: Function
     x::T
 
     Fix1(f::F, x::T) where {F,T} = new{F,T}(f, x)
+    Fix1(f::F, x::Type{T}) where {F,T} = new{F,Type{T}}(f, x)
     Fix1(f::Type{F}, x::T) where {F,T} = new{Type{F},T}(f, x)
+    Fix1(f::Type{F}, x::Type{T}) where {F,T} = new{Type{F},Type{T}}(f, x)
 end
 
 (f::Fix1)(y) = f.f(f.x, y)
@@ -942,7 +944,9 @@ struct Fix2{F,T} <: Function
     x::T
 
     Fix2(f::F, x::T) where {F,T} = new{F,T}(f, x)
+    Fix2(f::F, x::Type{T}) where {F,T} = new{F,Type{T}}(f, x)
     Fix2(f::Type{F}, x::T) where {F,T} = new{Type{F},T}(f, x)
+    Fix2(f::Type{F}, x::Type{T}) where {F,T} = new{Type{F},Type{T}}(f, x)
 end
 
 (f::Fix2)(y) = f.f(y, f.x)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -986,6 +986,8 @@ used to implement specialized methods.
 """
 !=(x) = Fix2(!=, x)
 
+!==(x) = Fix2(!==, x)
+
 """
     >=(x)
 

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -12,11 +12,11 @@ extern "C" {
 #ifdef DEFINE_BUILTIN_GLOBALS
 #define DECLARE_BUILTIN(name) \
     JL_CALLABLE(jl_f_##name); \
-    jl_value_t *jl_builtin_##name
+    jl_value_t *jl_builtin_##name JL_GLOBALLY_ROOTED
 #else
 #define DECLARE_BUILTIN(name) \
     JL_CALLABLE(jl_f_##name); \
-    extern jl_value_t *jl_builtin_##name
+    extern jl_value_t *jl_builtin_##name JL_GLOBALLY_ROOTED
 #endif
 
 DECLARE_BUILTIN(throw);      DECLARE_BUILTIN(is);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -367,6 +367,8 @@ JL_CALLABLE(jl_f_is)
     JL_NARGS(===, 1, 2);
     if (nargs == 1) {
         jl_function_t *fix2 = jl_get_function(jl_base_module, "Fix2");
+        if (fix2 == NULL)
+            jl_undefined_var_error(jl_symbol("Fix2"));
         return jl_call2(fix2, jl_builtin_is, args[0]);
     }
     if (args[0] == args[1])
@@ -436,6 +438,8 @@ JL_CALLABLE(jl_f_isa)
     JL_NARGS(isa, 1, 2);
     if (nargs == 1) {
         jl_function_t *fix2 = jl_get_function(jl_base_module, "Fix2");
+        if (fix2 == NULL)
+            jl_undefined_var_error(jl_symbol("Fix2"));
         return jl_call2(fix2, jl_builtin_isa, args[0]);
     }
     JL_TYPECHK(isa, type, args[1]);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -364,7 +364,11 @@ JL_DLLEXPORT uintptr_t jl_object_id(jl_value_t *v) JL_NOTSAFEPOINT
 
 JL_CALLABLE(jl_f_is)
 {
-    JL_NARGS(===, 2, 2);
+    JL_NARGS(===, 1, 2);
+    if (nargs == 1) {
+        jl_function_t *fix2 = jl_get_function(jl_base_module, "Fix2");
+        return jl_call2(fix2, jl_builtin_is, args[0]);
+    }
     if (args[0] == args[1])
         return jl_true;
     return jl_egal(args[0], args[1]) ? jl_true : jl_false;
@@ -429,7 +433,11 @@ JL_CALLABLE(jl_f_issubtype)
 
 JL_CALLABLE(jl_f_isa)
 {
-    JL_NARGS(isa, 2, 2);
+    JL_NARGS(isa, 1, 2);
+    if (nargs == 1) {
+        jl_function_t *fix2 = jl_get_function(jl_base_module, "Fix2");
+        return jl_call2(fix2, jl_builtin_isa, args[0]);
+    }
     JL_TYPECHK(isa, type, args[1]);
     return (jl_isa(args[0],args[1]) ? jl_true : jl_false);
 }

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2734,3 +2734,17 @@ end
 
 f_generator_splat(t::Tuple) = tuple((identity(l) for l in t)...)
 @test Base.return_types(f_generator_splat, (Tuple{Symbol, Int64, Float64},)) == Any[Tuple{Symbol, Int64, Float64}]
+
+f_is2(x) = ===(x)
+@test @inferred(f_is2(1)) === Base.Fix2(===, 1)
+
+f_is2_ref(x) = ===(x[])
+@test Base.return_types(f_is2_ref, Tuple{Base.RefValue{Vector}}) ==
+      Any[Base.Fix2{typeof(===),Vector{T}} where {T}]
+
+f_isa2(T) = isa(T)
+@test @inferred(f_isa2(Int)) === Base.Fix2(isa, Int)
+
+f_isa2(b, T, S) = isa(b ? T : S)
+@test Base.return_types(f_isa2, Tuple{Bool,Type{Int64},Type{Float64}}) ==
+      Any[Union{Base.Fix2{typeof(isa),Type{Float64}},Base.Fix2{typeof(isa),Type{Int64}}}]

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -1,5 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+using Base: Fix1, Fix2
 using Random: randstring
 
 @testset "ifelse" begin
@@ -242,4 +243,16 @@ end
     @test lte5(5) && lte5(4)
     @test gt5(6) && !gt5(5)
     @test lt5(4) && !lt5(5)
+end
+
+@testset "curried comparisons (builtins)" begin
+    isaSymbol = isa(Symbol)
+    is5 = (===)(5)
+
+    @test isaSymbol(:yes) && !isaSymbol("no")
+    @test is5(5) && !is5(5.0)
+
+    # Make sure they are dispatchable:
+    @test isaSymbol isa Fix2{typeof(isa),Type{Symbol}}
+    @test is5 isa Fix2{typeof(===),Int}
 end

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -230,6 +230,7 @@ end
 end
 
 @testset "curried comparisons" begin
+    isnot5 = (!==)(5)
     eql5 = (==)(5)
     neq5 = (!=)(5)
     gte5 = (>=)(5)
@@ -237,6 +238,7 @@ end
     gt5  = (>)(5)
     lt5  = (<)(5)
 
+    @test isnot5(5.0) && !isnot5(5)
     @test eql5(5) && !eql5(0)
     @test neq5(6) && !neq5(5)
     @test gte5(5) && gte5(6)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -256,3 +256,12 @@ end
     @test isaSymbol isa Fix2{typeof(isa),Type{Symbol}}
     @test is5 isa Fix2{typeof(===),Int}
 end
+
+@testset "Fix1 and Fix2 on types" begin
+    @test Fix1(tuple, Fix1) isa Fix1{typeof(tuple),Type{Fix1}}
+    @test Fix1(Fix1, tuple) isa Fix1{Type{Fix1},typeof(tuple)}
+    @test Fix1(Fix1, Fix1) isa Fix1{Type{Fix1},Type{Fix1}}
+    @test Fix2(tuple, Fix2) isa Fix2{typeof(tuple),Type{Fix2}}
+    @test Fix2(Fix2, tuple) isa Fix2{Type{Fix2},typeof(tuple)}
+    @test Fix2(Fix2, Fix2) isa Fix2{Type{Fix2},Type{Fix2}}
+end


### PR DESCRIPTION
This PR adds `===(x)`, `!==(x)`, and `isa(T)` that creates a `Fix2` like `isequal` etc.  For `===(x)` and `isa(T)`, it looks like I needed to add tfuncs.

fix #36163
fix #32018
