### PR TITLE
Fix small Revise breakage

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -122,6 +122,8 @@ end
 # In case the line numbers in the source code have changed since the code was compiled,
 # allow packages to set a callback function that corrects them.
 # (Used by Revise and perhaps other packages.)
+# Any function `f` stored here must be consistent with the signature
+#    f(m::Method)::Tuple{Union{Symbol,String}, Union{Int32,Int64}}
 const methodloc_callback = Ref{Union{Function, Nothing}}(nothing)
 
 function fixup_stdlib_path(path::String)
@@ -139,7 +141,7 @@ function updated_methodloc(m::Method)::Tuple{String, Int32}
     file, line = m.file, m.line
     if methodloc_callback[] !== nothing
         try
-            file, line = invokelatest(methodloc_callback[], m)::Tuple{Symbol, Int32}
+            file, line = invokelatest(methodloc_callback[], m)::Tuple{Union{Symbol,String}, Union{Int32,Int64}}
         catch
         end
     end


### PR DESCRIPTION
It seems OK to allow a few more types here. Alternatively we could change Revise, but that wouldn't help older Revise versions.

xref #37744 (which I approved)