### PR TITLE
fix some invalidations with ChainRulesCore

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1068,7 +1068,7 @@ function show_mi(io::IO, l::Core.MethodInstance, from_stackframe::Bool=false)
         # to print a little more identifying information.
         if !from_stackframe
             linetable = l.uninferred.linetable
-            line = isempty(linetable) ? "unknown" : (lt = linetable[1]::Union{LineNumberNode,Core.LineInfoNode}; string(lt.file) * ':' * string(lt.line))
+            line = isempty(linetable) ? "unknown" : (lt = linetable[1]::Union{LineNumberNode,Core.LineInfoNode}; string(lt.file, ':', lt.line))
             print(io, " from ", def, " starting at ", line)
         end
     end
@@ -1092,7 +1092,7 @@ function show(io::IO, mi_info::Core.Compiler.Timings.InferenceFrameInfo)
         end
     else
         linetable = mi.uninferred.linetable
-        line = isempty(linetable) ? "" : (lt = linetable[1]; string(lt.file) * ':' * string(lt.line))
+        line = isempty(linetable) ? "" : (lt = linetable[1]; string(lt.file, ':', lt.line))
         print(io, "Toplevel InferenceFrameInfo thunk from ", def, " starting at ", line)
     end
 end

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -60,13 +60,13 @@ end
 function default_metafmt(level::LogLevel, _module, group, id, file, line)
     @nospecialize
     color = default_logcolor(level)
-    prefix = (level == Warn ? "Warning" : string(level))*':'
-    suffix = ""
+    prefix = string(level == Warn ? "Warning" : string(level), ':')
+    suffix::String = ""
     Info <= level < Warn && return color, prefix, suffix
     _module !== nothing && (suffix *= "$(_module)")
     if file !== nothing
         _module !== nothing && (suffix *= " ")
-        suffix *= Base.contractuser(file)
+        suffix *= Base.contractuser(file)::String
         if line !== nothing
             suffix *= ":$(isa(line, UnitRange) ? "$(first(line))-$(last(line))" : line)"
         end


### PR DESCRIPTION
on current master:
```julia
julia> using SnoopCompileCore

julia> i = @snoopr using ChainRulesCore;

julia> using SnoopCompile

julia> t = invalidation_trees(i)
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting convert(::Type{var"#s4"} where var"#s4"<:Tuple, comp::Composite{var"#s3", var"#s2"} where {var"#s3", var"#s2"<:Tuple}) in ChainRulesCore at /home/simeon/.julia/packages/ChainRulesCore/eBwSt/src/differentials/composite.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Tuple{DataType, DataType, DataType}}, Any} triggered MethodInstance for Pair{DataType, Tuple{DataType, DataType, DataType}}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{NTuple{8, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{8, DataType}}(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{NTuple{7, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{7, DataType}}(::Any, ::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Tuple{Symbol, Any, Symbol, Symbol}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Symbol, Any, Symbol, Symbol}}, ::Any, ::Int64) (0 children)
                 5: signature Tuple{typeof(convert), Type{Tuple{Any, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Any, String}}, ::Any, ::Int64) (0 children)

 inserting *(s, comp::Composite) in ChainRulesCore at /home/simeon/.julia/packages/ChainRulesCore/eBwSt/src/differential_arithmetic.jl:138 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Union{Regex, String}, Any} triggered MethodInstance for *(::Any, ::Char, ::Any) (0 children)

 inserting convert(::Type{var"#s4"} where var"#s4"<:Dict, comp::Composite{var"#s3", var"#s2"} where {var"#s3"<:Dict, var"#s2"<:Dict}) in ChainRulesCore at /home/simeon/.julia/packages/ChainRulesCore/eBwSt/src/differentials/composite.jl:69 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (0 children)
                 2: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                 3: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (18 children)

 inserting *(::One, b) in ChainRulesCore at /home/simeon/.julia/packages/ChainRulesCore/eBwSt/src/differential_arithmetic.jl:98 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Any, String} triggered MethodInstance for Pkg.REPLMode.promptf() (0 children)
                 2: signature Tuple{typeof(*), Any, String} triggered MethodInstance for Pkg.API.var"#precompile#215"(::Bool, ::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.precompile), ::Pkg.Types.Context) (15 children)
                 3: signature Tuple{typeof(*), Any, Char} triggered MethodInstance for *(::Any, ::Char, ::Any) (16 children)
```
With this PR + JuliaLang/Pkg.jl#2376:
```julia
julia> using SnoopCompileCore

julia> i = @snoopr using ChainRulesCore;

julia> using SnoopCompile

julia> t = invalidation_trees(i)
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting convert(::Type{var"#s4"} where var"#s4"<:Tuple, comp::Composite{var"#s3", var"#s2"} where {var"#s3", var"#s2"<:Tuple}) in ChainRulesCore at /home/simeon/.julia/packages/ChainRulesCore/eBwSt/src/differentials/composite.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Tuple{DataType, DataType, DataType}}, Any} triggered MethodInstance for Pair{DataType, Tuple{DataType, DataType, DataType}}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{NTuple{8, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{8, DataType}}(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{NTuple{7, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{7, DataType}}(::Any, ::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Tuple{Symbol, Any, Symbol, Symbol}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Symbol, Any, Symbol, Symbol}}, ::Any, ::Int64) (0 children)
                 5: signature Tuple{typeof(convert), Type{Tuple{Any, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Any, String}}, ::Any, ::Int64) (0 children)

 inserting convert(::Type{var"#s4"} where var"#s4"<:Dict, comp::Composite{var"#s3", var"#s2"} where {var"#s3"<:Dict, var"#s2"<:Dict}) in ChainRulesCore at /home/simeon/.julia/packages/ChainRulesCore/eBwSt/src/differentials/composite.jl:69 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (0 children)
                 2: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                 3: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (18 children)
   11 mt_cache
```