### PR TITLE
Make TerminalMenus header dynamic.

### DIFF
--- a/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/multiselect_menu.jl
@@ -30,10 +30,10 @@ for kws in ((charset=:ascii,),
     TerminalMenus.writeline(buf, multi_menu, 1, true)
     @test String(take!(buf)) == "$uck 1"
     TerminalMenus.printmenu(buf, multi_menu, 1; init=true)
-    @test startswith(String(take!(buf)), string("\e[2K $cur $uck 1"))
+    @test startswith(String(take!(buf)), string("\e[2K[press: d=done, a=all, n=none]\r\n\e[2K $cur $uck 1"))
     push!(multi_menu.selected, 1)
     TerminalMenus.printmenu(buf, multi_menu, 2; init=true)
-    @test startswith(String(take!(buf)), string("\e[2K   $chk 1\r\n\e[2K $cur $uck 2"))
+    @test startswith(String(take!(buf)), string("\e[2K[press: d=done, a=all, n=none]\r\n\e[2K   $chk 1\r\n\e[2K $cur $uck 2"))
 end
 
 # Preselection

--- a/stdlib/REPL/test/TerminalMenus/multiselect_with_skip_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/multiselect_with_skip_menu.jl
@@ -30,7 +30,7 @@ function MultiSelectWithSkipMenu(options::Array{String,1}; pagesize::Int=10,
                             TerminalMenus.MultiSelectConfig(; kwargs...))
 end
 
-TerminalMenus.header(m::MultiSelectWithSkipMenu) = "[press: d=done, a=all, c=none, npNP=move with skip]"
+TerminalMenus.header(m::MultiSelectWithSkipMenu) = "[press: d=done, a=all, c=none, npNP=move with skip, $(length(m.selected)) items selected]"
 
 TerminalMenus.options(m::MultiSelectWithSkipMenu) = m.options
 
@@ -118,7 +118,13 @@ end
 # These tests are specifically designed to verify that a `RefValue`
 # input to the AbstractMenu `request` function works as intended.
 menu = MultiSelectWithSkipMenu(string.(1:5), selected=[2, 3])
+buf = IOBuffer()
+TerminalMenus.printmenu(buf, menu, 1; init=true)
+@test occursin("2 items selected", String(take!(buf)))
 @test simulate_input(Set([2, 3, 4]), menu, 'n', :enter, 'd')
+buf = IOBuffer()
+TerminalMenus.printmenu(buf, menu, 1; init=true)
+@test occursin("3 items selected", String(take!(buf)))
 
 menu = MultiSelectWithSkipMenu(string.(1:5), selected=[2, 3])
 @test simulate_input(Set([2]), menu, 'P', :enter, 'd', cursor=5)


### PR DESCRIPTION
Cc @timholy 

Make TerminalMenus print the header in every update instead of only once at the start. This allows dynamic updates of the header as the state of the menu changes.

This is technically breaking in the sense that if someone defined a `header` function that was time or state dependent, they will now actually see the updates.