### PR TITLE
Fix constprop inference for varargs OpaqueClosure

### DIFF
--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -13,12 +13,12 @@ end
 # for the provided `linfo` and `given_argtypes`. The purpose of this function is
 # to return a valid value for `cache_lookup(linfo, argtypes, cache).argtypes`,
 # so that we can construct cache-correct `InferenceResult`s in the first place.
-function matching_cache_argtypes(linfo::MethodInstance, given_argtypes::Vector)
+function matching_cache_argtypes(linfo::MethodInstance, given_argtypes::Vector, va_override)
     @assert isa(linfo.def, Method) # ensure the next line works
     nargs::Int = linfo.def.nargs
     @assert length(given_argtypes) >= (nargs - 1)
     given_argtypes = anymap(widenconditional, given_argtypes)
-    if linfo.def.isva
+    if va_override || linfo.def.isva
         isva_given_argtypes = Vector{Any}(undef, nargs)
         for i = 1:(nargs - 1)
             isva_given_argtypes[i] = argtype_by_index(given_argtypes, i)
@@ -30,7 +30,7 @@ function matching_cache_argtypes(linfo::MethodInstance, given_argtypes::Vector)
         end
         given_argtypes = isva_given_argtypes
     end
-    cache_argtypes, overridden_by_const = matching_cache_argtypes(linfo, nothing)
+    cache_argtypes, overridden_by_const = matching_cache_argtypes(linfo, nothing, va_override)
     if nargs === length(given_argtypes)
         for i in 1:nargs
             given_argtype = given_argtypes[i]
@@ -134,10 +134,10 @@ function most_general_argtypes(method::Union{Method, Nothing}, @nospecialize(spe
     cache_argtypes
 end
 
-function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
+function matching_cache_argtypes(linfo::MethodInstance, ::Nothing, va_override::Bool)
     mthd = isa(linfo.def, Method) ? linfo.def::Method : nothing
-    cache_argtypes = most_general_argtypes(mthd, linfo.specTypes, isa(mthd, Method) ?
-            mthd.isva : false)
+    cache_argtypes = most_general_argtypes(mthd, linfo.specTypes,
+        va_override || (isa(mthd, Method) ? mthd.isva : false))
     return cache_argtypes, falses(length(cache_argtypes))
 end
 

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -3,7 +3,7 @@
 function inflate_ir(ci::CodeInfo, linfo::MethodInstance)
     sptypes = sptypes_from_meth_instance(linfo)
     if ci.inferred
-        argtypes, _ = matching_cache_argtypes(linfo, nothing)
+        argtypes, _ = matching_cache_argtypes(linfo, nothing, false)
     else
         argtypes = Any[ Any for i = 1:length(ci.slotflags) ]
     end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -29,8 +29,8 @@ mutable struct InferenceResult
     result # ::Type, or InferenceState if WIP
     src #::Union{CodeInfo, OptimizationState, Nothing} # if inferred copy is available
     valid_worlds::WorldRange # if inference and optimization is finished
-    function InferenceResult(linfo::MethodInstance, given_argtypes = nothing)
-        argtypes, overridden_by_const = matching_cache_argtypes(linfo, given_argtypes)
+    function InferenceResult(linfo::MethodInstance, given_argtypes = nothing, va_override=false)
+        argtypes, overridden_by_const = matching_cache_argtypes(linfo, given_argtypes, va_override)
         return new(linfo, argtypes, overridden_by_const, Any, nothing, WorldRange())
     end
 end

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -182,3 +182,10 @@ end
 end
 @test isa(oc_trivial_generated(), Core.OpaqueClosure{Tuple{}, Any})
 @test oc_trivial_generated()() == 1
+
+# Constprop through varargs OpaqueClosure
+function oc_varargs_constprop()
+    oc = @opaque (args...)->args[1]+args[2]+args[3]
+    return Val{oc(1,2,3)}()
+end
+Base.return_types(oc_varargs_constprop, Tuple{}) == Any[Val{6}]


### PR DESCRIPTION
OpaqueClosure are marked as vararg (or not) at construction time
rather than in the method. As a result, we need to chain this
information through to the cache. We may want to refactor this
code to deal with the vararg-ness (or not) of a particular
definition one level above this. We already keep the cache
in a form that represents the vararg tuple explicitly.
However, for now this fixes things for now (and also
prevents Cthulhu from getting confused upon encountering
these).