### PR TITLE
Allow the conversion of AbstractUnitRanges to OrdinalRanges

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -274,11 +274,6 @@ module IteratorsMD
         indices = map(r->convert(OrdinalRangeInt, r), inds)
         CartesianIndices{N, typeof(indices)}(indices)
     end
-    # specialized method in case conversion to an OrdinalRange is not defined for the indices (see issue #40035)
-    function CartesianIndices(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N}
-        indices = map(r->convert(AbstractUnitRange{Int}, r), inds)
-        CartesianIndices{N, typeof(indices)}(indices)
-    end
 
     CartesianIndices(index::CartesianIndex) = CartesianIndices(index.I)
     CartesianIndices(inds::NTuple{N,Union{<:Integer,OrdinalRange{<:Integer}}}) where {N} =

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -274,6 +274,11 @@ module IteratorsMD
         indices = map(r->convert(OrdinalRangeInt, r), inds)
         CartesianIndices{N, typeof(indices)}(indices)
     end
+    # specialized method in case conversion to an OrdinalRange is not defined for the indices (see issue #40035)
+    function CartesianIndices(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N}
+        indices = map(r->convert(AbstractUnitRange{Int}, r), inds)
+        CartesianIndices{N, typeof(indices)}(indices)
+    end
 
     CartesianIndices(index::CartesianIndex) = CartesianIndices(index.I)
     CartesianIndices(inds::NTuple{N,Union{<:Integer,OrdinalRange{<:Integer}}}) where {N} =

--- a/base/range.jl
+++ b/base/range.jl
@@ -1253,7 +1253,7 @@ AbstractUnitRange{T}(r::UnitRange) where {T} = UnitRange{T}(r)
 AbstractUnitRange{T}(r::OneTo) where {T} = OneTo{T}(r)
 
 OrdinalRange{T1, T2}(r::StepRange) where {T1, T2<: Integer} = StepRange{T1, T2}(r)
-OrdinalRange{T, T}(r::AbstractUnitRange) where {T<:Integer} = AbstractUnitRange{T}(r)
+OrdinalRange{T, T}(r::AbstractUnitRange) where {T} = AbstractUnitRange{T}(r)
 
 function promote_rule(::Type{StepRange{T1a,T1b}}, ::Type{StepRange{T2a,T2b}}) where {T1a,T1b,T2a,T2b}
     Tb = promote_type(T1b, T2b)

--- a/base/range.jl
+++ b/base/range.jl
@@ -1253,9 +1253,7 @@ AbstractUnitRange{T}(r::UnitRange) where {T} = UnitRange{T}(r)
 AbstractUnitRange{T}(r::OneTo) where {T} = OneTo{T}(r)
 
 OrdinalRange{T1, T2}(r::StepRange) where {T1, T2<: Integer} = StepRange{T1, T2}(r)
-OrdinalRange{T1, T2}(r::AbstractUnitRange{T1}) where {T1, T2<:Integer} = r
-OrdinalRange{T1, T2}(r::UnitRange) where {T1, T2<:Integer} = UnitRange{T1}(r)
-OrdinalRange{T1, T2}(r::OneTo) where {T1, T2<:Integer} = OneTo{T1}(r)
+OrdinalRange{T, T}(r::AbstractUnitRange) where {T<:Integer} = AbstractUnitRange{T}(r)
 
 function promote_rule(::Type{StepRange{T1a,T1b}}, ::Type{StepRange{T2a,T2b}}) where {T1a,T1b,T2a,T2b}
     Tb = promote_type(T1b, T2b)

--- a/base/range.jl
+++ b/base/range.jl
@@ -1252,7 +1252,7 @@ AbstractUnitRange{T}(r::AbstractUnitRange{T}) where {T} = r
 AbstractUnitRange{T}(r::UnitRange) where {T} = UnitRange{T}(r)
 AbstractUnitRange{T}(r::OneTo) where {T} = OneTo{T}(r)
 
-OrdinalRange{T,S}(r::AbstractUnitRange) where {T, S} = StepRange{T,S}(r)
+OrdinalRange{T, S}(r::OrdinalRange) where {T, S} = StepRange{T, S}(r)
 OrdinalRange{T, T}(r::AbstractUnitRange) where {T} = AbstractUnitRange{T}(r)
 
 function promote_rule(::Type{StepRange{T1a,T1b}}, ::Type{StepRange{T2a,T2b}}) where {T1a,T1b,T2a,T2b}

--- a/base/range.jl
+++ b/base/range.jl
@@ -1252,7 +1252,7 @@ AbstractUnitRange{T}(r::AbstractUnitRange{T}) where {T} = r
 AbstractUnitRange{T}(r::UnitRange) where {T} = UnitRange{T}(r)
 AbstractUnitRange{T}(r::OneTo) where {T} = OneTo{T}(r)
 
-OrdinalRange{T1, T2}(r::StepRange) where {T1, T2<: Integer} = StepRange{T1, T2}(r)
+OrdinalRange{T,S}(r::AbstractUnitRange) where {T, S} = StepRange{T,S}(r)
 OrdinalRange{T, T}(r::AbstractUnitRange) where {T} = AbstractUnitRange{T}(r)
 
 function promote_rule(::Type{StepRange{T1a,T1b}}, ::Type{StepRange{T2a,T2b}}) where {T1a,T1b,T2a,T2b}

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -788,7 +788,7 @@ end
     end
 end
 
-@testset "proper patition for non-1-indexed vector" begin
+@testset "proper partition for non-1-indexed vector" begin
     @test Iterators.partition(OffsetArray(1:10,10), 5) |> collect == [1:5,6:10] # OffsetVector
     @test Iterators.partition(OffsetArray(collect(1:10),10), 5) |> collect == [1:5,6:10] # OffsetVector
     @test Iterators.partition(OffsetArray(reshape(1:9,3,3), (3,3)), 5) |> collect == [1:5,6:9] #OffsetMatrix
@@ -821,4 +821,13 @@ end
     @test (@view x[y[begin], end])[] == 2
     @test (@view x[end, -y[end]])[] == 3
     @test (@view x[y[end], end])[] == 4
+end
+
+@testset "CartesianIndices (issue #40035)" begin
+    A = OffsetArray(big(1):big(2), 0);
+    B = OffsetArray(1:2, 0);
+    # axes of an OffsetArray may be converted to an AbstractUnitRange,
+    # but the conversion to an OrdinalRange was not defined.
+    # this is fixed in #40038, so the evaluation of its CartesianIndices should work
+    @test CartesianIndices(A) == CartesianIndices(B)
 end

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -44,6 +44,9 @@ function IdOffsetRange{T}(r::IdOffsetRange) where T<:Integer
 end
 IdOffsetRange(r::IdOffsetRange) = r
 
+AbstractUnitRange{T}(r::IdOffsetRange{T}) where {T} = r
+AbstractUnitRange{T}(r::IdOffsetRange) where {T} = IdOffsetRange{T}(r)
+
 # TODO: uncomment these when Julia is ready
 # # Conversion preserves both the values and the indexes, throwing an InexactError if this
 # # is not possible.


### PR DESCRIPTION
Fixes #40035

Now
```julia
julia> A = OffsetArray(big(1):big(2), 0);

julia> CartesianIndices(A)
2-element CartesianIndices{1, Tuple{Main.OffsetArrays.IdOffsetRange{Int64, Base.OneTo{Int64}}}} with indices 1:2:
 CartesianIndex(1,)
 CartesianIndex(2,)
```