### PR TITLE
parameterize `store_backedges`

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -277,7 +277,7 @@ function _typeinf(interp::AbstractInterpreter, frame::InferenceState)
         if doopt && last(valid_worlds) == typemax(UInt)
             # if we aren't cached, we don't need this edge
             # but our caller might, so let's just make it anyways
-            store_backedges(caller, edges)
+            store_backedges(interp, caller, edges)
         end
     end
     return true
@@ -424,15 +424,15 @@ function finish(src::CodeInfo, interp::AbstractInterpreter)
 end
 
 # record the backedges
-function store_backedges(frame::InferenceResult, edges::Vector{Any})
+function store_backedges(interp::AbstractInterpreter, frame::InferenceResult, edges::Vector{Any})
     toplevel = !isa(frame.linfo.def, Method)
     if !toplevel
-        store_backedges(frame.linfo, edges)
+        store_backedges(interp, frame.linfo, edges)
     end
     nothing
 end
 
-function store_backedges(caller::MethodInstance, edges::Vector)
+function store_backedges(interp::AbstractInterpreter, caller::MethodInstance, edges::Vector{Any})
     i = 1
     while i <= length(edges)
         to = edges[i]


### PR DESCRIPTION
These changes aren't really needed for `NativeInterpreter`, but can help
other down stream interpreters subtyping `NativeInterpreter` register 
cache invalidation callbacks.

`MethodInstance.callbacks` can be used to invalidate their own caches,
and under the current interfaces, the best way to register a callback is
to inject code on the cache setter (`setindex!`) as [KernelCompiler.jl does](https://github.com/vchuravy/KernelCompiler.jl/blob/9840716189051220f6002c9b75b791fb14643fbc/src/codecache.jl#L23-L35).
But it needs to create our own cache type and can be complicated since
it `get(::CustomCache, mi::MethodInstance, default)` can be called in
[optimization phase](https://github.com/JuliaLang/julia/blob/5ee2d601edcf2dcdd467041ba9f08c43bf23e1a3/base/compiler/ssair/inlining.jl#L1415).

This PR parameterizes `store_backedges` and allows us to register
callbacks more easily.

---

/cc @vchuravy could you tell me what you think on this ?