### PR TITLE
Let `muladd` accept arrays

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -183,6 +183,37 @@ for elty in (Float32,Float64)
 end
 
 """
+    muladd(A, y, z)
+
+Combined multiply-add, `A*y .+ z`, for either matrix-matrix multiplication or
+matrix-vector multiplication. The result is always the size of `A*y`, although
+`z` have fewer dimensions.
+
+# Examples
+```jldoctest
+julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; C=[0, 100];
+
+julia> muladd(A, B, C)
+2×2 Matrix{Float64}:
+   3.0    3.0
+ 107.0  107.0
+```
+"""
+function Base.muladd(A::AbstractMatrix{TA}, y::AbstractVector{Ty}, z::AbstractVector{Tz}) where {TA, Ty, Tz}
+    T = promote_type(TA, Ty, Tz)
+    C = similar(A, T, size(A,1))
+    C .= z
+    mul!(C, A, y, true, true)
+end
+
+function Base.muladd(A::AbstractMatrix{TA}, y::AbstractMatrix{Ty}, z::AbstractVecOrMat{Tz}) where {TA, Ty, Tz}
+    T = promote_type(TA, Ty, Tz)
+    C = similar(A, T, size(A,1), size(y,2))
+    C .= z
+    mul!(C, A, y, true, true)
+end
+
+"""
     mul!(Y, A, B) -> Y
 
 Calculates the matrix-matrix or matrix-vector product ``AB`` and stores the result in `Y`,

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -185,9 +185,8 @@ end
 """
     muladd(A, y, z)
 
-Combined multiply-add, `A*y .+ z`, for either matrix-matrix multiplication or
-matrix-vector multiplication. The result is always the size of `A*y`, although
-`z` may have fewer dimensions.
+Combined multiply-add, `A*y .+ z`, for matrix-matrix or matrix-vector multiplication.
+The result is always the size of `A*y`, but `z` may be smaller, or a scalar.
 
 !!! compat "Julia 1.6"
      These methods require Julia 1.6 or later.
@@ -220,18 +219,13 @@ Base.muladd(x::AdjointAbsVec, A::AbstractMatrix, z) = muladd(A', x', z')'
 Base.muladd(x::TransposeAbsVec, A::AbstractMatrix, z) = transpose(muladd(transpose(A), transpose(x), transpose(z)))
 
 function Base.muladd(u::AbstractVector, v::AdjOrTransAbsVec, z)
-    if z isa AbstractArray
-        ndims(z) > 2 && throw(DimensionMismatch("cannot broadcast array to have fewer dimensions"))
-    end
+    ndims(z) > 2 && throw(DimensionMismatch("cannot broadcast array to have fewer dimensions"))
     (u .* v) .+ z
 end
 
 function Base.muladd(u::AdjOrTransAbsVec, v::AbstractVector, z)
     uv = _dot_nonrecursive(u, v)
-    if z isa AbstractArray
-        uv isa AbstractArray && ndims(uv) <= ndims(z) ||
-            throw(DimensionMismatch("cannot broadcast array to have fewer dimensions"))
-    end
+    ndims(z) > ndims(uv) && throw(DimensionMismatch("cannot broadcast array to have fewer dimensions"))
     uv .+ z
 end
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -186,16 +186,16 @@ end
     muladd(A, y, z)
 
 Combined multiply-add, `A*y .+ z`, for matrix-matrix or matrix-vector multiplication.
-The result is always the size of `A*y`, but `z` may be smaller, or a scalar.
+The result is always the same size as `A*y`, but `z` may be smaller, or a scalar.
 
 !!! compat "Julia 1.6"
      These methods require Julia 1.6 or later.
 
 # Examples
 ```jldoctest
-julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; C=[0, 100];
+julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; z=[0, 100];
 
-julia> muladd(A, B, C)
+julia> muladd(A, B, z)
 2×2 Matrix{Float64}:
    3.0    3.0
  107.0  107.0

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -203,14 +203,14 @@ julia> muladd(A, B, C)
 ```
 """
 function Base.muladd(A::AbstractMatrix{TA}, y::AbstractVector{Ty}, z) where {TA, Ty}
-    T = promote_type(TA, Ty, z isa AbstractArray ? eltype(z) : typeof(z))
+    T = promote_type(TA, Ty, eltype(z))
     C = similar(A, T, axes(A,1))
     C .= z
     mul!(C, A, y, true, true)
 end
 
 function Base.muladd(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}, z) where {TA, TB}
-    T = promote_type(TA, TB, z isa AbstractArray ? eltype(z) : typeof(z))
+    T = promote_type(TA, TB, eltype(z))
     C = similar(A, T, axes(A,1), axes(B,2))
     C .= z
     mul!(C, A, B, true, true)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -187,7 +187,10 @@ end
 
 Combined multiply-add, `A*y .+ z`, for either matrix-matrix multiplication or
 matrix-vector multiplication. The result is always the size of `A*y`, although
-`z` have fewer dimensions.
+`z` may have fewer dimensions.
+
+!!! compat "Julia 1.6"
+     These methods require Julia 1.6 or later.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -323,6 +323,15 @@ end
     @test muladd(u2', u2, 0) isa Number
     @test muladd(v3', v3, im) == dot(v3,v3) + im
     @test_throws DimensionMismatch muladd(v3', v3, [1])
+
+    vofm = [rand(1:9,2,2) for _ in 1:3]
+    Mofm = [rand(1:9,2,2) for _ in 1:3, _ in 1:3]
+
+    @test muladd(vofm', vofm, vofm[1]) == vofm' * vofm .+ vofm[1] # inner
+    @test muladd(vofm, vofm', Mofm) == vofm * vofm' .+ Mofm       # outer
+    @test muladd(vofm', Mofm, vofm') == vofm' * Mofm .+ vofm'     # bra-mat
+    @test muladd(Mofm, Mofm, vofm) == Mofm * Mofm .+ vofm         # mat-mat
+    @test_broken muladd(Mofm, vofm, vofm) == Mofm * vofm .+ vofm  # mat-vec
 end
 
 # issue #6450

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -292,6 +292,36 @@ end
     end
 end
 
+@testset "muladd" begin
+    A23 = reshape(1:6, 2,3)
+    B34 = reshape(1:12, 3,4) .+ im
+    u2 = [10,20]
+    v3 = [3,5,7] .+ im
+    w4 = [11,13,17,19im]
+
+    @test muladd(A23, B34, 100) == A23 * B34 .+ 100
+    @test muladd(A23, B34, u2) == A23 * B34 .+ u2
+    @test muladd(A23, B34, w4') == A23 * B34 .+ w4'
+    @test_throws DimensionMismatch muladd(B34, A23, 1)
+    @test_throws DimensionMismatch muladd(A23, B34, ones(2,4,1))
+
+    @test muladd(A23, v3, 100) == A23 * v3 .+ 100
+    @test muladd(A23, v3, u2) == A23 * v3 .+ u2
+    @test_throws DimensionMismatch muladd(A23, v3, ones(2,2))
+
+    @test muladd(v3', B34, 0) isa Adjoint
+    @test muladd(v3', B34, 2im) == v3' * B34 .+ 2im
+    @test muladd(v3', B34, w4') == v3' * B34 .+ w4'
+
+    @test muladd(u2, v3', 0) isa Matrix
+    @test muladd(u2, v3', 99) == u2 * v3' .+ 99
+    @test muladd(u2, v3', A23) == u2 * v3' .+ A23
+
+    @test muladd(u2', u2, 0) isa Number
+    @test muladd(v3', v3, im) == dot(v3,v3) + im
+    @test_throws DimensionMismatch muladd(v3', v3, [1])
+end
+
 # issue #6450
 @test dot(Any[1.0,2.0], Any[3.5,4.5]) === 12.5
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -307,11 +307,13 @@ end
 
     @test muladd(A23, v3, 100) == A23 * v3 .+ 100
     @test muladd(A23, v3, u2) == A23 * v3 .+ u2
+    @test muladd(A23, v3, im) isa Vector{Complex{Int}}
     @test_throws DimensionMismatch muladd(A23, v3, ones(2,2))
 
     @test muladd(v3', B34, 0) isa Adjoint
     @test muladd(v3', B34, 2im) == v3' * B34 .+ 2im
     @test muladd(v3', B34, w4') == v3' * B34 .+ w4'
+    @test_throws DimensionMismatch muladd(v3', B34, ones(1,4))
 
     @test muladd(u2, v3', 0) isa Matrix
     @test muladd(u2, v3', 99) == u2 * v3' .+ 99

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -318,6 +318,7 @@ end
     @test muladd(u2, v3', 0) isa Matrix
     @test muladd(u2, v3', 99) == u2 * v3' .+ 99
     @test muladd(u2, v3', A23) == u2 * v3' .+ A23
+    @test_throws DimensionMismatch muladd(u2, v3', ones(2,3,4))
 
     @test muladd(u2', u2, 0) isa Number
     @test muladd(v3', v3, im) == dot(v3,v3) + im


### PR DESCRIPTION
This extends `Base.muladd` to work on arrays, using `mul!`, which makes some combinations more efficient:
```julia
julia> A = rand(20,5); x = rand(5, 1000); b = rand(20);

julia> @btime $A * $x .+ $b;
  29.787 μs (4 allocations: 312.66 KiB)

julia> @btime muladd($A, $x, $b);
  22.322 μs (2 allocations: 156.33 KiB)
```
Motivated by things like https://github.com/FluxML/Flux.jl/pull/1272, where it would be convenient to fuse these two, rather than fusing addition & function application `tanh.((W*x) .+ b)` with broadcasting.

~~Needs tests, and thinking about `muladd(::Adjoint, ...)` & `muladd(..., ::Number)` cases,~~ if anyone thinks this is a good idea. 
