### PR TITLE
Fix invalidations for `show(::MethodInstance)` and `detect_ambiguities`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1004,7 +1004,7 @@ function show_mi(io::IO, l::Core.MethodInstance, from_stackframe::Bool=false)
         # to print a little more identifying information.
         if !from_stackframe
             linetable = l.uninferred.linetable
-            line = isempty(linetable) ? "unknown" : (lt = linetable[1]; string(lt.file) * ':' * string(lt.line))
+            line = isempty(linetable) ? "unknown" : (lt = linetable[1]::Union{LineNumberNode,Core.LineInfoNode}; string(lt.file) * ':' * string(lt.line))
             print(io, " from ", def, " starting at ", line)
         end
     end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1459,7 +1459,7 @@ Use `recursive=true` to test in all submodules.
 `Union{}` type parameters are included; in most cases you probably
 want to set this to `false`. See [`Base.isambiguous`](@ref).
 """
-function detect_ambiguities(mods...;
+function detect_ambiguities(mods::Module...;
                             recursive::Bool = false,
                             ambiguous_bottom::Bool = false)
     @nospecialize


### PR DESCRIPTION
These shouldn't be backported since there are other recent changes to the same functions.