### PR TITLE
generate_precompile: Move parsing into try/catch

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -353,23 +353,23 @@ function generate_precompile_statements()
         # println(statement)
         # The compiler has problem caching signatures with `Vararg{?, N}`. Replacing
         # N with a large number seems to work around it.
-        ps = Meta.parse(statement)
-        if isexpr(ps, :call)
-            if isexpr(ps.args[end], :curly)
-                l = ps.args[end]
-                if length(l.args) == 2 && l.args[1] == :Vararg
-                    push!(l.args, 100)
+        try
+            ps = Meta.parse(statement)
+            if isexpr(ps, :call)
+                if isexpr(ps.args[end], :curly)
+                    l = ps.args[end]
+                    if length(l.args) == 2 && l.args[1] == :Vararg
+                        push!(l.args, 100)
+                    end
                 end
             end
-        end
-        try
             # println(ps)
             Core.eval(PrecompileStagingArea, ps)
             n_succeeded += 1
             print("\rExecuting precompile statements... $n_succeeded/$(length(statements))")
         catch
             # See #28808
-            @error "Failed to precompile $statement"
+            # @error "Failed to precompile $statement"
         end
     end
     println()


### PR DESCRIPTION
Our printing for precompile statements is not 100% reliable (#28808)
and can fail. I introduced the extra `parse` call in the Varargs
change, but because of #28808, it needs to go inside the try/catch.