### PR TITLE
lowering: Drop unused name expr for non-symbol names

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -361,6 +361,9 @@
 (define (outerref? e)
   (and (pair? e) (eq? (car e) 'outerref)))
 
+(define (nothing? e)
+  (and (pair? e) (eq? (car e) 'null)))
+
 (define (symbol-like? e)
   (or (symbol? e) (ssavalue? e)))
 


### PR DESCRIPTION
In expressions like `Foo.Bar.f() = 1`, we would lower this as

`Expr(:method, Expr(:call, :getproperty, Expr(:call, :getproperty, :Foo, :Bar), :f) ...)`

where args[1] is supposed to be the name of the method. However, if
this is not a symbol, the name is actually ignored and the method
is required to exist already (i.e. `function foo(); end` is allowed
to introduce a new method if `foo` doesn't exist, but `function Main.foo(); end`
is not). It doesn't do much harm currently other than being a bit ugly.
However, I was trying to do some experiments with getproperty lowering
that made the lowering a bit more complicated, which made the frontend
unhappy, because there were now more complicated expressions in there
(the fact that it works for call is a bit of an accident). Since there
is no good reason to keep it and I did the work to drop it anyway,
for my experimenting, let's just drop this unused expr arg entirely
and replace it by nothing if it's not supposed to be used.