### PR TITLE
[LinearAlgebra] Add `libblas` and `liblapack` bindings in again

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -66,6 +66,13 @@ export
 const libblastrampoline = "libblastrampoline"
 libblastrampoline_handle = C_NULL
 
+# Legacy bindings that some packages (such as NNlib.jl) use.
+# We maintain these for backwards-compatibility but new packages
+# should not look at these, instead preferring to parse the output
+# of BLAS.get_config()
+const libblas = libblastrampoline
+const liblapack = libblastrampoline
+
 import LinearAlgebra
 import LinearAlgebra: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, stride1, chkstride1, axpy!
 


### PR DESCRIPTION
Some packages use these; rather than create unnecesary package churn,
let's just define them again and add a note that serious applications
should use the much richer detail available from `BLAS.get_config()`.