### PR TITLE
Fix bug when inlining pending nodes

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -112,12 +112,12 @@ function inline_into_block!(state::CFGInliningState, block::Int)
     return
 end
 
-function cfg_inline_item!(idx::Int, spec::ResolvedInliningSpec, state::CFGInliningState, from_unionsplit::Bool=false)
+function cfg_inline_item!(ir::IRCode, idx::Int, spec::ResolvedInliningSpec, state::CFGInliningState, from_unionsplit::Bool=false)
     inlinee_cfg = spec.ir.cfg
     # Figure out if we need to split the BB
     need_split_before = false
     need_split = true
-    block = block_for_inst(state.cfg, idx)
+    block = block_for_inst(ir, idx)
     inline_into_block!(state, block)
 
     if !isempty(inlinee_cfg.blocks[1].preds)
@@ -206,8 +206,8 @@ function cfg_inline_item!(idx::Int, spec::ResolvedInliningSpec, state::CFGInlini
     end
 end
 
-function cfg_inline_unionsplit!(idx::Int, item::UnionSplit, state::CFGInliningState)
-    block = block_for_inst(state.cfg, idx)
+function cfg_inline_unionsplit!(ir::IRCode, idx::Int, item::UnionSplit, state::CFGInliningState)
+    block = block_for_inst(ir, idx)
     inline_into_block!(state, block)
     from_bbs = Int[]
     delete!(state.split_targets, length(state.new_cfg_blocks))
@@ -223,7 +223,7 @@ function cfg_inline_unionsplit!(idx::Int, item::UnionSplit, state::CFGInliningSt
         if isa(case, InliningTodo)
             spec = case.spec::ResolvedInliningSpec
             if !spec.linear_inline_eligible
-                cfg_inline_item!(idx, spec, state, true)
+                cfg_inline_item!(ir, idx, spec, state, true)
             end
         end
         bb = length(state.new_cfg_blocks)
@@ -501,13 +501,13 @@ function batch_inline!(todo::Vector{Pair{Int, Any}}, ir::IRCode, linetable::Vect
     state = CFGInliningState(ir)
     for (idx, item) in todo
         if isa(item, UnionSplit)
-            cfg_inline_unionsplit!(idx, item::UnionSplit, state)
+            cfg_inline_unionsplit!(ir, idx, item::UnionSplit, state)
         else
             item = item::InliningTodo
             spec = item.spec::ResolvedInliningSpec
             # A linear inline does not modify the CFG
             spec.linear_inline_eligible && continue
-            cfg_inline_item!(idx, spec, state, false)
+            cfg_inline_item!(ir, idx, spec, state, false)
         end
     end
     finish_cfg_inline!(state)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -272,6 +272,13 @@ struct IRCode
         copy(ir.linetable), copy(ir.cfg), copy(ir.new_nodes), copy(ir.meta))
 end
 
+function block_for_inst(ir::IRCode, inst::Int)
+    if inst > length(ir.stmts)
+        inst = ir.new_nodes.info[inst - length(ir.stmts)].pos
+    end
+    block_for_inst(ir.cfg, inst)
+end
+
 function getindex(x::IRCode, s::SSAValue)
     if s.id <= length(x.stmts)
         return x.stmts[s.id][:inst]

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -307,3 +307,11 @@ let ci = code_typed(f_29115, Tuple{Pair{Int64, Int64}})[1].first
     @test length(ci.code) == 4 && isexpr(ci.code[1], :call) &&
         ci.code[end-1].args[1] === GlobalRef(Core, :tuple)
 end
+
+# Issue #37182 & #37555 - Inlining of pending nodes
+function f37555(x::Int; kwargs...)
+    @assert x < 10
+    +(x, kwargs...)
+end
+@test f37555(1) == 1
+


### PR DESCRIPTION
While working on IR, we give pending nodes SSA ids after the main
body of the function, and then we drop them in place during compaction.
Inlining was using thse IDs to try to determine which basic block
we're currently inlining into, but for pending blocks it was looking
at the raw ID rather than the insertion position, corrupting the CFG.

Fixes #37555
Fixes #37182