### PR TITLE
Fix missed 2 lines in tanh rewrite

### DIFF
--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -130,8 +130,8 @@ end
 cosh(x::Real) = cosh(float(x))
 
 # tanh methods
-TANH_LARGE_X(::Type{Float64}) = 22.0
-TANH_LARGE_X(::Type{Float32}) = 9.0f0
+TANH_LARGE_X(::Type{Float64}) = 44.0
+TANH_LARGE_X(::Type{Float32}) = 18.0f0
 TANH_SMALL_X(::Type{Float64}) = 1.0
 TANH_SMALL_X(::Type{Float32}) = 1.3862944f0       #2*log(2)
 @inline function tanh_kernel(x::Float64)

--- a/test/math.jl
+++ b/test/math.jl
@@ -992,9 +992,11 @@ end
         @test isnan_type(T, tanh(T(NaN)))
         for x in Iterators.flatten(pcnfloat.([H_SMALL_X(T), T(1.0), H_MEDIUM_X(T)]))
             @test tanh(x) ≈ tanh(big(x)) rtol=eps(T)
-            @test tanh(-x) ≈ tanh(big(-x)) rtol=eps(T)
+            @test tanh(-x) ≈ -tanh(big(x)) rtol=eps(T)
         end
     end
+    @test tanh(18.0) ≈ tanh(big(18.0)) rtol=eps(Float64)
+    @test tanh(8.0) ≈ tanh(big(8.0)) rtol=eps(Float32)
 end
 
 @testset "asinh" begin


### PR DESCRIPTION
This fixes a slight regression for tanh when the output should be close to but not exactly +-1. This is just fixing a typo from the PR that I merged a few days ago. This should be merged ASAP. Sorry about this.