### PR TITLE
special-case Base.rest for AbstractString

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -711,3 +711,12 @@ julia> ascii("abcdefgh")
 ```
 """
 ascii(x::AbstractString) = ascii(String(x))
+
+Base.rest(s::Union{String,SubString{String}}, i=1) = SubString(s, i)
+function Base.rest(s::AbstractString, st...)
+    io = IOBuffer()
+    for c in Iterators.rest(s, st...)
+        print(io, c)
+    end
+    return String(take!(io))
+end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -100,8 +100,10 @@ end
     Base.rest(collection[, itr_state])
 
 Generic function for taking the tail of `collection`, starting from a specific iteration
-state `itr_state`. Return a `Tuple`, if `collection` itself is a `Tuple`, a `Vector`, if
-`collection` is an `AbstractArray` and `Iterators.rest(collection[, itr_state])` otherwise.
+state `itr_state`. Return a `Tuple`, if `collection` itself is a `Tuple`, a subtype of
+`AbstractVector`, if `collection` is an `AbstractArray`, a subtype of `AbstractString`
+if `collection` is an `AbstractString`, and an arbitrary iterator, falling back to
+`Iterators.rest(collection[, itr_state])`, otherwise.
 Can be overloaded for user-defined collection types to customize the behavior of slurping
 in assignments, like `a, b... = collection`.
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -386,3 +386,20 @@ let testb() = b"0123"
     @test_throws ErrorException b[4] = '4'
     @test testb() == UInt8['0','1','2','3']
 end
+
+@testset "Base.rest" begin
+    s = "aβcd"
+    @test Base.rest(s) === SubString(s)
+    a, b, c... = s
+    @test c === SubString(s, 4)
+
+    s = SubString("aβcd", 2)
+    @test Base.rest(s) === SubString(s)
+    b, c... = s
+    @test c === SubString(s, 3)
+
+    s = GenericString("aβcd")
+    @test Base.rest(s) === "aβcd"
+    a, b, c... = s
+    @test c === "cd"
+end


### PR DESCRIPTION
I just noticed that the new slurping syntax is probably useful for strings as well, so this now returns a `SubString` for `String` and `SubString{String}` and `String` for any other `AbstractString`. I also loosened the docstring for `Base.rest` a bit, so we have a bit more freedom to return types that make more sense than the current default implementation in Base for other types.