### PR TITLE
Add `ismutabletype`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -656,6 +656,7 @@ export
     isbits,
     isequal,
     ismutable,
+    ismutabletype,
     isless,
     isunordered,
     ifelse,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -460,6 +460,23 @@ true
 """
 ismutable(@nospecialize(x)) = (@_pure_meta; typeof(x).mutable)
 
+
+"""
+    ismutabletype(T) -> Bool
+
+Determine whether type `T` was declared as a mutable type
+(i.e. using `mutable struct` keyword).
+
+!!! compat "Julia 1.7"
+    This function requires at least Julia 1.7.
+"""
+function ismutabletype(@nospecialize(t::Type))
+    t = unwrap_unionall(t)
+    # TODO: what to do for `Union`?
+    return isa(t, DataType) && t.mutable
+end
+
+
 """
     isstructtype(T) -> Bool
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -113,6 +113,9 @@ not_const = 1
 
 @test ismutable(1) == false
 @test ismutable([]) == true
+@test ismutabletype(Int) == false
+@test ismutabletype(Vector{Any}) == true
+@test ismutabletype(Union{Int, Vector{Any}}) == false
 
 ## find bindings tests
 @test ccall(:jl_get_module_of_binding, Any, (Any, Any), Base, :sin)==Base


### PR DESCRIPTION
Determines whether a type was declared using `mutable struct`.
Naming follows from the `ismutable` query we already have, analogous
to `isbits`/`isbitstype`. Replaces #18168.