### PR TITLE
Short-circuit `replace` for `String`s when pattern is not found

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -507,6 +507,10 @@ function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
     pattern = _pat_replacer(pattern)
     r = something(findnext(pattern,str,i), 0)
     j, k = first(r), last(r)
+    if j == 0
+        _free_pat_replacer(pattern)
+        return str
+    end
     out = IOBuffer(sizehint=floor(Int, 1.2sizeof(str)))
     while j != 0
         if i == a || i <= k


### PR DESCRIPTION
This simply returns the original string if the pattern is not found (instead of allocating a new `IOBuffer`). This is considerably faster if the pattern is not found.

Before:
```julia
julia> @btime replace("abc", "e" => "f")
  173.027 ns (6 allocations: 288 bytes)
"abc"
```

After:
```julia
julia> @btime replace("abc", "e" => "f")
  37.549 ns (0 allocations: 0 bytes)
"abc"
```