### PR TITLE
Remove unnecessary zero initialization in escape_raw_string

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -559,7 +559,6 @@ function escape_raw_string(io, str::AbstractString)
                 write(io, '\\')
                 escapes -= 1
             end
-            escapes = 0
             write(io, c)
         end
     end


### PR DESCRIPTION
Noted in https://github.com/JuliaLang/julia/pull/35309#discussion_r526563165