### PR TITLE
Random: cut randstring allocation size in half

### DIFF
--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -71,7 +71,12 @@ function randstring end
 
 let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
-    randstring(r::AbstractRNG, chars=b, n::Integer=8) = String(rand(r, chars, n))
+    function randstring(r::AbstractRNG, chars=b, n::Integer=8)
+        T = eltype(chars)
+        v = T === UInt8 ? Base.StringVector(n) : Vector{T}(undef, n)
+        rand!(r, v, chars)
+        return String(v)
+    end
     randstring(r::AbstractRNG, n::Integer) = randstring(r, b, n)
     randstring(chars=b, n::Integer=8) = randstring(default_rng(), chars, n)
     randstring(n::Integer) = randstring(default_rng(), b, n)


### PR DESCRIPTION
```
julia> @time randstring(300) # master
  0.000004 seconds (2 allocations: 736 bytes)

julia> @time randstring(300) # PR
  0.000003 seconds (2 allocations: 400 bytes)
```
voila