### PR TITLE
fix numerous issues with WeakKeyDict

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -31,9 +31,13 @@ function in(p, a::AbstractDict)
 end
 
 function summary(io::IO, t::AbstractDict)
-    n = length(t)
     showarg(io, t, true)
-    print(io, " with ", n, (n==1 ? " entry" : " entries"))
+    if Base.IteratorSize(t) isa HasLength
+        n = length(t)
+        print(io, " with ", n, (n==1 ? " entry" : " entries"))
+    else
+        print(io, "(...)")
+    end
 end
 
 struct KeySet{K, T <: AbstractDict{K}} <: AbstractSet{K}

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -895,18 +895,16 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     d26939 = WeakKeyDict()
     (@noinline d -> d[big"1.0" + 1.1] = 1)(d26939)
     GC.gc() # primarily to make sure this doesn't segfault
-    @test length(d26939.ht) == 1
-    @test length(d26939) == 1
-    @test !isempty(d26939)
     @test count(d26939) == 0
+    @test length(d26939.ht) == 1
+    @test length(d26939) == 0
+    @test isempty(d26939)
     empty!(d26939)
     for i in 1:8
         (@noinline (d, i) -> d[big(i + 12345)] = 1)(d26939, i)
     end
     lock(GC.gc, d26939)
     @test length(d26939.ht) == 8
-    @test length(d26939) == 8
-    @test !isempty(d26939)
     @test count(d26939) == 0
     @test !haskey(d26939, nothing)
     @test_throws KeyError(nothing) d26939[nothing]
@@ -920,8 +918,9 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     @test_throws ArgumentError d26939[nothing] = 1
     @test_throws ArgumentError get!(d26939, nothing, 1)
     @test_throws ArgumentError get!(() -> 1, d26939, nothing)
-    Base._cleanup_locked(d26939)
+    @test isempty(d26939)
     @test length(d26939.ht) == 0
+    @test length(d26939) == 0
 
     # WeakKeyDict does not convert keys on setting
     @test_throws ArgumentError WeakKeyDict{Vector{Int},Any}([5.0]=>1)


### PR DESCRIPTION
Delay cleanup of WeakKeyDict items until the next insertion. (And fix
`get!`, since previously usage of it would have added keys without
finalizers to the dict.)

The most significant change here is that I'm changing the way WeakKey works: now instead of the GC clearing the internal reference *after* the last instance of it disappears from the system (after running finalizers), I'm instead clearing it *prior to* (happens-before) scheduling any finalization. This is significant because—while this breaks the old implementation of WeakKeyDict—it is a necessary property for precise detection of whether the object is still strongly alive after recovering a reference to it out of a WeakKey object. This happens to be how other languages do it (https://docs.oracle.com/javase/8/docs/api/java/lang/ref/WeakReference.html, https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/weak-references), so I feel reassured this is the right change.

This also means we could also now drop the internal `lock` that was need to make this thread-safe (not implemented yet). Thoughts?

Fixes #26939