### PR TITLE
RFC: stop generating precompile signatures for Distributed

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -64,6 +64,9 @@ if have_repl
     """
 end
 
+# This is disabled because it doesn't give much benefit
+# and the code in Distributed is poorly typed causing many invalidations
+#=
 Distributed = get(Base.loaded_modules,
           Base.PkgId(Base.UUID("8ba89e20-285c-5b6f-9357-94700520ee1b"), "Distributed"),
           nothing)
@@ -75,6 +78,8 @@ if Distributed !== nothing
     @distributed (+) for i = 1:100 Int(rand(Bool)) end
     """
 end
+=#
+
 
 Artifacts = get(Base.loaded_modules,
           Base.PkgId(Base.UUID("56f22d72-fd6d-98f1-02f0-08ddc0907c33"), "Artifacts"),


### PR DESCRIPTION
The distributed code is in general quite poorly typed so precompiling it leads to quite a lot of possible source of invalidations. Also, if you are spinning up a full distributed computation, you are probably not that worried about a short latency. This removes around 200 precompile signatures (out of 1500) from the build process.

Before:

```jl
julia> using Distributed

julia> @time     pmap(x->iseven(x) ? 1 : 0, 1:4);
  0.107108 seconds (128.56 k allocations: 7.853 MiB, 6.63% gc time, 99.45% compilation time)

julia> @time     @distributed (+) for i = 1:100 Int(rand(Bool)) end;
  0.055258 seconds (72.36 k allocations: 4.249 MiB, 98.02% compilation time)

```

vs now:

```jl
julia> using Distributed

julia> @time     pmap(x->iseven(x) ? 1 : 0, 1:4);
  0.510848 seconds (2.25 M allocations: 134.619 MiB, 4.30% gc time, 99.88% compilation time)

julia> @time     @distributed (+) for i = 1:100 Int(rand(Bool)) end;
  0.188521 seconds (394.07 k allocations: 23.134 MiB, 99.48% compilation time)
```

The only reason I added this in https://github.com/JuliaLang/julia/pull/33077 was that I found some random precompile files for Distributed lying around (that were probably very out of date)
