### PR TITLE
add *(::Missing, ::Char)

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -179,8 +179,8 @@ xor(b::Bool, a::Missing) = missing
 xor(::Missing, ::Integer) = missing
 xor(::Integer, ::Missing) = missing
 
-*(d::Missing, x::AbstractString) = missing
-*(d::AbstractString, x::Missing) = missing
+*(d::Missing, x::Union{AbstractString,AbstractChar}) = missing
+*(d::Union{AbstractString,AbstractChar}, x::Missing) = missing
 
 function float(A::AbstractArray{Union{T, Missing}}) where {T}
     U = typeof(float(zero(T)))

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -164,9 +164,11 @@ end
     @test ismissing(⊽(1, missing))
 end
 
-@testset "* string concatenation" begin
+@testset "* string/char concatenation" begin
     @test ismissing("a" * missing)
+    @test ismissing('a' * missing)
     @test ismissing(missing * "a")
+    @test ismissing(missing * 'a')
 end
 
 # Emulate a unitful type such as Dates.Minute


### PR DESCRIPTION
As `*(::Missing, ::String)` already exists, one would expect a `Char` version to also exist.