### PR TITLE
allow default_addprocs_params to be specialized on ClusterManager

### DIFF
--- a/stdlib/Distributed/docs/src/index.md
+++ b/stdlib/Distributed/docs/src/index.md
@@ -65,4 +65,5 @@ Distributed.connect(::ClusterManager, ::Int, ::WorkerConfig)
 Distributed.init_worker
 Distributed.start_worker
 Distributed.process_messages
+Distributed.default_addprocs_params
 ```

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -448,7 +448,7 @@ function addprocs(manager::ClusterManager; kwargs...)
 end
 
 function addprocs_locked(manager::ClusterManager; kwargs...)
-    params = merge(default_addprocs_params(), Dict{Symbol,Any}(kwargs))
+    params = merge(default_addprocs_params(manager), Dict{Symbol,Any}(kwargs))
     topology(Symbol(params[:topology]))
 
     if PGRP.topology !== :all_to_all
@@ -513,12 +513,16 @@ function set_valid_processes(plist::Array{Int})
     end
 end
 
+"""
+    default_addprocs_params(mgr::ClusterManager) -> Dict{Symbol, Any}
+
+Implemented by cluster managers. The default keyword parameters passed when calling
+`addprocs(mgr)`. The minimal set of options is available by calling
+`default_addprocs_params()`
+"""
+default_addprocs_params(::ClusterManager) = default_addprocs_params()
 default_addprocs_params() = Dict{Symbol,Any}(
     :topology => :all_to_all,
-    :ssh      => "ssh",
-    :shell    => :posix,
-    :cmdline_cookie => false,
-    :env      => [],
     :dir      => pwd(),
     :exename  => joinpath(Sys.BINDIR::String, julia_exename()),
     :exeflags => ``,

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -34,7 +34,7 @@ struct SSHManager <: ClusterManager
 end
 
 
-function check_addprocs_args(kwargs)
+function check_addprocs_args(manager, kwargs)
     valid_kw_names = keys(default_addprocs_params(manager))
     for keyname in keys(kwargs)
         !(keyname in valid_kw_names) && throw(ArgumentError("Invalid keyword argument $(keyname)"))
@@ -439,7 +439,7 @@ processes on the local machine. If `restrict` is `true`, binding is restricted t
 """
 function addprocs(np::Integer; restrict=true, kwargs...)
     manager = LocalManager(np, restrict)
-    check_addprocs_args(kwargs)
+    check_addprocs_args(manager, kwargs)
     addprocs(manager; kwargs...)
 end
 

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -137,7 +137,7 @@ This timeout can be controlled via environment variable `JULIA_WORKER_TIMEOUT`.
 The value of `JULIA_WORKER_TIMEOUT` on the master process specifies the number of seconds a
 newly launched worker waits for connection establishment.
 """
-function addprocs(machines::AbstractVector; , kwargs...)
+function addprocs(machines::AbstractVector; kwargs...)
     manager = SSHManager(machines)
     check_addprocs_args(manager, kwargs)
     addprocs(manager; kwargs...)


### PR DESCRIPTION
I made this change to allow the set to be expanded for my own package, but I noticed this also helps unify #38353 and existing ssh-only options.