### PR TITLE
add paths to file error messages

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -254,7 +254,7 @@ julia> rm("my", recursive=true)
 julia> rm("this_file_does_not_exist", force=true)
 
 julia> rm("this_file_does_not_exist")
-ERROR: IOError: unlink: no such file or directory (ENOENT)
+ERROR: IOError: unlink("this_file_does_not_exist"): no such file or directory (ENOENT)
 Stacktrace:
 [...]
 ```
@@ -811,7 +811,7 @@ function readdir(dir::AbstractString; join::Bool=false, sort::Bool=true)
     # defined in sys.c, to call uv_fs_readdir, which sets errno on error.
     err = ccall(:uv_fs_scandir, Int32, (Ptr{Cvoid}, Ptr{UInt8}, Cstring, Cint, Ptr{Cvoid}),
                 C_NULL, uv_readdir_req, dir, 0, C_NULL)
-    err < 0 && throw(_UVError("readdir", err, "with ", repr(dir)))
+    err < 0 && uv_error("readdir($(repr(dir)))", err)
 
     # iterate the listing into entries
     entries = String[]

--- a/base/file.jl
+++ b/base/file.jl
@@ -82,9 +82,7 @@ julia> pwd()
 """
 function cd(dir::AbstractString)
     ret = ccall(:uv_chdir, Cint, (Cstring,), dir)
-    if ret < 0
-        uv_error("cd($(repr(dir)))", ret)
-    end
+   ret < 0 && uv_error("cd($(repr(dir)))", ret)
     return nothing
 end
 cd() = cd(homedir())
@@ -917,7 +915,7 @@ end
 
 function unlink(p::AbstractString)
     err = ccall(:jl_fs_unlink, Int32, (Cstring,), p)
-    uv_error("unlink($(repr(p)))", err)
+    err < 0 && uv_error("unlink($(repr(p)))", err)
     nothing
 end
 
@@ -1029,7 +1027,7 @@ Return `path`.
 """
 function chmod(path::AbstractString, mode::Integer; recursive::Bool=false)
     err = ccall(:jl_fs_chmod, Int32, (Cstring, Cint), path, mode)
-    uv_error("chmod($(repr(path)), 0o$(string(mode, base=8)))", err)
+    err < 0 && uv_error("chmod($(repr(path)), 0o$(string(mode, base=8)))", err)
     if recursive && isdir(path)
         for p in readdir(path)
             if !islink(joinpath(path, p))
@@ -1049,6 +1047,6 @@ Return `path`.
 """
 function chown(path::AbstractString, owner::Integer, group::Integer=-1)
     err = ccall(:jl_fs_chown, Int32, (Cstring, Cint, Cint), path, owner, group)
-    uv_error("chown($(repr(path)), $owner, $group)",err)
+    err < 0 && uv_error("chown($(repr(path)), $owner, $group)", err)
     path
 end

--- a/base/file.jl
+++ b/base/file.jl
@@ -979,13 +979,16 @@ function symlink(p::AbstractString, np::AbstractString)
         end
     end
     err = ccall(:jl_fs_symlink, Int32, (Cstring, Cstring, Cint), p, np, flags)
-    sym = "symlink($(repr(p)), $(repr(np)))"
-    @static if Sys.iswindows()
-        if err < 0 && !isdir(p)
-            sym = "On Windows, creating symlinks requires Administrator privileges.\nsymlink"
+    if err < 0
+        msg = "symlink($(repr(p)), $(repr(np)))"
+        @static if Sys.iswindows()
+            if !isdir(p)
+                msg = "On Windows, creating symlinks requires Administrator privileges.\n$msg"
+            end
         end
+        uv_error(msg, err)
     end
-    uv_error(sym, err)
+    return nothing
 end
 
 """

--- a/base/file.jl
+++ b/base/file.jl
@@ -81,8 +81,8 @@ julia> pwd()
 ```
 """
 function cd(dir::AbstractString)
-    ret = ccall(:uv_chdir, Cint, (Cstring,), dir)
-   ret < 0 && uv_error("cd($(repr(dir)))", ret)
+    err = ccall(:uv_chdir, Cint, (Cstring,), dir)
+    err < 0 && uv_error("cd($(repr(dir)))", err)
     return nothing
 end
 cd() = cd(homedir())

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -84,7 +84,7 @@ function open(path::AbstractString, flags::Integer, mode::Integer=0)
                     C_NULL, req, path, flags, mode, C_NULL)
         handle = ccall(:uv_fs_get_result, Cssize_t, (Ptr{Cvoid},), req)
         ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)
-        uv_error("open", ret)
+        ret < 0 && uv_error("open($(repr(path)), $flags, $mode)", ret)
     finally # conversion to Cstring could cause an exception
         Libc.free(req)
     end

--- a/base/path.jl
+++ b/base/path.jl
@@ -72,7 +72,7 @@ function homedir()
         elseif rc == Base.UV_ENOBUFS
             resize!(buf, sz[] - 1) # space for null-terminator implied by StringVector
         else
-            uv_error(:homedir, rc)
+            uv_error("homedir()", rc)
         end
     end
 end
@@ -433,7 +433,7 @@ function realpath(path::AbstractString)
                     C_NULL, req, path, C_NULL)
         if ret < 0
             ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)
-            uv_error("realpath", ret)
+            uv_error("realpath($(repr(path)))", ret)
         end
         path = unsafe_string(ccall(:jl_uv_fs_t_ptr, Cstring, (Ptr{Cvoid},), req))
         ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -66,7 +66,7 @@ macro stat_call(sym, arg1type, arg)
         stat_buf = zeros(UInt8, ccall(:jl_sizeof_stat, Int32, ()))
         r = ccall($(Expr(:quote, sym)), Int32, ($(esc(arg1type)), Ptr{UInt8}), $(esc(arg)), stat_buf)
         if !(r in (0, Base.UV_ENOENT, Base.UV_ENOTDIR, Base.UV_EINVAL))
-            throw(_UVError("stat", r, "for file ", repr($(esc(arg)))))
+            uv_error(string("stat(",repr($(esc(arg))),")"), r)
         end
         st = StatStruct(stat_buf)
         if ispath(st) != (r == 0)

--- a/test/file.jl
+++ b/test/file.jl
@@ -15,14 +15,14 @@ subdir = joinpath(dir, "adir")
 mkdir(subdir)
 subdir2 = joinpath(dir, "adir2")
 mkdir(subdir2)
-@test_throws Base._UVError("mkdir", Base.UV_EEXIST) mkdir(file)
+@test_throws Base._UVError("mkdir($(repr(file)); mode=0o777)", Base.UV_EEXIST) mkdir(file)
 let err = nothing
     try
         mkdir(file)
     catch err
         io = IOBuffer()
         showerror(io, err)
-        @test startswith(String(take!(io)), "IOError: mkdir: file already exists (EEXIST)")
+        @test startswith(String(take!(io)), "IOError: mkdir") && err.code == Base.UV_EEXIST
     end
 end
 
@@ -459,9 +459,9 @@ close(f)
 
 rm(c_tmpdir, recursive=true)
 @test !isdir(c_tmpdir)
-@test_throws Base._UVError("unlink", Base.UV_ENOENT) rm(c_tmpdir)
+@test_throws Base._UVError("unlink($(repr(c_tmpdir)))", Base.UV_ENOENT) rm(c_tmpdir)
 @test rm(c_tmpdir, force=true) === nothing
-@test_throws Base._UVError("unlink", Base.UV_ENOENT) rm(c_tmpdir, recursive=true)
+@test_throws Base._UVError("unlink($(repr(c_tmpdir)))", Base.UV_ENOENT) rm(c_tmpdir, recursive=true)
 @test rm(c_tmpdir, force=true, recursive=true) === nothing
 
 if !Sys.iswindows()
@@ -476,8 +476,8 @@ if !Sys.iswindows()
         @test stat(file).gid == 0
         @test stat(file).uid == 0
     else
-        @test_throws Base._UVError("chown", Base.UV_EPERM) chown(file, -2, -1)  # Non-root user cannot change ownership to another user
-        @test_throws Base._UVError("chown", Base.UV_EPERM) chown(file, -1, -2)  # Non-root user cannot change group to a group they are not a member of (eg: nogroup)
+        @test_throws Base._UVError("chown($(repr(path)), -2, -1)", Base.UV_EPERM) chown(file, -2, -1)  # Non-root user cannot change ownership to another user
+        @test_throws Base._UVError("chown($(repr(path)), -1, -2)", Base.UV_EPERM) chown(file, -1, -2)  # Non-root user cannot change group to a group they are not a member of (eg: nogroup)
     end
 else
     # test that chown doesn't cause any errors for Windows
@@ -926,10 +926,10 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
         @test_throws(ArgumentError("'$nonexisting_src' is not a directory. Use `cp(src, dst)`"),
                      Base.cptree(nonexisting_src, dst; force=true, follow_symlinks=true))
         # cp
-        @test_throws Base._UVError("open", Base.UV_ENOENT) cp(nonexisting_src, dst; force=true, follow_symlinks=false)
-        @test_throws Base._UVError("open", Base.UV_ENOENT) cp(nonexisting_src, dst; force=true, follow_symlinks=true)
+        @test_throws Base._UVError("open($(repr(nonexisting_src)), $(Base.JL_O_RDONLY), 0)", Base.UV_ENOENT) cp(nonexisting_src, dst; force=true, follow_symlinks=false)
+        @test_throws Base._UVError("open($(repr(nonexisting_src)), $(Base.JL_O_RDONLY), 0)", Base.UV_ENOENT) cp(nonexisting_src, dst; force=true, follow_symlinks=true)
         # mv
-        @test_throws Base._UVError("open", Base.UV_ENOENT) mv(nonexisting_src, dst; force=true)
+        @test_throws Base._UVError("open($(repr(nonexisting_src)), $(Base.JL_O_RDONLY), 0)", Base.UV_ENOENT) mv(nonexisting_src, dst; force=true)
     end
 end
 
@@ -1302,7 +1302,7 @@ cd(dirwalk) do
     @test files == ["file1", "file2"]
 
     rm(joinpath("sub_dir1"), recursive=true)
-    @test_throws(Base._UVError("readdir", Base.UV_ENOENT, "with ", repr(joinpath(".", "sub_dir1"))),
+    @test_throws(Base._UVError("readdir($(repr(joinpath(".", "sub_dir1"))))", Base.UV_ENOENT),
                  take!(chnl_error)) # throws an error because sub_dir1 do not exist
 
     root, dirs, files = take!(chnl_noerror)
@@ -1322,7 +1322,7 @@ cd(dirwalk) do
         symlink("foo", foo)
 
         let files = walkdir(joinpath(".", "sub_dir3"); follow_symlinks=true)
-            @test_throws Base._UVError("stat", Base.UV_ELOOP, "for file ", repr(foo)) take!(files)
+            @test_throws Base._UVError("stat($(repr(foo)))", Base.UV_ELOOP)  take!(files)
         end
         root, dirs, files = take!(walkdir(joinpath(".", "sub_dir3"); follow_symlinks=false))
         @test root == joinpath(".", "sub_dir3")
@@ -1512,8 +1512,8 @@ end
                 rm(d, recursive=true)
                 @test !ispath(d)
                 @test isempty(readdir())
-                @test_throws Base._UVError("readdir", Base.UV_ENOENT, "with ", repr(d)) readdir(d)
-                @test_throws Base._UVError("cwd", Base.UV_ENOENT) readdir(join=true)
+                @test_throws Base._UVError("readdir($(repr(d)))", Base.UV_ENOENT) readdir(d)
+                @test_throws Base._UVError("pwd()", Base.UV_ENOENT) readdir(join=true)
             end
         end
     end

--- a/test/file.jl
+++ b/test/file.jl
@@ -362,9 +362,8 @@ function test_stat_error(stat::Function, pth)
     end
     ex = try; stat(pth); false; catch ex; ex; end::Base.IOError
     @test ex.code == (pth isa AbstractString ? Base.UV_EACCES : Base.UV_EBADF)
-    @test startswith(ex.msg, "stat: ")
     pth isa AbstractString || (pth = Base.INVALID_OS_HANDLE)
-    @test endswith(ex.msg, repr(pth))
+    @test startswith(ex.msg, "stat($(repr(pth)))")
     nothing
 end
 @testset "stat errors" begin # PR 32031
@@ -476,8 +475,8 @@ if !Sys.iswindows()
         @test stat(file).gid == 0
         @test stat(file).uid == 0
     else
-        @test_throws Base._UVError("chown($(repr(path)), -2, -1)", Base.UV_EPERM) chown(file, -2, -1)  # Non-root user cannot change ownership to another user
-        @test_throws Base._UVError("chown($(repr(path)), -1, -2)", Base.UV_EPERM) chown(file, -1, -2)  # Non-root user cannot change group to a group they are not a member of (eg: nogroup)
+        @test_throws Base._UVError("chown($(repr(file)), -2, -1)", Base.UV_EPERM) chown(file, -2, -1)  # Non-root user cannot change ownership to another user
+        @test_throws Base._UVError("chown($(repr(file)), -1, -2)", Base.UV_EPERM) chown(file, -1, -2)  # Non-root user cannot change group to a group they are not a member of (eg: nogroup)
     end
 else
     # test that chown doesn't cause any errors for Windows


### PR DESCRIPTION
Makes the error messages for various file operations more descriptive, including the paths and other arguments.

EDIT: closes #38005, closes #33236, closes #33201.