### PR TITLE
Remove useless nghttp2_jll import from LibGit2_jll

### DIFF
--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -3,7 +3,7 @@
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LibGit2_jll.jl
 
 baremodule LibGit2_jll
-using Base, Libdl, nghttp2_jll, MbedTLS_jll, LibSSH2_jll
+using Base, Libdl, MbedTLS_jll, LibSSH2_jll
 Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
 const PATH_list = String[]


### PR DESCRIPTION
This was a copy-paste error.