### PR TITLE
add a missing propagate_inbounds to a getindex method

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1170,7 +1170,7 @@ function getindex(A::AbstractArray, I...)
     _getindex(IndexStyle(A), A, to_indices(A, I)...)
 end
 # To avoid invalidations from multidimensional.jl: getindex(A::Array, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...)
-getindex(A::Array, i1::Integer, I::Integer...) = A[to_indices(A, (i1, I...))...]
+@propagate_inbounds getindex(A::Array, i1::Integer, I::Integer...) = A[to_indices(A, (i1, I...))...]
 
 function unsafe_getindex(A::AbstractArray, I...)
     @_inline_meta

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -251,5 +251,10 @@ if bc_opt == bc_default || bc_opt == bc_off
     @test occursin("vector.body", sprint(code_llvm, g27079, Tuple{Vector{Int}}))
 end
 
+# Boundschecking removal of indices with different type, see #40281
+getindex_40281(v, a, b, c) = @inbounds getindex(v, a, b, c)
+typed_40281 = sprint((io, args...) -> code_warntype(io, args...; optimize=true), getindex_40281, Tuple{Array{Float64, 3}, Int, UInt8, Int})
+@test occursin("arrayref(false", typed_40281)
+@test !occursin("arrayref(true", typed_40281)
 
 end

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -254,7 +254,9 @@ end
 # Boundschecking removal of indices with different type, see #40281
 getindex_40281(v, a, b, c) = @inbounds getindex(v, a, b, c)
 typed_40281 = sprint((io, args...) -> code_warntype(io, args...; optimize=true), getindex_40281, Tuple{Array{Float64, 3}, Int, UInt8, Int})
-@test occursin("arrayref(false", typed_40281)
-@test !occursin("arrayref(true", typed_40281)
+if bc_opt == bc_default || bc_opt == bc_off
+    @test occursin("arrayref(false", typed_40281)
+    @test !occursin("arrayref(true", typed_40281)
+end
 
 end


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/36427, many changes were made to reduce the number of invalidations during Julia bootstrap. One of them was the addition of this method:

https://github.com/JuliaLang/julia/blob/c0f8aef3bfcf59699ee0f4db46f183fcd8dde0c1/base/abstractarray.jl#L1172-L1173

This method lacks a `@propagate_inbounds` which leads to some performance degradation. This was for example reported in https://discourse.julialang.org/t/drop-of-performances-with-julia-1-6-0-for-interpolationkernels/58085/33?u=kristoffer.carlsson.
