### PR TITLE
remove unclear docs for pure macro

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -230,12 +230,6 @@ end
 `@pure` gives the compiler a hint for the definition of a pure function,
 helping for type inference.
 
-A pure function can only depend on immutable information.
-This also means a `@pure` function cannot use any global mutable state, including
-generic functions. Calls to generic functions depend on method tables which are
-mutable global state.
-Use with caution, incorrect `@pure` annotation of a function may introduce
-hard to identify bugs. Double check for calls to generic functions.
 This macro is intended for internal compiler use and may be subject to changes.
 """
 macro pure(ex)


### PR DESCRIPTION
It is unclear where this information actually comes from and it is clearly wrong since the usages in Base doesn't adhere to them. Just remove it.