### PR TITLE
let getopt() handle `--`

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -201,10 +201,6 @@ end
 include_ifexists(mod::Module, path::AbstractString) = isfile(path) && include(mod, path)
 
 function exec_options(opts)
-    if !isempty(ARGS)
-        idxs = findall(x -> x == "--", ARGS)
-        length(idxs) > 0 && deleteat!(ARGS, idxs[1])
-    end
     quiet                 = (opts.quiet != 0)
     startup               = (opts.startupfile != 2)
     history_file          = (opts.historyfile != 0)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -262,17 +262,8 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
     const char **cmds = NULL;
     int codecov = JL_LOG_NONE;
     int malloclog = JL_LOG_NONE;
-    // getopt handles argument parsing up to -- delineator
     int argc = *argcp;
     char **argv = *argvp;
-    if (argc > 0) {
-        for (int i = 0; i < argc; i++) {
-            if (!strcmp(argv[i], "--")) {
-                argc = i;
-                break;
-            }
-        }
-    }
     char *endptr;
     opterr = 0; // suppress getopt warning messages
     while (1) {

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -452,10 +452,20 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
         withenv((Sys.iswindows() ? "USERPROFILE" : "HOME") => dir) do
             output = "[\"foo\", \"-bar\", \"--baz\"]"
             @test readchomp(`$exename $testfile foo -bar --baz`) == output
-            @test readchomp(`$exename $testfile -- foo -bar --baz`) == output
+            @test readchomp(`$exename -- $testfile foo -bar --baz`) == output
             @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar --baz`) ==
                 output
             @test readchomp(`$exename --startup-file=yes -e 'exit(0)' -- foo -bar --baz`) ==
+                output
+
+            output = "[\"foo\", \"--\", \"-bar\", \"--baz\"]"
+            @test readchomp(`$exename $testfile foo -- -bar --baz`) == output
+            @test readchomp(`$exename -- $testfile foo -- -bar --baz`) == output
+            @test readchomp(`$exename -L $testfile -e 'exit(0)' foo -- -bar --baz`) ==
+                output
+            @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -- -bar --baz`) ==
+                output
+            @test readchomp(`$exename --startup-file=yes -e 'exit(0)' foo -- -bar --baz`) ==
                 output
 
             output = "String[]\nString[]"
@@ -463,8 +473,6 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
             @test readchomp(`$exename --startup-file=yes $testfile`) == output
 
             @test !success(`$exename --foo $testfile`)
-            @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar -- baz`) ==
-                "[\"foo\", \"-bar\", \"--\", \"baz\"]"
         end
     end
 


### PR DESCRIPTION
This is a proposed fix for #37009. It removes manual processing of `--` and relies on `getopt()` to handle it correctly. The expected behavior:
1. If `--` appears before the first non-option argument, it forces the end of option processing and does not appear in `ARGS`.
2. If `--` appears after a non-option argument, it is preserved in `ARGS`. This `--` has no effect on option processing since it's already stopped on the first non-option argument.