### PR TITLE
flatten recursive call to cat_shape

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1535,9 +1535,8 @@ cat_indices(A::AbstractArray, d) = axes(A, d)
 cat_similar(A, T, shape) = Array{T}(undef, shape)
 cat_similar(A::AbstractArray, T, shape) = similar(A, T, shape)
 
-cat_shape(dims, shape::Tuple) = shape
-@inline cat_shape(dims, shape::Tuple, nshape::Tuple, shapes::Tuple...) =
-    cat_shape(dims, _cshp(1, dims, shape, nshape), shapes...)
+cat_shape(dims, shape::Tuple{Vararg{Int}}) = shape
+cat_shape(dims, shapes::Tuple) = reduce((x,y)->_cshp(1, dims, x, y), shapes; init=())
 
 _cshp(ndim::Int, ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
 _cshp(ndim::Int, ::Tuple{}, ::Tuple{}, nshape) = nshape
@@ -1581,7 +1580,7 @@ _cat(dims, X...) = cat_t(promote_eltypeof(X...), X...; dims=dims)
 @inline cat_t(::Type{T}, X...; dims) where {T} = _cat_t(dims, T, X...)
 @inline function _cat_t(dims, T::Type, X...)
     catdims = dims2cat(dims)
-    shape = cat_shape(catdims, (), map(cat_size, X)...)
+    shape = cat_shape(catdims, map(cat_size, X))
     A = cat_similar(X[1], T, shape)
     if count(!iszero, catdims) > 1
         fill!(A, zero(T))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1536,7 +1536,13 @@ cat_similar(A, T, shape) = Array{T}(undef, shape)
 cat_similar(A::AbstractArray, T, shape) = similar(A, T, shape)
 
 cat_shape(dims, shape::Tuple{Vararg{Int}}) = shape
-cat_shape(dims, shapes::Tuple) = reduce((x,y)->_cshp(1, dims, x, y), shapes; init=())
+function cat_shape(dims, shapes::Tuple)
+    out_shape = ()
+    for s in shapes
+        out_shape = _cshp(1, dims, out_shape, s)
+    end
+    return out_shape
+end
 
 _cshp(ndim::Int, ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
 _cshp(ndim::Int, ::Tuple{}, ::Tuple{}, nshape) = nshape

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1810,7 +1810,7 @@ end
 # general case, specialized for BitArrays and Integers
 function _cat(dims::Integer, X::Union{BitArray, Bool}...)
     catdims = dims2cat(dims)
-    shape = cat_shape(catdims, (), map(cat_size, X)...)
+    shape = cat_shape(catdims, map(cat_size, X))
     A = falses(shape)
     return __cat(A, shape, catdims, X...)
 end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -232,5 +232,6 @@ end
 
 # these were internal functions, but some packages seem to be relying on them
 @deprecate cat_shape(dims, shape::Tuple{}, shapes::Tuple...) cat_shape(dims, shapes)
+cat_shape(dims, shape::Tuple{}) = () # make sure `cat_shape(dims, ())` do not recursively calls itself
 
 # END 1.6 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -230,4 +230,7 @@ function tuple_type_cons(::Type{S}, ::Type{T}) where T<:Tuple where S
     Tuple{S, T.parameters...}
 end
 
+# these were internal functions, but some packages seem to be relying on them
+@deprecate cat_shape(dims, shape::Tuple{}, shapes::Tuple...) cat_shape(dims, shapes)
+
 # END 1.6 deprecations


### PR DESCRIPTION
This brings a faster `cat` for arrays, especially for large ones

```julia
julia> s = [rand((0.0,1.0), 2,5,100) for _ = 1:5];

# before
julia> @btime cat(s...; dims=3);
  13.694 μs (83 allocations: 42.39 KiB)

# after
julia> @btime cat(s...; dims=3);
  10.816 μs (49 allocations: 41.19 KiB)

julia> s = [rand((0.0,1.0), 2,5,100) for _ = 1:5000];

# before
julia> @btime cat(s...; dims=3);
  751.367 ms (12552030 allocations: 803.21 MiB)

# after
julia> @btime cat(s...; dims=3);
  12.766 ms (30044 allocations: 40.10 MiB)
```

Similar results can be observed for `hcat` and `vcat`.

This also fixes #36750, would be nice to get this backported.

It is worth to note that there is actually a much slower workaround to #36750 

```julia
julia> s = [rand((0.0,1.0), 2,5,100) for _ = 1:5000];

julia> @btime reduce((x,y)->cat(x,y, dims=3), s);
  5.377 s (144963 allocations: 11.78 GiB)
```

and this is widely used in Flux community, e.g., https://github.com/FluxML/model-zoo/blob/4bf84760b370f264eadc7b19f6fb2070dd689bee/vision/dcgan_mnist/dcgan_mnist.jl#L27

cc: @cossio 