### PR TITLE
[LLVM] Update to API changes in LLVM 12

### DIFF
--- a/src/abi_aarch64.cpp
+++ b/src/abi_aarch64.cpp
@@ -23,8 +23,13 @@ Type *get_llvm_vectype(jl_datatype_t *dt) const
     assert(nfields > 0);
     if (nfields < 2)
         return nullptr;
+#if JL_LLVM_VERSION >= 120000
+    static Type *T_vec64 = FixedVectorType::get(T_int32, 2);
+    static Type *T_vec128 = FixedVectorType::get(T_int32, 4);
+#else
     static Type *T_vec64 = VectorType::get(T_int32, 2);
     static Type *T_vec128 = VectorType::get(T_int32, 4);
+#endif
     Type *lltype;
     // Short vector should be either 8 bytes or 16 bytes.
     // Note that there are only two distinct fundamental types for

--- a/src/abi_ppc64le.cpp
+++ b/src/abi_ppc64le.cpp
@@ -134,7 +134,11 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret) const override
             jl_datatype_t *vecty = (jl_datatype_t*)jl_field_type(ty0, 0);
             assert(jl_is_datatype(vecty) && vecty->name == jl_vecelement_typename);
             Type *ety = bitstype_to_llvm(jl_tparam0(vecty));
+#if JL_LLVM_VERSION >= 120000
+            Type *vty = FixedVectorType::get(ety, jl_datatype_nfields(ty0));
+#else
             Type *vty = VectorType::get(ety, jl_datatype_nfields(ty0));
+#endif
             return ArrayType::get(vty, hfa);
         }
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -624,7 +624,12 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, jl_
                 // and always end with an Int8 (selector byte).
                 // We may need to insert padding first to get to the right offset
                 if (al > MAX_ALIGN) {
-                    Type *AlignmentType = ArrayType::get(VectorType::get(T_int8, al), 0);
+                    Type *AlignmentType;
+#if JL_LLVM_VERSION >= 120000
+                    AlignmentType = ArrayType::get(FixedVectorType::get(T_int8, al), 0);
+#else
+                    AlignmentType = ArrayType::get(VectorType::get(T_int8, al), 0);
+#endif
                     latypes.push_back(AlignmentType);
                     al = MAX_ALIGN;
                 }
@@ -664,7 +669,11 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, jl_
         }
         else if (isarray && !type_is_ghost(lasttype)) {
             if (isTuple && isvector && jl_special_vector_alignment(ntypes, jlasttype) != 0)
+#if JL_LLVM_VERSION >= 120000
+                struct_decl = FixedVectorType::get(lasttype, ntypes);
+#else
                 struct_decl = VectorType::get(lasttype, ntypes);
+#endif
             else if (isTuple || !llvmcall)
                 struct_decl = ArrayType::get(lasttype, ntypes);
             else
@@ -1364,8 +1373,15 @@ std::vector<unsigned> first_ptr(Type *T)
             uint64_t num_elements;
             if (auto *AT = dyn_cast<ArrayType>(T))
                 num_elements = AT->getNumElements();
-            else
-                num_elements = cast<VectorType>(T)->getNumElements();
+            else {
+                VectorType *VT = cast<VectorType>(T);
+#if JL_LLVM_VERSION >= 120000
+                ElementCount EC = VT->getElementCount();
+                num_elements = EC.getKnownMinValue();
+#else
+                num_elements = VT->getNumElements();
+#endif
+            }
             if (num_elements == 0)
                 return {};
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7702,7 +7702,11 @@ extern "C" void jl_init_llvm(void)
             // This is the only way I can find to print the help message once.
             // It'll be nice if we can iterate through the features and print our own help
             // message...
+#if JL_LLVM_VERSION >= 120000
+            MSTI->setDefaultFeatures("help", "", "");
+#else
             MSTI->setDefaultFeatures("help", "");
+#endif
         }
     }
     // Package up features to be passed to target/subtarget


### PR DESCRIPTION
1. LLVM now has support for scalable vector types, for now this just uses `FixedVectorType` instead.
2. `ParseEnvironmentOptions` got removed in https://github.com/llvm/llvm-project/commit/c068e9c8c123e7f8c8f3feb57245a012ccd09ccf
3. `setDefaultFeatures` now takes a third argument
