### PR TITLE
Set TOML stdlib version to 1.0.0

### DIFF
--- a/stdlib/TOML/Project.toml
+++ b/stdlib/TOML/Project.toml
@@ -1,6 +1,6 @@
 name = "TOML"
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "0.1.0"
+version = "1.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
The one that is registered has that and it is weird if they look semver incompatible for the resolver.