### PR TITLE
Only allow dotted quad IPv4 addresses

### DIFF
--- a/stdlib/Sockets/src/IPAddr.jl
+++ b/stdlib/Sockets/src/IPAddr.jl
@@ -197,6 +197,9 @@ function parse(::Type{IPv4}, str::AbstractString)
     fields = split(str,'.')
     i = 1
     ret = 0
+    if length(fields) != 4
+        throw(ArgumentError("IPv4 addresses must be specified as a dotted quad"))
+    end
     for f in fields
         if isempty(f)
             throw(ArgumentError("empty field in IPv4 address"))
@@ -206,17 +209,10 @@ function parse(::Type{IPv4}, str::AbstractString)
         else
             r = parse(Int, f, base = 10)
         end
-        if i != length(fields)
-            if r < 0 || r > 255
-                throw(ArgumentError("IPv4 field out of range (must be 0-255)"))
-            end
-            ret |= UInt32(r) << ((4-i)*8)
-        else
-            if r > ((UInt64(1)<<((5-length(fields))*8))-1)
-                throw(ArgumentError("IPv4 field too large"))
-            end
-            ret |= r
+        if r < 0 || r > 255
+            throw(ArgumentError("IPv4 field out of range (must be 0-255)"))
         end
+        ret |= UInt32(r) << ((4-i)*8)
         i+=1
     end
     IPv4(ret)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -34,7 +34,6 @@ sockets_watchdog_timer = Timer(t -> killjob("KILLING BY SOCKETS TEST WATCHDOG\n"
 
 @testset "parsing" begin
     @test ip"127.0.0.1" == IPv4(127,0,0,1)
-    @test ip"192.0" == IPv4(192,0,0,0)
 
     # These used to work, but are now disallowed. Check that they error
     @test_throws ArgumentError parse(IPv4, "192.0xFFF") # IPv4(192,0,15,255)
@@ -42,6 +41,7 @@ sockets_watchdog_timer = Timer(t -> killjob("KILLING BY SOCKETS TEST WATCHDOG\n"
     @test_throws ArgumentError parse(IPv4, "192.0xFFFFF") # IPv4(192,15,255,255)
     @test_throws ArgumentError parse(IPv4, "192.0xFFFFFF") # IPv4(192,255,255,255)
     @test_throws ArgumentError parse(IPv4, "022.0.0.1") # IPv4(18,0,0,1)
+    @test_throws ArgumentError parse(IPv4, "192.0") # IPv4(192,0,0,0)
 
     @test UInt(IPv4(0x01020304)) == 0x01020304
     @test Int(IPv4("1.2.3.4")) == Int(0x01020304) == Int32(0x01020304)


### PR DESCRIPTION
See #40255

This commit makes Class A addresses a parse error in Julia because they
are probably not what the user wanted anyway.