### PR TITLE
improve (restore) performance of fieldname by moving out error paths in separate functions

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -143,15 +143,19 @@ julia> fieldname(Rational, 2)
 ```
 """
 function fieldname(t::DataType, i::Integer)
-    if t.abstract
-        throw(ArgumentError("type does not have definite field names"))
+    throw_not_def_field() = throw(ArgumentError("type does not have definite field names"))
+    function throw_field_access(t, i, n_fields)
+        field_label = n_fields == 1 ? "field" : "fields"
+        throw(ArgumentError("Cannot access field $i since type $t only has $n_fields $field_label."))
     end
+    throw_need_pos_int(i) = throw(ArgumentError("Field numbers must be positive integers. $i is invalid."))
+
+    t.abstract && throw_not_def_field()
     names = _fieldnames(t)
     n_fields = length(names)::Int
-    field_label = n_fields == 1 ? "field" : "fields"
-    i > n_fields && throw(ArgumentError("Cannot access field $i since type $t only has $n_fields $field_label."))
-    i < 1 && throw(ArgumentError("Field numbers must be positive integers. $i is invalid."))
-    return names[i]::Symbol
+    i > n_fields && throw_field_access(t, i, n_fields)
+    i < 1 && throw_need_pos_int(i)
+    return @inbounds names[i]::Symbol
 end
 
 fieldname(t::UnionAll, i::Integer) = fieldname(unwrap_unionall(t), i)


### PR DESCRIPTION
This makes it inline again (maybe new inference change to not infer error paths made it not inline anymore) and also improves performance relative 1.5.

Benchmark:

```jl
julia> using BenchmarkTools

julia> struct A
              a::Int
              b::Float64
              c::String
              end

julia> function ff(::Type{T}, i) where {T}
              return fieldname(T, i)
              end;

julia> @btime ff(A, 2)
``` 

Before (master): `245.346 ns`
Before (1.5.2): `4.747 ns`
PR:  `2.727 ns`

Fixes https://github.com/JuliaLang/julia/issues/38920

cc @quinnj 