### PR TITLE
fix replace for dicts/sets, when the eltype changes

### DIFF
--- a/test/sets.jl
+++ b/test/sets.jl
@@ -646,6 +646,26 @@ end
     x = @inferred replace([1, missing], missing=>2, 1=>missing)
     @test isequal(x, [missing, 2]) && x isa Vector{Union{Int, Missing}}
 
+    # eltype promotion for dicts
+    d = Dict(1=>2, 3=>4)
+    f = replace(d, (1=>2) => (1=>nothing))
+    @test f == Dict(3=>4, 1=>nothing)
+    @test eltype(f) == Pair{Int, Union{Nothing, Int}}
+    f = replace(d, (1=>2) => (1=>missing), (3=>4)=>(3=>missing))
+    @test valtype(f) == Union{Missing,Int}
+    f = replace(d, (1=>2) => (1=>'a'), (3=>4)=>(3=>'b'))
+    @test valtype(f) == Any
+    @test f == Dict(3=>'b', 1=>'a')
+
+    # eltype promotion for sets
+    s = Set([1, 2, 3])
+    f = replace(s, 2=>missing, 3=>nothing)
+    @test f == Set([1, missing, nothing])
+    @test eltype(f) == Union{Int,Missing,Nothing}
+    f = replace(s, 2=>'a')
+    @test eltype(f) == Any
+    @test f == Set([1, 3, 'a'])
+
     # test that isequal is used
     @test replace([NaN, 1.0], NaN=>0.0) == [0.0, 1.0]
     @test replace([1, missing], missing=>0) == [1, 0]


### PR DESCRIPTION
There were two bugs:
1. for dicts, `empty(d, elemtype)` was used instead of
   `empty(d, keytype, valtype)`
2. the lower-level `_replace!` routines were accepting only an
   old/new container pair with the exact same `eltype`, new items
   had to have the same type as old one.