### PR TITLE
Remove "concrete" in description of example

### DIFF
--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -295,7 +295,7 @@ julia> same_type(x,y) = false
 same_type (generic function with 2 methods)
 ```
 
-The first method applies whenever both arguments are of the same concrete type, regardless of
+The first method applies whenever both arguments are of the same type, regardless of
 what type that is, while the second method acts as a catch-all, covering all other cases. Thus,
 overall, this defines a boolean function that checks whether its two arguments are of the same
 type:


### PR DESCRIPTION
While the example in the docs indeed seem to require `T` to be a concrete type, the following slightly modified example matches `T` to an abstract type. This confused me, so I figured maybe only keeping the part "both arguments are of the same type" is a good compromise.
```julia
julia> a = Real[1, 1.0]
2-element Array{Real,1}:
 1
 1.0

julia> g(x::Vector{T}, y::Vector{T}) where T = T
g (generic function with 2 methods)

julia> g(a,a)
Real
```