### PR TITLE
Improve type stability for tryparse VersionNumber

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -107,7 +107,7 @@ end
 
 function tryparse(::Type{VersionNumber}, v::AbstractString)
     v == "∞" && return typemax(VersionNumber)
-    m = match(VERSION_REGEX, String(v))
+    m = match(VERSION_REGEX, String(v)::String)
     m === nothing && return nothing
     major, minor, patch, minus, prerl, plus, build = m.captures
     major = parse(VInt, major::AbstractString)

--- a/base/version.jl
+++ b/base/version.jl
@@ -107,7 +107,7 @@ end
 
 function tryparse(::Type{VersionNumber}, v::AbstractString)
     v == "∞" && return typemax(VersionNumber)
-    m = match(VERSION_REGEX, v)
+    m = match(VERSION_REGEX, String(v))
     m === nothing && return nothing
     major, minor, patch, minus, prerl, plus, build = m.captures
     major = parse(VInt, major::AbstractString)


### PR DESCRIPTION
I noticed that LaTeXStrings is causing 297 method invalidations:

```
inserting firstindex(s::LaTeXString) in LaTeXStrings at /home/rik/git/LaTeXStrings.jl/src/LaTeXStrings.jl:108 invalidated:
   backedges: 1: superseding firstindex(s::AbstractString) in Base at /nix/store/31534zna4n6p2s0jwadn8jl6lkvxqjch-julia_16/share/julia/base/strings/basic.jl:180 with MethodInstance for firstindex(::AbstractString) (297 children)
```

Specifically, the invalidation tree starts with

     firstindex(::AbstractString)
       match(::Regex, ::AbstractString)
         tryparse(::Type{VersionNumber}, ::AbstractString)

If I understand invalidations correctly, this invalidation will happen for any package which defines a new `firstindex(::T)` where `T isa AbstractString`. Although they can fix it by also defining `match(r::Regex, T)`; it is probably a good idea to avoid these invalidations altogether.
