### PR TITLE
Make UnformScaling inequal to matrices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@ New language features
 
 Language changes
 ----------------
+* Instances of `UniformScaling` can no longer compare equal to diagonal matrices.
+  Previous behavior violated the transitivity of `==` since previously,
+  `UniformScaling` compared equal to diagonal matrices of different sizes.
 
 
 Compiler/Runtime improvements

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -305,25 +305,6 @@ end
 
 ==(J1::UniformScaling,J2::UniformScaling) = (J1.λ == J2.λ)
 
-## equality comparison with UniformScaling
-==(J::UniformScaling, A::AbstractMatrix) = A == J
-function ==(A::AbstractMatrix, J::UniformScaling)
-    require_one_based_indexing(A)
-    size(A, 1) == size(A, 2) || return false
-    iszero(J.λ) && return iszero(A)
-    isone(J.λ) && return isone(A)
-    return A == J.λ*one(A)
-end
-function ==(A::StridedMatrix, J::UniformScaling)
-    size(A, 1) == size(A, 2) || return false
-    iszero(J.λ) && return iszero(A)
-    isone(J.λ) && return isone(A)
-    for j in axes(A, 2), i in axes(A, 1)
-        ifelse(i == j, A[i, j] == J.λ, iszero(A[i, j])) || return false
-    end
-    return true
-end
-
 function isapprox(J1::UniformScaling{T}, J2::UniformScaling{S};
             atol::Real=0, rtol::Real=Base.rtoldefault(T,S,atol), nans::Bool=false) where {T<:Number,S<:Number}
     isapprox(J1.λ, J2.λ, rtol=rtol, atol=atol, nans=nans)

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -45,6 +45,9 @@ end
 
 An object of type [`UniformScaling`](@ref), representing an identity matrix of any size.
 
+!!! compat "Julia 1.6"
+    From Julia 1.6, `UniformScaling` never compares equal to diagonal matrices.
+
 # Examples
 ```jldoctest
 julia> fill(1, (5,6)) * I == fill(1, (5,6))

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -376,29 +376,12 @@ end
 end
 
 @testset "equality comparison of matrices with UniformScaling" begin
-    # AbstractMatrix methods
-    diagI = Diagonal(fill(1, 3))
-    rdiagI = view(diagI, 1:2, 1:3)
-    bidiag = Bidiagonal(fill(2, 3), fill(2, 2), :U)
-    @test diagI  ==  I == diagI  # test isone(I) path / equality
-    @test 2diagI !=  I != 2diagI # test isone(I) path / inequality
-    @test 0diagI == 0I == 0diagI # test iszero(I) path / equality
-    @test 2diagI != 0I != 2diagI # test iszero(I) path / inequality
-    @test 2diagI == 2I == 2diagI # test generic path / equality
-    @test 0diagI != 2I != 0diagI # test generic path / inequality on diag
-    @test bidiag != 2I != bidiag # test generic path / inequality off diag
-    @test rdiagI !=  I != rdiagI # test square matrix check
-    # StridedMatrix specialization
     denseI = [1 0 0; 0 1 0; 0 0 1]
     rdenseI = [1 0 0 0; 0 1 0 0; 0 0 1 0]
     alltwos = fill(2, (3, 3))
-    @test denseI  ==  I == denseI  # test isone(I) path / equality
-    @test 2denseI !=  I != 2denseI # test isone(I) path / inequality
-    @test 0denseI == 0I == 0denseI # test iszero(I) path / equality
-    @test 2denseI != 0I != 2denseI # test iszero(I) path / inequality
-    @test 2denseI == 2I == 2denseI # test generic path / equality
-    @test 0denseI != 2I != 0denseI # test generic path / inequality on diag
-    @test alltwos != 2I != alltwos # test generic path / inequality off diag
+    @test denseI  !=  I != denseI  # test isone(I) path / inequality
+    @test 0denseI != 0I != 0denseI # test iszero(I) path / inequality
+    @test 2denseI != 2I != 2denseI # test generic path / inequality
     @test rdenseI !=  I != rdenseI # test square matrix check
 end
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2823,7 +2823,7 @@ end
     @test sparse([1,2,3,4,5]') == SparseMatrixCSC([1 2 3 4 5])
     @test sparse(UpperTriangular(A')) == UpperTriangular(B')
     @test sparse(Adjoint(UpperTriangular(A'))) == Adjoint(UpperTriangular(B'))
-    @test sparse(UnitUpperTriangular(spzeros(5,5))) == I
+    @test sparse(UnitUpperTriangular(spzeros(5,5))) == I(5)
     deepwrap(A) = (Adjoint(LowerTriangular(view(Symmetric(A), 5:7, 4:6))))
     @test sparse(deepwrap(A)) == Matrix(deepwrap(B))
 end


### PR DESCRIPTION
See issue JuliaLang/LinearAlgebra.jl#716 

This simply deletes the specialized code that previously made `UniformScaling` equal to identity matrices, such that it now just defaults back to the default implementation of `==`.