### PR TITLE
Add `@simd` to `copyto_unaliased!` loops

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1023,7 +1023,7 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
         else
             # Dual-index implementation
             i = idf - 1
-            @inbounds @simd for a in src
+            @inbounds for a in src
                 dest[i+=1] = a
             end
         end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1017,13 +1017,13 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
     if deststyle isa IndexLinear
         if srcstyle isa IndexLinear
             # Single-index implementation
-            @inbounds for i in srcinds
+            @inbounds @simd for i in srcinds
                 dest[i + Δi] = src[i]
             end
         else
             # Dual-index implementation
             i = idf - 1
-            @inbounds for a in src
+            @inbounds @simd for a in src
                 dest[i+=1] = a
             end
         end
@@ -1031,8 +1031,8 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
         iterdest, itersrc = eachindex(dest), eachindex(src)
         if iterdest == itersrc
             # Shared-iterator implementation
-            for I in iterdest
-                @inbounds dest[I] = src[I]
+            @inbounds @simd for I in iterdest
+                dest[I] = src[I]
             end
         else
             # Dual-iterator implementation


### PR DESCRIPTION
As suggested here: https://discourse.julialang.org/t/deferred-shape-arrays/48177/10, this should speed up copying from `ReshapedArray`s.

Tests, before:
```
julia> A = rand(2000); B = zeros(100,20);

julia> @btime $B .= reshape($A, (100, 20));
  263.395 ns (1 allocation: 64 bytes)

julia> @btime $B .= Base.ReshapedArray($A, (100, 20), ());
  944.538 ns (0 allocations: 0 bytes)

julia> @btime $B' .= reshape($A, (100, 20))';
  789.962 ns (1 allocation: 64 bytes)

julia> @btime $B' .= Base.ReshapedArray($A, (100, 20), ())';
  635.908 ns (0 allocations: 0 bytes)
```
after:
```
julia> A = rand(2000); B = zeros(100,20);

julia> @btime $B .= reshape($A, (100, 20));
  291.971 ns (1 allocation: 64 bytes)

julia> @btime $B .= Base.ReshapedArray($A, (100, 20), ());  # much improved
  182.660 ns (0 allocations: 0 bytes)

julia> @btime $B' .= reshape($A, (100, 20))';
  759.545 ns (1 allocation: 64 bytes)

julia> @btime $B' .= Base.ReshapedArray($A, (100, 20), ())'; # hmm, really?
  681.230 ns (0 allocations: 0 bytes)
```