### PR TITLE
Head off invalidations in to_indices for NTuple{N,Int}

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -323,6 +323,7 @@ to_indices(A, I::Tuple{Any}) = (@_inline_meta; to_indices(A, (eachindex(IndexLin
 # In simple cases, we know that we don't need to use axes(A), optimize those.
 # Having this here avoids invalidations from multidimensional.jl: to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex}}})
 to_indices(A, I::Tuple{}) = ()
+to_indices(A, I::Tuple{Vararg{Int}}) = I
 to_indices(A, I::Tuple{Vararg{Integer}}) = (@_inline_meta; to_indices(A, (), I))
 to_indices(A, inds, ::Tuple{}) = ()
 to_indices(A, inds, I::Tuple{Any, Vararg{Any}}) =


### PR DESCRIPTION
The most common argument type for `to_indices` is a tuple of `Int`, yet we rely on the `Integer` fallback. This makes it vulnerable to invalidation by methods like [this one](https://github.com/JuliaMath/Interpolations.jl/blob/bcd05a3f0843661104589c31da8d257fecdbe265/src/Interpolations.jl#L273) which would rather convert non-`Int` integers. This prevents approximately 80 MethodInstance invalidations.