### PR TITLE
Fix formatting in Base.Order.Ordering docstring

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -19,7 +19,7 @@ export # not exported by Base
     lt, ord, ordtype
 
 """
-        Base.Order.Ordering
+    Base.Order.Ordering
 
 Abstract type which represents a total order on some set of elements.
 


### PR DESCRIPTION
Very minor fix - the first line of the `Base.Order.Ordering` docstring is indented by 8 spaces instead of 4, making it look weird in the rendered documentation.