### PR TITLE
Include all exported functions in Test.jl documentation

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -243,6 +243,7 @@ Core.Module
 Core.Function
 Base.hasmethod
 Core.applicable
+Base.isambiguous
 Core.invoke
 Base.@invoke
 Base.invokelatest

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -102,6 +102,7 @@ or could not be evaluated due to an error, the test set will then throw a `TestS
 
 ```@docs
 Test.@testset
+Test.TestSetException
 ```
 
 We can put our tests for the `foo(x)` function in a test set:
@@ -293,6 +294,18 @@ And using that testset looks like:
         @test true
     end
 end
+```
+
+## Test utilities
+
+```@docs
+Test.GenericArray
+Test.GenericDict
+Test.GenericOrder
+Test.GenericSet
+Test.GenericString
+Test.detect_ambiguities
+Test.detect_unbound_args
 ```
 
 ```@meta


### PR DESCRIPTION
While writing #37360, I noticed that not all exported names are included in Test documentation.  This patch fixes it.

Exported names

```julia
julia> join(stdout, sort!(string.(names(Test))), "\n")
@inferred
@test
@test_broken
@test_deprecated
@test_logs
@test_nowarn
@test_skip
@test_throws
@test_warn
@testset
GenericArray
GenericDict
GenericOrder
GenericSet
GenericString
Test
TestSetException
detect_ambiguities
detect_unbound_args
```

With this PR:

```console
$ cd stdlib/Test/docs/src

$ grep '^Test\.' index.md | sed 's/^Test\.//g' | LANG=C sort
@inferred
@test
@test_broken
@test_deprecated
@test_logs
@test_nowarn
@test_skip
@test_throws
@test_warn
@testset
GenericArray
GenericDict
GenericOrder
GenericSet
GenericString
TestSetException
detect_ambiguities
detect_unbound_args
finish
get_testset
get_testset_depth
record
```

The first list (except `Test`) is a subset of the second list.
