### PR TITLE
Add load_libjulia in libjulialoader

### DIFF
--- a/cli/loader.h
+++ b/cli/loader.h
@@ -52,6 +52,7 @@
 
 // Declarations from `loader_lib.c` and `loader_win_utils.c`
 extern const char * get_exe_dir();
+extern void * load_libjulia(const char *);
 extern int load_repl(const char *, int, char **);
 void print_stderr(const char * msg);
 void print_stderr3(const char * msg1, const char * msg2, const char * msg3);

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -131,8 +131,8 @@ const char * get_exe_dir()
     return exe_dir;
 }
 
-// Load libjulia and run the REPL with the given arguments (in UTF-8 format)
-int load_repl(const char * exe_dir, int argc, char * argv[])
+// Load libjulia after loading its dependencies
+void * load_libjulia(const char * exe_dir)
 {
     // Pre-load libraries that libjulia needs.
     int deps_len = strlen(dep_libs);
@@ -152,7 +152,13 @@ int load_repl(const char * exe_dir, int argc, char * argv[])
     }
 
     // Last dependency is `libjulia`, so load that and we're done with `dep_libs`!
-    void * libjulia = load_library(curr_dep, exe_dir);
+    return load_library(curr_dep, exe_dir);
+}
+
+// Load libjulia and run the REPL with the given arguments (in UTF-8 format)
+int load_repl(const char * exe_dir, int argc, char * argv[])
+{
+    void * libjulia = load_libjulia(exe_dir);
 
     // Next, if we're on Linux/FreeBSD, set up fast TLS.
 #if !defined(_OS_WINDOWS_) && !defined(_OS_DARWIN_)


### PR DESCRIPTION
From the discussion in https://github.com/JuliaLang/julia/pull/36588#issuecomment-656374282, I'd imagine we need something like `void * load_libjulia(const char *)` for loading `libjulia` in a cross-platform manner.

This is a dead-simple implementation that just extracts out the first lines of `load_repl`.  @staticfloat If you have a better idea of doing this, please feel free to close this and implement it in a new PR.

Here is a simple Python session with this PR:

```python
In [1]: import ctypes
   ...: libjulialoader = ctypes.CDLL("usr/lib/libjulialoader.so")
   ...: libjulialoader.load_libjulia.restype = ctypes.c_void_p
   ...: libjulialoader.load_libjulia(b"usr/bin")
Out[1]: 94362114802096

In [2]: libjulia = ctypes.PyDLL("usr/lib/libjulia.so", ctypes.RTLD_GLOBAL)

In [3]: libjulia._handle
Out[3]: 94362114802096

In [4]: Out[1] == Out[3]
Out[4]: True
```

Question: Should it be renamed to `jl_load_libjulia` or something?

cc @davidanthoff @GunnarFarneback
