### PR TITLE
Update docs as a follow-up to #26733: “deprecating similar(f, …)”

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -712,7 +712,7 @@ to_shape(r::AbstractUnitRange) = r
 
 Create an uninitialized mutable array analogous to that specified by
 `storagetype`, but with `axes` specified by the last
-argument. `storagetype` might be a type or a function.
+argument.
 
 **Examples**:
 


### PR DESCRIPTION
Fixes #37226. Removes a reference in the docs to initializing an array using `similar()` with a function in the first argument position. Here is the documentation in question:

https://github.com/JuliaLang/julia/blob/1c9c24170c53273832088431de99fe19247af172/base/abstractarray.jl#L711-L715