### PR TITLE
fix #28188: filename lost in cmd interpolation

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -386,5 +386,6 @@ Process(`echo 1`, ProcessExited(0))
 ```
 """
 macro cmd(str)
-    return :(cmd_gen($(esc(shell_parse(str, special=shell_special)[1]))))
+    cmd_ex = shell_parse(str, special=shell_special, filename=String(__source__.file))[1]
+    return :(cmd_gen($(esc(cmd_ex))))
 end

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -17,7 +17,7 @@ function rstrip_shell(s::AbstractString)
 end
 
 function shell_parse(str::AbstractString, interpolate::Bool=true;
-                     special::AbstractString="")
+                     special::AbstractString="", filename="none")
     s = SubString(str, firstindex(str))
     s = rstrip_shell(lstrip(s))
 
@@ -71,7 +71,8 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
                 # string interpolation syntax (see #3150)
                 ex, j = :var, stpos+3
             else
-                ex, j = Meta.parse(s,stpos,greedy=false)
+                # use parseatom instead of parse to respect filename (#28188)
+                ex, j = Meta.parseatom(s, stpos, filename=filename)
             end
             last_parse = (stpos:prevind(s, j)) .+ s.offset
             update_arg(ex);

--- a/test/cmd.jl
+++ b/test/cmd.jl
@@ -1,0 +1,2 @@
+# issue #28188
+@test `$(@__FILE__)` == let file = @__FILE__; `$file` end

--- a/test/cmd.jl
+++ b/test/cmd.jl
@@ -1,2 +1,0 @@
-# issue #28188
-@test `$(@__FILE__)` == let file = @__FILE__; `$file` end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -842,3 +842,8 @@ end
 @testset "fieldtypes Module" begin
     @test fieldtypes(Module) isa Tuple
 end
+
+
+@testset "issue #28188" begin
+    @test `$(@__FILE__)` == let file = @__FILE__; `$file` end
+end


### PR DESCRIPTION
Didn't really know where else to put this test, can certainly move this somewhere else,
fixes #28188, fixes #37005 