### PR TITLE
add docstring for VecElement

### DIFF
--- a/base/baseext.jl
+++ b/base/baseext.jl
@@ -2,6 +2,15 @@
 
 # extensions to Core types to add features in Base
 
+"""
+    VecElement{T}
+
+Element type of vectors with elements of type `T`. Homogeneous tuples with
+this type element represent a SIMD (single instruction, multiple data) vector
+(e.g., `NTuple{4,VecElement{Float32}}`).
+"""
+VecElement
+
 # hook up VecElement constructor to Base.convert
 VecElement{T}(arg) where {T} = VecElement{T}(convert(T, arg))
 convert(::Type{T}, arg::T) where {T<:VecElement} = arg

--- a/base/baseext.jl
+++ b/base/baseext.jl
@@ -5,9 +5,11 @@
 """
     VecElement{T}
 
-Element type of vectors with elements of type `T`. Homogeneous tuples with
-this type element represent a SIMD (single instruction, multiple data) vector
-(e.g., `NTuple{4,VecElement{Float32}}`).
+A wrapper type that holds a single value of type `T`. When used in the context of an
+`NTuple{N, VecElement{T}} where {T, N}` object, it provides a hint to the runtime
+system to align that struct to be more amenable to vectorization optimization
+opportunities. In `ccall`, such an NTuple in the type signature will also use the
+vector register ABI, rather than the usual struct ABI.
 """
 VecElement
 


### PR DESCRIPTION
It is exported but not documented. I guess those who use this type should already know well what it is. But just for completeness. Suggestions are welcomed. 