### PR TITLE
Declare `level` type for `default_metafmt`

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -350,7 +350,7 @@ function logmsg_code(_module, file, line, level, message, exs...)
         let
             level = $level
             std_level = convert(LogLevel, level)
-            if std_level >= getindex(_min_enabled_level)
+            if std_level >= _min_enabled_level[]
                 group = $(log_data._group)
                 _module = $(log_data._module)
                 logger = current_logger_for_env(std_level, group, _module)
@@ -458,7 +458,7 @@ function logmsg_shim(level, message, _module, group, id, file, line, kwargs)
 end
 
 # Global log limiting mechanism for super fast but inflexible global log limiting.
-const _min_enabled_level = Ref(Debug)
+const _min_enabled_level = Ref{LogLevel}(Debug)
 
 # LogState - a cache of data extracted from the logger, plus the logger itself.
 struct LogState

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -50,14 +50,14 @@ function showvalue(io, e::Tuple{Exception,Any})
 end
 showvalue(io, ex::Exception) = showerror(io, ex)
 
-function default_logcolor(level)
+function default_logcolor(level::LogLevel)
     level < Info  ? Base.debug_color() :
     level < Warn  ? Base.info_color()  :
     level < Error ? Base.warn_color()  :
                     Base.error_color()
 end
 
-function default_metafmt(level, _module, group, id, file, line)
+function default_metafmt(level::LogLevel, _module, group, id, file, line)
     @nospecialize
     color = default_logcolor(level)
     prefix = (level == Warn ? "Warning" : string(level))*':'


### PR DESCRIPTION
While investigating invenia/Intervals.jl#144 I noticed these invalidations:

```julia
 inserting isless(a, b::Intervals.Endpoint{T, Intervals.Direction{:Left}(), B} where B where T) in Intervals at /Users/omus/.julia/dev/Intervals/src/endpoint.jl:155 invalidated:
   mt_backedges: 1: signature Tuple{typeof(isless), Base.CoreLogging.LogLevel, Any} triggered MethodInstance for <(::Base.CoreLogging.LogLevel, ::Any) (2 children)

 inserting isless(a::Intervals.Endpoint{T, Intervals.Direction{:Right}(), B} where B where T, b) in Intervals at /Users/omus/.julia/dev/Intervals/src/endpoint.jl:164 invalidated:
   mt_backedges: 1: signature Tuple{typeof(isless), Any, Base.CoreLogging.LogLevel} triggered MethodInstance for <(::Any, ::Base.CoreLogging.LogLevel) (3 children)
   41 mt_cache
```

These `Any` comparisons are created from `Logging.default_metafmt` which uses `@nospecialize` on all arguments. Using a type declaration removes these sources of invalidations. The other changes are minor refactoring to make the code clearer.