### PR TITLE
Remove outdated TODO about string encodings

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -141,9 +141,6 @@ end
 """
 abstract type AbstractMatch end
 
-# TODO: map offsets into strings in other encodings back to original indices.
-# or maybe it's better to just fail since that would be quite slow
-
 struct RegexMatch <: AbstractMatch
     match::SubString{String}
     captures::Vector{Union{Nothing,SubString{String}}}


### PR DESCRIPTION
This PR removes a TODO about mapping back to original indexes of regex for strings that are not in UTF-8.
At least that is how i understand it.
We are not going to support strings other than UTF-8 in Base any time soon.

That TODO has been there for 9 years.
https://github.com/JuliaLang/julia/commit/208642cec0ccf90ec199b9d7bf3b3cb5557e05d2