### PR TITLE
Reductions of Transpose, Adjoint, PermutedDimsArray

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -212,8 +212,6 @@ include("methodshow.jl")
 include("cartesian.jl")
 using .Cartesian
 include("multidimensional.jl")
-include("permuteddimsarray.jl")
-using .PermutedDimsArrays
 
 include("broadcast.jl")
 using .Broadcast
@@ -291,6 +289,9 @@ end
 # reduction along dims
 include("reducedim.jl")  # macros in this file relies on string.jl
 include("accumulate.jl")
+
+include("permuteddimsarray.jl")
+using .PermutedDimsArrays
 
 # basic data structures
 include("ordering.jl")

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -998,6 +998,8 @@ end
 ∘(f) = f
 ∘(f, g) = ComposedFunction(f, g)
 ∘(f, g, h...) = ∘(f ∘ g, h...)
+∘(f, ::typeof(identity)) = f
+∘(::typeof(identity), g) = g
 
 function show(io::IO, c::ComposedFunction)
     show(io, c.outer)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1000,6 +1000,7 @@ end
 ∘(f, g, h...) = ∘(f ∘ g, h...)
 ∘(f, ::typeof(identity)) = f
 ∘(::typeof(identity), g) = g
+∘(::typeof(identity), ::typeof(identity)) = identity
 
 function show(io::IO, c::ComposedFunction)
     show(io, c.outer)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -998,9 +998,6 @@ end
 ∘(f) = f
 ∘(f, g) = ComposedFunction(f, g)
 ∘(f, g, h...) = ∘(f ∘ g, h...)
-∘(f, ::typeof(identity)) = f
-∘(::typeof(identity), g) = g
-∘(::typeof(identity), ::typeof(identity)) = identity
 
 function show(io::IO, c::ComposedFunction)
     show(io, c.outer)

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -253,6 +253,16 @@ end
     P
 end
 
+function Base._mapreduce_dim(f, op, init::Base._InitialValue, A::PermutedDimsArray, dims::Colon)
+    Base._mapreduce_dim(f, op, init, parent(A), dims)
+end
+
+function Base.mapreducedim!(f, op, B::AbstractArray{T,N}, A::PermutedDimsArray{T,N,P,Q}) where {T,N,P,Q}
+    C = PermutedDimsArray{T,N,Q,P,typeof(B)}(B)
+    Base.mapreducedim!(f, op, C, parent(A))
+    B
+end
+
 function Base.showarg(io::IO, A::PermutedDimsArray{T,N,perm}, toplevel) where {T,N,perm}
     print(io, "PermutedDimsArray(")
     Base.showarg(io, parent(A), false)

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -257,8 +257,8 @@ function Base._mapreduce_dim(f, op, init::Base._InitialValue, A::PermutedDimsArr
     Base._mapreduce_dim(f, op, init, parent(A), dims)
 end
 
-function Base.mapreducedim!(f, op, B::AbstractArray{T,N}, A::PermutedDimsArray{T,N,P,Q}) where {T,N,P,Q}
-    C = PermutedDimsArray{T,N,Q,P,typeof(B)}(B)
+function Base.mapreducedim!(f, op, B::AbstractArray{T,N}, A::PermutedDimsArray{T,N,perm,iperm}) where {T,N,perm,iperm}
+    C = PermutedDimsArray{T,N,iperm,perm,typeof(B)}(B) # make the inverse permutation for the output
     Base.mapreducedim!(f, op, C, parent(A))
     B
 end

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -178,12 +178,6 @@ transpose(A::Transpose) = A.parent
 adjoint(A::Transpose{<:Real}) = A.parent
 transpose(A::Adjoint{<:Real}) = A.parent
 
-# composition
-∘(::typeof(adjoint), ::typeof(adjoint)) = identity
-∘(::typeof(transpose), ::typeof(transpose)) = identity
-∘(::typeof(adjoint), ::typeof(transpose)) = conj
-∘(::typeof(transpose), ::typeof(adjoint)) = conj
-
 # printing
 function Base.showarg(io::IO, v::Adjoint, toplevel)
     print(io, "adjoint(")

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Base: @propagate_inbounds, @_inline_meta
-import Base: length, size, axes, IndexStyle, getindex, setindex!, parent, vec, convert, similar, ∘
+import Base: length, size, axes, IndexStyle, getindex, setindex!, parent, vec, convert, similar
 
 ### basic definitions (types, aliases, constructors, abstractarray interface, sundry similar)
 

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -301,9 +301,9 @@ Base._mapreduce_dim(f, op, init::Base._InitialValue, A::Adjoint, dims::Colon) =
     adjoint(Base._mapreduce_dim(adjoint ∘ f ∘ adjoint, op, init, parent(A), dims))
 
 Base.mapreducedim!(f, op, B::AbstractArray, A::TransposeAbsMat) =
-    adjoint(Base.mapreducedim!(transpose ∘ f ∘ transpose, op, adjoint(B), adjoint(A)))
+    transpose(Base.mapreducedim!(transpose ∘ f ∘ transpose, op, transpose(B), parent(A)))
 Base.mapreducedim!(f, op, B::AbstractArray, A::AdjointAbsMat) =
-    adjoint(Base.mapreducedim!(adjoint ∘ f ∘ adjoint, op, adjoint(B), adjoint(A)))
+    adjoint(Base.mapreducedim!(adjoint ∘ f ∘ adjoint, op, adjoint(B), parent(A)))
 
 
 ### linear algebra

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -308,7 +308,7 @@ Base.mapreducedim!(f, op, B::AbstractArray, A::AdjointAbsMat) =
 
 _sandwich(adj::Function, fun) = (xs...,) -> adj(fun(map(adj, xs)...))
 for fun in [:identity, :add_sum, :mul_prod] #, :max, :min]
-    @eval _sandwich(::Function, ::typeof(Base.$op)) = Base.$fun
+    @eval _sandwich(::Function, ::typeof(Base.$fun)) = Base.$fun
 end
 
 

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Base: @propagate_inbounds, @_inline_meta
-import Base: length, size, axes, IndexStyle, getindex, setindex!, parent, vec, convert, similar
+import Base: length, size, axes, IndexStyle, getindex, setindex!, parent, vec, convert, similar, ∘
 
 ### basic definitions (types, aliases, constructors, abstractarray interface, sundry similar)
 
@@ -177,6 +177,12 @@ adjoint(A::Adjoint) = A.parent
 transpose(A::Transpose) = A.parent
 adjoint(A::Transpose{<:Real}) = A.parent
 transpose(A::Adjoint{<:Real}) = A.parent
+
+# composition
+∘(::typeof(adjoint), ::typeof(adjoint)) = identity
+∘(::typeof(transpose), ::typeof(transpose)) = identity
+∘(::typeof(adjoint), ::typeof(transpose)) = conj
+∘(::typeof(transpose), ::typeof(adjoint)) = conj
 
 # printing
 function Base.showarg(io::IO, v::Adjoint, toplevel)

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -195,7 +195,9 @@ end
 # some aliases for internal convenience use
 const AdjOrTrans{T,S} = Union{Adjoint{T,S},Transpose{T,S}} where {T,S}
 const AdjointAbsVec{T} = Adjoint{T,<:AbstractVector}
+const AdjointAbsMat{T} = Adjoint{T,<:AbstractMatrix}
 const TransposeAbsVec{T} = Transpose{T,<:AbstractVector}
+const TransposeAbsMat{T} = Transpose{T,<:AbstractMatrix}
 const AdjOrTransAbsVec{T} = AdjOrTrans{T,<:AbstractVector}
 const AdjOrTransAbsMat{T} = AdjOrTrans{T,<:AbstractMatrix}
 
@@ -284,6 +286,19 @@ broadcast(f, tvs::Union{Number,TransposeAbsVec}...) = transpose(broadcast((xs...
 Broadcast.broadcast_preserving_zero_d(f, avs::Union{Number,AdjointAbsVec}...) = adjoint(broadcast((xs...) -> adjoint(f(adjoint.(xs)...)), quasiparenta.(avs)...))
 Broadcast.broadcast_preserving_zero_d(f, tvs::Union{Number,TransposeAbsVec}...) = transpose(broadcast((xs...) -> transpose(f(transpose.(xs)...)), quasiparentt.(tvs)...))
 # TODO unify and allow mixed combinations with a broadcast style
+
+### reductions
+
+Base._mapreduce_dim(f, op, init::Base._InitialValue, A::Transpose, dims::Colon) =
+    transpose(Base._mapreduce_dim(transpose ∘ f ∘ transpose, op, init, parent(A), dims))
+Base._mapreduce_dim(f, op, init::Base._InitialValue, A::Adjoint, dims::Colon) =
+    adjoint(Base._mapreduce_dim(adjoint ∘ f ∘ adjoint, op, init, parent(A), dims))
+
+Base.mapreducedim!(f, op, B::AbstractArray, A::TransposeAbsMat) =
+    adjoint(Base.mapreducedim!(transpose ∘ f ∘ transpose, op, adjoint(B), adjoint(A)))
+Base.mapreducedim!(f, op, B::AbstractArray, A::AdjointAbsMat) =
+    adjoint(Base.mapreducedim!(adjoint ∘ f ∘ adjoint, op, adjoint(B), adjoint(A)))
+
 
 ### linear algebra
 

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -557,4 +557,23 @@ end
     @test transpose(Int[]) * Int[] == 0
 end
 
+@testset "reductions: $adjtrans" for adjtrans in [transpose, adjoint]
+    mat = rand(ComplexF64, 3,5)
+    @test sum(adjtrans(mat)) ≈ sum(collect(adjtrans(mat)))
+    @test sum(adjtrans(mat), dims=1) ≈ sum(collect(adjtrans(mat)), dims=1)
+    @test sum(adjtrans(mat), dims=(1,2)) ≈ sum(collect(adjtrans(mat)), dims=(1,2))
+
+    @test sum(imag, adjtrans(mat)) ≈ sum(imag, collect(adjtrans(mat)))
+    @test_skip sum(imag, adjtrans(mat), dims=1) ≈ sum(imag, collect(adjtrans(mat)), dims=1)
+
+    mat = [rand(ComplexF64,2,2) for _ in 1:3, _ in 1:5]
+    @test sum(adjtrans(mat)) ≈ sum(collect(adjtrans(mat)))
+    @test sum(adjtrans(mat), dims=1) ≈ sum(collect(adjtrans(mat)), dims=1)
+    @test sum(adjtrans(mat), dims=(1,2)) ≈ sum(collect(adjtrans(mat)), dims=(1,2))
+
+    @test sum(imag, adjtrans(mat)) ≈ sum(imag, collect(adjtrans(mat)))
+    @test_skip sum(imag, adjtrans(mat), dims=1) ≈ sum(imag, collect(adjtrans(mat)), dims=1)
+    @test sum(x -> x[1,2], adjtrans(mat), dims=1) ≈ sum(x -> x[1,2], collect(adjtrans(mat)), dims=1)
+end
+
 end # module TestAdjointTranspose

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -564,7 +564,7 @@ end
     @test sum(adjtrans(mat), dims=(1,2)) ≈ sum(collect(adjtrans(mat)), dims=(1,2))
 
     @test sum(imag, adjtrans(mat)) ≈ sum(imag, collect(adjtrans(mat)))
-    @test_skip sum(imag, adjtrans(mat), dims=1) ≈ sum(imag, collect(adjtrans(mat)), dims=1)
+    @test sum(imag, adjtrans(mat), dims=1) ≈ sum(imag, collect(adjtrans(mat)), dims=1)
 
     mat = [rand(ComplexF64,2,2) for _ in 1:3, _ in 1:5]
     @test sum(adjtrans(mat)) ≈ sum(collect(adjtrans(mat)))
@@ -572,7 +572,8 @@ end
     @test sum(adjtrans(mat), dims=(1,2)) ≈ sum(collect(adjtrans(mat)), dims=(1,2))
 
     @test sum(imag, adjtrans(mat)) ≈ sum(imag, collect(adjtrans(mat)))
-    @test_skip sum(imag, adjtrans(mat), dims=1) ≈ sum(imag, collect(adjtrans(mat)), dims=1)
+    @test sum(x -> x[1,2], adjtrans(mat)) ≈ sum(x -> x[1,2], collect(adjtrans(mat)))
+    @test sum(imag, adjtrans(mat), dims=1) ≈ sum(imag, collect(adjtrans(mat)), dims=1)
     @test sum(x -> x[1,2], adjtrans(mat), dims=1) ≈ sum(x -> x[1,2], collect(adjtrans(mat)), dims=1)
 end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -701,6 +701,10 @@ end
         perm = randperm(4)
         @test isequal(A,permutedims(permutedims(A,perm),invperm(perm)))
         @test isequal(A,permutedims(permutedims(A,invperm(perm)),perm))
+
+        @test sum(permutedims(A,perm)) ≈ sum(PermutedDimsArray(A,perm))
+        @test sum(permutedims(A,perm), dims=2) ≈ sum(PermutedDimsArray(A,perm), dims=2)
+        @test sum(permutedims(A,perm), dims=(2,4)) ≈ sum(PermutedDimsArray(A,perm), dims=(2,4))
     end
 
     m = [1 2; 3 4]


### PR DESCRIPTION
Closes #33029.

~~It also adds some methods to `∘` such that `adjoint ∘ identity ∘ adjoint === identity`, since it will tend to produce such combinations, and something else may wish to dispatch on them. But it would work without this, I can separate it if that's preferable. (Perhaps we should also complete the group with `conj ∘ transpose = adjoint` etc.)~~ Now removed, in favour of an explicit `_sandwich` function. 

The reduction functions which this overloads for `PermutedDimsArray` were defined after its file is loaded. I moved this file later, but could equally well move these methods to another file. 