### PR TITLE
Add missing variables to `LibCURL_jll`

### DIFF
--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -6,6 +6,9 @@ module LibCURL_jll
 
 using Libdl
 
+const PATH_list = String[]
+const LIBPATH_list = String[]
+
 export libcurl
 
 # These get calculated in __init__()


### PR DESCRIPTION
@staticfloat I think we can safely set thee variables to the empty set?

@quinnj can you please test `MySQL.jl` on this branch?