### PR TITLE
[Darwin/AArch64] Force BB triplet for now

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1499,7 +1499,11 @@ LIBGCC_NAME := libgcc_s_seh-1.$(SHLIB_EXT)
 endif
 endif
 ifeq ($(OS),Darwin)
+ifeq ($(ARCH),aarch64)
+LIBGCC_NAME := libgcc_s.2.$(SHLIB_EXT)
+else
 LIBGCC_NAME := libgcc_s.1.$(SHLIB_EXT)
+endif
 endif
 ifneq ($(findstring $(OS),Linux FreeBSD),)
 LIBGCC_NAME := libgcc_s.$(SHLIB_EXT).1

--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -4,8 +4,19 @@
 #    3 gfortran, \             # signifies a GCC ABI (e.g. libgfortran version) dependency
 #    4 cxx11)                  # signifies a cxx11 ABI dependency
 
+# Hardcode Darwin AArch64 triplet for now, since we're using an unstable toolchain that
+# we don't expect the user to have
+ifeq ($(OS)$(ARCH),Darwinaarch64)
+
+BB_TRIPLET_LIBGFORTRAN_CXXABI := aarch64-apple-darwin-libgfortran5
+
+else
+
 # Auto-detect triplet once, create different versions that we use as defaults below for each BB install target
 BB_TRIPLET_LIBGFORTRAN_CXXABI := $(shell $(call invoke_python,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(or $(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' ),1)")
+
+endif
+
 BB_TRIPLET_LIBGFORTRAN := $(subst $(SPACE),-,$(filter-out cxx%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI))))
 BB_TRIPLET_CXXABI := $(subst $(SPACE),-,$(filter-out libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI))))
 BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI)))))


### PR DESCRIPTION
The toolchain we're using in BB is experimental. Since there is no official
GCC toolchain (yet), we can't expect ABI compatibility, so just ignore whatever
fortran may or may not be installed on the host and hardcode the triplet
we expect.