### PR TITLE
Small bug fix: Put back check for malformed invoke

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2348,6 +2348,8 @@ JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types, size_t world)
 JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, size_t world, size_t *min_world, size_t *max_world)
 {
     jl_method_match_t *matc = _gf_invoke_lookup(types, world, min_world, max_world);
+    if (matc == NULL)
+        return jl_nothing;
     return (jl_value_t*)matc->method;
 }
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -7266,3 +7266,7 @@ struct X36104; x::Int; end
 @test fieldtypes(X36104) == (Int,)
 primitive type P36104 8 end
 @test_throws ErrorException("invalid redefinition of constant P36104") @eval(primitive type P36104 16 end)
+
+# Malformed invoke
+f_bad_invoke(x::Int) = invoke(x, (Any,), x)
+@test_throws TypeError f_bad_invoke(1)


### PR DESCRIPTION
This was accidentally lost in #36743 while I was shuffling
around what these methods actually return. However, we also
didn't have a test to catch that, so this adds such a test as
well.