### PR TITLE
[BinaryPlatforms] Do not cache host platform

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -1004,8 +1004,6 @@ function host_triplet()
     return str
 end
 
-# Cache the host platform value, and return it if someone asks for just `HostPlatform()`.
-default_host_platform = HostPlatform(parse(Platform, host_triplet()))
 """
     HostPlatform()
 
@@ -1015,7 +1013,7 @@ relevant comparison strategies set to host platform mode.  This is equivalent to
     HostPlatform(parse(Platform, Base.BinaryPlatforms.host_triplet()))
 """
 function HostPlatform()
-    return default_host_platform::Platform
+    return HostPlatform(parse(Platform, host_triplet()))::Platform
 end
 
 """

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -112,6 +112,11 @@ end
     # Now test libgfortran/cxxstring ABIs
     @test triplet(P("x86_64", "linux"; libgfortran_version=v"3", cxxstring_abi="cxx11")) == "x86_64-linux-gnu-libgfortran3-cxx11"
     @test triplet(P("armv7l", "linux"; libc="musl", cxxstring_abi="cxx03")) == "armv7l-linux-musleabihf-cxx03"
+    if !isnothing(detect_libgfortran_version())
+        # When `libgfortran` can be detected at runtime, make sure
+        # `HostPlatform` has the appropriate key.
+        @test tags(HostPlatform())["libgfortran_version"] == string(detect_libgfortran_version())
+    end
 
     # Test tags()
     t = tags(P("x86_64", "linux"))


### PR DESCRIPTION
Caching the host platform can lead to some nasty bugs, like libgfortran not
being detected because openblas -> libgfortran wasn't loaded when the variable
is set.