### PR TITLE
Speedup iteration for wrappers around arrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1091,6 +1091,7 @@ zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
 # own, IndexCartesian's CartesianIndices is more complicated and requires explicit
 # inlining.
 function iterate(A::AbstractArray, state=(eachindex(A),))
+    @_propagate_inbounds_meta
     y = iterate(state...)
     y === nothing && return nothing
     A[y[1]], (state[1], tail(y)...)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1674,14 +1674,18 @@
                          `(scope-block ,body))))
                `(block (= ,coll ,(car itrs))
                        (local ,next)
+                       (inbounds (true))
                        (= ,next (call (top iterate) ,coll))
+                       (inbounds pop)
                        ;; TODO avoid `local declared twice` error from this
                        ;;,@(if outer `((local ,lhs)) '())
                        ,@(if outer `((require-existing-local ,lhs)) '())
                        (if (call (top not_int) (call (core ===) ,next (null)))
-                           (_do_while
-			    (block ,body
-				   (= ,next (call (top iterate) ,coll ,state)))
+                         (_do_while
+                           (block ,body
+                                  (inbounds (true))
+                                  (= ,next (call (top iterate) ,coll ,state))
+                                  (inbounds pop))
 			    (call (top not_int) (call (core ===) ,next (null))))))))))))
 
 ;; wrap `expr` in a function appropriate for consuming values from given ranges


### PR DESCRIPTION
This will make `for` loops such as `for i in itr; #= body =#; end` lower to

```julia
@inbounds next = iterate(iter)
while next !== nothing
    (i, state) = next
    # body
    @inbounds next = iterate(iter, state)
end
```

Currently no `@inbounds` annotations are added unless the whole for loop is manually annotated. This should make, for instance, iteration over `views` faster.

 Before
```julia
using BenchmarkTools

let
    v = rand(100);
    w = view(v, :)
    @btime any(iszero, $v)  # 41.471 ns (0 allocations: 0 bytes)
    @btime any(iszero, $w)  # 61.306 ns (0 allocations: 0 bytes)
end
```

After
```julia
using BenchmarkTools

let
    v = rand(100);
    w = view(v, :)
    @btime any(iszero, $v)  # 41.471 ns (0 allocations: 0 bytes)
    @btime any(iszero, $w)  # 41.840 ns (0 allocations: 0 bytes)
end
```

Also fixes #39354.