### PR TITLE
ignore manifest of stdlibs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@
 .DS_Store
 .idea/*
 .vscode/*
-
-stdlib/*/Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 .DS_Store
 .idea/*
 .vscode/*
+
+stdlib/*/Manifest.toml

--- a/stdlib/.gitignore
+++ b/stdlib/.gitignore
@@ -14,3 +14,4 @@
 /NetworkOptions-*
 /NetworkOptions
 /*_jll/StdlibArtifacts.toml
+/*/Manifest.toml


### PR DESCRIPTION
Just realized Manifests from stdlibs were not ignored, can be a pain when testing locally