### PR TITLE
Improve copyto! for short heterogeneous tuples

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -831,12 +831,14 @@ end
 
 ## from general iterable to any array
 
+@noinline throw_dest_too_short() =
+    throw(ArgumentError("destination has fewer elements than required"))
+
 function copyto!(dest::AbstractArray, src)
     destiter = eachindex(dest)
     y = iterate(destiter)
     for x in src
-        y === nothing &&
-            throw(ArgumentError("destination has fewer elements than required"))
+        y === nothing && throw_dest_too_short()
         dest[y[1]] = x
         y = iterate(destiter, y[2])
     end

--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -91,3 +91,47 @@ end
         (t..., fill(val, N-M)...)
     end
 end
+
+# Specializations for copyto! of various `NTuple`s
+function check_inds_compatible(dest::AbstractArray, src::Tuple)
+    length(dest) >= length(src) || throw_dest_too_short()
+end
+
+function _copyto_generated!(dest::AbstractArray, src::NTuple{N, Any}) where N
+    if @generated
+        ret = quote
+            check_inds_compatible(dest, src)
+            idxs = eachindex(dest)
+        end
+        state = ()
+        for n in 1:N
+            append!(ret.args, (quote
+                ind, state = iterate(idxs, $(state...))
+                @inbounds dest[ind] = src[$n]
+            end).args)
+            state = (:state,)
+        end
+        push!(ret.args, :(return dest))
+        ret
+    else
+        length(src) == 0 && return dest
+        return copyto!(dest, firstindex(dest), src, firstindex(src))
+    end
+end
+
+# Non-homogeneous tuples
+function copyto!(dest::AbstractArray, src::Tuple)
+    if length(src) < 10
+        # Manual optimization for short tuples
+        # TODO: Better support for homogeneous tuple tails
+        return _copyto_generated!(dest, src)
+    else
+        return copyto!(dest, firstindex(dest), src, firstindex(src))
+    end
+end
+
+# Specialization for homogeneous tuples
+function copyto!(dest::AbstractArray, src::Tuple{Vararg{T}} where T)
+    length(src) == 0 && return dest
+    copyto!(dest, firstindex(dest), src, firstindex(src))
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1258,3 +1258,13 @@ Base.pushfirst!(tpa::TestPushArray{T}, a::T) where T = pushfirst!(tpa.data, a)
     pushfirst!(tpa, 6, 5, 4, 3, 2)
     @test tpa.data == reverse(collect(1:6))
 end
+
+@testset "copyto! with tuple" begin
+    randtype(n) = rand(Bool) ? 1.0 : 2
+    @test copyto!(fill(0.0, 100), ntuple(randtype, 100))[end] != 0.0
+    @test copyto!(fill(0.0, 100), ntuple(x->1.0, 100))[end] != 0.0
+    @test copyto!(fill(0.0, 100), ntuple(randtype, 50))[end] == 0.0
+    @test_throws BoundsError copyto!(fill(0.0, 50), ntuple(randtype, 100))
+    @test_throws BoundsError copyto!(fill(0.0, 50), ntuple(x->1.0, 100))
+    @test_throws ArgumentError copyto!(fill(0.0, 5), ntuple(randtype, 7))
+end


### PR DESCRIPTION
There was a complaint on Twitter [1], that Julia is slower than
Ruby(!) at allocating short heterogeneous arrays. The code looks
something like this:

```
f() = for i in 1:100000; b=[1,2.0]; end;
```

Of course, this benchmark is silly because the arrays are
unused, so the entire code should be dropped once we have
further improvements to our lifetime analysis, which will
change the runtime 0. However, since we're not quite able
to do that yet, it is somewhat unexpected that we should
be slower than Ruby here. Admittedly our arrays are tuned
for larger sizes, but still. Upon further investigation,
it turns out that the issue is that we're allocating extra
boxed objects when pulling the fields out of the literal,
since we don't have any specialization for `copyto!` from
tuples, falling back to the generic `copyto!` method, which
is type unstable in the presence of heterogeneous tuples.

Since this code is reachable from surface syntax, I think
it's worth putting in a couple of specializations to
accelerate the array construction. This PR does two things:
1) Use the indexed `copyto!` for tuples, which is faster than the iterator fallback
2) Add a special fast-path for short-length heterogeneous tuples (as might arise from surface syntax), which unrolls the assignment loop and preserves type stability.
Since the type-instability issue applies whether
the value is used or not, this should still be useful even
if we're able to prove that the allocations can be dropped
entirely.

There are some additional optimizations that could make
this better, but they are in the pipeline anyway as part of the
whole Vararg re-work, so I'll punt those until then. In the meantime:

Before:
```
julia> @benchmark f()
BenchmarkTools.Trial:
  memory estimate:  21.36 MiB
  allocs estimate:  600000
  --------------
  minimum time:     14.928 ms (0.00% GC)
  median time:      16.297 ms (0.00% GC)
  mean time:        16.323 ms (3.84% GC)
  maximum time:     26.042 ms (0.00% GC)
  --------------
  samples:          307
  evals/sample:     1
```

After:
```
julia> @benchmark f()
BenchmarkTools.Trial:
  memory estimate:  9.16 MiB
  allocs estimate:  100000
  --------------
  minimum time:     2.117 ms (0.00% GC)
  median time:      2.276 ms (0.00% GC)
  mean time:        2.455 ms (7.62% GC)
  maximum time:     4.638 ms (28.99% GC)
  --------------
  samples:          2036
  evals/sample:     1
```

Which puts us about on par with Ruby on my machine (not entirely
unsurprising, since this is essentially an allocation benchmark
at this point and both allocators are written in C).

[1] https://twitter.com/SimonDeDeo/status/1344031423704006656