### PR TITLE
Add shorthand for controlling the repl iocontext compact setting

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -369,6 +369,28 @@ function load_InteractiveUtils()
     return getfield(Main, :InteractiveUtils)
 end
 
+# REPL options helpers
+
+"""
+    repl_compact()
+    repl_compact(::Nothing)
+    repl_compact(b::Bool)
+
+Shorthand for toggling or setting `Base.active_repl.options.iocontext[:compact]` to control whether and how the repl
+specifies a `:compact` option in the IOContext, allowing `show` methods to customize level of detail and formatting.
+
+e.g.
+`repl_compact()`: toggles compact setting, starting with true if unset
+`repl_compact(nothing)`: removes the compact setting, to allow show methods to assume default behavior
+`repl_compact(true)`: sets the compact setting
+"""
+function repl_compact(b::Bool)
+    Base.active_repl.options.iocontext[:compact] = b
+    return Base.active_repl.options.iocontext
+end
+repl_compact(::Nothing) = delete!(Base.active_repl.options.iocontext, :compact)
+repl_compact() = repl_compact(!get(Base.active_repl.options.iocontext, :compact, false))
+
 # run the requested sort of evaluation loop on stdio
 function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
     global active_repl

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -784,6 +784,7 @@ export
 # misc
     atexit,
     atreplinit,
+    repl_compact,
     exit,
     ntuple,
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -76,6 +76,8 @@ julia> rand(2, 2)
  0.6244375177790158  0.9777957560761545
 ```
 
+As a shorthand, `repl_compact()` exists to toggle, set or unset `Base.active_repl.options.iocontext[:compact]`.
+
 In order to define automatically the values of this dictionary at startup time, one can use the
 [`atreplinit`](@ref) function in the `~/.julia/config/startup.jl` file, for example:
 ```julia


### PR DESCRIPTION
It might be nice if switching between compact and non-compact show methods in the repl was a bit more convenient.

The use case here is a simple example, but it seems there could be general potential for wider use of  `:compact`-specific show methods. 
One example being how `StatStruct` could be shown in https://github.com/JuliaLang/julia/pull/39463

Example with current options:
```julia
julia> rand(2, 2)
2×2 Array{Float64,2}:
 0.8833    0.329197
 0.719708  0.59114

julia> Base.active_repl.options.iocontext[:compact] = false;

julia> rand(2, 2)
2×2 Array{Float64,2}:
 0.2083967319174056  0.13330606013126012
 0.6244375177790158  0.9777957560761545
```

`Base.active_repl.options.iocontext[:compact] = false` is rather long to use routinely.

Alternatively, constructing an IOContext and calling the show method explicitly is rather long/complex.
`show(IOContext(stdout, :compact => false), "text/plain", rand(2, 2))`


This adds
```julia
julia> repl_compact()         # toggles value. Starts with true if unset
Dict{Symbol, Any} with 1 entry:
  :compact => true

julia> repl_compact(false)    # explicitly sets
Dict{Symbol, Any} with 1 entry:
  :compact => false

julia> repl_compact(nothing)  # removes the compact setting to allow show methods to assume default behavior
Dict{Symbol, Any}()
```

So the above example would become
```julia
julia> rand(2, 2)
2×2 Array{Float64,2}:
 0.8833    0.329197
 0.719708  0.59114

julia> repl_compact(false)
Dict{Symbol, Any} with 1 entry:
  :compact => false

julia> rand(2, 2)
2×2 Array{Float64,2}:
 0.2083967319174056  0.13330606013126012
 0.6244375177790158  0.9777957560761545
```

This may be tidier if there was an `options>` repl mode, but I'm not sure whether there's a broader need for that.