### PR TITLE
win: Set correct folder permissions after folder creation

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -179,6 +179,8 @@ function mkdir(path::AbstractString; mode::Integer = 0o777)
             uv_error("mkdir($(repr(path)); mode=0o$(string(mode,base=8)))", ret)
         end
         ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)
+        # mode is not implemented in mkdir in libuv yet, so do it here
+        Sys.iswindows() && chmod(path, mode)
         return path
     finally
         Libc.free(req)


### PR DESCRIPTION
libuv's `uv_fs_mkdir` does not implement the mode argument on Windows, as a
result the folder mode is never passed on the Windows platform.

This PR:
Forcibly change the folder permissions to agree with the mode passed into `mkdir`.

Fixes: https://github.com/JuliaLang/julia/issues/38411 


TODO: remove when libuv properly sets the `mode` argument in `uv_fs_mkdir`