### PR TITLE
Revert "add 'ᵀ postfix operator for transpose (#38062)"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -113,7 +113,6 @@ New library features
   inserting or consuming the first dimension depending on the ratio of `sizeof(T)` and `sizeof(S)`.
 * New `append!(vector, collections...)` and `prepend!(vector, collections...)` methods accept multiple
   collections to be appended or prepended ([#36227]).
-* The postfix operator `'ᵀ` can now be used as an alias for `transpose` ([#38062]).
 * `keys(io::IO)` has been added, which returns all keys of `io` if `io` is an `IOContext` and an empty
   `Base.KeySet` otherwise ([#37753]).
 * `count` now accepts an optional `init` argument to control the accumulation type ([#37461]).

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -467,7 +467,6 @@ export
 # linear algebra
     var"'", # to enable syntax a' for adjoint
     adjoint,
-    var"'ᵀ",
     transpose,
     kron,
     kron!,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -624,7 +624,6 @@ end
 function kron! end
 
 const var"'" = adjoint
-const var"'ᵀ" = transpose
 
 """
     \\(x, y)

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -136,7 +136,6 @@ julia> x'x
 adjoint(A::AbstractVecOrMat) = Adjoint(A)
 
 """
-    A'ᵀ
     transpose(A)
 
 Lazy transpose. Mutating the returned object should appropriately mutate `A`. Often,
@@ -145,9 +144,6 @@ that this operation is recursive.
 
 This operation is intended for linear algebra usage - for general data manipulation see
 [`permutedims`](@ref Base.permutedims), which is non-recursive.
-
-!!! compat "Julia 1.6"
-    The postfix operator `'ᵀ` requires Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -160,14 +156,6 @@ julia> transpose(A)
 2×2 transpose(::Matrix{Complex{Int64}}) with eltype Complex{Int64}:
  3+2im  8+7im
  9+2im  4+6im
-
-julia> x = [3, 4im]
-2-element Vector{Complex{Int64}}:
- 3 + 0im
- 0 + 4im
-
-julia> x'ᵀx
--7 + 0im
 ```
 """
 transpose(A::AbstractVecOrMat) = Transpose(A)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -280,7 +280,4 @@ end
     @test ∋(0)(-2:2)
 end
 
-a = rand(3, 3)
-@test transpose(a) === a'ᵀ
-
 @test [Base.afoldl(+, 1:i...) for i = 1:40] == [i * (i + 1) ÷ 2 for i = 1:40]


### PR DESCRIPTION
This reverts commit 665279aedb18501938c934d46aa593a26a506b3e.

There has been some discussion about whether https://github.com/JuliaLang/julia/pull/38062 was such a good idea in hindsight (https://github.com/JuliaLang/julia/issues/40070, https://github.com/JuliaLang/julia/pull/38062#issuecomment-774963899). It might make sense to go back on this feature to give us some more time to think about it, before locking it in into 1.6.

Fixes https://github.com/JuliaLang/julia/issues/40070