### PR TITLE
Add an option to force codegen in imaging mode

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -44,6 +44,7 @@ struct JLOptions
     incremental::Int8
     image_file_specified::Int8
     warn_scope::Int8
+    image_codegen::Int8
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7475,7 +7475,7 @@ static void init_jit_functions(void)
 extern "C" void jl_init_llvm(void)
 {
     jl_page_size = jl_getpagesize();
-    imaging_mode = jl_generating_output() && !jl_options.incremental;
+    imaging_mode = jl_options.image_codegen || (jl_generating_output() && !jl_options.incremental);
     jl_default_cgparams.module_setup = jl_nothing;
     jl_default_cgparams.module_activation = jl_nothing;
     jl_default_cgparams.raise_exception = jl_nothing;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -47,9 +47,17 @@ void jl_link_global(GlobalVariable *GV, void *addr)
 {
     Constant *P = literal_static_pointer_val(addr, GV->getValueType());
     GV->setInitializer(P);
-    GV->setConstant(true);
-    GV->setLinkage(GlobalValue::PrivateLinkage);
-    GV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+    if (jl_options.image_codegen) {
+        // If we are forcing imaging mode codegen for debugging,
+        // emit external non-const symbol to avoid LLVM optimizing the code
+        // similar to non-imaging mode.
+        GV->setLinkage(GlobalValue::ExternalLinkage);
+    }
+    else {
+        GV->setConstant(true);
+        GV->setLinkage(GlobalValue::PrivateLinkage);
+        GV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+    }
 }
 
 void jl_jit_globals(std::map<void *, GlobalVariable*> &globals)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -73,7 +73,8 @@ jl_options_t jl_options = { 0,    // quiet
                             NULL,    // output-code_coverage
                             0, // incremental
                             0, // image_file_specified
-                            JL_OPTIONS_WARN_SCOPE_ON  // ambiguous scope warning
+                            JL_OPTIONS_WARN_SCOPE_ON,  // ambiguous scope warning
+                            0, // image-codegen
 };
 
 static const char usage[] = "julia [switches] -- [programfile] [args...]\n";
@@ -163,6 +164,7 @@ static const char opts_hidden[]  =
     " --output-incremental=no   Generate an incremental output file (rather than complete)\n"
     " --trace-compile={stderr,name}\n"
     "                           Print precompile statements for methods compiled during execution or save to a path\n\n"
+    " --image-codegen           Force generate code in imaging mode\n"
 ;
 
 JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
@@ -199,7 +201,8 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_compiled_modules,
            opt_machine_file,
            opt_project,
-           opt_bug_report
+           opt_bug_report,
+           opt_image_codegen,
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:it:p:O:g:";
     static const struct option longopts[] = {
@@ -250,6 +253,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "worker",          optional_argument, 0, opt_worker },
         { "bind-to",         required_argument, 0, opt_bind_to },
         { "lisp",            no_argument,       0, 1 },
+        { "image-codegen",   no_argument,       0, opt_image_codegen },
         { 0, 0, 0, 0 }
     };
 
@@ -647,6 +651,9 @@ restart_switch:
                 jl_options.handle_signals = JL_OPTIONS_HANDLE_SIGNALS_OFF;
             else
                 jl_errorf("julia: invalid argument to --handle-signals (%s)", optarg);
+            break;
+        case opt_image_codegen:
+            jl_options.image_codegen = 1;
             break;
         default:
             jl_errorf("julia: unhandled option -- %c\n"

--- a/src/julia.h
+++ b/src/julia.h
@@ -1994,6 +1994,7 @@ typedef struct {
     int8_t incremental;
     int8_t image_file_specified;
     int8_t warn_scope;
+    int8_t image_codegen;
 } jl_options_t;
 
 extern JL_DLLEXPORT jl_options_t jl_options;


### PR DESCRIPTION
This allows much easier debugging of imaging mode codegen
without hacks like specifying a dummy output and manually running
module init functions.

Also allows specializing codegen to give result more similar to
code in actual sysimg in this debugging mode. Ref #36974.