### PR TITLE
Fix wrong := REPL documentation

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -220,7 +220,7 @@ function lookup_doc(ex)
     if isa(ex, Symbol) && Base.isoperator(ex)
         str = string(ex)
         isdotted = startswith(str, ".")
-        if endswith(str, "=") && Base.operator_precedence(ex) == Base.prec_assignment
+        if endswith(str, "=") && Base.operator_precedence(ex) == Base.prec_assignment && ex !== :(:=)
             op = str[1:end-1]
             eq = isdotted ? ".=" : "="
             return Markdown.parse("`x $op= y` is a synonym for `x $eq x $op y`")

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1092,6 +1092,9 @@ end
 @test occursin("identical", sprint(show, help_result("===")))
 @test occursin("broadcast", sprint(show, help_result(".<=")))
 
+# Issue 39427
+@test occursin("does not exist", sprint(show, help_result(":=")))
+
 # Issue #25930
 
 # Brief and extended docs (issue #25930)


### PR DESCRIPTION
Fixes #39427

It seems `:=` deserved special casing among the operators finishing with `=` since it is one of four unsupported assignment operators (`≔`, `⩴` `≕` and `:=`), as written here: https://github.com/JuliaLang/julia/blob/b2d66c99672cdd726a8222335f39900f405b72f1/src/julia-syntax.scm#L4431-L4433

Should they have special REPL documentation stating that they cannot be defined? With this PR, the default behavior is reinstated:
```julia
help?> :=
search:

  No documentation found.

  Binding := does not exist.
```
and the same for the other three, which I think should be enough since using any of these four operators yields:
```julia
julia> a := b
ERROR: syntax: unsupported assignment operator ":="
```