### PR TITLE
Add a function to locate the loaded libLLVM.

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -250,6 +250,8 @@ else
     VersionNumber(libllvm_version_string)
 end
 
+libllvm() = ccall(:jl_get_libllvm, Any, ())
+
 function banner(io::IO = stdout)
     if GIT_VERSION_INFO.tagged_commit
         commit_string = TAGGED_RELEASE_BANNER

--- a/src/julia.h
+++ b/src/julia.h
@@ -1500,6 +1500,7 @@ JL_DLLEXPORT long jl_getallocationgranularity(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_is_debugbuild(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_sym_t *jl_get_UNAME(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_sym_t *jl_get_ARCH(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_get_libllvm(void) JL_NOTSAFEPOINT;
 
 // environment entries
 JL_DLLEXPORT jl_value_t *jl_environ(int i);

--- a/src/sys.c
+++ b/src/sys.c
@@ -58,6 +58,8 @@
 
 #include "julia_assert.h"
 
+#include <llvm-c/Core.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -649,6 +651,26 @@ JL_DLLEXPORT size_t jl_maxrss(void)
 JL_DLLEXPORT int jl_threading_enabled(void)
 {
     return 1;
+}
+
+JL_DLLEXPORT jl_value_t *jl_get_libllvm(void) JL_NOTSAFEPOINT {
+#if defined(_OS_WINDOWS_)
+    HMODULE mod;
+    // FIXME: GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS on LLVMContextCreate,
+    //        but that just points to libjulia.dll
+    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, "LLVM", &mod))
+        return jl_nothing;
+
+    char path[MAX_PATH];
+    if (!GetModuleFileNameA(mod, path, sizeof(path)))
+        return jl_nothing;
+    return (jl_value_t*) jl_symbol(path);
+#else
+    Dl_info dli;
+    if (!dladdr(LLVMContextCreate, &dli))
+        return jl_nothing;
+    return (jl_value_t*) jl_symbol(dli.dli_fname);
+#endif
 }
 
 #ifdef __cplusplus

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -6,3 +6,6 @@
 sprint(Base.Sys.cpu_summary)
 @test Base.Sys.uptime() > 0
 Base.Sys.loadavg()
+
+@test Base.libllvm() isa Symbol
+@test contains(String(Base.libllvm()), "LLVM")


### PR DESCRIPTION
Otherwise LLVM.jl needs to do [some trickery](https://github.com/maleadt/LLVM.jl/blob/b6eafc99c39771b50813d59f8ac9114365699363/src/LLVM.jl#L58-L82) to find the correct one, resulting in issues like https://github.com/maleadt/LLVM.jl/issues/209 when there's multiple libraries loaded.

I couldn't find a way to get `GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS)` to work though, passing e.g. `LLVMContextCreate` always returned the main Julia module instead of the LLVM one.