### PR TITLE
Remove unused jl_get_ptls_states_wrapper, update comments

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -142,12 +142,10 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
 // We use the faster static version in the main executable to replace
 // the slower version in the shared object. The code in different libraries
 // or executables, however, have to agree on which version to use.
-// The general solution is to add one more indirection in the C entry point
-// (see `jl_get_ptls_states_wrapper`).
+// The general solution is to add one more indirection in the C entry point.
 //
 // When `ifunc` is available, we can use it to trick the linker to use the
 // real address (`jl_get_ptls_states_static`) directly as the symbol address.
-// (see `jl_get_ptls_states_resolve`).
 //
 // However, since the detection of the static version in `ifunc`
 // is not guaranteed to be reliable, we still need to fallback to the wrapper
@@ -182,13 +180,6 @@ static jl_ptls_t jl_get_ptls_states_init(void)
 #  endif
     jl_tls_states_cb = cb;
     return cb();
-}
-
-static JL_CONST_FUNC jl_ptls_t jl_get_ptls_states_wrapper(void) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT
-{
-#ifndef __clang_analyzer__
-    return (*jl_tls_states_cb)();
-#endif
 }
 
 JL_DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f)


### PR DESCRIPTION
Since jl_get_ptls_states_wrapper is static, it can't be called by outside code.

For some context: that function and the comments were added in as part of an optimization in PR #17220 by @yuyichao, but the code accessing it was removed in PR #38160 by @staticfloat.

I am not sure how much of the remaining comment is actually accurate, perhaps more of it ought to be removed.

Resolves #38924