### PR TITLE
cleanup cleanup real subtype fallbacks

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -534,7 +534,6 @@ for f in (:log2, :log10)
     @eval begin
         @inline ($f)(x::Float64) = nan_dom_err(ccall(($(string(f)), libm), Float64, (Float64,), x), x)
         @inline ($f)(x::Float32) = nan_dom_err(ccall(($(string(f, "f")), libm), Float32, (Float32,), x), x)
-        @inline ($f)(x::Real) = ($f)(float(x))
     end
 end
 
@@ -565,7 +564,7 @@ julia> sqrt(big(complex(-81)))
 0.0 + 9.0im
 ```
 """
-sqrt(x::Real) = sqrt(float(x))
+
 
 """
     hypot(x, y)

--- a/base/math.jl
+++ b/base/math.jl
@@ -564,7 +564,7 @@ julia> sqrt(big(complex(-81)))
 0.0 + 9.0im
 ```
 """
-
+sqrt(x)
 
 """
     hypot(x, y)

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -31,7 +31,6 @@ julia> cbrt(big(-27))
 -3.0
 ```
 """
-cbrt(x::Real) = cbrt(float(x))
 cbrt(x::AbstractFloat) = x < 0 ? -(-x)^(1//3) : x^(1//3)
 
 """


### PR DESCRIPTION
remove redundant Float16 methods for `log2`, `log10`, `sqrt`, and `cbrt` introduced by https://github.com/JuliaLang/julia/pull/39537.