### PR TITLE
Fix unnecessary use of closure boxing in type inference

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1175,10 +1175,10 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             at = abstract_eval_value(interp, e.args[2], vtypes, sv)
             n = fieldcount(t)
             if isa(at, Const) && isa(at.val, Tuple) && n == length(at.val) &&
-                    _all(i->at.val[i] isa fieldtype(t, i), 1:n)
+                let t = t, at = at; _all(i->at.val[i] isa fieldtype(t, i), 1:n); end
                 t = Const(ccall(:jl_new_structt, Any, (Any, Any), t, at.val))
             elseif isa(at, PartialStruct) && at ⊑ Tuple && n == length(at.fields) &&
-                    _all(i->at.fields[i] ⊑ fieldtype(t, i), 1:n)
+                let t = t, at = at; _all(i->at.fields[i] ⊑ fieldtype(t, i), 1:n); end
                 t = PartialStruct(t, at.fields)
             end
         end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -561,7 +561,7 @@ mutable struct IncrementalCompact
                     succs[j] = bb_rename[succs[j]]
                 end
             end
-            let blocks = blocks
+            let blocks = blocks, bb_rename = bb_rename
                 result_bbs = BasicBlock[blocks[i] for i = 1:length(blocks) if bb_rename[i] != -1]
             end
         else

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -84,7 +84,9 @@ function compute_value_for_use(ir::IRCode, domtree::DomTree, allblocks::Vector{I
     # Find the first dominating def
     curblock = stmtblock = block_for_inst(ir.cfg, use_idx)
     curblock = find_curblock(domtree, allblocks, curblock)
-    defblockdefs = Int[stmt for stmt in du.defs if block_for_inst(ir.cfg, stmt) == curblock]
+    defblockdefs = let curblock = curblock
+        Int[stmt for stmt in du.defs if block_for_inst(ir.cfg, stmt) == curblock]
+    end
     def = 0
     if !isempty(defblockdefs)
         if curblock != stmtblock
@@ -832,7 +834,9 @@ function getfield_elim_pass!(ir::IRCode)
         for (use, new_preserves) in preserve_uses
             useexpr = ir[SSAValue(use)]
             nccallargs = length(useexpr.args[3]::SimpleVector)
-            old_preserves = filter(ssa->!isa(ssa, SSAValue) || !(ssa.id in intermediaries), useexpr.args[(6+nccallargs):end])
+            old_preserves = let intermediaries = intermediaries
+                filter(ssa->!isa(ssa, SSAValue) || !(ssa.id in intermediaries), useexpr.args[(6+nccallargs):end])
+            end
             new_expr = Expr(:foreigncall, useexpr.args[1:(6+nccallargs-1)]...,
                 old_preserves..., new_preserves...)
             ir[SSAValue(use)] = new_expr

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -513,40 +513,40 @@ function typeof_tfunc(@nospecialize(t))
 end
 add_tfunc(typeof, 1, 1, typeof_tfunc, 0)
 
+function typeassert_type_instance(@nospecialize(v), @nospecialize(t))
+    if isa(v, Const)
+        if !has_free_typevars(t) && !isa(v.val, t)
+            return Bottom
+        end
+        return v
+    elseif isa(v, PartialStruct)
+        has_free_typevars(t) && return v
+        widev = widenconst(v)
+        if widev <: t
+            return v
+        elseif typeintersect(widev, t) === Bottom
+            return Bottom
+        end
+        @assert widev <: Tuple
+        new_fields = Vector{Any}(undef, length(v.fields))
+        for i = 1:length(new_fields)
+            new_fields[i] = typeassert_type_instance(v.fields[i], getfield_tfunc(t, Const(i)))
+            if new_fields[i] === Bottom
+                return Bottom
+            end
+        end
+        return tuple_tfunc(new_fields)
+    elseif isa(v, Conditional)
+        if !(Bool <: t)
+            return Bottom
+        end
+        return v
+    end
+    return typeintersect(widenconst(v), t)
+end
 function typeassert_tfunc(@nospecialize(v), @nospecialize(t))
     t = instanceof_tfunc(t)[1]
     t === Any && return v
-    function typeassert_type_instance(@nospecialize(v), @nospecialize(t))
-        if isa(v, Const)
-            if !has_free_typevars(t) && !isa(v.val, t)
-                return Bottom
-            end
-            return v
-        elseif isa(v, PartialStruct)
-            has_free_typevars(t) && return v
-            widev = widenconst(v)
-            if widev <: t
-                return v
-            elseif typeintersect(widev, t) === Bottom
-                return Bottom
-            end
-            @assert widev <: Tuple
-            new_fields = Vector{Any}(undef, length(v.fields))
-            for i = 1:length(new_fields)
-                new_fields[i] = typeassert_type_instance(v.fields[i], getfield_tfunc(t, Const(i)))
-                if new_fields[i] === Bottom
-                    return Bottom
-                end
-            end
-            return tuple_tfunc(new_fields)
-        elseif isa(v, Conditional)
-            if !(Bool <: t)
-                return Bottom
-            end
-            return v
-        end
-        return typeintersect(widenconst(v), t)
-    end
     return typeassert_type_instance(v, t)
 end
 add_tfunc(typeassert, 2, 2, typeassert_tfunc, 4)

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -71,36 +71,42 @@ function validate_code_in_debug_mode(linfo::MethodInstance, src::CodeInfo, kind:
     end
 end
 
+function _validate_val!(@nospecialize(x), errors, ssavals::BitSet)
+    if isa(x, Expr)
+        if x.head === :call || x.head === :invoke
+            f = x.args[1]
+            if f isa GlobalRef && (f.name === :cglobal) && x.head === :call
+                # TODO: these are not yet linearized
+            else
+                for arg in x.args
+                    if !is_valid_argument(arg)
+                        push!(errors, InvalidCodeError(INVALID_CALL_ARG, arg))
+                    else
+                        _validate_val!(arg, errors, ssavals)
+                    end
+                end
+            end
+        end
+    elseif isa(x, SSAValue)
+        id = x.id
+        !in(id, ssavals) && push!(ssavals, id)
+    end
+    return
+end
+
 """
     validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo)
 
 Validate `c`, logging any violation by pushing an `InvalidCodeError` into `errors`.
 """
 function validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo, is_top_level::Bool = false)
-    function validate_val!(@nospecialize(x))
-        if isa(x, Expr)
-            if x.head === :call || x.head === :invoke
-                f = x.args[1]
-                if f isa GlobalRef && (f.name === :cglobal) && x.head === :call
-                    # TODO: these are not yet linearized
-                else
-                    for arg in x.args
-                        if !is_valid_argument(arg)
-                            push!(errors, InvalidCodeError(INVALID_CALL_ARG, arg))
-                        else
-                            validate_val!(arg)
-                        end
-                    end
-                end
-            end
-        elseif isa(x, SSAValue)
-            id = x.id
-            !in(id, ssavals) && push!(ssavals, id)
-        end
-    end
-
     ssavals = BitSet()
     lhs_slotnums = BitSet()
+
+    # Do not define recursive function as closure to work around
+    # boxing of the function itself as `Core.Box`.
+    validate_val!(@nospecialize(x)) = _validate_val!(x, errors, ssavals)
+
     for x in c.code
         if isa(x, Expr)
             head = x.head


### PR DESCRIPTION
This should fix all appearance of `Core.Box` in the `Core` module with the exception of
`simple_walk_constraint` where it is actually necessary.

Most of the cases are the normal readonly closures fixed by adding a `let` around it
or moving assignments.
There are also two cases of recursive closures fixed by moving the recursion
out of the closure.