### PR TITLE
fix #37919, ir verifier on `isdefined`

### DIFF
--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -207,6 +207,9 @@ function verify_ir(ir::IRCode, print::Bool=true)
                     # blocks, which isn't allowed for regular SSA values, so
                     # we skip the validation below.
                     continue
+                elseif stmt.head === :isdefined && length(stmt.args) == 1 && stmt.args[1] isa GlobalRef
+                    # a GlobalRef isdefined check does not evaluate its argument
+                    continue
                 end
             end
             for op in userefs(stmt)

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -233,3 +233,9 @@ let ci = make_ci([
     ir = Core.Compiler.compact!(ir, true)
     @test Core.Compiler.verify_ir(ir) == nothing
 end
+
+# issue #37919
+let ci = code_lowered(()->@isdefined(_not_def_37919_), ())[1]
+    ir = Core.Compiler.inflate_ir(ci)
+    @test Core.Compiler.verify_ir(ir) === nothing
+end


### PR DESCRIPTION
fix #37919