### PR TITLE
fix `isknownlength` for new Vararg representation

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -49,7 +49,8 @@ argtypes_to_type(argtypes::Array{Any,1}) = Tuple{anymap(widenconst, argtypes)...
 
 function isknownlength(t::DataType)
     isvatuple(t) || return true
-    return length(t.parameters) > 0 && isa(unwrap_unionall(t.parameters[end]).parameters[2], Int)
+    va = t.parameters[end]
+    return isdefined(va, :N) && va.N isa Int
 end
 
 # test if non-Type, non-TypeVar `x` can be used to parameterize a type

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3023,3 +3023,11 @@ f_aggressive(x) = g_aggressive(x, 1)
 # render the annotation effectless.
 @test Base.return_types(f_nonaggressive, Tuple{Int})[1] == Val
 @test Base.return_types(f_aggressive, Tuple{Int})[1] == Val{1}
+
+function splat_lotta_unions()
+    a = Union{Tuple{Int},Tuple{String,Vararg{Int}},Tuple{Int,Vararg{Int}}}[(2,)][1]
+    b = Union{Int8,Int16,Int32,Int64,Int128}[1][1]
+    c = Union{Int8,Int16,Int32,Int64,Int128}[1][1]
+    (a...,b...,c...)
+end
+@test Core.Compiler.return_type(splat_lotta_unions, Tuple{}) >: Tuple{Int,Int,Int}


### PR DESCRIPTION
Ran into this loading ITensors on master.