### PR TITLE
add  `selectdim(A, 2, 3:4)` example

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -117,6 +117,11 @@ julia> selectdim(A, 2, 3)
 2-element view(::Matrix{Int64}, :, 3) with eltype Int64:
  3
  7
+
+julia> selectdim(A, 2, 3:4)
+2×2 view(::Matrix{Int64}, :, 3:4) with eltype Int64:
+ 3  4
+ 7  8
 ```
 """
 @inline selectdim(A::AbstractArray, d::Integer, i) = _selectdim(A, d, i, _setindex(i, d, map(Slice, axes(A))...))


### PR DESCRIPTION
This adds a `selectdim(A, 2, 3:4)` example to illustrate that several indices can be used (as this is not entirely clear in the text). Based on a suggestion in https://discourse.julialang.org/t/pick-rows-from-array-ndims-not-known-in-advance/59033/6