### PR TITLE
Define isnan for Number

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -447,7 +447,7 @@ Test whether a number value is a NaN, an indeterminate value which is neither an
 nor a finite number ("not a number").
 """
 isnan(x::AbstractFloat) = (x != x)::Bool
-isnan(x::Real) = false
+isnan(x::Number) = false
 
 isfinite(x::AbstractFloat) = x - x == 0
 isfinite(x::Real) = decompose(x)[3] != 0

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -178,3 +178,8 @@ end
     @test ≈(1.0; atol=1).(1.0:3.0) == [true, true, false]
 
 end
+
+@testset "isnan for Number" begin
+    struct CustomNumber <: Number end
+    @test !isnan(CustomNumber())
+end


### PR DESCRIPTION
Currently `isnan` is defined for `Real` and for `Complex` which are only subtypes of `Number` in Base.

However, in general it is possible that there are numbers that are subtype of `Number` that are not `Real` or `Complex` so it would be good to have `isnan` defined by default for all `Number` to avoid having writing code like:
```
function fun(x::Number)
    if x isa Union{Real, Complex)
        isnan(x)
    else
        # do something special as it is not guaranteed that isnan is defined here
    end
end
```
(or the equivalent of the above using multiple dispatch)