### PR TITLE
[BugReporting] pass `ARGS` through properly

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -404,7 +404,7 @@ function report_bug(kind)
     else
         BugReporting = Base.require(BugReportingId)
     end
-    return Base.invokelatest(BugReporting.make_interactive_report, kind)
+    return Base.invokelatest(BugReporting.make_interactive_report, kind, ARGS)
 end
 
 end


### PR DESCRIPTION
When calling `make_interactive_report()`, we really need to pass in
`ARGS` as well, otherwise it always starts an interactive session.

This commit, in combination with `--` allows the user to run an `rr`
session while still passing arguments to the child `julia` process via:

```
julia --bug-report=rr -- --project test/runtests.jl
```