### PR TITLE
use printf/exit instead of `jl_error` for "too many threads"

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -449,8 +449,8 @@ void jl_start_threads(void)
     // non-exclusive: no affinity settings; let the kernel move threads about
     if (exclusive) {
         if (jl_n_threads > jl_cpu_threads()) {
-            jl_n_threads = 1;
-            jl_error("Too many threads running for " MACHINE_EXCLUSIVE_NAME " option.");
+            jl_printf(JL_STDERR, "ERROR: Too many threads requested for %s option.\n", MACHINE_EXCLUSIVE_NAME);
+            exit(1);
         }
         memset(mask, 0, cpumasksize);
         mask[0] = 1;


### PR DESCRIPTION
This is too early for `jl_error` to work, and gave a "no exception handler" error.