### PR TITLE
remove unnecessary `AbstractEvalConstant` alias

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -884,7 +884,7 @@ function abstract_call_unionall(argtypes::Vector{Any})
             !isa(tv, TypeVar) && return Any
             body = UnionAll(tv, body)
         end
-        ret = canconst ? AbstractEvalConstant(body) : Type{body}
+        ret = canconst ? Const(body) : Type{body}
         return ret
     end
     return Any
@@ -1080,7 +1080,7 @@ end
 
 function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::VarTable, sv::InferenceState)
     if isa(e, QuoteNode)
-        return AbstractEvalConstant((e::QuoteNode).value)
+        return Const((e::QuoteNode).value)
     elseif isa(e, SSAValue)
         return abstract_eval_ssavalue(e::SSAValue, sv.src)
     elseif isa(e, Slot)
@@ -1089,7 +1089,7 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
         return abstract_eval_global(e.mod, e.name)
     end
 
-    return AbstractEvalConstant(e)
+    return Const(e)
 end
 
 function abstract_eval_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::VarTable, sv::InferenceState)
@@ -1231,7 +1231,7 @@ end
 
 function abstract_eval_global(M::Module, s::Symbol)
     if isdefined(M,s) && isconst(M,s)
-        return AbstractEvalConstant(getfield(M,s))
+        return Const(getfield(M,s))
     end
     return Any
 end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -6,8 +6,6 @@
 
 @nospecialize
 
-const AbstractEvalConstant = Const
-
 const _NAMEDTUPLE_NAME = NamedTuple.body.body.name
 
 const INT_INF = typemax(Int) # integer infinity
@@ -767,7 +765,7 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
                 if (fld == TYPENAME_NAME_FIELDINDEX ||
                     fld == TYPENAME_MODULE_FIELDINDEX ||
                     fld == TYPENAME_WRAPPER_FIELDINDEX)
-                    return AbstractEvalConstant(getfield(sv, fld))
+                    return Const(getfield(sv, fld))
                 end
             end
             if isa(sv, Module) && isa(nv, Symbol)
@@ -777,7 +775,7 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
                 return Bottom
             end
             if (isa(sv, SimpleVector) || !ismutable(sv)) && isdefined(sv, nv)
-                return AbstractEvalConstant(getfield(sv, nv))
+                return Const(getfield(sv, nv))
             end
         end
         s = typeof(sv)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -190,7 +190,7 @@ function argextype(@nospecialize(x), src, sptypes::Vector{Any}, slottypes::Vecto
             isa(src, IRCode) ? src.argtypes[x.n] :
             slottypes[x.n]
     elseif isa(x, QuoteNode)
-        return AbstractEvalConstant((x::QuoteNode).value)
+        return Const((x::QuoteNode).value)
     elseif isa(x, GlobalRef)
         return abstract_eval_global(x.mod, (x::GlobalRef).name)
     elseif isa(x, PhiNode)
@@ -198,7 +198,7 @@ function argextype(@nospecialize(x), src, sptypes::Vector{Any}, slottypes::Vecto
     elseif isa(x, PiNode)
         return x.typ
     else
-        return AbstractEvalConstant(x)
+        return Const(x)
     end
 end
 


### PR DESCRIPTION
- it's been as an alias to `Core.Const` and so there's been two ways to construct them, i.e. via `Const`'s constructor and `AbstractEvalCall`
- I think this indirection is unnecessary, but rather just confusing so I renamed all the `AbstractEvalConstant` to `Const`