### PR TITLE
Fix spurious warning about suitesparse-wrapper version mismatch.

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -160,7 +160,7 @@ endif
 # unlist targets that have not been converted to use the staged-install
 DEP_LIBS_STAGED := $(filter-out suitesparse-wrapper,$(DEP_LIBS))
 ifneq ($(USE_BINARYBUILDER_LIBUNWIND),1)
-DEP_LIBS_STAGED := $(filter-out osxunwind,$(DEP_LIBS))
+DEP_LIBS_STAGED := $(filter-out osxunwind,$(DEP_LIBS_STAGED))
 endif
 
 

--- a/deps/tools/uninstallers.mk
+++ b/deps/tools/uninstallers.mk
@@ -26,7 +26,7 @@ $(addprefix version-check-,$(DEP_LIBS_STAGED)) : version-check-% : install-%
 	@if [ ! -e $(build_prefix)/manifest/$* ] || ( \
 			[ "1" != "`wc -w $(build_prefix)/manifest/$* | cut -f 1 -d ' '`" ] && \
 			[ "$(UNINSTALL_$*)" != "`cat $(build_prefix)/manifest/$*`" ]) ; then \
-		echo "WARNING: using mismatched version for $$(cat $(build_prefix)/manifest/$*):" ; \
+		echo "WARNING: using mismatched version for $$( if [ -e $(build_prefix)/manifest/$* ]; then cat $(build_prefix)/manifest/$*; else echo $*; fi):" ; \
 		echo "  want $(UNINSTALL_$*)" ; \
 		echo "  To resolve this warning, you could try either of the following suggestions: " ; \
 		echo "  1. Run the following command: make -C deps uninstall" ; \


### PR DESCRIPTION
Also make sure the warning print something more useful if the version file can't be found and don't print an error about file not found.