### PR TITLE
Fix inference of `Argument`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1138,7 +1138,7 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
         return Const((e::QuoteNode).value)
     elseif isa(e, SSAValue)
         return abstract_eval_ssavalue(e::SSAValue, sv.src)
-    elseif isa(e, Slot)
+    elseif isa(e, Slot) || isa(e, Argument)
         return (vtypes[slot_id(e)]::VarState).typ
     elseif isa(e, GlobalRef)
         return abstract_eval_global(e.mod, e.name)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3021,3 +3021,7 @@ function splat_lotta_unions()
     (a...,b...,c...)
 end
 @test Core.Compiler.return_type(splat_lotta_unions, Tuple{}) >: Tuple{Int,Int,Int}
+
+# Bare Core.Argument in IR
+@eval f_bare_argument(x) = $(Core.Argument(2))
+@test Base.return_types(f_bare_argument, (Int,))[1] == Int


### PR DESCRIPTION
I was pretty sure I had made this commit already, but I guess
it never made it onto master. Regardless, in d6d5208, we switched
Argument to be a legal value in CodeInfo and gave it semantics
equivalent to `Slot`. This is useful to avoid back-and-forth
conversion. However, we missed one place in inference which
assumed that literal arguments would just end up as Consts,
which is of course wrong - causing crashes. Now usually we
don't end up with literal `Argument`s in CodeInfos, since
the frontend doesn't produce them, but they can come
in when trying to generate SSA code in an external
package and then converting back to `CodeInfo` (which
after the above commit no longer turns the `Argument`s
into Slots).