### PR TITLE
[release-1.6] Fix `typeassert_tfunc` for vararg `PartialStruct`s

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -561,12 +561,18 @@ function tmeet(@nospecialize(v), @nospecialize(t))
             return Bottom
         end
         @assert widev <: Tuple
-        new_fields = Vector{Any}(undef, length(v.fields))
+        if !(ti <: Tuple)
+            ti = widev
+        end
+        new_fields = Vector{Any}(undef, length(ti.parameters))
         for i = 1:length(new_fields)
-            new_fields[i] = tmeet(v.fields[i], widenconst(getfield_tfunc(t, Const(i))))
+            new_fields[i] = tmeet(getfield_tfunc(v, Const(i)), widenconst(getfield_tfunc(t, Const(i))))
             if new_fields[i] === Bottom
                 return Bottom
             end
+        end
+        if isvatuple(ti)
+            new_fields[end] = Vararg{new_fields[end]}
         end
         return tuple_tfunc(new_fields)
     elseif isa(v, Conditional)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2980,3 +2980,13 @@ f38888() = S38888(Base.inferencebarrier(3))
 @test f38888() isa S38888
 g38888() = S38888(Base.inferencebarrier(3), nothing)
 @test g38888() isa S38888
+
+# issue #38971
+f28971() = (1, [2,3]...)::Tuple{Int,Int,Int}
+@test @inferred(f28971()) == (1, 2, 3)
+g28971_1() = (1, [2,3]...)::Tuple{Vararg{Int}}
+@test @inferred(Tuple{Int, Vararg{Int}}, g28971_1()) == (1, 2, 3)
+g28971_2() = (1, [2,3]...)::Tuple{Int, Vararg{Int}}
+@test @inferred(Tuple{Int, Vararg{Int}}, g28971_2()) == (1, 2, 3)
+g28971_3() = (1, [2,3]...)::Tuple{Int, Int, Vararg{Int}}
+@test @inferred(Tuple{Int, Int, Vararg{Int}}, g28971_3()) == (1, 2, 3)


### PR DESCRIPTION
Fixes #38971.

Alternatively, we could just backport the relevant part of #38136, but that would loose some precision for the non-const part compared to 1.5 (inferring as a vararg tuple even tough the type that as being asserted to is non-vararg), while this patch maintains it.

Note: PR against backports-release-1.6.~~release-1.6. Or should this be against the backports branch?~~