### PR TITLE
Add PrecompileFailedException for throwing compilecache failures

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1293,6 +1293,19 @@ function compilecache_path(pkg::PkgId)::String
 end
 
 """
+    PrecompileFailedException(pkg::PkgId, cachefile::String)
+
+Failure to precompile a module
+"""
+struct PrecompileFailedException <: Exception
+    pkg::PkgId
+    cachefile::String
+end
+function showerror(io::IO, ex::PrecompileFailedException)
+    print(io, "PrecompileFailedException: Failed to precompile $(ex.pkg) to $(ex.cachefile).")
+end
+
+"""
     Base.compilecache(module::PkgId)
 
 Creates a precompiled cache file for a module and all of its dependencies.
@@ -1357,7 +1370,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
     if p.exitcode == 125
         return PrecompilableError()
     else
-        error("Failed to precompile $pkg to $cachefile.")
+        throw(PrecompileFailedException(pkg, cachefile))
     end
 end
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -464,7 +464,6 @@ try
             error("the \"break me\" test failed")
         catch exc
             isa(exc, Base.PrecompileFailedException) || rethrow()
-            isa(exc, ErrorException) && occursin("ERROR: LoadError: break me", exc.msg) && rethrow()
         end
 
     # Test that trying to eval into closed modules during precompilation is an error

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -463,8 +463,8 @@ try
             Base.require(Main, :FooBar2)
             error("the \"break me\" test failed")
         catch exc
-            isa(exc, ErrorException) || rethrow()
-            occursin("ERROR: LoadError: break me", exc.msg) && rethrow()
+            isa(exc, Base.PrecompileFailedException) || rethrow()
+            isa(exc, ErrorException) && occursin("ERROR: LoadError: break me", exc.msg) && rethrow()
         end
 
     # Test that trying to eval into closed modules during precompilation is an error
@@ -476,7 +476,7 @@ try
         @test_warn "Evaluation into the closed module `Base` breaks incremental compilation" try
                 Base.require(Main, :FooBar3)
             catch exc
-                isa(exc, ErrorException) || rethrow()
+                isa(exc, Base.PrecompileFailedException) || rethrow()
             end
     end
 


### PR DESCRIPTION
This is helpful for the `pkg> precompile` process to be more specific about error catching

cc. @KristofferC 