### PR TITLE
alter array alloc threshold to remove O(n^2) behavior

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -908,8 +908,8 @@ STATIC_INLINE void jl_array_grow_at_end(jl_array_t *a, size_t idx,
     if (__unlikely(reqmaxsize > a->maxsize)) {
         size_t nb1 = idx * elsz;
         size_t nbinc = inc * elsz;
-        // if the requested size is more than 2x current maxsize, grow exactly
-        // otherwise double the maxsize
+        // grow either by our computed overallocation factor or exactly the requested size,
+        // whichever is larger
         size_t newmaxsize = overallocation(a->maxsize);
         if (newmaxsize < reqmaxsize)
             newmaxsize = reqmaxsize;

--- a/src/init.c
+++ b/src/init.c
@@ -648,14 +648,6 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     restore_signals();
 
     jl_page_size = jl_getpagesize();
-    uint64_t total_mem = uv_get_total_memory();
-    uint64_t constrained_mem = uv_get_constrained_memory();
-    if (constrained_mem > 0 && constrained_mem < total_mem)
-        total_mem = constrained_mem;
-    if (total_mem >= (size_t)-1) {
-        total_mem = (size_t)-1;
-    }
-    jl_arr_xtralloc_limit = total_mem / 100;  // Extra allocation limited to 1% of total RAM
     jl_prep_sanitizers();
     void *stack_lo, *stack_hi;
     jl_init_stack_limits(1, &stack_lo, &stack_hi);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -651,7 +651,6 @@ extern char jl_using_oprofile_jitevents;
 extern char jl_using_perf_jitevents;
 #endif
 extern char jl_using_gdb_jitevents;
-extern size_t jl_arr_xtralloc_limit;
 
 // -- init.c -- //
 


### PR DESCRIPTION
The goal is to grow faster at small n, and slower at large n, but always as a function of n

Continuation of https://github.com/JuliaLang/julia/pull/32035, fixes https://github.com/JuliaLang/julia/issues/28588, closes https://github.com/JuliaLang/julia/issues/8269 @NHDaly 

This shows (purple line) how many operations (x-axis) it takes to allocate 2^y MB (y-axis). It also shows the current strategy (yellow line) without the memory limit threshold and the number of operations it would take previously on various machine sizes (blue/green/red) to reach the same array size
![fig](https://user-images.githubusercontent.com/330950/114506449-cccec200-9bff-11eb-8c01-4af28f3e762b.png)
See this gist for plot generation: https://gist.github.com/vtjnash/28cc68ffeb962b094fd8675bc2f6af63

We can also look at the experimental times, for various values for 2^n:
n  | Julia v1.7-dev | PR
-- | -- | --
26 | 1.16 s | 1.67 s
27 | 3.39 s | 3.32 s
28 | 10.45 s | 5.67 s
29 | 43.56 s | 12.07 s
30 | 333.55 s | 36.68 s
```julia
for j = 20:30
       @time let x = Int[]; for i = 1:2^j; push!(x, 1); end; end
end
```