### PR TITLE
[cli] Provide `.type` and `.size` annotations for symbols

### DIFF
--- a/cli/trampolines/common.h
+++ b/cli/trampolines/common.h
@@ -23,6 +23,9 @@
                             .ascii STR(-export:##I(name)); \
                             .ascii " "; \
                             .section .text
+#elif defined(__ELF__)
+#define DEBUGINFO(name)     .type CNAME(name),@function
+#define EXPORT(name)        .size CNAME(name), . - CNAME(name)
 #else
 #define DEBUGINFO(name)
 #define EXPORT(name)


### PR DESCRIPTION
On ELF platforms, `ld` can print out warnings that certain symbols do
not have a type or size annotation.  This adds the annotations to the
`DEBUGINFO` and `EXPORT` helper macros, which are where this information
was put for the windows assembler.  With this patch, we should eliminate
`ld` warnings such as:

```
warning: type and size of dynamic symbol `jl_symbol' are not defined
```