### PR TITLE
Support indexing with generators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -92,7 +92,7 @@ New library features
 * New constructor `NamedTuple(iterator)` that constructs a named tuple from a key-value pair iterator.
 * A new `reinterpret(reshape, T, a::AbstractArray{S})` reinterprets `a` to have eltype `T` while potentially
   inserting or consuming the first dimension depending on the ratio of `sizeof(T)` and `sizeof(S)`.
-* Generators support `getindex`, `firstindex`, and `lastindex` if indexing is supported by the underlying iterator ([#37648]).
+* Generators support `getindex` when the underlying iterator is a subtype of `AbstractArray` ([#37648]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -92,7 +92,7 @@ New library features
 * New constructor `NamedTuple(iterator)` that constructs a named tuple from a key-value pair iterator.
 * A new `reinterpret(reshape, T, a::AbstractArray{S})` reinterprets `a` to have eltype `T` while potentially
   inserting or consuming the first dimension depending on the ratio of `sizeof(T)` and `sizeof(S)`.
-* Generators support `getindex` when the underlying iterator is a subtype of `AbstractArray` ([#37648]).
+* Generators support `getindex`, `firstindex`, and `lastindex` ([#37648]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -92,6 +92,7 @@ New library features
 * New constructor `NamedTuple(iterator)` that constructs a named tuple from a key-value pair iterator.
 * A new `reinterpret(reshape, T, a::AbstractArray{S})` reinterprets `a` to have eltype `T` while potentially
   inserting or consuming the first dimension depending on the ratio of `sizeof(T)` and `sizeof(S)`.
+* Generators support `getindex`, `firstindex`, and `lastindex` if indexing is supported by the underlying iterator ([#37648]).
 
 Standard library changes
 ------------------------

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -52,6 +52,20 @@ size(g::Generator) = size(g.iter)
 axes(g::Generator) = axes(g.iter)
 ndims(g::Generator) = ndims(g.iter)
 
+function getindex(g::Generator{<:AbstractArray}, I...)
+    I′ = to_indices(g.iter, I)
+    subset = g.iter[I′...]
+    if isempty(index_shape(I′...))
+        g.f(subset)
+    else
+        map(g.f, subset)
+    end
+end
+
+getindex(g::Generator, I...) = collect(g)[I...]
+
+firstindex(g::Generator) = firstindex(g.iter)
+lastindex(g::Generator) = lastindex(g.iter)
 
 ## iterator traits
 

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -62,8 +62,6 @@ function getindex(g::Generator{<:AbstractArray}, I...)
     end
 end
 
-getindex(g::Generator, I...) = collect(g)[I...]
-
 firstindex(g::Generator) = firstindex(g.iter)
 lastindex(g::Generator) = lastindex(g.iter)
 

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -62,6 +62,16 @@ function getindex(g::Generator{<:AbstractArray}, I...)
     end
 end
 
+function getindex(g::Generator, I...)
+    A = collect(g.iter)
+    subset = A[I...]
+    if typeof(subset) == eltype(A)
+        g.f(subset)
+    else
+        map(g.f, subset)
+    end
+end
+
 firstindex(g::Generator) = firstindex(g.iter)
 lastindex(g::Generator) = lastindex(g.iter)
 

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -219,3 +219,16 @@ end
 let (:)(a,b) = (i for i in Base.:(:)(1,10) if i%2==0)
     @test Int8[ i for i = 1:2 ] == [2,4,6,8,10]
 end
+
+@testset "indexing" begin
+    g = (i % 2 == 0 ? error("invalid") : i for i in 1:3)
+
+    @test g[3] == 3
+    @test g[1:2:3] == [1, 3]
+    @test firstindex(g) == 1
+    @test lastindex(g) == 3
+
+    @test (tuple(x) for x in ["a"])[1] == ("a",)
+    @test (tuple(x) for x in [[0]])[1] == ([0],)
+    @test (x * y for (x, y) in Dict(3 => 4))[1] == 12
+end

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -230,5 +230,5 @@ end
 
     @test (tuple(x) for x in ["a"])[1] == ("a",)
     @test (tuple(x) for x in [[0]])[1] == ([0],)
-    @test_throws MethodError (x * y for (x, y) in Dict(3 => 4))[1]
+    @test (x * y for (x, y) in Dict(3 => 4))[1] == 12
 end

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -230,5 +230,5 @@ end
 
     @test (tuple(x) for x in ["a"])[1] == ("a",)
     @test (tuple(x) for x in [[0]])[1] == ([0],)
-    @test (x * y for (x, y) in Dict(3 => 4))[1] == 12
+    @test_throws MethodError (x * y for (x, y) in Dict(3 => 4))[1]
 end


### PR DESCRIPTION
Indexing into generators is something I found myself wanting as part of https://github.com/JuliaTime/TimeZones.jl/pull/291. Basically I had function which contained code similar to:
```julia
x = [expensive_call(i) for i in range]
```
In some cases I would need access to all of the elements but in the most performance critical case I only needed access to a single element for which the index was already known. Using an index-able generator was a good solution for this.

I realize that not all generators will be index-able but this allows a generator to use indexing if the underlying iterator used by the generator also supports indexing.