### PR TITLE
Properly handle move up zero lines in TerminalMenus.

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -322,7 +322,14 @@ function printmenu(out::IO, m::AbstractMenu, cursoridx::Int; oldstate=nothing, i
         # like clamp, except this takes the min if max < min
         m.pageoffset = max(0, min(cursoridx - m.pagesize ÷ 2, lastoption - m.pagesize))
     else
-        print(buf, "\x1b[999D\x1b[$(ncleared)A")   # move left 999 spaces and up `ncleared` lines
+        print(buf, "\r")
+        if ncleared > 0
+            # Move up `ncleared` lines. However, moving up zero lines
+            # is interpreted as one line, so need to do this
+            # conditionally. (More specifically, the `0` value means
+            # to use the default, and for move up this is one.)
+            print(buf, "\x1b[$(ncleared)A")
+        end
     end
 
     nheaderlines = 0
@@ -354,7 +361,7 @@ function printmenu(out::IO, m::AbstractMenu, cursoridx::Int; oldstate=nothing, i
         printcursor(buf, m, i == cursoridx)
         writeline(buf, m, i, i == cursoridx)
 
-        (firstline == lastline || i != lastline) && print(buf, "\r\n")
+        (i != lastline) && print(buf, "\r\n")
     end
 
     newstate = nheaderlines + lastline - firstline  # final line doesn't have `\n`


### PR DESCRIPTION
Cc @timholy 

Unfortunately #38489 wasn't quite correct in the case of a one element menu and at least one header line, as can be seen by running
```
using REPL.TerminalMenus
request(MultiSelectMenu(["1"]))
```
This was quite mysterious until I realized that the current implementation relies on the corner case that `"\x1b[0A"` ("move up zero lines") actually moves up one line. In fact the `0` parameter means to use the default value, which for cursor up is one, see https://vt100.net/docs/vt510-rm/chapter4.html, section 4.3.3.

This PR fixes moving up zero lines by conditionally doing nothing and removes a workaround related to this corner case. As an effect a one element menu is now drawn without a dummy empty line below it. This is not a regression from Julia 1.5, where a one element menu was an error.

Additionally I replaced the `"\x1b[999D"` control code ("move left 999 spaces") with a mundane carriage return. As far as I can tell that's the desired result.
