### PR TITLE
Don't interpolate stdout in printf macro to avoid precompilation issues

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -758,9 +758,8 @@ julia> @printf "%.0f %.1f %f\\n" 0.5 0.025 -0.0078125
 """
 macro printf(io_or_fmt, args...)
     if io_or_fmt isa String
-        io = stdout
         fmt = Format(io_or_fmt)
-        return esc(:($Printf.format($io, $fmt, $(args...))))
+        return esc(:($Printf.format(stdout, $fmt, $(args...))))
     else
         io = io_or_fmt
         isempty(args) && throw(ArgumentError("must provide required format string"))


### PR DESCRIPTION
Fixes #37665. The subtle issue here was the at-printf macro using the
`stdout` variable at _macro-expansion-time_ and interpolating it into
the final `Printf.format` expanded call. If `stdout` was rebound between
expansion time and usage time, then we saw ugly libuv errors
(segfaults). This would happen mainly when a `Printf.@printf` call was
precompiled directly, so the macro expansion was precompiled and led to
the messed up `stdout` usage at runtime. The fix is to just not
interpolate `stdout` at macro-expansion time, but have the expanded call
use the global `stdout` at runtime.