### PR TITLE
Add `parse()` and `tryparse()` for `VersionNumber`s

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -121,6 +121,18 @@ function VersionNumber(v::AbstractString)
     return VersionNumber(major, minor, patch, prerl, build)
 end
 
+parse(::Type{VersionNumber}, v::AbstractString) = VersionNumber(v)
+function tryparse(::Type{VersionNumber}, v::AbstractString)
+    try
+        return VersionNumber(v)
+    catch e
+        if isa(e, InterruptException)
+            rethrow(e)
+        end
+        return nothing
+    end
+end
+
 """
     @v_str
 

--- a/test/version.jl
+++ b/test/version.jl
@@ -79,6 +79,12 @@ using Random
 
 @test_throws ArgumentError VersionNumber(4, 3, 2, (), ("", 1))
 
+# parse()/tryparse()
+@test parse(VersionNumber, "1.2.3") == v"1.2.3"
+@test_throws ArgumentError parse(VersionNumber, "not a version")
+@test tryparse(VersionNumber, "3.2.1") == v"3.2.1"
+@test tryparse(VersionNumber, "not a version") === nothing
+
 # show
 io = IOBuffer()
 show(io,v"4.3.2+1.a")
@@ -227,3 +233,4 @@ io = IOBuffer()
 @test VersionNumber(true, 0x2, Int128(3), (GenericString("rc"), 0x1)) == v"1.2.3-rc.1"
 @test VersionNumber(true, 0x2, Int128(3), (GenericString("rc"), 0x1)) == v"1.2.3-rc.1"
 @test VersionNumber(true, 0x2, Int128(3), (), (GenericString("sp"), 0x2)) == v"1.2.3+sp.2"
+


### PR DESCRIPTION
This allows for a more consistent approach with `VersionNumbers` as
compared to other types that we may be parsing.