### PR TITLE
Hint on how to type the ÷ sign 

### DIFF
--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -9,24 +9,26 @@ collection of standard mathematical functions.
 The following [arithmetic operators](https://en.wikipedia.org/wiki/Arithmetic#Arithmetic_operations)
 are supported on all primitive numeric types:
 
-| Expression | Name           | Description                            |
-|:---------- |:-------------- |:-------------------------------------- |
-| `+x`       | unary plus     | the identity operation                 |
-| `-x`       | unary minus    | maps values to their additive inverses |
-| `x + y`    | binary plus    | performs addition                      |
-| `x - y`    | binary minus   | performs subtraction                   |
-| `x * y`    | times          | performs multiplication                |
-| `x / y`    | divide         | performs division                      |
-| `x ÷ y`    | integer divide | x / y, truncated to an integer         |
-| `x \ y`    | inverse divide | equivalent to `y / x`                  |
-| `x ^ y`    | power          | raises `x` to the `y`th power          |
-| `x % y`    | remainder      | equivalent to `rem(x,y)`               |
+| Expression | Name           | Description                             |
+|:---------- |:-------------- |:----------------------------------------|
+| `+x`       | unary plus     | the identity operation                  |
+| `-x`       | unary minus    | maps values to their additive inverses  |
+| `x + y`    | binary plus    | performs addition                       |
+| `x - y`    | binary minus   | performs subtraction                    |
+| `x * y`    | times          | performs multiplication                 |
+| `x / y`    | divide         | performs division                       |
+| `x ÷ y`    | integer divide | x / y, truncated to an integer          |
+| `x \ y`    | inverse divide | equivalent to `y / x`                   |
+| `x ^ y`    | power          | raises `x` to the `y`th power           |
+| `x % y`    | remainder      | equivalent to `rem(x,y)`                |
 
 A numeric literal placed directly before an identifier or parentheses, e.g. `2x` or `2(x+y)`, is treated as a multiplication, except with higher precedence than other binary operations.  See [Numeric Literal Coefficients](@ref man-numeric-literal-coefficients) for details.
 
 Julia's promotion system makes arithmetic operations on mixtures of argument types "just work"
 naturally and automatically. See [Conversion and Promotion](@ref conversion-and-promotion) for details of the promotion
 system.
+
+The ÷ sign can be conveniently typed by writing `\div<tab>` to the REPL or Julia IDE. See the [manual section on Unicode input](@ref Unicode-Input) for more information.
 
 Here are some simple examples using arithmetic operators:
 


### PR DESCRIPTION
The last attempt to improve the document unfortunately missed with the build and was therefore reverted. This pr is now the continuation of #38720.

> The ÷ sign is the only operator in this chapter which has no dedicated key on the keyboard. With the Unicode input being at the very end of the documentation, newcomers probably do not know how to write the integer division sign. Therefore, I added this short hint on how to type it.
> 
> Best regards

The issue was a changed Documenter reference which lead to issues with building but was not detected prior to merging. Consequently, I have already tried to fix the reference. Still, I would be glad if someone could check whether the `@ref` to the Unicode-Input chapter would work.

Best regards