### PR TITLE
Correctly escape \0 in isidentifier docstring

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1138,7 +1138,7 @@ is_id_char(c::AbstractChar) = ccall(:jl_id_char, Cint, (UInt32,), c) != 0
 Return whether the symbol or string `s` contains characters that are parsed as
 a valid identifier in Julia code.
 
-Internally Julia allows any sequence of characters in a `Symbol` (except `\0`s),
+Internally Julia allows any sequence of characters in a `Symbol` (except `\\0`s),
 and macros automatically use variable names containing `#` in order to avoid
 naming collision with the surrounding code. In order for the parser to
 recognize a variable, it uses a limited set of characters (greatly extended by


### PR DESCRIPTION
Currently, we end up with a literal `\0` character in the docstring. This was introduced in #38197 and is breaking PDF builds (it shouldn't, really, but that's a separate Documenter issue).

Would be good to get this merged before #38076, or this will have to be backported to the 1.6 branch.