### PR TITLE
use parent type in similar(::ReinterpretArray)

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -159,6 +159,8 @@ function strides(a::ReinterpretArray)
 end
 strides(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}) = size_to_strides(1, size(a)...)
 
+similar(a::ReinterpretArray, T::Type, d::Dims) = similar(a.parent, T, d)
+
 function check_readable(a::ReinterpretArray{T, N, S} where N) where {T,S}
     # See comment in check_writable
     if !a.readable && !array_subpadding(T, S)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2878,3 +2878,15 @@ end
     b = [2 for i in 1:5]
     @test_throws DimensionMismatch hcat(a, b)
 end
+
+@testset "similar(::ReshapedArray)" begin
+    a = reshape(TSlow(rand(Float64, 4, 4)), 2, :)
+
+    as = similar(a)
+    @test as isa TSlow{Float64,2}
+    @test size(as) == (2, 8)
+
+    as = similar(a, Int, (3, 5, 1))
+    @test as isa TSlow{Int,3}
+    @test size(as) == (3, 5, 1)
+end

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -350,3 +350,21 @@ ars = reinterpret(reshape, Int, a)
 a = [(k,k+1,k+2) for k = 1:3:4000]
 ars = reinterpret(reshape, Int, a)
 @test sum(ars) == 8010003
+
+@testset "similar(::ReinterpretArray)" begin
+    a = reinterpret(NTuple{2,Float64}, TSlow(rand(Float64, 4, 4)))
+
+    as = similar(a)
+    @test as isa TSlow{NTuple{2,Float64},2}
+    @test size(as) == (2, 4)
+
+    as = similar(a, Int, (3, 5, 1))
+    @test as isa TSlow{Int,3}
+    @test size(as) == (3, 5, 1)
+
+    a = reinterpret(reshape, NTuple{4,Float64}, TSlow(rand(Float64, 4, 4)))
+
+    as = similar(a)
+    @test as isa TSlow{NTuple{4,Float64},1}
+    @test size(as) == (4,)
+end


### PR DESCRIPTION
We already do this for `SubArray`, `PermutedDimsArray`, and `ReshapedArray`, so I think this makes sense here. This also adds tests for `similar(::ReshapedArray)`, since I didn't notice that was actually defined before.

ref https://github.com/JuliaGPU/CUDA.jl/issues/602