### PR TITLE
inference: improve inference of indexing into union of tuples

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -230,11 +230,15 @@ function unswitchtupleunion(u::Union)
     ts = uniontypes(u)
     n = -1
     for t in ts
-        if t isa DataType && t.name === Tuple.name && !isvarargtype(t.parameters[end])
-            if n == -1
-                n = length(t.parameters)
-            elseif n != length(t.parameters)
+        if t isa DataType && t.name === Tuple.name
+            if t === Tuple{}
                 return u
+            elseif !isvarargtype(t.parameters[end])
+                if n == -1
+                    n = length(t.parameters)
+                elseif n != length(t.parameters)
+                    return u
+                end
             end
         else
             return u

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3008,3 +3008,25 @@ f38888() = S38888(Base.inferencebarrier(3))
 @test f38888() isa S38888
 g38888() = S38888(Base.inferencebarrier(3), nothing)
 @test g38888() isa S38888
+
+@testset "indexing into union of tuples" begin
+    tt = (Union{Tuple{Int,String},Tuple{Int,Char}},)
+
+    # `getindex`
+    @test Base.return_types(tt) do t
+        getindex(t, 1)
+    end == Any[Int]
+    @test Base.return_types(tt) do t
+        getindex(t, 2)
+    end == Any[Union{String,Char}]
+
+    # `indexed_iterate`
+    @test Base.return_types(tt) do t
+        a, b = t
+        a
+    end == Any[Int]
+    @test Base.return_types(tt) do t
+        a, b = t
+        b
+    end == Any[Union{String,Char}]
+end


### PR DESCRIPTION
The precision of return type of tuple indexing really relies on constant
propagation, but when an argument is union of tuples, call signature
will be split and constant prop' won't happen, and so inference ends up
looser return type: e.g.
```julia
julia> Base.return_types((Union{Tuple{Int,Nothing},Tuple{Int,Missing}},)) do t
           a, b = t
           a # I expected a::Int, but a::Union{Missing,Nothing,Int}
       end |> first
Union{Missing, Nothing, Int64}
```

This PR special cases some of tuple indexing methods
(`getindex(::Tuple)` and `indexed_iterate(::Tuple)`) and forces constant
propagation to happen even when their argument is union of tuples,
by converting it to tuple of unions.

---

The diff certainly looks a bit odd; is there a better way to address this ?