### PR TITLE
Fixes so that test suite can run in more tightly sandboxed environment

### DIFF
--- a/stdlib/Artifacts/test/.gitignore
+++ b/stdlib/Artifacts/test/.gitignore
@@ -1,1 +1,0 @@
-/artifacts/

--- a/stdlib/Artifacts/test/refresh_artifacts.jl
+++ b/stdlib/Artifacts/test/refresh_artifacts.jl
@@ -1,13 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Artifacts: with_artifacts_directory
-# using Pkg.Artifacts: ensure_all_artifacts_installed
 using Pkg.Artifacts: load_artifacts_toml, ensure_artifact_installed
 let
-    tempdir = joinpath(@__DIR__, "artifacts")
     toml = joinpath(@__DIR__, "Artifacts.toml")
     unused = Base.BinaryPlatforms.Platform(string(Sys.ARCH), "linux")
-    with_artifacts_directory(tempdir) do
+    with_artifacts_directory(ARGS[1]) do
         # ensure_all_artifacts_installed(toml; include_lazy=false)
         dict = load_artifacts_toml(toml)
         for (name, meta) in dict

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -4,7 +4,8 @@ using Artifacts, Test, Base.BinaryPlatforms
 using Artifacts: with_artifacts_directory, pack_platform!, unpack_platform
 
 # prepare for the package tests by ensuring the required artifacts are downloaded now
-run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifacts.jl"))`, "TERM"=>"dumb"))
+artifacts_dir = mktempdir()
+run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifacts.jl")) $(artifacts_dir)`, "TERM"=>"dumb"))
 
 @testset "Artifact Paths" begin
     mktempdir() do tempdir
@@ -81,8 +82,7 @@ end
 end
 
 @testset "Artifact Slash-indexing" begin
-    tempdir = joinpath(@__DIR__, "artifacts")
-    with_artifacts_directory(tempdir) do
+    with_artifacts_directory(artifacts_dir) do
         exeext = Sys.iswindows() ? ".exe" : ""
 
         # simple lookup, gives us the directory for `c_simple` for the current architecture
@@ -112,8 +112,7 @@ end
 end
 
 @testset "@artifact_str Platform passing" begin
-    tempdir = joinpath(@__DIR__, "artifacts")
-    with_artifacts_directory(tempdir) do
+    with_artifacts_directory(artifacts_dir) do
         win64 = Platform("x86_64", "windows")
         mac64 = Platform("x86_64", "macos")
         @test basename(@artifact_str("c_simple", win64)) == "444cecb70ff39e8961dd33e230e151775d959f37"

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -663,11 +663,14 @@ let s, c, r
     @test s[r] == "tmp"
 
     # This should match things that are inside the tmp directory
-    if !isdir("/tmp/tmp")
-        s = "/tmp/"
+    s = tempdir()
+    if !endswith(s, "/")
+        s = string(s, "/")
+    end
+    if !isdir(joinpath(s, "tmp"))
         c,r = test_scomplete(s)
         @test !("tmp/" in c)
-        @test r === 6:5
+        @test r === length(s) + 1:0
         @test s[r] == ""
     end
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -699,20 +699,22 @@ let s, c, r
     end
 
     # Tests homedir expansion
-    let path, s, c, r
-        path = homedir()
-        dir = joinpath(path, "tmpfoobar")
-        mkdir(dir)
-        s = "\"" * path * "/tmpfoob"
-        c,r = test_complete(s)
-        @test "tmpfoobar/" in c
-        l = 3 + length(path)
-        @test r == l:l+6
-        @test s[r] == "tmpfoob"
-        s = "\"~"
-        @test "tmpfoobar/" in c
-        c,r = test_complete(s)
-        rm(dir)
+    mktempdir() do tmphome
+        withenv("HOME" => tmphome, "USERPROFILE" => tmphome) do
+            path = homedir()
+            dir = joinpath(path, "tmpfoobar")
+            mkdir(dir)
+            s = "\"" * path * "/tmpfoob"
+            c,r = test_complete(s)
+            @test "tmpfoobar/" in c
+            l = 3 + length(path)
+            @test r == l:l+6
+            @test s[r] == "tmpfoob"
+            s = "\"~"
+            @test "tmpfoobar/" in c
+            c,r = test_complete(s)
+            rm(dir)
+        end
     end
 
     # Tests detecting of files in the env path (in shell mode)


### PR DESCRIPTION
We can't assume that we have write permissions everywhere; the home directory, the `stdlib` directory, etc... should not be written to during our test suite.  This PR adjusts things to more consistently write out to `$TMPDIR` instead of other places, and this enables running the test suite inside of tightened sandbox such as the one constructed here: https://github.com/staticfloat/MacOSSandboxExperiments/