### PR TITLE
Automatically inform Revise of stdlibs in test suite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,10 +15,12 @@ tests = unique(tests)
 
 if use_revise
     using Revise
+    union!(Revise.stdlib_names, Symbol.(STDLIBS))
     # Remote-eval the following to initialize Revise in workers
     const revise_init_expr = quote
         using Revise
         const STDLIBS = $STDLIBS
+        union!(Revise.stdlib_names, Symbol.(STDLIBS))
         revise_trackall()
     end
 end


### PR DESCRIPTION
This doesn't make PRs like timholy/Revise.jl#522, timholy/Revise.jl#534,
timholy/Revise.jl#553, etc unnecessary since that will still be
required if you want to revise a stdlib while working normally from the
REPL, but this at least makes a quick `make test-revise-complex` to
work where you're trying out unrelated changes to the as-yet unknown
standard libraries.

Before:
```bash
$ make test-revise-complex
    JULIA test/revise-complex
ERROR: LoadError: no Revise.track recipe for module NetworkOptions
Stacktrace:
  [1] error(::String, ::Symbol)
    @ Base ./error.jl:42
  [2] _track(id::Base.PkgId, modname::Symbol; modified_files::Set{Tuple{Revise.PkgData, String}})
    @ Revise ~/.julia/packages/Revise/fwStr/src/recipes.jl:105
...
```

After:
```bash
$ make test-revise-complex
    JULIA test/revise-complex
WARNING: redefinition of constant _clipboard_copy. This may fail, cause incorrect answers, or produce other errors.
WARNING: redefinition of constant _clipboard_paste. This may fail, cause incorrect answers, or produce other errors.
┌ Warning: skipping callee #wait#19 (called by wait) due to UndefVarError(:WindowsRawSocket)
└ @ LoweredCodeUtils ~/.julia/packages/LoweredCodeUtils/cquzG/src/signatures.jl:279
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
complex    (1) |        started at 2020-11-15T12:06:27.051
complex    (1) |    17.83 |   0.29 |  1.6 |    1338.02 |   592.97

Test Summary: | Pass  Broken  Total
  Overall     | 8410       5   8415
    SUCCESS
```