### PR TITLE
allow symbols for filenames in parseatom/parseall

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -226,11 +226,11 @@ function parse(str::AbstractString; raise::Bool=true, depwarn::Bool=true)
 end
 
 function parseatom(text::AbstractString, pos::Integer; filename="none")
-    return _parse_string(text, filename, pos, :atom)
+    return _parse_string(text, String(filename), pos, :atom)
 end
 
 function parseall(text::AbstractString; filename="none")
-    ex,_ = _parse_string(text, filename, 1, :all)
+    ex,_ = _parse_string(text, String(filename), 1, :all)
     return ex
 end
 

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -210,3 +210,6 @@ let a = 1
     @test !macroexpand(@__MODULE__, :(@is_dollar_expr $a))
     @test @macroexpand @is_dollar_expr $a
 end
+
+@test Meta.parseatom("@foo", 1, filename=:bar)[1].args[2].file == :bar
+@test Meta.parseall("@foo", filename=:bar).args[1].file == :bar


### PR DESCRIPTION
This is quite useful, especially inside macros, because `LineNumberNode`s store the file name as a `Symbol`. I encountered this when implementing interpolation for a custom string literal and it took me a while to figure out, why I couldn't just pass `__source__.file` as `filename` to `parseatom`. Since `Core.fl_parse` converts the filename to `String` anyways, doing the conversion in `parseatom` and `parseall` directly shouldn't change anything else.