### PR TITLE
fix string indexing logic error in showing types in backtrace

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2184,7 +2184,7 @@ function print_type_stacktrace(io, type; color=:normal)
     if isnothing(i) || !get(io, :backtrace, false)::Bool
         printstyled(io, str; color=color)
     else
-        printstyled(io, str[1:i-1]; color=color)
+        printstyled(io, str[1:prevind(str,i)]; color=color)
         printstyled(io, str[i:end]; color=:light_black)
     end
 end


### PR DESCRIPTION
cc @mcabbott 

Ref https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/c3bb6df_vs_788b2c7/KVectors.1.6.0-DEV-a896693d33.log