### PR TITLE
return tuple type manipulations to deprecated.jl

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -219,4 +219,13 @@ iterate(match::Core.MethodMatch, field::Int=1) =
 getindex(match::Core.MethodMatch, field::Int) =
     getfield(match, field)
 
+
+# these were internal functions, but some packages seem to be relying on them
+tuple_type_head(T::Type) = fieldtype(T, 1)
+tuple_type_cons(::Type, ::Type{Union{}}) = Union{}
+function tuple_type_cons(::Type{S}, ::Type{T}) where T<:Tuple where S
+    @_pure_meta
+    Tuple{S, T.parameters...}
+end
+
 # END 1.6 deprecations


### PR DESCRIPTION
Some important packages seem to use these.