### PR TITLE
prevent conj! into uninitialized memory

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -683,7 +683,7 @@ function copyto!(B::AbstractVecOrMat, ir_dest::UnitRange{Int}, jr_dest::UnitRang
         copyto!(B, ir_dest, jr_dest, M, ir_src, jr_src)
     else
         LinearAlgebra.copy_transpose!(B, ir_dest, jr_dest, M, jr_src, ir_src)
-        tM == 'C' && conj!(B)
+        tM == 'C' && conj!(@view B[ir_dest, jr_dest])
     end
     B
 end
@@ -693,7 +693,7 @@ function copy_transpose!(B::AbstractMatrix, ir_dest::UnitRange{Int}, jr_dest::Un
         LinearAlgebra.copy_transpose!(B, ir_dest, jr_dest, M, ir_src, jr_src)
     else
         copyto!(B, ir_dest, jr_dest, M, jr_src, ir_src)
-        tM == 'C' && conj!(B)
+        tM == 'C' && conj!(@view B[ir_dest, jr_dest])
     end
     B
 end


### PR DESCRIPTION
From my understanding, the current matmul code loads some buffer memory and "casts" it to an array of the element type:

https://github.com/JuliaLang/julia/blob/2fed7c34739cfe97610fa648b8ddc29b3c5141d6/stdlib/LinearAlgebra/src/matmul.jl#L833

stores some data into a part of that buffer:


https://github.com/JuliaLang/julia/blob/2fed7c34739cfe97610fa648b8ddc29b3c5141d6/stdlib/LinearAlgebra/src/matmul.jl#L840

, but then goes on and `conj!` the full memory:

https://github.com/JuliaLang/julia/blob/2fed7c34739cfe97610fa648b8ddc29b3c5141d6/stdlib/LinearAlgebra/src/matmul.jl#L686

Since this code runs for user defined types calling `conj` on uninitialized memory can have side effects (like throwing). I think this is what causes the errors in https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/f2bc4d3_vs_9283b6c/NiceNumbers.1.6.1-pre-d190257cce.log. Tests passes with this PR.

Im not 100% sure my analysis here is correct so some more eyes on it would be nice.

