### PR TITLE
fix behavior of JULIA_EXCLUSIVE to agree with documentation

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -425,8 +425,8 @@ void jl_start_threads(void)
     // do we have exclusive use of the machine? default is no
     exclusive = DEFAULT_MACHINE_EXCLUSIVE;
     cp = getenv(MACHINE_EXCLUSIVE_NAME);
-    if (cp)
-        exclusive = strtol(cp, NULL, 10);
+    if (cp && strcmp(cp, "0") != 0)
+        exclusive = 1;
 
     // exclusive use: affinitize threads, master thread on proc 0, rest
     // according to a 'compact' policy


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/39947

```
❯ JULIA_EXCLUSIVE=1 ./julia -t 99 -q
ERROR: Too many threads requested for JULIA_EXCLUSIVE option.

❯ JULIA_EXCLUSIVE=true ./julia -t 99 -q
ERROR: Too many threads requested for JULIA_EXCLUSIVE option.

❯ JULIA_EXCLUSIVE=0 ./julia -t 99 -q
julia>
```