### PR TITLE
quite faster rand(::MersenneTwister, ::Type{Float64}) etc...

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -230,7 +230,7 @@ mt_setfull!(r::MersenneTwister) = r.idxF = 0
 mt_setempty!(r::MersenneTwister) = r.idxF = MT_CACHE_F
 mt_pop!(r::MersenneTwister) = @inbounds return r.vals[r.idxF+=1]
 
-function gen_rand(r::MersenneTwister)
+@noinline function gen_rand(r::MersenneTwister)
     r.adv_vals = r.adv
     GC.@preserve r fill_array!(r, pointer(r.vals), length(r.vals), CloseOpen12())
     mt_setfull!(r)


### PR DESCRIPTION
Generation of `Int64` just became faster than of `Float64` (#37914).
Given that dSFMT produces natively `Float64`, and that generating a random
`Float64` needs only 52 random bits, surely performance can be improved there.

Just ask the `gen_rand` routine, which randomizes the cache for floats,
to not inline, as it's unlikely to be called (once in a thousand).

The speedups are about 1.8x for `rand(rng, Float64)`, 13% for
`randn(rng, Float64)`, more than 1.9x for `rand(rng, Int32)`
and smaller integers (including `Bool`).

This is a pleasant benefits / typed characters ratio, reminiscent of #9126 :) 

Here are some number, in nanoseconds, for different versions of Julia (the starred ones are with this patch applied):

| Julia version  | 1.4  | 1.4* | 1.5  | 1.5* | master | master* |
| ---            | ---  | ---  | ---  | ---  | ---    | ---     |
| rand(Float64)  | 3.83 | 2.78 | 3.78 | 2.78 | 4.80   | 2.78    |
| randn(Float64) | 6.16 | 4.80 | 7.21 | 6.20 | 7.01   | 6.12    |
| rand(Int32)    | 3.71 | 2.44 | 3.70 | 2.45 | 4.69   | 2.43    |

We can note that:
* for `rand(Float64)`, the perfs decreased from 1.5 to master (non-*), but this change solves it
* for `randn()`, the perfs decreased from 1.4 to 1.5 (non-*, cf. #37030); this PR gives back the perfs of 1.4, but not as nice as what it "could" be (4.80ns); `code_typed` gives some insight as to why, I will comment on the PR which re-instantiate the 1.4 version

As a closing note: the limit here for `rand()` is 1ns (on my machine), the time it takes per `Float64` when using the low-level dSFMT routine to randomize an array; so there might still be a small margin for improvement, but I don't think there will be many more PR from me with "rand", "MersenneTwister" and "faster" in the title...