### PR TITLE
fix #39705: lowering of Expr(:||)

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1928,7 +1928,10 @@
          (stmts (if blk? (cdr (butlast test)) '()))
          (test  (if blk? (last test) test)))
     (if (and (pair? test) (memq (car test) '(&& |\|\||)))
-        (let ((clauses `(,(car test) ,@(map expand-forms (cdr (flatten-ex (car test) test))))))
+        (let* ((clauses `(,(car test) ,@(map expand-forms (cdr (flatten-ex (car test) test)))))
+               (clauses (if (null? (cdr clauses))
+                            (if (eq? (car clauses) '&&) '(true) '(false))
+                            clauses)))
           `(if ,(if blk?
                     `(block ,@(map expand-forms stmts) ,clauses)
                     clauses)

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -405,3 +405,7 @@ end
 
     @test @inferred(intersect(I, J)) == CartesianIndices((2:3, 4:5))
 end
+
+# issue #39705
+f39705() = Base.Cartesian.@nany 0 _ -> true
+@test f39705() === false

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2707,3 +2707,7 @@ end == 4
     @test ncalls_in_lowered(:(.!(1 .< A .< 2)), GlobalRef(Base, :materialize)) == 1
     @test ncalls_in_lowered(:((.!)(1 .< A .< 2)), GlobalRef(Base, :materialize)) == 1
 end
+
+# issue #39705
+@eval f39705(x) = $(Expr(:||)) && x
+@test f39705(1) === false


### PR DESCRIPTION
fixes #39705 