### PR TITLE
Add INNO_ARGS makefile var for signtool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ endif
 
 exe:
 	# run Inno Setup to compile installer
-	$(call spawn,$(JULIAHOME)/dist-extras/inno/iscc.exe /DAppVersion=$(JULIA_VERSION) /DSourceDir="$(call cygpath_w,$(BUILDROOT)/julia-$(JULIA_COMMIT))" /DRepoDir="$(call cygpath_w,$(JULIAHOME))" /F"$(JULIA_BINARYDIST_FILENAME)" /O"$(call cygpath_w,$(BUILDROOT))" $(call cygpath_w,$(JULIAHOME)/contrib/windows/build-installer.iss))
+	$(call spawn,$(JULIAHOME)/dist-extras/inno/iscc.exe /DAppVersion=$(JULIA_VERSION) /DSourceDir="$(call cygpath_w,$(BUILDROOT)/julia-$(JULIA_COMMIT))" /DRepoDir="$(call cygpath_w,$(JULIAHOME))" /F"$(JULIA_BINARYDIST_FILENAME)" /O"$(call cygpath_w,$(BUILDROOT))" $(INNO_ARGS) $(call cygpath_w,$(JULIAHOME)/contrib/windows/build-installer.iss))
 	chmod a+x "$(BUILDROOT)/$(JULIA_BINARYDIST_FILENAME).exe"
 
 app:

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -45,7 +45,9 @@ SelectTasksDesc=
 
 
 [Setup]
+#ifndef AppId
 AppId={{054B4BC6-BD30-45C8-A623-8F5BA6EBD55D}
+#endif
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppPublisher=Julia Language
@@ -75,6 +77,9 @@ UninstallDisplayIcon={app}\{#AppMainExeName}
 UninstallFilesDir={app}\uninstall
 ChangesEnvironment=true
 
+#ifdef Sign
+SignTool=mysigntool
+#endif
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -45,9 +45,7 @@ SelectTasksDesc=
 
 
 [Setup]
-#ifndef AppId
 AppId={{054B4BC6-BD30-45C8-A623-8F5BA6EBD55D}
-#endif
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppPublisher=Julia Language


### PR DESCRIPTION
@staticfloat 

Signing now works when I add the following to my `Make.user`

```
override INNO_ARGS=/Dsign=true "/Smysigntool=\$$q`cygpath -w /cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/10.0.19041.0/x64/signtool.exe`\$$q sign /f \$$q`cygpath -w /cygdrive/c/Users/Mus/Code/julia/mycert.pfx`\$$q /p Pass123 \$$f"
```

In simplified terms

```
override INNO_ARGS=/Dsign=true "/Smysigntool=\$$q`cygpath -w {{signtool path}}`\$$q sign /f \$$q`cygpath -w {{certificate path}}`\$$q /p {{certificate password}} \$$f"
```

Yes it's kind of a total mess, but we can't help it since this is going through like 3 layers of path/filename translations: makefiles, cygwin, and inno....