### PR TITLE
fix Meta.partially_inline! for ReturnNode

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -347,7 +347,14 @@ function _partially_inline!(@nospecialize(x), slot_replacements::Vector{Any},
     if isa(x, Core.ReturnNode)
         return Core.ReturnNode(
             _partially_inline!(x.val, slot_replacements, type_signature, static_param_values,
-                               slot_offset, statement_offset, boundscheck)
+                               slot_offset, statement_offset, boundscheck),
+        )
+    end
+    if isa(x, Core.GotoIfNot)
+        return Core.GotoIfNot(
+            _partially_inline!(x.cond, slot_replacements, type_signature, static_param_values,
+                               slot_offset, statement_offset, boundscheck),
+            x.dest,
         )
     end
     if isa(x, Expr)

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -344,6 +344,12 @@ function _partially_inline!(@nospecialize(x), slot_replacements::Vector{Any},
         x.edges .+= slot_offset
         return x
     end
+    if isa(x, Core.ReturnNode)
+        return Core.ReturnNode(
+            _partially_inline!(x.val, slot_replacements, type_signature, static_param_values,
+                               slot_offset, statement_offset, boundscheck)
+        )
+    end
     if isa(x, Expr)
         head = x.head
         if head === :static_parameter

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -238,3 +238,8 @@ f(::T) where {T} = T
 ci = code_lowered(f, Tuple{Int})[1]
 @test Meta.partially_inline!(ci.code, [], Tuple{typeof(f),Int}, Any[Int], 0, 0, :propagate) ==
     Any[Core.ReturnNode(QuoteNode(Int))]
+
+g(::Val{x}) where {x} = x ? 1 : 0
+ci = code_lowered(g, Tuple{Val{true}})[1]
+@test Meta.partially_inline!(ci.code, [], Tuple{typeof(g),Val{true}}, Any[Val{true}], 0, 0, :propagate)[1] ==
+   Core.GotoIfNot(QuoteNode(Val{true}), 3)

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -233,3 +233,8 @@ macro m() 2 end
 end
 
 @test _lower(TestExpandInWorldModule, :(@m), TestExpandInWorldModule.wa) == 1
+
+f(::T) where {T} = T
+ci = code_lowered(f, Tuple{Int})[1]
+@test Meta.partially_inline!(ci.code, [], Tuple{typeof(f),Int}, Any[Int], 0, 0, :propagate) ==
+    Any[Core.ReturnNode(QuoteNode(Int))]


### PR DESCRIPTION
`Meta.partially_inline!` currently doesn't recurse into `ReturnNode`s, which is important for IRTools, for example. Is this the correct solution here?