### PR TITLE
Remove extra close parenthesis in show of DiffFile

### DIFF
--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -520,7 +520,7 @@ end
 
 function Base.show(io::IO, df::DiffFile)
     println(io, "DiffFile:")
-    println(io, "Oid: $(df.id))")
+    println(io, "Oid: $(df.id)")
     println(io, "Path: $(df.path)")
     println(io, "Size: $(df.size)")
 end


### PR DESCRIPTION
Minor cosmetic change to remove an extra close parentheseis `)` from the Oid-line.