### PR TITLE
Show recursive dep precomp info during precomp

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1146,10 +1146,10 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
                        --eval 'eval(Meta.parse(read(stdin,String)))'`, stderr=stderr),
               "w", stdout)
     # write data over stdin to avoid the (unlikely) case of exceeding max command line size
-    # pass isprecompilinginteractively state recursively
+    # pass precompiling_interactively state recursively
     write(io.in, """
         begin
-            Base.isprecompilinginteractively!($(isprecompilinginteractively()))
+            Base.precompiling_interactively!($(is_precompiling_interactively()))
             Base.include_package_for_output($(repr(abspath(input))), $(repr(depot_path)), $(repr(dl_load_path)),
             $(repr(load_path)), $deps, $(repr(uuid_tuple)), $(repr(source_path(nothing))))
         end
@@ -1214,10 +1214,10 @@ function compilecache(pkg::PkgId, path::String)
     end
     # run the expression and cache the result
     verbosity = isinteractive() ? CoreLogging.Info : CoreLogging.Debug
-    isinteractive() && isprecompilinginteractively!(true)
+    isinteractive() && precompiling_interactively!(true)
     @logmsg verbosity "Precompiling $pkg"
     precomp_msg = " ► $(pkg.name)"
-    should_log_deps = isprecompilinginteractively() && !isinteractive() && (CoreLogging.current_logstate().min_enabled_level > CoreLogging.Debug) #don't print for main package or when in debug
+    should_log_deps = is_precompiling_interactively() && !isinteractive() && (CoreLogging.current_logstate().min_enabled_level > CoreLogging.Debug) #don't print for main package or when in debug
     should_log_deps && print(precomp_msg)
 
     # create a temporary file in `cachepath` directory, write the cache in it,
@@ -1250,9 +1250,9 @@ function compilecache(pkg::PkgId, path::String)
     end
 end
 
-const IS_PRECOMPILING_INTERACTIVELY = Ref{Bool}(false)
-isprecompilinginteractively!(b::Bool) = IS_PRECOMPILING_INTERACTIVELY[] = b
-isprecompilinginteractively()::Bool = IS_PRECOMPILING_INTERACTIVELY[]::Bool
+const PRECOMPILING_INTERACTIVELY = Ref{Bool}(false)
+precompiling_interactively!(b::Bool) = PRECOMPILING_INTERACTIVELY[] = b
+is_precompiling_interactively()::Bool = PRECOMPILING_INTERACTIVELY[]::Bool
 
 module_build_id(m::Module) = ccall(:jl_module_build_id, UInt64, (Any,), m)
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1241,7 +1241,7 @@ function compilecache(pkg::PkgId, path::String)
         end
     finally
         rm(tmppath, force=true)
-        should_log_deps && print("\e[$(length(precomp_msg))D\e[0K") #clear last dep print
+        should_log_deps && print("\e[$(length(precomp_msg))D\e[0J") #clear last dep print
     end
     if p.exitcode == 125
         return PrecompilableError()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1211,6 +1211,9 @@ function compilecache(pkg::PkgId, path::String)
     # run the expression and cache the result
     verbosity = isinteractive() ? CoreLogging.Info : CoreLogging.Debug
     @logmsg verbosity "Precompiling $pkg"
+    precomp_msg = " > $(pkg.name)"
+    should_log_deps = (Base.CoreLogging.current_logstate().min_enabled_level >= verbosity) && !isinteractive()
+    should_log_deps && print(precomp_msg)
 
     # create a temporary file in `cachepath` directory, write the cache in it,
     # write the checksum, _and then_ atomically move the file to `cachefile`.
@@ -1233,6 +1236,11 @@ function compilecache(pkg::PkgId, path::String)
         end
     finally
         rm(tmppath, force=true)
+        if should_log_deps
+            print("\e[$(length(precomp_msg))D") 
+            print(repeat(" ", length(precomp_msg))) #overwrite dep print
+            print("\e[$(length(precomp_msg))D") 
+        end
     end
     if p.exitcode == 125
         return PrecompilableError()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1216,8 +1216,8 @@ function compilecache(pkg::PkgId, path::String)
     verbosity = isinteractive() ? CoreLogging.Info : CoreLogging.Debug
     isinteractive() && precompiling_interactively!(true)
     @logmsg verbosity "Precompiling $pkg"
-    precomp_msg = " ► $(pkg.name)"
     should_log_deps = is_precompiling_interactively() && !isinteractive() && (CoreLogging.current_logstate().min_enabled_level > CoreLogging.Debug) #don't print for main package or when in debug
+    precomp_msg = " > $(pkg.name)"
     should_log_deps && print(precomp_msg)
 
     # create a temporary file in `cachepath` directory, write the cache in it,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1236,11 +1236,7 @@ function compilecache(pkg::PkgId, path::String)
         end
     finally
         rm(tmppath, force=true)
-        if should_log_deps
-            print("\e[$(length(precomp_msg))D") 
-            print(repeat(" ", length(precomp_msg))) #overwrite dep print
-            print("\e[$(length(precomp_msg))D") 
-        end
+        should_log_deps && print("\e[$(length(precomp_msg))D\e[0K") #clear last dep print
     end
     if p.exitcode == 125
         return PrecompilableError()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1216,7 +1216,7 @@ function compilecache(pkg::PkgId, path::String)
     @logmsg verbosity "Precompiling $pkg"
     precomp_msg = " > $(pkg.name)"
     should_log_deps = PRECOMPILING_INTERACTIVELY[] && !isinteractive() && (CoreLogging.current_logstate().min_enabled_level > CoreLogging.Debug) #don't print for main package or when in debug
-    should_log_deps && print(precomp_msg)
+    should_log_deps && print("\n",precomp_msg,"\e[$(length(precomp_msg))D")
 
     # create a temporary file in `cachepath` directory, write the cache in it,
     # write the checksum, _and then_ atomically move the file to `cachefile`.
@@ -1239,7 +1239,7 @@ function compilecache(pkg::PkgId, path::String)
         end
     finally
         rm(tmppath, force=true)
-        should_log_deps && print("\e[$(length(precomp_msg))D\e[0J") #clear last dep print
+        should_log_deps && print("\e[0J\e[A") #clear last dep print
     end
     if p.exitcode == 125
         return PrecompilableError()

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1216,6 +1216,7 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
         if have_color
             print(repl.stream,repl.prompt_color)
         end
+        Base.isprecompilinginteractively!(false) #state reset
         print(repl.stream, "julia> ")
         if have_color
             print(repl.stream, input_color(repl))

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1216,7 +1216,7 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
         if have_color
             print(repl.stream,repl.prompt_color)
         end
-        Base.precompiling_interactively!(false) #state reset
+        Base.PRECOMPILING_INTERACTIVELY[] = false #state reset
         print(repl.stream, "julia> ")
         if have_color
             print(repl.stream, input_color(repl))

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1216,7 +1216,7 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
         if have_color
             print(repl.stream,repl.prompt_color)
         end
-        Base.isprecompilinginteractively!(false) #state reset
+        Base.precompiling_interactively!(false) #state reset
         print(repl.stream, "julia> ")
         if have_color
             print(repl.stream, input_color(repl))


### PR DESCRIPTION
An idea for making the precompillation process a bit less opaque

Demo with loading Plots
https://www.dropbox.com/s/z9n5bwle6wd125o/Julia%20dep%20precomp%20printing.mov?dl=0



Todo: 
- [x] Figure out how disable printing when the parent precompillation wasn't started in interactive mode
- [x] Maybe there's a better glyph than `>` to use