### PR TITLE
shared_map map_size_inc check fsize limit

### DIFF
--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -10,6 +10,7 @@
 #ifdef _OS_LINUX_
 #  include <sys/syscall.h>
 #  include <sys/utsname.h>
+#  include <sys/resource.h>
 #endif
 #ifndef _OS_WINDOWS_
 #  include <sys/mman.h>
@@ -206,9 +207,23 @@ static intptr_t get_anon_hdl(void)
 static size_t map_offset = 0;
 // Multiple of 128MB.
 // Hopefully no one will set a ulimit for this to be a problem...
-static constexpr size_t map_size_inc = 128 * 1024 * 1024;
+static constexpr size_t map_size_inc_default = 128 * 1024 * 1024;
 static size_t map_size = 0;
 static jl_mutex_t shared_map_lock;
+
+static size_t get_map_size_inc()
+{
+    rlimit rl;
+    if (getrlimit(RLIMIT_FSIZE, &rl) != -1) {
+        if (rl.rlim_cur != RLIM_INFINITY) {
+            return std::min<size_t>(map_size_inc_default, rl.rlim_cur);
+        }
+        if (rl.rlim_max != RLIM_INFINITY) {
+            return std::min<size_t>(map_size_inc_default, rl.rlim_max);
+        }
+    }
+    return map_size_inc_default;
+}
 
 static void *create_shared_map(size_t size, size_t id)
 {
@@ -224,7 +239,7 @@ static intptr_t init_shared_map()
     if (anon_hdl == -1)
         return -1;
     map_offset = 0;
-    map_size = map_size_inc;
+    map_size = get_map_size_inc();
     int ret = ftruncate(anon_hdl, map_size);
     if (ret != 0) {
         perror(__func__);
@@ -238,6 +253,7 @@ static void *alloc_shared_page(size_t size, size_t *id, bool exec)
     assert(size % jl_page_size == 0);
     size_t off = jl_atomic_fetch_add(&map_offset, size);
     *id = off;
+    size_t map_size_inc = get_map_size_inc();
     if (__unlikely(off + size > map_size)) {
         JL_LOCK_NOGC(&shared_map_lock);
         size_t old_size = map_size;

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -23,6 +23,7 @@
 #endif
 #ifdef _OS_FREEBSD_
 #  include <sys/types.h>
+#  include <sys/resource.h>
 #endif
 #include "julia_assert.h"
 


### PR DESCRIPTION
Fixed 128MB ftruncate of shared_map failing under file size limit.