### PR TITLE
Remove try from at-time and close compile timer during throw

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -203,12 +203,9 @@ macro time(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        local val = try
-            $(esc(ex))
-        finally
-            elapsedtime = time_ns() - elapsedtime
-            compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
-        end
+        local val = $(esc(ex))
+        elapsedtime = time_ns() - elapsedtime
+        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
         local diff = GC_Diff(gc_num(), stats)
         time_print(elapsedtime, diff.allocd, diff.total_time, gc_alloc_count(diff), compile_elapsedtime, true)
         val
@@ -252,12 +249,9 @@ macro timev(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        local val = try
-            $(esc(ex))
-        finally
-            elapsedtime = time_ns() - elapsedtime
-            compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
-        end
+        local val = $(esc(ex))
+        elapsedtime = time_ns() - elapsedtime
+        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
         local diff = GC_Diff(gc_num(), stats)
         timev_print(elapsedtime, diff, compile_elapsedtime)
         val

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -482,6 +482,10 @@ JL_CALLABLE(jl_f_typeassert)
 JL_CALLABLE(jl_f_throw)
 {
     JL_NARGS(throw, 1, 1);
+    int tid = jl_threadid();
+    // @time needs its compile timer disabled on error,
+    // and cannot use a try-finally as it would break scope for assignments
+    jl_measure_compile_time[tid] = 0;
     jl_throw(args[0]);
     return jl_nothing;
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -482,10 +482,6 @@ JL_CALLABLE(jl_f_typeassert)
 JL_CALLABLE(jl_f_throw)
 {
     JL_NARGS(throw, 1, 1);
-    int tid = jl_threadid();
-    // @time needs its compile timer disabled on error,
-    // and cannot use a try-finally as it would break scope for assignments
-    jl_measure_compile_time[tid] = 0;
     jl_throw(args[0]);
     return jl_nothing;
 }

--- a/src/task.c
+++ b/src/task.c
@@ -584,6 +584,9 @@ static void JL_NORETURN throw_internal(jl_value_t *exception JL_MAYBE_UNROOTED)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     ptls->io_wait = 0;
+    // @time needs its compile timer disabled on error,
+    // and cannot use a try-finally as it would break scope for assignments
+    jl_measure_compile_time[ptls->tid] = 0;
     if (ptls->safe_restore)
         jl_longjmp(*ptls->safe_restore, 1);
     // During startup

--- a/test/core.jl
+++ b/test/core.jl
@@ -5080,6 +5080,19 @@ end
 @test f17255(10000)[1]
 GC.enable(true)
 
+# PR #39133, ensure that @time evaluates in the same scope
+function time_macro_scope()
+    @time time_macro_local_var = 1
+    time_macro_local_var
+end
+@test time_macro_scope() == 1
+
+function timev_macro_scope()
+    @timev timev_macro_local_var = 1
+    timev_macro_local_var
+end
+@time timev_macro_scope() == 1
+
 # issue #18710
 bad_tvars() where {T} = 1
 @test isa(which(bad_tvars, ()), Method)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/38915 accidentally swallowed assignments due to the try-finally scope
```
julia> @time x = 1
  0.000001 seconds
1
julia> x
ERROR: UndefVarError: x not defined
```

this removes the try and disables the timer during every `throw`
```
julia> @time x = 1
  0.000000 seconds
1

julia> x
1
```
And maintains the thread-locality introduced in https://github.com/JuliaLang/julia/pull/38915
```
julia> x = rand(3,3);

julia> Threads.@threads for i in 1:20 @time x * x; end
  0.652161 seconds (2.36 M allocations: 126.891 MiB, 16.46% gc time, 99.95% compilation time)
  0.655488 seconds (2.36 M allocations: 126.904 MiB, 16.38% gc time, 0.00% compilation time)
  0.652135 seconds (2.36 M allocations: 126.888 MiB, 16.46% gc time, 0.00% compilation time)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.655499 seconds (2.36 M allocations: 126.912 MiB, 16.38% gc time, 0.00% compilation time)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.655506 seconds (2.36 M allocations: 126.919 MiB, 16.37% gc time, 0.00% compilation time)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.653652 seconds (2.36 M allocations: 126.896 MiB, 16.42% gc time, 0.00% compilation time)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000002 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)


julia> @time error(ErrorException("hello"))
ERROR: ErrorException("hello")
Stacktrace:
 [1] error(s::ErrorException)
   @ Base ./error.jl:42
 [2] top-level scope
   @ ./timing.jl:206 [inlined]
 [3] top-level scope
   @ ./REPL[7]:0
```

cc. @vtjnash @ericphanson 