### PR TITLE
Remove start_repl_server code from REPL module

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1232,12 +1232,4 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     nothing
 end
 
-function start_repl_server(port::Int)
-    return listen(port) do server, status
-        client = accept(server)
-        run_repl(client)
-        nothing
-    end
-end
-
 end # module


### PR DESCRIPTION
`REPL.start_repl_server(port::Int)` uses outdated API and no longer functions. It should be removed.

```julia
julia> import REPL

julia> REPL.start_repl_server(8080)
ERROR: MethodError: no method matching listen(::REPL.var"#80#81", ::Int64)
```