### PR TITLE
fix part of #38936, getfield elim handling union of tuples

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -634,6 +634,9 @@ function getfield_elim_pass!(ir::IRCode)
         isa(field, Union{Int, Symbol}) || continue
 
         struct_typ = unwrap_unionall(widenconst(compact_exprtype(compact, stmt.args[2])))
+        if isa(struct_typ, Union) && struct_typ <: Tuple
+            struct_typ = unswitchtupleunion(struct_typ)
+        end
         isa(struct_typ, DataType) || continue
 
         def, typeconstraint = stmt.args[2], struct_typ

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -222,3 +222,21 @@ function improvable_via_constant_propagation(@nospecialize(t))
     end
     return false
 end
+
+# convert a Union of Tuple types to a Tuple of Unions
+function unswitchtupleunion(u::Union)
+    ts = uniontypes(u)
+    n = -1
+    for t in ts
+        if t isa DataType && t.name === Tuple.name && !isvarargtype(t.parameters[end])
+            if n == -1
+                n = length(t.parameters)
+            elseif n != length(t.parameters)
+                return u
+            end
+        else
+            return u
+        end
+    end
+    Tuple{Any[ Union{Any[t.parameters[i] for t in ts]...} for i in 1:n ]...}
+end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -352,3 +352,20 @@ let code = code_typed(pi_on_argument, Tuple{Any})[1].first.code,
     @test nisa == 1
     @test found_pi
 end
+
+# issue #38936
+# check that getfield elim can handle unions of tuple types
+mutable struct S38936{T} content::T end
+struct PrintAll{T} <: Function
+    parts::T
+end
+function (f::PrintAll)(io::IO)
+    for x in f.parts
+        print(io, x)
+    end
+end
+let f = PrintAll((S38936("<span>"), "data", S38936("</span")))
+    @test !any(code_typed(f, (IOBuffer,))[1][1].code) do stmt
+        stmt isa Expr && stmt.head === :call && stmt.args[1] === GlobalRef(Core, :tuple)
+    end
+end


### PR DESCRIPTION
This fixes the regression since 1.5, but not the slowdown due to removing `mutable` (which exists in multiple versions).