### PR TITLE
Initial build-system support for RegionVectorizer

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -340,6 +340,9 @@ USE_POLLY_ACC := 0     # Enable GPU code-generation
 # Options to use MLIR
 USE_MLIR := 0
 
+# Options to use RegionVectorizer
+USE_RV := 0
+
 # Cross-compile
 #XC_HOST := i686-w64-mingw32
 #XC_HOST := x86_64-w64-mingw32


### PR DESCRIPTION
Add support in the build-system to enable the region vectorizer.

Tested with a `Make.user`
```
USE_BINARYBUILDER_LLVM=0
LLVM_VER=svn
LLVM_GIT_VER=llvmorg-10.0.1
LLVM_RV_GIT_VER=release/10.x
USE_RV=1
```

cc: @simoll @efocht



