### PR TITLE
Improve inference in Method display and others

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -57,7 +57,7 @@ exception will continue propagation as if it had not been caught.
     described in [`catch_stack`](@ref).
 """
 rethrow() = ccall(:jl_rethrow, Bottom, ())
-rethrow(e) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
+rethrow(@nospecialize(e)) = ccall(:jl_rethrow_other, Bottom, (Any,), e)
 
 struct InterpreterIP
     code::Union{CodeInfo,Core.MethodInstance,Nothing}

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -90,7 +90,7 @@ function kwarg_decl(m::Method, kwtype = nothing)
         kwli = ccall(:jl_methtable_lookup, Any, (Any, Any, UInt), kwtype.name.mt, sig, get_world_counter())
         if kwli !== nothing
             kwli = kwli::Method
-            slotnames = ccall(:jl_uncompress_argnames, Vector{Any}, (Any,), kwli.slot_syms)
+            slotnames = ccall(:jl_uncompress_argnames, Vector{Symbol}, (Any,), kwli.slot_syms)
             kws = filter(x -> !(x === empty_sym || '#' in string(x)), slotnames[(kwli.nargs + 1):end])
             # ensure the kwarg... is always printed last. The order of the arguments are not
             # necessarily the same as defined in the function
@@ -102,7 +102,7 @@ function kwarg_decl(m::Method, kwtype = nothing)
             return kws
         end
     end
-    return Any[]
+    return Symbol[]
 end
 
 function show_method_params(io::IO, tv)
@@ -152,7 +152,7 @@ function updated_methodloc(m::Method)::Tuple{String, Int32}
         end
     end
     file = fixup_stdlib_path(string(file))
-    return file, line
+    return file, Int32(line)
 end
 
 functionloc(m::Core.MethodInstance) = functionloc(m.def)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -22,7 +22,7 @@ function startswith(a::AbstractString, b::AbstractString)
     a, b = Iterators.Stateful(a), Iterators.Stateful(b)
     all(splat(==), zip(a, b)) && isempty(b)
 end
-startswith(str::AbstractString, chars::Chars) = !isempty(str) && first(str) in chars
+startswith(str::AbstractString, chars::Chars) = !isempty(str) && first(str)::AbstractChar in chars
 
 """
     endswith(s::AbstractString, suffix::AbstractString)

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -129,13 +129,15 @@ end
 function _trimdocs(md::Markdown.MD, brief::Bool)
     content, trimmed = [], false
     for c in md.content
-        if isa(c, Markdown.Header{1}) && isa(c.text, AbstractArray) &&
-            !isempty(c.text) && isa(c.text[1], AbstractString) &&
-            lowercase(c.text[1]) ∈ ("extended help",
-                                    "extended documentation",
-                                    "extended docs")
-            trimmed = true
-            break
+        if isa(c, Markdown.Header{1}) && isa(c.text, AbstractArray) && !isempty(c.text)
+            item = c.text[1]
+            if isa(item, AbstractString) &&
+                lowercase(item) ∈ ("extended help",
+                                   "extended documentation",
+                                   "extended docs")
+                trimmed = true
+                break
+            end
         end
         c, trm = _trimdocs(c, brief)
         trimmed |= trm


### PR DESCRIPTION
`jl_uncompress_argnames` actually returns a `Vector{Symbol}`, so we were being unnecessarily pessimistic about the return type. This eliminates several hundred nonconcrete signature backedges.