### PR TITLE
Ensure that BitArrays are inferrable for arbitrary `Integer`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1411,7 +1411,7 @@ promote_eltype() = Bottom
 promote_eltype(v1, vs...) = promote_type(eltype(v1), promote_eltype(vs...))
 
 #TODO: ERROR CHECK
-_cat(catdim::Integer) = Vector{Any}()
+_cat(catdim::Int) = Vector{Any}()
 
 typed_vcat(::Type{T}) where {T} = Vector{T}()
 typed_hcat(::Type{T}) where {T} = Vector{T}()

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -601,9 +601,11 @@ end
 
 gen_bitarray(::IsInfinite, itr) =  throw(ArgumentError("infinite-size iterable used in BitArray constructor"))
 
-gen_bitarrayN(::Type{BitVector}, itsz, itr) = gen_bitarray(itsz, itr)
-gen_bitarrayN(::Type{BitVector}, itsz::HasShape{1}, itr) where N = gen_bitarray(itsz, itr)
+gen_bitarrayN(::Type{BitVector}, itsz, itr)                        = gen_bitarray(itsz, itr)
+gen_bitarrayN(::Type{BitVector}, itsz::HasShape{1}, itr)           = gen_bitarray(itsz, itr)
 gen_bitarrayN(::Type{BitArray{N}}, itsz::HasShape{N}, itr) where N = gen_bitarray(itsz, itr)
+# The first of these is just for ambiguity resolution
+gen_bitarrayN(::Type{BitVector}, itsz::HasShape{N}, itr) where N      = throw(DimensionMismatch("cannot create a $T from a $N-dimensional iterator"))
 gen_bitarrayN(@nospecialize(T::Type), itsz::HasShape{N}, itr) where N = throw(DimensionMismatch("cannot create a $T from a $N-dimensional iterator"))
 gen_bitarrayN(@nospecialize(T::Type), itsz, itr) = throw(DimensionMismatch("cannot create a $T from a generic iterator"))
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -219,6 +219,10 @@ timesofar("utils")
     # issue #24062
     @test_throws InexactError BitArray([0, 1, 2, 3])
     @test_throws MethodError BitArray([0, ""])
+
+    # construction with poor inference
+    f(c) = BitVector(c[1])
+    @test @inferred(f(AbstractVector[[0,1]])) == [false, true]
 end
 
 timesofar("constructors")


### PR DESCRIPTION
BitArray operations are frequently performed with partial inference information (particularly from Pkg but others as well). Currently the internal operations are a source of invalidation for common arithmetic and bitwise operators. There seems to be no need to live with this, as all the inference problems are fixed by converting `Integer`s to `Int`s. This is done elsewhere already in BitArray code, so it only seems to be continuing a process that is already underway.

Because of the multiplicity of methods `BitArray{N}(a::Any)` is not fully inferrable but there are at least limited victories, and the real benefits are in the elimination of instabilities in the internal operations.
