### PR TITLE
Qualify function when printing MethodInstance

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -999,7 +999,7 @@ function show_mi(io::IO, l::Core.MethodInstance, from_stackframe::Bool=false)
     else
         print(io, "Toplevel MethodInstance thunk")
         # `thunk` is not very much information to go on. If this
-        # MethodInstance is part of a stacktrace, it get location info
+        # MethodInstance is part of a stacktrace, it gets location info
         # added by other means.  But if it isn't, then we should try
         # to print a little more identifying information.
         if !from_stackframe

--- a/base/show.jl
+++ b/base/show.jl
@@ -984,7 +984,9 @@ function sourceinfo_slotnames(src::CodeInfo)
     return printnames
 end
 
-function show(io::IO, l::Core.MethodInstance)
+show(io::IO, l::Core.MethodInstance) = show_mi(io, l)
+
+function show_mi(io::IO, l::Core.MethodInstance, from_stackframe::Bool=false)
     def = l.def
     if isa(def, Method)
         if isdefined(def, :generator) && l === def.generator
@@ -992,10 +994,19 @@ function show(io::IO, l::Core.MethodInstance)
             show(io, def)
         else
             print(io, "MethodInstance for ")
-            show_tuple_as_call(io, def.name, l.specTypes)
+            show_tuple_as_call(io, def.name, l.specTypes, false, nothing, nothing, true)
         end
     else
         print(io, "Toplevel MethodInstance thunk")
+        # `thunk` is not very much information to go on. If this
+        # MethodInstance is part of a stacktrace, it get location info
+        # added by other means.  But if it isn't, then we should try
+        # to print a little more identifying information.
+        if !from_stackframe
+            linetable = l.uninferred.linetable
+            line = isempty(linetable) ? "unknown" : (lt = linetable[1]; string(lt.file) * ':' * string(lt.line))
+            print(io, " from ", def, " starting at ", line)
+        end
     end
 end
 

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -241,7 +241,7 @@ function show_spec_linfo(io::IO, frame::StackFrame)
                 Base.show_tuple_as_call(io, def.name, sig, true, nothing, argnames)
             end
         else
-            Base.show(io, linfo)
+            Base.show_mi(io, linfo, true)
         end
     elseif linfo isa CodeInfo
         print(io, "top-level scope")

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -254,7 +254,7 @@ let code = """
     """
 
     bt_str = read(`$(Base.julia_cmd()) --startup-file=no --compile=min -e $code`, String)
-    @test occursin("InterpreterIP in MethodInstance for foo", bt_str)
+    @test occursin(r"InterpreterIP in MethodInstance for .*A\.foo", bt_str)
     @test occursin("InterpreterIP in top-level CodeInfo for Main.A", bt_str)
 end
 


### PR DESCRIPTION
Also print more info for the case `l.def::Module`.

The module qualification builds off #38596. I've wanted the module-qualifier for a long time, but I recognize it might be bad to add it so close to a release. If desired we can wait until 1.7.

