### PR TITLE
Provide an error message for `Distributed.deserialize_msg`

### DIFF
--- a/stdlib/Distributed/src/messages.jl
+++ b/stdlib/Distributed/src/messages.jl
@@ -84,14 +84,14 @@ let msg_cases = :(@assert false "Message type index ($idx) expected to be betwee
     for i = length(msgtypes):-1:1
         mti = msgtypes[i]
         msg_cases = :(if idx == $i
-                          return $(Expr(:call, QuoteNode(mti), fill(:(deserialize(s)), fieldcount(mti))...))
+                          $(Expr(:call, QuoteNode(mti), fill(:(deserialize(s)), fieldcount(mti))...))
                       else
                           $msg_cases
                       end)
     end
     @eval function deserialize_msg(s::AbstractSerializer)
         idx = read(s.io, UInt8)
-        $msg_cases
+        return $msg_cases
     end
 end
 

--- a/stdlib/Distributed/src/messages.jl
+++ b/stdlib/Distributed/src/messages.jl
@@ -80,7 +80,7 @@ for (idx, tname) in enumerate(msgtypes)
     end
 end
 
-let msg_cases = :(@assert false)
+let msg_cases = :(@assert false "Message type index ($idx) expected to be between 1:$($(length(msgtypes)))")
     for i = length(msgtypes):-1:1
         mti = msgtypes[i]
         msg_cases = :(if idx == $i


### PR DESCRIPTION
I'm currently doing some experimentation with the cluster managers message passing API and I made a mistake where I was using `send_connection_hdr` and always sending the cookie information. When this occurred I was seeing the following error on the worker before the cluster was fully setup:

```julia
RemoteException(2, CapturedException(AssertionError("false"), Any[(deserialize_msg(s::ClusterSerializer{TCPSocket}) at messages.jl:89, 1), (#invokelatest#2 at essentials.jl:708 [inlined], 1), (invokelatest at essentials.jl:706 [inlined], 1), (process_messages(handle_msg::typeof(handle_message), r_stream::TCPSocket, w_stream::TCPSocket, incoming::Bool) at poc.jl:479, 1), ((::var"#37#39"{TCPSocket, TCPSocket, Bool, typeof(handle_message)})() at task.jl:406, 1)]))
```
This assertion isn't very helpful at all and require you to read over the generated `deserialize_msg` function to figure out what's going on. This is a small improvement to make the failure a little more obvious. With this PR:
```julia
RemoteException(2, CapturedException(AssertionError("Message type index (0) expected to be between 1:9"), Any[(deserialize_msg(s::ClusterSerializer{TCPSocket}) at messages.jl:89, 1), (#invokelatest#2 at essentials.jl:708 [inlined], 1), (invokelatest at essentials.jl:706 [inlined], 1), (process_messages(handle_msg::typeof(handle_message), r_stream::TCPSocket, w_stream::TCPSocket, incoming::Bool) at poc.jl:479, 1), ((::var"#37#39"{TCPSocket, TCPSocket, Bool, typeof(handle_message)})() at task.jl:406, 1)]))
```

Also, I removed the multiple `return` statements which were generated in `msg_cases` in favor of just using the result of the nested `if`. This allows for the use of `x = $msg_cases` while experimenting. 
