### PR TITLE
[build system]: Fix `USE_SYSTEM_LIBM=1` build

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -610,13 +610,15 @@ endif
 # On Windows, we want shared library files to end up in $(build_bindir), instead of $(build_libdir)
 # We also don't really have a private bindir on windows right now, due to lack of RPATH.
 ifeq ($(OS),WINNT)
-build_shlibdir := $(build_bindir)
 shlibdir := $(bindir)
 private_shlibdir := $(bindir)
+build_shlibdir := $(build_bindir)
+build_private_shlibdir := $(build_bindir)
 else
-build_shlibdir := $(build_libdir)
 shlibdir := $(libdir)
 private_shlibdir := $(private_libdir)
+build_shlibdir := $(build_libdir)
+build_private_shlibdir := $(build_private_libdir)
 endif
 
 # If we're on windows, don't do versioned shared libraries.  If we're on OSX,
@@ -1489,21 +1491,25 @@ LIBGCC_NAME := libgcc_s_sjlj-1.$(SHLIB_EXT)
 else
 LIBGCC_NAME := libgcc_s_seh-1.$(SHLIB_EXT)
 endif
-LIBOPENLIBM_NAME := libopenlibm.$(SHLIB_EXT)
 endif
 ifeq ($(OS),Darwin)
 LIBGCC_NAME := libgcc_s.1.$(SHLIB_EXT)
-LIBOPENLIBM_NAME := libopenlibm.3.$(SHLIB_EXT)
 endif
 ifneq ($(findstring $(OS),Linux FreeBSD),)
 LIBGCC_NAME := libgcc_s.$(SHLIB_EXT).1
-LIBOPENLIBM_NAME := libopenlibm.$(SHLIB_EXT).3
 endif
+
 
 LIBGCC_BUILD_DEPLIB := $(call dep_lib_path,$(build_bindir),$(build_shlibdir)/$(LIBGCC_NAME))
 LIBGCC_INSTALL_DEPLIB := $(call dep_lib_path,$(bindir),$(private_shlibdir)/$(LIBGCC_NAME))
-LIBOPENLIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_bindir),$(build_shlibdir)/$(LIBOPENLIBM_NAME))
-LIBOPENLIBM_INSTALL_DEPLIB := $(call dep_lib_path,$(bindir),$(private_shlibdir)/$(LIBOPENLIBM_NAME))
+
+# USE_SYSTEM_LIBM causes it to get symlinked into build_private_shlibdir
+ifeq ($(USE_SYSTEM_LIBM),1)
+LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_bindir),$(build_private_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
+else
+LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_bindir),$(build_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
+endif
+LIBM_INSTALL_DEPLIB := $(call dep_lib_path,$(bindir),$(private_shlibdir)/$(LIBNAME).$(SHLIB_EXT))
 
 # We list:
 #  * libgcc_s, because FreeBSD needs to load ours, not the system one.
@@ -1514,10 +1520,10 @@ LIBOPENLIBM_INSTALL_DEPLIB := $(call dep_lib_path,$(bindir),$(private_shlibdir)/
 #  * debug builds must link against libjuliadebug, not libjulia
 #  * install time relative paths are not equal to build time relative paths (../lib vs. ../lib/julia)
 # That second point will no longer be true for most deps once they are placed within Artifacts directories.
-LOADER_BUILD_DEP_LIBS = $(LIBGCC_BUILD_DEPLIB):$(LIBOPENLIBM_BUILD_DEPLIB):$(LIBJULIA_BUILD_DEPLIB)
-LOADER_DEBUG_BUILD_DEP_LIBS = $(LIBGCC_BUILD_DEPLIB):$(LIBOPENLIBM_BUILD_DEPLIB):$(LIBJULIA_DEBUG_BUILD_DEPLIB)
-LOADER_INSTALL_DEP_LIBS = $(LIBGCC_INSTALL_DEPLIB):$(LIBOPENLIBM_INSTALL_DEPLIB):$(LIBJULIA_INSTALL_DEPLIB)
-LOADER_DEBUG_INSTALL_DEP_LIBS = $(LIBGCC_INSTALL_DEPLIB):$(LIBOPENLIBM_INSTALL_DEPLIB):$(LIBJULIA_DEBUG_INSTALL_DEPLIB)
+LOADER_BUILD_DEP_LIBS = $(LIBGCC_BUILD_DEPLIB):$(LIBM_BUILD_DEPLIB):$(LIBJULIA_BUILD_DEPLIB)
+LOADER_DEBUG_BUILD_DEP_LIBS = $(LIBGCC_BUILD_DEPLIB):$(LIBM_BUILD_DEPLIB):$(LIBJULIA_DEBUG_BUILD_DEPLIB)
+LOADER_INSTALL_DEP_LIBS = $(LIBGCC_INSTALL_DEPLIB):$(LIBM_INSTALL_DEPLIB):$(LIBJULIA_INSTALL_DEPLIB)
+LOADER_DEBUG_INSTALL_DEP_LIBS = $(LIBGCC_INSTALL_DEPLIB):$(LIBM_INSTALL_DEPLIB):$(LIBJULIA_DEBUG_INSTALL_DEPLIB)
 
 # Colors for make
 ifndef VERBOSE

--- a/Make.inc
+++ b/Make.inc
@@ -1509,7 +1509,7 @@ LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_bindir),$(build_private_shlibdi
 else
 LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_bindir),$(build_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
 endif
-LIBM_INSTALL_DEPLIB := $(call dep_lib_path,$(bindir),$(private_shlibdir)/$(LIBNAME).$(SHLIB_EXT))
+LIBM_INSTALL_DEPLIB := $(call dep_lib_path,$(bindir),$(private_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
 
 # We list:
 #  * libgcc_s, because FreeBSD needs to load ours, not the system one.


### PR DESCRIPTION
When we started preloading `libm.so`, we neglected to take into account
the name and location of `libm.so` when `USE_SYSTEM_LIBM=1` is used.
This should fix it on all systems except for Ubuntu, which has an `ld`
linker script instead of an actual library for `libm.so`, which has
never worked.

@yuyichao this should fix the `libm.so` issues you were seeing on your build.  I imagine we will need to do something for `libgcc_s` as well, as you said that you don't get a `libgcc_so.so.1` copied into your `$(JULIAHOME)/usr`.  That surprises me a little, as it means that there may be no compiler support libraries bundled with Julia, which means that `contrib/fixup-libgfortran.sh` probably isn't doing its job at all.  This in turn means that the Julia build is entirely unportable; so not fatal, but certainly not the kind of build we like to create.