### PR TITLE
speedup norm on AbstractArray{<:Number}

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -644,13 +644,19 @@ true
 julia> norm(1:9) ≈ sqrt(sum(abs2, 1:9))
 true
 
-julia> norm(hcat(v,v), 1) == norm(vcat(v,v), 1) != norm([v,v], 1)
+julia> norm(hcat(v,v), 1) == norm(vcat(v,v), 1)
 true
 
-julia> norm(hcat(v,v), 2) == norm(vcat(v,v), 2) == norm([v,v], 2)
+julia> !(norm(vcat(v,v), 1) ≈ norm([v,v], 1))
 true
 
-julia> norm(hcat(v,v), Inf) == norm(vcat(v,v), Inf) != norm([v,v], Inf)
+julia> norm(hcat(v,v), 2) ≈ norm(vcat(v,v), 2) ≈ norm([v,v], 2)
+true
+
+julia> norm(hcat(v,v), Inf) == norm(vcat(v,v), Inf)
+true
+
+julia> !(norm(vcat(v,v), Inf) ≈ norm([v,v], Inf))
 true
 ```
 """

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -2,6 +2,7 @@
 
 module TestDense
 
+using InteractiveUtils
 using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasComplex, BlasFloat, BlasReal
 
@@ -330,6 +331,17 @@ end
 
                     # norm
                     for p in (-Inf, Inf, (-2:3)...)
+                        if norm(A, p) != norm(vec(A), p)
+                            @show A
+                            @show typeof(A)
+                            @show size(A)
+                            @show p
+                            @show InteractiveUtils.@which norm(A,p)
+                            @show InteractiveUtils.@which norm(vec(A),p)
+                            @show norm(A, p)
+                            @show norm(vec(A), p)
+                            error()
+                        end
                         @test norm(A, p) == norm(vec(A), p)
                     end
                 end

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -338,8 +338,12 @@ end
                             @show p
                             @show InteractiveUtils.@which norm(A,p)
                             @show InteractiveUtils.@which norm(vec(A),p)
+                            @show InteractiveUtils.@which LinearAlgebra.norm2(A)
+                            @show InteractiveUtils.@which LinearAlgebra.norm2(vec(A))
                             @show norm(A, p)
                             @show norm(vec(A), p)
+                            @show LinearAlgebra.norm2(A)
+                            @show LinearAlgebra.norm2(vec(A))
                             error()
                         end
                         @test norm(A, p) == norm(vec(A), p)


### PR DESCRIPTION
This gives a nice speedup for generic arrays.
## PR
```julia
julia> arr = randn(10^5); oarr = OffsetArray(arr, eachindex(arr)); @btime norm(arr); @btime norm(oarr)
  29.836 μs (1 allocation: 16 bytes)
  73.266 μs (1 allocation: 16 bytes)
```
## Baseline
```julia
julia> arr = randn(10^5); oarr = OffsetArray(arr, eachindex(arr)); @btime norm(arr); @btime norm(oarr)

  29.833 μs (1 allocation: 16 bytes)
  254.549 μs (1 allocation: 16 bytes)
```