### PR TITLE
fix #37610, allow constant prop on signatures with unions

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -133,10 +133,16 @@ function switchtupleunion(@nospecialize(ty))
     return _switchtupleunion(Any[tparams...], length(tparams), [], ty)
 end
 
+switchtupleunion(t::Vector{Any}) = _switchtupleunion(t, length(t), [], nothing)
+
 function _switchtupleunion(t::Vector{Any}, i::Int, tunion::Vector{Any}, @nospecialize(origt))
     if i == 0
-        tpl = rewrap_unionall(Tuple{t...}, origt)
-        push!(tunion, tpl)
+        if origt === nothing
+            push!(tunion, t)
+        else
+            tpl = rewrap_unionall(Tuple{t...}, origt)
+            push!(tunion, tpl)
+        end
     else
         ti = t[i]
         if isa(ti, Union)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -114,7 +114,7 @@ firstindex(t::NamedTuple) = 1
 lastindex(t::NamedTuple) = nfields(t)
 getindex(t::NamedTuple, i::Int) = getfield(t, i)
 getindex(t::NamedTuple, i::Symbol) = getfield(t, i)
-indexed_iterate(t::NamedTuple, i::Int, state=1) = (getfield(t, i), i+1)
+indexed_iterate(t::NamedTuple, i::Int, state=1) = (@_inline_meta; (getfield(t, i), i+1))
 isempty(::NamedTuple{()}) = true
 isempty(::NamedTuple) = false
 empty(::NamedTuple) = NamedTuple()

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -47,7 +47,7 @@ Pair, =>
 
 eltype(p::Type{Pair{A, B}}) where {A, B} = Union{A, B}
 iterate(p::Pair, i=1) = i > 2 ? nothing : (getfield(p, i), i + 1)
-indexed_iterate(p::Pair, i::Int, state=1) = (getfield(p, i), i + 1)
+indexed_iterate(p::Pair, i::Int, state=1) = (@_inline_meta; (getfield(p, i), i + 1))
 
 hash(p::Pair, h::UInt) = hash(p.second, hash(p.first, h))
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -554,7 +554,7 @@ function alloc_request(buffer::IOBuffer, recommended_size::UInt)
     ensureroom(buffer, Int(recommended_size))
     ptr = buffer.append ? buffer.size + 1 : buffer.ptr
     nb = min(length(buffer.data), buffer.maxsize) - ptr + 1
-    return (pointer(buffer.data, ptr), nb)
+    return (Ptr{Cvoid}(pointer(buffer.data, ptr)), nb)
 end
 
 notify_filled(buffer::IOBuffer, nread::Int, base::Ptr{Cvoid}, len::UInt) = notify_filled(buffer, nread)

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -367,7 +367,7 @@ function recvfrom(sock::UDPSocket)
     end
 end
 
-alloc_buf_hook(sock::UDPSocket, size::UInt) = (Libc.malloc(size), size) # size is always 64k from libuv
+alloc_buf_hook(sock::UDPSocket, size::UInt) = (Libc.malloc(size), Int(size)) # size is always 64k from libuv
 
 function uv_recvcb(handle::Ptr{Cvoid}, nread::Cssize_t, buf::Ptr{Cvoid}, addr::Ptr{Cvoid}, flags::Cuint)
     sock = @handle_as handle UDPSocket

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2813,3 +2813,14 @@ f_apply_cglobal(args...) = cglobal(args...)
 @test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Vararg{Type{Int}}}) == Ptr
 @test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Type{Int}, Vararg{Type{Int}}}) == Ptr{Int}
 @test Core.Compiler.return_type(f_apply_cglobal, Tuple{Any, Type{Int}, Type{Int}, Vararg{Type{Int}}}) == Union{}
+
+# issue #37610
+function f37610(a, i)
+    y = iterate(a, i)
+    if y !== nothing
+        (k, v), st = y
+        return k, v
+    end
+    return y
+end
+@test Base.return_types(f37610, (typeof(("foo" => "bar", "baz" => nothing)), Int)) == Any[Union{Nothing, Tuple{String, Union{Nothing, String}}}]


### PR DESCRIPTION
Constant prop looks at `nonbot` (# of non-Bottom-returning method signatures) to determine whether there is only one match. If we split Union types though, there appears to be more than one, so we don't do constant prop, which is the source of the issue. This fixes it by also splitting the `argtypes` array that includes constant information, and still constant prop'ing as long as there is only one actual method match. I have not seen any measurable latency impact so far.

I added inline declarations to some indexed_iterate methods for good measure, though it is not really necessary to fix this.

While working on this I noticed that the two methods of `alloc_buf_hook` returned spuriously different types, so I changed them to consistently return `Ptr{Cvoid}, Int`. I'm totally indifferent as to whether we return `Ptr{UInt8}, UInt` instead though if anybody prefers that :joy: 

fix #37610