### PR TITLE
Improve countlines docstring

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -1178,8 +1178,13 @@ julia> io = IOBuffer("JuliaLang is a GitHub organization.");
 julia> countlines(io)
 1
 
+julia> eof(io) # counting lines moves the file pointer
+true
+
+julia> io = IOBuffer("JuliaLang is a GitHub organization.");
+
 julia> countlines(io, eol = '.')
-0
+1
 ```
 """
 function countlines(io::IO; eol::AbstractChar='\n')


### PR DESCRIPTION
The last result was 0, but that's just because the IO has already moved the stream pointer to EOF, not because of anything to do with the `eol` keyword argument.