### PR TITLE
Allow ANSI escape codes in precompile test stacktrace

### DIFF
--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -478,7 +478,7 @@ precompile_test_harness(false) do dir
           error("break me")
           end
           """)
-    @test_warn "LoadError: break me\nStacktrace:\n [1] error" try
+    @test_warn r"LoadError: break me\nStacktrace:\n \[1\] [\e01m\[]*error" try
             Base.require(Main, :FooBar2)
             error("the \"break me\" test failed")
         catch exc


### PR DESCRIPTION
This test was failing when run locally (depends on display).
Similar to #36858.