### PR TITLE
Avoid eltype widening in StepRangeLen constructor

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -364,7 +364,7 @@ struct StepRangeLen{T,R,S} <: AbstractRange{T}
 end
 
 StepRangeLen(ref::R, step::S, len::Integer, offset::Integer = 1) where {R,S} =
-    StepRangeLen{typeof(ref+0*step),R,S}(ref, step, len, offset)
+    StepRangeLen{typeof(ref+zero(step)),R,S}(ref, step, len, offset)
 StepRangeLen{T}(ref::R, step::S, len::Integer, offset::Integer = 1) where {T,R,S} =
     StepRangeLen{T,R,S}(ref, step, len, offset)
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1721,4 +1721,12 @@ end
     @test isempty(range(typemin(Int), step=-1//1, length=0))
     @test eltype(range(typemin(Int), step=-1//1, length=0)) === Rational{Int}
     @test typeof(step(range(typemin(Int), step=-1//1, length=0))) === Rational{Int}
+
+    @test StepRangeLen(Int8(1), Int8(2), 3) == Int8[1, 3, 5]
+    @test eltype(StepRangeLen(Int8(1), Int8(2), 3)) === Int8
+    @test typeof(step(StepRangeLen(Int8(1), Int8(2), 3))) === Int8
+
+    @test StepRangeLen(Int8(1), Int8(2), 3, 2) == Int8[-1, 1, 3]
+    @test eltype(StepRangeLen(Int8(1), Int8(2), 3, 2)) === Int8
+    @test typeof(step(StepRangeLen(Int8(1), Int8(2), 3, 2))) === Int8
 end


### PR DESCRIPTION
Before:
```julia
julia> eltype(StepRangeLen(Int8(1), Int8(2), 3))
Int64
```

After:
```julia
julia> eltype(StepRangeLen(Int8(1), Int8(2), 3))
Int8
```