### PR TITLE
Don't call private reshape API in reshape(..., ::Colon).

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -115,7 +115,7 @@ reshape(parent::AbstractArray, dims::Dims)        = _reshape(parent, dims)
 reshape(parent::AbstractVector, ::Colon) = parent
 reshape(parent::AbstractArray, dims::Int...) = reshape(parent, dims)
 reshape(parent::AbstractArray, dims::Union{Int,Colon}...) = reshape(parent, dims)
-reshape(parent::AbstractArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = _reshape(parent, _reshape_uncolon(parent, dims))
+reshape(parent::AbstractArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = reshape(parent, _reshape_uncolon(parent, dims))
 @inline function _reshape_uncolon(A, dims)
     @noinline throw1(dims) = throw(DimensionMismatch(string("new dimensions $(dims) ",
         "may have at most one omitted dimension specified by `Colon()`")))


### PR DESCRIPTION
Otherwise CUDA.jl (which provides `reshape(::CuArray, dims::Int...)`) has to copy this method, ref https://github.com/JuliaGPU/CUDA.jl/pull/512.