### PR TITLE
Make parser link work in Documenter

### DIFF
--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -198,7 +198,7 @@ and
 \oplus `⊕`
 
 The complete list is in the parser code:
-https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm
+<https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm>
 
 Those that are parsed like `*` (in terms of precedence) include
 `* / ÷ % & ⋅ ∘ × |\\| ∩ ∧ ⊗ ⊘ ⊙ ⊚ ⊛ ⊠ ⊡ ⊓ ∗ ∙ ∤ ⅋ ≀ ⊼ ⋄ ⋆ ⋇ ⋉ ⋊ ⋋ ⋌ ⋏ ⋒ ⟑ ⦸ ⦼ ⦾ ⦿ ⧶ ⧷ ⨇ ⨰ ⨱ ⨲ ⨳ ⨴ ⨵ ⨶ ⨷ ⨸ ⨻ ⨼ ⨽ ⩀ ⩃ ⩄ ⩋ ⩍ ⩎ ⩑ ⩓ ⩕ ⩘ ⩚ ⩜ ⩞ ⩟ ⩠ ⫛ ⊍ ▷ ⨝ ⟕ ⟖ ⟗`


### PR DESCRIPTION
It currently doesn't work, as you can see on https://docs.julialang.org/en/v1/base/math/#Customizable-binary-operators-1.