### PR TITLE
Missing tests for string()

### DIFF
--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -277,3 +277,11 @@ for i = 1:10
     print(buf, join(s22021, "\n"))
     @test isvalid(String, take!(buf))
 end
+
+@testset "string()" begin
+    # test the Float sizehints
+    @test string(2.f0) == "2.0"
+    @test string(2.f0, 2.0) == "2.02.0"
+    # test empty args
+    @test string() == ""
+end


### PR DESCRIPTION
The size hinter for `Float32` wasn't tested, and neither was `string()` with no arguments.