### PR TITLE
fix #37872, avoid cycles in codegen for `===`

### DIFF
--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -495,3 +495,8 @@ let x = reinterpret(Has256Bits, [0xfcdac822cac89d82de4f9b3326da8294, 0x6ebac4d59
     @test reinterpret(UInt128, [h(x)]) == lshifted
     @test reinterpret(UInt128, [Base.shl_int(x, 0x8)]) == lshifted
 end
+
+# issue #37872
+let f(@nospecialize(x)) = x===Base.ImmutableDict(Int128=>:big)
+    @test !f(Dict(Int=>Int))
+end


### PR DESCRIPTION
fix #37872