### PR TITLE
make haskey with Integers work with RegexMatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,7 @@ Standard library changes
 * `intersect` on `CartesianIndices` now returns `CartesianIndices` instead of `Vector{<:CartesianIndex}` ([#36643]).
 * `push!(c::Channel, v)` now returns channel `c`. Previously, it returned the pushed value `v` ([#34202]).
 * `RegexMatch` objects can now be probed for whether a named capture group exists within it through `haskey()` ([#36717]).
+* For consistency `RegexMatch` objects can also probed by `haskey` with an integer index for if a capture group exists within it ([#37300]).
 * A new standard library `TOML` has been added for parsing and printing [TOML files](https://toml.io) ([#37034]).
 
 #### LinearAlgebra

--- a/NEWS.md
+++ b/NEWS.md
@@ -83,7 +83,7 @@ Standard library changes
 * `intersect` on `CartesianIndices` now returns `CartesianIndices` instead of `Vector{<:CartesianIndex}` ([#36643]).
 * `push!(c::Channel, v)` now returns channel `c`. Previously, it returned the pushed value `v` ([#34202]).
 * `RegexMatch` objects can now be probed for whether a named capture group exists within it through `haskey()` ([#36717]).
-* For consistency `RegexMatch` objects can also probed by `haskey` with an integer index for if a capture group exists within it ([#37300]).
+* For consistency `haskey(r::RegexMatch, i::Integer) has also been added and returns if the capture group for `i` exists ([#37300]).
 * A new standard library `TOML` has been added for parsing and printing [TOML files](https://toml.io) ([#37034]).
 
 #### LinearAlgebra

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -167,6 +167,8 @@ function getindex(m::RegexMatch, name::Symbol)
     m[idx]
 end
 getindex(m::RegexMatch, name::AbstractString) = m[Symbol(name)]
+
+haskey(m::RegexMatch, idx::Integer) = idx in eachindex(m.captures)
 function haskey(m::RegexMatch, name::Symbol)
     idx = PCRE.substring_number_from_name(m.regex.regex, name)
     return idx > 0

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -64,6 +64,16 @@
     @test count(r"\w*", "foo bar") == 4
     @test count(r"\b", "foo bar") == 4
 
+    # Unnamed subpatterns
+    let m = match(r"(.)(.)(.)", "xyz")
+        @test haskey(m, 1)
+        @test haskey(m, 2)
+        @test haskey(m, 3)
+        @test !haskey(m, 44)
+        @test (m[1], m[2], m[3]) == ("x", "y", "z")
+        @test sprint(show, m) == "RegexMatch(\"xyz\", 1=\"x\", 2=\"y\", 3=\"z\")"
+    end
+
     # Named subpatterns
     let m = match(r"(?<a>.)(.)(?<b>.)", "xyz")
         @test haskey(m, :a)


### PR DESCRIPTION
This is a follow up to https://github.com/JuliaLang/julia/pull/36717
Since we define `getindex`, and `haskey(::RegexMatch, ::Symbol)` we should keep going down the road towards being like a `NamedTuple` and also make `haskey(::RegexMatch, ::Integer)` work. 

See also my other PRs in this set to make it more NamedTupley #34355  and #37299 