### PR TITLE
fix IR showing not to show TypedSlot type twice

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -67,7 +67,7 @@ function print_stmt(io::IO, idx::Int, @nospecialize(stmt), used::BitSet, maxleng
     elseif stmt isa TypedSlot
         # call `show` with the type set to Any so it will not be shown, since
         # we will show the type ourselves.
-        show_unquoted(io, TypedSlot(stmt.id, Any), indent, show_type ? prec_decl : 0)
+        show_unquoted(io, SlotNumber(stmt.id), indent, show_type ? prec_decl : 0)
     # everything else in the IR, defer to the generic AST printer
     else
         show_unquoted(io, stmt, indent, show_type ? prec_decl : 0)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -64,6 +64,10 @@ function print_stmt(io::IO, idx::Int, @nospecialize(stmt), used::BitSet, maxleng
         show_unquoted_phinode(io, stmt, indent, "#")
     elseif stmt isa GotoIfNot
         show_unquoted_gotoifnot(io, stmt, indent, "#")
+    elseif stmt isa TypedSlot
+        # call `show` with the type set to Any so it will not be shown, since
+        # we will show the type ourselves.
+        show_unquoted(io, TypedSlot(stmt.id, Any), indent, show_type ? prec_decl : 0)
     # everything else in the IR, defer to the generic AST printer
     else
         show_unquoted(io, stmt, indent, show_type ? prec_decl : 0)


### PR DESCRIPTION
Before:
```
2 ┄ %6  = @_3::Union{Tuple{String, Int64}, Tuple{Bypass{String}, Int64}}::Union{Tuple{String, Int64}, Tuple{Bypass{String}, Int64}}
```
after:
```
2 ┄ %6  = @_3::Union{Tuple{String, Int64}, Tuple{Bypass{String}, Int64}}
```

Of course, this only comes up when showing unoptimized but inferred IR.