### PR TITLE
more effectively record precompile signatures from package precompilation

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1176,7 +1176,7 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_d
     deps = repr(eltype(concrete_deps)) * "[" * join(deps_strs, ",") * "]"
 
     trace = isassigned(PRECOMPILE_TRACE_COMPILE) ? `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[])` : ``
-    io = open(pipeline(`$(julia_cmd()::Cmd) -O0 -Cnative
+    io = open(pipeline(`$(julia_cmd()::Cmd) -O0
                        --output-ji $output --output-incremental=yes
                        --startup-file=no --history-file=no --warn-overwrite=yes
                        --color=$(have_color === nothing ? "auto" : have_color ? "yes" : "no")

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1176,7 +1176,7 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_d
     deps = repr(eltype(concrete_deps)) * "[" * join(deps_strs, ",") * "]"
 
     trace = isassigned(PRECOMPILE_TRACE_COMPILE) ? `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[])` : ``
-    io = open(pipeline(`$(julia_cmd()::Cmd) -O0
+    io = open(pipeline(`$(julia_cmd()::Cmd) -O0 -Cnative
                        --output-ji $output --output-incremental=yes
                        --startup-file=no --history-file=no --warn-overwrite=yes
                        --color=$(have_color === nothing ? "auto" : have_color ? "yes" : "no")

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -146,7 +146,6 @@ function generate_precompile_statements()
             Base.compilecache(Base.PkgId($(repr(pkgname))), $(repr(path)))
             """
         run(`$(julia_exepath()) -O0 --sysimage $sysimg -Cnative -e $s`)
-        t = read(tmp, String)
         hardcoded_precompile_statements *= "\n" * read(tmp, String)
     end
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -293,10 +293,6 @@ try
                  :Profile, :Random, :Serialization, :SharedArrays, :SparseArrays, :SuiteSparse, :Test,
                  :Unicode, :REPL, :InteractiveUtils, :Pkg, :LibGit2, :SHA, :UUIDs, :Sockets,
                  :Statistics, :TOML, :MozillaCACerts_jll, :LibCURL_jll, :LibCURL, :Downloads,]),
-                # Plus precompilation module generated at build time
-                let id = Base.PkgId("__PackagePrecompilationStatementModule")
-                    Dict(id => Base.module_build_id(Base.root_module(id)))
-                end
            )
         @test discard_module.(deps) == deps1
         modules, (deps, requires), required_modules = Base.parse_cache_header(cachefile; srcfiles_only=true)


### PR DESCRIPTION
This allows us to trace the precompile statements emitted in the process that is doing the precompilation. Use that to gather statements in the precompile process from executing `compilecache` on a module.

Also gets rid of the ugly `__PackagePrecompilationStatementModule` from `Base.loaded_modules`. The `using` of that module was in fact completely pointless because apparently precompilation doesn't happen when you load a package from a Julia instance that is creating a sysimage.

Before:
```
julia> @time using GTK3_jll
 [ Info: Precompiling GTK3_jll [77ec8976-b24b-556a-a1bf-49a033a670a6]
 25.203725 seconds (799.52 k allocations: 47.121 MiB, 0.02% gc time
```

After:

```
julia> @time using GTK3_jll
[ Info: Precompiling GTK3_jll [77ec8976-b24b-556a-a1bf-49a033a670a6]
 22.947980 seconds (701.36 k allocations: 40.960 MiB)
```

