### PR TITLE
Fix sparse Subarray fill!

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2588,7 +2588,7 @@ function Base.fill!(V::SubArray{Tv, <:Any, <:AbstractSparseMatrixCSC{Tv}, <:Tupl
     end
 end
 """
-Helper method for immediately preceding setindex! method. For all (i,j) such that i in I and
+Helper method for immediately preceding fill! method. For all (i,j) such that i in I and
 j in J, assigns zero to A[i,j] if A[i,j] is a presently-stored entry, and otherwise does nothing.
 """
 function _spsetz_setindex!(A::AbstractSparseMatrixCSC,
@@ -2624,7 +2624,7 @@ function _spsetz_setindex!(A::AbstractSparseMatrixCSC,
     end
 end
 """
-Helper method for immediately preceding setindex! method. For all (i,j) such that i in I
+Helper method for immediately preceding fill! method. For all (i,j) such that i in I
 and j in J, assigns x to A[i,j] if A[i,j] is a presently-stored entry, and allocates and
 assigns x to A[i,j] if A[i,j] is not presently stored.
 """
@@ -2671,7 +2671,7 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
 
                 while true
                     old_row = rowval[old_ptr]
-                    new_row = I[new_ptr]
+                    new_row = _getrowinds(I, new_ptr)
                     if old_row < new_row
                         rowvalA[rowidx] = old_row
                         nzvalA[rowidx] = nzval[old_ptr]
@@ -2704,7 +2704,7 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
                                 resize!(nzvalA, nnzA)
                             end
                             r = rowidx:(rowidx+(new_stop-new_ptr))
-                            rowvalA[r] .= I[new_ptr:new_stop]
+                            rowvalA[r] .= _getrowinds(I, new_ptr:new_stop)
                             for rr in r
                                 nzvalA[rr] = x
                             end
@@ -2738,6 +2738,9 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
     end
     return A
 end
+
+_getrowinds(I::Number, range) = I
+_getrowinds(I::AbstractVector{<:Integer}, range) = I[range]
 
 # Nonscalar A[I,J] = B: Convert B to a SparseMatrixCSC of the appropriate shape first
 _to_same_csc(::AbstractSparseMatrixCSC{Tv, Ti}, V::AbstractMatrix, I...) where {Tv,Ti} = convert(SparseMatrixCSC{Tv,Ti}, V)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2738,7 +2738,8 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
     end
     return A
 end
-
+# ignore indexing into a Number by range
+_getrowinds(I::Number, range) = I
 _getrowinds(I::AbstractVector{<:Integer}, range) = I[range]
 
 # Nonscalar A[I,J] = B: Convert B to a SparseMatrixCSC of the appropriate shape first

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2704,7 +2704,7 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
                                 resize!(nzvalA, nnzA)
                             end
                             r = rowidx:(rowidx+(new_stop-new_ptr))
-                            rowvalA[r] .= I <: Number ? I : I[new_ptr:new_stop]
+                            rowvalA[r] .= I isa Number ? I : I[new_ptr:new_stop]
                             for rr in r
                                 nzvalA[rr] = x
                             end

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2671,7 +2671,7 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
 
                 while true
                     old_row = rowval[old_ptr]
-                    new_row = _getrowinds(I, new_ptr)
+                    new_row = I[new_ptr]
                     if old_row < new_row
                         rowvalA[rowidx] = old_row
                         nzvalA[rowidx] = nzval[old_ptr]
@@ -2739,7 +2739,6 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
     return A
 end
 
-_getrowinds(I::Number, range) = I
 _getrowinds(I::AbstractVector{<:Integer}, range) = I[range]
 
 # Nonscalar A[I,J] = B: Convert B to a SparseMatrixCSC of the appropriate shape first

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2740,7 +2740,7 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
 end
 # ignore indexing into a Number by range
 _getrowinds(I::Number, range) = I
-_getrowinds(I::AbstractVector{<:Integer}, range) = I[range]
+_getrowinds(I::AbstractVector{<:Integer}, range) = @inbounds I[range]
 
 # Nonscalar A[I,J] = B: Convert B to a SparseMatrixCSC of the appropriate shape first
 _to_same_csc(::AbstractSparseMatrixCSC{Tv, Ti}, V::AbstractMatrix, I...) where {Tv,Ti} = convert(SparseMatrixCSC{Tv,Ti}, V)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2704,7 +2704,7 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
                                 resize!(nzvalA, nnzA)
                             end
                             r = rowidx:(rowidx+(new_stop-new_ptr))
-                            rowvalA[r] .= _getrowinds(I, new_ptr:new_stop)
+                            rowvalA[r] .= I <: Number ? I : I[new_ptr:new_stop]
                             for rr in r
                                 nzvalA[rr] = x
                             end
@@ -2738,9 +2738,6 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
     end
     return A
 end
-# ignore indexing into a Number by range
-_getrowinds(I::Number, range) = I
-_getrowinds(I::AbstractVector{<:Integer}, range) = @inbounds I[range]
 
 # Nonscalar A[I,J] = B: Convert B to a SparseMatrixCSC of the appropriate shape first
 _to_same_csc(::AbstractSparseMatrixCSC{Tv, Ti}, V::AbstractMatrix, I...) where {Tv,Ti} = convert(SparseMatrixCSC{Tv,Ti}, V)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1057,6 +1057,12 @@ end
     @test a[1,:] == sparse([1; 1; 3:10])
     a[1:0,2] .= 1
     @test a[:,2] == sparse([1:10;])
+    a[1,2:3] .= 1
+    @test a[1,:] == sparse([1; 1; 1; 4:10])
+    a[2:4,2] .= 1
+    @test a[:,2] == sparse([1; 1; 1; 1; 5:10])
+    a[2:4,2:3] .= 3
+    @test nnz(a) == 22
 
     @test_throws BoundsError a[:,11] = spzeros(10,1)
     @test_throws BoundsError a[11,:] = spzeros(1,10)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1057,12 +1057,12 @@ end
     @test a[1,:] == sparse([1; 1; 3:10])
     a[1:0,2] .= 1
     @test a[:,2] == sparse([1:10;])
-    a[1,2:3] .= 1
-    @test a[1,:] == sparse([1; 1; 1; 4:10])
-    a[2:4,2] .= 1
-    @test a[:,2] == sparse([1; 1; 1; 1; 5:10])
-    a[2:4,2:3] .= 3
-    @test nnz(a) == 22
+    a[3,2:3] .= 1 # one stored, one new value
+    @test a[3,2:3] == sparse([1; 1])
+    a[5:6,1] .= 1 # only new values
+    @test a[:,1] == sparse([1; 0; 0; 0; 1; 1; 0; 0; 0; 0;])
+    a[2:4,2:3] .= 3 # two ranges
+    @test nnz(a) == 24
 
     @test_throws BoundsError a[:,11] = spzeros(10,1)
     @test_throws BoundsError a[11,:] = spzeros(1,10)


### PR DESCRIPTION
Closes #38009.

This should actually improve performance in broadcasted scalar assignments to sparse matrices (`dest .= val`). The functionality touched here hasn't been called since #26347, which had a missing `<:` and hided the function in dispatch, which was fixed in #37856, but revealed #38009. Also, #26347 added support for `Integer`s, whereas the original code was written only for `I::AbstractVector{<:Integer}`, which included indexing into `I`. I haven't replaced the obviously scalar indexing calls by calls to the helper function, to allow for the detection of any flaws in the indexing logic (it's pretty involved, I must admit). You can index into a number, but only with index `1`. So, if there were scalar indexing calls with helper indices other than `1`, we should still see it, but tests seem to pass locally.