### PR TITLE
add a constructor for Union{}

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -226,6 +226,10 @@ ccall(:jl_toplevel_eval_in, Any, (Any, Any),
       (f::typeof(Typeof))(x) = ($(_expr(:meta,:nospecialize,:x)); isa(x,Type) ? Type{x} : typeof(x))
       end)
 
+# let the compiler assume that calling Union{} as a constructor does not need
+# to be considered ever (which comes up often as Type{<:T})
+Union{}(a...) = throw(MethodError(Union{}, a))
+
 macro nospecialize(x)
     _expr(:meta, :nospecialize, x)
 end


### PR DESCRIPTION
This often shows up accidentally in method intersections, which can force recompilation of completely unrelated code. Define this explicitly so that the compiler can always ignore this dispatch possibility.