### PR TITLE
Fix cross-compilation of libjulia

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -42,7 +42,7 @@ $(BUILDDIR)/errno_h.jl:
 $(BUILDDIR)/file_constants.jl: $(SRCDIR)/../src/file_constants.h
 	@$(call PRINT_PERL, $(CPP_STDOUT) -DJULIA $< | perl -nle 'print "$$1 0o$$2" if /^(\s*const\s+[A-z_]+\s+=)\s+(0[0-9]*)\s*$$/; print "$$1" if /^\s*(const\s+[A-z_]+\s+=\s+([1-9]|0x)[0-9A-z]*)\s*$$/' > $@)
 
-$(BUILDDIR)/uv_constants.jl: $(SRCDIR)/../src/uv_constants.h $(build_includedir)/uv/errno.h
+$(BUILDDIR)/uv_constants.jl: $(SRCDIR)/../src/uv_constants.h $(LIBUV_INC)/uv/errno.h
 	@$(call PRINT_PERL, $(CPP_STDOUT) "-I$(LIBUV_INC)" -DJULIA $< | tail -n 16 > $@)
 
 $(BUILDDIR)/build_h.jl.phony:

--- a/src/Makefile
+++ b/src/Makefile
@@ -139,8 +139,8 @@ FLISPDIR := $(BUILDDIR)/flisp/host
 else
 FLISPDIR := $(BUILDDIR)/flisp
 endif
-FLISP_EXECUTABLE_debug := $(FLISPDIR)/flisp-debug$(EXE)
-FLISP_EXECUTABLE_release := $(FLISPDIR)/flisp$(EXE)
+FLISP_EXECUTABLE_debug := $(FLISPDIR)/flisp-debug$(BUILD_EXE)
+FLISP_EXECUTABLE_release := $(FLISPDIR)/flisp$(BUILD_EXE)
 ifeq ($(OS),WINNT)
 FLISP_EXECUTABLE := $(FLISP_EXECUTABLE_release)
 else

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -115,8 +115,12 @@ $(BUILDDIR)/host/Makefile:
 	@echo 'BUILDING_HOST_TOOLS=1' >> $@
 	@echo 'include $(SRCDIR)/Makefile' >> $@
 
-$(BUILDDIR)/host/$(EXENAME): $(BUILDDIR)/host/Makefile
+$(BUILDDIR)/host/$(EXENAME): $(BUILDDIR)/host/Makefile | ${BUILDDIR}/host/flisp.boot
 	make -C $(BUILDDIR)/host $(EXENAME)
+
+
+$(BUILDDIR)/host/flisp.boot: $(SRCDIR)/flisp.boot | $(BUILDDIR)/host/Makefile
+	cp $< $@
 
 ifneq ($(BUILDDIR),.)
 ifneq ($(BUILDDIR),$(SRCDIR))

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -32,12 +32,20 @@ OBJS := $(SRCS:%.c=$(BUILDDIR)/%.o)
 DOBJS := $(SRCS:%.c=$(BUILDDIR)/%.dbg.obj)
 LLT_release := $(LLT_BUILDDIR)/libsupport.a
 LLT_debug := $(LLT_BUILDDIR)/libsupport-debug.a
-LIBFILES_release := $(LLT_release) $(LIBUV) $(LIBUTF8PROC)
-LIBFILES_debug := $(LLT_debug) $(LIBUV) $(LIBUTF8PROC)
+LIBFILES_release := $(LLT_release) $(LIBUV)
+LIBFILES_debug := $(LLT_debug) $(LIBUV)
 LIBS :=
 ifneq ($(OS),WINNT)
 LIBS += -lpthread
 endif
+
+ifeq ($(USE_SYSTEM_UTF8PROC),0)
+LIBFILES_release += $(LIBUTF8PROC)
+LIBFILES_debug += $(LIBUTF8PROC)
+else
+LIBS += $(LIBUTF8PROC)
+endif
+
 
 FLAGS := -I$(LLTSRCDIR) $(JCFLAGS) $(HFILEDIRS:%=-I%) \
         -I$(LIBUV_INC) -I$(UTF8PROC_INC) -I$(build_includedir) $(LIBDIRS:%=-L%) \


### PR DESCRIPTION
- Allow flips to be built against system UTF8PROC
- Use universal LIBUV_INC instead of build_includedir
- stage flisp.boot into host

x-ref: https://github.com/JuliaPackaging/Yggdrasil/pull/1694
