### PR TITLE
remove debug logging for the TOML cache in loading

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -203,7 +203,6 @@ function get_updated_dict(p::TOML.Parser, f::CachedTOMLDict)
             f.mtime = s.mtime
             f.size = s.size
             f.hash = new_hash
-            @debug "Cache of TOML file $(repr(f.path)) invalid, reparsing..."
             TOML.reinit!(p, String(content); filepath=f.path)
             return f.d = TOML.parse(p)
         end
@@ -222,7 +221,6 @@ parsed_toml(project_file::AbstractString) = parsed_toml(project_file, TOML_CACHE
 function parsed_toml(project_file::AbstractString, toml_cache::TOMLCache, toml_lock::ReentrantLock)
     lock(toml_lock) do
         if !haskey(toml_cache.d, project_file)
-            @debug "Creating new cache for $(repr(project_file))"
             d = CachedTOMLDict(toml_cache.p, project_file)
             toml_cache.d[project_file] = d
             return d.d


### PR DESCRIPTION
These are a bit excessive