### PR TITLE
Preserve non-concrete types in promote_typejoin

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -128,20 +128,12 @@ Compute a type that contains both `T` and `S`, which could be
 either a parent of both types, or a `Union` if appropriate.
 Falls back to [`typejoin`](@ref).
 """
-promote_typejoin(@nospecialize(a), @nospecialize(b)) = _promote_typejoin(a, b)::Type
-_promote_typejoin(@nospecialize(a), @nospecialize(b)) = typejoin(a, b)
-_promote_typejoin(::Type{Nothing}, ::Type{T}) where {T} =
-    isconcretetype(T) || T === Union{} ? Union{T, Nothing} : Any
-_promote_typejoin(::Type{T}, ::Type{Nothing}) where {T} =
-    isconcretetype(T) || T === Union{} ? Union{T, Nothing} : Any
-_promote_typejoin(::Type{Missing}, ::Type{T}) where {T} =
-    isconcretetype(T) || T === Union{} ? Union{T, Missing} : Any
-_promote_typejoin(::Type{T}, ::Type{Missing}) where {T} =
-    isconcretetype(T) || T === Union{} ? Union{T, Missing} : Any
-_promote_typejoin(::Type{Nothing}, ::Type{Missing}) = Union{Nothing, Missing}
-_promote_typejoin(::Type{Missing}, ::Type{Nothing}) = Union{Nothing, Missing}
-_promote_typejoin(::Type{Nothing}, ::Type{Nothing}) = Nothing
-_promote_typejoin(::Type{Missing}, ::Type{Missing}) = Missing
+function promote_typejoin(@nospecialize(a), @nospecialize(b))
+    c = typejoin(_promote_typesubtract(a), _promote_typesubtract(b))
+    return Union{a, b, c}::Type
+end
+_promote_typesubtract(@nospecialize(a)) = Core.Compiler.typesubtract(a, Union{Nothing, Missing})
+
 
 # Returns length, isfixed
 function full_va_len(p)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -113,22 +113,32 @@ function eltype(t::Type{<:Tuple{Vararg{E}}}) where {E}
     end
 end
 eltype(t::Type{<:Tuple}) = _compute_eltype(t)
-function _compute_eltype(t::Type{<:Tuple})
+function _tuple_unique_fieldtypes(@nospecialize t)
     @_pure_meta
-    @nospecialize t
-    t isa Union && return promote_typejoin(eltype(t.a), eltype(t.b))
+    types = IdSet()
+    t´ = unwrap_unionall(t)
     # Given t = Tuple{Vararg{S}} where S<:Real, the various
     # unwrapping/wrapping/va-handling here will return Real
-    t´ = unwrap_unionall(t)
-    # TODO: handle Union/UnionAll correctly here
-    # For Tuple{T}, short-circuit promote_typejoin
-    length(t´.parameters) == 1 && return rewrap_unionall(unwrapva(t´.parameters[1]), t)
-    r = Union{}
-    for ti in t´.parameters
-        r = promote_typejoin(r, rewrap_unionall(unwrapva(ti), t))
-        r === Any && break   # if we've already reached Any, it can't widen any more
+    if t isa Union
+        union!(types, _tuple_unique_fieldtypes(rewrap_unionall(t´.a, t)))
+        union!(types, _tuple_unique_fieldtypes(rewrap_unionall(t´.b, t)))
+    else
+        r = Union{}
+        for ti in (t´::DataType).parameters
+            r = push!(types, rewrap_unionall(unwrapva(ti), t))
+        end
     end
-    return r
+    return Core.svec(types...)
+end
+function _compute_eltype(@nospecialize t)
+    @_pure_meta # TODO: the compiler shouldn't need this
+    types = _tuple_unique_fieldtypes(t)
+    return afoldl(types...) do a, b
+        # if we've already reached Any, it can't widen any more
+        a === Any && return Any
+        b === Any && return Any
+        return promote_typejoin(a, b)
+    end
 end
 
 # version of tail that doesn't throw on empty tuples (used in array indexing)

--- a/test/core.jl
+++ b/test/core.jl
@@ -168,11 +168,21 @@ for T in (Nothing, Missing)
     @test Base.promote_typejoin(Int, T) === Union{Int, T}
     @test Base.promote_typejoin(T, String) === Union{T, String}
     @test Base.promote_typejoin(Vector{Int}, T) === Union{Vector{Int}, T}
-    @test Base.promote_typejoin(Vector, T) === Any
-    @test Base.promote_typejoin(Real, T) === Any
-    @test Base.promote_typejoin(Int, String) === Any
-    @test Base.promote_typejoin(Int, Union{Float64, T}) === Any
-    @test Base.promote_typejoin(Int, Union{String, T}) === Any
+    @test Base.promote_typejoin(Vector, T) === Union{Vector, T}
+    @test Base.promote_typejoin(Real, T) === Union{Real, T}
+    for U in (String, Float64)
+        @test Base.promote_typejoin(Int, U) === typejoin(Int, U)
+        @test Base.promote_typejoin(Int, Union{U, T}) === Union{typejoin(Int, U), T}
+        @test Base.promote_typejoin(Union{Int, U}, T) === Union{Union{Int, U}, T}
+        @test Base.promote_typejoin(Union{T, U}, Int) === Union{typejoin(Int, U), T}
+        @test Base.promote_typejoin(Union{T, U}, Union{T, Int}) === Union{typejoin(Int, U), T}
+        @test Base.promote_typejoin(Union{T, U}, Union{Missing, Int}) ===
+            Union{typejoin(Int, U), T, Missing}
+        @test Base.promote_typejoin(Union{T, U}, Union{Nothing, Int}) ===
+            Union{typejoin(Int, U), T, Nothing}
+        @test Base.promote_typejoin(Union{T, Nothing, U}, Union{Nothing, Missing, Int}) ===
+            Union{typejoin(Int, U), T, Nothing, Missing}
+    end
     @test Base.promote_typejoin(T, Union{}) === T
     @test Base.promote_typejoin(Union{}, T) === T
 end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -491,6 +491,11 @@ end
             @test_throws ArgumentError reduce(x -> x/2, itr)
             @test_throws ArgumentError mapreduce(x -> x/2, +, itr)
         end
+
+        # issue #35504
+        nt = NamedTuple{(:x, :y),Tuple{Union{Missing, Int},Union{Missing, Float64}}}(
+            (missing, missing))
+        @test sum(skipmissing(nt)) === 0
     end
 
     @testset "filter" begin

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -69,6 +69,8 @@ end
     NamedTuple{(:a,), Tuple{Union{Int,Nothing}}}((2,))
 
 @test eltype((a=[1,2], b=[3,4])) === Vector{Int}
+@test eltype(NamedTuple{(:x, :y),Tuple{Union{Missing, Int},Union{Missing, Float64}}}(
+    (missing, missing))) === Union{Real, Missing}
 
 @test Tuple((a=[1,2], b=[3,4])) == ([1,2], [3,4])
 @test Tuple(NamedTuple()) === ()


### PR DESCRIPTION
It is useful to have `promote_typejoin(Union{Missing, Int}, Float64}` return
`Union{Missing, Real}` instead of `Any`, in particular because `zero` is defined
on the former but not on the latter. This allows `sum(skipmissing(::NamedTuple))`
to work even when it contains only missing values.

This function, in theory, in the past was overloadable, but coverage of input types was actually rather poor previously already (one of the new tests in #36939 seemed wrong for `Base.promote_typejoin(Union{Int, U}, T) === Union{Union{Int, U}, T}`) despite an exponential increase in methods required for each new type overloaded (thus making it infeasible to correctly ever overload this function).

Fixes #35504, Closes #36939

Co-authored-by: Milan Bouchet-Valat <nalimilan@club.fr>