### PR TITLE
Add CPUID submodule

### DIFF
--- a/base/.gitignore
+++ b/base/.gitignore
@@ -1,3 +1,4 @@
+/features_h.jl
 /pcre_h.jl
 /errno_h.jl
 /build_h.jl

--- a/base/Makefile
+++ b/base/Makefile
@@ -12,7 +12,7 @@ else
 CPP_STDOUT := $(CPP) -E
 endif
 
-all: $(addprefix $(BUILDDIR)/,pcre_h.jl errno_h.jl build_h.jl.phony file_constants.jl uv_constants.jl version_git.jl.phony)
+all: $(addprefix $(BUILDDIR)/,pcre_h.jl errno_h.jl build_h.jl.phony features_h.jl file_constants.jl uv_constants.jl version_git.jl.phony)
 
 PCRE_CONST := 0x[0-9a-fA-F]+|[0-9]+|\([\-0-9]+\)
 ifeq ($(USE_SYSTEM_PCRE), 1)
@@ -20,6 +20,18 @@ ifeq ($(USE_SYSTEM_PCRE), 1)
 else
   PCRE_INCL_PATH := $(build_includedir)/pcre2.h
 endif
+
+define parse_features
+@echo "# $(2) features" >> $@
+@$(call PRINT_PERL, cat ../src/features_$(1).h | perl -lne 'print "const JL_$(2)_$$1 = UInt32($$2)" if /^\s*JL_FEATURE_DEF(?:_NAME)?\(\s*(\w+)\s*,\s*([^,]+)\s*,.*\)\s*(?:\/\/.*)?$$/' >> $@)
+@echo >> $@
+endef
+
+$(BUILDDIR)/features_h.jl: ../src/features_x86.h ../src/features_aarch32.h ../src/features_aarch64.h
+	@-rm -f $@
+	@$(call parse_features,x86,X86)
+	@$(call parse_features,aarch32,AArch32)
+	@$(call parse_features,aarch64,AArch64)
 
 $(BUILDDIR)/pcre_h.jl: $(PCRE_INCL_PATH)
 	@$(call PRINT_PERL, $(CPP) -D PCRE2_CODE_UNIT_WIDTH=8 -dM $< | perl -nle '/^\s*#define\s+PCRE2_(\w*)\s*\(?($(PCRE_CONST))\)?u?\s*$$/ and print index($$1, "ERROR_") == 0 ? "const $$1 = Cint($$2)" : "const $$1 = UInt32($$2)"' | LC_ALL=C sort > $@)
@@ -236,6 +248,7 @@ clean:
 	-rm -f $(BUILDDIR)/errno_h.jl
 	-rm -f $(BUILDDIR)/build_h.jl
 	-rm -f $(BUILDDIR)/build_h.jl.phony
+	-rm -f $(BUILDDIR)/features_h.jl
 	-rm -f $(BUILDDIR)/uv_constants.jl
 	-rm -f $(BUILDDIR)/file_constants.jl
 	-rm -f $(BUILDDIR)/version_git.jl

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -7,6 +7,74 @@ export AbstractPlatform, Platform, HostPlatform, platform_dlext, tags, arch, os,
        select_platform, platforms_match, platform_name
 import .Libc.Libdl
 
+### Submodule with information about CPU features
+module CPUID
+
+export cpu_isa
+
+"""
+    ISA(features::Set{UInt32})
+
+A structure which represents the Instruction Set Architecture (ISA) of a
+computer.  It holds the `Set` of features of the CPU.
+
+The numerical values of the features are automatically generated from the C
+source code of Julia and stored in the `features_h.jl` Julia file.
+"""
+struct ISA
+    features::Set{UInt32}
+end
+
+Base.:<=(a::ISA, b::ISA) = a.features <= b.features
+Base.:<(a::ISA,  b::ISA) = a.features <  b.features
+Base.isless(a::ISA,  b::ISA) = a < b
+
+include("features_h.jl")
+
+# Keep in sync with `arch_march_isa_mapping`.
+const ISAs_by_family = Dict(
+    "x86_64" => (
+        # Source: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html.
+        # Implicit in all sets, because always required: mmx, sse, sse2
+        "x86_64" => ISA(Set{UInt32}()),
+        "core2" => ISA(Set((JL_X86_sse3, JL_X86_ssse3))),
+        "nehalem" => ISA(Set((JL_X86_sse3, JL_X86_ssse3, JL_X86_sse41, JL_X86_sse42, JL_X86_popcnt))),
+        "sandybridge" => ISA(Set((JL_X86_sse3, JL_X86_ssse3, JL_X86_sse41, JL_X86_sse42, JL_X86_popcnt, JL_X86_avx, JL_X86_aes, JL_X86_pclmul))),
+        "haswell" => ISA(Set((JL_X86_movbe, JL_X86_sse3, JL_X86_ssse3, JL_X86_sse41, JL_X86_sse42, JL_X86_popcnt, JL_X86_avx, JL_X86_avx2, JL_X86_aes, JL_X86_pclmul, JL_X86_fsgsbase, JL_X86_rdrnd, JL_X86_fma, JL_X86_bmi, JL_X86_bmi2, JL_X86_f16c))),
+        "skylake" => ISA(Set((JL_X86_movbe, JL_X86_sse3, JL_X86_ssse3, JL_X86_sse41, JL_X86_sse42, JL_X86_popcnt, JL_X86_avx, JL_X86_avx2, JL_X86_aes, JL_X86_pclmul, JL_X86_fsgsbase, JL_X86_rdrnd, JL_X86_fma, JL_X86_bmi, JL_X86_bmi2, JL_X86_f16c, JL_X86_rdseed, JL_X86_adx, JL_X86_prfchw, JL_X86_clflushopt, JL_X86_xsavec, JL_X86_xsaves))),
+        "skylake_avx512" => ISA(Set((JL_X86_movbe, JL_X86_sse3, JL_X86_ssse3, JL_X86_sse41, JL_X86_sse42, JL_X86_popcnt, JL_X86_pku, JL_X86_avx, JL_X86_avx2, JL_X86_aes, JL_X86_pclmul, JL_X86_fsgsbase, JL_X86_rdrnd, JL_X86_fma, JL_X86_bmi, JL_X86_bmi2, JL_X86_f16c, JL_X86_rdseed, JL_X86_adx, JL_X86_prfchw, JL_X86_clflushopt, JL_X86_xsavec, JL_X86_xsaves, JL_X86_avx512f, JL_X86_clwb, JL_X86_avx512vl, JL_X86_avx512bw, JL_X86_avx512dq, JL_X86_avx512cd))),
+    ),
+    "arm" => (
+        "armv7l" => ISA(Set{UInt32}()),
+        "armv7l_neon" => ISA(Set((JL_AArch32_neon,))),
+        "armv7l_neon_vfp4" => ISA(Set((JL_AArch32_neon, JL_AArch32_vfp4))),
+    ),
+    "aarch64" => (
+        # Implicit in all sets, because always required: fp, asimd
+        "armv8.0_a" => ISA(Set{UInt32}()),
+        "armv8.1_a" => ISA(Set((JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm))),
+        "armv8.2_a_crypto" => ISA(Set((JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2))),
+        "armv8.4_a_crypto_sve" => ISA(Set((JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_fp16fml, JL_AArch64_dotprod, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_dotprod, JL_AArch64_sve))),
+    ),
+)
+
+test_cpu_feature(feature::UInt32) = ccall(:jl_test_cpu_feature, Bool, (UInt32,), feature)
+cpu_family() = String(Sys.ARCH)
+
+"""
+    cpu_isa()
+
+Return the [`ISA`](@ref) (instruction set architecture) of the current CPU.
+"""
+function cpu_isa()
+    all_features = last(last(get(ISAs_by_family, cpu_family(), "" => [ISA(Set{UInt32}())]))).features
+    return ISA(Set{UInt32}(feat for feat in all_features if test_cpu_feature(feat)))
+end
+
+end # module CPUID
+
+using .CPUID
+
 # This exists to ease compatibility with old-style Platform objects
 abstract type AbstractPlatform; end
 
@@ -567,6 +635,31 @@ const arch_mapping = Dict(
     "armv6l" => "armv6l",
     "powerpc64le" => "p(ower)?pc64le",
 )
+# Keep this in sync with `CPUID.ISAs_by_family`
+const arch_march_isa_mapping = let
+    function get_set(arch, name)
+        all = CPUID.ISAs_by_family[arch]
+        return all[findfirst(x -> x.first == name, all)].second
+    end
+    Dict(
+        "x86_64" => Dict{String,CPUID.ISA}(
+            "x86_64" => get_set("x86_64", "x86_64"),
+            "avx" => get_set("x86_64", "sandybridge"),
+            "avx2" => get_set("x86_64", "haswell"),
+            "avx512" => get_set("x86_64", "skylake_avx512"),
+        ),
+        "armv7l" => Dict{String,CPUID.ISA}(
+            "armv7l" => get_set("arm", "armv7l"),
+            "neon" => get_set("arm", "armv7l_neon"),
+            "vfp4" => get_set("arm", "armv7l_neon_vfp4"),
+        ),
+        "aarch64" => Dict{String,CPUID.ISA}(
+            "armv8" => get_set("aarch64", "armv8.0_a"),
+            "thunderx2" => get_set("aarch64", "armv8.1_a"),
+            "carmel" => get_set("aarch64", "armv8.2_a_crypto"),
+        ),
+    )
+end
 const os_mapping = Dict(
     "macos" => "-apple-darwin[\\d\\.]*",
     "freebsd" => "-(.*-)?freebsd[\\d\\.]*",

--- a/src/processor.h
+++ b/src/processor.h
@@ -123,7 +123,7 @@ typedef enum {
 } jl_cpu_feature_t;
 #undef JL_FEATURE_DEF_NAME
 
-int jl_test_cpu_feature(jl_cpu_feature_t feature);
+JL_DLLEXPORT int jl_test_cpu_feature(jl_cpu_feature_t feature);
 
 static const uint32_t jl_sysimg_tag_mask = 0x80000000u;
 static const uint32_t jl_sysimg_val_mask = ~((uint32_t)0x80000000u);

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -1,4 +1,16 @@
-using Test, Base.BinaryPlatforms
+using Test, Base.BinaryPlatforms, Base.BinaryPlatforms.CPUID
+
+@testset "CPUID" begin
+    @test CPUID.cpu_isa() isa CPUID.ISA
+
+    get_x86_64(n) = (CPUID.ISAs_by_family["x86_64"][n].second)
+    @test get_x86_64(2) <  get_x86_64(4)
+    @test get_x86_64(5) <= get_x86_64(5)
+    @test get_x86_64(3) >= get_x86_64(3)
+    @test get_x86_64(7) >= get_x86_64(1)
+    @test sort([get_x86_64(6), get_x86_64(4), get_x86_64(2), get_x86_64(4)]) ==
+        [get_x86_64(2), get_x86_64(4), get_x86_64(4), get_x86_64(6)]
+end
 
 # Helper constructor to create a Platform with `validate_strict` set to `true`.
 P(args...; kwargs...) = Platform(args...; validate_strict=true, kwargs...)


### PR DESCRIPTION
This is a small internal module which defines the API to query the Instruction
Set Architecture (ISA) of the current CPU.  This can be used for example to
select an artifact in a JLL package which is compatible with the current CPU.

This is related to #37320, and might change to accommodate some needs of that PR.

Fix #36367.  CC: @staticfloat.