### PR TITLE
Add type-instability warning to `getproperty` docs

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2452,6 +2452,14 @@ typeassert
 
 The syntax `a.b` calls `getproperty(a, :b)`.
 
+!!! warning
+
+    Using the dot operator in a custom implementation of `getproperty` invokes
+    `getproperty` recursively, which hampers type inference and can cause
+    [type-instability](@ref man-type-stability). To minimize the risk of type
+    instability, implement `getproperty` in terms of [`getfield`](@ref). For
+    example, replace `a.b` with `getfield(a, :b)`.
+
 # Examples
 ```jldoctest
 julia> struct MyType


### PR DESCRIPTION
I was recently tripped up by a performance problem with a custom implementation of `getproperty`. In summary, the problem is that using the dot operator within `getproperty` invokes `getproperty` recursively, which complicates the job of the type inference system in Julia, and causes type-instability. See the issue I posted to discourse for more details: https://discourse.julialang.org/t/type-inference-problem-with-getproperty/54585.

Using the dot operator is the obvious way to implement `getproperty`, especially considering the example in the official documentation does so. I think many other users will encounter this same problem, and many of them will be unaware of it. I am guessing it will be difficult to improve the optimizer to handle recursive `getproperty` calls more intelligently, so instead I propose adding a documentation blurb to warn users about this problem, and how to work around it, which this PR does.