### PR TITLE
add a global cache to the toml parsing in loading and propagate that to precompile processes

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -110,6 +110,8 @@ let
     empty!(DEPOT_PATH)
 end
 
+empty!(Base.TOML_CACHE.d)
+Base.TOML.reinit!(Base.TOML_CACHE.p, "")
 @eval Sys begin
     BINDIR = ""
     STDLIB = ""

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -102,7 +102,7 @@ function Parser(str::String; filepath=nothing)
             IdSet{TOMLDict}(),    # defined_tables
             root,
             filepath,
-            get(Base.loaded_modules, DATES_PKGID, nothing),
+            isdefined(Base, :loaded_modules) ? get(Base.loaded_modules, DATES_PKGID, nothing) : nothing,
         )
     startup(l)
     return l

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -271,7 +271,7 @@ function short_path(spath::Symbol, filenamecache::Dict{Symbol, String})
                     for proj in Base.project_names
                         project_file = joinpath(root, proj)
                         if Base.isfile_casesensitive(project_file)
-                            pkgid = Base.project_file_name_uuid(project_file, "", Base.TOMLCache())
+                            pkgid = Base.project_file_name_uuid(project_file, "")
                             isempty(pkgid.name) && return path # bad Project file
                             # return the joined the module name prefix and path suffix
                             path = path[nextind(path, sizeof(root)):end]

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -583,15 +583,16 @@ end
 
 function project_deps_get_completion_candidates(pkgstarts::String, project_file::String)
     loading_candidates = String[]
-    p = Base.TOML.Parser()
-    Base.TOML.reinit!(p, read(project_file, String); filepath=project_file)
-    d = Base.TOML.parse(p)
-    pkg = get(d, "name", nothing)
+    d = Base.parsed_toml(project_file)
+    pkg = get(d, "name", nothing)::Union{String, Nothing}
     if pkg !== nothing && startswith(pkg, pkgstarts)
         push!(loading_candidates, pkg)
     end
-    for (pkg, _) in get(d, "deps", [])
-        startswith(pkg, pkgstarts) && push!(loading_candidates, pkg)
+    deps = get(d, "deps", nothing)::Union{Dict{String, Any}, Nothing}
+    if deps !== nothing
+        for (pkg, _) in deps
+            startswith(pkg, pkgstarts) && push!(loading_candidates, pkg)
+        end
     end
     return Completion[PackageCompletion(name) for name in loading_candidates]
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -176,10 +176,9 @@ end
                 d = findfirst(line -> line == "[deps]", p)
                 t = findfirst(line -> startswith(line, "This"), p)
                 # look up various packages by name
-                cache = Base.TOMLCache()
-                root = Base.explicit_project_deps_get(project_file, "Root", cache)
-                this = Base.explicit_project_deps_get(project_file, "This", cache)
-                that = Base.explicit_project_deps_get(project_file, "That", cache)
+                root = Base.explicit_project_deps_get(project_file, "Root")
+                this = Base.explicit_project_deps_get(project_file, "This")
+                that = Base.explicit_project_deps_get(project_file, "That")
                 # test that the correct answers are given
                 @test root == (something(n, N+1) ≥ something(d, N+1) ? nothing :
                                something(u, N+1) < something(d, N+1) ? root_uuid : proj_uuid)
@@ -205,13 +204,13 @@ Base.ACTIVE_PROJECT[] = nothing
 
 # locate `tail(names)` package by following the search path graph through `names` starting from `where`
 function recurse_package(where::PkgId, name::String, names::String...)
-    pkg = identify_package(where, name, Base.TOMLCache())
+    pkg = identify_package(where, name)
     pkg === nothing && return nothing
     return recurse_package(pkg, names...)
 end
 
 recurse_package(pkg::String) = identify_package(pkg)
-recurse_package(where::PkgId, pkg::String) = identify_package(where, pkg, Base.TOMLCache())
+recurse_package(where::PkgId, pkg::String) = identify_package(where, pkg)
 
 function recurse_package(name::String, names::String...)
     pkg = identify_package(name)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -244,7 +244,7 @@ try
     # use _require_from_serialized to ensure that the test fails if
     # the module doesn't reload from the image:
     @test_logs (:warn, "Replacing module `$Foo_module`") begin
-        ms = Base._require_from_serialized(cachefile, Base.TOMLCache())
+        ms = Base._require_from_serialized(cachefile)
         @test isa(ms, Array{Any,1})
     end
 
@@ -417,7 +417,7 @@ try
           """)
 
     cachefile = Base.compilecache(Base.PkgId("FooBar"))
-    @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"), Base.TOMLCache())
+    @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"))
     @test isfile(joinpath(cachedir, "FooBar.ji"))
     @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) isa Vector
     @test !isdefined(Main, :FooBar)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/37782

The TOMLCache thing has been kinda annoying. It was supposed to be this internal thing but now Pkg and Revise use it and Revise even has some code for invalidating it. It seems kinda silly that a bunch of packages have to deal with it so I propose we just implement a global cache for it here in Base.

This also propagates the cache to workers so they do not have to reparse them over and over fixing https://github.com/JuliaLang/julia/pull/37632. It is still not at https://github.com/JuliaLang/julia/pull/37632 level where we want to send over the actual paths but it is one step towards it.

This will break `Revise` and `Pkg.precompile`.