### PR TITLE
make printing of typealias env shorter using `{<:T}` syntax, when possible

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -598,39 +598,50 @@ function show_can_elide(p::TypeVar, wheres::Vector, elide::Int, env::SimpleVecto
     return true
 end
 
-function show_typeparams(io::IO, env::SimpleVector, wheres::Vector)
+function show_typeparams(io::IO, env::SimpleVector, orig::SimpleVector, wheres::Vector)
     n = length(env)
-    print(io, "{")
     elide = length(wheres)
+    function egal_var(p::TypeVar, @nospecialize o)
+        return o isa TypeVar &&
+            ccall(:jl_types_egal, Cint, (Any, Any), p.ub, o.ub) != 0 &&
+            ccall(:jl_types_egal, Cint, (Any, Any), p.lb, o.lb) != 0
+    end
     for i = n:-1:1
         p = env[i]
         if p isa TypeVar
-            if p.lb === Union{} && show_can_elide(p, wheres, elide, env, i)
+            if i == n && egal_var(p, orig[i]) && show_can_elide(p, wheres, elide, env, i)
+                n -= 1
+                elide -= 1
+            elseif p.lb === Union{} && show_can_elide(p, wheres, elide, env, i)
                 elide -= 1
             elseif p.ub === Any && show_can_elide(p, wheres, elide, env, i)
                 elide -= 1
             end
         end
     end
-    for i = 1:n
-        p = env[i]
-        if p isa TypeVar
-            if p.lb === Union{} && something(findfirst(w -> w === p, wheres), 0) > elide
-                print(io, "<:")
-                show(io, p.ub)
-            elseif p.ub === Any && something(findfirst(w -> w === p, wheres), 0) > elide
-                print(io, ">:")
-                show(io, p.lb)
+    if n > 0
+        print(io, "{")
+        for i = 1:n
+            p = env[i]
+            if p isa TypeVar
+                if p.lb === Union{} && something(findfirst(w -> w === p, wheres), 0) > elide
+                    print(io, "<:")
+                    show(io, p.ub)
+                elseif p.ub === Any && something(findfirst(w -> w === p, wheres), 0) > elide
+                    print(io, ">:")
+                    show(io, p.lb)
+                else
+                    show(io, p)
+                end
             else
                 show(io, p)
             end
-        else
-            show(io, p)
+            i < n && print(io, ", ")
         end
-        i < n && print(io, ", ")
+        print(io, "}")
     end
-    print(io, "}")
-    return elide
+    resize!(wheres, elide)
+    nothing
 end
 
 function show_typealias(io::IO, name::GlobalRef, x::Type, env::SimpleVector, wheres::Vector)
@@ -650,8 +661,13 @@ function show_typealias(io::IO, name::GlobalRef, x::Type, env::SimpleVector, whe
     for p in wheres
         io = IOContext(io, :unionall_env => p)
     end
-    elide = show_typeparams(io, env, wheres)
-    resize!(wheres, elide)
+    orig = getfield(name.mod, name.name)
+    vars = TypeVar[]
+    while orig isa UnionAll
+        push!(vars, orig.var)
+        orig = orig.body
+    end
+    show_typeparams(io, env, Core.svec(vars...), wheres)
     nothing
 end
 
@@ -972,18 +988,17 @@ function show_datatype(io::IO, @nospecialize(x::DataType), wheres::Vector=TypeVa
     n = length(parameters)
 
     # Print homogeneous tuples with more than 3 elements compactly as NTuple{N, T}
-    if istuple && n > 3 && all(@nospecialize(i) -> (parameters[1] === i), parameters)
-        print(io, "NTuple{", n, ", ", parameters[1], "}")
+    if istuple
+        if n > 3 && all(@nospecialize(i) -> (parameters[1] === i), parameters)
+            print(io, "NTuple{", n, ", ", parameters[1], "}")
+        else
+            print(io, "Tuple{")
+            join(io, parameters, ", ")
+            print(io, "}")
+        end
     else
         show_type_name(io, x.name)
-        if (n > 0 || istuple) && x !== Tuple
-            # Do not print the type parameters for the primary type if we are
-            # printing a method signature or type parameter.
-            # Always print the type parameter if we are printing the type directly
-            # since this information is still useful.
-            elide = show_typeparams(io, parameters, wheres)
-            resize!(wheres, elide)
-        end
+        show_typeparams(io, parameters, unwrap_unionall(x.name.wrapper).parameters, wheres)
     end
 end
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1034,7 +1034,7 @@ consider the two types created by the following declarations:
 
 ```jldoctest
 julia> const T1 = Array{Array{T,1} where T, 1}
-Vector{Vector{T} where T} (alias for Array{Array{T, 1} where T, 1})
+Vector{Vector{<:Any}} (alias for Array{Array{T, 1} where T, 1})
 
 julia> const T2 = Array{Array{T, 1}, 1} where T
 Array{Vector{T}, 1} where T

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1034,7 +1034,7 @@ consider the two types created by the following declarations:
 
 ```jldoctest
 julia> const T1 = Array{Array{T, 1} where T, 1}
-Vector{Vector} (alias for Array{Array{<:Any, 1}, 1})
+Vector{Vector} (alias for Array{Array{T, 1} where T, 1})
 
 julia> const T2 = Array{Array{T, 1}, 1} where T
 Array{Vector{T}, 1} where T

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1033,8 +1033,8 @@ The `where` keyword itself can be nested inside a more complex declaration. For 
 consider the two types created by the following declarations:
 
 ```jldoctest
-julia> const T1 = Array{Array{T,1} where T, 1}
-Vector{Vector{<:Any}} (alias for Array{Array{T, 1} where T, 1})
+julia> const T1 = Array{Array{T, 1} where T, 1}
+Vector{Vector} (alias for Array{Array{<:Any, 1}, 1})
 
 julia> const T2 = Array{Array{T, 1}, 1} where T
 Array{Vector{T}, 1} where T

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -60,7 +60,7 @@ end
 Base.getindex(A::Stable, i) = A.A[i]
 Base.getindex(A::Unstable, i) = A.A[i]
 
-tag = "ARRAY{FLOAT64, N}"
+tag = "ARRAY{FLOAT64, <:ANY}"
 @test warntype_hastag(getindex, Tuple{Unstable{Float64},Int}, tag)
 @test !warntype_hastag(getindex, Tuple{Stable{Float64,2},Int}, tag)
 @test warntype_hastag(getindex, Tuple{Stable{Float64},Int}, tag)

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -60,7 +60,7 @@ end
 Base.getindex(A::Stable, i) = A.A[i]
 Base.getindex(A::Unstable, i) = A.A[i]
 
-tag = "ARRAY{FLOAT64, <:ANY}"
+tag = "ARRAY"
 @test warntype_hastag(getindex, Tuple{Unstable{Float64},Int}, tag)
 @test !warntype_hastag(getindex, Tuple{Stable{Float64,2},Int}, tag)
 @test warntype_hastag(getindex, Tuple{Stable{Float64},Int}, tag)

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -291,7 +291,7 @@ function summarize(io::IO, TT::Type, binding::Binding)
             println(io, "# Subtypes")
             println(io, "```")
             for t in subt
-                println(io, t)
+                println(io, Base.unwrap_unionall(t))
             end
             println(io, "```")
         end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -965,10 +965,10 @@ abstract type $(curmod_prefix)Undocumented.at0{T<:Number, N}
 # Subtypes
 
 ```
-$(curmod_prefix)Undocumented.at1{T, N} where {Integer<:T<:Number, N}
-$(curmod_prefix)Undocumented.pt2
-$(curmod_prefix)Undocumented.st3
-$(curmod_prefix)Undocumented.st4{T, N} where {T<:Number, N}
+$(curmod_prefix)Undocumented.at1{Integer<:T<:Number, N}
+$(curmod_prefix)Undocumented.pt2{T<:Number, N, A>:Integer}
+$(curmod_prefix)Undocumented.st3{T<:Integer, N}
+$(curmod_prefix)Undocumented.st4{T<:Number, N}
 ```
 """)
 @test docstrings_equal(@doc(Undocumented.at0), doc"$doc_str")
@@ -985,7 +985,7 @@ abstract type $(curmod_prefix)Undocumented.at1{T>:Integer, N}
 # Subtypes
 
 ```
-$(curmod_prefix)Undocumented.mt6{Integer, N} where N
+$(curmod_prefix)Undocumented.mt6{Integer, N}
 ```
 
 # Supertype Hierarchy
@@ -1007,9 +1007,9 @@ abstract type $(curmod_prefix)Undocumented.at0{Int64, N}
 # Subtypes
 
 ```
-$(curmod_prefix)Undocumented.pt2{Int64, N, A} where {N, A>:Integer}
-$(curmod_prefix)Undocumented.st3{Int64, N} where N
-$(curmod_prefix)Undocumented.st4{Int64, N} where N
+$(curmod_prefix)Undocumented.pt2{Int64, N, A>:Integer}
+$(curmod_prefix)Undocumented.st3{Int64, N}
+$(curmod_prefix)Undocumented.st4{Int64, N}
 ```
 """)
 @test docstrings_equal(@doc(Undocumented.at_), doc"$doc_str")
@@ -1157,9 +1157,9 @@ No documentation found.
 
 # Union Composed of Types
 
- - `$(curmod_prefix)Undocumented.at1{T, N} where {T, N}`
- - `$(curmod_prefix)Undocumented.pt2{T, N, A} where {T, N, A>:Integer}`
- - `$(curmod_prefix)Undocumented.st3{T, N} where {T, N}`
+ - `$(curmod_prefix)Undocumented.at1{<:Any}`
+ - `$(curmod_prefix)Undocumented.pt2{<:Any}`
+ - `$(curmod_prefix)Undocumented.st3{<:Any}`
  - `$(curmod_prefix)Undocumented.st4`
 """)
 @test docstrings_equal(@doc(Undocumented.ut9), doc"$doc_str")

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1157,9 +1157,9 @@ No documentation found.
 
 # Union Composed of Types
 
- - `$(curmod_prefix)Undocumented.at1{<:Any}`
- - `$(curmod_prefix)Undocumented.pt2{<:Any}`
- - `$(curmod_prefix)Undocumented.st3{<:Any}`
+ - `$(curmod_prefix)Undocumented.at1{T} where T`
+ - `$(curmod_prefix)Undocumented.pt2{T} where T`
+ - `$(curmod_prefix)Undocumented.st3{T} where T`
  - `$(curmod_prefix)Undocumented.st4`
 """)
 @test docstrings_equal(@doc(Undocumented.ut9), doc"$doc_str")

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -432,7 +432,7 @@ let err_str,
     @test startswith(sprint(show, which(FunctionLike(), Tuple{})),
                      "(::$(curmod_prefix)FunctionLike)() in $curmod_str at $sp:$(method_defs_lineno + 7)")
     @test startswith(sprint(show, which(StructWithUnionAllMethodDefs{<:Integer}, (Any,))),
-                     "($(curmod_prefix)StructWithUnionAllMethodDefs{T} where T<:Integer)(x)")
+                     "($(curmod_prefix)StructWithUnionAllMethodDefs{<:Integer})(x)")
     @test repr("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 1 method)"
     @test repr("text/plain", Core.arraysize) == "arraysize (built-in function)"
 

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -432,7 +432,7 @@ let err_str,
     @test startswith(sprint(show, which(FunctionLike(), Tuple{})),
                      "(::$(curmod_prefix)FunctionLike)() in $curmod_str at $sp:$(method_defs_lineno + 7)")
     @test startswith(sprint(show, which(StructWithUnionAllMethodDefs{<:Integer}, (Any,))),
-                     "($(curmod_prefix)StructWithUnionAllMethodDefs{<:Integer})(x)")
+                     "($(curmod_prefix)StructWithUnionAllMethodDefs{T} where T<:Integer)(x)")
     @test repr("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 1 method)"
     @test repr("text/plain", Core.arraysize) == "arraysize (built-in function)"
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -224,7 +224,7 @@ let ex = :(a + b)
 end
 foo13825(::Array{T, N}, ::Array, ::Vector) where {T, N} = nothing
 @test startswith(string(first(methods(foo13825))),
-                 "foo13825(::Array{T, N}, ::Array, ::Vector{<:Any}) where {T, N} in")
+                 "foo13825(::Array{T, N}, ::Array, ::Vector) where {T, N} in")
 
 mutable struct TLayout
     x::Int8

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -224,7 +224,7 @@ let ex = :(a + b)
 end
 foo13825(::Array{T, N}, ::Array, ::Vector) where {T, N} = nothing
 @test startswith(string(first(methods(foo13825))),
-                 "foo13825(::Array{T, N}, ::Array, ::Vector{T} where T)")
+                 "foo13825(::Array{T, N}, ::Array, ::Vector{<:Any}) where {T, N} in")
 
 mutable struct TLayout
     x::Int8

--- a/test/show.jl
+++ b/test/show.jl
@@ -1569,12 +1569,64 @@ end
 end
 
 let x = TypeVar(:_), y = TypeVar(:_)
-    @test repr(UnionAll(x, UnionAll(y, Pair{x,y}))) == "Pair{_1, _2} where {_1, _2}"
-    @test repr(UnionAll(x, UnionAll(y, Pair{UnionAll(x,Ref{x}),y}))) == "Pair{Ref{_1} where _1, _1} where _1"
+    @test repr(UnionAll(x, UnionAll(y, Pair{x,y}))) == "Pair{<:Any, <:Any}"
+    @test repr(UnionAll(y, UnionAll(x, Pair{x,y}))) == "Pair{<:Any, _1} where _1"
+    @test repr(UnionAll(x, UnionAll(y, Pair{UnionAll(x,Ref{x}),y}))) == "Pair{Ref{<:Any}, <:Any}"
+    @test repr(UnionAll(y, UnionAll(x, Pair{UnionAll(y,Ref{x}),y}))) == "Pair{Ref{_2}, _1} where {_1, _2}"
     x = TypeVar(:a)
     y = TypeVar(:a)
     z = TypeVar(:a)
-    @test repr(UnionAll(z, UnionAll(x, UnionAll(y, Tuple{x,y,z})))) == "Tuple{a1, a2, a} where {a, a1, a2}"
+    @test repr(UnionAll(z, UnionAll(x, UnionAll(y, Tuple{x,y,z})))) == "Tuple{<:Any, <:Any, a} where a"
+    @test repr(UnionAll(z, UnionAll(x, UnionAll(y, Tuple{z,y,x})))) == "Tuple{a, <:Any, a1} where {a, a1}"
+end
+
+is_juliarepr(x) = eval(Meta.parse(repr(x))) == x
+@testset "unionall types" begin
+    X = TypeVar(gensym())
+    Y = TypeVar(gensym(), Ref, Ref)
+    x, y, z = TypeVar(:a), TypeVar(:a), TypeVar(:a)
+    struct TestTVUpper{A<:Integer} end
+
+    # named typevars
+    @test is_juliarepr(Ref{A} where A)
+    @test is_juliarepr(Ref{A} where A>:Ref)
+    @test is_juliarepr(Ref{A} where A<:Ref)
+    @test is_juliarepr(Ref{A} where Ref<:A<:Ref)
+    @test is_juliarepr(TestTVUpper{<:Real})
+    @test is_juliarepr(TestTVUpper{<:Integer})
+    @test is_juliarepr(TestTVUpper{<:Signed})
+
+    # typearg order
+    @test is_juliarepr(UnionAll(X, Pair{X,<:Any}))
+    @test is_juliarepr(UnionAll(X, Pair{<:Any,X}))
+
+    # duplicates
+    @test is_juliarepr(UnionAll(X, Pair{X,X}))
+
+    # nesting
+    @test is_juliarepr(UnionAll(X, Ref{Ref{X}}))
+    @test is_juliarepr(Union{T, Int} where T)
+    @test is_juliarepr(Pair{A, <:A} where A)
+
+    # renumbered typevars with same names
+    @test is_juliarepr(UnionAll(z, UnionAll(x, UnionAll(y, Tuple{x,y,z}))))
+
+    # shortened typevar printing
+    @test repr(Ref{<:Any}) == "Ref{<:Any}" # improve?
+    @test repr(Pair{1, <:Any}) == "Pair{1, <:Any}" # improve?
+    @test repr(Ref{<:Ref}) == "Ref{<:Ref}"
+    @test repr(Ref{>:Ref}) == "Ref{>:Ref}"
+    @test repr(Pair{<:Any, 1}) == "Pair{<:Any, 1}"
+    yname = sprint(Base.show_unquoted, Y.name)
+    @test repr(UnionAll(Y, Ref{Y})) == "Ref{$yname} where Ref<:$yname<:Ref"
+    @test endswith(repr(TestTVUpper{<:Real}), "TestTVUpper{<:Real}")
+    @test endswith(repr(TestTVUpper{<:Integer}), "TestTVUpper{<:Integer}") # improve?
+    @test endswith(repr(TestTVUpper{<:Signed}), "TestTVUpper{<:Signed}")
+
+    # exception for tuples
+    @test is_juliarepr(Tuple)
+    @test is_juliarepr(Tuple{})
+    @test is_juliarepr(Tuple{<:Any})
 end
 
 @testset "showarg" begin
@@ -1659,7 +1711,7 @@ end
     @test showstr([Float16(1)]) == "Float16[1.0]"
     @test showstr([[Float16(1)]]) == "Vector{Float16}[[1.0]]"
     @test replstr(Real[Float16(1)]) == "1-element Vector{Real}:\n Float16(1.0)"
-    @test replstr(Array{Real}[Real[1]]) == "1-element Vector{Array{Real, N} where N}:\n [1]"
+    @test replstr(Array{Real}[Real[1]]) == "1-element Vector{Array{Real, <:Any}}:\n [1]"
     # printing tuples (Issue #25042)
     @test replstr(fill((Int64(1), zeros(Float16, 3)), 1)) ==
                  "1-element Vector{Tuple{Int64, Vector{Float16}}}:\n (1, [0.0, 0.0, 0.0])"
@@ -1706,9 +1758,9 @@ end
     @test replstr([[1.0]=>1.0]) == "1-element Vector{Pair{Vector{Float64}, Float64}}:\n [1.0] => 1.0"
 
     # issue #28159
-    @test replstr([(a=1, b=2), (a=3,c=4)]) == "2-element Vector{NamedTuple{names, Tuple{$Int, $Int}} where names}:\n (a = 1, b = 2)\n (a = 3, c = 4)"
+    @test replstr([(a=1, b=2), (a=3,c=4)]) == "2-element Vector{NamedTuple{<:Any, Tuple{$Int, $Int}}}:\n (a = 1, b = 2)\n (a = 3, c = 4)"
 
-    @test replstr(Vector[Any[1]]) == "1-element Vector{Vector{T} where T}:\n Any[1]"
+    @test replstr(Vector[Any[1]]) == "1-element Vector{Vector{<:Any}}:\n Any[1]"
     @test replstr(AbstractDict{Integer,Integer}[Dict{Integer,Integer}(1=>2)]) ==
         "1-element Vector{AbstractDict{Integer, Integer}}:\n Dict(1 => 2)"
 
@@ -1929,7 +1981,7 @@ end
 
 @testset """printing "Any" is not skipped with nested arrays""" begin
     @test replstr(Union{X28004,Vector}[X28004(Any[X28004(1)])], :compact => true) ==
-        "1-element Vector{Union{X28004, Vector{T} where T}}:\n X(Any[X(1)])"
+        "1-element Vector{Union{X28004, Vector{<:Any}}}:\n X(Any[X(1)])"
 end
 
 # Issue 25589 - Underlines in cmd printing
@@ -2096,11 +2148,13 @@ end
 @test Base.make_typealias(M37012.AStruct{1}) === nothing
 @test isempty(Base.make_typealiases(M37012.AStruct{1})[1])
 @test string(M37012.AStruct{1}) == "$(curmod_prefix)M37012.AStruct{1}"
-@test string(Union{Nothing, Number, Vector}) == "Union{Nothing, Number, Vector{T} where T}"
-@test string(Union{Nothing, AbstractVecOrMat}) == "Union{Nothing, AbstractVecOrMat{T} where T}"
+@test string(Union{Nothing, Number, Vector}) == "Union{Nothing, Number, Vector{<:Any}}"
+@test string(Union{Nothing, Number, Vector{<:Integer}}) == "Union{Nothing, Number, Vector{<:Integer}}"
+@test string(Union{Nothing, AbstractVecOrMat}) == "Union{Nothing, AbstractVecOrMat{<:Any}}"
+@test string(Union{Nothing, AbstractVecOrMat{<:Integer}}) == "Union{Nothing, AbstractVecOrMat{<:Integer}}"
 @test string(M37012.BStruct{T, T} where T) == "$(curmod_prefix)M37012.B2{T, T} where T"
-@test string(M37012.BStruct{T, S} where {T<:Unsigned, S<:Signed}) == "$(curmod_prefix)M37012.B2{S, T} where {T<:Unsigned, S<:Signed}"
-@test string(M37012.BStruct{T, S} where {T<:Signed, S<:T}) == "$(curmod_prefix)M37012.B2{S, T} where {T<:Signed, S<:T}"
+@test string(M37012.BStruct{T, S} where {T<:Unsigned, S<:Signed}) == "$(curmod_prefix)M37012.B2{<:Signed, T} where T<:Unsigned"
+@test string(M37012.BStruct{T, S} where {T<:Signed, S<:T}) == "$(curmod_prefix)M37012.B2{<:T, T} where T<:Signed"
 @test string(Union{M37012.SimpleU, Nothing}) == "Union{Nothing, $(curmod_prefix)M37012.SimpleU}"
 @test string(Union{M37012.SimpleU, Nothing, T} where T) == "Union{Nothing, $(curmod_prefix)M37012.SimpleU, T} where T"
 @test string(Union{AbstractVector{T}, T} where T) == "Union{AbstractVector{T}, T} where T"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1570,7 +1570,7 @@ end
 
 let x = TypeVar(:_), y = TypeVar(:_)
     @test repr(UnionAll(x, UnionAll(y, Pair{x,y}))) == "Pair"
-    @test repr(UnionAll(y, UnionAll(x, Pair{x,y}))) == "Pair{<:Any, _1} where _1"
+    @test repr(UnionAll(y, UnionAll(x, Pair{x,y}))) == "Pair{_2, _1} where {_1, _2}"
     @test repr(UnionAll(x, UnionAll(y, Pair{UnionAll(x,Ref{x}),y}))) == "Pair{Ref}"
     @test repr(UnionAll(y, UnionAll(x, Pair{UnionAll(y,Ref{x}),y}))) == "Pair{Ref{_2}, _1} where {_1, _2}"
 end
@@ -1584,9 +1584,9 @@ let x, y, x
 end
 
 let x = TypeVar(:_, Number), y = TypeVar(:_, Number)
-    @test repr(UnionAll(x, UnionAll(y, Pair{x,y}))) == "Pair{<:Number, <:Number}"
-    @test repr(UnionAll(y, UnionAll(x, Pair{x,y}))) == "Pair{<:Number, _1} where _1<:Number"
-    @test repr(UnionAll(x, UnionAll(y, Pair{UnionAll(x,Ref{x}),y}))) == "Pair{Ref{<:Number}, <:Number}"
+    @test repr(UnionAll(x, UnionAll(y, Pair{x,y}))) == "Pair{_1, _2} where {_1<:Number, _2<:Number}"
+    @test repr(UnionAll(y, UnionAll(x, Pair{x,y}))) == "Pair{_2, _1} where {_1<:Number, _2<:Number}"
+    @test repr(UnionAll(x, UnionAll(y, Pair{UnionAll(x,Ref{x}),y}))) == "Pair{Ref{_1} where _1<:Number, _1} where _1<:Number"
     @test repr(UnionAll(y, UnionAll(x, Pair{UnionAll(y,Ref{x}),y}))) == "Pair{Ref{_2}, _1} where {_1<:Number, _2<:Number}"
 end
 
@@ -1771,7 +1771,7 @@ end
     @test replstr([[1.0]=>1.0]) == "1-element Vector{Pair{Vector{Float64}, Float64}}:\n [1.0] => 1.0"
 
     # issue #28159
-    @test replstr([(a=1, b=2), (a=3,c=4)]) == "2-element Vector{NamedTuple{<:Any, Tuple{$Int, $Int}}}:\n (a = 1, b = 2)\n (a = 3, c = 4)"
+    @test replstr([(a=1, b=2), (a=3,c=4)]) == "2-element Vector{NamedTuple{names, Tuple{$Int, $Int}} where names}:\n (a = 1, b = 2)\n (a = 3, c = 4)"
 
     @test replstr(Vector[Any[1]]) == "1-element Vector{Vector}:\n Any[1]"
     @test replstr(AbstractDict{Integer,Integer}[Dict{Integer,Integer}(1=>2)]) ==
@@ -2166,8 +2166,8 @@ end
 @test string(Union{Nothing, AbstractVecOrMat}) == "Union{Nothing, AbstractVecOrMat}"
 @test string(Union{Nothing, AbstractVecOrMat{<:Integer}}) == "Union{Nothing, AbstractVecOrMat{<:Integer}}"
 @test string(M37012.BStruct{T, T} where T) == "$(curmod_prefix)M37012.B2{T, T} where T"
-@test string(M37012.BStruct{T, S} where {T<:Unsigned, S<:Signed}) == "$(curmod_prefix)M37012.B2{<:Signed, T} where T<:Unsigned"
-@test string(M37012.BStruct{T, S} where {T<:Signed, S<:T}) == "$(curmod_prefix)M37012.B2{<:T, T} where T<:Signed"
+@test string(M37012.BStruct{T, S} where {T<:Unsigned, S<:Signed}) == "$(curmod_prefix)M37012.B2{S, T} where {T<:Unsigned, S<:Signed}"
+@test string(M37012.BStruct{T, S} where {T<:Signed, S<:T}) == "$(curmod_prefix)M37012.B2{S, T} where {T<:Signed, S<:T}"
 @test string(Union{M37012.SimpleU, Nothing}) == "Union{Nothing, $(curmod_prefix)M37012.SimpleU}"
 @test string(Union{M37012.SimpleU, Nothing, T} where T) == "Union{Nothing, $(curmod_prefix)M37012.SimpleU, T} where T"
 @test string(Union{AbstractVector{T}, T} where T) == "Union{AbstractVector{T}, T} where T"


### PR DESCRIPTION
Inspired by https://github.com/JuliaLang/julia/pull/35710, including taking the tests (though not any of the implementation) from there. Unlike the original PR, this also prefers the short form (eliding the TypeVar name), even in case where it is not a gensym.
```
julia> struct A{B,C,D,E,F,G} end

julia> A{U, <:Any, T, Int, S, <:T} where {S, T<:S, U<:Integer}
A{<:Integer, <:Any, T, Int64, S, <:T} where {S, T<:S}
```

Github: this closes #35710 and fixes #34887