### PR TITLE
fix sinc(Inf+Inf*im)

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1079,10 +1079,8 @@ sinc(x::Integer) = iszero(x) ? one(x) : zero(x)
 _sinc(x::Number) = iszero(x) ? one(x) : isinf_real(x) ? zero(x) : sinpi(x)/(pi*x)
 _sinc_threshold(::Type{Float64}) = 0.001
 _sinc_threshold(::Type{Float32}) = 0.05f0
-@inline function _sinc(x::Union{T,Complex{T}}) where {T<:Union{Float32,Float64}}
-    a = fastabs(x)
-    return a < _sinc_threshold(T) ? evalpoly(x^2, (T(1), -T(pi)^2/6, T(pi)^4/120)) : isinf_real(a) ? zero(x) : sinpi(x)/(pi*x)
-end
+@inline _sinc(x::Union{T,Complex{T}}) where {T<:Union{Float32,Float64}} =
+    fastabs(x) < _sinc_threshold(T) ? evalpoly(x^2, (T(1), -T(pi)^2/6, T(pi)^4/120)) : isinf_real(x) ? zero(x) : sinpi(x)/(pi*x)
 _sinc(x::Float16) = Float16(_sinc(Float32(x)))
 _sinc(x::ComplexF16) = ComplexF16(_sinc(ComplexF32(x)))
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -471,6 +471,7 @@ end
     @test cosc(Inf + 3im) == 0
 
     @test isequal(sinc(Inf + Inf*im), NaN + NaN*im)
+    @test isequal(cosc(Inf + Inf*im), NaN + NaN*im)
 end
 
 # issue #37227

--- a/test/math.jl
+++ b/test/math.jl
@@ -469,6 +469,8 @@ end
 
     @test sinc(Inf + 3im) == 0
     @test cosc(Inf + 3im) == 0
+
+    @test isequal(sinc(Inf + Inf*im), NaN + NaN*im)
 end
 
 # issue #37227


### PR DESCRIPTION
Fixes a regression caused by a typo in ~~37217~~ #37273: if the imaginary part of `x` is infinite, `sinc(x)` should not be zero and is generally just NaN.

(In principle, we could return a non-NaN complex infinity for `sinc(finite ± Inf*im)`, but I'm not sure it is worth the logic for that additional case.  In any case, that could be a separate PR since it is not a regression.)