### PR TITLE
RFC: implement proper debug mode for packages (with support for re-precompilation)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,11 @@ New library functions
   efficiently ([#35816]).
 * New function `addenv` for adding environment mappings into a `Cmd` object, returning the new `Cmd` object.
 * New function `insorted` for determining whether an element is in a sorted collection or not ([#37490]).
+* New function `isdebug` for checking if julia is running in debug mode.
+  Packages use different precompile caches in debug and non-debug mode thus it
+  safe to use this function for compile time decisions. Also, note that
+  `@assert` now is a no-op unless `isdebug()` is true. Debug mode is activated
+  with the `-g2` flag.
 
 New library features
 --------------------
@@ -124,6 +129,8 @@ Standard library changes
 * The `Pkg.Artifacts` module has been imported as a separate standard library.  It is still available as
   `Pkg.Artifacts`, however starting from Julia v1.6+, packages may import simply `Artifacts` without importing
   all of `Pkg` alongside. ([#37320])
+* The `@assert` macro is now only active when julia is started with a debug
+  level of 2 (`julia -g2`).
 
 #### LinearAlgebra
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -66,6 +66,9 @@ time_ns() = ccall(:jl_hrtime, UInt64, ())
 
 start_base_include = time_ns()
 
+julia_debug = true
+isdebug() = julia_debug::Bool
+
 ## Load essential files and libraries
 include("essentials.jl")
 include("ctypes.jl")
@@ -396,6 +399,7 @@ in_sysimage(pkgid::PkgId) = pkgid in _sysimage_modules
 
 if is_primary_base_module
 function __init__()
+    global julia_debug = Base.JLOptions().debug_level >= 2
     # try to ensuremake sure OpenBLAS does not set CPU affinity (#1070, #9639)
     if !haskey(ENV, "OPENBLAS_MAIN_FREE") && !haskey(ENV, "GOTOBLAS_MAIN_FREE")
         ENV["OPENBLAS_MAIN_FREE"] = "1"

--- a/base/error.jl
+++ b/base/error.jl
@@ -183,21 +183,25 @@ windowserror(p, b::Bool; extrainfo=nothing) = b ? windowserror(p, extrainfo=extr
 windowserror(p, code::UInt32=Libc.GetLastError(); extrainfo=nothing) = throw(Main.Base.SystemError(string(p), 0, WindowsErrorInfo(code, extrainfo)))
 
 
-## assertion macro ##
+## assertion and ifdebug macros ##
+
+"""
+    @ifdebug expr
+
+Equivalent to `@static if isdebug()`
+"""
+macro ifdebug(expr)
+    isdefined(@__MODULE__, :isdebug) && !(isdebug()) && return nothing
+    return :(esc(expr))
+end
 
 
 """
     @assert cond [text]
 
 Throw an [`AssertionError`](@ref) if `cond` is `false`. Preferred syntax for writing assertions.
-Message `text` is optionally displayed upon assertion failure.
-
-!!! warning
-    An assert might be disabled at various optimization levels.
-    Assert should therefore only be used as a debugging tool
-    and not used for authentication verification (e.g., verifying passwords),
-    nor should side effects needed for the function to work correctly
-    be used inside of asserts.
+Message `text` is optionally displayed upon assertion failure. Only active when julia is started
+in debug mode (`julia -g`).
 
 # Examples
 ```jldoctest
@@ -208,6 +212,7 @@ julia> @assert isodd(3) "What even are numbers?"
 ```
 """
 macro assert(ex, msgs...)
+    isdefined(@__MODULE__, :isdebug) && !(isdebug()) && return nothing
     msg = isempty(msgs) ? ex : msgs[1]
     if isa(msg, AbstractString)
         msg = msg # pass-through

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -780,6 +780,7 @@ export
     atreplinit,
     exit,
     ntuple,
+    isdebug,
 
 # I/O and events
     close,

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@ SRCDIR           := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME        := $(abspath $(SRCDIR)/..)
 SRCCACHE         := $(abspath $(JULIAHOME)/deps/srccache)
 include $(JULIAHOME)/Make.inc
-JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia) --startup-file=no
+JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia) --startup-file=no -g2
 
 .PHONY: help clean cleanall html pdf deps deploy
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -1124,6 +1124,14 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t **udepsp, jl_array_t *
         }
         write_int32(s, 0); // terminator, for ease of reading
 
+        // Julia debug mode
+        jl_value_t *julia_debug = (jl_value_t*)jl_get_global(jl_base_module, jl_symbol("julia_debug"));
+        if (julia_debug) {
+            write_int8(s, jl_unbox_bool(julia_debug));
+        } else {
+            write_int8(s, 0);
+        }
+
         // Calculate Preferences hash for current package.
         jl_value_t *prefs_hash = NULL;
         if (jl_base_module) {

--- a/test/assert.jl
+++ b/test/assert.jl
@@ -1,0 +1,60 @@
+# This file is run from test/misc.jl separately since it needs to run with `-g2`.
+using Test
+
+# test @assert macro
+@test_throws AssertionError (@assert 1 == 2)
+@test_throws AssertionError (@assert false)
+@test_throws AssertionError (@assert false "this is a test")
+@test_throws AssertionError (@assert false "this is a test" "another test")
+@test_throws AssertionError (@assert false :a)
+let
+    try
+        @assert 1 == 2
+        error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test occursin("1 == 2", ex.msg)
+    end
+end
+# test @assert message
+let
+    try
+        @assert 1 == 2 "this is a test"
+        error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test ex.msg == "this is a test"
+    end
+end
+# @assert only uses the first message string
+let
+    try
+        @assert 1 == 2 "this is a test" "this is another test"
+        error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test ex.msg == "this is a test"
+    end
+end
+# @assert calls string() on second argument
+let
+    try
+        @assert 1 == 2 :random_object
+        error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test !occursin("1 == 2", ex.msg)
+        @test occursin("random_object", ex.msg)
+    end
+end
+# if the second argument is an expression, c
+let deepthought(x, y) = 42
+    try
+        @assert 1 == 2 string("the answer to the ultimate question: ",
+                              deepthought(6, 9))
+        error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test ex.msg == "the answer to the ultimate question: 42"
+    end
+end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -332,7 +332,7 @@ let undefvar
     @test err_str == "InterruptException:"
     err_str = @except_str throw(ArgumentError("not an error")) ArgumentError
     @test err_str == "ArgumentError: not an error"
-    err_str = @except_str @assert(false) AssertionError
+    err_str = read(`$(Base.julia_cmd()) -g2 -e 'try @assert false; catch e; showerror(stdout, e); end'`, String)
     @test err_str == "AssertionError: false"
 end
 

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -369,6 +369,8 @@ end
 end
 
 # issue #36527
+s = raw"""
+using Test
 function f36527()
     caught = false
     🏡 = Core.eval(Main, :(module asdf36527 end))
@@ -383,6 +385,8 @@ function f36527()
 end
 
 @test f36527()
+"""
+@test success(`$(Base.julia_cmd()) -g2 -e $s`)
 
 # accessing an undefined var in tail position in a catch block
 function undef_var_in_catch()


### PR DESCRIPTION
This adds a proper debug mode that packages can use. One of the crucial things is that the query for debug mode is available to use during precompilation and that Julia will create a new precompile cache when it changes. With the LRU cache system for `.ji` files one can swap between debug and non-debug mode freely without julia recompiling over and over. 

This also disables the assertion macro in normal running code.

As an example: Loading a package with this content:

```jl
module FooBar

@show Base.isdebug()
err() = @assert false

end # module
```

in non-debug mode:

```jl
❯ julia --project -q
julia> using FooBar
[ Info: Precompiling FooBar [fad23a86-9c0b-4cc2-9d4f-c6fb60d9cd78]
Base.isdebug() = false

julia> FooBar.err() # assertion did not not fire

julia> 
```

in debug mode:

```jl
❯ ~/julia/julia --project -q -g
julia> using FooBar
[ Info: Precompiling FooBar [fad23a86-9c0b-4cc2-9d4f-c6fb60d9cd78]
Base.isdebug() = true

julia> FooBar.err()
ERROR: AssertionError: false
Stacktrace:
 [1] err()
   @ FooBar ~/julia/FooBar/src/FooBar.jl:4
 [2] top-level scope
   @ REPL[2]:1
```

and then back to non debug mode (note no re-precompilation)

```jl
❯ ~/julia/julia --project -q
julia> using FooBar

julia> FooBar.err()

julia>
```

Questions (for triage):

1. Export `isdebug`?
2. Is it the `-g` flag we want to use to enable / disable debug mode for packages?
3. What about `@assert` in Base. We don't really want to ship two sysimages so maybe just leave it on there for now?
4. Is a true/false enough for debug level or should there be more fine-grained numbers?

TODO:
- Enable `@assert` in stdlibs
- Tests- Make `Pkg.test` run tests in debug mode

cc @tkf, @staticfloat 