### PR TITLE
Performance regression of scalar randn() between Julia 1.4 and 1.5

### DIFF
--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -35,9 +35,18 @@ julia> randn(rng, ComplexF32, (2, 3))
   0.611224+1.56403im   0.355204-0.365563im  0.0905552+1.31012im
 ```
 """
+#=
+When defining 
+`@inline randn(rng::AbstractRNG=default_rng()) = _randn(rng, rand(rng, UInt52Raw()))`
+the function call to `_randn` is currently not inlined, resulting in slightly worse
+performance for scalar random normal numbers than repeating the code of `_randn`
+inside the following function.
+=#
 @inline function randn(rng::AbstractRNG=default_rng())
     @inbounds begin
         r = rand(rng, UInt52Raw())
+        
+        # the following code is identical to the one in `_randn(rng::AbstractRNG, r::UInt64)`
         r &= 0x000fffffffffffff
         rabs = Int64(r>>1) # One bit for the sign
         idx = rabs & 0xFF

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -35,7 +35,17 @@ julia> randn(rng, ComplexF32, (2, 3))
   0.611224+1.56403im   0.355204-0.365563im  0.0905552+1.31012im
 ```
 """
-@inline randn(rng::AbstractRNG=default_rng()) = _randn(rng, rand(rng, UInt52Raw()))
+@inline function randn(rng::AbstractRNG=default_rng())
+    @inbounds begin
+        r = rand(rng, UInt52Raw())
+        r &= 0x000fffffffffffff
+        rabs = Int64(r>>1) # One bit for the sign
+        idx = rabs & 0xFF
+        x = ifelse(r % Bool, -rabs, rabs)*wi[idx+1]
+        rabs < ki[idx+1] && return x # 99.3% of the time we return here 1st try
+        return randn_unlikely(rng, idx, rabs, x)
+    end
+end
 
 @inline function _randn(rng::AbstractRNG, r::UInt64)
     @inbounds begin

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -35,14 +35,14 @@ julia> randn(rng, ComplexF32, (2, 3))
   0.611224+1.56403im   0.355204-0.365563im  0.0905552+1.31012im
 ```
 """
-#=
-When defining 
-`@inline randn(rng::AbstractRNG=default_rng()) = _randn(rng, rand(rng, UInt52Raw()))`
-the function call to `_randn` is currently not inlined, resulting in slightly worse
-performance for scalar random normal numbers than repeating the code of `_randn`
-inside the following function.
-=#
 @inline function randn(rng::AbstractRNG=default_rng())
+    #=
+    When defining 
+    `@inline randn(rng::AbstractRNG=default_rng()) = _randn(rng, rand(rng, UInt52Raw()))`
+    the function call to `_randn` is currently not inlined, resulting in slightly worse
+    performance for scalar random normal numbers than repeating the code of `_randn`
+    inside the following function.
+    =#
     @inbounds begin
         r = rand(rng, UInt52Raw())
         


### PR DESCRIPTION
The scalar `randn()` function is significantly slower in Julia 1.5 (and master) than it was in Julia 1.4. This was a side-effect of the drastic speed-up implemented for randn vectors.

See https://github.com/JuliaLang/julia/issues/36414

The underlying issue is that a function call is not inlined.
In this PR, this issue is avoided by redefining the scalar version of `randn()`, using the Julia 1.4 code.
This brings back the V1.4 performance for `randn()`, but is not the nicest solution. But unfortunately I have not found a better one yet.