### PR TITLE
Fix insert_node_here! if called at the end of the IR

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -708,7 +708,9 @@ end
 function insert_node_here!(compact::IncrementalCompact, @nospecialize(val), @nospecialize(typ), ltable_idx::Int32, reverse_affinity::Bool=false)
     refinish = false
     result_idx = compact.result_idx
-    if result_idx == first(compact.result_bbs[compact.active_result_bb].stmts) && reverse_affinity
+    if reverse_affinity &&
+            ((compact.active_result_bb == length(compact.result_bbs) + 1) ||
+             result_idx == first(compact.result_bbs[compact.active_result_bb].stmts))
         compact.active_result_bb -= 1
         refinish = true
     end


### PR DESCRIPTION
This method was throwing an error when called after the compaction
had processes the last instruction in the IR (with reverse affinity).
This currently can't happen, because we never use this method after compacting
a terminal instruction (inlining uses it to split BBs), but can after
the new code in #37849, so fix the bug now. Forward port from #37849.