### PR TITLE
Prevent invalidations from eltype(::Type{<:NamedTuple})

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -161,7 +161,9 @@ function show(io::IO, t::NamedTuple)
     end
 end
 
-eltype(::Type{NamedTuple{names,T}} where names) where {T} = eltype(T)
+eltype(::Type{T}) where T<:NamedTuple = nteltype(T)
+nteltype(::Type) = Any
+nteltype(::Type{NamedTuple{names,T}} where names) where {T} = eltype(T)
 
 ==(a::NamedTuple{n}, b::NamedTuple{n}) where {n} = Tuple(a) == Tuple(b)
 ==(a::NamedTuple, b::NamedTuple) = false


### PR DESCRIPTION
This provides a fallback `eltype` method specialized for imprecise NamedTuple types. Formerly we were calling the generic eltype fallback `eltype(::Type) = Any`, but relying on the generic fallback makes code vulnerable to invalidation when new `eltype` methods are added. Since this affects any poorly-inferred keyword-arg function, it's best to isolate this by defining a specialization.

I think this closes #36892