### PR TITLE
Allow edit to select method based on index; print available methods in edit error message

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -176,7 +176,7 @@ function functionloc(@nospecialize(f))
         end
     end
     if length(mt) > 1
-        error("function has multiple methods; please specify a type signature")
+        error("function has multiple methods; please specify a type signature:\n" * string(mt))
     end
     return functionloc(first(mt))
 end

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -208,11 +208,12 @@ end
 
 """
     edit(function, [types])
+    edit(function, [index])
     edit(module)
 
-Edit the definition of a function, optionally specifying a tuple of types to indicate which
-method to edit. For modules, open the main source file. The module needs to be loaded with
-`using` or `import` first.
+Edit the definition of a function, optionally specifying a tuple of types, or method
+index, to indicate which method to edit. For modules, open the main source file.
+The module needs to be loaded with `using` or `import` first.
 
 !!! compat "Julia 1.1"
     `edit` on modules requires at least Julia 1.1.
@@ -222,6 +223,7 @@ To ensure that the file can be opened at the given line, you may need to call
 """
 edit(f)                   = edit(functionloc(f)...)
 edit(f, @nospecialize t)  = edit(functionloc(f,t)...)
+edit(f::Function, index::Integer)  = edit(methods(f).ms[index])
 edit(file, line::Integer) = error("could not find source file for function")
 edit(m::Module) = edit(pathof(m))
 


### PR DESCRIPTION
From #39476. cc @timholy 

This PR adds the following:

1. A new function signature `edit(f::Function, method_idx::Integer)` that takes an array index for `methods(foo).ms` as input.
2. When a user calls `edit(f)`, and the function has >1 signatures, print out `methods(foo).ms` to the console, in addition to the normal `ERROR: function has multiple methods`.

I think this gives a much quicker experience when trying to edit functions that have many signatures, making Revise.jl even smoother.

Here's an example workflow. Say I want to edit a method of function `foo`:

```julia
julia> edit(foo)
ERROR: Function has multiple methods; please specify a type signature:
# 2 methods for generic function "foo":
[1] foo(lt1::LongTypeName1, lt2::LongTypeName2; lt3::LongTypeName3) in Main at REPL[5]:1
[2] foo() in Main at REPL[4]:1
...
julia> edit(foo, 1)
```
Editor then opens method `foo(lt1::LongTypeName1, lt2::LongTypeName2; lt3::LongTypeName3)`, instead of needing to write out manually `edit(methods(foo).ms[1])` or try to write out all the types. And `edit(foo)` printing the methods is nice, since then I don't need to print `methods(foo).ms` myself to check the signatures.

The new error message for ambiguous `edit` on the function `less` looks like this:

```julia
julia> edit(less)
ERROR: function has multiple methods; please specify a type signature:
# 5 methods for generic function "less":
[1] less(file::AbstractString) in InteractiveUtils at /Applications/Julia-1.5.app/Contents/Resources/julia/share/julia/stdlib/v1.5/InteractiveUtils/src/editless.jl:255
[2] less(file::AbstractString, line::Integer) in InteractiveUtils at /Applications/Julia-1.5.app/Contents/Resources/julia/share/julia/stdlib/v1.5/InteractiveUtils/src/editless.jl:242
[3] less(f) in InteractiveUtils at /Applications/Julia-1.5.app/Contents/Resources/julia/share/julia/stdlib/v1.5/InteractiveUtils/src/editless.jl:263
[4] less(file, line::Integer) in InteractiveUtils at /Applications/Julia-1.5.app/Contents/Resources/julia/share/julia/stdlib/v1.5/InteractiveUtils/src/editless.jl:265
[5] less(f, t) in InteractiveUtils at /Applications/Julia-1.5.app/Contents/Resources/julia/share/julia/stdlib/v1.5/InteractiveUtils/src/editless.jl:264
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at REPL[20]:1
```
Then one can choose a method from this list, with, e.g., `edit(less, 2)`, instead of having to: 1) print out all the methods with `methods(less)`, and 2) write out the tuple types or write `edit(methods(less).ms[2])`.