### PR TITLE
fix %a/%A format for zeros

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -425,7 +425,7 @@ const __BIG_FLOAT_MAX__ = 8192
         x = round(x, sigdigits=prec)
         newpos = Ryu.writeshortest(buf, pos, x, plus, space, hash, prec, T == Val{'g'} ? UInt8('e') : UInt8('E'), true, UInt8('.'))
     elseif T == Val{'a'} || T == Val{'A'}
-        x, neg = x < 0 ? (-x, true) : (x, false)
+        x, neg = x < 0 || x === -Base.zero(x) ? (-x, true) : (x, false)
         newpos = pos
         if neg
             buf[newpos] = UInt8('-')
@@ -456,6 +456,8 @@ const __BIG_FLOAT_MAX__ = 8192
                 buf[newpos] = UInt8('0')
                 newpos += 1
                 if prec > 0
+                    buf[newpos] = UInt8('.')
+                    newpos += 1
                     while prec > 0
                         buf[newpos] = UInt8('0')
                         newpos += 1
@@ -465,6 +467,7 @@ const __BIG_FLOAT_MAX__ = 8192
                 buf[newpos] = T <: Val{'a'} ? UInt8('p') : UInt8('P')
                 buf[newpos + 1] = UInt8('+')
                 buf[newpos + 2] = UInt8('0')
+                newpos += 3
             else
                 if prec > -1
                     s, p = frexp(x)

--- a/stdlib/Printf/test/runtests.jl
+++ b/stdlib/Printf/test/runtests.jl
@@ -27,6 +27,9 @@ end
 @testset "%a" begin
 
     # hex float
+    @test (Printf.@sprintf "%a" 0.0) == "0x0p+0"
+    @test (Printf.@sprintf "%a" -0.0) == "-0x0p+0"
+    @test (Printf.@sprintf "%.3a" 0.0) == "0x0.000p+0"
     @test (Printf.@sprintf "%a" 1.5) == "0x1.8p+0"
     @test (Printf.@sprintf "%a" 1.5f0) == "0x1.8p+0"
     @test (Printf.@sprintf "%a" big"1.5") == "0x1.8p+0"


### PR DESCRIPTION
Currently, the `%a` (`%A`) format specification is broken for zeros. This PR fixes the following three independent problems:
```
julia> using Printf

julia> @sprintf "%a" 0.0  # expected:  "0x0p+0"
"0x0"

julia> @sprintf "%a" -0.0  # expected: "-0x0p+0"
"0x0"

julia> @sprintf "%.3a" 0.0  # expected: "0x0.000p+0"
"0x0000"
```