### PR TITLE
Parameterize optimization that skips inference on throw blocks.

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -19,7 +19,7 @@ call_result_unused(frame::InferenceState, pc::LineNum=frame.currpc) =
 
 function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f), argtypes::Vector{Any}, @nospecialize(atype), sv::InferenceState,
                                   max_methods::Int = InferenceParams(interp).MAX_METHODS)
-    if sv.currpc in sv.throw_blocks
+    if sv.params.unoptimize_throw_blocks && sv.currpc in sv.throw_blocks
         return CallMeta(Any, false)
     end
     valid_worlds = WorldRange()

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -365,11 +365,14 @@ end
 function inline_worthy(body::Array{Any,1}, src::CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any},
                        params::OptimizationParams, cost_threshold::Integer=params.inline_cost_threshold)
     bodycost::Int = 0
-    throw_blocks = find_throw_blocks(body)
+    if params.unoptimize_throw_blocks
+        throw_blocks = find_throw_blocks(body)
+    end
     for line = 1:length(body)
         stmt = body[line]
         if stmt isa Expr
-            thiscost = statement_cost(stmt, line, src, sptypes, slottypes, params, line in throw_blocks)::Int
+            thiscost = statement_cost(stmt, line, src, sptypes, slottypes, params,
+                                      params.unoptimize_throw_blocks && line in throw_blocks)::Int
         elseif stmt isa GotoNode
             # loops are generally always expensive
             # but assume that forward jumps are already counted for from

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1126,9 +1126,11 @@ end
 function assemble_inline_todo!(ir::IRCode, sv::OptimizationState)
     # todo = (inline_idx, (isva, isinvoke, na), method, spvals, inline_linetable, inline_ir, lie)
     todo = Any[]
-    skip = find_throw_blocks(ir.stmts.inst, RefValue(ir))
+    if sv.params.unoptimize_throw_blocks
+        skip = find_throw_blocks(ir.stmts.inst, RefValue(ir))
+    end
     for idx in 1:length(ir.stmts)
-        idx in skip && continue
+        sv.params.unoptimize_throw_blocks && idx in skip && continue
         r = process_simple!(ir, todo, idx, sv.params, sv.world, sv)
         r === nothing && continue
 

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -53,6 +53,8 @@ struct OptimizationParams
     MAX_TUPLE_SPLAT::Int
     MAX_UNION_SPLITTING::Int
 
+    unoptimize_throw_blocks::Bool
+
     function OptimizationParams(;
             inlining::Bool = inlining_enabled(),
             inline_cost_threshold::Int = 100,
@@ -62,6 +64,7 @@ struct OptimizationParams
             max_methods::Int = 3,
             tuple_splat::Int = 32,
             union_splitting::Int = 4,
+            unoptimize_throw_blocks::Bool = true,
         )
         return new(
             inlining,
@@ -72,6 +75,7 @@ struct OptimizationParams
             max_methods,
             tuple_splat,
             union_splitting,
+            unoptimize_throw_blocks,
         )
     end
 end
@@ -84,6 +88,7 @@ Parameters that control type inference operation.
 struct InferenceParams
     ipo_constant_propagation::Bool
     aggressive_constant_propagation::Bool
+    unoptimize_throw_blocks::Bool
 
     # don't consider more than N methods. this trades off between
     # compiler performance and generated code performance.
@@ -109,6 +114,7 @@ struct InferenceParams
     function InferenceParams(;
             ipo_constant_propagation::Bool = true,
             aggressive_constant_propagation::Bool = false,
+            unoptimize_throw_blocks::Bool = true,
             max_methods::Int = 3,
             union_splitting::Int = 4,
             apply_union_enum::Int = 8,
@@ -118,6 +124,7 @@ struct InferenceParams
         return new(
             ipo_constant_propagation,
             aggressive_constant_propagation,
+            unoptimize_throw_blocks,
             max_methods,
             union_splitting,
             apply_union_enum,


### PR DESCRIPTION
Makes the optimization from https://github.com/JuliaLang/julia/pull/35982 configurable. This matters for the GPU compiler, where we (for now) pattern-match exception functions and replace them with something GPU compatible:

```julia
julia> kernel(ptr) = (unsafe_store!(ptr, sqrt(unsafe_load(ptr))); nothing)

julia> code_warntype(kernel, Tuple{Ptr{Float32}})
```

```llvm
;  @ REPL[3]:1 within `kernel'
define dso_local void @julia_kernel_5493(i64) local_unnamed_addr {
top:
; ┌ @ pointer.jl:105 within `unsafe_load' @ pointer.jl:105
   %1 = inttoptr i64 %0 to float*
   %2 = load float, float* %1, align 1
; └
; ┌ @ math.jl:574 within `sqrt'
; │┌ @ float.jl:457 within `<'
    %3 = fcmp uge float %2, 0.000000e+00
; │└
   br i1 %3, label %L6, label %L4

L4:                                               ; preds = %top
   call fastcc void @julia_throw_complex_domainerror_5496({}* inttoptr (i64 140289750596920 to {}*), float %2)
   unreachable

L6:                                               ; preds = %top
; └
; ┌ @ math.jl:575 within `sqrt'
   %4 = call float @llvm.sqrt.f32(float %2)
; └
; ┌ @ pointer.jl:118 within `unsafe_store!' @ pointer.jl:118
   store float %4, float* %1, align 1
; └
  ret void
}
```

After https://github.com/JuliaLang/julia/pull/35982, this had become a dynamic call:

```llvm
define dso_local void @julia_kernel_5564(i64) local_unnamed_addr {
top:
  %1 = alloca {}*, i32 2
; ┌ @ pointer.jl:105 within `unsafe_load' @ pointer.jl:105
   %2 = inttoptr i64 %0 to float*
   %3 = load float, float* %2, align 1
; └
; ┌ @ math.jl:574 within `sqrt'
; │┌ @ float.jl:457 within `<'
    %4 = fcmp uge float %3, 0.000000e+00
; │└
   br i1 %4, label %L6, label %L4

L4:                                               ; preds = %top
   %5 = call fastcc {}* @jl_box_float32(float %3)
   %6 = getelementptr inbounds {}*, {}** %1, i32 0
   store {}* inttoptr (i64 140289750596920 to {}*), {}** %6, align 8
   %7 = getelementptr inbounds {}*, {}** %1, i32 1
   store {}* %5, {}** %7, align 8
   %8 = call nonnull {}* @jl_apply_generic({}* inttoptr (i64 140289878036352 to {}*), {}** %1, i32 2)
   call void @llvm.trap()
   unreachable

L6:                                               ; preds = %top
; └
; ┌ @ math.jl:575 within `sqrt'
   %9 = call float @llvm.sqrt.f32(float %3)
; └
; ┌ @ pointer.jl:118 within `unsafe_store!' @ pointer.jl:118
   store float %9, float* %2, align 1
; └
  ret void
}
```

Not sure why I had to conditionalize all the changes, I had figured I could keep the inlining as it was, but maybe `assemble_inline_todo!` does a bunch more analysis?