### PR TITLE
Add `JULIA_PKG_SERVER` to Environment Variables in docs

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -158,9 +158,9 @@ $(DEPOT_PATH[1])/logs/repl_history.jl
 
 ### `JULIA_PKG_SERVER`
 
-Used by `Pkg.jl`, for loading packages. By default, `Pkg` uses https://pkg.julialang.org to
-host julia packages. You can use this environment variable to disable the use of this
-package server, and instead access the packages hosted by GitHub, by setting:
+Used by `Pkg.jl`, for downloading packages and updating the registry. By default, `Pkg` uses `https://pkg.julialang.org` to
+fetch Julia packages. You can use this environment variable to select a different server. In addition, you can disable the use of the
+PkgServer protocol, and instead access the packages directly from their hosts (GitHub, GitLab, etc.) by setting:
 ```
 export JULIA_PKG_SERVER=""
 ```
@@ -348,5 +348,4 @@ On debug builds of Julia this is always enabled. Recommended to use with `-g 2`.
 ### `JULIA_LLVM_ARGS`
 
 Arguments to be passed to the LLVM backend.
-
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -156,6 +156,15 @@ The absolute path `REPL.find_hist_file()` of the REPL's history file. If
 $(DEPOT_PATH[1])/logs/repl_history.jl
 ```
 
+### `JULIA_PKG_SERVER`
+
+Used by `Pkg.jl`, for loading packages. By default, `Pkg` uses https://pkg.julialang.org to
+host julia packages. You can use this environment variable to disable the use of this
+package server, and instead access the packages hosted by GitHub, by setting:
+```
+export JULIA_PKG_SERVER=""
+```
+
 ## External applications
 
 ### `JULIA_SHELL`


### PR DESCRIPTION
I'm not really sure what to write in here. I'm not super familiar with this ENV variable, nor do I know how best to explain it.

I'd love some help with this!! Please feel free to edit this PR directly!!

I am opening this because we recently needed to disable the package server (we were having consistency issues, where the registry wasn't updating), and we couldn't find documented anywhere what the Environment Variable is to do that. We eventually found it in the julia slack. I'd like to add it here so others can find it. :) thanks!