### PR TITLE
fix #40478: MethodError hint printed twice

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -313,7 +313,6 @@ function showerror(io::IO, ex::MethodError)
                       "\nYou can convert to a column vector with the vec() function.")
         end
     end
-    Experimental.register_error_hint(noncallable_number_hint_handler, MethodError)
     Experimental.show_error_hints(io, ex, arg_types_param, kwargs)
     try
         show_method_candidates(io, ex, kwargs)
@@ -885,3 +884,5 @@ function noncallable_number_hint_handler(io, ex, arg_types, kwargs)
         print(io, "?")
     end
 end
+
+Experimental.register_error_hint(noncallable_number_hint_handler, MethodError)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -638,7 +638,10 @@ struct ANumber <: Number end
 let err_str
     err_str = @except_str ANumber()(3 + 4) MethodError
     @test occursin("objects of type $(curmod_prefix)ANumber are not callable", err_str)
-    @test occursin("Maybe you forgot to use an operator such as *, ^, %, / etc. ?", err_str)
+    @test count(==("Maybe you forgot to use an operator such as *, ^, %, / etc. ?"), split(err_str, '\n')) == 1
+    # issue 40478
+    err_str = @except_str ANumber()(3 + 4) MethodError
+    @test count(==("Maybe you forgot to use an operator such as *, ^, %, / etc. ?"), split(err_str, '\n')) == 1
 end
 
 # Execute backtrace once before checking formatting, see #38858


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/40304 accidentally registered
the error hint every time the error was printed.