### PR TITLE
REPL-only: Print a hint if the user types `exit` in the REPL

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -370,6 +370,7 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
         if !isempty(line)
             response = eval_with_backend(ast, backend)
             print_response(repl, response, !ends_with_semicolon(line), false)
+            print_exit_hint(repl, line)
         end
         write(repl.terminal, '\n')
         ((!interrupted && isempty(line)) || hit_eof) && break
@@ -796,6 +797,7 @@ function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon:
             end
             hide_output = suppress_on_semicolon && ends_with_semicolon(line)
             print_response(repl, response, !hide_output, hascolor(repl))
+            print_exit_hint(repl, line)
         end
         prepare_next(repl)
         reset_state(s)
@@ -1224,12 +1226,29 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
             end
             response = eval_with_backend(ast, backend)
             print_response(repl, response, !ends_with_semicolon(line), have_color)
+            print_exit_hint(repl, line)
         end
     end
     # Terminate Backend
     put!(backend.repl_channel, (nothing, -1))
     dopushdisplay && popdisplay(d)
     nothing
+end
+
+function start_repl_server(port::Int)
+    return listen(port) do server, status
+        client = accept(server)
+        run_repl(client)
+        nothing
+    end
+end
+
+print_exit_hint(repl::AbstractREPL, line) = print_exit_hint(outstream(repl), line)
+function print_exit_hint(io::IO, line)
+    if lowercase(strip(line)) == "exit"
+        println(io, "\nTo exit Julia, use Ctrl-D, or type exit() and press enter.")
+    end
+    return nothing
 end
 
 end # module

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1235,14 +1235,6 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     nothing
 end
 
-function start_repl_server(port::Int)
-    return listen(port) do server, status
-        client = accept(server)
-        run_repl(client)
-        nothing
-    end
-end
-
 print_exit_hint(repl::AbstractREPL, line) = print_exit_hint(outstream(repl), line)
 function print_exit_hint(io::IO, line)
     if lowercase(strip(line)) == "exit"


### PR DESCRIPTION
Closes #21362
Closes #38307

This hint will only be shown if the input is `exit`.

```julia
julia> exit
exit (generic function with 2 methods)

To exit Julia, type exit() and press enter

julia> fs = [exit];

julia> fs[1]
exit (generic function with 2 methods)
```