### PR TITLE
fix #39259, leave `Main.ARGS` unresolved on startup

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-if isempty(ARGS) || ARGS[1] !== "0"
+if isempty(Base.ARGS) || Base.ARGS[1] !== "0"
 Sys.__init_build()
 # Prevent this from being put into the Main namespace
 @eval Module() begin

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -719,3 +719,6 @@ for yn in ("no", "yes")
     end
     @test v[2]
 end
+
+# issue #39259, shadowing `ARGS`
+@test success(`$(Base.julia_cmd()) --startup-file=no -e 'ARGS=1'`)


### PR DESCRIPTION
fix #39259