### PR TITLE
small printing improvement for invalid macrocall

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1747,7 +1747,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
         print(io, head, ' ')
         show_list(io, allow_macroname.(args), ", ", indent)
 
-    elseif head === :macrocall && nargs >= 2
+    elseif head === :macrocall && nargs >= 2 && args[2] isa LineNumberNode
         # handle some special syntaxes
         # `a b c`
         if is_core_macro(args[1], "@cmd")


### PR DESCRIPTION
We probably don't want to do this kind of checking everywhere, but it was useful for me for debugging and also shouldn't really hurt anything.