### PR TITLE
Better Vararg handling in tfuncs

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2789,3 +2789,27 @@ end
 @test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Any, Symbol, Vararg{Integer}}) == Integer
 @test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Any, Symbol, Integer, Vararg}) == Integer
 @test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Any, Symbol, Integer, Any, Vararg}) == Union{}
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(Core._expr), Vararg}) == Expr
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(Core._expr), Any, Vararg}) == Expr
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(Core._expr), Any, Any, Vararg}) == Expr
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(applicable), Vararg}) == Bool
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(applicable), Any, Vararg}) == Bool
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(applicable), Any, Any, Vararg}) == Bool
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(applicable), Any, Any, Any, Vararg}) == Bool
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(getfield), Tuple{Int}, Vararg}) == Int
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(getfield), Tuple{Int}, Any, Vararg}) == Int
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(getfield), Tuple{Int}, Any, Any, Vararg}) == Int
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(getfield), Any, Any, Any, Any, Vararg}) == Union{}
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(fieldtype), Vararg}) == Type
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(fieldtype), Any, Vararg}) == Type
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(fieldtype), Any, Any, Vararg}) == Type
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(fieldtype), Any, Any, Any, Vararg}) == Type
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(fieldtype), Any, Any, Any, Any, Vararg}) == Union{}
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(Core.apply_type), Vararg}) == Type
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(Core.apply_type), Any, Vararg}) == Type
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(Core.apply_type), Any, Any, Vararg}) == Type
+f_apply_cglobal(args...) = cglobal(args...)
+@test Core.Compiler.return_type(f_apply_cglobal, Tuple{Vararg{Type{Int}}}) == Ptr
+@test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Vararg{Type{Int}}}) == Ptr
+@test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Type{Int}, Vararg{Type{Int}}}) == Ptr{Int}
+@test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Type{Int}, Type{Int}, Vararg{Type{Int}}}) == Union{}

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2776,3 +2776,16 @@ for badf in [getfield_const_typename_bad1, getfield_const_typename_bad2]
     @test code[end] === Core.ReturnNode()
     @test_throws TypeError badf()
 end
+
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(sizeof), Vararg{DataType}}) == Int
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(sizeof), DataType, Vararg}) == Int
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(sizeof), DataType, Any, Vararg}) == Union{}
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(===), Vararg}) == Bool
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(===), Any, Vararg}) == Bool
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(===), Any, Any, Vararg}) == Bool
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(===), Any, Any, Any, Vararg}) == Union{}
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Vararg{Symbol}}) == Symbol
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Any, Vararg{Symbol}}) == Symbol
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Any, Symbol, Vararg{Integer}}) == Integer
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Any, Symbol, Integer, Vararg}) == Integer
+@test Core.Compiler.return_type(apply26826, Tuple{typeof(setfield!), Any, Symbol, Integer, Any, Vararg}) == Union{}


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/pull/37188#issuecomment-680095700

I've split this into three commits in case I should back-out part of it. The first commit special-cases tfuncs which take a fixed number of arguments and expands a `Vararg` into the needed number of arguments. The second commit expands a `Vararg` to obtain at least `minarg` arguments and chops off the `Vararg` if there are already `maxarg` "normal" arguments. Thus, tfuncs which take a variable number of arguments will have to deal with `Vararg` arguments, but not for the first `minarg` ones. Interestingly, only `apply_type_tfunc` needed an adjustment here. But that's where reviewers might want to take an extra careful look. The tfuncs to look at are the ones for (before the third commit):
```julia
julia> Core.Compiler.T_FFUNC_KEY[findall(tf -> tf[1] != tf[2], Core.Compiler.T_FFUNC_VAL)]
6-element Array{Any,1}:
 isdefined (built-in function)
 _expr (built-in function)
 applicable (built-in function)
 getfield (built-in function)
 fieldtype (built-in function)
 apply_type (built-in function)

julia> reinterpret.(Core.IntrinsicFunction, Int32.(findall(tf -> tf[1] != tf[2], Core.Compiler.T_IFUNC)))
2-element Array{Core.IntrinsicFunction,1}:
 llvmcall (intrinsic function #83)
 arraylen (intrinsic function #84) 
```
Finally, the third commit outlines the handling of `svec`, `arrayset`, `arrayref`, and `const_arrayref` into separate tfuncs. I assume they only received their special treatment in `builtin_tfunction` to deal with `Vararg`s which is not needed anymore now. I've left the cost at the default of 20, but of course, we'd now have the flexibility to adjust that.
There's still special handling for `tuple` and `invoke`, which have associated `tuple_tfunc` and `invoke_tfunc`, but these take different arguments, so I've left it at that for now.