### PR TITLE
Fix some arithmetic invalidations

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -92,7 +92,7 @@ String(s::CodeUnits{UInt8,String}) = s.s
 ## low-level functions ##
 
 pointer(s::String) = unsafe_convert(Ptr{UInt8}, s)
-pointer(s::String, i::Integer) = pointer(s)+(i-1)
+pointer(s::String, i::Integer) = pointer(s) + Int(i)::Int - 1
 
 @pure ncodeunits(s::String) = Core.sizeof(s)
 codeunit(s::String) = UInt8


### PR DESCRIPTION
While investigating https://github.com/invenia/Intervals.jl/issues/144 I noticed these invalidations:

```julia
 inserting +(a, b::T) where T<:Interval in Intervals at /Users/omus/.julia/dev/Intervals/src/interval.jl:312 invalidated:
   mt_backedges: 1: signature Tuple{typeof(+), Ptr{UInt8}, Any} triggered MethodInstance for memcpy(::Ptr{UInt8}, ::Int64, ::Ptr{UInt8}, ::Any, ::Int64) (0 children)
                 2: signature Tuple{typeof(+), Ptr{UInt8}, Any} triggered MethodInstance for pointer(::String, ::Integer) (6 children)
```

The use of `Any` stuck out to me so I looked into these and the changes PR was is the result. With these changes this invalidations no longer exist. Please let me know if I'm off base here as I am new to addressing invalidations.