### PR TITLE
Base.download: remove DOWNLOAD_HOOKS mechanism

### DIFF
--- a/base/download.jl
+++ b/base/download.jl
@@ -1,14 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-const DOWNLOAD_HOOKS = Callable[]
-
-function download_url(url::AbstractString)
-    for hook in DOWNLOAD_HOOKS
-        url = String(hook(url)::AbstractString)
-    end
-    return url
-end
-
 Downloads() = require(PkgId(
         UUID((0xf43a241f_c20a_4ad4, 0x852c_f6b1247861c6)),
         "Downloads",
@@ -30,5 +21,5 @@ download(url::AbstractString) = do_download(url, nothing)
 
 function do_download(url::AbstractString, path::Union{AbstractString, Nothing})
     depwarn("Base.download is deprecated; use Downloads.download instead", :download)
-    invokelatest(Downloads().download, download_url(url), path)
+    invokelatest(Downloads().download, url, path)
 end


### PR DESCRIPTION
This was originally introduced so that users behind a firewall had a mechanism for redirecting download requests when installing packages, but we now have the pkg protocol, which addresses that in a far better way. According to [JuliaHub.com](https://juliahub.com/ui/CodeSearch?q=DOWNLOAD_HOOKS&u=all&t=all), no one is using this, so removing it should be fine.