### PR TITLE
Add two missing packages to `getall`

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -180,7 +180,7 @@ install: $(addprefix install-, $(DEP_LIBS))
 cleanall: $(addprefix clean-, $(DEP_LIBS))
 distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)
-getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-nghttp2 get-curl get-libgit2 get-libwhich
+getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-nghttp2 get-curl get-libgit2 get-libwhich get-zlib get-p7zip
 
 # If we're building for MacOS, no matter what, `getall` should include `osxunwind`
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
We were missing `zlib` and `p7zip` from the `getall` target in `deps/Makefile`, which broke the `full-source-dist` tarball.