### PR TITLE
println stream should match showerror

### DIFF
--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -206,7 +206,7 @@ julia> try
            catch
                for (exc, bt) in Base.catch_stack()
                    showerror(stdout, exc, bt)
-                   println()
+                   println(stdout)
                end
            end
        end


### PR DESCRIPTION
This is a minor "fix" but for consistency I feel that in the `catch_stack()` example `println()` should specify `stdout` since `showerror()` uses an output stream as well.  At least it will encourage people to do the "right thing" if they want to change the stream they are writing the stack trace to.  At least I don't see a downside to specifying it.