### PR TITLE
Lift special-case Ref lowering to AbstractRef type

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -77,6 +77,7 @@
 #mutable struct TypeMapEntry
 #end
 
+#abstract type AbstractRef{T} end
 #abstract type Ref{T} end
 #primitive type Ptr{T} <: Ref{T} {32|64} end
 
@@ -161,7 +162,7 @@ export
     Function, Method,
     Module, Symbol, Task, Array, UndefInitializer, undef, WeakRef, VecElement,
     # numeric types
-    Number, Real, Integer, Bool, Ref, Ptr,
+    Number, Real, Integer, Bool, AbstractRef, Ref, Ptr,
     AbstractFloat, Float16, Float32, Float64,
     Signed, Int, Int8, Int16, Int32, Int64, Int128,
     Unsigned, UInt, UInt8, UInt16, UInt32, UInt64, UInt128,

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1581,6 +1581,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Builtin", (jl_value_t*)jl_builtin_type);
     add_builtin("MethodInstance", (jl_value_t*)jl_method_instance_type);
     add_builtin("CodeInfo", (jl_value_t*)jl_code_info_type);
+    add_builtin("AbstractRef", (jl_value_t*)jl_abstract_ref_type);
     add_builtin("Ref", (jl_value_t*)jl_ref_type);
     add_builtin("Ptr", (jl_value_t*)jl_pointer_type);
     add_builtin("LLVMPtr", (jl_value_t*)jl_llvmpointer_type);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4843,7 +4843,7 @@ static Function* gen_cfun_wrapper(
         assert(sig.fargt_sig.at(i + sig.sret) == val->getType());
         jl_cgval_t &inputarg = inputargs[i + 1];
         jl_value_t *jargty = jl_svecref(sig.at, i);
-        bool aref = jl_is_abstract_ref_type(jargty);
+        bool aref = jl_is_ref_type(jargty);
         if (aref) // a pointer to a value
             jargty = jl_tparam0(jargty);
 
@@ -5216,7 +5216,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
         sparam_vals = ctx.linfo->sparam_vals;
 
     jl_value_t *rt = declrt;
-    if (jl_is_abstract_ref_type(declrt)) {
+    if (jl_is_ref_type(declrt)) {
         declrt = jl_tparam0(declrt);
         if (!verify_ref_type(ctx, declrt, unionall_env, 0, "cfunction")) {
             return jl_cgval_t();
@@ -5271,7 +5271,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
         approx = true;
     for (size_t i = 0; i < nargt; i++) {
         jl_value_t *jargty = jl_svecref(argt, i);
-        if (jl_is_abstract_ref_type(jargty)) {
+        if (jl_is_ref_type(jargty)) {
             jargty = jl_tparam0(jargty);
             if (!verify_ref_type(ctx, jargty, unionall_env, i + 1, "cfunction")) {
                 JL_GC_POP();
@@ -5376,7 +5376,7 @@ void jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t *declr
     assert(ff);
     const char *name = jl_symbol_name(ft->name->mt->name);
     jl_value_t *crt = declrt;
-    if (jl_is_abstract_ref_type(declrt)) {
+    if (jl_is_ref_type(declrt)) {
         declrt = jl_tparam0(declrt);
         crt = (jl_value_t*)jl_any_type;
     }

--- a/src/dump.c
+++ b/src/dump.c
@@ -2557,7 +2557,7 @@ void jl_init_serializer(void)
                      jl_box_int64(21),
 
                      jl_bool_type, jl_linenumbernode_type, jl_pinode_type,
-                     jl_upsilonnode_type, jl_type_type, jl_bottom_type, jl_ref_type,
+                     jl_upsilonnode_type, jl_type_type, jl_bottom_type, jl_abstract_ref_type, jl_ref_type,
                      jl_pointer_type, jl_vararg_type, jl_abstractarray_type, jl_nothing_type,
                      jl_densearray_type, jl_function_type, jl_typename_type,
                      jl_builtin_type, jl_task_type, jl_uniontype_type,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -120,6 +120,7 @@ jl_datatype_t *jl_loaderror_type;
 jl_datatype_t *jl_initerror_type;
 jl_datatype_t *jl_undefvarerror_type;
 jl_datatype_t *jl_lineinfonode_type;
+jl_unionall_t *jl_abstract_ref_type;
 jl_unionall_t *jl_ref_type;
 jl_unionall_t *jl_pointer_type;
 jl_typename_t *jl_pointer_typename;
@@ -2401,8 +2402,12 @@ void jl_init_types(void) JL_GC_DISABLED
                                              jl_builtin_type, jl_emptysvec, 32);
 
     tv = jl_svec1(tvar("T"));
+    jl_abstract_ref_type = (jl_unionall_t*)
+        jl_new_abstracttype((jl_value_t*)jl_symbol("AbstractRef"), core, jl_any_type, tv)->name->wrapper;
+
+    tv = jl_svec1(tvar("T"));
     jl_ref_type = (jl_unionall_t*)
-        jl_new_abstracttype((jl_value_t*)jl_symbol("Ref"), core, jl_any_type, tv)->name->wrapper;
+        jl_new_abstracttype((jl_value_t*)jl_symbol("Ref"), core, (jl_datatype_t*)jl_apply_type((jl_value_t*)jl_abstract_ref_type, jl_svec_data(tv), 1), tv)->name->wrapper;
 
     tv = jl_svec1(tvar("T"));
     jl_pointer_type = (jl_unionall_t*)

--- a/src/julia.h
+++ b/src/julia.h
@@ -678,6 +678,7 @@ extern JL_DLLEXPORT jl_datatype_t *jl_voidpointer_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_uint8pointer_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_pointer_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_llvmpointer_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_unionall_t *jl_abstract_ref_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_ref_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_pointer_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_llvmpointer_typename JL_GLOBALLY_ROOTED;
@@ -1220,7 +1221,7 @@ STATIC_INLINE int jl_is_llvmpointer_type(jl_value_t *t) JL_NOTSAFEPOINT
             ((jl_datatype_t*)(t))->name == jl_llvmpointer_typename);
 }
 
-STATIC_INLINE int jl_is_abstract_ref_type(jl_value_t *t) JL_NOTSAFEPOINT
+STATIC_INLINE int jl_is_ref_type(jl_value_t *t) JL_NOTSAFEPOINT
 {
     return (jl_is_datatype(t) &&
             ((jl_datatype_t*)(t))->name == ((jl_datatype_t*)jl_ref_type->body)->name);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -42,7 +42,7 @@ static void *const _tags[] = {
          &jl_gotonode_type, &jl_quotenode_type, &jl_gotoifnot_type, &jl_argument_type, &jl_returnnode_type,
          &jl_const_type, &jl_partial_struct_type, &jl_method_match_type,
          &jl_pinode_type, &jl_phinode_type, &jl_phicnode_type, &jl_upsilonnode_type,
-         &jl_type_type, &jl_bottom_type, &jl_ref_type, &jl_pointer_type, &jl_llvmpointer_type,
+         &jl_type_type, &jl_bottom_type, &jl_abstract_ref_type, &jl_ref_type, &jl_pointer_type, &jl_llvmpointer_type,
          &jl_vararg_type, &jl_abstractarray_type,
          &jl_densearray_type, &jl_nothing_type, &jl_function_type, &jl_typeofbottom_type,
          &jl_unionall_type, &jl_typename_type, &jl_builtin_type, &jl_code_info_type,


### PR DESCRIPTION
`Ref` is currently special-cased by Julia's compiler to emit as a
pointer when used with `ccall` (notice the `i8*`):

```
julia> f(x) = ccall(:jl_breakpoint, Nothing, (Ref{Int},), x)

julia> @code_llvm debuginfo=:none f(1)

define void @julia_f_900(i64) #0 {
top:
  %1 = alloca i64, align 16
  %2 = bitcast i64* %1 to i8*
  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %2)
  store i64 %0, i64* %1, align 16
  call void inttoptr (i64 139799801759936 to void (i8*)*)(i8* nonnull %2)
  ret void
}
```

With CUDA.jl, I'd like to use a `CuRef` that has similar semantics, but
can't be used interchangeably with regular `Ref` to avoid passing a CPU
pointer to a C function (on the host, e.g., as part of GPU BLAS)
expecting a GPU pointer:

```julia
abstract type GPURef{T} end

struct GPURefValue{T} <: GPURef{T}
    # not important right now
end

Base.convert(::Type{GPURef{T}}, x::T) where {T} = GPURefValue{T}(x)
Base.unsafe_convert(::Type{GPURef{T}}, x::GPURefValue{T}) where {T} =
    reinterpret(Ptr{T}, C_NULL)
```

This currently emits bad code, as the `Ref` is passed as a `jl_value*`
(`GPURef` being abstract):

```
julia> g(x) = ccall(:jl_breakpoint, Nothing, (GPURef{Int},), x)

julia> @code_llvm debuginfo=:none g(1)

define void @julia_g_91(i64) {
top:
  call void inttoptr (i64 139782466969296 to void ({}*)*)({}* inttoptr (i64 139782225370544 to {}*))
  ret void
}
```

In this PR, I propose lifting the special codegen to an `AbstractRef`
type so that we can use it with our custom `Ref`:

```julia
abstract type GPURef{T} <: Base.AbstractRef{T} end
```

```
julia> g(x) = ccall(:jl_breakpoint, Nothing, (GPURef{Int},), x)

julia> @code_llvm debuginfo=:none g(1)

define void @julia_g_867(i64) #0 {
top:
  call void inttoptr (i64 140223028578496 to void (i8*)*)(i8* null)
  ret void
}
```