### PR TITLE
Allow PTLS to be changed in a function (preparation for task migration)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,7 @@ RUNTIME_SRCS += jitlayers aotcompile debuginfo disasm llvm-simdloop llvm-muladd 
 	llvm-final-gc-lowering llvm-pass-helpers llvm-late-gc-lowering \
 	llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces \
 	llvm-multiversioning llvm-alloc-opt cgmemmgr llvm-api llvm-remove-addrspaces \
-	llvm-remove-ni llvm-julia-licm llvm-demote-float16
+	llvm-remove-ni llvm-julia-licm llvm-demote-float16 llvm-ptls-reuse
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)
@@ -246,6 +246,7 @@ $(BUILDDIR)/llvm-gc-invariant-verifier.o $(BUILDDIR)/llvm-gc-invariant-verifier.
 $(BUILDDIR)/llvm-late-gc-lowering.o $(BUILDDIR)/llvm-late-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/llvm-multiversioning.o $(BUILDDIR)/llvm-multiversioning.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-pass-helpers.o $(BUILDDIR)/llvm-pass-helpers.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/codegen_shared.h
+$(BUILDDIR)/llvm-ptls-reuse.o $(BUILDDIR)/llvm-ptls-reuse.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-ptls.o $(BUILDDIR)/llvm-ptls.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/processor.o $(BUILDDIR)/processor.dbg.obj: $(addprefix $(SRCDIR)/,processor_*.cpp processor.h features_*.h)
 $(BUILDDIR)/signal-handling.o $(BUILDDIR)/signal-handling.dbg.obj: $(addprefix $(SRCDIR)/,signals-*.c)

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -628,7 +628,12 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createVerifierPass());
 #endif
 
+    // TODO: `createLowerPTLSReusePass` here requires `LowerPTLSReuse` pass to
+    // handle phi nodes (but currently it doesn't).
     PM->add(createLowerPTLSReusePass());
+#ifdef JL_DEBUG_BUILD
+    PM->add(createVerifierPass(false));
+#endif
     PM->add(createConstantMergePass());
     if (opt_level < 2) {
         PM->add(createCFGSimplificationPass());
@@ -650,6 +655,9 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
             PM->add(createLateLowerGCFramePass());
             PM->add(createFinalLowerGCPass());
             PM->add(createLowerPTLSReusePass());
+#ifdef JL_DEBUG_BUILD
+            PM->add(createVerifierPass(false));
+#endif
             PM->add(createLowerPTLSPass(dump_native));
         }
         else {
@@ -780,6 +788,9 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
         PM->add(createLateLowerGCFramePass());
         PM->add(createFinalLowerGCPass());
         PM->add(createLowerPTLSReusePass());
+#ifdef JL_DEBUG_BUILD
+        PM->add(createVerifierPass(false));
+#endif
         // We need these two passes and the instcombine below
         // after GC lowering to let LLVM do some constant propagation on the tags.
         // and remove some unnecessary write barrier checks.

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -628,8 +628,6 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createVerifierPass());
 #endif
 
-    // TODO: `createLowerPTLSReusePass` here requires `LowerPTLSReuse` pass to
-    // handle phi nodes (but currently it doesn't).
     PM->add(createLowerPTLSReusePass());
 #ifdef JL_DEBUG_BUILD
     PM->add(createVerifierPass(false));

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -628,6 +628,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createVerifierPass());
 #endif
 
+    PM->add(createLowerPTLSReusePass());
     PM->add(createConstantMergePass());
     if (opt_level < 2) {
         PM->add(createCFGSimplificationPass());
@@ -648,6 +649,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
             PM->add(createRemoveNIPass());
             PM->add(createLateLowerGCFramePass());
             PM->add(createFinalLowerGCPass());
+            PM->add(createLowerPTLSReusePass());
             PM->add(createLowerPTLSPass(dump_native));
         }
         else {
@@ -777,6 +779,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
         PM->add(createRemoveNIPass());
         PM->add(createLateLowerGCFramePass());
         PM->add(createFinalLowerGCPass());
+        PM->add(createLowerPTLSReusePass());
         // We need these two passes and the instcombine below
         // after GC lowering to let LLVM do some constant propagation on the tags.
         // and remove some unnecessary write barrier checks.

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2761,7 +2761,7 @@ static void emit_cpointercheck(jl_codectx_t &ctx, const jl_cgval_t &x, const std
 // allocation for known size object
 static Value *emit_allocobj(jl_codectx_t &ctx, size_t static_size, Value *jt)
 {
-    Value *ptls_ptr = emit_bitcast(ctx, ctx.ptlsStates, T_pint8);
+    Value *ptls_ptr = emit_bitcast(ctx, current_ptls(ctx), T_pint8);
     Function *F = prepare_call(jl_alloc_obj_func);
     auto call = ctx.builder.CreateCall(F, {ptls_ptr, ConstantInt::get(T_size, static_size), maybe_decay_untracked(ctx, jt)});
     call->setAttributes(F->getAttributes());
@@ -3087,7 +3087,7 @@ static void emit_signal_fence(jl_codectx_t &ctx)
 
 static Value *emit_defer_signal(jl_codectx_t &ctx)
 {
-    Value *ptls = emit_bitcast(ctx, ctx.ptlsStates,
+    Value *ptls = emit_bitcast(ctx, current_ptls(ctx),
                                         PointerType::get(T_sigatomic, 0));
     Constant *offset = ConstantInt::getSigned(T_int32,
         offsetof(jl_tls_states_t, defer_signal) / sizeof(sig_atomic_t));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3495,10 +3495,10 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
     if (!handled) {
         Value *r = emit_jlcall(ctx, jlinvoke_func, boxed(ctx, lival), argv, nargs, JLCALL_F2_CC);
         result = mark_julia_type(ctx, r, true, rt);
-#ifdef MIGRATE_TASKS
-        emit_refetch_ptls(ctx);
-#endif
     }
+#ifdef MIGRATE_TASKS
+    emit_refetch_ptls(ctx);
+#endif
     if (result.typ == jl_bottom_type)
         CreateTrap(ctx.builder);
     return result;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -230,6 +230,7 @@ private:
 };
 extern JuliaOJIT *jl_ExecutionEngine;
 
+Pass *createLowerPTLSReusePass();
 Pass *createLowerPTLSPass(bool imaging_mode);
 Pass *createCombineMulAddPass();
 Pass *createFinalLowerGCPass();

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -4,6 +4,7 @@
 #ifndef JL_THREADS_H
 #define JL_THREADS_H
 
+#include "options.h"
 #include <atomics.h>
 // threading ------------------------------------------------------------------
 

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -88,6 +88,8 @@ struct JuliaPassContext {
         return module->getContext();
     }
 
+    bool usePtls(llvm::Function &F);
+
     // Gets a call to the `julia.ptls_states` intrinsic in the entry
     // point of the given function, if there exists such a call.
     // Otherwise, a new call is created and returned.
@@ -97,6 +99,7 @@ struct JuliaPassContext {
     llvm::Function *getOrDeclarePtlsStatesFunc();
     llvm::Function *getOrDeclareReusePtlsStatesFunc();
     llvm::Function *getOrNullReusePtlsStatesFunc();
+    llvm::Function *getOrNullRefetchPtlsStatesFunc();
 
     // Gets the intrinsic or well-known function that conforms to
     // the given description if it exists in the module. If not,
@@ -120,6 +123,8 @@ namespace jl_intrinsics {
     extern const IntrinsicDescription ptlsStates;
     // `julia.reuse_ptls_states`:
     extern const IntrinsicDescription reusePtlsStates;
+    // `julia.refetch_ptls_states`:
+    extern const IntrinsicDescription refetchPtlsStates;
 
     // `julia.get_gc_frame_slot`: an intrinsic that creates a
     // pointer to a GC frame slot.

--- a/src/llvm-ptls-reuse.cpp
+++ b/src/llvm-ptls-reuse.cpp
@@ -1,0 +1,93 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "llvm-version.h"
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/Transforms/Utils/ModuleUtils.h>
+
+#include "codegen_shared.h"
+#include "julia.h"
+#include "julia_internal.h"
+#include "llvm-pass-helpers.h"
+
+#define DEBUG_TYPE "ptls_reuse_lowering"
+
+using namespace llvm;
+
+// Materialize PTLS if used.
+//
+// During the code gen, normal uses of the PTLS are marked by the placeholder
+// function `reuse_jltls_states_func` at each use-site while explicit refetches
+// are marked by another plaholder function `refetch_jltls_states_func`. These
+// placeholders are materialized using `jltls_states_func` after the control
+// flow structure is finalized. We merge all the reuses, possibly using the phi
+// nodes if at least one predecessor refetches the PTLS.
+struct LowerPTLSReuse : public ModulePass, private JuliaPassContext {
+    static char ID;
+    LowerPTLSReuse() : ModulePass(ID) {}
+
+private:
+    bool runOnModule(Module &M) override;
+    bool runOnFunction(Function &F);
+};
+
+bool LowerPTLSReuse::runOnModule(Module &M)
+{
+    LLVM_DEBUG(dbgs() << "LOWER PTLS REUSE (" << static_cast<void *>(this)
+                      << "): Processing module " << M.getName() << "\n");
+    initAll(M);
+    bool changed = false;
+    for (auto &F: M) {
+        changed |= runOnFunction(F);
+    }
+    if (reuse_jltls_states_func) {
+        reuse_jltls_states_func->eraseFromParent();
+    }
+    return changed;
+}
+
+bool LowerPTLSReuse::runOnFunction(Function &F)
+{
+    LLVM_DEBUG(dbgs() << "LOWER PTLS REUSE (" << static_cast<void *>(this)
+                      << "): Processing function  " << F.getName() << "\n");
+    getOrNullReusePtlsStatesFunc();
+    if (!reuse_jltls_states_func) {
+        return false;
+    }
+    // BBToInstructionMapTy bb_to_ptls;
+    SmallVector<CallInst *, 8> reuses;
+    for (auto &BB : F) {
+        for (auto &I : BB) {
+            if (auto *C = dyn_cast<CallInst>(&I)) {
+                if (C->getCalledFunction() == reuse_jltls_states_func) {
+                    reuses.push_back(C);
+                }
+            }
+        }
+    }
+    bool changed = false;
+    if (reuses.size()) {
+        auto ptls = ensureEntryBlockPtls(F);
+        // TODO: Handle refetch_jltls_states_func
+        for (auto C : reuses) {
+            C->replaceAllUsesWith(ptls);
+            C->eraseFromParent();
+        }
+        changed = true;
+    }
+    return changed;
+}
+
+char LowerPTLSReuse::ID = 0;
+static RegisterPass<LowerPTLSReuse> X("LowerPTLSReuse", "Lower PTLS reuses", false, false);
+
+Pass *createLowerPTLSReusePass()
+{
+    return new LowerPTLSReuse();
+}

--- a/src/llvm-ptls-reuse.cpp
+++ b/src/llvm-ptls-reuse.cpp
@@ -7,9 +7,13 @@
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/ValueMap.h>
 #include <llvm/Pass.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
+#ifdef JL_DEBUG_BUILD
+#include <llvm/IR/Verifier.h>
+#endif
 
 #include "codegen_shared.h"
 #include "julia.h"
@@ -19,6 +23,8 @@
 #define DEBUG_TYPE "ptls_reuse_lowering"
 
 using namespace llvm;
+
+using BbToInstructionMapTy = ValueMap<const BasicBlock *, Instruction *>;
 
 // Materialize PTLS if used.
 //
@@ -33,8 +39,13 @@ struct LowerPTLSReuse : public ModulePass, private JuliaPassContext {
     LowerPTLSReuse() : ModulePass(ID) {}
 
 private:
+    Type *PtlsType;
+
     bool runOnModule(Module &M) override;
     bool runOnFunction(Function &F);
+    Instruction *mergePtls(BasicBlock *BB, BbToInstructionMapTy &BbToPtls);
+    Instruction *ptlsForBb(BasicBlock *BB, BbToInstructionMapTy &BbToPtls);
+    void populatePtls(BasicBlock *BB, BbToInstructionMapTy &BbToPtls);
 };
 
 bool LowerPTLSReuse::runOnModule(Module &M)
@@ -42,14 +53,107 @@ bool LowerPTLSReuse::runOnModule(Module &M)
     LLVM_DEBUG(dbgs() << "LOWER PTLS REUSE (" << static_cast<void *>(this)
                       << "): Processing module " << M.getName() << "\n");
     initAll(M);
+    PtlsType = PointerType::get(T_ppjlvalue, 0);
     bool changed = false;
-    for (auto &F: M) {
+    for (auto &F : M) {
+#ifdef JL_DEBUG_BUILD
+        assert(!verifyFunction(F, &dbgs()));
+#endif
         changed |= runOnFunction(F);
+#ifdef JL_DEBUG_BUILD
+        assert(!verifyFunction(F, &dbgs()));
+#endif
     }
     if (reuse_jltls_states_func) {
         reuse_jltls_states_func->eraseFromParent();
     }
     return changed;
+}
+
+Instruction *LowerPTLSReuse::mergePtls(BasicBlock *BB, BbToInstructionMapTy &BbToPtls)
+{
+    if (BB == &BB->getParent()->getEntryBlock()) {
+        return ensureEntryBlockPtls(*BB->getParent());
+    }
+    SmallVector<BasicBlock *, 2> PreBbs;
+    for (auto Pre : predecessors(BB)) {
+        PreBbs.push_back(Pre);
+    }
+    auto Phi = PHINode::Create(PointerType::get(T_ppjlvalue, 0), PreBbs.size(), "ptls",
+                               BB->getFirstNonPHI() ? BB->getFirstNonPHI() : &BB->front());
+    if (!BbToPtls[BB]) {
+        // PTLS from this BB is requested as a transitive dependency. So,
+        // marking the phi node as the PTLS at the end of this basic block. This
+        // has to be done before the recursions.
+        BbToPtls[BB] = Phi;
+        assert(Phi->getType() == PtlsType);
+    }
+    for (auto Pre : PreBbs) {
+        Phi->addIncoming(ptlsForBb(Pre, BbToPtls), Pre);
+    }
+    return Phi;
+}
+
+// Get PTLS usable at the end of `BB`.
+Instruction *LowerPTLSReuse::ptlsForBb(BasicBlock *BB, BbToInstructionMapTy &BbToPtls)
+{
+    if (auto Ptls = BbToPtls[BB]) {
+        return Ptls;
+    }
+    auto Ptls = mergePtls(BB, BbToPtls);
+    assert(Ptls->getType() == PtlsType);
+    return Ptls;
+}
+
+void LowerPTLSReuse::populatePtls(BasicBlock *BB, BbToInstructionMapTy &BbToPtls)
+{
+    // First, go over instructions in `BB` and construct a mapping between
+    // "source" PTLS and its reuses.
+    Instruction *Ptls = mergePtls(BB, BbToPtls);
+    SmallVector<CallInst *> Refetches;
+    SmallVector<std::pair<Instruction *, std::unique_ptr<SmallVector<Instruction *>>>>
+        SourceAndReuses;
+    auto Reuses = std::make_unique<SmallVector<Instruction *>>();
+    for (Instruction &I : *BB) {
+        if (auto *C = dyn_cast<CallInst>(&I)) {
+            if (!C->getCalledFunction()) {
+                continue;
+            }
+            else if (C->getCalledFunction() == ptls_getter ||
+                     C->getCalledFunction() == refetch_jltls_states_func) {
+                auto Tmp = std::make_unique<SmallVector<Instruction *>>();
+                Tmp.swap(Reuses);
+                SourceAndReuses.push_back(std::make_pair(Ptls, std::move(Tmp)));
+                Ptls = &I;
+                if (C->getCalledFunction() == refetch_jltls_states_func) {
+                    Refetches.push_back(C);
+                }
+            }
+            else if (C->getCalledFunction() == reuse_jltls_states_func) {
+                Reuses->push_back(&I);
+            }
+        }
+    }
+    if (!Reuses->empty()) {
+        SourceAndReuses.push_back(std::make_pair(Ptls, std::move(Reuses)));
+    }
+
+    // Second, replace the reuses with the source PTLS.
+    for (auto &PtlsAndReuses : SourceAndReuses) {
+        auto Source = PtlsAndReuses.first;
+        auto Reuses = PtlsAndReuses.second.release();
+        for (auto &I : *Reuses) {
+            I->replaceAllUsesWith(Source);
+            I->eraseFromParent();
+        }
+    }
+    assert(Ptls->getType() == PtlsType);
+    BbToPtls[BB] = Ptls;
+
+    // Finally, materialize refetches in-place.
+    for (auto I : Refetches) {
+        I->setCalledFunction(ptls_getter);
+    }
 }
 
 bool LowerPTLSReuse::runOnFunction(Function &F)
@@ -60,28 +164,43 @@ bool LowerPTLSReuse::runOnFunction(Function &F)
     if (!reuse_jltls_states_func) {
         return false;
     }
-    // BBToInstructionMapTy bb_to_ptls;
-    SmallVector<CallInst *, 8> reuses;
-    for (auto &BB : F) {
-        for (auto &I : BB) {
+    if (!usePtls(F)) {
+        return false;
+    }
+    ensureEntryBlockPtls(F);
+
+    // Create a mapping from BB to PTLS-at-the-end-of-BB:
+    BbToInstructionMapTy BbToPtls;
+    SmallVector<BasicBlock *, 8> BbWithPtls;
+    for (BasicBlock &BB : F) {
+        auto inserted = false;
+        for (Instruction &I : BB) {
+            // TODO: handle phi nodes?
             if (auto *C = dyn_cast<CallInst>(&I)) {
-                if (C->getCalledFunction() == reuse_jltls_states_func) {
-                    reuses.push_back(C);
+                if (!C->getCalledFunction()) {
+                    continue;
+                }
+                else if (C->getCalledFunction() == ptls_getter ||
+                         C->getCalledFunction() == reuse_jltls_states_func ||
+                         C->getCalledFunction() == refetch_jltls_states_func) {
+                    assert(C->getType() == PtlsType);
+                    BbToPtls[&BB] = C;
+
+                    if (!inserted) {
+                        inserted = true;
+                        BbWithPtls.push_back(&BB);
+                    }
                 }
             }
         }
     }
-    bool changed = false;
-    if (reuses.size()) {
-        auto ptls = ensureEntryBlockPtls(F);
-        // TODO: Handle refetch_jltls_states_func
-        for (auto C : reuses) {
-            C->replaceAllUsesWith(ptls);
-            C->eraseFromParent();
-        }
-        changed = true;
+
+    // Process BBs that directly require PTLS and introduce the phi nodes in
+    // other BBs as needed.
+    for (BasicBlock *BB : BbWithPtls) {
+        populatePtls(BB, BbToPtls);
     }
-    return changed;
+    return true;
 }
 
 char LowerPTLSReuse::ID = 0;

--- a/src/task.c
+++ b/src/task.c
@@ -503,9 +503,11 @@ JL_DLLEXPORT void jl_switch(void)
         if (jl_atomic_compare_exchange(&t->tid, -1, ptls->tid) != -1)
             jl_error("cannot switch to task running on another thread");
     }
+#ifndef MIGRATE_TASKS
     else if (t->tid != ptls->tid) {
         jl_error("cannot switch to task running on another thread");
     }
+#endif
 
     // Store old values on the stack and reset
     sig_atomic_t defer_signal = ptls->defer_signal;


### PR DESCRIPTION
This PR tweaks how PTLS getters are generated and lets us insert multiple PTLS getters at arbitrary points in a function. There are two goals motivating this change:

1. Task migration across threads. To migrate the tasks across threads, we need to refetch PTLS after every point that a function can yield (= most of the function calls).

2. For Julia-Tapir integration (or, more in general, LLVM-level compiler support for the task system) we are working on, we need to be able to split out chunks of LLVM IR as functions. I think relaxing the current requirement that the PTLS has to be fetched only once at the entry block helps this part of the LLVM pass.

Note that this PR does not cover these goals and so I'm not 100% sure if it is the right approach yet. Also, there are some failures in tests due to this change and so it's not merge-ready. But it'd be great if I can get some feedbacks in the design before I spend more time fixing the bugs.

### Demo

I build `julia` with `MIGRATE_TASKS` enabled:

```diff
diff --git a/src/options.h b/src/options.h
index 3ffbf05b22..5ea220900b 100644
--- a/src/options.h
+++ b/src/options.h
@@ -114,7 +114,7 @@
 #endif

 // allow a suspended Task to restart on a different thread
-//#define MIGRATE_TASKS
+#define MIGRATE_TASKS

 // threading options ----------------------------------------------------------
```

and then

```julia
julia> function f()
           a = Threads.threadid()
           yield()
           b = Threads.threadid()
           (a, b)
       end
f (generic function with 1 method)

julia> @code_llvm debuginfo=:none f()
```

prints

```llvm
; Function Attrs: sspstrong
define void @julia_f_175([2 x i64]* noalias nocapture sret([2 x i64]) %0) #0 {
top:
  %thread_ptr4 = call i8* asm "movq %fs:0, $0", "=r"() #5
  %1 = getelementptr i8, i8* %thread_ptr4, i64 -32752
  %2 = bitcast i8* %1 to i16*
  %3 = load i16, i16* %2, align 2
  %4 = sext i16 %3 to i64
  %5 = add nsw i64 %4, 1
  %6 = call nonnull {}* @j_yield_177()
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #5
  %7 = getelementptr i8, i8* %thread_ptr, i64 -32752
  %8 = bitcast i8* %7 to i16*
  %9 = load i16, i16* %8, align 2
  %10 = sext i16 %9 to i64
  %11 = add nsw i64 %10, 1
  %.sroa.0.0..sroa_idx = getelementptr inbounds [2 x i64], [2 x i64]* %0, i64 0, i64 0
  store i64 %5, i64* %.sroa.0.0..sroa_idx, align 8
  %.sroa.2.0..sroa_idx1 = getelementptr inbounds [2 x i64], [2 x i64]* %0, i64 0, i64 1
  store i64 %11, i64* %.sroa.2.0..sroa_idx1, align 8
  ret void
}
```

Note that `%thread_ptr` is loaded twice. Once at the beginning (as usual) and also just after `@j_yield_177()`.

(Using multiple threads in `julia` with `MIGRATE_TASKS` crashes `julia`. I don't know if it's from the scheduler or this PR or both.)

### How it works

This patch introduces new LLVM placeholder functions `julia.reuse_ptls_states` and `julia.refetch_ptls_states` whose signature is identical to `julia.ptls_states`. During the codegen (`emit_function` etc.), it inserts `julia.reuse_ptls_states` _just before_ each instruction that needs PTLS. It inserts `julia.refetch_ptls_states` if we need to refetch the PTLS (but it's not used in the normal build that doesn't enable `MIGRATE_TASKS`). So, in the above example, `emit_function` produces this LLVM IR (`@code_llvm debuginfo=:none optimize=false f()`):

```llvm
; Function Attrs: sspstrong
define void @julia_f_235([2 x i64]* noalias nocapture sret([2 x i64]) %0) #0 {
top:
  %1 = alloca [2 x i64], align 8
  %2 = call {}*** @julia.reuse_ptls_states()
  %3 = bitcast {}*** %2 to i16*
  %4 = getelementptr inbounds i16, i16* %3, i64 8
  %5 = load i16, i16* %4, align 2
  %6 = sext i16 %5 to i64
  %7 = add i64 %6, 1
  %8 = call nonnull {}* @j_yield_237()
  %9 = call {}*** @julia.refetch_ptls_states()
  %10 = call {}*** @julia.reuse_ptls_states()
  %11 = bitcast {}*** %10 to i16*
  %12 = getelementptr inbounds i16, i16* %11, i64 8
  %13 = load i16, i16* %12, align 2
  %14 = sext i16 %13 to i64
  %15 = add i64 %14, 1
  %16 = getelementptr inbounds [2 x i64], [2 x i64]* %1, i32 0, i32 0
  store i64 %7, i64* %16, align 8
  %17 = getelementptr inbounds [2 x i64], [2 x i64]* %1, i32 0, i32 1
  store i64 %15, i64* %17, align 8
  %18 = bitcast [2 x i64]* %0 to i8*
  %19 = bitcast [2 x i64]* %1 to i8*
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %18, i8* %19, i64 16, i1 false)
  ret void
}
```

In this patch, `julia.ptls_states` is not emitted by the initial codegen anymore. Instead, I created a pass `LowerPTLSReuse` that inserts `julia.ptls_states` if required and merges all `@julia.refetch_ptls_states()` using phi nodes. I think it means that we are manually denoting a particular "task-pure" semantics of the function `@julia.reuse_ptls_states`. (Ideally, LLVM has the notion of pure/const appropriate for this use case. But, looking at `isLoadFromConstGV` and its comment, I'm guessing LLVM doesn't have this and implementing the pass ourselves is a reasonable approach.)

The `LowerPTLSReuse` pass is implemented in such a way that it is (supposed to be) safe to run multiple times. This is because `LateLowerGCFrame` can introduce new instructions that require PTLS (i.e., new `@julia.reuse_ptls_states()` calls) so that we need to re-run `LowerPTLSReuse` again. `LowerPTLSReuse` is called at the beginning of the LLVM pass to avoid interfering with the optimization passes that may give up when there are calls to opaque function like `@julia.reuse_ptls_states`.

### Next steps

Ideally:

1. Get OK for the design from compiler devs
2. Fix the bugs and make the CI happy
3. Get OK for the implementation and then merge it
