### PR TITLE
Fix for infinite loop when passing 0d array to setindex of n-dim arrays

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -239,7 +239,7 @@ setindex_shape_check(X::AbstractArray) =
 setindex_shape_check(X::AbstractArray, i::Integer) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
-setindex_shape_check(X::AbstractArray{T, 0}, i::Integer...) where T =
+setindex_shape_check(X::AbstractArray{<:Any, 0}, i::Integer...) =
     (prod(i) == 1 || throw_setindex_mismatch(X, i))
 
 setindex_shape_check(X::AbstractArray{<:Any,1}, i::Integer) =

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -240,7 +240,7 @@ setindex_shape_check(X::AbstractArray, i::Integer) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
 setindex_shape_check(X::AbstractArray{<:Any, 0}, i::Integer...) =
-    (prod(i) == 1 || throw_setindex_mismatch(X, i))
+    (length(X) == prod(i) || throw_setindex_mismatch(X, i))
 
 setindex_shape_check(X::AbstractArray{<:Any,1}, i::Integer) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -239,6 +239,9 @@ setindex_shape_check(X::AbstractArray) =
 setindex_shape_check(X::AbstractArray, i::Integer) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
+setindex_shape_check(X::AbstractArray{T, 0}, i::Integer...) where T =
+    (prod(i) == 1 || throw_setindex_mismatch(X, i))
+
 setindex_shape_check(X::AbstractArray{<:Any,1}, i::Integer) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2898,3 +2898,9 @@ end
     @test as isa TSlow{Int,3}
     @test size(as) == (3, 5, 1)
 end
+
+@testset "0-dimensional shape checking #39608" begin
+    @test [fill(1); [2; 2]] == [1; 2; 2]
+    @test [fill(1); fill(2, (2,1,1))] == reshape([1; 2; 2], (3, 1, 1))
+    @test_throws DimensionMismatch [fill(1); rand(2, 2, 2)]
+end


### PR DESCRIPTION
This PR fixes the infinite loop noted by @mbauman  here: https://github.com/JuliaLang/julia/issues/38019#issuecomment-726347197

Added a specialization of `setindex_shape_check` for 0-d arrays.