### PR TITLE
Run jl_resolve_globals_in_ir on the result of generated functions

### DIFF
--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -153,3 +153,30 @@ mk_va_opaque() = @opaque (x...)->x
 
 # OpaqueClosure show method
 @test repr(@opaque x->1) == "(::Any)::Any->◌"
+
+# Opaque closure in CodeInfo returned from generated functions
+function mk_ocg(args...)
+    ci = @code_lowered const_int()
+    cig = Meta.lower(@__MODULE__, Expr(:new_opaque_closure, Tuple{}, false, Any, Any,
+        Expr(:opaque_closure_method, 0, lno, ci))).args[1]
+    cig.slotnames = Symbol[Symbol("#self#")]
+    cig.slottypes = Any[Any]
+    cig.slotflags = UInt8[0x00]
+    cig
+end
+
+@eval function oc_trivial_generated()
+    $(Expr(:meta, :generated_only))
+    $(Expr(:meta,
+            :generated,
+            Expr(:new,
+                Core.GeneratedFunctionStub,
+                :mk_ocg,
+                Any[:oc_trivial_generated],
+                Any[],
+                @__LINE__,
+                QuoteNode(Symbol(@__FILE__)),
+                true)))
+end
+@test isa(oc_trivial_generated(), Core.OpaqueClosure{Tuple{}, Any})
+@test oc_trivial_generated()() == 1


### PR DESCRIPTION
We didn't use to run this when the generated function returned
a CodeInfo (though we did run it for AST). However, now that
this also does the conversion of :opaque_closure_method to
actual Method objects, I think the best thing to do would
be to run it here to avoid the generated function having
to construct its own Method object from scratch.