### PR TITLE
rm unnecessary `widenconst_bestguess` call

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -744,7 +744,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
         end
         typeinf(interp, frame)
         update_valid_age!(frame, caller)
-        return widenconst_bestguess(frame.bestguess), frame.inferred ? mi : nothing
+        return frame.bestguess, frame.inferred ? mi : nothing
     elseif frame === true
         # unresolvable cycle
         return Any, nothing
@@ -752,12 +752,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     # return the current knowledge about this cycle
     frame = frame::InferenceState
     update_valid_age!(frame, caller)
-    return widenconst_bestguess(frame.bestguess), nothing
-end
-
-function widenconst_bestguess(bestguess)
-    !isa(bestguess, Const) && !isa(bestguess, PartialStruct) && !isa(bestguess, Type) && return widenconst(bestguess)
-    return bestguess
+    return frame.bestguess, nothing
 end
 
 #### entry points for inferring a MethodInstance given a type signature ####


### PR DESCRIPTION
the equivalent widening logic is imposed on `frame.bestguess` [within 
`typeinf_local`](https://github.com/JuliaLang/julia/blob/6ddc7f1eccd45732212ae370566758a4614e5042/base/compiler/abstractinterpretation.jl#L1341-L1345), and so as far as I understand we don't need 
`widenconst_bestguess` in `typeinf_edge`