### PR TITLE
Allow CartesianIndices with Bool argument

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -278,6 +278,7 @@ module IteratorsMD
 
     CartesianIndices(A::AbstractArray) = CartesianIndices(axes(A))
 
+    _convert2ind(sz::Bool) = Base.OneTo(Int(sz))
     _convert2ind(sz::Integer) = Base.OneTo(sz)
     _convert2ind(sz::AbstractUnitRange) = first(sz):last(sz)
     _convert2ind(sz::OrdinalRange) = first(sz):step(sz):last(sz)

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -409,3 +409,10 @@ end
 # issue #39705
 f39705() = Base.Cartesian.@nany 0 _ -> true
 @test f39705() === false
+
+@testset "CartesianIndices with Bool" begin
+    @test @inferred(CartesianIndices((true,))) == CartesianIndices((1,))
+    @test @inferred(CartesianIndices((false,))) == CartesianIndices((0,))
+    @test @inferred(CartesianIndices((true, false))) == CartesianIndices((1, 0))
+    @test @inferred(CartesianIndices((false, true))) == CartesianIndices((0, 1))
+end


### PR DESCRIPTION
Follow up to the problem discussed in https://github.com/JuliaLang/julia/pull/31829#issuecomment-793030999.

I came to the conclusion that `CartesianIndices((true,))` should be allowed as in this context `true` represents a dimension length not an index.