### PR TITLE
WIP: Fixing the @sync/@async disappearing exception issue

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -989,7 +989,11 @@ function uv_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
         # wait for the last chunk to complete (or error)
         # assume that any errors would be sticky,
         # (so we don't need to monitor the error status of the intermediate writes)
-        wait()::Cint
+        r = wait()
+        while !(r isa Cint)
+            r = wait()
+        end
+        r
     finally
         # try-finally unwinds the sigatomic level, so need to repeat sigatomic_end
         sigatomic_end()


### PR DESCRIPTION
Fixing #32677.  This is the "disappearing exception" problem in the `@sync`/`@async` structure. The problem occurs because `sync_end` currently waits for the tasks in order, and therefore locks up when an earlier task is waiting for a later task that throws an exception.

This mod changes `sync_end` so that it monitors Tasks/Futures in parallel so that the order no longer matters and this specific lockup condition cannot occur.  Lockups due to poorly-constructed Channels or other resources are not dealt with - this is a just a bandage to help the programmer, making sure exceptions propagate rather than hang.  One step towards a more complete structured concurrency solution.  I recommend unifying the Task / Future interfaces as that happens, btw.

This has been tested against `1.5-release`, `1.6-release`, and `master`, and tests have been added to check the lockup condition for `@async`, `Threads.@spawn`, and `Distributed.@spawnat`.  If you would prefer that this go into Experimental, just let me know I can move and resubmit.