### PR TITLE
Add the public `Dates.periods` function for getting the `Vector` of `Period`s that comprise a `CompoundPeriod`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@ Standard library changes
 
 #### Dates
 
+* The `Dates.periods` function can be used to get the `Vector` of `Period`s that comprise a `CompoundPeriod` ([#39169]).
 
 #### Statistics
 

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -747,6 +747,7 @@ Dates.Period(::Any)
 Dates.CompoundPeriod(::Vector{<:Dates.Period})
 Dates.value
 Dates.default
+Dates.periods
 ```
 
 ### Rounding Functions

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -197,7 +197,7 @@ struct CompoundPeriod <: AbstractTime
 end
 
 """
-    periods(::CompoundPeriod) -> Vector{Period}
+    Dates.periods(::CompoundPeriod) -> Vector{Period}
 
 Return the `Vector` of `Period`s that comprise the given `CompoundPeriod`. 
 """

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -197,6 +197,13 @@ struct CompoundPeriod <: AbstractTime
 end
 
 """
+    periods(::CompoundPeriod) -> Vector{Period}
+
+Return the `Vector` of `Period`s that comprise the given `CompoundPeriod`. 
+"""
+periods(x::CompoundPeriod) = x.periods
+
+"""
     CompoundPeriod(periods) -> CompoundPeriod
 
 Construct a `CompoundPeriod` from a `Vector` of `Period`s. All `Period`s of the same type

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -199,7 +199,7 @@ end
 """
     Dates.periods(::CompoundPeriod) -> Vector{Period}
 
-Return the `Vector` of `Period`s that comprise the given `CompoundPeriod`. 
+Return the `Vector` of `Period`s that comprise the given `CompoundPeriod`.
 """
 periods(x::CompoundPeriod) = x.periods
 

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -366,6 +366,7 @@ end
     @test isequal(d - h, 2d - 2h - 1d + 1h)
     @test sprint(show, y + m) == string(y + m)
     @test convert(Dates.CompoundPeriod, y) + m == y + m
+    @test Dates.periods(convert(Dates.CompoundPeriod, y)) == convert(Dates.CompoundPeriod, y).periods
 end
 @testset "compound period simplification" begin
     # reduce compound periods into the most basic form


### PR DESCRIPTION
Currently, there is no public API for getting the `Vector` of `Period`s that comprise a `CompoundPeriod`.

This pull request adds the public `Dates.periods` function for accomplishing this. (It has a docstring, and it is listed in the manual, therefore it is in the public API.)