### PR TITLE
improve fastmath for `exp` and friends

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -273,6 +273,9 @@ end
 
 
 # Math functions
+exp2_fast(x::Union{Float32,Float64})  = Base.Math.exp2_fast(x)
+exp_fast(x::Union{Float32,Float64})   = Base.Math.exp_fast(x)
+exp10_fast(x::Union{Float32,Float64}) = Base.Math.exp10_fast(x)
 
 # builtins
 
@@ -282,28 +285,6 @@ pow_fast(x::FloatTypes, ::Val{p}) where {p} = pow_fast(x, p) # inlines already v
 @inline pow_fast(x, v::Val) = Base.literal_pow(^, x, v)
 
 sqrt_fast(x::FloatTypes) = sqrt_llvm_fast(x)
-
-# libm
-
-const libm = Base.libm_name
-
-for f in (:acosh, :asinh, :atanh, :cbrt,
-          :cosh, :exp2, :expm1, :log10, :log1p, :log2,
-          :log, :sinh, :tanh)
-    f_fast = fast_op[f]
-    @eval begin
-        $f_fast(x::Float32) =
-            ccall(($(string(f,"f")),libm), Float32, (Float32,), x)
-        $f_fast(x::Float64) =
-            ccall(($(string(f)),libm), Float64, (Float64,), x)
-    end
-end
-
-pow_fast(x::Float32, y::Float32) =
-    ccall(("powf",libm), Float32, (Float32,Float32), x, y)
-pow_fast(x::Float64, y::Float64) =
-    ccall(("pow",libm), Float64, (Float64,Float64), x, y)
-
 sincos_fast(v::FloatTypes) = sincos(v)
 
 @inline function sincos_fast(v::Float16)

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -246,7 +246,7 @@ end
     if !(abs(x) <= SUBNORM_EXP(base, T))
         x > MAX_EXP(base, T) && return Inf32
         x < MIN_EXP(base, T) && return 0.0f0
-        if N<=Int32(-24)
+        if N <= Int32(-24)
             twopk = reinterpret(T, (N+Int32(151)) << Int32(23))
             return (twopk*small_part)*(2f0^(-24))
         end

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -203,26 +203,26 @@ end
 
 @inline function exp_impl(x::T, base) where T<:Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
-            N = reinterpret(uinttype(T), N_float) % Int32
+    N = reinterpret(uinttype(T), N_float) % Int32
     N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
-            k = N >> 8
-            jU, jL = table_unpack(N&255 +1)
+    k = N >> 8
+    jU, jL = table_unpack(N&255 +1)
     small_part =  muladd(jU, expm1b_kernel(base, r), jL) + jU
 
     if !(abs(x) <= SUBNORM_EXP(base, T))
         x >= MAX_EXP(base, T) && return Inf
         x <= MIN_EXP(base, T) && return 0.0
-                if k <= -53
-                    # The UInt64 forces promotion. (Only matters for 32 bit systems.)
-                    twopk = (k + UInt64(53)) << 52
-                    return reinterpret(T, twopk + reinterpret(UInt64, small_part))*(2.0^-53)
-                end
-            end
-            twopk = Int64(k) << 52
-            return reinterpret(T, twopk + reinterpret(Int64, small_part))
+        if k <= -53
+            # The UInt64 forces promotion. (Only matters for 32 bit systems.)
+            twopk = (k + UInt64(53)) << 52
+            return reinterpret(T, twopk + reinterpret(UInt64, small_part))*(2.0^-53)
         end
+    end
+    twopk = Int64(k) << 52
+    return reinterpret(T, twopk + reinterpret(Int64, small_part))
+end
 
 @inline function exp_impl_fast(x::T,base) where T<:Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
@@ -231,7 +231,7 @@ end
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
     k = N >> 8
-    jU = reinterpret(Float64, JU_CONST | (@inbounds J_TABLE[k] & JU_MASK))
+    jU = reinterpret(Float64, JU_CONST | (@inbounds J_TABLE[N&255 + 1] & JU_MASK))
     small_part =  muladd(jU, expm1b_kernel(base, r), jU)
     twopk = Int64(k) << 52
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
@@ -239,22 +239,22 @@ end
 
 @inline function exp_impl(x::T, base) where T<:Float32
     N_float = round(x*LogBINV(base, T))
-            N = unsafe_trunc(Int32, N_float)
+    N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogBU(base, T), x)
     r = muladd(N_float, LogBL(base, T), r)
     small_part = expb_kernel(base, r)
     if !(abs(x) <= SUBNORM_EXP(base, T))
         x > MAX_EXP(base, T) && return Inf32
         x < MIN_EXP(base, T) && return 0.0f0
-                if N<=Int32(-24)
-                    twopk = reinterpret(T, (N+Int32(151)) << Int32(23))
-                    return (twopk*small_part)*(2f0^(-24))
-                end
-                N == (exponent_max(T)+1) && return small_part * T(2.0) * T(2.0)^exponent_max(T)
-            end
-            twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
-            return twopk*small_part
+        if N<=Int32(-24)
+            twopk = reinterpret(T, (N+Int32(151)) << Int32(23))
+            return (twopk*small_part)*(2f0^(-24))
         end
+        N == (exponent_max(T)+1) && return small_part * T(2.0) * T(2.0)^exponent_max(T)
+    end
+    twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
+    return twopk*small_part
+end
 
 @inline function exp_impl_fast(x::T, base) where T<:Float32
     N_float = round(x*LogBINV(base, T))
@@ -267,19 +267,19 @@ end
 end
 
 @inline function exp_impl(a::Float16, base)
-            T = Float32
-            x = T(a)
+    T = Float32
+    x = T(a)
     N_float = round(x*LogBINV(base, T))
-            N = unsafe_trunc(Int32, N_float)
+    N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogB(base, Float16), x)
     small_part = expb_kernel(base, r)
     if !(abs(x) <= SUBNORM_EXP(base, T))
         x > MAX_EXP(base, T) && return Inf16
-                N<=Int32(-24) && return zero(Float16)
-            end
-            twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
-            return Float16(twopk*small_part)
-        end
+        N<=Int32(-24) && return zero(Float16)
+    end
+    twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
+    return Float16(twopk*small_part)
+end
 
 for (func, fast_func, base) in ((:exp2,  :exp2_fast,  Val(2)),
                                 (:exp,   :exp_fast,   Val(:ℯ)), 
@@ -341,85 +341,3 @@ exp10(x)
         reinterpret(Float64, (exponent_bias(Float64) + (x % Int64)) << (significand_bits(Float64) % UInt))
     end
 end
-
-# min and max arguments by base and type
-MAX_EXP(::Type{Float64}) =  709.7827128933845   # log 2^1023*(2-2^-52)
-MIN_EXP(::Type{Float64}) = -37.42994775023705   # log 2^-54
-MAX_EXP(::Type{Float32}) =  88.72284f0          # log 2^127 *(2-2^-23)
-MIN_EXP(::Type{Float32}) = -17.32868f0          # log 2^-25
-
-Ln2INV(::Type{Float64}) = 1.4426950408889634
-Ln2(::Type{Float64}) = -0.6931471805599453
-
-# log(.75) <= x <= log(1.25)
-function expm1_small(x::Float32)
-    p = evalpoly(x, (0.16666666f0, 0.041666627f0, 0.008333682f0,
-                     0.0013908712f0, 0.0001933096f0))
-    p2 = exthorner(x, (1f0, .5f0, p))
-    return fma(x, p2[1], x*p2[2])
-end
-@inline function expm1_small(x::Float64)
-    p = evalpoly(x, (0.16666666666666632, 0.04166666666666556, 0.008333333333401227,
-                     0.001388888889068783, 0.00019841269447671544, 2.480157691845342e-5,
-                     2.7558212415361945e-6, 2.758218402815439e-7, 2.4360682937111612e-8))
-    p2 = exthorner(x, (1.0, .5, p))
-    return fma(x, p2[1], x*p2[2])
-end
-
-@inline function expm1(x::Float64)
-    T=Float64
-    if -0.2876820724517809 <= x <= 0.22314355131420976
-        return expm1_small(x)
-    elseif !(abs(x)<=MIN_EXP(Float64))
-        isnan(x) && return x
-        x > MAX_EXP(Float64) && return Inf
-        x < MIN_EXP(Float64) && return -1.0
-    end
-
-    N_float = muladd(x, LogBo256INV(Val(:ℯ), T), MAGIC_ROUND_CONST(T))
-    N = reinterpret(UInt64, N_float) % Int32
-    N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(Val(:ℯ), T))
-    r = muladd(N_float, LogBo256U(Val(:ℯ), T), x)
-    r = muladd(N_float, LogBo256L(Val(:ℯ), T), r)
-    k = Int64(N >> 8)
-    jU, jL = table_unpack(N&255 +1)
-    p = expm1b_kernel(Val(:ℯ), r)
-    twopk  = reinterpret(Float64, (1023+k) << 52)
-    twopnk = reinterpret(Float64, (1023-k) << 52)
-    k>=106 && return reinterpret(Float64, (1022+k) << 52)*(jU + muladd(jU, p, jL))*2
-    k>=53 && return twopk*(jU + muladd(jU, p, (jL-twopnk)))
-    k<=-2 && return twopk*(jU + muladd(jU, p, jL))-1
-    return twopk*((jU-twopnk) + fma(jU, p, jL))
-end
-
-@inline function expm1(x::Float32)
-    if -0.2876821f0 <=x <= 0.22314355f0
-        return expm1_small(x)
-    end
-    x = Float64(x)
-    N_float = round(x*Ln2INV(Float64))
-    N = unsafe_trunc(UInt64, N_float)
-    r = muladd(N_float, Ln2(Float64), x)
-    hi = evalpoly(r, (1.0, .5, 0.16666667546642386, 0.041666183019487026,
-                      0.008332997481506921, 0.0013966479175977883, 0.0002004037059220124))
-    small_part = r*hi
-    twopk = reinterpret(Float64, (N+1023) << 52)
-    x > MAX_EXP(Float32) && return Inf32
-    return Float32(muladd(twopk, small_part, twopk-1.0))
-end
-
-"""
-    expm1(x)
-
-Accurately compute ``e^x-1``. It avoids the loss of precision involved in the direct
-evaluation of exp(x)-1 for small values of x.
-# Examples
-```jldoctest
-julia> expm1(1e-16)
-1.0e-16
-
-julia> exp(1e-16) - 1
-0.0
-```
-"""
-expm1(x)

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -282,7 +282,7 @@ end
 end
 
 for (func, fast_func, base) in ((:exp2,  :exp2_fast,  Val(2)),
-                                (:exp,   :exp_fast,   Val(:ℯ)), 
+                                (:exp,   :exp_fast,   Val(:ℯ)),
                                 (:exp10, :exp10_fast, Val(10)))
     @eval begin
         $func(x::Union{Float16,Float32,Float64}) = exp_impl(x,$base)

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -285,8 +285,8 @@ for (func, fast_func, base) in ((:exp2,  :exp2_fast,  Val(2)),
                                 (:exp,   :exp_fast,   Val(:ℯ)),
                                 (:exp10, :exp10_fast, Val(10)))
     @eval begin
-        $func(x::Union{Float16,Float32,Float64}) = exp_impl(x,$base)
-        $fast_func(x::Union{Float32,Float64}) = exp_impl_fast(x,$base)
+        $func(x::Union{Float16,Float32,Float64}) = exp_impl(x, $base)
+        $fast_func(x::Union{Float32,Float64}) = exp_impl_fast(x, $base)
     end
 end
 

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -201,7 +201,8 @@ end
 # For both, a little extra care needs to be taken if b^r is subnormal.
 # The solution is to do the scaling back in 2 steps as just messing with the exponent wouldn't work.
 
-@inline function exp_impl(x::T, base) where T<:Float64
+@inline function exp_impl(x::Float64, base)
+    T = Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
     N = reinterpret(UInt64, N_float) % Int32
     N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
@@ -224,7 +225,8 @@ end
     twopk = Int64(k) << 52
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
 end
-@inline function exp_impl_fast(x::T,base) where T<:Float64
+@inline function exp_impl_fast(x::Float64, base)
+    T = Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
     N = reinterpret(UInt64, N_float) % Int32
     N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
@@ -237,7 +239,8 @@ end
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
 end
 
-@inline function exp_impl(x::T, base) where T<:Float32
+@inline function exp_impl(x::Float32, base)
+    T = Float32
     N_float = round(x*LogBINV(base, T))
     N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogBU(base, T), x)
@@ -256,7 +259,8 @@ end
     return twopk*small_part
 end
 
-@inline function exp_impl_fast(x::T, base) where T<:Float32
+@inline function exp_impl_fast(x::Float32, base)
+    T = Float32
     N_float = round(x*LogBINV(base, T))
     N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogBU(base, T), x)
@@ -368,7 +372,7 @@ end
 end
 
 @inline function expm1(x::Float64)
-    T=Float64
+    T = Float64
     if -0.2876820724517809 <= x <= 0.22314355131420976
         return expm1_small(x)
     elseif !(abs(x)<=MIN_EXP(Float64))

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -9,7 +9,7 @@ MAGIC_ROUND_CONST(::Type{Float32}) = 1.048576f7
 MAX_EXP(n::Val{2}, ::Type{Float32}) = 128.0f0
 MAX_EXP(n::Val{2}, ::Type{Float64}) = 1024.0
 MAX_EXP(n::Val{:ℯ}, ::Type{Float32}) = 88.72284f0
-MAX_EXP(n::Val{:ℯ}, ::Type{Float64}) = 709.782712893384
+MAX_EXP(n::Val{:ℯ}, ::Type{Float64}) = 709.7827128933841
 MAX_EXP(n::Val{10}, ::Type{Float32}) = 38.53184f0
 MAX_EXP(n::Val{10}, ::Type{Float64}) = 308.25471555991675
 
@@ -203,12 +203,12 @@ end
 
 @inline function exp_impl(x::T, base) where T<:Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
-    N = reinterpret(uinttype(T), N_float) % Int32
+    N = reinterpret(UInt64, N_float) % Int32
     N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
     k = N >> 8
-    jU, jL = table_unpack(N&255 +1)
+    jU, jL = table_unpack(N&255 + 1)
     small_part =  muladd(jU, expm1b_kernel(base, r), jL) + jU
 
     if !(abs(x) <= SUBNORM_EXP(base, T))
@@ -219,14 +219,14 @@ end
             twopk = (k + UInt64(53)) << 52
             return reinterpret(T, twopk + reinterpret(UInt64, small_part))*(2.0^-53)
         end
+        #k == 1024 && return (small_part * 2.0) * 2.0^1023
     end
     twopk = Int64(k) << 52
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
 end
-
 @inline function exp_impl_fast(x::T,base) where T<:Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
-    N = reinterpret(uinttype(T), N_float) % Int32
+    N = reinterpret(UInt64, N_float) % Int32
     N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
@@ -250,7 +250,7 @@ end
             twopk = reinterpret(T, (N+Int32(151)) << Int32(23))
             return (twopk*small_part)*(2f0^(-24))
         end
-        N == (exponent_max(T)+1) && return small_part * T(2.0) * T(2.0)^exponent_max(T)
+        N == 128 && return small_part * T(2.0) * T(2.0)^127
     end
     twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
     return twopk*small_part
@@ -289,6 +289,7 @@ for (func, fast_func, base) in ((:exp2,  :exp2_fast,  Val(2)),
         $fast_func(x::Union{Float32,Float64}) = exp_impl_fast(x,$base)
     end
 end
+
 @doc """
     exp(x)
 
@@ -341,3 +342,85 @@ exp10(x)
         reinterpret(Float64, (exponent_bias(Float64) + (x % Int64)) << (significand_bits(Float64) % UInt))
     end
 end
+
+# min and max arguments by base and type
+MAX_EXP(::Type{Float64}) =  709.7827128933845   # log 2^1023*(2-2^-52)
+MIN_EXP(::Type{Float64}) = -37.42994775023705   # log 2^-54
+MAX_EXP(::Type{Float32}) =  88.72284f0          # log 2^127 *(2-2^-23)
+MIN_EXP(::Type{Float32}) = -17.32868f0          # log 2^-25
+
+Ln2INV(::Type{Float64}) = 1.4426950408889634
+Ln2(::Type{Float64}) = -0.6931471805599453
+
+# log(.75) <= x <= log(1.25)
+function expm1_small(x::Float32)
+    p = evalpoly(x, (0.16666666f0, 0.041666627f0, 0.008333682f0,
+                     0.0013908712f0, 0.0001933096f0))
+    p2 = exthorner(x, (1f0, .5f0, p))
+    return fma(x, p2[1], x*p2[2])
+end
+@inline function expm1_small(x::Float64)
+    p = evalpoly(x, (0.16666666666666632, 0.04166666666666556, 0.008333333333401227,
+                     0.001388888889068783, 0.00019841269447671544, 2.480157691845342e-5,
+                     2.7558212415361945e-6, 2.758218402815439e-7, 2.4360682937111612e-8))
+    p2 = exthorner(x, (1.0, .5, p))
+    return fma(x, p2[1], x*p2[2])
+end
+
+@inline function expm1(x::Float64)
+    T=Float64
+    if -0.2876820724517809 <= x <= 0.22314355131420976
+        return expm1_small(x)
+    elseif !(abs(x)<=MIN_EXP(Float64))
+        isnan(x) && return x
+        x > MAX_EXP(Float64) && return Inf
+        x < MIN_EXP(Float64) && return -1.0
+    end
+
+    N_float = muladd(x, LogBo256INV(Val(:ℯ), T), MAGIC_ROUND_CONST(T))
+    N = reinterpret(UInt64, N_float) % Int32
+    N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(Val(:ℯ), T))
+    r = muladd(N_float, LogBo256U(Val(:ℯ), T), x)
+    r = muladd(N_float, LogBo256L(Val(:ℯ), T), r)
+    k = Int64(N >> 8)
+    jU, jL = table_unpack(N&255 +1)
+    p = expm1b_kernel(Val(:ℯ), r)
+    twopk  = reinterpret(Float64, (1023+k) << 52)
+    twopnk = reinterpret(Float64, (1023-k) << 52)
+    k>=106 && return reinterpret(Float64, (1022+k) << 52)*(jU + muladd(jU, p, jL))*2
+    k>=53 && return twopk*(jU + muladd(jU, p, (jL-twopnk)))
+    k<=-2 && return twopk*(jU + muladd(jU, p, jL))-1
+    return twopk*((jU-twopnk) + fma(jU, p, jL))
+end
+
+@inline function expm1(x::Float32)
+    if -0.2876821f0 <=x <= 0.22314355f0
+        return expm1_small(x)
+    end
+    x = Float64(x)
+    N_float = round(x*Ln2INV(Float64))
+    N = unsafe_trunc(UInt64, N_float)
+    r = muladd(N_float, Ln2(Float64), x)
+    hi = evalpoly(r, (1.0, .5, 0.16666667546642386, 0.041666183019487026,
+                      0.008332997481506921, 0.0013966479175977883, 0.0002004037059220124))
+    small_part = r*hi
+    twopk = reinterpret(Float64, (N+1023) << 52)
+    x > MAX_EXP(Float32) && return Inf32
+    return Float32(muladd(twopk, small_part, twopk-1.0))
+end
+
+"""
+    expm1(x)
+
+Accurately compute ``e^x-1``. It avoids the loss of precision involved in the direct
+evaluation of exp(x)-1 for small values of x.
+# Examples
+```jldoctest
+julia> expm1(1e-16)
+1.0e-16
+
+julia> exp(1e-16) - 1
+0.0
+```
+"""
+expm1(x)


### PR DESCRIPTION
It turns out that my improvements to `exp` and the rest of the scalar special functions mean that the libm versions `@fastmath` called were actually worse. This removes the old methods. Also, this slightly refactors the `exp` family of functions, and introduces dedicated `fast` versions that don't bother with the bounds checks and are a tiny bit less accurate. This PR also allows defining `^(x::Float32,y::Float32)=@fastmath Float32(exp2(log2(Float64(x))*y))`, which is a `pow` method faster and more accurate than what 1.5 used.