### PR TITLE
proper error for assignment to unary ::

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2230,6 +2230,9 @@
                    `(call (top setindex!) ,arr ,r ,@new-idxs))
                  (unnecessary ,r))))))
          ((|::|)
+          ;; (= (|::| T) rhs) is an error
+          (if (null? (cddr lhs))
+              (error (string "invalid assignment location \"" (deparse lhs) "\"")))
           ;; (= (|::| x T) rhs)
           (let ((x (cadr lhs))
                 (T (caddr lhs))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2726,3 +2726,7 @@ end
 # issue #39705
 @eval f39705(x) = $(Expr(:||)) && x
 @test f39705(1) === false
+
+@test Meta.@lower((::T) = x) == Expr(:error, "invalid assignment location \"::T\"")
+@test Meta.@lower((::T,) = x) == Expr(:error, "invalid assignment location \"::T\"")
+@test Meta.@lower((; ::T) = x) == Expr(:error, "invalid assignment location \"::T\"")


### PR DESCRIPTION
`(::T) = ...` gave `ERROR: syntax: malformed expression` before, this just adds an explicit check to give a proper error message.