### PR TITLE
RFC: Abbreviated stack traces in REPL

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -96,6 +96,9 @@ function scrub_repl_backtrace(bt)
         bt = bt isa Vector{StackFrame} ? copy(bt) : stacktrace(bt)
         # remove REPL-related frames from interactive printing
         eval_ind = findlast(frame -> !frame.from_c && frame.func === :eval, bt)
+        # sysimages may drop debug info and won't have inlined frames present in the backtrace
+        # in that case, `eval` may be dropped, but `eval_user_input` should be present
+        eval_ind === nothing && (eval_ind = findlast(frame -> !frame.from_c && frame.func === :eval_user_input, bt))
         eval_ind === nothing || deleteat!(bt, eval_ind:length(bt))
     end
     return bt

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -824,7 +824,7 @@ function show_compact_backtrace(io::IO, trace::Vector; print_linebreaks::Bool)
 
     # select frames from user-controlled code
     is = find_visible_frames(trace)
-    
+
     num_vis_frames = length(is)
 
     if num_vis_frames > 0
@@ -850,7 +850,7 @@ function show_compact_backtrace(io::IO, trace::Vector; print_linebreaks::Bool)
         end
 
         # print if frames other than top-level were omitted
-        if num_frames - 1 > num_vis_frames 
+        if num_frames - 1 > num_vis_frames
             if lasti < num_frames - 1
                 println(io)
                 print_omitted_modules(lasti + 1, num_frames - 1)

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -206,7 +206,6 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
             elseif miroots !== nothing
                 linfo = lookup_inline_frame_info(func, file, miroots)
             end
-            linfo = linfo === nothing ? parentmodule(res[i + 1]) : linfo # e.g. `macro expansion`
         end
         res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer)
     end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -308,7 +308,10 @@ is_top_level_frame(f::StackFrame) = f.linfo isa CodeInfo || (f.linfo === nothing
 
 function show_spec_linfo(io::IO, frame::StackFrame)
     linfo = frame.linfo
-    if linfo === nothing
+    internalflag = get(io, :stacktrace_internal_removed, nothing)
+    skip_internal = ((internalflag === nothing ? false : internalflag[]) || parse(Bool, get(ENV, "JULIA_STACKTRACE_ABBREVIATED", "false"))) &&
+        parse(Bool, get(ENV, "JULIA_STACKTRACE_MINIMAL", "false"))
+    if linfo === nothing || skip_internal
         if frame.func === empty_sym
             print(io, "ip:0x", string(frame.pointer, base=16))
         elseif frame.func === top_level_scope_sym

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -61,7 +61,7 @@ remote exception and a serializable form of the call stack when the exception wa
 RemoteException(captured) = RemoteException(myid(), captured)
 function showerror(io::IO, re::RemoteException)
     (re.pid != myid()) && print(io, "On worker ", re.pid, ":\n")
-    showerror(io, re.captured)
+    showerror(io, re.captured) # Does :stacktrace_internal_removed need to be set to false for the IO here anymore?
 end
 
 function run_work_thunk(thunk::Function, print_error::Bool)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -291,7 +291,8 @@ end
 function repl_display_error(errio::IO, @nospecialize errval)
     # this will be set to true if types in the stacktrace are truncated
     limitflag = Ref(false)
-    errio = IOContext(errio, :stacktrace_types_limited => limitflag)
+    internalflag = Ref(isinteractive() ? true : false)
+    errio = IOContext(errio, :stacktrace_types_limited => limitflag, :stacktrace_internal_removed => internalflag)
     Base.invokelatest(Base.display_error, errio, errval)
     if limitflag[]
         print(errio, "Some type information was truncated. Use `show(err)` to see complete types.")


### PR DESCRIPTION
I went ahead and implemented a version of my suggestion  #40138

**Post updated with current state 5/5/22**

The philosophy here is that for 95% of purposes, Julia Base, stdlib, and registry packages are black boxes to the user. While it's an important part of Julia that their internals are accessible, they don't need to be shown by default. Plots.jl and BenchmarkTools are excellent example of where cluttered stack traces get in the way and fill the screen:
```julia
using Plots, BenchmarkTools
@btime plot([1,2,3], seriestype=:blah);

ERROR: The backend must not support the series type Val{:blah}, and there isn't a series recipe defined.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] macro expansion
    @ ~/.julia/packages/RecipesPipeline/CirY4/src/type_recipe.jl:9 [inlined]
  [3] apply_recipe(plotattributes::AbstractDict{Symbol, Any}, #unused#::Type{Val{:blah}}, x::Any, y::Any, z::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesBase/92zOw/src/RecipesBase.jl:282
  [4] _process_seriesrecipe(plt::Any, plotattributes::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesPipeline/CirY4/src/series_recipe.jl:50
  [5] _process_seriesrecipes!(plt::Any, kw_list::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesPipeline/CirY4/src/series_recipe.jl:27
  [6] recipe_pipeline!(plt::Any, plotattributes::Any, args::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesPipeline/CirY4/src/RecipesPipeline.jl:97
  [7] _plot!(plt::Plots.Plot, plotattributes::Any, args::Any)
    @ Plots ~/.julia/packages/Plots/kyYZF/src/plot.jl:172
  [8] plot(args::Any; kw::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
    @ Plots ~/.julia/packages/Plots/kyYZF/src/plot.jl:58
  [9] var"##core#278"()
    @ Main ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:371
 [10] var"##sample#279"(__params::BenchmarkTools.Parameters)
    @ Main ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:377
 [11] _run(b::BenchmarkTools.Benchmark{Symbol("##benchmark#277")}, p::BenchmarkTools.Parameters; verbose::Bool, pad::String, kwargs::Base.Pairs{Symbol, Integer, NTuple{4, Symbol}, NamedTuple{(:samples, :evals, :gctrial, :gcsample), Tuple{Int64, Int64, Bool, Bool}}})
    @ Main ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:405
 [12] #invokelatest#2
    @ ./essentials.jl:723 [inlined]
 [13] #run_result#39
    @ ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:32 [inlined]
 [14] run(b::BenchmarkTools.Benchmark{Symbol("##benchmark#277")}, p::BenchmarkTools.Parameters; progressid::Nothing, nleaves::Float64, ndone::Float64, kwargs::Base.Pairs{Symbol, Integer, NTuple{5, Symbol}, NamedTuple{(:verbose, :samples, :evals, :gctrial, :gcsample), Tuple{Bool, Int64, Int64, Bool, Bool}}})
    @ BenchmarkTools ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:94
 [15] #warmup#47
    @ ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:141 [inlined]
 [16] warmup(item::BenchmarkTools.Benchmark{Symbol("##benchmark#277")})
    @ BenchmarkTools ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:141
 [17] top-level scope
    @ ~/.julia/packages/BenchmarkTools/Kt6kv/src/execution.jl:481
```

**What does this do?**
~~- Adds a global variable `err` that is set in the REPL when an exception is encountered, similar to `ans`, which is of type `ExceptionInfo`, which is just a wrapper around the array, to dispatch to the correct `show` method. Anything hidden in the default view will be shown here.~~ Was added in separate PR
- Adds a default compact stack trace display that elides all internal stack frames found in Base, an Stdlib, or an `add`ed registry package, except for the first one called into by a visible stack frame, which is the public surface of the other package
- Does **not** affect non-REPL Julia sessions or remote workers, so CI and HPC runs should display full stack traces

After this PR, the above example looks like this:
![image](https://user-images.githubusercontent.com/1438610/167051822-7cff3311-367a-4c5b-8552-f8a52e699a12.png)

The "Unknown" module comes from inlined stack frames, which are currently missing information. This may be removed with PRs like #41099