### PR TITLE
Adding the ∞ symbol as an alternative to Inf

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -32,6 +32,7 @@ const Inf64 = bitcast(Float64, 0x7ff0000000000000)
 const NaN64 = bitcast(Float64, 0x7ff8000000000000)
 
 const Inf = Inf64
+const ∞ = Inf64
 """
     Inf, Inf64
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -34,11 +34,11 @@ const NaN64 = bitcast(Float64, 0x7ff8000000000000)
 const Inf = Inf64
 const ∞ = Inf64
 """
-    Inf, Inf64
+    Inf, ∞, Inf64
 
 Positive infinity of type [`Float64`](@ref).
 """
-Inf, Inf64
+Inf, ∞, Inf64
 
 const NaN = NaN64
 """


### PR DESCRIPTION
I was surprised to see that Julia does not support `∞` as a symbol for `Inf` when I needed it the frist time a few weeks ago.
I think it's more about time to add it now.
Hopefully the line `const ∞ = Inf64` is all it takes to do so!