### PR TITLE
Fix `setindex!` docstring in abstractarray.jl to match array.jl:

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1239,7 +1239,7 @@ _unsafe_ind2sub(sz, i) = (@_inline_meta; _ind2sub(sz, i))
     A[inds...] = X
 
 Store values from array `X` within some subset of `A` as specified by `inds`.
-The syntax `A[inds...] = X` is equivalent to `setindex!(A, X, inds...)`.
+The syntax `A[inds...] = X` is equivalent to `(setindex!(A, X, inds...); X)`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Fix `setindex!` docstring to match array.jl:
https://github.com/JuliaLang/julia/blob/f8b9a52e23270990801a58015a4e6586e27d8a47/base/array.jl#L820-L821