### PR TITLE
[Artifacts]: Support `using Pkg.Artifacts` with LazyArtifacts

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -541,7 +541,9 @@ function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dic
     meta = artifact_meta(name, artifact_dict, artifacts_toml; platform)
     if meta !== nothing && get(meta, "lazy", false)
         if lazyartifacts isa Module && isdefined(lazyartifacts, :ensure_artifact_installed)
-            nameof(lazyartifacts) === :Pkg && Base.depwarn("using Pkg instead of using LazyArtifacts is deprecated", :var"@artifact_str", force=true)
+            if nameof(lazyartifacts) in (:Pkg, :Artifacts)
+                Base.depwarn("using Pkg instead of using LazyArtifacts is deprecated", :var"@artifact_str", force=true)
+            end
             return jointail(lazyartifacts.ensure_artifact_installed(string(name), artifacts_toml; platform), path_tail)
         end
         error("Artifact $(repr(name)) is a lazy artifact; package developers must call `using LazyArtifacts` in $(__module__) before using lazy artifacts.")
@@ -659,9 +661,13 @@ macro artifact_str(name, platform=nothing)
     Base.include_dependency(artifacts_toml)
 
     # Check if the user has provided `LazyArtifacts`, and thus supports lazy artifacts
-    lazyartifacts = isdefined(__module__, :LazyArtifacts) ? GlobalRef(__module__, :LazyArtifacts) : nothing
-    if lazyartifacts === nothing && isdefined(__module__, :Pkg)
-        lazyartifacts = GlobalRef(__module__, :Pkg) # deprecated
+    # If not, check to see if `Pkg` or `Pkg.Artifacts` has been imported.
+    lazyartifacts = nothing
+    for module_name in (:LazyArtifacts, :Pkg, :Artifacts)
+        if isdefined(__module__, module_name)
+            lazyartifacts = GlobalRef(__module__, module_name)
+            break
+        end
     end
 
     # If `name` is a constant, (and we're using the default `Platform`) we can actually load

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -133,12 +133,27 @@ end
 end
 
 @testset "@artifact_str install errors" begin
-    mktempdir() do tempdir
-        with_artifacts_directory(tempdir) do
-            ex = @test_throws ErrorException artifact"c_simple"
-            @test startswith(ex.value.msg, "Artifact \"c_simple\" was not installed correctly. ")
-            ex = @test_throws ErrorException artifact"socrates"
-            @test startswith(ex.value.msg, "Artifact \"socrates\" is a lazy artifact; ")
+    for imports in ("Artifacts, Pkg", "Pkg, Pkg.Artifacts", "Pkg.Artifacts")
+        mktempdir() do tempdir
+            with_artifacts_directory(tempdir) do
+                ex = @test_throws ErrorException artifact"c_simple"
+                @test startswith(ex.value.msg, "Artifact \"c_simple\" was not installed correctly. ")
+                ex = @test_throws ErrorException artifact"socrates"
+                @test startswith(ex.value.msg, "Artifact \"socrates\" is a lazy artifact; ")
+
+                # Can install if we load `Pkg` or `Pkg.Artifacts`
+                anon = Module(:__anon__)
+                Core.eval(anon, Meta.parse("using $(imports), Test"))
+                # Ensure that we get the expected exception, since this test runs with --depwarn=error
+                Core.eval(anon, quote
+                    try
+                        artifact"socrates"
+                        @assert false "this @artifact_str macro invocation should have failed!"
+                    catch e
+                        @test startswith("using Pkg instead of using LazyArtifacts is deprecated", e.msg)
+                    end
+                end)
+            end
         end
     end
 end


### PR DESCRIPTION
Just as we wanted to support users that used `using Pkg`, we should
support users that use `using Pkg.Artifacts` with their lazy artifacts.
This PR merely extends support to those users and adds regression tests.