### PR TITLE
[build] Fix `full-source-dist` downloading LibOSXUnwind on non-OSX platforms

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -180,7 +180,17 @@ install: $(addprefix install-, $(DEP_LIBS))
 cleanall: $(addprefix clean-, $(DEP_LIBS))
 distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)
-getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-osxunwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-nghttp2 get-curl get-libgit2 get-libwhich
+getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-nghttp2 get-curl get-libgit2 get-libwhich
+
+# If we're building for MacOS, no matter what, `getall` should include `osxunwind`
+ifeq ($(OS),Darwin)
+getall: get-osxunwind
+endif
+
+# Same if we're building a purely-source archive, always include `osxunwind`
+ifeq ($(USE_BINARYBUILDER_OSXUNWIND),0)
+getall: get-osxunwind
+endif
 
 include $(SRCDIR)/llvm.mk
 include $(SRCDIR)/libuv.mk


### PR DESCRIPTION
In `deps/Makefile`, only add `get-osxunwind` to the list of `getall`
dependencies if we're running on MacOS.  Because we are generally using
BinaryBuilder-built dependencies when running `getall`, we'll fail with
a 404 error here if we attempt this.