### PR TITLE
Add distclean-csl rule

### DIFF
--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -75,6 +75,7 @@ clean-csl:
 	-rm -f $(build_shlibdir)/libwinpthread*$(SHLIB_EXT)*
 	-rm -f $(build_shlibdir)/libatomic*$(SHLIB_EXT)*
 	-rm -f $(build_shlibdir)/libgomp*$(SHLIB_EXT)*
+distclean-csl: clean-csl
 
 else
 $(eval $(call bb-install,csl,CSL,true))


### PR DESCRIPTION
Adds a `distclean-csl` rule to silence this error:
```
$ make distcleanall
...
make[1]: *** No rule to make target `distclean-csl', needed by `distcleanall'.  Stop.
make: [distcleanall] Error 2 (ignored)
```