### PR TITLE
Fix type of allocated array when broadcasting type unstable function

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1029,7 +1029,7 @@ function copyto_nonleaf!(dest, bc::Broadcasted, iter, state, count)
         else
             # This element type doesn't fit in dest. Allocate a new dest with wider eltype,
             # copy over old values, and continue
-            newdest = Base.similar(dest, promote_typejoin(T, typeof(val)))
+            newdest = Base.similar(bc, promote_typejoin(T, typeof(val)))
             return restart_copyto_nonleaf!(newdest, dest, bc, val, I, iter, state, count)
         end
         count += 1

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -510,13 +510,17 @@ Base.BroadcastStyle(::Type{T}) where {T<:AD2Dim} = AD2DimStyle()
     aa = Array19745(a)
     fadd(aa) = aa .+ 1
     fadd2(aa) = aa .+ 1 .* 2
+    fadd3(aa) = aa .+ [missing; 1:9]
     fprod(aa) = aa .* aa'
     @test a .+ 1  == @inferred(fadd(aa))
     @test a .+ 1 .* 2  == @inferred(fadd2(aa))
     @test a .* a' == @inferred(fprod(aa))
+    @test isequal(a .+ [missing; 1:9], fadd3(aa))
+    @test_broken Core.Compiler.return_type(fadd3, (typeof(aa),)) <: Array19745{<:Union{Float64, Missing}}
     @test isa(aa .+ 1, Array19745)
     @test isa(aa .+ 1 .* 2, Array19745)
     @test isa(aa .* aa', Array19745)
+    @test isa(aa .* [missing; 1:9], Array19745)
     a1 = AD1(rand(2,3))
     a2 = AD2(rand(2))
     @test a1 .+ 1 isa AD1


### PR DESCRIPTION
We need to call similar on the `Broadcasted` object rather than on dest array. Otherwise the `BroadcastStyle` isn't taken into account when allocating new array due to function returning elements of different types.

See https://github.com/JuliaLang/julia/issues/36106#issuecomment-637022450.