### PR TITLE
more accurate and type-stable sinc/cosc

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1073,7 +1073,7 @@ sinc(x::Number) = _sinc(float(x))
 sinc(x::Integer) = iszero(x) ? one(x) : zero(x)
 _sinc(x::Number) = iszero(x) ? one(x) : x isa Real && isinf(x) ? zero(x) : sinpi(x)/(pi*x)
 _sinc_threshold(::Type{Float64}) = 0.001
-_sinc_threshold(::Type{Float32}) = 0.05
+_sinc_threshold(::Type{Float32}) = 0.05f0
 @inline function _sinc(x::Union{T,Complex{T}}) where {T<:Union{Float32,Float64}}
     a = fastabs(x)
     return a < _sinc_threshold(T) ? @evalpoly(x^2, T(1), -T(pi)^2/6, T(pi)^4/120) : x isa Real && isinf(a) ? zero(x) : sinpi(x)/(pi*x)
@@ -1116,7 +1116,7 @@ _cosc(x::Union{Float64,ComplexF64}) =
     fastabs(x) < 0.14 ? x*evalpoly(x^2, (-3.289868133696453, 3.2469697011334144, -1.1445109447325053, 0.2091827825412384, -0.023460810354558236, 0.001781145516372852)) :
     x isa Real && isinf(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
 _cosc(x::Union{Float32,ComplexF32}) =
-    fastabs(x) < 0.26 ? x*evalpoly(x^2, (-3.289868f0, 3.2469697f0, -1.144511f0, 0.20918278f0)) :
+    fastabs(x) < 0.26f0 ? x*evalpoly(x^2, (-3.289868f0, 3.2469697f0, -1.144511f0, 0.20918278f0)) :
     x isa Real && isinf(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
 _cosc(x::Float16) = Float16(_cosc(Float32(x)))
 _cosc(x::ComplexF16) = ComplexF16(_cosc(ComplexF32(x)))

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1054,15 +1054,32 @@ function sincospi(z::Complex{T}) where T
 end
 
 """
+    fastabs(x::Number)
+
+Faster `abs`-like function for rough magnitude comparisons.
+`fastabs` is equivalent to `abs(x)` for most `x`,
+but for complex `x` it computes `abs(real(x))+abs(imag(x))` rather
+than requiring `hypot`.
+"""
+fastabs(x::Number) = abs(x)
+fastabs(z::Complex) = abs(real(z)) + abs(imag(z))
+
+"""
     sinc(x)
 
 Compute ``\\sin(\\pi x) / (\\pi x)`` if ``x \\neq 0``, and ``1`` if ``x = 0``.
 """
-sinc(x::Number) = x==0 ? one(x)  : oftype(x,sinpi(x)/(pi*x))
-sinc(x::Integer) = x==0 ? one(x) : zero(x)
-sinc(x::Complex{<:AbstractFloat}) = x==0 ? one(x) : oftype(x, sinpi(x)/(pi*x))
-sinc(x::Complex) = sinc(float(x))
-sinc(x::Real) = x==0 ? one(x) : isinf(x) ? zero(x) : sinpi(x)/(pi*x)
+sinc(x::Number) = _sinc(float(x))
+sinc(x::Integer) = iszero(x) ? one(x) : zero(x)
+_sinc(x::Number) = iszero(x) ? one(x) : x isa Real && isinf(x) ? zero(x) : sinpi(x)/(pi*x)
+_sinc_threshold(::Type{Float64}) = 0.001
+_sinc_threshold(::Type{Float32}) = 0.05
+@inline function _sinc(x::Union{T,Complex{T}}) where {T<:Union{Float32,Float64}}
+    a = fastabs(x)
+    return a < _sinc_threshold(T) ? @evalpoly(x^2, T(1), -T(pi)^2/6, T(pi)^4/120) : x isa Real && isinf(a) ? zero(x) : sinpi(x)/(pi*x)
+end
+_sinc(x::Float16) = Float16(_sinc(Float32(x)))
+_sinc(x::ComplexF16) = ComplexF16(_sinc(ComplexF32(x)))
 
 """
     cosc(x)
@@ -1070,11 +1087,39 @@ sinc(x::Real) = x==0 ? one(x) : isinf(x) ? zero(x) : sinpi(x)/(pi*x)
 Compute ``\\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2)`` if ``x \\neq 0``, and ``0`` if
 ``x = 0``. This is the derivative of `sinc(x)`.
 """
-cosc(x::Number) = x==0 ? zero(x) : oftype(x,(cospi(x)-sinpi(x)/(pi*x))/x)
-cosc(x::Integer) = cosc(float(x))
-cosc(x::Complex{<:AbstractFloat}) = x==0 ? zero(x) : oftype(x,(cospi(x)-sinpi(x)/(pi*x))/x)
-cosc(x::Complex) = cosc(float(x))
-cosc(x::Real) = x==0 || isinf(x) ? zero(x) : (cospi(x)-sinpi(x)/(pi*x))/x
+cosc(x::Number) = _cosc(float(x))
+function _cosc(x::Number)
+    # naive cosc formula is susceptible to catastrophic
+    # cancellation error near x=0, so we use the Taylor series
+    # for small enough |x|.
+    if fastabs(x) < 0.5
+        # generic Taylor series: π ∑ (-πx)^{2n-1}/a(n) where
+        # a(n) = (1+2n)*(2n-1)! (= OEIS A174549)
+        s = (term = -(π*x))/3
+        π²x² = term^2
+        ε = eps(fastabs(term)) # error threshold to stop sum
+        n = 1
+        while true
+            n += 1
+            term *= π²x²/((1-2n)*(2n-2))
+            s += (δs = term/(1+2n))
+            fastabs(δs) ≤ ε && break
+        end
+        return π*s
+    else
+        return x isa Real && isinf(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+    end
+end
+# hard-code Float64/Float32 Taylor series, with coefficients
+#  Float64.([(-1)^n*big(pi)^(2n)/((2n+1)*factorial(2n-1)) for n = 1:6])
+_cosc(x::Union{Float64,ComplexF64}) =
+    fastabs(x) < 0.14 ? x*evalpoly(x^2, (-3.289868133696453, 3.2469697011334144, -1.1445109447325053, 0.2091827825412384, -0.023460810354558236, 0.001781145516372852)) :
+    x isa Real && isinf(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+_cosc(x::Union{Float32,ComplexF32}) =
+    fastabs(x) < 0.26 ? x*evalpoly(x^2, (-3.289868f0, 3.2469697f0, -1.144511f0, 0.20918278f0)) :
+    x isa Real && isinf(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+_cosc(x::Float16) = Float16(_cosc(Float32(x)))
+_cosc(x::ComplexF16) = ComplexF16(_cosc(ComplexF32(x)))
 
 for (finv, f, finvh, fh, finvd, fd, fn) in ((:sec, :cos, :sech, :cosh, :secd, :cosd, "secant"),
                                             (:csc, :sin, :csch, :sinh, :cscd, :sind, "cosecant"),

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1093,7 +1093,7 @@ function _cosc(x::Number)
     # cancellation error near x=0, so we use the Taylor series
     # for small enough |x|.
     if fastabs(x) < 0.5
-        # generic Taylor series: π ∑ (-πx)^{2n-1}/a(n) where
+        # generic Taylor series: π ∑ (-1)^n (πx)^{2n-1}/a(n) where
         # a(n) = (1+2n)*(2n-1)! (= OEIS A174549)
         s = (term = -(π*x))/3
         π²x² = term^2

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1081,7 +1081,7 @@ _sinc_threshold(::Type{Float64}) = 0.001
 _sinc_threshold(::Type{Float32}) = 0.05f0
 @inline function _sinc(x::Union{T,Complex{T}}) where {T<:Union{Float32,Float64}}
     a = fastabs(x)
-    return a < _sinc_threshold(T) ? @evalpoly(x^2, T(1), -T(pi)^2/6, T(pi)^4/120) : isinf_real(a) ? zero(x) : sinpi(x)/(pi*x)
+    return a < _sinc_threshold(T) ? evalpoly(x^2, (T(1), -T(pi)^2/6, T(pi)^4/120)) : isinf_real(a) ? zero(x) : sinpi(x)/(pi*x)
 end
 _sinc(x::Float16) = Float16(_sinc(Float32(x)))
 _sinc(x::ComplexF16) = ComplexF16(_sinc(ComplexF32(x)))

--- a/test/math.jl
+++ b/test/math.jl
@@ -476,7 +476,7 @@ end
     setprecision(256) do
         for R in (BigFloat, Float16, Float32, Float64)
             for T in (R, Complex{R})
-                for x in (0, 1e-20, 1e-30, 1e-40, 1e-50, 1e-60, 1e-70, 5.07138898934e-313)
+                for x in (0, 1e-5, 1e-20, 1e-30, 1e-40, 1e-50, 1e-60, 1e-70, 5.07138898934e-313)
                     if x < eps(R)
                         @test sinc(T(x)) == 1
                     end

--- a/test/math.jl
+++ b/test/math.jl
@@ -450,7 +450,7 @@ end
     @test ismissing(scdm[2])
 end
 
-@testset "Integer args to sinpi/cospi/sinc/cosc" begin
+@testset "Integer and Inf args for sinpi/cospi/sinc/cosc" begin
     for (sinpi, cospi) in ((sinpi, cospi), (x->sincospi(x)[1], x->sincospi(x)[2]))
         @test sinpi(1) == 0
         @test sinpi(-1) == -0
@@ -466,6 +466,9 @@ end
     @test cosc(0) == 0
     @test cosc(complex(1,0)) == -1
     @test cosc(Inf) == 0
+
+    @test sinc(Inf + 3im) == 0
+    @test cosc(Inf + 3im) == 0
 end
 
 # issue #37227

--- a/test/math.jl
+++ b/test/math.jl
@@ -468,6 +468,38 @@ end
     @test cosc(Inf) == 0
 end
 
+# issue #37227
+@testset "sinc/cosc accuracy" begin
+    setprecision(256) do
+        for R in (BigFloat, Float16, Float32, Float64)
+            for T in (R, Complex{R})
+                for x in (0, 1e-20, 1e-30, 1e-40, 1e-50, 1e-60, 1e-70, 5.07138898934e-313)
+                    if x < eps(R)
+                        @test sinc(T(x)) == 1
+                    end
+                    @test cosc(T(x)) ≈ pi*(-R(x)*pi)/3 rtol=max(eps(R)*100, (pi*R(x))^2)
+                end
+            end
+        end
+    end
+    @test @inferred(sinc(0//1)) === 1.0
+    @test @inferred(cosc(0//1)) === -0.0
+
+    # test right before/after thresholds of Taylor series
+    @test sinc(0.001) ≈ 0.999998355066745 rtol=1e-15
+    @test sinc(0.00099) ≈ 0.9999983878009009 rtol=1e-15
+    @test sinc(0.05f0) ≈ 0.9958927352435614 rtol=1e-7
+    @test sinc(0.0499f0) ≈ 0.9959091277049384 rtol=1e-7
+    @test cosc(0.14) ≈ -0.4517331883801308 rtol=1e-15
+    @test cosc(0.1399) ≈ -0.45142306168781854 rtol=1e-14
+    @test cosc(0.26f0) ≈ -0.7996401373462212 rtol=5e-7
+    @test cosc(0.2599f0) ≈ -0.7993744054401625 rtol=5e-7
+    setprecision(256) do
+        @test cosc(big"0.5") ≈ big"-1.273239544735162686151070106980114896275677165923651589981338752471174381073817" rtol=1e-76
+        @test cosc(big"0.499") ≈ big"-1.272045747741181369948389133250213864178198918667041860771078493955590574971317" rtol=1e-76
+    end
+end
+
 @testset "Irrational args to sinpi/cospi/sinc/cosc" begin
     for x in (pi, ℯ, Base.MathConstants.golden)
         for (sinpi, cospi) in ((sinpi, cospi), (x->sincospi(x)[1], x->sincospi(x)[2]))


### PR DESCRIPTION
Fixes #37227.

(Replaces original algorithm from 2010! 1917197353051c65929126b7afd2b0c38dbb93ea)

Backport?