### PR TITLE
Improve count performance

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1204,7 +1204,7 @@ _simple_count(pred, itr, init) = _simple_count_helper(Generator(pred, itr), init
 
 function _simple_count_helper(g, init::T) where {T}
     n::T = init
-    for x in itr
+    for x in g
         n += x::Bool
     end
     return n

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1200,10 +1200,12 @@ count(itr; init=0) = count(identity, itr; init)
 
 count(f, itr; init=0) = _simple_count(f, itr, init)
 
-function _simple_count(pred, itr, init::T) where {T}
+_simple_count(pred, itr, init) = _simple_count_helper(Generator(pred, itr), init)
+
+function _simple_count_helper(g, init::T) where {T}
     n::T = init
     for x in itr
-        n += pred(x)::Bool
+        n += x::Bool
     end
     return n
 end


### PR DESCRIPTION
This is a speculative PR as I do not fully understand why the original code was not properly optimized by the compiler (so maybe a better fix is to change compiler).

Here is an example of the performance difference:
```
julia> x = rand([1, missing], 10^6);

julia> @btime count(ismissing, $x)
  501.200 μs (0 allocations: 0 bytes)
500396

julia> @btime count(Base.Generator(ismissing, $x))
  70.800 μs (0 allocations: 0 bytes)
500396
```
(this is run on 1.6, but this PR is essentially doing the same by introducing a function barrier)