### PR TITLE
use SHA512 when seeding MersenneTwister

### DIFF
--- a/stdlib/Random/Project.toml
+++ b/stdlib/Random/Project.toml
@@ -3,6 +3,7 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Random/src/DSFMT.jl
+++ b/stdlib/Random/src/DSFMT.jl
@@ -65,7 +65,7 @@ function dsfmt_init_gen_rand(s::DSFMT_state, seed::UInt32)
           s.val, seed)
 end
 
-function dsfmt_init_by_array(s::DSFMT_state, seed::Vector{UInt32})
+function dsfmt_init_by_array(s::DSFMT_state, seed::AbstractVector{UInt32})
     ccall((:dsfmt_init_by_array,:libdSFMT),
           Cvoid,
           (Ptr{Cvoid}, Ptr{UInt32}, Int32),

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -14,6 +14,8 @@ using .DSFMT
 using Base.GMP.MPZ
 using Base.GMP: Limb
 
+import SHA
+
 using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing
 
 import Base: copymutable, copy, copy!, ==, hash, convert,


### PR DESCRIPTION
This hashes the provided seeds before feeding dSFMT initialization routine.
The passed seeds are still stored as-is in the `MersenneTwister.seed` field.

Goals:
* possibly lead to more independance between two streams corresponding to two
  user-provided seeds
* by feeding `VERSION.minor` and `VERSION.major` to the hashing process, this
  guarantees that random streams change between minor releases, helping users
  to not believe in stream stability

---

Closes #37165.

#### Performance

`Random.seed!(rng, 0)` takes, on my machine, 
* 12.655 μs on master
* 13.460 μs on this branch but using SHA1 (6% slowdown)
* 14.320 μs on this branch, with SHA2_512 (13% slowdown)

As seeding is usually not a time-critical operation, the slowdown here seems acceptable (it will probably be a different story when Xoshiro lands as the default RNG...)

#### Handling our tests

Many of our tests use `Random.seed!()`, and these would have to be changed for all minor releases. Alternatives include:
* having an escape hatch, e.g. `seed!(seed, hash=false)`, or `Random.seednohash(seed)`
* implement a simple RNG with stable streams in our tests...
