### PR TITLE
[LibCURL]: Reconcile BB and from-source configuration of LibCURL.

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -4,8 +4,12 @@ ifeq ($(USE_SYSTEM_LIBSSH2), 0)
 $(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/libssh2
 endif
 
-ifeq ($(USE_SYSTEM_MBEDTLS), 0)
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/mbedtls
+ifeq ($(USE_SYSTEM_ZLIB), 0)
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/zlib
+endif
+
+ifeq ($(USE_SYSTEM_NGHTTP2), 0)
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/nghttp2
 endif
 
 ifneq ($(USE_BINARYBUILDER_CURL),1)
@@ -29,16 +33,28 @@ $(SRCCACHE)/curl-$(CURL_VER)/source-extracted: $(SRCCACHE)/curl-$(CURL_VER).tar.
 checksum-curl: $(SRCCACHE)/curl-$(CURL_VER).tar.bz2
 	$(JLCHECKSUM) $<
 
+# We use different TLS libraries on different platforms.
+#   On Windows, we use schannel
+#   On MacOS, we use SecureTransport
+#   On Linux, we use mbedTLS
+ifeq ($(OS), WINNT)
+CURL_TLS_CONFIGURE_FLAGS := --with-schannel
+else ifeq ($(OS), Darwin)
+CURL_TLS_CONFIGURE_FLAGS := --with-secure-transport
+else
+CURL_TLS_CONFIGURE_FLAGS := --with-mbedtls=$(build_prefix)
+endif
+
 $(BUILDDIR)/curl-$(CURL_VER)/build-configured: $(SRCCACHE)/curl-$(CURL_VER)/source-extracted
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CONFIGURE_COMMON) --includedir=$(build_includedir) \
-		--without-ssl --without-gnutls --without-gssapi --without-zlib \
+		--without-ssl --without-gnutls --without-gssapi --disable-ares \
 		--without-libidn --without-libidn2 --without-libmetalink --without-librtmp \
-		--without-nghttp2 --without-nss --without-polarssl \
-		--without-spnego --without-libpsl --disable-ares \
-		--disable-ldap --disable-ldaps --without-zsh-functions-dir \
-		--with-libssh2=$(build_prefix) --with-mbedtls=$(build_prefix) \
+		--without-nss --without-polarssl --without-spnego --without-libpsl \
+		--disable-ldap --disable-ldaps --without-zsh-functions-dir --disable-static \
+		--with-libssh2=$(build_prefix) --with-zlib=$(build_prefix) --with-nghttp2=$(build_prefix) \
+		$(CURL_TLS_CONFIGURE_FLAGS) \
 		CFLAGS="$(CFLAGS) $(CURL_CFLAGS)" LDFLAGS="$(LDFLAGS) $(CURL_LDFLAGS)"
 	echo 1 > $@
 


### PR DESCRIPTION
We switched away from using MbedTLS on all platforms to use the native
TLS libraries on Windows/MacOS; let's ensure that a from-source build
does the same here as well.