### PR TITLE
make firstindex(a,d) and lastindex(a,d) default to calling axes(a,d)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,7 +44,7 @@ Language changes
   a function like other operators. The dotted version `.-->` is now parsed as well.
   For backwards compatibility, `-->` still parses using its own expression head
   instead of `:call`.
-* The `a[begin,k]` syntax now calls `firstindex(a,1)` rather than `first(axes(a,1))` ([#35779]), but the former now defaults to the latter for any `a` ([#38742]).
+* The `a[begin, k]` syntax now calls `firstindex(a, 1)` rather than `first(axes(a, 1))` ([#35779]), but the former now defaults to the latter for any `a` ([#38742]).
 * `⌿` (U+233F) and `¦` (U+00A6) are now infix operators with times-like and plus-like precedence,
   respectively. Previously they were parsed as identifier characters ([#37973]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,7 +44,7 @@ Language changes
   a function like other operators. The dotted version `.-->` is now parsed as well.
   For backwards compatibility, `-->` still parses using its own expression head
   instead of `:call`.
-* The `a[begin]` syntax now calls `firstindex(a,1)` rather than `first(axes(a,1))` ([#35779]).
+* The `a[begin,k]` syntax now calls `firstindex(a,1)` rather than `first(axes(a,1))` ([#35779]), but the former now defaults to the latter for any `a` ([#38742]).
 * `⌿` (U+233F) and `¦` (U+00A6) are now infix operators with times-like and plus-like precedence,
   respectively. Previously they were parsed as identifier characters ([#37973]).
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -345,7 +345,7 @@ julia> lastindex(rand(3,4,5), 2)
 ```
 """
 lastindex(a::AbstractArray) = (@_inline_meta; last(eachindex(IndexLinear(), a)))
-lastindex(a::AbstractArray, d) = (@_inline_meta; last(axes(a, d)))
+lastindex(a, d) = (@_inline_meta; last(axes(a, d)))
 
 """
     firstindex(collection) -> Integer
@@ -363,7 +363,7 @@ julia> firstindex(rand(3,4,5), 2)
 ```
 """
 firstindex(a::AbstractArray) = (@_inline_meta; first(eachindex(IndexLinear(), a)))
-firstindex(a::AbstractArray, d) = (@_inline_meta; first(axes(a, d)))
+firstindex(a, d) = (@_inline_meta; first(axes(a, d)))
 
 first(a::AbstractArray) = a[first(eachindex(a))]
 

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -193,7 +193,9 @@ julia> Squares(23)[end]
 529
 ```
 
-For multi-dimensional `begin`/`end` indexing as in `a[3,begin,7]`, for example, you should define `firstindex(a,dim)` and `lastindex(a,dim)` (which default to calling `first` and `last` on `axes(a,dim)`, respectively).
+For multi-dimensional `begin`/`end` indexing as in `a[3, begin, 7]`, for example,
+you should define `firstindex(a, dim)` and `lastindex(a, dim)`
+(which default to calling `first` and `last` on `axes(a, dim)`, respectively).
 
 Note, though, that the above *only* defines [`getindex`](@ref) with one integer index. Indexing with
 anything other than an `Int` will throw a [`MethodError`](@ref) saying that there was no matching method.

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -193,6 +193,8 @@ julia> Squares(23)[end]
 529
 ```
 
+For multi-dimensional `begin/end` indexing as in `a[3,begin,7]`, for example, you should define `firstindex(a,dim)` and `lastindex(a,dim)` (which default to calling `first` and `last` on `axes(a,dim)`, respectively).
+
 Note, though, that the above *only* defines [`getindex`](@ref) with one integer index. Indexing with
 anything other than an `Int` will throw a [`MethodError`](@ref) saying that there was no matching method.
 In order to support indexing with ranges or vectors of `Int`s, separate methods must be written:

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -193,7 +193,7 @@ julia> Squares(23)[end]
 529
 ```
 
-For multi-dimensional `begin/end` indexing as in `a[3,begin,7]`, for example, you should define `firstindex(a,dim)` and `lastindex(a,dim)` (which default to calling `first` and `last` on `axes(a,dim)`, respectively).
+For multi-dimensional `begin`/`end` indexing as in `a[3,begin,7]`, for example, you should define `firstindex(a,dim)` and `lastindex(a,dim)` (which default to calling `first` and `last` on `axes(a,dim)`, respectively).
 
 Note, though, that the above *only* defines [`getindex`](@ref) with one integer index. Indexing with
 anything other than an `Int` will throw a [`MethodError`](@ref) saying that there was no matching method.


### PR DESCRIPTION
As discussed in #35779, this improves backwards compatibility for the `a[begin]` change.

In fact, this was already the default behavior, but previously only for `AbstractArray` — with this change, it is the default for multidimensional indexing of any collection.

cc @bkamins, @nalimilan 