### PR TITLE
Remove specialized PartialQuickSort{<:Integer} method

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -616,31 +616,8 @@ function sort!(v::AbstractVector, lo::Integer, hi::Integer, a::MergeSortAlg, o::
     return v
 end
 
-function sort!(v::AbstractVector, lo::Integer, hi::Integer, a::PartialQuickSort{<:Integer},
+function sort!(v::AbstractVector, lo::Integer, hi::Integer, a::PartialQuickSort,
                o::Ordering)
-    @inbounds while lo < hi
-        hi-lo <= SMALL_THRESHOLD && return sort!(v, lo, hi, SMALL_ALGORITHM, o)
-        j = partition!(v, lo, hi, o)
-        if j >= a.k
-            # we don't need to sort anything bigger than j
-            hi = j-1
-        elseif j-lo < hi-j
-            # recurse on the smaller chunk
-            # this is necessary to preserve O(log(n))
-            # stack space in the worst case (rather than O(n))
-            lo < (j-1) && sort!(v, lo, j-1, a, o)
-            lo = j+1
-        else
-            (j+1) < hi && sort!(v, j+1, hi, a, o)
-            hi = j-1
-        end
-    end
-    return v
-end
-
-
-function sort!(v::AbstractVector, lo::Integer, hi::Integer, a::PartialQuickSort{T},
-               o::Ordering) where T<:OrdinalRange
     @inbounds while lo < hi
         hi-lo <= SMALL_THRESHOLD && return sort!(v, lo, hi, SMALL_ALGORITHM, o)
         j = partition!(v, lo, hi, o)
@@ -650,6 +627,9 @@ function sort!(v::AbstractVector, lo::Integer, hi::Integer, a::PartialQuickSort{
         elseif j >= last(a.k)
             hi = j-1
         else
+            # recurse on the smaller chunk
+            # this is necessary to preserve O(log(n))
+            # stack space in the worst case (rather than O(n))
             if j-lo < hi-j
                 lo < (j-1) && sort!(v, lo, j-1, a, o)
                 lo = j+1


### PR DESCRIPTION
This specialized method is actually considerably slower than the one that also works for `PartialQuickSort{<:OrdinalRange}`. It had been removed before in 9e8fcd3 due to an inference issue, and reintroduced by c41d5a3 (#31632) once that issue got fixed, but apparently without benchmarks. It turns out that saving one comparison per iteration isn't worth it. The gain is especially large when looking for a value among the largest in the array, as the specialized method always sorted all values lower than the requested one (fixes #34233).

I must say I'm not completely sure why the specialized method is so slow. At least it's not due to a type instability.

Here are some benchmarks. I could only find one case (the 3rd one) where this PR is very slightly slower. In all other cases it's much faster (the gain could even be higher if looking for one of the few largest values in the array). I can add benchmarks to BaseBenchmarks if the PR sounds OK.
```
using BenchmarkTools
for len in (100, 10_000, 10_000_000),
    k in (len ÷ 9, len  ÷ 2, len - (len ÷ 9))
    @show len, k
    @btime partialsort!(x, $k) setup=(x=rand($len));
    @btime partialsort!(x, $k) setup=(x=rand(UInt8, $len));
    @btime partialsort!(x, $k) setup=(x=big.(rand($len)));
end

# master
(len, k) = (100, 11)
  558.107 ns (0 allocations: 0 bytes)
  91.105 ns (0 allocations: 0 bytes)
  3.441 μs (0 allocations: 0 bytes)
(len, k) = (100, 50)
  762.342 ns (0 allocations: 0 bytes)
  199.935 ns (0 allocations: 0 bytes)
  5.313 μs (0 allocations: 0 bytes)
(len, k) = (100, 89)
  1.537 μs (0 allocations: 0 bytes)
  327.360 ns (0 allocations: 0 bytes)
  9.592 μs (0 allocations: 0 bytes)
(len, k) = (10000, 1111)
  121.428 μs (0 allocations: 0 bytes)
  52.193 μs (0 allocations: 0 bytes)
  571.665 μs (0 allocations: 0 bytes)
(len, k) = (10000, 5000)
  517.929 μs (0 allocations: 0 bytes)
  240.547 μs (0 allocations: 0 bytes)
  2.030 ms (0 allocations: 0 bytes)
(len, k) = (10000, 8889)
  877.613 μs (0 allocations: 0 bytes)
  411.764 μs (0 allocations: 0 bytes)
  3.458 ms (0 allocations: 0 bytes)
(len, k) = (10000000, 1111111)
  242.663 ms (0 allocations: 0 bytes)
  83.886 ms (0 allocations: 0 bytes)
  3.427 s (0 allocations: 0 bytes)
(len, k) = (10000000, 5000000)
  981.472 ms (0 allocations: 0 bytes)
  302.894 ms (0 allocations: 0 bytes)
  11.731 s (0 allocations: 0 bytes)
(len, k) = (10000000, 8888889)
  1.605 s (0 allocations: 0 bytes)
  495.437 ms (0 allocations: 0 bytes)
  20.273 s (0 allocations: 0 bytes)

# This PR
(len, k) = (100, 11)
  555.332 ns (0 allocations: 0 bytes)
  87.643 ns (0 allocations: 0 bytes)
  3.536 μs (0 allocations: 0 bytes)
(len, k) = (100, 50)
  558.176 ns (0 allocations: 0 bytes)
  88.413 ns (0 allocations: 0 bytes)
  3.564 μs (0 allocations: 0 bytes)
(len, k) = (100, 89)
  563.253 ns (0 allocations: 0 bytes)
  62.689 ns (0 allocations: 0 bytes)
  3.081 μs (0 allocations: 0 bytes)
(len, k) = (10000, 1111)
  47.266 μs (0 allocations: 0 bytes)
  18.533 μs (0 allocations: 0 bytes)
  265.108 μs (0 allocations: 0 bytes)
(len, k) = (10000, 5000)
  93.967 μs (0 allocations: 0 bytes)
  17.005 μs (0 allocations: 0 bytes)
  434.462 μs (0 allocations: 0 bytes)
(len, k) = (10000, 8889)
  47.566 μs (0 allocations: 0 bytes)
  19.584 μs (0 allocations: 0 bytes)
  326.543 μs (0 allocations: 0 bytes)
(len, k) = (10000000, 1111111)
  65.597 ms (0 allocations: 0 bytes)
  32.917 ms (0 allocations: 0 bytes)
  960.879 ms (0 allocations: 0 bytes)
(len, k) = (10000000, 5000000)
  144.927 ms (0 allocations: 0 bytes)
  79.717 ms (0 allocations: 0 bytes)
  1.897 s (0 allocations: 0 bytes)
(len, k) = (10000000, 8888889)
  80.506 ms (0 allocations: 0 bytes)
  29.989 ms (0 allocations: 0 bytes)
  1.356 s (0 allocations: 0 bytes)
```