### PR TITLE
Bump MACOSX_VERSION_MIN from 10.9 to 10.10

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -472,13 +472,13 @@ USEGCC := 0
 USECLANG := 1
 endif
 
-# Note: Supporting only macOS Mavericks and above
+# Note: Supporting only macOS Yosemite and above
 ifeq ($(OS), Darwin)
 APPLE_ARCH := $(shell uname -m)
 USEGCC := 0
 USECLANG := 1
 ifneq ($(APPLE_ARCH),arm64)
-MACOSX_VERSION_MIN := 10.9
+MACOSX_VERSION_MIN := 10.10
 else
 MACOSX_VERSION_MIN := 11.0
 endif


### PR DESCRIPTION
Testing for https://github.com/JuliaLang/LinearAlgebra.jl/issues/836 .

According to [Wikipedia](https://en.wikipedia.org/wiki/OS_X_Yosemite),
> All Macintosh products capable of running OS X Mountain Lion (v10.8.x) are able to run Yosemite as the two operating systems have the same requirements.

so that this should not restrict usable hardware.