### PR TITLE
Docs: Reference functions instead of methods

### DIFF
--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -198,7 +198,7 @@ Base.get
 Base.get!
 Base.getkey
 Base.delete!
-Base.pop!
+Base.pop!(::Any, ::Any, ::Any)
 Base.keys
 Base.values
 Base.pairs

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -93,9 +93,9 @@ Base.indexin
 Base.unique
 Base.unique!
 Base.allunique
-Base.reduce(::Any, ::Any)
-Base.foldl(::Any, ::Any)
-Base.foldr(::Any, ::Any)
+Base.reduce
+Base.foldl
+Base.foldr
 Base.maximum
 Base.maximum!
 Base.minimum
@@ -111,32 +111,26 @@ Base.sum
 Base.sum!
 Base.prod
 Base.prod!
-Base.any(::Any)
-Base.any(::AbstractArray, ::Any)
+Base.any
 Base.any!
-Base.all(::Any)
-Base.all(::AbstractArray, ::Any)
+Base.all
 Base.all!
 Base.count
-Base.any(::Any, ::Any)
-Base.all(::Any, ::Any)
 Base.foreach
 Base.map
 Base.map!
-Base.mapreduce(::Any, ::Any, ::Any)
-Base.mapfoldl(::Any, ::Any, ::Any)
-Base.mapfoldr(::Any, ::Any, ::Any)
+Base.mapreduce
+Base.mapfoldl
+Base.mapfoldr
 Base.first
 Base.last
 Base.front
 Base.tail
 Base.step
-Base.collect(::Any)
-Base.collect(::Type, ::Any)
+Base.collect
 Base.filter
 Base.filter!
-Base.replace(::Any, ::Pair...)
-Base.replace(::Base.Callable, ::Any)
+Base.replace
 Base.replace!
 Base.rest
 ```
@@ -200,13 +194,11 @@ Base.IdDict
 Base.WeakKeyDict
 Base.ImmutableDict
 Base.haskey
-Base.get(::Any, ::Any, ::Any)
 Base.get
-Base.get!(::Any, ::Any, ::Any)
-Base.get!(::Function, ::Any, ::Any)
+Base.get!
 Base.getkey
 Base.delete!
-Base.pop!(::Any, ::Any, ::Any)
+Base.pop!
 Base.keys
 Base.values
 Base.pairs

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -93,9 +93,9 @@ Base.indexin
 Base.unique
 Base.unique!
 Base.allunique
-Base.reduce
-Base.foldl
-Base.foldr
+Base.reduce(::Any, ::Any)
+Base.foldl(::Any, ::Any)
+Base.foldr(::Any, ::Any)
 Base.maximum
 Base.maximum!
 Base.minimum
@@ -111,26 +111,32 @@ Base.sum
 Base.sum!
 Base.prod
 Base.prod!
-Base.any
+Base.any(::Any)
+Base.any(::AbstractArray, ::Any)
 Base.any!
-Base.all
+Base.all(::Any)
+Base.all(::AbstractArray, ::Any)
 Base.all!
 Base.count
+Base.any(::Any, ::Any)
+Base.all(::Any, ::Any)
 Base.foreach
 Base.map
 Base.map!
-Base.mapreduce
-Base.mapfoldl
-Base.mapfoldr
+Base.mapreduce(::Any, ::Any, ::Any)
+Base.mapfoldl(::Any, ::Any, ::Any)
+Base.mapfoldr(::Any, ::Any, ::Any)
 Base.first
 Base.last
 Base.front
 Base.tail
 Base.step
-Base.collect
+Base.collect(::Any)
+Base.collect(::Type, ::Any)
 Base.filter
 Base.filter!
-Base.replace
+Base.replace(::Any, ::Pair...)
+Base.replace(::Base.Callable, ::Any)
 Base.replace!
 Base.rest
 ```


### PR DESCRIPTION
By referencing methods sometimes and not just functions, there was some duplication and confusion. For instance, we had `get(::Any, ::Any, ::Any)` method and also a `get` function, the latter of which duplicated the documentation for the former.

~~Is there an unseen benefit to referencing just the function at times?~~ EDIT: Documenter errors if there are exact duplicates, and sometimes it makes sense to split the functions by section.

~~If this PR is acceptable, I can go through the other pages to do the same.~~