### PR TITLE
Add vim bindings to TerminalMenus

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -197,9 +197,9 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu; cursor::Unio
             lastoption = numoptions(m)
             c = readkey(term.in_stream)
 
-            if c == Int(ARROW_UP)
+            if c == Int(ARROW_UP) || c == Int('k')
                 cursor[] = move_up!(m, cursor[], lastoption)
-            elseif c == Int(ARROW_DOWN)
+            elseif c == Int(ARROW_DOWN) || c == Int('j')
                 cursor[] = move_down!(m, cursor[], lastoption)
             elseif c == Int(PAGE_UP)
                 cursor[] = page_up!(m, cursor[], lastoption)
@@ -211,7 +211,7 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu; cursor::Unio
             elseif c == Int(END_KEY)
                 cursor[] = lastoption
                 m.pageoffset = lastoption - m.pagesize
-            elseif c == 13 # <enter>
+            elseif c == 13 || c == Int(' ') # <enter> or <space>
                 # will break if pick returns true
                 pick(m, cursor[]) && break
             elseif c == UInt32('q')

--- a/stdlib/REPL/test/TerminalMenus/runtests.jl
+++ b/stdlib/REPL/test/TerminalMenus/runtests.jl
@@ -6,10 +6,22 @@ using Test
 
 function simulate_input(expected, menu::TerminalMenus.AbstractMenu, keys...;
                         kwargs...)
-    keydict =  Dict(:up => "\e[A",
-                    :down => "\e[B",
-                    :enter => "\r")
+    keydict = Dict(:up => "\e[A",
+                   :down => "\e[B",
+                   :enter => "\r")
+    vimdict = Dict(:up => "k",
+                   :down => "j",
+                   :enter => " ")
+    errs = []
+    got = _simulate_input(keydict, deepcopy(menu), keys...; kwargs...)
+    got == expected || push!(errs, :arrows => got)
+    got = _simulate_input(vimdict, menu, keys...; kwargs...)
+    got == expected || push!(errs, :vim => got)
+    isempty(errs) || return errs
+end
 
+function _simulate_input(keydict, menu::TerminalMenus.AbstractMenu, keys...;
+                         kwargs...)
     for key in keys
         if isa(key, Symbol)
             write(stdin.buffer, keydict[key])
@@ -18,7 +30,7 @@ function simulate_input(expected, menu::TerminalMenus.AbstractMenu, keys...;
         end
     end
 
-    request(menu; suppress_output=true, kwargs...) == expected
+    request(menu; suppress_output=true, kwargs...)
 end
 
 include("radio_menu.jl")


### PR DESCRIPTION
In addition to the current way to interact with a menu, this PR adds

* `k` to move up,
* `j` to move down,
* `<space>` as an alternative to `<enter>`.