### PR TITLE
AbstractInterpreter: Add a hook to opt into more extensive stmt info

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1007,11 +1007,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
     elseif f === Tuple && la == 2 && !isconcretetype(widenconst(argtypes[2]))
         return CallMeta(Tuple, false)
     elseif is_return_type(f)
-        rt_rt = return_type_tfunc(interp, argtypes, sv)
-        if rt_rt !== nothing
-            return CallMeta(rt_rt, nothing)
-        end
-        return CallMeta(Type, nothing)
+        return return_type_tfunc(interp, argtypes, sv)
     elseif la == 2 && istopfunction(f, :!)
         # handle Conditional propagation through !Bool
         aty = argtypes[2]

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -81,3 +81,13 @@ This info is illegal on any statement that is not an `_apply_iterate` call.
 struct UnionSplitApplyCallInfo
     infos::Vector{ApplyCallInfo}
 end
+
+# Stmt infos that are used by external consumers, but not by optimization.
+# These are not produced by default and must be explicitly opted into by
+# the AbstractInterpreter.
+
+struct ReturnTypeCallInfo
+    # The info corresponding to the call that return_type was supposed to
+    # analyze.
+    info::Any
+end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1634,37 +1634,39 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                 if isa(af_argtype, DataType) && af_argtype <: Tuple
                     argtypes_vec = Any[aft, af_argtype.parameters...]
                     if contains_is(argtypes_vec, Union{})
-                        return Const(Union{})
+                        return CallMeta(Const(Union{}), nothing)
                     end
-                    rt = widenconditional(abstract_call(interp, nothing, argtypes_vec, sv, -1).rt)
+                    call = abstract_call(interp, nothing, argtypes_vec, sv, -1)
+                    info = verbose_stmt_info(interp) ? ReturnTypeCallInfo(call.info) : nothing
+                    rt = widenconditional(call.rt)
                     if isa(rt, Const)
                         # output was computed to be constant
-                        return Const(typeof(rt.val))
+                        return CallMeta(Const(typeof(rt.val)), info)
                     end
                     rt = widenconst(rt)
                     if rt === Bottom || (isconcretetype(rt) && !iskindtype(rt))
                         # output cannot be improved so it is known for certain
-                        return Const(rt)
+                        return CallMeta(Const(rt), info)
                     elseif !isempty(sv.pclimitations)
                         # conservatively express uncertainty of this result
                         # in two ways: both as being a subtype of this, and
                         # because of LimitedAccuracy causes
-                        return Type{<:rt}
+                        return CallMeta(Type{<:rt}, info)
                     elseif (isa(tt, Const) || isconstType(tt)) &&
                         (isa(aft, Const) || isconstType(aft))
                         # input arguments were known for certain
                         # XXX: this doesn't imply we know anything about rt
-                        return Const(rt)
+                        return CallMeta(Const(rt), info)
                     elseif isType(rt)
-                        return Type{rt}
+                        return CallMeta(Type{rt}, info)
                     else
-                        return Type{<:rt}
+                        return CallMeta(Type{<:rt}, info)
                     end
                 end
             end
         end
     end
-    return nothing
+    return CallMeta(Type, nothing)
 end
 
 # N.B.: typename maps type equivalence classes to a single value

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -210,6 +210,7 @@ add_remark!(ni::NativeInterpreter, sv, s) = nothing
 may_optimize(ni::NativeInterpreter) = true
 may_compress(ni::NativeInterpreter) = true
 may_discard_trees(ni::NativeInterpreter) = true
+verbose_stmt_info(ni::NativeInterpreter) = false
 
 method_table(ai::AbstractInterpreter) = InternalMethodTable(get_world_counter(ai))
 


### PR DESCRIPTION
I'm in the process of updating Cthulhu to make use of an AbstractInterpreter
instead of using raw inference queries. Over time Cthulhu has grown many
heuristics for trying to reverse engineer what inference did in order to
present this to the user. Of course, these heuristics are incomplete and
worse, we do already mostly have this information neatly packaged in
the stmt_info field, since optimization needs the same information.
Switching Cthulhu to an AbstractInterpreter gives it access to this info
(as well as allowing it to maintain its own caches, fixing various
weirdness around statement order dependence with the base inference
caches). However, there are a few places in inference where we drop
stmt info that Cthulhu would like to read because the optimizer doesn't
need it. This adds a hook for Cthulhu (and other tooling that would
like to receive it) to get more verbose stmt info out of inference.

As an example, this adds statement info for return_type, which is only
produced on opt in. There is a few more of these, but this shows the
flavor of what I'm going for.

My end goal here is to turn Cthulhu entirely into a viewer for inference
data structures, and not have it contain any heuristics that duplicate
inference functionality. I think we're pretty close to that, but
a few tweaks are required. Hopefully the end result should be a much
more functional and precise Cthulhu (as well as being easier to
maintain, since we get to delete half the code).