### PR TITLE
[LLVM] Manually prefix ManagedStatic static vars

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -520,6 +520,7 @@ endif # LLVM_VER 11.0
 
 # Add a JL prefix to the version map. DO NOT REMOVE
 ifneq ($(LLVM_VER), svn)
+$(eval $(call LLVM_PATCH,llvm-jl-prefix-static-variables))
 $(eval $(call LLVM_PATCH,llvm7-symver-jlprefix))
 endif
 

--- a/deps/patches/llvm-jl-prefix-static-variables.patch
+++ b/deps/patches/llvm-jl-prefix-static-variables.patch
@@ -1,0 +1,82 @@
+From ea445dcaab3d5d50a7042a49366e25f704a585f4 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Wed, 18 Nov 2020 12:49:56 -0500
+Subject: [PATCH] manually prefix global variables
+
+---
+ llvm/lib/Support/ManagedStatic.cpp | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git llvm/lib/Support/ManagedStatic.cpp llvm/lib/Support/ManagedStatic.cpp
+index 053493f72fb..881301c827a 100644
+--- llvm/lib/Support/ManagedStatic.cpp
++++ llvm/lib/Support/ManagedStatic.cpp
+@@ -17,17 +17,17 @@
+ #include <mutex>
+ using namespace llvm;
+ 
+-static const ManagedStaticBase *StaticList = nullptr;
+-static std::recursive_mutex *ManagedStaticMutex = nullptr;
+-static llvm::once_flag mutex_init_flag;
++static const ManagedStaticBase *JL_StaticList = nullptr;
++static std::recursive_mutex *JL_ManagedStaticMutex = nullptr;
++static llvm::once_flag JL_mutex_init_flag;
+ 
+ static void initializeMutex() {
+-  ManagedStaticMutex = new std::recursive_mutex();
++  JL_ManagedStaticMutex = new std::recursive_mutex();
+ }
+ 
+ static std::recursive_mutex *getManagedStaticMutex() {
+-  llvm::call_once(mutex_init_flag, initializeMutex);
+-  return ManagedStaticMutex;
++  llvm::call_once(JL_mutex_init_flag, initializeMutex);
++  return JL_ManagedStaticMutex;
+ }
+ 
+ void ManagedStaticBase::RegisterManagedStatic(void *(*Creator)(),
+@@ -43,8 +43,8 @@ void ManagedStaticBase::RegisterManagedStatic(void *(*Creator)(),
+       DeleterFn = Deleter;
+ 
+       // Add to list of managed statics.
+-      Next = StaticList;
+-      StaticList = this;
++      Next = JL_StaticList;
++      JL_StaticList = this;
+     }
+   } else {
+     assert(!Ptr && !DeleterFn && !Next &&
+@@ -53,17 +53,17 @@ void ManagedStaticBase::RegisterManagedStatic(void *(*Creator)(),
+     DeleterFn = Deleter;
+ 
+     // Add to list of managed statics.
+-    Next = StaticList;
+-    StaticList = this;
++    Next = JL_StaticList;
++    JL_StaticList = this;
+   }
+ }
+ 
+ void ManagedStaticBase::destroy() const {
+   assert(DeleterFn && "ManagedStatic not initialized correctly!");
+-  assert(StaticList == this &&
++  assert(JL_StaticList == this &&
+          "Not destroyed in reverse order of construction?");
+   // Unlink from list.
+-  StaticList = Next;
++  JL_StaticList = Next;
+   Next = nullptr;
+ 
+   // Destroy memory.
+@@ -78,6 +78,6 @@ void ManagedStaticBase::destroy() const {
+ void llvm::llvm_shutdown() {
+   std::lock_guard<std::recursive_mutex> Lock(*getManagedStaticMutex());
+ 
+-  while (StaticList)
+-    StaticList->destroy();
++  while (JL_StaticList)
++    JL_StaticList->destroy();
+ }
+-- 
+2.29.2
+


### PR DESCRIPTION
```
using Libdl
dlopen("/husr/lib/libLLVM-11.so")
```

Currently crashes with:

```
julia> dlopen("/usr/lib/libLLVM-11.so")
julia: /home/vchuravy/src/julia/deps/srccache/llvm-11.0.0/include/llvm/Support/CommandLine.h:851: void llvm:cl:parser<DataType>::addLiteralOption(llvm::StringRef, const DT&, llvm::StringRef) [with DT = llvm::FunctionPass* (*)(); DataType = llvm::FunctionPass* (*)()]: Assertion `findOption(Name) == Values.size() && "Option already exists!"' failed.

signal (6): Aborted
in expression starting at REPL[2]:1
gsignal at /usr/lib/libc.so.6 (unknown line)
abort at /usr/lib/libc.so.6 (unknown line)
__assert_fail_base.cold at /usr/lib/libc.so.6 (unknown line)
__assert_fail at /usr/lib/libc.so.6 (unknown line)
addLiteralOption<llvm::FunctionPass* (*)()> at /home/vchuravy/src/julia/deps/srccache/llvm-11.0.0/include/llvm/Support/CommandLine.h:851
NotifyAdd at /home/vchuravy/src/julia/deps/srccache/llvm-11.0.0/include/llvm/CodeGen/MachinePassRegistry.h:162
unknown function (ip: 0x7f94eabfb608)
call_init.part.0 at /lib64/ld-linux-x86-64.so.2 (unknown line)
_dl_init at /lib64/ld-linux-x86-64.so.2 (unknown line)
_dl_catch_exception at /usr/lib/libc.so.6 (unknown line)
dl_open_worker at /lib64/ld-linux-x86-64.so.2 (unknown line)
_dl_catch_exception at /usr/lib/libc.so.6 (unknown line)
_dl_open at /lib64/ld-linux-x86-64.so.2 (unknown line)
unknown function (ip: 0x7f953494f34b)
_dl_catch_exception at /usr/lib/libc.so.6 (unknown line)
_dl_catch_error at /usr/lib/libc.so.6 (unknown line)
unknown function (ip: 0x7f953494fb88)
dlopen at /usr/lib/libdl.so.2 (unknown line)
```

I have hypothesized that this boils down to static variables being
merged..., they are not exported so they should stay separate, but
somehow we still run into this wonderful issue.

cc: @staticfloat @maleadt 