### PR TITLE
fix 'error during bootstrap' printing

### DIFF
--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -163,15 +163,16 @@ JL_DLLEXPORT const char *jl_string_ptr(jl_value_t *s)
 JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs)
 {
     jl_value_t *v;
+    nargs++; // add f to args
     JL_TRY {
         jl_value_t **argv;
-        JL_GC_PUSHARGS(argv, nargs+1);
+        JL_GC_PUSHARGS(argv, nargs);
         argv[0] = (jl_value_t*)f;
-        for(int i=1; i<nargs+1; i++)
-            argv[i] = args[i-1];
+        for (int i = 1; i < nargs; i++)
+            argv[i] = args[i - 1];
         size_t last_age = jl_get_ptls_states()->world_age;
         jl_get_ptls_states()->world_age = jl_get_world_counter();
-        v = jl_apply(argv, nargs+1);
+        v = jl_apply(argv, nargs);
         jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
@@ -190,7 +191,7 @@ JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
         JL_GC_PUSH1(&f);
         size_t last_age = jl_get_ptls_states()->world_age;
         jl_get_ptls_states()->world_age = jl_get_world_counter();
-        v = jl_apply(&f, 1);
+        v = jl_apply_generic(f, NULL, 0);
         jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
@@ -208,7 +209,8 @@ JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
     JL_TRY {
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, 2);
-        argv[0] = f; argv[1] = a;
+        argv[0] = f;
+        argv[1] = a;
         size_t last_age = jl_get_ptls_states()->world_age;
         jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(argv, 2);
@@ -229,7 +231,9 @@ JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b
     JL_TRY {
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, 3);
-        argv[0] = f; argv[1] = a; argv[2] = b;
+        argv[0] = f;
+        argv[1] = a;
+        argv[2] = b;
         size_t last_age = jl_get_ptls_states()->world_age;
         jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(argv, 3);
@@ -251,7 +255,10 @@ JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
     JL_TRY {
         jl_value_t **argv;
         JL_GC_PUSHARGS(argv, 4);
-        argv[0] = f; argv[1] = a; argv[2] = b; argv[3] = c;
+        argv[0] = f;
+        argv[1] = a;
+        argv[2] = b;
+        argv[3] = c;
         size_t last_age = jl_get_ptls_states()->world_age;
         jl_get_ptls_states()->world_age = jl_get_world_counter();
         v = jl_apply(argv, 4);
@@ -496,25 +503,21 @@ static int exec_program(char *program)
         // TODO: It is possible for this output
         //       to be mangled due to `jlbacktrace`
         //       printing directly to STDERR_FILENO.
-        jl_value_t *errs = jl_stderr_obj();
-        JL_GC_PUSH1(&errs);
-        volatile int shown_err = 0;
+        int shown_err = 0;
         jl_printf(JL_STDERR, "error during bootstrap:\n");
-        JL_TRY {
+        jl_value_t *exc = jl_current_exception();
+        jl_value_t *showf = jl_get_function(jl_base_module, "show");
+        if (showf) {
+            jl_value_t *errs = jl_stderr_obj();
             if (errs) {
-                jl_value_t *showf = jl_get_function(jl_base_module, "show");
-                if (showf != NULL) {
-                    jl_call2(showf, errs, jl_current_exception());
+                if (jl_call2(showf, errs, exc)) {
                     jl_printf(JL_STDERR, "\n");
                     shown_err = 1;
                 }
             }
         }
-        JL_CATCH {
-        }
-        JL_GC_POP();
         if (!shown_err) {
-            jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+            jl_static_show((JL_STREAM*)STDERR_FILENO, exc);
             jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         }
         jlbacktrace(); // written to STDERR_FILENO

--- a/src/julia.h
+++ b/src/julia.h
@@ -1737,12 +1737,12 @@ STATIC_INLINE jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)
     return jl_apply_generic(args[0], &args[1], nargs - 1);
 }
 
-JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs);
-JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f);
-JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a);
-JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b);
-JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
-                                  jl_value_t *b, jl_value_t *c);
+JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t **args, int32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f JL_MAYBE_UNROOTED);
+JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED);
+JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED, jl_value_t *b JL_MAYBE_UNROOTED);
+JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f JL_MAYBE_UNROOTED, jl_value_t *a JL_MAYBE_UNROOTED,
+                                  jl_value_t *b JL_MAYBE_UNROOTED, jl_value_t *c JL_MAYBE_UNROOTED);
 
 // interfacing with Task runtime
 JL_DLLEXPORT void jl_yield(void);


### PR DESCRIPTION
Previously, we would stop printing the error itself (just the backtrace) as soon as `Base.show` exists (even when it fails). Seems like this probably broke a long time ago? Usually pretty minor, since we try to have `show` almost always available, but I was hitting a case where it wasn't happy. Needed to adjust the gc annotations a bit too.