### PR TITLE
better debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ endif
 endif
 
 ifneq ($(LOADER_BUILD_DEP_LIBS),$(LOADER_INSTALL_DEP_LIBS))
-	# Next, overwrite relative path to libjulia-internal in our loader if $(LOADER_BUILD_DEP_LIBS) != $(LOADER_INSTALL_DEP_LIBS)
+	# Next, overwrite relative path to libjulia-internal in our loader if $$(LOADER_BUILD_DEP_LIBS) != $$(LOADER_INSTALL_DEP_LIBS)
 	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_BUILD_DEP_LIBS)$$,$(LOADER_INSTALL_DEP_LIBS))
 
 ifeq ($(BUNDLE_DEBUG_LIBS),1)


### PR DESCRIPTION
I think

`# Next, overwrite relative path to libjulia-internal in our loader if $(LOADER_BUILD_DEP_LIBS) != $(LOADER_INSTALL_DEP_LIBS)`

is more readible than

`# Next, overwrite relative path to libjulia-internal in our loader if \$("/home/volker/.pyenv/shims/python" /home/volker/cloned/julia-git/src/julia/contrib/relative_path.py /home/volker/cloned/julia-git/src/julia/usr/lib /home/volker/cloned/julia-git/src/julia/usr/lib/libgcc_s.so.1):$("/home/volker/.pyenv/shims/python" /home/volker/cloned/julia-git/src/julia/contrib/relative_path.py /home/volker/cloned/julia-git/src/julia/usr/lib /home/volker/cloned/julia-git/src/julia/usr/lib/julia/libopenlibm.so):$("/home/volker/.pyenv/shims/python" /home/volker/cloned/julia-git/src/julia/contrib/relative_path.py /home/volker/cloned/julia-git/src/julia/usr/lib /home/volker/cloned/julia-git/src/julia/usr/lib/libjulia-internal.so.1.7) != \$("/home/volker/.pyenv/shims/python" /home/volker/cloned/julia-git/src/julia/contrib/relative_path.py /usr/lib /usr/lib/julia/libgcc_s.so.1):$("/home/volker/.pyenv/shims/python" /home/volker/cloned/julia-git/src/julia/contrib/relative_path.py /usr/lib /usr/lib/julia/libopenlibm.so):$("/home/volker/.pyenv/shims/python" /home/volker/cloned/julia-git/src/julia/contrib/relative_path.py /usr/lib /usr/lib/julia/libjulia-internal.so.1.7)`