### PR TITLE
Fix compact float printing when output contains exactly 6 digits

### DIFF
--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -330,7 +330,8 @@ end
     olength = decimallength(output)
     exp_form = true
     pt = nexp + olength
-    if -4 < pt <= (precision == -1 ? (T == Float16 ? 3 : 6) : precision)
+    if -4 < pt <= (precision == -1 ? (T == Float16 ? 3 : 6) : precision) &&
+        !(pt >= olength && abs(mod(x + 0.05, 10^(pt - olength)) - 0.05) > 0.05)
         exp_form = false
         if pt <= 0
             buf[pos] = UInt8('0')

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -415,14 +415,16 @@ end
     @test repr(-NaN) == "NaN"
     @test repr(Float64(pi)) == "3.141592653589793"
     # issue 6608
-    @test sprint(show, 666666.6, context=:compact => true) == "666667.0"
+    @test sprint(show, 666666.6, context=:compact => true) == "6.66667e5"
     @test sprint(show, 666666.049, context=:compact => true) == "666666.0"
     @test sprint(show, 666665.951, context=:compact => true) == "666666.0"
     @test sprint(show, 66.66666, context=:compact => true) == "66.6667"
-    @test sprint(show, -666666.6, context=:compact => true) == "-666667.0"
+    @test sprint(show, -666666.6, context=:compact => true) == "-6.66667e5"
     @test sprint(show, -666666.049, context=:compact => true) == "-666666.0"
     @test sprint(show, -666665.951, context=:compact => true) == "-666666.0"
     @test sprint(show, -66.66666, context=:compact => true) == "-66.6667"
+    @test sprint(show, -498796.2749933266, context=:compact => true) == "-4.98796e5"
+    @test sprint(show, 123456.78, context=:compact=>true) == "1.23457e5"
 
     @test repr(1.0f0) == "1.0f0"
     @test repr(-1.0f0) == "-1.0f0"


### PR DESCRIPTION
This was really just a regression when switching from grisu -> ryu
algorithm for float printing. The fix is just putting [@vtjnash's
code](https://github.com/JuliaLang/julia/commit/5d2a0ec06761ea2b445909757d7744b9f7a93072#diff-22819a3d47074bbe6530dfef9c94969cR75)
for the grisu fix into the ryu branch.

Can perhaps still be included in 1.5?