### PR TITLE
Refactor test/ranges.jl range construction

### DIFF
--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -71,7 +71,7 @@
             @test q === range(; start, stop             )
             @test q ==  range(; start, stop, step       )
             @test q ==  range(; start, stop,      length)
-            @test q ≈   range(;        stop,      length)
+            @test q ==  range(;        stop,      length)
         end
     end
     @testset "range(start, stop, length)" begin


### PR DESCRIPTION
# Refactor test/ranges.jl "range construction" testsets

Over several pull requests the inner ` @testset "range(;kw...)"` in test/ranges.jl introduced in #38041 by @jw3126 to test the all keyword form of range was lost. Here we reintroduce it and add separate test sets for `range(start, stop)` and `range(start, stop, length)`.

## Let block and compact keyword syntax

The tests are also reformatted to use a `let` block rather than repeatedly calling `first`, `last`, `step`, and `length`. The `let` block also allows use to use the compact keyword calling syntax when the variable name matches the keyword name. Alignment is kept across the test sets.

## Additional malformed calls of ranges

Additionally, several malformed calls of `range` are added based on other pull requests where such forms were proposed and found to be problematic or otherwise declined.

## Summary

In summary, the refactor results in the following form with distinct tests groups for the `range(; kw...)`, `range(start, stop)`, and `range(start, stop, length)`.

```julia
@testset "range construction" begin
    @testset "range(; kw...)" begin
        ...
        let start=first(r), stop=last(r), step=step(r), length=length(r)
            @test r === range(; start, stop, step        )
            @test r === range(; start, stop,       length)
            ...
        end
    end
    @testset "range(start, stop)" begin
        ...
        let start=first(r), stop=last(r), step=step(r), length=length(r)
            q = range(start, stop)
            ...
            @test q === range(  start;            length)
            ...
        end
    end
    @testset "range(start, stop, length)" begin
        ...
    end
end
```

History:
1. Extracted from #39241 and related feature branches. This pull request only add tests and no new features.