### PR TITLE
fix invalidations due to convert(Nothing, ::Any)

### DIFF
--- a/base/some.jl
+++ b/base/some.jl
@@ -34,6 +34,8 @@ end
 
 convert(::Type{T}, x::T) where {T>:Nothing} = x
 convert(::Type{T}, x) where {T>:Nothing} = convert(nonnothingtype_checked(T), x)
+convert(::Type{Nothing}, x) = throw(MethodError(convert, (Nothing, x)))
+convert(::Type{Nothing}, ::Nothing) = nothing
 convert(::Type{Some{T}}, x::Some{T}) where {T} = x
 convert(::Type{Some{T}}, x::Some) where {T} = Some{T}(convert(T, x.value))
 


### PR DESCRIPTION
Before this PR:
```julia
julia> using SnoopCompileCore

julia> struct A end

julia> @snoopr (::Type{<:A})(::AbstractVector) = 1
14-element Vector{Any}:
  MethodInstance for convert(::Type{Union{}}, ::AbstractArray)
 1
  MethodInstance for convert(::Type{Nothing}, ::Any)
 2
  MethodInstance for Union{}(::AbstractArray)
  "jl_method_table_insert"
  MethodInstance for Core.Compiler.convert(::Type{V} where V<:Core.Compiler.BitArray{1}, ::Vector{var"#s122"} where var"#s122"<:Union{Float32, Float64})
 1
  MethodInstance for Core.Compiler.convert(::Type{T}, ::Vector{var"#s122"} where var"#s122"<:Union{Float32, Float64}) where T<:(Vector{T} where T)
 1
  MethodInstance for Union{}(::Vector{var"#s122"} where var"#s122"<:Union{Float32, Float64})
  "jl_method_table_insert"
  (::Type{var"#s3"} where var"#s3"<:A)(::AbstractVector{T} where T) in Main at REPL[3]:1
  "jl_method_table_insert"
```

After:
```julia
julia> using SnoopCompileCore

julia> struct A end

julia> @snoopr (::Type{<:A})(::AbstractVector) = 1
Any[]
```

This was causing invalidations in StaticArrays.