### PR TITLE
specialize on mapfoldl(::Type, ...)

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -88,6 +88,8 @@ Create a mapping reducing function `rf′(acc, x) = rf(acc, f(x))`.
 struct MappingRF{F, T}
     f::F
     rf::T
+    MappingRF(f::F, rf::T) where {F,T} = new{F,T}(f, rf)
+    MappingRF(::Type{f}, rf::T) where {f,T} = new{Type{f},T}(f, rf)
 end
 
 @inline (op::MappingRF)(acc, x) = op.rf(acc, op.f(x))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -640,3 +640,6 @@ x = [j+7 for j in i]
         Iterators.flatten((1:2, 3:4)),
     ) == (1, 4)
 end
+
+# make sure we specialize on mapfoldl(::Type, ...)
+@test @inferred(mapfoldl(Int, +, [1, 2, 3]; init=0)) === 6


### PR DESCRIPTION
Before:
```julia
julia> using BenchmarkTools

julia> b = rand(Bool, 10000);

julia> @btime mapfoldl(Int, +, b; init=0)
  1.136 ms (9025 allocations: 141.02 KiB)
5057
```

After:
```julia
julia> @btime mapfoldl(Int, +, b; init=0)
  1.094 μs (1 allocation: 16 bytes)
5057
```