### PR TITLE
Avoid type widening to `Int` in `range_stop_length`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -145,7 +145,9 @@ _range(start::Any    , step::Any    , stop::Nothing, len::Any    ) = range_start
 _range(start::Any    , step::Any    , stop::Any    , len::Nothing) = range_start_step_stop(start, step, stop)
 _range(start::Any    , step::Any    , stop::Any    , len::Any    ) = range_error(start, step, stop, len)
 
-range_stop_length(stop, length) = (stop-length+1):stop
+range_stop_length(a::Real,          len::Integer) = UnitRange{typeof(a)}(oftype(a, a-len+1), a)
+range_stop_length(a::AbstractFloat, len::Integer) = range_step_stop_length(oftype(a, 1), a, len)
+range_stop_length(a,                len::Integer) = range_step_stop_length(oftype(a-a, 1), a, len)
 
 range_step_stop_length(step, stop, length) = reverse(range_start_step_length(stop, -step, length))
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -17,6 +17,10 @@
         # the next one uses ==, because it changes the eltype
         @test r  == range(start=first(r), stop=last(r), length=length(r))
         @test r === range(                stop=last(r), length=length(r))
+
+        for T = (Int8, Rational{Int16}, UInt32, Float64, Char)
+            @test typeof(range(start=T(5), length=3)) === typeof(range(stop=T(5), length=3))
+        end
     end
 end
 


### PR DESCRIPTION
Currently, `range(;stop, length)` unnecessarily widens the eltype to `Int`:
```julia
julia> range(start=Int8(3), length=2) |> eltype
Int8

julia> range(stop=Int8(3), length=2) |> eltype
Int64
```
This PR fixes that by adapting the `range_start_length` logic for `range_stop_length`.