### PR TITLE
Include nested ReinterpretArrays in StridedReinterpretArray

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -125,7 +125,7 @@ reinterpret(::typeof(reshape), ::Type{T}, a::ReshapedReinterpretArray) where {T}
 
 # Definition of StridedArray
 StridedFastContiguousSubArray{T,N,A<:DenseArray} = FastContiguousSubArray{T,N,A}
-StridedReinterpretArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray},IsReshaped} = ReinterpretArray{T,N,S,A,IsReshaped} where S
+StridedReinterpretArray{T,N,A<:Union{DenseArray,ReinterpretArray,StridedFastContiguousSubArray},IsReshaped} = ReinterpretArray{T,N,S,A,IsReshaped} where S
 StridedReshapedArray{T,N,A<:Union{DenseArray,StridedFastContiguousSubArray,StridedReinterpretArray}} = ReshapedArray{T,N,A}
 StridedSubArray{T,N,A<:Union{DenseArray,StridedReshapedArray,StridedReinterpretArray},
     I<:Tuple{Vararg{Union{RangeIndex, ReshapedUnitRange, AbstractCartesianIndex}}}} = SubArray{T,N,A,I}


### PR DESCRIPTION
Should nested `ReinterpretArray`s be covered in `StridedReinterpretArray`?

The reason I ask/propose this is because the introduction of `reinterpret(reshape, T, A)` broke a development branch of VideoIO (evident when testing 1.5.4 vs. 1.6 here https://github.com/JuliaIO/VideoIO.jl/pull/300#issuecomment-798825802)

With this PR, VideoIO passes, meaning that `stride` operates successfully on the `Base.ReinterpretArray{UInt8, 2, N6f10, Base.ReinterpretArray{N6f10, 2, Gray{N6f10}, Matrix{Gray{N6f10}}, true}, false}`

```julia
julia> using FixedPointNumbers, ColorTypes

julia> Base.ReinterpretArray{N0f8, 2, Gray{N0f8}, Matrix{Gray{N0f8}}, true} <: StridedArray
true

julia> Base.ReinterpretArray{UInt8, 2, N6f10, Base.ReinterpretArray{N6f10, 2, Gray{N6f10}, Matrix{Gray{N6f10}}, true}, false} <: StridedArray
true # false on master
```