### PR TITLE
Fix bug in snoopi_deep: missing copy() on slottypes array

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -34,7 +34,7 @@ function _typeinf_identifier(frame::Core.Compiler.InferenceState)
         frame.linfo,
         frame.world,
         copy(frame.sptypes),
-        frame.slottypes,
+        copy(frame.slottypes),
     )
     return mi_info
 end


### PR DESCRIPTION
The slottypes array is reused and modified inside julia's type inference, so we
need to make a copy of it for each inference frame. This was a bug accidentally
introduced in #38143.

CC: @timholy

Co-Authored-By: @Sacha0