### PR TITLE
Record more fields in Core.Compiler.Timings (SnoopCompiler snoopi_deep)

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -27,6 +27,8 @@ struct InferenceFrameInfo
     world::UInt64
     sptypes::Vector{Any}
     slottypes::Vector{Any}
+    nargs::Int
+    limited::Bool
 end
 
 function _typeinf_identifier(frame::Core.Compiler.InferenceState)
@@ -35,6 +37,8 @@ function _typeinf_identifier(frame::Core.Compiler.InferenceState)
         frame.world,
         copy(frame.sptypes),
         copy(frame.slottypes),
+        frame.nargs,
+        frame.limited,
     )
     return mi_info
 end
@@ -81,7 +85,7 @@ function reset_timings()
     empty!(_timings)
     push!(_timings, Timing(
         # The MethodInstance for ROOT(), and default empty values for other fields.
-        InferenceFrameInfo(ROOTmi, 0x0, Any[], Any[Core.Const(ROOT)]),
+        InferenceFrameInfo(ROOTmi, 0x0, Any[], Any[Core.Const(ROOT)], 1, false),
         _time_ns()))
     return nothing
 end


### PR DESCRIPTION
Adds more fields to `InferenceFrameInfo`, via `@snoopi_deep`:
 - `limited::Bool`: If true, the result of this frame will *not be cached*
 - `nargs::Int`: The number of arguments in the slottypes.

This is a follow-up to #37749.

@vtjnash suggested we add `limited` and `have_constants`. (have_constants can be computed in post-processing based on the presence of `Core.Const` in the `slottype`s. We're going to add an option to display the slottypes in the profile, so that you can see the consts, so I'm also adding `nargs`, to make the slottypes more readable.