### PR TITLE
RFC: expose expand-forms

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -178,6 +178,26 @@ macro lower(mod, code)
     return :(lower($(esc(mod)), $(QuoteNode(code))))
 end
 
+"""
+    expand_forms(m, ex)
+
+Return the unlinearized expanded form of the expression `ex` in the module `m`. This
+expands syntax like indexing expressions or broadcasting into the appropriate function
+calls.
+
+# Examples
+```jldoctest
+julia> Meta.expand_forms(Main, :(a[end]))
+:(Base.getindex(a, Base.lastindex(a)))
+
+julia> Meta.expand_forms(Main, :(a .+ f.(b, c)))
+:(Base.materialize(Base.broadcasted(+, a, Base.broadcasted(f, b, c))))
+```
+
+See also [`lower`](@ref), which returns the output after linearization.
+"""
+expand_forms(m::Module, @nospecialize(ex)) = ccall(:jl_expand_forms, Any, (Any, Any), ex, m)
+
 
 ## interface to parser ##
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -422,6 +422,7 @@ Core.QuoteNode
 Base.macroexpand
 Base.@macroexpand
 Base.@macroexpand1
+Meta.expand_forms
 Base.code_lowered
 Base.code_typed
 Base.precompile

--- a/src/ast.c
+++ b/src/ast.c
@@ -1189,6 +1189,17 @@ JL_DLLEXPORT jl_value_t *jl_macroexpand1(jl_value_t *expr, jl_module_t *inmodule
     return expr;
 }
 
+// first stage of lowering, produces an expanded AST instead of SSA form
+JL_DLLEXPORT jl_value_t *jl_expand_forms(jl_value_t *expr, jl_module_t *inmodule)
+{
+    JL_TIMING(LOWERING);
+    JL_GC_PUSH1(&expr);
+    expr = jl_copy_ast(expr);
+    expr = jl_call_scm_on_ast("expand-forms", expr, inmodule);
+    JL_GC_POP();
+    return expr;
+}
+
 // Lower an expression tree into Julia's intermediate-representation.
 JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr, jl_module_t *inmodule)
 {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1646,6 +1646,7 @@ JL_DLLEXPORT jl_value_t *jl_parse_all(const char *text, size_t text_len,
 JL_DLLEXPORT jl_value_t *jl_parse_string(const char *text, size_t text_len,
                                          int offset, int greedy);
 // lowering
+JL_DLLEXPORT jl_value_t *jl_expand_forms(jl_value_t *expr, jl_module_t *inmodule);
 JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr, jl_module_t *inmodule);
 JL_DLLEXPORT jl_value_t *jl_expand_with_loc(jl_value_t *expr, jl_module_t *inmodule,
                                             const char *file, int line);


### PR DESCRIPTION
I think this is not only useful for more fine-grained introspection, but I also see quite a few macros reimplementing a lot of this logic for certain transformation. One such recent example is #37379, where we might just want to remove a lot of the special cases for `@which` and similar macros and instead expand the expressions first.

One concern of course would be how much we want to expose implementation details of the frontend, as this might complicate future overhauls, but I would assume that even if we wanted to rewrite lowering in Julia at some point, we would likely still have some kind of desugaring pass over the AST, so I don't think this constrains us much in that regard.

I am not sure the module argument is actually needed. IIUC, this really only serves to resolve `(top ...)` and `(core ...)` to `Base` and `Core` accordingly, so we can maybe just always pass `Base` here.