### PR TITLE
Backport "Add two missing packages to `getall`" to release-1.5

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -178,7 +178,7 @@ install: $(addprefix install-, $(DEP_LIBS))
 cleanall: $(addprefix clean-, $(DEP_LIBS))
 distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)
-getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-curl get-libgit2 get-libwhich
+getall: get-llvm get-libuv get-pcre get-openlibm get-dsfmt get-openblas get-lapack get-suitesparse get-unwind get-gmp get-mpfr get-patchelf get-utf8proc get-objconv get-mbedtls get-libssh2 get-curl get-libgit2 get-libwhich get-zlib get-p7zip
 
 # If we're building for MacOS, no matter what, `getall` should include `osxunwind`
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
Building from the present release-1.5 full source tarball fails in environments without network access for lack zlib (and p7zip downstream I imagine). This pull request backports the commit that fixed that issue on master to release-1.5. Much thanks to @staticfloat for helping sort this out! :)