### PR TITLE
Add `PartialOpaque` lattice element for OpaqueClosure

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -424,6 +424,7 @@ eval(Core, :(CodeInstance(mi::MethodInstance, @nospecialize(rettype), @nospecial
                     mi, rettype, inferred_const, inferred, const_flags, min_world, max_world)))
 eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))))
 eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))))
+eval(Core, :(PartialOpaque(@nospecialize(typ), @nospecialize(env), isva::Bool, parent::MethodInstance, source::Method) = $(Expr(:new, :PartialOpaque, :typ, :env, :isva, :parent, :source))))
 eval(Core, :(MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) =
     $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))))
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -689,7 +689,7 @@ end
 function abstract_apply(interp::AbstractInterpreter, @nospecialize(itft), @nospecialize(aft), aargtypes::Vector{Any}, sv::InferenceState,
                         max_methods::Int = InferenceParams(interp).MAX_METHODS)
     aftw = widenconst(aft)
-    if !isa(aft, Const) && (!isType(aftw) || has_free_typevars(aftw))
+    if !isa(aft, Const) && !isa(aft, PartialOpaque) && (!isType(aftw) || has_free_typevars(aftw))
         if !isconcretetype(aftw) || (aftw <: Builtin)
             add_remark!(interp, sv, "Core._apply_iterate called on a function of a non-concrete type")
             # bail now, since it seems unlikely that abstract_call will be able to do any better after splitting
@@ -1096,7 +1096,7 @@ function abstract_call(interp::AbstractInterpreter, fargs::Union{Nothing,Vector{
         f = ft.instance
     elseif isa(ft, PartialOpaque)
         return abstract_call_opaque_closure(interp, ft, argtypes, sv)
-    elseif isa(ft, DataType) && unwrap_unionall(ft).name === typename(Core.OpaqueClosure)
+    elseif isa(unwrap_unionall(ft), DataType) && unwrap_unionall(ft).name === typename(Core.OpaqueClosure)
         return CallMeta(rewrap_unionall(unwrap_unionall(ft).parameters[2], ft), false)
     else
         # non-constant function, but the number of arguments is known

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1066,21 +1066,10 @@ function most_general_argtypes(closure::PartialOpaque)
     ret = Any[]
     cc = widenconst(closure)
     argt = unwrap_unionall(cc).parameters[1]
-    @assert isa(argt, DataType) && argt.name === typename(Tuple)
-    params = argt.parameters
-    for i = 2:closure.source.nargs
-        rt = unwrapva(params[max(i-1, length(params))])
-        if closure.isva
-            if length(params) > i-1
-                for j = (i):length(params)
-                    rt = tmerge(rt, unwrapva(params[j]))
-                end
-            end
-            rt = Vararg{rt}
-        end
-        push!(ret, rt)
+    if !isa(argt, DataType) || argt.name !== typename(Tuple)
+        argt = Tuple
     end
-    ret
+    return most_general_argtypes(closure.source, argt, closure.isva)
 end
 
 # call where the function is any lattice element

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -6,7 +6,7 @@ using Core.Intrinsics, Core.IR
 
 import Core: print, println, show, write, unsafe_write, stdout, stderr,
              _apply_iterate, svec, apply_type, Builtin, IntrinsicFunction,
-             MethodInstance, CodeInstance, MethodMatch
+             MethodInstance, CodeInstance, MethodMatch, PartialOpaque
 
 const getproperty = Core.getfield
 const setproperty! = Core.setfield!

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -3,7 +3,7 @@
 function is_argtype_match(@nospecialize(given_argtype),
                           @nospecialize(cache_argtype),
                           overridden_by_const::Bool)
-    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct)
+    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct) || isa(given_argtype, PartialOpaque)
         return is_lattice_equal(given_argtype, cache_argtype)
     end
     return !overridden_by_const

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -3,7 +3,7 @@
 function is_argtype_match(@nospecialize(given_argtype),
                           @nospecialize(cache_argtype),
                           overridden_by_const::Bool)
-    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct) || isa(given_argtype, PartialOpaque)
+    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct)
         return is_lattice_equal(given_argtype, cache_argtype)
     end
     return !overridden_by_const
@@ -45,15 +45,20 @@ function matching_cache_argtypes(linfo::MethodInstance, given_argtypes::Vector)
     return cache_argtypes, overridden_by_const
 end
 
-function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
-    toplevel = !isa(linfo.def, Method)
-    linfo_argtypes = Any[unwrap_unionall(linfo.specTypes).parameters...]
-    nargs::Int = toplevel ? 0 : linfo.def.nargs
+function most_general_argtypes(method::Union{Method, Nothing}, @nospecialize(specTypes),
+    isva::Bool)
+    toplevel = method === nothing
+    linfo_argtypes = Any[unwrap_unionall(specTypes).parameters...]
+    nargs::Int = toplevel ? 0 : method.nargs
+    if !toplevel && method.is_for_opaque_closure
+        # For opaque closure, the closure environment is processed elsewhere
+        nargs -= 1
+    end
     cache_argtypes = Vector{Any}(undef, nargs)
     # First, if we're dealing with a varargs method, then we set the last element of `args`
     # to the appropriate `Tuple` type or `PartialStruct` instance.
-    if !toplevel && linfo.def.isva
-        if linfo.specTypes == Tuple
+    if !toplevel && isva
+        if specTypes == Tuple
             if nargs > 1
                 linfo_argtypes = svec(Any[Any for i = 1:(nargs - 1)]..., Tuple.parameters[1])
             end
@@ -63,7 +68,7 @@ function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
             if nargs > linfo_argtypes_length
                 va = linfo_argtypes[linfo_argtypes_length]
                 if isvarargtype(va)
-                    new_va = rewrap_unionall(unconstrain_vararg_length(va), linfo.specTypes)
+                    new_va = rewrap_unionall(unconstrain_vararg_length(va), specTypes)
                     vargtype_elements = Any[new_va]
                     vargtype = Tuple{new_va}
                 else
@@ -74,7 +79,7 @@ function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
                 vargtype_elements = Any[]
                 for p in linfo_argtypes[nargs:linfo_argtypes_length]
                     p = isvarargtype(p) ? unconstrain_vararg_length(p) : p
-                    push!(vargtype_elements, rewrap(p, linfo.specTypes))
+                    push!(vargtype_elements, rewrap(p, specTypes))
                 end
                 for i in 1:length(vargtype_elements)
                     atyp = vargtype_elements[i]
@@ -115,7 +120,7 @@ function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
             elseif isconstType(atyp)
                 atyp = Const(atyp.parameters[1])
             else
-                atyp = rewrap(atyp, linfo.specTypes)
+                atyp = rewrap(atyp, specTypes)
             end
             i == n && (lastatype = atyp)
             cache_argtypes[i] = atyp
@@ -126,6 +131,13 @@ function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
     else
         @assert nargs == 0 "invalid specialization of method" # wrong number of arguments
     end
+    cache_argtypes
+end
+
+function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
+    mthd = isa(linfo.def, Method) ? linfo.def::Method : nothing
+    cache_argtypes = most_general_argtypes(mthd, linfo.specTypes, isa(mthd, Method) ?
+            mthd.isva : false)
     return cache_argtypes, falses(length(cache_argtypes))
 end
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1377,7 +1377,7 @@ function _opaque_closure_tfunc(@nospecialize(arg), @nospecialize(isva),
     t = argt_exact ? Core.OpaqueClosure{argt} : Core.OpaqueClosure{<:argt}
     t = lbt == ubt ? t{ubt} : (t{T} where lbt <: T <: ubt)
 
-    (isa(source, Const) && isa(source, Method)) || return t
+    (isa(source, Const) && isa(source.val, Method)) || return t
     (isa(isva, Const) && isa(isva.val, Bool)) || return t
 
     return PartialOpaque(t, tuple_tfunc(env), isva.val, linfo, source.val)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1374,7 +1374,7 @@ function _opaque_closure_tfunc(@nospecialize(arg), @nospecialize(isva),
 
     ubt, ub_exact = instanceof_tfunc(ub)
 
-    t = argt_exact ? Core.OpaqueClosure{argt} : Core.OpaqueClosure{<:argt}
+    t = (argt_exact ? Core.OpaqueClosure{argt, T} : Core.OpaqueClosure{<:argt, T}) where T
     t = lbt == ubt ? t{ubt} : (t{T} where lbt <: T <: ubt)
 
     (isa(source, Const) && isa(source.val, Method)) || return t

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -289,6 +289,9 @@ function CodeInstance(result::InferenceResult, @nospecialize(inferred_result::An
         if isa(result_type, Const)
             rettype_const = result_type.val
             const_flags = 0x2
+        elseif isa(result_type, PartialOpaque)
+            rettype_const = result_type
+            const_flags = 0x2
         elseif isconstType(result_type)
             rettype_const = result_type.parameters[1]
             const_flags = 0x2
@@ -773,6 +776,8 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
         if isdefined(code, :rettype_const)
             if isa(code.rettype_const, Vector{Any}) && !(Vector{Any} <: code.rettype)
                 return PartialStruct(code.rettype, code.rettype_const), mi
+            elseif code.rettype <: Core.OpaqueClosure && isa(code.rettype_const, PartialOpaque)
+                return code.rettype_const, mi
             else
                 return Const(code.rettype_const), mi
             end

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -231,6 +231,13 @@ function is_lattice_equal(@nospecialize(a), @nospecialize(b))
     isa(b, PartialStruct) && return false
     a isa Const && return false
     b isa Const && return false
+    if isa(a, PartialOpaque)
+        isa(b, PartialOpaque) || return false
+        widenconst(a) == widenconst(b) || return false
+        a.source == b.source || return false
+        a.parent == b.parent || return false
+        return is_lattice_equal(a.env, b.env)
+    end
     return a ⊑ b && b ⊑ a
 end
 

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -185,6 +185,14 @@ function ⊑(@nospecialize(a), @nospecialize(b))
         end
         return false
     end
+    if isa(a, PartialOpaque)
+        if isa(b, PartialOpaque)
+            (a.parent === b.parent && a.source === b.source) || return false
+            return (widenconst(a) <: widenconst(b)) &&
+                ⊑(a.env, b.env)
+        end
+        return widenconst(a) <: widenconst(b)
+    end
     if isa(a, Const)
         if isa(b, Const)
             return a.val === b.val
@@ -240,6 +248,7 @@ end
 widenconst(m::MaybeUndef) = widenconst(m.typ)
 widenconst(c::PartialTypeVar) = TypeVar
 widenconst(t::PartialStruct) = t.typ
+widenconst(t::PartialOpaque) = t.t
 widenconst(t::Type) = t
 widenconst(t::TypeVar) = t
 widenconst(t::Core.TypeofVararg) = t

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -191,7 +191,7 @@ function ⊑(@nospecialize(a), @nospecialize(b))
             return (widenconst(a) <: widenconst(b)) &&
                 ⊑(a.env, b.env)
         end
-        return widenconst(a) <: widenconst(b)
+        return widenconst(a) ⊑ b
     end
     if isa(a, Const)
         if isa(b, Const)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -255,7 +255,7 @@ end
 widenconst(m::MaybeUndef) = widenconst(m.typ)
 widenconst(c::PartialTypeVar) = TypeVar
 widenconst(t::PartialStruct) = t.typ
-widenconst(t::PartialOpaque) = t.t
+widenconst(t::PartialOpaque) = t.typ
 widenconst(t::Type) = t
 widenconst(t::TypeVar) = t
 widenconst(t::Core.TypeofVararg) = t

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -234,8 +234,8 @@ function is_lattice_equal(@nospecialize(a), @nospecialize(b))
     if isa(a, PartialOpaque)
         isa(b, PartialOpaque) || return false
         widenconst(a) == widenconst(b) || return false
-        a.source == b.source || return false
-        a.parent == b.parent || return false
+        a.source === b.source || return false
+        a.parent === b.parent || return false
         return is_lattice_equal(a.env, b.env)
     end
     return a ⊑ b && b ⊑ a

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -368,6 +368,15 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
        return anyconst ? PartialStruct(widenconst(typea), fields) :
             widenconst(typea)
     end
+    if isa(typea, PartialOpaque) && isa(typeb, PartialOpaque) && widenconst(typea) == widenconst(typeb)
+        if !(typea.source === typeb.source &&
+             typea.isva === typeb.isva &&
+             typea.parent === typeb.parent)
+            return widenconst(typea)
+        end
+        return PartialOpaque(typea.typ, tmerge(typea.env, typeb.env),
+            typea.isva, typea.parent, typea.source)
+    end
     # no special type-inference lattice, join the types
     typea, typeb = widenconst(typea), widenconst(typeb)
     if !isa(typea, Type) || !isa(typeb, Type)

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -34,6 +34,7 @@ end
 
 function has_nontrivial_const_info(@nospecialize t)
     isa(t, PartialStruct) && return true
+    isa(t, PartialOpaque) && return true
     isa(t, Const) || return false
     val = t.val
     return !isdefined(typeof(val), :instance) && !(isa(val, Type) && hasuniquerep(val))

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -114,17 +114,9 @@ end
 
 function get_staged(mi::MethodInstance)
     may_invoke_generator(mi) || return nothing
-    if isdefined(mi, :uninferred)
-        return copy(mi.uninferred::CodeInfo)
-    end
     try
         # user code might throw errors – ignore them
         ci = ccall(:jl_code_for_staged, Any, (Any,), mi)::CodeInfo
-        if has_opaque_closure(ci)
-            # For opaque closures, cache the generated code info to make sure
-            # that OpaqueClosure method identity is stable
-            mi.uninferred = copy(ci)
-        end
         return ci
     catch
         return nothing

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1615,6 +1615,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Argument", (jl_value_t*)jl_argument_type);
     add_builtin("Const", (jl_value_t*)jl_const_type);
     add_builtin("PartialStruct", (jl_value_t*)jl_partial_struct_type);
+    add_builtin("PartialOpaque", (jl_value_t*)jl_partial_opaque_type);
     add_builtin("MethodMatch", (jl_value_t*)jl_method_match_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);

--- a/src/dump.c
+++ b/src/dump.c
@@ -380,11 +380,11 @@ static void jl_serialize_module(jl_serializer_state *s, jl_module_t *m)
     write_uint8(s->s, m->infer);
 }
 
-static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_literal) JL_GC_DISABLED
+static inline int jl_serialize_generic(jl_serializer_state *s, jl_value_t *v) JL_GC_DISABLED
 {
     if (v == NULL) {
         write_uint8(s->s, TAG_NULL);
-        return;
+        return 1;
     }
 
     void *tag = ptrhash_get(&ser_tag, v);
@@ -393,28 +393,29 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         if (t8 <= LAST_TAG)
             write_uint8(s->s, 0);
         write_uint8(s->s, t8);
-        return;
+        return 1;
     }
+
     if (jl_is_symbol(v)) {
         void *idx = ptrhash_get(&common_symbol_tag, v);
         if (idx != HT_NOTFOUND) {
             write_uint8(s->s, TAG_COMMONSYM);
             write_uint8(s->s, (uint8_t)(size_t)idx);
-            return;
+            return 1;
         }
     }
     else if (v == (jl_value_t*)jl_core_module) {
         write_uint8(s->s, TAG_CORE);
-        return;
+        return 1;
     }
     else if (v == (jl_value_t*)jl_base_module) {
         write_uint8(s->s, TAG_BASE);
-        return;
+        return 1;
     }
 
     if (jl_typeis(v, jl_string_type) && jl_string_len(v) == 0) {
         jl_serialize_value(s, jl_an_empty_string);
-        return;
+        return 1;
     }
     else if (!jl_is_uint8(v)) {
         void **bp = ptrhash_bp(&backref_table, v);
@@ -428,7 +429,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
                 write_uint8(s->s, TAG_BACKREF);
                 write_int32(s->s, pos);
             }
-            return;
+            return 1;
         }
         intptr_t pos = backref_table_numel++;
         if (((jl_datatype_t*)(jl_typeof(v)))->name == jl_idtable_typename) {
@@ -451,6 +452,57 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         }
         pos <<= 1;
         ptrhash_put(&backref_table, v, (char*)HT_NOTFOUND + pos + 1);
+    }
+
+    return 0;
+}
+
+static void jl_serialize_code_instance(jl_serializer_state *s, jl_code_instance_t *codeinst, int skip_partial_opaque) JL_GC_DISABLED
+{
+    if (jl_serialize_generic(s, (jl_value_t*)codeinst)) {
+        return;
+    }
+
+    int validate = 0;
+    if (codeinst->max_world == ~(size_t)0)
+        validate = 1; // can check on deserialize if this cache entry is still valid
+    int flags = validate << 0;
+    if (codeinst->invoke == jl_fptr_const_return)
+        flags |= 1 << 2;
+    if (codeinst->precompile)
+        flags |= 1 << 3;
+
+    int write_ret_type = validate || codeinst->min_world == 0;
+    if (write_ret_type && codeinst->rettype_const &&
+            jl_typeis(codeinst->rettype_const, jl_partial_opaque_type)) {
+        if (skip_partial_opaque) {
+            jl_serialize_code_instance(s, codeinst->next, skip_partial_opaque);
+        } else {
+            jl_error("Cannot serialize CodeInstance with PartialOpaque rettype");
+        }
+    }
+
+    write_uint8(s->s, TAG_CODE_INSTANCE);
+    write_uint8(s->s, flags);
+    jl_serialize_value(s, (jl_value_t*)codeinst->def);
+    if (write_ret_type) {
+        jl_serialize_value(s, codeinst->inferred);
+        jl_serialize_value(s, codeinst->rettype_const);
+        jl_serialize_value(s, codeinst->rettype);
+    }
+    else {
+        // skip storing useless data
+        jl_serialize_value(s, NULL);
+        jl_serialize_value(s, NULL);
+        jl_serialize_value(s, jl_any_type);
+    }
+    jl_serialize_code_instance(s, codeinst->next, skip_partial_opaque);
+}
+
+static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_literal) JL_GC_DISABLED
+{
+    if (jl_serialize_generic(s, v)) {
+        return;
     }
 
     size_t i;
@@ -645,33 +697,10 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         }
         jl_serialize_value(s, (jl_value_t*)backedges);
         jl_serialize_value(s, (jl_value_t*)NULL); //callbacks
-        jl_serialize_value(s, (jl_value_t*)mi->cache);
+        jl_serialize_code_instance(s, mi->cache, 1);
     }
     else if (jl_is_code_instance(v)) {
-        write_uint8(s->s, TAG_CODE_INSTANCE);
-        jl_code_instance_t *codeinst = (jl_code_instance_t*)v;
-        int validate = 0;
-        if (codeinst->max_world == ~(size_t)0)
-            validate = 1; // can check on deserialize if this cache entry is still valid
-        int flags = validate << 0;
-        if (codeinst->invoke == jl_fptr_const_return)
-            flags |= 1 << 2;
-        if (codeinst->precompile)
-            flags |= 1 << 3;
-        write_uint8(s->s, flags);
-        jl_serialize_value(s, (jl_value_t*)codeinst->def);
-        if (validate || codeinst->min_world == 0) {
-            jl_serialize_value(s, codeinst->inferred);
-            jl_serialize_value(s, codeinst->rettype_const);
-            jl_serialize_value(s, codeinst->rettype);
-        }
-        else {
-            // skip storing useless data
-            jl_serialize_value(s, NULL);
-            jl_serialize_value(s, NULL);
-            jl_serialize_value(s, jl_any_type);
-        }
-        jl_serialize_value(s, codeinst->next);
+        jl_serialize_code_instance(s, (jl_code_instance_t*)v, 0);
     }
     else if (jl_typeis(v, jl_module_type)) {
         jl_serialize_module(s, (jl_module_t*)v);
@@ -2422,6 +2451,7 @@ static jl_method_t *jl_lookup_method(jl_methtable_t *mt, jl_datatype_t *sig, siz
 
 static jl_method_t *jl_recache_method(jl_method_t *m)
 {
+    assert(!m->is_for_opaque_closure);
     jl_datatype_t *sig = (jl_datatype_t*)m->sig;
     jl_methtable_t *mt = jl_method_table_for((jl_value_t*)m->sig);
     assert((jl_value_t*)mt != jl_nothing);

--- a/src/dump.c
+++ b/src/dump.c
@@ -380,7 +380,7 @@ static void jl_serialize_module(jl_serializer_state *s, jl_module_t *m)
     write_uint8(s->s, m->infer);
 }
 
-static inline int jl_serialize_generic(jl_serializer_state *s, jl_value_t *v) JL_GC_DISABLED
+static int jl_serialize_generic(jl_serializer_state *s, jl_value_t *v) JL_GC_DISABLED
 {
     if (v == NULL) {
         write_uint8(s->s, TAG_NULL);

--- a/src/dump.c
+++ b/src/dump.c
@@ -657,8 +657,11 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         jl_serialize_value(s, (jl_value_t*)m->invokes);
     }
     else if (jl_is_method_instance(v)) {
-        write_uint8(s->s, TAG_METHOD_INSTANCE);
         jl_method_instance_t *mi = (jl_method_instance_t*)v;
+        if (jl_is_method(mi->def.value) && mi->def.method->is_for_opaque_closure) {
+            jl_error("Cannot serialize MethodInstances for OpaqueClosure");
+        }
+        write_uint8(s->s, TAG_METHOD_INSTANCE);
         int internal = 0;
         if (!jl_is_method(mi->def.method))
             internal = 1;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1537,6 +1537,7 @@ static jl_typemap_entry_t *do_typemap_search(jl_methtable_t *mt JL_PROPAGATES_RO
 
 static void jl_method_table_invalidate(jl_methtable_t *mt, jl_typemap_entry_t *methodentry, jl_method_t *method, size_t max_world)
 {
+    assert(!method->is_for_opaque_closure);
     method->deleted_world = methodentry->max_world = max_world;
     // drop this method from mt->cache
     struct invalidate_mt_env mt_cache_env;

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -71,6 +71,7 @@
     XX(jl_nothing_type) \
     XX(jl_number_type) \
     XX(jl_partial_struct_type) \
+    XX(jl_partial_opaque_type) \
     XX(jl_phicnode_type) \
     XX(jl_phinode_type) \
     XX(jl_pinode_type) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2396,6 +2396,10 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_compute_field_offsets((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_opaque_closure_type));
 
 
+    jl_partial_opaque_type = jl_new_datatype(jl_symbol("PartialOpaque"), core, jl_any_type, jl_emptysvec,
+                                       jl_perm_symsvec(5, "typ", "env", "isva", "parent", "source"),
+                                       jl_svec(5, jl_type_type, jl_any_type, jl_bool_type, jl_method_instance_type, jl_method_type), 0, 0, 5);
+
     // complete builtin type metadata
     jl_voidpointer_type = (jl_datatype_t*)pointer_void;
     jl_uint8pointer_type = (jl_datatype_t*)jl_apply_type1((jl_value_t*)jl_pointer_type, (jl_value_t*)jl_uint8_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2397,8 +2397,9 @@ void jl_init_types(void) JL_GC_DISABLED
 
 
     jl_partial_opaque_type = jl_new_datatype(jl_symbol("PartialOpaque"), core, jl_any_type, jl_emptysvec,
-                                       jl_perm_symsvec(5, "typ", "env", "isva", "parent", "source"),
-                                       jl_svec(5, jl_type_type, jl_any_type, jl_bool_type, jl_method_instance_type, jl_method_type), 0, 0, 5);
+        jl_perm_symsvec(5, "typ", "env", "isva", "parent", "source"),
+        jl_svec(5, jl_type_type, jl_any_type, jl_bool_type, jl_method_instance_type, jl_method_type),
+        0, 0, 5);
 
     // complete builtin type metadata
     jl_voidpointer_type = (jl_datatype_t*)pointer_void;

--- a/src/julia.h
+++ b/src/julia.h
@@ -633,6 +633,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_typedslot_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_const_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_struct_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_partial_opaque_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_method_match_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_simplevector_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_typename_t *jl_tuple_typename JL_GLOBALLY_ROOTED;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1135,6 +1135,7 @@ JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
 JL_DLLEXPORT int jl_stored_inline(jl_value_t *el_type);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);
+JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary);
 
 JL_DLLEXPORT uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_set_next_task(jl_task_t *task) JL_NOTSAFEPOINT;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -68,6 +68,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_returnnode_type);
         INSERT_TAG(jl_const_type);
         INSERT_TAG(jl_partial_struct_type);
+        INSERT_TAG(jl_partial_opaque_type);
         INSERT_TAG(jl_method_match_type);
         INSERT_TAG(jl_pinode_type);
         INSERT_TAG(jl_phinode_type);


### PR DESCRIPTION
This adds a lattice element for tracking OpaqueClosures in inference,
but does not yet do anything with it. The reason I'm separating
this out is that just the introduction of the lattice element
raises some tricky issues. In particular, the lattice element
refers back to the OpaqueClosure method, which we currently
don't support in the serializer. I played with several ways
of adding support for that, but in the end it all ended up
super complicated for questionable benefit, so in this PR,
CodeInstances that get inferred to `PartialOpaque` get
omitted during serialization (i.e. they will be reinfered
upon loading the .ji).