### PR TITLE
Remove claim of AbstractString support in 1 arg findfirst and findlast

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1776,7 +1776,7 @@ function findfirst(A)
 end
 
 # Needed for bootstrap, and allows defining only an optimized findnext method
-findfirst(A::Union{AbstractArray, AbstractString}) = findnext(A, first(keys(A)))
+findfirst(A::AbstractArray) = findnext(A, first(keys(A)))
 
 """
     findnext(predicate::Function, A, i)
@@ -1964,7 +1964,7 @@ function findlast(A)
 end
 
 # Needed for bootstrap, and allows defining only an optimized findprev method
-findlast(A::Union{AbstractArray, AbstractString}) = findprev(A, last(keys(A)))
+findlast(A::AbstractArray) = findprev(A, last(keys(A)))
 
 """
     findprev(predicate::Function, A, i)


### PR DESCRIPTION
I think this is just a copy-paste error.
It doesn't work.

```julia
julia> findfirst("abc")
ERROR: TypeError: non-boolean (Char) used in boolean context
Stacktrace:
 [1] findnext(::String, ::Int64) at ./array.jl:1728
 [2] findfirst(::String) at ./array.jl:1779
 [3] top-level scope at REPL[85]:1
 [4] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1088

julia> findlast("abc")
ERROR: TypeError: non-boolean (Char) used in boolean context
Stacktrace:
 [1] findprev(::String, ::Int64) at ./array.jl:1915
 [2] findlast(::String) at ./array.jl:1967
 [3] top-level scope at REPL[86]:1
 [4] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1088
```

I think after this change it will still not work, but at least it won't have a specific method showing up for it when you do `methods(findfirst)` / `methods(findlast)`