### PR TITLE
#include poll.h instead of sys/poll.h

### DIFF
--- a/src/support/timefuncs.c
+++ b/src/support/timefuncs.c
@@ -1,25 +1,15 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
 #include <assert.h>
-#include <errno.h>
-#include <limits.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 
 #include "dtypes.h"
 
 #if defined(_OS_WINDOWS_)
-#include <malloc.h>
 #include <sys/timeb.h>
 #include <windows.h>
 #else
 #include <sys/time.h>
-#include <sys/poll.h>
-#include <unistd.h>
+#include <sys/select.h>
 #endif
 
 #include "timefuncs.h"


### PR DESCRIPTION
As far as I know, POSIX always mandated poll.h, and sys/poll.h comes from legacy systems. In any case, to the best of my knowledge on all systems supported by Julia, including poll.h works. In contrast, on FreeBSD including sys/poll.h triggers a warning.

UPDATE: oops for trying to use `#include` as the first word in a git commit message, not realizing this would be treated as a comment line :joy: