### PR TITLE
Add `Cmd` object notes in the Running External Programs section of the manual.

### DIFF
--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -373,3 +373,13 @@ stages have different latency so they use a different number of parallel workers
 saturated throughput.
 
 We strongly encourage you to try all these examples to see how they work.
+
+## `Cmd` Objects
+[`Cmd`](@ref) objects can also be used. It can customize them with the `dir` keyword to set the working directory,
+`detach` keyword to run the command in a new process group, and `env` keyword to set environment variables.
+
+A simple example is:
+```julia
+Cmd(`pwd`, dir="..")
+```
+

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -375,7 +375,7 @@ saturated throughput.
 We strongly encourage you to try all these examples to see how they work.
 
 ## `Cmd` Objects
-[`Cmd`](@ref) objects can also be used directly, since the cmd syntax does also produce [`Cmd`](@ref) objects.
+The syntax introduced above creates objects of type [`Cmd`](@ref). Such object may also be constructed directly:
 
 ```julia
 run(Cmd(`pwd`, dir=".."))
@@ -383,4 +383,3 @@ run(Cmd(`pwd`, dir=".."))
 
 This way, they may be used to customize them with the `dir` keyword to set the working directory,
 `detach` keyword to run the command in a new process group, and `env` keyword to set environment variables.
-

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -375,11 +375,12 @@ saturated throughput.
 We strongly encourage you to try all these examples to see how they work.
 
 ## `Cmd` Objects
-[`Cmd`](@ref) objects can also be used. It can customize them with the `dir` keyword to set the working directory,
-`detach` keyword to run the command in a new process group, and `env` keyword to set environment variables.
+[`Cmd`](@ref) objects can also be used directly, since the cmd syntax does also produce [`Cmd`](@ref) objects.
 
-A simple example is:
 ```julia
-Cmd(`pwd`, dir="..")
+run(Cmd(`pwd`, dir=".."))
 ```
+
+This way, they may be used to customize them with the `dir` keyword to set the working directory,
+`detach` keyword to run the command in a new process group, and `env` keyword to set environment variables.
 

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -381,5 +381,5 @@ The syntax introduced above creates objects of type [`Cmd`](@ref). Such object m
 run(Cmd(`pwd`, dir=".."))
 ```
 
-This way, they may be used to customize them with the `dir` keyword to set the working directory,
+This way, they may be customized with the `dir` keyword to set the working directory,
 `detach` keyword to run the command in a new process group, and `env` keyword to set environment variables.


### PR DESCRIPTION
I added `Cmd` object notes in the [Running External Programs](https://docs.julialang.org/en/v1/manual/running-external-programs/) section of the manual to fix #19286.