### PR TITLE
build: avoid gtar race bug when managing Tar.jl files

### DIFF
--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -47,7 +47,12 @@ UNINSTALL_$(strip $1) := $$($(2)_JLL_BASENAME:.tar.gz=) bb-uninstaller
 $$(build_prefix)/manifest/$(strip $1): $$(SRCCACHE)/$$($(2)_JLL_BASENAME) | $(build_prefix)/manifest
 	-+[ ! -e $$@ ] || $$(MAKE) uninstall-$(strip $1)
 	$$(JLCHECKSUM) $$<
-	mkdir -p $$(build_prefix)
+ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))
+	@# work-around a gtar bug: they do some complicated work to avoid the mkdir
+	@# syscall, which is buggy when working with Tar.jl files so we manually do
+	@# the mkdir calls first in a pre-pass
+	$(TAR) -tzf $$< | xargs -L 1 dirname | sort -u | (cd $$(build_prefix) && xargs -t mkdir -p)
+endif
 	$(UNTAR) $$< -C $$(build_prefix)
 	echo '$$(UNINSTALL_$(strip $1))' > $$@
 

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -174,7 +174,6 @@ UNINSTALL_$(strip $1) := $2 staged-uninstaller
 
 $$(build_prefix)/manifest/$(strip $1): $$(build_staging)/$2.tgz | $(build_prefix)/manifest
 	-+[ ! -e $$@ ] || $$(MAKE) uninstall-$(strip $1)
-	mkdir -p $$(build_prefix)
 	$(UNTAR) $$< -C $$(build_prefix)
 	$6
 	echo '$$(UNINSTALL_$(strip $1))' > $$@


### PR DESCRIPTION
Tar.jl omits the directory entry, but gtar has a race-condition where it
gets the error code wrong when run in parallel when that is missing,
resulting in failed builds. Probably it was a premature performance
optimization. Fix that by running gtar twice.

Fixes: https://build.julialang.org/#/builders/34/builds/1570/steps/3/logs/stdio