### PR TITLE
Add micro editor support

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -119,7 +119,7 @@ function define_default_editors()
     end
     # Must check that emacs not running in -t/-nw before regex match for general emacs
     define_editor([
-        "vim", "vi", "nvim", "mvim", "nano",
+        "vim", "vi", "nvim", "mvim", "nano", "micro",
         r"\bemacs\b.*\s(-nw|--no-window-system)\b",
         r"\bemacsclient\b.\s*-(-?nw|t|-?tty)\b"], wait=true) do cmd, path, line
         `$cmd +$line $path`


### PR DESCRIPTION
It's not clear to me that Base should offer specific support for all kinds of terminal-based editors, but as long at it does, it should at least support $MY_FAVORITE_EDITOR :)

This PR allows the `@edit` macro to work with the [Micro editor](https://micro-editor.github.io/) out of the box. 