### PR TITLE
Change getindex algorithms on sparse matrices

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2357,7 +2357,7 @@ function getindex_I_sorted_linear(A::AbstractSparseMatrixCSC{Tv,Ti}, I::Abstract
         stopA::Int = colptrA[col+1]
         while ptrA < stopA
             rowA = rowvalA[ptrA]
-            ptrI = haskey(hashmapI, rowA) ? hashmapI[rowA] : 0
+            ptrI = get(hashmapI, rowA, 0)
             if ptrI > 0
                 while ptrI <= nI && I[ptrI] == rowA
                     rowvalS[ptrS] = ptrI


### PR DESCRIPTION
Two of the current algorithms for accessing SparseMatrixCSC (`getindex_I_sorted_linear` and `getindex_I_sorted_bsearch_I`) are suboptimalas they use a cache linear in size of the overall matrix. 

I made changes to both algorithms to avoid this. `getindex_I_sorted_bsearch_I` seems fine now, although there might be performance improvements possible.

`getindex_I_sorted_linear` should ideally use an efficient implementation of a hashmap to be performant. As of now using Dict is somewhat slower on small matrices. One has to go to big problems in order to see performance benefits.

It could be great if people could look at this. I have raised the issue here: https://discourse.julialang.org/t/getindex-a-i-j-wrong-complexity-on-sparsematrixcsc/59277 