### PR TITLE
make compact type alias output more compact

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -789,15 +789,19 @@ function show_unionaliases(io::IO, x::Union)
 end
 
 function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
-    show(io, x)
-    if !print_without_params(x) && get(io, :compact, true)
+    if !print_without_params(x)
         properx = makeproper(io, x)
         if make_typealias(properx) !== nothing || (unwrap_unionall(x) isa Union && x <: make_typealiases(properx)[2])
-            print(io, " (alias for ")
-            show(IOContext(io, :compact => false), x)
-            print(io, ")")
+            show(IOContext(io, :compact => true), x)
+            if !(get(io, :compact, false)::Bool)
+                print(io, " (alias for ")
+                show(IOContext(io, :compact => false), x)
+                print(io, ")")
+            end
+            return
         end
     end
+    show(io, x)
     # give a helpful hint for function types
     if x isa DataType && x !== UnionAll && !(get(io, :compact, false)::Bool)
         tn = x.name::Core.TypeName


### PR DESCRIPTION
I just noticed that the "compact" output for type aliases is currently much less compact:

```
julia> show(IOContext(stdout,:compact=>false), MIME"text/plain"(), Matrix)
Array{T, 2} where T

julia> show(IOContext(stdout,:compact=>true), MIME"text/plain"(), Matrix)
Matrix{T} where T (alias for Array{T, 2} where T)
```

after:
```
julia> show(IOContext(stdout,:compact=>false), MIME"text/plain"(), Matrix)
Matrix{T} where T (alias for Array{T, 2} where T)

julia> show(IOContext(stdout,:compact=>true), MIME"text/plain"(), Matrix)
Matrix{T} where T
```

This is new functionality in 1.6 so I would consider backporting this frankly.