### PR TITLE
Add range(start => stop, length)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -95,16 +95,15 @@ range(start, stop; length::Union{Integer,Nothing}=nothing, step=nothing) =
     _range2(start, step, stop, length)
 
 """
-    range(start => stop[, length=2])
+    range(start => stop, length)
 
-Given a `start` to `stop` [`Pair`](@ref) and an optional integer `length`,
+Given a `start` to `stop` [`Pair`](@ref) and an integer `length`,
 construct a range iterator of `length` elements whose first element is `start`
-and last element is `stop`. If `length` is not provided, the range will consist
-of two elements.
+and last element is `stop`.
 
 This is distinct from `start:stop` where `stop` may not be the last
-element. Also, in this form `step` is not assumed to be 1. `length` cannot be
-`nothing`.
+element. Also, in this form `step` is not assumed to be 1. `length` must be an
+`Integer` and cannot be `nothing`.
 
 No keywords are accepted when `start` and `stop` are provided as a [`Pair`](@ref).
 
@@ -122,21 +121,15 @@ julia> range(1 => 5, 3)
 julia> range(0 => 100, 101)
 0.0:1.0:100.0
 
-julia> range(1 => 10)
-1.0:9.0:10.0
-
-julia> range(1 => 1.5)
-1.0:0.5:1.5
-
-julia> range(5 => 3)
-5.0:-2.0:3.0
-
 julia> range(5 => 3, 3)
 5.0:-1.0:3.0
 ```
 """
-range(start_stop::Pair, length::Integer=2) =
+range(start_stop::Pair, length::Integer) =
     _range(start_stop.first, nothing, start_stop.second, length)
+
+range(start_stop::Pair) =
+    throw(ArgumentError("`length` must be specified after $start_stop"))
 
 _range2(start, ::Nothing, stop, ::Nothing) =
     throw(ArgumentError("At least one of `length` or `step` must be specified"))

--- a/base/range.jl
+++ b/base/range.jl
@@ -120,13 +120,19 @@ julia> range(1 => 5, 3)
 1.0:2.0:5.0
 
 julia> range(0 => 100, 101)
-0.0:1.0:100.0)
+0.0:1.0:100.0
 
 julia> range(1 => 10)
 1.0:9.0:10.0
 
 julia> range(1 => 1.5)
 1.0:0.5:1.5
+
+julia> range(5 => 3)
+5.0:-2.0:3.0
+
+julia> range(5 => 3, 3)
+5.0:-1.0:3.0
 ```
 """
 range(start_stop::Pair, length::Integer=2) =

--- a/base/range.jl
+++ b/base/range.jl
@@ -128,7 +128,7 @@ julia> range(5 => 3, 3)
 range(start_stop::Pair, length::Integer) =
     _range(start_stop.first, nothing, start_stop.second, length)
 
-range(start_stop::Pair) =
+range(start_stop::Pair, length::Nothing = nothing) =
     throw(ArgumentError("`length` must be specified after $start_stop"))
 
 _range2(start, ::Nothing, stop, ::Nothing) =

--- a/base/range.jl
+++ b/base/range.jl
@@ -94,6 +94,44 @@ range(start; length::Union{Integer,Nothing}=nothing, stop=nothing, step=nothing)
 range(start, stop; length::Union{Integer,Nothing}=nothing, step=nothing) =
     _range2(start, step, stop, length)
 
+"""
+    range(start => stop[, length=2])
+
+Given a `start` to `stop` [`Pair`](@ref) and an optional integer `length`,
+construct a range iterator of `length` elements whose first element is `start`
+and last element is `stop`. If `length` is not provided, the range will consist
+of two elements.
+
+This is distinct from `start:stop` where `stop` may not be the last
+element. Also, in this form `step` is not assumed to be 1. `length` cannot be
+`nothing`.
+
+No keywords are accepted when `start` and `stop` are provided as a [`Pair`](@ref).
+
+Special care is taken to ensure intermediate values are computed rationally.
+To avoid this induced overhead, see the [`LinRange`](@ref) constructor.
+
+!!! compat "Julia 1.7"
+    Providing `start => stop` as a `Pair` requires at least Julia 1.7.
+
+# Examples
+```jldoctest
+julia> range(1 => 5, 3)
+1.0:2.0:5.0
+
+julia> range(0 => 100, 101)
+0.0:1.0:100.0)
+
+julia> range(1 => 10)
+1.0:9.0:10.0
+
+julia> range(1 => 1.5)
+1.0:0.5:1.5
+```
+"""
+range(start_stop::Pair, length::Integer=2) =
+    _range(start_stop.first, nothing, start_stop.second, length)
+
 _range2(start, ::Nothing, stop, ::Nothing) =
     throw(ArgumentError("At least one of `length` or `step` must be specified"))
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -101,11 +101,10 @@ Given a `start` to `stop` [`Pair`](@ref) and an integer `length`,
 construct a range iterator of `length` elements whose first element is `start`
 and last element is `stop`.
 
-This is distinct from `start:stop` where `stop` may not be the last
-element. Also, in this form `step` is not assumed to be 1. `length` must be an
-`Integer` and cannot be `nothing`.
-
-No keywords are accepted when `start` and `stop` are provided as a [`Pair`](@ref).
+In contrast to the [`:`](@ref) range syntaxes `start:stop` and `start:step:stop`,
+this method ensures the endpoints are hit exactly and a `length` must be provided.
+The `step` is always computed based upon the provided endpoints and length.
+In contrast to the other `range` methods, no keyword arguments are accepted.
 
 Special care is taken to ensure intermediate values are computed rationally.
 To avoid this induced overhead, see the [`LinRange`](@ref) constructor.

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1610,6 +1610,18 @@ end
     @test_throws ArgumentError range(1, 100)
 end
 
+@testset "range with start => stop Pair argument" begin
+    for starts in [-1, 0, 1, 10]
+        for stops in [-2, 0, 2, 100]
+            for lengths in [2, 10, 100]
+                @test range( starts => stops, lengths) === range(starts, stops; length = lengths)
+            end
+        end
+    end
+    @test_throws ArgumentError range( 1 => 5 )
+    @test_throws ArgumentError range( -1 => -5 , nothing )
+end
+
 @testset "Reverse empty ranges" begin
     @test reverse(1:0) === 0:-1:1
     @test reverse(Base.OneTo(0)) === 0:-1:1


### PR DESCRIPTION
The pull request creates a new form of `range` where `start` and `stop` are given as a `Pair` along with an integer `length`: `range(start => stop, length)`.

The idea for providing `start => stop` as a `Pair` originates with @mcabbott and @MasonProtter via [Zulip](https://julialang.zulipchat.com/#narrow/stream/137791-general/topic/range%28start.2C.20stop.2C.20length%29/near/220890377). Providing `start => stop` as a `Pair` has several advantages over other proposals:
1. The arguments `start` and `stop` provided as a `Pair` is distinct and can be easily distinguished from `length`.
2. Since the `start` and `stop` are provided as a separate type, allowing us to provide separate conventions due to multiple dispatch. This allows us to focus on `length` and frees us from having to assume `step = 1` if `length` is not provided _in a future pull request_.
3. In this form, `stop` is always included as the last element of the iteration.

<strike>Because of the default positional parameter `length=2`, this proposal also implements `range(start => stop)` which may differ from `start:stop` and `range(start; stop=stop)` since `step` is not assumed to be `1`.</strike>

This is an alternate option to pull request #39055 `range(start, stop, length)`. There `length` as positional argument has no default and a two argument `range(start,stop)` is not allowed. It is possible for this version to coexist with #39055 `range(start, stop, length)` if needed.

```julia
julia> Base.range(start_stop::Pair, length::Integer =
    Base._range(start_stop.first, nothing, start_stop.second, length)

julia> range(1 => 3.5, 26)
1.0:0.1:3.5

julia> range(1 => 3.5, 2)
1.0:2.5:3.5

julia> range(1; stop=3.5) # For contrast
1.0:1.0:3.0
```

Edit 2021/01/02: Fix attribution of using `Pair`

Edit 2021/01/03: Remove default `length` value of `2`. `length` is now required.