### PR TITLE
Tweak stacktrace printing to increase prominence of filename:line info

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -735,16 +735,8 @@ function print_stackframe(io, i, frame::StackFrame, n::Int, digit_align_width, m
         printstyled(io, joinpath(folderparts...) * (Sys.iswindows() ? "\\" : "/"), color = :light_black)
     end
 
-    # filename, separator, line
-    # use escape codes for formatting, printstyled can't do underlined and color
-    # codes are bright black (90) and underlined (4)
-    function print_underlined(io::IO, s...)
-        colored = get(io, :color, false)::Bool
-        start_s = colored ? "\033[90;4m" : ""
-        end_s   = colored ? "\033[0m"    : ""
-        print(io, start_s, s..., end_s)
-    end
-    print_underlined(io, pathparts[end], ":", line)
+    # filename, separator, line; use more prominent color than the rest of the filepath
+    printstyled(io, pathparts[end], ":", line; color=:normal)
 
     # inlined
     printstyled(io, inlined ? " [inlined]" : "", color = :light_black)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -736,7 +736,7 @@ function print_stackframe(io, i, frame::StackFrame, n::Int, digit_align_width, m
     end
 
     # filename, separator, line; use more prominent color than the rest of the filepath
-    printstyled(io, pathparts[end], ":", line; color=:normal)
+    printstyled(io, pathparts[end], ":", line; color=:underline)
 
     # inlined
     printstyled(io, inlined ? " [inlined]" : "", color = :light_black)


### PR DESCRIPTION
Closes #40228 

I think this would be a good resolution to #40228, but there are other options e.g. we could instead increase the configurability of printing, which we could discuss in #40228. Opening this to give us a concrete option (which i hope will be a minimally invasive one and help us avoid an extensive bikeshedding as i appreciate that a lot of thought has already gone into this).

This changes the display of the `~/path/to/filename:line` from `filename:line` being underlined in `:light_black` to be displayed in the `:normal` color, thereby still giving it more importance that the rest of the filepath, while (hopefully) making it easier to read, and simplifying the UI by reducing the number of different grey-styles we have (from 4 to 3).


## Dark theme example

### Before 
<img width="843" alt="Screenshot 2021-03-27 at 12 48 49" src="https://user-images.githubusercontent.com/13448787/112721311-1b3f4980-8efb-11eb-8b22-a3645955e468.png">

### After 
<img width="841" alt="Screenshot 2021-03-27 at 12 34 28" src="https://user-images.githubusercontent.com/13448787/112721327-2abe9280-8efb-11eb-950d-13f2bbb08816.png">

## Light Theme example
### Before 
<img width="843" alt="Screenshot 2021-03-27 at 12 58 21" src="https://user-images.githubusercontent.com/13448787/112721531-39f21000-8efc-11eb-9531-e16458ffab9e.png">

### After
<img width="839" alt="Screenshot 2021-03-27 at 12 58 43" src="https://user-images.githubusercontent.com/13448787/112721538-44aca500-8efc-11eb-89ad-cc8edd083b86.png">
