### PR TITLE
improve precompile generation for vararg signatures

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -235,6 +235,9 @@ function generate_precompile_statements()
         n_succeeded = 0
         include_time = @elapsed for statement in sort(collect(statements))
             # println(statement)
+            # The compiler has problem caching signatures with `Vararg{?, N}`. Replacing
+            # N with a large number seems to work around it.
+            statement = replace(statement, r"Vararg{(.*?), N} where N" => s"Vararg{\1, 100}")
             try
                 Base.include_string(PrecompileStagingArea, statement)
                 n_succeeded += 1


### PR DESCRIPTION
From advice by @vtjnash 

Before:

```
❯ ./julia --trace-compile=stderr -q
precompile(Tuple{typeof(Base.Filesystem.normpath), String, String, Vararg{String, N} where N})
precompile(Tuple{getfield(Base, Symbol("##s72#167")), Any, Any, Any, Any, Any})
precompile(Tuple{Type{Base.Dict{Symbol, REPL.LineEdit.Prompt}}, Base.Pair{Symbol, REPL.LineEdit.Prompt}, Vararg{Base.Pair{Symbol, REPL.LineEdit.Prompt}, N} where N})
precompile(Tuple{Type{Base.Dict{Any, Any}}, Base.Pair{String, getfield(REPL.LineEdit, Symbol("#45#76"))}, Vararg{Base.Pair{A, B} where B where A, N} where N})
precompile(Tuple{Type{Base.Dict{Any, Any}}, Base.Pair{String, getfield(REPL.LineEdit, Symbol("#74#105")){REPL.LineEdit.HistoryPrompt}}, Vararg{Base.Pair{A, B} where B where A, N} where N})
precompile(Tuple{Type{Base.Dict{Any, Any}}, Base.Pair{Char, getfield(REPL, Symbol("#73#83")){REPL.LineEdit.Prompt}}, Vararg{Base.Pair{A, B} where B where A, N} where N})
precompile(Tuple{Type{Base.Dict{Any, Any}}, Base.Pair{String, getfield(REPL.LineEdit, Symbol("#251#255")){REPL.LineEdit.PrefixHistoryPrompt}}, Vararg{Base.Pair{A, B} where B where A, N} where N})
precompile(Tuple{Type{Base.Dict{Any, Any}}, Base.Pair{Char, getfield(REPL, Symbol("#62#65")){REPL.LineEdit.Prompt}}, Vararg{Base.Pair{A, B} where B where A, N} where N})
precompile(Tuple{typeof(REPL.LineEdit.activate), REPL.LineEdit.TextInterface, REPL.LineEdit.MIState, REPL.Terminals.AbstractTerminal, REPL.Terminals.TextTerminal})
precompile(Tuple{typeof(REPL.LineEdit.refresh_multi_line), REPL.Terminals.UnixTerminal, Any})
```

After:

```
❯ ./julia --trace-compile=stderr -q
precompile(Tuple{getfield(Base, Symbol("##s72#167")), Any, Any, Any, Any, Any})
precompile(Tuple{typeof(REPL.LineEdit.activate), REPL.LineEdit.TextInterface, REPL.LineEdit.MIState, REPL.Terminals.AbstractTerminal, REPL.Terminals.TextTerminal})
precompile(Tuple{typeof(REPL.LineEdit.refresh_multi_line), REPL.Terminals.UnixTerminal, Any})
```

In the future, it would be good to fix this properly so that e.g. PackageCompiler and packages also get use out of it.