### PR TITLE
RFC: allow ** as unary and binary operator

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -336,6 +336,9 @@ include("meta.jl")
 include("stacktraces.jl")
 using .StackTraces
 
+# experimental API's
+include("experimental.jl")
+
 # utilities
 include("deepcopy.jl")
 include("download.jl")
@@ -358,9 +361,6 @@ include("timing.jl")
 include("util.jl")
 
 include("asyncmap.jl")
-
-# experimental API's
-include("experimental.jl")
 
 # deprecated functions
 include("deprecated.jl")

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -159,14 +159,28 @@ showerror(io::IO, ex::UndefKeywordError) =
     print(io, "UndefKeywordError: keyword argument $(ex.var) not assigned")
 
 function showerror(io::IO, ex::UndefVarError)
-    if ex.var in [:UTF16String, :UTF32String, :WString, :utf16, :utf32, :wstring, :RepString]
-        return showerror(io, ErrorException("""
-        `$(ex.var)` has been moved to the package LegacyStrings.jl:
-        Run Pkg.add("LegacyStrings") to install LegacyStrings on Julia v0.5-;
-        Then do `using LegacyStrings` to get `$(ex.var)`.
-        """))
-    end
     print(io, "UndefVarError: $(ex.var) not defined")
+    Experimental.show_error_hints(io, ex)
+end
+
+# TODO: remove these hints?
+Experimental.register_error_hint(UndefVarError) do io::IO, ex::UndefVarError
+    if ex.var in [:UTF16String, :UTF32String, :WString, :utf16, :utf32, :wstring, :RepString]
+        println(io)
+        print(io, """
+            `$(ex.var)` has been moved to the package LegacyStrings.jl:
+            Run Pkg.add("LegacyStrings") to install LegacyStrings on Julia v0.5-;
+            Then do `using LegacyStrings` to get `$(ex.var)`.""")
+    end
+end
+
+# lets give a nice error if a poor Python/Fortran user types `**`
+Experimental.register_error_hint(UndefVarError) do io::IO, ex::UndefVarError
+    if ex.var === :(**)
+        println(io)
+        print(io, "Use `x^y` instead of `x**y` for exponentiation, and `x...` instead of" *
+            " `**x` for splatting.")
+    end
 end
 
 function showerror(io::IO, ex::InexactError)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -27,7 +27,7 @@
 ;; `where`
 ;; implicit multiplication (juxtaposition)
 ;; unary
-(define prec-power       (add-dots '(^ ↑ ↓ ⇵ ⟰ ⟱ ⤈ ⤉ ⤊ ⤋ ⤒ ⤓ ⥉ ⥌ ⥍ ⥏ ⥑ ⥔ ⥕ ⥘ ⥙ ⥜ ⥝ ⥠ ⥡ ⥣ ⥥ ⥮ ⥯ ￪ ￬)))
+(define prec-power       (add-dots '(^ ** ↑ ↓ ⇵ ⟰ ⟱ ⤈ ⤉ ⤊ ⤋ ⤒ ⤓ ⥉ ⥌ ⥍ ⥏ ⥑ ⥔ ⥕ ⥘ ⥙ ⥜ ⥝ ⥠ ⥡ ⥣ ⥥ ⥮ ⥯ ￪ ￬)))
 (define prec-decl        '(|::|))
 ;; `where` occurring after `::`
 (define prec-dot         '(|.|))
@@ -97,19 +97,19 @@
                                       0))
 
 (define unary-ops (append! '(|<:| |>:|)
-                           (add-dots '(+ - ! ~ ¬ √ ∛ ∜ ⋆ ± ∓))))
+                           (add-dots '(+ - ! ~ ¬ √ ∛ ∜ ⋆ ± ∓ **))))
 
 (define unary-op? (Set unary-ops))
 
 ; operators that are both unary and binary
 (define unary-and-binary-ops (append! '($ & ~)
-                                      (add-dots '(+ - ⋆ ± ∓))))
+                                      (add-dots '(+ - ⋆ ± ∓ **))))
 
 (define unary-and-binary-op? (Set unary-and-binary-ops))
 
 ; operators that are special forms, not function names
 (define syntactic-operators
-  (append! (add-dots '(= += -= *= /= //= |\\=| ^= ÷= %= <<= >>= >>>= |\|=| &= ⊻=))
+  (append! (add-dots '(= += -= *= /= //= |\\=| ^= ÷= %= <<= >>= >>>= |\|=| &= ⊻= **=))
            '(:= $= && |\|\|| |.| ... ->)))
 (define syntactic-unary-operators '($ & |::|))
 
@@ -229,8 +229,6 @@
 (define (op-or-sufchar? c) (or (op-suffix-char? c) (opchar? c)))
 
 (define (read-operator port c0 (postfix? #f))
-  (if (and (eqv? c0 #\*) (eqv? (peek-char port) #\*))
-      (error "use \"x^y\" instead of \"x**y\" for exponentiation, and \"x...\" instead of \"**x\" for splatting."))
   (if (or (eof-object? (peek-char port)) (not (op-or-sufchar? (peek-char port))))
       (symbol (string c0)) ; 1-char operator
       (let ((str (let loop ((str (string c0))

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -763,3 +763,5 @@ let err = nothing
         @test !occursin("2d", err_str)
     end
 end
+
+@test contains(sprint(Base.showerror, UndefVarError(:UTF16String)), "LegacyStrings")

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -277,3 +277,17 @@ end
 
 a = rand(3, 3)
 @test transpose(a) === a'ᵀ
+
+@testset "**" begin
+    @test contains(sprint(Base.showerror, UndefVarError(:(**))), "x^y")
+    let a**b = a^b
+        @test 2**3 == 8
+        a, b = 3, 4
+        @test a**b == a^b
+    end
+    let **a = -a
+        @test **2 == -2
+        a = 3
+        @test **a == -3
+    end
+end


### PR DESCRIPTION
I was wondering before whether the lexer was the right place to handle such a hint and wanted an operator with precedence like `^` before, which is easy to type as ASCII, and I don't see a major drawback to just allowing this. If people think this should be reserved for some other syntax feature, I can also just close this, but nothing really jumped to my mind.