### PR TITLE
specialize copyto! and multiplication by numbers for Q from qr

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -533,6 +533,12 @@ function getindex(Q::AbstractQ, i::Integer, j::Integer)
     return dot(x, lmul!(Q, y))
 end
 
+# specialization avoiding the fallback using slow `getindex`
+function copyto!(dest::AbstractMatrix, src::LinearAlgebra.AbstractQ)
+    copyto!(dest, I)
+    lmul!(src, dest)
+end
+
 ## Multiplication by Q
 ### QB
 lmul!(A::QRCompactWYQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasFloat, S<:StridedMatrix} =
@@ -588,6 +594,13 @@ function (*)(A::AbstractQ, B::StridedMatrix)
         throw(DimensionMismatch("first dimension of matrix must have size either $(size(A.factors, 1)) or $(size(A.factors, 2))"))
     end
     lmul!(Anew, Bnew)
+end
+
+function (*)(A::AbstractQ, b::Number)
+    TAb = promote_type(eltype(A), typeof(b))
+    dest = similar(A, TAb)
+    copyto!(dest, b*I)
+    lmul!(A, dest)
 end
 
 ### QcB
@@ -681,6 +694,13 @@ function (*)(A::StridedMatrix, Q::AbstractQ)
     TAQ = promote_type(eltype(A), eltype(Q))
 
     return rmul!(copy_oftype(A, TAQ), convert(AbstractMatrix{TAQ}, Q))
+end
+
+function (*)(a::Number, B::AbstractQ)
+    TaB = promote_type(typeof(a), eltype(B))
+    dest = similar(B, TaB)
+    copyto!(dest, a*I)
+    rmul!(dest, B)
 end
 
 ### AQc

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -345,7 +345,7 @@ end
         n = 5
         Q, R = qr(randn(T,n,n))
         Qmat = Matrix(Q)
-        D = Diagonal(randn(n))
+        D = Diagonal(randn(T,n))
         @test Q * D ≈ Qmat * D
         @test D * Q ≈ D * Qmat
         J = 2*I

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -322,4 +322,36 @@ end
     end
 end
 
+@testset "QR factorization of Q" begin
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        Q1, R1 = qr(randn(T,5,5))
+        Q2, R2 = qr(Q1)
+        @test Q1 ≈ Q2
+        @test R2 ≈ I
+    end
+end
+
+@testset "Generation of orthogonal matrices" begin
+    for T in (Float32, Float64)
+        n = 5
+        Q, R = qr(randn(T,n,n))
+        O = Q * Diagonal(sign.(diag(R)))
+        @test O' * O ≈ I
+    end
+end
+
+@testset "Multiplication of Q by special matrices" begin
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        n = 5
+        Q, R = qr(randn(T,n,n))
+        Qmat = Matrix(Q)
+        D = Diagonal(randn(n))
+        @test Q * D ≈ Qmat * D
+        @test D * Q ≈ D * Qmat
+        J = 2*I
+        @test Q * J ≈ Qmat * J
+        @test J * Q ≈ J * Qmat
+    end
+end
+
 end # module TestQR

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -354,4 +354,21 @@ end
     end
 end
 
+@testset "copyto! for Q" begin
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        n = 5
+        Q, R = qr(randn(T,n,n))
+        Qmat = Matrix(Q)
+        dest1 = similar(Q)
+        copyto!(dest1, Q)
+        @test dest1 ≈ Qmat
+        dest2 = PermutedDimsArray(similar(Q), (1, 2))
+        copyto!(dest2, Q)
+        @test dest2 ≈ Qmat
+        dest3 = PermutedDimsArray(similar(Q), (2, 1))
+        copyto!(dest3, Q)
+        @test dest3 ≈ Qmat
+    end
+end
+
 end # module TestQR


### PR DESCRIPTION
This fixes two performance bugs reported in https://github.com/JuliaLang/LinearAlgebra.jl/issues/800 and https://github.com/JuliaLang/LinearAlgebra.jl/issues/800 (multiplication of `Q` from `qr` by a `Diagonal` or `UniformScaling`). In particular, it improves the performance of generating random orthogonal matrices as described in https://github.com/JuliaLang/LinearAlgebra.jl/issues/800.


Latest Julia nightly (v1.7.0-DEV.448)
```julia
julia> using LinearAlgebra

julia> n = 200; Q, R = qr(randn(n, n)); A = randn(n, n); D = Diagonal(randn(n));

julia> @time Q * A;
  0.073661 seconds (263.33 k allocations: 16.445 MiB, 98.74% compilation time)

julia> @time A * Q;
  0.007283 seconds (4.03 k allocations: 885.695 KiB, 86.00% compilation time)

julia> @time Q * D;
  1.402949 seconds (718.24 k allocations: 241.546 MiB, 1.77% gc time, 12.63% compilation time)

julia> @time D * Q;
  1.262098 seconds (386.20 k allocations: 222.074 MiB, 0.53% gc time, 3.97% compilation time)

julia> @time Q * I;
  1.255886 seconds (363.48 k allocations: 221.299 MiB, 0.56% gc time, 3.27% compilation time)

julia> @time I * Q;
  1.250831 seconds (330.64 k allocations: 219.089 MiB, 0.54% gc time, 3.02% compilation time)
```

This PR
```julia
julia> using LinearAlgebra

julia> n = 200; Q, R = qr(randn(n, n)); A = randn(n, n); D = Diagonal(randn(n));

julia> @time Q * A;
  0.079362 seconds (263.33 k allocations: 16.442 MiB, 98.72% compilation time)

julia> @time A * Q;
  0.008170 seconds (4.03 k allocations: 885.695 KiB, 85.55% compilation time)

julia> @time Q * D;
  0.117407 seconds (366.77 k allocations: 21.280 MiB, 9.75% gc time, 98.93% compilation time)

julia> @time D * Q;
  0.083525 seconds (265.85 k allocations: 15.456 MiB, 98.40% compilation time)

julia> @time Q * I;
  0.013162 seconds (15.95 k allocations: 1.567 MiB, 90.46% compilation time)

julia> @time I * Q;
  0.010540 seconds (8.82 k allocations: 1.140 MiB, 88.74% compilation time)
```
Of course, further performance optimizations are likely possibly by introducing better specializations of various multiplication methods of `Q` by something from the left/right as mentioned in https://github.com/JuliaLang/LinearAlgebra.jl/issues/800, but this should be a good first step.

I cannot add labels to this, but "linear algebra" and "performance" would be appropriate, I think.