### PR TITLE
Add optional `kwshow=true` argument to `@kwdef`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -388,9 +388,10 @@ show(io::IO, @nospecialize(x)) = show_default(io, x)
 show(x) = show(stdout::IO, x)
 
 # avoid inferring show_default on the type of `x`
-show_default(io::IO, @nospecialize(x)) = _show_default(io, inferencebarrier(x))
+show_default(io::IO, @nospecialize(x); kwshow::Bool=false) =
+    _show_default(io, inferencebarrier(x); kwshow=kwshow)
 
-function _show_default(io::IO, @nospecialize(x))
+function _show_default(io::IO, @nospecialize(x); kwshow::Bool)
     t = typeof(x)
     show(io, inferencebarrier(t))
     print(io, '(')
@@ -402,6 +403,9 @@ function _show_default(io::IO, @nospecialize(x))
                                  Pair{Symbol,Any}(:typeinfo, Any))
             for i in 1:nf
                 f = fieldname(t, i)
+                if kwshow
+                    print(io, f, " = ")
+                end
                 if !isdefined(x, f)
                     print(io, undef_ref_str)
                 else

--- a/base/util.jl
+++ b/base/util.jl
@@ -483,11 +483,7 @@ macro kwdef(flags, expr)
             should_kwshow = flags.args[2]
             if should_kwshow
                 kwshow = :(
-                    function $Base.show(io::$IO, s::$(esc(S)))
-                        $print(io, "$($(esc(S)))(")
-                        $print(io, join(("$a = $(repr(getfield(s,a)))" for a in $call_args), ", "))
-                        $print(io, ")")
-                    end
+                    $Base.show(io::$IO, s::$(esc(S))) = $Base.show_default(io, s, kwshow=true)
                 )
             end
         else


### PR DESCRIPTION
Adds an optional `kwshow=true` argument to `Base.@kwdef` that will
auto-generate a `Base.show()` method that prints arguments as keyword
arguments, matching the way the type is constructed.

For example:
```julia
julia> Base.@kwdef kwshow=true struct Bar
    a::Int = 1         # specified default
    b::String          # required keyword
end
Bar

julia> Bar(a = 1, b = "hi")
Bar(a = 1, b = "hi")
```