### PR TITLE
fix #37033, avoid backedges from default `include` definition

### DIFF
--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -191,11 +191,11 @@
        (= (call include ,x)
           (block
            ,@loc
-           (call (top include) ,name ,x)))
+           (call (core _apply_latest) (top include) (call (core svec) ,name ,x))))
        (= (call include (:: ,mex (top Function)) ,x)
           (block
            ,@loc
-           (call (top include) ,mex ,name ,x)))))
+           (call (core _apply_latest) (top include) (call (core svec) ,mex ,name ,x))))))
    'none 0))
 
 ; run whole frontend on a string. useful for testing.


### PR DESCRIPTION
fix #37033