### PR TITLE
fix exception stack pop for UndefVarError in catch block

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3780,7 +3780,9 @@ f(x) = yt(x)
         (let* ((x   (if rett
                         (compile (convert-for-type-decl x rett) '() #t #f)
                         x))
-               (tmp (if (valid-ir-return? x) #f (make-ssavalue))))
+               (tmp (if ((if (null? catch-token-stack) valid-ir-return? simple-atom?) x)
+                        #f
+                        (make-ssavalue))))
           (if tmp (emit `(= ,tmp ,x)))
           (let ((pexc (pop-exc-expr catch-token-stack '())))
             (if pexc (emit pexc)))

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -383,3 +383,18 @@ function f36527()
 end
 
 @test f36527()
+
+# accessing an undefined var in tail position in a catch block
+function undef_var_in_catch()
+    try
+        error("first error")
+    catch
+        __probably_n0t_defined__
+    end
+end
+@test length(try
+    undef_var_in_catch()
+    []
+catch
+    catch_stack()
+end) == 2


### PR DESCRIPTION
Before:
```
julia> try; error(0); catch; x; end
ERROR: UndefVarError: x not defined
Stacktrace:
 [1] top-level scope at REPL[2]:1
```
after:
```
julia> try; error(0); catch; x; end
ERROR: UndefVarError: x not defined
Stacktrace:
 [1] top-level scope
   @ REPL[1]:1

caused by:
0
Stacktrace:
 [1] error(s::Int64)
   @ Base ./error.jl:42
 [2] top-level scope
   @ REPL[1]:1
```