### PR TITLE
jl_llvmpointer_type is a unionall, but jl_is_llvmpointer treats it a datatype.

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1149,7 +1149,7 @@ static inline int jl_is_layout_opaque(const jl_datatype_layout_t *l) JL_NOTSAFEP
 #define jl_is_cpointer(v)    jl_is_cpointer_type(jl_typeof(v))
 #define jl_is_pointer(v)     jl_is_cpointer_type(jl_typeof(v))
 #define jl_is_uint8pointer(v)jl_typeis(v,jl_uint8pointer_type)
-#define jl_is_llvmpointer(v) jl_typeis(v,jl_llvmpointer_type)
+#define jl_is_llvmpointer(v) (((jl_datatype_t*)jl_typeof(v))->name == jl_llvmpointer_typename)
 #define jl_is_intrinsic(v)   jl_typeis(v,jl_intrinsic_type)
 #define jl_array_isbitsunion(a) (!(((jl_array_t*)(a))->flags.ptrarray) && jl_is_uniontype(jl_tparam0(jl_typeof(a))))
 


### PR DESCRIPTION
Hi,
The `jl_is_llvmpointer` macro uses `jl_typeis`, but `jl_llvmpointer_type` is a unionall. It should check if the typename is `jl_llvmpointer_typename` instead.