### PR TITLE
logging: redirect closed streams to stderr/stdout

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -611,21 +611,25 @@ attached to the task.
 """
 current_logger() = current_logstate().logger
 
+const closed_stream = IOBuffer(UInt8[])
+close(closed_stream)
 
 #-------------------------------------------------------------------------------
 # SimpleLogger
 """
-    SimpleLogger(stream=stderr, min_level=Info)
+    SimpleLogger([stream,] min_level=Info)
 
 Simplistic logger for logging all messages with level greater than or equal to
-`min_level` to `stream`.
+`min_level` to `stream`. If stream is closed then messages with log level
+greater or equal to `Warn` will be logged to `stderr` and below to `stdout`.
 """
 struct SimpleLogger <: AbstractLogger
     stream::IO
     min_level::LogLevel
     message_limits::Dict{Any,Int}
 end
-SimpleLogger(stream::IO=stderr, level=Info) = SimpleLogger(stream, level, Dict{Any,Int}())
+SimpleLogger(stream::IO, level=Info) = SimpleLogger(stream, level, Dict{Any,Int}())
+SimpleLogger(level=Info) = SimpleLogger(closed_stream, level)
 
 shouldlog(logger::SimpleLogger, level, _module, group, id) =
     get(logger.message_limits, id, 1) > 0
@@ -644,7 +648,11 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
         remaining > 0 || return
     end
     buf = IOBuffer()
-    iob = IOContext(buf, logger.stream)
+    stream = logger.stream
+    if !isopen(stream)
+        stream = level < Warn ? stdout : stderr
+    end
+    iob = IOContext(buf, stream)
     levelstr = level == Warn ? "Warning" : string(level)
     msglines = split(chomp(string(message)::String), '\n')
     println(iob, "┌ ", levelstr, ": ", msglines[1])
@@ -656,10 +664,10 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
         println(iob, "│   ", key, " = ", val)
     end
     println(iob, "└ @ ", _module, " ", filepath, ":", line)
-    write(logger.stream, take!(buf))
+    write(stream, take!(buf))
     nothing
 end
 
-_global_logstate = LogState(SimpleLogger(Core.stderr, CoreLogging.Info))
+_global_logstate = LogState(SimpleLogger())
 
 end # CoreLogging

--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -29,6 +29,9 @@ for sym in [
     @eval const $sym = Base.CoreLogging.$sym
 end
 
+using Base.CoreLogging:
+    closed_stream
+
 export
     AbstractLogger,
     LogLevel,
@@ -56,7 +59,7 @@ include("ConsoleLogger.jl")
 #  handle_message, shouldlog, min_enabled_level, catch_exceptions,
 
 function __init__()
-    global_logger(ConsoleLogger(stderr))
+    global_logger(ConsoleLogger())
 end
 
 end

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -341,15 +341,43 @@ end
         String(take!(io))
     end
 
+    function genmsg_out(level, message, _module, filepath, line; kws...)
+        fname = tempname()
+        f = open(fname, "w")
+        logger = SimpleLogger()
+        redirect_stdout(f) do
+            handle_message(logger, level, message, _module, :group, :id,
+                           filepath, line; kws...)
+        end
+        close(f)
+        buf = read(fname)
+        rm(fname)
+        String(buf)
+    end
+
+    function genmsg_err(level, message, _module, filepath, line; kws...)
+        fname = tempname()
+        f = open(fname, "w")
+        logger = SimpleLogger()
+        redirect_stderr(f) do
+            handle_message(logger, level, message, _module, :group, :id,
+                           filepath, line; kws...)
+        end
+        close(f)
+        buf = read(fname)
+        rm(fname)
+        String(buf)
+    end
+
     # Simple
-    @test genmsg(Info, "msg", Main, "some/path.jl", 101) ==
+    @test genmsg_out(Info, "msg", Main, "some/path.jl", 101) ==
     """
     ┌ Info: msg
     └ @ Main some/path.jl:101
     """
 
     # Multiline message
-    @test genmsg(Warn, "line1\nline2", Main, "some/path.jl", 101) ==
+    @test genmsg_err(Warn, "line1\nline2", Main, "some/path.jl", 101) ==
     """
     ┌ Warning: line1
     │ line2


### PR DESCRIPTION
This has the additional benefit of making the initial logger respect
changes to redirect_stderr/stdout, until the user explicitly sets
another stream as the logging destination.

Fix #26798
Fix #38482
Replaces #26920, which provided the idea and most of the implementation

Co-authored-by: @gaika Thanks for this initial work to make this happen! Sorry it took so long to review.