### PR TITLE
Drop use of `something` in reflection.jl

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -641,7 +641,7 @@ end
 function fieldindex(t::UnionAll, name::Symbol, err::Bool=true)
     t = argument_datatype(t)
     if t === nothing
-        throw(ArgumentError("type does not have a definite number of fields"))
+        throw(ArgumentError("type does not have definite fields"))
     end
     return fieldindex(t, name, err)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -638,7 +638,13 @@ function fieldindex(T::DataType, name::Symbol, err::Bool=true)
     return Int(ccall(:jl_field_index, Cint, (Any, Any, Cint), T, name, err)+1)
 end
 
-fieldindex(t::UnionAll, name::Symbol, err::Bool=true) = fieldindex(something(argument_datatype(t)), name, err)
+function fieldindex(t::UnionAll, name::Symbol, err::Bool=true)
+    t = argument_datatype(t)
+    if t === nothing
+        throw(ArgumentError("type does not have a definite number of fields"))
+    end
+    return fieldindex(t, name, err)
+end
 
 argument_datatype(@nospecialize t) = ccall(:jl_argument_datatype, Any, (Any,), t)
 


### PR DESCRIPTION
reflection.jl is included in Core.Compiler, but the `something` function is not, so we cannot use it here.
Throw an explicit error instead. I considered having it not throw the error when `err==false`, but it
seems to me like passing such a UnionAll is just a user error, rather than an acceptable query, so
I left it as is and simply did the bug fix.