### PR TITLE
Use non-ambiguous ordering in eigen and eigvals test

### DIFF
--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -82,14 +82,15 @@ aimg  = randn(n,n)/2
                 a1_nsg = view(a, 1:n1, 1:n1)
                 a2_nsg = view(a, n1+1:n2, n1+1:n2)
             end
-            f = eigen(a1_nsg, a2_nsg)
+            sortfunc = x -> real(x) + imag(x)
+            f = eigen(a1_nsg, a2_nsg; sortby = sortfunc)
             @test a1_nsg*f.vectors ≈ (a2_nsg*f.vectors) * Diagonal(f.values)
-            @test f.values ≈ eigvals(a1_nsg, a2_nsg)
-            @test prod(f.values) ≈ prod(eigvals(a1_nsg/a2_nsg)) atol=50000ε
-            @test eigvecs(a1_nsg, a2_nsg) == f.vectors
+            @test f.values ≈ eigvals(a1_nsg, a2_nsg; sortby = sortfunc)
+            @test prod(f.values) ≈ prod(eigvals(a1_nsg/a2_nsg, sortby = sortfunc)) atol=50000ε
+            @test eigvecs(a1_nsg, a2_nsg; sortby = sortfunc) == f.vectors
             @test_throws ErrorException f.Z
 
-            d,v = eigen(a1_nsg, a2_nsg)
+            d,v = eigen(a1_nsg, a2_nsg; sortby = sortfunc)
             @test d == f.values
             @test v == f.vectors
         end


### PR DESCRIPTION
This is an attempt to fix a failing test in #39216