### PR TITLE
Fix clangsa on LLVM 10

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -491,6 +491,7 @@ $(eval $(call LLVM_PATCH,llvm-D84031)) # remove for LLVM 12
 $(eval $(call LLVM_PATCH,llvm-10-D85553)) # remove for LLVM 12
 $(eval $(call LLVM_PATCH,llvm-10-r_aarch64_prel32)) # remove for LLVM 12
 $(eval $(call LLVM_PATCH,llvm-10-r_ppc_rel)) # remove for LLVM 12
+$(eval $(call LLVM_PATCH,llvm-10-unique_function_clang-sa))
 ifeq ($(BUILD_LLVM_CLANG),1)
 $(eval $(call LLVM_PATCH,llvm-D88630-clang-cmake))
 endif
@@ -508,6 +509,7 @@ $(eval $(call LLVM_PATCH,llvm-julia-tsan-custom-as))
 $(eval $(call LLVM_PATCH,llvm-D80101)) # remove for LLVM 12
 $(eval $(call LLVM_PATCH,llvm-D84031)) # remove for LLVM 12
 $(eval $(call LLVM_PATCH,llvm-10-D85553)) # remove for LLVM 12
+$(eval $(call LLVM_PATCH,llvm-10-unique_function_clang-sa))
 ifeq ($(BUILD_LLVM_CLANG),1)
 $(eval $(call LLVM_PATCH,llvm-D88630-clang-cmake))
 endif

--- a/deps/patches/llvm-10-unique_function_clang-sa.patch
+++ b/deps/patches/llvm-10-unique_function_clang-sa.patch
@@ -1,0 +1,28 @@
+From 1fa6efaa946243004c45be92e66b324dc980df7d Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Thu, 17 Sep 2020 23:22:45 +0200
+Subject: [PATCH] clang-sa can't determine that !RHS implies !LHS
+
+---
+ llvm/include/llvm/ADT/FunctionExtras.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/llvm/ADT/FunctionExtras.h b/include/llvm/ADT/FunctionExtras.h
+index 121aa527a5d..b9b6d829b14 100644
+--- a/include/llvm/ADT/FunctionExtras.h
++++ b/include/llvm/ADT/FunctionExtras.h
+@@ -193,9 +193,11 @@ public:
+     // Copy the callback and inline flag.
+     CallbackAndInlineFlag = RHS.CallbackAndInlineFlag;
+ 
++#ifndef __clang_analyzer__
+     // If the RHS is empty, just copying the above is sufficient.
+     if (!RHS)
+       return;
++#endif
+ 
+     if (!isInlineStorage()) {
+       // The out-of-line case is easiest to move.
+-- 
+2.28.0
+

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -1030,15 +1030,15 @@ SymbolRef GCChecker::getSymbolForResult(const Expr *Result,
                                         const ValueState *OldValS,
                                         ProgramStateRef &State,
                                         CheckerContext &C) const {
+  QualType QT = Result->getType();
+  if (!QT->isPointerType() || QT->getPointeeType()->isVoidType())
+    return nullptr;
   auto ValLoc = State->getSVal(Result, C.getLocationContext()).getAs<Loc>();
   if (!ValLoc) {
     return nullptr;
   }
   SVal Loaded = State->getSVal(*ValLoc);
   if (Loaded.isUnknown() || !Loaded.getAsSymbol()) {
-    QualType QT = Result->getType();
-    if (!QT->isPointerType())
-      return nullptr;
     if (OldValS || GCChecker::isGCTracked(Result)) {
       Loaded = C.getSValBuilder().conjureSymbolVal(
           nullptr, Result, C.getLocationContext(), Result->getType(),

--- a/test/clangsa/MissingRoots.c
+++ b/test/clangsa/MissingRoots.c
@@ -329,7 +329,7 @@ jl_module_t *propagation(jl_module_t *m JL_PROPAGATES_ROOT);
 void module_member(jl_module_t *m)
 {
     for(int i=(int)m->usings.len-1; i >= 0; --i) {
-      jl_module_t *imp = (jl_module_t*)m->usings.items[i];
+      jl_module_t *imp = propagation(m);
       jl_gc_safepoint();
       look_at_value((jl_value_t*)imp);
       jl_module_t *prop = propagation(imp);


### PR DESCRIPTION
It failed assertions that we didn't notice, because we don't generally build clang with assertions on CI.
Also, backport a patch we have in Ygg, but not locally.