### PR TITLE
Fix `Const` check in `tmerge`

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -335,7 +335,7 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
 
        typea_nfields = nfields_tfunc(typea)
        typeb_nfields = nfields_tfunc(typeb)
-       if !isa(typea_nfields, Const) || !isa(typea_nfields, Const) || typea_nfields.val !== typeb_nfields.val
+       if !isa(typea_nfields, Const) || !isa(typeb_nfields, Const) || typea_nfields.val !== typeb_nfields.val
             return widenconst(typea)
        end
 


### PR DESCRIPTION
This should not cause any real error since the condition for this branch
should guarantee that if `nfields_tfunc` returns a `Const` for one,
the other will be `Const` as well.
Still the check is clearly wrong and should be fixed...