### PR TITLE
Allow packages to force depwarns

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -76,12 +76,12 @@ macro deprecate(old, new, ex=true)
     end
 end
 
-function depwarn(msg, funcsym)
+function depwarn(msg, funcsym; force::Bool=false)
     opts = JLOptions()
     if opts.depwarn == 2
         throw(ErrorException(msg))
     end
-    deplevel = opts.depwarn == 1 ? CoreLogging.Warn : CoreLogging.BelowMinLevel
+    deplevel = force || opts.depwarn == 1 ? CoreLogging.Warn : CoreLogging.BelowMinLevel
     @logmsg(
         deplevel,
         msg,


### PR DESCRIPTION
Fixes #37164 in a gentler way than proposed in the OP, by allowing packages to call `depwarn(args...; force=true)`. No macro equivalent is provided in this PR.
