### PR TITLE
threads: avoid deadlock from recursive lock acquire

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,8 @@ Command-line option changes
 Multi-threading changes
 -----------------------
 
+* Locks now automatically inhibit finalizers from running, to avoid deadlock ([#TBD]).
+* New function `Base.Threads.foreach(f, channel::Channel)` for multithreaded `Channel` consumption ([#34543]).
 
 Build system changes
 --------------------
@@ -85,7 +87,6 @@ New library functions
 ---------------------
 
 * New function `Base.kron!` and corresponding overloads for various matrix types for performing Kronecker product in-place ([#31069]).
-* New function `Base.Threads.foreach(f, channel::Channel)` for multithreaded `Channel` consumption ([#34543]).
 * New function `Base.readeach(io, T)` for iteratively performing `read(io, T)` ([#36150]).
 * `Iterators.map` is added. It provides another syntax `Iterators.map(f, iterators...)`
   for writing `(f(args...) for args in zip(iterators...))`, i.e. a lazy `map` ([#34352]).

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -107,6 +107,16 @@ Control whether garbage collection is enabled using a boolean argument (`true` f
 enable(on::Bool) = ccall(:jl_gc_enable, Int32, (Int32,), on) != 0
 
 """
+    GC.enable_finalizers(on::Bool)
+
+Increment or decrement the counter that controls the running of finalizers on
+the current Task. Finalizers will only run when the counter is at zero. (Set
+`true` for enabling, `false` for disabling). They may still run concurrently on
+another Task or thread.
+"""
+enable_finalizers(on::Bool) = ccall(:jl_gc_enable_finalizers, Cvoid, (Ptr{Cvoid}, Int32,), C_NULL, on)
+
+"""
     GC.@preserve x1 x2 ... xn expr
 
 Mark the objects `x1, x2, ...` as being *in use* during the evaluation of the

--- a/src/gc.c
+++ b/src/gc.c
@@ -280,7 +280,7 @@ static void run_finalizer(jl_ptls_t ptls, jl_value_t *o, jl_value_t *ff)
         jl_printf((JL_STREAM*)STDERR_FILENO, "error in running finalizer: ");
         jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-        jlbacktrace(); // writen to STDERR_FILENO
+        jlbacktrace(); // written to STDERR_FILENO
     }
 }
 
@@ -392,12 +392,36 @@ static void run_finalizers(jl_ptls_t ptls)
     arraylist_free(&copied_list);
 }
 
+JL_DLLEXPORT int jl_gc_get_finalizers_inhibited(jl_ptls_t ptls)
+{
+    if (ptls == NULL)
+        ptls = jl_get_ptls_states();
+    return ptls->finalizers_inhibited;
+}
+
 JL_DLLEXPORT void jl_gc_enable_finalizers(jl_ptls_t ptls, int on)
 {
+    if (ptls == NULL)
+        ptls = jl_get_ptls_states();
     int old_val = ptls->finalizers_inhibited;
     int new_val = old_val + (on ? -1 : 1);
+    if (new_val < 0) {
+        JL_TRY {
+            jl_error(""); // get a backtrace
+        }
+        JL_CATCH {
+            jl_printf((JL_STREAM*)STDERR_FILENO, "WARNING: GC finalizers already enabled on this thread.\n");
+            // Only print the backtrace once, to avoid spamming the logs
+            static int backtrace_printed = 0;
+            if (backtrace_printed == 0) {
+                backtrace_printed = 1;
+                jlbacktrace(); // written to STDERR_FILENO
+            }
+        }
+        return;
+    }
     ptls->finalizers_inhibited = new_val;
-    if (!new_val && old_val && !ptls->in_finalizer) {
+    if (!new_val && old_val && !ptls->in_finalizer && ptls->locks.len == 0) {
         ptls->in_finalizer = 1;
         run_finalizers(ptls);
         ptls->in_finalizer = 0;
@@ -1581,7 +1605,7 @@ STATIC_INLINE uintptr_t gc_read_stack(void *_addr, uintptr_t offset,
 JL_NORETURN NOINLINE void gc_assert_datatype_fail(jl_ptls_t ptls, jl_datatype_t *vt,
                                                   jl_gc_mark_sp_t sp)
 {
-    jl_printf(JL_STDOUT, "GC error (probable corruption) :\n");
+    jl_safe_printf("GC error (probable corruption) :\n");
     gc_debug_print_status();
     jl_(vt);
     gc_debug_critical_error();
@@ -3192,7 +3216,7 @@ JL_DLLEXPORT void jl_gc_collect(jl_gc_collection_t collection)
     // Only disable finalizers on current thread
     // Doing this on all threads is racy (it's impossible to check
     // or wait for finalizers on other threads without dead lock).
-    if (!ptls->finalizers_inhibited) {
+    if (!ptls->finalizers_inhibited && ptls->locks.len == 0) {
         int8_t was_in_finalizer = ptls->in_finalizer;
         ptls->in_finalizer = 1;
         run_finalizers(ptls);

--- a/src/init.c
+++ b/src/init.c
@@ -745,9 +745,6 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
     jl_init_tasks();
     jl_init_root_task(stack_lo, stack_hi);
-#ifdef ENABLE_TIMINGS
-    jl_root_task->timing_stack = jl_root_timing;
-#endif
     jl_init_common_symbols();
     jl_init_flisp();
     jl_init_serializer();

--- a/src/julia.h
+++ b/src/julia.h
@@ -1730,7 +1730,6 @@ typedef struct _jl_handler_t {
     int8_t gc_state;
     size_t locks_len;
     sig_atomic_t defer_signal;
-    int finalizers_inhibited;
     jl_timing_block_t *timing_stack;
     size_t world_age;
 } jl_handler_t;
@@ -1753,8 +1752,6 @@ typedef struct _jl_task_t {
     int16_t tid;
     // multiqueue priority
     int16_t prio;
-    // current world age
-    size_t world_age;
     // saved exception stack
     jl_excstack_t *excstack;
     // current exception handler

--- a/src/julia.h
+++ b/src/julia.h
@@ -1765,8 +1765,6 @@ typedef struct _jl_task_t {
 
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
-
-    jl_timing_block_t *timing_stack;
 } jl_task_t;
 
 #define JL_TASK_STATE_RUNNABLE 0

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -207,6 +207,7 @@ struct _jl_tls_states_t {
     struct _jl_task_t *previous_task;
 #endif
     struct _jl_task_t *root_task;
+    struct _jl_timing_block_t *timing_stack;
     void *stackbase;
     size_t stacksize;
     jl_ucontext_t base_ctx; // base context of stack

--- a/src/locks.h
+++ b/src/locks.h
@@ -84,11 +84,9 @@ static inline void jl_lock_frame_pop(void)
 
 static inline void jl_mutex_lock(jl_mutex_t *lock)
 {
-    jl_ptls_t ptls = jl_get_ptls_states();
     JL_SIGATOMIC_BEGIN();
     jl_mutex_wait(lock, 1);
     jl_lock_frame_push(lock);
-    jl_gc_enable_finalizers(ptls, 0);
 }
 
 static inline int jl_mutex_trylock_nogc(jl_mutex_t *lock)
@@ -111,10 +109,8 @@ static inline int jl_mutex_trylock(jl_mutex_t *lock)
 {
     int got = jl_mutex_trylock_nogc(lock);
     if (got) {
-        jl_ptls_t ptls = jl_get_ptls_states();
         JL_SIGATOMIC_BEGIN();
         jl_lock_frame_push(lock);
-        jl_gc_enable_finalizers(ptls, 0);
     }
     return got;
 }
@@ -134,9 +130,12 @@ static inline void jl_mutex_unlock(jl_mutex_t *lock)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_mutex_unlock_nogc(lock);
-    jl_gc_enable_finalizers(ptls, 1);
     jl_lock_frame_pop();
     JL_SIGATOMIC_END();
+    if (ptls->locks.len == 0 && ptls->finalizers_inhibited == 0) {
+        ptls->finalizers_inhibited = 1;
+        jl_gc_enable_finalizers(ptls, 1); // call run_finalizers (may GC)
+    }
 }
 
 static inline void jl_mutex_init(jl_mutex_t *lock) JL_NOTSAFEPOINT

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -218,7 +218,6 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     eh->gc_state = ptls->gc_state;
     eh->locks_len = ptls->locks.len;
     eh->defer_signal = ptls->defer_signal;
-    eh->finalizers_inhibited = ptls->finalizers_inhibited;
     eh->world_age = ptls->world_age;
     current_task->eh = eh;
 #ifdef ENABLE_TIMINGS
@@ -249,14 +248,14 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_handler_t *eh)
     current_task->eh = eh->prev;
     ptls->pgcstack = eh->gcstack;
     small_arraylist_t *locks = &ptls->locks;
-    if (locks->len > eh->locks_len) {
-        for (size_t i = locks->len;i > eh->locks_len;i--)
+    int unlocks = locks->len > eh->locks_len;
+    if (unlocks) {
+        for (size_t i = locks->len; i > eh->locks_len; i--)
             jl_mutex_unlock_nogc((jl_mutex_t*)locks->items[i - 1]);
         locks->len = eh->locks_len;
     }
     ptls->world_age = eh->world_age;
     ptls->defer_signal = eh->defer_signal;
-    ptls->finalizers_inhibited = eh->finalizers_inhibited;
     if (old_gc_state != eh->gc_state) {
         jl_atomic_store_release(&ptls->gc_state, eh->gc_state);
         if (old_gc_state) {
@@ -265,6 +264,11 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_handler_t *eh)
     }
     if (old_defer_signal && !eh->defer_signal) {
         jl_sigint_safepoint(ptls);
+    }
+    if (unlocks && eh->locks_len == 0 && ptls->finalizers_inhibited == 0) {
+        // call run_finalizers
+        ptls->finalizers_inhibited = 1;
+        jl_gc_enable_finalizers(ptls, 1);
     }
 }
 

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -221,7 +221,7 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     eh->world_age = ptls->world_age;
     current_task->eh = eh;
 #ifdef ENABLE_TIMINGS
-    eh->timing_stack = current_task->timing_stack;
+    eh->timing_stack = ptls->timing_stack;
 #endif
 }
 

--- a/src/timing.c
+++ b/src/timing.c
@@ -17,7 +17,7 @@ extern "C" {
 #error Timings are not supported on your compiler
 #endif
 
-jl_timing_block_t *jl_root_timing;
+static uint64_t t0;
 uint64_t jl_timing_data[(int)JL_TIMING_LAST] = {0};
 const char *jl_timing_names[(int)JL_TIMING_LAST] =
     {
@@ -28,32 +28,32 @@ const char *jl_timing_names[(int)JL_TIMING_LAST] =
 
 void jl_print_timings(void)
 {
-    uint64_t total_time = 0;
+    uint64_t total_time = cycleclock() - t0;
+    uint64_t root_time = total_time;
     for (int i = 0; i < JL_TIMING_LAST; i++) {
-        total_time += jl_timing_data[i];
+        root_time -= jl_timing_data[i];
     }
+    jl_timing_data[0] = root_time;
     for (int i = 0; i < JL_TIMING_LAST; i++) {
         if (jl_timing_data[i] != 0)
-            fprintf(stderr,"%-25s : %5.2f %%   %" PRIu64 "\n", jl_timing_names[i],
+            fprintf(stderr, "%-25s : %5.2f %%   %" PRIu64 "\n", jl_timing_names[i],
                     100 * (((double)jl_timing_data[i]) / total_time), jl_timing_data[i]);
     }
 }
 
 void jl_init_timing(void)
 {
-    jl_root_timing = (jl_timing_block_t*)malloc_s(sizeof(jl_timing_block_t));
-    _jl_timing_block_init(jl_root_timing, JL_TIMING_ROOT);
-    jl_root_timing->prev = NULL;
+    t0 = cycleclock();
 }
 
 void jl_destroy_timing(void)
 {
-    jl_timing_block_t *stack = jl_current_task ? jl_current_task->timing_stack : jl_root_timing;
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_timing_block_t *stack = ptls->timing_stack;
     while (stack) {
         _jl_timing_block_destroy(stack);
         stack = stack->prev;
     }
-    free(jl_root_timing);
 }
 
 jl_timing_block_t *jl_pop_timing_block(jl_timing_block_t *cur_block)

--- a/src/timing.h
+++ b/src/timing.h
@@ -23,7 +23,6 @@ extern "C" {
 #endif
 void jl_print_timings(void);
 jl_timing_block_t *jl_pop_timing_block(jl_timing_block_t *cur_block);
-extern jl_timing_block_t *jl_root_timing;
 void jl_timing_block_start(jl_timing_block_t *cur_block);
 void jl_timing_block_stop(jl_timing_block_t *cur_block);
 #ifdef __cplusplus
@@ -117,7 +116,8 @@ STATIC_INLINE uint64_t _jl_timing_block_init(jl_timing_block_t *block, int owner
 
 STATIC_INLINE void _jl_timing_block_ctor(jl_timing_block_t *block, int owner) {
     uint64_t t = _jl_timing_block_init(block, owner);
-    jl_timing_block_t **prevp = jl_current_task ? &jl_current_task->timing_stack : &jl_root_timing;
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_timing_block_t **prevp = &ptls->timing_stack;
     block->prev = *prevp;
     if (block->prev)
         _jl_timing_block_stop(block->prev, t);
@@ -126,9 +126,10 @@ STATIC_INLINE void _jl_timing_block_ctor(jl_timing_block_t *block, int owner) {
 
 STATIC_INLINE void _jl_timing_block_destroy(jl_timing_block_t *block) {
     uint64_t t = cycleclock();
+    jl_ptls_t ptls = jl_get_ptls_states();
     _jl_timing_block_stop(block, t);
     jl_timing_data[block->owner] += block->total;
-    jl_timing_block_t **pcur = jl_current_task ? &jl_current_task->timing_stack : &jl_root_timing;
+    jl_timing_block_t **pcur = &ptls->timing_stack;
     assert(*pcur == block);
     *pcur = block->prev;
     if (block->prev)

--- a/stdlib/Distributed/src/messages.jl
+++ b/stdlib/Distributed/src/messages.jl
@@ -135,6 +135,7 @@ function flush_gc_msgs(w::Worker)
     end
 
     # del_msgs gets populated by finalizers, so be very careful here about ordering of allocations
+    # XXX: threading requires this to be atomic
     new_array = Any[]
     msgs = w.del_msgs
     w.del_msgs = new_array
@@ -166,7 +167,7 @@ function send_msg_(w::Worker, header, msg, now::Bool)
         wait(w.initialized)
     end
     io = w.w_stream
-    lock(io.lock)
+    lock(io)
     try
         reset_state(w.w_serializer)
         serialize_hdr_raw(io, header)
@@ -179,7 +180,7 @@ function send_msg_(w::Worker, header, msg, now::Bool)
             flush(io)
         end
     finally
-        unlock(io.lock)
+        unlock(io)
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -6,7 +6,6 @@ using Random, SparseArrays, InteractiveUtils
 
 const Bottom = Union{}
 
-
 # For curmod_*
 include("testenv.jl")
 
@@ -2081,7 +2080,7 @@ mutable struct A6142 <: AbstractMatrix{Float64}; end
 +(x::A6142, y::AbstractRange) = "AbstractRange method called" #16324 ambiguity
 
 # issue #6175
-function g6175(); print(""); (); end
+function g6175(); GC.safepoint(); (); end
 g6175(i::Real, I...) = g6175(I...)
 g6175(i, I...) = tuple(length(i), g6175(I...)...)
 @test g6175(1:5) === (5,)
@@ -2221,7 +2220,7 @@ day_in(obj6387)
 function segfault6793(;gamma=1)
     A = 1
     B = 1
-    print()
+    GC.safepoint()
     return
     -gamma
     nothing
@@ -3327,7 +3326,7 @@ function f11065()
         if i == 1
             z = "z is defined"
         elseif i == 2
-            print(z)
+            print(z) # z is undefined
         end
     end
 end
@@ -4244,7 +4243,10 @@ end
 end
 # disable GC to make sure no collection/promotion happens
 # when we are constructing the objects
+get_finalizers_inhibited() = ccall(:jl_gc_get_finalizers_inhibited, Int32, (Ptr{Cvoid},), C_NULL)
 let gc_enabled13995 = GC.enable(false)
+    @assert gc_enabled13995
+    @assert get_finalizers_inhibited() == 0
     finalized13995 = [false, false, false, false]
     create_dead_object13995(finalized13995)
     GC.enable(true)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -100,9 +100,12 @@ let
         """
 end
 
+# Debugging tool: return the current state of the enable_finalizers counter.
+get_finalizers_inhibited() = ccall(:jl_gc_get_finalizers_inhibited, Int32, (Ptr{Cvoid},), C_NULL)
+
 # lock / unlock
 let l = ReentrantLock()
-    lock(l)
+    @test lock(l) === nothing
     @test islocked(l)
     success = Ref(false)
     @test trylock(l) do
@@ -115,12 +118,41 @@ let l = ReentrantLock()
     @test success[]
     t = @async begin
         @test trylock(l) do
-            @test false
+            error("unreachable")
         end === false
     end
+    @test get_finalizers_inhibited() == 1
     Base.wait(t)
-    unlock(l)
+    @test get_finalizers_inhibited() == 1
+    @test unlock(l) === nothing
+    @test get_finalizers_inhibited() == 0
     @test_throws ErrorException unlock(l)
+end
+
+for l in (Threads.SpinLock(), ReentrantLock())
+    @test get_finalizers_inhibited() == 0
+    @test lock(get_finalizers_inhibited, l) == 1
+    @test get_finalizers_inhibited() == 0
+    try
+        GC.enable_finalizers(false)
+        GC.enable_finalizers(false)
+        @test get_finalizers_inhibited() == 2
+        GC.enable_finalizers(true)
+        @test get_finalizers_inhibited() == 1
+    finally
+        @test get_finalizers_inhibited() == 1
+        GC.enable_finalizers(false)
+        @test get_finalizers_inhibited() == 2
+    end
+    @test get_finalizers_inhibited() == 2
+    GC.enable_finalizers(true)
+    @test get_finalizers_inhibited() == 1
+    GC.enable_finalizers(true)
+    @test get_finalizers_inhibited() == 0
+    @test_warn "WARNING: GC finalizers already enabled on this thread." GC.enable_finalizers(true)
+
+    @test lock(l) === nothing
+    @test try unlock(l) finally end === nothing
 end
 
 # task switching


### PR DESCRIPTION
Finalizers can't safely acquire many essential locks (such as the
iolock, to cleanup libuv objects) if they are run inside another lock.
Therefore, inhibit all finalizers on the thread until all locks are
released (previously, this was only true for our internal locks).