### PR TITLE
Fix debug build

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -87,7 +87,7 @@ if Artifacts !== nothing
     artifacts = Artifacts.load_artifacts_toml(artifacts_toml)
     platforms = [Artifacts.unpack_platform(e, "c_simple", artifacts_toml) for e in artifacts["c_simple"]]
     best_platform = select_platform(Dict(p => triplet(p) for p in platforms))
-    dlopen("libjulia", RTLD_LAZY | RTLD_DEEPBIND)
+    dlopen("libjulia$(ccall(:jl_is_debugbuild, Cint, ()) != 0 ? "-debug" : "")", RTLD_LAZY | RTLD_DEEPBIND)
     """
 end
 


### PR DESCRIPTION
`dlopen`ing the release version of the library in the debug build is a **REALLY** bad idea.

This was caught by the [archlinux-cn buildbot](https://build.archlinuxcn.org/~imlonghao/log/julia-git/2020-09-20T01%3A17%3A01.html). It seems that the debug version isn't being built on CI anymore.
