### PR TITLE
Fix segfault in static_show, by using correct `vt` instead of `typeof(v)`

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -648,11 +648,17 @@ static int jl_static_is_function_(jl_datatype_t *vt) JL_NOTSAFEPOINT {
     if (!jl_function_type) {  // Make sure there's a Function type defined.
         return 0;
     }
+    int _iter_count = 0;  // To prevent infinite loops from corrupt type objects.
     while (vt != jl_any_type) {
-        if (vt == jl_function_type) {
+        if (vt == NULL) {
+            jl_error("static_show: Nullptr encountered inside datatype.");
+        } else if (_iter_count > 10000) {
+            jl_error("static_show: Exit after 10,000 iterations of supertype(). Presuming invalid cycle in datatype object.");
+        } else if (vt == jl_function_type) {
             return 1;
         }
         vt = vt->super;
+        _iter_count += 1;
     }
     return 0;
 }

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -999,7 +999,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_static_show_x(out, *(jl_value_t**)v, depth);
         n += jl_printf(out, ")");
     }
-    else if (jl_function_type && jl_isa(v, (jl_value_t*)jl_function_type)) {
+    else if (jl_function_type && jl_subtype(vt, (jl_value_t*)jl_function_type)) {
         // v is function instance (an instance of a Function type).
         jl_datatype_t *dv = (jl_datatype_t*)vt;
         jl_sym_t *sym = dv->name->mt->name;

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -651,9 +651,13 @@ static int jl_static_is_function_(jl_datatype_t *vt) JL_NOTSAFEPOINT {
     int _iter_count = 0;  // To prevent infinite loops from corrupt type objects.
     while (vt != jl_any_type) {
         if (vt == NULL) {
-            jl_error("static_show: Nullptr encountered inside datatype.");
+            jl_printf((JL_STREAM*)STDERR_FILENO,
+                "ERROR: static_show: Nullptr encountered inside datatype.\n");
+            return 0;
         } else if (_iter_count > 10000) {
-            jl_error("static_show: Exit after 10,000 iterations of supertype(). Presuming invalid cycle in datatype object.");
+            jl_printf((JL_STREAM*)STDERR_FILENO,
+                "ERROR: static_show: Exit after 10,000 iterations of supertype(). Presuming invalid cycle in datatype object.\n");
+            return 0;
         } else if (vt == jl_function_type) {
             return 1;
         }

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -644,7 +644,10 @@ static size_t jl_static_show_x_sym_escaped(JL_STREAM *out, jl_sym_t *name) JL_NO
 // `jl_static_show()` cannot call `jl_subtype()`, for the GC reasons
 // explained in the comment on `jl_static_show_x_()`, below.
 // This function checks if `vt <: Function` without triggering GC.
-static int jl_static_is_function_(jl_datatype_t *vt) {
+static int jl_static_is_function_(jl_datatype_t *vt) JL_NOTSAFEPOINT {
+    if (!jl_function_type) {  // Make sure there's a Function type defined.
+        return 0;
+    }
     while (vt != jl_any_type) {
         if (vt == jl_function_type) {
             return 1;
@@ -1012,7 +1015,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         n += jl_static_show_x(out, *(jl_value_t**)v, depth);
         n += jl_printf(out, ")");
     }
-    else if (jl_function_type && jl_static_is_function_(vt)) {
+    else if (jl_static_is_function_(vt)) {
         // v is function instance (an instance of a Function type).
         jl_datatype_t *dv = (jl_datatype_t*)vt;
         jl_sym_t *sym = dv->name->mt->name;

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -651,12 +651,10 @@ static int jl_static_is_function_(jl_datatype_t *vt) JL_NOTSAFEPOINT {
     int _iter_count = 0;  // To prevent infinite loops from corrupt type objects.
     while (vt != jl_any_type) {
         if (vt == NULL) {
-            jl_printf((JL_STREAM*)STDERR_FILENO,
-                "ERROR: static_show: Nullptr encountered inside datatype.\n");
             return 0;
         } else if (_iter_count > 10000) {
-            jl_printf((JL_STREAM*)STDERR_FILENO,
-                "ERROR: static_show: Exit after 10,000 iterations of supertype(). Presuming invalid cycle in datatype object.\n");
+            // We are very likely stuck in a cyclic datastructure, so we assume this is
+            // _not_ a Function.
             return 0;
         } else if (vt == jl_function_type) {
             return 1;


### PR DESCRIPTION
This fixes a segfault introduced in #38049.

Co-Authored-By: @Sacha0 