### PR TITLE
Use mpq functions for Rational{BigInt}

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -841,7 +841,7 @@ module MPQ
 
 # Rational{BigInt}
 import .Base: unsafe_rational, __throw_rational_argerror_zero
-import ..GMP: BigInt, MPZ, Limb
+import ..GMP: BigInt, MPZ, Limb, isneg
 
 mutable struct _MPQ
     num_alloc::Cint
@@ -885,7 +885,7 @@ end
 
 function Base.:+(x::Rational{BigInt}, y::Rational{BigInt})
     if iszero(x.den) || iszero(y.den)
-        if iszero(x.den) && iszero(y.den) && signbit(x.num) != signbit(y.num)
+        if iszero(x.den) && iszero(y.den) && isneg(x.num) != isneg(y.num)
             throw(DivideError())
         end
         return iszero(x.den) ? x : y
@@ -897,7 +897,7 @@ function Base.:+(x::Rational{BigInt}, y::Rational{BigInt})
 end
 function Base.:-(x::Rational{BigInt}, y::Rational{BigInt})
     if iszero(x.den) || iszero(y.den)
-        if iszero(x.den) && iszero(y.den) && signbit(x.num) == signbit(y.num)
+        if iszero(x.den) && iszero(y.den) && isneg(x.num) == isneg(y.num)
             throw(DivideError())
         end
         return iszero(x.den) ? x : -y
@@ -912,7 +912,7 @@ function Base.:*(x::Rational{BigInt}, y::Rational{BigInt})
         if iszero(x.num) || iszero(y.num)
             throw(DivideError())
         end
-        return xor(signbit(x.num),signbit(y.num)) ? -one(BigInt)//zero(BigInt) : one(BigInt)//zero(BigInt)
+        return xor(isneg(x.num),isneg(y.num)) ? -one(BigInt)//zero(BigInt) : one(BigInt)//zero(BigInt)
     end
     zq = _MPQ()
     ccall((:__gmpq_mul, :libgmp), Cvoid,

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -839,7 +839,7 @@ end
 
 module MPQ
 
-# Rational{BigFloat}
+# Rational{BigInt}
 import .Base: unsafe_rational, __throw_rational_argerror_zero
 import ..GMP: BigInt, MPZ, Limb
 
@@ -862,13 +862,14 @@ _MPQ(x::BigInt,y::BigInt) = _MPQ(x.alloc, x.size, x.d,
 _MPQ() = _MPQ(BigInt(), BigInt())
 _MPQ(x::Rational{BigInt}) = _MPQ(x.num, x.den)
 
-function _sync!(xq::_MPQ)
+function sync_rational!(xq::_MPQ)
     xq.rat.num.alloc = xq.num_alloc
     xq.rat.num.size  = xq.num_size
     xq.rat.num.d     = xq.num_d
     xq.rat.den.alloc = xq.den_alloc
     xq.rat.den.size  = xq.den_size
     xq.rat.den.d     = xq.den_d
+    return xq.rat
 end
 
 function Rational{BigInt}(num::BigInt, den::BigInt)
@@ -879,8 +880,7 @@ function Rational{BigInt}(num::BigInt, den::BigInt)
     end
     xq = _MPQ(MPZ.set(num), MPZ.set(den))
     ccall((:__gmpq_canonicalize, :libgmp), Cvoid, (mpq_t,), xq)
-    _sync!(xq)
-    return xq.rat
+    return sync_rational!(xq)
 end
 
 function Base.:+(x::Rational{BigInt}, y::Rational{BigInt})
@@ -893,8 +893,7 @@ function Base.:+(x::Rational{BigInt}, y::Rational{BigInt})
     zq = _MPQ()
     ccall((:__gmpq_add, :libgmp), Cvoid,
           (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    _sync!(zq)
-    return zq.rat
+    return sync_rational!(zq)
 end
 function Base.:-(x::Rational{BigInt}, y::Rational{BigInt})
     if iszero(x.den) || iszero(y.den)
@@ -906,8 +905,7 @@ function Base.:-(x::Rational{BigInt}, y::Rational{BigInt})
     zq = _MPQ()
     ccall((:__gmpq_sub, :libgmp), Cvoid,
           (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    _sync!(zq)
-    return zq.rat
+    return sync_rational!(zq)
 end
 function Base.:*(x::Rational{BigInt}, y::Rational{BigInt})
     if iszero(x.den) || iszero(y.den)
@@ -919,8 +917,7 @@ function Base.:*(x::Rational{BigInt}, y::Rational{BigInt})
     zq = _MPQ()
     ccall((:__gmpq_mul, :libgmp), Cvoid,
           (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    _sync!(zq)
-    return zq.rat
+    return sync_rational!(zq)
 end
 function Base.://(x::Rational{BigInt}, y::Rational{BigInt})
     if iszero(x.den)
@@ -939,8 +936,7 @@ function Base.://(x::Rational{BigInt}, y::Rational{BigInt})
     zq = _MPQ()
     ccall((:__gmpq_div, :libgmp), Cvoid,
           (mpq_t,mpq_t,mpq_t), zq, _MPQ(x), _MPQ(y))
-    _sync!(zq)
-    return zq.rat
+    return sync_rational!(zq)
 end
 
 end # MPQ module


### PR DESCRIPTION
Fixes #9826.

A quick benchmark:
```julia
julia> X = [big(rand(1:10000)) // big(rand(1:10000)) for i = 1:100, j = 1:100];

julia> @time X*X; # before
 12.525924 seconds (45.29 M allocations: 1.267 GiB, 8.44% gc time)

julia> @time X*X; # after
  2.343117 seconds (18.95 M allocations: 733.016 MiB, 18.66% gc time, 17.26% compilation time)
```