### PR TITLE
at_test_nowarn does not suppress the content of stderr anymore

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -688,13 +688,13 @@ macro test_nowarn(expr)
         # Duplicate some code from `@test_warn` to allow printing the content of
         # `stderr` again to `stderr` here while suppressing it for `@test_warn`.
         # If that shouldn't be used, it would be possible to just use
-        #     @test_warn r"^(?!.)"s $(esc(expr))
+        #     @test_warn isempty $(esc(expr))
         # here.
         let fname = tempname()
             try
                 ret = open(fname, "w") do f
                     redirect_stderr(f) do
-                    $(esc(expr))
+                        $(esc(expr))
                     end
                 end
                 stderr_content = read(fname, String)


### PR DESCRIPTION
Currently, I get something like 
```julia
julia> using Test

julia> @test_nowarn println(stderr, "Some informative warning helpful for debugging failing tests")
Test Failed at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Test/src/Test.jl:636
  Expression: contains_warn(read(fname, String), $(Expr(:escape, :(r"^(?!.)"s))))
ERROR: There was an error during testing
```
This doesn't really help much when debugging failing tests. This PR changes the output to
```julia
julia> using Test

julia> @test_nowarn println(stderr, "Some informative warning helpful for debugging failing tests")
Some informative warning helpful for debugging failing tests
Test Failed at /home/hendrik/Software/julia/usr/share/julia/stdlib/v1.7/Test/src/Test.jl:702
  Expression: isempty(stderr_content)
   Evaluated: isempty("Some informative warning helpful for debugging failing tests\n")
ERROR: There was an error during testing
```
This is helpful for me when trying to debug failing tests in packages using `@test_nowarn`.