### PR TITLE
Give const prop'ed calls their own statement info

### DIFF
--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -82,6 +82,18 @@ struct UnionSplitApplyCallInfo
     infos::Vector{ApplyCallInfo}
 end
 
+"""
+    struct ConstCallInfo
+
+Precision for this call was improved using constant information. This info
+keeps a reference to the result that was used (or created for these)
+constant information.
+"""
+struct ConstCallInfo
+    call::Any
+    result::InferenceResult
+end
+
 # Stmt infos that are used by external consumers, but not by optimization.
 # These are not produced by default and must be explicitly opted into by
 # the AbstractInterpreter.

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -234,7 +234,7 @@ function unswitchtupleunion(u::Union)
     ts = uniontypes(u)
     n = -1
     for t in ts
-        if t isa DataType && t.name === Tuple.name && !isvarargtype(t.parameters[end])
+        if t isa DataType && t.name === Tuple.name && length(t.parameters) != 0 && !isvarargtype(t.parameters[end])
             if n == -1
                 n = length(t.parameters)
             elseif n != length(t.parameters)


### PR DESCRIPTION
My primary motivation here is to let Cthulhu mark cases
where constant propagation improved the result, but this
also lets us avoid the second (linear) lookup in the
inference cache, which causes a marginal, but measurable
(a few percent) improvement in sysimage build time.