### PR TITLE
Cherry-Picked: fix erroneous code path within `show_sym` (#38830)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1434,12 +1434,12 @@ end
 # Print `sym` as it would appear as an identifier name in code
 # * Print valid identifiers & operators literally; also macros names if allow_macroname=true
 # * Escape invalid identifiers with var"" syntax
-function show_sym(io::IO, sym; allow_macroname=false)
+function show_sym(io::IO, sym::Symbol; allow_macroname=false)
     if is_valid_identifier(sym)
         print(io, sym)
     elseif allow_macroname && (sym_str = string(sym); startswith(sym_str, '@'))
         print(io, '@')
-        show_sym(io, sym_str[2:end])
+        show_sym(io, Symbol(sym_str[2:end]))
     else
         print(io, "var", repr(string(sym)))
     end


### PR DESCRIPTION
fix erroneous code path within `show_sym`

currently, `show_sym` can recur into `show(::IO, String)`, but it's a
bit "erroneous" since `is_syntactic_operator(::String)` is not defined.

---

The original PR ( #38830 ) is merged into master but not into backports-release-1.6.
The following will cause a similar error as reported in the original PR:

```julia
julia> :(@..{1,2,3})
:(#= REPL[XX]:1 =# @Error showing value of type Expr:
ERROR: MethodError: no method matching is_syntactic_operator(::String)
Closest candidates are:
  is_syntactic_operator(::Symbol) at show.jl:1221
Stacktrace:
  [1] is_valid_identifier
    @ ./show.jl:1399 [inlined]
  [2] show_sym(io::IOContext{Base.TTY}, sym::String; allow_macroname::Bool)
    @ Base ./show.jl:1438
  [3] show_sym
    @ ./show.jl:1438 [inlined]
  [4] show_sym(io::IOContext{Base.TTY}, sym::Symbol; allow_macroname::Bool)
    @ Base ./show.jl:1442
  : <snipped>
```