### PR TITLE
Add 3-arg * methods

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1096,6 +1096,8 @@ end
 *(α::Number, u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, α, u, v)
 *(u::AbstractVector, v::AdjOrTransAbsVec, α::Number) = broadcast(*, u, v, α)
 
+*(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix) = _tri_matmul(A,B,C)
+
 function _scalar_mat_vec(α, A, x)
     T = promote_type(typeof(α), eltype(A), eltype(x))
     C = similar(A, T, axes(A,1))
@@ -1111,3 +1113,16 @@ _scalar_mat_vec(α, A::AdjOrTransAbsVec, x) = α * (A * x)
 
 _scalar_mat_mat(α, A::AdjointAbsVec, B) = scalar_mat_vec(α', B', A')'
 _scalar_mat_mat(α, A::TransposeAbsVec, B) = transpose(scalar_mat_vec(α, transpose(B), transpose(A)))
+
+function _tri_matmul(A,B,C)
+    n,m = size(A)
+    # m,k == size(B)
+    k,l = size(C)
+    costAB_C = n*m*k + n*k*l
+    costA_BC = m*k*l + n*m*l
+    if costA_BC < costAB_C
+        A * (B*C)
+    else
+        (A*B) * C
+    end
+end

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1083,10 +1083,7 @@ function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMat
 end
 
 # Three-argument *
-*(x::AdjointAbsVec{<:Number}, A::AbstractMatrix, y::AbstractVector) = dot(x.parent,A,y)
-*(x::TransposeAbsVec{<:Real}, A::AbstractMatrix, y::AbstractVector) = dot(x.parent,A,y)
-
-*(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = A*(B*x)
+*(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = _mat_mat_vec(A,B,x)
 
 *(α::Number, A::AbstractMatrix, x::AbstractVector) = _scalar_mat_vec(α,A,x)
 *(α::Number, A::AbstractMatrix, B::AbstractMatrix) = _scalar_mat_mat(α,A,B)
@@ -1102,6 +1099,14 @@ end
 
 *(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix) = _tri_matmul(A,B,C)
 *(tv::AdjOrTransAbsVec, B::AbstractMatrix, C::AbstractMatrix) = (tv*B) * C
+
+function _mat_mat_vec(A,B,x)
+    if A isa AdjointAbsVec{<:Number} || A isa TransposeAbsVec{<:Real}
+        dot(A.parent, B, x)
+    else
+        A * (B*x)
+    end
+end
 
 function _scalar_mat_vec(α, A, x)
     T = promote_type(typeof(α), eltype(A), eltype(x))

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1089,14 +1089,14 @@ const RealOrComplex = Union{Real,Complex}
     *(A, B::AbstractMatrix, C)
 
 Most 3- and 4-argument `*` calls containing matrices or vectors are done in an
-efficient way, rather than the left-to-right default of `*(x,y,z,...)`.
+efficient way, rather than the left-to-right default of `*(x,y,z...)`.
 
 This can mean performing `B*C` first if `C::AbstractVector`, using five-argument
 `mul!` to fuse the scalar `A::Number` with the matrix multiplication `B*C`,
 or examining `size.((A,B,C,D))` to choose which to multiply first.
 
 !!! compat "Julia 1.6"
-    These optimisations require least Julia 1.6.
+    These optimisations require at least Julia 1.6.
 """
 *(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = A * (B*x)
 
@@ -1150,11 +1150,11 @@ function _mat_mat_scalar(A, B, γ)
 end
 
 mat_mat_scalar(A::AdjointAbsVec, B, γ) = (γ' .* (A * B)')' # preserving order, adjoint reverses
-mat_mat_scalar(A::AdjointAbsVec, B::StridedMaybeAdjOrTransMat, γ::Union{Real,Complex}) =
+mat_mat_scalar(A::AdjointAbsVec, B::StridedMaybeAdjOrTransMat, γ::RealOrComplex) =
     mat_vec_scalar(B', A', γ')'
 
 mat_mat_scalar(A::TransposeAbsVec, B, γ) = transpose(γ .* transpose(A * B))
-mat_mat_scalar(A::TransposeAbsVec, B::StridedMaybeAdjOrTransMat, γ::Union{Real,Complex}) =
+mat_mat_scalar(A::TransposeAbsVec, B::StridedMaybeAdjOrTransMat, γ::RealOrComplex) =
     transpose(mat_vec_scalar(transpose(B), transpose(A), γ))
 
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1096,8 +1096,8 @@ to choose which of these to execute.
 
 If the last factor is a vector, or the first a transposed vector, then it is efficient
 to deal with these first. In particular `x' * B * y` means `(x' * B) * y`
-for an ordinary colum-major `B::Matrix`. This is often equivalent to `dot(x, B, y)`,
-although it allocates an intermediate array.
+for an ordinary column-major `B::Matrix`. Unlike `dot(x, B, y)`, this
+allocates an intermediate array.
 
 If the first or last factor is a number, this will be fused with the matrix
 multiplication, using 5-arg [`mul!`](@ref).
@@ -1106,22 +1106,6 @@ See also [`muladd`](@ref), [`dot`](@ref).
 
 !!! compat "Julia 1.7"
     These optimisations require at least Julia 1.7.
-
-# Examples
-```
-julia> A, B, C = randn(100,10), randn(10,100), randn(100,10);
-
-julia> using BenchmarkTools
-
-julia> @btime ($A * $B) * $C;  # slow
-  13.500 μs (3 allocations: 86.14 KiB)
-
-julia> @btime $A * ($B * $C);  # fast
-  1.892 μs (2 allocations: 8.81 KiB)
-
-julia> @btime $A * $B * $C;  # automatic
-  1.896 μs (2 allocations: 8.81 KiB)
-```
 """
 *(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = A * (B*x)
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1150,11 +1150,11 @@ function _mat_mat_scalar(A, B, γ)
 end
 
 mat_mat_scalar(A::AdjointAbsVec, B, γ) = (γ' .* (A * B)')' # preserving order, adjoint reverses
-mat_mat_scalar(A::AdjointAbsVec, B::StridedMaybeAdjOrTransMat, γ::RealOrComplex) =
+mat_mat_scalar(A::AdjointAbsVec{<:RealOrComplex}, B::StridedMaybeAdjOrTransMat{<:RealOrComplex}, γ::RealOrComplex) =
     mat_vec_scalar(B', A', γ')'
 
 mat_mat_scalar(A::TransposeAbsVec, B, γ) = transpose(γ .* transpose(A * B))
-mat_mat_scalar(A::TransposeAbsVec, B::StridedMaybeAdjOrTransMat, γ::RealOrComplex) =
+mat_mat_scalar(A::TransposeAbsVec{<:RealOrComplex}, B::StridedMaybeAdjOrTransMat{<:RealOrComplex}, γ::RealOrComplex) =
     transpose(mat_vec_scalar(transpose(B), transpose(A), γ))
 
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1089,22 +1089,39 @@ const RealOrComplex = Union{Real,Complex}
     *(A, B::AbstractMatrix, C)
     A * B * C * D
 
-Chained multiplication of 3 or 4 matrices is done in the most efficient order,
-i.e. the order which minimises the total number of scalar multiplications involved,
-based on the sizes of the arrays.
+Chained multiplication of 3 or 4 matrices is done in the most efficient sequence,
+based on the sizes of the arrays. That is, the number of scalar multiplications needed
+for `(A * B) * C` (with 3 dense matrices) is compared to that for `A * (B * C)`
+to choose which of these to execute.
 
-If the last factor is a vector, or the first a transposed vector,
-it is efficient to do these first. In particular `x' * B * y` means `(x' * B) * y`
-for an ordinary colum-major `B`. This is usually faster than `dot(x, B, y)`,
+If the last factor is a vector, or the first a transposed vector, then it is efficient
+to deal with these first. In particular `x' * B * y` means `(x' * B) * y`
+for an ordinary colum-major `B::Matrix`. This is often equivalent to `dot(x, B, y)`,
 although it allocates an intermediate array.
 
 If the first or last factor is a number, this will be fused with the matrix
 multiplication, using 5-arg [`mul!`](@ref).
 
-See also [`dot`](@ref), [`muladd`](@ref).
+See also [`muladd`](@ref), [`dot`](@ref).
 
 !!! compat "Julia 1.7"
     These optimisations require at least Julia 1.7.
+
+# Examples
+```
+julia> A, B, C = randn(100,10), randn(10,100), randn(100,10);
+
+julia> using BenchmarkTools
+
+julia> @btime ($A * $B) * $C;  # slow
+  13.500 μs (3 allocations: 86.14 KiB)
+
+julia> @btime $A * ($B * $C);  # fast
+  1.892 μs (2 allocations: 8.81 KiB)
+
+julia> @btime $A * $B * $C;  # automatic
+  1.896 μs (2 allocations: 8.81 KiB)
+```
 """
 *(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = A * (B*x)
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1110,13 +1110,9 @@ or examining `size.((A,B,C))` to choose which to multiply first.
 *(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix) = _tri_matmul(A,B,C)
 *(tv::AdjOrTransAbsVec, B::AbstractMatrix, C::AbstractMatrix) = (tv*B) * C
 
-function _mat_mat_vec(A,B,x)
-    if A isa AdjointAbsVec{<:Number} || A isa TransposeAbsVec{<:Real}
-        dot(A.parent, B, x)
-    else
-        A * (B*x)
-    end
-end
+_mat_mat_vec(A::AdjointAbsVec{<:Number}, B, x) = dot(A.parent, B, x)
+_mat_mat_vec(A::TransposeAbsVec{<:Real}, B, x) = dot(A.parent, B, x)
+_mat_mat_vec(A, B, x) = A * (B*x)
 
 function _tri_matmul(A,B,C)
     n,m = size(A)
@@ -1159,4 +1155,3 @@ mat_mat_scalar(A::AdjointAbsVec, B::_SafeMatrix, γ::Union{Real,Complex}) = mat_
 mat_mat_scalar(A::TransposeAbsVec, B, γ) = transpose(γ .* transpose(A * B))
 mat_mat_scalar(A::TransposeAbsVec, B::_SafeMatrix, γ::Union{Real,Complex}) =
     transpose(mat_vec_scalar(transpose(B), transpose(A), γ))
-

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1100,9 +1100,8 @@ or examining `size.((A,B,C))` to choose which to multiply first.
 
 *(A::AbstractMatrix, x::AbstractVector, γ::Number) = mat_vec_scalar(A,x,γ)
 *(A::AbstractMatrix, B::AbstractMatrix, γ::Number) = mat_mat_scalar(A,B,γ)
-*(α::Number, B::AbstractMatrix, C::AbstractVecOrMat) = *(C',B',α')'
-*(α::Number, B::Transpose, C::AbstractVecOrMat) = transpose(*(transpose(C),transpose(B),α))
-
+*(α::Union{Real,Complex}, B::AbstractMatrix, C::AbstractVector) = mat_vec_scalar(B,C,α)
+*(α::Union{Real,Complex}, B::AbstractMatrix, C::AbstractMatrix) = mat_mat_scalar(B,C,α)
 
 *(α::Number, u::AbstractVector, tv::AdjOrTransAbsVec) = broadcast(*, α, u, tv)
 *(u::AbstractVector, tv::AdjOrTransAbsVec, γ::Number) = broadcast(*, u, tv, γ)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1139,7 +1139,7 @@ mat_vec_scalar(A::AdjOrTransAbsVec, x::StridedVector, γ) = (A * x) * γ
 function _mat_vec_scalar(A, x, γ)
     T = promote_type(eltype(A), eltype(x), typeof(γ))
     C = similar(A, T, axes(A,1))
-    mul!(C, A, x, γ, zero(γ))
+    mul!(C, A, x, γ, false)
 end
 
 mat_mat_scalar(A, B, γ) = (A*B) .* γ # fallback
@@ -1149,7 +1149,7 @@ mat_mat_scalar(A::StridedMaybeAdjOrTransMat, B::StridedMaybeAdjOrTransMat, γ) =
 function _mat_mat_scalar(A, B, γ)
     T = promote_type(eltype(A), eltype(B), typeof(γ))
     C = similar(A, T, axes(A,1), axes(B,2))
-    mul!(C, A, B, γ, zero(γ))
+    mul!(C, A, B, γ, false)
 end
 
 mat_mat_scalar(A::AdjointAbsVec, B, γ) = (γ' .* (A * B)')' # preserving order, adjoint reverses

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1128,7 +1128,6 @@ function _tri_matmul(A,B,C,δ=nothing)
 end
 
 # Fast path for two arrays * one scalar is opt-in, via mat_vec_scalar and mat_mat_scalar.
-StridedMaybeAdjOrTransMat{T} = Union{StridedMatrix{T}, Adjoint{T, <:StridedMatrix}, Transpose{T, <:StridedMatrix}}
 
 mat_vec_scalar(A, x, γ) = A * (x .* γ)  # fallback
 mat_vec_scalar(A::StridedMaybeAdjOrTransMat, x::StridedVector, γ) = _mat_vec_scalar(A, x, γ)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1093,10 +1093,12 @@ end
 *(A::AbstractMatrix, x::AbstractVector, α::Number) = _scalar_mat_vec(α,A,x)
 *(A::AbstractMatrix, B::AbstractMatrix, α::Number) = _scalar_mat_mat(α,A,B)
 
-*(α::Number, u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, α, u, v)
-*(u::AbstractVector, v::AdjOrTransAbsVec, α::Number) = broadcast(*, u, v, α)
+*(α::Number, u::AbstractVector, tv::AdjOrTransAbsVec) = broadcast(*, α, u, tv)
+*(u::AbstractVector, tv::AdjOrTransAbsVec, α::Number) = broadcast(*, u, tv, α)
+*(u::AbstractVector, tv::AdjOrTransAbsVec, A::AbstractMatrix) = u * (tv*A)
 
 *(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix) = _tri_matmul(A,B,C)
+*(tv::AdjOrTransAbsVec, B::AbstractMatrix, C::AbstractMatrix) = (tv*B) * C
 
 function _scalar_mat_vec(α, A, x)
     T = promote_type(typeof(α), eltype(A), eltype(x))
@@ -1111,8 +1113,8 @@ end
 
 _scalar_mat_vec(α, A::AdjOrTransAbsVec, x) = α * (A * x)
 
-_scalar_mat_mat(α, A::AdjointAbsVec, B) = scalar_mat_vec(α', B', A')'
-_scalar_mat_mat(α, A::TransposeAbsVec, B) = transpose(scalar_mat_vec(α, transpose(B), transpose(A)))
+_scalar_mat_mat(α, A::AdjointAbsVec, B) = _scalar_mat_vec(α', B', A')'
+_scalar_mat_mat(α, A::TransposeAbsVec, B) = transpose(_scalar_mat_vec(α, transpose(B), transpose(A)))
 
 function _tri_matmul(A,B,C)
     n,m = size(A)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1130,7 +1130,7 @@ end
 # Fast path for two arrays * one scalar is opt-in, via mat_vec_scalar and mat_mat_scalar.
 StridedMaybeAdjOrTransMat{T} = Union{StridedMatrix{T}, Adjoint{T, <:StridedMatrix}, Transpose{T, <:StridedMatrix}}
 
-mat_vec_scalar(A, x, γ) = (A*x) .* γ  # fallback
+mat_vec_scalar(A, x, γ) = A * (x .* γ)  # fallback
 mat_vec_scalar(A::StridedMaybeAdjOrTransMat, x::StridedVector, γ) = _mat_vec_scalar(A, x, γ)
 mat_vec_scalar(A::AdjOrTransAbsVec, x::StridedVector, γ) = (A * x) * γ
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1110,9 +1110,12 @@ or examining `size.((A,B,C,D))` to choose which to multiply first.
 *(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix) = _tri_matmul(A,B,C)
 *(tv::AdjOrTransAbsVec, B::AbstractMatrix, C::AbstractMatrix) = (tv*B) * C
 
-_mat_mat_vec(A::AdjointAbsVec{<:Number}, B, x) = dot(A.parent, B, x)
-_mat_mat_vec(A::TransposeAbsVec{<:Real}, B, x) = dot(A.parent, B, x)
-_mat_mat_vec(A, B, x) = A * (B*x)
+_mat_mat_vec(A, B, x) = A * (B*x) # fallback
+_mat_mat_vec(tv::AdjOrTransAbsVec, B, x) = (tv*B) * x
+_mat_mat_vec(tv::AdjointAbsVec{<:Number}, B, x) =
+    length(x)<64 ? dot(tv.parent, B, x) : (tv*B) * x
+_mat_mat_vec(tv::TransposeAbsVec{<:Real}, B, x) =
+    length(x)<64 ? dot(tv.parent, B, x) : (tv*B) * x
 
 function _tri_matmul(A,B,C,δ=nothing)
     n,m = size(A)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1089,14 +1089,14 @@ end
 Most 3- and 4-argument `*` calls containing matrices or vectors are done in an
 efficient way, rather than the left-to-right default of `*(x,y,z,...)`.
 
-This can mean performing `B*C` first if `C::AbstractVector`, calling `dot`, using
-five-argument `mul!` to fuse the scalar `A::Number` with the matrix multiplication `B*C`,
+This can mean performing `B*C` first if `C::AbstractVector`, using five-argument
+`mul!` to fuse the scalar `A::Number` with the matrix multiplication `B*C`,
 or examining `size.((A,B,C,D))` to choose which to multiply first.
 
 !!! compat "Julia 1.6"
     These optimisations require least Julia 1.6.
 """
-*(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = _mat_mat_vec(A,B,x)
+*(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = A * (B*x)
 
 *(A::AbstractMatrix, x::AbstractVector, γ::Number) = mat_vec_scalar(A,x,γ)
 *(A::AbstractMatrix, B::AbstractMatrix, γ::Number) = mat_mat_scalar(A,B,γ)
@@ -1109,13 +1109,6 @@ or examining `size.((A,B,C,D))` to choose which to multiply first.
 
 *(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix) = _tri_matmul(A,B,C)
 *(tv::AdjOrTransAbsVec, B::AbstractMatrix, C::AbstractMatrix) = (tv*B) * C
-
-_mat_mat_vec(A, B, x) = A * (B*x) # fallback
-_mat_mat_vec(tv::AdjOrTransAbsVec, B, x) = (tv*B) * x
-_mat_mat_vec(tv::AdjointAbsVec{<:Number}, B, x) =
-    length(x)<64 ? dot(tv.parent, B, x) : (tv*B) * x
-_mat_mat_vec(tv::TransposeAbsVec{<:Real}, B, x) =
-    length(x)<64 ? dot(tv.parent, B, x) : (tv*B) * x
 
 function _tri_matmul(A,B,C,δ=nothing)
     n,m = size(A)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1083,6 +1083,19 @@ function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMat
 end
 
 # Three-argument *
+"""
+    *(A, B::AbstractMatrix, C)
+
+Most 3-argument `*` calls containing matrices or vectors are done in an efficient way,
+rather than the left-to-right default of `*(x,y,z,...)`.
+
+This can mean performing `B*C` first if `C::AbstractVector`, calling `dot`, using
+five-argument `mul!` to fuse the scalar `A::Number` with the matrix multiplication `B*C`,
+or examining `size.((A,B,C))` to choose which to multiply first.
+
+!!! compat "Julia 1.6"
+    These optimisations require least Julia 1.6.
+"""
 *(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = _mat_mat_vec(A,B,x)
 
 *(A::AbstractMatrix, x::AbstractVector, γ::Number) = mat_vec_scalar(A,x,γ)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1093,6 +1093,9 @@ end
 *(A::AbstractMatrix, x::AbstractVector, α::Number) = _scalar_mat_vec(α,A,x)
 *(A::AbstractMatrix, B::AbstractMatrix, α::Number) = _scalar_mat_mat(α,A,B)
 
+*(α::Number, A::AbstractArray, β::Number) = (α*β) * A
+*(A::AbstractArray, α::Number, β::Number) = A * (α*β)
+
 *(α::Number, u::AbstractVector, tv::AdjOrTransAbsVec) = broadcast(*, α, u, tv)
 *(u::AbstractVector, tv::AdjOrTransAbsVec, α::Number) = broadcast(*, u, tv, α)
 *(u::AbstractVector, tv::AdjOrTransAbsVec, A::AbstractMatrix) = u * (tv*A)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1095,8 +1095,8 @@ This can mean performing `B*C` first if `C::AbstractVector`, using five-argument
 `mul!` to fuse the scalar `A::Number` with the matrix multiplication `B*C`,
 or examining `size.((A,B,C,D))` to choose which to multiply first.
 
-!!! compat "Julia 1.6"
-    These optimisations require at least Julia 1.6.
+!!! compat "Julia 1.7"
+    These optimisations require at least Julia 1.7.
 """
 *(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = A * (B*x)
 
@@ -1136,7 +1136,7 @@ mat_vec_scalar(A::AdjOrTransAbsVec, x::StridedVector, γ) = (A * x) * γ
 function _mat_vec_scalar(A, x, γ)
     T = promote_type(eltype(A), eltype(x), typeof(γ))
     C = similar(A, T, axes(A,1))
-    mul!(C, A, x, γ, false)
+    mul!(C, A, x, γ, zero(γ))
 end
 
 mat_mat_scalar(A, B, γ) = (A*B) .* γ # fallback
@@ -1146,7 +1146,7 @@ mat_mat_scalar(A::StridedMaybeAdjOrTransMat, B::StridedMaybeAdjOrTransMat, γ) =
 function _mat_mat_scalar(A, B, γ)
     T = promote_type(eltype(A), eltype(B), typeof(γ))
     C = similar(A, T, axes(A,1), axes(B,2))
-    mul!(C, A, B, γ, false)
+    mul!(C, A, B, γ, zero(γ))
 end
 
 mat_mat_scalar(A::AdjointAbsVec, B, γ) = (γ' .* (A * B)')' # preserving order, adjoint reverses

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1103,8 +1103,6 @@ or examining `size.((A,B,C))` to choose which to multiply first.
 *(α::Number, B::AbstractMatrix, C::AbstractVecOrMat) = *(C',B',α')'
 *(α::Number, B::Transpose, C::AbstractVecOrMat) = transpose(*(transpose(C),transpose(B),α))
 
-*(α::Number, B::AbstractArray, γ::Number) = broadcast(*, α, B, γ)
-*(A::AbstractArray, β::Number, γ::Number) = broadcast(*, A, β*γ)
 
 *(α::Number, u::AbstractVector, tv::AdjOrTransAbsVec) = broadcast(*, α, u, tv)
 *(u::AbstractVector, tv::AdjOrTransAbsVec, γ::Number) = broadcast(*, u, tv, γ)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1124,7 +1124,7 @@ end
 function mat_vec_scalar(A, x, γ)
     T = promote_type(eltype(A), eltype(x), typeof(γ))
     C = similar(A, T, axes(A,1))
-    mul!(C, A, x, γ, false) # γ on the right
+    mul!(C, A, x, γ, false)
 end
 
 mat_vec_scalar(A::AdjOrTransAbsVec, x, γ) = (A * x) * γ
@@ -1132,14 +1132,14 @@ mat_vec_scalar(A::AdjOrTransAbsVec, x, γ) = (A * x) * γ
 function mat_mat_scalar(A, B, γ)
     T = promote_type(eltype(A), eltype(B), typeof(γ))
     C = similar(A, T, axes(A,1), axes(B,2))
-    mul!(C, A, B, γ, false) # γ on the right
+    mul!(C, A, B, γ, false)
 end
 
 mat_mat_scalar(A::AdjointAbsVec, B, γ::Union{Real,Complex}) = mat_vec_scalar(B', A', γ')'
-mat_mat_scalar(A::AdjointAbsVec, B, γ) = (B' * (A' .* γ'))'
+mat_mat_scalar(A::AdjointAbsVec, B, γ) = (γ' .* (A * B)')' # preserving order, adjoint reverses
 
 mat_mat_scalar(A::TransposeAbsVec, B, γ::Union{Real,Complex}) = transpose(mat_vec_scalar(transpose(B), transpose(A), γ))
-mat_mat_scalar(A::TransposeAbsVec, B, γ) = transpose(transpose(B) * (transpose(A) .* γ))
+mat_mat_scalar(A::TransposeAbsVec, B, γ) = transpose(γ .* transpose(A * B))
 
 function _tri_matmul(A,B,C)
     n,m = size(A)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1162,7 +1162,7 @@ mat_mat_scalar(A::TransposeAbsVec, B::_SafeMatrix, γ::Union{Real,Complex}) =
 *(α::Number, β::Number, C::AbstractMatrix, D::AbstractMatrix) = (α*β) * C * D
 *(α::Number, B::AbstractMatrix, C::AbstractMatrix, x::AbstractVector) = α * B * (C*x)
 *(α::Number, vt::AdjOrTransAbsVec, C::AbstractMatrix, x::AbstractVector) = α * (vt*C*x)
-*(α::Number, vt::AdjOrTransAbsVec, C::AbstractMatrix, D::AbstractMatrix) = (α*vt*C) * D
+*(α::Union{Real,Complex}, vt::AdjOrTransAbsVec, C::AbstractMatrix, D::AbstractMatrix) = (α*vt*C) * D
 
 *(A::AbstractMatrix, x::AbstractVector, γ::Number, δ::Number) = A * x * (γ*δ)
 *(A::AbstractMatrix, B::AbstractMatrix, γ::Number, δ::Number) = A * B * (γ*δ)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -1100,6 +1100,9 @@ or examining `size.((A,B,C,D))` to choose which to multiply first.
 """
 *(A::AbstractMatrix, B::AbstractMatrix, x::AbstractVector) = A * (B*x)
 
+*(tu::AdjOrTransAbsVec, B::AbstractMatrix, v::AbstractVector) = (tu*B) * v
+*(tu::AdjOrTransAbsVec, B::AdjOrTransAbsMat, v::AbstractVector) = tu * (B*v)
+
 *(A::AbstractMatrix, x::AbstractVector, γ::Number) = mat_vec_scalar(A,x,γ)
 *(A::AbstractMatrix, B::AbstractMatrix, γ::Number) = mat_mat_scalar(A,B,γ)
 *(α::RealOrComplex, B::AbstractMatrix{<:RealOrComplex}, C::AbstractVector{<:RealOrComplex}) =

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -776,6 +776,9 @@ end
     b = 123
 
     @test x'*A*y == (x'*A)*y == x'*(A*y)
+    
+    @test y'*A'*x == (y'*A')*x == y'*(A'*x)
+    @test y'*transpose(A)*x == (y'*transpose(A))*x == y'*(transpose(A)*x)
 
     @test B*A*y == (B*A)*y == B*(A*y)
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -766,4 +766,37 @@ end
     @test Matrix{Int}(undef, 2, 0) * Matrix{Int}(undef, 0, 3) == zeros(Int, 2, 3)
 end
 
+@testset "3-argument *" begin
+    x = [1, 2im]
+    y = [im, 20, 30+40im]
+    z = [-1, 200+im, -3]
+    A = [1 2 3im; 4 5 6+im]
+    B = [-10 -20; -30 -40]
+    a = 3 + im * round(Int, 10^6*(pi-3))
+
+    @test x'*A*y == (x'*A)*y == x'*(A*y)
+
+    @test B*A*y == (B*A)*y == B*(A*y)
+
+    @test a*A*y == (a*A)*y == a*(A*y)
+    @test A*y*a == (A*y)*a == A*(y*a)
+
+    @test a*B*A == (a*B)*A == a*(B*A)
+    @test B*A*a == (B*A)*a == B*(A*a)
+
+    @test a*y'*z == (a*y')*z == a*(y'*z)
+    @test y'*z*a == (y'*z)*a == y'*(z*a)
+
+    @test a*y*z' == (a*y)*z' == a*(y*z')
+    @test y*z'*a == (y*z')*a == y*(z'*a)
+
+    @test a*x'*A == (a*x')*A == a*(x'*A)
+    @test x'*A*a == (x'*A)*a == x'*(A*a)
+    @test a*x'*A isa Adjoint
+
+    @test a*transpose(x)*A == (a*transpose(x))*A == a*(transpose(x)*A)
+    @test transpose(x)*A*a == (transpose(x)*A)*a == transpose(x)*(A*a)
+    @test a*transpose(x)*A isa Transpose
+end
+
 end # module TestMatmul

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -806,10 +806,6 @@ end
     y31 = reshape(y,3,1)
     @test y31*x'*A == (y31*x')*A == y31*(x'*A)
 
-    @test a*b*A == (a*b)*A == a*(b*A)
-    @test a*A*b == (a*A)*b == a*(A*b)
-    @test A*a*b == (A*a)*b == A*(a*b)
-
     vm = [rand(1:9,2,2) for _ in 1:3]
     Mm = [rand(1:9,2,2) for _ in 1:3, _ in 1:3]
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -804,6 +804,10 @@ end
     @test y*x'*A == (y*x')*A == y*(x'*A)
     y31 = reshape(y,3,1)
     @test y31*x'*A == (y31*x')*A == y31*(x'*A)
+
+    @test a*b*A == (a*b)*A == a*(b*A)
+    @test a*A*b == (a*A)*b == a*(A*b)
+    @test A*a*b == (A*a)*b == A*(a*b)
 end
 
 @testset "3-arg *, order by size" begin

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -824,4 +824,37 @@ end
     @test M44*M42*M24 ≈ (M44*M42)*M24 ≈ M44*(M42*M24)
 end
 
+@testset "4-arg *, by type" begin
+    y = [im, 20, 30+40im]
+    z = [-1, 200+im, -3]
+    a = 3 + im * round(Int, 10^6*(pi-3))
+    b = 123
+    M = rand(vcat(1:9, im.*[1,2,3]), 3,3)
+    N = rand(vcat(1:9, im.*[1,2,3]), 3,3)
+
+    @test a * b * M * y == (a*b) * (M*y)
+    @test a * b * M * N == (a*b) * (M*N)
+    @test a * M * N * y == (a*M) * (N*y)
+    @test a * y' * M * z == (a*y') * (M*z)
+    @test a * y' * M * N == (a*y') * (M*N)
+
+    @test M * y * a * b == (M*y) * (a*b)
+    @test M * N * a * b == (M*N) * (a*b)
+    @test M * N * y * a == (a*M) * (N*y)
+    @test y' * M * z * a == (a*y') * (M*z)
+    @test y' * M * N * a == (a*y') * (M*N)
+
+    @test M * N * conj(M) * y == (M*N) * (conj(M)*y)
+    @test y' * M * N * conj(M) == (y'*M) * (N*conj(M))
+    @test y' * M * N * z == (y'*M) * (N*z)
+end
+
+@testset "4-arg *, by size" begin
+    for shift in 1:5
+        s1,s2,s3,s4,s5 = circshift(3:7, shift)
+        a=randn(s1,s2); b=randn(s2,s3); c=randn(s3,s4); d=randn(s4,s5)
+        @test *(a,b,c,d) ≈ (a*b) * (c*d)
+    end
+end
+
 end # module TestMatmul

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -773,6 +773,7 @@ end
     A = [1 2 3im; 4 5 6+im]
     B = [-10 -20; -30 -40]
     a = 3 + im * round(Int, 10^6*(pi-3))
+    b = 123
 
     @test x'*A*y == (x'*A)*y == x'*(A*y)
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -793,14 +793,14 @@ end
 
     @test a*x'*A == (a*x')*A == a*(x'*A)
     @test x'*A*a == (x'*A)*a == x'*(A*a)
-    @test a*x'*A isa Adjoint
+    @test a*x'*A isa Adjoint{<:Any, <:Vector}
 
     @test a*transpose(x)*A == (a*transpose(x))*A == a*(transpose(x)*A)
     @test transpose(x)*A*a == (transpose(x)*A)*a == transpose(x)*(A*a)
-    @test a*transpose(x)*A isa Transpose
+    @test a*transpose(x)*A isa Transpose{<:Any, <:Vector}
 
     @test x'*B*A == (x'*B)*A == x'*(B*A)
-    @test x'*B*A isa Adjoint
+    @test x'*B*A isa Adjoint{<:Any, <:Vector}
 
     @test y*x'*A == (y*x')*A == y*(x'*A)
     y31 = reshape(y,3,1)

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -766,7 +766,7 @@ end
     @test Matrix{Int}(undef, 2, 0) * Matrix{Int}(undef, 0, 3) == zeros(Int, 2, 3)
 end
 
-@testset "3-argument *" begin
+@testset "3-arg *, order by type" begin
     x = [1, 2im]
     y = [im, 20, 30+40im]
     z = [-1, 200+im, -3]
@@ -797,6 +797,15 @@ end
     @test a*transpose(x)*A == (a*transpose(x))*A == a*(transpose(x)*A)
     @test transpose(x)*A*a == (transpose(x)*A)*a == transpose(x)*(A*a)
     @test a*transpose(x)*A isa Transpose
+end
+
+@testset "3-arg *, order by size" begin
+    M44 = randn(4,4)
+    M24 = randn(2,4)
+    M42 = randn(4,2)
+    @test M44*M44*M44 ≈ (M44*M44)*M44 ≈ M44*(M44*M44)
+    @test M42*M24*M44 ≈ (M42*M24)*M44 ≈ M42*(M24*M44)
+    @test M44*M42*M24 ≈ (M44*M42)*M24 ≈ M44*(M42*M24)
 end
 
 end # module TestMatmul

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -853,7 +853,13 @@ end
     for shift in 1:5
         s1,s2,s3,s4,s5 = circshift(3:7, shift)
         a=randn(s1,s2); b=randn(s2,s3); c=randn(s3,s4); d=randn(s4,s5)
+
+        # _quad_matmul
         @test *(a,b,c,d) ≈ (a*b) * (c*d)
+
+        # _tri_matmul(A,B,B,δ)
+        @test *(11.1,b,c,d) ≈ (11.1*b) * (c*d)
+        @test *(a,b,c,99.9) ≈ (a*b) * (c*99.9)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -776,7 +776,6 @@ end
     b = 123
 
     @test x'*A*y == (x'*A)*y == x'*(A*y)
-    
     @test y'*A'*x == (y'*A')*x == y'*(A'*x)
     @test y'*transpose(A)*x == (y'*transpose(A))*x == y'*(transpose(A)*x)
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -809,6 +809,14 @@ end
     @test a*b*A == (a*b)*A == a*(b*A)
     @test a*A*b == (a*A)*b == a*(A*b)
     @test A*a*b == (A*a)*b == A*(a*b)
+
+    vm = [rand(1:9,2,2) for _ in 1:3]
+    Mm = [rand(1:9,2,2) for _ in 1:3, _ in 1:3]
+
+    @test vm' * Mm * vm == (vm' * Mm) * vm == vm' * (Mm * vm)
+    @test Mm * Mm' * vm == (Mm * Mm') * vm == Mm * (Mm' * vm)
+    @test vm' * Mm * Mm == (vm' * Mm) * Mm == vm' * (Mm * Mm)
+    @test Mm * Mm' * Mm == (Mm * Mm') * Mm == Mm * (Mm' * Mm)
 end
 
 @testset "3-arg *, order by size" begin

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -797,6 +797,13 @@ end
     @test a*transpose(x)*A == (a*transpose(x))*A == a*(transpose(x)*A)
     @test transpose(x)*A*a == (transpose(x)*A)*a == transpose(x)*(A*a)
     @test a*transpose(x)*A isa Transpose
+
+    @test x'*B*A == (x'*B)*A == x'*(B*A)
+    @test x'*B*A isa Adjoint
+
+    @test y*x'*A == (y*x')*A == y*(x'*A)
+    y31 = reshape(y,3,1)
+    @test y31*x'*A == (y31*x')*A == y31*(x'*A)
 end
 
 @testset "3-arg *, order by size" begin


### PR DESCRIPTION
This addresses the simplest part of https://github.com/JuliaLang/LinearAlgebra.jl/issues/227, by adding some methods for `*` with 3 arguments, where this can be done more efficiently than working left-to-right:

```julia
using BenchmarkTools

# Matrix-matrix-vector
@btime A*B*x  setup=(N=100; A=rand(N,N); B=rand(N,N); x=rand(N));
@btime A*(B*x)  setup=(N=100; A=rand(N,N); B=rand(N,N); x=rand(N)); # 10x faster

# Scalar-matrix-vector (with function from PR)
@btime a*B*x  setup=(N=100; a=rand(); B=rand(N,N); x=rand(N));
@btime mat_vec_scalar(a,B,x)  setup=(N=100; a=rand(); B=rand(N,N); x=rand(N)); # 5x faster

# 3-arg dot
@btime x'*A*y  setup=(N=100; x=rand(N); A=rand(N,N); y=rand(N)); 
@btime dot(x,A,y)  setup=(N=100; x=rand(N); A=rand(N,N); y=rand(N)); # slightly faster, zero alloc.

# Three matrices
@btime A*B*C  setup=(N=100; A=rand(N,10); B=rand(10,N); C=rand(N,N));
@btime A*(B*C)  setup=(N=100; A=rand(N,10); B=rand(10,N); C=rand(N,N)); # 3x faster
```
I think it's careful about Adjoint & Transpose vectors, but might need more thought about Diagonal and other special matrix types. ~~(Edit -- testing says `(zeros(0))' * Diagonal(zeros(0)) * zeros(0)` is ambiguous.)~~

See also https://github.com/AustinPrivett/MatrixChainMultiply.jl, and discussion https://discourse.julialang.org/t/why-is-multiplication-a-b-c-left-associative-foldl-not-right-associative-foldr/17552.
