### PR TITLE
Don't touch gvars when compiling for an external back-end.

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -279,7 +279,7 @@ static void jl_ci_cache_lookup(const jl_cgparams_t &cgparams, jl_method_instance
 // takes the running content that has collected in the shadow module and dump it to disk
 // this builds the object file portion of the sysimage files for fast startup, and can
 // also be used be extern consumers like GPUCompiler.jl to obtain a module containing
-// all reachable & inferrrable functions. The `policy` flag switches between the defaul
+// all reachable & inferrrable functions. The `policy` flag switches between the default
 // mode `0` and the extern mode `1`.
 extern "C" JL_DLLEXPORT
 void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _policy)
@@ -404,16 +404,18 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _p
 
     // move everything inside, now that we've merged everything
     // (before adding the exported headers)
-    for (GlobalObject &G : clone->global_objects()) {
-        if (!G.isDeclaration()) {
-            G.setLinkage(Function::InternalLinkage);
-            makeSafeName(G);
-            addComdat(&G);
+    if (policy != CompilationPolicy::Extern) {
+        for (GlobalObject &G : clone->global_objects()) {
+            if (!G.isDeclaration()) {
+                G.setLinkage(Function::InternalLinkage);
+                makeSafeName(G);
+                addComdat(&G);
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
-            // Add unwind exception personalities to functions to handle async exceptions
-            if (Function *F = dyn_cast<Function>(&G))
-                F->setPersonalityFn(juliapersonality_func);
+                // Add unwind exception personalities to functions to handle async exceptions
+                if (Function *F = dyn_cast<Function>(&G))
+                    F->setPersonalityFn(juliapersonality_func);
 #endif
+            }
         }
     }
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -404,7 +404,7 @@ void *jl_create_native(jl_array_t *methods, const jl_cgparams_t cgparams, int _p
 
     // move everything inside, now that we've merged everything
     // (before adding the exported headers)
-    if (policy != CompilationPolicy::Extern) {
+    if (policy == CompilationPolicy::Default) {
         for (GlobalObject &G : clone->global_objects()) {
             if (!G.isDeclaration()) {
                 G.setLinkage(Function::InternalLinkage);


### PR DESCRIPTION
I noticed in https://github.com/JuliaGPU/CUDA.jl/pull/552 that exported global variables in an `llvmcall` got internalized along the way:

```julia
function main()
    Base.llvmcall(
        ("""@constant_memory = addrspace(4) externally_initialized global [1 x i32] [i32 42]
            define void @entry() {
                ret void
            }
         """, "entry"), Nothing, Tuple{})
end

main()  # make sure it works


## compile the code using the aot compiler interface

using LLVM

# get the method instance
world = Base.get_world_counter()
meth = which(main, Tuple{})
sig = Base.signature_type(main, Tuple{})::Type
(ti, env) = ccall(:jl_type_intersection_with_env, Any,
                    (Any, Any), sig, meth.sig)::Core.SimpleVector
meth = Base.func_for_method_checked(meth, ti, env)
method_instance = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance},
                (Any, Any, Any, UInt), meth, ti, env, world)

# set-up the compiler interface
params = Base.CodegenParams()

# generate IR
native_code = ccall(:jl_create_native, Ptr{Cvoid},
                    (Vector{Core.MethodInstance}, Base.CodegenParams, Cint),
                    [method_instance], params, #=extern policy=# 1)
@assert native_code != C_NULL
llvm_mod_ref = ccall(:jl_get_llvm_module, LLVM.API.LLVMModuleRef,
                        (Ptr{Cvoid},), native_code)
@assert llvm_mod_ref != C_NULL
llvm_mod = LLVM.Module(llvm_mod_ref)
```

```llvm
@constant_memory = internal addrspace(4) externally_initialized global [1 x i32] [i32 42]
```

It seems like this functionality should not trigger when compiling for an external compiler back-end.

---

FWIW, regular `@code_llvm` does not trigger this conversion, so just doing `@code_llvm dump_module=true main()` still results in:

```llvm
@constant_memory = addrspace(4) externally_initialized global [1 x i32] [i32 42]
```