### PR TITLE
reuse anon functions in channels test to reduce compilation time

### DIFF
--- a/test/channels.jl
+++ b/test/channels.jl
@@ -255,12 +255,14 @@ using Distributed
 end
 
 @testset "timedwait" begin
-    @test timedwait(() -> true, 0) === :ok
-    @test timedwait(() -> false, 0) === :timed_out
-    @test_throws ArgumentError timedwait(() -> true, 0; pollint=0)
+    alwaystrue() = true
+    alwaysfalse() = false
+    @test timedwait(alwaystrue, 0) === :ok
+    @test timedwait(alwaysfalse, 0) === :timed_out
+    @test_throws ArgumentError timedwait(alwaystrue, 0; pollint=0)
 
     # Allowing a smaller positive `pollint` results in `timewait` hanging
-    @test_throws ArgumentError timedwait(() -> true, 0, pollint=1e-4)
+    @test_throws ArgumentError timedwait(alwaystrue, 0, pollint=1e-4)
 
     # Callback passed in raises an exception
     failure_cb = function (fail_on_call=1)
@@ -288,10 +290,10 @@ end
         @test e.ex isa ErrorException
     end
 
-    duration = @elapsed timedwait(() -> false, 1)  # Using default pollint of 0.1
+    duration = @elapsed timedwait(alwaysfalse, 1)  # Using default pollint of 0.1
     @test duration ≈ 1 atol=0.4
 
-    duration = @elapsed timedwait(() -> false, 0; pollint=1)
+    duration = @elapsed timedwait(alwaysfalse, 0; pollint=1)
     @test duration ≈ 1 atol=0.4
 end
 


### PR DESCRIPTION
In practice this might be enough to fix #38661. Even in local testing it's clear that this change cuts down most of the time variation.