### PR TITLE
Preserve input type for unaliascopy(::ReinterpretArray)

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -278,7 +278,8 @@ eachindex(style::IndexSCartesian2, A::AbstractArray) = eachindex(style, parent(A
 
 parent(a::ReinterpretArray) = a.parent
 dataids(a::ReinterpretArray) = dataids(a.parent)
-unaliascopy(a::ReinterpretArray{T}) where {T} = reinterpret(T, unaliascopy(a.parent))
+unaliascopy(a::NonReshapedReinterpretArray{T}) where {T} = reinterpret(T, unaliascopy(a.parent))
+unaliascopy(a::ReshapedReinterpretArray{T}) where {T} = reinterpret(reshape, T, unaliascopy(a.parent))
 
 function size(a::NonReshapedReinterpretArray{T,N,S} where {N}) where {T,S}
     psize = size(a.parent)

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -368,3 +368,11 @@ ars = reinterpret(reshape, Int, a)
     @test as isa TSlow{NTuple{4,Float64},1}
     @test size(as) == (4,)
 end
+
+
+@testset "aliasing" begin
+    a = reinterpret(NTuple{2,Float64}, rand(Float64, 4, 4))
+    @test typeof(Base.unaliascopy(a)) === typeof(a)
+    a = reinterpret(reshape, NTuple{4,Float64}, rand(Float64, 4, 4))
+    @test typeof(Base.unaliascopy(a)) === typeof(a)
+end


### PR DESCRIPTION
This is a missing specialization from #37559