### PR TITLE
[libjulia] correct soname to use only major version number

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -114,7 +114,7 @@ endef
 endif
 
 $(build_shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT): $(LIB_OBJS) | $(build_shlibdir) $(build_libdir)
-	@$(call PRINT_LINK, $(CC) $(call IMPLIB_FLAGS,$@) $(LOADER_CFLAGS) -DLIBRARY_EXPORTS -shared $(SHIPFLAGS) $(LIB_OBJS) -o $@ $(LOADER_LDFLAGS) $(RPATH_LIB)) $(call SONAME_FLAGS,$(notdir $@))
+	@$(call PRINT_LINK, $(CC) $(call IMPLIB_FLAGS,$@) $(LOADER_CFLAGS) -DLIBRARY_EXPORTS -shared $(SHIPFLAGS) $(LIB_OBJS) -o $@ $(LOADER_LDFLAGS) $(RPATH_LIB)) $(call SONAME_FLAGS,libjulia.$(JL_MAJOR_SHLIB_EXT))
 	$(INSTALL_NAME_CMD)libjulia.$(SHLIB_EXT) $@
 ifneq ($(OS), WINNT)
 	@ln -sf $(notdir $@) $(build_shlibdir)/libjulia.$(JL_MAJOR_SHLIB_EXT)


### PR DESCRIPTION
The soname was changed in #38160 to be `libjulia.so.1.6` instead of
`libjulia.so.1`, but probably not on purpose.

This contradicts what is written in the comment in Make.inc and it breaks
e.g. `libcxxwrap_julia_jll` which is linked against `libjulia.so.1`.
See https://github.com/JuliaPackaging/Yggdrasil/issues/2233

Edit:
For example in the latest nightly:
```
$ objdump -x julia-6371070e73/lib/libjulia.so | grep -i soname
  SONAME               libjulia.so.1.6
```