### PR TITLE
Add `contrib/print_sorted_stdlibs.jl`

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -19,48 +19,56 @@ Base.init_load_path()
 if Base.is_primary_base_module
 # load some stdlib packages but don't put their names in Main
 let
-    # Stdlibs manually sorted in top down order
+    # Stdlibs sorted in dependency, then alphabetical, order by contrib/print_sorted_stdlibs.jl
     stdlibs = [
-            # No deps
-            :Base64,
-            :CRC32c,
-            :SHA,
-            :FileWatching,
-            :Unicode,
-            :Mmap,
-            :Serialization,
-            :Libdl,
-            :Printf,
-            :Markdown,
-            :NetworkOptions,
-            :LibGit2,
-            :Logging,
-            :Sockets,
-            :Profile,
-            :Dates,
-            :DelimitedFiles,
-            :Random,
-            :UUIDs,
-            :Future,
-            :LinearAlgebra,
-            :SparseArrays,
-            :SuiteSparse,
-            :Distributed,
-            :SharedArrays,
-            :TOML,
-            :Artifacts,
-            :Pkg,
-            :Test,
-            :REPL,
-            :Statistics,
-            :MozillaCACerts_jll,
-            :LibCURL_jll,
-            :LibCURL,
-            :Downloads,
-            :ArgTools,
-            :Tar,
-        ]
+        # No dependencies
+        :ArgTools,
+        :Artifacts,
+        :Base64,
+        :CRC32c,
+        :FileWatching,
+        :Libdl,
+        :Logging,
+        :Mmap,
+        :MozillaCACerts_jll,
+        :NetworkOptions,
+        :SHA,
+        :Serialization,
+        :Sockets,
+        :Unicode,
 
+        # 1-depth packages
+        :DelimitedFiles,
+        :LibCURL_jll,
+        :LinearAlgebra,
+        :Markdown,
+        :Printf,
+        :Random,
+        :Tar,
+
+        # 2-depth packages
+        :Dates,
+        :Distributed,
+        :Future,
+        :InteractiveUtils,
+        :LibCURL,
+        :LibGit2,
+        :Profile,
+        :SparseArrays,
+        :UUIDs,
+
+        # 3-depth packages
+        :Downloads,
+        :REPL,
+        :SharedArrays,
+        :Statistics,
+        :SuiteSparse,
+        :TOML,
+        :Test,
+
+        # 4-depth packages
+        :Pkg,
+    ]
     maxlen = reduce(max, textwidth.(string.(stdlibs)); init=0)
 
     tot_time_stdlib = 0.0

--- a/contrib/print_sorted_stdlibs.jl
+++ b/contrib/print_sorted_stdlibs.jl
@@ -1,0 +1,75 @@
+#!/usr/bin/env julia
+using TOML
+
+# Default to the `stdlib/vX.Y` directory
+STDLIB_DIR = get(ARGS, 1, joinpath(@__DIR__, "..", "usr", "share", "julia", "stdlib"))
+vXYdirs = readdir(STDLIB_DIR)
+if length(vXYdirs) == 1 && match(r"v\d\.\d", vXYdirs[1]) !== nothing
+    STDLIB_DIR = joinpath(STDLIB_DIR, vXYdirs[1])
+end
+
+project_deps = Dict{String,Set{String}}()
+for project_dir in readdir(STDLIB_DIR, join=true)
+    files = readdir(project_dir)
+    if "Project.toml" in files
+        project = TOML.parsefile(joinpath(project_dir, "Project.toml"))
+
+        if !haskey(project, "name")
+            continue
+        end
+        name = project["name"]
+        deps = Set(collect(keys(get(project, "deps", Dict{String,String}()))))
+        project_deps[name] = deps
+    end
+end
+
+#println("Found $(length(keys(project_deps))) stdlib projects")
+
+function project_depth(project)
+    deps = project_deps[project]
+    if isempty(deps)
+        return 0
+    end
+
+    depth = 1
+    while !all(isempty(project_deps[d]) for d in deps)
+        depth += 1
+
+        if depth > 100
+            error("Failed to converge while finding project depth for $(project)!")
+        end
+
+        new_deps = Set{String}()
+        for d in deps
+            union!(new_deps, project_deps[d])
+        end
+        deps = new_deps
+    end
+    return depth
+end
+
+project_depths = Dict(p => project_depth(p) for p in keys(project_deps))
+
+function project_isless(p1, p2)
+    if project_depths[p1] != project_depths[p2]
+        return isless(project_depths[p1], project_depths[p2])
+    end
+    return isless(p1, p2)
+end
+
+sorted_projects = sort(collect(keys(project_depths)), lt=project_isless)
+
+# Print out sorted projects, ready to be pasted into `sysimg.jl`
+last_depth = 0
+println("    # Stdlibs sorted in dependency, then alphabetical, order by contrib/print_sorted_stdlibs.jl")
+println("    stdlibs = [")
+println("        # No dependencies")
+for p in sorted_projects
+    if project_depths[p] != last_depth
+        global last_depth = project_depths[p]
+        println()
+        println("        # $(last_depth)-depth packages")
+    end
+    println("        :$(p),")
+end
+println("    ]")


### PR DESCRIPTION
We shouldn't have to manually insert stdlibs into `sysimg.jl`; make a
tool to do the work for us automatically.