### PR TITLE
win,Profile: fix timeout units

### DIFF
--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -337,9 +337,8 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
     }
     timeBeginPeriod(tc.wPeriodMin);
     while (1) {
-        DWORD timeout = nsecprof / GIGA;
-        timeout += tc.wPeriodMin;
-        Sleep(timeout);
+        DWORD timeout_ms = nsecprof / (GIGA / 1000);
+        Sleep(timeout_ms > 0 ? timeout_ms : 1);
         if (bt_size_cur < bt_size_max && running) {
             JL_LOCK_NOGC(&jl_in_stackwalk);
             jl_lock_profile();

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -64,11 +64,14 @@ function init(n::Integer, delay::Real)
 end
 
 # init with default values
-# Use a max size of 1M profile samples, and fire timer every 1ms
-if Sys.iswindows()
+# Use a max size of 10M profile samples, and fire timer every 1ms
+# (that should typically give around 100 seconds of record)
+if Sys.iswindows() && Sys.WORD_SIZE == 32
+    # The Win32 unwinder is 1000x slower than elsewhere (around 1ms/frame),
+    # so we don't want to slow the program down by quite that much
     __init__() = init(1_000_000, 0.01)
 else
-    __init__() = init(1_000_000, 0.001)
+    __init__() = init(10_000_000, 0.001)
 end
 
 """

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -84,14 +84,15 @@ end
 
 @testset "setting sample count and delay in init" begin
     n_, delay_ = Profile.init()
-    @test n_ == 1_000_000
-    def_delay = Sys.iswindows() ? 0.01 : 0.001
+    def_n = Sys.iswindows() && Sys.WORD_SIZE == 32 ? 1_000_000 : 10_000_000
+    @test n_ == def_n
+    def_delay = Sys.iswindows() && Sys.WORD_SIZE == 32 ? 0.01 : 0.001
     @test delay_ == def_delay
     Profile.init(n=1_000_001, delay=0.0005)
     n_, delay_ = Profile.init()
     @test n_ == 1_000_001
     @test delay_ == 0.0005
-    Profile.init(n=1_000_000, delay=def_delay)
+    Profile.init()
 end
 
 @testset "Line number correction" begin
@@ -131,5 +132,5 @@ let cmd = Base.julia_cmd()
     s = read(p, String)
     close(t)
     @test success(p)
-    @test parse(Int, s) > 1000
+    @test parse(Int, s) > 100
 end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -92,7 +92,7 @@ end
     n_, delay_ = Profile.init()
     @test n_ == 1_000_001
     @test delay_ == 0.0005
-    Profile.init()
+    Profile.init(n=def_n, delay=def_delay)
 end
 
 @testset "Line number correction" begin


### PR DESCRIPTION
Previously, we were using units of seconds (rounded down) but the
function expected milliseconds. So this was effectively always zero
(ignored) in the computation.