### PR TITLE
Improve performance of `inv(::ComplexF64)`

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -439,29 +439,33 @@ end
 function inv(w::ComplexF64)
     c, d = reim(w)
     (isinf(c) | isinf(d)) && return complex(copysign(0.0, c), flipsign(-0.0, d))
-    half = 0.5
-    two = 2.0
-    cd = max(abs(c), abs(d))
-    ov = floatmax(c)
-    un = floatmin(c)
-    ϵ = eps(Float64)
-    bs = two/(ϵ*ϵ)
+    absc, absd = abs(c), abs(d)
+    cd = ifelse(absc>absd, absc, absd) # cheap `max`: don't need sign- and nan-checks here
+
+    ϵ  = eps(Float64)
+    bs = 2/(ϵ*ϵ)
+
+    # scaling
     s = 1.0
-    cd >= half*ov  && (c=half*c; d=half*d; s=s*half) # scale down c,d
-    cd <= un*two/ϵ && (c=c*bs; d=d*bs; s=s*bs      ) # scale up c,d
-    if abs(d)<=abs(c)
-        r = d/c
-        t = 1.0/(c+d*r)
-        p = t
-        q = -r * t
-    else
-        c, d = d, c
-        r = d/c
-        t = 1.0/(c+d*r)
-        p = r * t
-        q = -t
+    if cd >= floatmax(Float64)/2
+        c *= 0.5; d *= 0.5; s = 0.5 # scale down c, d
+    elseif cd <= 2floatmin(Float64)/ϵ
+        c *= bs;  d *= bs;  s = bs  # scale up c, d
     end
-    return ComplexF64(p*s,q*s) # undo scaling
+
+    # inversion operations
+    if absd <= absc
+        p, q = robust_cinv(c, d)
+    else
+        q, p = robust_cinv(-d, -c)
+    end
+    return ComplexF64(p*s, q*s) # undo scaling
+end
+function robust_cinv(c::Float64, d::Float64)
+    r = d/c
+    p = inv(muladd(d, r, c))
+    q = -r*p
+    return p, q
 end
 
 function ssqs(x::T, y::T) where T<:Real


### PR DESCRIPTION
This is essentially just a rebase of https://github.com/JuliaLang/julia/pull/29058 (but my fork of that had gotten deleted so I had to open it anew): leads to a speedup of about 30% for `inv(::ComplexF64)` without changing the output.

The gist of the changes are the same as in the original PR: speed up `inv(::ComplexF64)` by combining two if statements into an `if-elseif` and opt for a cheaper variant of `max`, because we know we won't benefit from checking `NaN` or `Inf` values in this context. Also now use `muladd` explicitly in one spot.

**Benchmarks**:

```jl
v = rand(ComplexF64, 100000);
```
1.6-beta:
```jl
@btime inv($v) # 2.244 ms (2 allocations: 1.53 MiB)
```

PR: 
```jl
@btime inv($v) # 1.562 ms (2 allocations: 1.53 MiB)
```

Tagging @simonbyrne again, in case you still recall the PR that https://github.com/JuliaLang/julia/pull/29058 branched off originally (~2 years ago now 😮 ).
