### PR TITLE
Use `MACOSX_VERSION_MIN=11` on Apple silicon

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -508,6 +508,9 @@ USEGCC := 0
 USECLANG := 1
 MACOSX_VERSION_MIN := 10.9
 endif
+ifeq ($(shell uname -p),arm)  # Apple Silicon
+MACOSX_VERSION_MIN := 11.0
+endif
 endif
 
 ifeq ($(USEGCC),1)

--- a/Make.inc
+++ b/Make.inc
@@ -488,27 +488,14 @@ USEGCC := 0
 USECLANG := 1
 endif
 
+# Note: Supporting only macOS Mavericks and above
 ifeq ($(OS), Darwin)
-DARWINVER := $(shell uname -r | cut -b 1-2)
-DARWINVER_GTE11 := $(shell expr $(DARWINVER) \>= 11)
-DARWINVER_GTE13 := $(shell expr $(DARWINVER) \>= 13)
-ifeq ($(DARWINVER_GTE11),0) # Snow Leopard specific configuration
-USEGCC := 1
-USECLANG := 0
-MACOSX_VERSION_MIN := 10.6
-OPENBLAS_TARGET_ARCH := NEHALEM
-OPENBLAS_DYNAMIC_ARCH := 0
-USE_SYSTEM_LIBUNWIND := 1
-else ifeq ($(DARWINVER_GTE13),0) # Lion / Mountain Lion specific configuration
+APPLE_ARCH := $(shell uname -m)
 USEGCC := 0
 USECLANG := 1
-MACOSX_VERSION_MIN := 10.6
-else # Newer versions
-USEGCC := 0
-USECLANG := 1
+ifneq ($(APPLE_ARCH),arm64)
 MACOSX_VERSION_MIN := 10.9
-endif
-ifeq ($(shell uname -p),arm)  # Apple Silicon
+else
 MACOSX_VERSION_MIN := 11.0
 endif
 endif

--- a/Make.inc
+++ b/Make.inc
@@ -496,18 +496,17 @@ ifeq ($(DARWINVER_GTE11),0) # Snow Leopard specific configuration
 USEGCC := 1
 USECLANG := 0
 MACOSX_VERSION_MIN := 10.6
-OPENBLAS_TARGET_ARCH:=NEHALEM
-OPENBLAS_DYNAMIC_ARCH:=0
-USE_SYSTEM_LIBUNWIND:=1
-else
-ifeq ($(DARWINVER_GTE13),0) # Lion / Mountain Lion specific configuration
+OPENBLAS_TARGET_ARCH := NEHALEM
+OPENBLAS_DYNAMIC_ARCH := 0
+USE_SYSTEM_LIBUNWIND := 1
+else ifeq ($(DARWINVER_GTE13),0) # Lion / Mountain Lion specific configuration
 USEGCC := 0
 USECLANG := 1
 MACOSX_VERSION_MIN := 10.6
 else # Newer versions
 USEGCC := 0
 USECLANG := 1
-endif
+MACOSX_VERSION_MIN := 10.9
 endif
 endif
 
@@ -539,9 +538,6 @@ JCXXFLAGS := -pipe $(fPIC) -fno-rtti -pedantic
 DEBUGFLAGS := -O0 -g -DJL_DEBUG_BUILD -fstack-protector
 SHIPFLAGS := -O3 -g
 ifeq ($(OS), Darwin)
-ifeq ($(MACOSX_VERSION_MIN),)
-MACOSX_VERSION_MIN := 10.9
-endif
 CC += -mmacosx-version-min=$(MACOSX_VERSION_MIN)
 CXX += -mmacosx-version-min=$(MACOSX_VERSION_MIN)
 FC += -mmacosx-version-min=$(MACOSX_VERSION_MIN)


### PR DESCRIPTION
Sets the minimum macOS version for Apple silicon Macs. As can been [seen in this table](https://en.wikipedia.org/wiki/Xcode#Xcode_11.x_-_12.x_(since_SwiftUI_framework)) Xcode 12.0.0 (the first version to support Apple silicon) uses a macosx-version-min of 10.5.4 for Intel based Macs while Apple silicon Macs use 11.0.

Related to: https://github.com/JuliaLang/julia/issues/36617

