### PR TITLE
Improve inference for PhiNode.edges

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -569,7 +569,7 @@ function batch_inline!(todo::Vector{Any}, ir::IRCode, linetable::Vector{LineInfo
             elseif isa(stmt, GotoIfNot)
                 compact[idx] = GotoIfNot(stmt.cond, state.bb_rename[stmt.dest])
             elseif isa(stmt, PhiNode)
-                compact[idx] = PhiNode(Any[edge == length(state.bb_rename) ? length(state.new_cfg_blocks) : state.bb_rename[edge+1]-1 for edge in stmt.edges], stmt.values)
+                compact[idx] = PhiNode(Any[edge::Int == length(state.bb_rename) ? length(state.new_cfg_blocks) : state.bb_rename[edge::Int+1]-1 for edge in stmt.edges], stmt.values)
             end
         end
 

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -71,7 +71,7 @@ function basic_blocks_starts(stmts::Vector{Any})
         end
         if isa(stmt, PhiNode)
             for edge in stmt.edges
-                if edge === idx - 1
+                if edge::Int === idx - 1
                     push!(jump_dests, idx)
                 end
             end
@@ -992,7 +992,7 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             # There's only one predecessor left - just replace it
             ssa_rename[idx] = values[1]
         else
-            edges = compact.cfg_transforms_enabled ? map!(i->compact.bb_rename_pred[i], stmt.edges, stmt.edges) : stmt.edges
+            edges = compact.cfg_transforms_enabled ? map!(i->compact.bb_rename_pred[i::Int], stmt.edges, stmt.edges) : stmt.edges
             result[result_idx][:inst] = PhiNode(edges, values)
             result_idx += 1
         end

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -21,7 +21,7 @@ function inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
         elseif isa(stmt, GotoIfNot)
             code[i] = GotoIfNot(stmt.cond, block_for_inst(cfg, stmt.dest))
         elseif isa(stmt, PhiNode)
-            code[i] = PhiNode(Any[block_for_inst(cfg, edge) for edge in stmt.edges], stmt.values)
+            code[i] = PhiNode(Any[block_for_inst(cfg, edge::Int) for edge in stmt.edges], stmt.values)
         elseif isa(stmt, Expr) && stmt.head === :enter
             stmt.args[1] = block_for_inst(cfg, stmt.args[1])
             code[i] = stmt

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -202,7 +202,7 @@ function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospe
                 push!(possible_predecessors, n)
             end
             for n in possible_predecessors
-                pred = def.edges[n]
+                pred = def.edges[n]::Int
                 val = def.values[n]
                 if is_old(compact, defssa) && isa(val, SSAValue)
                     val = OldSSAValue(val.id)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -75,7 +75,7 @@ show_unquoted(io::IO, val::Argument, indent::Int, prec::Int) = show_unquoted(io,
 show_unquoted(io::IO, stmt::PhiNode, indent::Int, ::Int) = show_unquoted_phinode(io, stmt, indent, "%")
 function show_unquoted_phinode(io::IO, stmt::PhiNode, indent::Int, prefix::String)
     args = map(1:length(stmt.edges)) do i
-        e = stmt.edges[i]
+        e = stmt.edges[i]::Int
         v = !isassigned(stmt.values, i) ? "#undef" :
             sprint() do io′
                 show_unquoted(io′, stmt.values[i], indent)
@@ -713,7 +713,7 @@ function show_ir_stmt(io::IO, code::CodeInfo, idx::Int, line_info_preprinter, li
         stmt = GotoNode(block_for_inst(cfg, stmt.label))
     elseif stmt isa PhiNode
         e = stmt.edges
-        stmt = PhiNode(Any[block_for_inst(cfg, e[i]) for i in 1:length(e)], stmt.values)
+        stmt = PhiNode(Any[block_for_inst(cfg, e[i]::Int) for i in 1:length(e)], stmt.values)
     end
     show_type = types isa Vector{Any} && should_print_ssa_type(stmt)
     print_stmt(io, idx, stmt, used, maxlength_idx, true, show_type)

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -129,7 +129,7 @@ function fixemup!(cond, rename, ir::IRCode, ci::CodeInfo, idx::Int, @nospecializ
             val = stmt.values[i]
             isa(val, Union{SlotNumber, TypedSlot}) || continue
             cond(val) || continue
-            bb_idx = block_for_inst(ir.cfg, stmt.edges[i])
+            bb_idx = block_for_inst(ir.cfg, stmt.edges[i]::Int)
             from_bb_terminator = last(ir.cfg.blocks[bb_idx].stmts)
             stmt.values[i] = fixup_slot!(ir, ci, from_bb_terminator, slot_id(val), val, rename(val))
         end
@@ -355,6 +355,7 @@ function rename_phinode_edges(node, bb, result_order, bb_rename)
     new_values = Any[]
     new_edges = Any[]
     for (idx, edge) in pairs(node.edges)
+        edge = edge::Int
         (edge == 0 || haskey(bb_rename, edge)) || continue
         new_edge_from = edge == 0 ? 0 : rename_incoming_edge(edge, bb, result_order, bb_rename)
         push!(new_edges, new_edge_from)
@@ -683,6 +684,7 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, domtree::DomTree, defuse, narg
             end
             isa(stmt, PhiNode) || continue
             for (edgeidx, edge) in pairs(stmt.edges)
+                edge = edge::Int
                 from_bb = edge == 0 ? 0 : block_for_inst(cfg, edge)
                 from_bb == pred || continue
                 isassigned(stmt.values, edgeidx) || break
@@ -827,7 +829,7 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, domtree::DomTree, defuse, narg
             ssavalmap[idx] = SSAValue(idx)
             result_types[idx] = ci.ssavaluetypes[idx]
             if isa(stmt, PhiNode)
-                edges = Any[edge == 0 ? 0 : block_for_inst(cfg, edge) for edge in stmt.edges]
+                edges = Any[edge::Int == 0 ? 0 : block_for_inst(cfg, edge::Int) for edge in stmt.edges]
                 new_code[idx] = PhiNode(edges, stmt.values)
             else
                 new_code[idx] = stmt

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -111,7 +111,7 @@ function verify_ir(ir::IRCode, print::Bool=true)
             end
         elseif isexpr(terminator, :enter)
             @label enter_check
-            if length(block.succs) != 2 || (block.succs != [terminator.args[1], idx+1] && block.succs != [idx+1, terminator.args[1]])
+            if length(block.succs) != 2 || (block.succs != [terminator.args[1]::Int, idx+1] && block.succs != [idx+1, terminator.args[1]::Int])
                 @verify_error "Block $idx successors ($(block.succs)), does not match :enter terminator"
                 error()
             end
@@ -150,7 +150,7 @@ function verify_ir(ir::IRCode, print::Bool=true)
         if isa(stmt, PhiNode)
             @assert length(stmt.edges) == length(stmt.values)
             for i = 1:length(stmt.edges)
-                edge = stmt.edges[i]
+                edge = stmt.edges[i]::Int
                 if !(edge == 0 && bb == 1) && !(edge in ir.cfg.blocks[bb].preds)
                     #@Base.show ir.argtypes
                     #@Base.show ir
@@ -174,7 +174,7 @@ function verify_ir(ir::IRCode, print::Bool=true)
                     @verify_error "GlobalRefs and Exprs are not allowed as PhiNode values"
                     error()
                 end
-                check_op(ir, domtree, val, edge, last(ir.cfg.blocks[stmt.edges[i]].stmts)+1, print)
+                check_op(ir, domtree, val, edge, last(ir.cfg.blocks[stmt.edges[i]::Int].stmts)+1, print)
             end
         elseif isa(stmt, PhiCNode)
             for i = 1:length(stmt.values)


### PR DESCRIPTION
We have
```julia
julia> fieldtype(Core.PhiNode, :edges)
Vector{Any} = Array{Any,1}
```
despite the fact that all entries are `Int`. Even the [docs](https://docs.julialang.org/en/latest/devdocs/ssair/#Phi-nodes-and-Pi-nodes-1) say this field is a `Vector{Int}`. I spent a little bit of time trying to change that at the level of the C code but kept running into serialization-related problems. So this circumvents the problem by type-assertion. That said, I'd be happy with having someone close this PR and change the field type to `Vector{Int}` (or perhaps `Vector{Int32}` since there's already a corresponding C type declared).