### PR TITLE
Fix macos codesign workflow

### DIFF
--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -52,7 +52,7 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	find $@/Contents/Resources/julia -type f -exec chmod -w {} \;
 	if [ -n "$$MACOS_CODESIGN_IDENTITY" ]; then \
 	    echo "Codesigning with identity $$MACOS_CODESIGN_IDENTITY"; \
-		MACHO_FILES=$$(find "$@" -type f -perm -755 | cut -d: -f1); \
+		MACHO_FILES=$$(find "$@" -type f -perm -0111 | cut -d: -f1); \
 		for f in $${MACHO_FILES}; do \
 			echo "Codesigning $${f}..."; \
 			codesign -s "$$MACOS_CODESIGN_IDENTITY" --option=runtime --entitlements Entitlements.plist -vvv --timestamp --deep --force "$${f}"; \


### PR DESCRIPTION
We changed the permissions on executable files which caused this `find`
to not find any of the actual binaries that we need to sign.  Change it
to instead find anything with any executable permissions set, rather
than ones with exactly the permissions `0755`