### PR TITLE
Reinstate support for merging modules with non-const globals.

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -944,8 +944,7 @@ void jl_merge_module(Module *dest, std::unique_ptr<Module> src)
             //    continue;
             //}
             else {
-                assert(dG->isDeclaration() || (dG->getInitializer() == sG->getInitializer() &&
-                            dG->isConstant() && sG->isConstant()));
+                assert(dG->isDeclaration() || dG->getInitializer() == sG->getInitializer());
                 dG->replaceAllUsesWith(sG);
                 dG->eraseFromParent();
             }


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/36260 introduced a change in `jl_merge_modules`, now requiring const-ness of global variable declarations:
https://github.com/JuliaLang/julia/blob/40267bb03d9a6fa3406d84ed3a932e1f55b3cb4d/src/jitlayers.cpp#L947-L948

Meanwhile, in GPU land we don't really have proper globals (suggestions on how to implement those are appreciated, but with NVPTX we can't use LLVM's JITs), so we use functions emitting `weak` GVs to emulate globals like such:

```julia
@eval @inline exception_flag() =
    Base.llvmcall(
        $("""@exception_flag = weak externally_initialized global i$(WORD_SIZE) 0
             define i64 @entry() #0 {
                 %ptr = load i$(WORD_SIZE), i$(WORD_SIZE)* @exception_flag, align 8
                 ret i$(WORD_SIZE) %ptr
             }
             attributes #0 = { alwaysinline }
          """, "entry"), Ptr{Cvoid}, Tuple{})
```

We can have multiple calls to these kind of functions, emitting duplicate globals, which LLVM's IRMover happily links together when we finish emitting a function:
https://github.com/JuliaLang/julia/blob/40267bb03d9a6fa3406d84ed3a932e1f55b3cb4d/src/codegen.cpp#L7380-L7387

However, when the calls originate from different methods, `jl_compile_workqueue` ends up calling `jl_merge_modules` which doesn't support linking these together, triggering the assertion at the top of this issue instead.

Solutions that come to mind:

- relax the assertion (this PR): I assume this would be the simplest change, especially wrt. backporting for 1.6.1
- switch `jl_merge_modules` over to LLVM's IRMover, although there's probably a reason we aren't already doing that (@vtjnash?)
- emit globals differently: suggestions welcome.

I do realize that the assertion is specific to how Base Julia emits LLVM global variables, but it'd be nice to get existing code working again, and I'm happy to work on a better fix after that.