### PR TITLE
inference: limit single-level nested `Type` signature

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -128,7 +128,15 @@ function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVec
         end
         return Vararg{VaT}
     elseif isa(t, DataType)
-        if isa(c, DataType)
+        if isa(c, Core.TypeofVararg)
+            # Tuple{Vararg{T}} --> Tuple{T} is OK
+            return _limit_type_size(t, c.T, sources, depth, 0)
+        elseif isType(t) # allow taking typeof as Type{...}, but ensure it doesn't start nesting
+            tt = unwrap_unionall(t.parameters[1])
+            (!isa(tt, DataType) || isType(tt)) && (depth += 1)
+            is_derived_type_from_any(tt, sources, depth) && return t
+            return Type
+        elseif isa(c, DataType)
             tP = t.parameters
             cP = c.parameters
             if t.name === c.name && !isempty(cP)
@@ -157,15 +165,6 @@ function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVec
                     end
                     return Tuple{Q...}
                 end
-            end
-        elseif isa(c, Core.TypeofVararg)
-            # Tuple{Vararg{T}} --> Tuple{T} is OK
-            return _limit_type_size(t, c.T, sources, depth, 0)
-        end
-        if isType(t) # allow taking typeof as Type{...}, but ensure it doesn't start nesting
-            tt = unwrap_unionall(t.parameters[1])
-            if isa(tt, DataType) && !isType(tt)
-                is_derived_type_from_any(tt, sources, depth) && return t
             end
         end
         if allowed_tuplelen < 1 && t.name === Tuple.name
@@ -226,9 +225,19 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
         return t !== 1 && !(0 <= t < c) # alternatively, could use !(abs(t) <= abs(c) || abs(t) < n) for some n
     end
     # base case for data types
-    if isa(t, DataType)
+    if isa(t, Core.TypeofVararg)
+        if isa(c, Core.TypeofVararg)
+            return type_more_complex(unwrapva(t), unwrapva(c), sources, depth + 1, tupledepth, 0)
+        end
+    elseif isa(t, DataType)
         tP = t.parameters
-        if isa(c, DataType) && t.name === c.name
+        if isa(c, Core.TypeofVararg)
+            return type_more_complex(t, unwrapva(c), sources, depth, tupledepth, 0)
+        elseif isType(t) # allow taking typeof any source type anywhere as Type{...}, as long as it isn't nesting Type{Type{...}}
+            tt = unwrap_unionall(t.parameters[1])
+            (!isa(tt, DataType) || isType(tt)) && (depth += 1)
+            return !is_derived_type_from_any(tt, sources, depth)
+        elseif isa(c, DataType) && t.name === c.name
             cP = c.parameters
             length(cP) < length(tP) && return true
             length(cP) > length(tP) && !isvarargtype(tP[end]) && depth == 1 && return false
@@ -236,7 +245,7 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
             # allow creating variation within a nested tuple, but only so deep
             if t.name === Tuple.name && tupledepth > 0
                 tupledepth -= 1
-            elseif !isvarargtype(t)
+            else
                 tupledepth = 0
             end
             isgenerator = (t.name.name === :Generator && t.name.module === _topmod(t.name.module))
@@ -258,15 +267,6 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
                 type_more_complex(tPi, cPi, sources, depth + 1, tupledepth, 0) && return true
             end
             return false
-        elseif isvarargtype(c)
-            return type_more_complex(t, unwrapva(c), sources, depth, tupledepth, 0)
-        end
-        if isType(t) # allow taking typeof any source type anywhere as Type{...}, as long as it isn't nesting Type{Type{...}}
-            tt = unwrap_unionall(t.parameters[1])
-            if isa(tt, DataType) && !isType(tt)
-                is_derived_type_from_any(tt, sources, depth) || return true
-                return false
-            end
         end
     end
     return true


### PR DESCRIPTION
Previously `type_more_complex` returns `false` for `Type{Type{...}}`
compared against `Type{...}`. Per comment there, this should return `true`,
but the code was ordered incorrect (it was also missing support for
Vararg, after the recent changes).

Fixes #40336, Replaces #40341

@aviatesk I think this is a more complete fix, that matches the intent of the comment there.