### PR TITLE
constrain private argument of propertynames to Bool

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1465,7 +1465,7 @@ REPL tab completion on `x.` shows only the `private=false` properties.
 """
 propertynames(x) = fieldnames(typeof(x))
 propertynames(m::Module) = names(m)
-propertynames(x, private) = propertynames(x) # ignore private flag by default
+propertynames(x, private::Bool) = propertynames(x) # ignore private flag by default
 
 """
     hasproperty(x, s::Symbol)


### PR DESCRIPTION
Currently you can write:
```
propertynames(x, "anything you want")
```
and it does not throw an error.

I propose a breaking (but I fell consistent with the docstring) change that `private` positional argument should be forced to be `Bool` by default.

The rationale is that users can be confused that the second positional argument of `propertynames` is allowed but is ignored if it is not `Bool`