### PR TITLE
Refetch PTLS via Task struct (preparation for task migration)

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1458,7 +1458,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         JL_GC_POP();
         ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
         emit_signal_fence(ctx);
-        ctx.builder.CreateLoad(T_size, ctx.signalPage, true);
+        ctx.builder.CreateLoad(T_size, get_current_signal_page(ctx), true);
         emit_signal_fence(ctx);
         return ghostValue(jl_nothing_type);
     }
@@ -1467,14 +1467,14 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
         return mark_or_box_ccall_result(ctx,
-            ctx.builder.CreatePtrToInt(ctx.ptlsStates, lrt),
+            ctx.builder.CreatePtrToInt(get_current_ptls(ctx), lrt),
             retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_threadid)) {
         assert(lrt == T_int16);
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
-        Value *ptls_i16 = emit_bitcast(ctx, ctx.ptlsStates, T_pint16);
+        Value *ptls_i16 = emit_bitcast(ctx, get_current_ptls(ctx), T_pint16);
         const int tid_offset = offsetof(jl_tls_states_t, tid);
         Value *ptid = ctx.builder.CreateInBoundsGEP(ptls_i16, ConstantInt::get(T_size, tid_offset / 2));
         LoadInst *tid = ctx.builder.CreateAlignedLoad(ptid, Align(sizeof(int16_t)));
@@ -1485,18 +1485,14 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         assert(lrt == T_prjlvalue);
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
-        Value *ptls_pv = emit_bitcast(ctx, ctx.ptlsStates, T_pprjlvalue);
-        const int ct_offset = offsetof(jl_tls_states_t, current_task);
-        Value *pct = ctx.builder.CreateInBoundsGEP(ptls_pv, ConstantInt::get(T_size, ct_offset / sizeof(void*)));
-        LoadInst *ct = ctx.builder.CreateAlignedLoad(pct, Align(sizeof(void*)));
-        tbaa_decorate(tbaa_const, ct);
+        auto ct = get_current_task(ctx);
         return mark_or_box_ccall_result(ctx, ct, retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_set_next_task)) {
         assert(lrt == T_void);
         assert(!isVa && !llvmcall && nccallargs == 1);
         JL_GC_POP();
-        Value *ptls_pv = emit_bitcast(ctx, ctx.ptlsStates, T_ppjlvalue);
+        Value *ptls_pv = emit_bitcast(ctx, get_current_ptls(ctx), T_ppjlvalue);
         const int nt_offset = offsetof(jl_tls_states_t, next_task);
         Value *pnt = ctx.builder.CreateInBoundsGEP(ptls_pv, ConstantInt::get(T_size, nt_offset / sizeof(void*)));
         ctx.builder.CreateStore(emit_pointer_from_objref(ctx, boxed(ctx, argv[0])), pnt);
@@ -1537,7 +1533,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                 checkBB, contBB);
         ctx.builder.SetInsertPoint(checkBB);
         ctx.builder.CreateLoad(
-                ctx.builder.CreateConstInBoundsGEP1_32(T_size, ctx.signalPage, -1),
+                ctx.builder.CreateConstInBoundsGEP1_32(T_size, get_current_signal_page(ctx), -1),
                 true);
         ctx.builder.CreateBr(contBB);
         ctx.f->getBasicBlockList().push_back(contBB);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2761,7 +2761,7 @@ static void emit_cpointercheck(jl_codectx_t &ctx, const jl_cgval_t &x, const std
 // allocation for known size object
 static Value *emit_allocobj(jl_codectx_t &ctx, size_t static_size, Value *jt)
 {
-    Value *ptls_ptr = emit_bitcast(ctx, ctx.ptlsStates, T_pint8);
+    Value *ptls_ptr = emit_bitcast(ctx, get_current_ptls(ctx), T_pint8);
     Function *F = prepare_call(jl_alloc_obj_func);
     auto call = ctx.builder.CreateCall(F, {ptls_ptr, ConstantInt::get(T_size, static_size), maybe_decay_untracked(ctx, jt)});
     call->setAttributes(F->getAttributes());
@@ -3087,7 +3087,7 @@ static void emit_signal_fence(jl_codectx_t &ctx)
 
 static Value *emit_defer_signal(jl_codectx_t &ctx)
 {
-    Value *ptls = emit_bitcast(ctx, ctx.ptlsStates,
+    Value *ptls = emit_bitcast(ctx, get_current_ptls(ctx),
                                         PointerType::get(T_sigatomic, 0));
     Constant *offset = ConstantInt::getSigned(T_int32,
         offsetof(jl_tls_states_t, defer_signal) / sizeof(sig_atomic_t));

--- a/src/gc.c
+++ b/src/gc.c
@@ -342,8 +342,8 @@ static void jl_gc_push_arraylist(jl_ptls_t ptls, arraylist_t *list)
 {
     void **items = list->items;
     items[0] = (void*)JL_GC_ENCODE_PUSHARGS(list->len - 2);
-    items[1] = ptls->pgcstack;
-    ptls->pgcstack = (jl_gcframe_t*)items;
+    items[1] = jl_pgcstack;
+    jl_pgcstack = (jl_gcframe_t*)items;
 }
 
 // Same assumption as `jl_gc_push_arraylist`. Requires the finalizers lock
@@ -2630,7 +2630,7 @@ mark: {
             uintptr_t lb = 0;
             uintptr_t ub = (uintptr_t)-1;
             if (ptls2 && ta == ptls2->current_task) {
-                s = ptls2->pgcstack;
+                s = ta->gcstack;
             }
             else if (stkbuf) {
                 s = ta->gcstack;

--- a/src/init.c
+++ b/src/init.c
@@ -737,8 +737,8 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     // we need the `Task` type itself. We use stack-allocated "raw" `jl_task_t` struct to
     // workaround this chicken-and-egg problem. Note that this relies on GC to be turned
     // off just above as GC fails because we don't/can't allocate the type tag.
-    jl_task_t bootstrap_task;
-    bootstrap_task.gcstack = NULL;
+    jl_task_t bootstrap_task = {0};
+    assert(bootstrap_task.gcstack == NULL);
     jl_current_task = &bootstrap_task;
 
     jl_resolve_sysimg_location(rel);

--- a/src/julia.h
+++ b/src/julia.h
@@ -735,7 +735,7 @@ typedef struct _jl_gcframe_t {
 // jl_value_t *x=NULL, *y=NULL; JL_GC_PUSH2(&x, &y);
 // x = f(); y = g(); foo(x, y)
 
-#define jl_pgcstack (jl_get_ptls_states()->pgcstack)
+#define jl_pgcstack (jl_current_task->gcstack)
 
 #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<2)
 #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<2)|1)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1780,6 +1780,8 @@ typedef struct _jl_task_t {
     unsigned int copy_stack:31; // sizeof stack for copybuf
     unsigned int started:1;
 
+    jl_tls_states_t *ptls;
+
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
 } jl_task_t;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -181,7 +181,6 @@ struct _jl_bt_element_t;
 // Changes to TLS field types must be reflected in codegen.
 #define JL_MAX_BT_SIZE 80000
 struct _jl_tls_states_t {
-    struct _jl_gcframe_t *pgcstack;
     size_t world_age;
     int16_t tid;
     uint64_t rngseed;

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -69,6 +69,7 @@ void JuliaPassContext::initAll(Module &M)
     T_ppjlvalue = PointerType::get(T_pjlvalue, 0);
     T_pjlvalue_der = PointerType::get(T_jlvalue, AddressSpace::Derived);
     T_ppjlvalue_der = PointerType::get(T_prjlvalue, AddressSpace::Derived);
+    T_pppjlvalue = PointerType::get(T_ppjlvalue, 0);
 }
 
 llvm::CallInst *JuliaPassContext::getPtls(llvm::Function &F) const

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -49,6 +49,7 @@ struct JuliaPassContext {
     // Types derived from 'jl_value_t'.
     llvm::Type *T_jlvalue;
     llvm::PointerType *T_prjlvalue;
+    llvm::PointerType *T_pppjlvalue;
     llvm::PointerType *T_ppjlvalue;
     llvm::PointerType *T_pjlvalue;
     llvm::PointerType *T_pjlvalue_der;

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -214,7 +214,7 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     jl_task_t *current_task = ptls->current_task;
     // Must have no safepoint
     eh->prev = current_task->eh;
-    eh->gcstack = ptls->pgcstack;
+    eh->gcstack = current_task->gcstack;
     eh->gc_state = ptls->gc_state;
     eh->locks_len = ptls->locks.len;
     eh->defer_signal = ptls->defer_signal;
@@ -246,7 +246,7 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_handler_t *eh)
     sig_atomic_t old_defer_signal = ptls->defer_signal;
     int8_t old_gc_state = ptls->gc_state;
     current_task->eh = eh->prev;
-    ptls->pgcstack = eh->gcstack;
+    current_task->gcstack = eh->gcstack;
     small_arraylist_t *locks = &ptls->locks;
     int unlocks = locks->len > eh->locks_len;
     if (unlocks) {

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -189,8 +189,9 @@ static void jl_throw_in_thread(int tid, mach_port_t thread, jl_value_t *exceptio
     jl_ptls_t ptls2 = jl_all_tls_states[tid];
     if (!ptls2->safe_restore) {
         assert(exception);
-        ptls2->bt_size = rec_backtrace_ctx(ptls2->bt_data, JL_MAX_BT_SIZE,
-                                           (bt_context_t*)&state, ptls2->pgcstack);
+        ptls2->bt_size =
+            rec_backtrace_ctx(ptls2->bt_data, JL_MAX_BT_SIZE, (bt_context_t *)&state,
+                              ptls2->current_task->gcstack);
         ptls2->sig_exception = exception;
     }
     jl_call_in_state(ptls2, &state, &jl_sig_throw);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -186,8 +186,9 @@ static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void), int sig, void *_c
 static void jl_throw_in_ctx(jl_ptls_t ptls, jl_value_t *e, int sig, void *sigctx)
 {
     if (!ptls->safe_restore)
-        ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE,
-                                          jl_to_bt_context(sigctx), ptls->pgcstack);
+        ptls->bt_size =
+            rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, jl_to_bt_context(sigctx),
+                              ptls->current_task->gcstack);
     ptls->sig_exception = e;
     jl_call_in_ctx(ptls, &jl_sig_throw, sig, sigctx);
 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -108,7 +108,9 @@ static int have_backtrace_fiber;
 static void JL_NORETURN start_backtrace_fiber(void)
 {
     // collect the backtrace
-    stkerror_ptls->bt_size = rec_backtrace_ctx(stkerror_ptls->bt_data, JL_MAX_BT_SIZE, stkerror_ctx, stkerror_ptls->pgcstack);
+    stkerror_ptls->bt_size =
+        rec_backtrace_ctx(stkerror_ptls->bt_data, JL_MAX_BT_SIZE, stkerror_ctx,
+                          stkerror_ptls->current_task->gcstack);
     // switch back to the execution fiber
     jl_setcontext(&error_return_fiber);
     abort();
@@ -134,7 +136,8 @@ void jl_throw_in_ctx(jl_value_t *excpt, PCONTEXT ctxThread)
         assert(excpt != NULL);
         ptls->bt_size = 0;
         if (excpt != jl_stackovf_exception) {
-            ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, ctxThread, ptls->pgcstack);
+            ptls->bt_size = rec_backtrace_ctx(ptls->bt_data, JL_MAX_BT_SIZE, ctxThread,
+                                              ptls->current_task->gcstack);
         }
         else if (have_backtrace_fiber) {
             JL_LOCK(&backtrace_lock);

--- a/src/task.c
+++ b/src/task.c
@@ -396,14 +396,12 @@ static void ctx_switch(jl_ptls_t ptls)
         else
 #endif
         *pt = NULL; // can't fail after here: clear the gc-root for the target task now
-        lastt->gcstack = ptls->pgcstack;
+        lastt->ptls = NULL;
     }
 
     // set up global state for new task
     t->ptls = ptls;
-    ptls->pgcstack = t->gcstack;
     ptls->world_age = 0;
-    t->gcstack = NULL;
 #ifdef MIGRATE_TASKS
     ptls->previous_task = lastt;
 #endif

--- a/src/task.c
+++ b/src/task.c
@@ -400,6 +400,7 @@ static void ctx_switch(jl_ptls_t ptls)
     }
 
     // set up global state for new task
+    t->ptls = ptls;
     ptls->pgcstack = t->gcstack;
     ptls->world_age = 0;
     t->gcstack = NULL;
@@ -708,6 +709,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->started = 0;
     t->prio = -1;
     t->tid = -1;
+    t->ptls = ptls;
 
 #if defined(JL_DEBUG_BUILD)
     if (!t->copy_stack)
@@ -1259,6 +1261,7 @@ void jl_init_root_task(void *stack_lo, void *stack_hi)
     ptls->current_task->excstack = NULL;
     ptls->current_task->tid = ptls->tid;
     ptls->current_task->sticky = 1;
+    ptls->current_task->ptls = ptls;
 
 #ifdef JL_TSAN_ENABLED
     ptls->current_task->tsan_state = __tsan_get_current_fiber();

--- a/src/threading.c
+++ b/src/threading.c
@@ -252,7 +252,6 @@ void jl_init_threadtls(int16_t tid)
     assert(ptls->world_age == 0);
     ptls->world_age = 1; // OK to run Julia code on this thread
     ptls->tid = tid;
-    ptls->pgcstack = NULL;
     ptls->gc_state = 0; // GC unsafe
     // Conditionally initialize the safepoint address. See comment in
     // `safepoint.c`


### PR DESCRIPTION
This is an alternative approach to #39168. In this patch, PTLS is refetched through `jl_task_t`. We can "cache" the pointer to the `jl_task_t` as SSA variable since it is guaranteed that the task does not change within a function [1].

Functionally, I think the first commit is sufficient.  In the second commit, I removed `pgcstack` from PTLS as it's redundant. It turned out there is a bit of bootstrapping issue since we need to `Task` type to allocate a task but we need `gcstack` in `Task` field to create `Task` type.

I'm not sure what memory ordering of load we should use for refetching PTLS so I just put `monotonic` as the weakest placeholder (since `unordered` gets reordered w.r.t the function calls).

As I mentioned in the last comment https://github.com/JuliaLang/julia/pull/39168#issuecomment-757551959, a major disadvantage of this approach is that LICM of `threadid()` would not work. However, it might be better to stop using `array[threadid()]` pattern for "thread-local storage" anyway.

There are some test failures in codegen test. I'll fix them once this direction is OK.

[1] This won't be the case if we start doing continuation stealing like Cilk. But, I think we can mix the approach taken in #39168 to refetch the pointer to the task struct at the beginning of the continuation conditionally and then propagate the task pointer via phi nodes.

### Demo

```julia
function f()
    a = Threads.threadid()
    yield()
    b = Threads.threadid()
    (a, b)
end
```

#### `@code_llvm debuginfo=:none optimize=false f()`

```llvm
define void @julia_f_222([2 x i64]* noalias nocapture sret %0) {
top:
  %1 = alloca [2 x i64], align 8
  %2 = call {}*** @julia.ptls_states()
  %3 = bitcast {}*** %2 to {}**
  %current_task_field = getelementptr inbounds {}*, {}** %3, i64 825
  %current_task = load {}*, {}** %current_task_field, align 8
  %4 = bitcast {}* %current_task to {}**
  %ptls_field = getelementptr inbounds {}*, {}** %4, i64 38
  %5 = bitcast {}** %ptls_field to {}**
  %ptls_load = load atomic {}*, {}** %5 monotonic, align 8
  %6 = bitcast {}* %ptls_load to {}**
  %7 = bitcast {}** %6 to i16*
  %8 = getelementptr inbounds i16, i16* %7, i64 4
  %9 = load i16, i16* %8, align 2
  %10 = sext i16 %9 to i64
  %11 = add i64 %10, 1
  %12 = call nonnull {}* @j_yield_224()
  %13 = bitcast {}* %current_task to {}**
  %ptls_field1 = getelementptr inbounds {}*, {}** %13, i64 38
  %14 = bitcast {}** %ptls_field1 to {}**
  %ptls_load2 = load atomic {}*, {}** %14 monotonic, align 8
  %15 = bitcast {}* %ptls_load2 to {}**
  %16 = bitcast {}** %15 to i16*
  %17 = getelementptr inbounds i16, i16* %16, i64 4
  %18 = load i16, i16* %17, align 2
  %19 = sext i16 %18 to i64
  %20 = add i64 %19, 1
  %21 = getelementptr inbounds [2 x i64], [2 x i64]* %1, i32 0, i32 0
  store i64 %11, i64* %21, align 8
  %22 = getelementptr inbounds [2 x i64], [2 x i64]* %1, i32 0, i32 1
  store i64 %20, i64* %22, align 8
  %23 = bitcast [2 x i64]* %0 to i8*
  %24 = bitcast [2 x i64]* %1 to i8*
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %23, i8* %24, i64 16, i1 false)
  ret void
}
```

You can see `%ptls_load2 = load ...` after `@j_yield_224()`.

#### `@code_llvm debuginfo=:none f()`

```llvm
define void @julia_f_183([2 x i64]* noalias nocapture sret %0) {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #4
  %current_task_field4 = getelementptr i8, i8* %thread_ptr, i64 -26168
  %1 = bitcast i8* %current_task_field4 to {}***
  %current_task5 = load {}**, {}*** %1, align 8
  %ptls_field6 = getelementptr inbounds {}*, {}** %current_task5, i64 38
  %2 = bitcast {}** %ptls_field6 to {}**
  %ptls_load = load atomic {}*, {}** %2 monotonic, align 8
  %3 = bitcast {}* %ptls_load to i16*
  %4 = getelementptr inbounds i16, i16* %3, i64 4
  %5 = load i16, i16* %4, align 2
  %6 = sext i16 %5 to i64
  %7 = add nsw i64 %6, 1
  %8 = call nonnull {}* @j_yield_185()
  %ptls_load2 = load atomic {}*, {}** %2 monotonic, align 8
  %9 = bitcast {}* %ptls_load2 to i16*
  %10 = getelementptr inbounds i16, i16* %9, i64 4
  %11 = load i16, i16* %10, align 2
  %12 = sext i16 %11 to i64
  %13 = add nsw i64 %12, 1
  %.sroa.0.0..sroa_idx = getelementptr inbounds [2 x i64], [2 x i64]* %0, i64 0, i64 0
  store i64 %7, i64* %.sroa.0.0..sroa_idx, align 8
  %.sroa.2.0..sroa_idx3 = getelementptr inbounds [2 x i64], [2 x i64]* %0, i64 0, i64 1
  store i64 %13, i64* %.sroa.2.0..sroa_idx3, align 8
  ret void
}
```
