### PR TITLE
More detailed StatStruct show

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -4,6 +4,22 @@
 
 module Filesystem
 
+const S_IFDIR  = 0o040000  # directory
+const S_IFCHR  = 0o020000  # character device
+const S_IFBLK  = 0o060000  # block device
+const S_IFREG  = 0o100000  # regular file
+const S_IFIFO  = 0o010000  # fifo (named pipe)
+const S_IFLNK  = 0o120000  # symbolic link
+const S_IFSOCK = 0o140000  # socket file
+const S_IFMT   = 0o170000
+
+const S_ISUID = 0o4000  # set UID bit
+const S_ISGID = 0o2000  # set GID bit
+const S_ENFMT = S_ISGID # file locking enforcement
+const S_ISVTX = 0o1000  # sticky bit
+const S_IRWXU = 0o0700  # mask for owner permissions
+const S_IRUSR = 0o0400  # read by owner
+
 const S_IRUSR = 0o400
 const S_IWUSR = 0o200
 const S_IXUSR = 0o100

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -402,6 +402,79 @@ Interface to the C `srand(seed)` function.
 """
 srand(seed=floor(Int, time()) % Cuint) = ccall(:srand, Cvoid, (Cuint,), seed)
 
+struct Cpasswd
+   username::Cstring
+   uid::Clong
+   gid::Clong
+   shell::Cstring
+   homedir::Cstring
+   gecos::Cstring
+   Cpasswd() = new(C_NULL, -1, -1, C_NULL, C_NULL, C_NULL)
+end
+mutable struct Cgroup
+    groupname::Cstring     # group name
+    gid::Clong        # group ID
+    mem::Ptr{Cstring} # group members
+    Cgroup() = new(C_NULL, -1, C_NULL)
+end
+struct Passwd
+    username::String
+    uid::Int
+    gid::Int
+    shell::String
+    homedir::String
+    gecos::String
+end
+struct Group
+    groupname::String
+    gid::Int
+    mem::Vector{String}
+end
+
+function getpwuid(uid::Unsigned, throw_error::Bool=true)
+    ref_pd = Ref(Cpasswd())
+    ret = ccall(:jl_os_get_passwd, Cint, (Ref{Cpasswd}, UInt), ref_pd, uid)
+    if ret != 0
+        throw_error && uv_error("getpwuid", ret)
+        return
+    end
+    pd = ref_pd[]
+    pd = Passwd(
+        pd.username == C_NULL ? "" : unsafe_string(pd.username),
+        pd.uid,
+        pd.gid,
+        pd.shell == C_NULL ? "" : unsafe_string(pd.shell),
+        pd.homedir == C_NULL ? "" : unsafe_string(pd.homedir),
+        pd.gecos == C_NULL ? "" : unsafe_string(pd.gecos),
+    )
+    ccall(:uv_os_free_passwd, Cvoid, (Ref{Cpasswd},), ref_pd)
+    return pd
+end
+function getgrgid(gid::Unsigned, throw_error::Bool=true)
+    ref_gp = Ref(Cgroup())
+    ret = ccall(:jl_os_get_group, Cint, (Ref{Cgroup}, UInt), ref_gp, gid)
+    if ret != 0
+        throw_error && uv_error("getgrgid", ret)
+        return
+    end
+    gp = ref_gp[]
+    members = String[]
+    if gp.mem != C_NULL
+        while true
+            mem = unsafe_load(gp.mem, length(members) + 1)
+            mem == C_NULL && break
+            push!(members, unsafe_string(mem))
+        end
+    end
+    gp = Group(
+         gp.groupname == C_NULL ? "" : unsafe_string(gp.groupname),
+         gp.gid,
+         members,
+    )
+    ccall(:jl_os_free_group, Cvoid, (Ref{Cgroup},), ref_gp)
+    return gp
+end
+
 # Include dlopen()/dlpath() code
 include("libdl.jl")
 using .Libdl

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -435,7 +435,7 @@ function getpwuid(uid::Unsigned, throw_error::Bool=true)
     ref_pd = Ref(Cpasswd())
     ret = ccall(:jl_os_get_passwd, Cint, (Ref{Cpasswd}, UInt), ref_pd, uid)
     if ret != 0
-        throw_error && uv_error("getpwuid", ret)
+        throw_error && Base.uv_error("getpwuid", ret)
         return
     end
     pd = ref_pd[]
@@ -454,7 +454,7 @@ function getgrgid(gid::Unsigned, throw_error::Bool=true)
     ref_gp = Ref(Cgroup())
     ret = ccall(:jl_os_get_group, Cint, (Ref{Cgroup}, UInt), ref_gp, gid)
     if ret != 0
-        throw_error && uv_error("getgrgid", ret)
+        throw_error && Base.uv_error("getgrgid", ret)
         return
     end
     gp = ref_gp[]

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -654,19 +654,20 @@ use it in the following manner to summarize information about a struct:
 julia> structinfo(T) = [(fieldoffset(T,i), fieldname(T,i), fieldtype(T,i)) for i = 1:fieldcount(T)];
 
 julia> structinfo(Base.Filesystem.StatStruct)
-12-element Vector{Tuple{UInt64, Symbol, DataType}}:
- (0x0000000000000000, :device, UInt64)
- (0x0000000000000008, :inode, UInt64)
- (0x0000000000000010, :mode, UInt64)
- (0x0000000000000018, :nlink, Int64)
- (0x0000000000000020, :uid, UInt64)
- (0x0000000000000028, :gid, UInt64)
- (0x0000000000000030, :rdev, UInt64)
- (0x0000000000000038, :size, Int64)
- (0x0000000000000040, :blksize, Int64)
- (0x0000000000000048, :blocks, Int64)
- (0x0000000000000050, :mtime, Float64)
- (0x0000000000000058, :ctime, Float64)
+13-element Vector{Tuple{UInt64, Symbol, Type}}:
+ (0x0000000000000000, :desc, Union{RawFD, String})
+ (0x0000000000000008, :device, UInt64)
+ (0x0000000000000010, :inode, UInt64)
+ (0x0000000000000018, :mode, UInt64)
+ (0x0000000000000020, :nlink, Int64)
+ (0x0000000000000028, :uid, UInt64)
+ (0x0000000000000030, :gid, UInt64)
+ (0x0000000000000038, :rdev, UInt64)
+ (0x0000000000000040, :size, Int64)
+ (0x0000000000000048, :blksize, Int64)
+ (0x0000000000000050, :blocks, Int64)
+ (0x0000000000000058, :mtime, Float64)
+ (0x0000000000000060, :ctime, Float64)
 ```
 """
 fieldoffset(x::DataType, idx::Integer) = (@_pure_meta; ccall(:jl_get_field_offset, Csize_t, (Any, Cint), x, idx))

--- a/src/sys.c
+++ b/src/sys.c
@@ -27,6 +27,7 @@
 #include <sys/ptrace.h>
 #include <sys/mman.h>
 #include <dlfcn.h>
+#include <grp.h>
 #endif
 
 #ifndef _OS_WINDOWS_
@@ -229,6 +230,232 @@ JL_DLLEXPORT double jl_stat_ctime(char *statbuf)
     uv_stat_t *s;
     s = (uv_stat_t*)statbuf;
     return (double)s->st_ctim.tv_sec + (double)s->st_ctim.tv_nsec * 1e-9;
+}
+
+JL_DLLEXPORT int jl_os_get_passwd(uv_passwd_t *pwd, size_t uid)
+{
+#ifdef _OS_WINDOWS_
+  return UV_ENOTSUP;
+#else
+  // taken directly from libuv
+  struct passwd pw;
+  struct passwd* result;
+  char* buf;
+  size_t bufsize;
+  size_t name_size;
+  size_t homedir_size;
+  size_t shell_size;
+  size_t gecos_size;
+  long initsize;
+  int r;
+
+  if (pwd == NULL)
+    return UV_EINVAL;
+
+  initsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+
+  if (initsize <= 0)
+    bufsize = 4096;
+  else
+    bufsize = (size_t) initsize;
+
+  buf = NULL;
+
+  for (;;) {
+    free(buf);
+    buf = (char*)malloc(bufsize);
+
+    if (buf == NULL)
+      return UV_ENOMEM;
+
+    r = getpwuid_r(uid, &pw, buf, bufsize, &result);
+
+    if (r != ERANGE)
+      break;
+
+    bufsize *= 2;
+  }
+
+  if (r != 0) {
+    free(buf);
+    return -r;
+  }
+
+  if (result == NULL) {
+    free(buf);
+    return UV_ENOENT;
+  }
+
+  /* Allocate memory for the username, gecos, shell, and home directory. */
+  name_size = strlen(pw.pw_name) + 1;
+  homedir_size = strlen(pw.pw_dir) + 1;
+  shell_size = strlen(pw.pw_shell) + 1;
+
+#ifdef __MVS__
+  gecos_size = 0; /* pw_gecos does not exist on zOS. */
+#else
+  if (pw.pw_gecos != NULL)
+    gecos_size = strlen(pw.pw_gecos) + 1;
+  else
+    gecos_size = 0;
+#endif
+
+  pwd->username = (char*)malloc(name_size +
+                         homedir_size +
+                         shell_size +
+                         gecos_size);
+
+  if (pwd->username == NULL) {
+    free(buf);
+    return UV_ENOMEM;
+  }
+
+  /* Copy the username */
+  memcpy(pwd->username, pw.pw_name, name_size);
+
+  /* Copy the home directory */
+  pwd->homedir = pwd->username + name_size;
+  memcpy(pwd->homedir, pw.pw_dir, homedir_size);
+
+  /* Copy the shell */
+  pwd->shell = pwd->homedir + homedir_size;
+  memcpy(pwd->shell, pw.pw_shell, shell_size);
+
+  /* Copy the gecos field */
+#ifdef __MVS__
+  pwd->gecos = NULL;  /* pw_gecos does not exist on zOS. */
+#else
+  if (pw.pw_gecos == NULL) {
+    pwd->gecos = NULL;
+  } else {
+    pwd->gecos = pwd->shell + shell_size;
+    memcpy(pwd->gecos, pw.pw_gecos, gecos_size);
+  }
+#endif
+
+  /* Copy the uid and gid */
+  pwd->uid = pw.pw_uid;
+  pwd->gid = pw.pw_gid;
+
+  free(buf);
+
+  return 0;
+#endif
+}
+
+typedef struct jl_group_s {
+    char* groupname;
+    long gid;
+    char** members;
+} jl_group_t;
+
+JL_DLLEXPORT int jl_os_get_group(jl_group_t *grp, size_t gid)
+{
+#ifdef _OS_WINDOWS_
+  return UV_ENOTSUP;
+#else
+  // modified directly from uv_os_get_password
+  struct group gp;
+  struct group* result;
+  char* buf;
+  char* gr_mem;
+  size_t bufsize;
+  size_t name_size;
+  long members;
+  size_t mem_size;
+  long initsize;
+  int r;
+
+  if (grp == NULL)
+    return UV_EINVAL;
+
+  initsize = sysconf(_SC_GETGR_R_SIZE_MAX);
+
+  if (initsize <= 0)
+    bufsize = 4096;
+  else
+    bufsize = (size_t) initsize;
+
+  buf = NULL;
+
+  for (;;) {
+    free(buf);
+    buf = (char*)malloc(bufsize);
+
+    if (buf == NULL)
+      return UV_ENOMEM;
+
+    r = getgrgid_r(gid, &gp, buf, bufsize, &result);
+
+    if (r != ERANGE)
+      break;
+
+    bufsize *= 2;
+  }
+
+  if (r != 0) {
+    free(buf);
+    return -r;
+  }
+
+  if (result == NULL) {
+    free(buf);
+    return UV_ENOENT;
+  }
+
+  /* Allocate memory for the groupname and members. */
+  name_size = strlen(gp.gr_name) + 1;
+  members = 0;
+  mem_size = sizeof(char*);
+  for (r = 0; gp.gr_mem[r] != NULL; r++) {
+    mem_size += strlen(gp.gr_mem[r]) + 1 + sizeof(char*);
+    members++;
+  }
+
+  grp->groupname = (char*)malloc(name_size + mem_size);
+
+  if (grp->groupname == NULL) {
+    free(buf);
+    return UV_ENOMEM;
+  }
+
+  /* Copy the groupname */
+  memcpy(grp->groupname, gp.gr_name, name_size);
+
+  /* Copy the gid */
+  grp->gid = gp.gr_gid;
+
+  /* Copy the members */
+  gr_mem = grp->groupname + name_size;
+  grp->members = (char**) gr_mem;
+  grp->members[members] = NULL;
+  gr_mem = (char*) ((char**) gr_mem + members + 1);
+  for (r = 0; r < members; r++) {
+    grp->members[r] = gr_mem;
+    gr_mem = stpcpy(gr_mem, gp.gr_mem[r]);
+  }
+
+  assert(gr_mem == buf + name_size + mem_size);
+
+  free(buf);
+
+  return 0;
+#endif
+}
+
+JL_DLLEXPORT void jl_os_free_group(jl_group_t *grp)
+{
+  if (grp == NULL)
+    return;
+
+  /*
+    The memory for is allocated in a single uv__malloc() call. The base of the
+    pointer is stored in grp->groupname, so that is the only field that needs
+    to be freed.
+  */
+  free(grp->groupname);
+  grp->groupname = NULL;
+  grp->members = NULL;
 }
 
 // --- buffer manipulation ---


### PR DESCRIPTION
Perhaps the show for StatStruct could display more than it currently does?

Currently
```
julia> f, io = mktemp();

julia> stat(f)
StatStruct(mode=0o100600, size=0)
```

This PR
```
julia> f, io = mktemp();

julia> stat(f)
StatStruct
   size: 0
 device: 16777220
  inode: 108982358
   mode: 0o100600
  nlink: 1
    uid: 501
    gid: 20
   rdev: 0
blksize: 4096
 blocks: 0
  mtime: 1.612067396520361e9
  ctime: 1.612067396520361e9
```

Edit: latest version

```
julia> stat(f)
/var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_pOnU8k size: 0 bytes device: 16777225 inode: 114151349 mode: 0o100600 (-rw-------) nlink: 1 uid: 501 (ian) gid: 20 (staff) rdev: 0 blksize: 4096 blocks: 0 mtime: 2021-02-12T00:21:05-0500 (2 minutes ago) ctime: 2021-02-12T00:21:05-0500 (2 minutes ago)

julia> Base.active_repl.options.iocontext[:compact] = false;

julia> stat(f)
StatStruct for /var/folders/_6/1yf6sj0950vcg4t91m9ltb5w0000gn/T/jl_pOnU8k
   size: 0 bytes
 device: 16777225
  inode: 114151349
   mode: 0o100600 (-rw-------)
  nlink: 1
    uid: 501 (ian)
    gid: 20 (staff)
   rdev: 0
blksize: 4096
 blocks: 0
  mtime: 2021-02-12T00:21:05-0500 (2 minutes ago)
  ctime: 2021-02-12T00:21:05-0500 (2 minutes ago)
```