### PR TITLE
make sure TOML.parsefile error when used on a directory

### DIFF
--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -17,6 +17,9 @@ module Internals
     end
 end
 
+# https://github.com/JuliaLang/julia/issues/36605
+readstring(f::AbstractString) = isfile(f) ? read(f, String) : error(repr(f), ": No such file")
+
 """
     Parser()
 
@@ -38,9 +41,9 @@ Parse file `f` and return the resulting table (dictionary). Throw a
 See also: [`TOML.tryparsefile`](@ref)
 """
 parsefile(f::AbstractString) =
-    Internals.parse(Parser(read(f, String); filepath=abspath(f)))
+    Internals.parse(Parser(readstring(f); filepath=abspath(f)))
 parsefile(p::Parser, f::AbstractString) =
-    Internals.parse(Internals.reinit!(p, read(f, String); filepath=abspath(f)))
+    Internals.parse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
 """
     tryparsefile(f::AbstractString)
@@ -52,9 +55,9 @@ Parse file `f` and return the resulting table (dictionary). Return a
 See also: [`TOML.parsefile`](@ref)
 """
 tryparsefile(f::AbstractString) =
-    Internals.tryparse(Parser(read(f, String); filepath=abspath(f)))
+    Internals.tryparse(Parser(readstring(f); filepath=abspath(f)))
 tryparsefile(p::Parser, f::AbstractString) =
-    Internals.tryparse(Internals.reinit!(p, read(f, String); filepath=abspath(f)))
+    Internals.tryparse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
 """
     parse(x::Union{AbstractString, IO})

--- a/stdlib/TOML/test/parse.jl
+++ b/stdlib/TOML/test/parse.jl
@@ -38,6 +38,8 @@ using TOML: ParserError
     @test_throws ParserError TOML.parsefile(SubString(invalid_path))
     @test_throws ParserError TOML.parsefile(p, invalid_path)
     @test_throws ParserError TOML.parsefile(p, SubString(invalid_path))
+    @test_throws ErrorException TOML.parsefile(homedir())
+    @test_throws ErrorException TOML.parsefile(p, homedir())
     # TOML.tryparsefile
     @test TOML.tryparsefile(path) == TOML.tryparsefile(SubString(path)) ==
           TOML.tryparsefile(p, path) == TOML.tryparsefile(p, SubString(path)) == dict
@@ -45,4 +47,6 @@ using TOML: ParserError
     @test TOML.tryparsefile(SubString(invalid_path)) isa ParserError
     @test TOML.tryparsefile(p, invalid_path) isa ParserError
     @test TOML.tryparsefile(p, SubString(invalid_path)) isa ParserError
+    @test_throws ErrorException TOML.tryparsefile(homedir())
+    @test_throws ErrorException TOML.tryparsefile(p, homedir())
 end


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/issues/36605.

Previously:

```
julia> using TOML

julia> TOML.parsefile(homedir())
Dict{String, Any}()
```