### PR TITLE
aotcompile: avoid cache lookup when disallowed

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4620,7 +4620,7 @@ static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Module *M, jl_cod
     ctx.builder.SetInsertPoint(b0);
     Function *theFunc;
     Value *theFarg;
-    if (codeinst->invoke != NULL) {
+    if (params.cache && codeinst->invoke != NULL) {
         StringRef theFptrName = jl_ExecutionEngine->getFunctionAtAddress((uintptr_t)codeinst->invoke, codeinst);
         theFunc = cast<Function>(
             M->getOrInsertFunction(theFptrName, jlinvoke_func->_type(jl_LLVMContext)).getCallee());


### PR DESCRIPTION
Fix #38548