### PR TITLE
Mark ccall to git_libgit2_opts as variadic

### DIFF
--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -1003,8 +1003,10 @@ function set_ssl_cert_locations(cert_loc)
     else # files, /dev/null, non-existent paths, etc.
         cert_file = cert_loc
     end
-    ret = ccall((:git_libgit2_opts, :libgit2), Cint, (Cint, Cstring...),
-        Cint(Consts.SET_SSL_CERT_LOCATIONS), cert_file, cert_dir)
+    ret = @ccall "libgit2".git_libgit2_opts(
+        Consts.SET_SSL_CERT_LOCATIONS::Cint;
+        cert_file::Cstring,
+        cert_dir::Cstring)::Cint
     ret >= 0 && return ret
     err = Error.GitError(ret)
     err.class == Error.SSL &&

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -124,18 +124,21 @@ end
 
 function get_global_dir()
     buf = Ref(LibGit2.Buffer())
-    LibGit2.@check ccall((:git_libgit2_opts, :libgit2), Cint,
-                         (Cint, Cint, Ptr{LibGit2.Buffer}),
-                         LibGit2.Consts.GET_SEARCH_PATH, LibGit2.Consts.CONFIG_LEVEL_GLOBAL, buf)
+
+    LibGit2.@check @ccall "libgit2".git_libgit2_opts(
+        LibGit2.Consts.GET_SEARCH_PATH::Cint;
+        LibGit2.Consts.CONFIG_LEVEL_GLOBAL::Cint,
+        buf::Ptr{LibGit2.Buffer})::Cint
     path = unsafe_string(buf[].ptr)
     LibGit2.free(buf)
     return path
 end
 
 function set_global_dir(dir)
-    LibGit2.@check ccall((:git_libgit2_opts, :libgit2), Cint,
-                         (Cint, Cint, Cstring),
-                         LibGit2.Consts.SET_SEARCH_PATH, LibGit2.Consts.CONFIG_LEVEL_GLOBAL, dir)
+    LibGit2.@check @ccall "libgit2".git_libgit2_opts(
+        LibGit2.Consts.SET_SEARCH_PATH::Cint;
+        LibGit2.Consts.CONFIG_LEVEL_GLOBAL::Cint,
+        dir::Cstring)::Cint
     return
 end
 


### PR DESCRIPTION
Fixes #38638, as usual PPC is sensitive to variadic functions. Correctly done in `LibGit2.set_ssl_cert_locations`.


