### PR TITLE
Simplify inttoptr generation a little bit in codegen

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1518,7 +1518,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             return mark_or_box_ccall_result(
                     ctx,
                     ctx.builder.CreateAddrSpaceCast(
-                        ctx.builder.CreateIntToPtr(ary, T_pjlvalue),
+                        emit_inttoptr(ctx, ary, T_pjlvalue),
                         T_prjlvalue), // WARNING: this addrspace cast necessarily implies that the value is rooted elsewhere!
                     retboxed, rt, unionall, static_rt);
         }
@@ -1704,13 +1704,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         Value *destp = emit_unbox(ctx, T_size, dst, (jl_value_t*)jl_voidpointer_type);
 
         ctx.builder.CreateMemCpy(
-                ctx.builder.CreateIntToPtr(destp, T_pint8),
+                emit_inttoptr(ctx, destp, T_pint8),
 #if JL_LLVM_VERSION >= 100000
                 MaybeAlign(1),
 #else
                 1,
 #endif
-                ctx.builder.CreateIntToPtr(
+                emit_inttoptr(ctx,
                     emit_unbox(ctx, T_size, src, (jl_value_t*)jl_voidpointer_type),
                     T_pint8),
 #if JL_LLVM_VERSION >= 100000
@@ -1881,7 +1881,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
     else if (symarg.jl_ptr != NULL) {
         null_pointer_check(ctx, symarg.jl_ptr);
         Type *funcptype = PointerType::get(functype, 0);
-        llvmf = ctx.builder.CreateIntToPtr(symarg.jl_ptr, funcptype);
+        llvmf = emit_inttoptr(ctx, symarg.jl_ptr, funcptype);
     }
     else if (symarg.fptr != NULL) {
         Type *funcptype = PointerType::get(functype, 0);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1186,6 +1186,14 @@ static void undef_derived_strct(IRBuilder<> &irbuilder, Value *ptr, jl_datatype_
     }
 }
 
+static Value *emit_inttoptr(jl_codectx_t &ctx, Value *v, Type *ty)
+{
+    // Almost all of our inttoptr are generated due to representing `Ptr` with `T_size`
+    // in LLVM and most of these integers are generated from `ptrtoint` in the first place.
+    if (auto I = dyn_cast<PtrToIntInst>(v))
+        return ctx.builder.CreateBitCast(I->getOperand(0), ty);
+    return ctx.builder.CreateIntToPtr(v, ty);
+}
 
 static inline jl_cgval_t ghostValue(jl_value_t *typ)
 {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -309,7 +309,7 @@ static Value *emit_unboxed_coercion(jl_codectx_t &ctx, Type *to, Value *unboxed)
         Type *INTT_to = INTT(to);
         if (to != INTT_to)
             unboxed = ctx.builder.CreateBitCast(unboxed, INTT_to);
-        unboxed = ctx.builder.CreateIntToPtr(unboxed, to);
+        unboxed = emit_inttoptr(ctx, unboxed, to);
     }
     else if (ty != to) {
         unboxed = ctx.builder.CreateBitCast(unboxed, to);
@@ -490,7 +490,7 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
         else if (vxt->isPointerTy() && !llvmt->isPointerTy())
             vx = ctx.builder.CreatePtrToInt(vx, llvmt);
         else if (!vxt->isPointerTy() && llvmt->isPointerTy())
-            vx = ctx.builder.CreateIntToPtr(vx, llvmt);
+            vx = emit_inttoptr(ctx, vx, llvmt);
         else
             vx = emit_bitcast(ctx, vx, llvmt);
     }
@@ -1029,14 +1029,14 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
     case add_ptr: {
         return ctx.builder.CreatePtrToInt(
             ctx.builder.CreateGEP(T_int8,
-                ctx.builder.CreateIntToPtr(x, T_pint8), y), t);
+                emit_inttoptr(ctx, x, T_pint8), y), t);
 
     }
 
     case sub_ptr: {
         return ctx.builder.CreatePtrToInt(
             ctx.builder.CreateGEP(T_int8,
-                ctx.builder.CreateIntToPtr(x, T_pint8), ctx.builder.CreateNeg(y)), t);
+                emit_inttoptr(ctx, x, T_pint8), ctx.builder.CreateNeg(y)), t);
 
     }
 


### PR DESCRIPTION
This get rid of >90% of inttoptr during codegen, slightly less than half become no-op (and the rest will be no-op whenever llvm finally got rid of pointer element type...).

This should not have any effect on the final code after optimization.