### PR TITLE
Improve position of MKL.jl mention in build documentation

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -252,6 +252,8 @@ As a high-performance numerical language, Julia should be linked to a multi-thre
 
 ### Intel MKL
 
+**Note:** If you are building Julia for the sole purpose of incorporating Intel MKL, it may be beneficial to first try [MKL.jl](https://github.com/JuliaComputing/MKL.jl). This package will automatically download MKL and rebuild Julia's system image against it, sidestepping the need to set up a working build environment just to add MKL functionality.
+
 For a 64-bit architecture, the environment should be set up as follows:
 ```sh
 # bash
@@ -262,8 +264,6 @@ Add the following to the `Make.user` file:
     USE_INTEL_MKL = 1
 
 It is highly recommended to start with a fresh clone of the Julia repository.
-
-If you are building Julia for the sole purpose of incorporating Intel MKL, it may be beneficial to first try [MKL.jl](https://github.com/JuliaComputing/MKL.jl). This package will automatically download MKL and rebuild Julia's system image against it, sidestepping the need to set up a working build environment just to add MKL functionality.
 
 ## Source distributions of releases
 

--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -252,7 +252,7 @@ As a high-performance numerical language, Julia should be linked to a multi-thre
 
 ### Intel MKL
 
-**Note:** If you are building Julia for the sole purpose of incorporating Intel MKL, it may be beneficial to first try [MKL.jl](https://github.com/JuliaComputing/MKL.jl). This package will automatically download MKL and rebuild Julia's system image against it, sidestepping the need to set up a working build environment just to add MKL functionality.
+**Note:** If you are building Julia for the sole purpose of incorporating Intel MKL, it may be beneficial to first try [MKL.jl](https://github.com/JuliaComputing/MKL.jl). This package will automatically download MKL and rebuild Julia's system image against it, sidestepping the need to set up a working build environment just to add MKL functionality. MKL.jl replaces OpenBLAS with MKL for dense linear algebra functions called directly from Julia, but SuiteSparse and other C/Fortran libraries will continue to use the BLAS they were linked against at build time. If you want SuiteSparse to use MKL, you will need to build from source.
 
 For a 64-bit architecture, the environment should be set up as follows:
 ```sh


### PR DESCRIPTION
I just moved the block at the beginning of the MKL section and added a **Note:** marker. This way, people will see the note **before** they read how to link against MKL manually.