### PR TITLE
check for NULL handle in `_fd`

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1120,7 +1120,7 @@ _fd(x::Union{OS_HANDLE, RawFD}) = x
 
 function _fd(x::Union{LibuvStream, LibuvServer})
     fd = Ref{OS_HANDLE}(INVALID_OS_HANDLE)
-    if x.status != StatusUninit && x.status != StatusClosed
+    if x.status != StatusUninit && x.status != StatusClosed && x.handle != C_NULL
         err = ccall(:uv_fileno, Int32, (Ptr{Cvoid}, Ptr{OS_HANDLE}), x.handle, fd)
         # handle errors by returning INVALID_OS_HANDLE
     end


### PR DESCRIPTION
In this case the object is in an invalid state, but it at least allows printing the object so you can see that.

This is not *that* real a bug, and we would potentially need this check in other places too, but I think it's justified to at least make printing not crash. Then you see `invalid status` in the object's representation, giving a hint of the problem hopefully in time to avoid other segfaults :)