### PR TITLE
Remove a comment in Test.jl

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -18,7 +18,6 @@ export @test, @test_throws, @test_broken, @test_skip,
     @test_logs, @test_deprecated
 
 export @testset
-# Legacy approximate testing functions, yet to be included
 export @inferred
 export detect_ambiguities, detect_unbound_args
 export GenericString, GenericSet, GenericDict, GenericArray, GenericOrder


### PR DESCRIPTION
This comment ("Legacy approximate testing functions, yet to be included") seems to refer to `@test_approx_eq, @test_approx_eq_eps` existed when it was written:

https://github.com/JuliaLang/julia/commit/dc4f1798fe2fa7429e2551caba529cf0b022150d#diff-bef5fc2625b92f0ae308eb13927125abR23-R24

However, these macros do not exist anymore and it's confusing to keep this line.
