### PR TITLE
fix bug with rand(::MersenneTwister, ::UInt128)

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -232,12 +232,11 @@ function mt_pop!(r::MersenneTwister, ::Type{T}) where T<:BitInteger
     (x128 >> (i128 * (sizeof(T) << 3))) % T
 end
 
-# not necessary, but very slightly more efficient
 function mt_pop!(r::MersenneTwister, ::Type{T}) where {T<:Union{Int128,UInt128}}
     reserve1(r, T)
-    @inbounds res = r.ints[r.idxI >> 4]
-    r.idxI -= 16
-    res % T
+    idx = r.idxI >> 4
+    r.idxI = idx << 4 - 16
+    @inbounds r.ints[idx] % T
 end
 
 


### PR DESCRIPTION
Generation of UInt64 and UInt128 share the same cache, but the routine
handling generation of UInt128 was not fully aknowledging the sharing.
This leads to situations like:

```
julia> m = MersenneTwister(0); rand(m, UInt64); rand(m, UInt128)
0x79ed9db9ec79a6a019c5f638a776ab3c

julia> rand(m, UInt64)
0x19c5f638a776ab3c
```
These values aren't independent enough!