### PR TITLE
Add missing imports to SuiteSparse tests

### DIFF
--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -1,11 +1,15 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using SuiteSparse.CHOLMOD
+using SuiteSparse
 using DelimitedFiles
 using Test
 using Random
 using Serialization
-using LinearAlgebra: issuccess, PosDefException, ZeroPivotException
+using LinearAlgebra:
+    I, cholesky, cholesky!, det, diag, eigmax, ishermitian, isposdef, issuccess,
+    issymmetric, ldlt, ldlt!, logdet, norm, opnorm, Diagonal, Hermitian, Symmetric,
+    PosDefException, ZeroPivotException
 using SparseArrays
 using SparseArrays: getcolptr
 

--- a/stdlib/SuiteSparse/test/spqr.jl
+++ b/stdlib/SuiteSparse/test/spqr.jl
@@ -2,7 +2,9 @@
 
 using SuiteSparse.SPQR
 using SuiteSparse.CHOLMOD
-using LinearAlgebra: rmul!, lmul!, Adjoint, Transpose
+using SuiteSparse
+using LinearAlgebra: I, istriu, norm, qr, rank, rmul!, lmul!, Adjoint, Transpose
+using SparseArrays: sparse, sprandn, spzeros, SparseMatrixCSC
 
 @testset "Sparse QR" begin
 m, n = 100, 10

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -1,8 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+using SuiteSparse.UMFPACK
+using SuiteSparse
 using SuiteSparse: increment!
 using Serialization
-using LinearAlgebra: Adjoint, Transpose, SingularException
+using LinearAlgebra:
+    I, det, issuccess, ldiv!, lu, lu!, Adjoint, Transpose, SingularException, Diagonal
+using SparseArrays: nnz, sparse, sprand, sprandn, SparseMatrixCSC
 
 @testset "UMFPACK wrappers" begin
     se33 = sparse(1.0I, 3, 3)
@@ -33,11 +37,11 @@ using LinearAlgebra: Adjoint, Transpose, SingularException
 
             @test A*x ≈ b
             z = complex.(b)
-            x = LinearAlgebra.ldiv!(lua, z)
+            x = ldiv!(lua, z)
             @test x ≈ float([1:5;])
             @test z === x
             y = similar(z)
-            LinearAlgebra.ldiv!(y, lua, complex.(b))
+            ldiv!(y, lua, complex.(b))
             @test y ≈ x
 
             @test A*x ≈ b
@@ -48,11 +52,11 @@ using LinearAlgebra: Adjoint, Transpose, SingularException
 
             @test A'*x ≈ b
             z = complex.(b)
-            x = LinearAlgebra.ldiv!(adjoint(lua), z)
+            x = ldiv!(adjoint(lua), z)
             @test x ≈ float([1:5;])
             @test x === z
             y = similar(x)
-            LinearAlgebra.ldiv!(y, adjoint(lua), complex.(b))
+            ldiv!(y, adjoint(lua), complex.(b))
             @test y ≈ x
 
             @test A'*x ≈ b
@@ -60,10 +64,10 @@ using LinearAlgebra: Adjoint, Transpose, SingularException
             @test x ≈ float([1:5;])
 
             @test transpose(A) * x ≈ b
-            x = LinearAlgebra.ldiv!(transpose(lua), complex.(b))
+            x = ldiv!(transpose(lua), complex.(b))
             @test x ≈ float([1:5;])
             y = similar(x)
-            LinearAlgebra.ldiv!(y, transpose(lua), complex.(b))
+            ldiv!(y, transpose(lua), complex.(b))
             @test y ≈ x
 
             @test transpose(A) * x ≈ b
@@ -165,9 +169,9 @@ using LinearAlgebra: Adjoint, Transpose, SingularException
         X = zeros(ComplexF64, N, N)
         B = complex.(rand(N, N), rand(N, N))
         luA, lufA = lu(A), lu(Array(A))
-        @test LinearAlgebra.ldiv!(copy(X), luA, B) ≈ LinearAlgebra.ldiv!(copy(X), lufA, B)
-        @test LinearAlgebra.ldiv!(copy(X), adjoint(luA), B) ≈ LinearAlgebra.ldiv!(copy(X), adjoint(lufA), B)
-        @test LinearAlgebra.ldiv!(copy(X), transpose(luA), B) ≈ LinearAlgebra.ldiv!(copy(X), transpose(lufA), B)
+        @test ldiv!(copy(X), luA, B) ≈ ldiv!(copy(X), lufA, B)
+        @test ldiv!(copy(X), adjoint(luA), B) ≈ ldiv!(copy(X), adjoint(lufA), B)
+        @test ldiv!(copy(X), transpose(luA), B) ≈ ldiv!(copy(X), transpose(lufA), B)
     end
 
     @testset "singular matrix" begin


### PR DESCRIPTION
The `SuiteSparse/cholmod`, `SuiteSparse/spqr`, and `SuiteSparse/umfpack` cannot be run alone because of missing imports. This PR fixes that.