### PR TITLE
Add typedef jl_thread_t, fix jl_wakeup_thread

### DIFF
--- a/src/locks.h
+++ b/src/locks.h
@@ -20,8 +20,8 @@ extern "C" {
 
 static inline void jl_mutex_wait(jl_mutex_t *lock, int safepoint)
 {
-    unsigned long self = jl_thread_self();
-    unsigned long owner = jl_atomic_load_relaxed(&lock->owner);
+    jl_thread_t self = jl_thread_self();
+    jl_thread_t owner = jl_atomic_load_relaxed(&lock->owner);
     if (owner == self) {
         lock->count++;
         return;
@@ -93,8 +93,8 @@ static inline void jl_mutex_lock(jl_mutex_t *lock)
 
 static inline int jl_mutex_trylock_nogc(jl_mutex_t *lock)
 {
-    unsigned long self = jl_thread_self();
-    unsigned long owner = jl_atomic_load_acquire(&lock->owner);
+    jl_thread_t self = jl_thread_self();
+    jl_thread_t owner = jl_atomic_load_acquire(&lock->owner);
     if (owner == self) {
         lock->count++;
         return 1;

--- a/src/partr.c
+++ b/src/partr.c
@@ -348,9 +348,9 @@ static void wake_libuv(void)
 JL_DLLEXPORT void jl_wakeup_thread(int16_t tid)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    int16_t uvlock = jl_atomic_load(&jl_uv_mutex.owner);
+    jl_thread_t uvlock = jl_atomic_load(&jl_uv_mutex.owner);
     int16_t self = ptls->tid;
-    unsigned long system_self = jl_all_tls_states[self]->system_id;
+    jl_thread_t system_self = jl_all_tls_states[self]->system_id;
     JULIA_DEBUG_SLEEPWAKE( wakeup_enter = cycleclock() );
     if (tid == self || tid == -1) {
         // we're already awake, but make sure we'll exit uv_run
@@ -363,7 +363,7 @@ JL_DLLEXPORT void jl_wakeup_thread(int16_t tid)
         // something added to the sticky-queue: notify that thread
         wake_thread(tid);
         // check if we need to notify uv_run too
-        unsigned long system_tid = jl_all_tls_states[tid]->system_id;
+        jl_thread_t system_tid = jl_all_tls_states[tid]->system_id;
         if (uvlock != system_self && jl_atomic_load(&jl_uv_mutex.owner) == system_tid)
             wake_libuv();
     }

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -42,7 +42,7 @@ void jl_mach_gc_end(void)
         int8_t gc_state = (int8_t)(item >> 8);
         jl_ptls_t ptls2 = jl_all_tls_states[tid];
         jl_atomic_store_release(&ptls2->gc_state, gc_state);
-        thread_resume(pthread_mach_thread_np((pthread_t)ptls2->system_id));
+        thread_resume(pthread_mach_thread_np(ptls2->system_id));
     }
     suspended_threads.len = 0;
 }
@@ -121,7 +121,7 @@ static void allocate_segv_handler()
     }
     pthread_attr_destroy(&attr);
     for (int16_t tid = 0;tid < jl_n_threads;tid++) {
-        attach_exception_port(pthread_mach_thread_np((pthread_t)jl_all_tls_states[tid]->system_id), 0);
+        attach_exception_port(pthread_mach_thread_np(jl_all_tls_states[tid]->system_id), 0);
     }
 }
 
@@ -219,7 +219,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     jl_ptls_t ptls2 = NULL;
     for (tid = 0;tid < jl_n_threads;tid++) {
         jl_ptls_t _ptls2 = jl_all_tls_states[tid];
-        if (pthread_mach_thread_np((pthread_t)_ptls2->system_id) == thread) {
+        if (pthread_mach_thread_np(_ptls2->system_id) == thread) {
             ptls2 = _ptls2;
             break;
         }
@@ -308,7 +308,7 @@ static void attach_exception_port(thread_port_t thread, int segv_only)
 static void jl_thread_suspend_and_get_state(int tid, unw_context_t **ctx)
 {
     jl_ptls_t ptls2 = jl_all_tls_states[tid];
-    mach_port_t tid_port = pthread_mach_thread_np((pthread_t)ptls2->system_id);
+    mach_port_t tid_port = pthread_mach_thread_np(ptls2->system_id);
 
     kern_return_t ret = thread_suspend(tid_port);
     HANDLE_MACH_ERROR("thread_suspend", ret);
@@ -328,7 +328,7 @@ static void jl_thread_suspend_and_get_state(int tid, unw_context_t **ctx)
 static void jl_thread_resume(int tid, int sig)
 {
     jl_ptls_t ptls2 = jl_all_tls_states[tid];
-    mach_port_t thread = pthread_mach_thread_np((pthread_t)ptls2->system_id);
+    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
     kern_return_t ret = thread_resume(thread);
     HANDLE_MACH_ERROR("thread_resume", ret);
 }
@@ -338,7 +338,7 @@ static void jl_thread_resume(int tid, int sig)
 static void jl_try_deliver_sigint(void)
 {
     jl_ptls_t ptls2 = jl_all_tls_states[0];
-    mach_port_t thread = pthread_mach_thread_np((pthread_t)ptls2->system_id);
+    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
 
     kern_return_t ret = thread_suspend(thread);
     HANDLE_MACH_ERROR("thread_suspend", ret);
@@ -367,7 +367,7 @@ static void jl_try_deliver_sigint(void)
 static void jl_exit_thread0(int exitstate)
 {
     jl_ptls_t ptls2 = jl_all_tls_states[0];
-    mach_port_t thread = pthread_mach_thread_np((pthread_t)ptls2->system_id);
+    mach_port_t thread = pthread_mach_thread_np(ptls2->system_id);
     kern_return_t ret = thread_suspend(thread);
     HANDLE_MACH_ERROR("thread_suspend", ret);
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -5,17 +5,6 @@
 
 // Thread-local storage access
 
-// Copied from libuv. Add `JL_CONST_FUNC` so that the compiler
-// can optimize this better.
-static inline unsigned long JL_CONST_FUNC jl_thread_self(void)
-{
-#ifdef _OS_WINDOWS_
-    return (unsigned long)GetCurrentThreadId();
-#else
-    return (unsigned long)pthread_self();
-#endif
-}
-
 typedef struct _jl_tls_states_t jl_tls_states_t;
 
 typedef jl_tls_states_t *jl_ptls_t;


### PR DESCRIPTION
POSIX does not mandate that pthread_t is an integer (it used to be specified as being an arithmetic type, but that was changed ~2004; but in any case, it never was safe to assume that it'd fit in an `unsigned long`, even though it did in practice). And in fact on FreeBSD it is a pointer. While casting a pointer to an unsigned long and back works there right now, it seems safer on the long run to use the correct type.

Also fix a bug in jl_wakeup_thread where the native thread id of the owner of jl_uv_mutex was truncated to 16bits. This is of course much more likely to cause an actual issue when `pthread_t` is a pointer.