### PR TITLE
Fix broadcasted assignment for Cartesian indexing where the dimension of the `CartesianIndex` is greater than one

### DIFF
--- a/base/views.jl
+++ b/base/views.jl
@@ -131,7 +131,7 @@ end
 # (while remaining equivalent to getindex for scalar indices and non-array types)
 @propagate_inbounds maybeview(A, args...) = getindex(A, args...)
 @propagate_inbounds maybeview(A::AbstractArray, args...) = view(A, args...)
-@propagate_inbounds maybeview(A::AbstractArray, args::Union{Number,AbstractCartesianIndex}...) = getindex(A, args...)
+@propagate_inbounds maybeview(A::AbstractArray, args::Union{Number,AbstractCartesianIndex{1}}...) = getindex(A, args...)
 @propagate_inbounds maybeview(A) = getindex(A)
 @propagate_inbounds maybeview(A::AbstractArray) = getindex(A)
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -319,6 +319,11 @@ let a = [[4, 5], [6, 7]], b = reshape(a, 1, 2)
     b[1, CartesianIndex(1)] .= 5
     @test a == [[5, 5], [6, 7]]
 end
+let a = [1, 2, 3, 4]
+    @test a[1] == 1
+    a[CartesianIndex(1,1)] .= 0
+    @test a[1] == 0
+end
 let d = Dict(:foo => [1,3,7], (3,4) => [5,9])
     d[:foo] .+= 2
     @test d[:foo] == [3,5,9]


### PR DESCRIPTION
Briefly, #35926 breaks the following code:
```julia
a = [1, 2, 3, 4]
a[CartesianIndex(1,1)] .= 0
```

This PR fixes the behavior for `CartesianIndex` of dimension greater than one, but preserves the behavior for one-dimensional `CartesianIndex`.