### PR TITLE
Fix binaryplatforms `union` invalidation

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -992,7 +992,7 @@ only available in macOS `v"10.11"` and later, or an artifact can state that it r
 a libstdc++ that is at least `v"3.4.22"`, etc...
 """
 function platforms_match(a::AbstractPlatform, b::AbstractPlatform)
-    for k in union(keys(tags(a)), keys(tags(b)))
+    for k in union(keys(tags(a)::Dict{String,String}), keys(tags(b)::Dict{String,String}))
         ak = get(tags(a), k, nothing)
         bk = get(tags(b), k, nothing)
 


### PR DESCRIPTION
DataStructures' `union(s::DataStructures.SparseIntSet, ns)` yields
a bad invalidation.