### PR TITLE
Preserve structure under unit[upper/lower]triangular multiplication

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1820,6 +1820,14 @@ for (f, f2!) in ((:*, :lmul!), (:\, :ldiv!))
             return LowerTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
         end
 
+        function $(f)(A::UnitLowerTriangular, B::UnitLowerTriangular)
+            TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
+                         (*)(zero(eltype(A)), zero(eltype(B))))
+            BB = similar(B, TAB, size(B))
+            copyto!(BB, B)
+            return UnitLowerTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
+        end
+
         function ($f)(A::UpperTriangular, B::UpperTriangular)
             TAB = typeof(($f)(zero(eltype(A)), zero(eltype(B))) +
                          ($f)(zero(eltype(A)), zero(eltype(B))))
@@ -1834,6 +1842,14 @@ for (f, f2!) in ((:*, :lmul!), (:\, :ldiv!))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
             return UpperTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
+        end
+
+        function ($f)(A::UnitUpperTriangular, B::UnitUpperTriangular)
+            TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
+                         (*)(zero(eltype(A)), zero(eltype(B))))
+            BB = similar(B, TAB, size(B))
+            copyto!(BB, B)
+            return UnitUpperTriangular($f2!(convert(AbstractMatrix{TAB}, A), BB))
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -277,7 +277,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         @test ladb ≈ fladb atol=sqrt(eps(real(float(one(elty1)))))*n*n
 
         # Matrix square root
-        @test sqrt(A1) |> t -> t*t ≈ A1
+        @test sqrt(A1) |> (t -> (t*t)::typeof(t)) ≈ A1
 
         # naivesub errors
         @test_throws DimensionMismatch naivesub!(A1,Vector{elty1}(undef,n+1))


### PR DESCRIPTION
I assume this was just oversight. This is the out-of-place version of #36972, if you want. Currently, we return a dense array without structured wrapper:
```julia
julia> L
3×3 UnitLowerTriangular{Float64,Array{Float64,2}}:
 1.0        ⋅         ⋅ 
 0.772658  1.0        ⋅ 
 0.676703  0.830263  1.0

julia> L*L
3×3 Array{Float64,2}:
 1.0      0.0      0.0
 1.54532  1.0      0.0
 1.99492  1.66053  1.0
```
This PR makes it
```julia
julia> L*L
3×3 UnitLowerTriangular{Float64, Matrix{Float64}}:
```