### PR TITLE
Reduce reliance on promotion operations via container typing

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -608,7 +608,7 @@ Core.atdoc!(docm)
 
 function loaddocs(docs)
     for (mod, ex, str, file, line) in docs
-        data = Dict(:path => string(file), :linenumber => line)
+        data = Dict{Symbol,Any}(:path => string(file), :linenumber => line)
         doc = docstr(str, data)
         docstring = docm(LineNumberNode(line, file), mod, doc, ex, false) # expand the real @doc macro now
         Core.eval(mod, Expr(Core.unescape, docstring, Docs))

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -281,7 +281,7 @@ function showerror(io::IO, ex::MethodError)
         if any(x -> x <: AbstractArray{<:Number}, arg_types_param) &&
             any(x -> x <: Number, arg_types_param)
 
-            nouns = Dict(
+            nouns = Dict{Any,String}(
                 Base.:+ => "addition",
                 Base.:- => "subtraction",
             )
@@ -381,7 +381,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
     lines = []
     # These functions are special cased to only show if first argument is matched.
     special = f === convert || f === getindex || f === setindex!
-    funcs = Any[(f, arg_types_param)]
+    funcs = Tuple{Any,Vector{Any}}[(f, arg_types_param)]
 
     # An incorrect call method produces a MethodError for convert.
     # It also happens that users type convert when they mean call. So

--- a/base/file.jl
+++ b/base/file.jl
@@ -876,7 +876,7 @@ function walkdir(root; topdown=true, follow_symlinks=false, onerror=throw)
         end
         nothing
     end
-    return Channel(chnl -> _walkdir(chnl, root))
+    return Channel{Tuple{String,Vector{String},Vector{String}}}(chnl -> _walkdir(chnl, root))
 end
 
 function unlink(p::AbstractString)

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -210,7 +210,7 @@ function init_load_path()
         paths = parse_load_path(ENV["JULIA_LOAD_PATH"])
     else
         paths = filter!(env -> env !== nothing,
-            [env == "@." ? current_project() : env for env in DEFAULT_LOAD_PATH])
+            String[env == "@." ? current_project() : env for env in DEFAULT_LOAD_PATH])
     end
     append!(empty!(LOAD_PATH), paths)
 end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1419,7 +1419,7 @@ function checkdims_perm(P::AbstractArray{TP,N}, B::AbstractArray{TB,N}, perm) wh
     nothing
 end
 
-for (V, PT, BT) in [((:N,), BitArray, BitArray), ((:T,:N), Array, StridedArray)]
+for (V, PT, BT) in Any[((:N,), BitArray, BitArray), ((:T,:N), Array, StridedArray)]
     @eval @generated function permutedims!(P::$PT{$(V...)}, B::$BT{$(V...)}, perm) where $(V...)
         quote
             checkdims_perm(P, B, perm)

--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Generate encode table.
-const BASE64_ENCODE = [UInt8(x) for x in ['A':'Z'; 'a':'z'; '0':'9'; '+'; '/']]
+const BASE64_ENCODE = [UInt8(x) for x in Char['A':'Z'; 'a':'z'; '0':'9'; '+'; '/']]
 encode(x::UInt8) = @inbounds return BASE64_ENCODE[(x & 0x3f) + 1]
 encodepadding()  = UInt8('=')
 

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -129,7 +129,7 @@ function tryparsenext(d::DatePart{'p'}, str, i, len)
     return ap == 'a' ? AM : PM, ii
 end
 
-for (tok, fn) in zip("uUeE", [monthabbr_to_value, monthname_to_value, dayabbr_to_value, dayname_to_value])
+for (tok, fn) in zip("uUeE", Any[monthabbr_to_value, monthname_to_value, dayabbr_to_value, dayname_to_value])
     @eval @inline function tryparsenext(d::DatePart{$tok}, str, i, len, locale)
         next = tryparsenext_word(str, i, len, locale, max_width(d))
         next === nothing && return nothing
@@ -161,13 +161,13 @@ end
 
 hour12(dt) = let h = hour(dt); h > 12 ? h - 12 : h == 0 ? 12 : h; end
 
-for (c, fn) in zip("YmdHIMS", [year, month, day, hour, hour12, minute, second])
+for (c, fn) in zip("YmdHIMS", Any[year, month, day, hour, hour12, minute, second])
     @eval function format(io, d::DatePart{$c}, dt)
         print(io, string($fn(dt), base = 10, pad = d.width))
     end
 end
 
-for (tok, fn) in zip("uU", [monthabbr, monthname])
+for (tok, fn) in zip("uU", Any[monthabbr, monthname])
     @eval function format(io, d::DatePart{$tok}, dt, locale)
         print(io, $fn(month(dt), locale))
     end
@@ -178,7 +178,7 @@ function format(io, d::DatePart{'p'}, dt, locale)
     print(io, ampm)
 end
 
-for (tok, fn) in zip("eE", [dayabbr, dayname])
+for (tok, fn) in zip("eE", Any[dayabbr, dayname])
     @eval function format(io, ::DatePart{$tok}, dt, locale)
         print(io, $fn(dayofweek(dt), locale))
     end

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -114,11 +114,11 @@ function define_default_editors()
     define_editor(r".*") do cmd, path, line
         `$cmd $path`
     end
-    define_editor([r"\bemacs", "gedit", r"\bgvim"]) do cmd, path, line
+    define_editor(Any[r"\bemacs", "gedit", r"\bgvim"]) do cmd, path, line
         `$cmd +$line $path`
     end
     # Must check that emacs not running in -t/-nw before regex match for general emacs
-    define_editor([
+    define_editor(Any[
         "vim", "vi", "nvim", "mvim", "nano", "micro",
         r"\bemacs\b.*\s(-nw|--no-window-system)\b",
         r"\bemacsclient\b.\s*-(-?nw|t|-?tty)\b"], wait=true) do cmd, path, line
@@ -127,7 +127,7 @@ function define_default_editors()
     define_editor(["textmate", "mate", "kate"]) do cmd, path, line
         `$cmd $path -l $line`
     end
-    define_editor([r"\bsubl", r"\batom", "pycharm", "bbedit"]) do cmd, path, line
+    define_editor(Any[r"\bsubl", r"\batom", "pycharm", "bbedit"]) do cmd, path, line
         `$cmd $path:$line`
     end
     define_editor(["code", "code-insiders"]) do cmd, path, line

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1007,7 +1007,7 @@ function Base.getproperty(obj::GitObject, name::Symbol)
     end
 end
 
-for (typ, owntyp, sup, cname) in [
+for (typ, owntyp, sup, cname) in Tuple{Symbol,Any,Symbol,Symbol}[
     (:GitRepo,           nothing,                 :AbstractGitObject, :git_repository),
     (:GitConfig,         :(Union{GitRepo, Nothing}), :AbstractGitObject, :git_config),
     (:GitIndex,          :(Union{GitRepo, Nothing}), :AbstractGitObject, :git_index),

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -467,12 +467,12 @@ end
 
 # Define `mul!` for (Unit){Upper,Lower}Triangular matrices times a
 # number.
-for (Trig, UnitTrig) in [(UpperTriangular, UnitUpperTriangular),
-                         (LowerTriangular, UnitLowerTriangular)]
-    for (TB, TC) in [(Trig, Number),
-                     (Number, Trig),
-                     (UnitTrig, Number),
-                     (Number, UnitTrig)]
+for (Trig, UnitTrig) in Any[(UpperTriangular, UnitUpperTriangular),
+                            (LowerTriangular, UnitLowerTriangular)]
+    for (TB, TC) in Any[(Trig, Number),
+                        (Number, Trig),
+                        (UnitTrig, Number),
+                        (Number, UnitTrig)]
         @eval @inline mul!(A::$Trig, B::$TB, C::$TC, alpha::Number, beta::Number) =
             _mul!(A, B, C, MulAddMul(alpha, beta))
     end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -201,7 +201,8 @@ end
 beep(::ModeState) = nothing
 cancel_beep(::ModeState) = nothing
 
-for f in [:terminal, :on_enter, :add_history, :_buffer, :(Base.isempty),
+for f in Union{Symbol,Expr}[
+          :terminal, :on_enter, :add_history, :_buffer, :(Base.isempty),
           :replace_line, :refresh_multi_line, :input_string, :update_display_buffer,
           :empty_undo, :push_undo, :pop_undo, :options, :cancel_beep, :beep,
           :deactivate_region, :activate_region, :is_region_active, :region_active]

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -994,9 +994,9 @@ function setup_interface(
 
     # Setup history
     # We will have a unified history for all REPL modes
-    hp = REPLHistoryProvider(Dict{Symbol,Any}(:julia => julia_prompt,
-                                              :shell => shell_mode,
-                                              :help  => help_mode))
+    hp = REPLHistoryProvider(Dict{Symbol,Prompt}(:julia => julia_prompt,
+                                                 :shell => shell_mode,
+                                                 :help  => help_mode))
     if repl.history_file
         try
             hist_path = find_hist_file()
@@ -1172,7 +1172,7 @@ function setup_interface(
 
     shell_mode.keymap_dict = help_mode.keymap_dict = LineEdit.keymap(b)
 
-    allprompts = [julia_prompt, shell_mode, help_mode, search_prompt, prefix_prompt]
+    allprompts = LineEdit.TextInterface[julia_prompt, shell_mode, help_mode, search_prompt, prefix_prompt]
     return ModalInterface(allprompts)
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -1213,7 +1213,7 @@ cd(dirwalk) do
     has_symlinks && symlink(abspath("sub_dir2"), joinpath("sub_dir1", "link"))
     for follow_symlinks in follow_symlink_vec
         chnl = walkdir(".", follow_symlinks=follow_symlinks)
-        root, dirs, files = take!(chnl)
+        root, dirs, files = @inferred(take!(chnl))
         @test root == "."
         @test dirs == ["sub_dir1", "sub_dir2"]
         @test files == ["file1", "file2"]


### PR DESCRIPTION
While building Julia, we ~have~had a *lot* of calls to promote, often with abstract types. This short-circuits most of these by declaring the container type at the outset.

This has one user-visible outcome, improved inference for `walkdir`.

After my complete PR series is submitted, I'll post some benchmarks here on the impact on building Julia itself. Obviously no one PR accounts for the whole thing, but this one may be as good a place as any to deposit this info.