### PR TITLE
RFC: Generalize CartesianIndex and support ranges with static inner/outer size

### DIFF
--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -16,6 +16,9 @@ ex = Base.Cartesian.exprresolve(:(if 5 > 4; :x; else :y; end))
 
     # can't convert higher-dimensional indices to Int
     @test_throws MethodError convert(Int, CartesianIndex(42, 1))
+
+    @test Base.AbstractCartesianIndex((1, 2)) === Base.AbstractCartesianIndex((1, Int16(2))) ===
+          Base.AbstractCartesianIndex(1, 2)   === Base.AbstractCartesianIndex(1, Int16(2))   === CartesianIndex(1, 2)
 end
 
 @testset "CartesianIndices overflow" begin
@@ -65,6 +68,19 @@ end
 
     @test iterate(I, CartesianIndex(3, typemax(Int)))[1] == CartesianIndex(4,typemax(Int))
     @test iterate(I, CartesianIndex(4, typemax(Int)))    === nothing
+end
+
+@testset "GenericCartesianIndices iteration" begin
+    iter = CartesianIndices((Base.SDivRemUnitRange{3}(1:15), Base.OneTo(2)))
+    @test first(iter) === Base.IteratorsMD.GenericCartesianIndex(Base.SDivRemInt{3}(0, 1), 1)
+    @test last(iter)  === Base.IteratorsMD.GenericCartesianIndex(Base.SDivRemInt{3}(4, 3), 2)
+    iterref = CartesianIndices((1:15, 1:2))
+    ret, retref = iterate(iter), iterate(iterref)
+    while ret !== nothing
+        @test CartesianIndex{2}(ret[1]) === retref[1]
+        ret, retref = iterate(iter, ret[2]), iterate(iterref, retref[2])
+    end
+    @test retref === nothing
 end
 
 @testset "CartesianIndices operations" begin

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1627,3 +1627,26 @@ end
         @test eltype(T(1:5)) === eltype(T(1:5)[1:2])
     end
 end
+
+@testset "SDivRemUnitRanges" begin
+    r = Base.SDivRemUnitRange{3}(1:15)
+    @test first(r) == 1
+    @test last(r) == 15
+    @test step(r) == 1
+    @test length(r) == 15
+    @test !isempty(r)
+    j = 0
+    for i in r
+        @test i == (j += 1)
+    end
+    @test j == 15
+    @test_throws ArgumentError Base.SDivRemUnitRange{3}(2:15)
+    @test_throws ArgumentError Base.SDivRemUnitRange{3}(1:14)
+    r = Base.SDivRemUnitRange{3}(1:0)
+    @test isempty(r)
+    j = 0
+    for i in r
+        @test i == (j += 1)
+    end
+    @test j == 0
+end


### PR DESCRIPTION
Some array types, notably certain types of `ReinterpretArray`, can be thought of as having a first dimension that has an "inner/outer" pattern of iteration due to calling [`divrem`](https://github.com/JuliaLang/julia/blob/41e603e5836bebf447f14c82fb2671b3567fc3bf/base/reinterpretarray.jl#L148) on the first index. For efficient iteration and especially vectorization, it is helpful to avoid the `divrem`. You can see this in the new benchmarks in #37277, where most cases are reasonably well fixed (to within a factor of 2 of their corresponding `Array`s) but certain other array types still exhibit performance penalites of nearly 20x. On closer inspection, the ones that are "fixed" are conceptually like `reinterpret(NTuple{K,T}, ::Array{T})` and those that are not are the opposite, `reinterpret(T, ::Array{NTuple{K,T}})`. For the former, LLVM elides the `divrem` (it figures out that `sidx` is always zero and optimizes accordingly), but for the latter it cannot, and it seems that failure to eliminate the `divrem` kills vectorization. Conceptually, what you'd really like LLVM to do is a `K`-fold unrolling of the loop, but it doesn't seem to discover that it should do that.

This is a fairly scary PR that aims to fix that by eliminating the need for the `divrem`. The idea is to create a new `Integer` subtype that stores an `Int` as separate `div` and `rem` pieces. For it to work with vectorization, the "inner" size (the denominator in the `divrem`) must be known to the type-system, so this is now a parametrized subtype of Integer which I'm calling `SDivRemInt{K}`. (The `S` is for "static," presuming that someday someone might want a dynamic version that encodes `K` as a field rather than a type parameter.) When looping, it uses a `CartesianIndex{2}`-like iteration to increment the `SDivRemInt`. To make this work smoothly, you need an AbstractUnitRange that supports this type of integer (including storing the `K` as a type parameter), and then you need to generalize `CartesianIndices` to work with such objects. Altogether this is a fair amount of infrastructure just to change the inner iteration pattern, but I'm not sure I see an alternative that is clean and generic. Note that in the current state of the PR this is not yet "wired in" to `ReinterpretArray`, but I thought it might be important to put out the fundamental infrastructure first to see if this design makes sense or whether there are modifications that might increase applicability to other circumstances.

I'm aware of a couple of test failures, but none of them look as scary as the simple fact of changing the definition of the `CartesianIndices` type, which has the chance to be fairly breaking. Consequently, I wanted to put this out there for comment before going any further with this. Would love feedback from @mbauman and/or @chriselrod.

