### PR TITLE
fix #37558, allow optimizing calls to functions that throw

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -269,7 +269,7 @@ function find_throw_blocks(code::Vector{Any}, ir = RefValue{IRCode}())
                     push!(stmts, i)
                 end
             elseif s.head === :return
-            elseif is_throw_call(s) || s.head === :unreachable
+            elseif is_throw_call(s)
                 if try_depth == 0
                     push!(stmts, i)
                 end
@@ -277,9 +277,9 @@ function find_throw_blocks(code::Vector{Any}, ir = RefValue{IRCode}())
                 push!(stmts, i)
             end
         elseif isa(s, ReturnNode)
-            if try_depth == 0 && !isdefined(s, :val)
-                push!(stmts, i)
-            end
+            # NOTE: it potentially makes sense to treat unreachable nodes
+            # (where !isdefined(s, :val)) as `throw` points, but that can cause
+            # worse codegen around the call site (issue #37558)
         elseif isa(s, GotoNode)
             tgt = s.label
             if isassigned(ir)

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -101,12 +101,12 @@ Each statement gets analyzed for its total cost in a function called
 as follows:
 ```jldoctest; filter=r"tuple.jl:\d+"
 julia> Base.print_statement_costs(stdout, map, (typeof(sqrt), Tuple{Int},)) # map(sqrt, (2,))
-map(f, t::Tuple{Any}) in Base at tuple.jl:169
+map(f, t::Tuple{Any}) in Base at tuple.jl:179
   0 1 ─ %1  = Base.getfield(_3, 1, true)::Int64
   1 │   %2  = Base.sitofp(Float64, %1)::Float64
   2 │   %3  = Base.lt_float(%2, 0.0)::Bool
   0 └──       goto #3 if not %3
-  0 2 ─       Base.Math.throw_complex_domainerror(:sqrt, %2)::Union{}
+  0 2 ─       invoke Base.Math.throw_complex_domainerror(:sqrt::Symbol, %2::Float64)::Union{}
   0 └──       unreachable
  20 3 ─ %7  = Base.Math.sqrt_llvm(%2)::Float64
   0 └──       goto #4


### PR DESCRIPTION
This gives up a tiny bit of latency, but I suspect it's worth it to avoid inserting avoidable GC frames. Comparing against  8320fcc7d90ad2523a8f3a3410e7e2d6ac1aa1bf (the commit that introduced `find_throw_blocks`) as a baseline, this change adds ~2% to the TTFP. On master, it actually reduces the time to precompile Plots.jl by ~2% (don't know TTFP since it doesn't work currently). So overall the latency cost looks minimal.