### PR TITLE
added docstring for single-quote in basedocs.jl

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -277,6 +277,19 @@ julia> z
 kw"global"
 
 """
+    ' '
+
+the single-quote character delimits Char (that is, character) literals.
+
+# Examples
+```jldoctest
+julia> println('j')
+j
+```
+"""
+kw"' '"
+
+"""
     =
 
 `=` is the assignment operator.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -279,15 +279,15 @@ kw"global"
 """
     ' '
 
-the single-quote character delimits Char (that is, character) literals.
+A pair of single-quote characters delimit a [`Char`](@ref) (that is, character) literal.
 
 # Examples
 ```jldoctest
-julia> println('j')
-j
+julia> 'j'
+'j': ASCII/Unicode U+006A (category Ll: Letter, lowercase)
 ```
 """
-kw"' '"
+kw"''"
 
 """
     =


### PR DESCRIPTION
This is an attempt to add docstring for single-quote (' ') in basedocs.jl with reference to #33666. 
Also this is my first contribution to Open Source. :)

<img width="1161" alt="Screenshot 2021-02-11 at 8 11 38 AM" src="https://user-images.githubusercontent.com/74652697/107597486-c85a4d00-6c40-11eb-8aec-adfed51f3bf2.png">


 