### PR TITLE
faster, more accurate log2, log10

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -383,55 +383,6 @@ expm1(x)
 expm1(x::Float64) = ccall((:expm1,libm), Float64, (Float64,), x)
 expm1(x::Float32) = ccall((:expm1f,libm), Float32, (Float32,), x)
 
-"""
-    exp2(x)
-
-Compute the base 2 exponential of `x`, in other words ``2^x``.
-
-# Examples
-```jldoctest
-julia> exp2(5)
-32.0
-```
-"""
-exp2(x::AbstractFloat) = 2^x
-
-"""
-    exp10(x)
-
-Compute the base 10 exponential of `x`, in other words ``10^x``.
-
-# Examples
-```jldoctest
-julia> exp10(2)
-100.0
-```
-"""
-exp10(x::AbstractFloat) = 10^x
-
-for f in (:sin, :cos, :tan,  :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :expm1, :log, :log1p)
-    @eval function ($f)(x::Real)
-        xf = float(x)
-        x === xf && throw(MethodError($f, (x,)))
-        return ($f)(xf)
-    end
-end
-
-# functions with special cases for integer arguments
-@inline function exp2(x::Base.BitInteger)
-    if x > 1023
-        Inf64
-    elseif x <= -1023
-        # if -1073 < x <= -1023 then Result will be a subnormal number
-        # Hex literal with padding must be used to work on 32bit machine
-        reinterpret(Float64, 0x0000_0000_0000_0001 << ((x + 1074) % UInt))
-    else
-        # We will cast everything to Int64 to avoid errors in case of Int128
-        # If x is a Int128, and is outside the range of Int64, then it is not -1023<x<=1023
-        reinterpret(Float64, (exponent_bias(Float64) + (x % Int64)) << (significand_bits(Float64) % UInt))
-    end
-end
-
 # utility for converting NaN return to DomainError
 # the branch in nan_dom_err prevents its callers from inlining, so be sure to force it
 # until the heuristics can be improved

--- a/base/math.jl
+++ b/base/math.jl
@@ -383,6 +383,55 @@ expm1(x)
 expm1(x::Float64) = ccall((:expm1,libm), Float64, (Float64,), x)
 expm1(x::Float32) = ccall((:expm1f,libm), Float32, (Float32,), x)
 
+"""
+    exp2(x)
+
+Compute the base 2 exponential of `x`, in other words ``2^x``.
+
+# Examples
+```jldoctest
+julia> exp2(5)
+32.0
+```
+"""
+exp2(x::AbstractFloat) = 2^x
+
+"""
+    exp10(x)
+
+Compute the base 10 exponential of `x`, in other words ``10^x``.
+
+# Examples
+```jldoctest
+julia> exp10(2)
+100.0
+```
+"""
+exp10(x::AbstractFloat) = 10^x
+
+for f in (:sin, :cos, :tan,  :sinh, :cosh, :tanh, :atan, :acos, :asin, :asinh, :acosh, :atanh, :expm1, :log, :log1p)
+    @eval function ($f)(x::Real)
+        xf = float(x)
+        x === xf && throw(MethodError($f, (x,)))
+        return ($f)(xf)
+    end
+end
+
+# functions with special cases for integer arguments
+@inline function exp2(x::Base.BitInteger)
+    if x > 1023
+        Inf64
+    elseif x <= -1023
+        # if -1073 < x <= -1023 then Result will be a subnormal number
+        # Hex literal with padding must be used to work on 32bit machine
+        reinterpret(Float64, 0x0000_0000_0000_0001 << ((x + 1074) % UInt))
+    else
+        # We will cast everything to Int64 to avoid errors in case of Int128
+        # If x is a Int128, and is outside the range of Int64, then it is not -1023<x<=1023
+        reinterpret(Float64, (exponent_bias(Float64) + (x % Int64)) << (significand_bits(Float64) % UInt))
+    end
+end
+
 # utility for converting NaN return to DomainError
 # the branch in nan_dom_err prevents its callers from inlining, so be sure to force it
 # until the heuristics can be improved
@@ -530,12 +579,6 @@ Stacktrace:
 ```
 """
 log1p(x)
-for f in (:log2, :log10)
-    @eval begin
-        @inline ($f)(x::Float64) = nan_dom_err(ccall(($(string(f)), libm), Float64, (Float64,), x), x)
-        @inline ($f)(x::Float32) = nan_dom_err(ccall(($(string(f, "f")), libm), Float32, (Float32,), x), x)
-    end
-end
 
 @inline function sqrt(x::Union{Float32,Float64})
     x < zero(x) && throw_complex_domainerror(:sqrt, x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -303,8 +303,7 @@ Stacktrace:
 ```
 
 !!! note
-    If `b` is a power of 2 or 10, [`
-`](@ref) or [`log10`](@ref) should be used, as these will
+    If `b` is a power of 2 or 10, [`log2`](@ref) or [`log10`](@ref) should be used, as these will
     typically be faster and more accurate. For example,
 
     ```jldoctest

--- a/base/math.jl
+++ b/base/math.jl
@@ -303,7 +303,8 @@ Stacktrace:
 ```
 
 !!! note
-    If `b` is a power of 2 or 10, [`log2`](@ref) or [`log10`](@ref) should be used, as these will
+    If `b` is a power of 2 or 10, [`
+`](@ref) or [`log10`](@ref) should be used, as these will
     typically be faster and more accurate. For example,
 
     ```jldoctest
@@ -475,9 +476,9 @@ julia> log2(10)
 
 julia> log2(-2)
 ERROR: DomainError with -2.0:
-NaN result for non-NaN input.
+log2 will only return a complex result if called with a complex argument. Try log2(Complex(x)).
 Stacktrace:
- [1] nan_dom_err at ./math.jl:325 [inlined]
+ [1] throw_complex_domainerror(f::Symbol, x::Float64) at ./math.jl:31
 [...]
 ```
 """
@@ -499,9 +500,9 @@ julia> log10(2)
 
 julia> log10(-2)
 ERROR: DomainError with -2.0:
-NaN result for non-NaN input.
+log10 will only return a complex result if called with a complex argument. Try log10(Complex(x)).
 Stacktrace:
- [1] nan_dom_err at ./math.jl:325 [inlined]
+ [1] throw_complex_domainerror(f::Symbol, x::Float64) at ./math.jl:31
 [...]
 ```
 """

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -296,7 +296,7 @@ for (func, base) in (:log2=>Val(2), :log=>Val(:ℯ), :log10=>Val(10))
             elseif isnan(x)
                 NaN
             else
-                throw_complex_domainerror(:log, x)
+                throw_complex_domainerror(Symbol($func), x)
             end
         end
 
@@ -332,7 +332,7 @@ for (func, base) in (:log2=>Val(2), :log=>Val(:ℯ), :log10=>Val(10))
             elseif isnan(x)
                 NaN32
             else
-                throw_complex_domainerror(:log, x)
+                throw_complex_domainerror(Symbol($func), x)
             end
         end
     end

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -305,7 +305,7 @@ function _log(x::Float64, base, func)
     end
 end
 
-function $func(x::Float32, base, func)
+function _log(x::Float32, base, func)
     if x > 0f0
         x == Inf32 && return x
 


### PR DESCRIPTION
This uses our existing very good `log` implementation for `log2` and `log10`. This both reduces error, and increases speed for `Float32` and `Float64`. There is no impact on `log` (other than a pretty minor performance regression for `Float64`). I think I can solve the regression fairly easily, so I'm pushing it now so it can be reviewed (and I can see if CI passes)