### PR TITLE
Fix make install on master on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,7 @@ endif
 
 ifneq ($(LOADER_BUILD_DEP_LIBS),$(LOADER_INSTALL_DEP_LIBS))
 	# Next, overwrite relative path to libjulia-internal in our loader if $$(LOADER_BUILD_DEP_LIBS) != $$(LOADER_INSTALL_DEP_LIBS)
-	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_BUILD_DEP_LIBS)$$,$(LOADER_INSTALL_DEP_LIBS))
+	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_BUILD_DEP_LIBS),$(LOADER_INSTALL_DEP_LIBS))
 
 ifeq ($(BUNDLE_DEBUG_LIBS),1)
 	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_DEBUG_BUILD_DEP_LIBS)$$,$(LOADER_DEBUG_INSTALL_DEP_LIBS))


### PR DESCRIPTION
Currently `make install` errors out for me on master since a few days ago on openSUSE Leap 15.0.

There are other places with the `$$` in the Makefile, and i will admit i don't understand it's purpose here. But removing it at this point fixes `make install` and gives me a seemingly working julia install.

The error message i get during `make install` is:
```
# Set rpath for libjulia-internal, which is moving from `../lib` to `../lib/julia`.  We only need to do this for Linux/FreeBSD                   \

/local/marcom/julia/julia.git/usr/tools/patchelf --set-rpath '$ORIGIN:$ORIGIN/..' /home/marcom/app/julia/julia-master/lib/julia/libjulia-inter
nal.so                                                                                                                                           \

# Next, overwrite relative path to libjulia-internal in our loader if $(LOADER_BUILD_DEP_LIBS) != $(LOADER_INSTALL_DEP_LIBS)                     \

/local/marcom/julia/julia.git/usr/tools/stringreplace $(strings -t x - /home/marcom/app/julia/julia-master/lib/libjulia.so.1.7 | grep $("/home
/marcom/app/opensuse-15.0/bin/python" /local/marcom/julia/julia.git/contrib/relative_path.py /local/marcom/julia/julia.git/usr/lib /local/ma
tthies/julia/julia.git/usr/lib/libgcc_s.so.1):$("/home/marcom/app/opensuse-15.0/bin/python" /local/marcom/julia/julia.git/contrib/relative_pat
h.py /local/marcom/julia/julia.git/usr/lib /local/marcom/julia/julia.git/usr/lib/libopenlibm.so):$("/home/marcom/app/opensuse-15.0/bin/pytho
n" /local/marcom/julia/julia.git/contrib/relative_path.py /local/marcom/julia/julia.git/usr/lib /local/marcom/julia/julia.git/usr/lib/libjul
ia-internal.so.1)$ | awk '{print $1;}') $("/home/marcom/app/opensuse-15.0/bin/python" /local/marcom/julia/julia.git/contrib/relative_path.py /
home/marcom/app/julia/julia-master/lib /home/marcom/app/julia/julia-master/lib/julia/libgcc_s.so.1):$("/home/marcom/app/opensuse-15.0/bin/py
thon" /local/marcom/julia/julia.git/contrib/relative_path.py /home/marcom/app/julia/julia-master/lib /home/marcom/app/julia/julia-master/lib
/julia/libopenlibm.so):$("/home/marcom/app/opensuse-15.0/bin/python" /local/marcom/julia/julia.git/contrib/relative_path.py /home/marcom/app
/julia/julia-master/lib /home/marcom/app/julia/julia-master/lib/julia/libjulia-internal.so.1) 255 "/home/marcom/app/julia/julia-master/lib/lib
julia.so.1.7"                                                                                                                                    \

Usage:
  /local/marcom/julia/julia.git/usr/tools/stringreplace <hex offset> <string to write> <maxlen> <file>
make: *** [Makefile:272: install] Error 255
```