### PR TITLE
Base64: add isreadable and iswritable for Base64EncodePipe/Base64DecodePipe

### DIFF
--- a/stdlib/Base64/src/decode.jl
+++ b/stdlib/Base64/src/decode.jl
@@ -43,7 +43,7 @@ struct Base64DecodePipe <: IO
     end
 end
 
-Base.isreadable(pipe::Base64DecodePipe) = isreadable(pipe.io) && true
+Base.isreadable(pipe::Base64DecodePipe) = !isempty(pipe.rest) || isreadable(pipe.io)
 Base.iswritable(::Base64DecodePipe) = false
 
 function Base.unsafe_read(pipe::Base64DecodePipe, ptr::Ptr{UInt8}, n::UInt)

--- a/stdlib/Base64/src/decode.jl
+++ b/stdlib/Base64/src/decode.jl
@@ -43,6 +43,9 @@ struct Base64DecodePipe <: IO
     end
 end
 
+Base.isreadable(pipe::Base64DecodePipe) = isreadable(pipe.io) && true
+Base.iswritable(::Base64DecodePipe) = false
+
 function Base.unsafe_read(pipe::Base64DecodePipe, ptr::Ptr{UInt8}, n::UInt)
     p = read_until_end(pipe, ptr, n)
     if p < ptr + n

--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -45,7 +45,7 @@ struct Base64EncodePipe <: IO
 end
 
 Base.isreadable(::Base64EncodePipe) = false
-Base.iswritable(pipe::Base64EncodePipe) = iswritable(pipe.io) && true
+Base.iswritable(pipe::Base64EncodePipe) = iswritable(pipe.io)
 
 function Base.unsafe_write(pipe::Base64EncodePipe, ptr::Ptr{UInt8}, n::UInt)::Int
     buffer = pipe.buffer

--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -44,6 +44,9 @@ struct Base64EncodePipe <: IO
     end
 end
 
+Base.isreadable(::Base64EncodePipe) = false
+Base.iswritable(pipe::Base64EncodePipe) = iswritable(pipe.io) && true
+
 function Base.unsafe_write(pipe::Base64EncodePipe, ptr::Ptr{UInt8}, n::UInt)::Int
     buffer = pipe.buffer
     m = buffer.size


### PR DESCRIPTION
This mimics the `isreadable` and `iswritable` methods of `IOStream` for Base64 pipelines and fixes the following error:

```julia
julia> using Base64

julia> Base64EncodePipe <: IO
true

julia> isreadable(Base64EncodePipe(IOBuffer()))
ERROR: MethodError: no method matching isreadable(::Base64EncodePipe)
```