### PR TITLE
Close uv_idle handles when we're done with them

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -100,6 +100,10 @@ function Base.uvfinalize(t::UvTestIdle)
     nothing
 end
 
+function Base.close(idle::UvTestIdle)
+    Base.uvfinalize(idle)
+end
+
 function Base.wait(idle::UvTestIdle)
     Base.iolock_begin()
     Base.preserve_handle(idle)
@@ -129,12 +133,14 @@ proc = open(pipeline(`$(Base.julia_cmd()) -e $cmd`; stderr=stderr); write=true)
 
 let idle=UvTestIdle()
     wait(idle)
+    close(idle)
 end
 
 using Base.Threads
 @threads for i = 1:1
     let idle=UvTestIdle()
         wait(idle)
+        close(idle)
     end
 end
 


### PR DESCRIPTION
uv_idle handles are a bit dangerous because they essentially prevent
the uv loop from going to sleep, so if there's no work to be done
on the julia side, it just turns into a busy loop. We start such
an idle callback in the threads.jl test. We make sure it goes out
of scope, so the GC will eventually close it, but in the meantime
they keep the loop spinning. Now, unfortunately, the next test in
line is the Distributed test, which runs everything in a subprocess,
so it never builds up enough memory pressure to actually run the
GC, so the idle handles never get closed. This isn't too big a
deal, as the worst thing that happens is that it hogs one CPU
core on CI while the threads test is running, but we don't have
enough parallelism there anyway, so I don't expect a meaningful
impact on CI. It does however blow up our rr traces and apparently
causes significantly problems when trying to replay them on pernosco.
This is easy to fix by just closing these handles once we're done
with them.

Reported by @rocallahan