### PR TITLE
Make `static_show()` print valid identifiers

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -626,7 +626,10 @@ static size_t jl_static_show_x_sym_escaped(JL_STREAM *out, jl_sym_t *name) JL_NO
     size_t n = 0;
 
     char *sn = jl_symbol_name(name);
-    int hidden = strchr(sn, '#') != 0;
+    int hidden = 0;
+    if (!(jl_is_identifier(sn) || jl_is_operator(sn))) {
+        hidden = 1;
+    }
 
     if (hidden) {
         n += jl_printf(out, "var\"");

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -707,6 +707,9 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, "UnionAll");
     }
     else if (vt == jl_datatype_type) {
+        // typeof(v) == DataType, so v is a Type object.
+        // Types are printed as a fully qualified name, with parameters, e.g.
+        // `Base.Set{Int}`, and function types are printed as e.g. `typeof(Main.f)`
         jl_datatype_t *dv = (jl_datatype_t*)v;
         jl_sym_t *globname;
         int globfunc = is_globfunction(v, dv, &globname);
@@ -997,6 +1000,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_printf(out, ")");
     }
     else if (jl_function_type && jl_isa(v, (jl_value_t*)jl_function_type)) {
+        // v is function instance (an instance of a Function type).
         jl_datatype_t *dv = (jl_datatype_t*)vt;
         jl_sym_t *sym = dv->name->mt->name;
         char *sn = jl_symbol_name(sym);
@@ -1024,6 +1028,9 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         }
     }
     else if (jl_datatype_type && jl_is_datatype(vt)) {
+        // typeof(v) isa DataType, so v is an *instance of* a type that is a Datatype,
+        // meaning v is e.g. an instance of a struct. These are printed as a call to a
+        // type constructor, such as e.g. `Base.UnitRange{Int64}(start=1, stop=2)`
         int istuple = jl_is_tuple_type(vt), isnamedtuple = jl_is_namedtuple_type(vt);
         size_t tlen = jl_datatype_nfields(vt);
         if (isnamedtuple) {

--- a/test/show.jl
+++ b/test/show.jl
@@ -1338,6 +1338,7 @@ end
 
 # PR #38049
 struct var"#X#" end
+var"#f#"() = 2
 
 # (Just to make this test more sustainable,) we don't necesssarily need to test the exact
 # output format, just ensure that it prints at least the parts we expect:
@@ -1349,8 +1350,13 @@ struct var"#X#" end
     @testset for v in (
             var"#X#",
             var"#X#"(),
+            Vector,
             Vector{<:Any},
             Vector{var"#X#"},
+            +,
+            typeof(+),
+            var"#f#",
+            typeof(var"#f#"),
         )
         @test v == eval(Meta.parse(static_shown(v)))
     end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1336,6 +1336,26 @@ end
 
 @test static_shown(QuoteNode(:x)) == ":(:x)"
 
+# PR #38049
+struct var"#X#" end
+
+# (Just to make this test more sustainable,) we don't necesssarily need to test the exact
+# output format, just ensure that it prints at least the parts we expect:
+@test occursin(".var\"#X#\"", static_shown(var"#X#"))  # Leading `.` tests it printed a module name.
+@test occursin(r"Set{var\"[^\"]+\"} where var\"[^\"]+\"", static_shown(Set{<:Any}))
+
+# Test that static_shown is returning valid, correct julia expressions
+@testset "static_show() prints valid julia" begin
+    @testset for v in (
+            var"#X#",
+            var"#X#"(),
+            Vector{<:Any},
+            Vector{var"#X#"},
+        )
+        @test v == eval(Meta.parse(static_shown(v)))
+    end
+end
+
 # Test @show
 let fname = tempname()
     try

--- a/test/show.jl
+++ b/test/show.jl
@@ -1337,8 +1337,13 @@ end
 @test static_shown(QuoteNode(:x)) == ":(:x)"
 
 # PR #38049
+@test static_shown(sum) == "Base.sum"
+@test static_shown(+) == "Base.:(+)"
+@test static_shown(typeof(+)) == "typeof(Base.:(+))"
+
 struct var"#X#" end
 var"#f#"() = 2
+struct var"%X%" end  # Invalid name without '#'
 
 # (Just to make this test more sustainable,) we don't necesssarily need to test the exact
 # output format, just ensure that it prints at least the parts we expect:
@@ -1350,6 +1355,8 @@ var"#f#"() = 2
     @testset for v in (
             var"#X#",
             var"#X#"(),
+            var"%X%",
+            var"%X%"(),
             Vector,
             Vector{<:Any},
             Vector{var"#X#"},


### PR DESCRIPTION
This PR makes a few separate changes to `static_show()`, to bring it more in line with julia's `show()`, and to fix cases where it was printing non-valid code.
 - Use `var""` syntax in static_show to print names containing invalid characters as valid identifiers.
 - Start printing function instances by instance name, instead of via a non-existent type constructor.


Commit messages follow:

---------------------------

Use `var""` syntax in static_show to print valid identifiers

Previously, `static_show` was printing invalid identifiers for
`TypeVar`s that contain a `#`, such as those produced by `gensym()`.

For example:
```julia
julia> println(static_shown(Vector{<:Bool}))
Array{#s5, 1} where #s5<:Bool

julia> eval(Meta.parse(static_shown(Vector{<:Bool})))
ERROR: syntax: incomplete: premature end of input
```
After this commit, this is printed as a valid identifier:
```julia
julia> println(static_shown(Vector{<:Bool}))
Array{var"#s5", 1} where var"#s5"<:Bool

julia> eval(Meta.parse(static_shown(Vector{<:Bool})))
Vector{var"#s5"} where var"#s5"<:Bool (alias for Array{var"#s5", 1} where var"#s5"<:Bool)
```
As you can see, this mirrors the printing done from julia's `show()`.

This commit also applies the same technique to simplify the printing for
Type names that contain a `#`, simply for asthetic reasons and
consistency with julia `show()`, by reusing the above functionality.

Before:
```julia
julia> struct var"#X#" x::Int end

julia> println(static_shown(var"#X#"))
getfield(Main, Symbol("#X#"))

julia> println(static_shown(var"#X#"(0)))
getfield(Main, Symbol("#X#"))(x=0)
```
After:
```julia
julia> struct var"#X#" x::Int end

julia> println(static_shown(var"#X#"))
Main.var"#X#"

julia> println(static_shown(var"#X#"(0)))
Main.var"#X#"(x=0)
```

-------------------------------

Make functions print as valid julia expressions.

Previously, function instances would be printed in `static_show()` as
elements of a `DataType`, with no special printing for `<:Function`s.
This led to printing them via _invalid_ syntax, since there is no empty
constructor for `T<:Function`.

Before:
```julia
julia> g() = 2
g (generic function with 1 method)

julia> println(static_shown(g))
typeof(Main.g)()

julia> eval(Meta.parse(static_shown(g)))
ERROR: MethodError: no method matching typeof(g)()
```

After:
```julia
julia> g() = 2
g (generic function with 1 method)

julia> println(static_shown(g))
Main.g

julia> eval(Meta.parse(static_shown(g)))
g (generic function with 1 method)
```

I chose to keep the Module prefix on the functions, so that they will
be valid julia expressions that you can enter at the REPL to reproduce
the function instance, even though this is a break from the julia
`show()` behavior.

One caveat is that this is still not correct for anonymous functions,
but I'm also not really sure what would be a better way to print
anonymous functions... I think this is _probably_ better than it was
before, but very open to suggestions for how to improve it.

Before:
```julia
julia> l = (x,y)->x+y

julia> println(static_shown(l))
getfield(Main, Symbol("#3#4"))()

julia> eval(Meta.parse(static_shown(l)))
ERROR: MethodError: no method matching var"#3#4"()
```
After:
```julia
julia> l = (x,y)->x+y

julia> println(static_shown(l))
Main.var"#3"

julia> eval(Meta.parse(static_shown(l)))
ERROR: UndefVarError: #3 not defined
```

-----------------

Extend `static_show()` escaping to any illegal identifier via var"".

Previously, it was only escaping names with a `#` in them, but now it
will escape all names that are illegal identifiers.

Before:
```julia
julia> struct var"a%b+c" x::Int end

julia> println(static_shown(var"a%b+c"))
Main.a%b+c

julia> println(static_shown(var"a%b+c"(1)))
Main.a%b+c(x=1)
```
After:
```julia
julia> struct var"a%b+c" x::Int end

julia> println(static_shown(var"a%b+c"))
Main.var"a%b+c"

julia> println(static_shown(var"a%b+c"(1)))
Main.var"a%b+c"(x=1)
```
