### PR TITLE
Add getindex methods for NamedTuple

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ Standard library changes
 * `iseven` and `isodd` functions now support non-`Integer` numeric types ([#38976]).
 * `escape_string` can now receive a collection of characters in the keyword
   `keep` that are to be kept as they are. ([#38597]).
+* `getindex` can now be used on `NamedTuple`s with multiple values ([#38878])
 
 #### Package Manager
 

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -119,8 +119,8 @@ firstindex(t::NamedTuple) = 1
 lastindex(t::NamedTuple) = nfields(t)
 getindex(t::NamedTuple, i::Int) = getfield(t, i)
 getindex(t::NamedTuple, i::Symbol) = getfield(t, i)
-@inline getindex(t::NamedTuple, i::Tuple{Vararg{Symbol}}) = NamedTuple{s}(nt)
-#? Is this ok too ?# @inline getindex(t::NamedTuple, i::AbstractVector{Symbol}) = NamedTuple{Tuple(s)}(nt)
+@inline getindex(t::NamedTuple, idxs::Tuple{Vararg{Symbol}}) = NamedTuple{idxs}(t)
+@inline getindex(t::NamedTuple, idxs::AbstractVector{Symbol}) = NamedTuple{Tuple(idxs)}(t)
 indexed_iterate(t::NamedTuple, i::Int, state=1) = (getfield(t, i), i+1)
 isempty(::NamedTuple{()}) = true
 isempty(::NamedTuple) = false

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -30,7 +30,7 @@ julia> x.a
 julia> x[:a]
 1
 
-julia> nt[(:a,)]
+julia> x[(:a,)]
 (a = 1,)
 
 julia> keys(x)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -79,6 +79,9 @@ julia> (; t.x)
 
 !!! compat "Julia 1.5"
     Implicit names from identifiers and dot expressions are available as of Julia 1.5.
+
+!!! compat "Julia 1.7"
+    Use of `getindex` methods with multiple `Symbol`s is available as of Julia 1.7.
 """
 Core.NamedTuple
 

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -9,9 +9,9 @@ tuple-like collection of values, where each entry has a unique name, represented
 can be modified in place after construction.
 
 Accessing the value associated with a name in a named tuple can be done using field
-access syntax, e.g. `x.a`, or using [`getindex`](@ref), e.g. `x[:a]`. A tuple of the
-names can be obtained using [`keys`](@ref), and a tuple of the values can be obtained
-using [`values`](@ref).
+access syntax, e.g. `x.a`, or using [`getindex`](@ref), e.g. `x[:a]` or `x[(:a, :b)]`.
+A tuple of the names can be obtained using [`keys`](@ref), and a tuple of the values
+can be obtained using [`values`](@ref).
 
 !!! note
     Iteration over `NamedTuple`s produces the *values* without the names. (See example
@@ -29,6 +29,9 @@ julia> x.a
 
 julia> x[:a]
 1
+
+julia> nt[(:a,)]
+(a = 1,)
 
 julia> keys(x)
 (:a, :b)
@@ -116,6 +119,8 @@ firstindex(t::NamedTuple) = 1
 lastindex(t::NamedTuple) = nfields(t)
 getindex(t::NamedTuple, i::Int) = getfield(t, i)
 getindex(t::NamedTuple, i::Symbol) = getfield(t, i)
+@inline getindex(t::NamedTuple, i::Tuple{Vararg{Symbol}}) = NamedTuple{s}(nt)
+#? Is this ok too ?# @inline getindex(t::NamedTuple, i::AbstractVector{Symbol}) = NamedTuple{Tuple(s)}(nt)
 indexed_iterate(t::NamedTuple, i::Int, state=1) = (getfield(t, i), i+1)
 isempty(::NamedTuple{()}) = true
 isempty(::NamedTuple) = false

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -21,6 +21,13 @@
 @test (a=3,)[:a] == 3
 @test (x=4, y=5, z=6).y == 5
 @test (x=4, y=5, z=6).z == 6
+@test (x=4, y=5, z=6)[(:x, :y)] == (x=4, y=5)
+@test (x=4, y=5, z=6)[(:x,)] == (x=4,)
+# If the following are included, is it worth putting in 1 line with above, eg:
+# @test (x=4, y=5, z=6)[(:x, :y)] == (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
+# or keep separate, eg:
+# @test (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
+# @test (x=4, y=5, z=6)[[:x]] == (x=4,)
 @test_throws ErrorException (x=4, y=5, z=6).a
 @test_throws BoundsError (a=2,)[0]
 @test_throws BoundsError (a=2,)[2]

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -23,9 +23,6 @@
 @test (x=4, y=5, z=6).z == 6
 @test (x=4, y=5, z=6)[(:x, :y)] == (x=4, y=5)
 @test (x=4, y=5, z=6)[(:x,)] == (x=4,)
-# If the following are included, is it worth putting in 1 line with above, eg:
-# @test (x=4, y=5, z=6)[(:x, :y)] == (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
-# or keep separate, eg:
 @test (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
 @test (x=4, y=5, z=6)[[:x]] == (x=4,)
 @test (x=4, y=5, z=6)[()] == NamedTuple()

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -28,9 +28,16 @@
 # or keep separate, eg:
 @test (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
 @test (x=4, y=5, z=6)[[:x]] == (x=4,)
+@test (x=4, y=5, z=6)[()] == NamedTuple()
+@test NamedTuple()[()] == NamedTuple()
 @test_throws ErrorException (x=4, y=5, z=6).a
 @test_throws BoundsError (a=2,)[0]
 @test_throws BoundsError (a=2,)[2]
+@test_throws ErrorException (x=4, y=5, z=6)[(:a,)]
+@test_throws ErrorException (x=4, y=5, z=6)[(:x, :a)]
+@test_throws ErrorException (x=4, y=5, z=6)[[:a]]
+@test_throws ErrorException (x=4, y=5, z=6)[[:x, :a]]
+@test_throws ErrorException (x=4, y=5, z=6)[(:x, :x)]
 
 @test length(NamedTuple()) == 0
 @test length((a=1,)) == 1

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -26,8 +26,8 @@
 # If the following are included, is it worth putting in 1 line with above, eg:
 # @test (x=4, y=5, z=6)[(:x, :y)] == (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
 # or keep separate, eg:
-# @test (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
-# @test (x=4, y=5, z=6)[[:x]] == (x=4,)
+@test (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
+@test (x=4, y=5, z=6)[[:x]] == (x=4,)
 @test_throws ErrorException (x=4, y=5, z=6).a
 @test_throws BoundsError (a=2,)[0]
 @test_throws BoundsError (a=2,)[2]


### PR DESCRIPTION
See #38834 

This adds `getindex()` methods for `NamedTuple`s to return multiple values as a new `NamedTuple`, eg:

```
julia> nt = (a=1, b=2, c=3)
(a = 1, b = 2, c = 3)

julia> nt[(:a, :b)]
(a = 1, b = 2)

julia> nt[[:a, :b]]
(a = 1, b = 2)

julia> nt[[:a,]]
(a = 1,)
```

To be analogous with `getindex` for `Tuple`s and `Vector`s. When Jeff commented on the issue, he only gave explicit approval to the idea of using a tuple of `Symbol`s to index, not the `AbstractVector`, but it's easy enough to remove the latter if unwanted. If the `AbstractVector` method is approved, in the tests, I wasn't sure if testing all of the methods in 1 test would be a good idea or not (see comments) - I assumed keeping them separate would be better.

I also added a bit to the docstring, but I wasn't sure if I should also add something to `base/docs/basedocs.jl` [somewhere around here](https://github.com/JuliaLang/julia/blob/master/base/docs/basedocs.jl#L2391-L2403)

**Open questions / todos**

- [x] OK to keep `getindex(t::NamedTuple, idxs::AbstractVector{Symbol})` ?
- [x] If yes, should tests for different methods be kept separate?
  - [x] either way, remove comments in file
- [x] Should I add something to `basedocs.jl`?
- [x] Should I add a compat notice to docstring like the [one here](https://github.com/JuliaLang/julia/blob/master/base/namedtuple.jl#L77-L78)? If yes, I assume it would be for 1.7 at this point?

If there's anything else I've missed, please let me know!