### PR TITLE
Run tests in parallel, even when disconnected from network

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,12 +91,10 @@ prepend!(tests, linalg_tests)
 
 import LinearAlgebra
 cd(@__DIR__) do
-    n = 1
-    if net_on
-        n = min(Sys.CPU_THREADS, length(tests))
-        n > 1 && addprocs_with_testenv(n)
-        LinearAlgebra.BLAS.set_num_threads(1)
-    end
+    n = min(Sys.CPU_THREADS, length(tests))
+    n > 1 && addprocs_with_testenv(n)
+    LinearAlgebra.BLAS.set_num_threads(1)
+
     skipped = 0
 
     @everywhere include("testdefs.jl")


### PR DESCRIPTION
At present, tests are only run in parallel when running with access to the network. This does not seem to be necessary, and presents an issue for builds with restricted network access, esp. with Nix.

I discovered this while working on https://github.com/NixOS/nixpkgs/pull/118000 where this issue came up. Nix attempts to do hermetic builds, so network access is restricted. I see no reason why we shouldn't run tests in parallel in that scenario however.