### PR TITLE
[BinaryPlatforms]: Add dict-like adapter for `Platform` objects

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -135,7 +135,7 @@ tags(p::Platform) = p.tags
 # Make it act more like a dict
 Base.getindex(p::AbstractPlatform, k::String) = getindex(tags(p), k)
 Base.haskey(p::AbstractPlatform, k::String) = haskey(tags(p), k)
-Base.setindex!(p::AbstractPlatform, v::String, k::String) = setindex!(tags(p), v, k)
+Base.setindex!(p::AbstractPlatform, v::String, k::String) = (setindex!(tags(p), v, k); p)
 
 # Allow us to easily serialize Platform objects
 function Base.repr(p::Platform; context=nothing)

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -131,7 +131,11 @@ end
 
 # Other `Platform` types can override this (I'm looking at you, `AnyPlatform`)
 tags(p::Platform) = p.tags
+
+# Make it act more like a dict
+Base.getindex(p::AbstractPlatform, k::String) = getindex(tags(p), k)
 Base.haskey(p::AbstractPlatform, k::String) = haskey(tags(p), k)
+Base.setindex!(p::AbstractPlatform, v::String, k::String) = setindex!(tags(p), v, k)
 
 # Allow us to easily serialize Platform objects
 function Base.repr(p::Platform; context=nothing)

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -106,6 +106,15 @@ end
     @test all(haskey.(Ref(t), ("arch", "os", "libc")))
     @test haskey(tags(P("x86_64", "linux"; customtag="foo")), "customtag")
     @test tags(HostPlatform())["julia_version"] == string(VERSION.major, ".", VERSION.minor, ".", VERSION.patch)
+
+    # Test that we can modify tags at will using the dict-like interface:
+    p = P("x86_64", "linux")
+    p["foo"] = "bar"
+    @test tags(p)["foo"] == "bar"
+    @test p["foo"] == "bar"
+    @test p["os"] == "linux"
+    p["os"] = "JuliaOS"
+    @test p["os"] == "JuliaOS"
 end
 
 @testset "Triplet parsing" begin


### PR DESCRIPTION
This will make it a little bit easier to modify `Platform` objects