### PR TITLE
Make ldlt throw with zero pivot

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1284,13 +1284,11 @@ function factorize(A::StridedMatrix{T}) where T
                 return Bidiagonal(diag(A), diag(A, 1), :U)
             end
             if utri1
-                if (herm & (T <: Complex)) | sym
-                    try
-                        return ldlt!(SymTridiagonal(diag(A), diag(A, -1)))
-                    catch
-                    end
-                end
-                return lu(Tridiagonal(diag(A, -1), diag(A), diag(A, 1)))
+                # TODO: enable once a specialized, non-dense bunchkaufman method exists
+                # if (herm & (T <: Complex)) | sym
+                    # return bunchkaufman(SymTridiagonal(diag(A), diag(A, -1)))
+                # end
+                return lu!(Tridiagonal(diag(A, -1), diag(A), diag(A, 1)))
             end
         end
         if utri

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1288,7 +1288,7 @@ function factorize(A::StridedMatrix{T}) where T
                 # if (herm & (T <: Complex)) | sym
                     # return bunchkaufman(SymTridiagonal(diag(A), diag(A, -1)))
                 # end
-                return lu!(Tridiagonal(diag(A, -1), diag(A), diag(A, 1)))
+                return lu(Tridiagonal(diag(A, -1), diag(A), diag(A, 1)))
             end
         end
         if utri

--- a/stdlib/LinearAlgebra/src/ldlt.jl
+++ b/stdlib/LinearAlgebra/src/ldlt.jl
@@ -115,7 +115,8 @@ function ldlt!(S::SymTridiagonal{T,V}) where {T,V}
     n = size(S,1)
     d = S.dv
     e = S.ev
-    @inbounds @simd for i = 1:n-1
+    @inbounds for i in 1:n-1
+        iszero(d[i]) && throw(ZeroPivotException(i))
         e[i] /= d[i]
         d[i+1] -= e[i]^2*d[i]
     end

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -210,6 +210,15 @@ dimg  = randn(n)/2
             @test luhs.L*luhs.U ≈ luhs.P*Matrix(HS)
         end
     end
+
+    @testset "Attempt and failure of LDLt factorization (#38026)" begin
+        A = [0.0 -1.0 0.0 0.0
+            -1.0 0.0 0.0 0.0
+            0.0 0.0 0.0 -1.0
+            0.0 0.0 -1.0 0.0]
+        F = factorize(A)
+        @test F isa LU{Float64,<:Tridiagonal}
+    end
 end
 
 @testset "Singular matrices" for T in (Float64, ComplexF64)

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -211,13 +211,13 @@ dimg  = randn(n)/2
         end
     end
 
-    @testset "Attempt and failure of LDLt factorization (#38026)" begin
+    @testset "Factorization of symtridiagonal dense matrix with zero ldlt-pivot (#38026)" begin
         A = [0.0 -1.0 0.0 0.0
             -1.0 0.0 0.0 0.0
             0.0 0.0 0.0 -1.0
             0.0 0.0 -1.0 0.0]
         F = factorize(A)
-        @test F isa LU{Float64,<:Tridiagonal}
+        @test all((!isnan).(Matrix(F)))
     end
 end
 


### PR DESCRIPTION
Fix JuliaLang/LinearAlgebra.jl#771.

I removed the `@simd` macro, since I don't believe that the loop could be vectorized, and benchmarks seemed to indicate no significant difference. For larger test cases, the difference was ==0.

This fix makes `factorize` work on the matrix in the issue. Adding a pivot size-2 LDLt decomposition is a separate issue, but I guess that with the efficient `LU` "fallback" for the `Tridiagonal`, the pain is at least not very strong.