### PR TITLE
Time macros: use tryfinally macro approach

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -164,6 +164,14 @@ function timev_print(elapsedtime, diff::GC_Diff, compile_time)
     padded_nonzero_print(diff.full_sweep,   "full collections")
 end
 
+# Like a try-finally block, except without introducing the try scope
+macro tryfinally(ex, fin)
+    Expr(:tryfinally,
+       :($(esc(ex))),
+       :($(esc(fin)))
+       )
+end
+
 """
     @time
 

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -211,9 +211,10 @@ macro time(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        local val = $(esc(ex))
-        elapsedtime = time_ns() - elapsedtime
-        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+        local val = @tryfinally($(esc(ex)),
+            (elapsedtime = time_ns() - elapsedtime;
+            compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime)
+        )
         local diff = GC_Diff(gc_num(), stats)
         time_print(elapsedtime, diff.allocd, diff.total_time, gc_alloc_count(diff), compile_elapsedtime, true)
         val
@@ -257,9 +258,10 @@ macro timev(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        local val = $(esc(ex))
-        elapsedtime = time_ns() - elapsedtime
-        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+        local val = @tryfinally($(esc(ex)),
+            (elapsedtime = time_ns() - elapsedtime;
+            compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime)
+        )
         local diff = GC_Diff(gc_num(), stats)
         timev_print(elapsedtime, diff, compile_elapsedtime)
         val

--- a/src/task.c
+++ b/src/task.c
@@ -584,9 +584,6 @@ static void JL_NORETURN throw_internal(jl_value_t *exception JL_MAYBE_UNROOTED)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     ptls->io_wait = 0;
-    // @time needs its compile timer disabled on error,
-    // and cannot use a try-finally as it would break scope for assignments
-    jl_measure_compile_time[ptls->tid] = 0;
     if (ptls->safe_restore)
         jl_longjmp(*ptls->safe_restore, 1);
     // During startup


### PR DESCRIPTION
@KristofferC's suggestion in https://github.com/JuliaLang/julia/pull/39133 of the `@tryfinally` macro approach is a neat way to maintain scope while ensuring the finalizer is run

I verified that the finalizer is run in each of these:

```
julia> @time y = 1
  0.000005 seconds
1

julia> y
1

julia> @time error()
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:42
 [2] top-level scope
   @ ~/Documents/GitHub/julia/base/timing.jl:213 [inlined]
 [3] top-level scope
   @ ./REPL[31]:0

julia> x = rand(3,3);

julia> Threads.@threads for i in 1:20 @time x * x; end
  0.565114 seconds (2.36 M allocations: 126.880 MiB, 4.93% gc time, 99.95% compilation time)
  0.566743 seconds (2.36 M allocations: 126.893 MiB, 4.92% gc time, 0.00% compilation time)
  0.000002 seconds (1 allocation: 160 bytes)
  0.565122 seconds (2.36 M allocations: 126.882 MiB, 4.93% gc time, 0.00% compilation time)
  0.568685 seconds (2.36 M allocations: 126.907 MiB, 4.90% gc time, 0.00% compilation time)
  0.566732 seconds (2.36 M allocations: 126.890 MiB, 4.92% gc time, 0.00% compilation time)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
  0.565109 seconds (2.36 M allocations: 126.879 MiB, 4.93% gc time, 0.01% compilation time)
  0.000001 seconds (1 allocation: 160 bytes)
  0.000000 seconds (1 allocation: 160 bytes)
  0.000001 seconds (2 allocations: 192 bytes)
  0.000001 seconds (1 allocation: 160 bytes)
```



This new `@tryfinally` macro could be pretty useful! Perhaps in a future PR `@trycatch` could be added and both exported

```
julia> Base.@tryfinally(xx = 1, println("finalizer"))
finalizer
1

julia> xx
1

julia> Base.@tryfinally(error(), println("finalizer"))
finalizer
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:42
 [2] top-level scope
   @ REPL[37]:1

```