### PR TITLE
Allow `clamp(n, 1:10)`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -97,6 +97,15 @@ function clamp!(x::AbstractArray, lo, hi)
     x
 end
 
+"""
+    clamp(x::Integer, r::AbstractUnitRange)
+
+Clamp `x` to lie within range `r`.
+
+!!! compat "Julia 1.6"
+     This method requires at least Julia 1.6.
+"""
+clamp(x::Integer, r::AbstractUnitRange{<:Integer}) = clamp(x, first(r), last(r))
 
 """
     evalpoly(x, p)

--- a/base/range.jl
+++ b/base/range.jl
@@ -1147,7 +1147,7 @@ mod(i::Integer, r::AbstractUnitRange{<:Integer}) = mod(i-first(r), length(r)) + 
 
 Clamp `x` to lie within range `r`.
 
-!!! compat "Julia 1.5"
-     This method requires at least Julia 1.5.
+!!! compat "Julia 1.6"
+     This method requires at least Julia 1.6.
 """
-clamp(x::Integer, r::AbstractUnitRange) = clamp(x, first(r), last(r))
+clamp(x::Integer, r::AbstractUnitRange{<:Integer}) = clamp(x, first(r), last(r))

--- a/base/range.jl
+++ b/base/range.jl
@@ -1141,13 +1141,3 @@ julia> mod(3, 0:2)
 """
 mod(i::Integer, r::OneTo) = mod1(i, last(r))
 mod(i::Integer, r::AbstractUnitRange{<:Integer}) = mod(i-first(r), length(r)) + first(r)
-
-"""
-    clamp(x::Integer, r::AbstractUnitRange)
-
-Clamp `x` to lie within range `r`.
-
-!!! compat "Julia 1.6"
-     This method requires at least Julia 1.6.
-"""
-clamp(x::Integer, r::AbstractUnitRange{<:Integer}) = clamp(x, first(r), last(r))

--- a/base/range.jl
+++ b/base/range.jl
@@ -1141,3 +1141,13 @@ julia> mod(3, 0:2)
 """
 mod(i::Integer, r::OneTo) = mod1(i, last(r))
 mod(i::Integer, r::AbstractUnitRange{<:Integer}) = mod(i-first(r), length(r)) + first(r)
+
+"""
+    clamp(x::Integer, r::AbstractUnitRange)
+
+Clamp `x` to lie within range `r`.
+
+!!! compat "Julia 1.5"
+     This method requires at least Julia 1.5.
+"""
+clamp(x::Integer, r::AbstractUnitRange) = clamp(x, first(r), last(r))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1633,6 +1633,20 @@ end
     @test_throws DivideError mod(3, 1:0)
 end
 
+@testset "clamp with unitrange" begin
+    for n in -10:10
+        @test clamp(n, 0:4) == clamp(n, 0, 4)
+        @test clamp(n, Base.OneTo(5)) == clamp(n, 1, 5)
+    end
+    @test clamp(Int32(3), 1:5) == Int(3)
+    @test clamp(big(typemax(Int))+99, 0:4) == 4
+    @test_throws MethodError clamp(3.141, 1:5)
+    @test_throws MethodError clamp(3, UnitRange(1.0,5.0))
+    @test_throws MethodError clamp(3, 1:2:7)
+    @test clamp(3, 1:0) == clamp(3, 1, 0) == 0
+    @test clamp(-3, 1:0) == clamp(-3, 1, 0) == 1
+end
+
 @testset "issue #33882" begin
     r = StepRangeLen('a',2,4)
     @test step(r) === 2

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1638,7 +1638,7 @@ end
         @test clamp(n, 0:4) == clamp(n, 0, 4)
         @test clamp(n, Base.OneTo(5)) == clamp(n, 1, 5)
     end
-    @test clamp(Int32(3), 1:5) == Int(3)
+    @test clamp(Int32(3), 1:5) === Int(3)
     @test clamp(big(typemax(Int))+99, 0:4) == 4
     @test_throws MethodError clamp(3.141, 1:5)
     @test_throws MethodError clamp(3, UnitRange(1.0,5.0))


### PR DESCRIPTION
This might sometimes be convenient. Matches `mod(n, 1:10)` but without wrapping around. 