### PR TITLE
[PPC] relax fastmath test

### DIFF
--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -60,9 +60,6 @@ fm_fast_64_upd(x) = @fastmath (r=x; r+=eps64_2; r+=eps64_2)
         @test @fastmath(cmp(two,two)) == cmp(two,two)
         @test @fastmath(cmp(two,three)) == cmp(two,three)
         @test @fastmath(cmp(three,two)) == cmp(three,two)
-        @test @fastmath(one/zero) == convert(T,Inf)
-        @test @fastmath(-one/zero) == -convert(T,Inf)
-        @test isnan(@fastmath(zero/zero)) # must not throw
 
         for x in (zero, two, convert(T, Inf), convert(T, NaN))
             @test @fastmath(isfinite(x))


### PR DESCRIPTION
@shirodkara if I recall our discussion correctly the backend stance was there is no guarantee that
this operations yield `Inf` under fastmath?
