### PR TITLE
insert backtrace printing into user-facing JL_CATCH

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -2072,11 +2072,12 @@ static void jl_reinit_item(jl_value_t *v, int how, arraylist_t *tracee_list)
         }
     }
     JL_CATCH {
-        jl_printf(JL_STDERR, "WARNING: error while reinitializing value ");
-        jl_static_show(JL_STDERR, v);
-        jl_printf(JL_STDERR, ":\n");
-        jl_static_show(JL_STDERR, jl_current_exception());
-        jl_printf(JL_STDERR, "\n");
+        jl_printf((JL_STREAM*)STDERR_FILENO, "WARNING: error while reinitializing value ");
+        jl_static_show((JL_STREAM*)STDERR_FILENO, v);
+        jl_printf((JL_STREAM*)STDERR_FILENO, ":\n");
+        jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+        jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+        jlbacktrace(); // written to STDERR_FILENO
     }
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -277,9 +277,10 @@ static void run_finalizer(jl_ptls_t ptls, jl_value_t *o, jl_value_t *ff)
         jl_get_ptls_states()->world_age = last_age;
     }
     JL_CATCH {
-        jl_printf(JL_STDERR, "error in running finalizer: ");
-        jl_static_show(JL_STDERR, jl_current_exception());
-        jl_printf(JL_STDERR, "\n");
+        jl_printf((JL_STREAM*)STDERR_FILENO, "error in running finalizer: ");
+        jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+        jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+        jlbacktrace(); // writen to STDERR_FILENO
     }
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -60,10 +60,10 @@ void jl_call_tracer(tracer_cb callback, jl_value_t *tracee)
     }
     JL_CATCH {
         ptls->in_pure_callback = last_in;
-        jl_printf(JL_STDERR, "WARNING: tracer callback function threw an error:\n");
-        jl_static_show(JL_STDERR, jl_current_exception());
-        jl_printf(JL_STDERR, "\n");
-        jlbacktrace();
+        jl_printf((JL_STREAM*)STDERR_FILENO, "WARNING: tracer callback function threw an error:\n");
+        jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+        jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+        jlbacktrace(); // written to STDERR_FILENO
     }
 }
 
@@ -300,9 +300,9 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
         src = (jl_code_info_t*)jl_apply(fargs, 3);
     }
     JL_CATCH {
-        jl_printf(JL_STDERR, "Internal error: encountered unexpected error in runtime:\n");
-        jl_static_show(JL_STDERR, jl_current_exception());
-        jl_printf(JL_STDERR, "\n");
+        jl_printf((JL_STREAM*)STDERR_FILENO, "Internal error: encountered unexpected error in runtime:\n");
+        jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+        jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         jlbacktrace(); // written to STDERR_FILENO
         src = NULL;
     }

--- a/src/init.c
+++ b/src/init.c
@@ -223,8 +223,10 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
                 ptls->world_age = last_age;
             }
             JL_CATCH {
-                jl_printf(JL_STDERR, "\natexit hook threw an error: ");
-                jl_static_show(JL_STDERR, jl_current_exception());
+                jl_printf((JL_STREAM*)STDERR_FILENO, "\natexit hook threw an error: ");
+                jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+                jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+                jlbacktrace(); // written to STDERR_FILENO
             }
         }
     }
@@ -258,8 +260,10 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
                 //error handling -- continue cleanup, as much as possible
                 assert(item);
                 uv_unref(item->h);
-                jl_printf(JL_STDERR, "error during exit cleanup: close: ");
-                jl_static_show(JL_STDERR, jl_current_exception());
+                jl_printf((JL_STREAM*)STDERR_FILENO, "error during exit cleanup: close: ");
+                jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+                jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+                jlbacktrace(); // written to STDERR_FILENO
                 item = next_shutdown_queue_item(item);
             }
         }

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -492,6 +492,9 @@ static int exec_program(char *program)
         jl_load(jl_main_module, program);
     }
     JL_CATCH {
+        // TODO: It is possible for this output
+        //       to be mangled due to `jlbacktrace`
+        //       printing directly to STDERR_FILENO.
         jl_value_t *errs = jl_stderr_obj();
         JL_GC_PUSH1(&errs);
         volatile int shown_err = 0;
@@ -510,11 +513,11 @@ static int exec_program(char *program)
         }
         JL_GC_POP();
         if (!shown_err) {
-            jl_static_show(JL_STDERR, jl_current_exception());
-            jl_printf(JL_STDERR, "\n");
+            jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+            jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         }
-        jlbacktrace();
-        jl_printf(JL_STDERR, "\n");
+        jlbacktrace(); // written to STDERR_FILENO
+        jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         return 1;
     }
     return 0;
@@ -597,10 +600,10 @@ static NOINLINE int true_main(int argc, char *argv[])
                 free(line);
                 line = NULL;
             }
-            jl_printf(JL_STDERR, "\nparser error:\n");
-            jl_static_show(JL_STDERR, jl_current_exception());
-            jl_printf(JL_STDERR, "\n");
-            jlbacktrace();
+            jl_printf((JL_STREAM*)STDERR_FILENO, "\nparser error:\n");
+            jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+            jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+            jlbacktrace(); // written to STDERR_FILENO
         }
     }
     return 0;

--- a/src/task.c
+++ b/src/task.c
@@ -558,10 +558,10 @@ JL_DLLEXPORT void jl_switchto(jl_task_t **pt)
 
 JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
 {
-    jl_printf(JL_STDERR, "fatal: error thrown and no exception handler available.\n");
-    jl_static_show(JL_STDERR, e);
-    jl_printf(JL_STDERR, "\n");
-    jlbacktrace();
+    jl_printf((JL_STREAM*)STDERR_FILENO, "fatal: error thrown and no exception handler available.\n");
+    jl_static_show((JL_STREAM*)STDERR_FILENO, e);
+    jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+    jlbacktrace(); // written to STDERR_FILENO
     jl_exit(1);
 }
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -353,11 +353,9 @@ end
     @test istaskdone(t)
     @test fetch(t)
     @test run[] == 3
-    @test fetch(errstream) == """
-        error in running finalizer: ErrorException("task switch not allowed from inside gc finalizer")
-        error in running finalizer: ErrorException("task switch not allowed from inside gc finalizer")
-        error in running finalizer: ErrorException("task switch not allowed from inside gc finalizer")
-        """
+    output = fetch(errstream)
+    @test 3 == length(findall(
+        """error in running finalizer: ErrorException("task switch not allowed from inside gc finalizer")""", output))
     # test for invalid state in Workqueue during yield
     t = @async nothing
     t._state = 66


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/38134#issuecomment-717318172 I found it impossible to tell
which finalizer is to blame. With this a stacktrace is being printed:

```
julia> yield(t)
error in running finalizer: ErrorException("task switch not allowed from inside gc finalizer")
jl_error at /home/vchuravy/src/julia/src/rtutils.c:41
jl_switch at /home/vchuravy/src/julia/src/task.c:502
try_yieldto at ./task.jl:684
yieldto at ./task.jl:679 [inlined]
yieldto at ./task.jl:677 [inlined]
#9 at ./REPL[4]:11
_jl_invoke at /home/vchuravy/src/julia/src/gf.c:2172 [inlined]
jl_apply_generic at /home/vchuravy/src/julia/src/gf.c:2373
jl_apply at /home/vchuravy/src/julia/src/julia.h:1691 [inlined]
run_finalizer at /home/vchuravy/src/julia/src/gc.c:276
```

In this example the finalizer is `#9 at ./REPL[4]:11`
