### PR TITLE
Allow DCE of pure functions that are not inlined

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1265,6 +1265,8 @@ function maybe_erase_unused!(extra_worklist, compact, idx, callback = x->nothing
     stmt === nothing && return false
     if compact_exprtype(compact, SSAValue(idx)) === Bottom
         effect_free = false
+    elseif isa(compact.result[idx][:info], MethodResultPure)
+        effect_free = true
     else
         effect_free = stmt_effect_free(stmt, compact.result[idx][:type], compact, compact.ir.sptypes)
     end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -350,3 +350,15 @@ f_apply_type_typeof(x) = (Ref{typeof(x)}; nothing)
 struct RealConstrained{T <: Real}; end
 @test !fully_eliminated(x->(RealConstrained{x}; nothing), Tuple{Int})
 @test !fully_eliminated(x->(RealConstrained{x}; nothing), Tuple{Type{Vector{T}} where T})
+
+# Check that pure functions with non-inlineable results still get deleted
+struct Big
+    x::NTuple{1024, Int}
+end
+@Base.pure Big() = Big(ntuple(identity, 1024))
+function pure_elim_full()
+    Big()
+    nothing
+end
+
+@test fully_eliminated(pure_elim_full, Tuple{})


### PR DESCRIPTION
E.g. because the return value is too large.