### PR TITLE
Prune egal types when forming a `Union`

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -499,6 +499,7 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
             if (j != i && temp[i] && temp[j]) {
                 if (temp[i] == temp[j] || temp[i] == jl_bottom_type ||
                     temp[j] == (jl_value_t*)jl_any_type ||
+                    jl_egal(temp[i], temp[j]) ||
                     (!has_free && !jl_has_free_typevars(temp[j]) &&
                      jl_subtype(temp[i], temp[j]))) {
                     temp[i] = NULL;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1766,3 +1766,6 @@ end
 @testintersect(Tuple{Type{T}, AbstractVector{T}} where T,
                Tuple{Union, F36869{Int64, Missing}},
                Tuple{Union, F36869{Int64, Missing}})
+
+# issue #37180
+@test !(typeintersect(Tuple{AbstractArray{T}, VecOrMat{T}} where T, Tuple{Array, Any}).body.parameters[1] isa Union)


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/37191#issuecomment-680045594. Fixes #37180.