### PR TITLE
Correct definition of lcm

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -74,7 +74,7 @@ end
 """
     lcm(x, y...)
 
-Least common (non-negative) multiple.
+Least common (positive) multiple (or zero if any argument is zero).
 The arguments may be integer and rational numbers.
 
 !!! compat "Julia 1.4"


### PR DESCRIPTION
The old definition would imply that lcm always returns 0. This brings it more in line with that of gcd.

Actually, as an algebraist by profession, I am still unhappy with that documentation because I would not have been able to correctly guess what `lcm` and `gcd` return if given non-integer rational arguments -- after reading the source code, I understand the definition you implicitly are using here, and don't object to it; however, it contradicts the usual definition of `gcd` and `lcm` I would teach to my first year students and that one would find when picking up most (all?) books giving an introduction to Abstract Algebra. The confusion results from what exactly a "multiple" or a "divisor" is: here it means "integer multiple" resp. "number such that the quotient is an integer"; while in abstract algebra, the way to generalize would be to look at the gcd/lcm in the domain at rational numbers, and then allow rational multiples -- meaning that the gcd and lcm are always either 0 or 1.

Thus there is potential for confusion, and I think the documentation for `gcd` and `lcm` ought to be extended to state explicitly how they are defined for rationals. 

Perhaps like this (I can update this PR if people are OK with it, also if there are better suggestions):
> Greatest common (positive) divisor (or zero if all arguments are zero).
> Being a common divisor here means that every argument is a multiple of the result by some integer.
> The arguments may be integer and rational numbers.
>
> Least common (positive) multiple (or zero if any argument is zero).
> Being a common multiple here means that the result is a multiple of each argument by some integer.
> The arguments may be integer and rational numbers.
