### PR TITLE
Fix a possible typo in renumber_ir_elements!

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -450,7 +450,7 @@ function renumber_ir_elements!(body::Vector{Any}, ssachangemap::Vector{Int}, lab
             ssachangemap[i] += ssachangemap[i - 1]
         end
     end
-    if labelchangemap[end] == 0 && ssachangemap[end] == 0
+    if labelchangemap[end] == 0 || ssachangemap[end] == 0
         return
     end
     for i = 1:length(body)


### PR DESCRIPTION
#34254 [changed](https://github.com/JuliaLang/julia/commit/7ad2ea5afb823ec4a3162150d13b82d5a36d6eaa#diff-e04705952aec52ac6b24bd37c25cd11b8ba7d72b488b645bd5d2c104f79ccaabL411-R413)

https://github.com/JuliaLang/julia/blob/dd79e7744ba5a94a410217994af25f1a04d34e70/base/compiler/optimize.jl#L411

to

https://github.com/JuliaLang/julia/blob/7ad2ea5afb823ec4a3162150d13b82d5a36d6eaa/base/compiler/optimize.jl#L411-L413

If this part was meant to be an NFC, maybe it should be `labelchangemap[end] == 0 || ssachangemap[end] == 0` instead? Or was it actually a bug fix?
