### PR TITLE
Fix some OpaqueClosure related show methods

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -11,9 +11,16 @@ function strip_gensym(sym)
 end
 
 function argtype_decl(env, n, @nospecialize(sig::DataType), i::Int, nargs, isva::Bool) # -> (argname, argtype)
-    t = sig.parameters[i]
-    if i == nargs && isva && !isvarargtype(t)
-        t = Vararg{t,length(sig.parameters)-nargs+1}
+    t = sig.parameters[unwrapva(min(i, end))]
+    if i == nargs && isva
+        va = sig.parameters[end]
+        if isvarargtype(va) && (!isdefined(va, :N) || !isa(va.N, Int))
+            t = va
+        else
+            ntotal = length(sig.parameters)
+            isvarargtype(va) && (ntotal += va.N - 1)
+            t = Vararg{t,ntotal-nargs+1}
+        end
     end
     if isa(n,Expr)
         n = n.args[1]  # handle n::T in arg list
@@ -62,7 +69,7 @@ function arg_decl_parts(m::Method, html=false)
         end
         decls = Tuple{String,String}[argtype_decl(show_env, argnames[i], sig, i, m.nargs, m.isva)
                     for i = 1:m.nargs]
-        decls[1] = ("", sprint(show_signature_function, sig.parameters[1], false, decls[1][1], html,
+        decls[1] = ("", sprint(show_signature_function, unwrapva(sig.parameters[1]), false, decls[1][1], html,
                                context = show_env))
     else
         decls = Tuple{String,String}[("", "") for i = 1:length(sig.parameters::SimpleVector)]

--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -1,14 +1,3 @@
-function show(io::IO, oc::Core.OpaqueClosure)
-    A, R = typeof(oc).parameters
-    show_tuple_as_call(io, Symbol(""), A; hasfirst=false)
-    print(io, "::", R)
-    print(io, "->◌")
-end
-
-function show(io::IO, ::MIME"text/plain", oc::Core.OpaqueClosure{A, R}) where {A, R}
-    show(io, oc)
-end
-
 """
     @opaque (args...) -> body
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -2848,3 +2848,15 @@ end
 bitshow(B::BitArray) = bitshow(stdout, B)
 
 bitstring(B::BitArray) = sprint(bitshow, B)
+
+# printing OpaqueClosure
+function show(io::IO, oc::Core.OpaqueClosure)
+    A, R = typeof(oc).parameters
+    show_tuple_as_call(io, Symbol(""), A; hasfirst=false)
+    print(io, "::", R)
+    print(io, "->◌")
+end
+
+function show(io::IO, ::MIME"text/plain", oc::Core.OpaqueClosure{A, R}) where {A, R}
+    show(io, oc)
+end

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -150,3 +150,6 @@ end
 mk_va_opaque() = @opaque (x...)->x
 @test mk_va_opaque()(1) == (1,)
 @test mk_va_opaque()(1,2) == (1,2)
+
+# OpaqueClosure show method
+@test repr(@opaque x->1) == "(::Any)::Any->◌"


### PR DESCRIPTION
1. OC show method ended up in the wrong module after the move to Base.Experimental
2. The method show code was incorrectly using sig.parameters, when it meant to ask about the type of the argument (which are related, but not equivalent).