### PR TITLE
define `at-invoke` macro

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -234,6 +234,7 @@ Core.Function
 Base.hasmethod
 Core.applicable
 Core.invoke
+Base.@invoke
 Base.invokelatest
 Base.@invokelatest
 new


### PR DESCRIPTION
- provides easier syntax to call `Core.invoke`, e.g. `@invoke f(a::Integer)` will be expanded into `invoke(f, Tuple{Integer}, a)`
- when type annotation is omitted, the argument type is specified as `Any`

Built on top of #37971 (i.e. the current diff includes changes for`@invokelatest`); I would like to merge that PR first, and then I will rebase this PR against that.