### PR TITLE
fix #38279, yet another bounds circularity in type intersection

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2964,8 +2964,10 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
                     assert(yy->lb != y);
                 }
                 if (xx) {
-                    xx->lb = y;
-                    xx->ub = y;
+                    if (!compareto_var(y, (jl_tvar_t*)x, e, -1))
+                        xx->lb = y;
+                    if (!compareto_var(y, (jl_tvar_t*)x, e,  1))
+                        xx->ub = y;
                     assert(xx->ub != x);
                 }
                 JL_GC_POP();

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1791,13 +1791,18 @@ let X1 = Tuple{AlmostLU, Vector{T}} where T,
     @test_broken I == actual
 end
 
-# issue #22787
-# for now check that these don't stack overflow
 let
+    # issue #22787
+    # for now check that these don't stack overflow
     t = typeintersect(Tuple{Type{Q}, Q, Ref{Q}} where Q<:Ref,
                       Tuple{Type{S}, Union{Ref{S}, Ref{R}}, R} where R where S)
     @test_broken t != Union{}
     t = typeintersect(Tuple{Type{T}, T, Ref{T}} where T,
                       Tuple{Type{S}, Ref{S}, S} where S)
     @test_broken t != Union{}
+
+    # issue #38279
+    t = typeintersect(Tuple{<:Array{T, N}, Val{T}} where {T<:Real, N},
+                      Tuple{<:Array{T, N}, Val{<:AbstractString}}  where {T<:Real, N})
+    @test t == Tuple{<:Array{Union{}, N}, Val{Union{}}} where N
 end


### PR DESCRIPTION
Luckily almost the same issue. Should have looked around the code for similar cases!