### PR TITLE
Add doctest for IdDict with example

### DIFF
--- a/base/iddict.jl
+++ b/base/iddict.jl
@@ -6,7 +6,23 @@
 `IdDict{K,V}()` constructs a hash table using object-id as hash and
 `===` as equality with keys of type `K` and values of type `V`.
 
-See [`Dict`](@ref) for further help.
+See [`Dict`](@ref) for further help. In the example below, The `Dict`
+keys all hash to the same value as they are inserted and type-promoted,
+so they get overwritten. The IdDict hashes by object-id, and thus preserves the 
+3 different keys.
+
+# Examples
+```julia-repl
+julia> Dict(true => "yes", 1 => "no", 1.0 => "maybe")
+Dict{Real, String} with 1 entry:
+  1.0 => "maybe"
+
+julia> IdDict(true => "yes", 1 => "no", 1.0 => "maybe")
+IdDict{Any, String} with 3 entries:
+  true => "yes"
+  1.0  => "maybe"
+  1    => "no"
+```
 """
 mutable struct IdDict{K,V} <: AbstractDict{K,V}
     ht::Vector{Any}

--- a/base/iddict.jl
+++ b/base/iddict.jl
@@ -7,9 +7,8 @@
 `===` as equality with keys of type `K` and values of type `V`.
 
 See [`Dict`](@ref) for further help. In the example below, The `Dict`
-keys all hash to the same value as they are inserted and type-promoted,
-so they get overwritten. The `IdDict` hashes by object-id, and thus preserves the 
-3 different keys.
+keys are all `isequal` and therefore get hashed the same, so they get overwritten.
+The `IdDict` hashes by object-id, and thus preserves the 3 different keys.
 
 # Examples
 ```julia-repl

--- a/base/iddict.jl
+++ b/base/iddict.jl
@@ -8,7 +8,7 @@
 
 See [`Dict`](@ref) for further help. In the example below, The `Dict`
 keys all hash to the same value as they are inserted and type-promoted,
-so they get overwritten. The IdDict hashes by object-id, and thus preserves the 
+so they get overwritten. The `IdDict` hashes by object-id, and thus preserves the 
 3 different keys.
 
 # Examples


### PR DESCRIPTION
This came up from a Slack discussion and was based on a surprising [Python behavior](https://twitter.com/DahlitzF/status/1338384990040682498).
@haampie provided the example and I thought the docstrings could help out another beginner to understand why a different data structure is justified.