### PR TITLE
(Re)move some GC pushes to be defensive about #35708

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -22,7 +22,6 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     const jl_uuid_t uuid_zero = {0, 0};
     jl_module_t *m = (jl_module_t*)jl_gc_alloc(ptls, sizeof(jl_module_t),
                                                jl_module_type);
-    JL_GC_PUSH1(&m);
     assert(jl_is_symbol(name));
     m->name = name;
     m->parent = NULL;
@@ -41,6 +40,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     JL_MUTEX_INIT(&m->lock);
     htable_new(&m->bindings, 0);
     arraylist_new(&m->usings, 0);
+    JL_GC_PUSH1(&m);
     if (jl_core_module) {
         jl_module_using(m, jl_core_module);
     }

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -32,7 +32,7 @@ typedef struct {
 
 // initialize hash table, reserving space for `size` expected number of
 // elements. (Expect `h->size > size` for efficient occupancy factor.)
-htable_t *htable_new(htable_t *h, size_t size);
+htable_t *htable_new(htable_t *h, size_t size) JL_NOTSAFEPOINT;
 void htable_free(htable_t *h);
 
 // clear and (possibly) change size

--- a/src/sys.c
+++ b/src/sys.c
@@ -398,7 +398,7 @@ JL_DLLEXPORT int jl_cpu_threads(void) JL_NOTSAFEPOINT
 
 // -- high resolution timers --
 // Returns time in nanosec
-JL_DLLEXPORT uint64_t jl_hrtime(void)
+JL_DLLEXPORT uint64_t jl_hrtime(void) JL_NOTSAFEPOINT
 {
     return uv_hrtime();
 }


### PR DESCRIPTION
Somebody sent me a (Julia 1.4) trace that turned out to have the
same root cause as #35708. I took a look around just to be sure
that there was no other instance of this pattern and while I
didn't see any, I did see a useless push/pull pair as well
as a GC_PUSH of an uninitialized struct. While neither are a
problem by themselves, they will prevent the GC analyzer from
giving an error if any of the function in between ever become
safepoints (since the GC analyzer doesn't track initilized-ness).
I think it as a rule of thumb, we should never push uninitialized
values into a GC frame. Doing so assumes that there are no safepoints
before the value is fully initialized, but if that is the case,
the GC_PUSH may also be delayed until after initialization and if
the assumption ever changes, at least the GC analyzer will catch it.