### PR TITLE
Do not include commit-offset number in VERSION if we are building for a tag.

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -221,7 +221,7 @@ A `VersionNumber` object describing which version of Julia is in use. For detail
 """
 const VERSION = try
     ver = VersionNumber(VERSION_STRING)
-    if !isempty(ver.prerelease)
+    if !isempty(ver.prerelease) && !GIT_VERSION_INFO.tagged_commit
         if GIT_VERSION_INFO.build_number >= 0
             ver = VersionNumber(ver.major, ver.minor, ver.patch, (ver.prerelease..., GIT_VERSION_INFO.build_number), ver.build)
         else


### PR DESCRIPTION
In e.g. `1.5.0-rc2`:
```julia
julia> VERSION
v"1.5.0-rc2.0"
```
but since we are building for a tag it seems like it should just be
```julia
julia> VERSION
v"1.5.0-rc2"
```
similar to how we don't have
```julia
julia> VERSION
v"1.4.2-0"
```
in `1.4.2`