### PR TITLE
codegen: use new freeze intrinsics to avoid poison UB

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -542,6 +542,8 @@ static jl_cgval_t generic_cast(
 #endif
     }
     Value *ans = ctx.builder.CreateCast(Op, from, to);
+    if (f == fptosi || f == fptoui)
+        ans = ctx.builder.CreateFreeze(ans);
     return mark_julia_type(ctx, ans, false, jlto);
 }
 


### PR DESCRIPTION
LLVM would likely be required to insert this anyways to make hoisting
legal (converting branches to and/or), so might as well add it
ourselves, so that users can legally write that code directly.

Replaces https://github.com/JuliaLang/julia/pull/38735

```llvm
julia> f() = Ref(Inf)[] < typemax(Clong)
f (generic function with 1 method)

julia> @code_llvm optimize=false f()
@ REPL[1]:1 within `f'
define i8 @julia_f_186() {
top:
  %0 = call {}*** @julia.ptls_states()
  %1 = bitcast {}*** %0 to {}**
  %2 = getelementptr inbounds {}*, {}** %1, i64 4
  %3 = bitcast {}** %2 to i64**
  %4 = load i64*, i64** %3, align 8
; ┌ @ float.jl:416 within `<'
; │┌ @ float.jl:239 within `unsafe_trunc'
    %5 = freeze i64 poison
; │└
; │ @ float.jl:416 within `<' @ int.jl:83
   %6 = icmp slt i64 %5, 9223372036854775807
; │ @ float.jl:416 within `<'
; │┌ @ bool.jl:36 within `&'
    %7 = zext i1 %6 to i8
    %8 = and i8 0, %7
    %9 = trunc i8 %8 to i1
; │└
; │┌ @ bool.jl:37 within `|'
    %10 = zext i1 %9 to i8
    %11 = or i8 0, %10
    %12 = trunc i8 %11 to i1
; └└
  %13 = zext i1 %12 to i8
  ret i8 %13
}

julia> @code_llvm  f()
;  @ REPL[1]:1 within `f'
define i8 @julia_f_221() {
top:
  ret i8 0
}
```

(otherwise, the llvm::IRBuilder\<\> constant folds this to `ret i8 poison`)