### PR TITLE
Reduce codegen burden on simple broadcast

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -947,6 +947,20 @@ end
     end
 end
 
+# This specialization is easier on codegen for a common case `f.(v)`
+@inline function copyto!(dest::AbstractArray, bc::Broadcasted{DefaultArrayStyle{1},<:Tuple{<:AbstractUnitRange},<:Any,<:Tuple{<:AbstractArray{T,1}}}) where T
+    src = bc.args[1]
+    if axes(dest) == axes(src)
+        return map!(bc.f, dest, src)
+    end
+    @assert length(src) == 1
+    val = first(src)
+    for i in eachindex(dest)
+        dest[i] = bc.f(val)
+    end
+    return dest
+end
+
 # For broadcasted assignments like `broadcast!(f, A, ..., A, ...)`, where `A`
 # appears on both the LHS and the RHS of the `.=`, then we know we're only
 # going to make one pass through the array, and even though `A` is aliasing


### PR DESCRIPTION
For some packages, codegen in broadcasting is one of their bigger latency costs. This *slightly* decreases it:

master:
```julia
julia> using DataFrames

julia> df = DataFrame(rand(10^6, 2), :auto);

julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.296754 seconds (755.18 k allocations: 55.012 MiB, 22.68% gc time, 95.93% compilation time)

julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.158591 seconds (352.24 k allocations: 30.657 MiB, 4.73% gc time, 90.73% compilation time)

julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.152025 seconds (352.24 k allocations: 30.659 MiB, 95.51% compilation time)

julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.156261 seconds (352.24 k allocations: 30.653 MiB, 3.98% gc time, 96.58% compilation time)
```

This branch:
```julia
julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.170146 seconds (462.54 k allocations: 37.431 MiB, 4.10% gc time, 96.93% compilation time)

julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.121619 seconds (211.42 k allocations: 23.580 MiB, 94.17% compilation time)

julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.124764 seconds (211.41 k allocations: 23.577 MiB, 5.64% gc time, 95.89% compilation time)

julia> @time filter(:x1 => x -> x < 0.5 , df);
  0.119846 seconds (211.42 k allocations: 23.581 MiB, 94.72% compilation time)
```

It would be considerably better (~0.095s) without the `map!(f, ::BitArray, ::AbstractArray)` method, but that seems necessary to prevent a runtime performance regression compared to the current implementation. (BaseBenchmarks doesn't complain, but...)

CC @bkamins