### PR TITLE
support larger isinlinealloc types

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -513,7 +513,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
     if (isinlinealloc && st->layout->npointers > 0) {
         if (st->ninitialized != nfields)
             isinlinealloc = 0;
-        else if (st->layout->fielddesc_type != 0) // GC only implements support for this
+        else if (st->layout->fielddesc_type > 1) // GC only implements support for 8 and 16 (not array32)
             isinlinealloc = 0;
     }
     st->isbitstype = isbitstype;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1820,6 +1820,54 @@ STATIC_INLINE int gc_mark_scan_array8(jl_ptls_t ptls, jl_gc_mark_sp_t *sp,
     return 0;
 }
 
+// Scan a sparse array of object references, see `gc_mark_objarray_t`
+STATIC_INLINE int gc_mark_scan_array16(jl_ptls_t ptls, jl_gc_mark_sp_t *sp,
+                                      gc_mark_array16_t *ary16,
+                                      jl_value_t **begin, jl_value_t **end,
+                                      uint16_t *elem_begin, uint16_t *elem_end,
+                                      jl_value_t **pnew_obj, uintptr_t *ptag, uint8_t *pbits)
+{
+    (void)jl_assume(ary16 == (gc_mark_array16_t*)sp->data);
+    size_t elsize = ((jl_array_t*)ary16->elem.parent)->elsize / sizeof(jl_value_t*);
+    for (; begin < end; begin += elsize) {
+        for (; elem_begin < elem_end; elem_begin++) {
+            jl_value_t **slot = &begin[*elem_begin];
+            *pnew_obj = *slot;
+            if (*pnew_obj)
+                verify_parent2("array", ary16->elem.parent, slot, "elem(%d)",
+                               gc_slot_to_arrayidx(ary16->elem.parent, begin));
+            if (!gc_try_setmark(*pnew_obj, &ary16->elem.nptr, ptag, pbits))
+                continue;
+            elem_begin++;
+            // Found an object to mark
+            if (elem_begin < elem_end) {
+                // Haven't done with this one yet. Update the content and push it back
+                ary16->elem.begin = elem_begin;
+                ary16->begin = begin;
+                gc_repush_markdata(sp, gc_mark_array16_t);
+            }
+            else {
+                begin += elsize;
+                if (begin < end) {
+                    // Haven't done with this array yet. Reset the content and push it back
+                    ary16->elem.begin = ary16->rebegin;
+                    ary16->begin = begin;
+                    gc_repush_markdata(sp, gc_mark_array16_t);
+                }
+                else {
+                    // Finished scanning this one, finish up by checking the GC invariance
+                    // and let the next item replacing the current one directly.
+                    gc_mark_push_remset(ptls, ary16->elem.parent, ary16->elem.nptr);
+                }
+            }
+            return 1;
+        }
+        elem_begin = ary16->rebegin;
+    }
+    gc_mark_push_remset(ptls, ary16->elem.parent, ary16->elem.nptr);
+    return 0;
+}
+
 
 // Scan an object with 8bits field descriptors. see `gc_mark_obj8_t`
 STATIC_INLINE int gc_mark_scan_obj8(jl_ptls_t ptls, jl_gc_mark_sp_t *sp, gc_mark_obj8_t *obj8,
@@ -1937,6 +1985,8 @@ STATIC_INLINE int gc_mark_scan_obj32(jl_ptls_t ptls, jl_gc_mark_sp_t *sp, gc_mar
             goto objarray;                      \
         case GC_MARK_L_array8:                  \
             goto array8;                        \
+        case GC_MARK_L_array16:                 \
+            goto array16;                       \
         case GC_MARK_L_obj8:                    \
             goto obj8;                          \
         case GC_MARK_L_obj16:                   \
@@ -2029,6 +2079,7 @@ JL_EXTENSION NOINLINE void gc_mark_loop(jl_ptls_t ptls, jl_gc_mark_sp_t sp)
         gc_mark_label_addrs[GC_MARK_L_finlist] = gc_mark_laddr(finlist);
         gc_mark_label_addrs[GC_MARK_L_objarray] = gc_mark_laddr(objarray);
         gc_mark_label_addrs[GC_MARK_L_array8] = gc_mark_laddr(array8);
+        gc_mark_label_addrs[GC_MARK_L_array16] = gc_mark_laddr(array16);
         gc_mark_label_addrs[GC_MARK_L_obj8] = gc_mark_laddr(obj8);
         gc_mark_label_addrs[GC_MARK_L_obj16] = gc_mark_laddr(obj16);
         gc_mark_label_addrs[GC_MARK_L_obj32] = gc_mark_laddr(obj32);
@@ -2048,6 +2099,7 @@ JL_EXTENSION NOINLINE void gc_mark_loop(jl_ptls_t ptls, jl_gc_mark_sp_t sp)
     jl_value_t **objary_end;
 
     gc_mark_array8_t *ary8;
+    gc_mark_array16_t *ary16;
 
     gc_mark_obj8_t *obj8;
     char *obj8_parent;
@@ -2108,6 +2160,17 @@ array8_loaded:
         goto mark;
     goto pop;
 
+array16:
+    ary16 = gc_pop_markdata(&sp, gc_mark_array16_t);
+    objary_begin = ary16->begin;
+    objary_end = ary16->end;
+    obj16_begin = ary16->elem.begin;
+    obj16_end = ary16->elem.end;
+array16_loaded:
+    if (gc_mark_scan_array16(ptls, &sp, ary16, objary_begin, objary_end, obj16_begin, obj16_end,
+                            &new_obj, &tag, &bits))
+        goto mark;
+    goto pop;
 
 obj8:
     obj8 = gc_pop_markdata(&sp, gc_mark_obj8_t);
@@ -2474,6 +2537,15 @@ mark: {
                                        &markdata, sizeof(markdata), 0);
                     ary8 = (gc_mark_array8_t*)sp.data;
                     goto array8_loaded;
+                }
+                else if (layout->fielddesc_type == 1) {
+                    obj16_begin = (uint16_t*)jl_dt_layout_ptrs(layout);
+                    obj16_end = obj16_begin + npointers;
+                    gc_mark_array16_t markdata = {objary_begin, objary_end, obj16_begin, {new_obj, obj16_begin, obj16_end, nptr}};
+                    gc_mark_stack_push(&ptls->gc_cache, &sp, gc_mark_laddr(array16),
+                                       &markdata, sizeof(markdata), 0);
+                    ary16 = (gc_mark_array16_t*)sp.data;
+                    goto array16_loaded;
                 }
                 else {
                     assert(0 && "unimplemented");

--- a/src/gc.h
+++ b/src/gc.h
@@ -81,6 +81,7 @@ enum {
     GC_MARK_L_finlist,
     GC_MARK_L_objarray,
     GC_MARK_L_array8,
+    GC_MARK_L_array16,
     GC_MARK_L_obj8,
     GC_MARK_L_obj16,
     GC_MARK_L_obj32,
@@ -149,6 +150,13 @@ typedef struct {
     gc_mark_obj8_t elem;
 } gc_mark_array8_t;
 
+typedef struct {
+    jl_value_t **begin; // The first slot to be scanned.
+    jl_value_t **end; // The end address (after the last slot to be scanned)
+    uint16_t *rebegin;
+    gc_mark_obj16_t elem;
+} gc_mark_array16_t;
+
 // Stack frame
 typedef struct {
     jl_gcframe_t *s; // The current stack frame
@@ -192,6 +200,7 @@ union _jl_gc_mark_data {
     gc_mark_marked_obj_t marked;
     gc_mark_objarray_t objarray;
     gc_mark_array8_t array8;
+    gc_mark_array16_t array16;
     gc_mark_obj8_t obj8;
     gc_mark_obj16_t obj16;
     gc_mark_obj32_t obj32;

--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -350,8 +350,8 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Cvoid}}, url_ptr::Cstring,
 end
 
 function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
-                        oid_ptr::Ptr{GitHash}, is_merge::Cuint, payload::Ptr{Cvoid})
-    fhead_vec = unsafe_pointer_to_objref(payload)::Vector{FetchHead}
+                                    oid_ptr::Ptr{GitHash}, is_merge::Cuint, payload::Any)
+    fhead_vec = payload::Vector{FetchHead}
     Base.push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url),
         unsafe_load(oid_ptr), is_merge == 1))
     return Cint(0)
@@ -362,4 +362,4 @@ mirror_cb() = @cfunction(mirror_callback, Cint, (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cs
 "C function pointer for `credentials_callback`"
 credentials_cb() = @cfunction(credentials_callback, Cint, (Ptr{Ptr{Cvoid}}, Cstring, Cstring, Cuint, Any))
 "C function pointer for `fetchhead_foreach_callback`"
-fetchhead_foreach_cb() = @cfunction(fetchhead_foreach_callback, Cint, (Cstring, Cstring, Ptr{GitHash}, Cuint, Ptr{Cvoid}))
+fetchhead_foreach_cb() = @cfunction(fetchhead_foreach_callback, Cint, (Cstring, Cstring, Ptr{GitHash}, Cuint, Any))

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -174,10 +174,10 @@ The fields represent:
 
     notify_flags::Cuint          = Consts.CHECKOUT_NOTIFY_NONE
     notify_cb::Ptr{Cvoid}        = C_NULL
-    notify_payload::Ptr{Cvoid}   = C_NULL
+    notify_payload::Any          = nothing
 
     progress_cb::Ptr{Cvoid}      = C_NULL
-    progress_payload::Ptr{Cvoid} = C_NULL
+    progress_payload::Any        = nothing
 
     paths::StrArrayStruct        = StrArrayStruct()
 
@@ -190,8 +190,9 @@ The fields represent:
     their_label::Cstring         = Cstring(C_NULL)
 
     perfdata_cb::Ptr{Cvoid}      = C_NULL
-    perfdata_payload::Ptr{Cvoid} = C_NULL
+    perfdata_payload::Any        = Nothing
 end
+@assert CheckoutOptions.isinlinealloc
 
 """
     LibGit2.TransferProgress
@@ -208,8 +209,15 @@ Matches the [`git_transfer_progress`](https://libgit2.org/libgit2/#HEAD/type/git
     indexed_deltas::Cuint   = Cuint(0)
     received_bytes::Csize_t = Csize_t(0)
 end
+@assert TransferProgress.isinlinealloc
 
-@kwdef struct RemoteCallbacksStruct
+"""
+    LibGit2.RemoteCallbacks
+
+Callback settings.
+Matches the [`git_remote_callbacks`](https://libgit2.org/libgit2/#HEAD/type/git_remote_callbacks) struct.
+"""
+@kwdef struct RemoteCallbacks
     version::Cuint                     = Cuint(1)
     sideband_progress::Ptr{Cvoid}      = C_NULL
     completion::Ptr{Cvoid}             = C_NULL
@@ -222,11 +230,12 @@ end
     push_update_reference::Ptr{Cvoid}  = C_NULL
     push_negotiation::Ptr{Cvoid}       = C_NULL
     transport::Ptr{Cvoid}              = C_NULL
-    payload::Ptr{Cvoid}                = C_NULL
+    payload::Any                       = nothing
     @static if LibGit2.VERSION >= v"0.99.0"
         resolve_url::Ptr{Cvoid}        = C_NULL
     end
 end
+@assert RemoteCallbacks.isinlinealloc
 
 """
     LibGit2.Callbacks
@@ -249,23 +258,6 @@ See [`git_remote_callbacks`](https://libgit2.org/libgit2/#HEAD/type/git_remote_c
 for details on supported callbacks.
 """
 const Callbacks = Dict{Symbol, Tuple{Ptr{Cvoid}, Any}}
-
-"""
-    LibGit2.RemoteCallbacks
-
-Callback settings.
-Matches the [`git_remote_callbacks`](https://libgit2.org/libgit2/#HEAD/type/git_remote_callbacks) struct.
-"""
-struct RemoteCallbacks
-    cb::RemoteCallbacksStruct
-    gcroot::Ref{Any}
-
-    function RemoteCallbacks(; version::Cuint=Cuint(1), payload=C_NULL, callbacks...)
-        p = Ref{Any}(payload)
-        pp = unsafe_load(Ptr{Ptr{Cvoid}}(Base.unsafe_convert(Ptr{Any}, p)))
-        return new(RemoteCallbacksStruct(; version=version, payload=pp, callbacks...), p)
-    end
-end
 
 function RemoteCallbacks(c::Callbacks)
     callbacks = Dict{Symbol, Ptr{Cvoid}}()
@@ -319,22 +311,9 @@ julia> fetch(remote, "master", options=fo)
     url::Cstring                 = Cstring(C_NULL)
     credential_cb::Ptr{Cvoid}    = C_NULL
     certificate_cb::Ptr{Cvoid}   = C_NULL
-    payload::Ptr{Cvoid}          = C_NULL
+    payload::Any                 = nothing
 end
-
-@kwdef struct FetchOptionsStruct
-    version::Cuint                     = Cuint(1)
-    callbacks::RemoteCallbacksStruct   = RemoteCallbacksStruct()
-    prune::Cint                        = Consts.FETCH_PRUNE_UNSPECIFIED
-    update_fetchhead::Cint             = Cint(1)
-    download_tags::Cint                = Consts.REMOTE_DOWNLOAD_TAGS_AUTO
-    @static if LibGit2.VERSION >= v"0.25.0"
-        proxy_opts::ProxyOptions       = ProxyOptions()
-    end
-    @static if LibGit2.VERSION >= v"0.24.0"
-        custom_headers::StrArrayStruct = StrArrayStruct()
-    end
-end
+@assert ProxyOptions.isinlinealloc
 
 """
     LibGit2.FetchOptions
@@ -355,27 +334,21 @@ The fields represent:
   * `custom_headers`: any extra headers needed for the fetch. Only present on libgit2 versions
      newer than or equal to 0.24.0.
 """
-struct FetchOptions
-    opts::FetchOptionsStruct
-    cb_gcroot::Ref{Any}
-    function FetchOptions(; callbacks::RemoteCallbacks=RemoteCallbacks(), kwargs...)
-        return new(FetchOptionsStruct(; kwargs..., callbacks=callbacks.cb), callbacks.gcroot)
+@kwdef struct FetchOptions
+    version::Cuint                     = Cuint(1)
+    callbacks::RemoteCallbacks         = RemoteCallbacks()
+    prune::Cint                        = Consts.FETCH_PRUNE_UNSPECIFIED
+    update_fetchhead::Cint             = Cint(1)
+    download_tags::Cint                = Consts.REMOTE_DOWNLOAD_TAGS_AUTO
+    @static if LibGit2.VERSION >= v"0.25.0"
+        proxy_opts::ProxyOptions       = ProxyOptions()
+    end
+    @static if LibGit2.VERSION >= v"0.24.0"
+        custom_headers::StrArrayStruct = StrArrayStruct()
     end
 end
+@assert FetchOptions.isinlinealloc
 
-
-@kwdef struct CloneOptionsStruct
-    version::Cuint                      = Cuint(1)
-    checkout_opts::CheckoutOptions      = CheckoutOptions()
-    fetch_opts::FetchOptionsStruct      = FetchOptionsStruct()
-    bare::Cint                          = Cint(0)
-    localclone::Cint                    = Consts.CLONE_LOCAL_AUTO
-    checkout_branch::Cstring            = Cstring(C_NULL)
-    repository_cb::Ptr{Cvoid}           = C_NULL
-    repository_cb_payload::Ptr{Cvoid}   = C_NULL
-    remote_cb::Ptr{Cvoid}               = C_NULL
-    remote_cb_payload::Ptr{Cvoid}       = C_NULL
-end
 
 """
     LibGit2.CloneOptions
@@ -399,13 +372,19 @@ The fields represent:
   * `remote_cb`: An optional callback used to create the [`GitRemote`](@ref) before making the clone from it.
   * `remote_cb_payload`: The payload for the remote callback.
 """
-struct CloneOptions
-    opts::CloneOptionsStruct
-    cb_gcroot::Ref{Any}
-    function CloneOptions(; fetch_opts::FetchOptions=FetchOptions(), kwargs...)
-        return new(CloneOptionsStruct(; kwargs..., fetch_opts=fetch_opts.opts), fetch_opts.cb_gcroot)
-    end
+@kwdef struct CloneOptions
+    version::Cuint                      = Cuint(1)
+    checkout_opts::CheckoutOptions      = CheckoutOptions()
+    fetch_opts::FetchOptions            = FetchOptions()
+    bare::Cint                          = Cint(0)
+    localclone::Cint                    = Consts.CLONE_LOCAL_AUTO
+    checkout_branch::Cstring            = Cstring(C_NULL)
+    repository_cb::Ptr{Cvoid}           = C_NULL
+    repository_cb_payload::Any          = nothing
+    remote_cb::Ptr{Cvoid}               = C_NULL
+    remote_cb_payload::Any              = nothing
 end
+@assert CloneOptions.isinlinealloc
 
 """
     LibGit2.DiffOptionsStruct
@@ -449,7 +428,7 @@ The fields represent:
     @static if LibGit2.VERSION >= v"0.24.0"
         progress_cb::Ptr{Cvoid}              = C_NULL
     end
-    payload::Ptr{Cvoid}                      = C_NULL
+    payload::Any                             = nothing
 
     # options controlling how the diff text is generated
     context_lines::UInt32                    = UInt32(3)
@@ -459,6 +438,7 @@ The fields represent:
     old_prefix::Cstring                      = Cstring(C_NULL)
     new_prefix::Cstring                      = Cstring(C_NULL)
 end
+@assert DiffOptionsStruct.isinlinealloc
 
 """
     LibGit2.DescribeOptions
@@ -488,6 +468,7 @@ The fields represent:
     only_follow_first_parent::Cint    = Cint(0)
     show_commit_oid_as_fallback::Cint = Cint(0)
 end
+@assert DescribeOptions.isinlinealloc
 
 """
     LibGit2.DescribeFormatOptions
@@ -506,6 +487,7 @@ The fields represent:
     always_use_long_format::Cint = Cint(0)
     dirty_suffix::Cstring        = Cstring(C_NULL)
 end
+@assert DescribeFormatOptions.isinlinealloc
 
 """
     LibGit2.DiffFile
@@ -635,6 +617,7 @@ The fields represent:
     file_favor::GIT_MERGE_FILE_FAVOR  = Consts.MERGE_FILE_FAVOR_NORMAL
     file_flags::GIT_MERGE_FILE        = Consts.MERGE_FILE_DEFAULT
 end
+@assert MergeOptions.isinlinealloc
 
 """
     LibGit2.BlameOptions
@@ -664,18 +647,8 @@ The fields represent:
     min_line::Csize_t                 = Csize_t(1)
     max_line::Csize_t                 = Csize_t(0)
 end
+@assert BlameOptions.isinlinealloc
 
-@kwdef struct PushOptionsStruct
-    version::Cuint                     = Cuint(1)
-    parallelism::Cint                  = Cint(1)
-    callbacks::RemoteCallbacksStruct   = RemoteCallbacksStruct()
-    @static if LibGit2.VERSION >= v"0.25.0"
-        proxy_opts::ProxyOptions       = ProxyOptions()
-    end
-    @static if LibGit2.VERSION >= v"0.24.0"
-        custom_headers::StrArrayStruct = StrArrayStruct()
-    end
-end
 
 """
     LibGit2.PushOptions
@@ -694,13 +667,19 @@ The fields represent:
   * `custom_headers`: only relevant if the LibGit2 version is greater than or equal to `0.24.0`.
      Extra headers needed for the push operation.
 """
-struct PushOptions
-    opts::PushOptionsStruct
-    cb_gcroot::Ref{Any}
-    function PushOptions(; callbacks::RemoteCallbacks=RemoteCallbacks(), kwargs...)
-        return new(PushOptionsStruct(; kwargs..., callbacks=callbacks.cb), callbacks.gcroot)
+@kwdef struct PushOptions
+    version::Cuint                     = Cuint(1)
+    parallelism::Cint                  = Cint(1)
+    callbacks::RemoteCallbacks         = RemoteCallbacks()
+    @static if LibGit2.VERSION >= v"0.25.0"
+        proxy_opts::ProxyOptions       = ProxyOptions()
+    end
+    @static if LibGit2.VERSION >= v"0.24.0"
+        custom_headers::StrArrayStruct = StrArrayStruct()
     end
 end
+@assert PushOptions.isinlinealloc
+
 
 """
     LibGit2.CherrypickOptions
@@ -722,6 +701,7 @@ The fields represent:
     merge_opts::MergeOptions = MergeOptions()
     checkout_opts::CheckoutOptions = CheckoutOptions()
 end
+@assert CherrypickOptions.isinlinealloc
 
 
 """
@@ -791,6 +771,7 @@ The fields represent:
     end
     checkout_opts::CheckoutOptions = CheckoutOptions()
 end
+@assert RebaseOptions.isinlinealloc
 
 """
     LibGit2.RebaseOperation
@@ -853,6 +834,7 @@ The fields represent:
         baseline::Ptr{Cvoid} = C_NULL
     end
 end
+@assert StatusOptions.isinlinealloc
 
 """
     LibGit2.StatusEntry
@@ -918,8 +900,9 @@ Matches the [`git_config_entry`](https://libgit2.org/libgit2/#HEAD/type/git_conf
     value::Cstring      = Cstring(C_NULL)
     level::GIT_CONFIG   = Consts.CONFIG_LEVEL_DEFAULT
     free::Ptr{Cvoid}    = C_NULL
-    payload::Ptr{Cvoid} = C_NULL
+    payload::Any        = nothing
 end
+@assert ConfigEntry.isinlinealloc
 
 function Base.show(io::IO, ce::ConfigEntry)
     print(io, "ConfigEntry(\"", unsafe_string(ce.name), "\", \"", unsafe_string(ce.value), "\")")
@@ -1153,6 +1136,7 @@ The fields represent:
 
     boundary::Char                        = '\0'
 end
+@assert BlameHunk.isinlinealloc
 
 """
     with(f::Function, obj)


### PR DESCRIPTION
Because it's not hard, and there's a useful case now. Eventually I want to support `@inline struct` / `@noinline struct`, but currently just make it an `@assert` in the LibGit2 code where I'm now using this capability.