### PR TITLE
[build] Fix libgit2 build when `USE_BINARYBUILDER=0`

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -41,8 +41,15 @@ $(LIBGIT2_SRC_PATH)/libgit2-agent-nonfatal.patch-applied: $(LIBGIT2_SRC_PATH)/so
 		patch -p1 -f < $(SRCDIR)/patches/libgit2-agent-nonfatal.patch
 	echo 1 > $@
 
+# This can be removed once a release with https://github.com/libgit2/libgit2/pull/5685 lands
+$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-incdir.patch-applied: $(LIBGIT2_SRC_PATH)/libgit2-agent-nonfatal.patch-applied
+	cd $(LIBGIT2_SRC_PATH) && \
+		patch -p1 -f < $(SRCDIR)/patches/libgit2-mbedtls-incdir.patch
+	echo 1 > $@
+
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: \
-	$(LIBGIT2_SRC_PATH)/libgit2-agent-nonfatal.patch-applied
+	$(LIBGIT2_SRC_PATH)/libgit2-agent-nonfatal.patch-applied \
+	$(LIBGIT2_SRC_PATH)/libgit2-mbedtls-incdir.patch-applied
 
 $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured: $(LIBGIT2_SRC_PATH)/source-extracted
 	mkdir -p $(dir $@)
@@ -109,4 +116,3 @@ $(build_datarootdir)/julia/cert.pem: $(SRCCACHE)/cacert-$(MOZILLA_CACERT_VERSION
 
 # When "get"'ing libgit2, download the .pem
 get-libgit2: $(SRCCACHE)/cacert-$(MOZILLA_CACERT_VERSION).pem
-

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -23,6 +23,8 @@ $(SRCCACHE)/$(MBEDTLS_SRC)/source-extracted: $(SRCCACHE)/$(MBEDTLS_SRC).tar.gz
 	$(JLCHECKSUM) $<
 	mkdir -p $(dir $@) && \
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
+	# Force-enable MD4
+	sed "s|//#define MBEDTLS_MD4_C|#define MBEDTLS_MD4_C|" -i $(SRCCACHE)/$(MBEDTLS_SRC)/include/mbedtls/config.h
 	touch -c $(SRCCACHE)/$(MBEDTLS_SRC)/CMakeLists.txt # old target
 	echo 1 > $@
 

--- a/deps/patches/libgit2-mbedtls-incdir.patch
+++ b/deps/patches/libgit2-mbedtls-incdir.patch
@@ -1,0 +1,22 @@
+commit 1822b0827a652d5c970a3a906e1801fb8251135b
+Author: Elliot Saba <staticfloat@gmail.com>
+Date:   Tue Oct 20 23:26:47 2020 +0000
+
+    Include `${MBEDTLS_INCLUDE_DIR}` when compiling `crypt_mbedtls.c`
+    
+    Without this, mbedTLS installs in non-default install locations
+    that are otherwise found by the `FindmbedTLS.cmake` module are not
+    found by the C preprocessor at compile time.
+
+diff --git a/deps/ntlmclient/CMakeLists.txt b/deps/ntlmclient/CMakeLists.txt
+index 5fbf0d0f4..d933f4919 100644
+--- a/deps/ntlmclient/CMakeLists.txt
++++ b/deps/ntlmclient/CMakeLists.txt
+@@ -16,6 +16,7 @@ ELSEIF(USE_HTTPS STREQUAL "OpenSSL")
+ 	SET(SRC_NTLMCLIENT_CRYPTO "crypt_openssl.c")
+ ELSEIF(USE_HTTPS STREQUAL "mbedTLS")
+ 	ADD_DEFINITIONS(-DCRYPT_MBEDTLS)
++	INCLUDE_DIRECTORIES(${MBEDTLS_INCLUDE_DIR})
+ 	SET(SRC_NTLMCLIENT_CRYPTO "crypt_mbedtls.c")
+ ELSE()
+ 	MESSAGE(FATAL_ERROR "Unable to use libgit2's HTTPS backend (${USE_HTTPS}) for NTLM crypto")


### PR DESCRIPTION
This fixes a regression in the libgit2 build system which is unable to
find the `mbedTLS` headers at compile time.  It also synchronizes the
`mbedTLS` configuration to include `MD4`, which `libgit2` expects.

libgit2 upstream PR: https://github.com/libgit2/libgit2/pull/5685