### PR TITLE
Fix jl_new_task to avoid allocating stack twice

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -679,6 +679,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
         else {
             t->bufsz = JL_STACK_SIZE;
         }
+        t->stkbuf = NULL;
     }
     else {
         // user requested dedicated stack of a certain size
@@ -704,7 +705,6 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->sticky = 1;
     t->gcstack = NULL;
     t->excstack = NULL;
-    t->stkbuf = NULL;
     t->started = 0;
     t->prio = -1;
     t->tid = -1;


### PR DESCRIPTION
If the user requested dedicated stack of a certain size, then `jl_new_task` immediately allocates the stack by invoking `jl_alloc_fiber`.

However, it also later nulls `t->stkbuf`. As a result, `ctx_switch` invokes `jl_alloc_fiber` *again* to allocate another stack.

An alternate fix (assuming my explanation above is even correct...) might be to not pre-allocate the stack here, and leave that to `ctx_switch`.

Resolves #36361