### PR TITLE
remove redundant `exception` field from `Task`

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -283,7 +283,7 @@ function close_chnl_on_taskdone(t::Task, c::Channel)
     lock(c)
     try
         isopen(c) || return
-        if istaskfailed(t) && task_result(t) isa Exception
+        if istaskfailed(t)
             close(c, TaskFailedException(t))
             return
         end

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -173,7 +173,6 @@ function (ss::SummarySize)(obj::Task)
     end
     size += ss(obj.storage)::Int
     size += ss(obj.donenotify)::Int
-    size += ss(obj.exception)::Int
     size += ss(obj.result)::Int
     # TODO: add stack size, and possibly traverse stack roots
     return size

--- a/base/task.jl
+++ b/base/task.jl
@@ -147,6 +147,9 @@ const task_state_failed   = UInt8(2)
     elseif field === :backtrace
         # TODO: this field name should be deprecated in 2.0
         return catch_stack(t)[end][2]
+    elseif field === :exception
+        # TODO: this field name should be deprecated in 2.0
+        return t._isexception ? t.result : nothing
     else
         return getfield(t, field)
     end
@@ -619,7 +622,8 @@ function schedule(t::Task, @nospecialize(arg); error=false)
     t._state === task_state_runnable || Base.error("schedule: Task not runnable")
     if error
         t.queue === nothing || Base.list_deletefirst!(t.queue, t)
-        setfield!(t, :exception, arg)
+        setfield!(t, :result, arg)
+        setfield!(t, :_isexception, true)
     else
         t.queue === nothing || Base.error("schedule: Task not runnable")
         setfield!(t, :result, arg)
@@ -683,9 +687,10 @@ function try_yieldto(undo)
         rethrow()
     end
     ct = current_task()
-    exc = ct.exception
-    if exc !== nothing
-        ct.exception = nothing
+    if ct._isexception
+        exc = ct.result
+        ct.result = nothing
+        ct._isexception = false
         throw(exc)
     end
     result = ct.result
@@ -695,8 +700,10 @@ end
 
 # yield to a task, throwing an exception in it
 function throwto(t::Task, @nospecialize exc)
-    t.exception = exc
-    return yieldto(t)
+    t.result = exc
+    t._isexception = true
+    set_next_task(t)
+    return try_yieldto(identity)
 end
 
 function ensure_rescheduled(othertask::Task)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2448,11 +2448,11 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "storage",
                                         "donenotify",
                                         "result",
-                                        "exception",
                                         "logstate",
                                         "code",
                                         "_state",
-                                        "sticky"),
+                                        "sticky",
+                                        "_isexception"),
                         jl_svec(10,
                                 jl_any_type,
                                 jl_any_type,
@@ -2461,10 +2461,10 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
-                                jl_any_type,
                                 jl_uint8_type,
+                                jl_bool_type,
                                 jl_bool_type),
-                        0, 1, 7);
+                        0, 1, 6);
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1728,11 +1728,11 @@ typedef struct _jl_task_t {
     jl_value_t *tls;
     jl_value_t *donenotify;
     jl_value_t *result;
-    jl_value_t *exception;
     jl_value_t *logstate;
     jl_function_t *start;
     uint8_t _state;
     uint8_t sticky; // record whether this Task can be migrated to a new thread
+    uint8_t _isexception; // set if `result` is an exception to throw or that we exited with
 
 // hidden state:
     // id of owning thread - does not need to be defined until the task runs
@@ -1743,6 +1743,8 @@ typedef struct _jl_task_t {
     size_t world_age;
     // saved exception stack
     jl_excstack_t *excstack;
+    // current exception handler
+    jl_handler_t *eh;
 
     jl_ucontext_t ctx; // saved thread state
     void *stkbuf; // malloc'd memory (either copybuf or stack)
@@ -1750,8 +1752,6 @@ typedef struct _jl_task_t {
     unsigned int copy_stack:31; // sizeof stack for copybuf
     unsigned int started:1;
 
-    // current exception handler
-    jl_handler_t *eh;
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
 

--- a/src/partr.c
+++ b/src/partr.c
@@ -234,7 +234,7 @@ void jl_init_threadinginfra(void)
 }
 
 
-void JL_NORETURN jl_finish_task(jl_task_t *t, jl_value_t *resultval JL_MAYBE_UNROOTED);
+void JL_NORETURN jl_finish_task(jl_task_t *t);
 
 // thread function: used by all except the main thread
 void jl_threadfun(void *arg)
@@ -261,8 +261,7 @@ void jl_threadfun(void *arg)
     free(targ);
 
     (void)jl_gc_unsafe_enter(ptls);
-    jl_current_task->exception = jl_nothing;
-    jl_finish_task(jl_current_task, jl_nothing); // noreturn
+    jl_finish_task(jl_current_task); // noreturn
 }
 
 

--- a/src/task.c
+++ b/src/task.c
@@ -181,13 +181,11 @@ static void restore_stack2(jl_task_t *t, jl_ptls_t ptls, jl_task_t *lastt)
 /* Rooted by the base module */
 static jl_function_t *task_done_hook_func JL_GLOBALLY_ROOTED = NULL;
 
-void JL_NORETURN jl_finish_task(jl_task_t *t, jl_value_t *resultval JL_MAYBE_UNROOTED)
+void JL_NORETURN jl_finish_task(jl_task_t *t)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     JL_SIGATOMIC_BEGIN();
-    t->result = resultval;
-    jl_gc_wb(t, t->result);
-    if (t->exception != jl_nothing)
+    if (t->_isexception)
         jl_atomic_store_release(&t->_state, JL_TASK_STATE_FAILED);
     else
         jl_atomic_store_release(&t->_state, JL_TASK_STATE_DONE);
@@ -444,8 +442,9 @@ JL_DLLEXPORT void jl_switch(void)
         return;
     }
     if (t->_state != JL_TASK_STATE_RUNNABLE || (t->started && t->stkbuf == NULL)) {
-        ct->exception = t->exception;
+        ct->_isexception = t->_isexception;
         ct->result = t->result;
+        jl_gc_wb(ct, ct->result);
         return;
     }
     if (ptls->in_finalizer)
@@ -629,7 +628,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->start = start;
     t->result = jl_nothing;
     t->donenotify = completion_future;
-    t->exception = jl_nothing;
+    t->_isexception = 0;
     // Inherit logger state from parent task
     t->logstate = ptls->current_task->logstate;
     // there is no active exception handler available on this stack yet
@@ -754,11 +753,11 @@ STATIC_OR_JS void NOINLINE JL_NORETURN start_task(void)
 #endif
 
     t->started = 1;
-    if (t->exception != jl_nothing) {
+    if (t->_isexception) {
         record_backtrace(ptls, 0);
-        jl_push_excstack(&t->excstack, t->exception,
+        jl_push_excstack(&t->excstack, t->result,
                          ptls->bt_data, ptls->bt_size);
-        res = t->exception;
+        res = t->result;
     }
     else {
         JL_TRY {
@@ -772,13 +771,14 @@ STATIC_OR_JS void NOINLINE JL_NORETURN start_task(void)
         }
         JL_CATCH {
             res = jl_current_exception();
-            t->exception = res;
-            jl_gc_wb(t, res);
+            t->_isexception = 1;
             goto skip_pop_exception;
         }
 skip_pop_exception:;
     }
-    jl_finish_task(t, res);
+    t->result = res;
+    jl_gc_wb(t, t->result);
+    jl_finish_task(t);
     gc_debug_critical_error();
     abort();
 }
@@ -1199,7 +1199,7 @@ void jl_init_root_task(void *stack_lo, void *stack_hi)
     ptls->current_task->start = NULL;
     ptls->current_task->result = jl_nothing;
     ptls->current_task->donenotify = jl_nothing;
-    ptls->current_task->exception = jl_nothing;
+    ptls->current_task->_isexception = 0;
     ptls->current_task->logstate = jl_nothing;
     ptls->current_task->eh = NULL;
     ptls->current_task->gcstack = NULL;

--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -112,7 +112,7 @@ function serialize(s::ClusterSerializer, t::Task)
     serialize(s, t.storage)
     serialize(s, t._state)
     serialize(s, t.result)
-    serialize(s, t.exception)
+    serialize(s, t._isexception)
 end
 
 function serialize(s::ClusterSerializer, g::GlobalRef)
@@ -251,7 +251,7 @@ function deserialize(s::ClusterSerializer, ::Type{Task})
     t.storage = deserialize(s)
     t._state = deserialize(s)::UInt8
     t.result = deserialize(s)
-    t.exception = deserialize(s)
+    t._isexception = deserialize(s)
     t
 end
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -284,7 +284,7 @@ struct REPLBackendRef
 end
 REPLBackendRef(backend::REPLBackend) = REPLBackendRef(backend.repl_channel, backend.response_channel)
 function destroy(ref::REPLBackendRef, state::Task)
-    if istaskfailed(state) && Base.task_result(state) isa Exception
+    if istaskfailed(state)
         close(ref.repl_channel, TaskFailedException(state))
         close(ref.response_channel, TaskFailedException(state))
     end


### PR DESCRIPTION
This drops another 8 bytes from `Task`, which is nice since it happens to drop us down to the next lower GC size class.

This also makes task failure work properly if you use `nothing` as an exception. Not that that matters, but it's conceptually satisfying :)