### PR TITLE
Fix hashing of Dates.CompoundPeriod

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -472,6 +472,14 @@ Base.hash(x::Year, h::UInt) = hash(12 * value(x), h + otherperiod_seed(x))
 Base.hash(x::Quarter, h::UInt) = hash(3 * value(x), h + otherperiod_seed(x))
 Base.hash(x::Month, h::UInt) = hash(value(x), h + otherperiod_seed(x))
 
+function Base.hash(x::CompoundPeriod, h::UInt)
+    isempty(x.periods) && return hash(0, h + zero_or_fixedperiod_seed)
+    for p in x.periods
+        h = hash(p, h)
+    end
+    return h
+end
+
 Base.isless(x::FixedPeriod, y::OtherPeriod) = throw(MethodError(isless, (x, y)))
 Base.isless(x::OtherPeriod, y::FixedPeriod) = throw(MethodError(isless, (x, y)))
 

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -477,6 +477,14 @@ end
         end
     end
 end
+@testset "Hashing for CompoundPeriod (#37447)" begin
+    periods = [Dates.Year(0), Dates.Minute(0), Dates.Second(0), Dates.CompoundPeriod(),
+               Dates.Minute(2), Dates.Second(120), Dates.CompoundPeriod(Dates.Minute(2)),
+               Dates.CompoundPeriod(Dates.Second(120)), Dates.CompoundPeriod(Dates.Minute(1), Dates.Second(30))]
+    for x = periods, y = periods
+        @test isequal(x,y) == (hash(x) == hash(y))
+    end
+end
 
 @testset "#30832" begin
     @test Dates.toms(Dates.Second(1) + Dates.Nanosecond(1)) == 1e3

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -480,7 +480,7 @@ end
 @testset "Hashing for CompoundPeriod (#37447)" begin
     periods = [Dates.Year(0), Dates.Minute(0), Dates.Second(0), Dates.CompoundPeriod(),
                Dates.Minute(2), Dates.Second(120), Dates.CompoundPeriod(Dates.Minute(2)),
-               Dates.CompoundPeriod(Dates.Second(120)), Dates.CompoundPeriod(Dates.Minute(1), Dates.Second(30))]
+               Dates.CompoundPeriod(Dates.Second(120)), Dates.CompoundPeriod(Dates.Minute(1), Dates.Second(60))]
     for x = periods, y = periods
         @test isequal(x,y) == (hash(x) == hash(y))
     end


### PR DESCRIPTION
Fixes #37447.

This PR adds a `hash` method for `Base.CompoundPeriod` that is compatible with `isequal`.