### PR TITLE
Compat warning for Base.count(::String, ::String)

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -378,6 +378,9 @@ julia> findall("a", "banana")
  4:4
  6:6
 ```
+
+!!! compat "Julia 1.3"
+     This method requires at least Julia 1.3.
 """
 function findall(t::Union{AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)
     found = UnitRange{Int}[]

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -405,6 +405,9 @@ calling `length(findall(pattern, string))` but more efficient.
 
 If `overlap=true`, the matching sequences are allowed to overlap indices in the
 original string, otherwise they must be from disjoint character ranges.
+
+!!! compat "Julia 1.3"
+     This method requires at least Julia 1.3.
 """
 function count(t::Union{AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)
     n = 0


### PR DESCRIPTION
This method is defined in 1.3:
https://docs.julialang.org/en/v1.3/base/collections/#Base.count

But not in 1.2:
```julia
fons@woof:~/oldjulia$ julia-1.2.0/bin/julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.2.0 (2019-08-20)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> count("a", "Julia")
ERROR: MethodError: objects of type String are not callable
Stacktrace:
 [1] count(::String, ::String) at ./reduce.jl:772
 [2] top-level scope at REPL[1]:1
```