### PR TITLE
fix #39379, use first∘LinearIndices instead of 1

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1193,7 +1193,7 @@ function _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int,M}) where M
 end
 _to_linear_index(A::AbstractArray, i::Integer) = i
 _to_linear_index(A::AbstractVector, i::Integer, I::Integer...) = i
-_to_linear_index(A::AbstractArray) = 1
+_to_linear_index(A::AbstractArray) = first(LinearIndices(A))
 _to_linear_index(A::AbstractArray, I::Integer...) = (@_inline_meta; _sub2ind(A, I...))
 
 ## IndexCartesian Scalar indexing: Canonical method is full dimensionality of Ints

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -715,6 +715,16 @@ end
     @test axes(S) == (OffsetArrays.IdOffsetRange(0:1), Base.OneTo(2), OffsetArrays.IdOffsetRange(2:5))
 end
 
+@testset "Zero-index indexing" begin
+    @test OffsetArray([6], 2:2)[] == 6
+    @test OffsetArray(fill(6, 1, 1), 2:2, 3:3)[] == 6
+    @test OffsetArray(fill(6))[] == 6
+    
+    @test_throws BoundsError OffsetArray([6,7], 2:3)[]
+    @test_throws BoundsError OffsetArray([6 7], 2:2, 2:3)[]
+    @test_throws BoundsError OffsetArray([], 2:1)[]
+end
+
 @testset "IdentityUnitRange indexing" begin
     a = OffsetVector(3:4, 2:3)
     ax = IdentityUnitRange(2:3)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -719,7 +719,6 @@ end
     @test OffsetArray([6], 2:2)[] == 6
     @test OffsetArray(fill(6, 1, 1), 2:2, 3:3)[] == 6
     @test OffsetArray(fill(6))[] == 6
-    
     @test_throws BoundsError OffsetArray([6,7], 2:3)[]
     @test_throws BoundsError OffsetArray([6 7], 2:2, 2:3)[]
     @test_throws BoundsError OffsetArray([], 2:1)[]


### PR DESCRIPTION
to resolve a zero-index getindex to a linear index.

fix #39379