### PR TITLE
clarify example returning a tuple

### DIFF
--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -293,21 +293,21 @@ julia> threefloat()
 and similarly:
 
 ```jldoctest
-julia> function threetup()
+julia> function twothreetup()
            x, y = [2, 3] # assigns 2 to x and 3 to y
            x, y # returns a tuple
        end
-threetup (generic function with 1 method)
+twothreetup (generic function with 1 method)
 
-julia> function threearr()
+julia> function twothreearr()
            x, y = [2, 3] # returns an array
        end
-threearr (generic function with 1 method)
+twothreearr (generic function with 1 method)
 
-julia> threetup()
+julia> twothreetup()
 (2, 3)
 
-julia> threearr()
+julia> twothreearr()
 2-element Vector{Int64}:
  2
  3

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -294,7 +294,7 @@ and similarly:
 
 ```jldoctest
 julia> function threetup()
-           x, y = [3, 3]
+           x, y = [2, 3] # assigns 2 to x and 3 to y
            x, y # returns a tuple
        end
 threetup (generic function with 1 method)

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -300,16 +300,16 @@ julia> function threetup()
 threetup (generic function with 1 method)
 
 julia> function threearr()
-           x, y = [3, 3] # returns an array
+           x, y = [2, 3] # returns an array
        end
 threearr (generic function with 1 method)
 
 julia> threetup()
-(3, 3)
+(2, 3)
 
 julia> threearr()
 2-element Vector{Int64}:
- 3
+ 2
  3
 ```
 


### PR DESCRIPTION
There was room for confusion, or an unnecessary expectation of familiarity with assignment in the original version.