### PR TITLE
No load error on at macroexpand

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -5625,9 +5625,7 @@ f_isdefined_splat(x...) = @isdefined x
 @test f_isdefined_splat(1, 2, 3)
 let err = try; @macroexpand @isdefined :x; false; catch ex; ex; end,
     __source__ = LineNumberNode(@__LINE__() - 1, Symbol(@__FILE__))
-    @test err.file === string(__source__.file)
-    @test err.line === __source__.line
-    e = err.error::MethodError
+    e = err::MethodError
     @test e.f === getfield(@__MODULE__, Symbol("@isdefined"))
     @test e.args === (__source__, @__MODULE__, :(:x))
 end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -774,13 +774,7 @@ end
 # Issue #13905.
 let err = try; @macroexpand(@doc "" f() = @x); false; catch ex; ex; end
     __source__ = LineNumberNode(@__LINE__() -  1, Symbol(@__FILE__))
-    err::LoadError
-    @test err.file === string(__source__.file)
-    @test err.line === __source__.line
-    err = err.error::LoadError
-    @test err.file === string(__source__.file)
-    @test err.line === __source__.line
-    err = err.error::UndefVarError
+    err::UndefVarError
     @test err.var == Symbol("@x")
  end
 

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -473,12 +473,6 @@ let
     @test (@macroexpand @fastmath +      ) == :(Base.FastMath.add_fast)
     @test (@macroexpand @fastmath min(1) ) == :(Base.FastMath.min_fast(1))
     let err = try; @macroexpand @doc "" f() = @x; catch ex; ex; end
-        file, line = @__FILE__, @__LINE__() - 1
-        err = err::LoadError
-        @test err.file == file && err.line == line
-        err = err.error::LoadError
-        @test err.file == file && err.line == line
-        err = err.error::UndefVarError
         @test err == UndefVarError(Symbol("@x"))
     end
     @test (@macroexpand @seven_dollar $bar) == 7

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -92,18 +92,6 @@ import Base.SimdLoop.SimdError
 
 # Test that @simd rejects inner loop body with invalid control flow statements
 # issue #8613
-macro test_throws(ty, ex)
-    return quote
-        Test.@test_throws $(esc(ty)) try
-            $(esc(ex))
-        catch err
-            @test err isa LoadError
-            @test err.file === $(string(__source__.file))
-            @test err.line === $(__source__.line + 1)
-            rethrow(err.error)
-        end
-    end
-end
 
 @test_throws SimdError("break is not allowed inside a @simd loop body") @macroexpand begin
     @simd for x = 1:10

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -620,10 +620,8 @@ let ex = :(A15838.@f(1, 2)), __source__ = LineNumberNode(@__LINE__, Symbol(@__FI
         false
     catch ex
         ex
-    end::LoadError
-    @test nometh.file === string(__source__.file)
-    @test nometh.line === __source__.line
-    e = nometh.error::MethodError
+    end
+    e = nometh::MethodError
     @test e.f === getfield(A15838, Symbol("@f"))
     @test e.args === (__source__, @__MODULE__, 1, 2)
 end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -743,8 +743,7 @@ end
 try
     @macroexpand @threads(for i = 1:10, j = 1:10; end)
 catch ex
-    @test ex isa LoadError
-    @test ex.error isa ArgumentError
+    @test ex isa ArgumentError
 end
 
 @testset "@spawn interpolation" begin


### PR DESCRIPTION
There's three reasons I think this would be a good idea:

1) Semantic: code that is macroexpanded is not loaded, at least, it's certainly not evaluated.

2) Not particularly useful: load errors contain a line number and module, but that's not particularly helpful for macroexpand, which is usually used interactively

3) Convenience: not having to unwrap loaderrors to test macros is more convenient. I think a strong case for this can be made just by looking at the tests I've changed that no longer need to do this.