### PR TITLE
Allow scalars to be assigned to 1-element array/subarray

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -258,8 +258,8 @@ function setindex_shape_check(X::AbstractArray{<:Any,2}, i::Integer, j::Integer)
     end
 end
 
-setindex_shape_check(::Any...) =
-    throw(ArgumentError("indexed assignment with a single value to many locations is not supported; perhaps use broadcasting `.=` instead?"))
+setindex_shape_check(X::Any, I::Integer...) =
+    (prod(I) == 1 || throw(ArgumentError("indexed assignment with a single value to many locations is not supported; perhaps use broadcasting `.=` instead?")))
 
 # convert to a supported index type (array or Int)
 """

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -888,13 +888,17 @@ function _setindex!(l::IndexStyle, A::AbstractArray, x, I::Union{Real, AbstractA
     A
 end
 
+_iterate(x::AbstractString) = iterate(Ref(x))
+_iterate(x::Any) = iterate(x)
+iterate(::AbstractString, ::Nothing) = nothing
+
 function _generate_unsafe_setindex!_body(N::Int)
     quote
         x′ = unalias(A, x)
         @nexprs $N d->(I_d = unalias(A, I[d]))
         idxlens = @ncall $N index_lengths I
         @ncall $N setindex_shape_check x′ (d->idxlens[d])
-        Xy = iterate(x′)
+        Xy = _iterate(x′)
         @inbounds @nloops $N i d->I_d begin
             # This is never reached, but serves as an assumption for
             # the optimizer that it does not need to emit error paths

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2904,3 +2904,10 @@ end
     @test [fill(1); fill(2, (2,1,1))] == reshape([1; 2; 2], (3, 1, 1))
     @test_throws DimensionMismatch [fill(1); rand(2, 2, 2)]
 end
+
+@testset "setindex on 1-element range" begin
+    a = [1 2; 3 4]
+    @test a[1:1, 2:2] = 5
+    @test a[1, 2] = 5
+    @test_throws ArgumentError a[1:1, 1:2] = 5
+end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2907,7 +2907,7 @@ end
 
 @testset "setindex on 1-element range" begin
     a = [1 2; 3 4]
-    @test a[1:1, 2:2] = 5
+    a[1:1, 2:2] = 5
     @test a == [1 5; 3 4]
     @test_throws ArgumentError a[1:1, 1:2] = 5
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2910,4 +2910,15 @@ end
     a[1:1, 2:2] = 5
     @test a == [1 5; 3 4]
     @test_throws ArgumentError a[1:1, 1:2] = 5
+
+    # strings are tricky becuase they iterate chars
+    a = fill("test", 3)
+    a[2:2] = "foo"
+    @test a == ["test", "foo", "test"]
+
+    b = fill("test", 3, 3)
+    b[2:2,  2:2] = "foo"
+    @test b == ["test" "test" "test"
+                "test" "foo"  "test"
+                "test" "test" "test"]
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2917,7 +2917,7 @@ end
     @test a == ["test", "foo", "test"]
 
     b = fill("test", 3, 3)
-    b[2:2,  2:2] = "foo"
+    b[2:2, 2:2] = "foo"
     @test b == ["test" "test" "test"
                 "test" "foo"  "test"
                 "test" "test" "test"]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2908,6 +2908,6 @@ end
 @testset "setindex on 1-element range" begin
     a = [1 2; 3 4]
     @test a[1:1, 2:2] = 5
-    @test a[1, 2] = 5
+    @test a == [1 5; 3 4]
     @test_throws ArgumentError a[1:1, 1:2] = 5
 end


### PR DESCRIPTION
`a[1:1, 2:2] = 5` currently errors because `setindex_shape_check` throws an error.

Changing the check to let an item through when the length of the destination is 1 allows setindex to work.

```
a = [1 2; 3 4]
a[1:1, 2:2] = 9
a[1:1, 1:2] = 9 # throws
```

Allowing this makes it easier to work with mixed arrays and scalars. ~~Looking to see if any tests fail.~~ At least it doesn't break anything.