### PR TITLE
range: Assume start=1 when not given. Use OneTo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ Standard library changes
 
 * `count` and `findall` now accept an `AbstractChar` argument to search for a character in a string ([#38675]).
 * `range` now supports `start` as an optional keyword argument ([#38041]).
+* `range` now accepts a single positional argument as `stop` and may assume `start = 1` when `start` is not provided ([#39223])
 * `islowercase` and `isuppercase` are now compliant with the Unicode lower/uppercase categories ([#38574]).
 * `iseven` and `isodd` functions now support non-`Integer` numeric types ([#38976]).
 * `escape_string` can now receive a collection of characters in the keyword

--- a/base/range.jl
+++ b/base/range.jl
@@ -96,8 +96,11 @@ Base.OneTo(5)
 julia> range(; length = 10)
 Base.OneTo(10)
 
-julia> range(; stop = 5)
-1:5
+julia> range(; stop = 6)
+Base.OneTo(6)
+
+julia> range(; stop = 6.5)
+1.0:1.0:6.0
 ```
 If `length` is not specified and `stop - start` is not an integer multiple of `step`, a range that ends before `stop` will be produced.
 ```jldoctest
@@ -138,7 +141,7 @@ function range end
 
 range(start; stop=nothing, length::Union{Integer,Nothing}=nothing, step=nothing) =
     stop === length === step === nothing ?
-    range_stop(start) :
+    _range(nothing, nothing, start, nothing) :
     _range(start, step, stop, length)
 
 function range(start, stop; length::Union{Integer,Nothing}=nothing, step=nothing)

--- a/base/range.jl
+++ b/base/range.jl
@@ -56,10 +56,10 @@ Construct a specialized array with evenly spaced elements and optimized storage 
 Mathematically a range is uniquely determined by any three of `start`, `step`, `stop` and `length`.
 Valid invocations of range are:
 * Call `range` with any three of `start`, `step`, `stop`, `length`.
-* Call `range` with two of `start`, `stop`, `length`. In this case `step` will be assumed
-to be one. If both arguments are Integers, a [`UnitRange`](@ref) will be returned.
-* Call `range` with `step` and either `stop` or `length`. `start` will be assumed to be one.
-* Call `range` with one of `stop` or `length`. `start` and `step` will be assumed to be one.
+* Call `range` with fewer than three parameters. Either `stop` or `length` must be specified.
+If not provided, `step` and/or `start` are assumed to be one in that order of precedence.
+
+See Extended Help for additional details on the returned type.
 
 # Examples
 ```jldoctest
@@ -117,9 +117,12 @@ If both are specified as positional arguments, one of `step` or `length` must al
 !!! compat "Julia 1.7"
     Assuming `start` is one when not provided,
     `start` as a keyword argument, or
-    `length` as a positional argument requires at least Julia 1.7.
+    `stop` as a sole positional argument requires at least Julia 1.7.
 
 # Extended Help
+
+If only `length` and `stop` are provided as arguments, `step` rather than `start` is assumed
+to be one.
 
 `range` will produce a `Base.OneTo` when the arguments are Integers and
 * Only `length` is provided
@@ -129,7 +132,7 @@ If both are specified as positional arguments, one of `step` or `length` must al
 * Only `start`  and `stop` are provided
 * Only `length` and `stop` are provided
 
-A `UnitRange` is not produced if `step` is specified even if specified as one.
+A `UnitRange` is not produced if `step` is provided even if specified as one.
 """
 function range end
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -50,7 +50,7 @@ end
     range(start, stop; length, step)
     range(start; length, stop, step)
     range(;start, length, stop, step)
-    range(length::Integer)
+    range(stop)
 
 Construct a specialized array with evenly spaced elements and optimized storage (an [`AbstractRange`](@ref)) from the arguments.
 Mathematically a range is uniquely determined by any three of `start`, `step`, `stop` and `length`.

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -17,6 +17,22 @@
         # the next one uses ==, because it changes the eltype
         @test r  == range(start=first(r), stop=last(r), length=length(r))
         @test r === range(                stop=last(r), length=length(r))
+
+        r = 1:5
+        o = OneTo(5)
+        let start=first(r), step=step(r), stop=last(r), length=length(r)
+        @test o === range(                     length)
+        @test o === range(;              stop        )
+        @test o === range(;                    length)
+        @test r === range(; start,       stop        )
+        @test r === range(;              stop, length)
+        # the next four uses ==, because it changes the eltype
+        @test r ==  range(;        step, stop        )
+        @test r ==  range(;        step,       length)
+        @test r ==  range(; start,       stop, length)
+        @test r ==  range(; start, step,       length)
+        @test r ==  range(Float64(stop))
+        end
     end
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1459,10 +1459,8 @@ end
 end
 
 @testset "Bad range calls" begin
-    @test_throws ArgumentError range(1)
     @test_throws ArgumentError range(nothing)
     @test_throws ArgumentError range(1, step=4)
-    @test_throws ArgumentError range(nothing, length=2)
     @test_throws ArgumentError range(1.0, step=0.25, stop=2.0, length=5)
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -19,7 +19,7 @@
         @test r === range(                stop=last(r), length=length(r))
 
         r = 1:5
-        o = OneTo(5)
+        o = Base.OneTo(5)
         let start=first(r), step=step(r), stop=last(r), length=length(r)
         @test o === range(                     length)
         @test o === range(;              stop        )


### PR DESCRIPTION
This pull request expands the valid input to `range` when `start` can be assumed to be one and allows for a single positional argument to be `stop`.

`Base.OneTo` is used if either `stop` or `length` is provided as a single argument and are Integers.

```julia
julia> range(5)
Base.OneTo(5)

julia> range(6.0)
1.0:1.0:6.0

julia> range(; stop=7.5)
1.0:1.0:7.0

julia> range(; length=8)
Base.OneTo(8)

julia> range(; step=3, stop=7)
1:3:7

julia> range(; step=3, length=7)
1:3:19

julia> range(; stop=10, length=5) # Controversy: assumes step=1 rather than start=1
6:10
```

This pull request does not enable two or three positional argument syntax.