### PR TITLE
avoid excessive inlining of Ryu

### DIFF
--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -1,4 +1,4 @@
-@inline function writeexp(buf, pos, v::T,
+function writeexp(buf, pos, v::T,
     precision=-1, plus=false, space=false, hash=false,
     expchar=UInt8('e'), decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
     @assert 0 < pos <= length(buf)

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -1,4 +1,4 @@
-@inline function writefixed(buf, pos, v::T,
+function writefixed(buf, pos, v::T,
     precision=-1, plus=false, space=false, hash=false,
     decchar=UInt8('.'), trimtrailingzeros=false) where {T <: Base.IEEEFloat}
     @assert 0 < pos <= length(buf)

--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -224,11 +224,10 @@ integer. If a `maxsignif` argument is provided, then `b < maxsignif`.
     return b, e10
 end
 
-
-@inline function writeshortest(buf::Vector{UInt8}, pos, x::T,
-                               plus=false, space=false, hash=true,
-                               precision=-1, expchar=UInt8('e'), padexp=false, decchar=UInt8('.'),
-                               typed=false, compact=false) where {T}
+function writeshortest(buf::Vector{UInt8}, pos, x::T,
+                       plus=false, space=false, hash=true,
+                       precision=-1, expchar=UInt8('e'), padexp=false, decchar=UInt8('.'),
+                       typed=false, compact=false) where {T}
     @assert 0 < pos <= length(buf)
     neg = signbit(x)
     # special cases


### PR DESCRIPTION
This PR removes `@inline` annotations attached to `writefixed`, `writeexp`, and `writeshortest` of Ryu. The code sizes of `writefixed`, `writeexp`, and `writeshortest` are quite large (7664, 5552, and 6384 bytes, respectively) and thus inlining these methods results in machine code bloat, which leads to significant increase of compile time (and perhaps instruction cache misses).

I noticed this while I was working on Fmt.jl because the compile time was too long (~0.2-0.4 seconds) when formatting floating-point numbers. So, I added [an ad hoc fix](https://github.com/bicycle1885/Fmt.jl/commit/851c7428247f42be974d2e544897921c23979cee) to avoid inlining of the Ryu methods, which reduced the compile time down to 0.02 seconds or so. But I think this problem should be fixed in Base. The performance degradation of throughput was almost negligible in my experiment.