### PR TITLE
Converge JLL APIs a bit more

### DIFF
--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -2,9 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/CompilerSupportLibraries_jll.jl
 
-module CompilerSupportLibraries_jll
-
-using Libdl, Base.BinaryPlatforms
+baremodule CompilerSupportLibraries_jll
+using Base, Libdl, Base.BinaryPlatforms
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -60,6 +60,15 @@ function __init__()
     global libgomp_path = dlpath(libgomp_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libgfortran_path() = libgfortran_path
+get_libstdcxx_path() = libstdcxx_path
+get_libgomp_path() = libgomp_path
 
 end  # module CompilerSupportLibraries_jll

--- a/stdlib/GMP_jll/src/GMP_jll.jl
+++ b/stdlib/GMP_jll/src/GMP_jll.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/GMP_jll.jl
-module GMP_jll
-
-using Libdl
+baremodule GMP_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -39,6 +39,14 @@ function __init__()
     global libgmpxx_path = dlpath(libgmpxx_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libgmp_path() = libgmp_path
+get_libgmpxx_path() = libgmpxx_path
 
 end  # module GMP_jll

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -2,10 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl
 
-module LibCURL_jll
-
-using Libdl
-using nghttp2_jll
+baremodule LibCURL_jll
+using Base, Libdl, nghttp2_jll
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -34,6 +33,13 @@ function __init__()
     global libcurl_path = dlpath(libcurl_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libcurl_path() = libcurl_path
 
 end  # module LibCURL_jll

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -2,10 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibGit2_jll.jl
 
-module LibGit2_jll
-
-using Libdl
-using MbedTLS_jll, LibSSH2_jll
+baremodule LibGit2_jll
+using Base, Libdl, nghttp2_jll, MbedTLS_jll, LibSSH2_jll
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -34,6 +33,13 @@ function __init__()
     global libgit2_path = dlpath(libgit2_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libgit2_path() = libgit2_path
 
 end  # module LibGit2_jll

--- a/stdlib/LibOSXUnwind_jll/src/LibOSXUnwind_jll.jl
+++ b/stdlib/LibOSXUnwind_jll/src/LibOSXUnwind_jll.jl
@@ -2,9 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibOSXUnwind_jll.jl
 
-module LibOSXUnwind_jll
-
-using Libdl
+baremodule LibOSXUnwind_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -30,6 +30,13 @@ function __init__()
     end
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = @static Sys.isapple() ? true : false
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libosxunwind_path() = libosxunwind_path
 
 end  # module LibOSXUnwind_jll

--- a/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
+++ b/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
@@ -2,10 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibSSH2_jll.jl
 
-module LibSSH2_jll
-
-using Libdl
-using MbedTLS_jll
+baremodule LibSSH2_jll
+using Base, Libdl, MbedTLS_jll
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -34,6 +33,14 @@ function __init__()
     global libssh2_path = dlpath(libssh2_handle)
 end
 
+
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libssh2_path() = libssh2_path
 
 end  # module LibSSH2_jll

--- a/stdlib/LibUV_jll/src/LibUV_jll.jl
+++ b/stdlib/LibUV_jll/src/LibUV_jll.jl
@@ -2,9 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibUV_jll.jl
 
-module LibUV_jll
-
-using Libdl
+baremodule LibUV_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -33,6 +33,13 @@ function __init__()
     global libuv_path = dlpath(libuv_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libuv_path() = libuv_path
 
 end  # module LibUV_jll

--- a/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
+++ b/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
@@ -2,9 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibUnwind_jll.jl
 
-module LibUnwind_jll
-
-using Libdl
+baremodule LibUnwind_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -30,6 +30,13 @@ function __init__()
     end
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = @static (Sys.islinux() || Sys.isfreebsd()) ? true : false
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libunwind_path() = libunwind_path
 
 end  # module LibUnwind_jll

--- a/stdlib/MPFR_jll/src/MPFR_jll.jl
+++ b/stdlib/MPFR_jll/src/MPFR_jll.jl
@@ -1,10 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/MPFR_jll.jl
-module MPFR_jll
-using GMP_jll
-
-using Libdl
+baremodule MPFR_jll
+using Base, Libdl, GMP_jll
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -33,6 +32,13 @@ function __init__()
     global libmpfr_path = dlpath(libmpfr_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libmpfr_path() = libmpfr_path
 
 end  # module MPFR_jll

--- a/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
+++ b/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
@@ -2,9 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/MbedTLS_jll.jl
 
-module MbedTLS_jll
-
-using Libdl
+baremodule MbedTLS_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -47,6 +47,15 @@ function __init__()
     global libmbedx509_path = dlpath(libmbedx509_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libmbedcrypto_path() =libmbedcrypto_path
+get_libmbedtls_path() = libmbedtls_path
+get_libmbedx509_path() = libmbedx509_path
 
 end  # module MbedTLS_jll

--- a/stdlib/MozillaCACerts_jll/src/MozillaCACerts_jll.jl
+++ b/stdlib/MozillaCACerts_jll/src/MozillaCACerts_jll.jl
@@ -2,7 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/MozillaCACerts_jll.jl
 
-module MozillaCACerts_jll
+baremodule MozillaCACerts_jll
+using Base
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 # These get calculated in __init__()
 PATH = Ref("")
@@ -16,6 +18,12 @@ function __init__()
 	global cacert = normpath(Sys.BINDIR::String, Base.DATAROOTDIR, "julia", "cert.pem")
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
 
 end # module

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/OpenBLAS_jll.jl
-module OpenBLAS_jll
-
-using Libdl, CompilerSupportLibraries_jll, Base.BinaryPlatforms
+baremodule OpenBLAS_jll
+using Base, Libdl, CompilerSupportLibraries_jll, Base.BinaryPlatforms
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -38,6 +38,13 @@ function __init__()
     global libopenblas_path = dlpath(libopenblas_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libopenblas_path() = libopenblas_path
 
 end  # module OpenBLAS_jll

--- a/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
+++ b/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/OpenLibm_jll.jl
-module OpenLibm_jll
-
-using Libdl
+baremodule OpenLibm_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -32,8 +32,13 @@ function __init__()
     global libopenlibm_path = dlpath(libopenlibm_handle)
 end
 
-# JLLWrappers API
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
 get_libopenlibm_path() = libopenlibm_path
 
 end  # module OpenLibm_jll

--- a/stdlib/PCRE2_jll/src/PCRE2_jll.jl
+++ b/stdlib/PCRE2_jll/src/PCRE2_jll.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/PCRE2_jll.jl
-module PCRE2_jll
-
-using Libdl
+baremodule PCRE2_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -32,6 +32,13 @@ function __init__()
     global libpcre2_8_path = dlpath(libpcre2_8_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libpcre2_8_path() = libpcre2_8_path
 
 end  # module PCRE2_jll

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/SuiteSparse_jll.jl
-module SuiteSparse_jll
-
-using Libdl, OpenBLAS_jll
+baremodule SuiteSparse_jll
+using Base, Libdl, OpenBLAS_jll
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -117,6 +117,25 @@ function __init__()
     global libumfpack_path = dlpath(libumfpack_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libamd_path() = libamd_path
+get_libbtf_path() = libbtf_path
+get_libcamd_path() = libcamd_path
+get_libccolamd_path() = libccolamd_path
+get_libcholmod_path() = libcholmod_path
+get_libcolamd_path() = libcolamd_path
+get_libklu_path() = libklu_path
+get_libldl_path() = libldl_path
+get_librbio_path() = librbio_path
+get_libspqr_path() = libspqr_path
+get_libsuitesparse_wrapper_path() = libsuitesparse_wrapper_path
+get_libsuitesparseconfig_path() = libsuitesparseconfig_path
+get_libumfpack_path() = libumfpack_path
 
 end  # module SuiteSparse_jll

--- a/stdlib/Zlib_jll/src/Zlib_jll.jl
+++ b/stdlib/Zlib_jll/src/Zlib_jll.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/Zlib_jll.jl
-module Zlib_jll
-
-using Libdl
+baremodule Zlib_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -32,6 +32,13 @@ function __init__()
     global libz_path = dlpath(libz_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libz_path() = libz_path
 
 end  # module Zlib_jll

--- a/stdlib/dSFMT_jll/src/dSFMT_jll.jl
+++ b/stdlib/dSFMT_jll/src/dSFMT_jll.jl
@@ -2,9 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/dSFMT_jll.jl
 
-module dSFMT_jll
-
-using Libdl
+baremodule dSFMT_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -33,6 +33,13 @@ function __init__()
     global libdSFMT_path = dlpath(libdSFMT_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libdSFMT_path() = libdSFMT_path
 
 end  # module dSFMT_jll

--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
@@ -2,9 +2,9 @@
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/libLLVM_jll.jl
 
-module libLLVM_jll
-
-using Libdl
+baremodule libLLVM_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -34,6 +34,13 @@ function __init__()
     global libLLVM_path = dlpath(libLLVM_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libLLVM_path() = libLLVM_path
 
 end  # module libLLVM_jll

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/nghttp2_jll.jl
-module nghttp2_jll
-
-using Libdl
+baremodule nghttp2_jll
+using Base, Libdl
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -32,6 +32,13 @@ function __init__()
     global libnghttp2_path = dlpath(libnghttp2_handle)
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
+get_libnghttp2_path() = libnghttp2_path
 
 end  # module nghttp2_jll

--- a/stdlib/p7zip_jll/src/p7zip_jll.jl
+++ b/stdlib/p7zip_jll/src/p7zip_jll.jl
@@ -1,7 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/p7zip_jll.jl
-module p7zip_jll
+baremodule p7zip_jll
+using Base
+Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]
 const LIBPATH_list = String[]
@@ -42,6 +44,12 @@ function __init__()
     init_p7zip_path()
 end
 
+# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
+# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
+# there isn't one.  It instead returns the overall Julia prefix.
 is_available() = true
+find_artifact_dir() = artifact_dir
+dev_jll() = error("stdlib JLLs cannot be dev'ed")
+best_wrapper = nothing
 
 end  # module p7zip_jll


### PR DESCRIPTION
The initial draft of Fake JLLs missed some important points in JLL
API compatibility; let's close the gap somewhat, where we can.  This PR
adds the following exports:

* `get_artifact_dir()`: returns the Julia prefix
* `dev_jll()`: Throws an error
* `best_wrapper`: always set to `nothing`
* `get_*_path()`: returns the path of the identified library product

It also converts all fake JLL modules to `baremodule`s, and sets the
appropriate compiler options to minimize compilation.

Closes https://github.com/JuliaLang/julia/issues/38781