### PR TITLE
Docs: Fix status reporting to throw on error

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -314,6 +314,20 @@ function Documenter.deploy_folder(::BuildBotConfig; devurl, repo, branch, kwargs
     end
     return Documenter.DeployDecision(; all_ok=false)
 end
+function Documenter.post_status(::BuildBotConfig; type, repo::String, subfolder=nothing, kwargs...)
+    if type == "pending"
+        @info "Documentation build in progress"
+    elseif type == "success"
+        @info "Documentation build succeeded"
+    elseif type == "error"
+        error("Documentation build errored")
+    elseif type == "failure"
+        error("Documentation build failed")
+    else
+        error("unsupported status type: $type")
+    end
+end
+
 
 const devurl = "v$(VERSION.major).$(VERSION.minor)-dev"
 


### PR DESCRIPTION
Doc deploy is currently broken, but hasn't been throwing. Dev docs may be quite out of date.

A `post_status` method was missing for the build bot config, meaning that on an error status no error was thrown and just the fall back method that returns `nothing`.

This is evident because the `DOCUMENTER_KEY` appears to be broken in the build system but was just being printed as an `@error` in [a successful `make deploy` step](https://build.julialang.org/#/builders/34/builds/583/steps/5/logs/stdio)? @fredrikekre / @staticfloat ?

This adds throws on "errored" or "failed" status so the build system can catch it.

cc. @mortenpi 