### PR TITLE
fix #39895, crash from deserialized closure using the shared method table

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1289,6 +1289,8 @@ function deserialize_typename(s::AbstractSerializer, number)
                 tn.mt.kwsorter = kws
             end
         end
+    elseif makenew
+        tn.mt = Symbol.name.mt
     end
     return tn::Core.TypeName
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -609,3 +609,18 @@ let s = join(rand('a':'z', 1024)), io = IOBuffer()
     s2 = deserialize(io)
     @test Base.summarysize(s2) < 2*sizeof(s)
 end
+
+# issue #39895
+@eval Main begin
+    using Test, Serialization
+    let g = gensym(:g)
+        closure = eval(:(f -> $g(x) = f(x)))
+        inc(x) = x + 1
+        b = IOBuffer()
+        serialize(b, closure(inc))
+        seekstart(b)
+        f = deserialize(b)
+        # this should not crash
+        @test_broken f(1) == 2
+    end
+end


### PR DESCRIPTION
In this case we were serializing a type that uses the shared method table, but did not initialize its .mt field. This still does not fully work, but will now give a method error instead of a segfault, which is certainly worthwhile. To fix it completely we would need to send the type's methods as well, which is a bit trickier.