### PR TITLE
minor refactor for `Base._which`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1292,12 +1292,12 @@ end
 
 print_statement_costs(args...; kwargs...) = print_statement_costs(stdout, args...; kwargs...)
 
-function _which(@nospecialize(tt::Type), world=typemax(UInt))
+function _which(@nospecialize(tt::Type), world=get_world_counter())
     min_valid = RefValue{UInt}(typemin(UInt))
     max_valid = RefValue{UInt}(typemax(UInt))
     match = ccall(:jl_gf_invoke_lookup_worlds, Any,
         (Any, UInt, Ptr{Csize_t}, Ptr{Csize_t}),
-        tt, typemax(UInt), min_valid, max_valid)
+        tt, world, min_valid, max_valid)
     if match === nothing
         error("no unique matching method found for the specified argument types")
     end


### PR DESCRIPTION
Two minor changes:
1. look up matching methods in a passed `world`
2. pass the current world by default

The change 1. is strictly better.
As for 2., AFAIU there is no need to lookup in `typemax(UInt)`,
but I wonder if I miss something.

xref: https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/478