### PR TITLE
allow numbers as string macro suffixes

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1278,7 +1278,7 @@
                        (loop `(macrocall ,macname ,startloc ,macstr
                                          ,(if (symbol? nxt)
                                               (string (take-token s))
-                              					      (take-token s))))
+                                              (take-token s))))
                        (loop `(macrocall ,macname ,startloc ,macstr))))
                  ex))
             (else ex))))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1272,7 +1272,7 @@
                                        (parse-raw-literal s t)))
                         (nxt (peek-token s))
                         (macname (macroify-name ex (macsuffix t))))
-                   (if (and (symbol? nxt) (not (operator? nxt))
+                   (if (and (or (symbol? nxt) (number? nxt)) (not (operator? nxt))
                             (not (ts:space? s)))
                        ;; string literal suffix, "s"x
                        (loop `(macrocall ,macname ,startloc ,macstr

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1276,7 +1276,9 @@
                             (not (ts:space? s)))
                        ;; string literal suffix, "s"x
                        (loop `(macrocall ,macname ,startloc ,macstr
-                                         ,(string (take-token s))))
+                                         ,(if (symbol? nxt)
+                                              (string (take-token s))
+                              					      (take-token s))))
                        (loop `(macrocall ,macname ,startloc ,macstr))))
                  ex))
             (else ex))))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1272,7 +1272,7 @@
                                        (parse-raw-literal s t)))
                         (nxt (peek-token s))
                         (macname (macroify-name ex (macsuffix t))))
-                   (if (and (or (symbol? nxt) (number? nxt)) (not (operator? nxt))
+                   (if (and (or (symbol? nxt) (number? nxt) (large-number? nxt)) (not (operator? nxt))
                             (not (ts:space? s)))
                        ;; string literal suffix, "s"x
                        (loop `(macrocall ,macname ,startloc ,macstr

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -61,7 +61,7 @@ macro test999_str(args...); args; end
     b""" == ("a\nb",)
 
 # make sure a trailing integer, not just a symbol, is allowed also
-@test test999"foo"123 == ("foo", "123")
+@test test999"foo"123 == ("foo", 123)
 
 # issue #5997
 @test_throws ParseError Meta.parse(": x")

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -60,6 +60,9 @@ macro test999_str(args...); args; end
     a
     b""" == ("a\nb",)
 
+# make sure a trailing integer, not just a symbol, is allowed also
+@test test999"foo"123 == ("foo", "123")
+
 # issue #5997
 @test_throws ParseError Meta.parse(": x")
 @test_throws ParseError Meta.parse("""begin


### PR DESCRIPTION
E.g. `str"str"42`. Seems reasonable to me. (From https://github.com/ScottPJones/julia/pull/4)