### PR TITLE
Disable Profiler stack switch heuristic when running under rr

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -83,7 +83,7 @@ void JL_UV_LOCK(void);
 extern "C" {
 #endif
 
-int jl_running_under_rr(int recheck);
+int jl_running_under_rr(int recheck) JL_NOTSAFEPOINT;
 
 //--------------------------------------------------
 // timers

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -98,7 +98,7 @@ static int jl_unw_stepn(bt_cursor_t *cursor, jl_bt_element_t *bt_data, size_t *b
             }
             uintptr_t oldsp = thesp;
             have_more_frames = jl_unw_step(cursor, from_signal_handler, &return_ip, &thesp);
-            if (oldsp >= thesp) {
+            if (oldsp >= thesp && !jl_running_under_rr(0)) {
                 // The stack pointer is clearly bad, as it must grow downwards.
                 // But sometimes the external unwinder doesn't check that.
                 have_more_frames = 0;


### PR DESCRIPTION
rr uses a separately allocated stack to avoid disturbing the main application.
It has a carefully crafted set of CFI information to make sure that unwinders
can successfully unwind through this stack switching. However, our unwinder
has a bail out path when this stack switching is detected. This is sensible in
general (assuming we're dealing with unknown external code with potentially
bad unwind info). However, when running under rr it can cause failures in the
Profile test, so just disable it there.