### PR TITLE
show(::MersenneTwister) : use module qualification

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -183,7 +183,7 @@ function show(io::IO, rng::MersenneTwister)
     if rng.adv_jump == 0 && rng.adv == 0
         return print(io, MersenneTwister, "(", seed_str, ")")
     end
-    print(io, "$MersenneTwister($seed_str, (")
+    print(io, MersenneTwister, "(", seed_str, ", (")
     # state
     adv = Integer[rng.adv_jump, rng.adv]
     if rng.adv_vals != -1 || rng.adv_ints != -1

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -181,9 +181,9 @@ function show(io::IO, rng::MersenneTwister)
     seed = from_seed(rng.seed)
     seed_str = seed <= typemax(Int) ? string(seed) : "0x" * string(seed, base=16) # DWIM
     if rng.adv_jump == 0 && rng.adv == 0
-        return print(io, "MersenneTwister($seed_str)")
+        return print(io, "$MersenneTwister($seed_str)")
     end
-    print(io, "MersenneTwister($seed_str, (")
+    print(io, "$MersenneTwister($seed_str, (")
     # state
     adv = Integer[rng.adv_jump, rng.adv]
     if rng.adv_vals != -1 || rng.adv_ints != -1

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -181,7 +181,7 @@ function show(io::IO, rng::MersenneTwister)
     seed = from_seed(rng.seed)
     seed_str = seed <= typemax(Int) ? string(seed) : "0x" * string(seed, base=16) # DWIM
     if rng.adv_jump == 0 && rng.adv == 0
-        return print(io, "$MersenneTwister($seed_str)")
+        return print(io, MersenneTwister, "(", seed_str, ")")
     end
     print(io, "$MersenneTwister($seed_str, (")
     # state


### PR DESCRIPTION
Instead of always printing `MersenneTwister(...)`, we also prepend
`Random.` when not is scope, e.g.
```julia
julia> import Random; Random.MersenneTwister(0)
Random.MersenneTwister(0)
```

But I'm not sure whether this is the best implementation, and I don't know how to test that (as `using Random` is at the top of the test file). 