### PR TITLE
adding default argument value to reset!(stateful)

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1211,6 +1211,12 @@ julia> collect(a)
 2-element Vector{Char}:
  'e': ASCII/Unicode U+0065 (category Ll: Letter, lowercase)
  'f': ASCII/Unicode U+0066 (category Ll: Letter, lowercase)
+
+julia> Iterators.reset!(a); popfirst!(a)
+'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
+
+julia> Iterators.reset!(a, "hello"); popfirst!(a)
+'h': ASCII/Unicode U+0068 (category Ll: Letter, lowercase)
 ```
 
 ```jldoctest
@@ -1239,7 +1245,7 @@ mutable struct Stateful{T, VS}
     end
 end
 
-function reset!(s::Stateful{T,VS}, itr::T) where {T,VS}
+function reset!(s::Stateful{T,VS}, itr::T=s.itr) where {T,VS}
     s.itr = itr
     setfield!(s, :nextvalstate, iterate(itr))
     s.taken = 0


### PR DESCRIPTION
I think that most of the time when one calls `reset!(::Stateful, itr)` it will be to simply restart from the begin without changing the iterated collection. So I figured that adding sf.itr as a default value to the second argument would avoid having to write `reset!(sf, sf.itr)`. 
I also added the use of `reset!` to the documentation examples because it's not documented anywhere. This way users know of its existence.