### PR TITLE
limit Fix2 findfirst method to Number ranges

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1966,7 +1966,7 @@ findfirst(p::Union{Fix2{typeof(isequal),Int},Fix2{typeof(==),Int}}, r::OneTo{Int
 findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::AbstractUnitRange) where {T<:Integer} =
     first(r) <= p.x <= last(r) ? 1+Int(p.x - first(r)) : nothing
 
-function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
+function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T<:Number,S}
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing
     d = convert(S, p.x - first(r))


### PR DESCRIPTION
The `Fix2` `isequal` optimization is broken for `DateTime`,  This PR limits the optimization to `Number` so other
types use the regular implementation.

Heres a comparison of the `Fix2` and using an anonymous function:

```julia
julia> using Dates

julia> timespan = DateTime(2001,1):Month(1):DateTime(2001,12)
DateTime("2001-01-01T00:00:00"):Month(1):DateTime("2001-12-01T00:00:00")

julia> findfirst(x -> isequal(x, DateTime(2001, 1)), timespan)
1

julia> findfirst(isequal(DateTime(2001, 1)), timespan)
ERROR: MethodError: Cannot `convert` an object of type Millisecond to an object of type Month
Closest candidates are:
  convert(::Type{Month}, ::Year) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/periods.jl:434
  convert(::Type{Month}, ::Quarter) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Dates/src/periods.jl:452
  convert(::Type{T}, ::T) where T at essentials.jl:205
  ...
Stacktrace:
 [1] findfirst(p::Base.Fix2{typeof(isequal), DateTime}, r::StepRange{DateTime, Month})
   @ Base ./array.jl:1918
 [2] top-level scope
   @ REPL[39]:1
````