### PR TITLE
backport #38933: Carry MBedTLS patch that works around CMake 3.18.2 bug.

### DIFF
--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -31,6 +31,17 @@ $(SRCCACHE)/$(MBEDTLS_SRC)/source-extracted: $(SRCCACHE)/$(MBEDTLS_SRC).tar.gz
 checksum-mbedtls: $(SRCCACHE)/$(MBEDTLS_SRC).tar.gz
 	$(JLCHECKSUM) $<
 
+$(SRCCACHE)/$(MBEDTLS_SRC)/mbedtls-cmake-findpy.patch-applied: $(SRCCACHE)/$(MBEDTLS_SRC)/source-extracted
+	# Apply workaround for CMake 3.18.2 bug (https://github.com/ARMmbed/mbedtls/pull/3691).
+	# This patch merged upstream shortly after MBedTLS's 2.25.0 minor release, so chances
+	# are it will be included at least in their next minor release (2.26.0?).
+	cd $(SRCCACHE)/$(MBEDTLS_SRC) && \
+		patch -p1 -f < $(SRCDIR)/patches/mbedtls-cmake-findpy.patch
+	echo 1 > @$
+
+$(BUILDDIR)/$(MBEDTLS_SRC)/build-configured: \
+	$(SRCCACHE)/$(MBEDTLS_SRC)/mbedtls-cmake-findpy.patch-applied
+
 $(BUILDDIR)/$(MBEDTLS_SRC)/build-configured: $(SRCCACHE)/$(MBEDTLS_SRC)/source-extracted
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \

--- a/deps/patches/mbedtls-cmake-findpy.patch
+++ b/deps/patches/mbedtls-cmake-findpy.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8833246..2ed55ed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,6 +17,18 @@
+ #
+
+ cmake_minimum_required(VERSION 2.6)
++
++# https://cmake.org/cmake/help/latest/policy/CMP0011.html
++# Setting this policy is required in CMake >= 3.18.0, otherwise a warning is generated. The OLD
++# policy setting is deprecated, and will be removed in future versions.
++cmake_policy(SET CMP0011 NEW)
++# https://cmake.org/cmake/help/latest/policy/CMP0012.html
++# Setting the CMP0012 policy to NEW is required for FindPython3 to work with CMake 3.18.2
++# (there is a bug in this particular version), otherwise, setting the CMP0012 policy is required
++# for CMake versions >= 3.18.3 otherwise a deprecated warning is generated. The OLD policy setting
++# is deprecated and will be removed in future versions.
++cmake_policy(SET CMP0012 NEW)
++
+ if(TEST_CPP)
+  project("mbed TLS" C CXX)
+ else()


### PR DESCRIPTION
Title says it all :). Best!