### PR TITLE
Preserve non-concrete types in promote_typejoin

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -168,11 +168,29 @@ for T in (Nothing, Missing)
     @test Base.promote_typejoin(Int, T) === Union{Int, T}
     @test Base.promote_typejoin(T, String) === Union{T, String}
     @test Base.promote_typejoin(Vector{Int}, T) === Union{Vector{Int}, T}
-    @test Base.promote_typejoin(Vector, T) === Any
-    @test Base.promote_typejoin(Real, T) === Any
-    @test Base.promote_typejoin(Int, String) === Any
-    @test Base.promote_typejoin(Int, Union{Float64, T}) === Any
-    @test Base.promote_typejoin(Int, Union{String, T}) === Any
+    @test Base.promote_typejoin(Vector, T) === Union{Vector, T}
+    @test Base.promote_typejoin(Real, T) === Union{Real, T}
+    for U in (String, Float64)
+        @test Base.promote_typejoin(Int, U) === typejoin(Int, U)
+        @test Base.promote_typejoin(Int, Union{U, T}) === Union{typejoin(Int, U), T}
+        @test Base.promote_typejoin(Union{Int, U}, T) === Union{typejoin(Int, U), T}
+        @test Base.promote_typejoin(Union{T, U}, Int64) === Union{typejoin(Int, U), T}
+        @test Base.promote_typejoin(Union{T, U}, Union{T, Int64}) === Union{typejoin(Int, U), T}
+        @test Base.promote_typejoin(Union{T, U}, Union{Missing, Int64}) ===
+            Union{typejoin(Int, U), T, Missing}
+        @test Base.promote_typejoin(Union{T, U}, Union{Nothing, Int64}) ===
+            Union{typejoin(Int, U), T, Nothing}
+        @test Base.promote_typejoin(Union{T, Nothing, U}, Union{Nothing, Missing, Int64}) ===
+            Union{typejoin(Int, U), T, Nothing, Missing}
+        @test Base.promote_typejoin(Union{T, Missing, U}, Union{Nothing, Missing, Int64}) ===
+            Union{typejoin(Int, U), T, Nothing, Missing}
+        @test Base.promote_typejoin(Union{Nothing, Missing, U},
+                                    Union{Nothing, Missing, Int64}) ===
+            Union{typejoin(Int, U), Nothing, Missing}
+        @test Base.promote_typejoin(Union{Nothing, Missing, U},
+                                    Union{Nothing, Missing, Int64}) ===
+            Union{typejoin(Int, U), Nothing, Missing}
+    end
     @test Base.promote_typejoin(T, Union{}) === T
     @test Base.promote_typejoin(Union{}, T) === T
 end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -491,6 +491,11 @@ end
             @test_throws ArgumentError reduce(x -> x/2, itr)
             @test_throws ArgumentError mapreduce(x -> x/2, +, itr)
         end
+
+        # issue #35504
+        nt = NamedTuple{(:x, :y),Tuple{Union{Missing, Int},Union{Missing, Float64}}}(
+            (missing, missing))
+        @test sum(skipmissing(nt)) === 0
     end
 
     @testset "filter" begin

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -69,6 +69,8 @@ end
     NamedTuple{(:a,), Tuple{Union{Int,Nothing}}}((2,))
 
 @test eltype((a=[1,2], b=[3,4])) === Vector{Int}
+@test eltype(NamedTuple{(:x, :y),Tuple{Union{Missing, Int},Union{Missing, Float64}}}(
+    (missing, missing))) === Union{Real, Missing}
 
 @test Tuple((a=[1,2], b=[3,4])) == ([1,2], [3,4])
 @test Tuple(NamedTuple()) === ()


### PR DESCRIPTION
It is useful to have `promote_typejoin(Union{Missing, Int}, Float64}` return `Union{Missing, Real}` instead of `Any`, in particular because `zero` is defined on the former but not on the latter. This allows `sum(skipmissing(::NamedTuple))` to work even when it contains only missing values.

Fixes #35504.