### PR TITLE
Core printing: improve show of method signatures

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1199,55 +1199,71 @@ JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOIN
 
 JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT
 {
+    size_t n = 0;
+    size_t i;
     jl_value_t *ftype = (jl_value_t*)jl_first_argument_datatype(type);
     if (ftype == NULL)
         return jl_static_show(s, type);
-    size_t n = 0;
+    jl_unionall_t *tvars = (jl_unionall_t*)type;
+    int nvars = jl_subtype_env_size(type);
+    struct recur_list *depth = NULL;
+    if (nvars > 0)  {
+        depth = (struct recur_list*)alloca(sizeof(struct recur_list) * nvars);
+        for (i = 0; i < nvars; i++) {
+            depth[i].prev = i == 0 ? NULL : &depth[i - 1];
+            depth[i].v = type;
+            type = ((jl_unionall_t*)type)->body;
+        }
+        depth += nvars - 1;
+    }
+    if (!jl_is_datatype(type)) {
+        n += jl_static_show(s, type);
+        return n;
+    }
     if (jl_nparams(ftype) == 0 || ftype == ((jl_datatype_t*)ftype)->name->wrapper) {
         n += jl_printf(s, "%s", jl_symbol_name(((jl_datatype_t*)ftype)->name->mt->name));
     }
     else {
         n += jl_printf(s, "(::");
-        n += jl_static_show(s, ftype);
+        n += jl_static_show_x(s, ftype, depth);
         n += jl_printf(s, ")");
-    }
-    jl_unionall_t *tvars = (jl_unionall_t*)type;
-    type = jl_unwrap_unionall(type);
-    if (!jl_is_datatype(type)) {
-        n += jl_printf(s, " ");
-        n += jl_static_show(s, type);
-        return n;
     }
     size_t tl = jl_nparams(type);
     n += jl_printf(s, "(");
-    size_t i;
     for (i = 1; i < tl; i++) {
         jl_value_t *tp = jl_tparam(type, i);
         if (i != tl - 1) {
-            n += jl_static_show(s, tp);
+            n += jl_static_show_x(s, tp, depth);
             n += jl_printf(s, ", ");
         }
         else {
-            if (jl_is_vararg(tp)) {
-                n += jl_static_show(s, jl_unwrap_vararg(tp));
+            if (jl_vararg_kind(tp) == JL_VARARG_UNBOUND) {
+                tp = jl_unwrap_vararg(tp);
+                if (jl_is_unionall(tp))
+                    n += jl_printf(s, "(");
+                n += jl_static_show_x(s, tp, depth);
+                if (jl_is_unionall(tp))
+                    n += jl_printf(s, ")");
                 n += jl_printf(s, "...");
             }
             else {
-                n += jl_static_show(s, tp);
+                n += jl_static_show_x(s, tp, depth);
             }
         }
     }
     n += jl_printf(s, ")");
     if (jl_is_unionall(tvars)) {
+        depth -= nvars - 1;
         int first = 1;
         n += jl_printf(s, " where {");
         while (jl_is_unionall(tvars)) {
-            if (first)
-                first = 0;
-            else
+            if (!first)
                 n += jl_printf(s, ", ");
-            n += jl_static_show(s, (jl_value_t*)tvars->var);
+            n += jl_static_show_x(s, (jl_value_t*)tvars->var, first ? NULL : depth);
             tvars = (jl_unionall_t*)tvars->body;
+            if (!first)
+                depth += 1;
+            first = 0;
         }
         n += jl_printf(s, "}");
     }


### PR DESCRIPTION
This adds their environment when printing, so that their TypeVars/UnionAll bounds will print correctly.