### PR TITLE
don't use realpath in Sys.which

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -516,7 +516,7 @@ function which(program_name::String)
             program_path = joinpath(path_dir, pname)
             # If we find something that matches our name and we can execute
             if isfile(program_path) && isexecutable(program_path)
-                return realpath(program_path)
+                return program_path
             end
         end
     end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -582,8 +582,8 @@ end
 psep = if Sys.iswindows() ";" else ":" end
 withenv("PATH" => "$(Sys.BINDIR)$(psep)$(ENV["PATH"])") do
     julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
-    @test Sys.which("julia") == realpath(julia_exe)
-    @test Sys.which(julia_exe) == realpath(julia_exe)
+    @test Sys.which("julia") == abspath(julia_exe)
+    @test Sys.which(julia_exe) == abspath(julia_exe)
 end
 
 # Check that which behaves correctly when passed an empty string
@@ -598,8 +598,8 @@ mktempdir() do dir
         touch(foo_path)
         chmod(foo_path, 0o777)
         if !Sys.iswindows()
-            @test Sys.which("foo") == realpath(foo_path)
-            @test Sys.which(foo_path) == realpath(foo_path)
+            @test Sys.which("foo") == abspath(foo_path)
+            @test Sys.which(foo_path) == abspath(foo_path)
 
             chmod(foo_path, 0o666)
             @test Sys.which("foo") === nothing
@@ -636,20 +636,20 @@ mktempdir() do dir
         touch(foo2_path)
         chmod(foo1_path, 0o777)
         chmod(foo2_path, 0o777)
-        @test Sys.which("foo") == realpath(foo1_path)
+        @test Sys.which("foo") == abspath(foo1_path)
 
         # chmod() doesn't change which() on Windows, so don't bother to test that
         if !Sys.iswindows()
             chmod(foo1_path, 0o666)
-            @test Sys.which("foo") == realpath(foo2_path)
+            @test Sys.which("foo") == abspath(foo2_path)
             chmod(foo1_path, 0o777)
         end
 
         if Sys.iswindows()
             # On windows, check that pwd() takes precedence, except when we provide a path
             cd(joinpath(dir, "bin2")) do
-                @test Sys.which("foo") == realpath(foo2_path)
-                @test Sys.which(foo1_path) == realpath(foo1_path)
+                @test Sys.which("foo") == abspath(foo2_path)
+                @test Sys.which(foo1_path) == abspath(foo1_path)
             end
         end
 
@@ -662,7 +662,7 @@ mktempdir() do dir
         touch(bar_path)
         chmod(bar_path, 0o777)
         cd(dir) do
-            @test Sys.which(joinpath("bin1", "bar")) == realpath(bar_path)
+            @test Sys.which(joinpath("bin1", "bar")) == abspath(bar_path)
         end
     end
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -663,7 +663,7 @@ mktempdir() do dir
         chmod(bar_path, 0o777)
         cd(dir) do
             p = Sys.which(joinpath("bin1", "bar"))
-            @test p == joinpath(abspath("bin1"), basename(bar_path))
+            @test p == abspath("bin1", basename(bar_path))
             @test Base.samefile(p, bar_path)
         end
     end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -664,7 +664,7 @@ mktempdir() do dir
         cd(dir) do
             p = Sys.which(joinpath("bin1", "bar"))
             @test p == joinpath(abspath("bin1"), "bar")
-            @test realpath(p) == realpath(bar_path)
+            @test Base.samefile(p, bar_path)
         end
     end
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -663,7 +663,7 @@ mktempdir() do dir
         chmod(bar_path, 0o777)
         cd(dir) do
             p = Sys.which(joinpath("bin1", "bar"))
-            @test p == joinpath(abspath("bin1"), "bar")
+            @test p == joinpath(abspath("bin1"), Sys.iswindows() ? "bar.exe" : "bar")
             @test Base.samefile(p, bar_path)
         end
     end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -662,7 +662,9 @@ mktempdir() do dir
         touch(bar_path)
         chmod(bar_path, 0o777)
         cd(dir) do
-            @test Sys.which(joinpath("bin1", "bar")) == abspath(bar_path)
+            p = Sys.which(joinpath("bin1", "bar"))
+            @test p == joinpath(abspath("bin1"), "bar")
+            @test realpath(p) == realpath(bar_path)
         end
     end
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -663,7 +663,7 @@ mktempdir() do dir
         chmod(bar_path, 0o777)
         cd(dir) do
             p = Sys.which(joinpath("bin1", "bar"))
-            @test p == joinpath(abspath("bin1"), Sys.iswindows() ? "bar.exe" : "bar")
+            @test p == joinpath(abspath("bin1"), basename(bar_path))
             @test Base.samefile(p, bar_path)
         end
     end


### PR DESCRIPTION
As [discussed recently on discourse](https://discourse.julialang.org/t/weird-sys-which-function/58070), some programs require a certain executable name to function correctly, and behave badly if you call `realpath` to expand symbolic links (potentially changing the program name).

#26559 by @staticfloat implemented `Sys.which`, but there doesn't seem to have been any discussion about whether `realpath` was a good idea.