### PR TITLE
Allow setting lower bound on Experimental.@optlevel

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -114,7 +114,8 @@ parent module.
 Supported values are 0, 1, 2, and 3.
 
 The effective optimization level is the minimum of that specified on the
-command line and in per-module settings.
+command line and in per-module settings. If a `--optlevel-modmin` value is
+set on the command line, that is enforced as a lower bound.
 """
 macro optlevel(n::Int)
     return Expr(:meta, :optlevel, n)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -114,7 +114,7 @@ parent module.
 Supported values are 0, 1, 2, and 3.
 
 The effective optimization level is the minimum of that specified on the
-command line and in per-module settings. If a `--optlevel-modmin` value is
+command line and in per-module settings. If a `--min-optlevel` value is
 set on the command line, that is enforced as a lower bound.
 """
 macro optlevel(n::Int)

--- a/base/options.jl
+++ b/base/options.jl
@@ -21,6 +21,7 @@ struct JLOptions
     code_coverage::Int8
     malloc_log::Int8
     opt_level::Int8
+    opt_level_module_min::Int8
     debug_level::Int8
     check_bounds::Int8
     depwarn::Int8

--- a/base/options.jl
+++ b/base/options.jl
@@ -21,7 +21,7 @@ struct JLOptions
     code_coverage::Int8
     malloc_log::Int8
     opt_level::Int8
-    opt_level_module_min::Int8
+    opt_level_min::Int8
     debug_level::Int8
     check_bounds::Int8
     depwarn::Int8

--- a/base/util.jl
+++ b/base/util.jl
@@ -161,7 +161,7 @@ function julia_cmd(julia=joinpath(Sys.BINDIR::String, julia_exename()))
     opts.can_inline == 0 && push!(addflags, "--inline=no")
     opts.use_compiled_modules == 0 && push!(addflags, "--compiled-modules=no")
     opts.opt_level == 2 || push!(addflags, "-O$(opts.opt_level)")
-    opts.opt_level_module_min == 0 || push!(addflags, "--optlevel-modmin=$(opts.opt_level_module_min)")
+    opts.opt_level_min == 0 || push!(addflags, "--min-optlevel=$(opts.opt_level_min)")
     push!(addflags, "-g$(opts.debug_level)")
     if opts.code_coverage != 0
         # Forward the code-coverage flag only if applicable (if the filename is pid-dependent)

--- a/base/util.jl
+++ b/base/util.jl
@@ -161,6 +161,7 @@ function julia_cmd(julia=joinpath(Sys.BINDIR::String, julia_exename()))
     opts.can_inline == 0 && push!(addflags, "--inline=no")
     opts.use_compiled_modules == 0 && push!(addflags, "--compiled-modules=no")
     opts.opt_level == 2 || push!(addflags, "-O$(opts.opt_level)")
+    opts.opt_level_module_min == 0 || push!(addflags, "--optlevel-modmin=$(opts.opt_level_module_min)")
     push!(addflags, "-g$(opts.debug_level)")
     if opts.code_coverage != 0
         # Forward the code-coverage flag only if applicable (if the filename is pid-dependent)

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -147,7 +147,7 @@ Set the optimization level to <n>
 
 .TP
 --min-optlevel=<n>
-Set the minimum level for per-module optimization to <n>
+Set the minimum optimization level to <n>, overriding per-module settings
 
 .TP
 -g

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -146,6 +146,10 @@ Run time-intensive code optimizations
 Set the optimization level to <n>
 
 .TP
+--optlevel-modmin=<n>
+Set the minimum level for per-module optimization to <n>
+
+.TP
 -g
 Enable generation of full debug info
 

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -146,7 +146,7 @@ Run time-intensive code optimizations
 Set the optimization level to <n>
 
 .TP
---optlevel-modmin=<n>
+--min-optlevel=<n>
 Set the minimum level for per-module optimization to <n>
 
 .TP

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -28,6 +28,7 @@ The following is a complete list of command-line switches available when launchi
 |`--warn-overwrite={yes\|no}`           |Enable or disable method overwrite warnings|
 |`-C`, `--cpu-target <target>`          |Limit usage of CPU features up to `<target>`; set to `help` to see the available options|
 |`-O`, `--optimize={0,1,2,3}`           |Set the optimization level (default level is 2 if unspecified or 3 if used without a level)|
+|`--optlevel-modmin={0,1,2,3}`          |Set the lower bound on per-module optimization (default is 0)|
 |`-g`, `-g <level>`                     |Enable / Set the level of debug info generation (default level is 1 if unspecified or 2 if used without a level)|
 |`--inline={yes\|no}`                   |Control whether inlining is permitted, including overriding `@inline` declarations|
 |`--check-bounds={yes\|no}`             |Emit bounds checks always or never (ignoring declarations)|

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -28,7 +28,7 @@ The following is a complete list of command-line switches available when launchi
 |`--warn-overwrite={yes\|no}`           |Enable or disable method overwrite warnings|
 |`-C`, `--cpu-target <target>`          |Limit usage of CPU features up to `<target>`; set to `help` to see the available options|
 |`-O`, `--optimize={0,1,2,3}`           |Set the optimization level (default level is 2 if unspecified or 3 if used without a level)|
-|`--min-optlevel={0,1,2,3}`          |Set the lower bound on per-module optimization (default is 0)|
+|`--min-optlevel={0,1,2,3}`             |Set the lower bound on per-module optimization (default is 0)|
 |`-g`, `-g <level>`                     |Enable / Set the level of debug info generation (default level is 1 if unspecified or 2 if used without a level)|
 |`--inline={yes\|no}`                   |Control whether inlining is permitted, including overriding `@inline` declarations|
 |`--check-bounds={yes\|no}`             |Emit bounds checks always or never (ignoring declarations)|

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -28,7 +28,7 @@ The following is a complete list of command-line switches available when launchi
 |`--warn-overwrite={yes\|no}`           |Enable or disable method overwrite warnings|
 |`-C`, `--cpu-target <target>`          |Limit usage of CPU features up to `<target>`; set to `help` to see the available options|
 |`-O`, `--optimize={0,1,2,3}`           |Set the optimization level (default level is 2 if unspecified or 3 if used without a level)|
-|`--optlevel-modmin={0,1,2,3}`          |Set the lower bound on per-module optimization (default is 0)|
+|`--min-optlevel={0,1,2,3}`          |Set the lower bound on per-module optimization (default is 0)|
 |`-g`, `-g <level>`                     |Enable / Set the level of debug info generation (default level is 1 if unspecified or 2 if used without a level)|
 |`--inline={yes\|no}`                   |Control whether inlining is permitted, including overriding `@inline` declarations|
 |`--check-bounds={yes\|no}`             |Emit bounds checks always or never (ignoring declarations)|

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -602,10 +602,11 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
                 if (val != "") {
                     int ol = (int)val[0] - '0';
                     if (ol >= 0 && ol < optlevel)
-                        optlevel = std::max(ol, optlevel_min);
+                        optlevel = ol;
                 }
             }
         }
+        optlevel = std::max(optlevel, optlevel_min);
     }
     if (optlevel == 0)
         jit.PM0.run(M);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -588,13 +588,13 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
     JL_TIMING(LLVM_OPT);
 
     int optlevel;
-    int optlevel_modmin;
+    int optlevel_min;
     if (jl_generating_output()) {
         optlevel = 0;
     }
     else {
         optlevel = jl_options.opt_level;
-        optlevel_modmin = jl_options.opt_level_min;
+        optlevel_min = jl_options.opt_level_min;
         for (auto &F : M.functions()) {
             if (!F.getBasicBlockList().empty()) {
                 Attribute attr = F.getFnAttribute("julia-optimization-level");
@@ -602,7 +602,7 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
                 if (val != "") {
                     int ol = (int)val[0] - '0';
                     if (ol >= 0 && ol < optlevel)
-                        optlevel = std::max(ol, optlevel_modmin);
+                        optlevel = std::max(ol, optlevel_min);
                 }
             }
         }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -588,11 +588,13 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
     JL_TIMING(LLVM_OPT);
 
     int optlevel;
+    int optlevel_modmin;
     if (jl_generating_output()) {
         optlevel = 0;
     }
     else {
         optlevel = jl_options.opt_level;
+        optlevel_modmin = jl_options.opt_level_module_min;
         for (auto &F : M.functions()) {
             if (!F.getBasicBlockList().empty()) {
                 Attribute attr = F.getFnAttribute("julia-optimization-level");
@@ -600,7 +602,7 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
                 if (val != "") {
                     int ol = (int)val[0] - '0';
                     if (ol >= 0 && ol < optlevel)
-                        optlevel = ol;
+                        optlevel = std::max(ol, optlevel_modmin);
                 }
             }
         }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -594,7 +594,7 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
     }
     else {
         optlevel = jl_options.opt_level;
-        optlevel_modmin = jl_options.opt_level_module_min;
+        optlevel_modmin = jl_options.opt_level_min;
         for (auto &F : M.functions()) {
             if (!F.getBasicBlockList().empty()) {
                 Attribute attr = F.getFnAttribute("julia-optimization-level");

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -47,6 +47,7 @@ jl_options_t jl_options = { 0,    // quiet
                             0,    // code_coverage
                             0,    // malloc_log
                             2,    // opt_level
+                            0,    // opt_level_module_min
 #ifdef JL_DEBUG_BUILD
                             2,    // debug_level [debug build]
 #else
@@ -122,6 +123,7 @@ static const char opts[]  =
     // code generation options
     " -C, --cpu-target <target> Limit usage of CPU features up to <target>; set to \"help\" to see the available options\n"
     " -O, --optimize={0,1,2,3}  Set the optimization level (default level is 2 if unspecified or 3 if used without a level)\n"
+    " --optlevel-modmin={0,1,2,3}  Set the lower bound on per-module optimization (default is 0)\n"
     " -g, -g <level>            Enable / Set the level of debug info generation"
 #ifdef JL_DEBUG_BUILD
         " (default level for julia-debug is 2 if unspecified or if used without a level)\n"
@@ -190,6 +192,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_worker,
            opt_bind_to,
            opt_handle_signals,
+           opt_optlevel_modmin,
            opt_output_o,
            opt_output_asm,
            opt_output_ji,
@@ -236,6 +239,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "code-coverage",   optional_argument, 0, opt_code_coverage },
         { "track-allocation",optional_argument, 0, opt_track_allocation },
         { "optimize",        optional_argument, 0, 'O' },
+        { "optlevel-modmin", optional_argument, 0, opt_optlevel_modmin },
         { "check-bounds",    required_argument, 0, opt_check_bounds },
         { "output-bc",       required_argument, 0, opt_output_bc },
         { "output-unopt-bc", required_argument, 0, opt_output_unopt_bc },
@@ -534,6 +538,24 @@ restart_switch:
             }
             else {
                 jl_options.opt_level = 3;
+            }
+            break;
+        case opt_optlevel_modmin: // minimum module optimize level
+            if (optarg != NULL) {
+                if (!strcmp(optarg,"0"))
+                    jl_options.opt_level_module_min = 0;
+                else if (!strcmp(optarg,"1"))
+                    jl_options.opt_level_module_min = 1;
+                else if (!strcmp(optarg,"2"))
+                    jl_options.opt_level_module_min = 2;
+                else if (!strcmp(optarg,"3"))
+                    jl_options.opt_level_module_min = 3;
+                else
+                    jl_errorf("julia: invalid argument to --optlevel-modmin (%s)", optarg);
+                break;
+            }
+            else {
+                jl_options.opt_level_module_min = 0;
             }
             break;
         case 'i': // isinteractive

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -123,7 +123,7 @@ static const char opts[]  =
     // code generation options
     " -C, --cpu-target <target> Limit usage of CPU features up to <target>; set to \"help\" to see the available options\n"
     " -O, --optimize={0,1,2,3}  Set the optimization level (default level is 2 if unspecified or 3 if used without a level)\n"
-    " --min-optlevel={0,1,2,3}  Set the lower bound on per-module optimization (default is 0)\n"
+    " --min-optlevel={0,1,2,3}  Set a lower bound on the optimization level (default is 0)\n"
     " -g, -g <level>            Enable / Set the level of debug info generation"
 #ifdef JL_DEBUG_BUILD
         " (default level for julia-debug is 2 if unspecified or if used without a level)\n"
@@ -239,7 +239,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "code-coverage",   optional_argument, 0, opt_code_coverage },
         { "track-allocation",optional_argument, 0, opt_track_allocation },
         { "optimize",        optional_argument, 0, 'O' },
-        { "min-optlevel", optional_argument, 0, opt_optlevel_min },
+        { "min-optlevel",    optional_argument, 0, opt_optlevel_min },
         { "check-bounds",    required_argument, 0, opt_check_bounds },
         { "output-bc",       required_argument, 0, opt_output_bc },
         { "output-unopt-bc", required_argument, 0, opt_output_unopt_bc },

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -47,7 +47,7 @@ jl_options_t jl_options = { 0,    // quiet
                             0,    // code_coverage
                             0,    // malloc_log
                             2,    // opt_level
-                            0,    // opt_level_module_min
+                            0,    // opt_level_min
 #ifdef JL_DEBUG_BUILD
                             2,    // debug_level [debug build]
 #else
@@ -123,7 +123,7 @@ static const char opts[]  =
     // code generation options
     " -C, --cpu-target <target> Limit usage of CPU features up to <target>; set to \"help\" to see the available options\n"
     " -O, --optimize={0,1,2,3}  Set the optimization level (default level is 2 if unspecified or 3 if used without a level)\n"
-    " --optlevel-modmin={0,1,2,3}  Set the lower bound on per-module optimization (default is 0)\n"
+    " --min-optlevel={0,1,2,3}  Set the lower bound on per-module optimization (default is 0)\n"
     " -g, -g <level>            Enable / Set the level of debug info generation"
 #ifdef JL_DEBUG_BUILD
         " (default level for julia-debug is 2 if unspecified or if used without a level)\n"
@@ -239,7 +239,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "code-coverage",   optional_argument, 0, opt_code_coverage },
         { "track-allocation",optional_argument, 0, opt_track_allocation },
         { "optimize",        optional_argument, 0, 'O' },
-        { "optlevel-modmin", optional_argument, 0, opt_optlevel_modmin },
+        { "min-optlevel", optional_argument, 0, opt_optlevel_modmin },
         { "check-bounds",    required_argument, 0, opt_check_bounds },
         { "output-bc",       required_argument, 0, opt_output_bc },
         { "output-unopt-bc", required_argument, 0, opt_output_unopt_bc },
@@ -543,19 +543,19 @@ restart_switch:
         case opt_optlevel_modmin: // minimum module optimize level
             if (optarg != NULL) {
                 if (!strcmp(optarg,"0"))
-                    jl_options.opt_level_module_min = 0;
+                    jl_options.opt_level_min = 0;
                 else if (!strcmp(optarg,"1"))
-                    jl_options.opt_level_module_min = 1;
+                    jl_options.opt_level_min = 1;
                 else if (!strcmp(optarg,"2"))
-                    jl_options.opt_level_module_min = 2;
+                    jl_options.opt_level_min = 2;
                 else if (!strcmp(optarg,"3"))
-                    jl_options.opt_level_module_min = 3;
+                    jl_options.opt_level_min = 3;
                 else
-                    jl_errorf("julia: invalid argument to --optlevel-modmin (%s)", optarg);
+                    jl_errorf("julia: invalid argument to --min-optlevel (%s)", optarg);
                 break;
             }
             else {
-                jl_options.opt_level_module_min = 0;
+                jl_options.opt_level_min = 0;
             }
             break;
         case 'i': // isinteractive

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -192,7 +192,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_worker,
            opt_bind_to,
            opt_handle_signals,
-           opt_optlevel_modmin,
+           opt_optlevel_min,
            opt_output_o,
            opt_output_asm,
            opt_output_ji,
@@ -239,7 +239,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "code-coverage",   optional_argument, 0, opt_code_coverage },
         { "track-allocation",optional_argument, 0, opt_track_allocation },
         { "optimize",        optional_argument, 0, 'O' },
-        { "min-optlevel", optional_argument, 0, opt_optlevel_modmin },
+        { "min-optlevel", optional_argument, 0, opt_optlevel_min },
         { "check-bounds",    required_argument, 0, opt_check_bounds },
         { "output-bc",       required_argument, 0, opt_output_bc },
         { "output-unopt-bc", required_argument, 0, opt_output_unopt_bc },
@@ -540,7 +540,7 @@ restart_switch:
                 jl_options.opt_level = 3;
             }
             break;
-        case opt_optlevel_modmin: // minimum module optimize level
+        case opt_optlevel_min: // minimum module optimize level
             if (optarg != NULL) {
                 if (!strcmp(optarg,"0"))
                     jl_options.opt_level_min = 0;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1964,6 +1964,7 @@ typedef struct {
     int8_t code_coverage;
     int8_t malloc_log;
     int8_t opt_level;
+    int8_t opt_level_module_min;
     int8_t debug_level;
     int8_t check_bounds;
     int8_t depwarn;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1964,7 +1964,7 @@ typedef struct {
     int8_t code_coverage;
     int8_t malloc_log;
     int8_t opt_level;
-    int8_t opt_level_module_min;
+    int8_t opt_level_min;
     int8_t debug_level;
     int8_t check_bounds;
     int8_t depwarn;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -339,6 +339,9 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     @test readchomp(`$exename -E "Base.JLOptions().opt_level" --optimize`) == "3"
     @test readchomp(`$exename -E "Base.JLOptions().opt_level" -O0`) == "0"
 
+    @test readchomp(`$exename -E "Base.JLOptions().opt_level_module_min"`) == "0"
+    @test readchomp(`$exename -E "Base.JLOptions().opt_level_module_min" --optlevel-modmin=2`) == "2"
+
     # -g
     @test readchomp(`$exename -E "Base.JLOptions().debug_level" -g`) == "2"
     let code = writereadpipeline("code_llvm(stdout, +, (Int64, Int64), raw=true, dump_module=true)", `$exename -g0`)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -339,8 +339,8 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     @test readchomp(`$exename -E "Base.JLOptions().opt_level" --optimize`) == "3"
     @test readchomp(`$exename -E "Base.JLOptions().opt_level" -O0`) == "0"
 
-    @test readchomp(`$exename -E "Base.JLOptions().opt_level_module_min"`) == "0"
-    @test readchomp(`$exename -E "Base.JLOptions().opt_level_module_min" --optlevel-modmin=2`) == "2"
+    @test readchomp(`$exename -E "Base.JLOptions().opt_level_min"`) == "0"
+    @test readchomp(`$exename -E "Base.JLOptions().opt_level_min" --min-optlevel=2`) == "2"
 
     # -g
     @test readchomp(`$exename -E "Base.JLOptions().debug_level" -g`) == "2"


### PR DESCRIPTION
During the non-time-critical generation of a sysimage in PackageCompiler, it may be advantageous for code performance to override any per-module `Experimental.@optlevel` settings that have been reduced to help compile time.

The current tooling only allows modules to be the minimum of `-O` and `Experimental.@optlevel` per module. This adds `--min-optlevel` as a lower bound to the level that is used.

i.e. `julia -O3 --min-optlevel=3` would enforce all modules to opt level 3


Edit: Updated to `--min-optlevel`