### PR TITLE
Fix eltype example in Methods section of manual

### DIFF
--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -551,6 +551,7 @@ of any arbitrary subtype of `AbstractArray`:
 
 ```julia
 abstract type AbstractArray{T, N} end
+eltype(::Type{<:AbstractArray}) = Any
 eltype(::Type{<:AbstractArray{T}}) where {T} = T
 ```
 using so-called triangular dispatch.  Note that if `T` is a `UnionAll`

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -546,39 +546,19 @@ Here are a few common design patterns that come up sometimes when using dispatch
 ### Extracting the type parameter from a super-type
 
 
-Here is the correct code template for returning the element-type `T`
-of any arbitrary subtype of `AbstractArray`:
+Here is a correct code template for returning the element-type `T`
+of any arbitrary subtype of `AbstractArray` that has well-defined
+element type:
 
 ```julia
 abstract type AbstractArray{T, N} end
-eltype(::Type{<:AbstractArray}) = Any
 eltype(::Type{<:AbstractArray{T}}) where {T} = T
 ```
-using so-called triangular dispatch.  Note that if `T` is a `UnionAll`
-type, as e.g. `eltype(Array{T} where T <: Integer)`, then `Any` is
-returned (as does the version of `eltype` in `Base`).
 
-Another way, which used to be the only correct way before the advent of
-triangular dispatch in Julia v0.6, is:
-
-```julia
-abstract type AbstractArray{T, N} end
-eltype(::Type{AbstractArray}) = Any
-eltype(::Type{AbstractArray{T}}) where {T} = T
-eltype(::Type{AbstractArray{T, N}}) where {T, N} = T
-eltype(::Type{A}) where {A<:AbstractArray} = eltype(supertype(A))
-```
-
-Another possibility is the following, which could be useful to adapt
-to cases where the parameter `T` would need to be matched more
-narrowly:
-```julia
-eltype(::Type{AbstractArray{T, N} where {T<:S, N<:M}}) where {M, S} = Any
-eltype(::Type{AbstractArray{T, N} where {T<:S}}) where {N, S} = Any
-eltype(::Type{AbstractArray{T, N} where {N<:M}}) where {M, T} = T
-eltype(::Type{AbstractArray{T, N}}) where {T, N} = T
-eltype(::Type{A}) where {A <: AbstractArray} = eltype(supertype(A))
-```
+using so-called triangular dispatch.  Note that `UnionAll` types, for
+example `eltype(AbstractArray{T} where T <: Integer)`, do not match the
+above method. The implementation of `eltype` in `Base` adds a fallback
+method to `Any` for such cases.
 
 
 One common mistake is to try and get the element-type by using introspection:
@@ -596,6 +576,25 @@ struct BitVector <: AbstractArray{Bool, 1}; end
 Here we have created a type `BitVector` which has no parameters,
 but where the element-type is still fully specified, with `T` equal to `Bool`!
 
+
+Another mistake is to try to walk up the type hierarchy using
+`supertype`:
+```julia
+eltype_wrong(::Type{AbstractArray{T}}) where {T} = T
+eltype_wrong(::Type{AbstractArray{T, N}}) where {T, N} = T
+eltype_wrong(::Type{A}) where {A<:AbstractArray} = eltype_wrong(supertype(A))
+```
+
+While this works for declared types, it fails for types without
+supertypes:
+
+```julia-repl
+julia> eltype_wrong(Union{AbstractArray{Int}, AbstractArray{Float64}})
+ERROR: MethodError: no method matching supertype(::Type{Union{AbstractArray{Float64,N} where N, AbstractArray{Int64,N} where N}})
+Closest candidates are:
+  supertype(::DataType) at operators.jl:43
+  supertype(::UnionAll) at operators.jl:48
+```
 
 ### Building a similar type with a different type parameter
 


### PR DESCRIPTION
~The code as written doesn't work for me when passing `eltype(Array{T} where T <: Integer)` (Julia 1.5.4), IIUC because `Array{T} where T <: Integer` is not a subtype of `AbstractArray{Any}` (but it *is* a subtype of `AbstractArray`).

I guess maybe the example isn't meant to be complete, but I got confused when trying to understand why `eltype(Array{T} where T <: Integer)` should have been `Any` from the code, so maybe others would benefit from a little more detail too.

(Also apologies if I'm missing something obvious here; it's my first day with Julia.)~

My reading of the original example was that it should return `Any` for `UnionAll` types, which it doesn't (instead it's just the actual implementation in `Base` that does that). This PR clarifies that, and also removes the next two examples, which throw errors for certain types (for example unions). It replaces the latter with another section explaining that walking the type hierarchy using `supertype` can be problematic.