### PR TITLE
Make eltype of range(::Integer; step, length) depend on typeof(step)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -116,9 +116,9 @@ _range(a::T, step::T, ::Nothing, len::Integer) where {T <: AbstractFloat} =
 _range(a::T, step, ::Nothing, len::Integer) where {T} =
     _rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
 _rangestyle(::Ordered, ::ArithmeticWraps, a::T, step::S, len::Integer) where {T,S} =
-    StepRange{typeof(a+false*step),S}(a, step, a+step*(len-1))
+    StepRange{typeof(a+step),S}(a, step, a+step*(len-1))
 _rangestyle(::Any, ::Any, a::T, step::S, len::Integer) where {T,S} =
-    StepRangeLen{typeof(a+false*step),T,S}(a, step, len)
+    StepRangeLen{typeof(a+step),T,S}(a, step, len)
 
 # Malformed calls
 _range(start,     step,      ::Nothing, ::Nothing) = # range(a, step=s)

--- a/base/range.jl
+++ b/base/range.jl
@@ -116,9 +116,9 @@ _range(a::T, step::T, ::Nothing, len::Integer) where {T <: AbstractFloat} =
 _range(a::T, step, ::Nothing, len::Integer) where {T} =
     _rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
 _rangestyle(::Ordered, ::ArithmeticWraps, a::T, step::S, len::Integer) where {T,S} =
-    StepRange{typeof(a+0*step),S}(a, step, a+step*(len-1))
+    StepRange{typeof(a+false*step),S}(a, step, a+step*(len-1))
 _rangestyle(::Any, ::Any, a::T, step::S, len::Integer) where {T,S} =
-    StepRangeLen{typeof(a+0*step),T,S}(a, step, len)
+    StepRangeLen{typeof(a+false*step),T,S}(a, step, len)
 
 # Malformed calls
 _range(start,     step,      ::Nothing, ::Nothing) = # range(a, step=s)

--- a/base/range.jl
+++ b/base/range.jl
@@ -116,7 +116,7 @@ _range(a::T, step::T, ::Nothing, len::Integer) where {T <: AbstractFloat} =
 _range(a::T, step, ::Nothing, len::Integer) where {T} =
     _rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
 _rangestyle(::Ordered, ::ArithmeticWraps, a::T, step::S, len::Integer) where {T,S} =
-    StepRange{T,S}(a, step, convert(T, a+step*(len-1)))
+    StepRange{typeof(a+0*step),S}(a, step, a+step*(len-1))
 _rangestyle(::Any, ::Any, a::T, step::S, len::Integer) where {T,S} =
     StepRangeLen{typeof(a+0*step),T,S}(a, step, len)
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1692,3 +1692,8 @@ end
     @test @inferred(intersect(big(1):big(5), 3)) == 3:3
     @test @inferred(intersect(3, big(1):big(5))) == 3:3
 end
+
+@testset "eltype of range(::Integer; step::Rational, length) (#37295)" begin
+    @test range(1, step=1//2, length=3) == range(1//1, step=1//2, length=3)
+    @test eltype(range(1, step=1//2, length=3)) === Rational{Int}
+end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1694,6 +1694,23 @@ end
 end
 
 @testset "eltype of range(::Integer; step::Rational, length) (#37295)" begin
-    @test range(1, step=1//2, length=3) == range(1//1, step=1//2, length=3)
+    @test range(1, step=1//2, length=3) == [1//1, 3//2, 2//1]
     @test eltype(range(1, step=1//2, length=3)) === Rational{Int}
+    @test typeof(step(range(1, step=1//2, length=3))) === Rational{Int}
+
+    @test range(1//1, step=2, length=3) == [1, 3, 5]
+    @test eltype(range(1//1, step=2, length=3)) === Rational{Int}
+    @test typeof(step(range(1//1, step=2, length=3))) === Int
+
+    @test range(Int16(1), step=Rational{Int8}(1,2), length=3) == [1//1, 3//2, 2//1]
+    @test eltype(range(Int16(1), step=Rational{Int8}(1,2), length=3)) === Rational{Int16}
+    @test typeof(step(range(Int16(1), step=Rational{Int8}(1,2), length=3))) === Rational{Int8}
+
+    @test range(Rational{Int8}(1), step=Int16(2), length=3) == [1, 3, 5]
+    @test eltype(range(Rational{Int8}(1), step=Int16(2), length=3)) === Rational{Int16}
+    @test typeof(step(range(Rational{Int8}(1), step=Int16(2), length=3))) === Int16
+
+    @test range('a', step=2, length=3) == ['a', 'c', 'e']
+    @test eltype(range('a', step=2, length=3)) === Char
+    @test typeof(step(range('a', step=2, length=3))) === Int
 end


### PR DESCRIPTION
Fixes #37295. This makes `range(1; step=1//2, length=3)` return a `StepRange{Rational{Int}}` instead of a `StepRange{Int}`.

Current behavior:
```julia
julia> range(1, step=1//1, length=5) # StepRange{Int, Rational{Int}}
1:1//1:5

julia> range(1, step=1//2, length=5)
ERROR: ArgumentError: StepRange{<:Integer} cannot have non-integer step
Stacktrace:
[...]
```
With this PR:
```julia
julia> range(1, step=1//1, length=5) # StepRange{Rational{Int}, Rational{Int}}
1//1:1//1:5//1

julia> range(1, step=1//2, length=5)
1//1:1//2:3//1
```