### PR TITLE
Add `get-task-allow` entitlement to allow debuggers to attach to codesigned Julia

### DIFF
--- a/contrib/mac/app/Entitlements.plist
+++ b/contrib/mac/app/Entitlements.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.security.cs.get-task-allow</key>
+	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>


### PR DESCRIPTION
Without this entitlement, users that wish to attach a debugger to the
codesign Julia executable they receive from `julialang.org` must strip
the codesigning signature from the Julia executable (e.g. via `codesign
--remove-signature Julia-1.5.app/Contents/Resources/bin/julia`).  This
has its disadvantages, of course, so much better to simply declare to
the OS that it's alright for other processes to attach to this process.