### PR TITLE
`pop!` on unordered containers clarification.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1131,7 +1131,8 @@ end
     pop!(collection) -> item
 
 Remove an item in `collection` and return it. If `collection` is an
-ordered container, the last item is returned.
+ordered container, the last item is returned; for unordered containers,
+an arbitrary element is returned.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Updates the documentation as suggested by @timholy [here](https://discourse.julialang.org/t/why-does-delete-work-with-sets-but-not-deleteat/48596/10?u=henrique_becker). The text is provisional, the objective is to make clear the function also works on unordered containers and in such case the element removed is arbitrarily chosen.