### PR TITLE
Remove inlining's dependence on method table lookups

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1111,7 +1111,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         elseif la == 3
             ub_var = argtypes[3]
         end
-        return CallMeta(typevar_tfunc(n, lb_var, ub_var), nothing)
+        return CallMeta(typevar_tfunc(n, lb_var, ub_var), false)
     elseif f === UnionAll
         return CallMeta(abstract_call_unionall(argtypes), false)
     elseif f === Tuple && la == 2 && !isconcretetype(widenconst(argtypes[2]))

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -875,8 +875,10 @@ function abstract_apply(interp::AbstractInterpreter, @nospecialize(itft), @nospe
         push!(retinfos, ApplyCallInfo(call.info, arginfo))
         res = tmerge(res, call.rt)
         if bail_out_apply(interp, res, sv)
-            # No point carrying forward the info, we're not gonna inline it anyway
-            retinfo = false
+            if i != length(ctypes)
+                # No point carrying forward the info, we're not gonna inline it anyway
+                retinfo = false
+            end
             break
         end
     end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -26,11 +26,10 @@ struct InferenceCaches{T, S}
     mi_cache::S
 end
 
-struct InliningState{S <: Union{EdgeTracker, Nothing}, T <: Union{InferenceCaches, Nothing}, V <: Union{Nothing, MethodTableView}}
+struct InliningState{S <: Union{EdgeTracker, Nothing}, T <: Union{InferenceCaches, Nothing}}
     params::OptimizationParams
     et::S
     caches::T
-    method_table::V
 end
 
 mutable struct OptimizationState
@@ -49,8 +48,7 @@ mutable struct OptimizationState
             EdgeTracker(s_edges, frame.valid_worlds),
             InferenceCaches(
                 get_inference_cache(interp),
-                WorldView(code_cache(interp), frame.world)),
-            method_table(interp))
+                WorldView(code_cache(interp), frame.world)))
         return new(frame.linfo,
                    frame.src, frame.stmt_info, frame.mod, frame.nargs,
                    frame.sptypes, frame.slottypes, false,
@@ -85,8 +83,7 @@ mutable struct OptimizationState
             nothing,
             InferenceCaches(
                 get_inference_cache(interp),
-                WorldView(code_cache(interp), get_world_counter())),
-            method_table(interp))
+                WorldView(code_cache(interp), get_world_counter())))
         return new(linfo,
                    src, stmt_info, inmodule, nargs,
                    sptypes_from_meth_instance(linfo), slottypes, false,

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1386,6 +1386,11 @@ function late_inline_special_case!(ir::IRCode, sig::Signature, idx::Int, stmt::E
         subtype_call = Expr(:call, GlobalRef(Core, :(<:)), stmt.args[3], stmt.args[2])
         ir[SSAValue(idx)] = subtype_call
         return true
+    elseif params.inlining && f === TypeVar && 2 <= length(atypes) <= 4 && (atypes[2] ⊑ Symbol)
+        ir[SSAValue(idx)] = Expr(:call, GlobalRef(Core, :_typevar), stmt.args[2],
+            length(stmt.args) < 4 ? Bottom : stmt.args[3],
+            length(stmt.args) == 2 ? Any : stmt.args[end])
+        return true
     elseif is_return_type(f)
         if isconstType(typ)
             ir[SSAValue(idx)] = quoted(typ.parameters[1])

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1226,13 +1226,12 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
         end
 
         # Ok, now figure out what method to call
-        nu = unionsplitcost(sig.atypes)
-        if nu == 1 || nu > state.params.MAX_UNION_SPLITTING
-            isa(info, MethodMatchInfo) || continue
+        if isa(info, MethodMatchInfo)
             infos = MethodMatchInfo[info]
-        else
-            isa(info, UnionSplitInfo) || continue
+        elseif isa(info, UnionSplitInfo)
             infos = info.matches
+        else
+            continue
         end
 
         analyze_single_call!(ir, todo, idx, stmt, sig, calltype, infos, state.et, state.caches, state.params)

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -94,6 +94,16 @@ struct ConstCallInfo
     result::InferenceResult
 end
 
+"""
+    struct InvokeCallInfo
+
+Represents a resolved call to `invoke`, carrying the Method match of the
+method being processed.
+"""
+struct InvokeCallInfo
+    match::MethodMatch
+end
+
 # Stmt infos that are used by external consumers, but not by optimization.
 # These are not produced by default and must be explicitly opted into by
 # the AbstractInterpreter.

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -15,11 +15,17 @@ end
 """
     struct MethodResultPure
 
-This singleton represents a method result constant was proven to be
+This struct represents a method result constant was proven to be
 effect-free, including being no-throw (typically because the value was computed
 by calling an `@pure` function).
 """
-struct MethodResultPure end
+struct MethodResultPure
+    info::Any
+end
+let instance = MethodResultPure(false)
+    global MethodResultPure
+    MethodResultPure() = instance
+end
 
 """
     struct UnionSplitInfo

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1609,10 +1609,10 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                 if isa(af_argtype, DataType) && af_argtype <: Tuple
                     argtypes_vec = Any[aft, af_argtype.parameters...]
                     if contains_is(argtypes_vec, Union{})
-                        return CallMeta(Const(Union{}), nothing)
+                        return CallMeta(Const(Union{}), false)
                     end
                     call = abstract_call(interp, nothing, argtypes_vec, sv, -1)
-                    info = verbose_stmt_info(interp) ? ReturnTypeCallInfo(call.info) : nothing
+                    info = verbose_stmt_info(interp) ? ReturnTypeCallInfo(call.info) : false
                     rt = widenconditional(call.rt)
                     if isa(rt, Const)
                         # output was computed to be constant
@@ -1641,7 +1641,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
             end
         end
     end
-    return CallMeta(Type, nothing)
+    return CallMeta(Type, false)
 end
 
 # N.B.: typename maps type equivalence classes to a single value

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1285,25 +1285,6 @@ function apply_type_tfunc(@nospecialize(headtypetype), @nospecialize args...)
 end
 add_tfunc(apply_type, 1, INT_INF, apply_type_tfunc, 10)
 
-function invoke_tfunc(interp::AbstractInterpreter, @nospecialize(ft), @nospecialize(types), @nospecialize(argtype), sv::InferenceState)
-    argtype = typeintersect(types, argtype)
-    argtype === Bottom && return Bottom
-    argtype isa DataType || return Any # other cases are not implemented below
-    isdispatchelem(ft) || return Any # check that we might not have a subtype of `ft` at runtime, before doing supertype lookup below
-    types = rewrap_unionall(Tuple{ft, unwrap_unionall(types).parameters...}, types)
-    argtype = Tuple{ft, argtype.parameters...}
-    result = findsup(types, method_table(interp))
-    if result === nothing
-        return Any
-    end
-    method, valid_worlds = result
-    update_valid_age!(sv, valid_worlds)
-    (ti, env) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), argtype, method.sig)::SimpleVector
-    rt, edge = typeinf_edge(interp, method, ti, env, sv)
-    edge !== nothing && add_backedge!(edge::MethodInstance, sv)
-    return rt
-end
-
 function has_struct_const_info(x)
     isa(x, PartialTypeVar) && return true
     isa(x, Conditional) && return true
@@ -1489,26 +1470,6 @@ function builtin_tfunction(interp::AbstractInterpreter, @nospecialize(f), argtyp
                            sv::Union{InferenceState,Nothing})
     if f === tuple
         return tuple_tfunc(argtypes)
-    elseif f === invoke
-        if length(argtypes) > 1 && sv !== nothing && (isa(argtypes[1], Const) || isa(argtypes[1], Type))
-            if isa(argtypes[1], Const)
-                ft = Core.Typeof(argtypes[1].val)
-            else
-                ft = argtypes[1]
-            end
-            sig = argtypes[2]
-            if isa(sig, Const)
-                sigty = sig.val
-            elseif isType(sig)
-                sigty = sig.parameters[1]
-            else
-                sigty = nothing
-            end
-            if isa(sigty, Type) && !has_free_typevars(sigty) && sigty <: Tuple
-                return invoke_tfunc(interp, ft, sigty, argtypes_to_type(argtypes[3:end]), sv)
-            end
-        end
-        return Any
     end
     if isa(f, IntrinsicFunction)
         if is_pure_intrinsic_infer(f) && _all(@nospecialize(a) -> isa(a, Const), argtypes)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -362,3 +362,16 @@ function pure_elim_full()
 end
 
 @test fully_eliminated(pure_elim_full, Tuple{})
+
+# Union splitting of convert
+f_convert_missing(x) = convert(Int64, x)
+let ci = code_typed(f_convert_missing, Tuple{Union{Int64, Missing}})[1][1],
+    ci_unopt = code_typed(f_convert_missing, Tuple{Union{Int64, Missing}}; optimize=false)[1][1]
+    # We want to check that inlining was able to union split this, but we don't
+    # want to make the test too specific to the exact structure that inlining
+    # generates, so instead, we just check that the compiler made it bigger.
+    # There are performance tests that are also sensitive to union splitting
+    # here, so a non-obvious regression
+    @test length(ci.code) >
+        length(ci_unopt.code)
+end


### PR DESCRIPTION
When we switched to stmtinfo, we mostly stopped relying on doing method lookups during inlining.
However, there were a few leftover exceptions, in particular

1. Special cases like the TypeVar constructor, which had special support in inference and thus did not look into the methods that are supposed to be inlined.
2. Inlining support for :invoke

This addresses these as well as a few corner cases that are arguable bugs. To address the first kind, we simply need a special purpose inliner that can understand how to properly inline the call despite not having method information. It turns out we already had this for a number of these cases, this PR just completes that. For invoke, we simply need to add a new statement info type and plumb the information through from inference.

Lastly, there is the use case of external optimization pipelines wanting to run multiple iterations of inlining after some more aggressive optimizations. However, I think that is better addressed by those external pipelines annotating the proper info object in a separate pass. One missing ingredient here is that we currently drop info objects after inlining in the optimizer, but I'm working on a separate PR that should address that as well.

I instrumented the fallback case and with this, they are dead code. There are a few cases that we might want to consider giving special purpose inliners in the future (e.g. typename and typejoin), but they weren't being inlined anyway because inference was never visiting them to populate any caches, so this is not a change of behavior.