### PR TITLE
Make `findall` faster for AbstractArrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2107,6 +2107,10 @@ julia> findall(x -> x >= 0, d)
 """
 findall(testf::Function, A) = collect(first(p) for p in pairs(A) if testf(last(p)))
 
+# Broadcasting is much faster for small testf, and computing
+# integer indices from logical index using findall has a negligible cost
+findall(testf::Function, A::AbstractArray) = findall(testf.(A))
+
 """
     findall(A)
 
@@ -2404,7 +2408,8 @@ function findall(pred::Fix2{typeof(in),<:Union{Array{<:Real},Real}}, x::Array{<:
 end
 # issorted fails for some element types so the method above has to be restricted
 # to element with isless/< defined.
-findall(pred::Fix2{typeof(in)}, x::Union{AbstractArray, Tuple}) = _findin(x, pred.x)
+findall(pred::Fix2{typeof(in)}, x::AbstractArray) = _findin(x, pred.x)
+findall(pred::Fix2{typeof(in)}, x::Tuple) = _findin(x, pred.x)
 
 # Copying subregions
 function indcopy(sz::Dims, I::Vector)


### PR DESCRIPTION
The `findall` fallback is quite slow when predicate is a small function compared with generating a logical index using `broadcast` and calling `findall` on it to compute integer indices. The gain is most visible when predicate is true for a large proportion of entries, but it's there even when all of them are false.
The drawback of this approach is that it requires allocating a vector of `length(a)/8` bytes whatever the number of returned indices.

Some benchmarks using `>` and `==`, for which the impact of using `broacast` should be the most visible thanks to SIMD. Note the timings difference when changing the proportion of `true` entries.
```julia
using BenchmarkTools

findall2(testf::Function, A::AbstractArray) = findall([testf(x)::Bool for x in A])
findall3(testf::Function, A::AbstractArray) = findall(testf.(A))

x = rand(10_000_000);

# Current state
julia> @btime findall(>(0.5), x);
  148.785 ms (24 allocations: 65.00 MiB)

julia> @btime findall(>(0.8), x);
  55.894 ms (22 allocations: 17.00 MiB)

julia> @btime findall(>(0.95), x);
  21.648 ms (20 allocations: 5.00 MiB)

julia> @btime findall(==(0.5), x);
  18.071 ms (1 allocation: 80 bytes)

# Using a comprehension
julia> @btime findall2(>(0.5), x);
  87.761 ms (5 allocations: 47.68 MiB)

julia> @btime findall2(>(0.8), x);
  44.411 ms (5 allocations: 24.78 MiB)

julia> @btime findall2(>(0.95), x);
  28.501 ms (5 allocations: 13.34 MiB)

julia> @btime findall2(==(0.5), x);
  23.160 ms (4 allocations: 9.54 MiB)

# Using broadcast (this PR)
julia> @btime findall3(>(0.5), x);
  13.709 ms (8 allocations: 39.34 MiB)

julia> @btime findall3(>(0.8), x);
  10.507 ms (8 allocations: 16.44 MiB)

julia> @btime findall3(>(0.95), x);
  9.702 ms (8 allocations: 5.00 MiB)

julia> @btime findall3(==(0.5), x);
  7.945 ms (7 allocations: 1.20 MiB)
```