### PR TITLE
Broadcasted range methods for `StepRange{<:TimeType}`

### DIFF
--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -33,7 +33,7 @@ for more information.
 module Dates
 
 import Base: ==, div, fld, mod, rem, gcd, lcm, +, -, *, /, %, broadcast
-import Base.Broadcast: broadcastable
+import Base.Broadcast: broadcastable, broadcasted
 using Printf: @sprintf
 
 using Base.Iterators

--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -33,6 +33,7 @@ for more information.
 module Dates
 
 import Base: ==, div, fld, mod, rem, gcd, lcm, +, -, *, /, %, broadcast
+import Base.Broadcast: broadcastable
 using Printf: @sprintf
 
 using Base.Iterators

--- a/stdlib/Dates/src/arithmetic.jl
+++ b/stdlib/Dates/src/arithmetic.jl
@@ -97,3 +97,15 @@ end
 # Allow dates, times, and time zones to broadcast as unwrapped scalars
 broadcastable(x::AbstractTime) = Ref(x)
 broadcastable(x::TimeZone) = Ref(x)
+
+function broadcasted(::typeof(+), r::StepRange{T}, p::Period) where {T<:TimeType}
+    StepRange{T}(r.start + p, r.step, r.stop + p)
+end
+
+# Note: Since `Time` is cyclical adding a period may cause the resulting range to cross
+# over midnight. If this occurs we would return an empty range or incorrect result.
+broadcasted(::typeof(+), r::StepRange{Time}, p::Period) = collect(r) + p
+
+broadcasted(::typeof(+), p::Period, r::StepRange{<:TimeType}) = broadcasted(+, r, p)
+broadcasted(::typeof(-), r::StepRange{<:TimeType}, p::Period) = broadcasted(+, r, -p)
+broadcasted(::typeof(-), p::Period, r::StepRange{<:TimeType}) = broadcasted(-, r, p)

--- a/stdlib/Dates/src/arithmetic.jl
+++ b/stdlib/Dates/src/arithmetic.jl
@@ -95,5 +95,5 @@ end
 (-)(x::AbstractRange{T}, y::AbstractRange{T}) where {T<:TimeType} = Vector(x) - Vector(y)
 
 # Allow dates, times, and time zones to broadcast as unwrapped scalars
-Base.Broadcast.broadcastable(x::AbstractTime) = Ref(x)
-Base.Broadcast.broadcastable(x::TimeZone) = Ref(x)
+broadcastable(x::AbstractTime) = Ref(x)
+broadcastable(x::TimeZone) = Ref(x)

--- a/stdlib/Dates/test/arithmetic.jl
+++ b/stdlib/Dates/test/arithmetic.jl
@@ -530,6 +530,13 @@ end
             @test collect(r .+ Day(1)) == [Date(2020,2,29), Date(2021,2,28)]
             @test collect(r) .+ Day(1) == [Date(2020,2,29), Date(2021,3,1)]
         end
+
+        @testset "round-trip" begin
+            r = Date(2020,2,27):Day(1):Date(2020,3,1)
+
+            @test r .+ Year(0) == r
+            @test (r .+ Year(1)) .- Year(1) == r
+        end
     end
 
     @testset "DateTime" begin

--- a/stdlib/Dates/test/arithmetic.jl
+++ b/stdlib/Dates/test/arithmetic.jl
@@ -510,10 +510,26 @@ end
 
 @testset "Broadcasted range" begin
     @testset "Date" begin
-        result = (Date(2020):Week(1):Date(2021)) .+ Day(1)
+        @testset "basic" begin
+            result = (Date(2020):Week(1):Date(2021)) .+ Day(1)
 
-        @test result == Date(2020,1,2):Week(1):Date(2021,1,2)
-        @test result isa StepRange
+            @test result == Date(2020,1,2):Week(1):Date(2021,1,2)
+            @test result isa StepRange
+        end
+
+        @testset "end-of-month" begin
+            r = Date(2020,10,31):Month(1):Date(2021)
+
+            @test collect(r .- Day(1)) == [Date(2020,10,30), Date(2020,11,30), Date(2020,12,30)]
+            @test collect(r) .- Day(1) == [Date(2020,10,30), Date(2020,11,29), Date(2020,12,30)]
+        end
+
+        @testset "leap day" begin
+            r = Date(2020,2,28):Year(1):Date(2022)
+
+            @test collect(r .+ Day(1)) == [Date(2020,2,29), Date(2021,2,28)]
+            @test collect(r) .+ Day(1) == [Date(2020,2,29), Date(2021,3,1)]
+        end
     end
 
     @testset "DateTime" begin

--- a/stdlib/Dates/test/arithmetic.jl
+++ b/stdlib/Dates/test/arithmetic.jl
@@ -508,4 +508,27 @@ end
     end
 end
 
+@testset "Broadcasted range" begin
+    @testset "Date" begin
+        result = (Date(2020):Week(1):Date(2021)) .+ Day(1)
+
+        @test result == Date(2020,1,2):Week(1):Date(2021,1,2)
+        @test result isa StepRange
+    end
+
+    @testset "DateTime" begin
+        result = (DateTime(2020):Hour(1):DateTime(2021)) .+ Minute(1)
+
+        @test result == DateTime(2020,1,1,0,1):Hour(1):DateTime(2021,1,1,0,1)
+        @test result isa StepRange
+    end
+
+    @testset "Time" begin
+        result = (Time(18):Hour(1):Time(22)) .+ Hour(4)
+
+        @test result == [Time.(22:23); Time.(0:2)]
+        @test result isa Vector
+    end
+end
+
 end


### PR DESCRIPTION
Now returns a `StepRange` instead of a `Vector` when performing broadcasted arithmetic. I think we maybe used to support this back in the Julia 0.6 era and this functionality was probably lost with the transition to the new broadcasting system.