### PR TITLE
Make sure global constants are recognized as such in our own pass

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -234,6 +234,11 @@ static Value *julia_pgv(jl_codectx_t &ctx, const char *cname, void *addr)
         gv = new GlobalVariable(*M, T_pjlvalue,
                                 false, GlobalVariable::PrivateLinkage,
                                 NULL, localname);
+    // LLVM passes sometimes strip metadata when moving load around
+    // since the load at the new location satisfy the same condition as the origional one.
+    // Mark the global as constant to LLVM code using our own metadata
+    // which is much less likely to be striped.
+    gv->setMetadata("julia.constgv", MDNode::get(gv->getContext(), None));
     assert(localname == gv->getName());
     assert(!gv->hasInitializer());
     return gv;

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1124,11 +1124,12 @@ static bool isLoadFromConstGV(LoadInst *LI)
 {
     // We only emit single slot GV in codegen
     // but LLVM global merging can change the pointer operands to GEPs/bitcasts
-    if (!isa<GlobalVariable>(LI->getPointerOperand()->stripInBoundsOffsets()))
-        return false;
-    MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
-    if (isTBAA(TBAA, {"jtbaa_const"}))
-        return true;
+    if (auto gv = dyn_cast<GlobalVariable>(LI->getPointerOperand()->stripInBoundsOffsets())) {
+        MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
+        if (isTBAA(TBAA, {"jtbaa_const"}) || gv->getMetadata("julia.constgv")) {
+            return true;
+        }
+    }
     return false;
 }
 


### PR DESCRIPTION
The metadata on the load may be striped by LLVM when moving code around.

Example of passes that does this is [LICM](https://github.com/llvm/llvm-project/blob/fb943696cbc695b28d7deabf8ee0d1b1a6cc605a/llvm/lib/Transforms/Scalar/LICM.cpp#L1643-L1652), which is actually already doing a better job then [some of the other places](https://github.com/llvm/llvm-project/search?q=dropUnknownNonDebugMetadata&unscoped_q=dropUnknownNonDebugMetadata).

This is a bit of a hack, but AFAICT, it is **NOT** an LLVM bug to remove tbaa and other metadata here, since in general, these metadata might be guarded by some other checks. (Maybe there could be an exception made for constant tbaa metadata here though). Almost all of our metadata are based on static type info and is legal to keep when moving code around but I don't see a way to convince LLVM about it. If there is a way that'll be a better fix though the current one should be pretty cheap.

Reduce `.text` in the sysimg by ~2%, which sounds like quite a few gc frame stores and write barriers....
