### PR TITLE
fix an invalidation source in the TOML parser

### DIFF
--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -660,13 +660,13 @@ function push!!(v::Vector, el)
         return v
     else
         if typeof(T) === Union
-            newT = Base.typejoin(T, typeof(el))
+            newT = Any
         else
             newT = Union{T, typeof(el)}
         end
         new = Array{newT}(undef, length(v))
         copy!(new, v)
-        return push!!(new, el)
+        return push!(new, el)
     end
 end
 


### PR DESCRIPTION
Previously, we invalidated a lot from going down into `typejoin` with bad type information. This is completely unnecessary since, by virtue of the types we can actually parse, it will always evaluate to `Any`.