### PR TITLE
Speed up `Dates.isleapyear` by reordering exprs

### DIFF
--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -156,7 +156,7 @@ function totaldays(y, m, d)
 end
 
 # If the year is divisible by 4, except for every 100 years, except for every 400 years
-isleapyear(y) = ((y % 4 == 0) && (y % 100 != 0)) || (y % 400 == 0)
+isleapyear(y) = (y % 4 == 0) && ((y % 100 != 0) || (y % 400 == 0))
 
 # Number of days in month
 const DAYSINMONTH = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)


### PR DESCRIPTION
In the common case that `y` is not factored by 4, this code performs one
comparison rather than two. The number of comparisons for the two other
cases are unchanged.