### PR TITLE
Always use bundled getopt_long implementation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -85,7 +85,7 @@ endif
 
 RT_LLVM_LIBS := support
 
-SRCS += getopt
+SRCS += getopt getopt_long
 
 SRCS += $(RUNTIME_SRCS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -85,6 +85,8 @@ endif
 
 RT_LLVM_LIBS := support
 
+SRCS += getopt
+
 SRCS += $(RUNTIME_SRCS)
 
 CODEGEN_SRCS += $(RUNTIME_CODEGEN_SRCS)

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -72,7 +72,7 @@ int getopt(int argc, char * const argv[], const char *optstring)
 
   if (d != c) {
     if (optstring[0] != ':' && opterr) {
-      fprintf(stderr, "%s: illegal option: %c\n", argv[0], optchar);
+      fprintf(stderr, "%s: illegal option: %c\n", argv[0], *optchar);
     }
     return '?';
   }
@@ -80,7 +80,7 @@ int getopt(int argc, char * const argv[], const char *optstring)
     if (optind >= argc) {
       if (optstring[0] == ':') return ':';
       if (opterr) {
-        fprintf(stderr, "%s: option requires an argument: %c\n", argv[0], optchar);
+        fprintf(stderr, "%s: option requires an argument: %c\n", argv[0], *optchar);
       }
       return '?';
     }

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -4,25 +4,24 @@
 #include <string.h>
 #include <limits.h>
 #include <stdlib.h>
-#include "locale_impl.h"
-#include "stdio_impl.h"
+#include "getopt.h"
 
 char *optarg;
 int optind=1, opterr=1, optopt, __optpos, __optreset=0;
 
 #define optpos __optpos
-weak_alias(__optreset, optreset);
+// weak_alias(__optreset, optreset);
 
 void __getopt_msg(const char *a, const char *b, const char *c, size_t l)
 {
 	FILE *f = stderr;
-	b = __lctrans_cur(b);
-	FLOCK(f);
+// 	b = __lctrans_cur(b);
+// 	FLOCK(f);
 	fputs(a, f)>=0
-	&& fwrite(b, strlen(b), 1, f)
+// 	&& fwrite(b, strlen(b), 1, f)
 	&& fwrite(c, 1, l, f)==l
 	&& putc('\n', f);
-	FUNLOCK(f);
+// 	FUNLOCK(f);
 }
 
 int getopt(int argc, char * const argv[], const char *optstring)
@@ -102,4 +101,4 @@ int getopt(int argc, char * const argv[], const char *optstring)
 	return c;
 }
 
-weak_alias(getopt, __posix_getopt);
+// weak_alias(getopt, __posix_getopt);

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -1,147 +1,105 @@
-/* This file is adapted from musl-libc
-----------------------------------------------------------------------
-Copyright © 2005-2014 Rich Felker, et al.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-----------------------------------------------------------------------
-*/
-
+#define _BSD_SOURCE
+#include <unistd.h>
 #include <wchar.h>
 #include <string.h>
 #include <limits.h>
 #include <stdlib.h>
-#include <stdio.h>
-#include <stddef.h>
-#include "getopt.h"
+#include "locale_impl.h"
+#include "stdio_impl.h"
 
 char *optarg;
 int optind=1, opterr=1, optopt, __optpos, __optreset=0;
 
 #define optpos __optpos
+weak_alias(__optreset, optreset);
+
+void __getopt_msg(const char *a, const char *b, const char *c, size_t l)
+{
+	FILE *f = stderr;
+	b = __lctrans_cur(b);
+	FLOCK(f);
+	fputs(a, f)>=0
+	&& fwrite(b, strlen(b), 1, f)
+	&& fwrite(c, 1, l, f)==l
+	&& putc('\n', f);
+	FUNLOCK(f);
+}
 
 int getopt(int argc, char * const argv[], const char *optstring)
 {
-  int i;
-  wchar_t c, d;
-  int k, l;
-  char *optchar;
+	int i;
+	wchar_t c, d;
+	int k, l;
+	char *optchar;
 
-  if (!optind || __optreset) {
-    __optreset = 0;
-    __optpos = 0;
-    optind = 1;
-  }
+	if (!optind || __optreset) {
+		__optreset = 0;
+		__optpos = 0;
+		optind = 1;
+	}
 
-  if (optind >= argc || !argv[optind] || argv[optind][0] != '-' || !argv[optind][1])
-    return -1;
-  if (argv[optind][1] == '-' && !argv[optind][2])
-    return optind++, -1;
+	if (optind >= argc || !argv[optind])
+		return -1;
 
-  if (!optpos) optpos++;
-  if ((k = mbtowc(&c, argv[optind]+optpos, MB_LEN_MAX)) < 0) {
-    k = 1;
-    c = 0xfffd; /* replacement char */
-  }
-  optchar = argv[optind]+optpos;
-  optopt = c;
-  optpos += k;
+	if (argv[optind][0] != '-') {
+		if (optstring[0] == '-') {
+			optarg = argv[optind++];
+			return 1;
+		}
+		return -1;
+	}
 
-  if (!argv[optind][optpos]) {
-    optind++;
-    optpos = 0;
-  }
+	if (!argv[optind][1])
+		return -1;
 
-  for (i=0; (l = mbtowc(&d, optstring+i, MB_LEN_MAX)) && d!=c; i+=l>0?l:1);
+	if (argv[optind][1] == '-' && !argv[optind][2])
+		return optind++, -1;
 
-  if (d != c) {
-    if (optstring[0] != ':' && opterr) {
-      fprintf(stderr, "%s: illegal option: %c\n", argv[0], *optchar);
-    }
-    return '?';
-  }
-  if (optstring[i+1] == ':') {
-    if (optind >= argc) {
-      if (optstring[0] == ':') return ':';
-      if (opterr) {
-        fprintf(stderr, "%s: option requires an argument: %c\n", argv[0], *optchar);
-      }
-      return '?';
-    }
-    if (optstring[i+2] == ':') optarg = 0;
-    if (optstring[i+2] != ':' || optpos) {
-      optarg = argv[optind++] + optpos;
-      optpos = 0;
-    }
-  }
-  return c;
+	if (!optpos) optpos++;
+	if ((k = mbtowc(&c, argv[optind]+optpos, MB_LEN_MAX)) < 0) {
+		k = 1;
+		c = 0xfffd; /* replacement char */
+	}
+	optchar = argv[optind]+optpos;
+	optpos += k;
+
+	if (!argv[optind][optpos]) {
+		optind++;
+		optpos = 0;
+	}
+
+	if (optstring[0] == '-' || optstring[0] == '+')
+		optstring++;
+
+	i = 0;
+	d = 0;
+	do {
+		l = mbtowc(&d, optstring+i, MB_LEN_MAX);
+		if (l>0) i+=l; else i++;
+	} while (l && d != c);
+
+	if (d != c || c == ':') {
+		optopt = c;
+		if (optstring[0] != ':' && opterr)
+			__getopt_msg(argv[0], ": unrecognized option: ", optchar, k);
+		return '?';
+	}
+	if (optstring[i] == ':') {
+		optarg = 0;
+		if (optstring[i+1] != ':' || optpos) {
+			optarg = argv[optind++] + optpos;
+			optpos = 0;
+		}
+		if (optind > argc) {
+			optopt = c;
+			if (optstring[0] == ':') return ':';
+			if (opterr) __getopt_msg(argv[0],
+				": option requires an argument: ",
+				optchar, k);
+			return '?';
+		}
+	}
+	return c;
 }
 
-static int __getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
-{
-  if (!optind || __optreset) {
-    __optreset = 0;
-    __optpos = 0;
-    optind = 1;
-  }
-  if (optind >= argc || !argv[optind] || argv[optind][0] != '-') return -1;
-  if ((longonly && argv[optind][1]) ||
-    (argv[optind][1] == '-' && argv[optind][2]))
-  {
-    int i;
-    for (i=0; longopts[i].name; i++) {
-      const char *name = longopts[i].name;
-      char *opt = argv[optind]+1;
-      if (*opt == '-') opt++;
-      for (; *name && *name == *opt; name++, opt++);
-      if (*name || (*opt && *opt != '=')) continue;
-      if (*opt == '=') {
-        if (!longopts[i].has_arg) continue;
-        optarg = opt+1;
-      } else {
-        if (longopts[i].has_arg == required_argument) {
-          if (!(optarg = argv[++optind]))
-            return ':';
-        } else optarg = NULL;
-      }
-      optind++;
-      if (idx) *idx = i;
-      if (longopts[i].flag) {
-        *longopts[i].flag = longopts[i].val;
-        return 0;
-      }
-      return longopts[i].val;
-    }
-    if (argv[optind][1] == '-') {
-      optind++;
-      return '?';
-    }
-  }
-  return getopt(argc, argv, optstring);
-}
-
-int getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
-{
-  return __getopt_long(argc, argv, optstring, longopts, idx, 0);
-}
-
-int getopt_long_only(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
-{
-  return __getopt_long(argc, argv, optstring, longopts, idx, 1);
-}
+weak_alias(getopt, __posix_getopt);

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -30,6 +30,16 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 extern "C" {
 #endif
 
+// rename exported symbols to avoid clash with the corresponding symbols
+// in the C library.
+#define getopt              jl_getopt
+#define optarg              jl_optarg
+#define optind              jl_optind
+#define opterr              jl_opterr
+#define option              jl_option
+#define getopt_long         jl_getopt_long
+#define getopt_long_only    jl_getopt_long_only
+
 int getopt(int, char * const [], const char *);
 extern char *optarg;
 extern int optind, opterr, optopt;

--- a/src/getopt_long.c
+++ b/src/getopt_long.c
@@ -1,0 +1,148 @@
+#define _GNU_SOURCE
+#include <stddef.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <string.h>
+#include "stdio_impl.h"
+
+extern int __optpos, __optreset;
+
+static void permute(char *const *argv, int dest, int src)
+{
+	char **av = (char **)argv;
+	char *tmp = av[src];
+	int i;
+	for (i=src; i>dest; i--)
+		av[i] = av[i-1];
+	av[dest] = tmp;
+}
+
+static int __getopt_long_core(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly);
+
+static int __getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
+{
+	int ret, skipped, resumed;
+	if (!optind || __optreset) {
+		__optreset = 0;
+		__optpos = 0;
+		optind = 1;
+	}
+	if (optind >= argc || !argv[optind]) return -1;
+	skipped = optind;
+	if (optstring[0] != '+' && optstring[0] != '-') {
+		int i;
+		for (i=optind; ; i++) {
+			if (i >= argc || !argv[i]) return -1;
+			if (argv[i][0] == '-' && argv[i][1]) break;
+		}
+		optind = i;
+	}
+	resumed = optind;
+	ret = __getopt_long_core(argc, argv, optstring, longopts, idx, longonly);
+	if (resumed > skipped) {
+		int i, cnt = optind-resumed;
+		for (i=0; i<cnt; i++)
+			permute(argv, skipped, optind-1);
+		optind = skipped + cnt;
+	}
+	return ret;
+}
+
+static int __getopt_long_core(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
+{
+	optarg = 0;
+	if (longopts && argv[optind][0] == '-' &&
+		((longonly && argv[optind][1] && argv[optind][1] != '-') ||
+		 (argv[optind][1] == '-' && argv[optind][2])))
+	{
+		int colon = optstring[optstring[0]=='+'||optstring[0]=='-']==':';
+		int i, cnt, match;
+		char *arg, *opt, *start = argv[optind]+1;
+		for (cnt=i=0; longopts[i].name; i++) {
+			const char *name = longopts[i].name;
+			opt = start;
+			if (*opt == '-') opt++;
+			while (*opt && *opt != '=' && *opt == *name)
+				name++, opt++;
+			if (*opt && *opt != '=') continue;
+			arg = opt;
+			match = i;
+			if (!*name) {
+				cnt = 1;
+				break;
+			}
+			cnt++;
+		}
+		if (cnt==1 && longonly && arg-start == mblen(start, MB_LEN_MAX)) {
+			int l = arg-start;
+			for (i=0; optstring[i]; i++) {
+				int j;
+				for (j=0; j<l && start[j]==optstring[i+j]; j++);
+				if (j==l) {
+					cnt++;
+					break;
+				}
+			}
+		}
+		if (cnt==1) {
+			i = match;
+			opt = arg;
+			optind++;
+			if (*opt == '=') {
+				if (!longopts[i].has_arg) {
+					optopt = longopts[i].val;
+					if (colon || !opterr)
+						return '?';
+					__getopt_msg(argv[0],
+						": option does not take an argument: ",
+						longopts[i].name,
+						strlen(longopts[i].name));
+					return '?';
+				}
+				optarg = opt+1;
+			} else if (longopts[i].has_arg == required_argument) {
+				if (!(optarg = argv[optind])) {
+					optopt = longopts[i].val;
+					if (colon) return ':';
+					if (!opterr) return '?';
+					__getopt_msg(argv[0],
+						": option requires an argument: ",
+						longopts[i].name,
+						strlen(longopts[i].name));
+					return '?';
+				}
+				optind++;
+			}
+			if (idx) *idx = i;
+			if (longopts[i].flag) {
+				*longopts[i].flag = longopts[i].val;
+				return 0;
+			}
+			return longopts[i].val;
+		}
+		if (argv[optind][1] == '-') {
+			optopt = 0;
+			if (!colon && opterr)
+				__getopt_msg(argv[0], cnt ?
+					": option is ambiguous: " :
+					": unrecognized option: ",
+					argv[optind]+2,
+					strlen(argv[optind]+2));
+			optind++;
+			return '?';
+		}
+	}
+	return getopt(argc, argv, optstring);
+}
+
+int getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
+{
+	return __getopt_long(argc, argv, optstring, longopts, idx, 0);
+}
+
+int getopt_long_only(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
+{
+	return __getopt_long(argc, argv, optstring, longopts, idx, 1);
+}

--- a/src/getopt_long.c
+++ b/src/getopt_long.c
@@ -2,10 +2,9 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <getopt.h>
 #include <stdio.h>
 #include <string.h>
-#include "stdio_impl.h"
+#include "getopt.h"
 
 extern int __optpos, __optreset;
 

--- a/src/init.c
+++ b/src/init.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 
 #if !defined(_OS_WINDOWS_) || defined(_COMPILER_GCC_)
-#include <getopt.h>
+#include "getopt.h"
 #endif
 
 #if defined(_OS_FREEBSD_)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -5,12 +5,7 @@
 
 #include "julia.h"
 
-#ifndef _MSC_VER
-#include <unistd.h>
-#include <getopt.h>
-#else
 #include "getopt.h"
-#endif
 #include "julia_assert.h"
 
 #ifdef _OS_WINDOWS_


### PR DESCRIPTION
... not just when building with MSVC. This ensures that command line
arguments are processed uniformly on all platforms. It also gives us
full control over how it behaves.

Resolves #29669, that is, typos like `julia --projec=t.` (note how `=` and `t` are swapped) won't be silently accepted anymore.

The code is a bit hacky; I could rewrite it to get rid of the `#define` hack. On the other hand, it keeps the diff minimal and would make it very easy to revert this in the future again.