### PR TITLE
Relax type restriction on `factors` field of `LQPackedQ`

### DIFF
--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -56,8 +56,8 @@ Base.iterate(S::LQ) = (S.L, Val(:Q))
 Base.iterate(S::LQ, ::Val{:Q}) = (S.Q, Val(:done))
 Base.iterate(S::LQ, ::Val{:done}) = nothing
 
-struct LQPackedQ{T,S<:AbstractMatrix} <: AbstractMatrix{T}
-    factors::Matrix{T}
+struct LQPackedQ{T,S<:AbstractMatrix{T}} <: AbstractMatrix{T}
+    factors::S
     τ::Vector{T}
     LQPackedQ{T,S}(factors::AbstractMatrix{T}, τ::Vector{T}) where {T,S<:AbstractMatrix} = new(factors, τ)
 end

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -59,9 +59,7 @@ Base.iterate(S::LQ, ::Val{:done}) = nothing
 struct LQPackedQ{T,S<:AbstractMatrix{T}} <: AbstractMatrix{T}
     factors::S
     τ::Vector{T}
-    LQPackedQ{T,S}(factors::AbstractMatrix{T}, τ::Vector{T}) where {T,S<:AbstractMatrix} = new(factors, τ)
 end
-LQPackedQ(factors::AbstractMatrix{T}, τ::Vector{T}) where {T} = LQPackedQ{T,typeof(factors)}(factors, τ)
 
 
 """


### PR DESCRIPTION
This allows other `AbstractMatrix` types for the `factors` field of `LinearAlgebra.LQPackedQ`, using the (previously unused) second type parameter. That way, `factors` does not need to be converted when obtaining the Q matrix from the `LQ` object if the `factors` field of `LQ` is not a `Matrix` (although I’m not sure this ever occurs in reality).

Fixes JuliaLang/LinearAlgebra.jl#810.