### PR TITLE
use gray for debug info for code_llvm to be consistent with e.g. stacktraces

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -9,7 +9,7 @@ highlighting = Dict{Symbol, Bool}(
 
 llstyle = Dict{Symbol, Tuple{Bool, Union{Symbol, Int}}}(
     :default     => (false, :light_black), # e.g. comma, equal sign, unknown token
-    :comment     => (false, :green),
+    :comment     => (false, :light_black),
     :label       => (false, :light_red),
     :instruction => ( true, :light_cyan),
     :type        => (false, :cyan),


### PR DESCRIPTION
![Screenshot-20201007093645-943x450](https://user-images.githubusercontent.com/1282691/95301594-14efdf00-0881-11eb-9d8a-4d18a20b8df4.png)



![Screenshot-20201007093706-1000x433](https://user-images.githubusercontent.com/1282691/95301590-13261b80-0881-11eb-9ac4-cb440fb6ef6f.png)
