### PR TITLE
Update threadingconstructs.jl

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -146,9 +146,9 @@ end
 """
     Threads.@spawn expr
 
-Create a [`Task`](@ref) and [`schedule`](@ref) it to run on any available thread. 
-The task is allocated to a thread after it becomes available. To wait for the task 
-to finish, call [`wait`](@ref) on the result of this macro, or call [`fetch`](@ref) to 
+Create a [`Task`](@ref) and [`schedule`](@ref) it to run on any available thread.
+The task is allocated to a thread after it becomes available. To wait for the task
+to finish, call [`wait`](@ref) on the result of this macro, or call [`fetch`](@ref) to
 wait and then obtain its return value.
 
 Values can be interpolated into `@spawn` via `\$`, which copies the value directly into the

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -146,9 +146,11 @@ end
 """
     Threads.@spawn expr
 
-Create and run a [`Task`](@ref) on any available thread. To wait for the task to
-finish, call [`wait`](@ref) on the result of this macro, or call [`fetch`](@ref)
-to wait and then obtain its return value.
+Create a [`Task`](@ref) and [`schedule`](@ref) it to run on any available thread.
+The task is allocated to a thread after it becomes available.
+
+To wait for the task to finish, call [`wait`](@ref) on the result of this macro, or 
+call [`fetch`](@ref) to wait and then obtain its return value.
 
 Values can be interpolated into `@spawn` via `\$`, which copies the value directly into the
 constructed underlying closure. This allows you to insert the _value_ of a variable,

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -146,11 +146,10 @@ end
 """
     Threads.@spawn expr
 
-Create a [`Task`](@ref) and [`schedule`](@ref) it to run on any available thread.
-The task is allocated to a thread after it becomes available.
-
-To wait for the task to finish, call [`wait`](@ref) on the result of this macro, or 
-call [`fetch`](@ref) to wait and then obtain its return value.
+Create a [`Task`](@ref) and [`schedule`](@ref) it to run on any available thread. 
+The task is allocated to a thread after it becomes available. To wait for the task 
+to finish, call [`wait`](@ref) on the result of this macro, or call [`fetch`](@ref) to 
+wait and then obtain its return value.
 
 Values can be interpolated into `@spawn` via `\$`, which copies the value directly into the
 constructed underlying closure. This allows you to insert the _value_ of a variable,


### PR DESCRIPTION
I try to make clearer that the task **is scheduled** to run on an available thread. This makes an important difference since between the creation of the task and its allocation to a thread may be a time delay.

see: [discussion on Discourse](https://discourse.julialang.org/t/looking-for-code-to-solve-surely-common-embarrassing-parallelism-multithreading-use-case/53527/9)