### PR TITLE
Add isdefined check `count_const_size`

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -72,18 +72,21 @@ function quoted(@nospecialize(x))
     return is_self_quoting(x) ? x : QuoteNode(x)
 end
 
-function count_const_size(@nospecialize(x))
+function count_const_size(@nospecialize(x), count_self::Bool = true)
     (x isa Type || x isa Symbol) && return 0
     ismutable(x) && return MAX_INLINE_CONST_SIZE + 1
     isbits(x) && return Core.sizeof(x)
     dt = typeof(x)
-    sz = sizeof(dt)
+    sz = count_self ? sizeof(dt) : 0
     sz > MAX_INLINE_CONST_SIZE && return MAX_INLINE_CONST_SIZE + 1
     dtfd = DataTypeFieldDesc(dt)
     for i = 1:nfields(x)
-        dtfd[i].isptr || continue
         isdefined(x, i) || continue
-        sz += count_const_size(getfield(x, i))
+        f = getfield(x, i)
+        if !dtfd[i].isptr && datatype_pointerfree(typeof(f))
+            continue
+        end
+        sz += count_const_size(f, dtfd[i].isptr)
         sz > MAX_INLINE_CONST_SIZE && return MAX_INLINE_CONST_SIZE + 1
     end
     return sz

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -82,6 +82,7 @@ function count_const_size(@nospecialize(x))
     dtfd = DataTypeFieldDesc(dt)
     for i = 1:nfields(x)
         dtfd[i].isptr || continue
+        isdefined(x, i) || continue
         sz += count_const_size(getfield(x, i))
         sz > MAX_INLINE_CONST_SIZE && return MAX_INLINE_CONST_SIZE + 1
     end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -330,3 +330,4 @@ struct NonIsBitsDimsUndef
     NonIsBitsDimsUndef() = new()
 end
 @test Core.Compiler.is_inlineable_constant(NonIsBitsDimsUndef())
+@test !Core.Compiler.is_inlineable_constant((("a"^1000, "b"^1000), nothing))

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -324,3 +324,9 @@ let ci = code_typed(NonIsBitsDims, Tuple{})[1].first
     @test length(ci.code) == 1 && isa(ci.code[1], ReturnNode) &&
         ci.code[1].val.value == NonIsBitsDims()
 end
+
+struct NonIsBitsDimsUndef
+    dims::NTuple{N, Int} where N
+    NonIsBitsDimsUndef() = new()
+end
+@test Core.Compiler.is_inlineable_constant(NonIsBitsDimsUndef())


### PR DESCRIPTION
This doesn't do much currently, because we only call this function
on `Const` objects which we don't currently create if the initialization
of the object is incomplete, but we may want to do so in the future,
so might as well be defensive about it.