### PR TITLE
Avoid integer overflow in type computation (small correction to #38745)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -116,9 +116,9 @@ _range(a::T, step::T, ::Nothing, len::Integer) where {T <: AbstractFloat} =
 _range(a::T, step, ::Nothing, len::Integer) where {T} =
     _rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
 _rangestyle(::Ordered, ::ArithmeticWraps, a::T, step::S, len::Integer) where {T,S} =
-    StepRange{typeof(a+step),S}(a, step, a+step*(len-1))
+    StepRange{typeof(a+false*step),S}(a, step, a+step*(len-1))
 _rangestyle(::Any, ::Any, a::T, step::S, len::Integer) where {T,S} =
-    StepRangeLen{typeof(a+step),T,S}(a, step, len)
+    StepRangeLen{typeof(a+false*step),T,S}(a, step, len)
 
 # Malformed calls
 _range(start,     step,      ::Nothing, ::Nothing) = # range(a, step=s)

--- a/base/range.jl
+++ b/base/range.jl
@@ -116,9 +116,9 @@ _range(a::T, step::T, ::Nothing, len::Integer) where {T <: AbstractFloat} =
 _range(a::T, step, ::Nothing, len::Integer) where {T} =
     _rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
 _rangestyle(::Ordered, ::ArithmeticWraps, a::T, step::S, len::Integer) where {T,S} =
-    StepRange{typeof(a+false*step),S}(a, step, a+step*(len-1))
+    StepRange{typeof(a+zero(step)),S}(a, step, a+step*(len-1))
 _rangestyle(::Any, ::Any, a::T, step::S, len::Integer) where {T,S} =
-    StepRangeLen{typeof(a+false*step),T,S}(a, step, len)
+    StepRangeLen{typeof(a+zero(step)),T,S}(a, step, len)
 
 # Malformed calls
 _range(start,     step,      ::Nothing, ::Nothing) = # range(a, step=s)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1713,4 +1713,12 @@ end
     @test range('a', step=2, length=3) == ['a', 'c', 'e']
     @test eltype(range('a', step=2, length=3)) === Char
     @test typeof(step(range('a', step=2, length=3))) === Int
+
+    @test isempty(range(typemax(Int)//1, step=1, length=0))
+    @test eltype(range(typemax(Int)//1, step=1, length=0)) === Rational{Int}
+    @test typeof(step(range(typemax(Int)//1, step=1, length=0))) === Int
+
+    @test isempty(range(typemin(Int), step=-1//1, length=0))
+    @test eltype(range(typemin(Int), step=-1//1, length=0)) === Rational{Int}
+    @test typeof(step(range(typemin(Int), step=-1//1, length=0))) === Rational{Int}
 end


### PR DESCRIPTION
In #38745, the computation of the eltype was changed so that it can now overflow. It worked correctly before #38745.

Without this PR:
```julia
julia> range(typemax(Int)//1, step=1, length=0)
ERROR: OverflowError: 9223372036854775807 + 1 overflowed for type Int64
Stacktrace:
[...]
```
With this PR:
```julia
julia> range(typemax(Int)//1, step=1, length=0)
9223372036854775807//1:1:9223372036854775806//1
```