### PR TITLE
fix escaping in testset with options

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1237,7 +1237,7 @@ function parse_testset_args(args)
         elseif isa(arg, Expr) && arg.head === :(=)
             # we're building up a Dict literal here
             key = Expr(:quote, arg.args[1])
-            push!(options.args, Expr(:call, :(=>), key, arg.args[2]))
+            push!(options.args, Expr(:call, :(=>), key, esc(arg.args[2])))
         else
             error("Unexpected argument $arg to @testset")
         end

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -566,6 +566,13 @@ for i in 1:6
     @test typeof(tss[i].results[4].results[1]) == (iseven(i) ? Pass : Fail)
 end
 
+# test that second argument is escaped correctly
+foo = 3
+tss = @testset CustomTestSet foo=foo "custom testset - escaping" begin
+    @test true
+end
+@test tss.foo == 3
+
 # test @inferred
 uninferrable_function(i) = (1, "1")[i]
 uninferrable_small_union(i) = (1, nothing)[i]


### PR DESCRIPTION
Because the options passed to a custom testset are not escaped correctly, Jute.jl relies on #37540 to trick macro hygiene: 
https://github.com/fjarri/Jute.jl/blob/2e322e800ed10eef149da010ab79676926b0071b/src/run_testcase.jl#L140
This should fix 5 of the PkgEval failures in #37573.