### PR TITLE
[WIP/RFC] broaden the scope of `hash`

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -551,15 +551,20 @@ isinf(x::Real) = !isnan(x) & !isfinite(x)
 
 ## hashing small, built-in numeric types ##
 
-hx(a::UInt64, b::Float64, h::UInt) = hash_uint64((3a + reinterpret(UInt64,b)) - h)
+hx(a::UInt64, b::Float64, h::UInt) = hash_uint64(3a + reinterpret(UInt64, b) - h)
+hx(a::UInt64, b::Float64, h) = hash_uint(a, hash_uint(reinterpret(UInt64, b), h))
+
 const hx_NaN = hx(UInt64(0), NaN, UInt(0  ))
 
-hash(x::UInt64,  h::UInt) = hx(x, Float64(x), h)
-hash(x::Int64,   h::UInt) = hx(reinterpret(UInt64, abs(x)), Float64(x), h)
-hash(x::Float64, h::UInt) = isnan(x) ? (hx_NaN ⊻ h) : hx(fptoui(UInt64, abs(x)), x, h)
+hash_NaN(h) = hash(hx_NaN, h)
+hash_NaN(h::UInt) = hx_NaN ⊻ h
 
-hash(x::Union{Bool,Int8,UInt8,Int16,UInt16,Int32,UInt32}, h::UInt) = hash(Int64(x), h)
-hash(x::Float32, h::UInt) = hash(Float64(x), h)
+hash(x::UInt64,  h) = hx(x, Float64(x), h)
+hash(x::Int64,   h) = hx(reinterpret(UInt64, abs(x)), Float64(x), h)
+hash(x::Float64, h) = isnan(x) ? hash_NaN(h) : hx(fptoui(UInt64, abs(x)), x, h)
+
+hash(x::Union{Bool,Int8,UInt8,Int16,UInt16,Int32,UInt32}, h) = hash(Int64(x), h)
+hash(x::Float32, h) = hash(Float64(x), h)
 
 """
     precision(num::AbstractFloat)

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -2,12 +2,12 @@
 
 ## efficient value-based hashing of integers ##
 
-function hash_integer(n::Integer, h::UInt)
-    h ⊻= hash_uint((n % UInt) ⊻ h)
+function hash_integer(n::Integer, h)
+    h = hash(n % UInt,  h)
     n = abs(n)
     n >>>= sizeof(UInt) << 3
     while n != 0
-        h ⊻= hash_uint((n % UInt) ⊻ h)
+        h = hash(n % UInt, h)
         n >>>= sizeof(UInt) << 3
     end
     return h
@@ -34,7 +34,7 @@ end
 
 ## generic hashing for rational values ##
 
-function hash(x::Real, h::UInt)
+function hash(x::Real, h)
     # decompose x as num*2^pow/den
     num, pow, den = decompose(x)
 


### PR DESCRIPTION
Currently `hash(x, h::UInt)::UInt` is used for hashing values (`x` here) to be
used as keys in a hash-container. The `h::UInt` parameter is used to combine
hashes of subobjects in order to compute the hash of a parent object.

This PR suggests to extend the scope of `h` by having its generic signature be
`hash(x, h::H)::H`, where `H` is any type, with accompanying methods:
* `hashinit(::Type{H}) = H()` (e.g. `hashinit(UInt) == UInt(0)`)
* `hashdigest(h::H)::Integer` gives back the result of the hashing process
  when it's finished (e.g. `hashdigest(h::UInt) = h`)

It doesn't make writing `hash` methods much more complicated: basically, just don't consider `h` to be an integer, i.e. you can't directly xor its value; this mean replacing things like `h = hash(x, xor(h, 0x1234567))` by `...; h = hash(x, hash(0x1234567, h)); ...`.
  
### Motivation 1: cryptography in non-container context
 
Once in a while, I would like to get a cryptographic hash of some objects, to
compare them, uniquify them or whatnot, without having to compare them all
against each other. An ad-hoc `cryptohash` function could be written, but it would be
great to be able to re-use the pre-existing implementations (although not all
of them are compatible with cryptographic requirements, far from it). 

One concrete example is testing the reproducibility of an RNG. Instead of
having in your tests `@test rand(MyRng(0), 100) = [... long list of numbers
...]` for different seeds, you could do

`@test hashdigest(hash(rand(MyRng(0), 1000), SHA1Hash())) = 0xfe9160330ac0a5c265517b6831a92414c6ec889f`

Here is a little implementation of this idea (of course this would live in a package),
working atop this PR.

```julia
using SHA
import Base: hash
using BitIntegers

BitIntegers.@define_integers 160 SignedSHA1Sum SHA1Sum

struct SHA1Hash
    buf::Vector{UInt8}
    ctx::SHA1_CTX
end

SHA1Hash() = SHA1Hash(zeros(UInt8, 0), SHA1_CTX())

function Base.hash_uint(x::Base.BitInteger, s::SHA1Hash)
    resize!(s.buf, sizeof(x))
    reinterpret(typeof(x), s.buf)[1] = x
    SHA.update!(s.ctx, s.buf)
    s
end

Base.hashdigest(s::SHA1Hash) = reinterpret(SHA1Sum, SHA.digest!(s.ctx))[1]

Base.show(io::IO, s::SHA1Hash) = show(io, Base.hashdigest(SHA1Hash(UInt8[], copy(s.ctx))))

# can't use default method for vectors, as it doesn't read all elements
function Base.hash(a::AbstractArray, s::SHA1Hash)
    s = hash(0x85285f3d4c50ecee82ec4864a4e2a1e3, s)
    for x in a
        s = hash(x, s)
        s = hash(0x85285f3d4c50ecee82ec4864a4e2a1e3, s)
    end
    s
end

@test Base.hashdigest(hash([1, 2, 3, 4], SHA1Hash())) == 0x17a91ea956706f0383e4450a5359dc1ffa49485d
```

### Motivation 2: provide alternate hash/isequal couples to be used by `Dict`-like containers

I can think of three examples: 

1) use faster hashing in some contexts; for example, in `Dict`, `hash(x) == hash(y)` implies `isequal(x, y)`,
   and as all our numbers hash the same if they represent the same value, `hash` has to go its way
   to enforce this invariant. This can have some performance implications

2) use different meaning of equality in `Dict`, e.g. `===` (would behave like
   `IdDict`), or `(x, y) -> typeof(x) == typeof(y) && isequal(x, y)`.

3) related to 2), use a work-around hash when default hash fails, e.g. 
```
hash(1:Int128(2)^65)
ERROR: InexactError: trunc(Int64, 36893488147419103232)
```

As a proof of concept, this PR includes a small modification of `Dict` to
accomodate this: `Dict{K,V}` is replaced by `HashDict{K,V,H}` where `H` is a type of hash,
and `Dict{K,V}` is an alias for `HashDict{K,V,UInt}` (given how small this patch is,
I would find value in having this in `Base` rather than in a package, which would involve a
lot of duplication; but if this is taken seriously, this should move into another PR...)

To illustrate 1), we define a `Context{T}` hash type which can hash only
subtypes of `T`. We define corresponding `hash` for `BigInt`, `UnitRange` and `Set`
to show how this can compose. 
```julia
import Base: hash, HashDict

struct Context{T}
    h::UInt
end

Context{T}() where {T} = Context{T}(UInt(0))
Base.hashdigest(s::Context) = s.h

hash(x::T, h::Context{T}) where {T<:Integer} = Context{T}(Base.hash_integer(x, h.h))

# ambiguities
hash(x::Int64, h::Context{T}) where {Int64<:T<:Integer} = Context{T}(Base.hash_integer(x, h.h))
hash(x::UInt64, h::Context{T}) where {Int64<:T<:Integer} = Context{T}(Base.hash_integer(x, h.h))

hash(x::U, h::Context{U}) where {T,U<:AbstractUnitRange{T}} =
    Context{U}(hash(last(x), hash(first(x), Context{T}(0x7222d2d5c0db9f56 ⊻ h.h))).h)

function hash(s::U, h::Context{U}) where {T,U<:AbstractSet{T}}
    hv = Base.hashs_seed
    for x in s
        hv ⊻= hash(x, Context{T}()).h
    end
    Context{U}(hash(hv, h.h))
end
```
  
Demo:
```julia
julia> n = big(2)^100; d = Dict(n => 1)
Dict{BigInt, Int64} with 1 entry:
  1267650600228229401496703205376 => 1

julia> @btime $d[$n];
  42.216 ns (0 allocations: 0 bytes)

julia> d = HashDict{BigInt, Int, Context{Integer}}(s => 1)
HashDict{BigInt, Int64, Context{Integer}} with 1 entry:
  1267650600228229401496703205376 => 1

julia> @btime $d[$n];
  19.701 ns (0 allocations: 0 bytes)

julia> d[1] # 1 isa Integer, `Int` keys can be recognized by `d`
ERROR: KeyError: key 1 not found

julia> d[1.0] # but not so for floats
ERROR: MethodError: no method matching hash_uint(::UInt64, ::Context{Integer})
[...]

julia> r = 1:big(2)^60; d = Dict(r=>1)
Dict{UnitRange{BigInt}, Int64} with 1 entry:
  1:1152921504606846976 => 1

julia> @btime $d[$r] = 1;
  372.277 ms (5552083 allocations: 105.90 MiB)

julia> d = HashDict{typeof(r), Int, Context{typeof(r)}}(r => 1)
HashDict{UnitRange{BigInt}, Int64, Context{UnitRange{BigInt}}} with 1 entry:
  1:1152921504606846976 => 1

julia> @btime $d[$r] = 1;
  24.537 ns (0 allocations: 0 bytes)
  
julia> s = Set([r]); d = Dict(s => 1); @btime $d[$s];
  374.994 ms (5552083 allocations: 105.90 MiB)

julia> d = HashDict{typeof(s), Int, Context{typeof(s)}}(s => 1); @btime $d[$s];
  41.511 ns (0 allocations: 0 bytes)
```
As a last example, here how to implement an `IdDict` clone via `HashDict`:
```julia
struct IdHash
    h::UInt
end

IdHash() = IdHash(UInt(0))
Base.hashdigest(h::IdHash) = h.h

hash(x, ::IdHash) = IdHash(objectid(x))
hash(x::Int, ::IdHash) = IdHash(Base.hash_uint(x % UInt))
hash(x::UInt, ::IdHash) = IdHash(Base.hash_uint(x))
hash(x::Float64, ::IdHash) = IdHash(objectid(x))

Base.isequal(::Type{IdHash}, x, y) = x === y

# Demo
julia> d = HashDict{Any,Any,IdHash}(1 => 1, 1.0 => 2)
HashDict{Any, Any, IdHash} with 2 entries:
  1.0 => 2
  1   => 1

julia> @btime $d[1];
  11.786 ns (0 allocations: 0 bytes)

julia> f = IdDict(1 => 1, 1.0 => 2);

julia> @btime $f[1];
  20.101
```