### PR TITLE
fix markdown parser failed for tables with no first column (#38189)

### DIFF
--- a/stdlib/Markdown/src/GitHub/table.jl
+++ b/stdlib/Markdown/src/GitHub/table.jl
@@ -45,7 +45,6 @@ function github_table(stream::IO, md::MD)
         align = nothing
         while (row = parserow(stream)) !== nothing
             if length(rows) == 0
-                isempty(row[1]) && return false
                 cols = length(row)
             end
             if align === nothing && length(rows) == 1 # Must have a --- row

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -494,6 +494,12 @@ foo()
                                                           "f"]],
                                                   [:l, :r, :r]))
 @test md"""
+    |   | b |
+    |:--|--:|
+    | 1 |   |""" == MD(Table(Any[[Any[],"b"],
+                                 ["1",Any[]]], [:l, :r]))
+
+@test md"""
 no|table
 no error
 """ == MD([Paragraph(Any["no|table no error"])])


### PR DESCRIPTION
Fixes #38189 the cause code and add a test code for it.