### PR TITLE
make copy correctly handle 0-dimensional SubArray

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -69,7 +69,10 @@ sizeof(V::SubArray{<:Any,<:Any,<:Array}) = length(V) * elsize(V.parent)
 
 function Base.copy(V::SubArray)
     v = V.parent[V.indices...]
-    return ndims(V) == 0 ? fill(v) : v
+    ndims(V) == 0 || return v
+    x = similar(V) # ensure proper type of x
+    x[] = v
+    return x
 end
 
 parent(V::SubArray) = V.parent

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -67,7 +67,10 @@ similar(V::SubArray, T::Type, dims::Dims) = similar(V.parent, T, dims)
 sizeof(V::SubArray) = length(V) * sizeof(eltype(V))
 sizeof(V::SubArray{<:Any,<:Any,<:Array}) = length(V) * elsize(V.parent)
 
-copy(V::SubArray) = V.parent[V.indices...]
+function Base.copy(V::SubArray)
+    v = V.parent[V.indices...]
+    return ndims(V) == 0 ? fill(v) : v
+end
 
 parent(V::SubArray) = V.parent
 parentindices(V::SubArray) = V.indices

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -712,3 +712,9 @@ using .Main.InfiniteArrays, Base64
     @test size(v) == (Infinity(),)
     @test stringmime("text/plain", v; context=(:limit => true)) == "$(Infinity())-element view(::$(OneToInf{Int}), 1:1:$(Infinity())) with eltype $Int with indices 1:1:$(Infinity()):\n  1\n  2\n  3\n  4\n  5\n  6\n  7\n  8\n  9\n 10\n  ⋮"
 end
+
+@testset "PR #39809: copy on 0-dimensional SubArray" begin
+    v = [[1]]
+    s = @view v[1]
+    @test copy(s) == fill([1])
+end


### PR DESCRIPTION
The current definition of `copy` for `SubArray` [here](https://github.com/JuliaLang/julia/blob/master/base/subarray.jl#L70) has the following consequence:
```
julia> x = [1]
1-element Array{Int64,1}:
 1

julia> y = @view x[1]
0-dimensional view(::Array{Int64,1}, 1) with eltype Int64:
1

julia> copy(y)
1
```

which is inconsistent with the contract for `copy` that promises to produce an array when array is copied, e.g.:
```
julia> x = fill(1)
0-dimensional Array{Int64,0}:
1

julia> copy(x)
0-dimensional Array{Int64,0}:
1
```