### PR TITLE
Suppress "stream is closed" warning in tests

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -181,7 +181,7 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu; cursor::Int=
         REPL.Terminals.raw!(term, true)
         true
     catch err
-        @warn("TerminalMenus: Unable to enter raw mode: $err")
+        suppress_output || @warn("TerminalMenus: Unable to enter raw mode: $err")
         false
     end
     # hide the cursor


### PR DESCRIPTION
Currently when running tests in parallel we get several

```
┌ Warning: TerminalMenus: Unable to enter raw mode: Base.IOError("stream is closed or unusable", 0)
└ @ REPL.TerminalMenus ~/src/julia-master/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl:184
```

This eliminates them when `suppress_output` is true.