### PR TITLE
Support Core.Compiler.InterpreterIP in building stacktraces

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -118,7 +118,7 @@ end
 
 const top_level_scope_sym = Symbol("top-level scope")
 
-function lookup(ip::Base.InterpreterIP)
+function lookup(ip::Union{Base.InterpreterIP,Core.Compiler.InterpreterIP})
     code = ip.code
     if code === nothing
         # interpreted top-level expression with no CodeInfo
@@ -157,7 +157,7 @@ Returns a stack trace in the form of a vector of `StackFrame`s. (By default stac
 doesn't return C functions, but this can be enabled.) When called without specifying a
 trace, `stacktrace` first calls `backtrace`.
 """
-function stacktrace(trace::Vector{<:Union{Base.InterpreterIP,Ptr{Cvoid}}}, c_funcs::Bool=false)
+function stacktrace(trace::Vector{<:Union{Base.InterpreterIP,Core.Compiler.InterpreterIP,Ptr{Cvoid}}}, c_funcs::Bool=false)
     stack = StackTrace()
     for ip in trace
         for frame in lookup(ip)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2885,6 +2885,8 @@ end
     @test sort([mi_info.mi.def.name for (time,mi_info) in flatten_times(timing1)[end-1:end]]) == [:i, :i2]
     @test all(child->isa(child.bt, Vector), timing1.children)
     @test all(child->child.bt===nothing, timing1.children[1].children)
+    # Test the stacktrace
+    @test isa(stacktrace(timing1.children[1].bt), Vector{Base.StackTraces.StackFrame})
     # Test that inference has cached some of the Method Instances
     timing2 = time_inference() do
         @eval M.g(2, 3.0)


### PR DESCRIPTION
The new inference timing captures a backtrace for each descent into
inference as a mechanism to find out who it was triggered by.
This allows us to convert those backtraces to stacktraces when we need to.

CC @NHDaly 