### PR TITLE
add 'ᵀ postfix operator for transpose

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,7 @@ New library features
   inserting or consuming the first dimension depending on the ratio of `sizeof(T)` and `sizeof(S)`.
 * New `append!(vector, collections...)` and `prepend!(vector, collections...)` methods accept multiple
   collections to be appended or prepended ([#36227]).
+* The postfix operator `'ᵀ` can now be used as an alias for `transpose` ([#38043]).
 
 Standard library changes
 ------------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -464,6 +464,7 @@ export
 # linear algebra
     var"'", # to enable syntax a' for adjoint
     adjoint,
+    var"'ᵀ",
     transpose,
     kron,
     kron!,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -547,6 +547,7 @@ end
 function kron! end
 
 const var"'" = adjoint
+const var"'ᵀ" = transpose
 
 """
     \\(x, y)

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -136,6 +136,7 @@ julia> x'x
 adjoint(A::AbstractVecOrMat) = Adjoint(A)
 
 """
+    A'ᵀ
     transpose(A)
 
 Lazy transpose. Mutating the returned object should appropriately mutate `A`. Often,
@@ -144,6 +145,9 @@ that this operation is recursive.
 
 This operation is intended for linear algebra usage - for general data manipulation see
 [`permutedims`](@ref Base.permutedims), which is non-recursive.
+
+!!! compat "Julia 1.6"
+    The postfix operator `'ᵀ` requires Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -156,6 +160,14 @@ julia> transpose(A)
 2×2 Transpose{Complex{Int64}, Matrix{Complex{Int64}}}:
  3+2im  8+7im
  9+2im  4+6im
+
+julia> x = [3, 4im]
+2-element Vector{Complex{Int64}}:
+ 3 + 0im
+ 0 + 4im
+
+julia> x'ᵀx
+-7 + 0im
 ```
 """
 transpose(A::AbstractVecOrMat) = Transpose(A)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -243,3 +243,6 @@ end
     @test gt5(6) && !gt5(5)
     @test lt5(4) && !lt5(5)
 end
+
+a = rand(3, 3)
+@test transpose(a) === a'ᵀ


### PR DESCRIPTION
I feel like `transpose` is really the only sensible meaning of `'ᵀ` and this was also the main use case for JuliaLang/julia#37247, so I think defining it in Base makes the most sense.
fixes JuliaLang/LinearAlgebra.jl#410