### PR TITLE
Implement inlining for OpaqueClosure

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1235,11 +1235,14 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter, closure::Part
     pushfirst!(argtypes, closure.env)
     sig = argtypes_to_type(argtypes)
     rt, edgecycle, edge = abstract_call_method(interp, closure.source::Method, sig, Core.svec(), false, sv)
-    info = OpaqueClosureCallInfo(edge)
+    add_backedge!(edge, sv)
+    tt = closure.typ
+    sigT = unwrap_unionall(tt).parameters[1]
+    match = MethodMatch(sig, Core.svec(), closure.source::Method, sig <: rewrap_unionall(sigT, tt))
+    info = OpaqueClosureCallInfo(match)
     if !edgecycle
         const_rettype, result = abstract_call_method_with_const_args(interp, rt, closure, argtypes,
-            MethodMatch(sig, Core.svec(), closure.source::Method, false),
-            sv, edgecycle, closure.isva)
+            match, sv, edgecycle, closure.isva)
         if const_rettype ⊑ rt
            rt = const_rettype
         end

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -49,6 +49,21 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, sptypes::
                 eT ⊑ fT || return false
             end
             return true
+        elseif head === :new_opaque_closure
+            length(ea) < 5 && return false
+            a = ea[1]
+            typ = argextype(a, src, sptypes)
+            typ, isexact = instanceof_tfunc(typ)
+            isexact || return false
+            typ ⊑ Tuple || return false
+            isva = argextype(ea[2], src, sptypes)
+            rt_lb = argextype(ea[3], src, sptypes)
+            rt_ub = argextype(ea[4], src, sptypes)
+            src = argextype(ea[5], src, sptypes)
+            if !(isva ⊑ Bool && rt_lb ⊑ Type && rt_ub ⊑ Type && src ⊑ Method)
+                return false
+            end
+            return true
         elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds || head === :boundscheck
             return true
         else

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -111,7 +111,7 @@ struct InvokeCallInfo
 end
 
 struct OpaqueClosureCallInfo
-    mi::MethodInstance
+    match::MethodMatch
 end
 
 struct OpaqueClosureCreateInfo

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -46,8 +46,8 @@ let ci = @code_lowered OcClos2Int(1, 2)();
 end
 @test @inferred(oc_self_call_clos()) == 3
 let opt = @code_typed oc_self_call_clos()
-    @test_broken length(opt[1].code) == 1
-    @test_broken isa(opt[1].code[1], Core.ReturnNode)
+    @test length(opt[1].code) == 1
+    @test isa(opt[1].code[1], Core.ReturnNode)
 end
 
 struct OcClos1Any
@@ -88,8 +88,8 @@ end
 @test @inferred(complicated_identity(1)) == 1
 @test @inferred(complicated_identity("a")) == "a"
 let ci = (@code_typed complicated_identity(1))[1]
-    @test_broken length(ci.code) == 1
-    @test_broken isa(ci.code[1], Core.ReturnNode)
+    @test length(ci.code) == 1
+    @test isa(ci.code[1], Core.ReturnNode)
 end
 
 struct OcOpt


### PR DESCRIPTION
Inlining works basically the same as for regular methods
(except that the info is diffrent of course). One particular
difference is that inlining replaces `getfield` by a new
`getfield_closure_env` function that pierces through the
opaqueness of the closure. The getfield elim pass is taught
about this function and can eliminate it, but there is
also a fallback implementation of it in Core. This is
entirely intended to be a temporary implementation detail
until we do something better for the opaque closure
environment, so it's not supposed to have user facing
semantics.

This fixes all but one of the `test_broken` cases in 
the opaque closure tests. The last one
(optimizing out unused elements of the
environment) is a bit of an optimization for the case
where things are properly inferred but not inlined.
That's important in general, but for now, I'm primarily
focused on inference quality and the fully inlined case,
so I'm planning to leave that as future work for the moment.