### PR TITLE
Check issimpleenoughtype before stripping off type parameters in tmerge

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -432,6 +432,10 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
         (uw isa DataType && ti <: uw.name.wrapper) || return Any
         typenames[i] = uw.name
     end
+    u = Union{types...}
+    if issimpleenoughtype(u)
+        return u
+    end
     # see if any of the union elements have the same TypeName
     # in which case, simplify this tmerge by replacing it with
     # the widest possible version of itself (the wrapper)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -966,7 +966,7 @@ p0 = copy(p)
     @test isequal(tuple.([1, 2], [3.0, missing]), [(1, 3.0), (2, missing)])
     @test Core.Compiler.return_type(broadcast, Tuple{typeof(tuple), Vector{Int},
                                                      Vector{Union{Float64, Missing}}}) ==
-        Union{Vector{Tuple{Int64, Missing}}, Vector{Tuple{Int64, Any}}, Vector{Tuple{Int64, Float64}}}
+        Union{Vector{Tuple{Int, Missing}}, Vector{Tuple{Int, Any}}, Vector{Tuple{Int, Float64}}}
     # Check that corner cases do not throw an error
     @test isequal(broadcast(x -> x === 1 ? nothing : x, [1, 2, missing]),
                   [nothing, 2, missing])

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -955,18 +955,18 @@ p0 = copy(p)
     @test isequal([1, 2] .+ [3.0, missing], [4.0, missing])
     @test Core.Compiler.return_type(broadcast, Tuple{typeof(+), Vector{Int},
                                                      Vector{Union{Float64, Missing}}}) ==
-        Vector{<:Union{Float64, Missing}}
+        Union{Vector{Missing}, Vector{Union{Missing, Float64}}, Vector{Float64}}
     @test isequal([1, 2] + [3.0, missing], [4.0, missing])
     @test Core.Compiler.return_type(+, Tuple{Vector{Int},
                                              Vector{Union{Float64, Missing}}}) ==
-        Vector{<:Union{Float64, Missing}}
+        Union{Vector{Missing}, Vector{Union{Missing, Float64}}, Vector{Float64}}
     @test Core.Compiler.return_type(+, Tuple{Vector{Int},
                                              Vector{Union{Float64, Missing}}}) ==
-        Vector{<:Union{Float64, Missing}}
+        Union{Vector{Missing}, Vector{Union{Missing, Float64}}, Vector{Float64}}
     @test isequal(tuple.([1, 2], [3.0, missing]), [(1, 3.0), (2, missing)])
     @test Core.Compiler.return_type(broadcast, Tuple{typeof(tuple), Vector{Int},
                                                      Vector{Union{Float64, Missing}}}) ==
-        Vector{<:Tuple{Int, Any}}
+        Union{Vector{Tuple{Int64, Missing}}, Vector{Tuple{Int64, Any}}, Vector{Tuple{Int64, Float64}}}
     # Check that corner cases do not throw an error
     @test isequal(broadcast(x -> x === 1 ? nothing : x, [1, 2, missing]),
                   [nothing, 2, missing])

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -73,11 +73,13 @@ function test_jl_dump_compiles_toplevel_thunks()
     # Make sure to cause compilation of the eval function
     # before calling it below.
     Core.eval(Main, Any[:(nothing)][1])
+    GC.enable(false)  # avoid finalizers to be compiled
     topthunk = Meta.lower(Main, :(for i in 1:10; end))
     ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), io.handle)
     Core.eval(Main, topthunk)
     ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), C_NULL)
     close(io)
+    GC.enable(true)
     tstats = stat(tfile)
     tempty = tstats.size == 0
     rm(tfile)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -103,10 +103,16 @@ tmerge_test(Tuple{ComplexF64, ComplexF64, ComplexF32}, Tuple{Vararg{Union{Comple
 tmerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
     Tuple{Vararg{Complex}})
 @test Core.Compiler.tmerge(Tuple{}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
+    Union{Nothing, Tuple{}, Tuple{ComplexF32, ComplexF32}}
+@test Core.Compiler.tmerge(Tuple{}, Union{Nothing, Tuple{ComplexF32}, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
 @test Core.Compiler.tmerge(Union{Nothing, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
+    Union{Nothing, Tuple{ComplexF32}, Tuple{ComplexF32, ComplexF32}}
+@test Core.Compiler.tmerge(Union{Nothing, Tuple{}, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
-@test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Vector{Bool})) == Vector
+@test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Vector{Bool})) ==
+    Union{Vector{Bool}, Vector{Int64}, Vector{String}}
+@test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Union{Vector{Bool}, Vector{Symbol}})) == Vector
 @test Core.Compiler.tmerge(Base.BitIntegerType, Union{}) === Base.BitIntegerType
 @test Core.Compiler.tmerge(Union{}, Base.BitIntegerType) === Base.BitIntegerType
 @test Core.Compiler.tmerge(Core.Compiler.InterConditional(1, Int, Union{}), Core.Compiler.InterConditional(2, String, Union{})) === Core.Compiler.Const(true)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3202,3 +3202,13 @@ end
         return y
     end == Any[Union{Nothing, Tuple{String, Union{Nothing, String}}}]
 end
+
+@test Base.return_types((Int,)) do x
+    if x === 0
+        Some(0.0)
+    elseif x == 1
+        Some(1)
+    else
+        Some(0x2)
+    end
+end == [Union{Some{Float64}, Some{Int64}, Some{UInt8}}]

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -111,7 +111,7 @@ tmerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
 @test Core.Compiler.tmerge(Union{Nothing, Tuple{}, Tuple{ComplexF32}}, Union{Nothing, Tuple{ComplexF32, ComplexF32}}) ==
     Union{Nothing, Tuple{Vararg{ComplexF32}}}
 @test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Vector{Bool})) ==
-    Union{Vector{Bool}, Vector{Int64}, Vector{String}}
+    Union{Vector{Bool}, Vector{Int}, Vector{String}}
 @test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Union{Vector{Bool}, Vector{Symbol}})) == Vector
 @test Core.Compiler.tmerge(Base.BitIntegerType, Union{}) === Base.BitIntegerType
 @test Core.Compiler.tmerge(Union{}, Base.BitIntegerType) === Base.BitIntegerType
@@ -3217,4 +3217,4 @@ end
     else
         Some(0x2)
     end
-end == [Union{Some{Float64}, Some{Int64}, Some{UInt8}}]
+end == [Union{Some{Float64}, Some{Int}, Some{UInt8}}]

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -89,8 +89,8 @@ B265(x::Any, dummy::Nothing) = B265{UInt8}(x, dummy)
 @test (B265_(2)::B265{Float64}).field1 === 2.0e0
 @test (B265_(3)::B265{UInt8}).field1 === 0x03
 
-@test Base.return_types(B265_, (Int,)) == Any[B265]
-@test Core.Compiler.return_type(B265_, (Int,)) == B265
+@test B265{UInt8} <: only(Base.return_types(B265_, (Int,))) <: B265
+@test B265{UInt8} <: Core.Compiler.return_type(B265_, (Int,)) <: B265
 
 
 # test oldworld call / inference


### PR DESCRIPTION
This patch makes the following code inferable

```julia
julia> Base.return_types((Int,)) do x
           if x === 0
               Some(0.0)
           elseif x == 1
               Some(1)
           else
               Some(0x2)
           end
       end
1-element Vector{Any}:
 Union{Some{Float64}, Some{Int64}, Some{UInt8}}
```

while before we had

```julia
julia> Base.return_types((Int,)) do x
           if x === 0
               Some(0.0)
           elseif x == 1
               Some(1)
           else
               Some(0x2)
           end
       end
1-element Vector{Any}:
 Some
```

This was due to `tmerge` was treating wrapped types specially:

```julia
julia> Core.Compiler.tmerge(Union{Int8,Int16}, Int32)
Union{Int16, Int32, Int8}

julia> Core.Compiler.tmerge(Union{Some{Int8},Some{Int16}}, Int32)
Union{Int32, Some}
```

after this PR:

```julia
julia> Core.Compiler.tmerge(Union{Some{Int8},Some{Int16}}, Int32)
Union{Some{Int16}, Some{Int8}, Int32}
```

This is done simply by checking the complexity of the Union before removing the type constraints of the wrapper types.

I think reducing the difference between the behavior of union of parametric and non-parametric types is nice since it makes easier for Julia programmers to have consistent expectation for when union splitting happens.

My motivation behind this is that Transducers.jl creates "FSMs" at the type level to generate non-trivial reductions, using nested parameterized types. So, it'd be great if we can improve the type inference of small unions of wrapped types. This is particularly useful on GPU where I need to make sure to remove all dynamic dispatches.
