### PR TITLE
Revert "Replace LinearAlgebra._iszero by Base.iszero"

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -104,7 +104,9 @@ function isstructurepreserving(::typeof(Base.literal_pow), ::Ref{typeof(^)}, ::S
 end
 isstructurepreserving(f, args...) = false
 
-fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && iszero(v))
+_iszero(n::Number) = iszero(n)
+_iszero(x) = x == 0
+fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && _iszero(v))
 # Like sparse matrices, we assume that the zero-preservation property of a broadcasted
 # expression is stable.  We can test the zero-preservability by applying the function
 # in cases where all other arguments are known scalars against a zero from the structured

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -205,22 +205,4 @@ end
     @test typeof(tmp) <: Tridiagonal
 
 end
-
-struct Zero end
-Base.iszero(::Zero) = true
-Base.zero(::Type{Zero}) = Zero()
-@testset "PR #36193" begin
-    z = Zero()
-    Z = [z z
-         z z]
-    zz = [z, z]
-    U = UpperTriangular(Z)
-    L = LowerTriangular(Z)
-    D = Diagonal(zz)
-    for a in [U, L, D]
-        @test identity.(a) isa typeof(a)
-        @test map(identity, a) isa typeof(a)
-    end
-end
-
 end

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -205,4 +205,8 @@ end
     @test typeof(tmp) <: Tridiagonal
 
 end
+
+# structured broadcast with function returning non-number type
+@test tuple.(Diagonal([1, 2])) == [(1,) (0,); (0,) (2,)]
+
 end


### PR DESCRIPTION
Reverts JuliaLang/julia#36194

This broke broadcasting for `Diagonal`, since:
```
julia> LinearAlgebra.fzeropreserving(Base.broadcasted(tuple, Diagonal([1, 2])))
ERROR: MethodError: no method matching zero(::Tuple{Int64})
Closest candidates are:
  zero(::Union{Type{P}, P}) where P<:Dates.Period at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/periods.jl:53
  zero(::AbstractIrrational) at irrationals.jl:148
  zero(::Diagonal{T, StaticArrays.SVector{N, T}}) where {N, T} at /home/sschaub/.julia/packages/StaticArrays/NTbHj/src/SDiagonal.jl:41
  ...
Stacktrace:
 [1] iszero(x::Tuple{Int64})
   @ Base ./number.jl:40
 [2] fzeropreserving(bc::Base.Broadcast.Broadcasted{LinearAlgebra.StructuredMatrixStyle{Diagonal{Int64, Vector{Int64}}}, Nothing, typeof(tuple), Tuple{Diagonal{Int64, Vector{Int64}}}})
   @ LinearAlgebra /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/structuredbroadcast.jl:107
 [3] top-level scope
   @ REPL[11]:1
```
whereas before this just returned false. cc: @blegat 