### PR TITLE
Turn off client-side port reuse on Darwin

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -861,7 +861,7 @@ JL_DLLEXPORT int jl_tcp_quickack(uv_tcp_t *handle, int on)
 
 JL_DLLEXPORT int jl_has_so_reuseport(void)
 {
-#if defined(SO_REUSEPORT)
+#if defined(SO_REUSEPORT) && !defined(_OS_DARWIN_)
     return 1;
 #else
     return 0;


### PR DESCRIPTION
For scalability, in the Distributed code and when supported by the
operating system, we bind all client sockets to the same port (the
server ports still differ). In general, each tcp connection is
identified by the 4-tuple (source_ip, source_port, dest_ip, dest_port)
(also known as a 5-tuple if the protocol is included). Re-using
the client port saves on the number of available ports, but since
the 5-tuple is still different due to the varying server ports,
it doesn't end up causing any trouble.

However, on Darwin, we run into a bit of a pickle. When a connection
exits, the server side of the socket enters TIME_WAIT state, while
the client side of the socket immediately enters CLOSED state
allowing the port to be reused (if we weren't setting SO_REUSEPORT
anyway). Now, ordinarily the server port number is not allowed
to be re-used if there is any remaining PCB (Process control block,
basically the kernel data structure associated to a 5-tuple), that
references said port (including those in TIME_WAIT state). However,
this is very annoying for servers in general (since it would mean
that servers can't be restarted for some number of seconds until
after the last connection terminated), so it is common to pass
SO_REUSEADDR on server sockets. In fact, libuv does that for us
automatically. Unfortunately, as a result, there is nothing that
prevents us from re-using the same 5-tuple before the TIME_WAIT
state has timed out (the client just got immediately recycled,
and we explicitly bypassed the TIME_WAIT restriction on the
server). Linux appears to handle this fine, but Darwin does not.
On Darwin, when we try to connect with a re-used 5-tuple, there
is some chance (depending on the kernel hash table for PCBs),
that we will get the state PCB rather than the fresh one,
causing the connection to drop. This is the cause of #38812 and
our mac CI reliability issued in the Distributed test.

It is worth pointing out that this is not directly related to
SO_REUSEPORT. Since the client port is immediately available for
recycle, it is perfectly legal for us to re-use that port immediately,
even if SO_REUSEPORT is not set (which would exhibit the same problem).
However, because doing that is not particularly useful, we just randomize
the port if SO_REUSEPORT is not set. This doesn't fix the situation either,
but should hopefully reduce the incidence rate below the rate at
which it is problematic for CI.

We could turn off SO_REUSEADDR on the server entirely, but that is
undesirable for reasons mentioned above. Since Linux does not have
the same issue, I have some hope that Apple might consider this a
bug and adjust the behavior. I have an open support request with them
to that extent. However, in the meantime this will hopefully help
our CI reliability.