### PR TITLE
Fix `getfield_tfunc` for `PartialStruct` with `Vararg`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -809,7 +809,7 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
                 nv = fieldindex(widenconst(s), nv, false)
             end
             if isa(nv, Int) && 1 <= nv <= length(s.fields)
-                return s.fields[nv]
+                return unwrapva(s.fields[nv])
             end
         end
         s = widenconst(s)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2838,3 +2838,6 @@ f_apply_cglobal(args...) = cglobal(args...)
 @test !Core.Compiler.intrinsic_nothrow(Core.bitcast, Any[Type{Ptr}, Ptr])
 f37532(T, x) = (Core.bitcast(Ptr{T}, x); x)
 @test Base.return_types(f37532, Tuple{Any, Int}) == Any[Int]
+
+# issue #37638
+@test !(Core.Compiler.return_type(() -> (nothing, Any[]...)[2], Tuple{}) <: Vararg)


### PR DESCRIPTION
Add an `unwrapva` to ensure the returned type is not a `Vararg`. Fixes #37638.