### PR TITLE
Support shared named environments during startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ Compiler/Runtime improvements
 Command-line option changes
 ---------------------------
 
+* The Julia `--project` option and the `JULIA_PROJECT` environment variable now support selecting shared environments like `.julia/environments/myenv` the same way the package management console does: use `julia --project=@myenv` resp. `export JULIA_PROJECT="@myenv"` ([#40025]).
+
 
 Multi-threading changes
 -----------------------

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -235,7 +235,8 @@ function init_active_project()
     ACTIVE_PROJECT[] =
         project === nothing ? nothing :
         project == "" ? nothing :
-        project == "@." ? current_project() : abspath(expanduser(project))
+        project == "@." ? current_project() :
+        startswith(project, "@") ? abspath(load_path_expand(project)) : abspath(expanduser(project))
 end
 
 ## load path expansion: turn LOAD_PATH entries into concrete paths ##

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -235,8 +235,7 @@ function init_active_project()
     ACTIVE_PROJECT[] =
         project === nothing ? nothing :
         project == "" ? nothing :
-        project == "@." ? current_project() :
-        startswith(project, "@") ? abspath(load_path_expand(project)) : abspath(expanduser(project))
+        startswith(project, "@") ? load_path_expand(project) : abspath(expanduser(project))
 end
 
 ## load path expansion: turn LOAD_PATH entries into concrete paths ##

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -110,13 +110,16 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
     # ~ expansion in --project and JULIA_PROJECT
     if !Sys.iswindows()
-        expanded_a = abspath(expanduser("~/foo"))
-        @test occursin(expanded_a, readchomp(`$exename --project='~/foo' -E 'Base.active_project()'`))
-        @test occursin(expanded_a, readchomp(setenv(`$exename -E 'Base.active_project()'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir())))
+        let expanded = abspath(expanduser("~/foo/Project.toml"))
+            @test expanded == readchomp(`$exename --project='~/foo' -e 'println(Base.active_project())'`)
+            @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir()))
+        end
+    end
 
-        expanded_b = abspath(Base.load_path_expand("@foo"))
-        @test occursin(expanded_b, readchomp(`$exename --project='@foo' -E 'Base.active_project()'`))
-        @test occursin(expanded_b, readchomp(setenv(`$exename -E 'Base.active_project()'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir())))
+    # handling of @projectname in --project and JULIA_PROJECT
+    let expanded = abspath(Base.load_path_expand("@foo"))
+        @test expanded == readchomp(`$exename --project='@foo' -e 'println(Base.active_project())'`)
+        @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir()))
     end
 
     # --quiet, --banner

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -110,9 +110,13 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
     # ~ expansion in --project and JULIA_PROJECT
     if !Sys.iswindows()
-        expanded = abspath(expanduser("~/foo"))
-        @test occursin(expanded, readchomp(`$exename --project='~/foo' -E 'Base.active_project()'`))
-        @test occursin(expanded, readchomp(setenv(`$exename -E 'Base.active_project()'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir())))
+        expanded_a = abspath(expanduser("~/foo"))
+        @test occursin(expanded_a, readchomp(`$exename --project='~/foo' -E 'Base.active_project()'`))
+        @test occursin(expanded_a, readchomp(setenv(`$exename -E 'Base.active_project()'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir())))
+
+        expanded_b = abspath(Base.load_path_expand("@foo"))
+        @test occursin(expanded_b, readchomp(`$exename --project='@foo' -E 'Base.active_project()'`))
+        @test occursin(expanded_b, readchomp(setenv(`$exename -E 'Base.active_project()'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir())))
     end
 
     # --quiet, --banner


### PR DESCRIPTION
Implements #35354 .

I hope I did this right - from what I saw, most things @fredrikekre had in his proposed patch in #35354, `load_path_expand()` does already now. So just using `load_path_expand()` instead of `expanduser()` in `init_active_project()` seems to do the trick. I'm not an expert on Julia's init process, though.

WIth this, both `--project=@myenv` and `JULIA_PROJECT=@myenv` seem to behave the same way as `activate @myenv` on the Pkg console.