### PR TITLE
Address corner cases in "loading" test suite

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -195,12 +195,11 @@ saved_load_path = copy(LOAD_PATH)
 saved_depot_path = copy(DEPOT_PATH)
 saved_active_project = Base.ACTIVE_PROJECT[]
 
-push!(empty!(LOAD_PATH), "project")
-append!(empty!(DEPOT_PATH), [mktempdir(), "depot"])
+push!(empty!(LOAD_PATH), joinpath(@__DIR__, "project"))
+append!(empty!(DEPOT_PATH), [mktempdir(), joinpath(@__DIR__, "depot")])
 Base.ACTIVE_PROJECT[] = nothing
 
-@test load_path() == [abspath("project","Project.toml")]
-
+@test load_path() == [joinpath(@__DIR__, "project", "Project.toml")]
 
 # locate `tail(names)` package by following the search path graph through `names` starting from `where`
 function recurse_package(where::PkgId, name::String, names::String...)


### PR DESCRIPTION
Fixes the loading test when using `Base.runtests`. Without this PR I was seeing the following:
```sh
$ make test-loading
...
    JULIA test/loading
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
loading    (1) |        started at 2021-01-13T15:47:50.886
WARNING: replacing module Foo.
loading    (1) |    24.62 |   0.35 |  1.4 |    2996.02 |  1230.09

Test Summary: |   Pass   Total
  Overall     | 153686  153686
    SUCCESS

$ ./julia -e 'Base.runtests("loading")'
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
loading    (1) |        started at 2021-01-13T15:50:05.342
WARNING: replacing module Foo.
loading    (1) |         failed at 2021-01-13T15:50:30.019
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233
  Expression: joinpath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233 =# @__DIR__(), normpath(path)) == locate_package(pkg)
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Foo1/src/Foo.jl" == "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Foo1/src/Foo.jl"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233
  Expression: joinpath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233 =# @__DIR__(), normpath(path)) == locate_package(pkg)
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Foo2.jl/src/Foo.jl" == "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Foo2.jl/src/Foo.jl"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233
  Expression: joinpath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233 =# @__DIR__(), normpath(path)) == locate_package(pkg)
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Bar/src/Bar.jl" == "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Bar/src/Bar.jl"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233
  Expression: joinpath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233 =# @__DIR__(), normpath(path)) == locate_package(pkg)
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/depot/packages/Baz/81oLe/src/Baz.jl" == "/Users/omus/Development/Julia/x86/latest-src/test/depot/packages/Baz/81oLe/src/Baz.jl"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233
  Expression: joinpath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:233 =# @__DIR__(), normpath(path)) == locate_package(pkg)
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Qux.jl" == "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Qux.jl"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:309
  Expression: pathof(Foo) == normpath(abspath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:309 =# @__DIR__(), "project/deps/Foo1/src/Foo.jl"))
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Foo1/src/Foo.jl" == "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Foo1/src/Foo.jl"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:314
  Expression: pkgdir(Foo) == normpath(abspath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:314 =# @__DIR__(), "project/deps/Foo1"))
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Foo1" == "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Foo1"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:315
  Expression: pkgdir(Foo.SubFoo1) == normpath(abspath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:315 =# @__DIR__(), "project/deps/Foo1"))
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Foo1" == "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Foo1"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:316
  Expression: pkgdir(Foo.SubFoo2) == normpath(abspath(#= /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:316 =# @__DIR__(), "project/deps/Foo1"))
   Evaluated: "/Users/omus/Development/Julia/x86/latest-src/test/project/deps/Foo1" == "/Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/project/deps/Foo1"


Test Summary: |   Pass  Fail   Total
  Overall     | 148115     9  148124
    loading   | 148115     9  148124
    FAILURE

The global RNG seed was 0x5465f668216310b3d39c95fa57d3ce57.
```

Additionally using the `--color=yes` flag would cause other tests to fail:
```sh
$ ./julia --color=yes -e 'Base.runtests("loading")'
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
loading    (1) |        started at 2021-01-13T15:57:13.293
WARNING: replacing module Foo.
loading    (1) |         failed at 2021-01-13T15:57:38.437
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:53
  Expression: readchomp(`$exename -E "@__DIR__" -i`) == wd
   Evaluated: "\"/Users/omus/Development/Julia/x86/latest-src/test\"\n\e[0m\e[0m" == "\"/Users/omus/Development/Julia/x86/latest-src/test\""
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:54
  Expression: readchomp(`$exename -E "cd(()->eval(:(@__DIR__)), $s_dir)" -i`) == s_dir
   Evaluated: "\"/private/var/folders/j7/fwm5mtz52_xdxds4f1rnhn9c0000gn/T\"\n\e[0m\e[0m" == "\"/private/var/folders/j7/fwm5mtz52_xdxds4f1rnhn9c0000gn/T\""


Test Summary: |   Pass  Fail   Total
  Overall     | 155820     2  155822
    loading   | 155820     2  155822
    FAILURE

The global RNG seed was 0xafd5b59c67378aaf18573902b583186a.
```