### PR TITLE
fix #39982, reduce cursor artifacts in REPL after #39538

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -790,10 +790,12 @@ function edit_insert(s::PromptState, c::StringLike)
         offset = s.ias.curs_row == 1 || s.indent < 0 ?
             sizeof(prompt_string(s.p.prompt)::String) : s.indent
         offset += position(buf) - beginofline(buf) # size of current line
+        spinner = true
         if offset + textwidth(str) <= w
             # Avoid full update when appending characters to the end
             # and an update of curs_row isn't necessary (conservatively estimated)
             write(termbuf, str)
+            spinner = false
         elseif after == 0
             refresh_line(s)
             delayup = false
@@ -801,8 +803,10 @@ function edit_insert(s::PromptState, c::StringLike)
             delayup = true
         end
         if delayup
-            write(termbuf, spin_seq[mod1(position(buf) - w, length(spin_seq))])
-            cmove_left(termbuf)
+            if spinner
+                write(termbuf, spin_seq[mod1(position(buf) - w, length(spin_seq))])
+                cmove_left(termbuf)
+            end
             s.refresh_wait = Timer(after) do t
                 s.refresh_wait === t || return
                 s.refresh_wait = nothing

--- a/stdlib/REPL/src/options.jl
+++ b/stdlib/REPL/src/options.jl
@@ -46,7 +46,7 @@ Options(;
         auto_indent_tmp_off = false,
         auto_indent_bracketed_paste = false,
         auto_indent_time_threshold = 0.005,
-        auto_refresh_time_delay = 0.05,
+        auto_refresh_time_delay = Sys.iswindows() ? 0.05 : 0.0,
         iocontext = Dict{Symbol,Any}()) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,


### PR DESCRIPTION
This makes two tweaks to the delayed-update code:

1. Don't show the spinner when we're in the first row and the new text is printed anyway. This eliminates the artifact in the common case where you are just editing by hand at the start of a line.
2. Only enable delayed-update by default on windows.

These can be separated if people prefer.

fix #39982