### PR TITLE
Report the top of the exception stack when there's no handler.

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -558,6 +558,11 @@ JL_DLLEXPORT void jl_switchto(jl_task_t **pt)
 
 JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
 {
+    // NULL exception objects are used when rethrowing. we don't have a handler to process
+    // the exception stack, so at least report the exception at the top of the stack.
+    if (!e)
+        e = jl_current_exception();
+
     jl_printf((JL_STREAM*)STDERR_FILENO, "fatal: error thrown and no exception handler available.\n");
     jl_static_show((JL_STREAM*)STDERR_FILENO, e);
     jl_printf((JL_STREAM*)STDERR_FILENO, "\n");


### PR DESCRIPTION
This happens with PackageCompiler and modules that error during `__init__` (which gets called way earlier if said modules are part of the system image). Before:

```
fatal: error thrown and no exception handler available.
#<null>
error at ./error.jl:33
__init__ at /home/tim/Julia/pkg/DummyPackage/src/DummyPackage.jl:4
jl_sysimg_fvars_base at /tmp/sys.so (unknown line)
_jl_invoke at /home/tim/Julia/src/julia/src/gf.c:2205 [inlined]
jl_apply_generic at /home/tim/Julia/src/julia/src/gf.c:2406
jl_apply at /home/tim/Julia/src/julia/src/julia.h:1701 [inlined]
jl_module_run_initializer at /home/tim/Julia/src/julia/src/toplevel.c:74
_julia_init at /home/tim/Julia/src/julia/src/init.c:796
repl_entrypoint at /home/tim/Julia/src/julia/src/jlapi.c:682
main at julia (unknown line)
__libc_start_main at /nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/libc.so.6 (unknown line)
_start at julia (unknown line)
```

After:

```
fatal: error thrown and no exception handler available.
InitError(mod=:DummyPackage, error=ErrorException("true"))
error at ./error.jl:33
__init__ at /home/tim/Julia/pkg/DummyPackage/src/DummyPackage.jl:4
jl_sysimg_fvars_base at /tmp/sys.so (unknown line)
_jl_invoke at /home/tim/Julia/src/julia/src/gf.c:2205 [inlined]
jl_apply_generic at /home/tim/Julia/src/julia/src/gf.c:2406
jl_apply at /home/tim/Julia/src/julia/src/julia.h:1701 [inlined]
jl_module_run_initializer at /home/tim/Julia/src/julia/src/toplevel.c:74
_julia_init at /home/tim/Julia/src/julia/src/init.c:796
repl_entrypoint at /home/tim/Julia/src/julia/src/jlapi.c:682
main at julia (unknown line)
__libc_start_main at /nix/store/a6rnjp15qgp8a699dlffqj94hzy1nldg-glibc-2.32/lib/libc.so.6 (unknown line)
_start at julia (unknown line)
```

At least the exception is there now.

cc @KristofferC