### PR TITLE
InteractiveUtils: define default editors during package load

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -121,7 +121,8 @@ function define_default_editors()
     define_editor(Any[
         "vim", "vi", "nvim", "mvim", "nano", "micro",
         r"\bemacs\b.*\s(-nw|--no-window-system)\b",
-        r"\bemacsclient\b.\s*-(-?nw|t|-?tty)\b"], wait=true) do cmd, path, line
+        r"\bemacsclient\b.\s*-(-?nw|t|-?tty)\b",
+    ], wait=true) do cmd, path, line
         `$cmd +$line $path`
     end
     define_editor(["textmate", "mate", "kate"]) do cmd, path, line
@@ -159,6 +160,7 @@ function define_default_editors()
         end
     end
 end
+define_default_editors()
 
 """
     editor()
@@ -191,7 +193,6 @@ by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environment variable.
 See also: [`define_editor`](@ref)
 """
 function edit(path::AbstractString, line::Integer=0)
-    isempty(EDITOR_CALLBACKS) && define_default_editors()
     path isa String || (path = convert(String, path))
     if endswith(path, ".jl")
         p = find_source_file(path)


### PR DESCRIPTION
Previously if you defined a new editor before calling `edit` it
prevented the default editors from being defined ever. This defines
the default editors no matter what.