### PR TITLE
add a docstring for the isless method for AbstractVectors

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1925,6 +1925,11 @@ function cmp(A::AbstractVector, B::AbstractVector)
     return cmp(length(A), length(B))
 end
 
+"""
+    isless(A::AbstractVector, B::AbstractVector)
+
+Returns true when `A` is less than `B` in lexicographic order.
+"""
 isless(A::AbstractVector, B::AbstractVector) = cmp(A, B) < 0
 
 function (==)(A::AbstractArray, B::AbstractArray)


### PR DESCRIPTION
There is already one for `isless(::Tuple,::Tuple)`. See [this discussion](https://discourse.julialang.org/t/max-bug/48070).

The default lexicographic comparison is otherwise not documented.