### PR TITLE
Update `methods` to specialize on `mod` argument

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -849,7 +849,7 @@ A list of modules can also be specified as an array.
     At least Julia 1.4 is required for specifying a module.
 """
 function methods(@nospecialize(f), @nospecialize(t),
-                 @nospecialize(mod::Union{Tuple{Module},AbstractArray{Module},Nothing}=nothing))
+                 @nospecialize(mod::Union{Tuple{Module},Array{Module},Nothing}=nothing))
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end
@@ -879,7 +879,7 @@ function methods_including_ambiguous(@nospecialize(f), @nospecialize(t))
 end
 
 function methods(@nospecialize(f),
-                 @nospecialize(mod::Union{Module,AbstractArray{Module},Nothing}=nothing))
+                 @nospecialize(mod::Union{Module,Array{Module},Nothing}=nothing))
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -841,15 +841,15 @@ end
 
 Return the method table for `f`.
 
-If `types` is specified, return an array of methods whose types match.
-If `module` is specified, return an array of methods defined in that module.
-A list of modules can also be specified as an array.
+If `types` is specified, return a vector of methods whose types match.
+If `module` is specified, return a vector of methods defined in that module.
+A list of modules can also be specified as a vector.
 
 !!! compat "Julia 1.4"
     At least Julia 1.4 is required for specifying a module.
 """
 function methods(@nospecialize(f), @nospecialize(t),
-                 @nospecialize(mod::Union{Tuple{Module},Array{Module},Nothing}=nothing))
+                 @nospecialize(mod::Union{Tuple{Module},Array{Module,1},Nothing}=nothing))
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end
@@ -879,7 +879,7 @@ function methods_including_ambiguous(@nospecialize(f), @nospecialize(t))
 end
 
 function methods(@nospecialize(f),
-                 @nospecialize(mod::Union{Module,Array{Module},Nothing}=nothing))
+                 @nospecialize(mod::Union{Module,Array{Module,1},Nothing}=nothing))
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -841,15 +841,15 @@ end
 
 Return the method table for `f`.
 
-If `types` is specified, return a vector of methods whose types match.
-If `module` is specified, return a vector of methods defined in that module.
-A list of modules can also be specified as a vector.
+If `types` is specified, return an array of methods whose types match.
+If `module` is specified, return an array of methods defined in that module.
+A list of modules can also be specified as an array.
 
 !!! compat "Julia 1.4"
     At least Julia 1.4 is required for specifying a module.
 """
 function methods(@nospecialize(f), @nospecialize(t),
-                 @nospecialize(mod::Union{Tuple{Module},Array{Module,1},Nothing}=nothing))
+                 mod::Union{Tuple{Module},AbstractArray{Module},Nothing}=nothing)
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end
@@ -879,7 +879,7 @@ function methods_including_ambiguous(@nospecialize(f), @nospecialize(t))
 end
 
 function methods(@nospecialize(f),
-                 @nospecialize(mod::Union{Module,Array{Module,1},Nothing}=nothing))
+                 mod::Union{Module,AbstractArray{Module},Nothing}=nothing)
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
 end


### PR DESCRIPTION
While investigating invenia/Intervals.jl#144 I noticed this invalidation:
```julia
inserting -(a, b::Interval) in Intervals at /Users/omus/.julia/dev/Intervals/src/interval.jl:314 invalidated:
   mt_backedges: 1: signature Tuple{typeof(-), Module, Any} triggered MethodInstance for _in_range(::Module, ::AbstractRange{Module}) (1 children)
   49 mt_cache
```
An `AbstractRange{Module}` seemed strange so I did some digging and noticed `m.method.module ∈ mod` inside of `methods`. As far as I can tell nothing is actually creating a `AbstractRange{Module}` but, possibly due to `@nospecialize`, the compiler seems to be specializing `in` calls for all possible arguments. (Note: this is purely theory crafting on my part)

Restricting the argument to `Array` eliminates the invalidation. We could probably reduce the argument to `Vector` safely but that would require some changes to the docstring.