### PR TITLE
fix #36869, incorrect intersection with `Union` in supertype

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2760,7 +2760,7 @@ static jl_value_t *intersect_sub_datatype(jl_datatype_t *xd, jl_datatype_t *yd, 
     jl_value_t *isuper = R ? intersect((jl_value_t*)yd, (jl_value_t*)xd->super, e, param) :
                              intersect((jl_value_t*)xd->super, (jl_value_t*)yd, e, param);
     if (isuper == jl_bottom_type) return jl_bottom_type;
-    if (jl_nparams(xd) == 0 || jl_nparams(xd->super) == 0)
+    if (jl_nparams(xd) == 0 || jl_nparams(xd->super) == 0 || !jl_has_free_typevars(xd))
         return (jl_value_t*)xd;
     jl_value_t *super_pattern=NULL;
     JL_GC_PUSH2(&isuper, &super_pattern);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1759,3 +1759,10 @@ s26065 = Ref{Tuple{T,Ref{Union{Ref{Tuple{Ref{Union{Ref{Ref{Tuple{Ref{Tuple{Union
 # issue 36100
 @test NamedTuple{(:a, :b), Tuple{Missing, Union{}}} == NamedTuple{(:a, :b), Tuple{Missing, Union{}}}
 @test Val{Tuple{Missing, Union{}}} === Val{Tuple{Missing, Union{}}}
+
+# issue #36869
+struct F36869{T, V} <: AbstractArray{Union{T, V}, 1}
+end
+@testintersect(Tuple{Type{T}, AbstractVector{T}} where T,
+               Tuple{Union, F36869{Int64, Missing}},
+               Tuple{Union, F36869{Int64, Missing}})


### PR DESCRIPTION
I don't have a great solution to this, but fortunately in this case one of the types is concrete so a shortcut is possible.

The basic problem is the constraint `Union{T, S} == Union{A, B}`, where T and S are variables and A and B are types. We know the subtype relation holds, so that part is fine, but the values of T and S are not uniquely defined. In this case we were taking `T == Union{A, B}` and `S == A`. That makes it very difficult to use parameter values inferred from a supertype in intersection. As a next step we could perhaps try some heuristic for when it is "safe" to use the inferred values, e.g. if the variables appear as direct parameters of the supertype.

fixes #36869 