### PR TITLE
Add docs for emitting bounds check

### DIFF
--- a/doc/src/devdocs/boundscheck.md
+++ b/doc/src/devdocs/boundscheck.md
@@ -89,3 +89,7 @@ Note this hierarchy has been designed to reduce the likelihood of method ambigui
 to make `checkbounds` the place to specialize on array type, and try to avoid specializations
 on index types; conversely, `checkindex` is intended to be specialized only on index type (especially,
 the last argument).
+
+## Emit bounds checks
+
+Julia can be launched with `--check-bounds={yes|no}` to emit bounds checks always or never (ignoring declarations).


### PR DESCRIPTION
I couldn't find how to emit bounds checks in [the docs where I'd expect it to be](https://docs.julialang.org/en/v1/devdocs/boundscheck/#Eliding-bounds-checks), but there's a useful snippet @jakebolewski pointed out from `julia --help`. This PR adds some docs for emitting bounds checking.