### PR TITLE
Add IteratorIndexable trait

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -148,7 +148,7 @@ The default value (for iterators that do not define this function) is `NotIndexa
 
 ```jldoctest
 julia> Base.IteratorIndexable([1,2,3])
-Base.HasEachIndex{Base.OneTo{$Int}}
+Base.HasEachIndex{Base.OneTo{$Int}}()
 
 julia> Base.IteratorIndexable(Ref(1))
 Base.Indexable()

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -261,6 +261,7 @@ end
 
 IteratorSize(::Type{<:Pairs{<:Any, <:Any, I}}) where {I} = IteratorSize(I)
 IteratorSize(::Type{<:Pairs{<:Any, <:Any, <:Base.AbstractUnitRange, <:Tuple}}) = HasLength()
+EachIndexSupport(::Type{<:Pairs}) = HasEachIndex()
 
 reverse(v::Pairs) = Pairs(v.data, reverse(v.itr))
 

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -235,6 +235,8 @@ struct SkipMissing{T}
 end
 IteratorSize(::Type{<:SkipMissing}) = SizeUnknown()
 IteratorEltype(::Type{SkipMissing{T}}) where {T} = IteratorEltype(T)
+IteratorIndexable(::Type{SkipMissing{T}}) where T = IteratorIndexable(T)
+EachIndexSupport(::Type{SkipMissing{T}}) where T = EachIndexSupport(T)
 eltype(::Type{SkipMissing{T}}) where {T} = nonmissingtype(eltype(T))
 
 function iterate(itr::SkipMissing, state...)

--- a/base/process.jl
+++ b/base/process.jl
@@ -641,3 +641,6 @@ eltype(::Type{Cmd}) = eltype(fieldtype(Cmd, :exec))
 for f in (:iterate, :getindex)
     @eval $f(cmd::Cmd, i) = $f(cmd.exec, i)
 end
+IteratorIndexable(::Type{<:Cmd}) = IteratorIndexable(fieldtype(Cmd, :exec))
+EachIndexSupport(::Type{<:Cmd}) = EachIndexSupport(fieldtype(Cmd, :exec))
+

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -850,11 +850,25 @@ end
 end
 
 @testset "IteratorIndexable" begin
-    A = CartesianIndices([1 2; 3 4])
-    @test Base.IteratorIndexable(1) == Base.HasEachIndex{Base.OneTo{Int}}()
-    @test Base.IteratorIndexable([1]) == Base.HasEachIndex{Base.OneTo{Int}}()
-    @test Base.IteratorIndexable(Ref(1)) == Base.Indexable()
-    @test Base.IteratorIndexable((1,2)) == Base.HasEachIndex{Base.OneTo{Int}}()
-    @test Base.IteratorIndexable("abc") == Base.HasEachIndex{Base.EachStringIndex{String}}()
-    @test Base.IteratorIndexable(A) == Base.HasEachIndex{CartesianIndices{2, NTuple{2, Base.OneTo{Int}}}}()
+    @test Base.IteratorIndexable(1) == Base.IsIndexable()
+    @test Base.IteratorIndexable([1]) == Base.IsIndexable()
+    @test Base.IteratorIndexable(Ref(1)) == Base.IsIndexable()
+    @test Base.IteratorIndexable((1,2)) == Base.IsIndexable()
+    @test Base.IteratorIndexable("abc") == Base.IsIndexable()
+    @test Base.IteratorIndexable(Dict(1=>2)) == Base.NotIndexable()
+    @test Base.IteratorIndexable(skipmissing([1,2,3])) == Base.IsIndexable()
+    @test Base.IteratorIndexable(skipmissing(:x)) == Base.NotIndexable()
+    @test Base.IteratorIndexable(:x) == Base.NotIndexable()
 end
+
+@testset "eachindex_iteratortype" begin
+    A = CartesianIndices([1 2; 3 4])
+    @test Base.eachindex_iteratortype(1) == Base.OneTo{Int}
+    @test Base.eachindex_iteratortype([1]) == Base.OneTo{Int}
+    @test Base.eachindex_iteratortype(A) == CartesianIndices{2, NTuple{2, Base.OneTo{Int}}}
+    @test Base.eachindex_iteratortype(Ref(1)) === missing
+    @test Base.eachindex_iteratortype("abc") == Base.EachStringIndex{String}
+    @test Base.eachindex_iteratortype(Dict(1=>2)) === missing
+    @test Base.eachindex_iteratortype(:x) === missing
+end
+

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -848,3 +848,13 @@ end
     @test cumprod(x + 1 for x in 1:3) == [2, 6, 24]
     @test accumulate(+, (x^2 for x in 1:3); init=100) == [101, 105, 114]
 end
+
+@testset "IteratorIndexable" begin
+    A = CartesianIndices([1 2; 3 4])
+    @test Base.IteratorIndexable(1) == Base.HasEachIndex{Base.OneTo{Int}}()
+    @test Base.IteratorIndexable([1]) == Base.HasEachIndex{Base.OneTo{Int}}()
+    @test Base.IteratorIndexable(Ref(1)) == Base.Indexable()
+    @test Base.IteratorIndexable((1,2)) == Base.HasEachIndex{Base.OneTo{Int}}()
+    @test Base.IteratorIndexable("abc") == Base.HasEachIndex{Base.EachStringIndex{String}}()
+    @test Base.IteratorIndexable(A) == Base.HasEachIndex{CartesianIndices{2, NTuple{2, Base.OneTo{Int}}}}()
+end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,0 +1,33 @@
+@testset "EachIndexSupport" begin
+    @test Base.EachIndexSupport(1) == Base.HasEachIndex()
+    @test Base.EachIndexSupport([1]) == Base.HasEachIndex()
+    @test Base.EachIndexSupport((1,2,3)) == Base.HasEachIndex()
+    @test Base.EachIndexSupport((a=1,b=2)) == Base.HasEachIndex()
+    @test Base.EachIndexSupport(`echo`) == Base.HasEachIndex()
+    @test Base.EachIndexSupport(stdout) == Base.HasEachIndex()
+    @test Base.EachIndexSupport(Core.svec(1,2,3)) == Base.HasEachIndex()
+    @test Base.EachIndexSupport(pairs([1,2,3])) == Base.HasEachIndex()
+    @test Base.EachIndexSupport(Dict(1=>2)) == Base.HasEachIndex()
+    @test Base.EachIndexSupport(skipmissing([1,2,3])) == Base.HasEachIndex()
+    @test Base.EachIndexSupport(skipmissing(:x)) == Base.NoEachIndex()
+    @test Base.EachIndexSupport(Ref(1)) == Base.NoEachIndex()
+    @test Base.EachIndexSupport(:x) == Base.NoEachIndex()
+end
+
+@testset "eachindextype" begin
+    @test Base.eachindextype(1) == Base.OneTo{Int}
+    @test Base.eachindextype([1,2,3]) == Base.OneTo{Int}
+    @test Base.eachindextype(Dict(1=>2)) == Base.KeySet{Int, Dict{Int,Int}}
+    @test Base.eachindextype(:x) === missing
+    @test Base.eachindextype(Ref(1)) === missing
+end
+
+@testset "AdjacentIndexSupport" begin
+    @test Base.AdjacentIndexSupport([1,2,3]) == Base.HasAdjacentIndex()
+    @test Base.AdjacentIndexSupport((1,2,3)) == Base.HasAdjacentIndex()
+    @test Base.AdjacentIndexSupport((a=1,b=2)) == Base.HasAdjacentIndex()
+    @test Base.AdjacentIndexSupport("abc") == Base.HasAdjacentIndex()
+    @test Base.AdjacentIndexSupport(1) == Base.NoAdjacentIndex()
+    @test Base.AdjacentIndexSupport(:x) == Base.NoAdjacentIndex()
+    @test Base.AdjacentIndexSupport(Ref(1)) == Base.NoAdjacentIndex()
+end


### PR DESCRIPTION
I was asked to make this preliminary PR as I required this functionality. This trait checks for the ability to index an iterator to obtain the values that could've been obtained from iteration. There are two subtypes:

* `NotIndexable` - For any iterator that cannot be indexed or its indexable value is not its eltype.
* `IsIndexable` - For iterators that define `getindex` such that `getindex(iterator, idxs...)::eltype(iterator)`, for some `idxs`.

I've added two other traits, as wew as two functions. The traits are:

* `EachIndexSupport`, to check that the type defines `eachindex`
* `AdjacentIndexSupport`, to check that the type defines one of `nextind`, `prevind`, or both.

The functions are:

* `eachindextype`, which is `typeof(eachindex(value))` for values that have `eachindex`, or missing otherwise.
* `eachindex_iteratortype`, which is `eachindextype(value)` for indexable iterators, or missing otherwise.

The reason for these added traits and functions are that just knowing that a iterator is indexable is not enough for many applications, for example when implementing a optimized drop, you'd need to know how get the `nth` index of a iterator, which could be accomplished by either `eachindex` or `nextind`. My use case, a reversable `Take` and `TakeWhile`, requires both.

Use cases include a [drop without overhead for certain indexable iterators,](https://gist.github.com/fcard/2756d9895ba450a4f1880812b4fa47b6#file-fastdrop-jl-L17-L54) or a [default reverse for all indexable iterators. (that have invertible eachindices)](https://gist.github.com/fcard/2756d9895ba450a4f1880812b4fa47b6#file-defaultreverse-jl-L18-L40) `IteratorIndexable` could also be used to [implement indexing in iterators like `Generator`*, `Take` and `Drop`.](https://gist.github.com/fcard/2756d9895ba450a4f1880812b4fa47b6#file-indexiter-jl)

`Indexable` is also not a word apparently, but it already exists in other languages serving the same purpose, like in swift, so I didn't put any more thought into it.

`*`Really more appropriately `Iterators.map`, but since they make up the same Type I couldn't separate them.