### PR TITLE
Fix invalidation in show_unquoted

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1634,7 +1634,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     )
         op, arg1 = head === Symbol("'") ? (head, args[1]) : (args[1], args[2])
         if isa(arg1, Expr) || (isa(arg1, Symbol) && isoperator(arg1))
-            show_enclosed_list(io, '(', [arg1], ", ", ')', indent, 0)
+            show_enclosed_list(io, '(', [arg1::Union{Expr, Symbol}], ", ", ')', indent, 0)
         else
             show_unquoted(io, arg1, indent, 0, quote_level)
         end


### PR DESCRIPTION
Without this assertion `arg1` is inferred as `Any`, and the method gets invalidated when loading CategoricalArrays (https://github.com/JuliaData/CategoricalArrays.jl/issues/177#issuecomment-720075320). Not sure why the compiler isn't able to detect the type automatically given the `isa` checks in the `if`.