### PR TITLE
Fix some inference problems in logging

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -258,7 +258,7 @@ function log_record_id(_module, level, message, log_kws)
     modname = _module === nothing ?  "" : join(fullname(_module), "_")
     # Use an arbitrarily chosen eight hex digits here. TODO: Figure out how to
     # make the id exactly the same on 32 and 64 bit systems.
-    h = UInt32(hash(string(modname, level, message, log_kws)) & 0xFFFFFFFF)
+    h = UInt32(hash(string(modname, level, message, log_kws)::String) & 0xFFFFFFFF)
     while true
         id = Symbol(modname, '_', string(h, base = 16, pad = 8))
         # _log_record_ids is a registry of log record ids for use during
@@ -634,19 +634,19 @@ min_enabled_level(logger::SimpleLogger) = logger.min_level
 
 catch_exceptions(logger::SimpleLogger) = false
 
-function handle_message(logger::SimpleLogger, level, message, _module, group, id,
+function handle_message(logger::SimpleLogger, level::LogLevel, message, _module, group, id,
                         filepath, line; kwargs...)
     @nospecialize
     maxlog = get(kwargs, :maxlog, nothing)
     if maxlog isa Integer
-        remaining = get!(logger.message_limits, id, maxlog)
+        remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
         logger.message_limits[id] = remaining - 1
         remaining > 0 || return
     end
     buf = IOBuffer()
     iob = IOContext(buf, logger.stream)
     levelstr = level == Warn ? "Warning" : string(level)
-    msglines = split(chomp(string(message)), '\n')
+    msglines = split(chomp(string(message)::String), '\n')
     println(iob, "┌ ", levelstr, ": ", msglines[1])
     for i in 2:length(msglines)
         println(iob, "│ ", msglines[i])
@@ -655,8 +655,7 @@ function handle_message(logger::SimpleLogger, level, message, _module, group, id
         key === :maxlog && continue
         println(iob, "│   ", key, " = ", val)
     end
-    println(iob, "└ @ ", something(_module, "nothing"), " ",
-            something(filepath, "nothing"), ":", something(line, "nothing"))
+    println(iob, "└ @ ", _module, " ", filepath, ":", line)
     write(logger.stream, take!(buf))
     nothing
 end

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -96,24 +96,25 @@ function termlength(str)
     return N
 end
 
-function handle_message(logger::ConsoleLogger, level, message, _module, group, id,
+function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module, group, id,
                         filepath, line; kwargs...)
     @nospecialize
     hasmaxlog = haskey(kwargs, :maxlog) ? 1 : 0
     maxlog = get(kwargs, :maxlog, nothing)
     if maxlog isa Integer
-        remaining = get!(logger.message_limits, id, maxlog)
+        remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
         logger.message_limits[id] = remaining - 1
         remaining > 0 || return
     end
 
     # Generate a text representation of the message and all key value pairs,
     # split into lines.
-    msglines = [(indent=0, msg=l) for l in split(chomp(string(message)), '\n')]
+    msglines = [(indent=0, msg=l) for l in split(chomp(string(message)::String), '\n')]
     dsize = displaysize(logger.stream)::Tuple{Int,Int}
-    if length(kwargs) > hasmaxlog
+    nkwargs = length(kwargs)::Int
+    if nkwargs > hasmaxlog
         valbuf = IOBuffer()
-        rows_per_value = max(1, dsize[1] ÷ (length(kwargs) + 1 - hasmaxlog))
+        rows_per_value = max(1, dsize[1] ÷ (nkwargs + 1 - hasmaxlog))
         valio = IOContext(IOContext(valbuf, logger.stream),
                           :displaysize => (rows_per_value, dsize[2] - 5),
                           :limit => logger.show_limited)


### PR DESCRIPTION
Aside from the preferences system (xref #38285) and TOML parsing,
these trigger what appear to be the only remaining sources of vulnerability to
invalidation of `Base.require` among Julia's *exported* names,
which are the main names we can expect to be specialized by packages.

My main uncertainty is whether adding `::LogLevel` is OK, CC @c42f.

EDIT: in case it's not clear, `Base.require` deserves special attention: if your goal is to slow down package loading, you could hardly do better than invalidate `Base.require`. Bonus points for invalidating it with multiple package dependencies, since it would need recompilation each time it gets invalidated before the next package in the sequence can load.