### PR TITLE
[JLLs] Use `dirname(product_path)` to properly deal with Windows

### DIFF
--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -48,9 +48,6 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libgcc_s_handle = dlopen(libgcc_s)
     global libgcc_s_path = dlpath(libgcc_s_handle)
     global libgfortran_handle = dlopen(libgfortran)
@@ -59,6 +56,9 @@ function __init__()
     global libstdcxx_path = dlpath(libstdcxx_handle)
     global libgomp_handle = dlopen(libgomp)
     global libgomp_path = dlpath(libgomp_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libgcc_s_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/GMP_jll/src/GMP_jll.jl
+++ b/stdlib/GMP_jll/src/GMP_jll.jl
@@ -31,13 +31,13 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libgmp_handle = dlopen(libgmp)
     global libgmp_path = dlpath(libgmp_handle)
     global libgmpxx_handle = dlopen(libgmpxx)
     global libgmpxx_path = dlpath(libgmpxx_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libgmp_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -27,11 +27,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libcurl_handle = dlopen(libcurl)
     global libcurl_path = dlpath(libcurl_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libcurl_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/LibGit2_jll/src/LibGit2_jll.jl
+++ b/stdlib/LibGit2_jll/src/LibGit2_jll.jl
@@ -27,11 +27,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libgit2_handle = dlopen(libgit2)
     global libgit2_path = dlpath(libgit2_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libgit2_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/LibOSXUnwind_jll/src/LibOSXUnwind_jll.jl
+++ b/stdlib/LibOSXUnwind_jll/src/LibOSXUnwind_jll.jl
@@ -21,13 +21,13 @@ libosxunwind_path = ""
 const libosxunwind = "@rpath/libosxunwind.dylib"
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     # We only dlopen something on MacOS
     @static if Sys.isapple()
         global libosxunwind_handle = dlopen(libosxunwind)
         global libosxunwind_path = dlpath(libosxunwind_handle)
+        global artifact_dir = dirname(Sys.BINDIR)
+        global LIBPATH[] = dirname(libosxunwind_path)
+        push!(LIBPATH_list, LIBPATH[])
     end
 end
 

--- a/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
+++ b/stdlib/LibSSH2_jll/src/LibSSH2_jll.jl
@@ -27,11 +27,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libssh2_handle = dlopen(libssh2)
     global libssh2_path = dlpath(libssh2_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libssh2_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 

--- a/stdlib/LibUV_jll/src/LibUV_jll.jl
+++ b/stdlib/LibUV_jll/src/LibUV_jll.jl
@@ -27,11 +27,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libuv_handle = dlopen(libuv)
     global libuv_path = dlpath(libuv_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libuv_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
+++ b/stdlib/LibUnwind_jll/src/LibUnwind_jll.jl
@@ -21,13 +21,13 @@ libunwind_path = ""
 const libunwind = "libunwind.so.8"
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     # We only do something on Linux/FreeBSD
     @static if Sys.islinux() || Sys.isfreebsd()
         global libunwind_handle = dlopen(libunwind)
         global libunwind_path = dlpath(libunwind_handle)
+        global artifact_dir = dirname(Sys.BINDIR)
+        global LIBPATH[] = dirname(libunwind_path)
+        push!(LIBPATH_list, LIBPATH[])
     end
 end
 

--- a/stdlib/MPFR_jll/src/MPFR_jll.jl
+++ b/stdlib/MPFR_jll/src/MPFR_jll.jl
@@ -26,11 +26,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libmpfr_handle = dlopen(libmpfr)
     global libmpfr_path = dlpath(libmpfr_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libmpfr_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
+++ b/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
@@ -37,15 +37,15 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libmbedcrypto_handle = dlopen(libmbedcrypto)
     global libmbedcrypto_path = dlpath(libmbedcrypto_handle)
     global libmbedtls_handle = dlopen(libmbedtls)
     global libmbedtls_path = dlpath(libmbedtls_handle)
     global libmbedx509_handle = dlopen(libmbedx509)
     global libmbedx509_path = dlpath(libmbedx509_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libmbedtls_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/MozillaCACerts_jll/src/MozillaCACerts_jll.jl
+++ b/stdlib/MozillaCACerts_jll/src/MozillaCACerts_jll.jl
@@ -17,8 +17,6 @@ cacert = ""
 
 function __init__()
 	global artifact_dir = dirname(Sys.BINDIR)
-	global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
 	global cacert = normpath(Sys.BINDIR::String, Base.DATAROOTDIR, "julia", "cert.pem")
 end
 

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -32,11 +32,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libopenblas_handle = dlopen(libopenblas)
     global libopenblas_path = dlpath(libopenblas_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libopenblas_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
+++ b/stdlib/OpenLibm_jll/src/OpenLibm_jll.jl
@@ -26,11 +26,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libopenlibm_handle = dlopen(libopenlibm)
     global libopenlibm_path = dlpath(libopenlibm_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libopenlibm_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/PCRE2_jll/src/PCRE2_jll.jl
+++ b/stdlib/PCRE2_jll/src/PCRE2_jll.jl
@@ -26,11 +26,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libpcre2_8_handle = dlopen(libpcre2_8)
     global libpcre2_8_path = dlpath(libpcre2_8_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libpcre2_8_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
+++ b/stdlib/SuiteSparse_jll/src/SuiteSparse_jll.jl
@@ -87,9 +87,6 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libamd_handle = dlopen(libamd)
     global libamd_path = dlpath(libamd_handle)
     global libbtf_handle = dlopen(libbtf)
@@ -116,6 +113,9 @@ function __init__()
     global libsuitesparseconfig_path = dlpath(libsuitesparseconfig_handle)
     global libumfpack_handle = dlopen(libumfpack)
     global libumfpack_path = dlpath(libumfpack_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libsuitesparse_wrapper_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/Zlib_jll/src/Zlib_jll.jl
+++ b/stdlib/Zlib_jll/src/Zlib_jll.jl
@@ -26,11 +26,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libz_handle = dlopen(libz)
     global libz_path = dlpath(libz_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libz_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/dSFMT_jll/src/dSFMT_jll.jl
+++ b/stdlib/dSFMT_jll/src/dSFMT_jll.jl
@@ -27,11 +27,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libdSFMT_handle = dlopen(libdSFMT)
     global libdSFMT_path = dlpath(libdSFMT_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libdSFMT_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
@@ -27,13 +27,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libLLVM_handle = dlopen(libLLVM)
     global libLLVM_path = dlpath(libLLVM_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libLLVM_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
@@ -26,11 +26,11 @@ else
 end
 
 function __init__()
-    global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     global libnghttp2_handle = dlopen(libnghttp2)
     global libnghttp2_path = dlpath(libnghttp2_handle)
+    global artifact_dir = dirname(Sys.BINDIR)
+    global LIBPATH[] = dirname(libnghttp2_path)
+    push!(LIBPATH_list, LIBPATH[])
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.

--- a/stdlib/p7zip_jll/src/p7zip_jll.jl
+++ b/stdlib/p7zip_jll/src/p7zip_jll.jl
@@ -82,8 +82,6 @@ end
 
 function __init__()
     global artifact_dir = dirname(Sys.BINDIR)
-    global LIBPATH[] = joinpath(Sys.BINDIR, Base.LIBDIR, "julia")
-    push!(LIBPATH_list, LIBPATH[])
     init_p7zip_path()
     global PATH[] = dirname(p7zip_path)
     push!(PATH_list, PATH[])


### PR DESCRIPTION
These paths weren't getting set quite right on Windows, since it stores
its libraries in `bin`