### PR TITLE
Sticky shell REPL mode

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -41,6 +41,7 @@ display([1])
 display([1 2; 3 4])
 @time 1+1
 ; pwd
+$CTRL_C
 ? reinterpret
 using Ra\t$CTRL_C
 \\alpha\t$CTRL_C
@@ -288,7 +289,7 @@ function generate_precompile_statements()
     if have_repl
         # Seems like a reasonable number right now, adjust as needed
         # comment out if debugging script
-        @assert n_succeeded > 1100
+        @assert n_succeeded > 1200
     end
 
     tot_time = time_ns() - start_time

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -288,7 +288,7 @@ function generate_precompile_statements()
     if have_repl
         # Seems like a reasonable number right now, adjust as needed
         # comment out if debugging script
-        @assert n_succeeded > 1200
+        @assert n_succeeded > 1100
     end
 
     tot_time = time_ns() - start_time

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -920,7 +920,8 @@ function setup_interface(
             Expr(:call, :(Base.repl_cmd),
                 :(Base.cmd_gen($(Base.shell_parse(line::String)[1]))),
                 outstream(repl))
-        end)
+        end,
+        sticky = true)
 
 
     ################################# Stage II #############################

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -139,6 +139,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
             readuntil(stdout_read, "\n")
             readuntil(stdout_read, "\n")
             @test samefile(".", tmpdir)
+            write(stdin_write, "\b")
 
             # Test using `cd` to move to the home directory
             write(stdin_write, ";")
@@ -148,6 +149,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
             readuntil(stdout_read, "\n")
             readuntil(stdout_read, "\n")
             @test samefile(".", homedir_pwd)
+            write(stdin_write, "\b")
 
             # Test using `-` to jump backward to tmpdir
             write(stdin_write, ";")
@@ -157,6 +159,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
             readuntil(stdout_read, "\n")
             readuntil(stdout_read, "\n")
             @test samefile(".", tmpdir)
+            write(stdin_write, "\b")
 
             # Test using `~` (Base.expanduser) in `cd` commands
             if !Sys.iswindows()
@@ -167,6 +170,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
                 readuntil(stdout_read, "\n")
                 readuntil(stdout_read, "\n")
                 @test samefile(".", homedir_pwd)
+                write(stdin_write, "\b")
             end
         finally
             cd(origpwd)
@@ -196,6 +200,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
         s = readuntil(stdout_read, "\n\n")
         @test startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n  [1] ") ||
               startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n  [1] ")
+        write(stdin_write, "\b")
     end
 
     # issue #27293
@@ -219,6 +224,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
             close(proc_stdout)
             # check for the correct, expanded response
             @test occursin(expanduser("~"), fetch(get_stdout))
+            write(stdin_write, "\b")
         end
     end
 
@@ -270,6 +276,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
         end
         close(proc_stdout)
         @test fetch(get_stdout) == "HI\n"
+        write(stdin_write, "\b")
     end
 
     # Issue #7001


### PR DESCRIPTION
This PR makes the shell REPL mode sticky similar to the package manager REPL mode. This has been requested by many (see below).

Issues: #6320, #19202, #31910
Previous PR: #33174 (should probably be closed as it is outdated/not functional)

* Functionality is there.
* I have fixed the tests, that is I have added backspace commands to leave the shell mode after every individual test. This implicitly tests the stickiness of the REPL mode. Locally, all tests pass except for one: strangely, the test block (line 828 in REPL/test/repl.jl)
```julia
    # Test stream mode
    p = open(`$exename --startup-file=no -q`, "r+")
    write(p, "1\nexit()\n")
    @test read(p, String) == "1\n"
```
which seems to be completely **unrelated to this PR** fails
```julia
Test Failed at /Users/crstnbr/compiled/julia/usr/share/julia/stdlib/v1.6/REPL/test/repl.jl:832
  Expression: read(p, String) == "1\n"
   Evaluated: "\e[0m\e[0m1\n\e[0m" == "1\n"
ERROR: LoadError: LoadError: There was an error during testing
in expression starting at /Users/crstnbr/compiled/julia/usr/share/julia/stdlib/v1.6/REPL/test/repl.jl:787
in expression starting at /Users/crstnbr/compiled/julia/usr/share/julia/stdlib/v1.6/REPL/test/runtests.jl:3
ERROR: Package REPL errored during testing
```
If I manually run the test block above in the REPL (instead of `test REPL`) it works.... Any idea what's going on here?
* For some reason I had to change `@assert n_succeeded > 1200` to `@assert n_succeeded > 1100` (the threshold is 1183) in `generate_precompile.jl` for the build process to run through. A comment above that line says "adjust as needed" so I assume this is fine.


Would be great if someone could review!