### PR TITLE
Remove unnecessary pure annotations

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -145,7 +145,7 @@ include("abstractarraymath.jl")
 include("arraymath.jl")
 
 # SIMD loops
-@pure sizeof(s::String) = Core.sizeof(s)  # needed by gensym as called from simdloop
+sizeof(s::String) = Core.sizeof(s)  # needed by gensym as called from simdloop
 include("simdloop.jl")
 using .SimdLoop
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -95,7 +95,7 @@ String(s::CodeUnits{UInt8,String}) = s.s
 pointer(s::String) = unsafe_convert(Ptr{UInt8}, s)
 pointer(s::String, i::Integer) = pointer(s) + Int(i)::Int - 1
 
-@pure ncodeunits(s::String) = Core.sizeof(s)
+ncodeunits(s::String) = Core.sizeof(s)
 codeunit(s::String) = UInt8
 
 @inline function codeunit(s::String, i::Integer)


### PR DESCRIPTION
These should now be unnecessary. Our effect modeling of Core.sizeof
has improved sufficiently, that it should be able to know right away
that these functions are pure without the additional annotation.