### PR TITLE
Distributed: remove backtrace unwrapping from RemoteException

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -49,7 +49,7 @@ function showerror(io::IO, ex::CompositeException)
         showerror(io, ex.exceptions[1])
         remaining = length(ex) - 1
         if remaining > 0
-            print(io, string("\n\n...and ", remaining, " more exception(s).\n"))
+            print(io, "\n\n...and ", remaining, " more exception", remaining > 1 ? "s" : "", ".\n")
         end
     else
         print(io, "CompositeException()\n")

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -54,23 +54,7 @@ remote exception and a serializable form of the call stack when the exception wa
 RemoteException(captured) = RemoteException(myid(), captured)
 function showerror(io::IO, re::RemoteException)
     (re.pid != myid()) && print(io, "On worker ", re.pid, ":\n")
-    showerror(io, get_root_exception(re.captured))
-end
-
-isa_exception_container(ex) = (isa(ex, RemoteException) ||
-                               isa(ex, CapturedException) ||
-                               isa(ex, CompositeException))
-
-function get_root_exception(ex)
-    if isa(ex, RemoteException)
-        return get_root_exception(ex.captured)
-    elseif isa(ex, CapturedException) && isa_exception_container(ex.ex)
-        return get_root_exception(ex.ex)
-    elseif isa(ex, CompositeException) && length(ex.exceptions) > 0 && isa_exception_container(ex.exceptions[1])
-        return get_root_exception(ex.exceptions[1])
-    else
-        return ex
-    end
+    showerror(io, re.captured)
 end
 
 function run_work_thunk(thunk, print_error)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -439,7 +439,7 @@ catch ex
     # test showerror
     err_str = sprint(showerror, ex)
     err_one_str = sprint(showerror, ex.exceptions[1])
-    @test err_str == err_one_str * "\n\n...and 4 more exception(s).\n"
+    @test err_str == err_one_str * "\n\n...and 4 more exceptions.\n"
 end
 @test sprint(showerror, CompositeException()) == "CompositeException()\n"
 
@@ -1690,16 +1690,14 @@ let (h, t) = Distributed.head_and_tail(Int[], 0)
 end
 
 # issue #35937
-let e
-    try
-        pmap(1) do _
+let e = @test_throws RemoteException pmap(1) do _
             wait(@async error(42))
         end
-    catch ex
-        e = ex
-    end
     # check that the inner TaskFailedException is correctly formed & can be printed
-    @test sprint(showerror, e) isa String
+    es = @show sprint(showerror, e.value)
+    @test contains(es, ":\nTaskFailedException\nStacktrace:\n")
+    @test contains(es, "\n\n    nested task error:")
+    @test_broken contains(es, "\n\n    nested task error: 42\n")
 end
 
 # issue #27429, propagate relative `include` path to workers


### PR DESCRIPTION
I'm not sure why this is present (added in https://github.com/JuliaLang/julia/pull/20276/commits/25669b5feeec11165f27615f722fd0dfc7fa64a5), though it does make the example there (https://github.com/JuliaLang/julia/issues/20230#issuecomment-275866119) rather more verbose @amitmurthy:

```
julia> remotecall_fetch(()->eval(expr), 2)
ERROR: Error deserializing a remote exception from worker 2
Remote(original) exception of type BoundsError
Remote stacktrace : 
Stacktrace:
 [1] top-level scope
   @ REPL[19]:5
 [2] eval
   @ ./boot.jl:360 [inlined]
 [3] eval
   @ ./client.jl:446
 [4] #43
   @ ./REPL[20]:1
 [5] #106
   @ /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:278
 [6] run_work_thunk
   @ /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:63
 [7] macro expansion
   @ /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:278 [inlined]
 [8] #105
   @ ./task.jl:395

...and 1 more exception.

Stacktrace:
  [1] deserialize(s::Distributed.ClusterSerializer{Sockets.TCPSocket}, t::Type{CapturedException})
    @ Distributed /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/clusterserialize.jl:238
  [2] handle_deserialize(s::Distributed.ClusterSerializer{Sockets.TCPSocket}, b::Int32)
    @ Serialization /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Serialization/src/Serialization.jl:838
  [3] deserialize(s::Distributed.ClusterSerializer{Sockets.TCPSocket}, t::DataType)
    @ Serialization /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Serialization/src/Serialization.jl:1393
  [4] handle_deserialize(s::Distributed.ClusterSerializer{Sockets.TCPSocket}, b::Int32)
    @ Serialization /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Serialization/src/Serialization.jl:838
  [5] deserialize
    @ /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Serialization/src/Serialization.jl:774 [inlined]
  [6] deserialize_msg(s::Distributed.ClusterSerializer{Sockets.TCPSocket})
    @ Distributed /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/messages.jl:87
  [7] #invokelatest#2
    @ ./essentials.jl:709 [inlined]
  [8] invokelatest
    @ ./essentials.jl:708 [inlined]
  [9] message_handler_loop(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
    @ Distributed /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:169
 [10] process_tcp_streams(r_stream::Sockets.TCPSocket, w_stream::Sockets.TCPSocket, incoming::Bool)
    @ Distributed /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/process_messages.jl:126
 [11] (::Distributed.var"#99#100"{Sockets.TCPSocket, Sockets.TCPSocket, Bool})()
    @ Distributed ./task.jl:395
Stacktrace:
 [1] #remotecall_fetch#143
   @ /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/remotecall.jl:394 [inlined]
 [2] remotecall_fetch(::Function, ::Distributed.Worker)
   @ Distributed /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/remotecall.jl:386
 [3] remotecall_fetch(::Function, ::Int64; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Distributed /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/remotecall.jl:421
 [4] remotecall_fetch(::Function, ::Int64)
   @ Distributed /data/vtjnash/julia/usr/share/julia/stdlib/v1.6/Distributed/src/remotecall.jl:421
 [5] top-level scope
   @ REPL[20]:1
```