### PR TITLE
Simplify getfield and isdefined tfuncs by treating `DataType` as immutable

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -689,7 +689,7 @@ _broadcast_getindex_eltype(A) = eltype(A)  # Tuple, Array, etc.
 eltypes(::Tuple{}) = Tuple{}
 eltypes(t::Tuple{Any}) = Tuple{_broadcast_getindex_eltype(t[1])}
 eltypes(t::Tuple{Any,Any}) = Tuple{_broadcast_getindex_eltype(t[1]), _broadcast_getindex_eltype(t[2])}
-eltypes(t::Tuple) = Tuple{_broadcast_getindex_eltype(t[1]), eltypes(tail(t)).types...}
+eltypes(t::Tuple) = Tuple{_broadcast_getindex_eltype(t[1]), eltypes(tail(t)).parameters...}
 
 # Inferred eltype of result of broadcast(f, args...)
 combine_eltypes(f, args::Tuple) = Base._return_type(f, eltypes(args))

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2777,3 +2777,7 @@ end
 # getfield on DataType should const propagate
 f37293() = Number.abstract ? true : "no"
 @test @inferred f37293()
+# ... except for the types field
+g37293(::Type{T}) where T = isdefined(T, :types)
+struct T37293; x::Val{g37293(T37293)}; end # call g37293 on incomplete type with not-yet-set types
+@test g37293(T37293) == isdefined(T37293, :types)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2773,3 +2773,7 @@ for badf in [getfield_const_typename_bad1, getfield_const_typename_bad2]
     @test code[end] === Core.ReturnNode()
     @test_throws TypeError badf()
 end
+
+# getfield on DataType should const propagate
+f37293() = Number.abstract ? true : "no"
+@test @inferred f37293()

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -259,7 +259,7 @@ end
 function foo_apply_apply_type_svec()
     A = (Tuple, Float32)
     B = Tuple{Float32, Float32}
-    Core.apply_type(A..., B.types...)
+    Core.apply_type(A..., B.parameters...)
 end
 let ci = code_typed(foo_apply_apply_type_svec, Tuple{})[1].first
     @test length(ci.code) == 1 && ci.code[1] == ReturnNode(NTuple{3, Float32})


### PR DESCRIPTION
And a little cleanup: Neither `UnionAll` nor `SimpleVector` should need special-casing. The former is immutable and gets handled as well as any other immutable, the latter has no fields.

Technically, `DataType` can be mutated, but actually doing that is looking for more trouble than just wrong constant propagation, and we've been doing this for some fields of it anyway. But maybe we can throw in the `setfield` builtin when trying to modify a `DataType`? Or is it even possible to declare `DataType` immutable?