### PR TITLE
devdocs: Fix documentation of Meta.parse for @doc

### DIFF
--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -106,7 +106,7 @@ Doc string syntax:
 f(x) = x
 ```
 
-parses as `(macrocall (|.| Core '@doc) (line) "some docs" (= (call f x) (block x)))`.
+parses as `(macrocall GlobalRef(Core, Symbol("@doc")) (line) "some docs" (= (call f x) (block x)))`.
 
 ### Imports and such
 


### PR DESCRIPTION
These are parsed into `GlobalRef`s now, not `Expr(:(.), :Core, QuoteNode(Symbol("@doc")))`

The start of this part of the documentation also claims that 

> First there is a surface syntax AST returned by the parser (e.g. the Meta.parse function), and manipulated by macros... Next there is a lowered form...

But that is not true. `GlobalRef` is part of the lowered form, not the surface syntax, but you can get it from `Meta.parse`. Presumably either the implementation or the docs should change.

Example:

```jl
e = Meta.parse("""
    "A docstr"
    f() = 1
    """)
typeof(e.args[1]) == GlobalRef
```