### PR TITLE
Add devdocs section on bug report w/ julia

### DIFF
--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -109,7 +109,7 @@ on Github with a link to the gist.
 
 ## Other generic segfaults or unreachables reached
 
-As mentioned elsewhere, `julia` has good integration with `rr` for generating traces; this includes, on linux, the ability to automatically run `julia` under `rr` and share the trace after a crash. This can be immensely helpful when debugging such crashes and is strongly encouraged when reporting crash issues to the JuliaLang/julia repo. To run `julia` under `rr` automatically, do:
+As mentioned elsewhere, `julia` has good integration with `rr` for generating traces; this includes, on Linux, the ability to automatically run `julia` under `rr` and share the trace after a crash. This can be immensely helpful when debugging such crashes and is strongly encouraged when reporting crash issues to the JuliaLang/julia repo. To run `julia` under `rr` automatically, do:
 
 ```julia
 julia --bug-report=rr

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -11,6 +11,7 @@ and follow the instructions to generate the debugging information requested.  Ta
   * [Segfaults during bootstrap (`sysimg.jl`)](@ref)
   * [Segfaults when running a script](@ref)
   * [Errors during Julia startup](@ref)
+  * [Other generic segfaults or unreachables reached](@ref)
 
 ## [Version/Environment info](@id dev-version-info)
 
@@ -105,6 +106,20 @@ the disk activity of the `julia` process:
 Create a [gist](https://gist.github.com) with the `strace`/ `dtruss` output, the [version info](@ref dev-version-info),
 and any other pertinent information and open a new [issue](https://github.com/JuliaLang/julia/issues?q=is%3Aopen)
 on Github with a link to the gist.
+
+## Other generic segfaults or unreachables reached
+
+As mentioned elsewhere, `julia` has good integration with `rr` for generating traces; this includes, on linux, the ability to automatically run `julia` under `rr` and share the trace after a crash. This can be immensely helpful when debugging such crashes and is strongly encouraged when reporting crash issues to the JuliaLang/julia repo. To run `julia` under `rr` automatically, do:
+
+```julia
+julia --bug-report=rr
+```
+
+To generate the `rr` trace locally, but not share, you can do:
+
+```julia
+julia --bug-report=rr-local
+```
 
 ## Glossary
 

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -121,6 +121,8 @@ To generate the `rr` trace locally, but not share, you can do:
 julia --bug-report=rr-local
 ```
 
+Note that this is only works on Linux. The blog post on [Time Travelling Bug Reporting](https://julialang.org/blog/2020/05/rr/) has many more details.
+
 ## Glossary
 
 A few terms have been used as shorthand in this guide:


### PR DESCRIPTION
@Keno said if I added devdocs for generating `rr` traces, he'd fix our [DataFrames.jl bug](https://github.com/JuliaData/DataFrames.jl/issues/2326) 😉 