### PR TITLE
Let `LinearIndices(::Broadcasted)` return `LinearIndices`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -227,7 +227,7 @@ Base.IndexStyle(bc::Broadcasted) = IndexStyle(typeof(bc))
 Base.IndexStyle(::Type{<:Broadcasted{<:Any,<:Tuple{Any}}}) = IndexLinear()
 Base.IndexStyle(::Type{<:Broadcasted{<:Any}}) = IndexCartesian()
 
-Base.LinearIndices(bc::Broadcasted{<:Any,<:Tuple{Any}}) = axes(bc)[1]
+Base.LinearIndices(bc::Broadcasted{<:Any,<:Tuple{Any}}) = LinearIndices(axes(bc))::LinearIndices{1}
 
 Base.ndims(::Broadcasted{<:Any,<:NTuple{N,Any}}) where {N} = N
 Base.ndims(::Type{<:Broadcasted{<:Any,<:NTuple{N,Any}}}) where {N} = N


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/31020/files#r475669025. Not that it has caused me any trouble, but a constructor that returns an instance of another type than requested does have the potential for nasty surprises. And here, I don't think there is any advantage in not returning a `LinearIndices` ... but I don't know my ways around the broadcast code, so I might be wrong. ~While at it, this generalizes the definition to arbitrary `Broadcasted`.~