### PR TITLE
Add environment variable to override MAX_NUM_PRECOMPILE_FILES

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -419,6 +419,9 @@ function __init__()
     init_load_path()
     init_active_project()
     append!(empty!(_sysimage_modules), keys(loaded_modules))
+    if haskey(ENV, "JULIA_MAX_NUM_PRECOMPILE_FILES")
+        MAX_NUM_PRECOMPILE_FILES[] = parse(Int, ENV["JULIA_MAX_NUM_PRECOMPILE_FILES"])
+    end
     nothing
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1250,7 +1250,7 @@ function compilecache(pkg::PkgId, cache::TOMLCache = TOMLCache(), show_errors::B
     return compilecache(pkg, path, cache, show_errors)
 end
 
-const MAX_NUM_PRECOMPILE_FILES = 10
+const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 
 function compilecache(pkg::PkgId, path::String, cache::TOMLCache = TOMLCache(), show_errors::Bool = true)
     # decide where to put the resulting cache file
@@ -1260,7 +1260,7 @@ function compilecache(pkg::PkgId, path::String, cache::TOMLCache = TOMLCache(), 
     if pkg.uuid !== nothing
         entrypath, entryfile = cache_file_entry(pkg)
         cachefiles = filter!(x -> startswith(x, entryfile * "_"), readdir(cachepath))
-        if length(cachefiles) >= MAX_NUM_PRECOMPILE_FILES
+        if length(cachefiles) >= MAX_NUM_PRECOMPILE_FILES[]
             idx = findmin(mtime.(joinpath.(cachepath, cachefiles)))[2]
             rm(joinpath(cachepath, cachefiles[idx]))
         end


### PR DESCRIPTION
This is for PkgEval, where we now cache precompilation files across a run. That requires bumping `MAX_NUM_PRECOMPILE_FILES` to be effective.