### PR TITLE
fix _crc32c used in loading.jl

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -387,8 +387,8 @@ _crc32c(io::IO, crc::UInt32=0x00000000) = _crc32c(io, typemax(Int64), crc)
 _crc32c(io::IOStream, crc::UInt32=0x00000000) = _crc32c(io, filesize(io)-position(io), crc)
 _crc32c(uuid::UUID, crc::UInt32=0x00000000) =
     ccall(:jl_crc32c, UInt32, (UInt32, Ref{UInt128}, Csize_t), crc, uuid.value, 16)
-_crc32c(x::Integer, crc::UInt32=0x00000000) =
-    ccall(:jl_crc32c, UInt32, (UInt32, Vector{UInt8}, Csize_t), crc, reinterpret(UInt8, [x]), sizeof(x))
+_crc32c(x::UInt64, crc::UInt32=0x00000000) =
+    ccall(:jl_crc32c, UInt32, (UInt32, Ref{UInt64}, Csize_t), crc, x, 8)
 
 """
     @kwdef typedef

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -231,6 +231,7 @@ end
         pkg = recurse_package(n...)
         @test pkg == PkgId(UUID(uuid), n[end])
         @test joinpath(@__DIR__, normpath(path)) == locate_package(pkg)
+        @test Base.compilecache_path(pkg) == Base.compilecache_path(pkg)
     end
     @test identify_package("Baz") == nothing
     @test identify_package("Qux") == nothing


### PR DESCRIPTION
Previously:

```
julia> crc, x = 0x6635934445471676, 0x5202ff58;

julia> Base._crc32c(crc, x)
0x8b058d60

julia> Base._crc32c(crc, x)
0x2bcaa1e5

julia> Base._crc32c(crc, x)
0xdc2d7c70
```

Problem is that `Vector` instead of `Ptr` was used. Here I just simplified this to handle the return value of hash (`UInt64`) which is the only thing we use (this also avoids forming the `[x]`).

Fixes https://github.com/JuliaLang/julia/issues/38101.