### PR TITLE
define `ActiveIteration` type alias

### DIFF
--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -441,7 +441,7 @@ function _accumulate1!(op, B, v1, A::AbstractVector, dim::Integer)
     inds = LinearIndices(A)
     inds == LinearIndices(B) || throw(DimensionMismatch("LinearIndices of A and B don't match"))
     dim > 1 && return copyto!(B, A)
-    (i1, state) = iterate(inds)::NTuple{2,Any} # We checked earlier that A isn't empty
+    (i1, state) = iterate(inds)::ActiveIteration # We checked earlier that A isn't empty
     cur_val = v1
     B[i1] = cur_val
     next = iterate(inds, state)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -889,6 +889,9 @@ next element and the new iteration state should be returned.
 """
 function iterate end
 
+# can be used to annotate the return of an active iteration
+const ActiveIteration = Tuple{Any, Any}
+
 """
     isiterable(T) -> Bool
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -10,7 +10,7 @@ import ..@__MODULE__, ..parentmodule
 const Base = parentmodule(@__MODULE__)
 using .Base:
     @inline, Pair, Pairs, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
-    tail, SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo,
+    tail, SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo, ActiveIteration,
     @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator, AbstractRange,
     LinearIndices, (:), |, +, -, !==, !, <=, <, missing, any, _counttuple
 
@@ -1316,7 +1316,7 @@ See also: [`first`](@ref), [`last`](@ref).
     @boundscheck if i === nothing
         throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
     end
-    (ret, state) = i::NTuple{2,Any}
+    (ret, state) = i::ActiveIteration
     @boundscheck if iterate(x, state) !== nothing
         throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
     end

--- a/base/set.jl
+++ b/base/set.jl
@@ -308,7 +308,7 @@ function _groupedunique!(A::AbstractVector)
     idxs = eachindex(A)
     y = first(A)
     # We always keep the first element
-    T = NTuple{2,Any} # just to eliminate `iterate(idxs)::Nothing` candidate
+    T = ActiveIteration # just to eliminate `iterate(idxs)::Nothing` candidate
     it = iterate(idxs, (iterate(idxs)::T)[2])
     count = 1
     for x in Iterators.drop(A, 1)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -183,7 +183,7 @@ isempty(s::AbstractString) = iszero(ncodeunits(s)::Int)
 
 function getindex(s::AbstractString, i::Integer)
     @boundscheck checkbounds(s, i)
-    @inbounds return isvalid(s, i) ? (iterate(s, i)::NTuple{2,Any})[1] : string_index_err(s, i)
+    @inbounds return isvalid(s, i) ? (iterate(s, i)::ActiveIteration)[1] : string_index_err(s, i)
 end
 
 getindex(s::AbstractString, i::Colon) = s

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -665,8 +665,8 @@ function hex2bytes!(dest::AbstractArray{UInt8}, itr)
 
     next = iterate(itr)
     @inbounds for i in eachindex(dest)
-        x,state = next::NTuple{2,Any}
-        y,state = iterate(itr, state)::NTuple{2,Any}
+        x,state = next::ActiveIteration
+        y,state = iterate(itr, state)::ActiveIteration
         next = iterate(itr, state)
         dest[i] = number_from_hex(x) << 4 + number_from_hex(y)
     end


### PR DESCRIPTION
This alias can be used when `iterate` is not finished yet, and hopefully be clearer than `NTuple{2, Any}`