### PR TITLE
NamedTuple == seems broken eg. @test_broken (x=1, y=2) == (y=2, x=1)

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -168,7 +168,11 @@ nteltype(::Type) = Any
 nteltype(::Type{NamedTuple{names,T}} where names) where {T} = eltype(T)
 
 ==(a::NamedTuple{n}, b::NamedTuple{n}) where {n} = Tuple(a) == Tuple(b)
-==(a::NamedTuple, b::NamedTuple) = false
+==(a::NamedTuple, b::NamedTuple) =
+    length(a) == length(b) &&
+    all(keys(a)) do ka
+        haskey(b, ka) && getfield(a, ka) == getfield(b, ka)
+    end
 
 isequal(a::NamedTuple{n}, b::NamedTuple{n}) where {n} = isequal(Tuple(a), Tuple(b))
 isequal(a::NamedTuple, b::NamedTuple) = false


### PR DESCRIPTION
It seems very strange that

```jl
@test_broken (x=1, y=2) == (y=2, x=1)
```

I have seen seen no rational in doc for that.
Here is an implementation that test equality by accepting a key permutation.

And then, we will have

```jl
# @test_broken (x=1, y=2) == (y=2, x=1)
@test ==(x=1, y=2), (x=1, y=2))
@test ==((x=1, y=2), (y=2, x=1))
@test ==((x=1, y=2), (y=2,)) == false
@test ==((x=1, y=2), (x=1,y=3)) == false
```

> tests have not been updated for now, will do that if there's an agreement