### PR TITLE
improve speed of allunique

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -383,6 +383,7 @@ false
 """
 function allunique(C)
     seen = Set{eltype(C)}()
+    haslength(C) && sizehint!(seen, length(C))
     for (i, x) in enumerate(C)
         push!(seen, x)
         i > length(seen) && return false

--- a/base/set.jl
+++ b/base/set.jl
@@ -397,7 +397,6 @@ function allunique(C)
         end
     end
 
-    x === nothing && return true
     haslength(C) && sizehint!(seen, length(C))
 
     while x !== nothing
@@ -406,7 +405,6 @@ function allunique(C)
         idx > 0 && return false
         _setindex!(seen, nothing, v, -idx)
         x = iterate(C, s)
-    end
     end
     return true
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -383,10 +383,30 @@ false
 """
 function allunique(C)
     seen = Set{eltype(C)}()
+
+    x = iterate(C)
+    for i in OneTo(1000)
+        if x === nothing
+            return true
+        else
+            v, s = x
+            idx = ht_keyindex2!(seen, v)
+            idx > 0 && return false
+            _setindex!(seen, nothing, v, -idx)
+            x = iterate(C, s)
+        end
+    end
+
+    x === nothing && return true
     haslength(C) && sizehint!(seen, length(C))
-    for (i, x) in enumerate(C)
-        push!(seen, x)
-        i > length(seen) && return false
+
+    while x !== nothing
+        v, s = x
+        idx = ht_keyindex2!(seen, v)
+        idx > 0 && return false
+        _setindex!(seen, nothing, v, -idx)
+        x = iterate(C, s)
+    end
     end
     return true
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -383,14 +383,11 @@ false
 """
 function allunique(C)
     seen = Set{eltype(C)}()
-    for x in C
-        if in(x, seen)
-            return false
-        else
-            push!(seen, x)
-        end
+    for (i, x) in enumerate(C)
+        push!(seen, x)
+        i > length(seen) && return false
     end
-    true
+    return true
 end
 
 allunique(::Union{AbstractSet,AbstractDict}) = true

--- a/base/set.jl
+++ b/base/set.jl
@@ -382,7 +382,7 @@ false
 ```
 """
 function allunique(C)
-    seen = Set{eltype(C)}()
+    seen = Dict{eltype(C),Nothing}()
 
     x = iterate(C)
     for i in OneTo(1000)

--- a/base/set.jl
+++ b/base/set.jl
@@ -382,23 +382,18 @@ false
 ```
 """
 function allunique(C)
-    seen = Dict{eltype(C),Nothing}()
-
+    seen = Dict{eltype(C), Nothing}()
     x = iterate(C)
-    for i in OneTo(1000)
-        if x === nothing
-            return true
-        else
+    if haslength(C) && length(C) > 1000
+        for i in OneTo(1000)
             v, s = x
             idx = ht_keyindex2!(seen, v)
             idx > 0 && return false
             _setindex!(seen, nothing, v, -idx)
             x = iterate(C, s)
         end
+        sizehint!(seen, length(C))
     end
-
-    haslength(C) && sizehint!(seen, length(C))
-
     while x !== nothing
         v, s = x
         idx = ht_keyindex2!(seen, v)


### PR DESCRIPTION
I propose a bit faster implementation of `allunique`. Here is the benchmark on `x = collect(1:10^8)`.

Old:
```
julia> @time allunique(x)
 17.072063 seconds (82 allocations: 4.499 GiB, 0.65% gc time)
true
```

New:
```
julia> @time allunique2(x)
 15.096852 seconds (82 allocations: 4.499 GiB, 0.73% gc time)
true
```

We can make it even faster with this implementation:
```
function allunique(C)
    seen = Dict{eltype(C), Nothing}()
    for x in C
        idx = ht_keyindex2!(seen, x)
        idx > 0 && return false
        _setindex!(seen, nothing, x, -idx)
    end
    return true
end
```
here is a benchmark:
```
julia> @time allunique(x)
 14.542865 seconds (82 allocations: 4.499 GiB, 0.78% gc time)
true
```
but I was not sure if it is a best idea to add a dependency on low level functions like `ht_keyindex2!` and `_setindex!` in a high level function like `allunique`.