### PR TITLE
Avoid unnecessary `convert` in `setindex!` for `IdDict`

### DIFF
--- a/base/iddict.jl
+++ b/base/iddict.jl
@@ -69,10 +69,18 @@ function sizehint!(d::IdDict, newsz)
 end
 
 function setindex!(d::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where {K, V}
-    !isa(key, K) && throw(ArgumentError("$(limitrepr(key)) is not a valid key for type $K"))
     if !(val isa V) # avoid a dynamic call
         val = convert(V, val)
     end
+    return _iddict_setindex!(d, val, key)
+end
+
+function setindex!(d::IdDict{K,V}, @nospecialize(val::V), @nospecialize(key)) where {K, V}
+    return _iddict_setindex!(d, val, key)
+end
+
+function _iddict_setindex!(d::IdDict{K,V}, @nospecialize(val::V), @nospecialize(key)) where {K, V}
+    !isa(key, K) && throw(ArgumentError("$(limitrepr(key)) is not a valid key for type $K"))
     if d.ndel >= ((3*length(d.ht))>>2)
         rehash!(d, max(length(d.ht)>>1, 32))
         d.ndel = 0


### PR DESCRIPTION
This addresses https://github.com/JuliaLang/julia/pull/37193#issuecomment-727752729

The `@nospecialize` in `IdSet` and `IdDict` operations are necessary
to reduce latency, but they introduce backedges that are at risk of
invalidation. This PR reduces the impact for callers of
`setindex!(::IdDict, val, key)` who know that `val`
doesn't need conversion.

One of my previous specializations of dict-related methods resulted in
an excessive increase in the size of the sysimage, but this PR doesn't
hurt:

```sh
tim@diva:~/src/julia-master$ ls -lh usr/lib/julia/sys.so   # pre
-rwxr-xr-x 1 tim holy 141M Nov 16 03:11 usr/lib/julia/sys.so
tim@diva:~/src/julia-master$ ls -lh usr/lib/julia/sys.so   # post
-rwxr-xr-x 1 tim holy 140M Nov 16 03:48 usr/lib/julia/sys.so
```