### PR TITLE
Add parent module to function repr

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -238,7 +238,7 @@ function show_method_list_header(io::IO, ms::MethodList, namefmt::Function)
     else
         m = n==1 ? "method" : "methods"
         print(io, "# $n $m")
-        sname = string(name)
+        sname = string(mt.module, ".", name)
         namedisplay = namefmt(sname)
         if hasname
             what = startswith(sname, '@') ? "macro" : "generic function"

--- a/base/show.jl
+++ b/base/show.jl
@@ -37,7 +37,7 @@ function show(io::IO, ::MIME"text/plain", f::Function)
                  ft == typeof(getfield(ft.name.module, name))
         n = length(methods(f))
         m = n==1 ? "method" : "methods"
-        sname = string(name)
+        sname = sprint(show, f)
         ns = (isself || '#' in sname) ? sname : string("(::", ft, ")")
         what = startswith(ns, '@') ? "macro" : "generic function"
         print(io, ns, " (", what, " with $n $m)")
@@ -453,19 +453,16 @@ function show_function(io::IO, f::Function, compact::Bool)
         print(io, mt.name)
     elseif isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
         getfield(mt.module, mt.name) === f
-        if is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
-            show_sym(io, mt.name)
-        else
-            print(io, mt.module, ".")
-            show_sym(io, mt.name)
-        end
+
+        print(io, mt.module, ".")
+        show_sym(io, mt.name)
     else
         show_default(io, f)
     end
 end
 
 show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false)::Bool)
-print(io::IO, f::Function) = show_function(io, f, true)
+print(io::IO, f::Function) = show_function(io, f, get(io, :compact, false)::Bool)
 
 function show(io::IO, f::Core.IntrinsicFunction)
     if !(get(io, :compact, false)::Bool)


### PR DESCRIPTION
Possible close to #39016

Before fixing up tests I wanted to show examples for discussion - below is before/after for three different show functions, three different functions

####  `print(f)`

| function |  current | PR |
| -- | -- | --|
| `sum` |  "sum" |  "Base.sum" |
| `Statistics.mean` (Stdlib) | "mean" | "Statistics.mean" |
| `Revise.includet` (non-Stdlib) | "includet" | "Revise.includet" |

#### repl -  `show(io, ::MIME"text/plain", f)`

| function |  current | PR |
| -- | -- | --|
| `sum` |  "sum (generic function with 14 methods)" |  "Base.sum (generic function with 14 methods)"  |
| `Statistics.mean` (Stdlib) | "mean (generic function with 5 methods)" | "Statistics.mean (generic function with 5 methods)" |
| `Revise.includet` (non-Stdlib) | "includet (generic function with 2 methods)" | "Revise.includet (generic function with 2 methods" |

#### two arg show from repl - `show(io, f)`
| function |  current | PR |
| -- | -- | --|
| `sum` |  "sum" |  "Base.sum" |
| `Statistics.mean` (Stdlib) | "Statistics.mean"  | "Statistics.mean" |
| `Revise.includet` (non-Stdlib) | "Revise.includet" | "Revise.includet" |

