### PR TITLE
Add noscope macro to make try blocks evaluate in the local scope

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1002,6 +1002,9 @@ export
     @specialize,
     @polly,
 
+    # scope manipulation
+    @noscope,
+
     @assert,
     @__dot__,
     @enum,

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -928,3 +928,24 @@ end
 @testset "issue #28188" begin
     @test `$(@__FILE__)` == let file = @__FILE__; `$file` end
 end
+
+@testset "`try` scope change via. @noscope" begin
+    @assert !isdefined(@__MODULE__, :noscopevar1)
+    try noscopevar1 = 1; catch; end
+    @assert !isdefined(@__MODULE__, :noscopevar1)
+
+    @noscope try noscopevar1 = 1; catch end
+    @test noscopevar1 == 1
+
+    @noscope try noscopevar2 = 1; catch err display(err); end
+    @test noscopevar2 == 1
+
+    @noscope try noscopevar3 = 1; catch err display(err); finally 0; end
+    @test noscopevar3 == 1
+
+    @noscope try noscopevar4 = 1; catch; 0; finally 0; end
+    @test noscopevar4 == 1
+
+    @noscope try noscopevar5 = 1; finally 0; end
+    @test noscopevar5 == 1
+end


### PR DESCRIPTION
It could be generally useful to evaluate a `try` in the local scope, as is the case in https://github.com/JuliaLang/julia/pull/39138

Based on a suggestion by @vtjnash this adds `@noscope` for making `try` blocks evaluate in the local scope

```
julia> x
ERROR: UndefVarError: x not defined

julia> try
            x = 1
            error()
        catch err
            display(err)
        finally
            println("finally")
        end
ErrorException()
finally

julia> x
ERROR: UndefVarError: x not defined

julia> @noscope try
            x = 1
            error()
        catch err
            display(err)
        finally
            println("finally")
        end
ErrorException()
finally

julia> x
1
```

If this is supported, there may be a better place for the code and tests to sit?