### PR TITLE
Ensure Ryu.writeexp doesn't round past starting position

### DIFF
--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -2,6 +2,7 @@
     precision=-1, plus=false, space=false, hash=false,
     expchar=UInt8('e'), decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
     @assert 0 < pos <= length(buf)
+    startpos = pos
     x = Float64(v)
     neg = signbit(x)
     # special cases
@@ -212,7 +213,7 @@
         roundPos = pos
         while true
             roundPos -= 1
-            if roundPos == 0 || buf[roundPos] == UInt8('-')
+            if roundPos == (startpos - 1) || buf[roundPos] == UInt8('-')
                 buf[roundPos + 1] = UInt8('1')
                 e += 1
                 break

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -2,6 +2,7 @@
     precision=-1, plus=false, space=false, hash=false,
     decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
     @assert 0 < pos <= length(buf)
+    startpos = pos
     x = Float64(v)
     neg = signbit(x)
     # special cases
@@ -165,7 +166,7 @@
             dotPos = 1
             while true
                 roundPos -= 1
-                if roundPos == 0 || (buf[roundPos] == UInt8('-'))
+                if roundPos == (startpos - 1) || (buf[roundPos] == UInt8('-'))
                     buf[roundPos + 1] = UInt8('1')
                     if dotPos > 1
                         buf[dotPos] = UInt8('0')

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -425,6 +425,10 @@ end
 
     # print float as %d uses round(x)
     @test @sprintf("%d", 25.5) == "26"
+
+    # 37539
+    @test @sprintf(" %.1e\n", 0.999) == " 1.0e+00\n"
+    @test @sprintf("   %.1f", 9.999) == "   10.0"
 end
 
 @testset "integers" begin


### PR DESCRIPTION
Fixes #37539. The issue here was the `Ryu.writeexp` code got to the
rounding section and started rounding `0.999` up to precision of 1, but
because the format string specifies a space before the number, it kept
rounding the space "digit", which messed up the final string. The
solution proposed here keeps track of the original starting `pos` when
we start `writeexp` and terminates the rounding sequence if we get
there.

I also checked `Ryu.writefixed`, because it has similar rounding code,
but it doesn't fail on quite the same case because it explicitly keeps
track of the decimal point and will terminate rounding based on that in
some cases. I did, however, manage to reproduce with `9.999`, because
the rounding then extends before the decimal point, so a similar fix is
applied to `writefixed`.