### PR TITLE
doc manual noteworthy diff from C: division

### DIFF
--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -287,9 +287,8 @@ For users coming to Julia from R, these are some noteworthy differences:
     (prefixed with `0b`) literals are also treated as unsigned (or `BigInt` for more than 128 bits).
   * In Julia, the division operator [`/`](@ref) returns a floating point number when both operands
     are of integer type.  To perform integer division, use [`div`](@ref) or [`÷`](@ref div).
-  * Indexing an `Array` with a non-integer type is an error in Julia. The Julia equivalent of the C
-    expression `a[i / 2]` is a[i ÷ 2 + 1].    
-    type, will cause an error in Julia.
+  * Indexing an `Array` with floating point types is generally an error in Julia. The Julia
+    equivalent of the C expression `a[i / 2]` is `a[i ÷ 2 + 1]`, where `i` is of integer type.
   * String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain
     `"` characters without quoting it like `"\""`. String literals can have values of other variables
     or expressions interpolated into them, indicated by `$variablename` or `$(expression)`, which

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -288,7 +288,7 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, the division operator [`/`](@ref) returns a floating point number when both operands
     are of integer type.  To perform integer division, use [`div`](@ref) or [`÷`](@ref div).
     Indexing an `Array` with an expression involving `/` as in `a[i/2]` where `i` is of integer
-    type, will cause an error in Julia.    
+    type, will cause an error in Julia.
   * String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain
     `"` characters without quoting it like `"\""`. String literals can have values of other variables
     or expressions interpolated into them, indicated by `$variablename` or `$(expression)`, which

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -285,6 +285,9 @@ For users coming to Julia from R, these are some noteworthy differences:
     literals are rounded (and not promoted to the `BigFloat` type) if they can not be exactly represented.
      Floating point literals are closer in behavior to C/C++. Octal (prefixed with `0o`) and binary
     (prefixed with `0b`) literals are also treated as unsigned (or `BigInt` for more than 128 bits).
+  * In Julia, the division operator [`/`](@ref) always returns a floating point number.  To perform
+    integer division, use [`div`](@ref) or [`÷`](@ref). Indexing an array with an expression
+    involving `/` as in `a[i/2]`, will cause an error in Julia.
   * String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain
     `"` characters without quoting it like `"\""`. String literals can have values of other variables
     or expressions interpolated into them, indicated by `$variablename` or `$(expression)`, which

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -287,7 +287,8 @@ For users coming to Julia from R, these are some noteworthy differences:
     (prefixed with `0b`) literals are also treated as unsigned (or `BigInt` for more than 128 bits).
   * In Julia, the division operator [`/`](@ref) returns a floating point number when both operands
     are of integer type.  To perform integer division, use [`div`](@ref) or [`÷`](@ref div).
-    Indexing an `Array` with an expression involving `/` as in `a[i/2]` where `i` is of integer
+  * Indexing an `Array` with a non-integer type is an error in Julia. The Julia equivalent of the C
+    expression `a[i / 2]` is a[i ÷ 2 + 1].    
     type, will cause an error in Julia.
   * String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain
     `"` characters without quoting it like `"\""`. String literals can have values of other variables

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -285,9 +285,10 @@ For users coming to Julia from R, these are some noteworthy differences:
     literals are rounded (and not promoted to the `BigFloat` type) if they can not be exactly represented.
      Floating point literals are closer in behavior to C/C++. Octal (prefixed with `0o`) and binary
     (prefixed with `0b`) literals are also treated as unsigned (or `BigInt` for more than 128 bits).
-  * In Julia, the division operator [`/`](@ref) always returns a floating point number.  To perform
-    integer division, use [`div`](@ref) or [`÷`](@ref div). Indexing an array with an expression
-    involving `/` as in `a[i/2]`, will cause an error in Julia.
+  * In Julia, the division operator [`/`](@ref) returns a floating point number when both operands
+    are of integer type.  To perform integer division, use [`div`](@ref) or [`÷`](@ref div).
+    Indexing an `Array` with an expression involving `/` as in `a[i/2]` where `i` is of integer
+    type, will cause an error in Julia.    
   * String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain
     `"` characters without quoting it like `"\""`. String literals can have values of other variables
     or expressions interpolated into them, indicated by `$variablename` or `$(expression)`, which

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -286,7 +286,7 @@ For users coming to Julia from R, these are some noteworthy differences:
      Floating point literals are closer in behavior to C/C++. Octal (prefixed with `0o`) and binary
     (prefixed with `0b`) literals are also treated as unsigned (or `BigInt` for more than 128 bits).
   * In Julia, the division operator [`/`](@ref) always returns a floating point number.  To perform
-    integer division, use [`div`](@ref) or [`÷`](@ref). Indexing an array with an expression
+    integer division, use [`div`](@ref) or [`÷`](@ref div). Indexing an array with an expression
     involving `/` as in `a[i/2]`, will cause an error in Julia.
   * String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain
     `"` characters without quoting it like `"\""`. String literals can have values of other variables


### PR DESCRIPTION
When teaching Julia to C/C++ programmers, I have seen this mistake a few times. Especially in connection with indexing.