### PR TITLE
Dimension mismatch with SymTridiagonal's eigen

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -3807,10 +3807,16 @@ for (stev, stebz, stegr, stein, elty) in
             require_one_based_indexing(dv, ev)
             chkstride1(dv, ev)
             n = length(dv)
-            if length(ev) != n - 1
-                throw(DimensionMismatch("ev has length $(length(ev)) but needs one less than dv's length, $n)"))
+            ne = length(ev)
+            if ne == n - 1
+                eev = [ev; zero($elty)]
+            elseif ne == n
+                eev = copy(ev)
+                eev[n] = zero($elty)
+            else
+                throw(DimensionMismatch("ev has length $(length(ev)) but should be either $(length(dv) - 1) or $(length(dv))"))
             end
-            eev = [ev; zero($elty)]
+
             abstol = Vector{$elty}(undef, 1)
             m = Ref{BlasInt}()
             w = similar(dv, $elty, n)

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -409,7 +409,7 @@ end
         e = rand(elty,9)
         @test_throws DimensionMismatch LAPACK.stev!('U',d,rand(elty,10))
         @test_throws DimensionMismatch LAPACK.stebz!('A','B',zero(elty),zero(elty),0,0,-1.,d,rand(elty,10))
-        @test_throws DimensionMismatch LAPACK.stegr!('N','A',d,rand(elty,10),zero(elty),zero(elty),0,0)
+        @test_throws DimensionMismatch LAPACK.stegr!('N','A',d,rand(elty,11),zero(elty),zero(elty),0,0)
         @test_throws DimensionMismatch LAPACK.stein!(d,zeros(elty,10),zeros(elty,10),zeros(BlasInt,10),zeros(BlasInt,10))
         @test_throws DimensionMismatch LAPACK.stein!(d,e,zeros(elty,11),zeros(BlasInt,10),zeros(BlasInt,10))
     end

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -580,8 +580,11 @@ end
 @testset "Eigendecomposition with different lengths" begin
     # length(A.ev) can be either length(A.dv) or length(A.dv) - 1
     A = SymTridiagonal(fill(1.0, 3), fill(-1.0, 3))
-    @test eigen(A) == eigen(Matrix(A))
-    @test_throws DimensionMismatch LAPACK.stegr!('V', A.dv, [A.ev; 1.0])
+    F = eigen(A)
+    A2 = SymTridiagonal(fill(1.0, 3), fill(-1.0, 2))
+    F2 = eigen(A2)
+    test_approx_eq_modphase(F.vectors, F2.vectors)
+    @test F.values ≈ F2.values
 end
 
 end # module TestTridiagonal

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -576,4 +576,12 @@ end
     @test_throws ArgumentError SymTridiagonal{Float32}(T)
 end
 
+# Issue #38765
+@testset "Eigendecomposition with different lengths" begin
+    # length(A.ev) can be either length(A.dv) or length(A.dv) - 1
+    A = SymTridiagonal(fill(1.0, 3), fill(-1.0, 3))
+    @test eigen(A) == eigen(Matrix(A))
+    @test_throws DimensionMismatch LAPACK.stegr!('V', A.dv, [A.ev; 1.0])
+end
+
 end # module TestTridiagonal


### PR DESCRIPTION
Closes https://github.com/JuliaLang/LinearAlgebra.jl/issues/796.

Please note the [related suggestion](https://github.com/JuliaLang/LinearAlgebra.jl/issues/796) to relax the dimensional constraints of the superdiagonal vector in some LAPACK eigensolvers. I didn't address it in this PR.

CC: @dkarrasch 