### PR TITLE
Fix promote_typejoin_union with UnionAll

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -694,6 +694,8 @@ eltypes(t::Tuple) = Tuple{_broadcast_getindex_eltype(t[1]), eltypes(tail(t)).typ
 function promote_typejoin_union(::Type{T}) where T
     if T === Union{}
         return Union{}
+    elseif T isa UnionAll
+        return Any # TODO: compute more precise bounds
     elseif T isa Union
         return promote_typejoin(promote_typejoin_union(T.a), promote_typejoin_union(T.b))
     elseif T <: Tuple

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -987,4 +987,6 @@ p0 = copy(p)
          (1.0, "c") (2, "c") (3, "c")]
     @test typeof.([iszero, isdigit]) == [typeof(iszero), typeof(isdigit)]
     @test typeof.([iszero, iszero]) == [typeof(iszero), typeof(iszero)]
+    @test isequal(identity.(Vector{<:Union{Int, Missing}}[[1, 2],[missing, 1]]),
+                  [[1, 2],[missing, 1]])
 end


### PR DESCRIPTION
The current version returns a type which is narrower than what `typejoin` computes, which can make `broadcast` fail. Return `Any` until we develop code to compute the same result as `typejoin`, as this is only used for inference.

Fixes #38422.

@vtjnash @JeffBezanson This is the simplest fix I could find, but please feel free to suggest better ways to compute the actual type that `typejoin` would return.