### PR TITLE
Remove outdated checksums on refresh

### DIFF
--- a/contrib/refresh_checksums.mk
+++ b/contrib/refresh_checksums.mk
@@ -111,7 +111,7 @@ pack-checksum-%: FORCE
 				done; \
 				rmdir $$each; \
 			fi; \
-		done >> $*
+		done > $*
 	@cd "$(JULIAHOME)/deps/checksums" && \
 		sort $* > $*.tmp && \
 		mv $*.tmp $*


### PR DESCRIPTION
Automatically removes older checksums by overwriting the checksum file instead of appending to it.