### PR TITLE
Add ENV variables for disabling colour stacktrace printing

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -570,6 +570,8 @@ stacktrace_linebreaks()::Bool =
     tryparse(Bool, get(ENV, "JULIA_STACKTRACE_LINEBREAKS", "false")) === true
 stacktrace_color_lines()::Bool =
     tryparse(Bool, get(ENV, "JULIA_STACKTRACE_COLOR_LINES", "true")) === true
+stacktrace_color_modules()::Bool =
+    tryparse(Bool, get(ENV, "JULIA_STACKTRACE_COLOR_MODULES", "true")) === true
 
 stacktrace_line_color() = stacktrace_color_lines() ? :light_black : :normal
 
@@ -682,7 +684,7 @@ end
 # from `modulecolorcycler`.
 function print_stackframe(io, i, frame::StackFrame, n::Int, digit_align_width, modulecolordict, modulecolorcycler)
     m = Base.parentmodule(frame)
-    if m !== nothing
+    if m !== nothing && stacktrace_color_modules()
         while parentmodule(m) !== m
             pm = parentmodule(m)
             pm == Main && break

--- a/base/show.jl
+++ b/base/show.jl
@@ -2274,7 +2274,7 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type;
         first || print(io, ", ")
         first = false
         if show_argnames
-            print_within_stacktrace(io, argnames[i]; color=:light_black)
+            print_within_stacktrace(io, argnames[i]; color=stacktrace_line_color())
         end
         print(io, "::")
         print_type_stacktrace(env_io, sig[i])
@@ -2285,7 +2285,7 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type;
         for (k, t) in kwargs
             first || print(io, ", ")
             first = false
-            print_within_stacktrace(io, k; color=:light_black)
+            print_within_stacktrace(io, k; color=stacktrace_line_color())
             print(io, "::")
             print_type_stacktrace(io, t)
         end
@@ -2302,7 +2302,7 @@ function print_type_stacktrace(io, type; color=:normal)
         printstyled(io, str; color=color)
     else
         printstyled(io, str[1:prevind(str,i)]; color=color)
-        printstyled(io, str[i:end]; color=:light_black)
+        printstyled(io, str[i:end]; color=stacktrace_line_color())
     end
 end
 


### PR DESCRIPTION
Alternative option for closing #40228 (alternative to #40230)

Essentially I'd like to avoid the new `light_black` colour stacktrace printing which I find I can't really read, without having the run with `julia --color=no`

Couple comments on the approach: 
- how many env variables might we end up needing here?
   - i've gone for two: 1 for the color printing of modules + 1 for the color printing of the location. Seems the simplest way to split up the options and close #40228 ...I'd also be happy to remove the one for disabling module color, since that's not (yet) been requested.
   - (but we could have e.g. three: 1 for modules + 1 for the arguments + 1 for the location).
- should these be binary true/false or allow custom colours?
   - i've gone for binary true/false. Again, seems simplest. Also matches the existing `JULIA_STACKTRACE_*` variables.
      - by default (`true`) you get the color printing that Base sets
      - by setting `false` you can disable the color printing, recovering something very similar to the printing for Julia v1.0 - v1.5,
   - If we wanted to allow specifying colours we'd have to figure out how, and i don't have a use-case for that, and it seems more like the role of an external package anyway.

If this kind of solution seems acceptable, then i'd appreciate advice on what exactly should be included (i.e. places where the colour should be disabled by this flag), as i think the printing can be fairly complex (it's easy to miss a place).

## Example

### Default 
<img width="843" alt="Screenshot 2021-03-27 at 12 48 49" src="https://user-images.githubusercontent.com/13448787/112723828-6b70d880-8f08-11eb-9226-38d67d7f34f6.png">

### With `ENV["JULIA_STACKTRACE_COLOR_LINES"] = false`
<img width="759" alt="Screenshot 2021-03-27 at 17 13 41" src="https://user-images.githubusercontent.com/13448787/112728574-e72a4f80-8f1f-11eb-8225-bcefc79794dd.png">

### With `ENV["JULIA_STACKTRACE_COLOR_MODULES"] = false` too

<img width="768" alt="Screenshot 2021-03-27 at 17 14 04" src="https://user-images.githubusercontent.com/13448787/112728578-ea254000-8f1f-11eb-8670-207cc3c05458.png">