### PR TITLE
RFC: improve error message when calling types with free typevars

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -6657,7 +6657,7 @@ end
 # issue #21004
 const PTuple_21004{N,T} = NTuple{N,VecElement{T}}
 @test_throws ArgumentError("too few elements for tuple type $PTuple_21004") PTuple_21004(1)
-@test_throws UndefVarError(:T) PTuple_21004_2{N,T} = NTuple{N, VecElement{T}}(1)
+@test_throws ErrorException PTuple_21004_2{N,T} = NTuple{N, VecElement{T}}(1)
 
 #issue #22792
 foo_22792(::Type{<:Union{Int8,Int,UInt}}) = 1;
@@ -7484,3 +7484,5 @@ let array = Int[]
 end
 @test compare_union37557(Ref{Union{Int,Vector{Int}}}(1),
                          Ref{Union{Int,Vector{Int}}}(1))
+
+@test_throws ErrorException Val{TypeVar(:y)}()


### PR DESCRIPTION
People sometimes try to write code along the following lines:
```julia
julia> f(::typeof(Val(y))) where {y} = y
ERROR: UndefVarError: x not defined
Stacktrace:
 [1] (::Type{Val{y}})() at ./essentials.jl:694
 [2] Val(::TypeVar) at ./essentials.jl:696
 [3] top-level scope at REPL[7]:1
```
That of course can't work with the current implementation of `UnionAll`, but I find the error message here particularly confusing, because it looks like there's a bug in `(::Type{Val{y}})()`, since it complains about some unrelated undefined variable.

Since types with free `TypeVar`s should never be callable, I think it should be fine to check for this in `jl_apply_generic` and try to produce a more helpful error message. Is this the right place for this? I tried to make the error message as helpful as I could for people not familiar with the internals, but it may be too verbose?