### PR TITLE
REPL: also catch ArgumentError in expanduser in tab completion

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -278,10 +278,10 @@ function complete_path(path::AbstractString, pos::Int; use_envpath=false, shell_
                 filesinpath = readdir(pathdir)
             catch e
                 # Bash allows dirs in PATH that can't be read, so we should as well.
-                if isa(e, Base.IOError)
+                if isa(e, Base.IOError) || isa(e, Base.ArgumentError)
                     continue
                 else
-                    # We only handle IOError here
+                    # We only handle IOError and ArgumentError here
                     rethrow()
                 end
             end


### PR DESCRIPTION
Not sure how this happened but it did:

```
julia> @time readlines("~ ┌ Error: Error in the keymap
│   exception =
│    ArgumentError: ~user tilde expansion not yet implemented
│    Stacktrace:
│     [1] expanduser(::String) at ./path.jl:452
│     [2] complete_expanduser at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/REPL/src/REPLCompletions.jl:278 [inlined]
│     [3] completions(::String, ::Int64, ::Module) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/REPL/src/REPLCompletions.jl:597
...
```