### PR TITLE
Faster searchsorted methods for range and array inputs

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -461,7 +461,9 @@ export
     occursin,
     searchsorted,
     searchsortedfirst,
+    searchsortedfirst!,
     searchsortedlast,
+    searchsortedlast!,
     insorted,
     startswith,
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -324,10 +324,9 @@ for s in [:searchsortedfirst, :searchsortedlast, :searchsorted]
             $s(v,x,ord(lt,by,rev,order))
     end
 end
-for n in zip([:searchsortedfirst, :searchsortedlast],
-        [:_searchsortedfirst, :_searchsortedlast],
-        [:searchsortedfirst!, :searchsortedlast!],
-        [:_searchsortedfirst!, :_searchsortedlast!])
+for n in (
+    (:searchsortedfirst, :_searchsortedfirst, :searchsortedfirst!, :_searchsortedfirst!),
+    (:searchsortedlast, :_searchsortedlast, :searchsortedlast!, :_searchsortedlast!))
     s = n[1] # The Symbol construction method isn't available at Core.Compile time, so each name is written out manually
     us = n[2]
     mut = n[3]
@@ -339,7 +338,7 @@ for n in zip([:searchsortedfirst, :searchsortedlast],
         end
         $mut(i::AbstractArray, v::AbstractVector, x;
             lt=isless, by=identity, rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) =
-            $mut(i,v,x,ord(lt,by,rev,order))
+            $mut(i, v, x, ord(lt, by, rev, order))
         function $mut(i::AbstractArray, a::AbstractRange, x::AbstractArray, o::DirectOrdering)
             require_one_based_indexing(a)
             $usmut(i, a, x, o)
@@ -354,7 +353,7 @@ for n in zip([:searchsortedfirst, :searchsortedlast],
         function $usmut(i::AbstractArray, a::AbstractRange, x::AbstractArray, o::DirectOrdering)
             size(i) != size(x) && error("The sizes of arrays i and x must match. Got i: $(size(i)), x: $(size(x))")
             a_len = convert(keytype(a), length(a))
-            @inbounds for ci in CartesianIndices(x)
+            for ci in CartesianIndices(x)
                 i[ci] = $us(a, x[ci], o; a_len = a_len)
             end
             return i


### PR DESCRIPTION
For searching through an AbstractRange, the fastest one can use `searchsortedfirst` to evaluate multiple values currently is:
```julia
function foo(r, x)
   i = similar(x, keytype(r))
   @inbounds for ci in CartesianIndices(x)
       i[ci] = searchsortedfirst(r,x[ci])
   end
   return i
end
r = 0x00:0x02:0xff;
x = rand(UInt8, 1000, 1000);
@btime foo($r, $x)
```
```
  6.159 ms (2 allocations: 7.63 MiB)
1000×1000 Matrix{Int64}: ...
```

This PR provides the following, which only checks for one-based indexing and the length of `r` once, given they are expensive. It can also be preallocated:
```julia
@btime searchsortedfirst($r, $x)
```
```
  3.193 ms (2 allocations: 7.63 MiB)
1000×1000 Matrix{Int64}: ...
```
```julia
i = similar(x, keytype(r));
@btime searchsortedfirst!($i, $r, $x) 
```
```
  2.830 ms (0 allocations: 0 bytes)
1000×1000 Matrix{Int64}: ...
```

I didn't extend the methods for searching through AbstractVectors, as I didn't see a performance limitation with using those looped through values
  