### PR TITLE
Improve optimizations on NULL pointer check

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -56,8 +56,8 @@ function unsafe_convert end
 
 unsafe_convert(::Type{Ptr{UInt8}}, x::Symbol) = ccall(:jl_symbol_name, Ptr{UInt8}, (Any,), x)
 unsafe_convert(::Type{Ptr{Int8}}, x::Symbol) = ccall(:jl_symbol_name, Ptr{Int8}, (Any,), x)
-unsafe_convert(::Type{Ptr{UInt8}}, s::String) = convert(Ptr{UInt8}, pointer_from_objref(s)+sizeof(Int))
-unsafe_convert(::Type{Ptr{Int8}}, s::String) = convert(Ptr{Int8}, pointer_from_objref(s)+sizeof(Int))
+unsafe_convert(::Type{Ptr{UInt8}}, s::String) = ccall(:jl_string_ptr, Ptr{UInt8}, (Any,), s)
+unsafe_convert(::Type{Ptr{Int8}}, s::String) = ccall(:jl_string_ptr, Ptr{Int8}, (Any,), s)
 # convert strings to String etc. to pass as pointers
 cconvert(::Type{Ptr{UInt8}}, s::AbstractString) = String(s)
 cconvert(::Type{Ptr{Int8}}, s::AbstractString) = String(s)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -361,7 +361,7 @@ static AttributeList get_attrs_sext(LLVMContext &C)
 {
     return AttributeList::get(C,
                 AttributeSet(),
-                AttributeSet(),
+                Attributes(C, {Attribute::NonNull}),
                 {Attributes(C, {Attribute::SExt})});
 }
 
@@ -369,7 +369,7 @@ static AttributeList get_attrs_zext(LLVMContext &C)
 {
     return AttributeList::get(C,
                 AttributeSet(),
-                AttributeSet(),
+                Attributes(C, {Attribute::NonNull}),
                 {Attributes(C, {Attribute::ZExt})});
 }
 
@@ -614,7 +614,7 @@ static const auto jl_newbits_func = new JuliaFunction{
                 {T_prjlvalue, T_pint8}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
-            Attributes(C, {Attribute::NoAlias, Attribute::NonNull}),
+            Attributes(C, {Attribute::NonNull}),
             None); },
 };
 static const auto jl_typeof_func = new JuliaFunction{
@@ -769,9 +769,9 @@ BOX_FUNC(uint32, T_prjlvalue, T_int32, get_attrs_zext);
 BOX_FUNC(int64, T_prjlvalue, T_int64, get_attrs_sext);
 BOX_FUNC(uint64, T_prjlvalue, T_int64, get_attrs_zext);
 BOX_FUNC(char, T_prjlvalue, T_char, get_attrs_zext);
-BOX_FUNC(float32, T_prjlvalue, T_float32, nullptr);
-BOX_FUNC(float64, T_prjlvalue, T_float64, nullptr);
-BOX_FUNC(ssavalue, T_prjlvalue, T_size, nullptr);
+BOX_FUNC(float32, T_prjlvalue, T_float32, get_func_attrs);
+BOX_FUNC(float64, T_prjlvalue, T_float64, get_func_attrs);
+BOX_FUNC(ssavalue, T_prjlvalue, T_size, get_func_attrs);
 #undef BOX_FUNC
 
 
@@ -805,7 +805,7 @@ static const auto pointer_from_objref_func = new JuliaFunction{
             {PointerType::get(T_jlvalue, AddressSpace::Derived)}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet::get(C, makeArrayRef({Attribute::get(C, Attribute::ReadNone), Attribute::get(C, Attribute::NoUnwind)})),
-            AttributeSet(),
+            Attributes(C, {Attribute::NonNull}),
             None); },
 };
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1012,6 +1012,7 @@ STATIC_INLINE jl_value_t *jl_field_type_concrete(jl_datatype_t *st JL_PROPAGATES
 #define jl_datatype_nfields(t) (((jl_datatype_t*)(t))->layout->nfields)
 #define jl_datatype_isinlinealloc(t) (((jl_datatype_t *)(t))->isinlinealloc)
 
+JL_DLLEXPORT void *jl_symbol_name(jl_sym_t *s);
 // inline version with strong type check to detect typos in a `->name` chain
 STATIC_INLINE char *jl_symbol_name_(jl_sym_t *s) JL_NOTSAFEPOINT
 {


### PR DESCRIPTION
Mark more functions and calls as non-null and use inbounds gep instead of integer arithmetics
so that LLVM can more easily infer the non-null-ness of pointers. (Partially revert 2bb430e383809dcf5f73605a65f408c7e5bd22d6)

Also add inline optimization for `ccall` on `jl_symbol_name` and makes
sure the return value is treated as non-null by LLVM.