### PR TITLE
Faster indexing with ReinterpretArrays

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -151,18 +151,32 @@ end
         GC.@preserve t s begin
             tptr = Ptr{UInt8}(unsafe_convert(Ref{T}, t))
             sptr = Ptr{UInt8}(unsafe_convert(Ref{S}, s))
-            i = 1
-            nbytes_copied = 0
-            # This is a bit complicated to deal with partial elements
-            # at both the start and the end. LLVM will fold as appropriate,
-            # once it knows the data layout
-            while nbytes_copied < sizeof(T)
-                s[] = a.parent[ind_start + i, tailinds...]
-                nb = min(sizeof(S) - sidx, sizeof(T)-nbytes_copied)
-                _memcpy!(tptr + nbytes_copied, sptr + sidx, nb)
-                nbytes_copied += nb
-                sidx = 0
-                i += 1
+            # Optimizations that avoid branches
+            if sizeof(T) % sizeof(S) == 0
+                # T is bigger than S and contains an integer number of them
+                n = sizeof(T) ÷ sizeof(S)
+                for i = 1:n
+                    s[] = a.parent[ind_start + i, tailinds...]
+                    _memcpy!(tptr + (i-1)*sizeof(S), sptr, sizeof(S))
+                end
+            elseif sizeof(S) % sizeof(T) == 0
+                # S is bigger than T and contains an integer number of them
+                s[] = a.parent[ind_start + 1, tailinds...]
+                _memcpy!(tptr, sptr + sidx, sizeof(T))
+            else
+                i = 1
+                nbytes_copied = 0
+                # This is a bit complicated to deal with partial elements
+                # at both the start and the end. LLVM will fold as appropriate,
+                # once it knows the data layout
+                while nbytes_copied < sizeof(T)
+                    s[] = a.parent[ind_start + i, tailinds...]
+                    nb = min(sizeof(S) - sidx, sizeof(T)-nbytes_copied)
+                    _memcpy!(tptr + nbytes_copied, sptr + sidx, nb)
+                    nbytes_copied += nb
+                    sidx = 0
+                    i += 1
+                end
             end
         end
         return t[]
@@ -200,33 +214,48 @@ end
         GC.@preserve t s begin
             tptr = Ptr{UInt8}(unsafe_convert(Ref{T}, t))
             sptr = Ptr{UInt8}(unsafe_convert(Ref{S}, s))
-            nbytes_copied = 0
-            i = 1
-            # Deal with any partial elements at the start. We'll have to copy in the
-            # element from the original array and overwrite the relevant parts
-            if sidx != 0
-                s[] = a.parent[ind_start + i, tailinds...]
-                nb = min(sizeof(S) - sidx, sizeof(T))
-                _memcpy!(sptr + sidx, tptr, nb)
-                nbytes_copied += nb
-                a.parent[ind_start + i, tailinds...] = s[]
-                i += 1
-                sidx = 0
-            end
-            # Deal with the main body of elements
-            while nbytes_copied < sizeof(T) && (sizeof(T) - nbytes_copied) > sizeof(S)
-                nb = min(sizeof(S), sizeof(T) - nbytes_copied)
-                _memcpy!(sptr, tptr + nbytes_copied, nb)
-                nbytes_copied += nb
-                a.parent[ind_start + i, tailinds...] = s[]
-                i += 1
-            end
-            # Deal with trailing partial elements
-            if nbytes_copied < sizeof(T)
-                s[] = a.parent[ind_start + i, tailinds...]
-                nb = min(sizeof(S), sizeof(T) - nbytes_copied)
-                _memcpy!(sptr, tptr + nbytes_copied, nb)
-                a.parent[ind_start + i, tailinds...] = s[]
+            # Optimizations that avoid branches
+            if sizeof(T) % sizeof(S) == 0
+                # T is bigger than S and contains an integer number of them
+                n = sizeof(T) ÷ sizeof(S)
+                for i = 0:n-1
+                    _memcpy!(sptr, tptr + i*sizeof(S), sizeof(S))
+                    a.parent[ind_start + i + 1, tailinds...] = s[]
+                end
+            elseif sizeof(S) % sizeof(T) == 0
+                # S is bigger than T and contains an integer number of them
+                s[] = a.parent[ind_start + 1, tailinds...]
+                _memcpy!(sptr + sidx, tptr, sizeof(T))
+                a.parent[ind_start + 1, tailinds...] = s[]
+            else
+                nbytes_copied = 0
+                i = 1
+                # Deal with any partial elements at the start. We'll have to copy in the
+                # element from the original array and overwrite the relevant parts
+                if sidx != 0
+                    s[] = a.parent[ind_start + i, tailinds...]
+                    nb = min((sizeof(S) - sidx) % UInt, sizeof(T) % UInt)
+                    _memcpy!(sptr + sidx, tptr, nb)
+                    nbytes_copied += nb
+                    a.parent[ind_start + i, tailinds...] = s[]
+                    i += 1
+                    sidx = 0
+                end
+                # Deal with the main body of elements
+                while nbytes_copied < sizeof(T) && (sizeof(T) - nbytes_copied) > sizeof(S)
+                    nb = min(sizeof(S), sizeof(T) - nbytes_copied)
+                    _memcpy!(sptr, tptr + nbytes_copied, nb)
+                    nbytes_copied += nb
+                    a.parent[ind_start + i, tailinds...] = s[]
+                    i += 1
+                end
+                # Deal with trailing partial elements
+                if nbytes_copied < sizeof(T)
+                    s[] = a.parent[ind_start + i, tailinds...]
+                    nb = min(sizeof(S), sizeof(T) - nbytes_copied)
+                    _memcpy!(sptr, tptr + nbytes_copied, nb)
+                    a.parent[ind_start + i, tailinds...] = s[]
+                end
             end
         end
     end


### PR DESCRIPTION
First, this addresses a completely different issue from #37230, one that has been with us basically since the introduction of `ReinterpretArray`. JuliaImages uses these heavily to convert between arrays-with-one-dimension-as-a-color-channel and arrays-with-color-eltypes. The performance of the reinterpreted arrays is ok but still lags their "plain" counterparts. For example, on Julia 1.5, [these benchmarks](https://github.com/JuliaImages/ImageCore.jl/blob/master/test/benchmarks.jl) with `@show` statements in the obvious places yields the following:
```julia
 julia> include("benchmarks.jl")
[ Info: Benchmark tests are warnings for now
testf = test_getindex
f = mysum_elt_boundscheck
t_cv / t_ar = 4.777580203008076
t_cv / t_ar = 1.131872927212428
f = mysum_index_boundscheck
t_cv / t_ar = 3.7536299097427848
t_cv / t_ar = 1.113240418118467
f = mysum_elt_inbounds
t_cv / t_ar = 4.336681561357509
t_cv / t_ar = 1.1323093035433758
f = mysum_index_inbounds_simd
t_cv / t_ar = 9.71937984496124
t_cv / t_ar = 1.017641129032258
testf = test_setindex
f = myfill1!
t_cv / t_ar = 12.837561952893275
t_cv / t_ar = 6.482242035686005
┌ Warning: ColorView: failed on myfill1!, time ratio 6.482242035686005, tol 3
└ @ Main ~/.julia/dev/ImageCore/test/benchmarks.jl:115
f = myfill2!
t_cv / t_ar = 12.588068488356834
t_cv / t_ar = 5.892122808256755
┌ Warning: ColorView: failed on myfill2!, time ratio 5.892122808256755, tol 3
└ @ Main ~/.julia/dev/ImageCore/test/benchmarks.jl:115
```
The ratio is the time needed to perform the operation on the ReinterpretArray vs an Array analog (same size and dimensionality). As you can see, while there are a couple of cases where they are essentially indistinguishable, in many there is a pretty large gap.

In the case that JuliaImages cares about, either `S` or `T` has size that is an integer multiple of the size of the other, so some of the logic in ReinterpretArray indexing doesn't seem necessary. I decided to test whether a more streamlined implementation might yield better performance, and my efforts were reasonably well rewarded:

```julia
julia> include("benchmarks.jl")
[ Info: Benchmark tests are warnings for now
testf = test_getindex
f = mysum_elt_boundscheck
t_cv / t_ar = 2.0115922767379186
t_cv / t_ar = 1.169678196523834
f = mysum_index_boundscheck
t_cv / t_ar = 1.7171157186679973
t_cv / t_ar = 1.167269595176572
f = mysum_elt_inbounds
t_cv / t_ar = 1.7877239745298386
t_cv / t_ar = 1.1628865979381444
f = mysum_index_inbounds_simd
t_cv / t_ar = 3.8455890292624986
t_cv / t_ar = 0.8519592411564908
testf = test_setindex
f = myfill1!
t_cv / t_ar = 9.696876807148703
t_cv / t_ar = 1.002855631761487
f = myfill2!
t_cv / t_ar = 9.172384461284038
t_cv / t_ar = 1.0064263212146136
```
There are only two truly egregious cases left. A profile reveals a surprising answer:
```julia
julia> @profile test_setindex(myfill2!, a, vchan, 10^2)
(0.0015627129999999999, 0.0144178465)

julia> Profile.print()
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
   ╎1650 @Base/client.jl:485; _start()
   ╎ 1650 @Base/client.jl:302; exec_options(opts::Base.JLOptions)
   ╎  1650 @Base/client.jl:372; run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
   ╎   1650 @Base/essentials.jl:717; invokelatest
   ╎    1650 @Base/essentials.jl:718; #invokelatest#2
   ╎     1650 @Base/client.jl:387; (::Base.var"#836#838"{Bool,Bool,Bool})(REPL::Module)
   ╎    ╎ 1650 @REPL/src/REPL.jl:304; run_repl(repl::REPL.AbstractREPL, consumer::Any)
   ╎    ╎  1650 @REPL/src/REPL.jl:316; run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool)
   ╎    ╎   1650 @REPL/src/REPL.jl:185; start_repl_backend(backend::REPL.REPLBackend, consumer::Any)
   ╎    ╎    1650 @REPL/src/REPL.jl:200; repl_backend_loop(backend::REPL.REPLBackend)
   ╎    ╎     1650 @REPL/src/REPL.jl:139; eval_user_input(ast::Any, backend::REPL.REPLBackend)
   ╎    ╎    ╎ 1650 @Base/boot.jl:344; eval(m::Module, e::Any)
   ╎    ╎    ╎  152  @ImageCore/test/benchmarks.jl:69; test_setindex(f::typeof(myfill2!), ar::Array{Float64,3}, cv::Base.ReinterpretArray{Float64,3,RGB{Fl...
   ╎    ╎    ╎   152  @Base/timing.jl:233; macro expansion
   ╎    ╎    ╎    152  @ImageCore/test/benchmarks.jl:43; myfill2!
   ╎    ╎    ╎     123  @Base/simdloop.jl:77; macro expansion
   ╎    ╎    ╎    ╎ 123  @ImageCore/test/benchmarks.jl:44; macro expansion
122╎    ╎    ╎    ╎  123  @Base/array.jl:847; setindex!
   ╎    ╎    ╎     29   @Base/simdloop.jl:78; macro expansion
 29╎    ╎    ╎    ╎ 29   @Base/int.jl:87; +
   ╎    ╎    ╎  1498 @ImageCore/test/benchmarks.jl:70; test_setindex(f::typeof(myfill2!), ar::Array{Float64,3}, cv::Base.ReinterpretArray{Float64,3,RGB{Fl...
   ╎    ╎    ╎   1498 @Base/timing.jl:233; macro expansion
   ╎    ╎    ╎    1498 @ImageCore/test/benchmarks.jl:43; myfill2!(A::Base.ReinterpretArray{Float64,3,RGB{Float64},Array{RGB{Float64},3}}, val::Float64)
   ╎    ╎    ╎     1498 @Base/simdloop.jl:77; macro expansion
   ╎    ╎    ╎    ╎ 1498 @ImageCore/test/benchmarks.jl:44; macro expansion
   ╎    ╎    ╎    ╎  1498 @Base/reinterpretarray.jl:198; setindex!
   ╎    ╎    ╎    ╎   314  @Base/reinterpretarray.jl:211; _setindex_ra!
   ╎    ╎    ╎    ╎    314  @Base/div.jl:120; divrem
   ╎    ╎    ╎    ╎     314  @Base/div.jl:124; divrem
314╎    ╎    ╎    ╎    ╎ 314  @Base/int.jl:262; rem
   ╎    ╎    ╎    ╎   116  @Base/reinterpretarray.jl:227; _setindex_ra!
 34╎    ╎    ╎    ╎    34   @Base/array.jl:809; getindex
   ╎    ╎    ╎    ╎    82   @Base/refvalue.jl:33; setindex!
 82╎    ╎    ╎    ╎     82   @Base/Base.jl:34; setproperty!
   ╎    ╎    ╎    ╎   1068 @Base/reinterpretarray.jl:229; _setindex_ra!
155╎    ╎    ╎    ╎    155  @Base/array.jl:847; setindex!
   ╎    ╎    ╎    ╎    913  @Base/refvalue.jl:32; getindex
913╎    ╎    ╎    ╎     913  @Base/Base.jl:33; getproperty
Total snapshots: 1650
```
Surprisingly, it's the *read* from `s[]` that dominates the time, although the `divrem` is pretty unfortunate too. We might be able to design a custom iterator that avoids the divrem, but until that `load` gets faster there doesn't seem like a lot of point. Any ideas?

CC @johnnychen94.