### PR TITLE
Improve inferrability of generic matrix-vector multiplication

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -646,30 +646,34 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
 
     @inbounds begin
     if tA == 'T'  # fastest case
-        for k = 1:mA
-            aoffs = (k-1)*Astride
-            if mB == 0
-                s = false
-            else
+        if nA == 0
+            for k = 1:mA
+                _modify!(_add, false, C, k)
+            end
+        else
+            for k = 1:mA
+                aoffs = (k-1)*Astride
                 s = zero(A[aoffs + 1]*B[1] + A[aoffs + 1]*B[1])
+                for i = 1:nA
+                    s += transpose(A[aoffs+i]) * B[i]
+                end
+                _modify!(_add, s, C, k)
             end
-            for i = 1:nA
-                s += transpose(A[aoffs+i]) * B[i]
-            end
-            _modify!(_add, s, C, k)
         end
     elseif tA == 'C'
-        for k = 1:mA
-            aoffs = (k-1)*Astride
-            if mB == 0
-                s = false
-            else
+        if nA == 0
+            for k = 1:mA
+                _modify!(_add, false, C, k)
+            end
+        else
+            for k = 1:mA
+                aoffs = (k-1)*Astride
                 s = zero(A[aoffs + 1]*B[1] + A[aoffs + 1]*B[1])
+                for i = 1:nA
+                    s += A[aoffs + i]'B[i]
+                end
+                _modify!(_add, s, C, k)
             end
-            for i = 1:nA
-                s += A[aoffs + i]'B[i]
-            end
-            _modify!(_add, s, C, k)
         end
     else # tA == 'N'
         for i = 1:mA


### PR DESCRIPTION
This hoists some work-arounds for computation of eltypes for zero-size vectors out of the loops in order to get a speedup in some cases where type inference otherwise takes tuple types.

Thanks to https://github.com/JuliaLang/julia/issues/36941 for opening the issue.

Before:
```
julia> using BenchmarkTools
julia> N = 100;
julia> x0 = ones(N);
julia> A_t = transpose(ones(Int64, N, 5*N));
julia> @btime $A_t * $x0;
  103.525 μs (1 allocation: 4.06 KiB)
```
After:
```
julia> @btime $A_t * $x0;
  34.917 μs (1 allocation: 4.06 KiB)
```

I put partial blame on https://github.com/JuliaLang/julia/pull/35164. I verified that https://github.com/JuliaLang/LinearAlgebra.jl/issues/704 stays fixed.