### PR TITLE
Export oneto rather than implement range(stop)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,7 @@ Standard library changes
 
 * `count` and `findall` now accept an `AbstractChar` argument to search for a character in a string ([#38675]).
 * `range` now supports `start` as an optional keyword argument ([#38041]).
-* `oneto` is exported and allows access to `Base.OneTo`, an optimized version of `1:n` where `n` is an `Integer` ([#39242]).
+* `oneto` is exported and returns the equivalen to `1:n` where `n` is an `Integer` ([#39242]).
 * `islowercase` and `isuppercase` are now compliant with the Unicode lower/uppercase categories ([#38574]).
 * `iseven` and `isodd` functions now support non-`Integer` numeric types ([#38976]).
 * `escape_string` can now receive a collection of characters in the keyword

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ Standard library changes
 
 * `count` and `findall` now accept an `AbstractChar` argument to search for a character in a string ([#38675]).
 * `range` now supports `start` as an optional keyword argument ([#38041]).
+* `oneto` is exported and allows access to `Base.OneTo`, an optimized version of `1:n` where `n` is an `Integer` ([#39242]).
 * `islowercase` and `isuppercase` are now compliant with the Unicode lower/uppercase categories ([#38574]).
 * `iseven` and `isodd` functions now support non-`Integer` numeric types ([#38976]).
 * `escape_string` can now receive a collection of characters in the keyword

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -405,6 +405,7 @@ export
     minmax,
     ndims,
     ones,
+    oneto,
     parent,
     parentindices,
     partialsort,

--- a/base/range.jl
+++ b/base/range.jl
@@ -421,7 +421,7 @@ OneTo(r::AbstractRange{T}) where {T<:Integer} = OneTo{T}(r)
 
 Create an `AbstractRange` that behaves like to `1:n`. The returned
 range may be more efficient than using `1:n` since the lower limit
-is guaranteed to be one by the type system. The definition in `Base`
+is guaranteed to be 1 by the type system. The definition in `Base`
 requires that `n` be an `Integer`.
 
 See also [`Base.OneTo`](@ref).

--- a/base/range.jl
+++ b/base/range.jl
@@ -417,14 +417,11 @@ OneTo(stop::T) where {T<:Integer} = OneTo{T}(stop)
 OneTo(r::AbstractRange{T}) where {T<:Integer} = OneTo{T}(r)
 
 """
-    oneto(n)
+    oneto(n::Integer)
 
-Create an `AbstractRange` that behaves like to `1:n`. The returned
-range may be more efficient than using `1:n` since the lower limit
-is guaranteed to be one by the type system. The definition in `Base`
-requires that `n` be an `Integer`.
-
-See also [`Base.OneTo`](@ref).
+Create an [`AbstractRange`](@ref) that behaves like to `1:n`
+where `n` must be an Integer. The returned `AbstractRange`
+may be more efficient than `1:n`. See also [`range`](@ref).
 
 # Examples
 ```jldoctest
@@ -440,9 +437,11 @@ julia> collect( oneto(6) )
  5
  6
 
+julia> oneto(3) == range(1; stop = 3)
+true
+
 julia> oneto(5.5)
 ERROR: MethodError: no method matching Base.OneTo(::Float64)
-...
 ```
 """
 oneto(r) = OneTo(r)

--- a/base/range.jl
+++ b/base/range.jl
@@ -430,7 +430,7 @@ julia> oneto(5)
 Base.OneTo(5)
 
 julia> collect( oneto(6) )
-6-element Array{Int64,1}:
+6-element Vector{Int64}:
  1
  2
  3

--- a/base/range.jl
+++ b/base/range.jl
@@ -443,7 +443,7 @@ julia> collect( oneto(6) )
 julia> oneto(5.5)
 ERROR: MethodError: no method matching Base.OneTo(::Float64)
 ...
-````
+```
 """
 oneto(r) = OneTo(r)
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -415,6 +415,36 @@ struct OneTo{T<:Integer} <: AbstractUnitRange{T}
 end
 OneTo(stop::T) where {T<:Integer} = OneTo{T}(stop)
 OneTo(r::AbstractRange{T}) where {T<:Integer} = OneTo{T}(r)
+
+"""
+    oneto(n)
+
+Create an `AbstractRange` that behaves like to `1:n`. The returned
+range may be more efficient than using `1:n` since the lower limit
+is guaranteed to be one by the type system. The definition in `Base`
+requires that `n` be an `Integer`.
+
+See also [`Base.OneTo`](@ref).
+
+# Examples
+```jldoctest
+julia> oneto(5)
+Base.OneTo(5)
+
+julia> collect( oneto(6) )
+6-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+
+julia> oneto(5.5)
+ERROR: MethodError: no method matching Base.OneTo(::Float64)
+...
+````
+"""
 oneto(r) = OneTo(r)
 
 ## Step ranges parameterized by length

--- a/base/range.jl
+++ b/base/range.jl
@@ -421,7 +421,8 @@ OneTo(r::AbstractRange{T}) where {T<:Integer} = OneTo{T}(r)
 
 Create an [`AbstractRange`](@ref) that behaves like to `1:n`
 where `n` must be an Integer. The returned `AbstractRange`
-may be more efficient than `1:n`. See also [`range`](@ref).
+may be more efficient than `1:n`. See also [`:`](@ref) and
+[`range`](@ref).
 
 # Examples
 ```jldoctest

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -863,6 +863,7 @@ end
     @test 1:10 != 2:10 != 2:11 != Base.OneTo(11)
     @test Base.OneTo(10) != Base.OneTo(11) != 1:10
     @test Base.OneTo(0) == 5:4
+    @test oneto(5) == 1:5
 end
 # issue #2959
 @test 1.0:1.5 == 1.0:1.0:1.5 == 1.0:1.0
@@ -1271,6 +1272,7 @@ end
         @test isempty(r)
         @test length(r) == 0
         @test size(r) == (0,)
+        @test r === oneto(-5)
     end
     let r = Base.OneTo(3)
         @test !isempty(r)
@@ -1290,6 +1292,7 @@ end
         @test broadcast(+, r, 1) === 2:4
         @test 2*r === 2:2:6
         @test r + r === 2:2:6
+        @test r === oneto(3)
         k = 0
         for i in r
             @test i == (k += 1)
@@ -1317,6 +1320,7 @@ end
     @test Base.OneTo{Int32}(1:2) === Base.OneTo{Int32}(2)
     @test Base.OneTo(Int32(1):Int32(2)) === Base.OneTo{Int32}(2)
     @test Base.OneTo{Int16}(3.0) === Base.OneTo{Int16}(3)
+    @test oneto(9) === Base.OneTo{Int}(9)
     @test_throws InexactError(:Int16, Int16, 3.2) Base.OneTo{Int16}(3.2)
 end
 


### PR DESCRIPTION
# Export `oneto` as an alternative to `range(stop)`
* `oneto(n)` is an unambiguous alternative to `range(stop)`
* `oneto(n)` may be more intuitive than `1:n` for some people from distinct coding traditions (e.g. Python)
* `oneto(n)` uses Julia's type system to allow for fast code (via `Base.OneTo`)

Since a single argument `range` mapping to `Base.OneTo` is controversial (see #39223), let's export the recently created `oneto` (all lower case) which is unambiguous and accepts a single `Integer` argument.

`oneto` was recently merged into `Base` via #37741.  `oneto` is five lowercase letters like `range` but it clearly describes what it does. Additionally, as demonstrated by #37741 it can be extended for uses not directly involving `Base.OneTo`.

By exporting `oneto` we will make a highly optimized code path easily available for a very common use case.