### PR TITLE
Change Windows CRT func to be considered as libjulia func

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -57,6 +57,25 @@ static int endswith_extension(const char *path) JL_NOTSAFEPOINT
     return 0;
 }
 
+#ifdef _OS_WINDOWS_
+#ifdef _MSC_VER
+#if (_MSC_VER >= 1930) || (_MSC_VER < 1800)
+#error This version of MSVC has not been tested.
+#elif _MSC_VER >= 1900 // VC++ 2015 / 2017 / 2019
+#define CRTDLL_BASENAME "vcruntime140"
+#elif _MSC_VER >= 1800 // VC++ 2013
+#define CRTDLL_BASENAME "msvcr120"
+#endif
+#else
+#define CRTDLL_BASENAME "msvcrt"
+#endif
+
+const char jl_crtdll_basename[] = CRTDLL_BASENAME;
+const char jl_crtdll_name[] = CRTDLL_BASENAME ".dll";
+
+#undef CRTDLL_BASENAME
+#endif
+
 #define PATHBUF 4096
 
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
@@ -314,18 +333,10 @@ const char *jl_dlfind_win32(const char *f_name)
         return JL_LIBJULIA_DL_LIBNAME;
     if (jl_dlsym(jl_kernel32_handle, f_name, &dummy, 0))
         return "kernel32";
+    if (jl_dlsym(jl_crtdll_handle, f_name, &dummy, 0)) // Prefer crtdll over ntdll
+        return jl_crtdll_basename;
     if (jl_dlsym(jl_ntdll_handle, f_name, &dummy, 0))
         return "ntdll";
-    if (jl_dlsym(jl_crtdll_handle, f_name, &dummy, 0))
-#if defined(_MSC_VER)
-#if _MSC_VER == 1800
-        return "msvcr120";
-#else
-#error This version of MSVC has not been tested.
-#endif
-#else
-        return "msvcrt";
-#endif
     if (jl_dlsym(jl_winsock_handle, f_name, &dummy, 0))
         return "ws2_32";
     // additional common libraries (libc?) could be added here, but in general,

--- a/src/init.c
+++ b/src/init.c
@@ -302,6 +302,7 @@ void *jl_ntdll_handle;
 void *jl_kernel32_handle;
 void *jl_crtdll_handle;
 void *jl_winsock_handle;
+extern const char jl_crtdll_name[];
 #endif
 
 uv_loop_t *jl_io_loop;
@@ -665,11 +666,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 #ifdef _OS_WINDOWS_
     jl_ntdll_handle = jl_dlopen("ntdll.dll", 0); // bypass julia's pathchecking for system dlls
     jl_kernel32_handle = jl_dlopen("kernel32.dll", 0);
-#if defined(_MSC_VER) && _MSC_VER == 1800
-    jl_crtdll_handle = jl_dlopen("msvcr120.dll", 0);
-#else
-    jl_crtdll_handle = jl_dlopen("msvcrt.dll", 0);
-#endif
+    jl_crtdll_handle = jl_dlopen(jl_crtdll_name, 0);
     jl_winsock_handle = jl_dlopen("ws2_32.dll", 0);
     jl_exe_handle = GetModuleHandleA(NULL);
     JL_MUTEX_INIT(&jl_in_stackwalk);


### PR DESCRIPTION
This prefers crtdll ("msvcrt.dll") over ntdll ("ntdll.dll"). AFAIK, it should not be recommended to call the ntdll function directly.

This supports the specialization of `memcpy` ccall on Windows.

~This may possibly fix #38751, but I'm not sure yet. :sweat_smile:~
Fixes #38751, Fixes #39382