### PR TITLE
Artifacts: disallow downloading via reflection hacks on Pkg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,6 +150,8 @@ Standard library changes
 * The `Pkg.Artifacts` module has been imported as a separate standard library.  It is still available as
   `Pkg.Artifacts`, however starting from Julia v1.6+, packages may import simply `Artifacts` without importing
   all of `Pkg` alongside ([#37320]).
+* To download artifacts lazily, `LazyArtifacts` now must be explicitly listed as a dependency, to avoid needing the
+  support machinery to be available when it is not commonly needed ([#37844]).
 * `@time` now reports if the time presented included any compilation time, which is shown as a percentage ([#37678]).
 * `@varinfo` can now report non-exported objects within modules, look recursively into submodules, and return a sorted
   results table ([#38042]).

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -68,6 +68,9 @@ let
 
         # 4-depth packages
         :Pkg,
+
+        # 5-depth packages
+        :LazyArtifacts,
     ]
     maxlen = reduce(max, textwidth.(string.(stdlibs)); init=0)
 

--- a/stdlib/Artifacts/test/.gitignore
+++ b/stdlib/Artifacts/test/.gitignore
@@ -1,0 +1,1 @@
+/artifacts/

--- a/stdlib/Artifacts/test/refresh_artifacts.jl
+++ b/stdlib/Artifacts/test/refresh_artifacts.jl
@@ -1,0 +1,23 @@
+using Artifacts: with_artifacts_directory
+# using Pkg.Artifacts: ensure_all_artifacts_installed
+using Pkg.Artifacts: load_artifacts_toml, ensure_artifact_installed
+let
+    tempdir = joinpath(@__DIR__, "artifacts")
+    toml = joinpath(@__DIR__, "Artifacts.toml")
+    unused = Base.BinaryPlatforms.Platform(string(Sys.ARCH), "linux")
+    with_artifacts_directory(tempdir) do
+        # ensure_all_artifacts_installed(toml; include_lazy=false)
+        dict = load_artifacts_toml(toml)
+        for (name, meta) in dict
+            if meta isa Array
+                for meta in meta
+                    get(meta, "lazy", false) && continue
+                    ensure_artifact_installed(name, meta, toml; platform=unused)
+                end
+            else; meta::Dict
+                get(meta, "lazy", false) && continue
+                ensure_artifact_installed(name, meta, toml; platform=unused)
+            end
+        end
+    end
+end

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -3,6 +3,9 @@
 using Artifacts, Test, Base.BinaryPlatforms
 using Artifacts: with_artifacts_directory, pack_platform!, unpack_platform
 
+# prepare for the package tests by ensuring the required artifacts are downloaded now
+run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifacts.jl"))`, "TERM"=>"dumb"))
+
 @testset "Artifact Paths" begin
     mktempdir() do tempdir
         with_artifacts_directory(tempdir) do
@@ -78,45 +81,43 @@ end
 end
 
 @testset "Artifact Slash-indexing" begin
-    mktempdir() do tempdir
-        with_artifacts_directory(tempdir) do
-            exeext = Sys.iswindows() ? ".exe" : ""
+    tempdir = joinpath(@__DIR__, "artifacts")
+    with_artifacts_directory(tempdir) do
+        exeext = Sys.iswindows() ? ".exe" : ""
 
-            # simple lookup, gives us the directory for `c_simple` for the current architecture
-            c_simple_dir = artifact"c_simple"
-            @test isdir(c_simple_dir)
-            c_simple_exe_path = joinpath(c_simple_dir, "bin", "c_simple$(exeext)")
-            @test isfile(c_simple_exe_path)
+        # simple lookup, gives us the directory for `c_simple` for the current architecture
+        c_simple_dir = artifact"c_simple"
+        @test isdir(c_simple_dir)
+        c_simple_exe_path = joinpath(c_simple_dir, "bin", "c_simple$(exeext)")
+        @test isfile(c_simple_exe_path)
 
-            # Simple slash-indexed lookup
-            c_simple_bin_path = artifact"c_simple/bin"
-            @test isdir(c_simple_bin_path)
-            # Test that forward and backward slash are equivalent
-            @test artifact"c_simple\\bin" == artifact"c_simple/bin"
+        # Simple slash-indexed lookup
+        c_simple_bin_path = artifact"c_simple/bin"
+        @test isdir(c_simple_bin_path)
+        # Test that forward and backward slash are equivalent
+        @test artifact"c_simple\\bin" == artifact"c_simple/bin"
 
-            # Dynamically-computed lookup; not done at compile-time
-            generate_artifact_name() = "c_simple"
-            c_simple_dir = @artifact_str(generate_artifact_name())
-            @test isdir(c_simple_dir)
-            c_simple_exe_path = joinpath(c_simple_dir, "bin", "c_simple$(exeext)")
-            @test isfile(c_simple_exe_path)
+        # Dynamically-computed lookup; not done at compile-time
+        generate_artifact_name() = "c_simple"
+        c_simple_dir = @artifact_str(generate_artifact_name())
+        @test isdir(c_simple_dir)
+        c_simple_exe_path = joinpath(c_simple_dir, "bin", "c_simple$(exeext)")
+        @test isfile(c_simple_exe_path)
 
-            # Dynamically-computed slash-indexing:
-            generate_bin_path(pathsep) = "c_simple$(pathsep)bin$(pathsep)c_simple$(exeext)"
-            @test isfile(@artifact_str(generate_bin_path("/")))
-            @test isfile(@artifact_str(generate_bin_path("\\")))
-        end
+        # Dynamically-computed slash-indexing:
+        generate_bin_path(pathsep) = "c_simple$(pathsep)bin$(pathsep)c_simple$(exeext)"
+        @test isfile(@artifact_str(generate_bin_path("/")))
+        @test isfile(@artifact_str(generate_bin_path("\\")))
     end
 end
 
 @testset "@artifact_str Platform passing" begin
-    mktempdir() do tempdir
-        with_artifacts_directory(tempdir) do
-            win64 = Platform("x86_64", "windows")
-            mac64 = Platform("x86_64", "macos")
-            @test basename(@artifact_str("c_simple", win64)) == "444cecb70ff39e8961dd33e230e151775d959f37"
-            @test basename(@artifact_str("c_simple", mac64)) == "7ba74e239348ea6c060f994c083260be3abe3095"
-        end
+    tempdir = joinpath(@__DIR__, "artifacts")
+    with_artifacts_directory(tempdir) do
+        win64 = Platform("x86_64", "windows")
+        mac64 = Platform("x86_64", "macos")
+        @test basename(@artifact_str("c_simple", win64)) == "444cecb70ff39e8961dd33e230e151775d959f37"
+        @test basename(@artifact_str("c_simple", mac64)) == "7ba74e239348ea6c060f994c083260be3abe3095"
     end
 end
 
@@ -130,4 +131,15 @@ end
     @test length(keys(artifacts)) == 2
     @test artifacts["c_simple"]["git-tree-sha1"] == "0c509b3302db90a9393d6036c3ffcd14d190523d"
     @test artifacts["socrates"]["git-tree-sha1"] == "43563e7631a7eafae1f9f8d9d332e3de44ad7239"
+end
+
+@testset "@artifact_str install errors" begin
+    mktempdir() do tempdir
+        with_artifacts_directory(tempdir) do
+            ex = @test_throws ErrorException artifact"c_simple"
+            @test startswith(ex.value.msg, "Artifact \"c_simple\" was not installed correctly. ")
+            ex = @test_throws ErrorException artifact"socrates"
+            @test startswith(ex.value.msg, "Artifact \"socrates\" is a lazy artifact; ")
+        end
+    end
 end

--- a/stdlib/LazyArtifacts/Project.toml
+++ b/stdlib/LazyArtifacts/Project.toml
@@ -1,0 +1,12 @@
+name = "LazyArtifacts"
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/stdlib/LazyArtifacts/src/LazyArtifacts.jl
+++ b/stdlib/LazyArtifacts/src/LazyArtifacts.jl
@@ -1,0 +1,15 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module LazyArtifacts
+
+# reexport the Artifacts API
+using Artifacts: Artifacts,
+       artifact_exists, artifact_path, artifact_meta, artifact_hash,
+       select_downloadable_artifacts, find_artifacts_toml, @artifact_str
+export artifact_exists, artifact_path, artifact_meta, artifact_hash,
+       select_downloadable_artifacts, find_artifacts_toml, @artifact_str
+
+# define a function for satisfying lazy Artifact downloads
+using Pkg.Artifacts: ensure_artifact_installed
+
+end

--- a/stdlib/LazyArtifacts/test/Artifacts.toml
+++ b/stdlib/LazyArtifacts/test/Artifacts.toml
@@ -1,0 +1,1 @@
+../../Artifacts/test/Artifacts.toml

--- a/stdlib/LazyArtifacts/test/runtests.jl
+++ b/stdlib/LazyArtifacts/test/runtests.jl
@@ -1,0 +1,25 @@
+using LazyArtifacts
+using Test
+
+mktempdir() do tempdir
+    LazyArtifacts.Artifacts.with_artifacts_directory(tempdir) do
+        socrates_dir = artifact"socrates"
+        @test isdir(socrates_dir)
+        ex = @test_throws ErrorException artifact"c_simple"
+        @test startswith(ex.value.msg, "Artifact \"c_simple\" was not installed correctly. ")
+    end
+end
+
+# Need to set depwarn flag before testing deprecations
+@test success(run(setenv(`$(Base.julia_cmd()) --depwarn=no --startup-file=no -e '
+    using Artifacts, Pkg
+    using Test
+    mktempdir() do tempdir
+        Artifacts.with_artifacts_directory(tempdir) do
+            socrates_dir = @test_logs(
+                    (:warn, "using Pkg instead of using LazyArtifacts is deprecated"),
+                    artifact"socrates")
+            @test isdir(socrates_dir)
+        end
+    end'`,
+    dir=@__DIR__)))

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -15,7 +15,7 @@ $(build_datarootdir)/julia/stdlib/$(VERSDIR):
 	mkdir -p $@
 
 STDLIBS = Artifacts Base64 CRC32c Dates DelimitedFiles Distributed FileWatching \
-          Future InteractiveUtils Libdl LibGit2 LinearAlgebra Logging \
+          Future InteractiveUtils LazyArtifacts Libdl LibGit2 LinearAlgebra Logging \
           Markdown Mmap Printf Profile Random REPL Serialization SHA \
           SharedArrays Sockets SparseArrays SuiteSparse Test TOML Unicode UUIDs \
           MozillaCACerts_jll LibCURL_jll

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -112,7 +112,7 @@ function choosetests(choices = [])
         filter!(x -> (x != "Profile"), tests)
     end
 
-    net_required_for = ["Sockets", "LibGit2", "LibCURL", "Downloads"]
+    net_required_for = ["Sockets", "LibGit2", "LibCURL", "Downloads", "Artifacts", "LazyArtifacts"]
     net_on = true
     try
         ipa = getipaddr()

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -291,7 +291,7 @@ try
                      Base.PkgId(m) => Base.module_build_id(m)
                  end for s in
                 [:Artifacts, :Base64, :CRC32c, :Dates, :DelimitedFiles, :Distributed, :FileWatching, :Markdown,
-                 :Future, :Libdl, :LinearAlgebra, :Logging, :Mmap, :Printf,
+                 :Future, :LazyArtifacts, :Libdl, :LinearAlgebra, :Logging, :Mmap, :Printf,
                  :Profile, :Random, :Serialization, :SharedArrays, :SparseArrays, :SuiteSparse, :Test,
                  :Unicode, :REPL, :InteractiveUtils, :Pkg, :LibGit2, :SHA, :UUIDs, :Sockets,
                  :Statistics, :TOML, :MozillaCACerts_jll, :LibCURL_jll, :LibCURL, :Downloads,


### PR DESCRIPTION
Packages should never access `Base.loaded_modules()` to call functions from it. This avoids #37731 (in Artifacts, though the new LazyArtifacts test still would have triggered it), though doesn't fix the Pkg bug that causes it (which is now fixed).

Example:
```
julia> using Artifacts; artifact"c_simple"
ERROR: Artifact "c_simple" is missing. Try `using Pkg; Pkg.build("Main"); Pkg.Artifacts.ensure_all_artifacts_installed("/Users/jameson/julia/stdlib/Artifacts/test/Artifacts.toml")`?
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] _artifact_str(__module__::Module, artifacts_toml::String, name::SubString{String}, path_tail::String, artifact_dict::Dict{String, Any}, hash::Base.SHA1, platform::Base.BinaryPlatforms.Platform)
   @ Artifacts ~/julia/usr/share/julia/stdlib/v1.6/Artifacts/src/Artifacts.jl:495
 [3] invokelatest(::Any, ::Any, ::Vararg{Any, N} where N; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Base ./essentials.jl:709
 [4] invokelatest(::Any, ::Any, ::Vararg{Any, N} where N)
   @ Base ./essentials.jl:708
 [5] top-level scope
   @ ~/julia/usr/share/julia/stdlib/v1.6/Artifacts/src/Artifacts.jl:610
```