### PR TITLE
add FZ16 to fpcr_fz_mask for aarch64

### DIFF
--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -1810,6 +1810,8 @@ extern "C" int jl_test_cpu_feature(jl_cpu_feature_t feature)
 #ifdef _CPU_AARCH64_
 // FPCR FZ, bit [24]
 static constexpr uint32_t fpcr_fz_mask = 1 << 24;
+// FPCR FZ16, bit [19]
+static constexpr uint32_t fpcr_fz16_mask = 1 << 19;
 // FPCR DN, bit [25]
 static constexpr uint32_t fpcr_dn_mask = 1 << 25;
 
@@ -1833,7 +1835,8 @@ extern "C" JL_DLLEXPORT int32_t jl_get_zero_subnormals(void)
 extern "C" JL_DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
 {
     uint32_t fpcr = get_fpcr_aarch64();
-    fpcr = isZero ? (fpcr | fpcr_fz_mask) : (fpcr & ~fpcr_fz_mask);
+    static uint32_t mask = fpcr_fz_mask | (jl_test_cpu_feature(JL_AArch64_fullfp16) ? fpcr_fz16_mask : 0);
+    fpcr = isZero ? (fpcr | mask) : (fpcr & ~mask);
     set_fpcr_aarch64(fpcr);
     return 0;
 }


### PR DESCRIPTION
Fixes #40151 by also setting the FZ16 mask

@milankl can you test on your A64fx machine?
