### PR TITLE
Use specific method when including eps docstring on Dates manual page

### DIFF
--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -671,7 +671,7 @@ Dates.Time(::Function, ::Any...)
 Dates.Time(::Dates.DateTime)
 Dates.now()
 Dates.now(::Type{Dates.UTC})
-Base.eps
+Base.eps(::Union{Type{DateTime}, Type{Date}, Type{Time}, TimeType})
 ```
 
 ### Accessor Functions


### PR DESCRIPTION
Currently, the generic docstrings will also get included on the Dates stdlib page. This also leads to broken links and doc build warnings. This makes sure that only the Dates-specific method is documented on the Dates stdlib page.