### PR TITLE
Show methods for LBTConfig and LBTLibraryInfo

### DIFF
--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -119,7 +119,7 @@ function Base.show(io::IO, lbt::LBTConfig)
         print(io, join(gen, ", "))
         print(io, ")")
     else
-        print(io, "LBTConfig()")
+        print(io, "LBTConfig(...)")
     end
 end
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, lbt::LBTConfig)

--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -121,10 +121,18 @@ end
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, lbt::LBTConfig)
     summary(io, lbt); println(io)
     println(io, "Libraries: ")
-    for l in lbt.loaded_libs[1:end-1]
-        println(io, "├", basename(l.libname))
+    for (i,l) in enumerate(lbt.loaded_libs)
+        char = i == length(lbt.loaded_libs) ? "└" : "├"
+        interface_str = if l.interface == :ilp64
+            "ILP64"
+        elseif l.interface == :lp64
+            " LP64"
+        else
+            "UNKWN"
+        end
+        print(io, char, " [", interface_str,"] ", basename(l.libname))
+        i !== length(lbt.loaded_libs) && println()
     end
-    print(io, "└ ", basename(lbt.loaded_libs[end].libname))
 end
 
 function lbt_get_config()

--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -103,7 +103,7 @@ struct LBTConfig
     end
 end
 
-Base.show(io::IO, lbt::LBTLibraryInfo) = print(io, "LBTLibraryInfo($(basename(lbt.libname)))")
+Base.show(io::IO, lbt::LBTLibraryInfo) = print(io, "LBTLibraryInfo(", basename(lbt.libname), ", ", lbt.interface, ")")
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, lbt::LBTLibraryInfo)
     summary(io, lbt); println(io)
     println(io, "├ Library: ", basename(lbt.libname))
@@ -113,9 +113,13 @@ end
 
 function Base.show(io::IO, lbt::LBTConfig)
     if length(lbt.loaded_libs) <= 3
-        print(io, "LBTConfig(", join(basename.(getfield.(lbt.loaded_libs, :libname)), ", "), ")")
+        print(io, "LBTConfig(")
+        gen = (string("[", uppercase(string(l.interface)), "] ",
+            basename(l.libname)) for l in lbt.loaded_libs)
+        print(io, join(gen, ", "))
+        print(io, ")")
     else
-        print(io, "LBTConfig")
+        print(io, "LBTConfig()")
     end
 end
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, lbt::LBTConfig)

--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -103,6 +103,30 @@ struct LBTConfig
     end
 end
 
+Base.show(io::IO, lbt::LBTLibraryInfo) = print(io, "LBTLibraryInfo($(basename(lbt.libname)))")
+function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, lbt::LBTLibraryInfo)
+    summary(io, lbt); println(io)
+    println(io, "├ Library: ", basename(lbt.libname))
+    println(io, "├ Interface: ", lbt.interface)
+      print(io, "└ F2C: ", lbt.f2c)
+end
+
+function Base.show(io::IO, lbt::LBTConfig)
+    if length(lbt.loaded_libs) <= 3
+        print(io, "LBTConfig(", join(basename.(getfield.(lbt.loaded_libs, :libname)), ", "), ")")
+    else
+        print(io, "LBTConfig")
+    end
+end
+function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, lbt::LBTConfig)
+    summary(io, lbt); println(io)
+    println(io, "Libraries: ")
+    for l in lbt.loaded_libs[1:end-1]
+        println(io, "├", basename(l.libname))
+    end
+    print(io, "└ ", basename(lbt.loaded_libs[end].libname))
+end
+
 function lbt_get_config()
     config_ptr = ccall((:lbt_get_config, libblastrampoline), Ptr{lbt_config_t}, ())
     return LBTConfig(unsafe_load(config_ptr))


### PR DESCRIPTION
See discussion in https://github.com/JuliaLinearAlgebra/MKL.jl/issues/73. Because of the new libblastrampoline facilities, `BLAS.get_config()` is replacing `BLAS.vendor()` as the way to check which BLAS is used. However, the current output is very hard to parse and contains lots of unnecessary information. This PR improves the printing of the relevant LBT types.

Before the PR:

```Julia
julia> BLAS.get_config()
LinearAlgebra.BLAS.LBTConfig(LinearAlgebra.BLAS.LBTLibraryInfo[LinearAlgebra.BLAS.LBTLibraryInfo("/Applications/Julia-1.7.app/Contents/Resources/julia/bin/../lib/julia/libopenblas64_.dylib", Ptr{Nothing} @0x00007fb4d1d16690, "64_", UInt8[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  …  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01], :ilp64, :plain)], [:f2c_capable], ["LAPACKE_c_nancheck", "LAPACKE_cbbcsd", "LAPACKE_cbbcsd_work", "LAPACKE_cbdsqr", "LAPACKE_cbdsqr_work", "LAPACKE_cgb_nancheck", "LAPACKE_cgb_trans", "LAPACKE_cgbbrd", "LAPACKE_cgbbrd_work", "LAPACKE_cgbcon"  …  "zunmlq_", "zunmql_", "zunmqr_", "zunmr2_", "zunmr3_", "zunmrq_", "zunmrz_", "zunmtr_", "zupgtr_", "zupmtr_"])

julia> using MKL

julia> BLAS.get_config()
LinearAlgebra.BLAS.LBTConfig(LinearAlgebra.BLAS.LBTLibraryInfo[LinearAlgebra.BLAS.LBTLibraryInfo("/Users/crstnbr/.julia/artifacts/073ff95e2c63501547247d6e1321bf4ee2a78933/lib/libmkl_rt.1.dylib", Ptr{Nothing} @0x00007fb4d1e84e20, "", UInt8[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  …  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01], :ilp64, :plain)], [:f2c_capable], ["LAPACKE_c_nancheck", "LAPACKE_cbbcsd", "LAPACKE_cbbcsd_work", "LAPACKE_cbdsqr", "LAPACKE_cbdsqr_work", "LAPACKE_cgb_nancheck", "LAPACKE_cgb_trans", "LAPACKE_cgbbrd", "LAPACKE_cgbbrd_work", "LAPACKE_cgbcon"  …  "zunmlq_", "zunmql_", "zunmqr_", "zunmr2_", "zunmr3_", "zunmrq_", "zunmrz_", "zunmtr_", "zupgtr_", "zupmtr_"])

julia> BLAS.get_config().loaded_libs[1]
LinearAlgebra.BLAS.LBTLibraryInfo("/Users/crstnbr/.julia/artifacts/073ff95e2c63501547247d6e1321bf4ee2a78933/lib/libmkl_rt.1.dylib", Ptr{Nothing} @0x00007fb4d1e84e20, "", UInt8[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  …  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01], :ilp64, :plain)
```

After the PR:

```Julia
julia> BLAS.get_config()
LinearAlgebra.BLAS.LBTConfig
Libraries:
└ libopenblas64_.dylib

julia> using MKL
[ Info: Precompiling MKL [33e6dc65-8f57-5167-99aa-e5a354878fb2]

julia> BLAS.get_config()
LinearAlgebra.BLAS.LBTConfig
Libraries:
└ libmkl_rt.1.dylib

julia> BLAS.get_config().loaded_libs[1]
LinearAlgebra.BLAS.LBTLibraryInfo
├ Library: libmkl_rt.1.dylib
├ Interface: ilp64
└ F2C: plain
```

Should I also add tests for the new printing?

(cc: @ViralBShah, @staticfloat)