### PR TITLE
fix bug in `let` when a global var is both shadowed and used in an RHS

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -4124,15 +4124,6 @@ let ex = quote
     @test ex.args[2] == :test
 end
 
-# issue #25652
-x25652 = 1
-x25652_2 = let (x25652, _) = (x25652, nothing)
-    x25652 = x25652 + 1
-    x25652
-end
-@test x25652_2 == 2
-@test x25652 == 1
-
 # issue #15180
 function f15180(x::T) where T
     X = Vector{T}(undef, 1)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2678,3 +2678,21 @@ end
     @test f((b=3, c=2, a=4)) == (4, 3)
     @test_throws ErrorException f((;))
 end
+
+# issue #25652
+x25652 = 1
+x25652_2 = let (x25652, _) = (x25652, nothing)
+    x25652 = x25652 + 1
+    x25652
+end
+@test x25652_2 == 2
+@test x25652 == 1
+
+@test let x = x25652
+    x25652 = x+3
+    x25652
+end == 4
+@test let (x,) = (x25652,)
+    x25652 = x+3
+    x25652
+end == 4


### PR DESCRIPTION
This should only affect cases that incorrectly gave an undef var error before.

Also simplify the code a bit while I'm at it.