### PR TITLE
Replace manual-iteration with Iterators.zip() for faster copyto!

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -979,14 +979,8 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
             end
         else
             # Dual-iterator implementation
-#             for (idx, idy) in zip(iterdest, itersrc)
-#                 @inbounds dest[idx] = src[idy]
-#             end
-            ret = iterate(iterdest)
-            @inbounds for a in src
-                idx, state = ret	
-                dest[idx] = a	
-                ret = iterate(iterdest, state)	
+            for (idx, idy) in zip(iterdest, itersrc)
+                @inbounds dest[idx] = src[idy]
             end
         end
     end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -979,11 +979,8 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
             end
         else
             # Dual-iterator implementation
-            ret = iterate(iterdest)
-            @inbounds for a in src
-                idx, state = ret
-                dest[idx] = a
-                ret = iterate(iterdest, state)
+            for (idx, idy) in Iterators.zip(iterdest, itersrc)
+                @inbounds dest[idx] = src[idy]
             end
         end
     end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -979,7 +979,7 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
             end
         else
             # Dual-iterator implementation
-            for (idx, idy) in Iterators.zip(iterdest, itersrc)
+            for (idx, idy) in zip(iterdest, itersrc)
                 @inbounds dest[idx] = src[idy]
             end
         end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -979,8 +979,14 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
             end
         else
             # Dual-iterator implementation
-            for (idx, idy) in zip(iterdest, itersrc)
-                @inbounds dest[idx] = src[idy]
+#             for (idx, idy) in zip(iterdest, itersrc)
+#                 @inbounds dest[idx] = src[idy]
+#             end
+            ret = iterate(iterdest)
+            @inbounds for a in src
+                idx, state = ret	
+                dest[idx] = a	
+                ret = iterate(iterdest, state)	
             end
         end
     end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -979,7 +979,7 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
             end
         else
             # Dual-iterator implementation
-            for (idx, idy) in zip(iterdest, itersrc)
+            for (idy, idx) in zip(itersrc, iterdest)
                 @inbounds dest[idx] = src[idy]
             end
         end


### PR DESCRIPTION
#39345 

Manual-iteration version is about 2-3 times slower than `Iterators.zip()` version in my test.
```julia
function zip_copyto!(dest, src)
    iterdest, itersrc = eachindex(dest), eachindex(src)
    for (idx, idy) in Iterators.zip(iterdest, itersrc)
        @inbounds dest[idx] = src[idy]
    end
end

function base_copyto!(dest, src)
    iterdest, itersrc = eachindex(dest), eachindex(src)
    ret = iterate(iterdest)
    @inbounds for a in src
        idx, state = ret
        dest[idx] = a
        ret = iterate(iterdest, state)
    end
end

a = randn(1000,1000)
a_ = view(a,1:600,:)
b = randn(600,1000)
b_ = view(b,1:500,:)
using BenchmarkTools
@btime base_copyto!(a_,b)   #   794.900 μs (0 allocations: 0 bytes)
@btime zip_copyto!(a_,b)  #    425.400 μs (0 allocations: 0 bytes)
@btime base_copyto!(a_,b_)  #    1.293 ms (0 allocations: 0 bytes)
@btime zip_copyto!(a_,b_)  #    403.201 μs (0 allocations: 0 bytes)
```