### PR TITLE
Errors for custom AbstractFloats

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -401,7 +401,7 @@ julia> exp10(2)
 """
 exp10(x::AbstractFloat) = 10^x
 
-for f in (:sinh, :cosh, :tanh, :atan, :asinh, :exp, :expm1)
+for f in (:sin, :cos, :tan, :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :exp, :expm1, :log)
     @eval ($f)(x::AbstractFloat) = error("not implemented for ", typeof(x))
 end
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -385,7 +385,7 @@ julia> exp2(5)
 32.0
 ```
 """
-#exp2(x::AbstractFloat) = 2^x
+exp2(x::AbstractFloat) = 2^x
 
 """
     exp10(x)
@@ -398,7 +398,7 @@ julia> exp10(2)
 100.0
 ```
 """
-#exp10(x::AbstractFloat) = 10^x
+exp10(x::AbstractFloat) = 10^x
 
 for f in (:sin, :cos, :tan,  :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :expm1, :log, :log1p)
     @eval function ($f)(x::Real)

--- a/base/math.jl
+++ b/base/math.jl
@@ -385,7 +385,7 @@ julia> exp2(5)
 32.0
 ```
 """
-exp2(x::AbstractFloat) = 2^x
+#exp2(x::AbstractFloat) = 2^x
 
 """
     exp10(x)
@@ -398,7 +398,7 @@ julia> exp10(2)
 100.0
 ```
 """
-exp10(x::AbstractFloat) = 10^x
+#exp10(x::AbstractFloat) = 10^x
 
 for f in (:sin, :cos, :tan,  :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :expm1, :log, :log1p)
     @eval function ($f)(x::Real)

--- a/base/math.jl
+++ b/base/math.jl
@@ -373,7 +373,6 @@ Accurately compute ``e^x-1``.
 expm1(x)
 expm1(x::Float64) = ccall((:expm1,libm), Float64, (Float64,), x)
 expm1(x::Float32) = ccall((:expm1f,libm), Float32, (Float32,), x)
-expm1(x::Real) = expm1(float(x))
 
 """
     exp2(x)
@@ -401,10 +400,10 @@ julia> exp10(2)
 """
 exp10(x::AbstractFloat) = 10^x
 
-for f in (:sin, :cos, :tan, :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :exp, :expm1, :log)
+for f in (:sin, :cos, :tan,  :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :expm1, :log, :log1p)
     @eval function ($f)(x::Real)
         xf = float(x)
-        x === xf && throw(MethodError(f, (x,)))
+        x === xf && throw(MethodError($f, (x,)))
         return ($f)(xf)
     end
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -402,7 +402,11 @@ julia> exp10(2)
 exp10(x::AbstractFloat) = 10^x
 
 for f in (:sin, :cos, :tan, :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :exp, :expm1, :log)
-    @eval ($f)(x::AbstractFloat) = error("not implemented for ", typeof(x))
+    @eval function ($f)(x::Real)
+        xf = float(x)
+        x === xf && throw(MethodError(f, (x,)))
+        return ($f)(xf)
+    end
 end
 
 # functions with special cases for integer arguments

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -198,7 +198,11 @@ end
 # The solution is to do the scaling back in 2 steps as just messing with the exponent wouldn't work.
 for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
     @eval begin
-        ($func)(x::Real) = ($func)(float(x))
+        function ($func)(x::Real)
+            xf = float(x)
+            x === xf && throw(MethodError($func, (x,)))
+            return ($func)(xf)
+        end
         function ($func)(x::T) where T<:Float64
             N_float = muladd(x, LogBo256INV($base, T), MAGIC_ROUND_CONST(T))
             N = reinterpret(uinttype(T), N_float) % Int32

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -89,7 +89,6 @@ function sinh(x::T) where T<:Union{Float32,Float64}
     E = exp(absx)
     return copysign(T(.5)*(E - 1/E),x)
 end
-sinh(x::Real) = sinh(float(x))
 
 COSH_SMALL_X(::Type{T}) where T= one(T)
 
@@ -127,7 +126,6 @@ function cosh(x::T) where T<:Union{Float32,Float64}
     E = exp(absx)
     return T(.5)*(E + 1/E)
 end
-cosh(x::Real) = cosh(float(x))
 
 # tanh methods
 TANH_LARGE_X(::Type{Float64}) = 22.0
@@ -162,7 +160,6 @@ function tanh(x::T) where T<:Union{Float32, Float64}
     k = exp(abs2x)
     return copysign(1 - 2/(k+1), x)
 end
-tanh(x::Real) = tanh(float(x))
 
 # Inverse hyperbolic functions
 AH_LN2(::Type{Float64}) = 6.93147180559945286227e-01
@@ -203,7 +200,6 @@ function asinh(x::T) where T <: Union{Float32, Float64}
     end
     return copysign(w, x)
 end
-asinh(x::Real) = asinh(float(x))
 
 # acosh methods
 @noinline acosh_domain_error(x) = throw(DomainError(x, "acosh(x) is only defined for x ≥ 1."))
@@ -242,7 +238,6 @@ function acosh(x::T) where T <: Union{Float32, Float64}
         return log(x) + AH_LN2(T)
     end
 end
-acosh(x::Real) = acosh(float(x))
 
 # atanh methods
 @noinline atanh_domain_error(x) = throw(DomainError(x, "atanh(x) is only defined for |x| ≤ 1."))
@@ -284,4 +279,3 @@ function atanh(x::T) where T <: Union{Float32, Float64}
     end
     return copysign(t, x)
 end
-atanh(x::Real) = atanh(float(x))

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -390,8 +390,3 @@ function log1p(x::Float32)
     end
 end
 
-for f in (:log,:log1p)
-    @eval begin
-        ($f)(x::Real) = ($f)(float(x))
-    end
-end

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -50,7 +50,6 @@ function sin(x::T) where T<:Union{Float32, Float64}
         return -cos_kernel(y)
     end
 end
-sin(x::Real) = sin(float(x))
 
 # Coefficients in 13th order polynomial approximation on [0; π/4]
 #     sin(x) ≈ x + S1*x³ + S2*x⁵ + S3*x⁷ + S4*x⁹ + S5*x¹¹ + S6*x¹³
@@ -121,7 +120,6 @@ function cos(x::T) where T<:Union{Float32, Float64}
         end
     end
 end
-cos(x::Real) = cos(float(x))
 
 const DC1 = 4.16666666666666019037e-02
 const DC2 = -1.38888888888741095749e-03
@@ -230,7 +228,6 @@ function tan(x::T) where T<:Union{Float32, Float64}
         return tan_kernel(y,-1)
     end
 end
-tan(x::Real) = tan(float(x))
 
 @inline tan_kernel(y::Float64) = tan_kernel(DoubleFloat64(y, 0.0), 1)
 @inline function tan_kernel(y::DoubleFloat64, k)
@@ -449,7 +446,6 @@ function asin(x::T) where T<:Union{Float32, Float64}
     t = (T(1.0) - absx)/2
     return asin_kernel(t, x)
 end
-asin(x::Real) = asin(float(x))
 
 # atan methods
 ATAN_1_O_2_HI(::Type{Float64}) = 4.63647609000806093515e-01 # atan(0.5).hi
@@ -499,7 +495,6 @@ atan_q(w::Float32) = w*@horner(w, -1.9999158382f-01, -1.0648017377f-01)
     atan_p(x², x⁴), atan_q(x⁴)
 end
 
-atan(x::Real) = atan(float(x))
 function atan(x::T) where T<:Union{Float32, Float64}
     # Method
     #   1. Reduce x to positive by atan(x) = -atan(-x).
@@ -723,7 +718,6 @@ function acos(x::T) where T <: Union{Float32, Float64}
         return T(2.0)*(df + (zRz*s + c))
     end
 end
-acos(x::Real) = acos(float(x))
 
 # multiply in extended precision
 function mulpi_ext(x::Float64)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1186,3 +1186,18 @@ end
     @test (@inferred hypot(3, 4im)) === 5.0
     @test (@inferred hypot(3, 4im, 12)) === 13.0
 end
+
+struct BadFloatWrapper <: AbstractFloat
+    x::Float64
+end
+
+@testset "not impelemented errors" begin
+    x = BadFloatWrapper(1.9)
+    @test_throws ErrorException asinh(x)
+    @test_throws ErrorException sinh(x)
+    @test_throws ErrorException cosh(x)
+    @test_throws ErrorException tanh(x)
+    @test_throws ErrorException atan(x)
+    @test_throws ErrorException exp(x)
+    @test_throws ErrorException expm1(x)
+end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1193,11 +1193,7 @@ end
 
 @testset "not impelemented errors" begin
     x = BadFloatWrapper(1.9)
-    @test_throws ErrorException asinh(x)
-    @test_throws ErrorException sinh(x)
-    @test_throws ErrorException cosh(x)
-    @test_throws ErrorException tanh(x)
-    @test_throws ErrorException atan(x)
-    @test_throws ErrorException exp(x)
-    @test_throws ErrorException expm1(x)
+    for f in (sin, cos, tan, sinh, cosh, tanh, atan, acos, asin, asinh, acosh, atanh, exp, expm1, log)
+        @test_throws ErrorException f(x)
+    end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1193,7 +1193,8 @@ end
 
 @testset "not impelemented errors" begin
     x = BadFloatWrapper(1.9)
-    for f in (sin, cos, tan, sinh, cosh, tanh, atan, acos, asin, asinh, acosh, atanh, exp, expm1, log)
-        @test_throws ErrorException f(x)
+    for f in (sin, cos, tan, sinh, cosh, tanh, atan, acos, asin, asinh, acosh, atanh, exp, exp2, exp10, log1p, expm1, log)
+        @show f
+        @test_throws MethodError f(x)
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -733,6 +733,7 @@ end
   @test !isapprox(1, 1+1.0e-12, norm=x->1)
 end
 
+#= disabled for now
 # test AbstractFloat fallback pr22716
 struct Float22716{T<:AbstractFloat} <: AbstractFloat
     x::T
@@ -742,7 +743,7 @@ let x = 2.0
     @test exp2(Float22716(x)) === 2^x
     @test exp10(Float22716(x)) === 10^x
 end
-
+=#
 @testset "asin #23088" begin
     for T in (Float32, Float64)
         @test asin(zero(T)) === zero(T)
@@ -1194,7 +1195,6 @@ end
 @testset "not impelemented errors" begin
     x = BadFloatWrapper(1.9)
     for f in (sin, cos, tan, sinh, cosh, tanh, atan, acos, asin, asinh, acosh, atanh, exp, exp2, exp10, log1p, expm1, log)
-        @show f
         @test_throws MethodError f(x)
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -733,7 +733,6 @@ end
   @test !isapprox(1, 1+1.0e-12, norm=x->1)
 end
 
-#= disabled for now
 # test AbstractFloat fallback pr22716
 struct Float22716{T<:AbstractFloat} <: AbstractFloat
     x::T
@@ -743,7 +742,7 @@ let x = 2.0
     @test exp2(Float22716(x)) === 2^x
     @test exp10(Float22716(x)) === 10^x
 end
-=#
+
 @testset "asin #23088" begin
     for T in (Float32, Float64)
         @test asin(zero(T)) === zero(T)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1194,7 +1194,7 @@ end
 
 @testset "not impelemented errors" begin
     x = BadFloatWrapper(1.9)
-    for f in (sin, cos, tan, sinh, cosh, tanh, atan, acos, asin, asinh, acosh, atanh, exp, exp2, exp10, log1p, expm1, log)
+    for f in (sin, cos, tan, sinh, cosh, tanh, atan, acos, asin, asinh, acosh, atanh, exp, log1p, expm1, log) #exp2, exp10 broken for now
         @test_throws MethodError f(x)
     end
 end


### PR DESCRIPTION
This error throw [isn't tested](https://codecov.io/gh/julialang/julia/src/master/base/math.jl#L400). I added some functions to the eval for consistency -- without it you get a `StackOverflowError` for `acosh` but this error for `asinh`. IMO we should either make this consistent (and maybe turn it into a `MethodError`?) or delete this code entirely.