### PR TITLE
Add isdone(itr::ReadEachIterator, state...)

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -1059,6 +1059,8 @@ eltype(::Type{ReadEachIterator{T}}) where T = T
 
 IteratorSize(::Type{<:ReadEachIterator}) = SizeUnknown()
 
+isdone(itr::ReadEachIterator, state...) = eof(itr.stream)
+
 # IOStream Marking
 # Note that these functions expect that io.mark exists for
 # the concrete IO type. This may not be true for IO types

--- a/test/read.jl
+++ b/test/read.jl
@@ -618,8 +618,7 @@ let p = Pipe()
     close(p)
 end
 
-@testset "issue #27412" begin
-    itr = eachline(IOBuffer("a"))
+@testset "issue #27412" for itr in [eachline(IOBuffer("a")), readeach(IOBuffer("a"), Char)]
     @test !isempty(itr)
     # check that the earlier isempty did not consume the iterator
     @test !isempty(itr)


### PR DESCRIPTION
This prevents `isempty` and friends from advancing the iterator when they shouldn't.

Note: `collect(readeach(io, T))` can throw an exception if `io` isn't a multiple of the right size. `isempty` will still return `false`, even if the next call to `iterate` will throw an exception.

Similar to: #27412