### PR TITLE
Add missing docstring for `zero` function which input is type

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -223,7 +223,7 @@ map(f, x::Number, ys::Number...) = f(x, ys...)
 
 """
     zero(x)
-    zero(T::type)
+    zero(::Type)
 
 Get the additive identity element for the type of `x` (`x` can also specify the type itself).
 
@@ -246,7 +246,7 @@ zero(::Type{T}) where {T<:Number} = convert(T,0)
 
 """
     one(x)
-    one(::Type)
+    one(T::type)
 
 Return a multiplicative identity for `x`: a value such that
 `one(x)*x == x*one(x) == x`.  Alternatively `one(T)` can

--- a/base/number.jl
+++ b/base/number.jl
@@ -223,6 +223,7 @@ map(f, x::Number, ys::Number...) = f(x, ys...)
 
 """
     zero(x)
+    zero(T::type)
 
 Get the additive identity element for the type of `x` (`x` can also specify the type itself).
 

--- a/base/number.jl
+++ b/base/number.jl
@@ -246,7 +246,7 @@ zero(::Type{T}) where {T<:Number} = convert(T,0)
 
 """
     one(x)
-    one(T::type)
+    one(::Type)
 
 Return a multiplicative identity for `x`: a value such that
 `one(x)*x == x*one(x) == x`.  Alternatively `one(T)` can


### PR DESCRIPTION
I found `zero` function can accept a type, not only a variable:

```
julia> zero(1.0)
0.0

julia> zero(Float64)
0.0
```

But, its docstring looks like missing later one, so I added it.