### PR TITLE
Override read-only permissions during `rm(path, recursive=true, force=true)`

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -274,6 +274,10 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
         end
     else
         if recursive
+            # If folders don't have write access, we can't remove children from them.
+            if force
+                chmod(path, filemode(path) | 0o200)
+            end
             for p in readdir(path)
                 rm(joinpath(path, p), force=force, recursive=true)
             end

--- a/test/file.jl
+++ b/test/file.jl
@@ -432,6 +432,13 @@ cp(newfile, c_file)
 @test_throws SystemError rm(c_tmpdir)
 @test_throws SystemError rm(c_tmpdir, force=true)
 
+# Test force-deletion of directories with children and that have no write permissions
+nw_tmpdir = mktempdir()
+touch(joinpath(nw_tmpdir, "foo"))
+chmod(nw_tmpdir, 0o555, recursive=true)
+rm(nw_tmpdir; recursive=true, force=true)
+@test !isdir(nw_tmpdir)
+
 # create temp dir in specific directory
 d_tmpdir = mktempdir(c_tmpdir)
 @test isdir(d_tmpdir)


### PR DESCRIPTION
If a directory is marked as read-only for the current user, `rm()` can
fail when a child within that directory is attempted to be removed.
This is most annoying when recursively removing directories where one of
the directories has been set to read-only.  This PR changes a recursive
remove to first set all directories to writable before removing them,
but only when `force` is set to `true`.

This is particularly a problem with artifacts, as some artifacts (such as the MacOS SDK shards) have strange installation procedures where the install script sets a directory as read-only; then when the user removes BinaryBuilder and tries to `Pkg.gc()` the artifacts, it fails.  We have a patch in-flight to Pkg to fix that in particular, but it seems that `force=true` should perform all reasonable steps to ensure that the operation goes through without an issue.