### PR TITLE
Missing branch for last_error

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -171,6 +171,12 @@ end
     @test findfirst(isequal(LibGit2.Consts.FEATURE_HTTPS), f) !== nothing
 end
 
+@testset "No error at first" begin
+    class, msg = LibGit2.Error.last_error()
+    @test msg == "No errors"
+    @test class == LibGit2.Error.Class(0)
+end
+
 @testset "OID" begin
     z = LibGit2.GitHash()
     @test LibGit2.iszero(z)


### PR DESCRIPTION
We don't actually test what should be returned if there have been no errors yet!