### PR TITLE
Backports release 1.6.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -114,7 +114,6 @@ New library features
   inserting or consuming the first dimension depending on the ratio of `sizeof(T)` and `sizeof(S)`.
 * New `append!(vector, collections...)` and `prepend!(vector, collections...)` methods accept multiple
   collections to be appended or prepended ([#36227]).
-* The postfix operator `'ᵀ` can now be used as an alias for `transpose` ([#38062]).
 * `keys(io::IO)` has been added, which returns all keys of `io` if `io` is an `IOContext` and an empty
   `Base.KeySet` otherwise ([#37753]).
 * `count` now accepts an optional `init` argument to control the accumulation type ([#37461]).

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -467,7 +467,6 @@ export
 # linear algebra
     var"'", # to enable syntax a' for adjoint
     adjoint,
-    var"'ᵀ",
     transpose,
     kron,
     kron!,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -567,7 +567,6 @@ end
 function kron! end
 
 const var"'" = adjoint
-const var"'ᵀ" = transpose
 
 """
     \\(x, y)

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -172,6 +172,10 @@ allocations, and the total number of bytes its execution caused to be allocated,
 returning the value of the expression. Any time spent garbage collecting (gc) or
 compiling is shown as a percentage.
 
+In some cases the system will look inside the `@time` expression and compile some of the
+called code before execution of the top-level expression begins. When that happens, some
+compilation time will not be counted. To include this time you can run `@time @eval ...`.
+
 See also [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref), and
 [`@allocated`](@ref).
 
@@ -264,6 +268,10 @@ end
 A macro to evaluate an expression, discarding the resulting value, instead returning the
 number of seconds it took to execute as a floating-point number.
 
+In some cases the system will look inside the `@elapsed` expression and compile some of the
+called code before execution of the top-level expression begins. When that happens, some
+compilation time will not be counted. To include this time you can run `@elapsed @eval ...`.
+
 See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
 and [`@allocated`](@ref).
 
@@ -322,6 +330,10 @@ end
 A macro to execute an expression, and return the value of the expression, elapsed time,
 total bytes allocated, garbage collection time, and an object with various memory allocation
 counters.
+
+In some cases the system will look inside the `@timed` expression and compile some of the
+called code before execution of the top-level expression begins. When that happens, some
+compilation time will not be counted. To include this time you can run `@timed @eval ...`.
 
 See also [`@time`](@ref), [`@timev`](@ref), [`@elapsed`](@ref), and
 [`@allocated`](@ref).

--- a/deps/p7zip.mk
+++ b/deps/p7zip.mk
@@ -9,7 +9,7 @@ $(BUILDDIR)/p7zip-$(P7ZIP_VER)/source-extracted: $(SRCCACHE)/p7zip-$(P7ZIP_VER).
 	$(JLCHECKSUM) $<
 	mkdir -p $(dir $@)
 	cd $(dir $@) && $(TAR) --strip-components 1 -jxf $<
-	echo $1 > $@
+	echo 1 > $@
 
 checksum-p7zip: $(SRCCACHE)/p7zip-$(P7ZIP_VER).tar.bz2
 	$(JLCHECKSUM) $<

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -18,7 +18,7 @@ $(SRCCACHE)/pcre2-$(PCRE_VER)/source-extracted: $(SRCCACHE)/pcre2-$(PCRE_VER).ta
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/Makefile.am
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/Makefile.in
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/configure
-	echo $1 > $@
+	echo 1 > $@
 
 checksum-pcre2: $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2
 	$(JLCHECKSUM) $<

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -14,9 +14,9 @@ $(SRCCACHE)/pcre2-$(PCRE_VER)/source-extracted: $(SRCCACHE)/pcre2-$(PCRE_VER).ta
 	cp $(SRCDIR)/patches/config.sub $(SRCCACHE)/pcre2-$(PCRE_VER)/config.sub
 	cd $(SRCCACHE)/pcre2-$(PCRE_VER) && patch -p1 -f < $(SRCDIR)/patches/pcre2-cet-flags.patch
 	# Fix some old targets modified by the patching
+	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/aclocal.m4
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/Makefile.am
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/Makefile.in
-	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/aclocal.m4
 	touch -c $(SRCCACHE)/pcre2-$(PCRE_VER)/configure
 	echo $1 > $@
 

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -136,7 +136,6 @@ julia> x'x
 adjoint(A::AbstractVecOrMat) = Adjoint(A)
 
 """
-    A'ᵀ
     transpose(A)
 
 Lazy transpose. Mutating the returned object should appropriately mutate `A`. Often,
@@ -145,9 +144,6 @@ that this operation is recursive.
 
 This operation is intended for linear algebra usage - for general data manipulation see
 [`permutedims`](@ref Base.permutedims), which is non-recursive.
-
-!!! compat "Julia 1.6"
-    The postfix operator `'ᵀ` requires Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -160,14 +156,6 @@ julia> transpose(A)
 2×2 transpose(::Matrix{Complex{Int64}}) with eltype Complex{Int64}:
  3+2im  8+7im
  9+2im  4+6im
-
-julia> x = [3, 4im]
-2-element Vector{Complex{Int64}}:
- 3 + 0im
- 0 + 4im
-
-julia> x'ᵀx
--7 + 0im
 ```
 """
 transpose(A::AbstractVecOrMat) = Transpose(A)

--- a/stdlib/Markdown/src/render/terminal/formatting.jl
+++ b/stdlib/Markdown/src/render/terminal/formatting.jl
@@ -42,6 +42,7 @@ wrapped_lines(io::IO, f::Function, args...; width = 80, i = 0) =
 
 function print_wrapped(io::IO, s...; width = 80, pre = "", i = 0)
     lines = wrapped_lines(io, s..., width = width, i = i)
+    isempty(lines) && return 0, 0
     print(io, lines[1])
     for line in lines[2:end]
         print(io, '\n', pre, line)

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1213,3 +1213,12 @@ end
         |  $x  |
         """)
 end
+
+@testset "issue 40080: empty list item breaks display()" begin
+    d = TextDisplay(devnull)
+    display(d, md"""
+               1. hello
+               2.
+               """)
+end
+

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -13,7 +13,9 @@ type, which is a wrapper over the OS provided entropy.
 Most functions related to random generation accept an optional `AbstractRNG` object as first argument,
 which defaults to the global one if not provided. Moreover, some of them accept optionally
 dimension specifications `dims...` (which can be given as a tuple) to generate arrays of random
-values.
+values.  In a multi-threaded program, you should generally use different RNG objects from different threads
+in order to be thread-safe. However, the default global RNG is thread-safe as of Julia 1.3 (because
+it internally corresponds to a per-thread RNG).
 
 A `MersenneTwister` or `RandomDevice` RNG can generate uniformly random numbers of the following types:
 [`Float16`](@ref), [`Float32`](@ref), [`Float64`](@ref), [`BigFloat`](@ref), [`Bool`](@ref),

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -253,7 +253,4 @@ end
     @test ∋(0)(-2:2)
 end
 
-a = rand(3, 3)
-@test transpose(a) === a'ᵀ
-
 @test [Base.afoldl(+, 1:i...) for i = 1:40] == [i * (i + 1) ÷ 2 for i = 1:40]


### PR DESCRIPTION
Backported PRs:
- [x] #39802 - Add explanation about top-level compilation to timing macros
- [x] #40109 - document thread safety for RNGs
- [x] #40003 - Fix a couple of likely typos in deps/p7zip.mk and deps/pcre.mk.
- [x] #40075 - Revert "add 'ᵀ postfix operator for transpose (#38062)"
- [x] #40062 - Prevent PCRE from needing a rebuild/reconf.

Non-merged PRs with backport label:
- [ ] #40095 - fix #40050, handling fields that are pointers due to subtype circularity
- [ ] #40038 - Allow the conversion of AbstractUnitRanges to OrdinalRanges
- [ ] #39544 - fix definition of open I/O to Process
- [ ] #38981 - Fix #38491: fix an abspath() edge case on Windows
- [ ] #38405 - Make Distributed.jl `Worker` struct thread-safe.