### PR TITLE
Support passing `auto` as the value to the `JULIA_NUM_THREADS` environment variable

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -392,12 +392,17 @@ void jl_init_threading(void)
 
     // how many threads available, usable
     jl_n_threads = JULIA_NUM_THREADS;
-    if (jl_options.nthreads < 0) // --threads=auto
+    if (jl_options.nthreads < 0) { // --threads=auto
         jl_n_threads = jl_cpu_threads();
-    else if (jl_options.nthreads > 0) // --threads=N
+    } else if (jl_options.nthreads > 0) { // --threads=N
         jl_n_threads = jl_options.nthreads;
-    else if ((cp = getenv(NUM_THREADS_NAME)))
-        jl_n_threads = (uint64_t)strtol(cp, NULL, 10);
+    } else if ((cp = getenv(NUM_THREADS_NAME))) {
+        if (strcmp(cp, "auto")) {
+            jl_n_threads = (uint64_t)strtol(cp, NULL, 10); // ENV[NUM_THREADS_NAME] == "N"
+        } else {
+            jl_n_threads = jl_cpu_threads(); // ENV[NUM_THREADS_NAME] == "auto"
+        }
+    }
     if (jl_n_threads <= 0)
         jl_n_threads = 1;
 #ifndef __clang_analyzer__


### PR DESCRIPTION
With this pull request, if the `JULIA_NUM_THREADS` environment variable is set to `auto`, then the number of threads is set automatically to the number of CPU threads. This is similar to the behavior of the `--threads=auto` command-line flag.

Example usage:
```
$ export JULIA_NUM_THREADS="auto"
$ ./julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.7.0-DEV.131 (2020-12-20)
 _/ |\__'_|_|_|\__'_|  |  dpa/julia-num-threads-env-auto/96bc22f8c2 (fork: 1 commits, 0 days)
|__/                   |

julia> Threads.nthreads()
4

julia> ENV["JULIA_NUM_THREADS"]
"auto"
```