### PR TITLE
Fix `builtin_tfunction` for `Core._expr`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1412,7 +1412,7 @@ function builtin_tfunction(interp::AbstractInterpreter, @nospecialize(f), argtyp
             end
         end
         return Any
-    elseif f === Expr
+    elseif f === Core._expr
         if length(argtypes) < 1 && !isva
             return Bottom
         end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2741,3 +2741,5 @@ f_generator_splat(t::Tuple) = tuple((identity(l) for l in t)...)
 @test (sizeof(Ptr),) == sizeof.((Ptr,)) == sizeof.((Ptr{Cvoid},))
 @test Core.Compiler.sizeof_tfunc(UnionAll) === Int
 @test !Core.Compiler.sizeof_nothrow(UnionAll)
+
+@test Base.return_types(Expr) == Any[Expr]


### PR DESCRIPTION
This had no effect before, as `Expr` is not a `Builtin`, but `Core._expr` is.

Before:
```julia
julia> code_typed(Expr)
1-element Vector{Any}:
 CodeInfo(
1 ─ %1 = Core._apply_iterate(Core.iterate, Core._expr, args)::Any
└──      return %1
) => Any
```
After:
```julia
julia> code_typed(Expr)
1-element Vector{Any}:
 CodeInfo(
1 ─ %1 = Core._apply_iterate(Core.iterate, Core._expr, args)::Expr
└──      return %1
) => Expr
```