### PR TITLE
fix #40050, handling fields that are pointers due to subtype circularity

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -608,7 +608,10 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, jl_
             size_t fsz = 0, al = 0;
             bool isptr = !jl_islayout_inline(ty, &fsz, &al);
             if (jst->layout) {
-                assert(isptr == jl_field_isptr(jst, i));
+                // NOTE: jl_field_isptr can disagree with jl_islayout_inline here if the
+                // struct decided this field must be a pointer due to a type circularity.
+                // Example from issue #40050: `struct B <: Ref{Tuple{B}}; end`
+                isptr = jl_field_isptr(jst, i);
                 assert((isptr ? sizeof(void*) : fsz + jl_is_uniontype(ty)) == jl_field_size(jst, i));
             }
             Type *lty;

--- a/test/core.jl
+++ b/test/core.jl
@@ -7227,6 +7227,11 @@ end
 @test_broken isbitstype(Tuple{B33954})
 @test_broken isbitstype(B33954)
 
+struct B40050 <: Ref{Tuple{B40050}}
+end
+@test string((B40050(),)) == "($B40050(),)"
+@test_broken isbitstype(Tuple{B40050})
+
 # Issue #34206/34207
 function mre34206(a, n)
     va = view(a, :)


### PR DESCRIPTION
Hopefully this works as kind of a quick fix. It would be nice to do better, maybe by computing layouts more lazily, but that would be more involved.

fix #40050
