### PR TITLE
define keys on RegexMatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@ Standard library changes
 * `escape_string` can now receive a collection of characters in the keyword
   `keep` that are to be kept as they are. ([#38597]).
 * `getindex` can now be used on `NamedTuple`s with multiple values ([#38878])
+* `keys(::RegexMatch)` is now defined to return the capture's keys, by name if named, or by index if not ([#37299]).
 
 #### Package Manager
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -149,16 +149,21 @@ struct RegexMatch <: AbstractMatch
     regex::Regex
 end
 
+function keys(m::RegexMatch)
+    idx_to_capture_name = PCRE.capture_names(m.regex.regex)
+    return map(eachindex(m.captures)) do i
+        # If the capture group is named, return it's name, else return it's index
+        get(idx_to_capture_name, i, i)
+    end
+end
+
 function show(io::IO, m::RegexMatch)
     print(io, "RegexMatch(")
     show(io, m.match)
-    idx_to_capture_name = PCRE.capture_names(m.regex.regex)
-    if !isempty(m.captures)
+    capture_keys = keys(m)
+    if !isempty(capture_keys)
         print(io, ", ")
-        for i = 1:length(m.captures)
-            # If the capture group is named, show the name.
-            # Otherwise show its index.
-            capture_name = get(idx_to_capture_name, i, i)
+        for (i, capture_name) in enumerate(capture_keys)
             print(io, capture_name, "=")
             show(io, m.captures[i])
             if i < length(m.captures)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -98,6 +98,7 @@
         @test !haskey(m, "foo")
         @test (m[:a], m[2], m["b"]) == ("x", "y", "z")
         @test sprint(show, m) == "RegexMatch(\"xyz\", a=\"x\", 2=\"y\", b=\"z\")"
+        @test keys(m) == ["a", 2, "b"]
     end
 
     # Backcapture reference in substitution string


### PR DESCRIPTION
This came up in discussion in  https://github.com/JuliaLang/julia/pull/34355
Seperating it out from that PR because it is a far less clear question/answer.

In general if we define `getindex` we should define `keys`.

Some things in this PR you might take issue with:

<s>
### 1. It returns a tuple.
`keys`  only promises that it will return a iterator. `keys` on a `NamedTuple` returns a `Tuple`, `keys` on a `Vector` returns a `OneTo`.
A `Tuple` just seems like the simplest thing to do this will normally be small so i didn't think some kind of `KeySet` would be appropriate
also the keys *are* infact ordered, just like the are for a `NamedTuple`.
</s>

### 2. It returns a mix of named and number keys.
We can't return all named since they might not all be named.
We could return all numbered, I would be down with that.
Very easy PR. `keys(m::RegexMatch = keys(m.captures)`.

It seems like this is what we want since this is what `show` currently displays.
