### PR TITLE
Change isequal to hash for unique docstring

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -101,9 +101,9 @@ end
     unique(itr)
 
 Return an array containing only the unique elements of collection `itr`, as
-determined by [`hash`](@ref) equality, in the order that the first of each set
-of equivalent elements originally appears. The element type of the input is
-preserved.
+determined by [`isequal`](@ref), in the order that the first of each set of
+equivalent elements originally appears. The element type of the input is
+preserved. Note that [`isequal`](@ref) requires equality of [`hash`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/set.jl
+++ b/base/set.jl
@@ -100,10 +100,10 @@ end
 """
     unique(itr)
 
-Return an array containing only the unique elements of collection `itr`,
-as determined by [`isequal`](@ref), in the order that the first of each
-set of equivalent elements originally appears. The element type of the
-input is preserved.
+Return an array containing only the unique elements of collection `itr`, as
+determined by [`hash`](@ref) equality, in the order that the first of each set
+of equivalent elements originally appears. The element type of the input is
+preserved.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Following on from my forum post at https://discourse.julialang.org/t/unique-doesnt-seem-to-obey-definitions/47455, I'm submitting this change to the `unique` docstring to refer to `hash` rather than `isequal`.

The issue that I came across was that I did these steps:

a) read the docs for `unique`
b) implemented `isequal` for my custom class `A` (but not `hash`)
c) was surprised when the behaviour of `unique([A(1), A(1)])` didn't give back a single item.

This is because all decision points in the different methods for `unique` end up not using any calls to `isequal` directly.