### PR TITLE
Fix Dict key check in type inference

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -515,8 +515,7 @@ function perform_lifting!(compact::IncrementalCompact,
 
     if stmt_val in keys(lifted_leaves)
         stmt_val = lifted_leaves[stmt_val]
-    else
-        isa(stmt_val, Union{SSAValue, OldSSAValue}) && stmt_val in keys(reverse_mapping)
+    elseif isa(stmt_val, Union{NewSSAValue, SSAValue, OldSSAValue}) && stmt_val in keys(reverse_mapping)
         stmt_val = RefValue{Any}(lifted_phis[reverse_mapping[stmt_val]].ssa)
     end
 


### PR DESCRIPTION
This has been there since #27126 (9100329d189b3d2ac6d1e03bfc7431cbe8d18c00)

Judging by the use of `reverse_mapping[stmt_val]` below
this should either be a branch condition or an assert.