### PR TITLE
Various fixes for `reinterpret(reshape, T, a)`

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -46,6 +46,7 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S},IsReshaped} <: AbstractArray{T
         writable = array_subpadding(S, T)
         new{T, N, S, A, false}(a, readable, writable)
     end
+    reinterpret(::Type{T}, a::AbstractArray{T}) where {T} = a
 
     # With reshaping
     function reinterpret(::typeof(reshape), ::Type{T}, a::A) where {T,S,A<:AbstractArray{S}}
@@ -74,6 +75,7 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S},IsReshaped} <: AbstractArray{T
         writable = array_subpadding(S, T)
         new{T, N, S, A, true}(a, readable, writable)
     end
+    reinterpret(::typeof(reshape), ::Type{T}, a::AbstractArray{T}) where {T} = a
 end
 
 ReshapedReinterpretArray{T,N,S,A<:AbstractArray{S}} = ReinterpretArray{T,N,S,A,true}
@@ -97,7 +99,7 @@ julia> A = [1 2; 3 4]
  3  4
 
 julia> reinterpret(reshape, Complex{Int}, A)    # the result is a vector
-2-element reinterpret(reshape, Complex{$Int}, ::Matrix{$Int}):
+2-element reinterpret(reshape, Complex{$Int}, ::Matrix{$Int}) with eltype Complex{$Int}:
  1 + 3im
  2 + 4im
 
@@ -107,7 +109,7 @@ julia> a = [(1,2,3), (4,5,6)]
  (4, 5, 6)
 
 julia> reinterpret(reshape, Int, a)             # the result is a matrix
-3×2 reinterpret(reshape, $Int, ::Vector{Tuple{$Int, $Int, $Int}}):
+3×2 reinterpret(reshape, $Int, ::Vector{Tuple{$Int, $Int, $Int}}) with eltype $Int:
  1  4
  2  5
  3  6
@@ -115,7 +117,8 @@ julia> reinterpret(reshape, Int, a)             # the result is a matrix
 """
 reinterpret(::typeof(reshape), T::Type, a::AbstractArray)
 
-reinterpret(::Type{T}, a::ReinterpretArray) where {T} = reinterpret(T, a.parent)
+reinterpret(::Type{T}, a::NonReshapedReinterpretArray) where {T} = reinterpret(T, a.parent)
+reinterpret(::typeof(reshape), ::Type{T}, a::ReshapedReinterpretArray) where {T} = reinterpret(reshape, T, a.parent)
 
 # Definition of StridedArray
 StridedFastContiguousSubArray{T,N,A<:DenseArray} = FastContiguousSubArray{T,N,A}
@@ -316,7 +319,7 @@ end
     # Convert to full indices here, to avoid needing multiple conversions in
     # the loop in _getindex_ra
     inds = _to_subscript_indices(a, i)
-    _getindex_ra(a, inds[1], tail(inds))
+    isempty(inds) ? _getindex_ra(a, 1, ()) : _getindex_ra(a, inds[1], tail(inds))
 end
 
 @inline @propagate_inbounds function getindex(a::ReshapedReinterpretArray{T,N,S}, ind::SCartesianIndex2) where {T,N,S}

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -185,7 +185,7 @@ end
 _reshape(v::ReshapedArray{<:Any,1}, dims::Dims{1}) = _reshape(v.parent, dims)
 _reshape(R::ReshapedArray, dims::Dims) = _reshape(R.parent, dims)
 
-function __reshape(p::Tuple{AbstractArray,IndexCartesian}, dims::Dims)
+function __reshape(p::Tuple{AbstractArray,IndexStyle}, dims::Dims)
     parent = p[1]
     strds = front(size_to_strides(map(length, axes(parent))..., 1))
     strds1 = map(s->max(1,Int(s)), strds)  # for resizing empty arrays

--- a/base/show.jl
+++ b/base/show.jl
@@ -2572,6 +2572,7 @@ function showarg(io::IO, r::ReshapedReinterpretArray{T}, toplevel) where {T}
     print(io, "reinterpret(reshape, ", T, ", ")
     showarg(io, parent(r), false)
     print(io, ')')
+    toplevel && print(io, " with eltype ", eltype(r))
 end
 
 # printing iterators from Base.Iterators

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -313,6 +313,19 @@ B[] = Int32(5)
 @test Brs[] === Int32(5)
 @test A[] === UInt32(5)
 
+a = [(1.0,2.0)]
+af = @inferred(reinterpret(reshape, Float64, a))
+anew = @inferred(reinterpret(reshape, Tuple{Float64,Float64}, vec(af)))
+@test anew[1] == a[1]
+@test ndims(anew) == 0
+
+# re-reinterpret
+a0 = reshape([0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04], 4, 2)
+a = reinterpret(reshape, NTuple{4,UInt8}, a0)
+@test a == [(0x22, 0x44, 0x88, 0xf0), (0x01, 0x02, 0x03, 0x04)]
+@test reinterpret(UInt8, a) == [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04]
+@test reinterpret(reshape, UInt8, a) === a0
+
 # reductions
 a = [(1,2,3), (4,5,6)]
 ars = reinterpret(reshape, Int, a)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1528,6 +1528,8 @@ end
     @test summary(r) == "4×2 reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2) with eltype Int16"
     p = PermutedDimsArray(r, (2, 1))
     @test summary(p) == "2×4 PermutedDimsArray(reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2), (2, 1)) with eltype Int16"
+    p = reinterpret(reshape, Tuple{Float32,Float32}, [1.0f0 3.0f0; 2.0f0 4.0f0])
+    @test summary(p) == "2-element reinterpret(reshape, Tuple{Float32, Float32}, ::Matrix{Float32}) with eltype Tuple{Float32, Float32}"
 end
 
 @testset "Methods" begin


### PR DESCRIPTION
I detected these while porting ImageCore to use the new `reinterpret` machinery. Most of these are no big deal, but the `base/reshapedarray.jl` change is emblematic of precisely the problem I worried about in #37559: that `IndexStyle` has had just two subtypes, `IndexLinear` and `IndexCartesian`, for so long that it's likely this has been assumed to be all the possible choices. It won't be surprising if some packages need migration too.