### PR TITLE
WIP: Add sysimage autoload mechanism

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -486,6 +486,13 @@ function explicit_project_deps_get(project_file::String, name::String)::Union{No
     return nothing
 end
 
+function explicit_project_deps_get_all(project_file::String)
+    d = parsed_toml(project_file)
+    deps = get(d, "deps", nothing)::Union{Dict{String, Any}, Nothing}
+    deps === nothing && return PkgId[]
+    [PkgId(UUID(uuid), name) for (name, uuid) in deps if uuid !== nothing]
+end
+
 # find `where` stanza and return the PkgId for `name`
 # return `nothing` if it did not find `where` (indicating caller should continue searching)
 function explicit_manifest_deps_get(project_file::String, where::UUID, name::String)::Union{Nothing,PkgId}

--- a/base/options.jl
+++ b/base/options.jl
@@ -28,6 +28,7 @@ struct JLOptions
     warn_overwrite::Int8
     can_inline::Int8
     polly::Int8
+    autoload::Int8
     trace_compile::Ptr{UInt8}
     fast_math::Int8
     worker::Int8

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7888,7 +7888,6 @@ extern "C" void jl_init_llvm(void)
 {
     jl_page_size = jl_getpagesize();
     imaging_mode = jl_options.image_codegen || (jl_generating_output() && !jl_options.incremental);
-    jl_default_cgparams.generic_context = jl_nothing;
     jl_init_debuginfo();
 
     InitializeNativeTarget();
@@ -8050,6 +8049,11 @@ extern "C" void jl_init_llvm(void)
 
 extern "C" void jl_init_codegen(void)
 {
+    static bool codegen_inited = false;
+    jl_default_cgparams.generic_context = jl_nothing;
+    if (codegen_inited)
+        return;
+
     jl_init_llvm();
     // Now that the execution engine exists, initialize all modules
     jl_init_jit();
@@ -8060,6 +8064,7 @@ extern "C" void jl_init_codegen(void)
     init_julia_llvm_env(m);
 
     jl_init_intrinsic_functions_codegen();
+    codegen_inited = true;
 }
 
 extern "C" void jl_teardown_codegen()

--- a/src/gf.c
+++ b/src/gf.c
@@ -2272,6 +2272,12 @@ STATIC_INLINE int sig_match_fast(jl_value_t *arg1t, jl_value_t **args, jl_value_
 
 jl_typemap_entry_t *call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 static uint8_t pick_which[N_CALL_CACHE];
+
+void jl_reset_call_cache(void)
+{
+    memset(call_cache, 0, sizeof(call_cache));
+}
+
 #ifdef JL_GF_PROFILE
 size_t ncalls;
 void call_cache_stats()

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -58,6 +58,7 @@ jl_options_t jl_options = { 0,    // quiet
                             0,    // method overwrite warning
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly
+                            0,    // autoload
                             NULL, // trace_compile
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
@@ -208,6 +209,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_bug_report,
            opt_image_codegen,
            opt_rr_detach,
+           opt_autoload,
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:it:p:O:g:";
     static const struct option longopts[] = {
@@ -231,6 +233,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "procs",           required_argument, 0, 'p' },
         { "threads",         required_argument, 0, 't' },
         { "machine-file",    required_argument, 0, opt_machine_file },
+        { "autoload",        no_argument,       0, opt_autoload },
         { "project",         optional_argument, 0, opt_project },
         { "color",           required_argument, 0, opt_color },
         { "history-file",    required_argument, 0, opt_history_file },
@@ -445,6 +448,9 @@ restart_switch:
             break;
         case opt_project:
             jl_options.project = optarg ? strdup(optarg) : "@.";
+            break;
+        case opt_autoload:
+            jl_options.autoload=1;
             break;
         case opt_color:
             if (!strcmp(optarg, "yes"))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1656,7 +1656,8 @@ JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
 JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
-JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname);
+JL_DLLEXPORT int jl_preload_sysimg_so(const char *fname);
+JL_DLLEXPORT void jl_unload_system_image(int dlclose_handle);
 JL_DLLEXPORT void jl_set_sysimg_so(void *handle);
 JL_DLLEXPORT ios_t *jl_create_system_image(void *);
 JL_DLLEXPORT void jl_save_system_image(const char *fname);
@@ -1998,6 +1999,7 @@ typedef struct {
     int8_t warn_overwrite;
     int8_t can_inline;
     int8_t polly;
+    int8_t autoload;
     const char *trace_compile;
     int8_t fast_math;
     int8_t worker;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -197,6 +197,7 @@ extern size_t jl_page_size;
 extern jl_function_t *jl_typeinf_func;
 extern size_t jl_typeinf_world;
 extern jl_typemap_entry_t *call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
+void jl_reset_call_cache(void);
 extern jl_array_t *jl_all_methods JL_GLOBALLY_ROOTED;
 
 JL_DLLEXPORT extern int jl_lineno;
@@ -1338,6 +1339,7 @@ void jl_write_compiler_output(void);
 #endif
 
 jl_sym_t *_jl_symbol(const char *str, size_t len) JL_NOTSAFEPOINT;
+void jl_reset_symbol_type(void) JL_GC_DISABLED;
 
 // Tools for locally disabling spurious compiler warnings
 //

--- a/src/processor.h
+++ b/src/processor.h
@@ -159,6 +159,7 @@ typedef struct _jl_sysimg_fptrs_t {
  * Return the data about the function pointers selected.
  */
 jl_sysimg_fptrs_t jl_init_processor_sysimg(void *hdl);
+void jl_reset_processor_sysimg(void);
 
 // Return the name of the host CPU as a julia string.
 JL_DLLEXPORT jl_value_t *jl_get_cpu_name(void);

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -1011,6 +1011,11 @@ jl_sysimg_fptrs_t jl_init_processor_sysimg(void *hdl)
     return parse_sysimg(hdl, sysimg_init_cb);
 }
 
+void jl_reset_processor_sysimg()
+{
+    jit_targets.clear();
+}
+
 std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags)
 {
     ensure_jit_target(imaging);


### PR DESCRIPTION
This is the second part of the plan described in #40414
(though complimentary to the PR itself). In particular, this
PR makes it possible to quickly replace a system image during
initial startup. This is done by adding a hook early in the
startup sequence (after the system image, but before any
dependent libraries are initialized) for Julia to look at
the specified project file and decide to load a different
sysimage instead.

In the current version of the PR, this works as following:
 - If the `--autoload` argument is specified, julia will hash
   the contents of the currently active project's manifest path.
 - If a corresponding .so is found in `~/.julia/sysimages`, it will
   load that sysimage instead.
 - If not, loading will proceed as usual, a warning is generated
   but before any user code is run, Julia will `require` any
   dependencies specified in the Project.toml.

The third point is there such that independent of whether or not
the system image is found, the environment upon transfer of
control to the user is always the same (e.g. a package may
have type-pirated a method, which is available independent
of whether the user ever explicitly did `using`).

This is highly incomplete. In particular, these scheme to find
the system image needs to take account of preferences and should
probably exlcude any packages that are `dev`'ed (or their
dependents). I'm not sure I'll have the time to get around to
finishing this, but I'm hoping somebody else would be willing
to jump in for that part. The underlying mechanism seems to work
fine at this point, so this work should be mostly confined to
loading.jl.