### PR TITLE
Remove restriction on documenting empty baremodules

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -406,8 +406,7 @@ function moduledoc(__source__, __module__, meta, def, def′::Expr)
         def = unblock(def)
         block = def.args[3].args
         if !def.args[1]
-            isempty(block) && error("empty baremodules are not documentable.")
-            insert!(block, 2, :(import Base: @doc))
+            pushfirst!(block, :(import Base: @doc))
         end
         push!(block, docex)
         esc(Expr(:toplevel, def))

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -496,7 +496,7 @@ end
 
 Documenting a `baremodule` by placing a docstring above the expression automatically imports
 `@doc` into the module. These imports must be done manually when the module expression is not
-documented. Empty `baremodule`s cannot be documented.
+documented.
 
 ### Global Variables
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1236,3 +1236,7 @@ Test.collect_test_logs() do                          # suppress printing of any 
     eval(quote "Second docstring" Module29432 end)   # requires toplevel
 end
 @test docstrings_equal(@doc(Module29432), doc"Second docstring")
+
+# Issue #13109
+eval(Expr(:block, Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), nothing, "...", Expr(:module, false, :MBareModuleEmpty, Expr(:block)))))
+@test docstrings_equal(@doc(MBareModuleEmpty), doc"...")


### PR DESCRIPTION
Replaces and closes #13109. The underlying bug here appears to have
been fixed and the restriction here was never triggered since lowering
now always inserts LineNumberNodes, but we might as well remove the
restriction since the bug is fixed.