### PR TITLE
dump: ensure Array eltype layout is initialized early

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -97,6 +97,9 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     t->isinlinealloc = 0;
     t->has_concrete_subtype = 1;
     t->cached_by_hash = 0;
+    t->name = NULL;
+    t->super = NULL;
+    t->parameters = NULL;
     t->layout = NULL;
     t->names = NULL;
     t->types = NULL;


### PR DESCRIPTION
Deserializing an array needs to examine the element type (tparam0) layout. Usually we know the layout of a DataType is initialized early (when present). This also ensures that the path to it is initialized (for our case where it may be inline allocated with interior pointers).

Reported https://github.com/JuliaLang/julia/commit/4c805d2310111d65dbff9ac96d475dd6b9ea47cc#comments by @KristofferC 