### PR TITLE
 Don't override target passed on command-line with target from sysimg for processor_fallback

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7712,7 +7712,7 @@ extern "C" void jl_init_llvm(void)
         std::unique_ptr<MCSubtargetInfo> MSTI(
             TheTarget->createMCSubtargetInfo(TheTriple.str(), "", ""));
         if (!MSTI->isCPUStringValid(TheCPU))
-            jl_errorf("Invalid CPU name %s.", TheCPU.c_str());
+            jl_errorf("Invalid CPU name \"%s\".", TheCPU.c_str());
         if (jl_processor_print_help) {
             // This is the only way I can find to print the help message once.
             // It'll be nice if we can iterate through the features and print our own help

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -47,7 +47,6 @@ static uint32_t sysimg_init_cb(const void *id)
             best_idx = i;
         }
     }
-    target = sysimg[best_idx];
     jit_targets.push_back(std::move(target));
     return best_idx;
 }


### PR DESCRIPTION
~Until #26252 is fixed mark the `--cpu-target` tests as broken.~

Don't override target passed on command-line with target from sysimg for processor_fallback