### PR TITLE
fix macro hygiene for `@nospecialize(::T)`

### DIFF
--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -210,7 +210,8 @@
         ((atom? v) '())
         (else
          (case (car v)
-           ((... kw |::| =) (try-arg-name (cadr v)))
+           ((|::|) (if (length= v 2) '() (try-arg-name (cadr v))))
+           ((... kw =) (try-arg-name (cadr v)))
            ((escape) (list v))
            ((hygienic-scope) (try-arg-name (cadr v)))
            ((meta)  ;; allow certain per-argument annotations

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2771,3 +2771,9 @@ end
 
 @test eval(Expr(:string, "a", Expr(:string, "b", "c"))) == "abc"
 @test eval(Expr(:string, "a", Expr(:string, "b", Expr(:string, "c")))) == "abc"
+
+macro m_nospecialize_unnamed_hygiene()
+    return :(f(@nospecialize(::Any)) = Any)
+end
+
+@test @m_nospecialize_unnamed_hygiene()(1) === Any


### PR DESCRIPTION
This was accidentally recognizing `T` as a new binding.