### PR TITLE
Correct `SparseMatrixCSC` supertype in docs

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -17,7 +17,7 @@ type of the stored values, and `Ti` is the integer type for storing column point
 row indices. The internal representation of `SparseMatrixCSC` is as follows:
 
 ```julia
-struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
+struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrixCSC{Tv,Ti}
     m::Int                  # Number of rows
     n::Int                  # Number of columns
     colptr::Vector{Ti}      # Column j is in colptr[j]:(colptr[j+1]-1)


### PR DESCRIPTION
Should not be `AbstractSparseMatrixCSC` the correct supertype for `SparseMatrixCSC`?

See: https://github.com/JuliaLang/julia/blob/381693d3dfc9b7072707f6d544f82f6637fc5e7c/stdlib/SparseArrays/src/sparsematrix.jl#L19