### PR TITLE
Add dirname(path, n)

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -161,7 +161,26 @@ julia> dirname("/home/myuser/")
 
 See also: [`basename`](@ref)
 """
- dirname(path::AbstractString) = splitdir(path)[1]
+dirname(path::AbstractString) = splitdir(path)[1]
+
+"""
+    dirname(path::AbstractString, n::Integer) -> AbstractString
+Get the `n`-th parent directory of a path. Trailing characters ('/' or '\\') in the path
+are counted as part of the path.
+
+# Examples
+```jldoctest
+julia> dirname("/home/myuser", 1)
+"/home"
+
+julia> dirname("/home/myuser/", 1)
+"/home/myuser"
+
+julia> dirname("/home/myuser/stats/plots", 3)
+"/home"
+```
+"""
+dirname(path::AbstractString, n::Integer) = ∘(repeat([dirname], n)...)(path)
 
 """
     basename(path::AbstractString) -> AbstractString

--- a/test/path.jl
+++ b/test/path.jl
@@ -11,6 +11,8 @@
     end
     @test basename(S("foo$(sep)bar")) == "bar"
     @test dirname(S("foo$(sep)bar")) == "foo"
+    @test dirname(S("foo$(sep)bar"), 1) == "foo"
+    @test dirname(S("a$(sep)b$(sep)c$(sep)d"), 3) == "a"
 
     @testset "expanduser" begin
         @test expanduser(S("")) == ""


### PR DESCRIPTION
Going up multiple directories doesn't seem to be in the Julia base yet. As far as I know, using `normpath` is the best way, and that is what people typically use for the project root
```
project_root = normpath(joinpath(@__FILE__, "..", ".."))
```
from <https://stackoverflow.com/questions/35466572>. Alternatively, people use `dirname` multiple times
```
project_root = dirname(dirname(@__FILE___))
```
see <https://github.com/search?q=filename%3A*.jl+dirname%28dirname%28>.

With this PR, I propose to add an integer as second parameter for `dirname`. Then, we could write
```
project_root = dirname(@__FILE__, 2)
```
Or, for longer paths
```
julia> dirname("/a/b/c/d/e", 3)
"a/b"
```