### PR TITLE
include: add compat annotation for mapexpr argument

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -478,6 +478,9 @@ it is evaluated: for each parsed expression `expr` in `path`, the `include` func
 actually evaluates `mapexpr(expr)`.  If it is omitted, `mapexpr` defaults to [`identity`](@ref).
 
 Use [`Base.include`](@ref) to evaluate a file into another module.
+
+!!! compat "Julia 1.5"
+    Julia 1.5 is required for passing the `mapexpr` argument.
 """
 MainInclude.include
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1072,6 +1072,9 @@ Like [`include`](@ref), except reads code from the given string rather than from
 The optional first argument `mapexpr` can be used to transform the included code before
 it is evaluated: for each parsed expression `expr` in `code`, the `include_string` function
 actually evaluates `mapexpr(expr)`.  If it is omitted, `mapexpr` defaults to [`identity`](@ref).
+
+!!! compat "Julia 1.5"
+    Julia 1.5 is required for passing the `mapexpr` argument.
 """
 function include_string(mapexpr::Function, mod::Module, code::AbstractString,
                         filename::AbstractString="string")
@@ -1131,6 +1134,9 @@ interactively, or to combine files in packages that are broken into multiple sou
 The optional first argument `mapexpr` can be used to transform the included code before
 it is evaluated: for each parsed expression `expr` in `path`, the `include` function
 actually evaluates `mapexpr(expr)`.  If it is omitted, `mapexpr` defaults to [`identity`](@ref).
+
+!!! compat "Julia 1.5"
+    Julia 1.5 is required for passing the `mapexpr` argument.
 """
 Base.include # defined in Base.jl
 


### PR DESCRIPTION
`mapexpr` was added in #34595.