### PR TITLE
Repair jl_init.

### DIFF
--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -78,6 +78,7 @@ static void * lookup_symbol(const void * lib_handle, const char * symbol_name) {
 #endif
 }
 
+// Find the location of libjulia.
 char lib_dir[PATH_MAX];
 JL_DLLEXPORT const char * jl_get_libdir()
 {
@@ -90,7 +91,7 @@ JL_DLLEXPORT const char * jl_get_libdir()
     wchar_t libjulia_path[PATH_MAX];
     HMODULE libjulia = NULL;
 
-    // Get a handle to libjulia internal
+    // Get a handle to libjulia.
     if (!utf8_to_wchar(LIBJULIA_NAME, libjulia_path, PATH_MAX)) {
         jl_loader_print_stderr3("ERROR: Unable to convert path ", LIBJULIA_NAME, " to wide string!\n");
         exit(1);
@@ -100,7 +101,7 @@ JL_DLLEXPORT const char * jl_get_libdir()
         jl_loader_print_stderr3("ERROR: Unable to load ", LIBJULIA_NAME, "!\n");
         exit(1);
     }
-    if (!GetModuleFileName(libjulia, libjulia_path, PATH_MAX)) {
+    if (!GetModuleFileNameW(libjulia, libjulia_path, PATH_MAX)) {
         jl_loader_print_stderr("ERROR: GetModuleFileName() failed\n");
         exit(1);
     }

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -79,24 +79,28 @@ static void * lookup_symbol(const void * lib_handle, const char * symbol_name) {
 }
 
 char lib_dir[PATH_MAX];
-const char * get_libdir()
+JL_DLLEXPORT const char * jl_get_libdir()
 {
+    // Reuse the path if this is not the first call.
+    if (lib_dir[0] != 0) {
+        return lib_dir;
+    }
 #if defined(_OS_WINDOWS_)
     // On Windows, we use GetModuleFileNameW
     wchar_t libjulia_path[PATH_MAX];
-    HMODULE libjulia_internal = NULL;
+    HMODULE libjulia = NULL;
 
     // Get a handle to libjulia internal
     if (!utf8_to_wchar(LIBJULIA_NAME, libjulia_path, PATH_MAX)) {
         jl_loader_print_stderr3("ERROR: Unable to convert path ", LIBJULIA_NAME, " to wide string!\n");
         exit(1);
     }
-    libjulia_internal = LoadLibraryW(libjulia_path);
-    if (libjulia_internal == NULL) {
+    libjulia = LoadLibraryW(libjulia_path);
+    if (libjulia == NULL) {
         jl_loader_print_stderr3("ERROR: Unable to load ", LIBJULIA_NAME, "!\n");
         exit(1);
     }
-    if (!GetModuleFileName(libjulia_internal, libjulia_path, PATH_MAX)) {
+    if (!GetModuleFileName(libjulia, libjulia_path, PATH_MAX)) {
         jl_loader_print_stderr("ERROR: GetModuleFileName() failed\n");
         exit(1);
     }
@@ -107,8 +111,8 @@ const char * get_libdir()
 #else
     // On all other platforms, use dladdr()
     Dl_info info;
-    if (!dladdr(&get_libdir, &info)) {
-        jl_loader_print_stderr("ERROR: Unable to dladdr(&get_libdir)!\n");
+    if (!dladdr(&jl_get_libdir, &info)) {
+        jl_loader_print_stderr("ERROR: Unable to dladdr(&jl_get_libdir)!\n");
         jl_loader_print_stderr3("Message:", dlerror(), "\n");
         exit(1);
     }
@@ -126,7 +130,7 @@ const char * get_libdir()
 void * libjulia_internal = NULL;
 __attribute__((constructor)) void jl_load_libjulia_internal(void) {
     // Introspect to find our own path
-    const char * lib_dir = get_libdir();
+    const char * lib_dir = jl_get_libdir();
 
     // Pre-load libraries that libjulia-internal needs.
     int deps_len = strlen(dep_libs);

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -79,21 +79,9 @@ JL_DLLEXPORT void jl_init(void)
 {
     char *libbindir = NULL;
 #ifdef _OS_WINDOWS_
-    void *hdl = (void*)jl_load_dynamic_library(NULL, JL_RTLD_DEFAULT, 0);
-    if (hdl) {
-        char *to_free = (char*)jl_pathname_for_handle(hdl);
-        if (to_free) {
-            libbindir = strdup(dirname(to_free));
-            free(to_free);
-        }
-    }
+    libbindir = strdup(jl_get_libdir());
 #else
-    Dl_info dlinfo;
-    if (dladdr((void*)jl_init, &dlinfo) != 0 && dlinfo.dli_fname) {
-        char *to_free = strdup(dlinfo.dli_fname);
-        (void)asprintf(&libbindir, "%s" PATHSEPSTRING ".." PATHSEPSTRING "%s", dirname(to_free), "bin");
-        free(to_free);
-    }
+    (void)asprintf(&libbindir, "%s" PATHSEPSTRING ".." PATHSEPSTRING "%s", jl_get_libdir(), "bin");
 #endif
     if (!libbindir) {
         printf("jl_init unable to find libjulia!\n");

--- a/src/julia.h
+++ b/src/julia.h
@@ -1587,6 +1587,7 @@ typedef enum {
 #define jl_init jl_init__threading
 #define jl_init_with_image jl_init_with_image__threading
 
+JL_DLLEXPORT const char *jl_get_libdir(void);
 JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
 JL_DLLEXPORT void jl_init(void);
 JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,


### PR DESCRIPTION
Cc: @staticfloat 

As noted in https://github.com/JuliaLang/julia/pull/38160#issuecomment-744733181, `jl_init` is no longer correctly finding the location of `libjulia`. This PR attempts to fix that by exporting a function that lives in `libjulia` and can reliably introspect itself to find the `libjulia` location, then uses that from `jl_init`.
