### PR TITLE
Do not use zero(...) in generic_lu! algorithm to support Unitful

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -139,9 +139,9 @@ function generic_lufact!(A::StridedMatrix{T}, ::Val{Pivot} = Val(true);
         for k = 1:minmn
             # find index max
             kp = k
-            if Pivot
-                amax = abs(zero(T))
-                for i = k:m
+            if Pivot && k < m
+                amax = abs(A[k, k])
+                for i = k+1:m
                     absi = abs(A[i,k])
                     if absi > amax
                         kp = i

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -324,6 +324,22 @@ include("trickyarithmetic.jl")
     @test B isa LinearAlgebra.LU{ElT,Matrix{ElT}}
 end
 
+# dimensional correctness:
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
+using .Main.Furlongs
+
+@testset "lu factorization with dimension type" begin
+    n = 4
+    A = Matrix(Furlong(1.0) * I, n, n)
+    F = lu(A).factors
+    @test Diagonal(F) == Diagonal(A)
+    # upper triangular part has a unit Furlong{1}
+    @test all(x -> typeof(x) == Furlong{1, Float64}, F[i,j] for j=1:n for i=1:j)
+    # lower triangular part is unitless Furlong{0}
+    @test all(x -> typeof(x) == Furlong{0, Float64}, F[i,j] for j=1:n for i=j+1:n)
+end
+
 @testset "Issue #30917. Determinant of integer matrix" begin
     @test det([1 1 0 0 1 0 0 0
                1 0 1 0 0 1 0 0


### PR DESCRIPTION
This is a minimal effort attempt to work around the bigger problem that factorizations only define a single number type.

Suppose `eltype(A) == typeof(1.0u"kg")`, then by design of the algorithm the LU factorization should end up with `A = L * U` where `eltype(L) = Float64` and `eltype(U) == eltype(A) == typeof(1.0u"kg")`.

In julia the algorithm assumes it can work in-place, so we have to promote/union number types of L and U:

```
julia> promote_type(Float64, typeof(1.0u"kg"))
Quantity{Float64, D, U} where U where D
```

and in this case `zero(promote_type(Float64, typeof(1.0u"kg")))` will error. This PR tries to avoid using zero then.

A better solution IMHO is to allocate L and U separately (or at the very least parametrize the eltype of L and U separately in the factorization) to avoid having to work with non-concrete number types. It's nice to get a unitful LU-factorization, but pretty much any linalg operation `\`, `*`, `+`, etc will run `oneunit(eltype(factorization))` and throw:

```
julia> F = lu(rand(typeof(1.0u"kg"), 3, 3))
LU{Quantity{Float64, D, U} where U where D, Matrix{Quantity{Float64, D, U} where U where D}}
L factor:
3×3 Matrix{Quantity{Float64, D, U} where U where D}:
      1.0     0.0 kg  0.0 kg
 0.268046        1.0  0.0 kg
 0.512366  -0.566135     1.0
U factor:
3×3 Matrix{Quantity{Float64, D, U} where U where D}:
 0.654136 kg  0.762665 kg  0.637124 kg
         0.0  0.640381 kg  0.682195 kg
         0.0          0.0  0.102111 kg

julia> F \ rand(3)
ERROR: MethodError: no method matching (Quantity{Float64, D, U} where U where D)(::Float64)
Closest candidates are:

```