### PR TITLE
build-stats: install `llvm-tools` before trying to run if using BB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,9 @@ else
 LLVM_SIZE := $(build_depsbindir)/llvm-size$(EXE)
 endif
 build-stats:
+ifeq ($(USE_BINARYBUILDER_LLVM),1)
+	@$(MAKE) -C deps install-llvm-tools
+endif
 	@printf $(JULCOLOR)' ==> ./julia binary sizes\n'$(ENDCOLOR)
 	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_libdir)/sys.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \


### PR DESCRIPTION
Now that we've split up the LLVM JLLs a bit, ensure that `llvm-tools` is
installed if we're using BB LLVM and we try to run `make build-stats`