### PR TITLE
MacOS App: make only files read-only

### DIFF
--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -49,7 +49,7 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	-mkdir -p $@/Contents/Resources/julia
 	make -C $(JULIAHOME) binary-dist
 	tar zxf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
-	chmod -R -w $@/Contents/Resources/julia
+	find $@/Contents/Resources/julia -type f -exec chmod -w {} \;
 	if [ -n "$$MACOS_CODESIGN_IDENTITY" ]; then \
 	    echo "Codesigning with identity $$MACOS_CODESIGN_IDENTITY"; \
 		MACHO_FILES=$$(find "$@" -type f -perm -755 | cut -d: -f1); \


### PR DESCRIPTION
PR #38235 seemed to cause problems

- it seems to break GitHub Actions: https://github.com/JuliaParallel/MPI.jl/runs/1345656760?check_suite_focus=true#step:4:33
- it now requires a password to upgrade a patch release (which replaces the `/Applications/Julia-1.6.app` directory)

This makes only the files read-only, which should solve the problem