### PR TITLE
make \ith alias for \planck

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -1654,6 +1654,7 @@ const latex_symbols = Dict(
     italic*"e" => "𝑒",  # mathematical italic small e
     italic*"f" => "𝑓",  # mathematical italic small f
     italic*"g" => "𝑔",  # mathematical italic small g
+    italic*"h" => "ℎ",  # mathematical italic small h (planck constant)
     italic*"i" => "𝑖",  # mathematical italic small i
     italic*"j" => "𝑗",  # mathematical italic small j
     italic*"k" => "𝑘",  # mathematical italic small k


### PR DESCRIPTION
`\planck` is also listed as a substitute [here](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols#Latin_letters), so I think this makes sense to add.