### PR TITLE
Revert "Improve typesubtract for tuples (#35600)"

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -70,15 +70,6 @@ function typesubtract(@nospecialize(a), @nospecialize(b))
     if isa(a, Union)
         return Union{typesubtract(a.a, b),
                      typesubtract(a.b, b)}
-    elseif a isa DataType
-        if b isa DataType
-            if a.name === b.name === Tuple.name && length(a.types) == length(b.types)
-                ta = switchtupleunion(a)
-                if length(ta) > 1
-                    return typesubtract(Union{ta...}, b)
-                end
-            end
-        end
     end
     return a # TODO: improve this bound?
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2587,47 +2587,6 @@ end
 
 @test map(>:, [Int], [Int]) == [true]
 
-# issue 35566
-module Issue35566
-function step(acc, x)
-    xs, = acc
-    y = x > 0.0 ? x : missing
-    if y isa eltype(xs)
-        ys = push!(xs, y)
-    else
-        ys = vcat(xs, [y])
-    end
-    return (ys,)
-end
-
-function probe(y)
-    if y isa Tuple{Vector{Missing}}
-        return Val(:missing)
-    else
-        return Val(:expected)
-    end
-end
-
-function _foldl_iter(rf, val::T, iter, state) where {T}
-    while true
-        ret = iterate(iter, state)
-        ret === nothing && break
-        x, state = ret
-        y = rf(val, x)
-        if y isa T
-            val = y
-        else
-            return probe(y)
-        end
-    end
-    return Val(:expected)
-end
-
-f() = _foldl_iter(step, (Missing[],), [0.0], 1)
-end
-@test Core.Compiler.typesubtract(Tuple{Union{Int,Char}}, Tuple{Char}) == Tuple{Int}
-@test Base.return_types(Issue35566.f) == [Val{:expected}]
-
 # constant prop through keyword arguments
 _unstable_kw(;x=1,y=2) = x == 1 ? 0 : ""
 _use_unstable_kw_1() = _unstable_kw(x = 2)


### PR DESCRIPTION
Closes #37448, reopens #35566

Uses of `switchtupleunion` need to be guarded in cost (e.g. with `countunionsplit`), while there's currently no practical way to limit this. The inference algorithm assumes that the canonical form is that of `tuplemerge`, and dislikes when we form the switched version implicitly, as it has a higher lattice cost, so it's expected to only appear explicitly.