### PR TITLE
Make some constructors bold in stacktraces

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2226,7 +2226,7 @@ function show_signature_function(io::IO, @nospecialize(ft), demangle=false, farg
         uwf = unwrap_unionall(f)
         parens = isa(f, UnionAll) && !(isa(uwf, DataType) && f === uwf.name.wrapper)
         parens && print(io, "(")
-        show(io, f)
+        print_within_stacktrace(io, f, bold=true)
         parens && print(io, ")")
     else
         if html


### PR DESCRIPTION
In the 1.6 stack trace printing, some constructors aren't printed in bold, unlike most function names. 

The problem can be seen with `Matrix{Int}([1 2; 3 4.5])` from here: https://github.com/JuliaLang/julia/pull/37773#issuecomment-716147263, or `using DataFrames; DataFrame(1 => 2)` from here: https://github.com/JuliaLang/julia/issues/40228 (with pictures).

This should be a minimal repair. I believe it ought not to change any other behaviour. 