### PR TITLE
Only print a single `LoadError:` prefix for nested LoadErrors during showerror

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -91,17 +91,9 @@ function showerror(io::IO, ex, bt; backtrace=true)
     end
 end
 
-function showerror(io::IO, ex::LoadError, bt; backtrace=true, depth = 1)
-    if ex.error isa LoadError
-        showerror(io, ex.error, bt, backtrace=backtrace, depth = depth + 1)
-    else
-        if depth == 1
-            print(io, "LoadError: ")
-        else
-            print(io, "LoadError (x$depth): ")
-        end
-        showerror(io, ex.error, bt, backtrace=backtrace)
-    end
+function showerror(io::IO, ex::LoadError, bt; backtrace=true)
+    !isa(ex.error, LoadError) && print(io, "LoadError: ")
+    showerror(io, ex.error, bt, backtrace=backtrace)
     print(io, "\nin expression starting at $(ex.file):$(ex.line)")
 end
 showerror(io::IO, ex::LoadError) = showerror(io, ex, [])

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -91,9 +91,17 @@ function showerror(io::IO, ex, bt; backtrace=true)
     end
 end
 
-function showerror(io::IO, ex::LoadError, bt; backtrace=true)
-    print(io, "LoadError: ")
-    showerror(io, ex.error, bt, backtrace=backtrace)
+function showerror(io::IO, ex::LoadError, bt; backtrace=true, depth = 1)
+    if ex.error isa LoadError
+        showerror(io, ex.error, bt, backtrace=backtrace, depth = depth + 1)
+    else
+        if depth == 1
+            print(io, "LoadError: ")
+        else
+            print(io, "LoadError (x$depth): ")
+        end
+        showerror(io, ex.error, bt, backtrace=backtrace)
+    end
     print(io, "\nin expression starting at $(ex.file):$(ex.line)")
 end
 showerror(io::IO, ex::LoadError) = showerror(io, ex, [])


### PR DESCRIPTION
Edit: Updated to

```
ERROR: LoadError: ArgumentError: Package CompilerSupportLibraries_jll [e66e0078-7015-5450-92f7-15fbd957f2ae] is required but does not seem to be installed:
 - Run `Pkg.instantiate()` to install all recorded dependencies.
... (backtrace)
in expression starting at /Users/ian/.julia/packages/OpenSpecFun_jll/Xw8XK/src/wrappers/x86_64-apple-darwin-libgfortran5.jl:4
in expression starting at /Users/ian/.julia/packages/OpenSpecFun_jll/Xw8XK/src/OpenSpecFun_jll.jl:2
in expression starting at /Users/ian/.julia/packages/SpecialFunctions/24S26/src/SpecialFunctions.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/forward/number.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/forward/Forward.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/Zygote.jl:1
in expression starting at /Users/ian/.julia/packages/Flux/q3zeA/src/Flux.jl:1
```

________
(Original suggestion)

Folds repeated `LoadError:` prints into `LoadError (xN):` where N is the depth. Prints normally if depth is 1

Before:
```
ERROR: LoadError: LoadError: LoadError: LoadError: LoadError: LoadError: LoadError: ArgumentError: Package CompilerSupportLibraries_jll [e66e0078-7015-5450-92f7-15fbd957f2ae] is required but does not seem to be installed:
 - Run `Pkg.instantiate()` to install all recorded dependencies.
... (backtrace)
in expression starting at /Users/ian/.julia/packages/OpenSpecFun_jll/Xw8XK/src/wrappers/x86_64-apple-darwin-libgfortran5.jl:4
in expression starting at /Users/ian/.julia/packages/OpenSpecFun_jll/Xw8XK/src/OpenSpecFun_jll.jl:2
in expression starting at /Users/ian/.julia/packages/SpecialFunctions/24S26/src/SpecialFunctions.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/forward/number.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/forward/Forward.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/Zygote.jl:1
in expression starting at /Users/ian/.julia/packages/Flux/q3zeA/src/Flux.jl:1

```
This PR:
```
ERROR: LoadError (x7): ArgumentError: Package CompilerSupportLibraries_jll [e66e0078-7015-5450-92f7-15fbd957f2ae] is required but does not seem to be installed:
 - Run `Pkg.instantiate()` to install all recorded dependencies.
... (backtrace)
in expression starting at /Users/ian/.julia/packages/OpenSpecFun_jll/Xw8XK/src/wrappers/x86_64-apple-darwin-libgfortran5.jl:4
in expression starting at /Users/ian/.julia/packages/OpenSpecFun_jll/Xw8XK/src/OpenSpecFun_jll.jl:2
in expression starting at /Users/ian/.julia/packages/SpecialFunctions/24S26/src/SpecialFunctions.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/forward/number.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/forward/Forward.jl:1
in expression starting at /Users/ian/.julia/packages/Zygote/nK6sg/src/Zygote.jl:1
in expression starting at /Users/ian/.julia/packages/Flux/q3zeA/src/Flux.jl:1
```