### PR TITLE
fix #39218, bug in subtyping fast path for tuples with repeated elements

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1033,7 +1033,7 @@ static int subtype_tuple_tail(jl_datatype_t *xd, jl_datatype_t *yd, int8_t R, jl
             // an identical type on the left doesn't need to be compared to a Vararg
             // element type on the right more than twice.
         }
-        else if (x_same &&
+        else if (x_same && e->Runions.depth == 0 &&
             ((yi == lasty && !jl_has_free_typevars(xi) && !jl_has_free_typevars(yi)) ||
              (yi == lastx && !vx && vy && jl_is_concrete_type(xi)))) {
             // fast path for repeated elements

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1854,3 +1854,17 @@ let A = Tuple{Type{T} where T<:Ref, Ref, Union{T, Union{Ref{T}, T}} where T<:Ref
     @test I == typeintersect(A,B)
     @test I == Tuple{Type{T}, Ref{T}, Union{Ref{T}, T}} where T<:Ref
 end
+
+# issue #39218
+let A = Int, B = String, U = Union{A, B}
+    @test issub_strict(Union{Tuple{A, A}, Tuple{B, B}}, Tuple{U, U})
+    @test issub_strict(Union{Tuple{A, A}, Tuple{B, B}}, Tuple{Union{A, B}, Union{A, B}})
+end
+
+struct A39218 end
+struct B39218 end
+const AB39218 = Union{A39218,B39218}
+f39218(::T, ::T) where {T<:AB39218} = false
+g39218(a, b) = (@nospecialize; if a isa AB39218 && b isa AB39218; f39218(a, b); end;)
+@test g39218(A39218(), A39218()) === false
+@test_throws MethodError g39218(A39218(), B39218())


### PR DESCRIPTION
fix #39218

This bug seems to go all the way back to v0.6.
