### PR TITLE
RFC: deprecate -unsigned unary operator

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -305,7 +305,7 @@ muladd(z::Complex, w::Complex, x::Complex) =
 
 +(x::Bool, z::Complex) = Complex(x + real(z), imag(z))
 +(z::Complex, x::Bool) = Complex(real(z) + x, imag(z))
--(x::Bool, z::Complex) = Complex(x - real(z), - imag(z))
+-(x::Bool, z::Complex) = Complex(x - real(z), false - imag(z))
 -(z::Complex, x::Bool) = Complex(real(z) - x, imag(z))
 *(x::Bool, z::Complex) = Complex(x * real(z), x * imag(z))
 *(z::Complex, x::Bool) = Complex(real(z) * x, imag(z) * x)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -330,7 +330,7 @@ end
 rem(x::BigInt, ::Type{Bool}) = !iszero(x) & unsafe_load(x.d) % Bool # never unsafe here
 
 rem(x::BigInt, ::Type{T}) where T<:Union{SLimbMax,ULimbMax} =
-    iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % T, x.size)
+    iszero(x) ? zero(T) : flipsign(unsafe_load(x.d) % signed(T), x.size) % T
 
 function rem(x::BigInt, ::Type{T}) where T<:Union{Base.BitUnsigned,Base.BitSigned}
     u = zero(T)
@@ -530,10 +530,10 @@ end
 -(x::BigInt, c::CulongMax) = MPZ.sub_ui(x, c)
 -(c::CulongMax, x::BigInt) = MPZ.ui_sub(c, x)
 
-+(x::BigInt, c::ClongMax) = c < 0 ? -(x, -(c % Culong)) : x + convert(Culong, c)
-+(c::ClongMax, x::BigInt) = c < 0 ? -(x, -(c % Culong)) : x + convert(Culong, c)
--(x::BigInt, c::ClongMax) = c < 0 ? +(x, -(c % Culong)) : -(x, convert(Culong, c))
--(c::ClongMax, x::BigInt) = c < 0 ? -(x + -(c % Culong)) : -(convert(Culong, c), x)
++(x::BigInt, c::ClongMax) = c < 0 ? x - (-Clong(c) % Culong) : x + (c % Culong)
++(c::ClongMax, x::BigInt) = c < 0 ? x - (-Clong(c) % Culong) : x + (c % Culong)
+-(x::BigInt, c::ClongMax) = c < 0 ? x + (-Clong(c) % Culong) : x - (c % Culong)
+-(c::ClongMax, x::BigInt) = c < 0 ? -(x + (-Clong(c) % Culong)) : (c % Culong) - x
 
 *(x::BigInt, c::CulongMax) = MPZ.mul_ui(x, c)
 *(c::CulongMax, x::BigInt) = x * c

--- a/base/int.jl
+++ b/base/int.jl
@@ -82,7 +82,8 @@ signed(::Type{T}) where {T<:Signed} = T
 
 (<)(x::T, y::T) where {T<:BitSigned}  = slt_int(x, y)
 
-(-)(x::BitInteger)                    = neg_int(x)
+(-)(x::BitSigned)                     = neg_int(x)
+(-)(x::BitUnsigned)                   = throw(DomainError(x, "-unsigned"))
 (-)(x::T, y::T) where {T<:BitInteger} = sub_int(x, y)
 (+)(x::T, y::T) where {T<:BitInteger} = add_int(x, y)
 (*)(x::T, y::T) where {T<:BitInteger} = mul_int(x, y)

--- a/base/number.jl
+++ b/base/number.jl
@@ -154,9 +154,11 @@ julia> sign(0 + im)
 ```
 """
 sign(x::Number) = iszero(x) ? x/abs(oneunit(x)) : x/abs(x)
-sign(x::Real) = ifelse(x < zero(x), oftype(one(x),-1), ifelse(x > zero(x), one(x), typeof(one(x))(x)))
-sign(x::Unsigned) = ifelse(x > zero(x), one(x), oftype(one(x),0))
-abs(x::Real) = ifelse(signbit(x), -x, x)
+sign(x::Real) = x < zero(x) ? oftype(one(x), -1) :
+                x > zero(x) ? one(x) :
+                              typeof(one(x))(x)
+sign(x::Unsigned) = x > zero(x) ? one(x) : oftype(one(x), 0)
+abs(x::Real) = signbit(x) ? -x : +x
 
 """
     abs2(x)
@@ -185,7 +187,7 @@ julia> flipsign(5, -3)
 -5
 ```
 """
-flipsign(x::Real, y::Real) = ifelse(signbit(y), -x, +x) # the + is for type-stability on Bool
+flipsign(x::Real, y::Real) = signbit(y) ? -x : +x # the + is for type-stability on Bool
 
 """
     copysign(x, y) -> z
@@ -201,7 +203,7 @@ julia> copysign(-1, 2)
 1
 ```
 """
-copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, +x)
+copysign(x::Real, y::Real) = signbit(x) != signbit(y) ? -x : +x
 
 conj(x::Real) = x
 transpose(x::Number) = x

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -340,10 +340,10 @@ function aligned_sizeof(T::Type)
     @_pure_meta
     if isbitsunion(T)
         _, sz, al = uniontype_layout(T)
-        return (sz + al - 1) & -al
+        return (sz + al - 1) & ~(al - 1)
     elseif allocatedinline(T)
         al = datatype_alignment(T)
-        return (Core.sizeof(T) + al - 1) & -al
+        return (Core.sizeof(T) + al - 1) & ~(al - 1)
     else
         return Core.sizeof(Ptr{Cvoid})
     end

--- a/base/special/rem_pio2.jl
+++ b/base/special/rem_pio2.jl
@@ -190,11 +190,11 @@ function paynehanek(x::Float64)
     w = w1 + w2 + w3         # quotient fraction after division by 2π
 
     # adjust for sign of x
-    w = flipsign(w,x)
+    w = flipsign(w % Int128, x)
 
     # 4. convert to quadrant, quotient fraction after division by π/2:
-    q = (((w>>125)%Int +1)>>1) # nearest quadrant
-    f = (w<<2) % Int128 # fraction part of quotient after division by π/2, taking values on [-0.5,0.5)
+    q = (((w >>> 125) % Int + 1) >> 1) # nearest quadrant
+    f = w << 2 # fraction part of quotient after division by π/2, taking values on [-0.5,0.5)
 
     # 5. convert quotient fraction to split precision Float64
     z_hi,z_lo = fromfraction(f)

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -322,7 +322,7 @@ function SamplerRangeNDL(r::AbstractUnitRange{T}) where {T}
     a = first(r)
     U = uint_sup(T)
     s = (last(r) - first(r)) % unsigned(T) % U + one(U) # overflow ok
-    # mod(-s, s) could be put in the Sampler object for repeated calls, but
+    # mod(0-s, s) could be put in the Sampler object for repeated calls, but
     # this would be an advantage only for very big s and number of calls
     SamplerRangeNDL(a, s)
 end
@@ -332,15 +332,16 @@ function rand(rng::AbstractRNG, sp::SamplerRangeNDL{U,T}) where {U,T}
     x = widen(rand(rng, U))
     m = x * s
     l = m % U
+    z = zero(s)
     if l < s
-        t = mod(-s, s) # as s is unsigned, -s is equal to 2^L - s in the paper
+        t = mod(z-s, s) # as s is unsigned, -s is equal to 2^L - s in the paper
         while l < t
             x = widen(rand(rng, U))
             m = x * s
             l = m % U
         end
     end
-    (s == 0 ? x : m >> (8*sizeof(U))) % T + sp.a
+    (s == z ? x : m >> (8*sizeof(U))) % T + sp.a
 end
 
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1253,9 +1253,9 @@ let
    @test UInt(b) == 1
    @test UInt(c) == typemax(UInt)
 
-   @test b - a == -(a - b) == 1
-   @test c - a == -(a - c) == typemax(UInt)
-   @test c - b == -(b - c) == typemax(UInt) - 1
+   @test b - a == 0 - (a - b) == 1
+   @test c - a == 0 - (a - c) == typemax(UInt)
+   @test c - b == 0 - (b - c) == typemax(UInt) - 1
    @test a < b < c
 end
 


### PR DESCRIPTION
This PR explores the deprecation of negation of unsigned numbers. It would fix the gotcha discovered in #34325, replacing the targeted fix in #39318.

This currently breaks some tests in int, intfuncs, and numbers which specifically test for the ability to negate unsigned numbers. Of note, this PR is a bit counter to our usual policy of using wrapping arithmetic (e.g. it means `-x` differs slightly from `-zero(x) - x`). And therefore, for self-consistency and clarity, I've also opted to define that `-0x0` is also an error, even though that would be representable (and therefore would require fixing fewer tests).

For example, with this PR, the behavior of #34325 is:
```julia
julia> rem(UInt(10), UInt(5), RoundUp)
ERROR: DomainError:
Stacktrace:
 [1] -(x::UInt64)
   @ Base ./int.jl:86
 [2] rem(x::UInt64, y::UInt64, ::RoundingMode{:Up})
   @ Base ./div.jl:82
```

Even if we decide against this deprecation, the removal of `ifelse` should be at least a performance improvement, so many of the other changes may still be valuable to adopt into a separate PR.