### PR TITLE
Remove unnecessary volatile on memcpy

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1824,7 +1824,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                     auto slot = emit_static_alloca(ctx, resultTy);
                     slot->setAlignment(Align(boxalign));
                     ctx.builder.CreateAlignedStore(result, slot, Align(boxalign));
-                    emit_memcpy(ctx, strct, tbaa, slot, tbaa, rtsz, boxalign, tbaa);
+                    emit_memcpy(ctx, strct, tbaa, slot, tbaa, rtsz, boxalign);
                 }
                 else {
                     init_bits_value(ctx, strct, result, tbaa, boxalign);


### PR DESCRIPTION
This is a local bitcast of different size through memory and doesn't need to be volatile.
This was introduced due to a typo in 8e4327cd75af515feffc7db00c0dfeac4dca306b when the
argument order changed and the old tbaa parameter was passed in as isvolatile.