### PR TITLE
titlecase(::String) should not break words inside graphemes

### DIFF
--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -385,6 +385,7 @@ end
         @test titlecase("abc-def")                     == "Abc-Def"
         @test titlecase("abc-def", wordsep = !Base.Unicode.iscased) == "Abc-Def"
         @test titlecase("abc-def", wordsep = isspace)  == "Abc-def"
+        @test titlecase("bôrked") == "Bôrked"
     end
 end
 


### PR DESCRIPTION
As mentioned in https://github.com/JuliaLang/julia/pull/38574#issuecomment-733458328, at the very least we should not consider characters in the middle of graphemes to be word separators — this PR fixes `titlecase(::String)` to give `titlecase("bôrked") == "Bôrked"` instead of `"BôRked"`.

Also, the documentation said that the default word separator is any "non-letter" character, but actually it was `!iscased`.  I see no reason to not actually use `!isletter` here.

In the future, it would be better to follow the [Unicode standard for word boundaries](https://unicode.org/reports/tr29/#Word_Boundaries), and ideally have a "word" iterator much like our current grapheme iterator, but this requires support from utf8proc (https://github.com/JuliaStrings/utf8proc/issues/208).  But the behavior in this PR is at least closer to the standard.

This is technically not backward compatible, but I think it is unlikely to be a problem — the old behavior seems more like a bug to me.

cc @rfourquet, who last touched this function in #23393.