### PR TITLE
Fix documentation of strip

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -290,7 +290,7 @@ rstrip(s::AbstractString, chars::Chars) = rstrip(in(chars), s)
 Remove leading and trailing characters from `str`, either those specified by `chars` or
 those for which the function `pred` returns `true`.
 
-The default behaviour is to remove leading whitespace and delimiters: see
+The default behaviour is to remove leading and trailing whitespace and delimiters: see
 [`isspace`](@ref) for precise details.
 
 The optional `chars` argument specifies which characters to remove: it can be a single


### PR DESCRIPTION
I noticed that `strip`'s documentation states that 
```
The default behavior is to remove leading whitespace and delimiters: see `isspace` for precise details.
```
This is, of course, not true because it also removes trailing white spaces. In Julia 1.5.3:
```
julia> strip("  foo\n  ")
"foo"
```
This mistake is probably caused by copying text from `lstrip`.