### PR TITLE
fix #34170, assertion failure with obvious_subtype

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2549,7 +2549,7 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
                 res = jl_substitute_var(res, vb->var, (jl_value_t*)newvar);
             varval = (jl_value_t*)newvar;
             if (wrap)
-                res = jl_new_struct(jl_unionall_type, (jl_tvar_t*)newvar, res);
+                res = jl_type_unionall((jl_tvar_t*)newvar, res);
         }
     }
 
@@ -2558,7 +2558,7 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
         for(i=0; i < jl_array_len(vb->innervars); i++) {
             jl_tvar_t *var = (jl_tvar_t*)jl_array_ptr_ref(vb->innervars, i);
             if (jl_has_typevar(res, var))
-                res = jl_new_struct(jl_unionall_type, (jl_tvar_t*)var, res);
+                res = jl_type_unionall((jl_tvar_t*)var, res);
         }
     }
 

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1845,3 +1845,12 @@ let A = Tuple{T, Ref{T}, T} where {T},
     @test_broken I <: A
     @test_broken I <: B
 end
+
+# issue #34170
+let A = Tuple{Type{T} where T<:Ref, Ref, Union{T, Union{Ref{T}, T}} where T<:Ref},
+    B = Tuple{Type{T}, Ref{T}, Union{Int, Ref{T}, T}} where T
+    I = typeintersect(A,B)
+    # this was a case where <: disagreed with === (due to a badly-normalized type)
+    @test I == typeintersect(A,B)
+    @test I == Tuple{Type{T}, Ref{T}, Union{Ref{T}, T}} where T<:Ref
+end


### PR DESCRIPTION
There were a couple places in type intersection that could produce non-normalized UnionAlls by calling jl_new_struct directly. Fixing that seems to be enough, and also simplifies some returned results.