### PR TITLE
Improve performance of `==(::AbstractString, ::AbstractString)`

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -323,10 +323,10 @@ false
 """
 function ==(a::AbstractString, b::AbstractString)
     a === b && return true
-    lastindex(a) != lastindex(b) && return false
     for (c::AbstractChar, d::AbstractChar) in zip(a, b)
         c != d && return false
     end
+    length(a) != length(b) && return false
     return true
 end
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -321,7 +321,14 @@ julia> "abc" == "αβγ"
 false
 ```
 """
-==(a::AbstractString, b::AbstractString) = cmp(a, b) == 0
+function ==(a::AbstractString, b::AbstractString)
+    a === b && return true
+    ncodeunits(a) != ncodeunits(b) && return false
+    for (c::AbstractChar, d::AbstractChar) in zip(a, b)
+        c != d && return false
+    end
+    return true
+end
 
 """
     isless(a::AbstractString, b::AbstractString) -> Bool

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -323,7 +323,7 @@ false
 """
 function ==(a::AbstractString, b::AbstractString)
     a === b && return true
-    ncodeunits(a) != ncodeunits(b) && return false
+    lastindex(a) != lastindex(b) && return false
     for (c::AbstractChar, d::AbstractChar) in zip(a, b)
         c != d && return false
     end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -680,7 +680,6 @@ end
 Base.iterate(x::CharStr) = iterate(x.chars)
 Base.iterate(x::CharStr, i::Int) = iterate(x.chars, i)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
-Base.ncodeunits(x::CharStr) = sum(ncodeunits, x.chars)
 
 @testset "cmp without UTF-8 indexing" begin
     # Simple case, with just ANSI Latin 1 characters

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -680,6 +680,8 @@ end
 Base.iterate(x::CharStr) = iterate(x.chars)
 Base.iterate(x::CharStr, i::Int) = iterate(x.chars, i)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
+Base.ncodeunits(x::CharStr) = sum(ncodeunits, x.chars)
+
 @testset "cmp without UTF-8 indexing" begin
     # Simple case, with just ANSI Latin 1 characters
     @test "áB" != CharStr("áá") # returns false with bug


### PR DESCRIPTION
Originally I was aiming to optimized `==(::SubString, ::String)` but that was already addressed as part of https://github.com/JuliaLang/julia/pull/35973. Most of the performance increase is probably due to removing allocations.

Current master (594ac899ff)

```julia
julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $"ABC", $"ABC")
  3.905 ns (0 allocations: 0 bytes)
true

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString("ABC")), $"ABCD")
  23.621 ns (1 allocation: 64 bytes)
false

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString("ABC")), $"ABC")
  24.395 ns (1 allocation: 64 bytes)
true

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString("ABC")), $"DEF")
  14.759 ns (1 allocation: 64 bytes)
false

julia> str = "A" ^ 1000;

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString(str)), $str)
  4.141 μs (1 allocation: 64 bytes)
true
```

Current PR:

```julia
julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $"ABC", $"ABC")
  4.364 ns (0 allocations: 0 bytes)
true

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString("ABC")), $"ABCD")
  5.533 ns (0 allocations: 0 bytes)
false

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString("ABC")), $"ABC")
  13.041 ns (0 allocations: 0 bytes)
true

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString("ABC")), $"DEF")
  7.283 ns (0 allocations: 0 bytes)
false

julia> str = "A" ^ 1000;

julia> @btime invoke(==, Tuple{AbstractString, AbstractString}, $(SubString(str)), $str)
  2.524 μs (0 allocations: 0 bytes)
true
```