### PR TITLE
Avoid AbstractString in GitError struct

### DIFF
--- a/stdlib/LibGit2/src/error.jl
+++ b/stdlib/LibGit2/src/error.jl
@@ -77,7 +77,7 @@ end
 struct GitError <: Exception
     class::Class
     code::Code
-    msg::AbstractString
+    msg::String
 end
 Base.show(io::IO, err::GitError) = print(io, "GitError(Code:$(err.code), Class:$(err.class), $(err.msg))")
 


### PR DESCRIPTION
to make extraction inferred. This reduces the number of invalidated methods by 255 when loading `ProgressLogging`.