### PR TITLE
RFC: Use standard math intrinsics for optimization, replacing back with Julia variants to execute

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -26,7 +26,7 @@ end
 # Trigonometric functions
 # sin methods
 @noinline sin_domain_error(x) = throw(DomainError(x, "sin(x) is only defined for finite x."))
-function sin(x::T) where T<:Union{Float32, Float64}
+function jl_sin(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx < T(pi)/4 #|x| ~<= pi/4, no need for reduction
         if absx < sqrt(eps(T))
@@ -49,6 +49,40 @@ function sin(x::T) where T<:Union{Float32, Float64}
     else
         return -cos_kernel(y)
     end
+end
+
+Base.@ccallable function jl_sin64(x::Float64)::Float64
+    return jl_sin(x)
+end
+
+function sin(x::Float64)
+    func = """declare double @llvm.sin.f64(double)
+        define double @entry(double) #0 {
+        1:
+        %2 = call double @llvm.sin.f64(double %0) #1
+        ret double %2
+        }
+        attributes #0 = { alwaysinline }
+        attributes #1 = { "replace_jl_sin64"}
+    """
+   return Base.llvmcall((func, "entry"), Float64, Tuple{Float64}, x)
+end
+
+Base.@ccallable function jl_sin32(x::Float32)::Float32
+    return jl_sin(x)
+end
+
+function sin(x::Float32)
+    func = """declare float @llvm.sin.f32(float) #1
+        define float @entry(float) #0 {
+        1:
+        %2 = call float @llvm.sin.f32(float %0) #1
+        ret float %2
+        }
+        attributes #0 = { alwaysinline }
+        attributes #1 = { "replace_jl_sin32"}
+    """
+   return Base.llvmcall((func, "entry"), Float32, Tuple{Float32}, x)
 end
 
 # Coefficients in 13th order polynomial approximation on [0; π/4]
@@ -433,7 +467,7 @@ function asin(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx >= T(1.0) # |x|>= 1
         if absx == T(1.0)
-            return flipsign(T(pi)/2, x)
+            return copysign(T(pi)/2, x)
         end
         asin_domain_error(x)
     elseif absx < T(1.0)/2
@@ -598,7 +632,7 @@ function atan(y::T, x::T) where T<:Union{Float32, Float64}
             return -T(pi) # atan(-0, -anything) =-pi
         end
     elseif iszero(x)
-        return flipsign(T(pi)/2, y)
+        return copysign(T(pi)/2, y)
     end
 
     if isinf(x)

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ LLVMLINK :=
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen llvm-ptls
 RUNTIME_SRCS += jitlayers aotcompile debuginfo disasm llvm-simdloop llvm-muladd \
-	llvm-final-gc-lowering llvm-pass-helpers llvm-late-gc-lowering \
+	llvm-final-gc-lowering llvm-pass-helpers llvm-late-gc-lowering llvm-replace \
 	llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces \
 	llvm-multiversioning llvm-alloc-opt cgmemmgr llvm-api llvm-remove-addrspaces \
 	llvm-remove-ni llvm-julia-licm llvm-demote-float16

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -805,6 +805,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
 #if defined(JL_TSAN_ENABLED)
     PM->add(createThreadSanitizerLegacyPassPass());
 #endif
+    PM->add(createReplaceCallPass());
 }
 
 // An LLVM module pass that just runs all julia passes in order. Useful for

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -232,6 +232,7 @@ extern JuliaOJIT *jl_ExecutionEngine;
 
 Pass *createLowerPTLSPass(bool imaging_mode);
 Pass *createCombineMulAddPass();
+Pass *createReplaceCallPass();
 Pass *createFinalLowerGCPass();
 Pass *createLateLowerGCFramePass();
 Pass *createLowerExcHandlersPass();

--- a/src/llvm-replace.cpp
+++ b/src/llvm-replace.cpp
@@ -1,0 +1,73 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#define DEBUG_TYPE "replace"
+#undef DEBUG
+#include "llvm-version.h"
+
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
+#include <llvm/IR/Value.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Operator.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/Debug.h>
+
+#include "julia.h"
+#include "julia_assert.h"
+
+using namespace llvm;
+
+struct ReplaceCall : public FunctionPass {
+    static char ID;
+    ReplaceCall() : FunctionPass(ID)
+    {}
+
+private:
+    bool runOnFunction(Function &F) override;
+};
+
+bool ReplaceCall::runOnFunction(Function &F)
+{
+    for (auto &BB: F) {
+        for (auto it = BB.begin(); it != BB.end();) {
+            auto &I = *it;
+            it++;
+            if (auto CI = dyn_cast<CallInst>(&I)) {
+                for (auto &attr : CI->getAttributes().getAttributes(AttributeList::FunctionIndex)) {
+                    if (attr.isStringAttribute()) {
+                        auto str = attr.getKindAsString();
+                        std::string prefix = "replace_";
+                        if (str.startswith(prefix)) {
+                            auto NewF = F.getParent()->getOrInsertFunction(str.substr(prefix.size()),
+                                CI->getFunctionType());
+                            CI->setCalledOperand(NewF.getCallee());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return true;
+}
+
+char ReplaceCall::ID = 0;
+static RegisterPass<ReplaceCall> X("ReplaceCall", "Replace calls",
+                                     false /* Only looks at CFG */,
+                                     false /* Analysis Pass */);
+
+Pass *createReplaceCallPass()
+{
+    return new ReplaceCall();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddReplaceCallPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createReplaceCallPass());
+}


### PR DESCRIPTION
Julia implements its own version of various intrinsics (e.g. sin). However, the implementation of these intrinsics isn't amenable to standard optimizations (and in fact obscures said optimizations such as vectorization, CSE, etc). This RFC allows Julia functions to appear as standard intrinsics which are replaced by a given Julia function at runtime.

This is demonstrated for the sin function.