### PR TITLE
[RFC] Adding `get(::Function, ::ImmutableDict, key)` to resolve #40413

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -792,6 +792,14 @@ function get(dict::ImmutableDict, key, default)
     return default
 end
 
+function get(default::Callable, dict::ImmutableDict, key)
+    while isdefined(dict, :parent)
+        isequal(dict.key, key) && return dict.value
+        dict = dict.parent
+    end
+    return default()
+end
+
 # this actually defines reverse iteration (e.g. it should not be used for merge/copy/filter type operations)
 function iterate(d::ImmutableDict{K,V}, t=d) where {K, V}
     !isdefined(t, :parent) && return nothing

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -736,7 +736,7 @@ import Base.ImmutableDict
     @test get(d4, "key1") do
         f(4)
     end === v2
-    @test get(d4, "foo") do 
+    @test get(d4, "foo") do
         f(6)
     end === 36
     @test get(d, k1) do

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -684,6 +684,7 @@ import Base.ImmutableDict
     d4 = ImmutableDict(d3, k2 => v1)
     dnan = ImmutableDict{String, Float64}(k2, NaN)
     dnum = ImmutableDict(dnan, k2 => 1)
+    f(x) = x^2
 
     @test isempty(collect(d))
     @test !isempty(collect(d1))
@@ -729,6 +730,18 @@ import Base.ImmutableDict
     @test get(d4, "key1", :default) === v2
     @test get(d4, "foo", :default) === :default
     @test get(d, k1, :default) === :default
+    @test get(d1, "key1") do
+        f(2)
+    end === v1
+    @test get(d4, "key1") do
+        f(4)
+    end === v2
+    @test get(d4, "foo") do 
+        f(6)
+    end === 36
+    @test get(d, k1) do
+        f(8)
+    end === 64
     @test d1["key1"] === v1
     @test d4["key1"] === v2
     @test empty(d3) === d


### PR DESCRIPTION
Added a function to `base/dict.jl` to extend `get()` to accept a default function as argument, as discussed in, and to resolve #40413.
Added tests to `test/dict.jl`, in analogy with those defined for `get(::Function, ::Dict, key)`.