### PR TITLE
Add `keytype` and `valtype` methods for `Pair`

### DIFF
--- a/base/pair.jl
+++ b/base/pair.jl
@@ -84,7 +84,7 @@ Get the key type of a pair type. Behaves similarly to [`eltype`](@ref).
 julia> keytype(Int32(1) => "foo")
 Int32
 
-julia> keytype(Pair(Int32(1) => "foo"))
+julia> keytype(Pair(Int32(1), "foo"))
 Int32
 ```
 """

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -73,3 +73,37 @@ end
 
 promote_rule(::Type{Pair{A1,B1}}, ::Type{Pair{A2,B2}}) where {A1,B1,A2,B2} =
     Pair{promote_type(A1, A2), promote_type(B1, B2)}
+
+"""
+    keytype(type)
+
+Get the key type of a pair type. Behaves similarly to [`eltype`](@ref).
+
+# Examples
+```jldoctest
+julia> keytype(Int32(1) => "foo")
+Int32
+
+julia> keytype(Pair(Int32(1) => "foo"))
+Int32
+```
+"""
+keytype(::Type{<:Pair{K,V}}) where {K,V} = K
+keytype(a::Pair) = keytype(typeof(a))
+
+"""
+    valtype(type)
+
+Get the value type of a pair type. Behaves similarly to [`eltype`](@ref).
+
+# Examples
+```jldoctest
+julia> valtype(Int32(1) => "foo")
+String
+
+julia> valtype(Pair(Int32(1), "foo"))
+String
+```
+"""
+valtype(::Type{<:Pair{K,V}}) where {K,V} = V
+valtype(a::Pair) = valtype(typeof(a))

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -31,6 +31,9 @@ using Random
     @test eltype(p) == Int
     @test eltype(4 => 5.6) == Union{Int,Float64}
     @test vcat(1 => 2.0, 1.0 => 2) == [1.0 => 2.0, 1.0 => 2.0]
+    @test valtype(4 => 5.6) == Float64
+    @test keytype(4 => 5.6) == Int
+    @test keytype(4 => ("a" => 1)) == Pair{String,Int}
 end
 
 @testset "Dict" begin


### PR DESCRIPTION
Closes #36968 . This is my first Julia PR.

Question on the docstrings - I copied the bulk of the contents from [abstractdict.jl](https://github.com/JuliaLang/julia/blob/dffc8895b897a78a8dca64c784962675df49c344/base/abstractdict.jl#L245) . I think the method signature should be more specific than what's in that docstring.

Should the docstring for the Pair version be the following?
```
valtype(::Pair)
valtype(p::Pair)
```
Should I change the Dict docstring from:

```
valtype(type)
```

to:

```
valtype(::AbstractDict)
valtype(a::AbstractDict)
```