### PR TITLE
[release-1.6] Prevent PCRE from needing a rebuild/reconf.

### DIFF
--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -14,9 +14,9 @@ $(SRCCACHE)/pcre2-$(PCRE_VER)/source-extracted: $(SRCCACHE)/pcre2-$(PCRE_VER).ta
 	cp $(SRCDIR)/patches/config.sub $(SRCCACHE)/pcre2-$(PCRE_VER)/config.sub
 	cd $(SRCCACHE)/pcre2-$(PCRE_VER) && patch -p1 -f < $(SRCDIR)/patches/pcre2-cet-flags.patch
 	# Fix some old targets modified by the patching
+	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/aclocal.m4
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/Makefile.am
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/Makefile.in
-	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/aclocal.m4
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/configure
 	echo $1 > $@
 


### PR DESCRIPTION
```
This commit reorders a couple touches in deps/pcre.mkl. Those touches are
intended to prevent patch application from triggering rebuild/reconf.
The present ordering doesn't quite succeed in that objective; patch
application triggers rebuild. On systems with compatible autotools,
the rebuild succeeds and the build is nonetheless happy. On systems
with incompatible versions of autotools, however, the build fails for
need of a reconf. The reordering in this commit prevents the rebuild.

Co-Authored-By: Rob Vermaas <rob.vermaas@gmail.com>
```
Applies only to `release-1.6`; the relevant patches and touches are gone on `master` :).

@KristofferC, let me know if I should target some other branch :).

cc @rbvermaa