### PR TITLE
Add default constructor for Reverse{Fwd}()

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -45,6 +45,7 @@ end
 ReverseOrdering(rev::ReverseOrdering) = rev.fwd
 ReverseOrdering(fwd::Fwd) where {Fwd} = ReverseOrdering{Fwd}(fwd)
 ReverseOrdering() = ReverseOrdering(ForwardOrdering())
+ReverseOrdering{Fwd}() where {Fwd} = ReverseOrdering{Fwd}(Fwd())
 
 const DirectOrdering = Union{ForwardOrdering,ReverseOrdering{ForwardOrdering}}
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -12,6 +12,9 @@ using .Main.OffsetArrays
 @testset "Order" begin
     @test Forward == ForwardOrdering()
     @test Reverse == ReverseOrdering() == ReverseOrdering(Forward) == ReverseOrdering{ForwardOrdering}()
+    let T = ReverseOrdering{ReverseOrdering{ForwardOrdering}}
+        @test T() isa T
+    end
 end
 
 @testset "midpoint" begin

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -11,7 +11,7 @@ using .Main.OffsetArrays
 
 @testset "Order" begin
     @test Forward == ForwardOrdering()
-    @test Reverse == ReverseOrdering() == ReverseOrdering(Forward) == ReverseOrdering{ForwardOrdering}() 
+    @test Reverse == ReverseOrdering() == ReverseOrdering(Forward) == ReverseOrdering{ForwardOrdering}()
 end
 
 @testset "midpoint" begin

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -11,7 +11,7 @@ using .Main.OffsetArrays
 
 @testset "Order" begin
     @test Forward == ForwardOrdering()
-    @test ReverseOrdering(Forward) == ReverseOrdering() == Reverse
+    @test Reverse == ReverseOrdering() == ReverseOrdering(Forward) == ReverseOrdering{ForwardOrdering}() 
 end
 
 @testset "midpoint" begin


### PR DESCRIPTION
Follow up to https://github.com/JuliaLang/julia/pull/33736
if you have a RevereOrdering type and it has its type parameter.
Then most often it is the standard `typeof(Base.Reverse)` which is `ReverseOrdering{ForwardOrdering}`
which can be constructed as `ReverseOrdering(ForwardOrdering()) == Reverse`