### PR TITLE
Fix docstring for `Val(c)` in order that `c` accepts a `Symbol`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -683,8 +683,8 @@ const (:) = Colon()
 
 Return `Val{c}()`, which contains no run-time data. Types like this can be used to
 pass the information between functions through the value `c`, which must be an `isbits`
-value. The intent of this construct is to be able to dispatch on constants directly (at
-compile time) without having to test the value of the constant at run time.
+value or a `Symbol`. The intent of this construct is to be able to dispatch on constants
+directly (at compile time) without having to test the value of the constant at run time.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This was mentioned on the slack. Even though a `Symbol` instance is not an `isbits` value, `Val{:symbol}` is valid.

Strictly speaking, a value of the composite type consisting of symbols and `isbits` values ​​is also available. However, I prefer simplicity here to strictness. I don't know whether there are any exceptions other than the `Symbol`.

```julia
julia> isbits(:symbol)
false

julia> Val(:symbol)
Val{:symbol}()

julia> isbits((:foo, 1))
false

julia> Val((:foo, 1))
Val{(:foo, 1)}()
```