### PR TITLE
Missing branch for popat with default

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -477,6 +477,7 @@ end
     @test a == [2, 3, 4]
     @test popat!(a, 2) == 3
     @test a == [2, 4]
+    @test popat!(a, 1, "default") == 2
     badpop() = @inbounds popat!([1], 2)
     @test_throws BoundsError badpop()
 end


### PR DESCRIPTION
Didn't actually test the branch where we don't need the `default`.