### PR TITLE
Fewer allocations for print

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -43,7 +43,7 @@ function print(io::IO, xs...)
     lock(io)
     try
         for x in xs
-            print(io, x)
+            show(io, x)
         end
     finally
         unlock(io)
@@ -70,7 +70,7 @@ julia> String(take!(io))
 "Hello, world\\n"
 ```
 """
-println(io::IO, xs...) = print(io, xs..., '\n')
+println(io::IO, xs...) = print(io, xs..., "\n")
 
 ## conversion of general objects to strings ##
 

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -43,7 +43,7 @@ function print(io::IO, xs...)
     lock(io)
     try
         for x in xs
-            show(io, x)
+            print(io, x)
         end
     finally
         unlock(io)


### PR DESCRIPTION
A. Fewer allocations (faster printing? [in terminal]).

<s>B. It's generally good to reuse code, there print (see the lines immediately above), but that print is doing show, and nothing else except locking and I assume you don't need to do twice or n-times actually.</s>

Surprisingly,  
```
print(io, xs..., \n')
```

has more allocations ('\n' allocation issue can maybe be fixed separately. I'm not sure, but it seems to be related to if type of that and xs do not match).


Not solved here, print('1') allocates more than print('1').

https://discourse.julialang.org/t/why-is-printing-to-a-terminal-slow/42987/27?u=palli