### PR TITLE
clarify non-scalar indexed assignment

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -259,7 +259,7 @@ function setindex_shape_check(X::AbstractArray{<:Any,2}, i::Integer, j::Integer)
 end
 
 setindex_shape_check(::Any...) =
-    throw(ArgumentError("indexed assignment with a single value to many locations is not supported; perhaps use broadcasting `.=` instead?"))
+    throw(ArgumentError("indexed assignment with a single value to possibly many locations is not supported; perhaps use broadcasting `.=` instead?"))
 
 # convert to a supported index type (array or Int)
 """

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -470,7 +470,7 @@ overwritten with the value of `X`, [`convert`](@ref)ing to the
 [`eltype`](@ref) of `A` if necessary.
 
 
-If any index `I_k` has one or more dimensions, then the right hand side `X` must be an
+If any index `I_k` is itself an array, then the right hand side `X` must also be an
 array with the same shape as the result of indexing `A[I_1, I_2, ..., I_n]` or a vector with
 the same number of elements. The value in location `I_1[i_1], I_2[i_2], ..., I_n[i_n]` of
 `A` is overwritten with the value `X[I_1, I_2, ..., I_n]`, converting if necessary. The

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -470,7 +470,7 @@ overwritten with the value of `X`, [`convert`](@ref)ing to the
 [`eltype`](@ref) of `A` if necessary.
 
 
-If any index `I_k` selects more than one location, then the right hand side `X` must be an
+If any index `I_k` has one or more dimensions, then the right hand side `X` must be an
 array with the same shape as the result of indexing `A[I_1, I_2, ..., I_n]` or a vector with
 the same number of elements. The value in location `I_1[i_1], I_2[i_2], ..., I_n[i_n]` of
 `A` is overwritten with the value `X[I_1, I_2, ..., I_n]`, converting if necessary. The


### PR DESCRIPTION
The key isn't that indices select more than one location, it's that they _could_ select more than one element.  That is, that they have one or more dimensions.

Ref: #39725