### PR TITLE
Run Distributed tests on node 1

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ end
 move_to_node1("precompile")
 move_to_node1("SharedArrays")
 move_to_node1("threads")
+move_to_node1("Distributed")
 # Ensure things like consuming all kernel pipe memory doesn't interfere with other tests
 move_to_node1("stress")
 


### PR DESCRIPTION
We're still seeing fairly regular timeouts in the Distributed test.
I'd like to try moving it into the node1 section, like we do with e.g.
the threads test that spawns lots of threads. Particularly our small
buildbots can get a bit overloaded with all the other tests, so I'm thinking
the timeout might be genuine. If it is, then this will fix it. If we still see timeouts,
we have some other underlying problem.