### PR TITLE
fix logdet(Diagonal{<:Real}) with negative entries

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -595,7 +595,6 @@ function diag(D::Diagonal, k::Integer=0)
 end
 tr(D::Diagonal) = sum(tr, D.diag)
 det(D::Diagonal) = prod(det, D.diag)
-logdet(D::Diagonal{<:Real}) = sum(log, D.diag)
 function logdet(D::Diagonal{<:Complex}) # make sure branch cut is correct
     z = sum(log, D.diag)
     complex(real(z), rem2pi(imag(z), RoundNearest))

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -361,6 +361,8 @@ Random.seed!(1)
         d2, s2 = logabsdet(lM)
         @test d1 ≈ d2
         @test s1 == s2
+        @test logdet(Diagonal(relty[-1,-2])) ≈ log(2)
+        @test_throws DomainError logdet(Diagonal(relty[-1,-2,-3]))
     end
 
     @testset "similar" begin


### PR DESCRIPTION
Previously this was an error even though it shouldn't be:

```julia
julia> logdet(Diagonal([-1,-2]))
ERROR: DomainError with -1.0:
```

Removing the specialized method and falling back to the [generic](https://github.com/JuliaLang/julia/blob/8937f7e522c9b3f96920d2f196f452c9f8a9e248/stdlib/LinearAlgebra/src/generic.jl#L1620-L1623) gives the right answer and should be just as performant since it still calls `logabsdet(A::Diagonal)`. 