### PR TITLE
change display of type aliases to avoid `=`

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1848,7 +1848,7 @@ Rational{Int64}
 julia> M = [1 2; 3.5 4];
 
 julia> typeof(M)
-Matrix{Float64} = Array{Float64, 2}
+Matrix{Float64} (alias for Array{Float64, 2})
 ```
 """
 typeof

--- a/base/float.jl
+++ b/base/float.jl
@@ -285,7 +285,7 @@ Equivalent to `typeof(float(zero(T)))`.
 # Examples
 ```jldoctest
 julia> float(Complex{Int})
-ComplexF64 = Complex{Float64}
+ComplexF64 (alias for Complex{Float64})
 
 julia> float(Int)
 Float64

--- a/base/show.jl
+++ b/base/show.jl
@@ -740,8 +740,9 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
     if !print_without_params(x) && get(io, :compact, true)
         properx = makeproper(io, x)
         if make_typealias(properx) !== nothing || x <: make_typealiases(properx)[2]
-            print(io, " = ")
+            print(io, " (alias for ")
             show(IOContext(io, :compact => false), x)
+            print(io, ")")
         end
     end
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1033,7 +1033,7 @@ consider the two types created by the following declarations:
 
 ```jldoctest
 julia> const T1 = Array{Array{T,1} where T, 1}
-Vector{Vector{T} where T} = Array{Array{T, 1} where T, 1}
+Vector{Vector{T} where T} (alias for Array{Array{T, 1} where T, 1})
 
 julia> const T2 = Array{Array{T, 1}, 1} where T
 Array{Vector{T}, 1} where T

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1617,7 +1617,7 @@ julia> a = [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]]
   Any[0 + 6im, [7.0, 8.0]]
 
 julia> LinearAlgebra.promote_leaf_eltypes(a)
-ComplexF64 = Complex{Float64}
+ComplexF64 (alias for Complex{Float64})
 ```
 """
 promote_leaf_eltypes(x::Union{AbstractArray{T},Tuple{T,Vararg{T}}}) where {T<:Number} = T


### PR DESCRIPTION
```
julia> Vector
Vector{T} where T (alias for Array{T, 1} where T)
```
instead of
```
julia> Vector
Vector{T} where T = Array{T, 1} where T
```
The `where T =` is probably confusing for new users.
