### PR TITLE
build: drop explicit support for pre-Mavericks OS in the default binaries

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -83,9 +83,6 @@ USE_OPROFILE_JITEVENTS ?= 0
 # Set to 1 to enable profiling with perf
 USE_PERF_JITEVENTS ?= 0
 
-# libc++ is standard on OS X 10.9, but not for earlier releases
-USE_LIBCPP := 0
-
 # assume we don't have LIBSSP support in our compiler, will enable later if likely true
 HAVE_SSP := 0
 
@@ -463,8 +460,6 @@ else
 FC := $(CROSS_COMPILE)gfortran
 endif
 
-STDLIBCPP_FLAG :=
-
 ifeq ($(OS), FreeBSD)
 USEGCC := 0
 USECLANG := 1
@@ -472,29 +467,28 @@ endif
 
 ifeq ($(OS), Darwin)
 DARWINVER := $(shell uname -r | cut -b 1-2)
-DARWINVER_GTE13 := $(shell expr `uname -r | cut -b 1-2` \>= 13)
-ifeq ($(DARWINVER), 10) # Snow Leopard specific configuration
+DARWINVER_GTE11 := $(shell expr $(DARWINVER) \>= 11)
+DARWINVER_GTE13 := $(shell expr $(DARWINVER) \>= 13)
+ifeq ($(DARWINVER_GTE11),0) # Snow Leopard specific configuration
 USEGCC := 1
 USECLANG := 0
+MACOSX_VERSION_MIN := 10.6
 OPENBLAS_TARGET_ARCH:=NEHALEM
 OPENBLAS_DYNAMIC_ARCH:=0
 USE_SYSTEM_LIBUNWIND:=1
 else
-ifeq ($(DARWINVER_GTE13),1)
-USE_LIBCPP := 1
-STDLIBCPP_FLAG := -stdlib=libstdc++
-else
-USE_LIBCPP := 0
-endif
+ifeq ($(DARWINVER_GTE13),0) # Lion / Mountain Lion specific configuration
+USEGCC := 0
+USECLANG := 1
+MACOSX_VERSION_MIN := 10.6
+else # Newer versions
 USEGCC := 0
 USECLANG := 1
 endif
 endif
+endif
 
 ifeq ($(USEGCC),1)
-ifeq ($(USE_LIBCPP),1)
-$(error USE_LIBCPP only supported with clang. Try setting USE_LIBCPP=0)
-endif
 ifeq ($(SANITIZE),1)
 $(error Sanitizers are only supported with clang. Try setting SANITIZE=0)
 endif
@@ -522,16 +516,12 @@ JCXXFLAGS := -pipe $(fPIC) -fno-rtti -pedantic
 DEBUGFLAGS := -O0 -g -DJL_DEBUG_BUILD -fstack-protector-all
 SHIPFLAGS := -O3 -g
 ifeq ($(OS), Darwin)
-ifeq ($(USE_LIBCPP), 1)
-MACOSX_VERSION_MIN := 10.8
-CC += -stdlib=libc++ -mmacosx-version-min=$(MACOSX_VERSION_MIN)
-CXX += -stdlib=libc++ -mmacosx-version-min=$(MACOSX_VERSION_MIN)
-FC += -mmacosx-version-min=$(MACOSX_VERSION_MIN)
-else
-MACOSX_VERSION_MIN := 10.6
-CC += $(STDLIBCPP_FLAG) -mmacosx-version-min=$(MACOSX_VERSION_MIN)
-CXX += $(STDLIBCPP_FLAG) -mmacosx-version-min=$(MACOSX_VERSION_MIN)
+ifeq ($(MACOSX_VERSION_MIN),)
+MACOSX_VERSION_MIN := 10.9
 endif
+CC += -mmacosx-version-min=$(MACOSX_VERSION_MIN)
+CXX += -mmacosx-version-min=$(MACOSX_VERSION_MIN)
+FC += -mmacosx-version-min=$(MACOSX_VERSION_MIN)
 # export MACOSX_DEPLOYMENT_TARGET so that ld picks it up, especially for deps
 export MACOSX_DEPLOYMENT_TARGET=$(MACOSX_VERSION_MIN)
 JCPPFLAGS += -D_LARGEFILE_SOURCE -D_DARWIN_USE_64_BIT_INODE=1
@@ -539,9 +529,6 @@ endif
 endif
 
 ifeq ($(USEICC),1)
-ifeq ($(USE_LIBCPP),1)
-$(error USE_LIBCPP only supported with clang. Try setting USE_LIBCPP=0)
-endif
 ifeq ($(SANITIZE),1)
 $(error Sanitizers only supported with clang. Try setting SANITIZE=0)
 endif

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -88,6 +88,7 @@ LLVM_CPPFLAGS += $(CPPFLAGS)
 LLVM_LDFLAGS += $(LDFLAGS)
 LLVM_CMAKE += -DLLVM_TARGETS_TO_BUILD:STRING="$(LLVM_TARGETS)" -DCMAKE_BUILD_TYPE="$(LLVM_CMAKE_BUILDTYPE)"
 LLVM_CMAKE += -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_LIBXML2=OFF -DLLVM_HOST_TRIPLE="$(or $(XC_HOST),$(BUILD_MACHINE))"
+LLVM_CMAKE += -DCOMPILER_RT_ENABLE_IOS=OFF -DCOMPILER_RT_ENABLE_WATCHOS=OFF -DCOMPILER_RT_ENABLE_TVOS=OFF
 ifeq ($(USE_POLLY_ACC),1)
 LLVM_CMAKE += -DPOLLY_ENABLE_GPGPU_CODEGEN=ON
 endif
@@ -187,6 +188,15 @@ endif # BUILD_CUSTOM_LIBCXX
 
 LLVM_CMAKE += -DCMAKE_C_FLAGS="$(LLVM_CPPFLAGS) $(LLVM_CFLAGS)" \
 	-DCMAKE_CXX_FLAGS="$(LLVM_CPPFLAGS) $(LLVM_CXXFLAGS)"
+# We force some flags into other build systems, but LLVM doesn't need them,
+# and it makes it harder for it to compile some of its support libraries,
+# so let's force those to be ignored here
+LLVM_CMAKE += -DCMAKE_CXX_COMPILER_ARG1=""
+LLVM_CMAKE += -DCMAKE_C_COMPILER_ARG1=""
+ifeq ($(OS),Darwin)
+# Explicitly use the default for -mmacosx-version-min=10.9 and later
+LLVM_CMAKE += -DLLVM_ENABLE_LIBCXX=ON
+endif
 
 ifeq ($(BUILD_LLVM_CLANG),0)
 # block default building of Clang

--- a/doc/src/devdocs/sanitizers.md
+++ b/doc/src/devdocs/sanitizers.md
@@ -14,6 +14,19 @@ folder by specifying `USECLANG=1` while overriding the `CC` and `CXX` variables.
 To use one of of the sanitizers set `SANITIZE=1` and then the appropriate flag for the sanitizer you
 want to use.
 
+On macOS, this might need some extra flags also to work. Altogether, it might
+look like this, plus one or more of the `SANITIZE_*` flags listed below:
+
+    make -C deps USE_BINARYBUILDER_LLVM=0 LLVM_VER=svn stage-llvm
+
+    make -C src SANITIZE=1 USECLANG=1 \
+        CC=~+/deps/scratch/llvm-svn/build_Release/bin/clang \
+        CXX=~+/deps/scratch/llvm-svn/build_Release/bin/clang++ \
+        CPPFLAGS="-isysroot $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" \
+        CXXFLAGS="-isystem $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"
+
+(or put these into your `Make.user`, so you don't need to remember them every time).
+
 ## Address Sanitizer (ASAN)
 
 For detecting or debugging memory bugs, you can use Clang's [address sanitizer (ASAN)](http://clang.llvm.org/docs/AddressSanitizer.html).


### PR DESCRIPTION
Hypothetically still supported in the build system back to 10.6 or so,
though I doubt it has been tested in a long time on such a system.

This lets us avoid needing to specify the libc++ explicitly, which makes
the build a bit simpler, and can help with building `clang` in our
`deps` folder (which may try to to build support libraries for foreign
targets, and get confused by these extra flags).