### PR TITLE
[release-1.6] Backport "Try to close race condition in FileWatching tests"

### DIFF
--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -12,7 +12,7 @@ using Base: uv_error, Experimental
 # Writable ends are always tested for write-ability before a write
 
 n = 20
-intvls = [2, .2, .1, .005]
+intvls = [2, .2, .1, .005, .00001]
 
 pipe_fds = fill((Base.INVALID_OS_HANDLE, Base.INVALID_OS_HANDLE), n)
 for i in 1:n


### PR DESCRIPTION
This backports Keno's FileWatching fix to the `release-1.6` branch in hopes of fixing the x64 Linux failure in https://github.com/JuliaLang/julia/pull/39977. cc @KristofferC 