### PR TITLE
inference: inter-procedural conditional constraint back-propagation

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -425,6 +425,7 @@ eval(Core, :(CodeInstance(mi::MethodInstance, @nospecialize(rettype), @nospecial
 eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))))
 eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))))
 eval(Core, :(PartialOpaque(@nospecialize(typ), @nospecialize(env), isva::Bool, parent::MethodInstance, source::Method) = $(Expr(:new, :PartialOpaque, :typ, :env, :isva, :parent, :source))))
+eval(Core, :(InterConditional(slot::Int, @nospecialize(vtype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :vtype, :elsetype))))
 eval(Core, :(MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) =
     $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))))
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -28,8 +28,9 @@ function is_improvable(@nospecialize(rtype))
     return isa(rtype, PartialStruct) || isa(rtype, InterConditional)
 end
 
-function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f), argtypes::Vector{Any}, @nospecialize(atype), sv::InferenceState,
-                                  max_methods::Int = InferenceParams(interp).MAX_METHODS)
+function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
+                                  fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any}, @nospecialize(atype),
+                                  sv::InferenceState, max_methods::Int = InferenceParams(interp).MAX_METHODS)
     if sv.params.unoptimize_throw_blocks && sv.currpc in sv.throw_blocks
         return CallMeta(Any, false)
     end
@@ -98,8 +99,9 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
     rettype = Bottom
     edgecycle = false
     edges = MethodInstance[]
-    nonbot = 0  # the index of the only non-Bottom inference result if > 0
-    seen = 0    # number of signatures actually inferred
+    conditionals = nothing # keeps refinement information of call argument types when the return type is boolean
+    nonbot = 0             # the index of the only non-Bottom inference result if > 0
+    seen = 0               # number of signatures actually inferred
     multiple_matches = napplicable > 1
 
     if f !== nothing && napplicable == 1 && is_method_pure(applicable[1]::MethodMatch)
@@ -121,18 +123,18 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             break
         end
         sigtuple = unwrap_unionall(sig)::DataType
-        splitunions = false
         this_rt = Bottom
+        splitunions = false
         # TODO: splitunions = 1 < unionsplitcost(sigtuple.parameters) * napplicable <= InferenceParams(interp).MAX_UNION_SPLITTING
-        # currently this triggers a bug in inference recursion detection
+        # this used to trigger a bug in inference recursion detection, and is unmaintained now
         if splitunions
             splitsigs = switchtupleunion(sig)
             for sig_n in splitsigs
                 rt, edgecycle1, edge = abstract_call_method(interp, method, sig_n, svec(), multiple_matches, sv)
+                edgecycle |= edgecycle1::Bool
                 if edge !== nothing
                     push!(edges, edge)
                 end
-                edgecycle |= edgecycle1::Bool
                 this_rt = tmerge(this_rt, rt)
                 if bail_out_call(interp, this_rt, sv)
                     break
@@ -145,6 +147,9 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                 push!(edges, edge)
             end
         end
+        this_conditional = ignorelimited(this_rt)
+        this_rt = widenwrappedconditional(this_rt)
+        @assert !(this_conditional isa Conditional) "invalid lattice element returned from inter-procedural context"
         if this_rt !== Bottom
             if nonbot === 0
                 nonbot = i
@@ -157,6 +162,26 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         if bail_out_call(interp, rettype, sv)
             break
         end
+        if this_conditional !== Bottom && is_lattice_bool(rettype) && fargs !== nothing
+            if conditionals === nothing
+                conditionals = Any[Bottom for _ in 1:length(argtypes)],
+                               Any[Bottom for _ in 1:length(argtypes)]
+            end
+            condval = maybe_extract_const_bool(this_conditional)
+            for i = 1:length(argtypes)
+                fargs[i] isa Slot || continue
+                if this_conditional isa InterConditional && this_conditional.slot == i
+                    vtype = this_conditional.vtype
+                    elsetype = this_conditional.elsetype
+                else
+                    elsetype = vtype = tmeet(argtypes[i], fieldtype(sig, i))
+                    condval === true && (elsetype = Union{})
+                    condval === false && (vtype = Union{})
+                end
+                conditionals[1][i] = tmerge(conditionals[1][i], vtype)
+                conditionals[2][i] = tmerge(conditionals[2][i], elsetype)
+            end
+        end
     end
     # try constant propagation if only 1 method is inferred to non-Bottom
     # this is in preparation for inlining, or improving the return result
@@ -165,16 +190,99 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             is_improvable(rettype) && InferenceParams(interp).ipo_constant_propagation
         # if there's a possibility we could constant-propagate a better result
         # (hopefully without doing too much work), try to do that now
-        # TODO: it feels like this could be better integrated into abstract_call_method / typeinf_edge
+        # TODO: refactor this, enable constant propagation for each (union-split) signature
+        match = applicable[nonbot]::MethodMatch
         const_rettype, result = abstract_call_method_with_const_args(interp, rettype, f, argtypes, applicable[nonbot]::MethodMatch, sv, edgecycle)
-        if const_rettype ⊑ rettype
-            # use the better result, if it's a refinement of rettype
+        const_conditional = ignorelimited(const_rettype)
+        @assert !(const_conditional isa Conditional) "invalid lattice element returned from inter-procedural context"
+        const_rettype = widenwrappedconditional(const_rettype)
+        if ignorelimited(const_rettype) ⊑ rettype
+            # use the better result, if it is a refinement of rettype
             rettype = const_rettype
+            if const_conditional isa InterConditional && conditionals === nothing && fargs !== nothing
+                arg = fargs[const_conditional.slot]
+                if arg isa Slot
+                    rettype = Conditional(arg, const_conditional.vtype, const_conditional.elsetype)
+                    if const_rettype isa LimitedAccuracy
+                        rettype = LimitedAccuracy(rettype, const_rettype.causes)
+                    end
+                end
+            end
         end
         if result !== nothing
             info = ConstCallInfo(info, result)
         end
+        # and update refinements with the InterConditional info too
+        # (here we ignorelimited, since there isn't much below this in the
+        # lattice, particularly when we're already using tmeet)
+        if const_conditional isa InterConditional && conditionals !== nothing
+            let i = const_conditional.slot,
+                vtype = const_conditional.vtype,
+                elsetype = const_conditional.elsetype
+                if !(vtype ⊑ conditionals[1][i])
+                    vtype = tmeet(conditionals[1][i], widenconst(vtype))
+                end
+                if !(elsetype ⊑ conditionals[2][i])
+                    elsetype = tmeet(conditionals[2][i], widenconst(elsetype))
+                end
+                conditionals[1][i] = vtype
+                conditionals[2][i] = elsetype
+            end
+        end
     end
+    if rettype isa LimitedAccuracy
+        union!(sv.pclimitations, rettype.causes)
+        rettype = rettype.typ
+    end
+    # if we have argument refinement information, apply that now to get the result
+    if is_lattice_bool(rettype) && conditionals !== nothing && fargs !== nothing
+        slot = 0
+        vtype = elsetype = Any
+        condval = maybe_extract_const_bool(rettype)
+        for i in 1:length(fargs)
+            # find the first argument which supports refinment,
+            # and intersect all equvalent arguments with it
+            arg = fargs[i]
+            arg isa Slot || continue # can't refine
+            old = argtypes[i]
+            old isa Type || continue # unlikely to refine
+            id = slot_id(arg)
+            if slot == 0 || id == slot
+                new_vtype = conditionals[1][i]
+                if condval === false
+                    vtype = Union{}
+                elseif new_vtype ⊑ vtype
+                    vtype = new_vtype
+                else
+                    vtype = tmeet(vtype, widenconst(new_vtype))
+                end
+                new_elsetype = conditionals[2][i]
+                if condval === true
+                    elsetype = Union{}
+                elseif new_elsetype ⊑ elsetype
+                    elsetype = new_elsetype
+                else
+                    elsetype = tmeet(elsetype, widenconst(new_elsetype))
+                end
+                if (slot > 0 || condval !== false) && !(old ⊑ vtype) # essentially vtype ⋤ old
+                    slot = id
+                elseif (slot > 0 || condval !== true) && !(old ⊑ elsetype) # essentially elsetype ⋤ old
+                    slot = id
+                else # reset: no new useful information for this slot
+                    vtype = elsetype = Any
+                    if slot > 0
+                        slot = 0
+                    end
+                end
+            end
+        end
+        if vtype === Bottom && elsetype === Bottom
+            rettype = Bottom # accidentally proved this call to be dead / throw !
+        elseif slot > 0
+            rettype = Conditional(SlotNumber(slot), vtype, elsetype) # record a Conditional improvement to this slot
+        end
+    end
+    @assert !(rettype isa InterConditional) "invalid lattice element returned from inter-procedural context"
     if is_unused && !(rettype === Bottom)
         add_remark!(interp, sv, "Call result type was widened because the return value is unused")
         # We're mainly only here because the optimizer might want this code,
@@ -186,20 +294,18 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         rettype = Any
     end
     add_call_backedges!(interp, rettype, edges, fullmatch, mts, atype, sv)
-    @assert !(rettype isa Conditional) "invalid lattice element returned from inter-procedural context"
-    #print("=> ", rettype, "\n")
-    if rettype isa LimitedAccuracy
-        union!(sv.pclimitations, rettype.causes)
-        rettype = rettype.typ
-    end
     if !isempty(sv.pclimitations) # remove self, if present
         delete!(sv.pclimitations, sv)
         for caller in sv.callers_in_cycle
             delete!(sv.pclimitations, caller)
         end
     end
+    #print("=> ", rettype, "\n")
     return CallMeta(rettype, info)
 end
+
+widenwrappedconditional(@nospecialize(typ))   = widenconditional(typ)
+widenwrappedconditional(typ::LimitedAccuracy) = LimitedAccuracy(widenconditional(typ.typ), typ.causes)
 
 function add_call_backedges!(interp::AbstractInterpreter,
                              @nospecialize(rettype),
@@ -1016,7 +1122,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         # handle Conditional propagation through !Bool
         aty = argtypes[2]
         if isa(aty, Conditional)
-            call = abstract_call_gf_by_type(interp, f, Any[Const(f), Bool], Tuple{typeof(f), Bool}, sv) # make sure we've inferred `!(::Bool)`
+            call = abstract_call_gf_by_type(interp, f, fargs, Any[Const(f), Bool], Tuple{typeof(f), Bool}, sv) # make sure we've inferred `!(::Bool)`
             return CallMeta(Conditional(aty.var, aty.elsetype, aty.vtype), call.info)
         end
     elseif la == 3 && istopfunction(f, :!==)
@@ -1060,7 +1166,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         return CallMeta(val === false ? Type : val, MethodResultPure())
     end
     atype = argtypes_to_type(argtypes)
-    return abstract_call_gf_by_type(interp, f, argtypes, atype, sv, max_methods)
+    return abstract_call_gf_by_type(interp, f, fargs, argtypes, atype, sv, max_methods)
 end
 
 function abstract_call_opaque_closure(interp::AbstractInterpreter, closure::PartialOpaque, argtypes::Vector{Any}, sv::InferenceState)
@@ -1099,29 +1205,9 @@ function abstract_call(interp::AbstractInterpreter, fargs::Union{Nothing,Vector{
             add_remark!(interp, sv, "Could not identify method table for call")
             return CallMeta(Any, false)
         end
-        callinfo = abstract_call_gf_by_type(interp, nothing, argtypes, argtypes_to_type(argtypes), sv, max_methods)
-        return callinfo_from_interprocedural(callinfo, fargs)
+        return abstract_call_gf_by_type(interp, nothing, fargs, argtypes, argtypes_to_type(argtypes), sv, max_methods)
     end
-    callinfo = abstract_call_known(interp, f, fargs, argtypes, sv, max_methods)
-    return callinfo_from_interprocedural(callinfo, fargs)
-end
-
-function callinfo_from_interprocedural(callinfo::CallMeta, ea::Union{Nothing,Vector{Any}})
-    rt = callinfo.rt
-    if isa(rt, InterConditional)
-        if ea !== nothing
-            # convert inter-procedural conditional constraint from callee into the constraint
-            # on slots of the current frame; `InterConditional` only comes from a "valid"
-            # `abstract_call` as such its slot should always be within the bound of this
-            # call arguments `ea`
-            e = ea[rt.slot]
-            if isa(e, Slot)
-                return CallMeta(Conditional(e, rt.vtype, rt.elsetype), callinfo.info)
-            end
-        end
-        return CallMeta(widenconditional(rt), callinfo.info)
-    end
-    return callinfo
+    return abstract_call_known(interp, f, fargs, argtypes, sv, max_methods)
 end
 
 function sp_type_rewrap(@nospecialize(T), linfo::MethodInstance, isreturn::Bool)
@@ -1396,29 +1482,46 @@ function abstract_eval_ssavalue(s::SSAValue, src::CodeInfo)
     return typ
 end
 
-function widenreturn(@nospecialize(rt), @nospecialize(bestguess), isva::Bool, nargs::Int, changes::VarTable)
-    if isva
-        # give up inter-procedural constraint back-propagation from vararg methods
-        # because types of same slot may differ between callee and caller
+function widenreturn(@nospecialize(rt), @nospecialize(bestguess), nslots::Int, slottypes::Vector{Any}, changes::VarTable)
+    if !(bestguess ⊑ Bool) || bestguess === Bool
+        # give up inter-procedural constraint back-propagation
+        # when tmerge would widen the result anyways (as an optimization)
         rt = widenconditional(rt)
     else
-        if isa(rt, Conditional) && !(1 ≤ slot_id(rt.var) ≤ nargs)
-            # discard this `Conditional` imposed on non-call arguments,
-            # since it's not interesting in inter-procedural context;
-            # we may give constraints on other call argument
-            rt = widenconditional(rt)
+        if isa(rt, Conditional)
+            id = slot_id(rt.var)
+            if 1 ≤ id ≤ nslots
+                old_id_type = widenconditional(slottypes[id]) # same as `((s[1]::VarTable)[id]::VarState).typ`
+                if (!(rt.vtype ⊑ old_id_type) || old_id_type ⊑ rt.vtype) &&
+                   (!(rt.elsetype ⊑ old_id_type) || old_id_type ⊑ rt.elsetype)
+                   # discard this `Conditional` since it imposes
+                   # no new constraint on the argument type
+                   # (the caller will recreate it if needed)
+                   rt = widenconditional(rt)
+               end
+            else
+                # discard this `Conditional` imposed on non-call arguments,
+                # since it's not interesting in inter-procedural context;
+                # we may give constraints on other call argument
+                rt = widenconditional(rt)
+            end
         end
-        if !isa(rt, Conditional) && rt ⊑ Bool
+        if isa(rt, Conditional)
+            rt = InterConditional(slot_id(rt.var), rt.vtype, rt.elsetype)
+        elseif is_lattice_bool(rt)
             if isa(bestguess, InterConditional)
                 # if the bestguess so far is already `Conditional`, try to convert
                 # this `rt` into `Conditional` on the slot to avoid overapproximation
                 # due to conflict of different slots
-                rt = boolean_rt_to_conditional(rt, changes, bestguess.slot)
-            elseif nargs ≥ 1
+                rt = bool_rt_to_conditional(rt, slottypes, changes, bestguess.slot)
+            else
                 # pick up the first "interesting" slot, convert `rt` to its `Conditional`
-                # TODO: this is very naive heuristic, ideally we want `Conditional`
-                # and `InterConditional` to convey constraints on multiple slots
-                rt = boolean_rt_to_conditional(rt, changes, nargs > 1 ? 2 : 1)
+                # TODO: ideally we want `Conditional` and `InterConditional` to convey
+                # constraints on multiple slots
+                for slot_id in 1:nslots
+                    rt = bool_rt_to_conditional(rt, slottypes, changes, slot_id)
+                    rt isa InterConditional && break
+                end
             end
         end
     end
@@ -1426,13 +1529,14 @@ function widenreturn(@nospecialize(rt), @nospecialize(bestguess), isva::Bool, na
     # only propagate information we know we can store
     # and is valid and good inter-procedurally
     isa(rt, Conditional) && return InterConditional(slot_id(rt.var), rt.vtype, rt.elsetype)
+    isa(rt, InterConditional) && return rt
     isa(rt, Const) && return rt
     isa(rt, Type) && return rt
     if isa(rt, PartialStruct)
         fields = copy(rt.fields)
         haveconst = false
         for i in 1:length(fields)
-            a = widenreturn(fields[i], bestguess, isva, nargs, changes)
+            a = widenreturn(fields[i], bestguess, nslots, slottypes, changes)
             if !haveconst && has_const_info(a)
                 # TODO: consider adding && const_prop_profitable(a) here?
                 haveconst = true
@@ -1457,6 +1561,8 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
     nargs = frame.nargs
     def = frame.linfo.def
     isva = isa(def, Method) && def.isva
+    nslots = nargs - isva
+    slottypes = frame.slottypes
     while frame.pc´´ <= n
         # make progress on the active ip set
         local pc::Int = frame.pc´´ # current program-counter
@@ -1527,7 +1633,19 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
             elseif isa(stmt, ReturnNode)
                 pc´ = n + 1
                 bestguess = frame.bestguess
-                rt = widenreturn(abstract_eval_value(interp, stmt.val, changes, frame), bestguess, isva, nargs, changes)
+                rt = abstract_eval_value(interp, stmt.val, changes, frame)
+                rt = widenreturn(rt, bestguess, nslots, slottypes, changes)
+                # narrow representation of bestguess slightly to prepare for tmerge with rt
+                if rt isa InterConditional && bestguess isa Const
+                    let slot_id = rt.slot
+                        old_id_type = slottypes[slot_id]
+                        if bestguess.val === true && rt.elsetype !== Bottom
+                            bestguess = InterConditional(slot_id, old_id_type, Bottom)
+                        elseif bestguess.val === false && rt.vtype !== Bottom
+                            bestguess = InterConditional(slot_id, Bottom, old_id_type)
+                        end
+                    end
+                end
                 # copy limitations to return value
                 if !isempty(frame.pclimitations)
                     union!(frame.limitations, frame.pclimitations)
@@ -1538,7 +1656,9 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                 end
                 if tchanged(rt, bestguess)
                     # new (wider) return type for frame
-                    frame.bestguess = tmerge(bestguess, rt)
+                    bestguess = tmerge(bestguess, rt)
+                    # TODO: if bestguess isa InterConditional && !interesting(bestguess); bestguess = widenconditional(bestguess); end
+                    frame.bestguess = bestguess
                     for (caller, caller_pc) in frame.cycle_backedges
                         # notify backedges of updated type information
                         typeassert(caller.stmt_types[caller_pc], VarTable) # we must have visited this statement before
@@ -1654,16 +1774,20 @@ function conditional_changes(changes::VarTable, @nospecialize(typ), var::Slot)
     return changes
 end
 
-function boolean_rt_to_conditional(@nospecialize(rt), state::VarTable, slot_id::Int)
-    typ = widenconditional((state[slot_id]::VarState).typ) # avoid nested conditional
-    if isa(rt, Const)
-        if rt.val === true
-            return Conditional(SlotNumber(slot_id), typ, Bottom)
-        elseif rt.val === false
-            return Conditional(SlotNumber(slot_id), Bottom, typ)
+function bool_rt_to_conditional(@nospecialize(rt), slottypes::Vector{Any}, state::VarTable, slot_id::Int)
+    old = slottypes[slot_id]
+    new = widenconditional((state[slot_id]::VarState).typ) # avoid nested conditional
+    if new ⊑ old && !(old ⊑ new)
+        if isa(rt, Const)
+            val = rt.val
+            if val === true
+                return InterConditional(slot_id, new, Bottom)
+            elseif val === false
+                return InterConditional(slot_id, Bottom, new)
+            end
+        elseif rt === Bool
+            return InterConditional(slot_id, new, new)
         end
-    elseif rt === Bool
-        return Conditional(SlotNumber(slot_id), typ, typ)
     end
     return rt
 end

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -4,7 +4,7 @@
 # structs/constants #
 #####################
 
-# N.B.: Const/PartialStruct are defined in Core, to allow them to be used
+# N.B.: Const/PartialStruct/InterConditional are defined in Core, to allow them to be used
 # inside the global code cache.
 #
 # # The type of a value might be constant
@@ -17,7 +17,6 @@
 #     fields::Vector{Any} # elements are other type lattice members
 # end
 import Core: Const, PartialStruct
-
 
 # The type of this value might be Bool.
 # However, to enable a limited amount of back-propagagation,
@@ -44,6 +43,18 @@ struct Conditional
         return new(var, vtype, nottype)
     end
 end
+
+# # Similar to `Conditional`, but conveys inter-procedural constraints imposed on call arguments.
+# # This is separate from `Conditional` to catch logic errors: the lattice element name is InterConditional
+# # while processing a call, then Conditional everywhere else. Thus InterConditional does not appear in
+# # CompilerTypes—these type's usages are disjoint—though we define the lattice for InterConditional.
+# struct InterConditional
+#     slot::Int
+#     vtype
+#     elsetype
+# end
+import Core: InterConditional
+const AnyConditional = Union{Conditional,InterConditional}
 
 struct PartialTypeVar
     tv::TypeVar
@@ -101,11 +112,10 @@ const CompilerTypes = Union{MaybeUndef, Const, Conditional, NotFound, PartialStr
 # lattice logic #
 #################
 
-function issubconditional(a::Conditional, b::Conditional)
-    avar = a.var
-    bvar = b.var
-    if (isa(avar, Slot) && isa(bvar, Slot) && slot_id(avar) === slot_id(bvar)) ||
-       (isa(avar, SSAValue) && isa(bvar, SSAValue) && avar === bvar)
+# `Conditional` and `InterConditional` are valid in opposite contexts
+# (i.e. local inference and inter-procedural call), as such they will never be compared
+function issubconditional(a::C, b::C) where {C<:AnyConditional}
+    if is_same_conditionals(a, b)
         if a.vtype ⊑ b.vtype
             if a.elsetype ⊑ b.elsetype
                 return true
@@ -114,9 +124,11 @@ function issubconditional(a::Conditional, b::Conditional)
     end
     return false
 end
+is_same_conditionals(a::Conditional,      b::Conditional)      = slot_id(a.var) === slot_id(b.var)
+is_same_conditionals(a::InterConditional, b::InterConditional) = a.slot === b.slot
 
-maybe_extract_const_bool(c::Const) = isa(c.val, Bool) ? c.val : nothing
-function maybe_extract_const_bool(c::Conditional)
+maybe_extract_const_bool(c::Const) = (val = c.val; isa(val, Bool)) ? val : nothing
+function maybe_extract_const_bool(c::AnyConditional)
     (c.vtype === Bottom && !(c.elsetype === Bottom)) && return false
     (c.elsetype === Bottom && !(c.vtype === Bottom)) && return true
     nothing
@@ -145,14 +157,14 @@ function ⊑(@nospecialize(a), @nospecialize(b))
     b === Union{} && return false
     @assert !isa(a, TypeVar) "invalid lattice item"
     @assert !isa(b, TypeVar) "invalid lattice item"
-    if isa(a, Conditional)
-        if isa(b, Conditional)
+    if isa(a, AnyConditional)
+        if isa(b, AnyConditional)
             return issubconditional(a, b)
         elseif isa(b, Const) && isa(b.val, Bool)
             return maybe_extract_const_bool(a) === b.val
         end
         a = Bool
-    elseif isa(b, Conditional)
+    elseif isa(b, AnyConditional)
         return false
     end
     if isa(a, PartialStruct)
@@ -251,7 +263,7 @@ function is_lattice_equal(@nospecialize(a), @nospecialize(b))
     return a ⊑ b && b ⊑ a
 end
 
-widenconst(c::Conditional) = Bool
+widenconst(c::AnyConditional) = Bool
 function widenconst(c::Const)
     if isa(c.val, Type)
         if isvarargtype(c.val)
@@ -286,7 +298,7 @@ end
 @inline schanged(@nospecialize(n), @nospecialize(o)) = (n !== o) && (o === NOT_FOUND || (n !== NOT_FOUND && !issubstate(n, o)))
 
 widenconditional(@nospecialize typ) = typ
-function widenconditional(typ::Conditional)
+function widenconditional(typ::AnyConditional)
     if typ.vtype === Union{}
         return Const(false)
     elseif typ.elsetype === Union{}

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -124,8 +124,11 @@ function issubconditional(a::C, b::C) where {C<:AnyConditional}
     end
     return false
 end
+
 is_same_conditionals(a::Conditional,      b::Conditional)      = slot_id(a.var) === slot_id(b.var)
 is_same_conditionals(a::InterConditional, b::InterConditional) = a.slot === b.slot
+
+is_lattice_bool(@nospecialize(typ)) = typ !== Bottom && typ ⊑ Bool
 
 maybe_extract_const_bool(c::Const) = (val = c.val; isa(val, Bool)) ? val : nothing
 function maybe_extract_const_bool(c::AnyConditional)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -817,8 +817,7 @@ const missing = Missing()
 
 Indicate whether `x` is [`missing`](@ref).
 """
-ismissing(::Any) = false
-ismissing(::Missing) = true
+ismissing(x) = x === missing
 
 function popfirst! end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1382,7 +1382,7 @@ function operator_associativity(s::Symbol)
 end
 
 is_expr(@nospecialize(ex), head::Symbol)         = isa(ex, Expr) && (ex.head === head)
-is_expr(@nospecialize(ex), head::Symbol, n::Int) = is_expr(ex, head) && length((ex::Expr).args) == n
+is_expr(@nospecialize(ex), head::Symbol, n::Int) = is_expr(ex, head) && length(ex.args) == n
 
 is_quoted(ex)            = false
 is_quoted(ex::QuoteNode) = true

--- a/base/some.jl
+++ b/base/some.jl
@@ -65,8 +65,7 @@ Return `true` if `x === nothing`, and return `false` if not.
 !!! compat "Julia 1.1"
     This function requires at least Julia 1.1.
 """
-isnothing(::Any) = false
-isnothing(::Nothing) = true
+isnothing(x) = x === nothing
 
 
 """

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1616,6 +1616,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Const", (jl_value_t*)jl_const_type);
     add_builtin("PartialStruct", (jl_value_t*)jl_partial_struct_type);
     add_builtin("PartialOpaque", (jl_value_t*)jl_partial_opaque_type);
+    add_builtin("InterConditional", (jl_value_t*)jl_interconditional_type);
     add_builtin("MethodMatch", (jl_value_t*)jl_method_match_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -72,6 +72,7 @@
     XX(jl_number_type) \
     XX(jl_partial_struct_type) \
     XX(jl_partial_opaque_type) \
+    XX(jl_interconditional_type) \
     XX(jl_phicnode_type) \
     XX(jl_phinode_type) \
     XX(jl_pinode_type) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2308,6 +2308,10 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_perm_symsvec(2, "typ", "fields"),
                                        jl_svec2(jl_any_type, jl_array_any_type), 0, 0, 2);
 
+    jl_interconditional_type = jl_new_datatype(jl_symbol("InterConditional"), core, jl_any_type, jl_emptysvec,
+                                          jl_perm_symsvec(3, "slot", "vtype", "elsetype"),
+                                          jl_svec(3, jl_long_type, jl_any_type, jl_any_type), 0, 0, 3);
+
     jl_method_match_type = jl_new_datatype(jl_symbol("MethodMatch"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(4, "spec_types", "sparams", "method", "fully_covers"),
                                        jl_svec(4, jl_type_type, jl_simplevector_type, jl_method_type, jl_bool_type), 0, 0, 4);

--- a/src/julia.h
+++ b/src/julia.h
@@ -634,6 +634,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_const_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_struct_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_opaque_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_interconditional_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_method_match_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_simplevector_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_typename_t *jl_tuple_typename JL_GLOBALLY_ROOTED;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -30,7 +30,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    146
+#define NUM_TAGS    147
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -69,6 +69,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_const_type);
         INSERT_TAG(jl_partial_struct_type);
         INSERT_TAG(jl_partial_opaque_type);
+        INSERT_TAG(jl_interconditional_type);
         INSERT_TAG(jl_method_match_type);
         INSERT_TAG(jl_pinode_type);
         INSERT_TAG(jl_phinode_type);


### PR DESCRIPTION
This PR propagates `Conditional`s inter-procedurally when a
`Conditional` at return site imposes a constraint on the call arguments.
When inference exits local frame and the return type is annotated as
`Conditional`, it will be converted into `InterConditional` object,
which is implemented in `Core` and can be directly put into the global
cache. Finally after going back to caller frame, `InterConditional` will
be re-converted into `Conditional` in the context of the caller frame.

 ## improvements 
 
So now some simple "is-wrapper" functions will propagate its constraint
as expected, e.g.:
```julia
isaint(a) = isa(a, Int)
@test Base.return_types((Any,)) do a
    isaint(a) && return a # a::Int
    return 0
end == Any[Int]

isaint2(::Any) = false
isaint2(::Int) = true
@test Base.return_types((Any,)) do a
    isaint2(a) && return a # a::Int
    return 0
end == Any[Int]

function isa_int_or_float64(a)
    isa(a, Int) && return true
    isa(a, Float64) && return true
    return false
end
@test Base.return_types((Any,)) do a
    isa_int_or_float64(a) && return a # a::Union{Float64,Int}
    0
end == Any[Union{Float64,Int}]
```

(and now we don't need something like #38636)

 ## benchmarks

A compile time comparison:
> on the current master (82d79ce18f88923c14d322b70699da43a72e6b32)
```
Sysimage built. Summary:
Total ───────  55.295376 seconds
Base: ───────  23.359226 seconds 42.2444%
Stdlibs: ────  31.934773 seconds 57.7531%
    JULIA usr/lib/julia/sys-o.a
Generating REPL precompile statements... 29/29
Executing precompile statements... 1283/1283
Precompilation complete. Summary:
Total ───────  91.129162 seconds
Generation ──  68.800937 seconds 75.4983%
Execution ───  22.328225 seconds 24.5017%
    LINK usr/lib/julia/sys.dylib
```

> on this PR (37e279bce7136e48f159811641b68143412c3881)
```
Sysimage built. Summary:
Total ───────  51.694730 seconds
Base: ───────  21.943914 seconds 42.449%
Stdlibs: ────  29.748987 seconds 57.5474%
    JULIA usr/lib/julia/sys-o.a
Generating REPL precompile statements... 29/29
Executing precompile statements... 1357/1357
Precompilation complete. Summary:
Total ───────  88.956226 seconds
Generation ──  67.077710 seconds 75.4053%
Execution ───  21.878515 seconds 24.5947%
    LINK usr/lib/julia/sys.dylib
```

Here is a sample code that benefits from this PR:
```julia
function summer(ary)
    r = 0
    for a in ary
        if ispositive(a)
            r += a
        end
    end
    r
end

ispositive(a) = isa(a, Int) && a > 0

ary = Any[]
for _ in 1:100_000
    if rand(Bool)
        push!(ary, rand(-100:100))
    elseif rand(Bool)
        push!(ary, rand('a':'z'))
    else
        push!(ary, nothing)
    end
end

using BenchmarkTools
@btime summer($(ary))
```

> on the current master (82d79ce18f88923c14d322b70699da43a72e6b32)
```
❯ julia summer.jl
  1.214 ms (24923 allocations: 389.42 KiB)
```

> on this PR (37e279bce7136e48f159811641b68143412c3881)
```
❯ julia summer.jl
  421.223 μs (0 allocations: 0 bytes)
```

 ## caveats
  
Within the `Conditional`/`InterConditional` framework, only a single
constraint can be back-propagated inter-procedurally. This PR implements
a naive heuristic to "pick up" a constraint to be propagated when a
return type is a boolean. The heuristic may fail to select an
"interesting" constraint in some cases. For example, we may expect
`::Expr` constraint to be imposed on the first argument of
`Meta.isexpr`, but the current heuristic ends up picking up a constraint
on the second argument (i.e. `ex.head === head`).
```julia
isexpr(@nospecialize(ex), head::Symbol) = isa(ex, Expr) && ex.head === head

@test_broken Base.return_types((Any,)) do x
    Meta.isexpr(x, :call) && return x # x::Expr, ideally
    return nothing
end == Any[Union{Nothing,Expr}]
```

I think We can get rid of this limitation by extending `Conditional` and
`InterConditional`
so that they can convey multiple constraints, but I'd like to leave this
as a future work.

EDIT: 3df027a implements the "pick up" logic within a caller
(i.e. within `abstract_call_gf_by_type`), which allows us to choose a
constraint more appropriately, and now the `Meta.isexpr` case is fixed.
Still there is a limitation of multiple conditional constraint
back-propagation; the following broken test case will explain the future
work.
```julia
is_int_and_int(a, b) = isa(a, Int) && isa(b, Int)
@test_broken Base.return_types((Any,Any)) do a, b
    is_int_and_int(a, b) && return a, b # (a::Int, b::Int) ideally, but (a::Any, b::Int)
    0, 0
end == Any[Tuple{Int,Int}]
```

---

- closes #38636
- closes #37342
