### PR TITLE
add `zeros!` and `ones!`, mutating versions of `zeros` and `ones`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1135,6 +1135,28 @@ copymutable(itr) = collect(itr)
 
 zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
 
+"""
+    zeros!(x::AbstractArray)
+
+Fills `x` with zeros. This is equivalent to `fill!(x, zero(eltype(x)))`.
+See also [`zeros`](@ref) and [`ones!`](@ref).
+
+!!! compat "Julia 1.7"
+    This method is available as of Julia 1.7.
+"""
+zeros!(x::AbstractArray) = fill!(x, zero(eltype(x)))
+
+"""
+    ones!(x::AbstractArray)
+
+Fills `x` with ones. This is equivalent to `fill!(x, one(eltype(x)))`.
+See also [`ones`](@ref) and [`zeros!`](@ref).
+
+!!! compat "Julia 1.7"
+    This method is available as of Julia 1.7.
+"""
+ones!(x::AbstractArray) = fill!(x, one(eltype(x)))
+
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both IndexLinear and IndexCartesian arrays
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -410,6 +410,7 @@ export
     minmax,
     ndims,
     ones,
+    ones!,
     parent,
     parentindices,
     partialsort,
@@ -447,6 +448,7 @@ export
     vec,
     view,
     zeros,
+    zeros!,
 
 # search, find, match and related functions
     contains,

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -32,7 +32,9 @@ Base.StridedMatrix
 Base.StridedVecOrMat
 Base.getindex(::Type, ::Any...)
 Base.zeros
+Base.zeros!
 Base.ones
+Base.ones!
 Base.BitArray
 Base.BitArray(::UndefInitializer, ::Integer...)
 Base.BitArray(::Any)

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -207,8 +207,8 @@ end
 
 function reset_caches!(r::MersenneTwister)
     # zeroing the caches makes comparing two MersenneTwister RNGs easier
-    fill!(r.vals, 0.0)
-    fill!(r.ints, zero(UInt128))
+    zeros!(r.vals)
+    zeros!(r.ints)
     mt_setempty!(r)
     mt_setempty!(r, UInt128)
     r.adv_vals = -1


### PR DESCRIPTION
The current alternative is to use `fill!(x, 0)`, but this does not always
work, when `convert(eltype(x), 0)` is not defined, for example
when `x` is an array of `DateTime` objects.

Another benefit of introducing `zeros!` is that in some cases, the zero
element can't be known from the `eltype` alone, but rather from the values.
In this case, package can define their own appropriate method.
For example, we could define in `Base` a `zeros!(::AbstractArray{<:AbstractArray})`
which replaces each value `v` by `zero(v)`.