### PR TITLE
Add predicate-reduce specializations over sparse matrix columns

### DIFF
--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2962,6 +2962,28 @@ end
     @test SparseArrays.getcolptr(vA) == SparseArrays.getcolptr(A[:, 1:5])
 end
 
+@testset "any/all predicates over dims = 1" begin
+    As = sparse([2, 3], [2, 3], [0.0, 1.0]) # empty, structural zero, non-zero
+    Ad = Matrix(As)
+    Bs = copy(As) # like As, but full column
+    Bs[:,3] .= 1.0
+    Bd = Matrix(Bs)
+    Cs = copy(Bs) # like Bs, but full column is all structural zeros
+    Cs[:,3] .= 0.0
+    Cd = Matrix(Cs)
+
+    @testset "any($(repr(pred)))" for pred in (iszero, !iszero, >(-1.0), !=(1.0))
+        @test any(pred, As, dims = 1) == any(pred, Ad, dims = 1)
+        @test any(pred, Bs, dims = 1) == any(pred, Bd, dims = 1)
+        @test any(pred, Cs, dims = 1) == any(pred, Cd, dims = 1)
+    end
+    @testset "all($(repr(pred)))" for pred in (iszero, !iszero, >(-1.0), !=(1.0))
+        @test all(pred, As, dims = 1) == all(pred, Ad, dims = 1)
+        @test all(pred, Bs, dims = 1) == all(pred, Bd, dims = 1)
+        @test all(pred, Cs, dims = 1) == all(pred, Cd, dims = 1)
+    end
+end
+
 @testset "mapreducecols" begin
     n = 20
     m = 10


### PR DESCRIPTION
Being able to short-circuit `any` and `all` reductions with boolean
predicates can be a huge performance boost for very large sparse
matrices. For instance, I have a sparse matrix:

```julia
julia> R
47200×187218 SparseMatrixCSC{Float64, Int64} with 1266010944 stored entries:
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣠⣤⣴⣶⣶⣶⠆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣠⣤⣴⣶⣶⣶⠆
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣤⣤⣴⣶⣶⣿⣿⡿⠿⠟⠛⠋⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣤⣤⣴⣶⣶⣿⣿⡿⠿⠟⠛⠋⠉⠁⠀⠀
⠀⣀⣀⣠⣤⣤⣶⣶⣶⣿⣿⠿⠿⠿⠛⠛⠋⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣀⣠⣤⣤⣶⣶⣶⣿⣿⠿⠿⠿⠛⠛⠋⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠛⠛⠛⠛⠛⠛⠉⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⡛⠛⠛⠛⠛⠛⠉⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⡀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣤⣤⣴⣶⣾⣿⡿⠿⠟⠛⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣤⣤⣴⣶⣾⣿⡿⠿⠟⠛⠁
⠀⠀⠀⠀⠀⠀⣀⣀⣀⣤⣤⣴⣶⣶⣿⣿⡿⠿⠿⠛⠛⠋⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣀⣀⣤⣤⣴⣶⣶⣿⣿⡿⠿⠿⠛⠛⠋⠉⠁⠀⠀⠀⠀⠀⠀
⣤⣶⣶⣾⣿⣿⠿⠿⠟⠛⠛⠉⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣤⣶⣶⣾⣿⣿⠿⠿⠟⠛⠛⠉⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀

julia> nnz(R) / prod(size(R))
0.14326755847574413
```

which prior to this commit, trying to find whether there are any columns
which are all-zeros (or any other boolean predicate) takes ~1 sec to
calculate:

```julia
julia> @btime any(!iszero, $R, dims = 1);
  954.357 ms (4 allocations: 183.05 KiB)

julia> @btime all(iszero, $R, dims = 1);
  925.756 ms (2 allocations: 182.95 KiB)

julia> @btime any(iszero, $R, dims = 1);
  989.635 ms (2 allocations: 182.95 KiB)

julia> @btime all(!iszero, $R, dims = 1);
  965.530 ms (3 allocations: 183.00 KiB)
```

With this commit, the reduction is sped up by a factor of over 1000×:

```julia
julia> @btime any(!iszero, $R, dims = 1);
  583.325 μs (2 allocations: 182.95 KiB)

julia> @btime all(iszero, $R, dims = 1);
  605.050 μs (2 allocations: 182.95 KiB)

julia> @btime any(iszero, $R, dims = 1);
  190.306 μs (2 allocations: 182.95 KiB)

julia> @btime all(!iszero, $R, dims = 1);
  190.747 μs (2 allocations: 182.95 KiB)
```