### PR TITLE
allow trailing dims in inplace broadcast

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -995,21 +995,23 @@ end
 end
 
 @testset "inplace broadcast with trailing singleton dims" begin
-    a, b, c = [1, 2], reshape([3 4], :, 1), reshape([5, 6], :, 1, 1)
+    for (a, b, c) in (([1, 2], reshape([3 4], :, 1), reshape([5, 6], :, 1, 1)),
+            ([1 2; 3 4], reshape([5 6; 7 8], 2, 2, 1), reshape([9 10; 11 12], 2, 2, 1, 1)))
 
-    a_ = copy(a)
-    a_ .= b
-    @test a_ == vec(b)
+        a_ = copy(a)
+        a_ .= b
+        @test a_ == dropdims(b, dims=(findall(==(1), size(b))...,))
 
-    a_ = copy(a)
-    a_ .= b
-    @test a_ == vec(b)
+        a_ = copy(a)
+        a_ .= b
+        @test a_ == dropdims(b, dims=(findall(==(1), size(b))...,))
 
-    a_ = copy(a)
-    a_ .= b .+ c
-    @test a_ == vec(b .+ c)
+        a_ = copy(a)
+        a_ .= b .+ c
+        @test a_ == dropdims(b .+ c, dims=(findall(==(1), size(c))...,))
 
-    a_ = copy(a)
-    a_ .*= c
-    @test a_ == vec(a .* c)
+        a_ = copy(a)
+        a_ .*= c
+        @test a_ == dropdims(a .* c, dims=(findall(==(1), size(c))...,))
+    end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -993,3 +993,23 @@ end
 
     @test Cyclotomic() .* [2, 3] == [[1, 2], [1, 2]]
 end
+
+@testset "inplace broadcast with trailing singleton dims" begin
+    a, b, c = [1, 2], reshape([3 4], :, 1), reshape([5, 6], :, 1, 1)
+
+    a_ = copy(a)
+    a_ .= b
+    @test a_ == vec(b)
+
+    a_ = copy(a)
+    a_ .= b
+    @test a_ == vec(b)
+
+    a_ = copy(a)
+    a_ .= b .+ c
+    @test a_ == vec(b .+ c)
+
+    a_ = copy(a)
+    a_ .*= c
+    @test a_ == vec(a .* c)
+end


### PR DESCRIPTION
This allows inplace broadcasting into arrays that contain less dimensions than the rhs, as long as the trailing dimensions all have length one. This seems more consistent to me with how we handle trailing dimensions in other places.

Fixes #39904