### PR TITLE
fix an inference failure in full_va_len

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -142,7 +142,7 @@ function full_va_len(p)
     if isvarargtype(last)
         N = unwrap_unionall(last).parameters[2]
         if isa(N, Integer)
-            return length(p)::Int + Int(N) - 1, true
+            return length(p)::Int + Int(N)::Int - 1, true
         end
         return length(p)::Int, false
     end

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -141,8 +141,8 @@ function full_va_len(p)
     last = p[end]
     if isvarargtype(last)
         N = unwrap_unionall(last).parameters[2]
-        if isa(N, Integer)
-            return length(p)::Int + Int(N)::Int - 1, true
+        if isa(N, Int)
+            return length(p)::Int + N - 1, true
         end
         return length(p)::Int, false
     end


### PR DESCRIPTION
This stops inferring when we have loaded enough packages that `Int(n::Integer)` no longer infers (which happens to be `Plots`:.

```
julia> methods(Int, (Integer,))
# 5 methods for type constructor:
[1] (::Type{T})(x::BigInt) where T<:Union{Int128, Int16, Int32, Int64, Int8} in Base.GMP at gmp.jl:356
[2] (::Type{IT})(x::GeometryBasics.OffsetInteger) where IT<:Integer in GeometryBasics at /home/kc/.julia/packages/GeometryBasics/L1NZA/src/offsetintegers.jl:37
[3] (::Type{IT})(x::GeometryTypes.OffsetInteger{O, T}) where {IT<:Integer, O, T<:Integer} in GeometryTypes at /home/kc/.julia/packages/GeometryTypes/gpBFp/src/faces.jl:15
[4] Int64(x::Union{Bool, Int32, Int64, UInt32, UInt64, UInt8, Int128, Int16, Int8, UInt128, UInt16}) in Core at boot.jl:737
[5] (::Type{T})(x::T) where T<:Number in Core at boot.jl:745
```

The inference failure here caused many things to invalidate.
