### PR TITLE
Resize credential buffer in winprompt in case of failure

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -306,7 +306,13 @@ if Sys.iswindows()
         succeeded = ccall((:CredPackAuthenticationBufferW, "credui.dll"), stdcall, Bool,
             (UInt32, Cwstring, Cwstring, Ptr{UInt8}, Ptr{UInt32}),
              CRED_PACK_GENERIC_CREDENTIALS, default_username, "", credbuf, credbufsize)
-        @assert succeeded
+        if !succeeded
+            credbuf = resize!(credbuf, credbufsize[])
+            succeeded = ccall((:CredPackAuthenticationBufferW, "credui.dll"), stdcall, Bool,
+                (UInt32, Cwstring, Cwstring, Ptr{UInt8}, Ptr{UInt32}),
+                 CRED_PACK_GENERIC_CREDENTIALS, default_username, "", credbuf, credbufsize)
+            @assert succeeded
+        end
 
         # Step 2: Create the actual dialog
         #      2.1: Set up the window


### PR DESCRIPTION
This function can only fail if the buffer is too small, so resize it in case of failure. If the buffer is not the correct size, `credbufsize` reports the size of the required buffer. 

Docs: https://docs.microsoft.com/en-us/windows/win32/api/wincred/nf-wincred-credpackauthenticationbufferw