### PR TITLE
Add some costly precompiles

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -19,24 +19,36 @@ hardcoded_precompile_statements = """
 # used by Revise.jl
 @assert precompile(Tuple{typeof(Base.parse_cache_header), String})
 @assert precompile(Base.read_dependency_src, (String, String))
-@assert precompile(Base.CoreLogging.current_logger_for_env, (Base.CoreLogging.LogLevel, String, Module))
 
 # used by Requires.jl
 @assert precompile(Tuple{typeof(get!), Type{Vector{Function}}, Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
 @assert precompile(Tuple{typeof(haskey), Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
 @assert precompile(Tuple{typeof(delete!), Dict{Base.PkgId,Vector{Function}}, Base.PkgId})
 @assert precompile(Tuple{typeof(push!), Vector{Function}, Function})
+
 # miscellaneous
 @assert precompile(Tuple{typeof(Base.require), Base.PkgId})
 @assert precompile(Tuple{typeof(Base.recursive_prefs_merge), Base.Dict{String, Any}})
 @assert precompile(Tuple{typeof(isassigned), Core.SimpleVector, Int})
 @assert precompile(Tuple{typeof(getindex), Core.SimpleVector, Int})
 @assert precompile(Tuple{typeof(Base.Experimental.register_error_hint), Any, Type})
+@assert precompile(Tuple{typeof(Base.display_error), MethodError, Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}})
+@assert precompile(Tuple{typeof(Base.display_error), ErrorException})
+@assert precompile(Tuple{typeof(Base.display_error), BoundsError})
+@assert precompile(Tuple{Core.kwftype(typeof(Type)), NamedTuple{(:sizehint,), Tuple{Int64}}, Type{IOBuffer}})
+@assert precompile(Base.CoreLogging.current_logger_for_env, (Base.CoreLogging.LogLevel, String, Module))
+@assert precompile(Base.CoreLogging.current_logger_for_env, (Base.CoreLogging.LogLevel, Symbol, Module))
 """
+
+for T in (Float16, Float32, Float64), IO in (IOBuffer, IOContext{IOBuffer}, Base.TTY, IOContext{Base.TTY})
+    global hardcoded_precompile_statements
+    hardcoded_precompile_statements *= "@assert precompile(Tuple{typeof(show), $IO, $T})\n"
+end
 
 repl_script = """
 2+2
 print("")
+printstyled("a", "b")
 display([1])
 display([1 2; 3 4])
 @time 1+1
@@ -174,8 +186,40 @@ if Test !== nothing
     hardcoded_precompile_statements *= """
     @assert precompile(Tuple{typeof(Test.do_test), Test.ExecutionResult, Any})
     @assert precompile(Tuple{typeof(Test.testset_beginend), Tuple{String, Expr}, Expr, LineNumberNode})
+    @assert precompile(Tuple{Type{Test.DefaultTestSet}, String})
+    @assert precompile(Tuple{Type{Test.DefaultTestSet}, AbstractString})
+    @assert precompile(Tuple{Core.kwftype(Type{Test.DefaultTestSet}), Any, Type{Test.DefaultTestSet}, AbstractString})
     @assert precompile(Tuple{typeof(Test.finish), Test.DefaultTestSet})
     @assert precompile(Tuple{typeof(Test.eval_test), Expr, Expr, LineNumberNode, Bool})
+    @assert precompile(Tuple{typeof(Test._inferred), Expr, Module})
+    @assert precompile(Tuple{typeof(Test.push_testset), Test.DefaultTestSet})
+    @assert precompile(Tuple{typeof(Test.get_alignment), Test.DefaultTestSet, Int})
+    @assert precompile(Tuple{typeof(Test.get_test_result), Any, Any})
+    @assert precompile(Tuple{typeof(Test.do_test_throws), Test.ExecutionResult, Any, Any})
+    @assert precompile(Tuple{typeof(Test.print_counts), Test.DefaultTestSet, Int, Int, Int, Int, Int, Int, Int})
+    @assert precompile(Tuple{typeof(Test._check_testset), Type, Expr})
+    @assert precompile(Tuple{typeof(Test.test_expr!), Any, Any})
+    @assert precompile(Tuple{typeof(Test.test_expr!), Any, Any, Vararg{Any, 100}})
+    @assert precompile(Tuple{typeof(Test.pop_testset)})
+    @assert precompile(Tuple{typeof(Test.match_logs), Function, Tuple{Symbol, Regex}})
+    @assert precompile(Tuple{typeof(Test.match_logs), Function, Tuple{String, Regex}})
+    @assert precompile(Tuple{typeof(Base.CoreLogging.shouldlog), Test.TestLogger, Base.CoreLogging.LogLevel, Module, Symbol, Symbol})
+    @assert precompile(Tuple{typeof(Base.CoreLogging.handle_message), Test.TestLogger, Base.CoreLogging.LogLevel, String, Module, Symbol, Symbol, String, Int})
+    @assert precompile(Tuple{typeof(Core.kwfunc(Base.CoreLogging.handle_message)), typeof((exception=nothing,)), typeof(Base.CoreLogging.handle_message), Test.TestLogger, Base.CoreLogging.LogLevel, String, Module, Symbol, Symbol, String, Int})
+    @assert precompile(Tuple{typeof(Test.detect_ambiguities), Any})
+    @assert precompile(Tuple{typeof(Test.collect_test_logs), Function})
+    @assert precompile(Tuple{typeof(Test.do_broken_test), Test.ExecutionResult, Any})
+    @assert precompile(Tuple{typeof(Test.record), Test.DefaultTestSet, Union{Test.Error, Test.Fail}})
+    @assert precompile(Tuple{typeof(Test.filter_errors), Test.DefaultTestSet})
+    """
+end
+
+Profile = get(Base.loaded_modules,
+          Base.PkgId(Base.UUID("9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"), "Profile"),
+          nothing)
+if Profile !== nothing
+    hardcoded_precompile_statements *= """
+    @assert precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol})
     """
 end
 


### PR DESCRIPTION
These are things that have shown up in analysis of various packages
by SnoopCompile. Either they are particularly costly, or in the
case of `Test`, just plain annoying to have them show up again
and again.

Complementary (but independent) PR: #39177
Most of the remaining `Test`-related inference triggers I've discovered are due to #34516
