### PR TITLE
Solving Lyapunov equation for matrices given in Adjoint form

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1567,4 +1567,5 @@ function lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:BlasFloat}
     rmul!(Q*(Y * adjoint(Q)), inv(scale))
 end
 lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:Integer} = lyap(float(A), float(C))
+lyap(A::Adjoint{T,Matrix{T}}, C::Adjoint{T,Matrix{T}}) where T = lyap(Matrix(A), Matrix(C))
 lyap(a::T, c::T) where {T<:Number} = -c/(2a)


### PR DESCRIPTION
There seems to be no consensus about what should be the Lyapunov equation: A'P+PA+Q=0 or AP+PA'+Q=0. For instance, Wikipedia says differently than the doc of `lyap`. For this reason, I think it would be nice to have an easy interface to switch between both definitions by allowing to put `A'` directly in the arguments of `lyap`.