### PR TITLE
Advertise `readchomp` function more

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -136,7 +136,7 @@ Note that Julia does not convert the endianness for you. Use [`ntoh`](@ref) or
 
     read(io::IO, String)
 
-Read the entirety of `io`, as a `String`.
+Read the entirety of `io`, as a `String` (see also [`readchomp`](@ref)).
 
 # Examples
 ```jldoctest

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -37,14 +37,15 @@ The `hello` is the output of the `echo` command, sent to [`stdout`](@ref). The r
 returns `nothing`, and throws an [`ErrorException`](@ref) if the external command fails to run
 successfully.
 
-If you want to read the output of the external command, [`read`](@ref) can be used instead:
+If you want to read the output of the external command, [`read`](@ref) or [`readchomp`](@ref)
+can be used instead:
 
 ```jldoctest
-julia> a = read(`echo hello`, String)
+julia> read(`echo hello`, String)
 "hello\n"
 
-julia> chomp(a) == "hello"
-true
+julia> readchomp(`echo hello`)
+"hello"
 ```
 
 More generally, you can use [`open`](@ref) to read from or write to an external command.


### PR DESCRIPTION
It seems to be the most convenient way to read text files/process
output, but it's hard to realize that it exists.