### PR TITLE
faster Float32 and Float16 pow

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -867,13 +867,19 @@ end
     z
 end
 @inline function ^(x::Float32, y::Float32)
-    z = ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, y)
+    z = Float32(exp2_fast(log2(Float64(x))*y))
     if isnan(z) & !isnan(x+y)
         throw_exp_domainerror(x)
     end
     z
 end
-@inline ^(x::Float16, y::Float16) = Float16(Float32(x)^Float32(y))  # TODO: optimize
+@inline function ^(x::Float16, y::Float16)
+    z = Float16(exp2_fast(log2(Float32(x))*y))
+    if isnan(z) & !isnan(x+y)
+        throw_exp_domainerror(x)
+    end
+    z
+end
 
 @inline function ^(x::Float64, y::Integer)
     y == -1 && return inv(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -887,7 +887,7 @@ end
     y == 1 && return x
     y == 2 && return x*x
     y == 3 && return x*x*x
-    ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, Float64(y))
+    return x^Float64(y)
 end
 @inline function ^(x::Float32, y::Integer)
     y == -1 && return inv(x)
@@ -895,7 +895,7 @@ end
     y == 1 && return x
     y == 2 && return x*x
     y == 3 && return x*x*x
-    ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, Float32(y))
+    x^Float32(y)
 end
 @inline ^(x::Float16, y::Integer) = Float16(Float32(x) ^ y)
 @inline literal_pow(::typeof(^), x::Float16, ::Val{p}) where {p} = Float16(literal_pow(^,Float32(x),Val(p)))


### PR DESCRIPTION
Returns `Float32` speed to roughly the speed of 1.5. Also speeds up `Float16` pow. These new methods are .5 ULP (from limited testing). There is further room to optimize these, but this fixes the regression. At some point, I hope to have a `Float64` version, but that will be much harder as it requires a `log2` function that gives extra bits of precision, and an `exp2` function that takes in a `Double Double`