### PR TITLE
Mark array/string/svec size range

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1683,7 +1683,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                 LoadInst *load = ctx.builder.CreateAlignedLoad(T_prjlvalue, slot_addr, sizeof(void*));
                 load->setAtomic(AtomicOrdering::Unordered);
                 tbaa_decorate(tbaa_ptrarraybuf, load);
-                Value *res = ctx.builder.CreateZExt(ctx.builder.CreateICmpNE(load, Constant::getNullValue(T_prjlvalue)), T_int32);
+                Value *res = ctx.builder.CreateZExt(ctx.builder.CreateICmpNE(load, V_rnull), T_int32);
                 JL_GC_POP();
                 return mark_or_box_ccall_result(ctx, res, retboxed, rt, unionall, static_rt);
             }


### PR DESCRIPTION
We require the length and size to both be signed integer so mark them as such for LLVM.
This helps removing some unnecessary sign checks when calling C functions that expect a `size_t`.

Also includes some minor clean up on global constants in codegen and return types.

1.7% reduction in sysimg code size... Quite a bit more significant than what I expected...
