### PR TITLE
README: turn directory structure into a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,18 @@ can be uninstalled by deleting `~/.julia`.
 
 The Julia source code is organized as follows:
 
-    base/          source code for the Base module (part of Julia's standard library)
-    stdlib/        source code for other standard library packages
-    contrib/       editor support for Julia source, miscellaneous scripts
-    deps/          external dependencies
-    doc/src/manual source for the user manual
-    doc/build      detailed notes for building Julia
-    src/           source for Julia language core
-    test/          test suites
-    ui/            source for various front ends
-    usr/           binaries and shared libraries loaded by Julia's standard libraries
+| Directory         | Contents                                                           |
+| -                 | -                                                                  |
+| `base/`           | source code for the Base module (part of Julia's standard library) |
+| `stdlib/`         | source code for other standard library packages                    |
+| `contrib/`        | editor support for Julia source, miscellaneous scripts             |
+| `deps/`           | external dependencies                                              |
+| `doc/src/manual/` | source for the user manual                                         |
+| `doc/build/`      | detailed notes for building Julia                                  |
+| `src/`            | source for Julia language core                                     |
+| `test/`           | test suites                                                        |
+| `ui/`             | source for various front ends                                      |
+| `usr/`            | binaries and shared libraries loaded by Julia's standard libraries |
 
 ## Terminal, Editors and IDEs
 


### PR DESCRIPTION
More readable and properly displayed on mobile devices. (You can check this out in the rich diff provided by GitHub.)

Since GitHub tables must have a header, I've chosen "Directory" and "Contents" as appropriate descriptions. If you have something better in mind, edits are welcome.