### PR TITLE
Fix armv7l trampoline

### DIFF
--- a/cli/trampolines/trampolines_arm.S
+++ b/cli/trampolines/trampolines_arm.S
@@ -5,7 +5,7 @@
 .global CNAME(name); \
 .cfi_startproc; \
 CNAME(name)##:; \
-    ldr ip, CONCAT(.L,CNAME(name)); \
+    ldr ip, CONCAT(.L,CNAMEADDR(name)); \
 CONCAT(.L,CNAME(name)): ;\
     add ip, pc, ip; \
     ldr pc, [ip]; \


### PR DESCRIPTION
We copy-pasted the wrong macro here, should have used `CNAMEADDR()` not `CNAME()`.  This causes segfaults on armv7l processors by trying to read from an incorrect address when loading the trampoline target address value.

Fixes https://github.com/JuliaLang/julia/issues/39293