### PR TITLE
fix up addition of `¦` and `⌿` operators (#37973)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,8 @@ Language changes
   instead of `:call`.
 * Instances of `UniformScaling` are no longer `isequal` to matrices. Previous
   behaviour violated the rule that `isequal(x, y)` implies `hash(x) == hash(y)`.
+* `⌿` (U+233F) and `¦` (U+00A6) are now infix operators with times-like and plus-like precedence,
+  respectively. Previously they were parsed as identifier characters ([#37973]).
 
 Compiler/Runtime improvements
 -----------------------------

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -72,7 +72,9 @@ static int is_wc_cat_id_start(uint32_t wc, utf8proc_category_t cat)
             cat == UTF8PROC_CATEGORY_SC ||  // allow currency symbols
             // other symbols, but not arrows or replacement characters
             (cat == UTF8PROC_CATEGORY_SO && !(wc >= 0x2190 && wc <= 0x21FF) &&
-             wc != 0xfffc && wc != 0xfffd) ||
+             wc != 0xfffc && wc != 0xfffd &&
+             wc != 0x233f &&  // notslash
+             wc != 0x00a6) || // broken bar
 
             // math symbol (category Sm) whitelist
             (wc >= 0x2140 && wc <= 0x2a1c &&

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2490,3 +2490,6 @@ end
             in 1:3
         end""")
 end
+
+# PR #37973
+@test Meta.parse("1¦2⌿3") == Expr(:call, :¦, 1, Expr(:call, :⌿, 2, 3))


### PR DESCRIPTION
see #37973