### PR TITLE
Fixes rendering of nested lists.

### DIFF
--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -160,11 +160,11 @@ What happens if `import Zebra` is evaluated in the main `App` code base? Since `
 **The paths map** of a project environment is extracted from the manifest file. The path of a package `uuid` named `X` is determined by these rules (in order):
 
 1. If the project file in the directory matches `uuid` and name `X`, then either:
-  - It has a toplevel `path` entry, then `uuid` will be mapped to that path, interpreted relative to the directory containing the project file.
-  - Otherwise, `uuid` is mapped to  `src/X.jl` relative to the directory containing the project file.
+   - It has a toplevel `path` entry, then `uuid` will be mapped to that path, interpreted relative to the directory containing the project file.
+   - Otherwise, `uuid` is mapped to  `src/X.jl` relative to the directory containing the project file.
 2. If the above is not the case and the project file has a corresponding manifest file and the manifest contains a stanza matching `uuid` then:
-  - If it has a `path` entry, use that path (relative to the directory containing the manifest file).
-  - If it has a `git-tree-sha1` entry, compute a deterministic hash function of `uuid` and `git-tree-sha1`—call it `slug`—and look for a directory named `packages/X/$slug` in each directory in the Julia `DEPOT_PATH` global array. Use the first such directory that exists.
+   - If it has a `path` entry, use that path (relative to the directory containing the manifest file).
+   - If it has a `git-tree-sha1` entry, compute a deterministic hash function of `uuid` and `git-tree-sha1`—call it `slug`—and look for a directory named `packages/X/$slug` in each directory in the Julia `DEPOT_PATH` global array. Use the first such directory that exists.
 
 If any of these result in success, the path to the source code entry point will be either that result, the relative path from that result plus `src/X.jl`; otherwise, there is no path mapping for `uuid`. When loading `X`, if no source code path is found, the lookup will fail, and the user may be prompted to install the appropriate package version or to take other corrective action (e.g. declaring `X` as a dependency).
 


### PR DESCRIPTION
This change fixes the rendering of nested lists in the documentation by adding indentation.

Previously, the items in the outer ordered list would both be labeled with "1." when rendered to html. This change adds a single space to the indentation of each item in the unordered lists, resulting in the correct labels "1." and "2." when rendered to html.

### Screenshot: Before
<img width="836" alt="Screen Shot 2021-03-12 at 2 43 13 AM" src="https://user-images.githubusercontent.com/14797301/110909324-355b1400-82cd-11eb-9400-65b6e767d20a.png">


### Screenshot: After
<img width="824" alt="Screen Shot 2021-03-12 at 2 42 54 AM" src="https://user-images.githubusercontent.com/14797301/110909278-283e2500-82cd-11eb-8f63-f00327baa451.png">