### PR TITLE
[Make] remove BINARYBUILDER_LLVM_ASSERTS and use LLVM_ASSERTIONS instead

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -454,10 +454,6 @@ CXX_DISABLE_ASSERTION := -DJL_NDEBUG
 DISABLE_ASSERTIONS := -DNDEBUG -DJL_NDEBUG
 endif
 
-ifeq ($(LLVM_ASSERTIONS),0)
-CXX_DISABLE_ASSERTION += -DNDEBUG
-endif
-
 # Compiler specific stuff
 
 ifeq ($(USEMSVC), 1)
@@ -1198,12 +1194,6 @@ endif
 endif
 endef
 $(foreach proj,$(BB_PROJECTS),$(eval $(call SET_BB_DEFAULT,$(proj))))
-
-
-
-# Use the Assertions build
-BINARYBUILDER_LLVM_ASSERTS ?= 0
-
 
 
 # OS specific stuff

--- a/contrib/refresh_checksums.mk
+++ b/contrib/refresh_checksums.mk
@@ -39,7 +39,7 @@ endef
 # If $(2) == `src`, this will generate a `USE_BINARYBUILDER_FOO=0` make flag
 # It will also generate a `FOO_BB_TRIPLET=$(2)` make flag.
 define make_flags
-USE_BINARYBUILDER=$(if $(filter src,$(2)),0,1) $(call makevar,$(1))_BB_TRIPLET=$(if $(filter src,$(2)),,$(2)) BINARYBUILDER_LLVM_ASSERTS=$(if $(filter assert,$(3)),1,0) DEPS_GIT=0
+USE_BINARYBUILDER=$(if $(filter src,$(2)),0,1) $(call makevar,$(1))_BB_TRIPLET=$(if $(filter src,$(2)),,$(2)) LLVM_ASSERTIONS=$(if $(filter assert,$(3)),1,0) DEPS_GIT=0
 endef
 
 # checksum_bb_dep takes in (name, triplet), and generates a `checksum-$(1)-$(2)` target.

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -632,7 +632,7 @@ endif
 else # USE_BINARYBUILDER_LLVM
 
 # We provide a way to subversively swap out which LLVM JLL we pull artifacts from
-ifeq ($(BINARYBUILDER_LLVM_ASSERTS), 1)
+ifeq ($(LLVM_ASSERTIONS), 1)
 LLVM_JLL_DOWNLOAD_NAME := libLLVM_assert
 LLVM_JLL_VER := $(LLVM_ASSERT_JLL_VER)
 endif

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1053,7 +1053,7 @@ std::string generate_func_sig(const char *fname)
                 // see pull req #978. need to annotate signext/zeroext for
                 // small integer arguments.
                 jl_datatype_t *bt = (jl_datatype_t*)tti;
-                if (jl_datatype_size(bt) < 4) {
+                if (jl_datatype_size(bt) < 4 && bt != jl_float16_type) {
                     if (jl_signed_type && jl_subtype(tti, (jl_value_t*)jl_signed_type))
                         ab.addAttribute(Attribute::SExt);
                     else

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -974,10 +974,10 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
                     DebugInfo(errorCodeToError(std::make_error_code(std::errc::no_such_file_or_directory)));
                 // Can't find a way to construct an empty Expected object
                 // that can be ignored.
-                ignoreError(DebugInfo);
                 if (fname.substr(sep + 1) != info.filename) {
                     debuginfopath = fname.substr(0, sep + 1).str();
                     debuginfopath += info.filename;
+                    ignoreError(DebugInfo);
                     DebugInfo = openDebugInfo(debuginfopath, info);
                 }
                 if (!DebugInfo) {

--- a/test/llvmpasses/llvmcall.jl
+++ b/test/llvmpasses/llvmcall.jl
@@ -13,7 +13,7 @@ end
 @generated foo(x)=:(ccall("extern foo", llvmcall, $x, ($x,), x))
 bar(x) = ntuple(i -> VecElement{Float16}(x[i]), 2)
 
-# CHECK: call half @foo(half zeroext %{{[0-9]+}})
+# CHECK: call half @foo(half %{{[0-9]+}})
 emit(foo, Float16)
 
 # CHECK: call [2 x half] @foo([2 x half] %{{[0-9]+}})


### PR DESCRIPTION
Marked as a draft since the assert binaries are older than the current release binaries.

@staticfloat is currently building those manually and building them automatically involves https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/778#issuecomment-628886000 and https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/917

CI is still set-up to run `LLVM_ASSERTIONS=1` so this fixes #38244
