### PR TITLE
Fix compiler warnings and undefined behaviors

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -471,7 +471,7 @@ static NOINLINE jl_svec_t *_copy_to(size_t newalloc, jl_value_t **oldargs, size_
     return newheap;
 }
 
-void STATIC_INLINE _grow_to(jl_value_t **root, jl_value_t ***oldargs, jl_svec_t **arg_heap, size_t *n_alloc, size_t newalloc, size_t extra)
+STATIC_INLINE void _grow_to(jl_value_t **root, jl_value_t ***oldargs, jl_svec_t **arg_heap, size_t *n_alloc, size_t newalloc, size_t extra)
 {
     size_t oldalloc = *n_alloc;
     if (oldalloc >= newalloc)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2879,6 +2879,7 @@ static Value *emit_defer_signal(jl_codectx_t &ctx)
     return ctx.builder.CreateInBoundsGEP(T_sigatomic, ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
 }
 
+#ifndef NDEBUG
 static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)
 {
     return
@@ -2893,3 +2894,4 @@ static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)
            (a->raise_exception == b->raise_exception) &&
            (a->generic_context == b->generic_context);
 }
+#endif

--- a/src/gf.c
+++ b/src/gf.c
@@ -1237,11 +1237,9 @@ static jl_value_t *get_intersect_matches(jl_typemap_t *defs, jl_typemap_entry_t 
         else
             va = NULL;
     }
-    struct matches_env env = {{get_intersect_visitor, (jl_value_t*)type, va}};
-    env.match.ti = NULL;
-    env.match.env = jl_emptysvec;
-    env.newentry = newentry;
-    env.shadowed = NULL;
+    struct matches_env env = {{get_intersect_visitor, (jl_value_t*)type, va,
+            /* .ti = */ NULL, /* .env = */ jl_emptysvec, /* .issubty = */ 0},
+        /* .newentry = */ newentry, /* .shadowed */ NULL};
     JL_GC_PUSH3(&env.match.env, &env.match.ti, &env.shadowed);
     jl_typemap_intersection_visitor(defs, 0, &env.match);
     JL_GC_POP();
@@ -2603,13 +2601,10 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
         else
             va = NULL;
     }
-    struct ml_matches_env env = {{ml_matches_visitor, (jl_value_t*)type, va}, intersections, world, lim};
-    env.match.ti = NULL;
-    env.match.env = jl_emptysvec;
-    env.t = jl_an_empty_vec_any;
-    env.matc = NULL;
-    env.min_valid = *min_valid;
-    env.max_valid = *max_valid;
+    struct ml_matches_env env = {{ml_matches_visitor, (jl_value_t*)type, va,
+            /* .ti = */ NULL, /* .env = */ jl_emptysvec, /* .issubty = */ 0},
+        intersections, world, lim, /* .t = */ jl_an_empty_vec_any,
+        /* .min_valid = */ *min_valid, /* .max_valid = */ *max_valid, /* .matc = */ NULL};
     struct jl_typemap_assoc search = {(jl_value_t*)type, world, jl_emptysvec, 1, ~(size_t)0};
     JL_GC_PUSH5(&env.t, &env.matc, &env.match.env, &search.env, &env.match.ti);
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1029,6 +1029,7 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
             return (uintptr_t)jl_box_uint8(offset);
         // offset -= 256;
         assert(0 && "corrupt relocation item id");
+        jl_unreachable(); // terminate control flow if assertion is disabled.
     case BuiltinFunctionRef:
         assert(offset < sizeof(id_to_fptrs) / sizeof(*id_to_fptrs) && "unknown function pointer ID");
         return (uintptr_t)id_to_fptrs[offset];

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2760,7 +2760,7 @@ static jl_value_t *intersect_sub_datatype(jl_datatype_t *xd, jl_datatype_t *yd, 
     jl_value_t *isuper = R ? intersect((jl_value_t*)yd, (jl_value_t*)xd->super, e, param) :
                              intersect((jl_value_t*)xd->super, (jl_value_t*)yd, e, param);
     if (isuper == jl_bottom_type) return jl_bottom_type;
-    if (jl_nparams(xd) == 0 || jl_nparams(xd->super) == 0 || !jl_has_free_typevars(xd))
+    if (jl_nparams(xd) == 0 || jl_nparams(xd->super) == 0 || !jl_has_free_typevars((jl_value_t*)xd))
         return (jl_value_t*)xd;
     jl_value_t *super_pattern=NULL;
     JL_GC_PUSH2(&isuper, &super_pattern);


### PR DESCRIPTION
* Minor ones including position of `static` and `inline`; Unused function/fallthrough with assertion off; implicit pointer type cast in C.

* Structure initialization

    GCC warns about this and since we actually do initialize most of the field,
    I simply moved the assignment into initialization.
    To make the field initialized as clear as before,
    I included commented out version of designated initializer syntax.

* Fix undefined behavior regarding shifting negative value in `runtime_intrinsics.c`

    `a - a` does **not** return the same type as `a` for small integer types and returns `int`
    instead AFAICT. This cause the LHS of some shift to be negative which is undefined behavior
    in C (one of the most annoy ones...).
    Pass in the type instead of value to cast values to the correct types to fix this.

One remaining warning is a GCC bug... https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96629