### PR TITLE
performance tip: consider StaticArrays for small fixed-size arrays

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1110,7 +1110,7 @@ specialize code for the *size* of the array, e.g. by completely unrolling vector
 
 For example, if you are doing computations with 2d geometries, you might have many computations with 2-component vectors.  By
 using the `SVector` type from StaticArrays.jl, you can use convenient vector notation and operations like `norm(3v - w)` on
-these vectors `v` and `w`, while allowing the compiler to unroll the code to a minimal computation like `@inbounds hypot(3v[1]-w[1], 3v[2]-w[2])`.
+vectors `v` and `w`, while allowing the compiler to unroll the code to a minimal computation equivalent to `@inbounds hypot(3v[1]-w[1], 3v[2]-w[2])`.
 
 ## Avoid string interpolation for I/O
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1103,7 +1103,7 @@ far outweighed by the speed boost from doing the matrix multiplication on a cont
 
 ## Consider StaticArrays for small fixed-size vector/matrix operations
 
-If your application involves many small (`< 20` element) arrays of fixed sizes (i.e. the size is
+If your application involves many small (`< 100` element) arrays of fixed sizes (i.e. the size is
 known prior to execution), then you might want to consider using the [StaticArrays.jl package](https://github.com/JuliaArrays/StaticArrays.jl).
 This package allows you to represent such arrays in a way that avoids unnecessary heap allocations and allows the compiler to
 specialize code for the *size* of the array, e.g. by completely unrolling vector operations (eliminating the loops) and storing elements in CPU registers.

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1101,7 +1101,7 @@ julia> @time begin
 Provided there is enough memory for the copies, the cost of copying the view to an array is
 far outweighed by the speed boost from doing the matrix multiplication on a contiguous array.
 
-## Consider StaticArrays for small fixed-size vector/matrix operations
+## Consider StaticArrays.jl for small fixed-size vector/matrix operations
 
 If your application involves many small (`< 100` element) arrays of fixed sizes (i.e. the size is
 known prior to execution), then you might want to consider using the [StaticArrays.jl package](https://github.com/JuliaArrays/StaticArrays.jl).

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1101,6 +1101,17 @@ julia> @time begin
 Provided there is enough memory for the copies, the cost of copying the view to an array is
 far outweighed by the speed boost from doing the matrix multiplication on a contiguous array.
 
+## Consider StaticArrays for small fixed-size vector/matrix operations
+
+If your application involves many small (`< 20` element) arrays of fixed sizes (i.e. the size is
+known prior to execution), then you might want to consider using the [StaticArrays.jl package](https://github.com/JuliaArrays/StaticArrays.jl).
+This package allows you to represent such arrays in a way that avoids unnecessary heap allocations and allows the compiler to
+specialize code for the *size* of the array, e.g. by completely unrolling vector operations (eliminating the loops) and storing elements in CPU registers.
+
+For example, if you are doing computations with 2d geometries, you might have many computations with 2-component vectors.  By
+using the `SVector` type from StaticArrays.jl, you can use convenient vector notation and operations like `norm(3v - w)` on
+these vectors `v` and `w`, while allowing the compiler to unroll the code to a minimal computation like `@inbounds hypot(3v[1]-w[1], 3v[2]-w[2])`.
+
 ## Avoid string interpolation for I/O
 
 When writing data to a file (or other I/O device), forming extra intermediate strings is a source


### PR DESCRIPTION
I find myself recommending StaticArrays over and over again to people working with small fixed-size arrays.  Can we suggest this in the performance tips even though it is an external package?