### PR TITLE
Try to avoid deadlock in Distributed test

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -87,7 +87,7 @@ let
         @test count == testcount
         put!(c, "foo")
         testcount -= 1
-        wait(count_condition)
+        (count == testcount) || wait(count_condition)
         @test count == testcount
         @test isready(pool) == true
     end
@@ -106,7 +106,7 @@ let
         @test count == testcount
         put!(c, "foo")
         testcount -= 1
-        wait(count_condition)
+        (count == testcount) || wait(count_condition)
         @test count == testcount
         @test isready(pool) == true
     end


### PR DESCRIPTION
What I believe is happening here is that, since put! is a yield point, the remote call finishes
and the async task gets run before the `wait` statement is reached, thus causing a deadlock.
I don't have 100% proof that this is the issue, but I did see the test hanging during this test,
so I figured it's worth a try. May help #38712 (particularly, the second of the linked test failures).