### PR TITLE
Support recursive struct in llvm-remove-addrspaces

### DIFF
--- a/test/llvmpasses/remove-addrspaces.ll
+++ b/test/llvmpasses/remove-addrspaces.ll
@@ -41,3 +41,63 @@ top:
   store i64 %0, i64 addrspace(13)* %4, align 8
   ret {} addrspace(10)* %1
 }
+
+; COM: A type used for testing that remove-addrspaces can handle recursive types.
+%list = type { i64, %list* }
+
+; COM: There's nothing to remove in this function; but remove-addrspaces shouldn't crash.
+define i64 @sum.linked.list() #0 {
+; CHECK-LABEL: @sum.linked.list
+top:
+  %a = alloca %list
+  %b = alloca %list
+  %c = alloca %list
+  %a.car = getelementptr %list, %list* %a, i32 0, i32 0
+  %a.cdr = getelementptr %list, %list* %a, i32 0, i32 1
+  %b.car = getelementptr %list, %list* %b, i32 0, i32 0
+  %b.cdr = getelementptr %list, %list* %b, i32 0, i32 1
+  %c.car = getelementptr %list, %list* %c, i32 0, i32 0
+  %c.cdr = getelementptr %list, %list* %c, i32 0, i32 1
+; COM: Allow remove-addrspaces to rename the type but expect it to use the same prefix.
+; CHECK: getelementptr %list
+; CHECK-SAME: %list
+; CHECK-SAME: * %a
+; CHECK: getelementptr %list
+; CHECK-SAME: %list
+; CHECK-SAME: * %a
+; CHECK: getelementptr %list
+; CHECK-SAME: %list
+; CHECK-SAME: * %b
+; CHECK: getelementptr %list
+; CHECK-SAME: %list
+; CHECK-SAME: * %b
+; CHECK: getelementptr %list
+; CHECK-SAME: %list
+; CHECK-SAME: * %c
+; CHECK: getelementptr %list
+; CHECK-SAME: %list
+; CHECK-SAME: * %c
+  store i64 111, i64* %a.car
+  store i64 222, i64* %b.car
+  store i64 333, i64* %c.car
+  store %list* %b, %list** %a.cdr
+  store %list* %c, %list** %b.cdr
+  store %list* null, %list** %c.cdr
+  br label %loop
+
+loop:
+  %x = phi %list* [ %a, %top ], [ %x.cdr.value, %loop ]
+  %sum.prev = phi i64 [ 0, %top ], [ %sum, %loop ]
+  %x.car = getelementptr %list, %list* %x, i32 0, i32 0
+  %x.cdr = getelementptr %list, %list* %x, i32 0, i32 1
+  %x.car.value = load i64, i64* %x.car
+  %x.cdr.value = load %list*, %list** %x.cdr
+  %sum = add i64 %sum.prev, %x.car.value
+  %null.int = ptrtoint %list* null to i64
+  %x.cdr.value.int = ptrtoint %list* %x.cdr.value to i64
+  %cond = icmp eq i64 %x.cdr.value.int, %null.int
+  br i1 %cond, label %exit, label %loop
+
+exit:
+  ret i64 %sum
+}


### PR DESCRIPTION
Currently, remove-addrspaces pass crashes with a StackOverflowError when trying to process recursively defined LLVM structs:

```julia
function llvm_linked_list()
    Base.llvmcall((
        """
        %list = type { i64, %list* }

        define i64 @entry() #0 {
        top:
            %a = alloca %list
            %b = alloca %list
            %c = alloca %list
            %a.car = getelementptr %list, %list* %a, i32 0, i32 0
            %a.cdr = getelementptr %list, %list* %a, i32 0, i32 1
            %b.car = getelementptr %list, %list* %b, i32 0, i32 0
            %b.cdr = getelementptr %list, %list* %b, i32 0, i32 1
            %c.car = getelementptr %list, %list* %c, i32 0, i32 0
            %c.cdr = getelementptr %list, %list* %c, i32 0, i32 1
            store i64 111, i64* %a.car
            store i64 222, i64* %b.car
            store i64 333, i64* %c.car
            store %list* %b, %list** %a.cdr
            store %list* %c, %list** %b.cdr
            store %list* null, %list** %c.cdr
            br label %loop

        loop:
            %x = phi %list* [ %a, %top ], [ %x.cdr.value, %loop ]
            %sum.prev = phi i64 [ 0, %top ], [ %sum, %loop ]
            %x.car = getelementptr %list, %list* %x, i32 0, i32 0
            %x.cdr = getelementptr %list, %list* %x, i32 0, i32 1
            %x.car.value = load i64, i64* %x.car
            %x.cdr.value = load %list*, %list** %x.cdr
            %sum = add i64 %sum.prev, %x.car.value
            %null.int = ptrtoint %list* null to i64
            %x.cdr.value.int = ptrtoint %list* %x.cdr.value to i64
            %cond = icmp eq i64 %x.cdr.value.int, %null.int
            br i1 %cond, label %exit, label %loop

        exit:
            ret i64 %sum
        }
        """,
        "entry",
    ), Int64, Tuple{})
end

@show llvm_linked_list()  # works

using InteractiveUtils
@code_llvm dump_module=true optimize=false raw=true llvm_linked_list()  # works
@code_llvm dump_module=true optimize=false llvm_linked_list()  # crash
```

To make it work, I tweaked `AddrspaceRemoveTypeRemapper::remapType`. It now creates an opaque struct, cache it into `MappedTypes` before recursing into the fields, and then finalize constructing the struct (i.e., `setBody`) after the recursion.

With this approach, I think we need to create a different branch for mapping a literal struct as a literal struct which requires the body to exist at the construction time.
