### PR TITLE
Add compat note for `reinterpret(reshape, T, A)`

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -90,6 +90,9 @@ If `sizeof(T) = n*sizeof(S)` for `n>1`, `A`'s first dimension must be
 of size `n` and `B` lacks `A`'s first dimension. Conversely, if `sizeof(S) = n*sizeof(T)` for `n>1`,
 `B` gets a new first dimension of size `n`. The dimensionality is unchanged if `sizeof(T) == sizeof(S)`.
 
+!!! compat "Julia 1.6"
+    This method requires at least Julia 1.6.
+
 # Examples
 
 ```jldoctest


### PR DESCRIPTION
The method with `reshape` as first argument was added for Julia 1.6, this PR adds the usual note to the docstring. This should be backported.