### PR TITLE
Enable Perf JITEvents by default

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -82,7 +82,7 @@ endif
 USE_OPROFILE_JITEVENTS ?= 0
 
 # Set to 1 to enable profiling with perf
-USE_PERF_JITEVENTS ?= 0
+USE_PERF_JITEVENTS ?= 1
 
 # assume we don't have LIBSSP support in our compiler, will enable later if likely true
 HAVE_SSP := 0

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -314,6 +314,12 @@ event listener for just-in-time (JIT) profiling.
     * [OProfile](http://oprofile.sourceforge.net/news/) (`USE_OPROFILE_JITEVENTS` set to `1`
       in the build configuration).
 
+### `ENABLE_GDBLISTENER`
+
+If set to anything besides `0` enables GDB registration of Julia code on release builds.
+On debug builds of Julia this is always enabled. Recommended to use with `-g 2`.
+
+
 ### `JULIA_LLVM_ARGS`
 
 Arguments to be passed to the LLVM backend.

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -313,6 +313,8 @@ event listener for just-in-time (JIT) profiling.
       (`USE_INTEL_JITEVENTS` set to `1` in the build configuration), or
     * [OProfile](http://oprofile.sourceforge.net/news/) (`USE_OPROFILE_JITEVENTS` set to `1`
       in the build configuration).
+    * [Perf](https://perf.wiki.kernel.org) (`USE_PERF_JITEVENTS` set to `1`
+      in the build configuration). This integration is enabled by default.
 
 ### `ENABLE_GDBLISTENER`
 

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -342,7 +342,8 @@ Or similary with `perf` :
 
 ```
 $ ENABLE_JITPROFILING=1 perf record -o /tmp/perf.data --call-graph dwarf ./julia /test/fastmath.jl
-$ perf report --call-graph -G
+$ perf inject --jit --input /tmp/perf.data --output /tmp/perf-jit.data
+$ perf report --call-graph -G -i /tmp/perf-jit.data
 ```
 
 There are many more interesting things that you can measure about your program, to get a comprehensive list

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7728,10 +7728,9 @@ extern "C" void jl_init_llvm(void)
     std::string DL = jl_data_layout.getStringRepresentation() + "-ni:10:11:12:13";
     jl_data_layout.reset(DL);
 
-// Register GDB event listener
-#ifdef JL_DEBUG_BUILD
-    jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createGDBRegistrationListener());
-#endif
+    // Register GDB event listener
+    if(jl_using_gdb_jitevents)
+        jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createGDBRegistrationListener());
 
 #ifdef JL_USE_INTEL_JITEVENTS
     if (jl_using_intel_jitevents)

--- a/src/init.c
+++ b/src/init.c
@@ -436,6 +436,8 @@ char jl_using_oprofile_jitevents = 0; // Non-zero if running under OProfile
 char jl_using_perf_jitevents = 0;
 #endif
 
+char jl_using_gdb_jitevents = 0;
+
 int isabspath(const char *in) JL_NOTSAFEPOINT
 {
 #ifdef _OS_WINDOWS_
@@ -689,6 +691,15 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
     if (jit_profiling && atoi(jit_profiling)) {
         jl_using_perf_jitevents= 1;
+    }
+#endif
+
+#if defined(JL_DEBUG_BUILD)
+    jl_using_gdb_jitevents = 1;
+# else
+    const char *jit_gdb = getenv("ENABLE_GDBLISTENER");
+    if (jit_gdb && atoi(jit_gdb)) {
+        jl_using_gdb_jitevents = 1;
     }
 #endif
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -595,6 +595,7 @@ extern char jl_using_oprofile_jitevents;
 #ifdef JL_USE_PERF_JITEVENTS
 extern char jl_using_perf_jitevents;
 #endif
+extern char jl_using_gdb_jitevents;
 extern size_t jl_arr_xtralloc_limit;
 
 // -- init.c -- //


### PR DESCRIPTION
Yggdrasil is already shipping with this integration, and so it would be nice to have this available on release builds.
I also added the option to enable GDB's JIT integration on normal builds.

For the perf support to work well one probably needs a very recent `perf`.

https://github.com/dotnet/coreclr/pull/26897#issuecomment-691195475

