### PR TITLE
Execute `backtrace` once before testing formatting

### DIFF
--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -193,6 +193,9 @@ end
     └ SUFFIX
     """
 
+    # Execute backtrace once before checking formatting, see #3885
+    backtrace()
+
     # Attaching backtraces
     bt = func1()
     @test startswith(genmsg("msg", exception=(DivideError(),bt)),

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -634,6 +634,8 @@ catch ex
 end
 pop!(Base.Experimental._hint_handlers[DomainError])  # order is undefined, don't copy this
 
+# Execute backtrace once before checking formatting, see #38858
+backtrace()
 
 # issue #28442
 @testset "Long stacktrace printing" begin


### PR DESCRIPTION
Fixes #38858

On some platforms (PowerPC) the call to the `jlplt` is not a tail-call
and so it will be part of the backtrace. This means we are off-by-one
and won't skip the Julia function `backtrace` messing up tests that
check precise formatting.