### PR TITLE
Fix inference precision regression for functions returning PartialStruct

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2965,3 +2965,8 @@ f37943(x::Any, i::Int) = getfield((x::Pair{false, Int}), i)
 g37943(i::Int) = fieldtype(Pair{false, T} where T, i)
 @test only(Base.return_types(f37943, Tuple{Any, Int})) === Union{}
 @test only(Base.return_types(g37943, Tuple{Int})) === Union{Type{Union{}}, Type{Any}}
+
+# Don't let PartialStruct prevent const prop
+f_partial_struct_constprop(a, b) = (a[1]+b[1], nothing)
+g_partial_struct_constprop() = Val{f_partial_struct_constprop((1,), (1,))[1]}()
+@test only(Base.return_types(g_partial_struct_constprop, Tuple{})) === Val{2}


### PR DESCRIPTION
Consider the included test case:
```
f_partial_struct_constprop(a, b) = (a[1]+b[1], 2)
g_partial_struct_constprop() = Val{f_partial_struct_constprop((1,), (1,))[1]}()
```

The function `f_partial_struct_constprop` used to infer to `Tuple{Int, Int}`
be eligible for constprop and then get improved to `Const((2,2))`. However,
at some point we sharpened the original inference to `PartialStrict((::Int, 2))`,
which caused an early-out that prevented the consideration of this method
for constant propagation purposes, regressing the overall inference result
to `Tuple{Int, Int}`. Fix that by allowing `PartialStruct` to pass through
the early out. I'm not seeing any impact on inference times.