### PR TITLE
Add kakoune editor support

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -119,7 +119,7 @@ function define_default_editors()
     end
     # Must check that emacs not running in -t/-nw before regex match for general emacs
     define_editor(Any[
-        "vim", "vi", "nvim", "mvim", "nano", "micro",
+        "vim", "vi", "nvim", "mvim", "nano", "micro", "kak",
         r"\bemacs\b.*\s(-nw|--no-window-system)\b",
         r"\bemacsclient\b.\s*-(-?nw|t|-?tty)\b",
     ], wait=true) do cmd, path, line

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -62,6 +62,8 @@ already work:
 - vim
 - nvim
 - nano
+- micro
+- kak
 - textmate
 - mate
 - kate


### PR DESCRIPTION
I'm really excited to have found Julia. Over the past month it's let me do so much cool stuff.

This PR adds out-of-the-box support for using [Kakoune](https://kakoune.org/) with the `@edit` macro by listing it alongside `vim` as needing `wait=true`.

Before:
```
julia> @edit length("123")
Fatal error: stdout is not a tty
```

After:
```
julia> @edit length("123")
*kakoune works as intended*
```
