### PR TITLE
Fix indexing IdentityUnitRange with Integers and Boolean ranges

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -380,18 +380,19 @@ Represent an AbstractUnitRange `range` as an offset vector such that `range[i] =
 struct IdentityUnitRange{I<:AbstractUnitRange, T} <: AbstractUnitRange{T}
     indices::I
 
-    _eltypecheck(::Type{T}, ::Type{Eltype}) where {T,Eltype} = throw(ArgumentError("type parameter T must be the element type ($Eltype), received T = $T"))
-    _eltypecheck(::Type{T}, ::Type{T}) where {T} = nothing
     function IdentityUnitRange{I,T}(indices::I) where {I<:AbstractUnitRange, T}
         _eltypecheck(T, eltype(I))
         new{I,T}(indices)
     end
 end
+_eltypecheck(::Type{T}, ::Type{T}) where {T} = nothing
+_eltypecheck(::Type{T}, ::Type{Eltype}) where {T,Eltype} = throw(ArgumentError("type parameter T must be the element type ($Eltype), received T = $T"))
+
 function IdentityUnitRange{I,T}(indices::AbstractUnitRange) where {I<:AbstractUnitRange, T}
     IdentityUnitRange{I,T}(convert(I, indices)::I)
 end
 IdentityUnitRange{I}(indices::I) where {I<:AbstractUnitRange} = IdentityUnitRange{I, eltype(I)}(indices)
-IdentityUnitRange(indices::I) where {I<:AbstractUnitRange} = IdentityUnitRange{I}(indices)
+IdentityUnitRange(indices::I) where {I<:AbstractUnitRange} = IdentityUnitRange{I, eltype(I)}(indices)
 IdentityUnitRange(S::IdentityUnitRange) = S
 # IdentityUnitRanges are offset and thus have offset axes, so they are their own axes
 axes(S::IdentityUnitRange) = (S,)

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -396,9 +396,9 @@ length(S::IdentityUnitRange) = length(S.indices)
 unsafe_length(S::IdentityUnitRange) = unsafe_length(S.indices)
 function getindex(S::IdentityUnitRange, i::Integer)
     @_inline_meta
-    i isa Bool && throw(ArgumentError("invalid index: $i of type Bool"))
     @boundscheck checkbounds(S, i)
-    i
+    j = to_indices(S, (i,))[1]
+    return j
 end
 function getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer})
     @_inline_meta
@@ -409,15 +409,15 @@ function getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer})
             return range(first(S), length = 0)
         elseif length(i) == 1
             if first(i)
-                return range(first(S), length = length(S))
+                return range(first(S), length = 1)
             else
                 return range(first(S), length=0)
             end
         else # length(i) == 2
-            return range(first(S) + one(first(S)), length=1)
+            return range(last(S), length=1)
         end
     else
-        return i
+        return map(Int, i)
     end
 end
 function getindex(S::IdentityUnitRange, i::StepRange{<:Integer})
@@ -426,18 +426,18 @@ function getindex(S::IdentityUnitRange, i::StepRange{<:Integer})
     if eltype(i) === Bool
         # logical indexing
         if length(i) == 0
-            return range(first(S), step=one(eltype(S)), length=0)
+            return range(first(S), step=oneunit(eltype(S)), length=0)
         elseif length(i) == 1
             if first(i)
-                return range(first(S), step=one(eltype(S)), length=1)
+                return range(first(S), step=oneunit(eltype(S)), length=1)
             else
-                return range(first(S), step=one(eltype(S)), length=0)
+                return range(first(S), step=oneunit(eltype(S)), length=0)
             end
         else # length(i) == 2
-            return range(first(S) + one(first(S)), step=one(eltype(S)), length=1)
+            return range(last(S), step=oneunit(eltype(S)), length=1)
         end
     else
-        return i
+        return map(Int, i)
     end
 end
 show(io::IO, r::IdentityUnitRange) = print(io, "Base.IdentityUnitRange(", r.indices, ")")

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -394,7 +394,12 @@ last(S::IdentityUnitRange) = last(S.indices)
 size(S::IdentityUnitRange) = (length(S.indices),)
 length(S::IdentityUnitRange) = length(S.indices)
 unsafe_length(S::IdentityUnitRange) = unsafe_length(S.indices)
-getindex(S::IdentityUnitRange, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
+function getindex(S::IdentityUnitRange, i::Integer)
+    @_inline_meta
+    i isa Bool && throw(ArgumentError("invalid index: $i of type Bool"))
+    @boundscheck checkbounds(S, i)
+    i
+end
 getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::IdentityUnitRange, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 show(io::IO, r::IdentityUnitRange) = print(io, "Base.IdentityUnitRange(", r.indices, ")")

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -400,8 +400,46 @@ function getindex(S::IdentityUnitRange, i::Integer)
     @boundscheck checkbounds(S, i)
     i
 end
-getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
-getindex(S::IdentityUnitRange, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
+function getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer})
+    @_inline_meta
+    @boundscheck checkbounds(S, i)
+    if eltype(i) === Bool
+        # logical indexing
+        if length(i) == 0
+            return range(first(S), length = 0)
+        elseif length(i) == 1
+            if first(i)
+                return range(first(S), length = length(S))
+            else
+                return range(first(S), length=0)
+            end
+        else # length(i) == 2
+            return range(first(S) + one(first(S)), length=1)
+        end
+    else
+        return i
+    end
+end
+function getindex(S::IdentityUnitRange, i::StepRange{<:Integer})
+    @_inline_meta
+    @boundscheck checkbounds(S, i)
+    if eltype(i) === Bool
+        # logical indexing
+        if length(i) == 0
+            return range(first(S), step=one(eltype(S)), length=0)
+        elseif length(i) == 1
+            if first(i)
+                return range(first(S), step=one(eltype(S)), length=1)
+            else
+                return range(first(S), step=one(eltype(S)), length=0)
+            end
+        else # length(i) == 2
+            return range(first(S) + one(first(S)), step=one(eltype(S)), length=1)
+        end
+    else
+        return i
+    end
+end
 show(io::IO, r::IdentityUnitRange) = print(io, "Base.IdentityUnitRange(", r.indices, ")")
 iterate(S::IdentityUnitRange, s...) = iterate(S.indices, s...)
 

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -377,17 +377,26 @@ Represent an AbstractUnitRange `range` as an offset vector such that `range[i] =
 
 `IdentityUnitRange`s are frequently used as axes for offset arrays.
 """
-struct IdentityUnitRange{T<:Integer, I<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
+struct IdentityUnitRange{I<:AbstractUnitRange, T} <: AbstractUnitRange{T}
     indices::I
+    function IdentityUnitRange{I,T}(indices::I) where {I<:AbstractUnitRange, T}
+        T === eltype(I) || throw(ArgumentError("type parameter T must be be the eltype of the indices ($(eltype(I))), received $T"))
+        new{I,T}(indices)
+    end
 end
+function IdentityUnitRange{I,T}(indices::AbstractUnitRange) where {I<:AbstractUnitRange, T}
+    IdentityUnitRange{I,T}(convert(I, indices)::I)
+end
+IdentityUnitRange{I}(indices::I) where {I<:AbstractUnitRange} = IdentityUnitRange{I, eltype(I)}(indices)
+IdentityUnitRange(indices::I) where {I<:AbstractUnitRange} = IdentityUnitRange{I}(indices)
 IdentityUnitRange(S::IdentityUnitRange) = S
 # IdentityUnitRanges are offset and thus have offset axes, so they are their own axes
 axes(S::IdentityUnitRange) = (S,)
 unsafe_indices(S::IdentityUnitRange) = (S,)
 axes1(S::IdentityUnitRange) = S
-axes(S::IdentityUnitRange{T, OneTo{T}}) where {T<:Integer} = (S.indices,)
-unsafe_indices(S::IdentityUnitRange{T, OneTo{T}}) where {T<:Integer} = (S.indices,)
-axes1(S::IdentityUnitRange{T, OneTo{T}}) where {T<:Integer} = S.indices
+axes(S::IdentityUnitRange{<:OneTo}) = (S.indices,)
+unsafe_indices(S::IdentityUnitRange{<:OneTo}) = (S.indices,)
+axes1(S::IdentityUnitRange{<:OneTo}) = S.indices
 
 first(S::IdentityUnitRange) = first(S.indices)
 last(S::IdentityUnitRange) = last(S.indices)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -285,6 +285,7 @@ end
             val = r[5]
             for T in [Int8, Int16, Int32, Int64, Int128, BigInt]
                 @test r[T(5)] == val
+                @test r[T(5)] isa eltype(r)
             end
             # indexing with a single Bool should throw an error
             @test_throws ArgumentError r[true]

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -279,6 +279,16 @@ end
         end
         R = LinearIndices((Base.IdentityUnitRange(0:1), 0:1))
         @test axes(R) == (Base.IdentityUnitRange(0:1), Base.OneTo(2))
+
+        @testset "indexing with Integers (issue #39997)" begin
+            r = Base.IdentityUnitRange(1:1000)
+            val = r[5]
+            for T in [Int8, Int16, Int32, Int64, Int128, BigInt]
+                @test r[T(5)] == val
+            end
+            # indexing with a single Bool should throw an error
+            @test_throws ArgumentError r[true]
+        end
     end
 end
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -289,6 +289,35 @@ end
             # indexing with a single Bool should throw an error
             @test_throws ArgumentError r[true]
         end
+        @testset "logical indexing" begin
+            for (ur, inds) in Any[(1:2, false:true), (1:1, true:true), (1:1, false:false), (1:0, true:false)]
+                iur = Base.IdentityUnitRange(ur)
+                @test iur[inds] == ur[inds]
+                @test iur[inds] == collect(iur)[inds]
+                @test iur[StepRange(inds)] == ur[StepRange(inds)]
+                @test iur[StepRange(inds)] == collect(iur)[StepRange(inds)]
+            end
+
+            for inds in [true:true, false:false, false:true]
+                @test_throws BoundsError Base.IdentityUnitRange(1:0)[inds]
+                @test_throws BoundsError Base.IdentityUnitRange(1:0)[StepRange(inds)]
+            end
+
+            for inds in [true:false, false:true]
+                @test_throws BoundsError Base.IdentityUnitRange(1:1)[inds]
+                @test_throws BoundsError Base.IdentityUnitRange(1:1)[StepRange(inds)]
+            end
+
+            for inds in [true:false, true:true, false:false]
+                @test_throws BoundsError Base.IdentityUnitRange(1:2)[inds]
+                @test_throws BoundsError Base.IdentityUnitRange(1:2)[StepRange(inds)]
+            end
+
+            for inds in [true:false, true:true, false:false, false:true]
+                @test_throws BoundsError Base.IdentityUnitRange(1:4)[inds]
+                @test_throws BoundsError Base.IdentityUnitRange(1:4)[StepRange(inds)]
+            end
+        end
     end
 end
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -281,14 +281,27 @@ end
         @test axes(R) == (Base.IdentityUnitRange(0:1), Base.OneTo(2))
 
         @testset "indexing with Integers (issue #39997)" begin
-            r = Base.IdentityUnitRange(1:1000)
-            val = r[5]
-            for T in [Int8, Int16, Int32, Int64, Int128, BigInt]
-                @test r[T(5)] == val
-                @test r[T(5)] isa eltype(r)
+            for ur in [1:1000, big(2):big(2)^65]
+                r = Base.IdentityUnitRange(ur)
+                val = r[5]
+                for T in [Int8, Int16, Int32, Int64, Int128, BigInt]
+                    @test r[T(5)] == val
+                    @test r[T(5)] isa eltype(r)
+                end
+                # indexing with a single Bool should throw an error
+                @test_throws ArgumentError r[true]
+
+                @testset "iteration" begin
+                    @test first(r) === r[begin]
+                    @test last(r) === r[end]
+                    v, st = iterate(r)
+                    @test v == r[begin]
+                    @test v isa eltype(r)
+                    v, st = iterate(r, st)
+                    @test v == r[begin + 1]
+                    @test v isa eltype(r)
+                end
             end
-            # indexing with a single Bool should throw an error
-            @test_throws ArgumentError r[true]
         end
         @testset "logical indexing" begin
             for (ur, inds) in Any[(1:2, false:true), (1:1, true:true), (1:1, false:false), (1:0, true:false)]

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -12,7 +12,7 @@ module OffsetArrays
 using Base: tail, @propagate_inbounds
 using Base: IdentityUnitRange
 
-const IIUR = IdentityUnitRange{AbstractUnitRange{T},T} where T<:Integer
+const IIUR = IdentityUnitRange{<:AbstractUnitRange{T},T} where T<:Integer
 
 export OffsetArray, OffsetMatrix, OffsetVector
 

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -362,7 +362,7 @@ Broadcast.broadcast_unalias(dest::OffsetArray, src::OffsetArray) = parent(dest) 
 ### Special handling for AbstractRange
 
 const OffsetRange{T} = OffsetArray{T,1,<:AbstractRange{T}}
-const IIUR = IdentityUnitRange{S} where S<:AbstractUnitRange{T} where T<:Integer
+const IIUR = IdentityUnitRange{AbstractUnitRange{T},T} where T<:Integer
 
 Base.step(a::OffsetRange) = step(parent(a))
 

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -72,7 +72,7 @@ offset_coerce(::Type{I}, r::AbstractUnitRange) where I<:AbstractUnitRange{T} whe
 @inline Base.length(r::IdOffsetRange) = length(r.parent)
 Base.reduced_index(i::IdOffsetRange) = typeof(i)(first(i):first(i))
 # Workaround for #92 on Julia < 1.4
-Base.reduced_index(i::IdentityUnitRange{<:Integer, <:IdOffsetRange}) = typeof(i)(first(i):first(i))
+Base.reduced_index(i::IdentityUnitRange{<:IdOffsetRange}) = typeof(i)(first(i):first(i))
 for f in [:firstindex, :lastindex]
     @eval Base.$f(r::IdOffsetRange) = $f(r.parent) .+ r.offset
 end
@@ -362,6 +362,7 @@ Broadcast.broadcast_unalias(dest::OffsetArray, src::OffsetArray) = parent(dest) 
 ### Special handling for AbstractRange
 
 const OffsetRange{T} = OffsetArray{T,1,<:AbstractRange{T}}
+const IIUR = IdentityUnitRange{S} where S<:AbstractUnitRange{T} where T<:Integer
 
 Base.step(a::OffsetRange) = step(parent(a))
 
@@ -369,25 +370,25 @@ Base.step(a::OffsetRange) = step(parent(a))
 @propagate_inbounds function Base.getindex(a::OffsetRange, r::IdOffsetRange)
     OffsetArray(a.parent[r.parent .+ (r.offset - a.offsets[1])], r.offset)
 end
-@propagate_inbounds Base.getindex(r::OffsetRange, s::IdentityUnitRange) =
+@propagate_inbounds Base.getindex(r::OffsetRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
 @propagate_inbounds Base.getindex(a::OffsetRange, r::AbstractRange) = a.parent[r .- a.offsets[1]]
 @propagate_inbounds Base.getindex(a::AbstractRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
 
-@propagate_inbounds Base.getindex(r::UnitRange, s::IdentityUnitRange) =
+@propagate_inbounds Base.getindex(r::UnitRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
 
-@propagate_inbounds Base.getindex(r::StepRange, s::IdentityUnitRange) =
+@propagate_inbounds Base.getindex(r::StepRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
 
 # this method is needed for ambiguity resolution
-@propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::IdentityUnitRange) where T =
+@propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::IIUR) where T =
     OffsetArray(r[s.indices], s)
 
-@propagate_inbounds Base.getindex(r::StepRangeLen{T}, s::IdentityUnitRange) where {T} =
+@propagate_inbounds Base.getindex(r::StepRangeLen{T}, s::IIUR) where {T} =
     OffsetArray(r[s.indices], s)
 
-@propagate_inbounds Base.getindex(r::LinRange, s::IdentityUnitRange) =
+@propagate_inbounds Base.getindex(r::LinRange, s::IIUR) =
     OffsetArray(r[s.indices], s)
 
 function Base.show(io::IO, r::OffsetRange)
@@ -406,7 +407,7 @@ Base.append!(A::OffsetVector, items) = (append!(A.parent, items); A)
 Base.empty!(A::OffsetVector) = (empty!(A.parent); A)
 
 # These functions keep the summary compact
-function Base.inds2string(inds::Tuple{Vararg{Union{IdOffsetRange,IdentityUnitRange{<:Integer,<:IdOffsetRange}}}})
+function Base.inds2string(inds::Tuple{Vararg{Union{IdOffsetRange,IdentityUnitRange{<:IdOffsetRange}}}})
     Base.inds2string(map(UnitRange, inds))
 end
 Base.showindices(io::IO, ind1::IdOffsetRange, inds::IdOffsetRange...) = Base.showindices(io, map(UnitRange, (ind1, inds...))...)

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -12,6 +12,8 @@ module OffsetArrays
 using Base: tail, @propagate_inbounds
 using Base: IdentityUnitRange
 
+const IIUR = IdentityUnitRange{AbstractUnitRange{T},T} where T<:Integer
+
 export OffsetArray, OffsetMatrix, OffsetVector
 
 struct IdOffsetRange{T<:Integer,I<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
@@ -95,7 +97,7 @@ end
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::AbstractUnitRange{<:Integer})
     return r.parent[s .- r.offset] .+ r.offset
 end
-@propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IdentityUnitRange)
+@propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IIUR)
     return IdOffsetRange(r.parent[s .- r.offset], r.offset)
 end
 @propagate_inbounds function Base.getindex(r::IdOffsetRange, s::IdOffsetRange)
@@ -360,9 +362,7 @@ Base.dataids(A::OffsetArray) = Base.dataids(parent(A))
 Broadcast.broadcast_unalias(dest::OffsetArray, src::OffsetArray) = parent(dest) === parent(src) ? src : Broadcast.unalias(dest, src)
 
 ### Special handling for AbstractRange
-
 const OffsetRange{T} = OffsetArray{T,1,<:AbstractRange{T}}
-const IIUR = IdentityUnitRange{AbstractUnitRange{T},T} where T<:Integer
 
 Base.step(a::OffsetRange) = step(parent(a))
 


### PR DESCRIPTION
Fixes #39997 

Now:
```julia
julia> r = Base.IdentityUnitRange(2:1000)
Base.IdentityUnitRange(2:1000)

julia> r[Int32(5)]
5

julia> r[Int64(5)]
5
```