### PR TITLE
float16 cbrt, 50% faster

### DIFF
--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -147,3 +147,20 @@ function cbrt(x::Union{Float32,Float64})
     t = _approx_cbrt(x)
     return _improve_cbrt(x, t)
 end
+
+function Base.cbrt(a::Float16)
+    if !isfinite(a) || iszero(a)
+        return a
+    end
+    x=Float32(a)
+    
+    # 5 bit approximation. Simpler than _approx_cbrt since subnormals can not appear
+    u = highword(x) & 0x7fff_ffff
+    v = div(u, UInt32(3)) + 0x2a5119f2
+    t = copysign(fromhighword(Float32, v), x)
+    
+    # 2 newton iterations
+    t = 0.33333334f0 * (2f0*t + x/(t*t))
+    t = 0.33333334f0 * (2f0*t + x/(t*t))
+    return Float16(t)
+end

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -148,7 +148,7 @@ function cbrt(x::Union{Float32,Float64})
     return _improve_cbrt(x, t)
 end
 
-function Base.cbrt(a::Float16)
+function cbrt(a::Float16)
     if !isfinite(a) || iszero(a)
         return a
     end

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -153,12 +153,12 @@ function cbrt(a::Float16)
         return a
     end
     x=Float32(a)
-    
+
     # 5 bit approximation. Simpler than _approx_cbrt since subnormals can not appear
     u = highword(x) & 0x7fff_ffff
     v = div(u, UInt32(3)) + 0x2a5119f2
     t = copysign(fromhighword(Float32, v), x)
-    
+
     # 2 newton iterations
     t = 0.33333334f0 * (2f0*t + x/(t*t))
     t = 0.33333334f0 * (2f0*t + x/(t*t))

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -152,7 +152,7 @@ function cbrt(a::Float16)
     if !isfinite(a) || iszero(a)
         return a
     end
-    x=Float32(a)
+    x = Float32(a)
 
     # 5 bit approximation. Simpler than _approx_cbrt since subnormals can not appear
     u = highword(x) & 0x7fff_ffff


### PR DESCRIPTION
.5 ULP error tested on all `Float16` 