### PR TITLE
Reword doc on undef arrays with missing

### DIFF
--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -260,13 +260,9 @@ julia> Array{Union{Missing, String}}(missing, 2, 3)
 ```
 
 !!! note
-    Currently for `T` that is bits type (`isbitstype(T)` returns `true`), if `T`
-    is not a singleton type then `Array{Union{Missing, T}}(undef, dims)` creates
-    an array filled with `missing` values. Also in this case calling `similar`
-    to create an unitialized array that has element type of the form
-    `Union{Missing, T}` creates an array filled with `missing`. If `T` is a
-    singleton type the value that is used to fill the array is undefined and
-    could change in the future, so it should not be relied upon.
+    Using `undef` or `similar` may currently give an array filled with
+    `missing`, but this is not the correct way to obtain such an array.
+    Use a `missing` constructor as shown above instead.
 
 An array allowing for `missing` values but which does not contain any such value
 can be converted back to an array which does not allow for missing values using


### PR DESCRIPTION
This is a follow-up to https://github.com/JuliaLang/julia/pull/31091. The intent is to make clear that `undef` constructors are not the right way to initialize arrays to missing. This way, other array implementations (such as SentinelArrays.jl) are free to provide faster `undef` constructors that actually leave data uninitialized (without creating an incompatiblity with specified behavior from Base).