### PR TITLE
Cleanup of warnings in documentation admonitions

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -321,7 +321,7 @@ and take ownership of the fd handle.
 Call `open(Libc.dup(fd))` to avoid the ownership capture
 of the original handle.
 
-!!! warn
+!!! warning
     Do not call this on a handle that's already owned by some
     other part of the system.
 """

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -26,7 +26,7 @@ unbounded integers, the interval must be specified (e.g. `rand(big.(1:6))`).
 Additionally, normal and exponential distributions are implemented for some `AbstractFloat` and
 `Complex` types, see [`randn`](@ref) and [`randexp`](@ref) for details.
 
-!!! warn
+!!! warning
     Because the precise way in which random numbers are generated is considered an implementation detail, bug fixes and speed improvements may change the stream of numbers that are generated after a version change. Relying on a specific seed or generated stream of numbers during unit testing is thus discouraged - consider testing properties of the methods in question instead.
 
 ## Random numbers module


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/34670#issuecomment-667869199

Seems like they were missed, either when changing doc systems or when changing the keyword in the markdown parser.

If there are other places that I missed or other keywords that have not been changed, we can update those here as well.