### PR TITLE
Fix ~700 PyPlot invalidations

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -71,7 +71,7 @@ struct Platform <: AbstractPlatform
                 if isa(value, VersionNumber)
                     value = string(value)
                 elseif isa(value, AbstractString)
-                    v = tryparse(VersionNumber, value)
+                    v = tryparse(VersionNumber, String(value))
                     if isa(v, VersionNumber)
                         value = string(v)
                     end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -281,14 +281,11 @@ function showerror(io::IO, ex::MethodError)
         if any(x -> x <: AbstractArray{<:Number}, arg_types_param) &&
             any(x -> x <: Number, arg_types_param)
 
-            nouns = Dict{Any,String}(
-                Base.:+ => "addition",
-                Base.:- => "subtraction",
-            )
+            nounf = f === Base.:+ ? "addition" : "subtraction"
             varnames = ("scalar", "array")
             first, second = arg_types_param[1] <: Number ? varnames : reverse(varnames)
             fstring = f === Base.:+ ? "+" : "-"  # avoid depending on show_default for functions (invalidation)
-            print(io, "\nFor element-wise $(nouns[f]), use broadcasting with dot syntax: $first .$fstring $second")
+            print(io, "\nFor element-wise $nounf, use broadcasting with dot syntax: $first .$fstring $second")
         end
     end
     if ft <: AbstractArray

--- a/base/file.jl
+++ b/base/file.jl
@@ -318,8 +318,8 @@ function checkfor_mv_cp_cptree(src::AbstractString, dst::AbstractString, txt::Ab
     end
 end
 
-function cptree(src::AbstractString, dst::AbstractString; force::Bool=false,
-                                                          follow_symlinks::Bool=false)
+function cptree(src::String, dst::String; force::Bool=false,
+                                          follow_symlinks::Bool=false)
     isdir(src) || throw(ArgumentError("'$src' is not a directory. Use `cp(src, dst)`"))
     checkfor_mv_cp_cptree(src, dst, "copying"; force=force)
     mkdir(dst)
@@ -335,6 +335,8 @@ function cptree(src::AbstractString, dst::AbstractString; force::Bool=false,
         end
     end
 end
+cptree(src::AbstractString, dst::AbstractString; kwargs...) =
+    cptree(String(src)::String, String(dst)::String; kwargs...)
 
 """
     cp(src::AbstractString, dst::AbstractString; force::Bool=false, follow_symlinks::Bool=false)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -286,7 +286,8 @@ function merge(a::NamedTuple, itr)
     names = Symbol[]
     vals = Any[]
     inds = IdDict{Symbol,Int}()
-    for (k::Symbol, v) in itr
+    for (k, v) in itr
+        k = k::Symbol
         oldind = get(inds, k, 0)
         if oldind > 0
             vals[oldind] = v

--- a/stdlib/Markdown/src/parse/parse.jl
+++ b/stdlib/Markdown/src/parse/parse.jl
@@ -2,7 +2,7 @@
 
 mutable struct MD
     content::Vector{Any}
-    meta::Dict{Any, Any}
+    meta::Dict{Symbol, Any}
 
     MD(content::AbstractVector, meta::Dict = Dict()) =
         new(content, meta)


### PR DESCRIPTION
PyCall specializes a lot of low-level methods like
`convert(::Type{Symbol}, arg)`, and this triggers a lot of invalidations.
The worst are for keyword-argument functions, but there are quite
a few others. This drops the number from ~1100 to ~400.
It's quite likely that additional improvements could be made, but this
is major progress.

Related: #39419, https://github.com/JuliaLang/Pkg.jl/pull/2365