### PR TITLE
fix Dict `sizehint!` to allow enough space for the requested length

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -231,15 +231,16 @@ end
 
 function sizehint!(d::Dict{T}, newsz) where T
     oldsz = length(d.slots)
+    # limit new element count to max_values of the key type
+    newsz = min(newsz, max_values(T)::Int)
+    # need at least 1.5n space to hold n elements
+    newsz = cld(3 * newsz, 2)
     if newsz <= oldsz
         # todo: shrink
         # be careful: rehash!() assumes everything fits. it was only designed
         # for growing.
         return d
     end
-    # grow at least 25%
-    newsz = min(max(newsz, (oldsz*5)>>2),
-                max_values(T)::Int)
     rehash!(d, newsz)
 end
 


### PR DESCRIPTION
fixes #9909
noticed in #37208

Test code:
```
function grow_dict(szh::Bool)
    d = Dict{Int,Nothing}()
    szh && sizehint!(d, 32768)
    for i in 1:32768
        d[i] = nothing
    end
    length(d.keys)
end
```
before:
```
julia> @btime grow_dict(true)
  704.747 μs (12 allocations: 1.41 MiB)
131072

julia> @btime grow_dict(false)
  702.613 μs (27 allocations: 770.16 KiB)
65536
```
after:
```
julia> @btime grow_dict(true)
  464.426 μs (7 allocations: 576.66 KiB)
65536

julia> @btime grow_dict(false)
  702.545 μs (27 allocations: 770.16 KiB)
65536
```

@bkamins You'll probably want to rerun the benchmarks for `allunique`!
