### PR TITLE
Added x^-y clarification in Base.^ docs

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -333,7 +333,9 @@ If `y` is an `Int` literal (e.g. `2` in `x^2` or `-3` in `x^-3`), the Julia code
 enable compile-time specialization on the value of the exponent.
 (As a default fallback we have `Base.literal_pow(^, x, Val(y)) = ^(x,y)`,
 where usually `^ == Base.^` unless `^` has been defined in the calling
-namespace.)
+namespace.) If `y` is a negative integer literal, then `Base.literal_pow`
+transforms the operation to `inv(x)^y` by default.
+
 
 ```jldoctest
 julia> 3^5


### PR DESCRIPTION
Closes #38230 . The clarification added was that, in the case of the operation x^-y, Base.literal_pow transforms the operation to inv(x)^y by default.