### PR TITLE
Use ind2sub directly in reinterpret(reshape, ...) fallbacks

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -257,13 +257,13 @@ end
 # but which don't handle SCartesianIndex2
 function _getindex(::IndexSCartesian2, A::AbstractArray{T,N}, ind::SCartesianIndex2) where {T,N}
     @_propagate_inbounds_meta
-    I = _to_subscript_indices(A, ind.i, ind.j)
-    getindex(A, I...)
+    J = _ind2sub(tail(axes(A)), ind.j)
+    getindex(A, ind.i, J...)
 end
 function _setindex!(::IndexSCartesian2, A::AbstractArray{T,N}, v, ind::SCartesianIndex2) where {T,N}
     @_propagate_inbounds_meta
-    I = _to_subscript_indices(A, ind.i, ind.j)
-    setindex!(A, v, I...)
+    J = _ind2sub(tail(axes(A)), ind.j)
+    setindex!(A, v, ind.i, J...)
 end
 
 

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -130,6 +130,12 @@ end
 @test B[1] === Complex{Int64}(11+12im)
 @test B[2] === Complex{Int64}(13+14im)
 @test B[3] === Complex{Int64}(15+16im)
+z3 = (0x00, 0x00, 0x00)
+Az = [z3 z3; z3 z3]
+Azr = reinterpret(reshape, UInt8, Az)
+W = WrapperArray(Azr)
+copyto!(W, fill(0x01, 3, 2, 2))
+@test all(isequal((0x01, 0x01, 0x01)), Az)
 
 # ensure that reinterpret arrays aren't erroneously classified as strided
 let A = reshape(1:20, 5, 4)


### PR DESCRIPTION
`_to_subscript_indices` doesn't do quite the same thing in higher-dimensional contexts, so best to use `ind2sub` directly.