### PR TITLE
Add support to (+)(::UniformScaling)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,12 +76,12 @@ Standard library changes
 * `first` and `last` functions now accept an integer as second argument to get that many
   leading or trailing elements of any iterable ([#34868]).
 * `intersect` on `CartesianIndices` now returns `CartesianIndices` instead of `Vector{<:CartesianIndex}` ([#36643]).
-* `(+)(::UniformScaling)` is now defined, making `+I` a valid unary operation.
 
 #### LinearAlgebra
 * New method `LinearAlgebra.issuccess(::CholeskyPivoted)` for checking whether pivoted Cholesky factorization was successful ([#36002]).
 * `UniformScaling` can now be indexed into using ranges to return dense matrices and vectors ([#24359]).
 * New function `LinearAlgebra.BLAS.get_num_threads()` for getting the number of BLAS threads. ([#36360])
+* `(+)(::UniformScaling)` is now defined, making `+I` a valid unary operation. ([#36784])
 
 #### Markdown
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,7 @@ Standard library changes
 * `first` and `last` functions now accept an integer as second argument to get that many
   leading or trailing elements of any iterable ([#34868]).
 * `intersect` on `CartesianIndices` now returns `CartesianIndices` instead of `Vector{<:CartesianIndex}` ([#36643]).
+* `(+)(::UniformScaling)` is now defined, making `+I` a valid unary operation.
 
 #### LinearAlgebra
 * New method `LinearAlgebra.issuccess(::CholeskyPivoted)` for checking whether pivoted Cholesky factorization was successful ([#36002]).

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -147,6 +147,7 @@ isposdef(J::UniformScaling) = isposdef(J.λ)
 (-)(J::UniformScaling, x::Number) = J.λ - x
 (-)(x::Number, J::UniformScaling) = x - J.λ
 
+(+)(J::UniformScaling)                      = UniformScaling(+J.λ)
 (+)(J1::UniformScaling, J2::UniformScaling) = UniformScaling(J1.λ+J2.λ)
 (+)(B::BitArray{2}, J::UniformScaling)      = Array(B) + J
 (+)(J::UniformScaling, B::BitArray{2})      = J + Array(B)

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -153,6 +153,11 @@ end
     @test (α * I) .^ β == UniformScaling(α^β)
 end
 
+@testset "unary" begin
+    @test +I === +1*I
+    @test -I === -1*I
+end
+
 @testset "tr, det and logdet" begin
     for T in (Int, Float64, ComplexF64, Bool)
         @test tr(UniformScaling(zero(T))) === zero(T)


### PR DESCRIPTION
This commit add support to the operation `(+)(::UniformScaling)`. Hence, operations like: `+I` or `A = 4.0*I; +A` are now valid.

Closes JuliaLang/LinearAlgebra.jl#745 