### PR TITLE
test: fix textual output for precompile

### DIFF
--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -407,7 +407,7 @@ try
           error("break me")
           end
           """)
-    @test_warn "ERROR: LoadError: break me\nStacktrace:\n [1] error" try
+    @test_warn "LoadError: break me\nStacktrace:\n [1] error" try
             Base.require(Main, :FooBar2)
             error("the \"break me\" test failed")
         catch exc


### PR DESCRIPTION
We might print ANSI codes around ERROR, making this test unreliable now.