### PR TITLE
Make any_gc_flag threadsafe

### DIFF
--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -251,9 +251,13 @@ const any_gc_flag = Threads.Condition()
 function start_gc_msgs_task()
     @async begin
         lock(any_gc_flag)
-        while true
-            wait(any_gc_flag)
-            flush_gc_msgs()
+        try
+            while true
+                wait(any_gc_flag)
+                flush_gc_msgs()
+            end
+        finally
+            unlock(any_gc_flag)
         end
     end
 end


### PR DESCRIPTION
I don't know the intrinsics of Julia's garbage collection, but maybe it's the remoterefs to `chan` running out of scope on the worker processes that cause the failures:

* https://github.com/JuliaLang/julia/blob/master/stdlib/Distributed/test/threads.jl#L40
* https://github.com/JuliaLang/julia/blob/master/stdlib/Distributed/test/threads.jl#L43

If the corresponding closures are executed on threads 1 and 2, and both issue the finalizers for (their local copy of) `chan` to run, there are to threads executing `send_del_client` and thus calling `notify(any_gc_flag)`. Is my guess correct?

Ref JuliaLang/julia#38134
Ref JuliaLang/Distributed.jl#73 

cc @vtjnash @vchuravy 