### PR TITLE
win: skip bad paths in dllist

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -606,6 +606,7 @@ JL_DLLEXPORT int jl_dllist(jl_array_t *list)
             continue;
         jl_array_grow_end((jl_array_t*)list, 1);
         jl_value_t *v = jl_cstr_to_string(path);
+        free(path);
         jl_array_ptr_set(list, jl_array_dim0(list) - 1, v);
     }
     free(hMods);

--- a/src/sys.c
+++ b/src/sys.c
@@ -600,9 +600,11 @@ JL_DLLEXPORT int jl_dllist(jl_array_t *list)
         }
     } while (cb < cbNeeded);
     for (i = 0; i < cbNeeded / sizeof(HMODULE); i++) {
-        jl_array_grow_end((jl_array_t*)list, 1);
         const char *path = jl_pathname_for_handle(hMods[i]);
         // XXX: change to jl_arrayset if array storage allocation for Array{String,1} changes:
+        if (path == NULL)
+            continue;
+        jl_array_grow_end((jl_array_t*)list, 1);
         jl_value_t *v = jl_cstr_to_string(path);
         jl_array_ptr_set(list, jl_array_dim0(list) - 1, v);
     }


### PR DESCRIPTION
Probably needs WTF-8 support to be correct, but may avoid crashing.

Fix #38838