### PR TITLE
Fix performance regression in broadcasting with CartesianIndices

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -977,8 +977,10 @@ preprocess_args(dest, args::Tuple{}) = ()
         end
     end
     bc′ = preprocess(dest, bc)
-    @simd for I in eachindex(bc′)
-        @inbounds dest[I] = bc′[I]
+    # Performance may vary depending on whether `@inounds` is placed outside the
+    # for loop or not. (cf. https://github.com/JuliaLang/julia/issues/38086)
+    @inbounds @simd for I in eachindex(bc′)
+        dest[I] = bc′[I]
     end
     return dest
 end

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -977,7 +977,7 @@ preprocess_args(dest, args::Tuple{}) = ()
         end
     end
     bc′ = preprocess(dest, bc)
-    # Performance may vary depending on whether `@inounds` is placed outside the
+    # Performance may vary depending on whether `@inbounds` is placed outside the
     # for loop or not. (cf. https://github.com/JuliaLang/julia/issues/38086)
     @inbounds @simd for I in eachindex(bc′)
         dest[I] = bc′[I]


### PR DESCRIPTION
This avoids the boundary check due to a change in the implementation of iteration using `CartesianIndices` in PR #37829.

This is a workaround on the caller side and does not change the iteration mechanism itself.

```julia
julia> xu8 = rand(UInt8, 1000, 1000); yu8 = rand(UInt8, 1000, 1000);

julia> @btime $xu8 .+ $yu8;
  795.800 μs (2 allocations: 976.70 KiB) # before (master and v1.6.0-beta1)
  85.900 μs (2 allocations: 976.70 KiB) # after
```

Thanks to @chriselrod.

Fixes #38086