### PR TITLE
Canonicalize IR to disallow mutable GlobalRef in value position

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -162,7 +162,7 @@ function fixemup!(cond, rename, ir::IRCode, ci::CodeInfo, idx::Int, @nospecializ
                 return nothing
             end
             op[] = x
-        elseif isa(val, GlobalRef) && !isdefined(val.mod, val.name)
+        elseif isa(val, GlobalRef) && !(isdefined(val.mod, val.name) && isconst(val.mod, val.name))
             op[] = NewSSAValue(insert_node!(ir, idx, Any, val).id - length(ir.stmts))
         end
     end

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -36,7 +36,7 @@ function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, 
             end
         end
     elseif isa(op, GlobalRef)
-        if !isdefined(op.mod, op.name)
+        if !isdefined(op.mod, op.name) || !isconst(op.mod, op.name)
             @verify_error "Unbound GlobalRef not allowed in value position"
             error("")
         end


### PR DESCRIPTION
Generally we assume parameters can be duplicated without seeing
side-effects. That is not entirely true of mutable globals and
multi-threading.

Refs: #36450
Fixes: #39508