### PR TITLE
Explicit test that `shuffle!` behaves correct on `BitArray`s

### DIFF
--- a/stdlib/Random/Project.toml
+++ b/stdlib/Random/Project.toml
@@ -9,6 +9,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [targets]
-test = ["Test", "SparseArrays", "LinearAlgebra", "Future"]
+test = ["Test", "SparseArrays", "LinearAlgebra", "Future", "Statistics"]

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -906,7 +906,7 @@ end
     m = mean(1:50_000) do _
         shuffle!(rng, a)
     end # mean result of shuffle!-ing a 50_000 times. If the shuffle! is uniform, then each index has a
-    # 10% chance of having a true in it, so each value should converge to 0.1. 
+    # 10% chance of having a true in it, so each value should converge to 0.1.
     @test minimum(m) >= 0.094
     @test maximum(m) <= 0.106
 end

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -2,6 +2,7 @@
 
 using Test, SparseArrays
 using Test: guardseed
+using Statistics: mean
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -898,3 +898,15 @@ end
     x = BigFloat()
     @test_throws ArgumentError rand!(rng, x, s) # incompatible precision
 end
+
+@testset "shuffle! for BitArray" begin
+    # Test that shuffle! is uniformly random on BitArrays
+    rng = MersenneTwister(123)
+    a = (reshape(1:(4*5), 4, 5) .<= 2) # 4x5 BitMatrix whose first two elements are true, rest are false
+    m = mean(1:50_000) do _
+        shuffle!(rng, a)
+    end # mean result of shuffle!-ing a 50_000 times. If the shuffle! is uniform, then each index has a
+    # 10% chance of having a true in it, so each value should converge to 0.1. 
+    @test minimum(m) >= 0.094
+    @test maximum(m) <= 0.106
+end


### PR DESCRIPTION
Someone asked a question on Slack recently and my answer involved using `shuffle!` on a `BitMatrix`. I ran the code a few times and the bits ended up in the bottom right of the matrix each time which freaked me out, but then I did an actual statistical test and found that it was a fluke. 

@StefanKarpinski suggested that I might as well stick it in the testsuite as a regression test, so here is that PR. 