### PR TITLE
Rename format_bytes to formatbytes, and export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,7 @@ New library functions
 * New function `insorted` for determining whether an element is in a sorted collection or not ([#37490]).
 * New function `Base.rest` for taking the rest of a collection, starting from a specific
   iteration state, in a generic way ([#37410]).
+* The internal function for pretty-printing a number of bytes `format_bytes` is now named `formatbytes` and exported
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -94,7 +94,7 @@ New library functions
 * New function `insorted` for determining whether an element is in a sorted collection or not ([#37490]).
 * New function `Base.rest` for taking the rest of a collection, starting from a specific
   iteration state, in a generic way ([#37410]).
-* The internal function for pretty-printing a number of bytes `format_bytes` is now named `formatbytes` and exported
+* The internal function for pretty-printing a number of bytes `format_bytes` is now named `formatbytes` and exported ([#38464]).
 
 New library features
 --------------------

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -240,6 +240,6 @@ cat_shape(dims, shape::Tuple{}) = () # make sure `cat_shape(dims, ())` do not re
 
 # format_bytes was an internal function that a fair few packages use. Now renamed to formatbytes and exported
 # https://github.com/JuliaLang/julia/pull/38464
-@deprecate format_bytes(bytes) formatbytes(bytes; digits::Int = 3) false
+@deprecate format_bytes(bytes) formatbytes(bytes) false
 
 # END 1.6 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -238,4 +238,8 @@ end
 @deprecate cat_shape(dims, shape::Tuple{}, shapes::Tuple...) cat_shape(dims, shapes)
 cat_shape(dims, shape::Tuple{}) = () # make sure `cat_shape(dims, ())` do not recursively calls itself
 
+# format_bytes was an internal function that a fair few packages use. Now renamed to formatbytes and exported
+# https://github.com/JuliaLang/julia/pull/38464
+@depreciate format_bytes(bytes) formatbytes(bytes; digits::Int = 3) false
+
 # END 1.6 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -240,6 +240,6 @@ cat_shape(dims, shape::Tuple{}) = () # make sure `cat_shape(dims, ())` do not re
 
 # format_bytes was an internal function that a fair few packages use. Now renamed to formatbytes and exported
 # https://github.com/JuliaLang/julia/pull/38464
-@depreciate format_bytes(bytes) formatbytes(bytes; digits::Int = 3) false
+@deprecate format_bytes(bytes) formatbytes(bytes; digits::Int = 3) false
 
 # END 1.6 deprecations

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -618,7 +618,7 @@ export
     IOContext,
     displaysize,
     dump,
-    format_bytes,
+    formatbytes,
     print,
     println,
     printstyled,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -618,6 +618,7 @@ export
     IOContext,
     displaysize,
     dump,
+    format_bytes,
     print,
     println,
     printstyled,

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -109,9 +109,27 @@ end
 
 Converts from an integer number of bytes to a pretty printed string in nearest significant size units.
 
-```julia-repl
-julia> formatbytes(123456789)
-"117.738 MiB"
+```jldoctest
+julia> formatbytes(123)
+"123 bytes"
+
+julia> formatbytes(1234)
+"1.205 KiB"
+
+julia> formatbytes(1234567)
+"1.177 MiB"
+
+julia> formatbytes(1234567891)
+"1.150 GiB"
+
+julia> formatbytes(1234567891234)
+"1.123 TiB"
+
+julia> formatbytes(1234567891234567)
+"1.097 PiB"
+
+julia> formatbytes(1234567891234567891)
+"1096.517 PiB"
 ```
 
 !!! compat "Julia 1.6"

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -113,6 +113,9 @@ Converts from an integer number of bytes to a pretty printed string in nearest s
 julia> formatbytes(123456789)
 "117.738 MiB"
 ```
+
+!!! compat "Julia 1.6"
+    This function was an internal function named `format_bytes` prior to Julia 1.6.
 """
 function formatbytes(bytes; digits::Int = 3) # also used by InteractiveUtils
     bytes, mb = prettyprint_getunits(bytes, length(_mem_units), Int64(1024))

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -104,13 +104,22 @@ function padded_nonzero_print(value, str)
     end
 end
 
+"""
+    format_bytes(bytes; digits = 3)
 
-function format_bytes(bytes) # also used by InteractiveUtils
+Converts from an integer number of bytes to a pretty printed string in nearest significant size units.
+
+```julia-repl
+julia> format_bytes(123456789)
+"117.738 MiB"
+```
+"""
+function format_bytes(bytes; digits = 3) # also used by InteractiveUtils
     bytes, mb = prettyprint_getunits(bytes, length(_mem_units), Int64(1024))
     if mb == 1
         return string(Int(bytes), " ", _mem_units[mb], bytes==1 ? "" : "s")
     else
-        return string(Ryu.writefixed(Float64(bytes), 3), " ", _mem_units[mb])
+        return string(Ryu.writefixed(Float64(bytes), digits), " ", _mem_units[mb])
     end
 end
 

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -105,16 +105,16 @@ function padded_nonzero_print(value, str)
 end
 
 """
-    format_bytes(bytes; digits = 3)
+    formatbytes(bytes; digits = 3)
 
 Converts from an integer number of bytes to a pretty printed string in nearest significant size units.
 
 ```julia-repl
-julia> format_bytes(123456789)
+julia> formatbytes(123456789)
 "117.738 MiB"
 ```
 """
-function format_bytes(bytes; digits = 3) # also used by InteractiveUtils
+function formatbytes(bytes; digits = 3) # also used by InteractiveUtils
     bytes, mb = prettyprint_getunits(bytes, length(_mem_units), Int64(1024))
     if mb == 1
         return string(Int(bytes), " ", _mem_units[mb], bytes==1 ? "" : "s")
@@ -136,7 +136,7 @@ function time_print(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0)
         else
             print(Ryu.writefixed(Float64(allocs), 2), _cnt_units[ma], " allocations: ")
         end
-        print(format_bytes(bytes))
+        print(formatbytes(bytes))
     end
     if gctime > 0
         if bytes != 0 || allocs != 0

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -105,7 +105,7 @@ function padded_nonzero_print(value, str)
 end
 
 """
-    formatbytes(bytes; digits = 3)
+    formatbytes(bytes; digits::Int = 3)
 
 Converts from an integer number of bytes to a pretty printed string in nearest significant size units.
 
@@ -114,7 +114,7 @@ julia> formatbytes(123456789)
 "117.738 MiB"
 ```
 """
-function formatbytes(bytes; digits = 3) # also used by InteractiveUtils
+function formatbytes(bytes; digits::Int = 3) # also used by InteractiveUtils
     bytes, mb = prettyprint_getunits(bytes, length(_mem_units), Int64(1024))
     if mb == 1
         return string(Int(bytes), " ", _mem_units[mb], bytes==1 ? "" : "s")

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -11,7 +11,7 @@ export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, 
 import Base.Docs.apropos
 
 using Base: unwrap_unionall, rewrap_unionall, isdeprecated, Bottom, show_unquoted, summarysize,
-    to_tuple_type, signature_type, format_bytes
+    to_tuple_type, signature_type, formatbytes
 
 using Markdown
 
@@ -43,7 +43,7 @@ function varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported
                     ("", typemax(Int))
                 else
                     ss = summarysize(value)
-                    (format_bytes(ss), ss)
+                    (formatbytes(ss), ss)
                 end
                 Any[string(prep, v), ssize_str, summary(value), ssize]
             end


### PR DESCRIPTION
`format_bytes(bytes)` is a useful function. It'd be nice for it to be exported.

I also added a `digits` kwarg, along the lines of `round(x, digits=3)`

```
julia> format_bytes(123456789, digits=2)
"117.74 MiB"
```