### PR TITLE
Only create legal int types during alloc opt

### DIFF
--- a/test/llvmpasses/alloc-opt.jl
+++ b/test/llvmpasses/alloc-opt.jl
@@ -5,6 +5,8 @@
 isz = sizeof(UInt) == 8 ? "i64" : "i32"
 
 println("""
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+
 @tag = external addrspace(10) global {}
 """)
 
@@ -167,7 +169,7 @@ define void @object_field({} addrspace(10)* %field) {
 # CHECK-LABEL: }{{$}}
 
 # CHECK-LABEL: @memcpy_opt
-# CHECK: alloca i128, align 16
+# CHECK: alloca [16 x i8], align 16
 # CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc

--- a/test/llvmpasses/alloc-opt2.jl
+++ b/test/llvmpasses/alloc-opt2.jl
@@ -79,12 +79,30 @@ L3:
 """)
 # CHECK-LABEL: }{{$}}
 
+# CHECK-LABEL: @legal_int_types
+# CHECK: alloca [12 x i8]
+# CHECK-NOT: alloca i96
+# CHECK: ret void
+println("""
+define void @legal_int_types() {
+  %ptls = call {}*** @julia.ptls_states()
+  %ptls_i8 = bitcast {}*** %ptls to i8*
+  %var1 = call {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 12, {} addrspace(10)* @tag)
+  %var2 = addrspacecast {} addrspace(10)* %var1 to {} addrspace(11)*
+  %var3 = call {}* @julia.pointer_from_objref({} addrspace(11)* %var2)
+  ret void
+}
+""")
+# CHECK-LABEL: }{{$}}
+
+
+
 println("""
 declare void @external_function()
 declare {} addrspace(10)* @external_function2()
 declare {}*** @julia.ptls_states()
 declare noalias {} addrspace(10)* @julia.gc_alloc_obj(i8*, $isz, {} addrspace(10)*)
-declare i64 @julia.pointer_from_objref({} addrspace(11)*)
+declare {}* @julia.pointer_from_objref({} addrspace(11)*)
 declare void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(11)* nocapture writeonly, i8* nocapture readonly, i64, i32, i1)
 declare token @llvm.julia.gc_preserve_begin(...)
 declare void @llvm.julia.gc_preserve_end(token)


### PR DESCRIPTION
When promoting heap to stack allocations, make sure we only emit legal integer allocas by checking with the module's datalayout. X86 doesn't seem to care, but back-ends like SPIR-V don't know how to handle arbitrarily-sized integers.

Fixes JuliaGPU/oneAPI.jl#55