### PR TITLE
Optimize write barrier when the child is a perminately allocated object

### DIFF
--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include <utility>
+#include <llvm/ADT/ArrayRef.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/IR/DebugLoc.h>
 #include <llvm/IR/IRBuilder.h>
@@ -30,10 +31,10 @@ struct CountTrackedPointers {
 
 #if JL_LLVM_VERSION >= 110000
 unsigned TrackWithShadow(llvm::Value *Src, llvm::Type *T, bool isptr, llvm::Value *Dst, llvm::IRBuilder<> &irbuilder);
-std::vector<llvm::Value*> ExtractTrackedValues(llvm::Value *Src, llvm::Type *STy, bool isptr, llvm::IRBuilder<> &irbuilder);
+std::vector<llvm::Value*> ExtractTrackedValues(llvm::Value *Src, llvm::Type *STy, bool isptr, llvm::IRBuilder<> &irbuilder, llvm::ArrayRef<unsigned> perm_offsets={});
 #else
 unsigned TrackWithShadow(llvm::Value *Src, llvm::Type *T, bool isptr, llvm::Value *Dst, llvm::IRBuilder<> irbuilder);
-std::vector<llvm::Value*> ExtractTrackedValues(llvm::Value *Src, llvm::Type *STy, bool isptr, llvm::IRBuilder<> irbuilder);
+std::vector<llvm::Value*> ExtractTrackedValues(llvm::Value *Src, llvm::Type *STy, bool isptr, llvm::IRBuilder<> irbuilder, llvm::ArrayRef<unsigned> perm_offsets={});
 #endif
 
 static inline void llvm_dump(llvm::Value *v)


### PR DESCRIPTION
Currently support `Int8`, `UInt8` and `Symbol`.
Most useful for `Symbol` since box with known `Int8` or `UInt8` types are almost always allocated locally which now automatically handled by our llvm pass after https://github.com/JuliaLang/julia/pull/36991.

I believe this is the correct way / place to do this. Passing this information to LLVM passes without overhead and without causing any visible change to llvmcall (since this should be an optimization) seems quite hard... As long as type inference is doing a good job there should be little optimization opportunity missing here.

Another 0.4% reduction in sysimg code size...
