### PR TITLE
Add input function

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -818,6 +818,7 @@ export
     readdir,
     readline,
     readlines,
+    input,
     readuntil,
     redirect_stderr,
     redirect_stdin,

--- a/base/io.jl
+++ b/base/io.jl
@@ -550,6 +550,16 @@ function readlines(filename::AbstractString; kw...)
 end
 readlines(s=stdin; kw...) = collect(eachline(s; kw...))
 
+"""
+    input(message::AbstractString)
+
+Prints a message to `stdout` and reads a single line of text from `stdin`.
+"""
+function input(message::AbstractString)
+    print(message)
+    return readline()
+end
+
 ## byte-order mark, ntoh & hton ##
 
 let a = UInt32[0x01020304]


### PR DESCRIPTION
I translated over a thousand lines of Python code aimed at beginners into Julia. Almost everything was as easy, if not easier. However, typing the combination of `println` and `readline` gets tiring very quickly. Python has the function `input`, which prints a message and returns an input, and so I thought Julia should have something similar.

Juno/Atom.jl has an input function that takes an input from an Atom dialog box; that might need to import from Base.

I'm not sure how to test `stdin`, would appreciate any pointers.