### PR TITLE
`include` only works on global scope

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -26,8 +26,8 @@ end
 
 Files and file names are mostly unrelated to modules; modules are associated only with module
 expressions. One can have multiple files per module, and multiple modules per file. `include`
-behaves as if the contents of the source file were evaluated in its place. In this chapter, we use
-short and simplified examples, so we won't use `include`.
+behaves as if the contents of the source file were evaluated in the global scope of the
+including module. In this chapter, we use short and simplified examples, so we won't use `include`.
 
 The recommended style is not to indent the body of the module, since that would typically lead to
 whole files being indented. Also, it is common to use `UpperCamelCase` for module names (just like


### PR DESCRIPTION
Just changed the ending of a phrase:

"`include` behaves as if the contents of the source file were evaluated in its place."

to

"`include` behaves as if the contents of the source file were evaluated in the global scope of the including module."

because I have already answered more than one person in Discourse trying to load variable definitions and code pieces from another file to inside a function scope (instead the global scope).