### PR TITLE
Add nospecialize(X) in print_matrix and some precompiles

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -65,7 +65,7 @@ function alignment(io::IO, X::AbstractVecOrMat,
         l = r = 0
         for i in rows # plumb down and see what largest element sizes are
             if isassigned(X,i,j)
-                aij = alignment(io, X[i,j])
+                aij = alignment(io, X[i,j])::Tuple{Int,Int}
             else
                 aij = undef_ref_alignment
             end
@@ -158,7 +158,7 @@ string post (printed at the end of the last row of the matrix).
 Also options to use different ellipsis characters hdots, vdots, ddots.
 These are repeated every hmod or vmod elements.
 """
-function print_matrix(io::IO, X::AbstractVecOrMat,
+function print_matrix(io::IO, @nospecialize(X::AbstractVecOrMat),
                       pre::AbstractString = " ",  # pre-matrix string
                       sep::AbstractString = "  ", # separator between elements
                       post::AbstractString = "",  # post-matrix string

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -32,6 +32,8 @@ hardcoded_precompile_statements = """
 repl_script = """
 2+2
 print("")
+display([1])
+display([1 2; 3 4])
 @time 1+1
 ; pwd
 ? reinterpret


### PR DESCRIPTION
Fixes #37922

Julia 1.5:
```julia
julia> @time display([0x0001//0x0002])
1-element Array{Rational{UInt16},1}:
 0x0001//0x0002
  0.404508 seconds (696.75 k allocations: 35.038 MiB, 10.47% gc time)

julia> @time display([0x01//0x02])
1-element Array{Rational{UInt8},1}:
 0x01//0x02
  0.335414 seconds (645.87 k allocations: 32.472 MiB, 2.04% gc time)
```

With this PR:
```julia
julia> @time display([0x0001//0x0002])
1-element Vector{Rational{UInt16}}:
 0x0001//0x0002
  0.398445 seconds (1.01 M allocations: 54.781 MiB, 1.94% gc time, 99.60% compilation time)

julia> @time display([0x01//0x02])
1-element Vector{Rational{UInt8}}:
 0x01//0x02
  0.264985 seconds (1.00 M allocations: 54.166 MiB, 2.93% gc time, 99.47% compilation time)
```

Interestingly, we spend ~100ms inferring [this method](https://github.com/JuliaLang/julia/blob/389d819fe95bf730e15e5e4a7bbbf1967449d579/stdlib/REPL/src/REPL.jl#L211-L223) each time. Adding `@nospecialize(x)` there doesn't help since the whole module is under `@nospecialize` already. I do wonder if it's worth considering an even more aggressive version of `@nospecialize` that short-circuits inference too.