### PR TITLE
change how we document what is brought into scope

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -78,13 +78,13 @@ In this module we export the `x` and `y` functions (with the keyword [`export`](
 the non-exported function `p`. There are several different ways to load the Module and its inner
 functions into the current workspace:
 
-| Import Command                  | What is brought into scope                                                      | Available for method extension              |
-|:------------------------------- |:------------------------------------------------------------------------------- |:------------------------------------------- |
-| `using MyModule`                | All `export`ed names (`x` and `y`), `MyModule.x`, `MyModule.y` and `MyModule.p` | `MyModule.x`, `MyModule.y` and `MyModule.p` |
-| `using MyModule: x, p`          | `x` and `p`                                                                     |                                             |
-| `import MyModule`               | `MyModule.x`, `MyModule.y` and `MyModule.p`                                     | `MyModule.x`, `MyModule.y` and `MyModule.p` |
-| `import MyModule.x, MyModule.p` | `x` and `p`                                                                     | `x` and `p`                                 |
-| `import MyModule: x, p`         | `x` and `p`                                                                     | `x` and `p`                                 |
+| Import Command                                  | What is brought into scope                                  | Available for method extension              |
+|:----------------------------------------------- |:----------------------------------------------------------- |:------------------------------------------- |
+| `using MyModule`                                | All `export`ed names (`x` and `y`), and `MyModule` itself   | `MyModule.x`, `MyModule.y` and `MyModule.p` |
+| `using MyModule: x, p`                          | Only `x` and `p`                                            |                                             |
+| `import MyModule` or `using MyModule: MyModule` | Only `MyModule` itself                                      | `MyModule.x`, `MyModule.y` and `MyModule.p` |
+| `import MyModule.x, MyModule.p`                 | Only `x` and `p`                                            | `x` and `p`                                 |
+| `import MyModule: x, p`                         | Only `x` and `p`                                            | `x` and `p`                                 |
 
 ### Import renaming
 


### PR DESCRIPTION
What do folks think.
Is it clearer to mention that we are bring into scope the module object itself, rather than saying we were bring into scrope `MyModule.x` etc?
