### PR TITLE
Fix elimination of PiNode for Argument

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -981,6 +981,11 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
                 ssa_rename[idx] = pi_val
                 return result_idx
             end
+        elseif isa(pi_val, Argument)
+            if stmt.typ === compact.ir.argtypes[pi_val.n]
+                ssa_rename[idx] = pi_val
+                return result_idx
+            end
         elseif !isa(pi_val, AnySSAValue) && !isa(pi_val, GlobalRef)
             valtyp = isa(pi_val, QuoteNode) ? typeof(pi_val.value) : typeof(pi_val)
             if valtyp === stmt.typ

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -319,3 +319,26 @@ end
 const _some_coeffs = (1,[2],3,4)
 splat_from_globalref(x) = (x, _some_coeffs...,)
 @test splat_from_globalref(0) == (0, 1, [2], 3, 4)
+
+function pi_on_argument(x)
+    if isa(x, Core.Argument)
+        return x.n
+    end
+    return -2
+end
+let code = code_typed(pi_on_argument, Tuple{Any})[1].first.code,
+    nisa = 0, found_pi = false
+    for stmt in code
+        if Meta.isexpr(stmt, :call)
+            callee = stmt.args[1]
+            if (callee === isa || callee === :isa || (isa(callee, GlobalRef) &&
+                                                      callee.name === :isa))
+                nisa += 1
+            end
+        elseif stmt === Core.PiNode(Core.Argument(2), Core.Argument)
+            found_pi = true
+        end
+    end
+    @test nisa == 1
+    @test found_pi
+end


### PR DESCRIPTION
This causes `PiNode` on `Argument` of type `Argument` to be incorrectly eliminated.
Ironically, this happens for `compact_exprtype` which is exactly where the solution is found.

-----

Another behavior issue found when scanning the Core code for type instability...
