### PR TITLE
Add `addenv()`; a way to add new mappings into `Cmd` environment blocks.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,7 @@ New library functions
   for writing `(f(args...) for args in zip(iterators...))`, i.e. a lazy `map` ([#34352]).
 * New function `sincospi` for simultaneously computing `sinpi(x)` and `cospi(x)` more
   efficiently ([#35816]).
+* New function `addenv` for adding environment mappings into a `Cmd` object, returning the new `Cmd` object.
 
 New library features
 --------------------

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -60,9 +60,10 @@ while changing the settings of the optional keyword arguments:
   already open or on non-Windows systems.
 * `env`: Set environment variables to use when running the `Cmd`. `env` is either a
   dictionary mapping strings to strings, an array of strings of the form `"var=val"`, an
-  array or tuple of `"var"=>val` pairs, or `nothing`. In order to modify (rather than
-  replace) the existing environment, create `env` by `copy(ENV)` and then set
-  `env["var"]=val` as desired.
+  array or tuple of `"var"=>val` pairs. In order to modify (rather than replace) the
+  existing environment, initialize `env` with `copy(ENV)` and then set `env["var"]=val` as
+  desired.  To add to an environment block within a `Cmd` object without replacing all
+  elements, use `addenv()` which will return a `Cmd` object with the updated environment.
 * `dir::AbstractString`: Specify a working directory for the command (instead
   of the current directory).
 
@@ -230,10 +231,10 @@ byteenv(env::Union{AbstractVector{Pair{T,V}}, Tuple{Vararg{Pair{T,V}}}}) where {
     setenv(command::Cmd, env; dir="")
 
 Set environment variables to use when running the given `command`. `env` is either a
-dictionary mapping strings to strings, an array of strings of the form `"var=val"`, or zero
-or more `"var"=>val` pair arguments. In order to modify (rather than replace) the existing
-environment, create `env` by `copy(ENV)` and then setting `env["var"]=val` as desired, or
-use `withenv`.
+dictionary mapping strings to strings, an array of strings of the form `"var=val"`, or
+zero or more `"var"=>val` pair arguments. In order to modify (rather than replace) the
+existing environment, create `env` through `copy(ENV)` and then setting `env["var"]=val`
+as desired, or use `addenv`.
 
 The `dir` keyword argument can be used to specify a working directory for the command.
 """
@@ -241,6 +242,33 @@ setenv(cmd::Cmd, env; dir="") = Cmd(cmd; env=byteenv(env), dir=dir)
 setenv(cmd::Cmd, env::Pair{<:AbstractString}...; dir="") =
     setenv(cmd, env; dir=dir)
 setenv(cmd::Cmd; dir="") = Cmd(cmd; dir=dir)
+
+"""
+    addenv(command::Cmd, env...)
+
+Merge new environment mappings into the given `Cmd` object, returning a new `Cmd` object.
+Duplicate keys are replaced.
+"""
+function addenv(cmd::Cmd, env::Dict)
+    new_env = Dict{String,String}()
+    if cmd.env !== nothing
+        for (k, v) in split.(cmd.env, "=")
+            new_env[string(k)::String] = string(v)::String
+        end
+    end
+    for (k, v) in env
+        new_env[string(k)::String] = string(v)::String
+    end
+    return setenv(cmd, new_env)
+end
+
+function addenv(cmd::Cmd, pairs::Pair{<:AbstractString}...)
+    return addenv(cmd, Dict(k => v for (k, v) in pairs))
+end
+
+function addenv(cmd::Cmd, env::Vector{<:AbstractString})
+    return addenv(cmd, Dict(k => v for (k, v) in split.(env, "=")))
+end
 
 (&)(left::AbstractCmd, right::AbstractCmd) = AndCmds(left, right)
 redir_out(src::AbstractCmd, dest::AbstractCmd) = OrCmds(src, dest)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -914,6 +914,7 @@ export
     process_running,
     run,
     setenv,
+    addenv,
     success,
     withenv,
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -700,6 +700,19 @@ end
 @test repr(Base.CmdRedirect(``, devnull, 11, true)) == "pipeline(``, 11<Base.DevNull())"
 
 
+# Issue #37070
+@testset "addenv()" begin
+    cmd = Cmd(`$shcmd -c "echo \$FOO \$BAR"`, env=Dict("FOO" => "foo"))
+    @test strip(String(read(cmd))) == "foo"
+    cmd = addenv(cmd, "BAR" => "bar")
+    @test strip(String(read(cmd))) == "foo bar"
+    cmd = addenv(cmd, Dict("FOO" => "bar"))
+    @test strip(String(read(cmd))) == "bar bar"
+    cmd = addenv(cmd, ["FOO=baz"])
+    @test strip(String(read(cmd))) == "baz bar"
+end
+
+
 # clean up busybox download
 if Sys.iswindows()
     rm(busybox, force=true)


### PR DESCRIPTION
This addresses one-half of https://github.com/JuliaLang/julia/issues/37070 as discussed during triage today.  One slightly awkward part of this is that `setenv()` and `addenv()` don't actually mutate the `cmd` object passed in, so you must make sure to `cmd = addenv(cmd, "FOO" => "bar")`.  I have made the docs as explicit as possible about this.