### PR TITLE
allow unicode modifiers after ' 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,9 @@ New language features
   can now be used to rename imported modules and identifiers ([#1255]).
 * Unsigned literals (starting with `0x`) which are too big to fit in an `UInt128` object
   are now interpreted as `BigInt` ([#23546]).
+* The postfix conjugate transpose operator `'` now accepts Unicode modifiers as
+  suffixes, so e.g. `a'ᵀ` is parsed as `var"'ᵀ"(a)`, which can be defined by the
+  user. `a'ᵀ` parsed as `a' * ᵀ` before, so this is a minor change ([#37247]).
 
 Language changes
 ----------------

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -152,7 +152,7 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
 #include "julia_opsuffs.h"
 
 // chars that can follow an operator (e.g. +) and be parsed as part of the operator
-int jl_op_suffix_char(uint32_t wc)
+JL_DLLEXPORT int jl_op_suffix_char(uint32_t wc)
 {
     static htable_t jl_opsuffs; // XXX: requires uv_once
     if (!jl_opsuffs.size) { // initialize hash table of suffixes

--- a/test/show.jl
+++ b/test/show.jl
@@ -2028,3 +2028,12 @@ end
 
 @test sprint(show, :(./)) == ":((./))"
 @test sprint(show, :((.|).(.&, b))) == ":((.|).((.&), b))"
+
+@test sprint(show, :(a'ᵀ)) == ":(a'ᵀ)"
+@test sprint(show, :((+)')) == ":((+)')"
+for s in (Symbol("'"), Symbol("'⁻¹"))
+    @test Base.isoperator(s)
+    @test !Base.isunaryoperator(s)
+    @test !Base.isbinaryoperator(s)
+    @test Base.ispostfixoperator(s)
+end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2445,3 +2445,10 @@ end
 import .TestImportAs.Mod2 as M2
 @test !@isdefined(Mod2)
 @test M2 === TestImportAs.Mod2
+
+@testset "unicode modifiers after '" begin
+    @test Meta.parse("a'ᵀ") == Expr(:call, Symbol("'ᵀ"), :a)
+    @test Meta.parse("a'⁻¹") == Expr(:call, Symbol("'⁻¹"), :a)
+    @test Meta.parse("a'ᵀb") == Expr(:call, :*, Expr(:call, Symbol("'ᵀ"), :a), :b)
+    @test Meta.parse("a'⁻¹b") == Expr(:call, :*, Expr(:call, Symbol("'⁻¹"), :a), :b)
+end


### PR DESCRIPTION
As discussed in the triage call, this is technically breaking because we currently parse `a'ᵀ` as `a' * ᵀ` and `a'ᵀb` as `a' * ᵀb`, but it doesn't look like this is actually [used in the wild](https://juliahub.com/ui/RepoSearch?q=.%2a%27%5B%5Cp%7BLm%7D%5D%28%3F%21%27%29.%2a&r=true). Still needs news.

fixes #34507