### PR TITLE
simplify and improve printing of qualified names

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -28,16 +28,7 @@ Base.Symbol(x::Enum) = namemap(typeof(x))[Integer(x)]::Symbol
 Base.print(io::IO, x::Enum) = print(io, Symbol(x))
 
 function Base.show(io::IO, x::Enum)
-    sym = Symbol(x)
-    if !(get(io, :compact, false)::Bool)
-        from = get(io, :module, Main)
-        def = typeof(x).name.module
-        if from === nothing || !Base.isvisible(sym, def, from)
-            show(io, def)
-            print(io, ".")
-        end
-    end
-    print(io, sym)
+    Base.print_qualified_name(io, parentmodule(typeof(x)), Symbol(x))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", x::Enum)

--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -60,7 +60,7 @@ Atomic objects can be accessed using the `[]` notation:
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> x[] = 1
 1
@@ -100,17 +100,17 @@ time.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_cas!(x, 4, 2);
 
 julia> x
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_cas!(x, 3, 2);
 
 julia> x
-Base.Threads.Atomic{Int64}(2)
+Threads.Atomic{Int64}(2)
 ```
 """
 function atomic_cas! end
@@ -128,7 +128,7 @@ For further details, see LLVM's `atomicrmw xchg` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_xchg!(x, 2)
 3
@@ -152,7 +152,7 @@ For further details, see LLVM's `atomicrmw add` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_add!(x, 2)
 3
@@ -176,7 +176,7 @@ For further details, see LLVM's `atomicrmw sub` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_sub!(x, 2)
 3
@@ -199,7 +199,7 @@ For further details, see LLVM's `atomicrmw and` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_and!(x, 2)
 3
@@ -222,7 +222,7 @@ For further details, see LLVM's `atomicrmw nand` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_nand!(x, 2)
 3
@@ -245,7 +245,7 @@ For further details, see LLVM's `atomicrmw or` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(5)
-Base.Threads.Atomic{Int64}(5)
+Threads.Atomic{Int64}(5)
 
 julia> Threads.atomic_or!(x, 7)
 5
@@ -268,7 +268,7 @@ For further details, see LLVM's `atomicrmw xor` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(5)
-Base.Threads.Atomic{Int64}(5)
+Threads.Atomic{Int64}(5)
 
 julia> Threads.atomic_xor!(x, 7)
 5
@@ -291,7 +291,7 @@ For further details, see LLVM's `atomicrmw max` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(5)
-Base.Threads.Atomic{Int64}(5)
+Threads.Atomic{Int64}(5)
 
 julia> Threads.atomic_max!(x, 7)
 5
@@ -314,7 +314,7 @@ For further details, see LLVM's `atomicrmw min` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(7)
-Base.Threads.Atomic{Int64}(7)
+Threads.Atomic{Int64}(7)
 
 julia> Threads.atomic_min!(x, 5)
 7

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -411,7 +411,7 @@ Uses [`BroadcastStyle`](@ref) to get the style for each argument, and uses
 
 ```jldoctest
 julia> Broadcast.combine_styles([1], [1 2; 3 4])
-Base.Broadcast.DefaultArrayStyle{2}()
+Broadcast.DefaultArrayStyle{2}()
 ```
 """
 function combine_styles end
@@ -431,10 +431,10 @@ determine a common `BroadcastStyle`.
 
 ```jldoctest
 julia> Broadcast.result_style(Broadcast.DefaultArrayStyle{0}(), Broadcast.DefaultArrayStyle{3}())
-Base.Broadcast.DefaultArrayStyle{3}()
+Broadcast.DefaultArrayStyle{3}()
 
 julia> Broadcast.result_style(Broadcast.Unknown(), Broadcast.DefaultArrayStyle{1}())
-Base.Broadcast.DefaultArrayStyle{1}()
+Broadcast.DefaultArrayStyle{1}()
 ```
 """
 function result_style end

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -33,11 +33,8 @@ macro var(x)
 end
 
 function Base.show(io::IO, b::Binding)
-    if b.mod === Main
-        print(io, b.var)
-    else
-        print(io, b.mod, '.', Base.isoperator(b.var) ? ":" : "", b.var)
-    end
+    from = Base.moduleroot(b.mod) === Main ? Main : nothing
+    Base.print_qualified_name(io, b.mod, b.var, from, allow_macroname=true)
 end
 
 aliasof(b::Binding)     = defined(b) ? (a = aliasof(resolve(b), b); defined(a) ? a : b) : b

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -435,7 +435,7 @@ See [`Base.filter`](@ref) for an eager implementation of filtering for arrays.
 # Examples
 ```jldoctest
 julia> f = Iterators.filter(isodd, [1, 2, 3, 4, 5])
-Base.Iterators.Filter{typeof(isodd), Vector{Int64}}(isodd, [1, 2, 3, 4, 5])
+Iterators.Filter{typeof(isodd), Vector{Int64}}(isodd, [1, 2, 3, 4, 5])
 
 julia> foreach(println, f)
 1

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -246,7 +246,7 @@ julia> Meta.parse("x = ")
 :($(Expr(:incomplete, "incomplete: premature end of input")))
 
 julia> Meta.parse("1.0.2")
-ERROR: Base.Meta.ParseError("invalid numeric constant \\\"1.0.\\\"")
+ERROR: Meta.ParseError("invalid numeric constant \\\"1.0.\\\"")
 Stacktrace:
 [...]
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -202,7 +202,8 @@ function show(io::IO, m::Method)
     sig = unwrap_unionall(m.sig)
     if sig === Tuple
         # Builtin
-        print(io, m.name, "(...) in ", m.module)
+        print(io, m.name, "(...) in ")
+        show(io, m.module)
         return
     end
     print(io, decls[1][2], "(")
@@ -219,7 +220,8 @@ function show(io::IO, m::Method)
     end
     print(io, ")")
     show_method_params(io, tv)
-    print(io, " in ", m.module)
+    print(io, " in ")
+    show(io, m.module)
     if line > 0
         file, line = updated_methodloc(m)
         print(io, " at ", file, ":", line)
@@ -352,7 +354,8 @@ function show(io::IO, ::MIME"text/html", m::Method)
     sig = unwrap_unionall(m.sig)
     if sig === Tuple
         # Builtin
-        print(io, m.name, "(...) in ", m.module)
+        print(io, m.name, "(...) in ")
+        show(io, m.module)
         return
     end
     print(io, decls[1][2], "(")
@@ -376,7 +379,8 @@ function show(io::IO, ::MIME"text/html", m::Method)
         show_method_params(io, tv)
         print(io,"</i>")
     end
-    print(io, " in ", m.module)
+    print(io, " in ")
+    show(io, m.module)
     if line > 0
         file, line = updated_methodloc(m)
         u = url(m)

--- a/stdlib/Distributed/src/pmap.jl
+++ b/stdlib/Distributed/src/pmap.jl
@@ -241,7 +241,7 @@ and `tail`: an iterator over the remaining elements.
 
 ```jldoctest
 julia> b, c = Distributed.head_and_tail(1:10, 3)
-([1, 2, 3], Base.Iterators.Rest{UnitRange{Int64}, Int64}(1:10, 3))
+([1, 2, 3], Iterators.Rest{UnitRange{Int64}, Int64}(1:10, 3))
 
 julia> collect(c)
 7-element Vector{Int64}:

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -314,7 +314,9 @@ function summarize(io::IO, TT::Type, binding::Binding)
 end
 
 function summarize(io::IO, m::Module, binding::Binding)
-    println(io, "No docstring found for module `", m, "`.\n")
+    print(io, "No docstring found for module `")
+    show(io, m)
+    println(io, "`.\n")
     exports = filter!(!=(nameof(m)), names(m))
     if isempty(exports)
         println(io, "Module does not export any names.")

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -11,9 +11,6 @@ ambig(x::Int, y::Int) = 4
 ambig(x::Number, y) = 5
 # END OF LINE NUMBER SENSITIVITY
 
-# For curmod_*
-include("testenv.jl")
-
 @test length(methods(ambig)) == 5
 @test length(Base.methods_including_ambiguous(ambig, Tuple)) == 5
 
@@ -40,9 +37,9 @@ let err = try
     io = IOBuffer()
     Base.showerror(io, err)
     lines = split(String(take!(io)), '\n')
-    ambig_checkline(str) = startswith(str, "  ambig(x, y::Integer) in $curmod_str at") ||
-                           startswith(str, "  ambig(x::Integer, y) in $curmod_str at") ||
-                           startswith(str, "  ambig(x::Number, y) in $curmod_str at")
+    ambig_checkline(str) = startswith(str, "  ambig(x, y::Integer) in ") ||
+                           startswith(str, "  ambig(x::Integer, y) in ") ||
+                           startswith(str, "  ambig(x::Number, y) in ")
     @test ambig_checkline(lines[2])
     @test ambig_checkline(lines[3])
     @test ambig_checkline(lines[4])

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -948,7 +948,7 @@ p0 = copy(p)
 @test identity(.+) == Broadcast.BroadcastFunction(+)
 @test identity.(.*) == Broadcast.BroadcastFunction(*)
 @test map(.+, [[1,2], [3,4]], [5, 6]) == [[6,7], [9,10]]
-@test repr(.!) == "Base.Broadcast.BroadcastFunction(!)"
+@test repr(.!) == "Broadcast.BroadcastFunction(!)"
 @test eval(:(.+)) == Base.BroadcastFunction(+)
 
 @testset "Issue #28382: inferrability of broadcast with Union eltype" begin

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3030,11 +3030,11 @@ end
     ifi = sel[end].second
     @test length(ifi.slottypes) > ifi.nargs
     str = sprint(show, sel)
-    @test occursin("InferenceFrameInfo for $(@__MODULE__).C.loopc(5::$Int)", str)
+    @test occursin("InferenceFrameInfo for $(repr(@__MODULE__)).C.loopc(5::$Int)", str)
     # check that types aren't double-printed as `T::Type{T}`
     sel = filter(ti -> ti.second.mi.def.name === :myfloor, ft)
     str = sprint(show, sel)
-    @test occursin("InferenceFrameInfo for $(@__MODULE__).C.myfloor(::Type{Int16}, ::Float64)", str)
+    @test occursin("InferenceFrameInfo for $(repr(@__MODULE__)).C.myfloor(::Type{Int16}, ::Float64)", str)
 end
 
 # issue #37638

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -132,8 +132,13 @@ end
 # and names
 @test_throws ArgumentError("name \"_zero_Test15\" in Enum Test15 is not unique") @macrocall(@enum(Test15, _zero_Test15, _one_Test15, _zero_Test15))
 
-@test repr(apple) == "$(@__MODULE__).apple"
 @test string(apple) == "apple"
+
+module ModuleWithEnum
+@enum Fruit apple orange kiwi
+end
+
+@test repr(ModuleWithEnum.apple) == "$(repr(ModuleWithEnum)).apple"
 
 @test repr("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
 @test repr("text/plain", orange) == "orange::Fruit = 1"
@@ -207,6 +212,5 @@ let b = IOBuffer()
     b = IOBuffer()
     show(b, MIME"text/plain"(), Union{Alphabet, BritishFood})
     str = String(take!(b))
-    p = string(@__MODULE__)
-    @test str == "Union{$p.Alphabet, $p.BritishFood}" || str == "Union{$p.BritishFood, $p.Alphabet}"
+    @test str == "Union{$(repr(Alphabet)), $(repr(BritishFood))}" || str == "Union{$(repr(BritishFood)), $(repr(Alphabet))}"
 end

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -42,8 +42,9 @@ if !@isdefined(testenv_defined)
 
     const curmod = @__MODULE__
     const curmod_name = fullname(curmod)
-    const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
-    const curmod_prefix = "$(["$m." for m in curmod_name]...)"
+    const curmod_rel_name = curmod_name[1] === :Main ? curmod_name[2:end] : curmod_name
+    const curmod_str = join(curmod_rel_name, ".")
+    const curmod_prefix = "$(["$m." for m in curmod_rel_name]...)"
 
     # platforms that support cfunction with closures
     # (requires LLVM back-end support for trampoline intrinsics)


### PR DESCRIPTION
This removes repeated code, fixes some cases where quoting was not done
correcly (e.g. `Mod.:+`), and checks identifier visibility recursively
so only a minimal module path is printed.

fixes #39834