### PR TITLE
Add curl to Debian dependency line

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -160,7 +160,7 @@ Building Julia requires that the following software be installed:
 
 On Debian-based distributions (e.g. Ubuntu), you can easily install them with `apt-get`:
 ```
-sudo apt-get install build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config
+sudo apt-get install build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config curl
 ```
 
 Julia uses the following external libraries, which are automatically


### PR DESCRIPTION
LibCURL requires curl for its tests, and it's not installed by default on Ubuntu systems.

Fixes
```julia
Error in testset LibCURL:
Error During Test at /home/tim/src/julia-branch/usr/share/julia/stdlib/v1.6/LibCURL/test/runtests.jl:43
  Got exception outside of a @test
  IOError: could not spawn `curl -s -S -g -L -f -o /tmp/jl_4rWW3e/README.md https://github.com/JuliaWeb/LibCURL.jl/blob/master/README.md`: no such file or directory (ENOENT)
  Stacktrace:
    [1] _spawn_primitive(file::String, cmd::Cmd, stdio::Vector{Any})
      @ Base ./process.jl:99
...
```