### PR TITLE
fix #22787, another bounds circularity in type intersection

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1786,3 +1786,14 @@ let X1 = Tuple{AlmostLU, Vector{T}} where T,
     @test I >: actual
     @test_broken I == actual
 end
+
+# issue #22787
+# for now check that these don't stack overflow
+let
+    t = typeintersect(Tuple{Type{Q}, Q, Ref{Q}} where Q<:Ref,
+                      Tuple{Type{S}, Union{Ref{S}, Ref{R}}, R} where R where S)
+    @test_broken t != Union{}
+    t = typeintersect(Tuple{Type{T}, T, Ref{T}} where T,
+                      Tuple{Type{S}, Ref{S}, S} where S)
+    @test_broken t != Union{}
+end


### PR DESCRIPTION
Note the added tests are broken, but at least they don't stack overflow. The first test is reduced from the issue. The second test is a simpler version that did not overflow before, but did incorrectly give `Union{}` before. That makes me hopeful that this will not make anything worse.