### PR TITLE
Fix replace(::String, count=1) with empty pattern (issue #36953)

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -521,7 +521,7 @@ function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
             i = k = nextind(str, k)
         end
         r = something(findnext(pattern,str,k), 0)
-        r == 0:-1 || n == count && break
+        r === 0:-1 || n == count && break
         j, k = first(r), last(r)
         n += 1
     end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -297,6 +297,9 @@ end
     @test replace("a", in("a") => typeof) == "Char"
     @test replace("a", ['a'] => typeof) == "Char"
 
+    # Issue 36953
+    @test replace("abc", "" => "_", count=1) == "_abc"
+
 end
 
 @testset "chomp/chop" begin


### PR DESCRIPTION
Fixes #36953.