### PR TITLE
REPL-only: Print a hint if the user types `exit` in the REPL

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -218,6 +218,9 @@ function display(d::REPLDisplay, mime::MIME"text/plain", x)
             io = foldl(IOContext, d.repl.options.iocontext, init=io)
         end
         show(io, mime, x[])
+        if x[] === exit
+            print(io, ". To exit Julia, type exit() and press enter")
+        end
         println(io)
     end
     return nothing


### PR DESCRIPTION
Closes #21362 

Before this PR:

```julia
julia> exit
exit (generic function with 2 methods)
```

After this PR:

```julia
julia> exit
exit (generic function with 2 methods). To exit Julia, type exit() and press enter
```

The hint will only be shown in the REPL.