### PR TITLE
inline exp functions

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -203,7 +203,7 @@ for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
             x === xf && throw(MethodError($func, (x,)))
             return ($func)(xf)
         end
-        function ($func)(x::T) where T<:Float64
+        @inline function ($func)(x::T) where T<:Float64
             N_float = muladd(x, LogBo256INV($base, T), MAGIC_ROUND_CONST(T))
             N = reinterpret(uinttype(T), N_float) % Int32
             N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV($base, T))
@@ -226,7 +226,7 @@ for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
             return reinterpret(T, twopk + reinterpret(Int64, small_part))
         end
 
-        function ($func)(x::T) where T<:Float32
+        @inline function ($func)(x::T) where T<:Float32
             N_float = round(x*LogBINV($base, T))
             N = unsafe_trunc(Int32, N_float)
             r = muladd(N_float, LogBU($base, T), x)


### PR DESCRIPTION
Now that the bulk of my changes to exp have been merged, I want to know if we should consider adding `@inline` to the code. The upside is faster performance and possible vectorization (although vectorizing requires `@simd ivdep` for `Float64`). The disadvantage is probable increased compile times, and possible performance hits in some situations due to spilling code caches. This `@inline` was removed from the original PR as it added questions to a PR that was already hard to merge due to it's scope, but I think this is probably worth it.