### PR TITLE
RFC: Drop free_typevars check when simplifying in `jl_type_union`

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -494,13 +494,11 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
     assert(count == nt);
     size_t j;
     for(i=0; i < nt; i++) {
-        int has_free = temp[i]!=NULL && jl_has_free_typevars(temp[i]);
         for(j=0; j < nt; j++) {
             if (j != i && temp[i] && temp[j]) {
                 if (temp[i] == temp[j] || temp[i] == jl_bottom_type ||
                     temp[j] == (jl_value_t*)jl_any_type ||
-                    (!has_free && !jl_has_free_typevars(temp[j]) &&
-                     jl_subtype(temp[i], temp[j]))) {
+                    jl_subtype(temp[i], temp[j])) {
                     temp[i] = NULL;
                 }
             }


### PR DESCRIPTION
Types with free typevars make me a but uncomfortable, but here, I think we can drop the check. The individual union elements would be enclosed in a single `UnionAll` afterwards anyway. At least, this change doesn't make everything explode immediately and it fixes #37180. It may well be that I missed something and this is invalid (hence RFC), but in that case, it would be nice to add a counter example to the subtype tests.