### PR TITLE
InteractiveUtils: add more info to code_warntype

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -4,7 +4,7 @@
 
 const empty_sym = Symbol("")
 function strip_gensym(sym)
-    if sym === Symbol("#self#") || sym === Symbol("#unused#")
+    if sym === :var"#self#" || sym === :var"#unused#"
         return empty_sym
     end
     return Symbol(replace(String(sym), r"^(.*)#(.*#)?\d+$" => s"\1"))

--- a/base/show.jl
+++ b/base/show.jl
@@ -1030,6 +1030,10 @@ function sourceinfo_slotnames(src::CodeInfo)
     names = Dict{String,Int}()
     printnames = Vector{String}(undef, length(slotnames))
     for i in eachindex(slotnames)
+        if slotnames[i] == :var"#unused#"
+            printnames[i] = "_"
+            continue
+        end
         name = string(slotnames[i])
         idx = get!(names, name, i)
         if idx != i || isempty(name)

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -29,18 +29,15 @@ end
 
 function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
     used || return
-    if ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
-        if highlighting[:warntype] && ty isa Union && Base.is_expected_union(ty)
-            Base.emphasize(io, "::$ty", Base.warn_color()) # more mild user notification
-        else
-            Base.emphasize(io, "::$ty")
-        end
+    str = "::$ty"
+    if !highlighting[:warntype]
+        print(io, str)
+    elseif ty isa Union && Base.is_expected_union(ty)
+        Base.emphasize(io, str, Base.warn_color()) # more mild user notification
+    elseif ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
+        Base.emphasize(io, str)
     else
-        if highlighting[:warntype]
-            Base.printstyled(io, "::$ty", color=:cyan) # show the "good" type
-        else
-            Base.print(io, "::$ty")
-        end
+        Base.printstyled(io, str, color=:cyan) # show the "good" type
     end
     nothing
 end
@@ -65,25 +62,73 @@ function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); debuginfo::Sy
     lineprinter = Base.IRShow.__debuginfo[debuginfo]
     for (src, rettype) in code_typed(f, t, optimize=optimize)
         lambda_io::IOContext = io
+        p = src.parent
+        nargs::Int = 0
+        if p isa Core.MethodInstance
+            println(io, p)
+            print(io, "  from ")
+            println(io, p.def)
+            p.def isa Method && (nargs = p.def.nargs)
+            if !isempty(p.sparam_vals)
+                println(io, "Static Parameters")
+                sig = p.def.sig
+                warn_color = Base.warn_color() # more mild user notification
+                for i = 1:length(p.sparam_vals)
+                    sig = sig::UnionAll
+                    name = sig.var.name
+                    val = p.sparam_vals[i]
+                    print_highlighted(io::IO, v::String, color::Symbol) =
+                        if highlighting[:warntype]
+                            Base.printstyled(io, v; color)
+                        else
+                            Base.print(io, v)
+                        end
+                    if val isa TypeVar
+                        if val.lb === Union{}
+                            print(io, "  ", name, " <: ")
+                            print_highlighted(io, "$(val.ub)", warn_color)
+                        elseif val.ub === Any
+                            print(io, "  ", sig.var.name, " >: ")
+                            print_highlighted(io, "$(val.lb)", warn_color)
+                        else
+                            print(io, "  ")
+                            print_highlighted(io, "$(val.lb)", warn_color)
+                            print(io, " <: ", sig.var.name, " <: ")
+                            print_highlighted(io, "$(val.ub)", warn_color)
+                        end
+                    elseif val isa typeof(Vararg)
+                        print(io, "  ", name, "::")
+                        print_highlighted(io, "Int", warn_color)
+                    else
+                        print(io, "  ", sig.var.name, " = ")
+                        print_highlighted(io, "$(val)", :cyan) # show the "good" type
+                    end
+                    println(io)
+                    sig = sig.body
+                end
+            end
+        end
         if src.slotnames !== nothing
             slotnames = Base.sourceinfo_slotnames(src)
             lambda_io = IOContext(lambda_io, :SOURCE_SLOTNAMES => slotnames)
-            println(io, "Variables")
             slottypes = src.slottypes
+            nargs > 0 && println(io, "Arguments")
             for i = 1:length(slotnames)
+                if i == nargs + 1
+                    println(io, "Locals")
+                end
                 print(io, "  ", slotnames[i])
                 if isa(slottypes, Vector{Any})
                     warntype_type_printer(io, slottypes[i], true)
                 end
                 println(io)
             end
-            println(io)
         end
         print(io, "Body")
         warntype_type_printer(io, rettype, true)
         println(io)
-        # TODO: static parameter values
         Base.IRShow.show_ir(lambda_io, src, lineprinter(src), warntype_type_printer)
+        println(io)
     end
     nothing
 end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -106,6 +106,7 @@ end # module ImportIntrinsics15819
 foo11122(x) = @fastmath x - 1.0
 
 # issue #11122, #13568 and #15819
+tag = "ANY"
 @test !warntype_hastag(+, Tuple{Int,Int}, tag)
 @test !warntype_hastag(-, Tuple{Int,Int}, tag)
 @test !warntype_hastag(*, Tuple{Int,Int}, tag)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1358,10 +1358,11 @@ julia> typeof(f(2))
 Int64
 
 julia> @code_warntype f(2)
-Variables
+MethodInstance for f(::Int64)
+  from f(a) in Main at none:1
+Arguments
   #self#::Core.Const(f)
   a::Int64
-
 Body::UNION{FLOAT64, INT64}
 1 ─ %1 = (a > 1)::Bool
 └──      goto #3 if not %1


### PR DESCRIPTION
Show the method it came from and the static-parameter values for it and adds a bit of additional formatting

Closes #31227

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/330950/106059807-393a2a80-60c1-11eb-9615-25edae5d3cd4.png">

<img width="956" alt="image" src="https://user-images.githubusercontent.com/330950/106059766-2c1d3b80-60c1-11eb-8285-7509957deb1b.png">
