### PR TITLE
Allow a slightly wider class of constants to be inlined

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -72,11 +72,24 @@ function quoted(@nospecialize(x))
     return is_self_quoting(x) ? x : QuoteNode(x)
 end
 
-function is_inlineable_constant(@nospecialize(x))
-    if x isa Type || x isa Symbol
-        return true
+function count_const_size(@nospecialize(x))
+    (x isa Type || x isa Symbol) && return 0
+    ismutable(x) && return MAX_INLINE_CONST_SIZE + 1
+    isbits(x) && return Core.sizeof(x)
+    dt = typeof(x)
+    sz = sizeof(dt)
+    sz > MAX_INLINE_CONST_SIZE && return MAX_INLINE_CONST_SIZE + 1
+    dtfd = DataTypeFieldDesc(dt)
+    for i = 1:nfields(x)
+        dtfd[i].isptr || continue
+        sz += count_const_size(getfield(x, i))
+        sz > MAX_INLINE_CONST_SIZE && return MAX_INLINE_CONST_SIZE + 1
     end
-    return isbits(x) && Core.sizeof(x) <= MAX_INLINE_CONST_SIZE
+    return sz
+end
+
+function is_inlineable_constant(@nospecialize(x))
+    return count_const_size(x) <= MAX_INLINE_CONST_SIZE
 end
 
 ###########################

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -315,3 +315,12 @@ function f37555(x::Int; kwargs...)
 end
 @test f37555(1) == 1
 
+# Test that we can inline small constants even if they are not isbits
+struct NonIsBitsDims
+    dims::NTuple{N, Int} where N
+end
+NonIsBitsDims() = NonIsBitsDims(())
+let ci = code_typed(NonIsBitsDims, Tuple{})[1].first
+    @test length(ci.code) == 1 && isa(ci.code[1], ReturnNode) &&
+        ci.code[1].val.value == NonIsBitsDims()
+end


### PR DESCRIPTION
Currently we only inline constants (i.e. replace Const() yielding
statements by the constants themselves) if the constant in question
is isbits. We do this to avoid blowing up the size of the IR by
inlining constants that are too large. However, there are some
useful small constants that this definition ignores. E.g. I
was working with structs of the form:
```
struct Dims
    d::NTuple{N, Int} where N
end
```
and the IR was littered with various pure statements that the
optimizer wouldn't inline because this struct isn't considered
isbits (side-note, I want to change that, but that's a separate
issue). Here I'm proposing changing the criteria for a struct
to be eligible for inlining slightly: Rather than just looking
for isbits, we recurse through any immutable, isbits fields and
as long as the size of all structs combined isn't too large, we
allow the inlining.