### PR TITLE
improve bunch of type stabilities in `Core.Compiler`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -459,7 +459,7 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
             # Under direct self-recursion, permit much greater use of reducers.
             # here we assume that complexity(specTypes) :>= complexity(sig)
             comparison = sv.linfo.specTypes
-            l_comparison = length(unwrap_unionall(comparison).parameters)
+            l_comparison = length(unwrap_unionall(comparison).parameters)::Int
             spec_len = max(spec_len, l_comparison)
         else
             comparison = method.sig
@@ -700,16 +700,20 @@ function abstract_apply(interp::AbstractInterpreter, @nospecialize(itft), @nospe
     res = Union{}
     nargs = length(aargtypes)
     splitunions = 1 < unionsplitcost(aargtypes) <= InferenceParams(interp).MAX_APPLY_UNION_ENUM
-    ctypes = Any[Any[aft]]
+    ctypes = [Any[aft]]
     infos = [Union{Nothing, AbstractIterationInfo}[]]
     for i = 1:nargs
-        ctypes´ = []
-        infos′ = []
+        ctypes´ = Vector{Any}[]
+        infos′ = Vector{Union{Nothing, AbstractIterationInfo}}[]
         for ti in (splitunions ? uniontypes(aargtypes[i]) : Any[aargtypes[i]])
             if !isvarargtype(ti)
-                cti, info = precise_container_type(interp, itft, ti, sv)
+                cti_info = precise_container_type(interp, itft, ti, sv)
+                cti = cti_info[1]::Vector{Any}
+                info = cti_info[2]::Union{Nothing,AbstractIterationInfo}
             else
-                cti, info = precise_container_type(interp, itft, unwrapva(ti), sv)
+                cti_info = precise_container_type(interp, itft, unwrapva(ti), sv)
+                cti = cti_info[1]::Vector{Any}
+                info = cti_info[2]::Union{Nothing,AbstractIterationInfo}
                 # We can't represent a repeating sequence of the same types,
                 # so tmerge everything together to get one type that represents
                 # everything.
@@ -726,7 +730,7 @@ function abstract_apply(interp::AbstractInterpreter, @nospecialize(itft), @nospe
                 continue
             end
             for j = 1:length(ctypes)
-                ct = ctypes[j]
+                ct = ctypes[j]::Vector{Any}
                 if isvarargtype(ct[end])
                     # This is vararg, we're not gonna be able to do any inling,
                     # drop the info
@@ -850,7 +854,8 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, fargs::U
        (a3 = argtypes[3]; isa(a3, Const)) && (idx = a3.val; isa(idx, Int)) &&
        (a2 = argtypes[2]; a2 ⊑ Tuple)
         # TODO: why doesn't this use the getfield_tfunc?
-        cti, _ = precise_container_type(interp, iterate, a2, sv)
+        cti_info = precise_container_type(interp, iterate, a2, sv)
+        cti = cti_info[1]::Vector{Any}
         if 1 <= idx <= length(cti)
             rt = unwrapva(cti[idx])
         end
@@ -1392,7 +1397,8 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
             delete!(W, pc)
             frame.currpc = pc
             frame.cur_hand = frame.handler_at[pc]
-            frame.stmt_edges[pc] === nothing || empty!(frame.stmt_edges[pc])
+            edges = frame.stmt_edges[pc]
+            edges === nothing || empty!(edges)
             stmt = frame.src.code[pc]
             changes = s[pc]::VarTable
             t = nothing
@@ -1405,7 +1411,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
             elseif isa(stmt, GotoNode)
                 pc´ = (stmt::GotoNode).label
             elseif isa(stmt, GotoIfNot)
-                condt = abstract_eval_value(interp, stmt.cond, s[pc], frame)
+                condt = abstract_eval_value(interp, stmt.cond, changes, frame)
                 if condt === Bottom
                     empty!(frame.pclimitations)
                 end
@@ -1438,7 +1444,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                         end
                     end
                     newstate_else = stupdate!(s[l], changes_else)
-                    if newstate_else !== false
+                    if newstate_else !== nothing
                         # add else branch to active IP list
                         if l < frame.pc´´
                             frame.pc´´ = l
@@ -1449,7 +1455,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                 end
             elseif isa(stmt, ReturnNode)
                 pc´ = n + 1
-                rt = widenconditional(abstract_eval_value(interp, stmt.val, s[pc], frame))
+                rt = widenconditional(abstract_eval_value(interp, stmt.val, changes, frame))
                 if !isa(rt, Const) && !isa(rt, Type) && !isa(rt, PartialStruct) && !isa(rt, PartialOpaque)
                     # only propagate information we know we can store
                     # and is valid inter-procedurally
@@ -1483,9 +1489,8 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                 frame.cur_hand = Pair{Any,Any}(l, frame.cur_hand)
                 # propagate type info to exception handler
                 old = s[l]
-                new = s[pc]::VarTable
-                newstate_catch = stupdate!(old, new)
-                if newstate_catch !== false
+                newstate_catch = stupdate!(old, changes)
+                if newstate_catch !== nothing
                     if l < frame.pc´´
                         frame.pc´´ = l
                     end
@@ -1556,12 +1561,12 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                 # (such as a terminator for a loop, if-else, or try block),
                 # consider whether we should jump to an older backedge first,
                 # to try to traverse the statements in approximate dominator order
-                if newstate !== false
+                if newstate !== nothing
                     s[pc´] = newstate
                 end
                 push!(W, pc´)
                 pc = frame.pc´´
-            elseif newstate !== false
+            elseif newstate !== nothing
                 s[pc´] = newstate
                 pc = pc´
             elseif pc´ in W

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -371,7 +371,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
         end
         a = ex.args[2]
         if a isa Expr
-            cost = plus_saturate(cost, statement_cost(a, -1, src, sptypes, slottypes, params, error_path))
+            cost = plus_saturate(cost, statement_cost(a, -1, src, sptypes, slottypes, union_penalties, params, error_path))
         end
         return cost
     elseif head === :copyast
@@ -392,7 +392,7 @@ function statement_or_branch_cost(@nospecialize(stmt), line::Int, src::CodeInfo,
     thiscost = 0
     if stmt isa Expr
         thiscost = statement_cost(stmt, line, src, sptypes, slottypes, union_penalties, params,
-                                  params.unoptimize_throw_blocks && line in throw_blocks)::Int
+                                  throw_blocks !== nothing && line in throw_blocks)::Int
     elseif stmt isa GotoNode
         # loops are generally always expensive
         # but assume that forward jumps are already counted for from

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -630,7 +630,7 @@ function rewrite_apply_exprargs!(ir::IRCode, todo::Vector{Pair{Int, Any}}, idx::
                 call = thisarginfo.each[i]
                 new_stmt = Expr(:call, argexprs[2], def, state...)
                 state1 = insert_node!(ir, idx, call.rt, new_stmt)
-                new_sig = with_atype(call_sig(ir, new_stmt))
+                new_sig = with_atype(call_sig(ir, new_stmt)::Signature)
                 if isa(call.info, MethodMatchInfo) || isa(call.info, UnionSplitInfo)
                     info = isa(call.info, MethodMatchInfo) ?
                         MethodMatchInfo[call.info] : call.info.matches
@@ -988,9 +988,12 @@ function inline_invoke!(ir::IRCode, idx::Int, sig::Signature, invoke_data::Invok
             sig.atype, method.sig)::SimpleVector
     methsp = methsp::SimpleVector
     match = MethodMatch(metharg, methsp, method, true)
-    result = analyze_method!(match, sig.atypes, state.et, state.caches, state.params, calltype)
+    et = state.et
+    result = analyze_method!(match, sig.atypes, et, state.caches, state.params, calltype)
     handle_single_case!(ir, stmt, idx, result, true, todo)
-    intersect!(state.et, WorldRange(invoke_data.min_valid, invoke_data.max_valid))
+    if et !== nothing
+        intersect!(et, WorldRange(invoke_data.min_valid, invoke_data.max_valid))
+    end
     return nothing
 end
 
@@ -1073,9 +1076,12 @@ function analyze_single_call!(ir::IRCode, todo::Vector{Pair{Int, Any}}, idx::Int
     for i in 1:length(infos)
         info = infos[i]
         meth = info.results
-        if meth === missing || meth.ambig
+        if meth === missing
             # Too many applicable methods
-            # Or there is a (partial?) ambiguity
+            too_many = true
+            break
+        elseif meth.ambig
+            # there is a (partial?) ambiguity
             too_many = true
             break
         elseif length(meth) == 0
@@ -1118,6 +1124,7 @@ function analyze_single_call!(ir::IRCode, todo::Vector{Pair{Int, Any}}, idx::Int
                 sig.atype, only_method.sig)::SimpleVector
             match = MethodMatch(metharg, methsp, only_method, true)
         else
+            meth = meth::MethodLookupResult
             @assert length(meth) == 1
             match = meth[1]
         end
@@ -1145,6 +1152,8 @@ end
 function assemble_inline_todo!(ir::IRCode, state::InliningState)
     # todo = (inline_idx, (isva, isinvoke, na), method, spvals, inline_linetable, inline_ir, lie)
     todo = Pair{Int, Any}[]
+    et = state.et
+    method_table = state.method_table
     for idx in 1:length(ir.stmts)
         r = process_simple!(ir, todo, idx, state)
         r === nothing && continue
@@ -1176,20 +1185,18 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
         nu = unionsplitcost(sig.atypes)
         if nu == 1 || nu > state.params.MAX_UNION_SPLITTING
             if !isa(info, MethodMatchInfo)
-                if state.method_table === nothing
-                    continue
-                end
-                info = recompute_method_matches(sig.atype, state.params, state.et, state.method_table)
+                method_table === nothing && continue
+                et === nothing && continue
+                info = recompute_method_matches(sig.atype, state.params, et, method_table)
             end
             infos = MethodMatchInfo[info]
         else
             if !isa(info, UnionSplitInfo)
-                if state.method_table === nothing
-                    continue
-                end
+                method_table === nothing && continue
+                et === nothing && continue
                 infos = MethodMatchInfo[]
                 for union_sig in UnionSplitSignature(sig.atypes)
-                    push!(infos, recompute_method_matches(argtypes_to_type(union_sig), state.params, state.et, state.method_table))
+                    push!(infos, recompute_method_matches(argtypes_to_type(union_sig), state.params, et, method_table))
                 end
             else
                 infos = info.matches

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1076,12 +1076,9 @@ function analyze_single_call!(ir::IRCode, todo::Vector{Pair{Int, Any}}, idx::Int
     for i in 1:length(infos)
         info = infos[i]
         meth = info.results
-        if meth === missing
+        if meth === missing || meth.ambig
             # Too many applicable methods
-            too_many = true
-            break
-        elseif meth.ambig
-            # there is a (partial?) ambiguity
+            # Or there is a (partial?) ambiguity
             too_many = true
             break
         elseif length(meth) == 0

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -680,7 +680,7 @@ function resolve_todo(todo::InliningTodo, et::Union{EdgeTracker, Nothing}, cache
     spec = todo.spec::DelayedInliningSpec
     isconst, src = find_inferred(todo.mi, spec.atypes, caches, spec.stmttype)
 
-    if isconst
+    if isconst && et !== nothing
         push!(et, todo.mi)
         return ConstantCase(src)
     end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -139,6 +139,7 @@ function compute_basic_blocks(stmts::Vector{Any})
     return CFG(blocks, basic_block_index)
 end
 
+# this function assumes insert position exists
 function first_insert_for_bb(code, cfg::CFG, block::Int)
     for idx in cfg.blocks[block].stmts
         stmt = code[idx]
@@ -146,6 +147,7 @@ function first_insert_for_bb(code, cfg::CFG, block::Int)
             return idx
         end
     end
+    error("any insert position isn't found")
 end
 
 # SSA-indexed nodes

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -895,7 +895,7 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
     # Check if the block is now dead
     if length(preds) == 0
         for succ in copy(compact.result_bbs[compact.bb_rename_succ[to]].succs)
-            kill_edge!(compact, active_bb, to, findfirst(x->x === succ, compact.bb_rename_pred))
+            kill_edge!(compact, active_bb, to, findfirst(x->x === succ, compact.bb_rename_pred)::Int)
         end
         if to < active_bb
             # Kill all statements in the block

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -764,7 +764,7 @@ function construct_ssa!(ci::CodeInfo, ir::IRCode, domtree::DomTree, defuse, narg
                     # Having undef_token appear on the RHS is possible if we're on a dead branch.
                     # Do something reasonable here, by marking the LHS as undef as well.
                     if val !== undef_token
-                        incoming_vals[id] = SSAValue(make_ssa!(ci, code, idx, id, typ))
+                        incoming_vals[id] = SSAValue(make_ssa!(ci, code, idx, id, typ)::Int)
                     else
                         code[idx] = nothing
                         incoming_vals[id] = undef_token

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -14,13 +14,13 @@ end
 function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, use_idx::Int, print::Bool)
     if isa(op, SSAValue)
         if op.id > length(ir.stmts)
-            def_bb = block_for_inst(ir.cfg, ir.new_nodes[op.id - length(ir.stmts)].pos)
+            def_bb = block_for_inst(ir.cfg, ir.new_nodes.info[op.id - length(ir.stmts)].pos)
         else
             def_bb = block_for_inst(ir.cfg, op.id)
         end
         if (def_bb == use_bb)
             if op.id > length(ir.stmts)
-                @assert ir.new_nodes[op.id - length(ir.stmts)].pos <= use_idx
+                @assert ir.new_nodes.info[op.id - length(ir.stmts)].pos <= use_idx
             else
                 if op.id >= use_idx
                     @verify_error "Def ($(op.id)) does not dominate use ($(use_idx)) in same BB"

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -712,6 +712,7 @@ function merge_call_chain!(parent::InferenceState, ancestor::InferenceState, chi
     # and merge all of the callers into ancestor.callers_in_cycle
     # and ensure that walking the parent list will get the same result (DAG) from everywhere
     while true
+        parent = parent::InferenceState
         add_cycle_backedge!(child, parent, parent.currpc)
         union_caller_cycle!(ancestor, child)
         child = parent

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -712,12 +712,11 @@ function merge_call_chain!(parent::InferenceState, ancestor::InferenceState, chi
     # and merge all of the callers into ancestor.callers_in_cycle
     # and ensure that walking the parent list will get the same result (DAG) from everywhere
     while true
-        parent = parent::InferenceState
         add_cycle_backedge!(child, parent, parent.currpc)
         union_caller_cycle!(ancestor, child)
         child = parent
-        parent = child.parent
         child === ancestor && break
+        parent = child.parent::InferenceState
     end
 end
 

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -317,7 +317,7 @@ function stupdate!(state::VarTable, changes::StateUpdate)
     if !isa(changes.var, Slot)
         return stupdate!(state, changes.state)
     end
-    newstate = false
+    newstate = nothing
     changeid = slot_id(changes.var::Slot)
     for i = 1:length(state)
         if i == changeid
@@ -346,7 +346,7 @@ function stupdate!(state::VarTable, changes::StateUpdate)
 end
 
 function stupdate!(state::VarTable, changes::VarTable)
-    newstate = false
+    newstate = nothing
     for i = 1:length(state)
         newtype = changes[i]
         oldtype = state[i]
@@ -360,7 +360,7 @@ end
 
 stupdate!(state::Nothing, changes::VarTable) = copy(changes)
 
-stupdate!(state::Nothing, changes::Nothing) = false
+stupdate!(state::Nothing, changes::Nothing) = nothing
 
 function stupdate1!(state::VarTable, change::StateUpdate)
     if !isa(change.var, Slot)

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -204,18 +204,18 @@ end
 # unioncomplexity estimates the number of calls to `tmerge` to obtain the given type by
 # counting the Union instances, taking also into account those hidden in a Tuple or UnionAll
 function unioncomplexity(u::Union)
-    return unioncomplexity(u.a) + unioncomplexity(u.b) + 1
+    return unioncomplexity(u.a)::Int + unioncomplexity(u.b)::Int + 1
 end
 function unioncomplexity(t::DataType)
     t.name === Tuple.name || isvarargtype(t) || return 0
     c = 0
     for ti in t.parameters
-        c = max(c, unioncomplexity(ti))
+        c = max(c, unioncomplexity(ti)::Int)
     end
     return c
 end
-unioncomplexity(u::UnionAll) = max(unioncomplexity(u.body), unioncomplexity(u.var.ub))
-unioncomplexity(t::Core.TypeofVararg) = isdefined(t, :T) ? unioncomplexity(t.T) : 0
+unioncomplexity(u::UnionAll) = max(unioncomplexity(u.body)::Int, unioncomplexity(u.var.ub)::Int)
+unioncomplexity(t::Core.TypeofVararg) = isdefined(t, :T) ? unioncomplexity(t.T)::Int : 0
 unioncomplexity(@nospecialize(x)) = 0
 
 function improvable_via_constant_propagation(@nospecialize(t))

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Expr head => argument count bounds
-const VALID_EXPR_HEADS = IdDict{Any,Any}(
+const VALID_EXPR_HEADS = IdDict{Symbol,UnitRange}(
     :call => 1:typemax(Int),
     :invoke => 2:typemax(Int),
     :static_parameter => 1:1,

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -257,10 +257,14 @@ end
 
 function rewrap_unionall(t::Core.TypeofVararg, @nospecialize(u))
     isdefined(t, :T) || return t
-    if !isdefined(t, :N) || (isa(u, UnionAll) && t.N === u.var)
-        return Vararg{rewrap_unionall(t.T, u)}
+    if !isa(u, UnionAll)
+        return t
     end
-    Vararg{rewrap_unionall(t.T, u), t.N}
+    T = rewrap_unionall(t.T, u)
+    if !isdefined(t, :N) || t.N === u.var
+        return Vararg{T}
+    end
+    return Vararg{T, t.N}
 end
 
 # replace TypeVars in all enclosing UnionAlls with fresh TypeVars

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -257,7 +257,7 @@ end
 
 function rewrap_unionall(t::Core.TypeofVararg, @nospecialize(u))
     isdefined(t, :T) || return t
-    if !isdefined(t, :N) || t.N === u.var
+    if !isdefined(t, :N) || (isa(u, UnionAll) && t.N === u.var)
         return Vararg{rewrap_unionall(t.T, u)}
     end
     Vararg{rewrap_unionall(t.T, u), t.N}


### PR DESCRIPTION
All of them are detected by JET.jl's self-profiling.
The following code will print type-instabilities/type-errors for
code paths reachable from `typeinf(::NativeInterpreter,
::InferenceState)`.
```julia
julia> using JET
julia> report_call(Core.Compiler.typeinf, (Core.Compiler.NativeInterpreter, Core.Compiler.InferenceState); annotate_types = true)
```

The remaining error reports (e.g. `variable Core.Compiler.string is not
defined`)
are because of missing imports.

> on master
<details><summary>101 possible errors found</summary>
<p>

```julia
┌ @ compiler/typeinfer.jl:205 Core.Compiler._typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
│┌ @ compiler/typeinfer.jl:214 Core.Compiler.typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
││┌ @ compiler/abstractinterpretation.jl:1515 Core.Compiler.typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
│││┌ @ compiler/abstractinterpretation.jl:1336 Core.Compiler.empty!(Core.Compiler.getindex(Core.Compiler.getproperty(frame::Core.Compiler.InferenceState, :stmt_edges::Symbol)::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}})
││││ for one of the union split cases, no matching method found for signature: Core.Compiler.empty!(Core.Compiler.getindex(Core.Compiler.getproperty(frame::Core.Compiler.InferenceState, :stmt_edges::Symbol)::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}})
│││└───────────────────────────────────────────
│││┌ @ compiler/abstractinterpretation.jl:1349 Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.GotoIfNot, :cond::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
││││ for one of the union split cases, no matching method found for signature: Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.GotoIfNot, :cond::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
│││└───────────────────────────────────────────
│││┌ @ compiler/abstractinterpretation.jl:1379 Core.Compiler.stupdate!(Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, l::Int64)::Union{Nothing, Vector{Any}}, changes_else::Union{Core.Compiler.StateUpdate, Vector{Any}})
││││┌ @ compiler/typelattice.jl:302 Core.Compiler.stupdate!(state::Vector{Any}, Core.Compiler.getproperty(changes::Core.Compiler.StateUpdate, :state::Symbol)::Vector{Any})
│││││┌ @ compiler/typelattice.jl:339 Core.Compiler.smerge(oldtype::Any, newtype::Any)
││││││┌ @ compiler/typelattice.jl:256 Core.Compiler.tmerge(Core.Compiler.getproperty(sa::Core.Compiler.VarState, :typ::Symbol)::Any, Core.Compiler.getproperty(sb::Core.Compiler.VarState, :typ::Symbol)::Any)
│││││││┌ @ compiler/typelimits.jl:354 Core.Compiler.nfields_tfunc(typea::Union{Core.Const, Core.PartialStruct})
││││││││┌ @ compiler/tfuncs.jl:412 Core.Compiler.nfields_tfunc(Core.Compiler.getproperty(x::Union, :a::Symbol)::Any)
│││││││││┌ @ compiler/tfuncs.jl:414 Core.Compiler.tmerge(na::Core.Const, Core.Compiler.nfields_tfunc(Core.Compiler.getproperty(x::Union, :b::Symbol)::Any)::Core.Const)
││││││││││┌ @ compiler/typelimits.jl:364 Core.Compiler.getfield_tfunc(typea::Core.Const, Core.Compiler.Const(i::Int64)::Core.Const)
│││││││││││┌ @ compiler/tfuncs.jl:827 Core.Compiler.rewrap_unionall(_ts::Any, s00::Core.Const)
││││││││││││┌ @ essentials.jl:260 Core.Compiler.getproperty(u::Core.Const, :var::Symbol)
│││││││││││││ type Core.Const has no field var
││││││││││││└─────────────────────
│││││││┌ @ compiler/tfuncs.jl:831 Core.Compiler.getfield_tfunc(_ts::Any, name::Union{Core.Const, Type{Int64}})
││││││││┌ @ compiler/tfuncs.jl:844 Core.Compiler.==(Core.Compiler.length(ftypes::Any)::Any, 1)
│││││││││┌ @ promotion.jl:359 Core.Compiler.promote(x::Number, y::Int64)
││││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Number, y::Int64)::Tuple{Number, Int64}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
│││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Number, Int64})
││││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Number, Int64})
│││││││││││││┌ @ tuple.jl:214 f::Core.Compiler.var"#39#40"(Core.Compiler.getindex(t::Tuple{Number, Int64}, 1)::Number)
││││││││││││││┌ @ promotion.jl:316 Core.Compiler.string(Core.Compiler.typeof(x::Number)::Type{var"#s446"} where var"#s446"<:Number)
│││││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.typeof(x::Number)::Type{var"#s446"} where var"#s446"<:Number)
││││││││││││││└────────────────────
│││││││││││││┌ @ tuple.jl:214 f::Core.Compiler.var"#39#40"(Core.Compiler.getindex(t::Tuple{Number, Int64}, 2)::Int64)
││││││││││││││┌ @ promotion.jl:316 Core.Compiler.string(Core.Compiler.typeof(x::Int64)::Type{Int64})
│││││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.typeof(x::Int64)::Type{Int64})
││││││││││││││└────────────────────
││││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Number, Int64})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Number, Int64})::Tuple{Any, Any}, ", ", " and ")
││││││││││││└────────────────────
│││││││┌ @ compiler/typelimits.jl:364 Core.Compiler.getfield_tfunc(typea::Union{Core.Const, Core.PartialStruct}, Core.Compiler.Const(i::Int64)::Core.Const)
││││││││┌ @ compiler/tfuncs.jl:827 Core.Compiler.rewrap_unionall(_ts::Any, s00::Core.PartialStruct)
│││││││││┌ @ essentials.jl:260 Core.Compiler.getproperty(u::Core.PartialStruct, :var::Symbol)
││││││││││ type Core.PartialStruct has no field var
│││││││││└─────────────────────
│││┌ @ compiler/abstractinterpretation.jl:1386 Core.Compiler.setindex!(s::Vector{Union{Nothing, Vector{Any}}}, newstate_else::Union{Bool, Vector{Any}}, l::Int64)
││││┌ @ array.jl:839 Core.Compiler.convert(_::Type{Union{Nothing, Vector{Any}}}, x::Bool)
│││││ no matching method found for call signature: Core.Compiler.convert(_::Type{Union{Nothing, Vector{Any}}}, x::Bool)
││││└────────────────
│││┌ @ compiler/abstractinterpretation.jl:1391 Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.ReturnNode, :val::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
││││ for one of the union split cases, no matching method found for signature: Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.ReturnNode, :val::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
│││└───────────────────────────────────────────
│││┌ @ compiler/abstractinterpretation.jl:1442 Core.Compiler.abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getindex(Core.Compiler.getproperty(stmt::Any, :args::Symbol)::Any, 2)::Any, changes::Vector{Any}, frame::Core.Compiler.InferenceState)
││││┌ @ compiler/abstractinterpretation.jl:1179 Core.Compiler.abstract_call(interp::Core.Compiler.NativeInterpreter, ea::Vector{Any}, argtypes::Vector{Any}, sv::Core.Compiler.InferenceState)
│││││┌ @ compiler/abstractinterpretation.jl:1051 #self#::typeof(Core.Compiler.abstract_call)(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Compiler.InferenceState, Core.Compiler.getproperty(Core.Compiler.InferenceParams(interp::Core.Compiler.NativeInterpreter)::Core.Compiler.InferenceParams, :MAX_METHODS::Symbol)::Int64)
││││││┌ @ compiler/abstractinterpretation.jl:1065 Core.Compiler.abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, Core.Compiler.nothing, argtypes::Vector{Any}, Core.Compiler.argtypes_to_type(argtypes::Vector{Any})::Type, sv::Core.Compiler.InferenceState, max_methods::Int64)
│││││││┌ @ compiler/abstractinterpretation.jl:141 Core.Compiler.abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Type, Core.Compiler.getproperty(match::Core.MethodMatch, :sparams::Symbol)::Core.SimpleVector, multiple_matches::Bool, sv::Core.Compiler.InferenceState)
││││││││┌ @ compiler/abstractinterpretation.jl:449 Core.Compiler.max(spec_len::Int64, l_comparison::Any)
│││││││││┌ @ promotion.jl:369 Core.Compiler.promote(x::Int64, y::Real)
││││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Int64, y::Real)::Tuple{Int64, Real}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
│││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Int64, Real})
││││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Real})
│││││││││││││┌ @ tuple.jl:214 f::Core.Compiler.var"#39#40"(Core.Compiler.getindex(t::Tuple{Int64, Real}, 2)::Real)
││││││││││││││┌ @ promotion.jl:316 Core.Compiler.string(Core.Compiler.typeof(x::Real)::Type{var"#s446"} where var"#s446"<:Real)
│││││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.typeof(x::Real)::Type{var"#s446"} where var"#s446"<:Real)
││││││││││││││└────────────────────
││││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Real})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Real})::Tuple{Any, Any}, ", ", " and ")
││││││││││││└────────────────────
│││││││││┌ @ promotion.jl:369 Core.Compiler.max(Core.Compiler.promote(x::Int64, y::Real)::Tuple{Any, Any}...)
││││││││││┌ @ promotion.jl:369 Core.Compiler.promote(x::Real, y::Real)
│││││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Real, y::Real)::Tuple{Real, Real}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Real, Real})
│││││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Real, Real})::Tuple{Any, Any}, ", ", " and ")
││││││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Real, Real})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││└────────────────────
│││││││││┌ @ operators.jl:476 Core.Compiler.isless(y::Any, x::Int64)
││││││││││┌ @ operators.jl:169 Core.Compiler.isnan(x::AbstractFloat)
│││││││││││ variable Core.Compiler.isnan is not defined: Core.Compiler.isnan(x::AbstractFloat)
││││││││││└────────────────────
││││││││││┌ @ operators.jl:169 Core.Compiler.isnan(y::Int64)
│││││││││││ variable Core.Compiler.isnan is not defined: Core.Compiler.isnan(y::Int64)
││││││││││└────────────────────
││││││││││┌ @ operators.jl:169 Core.Compiler.|(Core.Compiler.isnan(y::Int64)::Any, Core.Compiler.signless(x::AbstractFloat, y::Int64)::Bool)
│││││││││││┌ @ int.jl:924 Core.Compiler.not_sametype(Core.tuple(a::Integer, b::Bool)::Tuple{Integer, Bool}, Core.tuple(aT::Any, bT::Any)::Tuple{Any, Any})
││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Integer, Bool})
│││││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Integer, Bool})
││││││││││││││┌ @ tuple.jl:214 f::Core.Compiler.var"#39#40"(Core.Compiler.getindex(t::Tuple{Integer, Bool}, 1)::Integer)
│││││││││││││││┌ @ promotion.jl:316 Core.Compiler.string(Core.Compiler.typeof(x::Integer)::Type{var"#s446"} where var"#s446"<:Integer)
││││││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.typeof(x::Integer)::Type{var"#s446"} where var"#s446"<:Integer)
│││││││││││││││└────────────────────
││││││││││││││┌ @ tuple.jl:214 f::Core.Compiler.var"#39#40"(Core.Compiler.getindex(t::Tuple{Integer, Bool}, 2)::Bool)
│││││││││││││││┌ @ promotion.jl:316 Core.Compiler.string(Core.Compiler.typeof(x::Bool)::Type{Bool})
││││││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.typeof(x::Bool)::Type{Bool})
│││││││││││││││└────────────────────
│││││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Integer, Bool})::Tuple{Any, Any}, ", ", " and ")
││││││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Integer, Bool})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││└────────────────────
││││││││││┌ @ operators.jl:169 Core.Compiler.&(Core.Compiler.!(Core.Compiler.isnan(x::AbstractFloat)::Any)::Union{Bool, Core.Compiler.var"#80#81"{_A} where _A}, Core.Compiler.|(Core.Compiler.isnan(y::Int64)::Any, Core.Compiler.signless(x::AbstractFloat, y::Int64)::Bool)::Any)
│││││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.&(Core.Compiler.!(Core.Compiler.isnan(x::AbstractFloat)::Any)::Union{Bool, Core.Compiler.var"#80#81"{_A} where _A}, Core.Compiler.|(Core.Compiler.isnan(y::Int64)::Any, Core.Compiler.signless(x::AbstractFloat, y::Int64)::Bool)::Any)
││││││││││└────────────────────
││││││││││┌ @ operators.jl:169 Core.Compiler.&(Core.Compiler.!(Core.Compiler.isnan(x::AbstractFloat)::Any)::Union{Bool, Core.Compiler.var"#80#81"{_A} where _A}, Core.Compiler.|(Core.Compiler.isnan(y::Int64)::Any, Core.Compiler.signless(x::AbstractFloat, y::Int64)::Bool)::Any)
│││││││││││┌ @ int.jl:924 Core.Compiler.not_sametype(Core.tuple(a::Bool, b::Integer)::Tuple{Bool, Integer}, Core.tuple(aT::Any, bT::Any)::Tuple{Any, Any})
││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Bool, Integer})
│││││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Bool, Integer})::Tuple{Any, Any}, ", ", " and ")
││││││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Bool, Integer})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││└────────────────────
││││││││││┌ @ operators.jl:414 Core.Compiler.<(x::Real, y::Int64)
│││││││││││┌ @ promotion.jl:360 Core.Compiler.promote(x::Real, y::Int64)
││││││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Real, y::Int64)::Tuple{Real, Int64}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
│││││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Real, Int64})
││││││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Real, Int64})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Real, Int64})::Tuple{Any, Any}, ", ", " and ")
││││││││││││││└────────────────────
││││││││┌ @ compiler/abstractinterpretation.jl:502 Core.Compiler.typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams::Core.SimpleVector, sv::Core.Compiler.InferenceState)
│││││││││┌ @ compiler/typeinfer.jl:791 Core.Compiler.resolve_call_cycle!(interp::Core.Compiler.NativeInterpreter, mi::Core.MethodInstance, caller::Core.Compiler.InferenceState)
││││││││││┌ @ compiler/typeinfer.jl:749 Core.Compiler.merge_call_chain!(parent::Core.Compiler.InferenceState, frame::Core.Compiler.InferenceState, frame::Core.Compiler.InferenceState)
│││││││││││┌ @ compiler/typeinfer.jl:712 Core.Compiler.add_cycle_backedge!(child::Core.Compiler.InferenceState, parent::Union{Nothing, Core.Compiler.InferenceState}, Core.Compiler.getproperty(parent::Union{Nothing, Core.Compiler.InferenceState}, :currpc::Symbol)::Int64)
││││││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.add_cycle_backedge!(child::Core.Compiler.InferenceState, parent::Union{Nothing, Core.Compiler.InferenceState}, Core.Compiler.getproperty(parent::Union{Nothing, Core.Compiler.InferenceState}, :currpc::Symbol)::Int64)
│││││││││││└─────────────────────────────
│││││││││││┌ @ compiler/typeinfer.jl:712 Core.Compiler.add_cycle_backedge!(child::Union{Nothing, Core.Compiler.InferenceState}, parent::Union{Nothing, Core.Compiler.InferenceState}, Core.Compiler.getproperty(parent::Union{Nothing, Core.Compiler.InferenceState}, :currpc::Symbol)::Int64)
││││││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.add_cycle_backedge!(child::Union{Nothing, Core.Compiler.InferenceState}, parent::Union{Nothing, Core.Compiler.InferenceState}, Core.Compiler.getproperty(parent::Union{Nothing, Core.Compiler.InferenceState}, :currpc::Symbol)::Int64)
│││││││││││└─────────────────────────────
│││││││││││┌ @ compiler/typeinfer.jl:713 Core.Compiler.union_caller_cycle!(ancestor::Core.Compiler.InferenceState, child::Union{Nothing, Core.Compiler.InferenceState})
││││││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.union_caller_cycle!(ancestor::Core.Compiler.InferenceState, child::Union{Nothing, Core.Compiler.InferenceState})
│││││││││││└─────────────────────────────
┌ @ compiler/abstractinterpretation.jl:1067 Core.Compiler.abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Compiler.InferenceState, max_methods::Int64)
│┌ @ compiler/abstractinterpretation.jl:961 Core.Compiler.abstract_apply(interp::Core.Compiler.NativeInterpreter, itft::Any, ft::Any, Core.Compiler.argtype_tail(argtypes::Vector{Any}, 4)::Vector{Any}, sv::Core.Compiler.InferenceState, max_methods::Int64)
││┌ @ compiler/abstractinterpretation.jl:702 Core.Compiler.lastindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
│││ for one of the union split cases, no matching method found for signature: Core.Compiler.lastindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
││└──────────────────────────────────────────
││┌ @ compiler/abstractinterpretation.jl:702 Core.Compiler.getindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}}, Core.Compiler.lastindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})::Int64)
│││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}}, Core.Compiler.lastindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})::Int64)
││└──────────────────────────────────────────
││┌ @ compiler/abstractinterpretation.jl:706 Core.Compiler.length(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
│││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
││└──────────────────────────────────────────
││┌ @ compiler/abstractinterpretation.jl:707 Core.Compiler.getindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}}, i::Int64)
│││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}}, i::Int64)
││└──────────────────────────────────────────
││┌ @ compiler/abstractinterpretation.jl:711 Core.Compiler._any(#266::Core.Compiler.var"#266#267", cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
│││┌ @ compiler/utilities.jl:17 Core.Compiler.iterate(a::Nothing)
││││ no matching method found for call signature: Core.Compiler.iterate(a::Nothing)
│││└────────────────────────────
│││┌ @ compiler/utilities.jl:17 Core.Compiler.iterate(a::Core.Compiler.AbstractIterationInfo)
││││ no matching method found for call signature: Core.Compiler.iterate(a::Core.Compiler.AbstractIterationInfo)
│││└────────────────────────────
││┌ @ compiler/abstractinterpretation.jl:721 Core.Compiler.tuple_tail_elem(Core.Compiler.unwrapva(Core.Compiler.getindex(ct::Any, Core.Compiler.lastindex(ct::Any)::Any)::Any)::Any, cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
│││ for one of the union split cases, no matching method found for signature: Core.Compiler.tuple_tail_elem(Core.Compiler.unwrapva(Core.Compiler.getindex(ct::Any, Core.Compiler.lastindex(ct::Any)::Any)::Any)::Any, cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
││└──────────────────────────────────────────
││┌ @ compiler/abstractinterpretation.jl:724 Core.Compiler.append!(Core.Compiler.getindex(ct::Any, Core.Compiler.:)::Any, cti::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
│││┌ @ bitarray.jl:782 Core.Compiler.BitVector(items::Nothing)
││││┌ @ bitarray.jl:575 Core.Compiler.gen_bitarrayN(Core.apply_type(Core.Compiler.BitArray, _::Int64)::Type{Core.Compiler.BitArray{1}}, Core.Compiler.IteratorSize(itr::Nothing)::Core.Compiler.HasLength, itr::Nothing)
│││││┌ @ bitarray.jl:604 Core.Compiler.gen_bitarray(itsz::Core.Compiler.HasLength, itr::Nothing)
││││││┌ @ bitarray.jl:598 Core.Compiler.length(itr::Nothing)
│││││││ no matching method found for call signature: Core.Compiler.length(itr::Nothing)
││││││└───────────────────
│││┌ @ array.jl:981 Core.Compiler._append!(a::AbstractVector{T} where T, Core.Compiler.IteratorSize(iter::Nothing)::Core.Compiler.HasLength, iter::Nothing)
││││┌ @ array.jl:989 Core.Compiler.length(iter::Nothing)
│││││ no matching method found for call signature: Core.Compiler.length(iter::Nothing)
││││└────────────────
│││┌ @ bitarray.jl:782 Core.Compiler.BitVector(items::Core.Compiler.AbstractIterationInfo)
││││┌ @ bitarray.jl:575 Core.Compiler.gen_bitarrayN(Core.apply_type(Core.Compiler.BitArray, _::Int64)::Type{Core.Compiler.BitArray{1}}, Core.Compiler.IteratorSize(itr::Core.Compiler.AbstractIterationInfo)::Core.Compiler.HasLength, itr::Core.Compiler.AbstractIterationInfo)
│││││┌ @ bitarray.jl:604 Core.Compiler.gen_bitarray(itsz::Core.Compiler.HasLength, itr::Core.Compiler.AbstractIterationInfo)
││││││┌ @ bitarray.jl:598 Core.Compiler.length(itr::Core.Compiler.AbstractIterationInfo)
│││││││ no matching method found for call signature: Core.Compiler.length(itr::Core.Compiler.AbstractIterationInfo)
││││││└───────────────────
│││┌ @ array.jl:981 Core.Compiler._append!(a::AbstractVector{T} where T, Core.Compiler.IteratorSize(iter::Core.Compiler.AbstractIterationInfo)::Core.Compiler.HasLength, iter::Core.Compiler.AbstractIterationInfo)
││││┌ @ array.jl:989 Core.Compiler.length(iter::Core.Compiler.AbstractIterationInfo)
│││││ no matching method found for call signature: Core.Compiler.length(iter::Core.Compiler.AbstractIterationInfo)
││││└────────────────
│││┌ @ array.jl:981 Core.Compiler._append!(a::AbstractVector{T} where T, Core.Compiler.IteratorSize(iter::Vector{Any})::Core.Compiler.HasShape{1}, iter::Vector{Any})
││││┌ @ array.jl:989 Core.Compiler.resize!(a::AbstractVector{T} where T, Core.Compiler.+(n::Any, Core.typeassert(Core.Compiler.Int(Core.Compiler.length(iter::Vector{Any})::Int64)::Int64, Core.Compiler.Int)::Int64)::Any)
│││││┌ @ array.jl:1103 Core.Compiler.>(nl::Integer, l::Int64)
││││││┌ @ operators.jl:362 Core.Compiler.<(y::Int64, x::Integer)
│││││││┌ @ promotion.jl:360 Core.Compiler.promote(x::Int64, y::Integer)
││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Int64, y::Integer)::Tuple{Int64, Integer}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
│││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Int64, Integer})
││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Integer})::Tuple{Any, Any}, ", ", " and ")
│││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Integer})::Tuple{Any, Any}, ", ", " and ")
││││││││││└────────────────────
││┌ @ compiler/abstractinterpretation.jl:726 Core.Compiler.push!(Core.Compiler.copy(Core.Compiler.getindex(infos::Vector{Vector{Union{Nothing, Core.Compiler.AbstractIterationInfo}}}, j::Int64)::Vector{Union{Nothing, Core.Compiler.AbstractIterationInfo}})::Vector{Union{Nothing, Core.Compiler.AbstractIterationInfo}}, info::Union{Nothing, Core.Compiler.AbstractIterationInfo, Vector{Any}})
│││┌ @ array.jl:928 Core.Compiler.convert(_::Type{Union{Nothing, Core.Compiler.AbstractIterationInfo}}, item::Vector{Any})
││││ no matching method found for call signature: Core.Compiler.convert(_::Type{Union{Nothing, Core.Compiler.AbstractIterationInfo}}, item::Vector{Any})
│││└────────────────
┌ @ compiler/abstractinterpretation.jl:1336 Core.Compiler.empty!(Core.Compiler.getindex(Core.Compiler.getproperty(frame::Core.Compiler.InferenceState, :stmt_edges::Symbol)::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}})
│ for one of the union split cases, no matching method found for signature: Core.Compiler.empty!(Core.Compiler.getindex(Core.Compiler.getproperty(frame::Core.Compiler.InferenceState, :stmt_edges::Symbol)::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}})
└───────────────────────────────────────────
┌ @ compiler/abstractinterpretation.jl:1349 Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.GotoIfNot, :cond::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
│ for one of the union split cases, no matching method found for signature: Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.GotoIfNot, :cond::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
└───────────────────────────────────────────
┌ @ compiler/abstractinterpretation.jl:1391 Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.ReturnNode, :val::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
│ for one of the union split cases, no matching method found for signature: Core.Compiler.abstract_eval_value(interp::Core.Compiler.NativeInterpreter, Core.Compiler.getproperty(stmt::Core.ReturnNode, :val::Symbol)::Any, Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, pc::Int64)::Union{Nothing, Vector{Any}}, frame::Core.Compiler.InferenceState)
└───────────────────────────────────────────
┌ @ compiler/typeinfer.jl:227 Core.Compiler.finish(caller::Core.Compiler.InferenceState, interp::Core.Compiler.NativeInterpreter)
│┌ @ compiler/typeinfer.jl:421 Core.Compiler.append!(s_edges::Vector{Any}, Core.Compiler.getproperty(Core.Compiler.getproperty(me::Core.Compiler.InferenceState, :src::Symbol)::Core.CodeInfo, :edges::Symbol)::Any)
││┌ @ array.jl:977 Core.Compiler.-(Core.Compiler.length(a::Vector{Any})::Int64, n::Any)
│││┌ @ promotion.jl:322 Core.Compiler.promote(x::Int64, y::Number)
││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Int64, y::Number)::Tuple{Int64, Number}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
│││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Int64, Number})
││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Number})::Tuple{Any, Any}, ", ", " and ")
│││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Number})::Tuple{Any, Any}, ", ", " and ")
││││││└────────────────────
┌ @ compiler/typeinfer.jl:244 Core.Compiler.optimize(interp::Core.Compiler.NativeInterpreter, opt::Core.Compiler.OptimizationState, Core.Compiler.OptimizationParams(interp::Core.Compiler.NativeInterpreter)::Core.Compiler.OptimizationParams, result_type::Any)
│┌ @ compiler/optimize.jl:272 Core.Compiler.run_passes(Core.Compiler.getproperty(opt::Core.Compiler.OptimizationState, :src::Symbol)::Core.CodeInfo, nargs::Int64, opt::Core.Compiler.OptimizationState)
││┌ @ compiler/ssair/driver.jl:123 Core.Compiler.convert_to_ircode(ci::Core.CodeInfo, Core.Compiler.copy_exprargs(Core.Compiler.getproperty(ci::Core.CodeInfo, :code::Symbol)::Vector{Any})::Vector{Any}, preserve_coverage::Bool, nargs::Int64, sv::Core.Compiler.OptimizationState)
│││┌ @ compiler/ssair/driver.jl:52 Core.Compiler.insert!(Core.Compiler.getproperty(ci::Core.CodeInfo, :ssavaluetypes::Symbol)::Any, idx::Int64, Core.Compiler.Nothing)
││││┌ @ bitarray.jl:887 Core.Compiler._insert_int!(B::Core.Compiler.BitArray{1}, Core.Compiler.Int(i::Int64)::Int64, item::Type{Nothing})
│││││┌ @ bitarray.jl:892 Core.Compiler.convert(Core.Compiler.Bool, item::Type{Nothing})
││││││ no matching method found for call signature: Core.Compiler.convert(Core.Compiler.Bool, item::Type{Nothing})
│││││└───────────────────
│││┌ @ compiler/ssair/driver.jl:66 Core.Compiler.insert!(Core.Compiler.getproperty(ci::Core.CodeInfo, :ssavaluetypes::Symbol)::Any, Core.Compiler.+(idx::Int64, 1)::Int64, Core.apply_type(Core.Compiler.Union)::Type{Union{}})
││││┌ @ bitarray.jl:887 Core.Compiler._insert_int!(B::Core.Compiler.BitArray{1}, Core.Compiler.Int(i::Int64)::Int64, item::Type{Union{}})
│││││┌ @ bitarray.jl:892 Core.Compiler.convert(Core.Compiler.Bool, item::Type{Union{}})
││││││ no matching method found for call signature: Core.Compiler.convert(Core.Compiler.Bool, item::Type{Union{}})
│││││└───────────────────
││┌ @ compiler/ssair/driver.jl:124 Core.Compiler.slot2reg(ir::Core.Compiler.IRCode, ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
│││┌ @ compiler/ssair/driver.jl:117 Core.Compiler.construct_ssa!(ci::Core.CodeInfo, ir::Core.Compiler.IRCode, domtree::Core.Compiler.DomTree, defuse_insts::Vector{Core.Compiler.SlotInfo}, nargs::Int64, Core.Compiler.getproperty(sv::Core.Compiler.OptimizationState, :slottypes::Symbol)::Vector{Any})
││││┌ @ compiler/ssair/slot2ssa.jl:646 Core.Compiler.insert_node!(ir::Core.Compiler.IRCode, Core.Compiler.first_insert_for_bb(code::Vector{Any}, cfg::Core.Compiler.CFG, li::Int64)::Union{Nothing, Int64}, Core.apply_type(Core.Compiler.Union)::Type{Union{}}, node::Core.PhiCNode)
│││││ for one of the union split cases, no matching method found for signature: Core.Compiler.insert_node!(ir::Core.Compiler.IRCode, Core.Compiler.first_insert_for_bb(code::Vector{Any}, cfg::Core.Compiler.CFG, li::Int64)::Union{Nothing, Int64}, Core.apply_type(Core.Compiler.Union)::Type{Union{}}, node::Core.PhiCNode)
││││└──────────────────────────────────
││││┌ @ compiler/ssair/slot2ssa.jl:658 Core.Compiler.insert_node!(ir::Core.Compiler.IRCode, Core.Compiler.first_insert_for_bb(code::Vector{Any}, cfg::Core.Compiler.CFG, block::Int64)::Union{Nothing, Int64}, Core.apply_type(Core.Compiler.Union)::Type{Union{}}, node::Core.PhiNode)
│││││ for one of the union split cases, no matching method found for signature: Core.Compiler.insert_node!(ir::Core.Compiler.IRCode, Core.Compiler.first_insert_for_bb(code::Vector{Any}, cfg::Core.Compiler.CFG, block::Int64)::Union{Nothing, Int64}, Core.apply_type(Core.Compiler.Union)::Type{Union{}}, node::Core.PhiNode)
││││└──────────────────────────────────
││││┌ @ compiler/ssair/slot2ssa.jl:740 Core.Compiler.insert_node!(ir::Core.Compiler.IRCode, Core.Compiler.first_insert_for_bb(code::Vector{Any}, cfg::Core.Compiler.CFG, item::Int64)::Union{Nothing, Int64}, typ::Any, unode::Core.UpsilonNode, true)
│││││ for one of the union split cases, no matching method found for signature: Core.Compiler.insert_node!(ir::Core.Compiler.IRCode, Core.Compiler.first_insert_for_bb(code::Vector{Any}, cfg::Core.Compiler.CFG, item::Int64)::Union{Nothing, Int64}, typ::Any, unode::Core.UpsilonNode, true)
││││└──────────────────────────────────
││││┌ @ compiler/ssair/slot2ssa.jl:767 Core.Compiler.SSAValue(Core.Compiler.make_ssa!(ci::Core.CodeInfo, code::Vector{Any}, idx::Int64, id::Int64, typ::Any)::Union{Core.Argument, Int64})
│││││ for one of the union split cases, no matching method found for signature: Core.Compiler.SSAValue(Core.Compiler.make_ssa!(ci::Core.CodeInfo, code::Vector{Any}, idx::Int64, id::Int64, typ::Any)::Union{Core.Argument, Int64})
││││└──────────────────────────────────
││││┌ @ compiler/ssair/slot2ssa.jl:898 Core.Compiler.domsort_ssa!(ir::Core.Compiler.IRCode, domtree::Core.Compiler.DomTree)
│││││┌ @ compiler/ssair/slot2ssa.jl:396 Core.Compiler.sort(Core.Compiler.filter(#326::Core.Compiler.var"#326#333"{Int64}, cs::Vector{Int64})::Vector{Int64})
││││││┌ @ sort.jl:794 Core.Compiler.Sort.#sort#9(Core.Compiler.pairs(Core.NamedTuple()::NamedTuple{(), Tuple{}})::Core.Compiler.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, #self#::typeof(Core.Compiler.sort), v::Vector{Int64})
│││││││┌ @ sort.jl:794 Core.Compiler.Sort.sort!(Core.Compiler.Sort.copymutable(v::Vector{Int64})::Vector{Int64})
││││││││┌ @ sort.jl:735 Core.Compiler.Sort.#sort!#8(Core.Compiler.Sort.defalg(v::Vector{Int64})::Core.Compiler.Sort.QuickSortAlg, Core.Compiler.Sort.isless, Core.Compiler.Sort.identity, Core.Compiler.Sort.nothing, Core.Compiler.Sort.Forward, #self#::typeof(Core.Compiler.sort!), v::Vector{Int64})
│││││││││┌ @ sort.jl:743 Core.Compiler.Sort.sort_int_range!(v::Vector{Int64}, rangelen::Int64, min::Int64, _21::typeof(Core.Compiler.identity))
││││││││││┌ @ sort.jl:759 Core.Compiler.Sort.firstindex(x::Vector{Int64})
│││││││││││ variable Core.Compiler.Sort.firstindex is not defined: Core.Compiler.Sort.firstindex(x::Vector{Int64})
││││││││││└───────────────
││││││││││┌ @ sort.jl:764 Core.Compiler.setindex!(x::Vector{Int64}, val::Int64, j::Any)
│││││││││││┌ @ abstractarray.jl:1261 Core.Compiler._setindex!(Core.tuple(Core.Compiler.IndexStyle(A::Vector{Int64})::Core.Compiler.IndexLinear, A::Vector{Int64}, v::Int64)::Tuple{Core.Compiler.IndexLinear, Vector{Int64}, Int64}, Core.Compiler.to_indices(A::Vector{Int64}, I::Tuple{Any})::Tuple{Any}...)
││││││││││││┌ @ abstractarray.jl:1276 Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Int64})::Type{Vector{Int64}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
│││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Int64})::Type{Vector{Int64}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
││││││││││││└─────────────────────────
││┌ @ compiler/ssair/driver.jl:128 Core.Compiler.ssa_inlining_pass!(ir::Core.Compiler.IRCode, Core.Compiler.getproperty(ir::Core.Compiler.IRCode, :linetable::Symbol)::Vector{Core.LineInfoNode}, Core.Compiler.getproperty(sv::Core.Compiler.OptimizationState, :inlining::Symbol)::Core.Compiler.InliningState, Core.Compiler.getproperty(ci::Core.CodeInfo, :propagate_inbounds::Symbol)::Bool)
│││┌ @ compiler/ssair/inlining.jl:68 Core.Compiler.assemble_inline_todo!(ir::Core.Compiler.IRCode, state::Core.Compiler.InliningState)
││││┌ @ compiler/ssair/inlining.jl:1149 Core.Compiler.process_simple!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, state::Core.Compiler.InliningState)
│││││┌ @ compiler/ssair/inlining.jl:1014 Core.Compiler.inline_apply!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, sig::Core.Compiler.Signature, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :caches::Symbol)::Union{Nothing, Core.Compiler.InferenceCaches}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :params::Symbol)::Core.Compiler.OptimizationParams)
││││││┌ @ compiler/ssair/inlining.jl:967 Core.Compiler.rewrite_apply_exprargs!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, Core.Compiler.getproperty(stmt::Any, :args::Symbol)::Any, atypes::Vector{Any}, infos::Vector{Any}, arg_start::Int64, et::Nothing, caches::Nothing, params::Core.Compiler.OptimizationParams)
│││││││┌ @ compiler/ssair/inlining.jl:633 Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
│││││││└──────────────────────────────────
││││││┌ @ compiler/ssair/inlining.jl:967 Core.Compiler.rewrite_apply_exprargs!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, Core.Compiler.getproperty(stmt::Any, :args::Symbol)::Any, atypes::Vector{Any}, infos::Vector{Any}, arg_start::Int64, et::Core.Compiler.EdgeTracker, caches::Nothing, params::Core.Compiler.OptimizationParams)
│││││││┌ @ compiler/ssair/inlining.jl:633 Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
│││││││└──────────────────────────────────
││││││┌ @ compiler/ssair/inlining.jl:967 Core.Compiler.rewrite_apply_exprargs!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, Core.Compiler.getproperty(stmt::Any, :args::Symbol)::Any, atypes::Vector{Any}, infos::Vector{Any}, arg_start::Int64, et::Nothing, caches::Core.Compiler.InferenceCaches, params::Core.Compiler.OptimizationParams)
│││││││┌ @ compiler/ssair/inlining.jl:633 Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
│││││││└──────────────────────────────────
││││││┌ @ compiler/ssair/inlining.jl:967 Core.Compiler.rewrite_apply_exprargs!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, Core.Compiler.getproperty(stmt::Any, :args::Symbol)::Any, atypes::Vector{Any}, infos::Vector{Any}, arg_start::Int64, et::Core.Compiler.EdgeTracker, caches::Core.Compiler.InferenceCaches, params::Core.Compiler.OptimizationParams)
│││││││┌ @ compiler/ssair/inlining.jl:633 Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
││││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.with_atype(Core.Compiler.call_sig(ir::Core.Compiler.IRCode, new_stmt::Expr)::Union{Nothing, Core.Compiler.Signature})
│││││││└──────────────────────────────────
││││┌ @ compiler/ssair/inlining.jl:1172 Core.Compiler.inline_invoke!(ir::Core.Compiler.IRCode, idx::Int64, sig::Core.Compiler.Signature, invoke_data::Core.Compiler.InvokeData, state::Core.Compiler.InliningState, todo::Vector{Core.Compiler.Pair{Int64, Any}})
│││││┌ @ compiler/ssair/inlining.jl:993 Core.Compiler.intersect!(Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.WorldRange(Core.Compiler.getproperty(invoke_data::Core.Compiler.InvokeData, :min_valid::Symbol)::UInt64, Core.Compiler.getproperty(invoke_data::Core.Compiler.InvokeData, :max_valid::Symbol)::UInt64)::Core.Compiler.WorldRange)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.intersect!(Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.WorldRange(Core.Compiler.getproperty(invoke_data::Core.Compiler.InvokeData, :min_valid::Symbol)::UInt64, Core.Compiler.getproperty(invoke_data::Core.Compiler.InvokeData, :max_valid::Symbol)::UInt64)::Core.Compiler.WorldRange)
│││││└──────────────────────────────────
││││┌ @ compiler/ssair/inlining.jl:1182 Core.Compiler.recompute_method_matches(Core.Compiler.getproperty(sig::Core.Compiler.Signature, :atype::Symbol)::Type, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :params::Symbol)::Core.Compiler.OptimizationParams, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :method_table::Symbol)::Union{Nothing, Core.Compiler.MethodTableView})
│││││ for one of the union split cases, no matching method found for signature: Core.Compiler.recompute_method_matches(Core.Compiler.getproperty(sig::Core.Compiler.Signature, :atype::Symbol)::Type, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :params::Symbol)::Core.Compiler.OptimizationParams, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :method_table::Symbol)::Union{Nothing, Core.Compiler.MethodTableView})
││││└───────────────────────────────────
││││┌ @ compiler/ssair/inlining.jl:1192 Core.Compiler.recompute_method_matches(Core.Compiler.argtypes_to_type(union_sig::Vector{Any})::Type, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :params::Symbol)::Core.Compiler.OptimizationParams, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :method_table::Symbol)::Union{Nothing, Core.Compiler.MethodTableView})
│││││ for one of the union split cases, no matching method found for signature: Core.Compiler.recompute_method_matches(Core.Compiler.argtypes_to_type(union_sig::Vector{Any})::Type, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :params::Symbol)::Core.Compiler.OptimizationParams, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :method_table::Symbol)::Union{Nothing, Core.Compiler.MethodTableView})
││││└───────────────────────────────────
││││┌ @ compiler/ssair/inlining.jl:1199 Core.Compiler.analyze_single_call!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, stmt::Any, sig::Core.Compiler.Signature, calltype::Any, infos::Vector{Core.Compiler.MethodMatchInfo}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :et::Symbol)::Union{Nothing, Core.Compiler.EdgeTracker}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :caches::Symbol)::Union{Nothing, Core.Compiler.InferenceCaches}, Core.Compiler.getproperty(state::Core.Compiler.InliningState, :params::Symbol)::Core.Compiler.OptimizationParams)
│││││┌ @ compiler/ssair/inlining.jl:1081 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1084 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1086 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1093 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1106 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1087 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1121 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1122 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1081 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1084 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1086 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1093 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1106 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1087 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1121 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1122 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1081 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1084 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1086 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1093 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1106 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1087 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1121 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1122 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1081 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1084 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1086 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1093 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1106 Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.iterate(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, Core.getfield(_26::Tuple{Core.MethodMatch, Int64}, 2)::Int64)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1087 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1121 Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.length(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult})
│││││└───────────────────────────────────
│││││┌ @ compiler/ssair/inlining.jl:1122 Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
││││││ for one of the union split cases, no matching method found for signature: Core.Compiler.getindex(meth::Union{Core.Compiler.Missing, Core.Compiler.MethodLookupResult}, 1)
│││││└───────────────────────────────────
│││┌ @ compiler/ssair/inlining.jl:71 Core.Compiler.batch_inline!(todo::Vector{Core.Compiler.Pair{Int64, Any}}, ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, propagate_inbounds::Bool)
││││┌ @ compiler/ssair/inlining.jl:504 Core.Compiler.cfg_inline_unionsplit!(ir::Core.Compiler.IRCode, idx::Int64, Core.typeassert(item::Core.Compiler.UnionSplit, Core.Compiler.UnionSplit)::Core.Compiler.UnionSplit, state::Core.Compiler.CFGInliningState)
│││││┌ @ compiler/ssair/inlining.jl:211 Core.Compiler.inline_into_block!(state::Core.Compiler.CFGInliningState, block::Int64)
││││││┌ @ compiler/ssair/inlining.jl:107 Core.Compiler.setindex!(Core.Compiler.getproperty(state::Core.Compiler.CFGInliningState, :bb_rename::Symbol)::Vector{Int64}, Core.Compiler.:(Core.Compiler.+(l::Int64, 1)::Int64, Core.Compiler.+(l::Int64, Core.Compiler.length(new_range::Core.Compiler.UnitRange{Int64})::Int64)::Int64)::Core.Compiler.UnitRange{Int64}, new_range::Core.Compiler.UnitRange{Int64})
│││││││┌ @ array.jl:846 Core.Compiler.setindex_shape_check(X::Core.Compiler.UnitRange{Int64}, Core.Compiler.length(I::Core.Compiler.UnitRange{Int64})::Int64)
││││││││┌ @ indices.jl:242 Core.Compiler.throw_setindex_mismatch(X::Core.Compiler.UnitRange{Int64}, Core.tuple(i::Int64)::Tuple{Int64})
│││││││││┌ @ indices.jl:191 Core.Compiler.string("tried to assign ", Core.Compiler.length(X::Core.Compiler.UnitRange{Int64})::Any, " elements to ", Core.Compiler.getindex(I::Tuple{Int64}, 1)::Any, " destinations")
││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("tried to assign ", Core.Compiler.length(X::Core.Compiler.UnitRange{Int64})::Any, " elements to ", Core.Compiler.getindex(I::Tuple{Int64}, 1)::Any, " destinations")
│││││││││└──────────────────
│││││││││┌ @ indices.jl:193 Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)
││││││││││ variable Core.Compiler.dims2string is not defined: Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)
│││││││││└──────────────────
│││││││││┌ @ indices.jl:193 Core.Compiler.dims2string(I::Tuple{Int64})
││││││││││ variable Core.Compiler.dims2string is not defined: Core.Compiler.dims2string(I::Tuple{Int64})
│││││││││└──────────────────
│││││││││┌ @ indices.jl:193 Core.Compiler.string("tried to assign ", Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)::Any, " array to ", Core.Compiler.dims2string(I::Tuple{Int64})::Any, " destination")
││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("tried to assign ", Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)::Any, " array to ", Core.Compiler.dims2string(I::Tuple{Int64})::Any, " destination")
│││││││││└──────────────────
││││┌ @ compiler/ssair/inlining.jl:551 Core.Compiler.ir_inline_unionsplit!(compact::Core.Compiler.IncrementalCompact, idx::Int64, argexprs::Any, linetable::Vector{Core.LineInfoNode}, item::Core.Compiler.UnionSplit, boundscheck::Symbol, Core.Compiler.getproperty(state::Core.Compiler.CFGInliningState, :todo_bbs::Symbol)::Vector{Tuple{Int64, Int64}})
│││││┌ @ compiler/ssair/inlining.jl:457 Core.Compiler.setindex!(argexprs′::Vector{Any}, Core.Compiler.insert_node_here!(compact::Core.Compiler.IncrementalCompact, Core.Compiler.PiNode(Core.Compiler.getindex(argexprs′::Vector{Any}, i::Any)::Any, m::Any)::Core.PiNode, m::Any, line::Int32)::Core.SSAValue, i::Any)
││││││┌ @ abstractarray.jl:1261 Core.Compiler._setindex!(Core.tuple(Core.Compiler.IndexStyle(A::Vector{Any})::Core.Compiler.IndexLinear, A::Vector{Any}, v::Core.SSAValue)::Tuple{Core.Compiler.IndexLinear, Vector{Any}, Core.SSAValue}, Core.Compiler.to_indices(A::Vector{Any}, I::Tuple{Any})::Tuple{Any}...)
│││││││┌ @ abstractarray.jl:1276 Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Any})::Type{Vector{Any}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Any})::Type{Vector{Any}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
│││││││└─────────────────────────
││┌ @ compiler/ssair/driver.jl:132 Core.Compiler.getfield_elim_pass!(ir::Core.Compiler.IRCode)
│││┌ @ compiler/ssair/passes.jl:617 Core.Compiler.union!(mid::Core.Compiler.IdSet{Int64}, intermediaries::Core.Compiler.IdSet{Any})
││││┌ @ abstractset.jl:91 Core.Compiler.push!(s::Core.Compiler.IdSet{Int64}, x::Any)
│││││┌ @ idset.jl:20 Core.Compiler.setindex!(Core.Compiler.getproperty(s::Core.Compiler.IdSet{Int64}, :dict::Symbol)::Core.Compiler.IdDict{Int64, Nothing}, Core.Compiler.nothing, x::Any)
││││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key::Any)
│││││││ variable Core.Compiler.limitrepr is not defined: Core.Compiler.limitrepr(key::Any)
││││││└────────────────
││││││┌ @ iddict.jl:87 Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
│││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
││││││└────────────────
││┌ @ compiler/ssair/driver.jl:137 Core.Compiler.type_lift_pass!(ir::Core.Compiler.IRCode)
│││┌ @ compiler/ssair/passes.jl:974 Core.Compiler.setindex!(lifted_undef::Core.Compiler.IdDict{Int64, Any}, new_phi::Union{Bool, Core.SSAValue}, stmt_id::Any)
││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key::Any)
│││││ variable Core.Compiler.limitrepr is not defined: Core.Compiler.limitrepr(key::Any)
││││└────────────────
││││┌ @ iddict.jl:87 Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
│││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
││││└────────────────
││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key::Any)
│││││ variable Core.Compiler.limitrepr is not defined: Core.Compiler.limitrepr(key::Any)
││││└────────────────
││││┌ @ iddict.jl:87 Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
│││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
││││└────────────────
│┌ @ compiler/optimize.jl:273 Core.Compiler.finish(opt::Core.Compiler.OptimizationState, params::Core.Compiler.OptimizationParams, ir::Core.Compiler.IRCode, result::Any)
││┌ @ compiler/optimize.jl:263 Core.Compiler.isinlineable(def::Method, opt::Core.Compiler.OptimizationState, params::Core.Compiler.OptimizationParams, union_penalties::Bool, bonus::Int64)
│││┌ @ compiler/optimize.jl:155 Core.Compiler.inline_worthy(Core.Compiler.getproperty(Core.Compiler.getproperty(me::Core.Compiler.OptimizationState, :src::Symbol)::Core.CodeInfo, :code::Symbol)::Vector{Any}, Core.Compiler.getproperty(me::Core.Compiler.OptimizationState, :src::Symbol)::Core.CodeInfo, Core.Compiler.getproperty(me::Core.Compiler.OptimizationState, :sptypes::Symbol)::Vector{Any}, Core.Compiler.getproperty(me::Core.Compiler.OptimizationState, :slottypes::Symbol)::Vector{Any}, params::Core.Compiler.OptimizationParams, union_penalties::Bool, Core.Compiler.+(cost_threshold::Int64, bonus::Int64)::Int64)
││││┌ @ compiler/optimize.jl:413 Core.Compiler.statement_or_branch_cost(stmt::Any, line::Int64, src::Core.CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any}, union_penalties::Bool, params::Core.Compiler.OptimizationParams, throw_blocks::Union{Nothing, Core.Compiler.BitSet})
│││││┌ @ compiler/optimize.jl:394 Core.Compiler.in(line::Int64, throw_blocks::Nothing)
││││││┌ @ operators.jl:1189 Core.Compiler.iterate(itr::Nothing)
│││││││ no matching method found for call signature: Core.Compiler.iterate(itr::Nothing)
││││││└─────────────────────
│││││┌ @ compiler/optimize.jl:394 Core.Compiler.statement_cost(stmt::Expr, line::Int64, src::Core.CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any}, union_penalties::Bool, params::Core.Compiler.OptimizationParams, _11::Bool)
││││││┌ @ compiler/optimize.jl:374 Core.Compiler.statement_cost(a::Expr, -1, src::Core.CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any}, params::Core.Compiler.OptimizationParams, error_path::Bool)
│││││││ no matching method found for call signature: Core.Compiler.statement_cost(a::Expr, -1, src::Core.CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any}, params::Core.Compiler.OptimizationParams, error_path::Bool)
││││││└────────────────────────────
┌ @ compiler/typeinfer.jl:206 Core.Compiler.Timings.exit_current_timer::typeof(Core.Compiler.Timings.exit_current_timer)(frame::Core.Compiler.InferenceState)
│┌ @ compiler/typeinfer.jl:164 Core.Compiler.Timings.backtrace()
││┌ @ error.jl:113 Core.Compiler._reformat_bt(Core.typeassert(bt1::Any, Core.apply_type(Core.Compiler.Vector, Core.apply_type(Core.Compiler.Ptr, Core.Compiler.Cvoid)::Type{Ptr{Nothing}})::Type{Vector{Ptr{Nothing}}})::Vector{Ptr{Nothing}}, Core.typeassert(bt2::Any, Core.apply_type(Core.Compiler.Vector, Core.Compiler.Any)::Type{Vector{Any}})::Vector{Any})
│││┌ @ error.jl:93 Core.Compiler.string("Unexpected extended backtrace entry tag ", tag::UInt64, " at bt[", i::Int64, "]")
││││ variable Core.Compiler.string is not defined: Core.Compiler.string("Unexpected extended backtrace entry tag ", tag::UInt64, " at bt[", i::Int64, "]")
│││└───────────────
```

</p>
</details>

> on this PR
<details><summary>20 possible errors found</summary>
<p>

```julia
┌ @ compiler/typeinfer.jl:205 Core.Compiler._typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
│┌ @ compiler/typeinfer.jl:214 Core.Compiler.typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
││┌ @ compiler/abstractinterpretation.jl:1520 Core.Compiler.typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
│││┌ @ compiler/abstractinterpretation.jl:1385 Core.Compiler.stupdate!(Core.Compiler.getindex(s::Vector{Union{Nothing, Vector{Any}}}, l::Int64)::Union{Nothing, Vector{Any}}, changes_else::Union{Core.Compiler.StateUpdate, Vector{Any}})
││││┌ @ compiler/typelattice.jl:302 Core.Compiler.stupdate!(state::Vector{Any}, Core.Compiler.getproperty(changes::Core.Compiler.StateUpdate, :state::Symbol)::Vector{Any})
│││││┌ @ compiler/typelattice.jl:339 Core.Compiler.smerge(oldtype::Any, newtype::Any)
││││││┌ @ compiler/typelattice.jl:256 Core.Compiler.tmerge(Core.Compiler.getproperty(sa::Core.Compiler.VarState, :typ::Symbol)::Any, Core.Compiler.getproperty(sb::Core.Compiler.VarState, :typ::Symbol)::Any)
│││││││┌ @ compiler/tfuncs.jl:831 Core.Compiler.getfield_tfunc(_ts::Any, name::Union{Core.Const, Type{Int64}})
││││││││┌ @ compiler/tfuncs.jl:844 Core.Compiler.==(Core.Compiler.length(ftypes::Any)::Any, 1)
│││││││││┌ @ promotion.jl:359 Core.Compiler.promote(x::Number, y::Int64)
││││││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Number, y::Int64)::Tuple{Number, Int64}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
│││││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Number, Int64})
││││││││││││┌ @ promotion.jl:315 Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Number, Int64})
│││││││││││││┌ @ tuple.jl:214 f::Core.Compiler.var"#39#40"(Core.Compiler.getindex(t::Tuple{Number, Int64}, 1)::Number)
││││││││││││││┌ @ promotion.jl:316 Core.Compiler.string(Core.Compiler.typeof(x::Number)::Type{var"#s446"} where var"#s446"<:Number)
│││││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.typeof(x::Number)::Type{var"#s446"} where var"#s446"<:Number)
││││││││││││││└────────────────────
│││││││││││││┌ @ tuple.jl:214 f::Core.Compiler.var"#39#40"(Core.Compiler.getindex(t::Tuple{Number, Int64}, 2)::Int64)
││││││││││││││┌ @ promotion.jl:316 Core.Compiler.string(Core.Compiler.typeof(x::Int64)::Type{Int64})
│││││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.typeof(x::Int64)::Type{Int64})
││││││││││││││└────────────────────
││││││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Number, Int64})::Tuple{Any, Any}, ", ", " and ")
│││││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Number, Int64})::Tuple{Any, Any}, ", ", " and ")
││││││││││││└────────────────────
┌ @ compiler/typeinfer.jl:227 Core.Compiler.finish(caller::Core.Compiler.InferenceState, interp::Core.Compiler.NativeInterpreter)
│┌ @ compiler/typeinfer.jl:421 Core.Compiler.append!(s_edges::Vector{Any}, Core.Compiler.getproperty(Core.Compiler.getproperty(me::Core.Compiler.InferenceState, :src::Symbol)::Core.CodeInfo, :edges::Symbol)::Any)
││┌ @ array.jl:977 Core.Compiler.-(Core.Compiler.length(a::Vector{Any})::Int64, n::Any)
│││┌ @ int.jl:924 Core.Compiler.not_sametype(Core.tuple(a::Int64, b::Integer)::Tuple{Int64, Integer}, Core.tuple(aT::Any, bT::Any)::Tuple{Any, Any})
││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Int64, Integer})
│││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Integer})::Tuple{Any, Any}, ", ", " and ")
││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Integer})::Tuple{Any, Any}, ", ", " and ")
│││││└────────────────────
│││┌ @ promotion.jl:322 Core.Compiler.promote(x::Int64, y::Number)
││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Int64, y::Number)::Tuple{Int64, Number}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
│││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Int64, Number})
││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Number})::Tuple{Any, Any}, ", ", " and ")
│││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Int64, Number})::Tuple{Any, Any}, ", ", " and ")
││││││└────────────────────
┌ @ compiler/typeinfer.jl:244 Core.Compiler.optimize(interp::Core.Compiler.NativeInterpreter, opt::Core.Compiler.OptimizationState, Core.Compiler.OptimizationParams(interp::Core.Compiler.NativeInterpreter)::Core.Compiler.OptimizationParams, result_type::Any)
│┌ @ compiler/optimize.jl:272 Core.Compiler.run_passes(Core.Compiler.getproperty(opt::Core.Compiler.OptimizationState, :src::Symbol)::Core.CodeInfo, nargs::Int64, opt::Core.Compiler.OptimizationState)
││┌ @ compiler/ssair/driver.jl:125 Core.Compiler.slot2reg(ir::Core.Compiler.IRCode, ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
│││┌ @ compiler/ssair/driver.jl:118 Core.Compiler.construct_ssa!(ci::Core.CodeInfo, ir::Core.Compiler.IRCode, domtree::Core.Compiler.DomTree, defuse_insts::Vector{Core.Compiler.SlotInfo}, nargs::Int64, Core.Compiler.getproperty(sv::Core.Compiler.OptimizationState, :slottypes::Symbol)::Vector{Any})
││││┌ @ compiler/ssair/slot2ssa.jl:898 Core.Compiler.domsort_ssa!(ir::Core.Compiler.IRCode, domtree::Core.Compiler.DomTree)
│││││┌ @ compiler/ssair/slot2ssa.jl:396 Core.Compiler.sort(Core.Compiler.filter(#326::Core.Compiler.var"#326#333"{Int64}, cs::Vector{Int64})::Vector{Int64})
││││││┌ @ sort.jl:794 Core.Compiler.Sort.#sort#9(Core.Compiler.pairs(Core.NamedTuple()::NamedTuple{(), Tuple{}})::Core.Compiler.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, #self#::typeof(Core.Compiler.sort), v::Vector{Int64})
│││││││┌ @ sort.jl:794 Core.Compiler.Sort.sort!(Core.Compiler.Sort.copymutable(v::Vector{Int64})::Vector{Int64})
││││││││┌ @ sort.jl:735 Core.Compiler.Sort.#sort!#8(Core.Compiler.Sort.defalg(v::Vector{Int64})::Core.Compiler.Sort.QuickSortAlg, Core.Compiler.Sort.isless, Core.Compiler.Sort.identity, Core.Compiler.Sort.nothing, Core.Compiler.Sort.Forward, #self#::typeof(Core.Compiler.sort!), v::Vector{Int64})
│││││││││┌ @ sort.jl:743 Core.Compiler.Sort.sort_int_range!(v::Vector{Int64}, rangelen::Int64, min::Int64, _21::typeof(Core.Compiler.identity))
││││││││││┌ @ sort.jl:759 Core.Compiler.Sort.firstindex(x::Vector{Int64})
│││││││││││ variable Core.Compiler.Sort.firstindex is not defined: Core.Compiler.Sort.firstindex(x::Vector{Int64})
││││││││││└───────────────
││││││││││┌ @ sort.jl:764 Core.Compiler.setindex!(x::Vector{Int64}, val::Int64, j::Any)
│││││││││││┌ @ abstractarray.jl:1261 Core.Compiler._setindex!(Core.tuple(Core.Compiler.IndexStyle(A::Vector{Int64})::Core.Compiler.IndexLinear, A::Vector{Int64}, v::Int64)::Tuple{Core.Compiler.IndexLinear, Vector{Int64}, Int64}, Core.Compiler.to_indices(A::Vector{Int64}, I::Tuple{Any})::Tuple{Any}...)
││││││││││││┌ @ abstractarray.jl:1276 Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Int64})::Type{Vector{Int64}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
│││││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Int64})::Type{Vector{Int64}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
││││││││││││└─────────────────────────
││┌ @ compiler/ssair/driver.jl:129 Core.Compiler.ssa_inlining_pass!(ir::Core.Compiler.IRCode, Core.Compiler.getproperty(ir::Core.Compiler.IRCode, :linetable::Symbol)::Vector{Core.LineInfoNode}, Core.Compiler.getproperty(sv::Core.Compiler.OptimizationState, :inlining::Symbol)::Core.Compiler.InliningState, Core.Compiler.getproperty(ci::Core.CodeInfo, :propagate_inbounds::Symbol)::Bool)
│││┌ @ compiler/ssair/inlining.jl:71 Core.Compiler.batch_inline!(todo::Vector{Core.Compiler.Pair{Int64, Any}}, ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, propagate_inbounds::Bool)
││││┌ @ compiler/ssair/inlining.jl:504 Core.Compiler.cfg_inline_unionsplit!(ir::Core.Compiler.IRCode, idx::Int64, Core.typeassert(item::Core.Compiler.UnionSplit, Core.Compiler.UnionSplit)::Core.Compiler.UnionSplit, state::Core.Compiler.CFGInliningState)
│││││┌ @ compiler/ssair/inlining.jl:211 Core.Compiler.inline_into_block!(state::Core.Compiler.CFGInliningState, block::Int64)
││││││┌ @ compiler/ssair/inlining.jl:107 Core.Compiler.setindex!(Core.Compiler.getproperty(state::Core.Compiler.CFGInliningState, :bb_rename::Symbol)::Vector{Int64}, Core.Compiler.:(Core.Compiler.+(l::Int64, 1)::Int64, Core.Compiler.+(l::Int64, Core.Compiler.length(new_range::Core.Compiler.UnitRange{Int64})::Int64)::Int64)::Core.Compiler.UnitRange{Int64}, new_range::Core.Compiler.UnitRange{Int64})
│││││││┌ @ array.jl:846 Core.Compiler.setindex_shape_check(X::Core.Compiler.UnitRange{Int64}, Core.Compiler.length(I::Core.Compiler.UnitRange{Int64})::Int64)
││││││││┌ @ indices.jl:242 Core.Compiler.throw_setindex_mismatch(X::Core.Compiler.UnitRange{Int64}, Core.tuple(i::Int64)::Tuple{Int64})
│││││││││┌ @ indices.jl:191 Core.Compiler.string("tried to assign ", Core.Compiler.length(X::Core.Compiler.UnitRange{Int64})::Any, " elements to ", Core.Compiler.getindex(I::Tuple{Int64}, 1)::Any, " destinations")
││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("tried to assign ", Core.Compiler.length(X::Core.Compiler.UnitRange{Int64})::Any, " elements to ", Core.Compiler.getindex(I::Tuple{Int64}, 1)::Any, " destinations")
│││││││││└──────────────────
│││││││││┌ @ indices.jl:193 Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)
││││││││││ variable Core.Compiler.dims2string is not defined: Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)
│││││││││└──────────────────
│││││││││┌ @ indices.jl:193 Core.Compiler.dims2string(I::Tuple{Int64})
││││││││││ variable Core.Compiler.dims2string is not defined: Core.Compiler.dims2string(I::Tuple{Int64})
│││││││││└──────────────────
│││││││││┌ @ indices.jl:193 Core.Compiler.string("tried to assign ", Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)::Any, " array to ", Core.Compiler.dims2string(I::Tuple{Int64})::Any, " destination")
││││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("tried to assign ", Core.Compiler.dims2string(Core.Compiler.size(X::Core.Compiler.UnitRange{Int64})::Any)::Any, " array to ", Core.Compiler.dims2string(I::Tuple{Int64})::Any, " destination")
│││││││││└──────────────────
││││┌ @ compiler/ssair/inlining.jl:549 Core.Compiler.ir_inline_item!(compact::Core.Compiler.IncrementalCompact, idx::Int64, argexprs::Any, linetable::Vector{Core.LineInfoNode}, item::Core.Compiler.InliningTodo, boundscheck::Symbol, Core.Compiler.getproperty(state::Core.Compiler.CFGInliningState, :todo_bbs::Symbol)::Vector{Tuple{Int64, Int64}})
│││││┌ @ compiler/ssair/inlining.jl:315 Core.Compiler.:(nargs_def::Any, Core.Compiler.lastindex(argexprs::Vector{Any})::Int64)
││││││┌ @ range.jl:3 Core.Compiler.promote(a::Real, b::Int64)
│││││││┌ @ promotion.jl:292 Core.Compiler.not_sametype(Core.tuple(x::Real, y::Int64)::Tuple{Real, Int64}, Core.tuple(px::Any, py::Any)::Tuple{Any, Any})
││││││││┌ @ promotion.jl:309 Core.Compiler.sametype_error(x::Tuple{Real, Int64})
│││││││││┌ @ promotion.jl:315 Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Real, Int64})::Tuple{Any, Any}, ", ", " and ")
││││││││││ variable Core.Compiler.join is not defined: Core.Compiler.join(Core.Compiler.map(#39::Core.Compiler.var"#39#40", input::Tuple{Real, Int64})::Tuple{Any, Any}, ", ", " and ")
│││││││││└────────────────────
││││┌ @ compiler/ssair/inlining.jl:551 Core.Compiler.ir_inline_unionsplit!(compact::Core.Compiler.IncrementalCompact, idx::Int64, argexprs::Any, linetable::Vector{Core.LineInfoNode}, item::Core.Compiler.UnionSplit, boundscheck::Symbol, Core.Compiler.getproperty(state::Core.Compiler.CFGInliningState, :todo_bbs::Symbol)::Vector{Tuple{Int64, Int64}})
│││││┌ @ compiler/ssair/inlining.jl:457 Core.Compiler.setindex!(argexprs′::Vector{Any}, Core.Compiler.insert_node_here!(compact::Core.Compiler.IncrementalCompact, Core.Compiler.PiNode(Core.Compiler.getindex(argexprs′::Vector{Any}, i::Any)::Any, m::Any)::Core.PiNode, m::Any, line::Int32)::Core.SSAValue, i::Any)
││││││┌ @ abstractarray.jl:1261 Core.Compiler._setindex!(Core.tuple(Core.Compiler.IndexStyle(A::Vector{Any})::Core.Compiler.IndexLinear, A::Vector{Any}, v::Core.SSAValue)::Tuple{Core.Compiler.IndexLinear, Vector{Any}, Core.SSAValue}, Core.Compiler.to_indices(A::Vector{Any}, I::Tuple{Any})::Tuple{Any}...)
│││││││┌ @ abstractarray.jl:1276 Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Any})::Type{Vector{Any}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
││││││││ variable Core.Compiler.string is not defined: Core.Compiler.string("setindex! for ", Core.Compiler.typeof(A::Vector{Any})::Type{Vector{Any}}, " with types ", Core.Compiler.typeof(I::Tuple{Any})::Type{var"#s446"} where var"#s446"<:Tuple{Any}, " is not supported")
│││││││└─────────────────────────
││┌ @ compiler/ssair/driver.jl:133 Core.Compiler.getfield_elim_pass!(ir::Core.Compiler.IRCode)
│││┌ @ compiler/ssair/passes.jl:617 Core.Compiler.union!(mid::Core.Compiler.IdSet{Int64}, intermediaries::Core.Compiler.IdSet{Any})
││││┌ @ abstractset.jl:91 Core.Compiler.push!(s::Core.Compiler.IdSet{Int64}, x::Any)
│││││┌ @ idset.jl:20 Core.Compiler.setindex!(Core.Compiler.getproperty(s::Core.Compiler.IdSet{Int64}, :dict::Symbol)::Core.Compiler.IdDict{Int64, Nothing}, Core.Compiler.nothing, x::Any)
││││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key::Any)
│││││││ variable Core.Compiler.limitrepr is not defined: Core.Compiler.limitrepr(key::Any)
││││││└────────────────
││││││┌ @ iddict.jl:87 Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
│││││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
││││││└────────────────
││┌ @ compiler/ssair/driver.jl:138 Core.Compiler.type_lift_pass!(ir::Core.Compiler.IRCode)
│││┌ @ compiler/ssair/passes.jl:974 Core.Compiler.setindex!(lifted_undef::Core.Compiler.IdDict{Int64, Any}, new_phi::Union{Bool, Core.SSAValue}, stmt_id::Any)
││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key::Any)
│││││ variable Core.Compiler.limitrepr is not defined: Core.Compiler.limitrepr(key::Any)
││││└────────────────
││││┌ @ iddict.jl:87 Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
│││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
││││└────────────────
││││┌ @ iddict.jl:87 Core.Compiler.limitrepr(key::Any)
│││││ variable Core.Compiler.limitrepr is not defined: Core.Compiler.limitrepr(key::Any)
││││└────────────────
││││┌ @ iddict.jl:87 Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
│││││ variable Core.Compiler.string is not defined: Core.Compiler.string(Core.Compiler.limitrepr(key::Any)::Any, " is not a valid key for type ", _::Type{Int64})
││││└────────────────
┌ @ compiler/typeinfer.jl:206 Core.Compiler.Timings.exit_current_timer::typeof(Core.Compiler.Timings.exit_current_timer)(frame::Core.Compiler.InferenceState)
│┌ @ compiler/typeinfer.jl:164 Core.Compiler.Timings.backtrace()
││┌ @ error.jl:113 Core.Compiler._reformat_bt(Core.typeassert(bt1::Any, Core.apply_type(Core.Compiler.Vector, Core.apply_type(Core.Compiler.Ptr, Core.Compiler.Cvoid)::Type{Ptr{Nothing}})::Type{Vector{Ptr{Nothing}}})::Vector{Ptr{Nothing}}, Core.typeassert(bt2::Any, Core.apply_type(Core.Compiler.Vector, Core.Compiler.Any)::Type{Vector{Any}})::Vector{Any})
│││┌ @ error.jl:93 Core.Compiler.string("Unexpected extended backtrace entry tag ", tag::UInt64, " at bt[", i::Int64, "]")
││││ variable Core.Compiler.string is not defined: Core.Compiler.string("Unexpected extended backtrace entry tag ", tag::UInt64, " at bt[", i::Int64, "]")
│││└───────────────
```

</p>
</details>
