### PR TITLE
Mark load from DataType as constant

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -866,6 +866,9 @@ static void add_return_attr(T *f, Attribute::AttrKind Kind)
 
 static MDNode *best_tbaa(jl_value_t *jt) {
     jt = jl_unwrap_unionall(jt);
+    if (jt == (jl_value_t*)jl_datatype_type ||
+        (jl_is_type_type(jt) && jl_is_datatype(jl_tparam0(jt))))
+        return tbaa_const;
     if (!jl_is_datatype(jt))
         return tbaa_value;
     if (jl_is_abstracttype(jt))


### PR DESCRIPTION
This is marked as mutable type only to give it the correct storage type and stable pointer address. There's no reason to penalize reader of type properties... Also, since we never allocate `DataType` in LLVM, we can go straight to `tbaa_const` skipping `tbaa_immut`.

Another 0.15% reduction in sysimg code size...
