### PR TITLE
clarify && and ||

### DIFF
--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -4,7 +4,7 @@ Julia provides a variety of control flow constructs:
 
   * [Compound Expressions](@ref man-compound-expressions): `begin` and `;`.
   * [Conditional Evaluation](@ref man-conditional-evaluation): `if`-`elseif`-`else` and `?:` (ternary operator).
-  * [Short-Circuit Evaluation](@ref): `&&`, `||` and chained comparisons.
+  * [Short-Circuit Evaluation](@ref): logical operators `&&` (“and”) and `||` (“or”), and also chained comparisons.
   * [Repeated Evaluation: Loops](@ref man-loops): `while` and `for`.
   * [Exception Handling](@ref): `try`-`catch`, [`error`](@ref) and [`throw`](@ref).
   * [Tasks (aka Coroutines)](@ref man-tasks): [`yieldto`](@ref).
@@ -246,6 +246,12 @@ no
 ```
 
 ## Short-Circuit Evaluation
+
+The `&&` and `||` operators in Julia correspond to logical “and” and “or” operations, respectively,
+and are typically used for this purpose.  However, they have an additional property of *short-circuit*
+evaluation: they don't necessarily evaluate their second argument, as explained below.  (There
+are also bitwise `&` and `|` operators that can be used as logical “and” and “or” *without*
+short-circuit behavior, but beware that `&` and `|` have higher precedence than `&&` and `||` for evaluation order.)
 
 Short-circuit evaluation is quite similar to conditional evaluation. The behavior is found in
 most imperative programming languages having the `&&` and `||` boolean operators: in a series


### PR DESCRIPTION
Some clarification pursuant to [this discussion](https://discourse.julialang.org/t/and-or-bitwise-or-shortcircuit-what-we-get-searching-docs/46263).