### PR TITLE
Set DelimitedFiles.readdlm use_mmap default to false for all OSes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -126,7 +126,10 @@ Standard library changes
 
 * `mmap` is now exported ([#39816]).
 
+#### DelimitedFiles
 
+* `readdlm` now defaults to `use_mmap=false` on all OSes for increased reliability across abnormal filesystem situations ([#40415]).
+  
 Deprecated or removed
 ---------------------
 - Multiple successive semicolons in an array expresion were previously ignored (e.g. `[1 ;; 2] == [1 ; 2]`). Multiple semicolons are being reserved for future syntax and may have different behavior in a future release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -128,7 +128,7 @@ Standard library changes
 
 #### DelimitedFiles
 
-* `readdlm` now defaults to `use_mmap=false` on all OSes for increased reliability across abnormal filesystem situations ([#40415]).
+* `readdlm` now defaults to `use_mmap=false` on all OSes for consistent reliability in abnormal filesystem situations ([#40415]).
   
 Deprecated or removed
 ---------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -129,7 +129,7 @@ Standard library changes
 #### DelimitedFiles
 
 * `readdlm` now defaults to `use_mmap=false` on all OSes for consistent reliability in abnormal filesystem situations ([#40415]).
-  
+
 Deprecated or removed
 ---------------------
 - Multiple successive semicolons in an array expresion were previously ignored (e.g. `[1 ;; 2] == [1 ; 2]`). Multiple semicolons are being reserved for future syntax and may have different behavior in a future release.

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -190,7 +190,7 @@ Specifying `skipstart` will ignore the corresponding number of initial lines fro
 If `skipblanks` is `true`, blank lines in the input will be ignored.
 
 If `use_mmap` is `true`, the file specified by `source` is memory mapped for potential
-speedups if the file is large. Default is `false'. On a Windows filesystem, `use_mmap` should not be set 
+speedups if the file is large. Default is `false'. On a Windows filesystem, `use_mmap` should not be set
 to `true` unless the file is only read once and is also not written to.
 Some edge cases exist where an OS is Unix-like but the filesystem is Windows-like.
 

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -190,8 +190,9 @@ Specifying `skipstart` will ignore the corresponding number of initial lines fro
 If `skipblanks` is `true`, blank lines in the input will be ignored.
 
 If `use_mmap` is `true`, the file specified by `source` is memory mapped for potential
-speedups if the file is large. Default is `false'. On Windows, `use_mmap` should not be set 
+speedups if the file is large. Default is `false'. On a Windows filesystem, `use_mmap` should not be set 
 to `true` unless the file is only read once and is also not written to.
+Some edge cases exist where an OS is Unix-like but the filesystem is Windows-like.
 
 If `quotes` is `true`, columns enclosed within double-quote (\") characters are allowed to
 contain new lines and column delimiters. Double-quote characters within a quoted field must

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -190,8 +190,8 @@ Specifying `skipstart` will ignore the corresponding number of initial lines fro
 If `skipblanks` is `true`, blank lines in the input will be ignored.
 
 If `use_mmap` is `true`, the file specified by `source` is memory mapped for potential
-speedups. Default is `true` except on Windows. On Windows, you may want to specify `true` if
-the file is large, and is only read once and not written to.
+speedups if the file is large. Default is `false'. On Windows, `use_mmap` should not be set 
+to `true` unless the file is only read once and is also not written to.
 
 If `quotes` is `true`, columns enclosed within double-quote (\") characters are allowed to
 contain new lines and column delimiters. Double-quote characters within a quoted field must
@@ -232,7 +232,7 @@ readdlm_auto(input::IO, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Boo
 function readdlm_auto(input::AbstractString, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Bool; opts...)
     isfile(input) || throw(ArgumentError("Cannot open \'$input\': not a file"))
     optsd = val_opts(opts)
-    use_mmap = get(optsd, :use_mmap, Sys.iswindows() ? false : true)
+    use_mmap = get(optsd, :use_mmap, false)
     fsz = filesize(input)
     if use_mmap && fsz > 0 && fsz < typemax(Int)
         a = open(input, "r") do f


### PR DESCRIPTION
Increased resilience to edge cases where `Sys.isunix() == true` but the Filesystem behaves Windows-like instead of Unix-like.

Current behavior in these edge cases can cause ugly bugs, and I believe it is best to sacrifice default performance in favor of default portability.

@vtjnash has also [demonstrated](https://github.com/JuliaLang/julia/issues/40352#issuecomment-813479184) that the current default also leads to worse performance on Unix-like systems for very small delimited files, so the change in defaults also leads to improved performance in at least some situations.

Specific examples of edge cases where the current default is dangerous: 
- #8891 (Mac + NFS of probably Windows origin)
- #40352 (WSL1 + Windows Filesystem)
