### PR TITLE
Fix CI: Revert "[Libdl] Use RTLD_NOLOAD when calling dlpath(::String) (#39676)"

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -237,9 +237,10 @@ julia> dlpath("libjulia")
 ```
 """
 function dlpath(libname::Union{AbstractString, Symbol})
-    dlopen(libname, RTLD_NOLOAD) do handle
-        return dlpath(handle)
-    end
+    handle = dlopen(libname)
+    path = dlpath(handle)
+    dlclose(handle)
+    return path
 end
 
 if Sys.isapple()


### PR DESCRIPTION
This reverts commit 514426d3fd2723c6ddfc33444bfc23891c55454d since it is broken on CI, and seems possibly to be a breaking change. This may be a beneficial, and even a desirable change, but it changes how this function operates, and macOS is unexpectedly more strict about this (relative to gnulib).