### PR TITLE
inference: fix precision regression

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -286,6 +286,8 @@ end
 # but without losing too much precision in common cases
 # and also trying to be mostly associative and commutative
 function tmerge(@nospecialize(typea), @nospecialize(typeb))
+    typea === Union{} && return typeb
+    typeb === Union{} && return typea
     suba = typea ⊑ typeb
     suba && issimpleenoughtype(typeb) && return typeb
     subb = typeb ⊑ typea

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -99,6 +99,14 @@ tmerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
 @test Core.Compiler.tmerge(Union{Nothing, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
 @test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Vector{Bool})) == Vector
+@test Core.Compiler.tmerge(Base.BitIntegerType, Union{}) === Base.BitIntegerType
+@test Core.Compiler.tmerge(Union{}, Base.BitIntegerType) === Base.BitIntegerType
+
+struct SomethingBits
+    x::Base.BitIntegerType
+end
+@test Base.return_types(getproperty, (SomethingBits, Symbol)) == Any[Base.BitIntegerType]
+
 
 # issue 9770
 @noinline x9770() = false


### PR DESCRIPTION
While in 1d08d70fb07cfcfc9e89ae1a2521411b1e1724e5 we wanted to avoid combining two types, we did not intend to prevent a type from being just a pass-through value.