### PR TITLE
Add punctuation for pipes (|>) and composition (∘)

### DIFF
--- a/doc/src/base/punctuation.md
+++ b/doc/src/base/punctuation.md
@@ -56,3 +56,5 @@ Extended documentation for mathematical symbols & functions is [here](@ref math-
 | [`===`](@ref) | triple equals sign is programmatically identical equality comparison                      |
 | [`=>`](@ref Pair) | right arrow using an equals sign defines a [`Pair`](@ref) typically used to populate [dictionaries](@ref Dictionaries) |
 | `->` | right arrow using a hyphen defines an [anonymous function](@ref man-anonymous-functions) on a single line         |
+| `|>` | pipe operator passes output from the left argument to input of right argument, usually a [function](@ref Function-composition-and-piping) |
+| `∘` | function composition operator combines two functions as though they are a single larger [function](@ref Function-composition-and-piping) |

--- a/doc/src/base/punctuation.md
+++ b/doc/src/base/punctuation.md
@@ -57,4 +57,4 @@ Extended documentation for mathematical symbols & functions is [here](@ref math-
 | [`=>`](@ref Pair) | right arrow using an equals sign defines a [`Pair`](@ref) typically used to populate [dictionaries](@ref Dictionaries) |
 | `->` | right arrow using a hyphen defines an [anonymous function](@ref man-anonymous-functions) on a single line         |
 | `|>` | pipe operator passes output from the left argument to input of right argument, usually a [function](@ref Function-composition-and-piping) |
-| `∘` | function composition operator combines two functions as though they are a single larger [function](@ref Function-composition-and-piping) |
+| `∘` | function composition operator (typed with \circ{tab}) combines two functions as though they are a single larger [function](@ref Function-composition-and-piping) |

--- a/doc/src/base/punctuation.md
+++ b/doc/src/base/punctuation.md
@@ -56,5 +56,5 @@ Extended documentation for mathematical symbols & functions is [here](@ref math-
 | [`===`](@ref) | triple equals sign is programmatically identical equality comparison                      |
 | [`=>`](@ref Pair) | right arrow using an equals sign defines a [`Pair`](@ref) typically used to populate [dictionaries](@ref Dictionaries) |
 | `->` | right arrow using a hyphen defines an [anonymous function](@ref man-anonymous-functions) on a single line         |
-| `|>` | pipe operator passes output from the left argument to input of right argument, usually a [function](@ref Function-composition-and-piping) |
+| `|>` | pipe operator passes output from the left argument to input of the right argument, usually a [function](@ref Function-composition-and-piping) |
 | `∘` | function composition operator (typed with \circ{tab}) combines two functions as though they are a single larger [function](@ref Function-composition-and-piping) |


### PR DESCRIPTION
I will need the syntax and accuracy checked but thought these should be included in the list.