### PR TITLE
Fix a couple of invalidations for tuple-handling

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -58,8 +58,9 @@ end
 
 ## data movement ##
 
-function reverse(A::Array{T}; dims::Integer) where T
-    nd = ndims(A); d = dims
+reverse(A::Array; dims::Integer) = _reverse_int(A, Int(dims))
+function _reverse_int(A::Array{T}, d::Int) where T
+    nd = ndims(A)
     1 ≤ d ≤ nd || throw(ArgumentError("dimension $d is not 1 ≤ $d ≤ $nd"))
     sd = size(A, d)
     if sd == 1 || isempty(A)
@@ -70,7 +71,7 @@ function reverse(A::Array{T}; dims::Integer) where T
 
     nnd = 0
     for i = 1:nd
-        nnd += Int(size(A,i)==1 || i==d)
+        nnd += size(A,i)==1 || i==d
     end
     if nnd==nd
         # reverse along the only non-singleton dimension
@@ -81,8 +82,10 @@ function reverse(A::Array{T}; dims::Integer) where T
     end
 
     d_in = size(A)
-    leading = d_in[1:(d-1)]
-    M = prod(leading)
+    M = 1
+    for i = 1:d-1
+        M *= d_in[i]
+    end
     N = length(A)
     stride = M * sd
 

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -90,6 +90,7 @@ Base.HasLength()
 IteratorSize(x) = IteratorSize(typeof(x))
 IteratorSize(::Type) = HasLength()  # HasLength is the default
 
+IteratorSize(::Type{<:Tuple}) = HasLength()
 IteratorSize(::Type{<:AbstractArray{<:Any,N}})  where {N} = HasShape{N}()
 IteratorSize(::Type{Generator{I,F}}) where {I,F} = IteratorSize(I)
 


### PR DESCRIPTION
Defining a method of `IteratorSize` prevents invalidation via the fallback.