### PR TITLE
cmdlineargs test: on 32-bit systems, impose a constant upper limit on the number of threads

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -206,6 +206,9 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # We want to test oversubscription, but on manycore machines, this can
     # actually exhaust limited PID spaces
     cpu_threads = max(2*cpu_threads, min(50, 10*cpu_threads))
+    if Sys.WORD_SIZE == 32
+        cpu_threads = min(cpu_threads, 50)
+    end
     @test read(`$exename -t $cpu_threads -e $code`, String) == string(cpu_threads)
     withenv("JULIA_NUM_THREADS" => string(cpu_threads)) do
         @test read(`$exename -e $code`, String) == string(cpu_threads)


### PR DESCRIPTION
Before this PR, if the computer has e.g. 200 CPU threads, then the `cmdlinearargs` test will use 400 threads.

After this PR, on 32-bit systems, the `cmdlinearargs` will never use more than 50 threads.

The behavior on 64-bit systems is unchanged.