### PR TITLE
Add Documentation to RegexMatch and keys(::RegexMatch)

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -145,6 +145,46 @@ in a string using an `AbstractPattern`.
 """
 abstract type AbstractMatch end
 
+"""
+A type representing a single match to a `Regex` found in a string.
+Typically created from the [`match`](@ref) function.
+
+The `match` field stores the substring of the entire matched string.
+The `captures` field stores the substrings for each capture group, indexed by number.
+To index by capture group name, the entire match object should be indexed instead,
+as shown in the examples.
+The location of the start of the match is stored in the `offset` field.
+The `offsets` field stores the locations of the start of each capture group,
+with 0 denoting a group that was not captured.
+
+This type can be used as an iterator over the capture groups of the `Regex`,
+yielding the substrings captured in each group.
+Because of this, the captures of a match can be destructured.
+If a group was not captured, `nothing` will be yielded instead of a substring.
+
+Methods that accept a `RegexMatch` object are defined for [`iterate`](@ref),
+[`length`](@ref), [`eltype`](@ref), [`keys`](@ref keys(::RegexMatch)), [`haskey`](@ref), and
+[`getindex`](@ref), where keys are the the names or numbers of a capture group.
+See [`keys`](@ref keys(::RegexMatch)) for more information.
+
+# Examples
+```jldoctest
+julia> m = match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "11:30 in the morning")
+RegexMatch("11:30", hour="11", minute="30", 3=nothing)
+
+julia> hr, min, ampm = m
+RegexMatch("11:30", hour="11", minute="30", 3=nothing)
+
+julia> hr
+"11"
+
+julia> m["minute"]
+"30"
+
+julia> m.match
+"11:30"
+```
+"""
 struct RegexMatch <: AbstractMatch
     match::SubString{String}
     captures::Vector{Union{Nothing,SubString{String}}}
@@ -153,6 +193,28 @@ struct RegexMatch <: AbstractMatch
     regex::Regex
 end
 
+"""
+    keys(m::RegexMatch) -> Vector
+
+Returns a vector of keys for all capture groups of the underlying regex.
+A key is included even if the capture group fails to match.
+That is, `idx` will be in the return value even if `m.captures[idx] == nothing`.
+
+Unnamed capture groups will have integer keys corresponding to their index.
+Named capture groups will have string keys.
+
+!!! compat "Julia 1.7"
+    This method was added in Julia 1.7
+
+# Examples
+```jldoctest
+julia> keys(match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "11:30"))
+3-element Vector{Any}:
+  "hour"
+  "minute"
+ 3
+```
+"""
 function keys(m::RegexMatch)
     idx_to_capture_name = PCRE.capture_names(m.regex.regex)
     return map(eachindex(m.captures)) do i
@@ -275,7 +337,7 @@ end
 """
     match(r::Regex, s::AbstractString[, idx::Integer[, addopts]])
 
-Search for the first match of the regular expression `r` in `s` and return a `RegexMatch`
+Search for the first match of the regular expression `r` in `s` and return a [`RegexMatch`](@ref)
 object containing the match, or nothing if the match failed. The matching substring can be
 retrieved by accessing `m.match` and the captured sequences can be retrieved by accessing
 `m.captures` The optional `idx` argument specifies an index at which to start the search.

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -146,6 +146,8 @@ in a string using an `AbstractPattern`.
 abstract type AbstractMatch end
 
 """
+    RegexMatch
+
 A type representing a single match to a `Regex` found in a string.
 Typically created from the [`match`](@ref) function.
 
@@ -172,8 +174,7 @@ See [`keys`](@ref keys(::RegexMatch)) for more information.
 julia> m = match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "11:30 in the morning")
 RegexMatch("11:30", hour="11", minute="30", 3=nothing)
 
-julia> hr, min, ampm = m
-RegexMatch("11:30", hour="11", minute="30", 3=nothing)
+julia> hr, min, ampm = m;
 
 julia> hr
 "11"
@@ -196,15 +197,15 @@ end
 """
     keys(m::RegexMatch) -> Vector
 
-Returns a vector of keys for all capture groups of the underlying regex.
+Return a vector of keys for all capture groups of the underlying regex.
 A key is included even if the capture group fails to match.
-That is, `idx` will be in the return value even if `m.captures[idx] == nothing`.
+That is, `idx` will be in the return value even if `m[idx] == nothing`.
 
 Unnamed capture groups will have integer keys corresponding to their index.
 Named capture groups will have string keys.
 
-!!! compat "Julia 1.7"
-    This method was added in Julia 1.7
+!!! compat "Julia 1.6"
+    This method was added in Julia 1.6
 
 # Examples
 ```jldoctest

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -33,6 +33,8 @@ Base.isvalid(::Any, ::Any)
 Base.isvalid(::AbstractString, ::Integer)
 Base.match
 Base.eachmatch
+Base.RegexMatch
+Base.keys(::RegexMatch)
 Base.isless(::AbstractString, ::AbstractString)
 Base.:(==)(::AbstractString, ::AbstractString)
 Base.cmp(::AbstractString, ::AbstractString)

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -801,7 +801,7 @@ else
 end
 ```
 
-If a regular expression does match, the value returned by [`match`](@ref) is a `RegexMatch`
+If a regular expression does match, the value returned by [`match`](@ref) is a [`RegexMatch`](@ref)
 object. These objects record how the expression matches, including the substring that the pattern
 matches and any captured substrings, if there are any. This example only captures the portion
 of the substring that matches, but perhaps we want to capture any non-blank text after the comment
@@ -882,10 +882,10 @@ julia> m.offsets
 ```
 
 It is convenient to have captures returned as an array so that one can use destructuring syntax
-to bind them to local variables:
+to bind them to local variables. As a convinience, the `RegexMatch` object implements iterator methods that pass through to the `captures` field, so you can destructure the match object directly:
 
 ```jldoctest acdmatch
-julia> first, second, third = m.captures; first
+julia> first, second, third = m; first
 "a"
 ```
 


### PR DESCRIPTION
Fixes #40347. I went ahead and added documentation for the the RegexMatch type as well. I also updated the manual to destructure on m rather than m.captures.

Sorry about the second PR. I had whitespace issues in the old PR (#40485) and accidentally made a mess of the the commit graph trying to fix it, so I squashed those commits and opened a new PR.