### PR TITLE
Don't clobber rax in x86_64 trampoline

### DIFF
--- a/cli/trampolines/trampolines_x86_64.S
+++ b/cli/trampolines/trampolines_x86_64.S
@@ -40,8 +40,8 @@ SEH_START1(name); \
 name##:; \
 SEH_START2(); \
     CET_START(); \
-    mov CNAME(name##_addr)(%rip),%rax; \
-    jmpq *%rax; \
+    mov CNAME(name##_addr)(%rip),%r11; \
+    jmpq *%r11; \
     ud2; \
 SEH_END(); \
 .cfi_endproc; \


### PR DESCRIPTION
rax is used to pass vararg metadata. r11 can be used for dynamic linker shenanigans between
functions. Messing with rax here can cause `jl_` to print nonsense.