### PR TITLE
Avoid several bad `show_default` invalidations

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -287,7 +287,8 @@ function showerror(io::IO, ex::MethodError)
             )
             varnames = ("scalar", "array")
             first, second = arg_types_param[1] <: Number ? varnames : reverse(varnames)
-            print(io, "\nFor element-wise $(nouns[f]), use broadcasting with dot syntax: $first .$f $second")
+            fstring = f === Base.:+ ? "+" : "-"  # avoid depending on show_default for functions (invalidation)
+            print(io, "\nFor element-wise $(nouns[f]), use broadcasting with dot syntax: $first .$fstring $second")
         end
     end
     if ft <: AbstractArray

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1515,7 +1515,7 @@ function stale_cachefile(modpath::String, cachefile::String)
                     skip_timecheck = true
                     break
                 end
-                @debug "Rejecting cache file $cachefile because it provides the wrong uuid (got $build_id) for $mod (want $req_build_id)"
+                @debug "Rejecting cache file $cachefile because it provides the wrong uuid (got $build_id) for $req_key (want $req_build_id)"
                 return true # cachefile doesn't provide the required version of the dependency
             end
         end

--- a/base/show.jl
+++ b/base/show.jl
@@ -904,7 +904,7 @@ function gettypeinfos(io::IO, p::Pair)
 end
 
 function show(io::IO, p::Pair)
-    isdelimited(io, p) && return show_default(io, p)
+    isdelimited(io, p) && return show_pairtyped(io, p)
     typeinfos = gettypeinfos(io, p)
     for i = (1, 2)
         io_i = IOContext(io, :typeinfo => typeinfos[i])
@@ -913,6 +913,11 @@ function show(io::IO, p::Pair)
         isdelimited(io_i, p[i]) || print(io, ")")
         i == 1 && print(io, get(io, :compact, false) ? "=>" : " => ")
     end
+end
+
+function show_pairtyped(io::IO, p::Pair{K,V}) where {K,V}
+    print(io, "Pair{", K, ',', V, '}')
+    show(io, (p.first, p.second))
 end
 
 function show(io::IO, m::Module)
@@ -2401,6 +2406,7 @@ end
 
 const undef_ref_str = "#undef"
 
+show(io::IO, ::UndefInitializer) = print(io, "UndefInitializer()")
 
 """
     summary(io::IO, x)

--- a/base/show.jl
+++ b/base/show.jl
@@ -916,7 +916,7 @@ function show(io::IO, p::Pair)
 end
 
 function show_pairtyped(io::IO, p::Pair{K,V}) where {K,V}
-    print(io, "Pair{", K, ',', V, '}')
+    show(io, typeof(p))
     show(io, (p.first, p.second))
 end
 

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -140,7 +140,7 @@ getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host),
 function getaddrinfo(host::AbstractString)
     addrs = getalladdrinfo(String(host))
     if !isempty(addrs)
-        return addrs[begin]
+        return addrs[begin]::Union{IPv4,IPv6}
     end
     throw(DNSError(host, UV_EAI_NONAME))
 end


### PR DESCRIPTION
This fixes 53 quite critical invalidations from loading StaticArrays. At least by our old standards, 53 invalidations would be considered a modest number, but in this case they manage to hit the package-loading code, the docstring code, and the `MethodError` display code. Since particularly the first two are used by *everything*, these invalidations are about as bad as they could be.

The invalidation of the package-loading code is due to a rather hilarious chain of events. [This method definition](https://github.com/JuliaArrays/StaticArrays.jl/blob/ad583c99768f3a381ba20b1a0782c9ca50890b50/src/SArray.jl#L125-L126)
ends up invalidating [`show_default`](https://github.com/JuliaLang/julia/blob/89d6b469b633dde8f92b4d245ca3d8e5606e229c/base/show.jl#L417), which got called because `stale_cachefile` used an outdated variable name in a [`@debug` macro](https://github.com/JuliaLang/julia/blob/89d6b469b633dde8f92b4d245ca3d8e5606e229c/base/loading.jl#L1518) that ended up grabbing the global `mod` function. Since `show(::IO, ::Function)` can call `show_default`, this ended up invalidating basically all the package-loading code.

The docstring code got invalidated because `show(::IO, ::Pair{Symbol,Any})` [calls `show_default`](https://github.com/JuliaLang/julia/blob/89d6b469b633dde8f92b4d245ca3d8e5606e229c/base/show.jl#L907). This PR provides a dedicated path that circumvents `show_default`.

Finally, an innocuous-seeming function-print in `showerror(::IO, ::MethodError)` also led to quite a chain of invalidation.

EDIT: as pointed out below by @KristofferC, this fixes #36005. (~If master hadn't already fixed it, I haven't checked.~)