### PR TITLE
choosetests: move testnames array at top-level

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -5,6 +5,32 @@ using Random, Sockets
 const STDLIB_DIR = Sys.STDLIB
 const STDLIBS = filter!(x -> isfile(joinpath(STDLIB_DIR, x, "src", "$(x).jl")), readdir(STDLIB_DIR))
 
+const TESTNAMES = [
+        "subarray", "core", "compiler", "worlds", "atomics",
+        "keywordargs", "numbers", "subtype",
+        "char", "strings", "triplequote", "unicode", "intrinsics",
+        "dict", "hashing", "iobuffer", "staged", "offsetarray",
+        "arrayops", "tuple", "reduce", "reducedim", "abstractarray",
+        "intfuncs", "simdloop", "vecelement", "rational",
+        "bitarray", "copy", "math", "fastmath", "functional", "iterators",
+        "operators", "ordering", "path", "ccall", "parse", "loading", "gmp",
+        "sorting", "spawn", "backtrace", "exceptions",
+        "file", "read", "version", "namedtuple",
+        "mpfr", "broadcast", "complex",
+        "floatapprox", "stdlib", "reflection", "regex", "float16",
+        "combinatorics", "sysinfo", "env", "rounding", "ranges", "mod2pi",
+        "euler", "show", "client",
+        "errorshow", "sets", "goto", "llvmcall", "llvmcall2", "ryu",
+        "some", "meta", "stacktraces", "docs",
+        "misc", "threads", "stress", "binaryplatforms", "atexit",
+        "enums", "cmdlineargs", "int", "interpreter",
+        "checked", "bitset", "floatfuncs", "precompile",
+        "boundscheck", "error", "ambiguous", "cartesian", "osutils",
+        "channels", "iostream", "secretbuffer", "specificity",
+        "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
+        "smallarrayshrink", "opaque_closure", "filesystem", "download"
+]
+
 """
 
 `tests, net_on, exit_on_error, seed = choosetests(choices)` selects a set of tests to be
@@ -32,32 +58,6 @@ in the `choices` argument:
      This option can be used to reproduce failed tests.
 """
 function choosetests(choices = [])
-    testnames = [
-        "subarray", "core", "compiler", "worlds", "atomics",
-        "keywordargs", "numbers", "subtype",
-        "char", "strings", "triplequote", "unicode", "intrinsics",
-        "dict", "hashing", "iobuffer", "staged", "offsetarray",
-        "arrayops", "tuple", "reduce", "reducedim", "abstractarray",
-        "intfuncs", "simdloop", "vecelement", "rational",
-        "bitarray", "copy", "math", "fastmath", "functional", "iterators",
-        "operators", "ordering", "path", "ccall", "parse", "loading", "gmp",
-        "sorting", "spawn", "backtrace", "exceptions",
-        "file", "read", "version", "namedtuple",
-        "mpfr", "broadcast", "complex",
-        "floatapprox", "stdlib", "reflection", "regex", "float16",
-        "combinatorics", "sysinfo", "env", "rounding", "ranges", "mod2pi",
-        "euler", "show", "client",
-        "errorshow", "sets", "goto", "llvmcall", "llvmcall2", "ryu",
-        "some", "meta", "stacktraces", "docs",
-        "misc", "threads", "stress", "binaryplatforms", "atexit",
-        "enums", "cmdlineargs", "int", "interpreter",
-        "checked", "bitset", "floatfuncs", "precompile",
-        "boundscheck", "error", "ambiguous", "cartesian", "osutils",
-        "channels", "iostream", "secretbuffer", "specificity",
-        "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
-        "smallarrayshrink", "opaque_closure", "filesystem", "download"
-    ]
-
     tests = []
     skip_tests = []
     exit_on_error = false
@@ -80,7 +80,7 @@ function choosetests(choices = [])
     end
 
     if tests == ["all"] || isempty(tests)
-        tests = testnames
+        tests = TESTNAMES
     end
 
     function filtertests!(tests, name, files=[name])


### PR DESCRIPTION
This allows scripts loading this file to know the list of tests.