### PR TITLE
Improve precision of nfields_tfunc on `Union`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -381,6 +381,11 @@ function nfields_tfunc(@nospecialize(x))
             return Const(isdefined(x, :types) ? length(x.types) : length(x.name.names))
         end
     end
+    if isa(x, Union)
+        na = nfields_tfunc(x.a)
+        na === Int && return Int
+        return tmerge(na, nfields_tfunc(x.b))
+    end
     return Int
 end
 add_tfunc(nfields, 1, 1, nfields_tfunc, 1)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1435,6 +1435,7 @@ end
 @test nfields_tfunc(Type{Union{}}) === Const(0)
 @test nfields_tfunc(Tuple{Int, Vararg{Int}}) === Int
 @test nfields_tfunc(Tuple{Int, Integer}) === Const(2)
+@test nfields_tfunc(Union{Tuple{Int, Float64}, Tuple{Int, Int}}) === Const(2)
 
 using Core.Compiler: typeof_tfunc
 @test typeof_tfunc(Tuple{Vararg{Int}}) == Type{Tuple{Vararg{Int,N}}} where N


### PR DESCRIPTION
`nfields_tfunc(Tuple{Int, Union{Int, Float64}})` gave `Const(2)`,
but `nfields_tfunc(Union{Tuple{Int, Float64}, Tuple{Int, Int}})` gave
`Int`. In general, it's not great for the tfuncs to give different
answers when given `==` types, because other parts of the system
will happily substitute such types without changes to the user code,
which can change the inference result and lead to instability.