### PR TITLE
Use lower limit on number of threads in cmdlineargs test

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -205,7 +205,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     end
     # We want to test oversubscription, but on manycore machines, this can
     # actually exhaust limited PID spaces
-    cpu_threads = max(2*cpu_threads, min(200, 10*cpu_threads))
+    cpu_threads = max(2*cpu_threads, min(50, 10*cpu_threads))
     @test read(`$exename -t $cpu_threads -e $code`, String) == string(cpu_threads)
     withenv("JULIA_NUM_THREADS" => string(cpu_threads)) do
         @test read(`$exename -e $code`, String) == string(cpu_threads)


### PR DESCRIPTION
200 is still too high for some 32-bit systems. See https://github.com/JuliaLang/julia/pull/38633#issuecomment-743383358.

I have no idea how many threads this test actually needs to reliably check oversubscription, so I kept a relatively high value of 50, which fixed the failure on the Fedora build VM where 200 was too high.