### PR TITLE
Use faster hash for short arrays.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2405,9 +2405,9 @@ function hash(A::AbstractArray, h::UInt)
     h = hash(map(last, axes(A)), h)
 
     # For short arrays, it's not worth doing anything complicated 
-    if length(A) < 10000
-        @inbounds for p in pairs(IndexLinear(),A)
-            h ⊻= hash(p)
+    if length(A) < 8192
+        @inbounds for x in A
+            h = hash(x,h)
         end
         return h
     end
@@ -2441,9 +2441,8 @@ function hash(A::AbstractArray, h::UInt)
     n = 0
     while true
         n += 1
-        # Hash the current key-index and its element
-        elt = A[keyidx]
-        h = hash(keyidx=>elt, h)
+        # Hash the element
+        h = hash(A[keyidx], h)
 
         # Skip backwards a Fibonacci number of indices -- this is a linear index operation
         linidx = key_to_linear[keyidx]

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2404,7 +2404,7 @@ function hash(A::AbstractArray, h::UInt)
     h = hash(map(first, axes(A)), h)
     h = hash(map(last, axes(A)), h)
 
-    # For short arrays, it's not worth doing anything complicated 
+    # For short arrays, it's not worth doing anything complicated
     if length(A) < 8192
         @inbounds for x in A
             h = hash(x,h)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2407,7 +2407,7 @@ function hash(A::AbstractArray, h::UInt)
     # For short arrays, it's not worth doing anything complicated
     if length(A) < 8192
         for x in A
-            h = hash(x,h)
+            h = hash(x, h)
         end
         return h
     end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2439,7 +2439,7 @@ function hash(A::AbstractArray, h::UInt)
     fibskip = prevfibskip = oneunit(linidx)
     first_linear = first(LinearIndices(linear_to_key))
     n = 0
-    while true
+    @inbounds while true
         n += 1
         # Hash the element
         h = hash(A[keyidx], h)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2406,7 +2406,7 @@ function hash(A::AbstractArray, h::UInt)
 
     # For short arrays, it's not worth doing anything complicated
     if length(A) < 8192
-        @inbounds for x in A
+        for x in A
             h = hash(x,h)
         end
         return h

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2439,7 +2439,7 @@ function hash(A::AbstractArray, h::UInt)
     fibskip = prevfibskip = oneunit(linidx)
     first_linear = first(LinearIndices(linear_to_key))
     n = 0
-    @inbounds while true
+    while true
         n += 1
         # Hash the element
         h = hash(A[keyidx], h)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2403,7 +2403,14 @@ function hash(A::AbstractArray, h::UInt)
     # Instead hash the tuple of firsts and lasts along each dimension
     h = hash(map(first, axes(A)), h)
     h = hash(map(last, axes(A)), h)
-    isempty(A) && return h
+
+    # For short arrays, it's not worth doing anything complicated 
+    if length(A) < 10000
+        @inbounds for p in pairs(IndexLinear(),A)
+            h ⊻= hash(p)
+        end
+        return h
+    end
 
     # Goal: Hash approximately log(N) entries with a higher density of hashed elements
     # weighted towards the end and special consideration for repeated values. Colliding


### PR DESCRIPTION
Since the current code already hashes all elements of small arrays (<4096 elements), this is basically a fast-path that avoids a lot of the math. It also xors the hashes, which should allow the compiler to vectorize hashing. As a result, I'm measuring about a 4x speedup for hashing a 20x20 matrix, and have not found cases where this is slower. The biggest thing this needs is someone more familiar with `Array` hashing to make sure I'm not missing anything obvious about how hashing should work.