### PR TITLE
fix inf rational

### DIFF
--- a/test/rational.jl
+++ b/test/rational.jl
@@ -116,6 +116,14 @@ using Test
     @test abs(one(Rational{UInt})) === one(Rational{UInt})
     @test abs(one(Rational{Int})) === one(Rational{Int})
     @test abs(-one(Rational{Int})) === one(Rational{Int})
+
+    # inf addition
+    @test 1//0 + 1//0 == 1//0
+    @test -1//0 - 1//0 == -1//0
+    @test_throws DivideError 1//0 - 1//0
+    @test_throws DivideError -1//0 + 1//0
+    @test Int128(1)//0 + 1//0 isa Rational{Int128}
+    @test 1//0 + Int128(1)//0 isa Rational{Int128}    
 end
 
 @testset "Rational methods" begin

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -123,7 +123,7 @@ using Test
     @test_throws DivideError 1//0 - 1//0
     @test_throws DivideError -1//0 + 1//0
     @test Int128(1)//0 + 1//0 isa Rational{Int128}
-    @test 1//0 + Int128(1)//0 isa Rational{Int128}    
+    @test 1//0 + Int128(1)//0 isa Rational{Int128}
 end
 
 @testset "Rational methods" begin


### PR DESCRIPTION
This PR fixes inf addition with rational numbers, so that `Inf + Inf == Inf` and `-Inf -Inf == -Inf`, with appropriate promotions.
The behaviour that would yield a NaN in floating points remains unchanged and throws the DivideError