### PR TITLE
Fixed typo in base/promotion.jl

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -334,7 +334,7 @@ enable compile-time specialization on the value of the exponent.
 (As a default fallback we have `Base.literal_pow(^, x, Val(y)) = ^(x,y)`,
 where usually `^ == Base.^` unless `^` has been defined in the calling
 namespace.) If `y` is a negative integer literal, then `Base.literal_pow`
-transforms the operation to `inv(x)^-y` by default, where -y is a positive value.
+transforms the operation to `inv(x)^-y` by default, where `-y` is positive.
 
 
 ```jldoctest

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -334,7 +334,7 @@ enable compile-time specialization on the value of the exponent.
 (As a default fallback we have `Base.literal_pow(^, x, Val(y)) = ^(x,y)`,
 where usually `^ == Base.^` unless `^` has been defined in the calling
 namespace.) If `y` is a negative integer literal, then `Base.literal_pow`
-transforms the operation to `inv(x)^y` by default.
+transforms the operation to `inv(x)^-y` by default, where -y is a positive value.
 
 
 ```jldoctest


### PR DESCRIPTION
Solves #38317 . Fixed a minor typo in the docstring for Base.:^
Further linked to the review in #38295 