### PR TITLE
Expand SnoopCompileCore.@snoopi to report _all MethodInstances_ that are inferred during a single inference call.

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1257,8 +1257,15 @@ function abstract_eval_ssavalue(s::SSAValue, src::CodeInfo)
     return typ
 end
 
+#const __collect_inference_callees__ = Ref{Bool}(false)
+const __inference_callees__ = Vector{MethodInstance}()
+
 # make as much progress on `frame` as possible (without handling cycles)
 function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
+    #if __collect_inference_callees__[]
+        push!(__inference_callees__, frame.linfo)
+    #end
+
     @assert !frame.inferred
     frame.dont_work_on_me = true # mark that this function is currently on the stack
     W = frame.ip

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1257,14 +1257,14 @@ function abstract_eval_ssavalue(s::SSAValue, src::CodeInfo)
     return typ
 end
 
-#const __collect_inference_callees__ = Ref{Bool}(false)
+const __collect_inference_callees__ = fill(false)  # Singleton Unary Array since Ref isn't available yet
 const __inference_callees__ = Vector{MethodInstance}()
 
 # make as much progress on `frame` as possible (without handling cycles)
 function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
-    #if __collect_inference_callees__[]
+    if __collect_inference_callees__[]
         push!(__inference_callees__, frame.linfo)
-    #end
+    end
 
     @assert !frame.inferred
     frame.dont_work_on_me = true # mark that this function is currently on the stack

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1258,13 +1258,13 @@ function abstract_eval_ssavalue(s::SSAValue, src::CodeInfo)
 end
 
 const __collect_inference_callees__ = fill(false)  # Singleton Unary Array since Ref isn't available yet
-const __inference_callees__ = Vector{MethodInstance}()
+#const __inference_callees__ = Vector{MethodInstance}()
 
 # make as much progress on `frame` as possible (without handling cycles)
 function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
-    if __collect_inference_callees__[]
-        push!(__inference_callees__, frame.linfo)
-    end
+    #if __collect_inference_callees__[]
+    #    push!(__inference_callees__, frame.linfo)
+    #end
 
     @assert !frame.inferred
     frame.dont_work_on_me = true # mark that this function is currently on the stack

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -497,6 +497,8 @@ function resolve_call_cycle!(interp::AbstractInterpreter, linfo::MethodInstance,
     return false
 end
 
+const __inference_callee_edges4__ = Vector{Tuple{MethodInstance, Vector{Tuple{MethodInstance,MethodInstance}}}}()
+
 # compute (and cache) an inferred AST and return the current best estimate of the result type
 function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize(atypes), sparams::SimpleVector, caller::InferenceState)
     mi = specialize_method(method, atypes, sparams)::MethodInstance
@@ -532,6 +534,11 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
         end
         if caller.cached || caller.limited # don't involve uncached functions in cycle resolution
             frame.parent = caller
+        end
+        if __collect_inference_callees__[]
+            #Core.println("edge!")
+            #Core.println(__inference_callee_edges4__)
+            push!(__inference_callee_edges4__[end][2], (caller.linfo, frame.linfo))
         end
         typeinf(interp, frame)
         update_valid_age!(frame, caller)


### PR DESCRIPTION
Before this PR, it reported only the entry MethodInstance:
```julia
julia> module M
           h(a::Array) = a[1]::Integer + 1
           g(y::Integer, x) = h(Any[y]) + Int(x)
       end;

julia> SnoopCompileCore.@snoopi begin
           M.g(2,3.0)
       end
1-element Array{Tuple{Float64,Core.MethodInstance},1}:
 (0.0011429786682128906, MethodInstance for g(::Int64, ::Float64))
```

After this PR, we want to be able to get _all_ the MethodInstances that are (recursively) inferred during the inference to the top method instance.

Currently, it now looks like this:
```julia
julia> SnoopCompileCore.@snoopi begin
           M.g(2,3.0)
       end
1-element Vector{Tuple{Float64,Vector{Core.MethodInstance}}}:
 (0.001068115234375, [MethodInstance for g(::Int64, ::Float64), MethodInstance for h(::Vector{Any})])
```
But we're very open to other ideas for how best to represent this! :)
I think it might be super cool to return this as a _DAG_ rather than a vector, so that we could maybe then work our way up from the leaves timing `code_typed` on each of them one at a time to try to understand which function had the most _exclusive_ time?

----

This PR is basically applying the same trick we did in https://github.com/JuliaLang/julia/pull/37136 to get the full set of MethodInstances being compiled, rather than just the entry method instance.