### PR TITLE
[release-1.6] NEWS and a doc fix for #36778

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,7 @@ Multi-threading changes
 
 * Locks now automatically inhibit finalizers from running, to avoid deadlock ([#38487]).
 * New function `Base.Threads.foreach(f, channel::Channel)` for multithreaded `Channel` consumption ([#34543]).
+* There is no longer a restriction on the number of threads ([#36778]).
 
 Build system changes
 --------------------

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -190,11 +190,9 @@ a master process to establish a connection before dying.
 ### [`JULIA_NUM_THREADS`](@id JULIA_NUM_THREADS)
 
 An unsigned 64-bit integer (`uint64_t`) that sets the maximum number of threads
-available to Julia. If `$JULIA_NUM_THREADS` exceeds the number of available
-CPU threads (logical cores), then the number of threads is set to the number of CPU threads. If
-`$JULIA_NUM_THREADS` is not positive or is not set, or if the number of CPU
-threads cannot be determined through system calls, then the number of threads is
-set to `1`.
+available to Julia. If `$JULIA_NUM_THREADS` is not positive or is not set, or if
+the number of CPU threads cannot be determined through system calls, then the number
+of threads is set to `1`.
 
 !!! note
 


### PR DESCRIPTION
This PR:
- Adds a NEWS entry for #36778
- Removes a sentence from the docs that was made obsolete by #36778