### PR TITLE
[RFC] Add estimates of operator norms

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -115,6 +115,7 @@ export
     normalize,
     normalize!,
     nullspace,
+    opnormest,
     ordschur!,
     ordschur,
     pinv,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -18,6 +18,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
 using Base: hvcat_fill, IndexLinear, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_vcat, require_one_based_indexing
 using Base.Broadcast: Broadcasted, broadcasted
+using Random: rand!
 
 export
 # Modules

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -854,7 +854,6 @@ function _each_col_has_parallel_col(X, Y)
     return true
 end
 
-# algorithm 2.4 (practical block 1-norm estimator) from
 """
     opnormest1(A, t::Integer = 2) -> est
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -953,17 +953,15 @@ function opnormest1(
         # Use the conjugate transpose
         Z = A' * S
         h_max = zero(eltype(h))
-        h_ind = 0
         for i = 1:n
-            h[i] = normInf(view(Z,i,1:t))
-            if h[i] > h_max
-                h_max = h[i]
-                h_ind = i
+            h[i] = hi = normInf(view(Z,i,1:t))
+            if hi > h_max
+                h_max = hi
             end
             ind[i] = i
         end
         # (4)
-        if iter >= 2 && ind_best == h_ind
+        if iter >= 2 && h_max == h[ind_best]
             break
         end
         sortperm!(p, h; rev=true)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -866,7 +866,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
     for j = 2:t
         while true
             rand!(view(X,1:n,j), (-1, 1))
-            yaux = X[1:n,j]' * X[1:n,1:j-1]
+            yaux = @views X[1:n,j]' * X[1:n,1:j-1]
             if !_any_abs_eq(yaux,n)
                 break
             end
@@ -884,7 +884,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
         est = zero(real(eltype(Y)))
         est_ind = 0
         for i = 1:t
-            y = norm(Y[1:n,i], 1)
+            y = norm(view(Y,1:n,i), 1)
             if y > est
                 est = y
                 est_ind = i
@@ -914,13 +914,13 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
                 while true
                     repeated = false
                     if j > 1
-                        saux = S[1:n,j]' * S[1:n,1:j-1]
+                        saux = @views S[1:n,j]' * S[1:n,1:j-1]
                         if _any_abs_eq(saux,n)
                             repeated = true
                         end
                     end
                     if !repeated
-                        saux2 = S[1:n,j]' * S_old[1:n,1:t]
+                        saux2 = @views S[1:n,j]' * S_old[1:n,1:t]
                         if _any_abs_eq(saux2,n)
                             repeated = true
                         end
@@ -940,7 +940,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
         h = zeros(real(eltype(Z)), n)
         h_ind = 0
         for i = 1:n
-            h[i] = norm(Z[i,1:t], Inf)
+            h[i] = norm(view(Z,i,1:t), Inf)
             if h[i] > h_max
                 h_max = h[i]
                 h_ind = i

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -934,15 +934,13 @@ function opnormest1(
     end
 
     iter = 0
-    local est
-    local ind_best
-    est_ind = 0
-    est_old = zero(real(eltype(X)))
+    ind_best = 1
+    est = est_old = zero(real(eltype(X)))
     while true
         iter += 1
         Y = A * X
         est = zero(real(eltype(Y)))
-        est_ind = 0
+        est_ind = 1
         for i = 1:t
             y = norm1(view(Y,1:m,i))
             if y > est

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1081,7 +1081,7 @@ struct InvMat{T}
     A::T
 end
 Base.eltype(M::InvMat) = eltype(M.A)
-Base.size(M::InvMat) = size(M.A)
+Base.size(M::InvMat) = reverse(size(M.A))
 Base.:*(M::InvMat, X) = M.A \ X
 Base.adjoint(M::InvMat) = InvMat(adjoint(M.A))
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -870,9 +870,15 @@ function opnormest2(
     m, n = size(A)
     A′ = A'
     c = float(T)(inv(sqrt(n)))
-    v = rand((-c, c), n)
+    v = fill(c, n)
     w = A * v
     est = norm(w)
+    if iszero(est)
+        # either A is zero or we picked a bad initial v. try sampling v.
+        rand!(v, (-c, c))
+        w = A * v
+        est = norm(w)
+    end
     est_old = oftype(est, Inf)
     for iter in 1:maxiter
         z = A′ * w

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -899,7 +899,6 @@ function opnormest1(
     maxiter = 5
     # Check the input
     n = checksquare(A)
-    iszero(n) && return zero(T)
     if t <= 0
         throw(ArgumentError("number of blocks must be a positive integer"))
     end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -930,8 +930,8 @@ function opnormest1(
             break
         end
         est_old = est
-        iter > maxiter && break
         S, S_old = S_old, S
+        iter > maxiter && break
         broadcast!(S, Y) do Yij
             Sij = sign(Yij)
             return ifelse(iszero(Sij), one(Sij), Sij)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -888,7 +888,7 @@ must not exceed the number of rows or columns of `A`.
 Along with the estimate of the operator 1-norm, return a vector `v` and/or a vector `w` that
 correspond to the estimate, such that ``w = A v`` and
 ``\\|w\\|_1 = \\mathrm{est} \\|v\\|_1``, where ``\\mathrm{est}`` is the estimate of the
-matrix 1-norm of `A`, and ``\\|⋅\\|`` is the Frobenius 1-[`norm`](@ref).
+matrix 1-norm of `A`, and ``\\|⋅\\|_1`` is the Frobenius 1-[`norm`](@ref).
 """
 function opnormest1(
     A,

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -885,7 +885,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
         est = zero(real(eltype(Y)))
         est_ind = 0
         for i = 1:t
-            y = norm(view(Y,1:n,i), 1)
+            y = norm1(view(Y,1:n,i))
             if y > est
                 est = y
                 est_ind = i
@@ -941,7 +941,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
         h = zeros(real(eltype(Z)), n)
         h_ind = 0
         for i = 1:n
-            h[i] = norm(view(Z,i,1:t), Inf)
+            h[i] = normInf(view(Z,i,1:t))
             if h[i] > h_max
                 h_max = h[i]
                 h_ind = i

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -984,8 +984,8 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
                 end
             end
         else
-            ind_hist[1:t] = ind[1:t]
             for j = 1:t
+                ind_hist[j] = ind[j]
                 for i = 1:ind[j] - 1
                     X[i,j] = 0
                 end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -863,7 +863,7 @@ function opnormest2(
     A,
     ::Val{retv} = Val(false),
     ::Val{retw} = Val(false);
-    tol = sqrt(eps(real(float(eltype(A))))),
+    tol = 1e-6,
     maxiter = 100,
 ) where {retv,retw}
     T = eltype(A)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -852,6 +852,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))), maxiter::Integer = 
     S = zeros(T <: Real ? Int : Ti, n, t)
     S_old = copy(S)
     h = Vector{real(Base.promote_eltype(S, A))}(undef, n)
+    p = Vector{Int64}(undef, n)
 
     function _any_abs_eq(v,n::Int)
         for vv in v
@@ -950,8 +951,8 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))), maxiter::Integer = 
         if iter >=2 && ind_best == h_ind
             break
         end
-        p = sortperm(h, rev=true)
-        h = h[p]
+        sortperm!(p, h; rev=true)
+        permute!(h, p)
         permute!(ind, p)
         if t > 1
             addcounter = t

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1105,13 +1105,13 @@ than `opnorm` for large and sparse matrices.
 - `*(A::Op, B::AbstractMatrix)`
 - `adjoint(A::Op)`
 
-    opnormest(f, A, p::Real=2)
+    opnormest(f, A, p::Real)
 
 Estimate the operator p-norm [`opnorm(inv(A), p)`](@ref) of a matrix or linear operator
 `A` without computing `f(A)`.
 
-    opnormest(::typeof(inv), A[, p])
-    opnormest(::typeof(pinv), A[, p])
+    opnormest(::typeof(inv), A, p::Real)
+    opnormest(::typeof(pinv), A, p::Real)
 
 Estimate the operator p-norm of `inv(A)` or `pinv(A)`. If `A` is an `AbstractMatrix`, it
 will be more efficient to pass its factorization to this function.
@@ -1122,7 +1122,7 @@ will be more efficient to pass its factorization to this function.
 - `\\(A::Op, B::AbstractMatrix)`
 - `adjoint(A::Op)`
 
-    opnormest(::typeof(prod), As[, p])
+    opnormest(::typeof(prod), As, p::Real)
 
 Estimate the operator p-norm of the product of the matrices or linear operators `As` without
 forming the product `prod(As)`.
@@ -1150,12 +1150,12 @@ Base.size(M::PInvLinearOperator) = reverse(size(M.A))
 Base.:*(M::PInvLinearOperator, X) = M.A \ X
 Base.adjoint(M::PInvLinearOperator) = PInvLinearOperator(adjoint(M.A))
 
-function opnormest(::typeof(inv), A, p::Real=2)
+function opnormest(::typeof(inv), A, p::Real)
     checksquare(A)
     return opnormest(PInvLinearOperator(A), p)
 end
 
-function opnormest(::typeof(pinv), A, p::Real=2)
+function opnormest(::typeof(pinv), A, p::Real)
     return opnormest(PInvLinearOperator(A), p)
 end
 
@@ -1176,7 +1176,7 @@ function Base.adjoint(M::ProdLinearOperator)
     return ProdLinearOperator(Ast)
 end
 
-function opnormest(::typeof(prod), As, p::Real=2)
+function opnormest(::typeof(prod), As, p::Real)
     return opnormest(ProdLinearOperator(As), p)
 end
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -836,13 +836,15 @@ opnorm(v::TransposeAbsVec) = norm(v.parent)
 _isparallel(x, y) = abs(dot(x, y)) == length(x)
 
 """
-    opnormest2(A; tol) -> est
+    opnormest2(A; tol=1e-6, maxiter=100) -> est
 
 Estimate the operator 2-norm [`opnorm(A, 2)`](@ref) of the matrix or linear operator `A`
 using power iteration.
 
 The estimate is a lower bound on the 2-norm and can be much more efficient than `opnorm` for
-large and sparse matrices. To improve the estimate, set `tol`.
+large and sparse matrices. The power iteration terminates when the estimate converges,
+within the relative tolerance `tol`, or after `maxiter` iterations. Note that the algorithm
+uses random numbers, so the result may change between evaluations.
 
 `A` can be of any type `Op`, representing a matrix, that implements the following methods:
 - `size(A::Op)`
@@ -850,9 +852,9 @@ large and sparse matrices. To improve the estimate, set `tol`.
 - `*(A::Op, B::AbstractMatrix)`
 - `adjoint(A::Op)`
 
-    opnormest2(A, retv::Val{true}; tol) -> (est, v)
-    opnormest2(A, retv::Val{false}, retw::Val{true}; tol) -> (est, w)
-    opnormest2(A, retv::Val{true}, retw::Val{true}; tol) -> (est, v, w)
+    opnormest2(A, retv::Val{true}; kwargs...) -> (est, v)
+    opnormest2(A, retv::Val{false}, retw::Val{true}; kwargs...) -> (est, w)
+    opnormest2(A, retv::Val{true}, retw::Val{true}; kwargs...) -> (est, v, w)
 
 Along with the estimate of the operator 2-norm, return a vector `v` and/or a vector `w` that
 correspond to the estimate, such that ``w = A v`` and

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -884,9 +884,9 @@ Note: the algorithm uses random numbers, so the result may change between evalua
     opnormest1(A, t::Integer, retv::Val{true}, retw::Val{true}) -> (est, v, w)
 
 Along with the estimate of the operator 1-norm, return a vector `v` and/or a vector `w` that
-correspond to the estimate, such that ``w = A v`` and ``\\|w\\|_1 = γ \\|v\\|_1``,
-where ``γ`` is the estimate of the 1-norm of `A`, and ``\\|⋅\\|`` is the Frobenius
-1-[`norm`](@ref).
+correspond to the estimate, such that ``w = A v`` and
+``\\|w\\|_1 = \\mathrm{est} \\|v\\|_1``, where ``\\mathrm{est}`` is the estimate of the
+matrix 1-norm of `A`, and ``\\|⋅\\|`` is the Frobenius 1-[`norm`](@ref).
 """
 function opnormest1(
     A,

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -919,6 +919,7 @@ function opnormest1(
             ind_best = ind[est_ind]
             retw && copyto!(w, view(Y, 1:n, est_ind))
         end
+        # (1)
         if iter >= 2 && est <= est_old
             est = est_old
             break
@@ -930,8 +931,8 @@ function opnormest1(
             Sij = sign(Yij)
             return ifelse(iszero(Sij), one(Sij), Sij)
         end
-
         if T <: Real
+            # (2)
             _each_col_has_parallel_col(S, S_old) && break
             # Check whether cols of S are parallel to cols of S or S_old
             for j = 1:t
@@ -954,6 +955,7 @@ function opnormest1(
             end
         end
 
+        # (3)
         # Use the conjugate transpose
         Z = A' * S
         h_max = zero(eltype(h))
@@ -966,13 +968,15 @@ function opnormest1(
             end
             ind[i] = i
         end
-        if iter >=2 && ind_best == h_ind
+        # (4)
+        if iter >= 2 && ind_best == h_ind
             break
         end
         sortperm!(p, h; rev=true)
         permute!(h, p)
         permute!(ind, p)
         if t > 1
+            # (5)
             addcounter = t
             elemcounter = 0
             while addcounter > 0 && elemcounter < n
@@ -1015,6 +1019,7 @@ function opnormest1(
         end
     end
     ret = (est,)
+    # (6)
     if retv
         v = zeros(Ti, n)
         v[ind_best] = 1

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -961,10 +961,12 @@ function opnormest1(
             # Complex vectors are much less likely to be parallel, so the check is skipped
             iter >= 2 && _each_col_has_parallel_col(S, S_old) && break
             # Randomly permute any cols of S that are parallel to cols of S or S_old
-            for j = 1:t
-                while (j > 1 && _any_cols_are_parallel(S, j, S, 1:(j - 1))) ||
-                      (iter >= 2 && _any_cols_are_parallel(S, j, S_old, 1:t))
-                    rand!(view(S, 1:m, j), (-1, 1))
+            if t > 1 # if t == 1 and we've reached this loop, then never runs
+                for j = 1:t
+                    while (j > 1 && _any_cols_are_parallel(S, j, S, 1:(j - 1))) ||
+                        (iter >= 2 && _any_cols_are_parallel(S, j, S_old, 1:t))
+                        rand!(view(S, 1:m, j), (-1, 1))
+                    end
                 end
             end
         end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -939,15 +939,7 @@ function opnormest1(
     while true
         iter += 1
         Y = A * X
-        est = zero(real(eltype(Y)))
-        est_ind = 1
-        for i = 1:t
-            y = norm1(view(Y,1:m,i))
-            if y > est
-                est = y
-                est_ind = i
-            end
-        end
+        est, est_ind = findmax(i -> norm1(view(Y,1:m,i)), 1:t)
         if est > est_old || iter == 2
             ind_best = ind[est_ind]
             retw && copyto!(w, view(Y, 1:m, est_ind))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -851,6 +851,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
     Ti = typeof(float(zero(T)))
 
     S = zeros(T <: Real ? Int : Ti, n, t)
+    S_old = copy(S)
 
     function _any_abs_eq(v,n::Int)
         for vv in v
@@ -902,11 +903,9 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
             break
         end
         est_old = est
-        S_old = copy(S)
-        for j = 1:t
-            for i = 1:n
-                S[i,j] = Y[i,j]==0 ? one(Y[i,j]) : sign(Y[i,j])
-            end
+        copyto!(S_old, S)
+        for j = 1:t, i = 1:n
+            S[i,j] = Y[i,j]==0 ? one(Y[i,j]) : sign(Y[i,j])
         end
 
         if T <: Real

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -847,6 +847,13 @@ function _any_cols_are_parallel(X, xrange, Y, yrange)
     return false
 end
 
+function _each_col_has_parallel_col(X, Y)
+    for x in eachcol(X)
+        any(y -> _isparallel(x, y), eachcol(Y)) || return false
+    end
+    return true
+end
+
 function opnormest1(
     A,
     t::Integer=min(2,maximum(size(A))),
@@ -928,6 +935,7 @@ function opnormest1(
         end
 
         if T <: Real
+            _each_col_has_parallel_col(S, S_old) && break
             # Check whether cols of S are parallel to cols of S or S_old
             for j = 1:t
                 while true

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -885,7 +885,6 @@ function opnormest1(
     S_old = zeros(Ti, n, t)
     S = Matrix{Ti}(undef, n, t)
     h = Vector{real(Base.promote_type(Ti, T))}(undef, n)
-    p = Vector{Int64}(undef, n)
 
     # Generate the block matrix
     X = Matrix{Ti}(undef, n, t)
@@ -958,15 +957,13 @@ function opnormest1(
             if hi > h_max
                 h_max = hi
             end
-            ind[i] = i
         end
         # (4)
         if iter >= 2 && h_max == h[ind_best]
             break
         end
-        sortperm!(p, h; rev=true)
-        permute!(h, p)
-        permute!(ind, p)
+        sortperm!(ind, h; rev=true)
+        permute!(h, ind)
         if t > 1
             # (5)
             addcounter = t

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -871,9 +871,6 @@ function opnormest1(
 
     # Generate the block matrix
     X = Matrix{Ti}(undef, n, t)
-    if retw
-        w = Vector{Ti}(undef, n)
-    end
     X[1:n,1] .= 1
     for j = 2:t
         while true
@@ -885,6 +882,10 @@ function opnormest1(
         end
     end
     rmul!(X, inv(n))
+
+    if retw
+        w = Vector{Ti}(undef, n)
+    end
 
     iter = 0
     local est

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -850,7 +850,7 @@ function opnormest1(
     if t > n
         throw(ArgumentError("number of blocks must not be greater than $n"))
     end
-    ind = Vector{Int64}(undef, n)
+    ind = ones(Int64, n)
     ind_hist = Vector{Int64}(undef, maxiter * t)
 
     Ti = typeof(float(zero(T)))
@@ -908,7 +908,7 @@ function opnormest1(
             est_old = est
         end
         if est > est_old || iter == 2
-            ind_best = est_ind
+            ind_best = ind[est_ind]
             retw && copyto!(w, view(Y, 1:n, est_ind))
         end
         if iter >= 2 && est <= est_old

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -838,6 +838,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
     maxiter = 5
     # Check the input
     n = checksquare(A)
+    iszero(n) && return zero(T)
     if t <= 0
         throw(ArgumentError("number of blocks must be a positive integer"))
     end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -904,8 +904,9 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
         end
         est_old = est
         copyto!(S_old, S)
-        for j = 1:t, i = 1:n
-            S[i,j] = Y[i,j]==0 ? one(Y[i,j]) : sign(Y[i,j])
+        broadcast!(S, Y) do Yij
+            Sij = sign(Yij)
+            return ifelse(iszero(Sij), one(Sij), Sij)
         end
 
         if T <: Real

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1092,7 +1092,7 @@ end
 opnormestInf(A) = opnormest1(A')
 
 """
-    opnormest(A, p::Real) -> est
+    opnormest(A, p::Real=2) -> est
 
 Estimate the operator p-norm [`opnorm(A, p)`](@ref) of the matrix or linear operator `A`.
 
@@ -1105,13 +1105,13 @@ than `opnorm` for large and sparse matrices.
 - `*(A::Op, B::AbstractMatrix)`
 - `adjoint(A::Op)`
 
-    opnormest(f, A, p::Real, args...)
+    opnormest(f, A, p::Real=2)
 
 Estimate the operator p-norm [`opnorm(inv(A), p)`](@ref) of a matrix or linear operator
 `A` without computing `f(A)`.
 
-    opnormest(::typeof(inv), A, p::Real)
-    opnormest(::typeof(pinv), A, p::Real)
+    opnormest(::typeof(inv), A[, p])
+    opnormest(::typeof(pinv), A[, p])
 
 Estimate the operator p-norm of `inv(A)` or `pinv(A)`. If `A` is an `AbstractMatrix`, it
 will be more efficient to pass its factorization to this function.
@@ -1122,20 +1122,22 @@ will be more efficient to pass its factorization to this function.
 - `\\(A::Op, B::AbstractMatrix)`
 - `adjoint(A::Op)`
 
-    opnormest(::typeof(prod), As, p::Real)
+    opnormest(::typeof(prod), As[, p])
 
 Estimate the operator p-norm of the product of the matrices or linear operators `As` without
 forming the product `prod(As)`.
 """
 opnormest
 
-function opnormest(A, p::Real)
-    if p == 1
+function opnormest(A, p::Real=2)
+    if p == 2
+        return opnormest2(A)
+    elseif p == 1
         return opnormest1(A)
     elseif p == Inf
         return opnormestInf(A)
     else
-        throw(ArgumentError("unsupported p-norm p=$p. Valid: 1, Inf"))
+        throw(ArgumentError("invalid p-norm p=$p. Valid: 1, 2, Inf"))
     end
 end
 
@@ -1148,12 +1150,12 @@ Base.size(M::PInvLinearOperator) = reverse(size(M.A))
 Base.:*(M::PInvLinearOperator, X) = M.A \ X
 Base.adjoint(M::PInvLinearOperator) = PInvLinearOperator(adjoint(M.A))
 
-function opnormest(::typeof(inv), A, p::Real)
+function opnormest(::typeof(inv), A, p::Real=2)
     checksquare(A)
     return opnormest(PInvLinearOperator(A), p)
 end
 
-function opnormest(::typeof(pinv), A, p::Real)
+function opnormest(::typeof(pinv), A, p::Real=2)
     return opnormest(PInvLinearOperator(A), p)
 end
 
@@ -1174,7 +1176,7 @@ function Base.adjoint(M::ProdLinearOperator)
     return ProdLinearOperator(Ast)
 end
 
-function opnormest(::typeof(prod), As, p::Real)
+function opnormest(::typeof(prod), As, p::Real=2)
     return opnormest(ProdLinearOperator(As), p)
 end
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -872,8 +872,7 @@ evaluations.
     SIAM Journal on Matrix Analysis and Applications, 21(4), 2000, pp. 1185-1201.
     [doi:10.1137/S0895479899356080](https://doi.org/10.1137/S0895479899356080)
 
-`A` can be of any type `Op`, representing a square matrix, that implements the following
-methods:
+`A` can be of any type `Op`, representing a matrix, that implements the following methods:
 - `size(A::Op)`
 - `eltype(A::Op)`
 - `*(A::Op, B::AbstractMatrix)`

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -900,9 +900,9 @@ function opnormest1(
 
     iter = 0
     local est
-    local est_old
     local ind_best
     est_ind = 0
+    est_old = zero(real(eltype(X)))
     while true
         iter += 1
         Y = A * X
@@ -914,9 +914,6 @@ function opnormest1(
                 est = y
                 est_ind = i
             end
-        end
-        if iter == 1
-            est_old = est
         end
         if est > est_old || iter == 2
             ind_best = ind[est_ind]

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -835,25 +835,6 @@ opnorm(v::TransposeAbsVec) = norm(v.parent)
 
 _isparallel(x, y) = abs(dot(x, y)) == length(x)
 
-function _any_cols_are_parallel(X, xrange, Y, yrange)
-    n = size(X, 1)
-    for i in xrange
-        x = view(X,1:n,i)
-        for j in yrange
-            y = view(Y,1:n,j)
-            _isparallel(x, y) && return true
-        end
-    end
-    return false
-end
-
-function _each_col_has_parallel_col(X, Y)
-    for x in eachcol(X)
-        any(y -> _isparallel(x, y), eachcol(Y)) || return false
-    end
-    return true
-end
-
 """
     opnormest2(A; tol) -> est
 
@@ -923,6 +904,25 @@ function opnormest2(
         ret = (ret..., w)
     end
     return ret
+end
+
+function _any_cols_are_parallel(X, xrange, Y, yrange)
+    n = size(X, 1)
+    for i in xrange
+        x = view(X,1:n,i)
+        for j in yrange
+            y = view(Y,1:n,j)
+            _isparallel(x, y) && return true
+        end
+    end
+    return false
+end
+
+function _each_col_has_parallel_col(X, Y)
+    for x in eachcol(X)
+        any(y -> _isparallel(x, y), eachcol(Y)) || return false
+    end
+    return true
 end
 
 """

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -854,6 +854,12 @@ function _each_col_has_parallel_col(X, Y)
     return true
 end
 
+# algorithm 2.4 (practical block 1-norm estimator) from
+# Higham, Nicholas J. and Tisseur, Françoise (2000)
+# A block algorithm for matrix 1-norm estimation, with an application to 1-norm pseudospectra.
+# SIAM Journal On Matrix Analysis And Applications, 21 (4). pp. 1185-1201. ISSN 1095-7162
+# doi: 10.1137/S0895479899356080
+# http://eprints.maths.manchester.ac.uk/id/eprint/321
 function opnormest1(
     A,
     t::Integer=min(2,maximum(size(A))),

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -988,7 +988,7 @@ function opnormest1(
     if retv
         v = zeros(Ti, n)
         v[ind_best] = 1
-        ret = (ret..., v)
+        ret = (ret, v)
     end
     if retw
         ret = (ret..., w)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1103,7 +1103,10 @@ methods:
 If `A` is an `AbstractMatrix`, it will be more efficient to pass its factorization
 to this function.
 """
-opnormestinv1(A, args...) = opnormest1(InvMat(A), args...)
+function opnormestinv1(A, args...)
+    checksquare(A)
+    return opnormest1(InvMat(A), args...)
+end
 
 norm(v::Union{TransposeAbsVec,AdjointAbsVec}, p::Real) = norm(v.parent, p)
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -892,7 +892,7 @@ function opnormest1(
     local est_old
     local ind_best
     est_ind = 0
-    while iter < maxiter
+    while true
         iter += 1
         Y = A * X
         est = zero(real(eltype(Y)))
@@ -916,6 +916,7 @@ function opnormest1(
             break
         end
         est_old = est
+        iter > maxiter && break
         copyto!(S_old, S)
         broadcast!(S, Y) do Yij
             Sij = sign(Yij)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -833,9 +833,8 @@ opnorm(v::AdjointAbsVec, q::Real) = q == Inf ? norm(conj(v.parent), 1) : norm(co
 opnorm(v::AdjointAbsVec) = norm(conj(v.parent))
 opnorm(v::TransposeAbsVec) = norm(v.parent)
 
-function opnormest1(A, t::Integer = min(2,maximum(size(A))))
+function opnormest1(A, t::Integer = min(2,maximum(size(A))), maxiter::Integer = 5)
     T = eltype(A)
-    maxiter = 5
     # Check the input
     n = checksquare(A)
     iszero(n) && return zero(T)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -939,24 +939,12 @@ function opnormest1(
         end
         if T <: Real
             # (2)
-            _each_col_has_parallel_col(S, S_old) && break
-            # Check whether cols of S are parallel to cols of S or S_old
+            iter >= 2 && _each_col_has_parallel_col(S, S_old) && break
+            # Randomly permute any cols of S that are parallel to cols of S or S_old
             for j = 1:t
-                while true
-                    repeated = false
-                    if j > 1 && _any_cols_are_parallel(S, j, S, 1:j-1)
-                        repeated = true
-                    end
-                    if !repeated
-                        if _any_cols_are_parallel(S, j, S_old, 1:t)
-                            repeated = true
-                        end
-                    end
-                    if repeated
-                        rand!(view(S,1:n,j), (-1, 1))
-                    else
-                        break
-                    end
+                while (j > 1 && _any_cols_are_parallel(S, j, S, 1:(j - 1))) ||
+                    (iter >= 2 && _any_cols_are_parallel(S, j, S_old, 1:t))
+                    rand!(view(S, 1:n, j), (-1, 1))
                 end
             end
         end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -947,7 +947,6 @@ function opnormest1(
                 end
             end
         end
-
         # (3)
         # Use the conjugate transpose
         Z = A' * S
@@ -984,7 +983,7 @@ function opnormest1(
         end
         union!(ind_hist, view(ind,1:t))
     end
-    ret = (est,)
+    ret = est
     # (6)
     if retv
         v = zeros(Ti, n)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -855,7 +855,7 @@ function opnormest1(
 
     Ti = typeof(float(zero(T)))
 
-    S = zeros(T <: Real ? Int : Ti, n, t)
+    S = zeros(Ti, n, t)
     S_old = copy(S)
     h = Vector{real(Base.promote_eltype(S, A))}(undef, n)
     p = Vector{Int64}(undef, n)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -833,6 +833,171 @@ opnorm(v::AdjointAbsVec, q::Real) = q == Inf ? norm(conj(v.parent), 1) : norm(co
 opnorm(v::AdjointAbsVec) = norm(conj(v.parent))
 opnorm(v::TransposeAbsVec) = norm(v.parent)
 
+function opnormest1(A, t::Integer = min(2,maximum(size(A))))
+    T = eltype(A)
+    maxiter = 5
+    # Check the input
+    n = checksquare(A)
+    if t <= 0
+        throw(ArgumentError("number of blocks must be a positive integer"))
+    end
+    if t > n
+        throw(ArgumentError("number of blocks must not be greater than $n"))
+    end
+    ind = Vector{Int64}(undef, n)
+    ind_hist = Vector{Int64}(undef, maxiter * t)
+
+    Ti = typeof(float(zero(T)))
+
+    S = zeros(T <: Real ? Int : Ti, n, t)
+
+    function _any_abs_eq(v,n::Int)
+        for vv in v
+            if abs(vv)==n
+                return true
+            end
+        end
+        return false
+    end
+
+    # Generate the block matrix
+    X = Matrix{Ti}(undef, n, t)
+    X[1:n,1] .= 1
+    for j = 2:t
+        while true
+            rand!(view(X,1:n,j), (-1, 1))
+            yaux = X[1:n,j]' * X[1:n,1:j-1]
+            if !_any_abs_eq(yaux,n)
+                break
+            end
+        end
+    end
+    rmul!(X, inv(n))
+
+    iter = 0
+    local est
+    local est_old
+    est_ind = 0
+    while iter < maxiter
+        iter += 1
+        Y = A * X
+        est = zero(real(eltype(Y)))
+        est_ind = 0
+        for i = 1:t
+            y = norm(Y[1:n,i], 1)
+            if y > est
+                est = y
+                est_ind = i
+            end
+        end
+        if iter == 1
+            est_old = est
+        end
+        if est > est_old || iter == 2
+            ind_best = est_ind
+        end
+        if iter >= 2 && est <= est_old
+            est = est_old
+            break
+        end
+        est_old = est
+        S_old = copy(S)
+        for j = 1:t
+            for i = 1:n
+                S[i,j] = Y[i,j]==0 ? one(Y[i,j]) : sign(Y[i,j])
+            end
+        end
+
+        if T <: Real
+            # Check whether cols of S are parallel to cols of S or S_old
+            for j = 1:t
+                while true
+                    repeated = false
+                    if j > 1
+                        saux = S[1:n,j]' * S[1:n,1:j-1]
+                        if _any_abs_eq(saux,n)
+                            repeated = true
+                        end
+                    end
+                    if !repeated
+                        saux2 = S[1:n,j]' * S_old[1:n,1:t]
+                        if _any_abs_eq(saux2,n)
+                            repeated = true
+                        end
+                    end
+                    if repeated
+                        rand!(view(S,1:n,j), (-1, 1))
+                    else
+                        break
+                    end
+                end
+            end
+        end
+
+        # Use the conjugate transpose
+        Z = A' * S
+        h_max = zero(real(eltype(Z)))
+        h = zeros(real(eltype(Z)), n)
+        h_ind = 0
+        for i = 1:n
+            h[i] = norm(Z[i,1:t], Inf)
+            if h[i] > h_max
+                h_max = h[i]
+                h_ind = i
+            end
+            ind[i] = i
+        end
+        if iter >=2 && ind_best == h_ind
+            break
+        end
+        p = sortperm(h, rev=true)
+        h = h[p]
+        permute!(ind, p)
+        if t > 1
+            addcounter = t
+            elemcounter = 0
+            while addcounter > 0 && elemcounter < n
+                elemcounter = elemcounter + 1
+                current_element = ind[elemcounter]
+                found = false
+                for i = 1:t * (iter - 1)
+                    if current_element == ind_hist[i]
+                        found = true
+                        break
+                    end
+                end
+                if !found
+                    addcounter = addcounter - 1
+                    for i = 1:current_element - 1
+                        X[i,t-addcounter] = 0
+                    end
+                    X[current_element,t-addcounter] = 1
+                    for i = current_element + 1:n
+                        X[i,t-addcounter] = 0
+                    end
+                    ind_hist[iter * t - addcounter] = current_element
+                else
+                    if elemcounter == t && addcounter == t
+                        break
+                    end
+                end
+            end
+        else
+            ind_hist[1:t] = ind[1:t]
+            for j = 1:t
+                for i = 1:ind[j] - 1
+                    X[i,j] = 0
+                end
+                X[ind[j],j] = 1
+                for i = ind[j] + 1:n
+                    X[i,j] = 0
+                end
+            end
+        end
+    end
+    return est
+end
+
 norm(v::Union{TransposeAbsVec,AdjointAbsVec}, p::Real) = norm(v.parent, p)
 
 """

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -942,7 +942,7 @@ function opnormest1(
             # Randomly permute any cols of S that are parallel to cols of S or S_old
             for j = 1:t
                 while (j > 1 && _any_cols_are_parallel(S, j, S, 1:(j - 1))) ||
-                    (iter >= 2 && _any_cols_are_parallel(S, j, S_old, 1:t))
+                      (iter >= 2 && _any_cols_are_parallel(S, j, S_old, 1:t))
                     rand!(view(S, 1:n, j), (-1, 1))
                 end
             end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -833,8 +833,9 @@ opnorm(v::AdjointAbsVec, q::Real) = q == Inf ? norm(conj(v.parent), 1) : norm(co
 opnorm(v::AdjointAbsVec) = norm(conj(v.parent))
 opnorm(v::TransposeAbsVec) = norm(v.parent)
 
-function opnormest1(A, t::Integer = min(2,maximum(size(A))), maxiter::Integer = 5)
+function opnormest1(A, t::Integer = min(2,maximum(size(A))))
     T = eltype(A)
+    maxiter = 5
     # Check the input
     n = checksquare(A)
     iszero(n) && return zero(T)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -852,6 +852,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
 
     S = zeros(T <: Real ? Int : Ti, n, t)
     S_old = copy(S)
+    h = Vector{real(Base.promote_eltype(S, A))}(undef, n)
 
     function _any_abs_eq(v,n::Int)
         for vv in v
@@ -937,8 +938,7 @@ function opnormest1(A, t::Integer = min(2,maximum(size(A))))
 
         # Use the conjugate transpose
         Z = A' * S
-        h_max = zero(real(eltype(Z)))
-        h = zeros(real(eltype(Z)), n)
+        h_max = zero(eltype(h))
         h_ind = 0
         for i = 1:n
             h[i] = normInf(view(Z,i,1:t))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1072,6 +1072,35 @@ function opnormestprod1(A, p::Integer)
     return opnormest1(ProductMat(repeat([A], p)))
 end
 
+# Linear operator representing inverse of a matrix
+# utility type for opnormestinv
+struct InvMat{T}
+    A::T
+end
+Base.eltype(M::InvMat) = eltype(M.A)
+Base.size(M::InvMat) = size(M.A)
+Base.:*(M::InvMat, X) = M.A \ X
+Base.adjoint(M::InvMat) = InvMat(adjoint(M.A))
+
+"""
+    opnormestinv1(A, args...)
+
+Estimate the operator 1-norm [`opnorm(inv(A), 1)`](@ref) of a matrix or linear operator
+`A` without computing the inverse.
+
+See [`opnormest1`](@ref) for a description of the arguments and return values.
+
+`A` can be of any type `Op`, representing a square matrix, that implements the following
+methods:
+- `size(A::Op)`
+- `eltype(A::Op)`
+- `\\(A::Op, B::AbstractMatrix)`
+- `adjoint(A::Op)`
+If `A` is an `AbstractMatrix`, it is passed to [`factorize`](@ref).
+"""
+opnormestinv1(A, args...) = opnormest1(InvMat(A), args...)
+opnormestinv1(A::AbstractMatrix, args...) = opnormest1(InvMat(factorize(A)), args...)
+
 norm(v::Union{TransposeAbsVec,AdjointAbsVec}, p::Real) = norm(v.parent, p)
 
 """

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -870,16 +870,17 @@ function opnormest2(
     m, n = size(A)
     A′ = A'
     c = float(T)(inv(sqrt(n)))
-    v = v_old = rand((-c, c), n)
+    v = rand((-c, c), n)
     w = A * v
     est = norm(w)
     est_old = oftype(est, Inf)
     for iter in 1:maxiter
-        v, v_old = A′ * w, v
-        vnorm = norm(v)
-        # stop if v_old and v are equal
-        vnorm ≤ real(dot(v, v_old)) && break
-        iszero(vnorm) || rmul!(v, inv(vnorm))
+        z = A′ * w
+        znorm = norm(z)
+        # stop if new v will equal old v
+        znorm ≤ real(dot(z, v)) && break
+        iszero(znorm) || rmul!(z, inv(znorm))
+        v = z
         w = A * v
         est, est_old = norm(w), est
         # stop if estimate has converged within tolerance

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -917,7 +917,7 @@ function opnormest1(
     h = Vector{real(Base.promote_type(Ti, T))}(undef, n)
 
     # Generate the block matrix
-    X = Matrix{Ti}(undef, n, t)
+    X = Matrix{real(Ti)}(undef, n, t)
     X[1:n,1] .= 1
     for j = 2:t
         while true

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -855,7 +855,7 @@ function _each_col_has_parallel_col(X, Y)
 end
 
 """
-    opnormest1(A, t::Integer = 2) -> est
+    opnormest1(A; t::Integer = 2) -> est
 
 Estimate the operator 1-norm [`opnorm(A, 1)`](@ref) of the matrix or linear operator `A`
 using a block algorithm.
@@ -882,9 +882,9 @@ methods:
 `t` is a parameter that sets the number of columns of a matrix that is multiplied by `A` and
 must not exceed the number of rows or columns of `A`.
 
-    opnormest1(A, t::Integer, retv::Val{true}) -> (est, v)
-    opnormest1(A, t::Integer, retv::Val{false}, retw::Val{true}) -> (est, w)
-    opnormest1(A, t::Integer, retv::Val{true}, retw::Val{true}) -> (est, v, w)
+    opnormest1(A, retv::Val{true}; t::Integer = 2) -> (est, v)
+    opnormest1(A, retv::Val{false}, retw::Val{true}; t::Integer = 2) -> (est, w)
+    opnormest1(A, retv::Val{true}, retw::Val{true}; t::Integer = 2) -> (est, v, w)
 
 Along with the estimate of the operator 1-norm, return a vector `v` and/or a vector `w` that
 correspond to the estimate, such that ``w = A v`` and
@@ -893,9 +893,9 @@ matrix 1-norm of `A`, and ``\\|⋅\\|`` is the Frobenius 1-[`norm`](@ref).
 """
 function opnormest1(
     A,
-    t::Integer=min(2,minimum(size(A))),
     ::Val{retv}=Val(false),
-    ::Val{retw}=Val(false),
+    ::Val{retw}=Val(false);
+    t::Integer=min(2,minimum(size(A))),
 ) where {retv,retw}
     T = eltype(A)
     maxiter = 5

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -882,9 +882,9 @@ function opnormest1(
 
     Ti = typeof(float(zero(T)))
 
-    S = zeros(Ti, n, t)
-    S_old = copy(S)
-    h = Vector{real(Base.promote_eltype(S, A))}(undef, n)
+    S_old = zeros(Ti, n, t)
+    S = Matrix{Ti}(undef, n, t)
+    h = Vector{real(Base.promote_type(Ti, T))}(undef, n)
     p = Vector{Int64}(undef, n)
 
     # Generate the block matrix
@@ -932,7 +932,7 @@ function opnormest1(
         end
         est_old = est
         iter > maxiter && break
-        copyto!(S_old, S)
+        S, S_old = S_old, S
         broadcast!(S, Y) do Yij
             Sij = sign(Yij)
             return ifelse(iszero(Sij), one(Sij), Sij)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1096,10 +1096,11 @@ methods:
 - `eltype(A::Op)`
 - `\\(A::Op, B::AbstractMatrix)`
 - `adjoint(A::Op)`
-If `A` is an `AbstractMatrix`, it is passed to [`factorize`](@ref).
+
+If `A` is an `AbstractMatrix`, it will be more efficient to pass its factorization
+to this function.
 """
 opnormestinv1(A, args...) = opnormest1(InvMat(A), args...)
-opnormestinv1(A::AbstractMatrix, args...) = opnormest1(InvMat(factorize(A)), args...)
 
 norm(v::Union{TransposeAbsVec,AdjointAbsVec}, p::Real) = norm(v.parent, p)
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -278,12 +278,18 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         @test abs(dot(w2, U[:,1])) ≈ est2
         @test abs(dot(v2, V[:,1])) ≈ 1
 
-        if T <: Real
-            # matrix with Asign * ones(n) = 0, so power iteration needs a new start
-            if (m, n) == (1, 10) || (m, n) == (10, 1)
+        if TOp <: Matrix
+            # A orthogonal to ones(n) = 0, so power iteration needs a new start
+            if (m, n) == (1, 10)
                 Asign = reshape([1, -1, 1, 1, -1, -1, 1, 1, -1, -1], m, n)
                 @test LinearAlgebra.opnormest2(TOp(Asign); tol=eps(real(T)), maxiter=1000) ≈ opnorm(Asign, 2)
             end
+
+            Azero = zeros(T, m, n)
+            est3, v3, w3 = LinearAlgebra.opnormest2(Azero, Val(true), Val(true))
+            @test iszero(est3)
+            @test v3 ≈ T[1; zeros(n-1)]
+            @test iszero(w3)
         end
     end
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -294,14 +294,14 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         nrm = opnorm(A, p)
         @test all(est -> est ≈ nrm || est < nrm, ests)
 
-        if T <: Real
+        if T <: Real && p in (1, Inf)
             # estimate is exact for positive matrix
             Apos = abs.(randn(T, m, n))
-            @test opnormest(TOp(Apos), p) ≈ opnorm(Apos, p) atol=(p==2 ? 1e-3 : 1e-8)
+            @test opnormest(TOp(Apos), p) ≈ opnorm(Apos, p)
 
             # estimate is exact for matrix with entries in {-1, 1}
             Asign = rand((-1, 1), m, n)
-            @test opnormest(TOp(Asign), p) ≈ opnorm(Asign, p) atol=(p==2 ? 1e-3 : 1e-8)
+            @test opnormest(TOp(Asign), p) ≈ opnorm(Asign, p)
         end
     end
 
@@ -321,9 +321,9 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         @test all(est -> est ≈ nrm || est < nrm, ests)
 
         # estimate is exact for positive matrix
-        if m == n
+        if m == n && p in (1, Inf)
             Apos = f(abs.(randn(m, n)))
-            @test opnormest(f, Apos, p) ≈ opnorm(f(Apos), p) atol=(p==2 ? 1e-3 : 1e-8)
+            @test opnormest(f, Apos, p) ≈ opnorm(f(Apos), p)
         end
 
         if f === inv
@@ -340,15 +340,17 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         nrm = opnorm(prod(As), p)
         @test all(est -> est ≈ nrm || est < nrm, ests)
 
-        # estimate is exact for positive matrix
-        Apos = abs.(randn(10, 10))
-        sqrtApos = sqrt(Apos)
-        @test opnormest(prod, [sqrtApos, sqrtApos], p) ≈ opnorm(Apos, p) atol=(p==2 ? 1e-3 : 1e-8)
+        if p in (1, Inf)
+            # estimate is exact for positive matrix
+            Apos = abs.(randn(10, 10))
+            sqrtApos = sqrt(Apos)
+            @test opnormest(prod, [sqrtApos, sqrtApos], p) ≈ opnorm(Apos, p)
 
-        # estimate is exact for matrix with entries in {-1, 1}
-        Asign = rand((-1, 1), 10, 10)
-        sqrtAsign = sqrt(Asign)
-        @test opnormest(prod, [sqrtAsign, sqrtAsign], p) ≈ opnorm(Asign, p) atol=(p==2 ? 1e-3 : 1e-8)
+            # estimate is exact for matrix with entries in {-1, 1}
+            Asign = rand((-1, 1), 10, 10)
+            sqrtAsign = sqrt(Asign)
+            @test opnormest(prod, [sqrtAsign, sqrtAsign], p) ≈ opnorm(Asign, p)
+        end
     end
 end
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -287,6 +287,7 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         A = randn(ComplexF64, 10, 10)
         @test_throws ArgumentError LinearAlgebra.opnormestinv1(A,0)
         @test_throws ArgumentError LinearAlgebra.opnormestinv1(A,11)
+        @test_throws DimensionMismatch LinearAlgebra.opnormestinv1(randn(3,5))
     end
 
     @testset "opnormestprod1" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -223,7 +223,7 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         A = randn(T, m, n)
         OpA = TOp(A)
         @inferred LinearAlgebra.opnormest1(OpA)
-        # estimates are probabilistic but bounded by opnorm
+        # estimates are bounded by opnorm
         ests = [LinearAlgebra.opnormest1(OpA) for _ in 1:100]
         nrm = opnorm(A, 1)
         @test all(est -> est ≈ nrm || est < nrm, ests)
@@ -251,7 +251,7 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         A = randn(T, m, n)
         OpA = TOp(A)
         @inferred LinearAlgebra.opnormest2(OpA)
-        # estimates are probabilistic but bounded by opnorm
+        # estimates are bounded by opnorm
         ests = [LinearAlgebra.opnormest2(OpA) for _ in 1:100]
         nrm = opnorm(A, 2)
         @test all(est -> est ≈ nrm || est < nrm, ests)
@@ -289,7 +289,7 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         A = randn(T, m, n)
         OpA = TOp(A)
         @inferred opnormest(OpA, p)
-        # estimates are probabilistic but bounded by opnorm
+        # estimates are bounded by opnorm
         ests = [opnormest(OpA, p) for _ in 1:100]
         nrm = opnorm(A, p)
         @test all(est -> est ≈ nrm || est < nrm, ests)
@@ -315,7 +315,7 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         m = f === pinv ? 20 : n
         A = randn(m, n)
         @inferred opnormest(f, A, p)
-        # estimates are probabilistic but bounded by opnorm
+        # estimates are bounded by opnorm
         ests = [opnormest(f, A, p) for _ in 1:100]
         nrm = opnorm(f(A), p)
         @test all(est -> est ≈ nrm || est < nrm, ests)
@@ -335,7 +335,7 @@ Base.adjoint(M::LinearOperator) = LinearOperator(adjoint(M.A))
         As = [randn(10, 2), randn(2, 10), randn(10, 11)]
         @inferred opnormest(prod, As, p)
 
-        # estimates are probabilistic but bounded by opnorm
+        # estimates are bounded by opnorm
         ests = [opnormest(prod, As, p) for _ in 1:100]
         nrm = opnorm(prod(As), p)
         @test all(est -> est ≈ nrm || est < nrm, ests)

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import LinearAlgebra: checksquare, sym_uplo
+import LinearAlgebra: checksquare, sym_uplo, opnormestinv1
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 const StridedOrTriangularMatrix{T} = Union{StridedMatrix{T}, LowerTriangular{T}, UnitLowerTriangular{T}, UpperTriangular{T}, UnitUpperTriangular{T}}
@@ -1161,21 +1161,13 @@ function cond(A::AbstractSparseMatrixCSC, p::Real=2)
     end
 end
 
-# utility type for opnormestinv
-struct InvMat{TF}
-    F::TF
-end
-InvMat(A::AbstractMatrix) = InvMat(factorize(A))
-Base.eltype(M::InvMat) = eltype(M.F)
-Base.size(M::InvMat) = size(M.F)
-Base.:*(M::InvMat, X) = M.F \ X
-function Base.adjoint(M::InvMat)
-    Ft = adjoint(M.F)
-    return InvMat{typeof(Ft)}(Ft)
+# this method exists to preserve old functionality
+function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
+    return opnormestinv1(A, t)
 end
 
-function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
-    return LinearAlgebra.opnormest1(InvMat(A), t)
+function opnormestinv1(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
+    return opnormestinv1(factorize(A), t)
 end
 
 ## kron

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import LinearAlgebra: checksquare, sym_uplo, opnormestinv1
+import LinearAlgebra: checksquare, sym_uplo, opnormest
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 const StridedOrTriangularMatrix{T} = Union{StridedMatrix{T}, LowerTriangular{T}, UnitLowerTriangular{T}, UpperTriangular{T}, UnitUpperTriangular{T}}
@@ -1147,11 +1147,11 @@ end
 # cond
 function cond(A::AbstractSparseMatrixCSC, p::Real=2)
     if p == 1
-        normAinv = opnormestinv1(A)
+        normAinv = opnormest(inv, A, 1)
         normA = opnorm(A, 1)
         return normA * normAinv
     elseif p == Inf
-        normAinv = opnormestinv1(A')
+        normAinv = opnormest(inv, A, Inf)
         normA = opnorm(A, Inf)
         return normA * normAinv
     elseif p == 2
@@ -1163,11 +1163,16 @@ end
 
 # this method exists to preserve old functionality
 function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
-    return opnormestinv1(A, t)
+    checksquare(A)
+    invA = LinearAlgebra.PInvLinearOperator(factorize(A))
+    return LinearAlgebra.opnormest1(invA; t = t)
 end
 
-function opnormestinv1(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
-    return opnormestinv1(factorize(A), t)
+function opnormest(::typeof(inv), A::AbstractSparseMatrixCSC, p::Real)
+    return opnormest(inv, factorize(A), p)
+end
+function opnormest(::typeof(pinv), A::AbstractSparseMatrixCSC, p::Real)
+    return opnormest(pinv, factorize(A), p)
 end
 
 ## kron

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1147,7 +1147,7 @@ end
 # cond
 function cond(A::AbstractSparseMatrixCSC, p::Real=2)
     if p == 1
-        normAinv = opnormestinv(A)
+        normAinv = opnormestinv1(A)
         normA = opnorm(A, 1)
         return normA * normAinv
     elseif p == Inf

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1151,7 +1151,7 @@ function cond(A::AbstractSparseMatrixCSC, p::Real=2)
         normA = opnorm(A, 1)
         return normA * normAinv
     elseif p == Inf
-        normAinv = opnormestinv(copy(A'))
+        normAinv = opnormestinv1(A')
         normA = opnorm(A, Inf)
         return normA * normAinv
     elseif p == 2

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1168,10 +1168,10 @@ function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(siz
     return LinearAlgebra.opnormest1(invA; t = t)
 end
 
-function opnormest(::typeof(inv), A::AbstractSparseMatrixCSC, p::Real)
+function opnormest(::typeof(inv), A::AbstractSparseMatrixCSC, p::Real=2)
     return opnormest(inv, factorize(A), p)
 end
-function opnormest(::typeof(pinv), A::AbstractSparseMatrixCSC, p::Real)
+function opnormest(::typeof(pinv), A::AbstractSparseMatrixCSC, p::Real=2)
     return opnormest(pinv, factorize(A), p)
 end
 

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1168,10 +1168,10 @@ function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(siz
     return LinearAlgebra.opnormest1(invA; t = t)
 end
 
-function opnormest(::typeof(inv), A::AbstractSparseMatrixCSC, p::Real=2)
+function opnormest(::typeof(inv), A::AbstractSparseMatrixCSC, p::Real)
     return opnormest(inv, factorize(A), p)
 end
-function opnormest(::typeof(pinv), A::AbstractSparseMatrixCSC, p::Real=2)
+function opnormest(::typeof(pinv), A::AbstractSparseMatrixCSC, p::Real)
     return opnormest(pinv, factorize(A), p)
 end
 

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1161,8 +1161,8 @@ function cond(A::AbstractSparseMatrixCSC, p::Real=2)
     end
 end
 
-# this method exists to preserve old functionality
 function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
+    Base.depwarn("`SparseArrays.opnormestinv(A)` is deprecated, use `LinearAlgebra.opnormest(inv,A,1)` instead.", :opnormestinv)
     checksquare(A)
     invA = LinearAlgebra.PInvLinearOperator(factorize(A))
     return LinearAlgebra.opnormest1(invA; t = t)

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 import LinearAlgebra: checksquare, sym_uplo
-using Random: rand!
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 const StridedOrTriangularMatrix{T} = Union{StridedMatrix{T}, LowerTriangular{T}, UnitLowerTriangular{T}, UpperTriangular{T}, UnitUpperTriangular{T}}
@@ -1162,169 +1161,17 @@ function cond(A::AbstractSparseMatrixCSC, p::Real=2)
     end
 end
 
-function opnormestinv(A::AbstractSparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)))) where T
-    maxiter = 5
-    # Check the input
-    n = checksquare(A)
-    F = factorize(A)
-    if t <= 0
-        throw(ArgumentError("number of blocks must be a positive integer"))
-    end
-    if t > n
-        throw(ArgumentError("number of blocks must not be greater than $n"))
-    end
-    ind = Vector{Int64}(undef, n)
-    ind_hist = Vector{Int64}(undef, maxiter * t)
+# utility type for opnormestinv
+struct InvMat{TF<:Factorization}
+    F::TF
+end
+InvMat(A::AbstractMatrix) = InvMat(factorize(A))
+Base.eltype(M::InvMat) = eltype(M.F)
+Base.size(M::InvMat) = size(M.F)
+Base.:*(M::InvMat, X) = M.F \ X
 
-    Ti = typeof(float(zero(T)))
-
-    S = zeros(T <: Real ? Int : Ti, n, t)
-
-    function _any_abs_eq(v,n::Int)
-        for vv in v
-            if abs(vv)==n
-                return true
-            end
-        end
-        return false
-    end
-
-    # Generate the block matrix
-    X = Matrix{Ti}(undef, n, t)
-    X[1:n,1] .= 1
-    for j = 2:t
-        while true
-            rand!(view(X,1:n,j), (-1, 1))
-            yaux = X[1:n,j]' * X[1:n,1:j-1]
-            if !_any_abs_eq(yaux,n)
-                break
-            end
-        end
-    end
-    rmul!(X, inv(n))
-
-    iter = 0
-    local est
-    local est_old
-    est_ind = 0
-    while iter < maxiter
-        iter += 1
-        Y = F \ X
-        est = zero(real(eltype(Y)))
-        est_ind = 0
-        for i = 1:t
-            y = norm(Y[1:n,i], 1)
-            if y > est
-                est = y
-                est_ind = i
-            end
-        end
-        if iter == 1
-            est_old = est
-        end
-        if est > est_old || iter == 2
-            ind_best = est_ind
-        end
-        if iter >= 2 && est <= est_old
-            est = est_old
-            break
-        end
-        est_old = est
-        S_old = copy(S)
-        for j = 1:t
-            for i = 1:n
-                S[i,j] = Y[i,j]==0 ? one(Y[i,j]) : sign(Y[i,j])
-            end
-        end
-
-        if T <: Real
-            # Check whether cols of S are parallel to cols of S or S_old
-            for j = 1:t
-                while true
-                    repeated = false
-                    if j > 1
-                        saux = S[1:n,j]' * S[1:n,1:j-1]
-                        if _any_abs_eq(saux,n)
-                            repeated = true
-                        end
-                    end
-                    if !repeated
-                        saux2 = S[1:n,j]' * S_old[1:n,1:t]
-                        if _any_abs_eq(saux2,n)
-                            repeated = true
-                        end
-                    end
-                    if repeated
-                        rand!(view(S,1:n,j), (-1, 1))
-                    else
-                        break
-                    end
-                end
-            end
-        end
-
-        # Use the conjugate transpose
-        Z = F' \ S
-        h_max = zero(real(eltype(Z)))
-        h = zeros(real(eltype(Z)), n)
-        h_ind = 0
-        for i = 1:n
-            h[i] = norm(Z[i,1:t], Inf)
-            if h[i] > h_max
-                h_max = h[i]
-                h_ind = i
-            end
-            ind[i] = i
-        end
-        if iter >=2 && ind_best == h_ind
-            break
-        end
-        p = sortperm(h, rev=true)
-        h = h[p]
-        permute!(ind, p)
-        if t > 1
-            addcounter = t
-            elemcounter = 0
-            while addcounter > 0 && elemcounter < n
-                elemcounter = elemcounter + 1
-                current_element = ind[elemcounter]
-                found = false
-                for i = 1:t * (iter - 1)
-                    if current_element == ind_hist[i]
-                        found = true
-                        break
-                    end
-                end
-                if !found
-                    addcounter = addcounter - 1
-                    for i = 1:current_element - 1
-                        X[i,t-addcounter] = 0
-                    end
-                    X[current_element,t-addcounter] = 1
-                    for i = current_element + 1:n
-                        X[i,t-addcounter] = 0
-                    end
-                    ind_hist[iter * t - addcounter] = current_element
-                else
-                    if elemcounter == t && addcounter == t
-                        break
-                    end
-                end
-            end
-        else
-            ind_hist[1:t] = ind[1:t]
-            for j = 1:t
-                for i = 1:ind[j] - 1
-                    X[i,j] = 0
-                end
-                X[ind[j],j] = 1
-                for i = ind[j] + 1:n
-                    X[i,j] = 0
-                end
-            end
-        end
-    end
-    return est
+function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
+    return LinearAlgebra.opnormest1(InvMat(A), t)
 end
 
 ## kron

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1162,13 +1162,17 @@ function cond(A::AbstractSparseMatrixCSC, p::Real=2)
 end
 
 # utility type for opnormestinv
-struct InvMat{TF<:Factorization}
+struct InvMat{TF}
     F::TF
 end
 InvMat(A::AbstractMatrix) = InvMat(factorize(A))
 Base.eltype(M::InvMat) = eltype(M.F)
 Base.size(M::InvMat) = size(M.F)
 Base.:*(M::InvMat, X) = M.F \ X
+function Base.adjoint(M::InvMat)
+    Ft = adjoint(M.F)
+    return InvMat{typeof(Ft)}(Ft)
+end
 
 function opnormestinv(A::AbstractSparseMatrixCSC, t::Integer = min(2,maximum(size(A))))
     return LinearAlgebra.opnormest1(InvMat(A), t)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2031,13 +2031,13 @@ end
     Ari = ceil.(Int64, 100*Ar)
     if Base.USE_GPL_LIBS
         # NOTE: opnormestinv is probabilistic, so requires a fixed seed (set above in Random.seed!(1234))
-        @test (@test_deprecated SparseArrays.opnormestinv(Ac,3)) ≈ opnorm(inv(Array(Ac)),1) atol=1e-4
-        @test (@test_deprecated SparseArrays.opnormestinv(Aci,3)) ≈ opnorm(inv(Array(Aci)),1) atol=1e-4
-        @test (@test_deprecated SparseArrays.opnormestinv(Ar)) ≈ opnorm(inv(Array(Ar)),1) atol=1e-4
-        @test_throws ArgumentError (@test_deprecated SparseArrays.opnormestinv(Ac,0))
-        @test_throws ArgumentError (@test_deprecated SparseArrays.opnormestinv(Ac,21))
+        @test_deprecated SparseArrays.opnormestinv(Ac,3)
+        @test_deprecated SparseArrays.opnormestinv(Aci,3)
+        @test_deprecated SparseArrays.opnormestinv(Ar)
+        @test_deprecated SparseArrays.opnormestinv(Ac,0)
+        @test_deprecated SparseArrays.opnormestinv(Ac,21)
     end
-    @test_throws DimensionMismatch (@test_deprecated SparseArrays.opnormestinv(sprand(3,5,.9)))
+    @test_deprecated SparseArrays.opnormestinv(sprand(3,5,.9))
 end
 
 @testset "sparse matrix opnormest(inv, A[, p])" begin

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2040,6 +2040,23 @@ end
     @test_throws DimensionMismatch (@test_deprecated SparseArrays.opnormestinv(sprand(3,5,.9)))
 end
 
+@testset "sparse matrix opnormest(inv, A[, p])" begin
+    Ac = sprandn(20,20,.5) + im* sprandn(20,20,.5)
+    Aci = ceil.(Int64, 100*sprand(20,20,.5)) + im*ceil.(Int64, sprand(20,20,.5))
+    Ar = sprandn(20,20,.5)
+
+    @test opnormest(inv, Ac, 2) == opnormest(inv, Ac)
+
+    Base.USE_GPL_LIBS && @testset "p=$p" for p in (1,2,Inf)
+        # estimates are bounded by opnorm
+        for A in (Ac, Aci, Ar)
+            ests = [opnormest(inv, A, p) for _ in 1:100]
+            nrm = opnorm(inv(Array(A)), p)
+            @test all(est -> est ≈ nrm || est < nrm, ests)
+        end
+    end
+end
+
 @testset "issue #13008" begin
     @test_throws ArgumentError sparse(Vector(1:100), Vector(1:100), fill(5,100), 5, 5)
     @test_throws ArgumentError sparse(Int[], Vector(1:5), Vector(1:5))

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2040,20 +2040,16 @@ end
     @test_deprecated SparseArrays.opnormestinv(sprand(3,5,.9))
 end
 
-@testset "sparse matrix opnormest(inv, A[, p])" begin
+Base.USE_GPL_LIBS && @testset "sparse matrix opnormest(inv, A, $p)" for p in (1,2,Inf)
     Ac = sprandn(20,20,.5) + im* sprandn(20,20,.5)
     Aci = ceil.(Int64, 100*sprand(20,20,.5)) + im*ceil.(Int64, sprand(20,20,.5))
     Ar = sprandn(20,20,.5)
 
-    @test opnormest(inv, Ac, 2) == opnormest(inv, Ac)
-
-    Base.USE_GPL_LIBS && @testset "p=$p" for p in (1,2,Inf)
-        # estimates are bounded by opnorm
-        for A in (Ac, Aci, Ar)
-            ests = [opnormest(inv, A, p) for _ in 1:100]
-            nrm = opnorm(inv(Array(A)), p)
-            @test all(est -> est ≈ nrm || est < nrm, ests)
-        end
+    # estimates are bounded by opnorm
+    for A in (Ac, Aci, Ar)
+        ests = [opnormest(inv, A, p) for _ in 1:100]
+        nrm = opnorm(inv(Array(A)), p)
+        @test all(est -> est ≈ nrm || est < nrm, ests)
     end
 end
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2031,13 +2031,13 @@ end
     Ari = ceil.(Int64, 100*Ar)
     if Base.USE_GPL_LIBS
         # NOTE: opnormestinv is probabilistic, so requires a fixed seed (set above in Random.seed!(1234))
-        @test SparseArrays.opnormestinv(Ac,3) ≈ opnorm(inv(Array(Ac)),1) atol=1e-4
-        @test SparseArrays.opnormestinv(Aci,3) ≈ opnorm(inv(Array(Aci)),1) atol=1e-4
-        @test SparseArrays.opnormestinv(Ar) ≈ opnorm(inv(Array(Ar)),1) atol=1e-4
-        @test_throws ArgumentError SparseArrays.opnormestinv(Ac,0)
-        @test_throws ArgumentError SparseArrays.opnormestinv(Ac,21)
+        @test (@test_deprecated SparseArrays.opnormestinv(Ac,3)) ≈ opnorm(inv(Array(Ac)),1) atol=1e-4
+        @test (@test_deprecated SparseArrays.opnormestinv(Aci,3)) ≈ opnorm(inv(Array(Aci)),1) atol=1e-4
+        @test (@test_deprecated SparseArrays.opnormestinv(Ar)) ≈ opnorm(inv(Array(Ar)),1) atol=1e-4
+        @test_throws ArgumentError (@test_deprecated SparseArrays.opnormestinv(Ac,0))
+        @test_throws ArgumentError (@test_deprecated SparseArrays.opnormestinv(Ac,21))
     end
-    @test_throws DimensionMismatch SparseArrays.opnormestinv(sprand(3,5,.9))
+    @test_throws DimensionMismatch (@test_deprecated SparseArrays.opnormestinv(sprand(3,5,.9)))
 end
 
 @testset "issue #13008" begin


### PR DESCRIPTION
This PR adds ~three~ methods:
- `opnormest1(A)`: lower-bound estimate of `opnorm(A, 1)`
- ~`opnormestprod1(As...)`/`opnormestprod1(A,p::Integer)`: lower-bound estimate of `opnorm(prod(As), 1)`~
- ~`opnormestinv1(A)`: lower-bound estimate of `opnorm(inv(A), 1)`~

The implementation of `opnormest1` comes from the [paper by Higham and Tisseur](http://eprints.maths.manchester.ac.uk/321/). It is especially useful when computing the actions of matrix functions (e.g. `exp(A)*b`) for large and sparse `A`. Edit: It also works on any object that implements a minimal interface of a linear operator.

There was already an implementation of ~`opnormestinv1`~ `opnormest(inv, A, 1)` (called `opnormestinv(A)`) in SparseArrays which served as the starting point for this implementation and is now superseded. From a quick scan, future PRs could make use of this estimate for computing condition numbers and for speeding up the matrix logarithm, which currently calls `opnorm(A^p, 1)` for powers of 1 through 5. Even for a dense `A`, the estimate is faster and on my machine gives a 20% speed-up for a large matrix. Edit: this implementation also minimizes the number of allocations, which causes a substantial speed-up

I've marked this as RFC because I'm not very satisfied with the interface thus far, in particular the interface to return vectors corresponding to the estimate (see docstrings).

Edit: I've added the `opnormest` function which is exported. The public interface is now:
- `opnormest(A, p=2)`: estimate `opnorm(A, p)`
- `opnormest(f, A, p=2)`: estimate `opnorm(f(A), p)` for certain `f` (`pinv`, `inv`, and `prod` already supported). While clean, this interface is not very extensible. e.g., if we want to support `f(A) = A^n` or `f(A) = A^(-n)`, there's not an obvious existing `f` we can use (except maybe `Base.Fix2`, but we would need to add `^(n::Integer) = Base.Fix2(^, n)` to make it user-friendly).

I also added a power iteration method for estimating the 2-norm, which I believe is the approach matlab's `normest` function uses.

Relates JuliaLang/julia#12609, JuliaLang/LinearAlgebra.jl#232