### PR TITLE
docs: clarification about the integer division with 'div'

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -5,8 +5,8 @@
 """
     div(x, y, r::RoundingMode=RoundToZero)
 
-The quotient from Euclidean division. Computes x/y, rounded to an integer according
-to the rounding mode `r`. In other words, the quantity
+The quotient from Euclidean (integer) division. Computes x/y, rounded to
+an integer according to the rounding mode `r`. In other words, the quantity
 
     round(x/y,r)
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -803,7 +803,8 @@ const % = rem
     div(x, y)
     ÷(x, y)
 
-The quotient from Euclidean division. Computes `x/y`, truncated to an integer.
+The quotient from Euclidean (integer) division. Generally equivalent
+to a mathematical operation x/y without a fractional part.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Clarification of the documentation for the `div` operation to avoid confusion with `trunc(Int, x/y)`