### PR TITLE
Use BINARY=64 on aarch64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -898,6 +898,7 @@ ifneq (,$(findstring aarch64,$(ARCH)))
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
 USE_BLAS64:=1
+BINARY:=64
 ifeq ($(OS),Darwin)
 # Apple Chips are all at least A12Z
 MCPU:=apple-a12


### PR DESCRIPTION
Fix #39612

Note that this will pick ILP64 for openblas when built from source (which we are already doing in Yggdrasil now), and is a good enough reason to merge this PR.

Currently, the `-m64` flag only gets passed on `x86_64`: https://github.com/JuliaLang/julia/blob/6fe0827ba48a135caa5bc32308aa7e1ffb43486e/Make.inc#L951

Do we want `-m64` on `aarch64` and `ppc64le`? 