### PR TITLE
fix #39948, stack overflow due to free typevar during `jl_type_intersection2`

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1600,6 +1600,9 @@ static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **is
         return 0;
     if (is_subty)
         return 1;
+    // TODO: sometimes type intersection returns types with free variables
+    if (jl_has_free_typevars(t1) || jl_has_free_typevars(t2))
+        return 1;
     // determine if type-intersection can be convinced to give a better, non-bad answer
     // if the intersection was imprecise, see if we can do better by switching the types
     *isect2 = jl_type_intersection(t2, t1);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1894,3 +1894,10 @@ let T = Type{T} where T<:(AbstractArray{I}) where I<:(Base.IteratorsMD.Cartesian
     @test I <: S
     @test_broken I == typeintersect(S, T)
 end
+
+# issue #39948
+let A = Tuple{Array{Pair{T, JT} where JT<:Ref{T}, 1} where T, Vector},
+    I = typeintersect(A, Tuple{Vararg{Vector{T}}} where T)
+    @test_broken I <: A
+    @test_broken !Base.has_free_typevars(I)
+end


### PR DESCRIPTION
I don't have a complete fix for this, but it seems type intersection sometimes returns a type with free variables, throwing a wrench into the works. The temporary solution is to try not to pass an intersection result back into intersection. In such a case I doubt jl_type_intersection2 could have been doing anything useful anyway, so it seems safe to just disable part of it when that happens.