### PR TITLE
Bump libblastrampoline to v3.0.4

### DIFF
--- a/stdlib/libblastrampoline_jll/Project.toml
+++ b/stdlib/libblastrampoline_jll/Project.toml
@@ -1,6 +1,6 @@
 name = "libblastrampoline_jll"
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "3.0.2+0"
+version = "3.0.4+0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"


### PR DESCRIPTION
This should fix some armv7l issues, as libblastrampoline had the same
issues in its armv7l trampolines as Julia itself had.