### PR TITLE
[cli/trampolines] Clean up definitions, fix win32 exporting issue

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -53,7 +53,7 @@ $(BUILDDIR)/loader_exe.o : $(SRCDIR)/loader_exe.c $(HEADERS) $(JULIAHOME)/VERSIO
 	@$(call PRINT_CC, $(CC) $(SHIPFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
 $(BUILDDIR)/loader_exe.dbg.obj : $(SRCDIR)/loader_exe.c $(HEADERS) $(JULIAHOME)/VERSION
 	@$(call PRINT_CC, $(CC) $(DEBUGFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
-$(BUILDDIR)/loader_trampolines.o : $(SRCDIR)/trampolines/trampolines_$(ARCH).S
+$(BUILDDIR)/loader_trampolines.o : $(SRCDIR)/trampolines/trampolines_$(ARCH).S $(HEADERS) $(SRCDIR)/trampolines/common.h
 	@$(call PRINT_CC, $(CC) $(SHIPFLAGS) $(LOADER_CFLAGS) $< -c -o $@)
 
 # Debugging target to help us see what kind of code is being generated for our trampolines

--- a/cli/trampolines/common.h
+++ b/cli/trampolines/common.h
@@ -1,0 +1,70 @@
+// Preprocessor annoyances
+#define CONCAT_(x,y)    x##y
+#define CONCAT(x,y)     CONCAT_(x, y)
+#define CNAMEADDR(name) CONCAT(CNAME(name),_addr)
+#define STR_(x)         #x
+#define STR(x)          STR_(x)
+#define I(x)            x
+
+// On macOS and 32-bit windows, we need to prepend underscores on symbols to match the C ABI
+#if defined(__APPLE__) || (defined(_WIN32) && !defined(_WIN64))
+#define UNDERSCORE(x) _##x
+#else
+#define UNDERSCORE(x)    x
+#endif
+
+// Windows requires some help with the linker when it comes to debuginfo/exporting
+#if defined(_WIN32) || defined(_WIN64)
+#define DEBUGINFO(name)     .def name; \
+                            .scl 2; \
+                            .type 32; \
+                            .endef
+#define EXPORT(name)        .section .drectve,"r"; \
+                            .ascii STR(-export:##I(name)); \
+                            .ascii " "; \
+                            .section .text
+#else
+#define DEBUGINFO(name)
+#define EXPORT(name)
+#endif
+
+// Windows 64-bit uses SEH
+#if defined(_WIN64)
+#define SEH_START1(name)    .seh_proc CNAME(name)
+#define SEH_START2()        .seh_endprologue
+#define SEH_END()           .seh_endproc
+#else
+#define SEH_START1(name)
+#define SEH_START2()
+#define SEH_END()
+#endif
+
+// If we're compiling with control-flow branch protection, mark the trampoline entry
+// points with `endbr{32,64}`, as appropriate on this arch
+#if defined(__CET__) && __CET__ & 1 != 0
+#if defined(__x86_64__)
+#define CET_START()     endbr64
+#else
+#define CET_START()     endbr32
+#endif
+#else
+#define CET_START()
+#endif
+
+// aarch64 on mac requires some special assembler syntax for both calculating memory
+// offsets and even just the assembler statement separator token
+#if defined(__aarch64__)
+#if defined(__APPLE__)
+#define PAGE(x)     x##@PAGE
+#define PAGEOFF(x)  x##@PAGEOFF
+#define SEP         %%
+#else
+#define PAGE(x)     x
+#define PAGEOFF(x)  :lo12:##x
+#define SEP         ;
+#endif
+#endif
+
+// If someday we need to mangle everything, we do so by defining this `CNAME()`
+// to do something more complex than just `UNDERSCORE(x)`.
+#define CNAME(x)    UNDERSCORE(x)

--- a/cli/trampolines/trampolines_aarch64.S
+++ b/cli/trampolines/trampolines_aarch64.S
@@ -1,17 +1,5 @@
+#include "common.h"
 #include "../../src/jl_exported_funcs.inc"
-
-// On macOS, we need to prepend underscores on symbols
-#if defined(__APPLE__) && defined(__MACH__)
-#define CNAME(x)    _##x
-#define PAGE(x)     x##@PAGE
-#define PAGEOFF(x)  x##@PAGEOFF
-#define SEP         %%
-#else
-#define CNAME(x)    x
-#define PAGE(x)     x
-#define PAGEOFF(x)  #:lo12:##x
-#define SEP         ;
-#endif
 
 #define XX(name) \
 .global CNAME(name) SEP \

--- a/cli/trampolines/trampolines_arm.S
+++ b/cli/trampolines/trampolines_arm.S
@@ -1,16 +1,17 @@
+#include "common.h"
 #include "../../src/jl_exported_funcs.inc"
 
 #define XX(name) \
-.global name; \
+.global CNAME(name); \
 .cfi_startproc; \
-name##:; \
-    ldr ip, .L##name; \
-.L##name: ;\
+CNAME(name)##:; \
+    ldr ip, .L##CNAME(name); \
+.L##CNAME(name): ;\
     add ip, pc, ip; \
     ldr pc, [ip]; \
     .align 2; \
-.L##name##_addr: ; \
-    .word name##_addr-(.L##name + 8); \
+.L##CNAMEADDR(name)##: ; \
+    .word CNAMEADDR(name)##-(.L##name + 8); \
 .cfi_endproc; \
 
 JL_EXPORTED_FUNCS(XX)

--- a/cli/trampolines/trampolines_arm.S
+++ b/cli/trampolines/trampolines_arm.S
@@ -5,13 +5,13 @@
 .global CNAME(name); \
 .cfi_startproc; \
 CNAME(name)##:; \
-    ldr ip, .L##CNAME(name); \
-.L##CNAME(name): ;\
+    ldr ip, CONCAT(.L,CNAME(name)); \
+CONCAT(.L,CNAME(name)): ;\
     add ip, pc, ip; \
     ldr pc, [ip]; \
     .align 2; \
-.L##CNAMEADDR(name)##: ; \
-    .word CNAMEADDR(name)##-(.L##name + 8); \
+CONCAT(.L,CNAMEADDR(name))##: ; \
+    .word CNAMEADDR(name)##-(CONCAT(.L,CNAME(name)) + 8); \
 .cfi_endproc; \
 
 JL_EXPORTED_FUNCS(XX)

--- a/cli/trampolines/trampolines_i686.S
+++ b/cli/trampolines/trampolines_i686.S
@@ -1,32 +1,16 @@
+#include "common.h"
 #include "../../src/jl_exported_funcs.inc"
 
-// On Windows, we need to prepend underscores on symbols
-#if defined(_WIN32)
-#define CNAME(x) _##x
-#define DEBUGINFO(name)     .def CNAME(name); \
-                            .scl 2; \
-                            .type 32; \
-                            .endef
-#else
-#define CNAME(x) x
-#define DEBUGINFO(name)
-#endif
-
-#if defined(__CET__) && __CET__ & 1 != 0
-#define CET_START() endbr32
-#else
-#define CET_START()
-#endif
-
 #define XX(name) \
-DEBUGINFO(name); \
+DEBUGINFO(CNAME(name)); \
 .global CNAME(name); \
 .cfi_startproc; \
 CNAME(name)##:; \
     CET_START(); \
-    jmpl *(CNAME(name##_addr)); \
+    jmpl *(CNAMEADDR(name)); \
     ud2; \
 .cfi_endproc; \
+EXPORT(name); \
 
 JL_EXPORTED_FUNCS(XX)
 #undef XX

--- a/cli/trampolines/trampolines_powerpc64le.S
+++ b/cli/trampolines/trampolines_powerpc64le.S
@@ -15,8 +15,8 @@ CNAME(name)##: ; \
     addis 2, 12, .TOC.-CNAME(name)##@ha; \
     addi 2, 2, .TOC.-CNAME(name)##@l; \
     .localentry CNAME(name)##,.-CNAME(name)##; \
-    addis 9,2,CNAMEADDR(name)##@toc@ha; \
-    ld 12,CNAMEADDR(name)##@toc@l(9); \
+    addis 12,2,CNAMEADDR(name)##@toc@ha; \
+    ld 12,CNAMEADDR(name)##@toc@l(12); \
     mtctr 12; \
     bctr; \
 .cfi_endproc; \

--- a/cli/trampolines/trampolines_powerpc64le.S
+++ b/cli/trampolines/trampolines_powerpc64le.S
@@ -1,3 +1,4 @@
+#include "common.h"
 #include "../../src/jl_exported_funcs.inc"
 
 // Notes:
@@ -7,19 +8,19 @@
 // See 64-Bit ELF V2 ABI Specification: Power Architecture v1.4
 
 #define XX(name) \
-.global name; \
-.type name##, @function; \
+.global CNAME(name); \
+.type CNAME(name)##, @function; \
 .cfi_startproc; \
-name##: ; \
-    addis 2, 12, .TOC.-name##@ha; \
-    addi 2, 2, .TOC.-name##@l; \
-    .localentry name##,.-name##; \
-    addis 9,2,name##_addr@toc@ha; \
-    ld 12,name##_addr@toc@l(9); \
+CNAME(name)##: ; \
+    addis 2, 12, .TOC.-CNAME(name)##@ha; \
+    addi 2, 2, .TOC.-CNAME(name)##@l; \
+    .localentry CNAME(name)##,.-CNAME(name)##; \
+    addis 9,2,CNAMEADDR(name)##@toc@ha; \
+    ld 12,CNAMEADDR(name)##@toc@l(9); \
     mtctr 12; \
     bctr; \
 .cfi_endproc; \
-.size name##,.-name##; \
+.size CNAME(name)##,.-CNAME(name)##; \
 
 JL_EXPORTED_FUNCS(XX)
 #undef XX

--- a/cli/trampolines/trampolines_x86_64.S
+++ b/cli/trampolines/trampolines_x86_64.S
@@ -1,36 +1,5 @@
+#include "common.h"
 #include "../../src/jl_exported_funcs.inc"
-
-// On macOS, we need to prepend underscores on symbols
-#if defined(__APPLE__) && defined(__MACH__)
-#define CNAME(x) _##x
-#else
-#define CNAME(x) x
-#endif
-
-#if defined(_WIN64)
-#define DEBUGINFO(name)     .def CNAME(name); \
-                            .scl 2; \
-                            .type 32; \
-                            .endef
-#define EXPORT(name)        .section .drectve,"r"; \
-                            .ascii " -export:"#name""; \
-                            .section .text
-#define SEH_START1(name)    .seh_proc name
-#define SEH_START2()        .seh_endprologue
-#define SEH_END()           .seh_endproc
-#else
-#define DEBUGINFO(name)
-#define EXPORT(name)
-#define SEH_START1(name)
-#define SEH_START2()
-#define SEH_END()
-#endif
-
-#if defined(__CET__) && __CET__ & 1 != 0
-#define CET_START() endbr64
-#else
-#define CET_START()
-#endif
 
 #define XX(name) \
 DEBUGINFO(name); \
@@ -40,7 +9,7 @@ SEH_START1(name); \
 CNAME(name)##:; \
 SEH_START2(); \
     CET_START(); \
-    mov CNAME(name##_addr)(%rip),%r11; \
+    mov CNAMEADDR(name)(%rip),%r11; \
     jmpq *%r11; \
     ud2; \
 SEH_END(); \


### PR DESCRIPTION
Our win32 trampolines weren't getting exported properly.  Also take the
opportunity to properly organize after debugging libblastrampoline and
finding the current organizational strategy lacking.

In the future, if we ever want to mangle the symbols from these
trampolines, we now have a convenient `CNAME()` that is properly invoked
from all trampolines and can consistently mangle names.