### PR TITLE
stop propagating the dict to precompile workers via repr

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1205,11 +1205,10 @@ end
 
 # this is called in the external process that generates precompiled package files
 function include_package_for_output(pkg::PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String},
-                                    concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String}, toml_cache::Dict{String, CachedTOMLDict})
+                                    concrete_deps::typeof(_concrete_dependencies), source::Union{Nothing,String})
     append!(empty!(Base.DEPOT_PATH), depot_path)
     append!(empty!(Base.DL_LOAD_PATH), dl_load_path)
     append!(empty!(Base.LOAD_PATH), load_path)
-    copy!(Base.TOML_CACHE.d, toml_cache)
     ENV["JULIA_LOAD_PATH"] = join(load_path, Sys.iswindows() ? ';' : ':')
     Base.ACTIVE_PROJECT[] = nothing
     Base._track_dependencies[] = true
@@ -1231,8 +1230,8 @@ function include_package_for_output(pkg::PkgId, input::String, depot_path::Vecto
     end
 end
 
-@assert precompile(include_package_for_output, (PkgId,String,Vector{String},Vector{String},Vector{String},typeof(_concrete_dependencies),Nothing, Dict{String,CachedTOMLDict}))
-@assert precompile(include_package_for_output, (PkgId,String,Vector{String},Vector{String},Vector{String},typeof(_concrete_dependencies),String, Dict{String,CachedTOMLDict}))
+@assert precompile(include_package_for_output, (PkgId,String,Vector{String},Vector{String},Vector{String},typeof(_concrete_dependencies),Nothing))
+@assert precompile(include_package_for_output, (PkgId,String,Vector{String},Vector{String},Vector{String},typeof(_concrete_dependencies),String))
 
 const PRECOMPILE_TRACE_COMPILE = Ref{String}()
 function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_deps::typeof(_concrete_dependencies), show_errors::Bool = true)
@@ -1268,7 +1267,7 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_d
     # write data over stdin to avoid the (unlikely) case of exceeding max command line size
     write(io.in, """
         Base.include_package_for_output($(pkg_str(pkg)), $(repr(abspath(input))), $(repr(depot_path)), $(repr(dl_load_path)),
-            $(repr(load_path)), $deps, $(repr(source_path(nothing))), $(repr(TOML_CACHE.d)))
+            $(repr(load_path)), $deps, $(repr(source_path(nothing))))
         """)
     close(io.in)
     return io


### PR DESCRIPTION
I completely misjudged the cost of `repr` on a heavily nested dict:

```
julia> using BenchmarkTools

julia> Base.parsed_toml("/home/kc/.julia/environments/v1.6/Manifest.toml");

julia> @btime repr(d);
  112.659 ms (32433 allocations: 7.35 MiB)
```

waaat(!!??).

With that time for `repr`, we just have to stop propagating the dict to the workers via this method. At least the workers will just parse the toml dict once each.

Noticed by @ianshmean when his parallel precompile PR in Pkg started lagging.

The culprit seems to be

```
  155 @Base/show.jl:763; show(io::IOBuffer, x::Type)
  ╎    ╎    ╎    ╎    ╎    ╎    155 @Base/show.jl:637; show_typealias(io::IOBuffer, x::Type)
  ╎    ╎    ╎    ╎    ╎    ╎     1   @Base/show.jl:546; make_typealias(x::Type)
 1╎    ╎    ╎    ╎    ╎    ╎    ╎ 1   @Base/reflection.jl:801; uniontypes(x::Any)
  ╎    ╎    ╎    ╎    ╎    ╎     64  @Base/show.jl:551; make_typealias(x::Type)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎ 64  @Base/reflection.jl:98; names
29╎    ╎    ╎    ╎    ╎    ╎    ╎  64  @Base/reflection.jl:98; #names#10
  ╎    ╎    ╎    ╎    ╎    ╎    ╎   35  @Base/sort.jl:735; sort!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    35  @Base/sort.jl:747; #sort!#8
```

which I'm guessing is the new fancy type alias printing.

We could perhaps go via `TOML.print`:

```
julia> @btime sprint(TOML.print, d);
  2.135 ms (20723 allocations: 994.95 KiB)
```

or serialization

```
julia> @btime serialize(IOBuffer(), d)
  409.462 μs (2913 allocations: 200.86 KiB)
```
but that can be a follow-up (neither of these are available in Base so it isn't trivial to swap).

Edit: Fun fact, `names` gets called 308 times for this `repr`.