### PR TITLE
Fix memory leak in umfpack_numeric!

### DIFF
--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -333,6 +333,7 @@ for itype in UmfpackIndexTypes
             if status != UMFPACK_WARNING_singular_matrix
                 umferror(status)
             end
+            U.numeric != C_NULL && umfpack_free_numeric(U)
             U.numeric = tmp[1]
             return U
         end
@@ -349,6 +350,7 @@ for itype in UmfpackIndexTypes
             if status != UMFPACK_WARNING_singular_matrix
                 umferror(status)
             end
+            U.numeric != C_NULL && umfpack_free_numeric(U)
             U.numeric = tmp[1]
             return U
         end


### PR DESCRIPTION
Fix #37118
If umfpack_numeric! is called on a UmfpackLU struct that has already been factorized, its pointer "numeric" is overwritten without freeing the pointed Numeric object.

This simple fix does:

- Check for an existing Numeric object before writing to UmfpackLU.numeric.
- If it exists, free the object.