### PR TITLE
Add `Base.isdone(itr::EachLine)`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -1023,6 +1023,8 @@ eltype(::Type{<:EachLine}) = String
 
 IteratorSize(::Type{<:EachLine}) = SizeUnknown()
 
+isdone(itr::EachLine, state...) = eof(itr.stream)
+
 struct ReadEachIterator{T, IOT <: IO}
     stream::IOT
 end

--- a/test/read.jl
+++ b/test/read.jl
@@ -617,3 +617,12 @@ let p = Pipe()
     wait(t)
     close(p)
 end
+
+@testset "issue #27412" begin
+    itr = eachline(IOBuffer("a"))
+    @test !isempty(itr)
+    # check that the earlier isempty did not consume the iterator
+    @test !isempty(itr)
+    first(itr) # consume the iterator
+    @test  isempty(itr) # now it is empty
+end


### PR DESCRIPTION
With this method, `isempty` won't consume values from the iterator (See #27412).

This is completely untested. I'm trusting the CI to pick up any problems.

If this works and is accepted then I can do another PR for some of the other stateful iterators in Base.