### PR TITLE
remove mention that non-underscored symbols denote public API

### DIFF
--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -142,9 +142,6 @@ uses (e.g. `a[i]::Int`) than to try to pack many alternatives into one type.
     as word separators. Underscores are also used to indicate a combination of concepts ([`remotecall_fetch`](@ref)
     as a more efficient implementation of `fetch(remotecall(...))`) or as modifiers.
   * functions mutating at least one of their arguments end in `!`.
-  * use identifiers starting with `_` to
-    denote functions, macros or variables that should be considered private and not part of a package's
-    public API.
   * conciseness is valued, but avoid abbreviation ([`indexin`](@ref) rather than `indxin`) as
     it becomes difficult to remember whether and how particular words are abbreviated.
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -141,7 +141,5 @@ conventions:
   * Functions that write to their arguments have names that end in `!`. These are sometimes called
     "mutating" or "in-place" functions because they are intended to produce changes in their arguments
     after the function is called, not just return a value.
-  * Names starting with an underscore denote functions, macros or variables that are only used internally
-    by a package and are not part of its public API.
 
 For more information about stylistic conventions, see the [Style Guide](@ref).


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/40131#issuecomment-804416847 

This is barely used in Base nor in almost any package I've read at read so it seems odd to have in the style guide.