### PR TITLE
[Compiler] call error("") instead of error(), since the later is not callable yet

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -258,7 +258,7 @@ function already_inserted(compact::IncrementalCompact, old::OldSSAValue)
     end
     id -= length(compact.ir.stmts)
     if id < length(compact.ir.new_nodes)
-        error()
+        error("")
     end
     id -= length(compact.ir.new_nodes)
     @assert id <= length(compact.pending_nodes)


### PR DESCRIPTION
Anyone recall why `@verify_error` does not include a call to `error("Verification Error")`?
All uses seem to be succeeded by `error()`, which as I noted in #38632 is not callable from `Core.Compiler`.

```
From worker 15:	Internal error: encountered unexpected error in runtime:
From worker 15:	MethodError(f=Base.string, args=(), world=0x0000000000001088)
From worker 15:	jl_method_error_bare at /home/vchuravy/src/julia/src/gf.c:1803
From worker 15:	jl_method_error at /home/vchuravy/src/julia/src/gf.c:1821
From worker 15:	jl_lookup_generic_ at /home/vchuravy/src/julia/src/gf.c:2391
From worker 15:	jl_apply_generic at /home/vchuravy/src/julia/src/gf.c:2406
From worker 15:	error at ./error.jl:42
From worker 15:	verify_ir at ./compiler/ssair/verify.jl:131
From worker 15:	verify_ir at ./compiler/ssair/verify.jl:67 [inlined]
```
