### PR TITLE
Update dimension checks in symtridiag eigen calls

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -3814,7 +3814,7 @@ for (stev, stebz, stegr, stein, elty) in
                 eev = copy(ev)
                 eev[n] = zero($elty)
             else
-                throw(DimensionMismatch("ev has length $(length(ev)) but should be either $(length(dv) - 1) or $(length(dv))"))
+                throw(DimensionMismatch("ev has length $ne but should be either $(n - 1) or $n"))
             end
 
             abstol = Vector{$elty}(undef, 1)
@@ -3855,10 +3855,16 @@ for (stev, stebz, stegr, stein, elty) in
             require_one_based_indexing(dv, ev_in, w_in, iblock_in, isplit_in)
             chkstride1(dv, ev_in, w_in, iblock_in, isplit_in)
             n = length(dv)
-            if length(ev_in) != n - 1
-                throw(DimensionMismatch("ev_in has length $(length(ev_in)) but needs one less than dv's length, $n)"))
+            ne = length(ev_in)
+            if ne == n - 1
+                ev = [ev_in; zero($elty)]
+            elseif ne == n
+                ev = copy(ev_in)
+                ev[n] = zero($elty)
+            else
+                throw(DimensionMismatch("ev has length $ne but should be either $(n - 1) or $n"))
             end
-            ev = [ev_in; zeros($elty,1)]
+
             ldz = n #Leading dimension
             #Number of eigenvalues to find
             if !(1 <= length(w_in) <= n)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -295,10 +295,8 @@ function eigvals!(A::SymTridiagonal{<:BlasReal})
     ne = length(A.ev)
     if ne == n-1
         ev = A.ev
-    elseif ne == n
-        ev = view(A.ev, 1:n)
     else
-        throw(DimensionMismatch("ev has length $ne but should be either $(n - 1) or $n"))
+        ev = view(A.ev, 1:n-1)
     end
     LAPACK.stev!('N', A.dv, ev)[1]
 end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -290,7 +290,18 @@ eigen!(A::SymTridiagonal{<:BlasReal}, vl::Real, vu::Real) =
 eigen(A::SymTridiagonal{T}, vl::Real, vu::Real) where T =
     eigen!(copy_oftype(A, eigtype(T)), vl, vu)
 
-eigvals!(A::SymTridiagonal{<:BlasReal}) = LAPACK.stev!('N', A.dv, A.ev)[1]
+function eigvals!(A::SymTridiagonal{<:BlasReal})
+    n = length(A.dv)
+    ne = length(A.ev)
+    if ne == n-1
+        ev = A.ev
+    elseif ne == n
+        ev = view(A.ev, 1:n)
+    else
+        throw(DimensionMismatch("ev has length $ne but should be either $(n - 1) or $n"))
+    end
+    LAPACK.stev!('N', A.dv, ev)[1]
+end
 eigvals(A::SymTridiagonal{T}) where T = eigvals!(copy_oftype(A, eigtype(T)))
 
 eigvals!(A::SymTridiagonal{<:BlasReal}, irange::UnitRange) =

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -410,7 +410,7 @@ end
         @test_throws DimensionMismatch LAPACK.stev!('U',d,rand(elty,10))
         @test_throws DimensionMismatch LAPACK.stebz!('A','B',zero(elty),zero(elty),0,0,-1.,d,rand(elty,10))
         @test_throws DimensionMismatch LAPACK.stegr!('N','A',d,rand(elty,11),zero(elty),zero(elty),0,0)
-        @test_throws DimensionMismatch LAPACK.stein!(d,zeros(elty,10),zeros(elty,10),zeros(BlasInt,10),zeros(BlasInt,10))
+        @test_throws DimensionMismatch LAPACK.stein!(d,zeros(elty,11),zeros(elty,10),zeros(BlasInt,10),zeros(BlasInt,10))
         @test_throws DimensionMismatch LAPACK.stein!(d,e,zeros(elty,11),zeros(BlasInt,10),zeros(BlasInt,10))
     end
 end


### PR DESCRIPTION
This PR continues https://github.com/JuliaLang/julia/pull/38793, addressing comment https://github.com/JuliaLang/LinearAlgebra.jl/issues/796. The motivation is to fix a small inconsistency between the `SymTridiagonal` type and admissible calls to `eigen` / `eigen!` for that type.

In `master`, the `SymTridiagonal` constructor allows the superdiagonal vector (`ev`) to be of length either `n` or `n-1` (where `n` is the length of the main diagonal), but some calls to LAPACK eigensolvers which dispatch on `SymTridiagonal` through `eigen` / `eigen!` are stricter, only allowing `ev` to have dimension `n-1`.

CC @dkarrasch 