### PR TITLE
Make overriding closure methods an error

### DIFF
--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -81,19 +81,15 @@ _bound_vararg_specificity_1(::Type{Array{T,1}}, d::Int) where {T} = 1
 @test args_morespecific(Tuple{Matrix}, Tuple{AbstractVector})
 
 # Method specificity
-begin
-    local f, A
-    f(dims::Tuple{}, A::AbstractArray{T,0}) where {T} = 1
-    f(dims::NTuple{N,Int}, A::AbstractArray{T,N}) where {T,N} = 2
-    f(dims::NTuple{M,Int}, A::AbstractArray{T,N}) where {T,M,N} = 3
-    A = zeros(2,2)
-    @test f((1,2,3), A) == 3
-    @test f((1,2), A) == 2
-    @test f((), reshape([1])) == 1
-    f(dims::NTuple{N,Int}, A::AbstractArray{T,N}) where {T,N} = 4
-    @test f((1,2), A) == 4
-    @test f((1,2,3), A) == 3
-end
+f22162(dims::Tuple{}, A::AbstractArray{T,0}) where {T} = 1
+f22162(dims::NTuple{N,Int}, A::AbstractArray{T,N}) where {T,N} = 2
+f22162(dims::NTuple{M,Int}, A::AbstractArray{T,N}) where {T,M,N} = 3
+@test f22162((1,2,3), zeros(2,2)) == 3
+@test f22162((1,2), zeros(2,2)) == 2
+@test f22162((), reshape([1])) == 1
+f22162(dims::NTuple{N,Int}, A::AbstractArray{T,N}) where {T,N} = 4
+@test f22162((1,2), zeros(2,2)) == 4
+@test f22162((1,2,3), zeros(2,2)) == 3
 
 # a method specificity issue
 c99991(::Type{T},x::T) where {T} = 0

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -607,9 +607,9 @@ f38837(xs) = map((F,x)->F(x), (Float32, Float64), xs)
     @test @inferred(f(Tuple(1:10))) === Tuple(3:8)
     @test @inferred(f((true, 2., 3, 4f0, 0x05, 6, 7.))) === (3, 4f0, 0x05)
 
-    f(t) = t[Base.OneTo(5)]
-    @test @inferred(f(Tuple(1:10))) === Tuple(1:5)
-    @test @inferred(f((true, 2., 3, 4f0, 0x05, 6, 7.))) === (true, 2., 3, 4f0, 0x05)
+    g(t) = t[Base.OneTo(5)]
+    @test @inferred(g(Tuple(1:10))) === Tuple(1:5)
+    @test @inferred(g((true, 2., 3, 4f0, 0x05, 6, 7.))) === (true, 2., 3, 4f0, 0x05)
 
     @test @inferred((t -> t[1:end])(Tuple(1:15))) === Tuple(1:15)
     @test @inferred((t -> t[2:end])(Tuple(1:15))) === Tuple(2:15)


### PR DESCRIPTION
Overriding closure methods is a strong sign that the programmer is
confused about the lexical scoping rules for closure methods. (That is,
they expect them to behave like generic functions in top level code).
Make this an error so that people can't get caught out by this.

Helps with #15602.  May close it, though we may also want detection in lowering as a more complete solution?

After changing this there were two failing tests so this is likely to be slightly breaking for some user code as well. In particular, `@testset` puts code inside a `let` block (#33864) so functions declared inside `@testset` become closures.

Nevertheless, Julia 1.6 will make this a warning due to the changes in #36609 so people will have some time to adjust.