### PR TITLE
inference: attach "Const.actual" flag to call instead of result type

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -404,8 +404,7 @@ eval(Core, :(CodeInstance(mi::MethodInstance, @nospecialize(rettype), @nospecial
                           min_world::UInt, max_world::UInt) =
                 ccall(:jl_new_codeinst, Ref{CodeInstance}, (Any, Any, Any, Any, Int32, UInt, UInt),
                     mi, rettype, inferred_const, inferred, const_flags, min_world, max_world)))
-eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, :Const, :v, false))))
-eval(Core, :(Const(@nospecialize(v), actual::Bool) = $(Expr(:new, :Const, :v, :actual))))
+eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))))
 eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))))
 eval(Core, :(MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) =
     $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))))

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1142,10 +1142,11 @@ function assemble_inline_todo!(ir::IRCode, sv::OptimizationState)
         (sig, invoke_data) = r
 
         # Check whether this call was @pure and evaluates to a constant
-        if isa(sig.f, widenconst(sig.ft)) &&
-                isa(calltype, Const) && calltype.actual && is_inlineable_constant(calltype.val)
-            ir.stmts[idx][:inst] = quoted(calltype.val)
-            continue
+        if calltype isa Const && info isa MethodResultPure
+            if is_inlineable_constant(calltype.val)
+                ir.stmts[idx][:inst] = quoted(calltype.val)
+                continue
+            end
         end
 
         # Ok, now figure out what method to call

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -11,6 +11,16 @@ struct MethodMatchInfo
 end
 
 """
+    struct MethodResultPure
+
+This singleton represents a method result constant was proven to be
+effect-free, including being no-throw (typically because the value was computed
+by calling an `@pure` function).
+"""
+struct MethodResultPure end
+
+
+"""
     struct UnionSplitInfo
 
 If inference decides to partition the method search space by splitting unions,

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -10,9 +10,6 @@
 # # The type of a value might be constant
 # struct Const
 #     val
-#     actual::Bool  # if true, we obtained `val` by actually calling a @pure function
-#     Const(@nospecialize(v)) = new(v, false)
-#     Const(@nospecialize(v), a::Bool) = new(v, a)
 # end
 #
 # struct PartialStruct

--- a/doc/src/devdocs/ssair.md
+++ b/doc/src/devdocs/ssair.md
@@ -143,7 +143,7 @@ The corresponding IR (with irrelevant types stripped) is:
 └──       $(Expr(:unreachable))::Union{}
 4 ┄ %13 = φᶜ (%3, %6, %9)::Bool
 │   %14 = φᶜ (%4, %7, %10)::Core.Compiler.MaybeUndef(Int64)
-│   %15 = φᶜ (%5)::Core.Const(1, false)
+│   %15 = φᶜ (%5)::Core.Const(1)
 └──       $(Expr(:leave, 1))
 5 ─       $(Expr(:pop_exception, :(%2)))::Any
 │         $(Expr(:throw_undef_if_not, :y, :(%13)))::Any

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1436,7 +1436,7 @@ julia> function f(x)
 
 julia> @code_warntype f(3.2)
 Variables
-  #self#::Core.Const(f, false)
+  #self#::Core.Const(f)
   x::Float64
   y::UNION{FLOAT64, INT64}
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2381,8 +2381,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_code_instance_type->types, 1, jl_code_instance_type);
 
     jl_const_type = jl_new_datatype(jl_symbol("Const"), core, jl_any_type, jl_emptysvec,
-                                       jl_perm_symsvec(2, "val", "actual"),
-                                       jl_svec2(jl_any_type, jl_bool_type), 0, 0, 2);
+                                       jl_perm_symsvec(1, "val"),
+                                       jl_svec1(jl_any_type), 0, 0, 1);
 
     jl_partial_struct_type = jl_new_datatype(jl_symbol("PartialStruct"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(2, "typ", "fields"),

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1321,7 +1321,7 @@ Int64
 
 julia> @code_warntype f(2)
 Variables
-  #self#::Core.Const(f, false)
+  #self#::Core.Const(f)
   a::Int64
 
 Body::UNION{FLOAT64, INT64}

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1408,7 +1408,7 @@ using Core.Compiler: PartialStruct, nfields_tfunc, sizeof_tfunc, sizeof_nothrow
 @test sizeof_nothrow(String)
 @test !sizeof_nothrow(Type{String})
 @test sizeof_tfunc(Type{Union{Int64, Int32}}) == Const(Core.sizeof(Union{Int64, Int32}))
-let PT = PartialStruct(Tuple{Int64,UInt64}, Any[Const(10, false), UInt64])
+let PT = PartialStruct(Tuple{Int64,UInt64}, Any[Const(10), UInt64])
     @test sizeof_tfunc(PT) === Const(16)
     @test nfields_tfunc(PT) === Const(2)
     @test sizeof_nothrow(PT)


### PR DESCRIPTION
Been wanting to fix this for a long time, but finally it has become convenient.

"Const.actual" was not a property of the type-lattice but of the call, so it was a bit odd to track in this type (since it should not propagate). Instead, we can attach this to the stmt_info field now, where inlining will find it when needed.

(Possibly somewhat related to https://github.com/JuliaLang/julia/pull/33753 also.)