### PR TITLE
Refactor InliningState

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -358,9 +358,7 @@ function const_prop_heuristic(interp::AbstractInterpreter, method::Method, mi::M
     if isdefined(code, :inferred) && !cache_inlineable
         cache_inf = code.inferred
         if !(cache_inf === nothing)
-            cache_src_inferred = ccall(:jl_ir_flag_inferred, Bool, (Any,), cache_inf)
-            cache_src_inlineable = ccall(:jl_ir_flag_inlineable, Bool, (Any,), cache_inf)
-            cache_inlineable = cache_src_inferred && cache_src_inlineable
+            cache_inlineable = inlining_policy(interp)(cache_inf)
         end
     end
     if !cache_inlineable

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -213,6 +213,7 @@ may_discard_trees(ni::NativeInterpreter) = true
 verbose_stmt_info(ni::NativeInterpreter) = false
 
 method_table(ai::AbstractInterpreter) = InternalMethodTable(get_world_counter(ai))
+inlining_policy(ai::AbstractInterpreter) = default_inlining_policy
 
 # define inference bail out logic
 # `NativeInterpreter` bails out from inference when


### PR DESCRIPTION
We recently dropped the method table from this and we can get rid
of one of the cache references now too, since we're now passing that
info in the stmtinfo. Also factor out the inlining policy into a
separate option to the inliner to make it easier for downstream
projects like Diffractor and Cthulhu to override it without playing
cache games (which is now harder, since one of the caches is gone).

Other than that, this is mostly code movement and folding function
arguments back into InliningState, since the point of not doing
that before was mostly to avoid using the caches and method
tables in places where they were not supposed to be accessed.