### PR TITLE
fix REPL precompile generation for Pkg

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -193,6 +193,7 @@ function generate_precompile_statements()
         p = withenv("JULIA_HISTORY" => blackhole,
                     "JULIA_PROJECT" => nothing, # remove from environment
                     "JULIA_LOAD_PATH" => Sys.iswindows() ? "@;@stdlib" : "@:@stdlib",
+                    "JULIA_PKG_PRECOMPILE_AUTO" => "0",
                     "TERM" => "") do
             run(```$(julia_exepath()) -O0 --trace-compile=$precompile_file --sysimage $sysimg
                    --cpu-target=native --startup-file=no --color=yes


### PR DESCRIPTION
For some reason, the auto precompile thing in Pkg messes something up so that the REPL commands for Pkg are not executed when `generate_precompile.jl` is running. I am guessing the REPL commands get put in while the pretty output from Pkg.precompile is running and that somehow makes them not run. Turn it off for now.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/2200