### PR TITLE
RFC: allow splatting in hvcat syntax

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1793,6 +1793,11 @@ typed_hcat(T::Type, A::AbstractArray...) = cat_t(T, A...; dims=Val(2))
 
 # 2d horizontal and vertical concatenation
 
+tuple_cat(t) = foldl((x, y) -> (x..., y...), t; init=())
+# these are produced in lowering if splatting occurs inside hvcat
+hvcat_rows(rows::Tuple...) = hvcat(map(length, rows), tuple_cat(rows)...)
+typed_hvcat_rows(T::Type, rows::Tuple...) = typed_hvcat(T, map(length, rows), tuple_cat(rows)...)
+
 function hvcat(nbc::Integer, as...)
     # nbc = # of block columns
     n = length(as)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1793,10 +1793,9 @@ typed_hcat(T::Type, A::AbstractArray...) = cat_t(T, A...; dims=Val(2))
 
 # 2d horizontal and vertical concatenation
 
-tuple_cat(t) = foldl((x, y) -> (x..., y...), t; init=())
 # these are produced in lowering if splatting occurs inside hvcat
-hvcat_rows(rows::Tuple...) = hvcat(map(length, rows), tuple_cat(rows)...)
-typed_hvcat_rows(T::Type, rows::Tuple...) = typed_hvcat(T, map(length, rows), tuple_cat(rows)...)
+hvcat_rows(rows::Tuple...) = hvcat(map(length, rows), (rows...)...)
+typed_hvcat_rows(T::Type, rows::Tuple...) = typed_hvcat(T, map(length, rows), (rows...)...)
 
 function hvcat(nbc::Integer, as...)
     # nbc = # of block columns

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1972,11 +1972,11 @@
                ;; in case there is splatting inside `hvcat`, collect each row as a
                ;; separate tuple and pass those to `hvcat_rows` instead (ref #38844)
                (if (any (lambda (row) (any vararg? row)) rows)
-                   `(call ,.hvcat_rows ,.(map (lambda (x) `(tuple ,.x)) rows))
-                   `(call ,.hvcat
-                          (tuple ,.(map length rows))
-                          ,.(apply append rows))))
-             `(call ,.vcat ,.a))))))
+                   `(call ,@hvcat_rows ,@(map (lambda (x) `(tuple ,@x)) rows))
+                   `(call ,@hvcat
+                          (tuple ,@(map length rows))
+                          ,@(apply append rows))))
+             `(call ,@vcat ,@a))))))
 
 (define (expand-tuple-destruct lhss x)
   (define (sides-match? l r)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1950,6 +1950,34 @@
                ,@(map expand-forms (cddr e))))
         (cons (car e) (map expand-forms (cdr e))))))
 
+(define (expand-vcat e
+                     (vcat '((top vcat)))
+                     (hvcat '((top hvcat)))
+                     (hvcat_rows '((top hvcat_rows))))
+  (let ((a (cdr e)))
+    (if (any assignment? a)
+        (error (string "misplaced assignment statement in \"" (deparse e) "\"")))
+    (if (has-parameters? a)
+        (error "unexpected semicolon in array expression")
+        (expand-forms
+         (if (any (lambda (x)
+                    (and (pair? x) (eq? (car x) 'row)))
+                  a)
+             ;; convert nested hcat inside vcat to hvcat
+             (let ((rows (map (lambda (x)
+                                (if (and (pair? x) (eq? (car x) 'row))
+                                    (cdr x)
+                                    (list x)))
+                              a)))
+               ;; in case there is splatting inside `hvcat`, collect each row as a
+               ;; separate tuple and pass those to `hvcat_rows` instead (ref #38844)
+               (if (any (lambda (row) (any vararg? row)) rows)
+                   `(call ,.hvcat_rows ,.(map (lambda (x) `(tuple ,.x)) rows))
+                   `(call ,.hvcat
+                          (tuple ,.(map length rows))
+                          ,.(apply append rows))))
+             `(call ,.vcat ,.a))))))
+
 (define (expand-tuple-destruct lhss x)
   (define (sides-match? l r)
     ;; l and r either have equal lengths, or r has a trailing ...
@@ -2449,27 +2477,7 @@
          (error (string "misplaced assignment statement in \"" (deparse e) "\"")))
      (expand-forms `(call (top hcat) ,@(cdr e))))
 
-   'vcat
-   (lambda (e)
-     (let ((a (cdr e)))
-       (if (any assignment? a)
-           (error (string "misplaced assignment statement in \"" (deparse e) "\"")))
-       (if (has-parameters? a)
-           (error "unexpected semicolon in array expression")
-           (expand-forms
-            (if (any (lambda (x)
-                       (and (pair? x) (eq? (car x) 'row)))
-                     a)
-                ;; convert nested hcat inside vcat to hvcat
-                (let ((rows (map (lambda (x)
-                                   (if (and (pair? x) (eq? (car x) 'row))
-                                       (cdr x)
-                                       (list x)))
-                                 a)))
-                  `(call (top hvcat)
-                         (tuple ,.(map length rows))
-                         ,.(apply append rows)))
-                `(call (top vcat) ,@a))))))
+   'vcat expand-vcat
 
    'typed_hcat
    (lambda (e)
@@ -2480,23 +2488,8 @@
    'typed_vcat
    (lambda (e)
      (let ((t (cadr e))
-           (a (cddr e)))
-       (if (any assignment? (cddr e))
-           (error (string "misplaced assignment statement in \"" (deparse e) "\"")))
-       (expand-forms
-        (if (any (lambda (x)
-                   (and (pair? x) (eq? (car x) 'row)))
-                 a)
-            ;; convert nested hcat inside vcat to hvcat
-            (let ((rows (map (lambda (x)
-                               (if (and (pair? x) (eq? (car x) 'row))
-                                   (cdr x)
-                                   (list x)))
-                             a)))
-              `(call (top typed_hvcat) ,t
-                     (tuple ,.(map length rows))
-                     ,.(apply append rows)))
-            `(call (top typed_vcat) ,t ,@a)))))
+           (e (cdr e)))
+       (expand-vcat e `((top typed_vcat) ,t) `((top typed_hvcat) ,t) `((top typed_hvcat_rows) ,t))))
 
    '|'|  (lambda (e) (expand-forms `(call |'| ,(cadr e))))
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1269,3 +1269,14 @@ Base.pushfirst!(tpa::TestPushArray{T}, a::T) where T = pushfirst!(tpa.data, a)
     pushfirst!(tpa, 6, 5, 4, 3, 2)
     @test tpa.data == reverse(collect(1:6))
 end
+
+@testset "splatting into hvcat" begin
+    t = (1, 2)
+    @test [t...; 3 4] == [1 2; 3 4]
+    @test [0 t...; t... 0] == [0 1 2; 1 2 0]
+    @test_throws ArgumentError [t...; 3 4 5]
+
+    @test Int[t...; 3 4] == [1 2; 3 4]
+    @test Int[0 t...; t... 0] == [0 1 2; 1 2 0]
+    @test_throws ArgumentError Int[t...; 3 4 5]
+end


### PR DESCRIPTION
This changes the lowering of hvcat syntax to properly support splatting, which also simplified lowering slightly. I was a bit worried about introducing another function call here in terms of type inference/constant prop, but in my initial micro benchmarks, I don't see any regression:
master:
```julia
julia> @time [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]
  0.075053 seconds (36.30 k allocations: 2.334 MiB, 99.99% compilation time)
4×4 Matrix{Int64}:
  1   2   3   4
  5   6   7   8
  9  10  11  12
 13  14  15  16

julia> @time [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]
  0.000008 seconds (2 allocations: 352 bytes)
4×4 Matrix{Int64}:
  1   2   3   4
  5   6   7   8
  9  10  11  12
 13  14  15  16

julia> @time [[1, 2] [3 4; 5 6]; [7 8] 9]
  0.966912 seconds (964.36 k allocations: 57.004 MiB, 4.15% gc time, 99.93% compilation time)
3×3 Matrix{Int64}:
 1  3  4
 2  5  6
 7  8  9

julia> @time [[1, 2] [3 4; 5 6]; [7 8] 9]
  0.000108 seconds (49 allocations: 2.453 KiB)
3×3 Matrix{Int64}:
 1  3  4
 2  5  6
 7  8  9
```
This PR:
```julia
julia> @time [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]
  0.064680 seconds (36.30 k allocations: 2.334 MiB, 99.99% compilation time)
4×4 Matrix{Int64}:
  1   2   3   4
  5   6   7   8
  9  10  11  12
 13  14  15  16

julia> @time [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]
  0.000010 seconds (2 allocations: 352 bytes)
4×4 Matrix{Int64}:
  1   2   3   4
  5   6   7   8
  9  10  11  12
 13  14  15  16

julia> @time [[1, 2] [3 4; 5 6]; [7 8] 9]
  0.847476 seconds (963.75 k allocations: 56.888 MiB, 3.57% gc time, 99.94% compilation time)
3×3 Matrix{Int64}:
 1  3  4
 2  5  6
 7  8  9

julia> @time [[1, 2] [3 4; 5 6]; [7 8] 9]
  0.000080 seconds (49 allocations: 2.453 KiB)
3×3 Matrix{Int64}:
 1  3  4
 2  5  6
 7  8  9
```
fixes #38844