### PR TITLE
declare PhiNode.edges::Vector{Int32}

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -118,7 +118,7 @@
 #end
 
 #struct PhiNode
-#    edges::Vector{Any}
+#    edges::Vector{Int32}
 #    values::Vector{Any}
 #end
 
@@ -391,7 +391,7 @@ LineNumberNode(l::Int, f::String) = LineNumberNode(l, Symbol(f))
 eval(Core, :(GlobalRef(m::Module, s::Symbol) = $(Expr(:new, :GlobalRef, :m, :s))))
 eval(Core, :(SlotNumber(n::Int) = $(Expr(:new, :SlotNumber, :n))))
 eval(Core, :(TypedSlot(n::Int, @nospecialize(t)) = $(Expr(:new, :TypedSlot, :n, :t))))
-eval(Core, :(PhiNode(edges::Array{Any, 1}, values::Array{Any, 1}) = $(Expr(:new, :PhiNode, :edges, :values))))
+eval(Core, :(PhiNode(edges::Array{Int32, 1}, values::Array{Any, 1}) = $(Expr(:new, :PhiNode, :edges, :values))))
 eval(Core, :(PiNode(val, typ) = $(Expr(:new, :PiNode, :val, :typ))))
 eval(Core, :(PhiCNode(values::Array{Any, 1}) = $(Expr(:new, :PhiCNode, :values))))
 eval(Core, :(UpsilonNode(val) = $(Expr(:new, :UpsilonNode, :val))))

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -391,7 +391,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
             elseif isa(stmt′, GotoIfNot)
                 stmt′ = GotoIfNot(stmt′.cond, stmt′.dest + bb_offset)
             elseif isa(stmt′, PhiNode)
-                stmt′ = PhiNode(Any[edge+bb_offset for edge in stmt′.edges], stmt′.values)
+                stmt′ = PhiNode(Int32[edge+bb_offset for edge in stmt′.edges], stmt′.values)
             end
             inline_compact[idx′] = stmt′
         end
@@ -569,7 +569,7 @@ function batch_inline!(todo::Vector{Any}, ir::IRCode, linetable::Vector{LineInfo
             elseif isa(stmt, GotoIfNot)
                 compact[idx] = GotoIfNot(stmt.cond, state.bb_rename[stmt.dest])
             elseif isa(stmt, PhiNode)
-                compact[idx] = PhiNode(Any[edge == length(state.bb_rename) ? length(state.new_cfg_blocks) : state.bb_rename[edge+1]-1 for edge in stmt.edges], stmt.values)
+                compact[idx] = PhiNode(Int32[edge == length(state.bb_rename) ? length(state.new_cfg_blocks) : state.bb_rename[edge+1]-1 for edge in stmt.edges], stmt.values)
             end
         end
 

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 @inline isexpr(@nospecialize(stmt), head::Symbol) = isa(stmt, Expr) && stmt.head === head
-Core.PhiNode() = Core.PhiNode(Any[], Any[])
+Core.PhiNode() = Core.PhiNode(Int32[], Any[])
 
 """
 Like UnitRange{Int}, but can handle the `last` field, being temporarily
@@ -71,7 +71,7 @@ function basic_blocks_starts(stmts::Vector{Any})
         end
         if isa(stmt, PhiNode)
             for edge in stmt.edges
-                if edge === idx - 1
+                if edge == idx - 1
                     push!(jump_dests, idx)
                 end
             end
@@ -905,7 +905,7 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
                 stmt = compact.result[idx][:inst]
                 stmt === nothing && continue
                 isa(stmt, PhiNode) || break
-                i = findfirst(x-> x === compact.bb_rename_pred[from], stmt.edges)
+                i = findfirst(x-> x == compact.bb_rename_pred[from], stmt.edges)
                 if i !== nothing
                     deleteat!(stmt.edges, i)
                     deleteat!(stmt.values, i)
@@ -917,7 +917,7 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
             for stmt in CompactPeekIterator(compact, first(stmts), last(stmts))
                 stmt === nothing && continue
                 isa(stmt, PhiNode) || break
-                i = findfirst(x-> x === from, stmt.edges)
+                i = findfirst(x-> x == from, stmt.edges)
                 if i !== nothing
                     deleteat!(stmt.edges, i)
                     deleteat!(stmt.values, i)
@@ -1009,7 +1009,7 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             # not a value we can copy), we copy only the edges and (defined)
             # values we want to keep to new arrays initialized with undefined
             # elements.
-            edges = Vector{Any}(undef, length(stmt.edges))
+            edges = Vector{Int32}(undef, length(stmt.edges))
             values = Vector{Any}(undef, length(stmt.values))
             new_index = 1
             for old_index in 1:length(stmt.edges)

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -21,7 +21,7 @@ function inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
         elseif isa(stmt, GotoIfNot)
             code[i] = GotoIfNot(stmt.cond, block_for_inst(cfg, stmt.dest))
         elseif isa(stmt, PhiNode)
-            code[i] = PhiNode(Any[block_for_inst(cfg, edge) for edge in stmt.edges], stmt.values)
+            code[i] = PhiNode(Int32[block_for_inst(cfg, Int(edge)) for edge in stmt.edges], stmt.values)
         elseif isa(stmt, Expr) && stmt.head === :enter
             stmt.args[1] = block_for_inst(cfg, stmt.args[1])
             code[i] = stmt
@@ -59,7 +59,7 @@ function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
         elseif isa(stmt, GotoIfNot)
             stmt = GotoIfNot(stmt.cond, first(ir.cfg.blocks[stmt.dest].stmts))
         elseif isa(stmt, PhiNode)
-            stmt = PhiNode(Any[last(ir.cfg.blocks[edge::Int].stmts) for edge in stmt.edges], stmt.values)
+            stmt = PhiNode(Int32[last(ir.cfg.blocks[edge].stmts) for edge in stmt.edges], stmt.values)
         elseif isa(stmt, Expr) && stmt.head === :enter
             stmt.args[1] = first(ir.cfg.blocks[stmt.args[1]::Int].stmts)
         end

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -716,7 +716,7 @@ function show_ir_stmt(io::IO, code::CodeInfo, idx::Int, line_info_preprinter, li
         stmt = GotoNode(block_for_inst(cfg, stmt.label))
     elseif stmt isa PhiNode
         e = stmt.edges
-        stmt = PhiNode(Any[block_for_inst(cfg, e[i]) for i in 1:length(e)], stmt.values)
+        stmt = PhiNode(Int32[block_for_inst(cfg, Int(e[i])) for i in 1:length(e)], stmt.values)
     end
     show_type = types isa Vector{Any} && should_print_ssa_type(stmt)
     print_stmt(io, idx, stmt, used, maxlength_idx, true, show_type)

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -174,7 +174,7 @@ function verify_ir(ir::IRCode, print::Bool=true)
                     @verify_error "GlobalRefs and Exprs are not allowed as PhiNode values"
                     error()
                 end
-                check_op(ir, domtree, val, edge, last(ir.cfg.blocks[stmt.edges[i]].stmts)+1, print)
+                check_op(ir, domtree, val, Int(edge), last(ir.cfg.blocks[stmt.edges[i]].stmts)+1, print)
             end
         elseif isa(stmt, PhiCNode)
             for i = 1:length(stmt.values)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6509,7 +6509,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
             } else if (jl_is_phinode(stmt)) {
                 jl_array_t *edges = (jl_array_t*)jl_fieldref_noalloc(stmt, 0);
                 for (size_t j = 0; j < jl_array_len(edges); ++j) {
-                    size_t edge = jl_unbox_long(jl_array_ptr_ref(edges, j));
+                    size_t edge = ((int32_t*)jl_array_data(edges))[j];
                     if (edge == i)
                         branch_targets.insert(i + 1);
                 }
@@ -6757,7 +6757,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
         PHINode *TindexN = cast_or_null<PHINode>(phi_result.TIndex);
         DenseSet<BasicBlock*> preds;
         for (size_t i = 0; i < jl_array_len(edges); ++i) {
-            size_t edge = jl_unbox_long(jl_array_ptr_ref(edges, i));
+            size_t edge = ((int32_t*)jl_array_data(edges))[i];
             jl_value_t *value = jl_array_ptr_ref(values, i);
             // This edge value is undef, handle it the same as if the edge wasn't listed at all
             if (!value)
@@ -6776,7 +6776,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                 // Only codegen this branch once for each PHI (the expression must be the same on all branches)
 #ifndef NDEBUG
                 for (size_t j = 0; j < i; ++j) {
-                    size_t j_edge = jl_unbox_long(jl_array_ptr_ref(edges, j));
+                    size_t j_edge = ((int32_t*)jl_array_data(edges))[j];
                     if (j_edge == edge) {
                         assert(jl_egal(value, jl_array_ptr_ref(values, j)));
                     }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -335,7 +335,7 @@ static size_t eval_phi(jl_array_t *stmts, interpreter_state *s, size_t ns, size_
             //   %3 = phi (1)[1 => %a], (2)[2 => %b]
             // from = 1, to = closest = 2, i = 1 --> edge = 2, edge_from = 2, from = 2
             for (unsigned j = 0; j < jl_array_len(edges); ++j) {
-                size_t edge_from = jl_unbox_long(jl_arrayref(edges, j)); // 1-indexed
+                size_t edge_from = ((int32_t*)jl_array_data(edges))[j]; // 1-indexed
                 if (edge_from == from + 1) {
                     if (edge == -1)
                         edge = j;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2218,7 +2218,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_phinode_type =
         jl_new_datatype(jl_symbol("PhiNode"), core, jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(2, "edges", "values"),
-                        jl_svec(2, jl_array_any_type, jl_array_any_type), 0, 0, 2);
+                        jl_svec(2, jl_array_int32_type, jl_array_any_type), 0, 0, 2);
 
     jl_phicnode_type =
         jl_new_datatype(jl_symbol("PhiCNode"), core, jl_any_type, jl_emptysvec,

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -78,7 +78,7 @@ const TAGS = Any[
 
 @assert length(TAGS) == 255
 
-const ser_version = 11 # do not make changes without bumping the version #!
+const ser_version = 12 # do not make changes without bumping the version #!
 
 const NTAGS = length(TAGS)
 
@@ -1044,6 +1044,15 @@ function deserialize(s::AbstractSerializer, ::Type{Core.LineInfoNode})
         _meth = deserialize(s)
     end
     return Core.LineInfoNode(_meth::Symbol, deserialize(s)::Symbol, deserialize(s)::Int, deserialize(s)::Int)
+end
+
+function deserialize(s::AbstractSerializer, ::Type{PhiNode})
+    edges = deserialize(s)
+    if edges isa Vector{Any}
+        edges = Vector{Int32}(edges)
+    end
+    values = deserialize(s)::Vector{Any}
+    return PhiNode(edges, values)
 end
 
 function deserialize(s::AbstractSerializer, ::Type{CodeInfo})

--- a/test/compiler/interpreter_exec.jl
+++ b/test/compiler/interpreter_exec.jl
@@ -15,8 +15,8 @@ let m = Meta.@lower 1 + 1
         GlobalRef(@__MODULE__, :test29262),
         GotoIfNot(Core.SSAValue(3), 6),
         # block 2
-        Core.PhiNode(Any[4], Any[Core.SSAValue(1)]),
-        Core.PhiNode(Any[4, 5], Any[Core.SSAValue(2), Core.SSAValue(5)]),
+        Core.PhiNode(Int32[4], Any[Core.SSAValue(1)]),
+        Core.PhiNode(Int32[4, 5], Any[Core.SSAValue(2), Core.SSAValue(5)]),
         ReturnNode(Core.SSAValue(6)),
     ]
     nstmts = length(src.code)
@@ -40,18 +40,18 @@ let m = Meta.@lower 1 + 1
         QuoteNode(:c),
         GlobalRef(@__MODULE__, :test29262),
         # block 2
-        Core.PhiNode(Any[4, 16], Any[false, true]), # false, true
-        Core.PhiNode(Any[4, 16], Any[Core.SSAValue(1), Core.SSAValue(2)]), # :a, :b
-        Core.PhiNode(Any[4, 16], Any[Core.SSAValue(3), Core.SSAValue(6)]), # :c, :a
-        Core.PhiNode(Any[16], Any[Core.SSAValue(7)]), # NULL, :c
+        Core.PhiNode(Int32[4, 16], Any[false, true]), # false, true
+        Core.PhiNode(Int32[4, 16], Any[Core.SSAValue(1), Core.SSAValue(2)]), # :a, :b
+        Core.PhiNode(Int32[4, 16], Any[Core.SSAValue(3), Core.SSAValue(6)]), # :c, :a
+        Core.PhiNode(Int32[16], Any[Core.SSAValue(7)]), # NULL, :c
         # block 3
-        Core.PhiNode(Any[], Any[]), # NULL, NULL
-        Core.PhiNode(Any[17, 8], Any[true, Core.SSAValue(4)]), # test29262, test29262, [true]
-        Core.PhiNode(Any[17], Vector{Any}(undef, 1)), # NULL, NULL
-        Core.PhiNode(Any[8], Vector{Any}(undef, 1)), # NULL, NULL
-        Core.PhiNode(Any[], Any[]), # NULL, NULL
-        Core.PhiNode(Any[17, 8], Any[Core.SSAValue(2), Core.SSAValue(8)]), # NULL, :c, [:b]
-        Core.PhiNode(Any[], Any[]), # NULL, NULL
+        Core.PhiNode(Int32[], Any[]), # NULL, NULL
+        Core.PhiNode(Int32[17, 8], Any[true, Core.SSAValue(4)]), # test29262, test29262, [true]
+        Core.PhiNode(Int32[17], Vector{Any}(undef, 1)), # NULL, NULL
+        Core.PhiNode(Int32[8], Vector{Any}(undef, 1)), # NULL, NULL
+        Core.PhiNode(Int32[], Any[]), # NULL, NULL
+        Core.PhiNode(Int32[17, 8], Any[Core.SSAValue(2), Core.SSAValue(8)]), # NULL, :c, [:b]
+        Core.PhiNode(Int32[], Any[]), # NULL, NULL
         GotoIfNot(Core.SSAValue(5), 5),
         # block 4
         GotoIfNot(Core.SSAValue(10), 9),

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -15,17 +15,17 @@ let m = Meta.@lower 1 + 1
         Expr(:call, :opaque),
         GotoIfNot(Core.SSAValue(1), 10),
         # block 2
-        Core.PhiNode(Any[8], Any[Core.SSAValue(7)]), # <- This phi must not get replaced by %7
-        Core.PhiNode(Any[2, 8], Any[true, false]),
+        Core.PhiNode(Int32[8], Any[Core.SSAValue(7)]), # <- This phi must not get replaced by %7
+        Core.PhiNode(Int32[2, 8], Any[true, false]),
         GotoIfNot(Core.SSAValue(1), 7),
         # block 3
         Expr(:call, :+, Core.SSAValue(3), 1),
         # block 4
-        Core.PhiNode(Any[5, 6], Any[0, Core.SSAValue(6)]),
+        Core.PhiNode(Int32[5, 6], Any[0, Core.SSAValue(6)]),
         Expr(:call, >, Core.SSAValue(7), 10),
         GotoIfNot(Core.SSAValue(8), 3),
         # block 5
-        Core.PhiNode(Any[2, 8], Any[0, Core.SSAValue(7)]),
+        Core.PhiNode(Int32[2, 8], Any[0, Core.SSAValue(7)]),
         ReturnNode(Core.SSAValue(10)),
     ]
     nstmts = length(src.code)
@@ -147,7 +147,7 @@ let m = Meta.@lower 1 + 1
         # block 1
         nothing,
         # block 2
-        PhiNode(Any[1, 7], Any[Core.Argument(2), SSAValue(9)]),
+        PhiNode(Int32[1, 7], Any[Core.Argument(2), SSAValue(9)]),
         Expr(:call, isa, SSAValue(2), UnionAll),
         GotoIfNot(Core.SSAValue(3), 11),
         # block 3

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -22,7 +22,7 @@ end
 #        GotoIfNot(SlotNumber(2), 4),
 #        Expr(:(=), SlotNumber(3), 2),
 #        # Test a SlotNumber as a value of a PhiNode
-#        PhiNode(Any[2,3], Any[1, SlotNumber(3)]),
+#        PhiNode(Int32[2,3], Any[1, SlotNumber(3)]),
 #        ReturnNode(SSAValue(3))
 #    ]
 #
@@ -196,7 +196,7 @@ let ci = make_ci([
         # even though this value is defined after it. We don't want this to
         # happen even though this block is dead because subsequent optimization
         # passes may look at all code, dead or not.
-        Core.PhiNode(Any[2], Any[Core.SSAValue(4)]),
+        Core.PhiNode(Int32[2], Any[Core.SSAValue(4)]),
         Expr(:call, :something, Core.SSAValue(2)),
         Expr(:call, :something2),
         Core.Compiler.GotoNode(2),
@@ -226,7 +226,7 @@ let ci = make_ci([
         # Block 2 (no predecessors)
         Core.Compiler.ReturnNode(3),
         # Block 3
-        Core.PhiNode(Any[1, 2], Any[100, 200]),
+        Core.PhiNode(Int32[1, 2], Any[100, 200]),
         Core.Compiler.ReturnNode(Core.SSAValue(3))
     ])
     ir = Core.Compiler.inflate_ir(ci)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1743,7 +1743,7 @@ h_line() = f_line()
 @test repr(Core.Compiler.ReturnNode(23)) == ":(return 23)"
 @test repr(Core.Compiler.ReturnNode()) == ":(unreachable)"
 @test repr(Core.Compiler.GotoIfNot(true, 4)) == ":(goto %4 if not true)"
-@test repr(Core.Compiler.PhiNode(Any[2, 3], Any[1, Core.SlotNumber(3)])) == ":(φ (%2 => 1, %3 => _3))"
+@test repr(Core.Compiler.PhiNode(Int32[2, 3], Any[1, Core.SlotNumber(3)])) == ":(φ (%2 => 1, %3 => _3))"
 @test repr(Core.Compiler.UpsilonNode(Core.SlotNumber(3))) == ":(ϒ (_3))"
 @test repr(Core.Compiler.PhiCNode(Any[1, Core.SlotNumber(3)])) == ":(φᶜ (1, _3))"
 @test sprint(Base.show_unquoted, Core.Compiler.Argument(23)) == "_23"


### PR DESCRIPTION
This is pretty clearly the right type to use, but it does come with some annoyance of needing to convert to `Int` several places in the compiler. Seems worth it to me.

fixes #37078