### PR TITLE
isless for CompoundPeriod and Period combinations

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -473,9 +473,9 @@ Base.hash(x::Month, h::UInt) = hash(value(x), h + otherperiod_seed)
 Base.isless(x::FixedPeriod, y::OtherPeriod) = throw(MethodError(isless, (x, y)))
 Base.isless(x::OtherPeriod, y::FixedPeriod) = throw(MethodError(isless, (x, y)))
 
-Base.isless(x::Period, y::CompoundPeriod) = tons(x) < sum(Dates.tons,y.periods)
-Base.isless(x::CompoundPeriod, y::Period) = sum(Dates.tons,x.periods) < tons(y)
-Base.isless(x::CompoundPeriod, y::CompoundPeriod) = sum(Dates.tons,x.periods) < sum(Dates.tons,y.periods) 
+Base.isless(x::Period, y::CompoundPeriod) = tons(x) < sum(tons,y.periods)
+Base.isless(x::CompoundPeriod, y::Period) = sum(tons,x.periods) < tons(y)
+Base.isless(x::CompoundPeriod, y::CompoundPeriod) = sum(tons,x.periods) < sum(tons,y.periods) 
 # truncating conversions to milliseconds, nanoseconds and days:
 # overflow can happen for periods longer than ~300,000 years
 toms(c::Nanosecond)  = div(value(c), 1000000)

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -483,12 +483,12 @@ function Base.isless(x::CompoundPeriod, y::CompoundPeriod)
     # if any overlap of OtherPeriod or FixedPeriod occurs an error is thrown so it can be treated as 
     # x and y val only being either Nanosecond or Month
     for p in x.periods
-        if(istype(p) <: FixedPeriod)
+        if(typeof(p) <: FixedPeriod)
             has_fixed = true
-            x_val += convert(Nanosecond,p)
+            x_val += tons(p)
         else
             has_other = true
-            x_val += convert(Month,p)
+            x_val += value(convert(Month,p))
         end
         if(has_fixed && has_other)
             throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
@@ -496,18 +496,17 @@ function Base.isless(x::CompoundPeriod, y::CompoundPeriod)
     end
 
     for p in y.periods
-        if(istype(p) <: FixedPeriod)
+        if(typeof(p) <: FixedPeriod)
             has_fixed = true
-            y_val += convert(Nanosecond,p)
+            y_val += tons(p)
         else
             has_other = true
-            y_val += convert(Month,p)
+            y_val += value(convert(Month,p))
         end
         if(has_fixed && has_other)
             throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
         end
     end
-
     return x_val < y_val
 end
 # truncating conversions to milliseconds, nanoseconds and days:

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -478,43 +478,35 @@ Base.isless(x::CompoundPeriod, y::Period) = x < CompoundPeriod(y)
 function Base.isless(x::CompoundPeriod, y::CompoundPeriod)
     has_other = false
     has_fixed = false
+    x_val::Int64 = 0
+    y_val::Int64 = 0
+    #if any overlap of OtherPeriod or FixedPeriod occurs an error is thrown so it can be treated as x and y val either being in Nanosecond or Month
     for p in x.periods
         if(istype(p) <: FixedPeriod)
             has_fixed = true
+            x_val += convert(Nanosecond,p)
         else
             has_other = true
+            x_val += convert(Month,p)
+        end
+        if(has_fixed && has_other)
+            throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
         end
     end
-    if(has_fixed && has_other)
-        throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
-    end
+
     for p in y.periods
         if(istype(p) <: FixedPeriod)
             has_fixed = true
+            y_val += convert(Nanosecond,p)
         else
             has_other = true
-        end
-    end
-    if(has_fixed && has_other)
-        throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
-    end
-    x_val::Int64 = 0
-    y_val::Int64 = 0
-    if(has_other)
-        for p in x.periods
-            x_val += convert(Month,p)
-        end
-        for p in y.periods
             y_val += convert(Month,p)
         end
-    else
-        for p in x.periods
-            x_val += convert(Nanosecond,p)
-        end
-        for p in y.periods
-            y_val += convert(Nanosecond,p)
+        if(has_fixed && has_other)
+            throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
         end
     end
+
     return x_val < y_val
 end
 # truncating conversions to milliseconds, nanoseconds and days:

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -473,6 +473,9 @@ Base.hash(x::Month, h::UInt) = hash(value(x), h + otherperiod_seed)
 Base.isless(x::FixedPeriod, y::OtherPeriod) = throw(MethodError(isless, (x, y)))
 Base.isless(x::OtherPeriod, y::FixedPeriod) = throw(MethodError(isless, (x, y)))
 
+Base.isless(x::Period, y::CompoundPeriod) = tons(x) < sum(Dates.tons,y.periods)
+Base.isless(x::CompoundPeriod, y::Period) = sum(Dates.tons,x.periods) < tons(y)
+Base.isless(x::CompoundPeriod, y::CompoundPeriod) = sum(Dates.tons,x.periods) < sum(Dates.tons,y.periods) 
 # truncating conversions to milliseconds, nanoseconds and days:
 # overflow can happen for periods longer than ~300,000 years
 toms(c::Nanosecond)  = div(value(c), 1000000)

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -475,40 +475,7 @@ Base.isless(x::OtherPeriod, y::FixedPeriod) = throw(MethodError(isless, (x, y)))
 
 Base.isless(x::Period, y::CompoundPeriod) = CompoundPeriod(x) < y
 Base.isless(x::CompoundPeriod, y::Period) = x < CompoundPeriod(y)
-function Base.isless(x::CompoundPeriod, y::CompoundPeriod)
-    has_other = false
-    has_fixed = false
-    x_val::Int64 = 0
-    y_val::Int64 = 0
-    # if any overlap of OtherPeriod or FixedPeriod occurs an error is thrown so it can be treated as 
-    # x and y val only being either Nanosecond or Month
-    for p in x.periods
-        if(typeof(p) <: FixedPeriod)
-            has_fixed = true
-            x_val += tons(p)
-        else
-            has_other = true
-            x_val += value(convert(Month,p))
-        end
-        if(has_fixed && has_other)
-            throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
-        end
-    end
-
-    for p in y.periods
-        if(typeof(p) <: FixedPeriod)
-            has_fixed = true
-            y_val += tons(p)
-        else
-            has_other = true
-            y_val += value(convert(Month,p))
-        end
-        if(has_fixed && has_other)
-            throw(ErrorException("Can not compare OtherPeriods and FixedPeriods in a CompoundPeriod."))
-        end
-    end
-    return x_val < y_val
-end
+Base.isless(x::CompoundPeriod, y::CompoundPeriod) = tons(x) < tons(y)
 # truncating conversions to milliseconds, nanoseconds and days:
 # overflow can happen for periods longer than ~300,000 years
 toms(c::Nanosecond)  = div(value(c), 1000000)

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -480,7 +480,8 @@ function Base.isless(x::CompoundPeriod, y::CompoundPeriod)
     has_fixed = false
     x_val::Int64 = 0
     y_val::Int64 = 0
-    #if any overlap of OtherPeriod or FixedPeriod occurs an error is thrown so it can be treated as x and y val either being in Nanosecond or Month
+    # if any overlap of OtherPeriod or FixedPeriod occurs an error is thrown so it can be treated as 
+    # x and y val only being either Nanosecond or Month
     for p in x.periods
         if(istype(p) <: FixedPeriod)
             has_fixed = true

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -467,4 +467,8 @@ end
     @test Dates.toms(Dates.Second(1) + Dates.Microsecond(1)) == 1e3
 end
 
+@testset "CompoundPeriod and Period isless()" begin
+    @test h < h + ns
+    @test h - ns < h
+end
 end

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -478,10 +478,7 @@ end
     @test (2y-m < 25m+1y) == true
     @test (2y < 25m+1y) == true
     @test (25m+1y < 2y) == false
-    #tests for error throwing for not allowed comparisons (FixedPeriod and OtherPeriod combinations)
-    @test_throws ErrorException y + h < h + m
-    @test_throws ErrorException y + h < m
-    @test_throws ErrorException y < m+h
-
+    #Test combined Fixed and Other Periods
+    @test (1m + 1d < 1m + 1s) = false
 end
 end

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -479,6 +479,6 @@ end
     @test (2y < 25m+1y) == true
     @test (25m+1y < 2y) == false
     #Test combined Fixed and Other Periods
-    @test (1m + 1d < 1m + 1s) = false
+    @test (1m + 1d < 1m + 1s) == false
 end
 end

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -468,7 +468,20 @@ end
 end
 
 @testset "CompoundPeriod and Period isless()" begin
-    @test h < h + ns
-    @test h - ns < h
+    #tests for allowed comparisons
+    #FixedPeriod
+    @test (h - ms < h + ns) == true
+    @test (h + ns < h -ms) == false
+    @test (h  < h -ms) == false
+    @test (h-ms  < h) == true
+    #OtherPeriod
+    @test (2y-m < 25m+1y) == true
+    @test (2y < 25m+1y) == true
+    @test (25m+1y < 2y) == false
+    #tests for error throwing for not allowed comparisons (FixedPeriod and OtherPeriod combinations)
+    @test_throws ErrorException y + h < h + m
+    @test_throws ErrorException y + h < m
+    @test_throws ErrorException y < m+h
+
 end
 end


### PR DESCRIPTION
Adds the isless() operator for CompoundPeriods aswell as the combinations of CompoundPeriod and Period. CompoundPeriods that contain both FixedPeriods and OtherPeriods instead throw an error as they are not directly comparable, this should follow the same idea as it appears the rest of the periods file is using.
Tests were also created for the changes
Feature was asked for in #32389 