### PR TITLE
Add reference to `indent` function

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -621,6 +621,8 @@ julia> Base.unindent("   a\\n   b", 2)
 julia> Base.unindent("\\ta\\n\\tb", 2, tabwidth=8)
 "      a\\n      b"
 ```
+
+See also `indent` (from the `MultilineStrings` package).
 """
 function unindent(str::AbstractString, indent::Int; tabwidth=8)
     indent == 0 && return str

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -622,7 +622,7 @@ julia> Base.unindent("\\ta\\n\\tb", 2, tabwidth=8)
 "      a\\n      b"
 ```
 
-See also `indent` (from the `MultilineStrings` package).
+See also `indent` from the [`MultilineStrings` package](https://github.com/invenia/MultilineStrings.jl).
 """
 function unindent(str::AbstractString, indent::Int; tabwidth=8)
     indent == 0 && return str


### PR DESCRIPTION
Originally the `indent` function was proposed to be included in `Base` to complement `Base.indentation` and `Base.unindent` but as the function wasn't part of the public API or used internally it was decided to add it to a package instead. For those who find the `Base.unindent` they may expect `Base.indent` to also exist. I've added a note to `Base.unindent` so the external `indent` function is discoverable.

https://github.com/JuliaLang/julia/pull/37927#issuecomment-742609128