### PR TITLE
Fix the performance of `reinterpretarray` with simultaneous reshaping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,8 @@ New library features
 
 * The `redirect_*` functions can now be called on `IOContext` objects.
 * New constructor `NamedTuple(iterator)` that constructs a named tuple from a key-value pair iterator.
+* A new `reinterpret(reshape, T, a::AbstractArray{S})` reinterprets `a` to have eltype `T` while potentially
+  inserting or consuming the first dimension depending on the ratio of `sizeof(T)` and `sizeof(S)`.
 
 Standard library changes
 ------------------------

--- a/base/show.jl
+++ b/base/show.jl
@@ -2562,8 +2562,14 @@ function showarg(io::IO, r::ReshapedArray, toplevel)
     toplevel && print(io, " with eltype ", eltype(r))
 end
 
-function showarg(io::IO, r::ReinterpretArray{T}, toplevel) where {T}
+function showarg(io::IO, r::NonReshapedReinterpretArray{T}, toplevel) where {T}
     print(io, "reinterpret(", T, ", ")
+    showarg(io, parent(r), false)
+    print(io, ')')
+end
+
+function showarg(io::IO, r::ReshapedReinterpretArray{T}, toplevel) where {T}
+    print(io, "reinterpret(reshape, ", T, ", ")
     showarg(io, parent(r), false)
     print(io, ')')
 end

--- a/test/testhelpers/arrayindexingtypes.jl
+++ b/test/testhelpers/arrayindexingtypes.jl
@@ -52,3 +52,15 @@ Base.similar(A::TSlow, ::Type{T}, dims::Dims) where {T} = TSlow(T, dims)
 Base.IndexStyle(::Type{A}) where {A<:TSlow} = IndexCartesian()
 Base.getindex(A::TSlow{T,N}, i::Vararg{Int,N}) where {T,N} = get(A.data, i, zero(T))
 Base.setindex!(A::TSlow{T,N}, v, i::Vararg{Int,N}) where {T,N} = (A.data[i] = v)
+
+# An array type that just passes through to the parent
+struct WrapperArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
+    parent::A
+end
+Base.IndexStyle(::Type{WrapperArray{T,N,A}}) where {T,N,A<:AbstractArray{T,N}} = IndexStyle(A)
+Base.parent(A::WrapperArray) = A.parent
+Base.size(A::WrapperArray) = size(A.parent)
+Base.axes(A::WrapperArray) = axes(A.parent)
+Base.getindex(A::WrapperArray, i::Int...) = A.parent[i...]
+Base.setindex!(A::WrapperArray, v, i::Int...) = A.parent[i...] = v
+Base.similar(A::WrapperArray, ::Type{T}, dims::Dims) where T = similar(A.parent, T, dims)


### PR DESCRIPTION
This introduces `reinterpret(reshape, T, A)`. This adds a dimension when reinterpreting to a smaller element size (e.g., `Tuple{Int,Int}->Int`), removes a dimension when reinterpreting to a bigger element size, and keeps the dimensionality constant when the element size is unchanged.  Here's a demo:
```julia
julia> a = [(1,2), (3,4)]
2-element Vector{Tuple{Int64, Int64}}:
 (1, 2)
 (3, 4)

julia> reinterpret(reshape, Int, a)       # bigger elsize to smaller elsize, adds a dimension
2×2 reinterpret(reshape, Int64, ::Vector{Tuple{Int64, Int64}}):
 1  3
 2  4

julia> b = [1 2; 3 4]
2×2 Matrix{Int64}:
 1  2
 3  4

julia> reinterpret(reshape, Tuple{Int,Int}, b)    # smaller elsize to bigger elsize, removes a dimension
2-element reinterpret(reshape, Tuple{Int64, Int64}, ::Matrix{Int64}):
 (1, 3)
 (2, 4)

julia> c = [1, -1]
2-element Vector{Int64}:
  1
 -1

julia> reinterpret(reshape, UInt, c) # same elsize, no change in dimensionality
2-element reinterpret(reshape, UInt64, ::Vector{Int64}):
 0x0000000000000001
 0xffffffffffffffff
```
Obviously, the first dimension must have size commensurate with the difference in element size.

This scenario is widely used:
- it's used when transitioning between a `Vector` of `SVector`s and a matrix where each vector is on a column
- it's used in splitting and combining color channels in image processing

Unfortunately, since Julia 1.0 the performance of ReinterpretArray has been quite poor in these circumstances. For those who want benchmarks, see https://github.com/JuliaImages/ImageCore.jl/pull/142; the short answer is that the improvements are dramatic, and come close to erasing any difference between the performance of a copy and the view itself (in some cases, even providing performance improvements). The trick here is that LLVM knows the size of the first dimension and so can often unroll the inner loop.

This replaces the strategy I was aiming for in #37290 by reshaping the array. I definitely think this is a better solution (thanks as always @mbauman, who has a gift for brief but incredibly useful suggestions). This is split into two commits: the first is pretty straightforward and, I think, relatively risk-free. The second is much scarier: it attempts to retain the performance advantages of linear indexing when the parent array supports it, but introduces a new `AbstractCartesianIndex` subtype. I *think* I've prevented packages from getting borked by not supporting this index type (see the new `WrappedArray` tests), but there's no doubt that this is the part that deserves the closest scrutiny.

Fixes #28980
Closes #37290
