### PR TITLE
Fix escaped '%' check when building Printf.Format

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -165,15 +165,13 @@ function Format(f::AbstractString)
         end
         push!(fmts, Spec{type}(leftalign, plus, space, zero, hash, width, precision))
         start = pos
-        prevperc = false
         while pos <= len
             b = bytes[pos]
             pos += 1
             if b == UInt8('%')
                 pos > len && throw(ArgumentError("invalid format string: '$f'"))
                 if bytes[pos] == UInt8('%')
-                    pos += 1
-                    pos > len && break
+                    # escaped '%'
                     b = bytes[pos]
                     pos += 1
                 else

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -414,6 +414,11 @@ end
     @test Printf.@sprintf("%f", 1) == "1.000000"
     @test Printf.@sprintf("%e", 1) == "1.000000e+00"
     @test Printf.@sprintf("%g", 1) == "1"
+
+    # escaped '%'
+    @test_throws ArgumentError @sprintf("%s%%%s", "a")
+    @test @sprintf("%s%%%s", "a", "b") == "a%%b"
+
 end
 
 @testset "integers" begin


### PR DESCRIPTION
Addresses
https://github.com/JuliaLang/julia/pull/32859#issuecomment-688826726.
The issue here was advancing the parsing position too far when an
escaped `'%'` was encountered after the first format specifier. If an
escaped `'%'` was then followed by another specifier, it was ignored due
to being classified as an "escaped" character.