### PR TITLE
Test for endswith

### DIFF
--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -403,3 +403,10 @@ end
     a, b, c... = s
     @test c === "cd"
 end
+
+@testset "endswith" begin
+    A = "Fun times with Julialang"
+    B = "A language called Julialang"
+    @test endswith(A, split(B, ' ')[end])
+    @test endswith(A, 'g')
+end


### PR DESCRIPTION
The method for seeing if `A` ends with an `AbstractString` was not tested. Checked that this test should catch it.