### PR TITLE
no call to Base.rest if vararg is all-underscore

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2115,14 +2115,14 @@
                          ;; skip last assignment if it is an all-underscore vararg
                          (n   (if (> n 0)
                                   (let ((l (last lhss)))
-                                    (if (and (pair? l) (eq? (car l) '|...|)
+                                    (if (and (vararg? l)
                                              (underscore-symbol? (cadr l)))
                                         (- n 1)
                                         n))
                                   n))
                          (st  (gensy)))
                     `(block
-                      ,.(if (> n 0) `((local ,st)) '())
+                      ,@(if (> n 0) `((local ,st)) '())
                       ,@ini
                       ,.(map (lambda (i lhs)
                                (expand-forms

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2112,9 +2112,17 @@
                                   x (make-ssavalue)))
                          (ini (if (eq? x xx) '() (list (sink-assignment xx (expand-forms x)))))
                          (n   (length lhss))
+                         ;; skip last assignment if it is an all-underscore vararg
+                         (n   (if (> n 0)
+                                  (let ((l (last lhss)))
+                                    (if (and (pair? l) (eq? (car l) '|...|)
+                                             (underscore-symbol? (cadr l)))
+                                        (- n 1)
+                                        n))
+                                  n))
                          (st  (gensy)))
                     `(block
-                      (local ,st)
+                      ,.(if (> n 0) `((local ,st)) '())
                       ,@ini
                       ,.(map (lambda (i lhs)
                                (expand-forms

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2115,8 +2115,7 @@
                          ;; skip last assignment if it is an all-underscore vararg
                          (n   (if (> n 0)
                                   (let ((l (last lhss)))
-                                    (if (and (vararg? l)
-                                             (underscore-symbol? (cadr l)))
+                                    (if (and (vararg? l) (underscore-symbol? (cadr l)))
                                         (- n 1)
                                         n))
                                   n))
@@ -2124,16 +2123,16 @@
                     `(block
                       ,@(if (> n 0) `((local ,st)) '())
                       ,@ini
-                      ,.(map (lambda (i lhs)
+                      ,@(map (lambda (i lhs)
                                (expand-forms
-                                 (if (and (pair? lhs) (eq? (car lhs) '|...|))
-                                     `(= ,(cadr lhs) (call (top rest) ,xx ,.(if (eq? i 0) '() `(,st))))
+                                 (if (vararg? lhs)
+                                     `(= ,(cadr lhs) (call (top rest) ,xx ,@(if (eq? i 0) '() `(,st))))
                                      (lower-tuple-assignment
-                                      (if (= i (- n 1))
-                                          (list lhs)
-                                          (list lhs st))
-                                      `(call (top indexed_iterate)
-                                             ,xx ,(+ i 1) ,.(if (eq? i 0) '() `(,st)))))))
+                                       (if (= i (- n 1))
+                                           (list lhs)
+                                           (list lhs st))
+                                       `(call (top indexed_iterate)
+                                              ,xx ,(+ i 1) ,@(if (eq? i 0) '() `(,st)))))))
                              (iota n)
                              lhss)
                       (unnecessary ,xx)))))))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2613,3 +2613,11 @@ end
 end
 
 @test eval(Expr(:if, Expr(:block, Expr(:&&, true, Expr(:call, :(===), 1, 1))), 1, 2)) == 1
+
+@testset "all-underscore varargs on the rhs" begin
+    @test ncalls_in_lowered(quote _..., = a end, GlobalRef(Base, :rest)) == 0
+    @test ncalls_in_lowered(quote ___..., = a end, GlobalRef(Base, :rest)) == 0
+    @test ncalls_in_lowered(quote a, _... = b end, GlobalRef(Base, :rest)) == 0
+    @test ncalls_in_lowered(quote a, _... = b, c end, GlobalRef(Base, :rest)) == 0
+    @test ncalls_in_lowered(quote a, _... = (b...,) end, GlobalRef(Base, :rest)) == 0
+end


### PR DESCRIPTION
I just noticed that `a, _... = b` still contains a call to `Base.rest` after lowering, which we probably don't want, especially if we eventually decide to go with https://github.com/JuliaLang/julia/issues/37132. This just skips all-underscore varargs during destructuring.