### PR TITLE
Fix `getfield_tfunc` for constant `TypeName`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -745,6 +745,9 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
         end
         if isa(name, Const)
             nv = name.val
+            if !(isa(nv,Symbol) || isa(nv,Int))
+                return Bottom
+            end
             if isa(sv, UnionAll)
                 if nv === :var || nv === 1
                     return Const(sv.var)
@@ -770,9 +773,6 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
             end
             if isa(sv, Module) && isa(nv, Symbol)
                 return abstract_eval_global(sv, nv)
-            end
-            if !(isa(nv,Symbol) || isa(nv,Int))
-                return Bottom
             end
             if (isa(sv, SimpleVector) || !ismutable(sv)) && isdefined(sv, nv)
                 return Const(getfield(sv, nv))


### PR DESCRIPTION
The field should be either `Symbol` or `Int`. Ref #37423

Unlike #37423, in additional to worse type info in inference,
the missing type check here can actually cause type inference error
due to errors in user code.