### PR TITLE
Add xrefs between upper, lower, and titlecase

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -284,7 +284,7 @@ Tests whether a character is a lowercase letter.
 A character is classified as lowercase if it belongs to Unicode category Ll,
 Letter: Lowercase.
 
-See also: [`isuppercase`](@ref), [`iscased`](@ref).
+See also: [`isuppercase`](@ref).
 
 # Examples
 ```jldoctest
@@ -309,7 +309,7 @@ Tests whether a character is an uppercase letter.
 A character is classified as uppercase if it belongs to Unicode category Lu,
 Letter: Uppercase, or Lt, Letter: Titlecase.
 
-See also: [`islowercase`](@ref), [`iscased`](@ref).
+See also: [`islowercase`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -284,6 +284,8 @@ Tests whether a character is a lowercase letter.
 A character is classified as lowercase if it belongs to Unicode category Ll,
 Letter: Lowercase.
 
+See also: [`isuppercase`](@ref), [`iscased`](@ref).
+
 # Examples
 ```jldoctest
 julia> islowercase('α')
@@ -307,6 +309,8 @@ Tests whether a character is an uppercase letter.
 A character is classified as uppercase if it belongs to Unicode category Lu,
 Letter: Uppercase, or Lt, Letter: Titlecase.
 
+See also: [`islowercase`](@ref), [`iscased`](@ref).
+
 # Examples
 ```jldoctest
 julia> isuppercase('γ')
@@ -328,6 +332,8 @@ end
     iscased(c::AbstractChar) -> Bool
 
 Tests whether a character is cased, i.e. is lower-, upper- or title-cased.
+
+See also: [`islowercase`](@ref), [`isuppercase`](@ref).
 """
 function iscased(c::AbstractChar)
     cat = category_code(c)
@@ -513,6 +519,8 @@ isxdigit(c::AbstractChar) = '0'<=c<='9' || 'a'<=c<='f' || 'A'<=c<='F'
 
 Return `s` with all characters converted to uppercase.
 
+See also: [`lowercase`](@ref), [`titlecase`](@ref), [`uppercasefirst`](@ref).
+
 # Examples
 ```jldoctest
 julia> uppercase("Julia")
@@ -525,6 +533,8 @@ uppercase(s::AbstractString) = map(uppercase, s)
     lowercase(s::AbstractString)
 
 Return `s` with all characters converted to lowercase.
+
+See also: [`uppercase`](@ref), [`titlecase`](@ref), [`lowercasefirst`](@ref).
 
 # Examples
 ```jldoctest
@@ -545,6 +555,8 @@ a predicate can be passed as the `wordsep` keyword to determine
 which characters should be considered as word separators.
 See also [`uppercasefirst`](@ref) to capitalize only the first
 character in `s`.
+
+See also: [`uppercase`](@ref), [`lowercase`](@ref), [`uppercasefirst`](@ref).
 
 # Examples
 ```jldoctest

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -69,7 +69,6 @@ Base.nextind
 Base.prevind
 Base.textwidth
 Base.isascii
-Base.iscased
 Base.iscntrl
 Base.isdigit
 Base.isletter

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -69,6 +69,7 @@ Base.nextind
 Base.prevind
 Base.textwidth
 Base.isascii
+Base.iscased
 Base.iscntrl
 Base.isdigit
 Base.isletter


### PR DESCRIPTION
- Add xrefs between `isuppercase`, `islowercase`, `iscased` and between `uppercase`, `lowercase`, `titlecase` `uppercasefirst`, `lowercasefirst`.
  - many other functions in this file alrady have lots of helpful xrefs :)
- Prompted by not knowing the name for `titlecase` or `uppercasefirst` (i was trying `capitalise`), and not being able to find it in the repl/help via knowing the names for `uppercase` and `lowercase`. 