### PR TITLE
Fix Markdown word wrap

### DIFF
--- a/stdlib/Markdown/src/render/terminal/formatting.jl
+++ b/stdlib/Markdown/src/render/terminal/formatting.jl
@@ -9,9 +9,8 @@ end
 words(s) = split(s, " ")
 lines(s) = split(s, "\n")
 
-function _wrapped_lines(s::AbstractString, width, i)
+function wrapped_lines!(lines, io::IO, s::AbstractString, width, i)
     ws = words(s)
-    lines = String[]
     for word in ws
         word_length = ansi_length(word)
         if i + word_length + 1 > width
@@ -26,14 +25,17 @@ function _wrapped_lines(s::AbstractString, width, i)
             end
         end
     end
-    return i, lines
+    return i
 end
 
 function wrapped_lines(io::IO, s::AbstractString; width = 80, i = 0)
-    lines = String[]
-    for ss in split(s, "\n")
-        i, line = _wrapped_lines(ss, width, i)
-        append!(lines, line)
+    lines = AbstractString[]
+    if occursin(r"\n", s)
+        for ss in split(s, "\n")
+            i = wrapped_lines!(lines, io, ss, width, i)
+        end
+    else
+        wrapped_lines!(lines, io, s, width, i)
     end
     return lines
 end

--- a/stdlib/Markdown/src/render/terminal/formatting.jl
+++ b/stdlib/Markdown/src/render/terminal/formatting.jl
@@ -13,16 +13,13 @@ function wrapped_lines!(lines, io::IO, s::AbstractString, width, i)
     ws = words(s)
     for word in ws
         word_length = ansi_length(word)
-        if i + word_length + 1 > width
+        word_length == 0 && continue
+        if isempty(lines) || i + word_length + 1 > width
             i = word_length
             push!(lines, word)
         else
             i += word_length + 1
-            if isempty(lines)
-                push!(lines, word)
-            else
-                lines[end] *= " " * word   # this could be more efficient
-            end
+            lines[end] *= " " * word   # this could be more efficient
         end
     end
     return i

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -70,7 +70,7 @@ end
 function term(io::IO, md::List, columns)
     for (i, point) in enumerate(md.items)
         print(io, ' '^2margin, isordered(md) ? "$(i + md.ordered - 1). " : "•  ")
-        print_wrapped(io, width = columns-(4margin+2), pre = ' '^(2margin+2),
+        print_wrapped(io, width = columns-(4margin+2), pre = ' '^(2margin+3),
                           i = 2margin+2) do io
             term(io, point, columns - 10)
         end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -272,6 +272,42 @@ end
     | L |
 """) == "  │ Tables in admonitions\n  │\n  │  R\n  │  –\n  │  L"
 
+# Issue #38275
+function test_list_wrap(str, lenmin, lenmax)
+    strs = split(str, '\n')
+    l = length.(strs)
+    for i = 1:length(l)-1
+        if l[i] != 0 && l[i+1] != 0    # the next line isn't blank, so this line should be "full"
+            lenmin <= l[i] <= lenmax || return false
+        else
+            l[i] <= lenmax || return false   # this line isn't too long (but there is no min)
+        end
+    end
+    # Check consistent indentation
+    rngs = findfirst.((". ",), strs)
+    k = last(rngs[1])
+    rex = Regex('^' * " "^k * "\\w")
+    for (i, rng) in enumerate(rngs)
+        isa(rng, AbstractRange) && last(rng) == k && continue  # every numbered line starts the text at the same position
+        rng === nothing && (isempty(strs[i]) || match(rex, strs[i]) !== nothing) && continue  # every unnumbered line is indented to text in numbered lines
+        return false
+    end
+    return true
+end
+
+let doc =
+    md"""
+    1. a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij
+    2. a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij a bc def ghij
+    """
+    str = sprint(term, doc, 50)
+    @test test_list_wrap(str, 40, 50)
+    str = sprint(term, doc, 60)
+    @test test_list_wrap(str, 50, 60)
+    str = sprint(term, doc, 80)
+    @test test_list_wrap(str, 70, 80)
+end
+
 # HTML output
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"
 @test md"something ***" |> html == "<p>something ***</p>\n"
@@ -340,7 +376,7 @@ table = md"""
 # mime output
 let out =
     @test sprint(show, "text/plain", book) ==
-        "  Title\n  ≡≡≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  ===================\n\n  Some bolded\n\n    •    list1\n\n    •    list2"
+        "  Title\n  ≡≡≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  ===================\n\n  Some bolded\n\n    •  list1\n\n    •  list2"
     @test sprint(show, "text/markdown", book) ==
         """
         # Title

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1171,11 +1171,3 @@ end
         |  $x  |
         """)
 end
-
-@testset "issue #37232: linebreaks" begin
-    s = @md_str """
-       Misc:\\
-       - line\\
-       """
-    @test sprint(show, MIME("text/plain"), s) == "  Misc:\n  - line\n  "
-end


### PR DESCRIPTION
Fixes #38275. This changes the output of one test, but IMO the extra spaces in the test result are not actually desirable. The alignment on Julia 1.5 is also off-by-one (see the screenshot in that issue), whereas this seems well-aligned.

Fixing this is one of the milestones for 1.6.