### PR TITLE
Fix formatting of compat notes

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/config.jl
+++ b/stdlib/REPL/src/TerminalMenus/config.jl
@@ -39,7 +39,7 @@ Configure behavior for selection menus via keyword arguments:
 Subtypes of `ConfiguredMenu` will print `cursor`, `up_arrow`, and `down_arrow` automatically
 as needed, your `writeline` method should not print them.
 
-!!! compat Julia 1.6
+!!! compat "Julia 1.6"
     `Config` is available as of Julia 1.6. On older releases use the global `CONFIG`.
 """
 function Config(;
@@ -81,7 +81,7 @@ All other keyword arguments are as described for [`TerminalMenus.Config`](@ref).
 `checked` and `unchecked` are not printed automatically, and should be printed by
 your `writeline` method.
 
-!!! compat Julia 1.6
+!!! compat "Julia 1.6"
     `MultiSelectConfig` is available as of Julia 1.6. On older releases use the global `CONFIG`.
 """
 function MultiSelectConfig(;
@@ -109,7 +109,7 @@ end
 
 Global menu configuration parameters
 
-!!! compat Julia 1.6
+!!! compat "Julia 1.6"
     `CONFIG` is deprecated, instead configure menus via their constructors.
 """
 const CONFIG = Dict{Symbol,Union{Char,String,Bool}}()
@@ -130,7 +130,7 @@ Keyword-only function to configure global menu parameters
  - `supress_output::Bool=false`: Ignored legacy argument, pass `suppress_output` as a keyword argument to `request` instead.
  - `ctrl_c_interrupt::Bool=true`: If `false`, return empty on ^C, if `true` throw InterruptException() on ^C
 
-!!! compat Julia 1.6
+!!! compat "Julia 1.6"
     As of Julia 1.6, `config` is deprecated. Use `Config` or `MultiSelectConfig` instead.
 """
 function config(;charset::Symbol = :na,


### PR DESCRIPTION
Some compat notes in `REPL.TerminalMenus` were not formatted correctly. This should be backported to 1.6.