### PR TITLE
Support `addprocs()` when remote ssh shell is `csh`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - csh
             - ccache
             - libssl1.0.0
             - bar
@@ -33,7 +32,6 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - csh
             - ccache
             - libssl1.0.0
             - bar
@@ -66,7 +64,6 @@ before_install:
         BUILDOPTS="-j5 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1 USECCACHE=1 USE_BINARYBUILDER_LIBUV=0 USE_BINARYBUILDER_LIBUNWIND=0 USE_BINARYBUILDER_LLVM=0";
         echo "override ARCH=$ARCH" >> Make.user;
         sudo sh -c "echo 0 > /proc/sys/net/ipv6/conf/lo/disable_ipv6";
-        sudo usermod --shell=/usr/bin/csh travis
         export JULIA_CPU_THREADS=4;
         export JULIA_TEST_MAXRSS_MB=1200;
         TESTSTORUN="all";

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - csh
             - ccache
             - libssl1.0.0
             - bar
@@ -32,6 +33,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - csh
             - ccache
             - libssl1.0.0
             - bar
@@ -64,6 +66,7 @@ before_install:
         BUILDOPTS="-j5 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1 USECCACHE=1 USE_BINARYBUILDER_LIBUV=0 USE_BINARYBUILDER_LIBUNWIND=0 USE_BINARYBUILDER_LLVM=0";
         echo "override ARCH=$ARCH" >> Make.user;
         sudo sh -c "echo 0 > /proc/sys/net/ipv6/conf/lo/disable_ipv6";
+        sudo usermod --shell=/usr/bin/csh travis
         export JULIA_CPU_THREADS=4;
         export JULIA_TEST_MAXRSS_MB=1200;
         TESTSTORUN="all";

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -225,10 +225,12 @@ function launch_on_machine(manager::SSHManager, machine::AbstractString, cnt, pa
     tval = get(ENV, "JULIA_WORKER_TIMEOUT", "")
 
     # Julia process with passed in command line flag arguments
-    cmds = """
-        cd -- $(shell_escape_posixly(dir))
-        $(isempty(tval) ? "" : "export JULIA_WORKER_TIMEOUT=$(shell_escape_posixly(tval))")
-        $(shell_escape_posixly(exename)) $(shell_escape_posixly(exeflags))"""
+    # join statement array into a single ;-separated command line
+    cmds = join([
+        "cd -- $(shell_escape_posixly(dir))"
+        """$(isempty(tval) ? "" : "export JULIA_WORKER_TIMEOUT=$(shell_escape_posixly(tval))")"""
+        "$(shell_escape_posixly(exename)) $(shell_escape_posixly(exeflags))"
+                ], ";")
 
     # shell login (-l) with string command (-c) to launch julia process
     cmd = `sh -l -c $cmds`


### PR DESCRIPTION
Re-write of https://github.com/JuliaLang/julia/pull/32765 considering the following:
- [diff against newer code](https://github.com/JuliaLang/julia/pull/32765#issuecomment-612549856)
- [use `csh` as remote shell for tests](https://github.com/JuliaLang/julia/pull/32765#issuecomment-688963441)