### PR TITLE
Update manual: Vararg{T,N} is not a type anymore

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2357,8 +2357,8 @@ kw"::"
 """
     Vararg{T,N}
 
-The last parameter of a tuple type [`Tuple`](@ref) can be the special type `Vararg`, which denotes any
-number of trailing elements. The type `Vararg{T,N}` corresponds to exactly `N` elements of type `T`.
+The last parameter of a tuple type [`Tuple`](@ref) can be the special value `Vararg`, which denotes any
+number of trailing elements. `Vararg{T,N}` corresponds to exactly `N` elements of type `T`. Finally
 `Vararg{T}` corresponds to zero or more elements of type `T`. `Vararg` tuple types are used to represent the
 arguments accepted by varargs methods (see the section on [Varargs Functions](@ref) in the manual.)
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -916,10 +916,11 @@ julia> isa(("1",1,2,3.0), mytupletype)
 false
 ```
 
-Notice that `Vararg{T}` corresponds to zero or more elements of type `T`. Vararg tuple types are
+Moreover `Vararg{T}` corresponds to zero or more elements of type `T`. Vararg tuple types are
 used to represent the arguments accepted by varargs methods (see [Varargs Functions](@ref)).
 
-The type `Vararg{T,N}` corresponds to exactly `N` elements of type `T`.  `NTuple{N,T}` is a convenient
+The special value `Vararg{T,N}` (when used as the last parameter of a tuple type)
+corresponds to exactly `N` elements of type `T`.  `NTuple{N,T}` is a convenient
 alias for `Tuple{Vararg{T,N}}`, i.e. a tuple type containing exactly `N` elements of type `T`.
 
 ### Named Tuple Types


### PR DESCRIPTION
I used the term "special value" as that is used a few lines above.

Perhaps this could be backported to 1.6, to avoid confusion there, too?