### PR TITLE
Precompile `watch_file` and a few other functions used by Revise

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -15,12 +15,14 @@ UP_ARROW = "\e[A"
 DOWN_ARROW = "\e[B"
 
 hardcoded_precompile_statements = """
-precompile(Tuple{typeof(Base.stale_cachefile), String, String})
-precompile(Tuple{typeof(push!), Set{Module}, Module})
-precompile(Tuple{typeof(push!), Set{Method}, Method})
-precompile(Tuple{typeof(push!), Set{Base.PkgId}, Base.PkgId})
-precompile(Tuple{typeof(setindex!), Dict{String,Base.PkgId}, Base.PkgId, String})
-precompile(Tuple{typeof(get!), Type{Vector{Function}}, Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
+@assert precompile(Tuple{typeof(Base.stale_cachefile), String, String})
+@assert precompile(Tuple{typeof(push!), Set{Module}, Module})
+@assert precompile(Tuple{typeof(push!), Set{Method}, Method})
+@assert precompile(Tuple{typeof(push!), Set{Base.PkgId}, Base.PkgId})
+@assert precompile(Tuple{typeof(setindex!), Dict{String,Base.PkgId}, Base.PkgId, String})
+@assert precompile(Tuple{typeof(get!), Type{Vector{Function}}, Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
+@assert precompile(Tuple{typeof(isassigned), Core.SimpleVector, Int})
+@assert precompile(Tuple{typeof(pushfirst!), Vector{Any}, Function})
 """
 
 precompile_script = """
@@ -45,6 +47,11 @@ julia_exepath() = joinpath(Sys.BINDIR, Base.julia_exename())
 
 have_repl =  haskey(Base.loaded_modules,
                     Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL"))
+if have_repl
+    hardcoded_precompile_statements *= """
+    @assert precompile(Tuple{typeof(getproperty), REPL.REPLBackend, Symbol})
+    """
+end
 
 Distributed = get(Base.loaded_modules,
           Base.PkgId(Base.UUID("8ba89e20-285c-5b6f-9357-94700520ee1b"), "Distributed"),
@@ -64,6 +71,16 @@ Pkg = get(Base.loaded_modules,
 
 if Pkg !== nothing
     precompile_script *= Pkg.precompile_script
+end
+
+FileWatching = get(Base.loaded_modules,
+          Base.PkgId(Base.UUID("7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"), "FileWatching"),
+          nothing)
+if FileWatching !== nothing
+    hardcoded_precompile_statements *= """
+    @assert precompile(Tuple{typeof(FileWatching.watch_file), String, Float64})
+    @assert precompile(Tuple{typeof(FileWatching.watch_file), String, Int})
+    """
 end
 
 function generate_precompile_statements()

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -688,7 +688,7 @@ giving the result of watching the file.
 This behavior of this function varies slightly across platforms. See
 <https://nodejs.org/api/fs.html#fs_caveats> for more detailed information.
 """
-function watch_file(s::AbstractString, timeout_s::Real=-1)
+function watch_file(s::String, timeout_s::Float64=-1.0)
     fm = FileMonitor(s)
     local timer
     try
@@ -703,6 +703,7 @@ function watch_file(s::AbstractString, timeout_s::Real=-1)
         @isdefined(timer) && close(timer)
     end
 end
+watch_file(s::AbstractString, timeout_s::Real=-1) = watch_file(String(s), Float64(timeout_s))
 
 """
     watch_folder(path::AbstractString, timeout_s::Real=-1)


### PR DESCRIPTION
Together with some internal changes coming in Revise v3.0, on my machine this drops the overhead of using Revise from 3.5s to 0.5s. The change in this PR only contributes about 0.1s of that improvement, but compared to a final baseline of 0.5s it's a noticeable enhancement. The only one of these that makes a sizable impact is `watch_file`, but this does ensure that Revise doesn't trigger any additional "generic" compilation.

Because `precompile` fails silently, there's a risk that useless precompile statements bitrot, so I threw in a bunch of `@assert`s to make sure these don't go stale. I'm happy to remove them if folks don't like that. With the `@assert`s, what it means is that if someone makes changes so that these signatures aren't resolved anymore, they'll get an error during the precompile phase of building Julia. They can then either remove or modify the offending statement(s), preferably "modify" if there is a new version that is relevant.