### PR TITLE
Update python instructions for compiling Julia on Windows

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -96,7 +96,7 @@ ARCH:=
 
 # We need python for things like BB triplet recognition and relative path computation.
 # We don't really care about version, generally, so just find something that works:
-PYTHON := "$(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)"
+PYTHON := "$(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo "{python|python3|python2} not found")"
 PYTHON_SYSTEM := $(shell $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())')
 
 # If we're running on Cygwin, but using a native-windows Python, we need to use cygpath -w

--- a/doc/build/windows.md
+++ b/doc/build/windows.md
@@ -90,7 +90,7 @@ MinGW-w64 compilers available through Cygwin's package manager.
 
     Advanced: you may skip steps 2-4 by running:
 
-        setup-x86_64.exe -s <url> -q -P cmake,gcc-g++,git,make,patch,curl,m4,python,p7zip,mingw64-i686-gcc-g++,mingw64-i686-gcc-fortran,mingw64-x86_64-gcc-g++,mingw64-x86_64-gcc-fortran
+        setup-x86_64.exe -s <url> -q -P cmake,gcc-g++,git,make,patch,curl,m4,python3,p7zip,mingw64-i686-gcc-g++,mingw64-i686-gcc-fortran,mingw64-x86_64-gcc-g++,mingw64-x86_64-gcc-fortran
         :: replace <url> with a site from https://cygwin.com/mirrors.html
         :: or run setup manually first and select a mirror
 
@@ -100,7 +100,7 @@ MinGW-w64 compilers available through Cygwin's package manager.
 
     1.  From the *Devel* category: `cmake`, `gcc-g++`, `git`, `make`, `patch`
     2.  From the *Net* category: `curl`
-    3.  From *Interpreters* (or *Python*) category: `m4`, `python`
+    3.  From *Interpreters* (or *Python*) category: `m4`, `python3`
     4.  From the *Archive* category: `p7zip`
     5.  For 32 bit Julia, and also from the *Devel* category:
         `mingw64-i686-gcc-g++` and `mingw64-i686-gcc-fortran`


### PR DESCRIPTION
- Suggested `python` package is obsoleted in Cygwin, suggest using `python3`
- Improve error message if {python|python3|python2} executable is not found in `Make.inc`.