### PR TITLE
choosetests: add a couple missing tests

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -55,7 +55,7 @@ function choosetests(choices = [])
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
         "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
-        "smallarrayshrink", "opaque_closure"
+        "smallarrayshrink", "opaque_closure", "filesystem", "download"
     ]
 
     tests = []
@@ -112,7 +112,8 @@ function choosetests(choices = [])
         filter!(x -> (x != "Profile"), tests)
     end
 
-    net_required_for = ["Sockets", "LibGit2", "LibCURL", "Downloads", "Artifacts", "LazyArtifacts"]
+    net_required_for = ["download", "Sockets", "LibGit2", "LibCURL", "Downloads",
+                        "Artifacts", "LazyArtifacts"]
     net_on = true
     try
         ipa = getipaddr()

--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -10,6 +10,7 @@ mktempdir() do dir
   # test filesystem truncate (shorten)
   file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
   Base.Filesystem.truncate(file, 2)
+  text = text[1:2]
   @test length(read(file)) == 2
   close(file)
 


### PR DESCRIPTION
Three files are not listed in `testnames` in the `choosetests` function: ["download", "filesystem", "stack_overflow"]`.
Still, the "download" test is run on CI, but not when running `Base.runtests()`. @vtjnash suggested:

> I think downloads pre-dated that and is explicitly listed in the buildbot config instead

It would seem better to me to have it in `testnames`, but this should be then removed from the buildbot config.

Jameson also suggested to leave out "stack_overflow" which is buggy. 