### PR TITLE
Make Vararg not a DataType

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -727,8 +727,7 @@ end
             ci = U
         end
         if i == lr && Core.Compiler.isvarargtype(pi)
-            N = (Base.unwrap_unionall(pi)::DataType).parameters[2]
-            c[i] = Base.rewrap_unionall(Vararg{ci, N}, pi)
+            c[i] = isdefined(pi, :N) ? Vararg{ci, pi.N} : Vararg{ci}
         else
             c[i] = ci
         end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -307,7 +307,7 @@ julia> 2^2 * 3^3
 !!! compat "Julia 1.6"
     The method that accepts a tuple requires Julia 1.6 or later.
 """
-function nextprod(a::Union{Tuple{Vararg{<:Integer}},AbstractVector{<:Integer}}, x::Real)
+function nextprod(a::Union{Tuple{Vararg{Integer}},AbstractVector{<:Integer}}, x::Real)
     if x > typemax(Int)
         throw(ArgumentError("unsafe for x > typemax(Int), got $x"))
     end

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -192,6 +192,8 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
                     ty = UnionAll(tv, Type{tv})
                 end
             end
+        elseif isa(v, Core.TypeofVararg)
+            ty = Int
         else
             ty = Const(v)
         end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -738,7 +738,7 @@ function analyze_method!(match::MethodMatch, atypes::Vector{Any},
     # Bail out if any static parameters are left as TypeVar
     ok = true
     for i = 1:length(match.sparams)
-        isa(match.sparams[i], TypeVar) && return nothing
+        (isa(match.sparams[i], TypeVar) || isa(match.sparams[i], Core.TypeofVararg)) && return nothing
     end
 
     if !params.inlining

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -220,6 +220,7 @@ widenconst(c::PartialTypeVar) = TypeVar
 widenconst(t::PartialStruct) = t.typ
 widenconst(t::Type) = t
 widenconst(t::TypeVar) = t
+widenconst(t::Core.TypeofVararg) = t
 
 issubstate(a::VarState, b::VarState) = (a.typ ⊑ b.typ && a.undef <= b.undef)
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2346,7 +2346,7 @@ arguments accepted by varargs methods (see the section on [Varargs Functions](@r
 # Examples
 ```jldoctest
 julia> mytupletype = Tuple{AbstractString, Vararg{Int}}
-Tuple{AbstractString, Vararg{Int64, N} where N}
+Tuple{AbstractString, Vararg{Int64}}
 
 julia> isa(("1",), mytupletype)
 true

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -423,7 +423,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                 # If isvarargtype then it checks whether the rest of the input arguments matches
                 # the varargtype
                 if Base.isvarargtype(sig[i])
-                    sigstr = (unwrap_unionall(sig[i]).parameters[1], "...")
+                    sigstr = (unwrap_unionall(sig[i]).T, "...")
                     j = length(t_i)
                 else
                     sigstr = (sig[i],)
@@ -460,7 +460,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                 # It ensures that methods like f(a::AbstractString...) gets the correct
                 # number of right_matches
                 for t in arg_types_param[length(sig):end]
-                    if t <: rewrap_unionall(unwrap_unionall(sig[end]).parameters[1], method.sig)
+                    if t <: rewrap_unionall(unwrap_unionall(sig[end]).T, method.sig)
                         right_matches += 1
                     end
                 end
@@ -473,7 +473,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                     for (k, sigtype) in enumerate(sig[length(t_i)+1:end])
                         sigtype = isvarargtype(sigtype) ? unwrap_unionall(sigtype) : sigtype
                         if Base.isvarargtype(sigtype)
-                            sigstr = ((sigtype::DataType).parameters[1], "...")
+                            sigstr = ((sigtype::Core.TypeofVararg).T, "...")
                         else
                             sigstr = (sigtype,)
                         end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -255,6 +255,14 @@ function rewrap_unionall(@nospecialize(t), @nospecialize(u))
     return UnionAll(u.var, rewrap_unionall(t, u.body))
 end
 
+function rewrap_unionall(t::Core.TypeofVararg, @nospecialize(u))
+    isdefined(t, :T) || return t
+    if !isdefined(t, :N) || t.N === u.var
+        return Vararg{rewrap_unionall(t.T, u)}
+    end
+    Vararg{rewrap_unionall(t.T, u), t.N}
+end
+
 # replace TypeVars in all enclosing UnionAlls with fresh TypeVars
 function rename_unionall(@nospecialize(u))
     if !isa(u, UnionAll)
@@ -271,10 +279,8 @@ function rename_unionall(@nospecialize(u))
     return UnionAll(nv, body{nv})
 end
 
-const _va_typename = Vararg.body.body.name
 function isvarargtype(@nospecialize(t))
-    t = unwrap_unionall(t)
-    return isa(t, DataType) && (t::DataType).name === _va_typename
+    return isa(t, Core.TypeofVararg)
 end
 
 function isvatuple(@nospecialize(t))
@@ -286,18 +292,14 @@ function isvatuple(@nospecialize(t))
     return false
 end
 
-function unwrapva(@nospecialize(t))
-    # NOTE: this returns a related type, but it's NOT a subtype of the original tuple
-    t2 = unwrap_unionall(t)
-    return isvarargtype(t2) ? rewrap_unionall(t2.parameters[1], t) : t
-end
+unwrapva(t::Core.TypeofVararg) = isdefined(t, :T) ? t.T : Any
+unwrapva(@nospecialize(t)) = t
 
-function unconstrain_vararg_length(@nospecialize(va))
+function unconstrain_vararg_length(va::Core.TypeofVararg)
     # construct a new Vararg type where its length is unconstrained,
     # but its element type still captures any dependencies the input
     # element type may have had on the input length
-    T = unwrap_unionall(va).parameters[1]
-    return rewrap_unionall(Vararg{T}, va)
+    return Vararg{unwrapva(va)}
 end
 
 typename(a) = error("typename does not apply to this type")

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -27,25 +27,14 @@ function argtype_decl(env, n, @nospecialize(sig::DataType), i::Int, nargs, isva:
         t === Any && return s, ""
     end
     if isvarargtype(t)
-        v1, v2 = nothing, nothing
-        if isa(t, UnionAll)
-            v1 = t.var
-            t = t.body
-            if isa(t, UnionAll)
-                v2 = t.var
-                t = t.body
-            end
-        end
-        ut = unwrap_unionall(t)
-        tt, tn = ut.parameters[1], ut.parameters[2]
-        if isa(tn, TypeVar) && (tn === v1 || tn === v2)
-            if tt === Any || (isa(tt, TypeVar) && (tt === v1 || tt === v2))
+        if !isdefined(t, :N)
+            if unwrapva(t) === Any
                 return string(s, "..."), ""
             else
-                return s, string_with_env(env, tt) * "..."
+                return s, string_with_env(env, unwrapva(t)) * "..."
             end
         end
-        return s, string_with_env(env, "Vararg{", tt, ", ", tn, "}")
+        return s, string_with_env(env, "Vararg{", t.T, ", ", t.N, "}")
     end
     return s, string_with_env(env, t)
 end

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -157,9 +157,8 @@ function full_va_len(p)
     isempty(p) && return 0, true
     last = p[end]
     if isvarargtype(last)
-        N = unwrap_unionall(last).parameters[2]
-        if isa(N, Int)
-            return length(p)::Int + N - 1, true
+        if isdefined(last, :N) && isa(last.N, Int)
+            return length(p)::Int + last.N - 1, true
         end
         return length(p)::Int, false
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -775,6 +775,9 @@ function to_tuple_type(@nospecialize(t))
     end
     if isa(t, Type) && t <: Tuple
         for p in unwrap_unionall(t).parameters
+            if isa(p, Core.TypeofVararg)
+                p = p.T
+            end
             if !(isa(p, Type) || isa(p, TypeVar))
                 error("argument tuple type must contain only types")
             end

--- a/base/show.jl
+++ b/base/show.jl
@@ -2290,6 +2290,19 @@ function show(io::IO, tv::TypeVar)
     nothing
 end
 
+function show(io::IO, vm::Core.TypeofVararg)
+    print(io, "Vararg")
+    if isdefined(vm, :T)
+        print(io, "{")
+        show(io, vm.T)
+        if isdefined(vm, :N)
+            print(io, ", ")
+            show(io, vm.N)
+        end
+        print(io, "}")
+    end
+end
+
 module IRShow
     const Compiler = Core.Compiler
     using Core.IR

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-const Chars = Union{AbstractChar,Tuple{Vararg{<:AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}}
+const Chars = Union{AbstractChar,Tuple{Vararg{AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}}
 
 # starts with and ends with predicates
 
@@ -402,7 +402,7 @@ function split(str::T, splitter;
                limit::Integer=0, keepempty::Bool=true) where {T<:AbstractString}
     _split(str, splitter, limit, keepempty, T <: SubString ? T[] : SubString{T}[])
 end
-function split(str::T, splitter::Union{Tuple{Vararg{<:AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}};
+function split(str::T, splitter::Union{Tuple{Vararg{AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}};
                limit::Integer=0, keepempty::Bool=true) where {T<:AbstractString}
     _split(str, in(splitter), limit, keepempty, T <: SubString ? T[] : SubString{T}[])
 end
@@ -478,7 +478,7 @@ function rsplit(str::T, splitter;
                 limit::Integer=0, keepempty::Bool=true) where {T<:AbstractString}
     _rsplit(str, splitter, limit, keepempty, T <: SubString ? T[] : SubString{T}[])
 end
-function rsplit(str::T, splitter::Union{Tuple{Vararg{<:AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}};
+function rsplit(str::T, splitter::Union{Tuple{Vararg{AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}};
                 limit::Integer=0, keepempty::Bool=true) where {T<:AbstractString}
     _rsplit(str, in(splitter), limit, keepempty, T <: SubString ? T[] : SubString{T}[])
 end
@@ -513,7 +513,7 @@ _replace(io, repl::Function, str, r, pattern::Function) =
 replace(str::String, pat_repl::Pair{<:AbstractChar}; count::Integer=typemax(Int)) =
     replace(str, isequal(first(pat_repl)) => last(pat_repl); count=count)
 
-replace(str::String, pat_repl::Pair{<:Union{Tuple{Vararg{<:AbstractChar}},
+replace(str::String, pat_repl::Pair{<:Union{Tuple{Vararg{AbstractChar}},
                                             AbstractVector{<:AbstractChar},Set{<:AbstractChar}}};
         count::Integer=typemax(Int)) =
     replace(str, in(first(pat_repl)) => last(pat_repl), count=count)
@@ -689,7 +689,7 @@ julia> bytes2hex(b)
 """
 function bytes2hex end
 
-function bytes2hex(a::Union{NTuple{<:Any, UInt8}, AbstractArray{UInt8}})
+function bytes2hex(a::Union{Tuple{Vararg{UInt8}}, AbstractArray{UInt8}})
     b = Base.StringVector(2*length(a))
     @inbounds for (i, x) in enumerate(a)
         b[2i - 1] = hex_chars[1 + x >> 4]
@@ -698,7 +698,7 @@ function bytes2hex(a::Union{NTuple{<:Any, UInt8}, AbstractArray{UInt8}})
     return String(b)
 end
 
-function bytes2hex(io::IO, a::Union{NTuple{<:Any, UInt8}, AbstractArray{UInt8}})
+function bytes2hex(io::IO, a::Union{Tuple{Vararg{UInt8}}, AbstractArray{UInt8}})
     for x in a
         print(io, Char(hex_chars[1 + x >> 4]), Char(hex_chars[1 + x & 0xf]))
     end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -287,9 +287,9 @@ function tuple_type_tail(T::Type)
     else
         T.name === Tuple.name || throw(MethodError(tuple_type_tail, (T,)))
         if isvatuple(T) && length(T.parameters) == 1
-            va = T.parameters[1]
-            (isa(va, DataType) && isa(va.parameters[2], Int)) || return T
-            return Tuple{Vararg{va.parameters[1], va.parameters[2]-1}}
+            va = unwrap_unionall(T.parameters[1])::Core.TypeofVararg
+            (isdefined(va, :N) && isa(va.N, Int)) || return T
+            return Tuple{Vararg{va.T, va.N-1}}
         end
         return Tuple{argtail(T.parameters...)...}
     end

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -252,7 +252,7 @@ julia> Tuple
 Tuple
 
 julia> Tuple.parameters
-svec(Vararg{Any, N} where N)
+svec(Vararg{Any})
 ```
 
 Unlike other types, tuple types are covariant in their parameters, so this definition permits

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -896,12 +896,12 @@ signature (when the signature matches).
 
 ### Vararg Tuple Types
 
-The last parameter of a tuple type can be the special type [`Vararg`](@ref), which denotes any number
+The last parameter of a tuple type can be the special value [`Vararg`](@ref), which denotes any number
 of trailing elements:
 
 ```jldoctest
 julia> mytupletype = Tuple{AbstractString,Vararg{Int}}
-Tuple{AbstractString, Vararg{Int64, N} where N}
+Tuple{AbstractString, Vararg{Int64}}
 
 julia> isa(("1",), mytupletype)
 true

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -170,6 +170,18 @@ static int egal_types(jl_value_t *a, jl_value_t *b, jl_typeenv_t *env) JL_NOTSAF
         }
         return 1;
     }
+    if (dt == jl_vararg_type)
+    {
+        jl_vararg_t *vma = (jl_vararg_t*)a;
+        jl_vararg_t *vmb = (jl_vararg_t*)b;
+        jl_value_t *vmaT = vma->T ? vma->T : (jl_value_t*)jl_any_type;
+        jl_value_t *vmbT = vmb->T ? vmb->T : (jl_value_t*)jl_any_type;
+        if (!egal_types(vmaT, vmbT, env))
+            return 0;
+        if (vma->N && vmb->N)
+            return egal_types(vma->N, vmb->N, env);
+        return !vma->N && !vmb->N;
+    }
     return jl_egal(a, b);
 }
 
@@ -289,6 +301,13 @@ static uintptr_t type_object_id_(jl_value_t *v, jl_varidx_t *env) JL_NOTSAFEPOIN
             h = bitmix(h, type_object_id_(jl_tparam(v, i), env));
         }
         return h;
+    }
+    if (tv == jl_vararg_type) {
+        jl_vararg_t *vm = (jl_vararg_t*)v;
+        jl_value_t *t = vm->T ? vm->T : (jl_value_t*)jl_any_type;
+        jl_value_t *n = vm->N ? vm->N : jl_nothing;
+        return bitmix(type_object_id_(t, env),
+            type_object_id_(n, env));
     }
     return jl_object_id_((jl_value_t*)tv, v);
 }
@@ -896,7 +915,7 @@ static jl_value_t *get_fieldtype(jl_value_t *t, jl_value_t *f, int dothrow)
     int nf = jl_svec_len(types);
     if (nf > 0 && field_index >= nf-1 && st->name == jl_tuple_typename) {
         jl_value_t *ft = jl_field_type(st, nf-1);
-        if (jl_is_vararg_type(ft))
+        if (jl_is_vararg(ft))
             return jl_unwrap_vararg(ft);
     }
     if (field_index < 0 || field_index >= nf) {
@@ -957,7 +976,7 @@ JL_CALLABLE(jl_f_isdefined)
 
 // apply_type -----------------------------------------------------------------
 
-static int valid_type_param(jl_value_t *v)
+int jl_valid_type_param(jl_value_t *v)
 {
     if (jl_is_tuple(v)) {
         // NOTE: tuples of symbols are not currently bits types, but have been
@@ -971,7 +990,7 @@ static int valid_type_param(jl_value_t *v)
         }
         return 1;
     }
-    if (jl_is_vararg_type(v))
+    if (jl_is_vararg(v))
         return 0;
     // TODO: maybe more things
     return jl_is_type(v) || jl_is_typevar(v) || jl_is_symbol(v) || jl_isbits(jl_typeof(v));
@@ -986,11 +1005,11 @@ JL_CALLABLE(jl_f_apply_type)
             jl_value_t *pi = args[i];
             // TODO: should possibly only allow Types and TypeVars, but see
             // https://github.com/JuliaLang/julia/commit/85f45974a581ab9af955bac600b90d9ab00f093b#commitcomment-13041922
-            if (jl_is_vararg_type(pi)) {
+            if (jl_is_vararg(pi)) {
                 if (i != nargs-1)
                     jl_type_error_rt("Tuple", "non-final parameter", (jl_value_t*)jl_type_type, pi);
             }
-            else if (!valid_type_param(pi)) {
+            else if (!jl_valid_type_param(pi)) {
                 jl_type_error_rt("Tuple", "parameter", (jl_value_t*)jl_type_type, pi);
             }
         }
@@ -1001,10 +1020,21 @@ JL_CALLABLE(jl_f_apply_type)
         // substituting typevars (a valid_type_param check here isn't sufficient).
         return (jl_value_t*)jl_type_union(&args[1], nargs-1);
     }
+    else if (jl_is_vararg(args[0])) {
+        jl_vararg_t *vm = (jl_vararg_t*)args[0];
+        if (!vm->T) {
+            JL_NARGS(apply_type, 2, 3);
+            return (jl_value_t*)jl_wrap_vararg(args[1], nargs == 3 ? args[2] : NULL);
+        }
+        else if (!vm->N) {
+            JL_NARGS(apply_type, 2, 2);
+            return (jl_value_t*)jl_wrap_vararg(vm->T, args[1]);
+        }
+    }
     else if (jl_is_unionall(args[0])) {
         for(i=1; i < nargs; i++) {
             jl_value_t *pi = args[i];
-            if (!valid_type_param(pi)) {
+            if (!jl_valid_type_param(pi)) {
                 jl_type_error_rt("Type", "parameter",
                                  jl_isa(pi, (jl_value_t*)jl_number_type) ?
                                  (jl_value_t*)jl_long_type : (jl_value_t*)jl_type_type,
@@ -1118,9 +1148,9 @@ JL_CALLABLE(jl_f__expr)
 // Typevar constructor for internal use
 JL_DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name, jl_value_t *lb, jl_value_t *ub)
 {
-    if ((lb != jl_bottom_type && !jl_is_type(lb) && !jl_is_typevar(lb)) || jl_is_vararg_type(lb))
+    if (lb != jl_bottom_type && !jl_is_type(lb) && !jl_is_typevar(lb))
         jl_type_error_rt("TypeVar", "lower bound", (jl_value_t *)jl_type_type, lb);
-    if ((ub != (jl_value_t *)jl_any_type && !jl_is_type(ub) && !jl_is_typevar(ub)) || jl_is_vararg_type(ub))
+    if (ub != (jl_value_t *)jl_any_type && !jl_is_type(ub) && !jl_is_typevar(ub))
         jl_type_error_rt("TypeVar", "upper bound", (jl_value_t *)jl_type_type, ub);
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_tvar_t *tv = (jl_tvar_t *)jl_gc_alloc(ptls, sizeof(jl_tvar_t), jl_tvar_type);
@@ -1256,7 +1286,6 @@ static void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
     if (!jl_is_datatype(super) || !jl_is_abstracttype(super) ||
         tt->super != NULL ||
         tt->name == ((jl_datatype_t*)super)->name ||
-        jl_subtype(super, (jl_value_t*)jl_vararg_type) ||
         jl_is_tuple_type(super) ||
         jl_is_namedtuple_type(super) ||
         jl_subtype(super, (jl_value_t*)jl_type_type) ||
@@ -1309,7 +1338,7 @@ JL_CALLABLE(jl_f__typebody)
         size_t nf = jl_svec_len(ft);
         for (size_t i = 0; i < nf; i++) {
             jl_value_t *elt = jl_svecref(ft, i);
-            if ((!jl_is_type(elt) && !jl_is_typevar(elt)) || jl_is_vararg_type(elt)) {
+            if (!jl_is_type(elt) && !jl_is_typevar(elt)) {
                 jl_type_error_rt(jl_symbol_name(dt->name->name),
                                  "type definition",
                                  (jl_value_t*)jl_type_type, elt);
@@ -1576,7 +1605,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Union", (jl_value_t*)jl_uniontype_type);
     add_builtin("TypeofBottom", (jl_value_t*)jl_typeofbottom_type);
     add_builtin("Tuple", (jl_value_t*)jl_anytuple_type);
-    add_builtin("Vararg", (jl_value_t*)jl_vararg_type);
+    add_builtin("TypeofVararg", (jl_value_t*)jl_vararg_type);
     add_builtin("SimpleVector", (jl_value_t*)jl_simplevector_type);
 
     add_builtin("Module", (jl_value_t*)jl_module_type);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -737,13 +737,13 @@ static bool is_tupletype_homogeneous(jl_svec_t *t, bool allow_va = false)
     if (l > 0) {
         jl_value_t *t0 = jl_svecref(t, 0);
         if (!jl_is_concrete_type(t0)) {
-            if (allow_va && jl_is_vararg_type(t0) &&
+            if (allow_va && jl_is_vararg(t0) &&
                   jl_is_concrete_type(jl_unwrap_vararg(t0)))
                 return true;
             return false;
         }
         for (i = 1; i < l; i++) {
-            if (allow_va && i == l - 1 && jl_is_vararg_type(jl_svecref(t, i))) {
+            if (allow_va && i == l - 1 && jl_is_vararg(jl_svecref(t, i))) {
                 if (t0 != jl_unwrap_vararg(jl_svecref(t, i)))
                     return false;
                 continue;

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -752,6 +752,7 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.endswith_lower("jl_task_t") ||
                    Name.endswith_lower("jl_uniontype_t") ||
                    Name.endswith_lower("jl_method_match_t") ||
+                   Name.endswith_lower("jl_vararg_t") ||
                    // Probably not technically true for these, but let's allow
                    // it
                    Name.endswith_lower("typemap_intersection_env") ||

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -265,7 +265,7 @@ static bool type_has_unique_rep(jl_value_t *t)
         return true;
     if (jl_is_datatype(t)) {
         jl_datatype_t *dt = (jl_datatype_t*)t;
-        if (dt->name != jl_tuple_typename && !jl_is_vararg_type(t)) {
+        if (dt->name != jl_tuple_typename) {
             for (size_t i = 0; i < jl_nparams(dt); i++)
                 if (!type_has_unique_rep(jl_tparam(dt, i)))
                     return false;
@@ -1732,7 +1732,7 @@ static std::pair<bool, bool> uses_specsig(jl_method_instance_t *lam, jl_value_t 
     if (jl_nparams(sig) == 0)
         return std::make_pair(false, false);
     if (va) {
-        if (jl_is_vararg_type(jl_tparam(sig, jl_nparams(sig) - 1)))
+        if (jl_is_vararg(jl_tparam(sig, jl_nparams(sig) - 1)))
             return std::make_pair(false, false);
     }
     // not invalid, consider if specialized signature is worthwhile
@@ -2996,7 +2996,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                     if (obj.ispointer()) {
                         // Determine which was the type that was homogenous
                         jl_value_t *jt = jl_tparam0(utt);
-                        if (jl_is_vararg_type(jt))
+                        if (jl_is_vararg(jt))
                             jt = jl_unwrap_vararg(jt);
                         Value *vidx = emit_unbox(ctx, T_size, fld, (jl_value_t*)jl_long_type);
                         // This is not necessary for correctness, but allows to omit
@@ -5255,7 +5255,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
 
     // some sanity checking and check whether there's a vararg
     size_t nargt = jl_svec_len(argt);
-    bool isVa = (nargt > 0 && jl_is_vararg_type(jl_svecref(argt, nargt - 1)));
+    bool isVa = (nargt > 0 && jl_is_vararg(jl_svecref(argt, nargt - 1)));
     if (isVa) {
         emit_error(ctx, "cfunction: Vararg syntax not allowed for argument list");
         return jl_cgval_t();

--- a/src/dump.c
+++ b/src/dump.c
@@ -2637,7 +2637,8 @@ void jl_init_serializer(void)
 
                      jl_bool_type, jl_linenumbernode_type, jl_pinode_type,
                      jl_upsilonnode_type, jl_type_type, jl_bottom_type, jl_ref_type,
-                     jl_pointer_type, jl_vararg_type, jl_abstractarray_type, jl_nothing_type,
+                     jl_pointer_type, jl_abstractarray_type, jl_nothing_type,
+                     jl_vararg_type,
                      jl_densearray_type, jl_function_type, jl_typename_type,
                      jl_builtin_type, jl_task_type, jl_uniontype_type,
                      jl_array_any_type, jl_intrinsic_type,

--- a/src/gf.c
+++ b/src/gf.c
@@ -530,7 +530,7 @@ jl_value_t *jl_nth_slot_type(jl_value_t *sig, size_t i) JL_NOTSAFEPOINT
         return NULL;
     if (i < len-1)
         return jl_tparam(sig, i);
-    if (jl_is_vararg_type(jl_tparam(sig, len-1)))
+    if (jl_is_vararg(jl_tparam(sig, len-1)))
         return jl_unwrap_vararg(jl_tparam(sig, len-1));
     if (i == len-1)
         return jl_tparam(sig, i);
@@ -631,6 +631,10 @@ static void jl_compilation_sig(
                 }
                 continue;
             }
+        }
+
+        if (jl_is_vararg(elt)) {
+            continue;
         }
 
         if (jl_types_equal(elt, (jl_value_t*)jl_type_type)) { // elt == Type{T} where T
@@ -738,7 +742,10 @@ static void jl_compilation_sig(
         size_t j = i;
         int all_are_subtypes = 1;
         for (; j < jl_svec_len(*newparams); j++) {
-            if (!jl_subtype(jl_svecref(*newparams, j), lasttype)) {
+            jl_value_t *paramj = jl_svecref(*newparams, j);
+            if (jl_is_vararg(paramj))
+                paramj = jl_unwrap_vararg(paramj);
+            if (!jl_subtype(paramj, lasttype)) {
                 all_are_subtypes = 0;
                 break;
             }
@@ -752,7 +759,7 @@ static void jl_compilation_sig(
         else {
             jl_value_t *unw = jl_unwrap_unionall(decl);
             jl_value_t *lastdeclt = jl_tparam(unw, nargs - 1);
-            assert(jl_is_vararg_type(lastdeclt) && jl_nparams(unw) == nargs);
+            assert(jl_is_vararg(lastdeclt) && jl_nparams(unw) == nargs);
             int nsp = jl_svec_len(sparams);
             if (nsp > 0 && jl_has_free_typevars(lastdeclt)) {
                 assert(jl_subtype_env_size(decl) == nsp);
@@ -813,7 +820,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
                 nspec_max = nspec_min;
         }
         int isbound = (jl_va_tuple_kind((jl_datatype_t*)decl) == JL_VARARG_UNBOUND);
-        if (jl_is_vararg_type(jl_tparam(type, np - 1))) {
+        if (jl_is_vararg(jl_tparam(type, np - 1))) {
             if (!isbound || np < nspec_min || np > nspec_max)
                 return 0;
         }
@@ -822,7 +829,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
                 return 0;
         }
     }
-    else if (np != nargs || jl_is_vararg_type(jl_tparam(type, np - 1))) {
+    else if (np != nargs || jl_is_vararg(jl_tparam(type, np - 1))) {
         return 0;
     }
 
@@ -831,7 +838,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
         jl_value_t *decl_i = jl_nth_slot_type((jl_value_t*)decl, i);
         size_t i_arg = (i < nargs - 1 ? i : nargs - 1);
 
-        if (jl_is_vararg_type(elt)) {
+        if (jl_is_vararg(elt)) {
             elt = jl_unwrap_vararg(elt);
             if (jl_has_free_typevars(decl_i)) {
                 // TODO: in this case, answer semi-conservatively that these varargs are always compilable
@@ -955,7 +962,7 @@ static int concretesig_equal(jl_value_t *tt, jl_value_t *simplesig) JL_NOTSAFEPO
     jl_value_t **sigs = jl_svec_data(((jl_datatype_t*)simplesig)->parameters);
     size_t i, lensig = jl_nparams(simplesig);
     assert(lensig == jl_nparams(tt));
-    assert(lensig > 0 && !jl_is_vararg_type(jl_tparam(simplesig, lensig - 1)));
+    assert(lensig > 0 && !jl_is_vararg(jl_tparam(simplesig, lensig - 1)));
     for (i = 0; i < lensig; i++) {
         jl_value_t *decl = sigs[i];
         jl_value_t *a = types[i];
@@ -1047,7 +1054,8 @@ static jl_method_instance_t *cache_method(
                 jl_svec_t *env = matc->sparams;
                 int k, l;
                 for (k = 0, l = jl_svec_len(env); k < l; k++) {
-                    if (jl_is_typevar(jl_svecref(env, k))) {
+                    jl_value_t *env_k = jl_svecref(env, k);
+                    if (jl_is_typevar(env_k) || jl_is_vararg(env_k)) {
                         unmatched_tvars = 1;
                         break;
                     }
@@ -1104,7 +1112,7 @@ static jl_method_instance_t *cache_method(
     newparams = NULL;
     for (i = 0; i < np; i++) {
         jl_value_t *elt = jl_svecref(cachett->parameters, i);
-        if (jl_is_vararg_type(elt)) {
+        if (jl_is_vararg(elt)) {
         }
         else if (jl_is_type_type(elt)) {
             // TODO: if (!jl_is_singleton(elt)) ...
@@ -1225,7 +1233,7 @@ static jl_value_t *get_intersect_matches(jl_typemap_t *defs, jl_typemap_entry_t 
     jl_value_t *va = NULL;
     if (l > 0) {
         va = jl_tparam(ttypes, l - 1);
-        if (jl_is_vararg_type(va))
+        if (jl_is_vararg(va))
             va = jl_unwrap_vararg(va);
         else
             va = NULL;
@@ -2668,7 +2676,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
     jl_value_t *va = NULL;
     if (l > 0) {
         va = jl_tparam(unw, l - 1);
-        if (jl_is_vararg_type(va))
+        if (jl_is_vararg(va))
             va = jl_unwrap_vararg(va);
         else
             va = NULL;
@@ -3125,7 +3133,7 @@ int jl_has_concrete_subtype(jl_value_t *typ)
     if (typ == jl_bottom_type)
         return 0;
     typ = jl_unwrap_unionall(typ);
-    if (jl_is_vararg_type(typ))
+    if (jl_is_vararg(typ))
         typ = jl_unwrap_vararg(typ);
     if (!jl_is_datatype(typ))
         return 1;

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -111,7 +111,6 @@
     XX(jl_uniontype_type) \
     XX(jl_upsilonnode_type) \
     XX(jl_vararg_type) \
-    XX(jl_vararg_typename) \
     XX(jl_vecelement_typename) \
     XX(jl_void_type) \
     XX(jl_voidpointer_type) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -43,6 +43,14 @@ static int has_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
     if (jl_is_uniontype(v))
         return has_free_typevars(((jl_uniontype_t*)v)->a, env) ||
             has_free_typevars(((jl_uniontype_t*)v)->b, env);
+    if (jl_is_vararg(v)) {
+        jl_vararg_t *vm = (jl_vararg_t*)v;
+        if (vm->T) {
+            if (has_free_typevars(vm->T, env))
+                return 1;
+            return vm->N && has_free_typevars(vm->N, env);
+        }
+    }
     if (jl_is_unionall(v)) {
         jl_unionall_t *ua = (jl_unionall_t*)v;
         jl_typeenv_t newenv = { ua->var, NULL, env };
@@ -79,6 +87,15 @@ static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out
         find_free_typevars(((jl_uniontype_t*)v)->a, env, out);
         find_free_typevars(((jl_uniontype_t*)v)->b, env, out);
     }
+    else if (jl_is_vararg(v)) {
+        jl_vararg_t *vm = (jl_vararg_t *)v;
+        if (vm->T) {
+            find_free_typevars(vm->T, env, out);
+            if (vm->N) {
+                find_free_typevars(vm->N, env, out);
+            }
+        }
+    }
     else if (jl_is_unionall(v)) {
         jl_unionall_t *ua = (jl_unionall_t*)v;
         jl_typeenv_t newenv = { ua->var, NULL, env };
@@ -112,6 +129,11 @@ static int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOI
     if (jl_is_uniontype(v))
         return jl_has_bound_typevars(((jl_uniontype_t*)v)->a, env) ||
             jl_has_bound_typevars(((jl_uniontype_t*)v)->b, env);
+    if (jl_is_vararg(v)) {
+        jl_vararg_t *vm = (jl_vararg_t *)v;
+        return vm->T && (jl_has_bound_typevars(vm->T, env) ||
+            (vm->N && jl_has_bound_typevars(vm->N, env)));
+    }
     if (jl_is_unionall(v)) {
         jl_unionall_t *ua = (jl_unionall_t*)v;
         if (jl_has_bound_typevars(ua->var->lb, env) || jl_has_bound_typevars(ua->var->ub, env))
@@ -359,7 +381,7 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
     size_t i;
     for(i=0; i < n; i++) {
         jl_value_t *pi = ts[i];
-        if (!(jl_is_type(pi) || jl_is_typevar(pi)) || jl_is_vararg_type(pi))
+        if (!(jl_is_type(pi) || jl_is_typevar(pi)))
             jl_type_error("Union", (jl_value_t*)jl_type_type, pi);
     }
     if (n == 1) return ts[0];
@@ -407,6 +429,34 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
 
 JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body)
 {
+    if (jl_is_vararg(body)) {
+        if (jl_options.depwarn) {
+            if (jl_options.depwarn == JL_OPTIONS_DEPWARN_ERROR)
+                jl_error("Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).");
+            jl_printf(JL_STDERR, "WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).");
+        }
+        jl_vararg_t *vm = (jl_vararg_t*)body;
+        int T_has_tv = vm->T && jl_has_typevar(vm->T, v);
+        int N_has_tv = vm->N && jl_has_typevar(vm->N, v);
+        if (!T_has_tv && !N_has_tv) {
+            return body;
+        }
+        if (T_has_tv && N_has_tv) {
+            jl_error("Wrapping `Vararg` directly in UnionAll is disallowed if the typevar occurs in both `T` and `N`");
+        }
+        if (T_has_tv) {
+            jl_value_t *wrapped = jl_type_unionall(v, vm->T);
+            JL_GC_PUSH1(&wrapped);
+            wrapped = (jl_value_t*)jl_wrap_vararg(wrapped, vm->N);
+            JL_GC_POP();
+            return wrapped;
+        }
+        else {
+            assert(N_has_tv);
+            assert(vm->N == (jl_value_t*)v);
+            return (jl_value_t*)jl_wrap_vararg(vm->T, NULL);
+        }
+    }
     if (!jl_is_type(body) && !jl_is_typevar(body))
         jl_type_error("UnionAll", (jl_value_t*)jl_type_type, body);
     // normalize `T where T<:S` => S
@@ -579,7 +629,7 @@ static ssize_t lookup_type_idx_linearvalue(jl_svec_t *cache, jl_value_t *key1, j
     return ~cl;
 }
 
-static jl_value_t *lookup_type(jl_typename_t *tn, jl_value_t **key, size_t n)
+static jl_value_t *lookup_type(jl_typename_t *tn JL_PROPAGATES_ROOT, jl_value_t **key, size_t n)
 {
     JL_TIMING(TYPE_CACHE_LOOKUP);
     unsigned hv = typekey_hash(tn, key, n, 0);
@@ -966,6 +1016,15 @@ static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
         // ignore var and lb, since those might get normalized out in equality testing
         return type_hash(((jl_tvar_t*)uw)->ub, failed);
     }
+    else if (jl_is_vararg(uw)) {
+        if (!*failed) {
+            *failed = 1;
+            return 0;
+        }
+        jl_vararg_t *vm = (jl_vararg_t *)uw;
+        // 0x064eeaab is just a randomly chosen constant
+        return bitmix(type_hash(vm->T ? vm->T : (jl_value_t*)jl_any_type, failed), vm->N ? type_hash(vm->N, failed) : 0x064eeaab);
+    }
     else if (jl_is_uniontype(uw)) {
         if (!*failed) {
             *failed = 1;
@@ -1025,8 +1084,6 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable)
     dt->hasfreetypevars = 0;
     dt->isconcretetype = !dt->abstract;
     dt->isdispatchtuple = istuple;
-    if (dt->name == jl_vararg_typename)
-        dt->isconcretetype = 0;
     size_t i, l = jl_nparams(dt);
     for (i = 0; i < l; i++) {
         jl_value_t *p = jl_tparam(dt, i);
@@ -1096,30 +1153,6 @@ static jl_value_t *extract_wrapper(jl_value_t *t JL_PROPAGATES_ROOT) JL_GLOBALLY
     return NULL;
 }
 
-// convert `Vararg{X, Y} where T` to `Vararg{X where T, Y}` where T doesn't occur free in Y
-static jl_value_t *normalize_vararg(jl_value_t *va)
-{
-    assert(jl_is_vararg_type(va));
-    if (!jl_is_unionall(va)) return va;
-    jl_value_t *body=NULL;
-    JL_GC_PUSH2(&va, &body);
-    jl_unionall_t *ua = (jl_unionall_t*)va;
-    body = normalize_vararg(ua->body);
-    jl_value_t *unw = jl_unwrap_unionall(body);
-    jl_value_t *va0 = jl_tparam0(unw), *va1 = jl_tparam1(unw);
-    if (jl_has_typevar(va1, ua->var)) {
-        if (body != ua->body)
-            va = jl_type_unionall(ua->var, body);
-    }
-    else {
-        va = jl_type_unionall(ua->var, va0);
-        va = jl_wrap_vararg(va, va1);
-        va = jl_rewrap_unionall(va, body);
-    }
-    JL_GC_POP();
-    return va;
-}
-
 static jl_value_t *_jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals, jl_typeenv_t *prev, jl_typestack_t *stack);
 
 static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **iparams, size_t ntp,
@@ -1138,7 +1171,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 continue;
             if (jl_is_datatype(pi))
                 continue;
-            if (jl_is_vararg_type(pi)) {
+            if (jl_is_vararg(pi)) {
                 pi = jl_unwrap_vararg(pi);
                 if (jl_has_free_typevars(pi))
                     continue;
@@ -1149,7 +1182,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                     jl_types_equal(pi, tw)) {
                 // This would require some special handling, but is never used at
                 // the moment.
-                assert(!jl_is_vararg_type(iparams[i]));
+                assert(!jl_is_vararg(iparams[i]));
                 iparams[i] = tw;
                 if (p) jl_gc_wb(p, tw);
             }
@@ -1163,20 +1196,6 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         return stack_lkup;
 
     if (!istuple) {
-        if (jl_is_vararg_type((jl_value_t*)dt) && ntp == 2) {
-            jl_value_t *lenparam = iparams[1];
-            if (jl_is_typevar(lenparam)) {
-                jl_tvar_t *N = (jl_tvar_t*)lenparam;
-                if (!(N->lb == jl_bottom_type && N->ub == (jl_value_t*)jl_any_type))
-                    jl_error("TypeVar in Vararg length must have bounds Union{} and Any");
-            }
-            else if (!jl_is_long(lenparam)) {
-                jl_type_error_rt("Vararg", "count", (jl_value_t*)jl_long_type, lenparam);
-            }
-            else if (jl_unbox_long(lenparam) < 0) {
-                jl_errorf("Vararg length is negative: %zd", jl_unbox_long(lenparam));
-            }
-        }
         // check parameters against bounds in type definition
         check_datatype_parameters(tn, iparams, ntp);
     }
@@ -1190,29 +1209,17 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
     JL_GC_PUSH3(&p, &ndt, &last);
 
     int isvatuple = 0;
-    if (istuple && ntp > 0 && jl_is_vararg_type(last)) {
+    if (istuple && ntp > 0 && jl_is_vararg(last)) {
         isvatuple = 1;
         // normalize Tuple{..., Vararg{Int, 3}} to Tuple{..., Int, Int, Int}
         jl_value_t *va = jl_unwrap_unionall(last);
-        jl_value_t *va0 = jl_tparam0(va), *va1 = jl_tparam1(va);
+        jl_value_t *va0 = jl_unwrap_vararg(va), *va1 = jl_unwrap_vararg_num(va);
         // return same `Tuple` object for types equal to it
-        if (ntp == 1 &&
-            (last == (jl_value_t*)jl_vararg_type ||  // Tuple{Vararg} == Tuple
-             (va0 == (jl_value_t*)jl_any_type &&
-              jl_is_unionall(last) && va1 == (jl_value_t*)((jl_unionall_t*)last)->var))) {
+        if (ntp == 1 && va0 == (jl_value_t*)jl_any_type && !va1) {
             JL_GC_POP();
             return (jl_value_t*)jl_anytuple_type;
         }
-        int did_normalize = 0;
-        jl_value_t *last2 = normalize_vararg(last);
-        assert(!jl_is_unionall(last2) || !jl_is_unionall(((jl_unionall_t*)last2)->body));
-        if (last2 != last) {
-            last = last2;
-            did_normalize = 1;
-            va = jl_unwrap_unionall(last);
-            va0 = jl_tparam0(va); va1 = jl_tparam1(va);
-        }
-        if (jl_is_long(va1)) {
+        if (va1 && jl_is_long(va1)) {
             ssize_t nt = jl_unbox_long(va1);
             assert(nt >= 0);
             if (nt == 0 || !jl_has_free_typevars(va0)) {
@@ -1231,12 +1238,6 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 JL_GC_POP();
                 return ndt;
             }
-        }
-        if (did_normalize) {
-            p = jl_alloc_svec(ntp);
-            for (size_t i = 0; i < ntp-1; i++)
-                jl_svecset(p, i, iparams[i]);
-            jl_svecset(p, ntp-1, last);
         }
     }
 
@@ -1462,8 +1463,8 @@ static jl_value_t *inst_tuple_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_
         // a fixed-length tuple
         jl_value_t *T=NULL, *N=NULL;
         jl_value_t *va = jl_unwrap_unionall(jl_tparam0(tt));
-        jl_value_t *ttT = jl_tparam0(va);
-        jl_value_t *ttN = jl_tparam1(va);
+        jl_value_t *ttT = jl_unwrap_vararg(va);
+        jl_value_t *ttN = jl_unwrap_vararg_num(va);
         jl_typeenv_t *e = env;
         while (e != NULL) {
             if ((jl_value_t*)e->var == ttT)
@@ -1563,6 +1564,22 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t
         JL_GC_POP();
         return t;
     }
+    if (jl_is_vararg(t)) {
+        jl_vararg_t *v = (jl_vararg_t*)t;
+        jl_value_t *T = NULL;
+        jl_value_t *N = NULL;
+        JL_GC_PUSH2(&T, &N);
+        if (v->T) {
+            T = inst_type_w_(v->T, env, stack, check);
+            if (v->N)
+                N = inst_type_w_(v->N, env, stack, check);
+        }
+        if (T != v->T || N != v->N) {
+            t = (jl_value_t*)jl_wrap_vararg(T, N);
+        }
+        JL_GC_POP();
+        return t;
+    }
     if (!jl_is_datatype(t))
         return t;
     jl_datatype_t *tt = (jl_datatype_t*)t;
@@ -1633,19 +1650,31 @@ jl_datatype_t *jl_wrap_Type(jl_value_t *t)
     return (jl_datatype_t*)jl_instantiate_unionall(jl_type_type, t);
 }
 
-jl_value_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n)
+jl_vararg_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n)
 {
-    if (t == NULL) {
-        assert(n == NULL);
-        return (jl_value_t*)jl_vararg_type;
+    if (n) {
+        if (jl_is_typevar(n)) {
+            jl_tvar_t *N = (jl_tvar_t*)n;
+            if (!(N->lb == jl_bottom_type && N->ub == (jl_value_t*)jl_any_type))
+                jl_error("TypeVar in Vararg length must have bounds Union{} and Any");
+        }
+        else if (!jl_is_long(n)) {
+            jl_type_error_rt("Vararg", "count", (jl_value_t*)jl_long_type, n);
+        }
+        else if (jl_unbox_long(n) < 0) {
+            jl_errorf("Vararg length is negative: %zd", jl_unbox_long(n));
+        }
     }
-    jl_value_t *vt = jl_instantiate_unionall(jl_vararg_type, t);
-    if (n == NULL)
-        return vt;
-    JL_GC_PUSH1(&vt);
-    jl_value_t *vn = jl_instantiate_unionall((jl_unionall_t*)vt, n);
-    JL_GC_POP();
-    return vn;
+    if (t) {
+        if (!jl_valid_type_param(t)) {
+            jl_type_error_rt("Vararg", "type", (jl_value_t*)jl_type_type, t);
+        }
+    }
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_vararg_t *vm = (jl_vararg_t *)jl_gc_alloc(ptls, sizeof(jl_vararg_t), jl_vararg_type);
+    vm->T = t;
+    vm->N = n;
+    return vm;
 }
 
 JL_DLLEXPORT jl_svec_t *jl_compute_fieldtypes(jl_datatype_t *st JL_PROPAGATES_ROOT, void *stack)
@@ -1889,10 +1918,10 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_svec(2, jl_tvar_type, jl_any_type),
                                        0, 0, 2);
 
-    jl_svec_t *tv;
-    tv = jl_svec2(tvar("T"),tvar("N"));
-    jl_vararg_type = (jl_unionall_t*)jl_new_abstracttype((jl_value_t*)jl_symbol("Vararg"), core, jl_any_type, tv)->name->wrapper;
-    jl_vararg_typename = ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_vararg_type))->name;
+    jl_vararg_type = jl_new_datatype(jl_symbol("TypeofVararg"), core, jl_any_type, jl_emptysvec,
+                                            jl_perm_symsvec(2, "T", "N"),
+                                            jl_svec(2, jl_any_type, jl_any_type),
+                                            0, 0, 0);
 
     jl_svec_t *anytuple_params = jl_svec(1, jl_wrap_vararg((jl_value_t*)jl_any_type, (jl_value_t*)NULL));
     jl_anytuple_type = jl_new_datatype(jl_symbol("Tuple"), core, jl_any_type, anytuple_params,
@@ -2014,7 +2043,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_function_type->name->mt = NULL; // subtypes of Function have independent method tables
     jl_builtin_type->name->mt = NULL;  // so they don't share the Any type table
 
-    tv = jl_svec2(tvar("T"), tvar("N"));
+    jl_svec_t *tv = jl_svec2(tvar("T"), tvar("N"));
     jl_abstractarray_type = (jl_unionall_t*)
         jl_new_abstracttype((jl_value_t*)jl_symbol("AbstractArray"), core,
                             jl_any_type, tv)->name->wrapper;

--- a/src/julia.h
+++ b/src/julia.h
@@ -481,6 +481,12 @@ typedef struct _jl_datatype_t {
     uint8_t cached_by_hash; // stored in hash-based set cache (instead of linear cache)
 } jl_datatype_t;
 
+typedef struct _jl_vararg_t {
+    JL_DATA_TYPE
+    jl_value_t *T;
+    jl_value_t *N;
+} jl_vararg_t;
+
 typedef struct {
     JL_DATA_TYPE
     jl_value_t *value;
@@ -621,8 +627,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_anytuple_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_emptytuple_type JL_GLOBALLY_ROOTED;
 #define jl_tuple_type jl_anytuple_type
 extern JL_DLLIMPORT jl_unionall_t *jl_anytuple_type_type JL_GLOBALLY_ROOTED;
-extern JL_DLLIMPORT jl_unionall_t *jl_vararg_type JL_GLOBALLY_ROOTED;
-extern JL_DLLIMPORT jl_typename_t *jl_vararg_typename JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_vararg_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_function_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_builtin_type JL_GLOBALLY_ROOTED;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -422,6 +422,8 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void);
 void jl_resolve_globals_in_ir(jl_array_t *stmts, jl_module_t *m, jl_svec_t *sparam_vals,
                               int binding_effects);
 
+int jl_valid_type_param(jl_value_t *v);
+
 JL_DLLEXPORT jl_value_t *jl_apply_2va(jl_value_t *f, jl_value_t **args, uint32_t nargs);
 
 void JL_NORETURN jl_method_error(jl_function_t *f, jl_value_t **args, size_t na, size_t world);
@@ -482,7 +484,7 @@ jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_module_t *module,
 jl_datatype_t *jl_new_uninitialized_datatype(void);
 void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable);
 jl_datatype_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}
-jl_value_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n);
+jl_vararg_t *jl_wrap_vararg(jl_value_t *t, jl_value_t *n);
 void jl_reinstantiate_inner_types(jl_datatype_t *t);
 jl_datatype_t *jl_lookup_cache_type_(jl_datatype_t *type);
 void jl_cache_type_(jl_datatype_t *type);
@@ -541,51 +543,49 @@ typedef enum {
     JL_VARARG_UNBOUND = 3
 } jl_vararg_kind_t;
 
-STATIC_INLINE int jl_is_vararg_type(jl_value_t *v) JL_NOTSAFEPOINT
+STATIC_INLINE int jl_is_vararg(jl_value_t *v) JL_NOTSAFEPOINT
 {
-    v = jl_unwrap_unionall(v);
-    return (jl_is_datatype(v) &&
-            ((jl_datatype_t*)(v))->name == jl_vararg_typename);
+    return jl_typeof(v) == (jl_value_t*)jl_vararg_type;
 }
 
-STATIC_INLINE jl_value_t *jl_unwrap_vararg(jl_value_t *v) JL_NOTSAFEPOINT
+STATIC_INLINE jl_value_t *jl_unwrap_vararg(jl_vararg_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
-    return jl_tparam0(jl_unwrap_unionall(v));
+    assert(jl_is_vararg((jl_value_t*)v));
+    jl_value_t *T = ((jl_vararg_t*)v)->T;
+    return T ? T : (jl_value_t*)jl_any_type;
 }
+#define jl_unwrap_vararg(v) (jl_unwrap_vararg)((jl_vararg_t *)v)
+
+STATIC_INLINE jl_value_t *jl_unwrap_vararg_num(jl_vararg_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
+{
+    assert(jl_is_vararg((jl_value_t*)v));
+    return ((jl_vararg_t*)v)->N;
+}
+#define jl_unwrap_vararg_num(v) (jl_unwrap_vararg_num)((jl_vararg_t *)v)
 
 STATIC_INLINE jl_vararg_kind_t jl_vararg_kind(jl_value_t *v) JL_NOTSAFEPOINT
 {
-    if (!jl_is_vararg_type(v))
+    if (!jl_is_vararg(v))
         return JL_VARARG_NONE;
-    jl_tvar_t *v1=NULL, *v2=NULL;
-    if (jl_is_unionall(v)) {
-        v1 = ((jl_unionall_t*)v)->var;
-        v = ((jl_unionall_t*)v)->body;
-        if (jl_is_unionall(v)) {
-            v2 = ((jl_unionall_t*)v)->var;
-            v = ((jl_unionall_t*)v)->body;
-        }
-    }
-    assert(jl_is_datatype(v));
-    jl_value_t *lenv = jl_tparam1(v);
-    if (jl_is_long(lenv))
+    jl_vararg_t *vm = (jl_vararg_t *)v;
+    if (!vm->N)
+        return JL_VARARG_UNBOUND;
+    if (jl_is_long(vm->N))
         return JL_VARARG_INT;
-    if (jl_is_typevar(lenv) && lenv != (jl_value_t*)v1 && lenv != (jl_value_t*)v2)
-        return JL_VARARG_BOUND;
-    return JL_VARARG_UNBOUND;
+    return JL_VARARG_BOUND;
 }
 
 STATIC_INLINE int jl_is_va_tuple(jl_datatype_t *t) JL_NOTSAFEPOINT
 {
     assert(jl_is_tuple_type(t));
     size_t l = jl_svec_len(t->parameters);
-    return (l>0 && jl_is_vararg_type(jl_tparam(t,l-1)));
+    return (l>0 && jl_is_vararg(jl_tparam(t,l-1)));
 }
 
 STATIC_INLINE size_t jl_vararg_length(jl_value_t *v) JL_NOTSAFEPOINT
 {
-    assert(jl_is_vararg_type(v));
-    jl_value_t *len = jl_tparam1(jl_unwrap_unionall(v));
+    assert(jl_is_vararg(v));
+    jl_value_t *len = jl_unwrap_vararg_num(v);
     assert(jl_is_long(len));
     return jl_unbox_long(len);
 }

--- a/src/method.c
+++ b/src/method.c
@@ -711,7 +711,7 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata,
     jl_svec_t *tvars = (jl_svec_t*)jl_svecref(argdata, 1);
     jl_value_t *functionloc = jl_svecref(argdata, 2);
     size_t nargs = jl_svec_len(atypes);
-    int isva = jl_is_vararg_type(jl_svecref(atypes, nargs - 1));
+    int isva = jl_is_vararg(jl_svecref(atypes, nargs - 1));
     assert(jl_is_svec(atypes));
     assert(nargs > 0);
     assert(jl_is_svec(tvars));
@@ -780,7 +780,7 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata,
 
     for (i = 0; i < na; i++) {
         jl_value_t *elt = jl_svecref(atypes, i);
-        if (!jl_is_type(elt) && !jl_is_typevar(elt)) {
+        if (!jl_is_type(elt) && !jl_is_typevar(elt) && !jl_is_vararg(elt)) {
             jl_sym_t *argname = (jl_sym_t*)jl_array_ptr_ref(f->slotnames, i);
             if (argname == unused_sym)
                 jl_exceptionf(jl_argumenterror_type,
@@ -797,7 +797,7 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata,
                               jl_symbol_name(m->file),
                               m->line);
         }
-        if (jl_is_vararg_type(elt) && i < na-1)
+        if (jl_is_vararg(elt) && i < na-1)
             jl_exceptionf(jl_argumenterror_type,
                           "Vararg on non-final argument in method definition for %s at %s:%d",
                           jl_symbol_name(name),

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -734,6 +734,19 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         // avoid printing `typeof(Type)` for `UnionAll`.
         n += jl_printf(out, "UnionAll");
     }
+    else if (vt == jl_vararg_type) {
+        jl_vararg_t *vm = (jl_vararg_t*)v;
+        n += jl_printf(out, "Vararg");
+        if (vm->T) {
+            n += jl_printf(out, "{");
+            n += jl_static_show_x(out, vm->T, depth);
+            if (vm->N) {
+                n += jl_printf(out, ", ");
+                n += jl_static_show_x(out, vm->N, depth);
+            }
+            n += jl_printf(out, "}");
+        }
+    }
     else if (vt == jl_datatype_type) {
         // typeof(v) == DataType, so v is a Type object.
         // Types are printed as a fully qualified name, with parameters, e.g.
@@ -1215,7 +1228,7 @@ JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_N
             n += jl_printf(s, ", ");
         }
         else {
-            if (jl_is_vararg_type(tp)) {
+            if (jl_is_vararg(tp)) {
                 n += jl_static_show(s, jl_unwrap_vararg(tp));
                 n += jl_printf(s, "...");
             }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -30,7 +30,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    146
+#define NUM_TAGS    145
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -131,7 +131,6 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_llvmpointer_typename);
         INSERT_TAG(jl_array_typename);
         INSERT_TAG(jl_type_typename);
-        INSERT_TAG(jl_vararg_typename);
         INSERT_TAG(jl_namedtuple_typename);
         INSERT_TAG(jl_vecelement_typename);
 

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -222,6 +222,12 @@ static int obviously_egal(jl_value_t *a, jl_value_t *b)
         return ((jl_unionall_t*)a)->var == ((jl_unionall_t*)b)->var &&
             obviously_egal(((jl_unionall_t*)a)->body, ((jl_unionall_t*)b)->body);
     }
+    if (jl_is_vararg(a)) {
+        jl_vararg_t *vma = (jl_vararg_t *)a;
+        jl_vararg_t *vmb = (jl_vararg_t *)b;
+        return obviously_egal(jl_unwrap_vararg(vma), jl_unwrap_vararg(vmb)) &&
+            ((!vma->N && !vmb->N) || (vma->N && vmb->N && obviously_egal(vma->N, vmb->N)));
+    }
     if (jl_is_typevar(a)) return 0;
     return !jl_is_type(a) && jl_egal(a,b);
 }
@@ -719,7 +725,9 @@ static int with_tvar(tvar_callback callback, void *context, jl_unionall_t *u, in
         // fill variable values into `envout` up to `envsz`
         if (e->envidx < e->envsz) {
             jl_value_t *val;
-            if (!vb.occurs_inv && vb.lb != jl_bottom_type)
+            if (vb.intvalued && vb.lb == (jl_value_t*)jl_any_type)
+                val = (jl_value_t*)jl_wrap_vararg(NULL, NULL);
+            else if (!vb.occurs_inv && vb.lb != jl_bottom_type)
                 val = is_leaf_bound(vb.lb) ? vb.lb : (jl_value_t*)jl_new_typevar(u->var->name, jl_bottom_type, vb.lb);
             else if (vb.lb == vb.ub)
                 val = vb.lb;
@@ -841,26 +849,12 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
     return res;
 }
 
-// unwrap <=1 layers of UnionAlls, leaving the var in *p1 the body
-static jl_datatype_t *unwrap_1_unionall(jl_value_t *t, jl_tvar_t **p1) JL_NOTSAFEPOINT
-{
-    assert(t);
-    if (jl_is_unionall(t)) {
-        *p1 = ((jl_unionall_t*)t)->var;
-        t = ((jl_unionall_t*)t)->body;
-    }
-    assert(jl_is_datatype(t));
-    return (jl_datatype_t*)t;
-}
-
 // check n <: (length of vararg type v)
 static int check_vararg_length(jl_value_t *v, ssize_t n, jl_stenv_t *e)
 {
-    jl_tvar_t *va_p1=NULL;
-    jl_datatype_t *tail = unwrap_1_unionall(v, &va_p1);
-    jl_value_t *N = jl_tparam1(tail);
+    jl_value_t *N = jl_unwrap_vararg_num(v);
     // only do the check if N is free in the tuple type's last parameter
-    if (N != (jl_value_t*)va_p1) {
+    if (N) {
         jl_value_t *nn = jl_box_long(n);
         JL_GC_PUSH1(&nn);
         e->invdepth++;
@@ -890,28 +884,25 @@ struct subtype_tuple_env {
 
 static int subtype_tuple_varargs(struct subtype_tuple_env *env, jl_stenv_t *e, int param)
 {
-    jl_tvar_t *yv1=NULL;
-    jl_datatype_t *yva = unwrap_1_unionall(env->vty, &yv1);
-    jl_tvar_t *xv1=NULL;
-    jl_datatype_t *xva = unwrap_1_unionall(env->vtx, &xv1);
+    jl_value_t *xp0 = jl_unwrap_vararg(env->vtx); jl_value_t *xp1 = jl_unwrap_vararg_num(env->vtx);
+    jl_value_t *yp0 = jl_unwrap_vararg(env->vty); jl_value_t *yp1 = jl_unwrap_vararg_num(env->vty);
 
-    jl_value_t *xp0 = jl_tparam0(xva); jl_value_t *xp1 = jl_tparam1(xva);
-    jl_value_t *yp0 = jl_tparam0(yva); jl_value_t *yp1 = jl_tparam1(yva);
-
-    if (!jl_is_datatype(env->vtx)) {
-        // Unconstrained on the left, constrained on the right
+    if (!xp1) {
         jl_value_t *yl = yp1;
-        if (jl_is_typevar(yl)) {
-            jl_varbinding_t *ylv = lookup(e, (jl_tvar_t*)yl);
-            if (ylv)
-                yl = ylv->lb;
-        }
-        if (jl_is_long(yl)) {
-            return 0;
+        if (yl) {
+            // Unconstrained on the left, constrained on the right
+            if (jl_is_typevar(yl)) {
+                jl_varbinding_t *ylv = lookup(e, (jl_tvar_t*)yl);
+                if (ylv)
+                    yl = ylv->lb;
+            }
+            if (jl_is_long(yl)) {
+                return 0;
+            }
         }
     }
     else {
-        jl_value_t *xl = jl_tparam1(env->vtx);
+        jl_value_t *xl = jl_unwrap_vararg_num(env->vtx);
         if (jl_is_typevar(xl)) {
             jl_varbinding_t *xlv = lookup(e, (jl_tvar_t*)xl);
             if (xlv)
@@ -922,15 +913,17 @@ static int subtype_tuple_varargs(struct subtype_tuple_env *env, jl_stenv_t *e, i
                 // LHS is exhausted. We're a subtype if the RHS is either
                 // exhausted as well or unbounded (in which case we need to
                 // set it to 0).
-                if (jl_is_datatype(env->vty)) {
-                    jl_value_t *yl = jl_tparam1(env->vty);
-                    if (jl_is_typevar(yl)) {
-                        jl_varbinding_t *ylv = lookup(e, (jl_tvar_t*)yl);
-                        if (ylv)
-                            yl = ylv->lb;
-                    }
-                    if (jl_is_long(yl)) {
-                        return jl_unbox_long(yl) + 1 == env->vy;
+                if (jl_is_vararg(env->vty)) {
+                    jl_value_t *yl = jl_unwrap_vararg_num(env->vty);
+                    if (yl) {
+                        if (jl_is_typevar(yl)) {
+                            jl_varbinding_t *ylv = lookup(e, (jl_tvar_t*)yl);
+                            if (ylv)
+                                yl = ylv->lb;
+                        }
+                        if (jl_is_long(yl)) {
+                            return jl_unbox_long(yl) + 1 == env->vy;
+                        }
                     }
                 }
                 else {
@@ -950,10 +943,14 @@ static int subtype_tuple_varargs(struct subtype_tuple_env *env, jl_stenv_t *e, i
     if (!subtype(xp0, yp0, e, 1)) return 0;
 
 constrain_length:
-    if (!jl_is_datatype(env->vtx)) {
+    if (!yp1) {
+        return 1;
+    }
+    if (!xp1) {
         jl_value_t *yl = yp1;
+        jl_varbinding_t *ylv = NULL;
         if (jl_is_typevar(yl)) {
-            jl_varbinding_t *ylv = lookup(e, (jl_tvar_t*)yl);
+            ylv = lookup(e, (jl_tvar_t*)yl);
             if (ylv)
                 yl = ylv->lb;
         }
@@ -963,13 +960,27 @@ constrain_length:
             // as a result of the subtype call above).
             return 0;
         }
+
+        if (ylv) {
+            if (ylv->depth0 != e->invdepth || ylv->occurs_inv)
+                return 0;
+            ylv->intvalued = 1;
+        }
+        // set lb to Any. Since `intvalued` is set, we'll interpret that
+        // appropriately.
+        e->invdepth++;
+        e->Rinvdepth++;
+        int ans = subtype((jl_value_t*)jl_any_type, yp1, e, 2);
+        e->invdepth--;
+        e->Rinvdepth--;
+        return ans;
     }
 
     // Vararg{T,N} <: Vararg{T2,N2}; equate N and N2
     e->invdepth++;
     e->Rinvdepth++;
     JL_GC_PUSH2(&xp1, &yp1);
-    if (jl_is_long(xp1) && env->vx != 1)
+    if (xp1 && jl_is_long(xp1) && env->vx != 1)
         xp1 = jl_box_long(jl_unbox_long(xp1) - env->vx + 1);
     if (jl_is_long(yp1) && env->vy != 1)
         yp1 = jl_box_long(jl_unbox_long(yp1) - env->vy + 1);
@@ -1050,7 +1061,7 @@ loop: // while (i <= lx) {
         }
 
         if (env->vx) {
-            xi = jl_tparam0(jl_unwrap_unionall(env->vtx));
+            xi = jl_unwrap_vararg(env->vtx);
             if (env->j >= env->ly)
                return 1;
         }
@@ -1059,7 +1070,7 @@ loop: // while (i <= lx) {
         }
         int x_same = env->lastx && jl_egal(xi, env->lastx);
         if (env->vy) {
-            yi = jl_tparam0(jl_unwrap_unionall(env->vty));
+            yi = jl_unwrap_vararg(env->vty);
             if (!env->vvx && yi == (jl_value_t*)jl_any_type)
                 goto done;  // if y ends in `Vararg{Any}` skip checking everything
             // keep track of number of consecutive identical types compared to Vararg
@@ -1095,7 +1106,7 @@ loop: // while (i <= lx) {
     // } (from loop:)
 
 done:
-    if (!env->vy && env->j < env->ly && jl_is_vararg_type(jl_tparam(env->yd, env->j)))
+    if (!env->vy && env->j < env->ly && jl_is_vararg(jl_tparam(env->yd, env->j)))
         env->vy += 1;
     if (env->vy && !env->vx && env->lx+1 >= env->ly) {
         // in Tuple{...,tn} <: Tuple{...,Vararg{T,N}}, check (lx+1-ly) <: N
@@ -1121,7 +1132,7 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
     if (env.lx > 0) {
         env.vvx = jl_vararg_kind(jl_tparam(env.xd, env.lx-1));
         if (env.vvx == JL_VARARG_BOUND)
-            xbb = lookup(e, (jl_tvar_t *)jl_tparam1(jl_tparam(env.xd, env.lx - 1)));
+            xbb = lookup(e, (jl_tvar_t *)jl_unwrap_vararg_num(jl_tparam(env.xd, env.lx - 1)));
     }
     if (env.ly > 0)
         env.vvy = jl_vararg_kind(jl_tparam(env.yd, env.ly-1));
@@ -1167,24 +1178,6 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
     JL_GC_PUSH2(&env.vtx, &env.vty);
     int ans = subtype_tuple_tail(&env, 0, e, param);
     JL_GC_POP();
-    return ans;
-}
-
-static int subtype_naked_vararg(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, int param)
-{
-    // Vararg: covariant in first parameter, invariant in second
-    jl_value_t *xp1=jl_tparam0(xd), *xp2=jl_tparam1(xd), *yp1=jl_tparam0(yd), *yp2=jl_tparam1(yd);
-    // in Vararg{T1} <: Vararg{T2}, need to check subtype twice to
-    // simulate the possibility of multiple arguments, which is needed
-    // to implement the diagonal rule correctly.
-    if (!subtype(xp1, yp1, e, param)) return 0;
-    if (!subtype(xp1, yp1, e, 1)) return 0;
-    e->invdepth++;
-    e->Rinvdepth++;
-    // Vararg{T,N} <: Vararg{T2,N2}; equate N and N2
-    int ans = forall_exists_equal(xp2, yp2, e);
-    e->invdepth--;
-    e->Rinvdepth--;
     return ans;
 }
 
@@ -1283,6 +1276,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
     }
     if (jl_is_unionall(y))
         return subtype_unionall(x, (jl_unionall_t*)y, e, 1, param);
+    assert(!jl_is_vararg(x) && !jl_is_vararg(y));
     if (jl_is_datatype(x) && jl_is_datatype(y)) {
         if (x == y) return 1;
         if (y == (jl_value_t*)jl_any_type) return 1;
@@ -1321,13 +1315,6 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
         if (xd == jl_any_type) return 0;
         if (xd->name == jl_tuple_typename)
             return subtype_tuple(xd, yd, e, param);
-        if (xd->name == jl_vararg_typename) {
-            // N.B.: This case is only used for raw varargs that are not part
-            // of a tuple (those that are have special handling in subtype_tuple).
-            // Vararg isn't really a proper type, but it does sometimes show up
-            // as e.g. Type{Vararg}, so we'd like to handle that correctly.
-            return subtype_naked_vararg(xd, yd, e, param);
-        }
         size_t i, np = jl_nparams(xd);
         int ans = 1;
         e->invdepth++;
@@ -1510,6 +1497,8 @@ static int concrete_min(jl_value_t *t)
             return 0; // Type{T} may have the concrete supertype `typeof(T)`, so don't try to handle them here
         return jl_is_concrete_type(t) ? 1 : 2;
     }
+    if (jl_is_vararg(t))
+        return 0;
     if (jl_is_typevar(t))
         return 0; // could be 0 or more, since we didn't track if it was unbound
     if (jl_is_uniontype(t)) {
@@ -1537,6 +1526,16 @@ static jl_value_t *find_var_body(jl_value_t *t, jl_tvar_t *v)
         jl_value_t *b = find_var_body(((jl_uniontype_t*)t)->a, v);
         if (b) return b;
         return find_var_body(((jl_uniontype_t*)t)->b, v);
+    }
+    else if (jl_is_vararg(t)) {
+        jl_vararg_t *vm = (jl_vararg_t *)t;
+        if (vm->T) {
+            jl_value_t *b = find_var_body(vm->T, v);
+            if (b) return b;
+            if (vm->N) {
+                return find_var_body(vm->N, v);
+            }
+        }
     }
     else if (jl_is_datatype(t)) {
         size_t i;
@@ -1594,6 +1593,13 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
         *subtype = 0;
         return 1;
     }
+    if (jl_is_vararg(x)) {
+        if (!jl_is_vararg(y)) {
+            *subtype = 0;
+            return 1;
+        }
+        return 0;
+    }
     if (!jl_is_type(x) || !jl_is_type(y)) {
         *subtype = jl_egal(x, y);
         return 1;
@@ -1635,7 +1641,7 @@ static int obvious_subtype(jl_value_t *x, jl_value_t *y, jl_value_t *y0, int *su
     }
     if (jl_is_datatype(y)) {
         int istuple = (((jl_datatype_t*)y)->name == jl_tuple_typename);
-        int iscov = istuple || (((jl_datatype_t*)y)->name == jl_vararg_typename);
+        int iscov = istuple;
         // TODO: this would be a nice fast-path to have, unfortuanately,
         //       datatype allocation fails to correctly hash-cons them
         //       and the subtyping tests include tests for this case
@@ -2192,6 +2198,22 @@ static jl_value_t *set_var_to_const(jl_varbinding_t *bb, jl_value_t *v JL_MAYBE_
     return v;
 }
 
+static jl_value_t *bound_var_below(jl_tvar_t *tv, jl_varbinding_t *bb, jl_stenv_t *e) {
+    if (!bb)
+        return (jl_value_t*)tv;
+    if (bb->depth0 != e->invdepth)
+        return jl_bottom_type;
+    record_var_occurrence(bb, e, 2);
+    if (jl_is_long(bb->lb)) {
+        if (bb->offset == 0)
+            return bb->lb;
+        if (jl_unbox_long(bb->lb) < bb->offset)
+            return jl_bottom_type;
+        return jl_box_long(jl_unbox_long(bb->lb) - bb->offset);
+    }
+    return (jl_value_t*)tv;
+}
+
 static int try_subtype_in_env(jl_value_t *a, jl_value_t *b, jl_stenv_t *e, int R, int d)
 {
     jl_value_t *root=NULL; jl_savedenv_t se;
@@ -2391,13 +2413,19 @@ static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want
             return 1;
         return var_occurs_inside(ua->body, var, inside, want_inv);
     }
+    else if (jl_is_vararg(v)) {
+        jl_vararg_t *vm = (jl_vararg_t*)v;
+        if (vm->T) {
+            if (var_occurs_inside(vm->T, var, inside || !want_inv, want_inv))
+                return 1;
+            return vm->N && var_occurs_inside(vm->N, var, 1, want_inv);
+        }
+    }
     else if (jl_is_datatype(v)) {
         size_t i;
         int istuple = jl_is_tuple_type(v);
-        int isva = jl_is_vararg_type(v);
         for (i=0; i < jl_nparams(v); i++) {
-            int invar = isva ? i == 1 : !istuple;
-            int ins_i = inside || !want_inv || invar;
+            int ins_i = inside || !want_inv || !istuple;
             if (var_occurs_inside(jl_tparam(v,i), var, ins_i, want_inv))
                 return 1;
         }
@@ -2652,11 +2680,9 @@ static jl_value_t *intersect_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_
 // check n = (length of vararg type v)
 static int intersect_vararg_length(jl_value_t *v, ssize_t n, jl_stenv_t *e, int8_t R)
 {
-    jl_tvar_t *va_p1=NULL;
-    jl_datatype_t *tail = unwrap_1_unionall(v, &va_p1);
-    jl_value_t *N = jl_tparam1(tail);
+    jl_value_t *N = jl_unwrap_vararg_num(v);
     // only do the check if N is free in the tuple type's last parameter
-    if (jl_is_typevar(N) && N != (jl_value_t*)va_p1) {
+    if (N && jl_is_typevar(N)) {
         jl_value_t *len = jl_box_long(n);
         JL_GC_PUSH1(&len);
         jl_value_t *il = R ? intersect(len, N, e, 2) : intersect(N, len, e, 2);
@@ -2667,13 +2693,61 @@ static int intersect_vararg_length(jl_value_t *v, ssize_t n, jl_stenv_t *e, int8
     return 1;
 }
 
+static jl_value_t *intersect_invariant(jl_value_t *x, jl_value_t *y, jl_stenv_t *e);
+static jl_value_t *intersect_varargs(jl_vararg_t *vmx, jl_vararg_t *vmy, jl_stenv_t *e, int param)
+{
+    // Vararg: covariant in first parameter, invariant in second
+    jl_value_t *xp1=jl_unwrap_vararg(vmx), *xp2=jl_unwrap_vararg_num(vmx),
+                *yp1=jl_unwrap_vararg(vmy), *yp2=jl_unwrap_vararg_num(vmy);
+    // in Vararg{T1} <: Vararg{T2}, need to check subtype twice to
+    // simulate the possibility of multiple arguments, which is needed
+    // to implement the diagonal rule correctly.
+    if (intersect(xp1, yp1, e, param==0 ? 1 : param) == jl_bottom_type)
+        return jl_bottom_type;
+    jl_value_t *i2=NULL, *ii = intersect(xp1, yp1, e, 1);
+    if (ii == jl_bottom_type) return jl_bottom_type;
+    JL_GC_PUSH2(&ii, &i2);
+    if (!xp2 && !yp2) {
+        ii = (jl_value_t*)jl_wrap_vararg(ii, NULL);
+        JL_GC_POP();
+        return ii;
+    }
+    if (xp2 && jl_is_typevar(xp2)) {
+        jl_varbinding_t *xb = lookup(e, (jl_tvar_t*)xp2);
+        if (xb) xb->intvalued = 1;
+        if (!yp2) {
+            i2 = bound_var_below((jl_tvar_t*)xp2, xb, e);
+        }
+    }
+    if (yp2 && jl_is_typevar(yp2)) {
+        jl_varbinding_t *yb = lookup(e, (jl_tvar_t*)yp2);
+        if (yb) yb->intvalued = 1;
+        if (!xp2) {
+            i2 = bound_var_below((jl_tvar_t*)yp2, yb, e);
+        }
+    }
+    if (xp2 && yp2) {
+        // Vararg{T,N} <: Vararg{T2,N2}; equate N and N2
+        i2 = intersect_invariant(xp2, yp2, e);
+        if (i2 == NULL || i2 == jl_bottom_type || (jl_is_long(i2) && jl_unbox_long(i2) < 0) ||
+            !((jl_is_typevar(i2) && ((jl_tvar_t*)i2)->lb == jl_bottom_type &&
+                ((jl_tvar_t*)i2)->ub == (jl_value_t*)jl_any_type) || jl_is_long(i2))) {
+            i2 = jl_bottom_type;
+        }
+    }
+    ii = i2 == jl_bottom_type ? (jl_value_t*)jl_bottom_type : (jl_value_t*)jl_wrap_vararg(ii, i2);
+    JL_GC_POP();
+    return ii;
+}
+
+
 static jl_value_t *intersect_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, int param)
 {
     size_t lx = jl_nparams(xd), ly = jl_nparams(yd);
     if (lx == 0 && ly == 0)
         return (jl_value_t*)yd;
-    int vx=0, vy=0, vvx = (lx > 0 && jl_is_vararg_type(jl_tparam(xd, lx-1)));
-    int vvy = (ly > 0 && jl_is_vararg_type(jl_tparam(yd, ly-1)));
+    int vx=0, vy=0, vvx = (lx > 0 && jl_is_vararg(jl_tparam(xd, lx-1)));
+    int vvy = (ly > 0 && jl_is_vararg(jl_tparam(yd, ly-1)));
     if (!vvx && !vvy && lx != ly)
         return jl_bottom_type;
     jl_svec_t *params = jl_alloc_svec(lx > ly ? lx : ly);
@@ -2682,14 +2756,15 @@ static jl_value_t *intersect_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_sten
     size_t i=0, j=0;
     jl_value_t *xi, *yi;
     while (1) {
+        vx = vy = 0;
         xi = i < lx ? jl_tparam(xd, i) : NULL;
         yi = j < ly ? jl_tparam(yd, j) : NULL;
         if (xi == NULL && yi == NULL) {
             assert(i == j && i == jl_svec_len(params));
             break;
         }
-        if (xi && jl_is_vararg_type(xi)) vx = 1;
-        if (yi && jl_is_vararg_type(yi)) vy = 1;
+        if (xi && jl_is_vararg(xi)) vx = 1;
+        if (yi && jl_is_vararg(yi)) vy = 1;
         if (xi == NULL || yi == NULL) {
             res = jl_bottom_type;
             if (vx && intersect_vararg_length(xi, ly+1-lx, e, 0))
@@ -2698,29 +2773,34 @@ static jl_value_t *intersect_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_sten
                 res = (jl_value_t*)jl_apply_tuple_type_v(jl_svec_data(params), i);
             break;
         }
-        if (vx && !vy)
-            xi = jl_unwrap_vararg(xi);
-        if (vy && !vx)
-            yi = jl_unwrap_vararg(yi);
         jl_varbinding_t *xb=NULL, *yb=NULL;
+        jl_value_t *ii = NULL;
         if (vx && vy) {
             // {A^n...,Vararg{T,N}} ∩ {Vararg{S,M}} = {(A∩S)^n...,Vararg{T∩S,N}} plus N = M-n
-            jl_value_t *xlen = jl_tparam1(jl_unwrap_unionall(xi));
-            if (jl_is_typevar(xlen)) {
+            jl_value_t *xlen = jl_unwrap_vararg_num(xi);
+            if (xlen && jl_is_typevar(xlen)) {
                 xb = lookup(e, (jl_tvar_t*)xlen);
                 if (xb)
                     xb->offset = ly-lx;
             }
-            jl_value_t *ylen = jl_tparam1(jl_unwrap_unionall(yi));
-            if (jl_is_typevar(ylen)) {
+            jl_value_t *ylen = jl_unwrap_vararg_num(yi);
+            if (ylen && jl_is_typevar(ylen)) {
                 yb = lookup(e, (jl_tvar_t*)ylen);
                 if (yb)
                     yb->offset = lx-ly;
             }
+            ii = intersect_varargs((jl_vararg_t*)xi,
+                                   (jl_vararg_t*)yi,
+                                   e, param);
+            if (xb) xb->offset = 0;
+            if (yb) yb->offset = 0;
+        } else {
+            if (vx)
+                xi = jl_unwrap_vararg(xi);
+            if (vy)
+                yi = jl_unwrap_vararg(yi);
+            ii = intersect(xi, yi, e, param == 0 ? 1 : param);
         }
-        jl_value_t *ii = intersect(xi, yi, e, param == 0 ? 1 : param);
-        if (xb) xb->offset = 0;
-        if (yb) yb->offset = 0;
         if (ii == jl_bottom_type) {
             if (vx && vy) {
                 int len = i > j ? i : j;
@@ -3022,7 +3102,7 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
         record_var_occurrence(lookup(e, (jl_tvar_t*)y), e, param);
         return intersect_var((jl_tvar_t*)y, x, e, 1, param);
     }
-    if (!jl_has_free_typevars(x) && !jl_has_free_typevars(y) && !jl_is_vararg_type(x) && !jl_is_vararg_type(y)) {
+    if (!jl_has_free_typevars(x) && !jl_has_free_typevars(y)) {
         if (jl_subtype(x, y)) return x;
         if (jl_subtype(y, x)) return y;
     }
@@ -3073,6 +3153,7 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
     }
     if (jl_is_unionall(y))
         return intersect_unionall(x, (jl_unionall_t*)y, e, 1, param);
+    assert(!jl_is_vararg(x) && !jl_is_vararg(y));
     if (jl_is_datatype(x) && jl_is_datatype(y)) {
         jl_datatype_t *xd = (jl_datatype_t*)x, *yd = (jl_datatype_t*)y;
         if (param < 2) {
@@ -3087,36 +3168,6 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
         if (xd->name == yd->name) {
             if (jl_is_tuple_type(xd))
                 return intersect_tuple(xd, yd, e, param);
-            if (jl_is_vararg_type(x)) {
-                // Vararg: covariant in first parameter, invariant in second
-                jl_value_t *xp1=jl_tparam0(xd), *xp2=jl_tparam1(xd), *yp1=jl_tparam0(yd), *yp2=jl_tparam1(yd);
-                // in Vararg{T1} <: Vararg{T2}, need to check subtype twice to
-                // simulate the possibility of multiple arguments, which is needed
-                // to implement the diagonal rule correctly.
-                if (intersect(xp1, yp1, e, param==0 ? 1 : param) == jl_bottom_type)
-                    return jl_bottom_type;
-                jl_value_t *i2=NULL, *ii = intersect(xp1, yp1, e, 1);
-                if (ii == jl_bottom_type) return jl_bottom_type;
-                JL_GC_PUSH2(&ii, &i2);
-                if (jl_is_typevar(xp2)) {
-                    jl_varbinding_t *xb = lookup(e, (jl_tvar_t*)xp2);
-                    if (xb) xb->intvalued = 1;
-                }
-                if (jl_is_typevar(yp2)) {
-                    jl_varbinding_t *yb = lookup(e, (jl_tvar_t*)yp2);
-                    if (yb) yb->intvalued = 1;
-                }
-                // Vararg{T,N} <: Vararg{T2,N2}; equate N and N2
-                i2 = intersect_invariant(xp2, yp2, e);
-                if (i2 == NULL || i2 == jl_bottom_type || (jl_is_long(i2) && jl_unbox_long(i2) < 0) ||
-                    !((jl_is_typevar(i2) && ((jl_tvar_t*)i2)->lb == jl_bottom_type &&
-                       ((jl_tvar_t*)i2)->ub == (jl_value_t*)jl_any_type) || jl_is_long(i2)))
-                    ii = jl_bottom_type;
-                else
-                    ii = jl_apply_type2((jl_value_t*)jl_vararg_type, ii, i2);
-                JL_GC_POP();
-                return ii;
-            }
             size_t i, np = jl_nparams(xd);
             jl_value_t **newparams;
             JL_GC_PUSHARGS(newparams, np);
@@ -3340,8 +3391,8 @@ static int might_intersect_concrete(jl_value_t *a)
     if (jl_is_uniontype(a))
         return might_intersect_concrete(((jl_uniontype_t*)a)->a) ||
                might_intersect_concrete(((jl_uniontype_t*)a)->b);
-    if (jl_is_vararg_type(a))
-        return might_intersect_concrete(jl_tparam0(a));
+    if (jl_is_vararg(a))
+        return might_intersect_concrete(jl_unwrap_vararg(a));
     if (jl_is_type_type(a))
         return 1;
     if (jl_is_datatype(a)) {
@@ -3539,11 +3590,11 @@ static jl_value_t *nth_tuple_elt(jl_datatype_t *t JL_PROPAGATES_ROOT, size_t i) 
     if (i < len-1)
         return jl_tparam(t, i);
     jl_value_t *last = jl_unwrap_unionall(jl_tparam(t, len-1));
-    if (jl_is_vararg_type(last)) {
-        jl_value_t *n = jl_tparam1(last);
-        if (jl_is_long(n) && i >= len-1+jl_unbox_long(n))
+    if (jl_is_vararg(last)) {
+        jl_value_t *n = jl_unwrap_vararg_num(last);
+        if (n && jl_is_long(n) && i >= len-1+jl_unbox_long(n))
             return NULL;
-        return jl_tparam0(last);
+        return jl_unwrap_vararg(last);
     }
     if (i == len-1)
         return jl_tparam(t, i);
@@ -3605,7 +3656,7 @@ static int tuple_morespecific(jl_datatype_t *cdt, jl_datatype_t *pdt, int invari
               C = Tuple{AbstractArray, Int, Array}
               we need A < B < C and A < C.
             */
-            return some_morespecific && cva && ckind == JL_VARARG_BOUND && num_occurs((jl_tvar_t*)jl_tparam1(jl_unwrap_unionall(clast)), env) > 1;
+            return some_morespecific && cva && ckind == JL_VARARG_BOUND && num_occurs((jl_tvar_t*)jl_unwrap_vararg_num(clast), env) > 1;
         }
 
         // Tuple{..., T} not more specific than Tuple{..., Vararg{S}} if S is diagonal
@@ -3628,8 +3679,8 @@ static size_t tuple_full_length(jl_value_t *t)
     size_t n = jl_nparams(t);
     if (n == 0) return 0;
     jl_value_t *last = jl_unwrap_unionall(jl_tparam(t,n-1));
-    if (jl_is_vararg_type(last)) {
-        jl_value_t *N = jl_tparam1(last);
+    if (jl_is_vararg(last)) {
+        jl_value_t *N = jl_unwrap_vararg_num(last);
         if (jl_is_long(N))
             n += jl_unbox_long(N)-1;
     }
@@ -3646,7 +3697,7 @@ static int args_morespecific_fix1(jl_value_t *a, jl_value_t *b, int swap, jl_typ
         return -1;
     assert(jl_is_va_tuple((jl_datatype_t*)a));
     jl_datatype_t *new_a = NULL;
-    jl_value_t *e[2] = { jl_tparam1(jl_unwrap_unionall(jl_tparam(a, n-1))), jl_box_long(taillen) };
+    jl_value_t *e[2] = { jl_unwrap_vararg_num(jl_unwrap_unionall(jl_tparam(a, n-1))), jl_box_long(taillen) };
     JL_GC_PUSH2(&new_a, &e[1]);
     new_a = (jl_datatype_t*)jl_instantiate_type_with((jl_value_t*)a, e, 1);
     int changed = 0;
@@ -3682,6 +3733,12 @@ static int count_occurs(jl_value_t *t, jl_tvar_t *v)
         if (((jl_unionall_t*)t)->var == v)
             return 0;
         return count_occurs(((jl_unionall_t*)t)->body, v);
+    }
+    if (jl_is_vararg(t)) {
+        jl_vararg_t *vm = (jl_vararg_t*)t;
+        if (vm->T) {
+            return count_occurs(vm->T, v) + (vm->N ? count_occurs(vm->N, v) : 0);
+        }
     }
     if (jl_is_datatype(t)) {
         int i, c=0;

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -170,7 +170,7 @@ function methodswith(t::Type, f::Function, meths = Method[]; supertypes::Bool=fa
         if any(function (x)
                    let x = rewrap_unionall(x, d.sig)
                        (type_close_enough(x, t) ||
-                        (supertypes ? (t <: x && (!isa(x,TypeVar) || x.ub != Any)) :
+                        (supertypes ? (isa(x, Type) && t <: x && (!isa(x,TypeVar) || x.ub != Any)) :
                          (isa(x,TypeVar) && x.ub != Any && t == x.ub)) &&
                         x != Any)
                    end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1581,9 +1581,8 @@ function constrains_param(var::TypeVar, @nospecialize(typ), covariant::Bool)
                 end
                 lastp = typ.parameters[fc]
                 vararg = Base.unwrap_unionall(lastp)
-                if vararg isa DataType && vararg.name === Base._va_typename
-                    N = vararg.parameters[2]
-                    constrains_param(var, N, covariant) && return true
+                if vararg isa Core.TypeofVararg && isdefined(vararg, :N)
+                    constrains_param(var, vararg.N, covariant) && return true
                     # T = vararg.parameters[1] doesn't constrain var
                 else
                     constrains_param(var, lastp, covariant) && return true

--- a/test/core.jl
+++ b/test/core.jl
@@ -1218,7 +1218,7 @@ end
 # issue #22842
 f22842(x::UnionAll) = UnionAll
 f22842(x::DataType) = length(x.parameters)
-@test f22842(Tuple{Vararg{Int64,N} where N}) == 1
+@test f22842(Tuple{Vararg{Int64}}) == 1
 @test f22842(Tuple{Vararg{Int64,N}} where N) === UnionAll
 
 # issue #1153
@@ -7009,7 +7009,6 @@ end
 @test_throws ArgumentError Array{Int, 2}(undef, -1, -1)
 
 # issue #28812
-@test Tuple{Vararg{Array{T},3} where T} === Tuple{Array,Array,Array}
 @test Tuple{Vararg{Array{T} where T,3}} === Tuple{Array,Array,Array}
 
 # issue #29145
@@ -7521,3 +7520,11 @@ for _ in 1:5
         @test all(x->ismissing(x.i), a)
     end
 end
+
+# Redefining types with Vararg
+abstract type RedefineVararg; end
+const RedefineVarargN{N} = Tuple{Vararg{RedefineVararg, N}}
+const RedefineVarargN{N} = Tuple{Vararg{RedefineVararg, N}}
+
+# NTuples with non-types
+@test NTuple{3, 2} == Tuple{2, 2, 2}

--- a/test/show.jl
+++ b/test/show.jl
@@ -1671,7 +1671,7 @@ end
     end
 
     # issue #25857
-    @test repr([(1,),(1,2),(1,2,3)]) == "Tuple{$Int, Vararg{$Int, N} where N}[(1,), (1, 2), (1, 2, 3)]"
+    @test repr([(1,),(1,2),(1,2,3)]) == "Tuple{$Int, Vararg{$Int}}[(1,), (1, 2), (1, 2, 3)]"
 
     # issues #25466 & #26256
     @test replstr([:A => [1]]) == "1-element Vector{Pair{Symbol, Vector{$Int}}}:\n :A => [1]"

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -62,7 +62,7 @@ _z_z_z_(::Int, c...) = 3
 @test args_morespecific(Tuple{Union{Int,String},Type{Pair{A,B} where B}} where A, Tuple{Integer,UnionAll})
 
 # PR #21750
-let A = Tuple{Any, Tuple{Vararg{Integer,N} where N}},
+let A = Tuple{Any, Tuple{Vararg{Integer}}},
     B = Tuple{Any, Tuple{Any}},
     C = Tuple{Any, Tuple{}}
     @test args_morespecific(A, B)
@@ -111,16 +111,16 @@ f17016(f, t1::Tuple) = 1
 @test !args_morespecific(Tuple{Type{Any}, Any}, Tuple{Type{T}, Any} where T<:VecElement)
 @test !args_morespecific((Tuple{Type{T}, Any} where T<:VecElement), Tuple{Type{Any}, Any})
 
-@test !args_morespecific(Tuple{Type{T}, Tuple{Any, Vararg{Any, N} where N}} where T<:Tuple{Any, Vararg{Any, N} where N},
+@test !args_morespecific(Tuple{Type{T}, Tuple{Any, Vararg{Any}}} where T<:Tuple{Any, Vararg{Any}},
                          Tuple{Type{Any}, Any})
-@test !args_morespecific(Tuple{Type{T}, Tuple{Any, Vararg{Any, N} where N}} where T<:Tuple{Any, Vararg{Any, N} where N},
+@test !args_morespecific(Tuple{Type{T}, Tuple{Any, Vararg{Any}}} where T<:Tuple{Any, Vararg{Any}},
                          Tuple{Type{Tuple}, Tuple})
-@test !args_morespecific(Tuple{Type{T}, T} where T<:Tuple{Any, Vararg{Any, N} where N},
+@test !args_morespecific(Tuple{Type{T}, T} where T<:Tuple{Any, Vararg{Any}},
                          Tuple{Type{T}, Any} where T<:VecElement)
 
 @test args_morespecific(Tuple{Any, Tuple{}, Tuple{}}, Tuple{Any, Tuple{Any}})
 @test args_morespecific(Tuple{Any, Tuple{Any}, Tuple{Any}}, Tuple{Any, Tuple{Any, Any}})
-@test args_morespecific(Tuple{Any, Vararg{Tuple{}, N} where N}, Tuple{Any, Tuple{Any}})
+@test args_morespecific(Tuple{Any, Vararg{Tuple{}}}, Tuple{Any, Tuple{Any}})
 
 @test  args_morespecific(Tuple{T, T} where T<:AbstractFloat, Tuple{T, T, T} where T<:AbstractFloat)
 @test  args_morespecific(Tuple{T, Real, T} where T<:AbstractFloat, Tuple{T, T} where T<:Real)
@@ -137,10 +137,10 @@ f17016(f, t1::Tuple) = 1
                          Tuple{T, T} where T<:Union{Base.StepRangeLen, Base.LinRange})
 
 @test args_morespecific(Tuple{Type{Tuple}, Any, Any},
-                        Tuple{Type{Tuple{Vararg{E, N} where N}}, Any, Any} where E)
+                        Tuple{Type{Tuple{Vararg{E}}}, Any, Any} where E)
 
 @test args_morespecific(Tuple{Type{Tuple{}}, Tuple{}},
-                        Tuple{Type{T}, T} where T<:Tuple{Any, Vararg{Any, N} where N})
+                        Tuple{Type{T}, T} where T<:Tuple{Any, Vararg{Any}})
 
 @test args_morespecific(Tuple{Type{CartesianIndex{N}}} where N,
                         Tuple{Type{CartesianIndex{N}},Vararg{Int,N}} where N)
@@ -235,14 +235,14 @@ let N = Tuple{Type{Union{Nothing, T}}, Union{Nothing, T}} where T,
 end
 
 # issue #29528
-@test !args_morespecific(Tuple{Array,Vararg{Int64,N} where N}, Tuple{AbstractArray, Array})
+@test !args_morespecific(Tuple{Array,Vararg{Int64}}, Tuple{AbstractArray, Array})
 @test !args_morespecific(Tuple{Array,Vararg{Int64,N}} where N, Tuple{AbstractArray, Array})
 @test  args_morespecific(Tuple{Array,Int64}, Tuple{Array,Vararg{Int64,N}} where N)
-@test  args_morespecific(Tuple{Array,Int64}, Tuple{Array,Vararg{Int64,N} where N})
+@test  args_morespecific(Tuple{Array,Int64}, Tuple{Array,Vararg{Int64}})
 @test !args_morespecific(Tuple{Array,Int64}, Tuple{AbstractArray, Array})
 
 # issue #30114
-let T1 = Tuple{Type{Tuple{Vararg{AbstractUnitRange{Int64},N} where N}},CartesianIndices{N,R} where R<:Tuple{Vararg{AbstractUnitRange{Int64},N}}} where N
+let T1 = Tuple{Type{Tuple{Vararg{AbstractUnitRange{Int64}}}},CartesianIndices{N,R} where R<:Tuple{Vararg{AbstractUnitRange{Int64},N}}} where N
     T2 = Tuple{Type{T},T} where T<:AbstractArray
     T3 = Tuple{Type{AbstractArray{T,N} where N},AbstractArray} where T
     T4 = Tuple{Type{AbstractArray{T,N}},AbstractArray{s57,N} where s57} where N where T
@@ -254,7 +254,7 @@ let T1 = Tuple{Type{Tuple{Vararg{AbstractUnitRange{Int64},N} where N}},Cartesian
 end
 
 @test !args_morespecific(Tuple{Type{Tuple{Vararg{AbstractUnitRange{Int64},N}}},} where N,
-                         Tuple{Type{Tuple{Vararg{AbstractUnitRange,N} where N}},})
+                         Tuple{Type{Tuple{Vararg{AbstractUnitRange}}},})
 
 @test  args_morespecific(Tuple{Type{SubArray{T,2,P} where T}, Array{T}} where T where P,
                          Tuple{Type{AbstractArray{T,N} where N},AbstractArray} where T)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1971,8 +1971,12 @@ let a(; b) = b
 end
 
 # issue #33987
-f33987(args::(Vararg{Any, N} where N); kwargs...) = args
-@test f33987(1,2,3) === (1,2,3)
+@test_deprecated eval(quote
+    # This syntax is deprecated. This test should be removed when the
+    # deprecation is.
+    f33987(args::(Vararg{Any, N} where N); kwargs...) = args
+    @test f33987(1,2,3) === (1,2,3)
+end)
 
 macro id_for_kwarg(x); x; end
 Xo65KdlD = @id_for_kwarg let x = 1

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -504,6 +504,7 @@ end
 
 # tuple_type_tail on non-normalized vararg tuple
 @test Base.tuple_type_tail(Tuple{Vararg{T, 3}} where T<:Real) == Tuple{Vararg{T, 2}} where T<:Real
+@test Base.tuple_type_tail(Tuple{Vararg{Int}}) == Tuple{Vararg{Int}}
 
 @testset "setindex" begin
     @test Base.setindex((1, ), 2, 1) === (2, )


### PR DESCRIPTION
Currently `Vararg` is a DataType, but is special cased in a
bunch of places to give it special behavior (e.g. in subtyping
and of course in tuple construction). However, unlike all other
DataTypes, it cannot appear as a type parameter, which caused trouble in
PR #38071. Having it be a DataType is a bit of a pun of convenience
in the first place - it's a lot more similar to a tvar (which can
be considered an implementation detail of UnionAll in the same way
Vararg is an implementation detail of Tuple), which has its own
non-type object. This PR does the same to Vararg, and moves it
from being an abstract DataType with special cased behavior to
its own custom type (called `Core.VarargMarker`). The user facing
behavior should be mostly unchanged, since `boot.jl` now has:
```
const Vararg{T, N} = VarargMarker{T, N}
```
i.e. we have a handly UnionAll wrapper that looks just like it
used to. The biggest difference is probably that VarargMarker
does not have `.parameters`, so code that tries to reach into
that explicitly will need to be adjusted. We could provide
a compatibility `getproperty` method to adapt that, but I'd
prefer to see how many packages need updating first, before
going that route.

This is essentially complete, but a few cleanup items remain.

Closes #30995 #34690 #26625 #37316