### PR TITLE
Markdown: Allow tabs instead of spaces in footnote and admonition (#37335)

### DIFF
--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -140,7 +140,7 @@ function footnote(stream::IO, block::MD)
             buffer = IOBuffer()
             write(buffer, readline(stream, keep=true))
             while !eof(stream)
-                if startswith(stream, "    ")
+                if startswith(stream, "    ") || startswith(stream, "\t")
                     write(buffer, readline(stream, keep=true))
                 elseif blankline(stream)
                     write(buffer, '\n')
@@ -224,10 +224,10 @@ function admonition(stream::IO, block::MD)
                     return false
                 end
             end
-        # Consume the following indented (4 spaces) block.
+        # Consume the following indented (4 spaces or tab) block.
         buffer = IOBuffer()
         while !eof(stream)
-            if startswith(stream, "    ")
+            if startswith(stream, "    ") || startswith(stream, "\t")
                 write(buffer, readline(stream, keep=true))
             elseif blankline(stream)
                 write(buffer, '\n')

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -85,6 +85,8 @@ let text =
 
         And *another* paragraph.
 
+    \tAnd a third paragraph indented with a *tab*.
+
     This isn't part of the footnote.
     """,
     md = Markdown.parse(text)
@@ -97,7 +99,7 @@ let text =
     @test md.content[2].id == "1"
     @test md.content[3].id == "note"
 
-    @test length(md.content[3].text) == 4
+    @test length(md.content[3].text) == 5
 
     let expected =
             """
@@ -115,6 +117,8 @@ let text =
                 ```
 
                 And *another* paragraph.
+
+                And a third paragraph indented with a *tab*.
 
 
             This isn't part of the footnote.
@@ -137,6 +141,8 @@ let text =
                    some.code
 
                And *another* paragraph.
+
+               And a third paragraph indented with a *tab*.
 
 
             This isn't part of the footnote.
@@ -671,6 +677,8 @@ let t_1 =
         !!! note
             foo bar baz
 
+        \tsecond tab-indented paragraph
+
         !!! warning "custom title"
             - foo
             - bar
@@ -714,6 +722,7 @@ let t_1 =
     @test m_2.content[1].category == "note"
     @test m_2.content[1].title == "Note"
     @test isa(m_2.content[1].content[1], Markdown.Paragraph)
+    @test isa(m_2.content[1].content[2], Markdown.Paragraph)
 
     @test isa(m_2.content[2], Markdown.Admonition)
     @test m_2.content[2].category == "warning"
@@ -810,6 +819,8 @@ let t_1 =
             !!! note
                 foo bar baz
 
+                second tab-indented paragraph
+
 
             !!! warning "custom title"
                   * foo
@@ -838,6 +849,8 @@ let t_1 =
             """
             .. note::
                foo bar baz
+
+               second tab-indented paragraph
 
 
             .. warning:: custom title


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/37335