### PR TITLE
Try to close race condition in FileWatching tests

### DIFF
--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -12,7 +12,7 @@ using Base: uv_error, Experimental
 # Writable ends are always tested for write-ability before a write
 
 n = 20
-intvls = [2, .2, .1, .005]
+intvls = [2, .2, .1, .005, .00001]
 
 pipe_fds = fill((Base.INVALID_OS_HANDLE, Base.INVALID_OS_HANDLE), n)
 for i in 1:n


### PR DESCRIPTION
We're seeing frequent test failures in the FileWatching test on
FreeBSD. Here's my theory of what happens:
 - Both the timer callback and the poll callback execute on the same libuv loop
 - They each schedule their respective tasks
 - Whichever task gets scheduled first first determines the result

However, in the test, we expect that, if the poll callback ran, (which we know
because we know there was an event pending), then that result does
actually get delivered to the toplevel task. This PR tries to close
this hole by adding the following condition:

If the task is no longer waiting on the file watcher (because libuv already
scheduled it), then wait for the task to run to completion, independent
of any timeout. I believe this should close the above race condition
and hopefully fix the test.