### PR TITLE
Backport "[build] Fix `full-source-dist` downloading LibOSXUnwind..." to release-1.5

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -178,7 +178,17 @@ install: $(addprefix install-, $(DEP_LIBS))
 cleanall: $(addprefix clean-, $(DEP_LIBS))
 distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)
-getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-osxunwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-curl get-libgit2 get-libwhich
+getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-curl get-libgit2 get-libwhich
+
+# If we're building for MacOS, no matter what, `getall` should include `osxunwind`
+ifeq ($(OS),Darwin)
+getall: get-osxunwind
+endif
+
+# Same if we're building a purely-source archive, always include `osxunwind`
+ifeq ($(USE_BINARYBUILDER_OSXUNWIND),0)
+getall: get-osxunwind
+endif
 
 include $(SRCDIR)/llvm.mk
 include $(SRCDIR)/libuv.mk


### PR DESCRIPTION
[The buildbots are unhappy with `release-1.5`](https://build.julialang.org/#/builders/34/builds/1069/steps/15/logs/stdio) for lack of [this commit](https://github.com/JuliaLang/julia/commit/3df8f6442861b194db77801cff3a0efb53100d2b). This pull request backports said commit to `release-1.5`. Much thanks to @staticfloat and @ararslan for sorting this out! :)