### PR TITLE
Allow LLVM to optimize GC write barriers for new objects

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -381,7 +381,10 @@ static Value *runtime_apply_type_env(jl_codectx_t &ctx, jl_value_t *ty)
                 ctx.spvals_ptr,
                 ConstantInt::get(T_size, sizeof(jl_svec_t) / sizeof(jl_value_t*)))
     };
-    return ctx.builder.CreateCall(prepare_call(jlapplytype_func), makeArrayRef(args));
+    auto call = ctx.builder.CreateCall(prepare_call(jlapplytype_func), makeArrayRef(args));
+    call->addAttribute(AttributeList::ReturnIndex,
+                       Attribute::getWithAlignment(jl_LLVMContext, Align(16)));
+    return call;
 }
 
 static const std::string make_errmsg(const char *fname, int n, const char *err)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -335,6 +335,11 @@ static unsigned julia_alignment(jl_value_t *jt)
         // Array always has this alignment
         return JL_SMALL_BYTE_ALIGNMENT;
     }
+    if (jt == (jl_value_t*)jl_datatype_type) {
+        // types are never allocated in julia code/on the stack
+        // and this is the guarantee we have for the GC bits
+        return 16;
+    }
     assert(jl_is_datatype(jt) && ((jl_datatype_t*)jt)->layout);
     unsigned alignment = jl_datatype_align(jt);
     if (alignment > JL_HEAP_ALIGNMENT)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -659,10 +659,13 @@ static const auto jlapplytype_func = new JuliaFunction{
     "jl_instantiate_type_in_env",
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
             {T_pjlvalue, T_pjlvalue, T_pprjlvalue}, false); },
-    [](LLVMContext &C) { return AttributeList::get(C,
+    [](LLVMContext &C) {
+        return AttributeList::get(C,
             AttributeSet(),
-            Attributes(C, {Attribute::NonNull}),
-            None); },
+            AttributeSet::get(C, makeArrayRef({Attribute::get(C, Attribute::NonNull),
+                                               Attribute::getWithAlignment(C, Align(16))})),
+            None);
+    },
 };
 static const auto jl_object_id__func = new JuliaFunction{
     "jl_object_id_",

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -S %s | FileCheck %s
 
-@tag = external addrspace(10) global {}
+@tag = external addrspace(10) global {}, align 16
 
 declare void @boxed_simple({} addrspace(10)*, {} addrspace(10)*)
 declare {} addrspace(10)* @jl_box_int64(i64)


### PR DESCRIPTION
Make alignment of tag more obvious for LLVM and
add a few optimization passes after GC lowering to let LLVM
delete some write barriers.

This fixes a regression from LLVM < 5 where the pass ordering makes this
happen automatically.

On top of https://github.com/JuliaLang/julia/pull/36970 and https://github.com/JuliaLang/julia/pull/36991, this reduces system image code size by 0.4%.

Testing this for sysimg code was the motivation for https://github.com/JuliaLang/julia/pull/36990 .
