### PR TITLE
Annotate iterate(::AbstractArray) with inbounds

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1093,9 +1093,10 @@ zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
 # own, IndexCartesian's CartesianIndices is more complicated and requires explicit
 # inlining.
 function iterate(A::AbstractArray, state=(eachindex(A),))
+    @_inline_meta
     y = iterate(state...)
     y === nothing && return nothing
-    A[y[1]], (state[1], tail(y)...)
+    @inbounds A[y[1]], (state[1], tail(y)...)
 end
 
 isempty(a::AbstractArray) = (length(a) == 0)


### PR DESCRIPTION
This PR adds inbounds and inline annotation to `iterate` on `AbstractArray` as already done for `Array`.

Before this PR, the effect of the missing inbounds annotation can be observed with this benchmark:

```julia
julia> function f(xs)
           a = 0.0
           for x in xs
               a += x
           end
           a
       end
f (generic function with 1 method)

julia> function f1!(a, xs)
           for x in xs
               @inbounds a[1] += x
           end
       end
f1! (generic function with 1 method)

julia> function f2!(a, xs)
           for i in eachindex(xs)
               @inbounds a[1] += xs[i]
           end
       end
f2! (generic function with 1 method)

julia> xs = randn(1000);

julia> @btime f($xs);
  879.981 ns (0 allocations: 0 bytes)

julia> @btime f($(view(xs, 1:length(xs))));
  887.688 ns (0 allocations: 0 bytes)

julia> @btime f1!($([0.0]), $xs)
  915.919 ns (0 allocations: 0 bytes)

julia> @btime f1!($([0.0]), $(view(xs, 1:length(xs))))  # the only slow case
  3.285 μs (0 allocations: 0 bytes)

julia> @btime f2!($([0.0]), $xs)
  916.216 ns (0 allocations: 0 bytes)

julia> @btime f2!($([0.0]), $(view(xs, 1:length(xs))))
  916.189 ns (0 allocations: 0 bytes)
```

(Aside: Interestingly, `f($(view(xs, 1:length(xs))))` showed no performance difference, even though the bound check is not eliminated when looking at the LLVM IR.)

The slow case `f1!($([0.0]), $(view(xs, 1:length(xs))))` is fixed this this PR.


Since

```julia
xs::AbstractArray
for I in eachindex(xs)
    checkbounds(xs, I)
end
```

must hold (not throw) for any abstract array `xs`, I think this use of `@inbounds` is correct. The use of `@inbounds` is justified by the information locally available inside the `iterate` method.
