### PR TITLE
add `rest` for `NamedTuple` and fix some destructuring cases

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -110,6 +110,8 @@ end # if Base
 
 length(t::NamedTuple) = nfields(t)
 iterate(t::NamedTuple, iter=1) = iter > nfields(t) ? nothing : (getfield(t, iter), iter + 1)
+rest(t::NamedTuple) = t
+@inline rest(t::NamedTuple{names}, i::Int) where {names} = NamedTuple{rest(names,i)}(t)
 firstindex(t::NamedTuple) = 1
 lastindex(t::NamedTuple) = nfields(t)
 getindex(t::NamedTuple, i::Int) = getfield(t, i)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2081,7 +2081,8 @@
                     ((null? r)          #f)
                     ((vararg? (car r))  (null? (cdr r)))
                     (else               (sides-match? (cdr l) (cdr r)))))
-            (if (and (pair? x) (pair? lhss) (eq? (car x) 'tuple)
+            (if (and (pair? x) (pair? lhss) (eq? (car x) 'tuple) (not (any assignment? (cdr x)))
+                     (not (has-parameters? (cdr x)))
                      (sides-match? lhss (cdr x)))
                 ;; (a, b, ...) = (x, y, ...)
                 (expand-forms

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2582,4 +2582,22 @@ end
     cdr((a, d...)) = d
     @test car(1:3) == 1
     @test cdr(1:3) == [2, 3]
+
+    @test begin a, b = (;c = 3, d = 4) end === (c = 3, d = 4)
+    @test begin a, b, c = (x = "", y = 2.0, z = 1) end === (x = "", y = 2.0, z = 1)
+    a, b, c = (x = "", y = 2.0, z = 1)
+    @test a === ""
+    @test b === 2.0
+    @test c === 1
+    @test begin a, b... = (x = "", y = 2.0, z = 1) end === (x = "", y = 2.0, z = 1)
+    a, b... = (x = "", y = 2.0, z = 1)
+    @test b === (y = 2.0, z = 1)
+    let t = (x = "", y = 1, z = 3.0)
+        _, a, b = t
+        @test a === 1
+        @test b === 3.0
+        a, b... = t
+        @test a === ""
+        @test b === (y = 1, z = 3.0)
+    end
 end


### PR DESCRIPTION
The lowering for destructuring thought a named tuple was a tuple. This was actually a long-standing bug, but you had to write a literal `a, b = (x=y, z=t)` and obtain the result of that expression to see it, which is extremely unlikely in a program. But in the repl:
```
julia> a, b = (x=2, z=1)
(2, 1)
```
