### PR TITLE
Don't form PartialStructs over tuples of trivial const info

### DIFF
--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -229,8 +229,18 @@ function is_lattice_equal(@nospecialize(a), @nospecialize(b))
         return true
     end
     isa(b, PartialStruct) && return false
-    a isa Const && return false
-    b isa Const && return false
+    if a isa Const
+        if issingletontype(b)
+            return a.val === b.instance
+        end
+        return false
+    end
+    if b isa Const
+        if issingletontype(a)
+            return a.instance === b.val
+        end
+        return false
+    end
     if isa(a, PartialOpaque)
         isa(b, PartialOpaque) || return false
         widenconst(a) == widenconst(b) || return false


### PR DESCRIPTION
This addresses an outstanding TODO in tuple_tfunc. There was
an old comment there that cache logic would need adjusting
for this change. However, we're already doing the equivalent
of this in the inference for :new, so I think most of that
is taken care of. I did notice that `is_lattice_equal`
did not consider `Const` equal a singleton constant (though
they already were lattice equal accoding to ⊑), but other
than that, things seem to just work.

The motiviation here was that these types get a bit messy
when looking at types in the AD world, which have lots of
tuples of lots of different singletons, but this should
also help sysimage size a bit, since we do now store
PartialStruct results.

I also tried going further than this and reversing the
normalization that singleton types be represented as
`Const` elsewhere in inference, but that turned out
pretty messy, since every check for Const basically needed
to be updated to account for it. I'm guessing it's better
to just leave that normalization in place.