### PR TITLE
require (using, import): give a hint in error message if typo in module name

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -907,17 +907,19 @@ end
 
 # return hint for modulname (if similar name in project deps / Stdlib) or nothing
 function modulnamehint(tn::AbstractString)
+    length(tn) < 3 && return nothing
     hns = vcat(try collect(keys(get(parsed_toml(load_path()[1]), "deps", nothing)))
             catch; String[] end, isdir(Sys.STDLIB) ? readdir(Sys.STDLIB) : String[])
-    ((length(tn) < 3) || isempty(hns)) && return nothing
+    isempty(hns) && return nothing
     scores = similar(hns, Int)
     for (index, hn) in enumerate(hns)
-        (length(tn) >= length(hn)) ? (o1 = tn; o2 = hn) : (o1 = hn; o2 = tn)
+        o1, o2 = length(tn) >= length(hn) ? (tn, hn) : (hn, tn)
         scores[index] = length(o1) - length(o2) + (contains(o1, o2) ? 0 :
                         contains(lowercase(o1), lowercase(o2)) ? 1 : 4)
     end
     score, index = findmin(scores)
-    return (score < 4) ? hns[index] : nothing
+    score > 3 && return nothing
+    return hns[index]
 end
 
 mutable struct PkgOrigin

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -863,7 +863,7 @@ function require(into::Module, mod::Symbol)
     if uuidkey === nothing
         where = PkgId(into)
         if where.uuid === nothing
-            hint = modulnamehint(String(mod))
+            hint = modulenamehint(String(mod))
             if isnothing(hint)
                 throw(ArgumentError("""
                 Package $mod not found in current path:
@@ -905,8 +905,8 @@ function require(into::Module, mod::Symbol)
     return require(uuidkey)
 end
 
-# return hint for modul name (from project deps / stdlib) or return nothing
-function modulnamehint(tn::AbstractString)
+# return hint for module name (from project deps / stdlib) or return nothing
+function modulenamehint(tn::AbstractString)
     length(tn) < 3 && return nothing
     hns = Vector{String}()
     for env in load_path()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -906,24 +906,18 @@ function require(into::Module, mod::Symbol)
 end
 
 # return hint for modulname (if similar name in project deps / Stdlib) or return nothing
-function modulnamehint(tname::AbstractString)
-    hnames = vcat(try collect(keys(get(parsed_toml(load_path()[1]), "deps", nothing)))
+function modulnamehint(tn::AbstractString)
+    hns = vcat(try collect(keys(get(parsed_toml(load_path()[1]), "deps", nothing)))
             catch; String[] end, isdir(Sys.STDLIB) && readdir(Sys.STDLIB))
-    ltn = length(tname)
-    ((ltn < 3) || isempty(hnames)) && return nothing
-    scores = similar(hnames, Int64)
-    for (index, hname) in enumerate(hnames)
-        lhn = length(hname)
-        if (ltn >= lhn)
-            scores[index] = ltn - lhn + (contains(tname, hname) ? 0 :
-            contains(lowercase(tname), lowercase(hname)) ? 1 : 4)
-        else
-            scores[index] = lhn - ltn + (contains(hname, tname) ? 0 :
-            contains(lowercase(hname), lowercase(tname)) ? 1 : 4)
-        end
+    ((length(tn) < 3) || isempty(hns)) && return nothing
+    scores = similar(hns, Int64)
+    for (index, hn) in enumerate(hns)
+        (length(tn) > length(hn)) ? (o1 = tn ; o2 = hn) : (o1 = hn; o2 = tn)
+        scores[index] = length(o1) - length(o2) + (contains(o1, o2) ? 0 :
+                        contains(lowercase(o1), lowercase(o2)) ? 1 : 4)
     end
     x, i = findmin(scores)
-    return (x < 4) ? hnames[i] : nothing
+    return (x < 4) ? hns[i] : nothing
 end
 
 mutable struct PkgOrigin

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -906,7 +906,7 @@ function require(into::Module, mod::Symbol)
 end
 
 # return hint for module name (from project deps / stdlib) or return nothing
-function modulenamehint(tn::AbstractString)
+function modulenamehint(tn::String)
     length(tn) < 3 && return nothing
     hns = Vector{String}()
     for env in load_path()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -863,7 +863,7 @@ function require(into::Module, mod::Symbol)
     if uuidkey === nothing
         where = PkgId(into)
         if where.uuid === nothing
-            hint = modulnamehint(String(mod)) # hint: String, if hint found, or nothing
+            hint = modulnamehint(String(mod))
             if isnothing(hint)
                 throw(ArgumentError("""
                 Package $mod not found in current path:
@@ -905,19 +905,19 @@ function require(into::Module, mod::Symbol)
     return require(uuidkey)
 end
 
-# return hint for modulname (if similar name in project deps / Stdlib) or return nothing
+# return hint for modulname (if similar name in project deps / Stdlib) or nothing
 function modulnamehint(tn::AbstractString)
     hns = vcat(try collect(keys(get(parsed_toml(load_path()[1]), "deps", nothing)))
-            catch; String[] end, isdir(Sys.STDLIB) && readdir(Sys.STDLIB))
+            catch; String[] end, isdir(Sys.STDLIB) ? readdir(Sys.STDLIB) : String[])
     ((length(tn) < 3) || isempty(hns)) && return nothing
     scores = similar(hns, Int64)
     for (index, hn) in enumerate(hns)
-        (length(tn) > length(hn)) ? (o1 = tn ; o2 = hn) : (o1 = hn; o2 = tn)
+        (length(tn) >= length(hn)) ? (o1 = tn ; o2 = hn) : (o1 = hn; o2 = tn)
         scores[index] = length(o1) - length(o2) + (contains(o1, o2) ? 0 :
                         contains(lowercase(o1), lowercase(o2)) ? 1 : 4)
     end
-    x, i = findmin(scores)
-    return (x < 4) ? hns[i] : nothing
+    score, index = findmin(scores)
+    return (score < 4) ? hns[index] : nothing
 end
 
 mutable struct PkgOrigin

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -910,9 +910,9 @@ function modulnamehint(tn::AbstractString)
     hns = vcat(try collect(keys(get(parsed_toml(load_path()[1]), "deps", nothing)))
             catch; String[] end, isdir(Sys.STDLIB) ? readdir(Sys.STDLIB) : String[])
     ((length(tn) < 3) || isempty(hns)) && return nothing
-    scores = similar(hns, Int64)
+    scores = similar(hns, Int)
     for (index, hn) in enumerate(hns)
-        (length(tn) >= length(hn)) ? (o1 = tn ; o2 = hn) : (o1 = hn; o2 = tn)
+        (length(tn) >= length(hn)) ? (o1 = tn; o2 = hn) : (o1 = hn; o2 = tn)
         scores[index] = length(o1) - length(o2) + (contains(o1, o2) ? 0 :
                         contains(lowercase(o1), lowercase(o2)) ? 1 : 4)
     end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -915,7 +915,7 @@ function modulenamehint(tn::String)
     append!(hns, readdir(Sys.STDLIB))
     isempty(hns) && return nothing
     scores = similar(hns, Int)
-    for (index, hn) in enumerate(hns)
+    for (index, hn) in collect(enumerate(hns))
         s1, s2 = length(tn) >= length(hn) ? (tn, hn) : (hn, tn)
         scores[index] = length(s1) - length(s2) + (contains(s1, s2) ? 0 :
                         contains(lowercase(s1), lowercase(s2)) ? 1 : 4)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -270,7 +270,7 @@ end
 module NotPkgModule; end
 
 @testset "modulenamehint()" begin
-#=  @test modulenamehint("Fooo") == "Foo"
+    @test modulenamehint("Fooo") == "Foo"
     @test modulenamehint("fooo") == "Foo"
     @test modulenamehint("foo") == "Foo"
     @test modulenamehint("xfooo") == "Foo"
@@ -287,14 +287,11 @@ module NotPkgModule; end
     not found in current path. Correct your entry and try again, or run
     `import Pkg; Pkg.add("foo")` to install the foo package.
     """) using foo
-    @test_throws ArgumentError import foo
 
     # using/import xfoxox - Error with modulenamehint = nothing
     @test_throws ArgumentError("""Package xfoxox not found in current path:
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox
-    @test_throws ArgumentError import xfoxox
-=#
 end
 
 @testset "project & manifest import" begin

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -279,7 +279,7 @@ module NotPkgModule; end
     @test modulnamehint("Rand") == "Random"
     @test modulnamehint("ran") == nothing
     @test modulnamehint("infoodrest") == nothing
-    @test modulnamehint("fo") == nothing
+    @test modulnamehint("xx") == nothing
     @test modulnamehint("xfoxox") == nothing
 
     #test try-catch error for empty load_path()
@@ -288,16 +288,18 @@ module NotPkgModule; end
     @test modulnamehint("Rand") == "Random"
     append!(LOAD_PATH, l_p)
 
-    # using foo - Error with modulmamehint = "Foo"
+    # using/import foo - Error with modulmamehint = "Foo"
     @test_throws ArgumentError("""Did you mean Foo? Your entry foo is
     not found in current path. Correct your entry and try again, or run
     `import Pkg; Pkg.add("foo")` to install the foo package.
     """) using foo
+    @test_throws ArgumentError import foo
 
-    # using xfoxox - Error with modulnamehint = nothing
+    # using/import xfoxox - Error with modulnamehint = nothing
     @test_throws ArgumentError("""Package xfoxox not found in current path:
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox
+    @test_throws ArgumentError import xfoxox
 
     # Error - xfoxox does not exist
     @test_throws ArgumentError require(Test, :xfoxox)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -270,7 +270,7 @@ end
 module NotPkgModule; end
 
 @testset "modulenamehint()" begin
-    @test modulenamehint("Fooo") == "Foo"
+#=  @test modulenamehint("Fooo") == "Foo"
     @test modulenamehint("fooo") == "Foo"
     @test modulenamehint("foo") == "Foo"
     @test modulenamehint("xfooo") == "Foo"
@@ -281,7 +281,7 @@ module NotPkgModule; end
     @test isnothing(modulenamehint("infoodrest"))
     @test isnothing(modulenamehint("fo"))
     @test isnothing(modulenamehint("xfoxox"))
-#=
+
     # using/import foo - Error with modulemamehint = "Foo"
     @test_throws ArgumentError("""Did you mean Foo? Your entry foo is
     not found in current path. Correct your entry and try again, or run
@@ -293,7 +293,7 @@ module NotPkgModule; end
     @test_throws ArgumentError("""Package xfoxox not found in current path:
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox
-    @test_throws ArgumentError import xfoxox 
+    @test_throws ArgumentError import xfoxox
 =#
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -88,7 +88,7 @@ end
 ## unit tests of project parsing ##
 
 import Base: SHA1, PkgId, load_path, identify_package, locate_package, version_slug,
-            dummy_uuid, modulnamehint
+            dummy_uuid, modulenamehint
 import UUIDs: UUID, uuid4, uuid_version
 import Random: shuffle, randstring
 using Test
@@ -269,27 +269,27 @@ end
 
 module NotPkgModule; end
 
-@testset "modulnamehint()" begin
-    @test modulnamehint("Fooo") == "Foo"
-    @test modulnamehint("fooo") == "Foo"
-    @test modulnamehint("foo") == "Foo"
-    @test modulnamehint("xfooo") == "Foo"
-    @test modulnamehint("UUID") == "UUIDs"
-    @test modulnamehint("uuid") == "UUIDs"
-    @test modulnamehint("Rand") == "Random"
-    @test isnothing(modulnamehint("ran"))
-    @test isnothing(modulnamehint("infoodrest"))
-    @test isnothing(modulnamehint("fo"))
-    @test isnothing(modulnamehint("xfoxox"))
+@testset "modulenamehint()" begin
+    @test modulenamehint("Fooo") == "Foo"
+    @test modulenamehint("fooo") == "Foo"
+    @test modulenamehint("foo") == "Foo"
+    @test modulenamehint("xfooo") == "Foo"
+    @test modulenamehint("UUID") == "UUIDs"
+    @test modulenamehint("uuid") == "UUIDs"
+    @test modulenamehint("Rand") == "Random"
+    @test isnothing(modulenamehint("ran"))
+    @test isnothing(modulenamehint("infoodrest"))
+    @test isnothing(modulenamehint("fo"))
+    @test isnothing(modulenamehint("xfoxox"))
 
-    # using/import foo - Error with modulmamehint = "Foo"
+    # using/import foo - Error with modulemamehint = "Foo"
     @test_throws ArgumentError("""Did you mean Foo? Your entry foo is
     not found in current path. Correct your entry and try again, or run
     `import Pkg; Pkg.add("foo")` to install the foo package.
     """) using foo
     @test_throws ArgumentError import foo
 
-    # using/import xfoxox - Error with modulnamehint = nothing
+    # using/import xfoxox - Error with modulenamehint = nothing
     @test_throws ArgumentError("""Package xfoxox not found in current path:
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -268,8 +268,8 @@ end
 end
 
 module NotPkgModule; end
-#=
-@testset "modul name hint" begin
+
+@testset "modulnamehint()" begin
     @test modulnamehint("Fooo") == "Foo"
     @test modulnamehint("fooo") == "Foo"
     @test modulnamehint("foo") == "Foo"
@@ -281,7 +281,7 @@ module NotPkgModule; end
     @test isnothing(modulnamehint("infoodrest"))
     @test isnothing(modulnamehint("fo"))
     @test isnothing(modulnamehint("xfoxox"))
-
+#=
     #test Stdlib still works with empty load_path() for Project
     l_p = copy(LOAD_PATH)
     empty!(LOAD_PATH)
@@ -299,9 +299,9 @@ module NotPkgModule; end
     @test_throws ArgumentError("""Package xfoxox not found in current path:
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox
-    @test_throws ArgumentError import xfoxox
+    @test_throws ArgumentError import xfoxox =#
 end
-=#
+
 @testset "project & manifest import" begin
     @test !@isdefined Foo
     @test !@isdefined Bar

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -269,7 +269,7 @@ end
 
 module NotPkgModule; end
 
-@testset "modul name hints and require errors" begin
+@testset "require exceptions and modul name hints" begin
     @test modulnamehint("Fooo") == "Foo"
     @test modulnamehint("fooo") == "Foo"
     @test modulnamehint("foo") == "Foo"
@@ -279,10 +279,10 @@ module NotPkgModule; end
     @test modulnamehint("Rand") == "Random"
     @test modulnamehint("ran") == nothing
     @test modulnamehint("infoodrest") == nothing
-    @test modulnamehint("xx") == nothing
+    @test modulnamehint("fo") == nothing
     @test modulnamehint("xfoxox") == nothing
 
-    #test try-catch error for empty load_path()
+    #test Stdlib still works with empty load_path() for Project
     l_p = copy(LOAD_PATH)
     empty!(LOAD_PATH)
     @test modulnamehint("Rand") == "Random"
@@ -301,11 +301,11 @@ module NotPkgModule; end
     """) using xfoxox
     @test_throws ArgumentError import xfoxox
 
-    # Error - xfoxox does not exist
+    # require Error - xfoxox does not exist
     @test_throws ArgumentError require(Test, :xfoxox)
 
-    # Warning - Loading Foo into Test
-    @test_logs (:warn, r"Loading Foo into Test from project dependency") require(Test, :Foo)
+    # require Warning - Loading Foo into Test
+    @test_logs (:warn, r"Loading Foo into Test from") require(Test, :Foo)
 end
 
 @testset "project & manifest import" begin

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -88,7 +88,7 @@ end
 ## unit tests of project parsing ##
 
 import Base: SHA1, PkgId, load_path, identify_package, locate_package, version_slug,
-            dummy_uuid, modulnamehint, require
+            dummy_uuid, modulnamehint
 import UUIDs: UUID, uuid4, uuid_version
 import Random: shuffle, randstring
 using Test
@@ -281,7 +281,7 @@ module NotPkgModule; end
     @test isnothing(modulnamehint("infoodrest"))
     @test isnothing(modulnamehint("fo"))
     @test isnothing(modulnamehint("xfoxox"))
-#=
+
     #test Stdlib still works with empty load_path() for Project
     l_p = copy(LOAD_PATH)
     empty!(LOAD_PATH)
@@ -299,7 +299,7 @@ module NotPkgModule; end
     @test_throws ArgumentError("""Package xfoxox not found in current path:
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox
-    @test_throws ArgumentError import xfoxox =#
+    @test_throws ArgumentError import xfoxox
 end
 
 @testset "project & manifest import" begin

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -269,7 +269,7 @@ end
 
 module NotPkgModule; end
 
-@testset "require exceptions and modul name hints" begin
+@testset "modul name hints" begin
     @test modulnamehint("Fooo") == "Foo"
     @test modulnamehint("fooo") == "Foo"
     @test modulnamehint("foo") == "Foo"
@@ -300,12 +300,6 @@ module NotPkgModule; end
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox
     @test_throws ArgumentError import xfoxox
-
-    # require Error - xfoxox does not exist
-    @test_throws ArgumentError require(Test, :xfoxox)
-
-    # require Warning - Loading Foo into Test
-    @test_logs (:warn, r"Loading Foo into Test from") require(Test, :Foo)
 end
 
 @testset "project & manifest import" begin

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -268,8 +268,8 @@ end
 end
 
 module NotPkgModule; end
-
-@testset "modul name hints" begin
+#=
+@testset "modul name hint" begin
     @test modulnamehint("Fooo") == "Foo"
     @test modulnamehint("fooo") == "Foo"
     @test modulnamehint("foo") == "Foo"
@@ -277,10 +277,10 @@ module NotPkgModule; end
     @test modulnamehint("UUID") == "UUIDs"
     @test modulnamehint("uuid") == "UUIDs"
     @test modulnamehint("Rand") == "Random"
-    @test modulnamehint("ran") == nothing
-    @test modulnamehint("infoodrest") == nothing
-    @test modulnamehint("fo") == nothing
-    @test modulnamehint("xfoxox") == nothing
+    @test isnothing(modulnamehint("ran"))
+    @test isnothing(modulnamehint("infoodrest"))
+    @test isnothing(modulnamehint("fo"))
+    @test isnothing(modulnamehint("xfoxox"))
 
     #test Stdlib still works with empty load_path() for Project
     l_p = copy(LOAD_PATH)
@@ -301,7 +301,7 @@ module NotPkgModule; end
     """) using xfoxox
     @test_throws ArgumentError import xfoxox
 end
-
+=#
 @testset "project & manifest import" begin
     @test !@isdefined Foo
     @test !@isdefined Bar

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -282,12 +282,6 @@ module NotPkgModule; end
     @test isnothing(modulnamehint("fo"))
     @test isnothing(modulnamehint("xfoxox"))
 
-    #test Stdlib still works with empty load_path() for Project
-    l_p = copy(LOAD_PATH)
-    empty!(LOAD_PATH)
-    @test modulnamehint("Rand") == "Random"
-    append!(LOAD_PATH, l_p)
-
     # using/import foo - Error with modulmamehint = "Foo"
     @test_throws ArgumentError("""Did you mean Foo? Your entry foo is
     not found in current path. Correct your entry and try again, or run

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -281,7 +281,7 @@ module NotPkgModule; end
     @test isnothing(modulenamehint("infoodrest"))
     @test isnothing(modulenamehint("fo"))
     @test isnothing(modulenamehint("xfoxox"))
-
+#=
     # using/import foo - Error with modulemamehint = "Foo"
     @test_throws ArgumentError("""Did you mean Foo? Your entry foo is
     not found in current path. Correct your entry and try again, or run
@@ -293,7 +293,8 @@ module NotPkgModule; end
     @test_throws ArgumentError("""Package xfoxox not found in current path:
     - Run `import Pkg; Pkg.add("xfoxox")` to install the xfoxox package.
     """) using xfoxox
-    @test_throws ArgumentError import xfoxox
+    @test_throws ArgumentError import xfoxox 
+=#
 end
 
 @testset "project & manifest import" begin


### PR DESCRIPTION
close #38604
I tried to keep it simple and avoid deps with REPL and Pkg.
The tests cover now this exception of require - so coverage should be better a little bit.