### PR TITLE
Define `OrderStyle` for `Union{}`

### DIFF
--- a/base/traits.jl
+++ b/base/traits.jl
@@ -11,6 +11,7 @@ OrderStyle(::Type{<:Real}) = Ordered()
 OrderStyle(::Type{<:AbstractString}) = Ordered()
 OrderStyle(::Type{Symbol}) = Ordered()
 OrderStyle(::Type{<:Any}) = Unordered()
+OrderStyle(::Type{Union{}}) = Unordered()
 
 # trait for objects that support arithmetic
 abstract type ArithmeticStyle end

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -11,7 +11,7 @@ OrderStyle(::Type{<:Real}) = Ordered()
 OrderStyle(::Type{<:AbstractString}) = Ordered()
 OrderStyle(::Type{Symbol}) = Ordered()
 OrderStyle(::Type{<:Any}) = Unordered()
-OrderStyle(::Type{Union{}}) = Unordered()
+OrderStyle(::Type{Union{}}) = Ordered()
 
 # trait for objects that support arithmetic
 abstract type ArithmeticStyle end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -440,7 +440,7 @@ end
     @test @inferred(unique!(iseven, [2, 3, 5, 7, 9])) == [2, 3]
     @test @inferred(unique!(x -> x % 2 == 0 ? :even : :odd, [1, 2, 3, 4, 2, 2, 1])) == [1, 2]
     @test @inferred(unique!(x -> x % 2 == 0 ? :even : "odd", [1, 2, 3, 4, 2, 2, 1]; seen=Set{Union{Symbol,String}}())) == [1, 2]
-                    
+
     @test isempty(unique!(Union{}[]))
     @test eltype(unique!([i for i in ["1"] if i isa Int])) <: Union{}
 end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -440,6 +440,9 @@ end
     @test @inferred(unique!(iseven, [2, 3, 5, 7, 9])) == [2, 3]
     @test @inferred(unique!(x -> x % 2 == 0 ? :even : :odd, [1, 2, 3, 4, 2, 2, 1])) == [1, 2]
     @test @inferred(unique!(x -> x % 2 == 0 ? :even : "odd", [1, 2, 3, 4, 2, 2, 1]; seen=Set{Union{Symbol,String}}())) == [1, 2]
+                    
+    @test isempty(unique!(Union{}[]))
+    @test eltype(unique!([i for i in ["1"] if i isa Int])) <: Union{}
 end
 
 @testset "allunique" begin


### PR DESCRIPTION
Removes ambiguity:
```
julia> Base.OrderStyle(Union{})
ERROR: MethodError: Base.OrderStyle(::Type{Union{}}) is ambiguous. Candidates:
```
This error is relevant as with current `unique!` definition that relies on `OrderStyle` one can have a problem in corner cases. E.g.:
```
julia> [i for i in ["1"] if i isa Int]
0-element Array{Union{},1}
```

I propose to make this case `Unordered()` as probably this was the intention of the original implementation, but probably it does not matter much which option is chosen.