### PR TITLE
Annotate function arguments with sext/zext

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5668,6 +5668,11 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
         else if (isboxed && jl_is_immutable_datatype(jt)) {
             attributes = attributes.addParamAttribute(jl_LLVMContext, argno, Attribute::ReadOnly);
         }
+        else if (jl_is_primitivetype(jt) && ty->isIntegerTy()) {
+            bool issigned = jl_signed_type && jl_subtype(jt, (jl_value_t*)jl_signed_type);
+            Attribute::AttrKind attr = issigned ? Attribute::SExt : Attribute::ZExt;
+            attributes = attributes.addParamAttribute(jl_LLVMContext, argno, attr);
+        }
         fsig.push_back(ty);
     }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5631,6 +5631,7 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
         unsigned argno = 1;
 #if JL_LLVM_VERSION < 120000
         attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::StructRet);
+        (void)srt; // silence unused variable error
 #else
         Attribute sret = Attribute::getWithStructRetType(jl_LLVMContext, srt);
         attributes = attributes.addAttribute(jl_LLVMContext, argno, sret);


### PR DESCRIPTION
https://bugs.llvm.org/show_bug.cgi?id=30451#c11 pointed out that we
need to annotate the parameters of functions with `sext`/`zext` so that
the backend can use the right semantics when promoting from a narrower type
to a register type. We do this for ccall (x-ref: #978) already, but it seems
like we need to do this generally.

Does anybody know if there are other places I might need to add this?
