### PR TITLE
Include address in opaque method's show output

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -198,6 +198,7 @@ function sym_to_string(sym)
 end
 
 function show(io::IO, m::Method)
+    is_opaque_closure_method(m) && return show_method_with_pointer(io, m)
     tv, decls, file, line = arg_decl_parts(m)
     sig = unwrap_unionall(m.sig)
     if sig === Tuple
@@ -296,6 +297,17 @@ end
 
 show(io::IO, ms::MethodList) = show_method_table(io, ms)
 show(io::IO, mt::Core.MethodTable) = show_method_table(io, MethodList(mt))
+
+function is_opaque_closure_method(m::Method)
+    sig = unwrap_unionall(m.sig)
+    return sig === Tuple && m.name === Symbol("opaque closure")
+    # ASK: what is the proper way to detect opaque closure?
+end
+
+function show_method_with_pointer(io::IO, m::Method)
+    hexstr = string(UInt(pointer_from_objref(m)), base = 16, pad = Sys.WORD_SIZE>>2)
+    print(io, m.name, " @0x", hexstr, " in ", m.module)
+end
 
 function inbase(m::Module)
     if m == Base

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -154,6 +154,9 @@ mk_va_opaque() = @opaque (x...)->x
 # OpaqueClosure show method
 @test repr(@opaque x->1) == "(::Any)::Any->◌"
 
+# Opaque closure method show method
+@test contains(repr((@opaque x->1).source), "opaque closure @0x")
+
 # Opaque closure in CodeInfo returned from generated functions
 function mk_ocg(args...)
     ci = @code_lowered const_int()


### PR DESCRIPTION
This PR tweaks `show` for Opaque Closure method to include the address.

Before:

```julia
julia> (Base.Experimental.@opaque () -> 123).source
opaque closure(...) in Main
```

After:

```julia
julia> (Base.Experimental.@opaque () -> 123).source
opaque closure @0x00007fb20cb211f0 in Main

julia> m = Base.unsafe_pointer_to_objref(Base.reinterpret(Ptr{Cvoid}, 0x00007fb20cb211f0))
opaque closure @0x00007fb20cb211f0 in Main

julia> Base.uncompressed_ir(m)
CodeInfo(
    @ REPL[7]:1 within `opaque closure'
1 ─     return 123
)
```

This is something I find it useful in #39773 while hacking with Opaque Closures. So, I thought it might make sense to extract it out from #39773.

This PR lets us see the pointer to Opaque Closure in `:new_opaque_closure` IR so that the body of Opaque Closure can be revealed by `m = Base.unsafe_pointer_to_objref(Base.reinterpret(Ptr{Cvoid}, $THE_ADDRESS))` (as in the example above and in #39773). This is handy when you want to know what is happening inside the Opaque Closure.

I just realized that @Keno is already started working on introspection for Opaque Closures with Cthulhu.jl https://github.com/JuliaDebug/Cthulhu.jl/pull/126. But maybe it's also nice to have a very "low tech" way to get Opaque Closure methods?
