### PR TITLE
Update doc for dlsym function

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -46,9 +46,12 @@ applicable.
 (RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOCAL, RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW)
 
 """
-    dlsym(handle, sym)
+    dlsym(handle, sym; throw_error::Bool = true)
 
 Look up a symbol from a shared library handle, return callable function pointer on success.
+
+If the symbol cannot be found, this method throws an error, unless the keyword argument
+`throw_error` is set to `false`, in which case this method returns `nothing`.
 """
 function dlsym(hnd::Ptr, s::Union{Symbol,AbstractString}; throw_error::Bool = true)
     hnd == C_NULL && throw(ArgumentError("NULL library handle"))


### PR DESCRIPTION
Add `throw_error` keyword argument in documentation of `dlsym` function