### PR TITLE
Mention `\Q...\E` in `Regex` docstring and manual

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -23,6 +23,9 @@ with [`match`](@ref).
 `Regex` objects can be created using the [`@r_str`](@ref) string macro. The
 `Regex(pattern[, flags])` constructor is usually used if the `pattern` string needs
 to be interpolated. See the documentation of the string macro for details on flags.
+
+!!! note
+    To escape interpolated variables use `\\Q` and `\\E` (e.g. `Regex("\\\\Q\$x\\\\E")`)
 """
 mutable struct Regex <: AbstractPattern
     pattern::String

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -1002,15 +1002,19 @@ RegexMatch("Day 10")
 julia> name = "Jon"
 "Jon"
 
-julia> regex_name = Regex("[\"( ]$name[\") ]")  # interpolate value of name
+julia> regex_name = Regex("[\"( ]\\Q$name\\E[\") ]")  # interpolate value of name
 r"[\"( ]Jon[\") ]"
 
-julia> match(regex_name," Jon ")
+julia> match(regex_name, " Jon ")
 RegexMatch(" Jon ")
 
-julia> match(regex_name,"[Jon]") === nothing
+julia> match(regex_name, "[Jon]") === nothing
 true
 ```
+
+Note the use of the `\Q...\E` escape sequence. All characters between the `\Q` and the `\E`
+are interpreted as literal characters (after string interpolation). This escape sequence can
+be useful when interpolating, possibly malicious, user input.
 
 ## [Byte Array Literals](@id man-byte-array-literals)
 


### PR DESCRIPTION
Adding this to the documentation as I know when I started with Julia I searched for a "regex escape" function (e.g. in Python [`re.escape`](https://docs.python.org/3/library/re.html#re.escape)). Obviously, I found the `\Q...\E` escape sequence but mentioning it in the manual and `Regex` docstring would have been helpful.