### PR TITLE
add missing newline to UnionAll Vararg warning

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -433,7 +433,7 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body)
         if (jl_options.depwarn) {
             if (jl_options.depwarn == JL_OPTIONS_DEPWARN_ERROR)
                 jl_error("Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).");
-            jl_printf(JL_STDERR, "WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).");
+            jl_printf(JL_STDERR, "WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).\n");
         }
         jl_vararg_t *vm = (jl_vararg_t*)body;
         int T_has_tv = vm->T && jl_has_typevar(vm->T, v);


### PR DESCRIPTION
added in #38136. Currently multiple warnings are printed like this, which is probably not intended:
```
~ >>> julia-latest --depwarn=yes                                                                              ✓ 500
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.7.0-DEV.168 (2020-12-25)
 _/ |\__'_|_|_|\__'_|  |  Commit dedf290c99 (1 day old master)
|__/                   |

julia> Vararg{<:Any}; Vararg{<:Any}
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).Vararg{Any}
```