### PR TITLE
Rebase of #35792, add cispi function

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -541,6 +541,40 @@ function cis(z::Complex)
     Complex(v * c, v * s)
 end
 
+cispi(sign::Bool) = sign ? -1 : 1
+cispi(sign::Integer) = oftype(sign, cispi(isodd(sign)))
+cispi(theta::Real) = Complex(cospi(theta), sinpi(theta))
+
+"""
+    cispi(z)
+
+Return ``\\exp(iπz)``.
+
+This function also accepts integer or boolean arguments, and then
+returns integer results. This allows calculating ``(-1)^s``
+conveniently and efficiently.
+
+`cispi` is related to [`signbit`](@ref), and allows decomposing
+integers into sign bit and absolute value: ``cispi(signbit(n)) *
+abs(n) == n``. For boolean values, it is also, ``signbit(cispi(b)) ==
+b``.
+
+# Examples
+```jldoctest
+julia> cispi(1) == -1
+true
+
+julia> cispi(0) == 1
+true
+```
+
+!!! compat "Julia 1.6"
+    This function requires Julia 1.6 or later.
+"""
+function cispi(z::Complex)
+    cospi(z) + im*sinpi(z)
+end
+
 """
     angle(z)
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -548,15 +548,6 @@ cispi(theta::Real) = Complex(reverse(sincospi(theta))...)
 
 Return ``\\exp(iπz)``.
 
-This function also accepts integer or boolean arguments, and then
-returns integer results. This allows calculating ``(-1)^s``
-conveniently and efficiently.
-
-`cispi` is related to [`signbit`](@ref), and allows decomposing
-integers into sign bit and absolute value: ``cispi(signbit(n)) *
-abs(n) == n``. For boolean values, it is also, ``signbit(cispi(b)) ==
-b``.
-
 # Examples
 ```jldoctest
 julia> cispi(1) == -1

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -546,7 +546,7 @@ cispi(theta::Real) = Complex(reverse(sincospi(theta))...)
 """
     cispi(z)
 
-Return ``\\exp(iπz)``.
+Compute ``\\exp(i\\pi x)`` more accurately than `cis(pi*x)`, especially for large `x`.
 
 # Examples
 ```jldoctest

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -550,11 +550,11 @@ Compute ``\\exp(i\\pi x)`` more accurately than `cis(pi*x)`, especially for larg
 
 # Examples
 ```jldoctest
-julia> cispi(1) == -1
-true
+julia> cispi(1)
+-1.0 + 0.0im
 
-julia> cispi(0) == 1
-true
+julia> cispi(0.25 + 1im)
+0.030556854645952924 + 0.030556854645952924im
 ```
 
 !!! compat "Julia 1.6"

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -541,9 +541,7 @@ function cis(z::Complex)
     Complex(v * c, v * s)
 end
 
-cispi(sign::Bool) = sign ? -1 : 1
-cispi(sign::Integer) = oftype(sign, cispi(isodd(sign)))
-cispi(theta::Real) = Complex(cospi(theta), sinpi(theta))
+cispi(theta::Real) = Complex(reverse(sincospi(theta))...)
 
 """
     cispi(z)
@@ -572,7 +570,8 @@ true
     This function requires Julia 1.6 or later.
 """
 function cispi(z::Complex)
-    cospi(z) + im*sinpi(z)
+    sipi, copi = sincospi(z)
+    return complex(real(copi) - imag(sipi), imag(copi) + real(sipi))
 end
 
 """

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -229,6 +229,7 @@ export
     cbrt,
     ceil,
     cis,
+    cispi,
     clamp,
     cld,
     cmp,

--- a/base/number.jl
+++ b/base/number.jl
@@ -110,6 +110,11 @@ copy(x::Number) = x # some code treats numbers as collection-like
 
 Returns `true` if the value of the sign of `x` is negative, otherwise `false`.
 
+Related to `signbit` is [`cispi`](@ref) (which calculates `(-1)^n`).
+This allows decomposing integers into sign bit and absolute value:
+``cispi(signbit(n)) * abs(n) == n``. For boolean values, it is also,
+``signbit(cispi(b)) == b``.
+
 # Examples
 ```jldoctest
 julia> signbit(-4)

--- a/base/number.jl
+++ b/base/number.jl
@@ -110,11 +110,6 @@ copy(x::Number) = x # some code treats numbers as collection-like
 
 Returns `true` if the value of the sign of `x` is negative, otherwise `false`.
 
-Related to `signbit` is [`cispi`](@ref) (which calculates `(-1)^n`).
-This allows decomposing integers into sign bit and absolute value:
-``cispi(signbit(n)) * abs(n) == n``. For boolean values, it is also,
-``signbit(cispi(b)) == b``.
-
 # Examples
 ```jldoctest
 julia> signbit(-4)

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -162,6 +162,7 @@ Base.reim
 Base.conj
 Base.angle
 Base.cis
+Base.cispi
 Base.binomial
 Base.factorial
 Base.gcd

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -123,6 +123,8 @@ end
             @test atanh(x) ≈ atanh(big(x))
             @test cis(real(x)) ≈ cis(real(big(x)))
             @test cis(x) ≈ cis(big(x))
+            @test cispi(real(x)) ≈ cispi(real(big(x)))
+            @test cispi(x) ≈ cispi(big(x))
             @test cos(x) ≈ cos(big(x))
             @test cosh(x) ≈ cosh(big(x))
             @test exp(x) ≈ exp(big(x))
@@ -918,6 +920,21 @@ end
     @test cis(1.0+0.0im) ≈ 0.54030230586813971740093660744297660373231042061+0.84147098480789650665250232163029899962256306079im
     @test cis(pi) ≈ -1.0+0.0im
     @test cis(pi/2) ≈ 0.0+1.0im
+    @test cispi(false) == 1
+    @test cispi(true) == -1
+    @test cispi(-1) == -1
+    @test cispi(0) == 1
+    @test cispi(1) == -1
+    @test cispi(2) == 1
+    @test cispi(0.0) == cispi(0)
+    @test cispi(1.0) == cispi(1)
+    @test cispi(2.0) == cispi(2)
+    @test cispi(0.5) == im
+    @test cispi(1.5) == -im
+    @test cispi(0.25) ≈ cis(π/4)
+    @test cispi(0.0+0.0im) == cispi(0)
+    @test cispi(1.0+0.0im) == cispi(1)
+    @test cispi(2.0+0.0im) == cispi(2)
 end
 
 @testset "exp2" begin


### PR DESCRIPTION
This is a rebase of #35792 with the couple of uncommitted review comments applied that undo the specializations on integer types. I think the only remaining task was to then remove the doc strings referencing the relation between `cispi` and `signbit` (which no longer exists once the Integer specializations are removed).