### PR TITLE
remove `===` for singleton equality tip

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1600,11 +1600,3 @@ will not require this degree of programmer annotation to attain performance.
 In the mean time, some user-contributed packages like
 [FastClosures](https://github.com/c42f/FastClosures.jl) automate the
 insertion of `let` statements as in `abmult3`.
-
-## Checking for equality with a singleton
-
-When checking if a value is equal to some singleton it can be
-better for performance to check for identicality (`===`) instead of
-equality (`==`). The same advice applies to using `!==` over `!=`.
-These type of checks frequently occur e.g. when implementing the iteration
-protocol and checking if `nothing` is returned from [`iterate`](@ref).


### PR DESCRIPTION
With #38905 merged, this shouldn't apply in general anymore. I am sure with `==` being a generic function, there will still be cases where using `===` will lead to more precise inference, but I don't think this is worth specifically mentioning in the performance tips.