### PR TITLE
Remove extra "```" in docs for `svd!`

### DIFF
--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -88,7 +88,6 @@ default_svd_alg(A) = DivideAndConquer()
 
 `svd!` is the same as [`svd`](@ref), but saves space by
 overwriting the input `A`, instead of creating a copy. See documentation of [`svd`](@ref) for details.
-```
 """
 function svd!(A::StridedMatrix{T}; full::Bool = false, alg::Algorithm = default_svd_alg(A)) where T<:BlasFloat
     m,n = size(A)
@@ -358,7 +357,6 @@ Base.iterate(S::GeneralizedSVD, ::Val{:done}) = nothing
 
 `svd!` is the same as [`svd`](@ref), but modifies the arguments
 `A` and `B` in-place, instead of making copies. See documentation of [`svd`](@ref) for details.
-```
 """
 function svd!(A::StridedMatrix{T}, B::StridedMatrix{T}) where T<:BlasFloat
     # xggsvd3 replaced xggsvd in LAPACK 3.6.0


### PR DESCRIPTION
The current docs are showing extra `\`\`\`` at the end.

![image](https://user-images.githubusercontent.com/25192197/92317791-b231cc00-efd2-11ea-8205-b3d51472824f.png)
