### PR TITLE
Revert "Let tmerge form a Union more often (#27843)"

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -375,10 +375,9 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
         return Any
     end
     typea == typeb && return typea
-    # it's always ok to form a Union of two Union-free types
-    u = Union{typea, typeb}
-    if unioncomplexity(u) <= 1
-        return u
+    # it's always ok to form a Union of two concrete types
+    if (isconcretetype(typea) || isType(typea)) && (isconcretetype(typeb) || isType(typeb))
+        return Union{typea, typeb}
     end
     # collect the list of types from past tmerge calls returning Union
     # and then reduce over that list

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2041,16 +2041,6 @@ let rt = Base.return_types(splat27434, (NamedTuple{(:x,), Tuple{T}} where T,))
     @test !Base.has_free_typevars(rt[1])
 end
 
-# PR #27843
-bar27843(x, y::Bool) = fill(x, 0)
-bar27843(x, y) = fill(x, ntuple(_ -> 0, y))::Array{typeof(x)}
-foo27843(x, y) = bar27843(x, y)
-@test Core.Compiler.return_type(foo27843, Tuple{Union{Float64,Int}, Any}) == Union{Array{Float64}, Array{Int}}
-let atypes1 = Tuple{Union{IndexCartesian, IndexLinear}, Any, Union{Tuple{}, Tuple{Any,Vararg{Any,N}} where N}, Tuple},
-    atypes2 = Tuple{Union{IndexCartesian, IndexLinear}, Any, Tuple, Tuple}
-    @test Core.Compiler.return_type(SubArray, atypes1) <: Core.Compiler.return_type(SubArray, atypes2)
-end
-
 # issue #27078
 f27078(T::Type{S}) where {S} = isa(T, UnionAll) ? f27078(T.body) : T
 T27078 = Vector{Vector{T}} where T


### PR DESCRIPTION
This reverts commit 6c1824d99769fa79f69eb866ce76df674fd37878. (#27843)

Fixes #39349. The extra inference precision is nice, but seems to carry too much risk of blowup.