### PR TITLE
Improve inference for paths leading to `similar`

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -116,7 +116,7 @@ julia> instances(Fruit)
 (apple, orange, kiwi)
 ```
 """
-macro enum(T, syms...)
+macro enum(T::Union{Symbol,Expr}, syms...)
     if isempty(syms)
         throw(ArgumentError("no arguments given for Enum $T"))
     end
@@ -131,7 +131,7 @@ macro enum(T, syms...)
     elseif !isa(T, Symbol)
         throw(ArgumentError("invalid type expression for enum $T"))
     end
-    values = basetype[]
+    values = basetype[]::Vector
     seen = Set{Symbol}()
     namemap = Dict{basetype,Symbol}()
     lo = hi = 0

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -131,7 +131,7 @@ macro enum(T::Union{Symbol,Expr}, syms...)
     elseif !isa(T, Symbol)
         throw(ArgumentError("invalid type expression for enum $T"))
     end
-    values = basetype[]::Vector
+    values = Vector{basetype}()
     seen = Set{Symbol}()
     namemap = Dict{basetype,Symbol}()
     lo = hi = 0

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -211,11 +211,12 @@ eachindex(itrs...) = keys(itrs...)
 # eachindex iterates over all indices. IndexCartesian definitions are later.
 eachindex(A::AbstractVector) = (@_inline_meta(); axes1(A))
 
-@noinline function throw_eachindex_mismatch(::IndexLinear, A...)
-    throw(DimensionMismatch("all inputs to eachindex must have the same indices, got $(join(eachindex.(A), ", ", " and "))"))
+
+@noinline function throw_eachindex_mismatch_indices(::IndexLinear, inds...)
+    throw(DimensionMismatch("all inputs to eachindex must have the same indices, got $(join(inds, ", ", " and "))"))
 end
-@noinline function throw_eachindex_mismatch(::IndexCartesian, A...)
-    throw(DimensionMismatch("all inputs to eachindex must have the same axes, got $(join(axes.(A), ", ", " and "))"))
+@noinline function throw_eachindex_mismatch_indices(::IndexCartesian, inds...)
+    throw(DimensionMismatch("all inputs to eachindex must have the same axes, got $(join(inds, ", ", " and "))"))
 end
 
 """
@@ -269,7 +270,7 @@ function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
     @_inline_meta
     indsA = eachindex(IndexLinear(), A)
     _all_match_first(X->eachindex(IndexLinear(), X), indsA, B...) ||
-        throw_eachindex_mismatch(IndexLinear(), A, B...)
+        throw_eachindex_mismatch_indices(IndexLinear(), eachindex(A), eachindex.(B)...)
     indsA
 end
 function _all_match_first(f::F, inds, A, B...) where F<:Function

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2232,13 +2232,7 @@ end
 map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 
 mapany(f, A::AbstractArray) = map!(f, Vector{Any}(undef, length(A)), A)
-function mapany(f, itr)
-    ret = []
-    for x in itr
-        push!(ret, f(x))
-    end
-    return ret
-end
+mapany(f, itr) = Any[f(x) for x in itr]
 
 # default to returning an Array for `map` on general iterators
 """

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2231,7 +2231,14 @@ end
 # map on collections
 map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 
-mapany(f, itr) = map!(f, Vector{Any}(undef, length(itr)::Int), itr)  # convenient for Expr.args
+mapany(f, A::AbstractArray) = map!(f, Vector{Any}(undef, length(A)), A)
+function mapany(f, itr)
+    ret = []
+    for x in itr
+        push!(ret, f(x))
+    end
+    return ret
+end
 
 # default to returning an Array for `map` on general iterators
 """

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -425,7 +425,7 @@ _show_nonempty(io::IO, X::AbstractArray{T,0} where T, prefix::String) = print_ar
 
 # NOTE: it's not clear how this method could use the :typeinfo attribute
 function _show_empty(io::IO, X::Array)
-    show_datatype(io, typeof(X))
+    show(io, typeof(X))
     print(io, "(undef, ", join(size(X),", "), ')')
 end
 _show_empty(io, X::AbstractArray) = summary(io, X)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1810,7 +1810,12 @@ end
 
 function vcat(A::BitMatrix...)
     nargs = length(A)
-    nrows = sum(a->size(a, 1), A)::Int
+    nrows, nrowsA = 0, sizehint!(Int[], nargs)
+    for a in A
+        sz1 = size(a, 1)
+        nrows += sz1
+        push!(nrowsA, sz1)
+    end
     ncols = size(A[1], 2)
     for j = 2:nargs
         size(A[j], 2) == ncols ||
@@ -1818,12 +1823,10 @@ function vcat(A::BitMatrix...)
     end
     B = BitMatrix(undef, nrows, ncols)
     Bc = B.chunks
-    nrowsA = [size(a, 1) for a in A]
-    Ac = [a.chunks for a in A]
     pos_d = 1
     pos_s = fill(1, nargs)
     for j = 1:ncols, k = 1:nargs
-        copy_chunks!(Bc, pos_d, Ac[k], pos_s[k], nrowsA[k])
+        copy_chunks!(Bc, pos_d, A[k].chunks, pos_s[k], nrowsA[k])
         pos_s[k] += nrowsA[k]
         pos_d += nrowsA[k]
     end

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1173,7 +1173,7 @@ function undot(x::Expr)
     if x.head === :.=
         Expr(:(=), x.args...)
     elseif x.head === :block # occurs in for x=..., y=...
-        Expr(:block, map(undot, x.args)...)
+        Expr(:block, mapany(undot, x.args)...)
     else
         x
     end

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -239,8 +239,8 @@ function inlineanonymous(ex::Expr, val)
     if !isa(ex.args[1], Symbol)
         throw(ArgumentError("not a single-argument anonymous function"))
     end
-    sym = ex.args[1]
-    ex = ex.args[2]
+    sym = ex.args[1]::Symbol
+    ex = ex.args[2]::Expr
     exout = lreplace(ex, sym, val)
     exout = poplinenum(exout)
     exprresolve(exout)
@@ -262,7 +262,7 @@ struct LReplace{S<:AbstractString}
 end
 LReplace(sym::Symbol, val::Integer) = LReplace(sym, string(sym), val)
 
-lreplace(ex, sym::Symbol, val) = lreplace!(copy(ex), LReplace(sym, val))
+lreplace(ex::Expr, sym::Symbol, val) = lreplace!(copy(ex), LReplace(sym, val))
 
 function lreplace!(sym::Symbol, r::LReplace)
     sym == r.pat_sym && return r.val

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -11,7 +11,7 @@ struct Cmd <: AbstractCmd
     exec::Vector{String}
     ignorestatus::Bool
     flags::UInt32 # libuv process flags
-    env::Union{Array{String},Nothing}
+    env::Union{Vector{String},Nothing}
     dir::String
     Cmd(exec::Vector{String}) =
         new(exec, false, 0x00, nothing, "")

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -92,13 +92,13 @@ function deepcopy_internal(x::Array, stackdict::IdDict)
     _deepcopy_array_t(x, eltype(x), stackdict)
 end
 
-function _deepcopy_array_t(@nospecialize(x), T, stackdict::IdDict)
+function _deepcopy_array_t(@nospecialize(x::Array), T, stackdict::IdDict)
     if isbitstype(T)
         return (stackdict[x]=copy(x))
     end
     dest = similar(x)
     stackdict[x] = dest
-    for i = 1:(length(x)::Int)
+    for i = 1:length(x)
         if ccall(:jl_array_isassigned, Cint, (Any, Csize_t), x, i-1) != 0
             xi = ccall(:jl_arrayref, Any, (Any, Csize_t), x, i-1)
             if !isbits(xi)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -225,7 +225,7 @@ function showerror(io::IO, ex::MethodError)
     # ex.args is a tuple type if it was thrown from `invoke` and is
     # a tuple of the arguments otherwise.
     is_arg_types = isa(ex.args, DataType)
-    arg_types = is_arg_types ? ex.args : typesof(ex.args...)
+    arg_types = (is_arg_types ? ex.args : typesof(ex.args...))::DataType
     f = ex.f
     meth = methods_including_ambiguous(f, arg_types)
     if length(meth) > 1
@@ -782,7 +782,7 @@ function show_backtrace(io::IO, t::Vector)
 
     try invokelatest(update_stackframes_callback[], filtered) catch end
     # process_backtrace returns a Vector{Tuple{Frame, Int}}
-    frames = (first.(filtered))::Vector{StackFrame}
+    frames = map(x->first(x)::StackFrame, filtered)
     show_full_backtrace(io, frames; print_linebreaks = stacktrace_linebreaks())
     return
 end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -67,9 +67,9 @@ function copy(c::CodeInfo)
     cnew.slotnames = copy(cnew.slotnames)
     cnew.slotflags = copy(cnew.slotflags)
     cnew.codelocs  = copy(cnew.codelocs)
-    cnew.linetable = copy(cnew.linetable)
+    cnew.linetable = copy(cnew.linetable::Union{Vector{Any},Vector{Core.LineInfoNode}})
     cnew.ssaflags  = copy(cnew.ssaflags)
-    cnew.edges     = cnew.edges === nothing ? nothing : copy(cnew.edges)
+    cnew.edges     = cnew.edges === nothing ? nothing : copy(cnew.edges::Vector)
     ssavaluetypes  = cnew.ssavaluetypes
     ssavaluetypes isa Vector{Any} && (cnew.ssavaluetypes = copy(ssavaluetypes))
     return cnew

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -335,7 +335,7 @@ module IteratorsMD
 
     @inline function eachindex(::IndexCartesian, A::AbstractArray, B::AbstractArray...)
         axsA = axes(A)
-        Base._all_match_first(axes, axsA, B...) || Base.throw_eachindex_mismatch(IndexCartesian(), A, B...)
+        Base._all_match_first(axes, axsA, B...) || Base.throw_eachindex_mismatch_indices(IndexCartesian(), axes(A), axes.(B)...)
         CartesianIndices(axsA)
     end
 

--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -31,10 +31,16 @@ julia> ntuple(i -> 2*i, 4)
     return t
 end
 
-function _ntuple(f, n)
+function _ntuple(f::F, n) where F
     @_noinline_meta
     (n >= 0) || throw(ArgumentError(string("tuple length should be ≥ 0, got ", n)))
     ([f(i) for i = 1:n]...,)
+end
+
+function ntupleany(f, n)
+    @_noinline_meta
+    (n >= 0) || throw(ArgumentError(string("tuple length should be ≥ 0, got ", n)))
+    (Any[f(i) for i = 1:n]...,)
 end
 
 # inferrable ntuple (enough for bootstrapping)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -170,7 +170,7 @@ julia> fieldnames(Rational)
 ```
 """
 fieldnames(t::DataType) = (fieldcount(t); # error check to make sure type is specific enough
-                           (_fieldnames(t)...,))
+                           (_fieldnames(t)...,))::Tuple{Vararg{Symbol}}
 fieldnames(t::UnionAll) = fieldnames(unwrap_unionall(t))
 fieldnames(::Core.TypeofBottom) =
     throw(ArgumentError("The empty type does not have field names since it does not have instances."))
@@ -871,8 +871,8 @@ function methods_including_ambiguous(@nospecialize(f), @nospecialize(t))
     max = UInt[typemax(UInt)]
     has_ambig = Int32[0]
     ms = _methods_by_ftype(tt, -1, world, true, min, max, has_ambig)
-    ms === false && return false
-    return MethodList(Method[m.method for m in ms], typeof(f).name.mt)
+    isa(ms, Bool) && return ms
+    return MethodList(Method[(m::Core.MethodMatch).method for m in ms], typeof(f).name.mt)
 end
 
 function methods(@nospecialize(f),

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -698,7 +698,7 @@ julia> fieldtypes(Foo)
 (Int64, String)
 ```
 """
-fieldtypes(T::Type) = ntuple(i -> fieldtype(T, i), fieldcount(T))
+fieldtypes(T::Type) = ntupleany(i -> fieldtype(T, i), fieldcount(T))
 
 # return all instances, for types that can be enumerated
 

--- a/base/ryu/utils.jl
+++ b/base/ryu/utils.jl
@@ -355,7 +355,7 @@ function pow5invsplit_lookup end
 for T in (Float64, Float32, Float16)
     e2_max = exponent_max(T) - precision(T) - 2
     i_max = log10pow2(e2_max)
-    table = [pow5invsplit(T, i) for i = 0:i_max]
+    table = Any[pow5invsplit(T, i) for i = 0:i_max]
     @eval pow5invsplit_lookup(::Type{$T}, i) = @inbounds($table[i+1])
 end
 
@@ -382,7 +382,7 @@ function pow5split_lookup end
 for T in (Float64, Float32, Float16)
     e2_min = 1 - exponent_bias(T) - significand_bits(T) - 2
     i_max = 1 - e2_min - log10pow5(-e2_min)
-    table = [pow5split(T, i) for i = 0:i_max]
+    table = Any[pow5split(T, i) for i = 0:i_max]
     @eval pow5split_lookup(::Type{$T}, i) = @inbounds($table[i+1])
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -844,13 +844,14 @@ function show_type_name(io::IO, tn::Core.TypeName)
     nothing
 end
 
-function show_datatype(io::IO, x::DataType)
+function show_datatype(io::IO, @nospecialize(x::DataType))
+    parameters = x.parameters::SimpleVector
     istuple = x.name === Tuple.name
-    n = length(x.parameters)::Int
+    n = length(parameters)
 
     # Print homogeneous tuples with more than 3 elements compactly as NTuple{N, T}
-    if istuple && n > 3 && all(i -> (x.parameters[1] === i), x.parameters)
-        print(io, "NTuple{", n, ", ", x.parameters[1], "}")
+    if istuple && n > 3 && all(i -> (parameters[1] === i), parameters)
+        print(io, "NTuple{", n, ", ", parameters[1], "}")
     else
         show_type_name(io, x.name)
         if (n > 0 || istuple) && x !== Tuple
@@ -860,7 +861,7 @@ function show_datatype(io::IO, x::DataType)
             # since this information is still useful.
             print(io, '{')
             for i = 1:n
-                p = x.parameters[i]
+                p = parameters[i]
                 show(io, p)
                 i < n && print(io, ", ")
             end

--- a/base/util.jl
+++ b/base/util.jl
@@ -520,7 +520,7 @@ to the standard libraries before running the tests.
 If a seed is provided via the keyword argument, it is used to seed the
 global RNG in the context where the tests are run; otherwise the seed is chosen randomly.
 """
-function runtests(tests = ["all"]; ncores = ceil(Int, Sys.CPU_THREADS / 2),
+function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int / 2),
                   exit_on_error::Bool=false,
                   revise::Bool=false,
                   seed::Union{BitInteger,Nothing}=nothing)

--- a/base/version.jl
+++ b/base/version.jl
@@ -101,10 +101,8 @@ $"ix
 
 function split_idents(s::AbstractString)
     idents = split(s, '.')
-    ntuple(length(idents)) do i
-        ident = idents[i]
-        occursin(r"^\d+$", ident) ? parse(UInt64, ident) : String(ident)
-    end
+    pidents = Union{UInt64,String}[occursin(r"^\d+$", ident) ? parse(UInt64, ident) : String(ident) for ident in idents]
+    return tuple(pidents...)::VerTuple
 end
 
 function VersionNumber(v::AbstractString)

--- a/base/views.jl
+++ b/base/views.jl
@@ -180,7 +180,7 @@ function _views(ex::Expr)
             Expr(:let,
                  Expr(:block,
                       :($a = $(_views(lhs.args[1]))),
-                      [:($(i[k]) = $(_views(lhs.args[k+1]))) for k=1:length(i)]...),
+                      Any[:($(i[k]) = $(_views(lhs.args[k+1]))) for k=1:length(i)]...),
                  Expr(first(h) == '.' ? :(.=) : :(=), :($a[$(I...)]),
                       Expr(:call, Symbol(h[1:end-1]),
                            :($maybeview($a, $(I...))),

--- a/base/views.jl
+++ b/base/views.jl
@@ -169,9 +169,10 @@ function _views(ex::Expr)
             # splat the corresponding temp var.
             I = similar(i, Any)
             for k = 1:length(i)
-                if Meta.isexpr(lhs.args[k+1], :...)
+                argk1 = lhs.args[k+1]
+                if Meta.isexpr(argk1, :...)
                     I[k] = Expr(:..., i[k])
-                    lhs.args[k+1] = lhs.args[k+1].args[1] # unsplat
+                    lhs.args[k+1] = (argk1::Expr).args[1] # unsplat
                 else
                     I[k] = i[k]
                 end

--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Generate encode table.
-const BASE64_ENCODE = [UInt8(x) for x in Char['A':'Z'; 'a':'z'; '0':'9'; '+'; '/']]
+const BASE64_ENCODE = [UInt8(x) for x in append!(['A':'Z'; 'a':'z'; '0':'9'], ['+', '/'])]
 encode(x::UInt8) = @inbounds return BASE64_ENCODE[(x & 0x3f) + 1]
 encodepadding()  = UInt8('=')
 

--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -13,7 +13,8 @@ import Base: getindex, wait, put!, take!, fetch, isready, push!, length,
 using Base: Process, Semaphore, JLOptions, buffer_writes, @sync_add,
             VERSION_STRING, binding_module, atexit, julia_exename,
             julia_cmd, AsyncGenerator, acquire, release, invokelatest,
-            shell_escape_posixly, uv_error, something, notnothing, isbuffered
+            shell_escape_posixly, uv_error, something, notnothing, isbuffered,
+            mapany
 using Base.Threads: Event
 
 using Serialization, Sockets

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1024,8 +1024,8 @@ end
 function _rmprocs(pids, waitfor)
     lock(worker_lock)
     try
-        rmprocset = []
-        for p in vcat(pids...)
+        rmprocset = Union{LocalProcess, Worker}[]
+        for p in pids
             if p == 1
                 @warn "rmprocs: process 1 not removed"
             else

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -654,10 +654,10 @@ function create_worker(manager, wconfig)
         end
     end
 
-    all_locs = map(x -> isa(x, Worker) ?
-                   (something(x.config.connect_at, ()), x.id) :
-                   ((), x.id, true),
-                   join_list)
+    all_locs = mapany(x -> isa(x, Worker) ?
+                      (something(x.config.connect_at, ()), x.id) :
+                      ((), x.id, true),
+                      join_list)
     send_connection_hdr(w, true)
     enable_threaded_blas = something(wconfig.enable_threaded_blas, false)
     join_message = JoinPGRPMsg(w.id, all_locs, PGRP.topology, enable_threaded_blas, isclusterlazy())

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -765,7 +765,7 @@ let next_pid = 2    # 1 is reserved for the client (always)
 end
 
 mutable struct ProcessGroup
-    name::AbstractString
+    name::String
     workers::Array{Any,1}
     refs::Dict{RRID,Any}                  # global references
     topology::Symbol

--- a/stdlib/Distributed/src/macros.jl
+++ b/stdlib/Distributed/src/macros.jl
@@ -275,7 +275,7 @@ function preduce(reducer, f, R)
         schedule(t)
         push!(w_exec, t)
     end
-    reduce(reducer, [fetch(t) for t in w_exec])
+    reduce(reducer, Any[fetch(t) for t in w_exec])
 end
 
 function pfor(f, R)

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -504,7 +504,7 @@ function connect(manager::ClusterManager, pid::Int, config::WorkerConfig)
 end
 
 function connect_w2w(pid::Int, config::WorkerConfig)
-    (rhost, rport) = notnothing(config.connect_at)::Tuple{AbstractString, Int}
+    (rhost, rport) = notnothing(config.connect_at)::Tuple{String, Int}
     config.host = rhost
     config.port = rport
     (s, bind_addr) = connect_to_worker(rhost, rport)

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -785,7 +785,7 @@ function merge!(repo::GitRepo;
                merge_opts=merge_opts,
                checkout_opts=checkout_opts)
     finally
-        Base.map(close, upst_anns)
+        Base.foreach(close, upst_anns)
     end
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -476,7 +476,7 @@ mutable struct REPLHistoryProvider <: HistoryProvider
     mode_mapping::Dict{Symbol,Prompt}
     modes::Vector{Symbol}
 end
-REPLHistoryProvider(mode_mapping) =
+REPLHistoryProvider(mode_mapping::Dict{Symbol}) =
     REPLHistoryProvider(String[], nothing, 0, 0, -1, IOBuffer(),
                         nothing, mode_mapping, UInt8[])
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -967,7 +967,7 @@ function setup_interface(
 
     # Canonicalize user keymap input
     if isa(extra_repl_keymap, Dict)
-        extra_repl_keymap = [extra_repl_keymap]
+        extra_repl_keymap = AnyDict[extra_repl_keymap]
     end
 
     repl_keymap = AnyDict(

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -9,7 +9,7 @@ using Base.Docs: catdoc, modules, DocStr, Binding, MultiDoc, keywords, isfield, 
 
 import Base.Docs: doc, formatdoc, parsedoc, apropos
 
-using Base: with_output_color
+using Base: with_output_color, mapany
 
 import REPL
 
@@ -186,7 +186,7 @@ function doc(binding::Binding, sig::Type = Union{})
             end
         end
         # Get parsed docs and concatenate them.
-        md = catdoc(map(parsedoc, results)...)
+        md = catdoc(mapany(parsedoc, results)...)
         # Save metadata in the generated markdown.
         if isa(md, Markdown.MD)
             md.meta[:results] = results
@@ -391,7 +391,7 @@ function _repl(x, brief::Bool=true)
         pargs = Any[]
         for arg in x.args[2:end]
             if isexpr(arg, :parameters)
-                kwargs = map(arg.args) do kwarg
+                kwargs = mapany(arg.args) do kwarg
                     if kwarg isa Symbol
                         kwarg = :($kwarg::Any)
                     elseif isexpr(kwarg, :kw)

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -48,20 +48,20 @@ end
 
 a_foo = 0
 
-const foo_keymap = Dict(
+const foo_keymap = Dict{Char,Any}(
     'a' => (o...)->(global a_foo; a_foo += 1)
 )
 
 b_foo = 0
 
-const foo2_keymap = Dict(
+const foo2_keymap = Dict{Char,Any}(
     'b' => (o...)->(global b_foo; b_foo += 1)
 )
 
 a_bar = 0
 b_bar = 0
 
-const bar_keymap = Dict(
+const bar_keymap = Dict{Char,Any}(
     'a' => (o...)->(global a_bar; a_bar += 1),
     'b' => (o...)->(global b_bar; b_bar += 1)
 )
@@ -84,7 +84,7 @@ run_test(test3_dict,IOBuffer("aab"))
 @test b_bar == 1
 
 # Multiple spellings in the same keymap
-const test_keymap_1 = Dict(
+const test_keymap_1 = Dict{Any,Any}(
     "^C" => (o...)->1,
     "\\C-C" => (o...)->2
 )
@@ -93,11 +93,11 @@ const test_keymap_1 = Dict(
 
 a_foo = a_bar = 0
 
-const test_keymap_2 = Dict(
+const test_keymap_2 = Dict{Any,Any}(
     "abc" => (o...)->(global a_foo = 1)
 )
 
-const test_keymap_3 = Dict(
+const test_keymap_3 = Dict{Any,Any}(
     "a"  => (o...)->(global a_foo = 2),
     "bc" => (o...)->(global a_bar = 3)
 )
@@ -119,13 +119,13 @@ end
 
 a_foo = 0
 
-const test_keymap_4 = Dict(
+const test_keymap_4 = Dict{Any,Any}(
     "a" => (o...)->(global a_foo = 1),
     "b" => "a",
     "c" => (o...)->(global a_foo = 2),
 )
 
-const test_keymap_5 = Dict(
+const test_keymap_5 = Dict{Any,Any}(
     "a" => (o...)->(global a_foo = 3),
     "d" => "c"
 )
@@ -143,7 +143,7 @@ end
 
 # Eager redirection with cycles
 
-const test_cycle = Dict(
+const test_cycle = Dict{Any,Any}(
     "a" => "b",
     "b" => "a"
 )
@@ -152,15 +152,15 @@ const test_cycle = Dict(
 
 # Lazy redirection with Cycles
 
-const level1 = Dict(
+const level1 = Dict{Any,Any}(
     "a" => LineEdit.KeyAlias("b")
 )
 
-const level2a = Dict(
+const level2a = Dict{Any,Any}(
     "b" => "a"
 )
 
-const level2b = Dict(
+const level2b = Dict{Any,Any}(
     "b" => LineEdit.KeyAlias("a")
 )
 
@@ -171,13 +171,13 @@ const level2b = Dict(
 
 a_foo = 0
 
-const test_keymap_6 = Dict(
+const test_keymap_6 = Dict{Any,Any}(
     "a" => (o...)->(global a_foo = 1),
     "b" => LineEdit.KeyAlias("a"),
     "c" => (o...)->(global a_foo = 2),
 )
 
-const test_keymap_7 = Dict(
+const test_keymap_7 = Dict{Any,Any}(
     "a" => (o...)->(global a_foo = 3),
     "d" => "c"
 )
@@ -200,7 +200,7 @@ global path1 = 0
 global path2 = 0
 global path3 = 0
 
-const test_keymap_8 = Dict(
+const test_keymap_8 = Dict{Any,Any}(
     "**" => (o...)->(global path1 += 1),
     "ab" => (o...)->(global path2 += 1),
     "cd" => (o...)->(global path3 += 1),
@@ -223,7 +223,7 @@ end
 global path1 = 0
 global path2 = 0
 
-const test_keymap_9 = Dict(
+const test_keymap_9 = Dict{Any,Any}(
     "***" => (o...)->(global path1 += 1),
     "*a*" => (o...)->(global path2 += 1)
 )

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -9,7 +9,7 @@ module Serialization
 
 import Base: GMP, Bottom, unsafe_convert, uncompressed_ast
 import Core: svec, SimpleVector
-using Base: unaliascopy, unwrap_unionall, require_one_based_indexing
+using Base: unaliascopy, unwrap_unionall, require_one_based_indexing, ntupleany
 using Core.IR
 
 export serialize, deserialize, AbstractSerializer, Serializer
@@ -930,7 +930,7 @@ function deserialize_symbol(s::AbstractSerializer, len::Int)
     return sym
 end
 
-deserialize_tuple(s::AbstractSerializer, len) = ntuple(i->deserialize(s), len)
+deserialize_tuple(s::AbstractSerializer, len) = ntupleany(i->deserialize(s), len)
 
 function deserialize_svec(s::AbstractSerializer)
     n = read(s.io, Int32)


### PR DESCRIPTION
For many packages that extend array functionality, `similar` now serves as the single biggest source of invalidation. These invalidations have been hard to diagnose using my SnoopCompile machinery, because runtime dispatch and a lack of "narrowing" of types lead to an absence of backedges (#36892). Without backedges, it's not easy to discover the callers, which is where you'd have to make changes to improve the quality of inference. This motivated me to implement a new general-purpose tool, `findcallers` in the [MethodAnalysis](https://github.com/timholy/MethodAnalysis.jl) package, that lets you search the type-inferred code of *every* `MethodInstance` for calls of a particular function with particular signature. (If you're already a MethodAnalysis user, note that 0.4.0 is the first release where `findcallers` is reasonably reliable, and even then it has some significant limitations as described in the docs).

I was able to use this tool to discover that the issue is not with the implementation of `similar` *per se*, but that we had many cases of comprehensions, `map`, broadcasting, and concatenation with poor inferrability. This PR, together with a companion to Pkg that I'll submit shortly, fixes almost all of them. Some of the patterns were a bit surprising, for example drilling down into
```julia
using Cthulhu
@descend vcat([1,2,3], 4)
```
you will discover that you get down into `_cat_t(::Val{1},::DataType,::Vector{Int64},::Vararg{Any,N} where N)::Any` and you end up calling `similar` with poor type information. (Conversely, `push!(copy([1,2,3]), 4)` has no such problems.)

An earlier version of this PR fixed all cases with poor container-type inference---we still had some with poor element-type inference from cases where `collect(::Generator{I,F})` had stopped specializing on the function type `F`, but since `similar` tends to be specialized on `I` this isn't really that big of a deal. However, I've at least temporarily abandoned the attempt to fix every last instance because of a single function, [maptwice](https://github.com/JuliaLang/julia/blob/0dab9e3f9f569a6462a0771d92c9e54c107164ea/base/asyncmap.jl#L156-L189), heavily used by `pmap`. If we could use `mapany` there then our inference problems there too would go away, but we have tests that explicitly check for element-type narrowing so this seems to be a no-go. It's a little odd given that Distributed has rampant inference problems to insist on the element narrowing, but perhaps that's essentially a way of compensating for Distributed's challenges in this regard. (And gettting good inference does seem in principle like it could be harder in a distributed context.)

Even having reverted those two `mapany`s in `maptwice`, this PR cuts the number of remaining invalidations from loading StaticArrays in half, compared to a local branch that includes all my still-open invalidation PRs. That leaves us with just 24 invalidations from StaticArrays, which is rather nice given that on Julia 1.5 it's more than 2000. Even for CategoricalArrays, `similar` now (locally, i.e., with all my modifications) only contributes 30 unique invalidations out of more than 2000 total, resolving a concern that @nalimilan expressed in https://github.com/JuliaData/CategoricalArrays.jl/issues/177.

### Noteworthy details (particularly directed at reviewers of this PR)

First, this changes field types of a few `struct`s, including `Cmd` which is exported. I don't think `Cmd` needs to support multidmensional arrays of Strings, but perhaps I'm mistaken.

Reviewers, also note the extra pickiness about arg types in REPL keymap functions. Since `setup_interface` converts all user-supplied keymaps into `Dict{Any,Any}` and none of the other functions are part of REPL's official interface, I don't think this would be considered breaking, but I did have to change some of REPL's tests (some of which directly call internal functions) in order to make them pass. As a reminder, the entire LineEdit module is under `@nospecialize`, so unless method arguments provide type information then inference uses `Any` no matter what the argument type actually is.

A final item of note concerns Julia's own build process. Together with my other open PRs, the total number of precompile statements is down to about 1550, a drop of about 400 compared to a couple months ago. This is getting close to the point where we'll actually have to change [this build-time assertion](https://github.com/JuliaLang/julia/blob/01fd807d5e9e8c4b66d92a598096406f4e3b1500/contrib/generate_precompile.jl#L197). The system image is also the smallest I've seen it in a long time:
```julia
tim@diva:~/src/julia-master$ ls -l usr/lib/julia/sys.so 
-rwxr-xr-x 1 tim holy 141802056 Aug 23 08:05 usr/lib/julia/sys.so
```
(Reference https://github.com/JuliaLang/julia/pull/37088#issuecomment-675106241 for where I was relatively recently.) While my general experience has been that the precompilation phase has gone slightly faster with fewer `MethodInstance`s, this PR (or perhaps more likely, the companion Pkg PR I'll also submit) violates that: now I'm getting
```julia
Generating precompile statements... 30/30
Executing precompile statements... 1543/1554
Precompilation complete. Summary:
Total ─────── 141.154365 seconds
Generation ── 118.166039 seconds 83.7141%
Execution ───  22.988326 seconds 16.2859%
    LINK usr/lib/julia/sys.so
```
which is a big slowdown. I'm guessing it's because inference stops "punting" so much, but I haven't made any attempt to investigate this.