### PR TITLE
[minor] removed a confusing semicolon after "end"

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -154,7 +154,7 @@ the return value to the specified type.
 ```jldoctest
 julia> function g(x, y)::Int8
            return x * y
-       end;
+       end
 
 julia> typeof(g(1, 2))
 Int8


### PR DESCRIPTION
removed a confusing semicolon after "end" that did nothing