### PR TITLE
fix some invalidations when loading CUDA

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -139,7 +139,7 @@ function updated_methodloc(m::Method)::Tuple{String, Int32}
     file, line = m.file, m.line
     if methodloc_callback[] !== nothing
         try
-            file, line = invokelatest(methodloc_callback[], m)
+            file, line = invokelatest(methodloc_callback[], m)::Tuple{Symbol, Int32}
         catch
         end
     end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -97,7 +97,7 @@ mutable struct PromptState <: ModeState
     # indentation of lines which do not include the prompt
     # if negative, the width of the prompt is used
     indent::Int
-    refresh_lock::Threads.AbstractLock
+    refresh_lock::Threads.SpinLock
     # this would better be Threads.Atomic{Float64}, but not supported on some platforms
     beeping::Float64
     # this option is to detect when code is pasted in non-"bracketed paste mode" :

--- a/test/show.jl
+++ b/test/show.jl
@@ -757,7 +757,7 @@ else
 end
 
 # Method location correction (Revise integration)
-dummyloc(m::Method) = :nofile, 123456789
+dummyloc(m::Method) = :nofile, Int32(123456789)
 Base.methodloc_callback[] = dummyloc
 let repr = sprint(show, "text/plain", methods(Base.inbase))
     @test occursin("nofile:123456789", repr)


### PR DESCRIPTION
Cuda:

- defines a new `trylock`
- (used to) define a new `convert(Type{String}, ...)`, https://github.com/JuliaLang/Pkg.jl/pull/2045 for that
- defines a new `deepcopy_internal`

This fixes most of the invalidations, the exception is invalidations of everything calling `deepcopy` because there is a `@nospecialize` on the `Base.deepcopy_internal`: https://github.com/JuliaLang/julia/blob/55aeb2ff0195e40acea6310dcf3e3826a121f657/base/deepcopy.jl#L53

so calls to it get invalidated from the new method.