### PR TITLE
Reduce latency of Revise.revise()

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -391,6 +391,42 @@ end_base_include = time_ns()
 const _sysimage_modules = PkgId[]
 in_sysimage(pkgid::PkgId) = pkgid in _sysimage_modules
 
+# Precompiles for Revise
+# TODO: move these to contrib/generate_precompile.jl
+# The problem is they don't work there
+let m = which(+, (Int, Int))
+    while true  # defeat interpreter heuristic to force compilation
+        delete!(push!(Set{Method}(), m), m)
+        copy(Core.Compiler.retrieve_code_info(Core.Compiler.specialize_method(m, [Int, Int], Core.svec())))
+
+        empty!(Set())
+        push!(push!(Set{Union{GlobalRef,Symbol}}(), :two), GlobalRef(Base, :two))
+        (setindex!(Dict{String,Base.PkgId}(), Base.PkgId(Base), "file.jl"))["file.jl"]
+        (setindex!(Dict{Symbol,Vector{Int}}(), [1], :two))[:two]
+        (setindex!(Dict{Base.PkgId,String}(), "file.jl", Base.PkgId(Base)))[Base.PkgId(Base)]
+        (setindex!(Dict{Union{GlobalRef,Symbol}, Vector{Int}}(), [1], :two))[:two]
+        (setindex!(IdDict{Type, Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}}(), missing, Int))[Int]
+        Dict{Symbol, Union{Nothing, Bool, Symbol}}(:one => false)[:one]
+        Dict(Base => [:(1+1)])[Base]
+        Dict(:one => [1])[:one]
+        Dict("abc" => Set())["abc"]
+        pushfirst!([], sum)
+        get(Base.pkgorigins, Base.PkgId(Base), nothing)
+        sort!([1,2,3])
+        unique!([1,2,3])
+        cumsum([1,2,3])
+        append!(Int[], BitSet())
+        isempty(BitSet())
+        delete!(BitSet([1,2]), 3)
+        deleteat!(Int32[1,2,3], [1,3])
+        deleteat!(Any[1,2,3], [1,3])
+        Core.svec(1, 2) == Core.svec(3, 4)
+        any(t->t[1].line > 1, [(LineNumberNode(2,:none), :(1+1))])
+
+        break   # end defeat interpreter heuristic
+    end
+end
+
 if is_primary_base_module
 function __init__()
     # try to ensuremake sure OpenBLAS does not set CPU affinity (#1070, #9639)

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -55,34 +55,38 @@ cd("complet_path\t\t$CTRL_C
 """
 
 precompile_script = """
-# Used by Revise & its dependencies
-delete!(push!(Set{Module}(), Base), Main)
-m = first(methods(+))
-delete!(push!(Set{Method}(), m), m)
-empty!(Set())
-push!(push!(Set{Union{GlobalRef,Symbol}}(), :two), GlobalRef(Base, :two))
-(setindex!(Dict{String,Base.PkgId}(), Base.PkgId(Base), "file.jl"))["file.jl"]
-(setindex!(Dict{Symbol,Vector{Int}}(), [1], :two))[:two]
-(setindex!(Dict{Base.PkgId,String}(), "file.jl", Base.PkgId(Base)))[Base.PkgId(Base)]
-(setindex!(Dict{Union{GlobalRef,Symbol}, Vector{Int}}(), [1], :two))[:two]
-(setindex!(IdDict{Type, Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}}(), missing, Int))[Int]
-Dict{Symbol, Union{Nothing, Bool, Symbol}}(:one => false)[:one]
-Dict(Base => [:(1+1)])[Base]
-Dict(:one => [1])[:one]
-Dict("abc" => Set())["abc"]
-pushfirst!([], sum)
-get(Base.pkgorigins, Base.PkgId(Base), nothing)
-sort!([1,2,3])
-unique!([1,2,3])
-cumsum([1,2,3])
-append!(Int[], BitSet())
-isempty(BitSet())
-delete!(BitSet([1,2]), 3)
-deleteat!(Int32[1,2,3], [1,3])
-deleteat!(Any[1,2,3], [1,3])
-Core.svec(1, 2) == Core.svec(3, 4)
-copy(Core.Compiler.retrieve_code_info(Core.Compiler.specialize_method(which(+, (Int, Int)), [Int, Int], Core.svec())))
-any(t->t[1].line > 1, [(LineNumberNode(2,:none),:(1+1))])
+# NOTE: these were moved to the end of Base.jl. TODO: move back here.
+# # Used by Revise & its dependencies
+# while true  # force inference
+# delete!(push!(Set{Module}(), Base), Main)
+# m = first(methods(+))
+# delete!(push!(Set{Method}(), m), m)
+# empty!(Set())
+# push!(push!(Set{Union{GlobalRef,Symbol}}(), :two), GlobalRef(Base, :two))
+# (setindex!(Dict{String,Base.PkgId}(), Base.PkgId(Base), "file.jl"))["file.jl"]
+# (setindex!(Dict{Symbol,Vector{Int}}(), [1], :two))[:two]
+# (setindex!(Dict{Base.PkgId,String}(), "file.jl", Base.PkgId(Base)))[Base.PkgId(Base)]
+# (setindex!(Dict{Union{GlobalRef,Symbol}, Vector{Int}}(), [1], :two))[:two]
+# (setindex!(IdDict{Type, Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}}(), missing, Int))[Int]
+# Dict{Symbol, Union{Nothing, Bool, Symbol}}(:one => false)[:one]
+# Dict(Base => [:(1+1)])[Base]
+# Dict(:one => [1])[:one]
+# Dict("abc" => Set())["abc"]
+# pushfirst!([], sum)
+# get(Base.pkgorigins, Base.PkgId(Base), nothing)
+# sort!([1,2,3])
+# unique!([1,2,3])
+# cumsum([1,2,3])
+# append!(Int[], BitSet())
+# isempty(BitSet())
+# delete!(BitSet([1,2]), 3)
+# deleteat!(Int32[1,2,3], [1,3])
+# deleteat!(Any[1,2,3], [1,3])
+# Core.svec(1, 2) == Core.svec(3, 4)
+# # copy(Core.Compiler.retrieve_code_info(Core.Compiler.specialize_method(which(+, (Int, Int)), [Int, Int], Core.svec())))
+# any(t->t[1].line > 1, [(LineNumberNode(2,:none),:(1+1))])
+# break   # end force inference
+# end
 """
 
 julia_exepath() = joinpath(Sys.BINDIR::String, Base.julia_exename())

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -15,12 +15,11 @@ UP_ARROW = "\e[A"
 DOWN_ARROW = "\e[B"
 
 hardcoded_precompile_statements = """
-# used by JuliaInterpreter.jl and Revise.jl
+# used by Revise.jl
 @assert precompile(Tuple{typeof(Base.parse_cache_header), String})
-@assert precompile(Tuple{typeof(pushfirst!), Vector{Any}, Function})
-@assert precompile(Tuple{typeof(push!), Set{Module}, Module})
-@assert precompile(Tuple{typeof(push!), Set{Method}, Method})
-@assert precompile(Tuple{typeof(empty!), Set{Any}})
+@assert precompile(Base.read_dependency_src, (String, String))
+@assert precompile(Base.CoreLogging.current_logger_for_env, (Base.CoreLogging.LogLevel, String, Module))
+
 # used by Requires.jl
 @assert precompile(Tuple{typeof(get!), Type{Vector{Function}}, Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
 @assert precompile(Tuple{typeof(haskey), Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
@@ -56,10 +55,34 @@ cd("complet_path\t\t$CTRL_C
 """
 
 precompile_script = """
-# Used by Revise
+# Used by Revise & its dependencies
+delete!(push!(Set{Module}(), Base), Main)
+m = first(methods(+))
+delete!(push!(Set{Method}(), m), m)
+empty!(Set())
+push!(push!(Set{Union{GlobalRef,Symbol}}(), :two), GlobalRef(Base, :two))
 (setindex!(Dict{String,Base.PkgId}(), Base.PkgId(Base), "file.jl"))["file.jl"]
+(setindex!(Dict{Symbol,Vector{Int}}(), [1], :two))[:two]
 (setindex!(Dict{Base.PkgId,String}(), "file.jl", Base.PkgId(Base)))[Base.PkgId(Base)]
+(setindex!(Dict{Union{GlobalRef,Symbol}, Vector{Int}}(), [1], :two))[:two]
+(setindex!(IdDict{Type, Union{Missing, Vector{Tuple{LineNumberNode, Expr}}}}(), missing, Int))[Int]
+Dict{Symbol, Union{Nothing, Bool, Symbol}}(:one => false)[:one]
+Dict(Base => [:(1+1)])[Base]
+Dict(:one => [1])[:one]
+Dict("abc" => Set())["abc"]
+pushfirst!([], sum)
 get(Base.pkgorigins, Base.PkgId(Base), nothing)
+sort!([1,2,3])
+unique!([1,2,3])
+cumsum([1,2,3])
+append!(Int[], BitSet())
+isempty(BitSet())
+delete!(BitSet([1,2]), 3)
+deleteat!(Int32[1,2,3], [1,3])
+deleteat!(Any[1,2,3], [1,3])
+Core.svec(1, 2) == Core.svec(3, 4)
+copy(Core.Compiler.retrieve_code_info(Core.Compiler.specialize_method(which(+, (Int, Int)), [Int, Int], Core.svec())))
+any(t->t[1].line > 1, [(LineNumberNode(2,:none),:(1+1))])
 """
 
 julia_exepath() = joinpath(Sys.BINDIR::String, Base.julia_exename())
@@ -72,21 +95,26 @@ if have_repl
     """
 end
 
-# This is disabled because it doesn't give much benefit
-# and the code in Distributed is poorly typed causing many invalidations
-#=
 Distributed = get(Base.loaded_modules,
           Base.PkgId(Base.UUID("8ba89e20-285c-5b6f-9357-94700520ee1b"), "Distributed"),
           nothing)
 if Distributed !== nothing
+    hardcoded_precompile_statements *= """
+    @assert precompile(Tuple{typeof(Distributed.remotecall),Function,Int,Module,Vararg{Any, 100}})
+    @assert precompile(Tuple{typeof(Distributed.procs)})
+    @assert precompile(Tuple{typeof(Distributed.finalize_ref), Distributed.Future})
+    """
+# This is disabled because it doesn't give much benefit
+# and the code in Distributed is poorly typed causing many invalidations
+#=
     precompile_script *= """
     using Distributed
     addprocs(2)
     pmap(x->iseven(x) ? 1 : 0, 1:4)
     @distributed (+) for i = 1:100 Int(rand(Bool)) end
     """
-end
 =#
+end
 
 
 Artifacts = get(Base.loaded_modules,
@@ -121,6 +149,7 @@ if FileWatching !== nothing
     hardcoded_precompile_statements *= """
     @assert precompile(Tuple{typeof(FileWatching.watch_file), String, Float64})
     @assert precompile(Tuple{typeof(FileWatching.watch_file), String, Int})
+    @assert precompile(Tuple{typeof(FileWatching._uv_hook_close), FileWatching.FileMonitor})
     """
 end
 


### PR DESCRIPTION
Perhaps the most annoying thing about Revise now is that the first revision is quite slow, about 3.1s on my machine. 
This drops the time to 1.85s, a nice improvement.

This was curious, so by way of explanation I'm just going to paste the comments of both commits.

Commit 1:
Add precompiles to reduce time to first Revise.revise()

Perhaps the most annoying thing about Revise now is that the first
revision is quite slow, about 3.1s on my machine. This PR drops the time
to about 2.4s. Basically the idea is to precompile statements that
Revise will need.

Discovered via the new snoopi_deep/Core.Compiler.Timings framework.

----------------------------

Commit 2:
Internalize Revise precompiles into Base

For some reason (perhaps #32705?) most or all of these fail if they
are emitted as precompile statements, so this moves them into Base itself.

This drops the time for a revision down to 1.85s.

----------------------------

The commits are separate because it was an interesting discovery on its own, and the second is evidently ugly so it would be nice not to need it.