### PR TITLE
Fix issue where approved credentials were not sent to git credential helpers

### DIFF
--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -30,7 +30,12 @@ function GitCredential(cfg::GitConfig, url::AbstractString)
     fill!(cfg, parse(GitCredential, url))
 end
 
-GitCredential(cred::UserPasswordCredential, url::AbstractString) = parse(GitCredential, url)
+function GitCredential(user_pass_cred::UserPasswordCredential, url::AbstractString)
+    cred = parse(GitCredential, url)
+    cred.username = user_pass_cred.user
+    cred.password = user_pass_cred.pass
+    return cred
+end
 
 Base.:(==)(c1::GitCredential, c2::GitCredential) = (c1.protocol, c1.host, c1.path, c1.username, c1.password, c1.use_http_path) ==
                                                    (c2.protocol, c2.host, c2.path, c2.username, c2.password, c2.use_http_path)

--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -33,7 +33,7 @@ end
 function GitCredential(user_pass_cred::UserPasswordCredential, url::AbstractString)
     cred = parse(GitCredential, url)
     cred.username = user_pass_cred.user
-    cred.password = user_pass_cred.pass
+    cred.password = deepcopy(user_pass_cred.pass)
     return cred
 end
 


### PR DESCRIPTION
If a Julia user was setup to use [git credential helpers](https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage) then Julia was supposed to interact with the credential helpers such that if a user was prompted for credentials those credentials would be sent to the helper and stored appropriately. Due to this bug a user would be repeated asked for credentials which is annoying. Unfortunately, only if a user had used `git` or another tool that properly interacted with the helpers would the prompts be avoided. Essentially Julia was interacting with the helpers in a read-only mode.

This is a long standing issue that was introduced in: https://github.com/JuliaLang/julia/commit/8abc616fb0#diff-c023d2e7a114f660901703fc5bec91bcff1215f598f6126561a050defeced5d1R31.