### PR TITLE
Improve inference in Docs and Markdown

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -332,7 +332,7 @@ function metadata(__source__, __module__, expr, ismodule)
     end
     if isexpr(expr, :struct)
         # Field docs for concrete types.
-        P = Pair{Any,Any}
+        P = Pair{Symbol,Any}
         fields = P[]
         last_docstr = nothing
         for each in expr.args[3].args
@@ -350,10 +350,10 @@ function metadata(__source__, __module__, expr, ismodule)
                 last_docstr = each
             end
         end
-        dict = :($(Dict)($([(:($(P)($(quot(f)), $d)))::Expr for (f, d) in fields]...)))
+        dict = :($(Dict{Symbol,Any})($([(:($(P)($(quot(f)), $d)))::Expr for (f, d) in fields]...)))
         push!(args, :($(Pair)(:fields, $dict)))
     end
-    return :($(Dict)($(args...)))
+    return :($(Dict{Symbol,Any})($(args...)))
 end
 
 function keyworddoc(__source__, __module__, str, def::Base.BaseDocs.Keyword)

--- a/stdlib/Markdown/src/parse/config.jl
+++ b/stdlib/Markdown/src/parse/config.jl
@@ -12,15 +12,13 @@ Config() = Config(Function[], Function[], InnerConfig())
 
 const META = IdDict{Function, Dict{Symbol, Any}}()
 
-getset(coll, key, default) = coll[key] = get(coll, key, default)
-
-meta(f) = getset(META, f, Dict{Symbol, Any}())
+meta(f) = get!(Dict{Symbol,Any}, META, f)
 
 breaking!(f) = meta(f)[:breaking] = true
-breaking(f) = get(meta(f), :breaking, false)
+breaking(f) = get(meta(f), :breaking, false)::Bool
 
 triggers!(f, ts) = meta(f)[:triggers] = Set{Char}(ts)
-triggers(f) = get(meta(f), :triggers, Set{Char}())
+triggers(f) = get!(Set{Char}, meta(f), :triggers)::Set{Char}
 
 # Macros
 
@@ -61,7 +59,7 @@ function config(parsers::Function...)
             push!(c.breaking, parser)
         elseif !isempty(ts)
             for t in ts
-                push!(getset(c.inner, t, Function[]), parser)
+                push!(get!(Vector{Function}, c.inner, t), parser)
             end
         else
             push!(c.regular, parser)


### PR DESCRIPTION
Because Docs is set to `@nospecialize` for the entire module, declaring types on input arguments makes a large difference in what
methods get inferred. This heads off a number of completely impossible combinations.

It's worth noting that enough methods have `@nospecialize` arguments that it might be worth considering removing the module-global `@nospecialize`. I understand the convenience of the module-global version, but it made for some really bizarre headscratching for why we were getting a `signature!(::Any, ::Expr)` MethodInstance.