### PR TITLE
Allow kwarg in function composition 

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -900,7 +900,7 @@ julia> [1:5;] |> x->x.^2 |> sum |> inv
 """
     f ∘ g
 
-Compose functions: i.e. `(f ∘ g)(args...)` means `f(g(args...))`. The `∘` symbol can be
+Compose functions: i.e. `(f ∘ g)(args...; kwargs...)` means `f(g(args...; kwargs...))`. The `∘` symbol can be
 entered in the Julia REPL (and most editors, appropriately configured) by typing `\\circ<tab>`.
 
 Function composition also works in prefix form: `∘(f, g)` is the same as `f ∘ g`.
@@ -912,7 +912,9 @@ and splatting `∘(fs...)` for composing an iterable collection of functions.
 
 !!! compat "Julia 1.5"
     Composition of one function ∘(f) requires at least Julia 1.5.
-    Composition of one function ∘(f)  requires at least Julia 1.5.
+
+!!! compat "Julia 1.7"
+    Using keyword arguments requires at least Julia 1.7.
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -973,7 +973,7 @@ struct ComposedFunction{O,I} <: Function
     ComposedFunction(outer, inner) = new{Core.Typeof(outer),Core.Typeof(inner)}(outer, inner)
 end
 
-(c::ComposedFunction)(x...) = c.outer(c.inner(x...))
+(c::ComposedFunction)(x...; kw...) = c.outer(c.inner(x...; kw...))
 
 ∘(f) = f
 ∘(f, g) = ComposedFunction(f, g)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -911,6 +911,7 @@ and splatting `∘(fs...)` for composing an iterable collection of functions.
     Multiple function composition requires at least Julia 1.4.
 
 !!! compat "Julia 1.5"
+    Composition of one function ∘(f) requires at least Julia 1.5.
     Composition of one function ∘(f)  requires at least Julia 1.5.
 
 # Examples

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -160,6 +160,11 @@ Base.promote_rule(::Type{T19714}, ::Type{Int}) = T19714
 
     @test repr(uppercase ∘ first) == "uppercase ∘ first"
     @test sprint(show, "text/plain", uppercase ∘ first) == "uppercase ∘ first"
+
+    # test keyword ags in composition
+    function kwf(a;b,c); a + b + c; end
+    @test (abs2 ∘ kwf)(1,b=2,c=3) == 36
+
 end
 
 @testset "function negation" begin


### PR DESCRIPTION
closes #38351

This pull request would allow kwargs in functions that are composed with `∘` (a `ComposedFunction`). This is my first commit to Julia base.

The compat note in the docstring assumes that this change would make it into 1.7.

Needs:
 - [x] test case
 - [x] docstring update