### PR TITLE
implement faster `issubset(::BitSet, BitSet)`

### DIFF
--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -416,7 +416,17 @@ function ==(s1::BitSet, s2::BitSet)
     return true
 end
 
-issubset(a::BitSet, b::BitSet) = a == intersect(a,b)
+function issubset(a::BitSet, b::BitSet)
+    n = length(a.bits)
+    shift = b.offset - a.offset
+    i, j = shift, shift + length(b.bits)
+
+    f(a, b) = a == a & b
+    return (
+        all(@inbounds iszero(a.bits[i]) for i in 1:min(n, i)) &&
+        all(@inbounds f(a.bits[i], b.bits[i - shift]) for i in max(1, i+1):min(n, j)) &&
+        all(@inbounds iszero(a.bits[i]) for i in max(1, j+1):n))
+end
 ⊊(a::BitSet, b::BitSet) = a <= b && a != b
 
 

--- a/test/bitset.jl
+++ b/test/bitset.jl
@@ -244,6 +244,9 @@ end
 
     @test issubset(BitSet([1, 2, 4]), BitSet(1:10))
     @test issubset(BitSet([]), BitSet([]))
+    @test issubset(BitSet([0]), BitSet([-1,0]))
+    @test !issubset(BitSet([-1]), BitSet([]))
+    @test !issubset(BitSet([65]), BitSet([]))
     @test BitSet([1, 2, 4]) < BitSet(1:10)
     @test !(BitSet([]) < BitSet([]))
     @test BitSet([1, 2, 4]) <= BitSet(1:10)


### PR DESCRIPTION
The new implementation avoids allocation completely and seems to be
consistently at least 3x faster even in the wort-case (large BitSet,
complete loop).

Some tests have been added to cover different early-return branches.

memo: the `BitSet` offsets make things unnecessarily complicated, implementing `BitSet` by storing positive/negative entries in two different vectors might be way simpler without sacrificing performance.