### PR TITLE
Add in_sysimage(pkgid::PkgId) to check if a package is in the sysimage

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -381,6 +381,9 @@ include(mapexpr::Function, mod::Module, _path::AbstractString) = _include(mapexp
 
 end_base_include = time_ns()
 
+const _sysimage_modules = PkgId[]
+in_sysimage(pkgid::PkgId) = pkgid in _sysimage_modules
+
 if is_primary_base_module
 function __init__()
     # try to ensuremake sure OpenBLAS does not set CPU affinity (#1070, #9639)
@@ -405,6 +408,7 @@ function __init__()
     init_depot_path()
     init_load_path()
     init_active_project()
+    append!(_sysimage_modules, keys(loaded_modules))
     nothing
 end
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -408,7 +408,7 @@ function __init__()
     init_depot_path()
     init_load_path()
     init_active_project()
-    append!(_sysimage_modules, keys(loaded_modules))
+    append!(empty!(_sysimage_modules), keys(loaded_modules))
     nothing
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -58,7 +58,7 @@ let exename = `$(Base.julia_cmd()) --compiled-modules=yes --startup-file=no`,
 end
 
 @test Base.in_sysimage(Base.PkgId(Base.UUID("cf7118a7-6976-5b1a-9a39-7adc72f591a4"), "UUIDs"))
-@test !Base.in_sysimage(Base.PkgId(UUID("3a7fdc7e-7467-41b4-9f64-ea033d046d5b"), "NotAPackage"))
+@test Base.in_sysimage(Base.PkgId(Base.UUID("3a7fdc7e-7467-41b4-9f64-ea033d046d5b"), "NotAPackage")) == false
 
 # Issue #5789 and PR #13542:
 mktempdir() do dir

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -57,6 +57,9 @@ let exename = `$(Base.julia_cmd()) --compiled-modules=yes --startup-file=no`,
     @test !endswith(s_dir, Base.Filesystem.path_separator)
 end
 
+@test Base.in_sysimage(Base.PkgId(Base.UUID("cf7118a7-6976-5b1a-9a39-7adc72f591a4"), "UUIDs"))
+@test !Base.in_sysimage(Base.PkgId(UUID("3a7fdc7e-7467-41b4-9f64-ea033d046d5b"), "NotAPackage"))
+
 # Issue #5789 and PR #13542:
 mktempdir() do dir
     cd(dir) do


### PR DESCRIPTION
Adds `in_sysimage(pkgid::PkgId)` for checking if a package is in the sysimage.

Proposed as the correct-est way to filter out packages that definitely won't need precompiling, in https://github.com/JuliaLang/Pkg.jl/pull/2021

Discussed here https://github.com/JuliaLang/Pkg.jl/pull/2018#discussion_r490576496

cc. @tkf @fredrikekre 