### PR TITLE
recovers generics of `LineEdit.keymap` while keeping specialization

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1607,7 +1607,7 @@ function validate_keymap(keymap)
     end
 end
 
-function keymap(keymaps::Union{Vector{AnyDict},Vector{Dict{Char,Any}}})
+function keymap(@specialize(keymaps::AbstractVector{<:AbstractDict}))
     # keymaps is a vector of prioritized keymaps, with highest priority first
     ret = keymap_unify(map(normalize_keys, reverse(keymaps)))
     validate_keymap(ret)


### PR DESCRIPTION
- `LineEdit.keymap` was annotated with concrete argument types (`Union{Vector{AnyDict}, Vector{Dict{Char,Any}}}`) to fix invalidations in #37163
- but it loses generics of this function, which in turn makes
OhMyREPL.jl errors on its initialization with `NoMethodError` on master
  * especially [this line](https://github.com/KristofferC/OhMyREPL.jl/blob/cc7e467606e1cc13f11f95576d1a12c371cd4214/src/repl.jl#L284) can't be matched to `Union{Vector{AnyDict}, Vector{Dict{Char,Any}}}`
  * no sure why but `LineEdit.keymap(Base.AnyDict[NEW_KEYBINDINGS, main_mode.keymap_dict])` doesn't help the matching; the error seems to say `Base.AnyDict[NEW_KEYBINDINGS, main_mode.keymap_dict]` is somehow
widened to `Vector{Dict}`:

    ```
    MethodError: no method matching keymap(::Vector{Dict})
    Closest candidates are:
      keymap(::Any, ::Union{REPL.LineEdit.HistoryPrompt, REPL.LineEdit.PrefixHistoryPrompt}) at /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:2007
      keymap(::Union{Vector{Dict{Any, Any}}, Vector{Dict{Char, Any}}}) at /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:1610
      keymap(::REPL.LineEdit.PromptState, ::REPL.LineEdit.Prompt) at /Users/aviatesk/julia/julia/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:2505
      ...
     ```

- I think it's better to keep the generics anyway, so this PR widens function while keeping specialization by annotating `at-specialize`

/cc @timholy does this looks right so it won't spoil your work on fixing invalidation ?