### PR TITLE
Add remarks about the abs2 function

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -465,7 +465,7 @@ sum(A::AbstractArray; dims)
     sum(f, A::AbstractArray; dims)
 
 Sum the results of calling function `f` on each element of an array over the given
-dimensions.
+dimensions. In the below examples, `f` is the [`abs2`](@ref) function.
 
 # Examples
 ```jldoctest
@@ -538,7 +538,7 @@ prod(A::AbstractArray; dims)
     prod(f, A::AbstractArray; dims)
 
 Multiply the results of calling the function `f` on each element of an array over the given
-dimensions.
+dimensions. In the below examples, `f` is the [`abs2`](@ref) function.
 
 # Examples
 ```jldoctest
@@ -688,7 +688,7 @@ minimum(A::AbstractArray; dims)
     minimum(f, A::AbstractArray; dims)
 
 Compute the minimum value from of calling the function `f` on each element of an array over the given
-dimensions.
+dimensions. In the below examples, `f` is the [`abs2`](@ref) function.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This will hopefully add some clarity to the examples, as I was reading through them, I was confused for 30 seconds as to what `abs2` was as I have never used the function and it was not mentioned. 

I think this idea should apply in a bunch of other places. IMO, better to be exact and say that we are doing something rather than just throwing in a function name with no context. 