### PR TITLE
Streamline bail path in inlining

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -406,6 +406,8 @@ eval(Core, :(CodeInstance(mi::MethodInstance, @nospecialize(rettype), @nospecial
 eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, :Const, :v, false))))
 eval(Core, :(Const(@nospecialize(v), actual::Bool) = $(Expr(:new, :Const, :v, :actual))))
 eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))))
+eval(Core, :(MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) =
+    $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))))
 
 Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool), name, std_imports)
 

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -118,8 +118,24 @@ function retrieve_code_info(linfo::MethodInstance)
     end
 end
 
+# Get at the nonfunction_mt, which happens to be the mt of SimpleVector
+const nonfunction_mt = typename(SimpleVector).mt
+
+function get_compileable_sig(method::Method, @nospecialize(atypes), sparams::SimpleVector)
+    isa(atypes, DataType) || return Nothing
+    mt = ccall(:jl_method_table_for, Any, (Any,), atypes)
+    mt === nothing && return nothing
+    return ccall(:jl_normalize_to_compilable_sig, Any, (Any, Any, Any, Any),
+        mt, atypes, sparams, method)
+end
+
 # get a handle to the unique specialization object representing a particular instantiation of a call
-function specialize_method(method::Method, @nospecialize(atypes), sparams::SimpleVector, preexisting::Bool=false)
+function specialize_method(method::Method, @nospecialize(atypes), sparams::SimpleVector, preexisting::Bool=false, compilesig::Bool=false)
+    if compilesig
+        new_atypes = get_compileable_sig(method, atypes, sparams)
+        new_atypes === nothing && return nothing
+        atypes = new_atypes
+    end
     if preexisting
         # check cached specializations
         # for an existing result stored there
@@ -128,8 +144,8 @@ function specialize_method(method::Method, @nospecialize(atypes), sparams::Simpl
     return ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), method, atypes, sparams)
 end
 
-function specialize_method(match::MethodMatch, preexisting::Bool=false)
-    return specialize_method(match.method, match.spec_types, match.sparams, preexisting)
+function specialize_method(match::MethodMatch, preexisting::Bool=false, compilesig::Bool=false)
+    return specialize_method(match.method, match.spec_types, match.sparams, preexisting, compilesig)
 end
 
 # This function is used for computing alternate limit heuristics


### PR DESCRIPTION
When inlining declines to inline something, it instead turns them into
:invoke statements. These are then turned into direct (non-inlined)
calls by codegen or otherwise receive a fast path at runtime. While
inlining has evolved quite a bit, this code has stayed much the same
since it was introduced four years ago and doesn't seem to make much
sense as is. In particular:

1. For the non-`invoke()` case we were doing an extra method look that
seems entirely superfluous, because we already had to do the very same
method lookup just to reach this point. The only thing this path was
doing at that point was creating a "compilable" specialization (which
might use a slightly different signature). We might as well do that
directly.

2. For the invoke case, we were pro-actively adding the specialization
to the `->invokes` dispatch cache. However, this doesn't make much sense
a priori either, because the bail path does not go through the runtime
`invoke()` code that uses that cache (it did many years ago when this
code was introduced, but hasn't in a long time). There does not seem
to be a good reason to believe that this signature will be any more
likely than any other to be invoked using the runtime mechanism.

This cleans up that path by getting rid of both the superfluous method
lookup and the superfluous addition to the `->invokes` cache. There
should be a slight performance improvement as well from avoiding
this superfluous work, but the bail path is less common than one
might expect (the vast majority of call sites are inlined) and in
measurements the effect seems to be in the noise. Nevertheless,
it seems like a nice simplification and is conceptually clearer.