### PR TITLE
Fix lock leak in iostream test

### DIFF
--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -93,6 +93,7 @@ end
         #  with resizing of b
         b = view(UInt8[0, 0, 0], 1:0)
         @test_throws MethodError readbytes!(file, b, 2)
+        @test !islocked(file.lock) # Issue #37218
         @test isempty(b)
     end
 end


### PR DESCRIPTION
The `resize!` call can throw if the array is not resizable (we even
have a test for it). However, this would leak the lock, since the
`_lock_ios` macro does not have an implicit try/catch, since it's
really only supposed to lock the C calls. Fix that by adding the
necessary try/catch around the resize call. Perhaps in the future
the compiler will be able to automatically elide try/catch blocks
around calls known not to throw, in which case, we could just put
it in the macro, without inviting performance problems.

Fixes #37218