### PR TITLE
Enable REPL to offer to install missing packages if install hooks are provided

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -804,7 +804,9 @@ function modules_to_be_loaded(ast, mods = Symbol[])
     if ast.head in [:using, :import]
         for arg in ast.args
             if first(arg.args) isa Symbol # i.e. `Foo`
-                push!(mods, first(arg.args))
+                if first(arg.args) != :.
+                    push!(mods, first(arg.args))
+                end
             else # i.e. `Foo: bar`
                 push!(mods, first(first(arg.args).args))
             end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -123,6 +123,12 @@ const softscope! = softscope
 
 const repl_ast_transforms = Any[softscope] # defaults for new REPL backends
 
+# Allows an external package to add hooks into the code loading.
+# The hook should take a Vector{Symbol} of package names and
+# return true if all packages could be installed, false if not
+# to e.g. install packages on demand
+const install_packages_hooks = Any[]
+
 function eval_user_input(@nospecialize(ast), backend::REPLBackend)
     lasterr = nothing
     Base.sigatomic_begin()
@@ -133,6 +139,9 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend)
                 put!(backend.response_channel, Pair{Any, Bool}(lasterr, true))
             else
                 backend.in_eval = true
+                if !isempty(install_packages_hooks)
+                    check_for_missing_packages_and_run_hooks(ast)
+                end
                 for xf in backend.ast_transforms
                     ast = Base.invokelatest(xf, ast)
                 end
@@ -153,6 +162,34 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend)
     end
     Base.sigatomic_end()
     nothing
+end
+
+function check_for_missing_packages_and_run_hooks(ast)
+    mods = modules_to_be_loaded(ast)
+    filter!(mod -> isnothing(Base.identify_package(String(mod))), mods) # keep missing modules
+    if !isempty(mods)
+        for f in install_packages_hooks
+            Base.invokelatest(f, mods) && return
+        end
+    end
+end
+
+function modules_to_be_loaded(ast, mods = Symbol[])
+    if ast.head in [:using, :import]
+        for arg in ast.args
+            if first(arg.args) isa Symbol # i.e. `Foo`
+                if first(arg.args) != :. # don't include local imports
+                    push!(mods, first(arg.args))
+                end
+            else # i.e. `Foo: bar`
+                push!(mods, first(first(arg.args).args))
+            end
+        end
+    end
+    for arg in ast.args
+        arg isa Expr && modules_to_be_loaded(arg, mods)
+    end
+    return mods
 end
 
 """
@@ -776,46 +813,9 @@ find_hist_file() = get(ENV, "JULIA_HISTORY",
 
 backend(r::AbstractREPL) = r.backendref
 
-# Allows an external package to add hooks into the code loading.
-# The hook should take a Vector{Symbol} of package names and
-# return true if all packages could be installed, false if not
-# to e.g. install packages on demand
-const install_packages_hooks = Any[]
-
 function eval_with_backend(ast, backend::REPLBackendRef)
-    if !isempty(install_packages_hooks)
-        check_for_missing_packages_and_run_hooks(ast)
-    end
     put!(backend.repl_channel, (ast, 1))
     return take!(backend.response_channel) # (val, iserr)
-end
-
-function check_for_missing_packages_and_run_hooks(ast)
-    mods = modules_to_be_loaded(ast)
-    filter!(mod -> isnothing(Base.identify_package(String(mod))), mods) # keep missing modules
-    if !isempty(mods)
-        for f in install_packages_hooks
-            f(mods) && return
-        end
-    end
-end
-
-function modules_to_be_loaded(ast, mods = Symbol[])
-    if ast.head in [:using, :import]
-        for arg in ast.args
-            if first(arg.args) isa Symbol # i.e. `Foo`
-                if first(arg.args) != :.
-                    push!(mods, first(arg.args))
-                end
-            else # i.e. `Foo: bar`
-                push!(mods, first(first(arg.args).args))
-            end
-        end
-    end
-    for arg in ast.args
-        arg isa Expr && modules_to_be_loaded(arg, mods)
-    end
-    return mods
 end
 
 function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon::Bool = true)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -776,18 +776,28 @@ find_hist_file() = get(ENV, "JULIA_HISTORY",
 
 backend(r::AbstractREPL) = r.backendref
 
-# Allows an external package to add hooks into the code loading
+# Allows an external package to add hooks into the code loading.
+# The hook should take a Vector{Symbol} of package names and
 # return true if all packages could be installed, false if not
 # to e.g. install packages on demand
 const install_packages_hooks = Any[]
 
 function eval_with_backend(ast, backend::REPLBackendRef)
-    mods_to_be_loaded = modules_to_be_loaded(ast)
-    mods_not_found = list_unfindable_modules(mods_to_be_loaded)
-    !isempty(mods_not_found) && pass_to_install_package_hooks(mods_not_found)
+    if !isempty(install_packages_hooks)
+        check_for_missing_packages_and_run_hooks(ast)
+    end
     put!(backend.repl_channel, (ast, 1))
-    resp = take!(backend.response_channel) # (val, iserr)
-    return resp
+    return take!(backend.response_channel) # (val, iserr)
+end
+
+function check_for_missing_packages_and_run_hooks(ast)
+    mods = modules_to_be_loaded(ast)
+    filter!(mod -> isnothing(Base.identify_package(String(mod))), mods) # keep missing modules
+    if !isempty(mods)
+        for f in install_packages_hooks
+            f(mods) && return
+        end
+    end
 end
 
 function modules_to_be_loaded(ast, mods = Symbol[])
@@ -795,7 +805,7 @@ function modules_to_be_loaded(ast, mods = Symbol[])
         for arg in ast.args
             if first(arg.args) isa Symbol # i.e. `Foo`
                 push!(mods, first(arg.args))
-            else # i.e. `Foo: Bar`
+            else # i.e. `Foo: bar`
                 push!(mods, first(first(arg.args).args))
             end
         end
@@ -804,16 +814,6 @@ function modules_to_be_loaded(ast, mods = Symbol[])
         arg isa Expr && modules_to_be_loaded(arg, mods)
     end
     return mods
-end
-
-function list_unfindable_modules(mods)
-    filter(mod -> isnothing(Base.identify_package(String(mod))), mods)
-end
-
-function pass_to_install_package_hooks(mods)
-    for f in install_packages_hooks
-        f(mods) && return
-    end
 end
 
 function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon::Bool = true)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1292,3 +1292,30 @@ Base.wait(frontend_task)
 macro throw_with_linenumbernode(err)
     Expr(:block, LineNumberNode(42, Symbol("test.jl")), :(() -> throw($err)))
 end
+
+@testset "Install missing packages via hooks" begin
+    @testset "Parse AST for packages" begin
+        mods = REPL.modules_to_be_loaded(Meta.parse("using Foo"))
+        @test mods == [:Foo]
+        mods = REPL.modules_to_be_loaded(Meta.parse("import Foo"))
+        @test mods == [:Foo]
+        mods = REPL.modules_to_be_loaded(Meta.parse("using Foo, Bar"))
+        @test mods == [:Foo, :Bar]
+        mods = REPL.modules_to_be_loaded(Meta.parse("import Foo, Bar"))
+        @test mods == [:Foo, :Bar]
+
+        mods = REPL.modules_to_be_loaded(Meta.parse("if false using Foo end"))
+        @test mods == [:Foo]
+        mods = REPL.modules_to_be_loaded(Meta.parse("if false if false using Foo end end"))
+        @test mods == [:Foo]
+        mods = REPL.modules_to_be_loaded(Meta.parse("if false using Foo, Bar end"))
+        @test mods == [:Foo, :Bar]
+        mods = REPL.modules_to_be_loaded(Meta.parse("if false using Foo: bar end"))
+        @test mods == [:Foo]
+
+        mods = REPL.modules_to_be_loaded(Meta.parse("import Foo.bar as baz"))
+        @test mods == [:Foo]
+        mods = REPL.modules_to_be_loaded(Meta.parse("using .Foo"))
+        @test mods == []
+    end
+end


### PR DESCRIPTION
Just trying out the ideas discussed in https://github.com/JuliaLang/julia/pull/26469 and in https://github.com/JuliaLang/julia/issues/35062 and the suggestion here https://github.com/JuliaLang/julia/pull/26469#issuecomment-597337630 to introduce a specific error type to allow other handlers to decide what to do.

This goes for a more basic `y/n` prompt than the example in https://github.com/JuliaLang/julia/pull/26469, with the default being `n`, which is selected here first.
It also leaves it up to the user to decide if the _active environment_ is appropriate to install into.
A `ctrl-c` acts the same as returning `n` or just pressing `enter`.

Here the default is selected first by just hitting `enter`

[![asciicast](https://asciinema.org/a/kO5Q4sZJp6qfI0a1Gtvo0xArx.svg)](https://asciinema.org/a/kO5Q4sZJp6qfI0a1Gtvo0xArx)

cc. @KristofferC @oxinabox 