### PR TITLE
Add platform-specific note to `JULIA_DEPOT_PATH`

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -137,6 +137,11 @@ chosen so that it would be possible to set an empty depot path via the environme
 variable. If you want the default depot path, either unset the environment variable
 or if it must have a value, set it to the string `:`.
 
+!!! note
+
+    On Windows, path elements are separated by the `;` character, as is the case with
+    most path lists on Windows.
+
 ### `JULIA_HISTORY`
 
 The absolute path `REPL.find_hist_file()` of the REPL's history file. If


### PR DESCRIPTION
On windows, we separate elements of the `JULIA_DEPOT_PATH` with `;` instead of `:`, so make a note of that in the environment variables.