### PR TITLE
ensure require_one_based_indexing can constant-fold for ranges

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -96,7 +96,8 @@ end
 Return `true` if the indices of `A` start with something other than 1 along any axis.
 If multiple arguments are passed, equivalent to `has_offset_axes(A) | has_offset_axes(B) | ...`.
 """
-has_offset_axes(A)    = _tuple_any(x->Int(first(x))::Int != 1, axes(A))
+has_offset_axes(A) = _tuple_any(x->Int(first(x))::Int != 1, axes(A))
+has_offset_axes(A::AbstractVector) = Int(firstindex(A))::Int != 1 # improve performance of a common case (ranges)
 has_offset_axes(A...) = _tuple_any(has_offset_axes, A)
 has_offset_axes(::Colon) = false
 


### PR DESCRIPTION
Refs performance issue noted in #38527

As noted there, `length(m:n)` can throw exceptions, which makes that function quite costly. I'm not sure there is much we can do about that, other than change our ranges to be exclusive `[)`? 😬 