### PR TITLE
inference: fix bitcast nothrow computation

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2811,3 +2811,10 @@ f_apply_cglobal(args...) = cglobal(args...)
 @test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Vararg{Type{Int}}}) == Ptr
 @test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Type{Int}, Vararg{Type{Int}}}) == Ptr{Int}
 @test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Type{Int}, Type{Int}, Vararg{Type{Int}}}) == Union{}
+
+# issue #37532
+@test Core.Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr{Int}}, Int])
+@test Core.Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr{T}} where T, Ptr])
+@test !Core.Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr}, Ptr])
+f37532(T, x) = (Core.bitcast(Ptr{T}, x); x)
+@test Base.return_types(f37532, Tuple{Any, Int}) == Any[Int]


### PR DESCRIPTION
Attempted fix for #37532

This was suggested in one of the issue comments there, but also fails one of my added tests. There's also a bit of a problem with 7466d1168ea that may be relevant here: most users of this function aren't actually enforcing the constraint at runtime that's assumed by that PR. We should fix that too, so that the PR there is only relevant to the call to this function where that applies. I mention this here, since it may change how we want to define `isexact` for the different sorts of callers.