### PR TITLE
Add `Artifacts.toml` files for our fake JLL packages

### DIFF
--- a/deps/Versions.make
+++ b/deps/Versions.make
@@ -24,6 +24,7 @@ MBEDTLS_VER = 2.16.8
 MBEDTLS_BB_REL = 0
 LIBSSH2_VER = 1.9.0
 LIBSSH2_BB_REL = 1
+# Note: keep stdlib/LibCURL_jll/Artifacts.toml in-sync
 CURL_VER = 7.71.1
 CURL_BB_REL = 0
 NGHTTP2_VER = 1.40.0

--- a/stdlib/LibCURL_jll/Artifacts.toml
+++ b/stdlib/LibCURL_jll/Artifacts.toml
@@ -1,0 +1,113 @@
+[[LibCURL]]
+arch = "aarch64"
+git-tree-sha1 = "0064bd998f4055cd199f9a716a4c3ce8857c1384"
+libc = "glibc"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "b7cfd612b7c7f1e9b6046f8532ddc6bcd249fe0cca5b90eedf344ecb08a4abd0"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.aarch64-linux-gnu.tar.gz"
+[[LibCURL]]
+arch = "aarch64"
+git-tree-sha1 = "4da22cad991ca60c2c1ca59c85ad72b8d3a55337"
+libc = "musl"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "ddbfd6a41046b8dc9a89da333074e8803b69db16eccf5039ab16828ffaa827f9"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.aarch64-linux-musl.tar.gz"
+[[LibCURL]]
+arch = "armv7l"
+git-tree-sha1 = "ae5a673ef50fa3716ae9230bd7a4e800f69798e0"
+libc = "glibc"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "8717af3a3e9e03c30bb5a1173a6d454f1f30fca9902083faf9e445992d52cb4b"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.armv7l-linux-gnueabihf.tar.gz"
+[[LibCURL]]
+arch = "armv7l"
+git-tree-sha1 = "2959d2fe1f7e614252f2b7b3148e8b986073423a"
+libc = "musl"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "870f03ce1822cb3783d5585d4bc881eafca75f399fa245d1ca8f4144a1879591"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.armv7l-linux-musleabihf.tar.gz"
+[[LibCURL]]
+arch = "i686"
+git-tree-sha1 = "46f77005e428d793b4f8b62f65b11553d37ab336"
+libc = "glibc"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "801504c8dd73aa11e1ebad032ecb86609cbafa6d006793a8c1f2d92c21b46716"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.i686-linux-gnu.tar.gz"
+[[LibCURL]]
+arch = "i686"
+git-tree-sha1 = "b3f712ed1a8776ee6b211e9fba04cd5ba009bb89"
+libc = "musl"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "4737272eaf45b33a90a92d3c36ab39766cb09a80d10844936f7aa7fac161d08d"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.i686-linux-musl.tar.gz"
+[[LibCURL]]
+arch = "i686"
+git-tree-sha1 = "c98a3ed03ec134f226e6c060c4ecaddb4ddffd78"
+os = "windows"
+
+    [[LibCURL.download]]
+    sha256 = "a4de21f91395dcfb01afaef8bd2852fb2bcbb37c173c9429ccf100f0cd2066df"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.i686-w64-mingw32.tar.gz"
+[[LibCURL]]
+arch = "powerpc64le"
+git-tree-sha1 = "f35072b02827fee7aa898490a4abd128084fc30e"
+libc = "glibc"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "851773743a8f220f146c4f66b2acc92d9b2e6a00b2b7742247dcace8b816d9a4"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.powerpc64le-linux-gnu.tar.gz"
+[[LibCURL]]
+arch = "x86_64"
+git-tree-sha1 = "2b59c79c5b82d73855b3b825b5711d42e85114d3"
+os = "macos"
+
+    [[LibCURL.download]]
+    sha256 = "2baccce2852705d89ecf3a8de0dd73a4b51d9a88fd4b8fd6bda3709d08a41fce"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.x86_64-apple-darwin14.tar.gz"
+[[LibCURL]]
+arch = "x86_64"
+git-tree-sha1 = "2f1155c51d79440c61a695481f3cfb3e9b4e3f04"
+libc = "glibc"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "4604e972a28b32803f08b3886b78cb0bef847b12c7ca854946feeafebb88f453"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.x86_64-linux-gnu.tar.gz"
+[[LibCURL]]
+arch = "x86_64"
+git-tree-sha1 = "f58f485420509e1b2f8cb30224305da1adb17c55"
+libc = "musl"
+os = "linux"
+
+    [[LibCURL.download]]
+    sha256 = "37e07e08d09548d4a7b0e928b0d1ead8d0df1cb05e403b6fd65fd349c7e33c73"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.x86_64-linux-musl.tar.gz"
+[[LibCURL]]
+arch = "x86_64"
+git-tree-sha1 = "fba220544378b09602d5d6b81ff0af6630b8f5b1"
+os = "freebsd"
+
+    [[LibCURL.download]]
+    sha256 = "610c3879279fc2ae0ee9e57092ca771cf19993835c536cfe8e64baceccbe0a98"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.x86_64-unknown-freebsd11.1.tar.gz"
+[[LibCURL]]
+arch = "x86_64"
+git-tree-sha1 = "93a125a1f028ecc90665616e44072e4da65aea23"
+os = "windows"
+
+    [[LibCURL.download]]
+    sha256 = "615f42ee7955ada11dc2f9c7e07e83252551852e6f2d22531143c9e7826f4e21"
+    url = "https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl/releases/download/LibCURL-v7.71.1+0/LibCURL.v7.71.1.x86_64-w64-mingw32.tar.gz"

--- a/stdlib/MozillaCACerts_jll/Artifacts.toml
+++ b/stdlib/MozillaCACerts_jll/Artifacts.toml
@@ -1,0 +1,6 @@
+[MozillaCACerts]
+git-tree-sha1 = "bb24cbe35cf50be29d24135e8236a069533cca3a"
+
+    [[MozillaCACerts.download]]
+    sha256 = "3397e85496d9c25c8e79536a8baed72c523843afef3ddbb6074a74b030b368e8"
+    url = "https://github.com/JuliaBinaryWrappers/MozillaCACerts_jll.jl/releases/download/MozillaCACerts-v2020.7.22+0/MozillaCACerts.v2020.7.22.any.tar.gz"


### PR DESCRIPTION
These don't do anyhting except play nicely with other tools that expect
to find `Artifacts.toml` files within JLL package directories, like BB.