### PR TITLE
Enable pasted lines to switch to pkg, shell and help repl modes

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1077,6 +1077,12 @@ function setup_interface(
                         isprompt_paste = true
                         oldpos += pkg_prompt_len
                         Base.active_repl.interface.modes[1].keymap_dict[']'](s, o...)
+                    # Check if input line starts with "(xxx) pkg> ", remove it if we are in prompt paste mode and switch mode
+                    elseif (firstline || isprompt_paste) && startswith(SubString(input, oldpos), Regex("\\(.+\\) $(PKG_PROMPT)"))
+                        env_pkg_prompt = match(Regex("\\(.+\\) $(PKG_PROMPT)"), SubString(input, oldpos)).match
+                        isprompt_paste = true
+                        oldpos += length(env_pkg_prompt)
+                        Base.active_repl.interface.modes[1].keymap_dict[']'](s, o...)
                     # Check if input line starts with "shell> ", remove it if we are in prompt paste mode and switch mode
                     elseif (firstline || isprompt_paste) && startswith(SubString(input, oldpos), SHELL_PROMPT)
                         isprompt_paste = true

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1059,6 +1059,7 @@ function setup_interface(
             pkg_prompt_len = length(PKG_PROMPT)
             shell_prompt_len = length(SHELL_PROMPT)
             help_prompt_len = length(HELP_PROMPT)
+            curr_prompt_len = 0
             while oldpos <= lastindex(input) # loop until all lines have been executed
                 if JL_PROMPT_PASTE[]
                     # Check if the next statement starts with "julia> ", in that case
@@ -1071,27 +1072,32 @@ function setup_interface(
                     if (firstline || isprompt_paste) && startswith(SubString(input, oldpos), JULIA_PROMPT)
                         isprompt_paste = true
                         oldpos += jl_prompt_len
+                        curr_prompt_len = jl_prompt_len
                         transition(s, julia_prompt)
                     # Check if input line starts with "pkg> ", remove it if we are in prompt paste mode and switch mode
                     elseif (firstline || isprompt_paste) && startswith(SubString(input, oldpos), PKG_PROMPT)
                         isprompt_paste = true
                         oldpos += pkg_prompt_len
+                        curr_prompt_len = pkg_prompt_len
                         Base.active_repl.interface.modes[1].keymap_dict[']'](s, o...)
-                    # Check if input line starts with "(xxx) pkg> ", remove it if we are in prompt paste mode and switch mode
+                    # Check if input line starts with "(...) pkg> ", remove it if we are in prompt paste mode and switch mode
                     elseif (firstline || isprompt_paste) && startswith(SubString(input, oldpos), Regex("\\(.+\\) $(PKG_PROMPT)"))
                         env_pkg_prompt = match(Regex("\\(.+\\) $(PKG_PROMPT)"), SubString(input, oldpos)).match
                         isprompt_paste = true
-                        oldpos += length(env_pkg_prompt)
+                        curr_prompt_len = length(env_pkg_prompt)
+                        oldpos += curr_prompt_len
                         Base.active_repl.interface.modes[1].keymap_dict[']'](s, o...)
                     # Check if input line starts with "shell> ", remove it if we are in prompt paste mode and switch mode
                     elseif (firstline || isprompt_paste) && startswith(SubString(input, oldpos), SHELL_PROMPT)
                         isprompt_paste = true
                         oldpos += shell_prompt_len
+                        curr_prompt_len = shell_prompt_len
                         transition(s, shell_mode)
                     # Check if input line starts with "help?> ", remove it if we are in prompt paste mode and switch mode
                     elseif (firstline || isprompt_paste) && startswith(SubString(input, oldpos), HELP_PROMPT)
                         isprompt_paste = true
                         oldpos += help_prompt_len
+                        curr_prompt_len = help_prompt_len
                         transition(s, help_mode)
                     # If we are prompt pasting and current statement does not begin with a mode prefix, skip to next line
                     elseif isprompt_paste
@@ -1102,29 +1108,46 @@ function setup_interface(
                         continue
                     end
                 end
-                ast, pos = Meta.parse(input, oldpos, raise=false, depwarn=false)
-                if (isa(ast, Expr) && (ast.head === :error || ast.head === :incomplete)) ||
-                        (pos > ncodeunits(input) && !endswith(input, '\n'))
-                    # remaining text is incomplete (an error, or parser ran to the end but didn't stop with a newline):
-                    # Insert all the remaining text as one line (might be empty)
-                    tail = input[oldpos:end]
-                    if !firstline
-                        # strip leading whitespace, but only if it was the result of executing something
-                        # (avoids modifying the user's current leading wip line)
-                        tail = lstrip(tail)
+                if s.current_mode == julia_prompt
+                    ast, pos = Meta.parse(input, oldpos, raise=false, depwarn=false)
+                    if (isa(ast, Expr) && (ast.head === :error || ast.head === :incomplete)) ||
+                            (pos > ncodeunits(input) && !endswith(input, '\n'))
+                        # remaining text is incomplete (an error, or parser ran to the end but didn't stop with a newline):
+                        # Insert all the remaining text as one line (might be empty)
+                        tail = input[oldpos:end]
+                        if !firstline
+                            # strip leading whitespace, but only if it was the result of executing something
+                            # (avoids modifying the user's current leading wip line)
+                            tail = lstrip(tail)
+                        end
+                        if isprompt_paste # remove indentation spaces corresponding to the prompt
+                            tail = replace(tail, r"^"m * ' '^curr_prompt_len => "")
+                        end
+                        LineEdit.replace_line(s, tail, true)
+                        LineEdit.refresh_line(s)
+                        break
                     end
-                    if isprompt_paste # remove indentation spaces corresponding to the prompt
-                        tail = replace(tail, r"^"m * ' '^jl_prompt_len => "")
+                elseif s.current_mode == shell_mode # handle multiline shell commands
+                    lines = split(input[oldpos:end], '\n')
+                    pos = oldpos + sizeof(lines[1]) + 1
+                    if length(lines) > 1
+                        for line in lines[2:end]
+                            # to be recognized as a multiline shell command, the lines must be indented to the
+                            # same prompt position
+                            if !startswith(line, ' '^curr_prompt_len)
+                                break
+                            end
+                            pos += sizeof(line) + 1
+                        end
                     end
-                    LineEdit.replace_line(s, tail, true)
-                    LineEdit.refresh_line(s)
-                    break
+                else
+                    pos = oldpos + findfirst('\n', input[oldpos:end]) + 1
                 end
                 # get the line and strip leading and trailing whitespace
                 line = strip(input[oldpos:prevind(input, pos)])
                 if !isempty(line)
                     if isprompt_paste # remove indentation spaces corresponding to the prompt
-                        line = replace(line, r"^"m * ' '^jl_prompt_len => "")
+                        line = replace(line, r"^"m * ' '^curr_prompt_len => "")
                     end
                     # put the line on the screen and history
                     LineEdit.replace_line(s, line)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1141,7 +1141,8 @@ function setup_interface(
                         end
                     end
                 else
-                    pos = oldpos + findfirst('\n', input[oldpos:end]) + 1
+                    nl_pos = findfirst('\n', input[oldpos:end])
+                    pos = isnothing(nl_pos) ? oldpos : oldpos + nl_pos
                 end
                 # get the line and strip leading and trailing whitespace
                 line = strip(input[oldpos:prevind(input, pos)])

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -761,12 +761,6 @@ fake_repl() do stdin_write, stdout_read, repl
             help?> Int
             Dummy docstring
 
-            pkg> st
-            Dummy pkg info
-
-            (Foo) pkg> st
-            Dummy pkg info
-
             julia> B = 2
             2\e[201~
              """)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -764,6 +764,9 @@ fake_repl() do stdin_write, stdout_read, repl
             pkg> st
             Dummy pkg info
 
+            (Foo) pkg> st
+            Dummy pkg info
+
             julia> B = 2
             2\e[201~
              """)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -753,15 +753,19 @@ fake_repl() do stdin_write, stdout_read, repl
     # Test switching repl modes
     sendrepl2("""\e[200~
             julia> A = 1
+            1
 
             shell> pwd
+            /home/usr
 
             help?> Int
+            Dummy docstring
 
             pkg> st
+            Dummy pkg info
 
             julia> B = 2
-            \e[201~
+            2\e[201~
              """)
     wait(c)
     @test Main.A == 1

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -755,11 +755,19 @@ fake_repl() do stdin_write, stdout_read, repl
             julia> A = 1
             1
 
-            shell> pwd
-            /home/usr
+            shell> echo foo
+            foo
+
+            shell> echo foo
+                   foo
+            foo foo
 
             help?> Int
             Dummy docstring
+
+                Some text
+
+                julia> error("If this error throws, the paste handler has failed to ignore this docstring example")
 
             julia> B = 2
             2\e[201~

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -750,6 +750,23 @@ fake_repl() do stdin_write, stdout_read, repl
     readuntil(stdout_read, "begin")
     @test readuntil(stdout_read, "end", keep=true) == "\n\r\e[7C    α=1\n\r\e[7C    β=2\n\r\e[7Cend"
 
+    # Test switching repl modes
+    sendrepl2("""\e[200~
+            julia> A = 1
+
+            shell> pwd
+
+            help?> Int
+
+            pkg> st
+
+            julia> B = 2
+            \e[201~
+             """)
+    wait(c)
+    @test Main.A == 1
+    @test Main.B == 2
+
     # Close repl
     write(stdin_write, '\x04')
     Base.wait(repltask)


### PR DESCRIPTION
Currently it's possible to paste `julia> 1+1` into the repl, and `julia> ` will be stripped, and the `1+1` evaluated, etc.

This adds the handling of `pkg> `, `shell> `, and `help?> ` prefixes, which are stripped and the mode changed.

With this PR, for instance if I copy this
```
julia> 1 + 1

shell> pwd

help?> trues

pkg> st

```

and paste it into the `julia>` repl mode, I get:
```
julia> 1 + 1
2

shell> pwd
/Users/ian/Documents/GitHub/julia

help?> trues
search: trues truncate InterruptException promote_rule isstructtype AbstractUnitRange

  trues(dims)

  Create a BitArray with all values set to true.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> trues(2,3)
  2×3 BitMatrix:
   1  1  1
   1  1  1

(@v1.7) pkg> st
      Status `~/.julia/environments/v1.7/Project.toml`
  [6e4b80f9] BenchmarkTools v0.7.0
  [295af30f] Revise v3.1.15

(@v1.7) pkg> 
```

Note that this only works for pasted text. Typing `pkg> st` into the `julia>` repl won't trigger the same behavior as it is paste-specific like the existing `julia> ` prefix handling