### PR TITLE
Add jl_active_task_stack to gcext API

### DIFF
--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -125,7 +125,14 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
 // the size of that stack buffer upon return. Also, if task is a thread's
 // current task, that thread's id will be stored in *tid; otherwise,
 // *tid will be set to -1.
+//
+// DEPRECATED: use jl_active_task_stack() instead.
 JL_DLLEXPORT void *jl_task_stack_buffer(jl_task_t *task, size_t *size, int *tid);
+
+// Query the active stack range for the given task, and set *start and *end
+// accordingly. That is, the active part of the stack is between *start and *end.
+// However, these bounds may not be tight.
+JL_DLLEXPORT void jl_active_task_stack(jl_task_t *task, char **start, char **end);
 
 #ifdef __cplusplus
 }

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -129,10 +129,13 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
 // DEPRECATED: use jl_active_task_stack() instead.
 JL_DLLEXPORT void *jl_task_stack_buffer(jl_task_t *task, size_t *size, int *tid);
 
-// Query the active stack range for the given task, and set *start and *end
-// accordingly. That is, the active part of the stack is between *start and *end.
-// However, these bounds may not be tight.
-JL_DLLEXPORT void jl_active_task_stack(jl_task_t *task, char **start, char **end);
+// Query the active and total stack range for the given task, and set
+// *active_start and *active_end respectively *total_start and *total_end
+// accordingly. The range for the active part is a best-effort approximation
+// and may not be tight.
+JL_DLLEXPORT void jl_active_task_stack(jl_task_t *task,
+                                       char **active_start, char **active_end,
+                                       char **total_start, char **total_end);
 
 #ifdef __cplusplus
 }

--- a/src/task.c
+++ b/src/task.c
@@ -247,6 +247,52 @@ JL_DLLEXPORT void *jl_task_stack_buffer(jl_task_t *task, size_t *size, int *tid)
     return (void *)((char *)task->stkbuf + off);
 }
 
+JL_DLLEXPORT void jl_active_task_stack(jl_task_t *task, char **start, char **end)
+{
+    if (!task->started) {
+        *start = *end = 0;
+        return;
+    }
+
+    int16_t tid = task->tid;
+    jl_ptls_t ptls2 = (tid != -1) ? jl_all_tls_states[tid] : 0;
+
+    if (task->copy_stack && ptls2 && task == ptls2->current_task) {
+        *start  = (char*)ptls2->stackbase - ptls2->stacksize;
+        *end = (char*)ptls2->stackbase;
+    }
+    else if (task->stkbuf) {
+        *start  = (char*)task->stkbuf;
+#ifdef COPY_STACKS
+        // save_stack stores the stack of an inactive task in stkbuf, and the
+        // actual number of used bytes in copy_stack.
+        if (task->copy_stack > 1)
+            *end = (char*)task->stkbuf + task->copy_stack;
+        else
+#endif
+            *end = (char*)task->stkbuf + task->bufsz;
+
+#ifndef _OS_WINDOWS_
+        if (jl_all_tls_states[0]->root_task == task) {
+            // See jl_init_root_task(). The root task of the main thread
+            // has its buffer enlarged by an artificial 3000000 bytes, but
+            // that means that the start of the buffer usually points to
+            // inaccessible memory. We need to correct for this.
+            *start += ROOT_TASK_STACK_ADJUSTMENT;
+        }
+#endif
+    }
+    else {
+        *start = *end = 0;
+        return;
+    }
+
+    if (task == jl_current_task) {
+        // scan up to current `sp` for current thread and task
+        *start = (char*)jl_get_frame_addr();
+    }
+}
+
 // Marked noinline so we can consistently skip the associated frame.
 // `skip` is number of additional frames to skip.
 NOINLINE static void record_backtrace(jl_ptls_t ptls, int skip) JL_NOTSAFEPOINT

--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -486,7 +486,9 @@ void task_scanner(jl_task_t *task, int root_task)
     // doing actual work does not trigger a problem.
     char *start_stack;
     char *end_stack;
-    jl_active_task_stack(task, &start_stack, &end_stack);
+    char *total_start_stack;
+    char *total_end_stack;
+    jl_active_task_stack(task, &start_stack, &end_stack, &total_start_stack, &total_end_stack);
 
     // this is the live stack of a thread. Is it ours?
     if (start_stack && task == (jl_task_t *)jl_get_current_task()) {

--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -478,37 +478,27 @@ static int stack_grows_down(void) {
 
 void task_scanner(jl_task_t *task, int root_task)
 {
+    int var_on_frame;
+
     // The task scanner is not necessary for liveness, as the
     // corresponding task stack is already part of the stack.
     // Its purpose is simply to test that the task scanner
     // doing actual work does not trigger a problem.
-    size_t size;
-    int tid;
-    void *stack = jl_task_stack_buffer(task, &size, &tid);
-    if (tid >= 0) {
-        // this is the live stack of a thread. Is it ours?
-        if (stack && tid == jl_threadid()) {
-            // only scan the live portion of the stack.
-            char *end_stack = (char *) stack + size;
-            if (lt_ptr(stack, &size) && lt_ptr(&size, (char *)stack + size)) {
-                if (stack_grows_down()) {
-                    size = end_stack - (char *)&size;
-                    stack = (void *)&size;
-                }
-                else {
-                    size = (char *) end_stack - (char *) &size;
-                }
-            } else {
-                // error, current stack frame must be on the live stack.
-                jl_error("stack frame not part of the current task");
-            }
+    char *start_stack;
+    char *end_stack;
+    jl_active_task_stack(task, &start_stack, &end_stack);
+
+    // this is the live stack of a thread. Is it ours?
+    if (start_stack && task == (jl_task_t *)jl_get_current_task()) {
+        if (!(lt_ptr(start_stack, &var_on_frame) && lt_ptr(&var_on_frame, end_stack))) {
+            // error, current stack frame must be on the live stack.
+            jl_error("stack frame not part of the current task");
         }
-        else
-            stack = NULL;
     }
-    if (stack) {
-        void **start = (void **) stack;
-        void **end = start + size / sizeof(void *);
+
+    if (start_stack) {
+        void **start = (void **)start_stack;
+        void **end = (void **)end_stack;
         while (start < end) {
             void *p = *start++;
             void *q = jl_gc_internal_obj_base_ptr(p);


### PR DESCRIPTION
This is meant as a successor for `jl_task_stack_buffer`, which this patch marks as deprecated in a comment.
See also the discussion in PR #36064 for more information -- note that this PR does *not* (yet) attempt the more refined tracking of task stack sizes (in particular, there is no attempt to determine better stack bounds for tasks which are active on other threads). However, this PR should already allow us to simplify some code in GAP and in particular allow that code to not access the `copy_stacks` member of tasks. <s>This is somewhat urgent now for us, as https://github.com/JuliaLang/julia/pull/36802 is about to change the layout of `jl_task_t`.</s> Instead of adding an accessor function for `copy_tasks`, it seems better to just implement a first version of `jl_active_task_stack` now, and refine it later (the API would stay the same, just the returned bounds would be tighter).

@rbehrends please scrutinize this closely, I hacked this together rather quickly and would be surprised if I didn't screw up something somewhere ;-). 

I also have *not* yet tested this PR with GAP, so until that and until @rbehrends went over it, the Julia team should not feel obliged to waste time looking at this (that said, any feedback is of course highly welcome).