### PR TITLE
define `method bytesavailable(::DevNull)`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -401,6 +401,7 @@ julia> bytesavailable(io)
 ```
 """
 bytesavailable(io::AbstractPipe) = bytesavailable(pipe_reader(io)::IO)
+bytesavailable(io::DevNull) = 0
 
 """
     eof(stream) -> Bool

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -341,3 +341,7 @@ end
     @test peek(io, Int32) == -476872221
     close(io)
 end
+
+@testset "bytesavailable devnull" begin
+    @test bytesavailable(devnull) == 0
+end


### PR DESCRIPTION
This method extends the usability of the `devnull` device. The returned value of `0` seems appropriate for a device, which is not able to deliver any byte at any time.