### PR TITLE
Fix missing escape in Makefile comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ endif
 		$(call stringreplace,$${DEBUG_TARGET},sys-debug.$(SHLIB_EXT)$$,$(private_libdir_rel)/sys-debug.$(SHLIB_EXT)); \
 	fi;
 endif
-	
+
 	# Set rpath for libjulia-internal, which is moving from `../lib` to `../lib/julia`.  We only need to do this for Linux/FreeBSD
 ifneq (,$(findstring $(OS),Linux FreeBSD))
 	$(PATCHELF) --set-rpath '$$ORIGIN:$$ORIGIN/$(reverse_private_libdir_rel)' $(DESTDIR)$(private_libdir)/libjulia-internal.$(SHLIB_EXT)

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -106,7 +106,7 @@ ABI_UNDERSCORE := _\#\#
 else
 ABI_UNDERSCORE :=
 endif
-EXPORTED_FUNCS := $(shell echo -e "#include \"jl_exported_funcs.inc\"\n#define XX(x) $(ABI_UNDERSCORE)x\nJL_EXPORTED_FUNCS(XX)" | $(CPP) -I$(JULIAHOME)/src - | tail -n 1)
+EXPORTED_FUNCS := $(shell printf "\#include \"jl_exported_funcs.inc\"\n\#define XX(x) $(ABI_UNDERSCORE)x\nJL_EXPORTED_FUNCS(XX)" | $(CPP) -I$(JULIAHOME)/src - | tail -n 1)
 STRIP_EXPORTED_FUNCS := $(patsubst %,--strip-symbol=%,$(EXPORTED_FUNCS))
 
 # Note that if the objcopy command starts getting too long, we can use `@file` to read


### PR DESCRIPTION
This was causing a shell escape error when attempting to cross-compile. Fix is from @vtjnash, opening this so he doesn't forget again 😅 

...Hmm this doesn't want to work on Cygwin 