### PR TITLE
[LLVM] Set type of StructRet attribute

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1014,7 +1014,11 @@ std::string generate_func_sig(const char *fname)
         else if (abi->use_sret((jl_datatype_t*)rt)) {
             AttrBuilder retattrs = AttrBuilder();
 #if !defined(_OS_WINDOWS_) // llvm used to use the old mingw ABI, skipping this marking works around that difference
+#if JL_LLVM_VERSION < 120000
             retattrs.addAttribute(Attribute::StructRet);
+#else
+            retattrs.addStructRetAttr(lrt);
+#endif
 #endif
             retattrs.addAttribute(Attribute::NoAlias);
             paramattrs.push_back(std::move(retattrs));

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1446,6 +1446,7 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                     MaybeNoteDef(S, BBS, CI, BBS.Safepoints);
                 }
                 if (CI->hasStructRetAttr()) {
+                    // TODO: get ElT from SRet attribute
                     Type *ElT = (CI->arg_begin()[0])->getType()->getPointerElementType();
                     auto tracked = CountTrackedPointers(ElT);
                     if (tracked.count) {


### PR DESCRIPTION
The Langref for LLVM states that type for the `StructRet` attribute is optional, but to quote:

> The sret attribute also supports an optional type argument, which must be the same as the pointee type of the argument. In the future this will be required.

In LLVM 12/current master I observed crashes in code that already assumes that the type is set, so this future proof things by always emitting the type alongside the attribute.
