### PR TITLE
RFC: process: make SIGPIPE an always failure

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -476,7 +476,7 @@ function test_success(proc::Process)
         #TODO: this codepath is not currently tested
         throw(_UVError("could not start process " * repr(proc.cmd), proc.exitcode))
     end
-    return proc.exitcode == 0 && (proc.termsignal == 0 || proc.termsignal == SIGPIPE)
+    return proc.exitcode == 0 && proc.termsignal == 0
 end
 
 function success(x::Process)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -55,8 +55,8 @@ out = read(`$echocmd hello` & `$echocmd world`, String)
 
 @test (run(`$printfcmd "       \033[34m[stdio passthrough ok]\033[0m\n"`); true)
 
-# Test for SIGPIPE being treated as normal termination (throws an error if broken)
-Sys.isunix() && run(pipeline(yescmd, `head`, devnull))
+# Test for SIGPIPE being a failure condition
+@test_throws ProcessFailedException run(pipeline(yescmd, `head`, devnull))
 
 let p = run(pipeline(yescmd, devnull), wait=false)
     t = @async kill(p)


### PR DESCRIPTION
This error code does not exist on Windows, so any code that relied on
this was broken (would fail this test) on that platform already. In most
cases, it was actually a serious error too, such as `cp -v` or `tar -v`,
which will indeed fail midway and give corrupt results if you do not read
their output to completion!

Therefore, while breaking for posix, I think this should be considered a bugfix.

Discovered while trying to fix the CI problems with AArch64/Tar/ArgTools (https://github.com/JuliaLang/julia/pull/39544).