### PR TITLE
a few improvements to compilation timing

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -108,24 +108,30 @@ function time_print(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0)
     timestr = Ryu.writefixed(Float64(elapsedtime/1e9), 6)
     length(timestr) < 10 && print(" "^(10 - length(timestr)))
     print(timestr, " seconds")
+    parens = bytes != 0 || allocs != 0 || gctime > 0 || compile_time > 0
+    parens && print(" (")
     if bytes != 0 || allocs != 0
         allocs, ma = prettyprint_getunits(allocs, length(_cnt_units), Int64(1000))
         if ma == 1
-            print(" (", Int(allocs), _cnt_units[ma], allocs==1 ? " allocation: " : " allocations: ")
+            print(Int(allocs), _cnt_units[ma], allocs==1 ? " allocation: " : " allocations: ")
         else
-            print(" (", Ryu.writefixed(Float64(allocs), 2), _cnt_units[ma], " allocations: ")
+            print(Ryu.writefixed(Float64(allocs), 2), _cnt_units[ma], " allocations: ")
         end
         print(format_bytes(bytes))
     end
     if gctime > 0
-        print(", ", Ryu.writefixed(Float64(100*gctime/elapsedtime), 2), "% gc time")
+        if bytes != 0 || allocs != 0
+            print(", ")
+        end
+        print(Ryu.writefixed(Float64(100*gctime/elapsedtime), 2), "% gc time")
     end
     if compile_time > 0
-        print(", ", Ryu.writefixed(Float64(100*compile_time/elapsedtime), 2), "% compilation time")
+        if bytes != 0 || allocs != 0 || gctime > 0
+            print(", ")
+        end
+        print(Ryu.writefixed(Float64(100*compile_time/elapsedtime), 2), "% compilation time")
     end
-    if bytes != 0 || allocs != 0
-        print(")")
-    end
+    parens && print(")")
     nothing
 end
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7140,6 +7140,7 @@ jl_compile_result_t jl_emit_code(
         jl_value_t *jlrettype,
         jl_codegen_params_t &params)
 {
+    JL_TIMING(CODEGEN);
     // caller must hold codegen_lock
     jl_llvm_functions_t decls = {};
     std::unique_ptr<Module> m;
@@ -7170,6 +7171,7 @@ jl_compile_result_t jl_emit_codeinst(
         jl_code_info_t *src,
         jl_codegen_params_t &params)
 {
+    JL_TIMING(CODEGEN);
     JL_GC_PUSH1(&src);
     if (!src) {
         src = (jl_code_info_t*)codeinst->inferred;
@@ -7242,6 +7244,7 @@ void jl_compile_workqueue(
     std::map<jl_code_instance_t*, jl_compile_result_t> &emitted,
     jl_codegen_params_t &params, CompilationPolicy policy)
 {
+    JL_TIMING(CODEGEN);
     jl_code_info_t *src = NULL;
     JL_GC_PUSH1(&src);
     while (!params.workqueue.empty()) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -67,11 +67,10 @@ void jl_jit_globals(std::map<void *, GlobalVariable*> &globals)
     }
 }
 
-static uint64_t cumulative_compile_time = 0;
-
 extern "C" JL_DLLEXPORT
-uint64_t jl_cumulative_compile_time_ns() {
-    return cumulative_compile_time;
+uint64_t jl_cumulative_compile_time_ns()
+{
+    return jl_cumulative_compile_time;
 }
 
 // this generates llvm code for the lambda info
@@ -105,7 +104,6 @@ static jl_callptr_t _jl_compile_codeinst(
     params.world = world;
     std::map<jl_code_instance_t*, jl_compile_result_t> emitted;
     {
-        JL_TIMING(CODEGEN);
         jl_compile_result_t result = jl_emit_codeinst(codeinst, src, params);
         if (std::get<0>(result))
             emitted[codeinst] = std::move(result);
@@ -236,7 +234,8 @@ void jl_compile_extern_c(void *llvmmod, void *p, void *sysimg, jl_value_t *declr
         if (llvmmod == NULL)
             jl_add_to_ee(std::unique_ptr<Module>(into));
     }
-    cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1)
+        jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock);
 }
 
@@ -260,10 +259,8 @@ void jl_extern_c(jl_value_t *declrt, jl_tupletype_t *sigt)
     if (!jl_is_concrete_type(declrt) || jl_is_kind(declrt))
         jl_error("@ccallable: return type must be concrete and correspond to a C type");
     JL_LOCK(&codegen_lock);
-    uint64_t compiler_start_time = jl_hrtime();
     if (!jl_type_mappable_to_c(declrt))
         jl_error("@ccallable: return type doesn't correspond to a C type");
-    cumulative_compile_time += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock);
 
     // validate method signature
@@ -329,7 +326,8 @@ jl_code_instance_t *jl_generate_fptr(jl_method_instance_t *mi JL_PROPAGATES_ROOT
     else {
         codeinst = NULL;
     }
-    cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1)
+        jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock);
     JL_GC_POP();
     return codeinst;
@@ -369,7 +367,8 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
         }
         JL_GC_POP();
     }
-    cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1)
+        jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock); // Might GC
 }
 
@@ -415,7 +414,7 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
                 }
                 JL_GC_POP();
             }
-            cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+            jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
             JL_UNLOCK(&codegen_lock);
         }
         if (specfptr != 0)
@@ -948,7 +947,6 @@ void jl_jit_share_data(Module &M)
 
 static void jl_add_to_ee(std::unique_ptr<Module> m)
 {
-    JL_TIMING(LLVM_EMIT);
 #if defined(_CPU_X86_64_) && defined(_OS_WINDOWS_)
     // Add special values used by debuginfo to build the UnwindData table registration for Win64
     Type *T_uint32 = Type::getInt32Ty(m->getContext());

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -116,6 +116,8 @@ static inline uint64_t cycleclock(void)
 
 #include "timing.h"
 
+extern uint64_t jl_cumulative_compile_time;
+
 #ifdef _COMPILER_MICROSOFT_
 #  define jl_return_address() ((uintptr_t)_ReturnAddress())
 #else

--- a/src/timing.h
+++ b/src/timing.h
@@ -53,8 +53,6 @@ void jl_timing_block_stop(jl_timing_block_t *cur_block);
         X(METHOD_LOOKUP_FAST),    \
         X(LLVM_OPT),              \
         X(LLVM_MODULE_FINISH),    \
-        X(LLVM_EMIT),             \
-        X(METHOD_LOOKUP_COMPILE), \
         X(METHOD_MATCH),          \
         X(TYPE_CACHE_LOOKUP),     \
         X(TYPE_CACHE_INSERT),     \


### PR DESCRIPTION
- print extra time info consistently parenthesized
- include more inference time in compile time
- try to make CODEGEN timing more accurate
- remove useless METHOD_LOOKUP_COMPILE and LLVM_EMIT timings