### PR TITLE
Showing raw machine code along with disassembled code

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -861,11 +861,12 @@ static void jl_dump_asm_internal(
     }
 
     if (raw_code) {
-        // Print the complete address at the top (instruction addresses are abbreviated)
-        std::string Buffer{"; Address starting from "};
+        // Print the complete address and the size at the top (instruction addresses are abbreviated)
+        std::string Buffer{"; code origin: "};
         llvm::raw_string_ostream Stream{Buffer};
         auto Address = reinterpret_cast<uintptr_t>(memoryObject.data());
         llvm::write_hex(Stream, Address, HexPrintStyle::Lower, 16);
+        Stream << ", code size: " << memoryObject.size();
         Streamer->emitRawText(Stream.str());
     }
 

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -471,7 +471,7 @@ static void jl_dump_asm_internal(
         raw_ostream &rstream,
         const char* asm_variant,
         const char* debuginfo,
-        bool raw_code);
+        bool binary);
 
 // This isn't particularly fast, but neither is printing assembly, and they're only used for interactive mode
 static uint64_t compute_obj_symsize(object::SectionRef Section, uint64_t offset)
@@ -507,7 +507,7 @@ static uint64_t compute_obj_symsize(object::SectionRef Section, uint64_t offset)
 
 // print a native disassembly for the function starting at fptr
 extern "C" JL_DLLEXPORT
-jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant, const char *debuginfo, char raw_code)
+jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant, const char *debuginfo, char binary)
 {
     assert(fptr != 0);
     jl_ptls_t ptls = jl_get_ptls_states();
@@ -545,7 +545,7 @@ jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant,
             stream,
             asm_variant,
             debuginfo,
-            raw_code);
+            binary);
     jl_gc_safe_leave(ptls, gc_state);
 
     return jl_pchar_to_string(stream.str().data(), stream.str().size());
@@ -776,7 +776,7 @@ static void jl_dump_asm_internal(
         raw_ostream &rstream,
         const char* asm_variant,
         const char* debuginfo,
-        bool raw_code)
+        bool binary)
 {
     // GC safe
     // Get the host information
@@ -872,7 +872,7 @@ static void jl_dump_asm_internal(
         }
     }
 
-    if (raw_code) {
+    if (binary) {
         // Print the complete address and the size at the top (instruction addresses are abbreviated)
         std::string Buffer{"; code origin: "};
         llvm::raw_string_ostream Stream{Buffer};
@@ -1024,7 +1024,7 @@ static void jl_dump_asm_internal(
                             }
                         }
                     }
-                    if (raw_code)
+                    if (binary)
                         Streamer->emitRawText(rawCodeComment(memoryObject.slice(Index, insSize), TheTriple));
                     Streamer->emitInstruction(Inst, *STI);
                 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -409,14 +409,14 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
 // get a native disassembly for a compiled method
 extern "C" JL_DLLEXPORT
 jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
-        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char raw_code)
+        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary)
 {
     // printing via disassembly
     jl_code_instance_t *codeinst = jl_generate_fptr(mi, world);
     if (codeinst) {
         uintptr_t fptr = (uintptr_t)codeinst->invoke;
         if (getwrapper)
-            return jl_dump_fptr_asm(fptr, raw_mc, asm_variant, debuginfo, raw_code);
+            return jl_dump_fptr_asm(fptr, raw_mc, asm_variant, debuginfo, binary);
         uintptr_t specfptr = (uintptr_t)codeinst->specptr.fptr;
         if (fptr == (uintptr_t)&jl_fptr_const_return && specfptr == 0) {
             // normally we prevent native code from being generated for these functions,
@@ -455,7 +455,7 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
             JL_UNLOCK(&codegen_lock);
         }
         if (specfptr != 0)
-            return jl_dump_fptr_asm(specfptr, raw_mc, asm_variant, debuginfo, raw_code);
+            return jl_dump_fptr_asm(specfptr, raw_mc, asm_variant, debuginfo, binary);
     }
 
     // whatever, that didn't work - use the assembler output instead

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -409,14 +409,14 @@ void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec)
 // get a native disassembly for a compiled method
 extern "C" JL_DLLEXPORT
 jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
-        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo)
+        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char raw_code)
 {
     // printing via disassembly
     jl_code_instance_t *codeinst = jl_generate_fptr(mi, world);
     if (codeinst) {
         uintptr_t fptr = (uintptr_t)codeinst->invoke;
         if (getwrapper)
-            return jl_dump_fptr_asm(fptr, raw_mc, asm_variant, debuginfo);
+            return jl_dump_fptr_asm(fptr, raw_mc, asm_variant, debuginfo, raw_code);
         uintptr_t specfptr = (uintptr_t)codeinst->specptr.fptr;
         if (fptr == (uintptr_t)&jl_fptr_const_return && specfptr == 0) {
             // normally we prevent native code from being generated for these functions,
@@ -455,7 +455,7 @@ jl_value_t *jl_dump_method_asm(jl_method_instance_t *mi, size_t world,
             JL_UNLOCK(&codegen_lock);
         }
         if (specfptr != 0)
-            return jl_dump_fptr_asm(specfptr, raw_mc, asm_variant, debuginfo);
+            return jl_dump_fptr_asm(specfptr, raw_mc, asm_variant, debuginfo, raw_code);
     }
 
     // whatever, that didn't work - use the assembler output instead

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -743,9 +743,9 @@ static inline void jl_set_gc_and_wait(void)
 void jl_gc_set_permalloc_region(void *start, void *end);
 
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm(jl_method_instance_t *linfo, size_t world,
-        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char raw_code);
+        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary);
 JL_DLLEXPORT void *jl_get_llvmf_defn(jl_method_instance_t *linfo, size_t world, char getwrapper, char optimize, const jl_cgparams_t params);
-JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant, const char *debuginfo, char raw_code);
+JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant, const char *debuginfo, char binary);
 JL_DLLEXPORT jl_value_t *jl_dump_llvm_asm(void *F, const char* asm_variant, const char *debuginfo);
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir(void *f, char strip_ir_metadata, char dump_module, const char *debuginfo);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -743,9 +743,9 @@ static inline void jl_set_gc_and_wait(void)
 void jl_gc_set_permalloc_region(void *start, void *end);
 
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm(jl_method_instance_t *linfo, size_t world,
-        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo);
+        int raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char raw_code);
 JL_DLLEXPORT void *jl_get_llvmf_defn(jl_method_instance_t *linfo, size_t world, char getwrapper, char optimize, const jl_cgparams_t params);
-JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant, const char *debuginfo);
+JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant, const char *debuginfo, char raw_code);
 JL_DLLEXPORT jl_value_t *jl_dump_llvm_asm(void *F, const char* asm_variant, const char *debuginfo);
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir(void *f, char strip_ir_metadata, char dump_module, const char *debuginfo);
 

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -141,7 +141,7 @@ import Base.CodegenParams
 # Printing code representations in IR and assembly
 function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrapper::Bool,
                         strip_ir_metadata::Bool, dump_module::Bool, syntax::Symbol,
-                        optimize::Bool, debuginfo::Symbol,
+                        optimize::Bool, debuginfo::Symbol, rawcode::Bool,
                         params::CodegenParams=CodegenParams())
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
@@ -153,7 +153,7 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
     linfo = Core.Compiler.specialize_method(match)
     # get the code for it
     if native
-        str = _dump_function_linfo_native(linfo, world, wrapper, syntax, debuginfo)
+        str = _dump_function_linfo_native(linfo, world, wrapper, syntax, debuginfo, rawcode)
     else
         str = _dump_function_linfo_llvm(linfo, world, wrapper, strip_ir_metadata, dump_module, optimize, debuginfo, params)
     end
@@ -162,7 +162,7 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
     return str
 end
 
-function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wrapper::Bool, syntax::Symbol, debuginfo::Symbol)
+function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wrapper::Bool, syntax::Symbol, debuginfo::Symbol, rawcode::Bool)
     if syntax !== :att && syntax !== :intel
         throw(ArgumentError("'syntax' must be either :intel or :att"))
     end
@@ -172,8 +172,8 @@ function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wr
         throw(ArgumentError("'debuginfo' must be either :source or :none"))
     end
     str = ccall(:jl_dump_method_asm, Ref{String},
-                (Any, UInt, Cint, Bool, Ptr{UInt8}, Ptr{UInt8}),
-                linfo, world, 0, wrapper, syntax, debuginfo)
+                (Any, UInt, Cint, Bool, Ptr{UInt8}, Ptr{UInt8}, Bool),
+                linfo, world, 0, wrapper, syntax, debuginfo, rawcode)
     return str
 end
 
@@ -208,7 +208,7 @@ Keyword argument `debuginfo` may be one of source (default) or none, to specify 
 """
 function code_llvm(io::IO, @nospecialize(f), @nospecialize(types), raw::Bool,
                    dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default)
-    d = _dump_function(f, types, false, false, !raw, dump_module, :att, optimize, debuginfo)
+    d = _dump_function(f, types, false, false, !raw, dump_module, :att, optimize, debuginfo, false)
     if highlighting[:llvm] && get(io, :color, false)
         print_llvm(io, d)
     else
@@ -222,24 +222,25 @@ code_llvm(@nospecialize(f), @nospecialize(types=Tuple); raw=false, dump_module=f
 
 
 """
-    code_native([io=stdout,], f, types; syntax=:att, debuginfo=:default)
+    code_native([io=stdout,], f, types; syntax=:att, debuginfo=:default, rawcode=false)
 
 Prints the native assembly instructions generated for running the method matching the given
 generic function and type signature to `io`.
 Switch assembly syntax using `syntax` symbol parameter set to `:att` for AT&T syntax or `:intel` for Intel syntax.
 Keyword argument `debuginfo` may be one of source (default) or none, to specify the verbosity of code comments.
+If `rawcode` is `true`, it also prints the binary machine code for each instruction precedented by an abbreviated address.
 """
 function code_native(io::IO, @nospecialize(f), @nospecialize(types=Tuple);
-                     syntax::Symbol=:att, debuginfo::Symbol=:default)
-    d = _dump_function(f, types, true, false, false, false, syntax, true, debuginfo)
+                     syntax::Symbol=:att, debuginfo::Symbol=:default, rawcode::Bool=false)
+    d = _dump_function(f, types, true, false, false, false, syntax, true, debuginfo, rawcode)
     if highlighting[:native] && get(io, :color, false)
         print_native(io, d)
     else
         print(io, d)
     end
 end
-code_native(@nospecialize(f), @nospecialize(types=Tuple); syntax::Symbol=:att, debuginfo::Symbol=:default) =
-    code_native(stdout, f, types; syntax=syntax, debuginfo=debuginfo)
+code_native(@nospecialize(f), @nospecialize(types=Tuple); syntax::Symbol=:att, debuginfo::Symbol=:default, rawcode::Bool=false) =
+    code_native(stdout, f, types; syntax=syntax, debuginfo=debuginfo, rawcode=rawcode)
 code_native(::IO, ::Any, ::Symbol) = error("illegal code_native call") # resolve ambiguous call
 
 ## colorized IR and assembly printing

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -141,7 +141,7 @@ import Base.CodegenParams
 # Printing code representations in IR and assembly
 function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrapper::Bool,
                         strip_ir_metadata::Bool, dump_module::Bool, syntax::Symbol,
-                        optimize::Bool, debuginfo::Symbol, rawcode::Bool,
+                        optimize::Bool, debuginfo::Symbol, binary::Bool,
                         params::CodegenParams=CodegenParams())
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
@@ -153,7 +153,7 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
     linfo = Core.Compiler.specialize_method(match)
     # get the code for it
     if native
-        str = _dump_function_linfo_native(linfo, world, wrapper, syntax, debuginfo, rawcode)
+        str = _dump_function_linfo_native(linfo, world, wrapper, syntax, debuginfo, binary)
     else
         str = _dump_function_linfo_llvm(linfo, world, wrapper, strip_ir_metadata, dump_module, optimize, debuginfo, params)
     end
@@ -162,7 +162,7 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
     return str
 end
 
-function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wrapper::Bool, syntax::Symbol, debuginfo::Symbol, rawcode::Bool)
+function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wrapper::Bool, syntax::Symbol, debuginfo::Symbol, binary::Bool)
     if syntax !== :att && syntax !== :intel
         throw(ArgumentError("'syntax' must be either :intel or :att"))
     end
@@ -173,7 +173,7 @@ function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wr
     end
     str = ccall(:jl_dump_method_asm, Ref{String},
                 (Any, UInt, Cint, Bool, Ptr{UInt8}, Ptr{UInt8}, Bool),
-                linfo, world, 0, wrapper, syntax, debuginfo, rawcode)
+                linfo, world, 0, wrapper, syntax, debuginfo, binary)
     return str
 end
 
@@ -222,25 +222,25 @@ code_llvm(@nospecialize(f), @nospecialize(types=Tuple); raw=false, dump_module=f
 
 
 """
-    code_native([io=stdout,], f, types; syntax=:att, debuginfo=:default, rawcode=false)
+    code_native([io=stdout,], f, types; syntax=:att, debuginfo=:default, binary=false)
 
 Prints the native assembly instructions generated for running the method matching the given
 generic function and type signature to `io`.
 Switch assembly syntax using `syntax` symbol parameter set to `:att` for AT&T syntax or `:intel` for Intel syntax.
 Keyword argument `debuginfo` may be one of source (default) or none, to specify the verbosity of code comments.
-If `rawcode` is `true`, it also prints the binary machine code for each instruction precedented by an abbreviated address.
+If `binary` is `true`, it also prints the binary machine code for each instruction precedented by an abbreviated address.
 """
 function code_native(io::IO, @nospecialize(f), @nospecialize(types=Tuple);
-                     syntax::Symbol=:att, debuginfo::Symbol=:default, rawcode::Bool=false)
-    d = _dump_function(f, types, true, false, false, false, syntax, true, debuginfo, rawcode)
+                     syntax::Symbol=:att, debuginfo::Symbol=:default, binary::Bool=false)
+    d = _dump_function(f, types, true, false, false, false, syntax, true, debuginfo, binary)
     if highlighting[:native] && get(io, :color, false)
         print_native(io, d)
     else
         print(io, d)
     end
 end
-code_native(@nospecialize(f), @nospecialize(types=Tuple); syntax::Symbol=:att, debuginfo::Symbol=:default, rawcode::Bool=false) =
-    code_native(stdout, f, types; syntax=syntax, debuginfo=debuginfo, rawcode=rawcode)
+code_native(@nospecialize(f), @nospecialize(types=Tuple); syntax::Symbol=:att, debuginfo::Symbol=:default, binary::Bool=false) =
+    code_native(stdout, f, types; syntax=syntax, debuginfo=debuginfo, binary=binary)
 code_native(::IO, ::Any, ::Symbol) = error("illegal code_native call") # resolve ambiguous call
 
 ## colorized IR and assembly printing

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -456,20 +456,20 @@ if Sys.ARCH === :x86_64 || occursin(ix86, string(Sys.ARCH))
     output = String(take!(buf))
     @test occursin(rgx, output)
 
-    @testset "rawcode" begin
+    @testset "binary" begin
         # check the RET instruction (opcode: C3)
         ret = r"^; [0-9a-f]{4}: c3$"m
 
-        # without rawcode flag (default)
+        # without binary flag (default)
         code_native(buf, linear_foo, ())
         output = String(take!(buf))
         @test !occursin(ret, output)
 
-        # with rawcode flag
-        for rawcode in false:true
-            code_native(buf, linear_foo, (), rawcode = rawcode)
+        # with binary flag
+        for binary in false:true
+            code_native(buf, linear_foo, (), binary = binary)
             output = String(take!(buf))
-            @test occursin(ret, output) == rawcode
+            @test occursin(ret, output) == binary
         end
     end
 end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -442,23 +442,36 @@ if Sys.ARCH === :x86_64 || occursin(ix86, string(Sys.ARCH))
 
     rgx = r"%"
     buf = IOBuffer()
-    output = ""
     #test that the string output is at&t syntax by checking for occurrences of '%'s
     code_native(buf, linear_foo, (), syntax = :att, debuginfo = :none)
     output = String(take!(buf))
-
     @test occursin(rgx, output)
 
     #test that the code output is intel syntax by checking it has no occurrences of '%'
     code_native(buf, linear_foo, (), syntax = :intel, debuginfo = :none)
     output = String(take!(buf))
-
     @test !occursin(rgx, output)
 
     code_native(buf, linear_foo, ())
     output = String(take!(buf))
-
     @test occursin(rgx, output)
+
+    @testset "rawcode" begin
+        # check the RET instruction (opcode: C3)
+        ret = r"^; [0-9a-f]{4}: c3$"m
+
+        # without rawcode flag (default)
+        code_native(buf, linear_foo, ())
+        output = String(take!(buf))
+        @test !occursin(ret, output)
+
+        # with rawcode flag
+        for rawcode in false:true
+            code_native(buf, linear_foo, (), rawcode = rawcode)
+            output = String(take!(buf))
+            @test occursin(ret, output) == rawcode
+        end
+    end
 end
 
 @testset "error message" begin

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -883,7 +883,7 @@ _test_at_locals2(1,1,0.5f0)
     _dump_function(f31687_parent, Tuple{},
                    #=native=#false, #=wrapper=#false, #=strip=#false,
                    #=dump_module=#true, #=syntax=#:att, #=optimize=#false, :none,
-                   #=rawcode=#false,
+                   #=binary=#false,
                    params)
 end
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -883,6 +883,7 @@ _test_at_locals2(1,1,0.5f0)
     _dump_function(f31687_parent, Tuple{},
                    #=native=#false, #=wrapper=#false, #=strip=#false,
                    #=dump_module=#true, #=syntax=#:att, #=optimize=#false, :none,
+                   #=rawcode=#false,
                    params)
 end
 


### PR DESCRIPTION
This pull request implements a new option to `code_native` to print raw machine code along with disassembled code. If the keyword argument `rawcode` is set to `true` (`false` by default), raw machine code in hexadecimal format is printed as a comment just before each disassembled instruction line. This kind of information may sometimes be useful when the user is interested in code size or alignment of a tight loop (see https://github.com/JuliaLang/julia/issues/39108#issuecomment-754990438, for example).

Here is an example. You can see `L16` is aligned with a `nop` instruction.
```
julia> function collatz(n)
           s = 0
           while n != 1
               if iseven(n)
                   n = n ÷ 2
               else
                   n = 3n + 1
               end
               s += 1
           end
           return s
       end
collatz (generic function with 1 method)

julia> code_native(collatz, (Int,), syntax = :intel, binary = true)
        .text
; code origin: 00007f4736da69a0, code size: 64
; ┌ @ REPL[1]:1 within `collatz'
; 69a0: 31 c0
        xor     eax, eax
; │ @ REPL[1]:3 within `collatz'
; │┌ @ operators.jl:264 within `!='
; ││┌ @ promotion.jl:409 within `=='
; 69a2: 48 83 ff 01
        cmp     rdi, 1
; │└└
; 69a6: 75 16
        jne     L30
; │ @ REPL[1]:11 within `collatz'
L8:
; 69a8: c3
        ret
; 69a9: 0f 1f 80 00 00 00 00
        nop     dword ptr [rax]
; │ @ REPL[1]:7 within `collatz'
; │┌ @ int.jl:87 within `+'
L16:
; 69b0: 48 8d 7c 7f 01
        lea     rdi, [rdi + 2*rdi + 1]
; │└
; │ @ REPL[1]:9 within `collatz'
; │┌ @ int.jl:87 within `+'
L21:
; 69b5: 48 ff c0
        inc     rax
; │└
; │ @ REPL[1]:3 within `collatz'
; │┌ @ operators.jl:264 within `!='
; ││┌ @ promotion.jl:409 within `=='
; 69b8: 48 83 ff 01
        cmp     rdi, 1
; │└└
; 69bc: 74 ea
        je      L8
; │ @ REPL[1]:4 within `collatz'
L30:
; 69be: 40 f6 c7 01
        test    dil, 1
; 69c2: 75 ec
        jne     L16
; │ @ REPL[1]:5 within `collatz'
; │┌ @ int.jl:263 within `div'
; 69c4: 48 89 f9
        mov     rcx, rdi
; 69c7: 48 c1 e9 3f
        shr     rcx, 63
; 69cb: 48 01 f9
        add     rcx, rdi
; 69ce: 48 d1 f9
        sar     rcx
; 69d1: 48 89 cf
        mov     rdi, rcx
; │└
; 69d4: eb df
        jmp     L21
; 69d6: 66 2e 0f 1f 84 00 00 00 00 00
        nop     word ptr cs:[rax + rax]
; └
```

Closes #39108.