### PR TITLE
Ensure errors in startup.jl don't block the REPL

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -253,7 +253,14 @@ function exec_options(opts)
     end
 
     # load ~/.julia/config/startup.jl file
-    startup && load_julia_startup()
+    if startup
+        try
+            load_julia_startup()
+        catch
+            invokelatest(display_error, catch_stack())
+            !(repl || is_interactive) && exit(1)
+        end
+    end
 
     # process cmds list
     for (cmd, arg) in cmds


### PR DESCRIPTION
This addresses issue #38142.
Following @fredrikekre's suggestion, in non-interactive mode behavior was not changed, but now it's possible to still access REPL despite errors in `startup.jl` file.
```fish
❯❯❯ echo 'x y' > ~/.julia/config/startup.jl
❯❯❯ ./julia a.jl
ERROR: LoadError: syntax: extra token "y" after end of expression
Stacktrace:
 [1] top-level scope
   @ ~/.julia/config/startup.jl:1
in expression starting at /home/julian/.julia/config/startup.jl:1
❯❯❯ ./julia
ERROR: LoadError: syntax: extra token "y" after end of expression
Stacktrace:
 [1] top-level scope
   @ ~/.julia/config/startup.jl:1
in expression starting at /home/julian/.julia/config/startup.jl:1
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.0-DEV.1398 (2020-11-01)
 _/ |\__'_|_|_|\__'_|  |  Commit 238874c0b6* (0 days old master)
|__/                   |

julia>
```
Errors and stack traces displayed are unchanged in all affected situations.