### PR TITLE
[file]: Fix EBADF errors when removing files that don't exist

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -261,7 +261,8 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
         try
             @static if Sys.iswindows()
                 # is writable on windows actually means "is deletable"
-                if (filemode(lstat(path)) & 0o222) == 0
+                st = lstat(path)
+                if ispath(st) && (filemode(st) & 0o222) == 0
                     chmod(path, 0o777)
                 end
             end

--- a/test/file.jl
+++ b/test/file.jl
@@ -459,9 +459,9 @@ close(f)
 
 rm(c_tmpdir, recursive=true)
 @test !isdir(c_tmpdir)
-@test_throws Base._UVError(Sys.iswindows() ? "chmod" : "unlink", Base.UV_ENOENT) rm(c_tmpdir)
+@test_throws Base._UVError("unlink", Base.UV_ENOENT) rm(c_tmpdir)
 @test rm(c_tmpdir, force=true) === nothing
-@test_throws Base._UVError(Sys.iswindows() ? "chmod" : "unlink", Base.UV_ENOENT) rm(c_tmpdir, recursive=true)
+@test_throws Base._UVError("unlink", Base.UV_ENOENT) rm(c_tmpdir, recursive=true)
 @test rm(c_tmpdir, force=true, recursive=true) === nothing
 
 if !Sys.iswindows()


### PR DESCRIPTION
On Windows, we need to add back write permissions to files that we want
to delete.  When attempting to do this, if the file itself doesn't
exist, `chmod()` can throw a couple of different errors that are not
caught by our `catch` statements here.  Rather than attempt to do these
useless operations, we'll instead only `chmod()` if the file itself
actually exists.