### PR TITLE
Add a statement-cost printer for analyzing inlining decisions

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2169,9 +2169,9 @@ module IRShow
     include("compiler/ssair/show.jl")
 
     const __debuginfo = Dict{Symbol, Any}(
-        # :full => src -> Base.IRShow.DILineInfoPrinter(src.linetable), # and add variable slot information
-        :source => src -> Base.IRShow.DILineInfoPrinter(src.linetable),
-        # :oneliner => src -> Base.IRShow.PartialLineInfoPrinter(src.linetable),
+        # :full => src -> Base.IRShow.statementidx_lineinfo_printer(src), # and add variable slot information
+        :source => src -> Base.IRShow.statementidx_lineinfo_printer(src),
+        # :oneliner => src -> Base.IRShow.statementidx_lineinfo_printer(Base.IRShow.PartialLineInfoPrinter, src),
         :none => src -> Base.IRShow.lineinfo_disabled,
         )
     const default_debuginfo = Ref{Symbol}(:none)

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -97,49 +97,22 @@ dynamic dispatch, but a mere heuristic indicating that dynamic
 dispatch is extremely expensive.
 
 Each statement gets analyzed for its total cost in a function called
-`statement_cost`. You can run this yourself by following the sketch below,
-where `f` is your function and `tt` is the Tuple-type of the arguments:
-
-```jldoctest
-# A demo on `fill(3.5, (2, 3))`
-f = fill
-tt = Tuple{Float64, Tuple{Int,Int}}
-# Create the objects we need to interact with the compiler
-opt_params = Core.Compiler.OptimizationParams()
-mi = Base.method_instances(f, tt)[1]
-ci = code_typed(f, tt)[1][1]
-interp = Core.Compiler.NativeInterpreter()
-opt = Core.Compiler.OptimizationState(mi, opt_params, interp)
-# Calculate cost of each statement
-cost(stmt::Expr) = Core.Compiler.statement_cost(stmt, -1, ci, opt.sptypes, opt.slottypes, opt.params)
-cost(stmt) = 0
-cst = map(cost, ci.code)
-
-# output
-
-31-element Vector{Int64}:
-  0
-  0
- 20
-  4
-  1
-  1
-  1
-  0
-  0
-  0
-  ⋮
-  0
-  0
-  0
-  0
-  0
-  0
-  0
-  0
-  0
+`statement_cost`. You can display the cost associated with each statement
+as follows:
+```jldoctest; filter=r"tuple.jl:\d+"
+julia> Base.print_statement_costs(stdout, map, (typeof(sqrt), Tuple{Int},)) # map(sqrt, (2,))
+map(f, t::Tuple{Any}) in Base at tuple.jl:169
+  0 1 ─ %1  = Base.getfield(_3, 1, true)::Int64
+  1 │   %2  = Base.sitofp(Float64, %1)::Float64
+  2 │   %3  = Base.lt_float(%2, 0.0)::Bool
+  0 └──       goto #3 if not %3
+  0 2 ─       Base.Math.throw_complex_domainerror(:sqrt, %2)::Union{}
+  0 └──       unreachable
+ 20 3 ─ %7  = Base.Math.sqrt_llvm(%2)::Float64
+  0 └──       goto #4
+  0 4 ─       goto #5
+  0 5 ─ %10 = Core.tuple(%7)::Tuple{Float64}
+  0 └──       return %10
 ```
 
-The output is a `Vector{Int}` holding the estimated cost of each
-statement in `ci.code`.  Note that `ci` includes the consequences of
-inlining callees, and consequently the costs do too.
+The line costs are in the left column. This includes the consequences of inlining and other forms of optimization.

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -42,6 +42,13 @@ end
 test_code_reflections(test_ir_reflection, code_lowered)
 test_code_reflections(test_ir_reflection, code_typed)
 
+io = IOBuffer()
+Base.print_statement_costs(io, map, (typeof(sqrt), Tuple{Int}))
+str = String(take!(io))
+@test occursin("map(f, t::Tuple{Any})", str)
+@test occursin("sitofp", str)
+@test occursin(r"20 .*sqrt_llvm.*::Float64", str)
+
 end # module ReflectionTest
 
 # isbits, isbitstype


### PR DESCRIPTION
While it now has a doctest, https://docs.julialang.org/en/latest/devdocs/inference/#The-inlining-algorithm-(inline_worthy)-1 has bitrotted more than once. And it's sufficiently laborious that it discourages rapid investigation. This makes printing the costs easy.

Here's a demo:
```julia
julia> Base.print_statement_costs(map, (typeof(sqrt), Tuple{Int}))
map(f, t::Tuple{Any}) in Base at tuple.jl:169
  0 1 ─ %1  = Base.getfield(_3, 1, true)::Int64
  1 │   %2  = Base.sitofp(Float64, %1)::Float64
  2 │   %3  = Base.lt_float(%2, 0.0)::Bool
  0 └──       goto #3 if not %3
  0 2 ─       Base.Math.throw_complex_domainerror(:sqrt, %2)::Union{}
  0 └──       unreachable
 20 3 ─ %7  = Base.Math.sqrt_llvm(%2)::Float64
  0 └──       goto #4
  0 4 ─       goto #5
  0 5 ─ %10 = Core.tuple(%7)::Tuple{Float64}
  0 └──       return %10
```
The numbers in the first column are the inliner's assigned cost.

~~If folks like this, I can add a test to make sure this stays working.~~ (done)