### PR TITLE
Fix signed integer overflow in `mapreduce_impl`: review required

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -307,11 +307,7 @@ _mapreduce(f, op, ::IndexCartesian, itr::SkipMissing) = mapfoldl(f, op, itr)
 
 function mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer)
     blksize = pairwise_blocksize(f, op)
-    if blksize <= 0
-        error("pairwise_blocksize($f, $op) must be positive")
-    else
-        mapreduce_impl(f, op, A, ifirst, ilast, blksize)
-    end
+    mapreduce_impl(f, op, A, ifirst, ilast, blksize)
 end
 
 # Returns nothing when the input contains only missing values, and Some(x) otherwise

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -305,10 +305,8 @@ end
 
 _mapreduce(f, op, ::IndexCartesian, itr::SkipMissing) = mapfoldl(f, op, itr)
 
-function mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer)
-    blksize = pairwise_blocksize(f, op)
-    mapreduce_impl(f, op, A, ifirst, ilast, blksize)
-end
+mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
+    mapreduce_impl(f, op, A, ifirst, ilast, pairwise_blocksize(f, op))
 
 # Returns nothing when the input contains only missing values, and Some(x) otherwise
 @noinline function mapreduce_impl(f, op, itr::SkipMissing{<:AbstractArray},

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -256,10 +256,8 @@ foldr(op, itr; kw...) = mapfoldr(identity, op, itr; kw...)
     end
 end
 
-function mapreduce_impl(f, op, A::AbstractArrayOrBroadcasted, ifirst::Integer, ilast::Integer)
-    blksize = pairwise_blocksize(f, op)
-    mapreduce_impl(f, op, A, ifirst, ilast, blksize)
-end
+mapreduce_impl(f, op, A::AbstractArrayOrBroadcasted, ifirst::Integer, ilast::Integer) =
+    mapreduce_impl(f, op, A, ifirst, ilast, pairwise_blocksize(f, op))
 
 """
     mapreduce(f, op, itrs...; [init])

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -258,11 +258,7 @@ end
 
 function mapreduce_impl(f, op, A::AbstractArrayOrBroadcasted, ifirst::Integer, ilast::Integer)
     blksize = pairwise_blocksize(f, op)
-    if blksize <= 0
-        error("pairwise_blocksize($f, $op) must be positive")
-    else
-        mapreduce_impl(f, op, A, ifirst, ilast, blksize)
-    end
+    mapreduce_impl(f, op, A, ifirst, ilast, blksize)
 end
 
 """

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -711,9 +711,5 @@ end
 
 function mapreduce_impl(f::F, op::OP, A::AbstractArrayOrBroadcasted, ifirst::SCartesianIndex2, ilast::SCartesianIndex2) where {F,OP}
     blksize = pairwise_blocksize(f, op)
-    if blksize <= 0
-        error("pairwise_blocksize($f, $op) must be positive")
-    else
-        mapreduce_impl(f, op, A, ifirst, ilast, blksize)
-    end
+    mapreduce_impl(f, op, A, ifirst, ilast, blksize)
 end

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -709,7 +709,5 @@ end
     end
 end
 
-function mapreduce_impl(f::F, op::OP, A::AbstractArrayOrBroadcasted, ifirst::SCartesianIndex2, ilast::SCartesianIndex2) where {F,OP}
-    blksize = pairwise_blocksize(f, op)
-    mapreduce_impl(f, op, A, ifirst, ilast, blksize)
-end
+mapreduce_impl(f::F, op::OP, A::AbstractArrayOrBroadcasted, ifirst::SCartesianIndex2, ilast::SCartesianIndex2) where {F,OP} =
+    mapreduce_impl(f, op, A, ifirst, ilast, pairwise_blocksize(f, op))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -646,3 +646,13 @@ end
 
 # issue #39281
 @test @inferred(extrema(rand(2), dims=1)) isa Vector{Tuple{Float64,Float64}}
+
+# issue #38627
+@testset "overflow in mapreduce" begin
+    # at len = 16 and len = 1025 there is a change in codepath
+    for len in [0, 1, 15, 16, 1024, 1025, 2048, 2049]
+        oa = OffsetArray(repeat([1], len), typemax(Int)-len)
+        @test sum(oa) == reduce(+, oa) == len
+        @test mapreduce(+, +, oa, oa) == 2len
+    end
+end


### PR DESCRIPTION
**Warning**: this PR requires review.

---

This PR solves #38627 as regards the code in `reducedim.jl`, `reduce.jl` and `reinterpretarray.jl`. It **does not** solve all the issues with `missing.jl`.

In the code for [`_mapreduce`](https://github.com/FedericoStra/julia/blob/mapreduce/base/missing.jl#L275-L297) and [`mapreduce_impl`](https://github.com/FedericoStra/julia/blob/mapreduce/base/missing.jl#L311-L364) in `missing.jl` there are still several instances of the construct
```julia
while i <= ilast
    ...
    i += 1
end
```

This overflows when `ilast == typemax(Int)`. More seriously, inside the `while` loops there is often `@inbounds A[i]`, which is then an out-of-bounds read!

I'm pretty sure
```julia
while i <= ilast
    @inbounds ai = A[i]
    ai === missing || break
    i += 1
end
```
can be replaced by
```julia
for outer i = i:ilast
    @inbounds ai = A[i]
    ai === missing || break
end
```

But there are still other lines to fix, such as `i > ilast && return nothing`, so I want to think about it a bit more to see if there is a cleaner way to rewrite it altogether.

Also, I have to add tests!