### PR TITLE
Add range(start, stop, length)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -47,7 +47,7 @@ function _colon(start::T, step, stop::T) where T
 end
 
 """
-    range(start[, stop]; length, stop, step=1)
+    range(start[, stop[, length]]; length, stop, step=1)
 
 Given a starting value, construct a range either by length or from `start` to `stop`,
 optionally with a given step (defaults to 1, a [`UnitRange`](@ref)).
@@ -58,6 +58,8 @@ automatically such that there are `length` linearly spaced elements in the range
 
 If `step` and `stop` are provided and `length` is not, the overall range length will be computed
 automatically such that the elements are `step` spaced.
+
+If `start`, `stop`, and `length` are specified by position, no keywords are permitted.
 
 Special care is taken to ensure intermediate values are computed rationally.
 To avoid this induced overhead, see the [`LinRange`](@ref) constructor.
@@ -84,6 +86,9 @@ julia> range(1, step=5, stop=100)
 julia> range(1, 10, length=101)
 1.0:0.09:10.0
 
+julia> range(1, 10, 101)
+1.0:0.09:10.0
+
 julia> range(1, 100, step=5)
 1:5:96
 ```
@@ -93,6 +98,9 @@ range(start; length::Union{Integer,Nothing}=nothing, stop=nothing, step=nothing)
 
 range(start, stop; length::Union{Integer,Nothing}=nothing, step=nothing) =
     _range2(start, step, stop, length)
+
+range(start, stop, length::Union{Integer,Nothing}) =
+    _range(start, nothing, stop, length)
 
 _range2(start, ::Nothing, stop, ::Nothing) =
     throw(ArgumentError("At least one of `length` or `step` must be specified"))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1610,6 +1610,17 @@ end
     @test_throws ArgumentError range(1, 100)
 end
 
+@testset "range wtih start, stop, and length" begin
+    for starts in [-1, 0, 1, 10]
+        for stops in [-2, 0, 2, 100]
+            for lengths in [2, 10, 100]
+                @test range(starts, stops, lengths) === range(starts, stop=stops, length=lengths)
+            end
+            @test range(starts, stops, nothing) === range(starts, stop=stops)
+        end
+    end
+end
+
 @testset "Reverse empty ranges" begin
     @test reverse(1:0) === 0:-1:1
     @test reverse(Base.OneTo(0)) === 0:-1:1


### PR DESCRIPTION
This is a minimal implementation of `range(start, stop, length)` with no fuss. It adds the three positional argument version. One or two positional arguments are still disallowed.

Closes #38750

```julia
# The one line of actual code added is literally the one line below
julia> Base.range(start, stop, length::Union{Integer,Nothing}) = Base._range(start, nothing, stop, length)

julia> range(1,5,5)
1.0:1.0:5.0

julia> range(1,5,2)
1.0:4.0:5.0

julia> range(1,5)
ERROR: ArgumentError: At least one of `length` or `step` must be specified
Stacktrace:
 [1] _range2(::Int64, ::Nothing, ::Int64, ::Nothing) at .\range.jl:97
 [2] range(::Int64, ::Int64; length::Nothing, step::Nothing) at .\range.jl:94
 [3] range(::Int64, ::Int64) at .\range.jl:94
 [4] top-level scope at REPL[4]:1
 
 julia> range(5)
ERROR: ArgumentError: At least one of `length` or `stop` must be specified
Stacktrace:
 [1] _range(::Int64, ::Nothing, ::Nothing, ::Nothing) at .\range.jl:126
 [2] range(::Int64; length::Nothing, stop::Nothing, step::Nothing) at .\range.jl:91
 [3] range(::Int64) at .\range.jl:91
 [4] top-level scope at REPL[5]:1
```

While I still think we should evaluate the larger picture, there are compatible alternatives I would like to explore such as using `Pair` to represent `start => stop`, resulting in unambiguous syntax. My approach to that depends on if this is integrated or not.