### PR TITLE
error message for indexing with BitArray

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -47,6 +47,8 @@ function showerror(io::IO, ex::BoundsError)
                 print(io, ex.i)
             elseif ex.i isa AbstractString
                 show(io, ex.i)
+            elseif ex.i isa BitArray
+                summary(io, ex.i)
             else
                 for (i, x) in enumerate(ex.i)
                     i > 1 && print(io, ", ")

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -31,7 +31,7 @@ showerror(io::IO, ex) = show(io, ex)
 
 show_index(io::IO, x::Any) = show(io, x)
 show_index(io::IO, x::Slice) = show_index(io, x.indices)
-show_index(io::IO, x::LogicalIndex) = show_index(io, x.mask)
+show_index(io::IO, x::LogicalIndex) = summary(io, x.mask)
 show_index(io::IO, x::OneTo) = print(io, "1:", x.stop)
 show_index(io::IO, x::Colon) = print(io, ':')
 
@@ -47,8 +47,6 @@ function showerror(io::IO, ex::BoundsError)
                 print(io, ex.i)
             elseif ex.i isa AbstractString
                 show(io, ex.i)
-            elseif ex.i isa BitArray
-                summary(io, ex.i)
             else
                 for (i, x) in enumerate(ex.i)
                     i > 1 && print(io, ", ")

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2842,7 +2842,7 @@ end
     b = IOBuffer()
     showerror(b, err)
     @test String(take!(b)) ==
-        "BoundsError: attempt to access 2×2 Matrix{Float64} at index [10, 2-element BitArray{1}]"
+        "BoundsError: attempt to access 2×2 Matrix{Float64} at index [10, 2-element BitVector]"
 
     # Also test : directly for custom types for which it may appear as-is
     err = BoundsError(x, (10, :))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2842,7 +2842,7 @@ end
     b = IOBuffer()
     showerror(b, err)
     @test String(take!(b)) ==
-        "BoundsError: attempt to access 2×2 Matrix{Float64} at index [10, Bool[1, 1]]"
+        "BoundsError: attempt to access 2×2 Matrix{Float64} at index [10, 2-element BitArray{1}]"
 
     # Also test : directly for custom types for which it may appear as-is
     err = BoundsError(x, (10, :))

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -297,6 +297,8 @@ let undefvar
     @test err_str == "BoundsError: attempt to access 3-element Vector{$Int} at index [-2, 1]"
     err_str = @except_str [5, 4, 3][1:5] BoundsError
     @test err_str == "BoundsError: attempt to access 3-element Vector{$Int} at index [1:5]"
+    err_str = @except_str [5, 4, 3][trues(6,7)] BoundsError
+    @test err_str == "BoundsError: attempt to access 3-element Vector{$Int} at index [6×7 BitArray{2}]"
 
     err_str = @except_str Bounded(2)[3] BoundsError
     @test err_str == "BoundsError: attempt to access 2-size Bounded at index [3]"

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -298,7 +298,7 @@ let undefvar
     err_str = @except_str [5, 4, 3][1:5] BoundsError
     @test err_str == "BoundsError: attempt to access 3-element Vector{$Int} at index [1:5]"
     err_str = @except_str [5, 4, 3][trues(6,7)] BoundsError
-    @test err_str == "BoundsError: attempt to access 3-element Vector{$Int} at index [6×7 BitArray{2}]"
+    @test err_str == "BoundsError: attempt to access 3-element Vector{$Int} at index [6×7 BitMatrix]"
 
     err_str = @except_str Bounded(2)[3] BoundsError
     @test err_str == "BoundsError: attempt to access 2-size Bounded at index [3]"


### PR DESCRIPTION
Closes #38685 by making the error message for (e.g.) `ones(2,3)[trues(4,5)]` more informative.

This is a WIP because I don't know how to test locally, so let's see what the CI says.

Will this change require a line in the release notes?
Seems small enough to me to be below the threshold of worth mentioning, but up to y'all...