### PR TITLE
Replace _iszero by iszerodefined && iszero

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -104,9 +104,29 @@ function isstructurepreserving(::typeof(Base.literal_pow), ::Ref{typeof(^)}, ::S
 end
 isstructurepreserving(f, args...) = false
 
-_iszero(n::Number) = iszero(n)
-_iszero(x) = x == 0
-fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && _iszero(v))
+"""
+    iszerodefined(T::Type)
+
+Return a `Bool` indicating whether `iszero` is well-defined for objects of type
+`T`. By default, this function returns `true` for types `T` such that
+`zero(::T)` is defined. Note that this function may return `true` even if
+`zero(::T)` is not defined as long as `iszero(::T)` has a method that does not
+requires `zero(::T)`.
+
+This function is used to determine if mapping the elements of an array with
+a specific structure of nonzero elements preserve this structure.
+For instance, it is used to determine whether the output of
+`tuple.(Diagonal([1, 2]))` is `Diagonal([(1,), (2,)])` or
+`[(1,) (0,); (0,) (2,)]`. For this, we need to determine whether `(0,)` is
+considered to be zero. `iszero((0,))` falls back to `(0,) == zero((0,))` which
+fails as `zero(::Tuple{Int})` is not defined. However,
+`iszerodefined(::Tuple{Int})` is `false` hence
+`iszerodefined(::Tuple{Int}) && iszero((0,))` is `false` which decides that the
+correct output is `[(1,) (0,); (0,) (2,)]`.
+"""
+iszerodefined(::Type{T}) where T = hasmethod(zero, Tuple{T})
+
+fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && iszerodefined(typeof(v)) && iszero(v))
 # Like sparse matrices, we assume that the zero-preservation property of a broadcasted
 # expression is stable.  We can test the zero-preservability by applying the function
 # in cases where all other arguments are known scalars against a zero from the structured

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -228,6 +228,8 @@ LinearAlgebra.iszerodefined(::Type{Zero}) = true
     # This should not need `zero(::Type{Zero})` to be defined
     test(1)
     Base.zero(::Type{Zero}) = Zero()
+    # This should not need `==(::Zero, ::Int)` to be defined as `iszerodefined`
+    # returns true.
     test(Zero())
 end
 

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -206,11 +206,11 @@ end
 
 end
 
-struct Zero end
-Base.iszero(::Zero) = true
-LinearAlgebra.iszerodefined(::Type{Zero}) = true
+struct Zero36193 end
+Base.iszero(::Zero36193) = true
+LinearAlgebra.iszerodefined(::Type{Zero36193}) = true
 @testset "PR #36193" begin
-    f(::Union{Int, Zero}) = Zero()
+    f(::Union{Int, Zero36193}) = Zero36193()
     function test(el)
         M = [el el
              el el]
@@ -221,16 +221,16 @@ LinearAlgebra.iszerodefined(::Type{Zero}) = true
         for (T, A) in [(UpperTriangular, U), (LowerTriangular, L), (Diagonal, D)]
             @test identity.(A) isa typeof(A)
             @test map(identity, A) isa typeof(A)
-            @test f.(A) isa T{Zero}
-            @test map(f, A) isa T{Zero}
+            @test f.(A) isa T{Zero36193}
+            @test map(f, A) isa T{Zero36193}
         end
     end
-    # This should not need `zero(::Type{Zero})` to be defined
+    # This should not need `zero(::Type{Zero36193})` to be defined
     test(1)
-    Base.zero(::Type{Zero}) = Zero()
-    # This should not need `==(::Zero, ::Int)` to be defined as `iszerodefined`
+    Base.zero(::Type{Zero36193}) = Zero36193()
+    # This should not need `==(::Zero36193, ::Int)` to be defined as `iszerodefined`
     # returns true.
-    test(Zero())
+    test(Zero36193())
 end
 
 # structured broadcast with function returning non-number type


### PR DESCRIPTION
Take 2 of https://github.com/JuliaLang/julia/pull/36194 after it was reverted in https://github.com/JuliaLang/julia/pull/38764.

What was missing in https://github.com/JuliaLang/julia/pull/36194 is that in case `iszero` is not working for a given type, we should drop the structure and fall back to an `Array`.
This PR defines a `iszerodefined` function that custom types implements in case `iszero` is well-defined even if `zero` is not defined.