### PR TITLE
Make show_function() use var""-syntax to escape names

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -454,9 +454,10 @@ function show_function(io::IO, f::Function, compact::Bool)
     elseif isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
         getfield(mt.module, mt.name) === f
         if is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
-            print(io, mt.name)
+            show_sym(io, mt.name)
         else
-            print(io, mt.module, ".", mt.name)
+            print(io, mt.module, ".")
+            show_sym(io, mt.name)
         end
     else
         show_default(io, f)

--- a/test/show.jl
+++ b/test/show.jl
@@ -506,6 +506,10 @@ end
 # Hidden macro names
 @test sprint(show, Expr(:macrocall, Symbol("@#"), nothing, :a)) == ":(@var\"#\" a)"
 
+# PR #38418
+module M1 var"#foo#"() = 2 end
+@test occursin("M1.var\"#foo#\"", sprint(show, M1.var"#foo#", context = :module=>@__MODULE__))
+
 # issue #12477
 @test sprint(show,  Union{Int64, Int32, Int16, Int8, Float64}) == "Union{Float64, Int16, Int32, Int64, Int8}"
 


### PR DESCRIPTION
Before:
```julia
julia> module M
          var"#f#"(x) = x+5
       end
Main.M

julia> M.var"#f#"

julia> show(stdout, M.var"#f#")
Main.M.#f#
```

After:
```julia
julia> module M
          var"#f#"(x) = x+5
       end
Main.M

julia> M.var"#f#"

julia> show(stdout, M.var"#f#")
Main.M.var"#f#"
```

Without this, the result of `show()` is not valid, interpretable julia.

This is similar to https://github.com/JuliaLang/julia/pull/38049, but
acts on julia's show method, rather than C's `static_show()`.

This brings `Base.show()` in line with the same behavior. :)