### PR TITLE
added namedtuple convenience function for constructing NamedTuple

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -394,7 +394,7 @@ keys must be of type `Symbol`.
 # Examples
 ```jldoctest
 julia> namedtuple([:a, :b, :c], [1, 2, 3])
- (a = 1, b = 2, c = 3)
+(a = 1, b = 2, c = 3)
 ```
 """
 namedtuple(K, V) = NamedTuple{Tuple(K)}(V)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -384,3 +384,33 @@ macro NamedTuple(ex)
     types = [esc(e isa Symbol ? :Any : e.args[2]) for e in decls]
     return :(NamedTuple{($(vars...),), Tuple{$(types...)}})
 end
+
+"""
+    namedtuple(K, V)
+
+Creates a `NamedTuple` object out of `K`, an iterator of keys and `V`, an iterator of values.  All
+keys must be of type `Symbol`.
+
+# Examples
+```jldoctest
+julia> namedtuple([:a, :b, :c], [1, 2, 3])
+ (a = 1, b = 2, c = 3)
+```
+"""
+namedtuple(K, V) = NamedTuple{Tuple(K)}(V)
+
+"""
+    namedtuple(d)
+
+Create a `NamedTuple` object from any iterable of `Pair`s `d` (for example, any `AbstractDict`).
+The first value in each pair must be of type `Symbol`.
+"""
+namedtuple(d::AbstractDict) = namedtuple(keys(d), values(d))
+function namedtuple(d)
+    NamedTuple{Tuple(first(p) for p ∈ d)}(last(p) for p ∈ d)
+end
+
+namedtuple(nt::NamedTuple) = nt
+
+
+export namedtuple

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -407,7 +407,8 @@ The first value in each pair must be of type `Symbol`.
 """
 namedtuple(d::AbstractDict) = namedtuple(keys(d), values(d))
 function namedtuple(d)
-    NamedTuple{Tuple(first(p) for p ∈ d)}(last(p) for p ∈ d)
+    t = Tuple(d)
+    NamedTuple{map(first, t)}(map(last, t))
 end
 
 namedtuple(nt::NamedTuple) = nt

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -304,3 +304,10 @@ let x = 1, y = 2
     @test Meta.lower(Main, Meta.parse("(; a.y, y)")) == Expr(:error, "field name \"y\" repeated in named tuple")
     @test (; a.y, x) === (y=2, x=1)
 end
+
+@testset "namedtuple" begin
+    @test namedtuple([:a, :b, :c], [1, 2, 3]) == (a=1, b=2, c=3)
+    @test namedtuple((:kirk, :spock, :bones), (im, ℯ, π)) == (kirk=im, spock=ℯ, bones=π)
+    @test namedtuple(Dict(:a=>1, :b=>2, :c=>3)) == (a=1, b=2, c=3)
+    @test namedtuple([:kirk=>im, :spock=>ℯ, :bones=>π]) == (kirk=im, spock=ℯ, bones=π)
+end


### PR DESCRIPTION
I find constructing named tuples to be somewhat confusing, and when I mentioned this on slack today I got 6 check mark emojis in what felt like 5 minutes, so I'm apparently not the only one.

This pull adds the `namedtuple` constructor function, in analogy to `tuple`, which adds some convenient constructors.  An argument in favor of adding these is that, even though the method bodies here are quite short, I often have a hard time remembering what is the "right way" to construct these, and I suspect I'm not alone.

From some quick benchmarking, it looks to me like `NamedTuple` is normally *much* faster than splatting, so having this constructor function might have people reaching for splatting less often, which seems to be a good thing.  It also seems more intuitive in a lot of cases, again, I find myself very often fumbling with things like `(;zip(K, V)...)` not necessarily immediately thinking that's a way to do it, since it's not really a common Julia pattern for anything else. 