### PR TITLE
Fix real matrix sqrt and log for edge cases

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2443,8 +2443,7 @@ Base.@propagate_inbounds function _sqrt_real_2x2!(R, A)
     θ, a21, a12 = A[1, 1], A[2, 1], A[1, 2]
     # avoid overflow/underflow of μ
     # for real sqrt, |d| ≤ 2 max(|a12|,|a21|)
-    μₛ = max(abs(a12), abs(a21))
-    μ = sqrt(-(a21 / μₛ) * (a12 / μₛ)) * μₛ
+    μ = sqrt(abs(a12)) * sqrt(abs(a21))
     α = _real_sqrt(θ, μ)
     c = 2α
     R[1, 1] = α

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2442,7 +2442,10 @@ Base.@propagate_inbounds function _sqrt_real_2x2!(R, A)
     a11, a21, a12, a22 = A[1, 1], A[2, 1], A[1, 2], A[2, 2]
     d = a11 - a22
     θ = (a11 + a22) / 2
-    μ = sqrt(-d^2 - 4 * a21 * a12) / 2
+    # avoid overflow/underflow of μ
+    # for real sqrt, |d| ≤ 2 max(|a12|,|a21|)
+    μₛ = max(abs(a12), abs(a21))
+    μ = μₛ * sqrt(-(d / μₛ)^2 - 4 * (a21 / μₛ) * (a12 / μₛ)) / 2
     α = _real_sqrt(θ, μ)
     c = 2α
     f = d / 4α

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2446,11 +2446,11 @@ Base.@propagate_inbounds function _sqrt_real_2x2!(R, A)
         α = μ / sqrt(2 * (sqrt(θ^2 + μ²) - θ))
     end
     c = 2α
-    d = α - θ / c
-    R[1, 1] = a11 / c + d
+    d = (a11 - a22) / 4α
+    R[1, 1] = α + d
     R[2, 1] = a21 / c
     R[1, 2] = a12 / c
-    R[2, 2] = a22 / c + d
+    R[2, 2] = α - d
     return R
 end
 

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2521,7 +2521,7 @@ Base.@propagate_inbounds function _sqrt_quasitriu_offdiag_block_2x2!(R, A, i, j)
     Rii = @view R[irange, irange]
     Rjj = @view R[jrange, jrange]
     Rij = @view R[irange, jrange]
-    if !(iszero(Rij) && all(isfinite, A) && all(isfinite, B))
+    if !(iszero(Rij) && all(isfinite, Rii) && all(isfinite, Rjj))
         _sylvester_2x2!(Rii, Rjj, Rij)
     end
     return R

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2439,11 +2439,10 @@ Base.@propagate_inbounds function _sqrt_real_2x2!(R, A)
     a11, a21, a12, a22 = A[1, 1], A[2, 1], A[1, 2], A[2, 2]
     θ = (a11 + a22) / 2
     μ² = -(a11 - a22)^2 / 4 - a21 * a12
-    μ = sqrt(μ²)
     if θ > 0
         α = sqrt((sqrt(θ^2 + μ²) + θ) / 2)
     else
-        α = μ / sqrt(2 * (sqrt(θ^2 + μ²) - θ))
+        α = sqrt(μ² / (2 * (sqrt(θ^2 + μ²) - θ)))
     end
     c = 2α
     d = (a11 - a22) / 4α

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2522,7 +2522,9 @@ Base.@propagate_inbounds function _sqrt_quasitriu_offdiag_block_2x2!(R, A, i, j)
     Rii = @view R[irange, irange]
     Rjj = @view R[jrange, jrange]
     Rij = @view R[irange, jrange]
-    _sylvester_2x2!(Rii, Rjj, Rij)
+    if !(iszero(Rij) && all(isfinite, A) && all(isfinite, B))
+        _sylvester_2x2!(Rii, Rjj, Rij)
+    end
     return R
 end
 

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2445,7 +2445,8 @@ Base.@propagate_inbounds function _sqrt_real_2x2!(R, A)
     # avoid overflow/underflow of μ
     # for real sqrt, |d| ≤ 2 max(|a12|,|a21|)
     μₛ = max(abs(a12), abs(a21))
-    μ = μₛ * sqrt(-(d / μₛ)^2 - 4 * (a21 / μₛ) * (a12 / μₛ)) / 2
+    μₛ⁻¹ = inv(μₛ)
+    μ = μₛ * sqrt(-(d * μₛ⁻¹)^2 - 4 * (a21 * μₛ⁻¹) * (a12 * μₛ⁻¹)) / 2
     α = _real_sqrt(θ, μ)
     c = 2α
     f = d / 4α

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2439,21 +2439,18 @@ end
 # decomposition. Eqs 6.8-6.9 and Algorithm 6.5 of
 # Higham, 2008, "Functions of Matrices: Theory and Computation", SIAM.
 Base.@propagate_inbounds function _sqrt_real_2x2!(R, A)
-    a11, a21, a12, a22 = A[1, 1], A[2, 1], A[1, 2], A[2, 2]
-    d = a11 - a22
-    θ = (a11 + a22) / 2
+    # in the real Schur form, A[1, 1] == A[2, 2], and A[2, 1] * A[1, 2] < 0
+    θ, a21, a12 = A[1, 1], A[2, 1], A[1, 2]
     # avoid overflow/underflow of μ
     # for real sqrt, |d| ≤ 2 max(|a12|,|a21|)
     μₛ = max(abs(a12), abs(a21))
-    μₛ⁻¹ = inv(μₛ)
-    μ = μₛ * sqrt(-(d * μₛ⁻¹)^2 - 4 * (a21 * μₛ⁻¹) * (a12 * μₛ⁻¹)) / 2
+    μ = sqrt(-(a21 / μₛ) * (a12 / μₛ)) * μₛ
     α = _real_sqrt(θ, μ)
     c = 2α
-    f = d / 4α
-    R[1, 1] = α + f
+    R[1, 1] = α
     R[2, 1] = a21 / c
     R[1, 2] = a12 / c
-    R[2, 2] = α - f
+    R[2, 2] = α
     return R
 end
 

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2435,22 +2435,29 @@ function _sqrt_quasitriu_offdiag_block!(R, A)
     return R
 end
 
+# real square root of 2x2 diagonal block of quasi-triangular matrix from real Schur
+# decomposition. Eqs 6.8-6.9 and Algorithm 6.5 of
+# Higham, 2008, "Functions of Matrices: Theory and Computation", SIAM.
 Base.@propagate_inbounds function _sqrt_real_2x2!(R, A)
     a11, a21, a12, a22 = A[1, 1], A[2, 1], A[1, 2], A[2, 2]
+    d = a11 - a22
     θ = (a11 + a22) / 2
-    μ² = -(a11 - a22)^2 / 4 - a21 * a12
-    if θ > 0
-        α = sqrt((sqrt(θ^2 + μ²) + θ) / 2)
-    else
-        α = sqrt(μ² / (2 * (sqrt(θ^2 + μ²) - θ)))
-    end
+    μ = sqrt(-d^2 - 4 * a21 * a12) / 2
+    α = _real_sqrt(θ, μ)
     c = 2α
-    d = (a11 - a22) / 4α
-    R[1, 1] = α + d
+    f = d / 4α
+    R[1, 1] = α + f
     R[2, 1] = a21 / c
     R[1, 2] = a12 / c
-    R[2, 2] = α - d
+    R[2, 2] = α - f
     return R
+end
+
+# real part of square root of θ+im*μ
+@inline function _real_sqrt(θ, μ)
+    iszero(θ) && iszero(μ) && return sqrt(zero(θ)^2 + zero(μ)^2)
+    t = sqrt((abs(θ) + hypot(θ, μ)) / 2)
+    return θ ≥ 0 ? t : μ / 2t
 end
 
 Base.@propagate_inbounds function _sqrt_quasitriu_offdiag_block_1x1!(R, A, i, j)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2455,7 +2455,6 @@ end
 
 # real part of square root of θ+im*μ
 @inline function _real_sqrt(θ, μ)
-    iszero(θ) && iszero(μ) && return sqrt(zero(θ)^2 + zero(μ)^2)
     t = sqrt((abs(θ) + hypot(θ, μ)) / 2)
     return θ ≥ 0 ? t : μ / 2t
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2521,7 +2521,7 @@ Base.@propagate_inbounds function _sqrt_quasitriu_offdiag_block_2x2!(R, A, i, j)
     Rii = @view R[irange, irange]
     Rjj = @view R[jrange, jrange]
     Rij = @view R[irange, jrange]
-    if !(iszero(Rij) && all(isfinite, Rii) && all(isfinite, Rjj))
+    if !iszero(Rij) && !all(isnan, Rij)
         _sylvester_2x2!(Rii, Rjj, Rij)
     end
     return R

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2156,12 +2156,17 @@ end
 # 35(4), (2013), C394–C410.
 # Eq. 6.1
 Base.@propagate_inbounds function _log_diag_block_2x2!(A, A0)
-    a, b, c, d = A0[1,1], A0[1,2], A0[2,1], A0[2,2]
-    bc = b * c
-    s = sqrt(-bc)
+    a, b, c = A0[1,1], A0[1,2], A0[2,1]
+    # avoid underflow/overflow for large/small b and c
+    s = sqrt(abs(b)) * sqrt(abs(c))
     θ = atan(s, a)
     t = θ / s
-    a1 = log(a^2 - bc) / 2
+    au = abs(a)
+    if au > s
+        a1 = log1p((s / au)^2) / 2 + log(au)
+    else
+        a1 = log1p((au / s)^2) / 2 + log(s)
+    end
     A[1,1] = a1
     A[2,1] = c*t
     A[1,2] = b*t

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -879,6 +879,13 @@ end
 
     x3 = [-1 -eps() 0 0; eps() -1 0 0; 0 0 -1 -eps(); 0 0 eps() Inf]
     @test all(isnan, sqrt(x3))
+
+    # test overflow/underflow handled
+    x4 = [0 -1e200; 1e200 0]
+    @test sqrt(x4)^2 ≈ x4
+
+    x5 = [0 -1e-200; 1e-200 0]
+    @test sqrt(x5)^2 ≈ x5
 end
 
 @testset "issue #7181" begin

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -870,6 +870,14 @@ end
     end
 end
 
+@testset "issue #40141" begin
+    x = [-1 -eps() 0 0; eps() -1 0 0; 0 0 -1 -eps(); 0 0 eps() -1]
+    @test sqrt(x)^2 ≈ x
+
+    x2 =  [-1 -eps() 0 0; 3eps() -1 0 0; 0 0 -1 -3eps(); 0 0 eps() -1]
+    @test sqrt(x2)^2 ≈ x2
+end
+
 @testset "issue #7181" begin
     A = [ 1  5  9
           2  6 10

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -891,6 +891,17 @@ end
     @test sqrt(x6)^2 ≈ x6
 end
 
+@testset "matrix logarithm block diagonal underflow/overflow" begin
+    x1 = [0 -1e200; 1e200 0]
+    @test exp(log(x1)) ≈ x1
+
+    x2 = [0 -1e-200; 1e-200 0]
+    @test exp(log(x2)) ≈ x2
+
+    x3 = [1.0 1e200; -1e-200 1.0]
+    @test exp(log(x3)) ≈ x3
+end
+
 @testset "issue #7181" begin
     A = [ 1  5  9
           2  6 10

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -886,6 +886,9 @@ end
 
     x5 = [0 -1e-200; 1e-200 0]
     @test sqrt(x5)^2 ≈ x5
+
+    x6 = [1.0 1e200; -1e-200 1.0]
+    @test sqrt(x6)^2 ≈ x6
 end
 
 @testset "issue #7181" begin

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -876,6 +876,9 @@ end
 
     x2 =  [-1 -eps() 0 0; 3eps() -1 0 0; 0 0 -1 -3eps(); 0 0 eps() -1]
     @test sqrt(x2)^2 ≈ x2
+
+    x3 = [-1 -eps() 0 0; eps() -1 0 0; 0 0 -1 -eps(); 0 0 eps() Inf]
+    @test all(isnan, sqrt(x3))
 end
 
 @testset "issue #7181" begin


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#825, also ~eliminates an unnecessary scalar `sqrt`~ tries to reduce potential numerical issues in `_sqrt_real_2x2!`.

The added tests fail on master. Test 1 fails unless we make this change to `_sqrt_real_2x2!`. Test 2 also fails unless we make this change to `_sqrt_quasitriu_offdiag_block_2x2!`.

Edit: Test 3 tests the case where `NaN`s would cause `LAPACK.trsyl!` to error.