### PR TITLE
RFC: Teach intersection that 4 != 5

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -180,7 +180,7 @@ static int egal_types(const jl_value_t *a, const jl_value_t *b, jl_typeenv_t *en
             return 0;
         if (!(egal_types(ua->var->lb, ub->var->lb, env, tvar_names) && egal_types(ua->var->ub, ub->var->ub, env, tvar_names)))
             return 0;
-        jl_typeenv_t e = { ua->var, (jl_value_t*)ub->var, env };
+        jl_typeenv_t e = { ua->var, (jl_value_t*)ub->var, 0, env };
         return egal_types(ua->body, ub->body, &e, tvar_names);
     }
     if (dt == jl_uniontype_type) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -823,11 +823,14 @@ static void jl_compilation_sig(
             int nsp = jl_svec_len(sparams);
             if (nsp > 0 && jl_has_free_typevars(lastdeclt)) {
                 assert(jl_subtype_env_size(decl) == nsp);
-                lastdeclt = jl_instantiate_type_in_env(lastdeclt, (jl_unionall_t*)decl, jl_svec_data(sparams));
+                lastdeclt = jl_instantiate_type_in_env(((jl_vararg_t*)lastdeclt)->T, (jl_unionall_t*)decl, jl_svec_data(sparams));
+                jl_svecset(limited, i, lastdeclt); // Root it
+                jl_svecset(limited, i, jl_wrap_vararg(lastdeclt, NULL));
                 // TODO: rewrap_unionall(lastdeclt, sparams) if any sparams isa TypeVar???
                 // TODO: if we made any replacements above, sparams may now be incorrect
+            } else {
+                jl_svecset(limited, i, lastdeclt);
             }
-            jl_svecset(limited, i, lastdeclt);
         }
         *newparams = limited;
         // now there is a problem: the widened signature is more

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1726,10 +1726,14 @@ static jl_value_t *inst_tuple_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_
         jl_value_t *ttN = jl_unwrap_vararg_num(va);
         jl_typeenv_t *e = env;
         while (e != NULL) {
-            if ((jl_value_t*)e->var == ttT)
+            if ((jl_value_t*)e->var == ttT) {
                 T = e->val;
-            else if ((jl_value_t*)e->var == ttN)
+            }
+            else if ((jl_value_t*)e->var == ttN) {
+                if (e->val_is_lb)
+                    break;
                 N = e->val;
+            }
             e = e->prev;
         }
         if (T != NULL && N != NULL && jl_is_long(N)) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1472,6 +1472,7 @@ JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b);
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n);
 JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n);
 JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a);
+JL_DLLEXPORT jl_svec_t *jl_svec_copy_resize(jl_svec_t *a, size_t n);
 JL_DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x);
 JL_DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v);
 JL_DLLEXPORT jl_sym_t *jl_symbol(const char *str) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -643,6 +643,7 @@ void jl_uv_flush(uv_stream_t *stream);
 typedef struct jl_typeenv_t {
     jl_tvar_t *var;
     jl_value_t *val;
+    int val_is_lb;
     struct jl_typeenv_t *prev;
 } jl_typeenv_t;
 
@@ -671,6 +672,7 @@ JL_DLLEXPORT int jl_type_morespecific_no_subtype(jl_value_t *a, jl_value_t *b);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
 JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals);
 jl_value_t *jl_substitute_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val);
+jl_value_t *jl_substitute_or_bound_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val, int is_bound);
 JL_DLLEXPORT jl_value_t *jl_unwrap_unionall(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u);
 int jl_count_union_components(jl_value_t *v);

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -79,6 +79,17 @@ JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a)
     return c;
 }
 
+JL_DLLEXPORT jl_svec_t *jl_svec_copy_resize(jl_svec_t *a, size_t n)
+{
+    size_t i, nold = jl_svec_len(a);
+    jl_svec_t *c = jl_alloc_svec_uninit(n);
+    for (i = 0; i < nold && i < n; i++)
+        jl_svecset(c, i, jl_svecref(a,i));
+    for (; i < n; i++)
+        jl_svec_data(c)[i] = NULL;
+    return c;
+}
+
 JL_DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x)
 {
     if (n == 0) return jl_emptysvec;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2020,3 +2020,8 @@ end
 #issue #43082
 struct X43082{A, I, B<:Union{Ref{I},I}}; end
 @testintersect(Tuple{X43082{T}, Int} where T, Tuple{X43082{Int}, Any}, Tuple{X43082{Int}, Int})
+
+# issue #39088
+@testintersect(Tuple{NTuple{N, Int}, NTuple{N, Int}} where N,
+               Tuple{Tuple{Int, Vararg{Any}}, NTuple{4, Int64}},
+               Tuple{NTuple{4, Int64}, NTuple{4, Int64}})

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2023,5 +2023,8 @@ struct X43082{A, I, B<:Union{Ref{I},I}}; end
 
 # issue #39088
 @testintersect(Tuple{NTuple{N, Int}, NTuple{N, Int}} where N,
-               Tuple{Tuple{Int, Vararg{Any}}, NTuple{4, Int64}},
-               Tuple{NTuple{4, Int64}, NTuple{4, Int64}})
+               Tuple{Tuple{Int, Vararg{Any}}, NTuple{4, Int}},
+               Tuple{NTuple{4, Int}, NTuple{4, Int}})
+@testintersect(Tuple{Vector, Vararg{Union{Int, Vector}, N}} where N,
+               Tuple{Any, Int, Vararg{Vector{Int}}},
+               Tuple{Vector, Union{Int, Vector{Int}}, Vararg{Union{Int, Vector{Int}}}}) # TODO: improve this bound


### PR DESCRIPTION
This one is very tricky, because we need to represent
"Vararg with at least n-elements", which we don't really
have a representation for. This just normalizes it to
Tuple{Vararg{T, N}} and stores an additional constraint
out of line that `N` must be greater or equal `n`. Then
if `N` is not resolved to an integer, we will normalize
this in a post processing step to e.g. `Tuple{T, T, Vararg{T, N}}`
(for `n == 2`). Eventually it might make sense to give `Vararg`
itself a lower bound. For now this seems to work ok, but
this code is very tricky, so we should PkgEval it before
merging.

Fix #39088