### PR TITLE
compiler: more accurate `isdefined_tfunc` for `NamedTuple` arg:

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -290,7 +290,7 @@ function isdefined_tfunc(@nospecialize(arg1), @nospecialize(sym))
                 else
                     ns = a1.parameters[1]
                     if isa(ns, Tuple)
-                        return Const(val in ns)
+                        return Const(1 <= idx <= length(ns))
                     end
                 end
             elseif idx <= 0 || (!isvatuple(a1) && idx > fieldcount(a1))

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -287,6 +287,11 @@ function isdefined_tfunc(@nospecialize(arg1), @nospecialize(sym))
             elseif a1.name === _NAMEDTUPLE_NAME
                 if isconcretetype(a1)
                     return Const(false)
+                else
+                    ns = a1.parameters[1]
+                    if isa(ns, Tuple)
+                        return Const(val in ns)
+                    end
                 end
             elseif idx <= 0 || (!isvatuple(a1) && idx > fieldcount(a1))
                 return Const(false)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1072,6 +1072,16 @@ end
 @test isdefined_tfunc(Tuple{Any,Vararg{Any}}, Const(1)) === Const(true)
 @test isdefined_tfunc(Tuple{Any,Vararg{Any}}, Const(2)) === Bool
 @test isdefined_tfunc(Tuple{Any,Vararg{Any}}, Const(3)) === Bool
+@testset "isdefined check for `NamedTuple`s" begin
+    # concrete `NamedTuple`s
+    @test isdefined_tfunc(NamedTuple{(:x,:y),Tuple{Int,Int}}, Const(:x)) === Const(true)
+    @test isdefined_tfunc(NamedTuple{(:x,:y),Tuple{Int,Int}}, Const(:y)) === Const(true)
+    @test isdefined_tfunc(NamedTuple{(:x,:y),Tuple{Int,Int}}, Const(:z)) === Const(false)
+    # non-concrete `NamedTuple`s
+    @test isdefined_tfunc(NamedTuple{(:x,:y),<:Tuple{Int,Any}}, Const(:x)) === Const(true)
+    @test isdefined_tfunc(NamedTuple{(:x,:y),<:Tuple{Int,Any}}, Const(:y)) === Const(true)
+    @test isdefined_tfunc(NamedTuple{(:x,:y),<:Tuple{Int,Any}}, Const(:z)) === Const(false)
+end
 
 @noinline map3_22347(f, t::Tuple{}) = ()
 @noinline map3_22347(f, t::Tuple) = (f(t[1]), map3_22347(f, Base.tail(t))...)


### PR DESCRIPTION
this will help the compiler, e.g. exclude unnecessary runtime calls of `haskey` when a keyword argument is inferred as non-concrete type
```julia
f(a; b = nothing, c = nothing) = return
let
    b = rand((nothing,1,1.))
    f(0; b) # <= now we don't need runtime `haskey(kwargs, :c)` call for this
end
```