### PR TITLE
improve inferrability of `list_deletefirst!(q::InvasiveLinkedList{T}, val::T)`

### DIFF
--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -87,6 +87,7 @@ function popfirst!(q::InvasiveLinkedList{T}) where {T}
     return val
 end
 
+# this function assumes `val` is found in `q`
 function list_deletefirst!(q::InvasiveLinkedList{T}, val::T) where T
     val.queue === q || return
     head = q.head::T
@@ -97,10 +98,10 @@ function list_deletefirst!(q::InvasiveLinkedList{T}, val::T) where T
             q.head = val.next::T
         end
     else
-        head_next = head.next
+        head_next = head.next::T
         while head_next !== val
             head = head_next
-            head_next = head.next::Union{T, Nothing}
+            head_next = head.next::T
         end
         if q.tail::T === val
             head.next = nothing


### PR DESCRIPTION
`head` shouldn't be `nothing` in this control flow

/cc @JeffBezanson (from the commit history)

---

/ref: it's just that [a type level execution](https://github.com/aviatesk/JET.jl/pull/62/checks?check_run_id=1330439423) on `rand(Bool)` reveals that this code might lead to err in succeeding `head.next` calls when `head_next === nothing`, and so this patch may not be necessary in actual execution (I'm afraid but I don't know implicit assumptions with `list_deletefirst!` calls)

<details><summary>details</summary>
<p>

```julia
[ Info: profiling for rand(Bool) ...
  1.800859 seconds (4.15 M allocations: 253.376 MiB, 4.63% gc time, 67.31% compilation time)
[ Info: 4 errors reported for rand(Bool)
═════ 4 possible errors found ═════
┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\Random.jl:259 Random.default_rng()
│┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\RNGs.jl:370 Random.default_rng(Base.getproperty(Random.Threads, :threadid::Symbol)::typeof(Base.Threads.threadid)()::Int64)
││┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\RNGs.jl:376 Random.MersenneTwister()
│││┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\RNGs.jl:147 #self#::Type{Random.MersenneTwister}(Random.nothing)
││││┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\RNGs.jl:147 Random.seed!(Random.MersenneTwister(Core.apply_type(Random.Vector, Random.UInt32)::Type{Vector{UInt32}}()::Vector{UInt32}, Random.DSFMT_state()::Random.DSFMT.DSFMT_state)::Random.MersenneTwister, seed::Nothing)
│││││┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\Random.jl:426 Random.seed!(rng::Random.MersenneTwister)
││││││┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\RNGs.jl:362 Random.make_seed()
│││││││┌ @ C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.6\Random\src\RNGs.jl:321 Random.println(Random.stderr, "Entropy pool not available to seed RNG; using ad-hoc entropy sources.")
││││││││┌ @ strings/io.jl:73 Base.print(Core.tuple(io::IO)::Tuple{IO}, xs::Tuple{String}, Core.tuple("\n")::Tuple{String}...)
│││││││││┌ @ strings/io.jl:43 Base.lock(io::IO)
││││││││││┌ @ show.jl:333 Base.lock(Base.getproperty(io::IOContext, :io::Symbol)::IO)
│││││││││││┌ @ stream.jl:282 Base.lock(Base.getproperty(s::Base.LibuvStream, :lock::Symbol)::Base.AbstractLock)
││││││││││││┌ @ lock.jl:83 Base.wait(Base.getproperty(rl::ReentrantLock, :cond_wait::Symbol)::Base.GenericCondition{Base.Threads.SpinLock})
│││││││││││││┌ @ condition.jl:106 Base.wait()
││││││││││││││┌ @ task.jl:752 Base.poptask(W::Base.InvasiveLinkedListSynchronized{Task})
│││││││││││││││┌ @ task.jl:742 Base.trypoptask(W::Base.InvasiveLinkedListSynchronized{Task})
││││││││││││││││┌ @ task.jl:728 Base.popfirst!(W::Base.InvasiveLinkedListSynchronized{Task})
│││││││││││││││││┌ @ task.jl:533 Base.popfirst!(Base.getproperty(W::Base.InvasiveLinkedListSynchronized{Task}, :queue::Symbol)::Base.InvasiveLinkedList{Task})
││││││││││││││││││┌ @ linked_list.jl:86 Base.list_deletefirst!(q::Base.InvasiveLinkedList{Task}, val::Task)
│││││││││││││││││││┌ @ linked_list.jl:103 Base.getproperty(head::Union{Task, Nothing}, :next::Symbol)
││││││││││││││││││││┌ @ Base.jl:33 Base.getfield(x::Nothing, f::Symbol)
│││││││││││││││││││││ invalid builtin function call: Base.getfield(x::Nothing, f::Symbol)
││││││││││││││││││││└──────────────
│││││││││││││││││││┌ @ linked_list.jl:106 Base.setproperty!(head::Union{Task, Nothing}, :next::Symbol, Base.nothing)
││││││││││││││││││││┌ @ Base.jl:34 Base.fieldtype(Base.typeof(x::Nothing)::Type{Nothing}, f::Symbol)
│││││││││││││││││││││ invalid builtin function call: Base.fieldtype(Base.typeof(x::Nothing)::Type{Nothing}, f::Symbol)
││││││││││││││││││││└──────────────
│││││││││││││││││││┌ @ linked_list.jl:109 Base.setproperty!(head::Union{Task, Nothing}, :next::Symbol, Core.typeassert(Base.getproperty(val::Task, :next::Symbol)::Union{Task, Nothing}, _::Type{Task})::Task)
││││││││││││││││││││┌ @ Base.jl:34 Base.fieldtype(Base.typeof(x::Nothing)::Type{Nothing}, f::Symbol)
│││││││││││││││││││││ invalid builtin function call: Base.fieldtype(Base.typeof(x::Nothing)::Type{Nothing}, f::Symbol)
││││││││││││││││││││└──────────────
│││││││││││││┌ @ condition.jl:108 Base.list_deletefirst!(Base.getproperty(ct::Task, :queue::Symbol)::Any, ct::Task)
││││││││││││││┌ @ linked_list.jl:145 Base.list_deletefirst!(q::Base.InvasiveLinkedList{Base.LinkedListItem{Task}}, h::Base.LinkedListItem{Task})
│││││││││││││││┌ @ linked_list.jl:109 Base.setproperty!(head::Union{Nothing, Base.LinkedListItem{Task}}, :next::Symbol, Core.typeassert(Base.getproperty(val::Base.LinkedListItem{Task}, :next::Symbol)::Union{Nothing, Base.LinkedListItem{Task}}, _::Type{Base.LinkedListItem{Task}})::Base.LinkedListItem{Task})
││││││││││││││││┌ @ Base.jl:34 Base.fieldtype(Base.typeof(x::Nothing)::Type{Nothing}, f::Symbol)
│││││││││││││││││ invalid builtin function call: Base.fieldtype(Base.typeof(x::Nothing)::Type{Nothing}, f::Symbol)
││││││││││││││││└──────────────
```

</p>
</details>