### PR TITLE
Support ::typeof(f) in method signature for nested closures

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -242,6 +242,9 @@ ccall(:jl_toplevel_eval_in, Any, (Any, Any),
       (f::typeof(Typeof))(x) = ($(_expr(:meta,:nospecialize,:x)); isa(x,Type) ? Type{x} : typeof(x))
       end)
 
+macro Typeof(x)
+    _expr(:Typeof, _expr(:escape, x))
+end
 
 macro nospecialize(x)
     _expr(:meta, :nospecialize, x)

--- a/test/core.jl
+++ b/test/core.jl
@@ -489,6 +489,15 @@ end
 @test f19333(0) == 7
 @test x19333 == 5
 
+@test @Core.Typeof(42) == Int
+@test @Core.Typeof(Int) == Type{Int}
+function two_nested_closures()
+    f() = 3
+    g(::@Core.Typeof(f)) = 4
+    return g(f)
+end
+@test two_nested_closures() == 4
+
 function h19333()
     s = 0
     for (i, j) in ((1, 2),)


### PR DESCRIPTION
This is a naive attempt at fixing #40129. In particular it does not support cases where `f` actually captures any variables: in that case the `('new ...)` expression yields `ERROR: invalid struct allocation` because we don't pass initialization parameters.