### PR TITLE
Prepend build_bindir to LLVM_CONFIG_PATH_FIX rather than append

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1043,7 +1043,7 @@ endif # SYSTEM_LLVM
 # Windows builds need a little help finding the LLVM libraries for llvm-config
 LLVM_CONFIG_PATH_FIX :=
 ifeq ($(OS),WINNT)
-LLVM_CONFIG_PATH_FIX := PATH="$(PATH):$(build_bindir)"
+LLVM_CONFIG_PATH_FIX := PATH="$(build_bindir):$(PATH)"
 endif
 
 ifeq ($(BUILD_OS),$(OS))


### PR DESCRIPTION
# Summary

Prepend rather than append `$(build_bindir)` to the `PATH` for `LLVM_CONFIG_PATH_FIX` on Windows to avoid using libraries from an older Julia install.

## Background

Windows requires that the environmental variable `PATH` include the `build_bindir`. Currently this is appended to the `PATH` making the `build_bindir` the the lowest priority directory to search.

Also on Windows, the installer for a Julia release will append the bin directory to the `PATH`.

This creates a scenario where some tools may use libraries in the binary release rather than libraries in the current source tree. For example this occurs with `usr/tools/llvm-config.exe` when using cygwin. In the example below, `llvm-config.exe` is dynamically linked to `LLVM.dll` in a Julia 1.5.0 install despite trying to build Juila master (1.7.0-DEV) causing `llvm-config.exe` to silently fail with a return code of 127:

```bash
$ cat VERSION
1.7.0-DEV

$ ldd usr/tools/llvm-config.exe
        ntdll.dll => /cygdrive/c/WINDOWS/SYSTEM32/ntdll.dll (0x7ffc5e420000)
        KERNEL32.DLL => /cygdrive/c/WINDOWS/System32/KERNEL32.DLL (0x7ffc5d010000)
        KERNELBASE.dll => /cygdrive/c/WINDOWS/System32/KERNELBASE.dll (0x7ffc5b570000)
        msvcrt.dll => /cygdrive/c/WINDOWS/System32/msvcrt.dll (0x7ffc5cef0000)
        libstdc++-6.dll => /cygdrive/c/Users/kittisopikulm/AppData/Local/Programs/Julia 1.5.0/bin/libstdc++-6.dll (0x6fc40000)
        LLVM.dll => /cygdrive/c/Users/kittisopikulm/AppData/Local/Programs/Julia 1.5.0/bin/LLVM.dll (0x66740000)

$ usr/tools/llvm-config.exe

$ echo $?
127

$ echo $PATH
/usr/local/bin:/usr/bin:/cygdrive/c/Users/kittisopikulm/AppData/Local/Programs/Julia 1.5.0/bin:/cygdrive/c/Users/kittisopikulm/AppData/Local/Programs/Julia-1.6.0-beta1/bin

$ PATH="usr/bin:$PATH" usr/tools/llvm-config.exe
usage: llvm-config <OPTION>... [<COMPONENT>...]
Get various configuration information needed to compile programs which use
LLVM.  Typically called from 'configure' scripts.  Examples:
...

$ PATH="usr/bin:$PATH" ldd usr/tools/llvm-config.exe
        ntdll.dll => /cygdrive/c/WINDOWS/SYSTEM32/ntdll.dll (0x7ffc5e420000)
        KERNEL32.DLL => /cygdrive/c/WINDOWS/System32/KERNEL32.DLL (0x7ffc5d010000)
        KERNELBASE.dll => /cygdrive/c/WINDOWS/System32/KERNELBASE.dll (0x7ffc5b570000)
        msvcrt.dll => /cygdrive/c/WINDOWS/System32/msvcrt.dll (0x7ffc5cef0000)
        libstdc++-6.dll => /cygdrive/c/Users/kittisopikulm/source/repos/julia/usr/bin/libstdc++-6.dll (0x6fc40000
)
        LLVM.dll => /cygdrive/c/Users/kittisopikulm/source/repos/julia/usr/bin/LLVM.dll (0x66740000)
...
```

The proposed fix is simple. Prepend rather than append `$(build_binddir)` so that `$(build_binddir)` is searched for the relevant for the relevant libraries first.

Further fixes may involve checking the return code of of `llvm-config.exe` to ensure that execution has not failed silently. Currently a problem is only detected when parsing "libllvm_version" in `base/version.jl`. In this case Julia attempts to parse an empty string, which fails.