### PR TITLE
support full exception stacks in Task error reporting

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -236,9 +236,10 @@ julia> take!(c)
 1
 
 julia> put!(c, 1);
-ERROR: TaskFailedException:
-foo
+ERROR: TaskFailedException
 Stacktrace:
+[...]
+    nested task error: foo
 [...]
 ```
 """

--- a/base/client.jl
+++ b/base/client.jl
@@ -102,6 +102,7 @@ function display_error(io::IO, stack::Vector)
     printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
     bt = Any[ (x[1], scrub_repl_backtrace(x[2])) for x in stack ]
     show_exception_stack(IOContext(io, :limit => true), bt)
+    println(io)
 end
 display_error(stack::Vector) = display_error(stderr, stack)
 display_error(er, bt=nothing) = display_error(stderr, er, bt)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -879,11 +879,11 @@ function show_exception_stack(io::IO, stack::Vector)
     nexc = length(stack)
     for i = nexc:-1:1
         if nexc != i
-            printstyled(io, "\ncaused by:\n", color=error_color())
+            printstyled(io, "\ncaused by: ", color=error_color())
         end
         exc, bt = stack[i]
         showerror(io, exc, bt, backtrace = bt!==nothing)
-        println(io)
+        i == 1 || println(io)
     end
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -204,7 +204,7 @@ function show(io::IO, ::MIME"text/plain", t::Task)
     show(io, t)
     if istaskfailed(t)
         println(io)
-        show_task_exception(io, t)
+        show_task_exception(io, t, indent = false)
     end
 end
 

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -172,7 +172,6 @@ function (ss::SummarySize)(obj::Task)
         size += ss(obj.code)::Int
     end
     size += ss(obj.storage)::Int
-    size += ss(obj.backtrace)::Int
     size += ss(obj.donenotify)::Int
     size += ss(obj.exception)::Int
     size += ss(obj.result)::Int

--- a/base/task.jl
+++ b/base/task.jl
@@ -66,21 +66,25 @@ struct TaskFailedException <: Exception
     task::Task
 end
 
-function showerror(io::IO, ex::TaskFailedException)
-    println(io, "TaskFailedException:")
+function showerror(io::IO, ex::TaskFailedException, bt = nothing; backtrace=true)
+    print(io, "TaskFailedException")
+    if bt !== nothing && backtrace
+        show_backtrace(io, bt)
+    end
+    println(io)
+    printstyled(io, "\n    nested task error: ", color=error_color())
     show_task_exception(io, ex.task)
 end
 
-function show_task_exception(io::IO, t::Task)
-    stacks = []
-    while isa(t.exception, TaskFailedException)
-        pushfirst!(stacks, t.backtrace)
-        t = t.exception.task
+function show_task_exception(io::IO, t::Task; indent = true)
+    stack = catch_stack(t)
+    b = IOBuffer()
+    show_exception_stack(IOContext(b, io), stack)
+    str = String(take!(b))
+    if indent
+        str = replace(str, "\n" => "\n    ")
     end
-    showerror(io, t.exception, t.backtrace)
-    for bt in stacks
-        show_backtrace(io, bt)
-    end
+    print(io, str)
 end
 
 function show(io::IO, t::Task)
@@ -140,6 +144,9 @@ const task_state_failed   = UInt8(2)
         else
             @assert false
         end
+    elseif field === :backtrace
+        # TODO: this field name should be deprecated in 2.0
+        return catch_stack(t)[end][2]
     else
         return getfield(t, field)
     end
@@ -438,9 +445,6 @@ function task_done_hook(t::Task)
     err = istaskfailed(t)
     result = task_result(t)
     handled = false
-    if err
-        t.backtrace = catch_backtrace()
-    end
 
     donenotify = t.donenotify
     if isa(donenotify, ThreadSynchronizer)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2451,20 +2451,18 @@ void jl_init_types(void) JL_GC_DISABLED
                         NULL,
                         jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(11,
+                        jl_perm_symsvec(10,
                                         "next",
                                         "queue",
                                         "storage",
                                         "donenotify",
                                         "result",
                                         "exception",
-                                        "backtrace",
                                         "logstate",
                                         "code",
                                         "_state",
                                         "sticky"),
-                        jl_svec(11,
-                                jl_any_type,
+                        jl_svec(10,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -2475,7 +2473,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_any_type,
                                 jl_uint8_type,
                                 jl_bool_type),
-                        0, 1, 8);
+                        0, 1, 7);
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1795,7 +1795,6 @@ typedef struct _jl_task_t {
     jl_value_t *donenotify;
     jl_value_t *result;
     jl_value_t *exception;
-    jl_value_t *backtrace;
     jl_value_t *logstate;
     jl_function_t *start;
     uint8_t _state;
@@ -1808,6 +1807,8 @@ typedef struct _jl_task_t {
     int16_t prio;
     // current world age
     size_t world_age;
+    // saved exception stack
+    jl_excstack_t *excstack;
 
     jl_ucontext_t ctx; // saved thread state
     void *stkbuf; // malloc'd memory (either copybuf or stack)
@@ -1819,8 +1820,6 @@ typedef struct _jl_task_t {
     jl_handler_t *eh;
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
-    // saved exception stack
-    jl_excstack_t *excstack;
 
     jl_timing_block_t *timing_stack;
 } jl_task_t;

--- a/src/task.c
+++ b/src/task.c
@@ -632,7 +632,6 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->result = jl_nothing;
     t->donenotify = completion_future;
     t->exception = jl_nothing;
-    t->backtrace = jl_nothing;
     // Inherit logger state from parent task
     t->logstate = ptls->current_task->logstate;
     // there is no active exception handler available on this stack yet
@@ -1203,7 +1202,6 @@ void jl_init_root_task(void *stack_lo, void *stack_hi)
     ptls->current_task->result = jl_nothing;
     ptls->current_task->donenotify = jl_nothing;
     ptls->current_task->exception = jl_nothing;
-    ptls->current_task->backtrace = jl_nothing;
     ptls->current_task->logstate = jl_nothing;
     ptls->current_task->eh = NULL;
     ptls->current_task->gcstack = NULL;

--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -110,13 +110,6 @@ function serialize(s::ClusterSerializer, t::Task)
     writetag(s.io, TASK_TAG)
     serialize(s, t.code)
     serialize(s, t.storage)
-    bt = t.backtrace
-    if bt !== nothing
-        if !isa(bt, Vector{Any})
-            bt = Base.process_backtrace(bt, 100)
-        end
-        serialize(s, bt)
-    end
     serialize(s, t._state)
     serialize(s, t.result)
     serialize(s, t.exception)
@@ -256,13 +249,7 @@ function deserialize(s::ClusterSerializer, ::Type{Task})
     deserialize_cycle(s, t)
     t.code = deserialize(s)
     t.storage = deserialize(s)
-    state_or_bt = deserialize(s)
-    if state_or_bt isa UInt8
-        t._state = state_or_bt
-    else
-        t.backtrace = state_or_bt
-        t._state = deserialize(s)
-    end
+    t._state = deserialize(s)::UInt8
     t.result = deserialize(s)
     t.exception = deserialize(s)
     t

--- a/test/client.jl
+++ b/test/client.jl
@@ -12,8 +12,7 @@ nested_error_pattern = r"""
     ERROR: DivideError: integer division error
     Stacktrace:.*
 
-    caused by:
-    UndefVarError: __not_a_binding__ not defined
+    caused by: UndefVarError: __not_a_binding__ not defined
     Stacktrace:.*
     """s
 


### PR DESCRIPTION
This removes the `backtrace` field from `Task`, which is redundant with the internal exception stack field. More importantly, it prints all exception information for chains of tasks and nested exceptions. For example:

```
t = @async try; error(1); catch; error(2); end
s = @async try; error(3); catch; wait(t); end
wait(s)
```

There are 5 total exceptions here. The output on v1.5 is:
```
ERROR: TaskFailedException:
2
Stacktrace:
 [1] error(::Int64) at ./error.jl:42
 [2] macro expansion at ./REPL[1]:1 [inlined]
 [3] (::var"#1#2")() at ./task.jl:356
Stacktrace:
 [1] wait(::Task) at ./task.jl:267
 [2] macro expansion at ./REPL[2]:1 [inlined]
 [3] (::var"#3#4")() at ./task.jl:356
Stacktrace:
 [1] wait(::Task) at ./task.jl:267
 [2] top-level scope at REPL[3]:1
```

As you can see, we only manage to show 2 exceptions and 3 stack traces.

Here's the output with this PR, in glorious technicolor:
![errornest](https://user-images.githubusercontent.com/744556/91363429-9c4e2b00-e7ca-11ea-906e-22b0b3947c43.png)

5 exceptions, 5 stack traces. It also maintains the most-recent-first printing convention.

It gets so out of hand that indenting is clearly necessary. I'm using the inefficient string-replace approach to indenting, but hopefully that is OK.