### PR TITLE
Add environment flag to pass extra exeflags

### DIFF
--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -18,6 +18,9 @@ if !@isdefined(testenv_defined)
         push!(test_exeflags.exec, "--startup-file=no")
         push!(test_exeflags.exec, "--depwarn=error")
     end
+    if haskey(ENV, "JULIA_TEST_EXTRA_EXEFLAGS")
+        append!(test_exeflags.exec, Base.shell_split(ENV["JULIA_TEST_EXTRA_EXEFLAGS"]))
+    end
 
     if haskey(ENV, "JULIA_TEST_EXENAME")
         popfirst!(test_exeflags.exec)


### PR DESCRIPTION
Allows one to pass extra flags to test, such as forcing a specific
architecture to flush out codegen bugs.

I have been using it to test LLVM for Power8 on Power9
```
JULIA_TEST_EXTRA_EXEFLAGS=-Cpwr8
```