### PR TITLE
Provide a better example for `get!(f::Function, collection, key)`

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -424,12 +424,25 @@ get!(collection, key, default)
 Return the value stored for the given key, or if no mapping for the key is present, store
 `key => f()`, and return `f()`.
 
-This is intended to be called using `do` block syntax:
-```julia
-get!(dict, key) do
-    # default value calculated here
-    time()
-end
+This is intended to be called using `do` block syntax.
+
+# Examples
+```jldoctest
+julia> squares = Dict{Int,Int}();
+
+julia> function get_square!(d, i)
+           get!(d, i) do
+               i^2
+           end
+       end
+get_square! (generic function with 1 method)
+
+julia> get_square!(squares, 2)
+4
+
+julia> squares
+Dict{Int64,Int64} with 1 entry:
+  2 => 4
 ```
 """
 get!(f::Function, collection, key)


### PR DESCRIPTION
I've needed `get!(f::Function, collection, key)` in the past, but the example given in the docstring was confusing or even actively misleading. So I didn't realize that `get!(f::Function, collection, key)` was in fact the right function. Instead, I ended up writing the naive code like this:

```julia
if haskey(d, k)
    return d[k]
else
    return d[k] = foo(a)
end
```

So, I've changed the example for `get!(f::Function, collection, key)`. I think the new example better motivates the usage of `get!`.

The example for `get(f::Function, collection, key)` (the non-mutating version) should probably also be updated. However, I'm actually not sure of a good example for the case where you don't update the dictionary.