### PR TITLE
Improve first/last docstrings

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -444,7 +444,7 @@ long enough.
 
 !!! compat "Julia 1.6"
     This method requires at least Julia 1.6.
-        
+
 # Examples
 ```jldoctest
 julia> last(["foo", "bar", "qux"], 2)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -394,6 +394,9 @@ end
 Get the first `n` elements of the iterable collection `itr`, or fewer elements if `v` is not
 long enough.
 
+!!! compat "Julia 1.6"
+    This method requires at least Julia 1.6.
+
 # Examples
 ```jldoctest
 julia> first(["foo", "bar", "qux"], 2)
@@ -439,6 +442,9 @@ last(a) = a[end]
 Get the last `n` elements of the iterable collection `itr`, or fewer elements if `v` is not
 long enough.
 
+!!! compat "Julia 1.6"
+    This method requires at least Julia 1.6.
+        
 # Examples
 ```jldoctest
 julia> last(["foo", "bar", "qux"], 2)


### PR DESCRIPTION
Improve `first`/`last` docstrings to indicate that two new methods have been added since v1.6 (#34868).