### PR TITLE
Mark failures in rr traces

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -553,6 +553,7 @@ function do_test(result::ExecutionResult, orig_expr)
         @assert isa(result, Threw)
         testres = Error(:test_error, orig_expr, result.exception, result.backtrace, result.source)
     end
+    isa(testres, Pass) || ccall(:jl_breakpoint, Cvoid, (Any,), result)
     record(get_testset(), testres)
 end
 


### PR DESCRIPTION
This makes it easy to navigate to failed test in long rr traces by setting a breakpoint in
`jl_breakpoint`. Longer term we may want to do something fancier to enable automation,
but hopefully this is at least makes it easier to debug traces from Julia CI.