### PR TITLE
Implement intersect for ProductIterator (matching CartesianIndices behaviour)

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1427,4 +1427,7 @@ only(x::NamedTuple) = throw(
     ArgumentError("NamedTuple contains $(length(x)) elements, must contain exactly 1 element")
 )
 
+
+Base.intersect(a::ProductIterator, b::ProductIterator) = ProductIterator(intersect.(a.iterators, b.iterators))
+
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -453,6 +453,10 @@ end
 @test length(product(1:2,1:10,4:6)) == 60
 @test Base.IteratorSize(product(1:2, countfrom(1))) == Base.IsInfinite()
 
+# intersection
+@test intersect(product(1:3, 4:6), product(2:4, 3:5)) == ProductIterator((2:3, 4:5))
+@test intersect(product(1:3, [4 5 ; 6 7]), product(2:4, [7 6 ; 5 4])).iterators == (2:3, [4, 6, 5, 7])
+
 # flatten
 # -------
 @test collect(flatten(Any[1:2, 4:5])) == Any[1,2,4,5]

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -454,7 +454,7 @@ end
 @test Base.IteratorSize(product(1:2, countfrom(1))) == Base.IsInfinite()
 
 # intersection
-@test intersect(product(1:3, 4:6), product(2:4, 3:5)) == ProductIterator((2:3, 4:5))
+@test intersect(product(1:3, 4:6), product(2:4, 3:5)) == Iterators.ProductIterator((2:3, 4:5))
 @test intersect(product(1:3, [4 5 ; 6 7]), product(2:4, [7 6 ; 5 4])).iterators == (2:3, [4, 6, 5, 7])
 
 # flatten


### PR DESCRIPTION
Fixes #39943
