### PR TITLE
unexport cat_shape

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -237,7 +237,11 @@ function parameter_upper_bound(t::UnionAll, idx)
 end
 
 # these were internal functions, but some packages seem to be relying on them
-@deprecate cat_shape(dims, shape::Tuple{}, shapes::Tuple...) cat_shape(dims, shapes)
+function cat_shape(dims, shape::Tuple{}, shapes::Tuple...)
+    # use depwarn so that `cat_shape` is not exported
+    depwarn("`cat_shape(dims, shape::Tuple{}, shapes::Tuple...)` is deprecated, use `cat_shae(dims, shapes)` instead.", :cat_shape)
+    cat_shape(dims, shapes)
+end
 cat_shape(dims, shape::Tuple{}) = () # make sure `cat_shape(dims, ())` do not recursively calls itself
 
 # END 1.6 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -237,11 +237,7 @@ function parameter_upper_bound(t::UnionAll, idx)
 end
 
 # these were internal functions, but some packages seem to be relying on them
-function cat_shape(dims, shape::Tuple{}, shapes::Tuple...)
-    # use depwarn so that `cat_shape` is not exported
-    depwarn("`cat_shape(dims, shape::Tuple{}, shapes::Tuple...)` is deprecated, use `cat_shae(dims, shapes)` instead.", :cat_shape)
-    cat_shape(dims, shapes)
-end
+@deprecate cat_shape(dims, shape::Tuple{}, shapes::Tuple...) cat_shape(dims, shapes) false
 cat_shape(dims, shape::Tuple{}) = () # make sure `cat_shape(dims, ())` do not recursively calls itself
 
 # END 1.6 deprecations


### PR DESCRIPTION
This symbol was unexpectedly exported by the `deprecate` macro

resolves the comment in https://github.com/JuliaLang/julia/pull/36838#discussion_r615951719

Should we backport this to 1.6?

cc: @mbauman 