### PR TITLE
Simplify computation of return type in broadcast

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -682,15 +682,6 @@ broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x
 broadcastable(x) = collect(x)
 broadcastable(::Union{AbstractDict, NamedTuple}) = throw(ArgumentError("broadcasting over dictionaries and `NamedTuple`s is reserved"))
 
-## Computation of inferred result type, for empty and concretely inferred cases only
-_broadcast_getindex_eltype(bc::Broadcasted) = Base._return_type(bc.f, eltypes(bc.args))
-_broadcast_getindex_eltype(A) = eltype(A)  # Tuple, Array, etc.
-
-eltypes(::Tuple{}) = Tuple{}
-eltypes(t::Tuple{Any}) = Tuple{_broadcast_getindex_eltype(t[1])}
-eltypes(t::Tuple{Any,Any}) = Tuple{_broadcast_getindex_eltype(t[1]), _broadcast_getindex_eltype(t[2])}
-eltypes(t::Tuple) = Tuple{_broadcast_getindex_eltype(t[1]), eltypes(tail(t)).types...}
-
 function promote_typejoin_union(::Type{T}) where T
     if T === Union{}
         return Union{}
@@ -734,10 +725,6 @@ end
     end
     return Base.rewrap_unionall(Tuple{c...}, T)
 end
-
-# Inferred eltype of result of broadcast(f, args...)
-combine_eltypes(f, args::Tuple) =
-    promote_typejoin_union(Base._return_type(f, eltypes(args)))
 
 ## Broadcasting core
 
@@ -901,7 +888,8 @@ copy(bc::Broadcasted{<:Union{Nothing,Unknown}}) =
 const NonleafHandlingStyles = Union{DefaultArrayStyle,ArrayConflict}
 
 @inline function copy(bc::Broadcasted{Style}) where {Style}
-    ElType = combine_eltypes(bc.f, bc.args)
+    ElType = promote_typejoin_union(Base._return_type(_broadcast_getindex,
+                                                      Tuple{typeof(bc), Int}))
     if Base.isconcretetype(ElType)
         # We can trust it and defer to the simpler `copyto!`
         return copyto!(similar(bc, ElType), bc)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -417,8 +417,8 @@ StrangeType18623(x,y) = (x,y)
 let
     f(A, n) = broadcast(x -> +(x, n), A)
     @test @inferred(f([1.0], 1)) == [2.0]
-    g() = (a = 1; Broadcast.combine_eltypes(x -> x + a, (1.0,)))
-    @test @inferred(g()) === Float64
+    g() = (a = 1; x -> x + a)
+    @test @inferred(broadcast(g(), 1.0)) === 2.0
 end
 
 # Ref as 0-dimensional array for broadcast
@@ -576,8 +576,9 @@ end
 
 # Test that broadcast's promotion mechanism handles closures accepting more than one argument.
 # (See issue #19641 and referenced issues and pull requests.)
-let f() = (a = 1; Broadcast.combine_eltypes((x, y) -> x + y + a, (1.0, 1.0)))
-    @test @inferred(f()) == Float64
+let
+    f() = (a = 1; (x, y) -> x + y + a)
+    @test @inferred(broadcast(f(), 1.0, 1.0)) === 3.0
 end
 
 @testset "broadcast resulting in BitArray" begin


### PR DESCRIPTION
Since we rely on inference, we can use `_return_type` directly instead of via a complex machinery.

As suggested by @mbauman at https://github.com/JuliaLang/julia/pull/39185#issuecomment-758142273.