### PR TITLE
RFC: Add cross references in subset related operator's docs.

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -245,6 +245,7 @@ function ⊇ end
     ⊇(b, a) -> Bool
 
 Determine whether every element of `a` is also in `b`, using [`in`](@ref).
+Here are some operators related to subset: [`⊊`](@ref), [`⊈`](@ref).
 
 # Examples
 ```jldoctest
@@ -305,6 +306,7 @@ function ⊋ end
     ⊋(b, a) -> Bool
 
 Determines if `a` is a subset of, but not equal to, `b`.
+Here are some operators related to subset: [`issubset`](@ref)(⊆), [`⊈`](@ref).
 
 # Examples
 ```jldoctest
@@ -328,6 +330,7 @@ function ⊉ end
     ⊉(b, a) -> Bool
 
 Negation of `⊆` and `⊇`, i.e. checks that `a` is not a subset of `b`.
+Here are some operators related to subset: [`issubset`](@ref)(⊆), [`⊊`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -306,7 +306,7 @@ function ⊋ end
     ⊋(b, a) -> Bool
 
 Determines if `a` is a subset of, but not equal to, `b`.
-Here are some operators related to subset: [`issubset`](@ref)(⊆), [`⊈`](@ref).
+Here are some operators related to subset: [`issubset`](@ref) (`⊆`), [`⊈`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -307,7 +307,8 @@ function ⊋ end
     ⊋(b, a) -> Bool
 
 Determines if `a` is a subset of, but not equal to, `b`.
-Here are some operators related to subset: [`issubset`](@ref) (`⊆`), [`⊈`](@ref).
+
+See also [`issubset`](@ref) (`⊆`), [`⊈`](@ref).
 
 # Examples
 ```jldoctest
@@ -331,7 +332,8 @@ function ⊉ end
     ⊉(b, a) -> Bool
 
 Negation of `⊆` and `⊇`, i.e. checks that `a` is not a subset of `b`.
-Here are some operators related to subset: [`issubset`](@ref) (`⊆`), [`⊊`](@ref).
+
+See also [`issubset`](@ref) (`⊆`), [`⊊`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -330,7 +330,7 @@ function ⊉ end
     ⊉(b, a) -> Bool
 
 Negation of `⊆` and `⊇`, i.e. checks that `a` is not a subset of `b`.
-Here are some operators related to subset: [`issubset`](@ref)(⊆), [`⊊`](@ref).
+Here are some operators related to subset: [`issubset`](@ref) (`⊆`), [`⊊`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -245,7 +245,8 @@ function ⊇ end
     ⊇(b, a) -> Bool
 
 Determine whether every element of `a` is also in `b`, using [`in`](@ref).
-Here are some operators related to subset: [`⊊`](@ref), [`⊈`](@ref).
+
+See also [`⊊`](@ref), [`⊈`](@ref).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
I added cross references in subset related operator's docs to fix #22639.
I think adding cross references is a good idea to allows us to find the desired function easily. 