### PR TITLE
lowering: remove incorrect comprehension eta reduction

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1718,7 +1718,7 @@
      ((and (null? splat)
            (length= expr 3) (eq? (car expr) 'call)
            (eq? (caddr expr) argname)
-           (eq? '_ argname)
+           (underscore-symbol? argname)
            (not (dotop-named? (cadr expr)))
            (not (expr-contains-eq argname (cadr expr))))
       ;; eta reduce `_->f(_)` => `f`

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1714,12 +1714,14 @@
      ((eq? expr argname)
       ;; use `identity` for x->x
       `(top identity))
+      ;; TODO: deprecate this (#18621):
      ((and (null? splat)
            (length= expr 3) (eq? (car expr) 'call)
            (eq? (caddr expr) argname)
+           (eq? '_ argname)
            (not (dotop-named? (cadr expr)))
            (not (expr-contains-eq argname (cadr expr))))
-      ;; eta reduce `x->f(x)` => `f`
+      ;; eta reduce `_->f(_)` => `f`
       (cadr expr))
      (else
       (let ((expr (cond ((and flat (pair? expr) (eq? (car expr) 'generator))

--- a/test/core.jl
+++ b/test/core.jl
@@ -7541,3 +7541,12 @@ const RedefineVarargN{N} = Tuple{Vararg{RedefineVararg, N}}
 
 # NTuples with non-types
 @test NTuple{3, 2} == Tuple{2, 2, 2}
+
+# issue #18621
+function f18621()
+   g = (k(i) for i in 1:5)
+   k = identity
+   return collect(g)
+end
+@test f18621() == 1:5
+@test [_ for _ in 1:5] == 1:5


### PR DESCRIPTION
But keep it for `[f(_) for _ in x]`, since that would now triggers a
deprecation error (which was previously incorrectly missing for _).

Fixes #18621