### PR TITLE
Improve alias analysis on julia.typeof and memcmp

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2,12 +2,12 @@
 
 // utility procedures used in code generation
 
-static Instruction *tbaa_decorate(MDNode *md, Instruction *load_or_store)
+static Instruction *tbaa_decorate(MDNode *md, Instruction *inst)
 {
-    load_or_store->setMetadata(llvm::LLVMContext::MD_tbaa, md);
-    if (isa<LoadInst>(load_or_store) && md == tbaa_const)
-        load_or_store->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(md->getContext(), None));
-    return load_or_store;
+    inst->setMetadata(llvm::LLVMContext::MD_tbaa, md);
+    if (isa<LoadInst>(inst) && md == tbaa_const)
+        inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(md->getContext(), None));
+    return inst;
 }
 
 static Value *track_pjlvalue(jl_codectx_t &ctx, Value *V)


### PR DESCRIPTION
* `julia.typeof` is a pure function of the pointer itself within the lifetime of the object
  so it can be treated as readnone until we expose write to the type tag (during allocation)
  to LLVM.
* The TBAA metadata can be applied to all functions that access only argument memory or
  inaccessible memory. Mark it on `memcmp` as well.

----

Note that the TBAA on `memcmp` currently doesn't do anything on linux and freebsd due to an LLVM bug. Ref https://reviews.llvm.org/D86837. A backportable version of the patch for LLVM 10 is available at https://github.com/archlinuxcn/repo/blob/443b0112e68ad95189a75a5d4324f4fb61b68714/archlinuxcn/llvm-julia/0001-Backportable-version-of-D86837.patch