### PR TITLE
Make constructors for basic number types inferable

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -48,7 +48,7 @@ A not-a-number value of type [`Float64`](@ref).
 NaN, NaN64
 
 ## conversions to floating-point ##
-Float16(x::Integer) = convert(Float16, convert(Float32, x))
+Float16(x::Integer) = convert(Float16, convert(Float32, x)::Float32)
 for t in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UInt128)
     @eval promote_rule(::Type{Float16}, ::Type{$t}) = Float16
 end

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -42,8 +42,8 @@ promote_rule(::Type{<:AbstractIrrational}, ::Type{<:AbstractIrrational}) = Float
 promote_rule(::Type{<:AbstractIrrational}, ::Type{T}) where {T<:Real} = promote_type(Float64, T)
 promote_rule(::Type{S}, ::Type{T}) where {S<:AbstractIrrational,T<:Number} = promote_type(promote_type(S, real(T)), T)
 
-AbstractFloat(x::AbstractIrrational) = Float64(x)
-Float16(x::AbstractIrrational) = Float16(Float32(x))
+AbstractFloat(x::AbstractIrrational) = Float64(x)::Float64
+Float16(x::AbstractIrrational) = Float16(Float32(x)::Float32)
 Complex{T}(x::AbstractIrrational) where {T<:Real} = Complex{T}(T(x))
 
 @pure function Rational{T}(x::AbstractIrrational) where T<:Integer
@@ -64,7 +64,7 @@ Rational{BigInt}(x::AbstractIrrational) = throw(ArgumentError("Cannot convert an
 
 @pure function (t::Type{T})(x::AbstractIrrational, r::RoundingMode) where T<:Union{Float32,Float64}
     setprecision(BigFloat, 256) do
-        T(BigFloat(x), r)
+        T(BigFloat(x)::BigFloat, r)
     end
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -224,8 +224,10 @@ function BigFloat(x::BigInt, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::Int
     return z
 end
 
-BigFloat(x::Integer, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::Integer=DEFAULT_PRECISION[]) =
-    BigFloat(BigInt(x), r; precision=precision)
+BigFloat(x::Integer; precision::Integer=DEFAULT_PRECISION[]) =
+    BigFloat(BigInt(x)::BigInt, ROUNDING_MODE[]; precision=precision)
+BigFloat(x::Integer, r::MPFRRoundingMode; precision::Integer=DEFAULT_PRECISION[]) =
+    BigFloat(BigInt(x)::BigInt, r; precision=precision)
 
 BigFloat(x::Union{Bool,Int8,Int16,Int32}, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::Integer=DEFAULT_PRECISION[]) =
     BigFloat(convert(Clong, x), r; precision=precision)
@@ -238,7 +240,7 @@ BigFloat(x::Union{Float16,Float32}, r::MPFRRoundingMode=ROUNDING_MODE[]; precisi
 function BigFloat(x::Rational, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::Integer=DEFAULT_PRECISION[])
     setprecision(BigFloat, precision) do
         setrounding_raw(BigFloat, r) do
-            BigFloat(numerator(x)) / BigFloat(denominator(x))
+            BigFloat(numerator(x))::BigFloat / BigFloat(denominator(x))::BigFloat
         end
     end
 end
@@ -259,7 +261,7 @@ AbstractFloat(x::BigInt) = BigFloat(x)
 float(::Type{BigInt}) = BigFloat
 
 BigFloat(x::Real, r::RoundingMode; precision::Integer=DEFAULT_PRECISION[]) =
-    BigFloat(x, convert(MPFRRoundingMode, r); precision=precision)
+    BigFloat(x, convert(MPFRRoundingMode, r); precision=precision)::BigFloat
 BigFloat(x::AbstractString, r::RoundingMode; precision::Integer=DEFAULT_PRECISION[]) =
     BigFloat(x, convert(MPFRRoundingMode, r); precision=precision)
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -106,13 +106,13 @@ Rational(x::Rational) = x
 
 Bool(x::Rational) = x==0 ? false : x==1 ? true :
     throw(InexactError(:Bool, Bool, x)) # to resolve ambiguity
-(::Type{T})(x::Rational) where {T<:Integer} = (isinteger(x) ? convert(T, x.num) :
+(::Type{T})(x::Rational) where {T<:Integer} = (isinteger(x) ? convert(T, x.num)::T :
     throw(InexactError(nameof(T), T, x)))
 
-AbstractFloat(x::Rational) = float(x.num)/float(x.den)
+AbstractFloat(x::Rational) = (float(x.num)/float(x.den))::AbstractFloat
 function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S
     P = promote_type(T,S)
-    convert(T, convert(P,x.num)/convert(P,x.den))
+    convert(T, convert(P,x.num)/convert(P,x.den))::T
 end
 
 function Rational{T}(x::AbstractFloat) where T<:Integer

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -197,19 +197,19 @@ end
 # Assumes conversion is performed by rounding to nearest value.
 
 # To avoid ambiguous dispatch with methods in mpfr.jl:
-(::Type{T})(x::Real, r::RoundingMode) where {T<:AbstractFloat} = _convert_rounding(T,x,r)
+(::Type{T})(x::Real, r::RoundingMode) where {T<:AbstractFloat} = _convert_rounding(T,x,r)::T
 
-_convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Nearest}) where {T<:AbstractFloat} = convert(T,x)
+_convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Nearest}) where {T<:AbstractFloat} = convert(T,x)::T
 function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Down}) where T<:AbstractFloat
-    y = convert(T,x)
+    y = convert(T,x)::T
     y > x ? prevfloat(y) : y
 end
 function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Up}) where T<:AbstractFloat
-    y = convert(T,x)
+    y = convert(T,x)::T
     y < x ? nextfloat(y) : y
 end
 function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:ToZero}) where T<:AbstractFloat
-    y = convert(T,x)
+    y = convert(T,x)::T
     if x > 0.0
         y > x ? prevfloat(y) : y
     else

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2692,3 +2692,15 @@ end
         end
     end
 end
+
+@testset "constructor inferability for $T" for T in [AbstractFloat, #=BigFloat,=# Float16,
+        Float32, Float64, Integer, Bool, Signed, BigInt, Int128, Int16, Int32, Int64, Int8,
+        Unsigned, UInt128, UInt16, UInt32, UInt64, UInt8]
+    @test all(R -> R<:T, Base.return_types(T))
+end
+@testset "constructor inferability for BigFloat" begin
+    T = BigFloat
+    @test_broken all(R -> R<:T, Base.return_types(T))
+    @test all(m -> m.file == Symbol("deprecated.jl"),
+        collect(methods(T))[findall(R -> !(R<:T), Base.return_types(T))])
+end

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -14,7 +14,7 @@ struct Furlong{p,T<:Number} <: Number
 end
 Furlong(x::T) where {T<:Number} = Furlong{1,T}(x)
 Furlong(x::Furlong) = x
-(::Type{T})(x::Furlong) where {T<:Number} = T(x.val)
+(::Type{T})(x::Furlong) where {T<:Number} = T(x.val)::T
 Furlong{p}(v::Number) where {p} = Furlong{p,typeof(v)}(v)
 Furlong{p}(x::Furlong{q}) where {p,q} = (@assert(p==q); Furlong{p,typeof(x.val)}(x.val))
 Furlong{p,T}(x::Furlong{q}) where {T,p,q} = (@assert(p==q); Furlong{p,T}(T(x.val)))


### PR DESCRIPTION
Starting from the assumption that a constructor should return an instance of the correct type, i.e. `T(...)::T` where `T isa Type`, I wondered: Does that hold for all types in julia proper? (Answer: no, e.g. ref. #37186 for an accidental violation I stumbled upon.) And can inference figure it out?

This PR makes the answer to the second question "yes" for the basic number types, see the test:
https://github.com/JuliaLang/julia/blob/dca67c9901e5962f3dc0cc2ba3b1e76937697947/test/numbers.jl#L2696-L2700
(There are two deprecated `BigFloat` methods which I haven't touched that would fail this test.)

However, while that holds for the individual constructor methods, for unknown argument types, usually too many methods match, so that e.g. `Float64(x::Any)` (26 possible methods) will still only be inferred as `Any`. So while I don't expect these changes to be wrong, I am not really sure how  useful they are. Maybe @timholy has some intuition about it from all his work on invalidations where he looked at a lot code with incomplete type information?