### PR TITLE
make `isa` a generic function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@ Language changes
   For backwards compatibility, `-->` still parses using its own expression head
   instead of `:call`.
 
+* `Base.isa` is now a generic function with a curried method, so that one can write
+  `isa(String)` to make the equivalent to `s -> s isa String`.
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,8 +17,9 @@ Language changes
   For backwards compatibility, `-->` still parses using its own expression head
   instead of `:call`.
 
-* `Base.isa` is now a generic function with a curried method, so that one can write
-  `isa(String)` to make the equivalent to `s -> s isa String`.
+* `Base.isa` has a curried method, so that one can write `isa(String)` to make
+  the equivalent to `s -> s isa String`. `Base.isa` still may not have new methods
+  attached to it.
 
 Compiler/Runtime improvements
 -----------------------------

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -402,6 +402,8 @@ function __init__()
     init_load_path()
     init_active_project()
     nothing
+
+    setfield!(typeof(isa).name.mt, fieldcount(Core.MethodTable), 0x01) # Stop people from being able to add methods to isa
 end
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1578,31 +1578,6 @@ Integer
 """
 invoke
 
-"""
-    isa(x, type) -> Bool
-
-Determine whether `x` is of the given `type`. Can also be used as an infix operator, e.g.
-`x isa type`.
-
-# Examples
-```jldoctest
-julia> isa(1, Int)
-true
-
-julia> isa(1, Matrix)
-false
-
-julia> isa(1, Char)
-false
-
-julia> isa(1, Number)
-true
-
-julia> 1 isa Number
-true
-```
-"""
-isa
 
 """
     DivideError()

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -40,6 +40,35 @@ macro _gc_preserve_end(token)
     Expr(:gc_preserve_end, esc(token))
 end
 
+
+"""
+    isa(x, type) -> Bool
+
+Determine whether `x` is of the given `type`. Can also be used as an infix operator, e.g.
+`x isa type`.
+
+# Examples
+```jldoctest
+julia> isa(1, Int)
+true
+
+julia> isa(1, Matrix)
+false
+
+julia> isa(1, Char)
+false
+
+julia> isa(1, Number)
+true
+
+julia> 1 isa Number
+true
+```
+
+
+"""
+isa(x, T) = Core.isa(x, T)
+
 """
     @nospecialize
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1194,3 +1194,15 @@ julia> [1, 2] .∉ ([2, 3],)
 ```
 """
 ∉, ∌
+
+
+"""
+    isa(T)
+
+Create a function that checks whether its argument [`isa`](@ref) `T`, i.e.
+a function equivalent to `x -> x isa T`.
+
+The returned function is of type `Base.Fix2{typeof(isa)}`, which can be
+used to implement specialized methods.
+"""
+isa(T) = Fix2(isa, T)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1206,3 +1206,4 @@ The returned function is of type `Base.Fix2{typeof(isa)}`, which can be
 used to implement specialized methods.
 """
 isa(T) = Fix2(isa, T)
+setfield!(typeof(isa).name.mt, fieldcount(Core.MethodTable), 0x01) # Stop people from being able to add methods to isa

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1206,4 +1206,3 @@ The returned function is of type `Base.Fix2{typeof(isa)}`, which can be
 used to implement specialized methods.
 """
 isa(T) = Fix2(isa, T)
-setfield!(typeof(isa).name.mt, fieldcount(Core.MethodTable), 0x01) # Stop people from being able to add methods to isa

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -251,4 +251,6 @@ end
     ismatrix = isa(Matrix)
     @test ismatrix([1 2; 3 4])
     @test !ismatrix("hi")
+
+    @test_throws ErrorException Base.:(isa)(x, T) = "boo!"
 end

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -243,3 +243,12 @@ end
     @test gt5(6) && !gt5(5)
     @test lt5(4) && !lt5(5)
 end
+
+@testset "generic isa" begin
+    @test 1 isa Int
+    @test "2" isa String
+
+    ismatrix = isa(Matrix)
+    @test ismatrix([1 2; 3 4])
+    @test !ismatrix("hi")
+end


### PR DESCRIPTION
Currently, `isa` is a builtin function which causes various annoyances.  For instance, 
```julia
julia> @which 1 isa Int
ERROR: ArgumentError: argument is not a generic function
Stacktrace:
 [1] which(::Any, ::Any) at ./reflection.jl:1149
 [2] top-level scope at REPL[14]:1
```
and it also makes it so that we can't have a curried method
```julia
julia> Core.isa(T) = x -> x isa T
ERROR: cannot add methods to a builtin function
Stacktrace:
 [1] top-level scope at REPL[17]:1
```

This PR simply makes generic function `Base.isa(x, T) = Core.isa(x, T)` and adds a curried method `isa(T) = Fix2(isa, T)` so that we can make functions like `isastring = isa(String)`. 

I think this is a nice, minor convenience that costs us little to add. 

Fixes https://github.com/JuliaLang/julia/issues/32018