### PR TITLE
more conservative name demangling in stacktraces

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2200,14 +2200,8 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
 end
 
 demangle_function_name(name::Symbol) = Symbol(demangle_function_name(string(name)))
-function demangle_function_name(name::AbstractString)
-    demangle = split(name, '#')
-    # kw sorters and impl methods use the name scheme `f#...`
-    if length(demangle) >= 2 && demangle[1] != ""
-        return demangle[1]
-    end
-    return name
-end
+# kw sorters and impl methods use the name scheme `f#...`
+demangle_function_name(name::AbstractString) = replace(name, r"^(.+?)#[\d#]+$" => s"\1")
 
 # show the called object in a signature, given its type `ft`
 # `io` should contain the UnionAll env of the signature


### PR DESCRIPTION
The motivation being here that I want to put whole method signatures into LineInfoNodes in inlined overdubs for better stacktraces, but currently those sometimes get cut off. This seems like a more accurate check here.