### PR TITLE
remove call to `find_throw_blocks` in inlining

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1145,11 +1145,7 @@ end
 function assemble_inline_todo!(ir::IRCode, state::InliningState)
     # todo = (inline_idx, (isva, isinvoke, na), method, spvals, inline_linetable, inline_ir, lie)
     todo = Pair{Int, Any}[]
-    if state.params.unoptimize_throw_blocks
-        skip = find_throw_blocks(ir.stmts.inst, RefValue(ir))
-    end
     for idx in 1:length(ir.stmts)
-        state.params.unoptimize_throw_blocks && idx in skip && continue
         r = process_simple!(ir, todo, idx, state)
         r === nothing && continue
 


### PR DESCRIPTION
This should now be handled by statement info. I can confirm removing this has a negligible effect. We will now do the process_simple cases for these, but I doubt that has much cost.