### PR TITLE
doc: move `at-noinline` note into admonition

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -213,9 +213,10 @@ prevented. This is shown in the following example:
         Function Definition
     =#
 end
-
-If the function is trivial (for example returning a constant) it might get inlined anyway.
 ```
+
+!!! note
+    If the function is trivial (for example returning a constant) it might get inlined anyway.
 """
 macro noinline(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :noinline) : ex)


### PR DESCRIPTION
would look nicer:
![image](https://user-images.githubusercontent.com/40514306/90728247-8be80d00-e2ff-11ea-855f-623381a847ff.png)
