### PR TITLE
ml-matches: fix table scan ordering for fast-path validity

### DIFF
--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -359,4 +359,12 @@ let ambig = Int32[0]
     @test ambig[1] == 1
 end
 
+struct B38280 <: Real; val; end
+let ambig = Int32[0]
+    ms = Base._methods_by_ftype(Tuple{Type{B38280}, Any}, 1, typemax(UInt), false, UInt[typemin(UInt)], UInt[typemax(UInt)], ambig)
+    @test ms isa Vector
+    @test length(ms) == 1
+    @test ambig[1] == 1
+end
+
 nothing


### PR DESCRIPTION
With the "ndisjoint" fast-path, we need to fully verify each item before considering the next. This ensures we do not over count the number of matches after consideration of ambiguities. It also lets us count the disjoint cases less conservatively, and appears to lead to a minor speed up when computing certain ambiguities (for LinearAlgebra/test/ambiguous_exec.jl, runtime is reduced from about 5 minutes to 30 seconds). View diff with ignore-whitespace (indentation changes) for better clarity.

Fixes #38280