### PR TITLE
fix #38501, wrap interpolated literal strings in `:string` exprs

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2263,7 +2263,10 @@
              (loop (read-char p) b e 0))))
 
       ((and (eqv? c #\$) (not raw))
-       (let ((ex (parse-interpolate s)))
+       (let* ((ex (parse-interpolate s))
+              ;; wrap interpolated literal strings in (string ) so we can
+              ;; distinguish them from the surrounding text (issue #38501)
+              (ex (if (string? ex) `(string ,ex) ex)))
          (loop (read-char p)
                (open-output-string)
                (list* ex (io.tostring! b) e)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2308,7 +2308,13 @@
    'bracescat (lambda (e) (error "{ } matrix syntax is discontinued"))
 
    'string
-   (lambda (e) (expand-forms `(call (top string) ,@(cdr e))))
+   (lambda (e)
+     (expand-forms
+      `(call (top string) ,@(map (lambda (s)
+                                   (if (and (pair? s) (eq? (car s) 'string))
+                                       (cadr s)
+                                       s))
+                                 (cdr e)))))
 
    '|::|
    (lambda (e)

--- a/test/show.jl
+++ b/test/show.jl
@@ -152,6 +152,8 @@ end
 @test_repr ":(:(:(x)))"
 @test_repr "-\"\""
 @test_repr "-(<=)"
+@test_repr "\$x"
+@test_repr "\$(\"x\")"
 
 # order of operations
 @test_repr "x + y * z"

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2642,3 +2642,6 @@ end
     @test ncalls_in_lowered(quote a, _... = b, c end, GlobalRef(Base, :rest)) == 0
     @test ncalls_in_lowered(quote a, _... = (b...,) end, GlobalRef(Base, :rest)) == 0
 end
+
+# issue #38501
+@test :"a $b $("str") c" == Expr(:string, "a ", :b, " ", Expr(:string, "str"), " c")


### PR DESCRIPTION
fix #38501
