### PR TITLE
doc: fix invalid doc example of `at-nospecialize`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -64,7 +64,7 @@ function example_function(@nospecialize x)
     ...
 end
 
-function example_function(@nospecialize(x = 1), y)
+function example_function(x, @nospecialize(y = 1))
     ...
 end
 


### PR DESCRIPTION
Optional positional arguments can't precede non optionals, and so currently this example yields the following error:
```julia
julia> function example_function(@nospecialize(x = 1), y)
           x + y
       end
       
ERROR: syntax: optional positional arguments must occur at end
Stacktrace:
 [1] top-level scope
   @ none:1
```