### PR TITLE
faster expm1

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -379,23 +379,6 @@ Compute the inverse hyperbolic sine of `x`.
 """
 asinh(x::Number)
 
-"""
-    expm1(x)
-
-Accurately compute ``e^x-1``. It avoids the loss of precision involved in the direct
-evaluation of exp(x)-1 for small values of x.
-# Examples
-```jldoctest
-julia> expm1(1e-16)
-1.0e-16
-
-julia> exp(1e-16) - 1
-0.0
-```
-"""
-expm1(x)
-expm1(x::Float64) = ccall((:expm1,libm), Float64, (Float64,), x)
-expm1(x::Float32) = ccall((:expm1f,libm), Float32, (Float32,), x)
 
 # utility for converting NaN return to DomainError
 # the branch in nan_dom_err prevents its callers from inlining, so be sure to force it

--- a/base/math.jl
+++ b/base/math.jl
@@ -1138,19 +1138,6 @@ julia> 3 * 2 + 1
 """
 muladd(x,y,z) = x*y+z
 
-# Float16 definitions
-
-for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
-             :atanh,:exp,:exp2,:exp10,:log,:log2,:log10,:sqrt,:lgamma,:log1p)
-    @eval begin
-        $func(a::Float16) = Float16($func(Float32(a)))
-        $func(a::ComplexF16) = ComplexF16($func(ComplexF32(a)))
-    end
-end
-
-atan(a::Float16,b::Float16) = Float16(atan(Float32(a),Float32(b)))
-cbrt(a::Float16) = Float16(cbrt(Float32(a)))
-sincos(a::Float16) = Float16.(sincos(Float32(a)))
 
 # helper functions for Libm functionality
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -548,7 +548,6 @@ for f in (:log2, :log10)
     @eval begin
         @inline ($f)(x::Float64) = nan_dom_err(ccall(($(string(f)), libm), Float64, (Float64,), x), x)
         @inline ($f)(x::Float32) = nan_dom_err(ccall(($(string(f, "f")), libm), Float32, (Float32,), x), x)
-        @inline ($f)(x::Real) = ($f)(float(x))
     end
 end
 
@@ -1202,6 +1201,7 @@ for f in (:sin, :cos, :tan, :asin, :atan, :acos,
         x === xf && throw(MethodError($f, (x,)))
         return ($f)(xf)
     end
+    @eval $(f)(::Missing) = missing
 end
 
 exp2(x::AbstractFloat) = 2^x

--- a/base/math.jl
+++ b/base/math.jl
@@ -579,6 +579,7 @@ julia> sqrt(big(complex(-81)))
 0.0 + 9.0im
 ```
 """
+sqrt(x)
 
 """
     hypot(x, y)
@@ -1201,7 +1202,6 @@ for f in (:sin, :cos, :tan, :asin, :atan, :acos,
         x === xf && throw(MethodError($f, (x,)))
         return ($f)(xf)
     end
-    @eval $(f)(::Missing) = missing
 end
 
 exp2(x::AbstractFloat) = 2^x

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -337,11 +337,6 @@ end
     return fma(x, p2[1], x*p2[2])
 end
 
-function expm1(x::Real)
-    xf = float(x)
-    x === xf && throw(MethodError(expm1, (x,)))
-    return expm1(xf)
-end
 @inline function expm1(x::Float64)
     T=Float64
     if -0.2876820724517809 <= x <= 0.22314355131420976

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -337,7 +337,11 @@ end
     return fma(x, p2[1], x*p2[2])
 end
 
-expm1(x::Real) = expm1(float(x))
+function expm1(x::Real)
+    xf = float(x)
+    x === xf && throw(MethodError(expm1, (x,)))
+    return expm1(xf)
+end
 @inline function expm1(x::Float64)
     T=Float64
     if -0.2876820724517809 <= x <= 0.22314355131420976

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -376,5 +376,6 @@ end
     small_part = r*hi
     twopk = reinterpret(Float64, (N+1023) << 52)
     x > MAX_EXP(Float32) && return Inf32
+    N == exponent_max(T) && return small_part * T(2.0) * T(2.0)^(exponent_max(T) - 1)
     return Float32(muladd(twopk, small_part, twopk-1.0))
 end

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -376,7 +376,6 @@ end
     small_part = r*hi
     twopk = reinterpret(Float64, (N+1023) << 52)
     x > MAX_EXP(Float32) && return Inf32
-    N == (exponent_max(Float32)+1) && return small_part * 2f0 * 2f0^exponent_max(Float32)
     return Float32(muladd(twopk, small_part, twopk-1.0))
 end
 

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -376,7 +376,7 @@ end
     small_part = r*hi
     twopk = reinterpret(Float64, (N+1023) << 52)
     x > MAX_EXP(Float32) && return Inf32
-    N == exponent_max(Float32) && return small_part * T(2.0) * T(2.0)^(exponent_max(T) - 1)
+    N == (exponent_max(Float32)+1) && return small_part * 2f0 * 2f0^exponent_max(Float32)
     return Float32(muladd(twopk, small_part, twopk-1.0))
 end
 

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -239,7 +239,7 @@ for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
                     twopk = reinterpret(T, (N+Int32(151)) << Int32(23))
                     return (twopk*small_part)*(2f0^(-24))
                 end
-                N == exponent_max(T) && return small_part * T(2.0) * T(2.0)^(exponent_max(T) - 1)
+                N == (exponent_max(T)+1) && return small_part * T(2.0) * T(2.0)^exponent_max(T)
             end
             twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
             return twopk*small_part
@@ -376,6 +376,22 @@ end
     small_part = r*hi
     twopk = reinterpret(Float64, (N+1023) << 52)
     x > MAX_EXP(Float32) && return Inf32
-    N == exponent_max(T) && return small_part * T(2.0) * T(2.0)^(exponent_max(T) - 1)
+    N == exponent_max(Float32) && return small_part * T(2.0) * T(2.0)^(exponent_max(T) - 1)
     return Float32(muladd(twopk, small_part, twopk-1.0))
 end
+
+"""
+    expm1(x)
+
+Accurately compute ``e^x-1``. It avoids the loss of precision involved in the direct
+evaluation of exp(x)-1 for small values of x.
+# Examples
+```jldoctest
+julia> expm1(1e-16)
+1.0e-16
+
+julia> exp(1e-16) - 1
+0.0
+```
+"""
+expm1(x)

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -239,7 +239,7 @@ for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
                     twopk = reinterpret(T, (N+Int32(151)) << Int32(23))
                     return (twopk*small_part)*(2f0^(-24))
                 end
-                N == (exponent_max(T)+1) && return small_part * T(2.0) * T(2.0)^exponent_max(T)
+                N == exponent_max(T) && return small_part * T(2.0) * T(2.0)^(exponent_max(T) - 1)
             end
             twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
             return twopk*small_part
@@ -364,7 +364,7 @@ expm1(x::Real) = expm1(float(x))
     return twopk*((jU-twopnk) + fma(jU, p, jL))
 end
 
-@inline function expm1(x::T) where T<:Float32
+@inline function expm1(x::Float32)
     if -0.2876821f0 <=x <= 0.22314355f0
         return expm1_small(x)
     end
@@ -373,9 +373,9 @@ end
     N = unsafe_trunc(UInt64, N_float)
     r = muladd(N_float, Ln2(Float64), x)
     hi = evalpoly(r, (1.0, .5, 0.16666667546642386, 0.041666183019487026,
-              0.008332997481506921, 0.0013966479175977883, 0.0002004037059220124))
+                      0.008332997481506921, 0.0013966479175977883, 0.0002004037059220124))
     small_part = r*hi
     twopk = reinterpret(Float64, (N+1023) << 52)
-    x > MAX_EXP(T) && return T(Inf)
+    x > MAX_EXP(Float32) && return Inf32
     return Float32(muladd(twopk, small_part, twopk-1.0))
 end

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -357,7 +357,7 @@ end
     N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(Val(:ℯ), T))
     r = muladd(N_float, LogBo256U(Val(:ℯ), T), x)
     r = muladd(N_float, LogBo256L(Val(:ℯ), T), r)
-    k = N >> 8
+    k = Int64(N >> 8)
     jU, jL = table_unpack(N&255 +1)
     p = expm1b_kernel(Val(:ℯ), r)
     twopk  = reinterpret(Float64, (1023+k) << 52)

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -14,20 +14,6 @@
 # is preserved.
 # ====================================================
 
-@inline function exthorner(x, p::Tuple)
-    # polynomial evaluation using compensated summation.
-    # much more accurate, especially when lo can be combined with other rounding errors
-    hi, lo = p[end], zero(x)
-    for i in length(p)-1:-1:1
-        pi = p[i]
-        prod = hi*x
-        err = fma(hi, x, -prod)
-        hi = pi+prod
-        lo = fma(lo, x, prod - (hi - pi) + err)
-    end
-    return hi, lo
-end
-
 # Hyperbolic functions
 # sinh methods
 H_SMALL_X(::Type{Float64}) = 2.0^-28
@@ -112,7 +98,7 @@ function cosh(x::T) where T<:Union{Float32,Float64}
     #               return cosh(x) = = (exp(x) + exp(-x))/2
     #      e)   H_LARGE_X  <= x
     #               return cosh(x) = exp(x/2)/2 * exp(x/2)
-    #                  Note that this branch automatically deals with Infs and NaNs
+    #      			Note that this branch automatically deals with Infs and NaNs
 
     absx = abs(x)
     if absx <= COSH_SMALL_X(T)

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -98,7 +98,7 @@ function cosh(x::T) where T<:Union{Float32,Float64}
     #               return cosh(x) = = (exp(x) + exp(-x))/2
     #      e)   H_LARGE_X  <= x
     #               return cosh(x) = exp(x/2)/2 * exp(x/2)
-    #      	        Note that this branch automatically deals with Infs and NaNs
+    #               Note that this branch automatically deals with Infs and NaNs
 
     absx = abs(x)
     if absx <= COSH_SMALL_X(T)

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -98,7 +98,7 @@ function cosh(x::T) where T<:Union{Float32,Float64}
     #               return cosh(x) = = (exp(x) + exp(-x))/2
     #      e)   H_LARGE_X  <= x
     #               return cosh(x) = exp(x/2)/2 * exp(x/2)
-    #      			Note that this branch automatically deals with Infs and NaNs
+    #      	        Note that this branch automatically deals with Infs and NaNs
 
     absx = abs(x)
     if absx <= COSH_SMALL_X(T)


### PR DESCRIPTION
4x faster for Float32, 2x faster for Float64. This has the same problem as https://github.com/JuliaLang/julia/pull/37426 in that it needs `exthorner` to achieve necessary precision.