### PR TITLE
Faster AbstractArray hashing

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2396,8 +2396,9 @@ pushfirst!(A, a, b, c...) = pushfirst!(pushfirst!(A, c...), a, b)
 
 ## hashing AbstractArray ##
 
+const hashabstrastarray_seed = UInt === UInt64 ? 0x7e2d6fb6448beb77 : 0xd4514ce5
 function hash(A::AbstractArray, h::UInt)
-    h = hash(AbstractArray, h)
+    h += hashabstrastarray_seed
     # Axes are themselves AbstractArrays, so hashing them directly would stack overflow
     # Instead hash the tuple of firsts and lasts along each dimension
     h = hash(map(first, axes(A)), h)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2396,9 +2396,9 @@ pushfirst!(A, a, b, c...) = pushfirst!(pushfirst!(A, c...), a, b)
 
 ## hashing AbstractArray ##
 
-const hashabstrastarray_seed = UInt === UInt64 ? 0x7e2d6fb6448beb77 : 0xd4514ce5
+const hash_abstractarray_seed = UInt === UInt64 ? 0x7e2d6fb6448beb77 : 0xd4514ce5
 function hash(A::AbstractArray, h::UInt)
-    h += hashabstrastarray_seed
+    h += hash_abstractarray_seed
     # Axes are themselves AbstractArrays, so hashing them directly would stack overflow
     # Instead hash the tuple of firsts and lasts along each dimension
     h = hash(map(first, axes(A)), h)


### PR DESCRIPTION
Currently, hashing AbstractArrays begins with hashing the type itself:
```julia
hash(AbstractArray, h)
```

This ends up using the `object_id` fallback, and it turns out to dominate the hashing time for small `AbstractArray`s:

```julia
julia> using StaticArrays, BenchmarkTools

julia> a = @SVector [1,2,3,4,5];

julia> @btime hash($a, UInt(0))
  77.935 ns (0 allocations: 0 bytes)
0xdeb6d0657a261f74

julia> @btime hash(AbstractArray, UInt(0))
  58.643 ns (0 allocations: 0 bytes)
0xc03f1dbe32103a9e
```

This replaces the hash of the objectid with a static randomly-generated
number. Now:
```julia
julia> @btime hash($a, UInt(0))
  18.580 ns (0 allocations: 0 bytes)
0x5e77b8bf73067ebd
```

and for a random `Float64` vector

```julia
julia> @btime hash($a, UInt(0))
  29.031 ns (0 allocations: 0 bytes)
0x9a574d69612587eb
```

However, I'm unsure whether in #26022 this design was deliberate in making the hashing vary across sessions. If so, perhaps we could generate a random number on Julia startup? I'd be grateful for feedback from @mbauman.