### PR TITLE
fix some invalidations in rpad/lpad

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -304,14 +304,15 @@ julia> lpad("March", 10)
 "     March"
 ```
 """
-lpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') = lpad(string(s), n, string(p))
+lpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') = lpad(string(s)::AbstractString, n, string(p))
 
 function lpad(
     s::Union{AbstractChar,AbstractString},
     n::Integer,
     p::Union{AbstractChar,AbstractString}=' ',
 ) :: String
-    m = signed(n) - length(s)
+    n = Int(n)::Int
+    m = signed(n) - Int(length(s))::Int
     m ≤ 0 && return string(s)
     l = length(p)
     q, r = divrem(m, l)
@@ -331,14 +332,15 @@ julia> rpad("March", 20)
 "March               "
 ```
 """
-rpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') = rpad(string(s), n, string(p))
+rpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') = rpad(string(s)::AbstractString, n, string(p))
 
 function rpad(
     s::Union{AbstractChar,AbstractString},
     n::Integer,
     p::Union{AbstractChar,AbstractString}=' ',
 ) :: String
-    m = signed(n) - length(s)
+    n = Int(n)::Int
+    m = signed(n) - Int(length(s))::Int
     m ≤ 0 && return string(s)
     l = length(p)
     q, r = divrem(m, l)


### PR DESCRIPTION
These are often called with imprecise type information. Prevent inference from going down the rabbit hole too much.