### PR TITLE
[Libdl] Use `RTLD_NOLOAD` when calling `dlpath(::String)`

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -237,10 +237,9 @@ julia> dlpath("libjulia")
 ```
 """
 function dlpath(libname::Union{AbstractString, Symbol})
-    handle = dlopen(libname)
-    path = dlpath(handle)
-    dlclose(handle)
-    return path
+    dlopen(libname, RTLD_NOLOAD) do handle
+        return dlpath(handle)
+    end
 end
 
 if Sys.isapple()


### PR DESCRIPTION
This should make it faster and have fewer side-effects to look up the absolute path of libraries.