### PR TITLE
Float16 exp2, exp, exp10

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1177,9 +1177,14 @@ muladd(x,y,z) = x*y+z
 # Float16 definitions
 
 for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
-             :atanh,:exp,:exp2,:exp10,:log,:log2,:log10,:sqrt,:lgamma,:log1p)
+             :atanh,:log,:log2,:log10,:sqrt,:lgamma,:log1p)
     @eval begin
         $func(a::Float16) = Float16($func(Float32(a)))
+        $func(a::ComplexF16) = ComplexF16($func(ComplexF32(a)))
+    end
+end
+for func in (:exp,:exp2,:exp10)
+    @eval begin
         $func(a::ComplexF16) = ComplexF16($func(ComplexF32(a)))
     end
 end

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -244,6 +244,21 @@ for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
             twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
             return twopk*small_part
         end
+        
+        function ($func)(a::Float16)
+            T = Float32
+            x = T(a)
+            N_float = round(x*LogBINV($base, T))
+            N = unsafe_trunc(Int32, N_float)
+            r = muladd(N_float, LogBU($base, T), x)
+            small_part = expb_kernel($base, r)
+            if !(abs(x) <= SUBNORM_EXP($base, T))
+                x > MAX_EXP($base, T) && return Inf16
+                N<=Int32(-24) && return zero(Float16)
+            end
+            twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
+            return Float16(twopk*small_part)
+        end
     end
 end
 @doc """

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -62,7 +62,6 @@ LogBL(::Val{2}, ::Type{Float32}) = 0.0f0
 LogBL(::Val{:ℯ}, ::Type{Float32}) = -1.4286068f-6
 LogBL(::Val{10}, ::Type{Float32}) = -4.605039f-6
 
-
 # -log(base, 2) as a Float32 for Float16 version.
 LogB(::Val{2}, ::Type{Float16}) = -1.0f0
 LogB(::Val{:ℯ}, ::Type{Float16}) = -0.6931472f0
@@ -250,7 +249,7 @@ for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
             twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
             return twopk*small_part
         end
-        
+
         function ($func)(a::Float16)
             T = Float32
             x = T(a)

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -62,6 +62,12 @@ LogBL(::Val{2}, ::Type{Float32}) = 0.0f0
 LogBL(::Val{:ℯ}, ::Type{Float32}) = -1.4286068f-6
 LogBL(::Val{10}, ::Type{Float32}) = -4.605039f-6
 
+
+# -log(base, 2) as a Float32 for Float16 version.
+LogB(::Val{2}, ::Type{Float16}) = -1.0f0
+LogB(::Val{:ℯ}, ::Type{Float16}) = -0.6931472f0
+LogB(::Val{10}, ::Type{Float16}) = -0.30103f0
+
 # Range reduced kernels
 @inline function expm1b_kernel(::Val{2}, x::Float64)
     return x * evalpoly(x, (0.6931471805599393, 0.24022650695910058,
@@ -250,7 +256,7 @@ for (func, base) in (:exp2=>Val(2), :exp=>Val(:ℯ), :exp10=>Val(10))
             x = T(a)
             N_float = round(x*LogBINV($base, T))
             N = unsafe_trunc(Int32, N_float)
-            r = muladd(N_float, LogBU($base, T), x)
+            r = muladd(N_float, LogB($base, Float16), x)
             small_part = expb_kernel($base, r)
             if !(abs(x) <= SUBNORM_EXP($base, T))
                 x > MAX_EXP($base, T) && return Inf16


### PR DESCRIPTION
This is about 2x faster than current exp varieties for Float16. Basically this just uses a version of the Float32 code, but with some of the checks removed. Surprisingly if we want to maintain .5 ULP accuracy, we have to compute in almost full Float32 precision because there are some outputs that are very close to the rounding line.

I have tested this on every `Float16` value (there aren't that many), and it produces the correctly rounded answer for all of them.