### PR TITLE
Reference mergewith from merge

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -277,6 +277,7 @@ Construct a merged collection from the given collections. If necessary, the
 types of the resulting collection will be promoted to accommodate the types of
 the merged collections. If the same key is present in another collection, the
 value for that key will be the value it has in the last collection listed.
+See also [`mergewith`](@ref) for custom handling of values with the same key.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
As `merge(combine, dicts...)` was renamed to `mergewith(combine, dicts...)` in Julia v1.5, it would be helpful to reference `mergewith` for the `merge` docstring.
At least, I was confused looking for it because of the transitions and had to Google search it that the link would have helped me.