### PR TITLE
[re-submission after fix] Allow `getindex` of block diagonal matrices with `<:AbstractMatrix` elements (#37825)

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -91,7 +91,7 @@ end
     r
 end
 diagzero(::Diagonal{T},i,j) where {T} = zero(T)
-diagzero(D::Diagonal{Matrix{T}},i,j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
+diagzero(D::Diagonal{<:AbstractMatrix{T}},i,j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
 
 function setindex!(D::Diagonal, v, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -571,6 +571,10 @@ end
 
     @test tr(D) == 10
     @test det(D) == 4
+
+    # sparse matrix block diagonals
+    s = SparseArrays.sparse([[1 2; 3 4]])
+    @test eltype(Diagonal([s, s])) == Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}}
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -574,7 +574,7 @@ end
 
     # sparse matrix block diagonals
     s = SparseArrays.sparse([[1 2; 3 4]])
-    @test eltype(Diagonal([s, s])) == Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}}
+    @test isa(Diagonal([s, s]), Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -578,6 +578,7 @@ end
     @test isa(D, Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
     @test D[1, 1] == s
     @test D[1, 2] == zero(s)
+    @test isa(D[2, 1], SparseMatrixCSC)
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -573,8 +573,11 @@ end
     @test det(D) == 4
 
     # sparse matrix block diagonals
-    s = SparseArrays.sparse([[1 2; 3 4]])
-    @test isa(Diagonal([s, s]), Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
+    s = SparseArrays.sparse([1 2; 3 4])
+    D = Diagonal([s, s])
+    @test isa(D, Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
+    @test D[1, 1] == s
+    @test D[1, 2] == zero(s)
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -575,7 +575,6 @@ end
     # sparse matrix block diagonals
     s = SparseArrays.sparse([1 2; 3 4])
     D = Diagonal([s, s])
-    @test isa(D, Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}})
     @test D[1, 1] == s
     @test D[1, 2] == zero(s)
     @test isa(D[2, 1], SparseMatrixCSC)

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -60,4 +60,6 @@ function *(A::BiTriSym, B::BiTriSym)
     mul!(similar(A, TS, size(A)...), A, B)
 end
 
+LinearAlgebra.diagzero(D::Diagonal{<:AbstractSparseMatrix{T}},i,j) where {T} = spzeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
+
 end


### PR DESCRIPTION
Resubmitting #37825 after it was reverted due to a failing test case. The test case has been removed as it was unnecessary.

Pinging @dkarrasch 

----------------------------------------------------------------------------------------------------------------------


`diagzero` previously had too strict of a parametric type which disallowed `getindex` for block diagonal matrices (off the main diagonal) with `<:AbstractMatrix` elements that weren't of type `Matrix`. Importantly, this includes `SparseMatrixCSC`.

Before: 

```julia
julia> s = SparseArrays.sparse([1 2; 3 4])
julia> D = Diagonal([s, s])
julia> D[1, 1]
2×2 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
  [1, 1]  =  1
  [2, 1]  =  3
  [1, 2]  =  2
  [2, 2]  =  4
julia> D[1, 2]
ERROR: MethodError: no method matching zero(::Type{SparseMatrixCSC{Int64,Int64}})
```

Now: (there is still some work to be done with displaying these nicely)

```julia
julia> s = SparseArrays.sparse([1 2; 3 4])
2×2 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
 1  2
 3  4

julia> D = Diagonal([s, s])
2×2 Diagonal{SparseMatrixCSC{Int64,Int64},Vector{SparseMatrixCSC{Int64,Int64}}}:
 
⠛  ⋅ 
 ⋅   
⠛

julia> D[1, 1]
2×2 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
 1  2
 3  4

julia> D[1, 2]
2×2 SparseMatrixCSC{Int64,Int64} with 0 stored entries:
 ⋅  ⋅
 ⋅  ⋅

```