### PR TITLE
mark julia.write_barrier readonly on argument

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -687,7 +687,7 @@ static const auto jl_write_barrier_func = new JuliaFunction{
     [](LLVMContext &C) { return AttributeList::get(C,
             Attributes(C, {Attribute::NoUnwind, Attribute::NoRecurse, Attribute::InaccessibleMemOnly}),
             AttributeSet(),
-            None); },
+            {Attributes(C, {Attribute::ReadOnly})}); },
 };
 static const auto jlisa_func = new JuliaFunction{
     "jl_isa",


### PR DESCRIPTION
While it is marked `InaccessibleMemOnly` already, that seems to still be only partially implemented in LLVM.
IIUC `readonly` on the argument is correct since `write_barrier` will escape the pointer but not write to it.

@wsmoses and I noticed this when looking at IR for Enzyme.
