### PR TITLE
Checkout last bugfix release of 1.5 series

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Julia. However, most users should use the most recent stable version
 of Julia. You can get this version by changing to the Julia directory
 and running:
 
-    git checkout v1.5.0
+    git checkout v1.5.3
 
 Now run `make` to build the `julia` executable.
 


### PR DESCRIPTION
README should advise to checkout last bugfix release 1.5.3 instead of first full 1.5.0

Given that 1.6 has already reached beta phase I'm late for the party but I stumbled over this today when pasting from the manual