### PR TITLE
[p7zip_jll] Set `LIBPATH` and `LIBPATH_list` at init-time

### DIFF
--- a/stdlib/p7zip_jll/src/p7zip_jll.jl
+++ b/stdlib/p7zip_jll/src/p7zip_jll.jl
@@ -85,6 +85,8 @@ function __init__()
     init_p7zip_path()
     PATH[] = dirname(p7zip_path)
     push!(PATH_list, PATH[])
+    append!(LIBPATH_list, [joinpath(Sys.BINDIR, Base.LIBDIR, "julia"), joinpath(Sys.BINDIR, Base.LIBDIR)])
+    LIBPATH[] = join(LIBPATH_list, pathsep)
 end
 
 # JLLWrappers API compatibility shims.  Note that not all of these will really make sense.


### PR DESCRIPTION
Fix #39154, take 2 (or 3?).  Ref: https://github.com/docker-library/julia/pull/51#issuecomment-776297077

Should be backported to `release-1.6`