### PR TITLE
outdent `UUID` doc

### DIFF
--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    Represents a Universally Unique Identifier (UUID).
-    Can be built from one `UInt128` (all byte values), two `UInt64`, or four `UInt32`.
-    Conversion from a string will check the UUID validity.
+Represents a Universally Unique Identifier (UUID).
+Can be built from one `UInt128` (all byte values), two `UInt64`, or four `UInt32`.
+Conversion from a string will check the UUID validity.
 """
 struct UUID
     value::UInt128


### PR DESCRIPTION
otherwise the whole section will be interpreted as code block by certain frontend.