### PR TITLE
snoopi_deep: Stop stripping function from `slottypes`

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -34,7 +34,7 @@ function _typeinf_identifier(frame::Core.Compiler.InferenceState)
         frame.linfo,
         frame.world,
         copy(frame.sptypes),
-        frame.slottypes[2:end],  # Skip repeating the method instance
+        frame.slottypes,
     )
     return mi_info
 end
@@ -80,7 +80,7 @@ function reset_timings()
     empty!(_timings)
     push!(_timings, Timing(
         # The MethodInstance for ROOT(), and default empty values for other fields.
-        InferenceFrameInfo(ROOTmi, 0x0, Any[], Any[]),
+        InferenceFrameInfo(ROOTmi, 0x0, Any[], Any[Core.Const(ROOT)]),
         _time_ns()))
     return nothing
 end


### PR DESCRIPTION
This is a follow-up to #37749.

The `slottypes` in a MethodInstance specialization contains the generic
function object as the first argument in the array, which we were
previously stripping out to "not write redundant information".

But this actually makes the output harder to read, because the `show()`
for `MethodInstance`s doesn't fully qualify the names of functions.

For example, before this commit (note that you might ask "*Which*
`fpsort!` is this? What module is it in?"):
```julia
 0.001485733 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for fpsort!(::Vector{Float64}, ::Base.Sort.QuickSortAlg, ::Base.Order.ForwardOrdering), 0x0000000000007310, Any[], Any[Vector{Float64}, Core.Const(Base.Sort.QuickSortAlg()), Core.Const(Base.Order.ForwardOrdering())])
```

And after this commit (note that the fully qualified function is the
first item in the slottypes array -- it's `Base.Sort.Float.fpsort!`):
```julia
 0.001485733 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for fpsort!(::Vector{Float64}, ::Base.Sort.QuickSortAlg, ::Base.Order.ForwardOrdering), 0x0000000000007310, Any[], Any[Core.Const(Base.Sort.Float.fpsort!), Vector{Float64}, Core.Const(Base.Sort.QuickSortAlg()), Core.Const(Base.Order.ForwardOrdering())])
```

While of course you could have gotten this information out of the
`MethodInstance` (which is why I left it out), it doesn't show up in the
output by default, which makes copy/pasting this output less useful.

The output is already quite large, so I don't think the "redundant
information" concern is very valid, since it's already quite big, so
it's better to include all the necessary information.