### PR TITLE
view macro hygiene + comment

### DIFF
--- a/base/views.jl
+++ b/base/views.jl
@@ -113,11 +113,13 @@ macro view(ex)
     if Meta.isexpr(ex, :ref)
         ex = replace_ref_begin_end!(ex)
         if Meta.isexpr(ex, :ref)
-            ex = Expr(:call, view, ex.args...)
+            ex = Expr(:call, Base.view, ex.args...)
         else # ex replaced by let ...; foo[...]; end
             @assert Meta.isexpr(ex, :let) && Meta.isexpr(ex.args[2], :ref)
-            ex.args[2] = Expr(:call, view, ex.args[2].args...)
+            ex.args[2] = Expr(:call, Base.view, ex.args[2].args...)
         end
+        # prevent accidentally redefining `view` if used on the LHS, i.e.
+        #   @view(A[x]) = 2
         Expr(:&&, true, esc(ex))
     else
         throw(ArgumentError("Invalid use of @view macro: argument must be a reference expression A[...]."))

--- a/base/views.jl
+++ b/base/views.jl
@@ -120,7 +120,7 @@ macro view(ex)
         @assert Meta.isexpr(ex.args[2], :ref)
         ex.args[1] = esc(ex.args[1])
         ex.args[2] = :(view($(map(esc, ex.args[2].args)...)))
-        return esc
+        return ex
     else
         throw(ArgumentError("Invalid use of @view macro: argument must be a reference expression A[...]."))
     end

--- a/base/views.jl
+++ b/base/views.jl
@@ -118,8 +118,9 @@ macro view(ex)
             ex = Expr(:let, Expr(:block), ex)
         end
         @assert Meta.isexpr(ex.args[2], :ref)
-        ex.args[2] = :(Base.view($(ex.args[2].args...))
-        return esc(ex)
+        ex.args[1] = esc(ex.args[1])
+        ex.args[2] = :(view($(map(esc, ex.args[2].args)...)))
+        return esc
     else
         throw(ArgumentError("Invalid use of @view macro: argument must be a reference expression A[...]."))
     end

--- a/base/views.jl
+++ b/base/views.jl
@@ -117,8 +117,9 @@ macro view(ex)
             #   @view(A[x]) = 2
             ex = Expr(:let, Expr(:block), ex)
         end
+        @assert Meta.isexpr(ex.args[2], :block)
         @assert Meta.isexpr(ex.args[2], :ref)
-        ex.args[1] = esc(ex.args[1])
+        ex.args[1].args = map(esc,ex.args[1].args)
         ex.args[2] = :(view($(map(esc, ex.args[2].args)...)))
         return ex
     else

--- a/base/views.jl
+++ b/base/views.jl
@@ -118,7 +118,7 @@ macro view(ex)
             ex = Expr(:let, Expr(:block), ex)
         end
         @assert Meta.isexpr(ex.args[2], :ref)
-        ex.args[2] = Expr(:call, Base.view, ex.args[2].args...)
+        ex.args[2] = :(Base.view($(ex.args[2].args...))
         return esc(ex)
     else
         throw(ArgumentError("Invalid use of @view macro: argument must be a reference expression A[...]."))


### PR DESCRIPTION
A comment on Slack asked why `@view(X[a])` expands to `true && view(X,a)`, which is not at all obvious, so added a comment. Also fixed a macro hygiene issue.