### PR TITLE
Allow startup despite `p7zip` not being found

### DIFF
--- a/stdlib/p7zip_jll/src/p7zip_jll.jl
+++ b/stdlib/p7zip_jll/src/p7zip_jll.jl
@@ -77,7 +77,7 @@ function init_p7zip_path()
             return
         end
     end
-    global p7zip_path = Sys.which(p7zip_exe)
+    global p7zip_path = something(Sys.which(p7zip_exe), p7zip_exe)
 end
 
 function __init__()


### PR DESCRIPTION
Without this, a failure to find a usable `p7zip` will cause an error at
startup.  With this, we will at least attempt to invoke `p7zip` and fail
at runtime, instead of failing at init time.