### PR TITLE
Manual claims that `run` returns `nothing`

### DIFF
--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -41,7 +41,7 @@ hello
 ```
 
 The `hello` is the output of the `echo` command, sent to [`stdout`](@ref). The run method itself
-returns `nothing`, and throws an [`ErrorException`](@ref) if the external command fails to run
+returns `nothing` [No. Actually: `run` (sometimes? always?) returns a `Process`], and throws an [`ErrorException`](@ref) if the external command fails to run
 successfully.
 
 If you want to read the output of the external command, [`read`](@ref) or [`readchomp`](@ref)

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -40,9 +40,8 @@ julia> run(mycommand);
 hello
 ```
 
-The `hello` is the output of the `echo` command, sent to [`stdout`](@ref). The run method itself
-returns `nothing` [No. Actually: `run` (sometimes? always?) returns a `Process`], and throws an [`ErrorException`](@ref) if the external command fails to run
-successfully.
+The `hello` is the output of the `echo` command, sent to [`stdout`](@ref). If the external command fails to run
+successfully, the run method throws an [`ErrorException`](@ref).
 
 If you want to read the output of the external command, [`read`](@ref) or [`readchomp`](@ref)
 can be used instead:


### PR DESCRIPTION
This  manual page claims that `run` returns `nothing`. However  (in version v1.5.3) it returns a `Process` object (I'm not sure if it always does).

Note: this commit does not (yet) propose changes that can be merged because I don't know for sure how to correct the error.
Note: the more recent (unreleased) versions of this file seem to have the same error.

To reproduce:
```julia
julia> VERSION
v"1.5.3"
julia> typeof(run(`echo`))
Base.Process
```