### PR TITLE
Use `roundeven` instead of `rint` for `round(x)`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -167,6 +167,7 @@ add_tfunc(ceil_llvm, 1, 1, math_tfunc, 10)
 add_tfunc(floor_llvm, 1, 1, math_tfunc, 10)
 add_tfunc(trunc_llvm, 1, 1, math_tfunc, 10)
 add_tfunc(rint_llvm, 1, 1, math_tfunc, 10)
+add_tfunc(roundeven_llvm, 1, 1, math_tfunc, 10)
 add_tfunc(sqrt_llvm, 1, 1, math_tfunc, 20)
 add_tfunc(sqrt_llvm_fast, 1, 1, math_tfunc, 20)
     ## same-type comparisons ##

--- a/base/float.jl
+++ b/base/float.jl
@@ -367,7 +367,7 @@ round(::Type{Bool}, x::AbstractFloat) = (-0.5 <= x < 1.5) ? 0.5 < x : throw(Inex
 round(x::IEEEFloat, r::RoundingMode{:ToZero})  = trunc_llvm(x)
 round(x::IEEEFloat, r::RoundingMode{:Down})    = floor_llvm(x)
 round(x::IEEEFloat, r::RoundingMode{:Up})      = ceil_llvm(x)
-round(x::IEEEFloat, r::RoundingMode{:Nearest}) = rint_llvm(x)
+round(x::IEEEFloat, r::RoundingMode{:Nearest}) = roundeven_llvm(x)
 
 ## floating point promotions ##
 promote_rule(::Type{Float32}, ::Type{Float16}) = Float32

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -65,6 +65,7 @@ static void jl_init_intrinsic_functions_codegen(void)
     float_func[floor_llvm] = true;
     float_func[trunc_llvm] = true;
     float_func[rint_llvm] = true;
+    float_func[roundeven_llvm] = true;
     float_func[sqrt_llvm] = true;
     float_func[sqrt_llvm_fast] = true;
 }
@@ -1484,6 +1485,10 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
     case rint_llvm: {
         FunctionCallee rintintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::rint, makeArrayRef(t));
         return ctx.builder.CreateCall(rintintr, x);
+    }
+    case roundeven_llvm: {
+        FunctionCallee roundevenintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::roundeven, makeArrayRef(t));
+        return ctx.builder.CreateCall(roundevenintr, x);
     }
     case sqrt_llvm: {
         FunctionCallee sqrtintr = Intrinsic::getDeclaration(jl_Module, Intrinsic::sqrt, makeArrayRef(t));

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -86,6 +86,7 @@
     ADD_I(floor_llvm, 1) \
     ADD_I(trunc_llvm, 1) \
     ADD_I(rint_llvm, 1) \
+    ADD_I(roundeven_llvm, 1) \
     ADD_I(sqrt_llvm, 1) \
     ADD_I(sqrt_llvm_fast, 1) \
     /*  pointer access */ \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1255,6 +1255,7 @@ JL_DLLEXPORT jl_value_t *jl_ceil_llvm(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_floor_llvm(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_trunc_llvm(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_rint_llvm(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_roundeven_llvm(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_sqrt_llvm(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_sqrt_llvm_fast(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_abs_float(jl_value_t *a);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1445,6 +1445,7 @@ un_fintrinsic(ceil_float,ceil_llvm)
 un_fintrinsic(floor_float,floor_llvm)
 un_fintrinsic(trunc_float,trunc_llvm)
 un_fintrinsic(rint_float,rint_llvm)
+un_fintrinsic(roundeven_float,roundeven_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm_fast)
 


### PR DESCRIPTION
The `llvm.rint` intrinsic is sensitive to the floating-point
environment, so determined enough users can change the definition
of `round(x, RoundNearest)` to not be rount to even.

```
julia> round(2.5, RoundNearest)
2.0
julia> Base.Rounding.setrounding_raw(Float64, Base.Rounding.to_fenv(RoundUp))
julia> round(2.5, RoundNearest)
3.0
julia> roundeven(x::Float64) = ccall("llvm.roundeven.f64", llvmcall, Float64, (Float64,), x)
round_even (generic function with 1 method)
julia> roundeven(2.5)
2.0
```

The intrinsic was introduced with LLVM 11, and `roundeven` will be part
of the `C23` standard (problematic for us due to `runtime_intrinsics.cpp`).

Sadly performance isn't looking to hot. Using @simonbyrne benchmark from
https://github.com/JuliaLang/julia/issues/8750#issuecomment-65452631

```
julia> roundeven_llvm(x::Float64) = ccall("llvm.roundeven.f64", llvmcall, Float64, (Float64,), x)
roundeven_llvm (generic function with 1 method)

julia> rint_llvm(x::Float64) = ccall("llvm.rint.f64", llvmcall, Float64, (Float64,), x)
rint_llvm (generic function with 1 method)

julia> function test_roundeven_llvm(N)
           t = 1.0
           s = 0.0
           for i = 1:N
               t += eps()
               s += roundeven_llvm(t)
           end
           s
       end
test_roundeven_llvm (generic function with 1 method)

julia> function test_rint_llvm(N)
           t = 1.0
           s = 0.0
           for i = 1:N
               t += eps()
               s += rint_llvm(t)
           end
           s
       end
test_rint_llvm (generic function with 1 method)

julia> @time test_roundeven_llvm(100_000_000);
  0.274178 seconds

julia> @time test_roundeven_llvm(100_000_000);
  0.274118 seconds

julia> @time test_rint_llvm(100_000_000);
  0.087601 seconds

julia> @time test_rint_llvm(100_000_000);
  0.087860 seconds
```

On x86:

```
julia> @code_native roundeven_llvm(2.5)
	.text
	movabsq	$roundevenf64, %rax
	jmpq	*%rax
	nopl	(%rax)
```

e.g it's implemented with a function call to `roundevenf64`, which is implemented by libc.

