### PR TITLE
Update performance tips to be explicit about compilation time practices

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -134,6 +134,23 @@ its algorithmic aspects (see [Pre-allocating outputs](@ref)).
     For more serious benchmarking, consider the [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl)
     package which among other things evaluates the function multiple times in order to reduce noise.
 
+## [Avoid Compilation Time in Performance-Sensitive Calculations](@id compilation_time)
+
+Due to Julia's JIT compilation, the first run of a new function or a new Julia environment will include the compilation 
+time of a function in its first call. Compilation time is determined by the code of a function and the input types and
+is not dependent on the input values. Thus compile times for a given function are essentially constant with respect to 
+the runtime costs which very with respect to runtime values like array size and required calculation tolerances.
+This means that for large complex analyses compilation time is dwarfed by runtime. However, when inputs are simpler, like
+in microbenchmarks or short calculations in a new REPL session, compilation time matters for performance.
+
+Recommended Julia practices for short calculations amortize this compilation cost over the lifetime of the program, using 
+tools like Revise.jl, within-module re-evalulation of IDEs like Juno and VS Code, or by keeping REPL sessions alive over 
+multiple analyses. It is inadvisable and not a recommended practice to repeatedly run short scripts directly from the 
+command line if compilation is a significant factor in the runtime and performance is necessary. Direct running of small 
+single scripts will not result in the highest performance is thus not recommended in any context where performance is 
+required or measured. If such a usage is required, the recommended approach is to use  PackageCompiler.jl to precompile 
+the functionality into the sysimage, giving a usage that is similar to shared libraries of other compiled languages like C.
+
 ## [Tools](@id tools)
 
 Julia and its package ecosystem includes tools that may help you diagnose problems and improve

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -147,7 +147,7 @@ Recommended Julia practices for short calculations amortize this compilation cos
 tools like Revise.jl, within-module re-evalulation of IDEs like Juno and VS Code, or by keeping REPL sessions alive over 
 multiple analyses. It is inadvisable and not a recommended practice to repeatedly run short scripts directly from the 
 command line if compilation is a significant factor in the runtime and performance is necessary. Direct running of small 
-single scripts will not result in the highest performance is thus not recommended in any context where performance is 
+single scripts will not result in the highest performance and is thus not recommended in any context where performance is 
 required or measured. If such a usage is required, the recommended approach is to use  PackageCompiler.jl to precompile 
 the functionality into the sysimage, giving a usage that is similar to shared libraries of other compiled languages like C.
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -139,7 +139,7 @@ its algorithmic aspects (see [Pre-allocating outputs](@ref)).
 Due to Julia's JIT compilation, the first run of a new function or a new Julia environment will include the compilation 
 time of a function in its first call. Compilation time is determined by the code of a function and the input types and
 is not dependent on the input values. Thus compile times for a given function are essentially constant with respect to 
-the runtime costs which very with respect to runtime values like array size and required calculation tolerances.
+the runtime costs which vary with respect to runtime values like array size and required calculation tolerances.
 This means that for large complex analyses compilation time is dwarfed by runtime. However, when inputs are simpler, like
 in microbenchmarks or short calculations in a new REPL session, compilation time matters for performance.
 


### PR DESCRIPTION
One of the things that has come up recently is that some benchmarks will include compilation time because "it's how I run code" or "it's a subjective thing", "it's a personal choice". The purpose of this change it to make it very explicit that this is not a personal choice and it is, as per the manual, using the programming language incorrectly. This gets rid of any debate around the topic and makes it easy for anyone, say a reviewer, to quote the manual in a way that says that any of the issues are user-induced because they are simply not programming or measuring in a style that mirrors common or recommended Julia usage.