### PR TITLE
some faster `Tuple` and `merge(::NamedTuple, ::Zip)` methods

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -251,6 +251,8 @@ merge(a::NamedTuple{()}, b::NamedTuple)     = b
 
 merge(a::NamedTuple, b::Iterators.Pairs{<:Any,<:Any,<:Any,<:NamedTuple}) = merge(a, b.data)
 
+merge(a::NamedTuple, b::Iterators.Zip{<:Tuple{Any,Any}}) = merge(a, NamedTuple{Tuple(b.is[1])}(b.is[2]))
+
 merge(a::NamedTuple, b::NamedTuple, cs::NamedTuple...) = merge(merge(a, b), cs...)
 
 merge(a::NamedTuple) = a

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -296,6 +296,11 @@ _totuple(::Type{Tuple{Vararg{E}}}, itr, s...) where {E} = (collect(E, Iterators.
 
 _totuple(::Type{Tuple}, itr, s...) = (collect(Iterators.rest(itr,s...))...,)
 
+# for types that `apply` knows about, just splatting is faster than collecting first
+_totuple(::Type{Tuple}, itr::Array) = (itr...,)
+_totuple(::Type{Tuple}, itr::SimpleVector) = (itr...,)
+_totuple(::Type{Tuple}, itr::NamedTuple) = (itr...,)
+
 end
 
 ## filter ##


### PR DESCRIPTION
Before:
```
julia> names = [:a,:b,:c,:d,:e,:f,:g,:h,:i]
julia> spl(n) = (n...,)
julia> tup(n) = Tuple(n)
julia> @btime spl(names)
  205.563 ns (1 allocation: 80 bytes)

julia> @btime tup(names)
  250.763 ns (2 allocations: 240 bytes)

julia> values = [1:9;]
julia> nt(k, v) = (; zip(k,v)...)
julia> @btime nt(names, values)
  1.798 μs (16 allocations: 1.44 KiB)
```
after:
```
julia> @btime tup(names)
  214.543 ns (1 allocation: 80 bytes)

julia> @btime nt(names, values)
  1.362 μs (6 allocations: 400 bytes)
```