### PR TITLE
Implement float() and complex() for Missing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -95,7 +95,7 @@ for f in (:(!), :(~), :(+), :(-), :(*), :(&), :(|), :(xor),
           :(zero), :(one), :(oneunit),
           :(isfinite), :(isinf), :(isodd),
           :(isinteger), :(isreal), :(isnan),
-          :(iszero), :(transpose), :(adjoint), :(float), :(conj),
+          :(iszero), :(transpose), :(adjoint), :(float), :(complex), :(conj),
           :(abs), :(abs2), :(iseven), :(ispow2),
           :(real), :(imag), :(sign), :(inv))
     @eval ($f)(::Missing) = missing
@@ -105,6 +105,13 @@ for f in (:(Base.zero), :(Base.one), :(Base.oneunit))
     @eval function $(f)(::Type{Union{T, Missing}}) where T
         T === Any && throw(MethodError($f, (Any,)))  # To prevent StackOverflowError
         $f(T)
+    end
+end
+for f in (:(Base.float), :(Base.complex))
+    @eval $f(::Type{Missing}) = Missing
+    @eval function $f(::Type{Union{T, Missing}}) where T
+        T === Any && throw(MethodError($f, (Any,)))  # To prevent StackOverflowError
+        Union{$f(T), Missing}
     end
 end
 

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -321,6 +321,8 @@ end
         pop!(need_to_handle_undef_sparam, which(Base._cat, Tuple{Any, AbstractArray}))
         pop!(need_to_handle_undef_sparam, which(Base.byteenv, (Union{AbstractArray{Pair{T,V}, 1}, Tuple{Vararg{Pair{T,V}}}} where {T<:AbstractString,V},)))
         pop!(need_to_handle_undef_sparam, which(Base.float, Tuple{AbstractArray{Union{Missing, T},N} where {T, N}}))
+        pop!(need_to_handle_undef_sparam, which(Base.float, Tuple{Type{Union{Missing, T}} where T}))
+        pop!(need_to_handle_undef_sparam, which(Base.complex, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.zero, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.one, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.oneunit, Tuple{Type{Union{Missing, T}} where T}))

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -158,7 +158,7 @@ Base.one(::Type{Unit}) = 1
                             identity, zero, one, oneunit,
                             iseven, isodd, ispow2,
                             isfinite, isinf, isnan, iszero,
-                            isinteger, isreal, transpose, adjoint, float, inv]
+                            isinteger, isreal, transpose, adjoint, float, complex, inv]
 
     # All elementary functions return missing when evaluating missing
     for f in elementary_functions
@@ -171,11 +171,15 @@ Base.one(::Type{Unit}) = 1
         @test zero(Union{T, Missing}) === T(0)
         @test one(Union{T, Missing}) === T(1)
         @test oneunit(Union{T, Missing}) === T(1)
+        @test float(Union{T, Missing}) === Union{float(T), Missing}
+        @test complex(Union{T, Missing}) === Union{complex(T), Missing}
     end
 
     @test_throws MethodError zero(Union{Symbol, Missing})
     @test_throws MethodError one(Union{Symbol, Missing})
     @test_throws MethodError oneunit(Union{Symbol, Missing})
+    @test_throws MethodError float(Union{Symbol, Missing})
+    @test_throws MethodError complex(Union{Symbol, Missing})
 
     for T in (Unit,)
         @test zero(Union{T, Missing}) === T(0)
@@ -186,10 +190,14 @@ Base.one(::Type{Unit}) = 1
     @test zero(Missing) === missing
     @test one(Missing) === missing
     @test oneunit(Missing) === missing
+    @test float(Missing) === Missing
+    @test complex(Missing) === Missing
 
     @test_throws MethodError zero(Any)
     @test_throws MethodError one(Any)
     @test_throws MethodError oneunit(Any)
+    @test_throws MethodError float(Any)
+    @test_throws MethodError complex(Any)
 
     @test_throws MethodError zero(String)
     @test_throws MethodError zero(Union{String, Missing})


### PR DESCRIPTION
`float` is already defined for `missing` and `AbstractArray{Union{T, Missing}}`.
Add a definition taking a type consistent with these methods.
Also implement similar definitions for `complex`.

Fixes #29693. Spotted at https://github.com/JuliaLang/Statistics.jl/pull/61.