### PR TITLE
Revert "win: Set correct folder permissions after folder creation (#38942)"

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -179,8 +179,6 @@ function mkdir(path::AbstractString; mode::Integer = 0o777)
             uv_error("mkdir($(repr(path)); mode=0o$(string(mode,base=8)))", ret)
         end
         ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)
-        # mode is not implemented in mkdir in libuv yet, so do it here
-        Sys.iswindows() && chmod(path, mode)
         return path
     finally
         Libc.free(req)


### PR DESCRIPTION
The crux of the issue is related to changes to the ACL permissions in chmod