### PR TITLE
WIP: add front-end support for OpaqueClosure

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -232,6 +232,9 @@ using .Libc: getpid, gethostname, time
 
 include("env.jl")
 
+# OpaqueClosure
+include("opaque_closure.jl")
+
 # Concurrency
 include("linked_list.jl")
 include("condition.jl")

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -89,7 +89,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
     edges = Any[]
     nonbot = 0  # the index of the only non-Bottom inference result if > 0
     seen = 0    # number of signatures actually inferred
-    istoplevel = sv.linfo.def isa Module
+    istoplevel = sv.linfo !== nothing && sv.linfo.def isa Module
     multiple_matches = napplicable > 1
 
     if f !== nothing && napplicable == 1 && is_method_pure(applicable[1]::MethodMatch)
@@ -337,7 +337,7 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
     sv_method2 isa Method || (sv_method2 = nothing) # Union{Method, Nothing}
     while !(infstate === nothing)
         infstate = infstate::InferenceState
-        if method === infstate.linfo.def
+        if infstate.linfo !== nothing && method === infstate.linfo.def
             if infstate.linfo.specTypes == sig
                 # avoid widening when detecting self-recursion
                 # TODO: merge call cycle and return right away
@@ -790,6 +790,10 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, fargs::U
             ty = typeintersect(ty, cnd.elsetype)
         end
         return tmerge(tx, ty)
+    elseif f === Core._opaque_closure
+        la >= 5 || return Union{}
+        return _opaque_closure_tfunc(argtypes[2], argtypes[3], argtypes[4],
+            argtypes[5], argtypes[6:end], sv.linfo)
     end
     rt = builtin_tfunction(interp, f, argtypes[2:end], sv)
     if f === getfield && isa(fargs, Vector{Any}) && la == 3 && isa(argtypes[3], Const) && isa(argtypes[3].val, Int) && argtypes[2] ⊑ Tuple
@@ -1003,6 +1007,28 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
     return abstract_call_gf_by_type(interp, f, argtypes, atype, sv, max_methods)
 end
 
+function abstract_call_opaque_closure(interp::AbstractInterpreter, clos::PartialOpaque, argtypes::Vector{Any}, sv::InferenceState)
+    if isa(clos.ci, CodeInfo)
+        nargtypes = argtypes[2:end]
+        pushfirst!(nargtypes, clos.env)
+        result = InferenceResult(Core.OpaqueClosure, nargtypes)
+        state = InferenceState(result, copy(clos.ci), false, interp)
+        typeinf_local(interp, state)
+        finish(state, interp)
+        result.src.src.inferred = true
+        clos.ci = result.src
+        return CallMeta(result.result, false)
+    elseif isa(clos.ci, OptimizationState)
+        return CallMeta(clos.ci.src.rettype, nothing)
+    else
+        nargtypes = argtypes[2:end]
+        pushfirst!(nargtypes, Core.OpaqueClosure)
+        sig = argtypes_to_type(nargtypes)
+        rt, edge = abstract_call_method(interp, clos.ci::Method, sig, Core.svec(), false, sv)
+        return CallMeta(rt, edge)
+    end
+end
+
 # call where the function is any lattice element
 function abstract_call(interp::AbstractInterpreter, fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any},
                        sv::InferenceState, max_methods::Int = InferenceParams(interp).MAX_METHODS)
@@ -1014,6 +1040,8 @@ function abstract_call(interp::AbstractInterpreter, fargs::Union{Nothing,Vector{
         f = ft.parameters[1]
     elseif isa(ft, DataType) && isdefined(ft, :instance)
         f = ft.instance
+    elseif isa(ft, PartialOpaque)
+        return abstract_call_opaque_closure(interp, ft, argtypes, sv)
     else
         # non-constant function, but the number of arguments is known
         # and the ft is not a Builtin or IntrinsicFunction
@@ -1326,14 +1354,14 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
             elseif isa(stmt, ReturnNode)
                 pc´ = n + 1
                 rt = widenconditional(abstract_eval_value(interp, stmt.val, s[pc], frame))
-                if !isa(rt, Const) && !isa(rt, Type) && !isa(rt, PartialStruct)
+                if !isa(rt, Const) && !isa(rt, Type) && !isa(rt, PartialStruct) && !isa(rt, PartialOpaque)
                     # only propagate information we know we can store
                     # and is valid inter-procedurally
                     rt = widenconst(rt)
                 end
                 if tchanged(rt, frame.bestguess)
                     # new (wider) return type for frame
-                    frame.bestguess = tmerge(frame.bestguess, rt)
+                    frame.bestguess = frame.bestguess === NOT_FOUND ? rt : tmerge(frame.bestguess, rt)
                     for (caller, caller_pc) in frame.cycle_backedges
                         # notify backedges of updated type information
                         typeassert(caller.stmt_types[caller_pc], VarTable) # we must have visited this statement before

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -5,7 +5,7 @@ const LineNum = Int
 mutable struct InferenceState
     params::InferenceParams
     result::InferenceResult # remember where to put the result
-    linfo::MethodInstance
+    linfo::Union{MethodInstance, Nothing}
     sptypes::Vector{Any}    # types of static parameter
     slottypes::Vector{Any}
     mod::Module
@@ -37,6 +37,8 @@ mutable struct InferenceState
     callers_in_cycle::Vector{InferenceState}
     parent::Union{Nothing, InferenceState}
 
+    has_opaque_closures::Bool
+
     # TODO: move these to InferenceResult / Params?
     cached::Bool
     limited::Bool
@@ -57,9 +59,23 @@ mutable struct InferenceState
                             cached::Bool, interp::AbstractInterpreter)
         linfo = result.linfo
         code = src.code::Array{Any,1}
-        toplevel = !isa(linfo.def, Method)
 
-        sp = sptypes_from_meth_instance(linfo::MethodInstance)
+        if !isa(linfo, Nothing)
+            toplevel = !isa(linfo.def, Method)
+            sp = sptypes_from_meth_instance(linfo::MethodInstance)
+            if !toplevel
+                meth = linfo.def
+                inmodule = meth.module
+            else
+                inmodule = linfo.def::Module
+            end
+        else
+            linfo = nothing
+            toplevel = true
+            inmodule = Core
+            sp = Any[]
+        end
+        code = src.code::Array{Any,1}
 
         nssavalues = src.ssavaluetypes::Int
         src.ssavaluetypes = Any[ NOT_FOUND for i = 1:nssavalues ]
@@ -93,13 +109,6 @@ mutable struct InferenceState
         W = BitSet()
         push!(W, 1) #initial pc to visit
 
-        if !toplevel
-            meth = linfo.def
-            inmodule = meth.module
-        else
-            inmodule = linfo.def::Module
-        end
-
         valid_worlds = WorldRange(src.min_world,
             src.max_world == typemax(UInt) ? get_world_counter() : src.max_world)
         frame = new(
@@ -112,7 +121,7 @@ mutable struct InferenceState
             ssavalue_uses, throw_blocks,
             Vector{Tuple{InferenceState,LineNum}}(), # cycle_backedges
             Vector{InferenceState}(), # callers_in_cycle
-            #=parent=#nothing,
+            #=parent=#nothing, #= has_opaque_closures =# false,
             cached, false, false, false,
             CachedMethodTable(method_table(interp)),
             interp)
@@ -242,6 +251,7 @@ end
 
 # temporarily accumulate our edges to later add as backedges in the callee
 function add_backedge!(li::MethodInstance, caller::InferenceState)
+    caller.linfo !== nothing || return # don't add backedges to opauqe closures
     isa(caller.linfo.def, Method) || return # don't add backedges to toplevel exprs
     if caller.stmt_edges[caller.currpc] === nothing
         caller.stmt_edges[caller.currpc] = []

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -34,7 +34,7 @@ struct InliningState{S <: Union{EdgeTracker, Nothing}, T <: Union{InferenceCache
 end
 
 mutable struct OptimizationState
-    linfo::MethodInstance
+    linfo::Union{MethodInstance, Nothing}
     src::CodeInfo
     stmt_info::Vector{Any}
     mod::Module
@@ -310,6 +310,13 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
             if isa(farg, GlobalRef) || isa(farg, QuoteNode) || isa(farg, IntrinsicFunction) || isexpr(farg, :static_parameter)
                 ftyp = argextype(farg, src, sptypes, slottypes)
             end
+        end
+        # Give calls to OpaqueClosures zero cost. The plan is for these to be a single
+        # indirect call so have very little cost. On the other hand, there
+        # is enormous benefit to inlining these into a function where we can
+        # see the definition of the OpaqueClosure. Perhaps this should even be negative
+        if widenconst(ftyp) <: Core.OpaqueClosure
+            return 0
         end
         f = singleton_type(ftyp)
         if isa(f, IntrinsicFunction)

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -33,7 +33,24 @@ function normalize(@nospecialize(stmt), meta::Vector{Any})
     return stmt
 end
 
-function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, nargs::Int, sv::OptimizationState)
+function add_opaque_closure_argtypes!(argtypes, t)
+    dt = unwrap_unionall(t)
+    dt1 = unwrap_unionall(dt.parameters[1])
+    if isa(dt1, TypeVar) || isa(dt1.parameters[1], TypeVar)
+        push!(argtypes, Any)
+    else
+        TT = dt1.parameters[1]
+        if isa(TT, Union)
+            TT = tuplemerge(TT.a, TT.b)
+        end
+        for p in TT.parameters
+            push!(argtypes, rewrap_unionall(p, t))
+        end
+    end
+end
+
+
+function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, nargs::Int, sv::OptimizationState, slottypes=sv.slottypes, stmtinfo=sv.stmt_info)
     # Go through and add an unreachable node after every
     # Union{} call. Then reindex labels.
     idx = 1
@@ -41,7 +58,8 @@ function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, narg
     changemap = fill(0, length(code))
     labelmap = coverage ? fill(0, length(code)) : changemap
     prevloc = zero(eltype(ci.codelocs))
-    stmtinfo = sv.stmt_info
+    stmtinfo = copy(stmtinfo)
+    opaques = IRCode[]
     while idx <= length(code)
         codeloc = ci.codelocs[idx]
         if coverage && codeloc != prevloc && codeloc != 0
@@ -57,7 +75,22 @@ function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, narg
             idx += 1
             prevloc = codeloc
         end
-        if code[idx] isa Expr && ci.ssavaluetypes[idx] === Union{}
+        stmt = code[idx]
+        if isexpr(stmt, :(=))
+            stmt = stmt.args[2]
+        end
+        ssat = ci.ssavaluetypes[idx]
+        if isa(ssat, PartialOpaque) && isexpr(stmt, :call)
+            ft = argextype(stmt.args[1], ci, sv.sptypes)
+            # Pre-convert any OpaqueClosure objects
+            if isa(ft, Const) && ft.val === Core._opaque_closure && isa(ssat.ci, OptimizationState)
+                opaque_ir = make_ir(ssat.ci.src, 0, ssat.ci)
+                push!(opaques, opaque_ir)
+                stmt.head = :new_opaque_closure
+                stmt.args[5] = OpaqueClosureIdx(length(opaques))
+            end
+        end
+        if stmt isa Expr && ssat === Union{}
             if !(idx < length(code) && isa(code[idx + 1], ReturnNode) && !isdefined((code[idx + 1]::ReturnNode), :val))
                 # insert unreachable in the same basic block after the current instruction (splitting it)
                 insert!(code, idx + 1, ReturnNode())
@@ -105,7 +138,7 @@ function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, narg
     cfg = compute_basic_blocks(code)
     types = Any[]
     stmts = InstructionStream(code, types, stmtinfo, ci.codelocs, flags)
-    ir = IRCode(stmts, cfg, collect(LineInfoNode, ci.linetable), sv.slottypes, meta, sv.sptypes)
+    ir = IRCode(stmts, cfg, collect(LineInfoNode, ci.linetable), slottypes, meta, sv.sptypes, opaques)
     return ir
 end
 
@@ -117,24 +150,37 @@ function slot2reg(ir::IRCode, ci::CodeInfo, nargs::Int, sv::OptimizationState)
     return ir
 end
 
-function run_passes(ci::CodeInfo, nargs::Int, sv::OptimizationState)
-    preserve_coverage = coverage_enabled(sv.mod)
-    ir = convert_to_ircode(ci, copy_exprargs(ci.code), preserve_coverage, nargs, sv)
+function compact_all!(ir::IRCode)
+    length(ir.stmts) == 0 && return ir
+    for i in 1:length(ir.opaques)
+        ir.opaques[i] = compact_all!(ir.opaques[i])
+    end
+    compact!(ir)
+end
+
+function make_ir(ci::CodeInfo, nargs::Int, sv::OptimizationState)
+    ir = convert_to_ircode(ci, copy_exprargs(ci.code), coverage_enabled(sv.mod), nargs, sv)
     ir = slot2reg(ir, ci, nargs, sv)
+    ir
+end
+
+function run_passes(ci::CodeInfo, nargs::Int, sv::OptimizationState)
+    ir = make_ir(ci, nargs, sv)
     #@Base.show ("after_construct", ir)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
     @timeit "compact 1" ir = compact!(ir)
     @timeit "Inlining" ir = ssa_inlining_pass!(ir, ir.linetable, sv.inlining, ci.propagate_inbounds)
     #@timeit "verify 2" verify_ir(ir)
-    ir = compact!(ir)
+    ir = compact_all!(ir)
     #@Base.show ("before_sroa", ir)
     @timeit "SROA" ir = getfield_elim_pass!(ir)
+    ir = opaque_closure_optim_pass!(ir)
     #@Base.show ir.new_nodes
     #@Base.show ("after_sroa", ir)
     ir = adce_pass!(ir)
     #@Base.show ("after_adce", ir)
     @timeit "type lift" ir = type_lift_pass!(ir)
-    @timeit "compact 3" ir = compact!(ir)
+    @timeit "compact 3" ir = compact_all!(ir)
     #@Base.show ir
     if JLOptions().debug_level == 2
         @timeit "verify 3" (verify_ir(ir); verify_linetable(ir.linetable))

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -40,7 +40,7 @@ end
 
 struct InliningTodo
     # The MethodInstance to be inlined
-    mi::MethodInstance
+    mi::Union{MethodInstance, Nothing}
     spec::Union{ResolvedInliningSpec, DelayedInliningSpec}
 end
 
@@ -65,6 +65,9 @@ end
 function ssa_inlining_pass!(ir::IRCode, linetable::Vector{LineInfoNode}, state::InliningState, propagate_inbounds::Bool)
     # Go through the function, performing simple ininlingin (e.g. replacing call by constants
     # and analyzing legality of inlining).
+    for (idx, ir′) in enumerate(ir.opaques)
+        ir.opaques[idx] = ssa_inlining_pass!(ir′, ir′.linetable, state, propagate_inbounds)
+    end
     @timeit "analysis" todo = assemble_inline_todo!(ir, state)
     isempty(todo) && return ir
     # Do the actual inlining for every call we identified
@@ -309,11 +312,17 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
         push!(linetable, LineInfoNode(entry.module, entry.method, entry.file, entry.line,
             (entry.inlined_at > 0 ? entry.inlined_at + linetable_offset : inlined_at)))
     end
-    nargs_def = item.mi.def.nargs
-    isva = nargs_def > 0 && item.mi.def.isva
-    if isva
-        vararg = mk_tuplecall!(compact, argexprs[nargs_def:end], compact.result[idx][:line])
-        argexprs = Any[argexprs[1:(nargs_def - 1)]..., vararg]
+    sparam_vals = Core.svec()
+    sig = Tuple
+    if item.mi !== nothing
+        nargs_def = item.mi.def.nargs
+        isva = nargs_def > 0 && item.mi.def.isva
+        if isva
+            vararg = mk_tuplecall!(compact, argexprs[nargs_def:end], compact.result[idx][:line])
+            argexprs = Any[argexprs[1:(nargs_def - 1)]..., vararg]
+        end
+        sig = item.mi.def.sig
+        sparam_vals = item.mi.sparam_vals
     end
     flag = compact.result[idx][:flag]
     boundscheck_idx = boundscheck
@@ -335,7 +344,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
             # face of rename_arguments! mutating in place - should figure out
             # something better eventually.
             inline_compact[idx′] = nothing
-            stmt′ = ssa_substitute!(idx′, stmt′, argexprs, item.mi.def.sig, item.mi.sparam_vals, linetable_offset, boundscheck_idx, compact)
+            stmt′ = ssa_substitute!(idx′, stmt′, argexprs, sig, sparam_vals, linetable_offset, boundscheck_idx, compact)
             if isa(stmt′, ReturnNode)
                 isa(stmt′.val, SSAValue) && (compact.used_ssas[stmt′.val.id] += 1)
                 return_value = SSAValue(idx′)
@@ -345,6 +354,10 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
                     compact_exprtype(compact, stmt′.val) :
                     compact_exprtype(inline_compact, stmt′.val)
                 break
+            elseif isexpr(stmt′, :new_opaque_closure)
+                stmt′ = Expr(:new_opaque_closure, stmt′.args[1:5]...,
+                    OpaqueClosureIdx((stmt′.args[6]::OpaqueClosureIdx).n + length(compact.ir.opaques)),
+                    stmt′.args[7:end]...)
             end
             inline_compact[idx′] = stmt′
         end
@@ -362,7 +375,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
         inline_compact = IncrementalCompact(compact, spec.ir, compact.result_idx)
         for ((_, idx′), stmt′) in inline_compact
             inline_compact[idx′] = nothing
-            stmt′ = ssa_substitute!(idx′, stmt′, argexprs, item.mi.def.sig, item.mi.sparam_vals, linetable_offset, boundscheck_idx, compact)
+            stmt′ = ssa_substitute!(idx′, stmt′, argexprs, sig, sparam_vals, linetable_offset, boundscheck_idx, compact)
             if isa(stmt′, ReturnNode)
                 if isdefined(stmt′, :val)
                     val = stmt′.val
@@ -382,7 +395,6 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
                         push!(pn.values, val)
                         stmt′ = GotoNode(post_bb_id)
                     end
-
                 end
             elseif isa(stmt′, GotoNode)
                 stmt′ = GotoNode(stmt′.label + bb_offset)
@@ -392,6 +404,10 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
                 stmt′ = GotoIfNot(stmt′.cond, stmt′.dest + bb_offset)
             elseif isa(stmt′, PhiNode)
                 stmt′ = PhiNode(Int32[edge+bb_offset for edge in stmt′.edges], stmt′.values)
+            elseif isexpr(stmt′, :new_opaque_closure)
+                stmt′ = Expr(:new_opaque_closure, stmt′.args[1:5]...,
+                    OpaqueClosureIdx((stmt′.args[6]::OpaqueClosureIdx).n + length(compact.ir.opaques)),
+                    stmt′.args[7:end]...)
             end
             inline_compact[idx′] = stmt′
         end
@@ -410,6 +426,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
             return_value = insert_node_here!(compact, pn, compact_exprtype(compact, SSAValue(idx)), compact.result[idx][:line])
         end
     end
+    append!(compact.ir.opaques, spec.ir.opaques)
     return_value
 end
 
@@ -533,6 +550,12 @@ function batch_inline!(todo::Vector{Pair{Int, Any}}, ir::IRCode, linetable::Vect
         for ((old_idx, idx), stmt) in compact
             if old_idx == inline_idx
                 argexprs = copy(stmt.args)
+                if isa(item, InliningTodo) && item.mi === nothing
+                    # For opaque closures, the `self` argument is the object passed as
+                    # the environment
+                    @assert isa(argexprs[1], SSAValue)
+                    argexprs[1] = compact[argexprs[1]].args[5]
+                end
                 refinish = false
                 if compact.result_idx == first(compact.result_bbs[compact.active_result_bb].stmts)
                     compact.active_result_bb -= 1
@@ -994,6 +1017,22 @@ function inline_invoke!(ir::IRCode, idx::Int, sig::Signature, invoke_data::Invok
     return nothing
 end
 
+function narrow_opaque_closure!(ir, stmt, calltype)
+    if isa(calltype, PartialOpaque)
+        lbt = argextype(stmt.args[3], ir, ir.sptypes)
+        lb, exact = instanceof_tfunc(lbt)
+        exact || return
+        # Narrow opaque closure type
+        if isa(calltype.ci, OptimizationState)
+            stmt.args[3] = stmt.args[4] = widenconst(tmerge(lb, calltype.ci.src.rettype))
+        elseif isa(calltype.ci, Method)
+            m = calltype.ci
+            stmt.args[5] = m
+            stmt.args[3] = stmt.args[4] = widenconst(tmerge(lb, m.unspecialized.cache.rettype))
+        end
+    end
+end
+
 # Handles all analysis and inlining of intrinsics and builtins. In particular,
 # this method does not access the method table or otherwise process generic
 # functions.
@@ -1002,6 +1041,9 @@ function process_simple!(ir::IRCode, todo::Vector{Pair{Int, Any}}, idx::Int, sta
     stmt isa Expr || return nothing
     if stmt.head === :splatnew
         inline_splatnew!(ir, idx)
+        return nothing
+    elseif stmt.head === :new_opaque_closure
+        narrow_opaque_closure!(ir, stmt, ir.stmts[idx][:type])
         return nothing
     end
 
@@ -1022,6 +1064,12 @@ function process_simple!(ir::IRCode, todo::Vector{Pair{Int, Any}}, idx::Int, sta
         return nothing
     end
 
+    # Handle _opaque_closure (if not already handled above)
+    if sig.f === Core._opaque_closure
+        narrow_opaque_closure!(ir, stmt, calltype)
+        return
+    end
+
     # Handle invoke
     invoke_data = nothing
     if sig.f === Core.invoke && length(sig.atypes) >= 3
@@ -1031,6 +1079,16 @@ function process_simple!(ir::IRCode, todo::Vector{Pair{Int, Any}}, idx::Int, sta
     elseif is_builtin(sig)
         # No inlining for builtins (other than what was previously handled)
         return nothing
+    end
+
+    # Inlining OpaqueClosure that don't have any specializations
+    if sig.ft ⊑ Core.OpaqueClosure
+        callee = stmt.args[1]
+        if isa(callee, SSAValue) && isexpr(ir.stmts[callee.id][:inst], :new_opaque_closure) && length(ir.stmts[callee.id][:inst].args) >= 6
+            ir′ = ir.opaques[(ir.stmts[callee.id][:inst].args[5]::OpaqueClosureIdx).n]::IRCode
+            push!(todo, idx=>InliningTodo(nothing, ResolvedInliningSpec(ir′, linear_inline_eligible(ir′))))
+            return nothing
+        end
     end
 
     sig = with_atype(sig)
@@ -1165,6 +1223,10 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
                 ir.stmts[idx][:inst] = quoted(calltype.val)
                 continue
             end
+            # Refuse to inline OpaqueClosures we can't see otherwise, to preserve the
+            # possibility of functions higher in the call stack seeing this
+            # and performing the inlining.
+            continue
         end
 
         # Ok, now figure out what method to call

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -260,12 +260,16 @@ struct IRCode
     cfg::CFG
     new_nodes::NewNodeStream
     meta::Vector{Any}
+    # For easier reference, we store all opaque closures. In general passes will want to
+    # just recurse into these. Passes that are opaque closure aware may do more fancy
+    # optimizations
+    opaques::Vector{IRCode}
 
-    function IRCode(stmts::InstructionStream, cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Any}, sptypes::Vector{Any})
-        return new(stmts, argtypes, sptypes, linetable, cfg, NewNodeStream(), meta)
+    function IRCode(stmts::InstructionStream, cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Any}, sptypes::Vector{Any}, opaques::Vector{IRCode})
+        return new(stmts, argtypes, sptypes, linetable, cfg, NewNodeStream(), meta, opaques)
     end
     function IRCode(ir::IRCode, stmts::InstructionStream, cfg::CFG, new_nodes::NewNodeStream)
-        return new(stmts, ir.argtypes, ir.sptypes, ir.linetable, cfg, new_nodes, ir.meta)
+        return new(stmts, ir.argtypes, ir.sptypes, ir.linetable, cfg, new_nodes, ir.meta, ir.opaques)
     end
     global copy
     copy(ir::IRCode) = new(copy(ir.stmts), copy(ir.argtypes), copy(ir.sptypes),
@@ -305,6 +309,10 @@ end
 # be actually inserted next time (they become `new_nodes` next time)
 struct NewSSAValue
     id::Int
+end
+
+struct OpaqueClosureIdx
+    n::Int
 end
 
 const AnySSAValue = Union{SSAValue, OldSSAValue, NewSSAValue}
@@ -379,7 +387,7 @@ function getindex(x::UseRef)
 end
 
 function is_relevant_expr(e::Expr)
-    return e.head in (:call, :invoke, :new, :splatnew, :(=), :(&),
+    return e.head in (:call, :invoke, :new, :new_opaque_closure, :splatnew, :(=), :(&),
                       :gc_preserve_begin, :gc_preserve_end,
                       :foreigncall, :isdefined, :copyast,
                       :undefcheck, :throw_undef_if_not,

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -42,14 +42,15 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, sptypes::
             isexact || return false
             isconcretedispatch(typ) || return false
             typ = typ::DataType
-            fieldcount(typ) >= length(ea) - 1 || return false
-            for fld_idx in 1:(length(ea) - 1)
+            nargs = length(ea) - (head === :new ? 1 : 2)
+            fieldcount(typ) >= nargs || return false
+            for fld_idx in 1:nargs
                 eT = argextype(ea[fld_idx + 1], src, sptypes)
                 fT = fieldtype(typ, fld_idx)
                 eT ⊑ fT || return false
             end
             return true
-        elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds || head === :boundscheck
+        elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds || head === :boundscheck || head === :new_opaque_closure
             return true
         else
             # e.g. :loopinfo

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -14,13 +14,13 @@ end
 function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, use_idx::Int, print::Bool)
     if isa(op, SSAValue)
         if op.id > length(ir.stmts)
-            def_bb = block_for_inst(ir.cfg, ir.new_nodes[op.id - length(ir.stmts)].pos)
+            def_bb = block_for_inst(ir.cfg, ir.new_nodes.info[op.id - length(ir.stmts)].pos)
         else
             def_bb = block_for_inst(ir.cfg, op.id)
         end
         if (def_bb == use_bb)
             if op.id > length(ir.stmts)
-                @assert ir.new_nodes[op.id - length(ir.stmts)].pos <= use_idx
+                @assert ir.new_nodes.info[op.id - length(ir.stmts)].pos <= use_idx
             else
                 if op.id >= use_idx
                     @verify_error "Def ($(op.id)) does not dominate use ($(use_idx)) in same BB"

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -79,3 +79,13 @@ This info is illegal on any statement that is not an `_apply_iterate` call.
 struct UnionSplitApplyCallInfo
     infos::Vector{ApplyCallInfo}
 end
+
+"""
+    struct OpaqueClosureCallInfo
+
+The call was to a OpaqueClosure of known provenance. A MethodInstance was created to
+hold the optimized code for this OpaqueClosure.
+"""
+struct OpaqueClosureCallInfo
+    mi::MethodInstance
+end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1368,6 +1368,24 @@ function array_builtin_common_nothrow(argtypes::Array{Any,1}, first_idx_idx::Int
     return false
 end
 
+function _opaque_closure_tfunc(@nospecialize(arg), @nospecialize(lb), @nospecialize(ub),
+    @nospecialize(ci), env::Vector{Any}, linfo::MethodInstance)
+    argt, argt_exact = instanceof_tfunc(arg)
+    lbt, lb_exact = instanceof_tfunc(lb)
+    if !lb_exact
+    lbt = Union{}
+    end
+
+    ubt, ub_exact = instanceof_tfunc(ub)
+
+    t = Core.OpaqueClosure{argt_exact ? argt : <:argt}
+    t = t{(lbt == ubt && ub_exact) ? ubt : T} where lbt<:T<:ubt
+
+    isa(ci, Const) || return t
+
+    PartialOpaque(t, tuple_tfunc(env), linfo, ci.val)
+end
+
 # Query whether the given builtin is guaranteed not to throw given the argtypes
 function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecialize(rt))
     if f === arrayset

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -96,6 +96,9 @@ function CodeInstance(result::InferenceResult, @nospecialize(inferred_result::An
         elseif isa(result.result, PartialStruct)
             rettype_const = (result.result::PartialStruct).fields
             const_flags = 0x2
+        elseif isa(result.result, PartialOpaque)
+            rettype_const = result.result
+            const_flags = 0x2
         else
             rettype_const = nothing
             const_flags = 0x00
@@ -173,6 +176,49 @@ function cache_result!(interp::AbstractInterpreter, result::InferenceResult, val
     nothing
 end
 
+function finish_opaque_closure!(clos::PartialOpaque, mod::Module, interp::AbstractInterpreter)
+    # Infer with the most general types possible, so that optimization has
+    # access to the result.
+
+    argt = unwrap_unionall(clos.t).parameters[1]
+
+    argtypes = Any[argt.parameters...]
+    pushfirst!(argtypes, clos.env)
+    if isdispatchtuple(argt)
+        # If we don't need to track specializations, just infer this here
+        # right now.
+        result = InferenceResult(Core.OpaqueClosure, argtypes)
+        state = InferenceState(result, copy(clos.ci), false, interp)
+        typeinf_local(interp, state)
+        finish(state, interp)
+        result.src.src.inferred = true
+        clos.ci = result.src
+    else
+        # Otherwise infer via the method instance cache.
+        m = ccall(:jl_mk_opaque_closure_method, Any, (Any,), mod)::Method
+        m.nargs = Int32(length(argtypes))
+        m.source = clos.ci
+        argtypes = Any[argt.parameters...]
+        pushfirst!(argtypes, Core.OpaqueClosure)
+        m.unspecialized = specialize_method(m, argtypes_to_type(argtypes), Core.svec())
+
+        mi = m.unspecialized
+
+        lock_mi_inference(interp, mi)
+        result = InferenceResult(mi)
+        frame = InferenceState(result, #=cached=#true, interp)
+        if frame === nothing
+            # can't get the source for this, so we know nothing
+            unlock_mi_inference(interp, mi)
+            return
+        end
+        typeinf(interp, frame)
+        unlock_mi_inference(interp, mi)
+
+        clos.ci = m
+    end
+end
+
 # inference completed on `me`
 # update the MethodInstance
 function finish(me::InferenceState, interp::AbstractInterpreter)
@@ -186,9 +232,15 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
     else
         # annotate fulltree with type information
         type_annotate!(me)
+        if isa(me.bestguess, PartialOpaque)
+            mod = isa(me.linfo.def, Module) ? me.linfo.def : me.linfo.def.module
+            finish_opaque_closure!(me.bestguess, mod, interp)
+        end
         me.result.src = OptimizationState(me, OptimizationParams(interp), interp)
     end
-    me.result.result = me.bestguess
+    if me.result !== nothing
+        me.result.result = me.bestguess
+    end
     nothing
 end
 
@@ -508,6 +560,8 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
         if isdefined(code, :rettype_const)
             if isa(code.rettype_const, Vector{Any}) && !(Vector{Any} <: code.rettype)
                 return PartialStruct(code.rettype, code.rettype_const), mi
+            elseif isa(code.rettype_const, PartialOpaque) && code.rettype <: Core.OpaqueClosure
+                return code.rettype_const, mi
             else
                 return Const(code.rettype_const), mi
             end
@@ -552,7 +606,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
 end
 
 function widenconst_bestguess(bestguess)
-    !isa(bestguess, Const) && !isa(bestguess, PartialStruct) && !isa(bestguess, Type) && return widenconst(bestguess)
+    !isa(bestguess, Const) && !isa(bestguess, PartialStruct) && !isa(bestguess, PartialOpaque) && !isa(bestguess, Type) && return widenconst(bestguess)
     return bestguess
 end
 

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -54,6 +54,15 @@ struct PartialTypeVar
     PartialTypeVar(tv::TypeVar, lb_certain::Bool, ub_certain::Bool) = new(tv, lb_certain, ub_certain)
 end
 
+mutable struct PartialOpaque
+    t::Type
+    env::Any
+    parent::MethodInstance
+    ci::Any
+    # TODO: Where do we cache these results?
+end
+widenconst(py::PartialOpaque) = py.t
+
 # Wraps a type and represents that the value may also be undef at this point.
 # (only used in optimize, not abstractinterpret)
 struct MaybeUndef
@@ -161,6 +170,9 @@ function ⊑(@nospecialize(a), @nospecialize(b))
             return true
         end
         return false
+    end
+    if isa(a, PartialOpaque)
+        return widenconst(a) <: widenconst(b)
     end
     if isa(a, Const)
         if isa(b, Const)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -23,7 +23,7 @@ abstract type AbstractInterpreter; end
 A type that represents the result of running type inference on a chunk of code.
 """
 mutable struct InferenceResult
-    linfo::MethodInstance
+    linfo::Union{Nothing, MethodInstance}
     argtypes::Vector{Any}
     overridden_by_const::BitVector
     result # ::Type, or InferenceState if WIP
@@ -31,6 +31,9 @@ mutable struct InferenceResult
     function InferenceResult(linfo::MethodInstance, given_argtypes = nothing)
         argtypes, overridden_by_const = matching_cache_argtypes(linfo, given_argtypes)
         return new(linfo, argtypes, overridden_by_const, Any, nothing)
+    end
+    function InferenceResult(::Type{Core.OpaqueClosure}, argtypes::Vector{Any})
+        new(nothing, argtypes, BitVector(), Any, nothing)
     end
 end
 

--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -1,0 +1,26 @@
+@noinline function (y::Core.OpaqueClosure{A, R})(args...) where {A,R}
+    typeassert(args, A)
+    ccall(y.fptr1, Any, (Any, Ptr{Any}, Int), y, Any[args...], length(args))::R
+end
+
+"""
+    _opaque_closure(argt::Type{<:Tuple}, lb::Type, ub::Type, source::CodeInfo, captures...)
+
+Create a new OpaqueClosure taking arguments specified by the types `argt`. When called,
+this opaque closure will execute the source specified in `source`. The `lb` and `ub`
+arguments constrain the return type of the opaque closure. In particular, any return
+value of type `Core.OpaqueClosure{argt, R} where lb<:R<:ub` is semantically valid. If
+the optimizer runs, it may replace `R` by the narrowest possible type inference
+was able to determine. To guarantee a particular value of `R`, set lb===ub.
+"""
+Core._opaque_closure
+
+function show(io::IO, oc::Core.OpaqueClosure{A, R}) where {A, R}
+    types = map(@nospecialize(T)->Expr(:(::), T), A.parameters)
+    show_enclosed_list(io, '(', types, ',', ')', 0)
+    print(io, "::", R)
+    print(io, "->◌")
+end
+
+
+# @opaque macro goes here

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ RUNTIME_SRCS := \
 	simplevector runtime_intrinsics precompile \
 	threading partr stackwalk gc gc-debug gc-pages gc-stacks method \
 	jlapi signal-handling safepoint timing subtype \
-	crc32c APInt-C processor ircode
+	crc32c APInt-C processor ircode opaque_closure
 SRCS := jloptions runtime_ccall rtutils
 
 LLVMLINK :=

--- a/src/ast.c
+++ b/src/ast.c
@@ -603,6 +603,13 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
             temp = (jl_value_t*)jl_exprn(sym, 1);
             jl_exprargset(temp, 0, ex);
         }
+        else if (sym == jl_symbol("anonymous_closure")) {
+            ex = scm_to_julia_(fl_ctx, car_(e), mod);
+            assert(jl_is_code_info(ex));
+            jl_linenumber_to_lineinfo((jl_code_info_t*)ex, mod, (jl_value_t*)jl_symbol("opaque"));
+            jl_resolve_globals_in_ir((jl_array_t*)((jl_code_info_t*)ex)->code, mod, NULL, 0);
+            temp = ex;
+        }
         if (temp) {
             JL_GC_POP();
             return temp;

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -35,6 +35,7 @@ DECLARE_BUILTIN(apply_type); DECLARE_BUILTIN(applicable);
 DECLARE_BUILTIN(invoke);     DECLARE_BUILTIN(_expr);
 DECLARE_BUILTIN(typeassert); DECLARE_BUILTIN(ifelse);
 DECLARE_BUILTIN(_typevar);   DECLARE_BUILTIN(_typebody);
+DECLARE_BUILTIN(_opaque_closure);
 
 JL_CALLABLE(jl_f_invoke_kwsorter);
 JL_CALLABLE(jl_f__structtype);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1395,6 +1395,20 @@ JL_CALLABLE(jl_f__equiv_typedef)
     return equiv_type(args[0], args[1]) ? jl_true : jl_false;
 }
 
+// opaque closure
+JL_CALLABLE(jl_f__opaque_closure)
+{
+    JL_NARGSV(_opaque_closure, 4)
+    JL_TYPECHK(_opaque_closure, type, args[0]);
+    JL_TYPECHK(_opaque_closure, type, args[1]);
+    JL_TYPECHK(_opaque_closure, type, args[2]);
+    if (!jl_is_method(args[3]) && !jl_is_code_info(args[3])) {
+        jl_error("Invalid OpaqueClosure source");
+    }
+    return (jl_value_t*)jl_new_opaque_closure((jl_tupletype_t*)args[0], args[1], args[2],
+        args[3], args+4, nargs-4);
+}
+
 // IntrinsicFunctions ---------------------------------------------------------
 
 static void (*runtime_fp[num_intrinsics])(void);
@@ -1554,6 +1568,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     jl_builtin__apply_iterate = add_builtin_func("_apply_iterate", jl_f__apply_iterate);
     jl_builtin__expr = add_builtin_func("_expr", jl_f__expr);
     jl_builtin_svec = add_builtin_func("svec", jl_f_svec);
+    jl_builtin__opaque_closure = add_builtin_func("_opaque_closure", jl_f__opaque_closure);
     add_builtin_func("_apply_pure", jl_f__apply_pure);
     add_builtin_func("_apply_latest", jl_f__apply_latest);
     add_builtin_func("_apply_in_world", jl_f__apply_in_world);
@@ -1604,6 +1619,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Ptr", (jl_value_t*)jl_pointer_type);
     add_builtin("LLVMPtr", (jl_value_t*)jl_llvmpointer_type);
     add_builtin("Task", (jl_value_t*)jl_task_type);
+    add_builtin("OpaqueClosure", (jl_value_t*)jl_opaque_closure_type);
 
     add_builtin("AbstractArray", (jl_value_t*)jl_abstractarray_type);
     add_builtin("DenseArray", (jl_value_t*)jl_densearray_type);

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -756,6 +756,7 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.endswith_lower("jl_task_t") ||
                    Name.endswith_lower("jl_uniontype_t") ||
                    Name.endswith_lower("jl_method_match_t") ||
+                   Name.endswith_lower("jl_opaque_closure_t") ||
                    // Probably not technically true for these, but let's allow
                    // it
                    Name.endswith_lower("typemap_intersection_env") ||

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2601,6 +2601,13 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
     return emit_box_compare(ctx, arg1, arg2, nullcheck1, nullcheck2);
 }
 
+static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
+    emit_function(
+        jl_method_instance_t *lam,
+        jl_code_info_t *src,
+        jl_value_t *jlrettype,
+        jl_codegen_params_t &params);
+
 static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                               const jl_cgval_t *argv, size_t nargs, jl_value_t *rt,
                               jl_expr_t *ex)
@@ -3207,6 +3214,78 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         }
         return true;
     }
+
+    else if (f == jl_builtin__opaque_closure && nargs >= 4) {
+        const jl_cgval_t &argt = argv[1];
+        const jl_cgval_t &ub = argv[3];
+        const jl_cgval_t &source = argv[4];
+        if (source.constant == NULL || argt.constant == NULL || ub.constant == NULL) {
+            // If we don't know the source, nothing we can do
+            return false;
+        }
+        if (jl_is_code_info(source.constant)) {
+            // TODO: Emit this inline and outline it late using LLVM's coroutine
+            // support.
+            jl_code_info_t *closure_src = (jl_code_info_t *)source.constant;
+            std::unique_ptr<Module> closure_m;
+            jl_llvm_functions_t closure_decls;
+
+            jl_method_instance_t *li;
+            jl_value_t *closure_t;
+            jl_tupletype_t *env_t;
+            jl_svec_t *sig_args;
+            JL_GC_PUSH4(&li, &closure_t, &env_t, &sig_args);
+
+            li = jl_new_method_instance_uninit();
+            li->uninferred = (jl_value_t*)closure_src;
+            jl_tupletype_t *argt_typ = (jl_tupletype_t *)argt.constant;
+
+            closure_t = jl_apply_type2((jl_value_t*)jl_opaque_closure_type, (jl_value_t*)argt_typ, ub.constant);
+
+            size_t nsig = 1 + jl_svec_len(argt_typ->parameters);
+            sig_args = jl_alloc_svec_uninit(nsig);
+            jl_svecset(sig_args, 0, closure_t);
+            for (size_t i = 0; i < jl_svec_len(argt_typ->parameters); ++i) {
+                jl_svecset(sig_args, 1+i, jl_svecref(argt_typ->parameters, i));
+            }
+            li->specTypes = (jl_value_t*)jl_apply_tuple_type_v(jl_svec_data(sig_args), nsig);
+            li->def.module = ctx.module;
+            std::tie(closure_m, closure_decls) = emit_function(li, closure_src,
+                ub.constant, ctx.emission_context);
+            jl_merge_module(ctx.f->getParent(), std::move(closure_m));
+
+            jl_value_t **env_component_ts = (jl_value_t**)alloca(sizeof(jl_value_t*) * nargs-4);
+            for (size_t i = 0; i < nargs - 4; ++i) {
+                env_component_ts[i] = argv[5+i].typ;
+            }
+
+            env_t = jl_apply_tuple_type_v(env_component_ts, nargs-4);
+
+            // TODO: Inline the env at the end of the opaque closure and generate a descriptor for GC
+            jl_cgval_t env = emit_new_struct(ctx, (jl_value_t*)env_t, nargs-4, &argv[5]);
+
+            Function *specptr = ctx.f->getParent()->getFunction(closure_decls.specFunctionObject);
+            jl_cgval_t fptr = mark_julia_type(ctx,
+                specptr ? (llvm::Value*)specptr : (llvm::Value*)ConstantPointerNull::get((llvm::PointerType*)T_pvoidfunc),
+                false, jl_voidpointer_type);
+            Function *jlptr = ctx.f->getParent()->getFunction(closure_decls.functionObject);
+            jl_cgval_t jlcall_ptr = mark_julia_type(ctx,
+                jlptr ? (llvm::Value*)jlptr : (llvm::Value*)ConstantPointerNull::get((llvm::PointerType*)T_pvoidfunc),
+                false, jl_voidpointer_type);
+
+            jl_cgval_t closure_fields[4] =  {
+                env,
+                source,
+                jlcall_ptr,
+                fptr
+            };
+
+            *ret = emit_new_struct(ctx, closure_t, 4, closure_fields);
+            JL_GC_POP();
+            return true;
+        }
+    }
+
     return false;
 }
 
@@ -5713,15 +5792,27 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     ctx.code = src->code;
 
     std::map<int, BasicBlock*> labels;
+    bool toplevel = false;
     ctx.module = jl_is_method(lam->def.method) ? lam->def.method->module : lam->def.module;
     ctx.linfo = lam;
+    ctx.name = name_from_method_instance(lam);
+    bool is_opaque_closure = false;
+    if (jl_is_method(lam->def.method)) {
+        ctx.nargs = lam->def.method->nargs;
+    } else {
+        ctx.nargs = 0;
+        // This is an opaque closure
+        jl_datatype_t *sig = (jl_datatype_t*)lam->specTypes;
+        if (jl_svec_len(sig->parameters) > 0 && jl_is_opaque_closure_type(jl_tparam0(sig))) {
+            ctx.nargs = 1 + jl_nparams(jl_tparam0(jl_tparam0(sig)));
+            is_opaque_closure = true;
+        }
+    }
+    toplevel = !jl_is_method(lam->def.method);
     ctx.rettype = jlrettype;
     ctx.source = src;
-    ctx.name = name_from_method_instance(lam);
     ctx.funcName = ctx.name;
     ctx.spvals_ptr = NULL;
-    ctx.nargs = jl_is_method(lam->def.method) ? lam->def.method->nargs : 0;
-    bool toplevel = !jl_is_method(lam->def.method);
     jl_array_t *stmts = ctx.code;
     size_t stmtslen = jl_array_dim0(stmts);
 
@@ -5735,7 +5826,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
 
     StringRef dbgFuncName = ctx.name;
     int toplineno = -1;
-    if (jl_is_method(lam->def.method)) {
+    if (lam && jl_is_method(lam->def.method)) {
         toplineno = lam->def.method->line;
         ctx.file = jl_symbol_name(lam->def.method->file);
     }
@@ -5764,7 +5855,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
 
     assert(lam->specTypes); // the specTypes field should always be assigned
 
-    if (nreq > 0 && lam->def.method->isva) {
+    if (nreq > 0 && jl_is_method(lam->def.value) && lam->def.method->isva) {
         nreq--;
         va = 1;
         jl_sym_t *vn = (jl_sym_t*)jl_array_ptr_ref(src->slotnames, ctx.nargs - 1);
@@ -5791,6 +5882,14 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
         if (argname == unused_sym)
             continue;
         jl_value_t *ty = jl_nth_slot_type(lam->specTypes, i);
+        // OpaqueClosure implicitly loads the env
+        if (i == 0 && is_opaque_closure) {
+            if (jl_is_array(src->slottypes)) {
+                ty = jl_arrayref((jl_array_t*)src->slottypes, i);
+            } else {
+                ty = (jl_value_t*)jl_any_type;
+            }
+        }
         varinfo.value = mark_julia_type(ctx, (Value*)NULL, false, ty);
     }
     if (va && ctx.vaSlot != -1) {
@@ -6271,6 +6370,11 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                                         ctx.builder.GetInsertBlock());
                     }
                 }
+            }
+
+            // If this is an opaque closure, implicitly load the env
+            if (i == 0 && is_opaque_closure) {
+                theArg = emit_getfield_knownidx(ctx, theArg, 0, (jl_datatype_t*)argType);
             }
 
             if (vi.boxroot == NULL) {

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -930,8 +930,9 @@ static void init_struct_tail(jl_datatype_t *type, jl_value_t *jv, size_t na)
 JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uint32_t na)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    if (!jl_is_datatype(type) || type->layout == NULL)
+    if (!jl_is_datatype(type) || type->layout == NULL) {
         jl_type_error("new", (jl_value_t*)jl_datatype_type, (jl_value_t*)type);
+    }
     if (type->ninitialized > na || na > jl_datatype_nfields(type))
         jl_error("invalid struct allocation");
     for (size_t i = 0; i < na; i++) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -2576,7 +2576,6 @@ void jl_init_serializer(void)
                      jl_box_int64(12), jl_box_int64(13), jl_box_int64(14),
                      jl_box_int64(15), jl_box_int64(16), jl_box_int64(17),
                      jl_box_int64(18), jl_box_int64(19), jl_box_int64(20),
-                     jl_box_int64(21),
 
                      jl_bool_type, jl_linenumbernode_type, jl_pinode_type,
                      jl_upsilonnode_type, jl_type_type, jl_bottom_type, jl_ref_type,
@@ -2592,6 +2591,7 @@ void jl_init_serializer(void)
                      jl_namedtuple_type, jl_array_int32_type,
                      jl_typedslot_type, jl_uint32_type, jl_uint64_type,
                      jl_type_type_mt, jl_nonfunction_mt,
+                     jl_opaque_closure_type,
 
                      ptls->root_task,
 
@@ -2660,6 +2660,7 @@ void jl_init_serializer(void)
     arraylist_push(&builtin_typenames, jl_tuple_typename);
     arraylist_push(&builtin_typenames, jl_vararg_typename);
     arraylist_push(&builtin_typenames, jl_namedtuple_typename);
+    arraylist_push(&builtin_typenames, jl_opaque_closure_typename);
 }
 
 #ifdef __cplusplus

--- a/src/gf.c
+++ b/src/gf.c
@@ -205,7 +205,6 @@ JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *typ
 
 // ----- MethodInstance specialization instantiation ----- //
 
-JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t*);
 JL_DLLEXPORT jl_code_instance_t* jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
@@ -2410,8 +2409,6 @@ JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, size_t wo
     return (jl_value_t*)matc->method;
 }
 
-static jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);
-
 // invoke()
 // this does method dispatch with a set of types to match other than the
 // types of the actual arguments. this means it sometimes does NOT call the
@@ -2441,7 +2438,7 @@ jl_value_t *jl_gf_invoke(jl_value_t *types0, jl_value_t *gf, jl_value_t **args, 
     return jl_gf_invoke_by_method(method, gf, args, nargs);
 }
 
-static jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs)
+jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs)
 {
     jl_method_instance_t *mfunc = NULL;
     jl_typemap_entry_t *tm = NULL;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -52,6 +52,7 @@ jl_datatype_t *jl_unionall_type;
 jl_datatype_t *jl_datatype_type;
 jl_datatype_t *jl_function_type;
 jl_datatype_t *jl_builtin_type;
+jl_unionall_t *jl_opaque_closure_type;
 
 jl_datatype_t *jl_typeofbottom_type;
 jl_value_t *jl_bottom_type;
@@ -84,6 +85,7 @@ JL_DLLEXPORT jl_value_t *jl_false;
 
 jl_unionall_t *jl_array_type;
 jl_typename_t *jl_array_typename;
+jl_typename_t *jl_opaque_closure_typename;
 jl_value_t *jl_array_uint8_type;
 jl_value_t *jl_array_any_type;
 jl_value_t *jl_array_symbol_type;
@@ -2393,7 +2395,6 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_perm_symsvec(4, "spec_types", "sparams", "method", "fully_covers"),
                                        jl_svec(4, jl_type_type, jl_simplevector_type, jl_method_type, jl_bool_type), 0, 0, 4);
 
-
     // all Kinds share the Type method table (not the nonfunction one)
     jl_unionall_type->name->mt = jl_uniontype_type->name->mt = jl_datatype_type->name->mt =
         jl_type_type_mt;
@@ -2468,8 +2469,17 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
 
-    // complete builtin type metadata
     jl_value_t *pointer_void = jl_apply_type1((jl_value_t*)jl_pointer_type, (jl_value_t*)jl_nothing_type);
+
+    tv = jl_svec2(tvar("A"), tvar("R"));
+    jl_opaque_closure_type = (jl_unionall_t*)jl_new_datatype(jl_symbol("OpaqueClosure"), core, jl_any_type, tv,
+        jl_perm_symsvec(4, "env", "ci", "fptr1", "fptr"),
+        jl_svec(4, jl_any_type, jl_code_info_type, pointer_void, pointer_void), 0, 0, 4)->name->wrapper;
+    jl_opaque_closure_typename = ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_opaque_closure_type))->name;
+    jl_compute_field_offsets((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_opaque_closure_type));
+
+
+    // complete builtin type metadata
     jl_voidpointer_type = (jl_datatype_t*)pointer_void;
     jl_uint8pointer_type = (jl_datatype_t*)jl_apply_type1((jl_value_t*)jl_pointer_type, (jl_value_t*)jl_uint8_type);
     jl_svecset(jl_datatype_type->types, 6, jl_voidpointer_type);

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1952,6 +1952,24 @@
         ,@(if (length= e 3) '(()) '())
         ,@(map expand-forms (cddr e))))
 
+   'opaque_closure
+   (lambda (e)
+     (let* ((meth (caddr (caddr (expand-forms (cadr e))))) ;; `method` expr
+            (lam       (cadddr meth))
+            (sig-block (caddr meth))
+            (sig-block (if (and (pair? sig-block) (eq? (car sig-block) 'block))
+                           sig-block
+                           `(block ,sig-block)))
+            (stmts     (cdr (butlast sig-block)))
+            (sig-svec  (last sig-block))
+            (typ-svec  (caddr sig-svec))
+            (tvars     (cddr (cadddr sig-svec)))
+            (argtypes  (cdddr typ-svec))
+            (argtype   (foldl (lambda (var ex) `(call (core UnionAll) ,var ,ex))
+                              (expand-forms `(curly (core Tuple) ,@argtypes))
+                              (reverse tvars))))
+       `(opaque_closure ,argtype ,lam)))
+
    'block
    (lambda (e)
      (cond ((null? (cdr e)) '(null))
@@ -3029,9 +3047,9 @@ f(x) = yt(x)
 (define (clear-capture-bits vinfos)
   (map vinfo:not-capt vinfos))
 
-(define (convert-lambda lam fname interp capt-sp)
+(define (convert-lambda lam fname interp capt-sp opaq)
   (let ((body (add-box-inits-to-body
-                lam (cl-convert (cadddr lam) fname lam (table) (table) #f interp))))
+               lam (cl-convert (cadddr lam) fname lam (table) (table) #f interp opaq))))
     `(lambda ,(lam:args lam)
        (,(clear-capture-bits (car (lam:vinfo lam)))
         ()
@@ -3071,12 +3089,17 @@ f(x) = yt(x)
             `(block (= ,temp ,(renumber-assigned-ssavalues t)) ,ex)
             ex))))
 
+(define (capt-var-access var fname opaq)
+  (if opaq
+      `(call (core getfield) (call (core getfield) ,fname (inert env)) ,(get opaq var))
+      `(call (core getfield) ,fname (inert ,var))))
+
 ;; convert assignment to a closed variable to a setfield! call.
 ;; while we're at it, generate `convert` calls for variables with
 ;; declared types.
 ;; when doing this, the original value needs to be preserved, to
 ;; ensure the expression `a=b` always returns exactly `b`.
-(define (convert-assignment var rhs0 fname lam interp)
+(define (convert-assignment var rhs0 fname lam interp opaq)
   (cond
     ((symbol? var)
      (let* ((vi (assq var (car  (lam:vinfo lam))))
@@ -3094,11 +3117,11 @@ f(x) = yt(x)
                             (make-ssavalue)))
                   (rhs  (if (equal? vt '(core Any))
                             rhs1
-                            (convert-for-type-decl rhs1 (cl-convert vt fname lam #f #f #f interp))))
+                            (convert-for-type-decl rhs1 (cl-convert vt fname lam #f #f #f interp opaq))))
                   (ex (cond (closed `(call (core setfield!)
                                            ,(if interp
                                                 `($ ,var)
-                                                `(call (core getfield) ,fname (inert ,var)))
+                                                (capt-var-access var fname opaq))
                                            (inert contents)
                                            ,rhs))
                             (capt `(call (core setfield!) ,var (inert contents) ,rhs))
@@ -3346,23 +3369,30 @@ f(x) = yt(x)
 (define (toplevel-preserving? e)
   (and (pair? e) (memq (car e) '(if elseif block trycatch tryfinally))))
 
-(define (map-cl-convert exprs fname lam namemap defined toplevel interp)
+(define (map-cl-convert exprs fname lam namemap defined toplevel interp opaq)
   (if toplevel
       (map (lambda (x)
              (let ((tl (lift-toplevel (cl-convert x fname lam namemap defined
                                                   (and toplevel (toplevel-preserving? x))
-                                                  interp))))
+                                                  interp opaq))))
                (if (null? (cdr tl))
                    (car tl)
                    `(block ,@(cdr tl) ,(car tl)))))
            exprs)
-      (map (lambda (x) (cl-convert x fname lam namemap defined #f interp)) exprs)))
+      (map (lambda (x) (cl-convert x fname lam namemap defined #f interp opaq)) exprs)))
 
-(define (cl-convert e fname lam namemap defined toplevel interp)
+(define (prepare-lam lam)
+  ;; mark all non-arguments as assigned, since locals that are never assigned
+  ;; need to be handled the same as those that are (i.e., boxed).
+  (for-each (lambda (vi) (vinfo:set-asgn! vi #t))
+            (list-tail (car (lam:vinfo lam)) (length (lam:args lam))))
+  (lambda-optimize-vars! lam))
+
+(define (cl-convert e fname lam namemap defined toplevel interp opaq)
   (if (and (not lam)
-           (not (and (pair? e) (memq (car e) '(lambda method macro)))))
+           (not (and (pair? e) (memq (car e) '(lambda method macro opaque_closure)))))
       (if (atom? e) e
-          (cons (car e) (map-cl-convert (cdr e) fname lam namemap defined toplevel interp)))
+          (cons (car e) (map-cl-convert (cdr e) fname lam namemap defined toplevel interp opaq)))
       (cond
        ((symbol? e)
         (define (new-undef-var name)
@@ -3381,7 +3411,7 @@ f(x) = yt(x)
                  (val (if (equal? typ '(core Any))
                           val
                           `(call (core typeassert) ,val
-                                 ,(cl-convert typ fname lam namemap defined toplevel interp)))))
+                                 ,(cl-convert typ fname lam namemap defined toplevel interp opaq)))))
             `(block
                ,@(if (eq? box access) '() `((= ,access ,box)))
                ,undefcheck
@@ -3393,7 +3423,7 @@ f(x) = yt(x)
                 (cv
                  (let ((access (if interp
                                    `($ (call (core QuoteNode) ,e))
-                                   `(call (core getfield) ,fname (inert ,e)))))
+                                   (capt-var-access e fname opaq))))
                    (if (and (vinfo:asgn cv) (vinfo:capt cv))
                        (get-box-contents access (vinfo:type cv))
                        access)))
@@ -3413,8 +3443,8 @@ f(x) = yt(x)
            e)
           ((=)
            (let ((var (cadr e))
-                 (rhs (cl-convert (caddr e) fname lam namemap defined toplevel interp)))
-             (convert-assignment var rhs fname lam interp)))
+                 (rhs (cl-convert (caddr e) fname lam namemap defined toplevel interp opaq)))
+             (convert-assignment var rhs fname lam interp opaq)))
           ((local-def) ;; make new Box for local declaration of defined variable
            (let ((vi (assq (cadr e) (car (lam:vinfo lam)))))
              (if (and vi (vinfo:asgn vi) (vinfo:capt vi))
@@ -3442,7 +3472,7 @@ f(x) = yt(x)
                     (if (and (vinfo:asgn cv) (vinfo:capt cv))
                         (let ((access (if interp
                                           `($ (call (core QuoteNode) ,sym))
-                                          `(call (core getfield) ,fname (inert ,sym)))))
+                                          (capt-var-access sym fname opaq))))
                           `(call (core isdefined) ,access (inert contents)))
                         '(true)))
                    (vi
@@ -3450,6 +3480,20 @@ f(x) = yt(x)
                         `(call (core isdefined) ,sym (inert contents))
                         e))
                    (else e))))
+          ((opaque_closure)
+           (let* ((lam2 (caddr e))
+                  (vis  (lam:vinfo lam2))
+                  (cvs  (map car (cadr vis))))
+             (prepare-lam lam2)
+             (let ((var-exprs (map (lambda (v)
+                                     (let ((cv (assq v (cadr (lam:vinfo lam)))))
+                                       (if cv
+                                           (capt-var-access v fname opaq)
+                                           v)))
+                                   cvs)))
+               `(call (core _opaque_closure) ,(cadr e) (call (core apply_type) Union) (core Any)
+                      (anonymous_closure ,(convert-lambda lam2 (car (lam:args lam2)) #f '() (symbol-to-idx-map cvs)))
+                      ,@var-exprs))))
           ((method)
            (let* ((name  (method-expr-name e))
                   (short (length= e 2))  ;; function f end
@@ -3462,7 +3506,7 @@ f(x) = yt(x)
                   (sp-inits (if (or short (not (eq? (car sig) 'block)))
                                 '()
                                 (map-cl-convert (butlast (cdr sig))
-                                                fname lam namemap defined toplevel interp)))
+                                                fname lam namemap defined toplevel interp opaq)))
                   (sig      (and sig (if (eq? (car sig) 'block)
                                          (last sig)
                                          sig))))
@@ -3471,13 +3515,7 @@ f(x) = yt(x)
                             (error (string "cannot add method to function argument " name)))
                         (if (eqv? (string.char (string name) 0) #\@)
                             (error "macro definition not allowed inside a local scope"))))
-             (if lam2
-                 (begin
-                   ;; mark all non-arguments as assigned, since locals that are never assigned
-                   ;; need to be handled the same as those that are (i.e., boxed).
-                   (for-each (lambda (vi) (vinfo:set-asgn! vi #t))
-                             (list-tail (car (lam:vinfo lam2)) (length (lam:args lam2))))
-                   (lambda-optimize-vars! lam2)))
+             (if lam2 (prepare-lam lam2))
              (if (not local) ;; not a local function; will not be closure converted to a new type
                  (cond (short (if (has? defined (cadr e))
                                   e
@@ -3495,21 +3533,21 @@ f(x) = yt(x)
                                           ;; anonymous functions with keyword args generate global
                                           ;; functions that refer to the type of a local function
                                           (rename-sig-types sig namemap)
-                                          fname lam namemap defined toplevel interp)
+                                          fname lam namemap defined toplevel interp opaq)
                                   ,(let ((body (add-box-inits-to-body
                                                 lam2
-                                                (cl-convert (cadddr lam2) 'anon lam2 (table) (table) #f interp))))
+                                                (cl-convert (cadddr lam2) 'anon lam2 (table) (table) #f interp opaq))))
                                      `(lambda ,(cadr lam2)
                                         (,(clear-capture-bits (car vis))
                                          ,@(cdr vis))
                                         ,body)))))
                        (else
-                        (let* ((exprs     (lift-toplevel (convert-lambda lam2 '|#anon| #t '())))
+                        (let* ((exprs     (lift-toplevel (convert-lambda lam2 '|#anon| #t '() #f)))
                                (top-stmts (cdr exprs))
                                (newlam    (compact-and-renumber (linearize (car exprs)) 'none 0)))
                           `(toplevel-butfirst
                             (block ,@sp-inits
-                                   (method ,name ,(cl-convert sig fname lam namemap defined toplevel interp)
+                                   (method ,name ,(cl-convert sig fname lam namemap defined toplevel interp opaq)
                                            ,(julia-bq-macro newlam)))
                             ,@top-stmts))))
 
@@ -3612,19 +3650,19 @@ f(x) = yt(x)
                                (append (map (lambda (gs tvar)
                                               (make-assignment gs `(call (core TypeVar) ',tvar (core Any))))
                                             closure-param-syms closure-param-names)
-                                       `((method #f ,(cl-convert arg-defs fname lam namemap defined toplevel interp)
+                                       `((method #f ,(cl-convert arg-defs fname lam namemap defined toplevel interp opaq)
                                                  ,(convert-lambda lam2
                                                                   (if iskw
                                                                       (caddr (lam:args lam2))
                                                                       (car (lam:args lam2)))
-                                                                  #f closure-param-names)))))))
+                                                                  #f closure-param-names #f)))))))
                         (mk-closure  ;; expression to make the closure
                          (let* ((var-exprs (map (lambda (v)
                                                   (let ((cv (assq v (cadr (lam:vinfo lam)))))
                                                     (if cv
                                                         (if interp
                                                             `($ (call (core QuoteNode) ,v))
-                                                            `(call (core getfield) ,fname (inert ,v)))
+                                                            (capt-var-access v fname opaq))
                                                         v)))
                                                 capt-vars))
                                 (P (append
@@ -3651,7 +3689,7 @@ f(x) = yt(x)
                        (begin
                          (put! defined name #t)
                          `(toplevel-butfirst
-                           ,(convert-assignment name mk-closure fname lam interp)
+                           ,(convert-assignment name mk-closure fname lam interp opaq)
                            ,@typedef
                            ,@(map (lambda (v) `(moved-local ,v)) moved-vars)
                            ,@sp-inits
@@ -3664,14 +3702,14 @@ f(x) = yt(x)
                                        (table)
                                        (table)
                                        (null? (cadr e)) ;; only toplevel thunks have 0 args
-                                       interp)))
+                                       interp opaq)))
              `(lambda ,(cadr e)
                 (,(clear-capture-bits (car (lam:vinfo e)))
                  () ,@(cddr (lam:vinfo e)))
                 (block ,@body))))
           ;; remaining `::` expressions are type assertions
           ((|::|)
-           (cl-convert `(call (core typeassert) ,@(cdr e)) fname lam namemap defined toplevel interp))
+           (cl-convert `(call (core typeassert) ,@(cdr e)) fname lam namemap defined toplevel interp opaq))
           ;; remaining `decl` expressions are only type assertions if the
           ;; argument is global or a non-symbol.
           ((decl)
@@ -3681,15 +3719,15 @@ f(x) = yt(x)
                  (else
                   (if (or (symbol? (cadr e)) (and (pair? (cadr e)) (eq? (caadr e) 'outerref)))
                       (error "type declarations on global variables are not yet supported"))
-                  (cl-convert `(call (core typeassert) ,@(cdr e)) fname lam namemap defined toplevel interp))))
+                  (cl-convert `(call (core typeassert) ,@(cdr e)) fname lam namemap defined toplevel interp opaq))))
           ;; `with-static-parameters` expressions can be removed now; used only by analyze-vars
           ((with-static-parameters)
-           (cl-convert (cadr e) fname lam namemap defined toplevel interp))
+           (cl-convert (cadr e) fname lam namemap defined toplevel interp opaq))
           (else
            (cons (car e)
-                 (map-cl-convert (cdr e) fname lam namemap defined toplevel interp))))))))
+                 (map-cl-convert (cdr e) fname lam namemap defined toplevel interp opaq))))))))
 
-(define (closure-convert e) (cl-convert e #f #f #f #f #f #f))
+(define (closure-convert e) (cl-convert e #f #f #f #f #f #f #f))
 
 ;; pass 5: convert to linear IR
 
@@ -4205,6 +4243,11 @@ f(x) = yt(x)
                (cond (tail  (emit-return temp))
                      (value temp)
                      (else  (emit temp)))))
+            ((anonymous_closure)
+             (let ((temp `(anonymous_closure ,(linearize (cadr e)))))
+               (cond (tail  (emit-return temp))
+                     (value temp)
+                     (else  (emit temp)))))
 
             ;; top level expressions
             ((thunk module)
@@ -4427,14 +4470,6 @@ f(x) = yt(x)
                        (set! reachable #f))))
             (loop (cdr stmts)))))
     (vector (reverse code) (reverse locs) (reverse linetable) ssavtable labltable)))
-
-(define (symbol-to-idx-map lst)
-  (let ((tbl (table)))
-    (let loop ((xs lst) (i 1))
-      (if (pair? xs)
-          (begin (put! tbl (car xs) i)
-                 (loop (cdr xs) (+ i 1)))))
-    tbl))
 
 (define (renumber-lambda lam file line)
   (let* ((stuff (compact-ir (lam:body lam) file line))

--- a/src/julia.h
+++ b/src/julia.h
@@ -351,6 +351,19 @@ struct _jl_method_instance_t {
     uint8_t inInference; // flags to tell if inference is running on this object
 };
 
+// YACK - Yet another kind of closure.
+typedef struct jl_opaque_closure_t {
+    JL_DATA_TYPE
+    jl_value_t *env;
+    union {
+        jl_value_t *code;
+        jl_code_info_t *source;
+        jl_method_t *method;
+    };
+    jl_fptr_args_t fptr1;
+    void *fptr;
+} jl_opaque_closure_t;
+
 // This type represents an executable operation
 typedef struct _jl_code_instance_t {
     JL_DATA_TYPE
@@ -624,6 +637,8 @@ extern JL_DLLEXPORT jl_unionall_t *jl_vararg_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_vararg_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_function_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_builtin_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_unionall_t *jl_opaque_closure_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_typename_t *jl_opaque_closure_typename JL_GLOBALLY_ROOTED;
 
 extern JL_DLLEXPORT jl_value_t *jl_bottom_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_method_instance_type JL_GLOBALLY_ROOTED;
@@ -1206,6 +1221,19 @@ STATIC_INLINE int jl_is_array(void *v) JL_NOTSAFEPOINT
 {
     jl_value_t *t = jl_typeof(v);
     return jl_is_array_type(t);
+}
+
+
+STATIC_INLINE int jl_is_opaque_closure_type(void *t) JL_NOTSAFEPOINT
+{
+    return (jl_is_datatype(t) &&
+            ((jl_datatype_t*)(t))->name == jl_opaque_closure_typename);
+}
+
+STATIC_INLINE int jl_is_opaque_closure(void *v) JL_NOTSAFEPOINT
+{
+    jl_value_t *t = jl_typeof(v);
+    return jl_is_opaque_closure_type(t);
 }
 
 STATIC_INLINE int jl_is_cpointer_type(jl_value_t *t) JL_NOTSAFEPOINT

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -484,6 +484,7 @@ jl_array_t *jl_get_loaded_modules(void);
 jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded);
 
 jl_value_t *jl_eval_global_var(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *e);
+jl_value_t *jl_interpret_opaque_closure(jl_opaque_closure_t *clos, jl_value_t **args, size_t nargs);
 jl_value_t *jl_interpret_toplevel_thunk(jl_module_t *m, jl_code_info_t *src);
 jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                           jl_code_info_t *src,
@@ -493,6 +494,8 @@ jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr, jl_module
 void jl_linenumber_to_lineinfo(jl_code_info_t *ci, jl_module_t *mod, jl_value_t *name);
 
 jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world);
+
+jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);
 jl_value_t *jl_gf_invoke(jl_value_t *types, jl_value_t *f, jl_value_t **args, size_t nargs);
 JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int include_ambiguous,
                                              size_t world, size_t *min_valid, size_t *max_valid, int *ambig);
@@ -514,6 +517,8 @@ void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b);
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT void jl_compile_extern_c(void *llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
+
+jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub, jl_value_t *source,  jl_value_t **env, size_t nenv);
 
 // Each tuple can exist in one of 4 Vararg states:
 //   NONE: no vararg                            Tuple{Int,Float32}
@@ -707,6 +712,8 @@ void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
 // make sure it is rooted if it is used after the function returns
 JL_DLLEXPORT jl_array_t *jl_idtable_rehash(jl_array_t *a, size_t newsz);
 jl_value_t **jl_table_peek_bp(jl_array_t *a, jl_value_t *key) JL_NOTSAFEPOINT;
+
+JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t*);
 
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
 jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types, size_t world, size_t *min_valid, size_t *max_valid, int mt_cache);

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -1,0 +1,48 @@
+#include "julia.h"
+#include "julia_internal.h"
+
+JL_DLLEXPORT jl_value_t *jl_invoke_opaque_closure(jl_opaque_closure_t *clos, jl_value_t **args, size_t nargs)
+{
+    // TODO: Compiler support
+    jl_tupletype_t *argt = (jl_tupletype_t*)jl_tparam0(jl_typeof(clos));
+    if (nargs != jl_nparams(argt))
+        jl_error("Incorrect argument count for OpaqueClosure");
+    for (int i = 0; i < nargs; ++i)
+        jl_typeassert(args[i], jl_field_type(argt, i));
+    jl_value_t *ret;
+    JL_GC_PUSH1(&ret);
+    if (jl_is_method(clos->source)) {
+        ret = jl_gf_invoke_by_method((jl_method_t*)clos->source, (jl_value_t*)clos, args, nargs + 1);
+    } else {
+        ret = jl_interpret_opaque_closure(clos, args, nargs);
+    }
+    jl_typeassert(ret, jl_tparam1(jl_typeof(clos)));
+    JL_GC_POP();
+    return ret;
+}
+
+jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub, jl_value_t *source, jl_value_t **env, size_t nenv)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_value_t *clos_t;
+    jl_opaque_closure_t *clos;
+    JL_GC_PUSH2(&clos_t, &clos);
+    clos_t = jl_apply_type2((jl_value_t*)jl_opaque_closure_type, (jl_value_t*)argt, rt_ub);
+    clos = (jl_opaque_closure_t*)jl_gc_alloc(ptls, sizeof(jl_opaque_closure_t), clos_t);
+    clos->source = (jl_code_info_t*)source;
+    clos->fptr1 = (jl_fptr_args_t)jl_invoke_opaque_closure;
+    clos->fptr = NULL;
+    clos->env = jl_f_tuple(NULL, env, nenv);
+    JL_GC_POP();
+    return clos;
+}
+
+
+JL_DLLEXPORT jl_method_t* jl_mk_opaque_closure_method(jl_module_t *def_mod)
+{
+    jl_method_t *m = jl_new_method_uninit(def_mod);
+    m->name = jl_symbol("OpaqueClosure");
+    m->sig = (jl_value_t*)jl_anytuple_type;
+    m->slot_syms = jl_an_empty_string;
+    return m;
+}

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -46,6 +46,7 @@ static void *const _tags[] = {
          &jl_vararg_type, &jl_abstractarray_type,
          &jl_densearray_type, &jl_nothing_type, &jl_function_type, &jl_typeofbottom_type,
          &jl_unionall_type, &jl_typename_type, &jl_builtin_type, &jl_code_info_type,
+         &jl_opaque_closure_type,
          &jl_task_type, &jl_uniontype_type, &jl_abstractstring_type,
          &jl_array_any_type, &jl_intrinsic_type, &jl_abstractslot_type,
          &jl_methtable_type, &jl_typemap_level_type, &jl_typemap_entry_type,
@@ -60,7 +61,7 @@ static void *const _tags[] = {
          // special typenames
          &jl_tuple_typename, &jl_pointer_typename, &jl_llvmpointer_typename, &jl_array_typename, &jl_type_typename,
          &jl_vararg_typename, &jl_namedtuple_typename,
-         &jl_vecelement_typename,
+         &jl_vecelement_typename, &jl_opaque_closure_typename,
          // special exceptions
          &jl_errorexception_type, &jl_argumenterror_type, &jl_typeerror_type,
          &jl_methoderror_type, &jl_loaderror_type, &jl_initerror_type,
@@ -85,6 +86,7 @@ static void *const _tags[] = {
          &jl_builtin_const_arrayref, &jl_builtin_arrayset, &jl_builtin_arraysize,
          &jl_builtin_apply_type, &jl_builtin_applicable, &jl_builtin_invoke,
          &jl_builtin__expr, &jl_builtin_ifelse, &jl_builtin__typebody,
+         &jl_builtin__opaque_closure,
          NULL };
 static jl_value_t **const*const tags = (jl_value_t**const*const)_tags;
 
@@ -125,7 +127,7 @@ static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_arrayref, &jl_f_const_arrayref, &jl_f_arrayset, &jl_f_arraysize, &jl_f_apply_type,
     &jl_f_applicable, &jl_f_invoke, &jl_f_sizeof, &jl_f__expr, &jl_f__typevar,
     &jl_f_ifelse, &jl_f__structtype, &jl_f__abstracttype, &jl_f__primitivetype,
-    &jl_f__typebody, &jl_f__setsuper, &jl_f__equiv_typedef,
+    &jl_f__typebody, &jl_f__setsuper, &jl_f__equiv_typedef, &jl_f__opaque_closure,
     NULL };
 
 typedef struct {

--- a/src/utils.scm
+++ b/src/utils.scm
@@ -93,3 +93,12 @@
         any
         (loop (cdr lst)
               (or (pred (car lst)) any)))))
+
+;; construct a table mapping each element of `lst` to its index (1-indexed)
+(define (symbol-to-idx-map lst)
+  (let ((tbl (table)))
+    (let loop ((xs lst) (i 1))
+      (if (pair? xs)
+          (begin (put! tbl (car xs) i)
+                 (loop (cdr xs) (+ i 1)))))
+    tbl))

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -54,7 +54,8 @@ function choosetests(choices = [])
         "checked", "bitset", "floatfuncs", "precompile",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
-        "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap"
+        "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
+        "opaque_closure"
     ]
 
     tests = []

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -121,7 +121,7 @@ let cfg = CFG(BasicBlock[
     make_bb([2, 3]    , []    ),
 ], Int[])
     insts = Compiler.InstructionStream([], [], Any[], Int32[], UInt8[])
-    code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], [], [])
+    code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], [], [], Compiler.IRCode[])
     compact = Compiler.IncrementalCompact(code, true)
     @test length(compact.result_bbs) == 4 && 0 in compact.result_bbs[3].preds
 end

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -1,0 +1,96 @@
+using Test
+using InteractiveUtils
+
+const_int() = 1
+
+let ci = @code_lowered const_int()
+    @eval function oc_trivial()
+        $(Expr(:call, Core._opaque_closure, Tuple{}, Any, Any, ci))
+    end
+end
+@test isa(oc_trivial(), Core.OpaqueClosure{Tuple{}, Any})
+@test oc_trivial()() == 1
+
+let ci = @code_lowered const_int()
+    @eval function oc_simple_inf()
+        $(Expr(:call, Core._opaque_closure, Tuple{}, Union{}, Any, ci))
+    end
+end
+@test isa(oc_simple_inf(), Core.OpaqueClosure{Tuple{}, Int})
+@test oc_simple_inf()() == 1
+
+struct OcClos2Int
+    a::Int
+    b::Int
+end
+(a::OcClos2Int)() = getfield(a, 1) + getfield(a, 2)
+let ci = @code_lowered OcClos2Int(1, 2)();
+    @eval function oc_trivial_clos()
+        $(Expr(:call, Core._opaque_closure, Tuple{}, Int, Int, ci, 1, 2))
+    end
+end
+@test oc_trivial_clos()() == 3
+
+let ci = @code_lowered OcClos2Int(1, 2)();
+    @eval function oc_self_call_clos()
+        $(Expr(:call, Core._opaque_closure, Tuple{}, Int, Int, ci, 1, 2))()
+    end
+end
+@test oc_self_call_clos() == 3
+let opt = @code_typed oc_self_call_clos()
+    @test length(opt[1].code) == 1
+    @test isa(opt[1].code[1], Core.ReturnNode)
+end
+
+struct OcClos1Any
+    a
+end
+(a::OcClos1Any)() = getfield(a, 1)
+let ci = @code_lowered OcClos1Any(1)()
+    @eval function oc_pass_clos(x)
+        $(Expr(:call, Core._opaque_closure, Tuple{}, Any, Any, ci, :x))
+    end
+end
+@test oc_pass_clos(1)() == 1
+@test oc_pass_clos("a")() == "a"
+
+let ci = @code_lowered OcClos1Any(1)()
+    @eval function oc_infer_pass_clos(x)
+        $(Expr(:call, Core._opaque_closure, Tuple{}, Union{}, Any, ci, :x))
+    end
+end
+@test isa(oc_infer_pass_clos(1), Core.OpaqueClosure{Tuple{}, typeof(1)})
+@test isa(oc_infer_pass_clos("a"), Core.OpaqueClosure{Tuple{}, typeof("a")})
+@test oc_infer_pass_clos(1)() == 1
+@test oc_infer_pass_clos("a")() == "a"
+
+let ci = @code_lowered identity(1)
+    @eval function oc_infer_pass_id()
+        $(Expr(:call, Core._opaque_closure, Tuple{Any}, Any, Any, ci))
+    end
+end
+function complicated_identity(x)
+    oc_infer_pass_id()(x)
+end
+@test @inferred(complicated_identity(1)) == 1
+@test @inferred(complicated_identity("a")) == "a"
+
+struct OcOpt
+    A
+end
+
+(A::OcOpt)() = ndims(getfield(A, 1))
+
+let ci = @code_lowered OcOpt([1 2])()
+    @eval function oc_opt_ndims(A)
+        $(Expr(:call, Core._opaque_closure, Tuple{}, Union{}, Any,  ci, :A))
+    end
+end
+oc_opt_ndims([1 2])
+
+let A = [1 2]
+    let Oc = oc_opt_ndims(A)
+        @test sizeof(Oc.env) == 0
+        @test Oc() == 2
+    end
+end

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -94,3 +94,17 @@ let A = [1 2]
         @test Oc() == 2
     end
 end
+
+macro opaque(ex)
+    Expr(:opaque_closure, esc(ex))
+end
+
+@test @opaque(x->2x)(8) == 16
+let f = @opaque (x::Int, y::Float64)->(2x, 3y)
+    @test_throws TypeError f(1, 1)
+    @test f(2, 3.0) === (4, 9.0)
+end
+function uses_frontend_opaque(x)
+    @opaque y->x+y
+end
+@test uses_frontend_opaque(10)(8) == 18


### PR DESCRIPTION
Got at least the basics working. Needs more tests. There's a bit of ugliness due to the need to call `jl_resolve_globals_in_ir`, which usually happens when a method is added. We might be able to do that eagerly for all CodeInfos instead though. We also convert line number data to a format that includes function name, but here there is no name, so a different code path is needed.