### PR TITLE
Measure compile time only when using time macros pt.2: handling when code under test throws and make compile timing thread-local

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -200,14 +200,16 @@ macro time(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        local val = $(esc(ex))
-        elapsedtime = time_ns() - elapsedtime
-        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
-        local diff = GC_Diff(gc_num(), stats)
-        time_print(elapsedtime, diff.allocd, diff.total_time,
-                   gc_alloc_count(diff), compile_elapsedtime)
-        println()
-        val
+        try
+            $(esc(ex))
+        finally
+            elapsedtime = time_ns() - elapsedtime
+            compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+            local diff = GC_Diff(gc_num(), stats)
+            time_print(elapsedtime, diff.allocd, diff.total_time,
+                    gc_alloc_count(diff), compile_elapsedtime)
+            println()
+        end
     end
 end
 
@@ -248,11 +250,13 @@ macro timev(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        local val = $(esc(ex))
-        elapsedtime = time_ns() - elapsedtime
-        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
-        timev_print(elapsedtime, GC_Diff(gc_num(), stats), compile_elapsedtime)
-        val
+        try
+            $(esc(ex))
+        finally
+            elapsedtime = time_ns() - elapsedtime
+            compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+            timev_print(elapsedtime, GC_Diff(gc_num(), stats), compile_elapsedtime)
+        end
     end
 end
 

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -56,8 +56,17 @@ function gc_alloc_count(diff::GC_Diff)
 end
 
 # cumulative total time spent on compilation
-cumulative_compile_time_ns_before() = ccall(:jl_cumulative_compile_time_ns_before, UInt64, ())
-cumulative_compile_time_ns_after() = ccall(:jl_cumulative_compile_time_ns_after, UInt64, ())
+const comp_timer_lock = ReentrantLock()
+function cumulative_compile_time_ns_before()
+    lock(comp_timer_lock) do
+        ccall(:jl_cumulative_compile_time_ns_before, UInt64, ())
+    end
+end
+function cumulative_compile_time_ns_after()
+    lock(comp_timer_lock) do
+        ccall(:jl_cumulative_compile_time_ns_after, UInt64, ())
+    end
+end
 
 # total time spend in garbage collection, in nanoseconds
 gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -56,12 +56,8 @@ function gc_alloc_count(diff::GC_Diff)
 end
 
 # cumulative total time spent on compilation
-function cumulative_compile_time_ns_before()
-    ccall(:jl_cumulative_compile_time_ns_before, UInt64, ())
-end
-function cumulative_compile_time_ns_after()
-    ccall(:jl_cumulative_compile_time_ns_after, UInt64, ())
-end
+cumulative_compile_time_ns_before() = ccall(:jl_cumulative_compile_time_ns_before, UInt64, ())
+cumulative_compile_time_ns_after() = ccall(:jl_cumulative_compile_time_ns_after, UInt64, ())
 
 # total time spend in garbage collection, in nanoseconds
 gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -56,16 +56,11 @@ function gc_alloc_count(diff::GC_Diff)
 end
 
 # cumulative total time spent on compilation
-const comp_timer_lock = ReentrantLock()
 function cumulative_compile_time_ns_before()
-    lock(comp_timer_lock) do
-        ccall(:jl_cumulative_compile_time_ns_before, UInt64, ())
-    end
+    ccall(:jl_cumulative_compile_time_ns_before, UInt64, ())
 end
 function cumulative_compile_time_ns_after()
-    lock(comp_timer_lock) do
-        ccall(:jl_cumulative_compile_time_ns_after, UInt64, ())
-    end
+    ccall(:jl_cumulative_compile_time_ns_after, UInt64, ())
 end
 
 # total time spend in garbage collection, in nanoseconds

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -293,7 +293,8 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _p
     JL_GC_PUSH1(&src);
     JL_LOCK(&codegen_lock);
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time[jl_threadid()])
+    int tid = jl_threadid();
+    if (jl_measure_compile_time[tid])
         compiler_start_time = jl_hrtime();
 
     CompilationPolicy policy = (CompilationPolicy) _policy;
@@ -417,8 +418,8 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _p
     }
 
     data->M = std::move(clone);
-    if (jl_measure_compile_time[jl_threadid()])
-        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
+    if (jl_measure_compile_time[tid])
+        jl_cumulative_compile_time[tid] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock); // Might GC
     return (void*)data;
 }
@@ -896,7 +897,8 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
         jl_llvm_functions_t decls;
         JL_LOCK(&codegen_lock);
         uint64_t compiler_start_time = 0;
-        if (jl_measure_compile_time[jl_threadid()])
+        int tid = jl_threadid();
+        if (jl_measure_compile_time[tid])
             compiler_start_time = jl_hrtime();
         std::tie(m, decls) = jl_emit_code(mi, src, jlrettype, output);
 
@@ -921,8 +923,8 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
             m.release(); // the return object `llvmf` will be the owning pointer
         }
         JL_GC_POP();
-        if (jl_measure_compile_time[jl_threadid()])
-            jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
+        if (jl_measure_compile_time[tid])
+            jl_cumulative_compile_time[tid] += (jl_hrtime() - compiler_start_time);
         JL_UNLOCK(&codegen_lock); // Might GC
         if (F)
             return F;

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -293,7 +293,7 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _p
     JL_GC_PUSH1(&src);
     JL_LOCK(&codegen_lock);
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time)
+    if (jl_measure_compile_time[jl_threadid()])
         compiler_start_time = jl_hrtime();
 
     CompilationPolicy policy = (CompilationPolicy) _policy;
@@ -417,8 +417,8 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _p
     }
 
     data->M = std::move(clone);
-    if (jl_measure_compile_time)
-        jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+    if (jl_measure_compile_time[jl_threadid()])
+        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock); // Might GC
     return (void*)data;
 }
@@ -896,7 +896,7 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
         jl_llvm_functions_t decls;
         JL_LOCK(&codegen_lock);
         uint64_t compiler_start_time = 0;
-        if (jl_measure_compile_time)
+        if (jl_measure_compile_time[jl_threadid()])
             compiler_start_time = jl_hrtime();
         std::tie(m, decls) = jl_emit_code(mi, src, jlrettype, output);
 
@@ -921,8 +921,8 @@ void *jl_get_llvmf_defn(jl_method_instance_t *mi, size_t world, char getwrapper,
             m.release(); // the return object `llvmf` will be the owning pointer
         }
         JL_GC_POP();
-        if (jl_measure_compile_time)
-            jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+        if (jl_measure_compile_time[jl_threadid()])
+            jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
         JL_UNLOCK(&codegen_lock); // Might GC
         if (F)
             return F;

--- a/src/gf.c
+++ b/src/gf.c
@@ -3147,21 +3147,20 @@ int jl_has_concrete_subtype(jl_value_t *typ)
 //static jl_mutex_t typeinf_lock;
 #define typeinf_lock codegen_lock
 
-uint8_t jl_measure_compile_time = 0;
-uint64_t jl_cumulative_compile_time = 0;
 static uint64_t inference_start_time = 0;
 
 JL_DLLEXPORT void jl_typeinf_begin(void)
 {
     JL_LOCK(&typeinf_lock);
-    if (jl_measure_compile_time)
+    if (jl_measure_compile_time[jl_threadid()])
         inference_start_time = jl_hrtime();
 }
 
 JL_DLLEXPORT void jl_typeinf_end(void)
 {
-    if (typeinf_lock.count == 1 && jl_measure_compile_time)
-        jl_cumulative_compile_time += (jl_hrtime() - inference_start_time);
+    int tid = jl_threadid();
+    if (typeinf_lock.count == 1 && jl_measure_compile_time[tid])
+        jl_cumulative_compile_time[tid] += (jl_hrtime() - inference_start_time);
     JL_UNLOCK(&typeinf_lock);
 }
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -78,14 +78,16 @@ void jl_jit_globals(std::map<void *, GlobalVariable*> &globals)
 extern "C" JL_DLLEXPORT
 uint64_t jl_cumulative_compile_time_ns_before()
 {
-    jl_measure_compile_time = 1;
-    return jl_cumulative_compile_time;
+    int tid = jl_threadid();
+    jl_measure_compile_time[tid] = 1;
+    return jl_cumulative_compile_time[tid];
 }
 extern "C" JL_DLLEXPORT
 uint64_t jl_cumulative_compile_time_ns_after()
 {
-    jl_measure_compile_time = 0;
-    return jl_cumulative_compile_time;
+    int tid = jl_threadid();
+    jl_measure_compile_time[tid] = 0;
+    return jl_cumulative_compile_time[tid];
 }
 
 // this generates llvm code for the lambda info
@@ -231,7 +233,7 @@ int jl_compile_extern_c(void *llvmmod, void *p, void *sysimg, jl_value_t *declrt
 {
     JL_LOCK(&codegen_lock);
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time)
+    if (jl_measure_compile_time[jl_threadid()])
         compiler_start_time = jl_hrtime();
     jl_codegen_params_t params;
     jl_codegen_params_t *pparams = (jl_codegen_params_t*)p;
@@ -255,8 +257,8 @@ int jl_compile_extern_c(void *llvmmod, void *p, void *sysimg, jl_value_t *declrt
         if (success && llvmmod == NULL)
             jl_add_to_ee(std::unique_ptr<Module>(into));
     }
-    if (codegen_lock.count == 1 && jl_measure_compile_time)
-        jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1 && jl_measure_compile_time[jl_threadid()])
+        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock);
     return success;
 }
@@ -314,7 +316,7 @@ jl_code_instance_t *jl_generate_fptr(jl_method_instance_t *mi JL_PROPAGATES_ROOT
 {
     JL_LOCK(&codegen_lock); // also disables finalizers, to prevent any unexpected recursion
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time)
+    if (jl_measure_compile_time[jl_threadid()])
         compiler_start_time = jl_hrtime();
     // if we don't have any decls already, try to generate it now
     jl_code_info_t *src = NULL;
@@ -352,8 +354,8 @@ jl_code_instance_t *jl_generate_fptr(jl_method_instance_t *mi JL_PROPAGATES_ROOT
     else {
         codeinst = NULL;
     }
-    if (codegen_lock.count == 1 && jl_measure_compile_time)
-        jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1 && jl_measure_compile_time[jl_threadid()])
+        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock);
     JL_GC_POP();
     return codeinst;
@@ -367,7 +369,7 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
     }
     JL_LOCK(&codegen_lock);
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time)
+    if (jl_measure_compile_time[jl_threadid()])
         compiler_start_time = jl_hrtime();
     if (unspec->invoke == NULL) {
         jl_code_info_t *src = NULL;
@@ -395,8 +397,8 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
         }
         JL_GC_POP();
     }
-    if (codegen_lock.count == 1 && jl_measure_compile_time)
-        jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1 && jl_measure_compile_time[jl_threadid()])
+        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock); // Might GC
 }
 
@@ -419,7 +421,7 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
             // so create an exception here so we can print pretty our lies
             JL_LOCK(&codegen_lock); // also disables finalizers, to prevent any unexpected recursion
             uint64_t compiler_start_time = 0;
-            if (jl_measure_compile_time)
+            if (jl_measure_compile_time[jl_threadid()])
                 compiler_start_time = jl_hrtime();
             specfptr = (uintptr_t)codeinst->specptr.fptr;
             if (specfptr == 0) {
@@ -444,8 +446,8 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
                 }
                 JL_GC_POP();
             }
-            if (jl_measure_compile_time)
-                jl_cumulative_compile_time += (jl_hrtime() - compiler_start_time);
+            if (jl_measure_compile_time[jl_threadid()])
+                jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
             JL_UNLOCK(&codegen_lock);
         }
         if (specfptr != 0)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -233,7 +233,8 @@ int jl_compile_extern_c(void *llvmmod, void *p, void *sysimg, jl_value_t *declrt
 {
     JL_LOCK(&codegen_lock);
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time[jl_threadid()])
+    int tid = jl_threadid();
+    if (jl_measure_compile_time[tid])
         compiler_start_time = jl_hrtime();
     jl_codegen_params_t params;
     jl_codegen_params_t *pparams = (jl_codegen_params_t*)p;
@@ -257,8 +258,8 @@ int jl_compile_extern_c(void *llvmmod, void *p, void *sysimg, jl_value_t *declrt
         if (success && llvmmod == NULL)
             jl_add_to_ee(std::unique_ptr<Module>(into));
     }
-    if (codegen_lock.count == 1 && jl_measure_compile_time[jl_threadid()])
-        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1 && jl_measure_compile_time[tid])
+        jl_cumulative_compile_time[tid] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock);
     return success;
 }
@@ -316,7 +317,8 @@ jl_code_instance_t *jl_generate_fptr(jl_method_instance_t *mi JL_PROPAGATES_ROOT
 {
     JL_LOCK(&codegen_lock); // also disables finalizers, to prevent any unexpected recursion
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time[jl_threadid()])
+    int tid = jl_threadid();
+    if (jl_measure_compile_time[tid])
         compiler_start_time = jl_hrtime();
     // if we don't have any decls already, try to generate it now
     jl_code_info_t *src = NULL;
@@ -354,8 +356,8 @@ jl_code_instance_t *jl_generate_fptr(jl_method_instance_t *mi JL_PROPAGATES_ROOT
     else {
         codeinst = NULL;
     }
-    if (codegen_lock.count == 1 && jl_measure_compile_time[jl_threadid()])
-        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1 && jl_measure_compile_time[tid])
+        jl_cumulative_compile_time[tid] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock);
     JL_GC_POP();
     return codeinst;
@@ -369,7 +371,8 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
     }
     JL_LOCK(&codegen_lock);
     uint64_t compiler_start_time = 0;
-    if (jl_measure_compile_time[jl_threadid()])
+    int tid = jl_threadid();
+    if (jl_measure_compile_time[tid])
         compiler_start_time = jl_hrtime();
     if (unspec->invoke == NULL) {
         jl_code_info_t *src = NULL;
@@ -397,8 +400,8 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
         }
         JL_GC_POP();
     }
-    if (codegen_lock.count == 1 && jl_measure_compile_time[jl_threadid()])
-        jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
+    if (codegen_lock.count == 1 && jl_measure_compile_time[tid])
+        jl_cumulative_compile_time[tid] += (jl_hrtime() - compiler_start_time);
     JL_UNLOCK(&codegen_lock); // Might GC
 }
 
@@ -421,7 +424,8 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
             // so create an exception here so we can print pretty our lies
             JL_LOCK(&codegen_lock); // also disables finalizers, to prevent any unexpected recursion
             uint64_t compiler_start_time = 0;
-            if (jl_measure_compile_time[jl_threadid()])
+            int tid = jl_threadid();
+            if (jl_measure_compile_time[tid])
                 compiler_start_time = jl_hrtime();
             specfptr = (uintptr_t)codeinst->specptr.fptr;
             if (specfptr == 0) {
@@ -446,8 +450,8 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
                 }
                 JL_GC_POP();
             }
-            if (jl_measure_compile_time[jl_threadid()])
-                jl_cumulative_compile_time[jl_threadid()] += (jl_hrtime() - compiler_start_time);
+            if (jl_measure_compile_time[tid])
+                jl_cumulative_compile_time[tid] += (jl_hrtime() - compiler_start_time);
             JL_UNLOCK(&codegen_lock);
         }
         if (specfptr != 0)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -122,8 +122,8 @@ static inline uint64_t cycleclock(void)
 
 #include "timing.h"
 
-extern uint8_t jl_measure_compile_time;
-extern uint64_t jl_cumulative_compile_time;
+extern uint8_t *jl_measure_compile_time;
+extern uint64_t *jl_cumulative_compile_time;
 
 #ifdef _COMPILER_MICROSOFT_
 #  define jl_return_address() ((uintptr_t)_ReturnAddress())

--- a/src/threading.c
+++ b/src/threading.c
@@ -223,6 +223,8 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
 
 JL_DLLEXPORT int jl_n_threads;
 jl_ptls_t *jl_all_tls_states JL_GLOBALLY_ROOTED;
+uint8_t *jl_measure_compile_time = NULL;
+uint64_t *jl_cumulative_compile_time = NULL;
 
 // return calling thread's ID
 // Also update the suspended_threads list in signals-mach when changing the
@@ -400,6 +402,8 @@ void jl_init_threading(void)
         jl_n_threads = (uint64_t)strtol(cp, NULL, 10);
     if (jl_n_threads <= 0)
         jl_n_threads = 1;
+    jl_measure_compile_time = realloc( jl_measure_compile_time, jl_n_threads * sizeof *jl_measure_compile_time );
+    jl_cumulative_compile_time = realloc( jl_cumulative_compile_time, jl_n_threads * sizeof *jl_cumulative_compile_time );
 #ifndef __clang_analyzer__
     jl_all_tls_states = (jl_ptls_t*)calloc(jl_n_threads, sizeof(void*));
 #endif


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/38885 intended to only enable compile time during the timing macros, however as @ericphanson [pointed out](https://github.com/JuliaLang/julia/pull/38885#pullrequestreview-553541059) if the code under test throws the timing could be left enabled.

The fix here of using a try-finally has the side effect of enabling the timing report even when errors throw, which didn't happen previously. That could be suppressed if the previous behavior is desired.

master
```
julia> x = rand(1000,1000);

julia> @time x * x;
  0.585421 seconds (2.35 M allocations: 134.031 MiB, 7.19% gc time, 94.24% compilation time)

julia> @time x * x;
  0.015857 seconds (2 allocations: 7.629 MiB)

julia> @time error()
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:42
 [2] top-level scope
   @ ./timing.jl:203 [inlined]
 [3] top-level scope
   @ ./REPL[3]:0

julia> # compilation timing is left enabled due to error
```

This PR
```
julia> x = rand(1000,1000);

julia> @time x * x;
  0.677077 seconds (2.36 M allocations: 134.586 MiB, 20.48% gc time, 90.76% compilation time)

julia> @time x * x;
  0.014838 seconds (2 allocations: 7.629 MiB)

julia> @time error()
  0.004712 seconds (406 allocations: 33.688 KiB, 98.85% compilation time)
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:42
 [2] top-level scope
   @ ./timing.jl:204 [inlined]
 [3] top-level scope
   @ ./REPL[3]:0
```



