### PR TITLE
Do not print delimiters twice in show(::OffsetMatrix) for matrices with certain shifted axes

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -386,7 +386,8 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
     nr, nc = length(indr), length(indc)
     rdots, cdots = false, false
     rr1, rr2 = UnitRange{Int}(indr), 1:0
-    cr1, cr2 = UnitRange{Int}(indc), first(indc) .+ (0:-1)
+    cr1 = UnitRange{Int}(indc)
+    cr2 = first(cr1) .+ (0:-1)
     if limit
         if nr > 4
             rr1, rr2 = rr1[1:2], rr1[nr-1:nr]

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -386,7 +386,7 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
     nr, nc = length(indr), length(indc)
     rdots, cdots = false, false
     rr1, rr2 = UnitRange{Int}(indr), 1:0
-    cr1, cr2 = UnitRange{Int}(indc), 1:0
+    cr1, cr2 = UnitRange{Int}(indc), first(indc) .+ (0:-1)
     if limit
         if nr > 4
             rr1, rr2 = rr1[1:2], rr1[nr-1:nr]
@@ -410,7 +410,7 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
                         show(io, el)
                     end
                 end
-                if !isempty(cr) && last(cr) == last(indc)
+                if last(cr) == last(indc)
                     i < last(indr) && print(io, "; ")
                 elseif cdots
                     print(io, " \u2026 ")

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -410,14 +410,14 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
                         show(io, el)
                     end
                 end
-                if last(cr) == last(indc)
+                if !isempty(cr) && last(cr) == last(indc)
                     i < last(indr) && print(io, "; ")
                 elseif cdots
                     print(io, " \u2026 ")
                 end
             end
         end
-        last(rr) != nr && rdots && print(io, "\u2026 ; ")
+        last(rr) != last(indr) && rdots && print(io, "\u2026 ; ")
     end
     print(io, "]")
 end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -757,3 +757,22 @@ end
         @test a[ax[i]] == a[ax][i]
     end
 end
+
+@testset "show OffsetMatrix" begin
+    Y = reshape(1:25, 5, 5)
+    X = OffsetArray(Y, -2:2, -4:0)
+
+    io = IOBuffer()
+    show(io, X)
+    strX = String(take!(io))
+    show(io, Y)
+    strY = String(take!(io))
+    @test strX == strY
+
+    io2 = IOContext(io, :limit => true)
+    show(io2, X)
+    strX = String(take!(io2))
+    show(io2, Y)
+    strY = String(take!(io2))
+    @test strX == strY
+end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -769,10 +769,10 @@ end
     strY = String(take!(io))
     @test strX == strY
 
-    io2 = IOContext(io, :limit => true)
-    show(io2, X)
-    strX = String(take!(io2))
-    show(io2, Y)
-    strY = String(take!(io2))
+    io_limit = IOContext(io, :limit => true)
+    show(io_limit, X)
+    strX = String(take!(io))
+    show(io_limit, Y)
+    strY = String(take!(io))
     @test strX == strY
 end


### PR DESCRIPTION
Currently the `_show_nonempty` method for an `AbstactMatrix` had some assumptions about 1-based indexing that did not hold true for `OffsetArray`s. This led to outputs such as 

```julia
julia> X = OffsetArray(reshape(1:3, 3, 1), -1:1, 0:0);

julia> show(X)
[1; ; 2; ; 3]
```

This PR attempts to fix the double delimiters. After this:

```julia
julia> show(X)
[1; 2; 3]
```

and in general `show(X)` should be identical to `show(parent(X))`