### PR TITLE
fix an instance of getting mapany from Base

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1173,7 +1173,7 @@ function undot(x::Expr)
     if x.head === :.=
         Expr(:(=), x.args...)
     elseif x.head === :block # occurs in for x=..., y=...
-        Expr(:block, mapany(undot, x.args)...)
+        Expr(:block, Base.mapany(undot, x.args)...)
     else
         x
     end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -938,3 +938,9 @@ ret =  @macroexpand @.([Int, Number] <: Real)
 
 ret =  @macroexpand @.([Int, Number] >: Real)
 @test ret == :([Int, Number] .>: Real)
+
+# Threw mapany not defined
+p = rand(4,4); r = rand(2,4);
+p0 = copy(p)
+@views @. p[1:2, :] += r
+@test p[1:2, :] ≈ p0[1:2, :] + r


### PR DESCRIPTION
Reported on slack.

On master:

```jl
julia> p = rand(4,4); r = rand(2,4);

julia> @. @views p[1:2, :] += r
2×4 view(::Matrix{Float64}, 1:2, :) with eltype Float64:
 0.770739  1.57416   0.920107  1.6553
 1.29553   0.335126  1.1543    0.566289

julia> @views @. p[1:2, :] += r
ERROR: LoadError: UndefVarError: mapany not defined
Stacktrace:
 [1] undot(x::Expr)
   @ Base.Broadcast ./broadcast.jl:1176
 [2] __dot__(x::Expr)
   @ Base.Broadcast ./broadcast.jl:1192
 [3] @__dot__(__source__::LineNumberNode, __module__::Module, x::Any)
   @ Base.Broadcast ./broadcast.jl:1242
in expression starting at REPL[3]:1
```

Ref https://github.com/JuliaLang/julia/pull/37163.