### PR TITLE
Allow `getindex` of block diagonal matrices with `<:AbstractMatrix` elements

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -91,7 +91,7 @@ end
     r
 end
 diagzero(::Diagonal{T},i,j) where {T} = zero(T)
-diagzero(D::Diagonal{Matrix{T}},i,j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
+diagzero(D::Diagonal{<:AbstractMatrix{T}},i,j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
 
 function setindex!(D::Diagonal, v, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -571,6 +571,10 @@ end
 
     @test tr(D) == 10
     @test det(D) == 4
+
+    # sparse matrix block diagonals
+    s = SparseArrays.sparse([[1 2; 3 4]])
+    @test eltype(Diagonal([s, s])) == Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}}
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -574,7 +574,7 @@ end
 
     # sparse matrix block diagonals
     s = SparseArrays.sparse([[1 2; 3 4]])
-    @test eltype(Diagonal([s, s])) == Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}}
+    @test isa(Diagonal([s, s]), Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -578,6 +578,7 @@ end
     @test isa(D, Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
     @test D[1, 1] == s
     @test D[1, 2] == zero(s)
+    @test isa(D[2, 1], SparseMatrixCSC)
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -573,8 +573,11 @@ end
     @test det(D) == 4
 
     # sparse matrix block diagonals
-    s = SparseArrays.sparse([[1 2; 3 4]])
-    @test isa(Diagonal([s, s]), Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
+    s = SparseArrays.sparse([1 2; 3 4])
+    D = Diagonal([s, s])
+    @test isa(D, Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
+    @test D[1, 1] == s
+    @test D[1, 2] == zero(s)
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -60,4 +60,6 @@ function *(A::BiTriSym, B::BiTriSym)
     mul!(similar(A, TS, size(A)...), A, B)
 end
 
+LinearAlgebra.diagzero(D::Diagonal{<:AbstractSparseMatrix{T}},i,j) where {T} = spzeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
+
 end


### PR DESCRIPTION
edit: I actually misread the error message and a different bug was happening that I saw. I have updated the PR accordingly. 

`diagzero` previously had too strict of a parametric type which disallowed `getindex` for block diagonal matrices (off the main diagonal) with `<:AbstractMatrix` elements that weren't of type `Matrix`. Importantly, this includes `SparseMatrixCSC`.

Before: 

```julia
julia> s = SparseArrays.sparse([1 2; 3 4])
julia> D = Diagonal([s, s])
julia> D[1, 1]
2×2 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
  [1, 1]  =  1
  [2, 1]  =  3
  [1, 2]  =  2
  [2, 2]  =  4
julia> D[1, 2]
ERROR: MethodError: no method matching zero(::Type{SparseMatrixCSC{Int64,Int64}})
```

Now: 

```julia
julia> s = SparseArrays.sparse([1 2; 3 4])
julia> D = Diagonal([s, s])
julia> D[1, 1]
2×2 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
  [1, 1]  =  1
  [2, 1]  =  3
  [1, 2]  =  2
  [2, 2]  =  4
julia> D[1, 2]
3×4 Matrix{Float64}:
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
```

Note that this sized matrix is what we expect as, with `Matrix` types, we have:
```julia
julia> X = Diagonal([rand(3, 3), rand(4, 4)])
2×2 Diagonal{Matrix{Float64},Vector{Matrix{Float64}}}:
 [0.235365 0.101717 0.522715; 0.685988 0.973403 0.231717; 0.523063 0.298545 0.554994]  …                           ⋅                         
                          ⋅                                                               [0.413394 0.550945 0.601697 0.374732; 0.512641 0.953217 0.224468 0.650387; 0.568898 0.623149 0.307394 0.51296; 0.178735 0.159803 0.326031 0.896045]

julia> X[1, 2]
3×4 Matrix{Float64}:
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
```
