### PR TITLE
[LLVM] add freeze intrinsic

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -10,7 +10,7 @@ const _NAMEDTUPLE_NAME = NamedTuple.body.body.name
 
 const INT_INF = typemax(Int) # integer infinity
 
-const N_IFUNC = reinterpret(Int32, arraylen) + 1
+const N_IFUNC = reinterpret(Int32, Core.Intrinsics.freeze_llvm) + 1
 const T_IFUNC = Vector{Tuple{Int, Int, Any}}(undef, N_IFUNC)
 const T_IFUNC_COST = Vector{Int}(undef, N_IFUNC)
 const T_FFUNC_KEY = Vector{Any}()
@@ -207,6 +207,7 @@ add_tfunc(checked_umul_int, 2, 2, chk_tfunc, 10)
     ## other, misc intrinsics ##
 add_tfunc(Core.Intrinsics.llvmcall, 3, INT_INF,
           (@nospecialize(fptr), @nospecialize(rt), @nospecialize(at), a...) -> instanceof_tfunc(rt)[1], 10)
+add_tfunc(Core.Intrinsics.freeze_llvm, 1, 1, math_tfunc, 1)
 cglobal_tfunc(@nospecialize(fptr)) = Ptr{Cvoid}
 cglobal_tfunc(@nospecialize(fptr), @nospecialize(t)) = (isType(t) ? Ptr{t.parameters[1]} : Ptr)
 cglobal_tfunc(@nospecialize(fptr), t::Const) = (isa(t.val, Type) ? Ptr{t.val} : Ptr)
@@ -1570,6 +1571,7 @@ function intrinsic_nothrow(f::IntrinsicFunction, argtypes::Array{Any, 1})
         # wrong # of args
         return false
     end
+    f === Intrinsics.freeze_llvm && return true
     # TODO: We could do better for cglobal
     f === Intrinsics.cglobal && return false
     # TODO: We can't know for sure, but the user should have a way to assert

--- a/base/float.jl
+++ b/base/float.jl
@@ -417,31 +417,33 @@ isless( x::Float64, y::Float64) = fpislt(x, y)
 #  a. convert fy back to Ti and compare with original y
 #  b. unsafe_convert undefined behaviour if fy == Tf(typemax(Ti))
 #     (but consequently x == fy > y)
+#     use `Intrinsics.freeze_llvm` to prevent poison propagation.
+freeze_trunc(::Type{T}, val) where T = Intrinsics.freeze_llvm(unsafe_trunc(T, val))
 for Ti in (Int64,UInt64,Int128,UInt128)
     for Tf in (Float16,Float32,Float64)
         @eval begin
             function ==(x::$Tf, y::$Ti)
                 fy = ($Tf)(y)
-                (x == fy) & (fy != $(Tf(typemax(Ti)))) & (y == unsafe_trunc($Ti,fy))
+                (x == fy) & (fy != $(Tf(typemax(Ti)))) & (y == freeze_trunc($Ti,fy))
             end
             ==(y::$Ti, x::$Tf) = x==y
 
             function <(x::$Ti, y::$Tf)
                 fx = ($Tf)(x)
-                (fx < y) | ((fx == y) & ((fx == $(Tf(typemax(Ti)))) | (x < unsafe_trunc($Ti,fx)) ))
+                (fx < y) | ((fx == y) & ((fx == $(Tf(typemax(Ti)))) | (x < freeze_trunc($Ti,fx)) ))
             end
             function <=(x::$Ti, y::$Tf)
                 fx = ($Tf)(x)
-                (fx < y) | ((fx == y) & ((fx == $(Tf(typemax(Ti)))) | (x <= unsafe_trunc($Ti,fx)) ))
+                (fx < y) | ((fx == y) & ((fx == $(Tf(typemax(Ti)))) | (x <= freeze_trunc($Ti,fx)) ))
             end
 
             function <(x::$Tf, y::$Ti)
                 fy = ($Tf)(y)
-                (x < fy) | ((x == fy) & (fy < $(Tf(typemax(Ti)))) & (unsafe_trunc($Ti,fy) < y))
+                (x < fy) | ((x == fy) & (fy < $(Tf(typemax(Ti)))) & (freeze_trunc($Ti,fy) < y))
             end
             function <=(x::$Tf, y::$Ti)
                 fy = ($Tf)(y)
-                (x < fy) | ((x == fy) & (fy < $(Tf(typemax(Ti)))) & (unsafe_trunc($Ti,fy) <= y))
+                (x < fy) | ((x == fy) & (fy < $(Tf(typemax(Ti)))) & (freeze_trunc($Ti,fy) <= y))
             end
         end
     end

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1291,6 +1291,9 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
         FunctionCallee sqrtintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::sqrt, makeArrayRef(t));
         return math_builder(ctx, true)().CreateCall(sqrtintr, x);
     }
+    case freeze_llvm: {
+        return ctx.builder.CreateFreeze(x);
+    }
 
     default:
         assert(0 && "invalid intrinsic");

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -97,8 +97,10 @@
     ALIAS(llvmcall, llvmcall) \
     /* object access */ \
     ADD_I(arraylen, 1) \
+    /* LLVM freeze */ \
+    ADD_I(freeze_llvm, 1) \
     /*  hidden intrinsics */ \
-    ADD_HIDDEN(cglobal_auto, 1)
+    ADD_HIDDEN(cglobal_auto, 1) \
 
 enum intrinsic {
 #define ADD_I(func, nargs) func,

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -757,4 +757,5 @@
     XX(jl_wakeup_thread) \
     XX(jl_xor_int) \
     XX(jl_yield) \
-    XX(jl_zext_int)
+    XX(jl_zext_int) \
+    XX(jl_freeze_llvm)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1035,6 +1035,7 @@ JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t 
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
 JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty);
 JL_DLLEXPORT jl_value_t *jl_cglobal_auto(jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_freeze_llvm(jl_value_t *v);
 
 JL_DLLEXPORT jl_value_t *jl_neg_int(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_add_int(jl_value_t *a, jl_value_t *b);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -31,6 +31,13 @@ JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v)
     return jl_new_bits(ty, jl_data_ptr(v));
 }
 
+
+// run time version of bitcast intrinsic
+JL_DLLEXPORT jl_value_t *jl_freeze_llvm(jl_value_t *v)
+{
+    return v;
+}
+
 // run time version of pointerref intrinsic (warning: i is not rooted)
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align)
 {


### PR DESCRIPTION
LLVM introduced the [freeze instruction](https://llvm.org/docs/LangRef.html#freeze-instruction), and started using [`poison`](https://llvm.org/docs/LangRef.html#poison-values), which is a stronger variant of `undef`, in many more places.

As an example:
```
define i64 @test() {
  %fval = sitofp i64 9223372036854775807 to double
  %val = fptosi double %fval to i64
  ret i64 %val
}
define double @test1() {
  %fval = sitofp i64 9223372036854775807 to double
  ret double %fval
}
define i64 @test2() {
  %val = fptosi double 0x43E0000000000000 to i64
  ret i64 %val
}
```

yields on LLVM 11:

```
~> opt -instcombine -S test.ll
; ModuleID = 'test.ll'
source_filename = "test.ll"
define i64 @test() {
  ret i64 undef
}
define double @test1() {
  ret double 0x43E0000000000000
}
define i64 @test2() {
  ret i64 undef
}
```

and on LLVM 12:

```
; ModuleID = 'test.ll'
source_filename = "test.ll"
define i64 @test() {
  ret i64 poison
}
define double @test1() {
  ret double 0x43E0000000000000
}
define i64 @test2() {
  ret i64 poison
}
```

In places where we have previously been relying on undefined behaviour like:
https://github.com/JuliaLang/julia/blob/65382c708d1fafeebb7b896dfeb2795362fe8921/base/float.jl#L394

We now need to `freeze` the poison value at that moment instead of allowing it to propagate. The test-case I came across this first was:

```julia
f(timeout) =  timeout < typemax(Clong)
```

which would yield: `f(Inf) == true` on LLVM 12.


