### PR TITLE
Try most recently modified cache files first during load

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -627,7 +627,7 @@ function find_all_in_cache_path(pkg::PkgId)
     entrypath, entryfile = cache_file_entry(pkg)
     for path in joinpath.(DEPOT_PATH, entrypath)
         isdir(path) || continue
-        for file in readdir(path)
+        for file in readdir(path, sort = false) # no sort given we sort later
             if !((pkg.uuid === nothing && file == entryfile * ".ji") ||
                  (pkg.uuid !== nothing && startswith(file, entryfile * "_")))
                  continue
@@ -636,6 +636,7 @@ function find_all_in_cache_path(pkg::PkgId)
             isfile_casesensitive(filepath) && push!(paths, filepath)
         end
     end
+    sort!(paths, by=p->stat(p).mtime, rev=true)
     return paths
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -636,8 +636,8 @@ function find_all_in_cache_path(pkg::PkgId)
             isfile_casesensitive(filepath) && push!(paths, filepath)
         end
     end
-    sort!(paths, by=p->stat(p).mtime, rev=true)
-    return paths
+    p = sortperm(mtime.(paths), rev = true)
+    return paths[p]
 end
 
 # these return either the array of modules loaded from the path / content given

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -636,10 +636,14 @@ function find_all_in_cache_path(pkg::PkgId)
             isfile_casesensitive(filepath) && push!(paths, filepath)
         end
     end
-    # allocating the sort vector is less expensive than using sort!(.. by=mtime), which would
-    # call the relatively slow mtime multiple times per path
-    p = sortperm(mtime.(paths), rev = true)
-    return paths[p]
+    if length(paths) > 1
+        # allocating the sort vector is less expensive than using sort!(.. by=mtime), which would
+        # call the relatively slow mtime multiple times per path
+        p = sortperm(mtime.(paths), rev = true)
+        return paths[p]
+    else
+        return paths
+    end
 end
 
 # these return either the array of modules loaded from the path / content given

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -636,6 +636,8 @@ function find_all_in_cache_path(pkg::PkgId)
             isfile_casesensitive(filepath) && push!(paths, filepath)
         end
     end
+    # allocating the sort vector is less expensive than using sort!(.. by=mtime), which would
+    # call the relatively slow mtime multiple times per path
     p = sortperm(mtime.(paths), rev = true)
     return paths[p]
 end


### PR DESCRIPTION
This tries the most recently modified cache files first, given they're most likely to be the desired files.
The approach is based on the assumption that running `stat` on the file for sorting is faster than looking into the file header to figure out if it's correct.

I monitored filesystem activity using `/Applications/Xcode.app/Contents/Applications/Instruments.app`

### Master
```
julia> @time using Plots
  3.912479 seconds (7.06 M allocations: 503.813 MiB, 5.54% gc time, 22.71% compilation time)
```
with 362 `open` calls and 7704 `stat64` calls

### This PR
```
julia> @time using Plots
  3.605881 seconds (6.57 M allocations: 472.992 MiB, 5.54% gc time, 24.93% compilation time)
```
with 287 `open` calls and 8672 `stat64` calls

____

Edit: I just realized that I had Revise loaded in the above tests. This is without:

### Master
```
julia> @time using Plots
  3.362885 seconds (6.26 M allocations: 453.605 MiB, 9.02% gc time, 16.55% compilation time)
```

### This PR
```
julia> @time using Plots
  3.087835 seconds (6.28 M allocations: 455.386 MiB, 7.02% gc time, 16.61% compilation time)
```