### PR TITLE
Revert "Allow `getindex` of block diagonal matrices with `<:AbstractMatrix` elements (#37825)"

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -91,7 +91,7 @@ end
     r
 end
 diagzero(::Diagonal{T},i,j) where {T} = zero(T)
-diagzero(D::Diagonal{<:AbstractMatrix{T}},i,j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
+diagzero(D::Diagonal{Matrix{T}},i,j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
 
 function setindex!(D::Diagonal, v, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -571,14 +571,6 @@ end
 
     @test tr(D) == 10
     @test det(D) == 4
-
-    # sparse matrix block diagonals
-    s = SparseArrays.sparse([1 2; 3 4])
-    D = Diagonal([s, s])
-    @test isa(D, Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
-    @test D[1, 1] == s
-    @test D[1, 2] == zero(s)
-    @test isa(D[2, 1], SparseMatrixCSC)
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -60,6 +60,4 @@ function *(A::BiTriSym, B::BiTriSym)
     mul!(similar(A, TS, size(A)...), A, B)
 end
 
-LinearAlgebra.diagzero(D::Diagonal{<:AbstractSparseMatrix{T}},i,j) where {T} = spzeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
-
 end


### PR DESCRIPTION
This reverts commit 8ea4082484ba86769904abb702ae00aa93d5f1b0.

Fails CI, e.g. https://build.julialang.org/#/builders/61/builds/4366