### PR TITLE
`Base.show_backtrace`: document and make public

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -761,7 +761,7 @@ Print the given backtrace to `io`.
 ## Example
 
 ```julia
-julia> show_backtrace(stdout, backtrace())
+julia> Base.show_backtrace(stdout, backtrace())
 ```
 """
 function show_backtrace(io::IO, t::Vector)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -753,7 +753,17 @@ function print_stackframe(io, i, frame::StackFrame, n::Int, digit_align_width, m
     printstyled(io, inlined ? " [inlined]" : "", color = :light_black)
 end
 
+"""
+    show_backtrace(io::IO, bt::Vector)
 
+Print the given backtrace to `io`.
+
+## Example
+
+```julia
+julia> show_backtrace(stdout, backtrace())
+```
+"""
 function show_backtrace(io::IO, t::Vector)
     if haskey(io, :last_shown_line_infos)
         empty!(io[:last_shown_line_infos])

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -338,6 +338,7 @@ Base.error
 Core.throw
 Base.rethrow
 Base.backtrace
+Base.show_backtrace
 Base.catch_backtrace
 Base.catch_stack
 Base.@assert


### PR DESCRIPTION
This pull request:
1. Adds a docstring for `Base.show_backtrace`
2. Add `Base.show_backtrace` to the manual

As a result, this pull request makes `Base.show_backtrace` a public function.

Note: I did not export `show_backtrace`. But I can make that change if people think that `show_backtrace` should be exported.