### PR TITLE
Enable BPF target in LLVM build

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -68,7 +68,7 @@ endif
 endif # LLVM_VER != svn
 
 # Figure out which targets to build
-LLVM_TARGETS := host;NVPTX;AMDGPU;WebAssembly
+LLVM_TARGETS := host;NVPTX;AMDGPU;WebAssembly;BPF
 
 LLVM_CFLAGS :=
 LLVM_CXXFLAGS :=


### PR DESCRIPTION
For supporting the WIP compiler at https://github.com/jpsamaroo/BPFnative.jl.

@staticfloat is there anything else I need to do to get this into the LLVM BB builds?