### PR TITLE
Fix tests sensitive to `--color=yes`

### DIFF
--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -784,12 +784,12 @@ end
 
 Base.exit_on_sigint(true)
 
-let exename = Base.julia_cmd()
+let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # Test REPL in dumb mode
     with_fake_pty() do pts, ptm
         nENV = copy(ENV)
         nENV["TERM"] = "dumb"
-        p = run(detach(setenv(`$exename --startup-file=no -q`, nENV)), pts, pts, pts, wait=false)
+        p = run(detach(setenv(`$exename -q`, nENV)), pts, pts, pts, wait=false)
         Base.close_stdio(pts)
         output = readuntil(ptm, "julia> ", keep=true)
         if ccall(:jl_running_on_valgrind, Cint,()) == 0
@@ -827,7 +827,7 @@ let exename = Base.julia_cmd()
     end
 
     # Test stream mode
-    p = open(`$exename --startup-file=no -q`, "r+")
+    p = open(`$exename -q`, "r+")
     write(p, "1\nexit()\n")
     @test read(p, String) == "1\n"
 end # let exename

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1578,7 +1578,8 @@ end
 
 # issue #34061
 let o_file = tempname(), err = Base.PipeEndpoint()
-    run(pipeline(Cmd(`$(Base.julia_cmd()) --output-o=$o_file -e 'Base.reinit_stdio();
+    run(pipeline(Cmd(`$(Base.julia_cmd()) --color=no --output-o=$o_file -e '
+        Base.reinit_stdio();
         f() = ccall((:dne, :does_not_exist), Cvoid, ());
         f()'`; ignorestatus=true), stderr=err), wait=false)
     output = read(err, String)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -50,7 +50,7 @@ let
     @test format_filename("%a%%b") == "a%b"
 end
 
-let exename = `$(Base.julia_cmd()) --startup-file=no`
+let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # tests for handling of ENV errors
     let v = writereadpipeline("println(\"REPL: \", @which(less), @isdefined(InteractiveUtils))",
                 setenv(`$exename -i -E 'empty!(LOAD_PATH); @isdefined InteractiveUtils'`,
@@ -94,7 +94,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
     end
 end
 
-let exename = `$(Base.julia_cmd()) --startup-file=no`
+let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # --version
     let v = split(read(`$exename -v`, String), "julia version ")[end]
         @test Base.VERSION_STRING == chomp(v)
@@ -673,7 +673,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
 end
 
 # issue #6310
-let exename = `$(Base.julia_cmd()) --startup-file=no`
+let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     @test writereadpipeline("2+2", exename) == ("4\n", true)
     @test writereadpipeline("2+2\n3+3\n4+4", exename) == ("4\n6\n8\n", true)
     @test writereadpipeline("", exename) == ("", true)
@@ -698,7 +698,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
 end
 
 # incomplete inputs to stream REPL
-let exename = `$(Base.julia_cmd()) --startup-file=no`
+let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     in = Pipe(); out = Pipe(); err = Pipe()
     proc = run(pipeline(exename, stdin = in, stdout = out, stderr = err), wait=false)
     write(in, "f(\n")
@@ -710,7 +710,7 @@ end
 
 # Issue #29855
 for yn in ("no", "yes")
-    exename = `$(Base.julia_cmd()) --inline=no --startup-file=no --inline=$yn`
+    exename = `$(Base.julia_cmd()) --inline=no --startup-file=no --color=no --inline=$yn`
     v = writereadpipeline("Base.julia_cmd()", exename)
     if yn == "no"
         @test occursin(r" --inline=no", v[1])

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -46,7 +46,7 @@ include_string_test_func = include_string(@__MODULE__, "include_string_test() = 
 @test isdir(@__DIR__)
 @test @__DIR__() == dirname(@__FILE__)
 @test !endswith(@__DIR__, Base.Filesystem.path_separator)
-let exename = `$(Base.julia_cmd()) --compiled-modules=yes --startup-file=no`,
+let exename = `$(Base.julia_cmd()) --compiled-modules=yes --startup-file=no --color=no`,
     wd = sprint(show, pwd())
     s_dir = sprint(show, realpath(tempdir()))
     @test wd != s_dir

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -215,13 +215,13 @@ let r, t, sock
 end
 
 # issue #4535
-exename = Base.julia_cmd()
+exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 if valgrind_off
     # If --trace-children=yes is passed to valgrind, we will get a
     # valgrind banner here, not "Hello World\n".
-    @test read(pipeline(`$exename --startup-file=no -e 'println(stderr,"Hello World")'`, stderr=catcmd), String) == "Hello World\n"
+    @test read(pipeline(`$exename -e 'println(stderr,"Hello World")'`, stderr=catcmd), String) == "Hello World\n"
     out = Pipe()
-    proc = run(pipeline(`$exename --startup-file=no -e 'println(stderr,"Hello World")'`, stderr = out), wait=false)
+    proc = run(pipeline(`$exename -e 'println(stderr,"Hello World")'`, stderr = out), wait=false)
     close(out.in)
     @test read(out, String) == "Hello World\n"
     @test success(proc)
@@ -229,7 +229,7 @@ end
 
 # setup_stdio for AbstractPipe
 let out = Pipe(),
-    proc = run(pipeline(`$exename --startup-file=no -e 'println(getpid())'`, stdout=IOContext(out, :foo => :bar)), wait=false)
+    proc = run(pipeline(`$exename -e 'println(getpid())'`, stdout=IOContext(out, :foo => :bar)), wait=false)
     # < don't block here before getpid call >
     pid = getpid(proc)
     close(out.in)
@@ -298,7 +298,7 @@ let fname = tempname(), p
     import Base.zzzInvalidIdentifier
     """
     try
-        io = open(pipeline(`$exename --startup-file=no`, stderr=stderr), "w")
+        io = open(pipeline(exename, stderr=stderr), "w")
         write(io, cmd)
         close(io)
         wait(io)
@@ -318,7 +318,7 @@ let bad = "bad\0name"
 end
 
 # issue #12829
-let out = Pipe(), echo = `$exename --startup-file=no -e 'print(stdout, " 1\t", read(stdin, String))'`, ready = Condition(), t, infd, outfd
+let out = Pipe(), echo = `$exename -e 'print(stdout, " 1\t", read(stdin, String))'`, ready = Condition(), t, infd, outfd
     @test_throws ArgumentError write(out, "not open error")
     inread = false
     t = @async begin # spawn writer task
@@ -399,7 +399,7 @@ let fname = tempname()
         run(cmd)
     end
     """
-    @test success(pipeline(`$catcmd $fname`, `$exename --startup-file=no -e $code`))
+    @test success(pipeline(`$catcmd $fname`, `$exename -e $code`))
     rm(fname)
 end
 
@@ -520,7 +520,7 @@ end
 
 # issue #19864 (PR #20497)
 let c19864 = readchomp(pipeline(ignorestatus(
-        `$exename --startup-file=no -e '
+        `$exename -e '
             struct Error19864 <: Exception; end
             Base.showerror(io::IO, e::Error19864) = print(io, "correct19864")
             throw(Error19864())'`),
@@ -573,7 +573,7 @@ end
 
 # Logging macros should not output to finalized streams (#26687)
 let
-    cmd = `$exename --startup-file=no -e 'finalizer(x->@info(x), "Hello")'`
+    cmd = `$exename -e 'finalizer(x->@info(x), "Hello")'`
     output = readchomp(pipeline(cmd, stderr=catcmd))
     @test occursin("Info: Hello", output)
 end
@@ -686,7 +686,7 @@ end
 
 let text = "input-test-text"
     b = PipeBuffer()
-    proc = open(Base.CmdRedirect(Base.CmdRedirect(```$exename --startup-file=no -E '
+    proc = open(Base.CmdRedirect(Base.CmdRedirect(```$exename -E '
                     in14 = Base.open(RawFD(14))
                     out15 = Base.open(RawFD(15))
                     write(out15, in14)'```,


### PR DESCRIPTION
Fixes tests which fail when `--color=yes` is set:
```
$ ./julia --color=yes -e 'Base.runtests(["loading", "cmdlineargs"])'
Test    (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
cmdlineargs  (3) |        started at 2021-01-16T09:09:29.376
loading      (2) |        started at 2021-01-16T09:09:29.498
      From worker 2:	WARNING: replacing module Foo.
loading      (2) |         failed at 2021-01-16T09:09:53.621
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:53
  Expression: readchomp(`$exename -E "@__DIR__" -i`) == wd
   Evaluated: "\"/Users/omus/Development/Julia/x86/latest-src/test\"\n\e[0m\e[0m" == "\"/Users/omus/Development/Julia/x86/latest-src/test\""
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/loading.jl:54
  Expression: readchomp(`$exename -E "cd(()->eval(:(@__DIR__)), $s_dir)" -i`) == s_dir
   Evaluated: "\"/private/var/folders/j7/fwm5mtz52_xdxds4f1rnhn9c0000gn/T\"\n\e[0m\e[0m" == "\"/private/var/folders/j7/fwm5mtz52_xdxds4f1rnhn9c0000gn/T\""

cmdlineargs  (3) |         failed at 2021-01-16T09:12:03.446
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:60
  Expression: v[1] == "false\nREPL: InteractiveUtilstrue\n"
   Evaluated: "false\n\e[0mREPL: InteractiveUtilstrue\n\e[0m" == "false\nREPL: InteractiveUtilstrue\n"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:69
  Expression: v[1] == "REPL: 3\n"
   Evaluated: "\e[0mREPL: 3\n\e[0m" == "REPL: 3\n"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:79
  Expression: isempty(v[2])
   Evaluated: isempty("\e[0m\e[0m")
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:80
  Expression: startswith(v[3], "┌ Warning: Failed to import InteractiveUtils into module Main\n")
   Evaluated: startswith("\e[33m\e[1m┌ \e[22m\e[39m\e[33m\e[1mWarning: \e[22m\e[39mFailed to import InteractiveUtils into module Main\n\e[33m\e[1m│ \e[22m\e[39m  exception =\n\e[33m\e[1m│ \e[22m\e[39m   ArgumentError: Package InteractiveUtils [b77e0a4c-d291-57a0-90e8-8db25a27a240] is required but does not seem to be installed:\n\e[33m\e[1m│ \e[22m\e[39m    - Run `Pkg.instantiate()` to install all recorded dependencies.\n\e[33m\e[1m│ \e[22m\e[39m   \n\e[33m\e[1m│ \e[22m\e[39m   Stacktrace:\n\e[33m\e[1m│ \e[22m\e[39m    [1] \e[0m\e[1m_require\e[22m\e[0m\e[1m(\e[22m\e[90mpkg\e[39m::\e[0mBase.PkgId\e[0m\e[1m)\e[22m\n\e[33m\e[1m│ \e[22m\e[39m   \e[90m   @ \e[39m\e[90mBase\e[39m \e[90m./\e[39m\e[90;4mloading.jl:986\e[0m\n\e[33m\e[1m│ \e[22m\e[39m    [2] \e[0m\e[1mrequire\e[22m\e[0m\e[1m(\e[22m\e[90muuidkey\e[39m::\e[0mBase.PkgId\e[0m\e[1m)\e[22m\n\e[33m\e[1m│ \e[22m\e[39m   \e[90m   @ \e[39m\e[90mBase\e[39m \e[90m./\e[39m\e[90;4mloading.jl:910\e[0m\n\e[33m\e[1m│ \e[22m\e[39m    [3] \e[0m\e[1mload_InteractiveUtils\e[22m\e[0m\e[1m(\e[22m\e[0m\e[1m)\e[22m\n\e[33m\e[1m│ \e[22m\e[39m   \e[90m   @ \e[39m\e[90mBase\e[39m \e[90m./\e[39m\e[90;4mclient.jl:359\e[0m\n\e[33m\e[1m│ \e[22m\e[39m    [4] \e[0m\e[1mrun_main_repl\e[22m\e[0m\e[1m(\e[22m\e[90minteractive\e[39m::\e[0mBool, \e[90mquiet\e[39m::\e[0mBool, \e[90mbanner\e[39m::\e[0mBool, \e[90mhistory_file\e[39m::\e[0mBool, \e[90mcolor_set\e[39m::\e[0mBool\e[0m\e[1m)\e[22m\n\e[33m\e[1m│ \e[22m\e[39m   \e[90m   @ \e[39m\e[90mBase\e[39m \e[90m./\e[39m\e[90;4mclient.jl:376\e[0m\n\e[33m\e[1m│ \e[22m\e[39m    [5] \e[0m\e[1mexec_options\e[22m\e[0m\e[1m(\e[22m\e[90mopts\e[39m::\e[0mBase.JLOptions\e[0m\e[1m)\e[22m\n\e[33m\e[1m│ \e[22m\e[39m   \e[90m   @ \e[39m\e[90mBase\e[39m \e[90m./\e[39m\e[90;4mclient.jl:309\e[0m\n\e[33m\e[1m│ \e[22m\e[39m    [6] \e[0m\e[1m_start\e[22m\e[0m\e[1m(\e[22m\e[0m\e[1m)\e[22m\n\e[33m\e[1m│ \e[22m\e[39m   \e[90m   @ \e[39m\e[90mBase\e[39m \e[90m./\e[39m\e[90;4mclient.jl:492\e[0m\n\e[33m\e[1m└ \e[22m\e[39m\e[90m@ Base client.jl:365\e[39m", "┌ Warning: Failed to import InteractiveUtils into module Main\n")
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:86
  Expression: v[2] == real_threads
   Evaluated: "8\n\e[0m\e[0m" == "8"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:86
  Expression: v[2] == real_threads
   Evaluated: "8\n\e[0m\e[0m" == "8"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:86
  Expression: v[2] == real_threads
   Evaluated: "8\n\e[0m\e[0m" == "8"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:86
  Expression: v[2] == real_threads
   Evaluated: "8\n\e[0m\e[0m" == "8"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:86
  Expression: v[2] == real_threads
   Evaluated: "8\n\e[0m\e[0m" == "8"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:86
  Expression: v[2] == real_threads
   Evaluated: "8\n\e[0m\e[0m" == "8"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:92
  Expression: v[2] == "1"
   Evaluated: "1\n\e[0m\e[0m" == "1"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:92
  Expression: v[2] == "1"
   Evaluated: "1\n\e[0m\e[0m" == "1"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:92
  Expression: v[2] == "1"
   Evaluated: "1\n\e[0m\e[0m" == "1"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:92
  Expression: v[2] == "1"
   Evaluated: "1\n\e[0m\e[0m" == "1"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:157
  Expression: read(`$exename -i --load=$testfile -e "println(testvar)"`, String) == "loaded\ntest\n"
   Evaluated: "loaded\ntest\n\e[0m\e[0m" == "loaded\ntest\n"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:158
  Expression: read(`$exename -i -L $testfile -e "println(testvar)"`, String) == "loaded\ntest\n"
   Evaluated: "loaded\ntest\n\e[0m\e[0m" == "loaded\ntest\n"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:245
  Expression: readchomp(`$exename -E "isinteractive()" -i`) == "true"
   Evaluated: "true\n\e[0m\e[0m" == "true"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:677
  Expression: writereadpipeline("2+2", exename) == ("4\n", true)
   Evaluated: ("\e[0m\e[0m4\n", true) == ("4\n", true)
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:678
  Expression: writereadpipeline("2+2\n3+3\n4+4", exename) == ("4\n6\n8\n", true)
   Evaluated: ("\e[0m\e[0m4\n\e[0m\e[0m6\n\e[0m\e[0m8\n", true) == ("4\n6\n8\n", true)
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:679
  Expression: writereadpipeline("", exename) == ("", true)
   Evaluated: ("\e[0m", true) == ("", true)
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:680
  Expression: writereadpipeline("print(2)", exename) == ("2", true)
   Evaluated: ("\e[0m2", true) == ("2", true)
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:681
  Expression: writereadpipeline("print(2)\nprint(3)", exename) == ("23", true)
   Evaluated: ("\e[0m2\e[0m3", true) == ("23", true)
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:685
  Expression: read(pipeline(exename, stdin = infile), String) == ""
   Evaluated: "\e[0m" == ""
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:687
  Expression: read(pipeline(exename, stdin = infile), String) == "(1, 5)\n"
   Evaluated: "\e[0m\e[0m\e[0m(1, 5)\n" == "(1, 5)\n"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:689
  Expression: read(pipeline(exename, stdin = infile), String) == "3\n4\n-1\n"
   Evaluated: "\e[0m\e[0m\e[0m3\n\e[0m\e[0m\e[0m4\n\e[0m\e[0m\e[0m-1\n" == "3\n4\n-1\n"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:691
  Expression: read(pipeline(exename, stdin = infile), String) == "2"
   Evaluated: "\e[0m\e[0m2" == "2"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:693
  Expression: read(pipeline(exename, stdin = infile), String) == "23"
   Evaluated: "\e[0m\e[0m2\e[0m\e[0m3" == "23"
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:708
  Expression: startswith(txt, "ERROR: syntax: incomplete")
   Evaluated: startswith("\e[91m\e[1mERROR: \e[22m\e[39msyntax: incomplete: premature end of input", "ERROR: syntax: incomplete")
Test Failed at /Users/omus/Development/Julia/x86/latest-src/usr/share/julia/test/cmdlineargs.jl:716
  Expression: occursin(r" --inline=no", v[1])
   Evaluated: occursin(r" --inline=no", "\e[0m\e[0m`\e[4m/Users/omus/Development/Julia/x86/latest-src/usr/bin/julia\e[24m \e[4m-Cnative\e[24m \e[4m-J/Users/omus/Development/Julia/x86/latest-src/usr/lib/julia/sys.dylib\e[24m \e[4m--depwarn=error\e[24m \e[4m--check-bounds=yes\e[24m \e[4m--inline=no\e[24m \e[4m-g1\e[24m \e[4m--color=yes\e[24m \e[4m--startup-file=no\e[24m`\n")


Test Summary: |   Pass  Fail  Broken   Total
  Overall     | 143956    31       3  143990
    loading   | 143742     2          143744
    cmdlineargs |    214    29       3     246
    FAILURE

The global RNG seed was 0xf2fd58b907e3ac97b58793d2b156ee71.
```