### PR TITLE
Use occursin instead of findfirst(...) === nothing

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -652,7 +652,7 @@ doc_completions(name::Symbol) = doc_completions(string(name))
 # Searching and apropos
 
 # Docsearch simply returns true or false if an object contains the given needle
-docsearch(haystack::AbstractString, needle) = findfirst(needle, haystack) !== nothing
+docsearch(haystack::AbstractString, needle) = occursin(needle, haystack)
 docsearch(haystack::Symbol, needle) = docsearch(string(haystack), needle)
 docsearch(::Nothing, needle) = false
 function docsearch(haystack::Array, needle)


### PR DESCRIPTION
Maybe I'm mistaken, but I couldn't find any reason why using `findfirst` is better at this spot than `occursin`. Both methods end up quite quickly at something with `firstindex(s)`.