### PR TITLE
RFC: hide the nospecialized deepcopy_internal from inference

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -50,7 +50,10 @@ function deepcopy_internal(x::String, stackdict::IdDict)
     return y
 end
 
-function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
+# Hide `_deepcopy_internal` which is nospecialized from inference to not act as a
+# source of invalidations when new methods for deepcopy_internal are defined
+deepcopy_internal(x, stackdict::IdDict) = invokelatest(_deepcopy_internal, x, stackdict)
+function _deepcopy_internal(@nospecialize(x), stackdict::IdDict)
     T = typeof(x)::DataType
     nf = nfields(x)
     if T.mutable


### PR DESCRIPTION
Right now, if we load any package that defines its own `deepcopy_internal` method, every location that has called `deepcopy` during the precompile generation during build time gets invalidated. That is (AFAIU) because of the `@nospecialize` on `deepcopy_internal` so a new method definition could change what method we call. Right now, the calls to `deepcopy` we precompile seem to be:

```
deepcopy(::Base.SecretBuffer)
deepcopy(::Pkg.Types.Project)
deepcopy(::LibGit2.GitCredential)
deepcopy(::Pkg.Types.EnvCache)
```

One suggestion of working around this is in this PR by shielding the body of `deepcopy_internal` with an `invokelatest` but still allow specialization on the method calling the body.

An example of a package that defines a `deepcopy_internal` method is CUDA.jl. This PR seems to quite drastically lower the time to load it:

```
julia> @time using CUDA
  3.118002 seconds (11.65 M allocations: 816.879 MiB, 2.52% gc time)
```

and after

```
julia> @time using CUDA
  2.248759 seconds (8.10 M allocations: 642.719 MiB, 1.48% gc time
```

That was a bigger change than I expected but it seems consistent. It removed a few hundred invalidations though. Would be good if someone else could try out the timing on this branch as well.

cc @maleadt, @timholy 