### PR TITLE
fix #38639, mktemp names not always unique on windows in test

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -56,10 +56,12 @@ using Random
     temps = map(1:100) do _
         path, io = mktemp(cleanup=false)
         close(io)
-        rm(path, force=true)
         return path
     end
     @test allunique(temps)
+    foreach(temps) do path
+        rm(path, force=true)
+    end
 end
 
 @testset "tempname with parent" begin


### PR DESCRIPTION
This uses the OS temp file functionality (`GetTempFileNameW`), which only guarantees uniqueness among files that already exist. Here we were removing files between mktemp calls, so names could be reused.

Hopefully fixes #38639