### PR TITLE
[Artifacts]: Add support for Pkg platform augmentation hook

### DIFF
--- a/stdlib/Artifacts/Project.toml
+++ b/stdlib/Artifacts/Project.toml
@@ -3,6 +3,7 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [targets]
-test = ["Test"]
+test = ["Test", "TOML"]

--- a/stdlib/Artifacts/test/hook_testing/.pkg/platform_augmentation_hook.jl
+++ b/stdlib/Artifacts/test/hook_testing/.pkg/platform_augmentation_hook.jl
@@ -1,0 +1,5 @@
+using Base.BinaryPlatforms
+function hook(p::Platform)
+    p["foo"] = get(ENV, "PLATAUG_VAL", "bar")
+    return p
+end

--- a/stdlib/Artifacts/test/hook_testing/hook_testing.jl
+++ b/stdlib/Artifacts/test/hook_testing/hook_testing.jl
@@ -1,0 +1,10 @@
+using Artifacts
+
+function get_artifact_compiletime()
+    return artifact"arty"
+end
+
+function get_artifact_runtime()
+    name = "arty"
+    return @artifact_str(name)
+end


### PR DESCRIPTION
Pkg will soon have the ability to augment `Platform` objects with a hook
at `Pkg.add()` time; for convenience, we will have our own `Artifacts`
machinery pick up the same hook inside the `@artifact_str` macro.

X-ref: https://github.com/JuliaLang/Pkg.jl/pull/2024