### PR TITLE
Add istril and istriu methods

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -303,8 +303,10 @@ function istriu(A::Union{UpperTriangular,UnitUpperTriangular}, k::Integer=0)
     end
     return true
 end
+istril(A::Union{UpperTriangular,UnitUpperTriangular}) = false
 istril(A::Adjoint) = istriu(A.parent)
 istril(A::Transpose) = istriu(A.parent)
+istriu(A::Union{LowerTriangular,UnitLowerTriangular}) = false
 istriu(A::Adjoint) = istril(A.parent)
 istriu(A::Transpose) = istril(A.parent)
 


### PR DESCRIPTION
I remarked that `istril` dispatch to generic function for `UpperTriangular` and `UnitUpperTriangular` type.
It's similar with `istriu` and `UnitLowerTriangular` and `LowerTriangular` type.