### PR TITLE
Let Float16 participate in at-fastmath.

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -158,7 +158,7 @@ end
 
 # Basic arithmetic
 
-const FloatTypes = Union{Float32,Float64}
+const FloatTypes = Union{Float16,Float32,Float64}
 
 sub_fast(x::FloatTypes) = neg_float_fast(x)
 

--- a/src/llvm-demote-float16.cpp
+++ b/src/llvm-demote-float16.cpp
@@ -57,6 +57,11 @@ bool DemoteFloat16Pass::runOnFunction(Function &F)
                 continue;
             }
 
+            // skip @fastmath operations
+            // TODO: more fine-grained check (afn?)
+            if (I.isFast())
+                continue;
+
             IRBuilder<> builder(&I);
 
             // extend Float16 operands to Float32

--- a/test/llvmpasses/fastmath.jl
+++ b/test/llvmpasses/fastmath.jl
@@ -26,9 +26,9 @@ foo(x::T,y::T) where T = x-y == zero(T)
 # FINAL: %2 = fpext half %0 to float
 # FINAL: %3 = fpext half %1 to float
 # FINAL: fsub half %2, %3
-emit(foo, Tuple{Float16,Float16})
+emit(foo, Float16, Float16)
 
 @fastmath foo(x::T,y::T) where T = x-y == zero(T)
 # LOWER: fsub fast half %0, %1
 # FINAL: fsub fast half %0, %1
-emit(foo, Tuple{Float16,Float16})
+emit(foo, Float16, Float16)

--- a/test/llvmpasses/fastmath.jl
+++ b/test/llvmpasses/fastmath.jl
@@ -16,3 +16,19 @@ import Base.FastMath
 
 # CHECK: call fast float @llvm.sqrt.f32(float %0)
 emit(FastMath.sqrt_fast, Float32)
+
+
+# Float16 operations should be performed as Float32, unless @fastmath is specified
+# TODO: this is not true for platforms that natively support Float16
+
+foo(x::T,y::T) where T = x-y == zero(T)
+# LOWER: fsub half %0, %1
+# FINAL: %2 = fpext half %0 to float
+# FINAL: %3 = fpext half %1 to float
+# FINAL: fsub half %2, %3
+emit(foo, Tuple{Float16,Float16})
+
+@fastmath foo(x::T,y::T) where T = x-y == zero(T)
+# LOWER: fsub fast half %0, %1
+# FINAL: fsub fast half %0, %1
+emit(foo, Tuple{Float16,Float16})


### PR DESCRIPTION
Also teaches the new Float16-to-Float32 pass about fast math (even though there's no flag that cleanly fits its behavior):

```llvm
julia> foo(x::T,y::T) where T = x-y == zero(T)
foo (generic function with 1 method)

julia> code_llvm(foo, Tuple{Float16,Float16})
;  @ REPL[1]:1 within `foo'
; Function Attrs: sspstrong
define i8 @julia_foo_859(half %0, half %1) #0 {
top:
; ┌ @ float.jl:327 within `-'
   %2 = fpext half %0 to float
   %3 = fpext half %1 to float
   %4 = fsub float %2, %3
   %5 = fptrunc float %4 to half
; └
; ┌ @ float.jl:363 within `=='
   %6 = fpext half %5 to float
   %7 = fcmp oeq float %6, 0.000000e+00
; └
  %8 = zext i1 %7 to i8
  ret i8 %8
}

julia> @fastmath foo(x::T,y::T) where T = x-y == zero(T)
foo (generic function with 1 method)

julia> code_llvm(foo, Tuple{Float16,Float16})
;  @ REPL[3]:1 within `foo'
; Function Attrs: sspstrong
define i8 @julia_foo_1009(half %0, half %1) #0 {
top:
; ┌ @ fastmath.jl:166 within `sub_fast'
   %2 = fsub fast half %0, %1
; └
; ┌ @ fastmath.jl:181 within `eq_fast'
   %3 = fcmp fast oeq half %2, 0xH0000
; └
  %4 = zext i1 %3 to i8
  ret i8 %4
}
```