### PR TITLE
Optimize codegen of access functions for SimpleVector

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -590,19 +590,11 @@ function getindex(v::SimpleVector, i::Int)
     @boundscheck if !(1 <= i <= length(v))
         throw(BoundsError(v,i))
     end
-    t = @_gc_preserve_begin v
-    x = unsafe_load(convert(Ptr{Ptr{Cvoid}},pointer_from_objref(v)) + i*sizeof(Ptr))
-    x == C_NULL && throw(UndefRefError())
-    o = unsafe_pointer_to_objref(x)
-    @_gc_preserve_end t
-    return o
+    return ccall(:jl_svec_ref, Any, (Any, Int), v, i - 1)
 end
 
 function length(v::SimpleVector)
-    t = @_gc_preserve_begin v
-    l = unsafe_load(convert(Ptr{Int},pointer_from_objref(v)))
-    @_gc_preserve_end t
-    return l
+    return ccall(:jl_svec_len, Int, (Any,), v)
 end
 firstindex(v::SimpleVector) = 1
 lastindex(v::SimpleVector) = length(v)
@@ -655,10 +647,7 @@ function isassigned end
 
 function isassigned(v::SimpleVector, i::Int)
     @boundscheck 1 <= i <= length(v) || return false
-    t = @_gc_preserve_begin v
-    x = unsafe_load(convert(Ptr{Ptr{Cvoid}},pointer_from_objref(v)) + i*sizeof(Ptr))
-    @_gc_preserve_end t
-    return x != C_NULL
+    return ccall(:jl_svec_isassigned, Bool, (Any, Int), v, i - 1)
 end
 
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1187,6 +1187,14 @@ struct typemap_intersection_env {
 };
 int jl_typemap_intersection_visitor(jl_typemap_t *a, int offs, struct typemap_intersection_env *closure);
 
+// -- simplevector.c -- //
+
+// For codegen only.
+JL_DLLEXPORT size_t (jl_svec_len)(jl_svec_t *t) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int8_t jl_svec_isassigned(jl_svec_t *t JL_PROPAGATES_ROOT, ssize_t i) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_svec_ref(jl_svec_t *t JL_PROPAGATES_ROOT, ssize_t i);
+
+
 unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *field_type);
 
 void register_eh_frames(uint8_t *Addr, size_t Size);

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -89,3 +89,21 @@ JL_DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x)
         jl_svecset(v, i, x);
     return v;
 }
+
+JL_DLLEXPORT size_t (jl_svec_len)(jl_svec_t *t) JL_NOTSAFEPOINT
+{
+    return jl_svec_len(t);
+}
+
+JL_DLLEXPORT int8_t jl_svec_isassigned(jl_svec_t *t JL_PROPAGATES_ROOT, ssize_t i) JL_NOTSAFEPOINT
+{
+    return jl_svecref(t, (size_t)i) != NULL;
+}
+
+JL_DLLEXPORT jl_value_t *jl_svec_ref(jl_svec_t *t JL_PROPAGATES_ROOT, ssize_t i)
+{
+    jl_value_t *v = jl_svecref(t, (size_t)i);
+    if (__unlikely(v == NULL))
+        jl_throw(jl_undefref_exception);
+    return v;
+}


### PR DESCRIPTION
Better alias info and GC root tracking.

This is the reason I made the observation in https://github.com/JuliaLang/julia/pull/37230#issuecomment-683287984