### PR TITLE
fix type inference regression in Ryu

### DIFF
--- a/base/ryu/utils.jl
+++ b/base/ryu/utils.jl
@@ -355,8 +355,9 @@ function pow5invsplit_lookup end
 for T in (Float64, Float32, Float16)
     e2_max = exponent_max(T) - precision(T) - 2
     i_max = log10pow2(e2_max)
-    table = Any[pow5invsplit(T, i) for i = 0:i_max]
-    @eval pow5invsplit_lookup(::Type{$T}, i) = @inbounds($table[i+1])
+    table_sym = Symbol("pow5invsplit_table_", string(T))
+    @eval const $table_sym = Tuple(Any[pow5invsplit($T, i) for i = 0:$i_max])
+    @eval pow5invsplit_lookup(::Type{$T}, i) = @inbounds($table_sym[i+1])
 end
 
 
@@ -382,8 +383,9 @@ function pow5split_lookup end
 for T in (Float64, Float32, Float16)
     e2_min = 1 - exponent_bias(T) - significand_bits(T) - 2
     i_max = 1 - e2_min - log10pow5(-e2_min)
-    table = Any[pow5split(T, i) for i = 0:i_max]
-    @eval pow5split_lookup(::Type{$T}, i) = @inbounds($table[i+1])
+    table_sym = Symbol("pow5split_table_", string(T))
+    @eval const $table_sym = Tuple(Any[pow5split($T, i) for i = 0:$i_max])
+    @eval pow5split_lookup(::Type{$T}, i) = @inbounds($table_sym[i+1])
 end
 
 const DIGIT_TABLE = UInt8[


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/37163, a performance regression snuck in, likely due to a misunderstanding in that this array is not only used during compilation time but also at runtime. Making it `Any` is therefore detrimental for performance. This restores things while also avoiding the interpolation of the array into the AST because it makes e.g. `@code_warntype` annoying to read. Also, make the array into a tuple because that tends to codegen slightly better.

Before:

```jl
julia> a = rand();

julia> @btime Base.Ryu.writeshortest($a)
  1.544 μs (40 allocations: 1.02 KiB)
"0.7946694032978381"
```

after

```jl
julia> @btime Base.Ryu.writeshortest($a)
  49.430 ns (2 allocations: 432 bytes)
"0.5526067771685965"
```