### PR TITLE
Fix Format parsing in Printf (escaped %)

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -73,7 +73,9 @@ end
 base(T) = T <: HexBases ? 16 : T <: Val{'o'} ? 8 : 10
 char(::Type{Val{c}}) where {c} = c
 
-@inline function _detectFormat!(f, bytes, len, pos::Int, fmts::Vector{Spec})
+# detect specific format such as "%04d" that starts at position pos
+# and push to vector of all formats fmts
+@inline function _detectformat!(f, bytes, len, pos::Int, fmts::Vector{Spec})
     leftalign = plus = space = zero = hash = false
     b = bytes[pos]
     pos += 1
@@ -158,15 +160,22 @@ function Format(f::AbstractString)
     isempty(f) && throw(ArgumentError("empty format string"))
     bytes = codeunits(f)
     len = length(bytes)
+    # start and actual position of the currently parsed segment
     start = pos = 1
+    # denotes if the current symbol (bytes[pos]) is escaped by '%'
     escaped = false
+    # denotes if the parsing reached the end of format f
     processing = true
+    # stores the actual symbol
     b = 0x00
+    # store the resulting substrings and formats
     strs = UnitRange{Int}[]
     fmts = Spec[]
     while processing
         while true
+            # the end of formate is reached
             if pos > len
+                # push the final substring range (if not escaped) and terminate
                 escaped && throw(ArgumentError("incomplete format string: '$f'"))
                 push!(strs, start:pos-1)
                 processing = false
@@ -174,12 +183,13 @@ function Format(f::AbstractString)
             end
             b = bytes[pos]
             if escaped && b != UInt8('%')
+                # new format detected: push actual substring range and detect the format
                 push!(strs, start:pos-2)
-                pos = _detectFormat!(f, bytes, len, pos, fmts)
-                start = pos
+                start = pos = _detectformat!(f, bytes, len, pos, fmts)
                 escaped = false
                 continue
             end
+            # update whether the next symbol is escaped and increment pos
             escaped = xor(escaped, b == UInt8('%'))
             pos += 1
         end
@@ -642,6 +652,9 @@ function fmtfallback(buf, pos, arg, spec::Spec{T}) where {T}
     return pos
 end
 
+# copy the subrange into output buffer (buf) starting at pos
+# while removing escaped '%' symbols
+# returns position of the next format
 @inline function _formatsubstringrange!(buf::Vector{UInt8}, str, range, pos)
     escapechar = false
     for i in range
@@ -690,16 +703,8 @@ plength(f::Spec{T}, x) where {T <: Floats} =
 @inline function computelen(substringranges, formats, args)
     len = sum(length, substringranges)
     N = length(formats)
-    # unroll up to 16 formats
-    Base.@nexprs 16 i -> begin
-        if N >= i
-            len += plength(formats[i], args[i])
-        end
-    end
-    if N > 16
-        for i = 17:length(formats)
-            len += plength(formats[i], args[i])
-        end
+    for i = 1:length(formats)
+        len += plength(formats[i], args[i])
     end
     return len
 end

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -162,7 +162,7 @@ function Format(f::AbstractString)
     escaped = false
     processing = true
     b = 0x00
-    strs = UnitRange{Int64}[]
+    strs = UnitRange{Int}[]
     fmts = Spec[]
     while processing
         while true

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -73,7 +73,7 @@ end
 base(T) = T <: HexBases ? 16 : T <: Val{'o'} ? 8 : 10
 char(::Type{Val{c}}) where {c} = c
 
-@inline function _detectFormat!(f, bytes, len, pos::Int64, fmts::Vector{Spec})
+@inline function _detectFormat!(f, bytes, len, pos::Int, fmts::Vector{Spec})
     leftalign = plus = space = zero = hash = false
     b = bytes[pos]
     pos += 1

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -435,6 +435,14 @@ end
     @test @sprintf("%d", 3//1) == "3"
     @test @sprintf("%d", Inf) == "Inf"
     @test @sprintf(" %d", NaN) == " NaN"
+
+    # 37784
+    @test Printf.@sprintf("1%%") == "1%"
+    @test Printf.@sprintf("%%1") == "%1"
+    @test Printf.@sprintf("1%%2") == "1%2"
+    @test Printf.@sprintf("1%%%d", 2) == "1%2"
+    @test Printf.@sprintf("1%%2%%3") == "1%2%3"
+
 end
 
 @testset "integers" begin


### PR DESCRIPTION
This PR aims to fix #37784 by updating `Format(f::AbstractString)` function. It moves format detection into a separate inlined function (only refactoring, no changes) for better readability. There are also new tests for the issue. Notice performance has not been properly tested yet.