### PR TITLE
win: allow key Inno variables to be set during compile time

### DIFF
--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -1,8 +1,19 @@
+#ifndef AppName
 #define AppName "Julia"
+#endif
+
+#ifndef AppId
+#define AppId "{{054B4BC6-BD30-45C8-A623-8F5BA6EBD55D}"
+#endif
+
+#ifndef DirName
+#define DirName AppName + "-" + AppVersion
+#endif
+
 #define AppNameLong AppName + " " + AppVersion
 #define AppMainExeName "bin\julia.exe"
 #define CurrentYear GetDateTimeString('yyyy', '', '')
-#define DirName AppName + "-" + AppVersion
+
 
 
 [LangOptions]
@@ -45,7 +56,7 @@ SelectTasksDesc=
 
 
 [Setup]
-AppId={{054B4BC6-BD30-45C8-A623-8F5BA6EBD55D}
+AppId={#AppId}
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppPublisher=Julia Language

--- a/contrib/windows/julia.rc
+++ b/contrib/windows/julia.rc
@@ -18,7 +18,7 @@ BEGIN
       VALUE "FileDescription", "Julia Programming Language"
       VALUE "FileVersion", JLVER_STR
       VALUE "InternalName", "julia"
-      VALUE "LegalCopyright", "(c) 2009-2019 Julia Language"
+      VALUE "LegalCopyright", "(c) 2009-2020 Julia Language"
       VALUE "OriginalFilename", "julia.exe"
       VALUE "ProductName", "Julia"
       VALUE "ProductVersion", JLVER_STR


### PR DESCRIPTION
- `AppID` is important to set different GUID's for different Julia channels
- `AppName` so we can change the app name  for the nightlies  and x86 releases.
-  `DirName` so we can have more fine grained default directory name changes, if need be. 