### PR TITLE
change import to using in Pkg error message

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -892,7 +892,7 @@ function require(into::Module, mod::Symbol)
         if where.uuid === nothing
             throw(ArgumentError("""
                 Package $mod not found in current path:
-                - Run `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package.
+                - Run `using Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package.
                 """))
         else
             s = """


### PR DESCRIPTION
We generally recommend `using` over `import`, so I don't see any reason to suggest `import` here.