### PR TITLE
manual: fix link in workflow-tips.md

### DIFF
--- a/doc/src/manual/workflow-tips.md
+++ b/doc/src/manual/workflow-tips.md
@@ -131,5 +131,4 @@ the following modifications:
 
    You can iteratively modify the code in MyPkg in your editor and re-run the
    tests with `include("runtests.jl")`.  You generally should not need to restart
-   your Julia session to see the changes take effect (subject to a few limitations,
-   see https://timholy.github.io/Revise.jl/stable/limitations/).
+   your Julia session to see the changes take effect (subject to a few [limitations](https://timholy.github.io/Revise.jl/stable/limitations/)).


### PR DESCRIPTION
Bare links are not turned into hyperlinks by Documenter.