### PR TITLE
Add script to bump stdlib versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,6 +246,18 @@ process before running the corresponding test. This can be useful as a shortcut
 on the command line (since tests aren't always designed to be run outside the
 runtest harness).
 
+#### Bumping version of dependencies
+Some Julia standard libraries (stdlib) are developed in their own repositories.
+The version of, e.g. `Pkg`, is determined by e.g. `stdlib/Pkg.version`.
+`make -C stdlib` will create new files in `deps/checksums`.
+The old checksum files should be removed from the repository.
+For a script to perform these steps, see `contrib/bump-stdlib.jl`, e.g.
+
+```
+$ cd $JULIAHOME
+$ contrib/bump-stdlib.jl Pkg 47105aaefb7eb8bda5c002315ccf1a28be8fdabb
+```
+
 ### Code Formatting Guidelines
 
 #### General Formatting Guidelines for Julia code contributions

--- a/contrib/bump-stdlib.jl
+++ b/contrib/bump-stdlib.jl
@@ -1,0 +1,64 @@
+#!/usr/bin/env julia
+
+function get_makefile_variables(path)
+    contents = read(open(path), String)
+    lines = split(contents, "\n")
+    lines = filter(line -> length(line) > 0, lines)
+    parsed = map(line -> map(strip, split(line, "=")), lines)
+    vars = first.(parsed)
+    vals = last.(parsed)
+    (;vars, vals)
+end
+
+is_versioned(path) = success(`git ls-files --error-unmatch $(path)`)
+clean_stage() = success(`git diff --cached --exit-code`)
+
+function write_makefile_variables(env, path)
+    is_versioned(path) || error("File $(path) is not versioned.")
+    open(path, "w") do f
+        for (var, val) in  zip(env.vars, env.vals)
+            println(f, "$(var) = $(val)")
+        end
+    end
+end
+
+function _get_hash_env(env)
+    i = findlast(==("$(uppercase(stdlib_name))_SHA1"), env.vars)
+    isnothing(i) || return i
+    error("hash variable not found among $(env.vars)")
+end
+
+function get_hash_val(env)
+    env.vals[_get_hash_env(env)]
+end
+
+function replace_hash(env, path, new_hash)
+    env.vals[_get_hash_env(env)] = new_hash
+    write_makefile_variables(env, path)
+end
+
+hash_dir(stdlib_name, stdlib_commit) = "deps/checksums/$(stdlib_name)-$(stdlib_commit).tar.gz"
+
+
+clean_stage() || error("run this script with no changes to be committed")
+stdlib_name = ARGS[1] # e.g. "Pkg"
+stdlib_new_commit = ARGS[2] # e.g. "47105aaefb7eb8bda5c002315ccf1a28be8fdabb"
+
+@show stdlib_name
+@show stdlib_new_commit
+
+version_file_path = "stdlib/$(stdlib_name).version"
+
+hash_files = ["md5", "sha512"] # just to avoid a dependency on `Glob.jl`
+
+length(stdlib_new_commit) == 40 || error("Commit hash expected to be 40 hex digits")
+
+env = get_makefile_variables(version_file_path)
+stdlib_old_commit = get_hash_val(env)
+replace_hash(env, version_file_path, stdlib_new_commit)
+run(`make -C stdlib`)
+
+for f in hash_files
+    run(`git rm $(joinpath(hash_dir(stdlib_name, stdlib_old_commit), f))`)
+    run(`git add $(joinpath(hash_dir(stdlib_name, stdlib_new_commit), f))`)
+end


### PR DESCRIPTION
I asked on slack for how to perform these steps because I was not sure what generated the new hashes.
I was going to just write the steps in `CONTRIBUTING.md`, but figured I could make a quick script as well.
I did not test it much. It would be better to use `make` to parse the `.version` file, too. But I think it's better than nothing.