### PR TITLE
Simplify Iterators.partition length

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1148,7 +1148,7 @@ end
 
 function length(itr::PartitionIterator)
     l = length(itr.c)
-    return div(l, itr.n) + ((mod(l, itr.n) > 0) ? 1 : 0)
+    return cld(l, itr.n)
 end
 
 function iterate(itr::PartitionIterator{<:AbstractRange}, state=1)


### PR DESCRIPTION
This is equivalent, right? I was playing with my own partitioning code and noticed this; so this is partly just a sanity check that my own code isn't buggy 😄 