### PR TITLE
Protect handle_message from Integer subtype invalidation

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -638,7 +638,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
                         filepath, line; kwargs...)
     @nospecialize
     maxlog = get(kwargs, :maxlog, nothing)
-    if maxlog isa Integer
+    if maxlog isa Core.BuiltinInts
         remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
         logger.message_limits[id] = remaining - 1
         remaining > 0 || return

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -101,7 +101,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     @nospecialize
     hasmaxlog = haskey(kwargs, :maxlog) ? 1 : 0
     maxlog = get(kwargs, :maxlog, nothing)
-    if maxlog isa Integer
+    if maxlog isa Core.BuiltinInts
         remaining = get!(logger.message_limits, id, Int(maxlog)::Int)
         logger.message_limits[id] = remaining - 1
         remaining > 0 || return


### PR DESCRIPTION
Resolves https://github.com/SciML/ArrayInterface.jl/issues/121.
There is a cost, but hopefully there's no strong need to supply
`maxlog` using whacky subtypes of Integer.

@c42f, is this OK?