### PR TITLE
improve inferrability of `findall(::Union{AbstractString,AbstractPattern}, ::AbstractString)`

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -417,7 +417,7 @@ function count(t::Union{AbstractString,AbstractPattern}, s::AbstractString; over
     i, e = firstindex(s), lastindex(s)
     while true
         r = findnext(t, s, i)
-        isnothing(r) && break
+        r === nothing && break
         n += 1
         j = overlap || isempty(r) ? first(r) : last(r)
         j > e && break

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -387,7 +387,7 @@ function findall(t::Union{AbstractString,AbstractPattern}, s::AbstractString; ov
     i, e = firstindex(s), lastindex(s)
     while true
         r = findnext(t, s, i)
-        isnothing(r) && break
+        r === nothing && break
         push!(found, r)
         j = overlap || isempty(r) ? first(r) : last(r)
         j > e && break


### PR DESCRIPTION
eliminates succeeding possibilities:
```julia
┌ @ regex.jl:386 Base.#findall#393(overlap, _3, t, s)
│┌ @ regex.jl:391 Base.push!(found, r)
││┌ @ array.jl:914 Base.convert(_, item)
│││ no matching method found for call signature: Base.convert(_::Type{UnitRange{Int64}}, item::Nothing)
││└────────────────
│┌ @ regex.jl:392 Base.isempty(r)
││┌ @ essentials.jl:768 Base.iterate(itr)
│││ no matching method found for call signature: Base.iterate(itr::Nothing)
││└─────────────────────
│┌ @ regex.jl:392 Base.first(r)
││┌ @ abstractarray.jl:386 Base.iterate(itr)
│││ no matching method found for call signature: Base.iterate(itr::Nothing)
││└────────────────────────
│┌ @ regex.jl:392 Base.last(r)
││┌ @ abstractarray.jl:434 Base.lastindex(a)
│││ no matching method found for call signature: Base.lastindex(a::Nothing)
││└────────────────────────
```

(underlying issue is https://github.com/JuliaLang/julia/issues/37342 though)