### PR TITLE
add Base.pkgdir to docs

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -389,6 +389,7 @@ Base.AsyncCondition(::Function)
 Base.nameof(::Module)
 Base.parentmodule
 Base.pathof(::Module)
+Base.pkgdir(::Module)
 Base.moduleroot
 __module__
 __source__


### PR DESCRIPTION
#33128 missed Including `pkgdir(::Module)` in the docs