### PR TITLE
Allow building without gfortran if we're just using everything from BB

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1173,7 +1173,9 @@ USE_BINARYBUILDER ?= 0
 endif
 
 # Auto-detect triplet once, create different versions that we use as defaults below for each BB install target
-BB_TRIPLET_LIBGFORTRAN_CXXABI := $(shell $(call invoke_python,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(or $(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' ),1)")
+FC_VERSION := $(shell $(FC) --version 2>/dev/null | head -1)
+FC_OR_CC_VERISON := $(or $(FC_VERSION),$(shell $(CC) --version 2>/dev/null | head -1))
+BB_TRIPLET_LIBGFORTRAN_CXXABI := $(shell $(call invoke_python,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(FC_OR_CC_VERSION)" "$(or $(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' ),1)")
 BB_TRIPLET_LIBGFORTRAN := $(subst $(SPACE),-,$(filter-out cxx%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI))))
 BB_TRIPLET_CXXABI := $(subst $(SPACE),-,$(filter-out libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI))))
 BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN_CXXABI)))))
@@ -1194,6 +1196,14 @@ endif
 endif
 endef
 $(foreach proj,$(BB_PROJECTS),$(eval $(call SET_BB_DEFAULT,$(proj))))
+
+
+# Warn if the user tries to build something that requires `gfortran` but they don't have it installed.
+ifeq ($(FC_VERSION),)
+ifneq ($(USE_BINARYBUILDER_OPENBLAS)$(USE_BINARYBUILDER_SUITESPARSE),11)
+$(error "Attempting to build OpenBLAS or SuiteSparse without a functioning fortran compiler!")
+endif
+endif
 
 
 # OS specific stuff

--- a/contrib/normalize_triplet.py
+++ b/contrib/normalize_triplet.py
@@ -106,19 +106,22 @@ def p(x):
 
 # If the user passes in a GCC version (like 8.2.0) use that to force a
 # "-libgfortran5" tag at the end of the triplet, but only if it has otherwise
-# not been specified
+# not been specified.
 if libgfortran_version == "blank_libgfortran":
     if len(sys.argv) >= 3:
-        libgfortran_version = {
-            "4":  "libgfortran3",
-            "5":  "libgfortran3",
-            "6":  "libgfortran3",
-            "7":  "libgfortran4",
-            "8":  "libgfortran5",
-            "9":  "libgfortran5",
-            "10": "libgfortran5",
-            "11": "libgfortran5",
-        }[list(filter(lambda x: re.match("\d+\.\d+(\.\d+)?", x), sys.argv[2].split()))[-1].split('.')[0]]
+        # If there was no gfortran/gcc version passed in, default to the latest libgfortran version
+        if not sys.argv[2]:
+            libgfortran_version = "libgfortran5"
+        else:
+            # Take the last thing that looks like a version number, and extract its major component
+            version_numbers = list(filter(lambda x: re.match("\d+\.\d+(\.\d+)?", x), sys.argv[2].split()))
+            major_ver = int(version_numbers[-1].split('.')[0])
+            if major_ver <= 6:
+                libgfortran_version = "libgfortran3"
+            elif major_ver <= 7:
+                libgfortran_version = "libgfortran4"
+            else:
+                libgfortran_version = "libgfortran5"
 
 if cxx_abi == "blank_cxx_abi":
     if len(sys.argv) == 4:


### PR DESCRIPTION
On systems where we don't have `gfortran` installed, there's no reason
to require it, because nowadays we get everything from Yggdrasil anyway.
Simply soldier on and assume that the user wants the latest support
libraries, unless they are trying to build from source.

This is particularly useful on Apple M1 machines, where a native build of `gfortran` is a bother to install.