### PR TITLE
Various fixes to trampolines for embedding on Windows

### DIFF
--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -196,6 +196,8 @@ JL_DLLEXPORT int jl_load_repl(int argc, char * argv[]) {
 
 #ifdef _OS_WINDOWS_
 int __stdcall DllMainCRTStartup(void* instance, unsigned reason, void* reserved) {
+    setup_stdio();
+
     // Because we override DllMainCRTStartup, we have to manually call our constructor methods
     jl_load_libjulia_internal();
     return 1;

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -130,6 +130,11 @@ JL_DLLEXPORT const char * jl_get_libdir()
 
 void * libjulia_internal = NULL;
 __attribute__((constructor)) void jl_load_libjulia_internal(void) {
+    // Only initalize this once
+    if (libjulia_internal != NULL) {
+        return;
+    }
+
     // Introspect to find our own path
     const char * lib_dir = jl_get_libdir();
 

--- a/cli/trampolines/trampolines_x86_64.S
+++ b/cli/trampolines/trampolines_x86_64.S
@@ -14,7 +14,7 @@
                             .endef
 #define EXPORT(name)        .section .drectve,"r"; \
                             .ascii " -export:"#name""; \
-                            .section text
+                            .section .text
 #define SEH_START1(name)    .seh_proc name
 #define SEH_START2()        .seh_endprologue
 #define SEH_END()           .seh_endproc


### PR DESCRIPTION
@GunnarFarneback this fixed your dynamic embedding test suite on Windows for me; I'd appreciate if you could corroborate.

Many thanks to @Keno and @vchuravy for teaching me how to track down the reason behind the segfault; turns out it was an improperly-named section that wasn't getting the right execute bits set for its pages.  The tool to figure this out is [vmmap](https://docs.microsoft.com/en-us/sysinternals/downloads/vmmap), made by sysinternals, as all good windows tools usually are.