### PR TITLE
Specialize _memory_offset on number of arguments.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1070,8 +1070,8 @@ function pointer(x::AbstractArray{T}, i::Integer) where T
 end
 
 # The distance from pointer(x) to the element at x[I...] in bytes
-_memory_offset(x::DenseArray, I...) = (_to_linear_index(x, I...) - first(LinearIndices(x)))*elsize(x)
-function _memory_offset(x::AbstractArray, I...)
+_memory_offset(x::DenseArray, I::Vararg{Any,N}) where {N} = (_to_linear_index(x, I...) - first(LinearIndices(x)))*elsize(x)
+function _memory_offset(x::AbstractArray, I::Vararg{Any,N}) where {N}
     J = _to_subscript_indices(x, I...)
     return sum(map((i, s, o)->s*(i-o), J, strides(x), Tuple(first(CartesianIndices(x)))))*elsize(x)
 end


### PR DESCRIPTION
```julia
using BenchmarkTools
N = 5; data4big = randn(N,N,N,N,100); data4view = @view data4big[:,:,:,:,5];
@benchmark pointer($data4view)
```
Before:
```julia
julia> @benchmark pointer($data4view)
BenchmarkTools.Trial:
  memory estimate:  848 bytes
  allocs estimate:  21
  --------------
  minimum time:     1.480 μs (0.00% GC)
  median time:      1.562 μs (0.00% GC)
  mean time:        1.654 μs (1.72% GC)
  maximum time:     288.553 μs (98.46% GC)
  --------------
  samples:          10000
  evals/sample:     10
```
After:
```julia
julia> @benchmark pointer($data4view)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     2.658 ns (0.00% GC)
  median time:      2.672 ns (0.00% GC)
  mean time:        2.686 ns (0.00% GC)
  maximum time:     12.688 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```