### PR TITLE
make "default" tokens in code_llvm have normal text

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -8,7 +8,7 @@ highlighting = Dict{Symbol, Bool}(
 )
 
 llstyle = Dict{Symbol, Tuple{Bool, Union{Symbol, Int}}}(
-    :default     => (false, :light_black), # e.g. comma, equal sign, unknown token
+    :default     => (false, :normal), # e.g. comma, equal sign, unknown token
     :comment     => (false, :light_black),
     :label       => (false, :light_red),
     :instruction => ( true, :light_cyan),

--- a/stdlib/InteractiveUtils/test/highlighting.jl
+++ b/stdlib/InteractiveUtils/test/highlighting.jl
@@ -233,7 +233,7 @@ const XU = B * "}" * XB
                            "to [2 x i16] addrspace(10)*") ==
             "  $(V)%28$(XV) $EQU $(I)bitcast$(XI) $(V)%jl_value_t$(XV) " *
             "$(K)addrspace$(XK)$P$(N)10$(XN)$XP$(D)*$(XD) $(V)%27$(XV) " *
-            "$(K)to$(XK) $S$(N)2$(XN) $(D)x$(XD) $(T)i16$(XD)$XS " *
+            "$(K)to$(XK) $S$(N)2$(XN) $(D)x$(XD) $(T)i16$(XT)$XS " *
             "$(K)addrspace$(XK)$P$(N)10$(XN)$XP$(D)*$(XD)\n"
     end
 


### PR DESCRIPTION
I felt like tokens like equal signs and commas disappeared too much in the background

<img width="696" alt="Screenshot 2020-10-08 at 11 53 20" src="https://user-images.githubusercontent.com/1282691/95443601-10005d80-095d-11eb-8bb4-bad1f93aa199.png">

<img width="703" alt="Screenshot 2020-10-08 at 11 53 28" src="https://user-images.githubusercontent.com/1282691/95443598-0ecf3080-095d-11eb-94b3-6ac3fdbb0e94.png">

