### PR TITLE
fix some of StaticArrays invalidating Revise

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -530,6 +530,7 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 ## Conversions ##
 
 convert(::Type{T}, a::AbstractArray) where {T<:Array} = a isa T ? a : T(a)
+convert(::Type{Union{}}, a::AbstractArray) = throw(MethodError(convert, (Union{}, a)))
 
 promote_rule(a::Type{Array{T,n}}, b::Type{Array{S,n}}) where {T,n,S} = el_same(promote_type(T,S), a, b)
 

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -112,6 +112,9 @@ NamedTuple{names}(itr) where {names} = NamedTuple{names}(Tuple(itr))
 
 NamedTuple(itr) = (; itr...)
 
+# avoids invalidating Union{}(...)
+NamedTuple{names, Union{}}(itr::Tuple) where {names} = throw(MethodError(NamedTuple{names, Union{}}, (itr,)))
+
 end # if Base
 
 length(t::NamedTuple) = nfields(t)


### PR DESCRIPTION
with #39434:
```julia
julia> using Revise, SnoopCompileCore

julia> struct A end

julia> @snoopr (::Type{<:A})(::AbstractVector) = 1
18-element Vector{Any}:
  MethodInstance for JuliaInterpreter.namedtuple(::Vector{Any})
 1
  MethodInstance for JuliaInterpreter.prepare_args(::Any, ::Vector{Any}, ::Vector{Any})
 2
  MethodInstance for JuliaInterpreter.var"#determine_method_for_expr#44"(::Bool, ::typeof(JuliaInterpreter.determine_method_for_expr), ::Expr)
 3
  MethodInstance for (::JuliaInterpreter.var"#determine_method_for_expr##kw")(::NamedTuple{(:enter_generated,), Tuple{Bool}}, ::typeof(JuliaInterpreter.determine_method_for_expr), ::Expr)
 4
  MethodInstance for JuliaInterpreter.var"#enter_call_expr#45"(::Bool, ::typeof(JuliaInterpreter.enter_call_expr), ::Expr)
 5
  MethodInstance for JuliaInterpreter.enter_call_expr(::Expr)
 6
  MethodInstance for Union{}(::Vector{Any})
  "jl_method_table_insert"
  MethodInstance for Union{}(::Vector{Any})
  "invalidate_mt_cache"
  (::Type{var"#s24"} where var"#s24"<:A)(::AbstractVector{T} where T) in Main at REPL[3]:1
  "jl_method_table_insert"
```

with #39434 and this PR:
```julia
julia> using Revise, SnoopCompileCore

julia> struct A end

julia> @snoopr (::Type{<:A})(::AbstractVector) = 1
Any[]
```