### PR TITLE
RFC: Add rowval index type to SparseMatrixCSC

### DIFF
--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -318,11 +318,11 @@ Q factor:
  1.0  0.0
  0.0  1.0
 D1 factor:
-2×2 SparseArrays.SparseMatrixCSC{Float64, Int64} with 2 stored entries:
+2×2 SparseArrays.SparseMatrixCSC{Float64, Int64, Int64} with 2 stored entries:
  0.707107   ⋅
   ⋅        0.707107
 D2 factor:
-2×2 SparseArrays.SparseMatrixCSC{Float64, Int64} with 2 stored entries:
+2×2 SparseArrays.SparseMatrixCSC{Float64, Int64, Int64} with 2 stored entries:
  0.707107   ⋅
   ⋅        0.707107
 R0 factor:

--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -12,16 +12,17 @@ compared to dense arrays.
 ## [Compressed Sparse Column (CSC) Sparse Matrix Storage](@id man-csc)
 
 In Julia, sparse matrices are stored in the [Compressed Sparse Column (CSC) format](https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_column_.28CSC_or_CCS.29).
-Julia sparse matrices have the type [`SparseMatrixCSC{Tv,Ti}`](@ref), where `Tv` is the
-type of the stored values, and `Ti` is the integer type for storing column pointers and
-row indices. The internal representation of `SparseMatrixCSC` is as follows:
+Julia sparse matrices have the type [`SparseMatrixCSC{Tv,Ti,Tr}`](@ref), where `Tv` is the
+type of the stored values, `Ti` is the integer type for storing column pointers and `Tr`
+is the integer type for storing row indices. The internal representation of `SparseMatrixCSC`
+is as follows:
 
 ```julia
-struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrixCSC{Tv,Ti}
+struct SparseMatrixCSC{Tv,Ti<:Integer,Tr<:Integer} <: AbstractSparseMatrixCSC{Tv,Ti}
     m::Int                  # Number of rows
     n::Int                  # Number of columns
     colptr::Vector{Ti}      # Column j is in colptr[j]:(colptr[j+1]-1)
-    rowval::Vector{Ti}      # Row indices of stored values
+    rowval::Vector{Tr}      # Row indices of stored values
     nzval::Vector{Tv}       # Stored values, typically nonzeros
 end
 ```
@@ -51,13 +52,13 @@ remove stored zeros from the sparse matrix.
 
 ```jldoctest
 julia> A = sparse([1, 1, 2, 3], [1, 3, 2, 3], [0, 1, 2, 0])
-3×3 SparseMatrixCSC{Int64, Int64} with 4 stored entries:
+3×3 SparseMatrixCSC{Int64, Int64, Int64} with 4 stored entries:
  0  ⋅  1
  ⋅  2  ⋅
  ⋅  ⋅  0
 
 julia> dropzeros(A)
-3×3 SparseMatrixCSC{Int64, Int64} with 2 stored entries:
+3×3 SparseMatrixCSC{Int64, Int64, Int64} with 2 stored entries:
  ⋅  ⋅  1
  ⋅  2  ⋅
  ⋅  ⋅  ⋅
@@ -105,7 +106,7 @@ such that `R[I[k]] = V[k]`.
 julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
 julia> S = sparse(I,J,V)
-5×18 SparseMatrixCSC{Int64, Int64} with 4 stored entries:
+5×18 SparseMatrixCSC{Int64, Int64, Int64} with 4 stored entries:
 ⠀⠈⠀⡀⠀⠀⠀⠀⠠
 ⠀⠀⠀⠀⠁⠀⠀⠀⠀
 
@@ -149,7 +150,7 @@ the [`sparse`](@ref) function:
 
 ```jldoctest
 julia> sparse(Matrix(1.0I, 5, 5))
-5×5 SparseMatrixCSC{Float64, Int64} with 5 stored entries:
+5×5 SparseMatrixCSC{Float64, Int64, Int64} with 5 stored entries:
  1.0   ⋅    ⋅    ⋅    ⋅
   ⋅   1.0   ⋅    ⋅    ⋅
   ⋅    ⋅   1.0   ⋅    ⋅

--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -111,7 +111,7 @@ Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of t
 # Examples
 ```jldoctest
 julia> A = sparse([1 2 0; 0 0 3; 0 4 0])
-3×3 SparseMatrixCSC{Int64, Int64} with 4 stored entries:
+3×3 SparseMatrixCSC{Int64, Int64, Int64} with 4 stored entries:
  1  2  ⋅
  ⋅  ⋅  3
  ⋅  4  ⋅

--- a/stdlib/SparseArrays/src/sparseconvert.jl
+++ b/stdlib/SparseArrays/src/sparseconvert.jl
@@ -22,6 +22,7 @@ for wr in (Symmetric, Hermitian, Transpose, Adjoint,
     @eval SparseMatrixCSC{Tv}(A::$wr{Tv}) where Tv = _sparsem(A)
     @eval SparseMatrixCSC{Tv}(A::$wr) where Tv = SparseMatrixCSC{Tv}(_sparsem(A))
     @eval SparseMatrixCSC{Tv,Ti}(A::$wr) where {Tv,Ti} = SparseMatrixCSC{Tv,Ti}(_sparsem(A))
+    @eval SparseMatrixCSC{Tv,Ti,Tr}(A::$wr) where {Tv,Ti,Tr} = SparseMatrixCSC{Tv,Ti,Tr}(_sparsem(A))
 end
 
 """
@@ -89,7 +90,7 @@ function _sparsem(@nospecialize A::AbstractArray{Tv}) where Tv
         end
     else
         # explicitly call abstract matrix fallback using getindex(A,...)
-        invoke(SparseMatrixCSC{Tv,Int}, Tuple{AbstractMatrix}, A)
+        invoke(SparseMatrixCSC{Tv,Int,Int}, Tuple{AbstractMatrix}, A)
     end
 end
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1944,16 +1944,16 @@ end
     B12118 = sparse([1,2,4,5],   [1,2,3,5],   [2,1,-1,-2])
 
     @test A12118 + B12118 == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], [3,3,3,-1,4,3])
-    @test typeof(A12118 + B12118) == SparseMatrixCSC{Int,Int}
+    @test typeof(A12118 + B12118) == SparseMatrixCSC{Int,Int,Int}
 
     @test A12118 - B12118 == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], [-1,1,3,1,4,7])
-    @test typeof(A12118 - B12118) == SparseMatrixCSC{Int,Int}
+    @test typeof(A12118 - B12118) == SparseMatrixCSC{Int,Int,Int}
 
     @test max.(A12118, B12118) == sparse([1,2,3,4,5], [1,2,3,4,5], [2,2,3,4,5])
-    @test typeof(max.(A12118, B12118)) == SparseMatrixCSC{Int,Int}
+    @test typeof(max.(A12118, B12118)) == SparseMatrixCSC{Int,Int,Int}
 
     @test min.(A12118, B12118) == sparse([1,2,4,5], [1,2,3,5], [1,1,-1,-2])
-    @test typeof(min.(A12118, B12118)) == SparseMatrixCSC{Int,Int}
+    @test typeof(min.(A12118, B12118)) == SparseMatrixCSC{Int,Int,Int}
 end
 
 @testset "unary minus for SparseMatrixCSC{Bool}" begin
@@ -2053,19 +2053,19 @@ end
     B13024 = sparse([1,2,4,5],   [1,2,3,5],   fill(true,4))
 
     @test broadcast(&, A13024, B13024) == sparse([1,2,5], [1,2,5], fill(true,3))
-    @test typeof(broadcast(&, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(&, A13024, B13024)) == SparseMatrixCSC{Bool,Int,Int}
 
     @test broadcast(|, A13024, B13024) == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], fill(true,6))
-    @test typeof(broadcast(|, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(|, A13024, B13024)) == SparseMatrixCSC{Bool,Int,Int}
 
     @test broadcast(⊻, A13024, B13024) == sparse([3,4,4], [3,3,4], fill(true,3), 5, 5)
-    @test typeof(broadcast(⊻, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(⊻, A13024, B13024)) == SparseMatrixCSC{Bool,Int,Int}
 
     @test broadcast(max, A13024, B13024) == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], fill(true,6))
-    @test typeof(broadcast(max, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(max, A13024, B13024)) == SparseMatrixCSC{Bool,Int,Int}
 
     @test broadcast(min, A13024, B13024) == sparse([1,2,5], [1,2,5], fill(true,3))
-    @test typeof(broadcast(min, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(min, A13024, B13024)) == SparseMatrixCSC{Bool,Int,Int}
 
     for op in (+, -)
         @test op(A13024, B13024) == op(Array(A13024), Array(B13024))
@@ -2095,9 +2095,9 @@ end
     A = A*transpose(A)
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(Array(A))))
     @test factorize(triu(A)) == triu(A)
-    @test isa(factorize(triu(A)), UpperTriangular{Float64, SparseMatrixCSC{Float64, Int}})
+    @test isa(factorize(triu(A)), UpperTriangular{Float64, SparseMatrixCSC{Float64,Int,Int}})
     @test factorize(tril(A)) == tril(A)
-    @test isa(factorize(tril(A)), LowerTriangular{Float64, SparseMatrixCSC{Float64, Int}})
+    @test isa(factorize(tril(A)), LowerTriangular{Float64, SparseMatrixCSC{Float64,Int,Int}})
     C, b = A[:, 1:4], fill(1., size(A, 1))
     @test !Base.USE_GPL_LIBS || factorize(C)\b ≈ Array(C)\b
     @test_throws ErrorException eigen(A)
@@ -2317,15 +2317,15 @@ end
 @testset "show" begin
     io = IOBuffer()
     show(io, MIME"text/plain"(), spzeros(Float64, Int64, 0, 0))
-    @test String(take!(io)) == "0×0 SparseArrays.SparseMatrixCSC{Float64, Int64} with 0 stored entries"
+    @test String(take!(io)) == "0×0 SparseArrays.SparseMatrixCSC{Float64, Int64, Int64} with 0 stored entries"
     show(io, MIME"text/plain"(), sparse(Int64[1], Int64[1], [1.0]))
-    @test String(take!(io)) == "1×1 SparseArrays.SparseMatrixCSC{Float64, Int64} with 1 stored entry:\n 1.0"
+    @test String(take!(io)) == "1×1 SparseArrays.SparseMatrixCSC{Float64, Int64, Int64} with 1 stored entry:\n 1.0"
     show(io, MIME"text/plain"(), spzeros(Float32, Int64, 2, 2))
-    @test String(take!(io)) == "2×2 SparseArrays.SparseMatrixCSC{Float32, Int64} with 0 stored entries:\n  ⋅    ⋅ \n  ⋅    ⋅ "
+    @test String(take!(io)) == "2×2 SparseArrays.SparseMatrixCSC{Float32, Int64, Int64} with 0 stored entries:\n  ⋅    ⋅ \n  ⋅    ⋅ "
 
     A = sparse(Int64[1, 1], Int64[1, 2], [1.0, 2.0])
     show(io, MIME"text/plain"(), A)
-    @test String(take!(io)) == "1×2 SparseArrays.SparseMatrixCSC{Float64, Int64} with 2 stored entries:\n 1.0  2.0"
+    @test String(take!(io)) == "1×2 SparseArrays.SparseMatrixCSC{Float64, Int64, Int64} with 2 stored entries:\n 1.0  2.0"
     _show_with_braille_patterns(convert(IOContext, io), A)
     @test String(take!(io)) == "⠉"
 
@@ -2344,13 +2344,13 @@ end
 
     A = sparse(Int64[1, 2, 4, 2, 3], Int64[1, 1, 1, 2, 2], Int64[1, 1, 1, 1, 1], 4, 2)
     show(io, MIME"text/plain"(), A)
-    @test String(take!(io)) == "4×2 SparseArrays.SparseMatrixCSC{Int64, Int64} with 5 stored entries:\n 1  ⋅\n 1  1\n ⋅  1\n 1  ⋅"
+    @test String(take!(io)) == "4×2 SparseArrays.SparseMatrixCSC{Int64, Int64, Int64} with 5 stored entries:\n 1  ⋅\n 1  1\n ⋅  1\n 1  ⋅"
     _show_with_braille_patterns(convert(IOContext, io), A)
     @test String(take!(io)) == "⡳"
 
     A = sparse(Int64[1, 3, 2, 4], Int64[1, 1, 2, 2], Int64[1, 1, 1, 1], 7, 3)
     show(io, MIME"text/plain"(), A)
-    @test String(take!(io)) == "7×3 SparseArrays.SparseMatrixCSC{Int64, Int64} with 4 stored entries:\n 1  ⋅  ⋅\n ⋅  1  ⋅\n 1  ⋅  ⋅\n ⋅  1  ⋅\n ⋅  ⋅  ⋅\n ⋅  ⋅  ⋅\n ⋅  ⋅  ⋅"
+    @test String(take!(io)) == "7×3 SparseArrays.SparseMatrixCSC{Int64, Int64, Int64} with 4 stored entries:\n 1  ⋅  ⋅\n ⋅  1  ⋅\n 1  ⋅  ⋅\n ⋅  1  ⋅\n ⋅  ⋅  ⋅\n ⋅  ⋅  ⋅\n ⋅  ⋅  ⋅"
     _show_with_braille_patterns(convert(IOContext, io), A)
     @test String(take!(io)) == "⢕" * Char(10240) * "\n" * Char(10240)^2
 
@@ -2360,7 +2360,7 @@ end
     @test String(take!(io)) == brailleString
 
     # Issue #30589
-    @test repr("text/plain", sparse([true true])) == "1×2 SparseArrays.SparseMatrixCSC{Bool, $Int} with 2 stored entries:\n 1  1"
+    @test repr("text/plain", sparse([true true])) == "1×2 SparseArrays.SparseMatrixCSC{Bool, $Int, $Int} with 2 stored entries:\n 1  1"
 
     function _filled_sparse(m::Integer, n::Integer)
         C = CartesianIndices((m, n))[:]
@@ -2422,9 +2422,9 @@ end
 @testset "similar with type conversion" begin
     local A = sparse(1.0I, 5, 5)
     @test size(similar(A, ComplexF64, Int)) == (5, 5)
-    @test typeof(similar(A, ComplexF64, Int)) == SparseMatrixCSC{ComplexF64, Int}
+    @test typeof(similar(A, ComplexF64, Int)) == SparseMatrixCSC{ComplexF64,Int,Int}
     @test size(similar(A, ComplexF64, Int8)) == (5, 5)
-    @test typeof(similar(A, ComplexF64, Int8)) == SparseMatrixCSC{ComplexF64, Int8}
+    @test typeof(similar(A, ComplexF64, Int8)) == SparseMatrixCSC{ComplexF64,Int8,Int8}
     @test similar(A, ComplexF64,(6, 6)) == spzeros(ComplexF64, 6, 6)
     @test convert(Matrix, A) == Array(A) # lolwut, are you lost, test?
 end
@@ -2440,14 +2440,14 @@ end
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type specification (preserves stored-entry structure)
     simA = similar(A, Float32)
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(getcolptr(A))}
+    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(getcolptr(A)),eltype(rowvals(A))}
     @test size(simA) == size(A)
     @test getcolptr(simA) == getcolptr(A)
     @test rowvals(simA) == rowvals(A)
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry and index type specification (preserves stored-entry structure)
     simA = similar(A, Float32, Int8)
-    @test typeof(simA) == SparseMatrixCSC{Float32,Int8}
+    @test typeof(simA) == SparseMatrixCSC{Float32,Int8,Int8}
     @test size(simA) == size(A)
     @test getcolptr(simA) == getcolptr(A)
     @test rowvals(simA) == rowvals(A)
@@ -2461,14 +2461,14 @@ end
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(getcolptr(A))}
+    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(getcolptr(A)),eltype(rowvals(A))}
     @test size(simA) == (6,6)
     @test getcolptr(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(rowvals(A))
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type, index type, and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, Int8, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32, Int8}
+    @test typeof(simA) == SparseMatrixCSC{Float32, Int8, Int8}
     @test size(simA) == (6,6)
     @test getcolptr(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(rowvals(A))

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1385,21 +1385,21 @@ end
     @test similar(A, Float32, Int8, 6) == similar(A, Float32, Int8, (6,))
     # test similar with Dims{2} specification (preserves storage space only, not stored-entry structure)
     simA = similar(A, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{eltype(nonzeros(A)),eltype(nonzeroinds(A))}
+    @test typeof(simA) == SparseMatrixCSC{eltype(nonzeros(A)),eltype(nonzeroinds(A)),eltype(nonzeroinds(A))}
     @test size(simA) == (6,6)
     @test getcolptr(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(nonzeroinds(A))
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(nonzeroinds(A))}
+    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(nonzeroinds(A)),eltype(nonzeroinds(A))}
     @test size(simA) == (6,6)
     @test getcolptr(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(nonzeroinds(A))
     @test length(nonzeros(simA)) == length(nonzeros(A))
     # test similar with entry type, index type, and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, Int8, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32, Int8}
+    @test typeof(simA) == SparseMatrixCSC{Float32, Int8, Int8}
     @test size(simA) == (6,6)
     @test getcolptr(simA) == fill(1, 6+1)
     @test length(rowvals(simA)) == length(nonzeroinds(A))

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -944,9 +944,9 @@ function Sparse(A::SparseMatrixCSC)
     o
 end
 
-Sparse(A::Symmetric{Tv, SparseMatrixCSC{Tv,Ti}}) where {Tv<:Real, Ti} =
+Sparse(A::Symmetric{Tv,<:SparseMatrixCSC{Tv,Ti}}) where {Tv<:Real, Ti} =
     Sparse(A.data, A.uplo == 'L' ? -1 : 1)
-Sparse(A::Hermitian{Tv,SparseMatrixCSC{Tv,Ti}}) where {Tv, Ti} =
+Sparse(A::Hermitian{Tv,<:SparseMatrixCSC{Tv,Ti}}) where {Tv, Ti} =
     Sparse(A.data, A.uplo == 'L' ? -1 : 1)
 
 Sparse(A::Dense) = dense_to_sparse(A, SuiteSparse_long)
@@ -1327,9 +1327,9 @@ See also [`cholesky`](@ref).
 """
 cholesky!(F::Factor, A::Union{SparseMatrixCSC{T},
           SparseMatrixCSC{Complex{T}},
-          Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
-          Hermitian{Complex{T},SparseMatrixCSC{Complex{T},SuiteSparse_long}},
-          Hermitian{T,SparseMatrixCSC{T,SuiteSparse_long}}};
+          Symmetric{T,<:SparseMatrixCSC{T,SuiteSparse_long}},
+          Hermitian{Complex{T},<:SparseMatrixCSC{Complex{T},SuiteSparse_long}},
+          Hermitian{T,<:SparseMatrixCSC{T,SuiteSparse_long}}};
           shift = 0.0, check::Bool = true) where {T<:Real} =
     cholesky!(F, Sparse(A); shift = shift, check = check)
 
@@ -1414,7 +1414,7 @@ julia> L * L' ≈ A[C.p, C.p]
 true
 
 julia> P = sparse(1:3, C.p, ones(3))
-3×3 SparseMatrixCSC{Float64, Int64} with 3 stored entries:
+3×3 SparseMatrixCSC{Float64, Int64, Int64} with 3 stored entries:
   ⋅    ⋅   1.0
   ⋅   1.0   ⋅
  1.0   ⋅    ⋅
@@ -1452,9 +1452,9 @@ true
     `Base.SparseArrays.CHOLMOD` module.
 """
 cholesky(A::Union{SparseMatrixCSC{T}, SparseMatrixCSC{Complex{T}},
-    Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
-    Hermitian{Complex{T},SparseMatrixCSC{Complex{T},SuiteSparse_long}},
-    Hermitian{T,SparseMatrixCSC{T,SuiteSparse_long}}};
+    Symmetric{T,<:SparseMatrixCSC{T,SuiteSparse_long}},
+    Hermitian{Complex{T},<:SparseMatrixCSC{Complex{T},SuiteSparse_long}},
+    Hermitian{T,<:SparseMatrixCSC{T,SuiteSparse_long}}};
     kws...) where {T<:Real} = cholesky(Sparse(A); kws...)
 
 
@@ -1491,9 +1491,9 @@ See also [`ldlt`](@ref).
 """
 ldlt!(F::Factor, A::Union{SparseMatrixCSC{T},
     SparseMatrixCSC{Complex{T}},
-    Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
-    Hermitian{Complex{T},SparseMatrixCSC{Complex{T},SuiteSparse_long}},
-    Hermitian{T,SparseMatrixCSC{T,SuiteSparse_long}}};
+    Symmetric{T,<:SparseMatrixCSC{T,SuiteSparse_long}},
+    Hermitian{Complex{T},<:SparseMatrixCSC{Complex{T},SuiteSparse_long}},
+    Hermitian{T,<:SparseMatrixCSC{T,SuiteSparse_long}}};
     shift = 0.0, check::Bool = true) where {T<:Real} =
     ldlt!(F, Sparse(A), shift = shift, check = check)
 
@@ -1556,9 +1556,9 @@ it should be a permutation of `1:size(A,1)` giving the ordering to use
     `Base.SparseArrays.CHOLMOD` module.
 """
 ldlt(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}},
-    Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
-    Hermitian{Complex{T},SparseMatrixCSC{Complex{T},SuiteSparse_long}},
-    Hermitian{T,SparseMatrixCSC{T,SuiteSparse_long}}};
+    Symmetric{T,<:SparseMatrixCSC{T,SuiteSparse_long}},
+    Hermitian{Complex{T},<:SparseMatrixCSC{Complex{T},SuiteSparse_long}},
+    Hermitian{T,<:SparseMatrixCSC{T,SuiteSparse_long}}};
     kws...) where {T<:Real} = ldlt(Sparse(A); kws...)
 
 ## Rank updates
@@ -1734,9 +1734,9 @@ function \(adjL::Adjoint{<:Any,<:Factor}, B::StridedMatrix)
 end
 
 const RealHermSymComplexHermF64SSL = Union{
-    Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}},
-    Hermitian{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}},
-    Hermitian{ComplexF64,SparseMatrixCSC{ComplexF64,SuiteSparse_long}}}
+    Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long,SuiteSparse_long}},
+    Hermitian{Float64,SparseMatrixCSC{Float64,SuiteSparse_long,SuiteSparse_long}},
+    Hermitian{ComplexF64,SparseMatrixCSC{ComplexF64,SuiteSparse_long,SuiteSparse_long}}}
 const StridedVecOrMatInclAdjAndTrans = Union{StridedVecOrMat, Adjoint{<:Any, <:StridedVecOrMat}, Transpose{<:Any, <:StridedVecOrMat}}
 function \(A::RealHermSymComplexHermF64SSL, B::StridedVecOrMatInclAdjAndTrans)
     F = cholesky(A; check = false)
@@ -1858,18 +1858,18 @@ function ishermitian(A::Sparse{ComplexF64})
     end
 end
 
-(*)(A::Symmetric{Float64,SparseMatrixCSC{Float64,Ti}},
+(*)(A::Symmetric{Float64,<:SparseMatrixCSC{Float64,Ti}},
     B::SparseVecOrMat{Float64,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
-(*)(A::Hermitian{ComplexF64,SparseMatrixCSC{ComplexF64,Ti}},
+(*)(A::Hermitian{ComplexF64,<:SparseMatrixCSC{ComplexF64,Ti}},
     B::SparseVecOrMat{ComplexF64,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
-(*)(A::Hermitian{Float64,SparseMatrixCSC{Float64,Ti}},
+(*)(A::Hermitian{Float64,<:SparseMatrixCSC{Float64,Ti}},
     B::SparseVecOrMat{Float64,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 
 (*)(A::SparseVecOrMat{Float64,Ti},
-    B::Symmetric{Float64,SparseMatrixCSC{Float64,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
+    B::Symmetric{Float64,<:SparseMatrixCSC{Float64,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 (*)(A::SparseVecOrMat{ComplexF64,Ti},
-    B::Hermitian{ComplexF64,SparseMatrixCSC{ComplexF64,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
+    B::Hermitian{ComplexF64,<:SparseMatrixCSC{ComplexF64,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 (*)(A::SparseVecOrMat{Float64,Ti},
-    B::Hermitian{Float64,SparseMatrixCSC{Float64,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
+    B::Hermitian{Float64,<:SparseMatrixCSC{Float64,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 
 end #module

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -164,7 +164,7 @@ solve least squares or underdetermined problems with [`\\`](@ref). The function 
 # Examples
 ```jldoctest
 julia> A = sparse([1,2,3,4], [1,1,2,2], [1.0,1.0,1.0,1.0])
-4×2 SparseMatrixCSC{Float64, Int64} with 4 stored entries:
+4×2 SparseMatrixCSC{Float64, Int64, Int64} with 4 stored entries:
  1.0   ⋅
  1.0   ⋅
   ⋅   1.0
@@ -179,7 +179,7 @@ Q factor:
   0.0       -0.707107   0.707107   0.0
  -0.707107   0.0        0.0        0.707107
 R factor:
-2×2 SparseMatrixCSC{Float64, Int64} with 2 stored entries:
+2×2 SparseMatrixCSC{Float64, Int64, Int64} with 2 stored entries:
  -1.41421    ⋅
    ⋅       -1.41421
 Row permutation:
@@ -309,7 +309,7 @@ julia> F.Q
  0.0  0.0  0.0  1.0
 
 julia> F.R
-4×4 SparseMatrixCSC{Float64, Int64} with 5 stored entries:
+4×4 SparseMatrixCSC{Float64, Int64, Int64} with 5 stored entries:
  3.0   ⋅    ⋅    ⋅
   ⋅   4.0   ⋅   2.0
   ⋅    ⋅   5.0   ⋅
@@ -441,7 +441,7 @@ when the problem is underdetermined.
 # Examples
 ```jldoctest
 julia> A = sparse([1,2,4], [1,1,1], [1.0,1.0,1.0], 4, 2)
-4×2 SparseMatrixCSC{Float64, Int64} with 3 stored entries:
+4×2 SparseMatrixCSC{Float64, Int64, Int64} with 3 stored entries:
  1.0   ⋅
  1.0   ⋅
   ⋅    ⋅


### PR DESCRIPTION
This allows to have distinct "index types" for the nonzeros on the one hand, and the rowvals on the other hand. In general, this may not be a dramatic reduction in memory usage, but in some cases this may push limits, see #38790. ~~This should be fully backward compatible, and~~ basically all existing tests pass up to minor obvious/inavoidable changes.

TODO (if we agree to go in this direction):
- [ ] new tests
- [ ] update documentation
- [ ] mention in NEWS

Closes #38790.