### PR TITLE
Add test for checked_den promotion in rational

### DIFF
--- a/test/rational.jl
+++ b/test/rational.jl
@@ -601,3 +601,7 @@ end
     @test !ispow2(3//8)
     @test !ispow2(0//1)
 end
+
+@testset "checked_den with different integer types" begin
+    @test Base.checked_den(Int8(4), Int32(8)) == Base.checked_den(Int32(4), Int32(8))
+end


### PR DESCRIPTION
This method is untested and kind of hard to provoke through other rational methods, because in those the promotion happens before `checked_den` is called.