### PR TITLE
improve inferrability of `peek(::Stateful, sentinel)`

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1296,7 +1296,10 @@ convert(::Type{Stateful}, itr) = Stateful(itr)
     end
 end
 
-@inline peek(s::Stateful, sentinel=nothing) = s.nextvalstate !== nothing ? s.nextvalstate[1] : sentinel
+@inline function peek(s::Stateful, sentinel=nothing)
+    ns = s.nextvalstate
+    return ns !== nothing ? ns[1] : sentinel
+end
 @inline iterate(s::Stateful, state=nothing) = s.nextvalstate === nothing ? nothing : (popfirst!(s), nothing)
 IteratorSize(::Type{Stateful{T,VS}}) where {T,VS} = IteratorSize(T) isa HasShape ? HasLength() : IteratorSize(T)
 eltype(::Type{Stateful{T, VS}} where VS) where {T} = eltype(T)


### PR DESCRIPTION
the current inference can't propagate constant values or `isa` 
condition of  object fields, and this helps inference eliminate the 
possibility of `getindex(s.nextvalstate::Nothing, 1)` call