### PR TITLE
fix part of #38650, `struct` should be a hard scope

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -904,6 +904,7 @@
        (global ,name) (const ,name)
        (scope-block
         (block
+         (hardscope)
          (local-def ,name)
          ,@(map (lambda (v) `(local ,v)) params)
          ,@(map (lambda (n v) (make-assignment n (bounds-to-TypeVar v #t))) params bounds)
@@ -934,6 +935,7 @@
        ;; "inner" constructors
        (scope-block
         (block
+         (hardscope)
          (global ,name)
          ,@(map (lambda (c)
                   (rewrite-ctor c name params field-names field-types))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2096,6 +2096,16 @@ end
 end
 @test z28789 == 42
 
+# issue #38650, `struct` should always be a hard scope
+f38650() = 0
+@eval begin
+    $(Expr(:softscope, true))
+    struct S38650
+        f38650() = 1
+    end
+end
+@test f38650() == 0
+
 # issue #37126
 @test isempty(Test.collect_test_logs() do
     include_string(@__MODULE__, """


### PR DESCRIPTION
This only affects the REPL, making it always behave the same as code in a file.