### PR TITLE
Fix spawn test when env `BAR` is set

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -713,7 +713,7 @@ end
     @test strip(String(read(cmd))) == "baz bar"
 
     # Test that `addenv()` works properly with `inherit`
-    withenv("FOO" => "foo") do
+    withenv("FOO" => "foo", "BAR" => nothing) do
         cmd = Cmd(`$shcmd -c "echo \$FOO \$BAR"`)
         @test strip(String(read(cmd))) == "foo"
 


### PR DESCRIPTION
When running the "spawn" tests I noticed this failure:
```julia
spawn                              (7) |         failed at 2021-01-12T14:23:55.599
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/spawn.jl:718
  Expression: strip(String(read(cmd))) == "foo"
   Evaluated: "foo 2" == "foo"
```
I discovered that the issue was that I had set `BAR=2` in my shell environment before starting Julia and running the tests. The change here ensures that the test doesn't rely on the user not defining `BAR`.

One thing to note. This issue only seems to appear when you have compiled the Julia dependencies from source and doesn't occur when using BinaryBuilder dependencies.