### PR TITLE
Fix some string-related invalidation risks

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -276,7 +276,7 @@ const (∛)=cbrt
 delete_method(which(include, (Module, String)))
 let SOURCE_PATH = ""
     global function include(mod::Module, path::String)
-        prev = SOURCE_PATH
+        prev = SOURCE_PATH::String
         path = normpath(joinpath(dirname(prev), path))
         Core.println(path)
         ccall(:jl_uv_flush, Nothing, (Ptr{Nothing},), Core.io_pointer(Core.stdout))
@@ -335,15 +335,15 @@ using .MathConstants: ℯ, π, pi
 # metaprogramming
 include("meta.jl")
 
+# Stack frames and traces
+include("stacktraces.jl")
+using .StackTraces
+
 # utilities
 include("deepcopy.jl")
 include("download.jl")
 include("summarysize.jl")
 include("errorshow.jl")
-
-# Stack frames and traces
-include("stacktraces.jl")
-using .StackTraces
 
 include("initdefs.jl")
 

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -499,7 +499,7 @@ julia> triplet(Platform("armv7l", "Linux"; libgfortran_version="3"))
 """
 function triplet(p::AbstractPlatform)
     str = string(
-        arch(p),
+        arch(p)::Union{Symbol,String},
         os_str(p),
         libc_str(p),
         call_abi_str(p),
@@ -552,15 +552,19 @@ end
 
 # Helper functions for Linux and FreeBSD libc/abi mishmashes
 function libc_str(p::AbstractPlatform)
-    if libc(p) === nothing
+    lc = libc(p)
+    if lc === nothing
         return ""
-    elseif libc(p) === "glibc"
+    elseif lc === "glibc"
         return "-gnu"
     else
-        return string("-", libc(p))
+        return string("-", lc)
     end
 end
-call_abi_str(p::AbstractPlatform) = (call_abi(p) === nothing) ? "" : call_abi(p)
+function call_abi_str(p::AbstractPlatform)
+    cabi = call_abi(p)
+    cabi === nothing ? "" : string(cabi::Union{Symbol,String})
+end
 
 Sys.isapple(p::AbstractPlatform) = os(p) == "macos"
 Sys.islinux(p::AbstractPlatform) = os(p) == "linux"

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -678,7 +678,7 @@ end
 # Print a stack frame where the module color is determined by looking up the parent module in
 # `modulecolordict`. If the module does not have a color, yet, a new one can be drawn
 # from `modulecolorcycler`.
-function print_stackframe(io, i, frame, n, digit_align_width, modulecolordict, modulecolorcycler)
+function print_stackframe(io, i, frame::StackFrame, n::Int, digit_align_width, modulecolordict, modulecolorcycler)
     m = Base.parentmodule(frame)
     if m !== nothing
         while parentmodule(m) !== m
@@ -698,7 +698,7 @@ end
 
 
 # Print a stack frame where the module color is set manually with `modulecolor`.
-function print_stackframe(io, i, frame, n, digit_align_width, modulecolor)
+function print_stackframe(io, i, frame::StackFrame, n::Int, digit_align_width, modulecolor)
     file, line = string(frame.file), frame.line
     stacktrace_expand_basepaths() && (file = something(find_source_file(file), file))
     stacktrace_contract_userdir() && (file = replaceuserpath(file))

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -90,9 +90,9 @@ const DEPOT_PATH = String[]
 function append_default_depot_path!(DEPOT_PATH)
     path = joinpath(homedir(), ".julia")
     path in DEPOT_PATH || push!(DEPOT_PATH, path)
-    path = abspath(Sys.BINDIR, "..", "local", "share", "julia")
+    path = abspath(Sys.BINDIR::String, "..", "local", "share", "julia")
     path in DEPOT_PATH || push!(DEPOT_PATH, path)
-    path = abspath(Sys.BINDIR, "..", "share", "julia")
+    path = abspath(Sys.BINDIR::String, "..", "share", "julia")
     path in DEPOT_PATH || push!(DEPOT_PATH, path)
 end
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -127,9 +127,9 @@ const methodloc_callback = Ref{Union{Function, Nothing}}(nothing)
 function fixup_stdlib_path(path::String)
     # The file defining Base.Sys gets included after this file is included so make sure
     # this function is valid even in this intermediary state
-    if isdefined(@__MODULE__, :Sys) && Sys.BUILD_STDLIB_PATH != Sys.STDLIB
+    if isdefined(@__MODULE__, :Sys) && Sys.BUILD_STDLIB_PATH != Sys.STDLIB::String
         # BUILD_STDLIB_PATH gets defined in sysinfo.jl
-        path = replace(path, normpath(Sys.BUILD_STDLIB_PATH) => normpath(Sys.STDLIB))
+        path = replace(path, normpath(Sys.BUILD_STDLIB_PATH) => normpath(Sys.STDLIB::String))
     end
     return path
 end

--- a/base/process.jl
+++ b/base/process.jl
@@ -418,7 +418,7 @@ end
 
 Run `command` and return the resulting output as a `String`.
 """
-read(cmd::AbstractCmd, ::Type{String}) = String(read(cmd))
+read(cmd::AbstractCmd, ::Type{String}) = String(read(cmd))::String
 
 """
     run(command, args...; wait::Bool = true)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -391,7 +391,9 @@ function split(str::T, splitter::AbstractChar;
     _split(str, isequal(splitter), limit, keepempty, T <: SubString ? T[] : SubString{T}[])
 end
 
-function _split(str::AbstractString, splitter, limit::Integer, keepempty::Bool, strs::Vector)
+function _split(str::AbstractString, splitter::F, limit::Integer, keepempty::Bool, strs::Vector) where F
+    # Forcing specialization on `splitter` improves performance (roughly 30% decrease in runtime)
+    # and prevents a major invalidation risk (1550 MethodInstances)
     i = 1 # firstindex(str)
     n = lastindex(str)::Int
     r = findfirst(splitter,str)::Union{Nothing,Int,UnitRange{Int}}

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -122,7 +122,7 @@ end
 function __init_build()
     global BINDIR = ccall(:jl_get_julia_bindir, Any, ())::String
     vers = "v$(VERSION.major).$(VERSION.minor)"
-    global STDLIB = abspath(BINDIR, "..", "share", "julia", "stdlib", vers)
+    global STDLIB = abspath(BINDIR::String, "..", "share", "julia", "stdlib", vers)
     nothing
 end
 

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -278,7 +278,7 @@ const Err{T} = Union{T, ParserError}
 function format_error_message_for_err_type(error::ParserError)
     msg = err_message[error.type]
     if error.type == ErrInvalidBareKeyCharacter
-        c_escaped = escape_string(string(error.data))
+        c_escaped = escape_string(string(error.data)::String)
         msg *= ": '$c_escaped'"
     end
     return msg

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -7,7 +7,7 @@ Sys.__init_build()
 if !isdefined(Base, :uv_eventloop)
     Base.reinit_stdio()
 end
-Base.include(@__MODULE__, joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testhelpers", "FakePTYs.jl"))
+Base.include(@__MODULE__, joinpath(Sys.BINDIR::String, "..", "share", "julia", "test", "testhelpers", "FakePTYs.jl"))
 import .FakePTYs: open_fake_pty
 
 CTRL_C = '\x03'
@@ -54,7 +54,7 @@ push!(Set{Method}(), first(methods(collect)))
 get(Base.pkgorigins, Base.PkgId(Base), nothing)
 """
 
-julia_exepath() = joinpath(Sys.BINDIR, Base.julia_exename())
+julia_exepath() = joinpath(Sys.BINDIR::String, Base.julia_exename())
 
 have_repl =  haskey(Base.loaded_modules,
                     Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL"))
@@ -195,7 +195,7 @@ function generate_precompile_statements()
         readavailable(output_copy)
         # Input our script
         if have_repl
-            precompile_lines = split(precompile_script, '\n'; keepempty=false)
+            precompile_lines = split(precompile_script::String, '\n'; keepempty=false)
             curr = 0
             for l in precompile_lines
                 sleep(0.1)
@@ -228,7 +228,7 @@ function generate_precompile_statements()
             push!(statements, statement)
         end
 
-        for statement in split(hardcoded_precompile_statements, '\n')
+        for statement in split(hardcoded_precompile_statements::String, '\n')
             push!(statements, statement)
         end
 

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -516,7 +516,7 @@ end
 default_addprocs_params() = Dict{Symbol,Any}(
     :topology => :all_to_all,
     :dir      => pwd(),
-    :exename  => joinpath(Sys.BINDIR, julia_exename()),
+    :exename  => joinpath(Sys.BINDIR::String, julia_exename()),
     :exeflags => ``,
     :enable_threaded_blas => false,
     :lazy => true)

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -992,7 +992,7 @@ end
             ENV["SSL_CERT_FILE"]
         else
             # If we have a bundled ca cert file, point libgit2 at that so SSL connections work.
-            abspath(ccall(:jl_get_julia_bindir, Any, ()), Base.DATAROOTDIR, "julia", "cert.pem")
+            abspath(ccall(:jl_get_julia_bindir, Any, ())::String, Base.DATAROOTDIR, "julia", "cert.pem")
         end
         set_ssl_cert_locations(cert_loc)
     end

--- a/stdlib/MozillaCACerts_jll/src/MozillaCACerts_jll.jl
+++ b/stdlib/MozillaCACerts_jll/src/MozillaCACerts_jll.jl
@@ -5,7 +5,7 @@
 module MozillaCACerts_jll
 
 function __init__()
-	global cacert = normpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "cert.pem")
+	global cacert = normpath(Sys.BINDIR::String, Base.DATAROOTDIR, "julia", "cert.pem")
 end
 
 end # module

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -901,7 +901,7 @@ function setup_interface(
         repl = repl,
         complete = replc,
         # When we're done transform the entered line into a call to helpmode function
-        on_done = respond(line->helpmode(outstream(repl), line), repl, julia_prompt,
+        on_done = respond(line::String->helpmode(outstream(repl), line), repl, julia_prompt,
                           pass_empty=true, suppress_on_semicolon=false))
 
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -146,7 +146,7 @@ mutable struct Error <: Result
     test_type::Symbol
     orig_expr
     value
-    backtrace
+    backtrace::String
     source::LineNumberNode
 
     function Error(test_type, orig_expr, value, bt, source)


### PR DESCRIPTION
While doing some other tests on #37754, I got the impression that the number of at-risk MethodInstances had risen (https://github.com/JuliaLang/julia/pull/37741#issuecomment-699487801). I'm still not sure it was causal, although precompiling Test methods makes sense as a potential source of newly-visible vulnerabilities. Whatever the origin, this PR reduces risk by helping inference mostly in path-related code (Pkg, BinaryPlatforms, and others). Together with https://github.com/JuliaLang/Pkg.jl/pull/2049, this drops our mean number of backedges for at-risk signatures (xref #37193) from the mid-30s to around 20, quite a significant drop for such a small set of changes.