### PR TITLE
Modify documentation for `view` to take into account range special case

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -122,7 +122,12 @@ _maybe_reshape_parent(A::AbstractArray, ::NTuple{N, Bool}) where {N} = reshape(A
 """
     view(A, inds...)
 
-Like [`getindex`](@ref), but returns a view into the parent array `A` with the
+Like [`getindex`](@ref), but returns a lightweight array that lazily references
+(or is effectively a _view_ into) the parent array `A` at the given index or indices
+`inds` instead of eagerly extracting elements or constructing a copied subset.
+Calling [`getindex`](@ref) or [`setindex!`](@ref) on the returned value
+(often a [`SubArray`](@ref)) computes the indices to access or modify the
+parent array on the fly (without checking bounds a second time).
 given indices instead of making a copy if (but not only if) `A` supports `setindex!`.
 Otherwise, it may create a new object if that is a cheap operation (e.g., `UnitRange`).
 Calling [`getindex`](@ref) or

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -128,10 +128,6 @@ Like [`getindex`](@ref), but returns a lightweight array that lazily references
 Calling [`getindex`](@ref) or [`setindex!`](@ref) on the returned value
 (often a [`SubArray`](@ref)) computes the indices to access or modify the
 parent array on the fly (without checking bounds a second time).
-given indices instead of making a copy if (but not only if) `A` supports `setindex!`.
-Otherwise, it may create a new object if that is a cheap operation (e.g., `UnitRange`).
-Calling [`getindex`](@ref) or
-[`setindex!`](@ref) on the returned value (usually a `SubArray`) computes the
 
 Some immutable parent arrays (like ranges) may choose to simply
 recompute a new array in some circumstances instead of returning

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -123,7 +123,8 @@ _maybe_reshape_parent(A::AbstractArray, ::NTuple{N, Bool}) where {N} = reshape(A
     view(A, inds...)
 
 Like [`getindex`](@ref), but returns a view into the parent array `A` with the
-given indices instead of making a copy, unless `A` is immutable.  
+given indices instead of making a copy if (but not only if) `A` supports `setindex!`.
+Otherwise, it may create a new object if that is a cheap operation (e.g., `UnitRange`).
 Calling [`getindex`](@ref) or
 [`setindex!`](@ref) on the returned value (usually a `SubArray`) computes the
 indices to the parent array on the fly without checking bounds.

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -123,8 +123,9 @@ _maybe_reshape_parent(A::AbstractArray, ::NTuple{N, Bool}) where {N} = reshape(A
     view(A, inds...)
 
 Like [`getindex`](@ref), but returns a view into the parent array `A` with the
-given indices instead of making a copy.  Calling [`getindex`](@ref) or
-[`setindex!`](@ref) on the returned `SubArray` computes the
+given indices instead of making a copy, unless `A` is immutable.  
+Calling [`getindex`](@ref) or
+[`setindex!`](@ref) on the returned value (usually a `SubArray`) computes the
 indices to the parent array on the fly without checking bounds.
 
 # Examples
@@ -148,6 +149,9 @@ julia> A # Note A has changed even though we modified b
 2×2 Matrix{Int64}:
  0  2
  0  4
+
+julia> view(2:5, 2:3) # returns a range as type is immutable
+3:4
 ```
 """
 function view(A::AbstractArray, I::Vararg{Any,N}) where {N}

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -127,7 +127,9 @@ Like [`getindex`](@ref), but returns a lightweight array that lazily references
 `inds` instead of eagerly extracting elements or constructing a copied subset.
 Calling [`getindex`](@ref) or [`setindex!`](@ref) on the returned value
 (often a [`SubArray`](@ref)) computes the indices to access or modify the
-parent array on the fly (without checking bounds a second time).
+parent array on the fly.  The behavior is undefined if the shape of the parent array is
+changed after `view` is called because there is no bound check for the parent array; e.g.,
+it may cause a segmentation fault.
 
 Some immutable parent arrays (like ranges) may choose to simply
 recompute a new array in some circumstances instead of returning

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -132,7 +132,10 @@ given indices instead of making a copy if (but not only if) `A` supports `setind
 Otherwise, it may create a new object if that is a cheap operation (e.g., `UnitRange`).
 Calling [`getindex`](@ref) or
 [`setindex!`](@ref) on the returned value (usually a `SubArray`) computes the
-indices to the parent array on the fly without checking bounds.
+
+Some immutable parent arrays (like ranges) may choose to simply
+recompute a new array in some circumstances instead of returning
+a `SubArray` if doing so is efficient and provides compatible semantics.
 
 # Examples
 ```jldoctest

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -128,6 +128,7 @@ Base.reinterpret
 Base.reshape
 Base.dropdims
 Base.vec
+Base.SubArray
 ```
 
 ## Concatenation and permutation


### PR DESCRIPTION
`view` sometimes does not return a `SubArray`, e.g.,
```julia
julia> view(2:5, 2:3) # returns a range as type is immutable
3:4
```
This is not really consistent with the docstring for `view`. So this PR modifies the docstring.

Cf https://github.com/JuliaArrays/FillArrays.jl/issues/84 where we want to do something similar with FillArrays.jl but want to make sure it's justified.