### PR TITLE
Fix type instability in showarg

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -257,7 +257,9 @@ function Base.showarg(io::IO, A::PermutedDimsArray{T,N,perm}, toplevel) where {T
     print(io, "PermutedDimsArray(")
     Base.showarg(io, parent(A), false)
     print(io, ", ", perm, ')')
-    toplevel && print(io, " with eltype ", eltype(A))
+    if toplevel
+        print(io, " with eltype ", eltype(A))
+    end
 end
 
 end

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -257,9 +257,8 @@ function Base.showarg(io::IO, A::PermutedDimsArray{T,N,perm}, toplevel) where {T
     print(io, "PermutedDimsArray(")
     Base.showarg(io, parent(A), false)
     print(io, ", ", perm, ')')
-    if toplevel
-        print(io, " with eltype ", eltype(A))
-    end
+    toplevel && print(io, " with eltype ", eltype(A))
+    return nothing
 end
 
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -2768,9 +2768,8 @@ function showarg(io::IO, v::SubArray, toplevel)
     showarg(io, parent(v), false)
     showindices(io, v.indices...)
     print(io, ')')
-    if toplevel
-        print(io, " with eltype ", eltype(v))
-    end
+    toplevel && print(io, " with eltype ", eltype(v))
+    return nothing
 end
 showindices(io, ::Union{Slice,IdentityUnitRange}, inds...) =
     (print(io, ", :"); showindices(io, inds...))
@@ -2783,9 +2782,8 @@ function showarg(io::IO, r::ReshapedArray, toplevel)
     showarg(io, parent(r), false)
     print(io, ", ", join(r.dims, ", "))
     print(io, ')')
-    if toplevel
-        print(io, " with eltype ", eltype(r))
-    end
+    toplevel && print(io, " with eltype ", eltype(r))
+    return nothing
 end
 
 function showarg(io::IO, r::NonReshapedReinterpretArray{T}, toplevel) where {T}
@@ -2798,9 +2796,8 @@ function showarg(io::IO, r::ReshapedReinterpretArray{T}, toplevel) where {T}
     print(io, "reinterpret(reshape, ", T, ", ")
     showarg(io, parent(r), false)
     print(io, ')')
-    if toplevel
-        print(io, " with eltype ", eltype(r))
-    end
+    toplevel && print(io, " with eltype ", eltype(r))
+    return nothing
 end
 
 # printing iterators from Base.Iterators

--- a/base/show.jl
+++ b/base/show.jl
@@ -2768,7 +2768,9 @@ function showarg(io::IO, v::SubArray, toplevel)
     showarg(io, parent(v), false)
     showindices(io, v.indices...)
     print(io, ')')
-    toplevel && print(io, " with eltype ", eltype(v))
+    if toplevel 
+        print(io, " with eltype ", eltype(v))
+    end
 end
 showindices(io, ::Union{Slice,IdentityUnitRange}, inds...) =
     (print(io, ", :"); showindices(io, inds...))
@@ -2781,7 +2783,9 @@ function showarg(io::IO, r::ReshapedArray, toplevel)
     showarg(io, parent(r), false)
     print(io, ", ", join(r.dims, ", "))
     print(io, ')')
-    toplevel && print(io, " with eltype ", eltype(r))
+    if toplevel
+        print(io, " with eltype ", eltype(r))
+    end
 end
 
 function showarg(io::IO, r::NonReshapedReinterpretArray{T}, toplevel) where {T}
@@ -2794,7 +2798,9 @@ function showarg(io::IO, r::ReshapedReinterpretArray{T}, toplevel) where {T}
     print(io, "reinterpret(reshape, ", T, ", ")
     showarg(io, parent(r), false)
     print(io, ')')
-    toplevel && print(io, " with eltype ", eltype(r))
+    if toplevel
+        print(io, " with eltype ", eltype(r))
+    end
 end
 
 # printing iterators from Base.Iterators

--- a/base/show.jl
+++ b/base/show.jl
@@ -2768,7 +2768,7 @@ function showarg(io::IO, v::SubArray, toplevel)
     showarg(io, parent(v), false)
     showindices(io, v.indices...)
     print(io, ')')
-    if toplevel 
+    if toplevel
         print(io, " with eltype ", eltype(v))
     end
 end

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -184,12 +184,14 @@ function Base.showarg(io::IO, v::Adjoint, toplevel)
     Base.showarg(io, parent(v), false)
     print(io, ')')
     toplevel && print(io, " with eltype ", eltype(v))
+    return nothing
 end
 function Base.showarg(io::IO, v::Transpose, toplevel)
     print(io, "transpose(")
     Base.showarg(io, parent(v), false)
     print(io, ')')
     toplevel && print(io, " with eltype ", eltype(v))
+    return nothing
 end
 
 # some aliases for internal convenience use

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -483,6 +483,22 @@ end
                   "$t of "*sprint((io, t) -> show(io, MIME"text/plain"(), t), parent(Fop))
 end
 
+@testset "showarg" begin
+    io = IOBuffer()
+
+    A = ones(Float64, 3,3)
+
+    B = Adjoint(A)
+    @test summary(B) == "3×3 adjoint(::Matrix{Float64}) with eltype Float64"
+    @test Base.showarg(io, B, false) === nothing
+    @test String(take!(io)) == "adjoint(::Matrix{Float64})"
+
+    B = Transpose(A)
+    @test summary(B) == "3×3 transpose(::Matrix{Float64}) with eltype Float64"
+    @test Base.showarg(io, B, false) === nothing
+    @test String(take!(io)) == "transpose(::Matrix{Float64})"
+end
+
 @testset "strided transposes" begin
     for t in (Adjoint, Transpose)
         @test strides(t(rand(3))) == (3, 1)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1578,16 +1578,30 @@ let x = TypeVar(:_), y = TypeVar(:_)
 end
 
 @testset "showarg" begin
+    io = IOBuffer()
+
     A = reshape(Vector(Int16(1):Int16(2*3*5)), 2, 3, 5)
     @test summary(A) == "2×3×5 Array{Int16, 3}"
+    
     v = view(A, :, 3, 2:5)
     @test summary(v) == "2×4 view(::Array{Int16, 3}, :, 3, 2:5) with eltype Int16"
+    @test Base.showarg(io, v, false) === nothing
+    @test String(take!(io)) == "view(::Array{Int16, 3}, :, 3, 2:5)"
+    
     r = reshape(v, 4, 2)
     @test summary(r) == "4×2 reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2) with eltype Int16"
+    @test Base.showarg(io, r, false) === nothing
+    @test String(take!(io)) == "reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2)"
+    
     p = PermutedDimsArray(r, (2, 1))
     @test summary(p) == "2×4 PermutedDimsArray(reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2), (2, 1)) with eltype Int16"
+    @test Base.showarg(io, p, false) === nothing
+    @test String(take!(io)) == "PermutedDimsArray(reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2), (2, 1))"
+    
     p = reinterpret(reshape, Tuple{Float32,Float32}, [1.0f0 3.0f0; 2.0f0 4.0f0])
     @test summary(p) == "2-element reinterpret(reshape, Tuple{Float32, Float32}, ::Matrix{Float32}) with eltype Tuple{Float32, Float32}"
+    @test Base.showarg(io, p, false) === nothing
+    @test String(take!(io)) == "reinterpret(reshape, Tuple{Float32, Float32}, ::Matrix{Float32})"
 end
 
 @testset "Methods" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -1582,22 +1582,22 @@ end
 
     A = reshape(Vector(Int16(1):Int16(2*3*5)), 2, 3, 5)
     @test summary(A) == "2×3×5 Array{Int16, 3}"
-    
+
     v = view(A, :, 3, 2:5)
     @test summary(v) == "2×4 view(::Array{Int16, 3}, :, 3, 2:5) with eltype Int16"
     @test Base.showarg(io, v, false) === nothing
     @test String(take!(io)) == "view(::Array{Int16, 3}, :, 3, 2:5)"
-    
+
     r = reshape(v, 4, 2)
     @test summary(r) == "4×2 reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2) with eltype Int16"
     @test Base.showarg(io, r, false) === nothing
     @test String(take!(io)) == "reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2)"
-    
+
     p = PermutedDimsArray(r, (2, 1))
     @test summary(p) == "2×4 PermutedDimsArray(reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2), (2, 1)) with eltype Int16"
     @test Base.showarg(io, p, false) === nothing
     @test String(take!(io)) == "PermutedDimsArray(reshape(view(::Array{Int16, 3}, :, 3, 2:5), 4, 2), (2, 1))"
-    
+
     p = reinterpret(reshape, Tuple{Float32,Float32}, [1.0f0 3.0f0; 2.0f0 4.0f0])
     @test summary(p) == "2-element reinterpret(reshape, Tuple{Float32, Float32}, ::Matrix{Float32}) with eltype Tuple{Float32, Float32}"
     @test Base.showarg(io, p, false) === nothing


### PR DESCRIPTION
The last line in certain `showarg` methods is of the form `toplevel && print(io, ...)`. This introduces an unnecessary type-instability aside from corrupting the display if `toplevel` is `false`:

```julia
julia> A = reshape(Vector(Int16(1):Int16(2*3*5)), 2, 3, 5);

julia> v = view(A, :, 3, 2:5);

julia> Base.showarg(stdout, v, false)
view(::Array{Int16, 3}, :, 3, 2:5)false
```

After this PR:
```julia
julia> Base.showarg(stdout, v, false)
view(::Array{Int16, 3}, :, 3, 2:5)
```