### PR TITLE
Fix some precompile directives that weren't working

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -15,9 +15,12 @@ UP_ARROW = "\e[A"
 DOWN_ARROW = "\e[B"
 
 hardcoded_precompile_statements = """
-# used by Revise.jl
+# used by JuliaInterpreter.jl and Revise.jl
 @assert precompile(Tuple{typeof(Base.parse_cache_header), String})
 @assert precompile(Tuple{typeof(pushfirst!), Vector{Any}, Function})
+@assert precompile(Tuple{typeof(push!), Set{Module}, Module})
+@assert precompile(Tuple{typeof(push!), Set{Method}, Method})
+@assert precompile(Tuple{typeof(empty!), Set{Any}})
 # used by Requires.jl
 @assert precompile(Tuple{typeof(get!), Type{Vector{Function}}, Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
 @assert precompile(Tuple{typeof(haskey), Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
@@ -25,7 +28,9 @@ hardcoded_precompile_statements = """
 @assert precompile(Tuple{typeof(push!), Vector{Function}, Function})
 # miscellaneous
 @assert precompile(Tuple{typeof(Base.require), Base.PkgId})
+@assert precompile(Tuple{typeof(Base.recursive_prefs_merge), Base.Dict{String, Any}})
 @assert precompile(Tuple{typeof(isassigned), Core.SimpleVector, Int})
+@assert precompile(Tuple{typeof(getindex), Core.SimpleVector, Int})
 @assert precompile(Tuple{typeof(Base.Experimental.register_error_hint), Any, Type})
 """
 
@@ -50,9 +55,6 @@ cd("complet_path\t\t$CTRL_C
 """
 
 precompile_script = """
-# Used by JuliaInterpreter
-push!(Set{Module}(), Main)
-push!(Set{Method}(), first(methods(collect)))
 # Used by Revise
 (setindex!(Dict{String,Base.PkgId}(), Base.PkgId(Base), "file.jl"))["file.jl"]
 (setindex!(Dict{Base.PkgId,String}(), "file.jl", Base.PkgId(Base)))[Base.PkgId(Base)]


### PR DESCRIPTION
This adds a few more precompiles and also converts some into direct calls
to `precompile`. It's not entirely clear why the old one didn't work.