### PR TITLE
Implement TOML.parse([::Parser,] ::IO)

### DIFF
--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -30,10 +30,10 @@ const Parser = Internals.Parser
     parsefile(f::AbstractString)
     parsefile(p::Parser, f::AbstractString)
 
-Parses a file `f` and returns the resulting table (dictionary). Throws a
+Parse file `f` and return the resulting table (dictionary). Throw a
 [`ParserError`](@ref) upon failure.
 
-See also [`TOML.tryparsefile`](@ref)
+See also: [`TOML.tryparsefile`](@ref)
 """
 parsefile(f::AbstractString) =
     Internals.parse(Parser(read(f, String); filepath=abspath(f)))
@@ -44,10 +44,10 @@ parsefile(p::Parser, f::AbstractString) =
     tryparsefile(f::AbstractString)
     tryparsefile(p::Parser, f::AbstractString)
 
-Parses a file `f` and returns the resulting table (dictionary). Returns a
+Parse file `f` and return the resulting table (dictionary). Return a
 [`ParserError`](@ref) upon failure.
 
-See also [`TOML.parsefile`](@ref)
+See also: [`TOML.parsefile`](@ref)
 """
 tryparsefile(f::AbstractString) =
     Internals.tryparse(Parser(read(f, String); filepath=abspath(f)))
@@ -55,32 +55,36 @@ tryparsefile(p::Parser, f::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, read(f, String); filepath=abspath(f)))
 
 """
-    parse(str::AbstractString)
-    parse(p::Parser, str::AbstractString)
+    parse(x::Union{AbstractString, IO})
+    parse(p::Parser, x::Union{AbstractString, IO})
 
-Parses a string `str` and returns the resulting table (dictionary). Returns a
-[`ParserError`](@ref) upon failure.
+Parse the string  or stream `x`, and return the resulting table (dictionary).
+Throw a [`ParserError`](@ref) upon failure.
 
-See also [`TOML.tryparse`](@ref)
+See also: [`TOML.tryparse`](@ref)
 """
 parse(str::AbstractString) =
     Internals.parse(Parser(String(str)))
 parse(p::Parser, str::AbstractString) =
     Internals.parse(Internals.reinit!(p, String(str)))
+parse(io::IO) = parse(read(io, String))
+parse(p::Parser, io::IO) = parse(p, read(io, String))
 
 """
-    tryparse(str::AbstractString)
-    tryparse(p::Parser, str::AbstractString)
+    tryparse(x::Union{AbstractString, IO})
+    tryparse(p::Parser, x::Union{AbstractString, IO})
 
-Parses a string `str` and returns the resulting table (dictionary). Returns a
-[`ParserError`](@ref) upon failure.
+Parse the string or stream `x`, and return the resulting table (dictionary).
+Return a [`ParserError`](@ref) upon failure.
 
-See also [`TOML.parse`](@ref)
+See also: [`TOML.parse`](@ref)
 """
 tryparse(str::AbstractString) =
     Internals.tryparse(Parser(String(str)))
 tryparse(p::Parser, str::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, String(str)))
+tryparse(io::IO) = tryparse(read(io, String))
+tryparse(p::Parser, io::IO) = tryparse(p, read(io, String))
 
 """
     ParserError

--- a/stdlib/TOML/test/parse.jl
+++ b/stdlib/TOML/test/parse.jl
@@ -1,0 +1,46 @@
+using TOML, Test
+using TOML: ParserError
+
+@testset "TOML.(try)parse(file) entrypoints" begin
+    dict = Dict{String,Any}("a" => 1)
+    str = "a = 1"; invalid_str = "a"
+    path, io = mktemp(); write(io, str); close(io)
+    invalid_path, io = mktemp(); write(io, invalid_str); close(io)
+    p = TOML.Parser()
+    # TOML.parse
+    @test TOML.parse(str) == TOML.parse(SubString(str)) ==
+          TOML.parse(IOBuffer(str)) ==
+          TOML.parse(p, str) == TOML.parse(p, SubString(str)) ==
+          TOML.parse(p, IOBuffer(str)) == dict
+    @test_throws ParserError TOML.parse(invalid_str)
+    @test_throws ParserError TOML.parse(SubString(invalid_str))
+    @test_throws ParserError TOML.parse(IOBuffer(invalid_str))
+    @test_throws ParserError TOML.parse(p, invalid_str)
+    @test_throws ParserError TOML.parse(p, SubString(invalid_str))
+    @test_throws ParserError TOML.parse(p, IOBuffer(invalid_str))
+    # TOML.tryparse
+    @test TOML.tryparse(str) == TOML.tryparse(SubString(str)) ==
+          TOML.tryparse(IOBuffer(str)) ==
+          TOML.tryparse(p, str) == TOML.tryparse(p, SubString(str)) ==
+          TOML.tryparse(p, IOBuffer(str)) == dict
+    @test TOML.tryparse(invalid_str) isa ParserError
+    @test TOML.tryparse(SubString(invalid_str)) isa ParserError
+    @test TOML.tryparse(IOBuffer(invalid_str)) isa ParserError
+    @test TOML.tryparse(p, invalid_str) isa ParserError
+    @test TOML.tryparse(p, SubString(invalid_str)) isa ParserError
+    @test TOML.tryparse(p, IOBuffer(invalid_str)) isa ParserError
+    # TOML.parsefile
+    @test TOML.parsefile(path) == TOML.parsefile(SubString(path)) ==
+          TOML.parsefile(p, path) == TOML.parsefile(p, SubString(path)) == dict
+    @test_throws ParserError TOML.parsefile(invalid_path)
+    @test_throws ParserError TOML.parsefile(SubString(invalid_path))
+    @test_throws ParserError TOML.parsefile(p, invalid_path)
+    @test_throws ParserError TOML.parsefile(p, SubString(invalid_path))
+    # TOML.tryparsefile
+    @test TOML.tryparsefile(path) == TOML.tryparsefile(SubString(path)) ==
+          TOML.tryparsefile(p, path) == TOML.tryparsefile(p, SubString(path)) == dict
+    @test TOML.tryparsefile(invalid_path) isa ParserError
+    @test TOML.tryparsefile(SubString(invalid_path)) isa ParserError
+    @test TOML.tryparsefile(p, invalid_path) isa ParserError
+    @test TOML.tryparsefile(p, SubString(invalid_path)) isa ParserError
+end

--- a/stdlib/TOML/test/runtests.jl
+++ b/stdlib/TOML/test/runtests.jl
@@ -19,5 +19,6 @@ include("values.jl")
 include("invalids.jl")
 include("error_printing.jl")
 include("print.jl")
+include("parse.jl")
 
 @inferred TOML.parse("foo = 3")


### PR DESCRIPTION
Implement `TOML.parse([::Parser,] ::IO)` and add more tests for `TOML.(try)parse(file)` entrypoints.