### PR TITLE
Add default parameter to numerical tryparse

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -262,18 +262,18 @@ Signed(x::BigInt) = x
 
 hastypemax(::Type{BigInt}) = false
 
-function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool)
+function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, endpos::Int, base_::Integer, raise::Bool, default)
     # don't make a copy in the common case where we are parsing a whole String
     bstr = startpos == firstindex(s) && endpos == lastindex(s) ? String(s) : String(SubString(s,startpos,endpos))
 
     sgn, base, i = Base.parseint_preamble(true,Int(base_),bstr,firstindex(bstr),lastindex(bstr))
     if !(2 <= base <= 62)
         raise && throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
-        return nothing
+        return default
     end
     if i == 0
         raise && throw(ArgumentError("premature end of integer: $(repr(bstr))"))
-        return nothing
+        return default
     end
     z = BigInt()
     if Base.containsnul(bstr)
@@ -283,7 +283,7 @@ function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, end
     end
     if err != 0
         raise && throw(ArgumentError("invalid BigInt: $(repr(bstr))"))
-        return nothing
+        return default
     end
     flipsign!(z, sgn)
 end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -243,11 +243,11 @@ function BigFloat(x::Rational, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::I
     end
 end
 
-function tryparse(::Type{BigFloat}, s::AbstractString; base::Integer=0, precision::Integer=DEFAULT_PRECISION[], rounding::MPFRRoundingMode=ROUNDING_MODE[])
+function tryparse(::Type{BigFloat}, s::AbstractString, default = nothing; base::Integer=0, precision::Integer=DEFAULT_PRECISION[], rounding::MPFRRoundingMode=ROUNDING_MODE[])
     !isempty(s) && isspace(s[end]) && return tryparse(BigFloat, rstrip(s), base = base)
     z = BigFloat(precision=precision)
     err = ccall((:mpfr_set_str, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Int32, MPFRRoundingMode), z, s, base, rounding)
-    err == 0 ? z : nothing
+    err == 0 ? z : default
 end
 
 BigFloat(x::AbstractString, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::Integer=DEFAULT_PRECISION[]) =

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -256,8 +256,9 @@ end
     @test tryparse(Bool, "falss", true) === true
     @test tryparse(Float64, "1.2.", 8.) === 8.
     @test tryparse(Float32, "1.2.", 8.f0) === 8.f0
-    @test tryparse(Float16, "1.2.", 3) === 3
+    @test tryparse(Float16, "1.2.", Float16(1.2)) === Float16(1.2)
     @test tryparse(Complex{Int}, "1+2ii", 12im) === 12im
+    @test tryparse(BigInt, "100000000000000000m", 4) === 4
 end
 
 # parsing complex numbers (#22250)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -248,6 +248,18 @@ end
 @test tryparse(Float32, "1.23") === 1.23f0
 @test tryparse(Float16, "1.23") === Float16(1.23)
 
+@testset "issue #37162" begin
+    @test tryparse(Float64, "BBB") === nothing
+    @test tryparse(Float64, "BBB", missing) === missing
+
+    @test tryparse(Int, "2 0", 5) === 5
+    @test tryparse(Bool, "falss", true) === true
+    @test tryparse(Float64, "1.2.", 8.) === 8.
+    @test tryparse(Float32, "1.2.", 8.f0) === 8.f0
+    @test tryparse(Float16, "1.2.", 3) === 3
+    @test tryparse(Complex{Int}, "1+2ii", 12im) === 12im
+end
+
 # parsing complex numbers (#22250)
 @testset "complex parsing" begin
     for sign in ('-','+'), Im in ("i","j","im"), s1 in (""," "), s2 in (""," "), s3 in (""," "), s4 in (""," ")


### PR DESCRIPTION
Should fix #37162, although I wonder if there's a cleaner way to do this.
