### PR TITLE
Enable stride/strides to work on a ReinterpretArray with complex Strided parents.

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -48,9 +48,10 @@ end
 reinterpret(::Type{T}, a::ReinterpretArray) where {T} = reinterpret(T, a.parent)
 
 # Definition of StridedArray
+ContiguousSubArray{T,N,P,I<:Union{Tuple{Union{Slice, AbstractUnitRange}, Vararg{Any}},Tuple{Vararg{ScalarIndex}}},L} = SubArray{T,N,P,I,L}
 StridedFastContiguousSubArray{T,N,A<:DenseArray} = FastContiguousSubArray{T,N,A}
-StridedReinterpretArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray}} = ReinterpretArray{T,N,S,A} where S
-StridedReshapedArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray,StridedReinterpretArray}} = ReshapedArray{T,N,A}
+StridedReinterpretArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray,ContiguousSubArray}} = ReinterpretArray{T,N,S,A} where S
+StridedReshapedArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray,StridedReinterpretArray,ContiguousSubArray}} = ReshapedArray{T,N,A}}
 StridedSubArray{T,N,A<:Union{DenseArray,StridedReshapedArray,StridedReinterpretArray},
     I<:Tuple{Vararg{Union{RangeIndex, ReshapedUnitRange, AbstractCartesianIndex}}}} = SubArray{T,N,A,I}
 StridedArray{T,N} = Union{DenseArray{T,N}, StridedSubArray{T,N}, StridedReshapedArray{T,N}, StridedReinterpretArray{T,N}}

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -53,7 +53,7 @@ let A = collect(reshape(1:20, 5, 4))
 end
 
 # and ensure a reinterpret array containing a strided array can have strides computed
-let A = view(reinterpret(Int16, collect(reshape(1:20, 5, 4))), :, 1:2)
+let A = view(reinterpret(Int16, collect(reshape(UnitRange{Int64}(1, 20), 5, 4))), :, 1:2)
     R = reinterpret(Int32, A)
     @test strides(R) == (1, 10)
     @test stride(R, 1) == 1

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -52,6 +52,14 @@ let A = collect(reshape(1:20, 5, 4))
     @test reshape(R, :) isa StridedArray
 end
 
+# and ensure a reinterpret array containing a strided array can have strides computed
+let A = view(reinterpret(Int16, collect(reshape(1:20, 5, 4))), :, 1:2)
+    R = reinterpret(Int32, A)
+    @test strides(R) == (1, 10)
+    @test stride(R, 1) == 1
+    @test stride(R, 2) == 10
+end
+
 @testset "strides" begin
     a = rand(10)
     b = view(a,2:2:10)


### PR DESCRIPTION
As described in issue #37405, a complex nested array type like reinterpret(view(reinterpret(view(A)) is not defined as a `StridedArray`. I tried implementing a type-based solution but it caused things to break and made the type signatures very long.

So instead I just implemented `stride`/`strides` methods that check if the parent is a `StridedArray`, erroring otherwise.