### PR TITLE
mention use of underscore for private fields in manual

### DIFF
--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -141,7 +141,8 @@ uses (e.g. `a[i]::Int`) than to try to pack many alternatives into one type.
     words squashed together ([`isequal`](@ref), [`haskey`](@ref)). When necessary, use underscores
     as word separators. Underscores are also used to indicate a combination of concepts ([`remotecall_fetch`](@ref)
     as a more efficient implementation of `fetch(remotecall(...))`) or as modifiers.
-  * functions mutating at least one of their arguments end in `!`. Use identifiers starting with `_` to
+  * functions mutating at least one of their arguments end in `!`.
+  * use identifiers starting with `_` to
     denote functions, macros or variables that should be considered private and not part of a package's
     public API.
   * conciseness is valued, but avoid abbreviation ([`indexin`](@ref) rather than `indxin`) as

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -141,6 +141,9 @@ uses (e.g. `a[i]::Int`) than to try to pack many alternatives into one type.
     words squashed together ([`isequal`](@ref), [`haskey`](@ref)). When necessary, use underscores
     as word separators. Underscores are also used to indicate a combination of concepts ([`remotecall_fetch`](@ref)
     as a more efficient implementation of `fetch(remotecall(...))`) or as modifiers.
+  * functions mutating at least one of their arguments end in `!`. Use identifiers starting with `_` to
+    denote functions, macros or variables that should be considered private and not part of a package's
+    public API.
   * conciseness is valued, but avoid abbreviation ([`indexin`](@ref) rather than `indxin`) as
     it becomes difficult to remember whether and how particular words are abbreviated.
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -141,7 +141,7 @@ conventions:
   * Functions that write to their arguments have names that end in `!`. These are sometimes called
     "mutating" or "in-place" functions because they are intended to produce changes in their arguments
     after the function is called, not just return a value.
-  * Names staring with an underscore denote functions, macros or variables that are only used internally
+  * Names starting with an underscore denote functions, macros or variables that are only used internally
     by a package and are not part of its public API.
 
 For more information about stylistic conventions, see the [Style Guide](@ref).

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -141,5 +141,7 @@ conventions:
   * Functions that write to their arguments have names that end in `!`. These are sometimes called
     "mutating" or "in-place" functions because they are intended to produce changes in their arguments
     after the function is called, not just return a value.
+  * Names staring with an underscore denote functions, macros or variables that are only used internally
+    by a package and are not part of its public API.
 
 For more information about stylistic conventions, see the [Style Guide](@ref).


### PR DESCRIPTION
I wasn't sure whether this should be mentioned both in the Variables section and in the style guide. I also noticed the `!` convention was not mentioned in the style guide, so I added that as well, but I can remove that part if this is not the right place.

Ref #40127 