### PR TITLE
LibGit2: fix pass-through for SSH

### DIFF
--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -371,7 +371,7 @@ function certificate_callback(
     transport = cert_type == Consts.CERT_TYPE_TLS ? "TLS" :
                 cert_type == Consts.CERT_TYPE_SSH ? "SSH" : nothing
     verify = NetworkOptions.verify_host(host, transport)
-    verify ? Consts.CERT_REJECT : Consts.CERT_ACCEPT
+    verify ? Consts.PASSTHROUGH : Consts.CERT_ACCEPT
 end
 
 "C function pointer for `mirror_callback`"

--- a/stdlib/LibGit2/src/consts.jl
+++ b/stdlib/LibGit2/src/consts.jl
@@ -313,6 +313,7 @@ const CERT_TYPE_TLS = 1 # GIT_CERT_X509
 const CERT_TYPE_SSH = 2 # GIT_CERT_HOSTKEY_LIBSSH2
 
 # certificate callback return values
+const PASSTHROUGH = -30
 const CERT_REJECT = -1
 const CERT_ACCEPT =  0
 


### PR DESCRIPTION
According to the libgit2 documentation, if the callback returns any postive value, it will behave as if the callback were unset (i.e. pass-through), but that's not true. The value that needs to be returned is actually -30 (`GIT_PASSTHROUGH`).
