### PR TITLE
[loading] Search in Sys.STDLIB if name/uuid is known.

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -290,6 +290,10 @@ function locate_package(pkg::PkgId)::Union{Nothing,String}
             path = manifest_uuid_path(env, pkg)
             path === nothing || return entry_path(path, pkg.name)
         end
+        # Allow loading of stdlibs if the name/uuid are given
+        # e.g. if they have been explicitly added to the project/manifest
+        path = manifest_uuid_path(Sys.STDLIB::String, pkg)
+        path === nothing || return entry_path(path, pkg.name)
     end
     return nothing
 end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -71,6 +71,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     end
     let v = readchomperrors(`$exename -i -e '
             empty!(LOAD_PATH)
+            @eval Sys STDLIB=mktempdir()
             Base.unreference_module(Base.PkgId(Base.UUID(0xb77e0a4c_d291_57a0_90e8_8db25a27a240), "InteractiveUtils"))
             '`)
         # simulate not having a working version of InteractiveUtils,


### PR DESCRIPTION
Locating a package with known uuid means the uuid was either
found in a manifest in LOAD_PATH or a "package folder" in LOAD_PATH.
However, this lookup fails for stdlibs that are not in the sysimage,
even if they have been explicitly added to project/manifest by the
user. This patch allows looking in Sys.STDLIB for stdlibs,
fixes #39504.