### PR TITLE
filesystem: fix error handling

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -777,7 +777,7 @@ function readdir(dir::AbstractString; join::Bool=false, sort::Bool=true)
     # defined in sys.c, to call uv_fs_readdir, which sets errno on error.
     err = ccall(:uv_fs_scandir, Int32, (Ptr{Cvoid}, Ptr{UInt8}, Cstring, Cint, Ptr{Cvoid}),
                 C_NULL, uv_readdir_req, dir, 0, C_NULL)
-    err < 0 && throw(SystemError("unable to read directory $dir", -err))
+    err < 0 && throw(_UVError("readdir", err, "with ", repr(dir)))
 
     # iterate the listing into entries
     entries = String[]
@@ -804,10 +804,9 @@ readdir(; join::Bool=false, sort::Bool=true) =
 Return an iterator that walks the directory tree of a directory.
 The iterator returns a tuple containing `(rootpath, dirs, files)`.
 The directory tree can be traversed top-down or bottom-up.
-If `walkdir` encounters a [`SystemError`](@ref)
-it will rethrow the error by default.
+If `walkdir` or `stat` encounters a `IOError` it will rethrow the error by default.
 A custom error handling function can be provided through `onerror` keyword argument.
-`onerror` is called with a `SystemError` as argument.
+`onerror` is called with a `IOError` as argument.
 
 # Examples
 ```julia
@@ -839,48 +838,45 @@ julia> (root, dirs, files) = first(itr)
 ```
 """
 function walkdir(root; topdown=true, follow_symlinks=false, onerror=throw)
-    content = nothing
-    try
-        content = readdir(root)
-    catch err
-        isa(err, SystemError) || throw(err)
-        onerror(err)
-        # Need to return an empty closed channel to skip the current root folder
-        chnl = Channel(0)
-        close(chnl)
-        return chnl
-    end
-    dirs = Vector{eltype(content)}()
-    files = Vector{eltype(content)}()
-    for name in content
-        path = joinpath(root, name)
-
-        # If we're not following symlinks, then treat all symlinks as files
-        if (!follow_symlinks && islink(path)) || !isdir(path)
-            push!(files, name)
-        else
-            push!(dirs, name)
-        end
-    end
-
-    function _it(chnl)
-        if topdown
-            put!(chnl, (root, dirs, files))
-        end
-        for dir in dirs
-            path = joinpath(root,dir)
-            if follow_symlinks || !islink(path)
-                for (root_l, dirs_l, files_l) in walkdir(path, topdown=topdown, follow_symlinks=follow_symlinks, onerror=onerror)
-                    put!(chnl, (root_l, dirs_l, files_l))
+    function _walkdir(chnl, root)
+        tryf(f, p) = try
+                f(p)
+            catch err
+                isa(err, IOError) || rethrow()
+                try
+                    onerror(err)
+                catch err2
+                    close(chnl, err2)
                 end
+                return
+            end
+        content = tryf(readdir, root)
+        content === nothing && return
+        dirs = Vector{eltype(content)}()
+        files = Vector{eltype(content)}()
+        for name in content
+            path = joinpath(root, name)
+
+            # If we're not following symlinks, then treat all symlinks as files
+            if (!follow_symlinks && something(tryf(islink, path), true)) || !something(tryf(isdir, path), false)
+                push!(files, name)
+            else
+                push!(dirs, name)
             end
         end
-        if !topdown
-            put!(chnl, (root, dirs, files))
-        end
-    end
 
-    return Channel(_it)
+        if topdown
+            push!(chnl, (root, dirs, files))
+        end
+        for dir in dirs
+            _walkdir(chnl, joinpath(root, dir))
+        end
+        if !topdown
+            push!(chnl, (root, dirs, files))
+        end
+        nothing
+    end
+    return Channel(chnl -> _walkdir(chnl, root))
 end
 
 function unlink(p::AbstractString)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -219,26 +219,26 @@ const SEEK_END = Int32(2)
 
 function seek(f::File, n::Integer)
     ret = ccall(:jl_lseek, Int64, (OS_HANDLE, Int64, Int32), f.handle, n, SEEK_SET)
-    systemerror("seek", ret == -1)
+    ret == -1 && (@static Sys.iswindows() ? windowserror : systemerror)("seek")
     return f
 end
 
 function seekend(f::File)
     ret = ccall(:jl_lseek, Int64, (OS_HANDLE, Int64, Int32), f.handle, 0, SEEK_END)
-    systemerror("seekend", ret == -1)
+    ret == -1 && (@static Sys.iswindows() ? windowserror : systemerror)("seekend")
     return f
 end
 
 function skip(f::File, n::Integer)
     ret = ccall(:jl_lseek, Int64, (OS_HANDLE, Int64, Int32), f.handle, n, SEEK_CUR)
-    systemerror("skip", ret == -1)
+    ret == -1 && (@static Sys.iswindows() ? windowserror : systemerror)("skip")
     return f
 end
 
 function position(f::File)
     check_open(f)
     ret = ccall(:jl_lseek, Int64, (OS_HANDLE, Int64, Int32), f.handle, 0, SEEK_CUR)
-    systemerror("lseek", ret == -1)
+    ret == -1 && (@static Sys.iswindows() ? windowserror : systemerror)("lseek")
     return ret
 end
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -250,10 +250,10 @@ function complete_path(path::AbstractString, pos; use_envpath=false, shell_escap
                 filesinpath = readdir(pathdir)
             catch e
                 # Bash allows dirs in PATH that can't be read, so we should as well.
-                if isa(e, SystemError)
+                if isa(e, Base.IOError)
                     continue
                 else
-                    # We only handle SystemErrors here
+                    # We only handle IOError here
                     rethrow()
                 end
             end

--- a/test/file.jl
+++ b/test/file.jl
@@ -445,9 +445,9 @@ close(f)
 
 rm(c_tmpdir, recursive=true)
 @test !isdir(c_tmpdir)
-@test_throws Base._UVError("unlink", Base.UV_ENOENT) rm(c_tmpdir)
+@test_throws Base._UVError(Sys.iswindows() ? "chmod" : "unlink", Base.UV_ENOENT) rm(c_tmpdir)
 @test rm(c_tmpdir, force=true) === nothing
-@test_throws Base._UVError("unlink", Base.UV_ENOENT) rm(c_tmpdir, recursive=true)
+@test_throws Base._UVError(Sys.iswindows() ? "chmod" : "unlink", Base.UV_ENOENT) rm(c_tmpdir, recursive=true)
 @test rm(c_tmpdir, force=true, recursive=true) === nothing
 
 if !Sys.iswindows()


### PR DESCRIPTION
walkdir: fix thrown error location and types and performance
 - previously the error for the root path would be handled differently than any other error, and errors from `isdir` would not be passed to the `onerror` hook
 - previously we'd recurse heavily through multiple channels, but there's no reason to do that

readdir: fix thrown error code on some OS
 - previously might report the wrong error code (usually just always resulting in saying "unknown error", on e.g. Windows)

seek: fix thrown error code on Windows
 - previously would just print a random error reason