### PR TITLE
make Profile more thread/signal-safe

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -546,7 +546,7 @@ Returns successfully if the process has already exited, but throws an
 error if killing the process failed for other reasons (e.g. insufficient
 permissions).
 """
-function kill(p::Process, signum::Integer)
+function kill(p::Process, signum::Integer=SIGTERM)
     iolock_begin()
     if process_running(p)
         @assert p.handle != C_NULL
@@ -558,9 +558,8 @@ function kill(p::Process, signum::Integer)
     iolock_end()
     nothing
 end
-kill(ps::Vector{Process}) = foreach(kill, ps)
-kill(ps::ProcessChain) = foreach(kill, ps.processes)
-kill(p::Process) = kill(p, SIGTERM)
+kill(ps::Vector{Process}, signum::Integer=SIGTERM) = for p in ps; kill(p, signum); end
+kill(ps::ProcessChain, signum::Integer=SIGTERM) = kill(ps.processes, signum)
 
 """
     getpid(process) -> Int32

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -756,7 +756,6 @@ typedef struct {
 
 // Might be called from unmanaged thread
 uint64_t jl_getUnwindInfo(uint64_t dwBase);
-uint64_t jl_trygetUnwindInfo(uint64_t dwBase);
 #ifdef _OS_WINDOWS_
 #include <dbghelp.h>
 JL_DLLEXPORT EXCEPTION_DISPOSITION __julia_personality(

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -27,6 +27,8 @@ static const    uint64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
+void jl_lock_profile(void);
+void jl_unlock_profile(void);
 
 static uint64_t jl_last_sigint_trigger = 0;
 static uint64_t jl_disable_sigint_time = 0;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -17,6 +17,18 @@
 
 #include "julia_assert.h"
 
+// private keymgr stuff
+#define KEYMGR_GCC3_DW2_OBJ_LIST 302
+enum {
+  NM_ALLOW_RECURSION = 1,
+  NM_RECURSION_ILLEGAL = 2
+};
+extern void _keymgr_set_and_unlock_processwide_ptr(unsigned int key, void *ptr);
+extern int _keymgr_unlock_processwide_ptr(unsigned int key);
+extern void *_keymgr_get_and_lock_processwide_ptr(unsigned int key);
+extern int _keymgr_get_and_lock_processwide_ptr_2(unsigned int key, void **result);
+extern int _keymgr_set_lockmode_processwide_ptr(unsigned int key, unsigned int mode);
+
 static void attach_exception_port(thread_port_t thread, int segv_only);
 
 // low 16 bits are the thread id, the next 8 bits are the original gc_state
@@ -78,6 +90,17 @@ void *mach_segv_listener(void *arg)
 
 static void allocate_segv_handler()
 {
+    // ensure KEYMGR_GCC3_DW2_OBJ_LIST is initialized, as this requires malloc
+    // and thus can deadlock when used without first initializing it.
+    // Apple caused this problem in their libunwind in 10.9 (circa keymgr-28)
+    // when they removed this part of the code from keymgr.
+    // Much thanks to Apple for providing source code, or this would probably
+    // have simply remained unsolved forever on their platform.
+    // This is similar to just calling checkKeyMgrRegisteredFDEs
+    // (this is quite thread-unsafe)
+    if (_keymgr_set_lockmode_processwide_ptr(KEYMGR_GCC3_DW2_OBJ_LIST, NM_ALLOW_RECURSION))
+        jl_error("_keymgr_set_lockmode_processwide_ptr failed");
+
     arraylist_new(&suspended_threads, jl_n_threads);
     pthread_t thread;
     pthread_attr_t attr;
@@ -463,6 +486,8 @@ void *mach_profile_listener(void *arg)
         // sample each thread, round-robin style in reverse order
         // (so that thread zero gets notified last)
         jl_lock_profile();
+        void *unused = NULL;
+        int keymgr_locked = _keymgr_get_and_lock_processwide_ptr_2(KEYMGR_GCC3_DW2_OBJ_LIST, &unused) == 0;
         for (i = jl_n_threads; i-- > 0; ) {
             // if there is no space left, break early
             if (bt_size_cur >= bt_size_max - 1)
@@ -511,6 +536,8 @@ void *mach_profile_listener(void *arg)
             // We're done! Resume the thread.
             jl_thread_resume(i, 0);
         }
+        if (keymgr_locked)
+            _keymgr_unlock_processwide_ptr(KEYMGR_GCC3_DW2_OBJ_LIST);
         jl_unlock_profile();
         if (running) {
             // Reset the alarm

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -673,6 +673,8 @@ static void *signal_listener(void *arg)
         unw_context_t *signal_context;
         // sample each thread, round-robin style in reverse order
         // (so that thread zero gets notified last)
+        if (critical || profile)
+            jl_lock_profile();
         for (int i = jl_n_threads; i-- > 0; ) {
             // notify thread to stop
             jl_thread_suspend_and_get_state(i, &signal_context);
@@ -717,6 +719,8 @@ static void *signal_listener(void *arg)
             // notify thread to resume
             jl_thread_resume(i, sig);
         }
+        if (critical || profile)
+            jl_unlock_profile();
 #endif
 
         // this part is async with the running of the rest of the program

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -111,3 +111,25 @@ end
     end
     @test getline(values(fdictc)) == getline(values(fdict0)) + 2
 end
+
+# Profile deadlocking in compilation (debuginfo registration)
+let cmd = Base.julia_cmd()
+    script = """
+        using Profile
+        f(::Val) = GC.safepoint()
+        @profile for i = 1:10^3; f(Val(i)); end
+        print(Profile.len_data())
+        """
+    p = open(`$cmd -e $script`)
+    t = Timer(120) do t
+        # should be under 10 seconds, so give it 2 minutes then report failure
+        println("KILLING BY PROFILE TEST WATCHDOG\n")
+        kill(p, Base.SIGTERM)
+        sleep(10)
+        kill(p, Base.SIGKILL)
+    end
+    s = read(p, String)
+    close(t)
+    @test success(p)
+    @test parse(Int, s) > 1000
+end


### PR DESCRIPTION
Internally these codepaths contain an rwlock on every platform (or are specified that you should hold one). So this adds that lock, and additionally blocks signals on unix for extra protection against deadlock here.

Fixes #35117
Fixes #13294