### PR TITLE
Use a fixed DateTime in rounding tests instead of now()

### DIFF
--- a/stdlib/Dates/test/rounding.jl
+++ b/stdlib/Dates/test/rounding.jl
@@ -190,7 +190,7 @@ end
 end
 
 @testset "Rouding DateTime to Date" begin
-    now_ = now()
+    now_ = DateTime(2020, 9, 1, 13)
     for p in (Year, Month, Day)
         for r in (RoundUp, RoundDown)
             @test round(Date, now_, p, r) == round(Date(now_), p, r)

--- a/stdlib/Dates/test/rounding.jl
+++ b/stdlib/Dates/test/rounding.jl
@@ -195,7 +195,7 @@ end
         for r in (RoundUp, RoundDown)
             @test round(Date, now_, p, r) == round(Date(now_), p, r)
         end
-        @test round(Date, now_, p) == round(Date, now_, p, RoundUp)
+        @test round(Date, now_, p) == round(Date, now_, p, RoundNearestTiesUp)
         @test floor(Date, now_, p) == round(Date, now_, p, RoundDown)
         @test ceil(Date, now_, p)  == round(Date, now_, p, RoundUp)
     end


### PR DESCRIPTION
Using now led to inconsistent answers depending on when `now()` is; make
tests more reliable by using a fixed `DateTime`.