### PR TITLE
Fix rounding cases for fixed-width printing in ryu routines

### DIFF
--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -213,7 +213,7 @@
         roundPos = pos
         while true
             roundPos -= 1
-            if roundPos == (startpos - 1) || buf[roundPos] == UInt8('-')
+            if roundPos == (startpos - 1) || buf[roundPos] == UInt8('-') || (plus && buf[roundPos] == UInt8('+')) || (space && buf[roundPos] == UInt8(' '))
                 buf[roundPos + 1] = UInt8('1')
                 e += 1
                 break

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -166,7 +166,7 @@
             dotPos = 1
             while true
                 roundPos -= 1
-                if roundPos == (startpos - 1) || (buf[roundPos] == UInt8('-'))
+                if roundPos == (startpos - 1) || (buf[roundPos] == UInt8('-')) || (plus && buf[roundPos] == UInt8('+')) || (space && buf[roundPos] == UInt8(' '))
                     buf[roundPos + 1] = UInt8('1')
                     if dotPos > 1
                         buf[dotPos] = UInt8('0')

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -141,6 +141,10 @@ end
     @test Printf.@sprintf("%+ 09.1f", 1.234) == "+000001.2"
     @test Printf.@sprintf("%+ 09.0f", 1.234) == "+00000001"
     @test Printf.@sprintf("%+ #09.0f", 1.234) == "+0000001."
+
+    #40303
+    @test Printf.@sprintf("%+7.1f", 9.96) == "  +10.0"
+    @test Printf.@sprintf("% 7.1f", 9.96) == "   10.0"
 end
 
 @testset "%e" begin
@@ -202,6 +206,10 @@ end
     @test Printf.@sprintf("%+ 09.1e", 1.234) == "+01.2e+00"
     @test Printf.@sprintf("%+ 09.0e", 1.234) == "+0001e+00"
     @test Printf.@sprintf("%+ #09.0e", 1.234) == "+001.e+00"
+
+    #40303
+    @test Printf.@sprintf("%+9.1e", 9.96) == " +1.0e+01"
+    @test Printf.@sprintf("% 9.1e", 9.96) == "  1.0e+01"
 end
 
 @testset "strings" begin


### PR DESCRIPTION
Fixes #40303. When printing values to fixed widths through the
`Ryu.writefixed` or `Ryu.writeexp` routines, we have a "cleanup" section
after a value has been printed to see if it needs to be rounded given
the input precision and width. The core issue was the terminating
condition: it previously only checked if we were at the start of a
buffer or had encountered the `'-'` character. Via Printf formatting,
however, it also allows specifying the `'+'` and `' '` characters to
preceed a formatted number. Hence, in the OP, the `'1'` character was
getting "rounded" up to the `','` character. The fix here is correctly
checking if the `plus` or `space` options were passed to the routine and
if so, include those in our rounding termination check. The original
issue only reported the "plus" case for the `f` format specifier, but
the same bug affects the `e` format specifier and the "space" option.