### PR TITLE
Add missing support for single argument *, &, |, xor

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -91,7 +91,8 @@ isapprox(::Missing, ::Any; kwargs...) = missing
 isapprox(::Any, ::Missing; kwargs...) = missing
 
 # Unary operators/functions
-for f in (:(!), :(~), :(+), :(-), :(zero), :(one), :(oneunit),
+for f in (:(!), :(~), :(+), :(-), :(*), :(&), :(|), :(xor),
+          :(zero), :(one), :(oneunit),
           :(isfinite), :(isinf), :(isodd),
           :(isinteger), :(isreal), :(isnan),
           :(iszero), :(transpose), :(adjoint), :(float), :(conj),

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -83,7 +83,7 @@ end
     arithmetic_operators = [+, -, *, /, ^, Base.div, Base.mod, Base.fld, Base.rem]
 
     # All unary operators return missing when evaluating missing
-    for f in [!, ~, +, -]
+    for f in [!, ~, +, -, *, &, |, xor]
         @test ismissing(f(missing))
     end
 


### PR DESCRIPTION
Not having this defined is:
1. inconsistent with e.g. `+`
2. disallows writing generic code like `(&)(args...)` without special casing for 1-argument scenario
3. all these functions are supported for single argument with integers

Closes #38154.