### PR TITLE
add option to `compilecache` so that Pkg precompilation can not skip different versions of loaded modules

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1304,7 +1304,7 @@ end
 const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 
 function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
-        skip_loaded_modules::Bool = true)
+        ignore_loaded_modules::Bool = true)
 
     @nospecialize internal_stderr internal_stdout
     # decide where to put the resulting cache file
@@ -1312,7 +1312,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
 
     # build up the list of modules that we want the precompile process to preserve
     concrete_deps = copy(_concrete_dependencies)
-    if skip_loaded_modules
+    if ignore_loaded_modules
         for (key, mod) in loaded_modules
             if !(mod === Main || mod === Core || mod === Base)
                 push!(concrete_deps, key => module_build_id(mod))

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1304,7 +1304,7 @@ end
 const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 
 function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
-        ignore_loaded_modules::Bool = true)
+                      ignore_loaded_modules::Bool = true)
 
     @nospecialize internal_stderr internal_stdout
     # decide where to put the resulting cache file

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1303,16 +1303,20 @@ end
 
 const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 
-function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, internal_stdout::IO = stdout)
+function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
+        skip_loaded_modules::Bool = true)
+
     @nospecialize internal_stderr internal_stdout
     # decide where to put the resulting cache file
     cachepath = compilecache_dir(pkg)
 
     # build up the list of modules that we want the precompile process to preserve
     concrete_deps = copy(_concrete_dependencies)
-    for (key, mod) in loaded_modules
-        if !(mod === Main || mod === Core || mod === Base)
-            push!(concrete_deps, key => module_build_id(mod))
+    if skip_loaded_modules
+        for (key, mod) in loaded_modules
+            if !(mod === Main || mod === Core || mod === Base)
+                push!(concrete_deps, key => module_build_id(mod))
+            end
         end
     end
     # run the expression and cache the result


### PR DESCRIPTION
Paired with https://github.com/JuliaLang/Pkg.jl/pull/2484

If I understand correctly, classical code-load precompilation skips precompiling different versions of loaded packages to save time, given they won't be loadable in the current session.

For the new pkg precompilation process this seems less critical.

The `compilecache` option added in this PR, along with https://github.com/JuliaLang/Pkg.jl/pull/2484 allows Pkg precompilation to precompile the different version of loaded packages, but warn the user that the package is loaded so the new version won't be accessible until after a session restart.

This avoids the `?` state in pkg precompilation that delayed precompilation until after session restart, which means the remaining precompilation was likely to happen at slower code-load as the user has to remember to go back to pkg mode and precompile.


The new behavior does all the precompilation in the current session, but reports as yellow `✓`'s, with an explanation that a restart is needed to access the new versions.

More details in https://github.com/JuliaLang/Pkg.jl/pull/2484