### PR TITLE
Make it easy to copy and paste JULIA_LLVM_ARGS from the docs

### DIFF
--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -60,8 +60,8 @@ implies that option by default.
 You can pass options to LLVM via the environment variable `JULIA_LLVM_ARGS`.
 Here are example settings using `bash` syntax:
 
-  * `export JULIA_LLVM_ARGS = -print-after-all` dumps IR after each pass.
-  * `export JULIA_LLVM_ARGS = -debug-only=loop-vectorize` dumps LLVM `DEBUG(...)` diagnostics for
+  * `export JULIA_LLVM_ARGS=-print-after-all` dumps IR after each pass.
+  * `export JULIA_LLVM_ARGS=-debug-only=loop-vectorize` dumps LLVM `DEBUG(...)` diagnostics for
     loop vectorizer. If you get warnings about "Unknown command line argument", rebuild LLVM with
     `LLVM_ASSERTIONS = 1`.
 
@@ -113,7 +113,7 @@ The best strategy is to create a code example in a form where you can use LLVM's
 study it and the pass of interest in isolation.
 
 1. Create an example Julia code of interest.
-2. Use `JULIA_LLVM_ARGS = -print-after-all` to dump the IR.
+2. Use `JULIA_LLVM_ARGS=-print-after-all` to dump the IR.
 3. Pick out the IR at the point just before the pass of interest runs.
 4. Strip the debug metadata and fix up the TBAA metadata by hand.
 


### PR DESCRIPTION
The comment promises it provides examples using bash syntax, but

```
$ export JULIA_LLVM_ARGS = -debug-only=loop-vectorize
-bash: export: `=': not a valid identifier
-bash: export: `-debug-only=loop-vectorize': not a valid identifier
```

it doesn't