### PR TITLE
Add options for varinfo() to show all and imported, sort by each column, search modules recursively

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -42,9 +42,7 @@ function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported
              end
              for v in sort!(names(m, all = all, imported = imported)) if isdefined(m, v) && occursin(pattern, string(v)) ]
     if sort_size
-        sizes = map(r->r[4], rows)
-        p = sortperm(sizes, rev=true)
-        rows = rows[p]
+        rows = sort!(rows, by=r->r[4], rev=true)
     end
     pushfirst!(rows, Any["name", "size", "summary"])
 

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -30,23 +30,44 @@ The memory consumption estimate is an approximate lower bound on the size of the
 
 - `all` : also list non-exported objects defined in the module, deprecated objects, and compiler-generated objects.
 - `imported` : also list objects explicitly imported from other modules.
+- `recursive` : recursively include objects in sub-modules, observing the same settings in each.
 - `sortby` : the column to sort results by. Options are `:name` (default), `:size`, and `:summary`.
 """
-function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name)
+function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name, recursive::Bool = false)
     @assert sortby in [:name, :size, :summary] "Unrecognized `sortby` value `:$sortby`. Possible options are `:name`, `:size`, and `:summary`"
-    rows =
-        Any[ let value = getfield(m, v)
-                 Any[string(v),
-                     (value===Base || value===Main || value===Core ? "" : format_bytes(summarysize(value))),
-                     summary(value),
-                     summarysize(value)]
-             end
-             for v in sort!(names(m, all = all, imported = imported)) if isdefined(m, v) && occursin(pattern, string(v)) ]
-    if sortby != :name
-        col = sortby == :size ? 4 : 3 # if it's not :size, it must be :summary here
-        reverse = sortby == :size ? true : false
-        rows = sort!(rows, by=r->r[col], rev=reverse)
+    function _populate_rows(m2::Module, allrows, include_self::Bool, prep::String)
+        newrows = Any[
+            let
+                value = getfield(m2, v)
+                ssize_str, ssize = if value===Base || value===Main || value===Core
+                    ("", typemax(Int))
+                else
+                    ss = summarysize(value)
+                    (format_bytes(ss), ss)
+                end
+                Any[string(prep, v), ssize_str, summary(value), ssize]
+            end
+            for v in names(m2; all, imported)
+            if (string(v) != split(string(m2), ".")[end] || include_self) && isdefined(m2, v) && occursin(pattern, string(v)) ]
+        append!(allrows, newrows)
+        if recursive
+            for row in newrows
+                if row[3] == "Module" && !in(split(row[1], ".")[end], [split(string(m2), ".")[end], "Base", "Main", "Core"])
+                    _populate_rows(getfield(m2, Symbol(split(row[1], ".")[end])), allrows, false, prep * "$(row[1]).")
+                end
+            end
+        end
+        return allrows
     end
+    rows = _populate_rows(m, Vector{Any}[], true, "")
+    if sortby == :name
+        col, reverse = 1, false
+    elseif sortby == :size
+        col, reverse = 4, true
+    elseif sortby == :summary
+        col, reverse = 3, false
+    end
+    rows = sort!(rows, by=r->r[col], rev=reverse)
     pushfirst!(rows, Any["name", "size", "summary"])
 
     return Markdown.MD(Any[Markdown.Table(map(r->r[1:3], rows), Symbol[:l, :r, :l])])

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -180,8 +180,11 @@ let v = repr(varinfo(_test_varinfo_, imported = true))
     @test !occursin("not_exp", v)
     @test occursin("@test", v)
 end
-let v = repr(varinfo(_test_varinfo_, all=true, sort_size = true))
+let v = repr(varinfo(_test_varinfo_, all = true, sortby = :size))
     @test findfirst("z_larger", v)[1] < findfirst("a_smaller", v)[1] # check for size order
+end
+let v = repr(varinfo(_test_varinfo_, sortby = :summary))
+    @test findfirst("Float64", v)[1] < findfirst("Module", v)[1] # check for summary order
 end
 
 # Issue 14173

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -153,38 +153,50 @@ mktemp() do f, io
 end
 
 module _test_varinfo_
+module inner_mod
+inner_x = 1
+end
 import Test: @test
-export exported
-exported = 1.0
-not_exp = 1.0
+export x_exported
+x_exported = 1.0
+y_not_exp = 1.0
 z_larger = Vector{Float64}(undef, 3)
 a_smaller = Vector{Float64}(undef, 2)
 end
+
+using Test
+
 @test repr(varinfo(Main, r"^$")) == """
 | name | size | summary |
 |:---- | ----:|:------- |
 """
 let v = repr(varinfo(_test_varinfo_))
-    @test occursin("| exported       |   8 bytes | Float64 |", v)
-    @test !occursin("not_exp", v)
+    @test occursin("| x_exported     |   8 bytes | Float64 |", v)
+    @test !occursin("y_not_exp", v)
     @test !occursin("@test", v)
+    @test !occursin("inner_x", v)
 end
 let v = repr(varinfo(_test_varinfo_, all = true))
-    @test occursin("exported", v)
-    @test occursin("not_exp", v)
+    @test occursin("x_exported", v)
+    @test occursin("y_not_exp", v)
     @test !occursin("@test", v)
     @test findfirst("a_smaller", v)[1] < findfirst("z_larger", v)[1] # check for alphabetical
+    @test !occursin("inner_x", v)
 end
 let v = repr(varinfo(_test_varinfo_, imported = true))
-    @test occursin("exported", v)
-    @test !occursin("not_exp", v)
+    @test occursin("x_exported", v)
+    @test !occursin("y_not_exp", v)
     @test occursin("@test", v)
+    @test !occursin("inner_x", v)
 end
 let v = repr(varinfo(_test_varinfo_, all = true, sortby = :size))
     @test findfirst("z_larger", v)[1] < findfirst("a_smaller", v)[1] # check for size order
 end
 let v = repr(varinfo(_test_varinfo_, sortby = :summary))
     @test findfirst("Float64", v)[1] < findfirst("Module", v)[1] # check for summary order
+end
+let v = repr(varinfo(_test_varinfo_, all = true, recursive = true))
+    @test occursin("inner_x", v)
 end
 
 # Issue 14173


### PR DESCRIPTION
Expands the functionality of `varinfo()` with kwargs:

- `all` : also list non-exported objects defined in the module, deprecated objects, and compiler-generated objects.
- `imported` : also list objects explicitly imported from other modules.
- `sortby` : the column to sort results by. Options are `:name` (default), `:size`, and `:summary`.

Edit: 
- `recursive` : recursively include objects in sub-modules, observing the same settings in each.
See https://github.com/JuliaLang/julia/pull/38042#issuecomment-714275219

The first two arcs match the kwargs from [`names`](https://docs.julialang.org/en/v1/base/base/#Base.names)

```
julia> module Foo
       import Logging: @info
       const foo_const = rand(1000000)
       foo_var =         rand(1000000)
       foo_func() =      rand(1000000)
       end
Main.Foo

julia> varinfo(Foo)
  name       size summary
  –––– –––––––––– –––––––
  Foo  15.262 MiB Module 

julia> varinfo(Foo, all=true)
  name            size summary                        
  ––––––––– –––––––––– –––––––––––––––––––––––––––––––
  #eval      172 bytes DataType                       
  #foo_func  172 bytes DataType                       
  #include   172 bytes DataType                       
  Foo       15.262 MiB Module                         
  eval         0 bytes typeof(Main.Foo.eval)          
  foo_const  7.629 MiB 1000000-element Vector{Float64}
  foo_func     0 bytes typeof(Main.Foo.foo_func)      
  foo_var    7.629 MiB 1000000-element Vector{Float64}
  include      0 bytes typeof(Main.Foo.include)   

julia> varinfo(Foo, imported=true)
  name        size summary                     
  ––––– –––––––––– ––––––––––––––––––––––––––––
  @info    0 bytes Base.CoreLogging.var"#@info"
  Foo   15.262 MiB Module      

julia> varinfo(Foo, all=true, sortby=:size)
  name            size summary                        
  ––––––––– –––––––––– –––––––––––––––––––––––––––––––
  Foo       15.262 MiB Module                         
  foo_const  7.629 MiB 1000000-element Vector{Float64}
  foo_var    7.629 MiB 1000000-element Vector{Float64}
  #eval      172 bytes DataType                       
  #foo_func  172 bytes DataType                       
  #include   172 bytes DataType                       
  eval         0 bytes typeof(Main.Foo.eval)          
  foo_func     0 bytes typeof(Main.Foo.foo_func)      
  include      0 bytes typeof(Main.Foo.include)    

julia> varinfo(Foo, all=true, sortby=:summary)
  name            size summary                        
  ––––––––– –––––––––– –––––––––––––––––––––––––––––––
  foo_const  7.629 MiB 1000000-element Vector{Float64}
  foo_var    7.629 MiB 1000000-element Vector{Float64}
  #eval      172 bytes DataType                       
  #foo_func  172 bytes DataType                       
  #include   172 bytes DataType                       
  Foo       15.262 MiB Module                         
  eval         0 bytes typeof(Main.Foo.eval)          
  foo_func     0 bytes typeof(Main.Foo.foo_func)      
  include      0 bytes typeof(Main.Foo.include)       
```