### PR TITLE
rand(BigFloat): create BigFloat with precision according to the sampler

### DIFF
--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -57,6 +57,7 @@ Sampler(::Type{<:AbstractRNG}, I::FloatInterval{BigFloat}, ::Repetition) =
     SamplerBigFloat{typeof(I)}(precision(BigFloat))
 
 function _rand!(rng::AbstractRNG, z::BigFloat, sp::SamplerBigFloat)
+    precision(z) == sp.prec || throw(ArgumentError("incompatible BigFloat precision"))
     limbs = sp.limbs
     rand!(rng, limbs)
     @inbounds begin
@@ -100,7 +101,7 @@ rand!(rng::AbstractRNG, z::BigFloat, sp::SamplerBigFloat{T}
           _rand!(rng, z, sp, T())
 
 rand(rng::AbstractRNG, sp::SamplerBigFloat{T}) where {T<:FloatInterval{BigFloat}} =
-    rand!(rng, BigFloat(), sp)
+    rand!(rng, BigFloat(; precision=sp.prec), sp)
 
 
 ### random integers

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -882,4 +882,19 @@ end
     y = rand!(rng, x, s)
     @test y === x
     @test 1 <= x < 2
+
+    old_prec = precision(BigFloat)
+    setprecision(100) do
+        x = rand(s) # should use precision of s
+        @test precision(x) == old_prec
+        x = BigFloat()
+        @test_throws ArgumentError rand!(rng, x, s) # incompatible precision
+    end
+    s = setprecision(100) do
+        Random.Sampler(MersenneTwister, Random.CloseOpen01(BigFloat))
+    end
+    x = rand(s) # should use precision of s
+    @test precision(x) == 100
+    x = BigFloat()
+    @test_throws ArgumentError rand!(rng, x, s) # incompatible precision
 end


### PR DESCRIPTION
If the global precision for `BigFloat` changed between creating the sampler
and generating a random `BigFloat`, bad things would happen, in particular
if the precision was decreasing (we would write into arrays out-of-bounds).
So create a fresh `BigFloat` without consideration for the current
precision, only for the precision stored in the sampler. 