### PR TITLE
RFC: handle colors in Dict limit printing

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -1,26 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-function _truncate_at_width_or_chars(str, width, chars="", truncmark="…")
-    truncwidth = textwidth(truncmark)
-    (width <= 0 || width < truncwidth) && return ""
-
-    wid = truncidx = lastidx = 0
-    for (idx, c) in pairs(str)
-        lastidx = idx
-        wid += textwidth(c)
-        wid >= width - truncwidth && truncidx == 0 && (truncidx = lastidx)
-        (wid >= width || c in chars) && break
-    end
-
-    lastidx != 0 && str[lastidx] in chars && (lastidx = prevind(str, lastidx))
-    truncidx == 0 && (truncidx = lastidx)
-    if lastidx < lastindex(str)
-        return String(SubString(str, 1, truncidx) * truncmark)
-    else
-        return String(str)
-    end
-end
-
 function show(io::IO, t::AbstractDict{K,V}) where V where K
     recur_io = IOContext(io, :SHOWN_SET => t,
                              :typeinfo => eltype(t))

--- a/base/show.jl
+++ b/base/show.jl
@@ -47,6 +47,58 @@ end
 show(io::IO, ::MIME"text/plain", c::ComposedFunction) = show(io, c)
 show(io::IO, ::MIME"text/plain", c::Returns) = show(io, c)
 
+const ansi_regex = r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])"
+# An iterator similar to `pairs` but skips over "tokens" corresponding to
+# ansi sequences
+struct IgnoreAnsiIterator
+    captures::Base.RegexMatchIterator
+end
+IgnoreAnsiIterator(s::AbstractString) =
+    IgnoreAnsiIterator(eachmatch(ansi_regex, s))
+
+Base.IteratorSize(::Type{IgnoreAnsiIterator}) = Base.SizeUnknown()
+function iterate(I::IgnoreAnsiIterator, (i, m_st)=(1, iterate(I.captures)))
+    # Advance until the next non ansi sequence
+    if m_st !== nothing
+        m, j = m_st
+        if m.offset == i
+            i += sizeof(m.match)
+            return iterate(I, (i, iterate(I.captures, j)))
+        end
+    end
+    ci = iterate(I.captures.string, i)
+    ci === nothing && return nothing
+    i_prev = i
+    (c, i) = ci
+    return (i_prev => c), (i, m_st)
+end
+
+function _truncate_at_width_or_chars(io::IO, str, width, chars="", truncmark="…")
+    truncwidth = textwidth(truncmark)
+    (width <= 0 || width < truncwidth) && return ""
+    wid = truncidx = lastidx = 0
+    color = get(io, :color, false) && match(ansi_regex, str) !== nothing
+    color && (truncmark = "\e[0m" * truncmark)
+    I = color ? IgnoreAnsiIterator(str) : pairs(str)
+    for (_lastidx, c) in I
+        lastidx = _lastidx
+        wid += textwidth(c)
+        if wid >= (width - truncwidth) && truncidx == 0
+            truncidx = lastidx
+        end
+        (wid >= width || c in chars) && break
+    end
+    if lastidx != 0 && str[lastidx] in chars
+        lastidx = prevind(str, lastidx)
+    end
+    truncidx == 0 && (truncidx = lastidx)
+    if lastidx < lastindex(str)
+        return String(SubString(str, 1, truncidx) * truncmark)
+    else
+        return String(str)
+    end
+end
+
 function show(io::IO, ::MIME"text/plain", iter::Union{KeySet,ValueIterator})
     isempty(iter) && get(io, :compact, false) && return show(io, iter)
     summary(io, iter)
@@ -70,7 +122,7 @@ function show(io::IO, ::MIME"text/plain", iter::Union{KeySet,ValueIterator})
 
         if limit
             str = sprint(show, v, context=io, sizehint=0)
-            str = _truncate_at_width_or_chars(str, cols, "\r\n")
+            str = _truncate_at_width_or_chars(io, str, cols, "\r\n")
             print(io, str)
         else
             show(io, v)
@@ -128,7 +180,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
         end
 
         if limit
-            key = rpad(_truncate_at_width_or_chars(ks[i], keylen, "\r\n"), keylen)
+            key = rpad(_truncate_at_width_or_chars(recur_io, ks[i], keylen, "\r\n"), keylen)
         else
             key = sprint(show, k, context=recur_io_k, sizehint=0)
         end
@@ -136,7 +188,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
         print(io, " => ")
 
         if limit
-            val = _truncate_at_width_or_chars(vs[i], cols - keylen, "\r\n")
+            val = _truncate_at_width_or_chars(recur_io, vs[i], cols - keylen, "\r\n")
             print(io, val)
         else
             show(recur_io_v, v)
@@ -180,7 +232,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractSet{T}) where T
 
         if limit
             str = sprint(show, v, context=recur_io, sizehint=0)
-            print(io, _truncate_at_width_or_chars(str, cols, "\r\n"))
+            print(io, _truncate_at_width_or_chars(io, str, cols, "\r\n"))
         else
             show(recur_io, v)
         end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -368,6 +368,26 @@ end
     close(io)
 end
 
+
+struct RainBowString
+    s::String
+end
+
+function Base.show(io::IO, rbs::RainBowString)
+    for s in rbs.s
+        _, color = rand(Base.text_colors)
+        print(io, color, s, "\e[0m")
+    end
+end
+
+@testset "Display with colors" begin
+    d = Dict([randstring(8) => [RainBowString(randstring(8)) for i in 1:10] for j in 1:5]...)
+    str = sprint(io -> show(io, MIME("text/plain"), d); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
+    lines = split(str, '\n')
+    @test all(endswith('…'), lines[2:end])
+    @test all(x -> length(x) > 100, lines[2:end])
+end
+
 @testset "Issue #15739" begin # Compact REPL printouts of an `AbstractDict` use brackets when appropriate
     d = Dict((1=>2) => (3=>45), (3=>10) => (10=>11))
     buf = IOBuffer()
@@ -1259,3 +1279,19 @@ end
     sizehint!(d, 10)
     @test length(d.slots) < 100
 end
+
+using Random
+
+struct RainBowString
+    s::String
+end
+
+function Base.show(io::IO, rbs::RainBowString)
+    for s in rbs.s
+        _, color = rand(Base.text_colors)
+        print(io, color, s, "\e[0m")
+    end
+end
+
+
+d = Dict([randstring(8) => [RainBowString(randstring(8)) for i in 1:10] for j in 1:5]...)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1279,19 +1279,3 @@ end
     sizehint!(d, 10)
     @test length(d.slots) < 100
 end
-
-using Random
-
-struct RainBowString
-    s::String
-end
-
-function Base.show(io::IO, rbs::RainBowString)
-    for s in rbs.s
-        _, color = rand(Base.text_colors)
-        print(io, color, s, "\e[0m")
-    end
-end
-
-
-d = Dict([randstring(8) => [RainBowString(randstring(8)) for i in 1:10] for j in 1:5]...)


### PR DESCRIPTION
When a dictionary prints values compactly, it cuts off the values after a certain number of characters and writes a couple of dots. In presence of colors, this doesn't work properly, because the computation of the width of the line will be wrong, and the printer might cut off the printing in the middle of the color sequence, corrupting the terminal color state. As an example, the following code

```jl
using Random

struct RainBowString
    s::String
end

function Base.show(io::IO, rbs::RainBowString)
    for s in rbs.s
        _, color = rand(Base.text_colors)
        print(io, color, s, "\e[0m")
    end
end


d = Dict([randstring(8) => [RainBowString(randstring(8)) for i in 1:10] for j in 1:5]...)
```

now shows in the REPL as

![Screenshot-20200914144516-606x195](https://user-images.githubusercontent.com/1282691/93095130-0445b200-f6a3-11ea-8071-796b049d74d4.png)

with this PR, it shows as:

![Screenshot-20200914144438-784x148](https://user-images.githubusercontent.com/1282691/93095148-09a2fc80-f6a3-11ea-9de4-3ec1d5f827e3.png)

The original reason for making this PR is that I made some struct print with color but then it printed as:

![Screenshot-20200914144907-881x613](https://user-images.githubusercontent.com/1282691/93094846-b92b9f00-f6a2-11ea-98b5-c4f3b8503b50.png)

With this PR, it prints as:
![Screenshot-20200914144854-917x617](https://user-images.githubusercontent.com/1282691/93094817-ae710a00-f6a2-11ea-83ed-95054ee880cf.png)

Marking as RFC because I don't know if we want to deal with colors inside containers in the display system outside of `MIME("text/plain")`.
Haven't added tests yet because they are annoying to write and want to see that people are ok with this first.



Fixes https://github.com/JuliaLang/julia/issues/44718