### PR TITLE
Precompile a `get!` instance used by Requires

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -20,6 +20,7 @@ precompile(Tuple{typeof(push!), Set{Module}, Module})
 precompile(Tuple{typeof(push!), Set{Method}, Method})
 precompile(Tuple{typeof(push!), Set{Base.PkgId}, Base.PkgId})
 precompile(Tuple{typeof(setindex!), Dict{String,Base.PkgId}, Base.PkgId, String})
+precompile(Tuple{typeof(get!), Type{Vector{Function}}, Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
 """
 
 precompile_script = """


### PR DESCRIPTION
In conjunction with xref https://github.com/JuliaPackaging/Requires.jl/pull/89, this shaves about 100ms off the first usage of Requires. Aside from the 60ms it takes to load Requires, this pretty much eliminates the disincentives for using it (the remaining compilation time is basically negligible).