### PR TITLE
Fix type-equality involving `Type{Union{}}`

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -244,6 +244,10 @@ static int obviously_unequal(jl_value_t *a, jl_value_t *b)
         if (jl_is_datatype(b)) {
             jl_datatype_t *ad = (jl_datatype_t*)a;
             jl_datatype_t *bd = (jl_datatype_t*)b;
+            if (a == (jl_value_t*)jl_typeofbottom_type && bd->name == jl_type_typename)
+                return obviously_unequal(jl_bottom_type, jl_tparam(bd, 0));
+            if (ad->name == jl_type_typename && b == (jl_value_t*)jl_typeofbottom_type)
+                return obviously_unequal(jl_tparam(ad, 0), jl_bottom_type);
             if (ad->name != bd->name)
                 return 1;
             int istuple = (ad->name == jl_tuple_typename);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1769,3 +1769,6 @@ end
 
 # issue #37180
 @test !(typeintersect(Tuple{AbstractArray{T}, VecOrMat{T}} where T, Tuple{Array, Any}).body.parameters[1] isa Union)
+
+# issue #37255
+@test Type{Union{}} == Type{T} where {Union{}<:T<:Union{}}


### PR DESCRIPTION
In particular, make `obviously_unequal(Type{Union{}}, Type{T} where {Union{}<:T<:Union{}})` false. Fixes #37255