### PR TITLE
remove method definition for `Int` in test/core.jl

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -2389,19 +2389,14 @@ let ex = Expr(:(=), :(f8338(x;y=4)), :(x*y))
 end
 
 # call overloading (#2403)
-(x::Int)(y::Int) = x + 3y
 issue2403func(f) = f(7)
-let x = 10
-    @test x(3) == 19
-    @test x((3,)...) == 19
-    @test issue2403func(x) == 31
-end
 mutable struct Issue2403
     x
 end
 (i::Issue2403)(y) = i.x + 2y
 let x = Issue2403(20)
     @test x(3) == 26
+    @test x((3,)...) == 26
     @test issue2403func(x) == 34
 end
 


### PR DESCRIPTION
This is hazardous; e.g. it causes errorshow to fail if this runs before, as happened here: https://build.julialang.org/#/builders/4/builds/2373/steps/5/logs/stdio
