### PR TITLE
Measure compile time only when using time macros

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -56,7 +56,8 @@ function gc_alloc_count(diff::GC_Diff)
 end
 
 # cumulative total time spent on compilation
-cumulative_compile_time_ns() = ccall(:jl_cumulative_compile_time_ns, UInt64, ())
+cumulative_compile_time_ns_before() = ccall(:jl_cumulative_compile_time_ns_before, UInt64, ())
+cumulative_compile_time_ns_after() = ccall(:jl_cumulative_compile_time_ns_after, UInt64, ())
 
 # total time spend in garbage collection, in nanoseconds
 gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())
@@ -197,11 +198,11 @@ macro time(ex)
     quote
         while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
         local stats = gc_num()
-        local compile_elapsedtime = cumulative_compile_time_ns()
+        local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
         local val = $(esc(ex))
         elapsedtime = time_ns() - elapsedtime
-        compile_elapsedtime = cumulative_compile_time_ns() - compile_elapsedtime
+        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
         local diff = GC_Diff(gc_num(), stats)
         time_print(elapsedtime, diff.allocd, diff.total_time,
                    gc_alloc_count(diff), compile_elapsedtime)
@@ -245,11 +246,11 @@ macro timev(ex)
     quote
         while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
         local stats = gc_num()
-        local compile_elapsedtime = cumulative_compile_time_ns()
+        local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
         local val = $(esc(ex))
         elapsedtime = time_ns() - elapsedtime
-        compile_elapsedtime = cumulative_compile_time_ns() - compile_elapsedtime
+        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
         timev_print(elapsedtime, GC_Diff(gc_num(), stats), compile_elapsedtime)
         val
     end

--- a/src/gf.c
+++ b/src/gf.c
@@ -3139,18 +3139,20 @@ int jl_has_concrete_subtype(jl_value_t *typ)
 //static jl_mutex_t typeinf_lock;
 #define typeinf_lock codegen_lock
 
+uint8_t jl_measure_compile_time = 0;
 uint64_t jl_cumulative_compile_time = 0;
 static uint64_t inference_start_time = 0;
 
 JL_DLLEXPORT void jl_typeinf_begin(void)
 {
     JL_LOCK(&typeinf_lock);
-    inference_start_time = jl_hrtime();
+    if (jl_measure_compile_time)
+        inference_start_time = jl_hrtime();
 }
 
 JL_DLLEXPORT void jl_typeinf_end(void)
 {
-    if (typeinf_lock.count == 1)
+    if (typeinf_lock.count == 1 && jl_measure_compile_time)
         jl_cumulative_compile_time += (jl_hrtime() - inference_start_time);
     JL_UNLOCK(&typeinf_lock);
 }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -122,6 +122,7 @@ static inline uint64_t cycleclock(void)
 
 #include "timing.h"
 
+extern uint8_t jl_measure_compile_time;
 extern uint64_t jl_cumulative_compile_time;
 
 #ifdef _COMPILER_MICROSOFT_


### PR DESCRIPTION
It turns out calling `jl_hrtime` on some BSD CI setups can be a lot more expensive than other platforms, which makes the overhead significant (https://github.com/JuliaLang/julia/issues/38877)

This changes to only grab the compile time measurement when called from `@time` and `@timev` macros.

