### PR TITLE
Recursively check wrapper arrays for issparse

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -130,6 +130,7 @@ Standard library changes
 #### SparseArrays
 
 * Display large sparse matrices with a Unicode "spy" plot of their nonzero patterns, and display small sparse matrices by an `Matrix`-like 2d layout of their contents.
+* `issparse` now applies consistently to all wrapper arrays, including nested, by checking `issparse` on the wrapped parent array ([#37644]).
 
 #### Dates
 * `Quarter` period is defined ([#35519]).

--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -50,17 +50,19 @@ julia> issparse(Array(sv))
 false
 ```
 """
-issparse(A::AbstractArray) = false
+function issparse(A::AbstractArray)
+    # Handle wrapper arrays: sparse if it is wrapping a sparse array.
+    # This gets compiled away during specialization.
+    p = parent(A)
+    if p === A
+        # have reached top of wrapping without finding a sparse array, assume it is not.
+        return false
+    else
+        return issparse(p)
+    end
+end
+issparse(A::DenseArray) = false
 issparse(S::AbstractSparseArray) = true
-issparse(S::LinearAlgebra.Adjoint{<:Any,<:AbstractSparseArray}) = true
-issparse(S::LinearAlgebra.Transpose{<:Any,<:AbstractSparseArray}) = true
-
-issparse(S::LinearAlgebra.Symmetric{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.Hermitian{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.LowerTriangular{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.UnitLowerTriangular{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.UpperTriangular{<:Any,<:AbstractSparseMatrix}) = true
-issparse(S::LinearAlgebra.UnitUpperTriangular{<:Any,<:AbstractSparseMatrix}) = true
 
 indtype(S::AbstractSparseArray{<:Any,Ti}) where {Ti} = Ti
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2114,6 +2114,11 @@ end
     @test issparse(LinearAlgebra.UnitLowerTriangular(Array(m))) == false
     @test issparse(UpperTriangular(Array(m))) == false
     @test issparse(LinearAlgebra.UnitUpperTriangular(Array(m))) == false
+    @test issparse(Base.ReshapedArray(m, (20, 5), ()))
+
+    # greater nesting
+    @test issparse(Symmetric(UpperTriangular(m)))
+    @test issparse(Symmetric(UpperTriangular(Array(m)))) == false
 end
 
 @testset "issparse for sparse vectors #34253" begin


### PR DESCRIPTION
Do we want this?
I don't know.
What does it mean to be `issparse`? 
I haven't seen a defination of an interface that must be furfilled.

Possibly all people want this for is to know if they have some algorthm that really won't run great on a sparse array, then they could issue a warning or run `collect` to make it dense.

`issparse` compiles away.

```
julia> @code_llvm debuginfo=:none issparse(Transpose(Base.ReshapedArray(Symmetric(m), (20, 5), ())))

define i8 @julia_issparse_2137([1 x { { { i64, i64, {}*, {}*, {}* }, i32 }, [2 x i64] }]* nocapture nonnull readonly align 8 dereferenceable(64)) {
top:
  ret i8 1
}

julia> @code_llvm debuginfo=:none issparse(Transpose(Base.ReshapedArray(Symmetric(Array(m)), (20, 5), ())))

define i8 @julia_issparse_2139([1 x { { {}*, i32 }, [2 x i64] }]* nocapture nonnull readonly align 8 dereferenceable(32)) {
top:
  ret i8 0
}
```