### PR TITLE
make it possible to serialize SnoopCompile results

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -909,7 +909,7 @@ static int jl_collect_methcache_from_mod(jl_typemap_entry_t *ml, void *closure) 
         size_t i, l = jl_svec_len(specializations);
         for (i = 0; i < l; i++) {
             jl_method_instance_t *callee = (jl_method_instance_t*)jl_svecref(specializations, i);
-            if (callee != NULL)
+            if ((jl_value_t*)callee != jl_nothing)
                 collect_backedges(callee);
         }
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -158,7 +158,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(jl_method_t *m J
                 jl_svec_t *nc = jl_alloc_svec_uninit(ncl);
                 if (i > 0)
                     memcpy((char*)jl_svec_data(nc), jl_svec_data(specializations), sizeof(void*) * i);
-                for(int j = 0; j < ncl - cl; j++)
+                for (int j = 0; j < ncl - cl; j++)
                     jl_svecset(nc, j+i, jl_nothing);
                 if (i < cl)
                     memcpy((char*)jl_svec_data(nc) + sizeof(void*) * (i + ncl - cl),

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -353,9 +353,9 @@ static int precompile_enq_all_specializations__(jl_typemap_entry_t *def, void *c
         jl_svec_t *specializations = def->func.method->specializations;
         size_t i, l = jl_svec_len(specializations);
         for (i = 0; i < l; i++) {
-            jl_method_instance_t *mi = (jl_method_instance_t*)jl_svecref(specializations, i);
-            if (mi != NULL)
-                precompile_enq_specialization_(mi, closure);
+            jl_value_t *mi = jl_svecref(specializations, i);
+            if (mi != jl_nothing)
+                precompile_enq_specialization_((jl_method_instance_t*)mi, closure);
         }
     }
     if (m->ccallable)

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -219,8 +219,8 @@ function instance(f, types)
     if isa(specs, Nothing)
     elseif isa(specs, Core.SimpleVector)
         for i = 1:length(specs)
-            if isassigned(specs, i)
-                mi = specs[i]::Core.MethodInstance
+            mi = specs[i]
+            if mi isa Core.MethodInstance
                 if mi.specTypes <: tt && tt <: mi.specTypes
                     inst = mi
                     break


### PR DESCRIPTION
Addresses #39655. I don't think it will realistically be possible for JLD to support these data structures, but `Serialization` might as well support it at least.

- use `nothing` instead of NULL as a sentinel in specializations. This field is technically visible and we don't support user-visible SimpleVectors with NULLs
- remove some Serializer restrictions around saving Methods. The code path for `method.generator` was broken. We disallowed serializing non-toplevel MethodInstance objects, but I don't see a good reason for that --- we might as well just save the data even if you can't do much with it.