### PR TITLE
fix #37677, unreliable lowering of assignments to gensym'd names

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -264,9 +264,6 @@
 (define (reset-gensyms)
   (set! *current-gensyms* *gensyms*))
 
-(define (some-gensym? x)
-  (or (gensym? x) (memq x *gensyms*)))
-
 (define make-ssavalue
   (let ((ssavalue-counter 0))
     (lambda ()


### PR DESCRIPTION
This was caused by a strange scoping rule that tried to avoid "leaking" gensym names as global variables. The way it was implemented was state-dependent, so it's unpredictable and doesn't really work. I'm pretty sure we don't need this anymore, and that it can be handled by macro hygiene and just declaring things local. There were 3 cases where we generated temp variables without local declarations in the front end.

fix #37677
