### PR TITLE
Replace haystack and needle with space and sub

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -596,10 +596,10 @@ findprev(pattern::AbstractVector{<:Union{Int8,UInt8}},
          start::Integer) =
     _rsearch(A, pattern, start)
 """
-    occursin(needle::Union{AbstractString,AbstractPattern,AbstractChar}, haystack::AbstractString)
+    occursin(sub::Union{AbstractString,AbstractPattern,AbstractChar}, space::AbstractString)
 
-Determine whether the first argument is a substring of the second. If `needle`
-is a regular expression, checks whether `haystack` contains a match.
+Determine whether the first argument is a substring of the second. If `sub`
+is a regular expression, checks whether `space` contains a match.
 
 # Examples
 ```jldoctest
@@ -618,17 +618,17 @@ false
 
 See also: [`contains`](@ref).
 """
-occursin(needle::Union{AbstractString,AbstractChar}, haystack::AbstractString) =
-    _searchindex(haystack, needle, firstindex(haystack)) != 0
+occursin(sub::Union{AbstractString,AbstractChar}, space::AbstractString) =
+    _searchindex(space, sub, firstindex(space)) != 0
 
 """
-    occursin(haystack)
+    occursin(space)
 
-Create a function that checks whether its argument occurs in `haystack`, i.e.
-a function equivalent to `needle -> occursin(needle, haystack)`.
+Create a function that checks whether its argument occurs in `space`, i.e.
+a function equivalent to `sub -> occursin(sub, space)`.
 
 The returned function is of type `Base.Fix2{typeof(occursin)}`.
 """
-occursin(haystack) = Base.Fix2(occursin, haystack)
+occursin(space) = Base.Fix2(occursin, space)
 
 in(::AbstractString, ::AbstractString) = error("use occursin(x, y) for string containment")

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -71,11 +71,11 @@ function endswith(a::Union{String, SubString{String}},
 end
 
 """
-    contains(haystack::AbstractString, needle)
+    contains(space::AbstractString, sub)
 
-Return `true` if `haystack` contains `needle`.
-This is the same as `occursin(needle, haystack)`, but is provided for consistency with
-`startswith(haystack, needle)` and `endswith(haystack, needle)`.
+Return `true` if `space` contains `sub`.
+This is the same as `occursin(sub, space)`, but is provided for consistency with
+`startswith(space, sub)` and `endswith(space, sub)`.
 
 # Examples
 ```jldoctest
@@ -95,7 +95,7 @@ false
 !!! compat "Julia 1.5"
     The `contains` function requires at least Julia 1.5.
 """
-contains(haystack::AbstractString, needle) = occursin(needle, haystack)
+contains(space::AbstractString, sub) = occursin(sub, space)
 
 """
     endswith(suffix)
@@ -148,15 +148,15 @@ false
 startswith(s) = Base.Fix2(startswith, s)
 
 """
-    contains(needle)
+    contains(sub)
 
-Create a function that checks whether its argument contains `needle`, i.e.
-a function equivalent to `haystack -> contains(haystack, needle)`.
+Create a function that checks whether its argument contains `sub`, i.e.
+a function equivalent to `space -> contains(space, sub)`.
 
 The returned function is of type `Base.Fix2{typeof(contains)}`, which can be
 used to implement specialized methods.
 """
-contains(needle) = Base.Fix2(contains, needle)
+contains(sub) = Base.Fix2(contains, sub)
 
 """
     chop(s::AbstractString; head::Integer = 0, tail::Integer = 1)

--- a/cli/loader_win_utils.c
+++ b/cli/loader_win_utils.c
@@ -186,13 +186,13 @@ char * loader_dirname(char * x) {
     return x;
 }
 
-char * loader_strchr(const char * haystack, int needle) {
+char * loader_strchr(const char * space, int sub) {
     int idx=0;
-    while (haystack[idx] != needle) {
-        if (haystack[idx] == 0) {
+    while (space[idx] != sub) {
+        if (space[idx] == 0) {
             return NULL;
         }
         idx++;
     }
-    return (char *)haystack + idx;
+    return (char *)space + idx;
 }

--- a/src/flisp/string.c
+++ b/src/flisp/string.c
@@ -141,7 +141,7 @@ value_t fl_string_find(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
     if (start > len)
         bounds_error(fl_ctx, "string.find", args[0], args[2]);
-    char *needle; size_t needlesz;
+    char *sub; size_t subsz;
 
     value_t v = args[1];
     cprim_t *cp = (cprim_t*)ptr(v);
@@ -149,30 +149,30 @@ value_t fl_string_find(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
         uint32_t c = *(uint32_t*)cp_data(cp);
         if (c <= 0x7f)
             return mem_find_byte(fl_ctx, s, (char)c, start, len);
-        needlesz = u8_toutf8(cbuf, sizeof(cbuf), &c, 1);
-        needle = cbuf;
+        subsz = u8_toutf8(cbuf, sizeof(cbuf), &c, 1);
+        sub = cbuf;
     }
     else if (iscprim(v) && cp_class(cp) == fl_ctx->bytetype) {
         return mem_find_byte(fl_ctx, s, *(char*)cp_data(cp), start, len);
     }
     else if (fl_isstring(fl_ctx, v)) {
         cvalue_t *cv = (cvalue_t*)ptr(v);
-        needlesz = cv_len(cv);
-        needle = (char*)cv_data(cv);
+        subsz = cv_len(cv);
+        sub = (char*)cv_data(cv);
     }
     else {
         type_error(fl_ctx, "string.find", "string", args[1]);
     }
-    if (needlesz > len-start)
+    if (subsz > len-start)
         return fl_ctx->F;
-    else if (needlesz == 1)
-        return mem_find_byte(fl_ctx, s, needle[0], start, len);
-    else if (needlesz == 0)
+    else if (subsz == 1)
+        return mem_find_byte(fl_ctx, s, sub[0], start, len);
+    else if (subsz == 0)
         return size_wrap(fl_ctx, start);
     size_t i;
-    for(i=start; i < len-needlesz+1; i++) {
-        if (s[i] == needle[0]) {
-            if (!memcmp(&s[i+1], needle+1, needlesz-1))
+    for(i=start; i < len-subsz+1; i++) {
+        if (s[i] == sub[0]) {
+            if (!memcmp(&s[i+1], sub+1, subsz-1))
                 return size_wrap(fl_ctx, i);
         }
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -223,16 +223,16 @@ jl_value_t *jl_nth_union_component(jl_value_t *v, int i) JL_NOTSAFEPOINT
 }
 
 // inverse of jl_nth_union_component
-int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth) JL_NOTSAFEPOINT
+int jl_find_union_component(jl_value_t *space, jl_value_t *sub, unsigned *nth) JL_NOTSAFEPOINT
 {
-    if (jl_is_uniontype(haystack)) {
-        if (jl_find_union_component(((jl_uniontype_t*)haystack)->a, needle, nth))
+    if (jl_is_uniontype(space)) {
+        if (jl_find_union_component(((jl_uniontype_t*)space)->a, sub, nth))
             return 1;
-        if (jl_find_union_component(((jl_uniontype_t*)haystack)->b, needle, nth))
+        if (jl_find_union_component(((jl_uniontype_t*)space)->b, sub, nth))
             return 1;
         return 0;
     }
-    if (needle == haystack)
+    if (sub == space)
         return 1;
     (*nth)++;
     return 0;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -476,7 +476,7 @@ jl_value_t *jl_unwrap_unionall(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u);
 int jl_count_union_components(jl_value_t *v);
 jl_value_t *jl_nth_union_component(jl_value_t *v JL_PROPAGATES_ROOT, int i) JL_NOTSAFEPOINT;
-int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth) JL_NOTSAFEPOINT;
+int jl_find_union_component(jl_value_t *space, jl_value_t *sub, unsigned *nth) JL_NOTSAFEPOINT;
 jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_module_t *module,
                                    jl_datatype_t *super, jl_svec_t *parameters);
 jl_datatype_t *jl_new_uninitialized_datatype(void);

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -103,11 +103,11 @@ function completes_global(x, name)
     return startswith(x, name) && !('#' in x)
 end
 
-function appendmacro!(syms, macros, needle, endchar)
+function appendmacro!(syms, macros, sub, endchar)
     for s in macros
-        if endswith(s, needle)
+        if endswith(s, sub)
             from = nextind(s, firstindex(s))
-            to = prevind(s, sizeof(s)-sizeof(needle)+1)
+            to = prevind(s, sizeof(s)-sizeof(sub)+1)
             push!(syms, s[from:to]*endchar)
         end
     end

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2118,9 +2118,9 @@ argmin(A::AbstractSparseMatrixCSC) = findmin(A)[2]
 argmax(A::AbstractSparseMatrixCSC) = findmax(A)[2]
 
 ## getindex
-function rangesearch(haystack::AbstractRange, needle)
-    (i,rem) = divrem(needle - first(haystack), step(haystack))
-    (rem==0 && 1<=i+1<=length(haystack)) ? i+1 : 0
+function rangesearch(space::AbstractRange, sub)
+    (i,rem) = divrem(sub - first(space), step(space))
+    (rem==0 && 1<=i+1<=length(space)) ? i+1 : 0
 end
 
 getindex(A::AbstractSparseMatrixCSC, I::Tuple{Integer,Integer}) = getindex(A, I[1], I[2])

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -606,7 +606,7 @@ function Base.Docs.catdoc(hs::LazyHelp...)
     end
 end
 
-REPL.docsearch(haystack::LazyHelp, needle) = REPL.docsearch(haystack.text, needle)
+REPL.docsearch(space::LazyHelp, sub) = REPL.docsearch(space.text, sub)
 
 @doc LazyHelp("LazyHelp\n") LazyHelp
 @doc LazyHelp("LazyHelp(text)\n") LazyHelp(text)

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -352,7 +352,7 @@ end
 @test findfirst(r"az", "foo,bar,baz") == 10:11
 @test findnext(r"az", "foo,bar,baz", 12) == nothing
 
-# occursin with a String and Char needle
+# occursin with a String and Char sub
 @test occursin("o", "foo")
 @test occursin('o', "foo")
 # occursin in curried form


### PR DESCRIPTION
At many places, the variable names `haystack` and `needle` are used. I get that these names are a convenient way to express that something (the needle) has to be found inside something else (the haystack). However, users will see these words mostly in the context of `contains(haystack, needle)`, which is confusing because

- "Finding a needle in a haystack" is about searching for something that is (near) impossible to find; not about **whether** it can be found. Also, for many calls, `contains` will return `true`. This contradicts the "(near) impossible to find".
- Programmers think in strings and substrings, spaces and subspaces, and types and subtypes; not in haystacks and needles.
- For me, a needle is associated with being pointy and dangerous; not with something that is in something else. 

Thinking about a **search space** is much more intuitive. Therefore, this PR proposes to change all occurrences of `haystack` with `space` and `needle` with `sub`. The reason that I propose sub instead of subspace is because the word sub is now shorter than space, just like the content of needle is usually shorter than haystack in `occursin(haystack, needle)`, and because sub isn't linked to a specific type, so it could easily be used to denote a substring, subtype or subspace.