### PR TITLE
Sign julia.exe executable within the installer

### DIFF
--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -103,7 +103,8 @@ Name: "addtopath"; Description: "Add {#AppName} to PATH"; GroupDescription: "{cm
 
 
 [Files]
-Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SourceDir}\*"; Excludes: "{#AppMainExeName}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs;
+Source: "{#SourceDir}\{#AppMainExeName}"; DestDir: "{app}\bin"; Flags: ignoreversion sign;
 
 
 [Icons]

--- a/contrib/windows/julia.rc
+++ b/contrib/windows/julia.rc
@@ -18,7 +18,7 @@ BEGIN
       VALUE "FileDescription", "Julia Programming Language"
       VALUE "FileVersion", JLVER_STR
       VALUE "InternalName", "julia"
-      VALUE "LegalCopyright", "(c) 2009-2020 Julia Language"
+      VALUE "LegalCopyright", "(c) 2009-2021 Julia Language"
       VALUE "OriginalFilename", "julia.exe"
       VALUE "ProductName", "Julia"
       VALUE "ProductVersion", JLVER_STR


### PR DESCRIPTION
Issue: Slack report that the julia.exe executable isn't signed 

This patch ends up signing the julia.exe in addition to the installer which we already sign.

Universally adding the sign flag to the existing Source  Line  ends up signing **all** executables **and** dlls, which is slow and probably not necessary.  Thus,  the exe is filtered away and a second step is added that handles copying the julia executable to the installer and signing it individually. 
