### PR TITLE
Build `julia_version.h` before running `clangsa`

### DIFF
--- a/test/clangsa/Makefile
+++ b/test/clangsa/Makefile
@@ -8,6 +8,7 @@ check: $(SRCDIR)
 TESTS = $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.c) $(wildcard $(SRCDIR)/*.cpp))
 
 $(SRCDIR) $(TESTS):
+	@$(MAKE) -C $(BUILDDIR)/../../src $(build_includedir)/julia/julia_version.h
 	@$(MAKE) -C $(BUILDDIR)/../../src clangsa
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
 	LD_LIBRARY_PATH="${build_libdir}:$$LD_LIBRARY_PATH" \


### PR DESCRIPTION
This hopefully will fix the `clangsa` pass on CI.