### PR TITLE
implement property destructuring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Julia v1.7 Release Notes
 New language features
 ---------------------
 
+* `(; a, b) = x` can now be used to destructure properties `a` and `b` of `x`. This syntax is equivalent to `a = getproperty(x, :a)`
+  and similarly for `b`. ([#39285])
+
 Language changes
 ----------------
 


### PR DESCRIPTION
This currently only allows the form `(; a, b) = x` and lowers this to calls to `getproperty`. We could think about whether we want to allow specifying default values for properties as well, or even some kind of property renaming in the lhs. We could even allow slurping unused properties, but all of that sounds more difficult to work out in detail and potentially controversial, so I left this as an error for now.

fixes #28579