### PR TITLE
Implement basic pager using TerminalMenus

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/Pager.jl
+++ b/stdlib/REPL/src/TerminalMenus/Pager.jl
@@ -1,0 +1,45 @@
+mutable struct Pager{C} <: _ConfiguredMenu{C}
+    lines::Array{String,1}
+    pagesize::Int
+    pageoffset::Int
+    selected::Nothing
+    config::C
+end
+
+function Pager(text::AbstractString; pagesize::Int=10, kwargs...)
+    lines = readlines(IOBuffer(text))
+    return Pager(lines, pagesize, 0, nothing, Config(; kwargs...))
+end
+
+function header(p::Pager)
+    total = length(p.lines)
+    current = min(p.pageoffset + p.pagesize, total)
+    percent = round(Int, (current / total) * 100)
+    return "($(lpad(current, ndigits(total))) / $total) $(lpad(percent, 3))%"
+end
+
+options(p::Pager) = p.lines
+
+cancel(::Pager) = nothing
+
+pick(::Pager, ::Int) = true
+
+function writeline(buf::IOBuffer, pager::Pager{Config}, idx::Int, iscursor::Bool)
+    print(buf, pager.lines[idx])
+end
+
+function writeLine(buf::IOBuffer, pager::Pager{<:Dict}, idx::Int, cursor::Bool)
+    cursor ? print(buf, pager.config[:cursor] ," ") : print(buf, "  ")
+    print(buf, pager.lines[idx])
+end
+
+function pager(terminal, object)
+    lines, columns = displaysize(terminal)
+    columns -= 3
+    buffer = IOBuffer()
+    ctx = IOContext(buffer, :color => REPL.Terminals.hascolor(terminal), :displaysize => (lines, columns))
+    show(ctx, "text/plain", object)
+    pager = Pager(String(take!(buffer)); pagesize = div(lines, 2))
+    return request(terminal, pager)
+end
+pager(object) = pager(terminal, object)

--- a/stdlib/REPL/src/TerminalMenus/Pager.jl
+++ b/stdlib/REPL/src/TerminalMenus/Pager.jl
@@ -1,5 +1,5 @@
 mutable struct Pager{C} <: _ConfiguredMenu{C}
-    lines::Array{String,1}
+    lines::Vector{String}
     pagesize::Int
     pageoffset::Int
     selected::Nothing
@@ -28,13 +28,8 @@ function writeline(buf::IOBuffer, pager::Pager{Config}, idx::Int, iscursor::Bool
     print(buf, pager.lines[idx])
 end
 
-function writeLine(buf::IOBuffer, pager::Pager{<:Dict}, idx::Int, cursor::Bool)
-    cursor ? print(buf, pager.config[:cursor] ," ") : print(buf, "  ")
-    print(buf, pager.lines[idx])
-end
-
 function pager(terminal, object)
-    lines, columns = displaysize(terminal)
+    lines, columns = displaysize(terminal)::Tuple{Int,Int}
     columns -= 3
     buffer = IOBuffer()
     ctx = IOContext(buffer, :color => REPL.Terminals.hascolor(terminal), :displaysize => (lines, columns))

--- a/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
+++ b/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
@@ -17,10 +17,12 @@ include("config.jl")
 include("AbstractMenu.jl")
 include("RadioMenu.jl")
 include("MultiSelectMenu.jl")
+include("Pager.jl")
 
 export
     RadioMenu,
     MultiSelectMenu,
+    Pager,
     request
 
 # TODO: remove in Julia 2.0

--- a/stdlib/REPL/test/TerminalMenus/pager.jl
+++ b/stdlib/REPL/test/TerminalMenus/pager.jl
@@ -1,0 +1,39 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+content =
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+    incididunt ut labore et dolore magna aliqua. Arcu non sodales neque sodales.
+    Placerat orci nulla pellentesque dignissim enim sit amet venenatis. Mauris
+    augue neque gravida in fermentum et sollicitudin. Amet venenatis urna cursus
+    eget. Enim praesent elementum facilisis leo vel fringilla est. Vitae sapien
+    pellentesque habitant morbi tristique. Ornare lectus sit amet est placerat in.
+    Leo urna molestie at elementum eu facilisis. Aliquam vestibulum morbi blandit
+    cursus risus at ultrices. Id aliquet lectus proin nibh. Facilisi etiam
+    dignissim diam quis enim lobortis scelerisque fermentum. Pretium lectus quam id
+    leo in vitae turpis massa sed. Elementum facilisis leo vel fringilla est.
+    Vulputate ut pharetra sit amet aliquam. Quis enim lobortis scelerisque
+    fermentum dui faucibus in ornare. Cursus turpis massa tincidunt dui ut.
+
+    A arcu cursus vitae congue mauris rhoncus. Tellus rutrum tellus pellentesque
+    eu. Fringilla phasellus faucibus scelerisque eleifend donec pretium. Aliquam
+    etiam erat velit scelerisque. Volutpat lacus laoreet non curabitur gravida.
+    Felis imperdiet proin fermentum leo vel orci. Viverra tellus in hac habitasse
+    platea dictumst vestibulum rhoncus est. Ullamcorper dignissim cras tincidunt
+    lobortis feugiat vivamus. Sit amet luctus venenatis lectus. Odio facilisis
+    mauris sit amet massa vitae tortor condimentum. Purus sit amet volutpat
+    consequat mauris nunc congue. Enim nunc faucibus a pellentesque sit amet. Purus
+    non enim praesent elementum facilisis leo vel fringilla est.
+    """ |> strip
+
+let p = Pager(content)
+    @test p.pagesize == 10
+    @test length(p.lines) == 22
+    @test startswith(content, p.lines[1])
+    @test endswith(content, p.lines[end])
+    buffer = IOBuffer()
+    TerminalMenus.printmenu(buffer, p, 1)
+    str = String(take!(buffer))
+    @test contains(str, "(10 / 22)  45%")
+    @test endswith(str, "leo in vitae turpis massa sed. Elementum facilisis leo vel fringilla est.")
+end

--- a/stdlib/REPL/test/TerminalMenus/runtests.jl
+++ b/stdlib/REPL/test/TerminalMenus/runtests.jl
@@ -25,6 +25,7 @@ include("radio_menu.jl")
 include("multiselect_menu.jl")
 include("dynamic_menu.jl")
 include("multiselect_with_skip_menu.jl")
+include("pager.jl")
 
 # Legacy tests
 include("legacytests/old_radio_menu.jl")


### PR DESCRIPTION
This is just a quick initial draft of a terminal pager built with `TerminalMenus` that can be used to display objects that might take up more than a screen's worth of space vertically. See linked demo video for an example usage. If there's interest in having something like this in base then I'll put some docs, tests, etc in.

[![asciicast](https://asciinema.org/a/380359.svg)](https://asciinema.org/a/380359)

Somewhat related: https://github.com/JuliaLang/julia/issues/6921, https://github.com/JuliaLang/julia/issues/36460, https://github.com/JuliaLang/julia/pull/34226