### PR TITLE
fix #37126, spurious soft scope warning on hidden name

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2051,6 +2051,7 @@
                        (n   (length lhss))
                        (st  (gensy)))
                   `(block
+                    (local ,st)
                     ,@ini
                     ,.(map (lambda (i lhs)
                              (expand-forms

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2091,6 +2091,18 @@ end
 end
 @test z28789 == 42
 
+# issue #37126
+@test isempty(Test.collect_test_logs() do
+    include_string(@__MODULE__, """
+        function foo37126()
+            f(lhs::Integer, rhs::Integer) = nothing
+            f(lhs::Integer, rhs::AbstractVector{<:Integer}) = nothing
+            return f
+        end
+        struct Bar37126{T<:Real, P<:Real} end
+        """)
+    end[1])
+
 # issue #34673
 # check that :toplevel still returns a value when nested inside something else
 @test eval(Expr(:block, 0, Expr(:toplevel, 43))) == 43


### PR DESCRIPTION
This is kind of a partial fix that should be very safe. We still have the issue that an inner function with a `A{<:B}` type on an argument causes a local (for the type variable) to be moved to the top-level after the scope pass, where it then becomes a global. Fixing that will be a lot trickier, but with this the problem is harder to hit.