### PR TITLE
Atomic operations on Pointers

### DIFF
--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -409,7 +409,7 @@ for typ in atomictypes, container in [Atomic, Ptr]
                          %rv = atomicrmw $rmw $lt* %ptr, $lt %1 acq_rel
                          ret $lt %rv
                          """, $typ, Tuple{Ptr{$typ}, $typ}, unsafe_convert(Ptr{$typ}, x), v)
-        else if rmwop === :xchg
+        elseif rmwop === :xchg
             @eval $fn(x::$container{$typ}, v::$typ) =
                 llvmcall($"""
                          %iptr = inttoptr i$WORD_SIZE %0 to $ilt*
@@ -418,7 +418,7 @@ for typ in atomictypes, container in [Atomic, Ptr]
                          %rv = bitcast $ilt %irv to $lt
                          ret $lt %rv
                          """, $typ, Tuple{Ptr{$typ}, $typ}, unsafe_convert(Ptr{$typ}, x), v)
-        else if rmwop === :add || rmwop == :sub
+        elseif rmwop === :add || rmwop == :sub
             rmw = (rmwop === :add ? "fadd" : "fsub")
             @eval $fn(x::$container{$typ}, v::$typ) =
                 llvmcall($"""
@@ -435,7 +435,7 @@ const opnames = Dict{Symbol, Symbol}(:+ => :add, :- => :sub)
 for op in [:+, :-, :max, :min], container in [Atomic, Ptr]
     fT = (op == :+ || op == :-) ? Float16 : FloatTypes
     opname = get(opnames, op, op)
-    @eval function $(Symbol("atomic_", opname, "!"))(var::$container{T}, val::T) where T<:fT
+    @eval function $(Symbol("atomic_", opname, "!"))(var::$container{T}, val::T) where T<:$fT
         IT = inttype(T)
         old = var[]
         while true

--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -418,7 +418,7 @@ for typ in atomictypes, container in [Atomic, Ptr]
                          %rv = bitcast $ilt %irv to $lt
                          ret $lt %rv
                          """, $typ, Tuple{Ptr{$typ}, $typ}, unsafe_convert(Ptr{$typ}, x), v)
-        elseif rmwop === :add || rmwop == :sub
+        elseif (rmwop === :add || rmwop === :sub) && (typ == Float32 || typ == Float64)
             rmw = (rmwop === :add ? "fadd" : "fsub")
             @eval $fn(x::$container{$typ}, v::$typ) =
                 llvmcall($"""


### PR DESCRIPTION
For some reason, `Threads` doesn't support atomic operations through general pointers. However, we need these operations in order to e.g. atomically operate on array entries.

While doing that, I noticed that llvm supports perfectly fine `atomicrmw fadd` and `fsub` intrinsics. These also boil down to a `cas` loop on x86_64, but the emitted assembly looks nicer for the llvm intrinsic than for the julia loop, so I took the liberty to change that as well (I don't expect significant performance changes for that).

Ref https://discourse.julialang.org/t/scattered-atomic-writes-into-array/46990/ and https://github.com/JuliaLang/julia/issues/32455