### PR TITLE
Add imaging_mode to jl_create_native

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7515,7 +7515,7 @@ void jl_compile_workqueue(
             else {
                 // Reinfer the function. The JIT came along and removed the inferred
                 // method body. See #34993
-                if (policy == CompilationPolicy::Extern &&
+                if (policy != CompilationPolicy::Default &&
                     codeinst->inferred && codeinst->inferred == jl_nothing) {
                     src = jl_type_infer(codeinst->def, jl_world_counter, 0);
                     if (src)

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -100,7 +100,8 @@ jl_compile_result_t jl_emit_codeinst(
 
 enum CompilationPolicy {
     Default = 0,
-    Extern = 1
+    Extern = 1,
+    ImagingMode = 2
 };
 
 void jl_compile_workqueue(


### PR DESCRIPTION
Lets `_policy==2` to enable imaging mode. This is possibly not thread-safe, but it works fine single-threaded.

Needs tests and proof that it does something useful that `_policy==1` doesn't.

@vchuravy 