### PR TITLE
TerminalMenus: initialize to cursor position, not menu start

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -295,8 +295,8 @@ end
 """
     printmenu(out, m::AbstractMenu, cursoridx::Int; init::Bool=false, oldstate=nothing) -> newstate
 
-Display the state of a menu. `init=true` causes `m.pageoffset` to be initialized to zero,
-and starts printing at the current cursor location; when `init` is false, the terminal will
+Display the state of a menu. `init=true` causes `m.pageoffset` to be initialized to start printing at
+or just above the current cursor location; when `init` is false, the terminal will
 preserve the current setting of `m.pageoffset` and overwrite the previous display.
 Returns `newstate`, which can be passed in as `oldstate` on the next call to allow accurate
 overwriting of the previous display.
@@ -314,7 +314,8 @@ function printmenu(out::IO, m::AbstractMenu, cursoridx::Int; oldstate=nothing, i
     ncleared = oldstate === nothing ? m.pagesize-1 : oldstate
 
     if init
-        m.pageoffset = 0
+        # like clamp, except this takes the min if max < min
+        m.pageoffset = max(0, min(cursoridx - m.pagesize ÷ 2, lastoption - m.pagesize))
     else
         print(buf, "\x1b[999D\x1b[$(ncleared)A")   # move left 999 spaces and up `ncleared` lines
     end

--- a/stdlib/REPL/test/TerminalMenus/radio_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/radio_menu.jl
@@ -34,6 +34,14 @@ for kws in ((charset=:ascii,),
     TerminalMenus.printmenu(buf, radio_menu, 2; init=true)
     @test startswith(String(take!(buf)), string("\e[2K   1\r\n\e[2K $c 2"))
 end
+@testset begin "cursor page"
+    radio_menu = RadioMenu(string.(1:20); charset=:ascii)
+    buf = IOBuffer()
+    TerminalMenus.printmenu(buf, radio_menu, 19; init=true)
+    @test String(take!(buf)) == "\e[2K^  11\r\n\e[2K   12\r\n\e[2K   13\r\n\e[2K   14\r\n\e[2K   15\r\n\e[2K   16\r\n\e[2K   17\r\n\e[2K   18\r\n\e[2K > 19\r\n\e[2K   20"
+    TerminalMenus.printmenu(buf, radio_menu, 8; init=true)
+    @test String(take!(buf)) == "\e[2K^  4\r\n\e[2K   5\r\n\e[2K   6\r\n\e[2K   7\r\n\e[2K > 8\r\n\e[2K   9\r\n\e[2K   10\r\n\e[2K   11\r\n\e[2K   12\r\n\e[2Kv  13"
+end
 
 # Test using stdin
 radio_menu = RadioMenu(string.(1:10); charset=:ascii)


### PR DESCRIPTION
This fixes a long-term minor annoyance with Cthulhu, returning you to where you left off if you go back to the tree of MethodInstances.