### PR TITLE
Fix rational division by zero

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -931,7 +931,7 @@ function Base.://(x::Rational{BigInt}, y::Rational{BigInt})
         if iszero(x.num)
             throw(DivideError())
         end
-        return isneg(x.num) ? typemin(BigFloat) : typemax(BigFloat)
+        return (isneg(x.num) ? -one(BigInt) : one(BigInt)) // y.num
     end
     zq = _MPQ()
     ccall((:__gmpq_div, :libgmp), Cvoid,

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -931,7 +931,7 @@ function Base.://(x::Rational{BigInt}, y::Rational{BigInt})
         if iszero(x.num)
             throw(DivideError())
         end
-        return (isneg(x.num) ? -one(BigFloat) : one(BigFloat)) // y.num
+        return isneg(x.num) ? typemin(BigFloat) : typemax(BigFloat)
     end
     zq = _MPQ()
     ccall((:__gmpq_div, :libgmp), Cvoid,

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -78,8 +78,8 @@ ee = typemax(Int64)
         @test -oz == oz / (-one(oz))
         @test zero(oz) == one(oz) / oz
         @test_throws DivideError() zo / zo
-        @test typemax(BigFloat) == one(zo) / zo
-        @test typemin(BigFloat) == -one(zo) / zo
+        @test one(zo) / zo == big(1//0)
+        @test -one(zo) / zo == big(-1//0)
     end
 end
 @testset "div, fld, mod, rem" begin

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -69,6 +69,18 @@ ee = typemax(Int64)
             @test big(typeof(complex(x, x))) == typeof(big(complex(x, x)))
         end
     end
+    @testset "division" begin
+        oz = big(2 // 0)
+        zo = big(0 // 2)
+
+        @test_throws DivideError() oz / oz
+        @test oz == oz / one(oz)
+        @test -oz == oz / (-one(oz))
+        @test zero(oz) == one(oz) / oz
+        @test_throws DivideError() zo / zo
+        @test typemax(BigFloat) == one(zo) / zo
+        @test typemin(BigFloat) == -one(zo) / zo
+    end
 end
 @testset "div, fld, mod, rem" begin
     for i = -10:10, j = [-10:-1; 1:10]

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -70,8 +70,8 @@ ee = typemax(Int64)
         end
     end
     @testset "division" begin
-        oz = big(2 // 0)
-        zo = big(0 // 2)
+        oz = big(1 // 0)
+        zo = big(0 // 1)
 
         @test_throws DivideError() oz / oz
         @test oz == oz / one(oz)


### PR DESCRIPTION
On Julia v1.5.3:
```julia
julia> a = big(1 // 1)
1//1

julia> a / zero(a)
1//0
```
On Julia v1.6.0
```julia
julia> a = big(1 // 1)
1//1

julia> a / zero(a)
ERROR: MethodError: no method matching //(::BigFloat, ::BigInt)
Closest candidates are:
  //(::Integer, ::Integer) at rational.jl:61
  //(::Rational, ::Integer) at rational.jl:63
  //(::Complex, ::Real) at rational.jl:77
simonbyrne   ...
Stacktrace:
 [1] //(x::Rational{BigInt}, y::Rational{BigInt})
   @ Base.GMP.MPQ ./gmp.jl:934
 [2] /(x::Rational{BigInt}, y::Rational{BigInt})
   @ Base ./rational.jl:321
 [3] top-level scope
   @ REPL[2]:1
```
It seems the line was not covered by tests so the PR both fixes the error and adds some tests.

Note that the behavior is still different from Julia v1.5.3 but there is no error and it seems to be the behavior intended by @simonbyrne in https://github.com/JuliaLang/julia/pull/38520