### PR TITLE
Rename `libllvm()` -> `libllvm_path()`

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -250,7 +250,7 @@ else
     VersionNumber(libllvm_version_string)
 end
 
-libllvm() = ccall(:jl_get_libllvm, Any, ())
+libllvm_path() = ccall(:jl_get_libllvm, Any, ())
 
 function banner(io::IO = stdout)
     if GIT_VERSION_INFO.tagged_commit

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -7,5 +7,5 @@ sprint(Base.Sys.cpu_summary)
 @test Base.Sys.uptime() > 0
 Base.Sys.loadavg()
 
-@test Base.libllvm() isa Symbol
-@test contains(String(Base.libllvm()), "LLVM")
+@test Base.libllvm_path() isa Symbol
+@test contains(String(Base.libllv_pathm()), "LLVM")

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -8,4 +8,4 @@ sprint(Base.Sys.cpu_summary)
 Base.Sys.loadavg()
 
 @test Base.libllvm_path() isa Symbol
-@test contains(String(Base.libllv_pathm()), "LLVM")
+@test contains(String(Base.libllvm_path()), "LLVM")


### PR DESCRIPTION
This renaming is to make way for `libLLVM_jll` to export a `libllvm` symbol.