### PR TITLE
yield: reduce DEFAULT_THREAD_SLEEP_THRESHOLD timeout

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -120,7 +120,7 @@
 
 // controls for when threads sleep
 #define THREAD_SLEEP_THRESHOLD_NAME     "JULIA_THREAD_SLEEP_THRESHOLD"
-#define DEFAULT_THREAD_SLEEP_THRESHOLD  4*1000*1000 // nanoseconds (4ms)
+#define DEFAULT_THREAD_SLEEP_THRESHOLD  16*1000 // nanoseconds (16us)
 
 // defaults for # threads
 #define NUM_THREADS_NAME                "JULIA_NUM_THREADS"


### PR DESCRIPTION
This defines how much time we waste before letting another process run.
Until we have performance measurements, this should probably be small.

Closes #36952