### PR TITLE
Fix TBAA for `DataType`

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1116,7 +1116,7 @@ static bool isLoadFromImmut(LoadInst *LI)
     if (LI->getMetadata(LLVMContext::MD_invariant_load))
         return true;
     MDNode *TBAA = LI->getMetadata(LLVMContext::MD_tbaa);
-    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const"}))
+    if (isTBAA(TBAA, {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype"}))
         return true;
     return false;
 }
@@ -1185,7 +1185,8 @@ static bool isLoadFromConstGV(LoadInst *LI, bool &task_local)
     // but LLVM global merging can change the pointer operands to GEPs/bitcasts
     auto load_base = LI->getPointerOperand()->stripInBoundsOffsets();
     auto gv = dyn_cast<GlobalVariable>(load_base);
-    if (isTBAA(LI->getMetadata(LLVMContext::MD_tbaa), {"jtbaa_immut", "jtbaa_const"})) {
+    if (isTBAA(LI->getMetadata(LLVMContext::MD_tbaa),
+               {"jtbaa_immut", "jtbaa_const", "jtbaa_datatype"})) {
         if (gv)
             return true;
         return isLoadFromConstGV(load_base, task_local);

--- a/test/core.jl
+++ b/test/core.jl
@@ -7270,3 +7270,21 @@ primitive type P36104 8 end
 # Malformed invoke
 f_bad_invoke(x::Int) = invoke(x, (Any,), x)
 @test_throws TypeError f_bad_invoke(1)
+
+# Fixup for #37044, make sure mutation of `types` field of `DataType` is respected.
+struct A37044{T1,T2}
+    x::T1
+    y::T2
+end
+struct Ref37044
+    x::DataType
+end
+function f37044(r)
+    t = r.x
+    if !isdefined(t, :types)
+        Base.datatype_fieldtypes(t)
+    end
+    return t.types
+end
+r37044 = Ref37044(A37044{Int}.body)
+@test f37044(r37044)[1] === Int


### PR DESCRIPTION
Due to lazy field type initialization, the `types` field is actually mutable in `DataType`.
This means that we cannot use immutable or constant TBAA for all `DataType` fields.

However, since any objects stored in the field are still rooted
over the lifetime of the `DataType` we can still let the GC root placement pass refine
any field to the parent `DataType`.
Also make use of the field offset to still mark known load from all other fields as constant.
This is currently done via a special case but it could also be useful for many other types too.

--------

Ref #37044
