### PR TITLE
jl_egal_types: don't reject equivalence just for gensyms

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1395,7 +1395,7 @@ static int equiv_type(jl_value_t *ta, jl_value_t *tb)
     while (jl_is_unionall(a)) {
         jl_unionall_t *ua = (jl_unionall_t*)a;
         jl_unionall_t *ub = (jl_unionall_t*)b;
-        if (!jl_egal(ua->var->lb, ub->var->lb) || !jl_egal(ua->var->ub, ub->var->ub) ||
+        if (!jl_types_egal(ua->var->lb, ub->var->lb) || !jl_types_egal(ua->var->ub, ub->var->ub) ||
             ua->var->name != ub->var->name)
             goto no;
         a = jl_instantiate_unionall(ua, (jl_value_t*)ub->var);

--- a/test/core.jl
+++ b/test/core.jl
@@ -7289,11 +7289,27 @@ end
 
 # issue #36104
 module M36104
+using Test
 struct T36104
     v::Vector{M36104.T36104}
 end
 struct T36104   # check that redefining it works, issue #21816
     v::Vector{T36104}
+end
+# with a gensymmed unionall
+struct Symmetric{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
+    data::S
+    uplo::Char
+end
+struct Symmetric{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
+    data::S
+    uplo::Char
+end
+@test_throws ErrorException begin
+    struct Symmetric{T,S<:AbstractMatrix{T}} <: AbstractMatrix{T}
+        data::S
+        uplo::Char
+    end
 end
 end
 @test fieldtypes(M36104.T36104) == (Vector{M36104.T36104},)


### PR DESCRIPTION
This fixes the following:

```
julia> struct Symmetric{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
           data::S
           uplo::Char
       end

julia> struct Symmetric{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
           data::S
           uplo::Char
       end
ERROR: invalid redefinition of constant Symmetric
```

`Core._equiv_typedef` returns false which ends up triggering the error.

This is the main part of fixing https://github.com/timholy/Revise.jl/issues/599.