### PR TITLE
Turn on inference for OpaqueClosure

### DIFF
--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -3,7 +3,7 @@
 function is_argtype_match(@nospecialize(given_argtype),
                           @nospecialize(cache_argtype),
                           overridden_by_const::Bool)
-    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct)
+    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct) || isa(given_argtype, PartialOpaque)
         return is_lattice_equal(given_argtype, cache_argtype)
     end
     return !overridden_by_const
@@ -46,11 +46,11 @@ function matching_cache_argtypes(linfo::MethodInstance, given_argtypes::Vector)
 end
 
 function most_general_argtypes(method::Union{Method, Nothing}, @nospecialize(specTypes),
-    isva::Bool)
+    isva::Bool, withfirst::Bool = true)
     toplevel = method === nothing
     linfo_argtypes = Any[unwrap_unionall(specTypes).parameters...]
     nargs::Int = toplevel ? 0 : method.nargs
-    if !toplevel && method.is_for_opaque_closure
+    if !withfirst
         # For opaque closure, the closure environment is processed elsewhere
         nargs -= 1
     end

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -110,6 +110,10 @@ struct InvokeCallInfo
     match::MethodMatch
 end
 
+struct OpaqueClosureCallInfo
+    mi::MethodInstance
+end
+
 # Stmt infos that are used by external consumers, but not by optimization.
 # These are not produced by default and must be explicitly opted into by
 # the AbstractInterpreter.

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -104,14 +104,6 @@ function invoke_api(li::CodeInstance)
     return ccall(:jl_invoke_api, Cint, (Any,), li)
 end
 
-function has_opaque_closure(c::CodeInfo)
-    for i = 1:length(c.code)
-        stmt = c.code[i]
-        (isa(stmt, Expr) && stmt.head === :new_opaque_closure) && return true
-    end
-    return false
-end
-
 function get_staged(mi::MethodInstance)
     may_invoke_generator(mi) || return nothing
     try

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -44,7 +44,7 @@ let ci = @code_lowered OcClos2Int(1, 2)();
             1, 2))()
     end
 end
-@test oc_self_call_clos() == 3
+@test @inferred(oc_self_call_clos()) == 3
 let opt = @code_typed oc_self_call_clos()
     @test_broken length(opt[1].code) == 1
     @test_broken isa(opt[1].code[1], Core.ReturnNode)
@@ -85,8 +85,8 @@ end
 function complicated_identity(x)
     oc_infer_pass_id()(x)
 end
-@test_broken @inferred(complicated_identity(1)) == 1
-@test_broken @inferred(complicated_identity("a")) == "a"
+@test @inferred(complicated_identity(1)) == 1
+@test @inferred(complicated_identity("a")) == "a"
 let ci = (@code_typed complicated_identity(1))[1]
     @test_broken length(ci.code) == 1
     @test_broken isa(ci.code[1], Core.ReturnNode)


### PR DESCRIPTION
This turns on inference for `PartialOpaque` callees (but no
optimization/inlining yet and also no dynamic dispatch
to the optimized implementations). Because of the current design
and some fixes getting pulled into previous PRs, I believe this
is all that remains to be done on the inference front.

In particular, we specialize the OpaqueClosure methods on
the tuple formed by the tuple type of the environment
(at inference time) and the argument tuples. This is a bit of
an odd method specialization, but it seems like inference
is just fine with it in general. In the fullness of time,
we may want to store the specializations differently
to give more freedom to partial optimizations, but that
would require being able to re-enter inference later, which
is currently not possible.