### PR TITLE
use `getfield` to access type fields in reflection

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -53,7 +53,7 @@ end
 function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
     T = typeof(x)::DataType
     nf = nfields(x)
-    if T.name.mutable
+    if getfield(getfield(T, :name), :mutable)
         if haskey(stackdict, x)
             return stackdict[x]
         end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -242,7 +242,7 @@ function showerror(io::IO, ex::MethodError)
     if f === Base.convert && length(arg_types_param) == 2 && !is_arg_types
         f_is_function = true
         show_convert_error(io, ex, arg_types_param)
-    elseif isempty(methods(f)) && isa(f, DataType) && f.name.abstract
+    elseif isempty(methods(f)) && isa(f, DataType) && getfield(getfield(f, :name), :abstract)
         print(io, "no constructors have been defined for ", f)
     elseif isempty(methods(f)) && !isa(f, Function) && !isa(f, Type)
         print(io, "objects of type ", ft, " are not callable")

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -143,7 +143,7 @@ See also: [`unsafe_pointer_to_objref`](@ref).
 """
 function pointer_from_objref(@nospecialize(x))
     @_inline_meta
-    typeof(x).name.mutable || error("pointer_from_objref cannot be used on immutable objects")
+    getfield(getfield(typeof(x), :name), :mutable) || error("pointer_from_objref cannot be used on immutable objects")
     ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), x)
 end
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -122,14 +122,15 @@ end
 const NamedTuple_typename = NamedTuple.body.body.name
 
 function _fieldnames(@nospecialize t)
-    if t.name === NamedTuple_typename
-        if t.parameters[1] isa Tuple
-            return t.parameters[1]
+    if getfield(t, :name) === NamedTuple_typename
+        p = getfield(t, :parameters)[1]
+        if p isa Tuple
+            return p
         else
             throw(ArgumentError("type does not have definite field names"))
         end
     end
-    isdefined(t, :names) ? t.names : t.name.names
+    isdefined(t, :names) ? getfield(t, :names) : getfield(t, :name).names
 end
 
 """
@@ -154,7 +155,7 @@ function fieldname(t::DataType, i::Integer)
     end
     throw_need_pos_int(i) = throw(ArgumentError("Field numbers must be positive integers. $i is invalid."))
 
-    t.name.abstract && throw_not_def_field()
+    getfield(getfield(t, :name), :abstract) && throw_not_def_field()
     names = _fieldnames(t)
     n_fields = length(names)::Int
     i > n_fields && throw_field_access(t, i, n_fields)
@@ -220,7 +221,7 @@ julia> nameof(Foo.S{T} where T)
 :S
 ```
 """
-nameof(t::DataType) = t.name.name
+nameof(t::DataType) = getfield(t, :name).name
 nameof(t::UnionAll) = nameof(unwrap_unionall(t))::Symbol
 
 """
@@ -242,7 +243,7 @@ julia> parentmodule(Foo.Int)
 Foo
 ```
 """
-parentmodule(t::DataType) = t.name.module
+parentmodule(t::DataType) = getfield(t, :name).module
 parentmodule(t::UnionAll) = parentmodule(unwrap_unionall(t))
 
 """
@@ -323,8 +324,8 @@ Can be called on any `isconcretetype`.
 """
 function datatype_alignment(dt::DataType)
     @_pure_meta
-    dt.layout == C_NULL && throw(UndefRefError())
-    alignment = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).alignment
+    getfield(dt, :layout) == C_NULL && throw(UndefRefError())
+    alignment = unsafe_load(convert(Ptr{DataTypeLayout}, getfield(dt, :layout))).alignment
     return Int(alignment)
 end
 
@@ -361,8 +362,8 @@ Can be called on any `isconcretetype`.
 """
 function datatype_haspadding(dt::DataType)
     @_pure_meta
-    dt.layout == C_NULL && throw(UndefRefError())
-    flags = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).flags
+    getfield(dt, :layout) == C_NULL && throw(UndefRefError())
+    flags = unsafe_load(convert(Ptr{DataTypeLayout}, getfield(dt, :layout))).flags
     return flags & 1 == 1
 end
 
@@ -374,8 +375,8 @@ Can be called on any `isconcretetype`.
 """
 function datatype_nfields(dt::DataType)
     @_pure_meta
-    dt.layout == C_NULL && throw(UndefRefError())
-    return unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).nfields
+    getfield(dt, :layout) == C_NULL && throw(UndefRefError())
+    return unsafe_load(convert(Ptr{DataTypeLayout}, getfield(dt, :layout))).nfields
 end
 
 """
@@ -386,8 +387,8 @@ Can be called on any `isconcretetype`.
 """
 function datatype_pointerfree(dt::DataType)
     @_pure_meta
-    dt.layout == C_NULL && throw(UndefRefError())
-    npointers = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).npointers
+    getfield(dt, :layout) == C_NULL && throw(UndefRefError())
+    npointers = unsafe_load(convert(Ptr{DataTypeLayout}, getfield(dt, :layout))).npointers
     return npointers == 0
 end
 
@@ -402,8 +403,8 @@ See also [`fieldoffset`](@ref).
 """
 function datatype_fielddesc_type(dt::DataType)
     @_pure_meta
-    dt.layout == C_NULL && throw(UndefRefError())
-    flags = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).flags
+    getfield(dt, :layout) == C_NULL && throw(UndefRefError())
+    flags = unsafe_load(convert(Ptr{DataTypeLayout}, getfield(dt, :layout))).flags
     return (flags >> 1) & 3
 end
 
@@ -426,13 +427,13 @@ FieldDesc(fd::FieldDescStorage{T}) where {T} =
 struct DataTypeFieldDesc
     dt::DataType
     function DataTypeFieldDesc(dt::DataType)
-        dt.layout == C_NULL && throw(UndefRefError())
+        getfield(dt, :layout) == C_NULL && throw(UndefRefError())
         new(dt)
     end
 end
 
 function getindex(dtfd::DataTypeFieldDesc, i::Int)
-    layout_ptr = convert(Ptr{DataTypeLayout}, dtfd.dt.layout)
+    layout_ptr = convert(Ptr{DataTypeLayout}, getfield(dtfd.dt, :layout))
     fd_ptr = layout_ptr + sizeof(DataTypeLayout)
     layout = unsafe_load(layout_ptr)
     fielddesc_type = (layout.flags >> 1) & 3
@@ -471,7 +472,7 @@ true
 !!! compat "Julia 1.5"
     This function requires at least Julia 1.5.
 """
-ismutable(@nospecialize(x)) = (@_pure_meta; typeof(x).name.mutable)
+ismutable(@nospecialize(x)) = (@_pure_meta; getfield(getfield(typeof(x), :name), :mutable))
 
 
 """
@@ -486,7 +487,7 @@ Determine whether type `T` was declared as a mutable type
 function ismutabletype(@nospecialize(t::Type))
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
-    return isa(t, DataType) && t.name.mutable
+    return isa(t, DataType) && getfield(getfield(t, :name), :mutable)
 end
 
 
@@ -501,8 +502,8 @@ function isstructtype(@nospecialize(t::Type))
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
     isa(t, DataType) || return false
-    hasfield = !isdefined(t, :types) || !isempty(t.types)
-    return hasfield || (t.size == 0 && !t.name.abstract)
+    hasfield = !isdefined(t, :types) || !isempty(getfield(t, :types))
+    return hasfield || (getfield(t, :size) == 0 && !getfield(getfield(t, :name), :abstract))
 end
 
 """
@@ -516,8 +517,8 @@ function isprimitivetype(@nospecialize(t::Type))
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
     isa(t, DataType) || return false
-    hasfield = !isdefined(t, :types) || !isempty(t.types)
-    return !hasfield && t.size != 0 && !t.name.abstract
+    hasfield = !isdefined(t, :types) || !isempty(getfield(t, :types))
+    return !hasfield && getfield(t, :size) != 0 && !getfield(getfield(t, :name), :abstract)
 end
 
 """
@@ -543,14 +544,14 @@ julia> isbitstype(Complex)
 false
 ```
 """
-isbitstype(@nospecialize(t::Type)) = (@_pure_meta; isa(t, DataType) && t.isbitstype)
+isbitstype(@nospecialize(t::Type)) = (@_pure_meta; isa(t, DataType) && getfield(t, :isbitstype))
 
 """
     isbits(x)
 
 Return `true` if `x` is an instance of an [`isbitstype`](@ref) type.
 """
-isbits(@nospecialize x) = (@_pure_meta; typeof(x).isbitstype)
+isbits(@nospecialize x) = (@_pure_meta; getfield(typeof(x), :isbitstype))
 
 """
     isdispatchtuple(T)
@@ -559,7 +560,7 @@ Determine whether type `T` is a tuple "leaf type",
 meaning it could appear as a type signature in dispatch
 and has no subtypes (or supertypes) which could appear in a call.
 """
-isdispatchtuple(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && t.isdispatchtuple)
+isdispatchtuple(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && getfield(t, :isdispatchtuple))
 
 iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
 isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)
@@ -570,7 +571,7 @@ has_free_typevars(@nospecialize(t)) = ccall(:jl_has_free_typevars, Cint, (Any,),
 const _TYPE_NAME = Type.body.name
 function isdispatchelem(@nospecialize v)
     return (v === Bottom) || (v === typeof(Bottom)) || isconcretedispatch(v) ||
-        (isa(v, DataType) && v.name === _TYPE_NAME && !has_free_typevars(v)) # isType(v)
+        (isa(v, DataType) && getfield(v, :name) === _TYPE_NAME && !has_free_typevars(v)) # isType(v)
 end
 
 """
@@ -602,7 +603,7 @@ julia> isconcretetype(Union{Int,String})
 false
 ```
 """
-isconcretetype(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && t.isconcretetype)
+isconcretetype(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && getfield(t, :isconcretetype))
 
 """
     isabstracttype(T)
@@ -623,7 +624,7 @@ function isabstracttype(@nospecialize(t))
     @_pure_meta
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
-    return isa(t, DataType) && t.name.abstract
+    return isa(t, DataType) && getfield(getfield(t, :name), :abstract)
 end
 
 """
@@ -747,8 +748,8 @@ function fieldcount(@nospecialize t)
     if !(t isa DataType)
         throw(TypeError(:fieldcount, DataType, t))
     end
-    if t.name === NamedTuple_typename
-        names, types = t.parameters
+    if getfield(t, :name) === NamedTuple_typename
+        names, types = getfield(t, :parameters)
         if names isa Tuple
             return length(names)
         end
@@ -757,15 +758,15 @@ function fieldcount(@nospecialize t)
         end
         abstr = true
     else
-        abstr = t.name.abstract || (t.name === Tuple.name && isvatuple(t))
+        abstr = getfield(getfield(t, :name), :abstract) || (getfield(t, :name) === getfield(Tuple, :name) && isvatuple(t))
     end
     if abstr
         throw(ArgumentError("type does not have a definite number of fields"))
     end
     if isdefined(t, :types)
-        return length(t.types)
+        return length(getfield(t, :types))
     end
-    return length(t.name.names)
+    return length(getfield(t, :name).names)
 end
 
 """

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -117,7 +117,7 @@ convert(::Type{Ref{T}}, x::AbstractArray{T}) where {T} = RefArray(x, 1)
 function unsafe_convert(P::Union{Type{Ptr{T}},Type{Ptr{Cvoid}}}, b::RefArray{T})::P where T
     if allocatedinline(T)
         p = pointer(b.x, b.i)
-    elseif isconcretetype(T) && T.name.mutable
+    elseif isconcretetype(T) && getfield(getfield(T, :name), :mutable)
         p = pointer_from_objref(b.x[b.i])
     else
         # see comment on equivalent branch for RefValue

--- a/base/refvalue.jl
+++ b/base/refvalue.jl
@@ -38,7 +38,7 @@ isassigned(x::RefValue) = isdefined(x, :x)
 function unsafe_convert(P::Union{Type{Ptr{T}},Type{Ptr{Cvoid}}}, b::RefValue{T})::P where T
     if allocatedinline(T)
         p = pointer_from_objref(b)
-    elseif isconcretetype(T) && T.name.mutable
+    elseif isconcretetype(T) && getfield(getfield(T, :name), :mutable)
         p = pointer_from_objref(b.x)
     else
         # If the slot is not leaf type, it could be either immutable or not.

--- a/base/show.jl
+++ b/base/show.jl
@@ -2616,7 +2616,7 @@ function dump(io::IOContext, x::DataType, n::Int, indent)
     if x !== Any
         print(io, " <: ", supertype(x))
     end
-    if n > 0 && !(x <: Tuple) && !x.name.abstract
+    if n > 0 && !(x <: Tuple) && !getfield(getfield(x, :name), :abstract)
         tvar_io::IOContext = io
         for tparam in x.parameters
             # approximately recapture the list of tvar parameterization


### PR DESCRIPTION
Should help avoid issues like #39534. Doesn't get every case of course, but should catch some common ones.