### PR TITLE
Add a method to similar with dims::Tuple{Integer, Vararg{Integer}}

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -746,6 +746,7 @@ similar(a::AbstractArray, ::Type{T}, dims::DimOrInd...) where {T}  = similar(a, 
 # define this method to convert supported axes to Ints, with the expectation that an offset array
 # package will define a method with dims::Tuple{Union{Integer, UnitRange}, Vararg{Union{Integer, UnitRange}}}
 similar(a::AbstractArray, ::Type{T}, dims::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where {T} = similar(a, T, to_shape(dims))
+similar(a::AbstractArray, ::Type{T}, dims::Tuple{Integer, Vararg{Integer}}) where {T} = similar(a, T, to_shape(dims))
 # similar creates an Array by default
 similar(a::AbstractArray, ::Type{T}, dims::Dims{N}) where {T,N}    = Array{T,N}(undef, dims)
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -857,6 +857,18 @@ end
 @testset "to_shape" begin
     @test Base.to_shape(()) === ()
     @test Base.to_shape(1) === 1
+    @test Base.to_shape(big(1)) === Base.to_shape(1)
+    @test Base.to_shape(Int8(1)) === Base.to_shape(1)
+end
+
+@testset "issue #39923: similar" begin
+    for ax in [(big(2), big(3)), (big(2), 3), (UInt64(2), 3), (2, UInt32(3)),
+        (big(2), Base.OneTo(3)), (Base.OneTo(2), Base.OneTo(big(3)))]
+
+        A = similar(ones(), Int, ax)
+        @test axes(A) === (Base.OneTo(2), Base.OneTo(3))
+        @test eltype(A) === Int
+    end
 end
 
 @testset "issue #19267" begin


### PR DESCRIPTION
Fixes #39923 by adding `similar(A, T, ::Tuple{Integer, Vararg{Integer}})`. Now there is no ambiguity on defining `similar` with `dims::Tuple{Union{Integer, UnitRange}, Vararg{Union{Integer, UnitRange}}}`

Now 
```julia
julia> Revise.track(Base)

julia> maybelength(i::Integer) = i;

julia> maybelength(r::AbstractUnitRange) = length(r);

julia> function Base.similar(A::AbstractArray, T, inds::Tuple{Union{Integer, UnitRange}, Vararg{Union{Integer, UnitRange}}})
           similar(A, T, map(maybelength, inds))
       end

julia> similar(ones(2), Float64, (big(1), big(2)))
1×2 Matrix{Float64}:
 6.91548e-310  0.0

julia> similar(ones(2), Float64, (1:3, big(2)))
3×2 Matrix{Float64}:
 0.0  0.0
 0.0  0.0
 0.0  0.0
```