### PR TITLE
tweak creation of initial array in toml parser to work around accidental type piracy in packages

### DIFF
--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -675,7 +675,7 @@ end
 
 function parse_array(l::Parser)::Err{Vector}
     skip_ws_nl(l)
-    array = Union{}[]
+    array = Vector{Union{}}()
     empty_array = accept(l, ']')
     while !empty_array
         v = @try parse_value(l)


### PR DESCRIPTION
At least two packages have managed to type pirate the `getindex` on a `Union` (by doing `Base.getindex(::Type{<:Foo}, i...)`) breaking pretty much everything when it comes to loading packages and Pkg. Use an alternative syntax that is less likely to be pirated.