### PR TITLE
Fixed description of nnz in documentation

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -44,7 +44,7 @@ In some applications, it is convenient to store explicit zero values in a `Spars
 *are* accepted by functions in `Base` (but there is no guarantee that they will be preserved in
 mutating operations). Such explicitly stored zeros are treated as structural nonzeros by many
 routines. The [`nnz`](@ref) function returns the number of elements explicitly stored in the
-sparse data structure, including structural nonzeros. In order to count the exact number of
+sparse data structure, including non-structural zeros. In order to count the exact number of
 numerical nonzeros, use [`count(!iszero, x)`](@ref), which inspects every stored element of a sparse
 matrix. [`dropzeros`](@ref), and the in-place [`dropzeros!`](@ref), can be used to
 remove stored zeros from the sparse matrix.


### PR DESCRIPTION
`nnz` counts the number of elements stored in the `SparseMatrixCSC`. "Structural nonzeros" is a tautology.