### PR TITLE
special/exp.jl: fix broken jldoctest block

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -270,6 +270,7 @@ Compute the natural base exponential of `x`, in other words ``e^x``.
 ```jldoctest
 julia> exp(1.0)
 2.718281828459045
+```
 """ exp(x::Real)
 
 


### PR DESCRIPTION
This was introduced in 0097bddf900c16a7c7591671a6a3a0e2bd8acb4d.
