### PR TITLE
RFC: remove special case for serializing Ptrs as NULL

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -188,8 +188,6 @@ end
 serialize(s::AbstractSerializer, x::Bool) = x ? writetag(s.io, TRUE_TAG) :
                                                 writetag(s.io, FALSE_TAG)
 
-serialize(s::AbstractSerializer, p::Ptr) = serialize_any(s, oftype(p, C_NULL))
-
 serialize(s::AbstractSerializer, ::Tuple{}) = writetag(s.io, EMPTYTUPLE_TAG)
 
 function serialize(s::AbstractSerializer, t::Tuple)
@@ -732,8 +730,8 @@ end
 Write an arbitrary value to a stream in an opaque format, such that it can be read back by
 [`deserialize`](@ref). The read-back value will be as identical as possible to the original.
 In general, this process will not work if the reading and writing are done by different
-versions of Julia, or an instance of Julia with a different system image. `Ptr` values are
-serialized as all-zero bit patterns (`NULL`).
+versions of Julia, or an instance of Julia with a different system image. `Ptr` values
+may cause problems if deserialized in a different process.
 
 An 8-byte identifying header is written to the stream first. To avoid writing the header,
 construct a `Serializer` and use it as the first argument to `serialize` instead.


### PR DESCRIPTION
There are several reasons I think we should do this.

- The feature is brittle and does not fully work. For example the data in a `Vector{Ptr{Cvoid}}` gets saved verbatim. It seems like quite a drag to search through every bits type trying to NULL out pointers.
- Any type that makes sense to serialize but contains a Ptr should probably just have a `serialize` method itself.
- There are use cases for saving pointers, e.g. if you have some serialized debug data plus a core file.
- Arguably surprising to clobber data by default.

If the current behavior is useful for `Distributed`, I'd be willing to bring it back for `ClusterSerializer`.

Is anybody aware of a case where the current behavior is useful and does the right thing?

Note that we also do this when saving precompiled modules, but I think that's arguably a different case, similar to static data in compiled executables. There, you might want to detect that some data has not been initialized yet and handle it.
