### PR TITLE
fix the description of ctime

### DIFF
--- a/base/stat.jl
+++ b/base/stat.jl
@@ -103,7 +103,7 @@ The fields of the structure are:
 | blksize | The file-system preferred block size for the file                  |
 | blocks  | The number of such blocks allocated                                |
 | mtime   | Unix timestamp of when the file was last modified                  |
-| ctime   | Unix timestamp of when the file was created                        |
+| ctime   | Unix timestamp of when the file's metadata was changed             |
 
 """
 stat(path...) = stat(joinpath(path...))


### PR DESCRIPTION
AFAIK, the `ctime` information returned by `stat` is not the file creation time but the changed time, which indicates "the file's last status change timestamp" according to [inode's manual](https://man7.org/linux/man-pages/man7/inode.7.html). Some filesystems seem to support the birth time (the file creation time) but unfortunately it would be not portable. I think this issue (#31022) stems from the confusion between `mtime` and `ctime` (editing a file changes both, but changing access permission, etc. changes only `ctime`).