### PR TITLE
fix erroneous code path within `show_sym`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1445,7 +1445,7 @@ end
 # Print `sym` as it would appear as an identifier name in code
 # * Print valid identifiers & operators literally; also macros names if allow_macroname=true
 # * Escape invalid identifiers with var"" syntax
-function show_sym(io::IO, sym; allow_macroname=false)
+function show_sym(io::IO, sym::Symbol; allow_macroname=false)
     if is_valid_identifier(sym)
         print(io, sym)
     elseif allow_macroname && (sym_str = string(sym); startswith(sym_str, '@'))

--- a/base/show.jl
+++ b/base/show.jl
@@ -1450,7 +1450,7 @@ function show_sym(io::IO, sym; allow_macroname=false)
         print(io, sym)
     elseif allow_macroname && (sym_str = string(sym); startswith(sym_str, '@'))
         print(io, '@')
-        show_sym(io, sym_str[2:end])
+        show_sym(io, Symbol(sym_str[2:end]))
     else
         print(io, "var", repr(string(sym)))
     end


### PR DESCRIPTION
currently, `show_sym` can recur into `show(::IO, String)`, but it's a
bit "erroneous" since `is_syntactic_operator(::String)` is not defined.

the virtual stacktrace from [JET.jl](https://github.com/aviatesk/JET.jl)
may describe this better:
```julia
julia> @report_call println(QuoteNode(nothing))
═════ 1 possible error found ═════
┌ @ coreio.jl:4 Base.println(Core.tuple(Core.typeassert(Base.stdout, Base.IO)), xs...)
│┌ @ strings/io.jl:73 Base.print(Core.tuple(io), xs, Core.tuple("\n")...)
││┌ @ strings/io.jl:46 Base.print(io, x)
│││┌ @ show.jl:1144 Base.show_unquoted(Base.IOContext(io, Base.=>(:unquote_fallback, false)), ex, 0, -1)
││││┌ @ show.jl:1496 Base.show_unquoted_quote_expr(io, Base.getproperty(ex, :value), indent, prec, 0)
│││││┌ @ show.jl:1522 Base.show_block(Base.IOContext(io, Base.=>(Base.beginsym, false)), "quote", value, indent,quote_level)
││││││┌ @ show.jl:1365 Base.show_block(io, head, Base.vect(), block, i, quote_level)
│││││││┌ @ show.jl:1361 Base.show_unquoted(io, ex, ind, -1, quote_level)
││││││││┌ @ show.jl:1955 Core.kwfunc(Base.show_globalref)(Core.apply_type(Core.NamedTuple, (:allow_macroname, (Core.tuple(true)), Base.show_globalref, io, arg1)
│││││││││┌ @ show.jl:1468 Base.#show_globalref#424(allow_macroname, _3, io, ex)
││││││││││┌ @ show.jl:1474 Core.kwfunc(Base.show_sym)(Core.apply_type(Core.NamedTuple, (:allow_macroname,)(Core.tuple(allow_macroname)), Base.show_sym, io, Base.getproperty(ex, :name))
│││││││││││┌ @ REPL[7]:2 Base.#show_sym#882(allow_macroname, _3, io, sym)
││││││││││││┌ @ REPL[7]:6 Base.show_sym(io, Base.getindex(sym_str, Base.:(2, Base.lastindex(sym_str))))
│││││││││││││┌ @ REPL[7]:2 Base.#show_sym#882(false, #self#, io, sym)
││││││││││││││┌ @ REPL[7]:2 Base.is_valid_identifier(sym)
│││││││││││││││┌ @ show.jl:1410 Base.is_syntactic_operator(sym)
││││││││││││││││ no matching method found for call signature: Base.is_syntactic_operator(sym::String)
│││││││││││││││└────────────────
Core.Const(nothing)

julia> # fix this
       @eval Base function show_sym(io::IO, sym; allow_macroname=false)
           if is_valid_identifier(sym)
               print(io, sym)
           elseif allow_macroname && (sym_str = string(sym); 
startswith(sym_str, '@'))
               print(io, '@')
               show_sym(io, Symbol(sym_str[2:end]))
           else
               print(io, "var", repr(string(sym)))
           end
       end
show_sym (generic function with 1 method)

julia> @report_call println(QuoteNode(nothing))
No errors !
Core.Const(nothing)
```