### PR TITLE
LibGit2: fix pass-through for SSH

### DIFF
--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -371,7 +371,7 @@ function certificate_callback(
     transport = cert_type == Consts.CERT_TYPE_TLS ? "TLS" :
                 cert_type == Consts.CERT_TYPE_SSH ? "SSH" : nothing
     verify = NetworkOptions.verify_host(host, transport)
-    verify ? Consts.CERT_REJECT : Consts.CERT_ACCEPT
+    verify ? Consts.PASSTHROUGH : Consts.CERT_ACCEPT
 end
 
 "C function pointer for `mirror_callback`"

--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -359,9 +359,26 @@ function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
     return Cint(0)
 end
 
+function certificate_callback(
+    cert_p :: Ptr{Cvoid},
+    valid  :: Cint,
+    host_p :: Ptr{Cchar},
+    user_p :: Ptr{Cvoid},
+)::Cint
+    valid != 0 && return Consts.CERT_ACCEPT
+    host = unsafe_string(host_p)
+    cert_type = unsafe_load(convert(Ptr{Cint}, cert_p))
+    transport = cert_type == Consts.CERT_TYPE_TLS ? "TLS" :
+                cert_type == Consts.CERT_TYPE_SSH ? "SSH" : nothing
+    verify = NetworkOptions.verify_host(host, transport)
+    verify ? Consts.CERT_REJECT : Consts.CERT_ACCEPT
+end
+
 "C function pointer for `mirror_callback`"
 mirror_cb() = @cfunction(mirror_callback, Cint, (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Cstring, Ptr{Cvoid}))
 "C function pointer for `credentials_callback`"
 credentials_cb() = @cfunction(credentials_callback, Cint, (Ptr{Ptr{Cvoid}}, Cstring, Cstring, Cuint, Any))
 "C function pointer for `fetchhead_foreach_callback`"
 fetchhead_foreach_cb() = @cfunction(fetchhead_foreach_callback, Cint, (Cstring, Cstring, Ptr{GitHash}, Cuint, Any))
+"C function pointer for `certificate_callback`"
+certificate_cb() = @cfunction(certificate_callback, Cint, (Ptr{Cvoid}, Cint, Ptr{Cchar}, Ptr{Cvoid}))

--- a/stdlib/LibGit2/src/consts.jl
+++ b/stdlib/LibGit2/src/consts.jl
@@ -313,6 +313,7 @@ const CERT_TYPE_TLS = 1 # GIT_CERT_X509
 const CERT_TYPE_SSH = 2 # GIT_CERT_HOSTKEY_LIBSSH2
 
 # certificate callback return values
+const PASSTHROUGH = -30
 const CERT_REJECT = -1
 const CERT_ACCEPT =  0
 

--- a/stdlib/LibGit2/src/consts.jl
+++ b/stdlib/LibGit2/src/consts.jl
@@ -308,6 +308,14 @@ const STATUS_OPT_UPDATE_INDEX                     = Cuint(1 << 13)
 const STATUS_OPT_INCLUDE_UNREADABLE               = Cuint(1 << 14)
 const STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED  = Cuint(1 << 15)
 
+# certificate types from `enum git_cert_t` in `cert.h`.
+const CERT_TYPE_TLS = 1 # GIT_CERT_X509
+const CERT_TYPE_SSH = 2 # GIT_CERT_HOSTKEY_LIBSSH2
+
+# certificate callback return values
+const CERT_REJECT = -1
+const CERT_ACCEPT =  0
+
 @enum(GIT_SUBMODULE_IGNORE, SUBMODULE_IGNORE_UNSPECIFIED  = -1, # use the submodule's configuration
                             SUBMODULE_IGNORE_NONE         = 1,  # any change or untracked == dirty
                             SUBMODULE_IGNORE_UNTRACKED    = 2,  # dirty if tracked files change

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -222,7 +222,7 @@ Matches the [`git_remote_callbacks`](https://libgit2.org/libgit2/#HEAD/type/git_
     sideband_progress::Ptr{Cvoid}      = C_NULL
     completion::Ptr{Cvoid}             = C_NULL
     credentials::Ptr{Cvoid}            = C_NULL
-    certificate_check::Ptr{Cvoid}      = C_NULL
+    certificate_check::Ptr{Cvoid}      = certificate_cb()
     transfer_progress::Ptr{Cvoid}      = C_NULL
     update_tips::Ptr{Cvoid}            = C_NULL
     pack_progress::Ptr{Cvoid}          = C_NULL
@@ -310,7 +310,7 @@ julia> fetch(remote, "master", options=fo)
     proxytype::Consts.GIT_PROXY  = Consts.PROXY_AUTO
     url::Cstring                 = Cstring(C_NULL)
     credential_cb::Ptr{Cvoid}    = C_NULL
-    certificate_cb::Ptr{Cvoid}   = C_NULL
+    certificate_cb::Ptr{Cvoid}   = certificate_cb()
     payload::Any                 = nothing
 end
 @assert ProxyOptions.isinlinealloc


### PR DESCRIPTION
According to the libgit2 documentation, if the callback returns any positive value, it will behave as if the callback were unset (i.e. pass-through), but that's not true. The value that needs to be returned is actually -30 (`GIT_PASSTHROUGH`).