### PR TITLE
Manually resolve $LD for $CMAKE_COMMON

### DIFF
--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -35,7 +35,7 @@ CMAKE_COMMON += -DCMAKE_CXX_COMPILER="$(CXX_BASE)"
 ifneq ($(strip $(CMAKE_CXX_ARG)),)
 CMAKE_COMMON += -DCMAKE_CXX_COMPILER_ARG1="$(CMAKE_CXX_ARG)"
 endif
-CMAKE_COMMON += -DCMAKE_LINKER="$(LD)" -DCMAKE_AR="$(shell which $(AR))" -DCMAKE_RANLIB="$(shell which $(RANLIB))"
+CMAKE_COMMON += -DCMAKE_LINKER="$(shell which $(LD))" -DCMAKE_AR="$(shell which $(AR))" -DCMAKE_RANLIB="$(shell which $(RANLIB))"
 
 ifeq ($(OS),WINNT)
 CMAKE_COMMON += -DCMAKE_SYSTEM_NAME=Windows


### PR DESCRIPTION
To reproduce the issue, create `Make.user`

```
USE_BINARYBUILDER_LLVM=0
LLVM_VER=svn
LLVM_GIT_VER=llvmorg-9.0.1
BUILD_LLVM_CLANG=1
```

and then run `make`. It'll fail with something like

```
...
[ 40%] Linking CXX static library ../../../../lib/clang/9.0.1/lib/linux/libclang_rt.fuzzer-x86_64.a
/bin/sh: 1: /home/arakaki/repos/watch/_wt/julia/master/deps/scratch/llvm-svn/build_Release/ld: not found
projects/compiler-rt/lib/fuzzer/CMakeFiles/clang_rt.fuzzer-x86_64.dir/build.make:114: recipe for target 'lib/clang/9.0.1/lib/linux/libclang_rt.fuzzer-x86_64.a' failed
make[4]: *** [lib/clang/9.0.1/lib/linux/libclang_rt.fuzzer-x86_64.a] Error 127
make[4]: *** Deleting file 'lib/clang/9.0.1/lib/linux/libclang_rt.fuzzer-x86_64.a'
CMakeFiles/Makefile2:30147: recipe for target 'projects/compiler-rt/lib/fuzzer/CMakeFiles/clang_rt.fuzzer-x86_64.dir/all' failed
make[3]: *** [projects/compiler-rt/lib/fuzzer/CMakeFiles/clang_rt.fuzzer-x86_64.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make[2]: *** [all] Error 2
/home/arakaki/repos/watch/_wt/julia/master/deps/llvm.mk:538: recipe for target 'scratch/llvm-svn/build_Release/build-compiled' failed
make[1]: *** [scratch/llvm-svn/build_Release/build-compiled] Error 2
Makefile:60: recipe for target 'julia-deps' failed
make: *** [julia-deps] Error 2
```

(I confirmed this on 0ed1752d51837fab3203025fd6d2104149d6f29b.)

It looks like this happens because `CMAKE_LINKER` points to `deps/scratch/llvm-svn/build_Release/ld`:

```console
$ grep CMAKE_LINKER: deps/scratch/llvm-svn/build_Release/CMakeCache.txt
CMAKE_LINKER:FILEPATH=/home/arakaki/repos/watch/_wt/julia/master/deps/scratch/llvm-svn/build_Release/ld
```

To fix/workaround this issue, I suggest to manually resolve `$(LD)` using `which` here, as currently done for `$(AR)` and `$(RANLIB)` (which are added by @staticfloat in #20796):

https://github.com/JuliaLang/julia/blob/bbfc58ccd51ca2802a6cc6f31b5a7d7792e9f5eb/deps/tools/common.mk#L38
