### PR TITLE
Change `julia --help` entry for `--check-bounds` to reference @inbounds

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -129,7 +129,7 @@ static const char opts[]  =
         " (default level is 1 if unspecified or 2 if used without a level)\n"
 #endif
     " --inline={yes|no}         Control whether inlining is permitted, including overriding @inline declarations\n"
-    " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)\n"
+    " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring @inbounds declarations)\n"
 #ifdef USE_POLLY
     " --polly={yes|no}          Enable or disable the polyhedral optimizer Polly (overrides @polly declaration)\n"
 #endif


### PR DESCRIPTION
Added explicit reference to `@inbounds` in the entry for `--check-bounds` in `julia --help`, this is consistent with `--inline`, `--polly` and `--math-mode`.