### PR TITLE
fix markdown list rendering

### DIFF
--- a/stdlib/Markdown/src/render/terminal/formatting.jl
+++ b/stdlib/Markdown/src/render/terminal/formatting.jl
@@ -9,8 +9,9 @@ end
 words(s) = split(s, " ")
 lines(s) = split(s, "\n")
 
-function wrapped_lines!(lines, io::IO, s::AbstractString, width, i)
+function wrapped_line(io::IO, s::AbstractString, width, i)
     ws = words(s)
+    lines = String[]
     for word in ws
         word_length = ansi_length(word)
         word_length == 0 && continue
@@ -22,19 +23,16 @@ function wrapped_lines!(lines, io::IO, s::AbstractString, width, i)
             lines[end] *= " " * word   # this could be more efficient
         end
     end
-    return i
+    return i, lines
 end
 
 function wrapped_lines(io::IO, s::AbstractString; width = 80, i = 0)
-    lines = AbstractString[]
-    if occursin(r"\n", s)
-        for ss in split(s, "\n")
-            i = wrapped_lines!(lines, io, ss, width, i)
-        end
-    else
-        wrapped_lines!(lines, io, s, width, i)
+    ls = String[]
+    for ss in lines(s)
+        i, line = wrapped_line(io, ss, width, i)
+        append!(ls, line)
     end
-    return lines
+    return ls
 end
 
 wrapped_lines(io::IO, f::Function, args...; width = 80, i = 0) =

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1222,3 +1222,11 @@ end
                """)
 end
 
+@testset "issue #37232: linebreaks" begin
+    s = @md_str """
+       Misc:\\
+       - line\\
+       """
+    @test sprint(show, MIME("text/plain"), s) == "  Misc:\n  - line"
+end
+


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/37232
Fixes https://github.com/JuliaDebug/Debugger.jl/issues/287

Before, the `wrapped_lines` put things on different lines onto the same line:

```jl
julia> using Markdown

julia> md = @md_str """
       Misc:\\
       - `o`: open the current line in an editor\\
       """;

julia> str = sprint(io->Markdown.terminline(io, md.content[end].content))
"Misc:\n- o: open the current line in an editor\n"

julia> Markdown.wrapped_lines(stdout, str)
1-element Vector{AbstractString}:
 "Misc: - o: open the current line in an editor"
```

Now:

```jl
2-element Vector{String}:
 "Misc:"
 "- o: open the current line in an editor"
```