### PR TITLE
fix REPL summary for types

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -302,6 +302,15 @@ end
 
 function summarize(io::IO, m::Module, binding::Binding)
     println(io, "No docstring found for module `", m, "`.\n")
+    exports = filter!(!=(nameof(m)), names(m))
+    if isempty(exports)
+        println(io, "Module does not export any names.")
+    else
+        println(io, "# Exported names:")
+        print(io, "  `")
+        join(io, exports, "`, `")
+        println(io, "`")
+    end
 end
 
 function summarize(io::IO, @nospecialize(T), binding::Binding)

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -264,39 +264,52 @@ function summarize(io::IO, λ::Function, binding::Binding)
     println(io, "```\n", methods(λ), "\n```")
 end
 
-function summarize(io::IO, T::DataType, binding::Binding)
+function summarize(io::IO, TT::Type, binding::Binding)
     println(io, "# Summary")
-    println(io, "```")
-    println(io,
-            T.abstract ? "abstract type" :
-            T.mutable  ? "mutable struct" :
-            Base.isstructtype(T) ? "struct" : "primitive type",
-            " ", T, " <: ", supertype(T)
-            )
-    println(io, "```")
-    if !T.abstract && T.name !== Tuple.name && !isempty(fieldnames(T))
-        println(io, "# Fields")
+    T = Base.unwrap_unionall(TT)
+    if T isa DataType
         println(io, "```")
-        pad = maximum(length(string(f)) for f in fieldnames(T))
-        for (f, t) in zip(fieldnames(T), T.types)
-            println(io, rpad(f, pad), " :: ", t)
+        print(io,
+            T.abstract ? "abstract type " :
+            T.mutable  ? "mutable struct " :
+            Base.isstructtype(T) ? "struct " :
+            "primitive type ")
+        supert = supertype(T)
+        println(io, T)
+        println(io, "```")
+        if !T.abstract && T.name !== Tuple.name && !isempty(fieldnames(T))
+            println(io, "# Fields")
+            println(io, "```")
+            pad = maximum(length(string(f)) for f in fieldnames(T))
+            for (f, t) in zip(fieldnames(T), T.types)
+                println(io, rpad(f, pad), " :: ", t)
+            end
+            println(io, "```")
         end
-        println(io, "```")
-    end
-    if !isempty(subtypes(T))
-        println(io, "# Subtypes")
-        println(io, "```")
-        for t in subtypes(T)
-            println(io, t)
+        subt = subtypes(TT)
+        if !isempty(subt)
+            println(io, "# Subtypes")
+            println(io, "```")
+            for t in subt
+                println(io, t)
+            end
+            println(io, "```")
         end
-        println(io, "```")
-    end
-    if supertype(T) != Any
-        println(io, "# Supertype Hierarchy")
-        println(io, "```")
-        Base.show_supertypes(io, T)
-        println(io)
-        println(io, "```")
+        if supert != Any
+            println(io, "# Supertype Hierarchy")
+            println(io, "```")
+            Base.show_supertypes(io, T)
+            println(io)
+            println(io, "```")
+        end
+    elseif T isa Union
+        println(io, "`", binding, "` is of type `", typeof(TT), "`.\n")
+        println(io, "# Union Composed of Types")
+        for T1 in Base.uniontypes(T)
+            println(io, " - `", Base.rewrap_unionall(T1, TT), "`")
+        end
+    else # unreachable?
+        println(io, "`", binding, "` is of type `", typeof(TT), "`.\n")
     end
 end
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -17,7 +17,22 @@ function docstrings_equal(d1, d2)
     io2 = IOBuffer()
     show(io1, MIME"text/markdown"(), d1)
     show(io2, MIME"text/markdown"(), d2)
-    String(take!(io1)) == String(take!(io2))
+    s1 = String(take!(io1))
+    s2 = String(take!(io2))
+    #if s1 != s2 # for debugging
+    #    e1 = eachline(IOBuffer(s1))
+    #    e2 = eachline(IOBuffer(s2))
+    #    for (l1, l2) in zip(e1, e2)
+    #        l1 == l2 || println(l1, "\n", l2, "\n")
+    #    end
+    #    for l1 in e1
+    #        println(l1, "\n[missing]\n")
+    #    end
+    #    for l2 in e2
+    #        println("[missing]\n", l2, "\n")
+    #    end
+    #end
+    return s1 == s2
 end
 docstrings_equal(d1::DocStr, d2) = docstrings_equal(parsedoc(d1), d2)
 
@@ -807,6 +822,38 @@ struct D <: B
     three::Float64
 end
 
+abstract type at0{T<:Number,N} end
+abstract type at1{T>:Integer,N} <:at0{T,N} end
+
+const at_ = at0{Int64}
+
+primitive type pt2{T<:Number,N,A>:Integer} <:at0{T,N} 32 end
+
+struct st3{T<:Integer,N} <: at0{T,N}
+    a::NTuple{N,T}
+    b::Array{Int64,N}
+    c::Int64
+end
+
+struct st4{T,N} <: at0{T,N}
+    a::T
+    b::NTuple{N,T}
+end
+
+struct st5{T>:Int64,N} <:at1{T,N}
+    c::st3{T,N}
+end
+
+mutable struct mt6{T<:Integer,N} <:at1{T,N}
+    d::st5{T,N}
+end
+
+const ut7 = Union{st5, mt6}
+
+const ut8 = Union{at1, pt2, st3, st4}
+
+const ut9{T} = Union{at1{T}, pt2{T}, st3{T}, st4{T}}
+
 f = () -> nothing
 
 undocumented() = 1
@@ -819,6 +866,10 @@ doc_str = Markdown.parse("""
 No documentation found.
 
 No docstring found for module `$(curmod_prefix)Undocumented`.
+
+# Exported names:
+
+`A`, `B`, `C`, `at0`, `pt2`
 """)
 @test docstrings_equal(@doc(Undocumented), doc"$doc_str")
 
@@ -834,7 +885,7 @@ No documentation found.
 
 # Summary
 ```
-abstract type $(curmod_prefix)Undocumented.A <: Any
+abstract type $(curmod_prefix)Undocumented.A
 ```
 
 # Subtypes
@@ -850,7 +901,7 @@ No documentation found.
 
 # Summary
 ```
-abstract type $(curmod_prefix)Undocumented.B <: $(curmod_prefix)Undocumented.A
+abstract type $(curmod_prefix)Undocumented.B
 ```
 
 # Subtypes
@@ -870,7 +921,7 @@ No documentation found.
 
 # Summary
 ```
-mutable struct $(curmod_prefix)Undocumented.C <: $(curmod_prefix)Undocumented.A
+mutable struct $(curmod_prefix)Undocumented.C
 ```
 
 # Supertype Hierarchy
@@ -885,7 +936,7 @@ No documentation found.
 
 # Summary
 ```
-struct $(curmod_prefix)Undocumented.D <: $(curmod_prefix)Undocumented.B
+struct $(curmod_prefix)Undocumented.D
 ```
 
 # Fields
@@ -901,6 +952,217 @@ $(curmod_prefix)Undocumented.D <: $(curmod_prefix)Undocumented.B <: $(curmod_pre
 ```
 """)
 @test docstrings_equal(@doc(Undocumented.D), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+abstract type $(curmod_prefix)Undocumented.at0{T<:Number, N}
+```
+
+# Subtypes
+
+```
+$(curmod_prefix)Undocumented.at1{T, N} where N where Integer<:T<:Number
+$(curmod_prefix)Undocumented.pt2
+$(curmod_prefix)Undocumented.st3
+$(curmod_prefix)Undocumented.st4{T, N} where N where T<:Number
+```
+""")
+@test docstrings_equal(@doc(Undocumented.at0), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+abstract type $(curmod_prefix)Undocumented.at1{T>:Integer, N}
+```
+
+# Subtypes
+
+```
+$(curmod_prefix)Undocumented.mt6{Integer, N} where N
+```
+
+# Supertype Hierarchy
+```
+$(curmod_prefix)Undocumented.at1{T>:Integer, N} <: $(curmod_prefix)Undocumented.at0{T>:Integer, N} <: Any
+```
+""")
+@test docstrings_equal(@doc(Undocumented.at1), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+abstract type $(curmod_prefix)Undocumented.at0{Int64, N}
+```
+
+# Subtypes
+
+```
+$(curmod_prefix)Undocumented.pt2{Int64, N, A} where A>:Integer where N
+$(curmod_prefix)Undocumented.st3{Int64, N} where N
+$(curmod_prefix)Undocumented.st4{Int64, N} where N
+```
+""")
+@test docstrings_equal(@doc(Undocumented.at_), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+primitive type $(curmod_prefix)Undocumented.pt2{T<:Number, N, A>:Integer}
+```
+
+# Supertype Hierarchy
+
+```
+$(curmod_prefix)Undocumented.pt2{T<:Number, N, A>:Integer} <: $(curmod_prefix)Undocumented.at0{T<:Number, N} <: Any
+```
+""")
+@test docstrings_equal(@doc(Undocumented.pt2), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+struct $(curmod_prefix)Undocumented.st3{T<:Integer, N}
+```
+
+# Fields
+```
+a :: Tuple{Vararg{T<:Integer, N}}
+b :: Array{Int64, N}
+c :: Int64
+```
+
+# Supertype Hierarchy
+```
+$(curmod_prefix)Undocumented.st3{T<:Integer, N} <: $(curmod_prefix)Undocumented.at0{T<:Integer, N} <: Any
+```
+""")
+@test docstrings_equal(@doc(Undocumented.st3), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+struct $(curmod_prefix)Undocumented.st4{T, N}
+```
+
+# Fields
+```
+a :: T
+b :: Tuple{Vararg{T, N}}
+```
+
+# Supertype Hierarchy
+```
+$(curmod_prefix)Undocumented.st4{T, N} <: $(curmod_prefix)Undocumented.at0{T, N} <: Any
+```
+""")
+@test docstrings_equal(@doc(Undocumented.st4), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+struct $(curmod_prefix)Undocumented.st5{T>:Int64, N}
+```
+
+# Fields
+```
+c :: $(curmod_prefix)Undocumented.st3{T>:Int64, N}
+```
+
+# Supertype Hierarchy
+```
+$(curmod_prefix)Undocumented.st5{T>:Int64, N} <: $(curmod_prefix)Undocumented.at1{T>:Int64, N} <: $(curmod_prefix)Undocumented.at0{T>:Int64, N} <: Any
+```
+""")
+@test docstrings_equal(@doc(Undocumented.st5), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+```
+mutable struct $(curmod_prefix)Undocumented.mt6{T<:Integer, N}
+```
+
+# Fields
+```
+d :: $(curmod_prefix)Undocumented.st5{T<:Integer, N}
+```
+
+# Supertype Hierarchy
+```
+$(curmod_prefix)Undocumented.mt6{T<:Integer, N} <: $(curmod_prefix)Undocumented.at1{T<:Integer, N} <: $(curmod_prefix)Undocumented.at0{T<:Integer, N} <: Any
+```
+""")
+@test docstrings_equal(@doc(Undocumented.mt6), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+`$(curmod_prefix)Undocumented.ut7` is of type `Union`.
+
+# Union Composed of Types
+
+ - `$(curmod_prefix)Undocumented.mt6`
+ - `$(curmod_prefix)Undocumented.st5`
+""")
+@test docstrings_equal(@doc(Undocumented.ut7), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+`$(curmod_prefix)Undocumented.ut8` is of type `Union`.
+
+# Union Composed of Types
+
+ - `$(curmod_prefix)Undocumented.at1`
+ - `$(curmod_prefix)Undocumented.pt2`
+ - `$(curmod_prefix)Undocumented.st3`
+ - `$(curmod_prefix)Undocumented.st4`
+""")
+@test docstrings_equal(@doc(Undocumented.ut8), doc"$doc_str")
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+# Summary
+
+`$(curmod_prefix)Undocumented.ut9` is of type `UnionAll`.
+
+# Union Composed of Types
+
+ - `$(curmod_prefix)Undocumented.at1{T, N} where N where T`
+ - `$(curmod_prefix)Undocumented.pt2{T, N, A} where A>:Integer where N where T`
+ - `$(curmod_prefix)Undocumented.st3{T, N} where N where T`
+ - `$(curmod_prefix)Undocumented.st4`
+""")
+@test docstrings_equal(@doc(Undocumented.ut9), doc"$doc_str")
 
 let d = @doc(Undocumented.f)
     io = IOBuffer()

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -794,6 +794,8 @@ let err = try; @macroexpand(@doc "" f() = @x); false; catch ex; ex; end
 
 module Undocumented
 
+export A, B, C, at0, pt2
+
 abstract type A end
 abstract type B <: A end
 
@@ -811,7 +813,14 @@ undocumented() = 1
 undocumented(x) = 2
 undocumented(x,y) = 3
 
-end
+end # module
+
+doc_str = Markdown.parse("""
+No documentation found.
+
+No docstring found for module `$(curmod_prefix)Undocumented`.
+""")
+@test docstrings_equal(@doc(Undocumented), doc"$doc_str")
 
 doc_str = Markdown.parse("""
 No documentation found.


### PR DESCRIPTION
Some improved help formatting:
```
help?> Base.GenericIOBuffer
  No documentation found.

  Summary
  ≡≡≡≡≡≡≡≡≡

  mutable struct Base.GenericIOBuffer{T<:AbstractVector{UInt8}}

  Fields
  ≡≡≡≡≡≡≡≡

  data     :: T<:AbstractVector{UInt8}
  readable :: Bool
  writable :: Bool
  seekable :: Bool
  append   :: Bool
  size     :: Int64
  maxsize  :: Int64
  ptr      :: Int64
  mark     :: Int64

  Supertype Hierarchy
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  Base.GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO <: Any

help?> Core.Intrinsics
  No documentation found.

  No docstring found for module Core.Intrinsics.

  Exported names:
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  abs_float, add_float, add_float_fast, add_int, add_ptr, and_int, arraylen, ashr_int, bitcast, bswap_int, ceil_llvm, cglobal, checked_sadd_int, checked_sdiv_int, checked_smul_int, checked_srem_int,
  checked_ssub_int, checked_uadd_int, checked_udiv_int, checked_umul_int, checked_urem_int, checked_usub_int, copysign_float, ctlz_int, ctpop_int, cttz_int, div_float, div_float_fast, eq_float,
  eq_float_fast, eq_int, flipsign_int, floor_llvm, fma_float, fpext, fpiseq, fpislt, fptosi, fptoui, fptrunc, le_float, le_float_fast, llvmcall, lshr_int, lt_float, lt_float_fast, mul_float,
  mul_float_fast, mul_int, muladd_float, ne_float, ne_float_fast, ne_int, neg_float, neg_float_fast, neg_int, not_int, or_int, pointerref, pointerset, rem_float, rem_float_fast, rint_llvm, sdiv_int,
  sext_int, shl_int, sitofp, sle_int, slt_int, sqrt_llvm, sqrt_llvm_fast, srem_int, sub_float, sub_float_fast, sub_int, sub_ptr, trunc_int, trunc_llvm, udiv_int, uitofp, ule_int, ult_int, urem_int,
  xor_int, zext_int
```

Replaces #21126
Fixes #21029