### PR TITLE
Accept AbstractChar in count and findall (::Char, ::String)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Julia v1.7 Release Notes
 
 New language features
 ---------------------
-* count and findall now accept AbstractChars as first argument to search for characaters in strings ((https://github.com/JuliaLang/julia/pull/38675)[#38675]).
+* count and findall now accept AbstractChars as first argument to search for characaters in strings ([#38675](https://github.com/JuliaLang/julia/pull/38675)).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Julia v1.7 Release Notes
 
 New language features
 ---------------------
-* count and findall now accept AbstractChar as first argument to search for characters in strings ([#38675](https://github.com/JuliaLang/julia/pull/38675)).
+* `count` and `findall` now accept an `AbstractChar` argument to search for a character in a string ([#38675]).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Julia v1.7 Release Notes
 
 New language features
 ---------------------
-* count and findall now accept AbstractChars as first argument to search for characaters in strings ([#38675]).
+* count and findall now accept AbstractChars as first argument to search for characaters in strings ((https://github.com/JuliaLang/julia/pull/38675)[#38675]).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Julia v1.7 Release Notes
 
 New language features
 ---------------------
-* count and findall now accept AbstractChars as first argument to search for characaters in strings.
+* count and findall now accept AbstractChars as first argument to search for characaters in strings ([#38675]).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Julia v1.7 Release Notes
 
 New language features
 ---------------------
-* count and findall now accept AbstractChars as first argument to search for characaters in strings ([#38675](https://github.com/JuliaLang/julia/pull/38675)).
+* count and findall now accept AbstractChar as first argument to search for characters in strings ([#38675](https://github.com/JuliaLang/julia/pull/38675)).
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Julia v1.7 Release Notes
 
 New language features
 ---------------------
-
+* count and findall now accept AbstractChars as first argument to search for characaters in strings.
 
 Language changes
 ----------------

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -397,6 +397,27 @@ function findall(t::Union{AbstractString,AbstractPattern}, s::AbstractString; ov
 end
 
 """
+    findall(c :: AbstractChar, s :: AbstractString)
+  
+Return a vector `I` of the indices of `s` where `s[i] == c`. If there are no such 
+elements in `s`, return an empty array.
+
+# Examples
+```jldoctest
+julia> findall('a', "batman")
+2-element Vector{Int64}:
+ 2
+ 5
+```
+
+!!! compat "Julia 1.6"
+     This method requires at least Julia 1.6.
+
+"""
+findall(c :: AbstractChar, s :: AbstractString) = findall(isequal(c),s)
+    
+
+"""
     count(
         pattern::Union{AbstractChar,AbstractString,AbstractPattern},
         string::AbstractString;

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -398,8 +398,8 @@ end
 
 """
     findall(c::AbstractChar, s::AbstractString)
-  
-Return a vector `I` of the indices of `s` where `s[i] == c`. If there are no such 
+
+Return a vector `I` of the indices of `s` where `s[i] == c`. If there are no such
 elements in `s`, return an empty array.
 
 # Examples
@@ -414,7 +414,7 @@ julia> findall('a', "batman")
      This method requires at least Julia 1.6.
 """
 findall(c::AbstractChar, s::AbstractString) = findall(isequal(c),s)
-    
+
 
 """
     count(

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -433,7 +433,7 @@ original string, otherwise they must be from disjoint character ranges.
      This method requires at least Julia 1.3.
 
 !!! compat "Julia 1.6"
-      Using a character as the pattern requires at least Julia 1.6.
+      Using a character as the pattern requires at least Julia 1.7.
 """
 function count(t::Union{AbstractChar,AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)
     n = 0

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -411,7 +411,7 @@ julia> findall('a', "batman")
 ```
 
 !!! compat "Julia 1.7"
-     This method requires at least Julia 1.6.
+     This method requires at least Julia 1.7.
 """
 findall(c::AbstractChar, s::AbstractString) = findall(isequal(c),s)
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -410,7 +410,7 @@ If `overlap=true`, the matching sequences are allowed to overlap indices in the
 original string, otherwise they must be from disjoint character ranges.
 
 !!! compat "Julia 1.3"
-     This method requires at least Julia 1.3.
+     This method requires at least Julia 1.3; using a character as the pattern requires Julia 1.6+.
 """
 function count(t::Union{AbstractChar,AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)
     n = 0

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -410,7 +410,7 @@ julia> findall('a', "batman")
  5
 ```
 
-!!! compat "Julia 1.6"
+!!! compat "Julia 1.7"
      This method requires at least Julia 1.6.
 """
 findall(c::AbstractChar, s::AbstractString) = findall(isequal(c),s)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -398,7 +398,7 @@ end
 
 """
     count(
-        pattern::Union{AbstractString,AbstractPattern},
+        pattern::Union{AbstractChar,AbstractString,AbstractPattern},
         string::AbstractString;
         overlap::Bool = false,
     )
@@ -412,7 +412,7 @@ original string, otherwise they must be from disjoint character ranges.
 !!! compat "Julia 1.3"
      This method requires at least Julia 1.3.
 """
-function count(t::Union{AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)
+function count(t::Union{AbstractChar,AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)
     n = 0
     i, e = firstindex(s), lastindex(s)
     while true

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -412,7 +412,6 @@ julia> findall('a', "batman")
 
 !!! compat "Julia 1.6"
      This method requires at least Julia 1.6.
-
 """
 findall(c::AbstractChar, s::AbstractString) = findall(isequal(c),s)
     
@@ -431,7 +430,10 @@ If `overlap=true`, the matching sequences are allowed to overlap indices in the
 original string, otherwise they must be from disjoint character ranges.
 
 !!! compat "Julia 1.3"
-     This method requires at least Julia 1.3; using a character as the pattern requires Julia 1.6+.
+     This method requires at least Julia 1.3.
+
+!!! compat "Julia 1.6"
+      Using a character as the pattern requires at least Julia 1.6.
 """
 function count(t::Union{AbstractChar,AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)
     n = 0

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -397,7 +397,7 @@ function findall(t::Union{AbstractString,AbstractPattern}, s::AbstractString; ov
 end
 
 """
-    findall(c :: AbstractChar, s :: AbstractString)
+    findall(c::AbstractChar, s::AbstractString)
   
 Return a vector `I` of the indices of `s` where `s[i] == c`. If there are no such 
 elements in `s`, return an empty array.
@@ -414,7 +414,7 @@ julia> findall('a', "batman")
      This method requires at least Julia 1.6.
 
 """
-findall(c :: AbstractChar, s :: AbstractString) = findall(isequal(c),s)
+findall(c::AbstractChar, s::AbstractString) = findall(isequal(c),s)
     
 
 """

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -432,7 +432,7 @@ original string, otherwise they must be from disjoint character ranges.
 !!! compat "Julia 1.3"
      This method requires at least Julia 1.3.
 
-!!! compat "Julia 1.6"
+!!! compat "Julia 1.7"
       Using a character as the pattern requires at least Julia 1.7.
 """
 function count(t::Union{AbstractChar,AbstractString,AbstractPattern}, s::AbstractString; overlap::Bool=false)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -80,7 +80,7 @@
     @test count('a', "aaa", overlap=true) == 3
     @test count('a', "") == 0
     @test count('→', "OH⁻ + H₃CBr →  (HOH₃CBr⁻)† → HOCH₃ + Br⁻") == 2
-    
+
     # Unnamed subpatterns
     let m = match(r"(.)(.)(.)", "xyz")
         @test haskey(m, 1)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -71,10 +71,11 @@
     @test count(r"\w*", "foo bar") == 4
     @test count(r"\b", "foo bar") == 4
     # count with char as argument
-    @test count('a',"batman") == 2
-    @test count('a',"aaa",overlap=true) == 3
-    @test count('a',"") == 0
-
+    @test count('a', "batman") == 2
+    @test count('a', "aaa",overlap=true) == 3
+    @test count('a', "") == 0
+    @test count('→', "OH⁻ + H₃CBr →  (HOH₃CBr⁻)† → HOCH₃ + Br⁻") == 2
+    
     # Unnamed subpatterns
     let m = match(r"(.)(.)(.)", "xyz")
         @test haskey(m, 1)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -70,6 +70,7 @@
     @test count(r"\w+", "foo bar", overlap=true) == 6
     @test count(r"\w*", "foo bar") == 4
     @test count(r"\b", "foo bar") == 4
+    @test count('a',"batman") == 2
 
     # Unnamed subpatterns
     let m = match(r"(.)(.)(.)", "xyz")

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -64,6 +64,11 @@
     @test findall(r"\w+", "foo bar", overlap=true) == [1:3, 2:3, 3:3, 5:7, 6:7, 7:7]
     @test all(findall(r"\w*", "foo bar") .=== [1:3, 4:3, 5:7, 8:7]) # use === to compare empty ranges
     @test all(findall(r"\b", "foo bar") .=== [1:0, 4:3, 5:4, 8:7])  # use === to compare empty ranges
+    # with Char as argument
+    @test findall('a', "batman") == [2, 5]
+    @test findall('→', "OH⁻ + H₃CBr →  HOH₃CBr⁻ → HOCH₃ + Br⁻") == [17, 35]
+    @test findall('a', "") == Int[]
+    @test findall('c', "batman") == Int[]
 
     # count
     @test count(r"\w+", "foo bar") == 2

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -77,7 +77,7 @@
     @test count(r"\b", "foo bar") == 4
     # count with char as argument
     @test count('a', "batman") == 2
-    @test count('a', "aaa",overlap=true) == 3
+    @test count('a', "aaa", overlap=true) == 3
     @test count('a', "") == 0
     @test count('→', "OH⁻ + H₃CBr →  (HOH₃CBr⁻)† → HOCH₃ + Br⁻") == 2
     

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -70,7 +70,10 @@
     @test count(r"\w+", "foo bar", overlap=true) == 6
     @test count(r"\w*", "foo bar") == 4
     @test count(r"\b", "foo bar") == 4
+    # count with char as argument
     @test count('a',"batman") == 2
+    @test count('a',"aaa",overlap=true) == 3
+    @test count('a',"") == 0
 
     # Unnamed subpatterns
     let m = match(r"(.)(.)(.)", "xyz")


### PR DESCRIPTION
Followup from this thread:

https://discourse.julialang.org/t/method-for-counting-characters-in-string-count-a-batman-vs-count-a-batman/51153

Seems that accepting AbstractChar in this function is enough to solve that problem.
