### PR TITLE
Partially fix building gmp on Apple Silicon

### DIFF
--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -17,6 +17,7 @@ $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted: $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) -jxf $<
 	touch -c $(SRCCACHE)/gmp-$(GMP_VER)/configure # old target
+	cp $(SRCDIR)/patches/config.sub $(SRCCACHE)/gmp-$(GMP_VER)/config.sub
 	echo 1 > $@
 
 checksum-gmp: $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2
@@ -28,7 +29,7 @@ $(SRCCACHE)/gmp-$(GMP_VER)/build-patched: $(SRCCACHE)/gmp-$(GMP_VER)/source-extr
 	cd $(dir $@) && patch -p1 < $(SRCDIR)/patches/gmp-apple-arm64.patch
 	echo 1 > $@
 
-$(BUILDDIR)/gmp-$(GMP_VER)/build-configured: $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted
+$(BUILDDIR)/gmp-$(GMP_VER)/build-configured: $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted $(SRCCACHE)/gmp-$(GMP_VER)/build-patched
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CONFIGURE_COMMON) F77= --enable-cxx --enable-shared --disable-static $(GMP_CONFIGURE_OPTS)


### PR DESCRIPTION
This PR fixes these two problem when building GMP from source on Apple silicon:
```
checking build system type... Invalid configuration `arm64-apple-darwin20.2.0': machine `arm64-apple' not recognized
configure: error: /bin/sh /Users/omus/Development/Julia/arm64/latest-src/deps/srccache/gmp-6.2.0/config.sub arm64-apple-darwin20.2.0 failed
```

```
 clang -mmacosx-version-min=10.9 -mcpu=apple-a12 -integrated-as -c -DHAVE_CONFIG_H -I. -I/Users/omus/Development/Julia/arm64/latest-src/deps/srccache/gmp-6.2.0/mpn -I.. -D__GMP_WITHIN_GMP -I/Users/omus/Development/Julia/arm64/latest-src/deps/srccache/gmp-6.2.0 -DOPERATION_bdiv_q_1 -O2 -pedantic -march=armv8-a tmp-bdiv_q_1.s -fno-common -DPIC -o .libs/bdiv_q_1.o
tmp-bdiv_q_1.s:75:2: error: ADR/ADRP relocations must be GOT relative
 adrp x7, :got:__gmp_binvert_limb_table
 ^
tmp-bdiv_q_1.s:75:2: error: unknown AArch64 fixup kind!
 adrp x7, :got:__gmp_binvert_limb_table
 ^
tmp-bdiv_q_1.s:77:2: error: unknown AArch64 fixup kind!
 ldr x7, [x7, #:got_lo12:__gmp_binvert_limb_table]
 ^
make[3]: *** [Makefile:768: bdiv_q_1.lo] Error 1
```

Unfortunately, there yet another problem:
```
tmp-bdiv_q_1.s:74:12: error: expected ')' in parentheses expression
 LEA_HI( x7, ___gmp_binvert_limb_table)
           ^
tmp-bdiv_q_1.s:74:8: error: invalid operand
 LEA_HI( x7, ___gmp_binvert_limb_table)
       ^
tmp-bdiv_q_1.s:76:12: error: expected ')' in parentheses expression
 LEA_LO( x7, ___gmp_binvert_limb_table)
           ^
tmp-bdiv_q_1.s:76:8: error: invalid operand
 LEA_LO( x7, ___gmp_binvert_limb_table)
       ^
make[3]: *** [Makefile:768: bdiv_q_1.lo] Error 1
```
My best guess is that `gmp-apple-arm64.patch` introduced in https://github.com/JuliaLang/julia/pull/36616 needs to be revised.
