### PR TITLE
[loading]: Fix new tests post-Preferences merge

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -231,7 +231,7 @@ end
         pkg = recurse_package(n...)
         @test pkg == PkgId(UUID(uuid), n[end])
         @test joinpath(@__DIR__, normpath(path)) == locate_package(pkg)
-        @test Base.compilecache_path(pkg, 0) == Base.compilecache_path(pkg, 0)
+        @test Base.compilecache_path(pkg, UInt64(0)) == Base.compilecache_path(pkg, UInt64(0))
     end
     @test identify_package("Baz") == nothing
     @test identify_package("Qux") == nothing

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -231,7 +231,7 @@ end
         pkg = recurse_package(n...)
         @test pkg == PkgId(UUID(uuid), n[end])
         @test joinpath(@__DIR__, normpath(path)) == locate_package(pkg)
-        @test Base.compilecache_path(pkg) == Base.compilecache_path(pkg)
+        @test Base.compilecache_path(pkg, 0) == Base.compilecache_path(pkg, 0)
     end
     @test identify_package("Baz") == nothing
     @test identify_package("Qux") == nothing


### PR DESCRIPTION
The new Preferences loading strategy changed some pieces of the loading
machinery, in particular, it added another parameter to
`Base.compilecache_path()`.  This was not caught by CI because the
Preferences PR stood open for so long that the other tests changed
after the CI had already turned green, and we don't re-run tests when
another branch is merged, so we often have stale tests.