### PR TITLE
Fix #31368: joinpath works on collections of paths

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -324,6 +324,8 @@ end
 
 end # os-test
 
+joinpath(paths::AbstractString...)::String = joinpath(paths)
+
 """
     joinpath(parts::AbstractString...) -> String
     joinpath(parts::Vector{AbstractString}) -> String

--- a/base/path.jl
+++ b/base/path.jl
@@ -343,8 +343,13 @@ letter casing, hence `joinpath("C:\\A","c:b") = "C:\\A\\b"`.
 julia> joinpath("/home/myuser", "example.jl")
 "/home/myuser/example.jl"
 ```
+
+```jldoctest
+julia> joinpath(["/home/myuser", "example.jl"])
+"/home/myuser/example.jl"
+```
 """
-joinpath(paths::AbstractString...)::String = joinpath(paths)
+joinpath
 
 """
     normpath(path::AbstractString) -> String

--- a/base/path.jl
+++ b/base/path.jl
@@ -325,27 +325,9 @@ end
 end # os-test
 
 """
-    joinpath(parts) -> String
-
-Join a non-empty collection of path components into a full path. If some argument is an
-absolute path or (on Windows) has a drive specification that doesn't match the drive computed for
-the join of the preceding paths, then prior components are dropped.
-
-Note on Windows since there is a current directory for each drive, `joinpath("c:", "foo")`
-represents a path relative to the current directory on drive "c:" so this is equal to "c:foo",
-not "c:\\foo". Furthermore, `joinpath` treats this as a non-absolute path and ignores the drive
-letter casing, hence `joinpath("C:\\A","c:b") = "C:\\A\\b"`.
-
-# Examples
-```jldoctest
-julia> joinpath(["/home/myuser", "example.jl"])
-"/home/myuser/example.jl"
-```
-"""
-joinpath
-
-"""
     joinpath(parts::AbstractString...) -> String
+    joinpath(parts::Vector{AbstractString}) -> String
+    joinpath(parts::Tuple{AbstractString}) -> String
 
 Join path components into a full path. If some argument is an absolute path or
 (on Windows) has a drive specification that doesn't match the drive computed for

--- a/test/path.jl
+++ b/test/path.jl
@@ -59,6 +59,11 @@
         @test joinpath(S("foo"), S(homedir())) == homedir()
         @test joinpath(S(abspath("foo")), S(homedir())) == homedir()
 
+        for str in map(S, [sep, "a$(sep)b", "a$(sep)b$(sep)c", "a$(sep)b$(sep)c$(sep)d"])
+            @test str == joinpath(splitpath(str))
+            @test joinpath(splitpath(str)) == joinpath(splitpath(str)...)
+        end
+
         if Sys.iswindows()
             @test joinpath(S("foo"),S("bar:baz")) == "bar:baz"
             @test joinpath(S("C:"),S("foo"),S("D:"),S("bar")) == "D:bar"
@@ -74,6 +79,11 @@
             @test joinpath(S("\\\\server"), S("share"), S("a"), S("b")) == "\\\\server\\share\\a\\b"
             @test joinpath(S("\\\\server\\share"),S("a")) == "\\\\server\\share\\a"
             @test joinpath(S("\\\\server\\share\\"), S("a")) == "\\\\server\\share\\a"
+
+            for str in map(S, ["c:\\", "c:\\a", "c:\\a\\b", "c:\\a\\b\\c", "c:\\a\\b\\c\\d"])
+                @test str == joinpath(splitpath(str))
+                @test joinpath(splitpath(str)) == joinpath(splitpath(str)...)
+            end
 
         elseif Sys.isunix()
             @test joinpath(S("foo"),S("bar:baz")) == "foo$(sep)bar:baz"


### PR DESCRIPTION
Implements @StefanKarpinski's proposition from #31368. `joinpath(splitpath(x)) == x` should now hold.

close https://github.com/JuliaLang/julia/issues/31368