### PR TITLE
Define dottable(::Function)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1216,6 +1216,7 @@ Base.@propagate_inbounds dotview(args...) = Base.maybeview(args...)
 # broadcasting "dot" calls/assignments:
 
 dottable(x) = false # avoid dotting spliced objects (e.g. view calls inserted by @view)
+dottable(x::Function) = dottable(nameof(x))
 # don't add dots to dot operators
 dottable(x::Symbol) = (!isoperator(x) || first(string(x)) != '.' || x === :..) && x !== :(:)
 dottable(x::Expr) = x.head !== :$

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1216,7 +1216,7 @@ Base.@propagate_inbounds dotview(args...) = Base.maybeview(args...)
 # broadcasting "dot" calls/assignments:
 
 dottable(x) = false # avoid dotting spliced objects (e.g. view calls inserted by @view)
-dottable(x::Function) = dottable(nameof(x))
+dottable(x::Function) = true
 # don't add dots to dot operators
 dottable(x::Symbol) = (!isoperator(x) || first(string(x)) != '.' || x === :..) && x !== :(:)
 dottable(x::Expr) = x.head !== :$

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -993,3 +993,6 @@ end
 
     @test Cyclotomic() .* [2, 3] == [[1, 2], [1, 2]]
 end
+
+# dottable test
+@test Broadcast.__dot__(:($(^)(t, 2))) == :($(^).(t, 2))


### PR DESCRIPTION
This makes `__dot__` work on expressions with interpolated functions.
```julia
julia> Broadcast.__dot__(:($(^)(t, 2)))
:((^).(t, 2))
```

Ref: https://github.com/SciML/ModelingToolkit.jl/issues/783#issuecomment-780604522