### PR TITLE
Rigorous Float16 tests

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -299,7 +299,7 @@ end
     x = T(a)
     N_float = round(x*LogBINV(base, T))
     N = unsafe_trunc(Int32, N_float)
-    r = muladd(N_float, LogB(base, T), x)
+    r = muladd(N_float, LogBU(base, T), x)
     r = muladd(N_float, LogBL(base, T), r)
     small_part = expb_kernel(base, r)
     if !(abs(x) <= 25)

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 # magic rounding constant: 1.5*2^52 Adding, then subtracting it from a float rounds it to an Int.
 # This works because eps(MAGIC_ROUND_CONST(T)) == one(T), so adding it to a smaller number aligns the lsb to the 1s place.
 # Values for which this trick doesn't work are going to have outputs of 0 or Inf.
@@ -11,7 +9,7 @@ MAGIC_ROUND_CONST(::Type{Float32}) = 1.048576f7
 MAX_EXP(n::Val{2}, ::Type{Float32}) = 128.0f0
 MAX_EXP(n::Val{2}, ::Type{Float64}) = 1024.0
 MAX_EXP(n::Val{:ℯ}, ::Type{Float32}) = 88.72284f0
-MAX_EXP(n::Val{:ℯ}, ::Type{Float64}) = 709.7827128933841
+MAX_EXP(n::Val{:ℯ}, ::Type{Float64}) = 709.782712893384
 MAX_EXP(n::Val{10}, ::Type{Float32}) = 38.53184f0
 MAX_EXP(n::Val{10}, ::Type{Float64}) = 308.25471555991675
 
@@ -63,11 +61,6 @@ LogBU(::Val{10}, ::Type{Float32}) = -0.3010254f0
 LogBL(::Val{2}, ::Type{Float32}) = 0.0f0
 LogBL(::Val{:ℯ}, ::Type{Float32}) = -1.4286068f-6
 LogBL(::Val{10}, ::Type{Float32}) = -4.605039f-6
-
-# -log(base, 2) as a Float32 for Float16 version.
-LogB(::Val{2}, ::Type{Float16}) = -1.0f0
-LogB(::Val{:ℯ}, ::Type{Float16}) = -0.6931472f0
-LogB(::Val{10}, ::Type{Float16}) = -0.30103f0
 
 # Range reduced kernels
 @inline function expm1b_kernel(::Val{2}, x::Float64)
@@ -306,7 +299,8 @@ end
     x = T(a)
     N_float = round(x*LogBINV(base, T))
     N = unsafe_trunc(Int32, N_float)
-    r = muladd(N_float, LogB(base, Float16), x)
+    r = muladd(N_float, LogB(base, T), x)
+    r = muladd(N_float, LogBL(base, T), r)
     small_part = expb_kernel(base, r)
     if !(abs(x) <= 25)
         x > 16 && return Inf16
@@ -341,6 +335,7 @@ julia> exp(im * pi) ≈ cis(pi)
 true
 ```
 """ exp(x::Real)
+
 
 """
     exp2(x)

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -94,13 +94,13 @@ end
 end
 @testset "unary ops" begin
     @test -f === Float16(-2.)
-    @test Float16(0.5f0)^2 ≈ Float16(0.5f0^2)
+    @test Float16(0.5f0)^2 === Float16(0.5f0^2)
     @testset "$func" for func in (sin,cos,tan,asin,acos,atan,
                                   sinh,cosh,tanh,asinh,acosh,atanh,
                                   exp,exp2,exp10,expm1,log,log2,log10,log1p,
                                   sqrt,cbrt)
         for x in FloatIterator{Float16}()
-             @test try func(x) === Float16(func(Float64(x))) catch; true end
+             @test try func(x) === Float16(func(Float64(x))) catch; true end || (func,x)
         end
     end
 end

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -4,6 +4,13 @@ using Test
 
 f = Float16(2.)
 g = Float16(1.)
+
+struct FloatIterator{T} end
+function Base.iterate(it::FloatIterator{T}, el=T(-Inf)) where T
+    return el == T(Inf) ? nothing : (el, nextfloat(el))
+end
+Base.length(::FloatIterator{Float16}) = 2^16 - 2^11
+
 @testset "comparisons" begin
     @test f >= g
     @test f > g
@@ -88,15 +95,23 @@ end
 @testset "unary ops" begin
     @test -f === Float16(-2.)
     @test Float16(0.5f0)^2 ≈ Float16(0.5f0^2)
-    @test sin(f) ≈ sin(2f0)
-    @test log10(Float16(100)) == Float16(2.0)
-    @test sin(ComplexF16(f)) ≈ sin(complex(2f0))
+    @testset "$func" for func in (sin,cos,tan,asin,acos,atan,
+                                  sinh,cosh,tanh,asinh,acosh,atanh,
+                                  exp,exp2,exp10,expm1,log,log2,log10,log1p,
+                                  sqrt,cbrt)
+        for x in FloatIterator{Float16}()
+             @test try func(x) === Float16(func(Float64(x))) catch; true end
 
+<<<<<<< HEAD
     # no domain error is thrown for negative values
     @test cbrt(Float16(-1.0)) == -1.0
     # test zero and Inf
     @test cbrt(Float16(0.0)) == Float16(0.0)
     @test cbrt(Inf16) == Inf16
+=======
+        end
+    end
+>>>>>>> e791da70c2 (More rigerous, easy to interpret checks)
 end
 @testset "binary ops" begin
     @test f+g === Float16(3f0)

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -101,17 +101,8 @@ end
                                   sqrt,cbrt)
         for x in FloatIterator{Float16}()
              @test try func(x) === Float16(func(Float64(x))) catch; true end
-
-<<<<<<< HEAD
-    # no domain error is thrown for negative values
-    @test cbrt(Float16(-1.0)) == -1.0
-    # test zero and Inf
-    @test cbrt(Float16(0.0)) == Float16(0.0)
-    @test cbrt(Inf16) == Inf16
-=======
         end
     end
->>>>>>> e791da70c2 (More rigerous, easy to interpret checks)
 end
 @testset "binary ops" begin
     @test f+g === Float16(3f0)


### PR DESCRIPTION
This tests every `Float16` value for the following functions. `sin,cos,tan,asin,acos,atan,sinh,cosh,tanh,asinh,acosh,atanh,exp,exp2,exp10,expm1,log,log2,log10,log1p,sqrt,cbrt`
Specifically, I think it is reasonable that any Float16 implementation in Base be accurate to .5 ULP since Float16 already is a very unstable type. This test takes about 5 seconds on my computer, so before merging, it would be a good idea to make sure this is acceptable for CI.