### PR TITLE
doc: at-(s)printf: add some spacing to doctests and an additional x-ref.

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -772,23 +772,29 @@ Print `args` using C `printf` style format specification string.
 Optionally, an `IO` may be passed as the first argument to redirect output.
 
 # Examples
-
 ```jldoctest
 julia> @printf "Hello %s" "world"
 Hello world
+
 julia> @printf "Scientific notation %e" 1.234
 Scientific notation 1.234000e+00
+
 julia> @printf "Scientific notation three digits %.3e" 1.23456
 Scientific notation three digits 1.235e+00
+
 julia> @printf "Decimal two digits %.2f" 1.23456
 Decimal two digits 1.23
+
 julia> @printf "Padded to length 5 %5i" 123
 Padded to length 5   123
+
 julia> @printf "Padded with zeros to length 6 %06i" 123
 Padded with zeros to length 6 000123
+
 julia> @printf "Use shorter of decimal or scientific %g %g" 1.23 12300000.0
 Use shorter of decimal or scientific 1.23 1.23e+07
 ```
+
 For a systematic specification of the format, see [here](https://www.cplusplus.com/reference/cstdio/printf/).
 See also: [`@sprintf`](@ref).
 
@@ -800,9 +806,10 @@ string further away from zero is chosen.
 
 # Examples
 ```jldoctest
-julia> @printf("%f %F %f %F\\n", Inf, Inf, NaN, NaN)
-Inf Inf NaN NaN\n
-julia> @printf "%.0f %.1f %f\\n" 0.5 0.025 -0.0078125
+julia> @printf("%f %F %f %F", Inf, Inf, NaN, NaN)
+Inf Inf NaN NaN
+
+julia> @printf "%.0f %.1f %f" 0.5 0.025 -0.0078125
 0 0.0 -0.007812
 ```
 """
@@ -821,7 +828,8 @@ end
 """
     @sprintf("%Fmt", args...)
 
-Return `@printf` formatted output as string.
+Return [`@printf`](@ref) formatted output as string.
+
 # Examples
 ```jldoctest
 julia> @sprintf "this is a %s %15.1f" "test" 34.567


### PR DESCRIPTION
Follow up to  #37980. While technically there are no newlines in a real REPL session this makes it easier to read.