### PR TITLE
Fix `make test-Test`

### DIFF
--- a/stdlib/Test/test/nothrow_testset.jl
+++ b/stdlib/Test/test/nothrow_testset.jl
@@ -1,0 +1,6 @@
+mutable struct NoThrowTestSet <: Test.AbstractTestSet
+    results::Vector
+    NoThrowTestSet(desc) = new([])
+end
+Test.record(ts::NoThrowTestSet, t::Test.Result) = (push!(ts.results, t); t)
+Test.finish(ts::NoThrowTestSet) = ts.results


### PR DESCRIPTION
This testset would fail unless `--depwarn=yes` was set
(as it is in process 1). Just run it in its own process
that has the commandline flag set appropriately.