### PR TITLE
inference: parameterize some of hard-coded inference logic

### DIFF
--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -212,3 +212,16 @@ may_compress(ni::NativeInterpreter) = true
 may_discard_trees(ni::NativeInterpreter) = true
 
 method_table(ai::AbstractInterpreter) = InternalMethodTable(get_world_counter(ai))
+
+# define inference bail out logic
+# `NativeInterpreter` bails out from inference when
+# - a lattice element grows up to `Any` (inter-procedural call, abstract apply)
+# - a lattice element gets down to `Bottom` (statement inference, local frame inference)
+# - inferring non-concrete toplevel call sites
+bail_out_call(interp::AbstractInterpreter, @nospecialize(t), sv)      = t === Any
+bail_out_apply(interp::AbstractInterpreter, @nospecialize(t), sv)     = t === Any
+bail_out_statement(interp::AbstractInterpreter, @nospecialize(t), sv) = t === Bottom
+bail_out_local(interp::AbstractInterpreter, @nospecialize(t), sv)     = t === Bottom
+function bail_out_toplevel_call(interp::AbstractInterpreter, @nospecialize(sig), sv)
+    return isa(sv.linfo.def, Module) && !isdispatchtuple(sig)
+end


### PR DESCRIPTION
This commit parameterizes some of hard-coded inference logic:
- to bail out from inference when a lattice element can't be refined or
  a current inference frame is proven to throw or to be dead
- to add call backedges when the call return type won't be refined

Those `AbstractInterpreter`s used for code optimization (including
`NativeInterpreter`) usually just want the methods defined for
`AbstractInterpreter`, but some other `AbstractInterpreter` may want
other implementations and heuristics to control inference process.
For example, [`JETInterpreter`](https://github.com/aviatesk/JET.jl) is
used for code analysis and wants to add call backedges even when a call
return type is `Any`.