### PR TITLE
Indexing is function evaluation: `f[A,B,C]` for orthogonal broadcasts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ New language features
 
 * `(; a, b) = x` can now be used to destructure properties `a` and `b` of `x`. This syntax is equivalent to `a = getproperty(x, :a)`
   and similarly for `b`. ([#39285])
+* `f[A, B, Cs...]` can now be used to evaluate the function `f` over the cartesian product of the arguments `A, B, Cs...` akin
+  to how indexing behaves. ([#])
 
 Language changes
 ----------------

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -10,11 +10,14 @@ module Broadcast
 using .Base.Cartesian
 using .Base: Indices, OneTo, tail, to_shape, isoperator, promote_typejoin, @pure,
              _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache, unalias
-import .Base: copy, copyto!, axes
+import .Base: copy, copyto!, axes, getindex
 export broadcast, broadcast!, BroadcastStyle, broadcast_axes, broadcastable, dotview, @__dot__, broadcast_preserving_zero_d, BroadcastFunction
 
 ## Computing the result's axes: deprecated name
 const broadcast_axes = axes
+
+### Orthoganol broadcast f[X,Y,Z]
+getindex(f::Function, args...) = broadcast(Base.splat(f), Iterators.product(args...))
 
 ### Objects with customized broadcasting behavior should declare a BroadcastStyle
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -922,6 +922,15 @@ julia> [1:5;] .|> [x->x^2, inv, x->2*x, -, isodd]
  true
 ```
 
+## [Function calls with orthogonal indexing](@id man-orthogonal-functions)
+
+Just as indexing into an array computes the orthogonal (cartesian) product of the indices to
+evaluate for [non scalar indexing](@ref man-indexing), the indexing syntax `f[A, B, C...]` may
+be used to evaluate the function `f` over the orthogonal product the arguments `A, B, C...`.
+
+This is the beautiful combination of indexing and broadcast in one succinct syntax.
+
+
 ## Further Reading
 
 We should mention here that this is far from a complete picture of defining functions. Julia has

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1015,3 +1015,11 @@ end
         @test a_ == dropdims(a .* c, dims=(findall(==(1), size(c))...,))
     end
 end
+
+@testset "indexing is orthoganol broadcasted function evaluation" begin
+    @test (+)[1:10, 1:10] == (1:10) .+ transpose(1:10)
+    @test (*)[.1:.1:1, 1:10] == (.1:.1:1) .* transpose(1:10)
+    @test sin[[pi,-pi,0]] == sin.([pi, -pi, 0])
+    A = rand(3, 4)
+    @test tuple[1:2, A] == tuple.(1:2, reshape(A, 1, 3, 4))
+end


### PR DESCRIPTION
`f[A, B, Cs...]` can now be used to evaluate the function `f` over the cartesian product of the arguments `A, B, Cs...` akin
  to how indexing behaves.

Long have we wanted the ability to broadcast over orthogonal (Cartesian) products of the arguments, and while we've thought about making indexing behave more like broadcasting, it somehow never occurred to us that we should go the other way!  This PR implements `f[A,B,C]` to evaluate `f` in the manner that indexing would index (with APL-style dim-sum Cartesian products)!

For example, we can create the times table quite simply:

```Julia
julia> (*)[1:4, 1:10]
4×10 Matrix{Int64}:
 1  2   3   4   5   6   7   8   9  10
 2  4   6   8  10  12  14  16  18  20
 3  6   9  12  15  18  21  24  27  30
 4  8  12  16  20  24  28  32  36  40
```

But of course we're not limited to arrays of integers or even numbers:

```Julia
julia> occursin[["a","b"],["foo","bar","baz","boo"]]
2×4 BitMatrix:
 0  1  1  0
 0  1  1  1
```

In this case, broadcasting would be especially awkward since we can't use `["foo"]'`.

Indexing is the **one r**ea**l API**.  Let's use it everywhere.