### PR TITLE
Unicode-compliant islower/uppercase

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ New library features
 Standard library changes
 ------------------------
 
+* `islowercase` and `isuppercase` are now compliant with the Unicode lower/uppercase categories ([#38574]).
 
 #### Package Manager
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -280,9 +280,8 @@ isassigned(c) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
 """
     islowercase(c::AbstractChar) -> Bool
 
-Tests whether a character is a lowercase letter.
-A character is classified as lowercase if it belongs to Unicode category Ll,
-Letter: Lowercase.
+Tests whether a character is a lowercase letter (according to the Unicode
+standard's `Lowercase` derived property).
 
 See also: [`isuppercase`](@ref).
 
@@ -298,16 +297,15 @@ julia> islowercase('❤')
 false
 ```
 """
-islowercase(c::AbstractChar) = category_code(c) == UTF8PROC_CATEGORY_LL
+islowercase(c::AbstractChar) = ismalformed(c) ? false : Bool(ccall(:utf8proc_islower, Cint, (UInt32,), UInt32(c)))
 
 # true for Unicode upper and mixed case
 
 """
     isuppercase(c::AbstractChar) -> Bool
 
-Tests whether a character is an uppercase letter.
-A character is classified as uppercase if it belongs to Unicode category Lu,
-Letter: Uppercase, or Lt, Letter: Titlecase.
+Tests whether a character is an uppercase letter (according to the Unicode
+standard's `Uppercase` derived property).
 
 See also: [`islowercase`](@ref).
 
@@ -323,10 +321,7 @@ julia> isuppercase('❤')
 false
 ```
 """
-function isuppercase(c::AbstractChar)
-    cat = category_code(c)
-    cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LT
-end
+isuppercase(c::AbstractChar) = ismalformed(c) ? false : Bool(ccall(:utf8proc_isupper, Cint, (UInt32,), UInt32(c)))
 
 """
     iscased(c::AbstractChar) -> Bool

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -92,7 +92,7 @@ end
 
 @testset "#5939 uft8proc character predicates" begin
     alower=['a', 'd', 'j', 'y', 'z']
-    ulower=['α', 'β', 'γ', 'δ', 'ф', 'я']
+    ulower=['α', 'β', 'γ', 'δ', 'ф', 'я', 'ª']
     for c in vcat(alower,ulower)
         @test islowercase(c) == true
         @test isuppercase(c) == false
@@ -101,7 +101,7 @@ end
     end
 
     aupper=['A', 'D', 'J', 'Y', 'Z']
-    uupper= ['Δ', 'Γ', 'Π', 'Ψ', 'ǅ', 'Ж', 'Д']
+    uupper= ['Δ', 'Γ', 'Π', 'Ψ', 'Ж', 'Д', 'Ⓐ']
 
     for c in vcat(aupper,uupper)
         @test islowercase(c) == false
@@ -109,6 +109,9 @@ end
         @test isdigit(c) == false
         @test isnumeric(c) == false
     end
+
+    @test !isuppercase('ǅ') # titlecase is not uppercase
+    @test Base.Unicode.iscased('ǅ') # but is "cased"
 
     nocase=['א','ﺵ']
     alphas=vcat(alower,ulower,aupper,uupper,nocase)

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -92,8 +92,8 @@ end
 
 @testset "#5939 uft8proc character predicates" begin
     alower=['a', 'd', 'j', 'y', 'z']
-    ulower=['α', 'β', 'γ', 'δ', 'ф', 'я', 'ª']
-    for c in vcat(alower,ulower)
+    ulower=['α', 'β', 'γ', 'δ', 'ф', 'я']
+    for c in vcat(alower,ulower,['ª'])
         @test islowercase(c) == true
         @test isuppercase(c) == false
         @test isdigit(c) == false
@@ -101,9 +101,9 @@ end
     end
 
     aupper=['A', 'D', 'J', 'Y', 'Z']
-    uupper= ['Δ', 'Γ', 'Π', 'Ψ', 'Ж', 'Д', 'Ⓐ']
+    uupper= ['Δ', 'Γ', 'Π', 'Ψ', 'Ж', 'Д']
 
-    for c in vcat(aupper,uupper)
+    for c in vcat(aupper,uupper,['Ⓐ'])
         @test islowercase(c) == false
         @test isuppercase(c) == true
         @test isdigit(c) == false

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -114,7 +114,7 @@ end
     @test Base.Unicode.iscased('ǅ') # but is "cased"
 
     nocase=['א','ﺵ']
-    alphas=vcat(alower,ulower,aupper,uupper,nocase)
+    alphas=vcat(alower,ulower,aupper,uupper,nocase,['ǅ'])
 
     for c in alphas
         @test isletter(c) == true


### PR DESCRIPTION
Closes #36618, using the new `utf8proc_islower` and `utf8proc_isupper` functions from utf8proc 2.6 (which we upgraded to in #38551).

Technically breaking, but I'm not sure who would be relying on the slight differences between the old behavior and the Unicode standard definitions?