### PR TITLE
REPL: assure the compiler that line::String

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -985,7 +985,7 @@ function setup_interface(
         # special)
         on_done = respond(repl, julia_prompt) do line
             Expr(:call, :(Base.repl_cmd),
-                :(Base.cmd_gen($(Base.shell_parse(line)[1]))),
+                :(Base.cmd_gen($(Base.shell_parse(line::String)[1]))),
                 outstream(repl))
         end)
 


### PR DESCRIPTION
This has been sitting in my local checkout for a while, and sadly I no longer remember what prompted it or how many invalidations it fixed. However, this seems very safe because of [this line](https://github.com/JuliaLang/julia/blob/7b9a9413941670ef5a238c3889db27505d3a83ce/stdlib/REPL/src/REPL.jl#L854).