### PR TITLE
RFC: add `and` and `or` suggestions to UndefVarError, per #37469

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -878,6 +878,7 @@ end
 # the instance of a number (probably missing the operator)
 # eg: (1 + 2)(3 + 4)
 function noncallable_number_hint_handler(io, ex, arg_types, kwargs)
+    @nospecialize
     if ex.f isa Number
         print(io, "\nMaybe you forgot to use an operator such as ")
         printstyled(io, "*, ^, %, / etc. ", color=:cyan)

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -817,4 +817,18 @@ function shell_completions(string, pos)
     return Completion[], 0:-1, false
 end
 
+function UndefVarError_hint(io::IO, ex::UndefVarError)
+    var = ex.var
+    if var === :or
+        print("\nsuggestion: Use `||` for short-circuiting boolean OR.")
+    elseif var === :and
+        print("\nsuggestion: Use `&&` for short-circuiting boolean AND.")
+    end
+end
+
+function __init__()
+    Base.Experimental.register_error_hint(UndefVarError_hint, UndefVarError)
+    nothing
+end
+
 end # module


### PR DESCRIPTION
Replaces #37471 and closes #37469. In the future, I envision this list becoming much longer, with completions based upon context and spell-checking (either here, or perhaps somewhere like OhMyRepl). But testing this out first to see whether others agree this is a good approach.

```
julia> or
ERROR: UndefVarError: or not defined
suggestion: Use `||` for short-circuiting boolean OR.

julia> and
ERROR: UndefVarError: and not defined
suggestion: Use `&&` for short-circuiting boolean AND.
```

Co-authored-by: Jerry Ling (@Moelf)