### PR TITLE
Backport "Ensure underscore is applied to trampoline symbols on OSX [#38925]" to release-1.6

### DIFF
--- a/cli/trampolines/trampolines_x86_64.S
+++ b/cli/trampolines/trampolines_x86_64.S
@@ -34,10 +34,10 @@
 
 #define XX(name) \
 DEBUGINFO(name); \
-.global name; \
+.global CNAME(name); \
 .cfi_startproc; \
 SEH_START1(name); \
-name##:; \
+CNAME(name)##:; \
 SEH_START2(); \
     CET_START(); \
     mov CNAME(name##_addr)(%rip),%r11; \


### PR DESCRIPTION
When backporting PR #38938, one commit was omitted, which means that issue #38925 still affects the release-1.6 branch. This PR backports the missing commit.

CC @KristofferC 

Fixes #38925