### PR TITLE
Mention export from InteractiveUtils in docs

### DIFF
--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -63,8 +63,8 @@ julia> InteractiveUtils.subtypes(AbstractFloat)
 Any abstract subtype will also be included in this list, but further subtypes thereof will not;
 recursive application of [`subtypes`](@ref) may be used to inspect the full type tree.
 
-Note that [`subtypes`](@ref) is located inside [`InteractiveUtils`](@ref) but is automatically
-exported when using the REPL.
+Note that [`subtypes`](@ref) is located inside [`InteractiveUtils`](@ref man-interactive-utils) but
+is automatically exported when using the REPL.
 
 ## DataType layout
 

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -51,7 +51,7 @@ The *direct* subtypes of any `DataType` may be listed using [`subtypes`](@ref). 
 the abstract `DataType` [`AbstractFloat`](@ref) has four (concrete) subtypes:
 
 ```jldoctest; setup = :(using InteractiveUtils)
-julia> subtypes(AbstractFloat)
+julia> InteractiveUtils.subtypes(AbstractFloat)
 5-element Vector{Any}:
  BigFloat
  Core.BFloat16
@@ -86,7 +86,7 @@ the unquoted and interpolated expression ([`Expr`](@ref)) form for a given macro
 be passed instead!). For example:
 
 ```jldoctest; setup = :(using InteractiveUtils)
-julia> macroexpand(@__MODULE__, :(@edit println("")) )
+julia> InteractiveUtils.macroexpand(@__MODULE__, :(@edit println("")) )
 :(InteractiveUtils.edit(println, (Base.typesof)("")))
 ```
 
@@ -143,8 +143,8 @@ For more information see [`@code_lowered`](@ref), [`@code_typed`](@ref), [`@code
 The aforementioned functions and macros take the keyword argument `debuginfo` that controls the level
 debug information printed.
 
-```julia-repl
-julia> @code_typed debuginfo=:source +(1,1)
+```jldoctest; setup = :(using InteractiveUtils)
+julia> InteractiveUtils.@code_typed debuginfo=:source +(1,1)
 CodeInfo(
     @ int.jl:53 within `+'
 1 ─ %1 = Base.add_int(x, y)::Int64

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -143,7 +143,7 @@ For more information see [`@code_lowered`](@ref), [`@code_typed`](@ref), [`@code
 The aforementioned functions and macros take the keyword argument `debuginfo` that controls the level
 debug information printed.
 
-```jldoctest; setup = :(using InteractiveUtils)
+```jldoctest; setup = :(using InteractiveUtils) filter=r"int.jl:\d+"
 julia> InteractiveUtils.@code_typed debuginfo=:source +(1,1)
 CodeInfo(
     @ int.jl:87 within `+'

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -61,7 +61,10 @@ julia> subtypes(AbstractFloat)
 ```
 
 Any abstract subtype will also be included in this list, but further subtypes thereof will not;
-recursive application of [`subtypes`](@ref) may be used to inspect the full type tree.
+recursive application of [`subtypes`](@ref) may be used to inspect the full type tree. 
+
+Note that [`subtypes`](@ref) is located inside [`InteractiveUtils`](@ref) but is automatically
+exported when using the REPL.
 
 ## DataType layout
 

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -143,7 +143,7 @@ For more information see [`@code_lowered`](@ref), [`@code_typed`](@ref), [`@code
 The aforementioned functions and macros take the keyword argument `debuginfo` that controls the level
 debug information printed.
 
-```jldoctest; setup = :(using InteractiveUtils) filter=r"int.jl:\d+"
+```jldoctest; setup = :(using InteractiveUtils), filter = r"int.jl:\d+"
 julia> InteractiveUtils.@code_typed debuginfo=:source +(1,1)
 CodeInfo(
     @ int.jl:87 within `+'

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -61,7 +61,7 @@ julia> InteractiveUtils.subtypes(AbstractFloat)
 ```
 
 Any abstract subtype will also be included in this list, but further subtypes thereof will not;
-recursive application of [`subtypes`](@ref) may be used to inspect the full type tree. 
+recursive application of [`subtypes`](@ref) may be used to inspect the full type tree.
 
 Note that [`subtypes`](@ref) is located inside [`InteractiveUtils`](@ref) but is automatically
 exported when using the REPL.

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -146,7 +146,7 @@ debug information printed.
 ```jldoctest; setup = :(using InteractiveUtils), filter = r"int.jl:\d+"
 julia> InteractiveUtils.@code_typed debuginfo=:source +(1,1)
 CodeInfo(
-    @ int.jl:87 within `+'
+    @ int.jl:87 within `+`
 1 ─ %1 = Base.add_int(x, y)::Int64
 └──      return %1
 ) => Int64

--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -146,7 +146,7 @@ debug information printed.
 ```jldoctest; setup = :(using InteractiveUtils)
 julia> InteractiveUtils.@code_typed debuginfo=:source +(1,1)
 CodeInfo(
-    @ int.jl:53 within `+'
+    @ int.jl:87 within `+'
 1 ─ %1 = Base.add_int(x, y)::Int64
 └──      return %1
 ) => Int64


### PR DESCRIPTION
I recently had a frustrating experience where seemingly valid code that worked in the REPL did not work in my own packages.

Specifically, it is not mentioned in the documentation that `subtypes` was being automatically exported from `InteractiveUtils` when using the REPL.
Thanks to @oheil for pointing this out (see exchange [here](https://discourse.julialang.org/t/error-with-base-generic-function-calls/44174)).

Although in my case I figured out that `subtypes` wasn't exactly what I needed, I still feel the documentation should be explicit about what functions are in Base and what functions aren't to avoid the kind of off-putting experience I had.

The change here isn't exhaustive but if there is agreement I'm willing to help update the documentation where needed.