### PR TITLE
Ensure 0 isn't padded unnecessarily with %g specifier in Printf

### DIFF
--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -259,7 +259,7 @@ end
             end
             return pos
         end
-        while precision > 1
+        while hash && precision > 1
             buf[pos] = UInt8('0')
             pos += 1
             precision -= 1

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -88,6 +88,10 @@ end
     @test Printf.@sprintf("%g", 123456.7) == "123457"
     @test Printf.@sprintf("%g", 1234567.8) == "1.23457e+06"
 
+    # zeros
+    @test Printf.@sprintf("%.15g", 0) == "0"
+    @test Printf.@sprintf("%#.15g", 0) == "0.00000000000000"
+
 end
 
 @testset "%f" begin


### PR DESCRIPTION
Fixes #37474. The issue here is that 0 is special-cased in the
`Ryu.writeshortest` algorithm, so it didn't hit the same code paths that
were already tested to ensure no unnecessary zero padding for the `%g`
specifier. We should only zero-pad when the `hash` argument is true to
match C, which this PR does.