### PR TITLE
improve FMA_NATIVE definition

### DIFF
--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -141,7 +141,7 @@ const t_log_Float32 = (0.0,0.007782140442054949,0.015504186535965254,0.023167059
 
 # determine if hardware FMA is available
 # should probably check with LLVM, see #9855.
-const FMA_NATIVE = muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)) != 0
+const FMA_NATIVE = fma(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)) != 0
 
 # truncate lower order bits (up to 26)
 # ideally, this should be able to use ANDPD instructions, see #9868.

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -141,8 +141,7 @@ const t_log_Float32 = (0.0,0.007782140442054949,0.015504186535965254,0.023167059
 
 # determine if hardware FMA is available
 # should probably check with LLVM, see #9855.
-const FMA_NATIVE = !(muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)) < 
-                     fma(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)))
+const FMA_NATIVE = !(muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)) < fma(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)))
 
 # truncate lower order bits (up to 26)
 # ideally, this should be able to use ANDPD instructions, see #9868.

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -141,7 +141,8 @@ const t_log_Float32 = (0.0,0.007782140442054949,0.015504186535965254,0.023167059
 
 # determine if hardware FMA is available
 # should probably check with LLVM, see #9855.
-const FMA_NATIVE = fma(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)) != 0
+const FMA_NATIVE = !(muladd(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)) < 
+                     fma(nextfloat(1.0),nextfloat(1.0),-nextfloat(1.0,2)))
 
 # truncate lower order bits (up to 26)
 # ideally, this should be able to use ANDPD instructions, see #9868.


### PR DESCRIPTION
improves the definition for `FMA_NATIVE`

see https://github.com/JuliaLang/julia/issues/33011#issuecomment-703358149

With old definition, the slower [non-fma] version of log(::Float64) is used by almost? everybody.