### PR TITLE
More accurate Base.lerpi for higher-precision numbers

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -685,7 +685,7 @@ end
 
 function lerpi(j::Integer, d::Integer, a::T, b::T) where T
     @_inline_meta
-    t = j/d
+    t = eltype(T)(j)/d
     T((1-t)*a + t*b)
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1326,6 +1326,15 @@ end
     @test r[4] === 3.0+im
 end
 
+@testset "issue #37276" begin
+    r = range(Complex{BigFloat}(0), stop=Complex{BigFloat}(1), length=4)
+    @test isa(@inferred(r[2]), Complex{BigFloat})
+    @test r[1] == 0.
+    @test r[2] ≈ big"1"/3   rtol=10eps(BigFloat)
+    @test r[3] ≈ big"2"/3   rtol=10eps(BigFloat)
+    @test r[4] == 1.
+end
+
 # ambiguity between (:) methods (#20988)
 struct NotReal; val; end
 Base.:+(x, y::NotReal) = x + y.val


### PR DESCRIPTION
This should fix #37276.

Examples of things that are more accurate with this PR include:
```
julia> LinRange(Complex{BigFloat}(0), Complex{BigFloat}(1), 11)[2]
0.1000000000000000000000000000000000000000000000000000000000000000000000000000002 + 0.0im

julia> LinRange([0//1], [1//1], 11)[2]
1-element Vector{Rational{Int64}}:
 1//10
```
in comparison to the current master:
```
julia> LinRange(Complex{BigFloat}(0), Complex{BigFloat}(1), 11)[2]
0.1000000000000000055511151231257827021181583404541015625 + 0.0im

julia> LinRange([0//1], [1//1], 11)[2]
1-element Array{Rational{Int64},1}:
 3602879701896397//36028797018963968
```

I think that the proposed implementation of a generic `Base.lerpi` makes it less useful to have a specific method for rationals (such as defined in [rational.jl:467](https://github.com/JuliaLang/julia/blob/master/base/rational.jl#L467)).

One potential downside to the way things are done in this PR, is that there could potentially be a loss of accuracy w.r.t how things are currently done, when working on ranges of small (i.e. less than 64 bits) floating-point numbers. I'm not sure whether that was intended, but in the current implementation, the `j/d` quotient usually results in `t` being a `Float64`, meaning that computations involving `a` and `b` will be promoted to `Float64` too if the end points are smaller FP numbers. With the current implementation, all calculations use the same precision as the range end points.

It would not be too difficult to restore the current master behavior for smaller FP number types, but I'm not sure whether it is worth making the implementation more complicated. In particular, I have no idea how many users expect and rely on the fact that points in a `LinRange{Float16}` are computed in double precision before being rounded to half precision. Would somebody have some insight on this?