### PR TITLE
Prevent scanning of debug files from the current working directory on Windows

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -656,8 +656,8 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     jl_winsock_handle = jl_dlopen("ws2_32.dll", 0);
     jl_exe_handle = GetModuleHandleA(NULL);
     JL_MUTEX_INIT(&jl_in_stackwalk);
-    SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
-    if (!SymInitialize(GetCurrentProcess(), NULL, 1)) {
+    SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES | SYMOPT_IGNORE_CVREC);
+    if (!SymInitialize(GetCurrentProcess(), "", 1)) {
         jl_printf(JL_STDERR, "WARNING: failed to initialize stack walk info\n");
     }
     needsSymRefreshModuleList = 0;


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/36911 .

[SymSetOptions](https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-symsetoptions) docs say this about SYMOPT_IGNORE_CVREC
Ignore path information in the CodeView record of the image header when loading a .pdb file.