### PR TITLE
Fix `pbpaste` error on MacOS buildbots

### DIFF
--- a/stdlib/InteractiveUtils/src/clipboard.jl
+++ b/stdlib/InteractiveUtils/src/clipboard.jl
@@ -25,7 +25,7 @@ if Sys.isapple()
 
         # See above comment in `clipboard(x)`
         if Sys.which("reattach-to-user-namespace") !== nothing
-            pbcopy_cmd = `reattach-to-user-namespace pbpaste`
+            pbpaste_cmd = `reattach-to-user-namespace pbpaste`
         end
         return read(pbpaste_cmd, String)
     end


### PR DESCRIPTION
We had a typo here for many a year; apparently the older buildbots did
not need `reattach-to-user-namespace` quite as desperately as we thought
they did.