### PR TITLE
Fix showindices for IdentityUnitRange

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2848,7 +2848,7 @@ function showarg(io::IO, v::SubArray, toplevel)
     toplevel && print(io, " with eltype ", eltype(v))
     return nothing
 end
-showindices(io, ::Union{Slice,IdentityUnitRange}, inds...) =
+showindices(io, ::Slice, inds...) =
     (print(io, ", :"); showindices(io, inds...))
 showindices(io, ind1, inds...) =
     (print(io, ", ", ind1); showindices(io, inds...))

--- a/test/show.jl
+++ b/test/show.jl
@@ -1667,6 +1667,11 @@ end
     @test summary(p) == "2-element reinterpret(reshape, Tuple{Float32, Float32}, ::Matrix{Float32}) with eltype Tuple{Float32, Float32}"
     @test Base.showarg(io, p, false) === nothing
     @test String(take!(io)) == "reinterpret(reshape, Tuple{Float32, Float32}, ::Matrix{Float32})"
+
+    r = Base.IdentityUnitRange(2:2)
+    B = @view ones(2)[r]
+    Base.showarg(io, B, false)
+    @test String(take!(io)) == "view(::Vector{Float64}, $(repr(r)))"
 end
 
 @testset "Methods" begin


### PR DESCRIPTION
`IdentityUnitRange` should not be displayed as `:` in the summary of `SubArray`s.

On master
```julia
julia> @view ones(2)[Base.IdentityUnitRange(2:2)]
1-element view(::Vector{Float64}, :) with eltype Float64 with indices 2:2:
 1.0
```

After this PR
```julia
julia> @view ones(2)[Base.IdentityUnitRange(2:2)]
1-element view(::Vector{Float64}, Base.IdentityUnitRange(2:2)) with eltype Float64 with indices 2:2:
 1.0
```