### PR TITLE
Split and parameterize Core.Compiler.optimize

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -179,11 +179,11 @@ function stmt_affects_purity(@nospecialize(stmt), ir)
     return true
 end
 
-# run the optimization work
-function optimize(opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
+# Convert IRCode back to CodeInfo and compute inlining cost and sideeffects
+function finish(opt::OptimizationState, params::OptimizationParams, ir, @nospecialize(result))
     def = opt.linfo.def
     nargs = Int(opt.nargs) - 1
-    @timeit "optimizer" ir = run_passes(opt.src, nargs, opt)
+
     force_noinline = _any(@nospecialize(x) -> isexpr(x, :meta) && x.args[1] === :noinline, ir.meta)
 
     # compute inlining and other related optimizations
@@ -269,6 +269,13 @@ function optimize(opt::OptimizationState, params::OptimizationParams, @nospecial
         end
     end
     nothing
+end
+
+# run the optimization work
+function optimize(opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
+    nargs = Int(opt.nargs) - 1
+    @timeit "optimizer" ir = run_passes(opt.src, nargs, opt)
+    finish(opt, params, ir, result)
 end
 
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -272,7 +272,7 @@ function finish(opt::OptimizationState, params::OptimizationParams, ir, @nospeci
 end
 
 # run the optimization work
-function optimize(opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
+function optimize(interp::AbstractInterpreter, opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
     nargs = Int(opt.nargs) - 1
     @timeit "optimizer" ir = run_passes(opt.src, nargs, opt)
     finish(opt, params, ir, result)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -232,7 +232,7 @@ function _typeinf(interp::AbstractInterpreter, frame::InferenceState)
             if opt isa OptimizationState
                 run_optimizer = doopt && may_optimize(interp)
                 if run_optimizer
-                    optimize(opt, OptimizationParams(interp), caller.result)
+                    optimize(interp, opt, OptimizationParams(interp), caller.result)
                     finish(opt.src, interp)
                     # finish updating the result struct
                     validate_code_in_debug_mode(opt.linfo, opt.src, "optimized")
@@ -768,7 +768,7 @@ function typeinf_code(interp::AbstractInterpreter, method::Method, @nospecialize
     if typeinf(interp, frame) && run_optimizer
         opt_params = OptimizationParams(interp)
         opt = OptimizationState(frame, opt_params, interp)
-        optimize(opt, opt_params, result.result)
+        optimize(interp, opt, opt_params, result.result)
         opt.src.inferred = true
     end
     ccall(:jl_typeinf_end, Cvoid, ())


### PR DESCRIPTION
I want to experiment with new compiler passes out-of-tree and for that I need to specialize `optimize` on the AbstractInterpreter.
I also split `optimize` into two functions to make re-use easier.


