### PR TITLE
Add comments to runtests.jl to explain the `net_on`/loopback situation

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,12 +92,12 @@ prepend!(tests, linalg_tests)
 import LinearAlgebra
 cd(@__DIR__) do
     # `net_on` implies that we have access to the loopback interface which is
-    # necessary for Distributed multi-processing. There are some test environments that do
-    # not allow access to loopback, so we must disable addprocs when
-    # `net_on` is false. Note that there exist build environments, including
-    # Nix, where `net_on` is false but we still have access to the loopback
-    # interface. It would be great to make this check more specific to identify
-    # those situations somehow. See
+    # necessary for Distributed multi-processing. There are some test
+    # environments that do not allow access to loopback, so we must disable
+    # addprocs when `net_on` is false. Note that there exist build environments,
+    # including Nix, where `net_on` is false but we still have access to the
+    # loopback interface. It would be great to make this check more specific to
+    # identify those situations somehow. See
     #   * https://github.com/JuliaLang/julia/issues/6722
     #   * https://github.com/JuliaLang/julia/pull/29384
     #   * https://github.com/JuliaLang/julia/pull/40348

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,8 +92,8 @@ prepend!(tests, linalg_tests)
 import LinearAlgebra
 cd(@__DIR__) do
     # `net_on` implies that we have access to the loopback interface which is
-    # necessary for multithreading. There are some build environments that do
-    # not allow access to loopback, so we must disable multithreading when
+    # necessary for Distributed multi-processing. There are some test environments that do
+    # not allow access to loopback, so we must disable addprocs when
     # `net_on` is false. Note that there exist build environments, including
     # Nix, where `net_on` is false but we still have access to the loopback
     # interface. It would be great to make this check more specific to identify

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,16 @@ prepend!(tests, linalg_tests)
 
 import LinearAlgebra
 cd(@__DIR__) do
+    # `net_on` implies that we have access to the loopback interface which is
+    # necessary for multithreading. There are some build environments that do
+    # not allow access to loopback, so we must disable multithreading when
+    # `net_on` is false. Note that there exist build environments, including
+    # Nix, where `net_on` is false but we still have access to the loopback
+    # interface. It would be great to make this check more specific to identify
+    # those situations somehow. See
+    #   * https://github.com/JuliaLang/julia/issues/6722
+    #   * https://github.com/JuliaLang/julia/pull/29384
+    #   * https://github.com/JuliaLang/julia/pull/40348
     n = 1
     if net_on
         n = min(Sys.CPU_THREADS, length(tests))


### PR DESCRIPTION
This is a followup to https://github.com/JuliaLang/julia/pull/40348 to explain what's going on in a comment.