### PR TITLE
fixed a bug in the build system

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1556,8 +1556,10 @@ endif
 LIBGCC_BUILD_DEPLIB := $(call dep_lib_path,$(build_libdir),$(build_shlibdir)/$(LIBGCC_NAME))
 LIBGCC_INSTALL_DEPLIB := $(call dep_lib_path,$(libdir),$(private_shlibdir)/$(LIBGCC_NAME))
 
-# USE_SYSTEM_LIBM causes it to get symlinked into build_private_shlibdir
+# USE_SYSTEM_LIBM and USE_SYSTEM_OPENLIBM causes it to get symlinked into build_private_shlibdir
 ifeq ($(USE_SYSTEM_LIBM),1)
+LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_libdir),$(build_private_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
+else ifeq ($(USE_SYSTEM_OPENLIBM),1)
 LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_libdir),$(build_private_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))
 else
 LIBM_BUILD_DEPLIB := $(call dep_lib_path,$(build_libdir),$(build_shlibdir)/$(LIBMNAME).$(SHLIB_EXT))


### PR DESCRIPTION
Without this patch, the build of julia fails on my machine:


```
$ /home/volker/cloned/julia-git/src/julia/usr/bin/julia 
ERROR: Unable to load dependent library /home/volker/cloned/julia-git/src/julia/usr/bin/../lib/libopenlibm.so
Message:/home/volker/cloned/julia-git/src/julia/usr/bin/../lib/libopenlibm.so: cannot open shared object file: No such file or directory
```

Slightly OT: Reading and debugging Gnu Make is not nice.