### PR TITLE
Use Documenter 0.25.2

### DIFF
--- a/doc/Manifest.toml
+++ b/doc/Manifest.toml
@@ -19,9 +19,9 @@ version = "0.8.2"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "1c593d1efa27437ed9dd365d1143c594b563e138"
+git-tree-sha1 = "fb1ff838470573adc15c71ba79f8d31328f035da"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.25.1"
+version = "0.25.2"
 
 [[DocumenterLaTeX]]
 deps = ["Documenter", "Test"]

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -165,7 +165,7 @@ f (generic function with 2 methods)
 This output tells us that `f` is a function object with two methods. To find out what the signatures
 of those methods are, use the [`methods`](@ref) function:
 
-```julia-repl
+```jldoctest fofxy
 julia> methods(f)
 # 2 methods for generic function "f":
 [1] f(x::Float64, y::Float64) in Main at none:1

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -184,12 +184,21 @@ meaning that it is unconstrained since all values in Julia are instances of the 
 julia> f(x,y) = println("Whoa there, Nelly.")
 f (generic function with 3 methods)
 
+julia> methods(f)
+# 3 methods for generic function "f":
+[1] f(x::Float64, y::Float64) in Main at none:1
+[2] f(x::Number, y::Number) in Main at none:1
+[3] f(x, y) in Main at none:1
+
 julia> f("foo", 1)
 Whoa there, Nelly.
 ```
 
 This catch-all is less specific than any other possible method definition for a pair of parameter
 values, so it will only be called on pairs of arguments to which no other method definition applies.
+
+Note that in the signature of the third method, there is no type specified for the arguments `x` and `y`.
+This is a shortened way of expressing `f(x::Any, y::Any)`.
 
 Although it seems a simple concept, multiple dispatch on the types of values is perhaps the single
 most powerful and central feature of the Julia language. Core operations typically have dozens


### PR DESCRIPTION
This bumps Documenter to 0.25.2.

- 0.25.2 fixes the handing of `#`s in doctest output, so this re-applies the documentation changes from #36673 by reverting #36696.