### PR TITLE
Simplify static_eval, remove allocation restriction

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -958,7 +958,6 @@ default_debug_info_kind() = unsafe_load(cglobal(:jl_default_debug_info_kind, Cin
 struct CodegenParams
     track_allocations::Cint
     code_coverage::Cint
-    static_alloc::Cint
     prefer_specsig::Cint
     gnu_pubnames::Cint
     debug_info_kind::Cint
@@ -974,7 +973,7 @@ struct CodegenParams
     generic_context::Any
 
     function CodegenParams(; track_allocations::Bool=true, code_coverage::Bool=true,
-                   static_alloc::Bool=true, prefer_specsig::Bool=false,
+                   prefer_specsig::Bool=false,
                    gnu_pubnames=true, debug_info_kind::Cint = default_debug_info_kind(),
                    module_setup=nothing, module_activation=nothing, raise_exception=nothing,
                    emit_function=nothing, emitted_function=nothing,
@@ -982,7 +981,7 @@ struct CodegenParams
                    generic_context = nothing)
         return new(
             Cint(track_allocations), Cint(code_coverage),
-            Cint(static_alloc), Cint(prefer_specsig),
+            Cint(prefer_specsig),
             Cint(gnu_pubnames), debug_info_kind,
             module_setup, module_activation, raise_exception,
             emit_function, emitted_function, lookup,

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -486,7 +486,7 @@ static void interpret_symbol_arg(jl_codectx_t &ctx, native_sym_arg_t &out, jl_va
     const char *&f_name = out.f_name;
     const char *&f_lib = out.f_lib;
 
-    jl_value_t *ptr = static_eval(ctx, arg, true);
+    jl_value_t *ptr = static_eval(ctx, arg);
     if (ptr == NULL) {
         jl_cgval_t arg1 = emit_expr(ctx, arg);
         jl_value_t *ptr_ty = arg1.typ;
@@ -557,7 +557,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
     JL_GC_PUSH2(&rt, &sym.gcroot);
 
     if (nargs == 2) {
-        rt = static_eval(ctx, args[2], true, true);
+        rt = static_eval(ctx, args[2]);
         if (rt == NULL) {
             JL_GC_POP();
             jl_cgval_t argv[2];
@@ -629,7 +629,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     JL_GC_PUSH4(&ir, &rt, &at, &entry);
     if (jl_is_ssavalue(ir_arg))
         ir_arg = jl_arrayref((jl_array_t*)ctx.source->code, ((jl_ssavalue_t*)ir_arg)->id - 1);
-    ir = static_eval(ctx, ir_arg, true, true);
+    ir = static_eval(ctx, ir_arg);
     if (!ir) {
         emit_error(ctx, "error statically evaluating llvm IR argument");
         return jl_cgval_t();
@@ -640,7 +640,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
             rt = jl_tparam0(rtt);
     }
     if (!rt) {
-        rt = static_eval(ctx, args[2], true, true);
+        rt = static_eval(ctx, args[2]);
         if (!rt) {
             emit_error(ctx, "error statically evaluating llvmcall return type");
             return jl_cgval_t();
@@ -652,7 +652,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
             at = jl_tparam0(att);
     }
     if (!at) {
-        at = static_eval(ctx, args[3], true, true);
+        at = static_eval(ctx, args[3]);
         if (!at) {
             emit_error(ctx, "error statically evaluating llvmcall argument tuple");
             return jl_cgval_t();

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2965,7 +2965,6 @@ static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)
            // language features
            (a->track_allocations == b->track_allocations) &&
            (a->code_coverage == b->code_coverage) &&
-           (a->static_alloc == b->static_alloc) &&
            (a->prefer_specsig == b->prefer_specsig) &&
            // hooks
            (a->module_setup == b->module_setup) &&

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -849,7 +849,7 @@ static int globalUnique = 0;
 // --- code generation ---
 extern "C" {
     int jl_default_debug_info_kind = (int) DICompileUnit::DebugEmissionKind::FullDebug;
-    jl_cgparams_t jl_default_cgparams = {1, 1, 1, 0,
+    jl_cgparams_t jl_default_cgparams = {1, 1, 0,
 #ifdef _OS_WINDOWS_
         0,
 #else

--- a/src/julia.h
+++ b/src/julia.h
@@ -2113,7 +2113,6 @@ typedef jl_value_t *(*jl_codeinstance_lookup_t)(jl_method_instance_t *mi JL_PROP
 typedef struct {
     int track_allocations;  // can we track allocations?
     int code_coverage;      // can we measure coverage?
-    int static_alloc;       // is the compiler allowed to allocate statically?
     int prefer_specsig;     // are specialized function signatures preferred?
 
     // controls the emission of debug-info. mirrors the clang options


### PR DESCRIPTION
The `static_alloc` cgparam was added for GPU compatibility when `static_eval` was used much more, and the resulting values were often embedded in the IR (resulting in pointers to CPU allocations in GPU code). Nowadays `static_eval` is only used for evaluating `llvmcall` and `ccall` arguments, so that param can go, together with the restriction altogether.

The `sparams` parameter was also unused and always set to `true`, so I removed it too.