### PR TITLE
fix #37890, fix `new` error checks with varargs

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2345,3 +2345,20 @@ end
 
 # issue #37656
 @test :(if true 'a' else 1 end) == Expr(:if, true, quote 'a' end, quote 1 end)
+
+# issue #37890
+struct A37890{A, B}
+    a
+    b
+    A37890(args::Tuple) = return new{typeof.(args)...}(args...)
+end
+@test A37890((1, "")) isa A37890{Int, String}
+@test_throws ErrorException A37890((1,1,1))
+@test_throws TypeError A37890((1,))
+
+struct B37890{A, B}
+    a
+    b
+    B37890(a, b) = new{Int, ()..., Int8}(a, b)
+end
+@test B37890(1.0, 2.0f0) isa B37890{Int, Int8}


### PR DESCRIPTION
This error check was incorrectly counting all argument expressions, including varargs. If there are no varargs, or if the number of parameters would be wrong independent of the number of splatted values, still give an error during lowering, but otherwise defer to runtime (although you get a different error of course).

fix #37890
