### PR TITLE
RFC: `eachsplit` for iterative splitting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ New language features
 * `@inline` and `@noinline` annotations can now be applied to a function callsite or block
   to enforce the involved function calls to be (or not to be) inlined. ([#41312])
 * The default behavior of observing `@inbounds` declarations is now an option via `auto` in `--check-bounds=yes|no|auto` ([#41551])
+* New function `eachsplit(str)` for iteratively performing `split(str)`.
 
 Language changes
 ----------------

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -706,7 +706,7 @@ function Base.parse(::Type{Platform}, triplet::AbstractString; validate_strict::
         libstdcxx_version = get_field(m, libstdcxx_version_mapping)
         cxxstring_abi = get_field(m, cxxstring_abi_mapping)
         function split_tags(tagstr)
-            tag_fields = filter(!isempty, split(tagstr, "-"))
+            tag_fields = split(tagstr, "-"; keepempty=false)
             if isempty(tag_fields)
                 return Pair{String,String}[]
             end

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -269,7 +269,7 @@ function addenv(cmd::Cmd, env::Dict; inherit::Bool = true)
             merge!(new_env, ENV)
         end
     else
-        for (k, v) in split.(cmd.env, "=")
+        for (k, v) in eachsplit.(cmd.env, "=")
             new_env[string(k)::String] = string(v)::String
         end
     end
@@ -284,7 +284,7 @@ function addenv(cmd::Cmd, pairs::Pair{<:AbstractString}...; inherit::Bool = true
 end
 
 function addenv(cmd::Cmd, env::Vector{<:AbstractString}; inherit::Bool = true)
-    return addenv(cmd, Dict(k => v for (k, v) in split.(env, "=")); inherit)
+    return addenv(cmd, Dict(k => v for (k, v) in eachsplit.(env, "=")); inherit)
 end
 
 (&)(left::AbstractCmd, right::AbstractCmd) = AndCmds(left, right)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -578,6 +578,7 @@ export
     codeunits,
     digits,
     digits!,
+    eachsplit,
     escape_string,
     hex2bytes,
     hex2bytes!,

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -100,7 +100,7 @@ function init_depot_path()
     if haskey(ENV, "JULIA_DEPOT_PATH")
         str = ENV["JULIA_DEPOT_PATH"]
         isempty(str) && return
-        for path in split(str, Sys.iswindows() ? ';' : ':')
+        for path in eachsplit(str, Sys.iswindows() ? ';' : ':')
             if isempty(path)
                 append_default_depot_path!(DEPOT_PATH)
             else
@@ -198,7 +198,7 @@ end
 function parse_load_path(str::String)
     envs = String[]
     isempty(str) && return envs
-    for env in split(str, Sys.iswindows() ? ';' : ':')
+    for env in eachsplit(str, Sys.iswindows() ? ';' : ':')
         if isempty(env)
             for env′ in DEFAULT_LOAD_PATH
                 env′ in envs || push!(envs, env′)

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -674,10 +674,11 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     end
     iob = IOContext(buf, stream)
     levelstr = level == Warn ? "Warning" : string(level)
-    msglines = split(chomp(string(message)::String), '\n')
-    println(iob, "┌ ", levelstr, ": ", msglines[1])
-    for i in 2:length(msglines)
-        println(iob, "│ ", msglines[i])
+    msglines = eachsplit(chomp(string(message)::String), '\n')
+    msg1, rest = Iterators.peel(msglines)
+    println(iob, "┌ ", levelstr, ": ", msg1)
+    for msg in rest
+        println(iob, "│ ", msg)
     end
     for (key, val) in kwargs
         key === :maxlog && continue

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -962,7 +962,7 @@ function string_mpfr(x::BigFloat, fmt::String)
 end
 
 function _prettify_bigfloat(s::String)::String
-    mantissa, exponent = split(s, 'e')
+    mantissa, exponent = eachsplit(s, 'e')
     if !occursin('.', mantissa)
         mantissa = string(mantissa, '.')
     end
@@ -973,7 +973,7 @@ function _prettify_bigfloat(s::String)::String
     expo = parse(Int, exponent)
     if -5 < expo < 6
         expo == 0 && return mantissa
-        int, frac = split(mantissa, '.')
+        int, frac = eachsplit(mantissa, '.')
         if expo > 0
             expo < length(frac) ?
                 string(int, frac[1:expo], '.', frac[expo+1:end]) :

--- a/base/path.jl
+++ b/base/path.jl
@@ -368,8 +368,8 @@ function normpath(path::String)
     isabs = isabspath(path)
     isdir = isdirpath(path)
     drive, path = splitdrive(path)
-    parts = split(path, path_separator_re)
-    filter!(x->!isempty(x) && x!=".", parts)
+    parts = split(path, path_separator_re; keepempty=false)
+    filter!(!=("."), parts)
     while true
         clean = true
         for j = 1:length(parts)-1

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -499,7 +499,7 @@ function which(program_name::String)
         # If we have been given just a program name (not a relative or absolute
         # path) then we should search `PATH` for it here:
         pathsep = iswindows() ? ';' : ':'
-        path_dirs = abspath.(split(get(ENV, "PATH", ""), pathsep))
+        path_dirs = map(abspath, eachsplit(get(ENV, "PATH", ""), pathsep))
 
         # On windows we always check the current directory as well
         if iswindows()

--- a/base/util.jl
+++ b/base/util.jl
@@ -97,7 +97,7 @@ function with_output_color(@nospecialize(f::Function), color::Union{Int, Symbol}
                            (bold ? disable_text_style[:bold] : "") *
                                get(disable_text_style, color, text_colors[:default])
             first = true
-            for line in split(str, '\n')
+            for line in eachsplit(str, '\n')
                 first || print(buf, '\n')
                 first = false
                 isempty(line) && continue

--- a/base/version.jl
+++ b/base/version.jl
@@ -100,7 +100,7 @@ const VERSION_REGEX = r"^
 $"ix
 
 function split_idents(s::AbstractString)
-    idents = split(s, '.')
+    idents = eachsplit(s, '.')
     pidents = Union{UInt64,String}[occursin(r"^\d+$", ident) ? parse(UInt64, ident) : String(ident) for ident in idents]
     return tuple(pidents...)::VerTuple
 end


### PR DESCRIPTION
Fixes #20603, replacing/closes #20688, closes #7027.

We might also want an `eachrsplit` to match `rsplit`.

Initial benchmarks show this being more expensive than the existing `split`. Advice on how to improve this would be appreciated.

Existing implementation:
```julia
julia> @benchmark split("α β γ", " ")
BenchmarkTools.Trial:
  memory estimate:  192 bytes
  allocs estimate:  2
  --------------
  minimum time:     267.648 ns (0.00% GC)
  median time:      281.473 ns (0.00% GC)
  mean time:        306.094 ns (2.61% GC)
  maximum time:     7.298 μs (95.83% GC)
  --------------
  samples:          10000
  evals/sample:     315

julia> @btime sum(length, split($"The quick brown fox jumps over the lazy dog."))
  876.213 ns (4 allocations: 800 bytes)
36
```
This PR:
```julia
@benchmark split("α β γ", " ")
BenchmarkTools.Trial:
  memory estimate:  384 bytes
  allocs estimate:  5
  --------------
  minimum time:     285.511 ns (0.00% GC)
  median time:      301.029 ns (0.00% GC)
  mean time:        333.977 ns (5.43% GC)
  maximum time:     10.054 μs (95.45% GC)
  --------------
  samples:          10000
  evals/sample:     276

julia> @btime sum(length, split($"The quick brown fox jumps over the lazy dog."))
  1.116 μs (13 allocations: 1.34 KiB)
36

julia> @btime sum(length, eachsplit($"The quick brown fox jumps over the lazy dog."))
  813.111 ns (9 allocations: 576 bytes)
36
```