### PR TITLE
[RFC] allow specializing Random.default_rng(X) on a "distribution" X

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -348,6 +348,9 @@ seed!(seed::Union{Integer,Vector{UInt32}}) = seed!(default_rng(), seed)
 
 ### Global RNG
 
+default_rng(X) = default_rng()
+default_rng(::Type{X}) where {X} = default_rng()
+
 const THREAD_RNGs = MersenneTwister[]
 @inline default_rng() = default_rng(Threads.threadid())
 @noinline function default_rng(tid::Int)

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -255,13 +255,13 @@ rand(rng::AbstractRNG, X)                                           = rand(rng, 
 rand(rng::AbstractRNG, X::Dims)                                     = rand(rng, Sampler(rng, X, Val(1)))
 rand(rng::AbstractRNG=default_rng(), ::Type{X}=Float64) where {X} = rand(rng, Sampler(rng, X, Val(1)))::X
 
-rand(X)                   = rand(default_rng(), X)
-rand(::Type{X}) where {X} = rand(default_rng(), X)
+rand(X)                   = rand(default_rng(X), X)
+rand(::Type{X}) where {X} = rand(default_rng(X), X)
 
 #### arrays
 
-rand!(A::AbstractArray{T}, X) where {T}             = rand!(default_rng(), A, X)
-rand!(A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(default_rng(), A, X)
+rand!(A::AbstractArray{T}, X) where {T}             = rand!(default_rng(X), A, X)
+rand!(A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(default_rng(X), A, X)
 
 rand!(rng::AbstractRNG, A::AbstractArray{T}, X) where {T}             = rand!(rng, A, Sampler(rng, X))
 rand!(rng::AbstractRNG, A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(rng, A, Sampler(rng, X))
@@ -277,7 +277,7 @@ rand(r::AbstractRNG, dims::Integer...) = rand(r, Float64, Dims(dims))
 rand(                dims::Integer...) = rand(Float64, Dims(dims))
 
 rand(r::AbstractRNG, X, dims::Dims)  = rand!(r, Array{gentype(X)}(undef, dims), X)
-rand(                X, dims::Dims)  = rand(default_rng(), X, dims)
+rand(                X, dims::Dims)  = rand(default_rng(X), X, dims)
 
 rand(r::AbstractRNG, X, d::Integer, dims::Integer...) = rand(r, X, Dims((d, dims...)))
 rand(                X, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...)))
@@ -286,7 +286,7 @@ rand(                X, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
 
 rand(r::AbstractRNG, ::Type{X}, dims::Dims) where {X} = rand!(r, Array{X}(undef, dims), X)
-rand(                ::Type{X}, dims::Dims) where {X} = rand(default_rng(), X, dims)
+rand(                ::Type{X}, dims::Dims) where {X} = rand(default_rng(X), X, dims)
 
 rand(r::AbstractRNG, ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(r, X, Dims((d, dims...)))
 rand(                ::Type{X}, d::Integer, dims::Integer...) where {X} = rand(X, Dims((d, dims...)))


### PR DESCRIPTION
The use-case is having a non-Julia library (e.g. in C) providing
random generation of certain objects (`X`), but using their internal
RNG. For such objects, the current `default_rng()` doesn't work, as
said library can't use it (MersenneTwister). This means that the
`Random` module doesn't support such cases.

The idea here is that on the Julia side, a "facade" RNG type can be
created to signal using the internal library RNG, and `default_rng(X)`
can return this RNG.

This would look like:
```julia
struct MyRNG <: AbstractRNG end

Random.default_rng(::Type{X}) = MyRNG()

rand(::MyRNG, ::SamplerType{X}) = MyLib.generate_random_X()
```

So the `rand` method is defined with the usual signature, but thanks
to the `default_rng` specialization, the `Random` module provides
`rand(X)`, `rand(X, 3)` etc.