### PR TITLE
Reorganize code to keep code as IRCode slightly longer

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -32,6 +32,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                                   fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any}, @nospecialize(atype),
                                   sv::InferenceState, max_methods::Int = InferenceParams(interp).MAX_METHODS)
     if sv.params.unoptimize_throw_blocks && sv.currpc in sv.throw_blocks
+        add_remark!(interp, sv, "Skipped call in throw block")
         return CallMeta(Any, false)
     end
     valid_worlds = WorldRange()
@@ -365,7 +366,7 @@ function const_prop_heuristic(interp::AbstractInterpreter, method::Method, mi::M
     if isdefined(code, :inferred) && !cache_inlineable
         cache_inf = code.inferred
         if !(cache_inf === nothing)
-            cache_inlineable = inlining_policy(interp)(cache_inf)
+            cache_inlineable = inlining_policy(interp)(cache_inf) !== nothing
         end
     end
     if !cache_inlineable

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -32,14 +32,18 @@ function default_inlining_policy(@nospecialize(src))
     if isa(src, CodeInfo) || isa(src, Vector{UInt8})
         src_inferred = ccall(:jl_ir_flag_inferred, Bool, (Any,), src)
         src_inlineable = ccall(:jl_ir_flag_inlineable, Bool, (Any,), src)
-        return src_inferred && src_inlineable
+        return src_inferred && src_inlineable ? src : nothing
     end
-    return false
+    if isa(src, OptimizationState) && isdefined(src, :ir)
+        return src.src.inlineable ? src.ir : nothing
+    end
+    return nothing
 end
 
 mutable struct OptimizationState
     linfo::MethodInstance
     src::CodeInfo
+    ir::Any # Union{Nothing, IRCode}
     stmt_info::Vector{Any}
     mod::Module
     nargs::Int
@@ -54,7 +58,7 @@ mutable struct OptimizationState
             WorldView(code_cache(interp), frame.world),
             inlining_policy(interp))
         return new(frame.linfo,
-                   frame.src, frame.stmt_info, frame.mod, frame.nargs,
+                   frame.src, nothing, frame.stmt_info, frame.mod, frame.nargs,
                    frame.sptypes, frame.slottypes, false,
                    inlining)
     end
@@ -88,7 +92,7 @@ mutable struct OptimizationState
             WorldView(code_cache(interp), get_world_counter()),
             inlining_policy(interp))
         return new(linfo,
-                   src, stmt_info, inmodule, nargs,
+                   src, nothing, stmt_info, inmodule, nargs,
                    sptypes_from_meth_instance(linfo), slottypes, false,
                    inlining)
         end
@@ -99,6 +103,20 @@ function OptimizationState(linfo::MethodInstance, params::OptimizationParams, in
     src === nothing && return nothing
     return OptimizationState(linfo, src, params, interp)
 end
+
+function ir_to_codeinf!(opt::OptimizationState)
+    replace_code_newstyle!(opt.src, opt.ir, opt.nargs - 1)
+    opt.ir = nothing
+    let src = opt.src::CodeInfo
+        widen_all_consts!(src)
+        src.inferred = true
+        # finish updating the result struct
+        validate_code_in_debug_mode(opt.linfo, src, "optimized")
+        return src
+    end
+end
+
+include("compiler/ssair/driver.jl")
 
 
 #############
@@ -152,7 +170,7 @@ function isinlineable(m::Method, me::OptimizationState, params::OptimizationPara
         end
     end
     if !inlineable
-        inlineable = inline_worthy(me.src.code, me.src, me.sptypes, me.slottypes, params, union_penalties, cost_threshold + bonus)
+        inlineable = inline_worthy(me.ir, params, union_penalties, cost_threshold + bonus)
     end
     return inlineable
 end
@@ -175,7 +193,7 @@ function stmt_affects_purity(@nospecialize(stmt), ir)
 end
 
 # Convert IRCode back to CodeInfo and compute inlining cost and sideeffects
-function finish(opt::OptimizationState, params::OptimizationParams, ir, @nospecialize(result))
+function finish(interp::AbstractInterpreter, opt::OptimizationState, params::OptimizationParams, ir, @nospecialize(result))
     def = opt.linfo.def
     nargs = Int(opt.nargs) - 1
 
@@ -225,7 +243,7 @@ function finish(opt::OptimizationState, params::OptimizationParams, ir, @nospeci
         end
     end
 
-    replace_code_newstyle!(opt.src, ir, nargs)
+    opt.ir = ir
 
     # determine and cache inlineability
     union_penalties = false
@@ -263,6 +281,7 @@ function finish(opt::OptimizationState, params::OptimizationParams, ir, @nospeci
             opt.src.inlineable = isinlineable(def, opt, params, union_penalties, bonus)
         end
     end
+
     nothing
 end
 
@@ -270,7 +289,7 @@ end
 function optimize(interp::AbstractInterpreter, opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
     nargs = Int(opt.nargs) - 1
     @timeit "optimizer" ir = run_passes(opt.src, nargs, opt)
-    finish(opt, params, ir, result)
+    finish(interp, opt, params, ir, result)
 end
 
 
@@ -296,7 +315,7 @@ plus_saturate(x::Int, y::Int) = max(x, y, x+y)
 # known return type
 isknowntype(@nospecialize T) = (T === Union{}) || isa(T, Const) || isconcretetype(widenconst(T))
 
-function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any},
+function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptypes::Vector{Any},
                         slottypes::Vector{Any}, union_penalties::Bool,
                         params::OptimizationParams, error_path::Bool = false)
     head = ex.head
@@ -308,7 +327,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
         if ftyp === IntrinsicFunction && farg isa SSAValue
             # if this comes from code that was already inlined into another function,
             # Consts have been widened. try to recover in simple cases.
-            farg = src.code[farg.id]
+            farg = isa(src, CodeInfo) ? src.code[farg.id] : src.stmts[farg.id][:inst]
             if isa(farg, GlobalRef) || isa(farg, QuoteNode) || isa(farg, IntrinsicFunction) || isexpr(farg, :static_parameter)
                 ftyp = argextype(farg, src, sptypes, slottypes)
             end
@@ -350,7 +369,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
             end
             return T_FFUNC_COST[fidx]
         end
-        extyp = line == -1 ? Any : src.ssavaluetypes[line]
+        extyp = line == -1 ? Any : argextype(SSAValue(line), src, sptypes, slottypes)
         if extyp === Union{}
             return 0
         end
@@ -361,7 +380,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
         # run-time of the function, we omit them from
         # consideration. This way, non-inlined error branches do not
         # prevent inlining.
-        extyp = line == -1 ? Any : src.ssavaluetypes[line]
+        extyp = line == -1 ? Any : argextype(SSAValue(line), src, sptypes, slottypes)
         return extyp === Union{} ? 0 : 20
     elseif head === :(=)
         if ex.args[1] isa GlobalRef
@@ -386,10 +405,11 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
     return 0
 end
 
-function statement_or_branch_cost(@nospecialize(stmt), line::Int, src::CodeInfo, sptypes::Vector{Any},
+function statement_or_branch_cost(@nospecialize(stmt), line::Int, src::Union{CodeInfo, IRCode}, sptypes::Vector{Any},
                                   slottypes::Vector{Any}, union_penalties::Bool, params::OptimizationParams,
                                   throw_blocks::Union{Nothing,BitSet})
     thiscost = 0
+    dst(tgt) = isa(src, IRCode) ? first(src.cfg.blocks[tgt].stmts) : tgt
     if stmt isa Expr
         thiscost = statement_cost(stmt, line, src, sptypes, slottypes, union_penalties, params,
                                   throw_blocks !== nothing && line in throw_blocks)::Int
@@ -397,20 +417,20 @@ function statement_or_branch_cost(@nospecialize(stmt), line::Int, src::CodeInfo,
         # loops are generally always expensive
         # but assume that forward jumps are already counted for from
         # summing the cost of the not-taken branch
-        thiscost = stmt.label < line ? 40 : 0
+        thiscost = dst(stmt.label) < line ? 40 : 0
     elseif stmt isa GotoIfNot
-        thiscost = stmt.dest < line ? 40 : 0
+        thiscost = dst(stmt.dest) < line ? 40 : 0
     end
     return thiscost
 end
 
-function inline_worthy(body::Array{Any,1}, src::CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any},
+function inline_worthy(ir::IRCode,
                        params::OptimizationParams, union_penalties::Bool=false, cost_threshold::Integer=params.inline_cost_threshold)
     bodycost::Int = 0
-    throw_blocks = params.unoptimize_throw_blocks ? find_throw_blocks(body) : nothing
-    for line = 1:length(body)
-        stmt = body[line]
-        thiscost = statement_or_branch_cost(stmt, line, src, sptypes, slottypes, union_penalties, params, throw_blocks)
+    throw_blocks = params.unoptimize_throw_blocks ? find_throw_blocks(ir.stmts.inst, RefValue(ir)) : nothing
+    for line = 1:length(ir.stmts)
+        stmt = ir.stmts[line][:inst]
+        thiscost = statement_or_branch_cost(stmt, line, ir, ir.sptypes, ir.argtypes, union_penalties, params, throw_blocks)
         bodycost = plus_saturate(bodycost, thiscost)
         bodycost > cost_threshold && return false
     end
@@ -490,5 +510,3 @@ function renumber_ir_elements!(body::Vector{Any}, ssachangemap::Vector{Int}, lab
         end
     end
 end
-
-include("compiler/ssair/driver.jl")


### PR DESCRIPTION
This moved the primary place where IRCode gets converted into CodeInfo
into the transform_result_for_cache call, which is a sensible place for
it to be since the primary reason we need to convert back to IRCode is
to make it acceptable for storing in the global cache. The reason we
might want to not perform the conversion, is that the conversion is
slightly lossy, because it drops stmtinfo. However, in Cthulhu, I would
like to keep the statement info around such that Cthulhu can present
it to the user, even in optimized code (i.e. where inlining decided
not to inline, I would still like Cthulhu to be able to introspect
inference's original annotations). This change makes that possible.

In an ideal world, we wouldn't have to do this at all for uncached
code, but of course both code_typed and typeinf_ext do look at the
code, even if it is uncached. Unfortunately, at the moment we don't
really have a good way to indicate whether or not the code will
be looked at, so there is a fallback path that always does the
conversion if we decided not to do the caching. Some future
refactoring can save some additional time here.