### PR TITLE
Add pretty-printing for inference timing

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -999,6 +999,33 @@ function show(io::IO, l::Core.MethodInstance)
     end
 end
 
+# These sometimes show up as Const-values in InferenceFrameInfo signatures
+show(io::IO, r::Core.Compiler.UnitRange) = show(io, r.start : r.stop)
+show(io::IO, mime::MIME{Symbol("text/plain")}, r::Core.Compiler.UnitRange) = show(io, mime, r.start : r.stop)
+
+function show(io::IO, mi_info::Core.Compiler.Timings.InferenceFrameInfo)
+    mi = mi_info.mi
+    def = mi.def
+    if isa(def, Method)
+        if isdefined(def, :generator) && mi === def.generator
+            print(io, "InferenceFrameInfo generator for ")
+            show(io, def)
+        else
+            print(io, "InferenceFrameInfo for ")
+            argnames = [isa(a, Core.Const) ? (isa(a.val, Type) ? "" : a.val) : "" for a in mi_info.slottypes[1:mi_info.nargs]]
+            show_tuple_as_call(io, def.name, mi.specTypes, false, nothing, argnames, true)
+        end
+    else
+        linetable = mi.uninferred.linetable
+        line = isempty(linetable) ? "" : (lt = linetable[1]; string(lt.file) * ':' * string(lt.line))
+        print(io, "Toplevel InferenceFrameInfo thunk from ", def, " starting at ", line)
+    end
+end
+
+function show(io::IO, tinf::Core.Compiler.Timings.Timing)
+    print(io, "Core.Compiler.Timings.Timing(", tinf.mi_info, ") with ", length(tinf.children), " children")
+end
+
 function show_delim_array(io::IO, itr::Union{AbstractArray,SimpleVector}, op, delim, cl,
                           delim_one, i1=first(LinearIndices(itr)), l=last(LinearIndices(itr)))
     print(io, op)
@@ -2103,11 +2130,14 @@ end
 
 # show the called object in a signature, given its type `ft`
 # `io` should contain the UnionAll env of the signature
-function show_signature_function(io::IO, @nospecialize(ft), demangle=false, fargname="", html=false)
+function show_signature_function(io::IO, @nospecialize(ft), demangle=false, fargname="", html=false, qualified=false)
     uw = unwrap_unionall(ft)
     if ft <: Function && isa(uw, DataType) && isempty(uw.parameters) &&
         isdefined(uw.name.module, uw.name.mt.name) &&
         ft == typeof(getfield(uw.name.module, uw.name.mt.name))
+        if qualified && !is_exported_from_stdlib(uw.name.mt.name, uw.name.module) && uw.name.module !== Main
+            print_within_stacktrace(io, uw.name.module, '.', bold=true)
+        end
         s = sprint(show_sym, (demangle ? demangle_function_name : identity)(uw.name.mt.name), context=io)
         print_within_stacktrace(io, s, bold=true)
     elseif isa(ft, DataType) && ft.name === Type.body.name &&
@@ -2135,7 +2165,7 @@ function print_within_stacktrace(io, s...; color=:normal, bold=false)
     end
 end
 
-function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing, argnames=nothing)
+function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing, argnames=nothing, qualified=false)
     # print a method signature tuple for a lambda definition
     if sig === Tuple
         print(io, demangle ? demangle_function_name(name) : name, "(...)")
@@ -2149,7 +2179,7 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type, demangle=false, kwa
         sig = sig.body
     end
     sig = (sig::DataType).parameters
-    show_signature_function(env_io, sig[1], demangle)
+    show_signature_function(env_io, sig[1], demangle, "", false, qualified)
     first = true
     print_within_stacktrace(io, "(", bold=true)
     show_argnames = argnames !== nothing && length(argnames) == length(sig)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2879,6 +2879,7 @@ end
     timing1 = time_inference() do
         @eval M.g(2, 3.0)
     end
+    @test occursin(r"Core.Compiler.Timings.Timing\(InferenceFrameInfo for Core.Compiler.Timings.ROOT\(\)\) with \d+ children", sprint(show, timing1))
     # The last two functions to be inferred should be `i` and `i2`, inferred at runtime with
     # their concrete types.
     @test sort([mi_info.mi.def.name for (time,mi_info) in flatten_times(timing1)[end-1:end]]) == [:i, :i2]
@@ -2889,6 +2890,23 @@ end
         @eval M.g(2, 3.0)
     end
     @test length(flatten_times(timing2)) < length(flatten_times(timing1))
+    # Printing of InferenceFrameInfo for mi.def isa Module
+    @eval module M
+        i(x) = x+5
+        i2(x) = x+2
+        h(a::Array) = i2(a[1]::Integer) + i(a[1]::Integer) + 2
+        g(y::Integer, x) = h(Any[y]) + Int(x)
+    end
+    # BEGIN LINE NUMBER SENSITIVITY (adjust the line offset below as needed)
+    timingmod = time_inference() do
+        @eval @testset "Outer" begin
+            @testset "Inner" begin
+                for i = 1:2 M.g(2, 3.0) end
+            end
+        end
+    end
+    @test occursin("thunk from $(@__MODULE__) starting at $(@__FILE__):$((@__LINE__) - 5)", string(timingmod.children))
+    # END LINE NUMBER SENSITIVITY
 
     # Recursive function
     @eval module _Recursive f(n::Integer) = n == 0 ? 0 : f(n-1) + 1 end
@@ -2903,12 +2921,38 @@ end
         i(x) = x === 0 ? 0 : 1 / x
         a(x) = i(0) * i(x)
         b() = i(0) * i(1) * i(0)
+        function loopc(n)
+            s = 0
+            for i = 1:n
+                s += i
+            end
+            return s
+        end
+        call_loopc() = loopc(5)
+        myfloor(::Type{T}, x) where T = floor(T, x)
+        d(x) = myfloor(Int16, x)
     end
     timing = time_inference() do
         @eval C.a(2)
         @eval C.b()
+        @eval C.call_loopc()
+        @eval C.d(3.2)
     end
-    @test !isempty(flatten_times(timing))
+    ft = flatten_times(timing)
+    @test !isempty(ft)
+    str = sprint(show, ft)
+    @test occursin("InferenceFrameInfo for /(1::$Int, ::$Int)", str)  # inference constants
+    @test occursin("InferenceFrameInfo for Core.Compiler.Timings.ROOT()", str) # qualified
+    # loopc has internal slots, check constant printing in this case
+    sel = filter(ti -> ti.second.mi.def.name === :loopc, ft)
+    ifi = sel[end].second
+    @test length(ifi.slottypes) > ifi.nargs
+    str = sprint(show, sel)
+    @test occursin("InferenceFrameInfo for $(@__MODULE__).C.loopc(5::$Int)", str)
+    # check that types aren't double-printed as `T::Type{T}`
+    sel = filter(ti -> ti.second.mi.def.name === :myfloor, ft)
+    str = sprint(show, sel)
+    @test occursin("InferenceFrameInfo for $(@__MODULE__).C.myfloor(::Type{Int16}, ::Float64)", str)
 end
 
 # issue #37638
@@ -2919,4 +2963,3 @@ f37943(x::Any, i::Int) = getfield((x::Pair{false, Int}), i)
 g37943(i::Int) = fieldtype(Pair{false, T} where T, i)
 @test only(Base.return_types(f37943, Tuple{Any, Int})) === Union{}
 @test only(Base.return_types(g37943, Tuple{Int})) === Union{Type{Union{}}, Type{Any}}
-


### PR DESCRIPTION
This adds pretty-printing for `Core.Compiler.Timings` objects. Let's see this in action.

Old printing:

```julia
julia> x = (0x01, Float16(1))
(0x01, Float16(1.0))

julia> 2x[1]+2x[2]         # warmup
Float16(4.0)

julia> using SnoopCompile  # currently you have to `dev` both SnoopCompile and SnoopCompileCore

julia> twice(x) = 2x
twice (generic function with 1 method)

julia> f(x) = twice(x[1]) + twice(x[2])
f (generic function with 1 method)

julia> tinf = @snoopi_deep f(x)  # note LOOONG output line
Core.Compiler.Timings.Timing(Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for ROOT(), 0x0000000000000000, Any[], Any[Core.Const(Core.Compiler.Timings.ROOT)], 1, false), 0x000dc0b9fbccf869, 0x000dc0b9fbd473de, 0x00000000007b65e2, Core.Compiler.Timings.Timing[Core.Compiler.Timings.Timing(Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for f(::Tuple{UInt8, Float16}), 0x000000000000732d, Any[], Any[Core.Const(f), Tuple{UInt8, Float16}], 2, false), 0x000dc0b9fbcdd021, 0x000dc0b9fbd18730, 0x0000000000029799, Core.Compiler.Timings.Timing[Core.Compiler.Timings.Timing(Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for getindex(::Tuple{UInt8, Float16}, ::Int64), 0x000000000000732d, Any[], Any[Core.Const(getindex), Tuple{UInt8, Float16}, Core.Const(1)], 3, true), 0x000dc0b9fbce23d8, 0x000dc0b9fbce23d8, 0x00000000000099ba, Core.Compiler.Timings.Timing[], nothing), Core.Compiler.Timings.Timing(Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for twice(::UInt8), 0x000000000000732d, Any[], Any[Core.Const(twice), UInt8], 2, false), 0x000dc0b9fbcefdb7, 0x000dc0b9fbcefdb7, 0x000000000000ecbd, Core.Compiler.Timings.Timing[], nothing), Core.Compiler.Timings.Timing(Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for getindex(::Tuple{UInt8, Float16}, ::Int64), 0x000000000000732d, Any[], Any[Core.Const(getindex), Tuple{UInt8, Float16}, Core.Const(2)], 3, true), 0x000dc0b9fbd011a1, 0x000dc0b9fbd011a1, 0x000000000000788a, Core.Compiler.Timings.Timing[], nothing), Core.Compiler.Timings.Timing(Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for twice(::Float16), 0x000000000000732d, Any[], Any[Core.Const(twice), Float16], 2, false), 0x000dc0b9fbd0b325, 0x000dc0b9fbd0b325, 0x000000000000d374, Core.Compiler.Timings.Timing[], nothing)], Union{Ptr{Nothing}, Core.Compiler.InterpreterIP}[Ptr{Nothing} @0x00007fe9fd5f6fca, Ptr{Nothing} @0x00007fe9fd6176e8, Ptr{Nothing} @0x00007fe9fd3cf2af, Ptr{Nothing} @0x00007fe9fd3cf6a1, Ptr{Nothing} @0x00007fe9fd3cf6df, Ptr{Nothing} @0x00007fea0af8751b, Ptr{Nothing} @0x00007fea0af87f83, Ptr{Nothing} @0x00007fea0b00c314, Ptr{Nothing} @0x00007fea0af850bc, Ptr{Nothing} @0x00007fea0af875e1  …  Ptr{Nothing} @0x00007fe9fd2f6ea8, Ptr{Nothing} @0x00007fe9fd307b01, Ptr{Nothing} @0x00007fe9fd3085d1, Ptr{Nothing} @0x00007fe9fd308745, Ptr{Nothing} @0x00007fea0af8751b, Ptr{Nothing} @0x00007fea0afe3ae4, Ptr{Nothing} @0x00007fea0afe44ba, Ptr{Nothing} @0x0000563744f26c6e, Ptr{Nothing} @0x00007fea0baf2bf6, Ptr{Nothing} @0x0000563744f26ca9])], nothing)

julia> flatten_times(tinf)
6-element Vector{Pair{Float64, Core.Compiler.Timings.InferenceFrameInfo}}:
   3.0858e-5 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for getindex(::Tuple{UInt8, Float16}, ::Int64), 0x000000000000732d, Any[], Any[Core.Const(getindex), Tuple{UInt8, Float16}, Core.Const(2)], 3, true)
   3.9354e-5 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for getindex(::Tuple{UInt8, Float16}, ::Int64), 0x000000000000732d, Any[], Any[Core.Const(getindex), Tuple{UInt8, Float16}, Core.Const(1)], 3, true)
   5.4132e-5 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for twice(::Float16), 0x000000000000732d, Any[], Any[Core.Const(twice), Float16], 2, false)
   6.0605e-5 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for twice(::UInt8), 0x000000000000732d, Any[], Any[Core.Const(twice), UInt8], 2, false)
 0.000169881 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for f(::Tuple{UInt8, Float16}), 0x000000000000732d, Any[], Any[Core.Const(f), Tuple{UInt8, Float16}], 2, false)
  0.00808701 => Core.Compiler.Timings.InferenceFrameInfo(MethodInstance for ROOT(), 0x0000000000000000, Any[], Any[Core.Const(Core.Compiler.Timings.ROOT)], 1, false)
```

With the new printing:
```julia
julia> Revise.track(Base)

julia> tinf
Core.Compiler.Timings.Timing(InferenceFrameInfo for Core.Compiler.Timings.ROOT()) with 1 children

julia> tinf.children
1-element Vector{Core.Compiler.Timings.Timing}:
 Core.Compiler.Timings.Timing(InferenceFrameInfo for f(::Tuple{UInt8, Float16})) with 4 children
```
Much shorter, but note that the unqualified `ROOT()` has become `Core.Compiler.Timings.ROOT()` to help people find the method. If you do want to see the whole thing at once, you can get that with https://github.com/JuliaCollections/AbstractTrees.jl/pull/65.

Also:
```julia
julia> flatten_times(tinf)
6-element Vector{Pair{Float64, Core.Compiler.Timings.InferenceFrameInfo}}:
   3.0858e-5 => InferenceFrameInfo for getindex(::Tuple{UInt8, Float16}, 2::Int64)
   3.9354e-5 => InferenceFrameInfo for getindex(::Tuple{UInt8, Float16}, 1::Int64)
   5.4132e-5 => InferenceFrameInfo for twice(::Float16)
   6.0605e-5 => InferenceFrameInfo for twice(::UInt8)
 0.000169881 => InferenceFrameInfo for f(::Tuple{UInt8, Float16})
  0.00808701 => InferenceFrameInfo for Core.Compiler.Timings.ROOT()
```
A key feature to notice here is that the `Core.Const` values are integrated into the signature: ` getindex(::Tuple{UInt8, Float16}, 2::Int64)` means that we inferred `x[2]` where `x::Tuple{UInt8, Float16}`.

Review requested from @NHDaly.

EDIT: the original version made changes to MethodInstance printing. I'll submit that separately.