### PR TITLE
add `jit_total_bytes` for getting amount allocated by the JIT

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -74,6 +74,16 @@ function gc_live_bytes()
     Int(ccall(:jl_gc_live_bytes, Int64, ())) + num.allocd + num.deferred_alloc
 end
 
+"""
+    Base.jit_total_bytes()
+
+Return the total amount (in bytes) allocated by the just-in-time compiler
+for e.g. native code and data.
+"""
+function jit_total_bytes()
+    return Int(ccall(:jl_jit_total_bytes, Csize_t, ()))
+end
+
 # print elapsed time, return expression value
 const _mem_units = ["byte", "KiB", "MiB", "GiB", "TiB", "PiB"]
 const _cnt_units = ["", " k", " M", " G", " T", " P"]

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -738,6 +738,7 @@ class RTDyldMemoryManagerJL : public SectionMemoryManager {
     std::unique_ptr<ROAllocator<false>> ro_alloc;
     std::unique_ptr<ROAllocator<true>> exe_alloc;
     bool code_allocated;
+    size_t total_allocated;
 
 public:
     RTDyldMemoryManagerJL()
@@ -746,7 +747,8 @@ public:
           rw_alloc(),
           ro_alloc(),
           exe_alloc(),
-          code_allocated(false)
+          code_allocated(false),
+          total_allocated(0)
     {
 #ifdef _OS_LINUX_
         if (!ro_alloc && get_self_mem_fd() != -1) {
@@ -762,6 +764,7 @@ public:
     ~RTDyldMemoryManagerJL() override
     {
     }
+    size_t getTotalBytes() { return total_allocated; }
     void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
                           size_t Size) override;
 #if 0
@@ -829,6 +832,7 @@ uint8_t *RTDyldMemoryManagerJL::allocateCodeSection(uintptr_t Size,
     // allocating more than one code section can confuse libunwind.
     assert(!code_allocated);
     code_allocated = true;
+    total_allocated += Size;
     if (exe_alloc)
         return (uint8_t*)exe_alloc->alloc(Size, Alignment);
     return SectionMemoryManager::allocateCodeSection(Size, Alignment, SectionID,
@@ -841,6 +845,7 @@ uint8_t *RTDyldMemoryManagerJL::allocateDataSection(uintptr_t Size,
                                                     StringRef SectionName,
                                                     bool isReadOnly)
 {
+    total_allocated += Size;
     if (!isReadOnly)
         return (uint8_t*)rw_alloc.alloc(Size, Alignment);
     if (ro_alloc)
@@ -912,4 +917,9 @@ void *lookupWriteAddressFor(RTDyldMemoryManager *memmgr, void *rt_addr)
 RTDyldMemoryManager* createRTDyldMemoryManager()
 {
     return new RTDyldMemoryManagerJL();
+}
+
+size_t getRTDyldMemoryManagerTotalBytes(RTDyldMemoryManager *mm)
+{
+    return ((RTDyldMemoryManagerJL*)mm)->getTotalBytes();
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -871,6 +871,13 @@ std::string JuliaOJIT::getMangledName(const GlobalValue *GV)
     return getMangledName(GV->getName());
 }
 
+size_t getRTDyldMemoryManagerTotalBytes(RTDyldMemoryManager *mm);
+
+size_t JuliaOJIT::getTotalBytes() const
+{
+    return getRTDyldMemoryManagerTotalBytes(MemMgr.get());
+}
+
 JuliaOJIT *jl_ExecutionEngine;
 
 // destructively move the contents of src into dest
@@ -1106,4 +1113,10 @@ static uint64_t getAddressForFunction(StringRef fname)
 void add_named_global(StringRef name, void *addr)
 {
     jl_ExecutionEngine->addGlobalMapping(name, (uint64_t)(uintptr_t)addr);
+}
+
+extern "C" JL_DLLEXPORT
+size_t jl_jit_total_bytes(void)
+{
+    return jl_ExecutionEngine->getTotalBytes();
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -199,6 +199,7 @@ public:
     StringRef getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *codeinst);
     const DataLayout& getDataLayout() const;
     const Triple& getTargetTriple() const;
+    size_t getTotalBytes() const;
 private:
     std::string getMangledName(StringRef Name);
     std::string getMangledName(const GlobalValue *GV);


### PR DESCRIPTION
This can be useful for analyzing memory use, accounting for where all the space is going.