### PR TITLE
pass correct typeinfo IOContext when showing keys and values in dict

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -85,6 +85,8 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
     if !haskey(io, :compact)
         recur_io = IOContext(recur_io, :compact => true)
     end
+    recur_io_k = IOContext(recur_io, :typeinfo=>keytype(t))
+    recur_io_v = IOContext(recur_io, :typeinfo=>valtype(t))
 
     summary(io, t)
     isempty(t) && return
@@ -105,8 +107,8 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
         vallen = 0
         for (i, (k, v)) in enumerate(t)
             i > rows && break
-            ks[i] = sprint(show, k, context=recur_io, sizehint=0)
-            vs[i] = sprint(show, v, context=recur_io, sizehint=0)
+            ks[i] = sprint(show, k, context=recur_io_k, sizehint=0)
+            vs[i] = sprint(show, v, context=recur_io_v, sizehint=0)
             keylen = clamp(length(ks[i]), keylen, cols)
             vallen = clamp(length(vs[i]), vallen, cols)
         end
@@ -127,7 +129,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
         if limit
             key = rpad(_truncate_at_width_or_chars(ks[i], keylen, "\r\n"), keylen)
         else
-            key = sprint(show, k, context=recur_io, sizehint=0)
+            key = sprint(show, k, context=recur_io_k, sizehint=0)
         end
         print(recur_io, key)
         print(io, " => ")
@@ -136,7 +138,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
             val = _truncate_at_width_or_chars(vs[i], cols - keylen, "\r\n")
             print(io, val)
         else
-            show(recur_io, v)
+            show(recur_io_v, v)
         end
     end
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1387,6 +1387,19 @@ end
 
     d = Dict("+"=>1)
     @test showstr(d) == "Dict(\"+\" => 1)"
+
+    struct Foo
+        a::Int
+    end
+    struct Bar
+        a::Int
+    end
+    d = Dict([Bar(1), Bar(2)] => [Foo(1), Foo(2)])
+    m = string(@__MODULE__)
+    @test showstr(d) == "Dict{Vector{$m.Bar}, Vector{$m.Foo}}([$m.Bar(1), $m.Bar(2)] => [$m.Foo(1), $m.Foo(2)])"
+    @test sprint(show, MIME("text/plain"), d) == """
+        Dict{Vector{$m.Bar}, Vector{$m.Foo}} with 1 entry:
+          [Bar(1), Bar(2)] => [Foo(1), Foo(2)]"""
 end
 
 @testset "alignment for pairs" begin  # (#22899)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1395,10 +1395,9 @@ end
         a::Int
     end
     d = Dict([Bar(1), Bar(2)] => [Foo(1), Foo(2)])
-    m = string(@__MODULE__)
-    @test showstr(d) == "Dict{Vector{$m.Bar}, Vector{$m.Foo}}([$m.Bar(1), $m.Bar(2)] => [$m.Foo(1), $m.Foo(2)])"
+    @test showstr(d) == "Dict{Vector{$(curmod_prefix)Bar}, Vector{$(curmod_prefix)Foo}}([$(curmod_prefix)Bar(1), $(curmod_prefix)Bar(2)] => [$(curmod_prefix)Foo(1), $(curmod_prefix)Foo(2)])"
     @test sprint(show, MIME("text/plain"), d) == """
-        Dict{Vector{$m.Bar}, Vector{$m.Foo}} with 1 entry:
+        Dict{Vector{$(curmod_prefix)Bar}, Vector{$(curmod_prefix)Foo}} with 1 entry:
           [Bar(1), Bar(2)] => [Foo(1), Foo(2)]"""
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/37565.

I'm not really familiar with the display system but seems to work?