### PR TITLE
Allow `clamp!(::Ref, lo, hi)`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -97,6 +97,11 @@ function clamp!(x::AbstractArray, lo, hi)
     x
 end
 
+function clamp!(x::Ref, lo, hi)
+    x[] = clamp(x[], lo, hi)
+    x
+end
+
 """
     clamp(x::Integer, r::AbstractUnitRange)
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -31,6 +31,15 @@ end
         x = [0.0, 1.0, 2.0, 3.0, 4.0]
         clamp!(x, 1, 3)
         @test x == [1.0, 1.0, 2.0, 3.0, 3.0]
+
+        x5 = Ref(x, 5)
+        clamp!(x5, 0, 1)
+        @test x5[] == 1.0
+        @test x[5] == 1.0
+
+        y = Ref(2*pi)
+        clamp!(y, 0, 5)
+        @test y[] == 5.0
     end
 end
 


### PR DESCRIPTION
Since `clamp!(fill(1.23), 0, 1)` works, perhaps `clamp!(Ref(1.23), 0, 1)` should, too.