### PR TITLE
Use logo in readme from within the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a name="logo"/>
 <div align="center">
 <a href="https://julialang.org/" target="_blank">
-<img src="https://julialang.org/images/logo_hires.png" alt="Julia Logo" width="210" height="142"></img>
+<img src="doc/src/assets/logo.svg" alt="Julia Logo" width="210" height="142"></img>
 </a>
 </div>
 


### PR DESCRIPTION
We were loading the logo from the www.julialang.org website.
Apparently that logo moved or something tas the link is now broken.

We have a copy of the logo inside the repo already.
For sake of being self-contained and making this less likely to occur in future
maybe it is better to just refer to that?