### PR TITLE
Add unsafe option to `notify` for unsafe unblocking

### DIFF
--- a/base/condition.jl
+++ b/base/condition.jl
@@ -127,9 +127,9 @@ is raised as an exception in the woken tasks.
 
 Return the count of tasks woken up. Return 0 if no tasks are waiting on `condition`.
 """
-notify(c::GenericCondition, @nospecialize(arg = nothing); all=true, error=false) = notify(c, arg, all, error)
-function notify(c::GenericCondition, @nospecialize(arg), all, error)
-    assert_havelock(c)
+notify(c::GenericCondition, @nospecialize(arg = nothing); all=true, error=false, unsafe=false) = notify(c, arg, all, error; unsafe=unsafe)
+function notify(c::GenericCondition, @nospecialize(arg), all, error; unsafe=false)
+    unsafe || assert_havelock(c)
     cnt = 0
     while !isempty(c.waitq)
         t = popfirst!(c.waitq)


### PR DESCRIPTION
In trying to find ways to unblock `readline(stdin)` for implementing a timeout for `Base.prompt` https://github.com/JuliaLang/julia/pull/39027, adding an `unsafe` option to `notify` to disable concurrency violation checks, and temporarily setting the io to closed seemingly "works" without breaking the repl stdin, but I suspect it's not legal?

```julia
julia> function readline_timeout(io::Base.TTY, timeout)
           stat_before = io.status
           Timer(timeout) do t
               io.status = Base.StatusClosed
               notify(io.cond, unsafe=true)
           end
           try
               readline(io)
           finally
               io.status = stat_before
          end
       end
readline_timeout (generic function with 1 method)

julia> readline_timeout(stdin, 3)
""

julia> versioninfo()
Julia Version 1.7.0-DEV.864
Commit d02aba4c21* (2021-04-07 16:11 UTC)
...
```