### PR TITLE
Disarm watchdog timer at the end of the Sockets test

### DIFF
--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -21,7 +21,7 @@ function killjob(d)
     ccall(:uv_kill, Cint, (Cint, Cint), getpid(), Base.SIGTERM)
     nothing
 end
-Timer(t -> killjob("KILLING BY SOCKETS TEST WATCHDOG\n"), 600)
+sockets_watchdog_timer = Timer(t -> killjob("KILLING BY SOCKETS TEST WATCHDOG\n"), 600)
 
 @testset "parsing" begin
     @test ip"127.0.0.1" == IPv4(127,0,0,1)
@@ -617,3 +617,6 @@ end
         end
     end
 end
+
+
+close(sockets_watchdog_timer)


### PR DESCRIPTION
The Sockets test sets up a time bomb to go off after 10 minutes
(intended to give a backtrace if the Sockets test hangs), but
never disarms it, so it often just blows up whatever hapless
test happens to come after it.