### PR TITLE
Add tests to make sure that `Base.project_names`, `Base.manifest_names`, `Base.preferences_names`, and `Artifacts.artifact_names` always have the same length

### DIFF
--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -157,3 +157,10 @@ end
         end
     end
 end
+
+@testset "`Artifacts.artifact_names` and friends" begin
+    n = length(Artifacts.artifact_names)
+    @test length(Base.project_names) == n
+    @test length(Base.manifest_names) == n
+    @test length(Base.preferences_names) == n
+end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -720,6 +720,7 @@ import .Foo.Libdl; import Libdl
 end
 
 @testset "`Base.project_names` and friends" begin
+    # Some functions in Pkg assumes that these tuples have the same length
     n = length(Base.project_names)
     @test length(Base.manifest_names) == n
     @test length(Base.preferences_names) == n

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -718,3 +718,9 @@ import .Foo.Libdl; import Libdl
         end
     end
 end
+
+@testset "`Base.project_names` and friends" begin
+    n = length(Base.project_names)
+    @test length(Base.manifest_names) == n
+    @test length(Base.preferences_names) == n
+end


### PR DESCRIPTION
There is code in Pkg.jl that assumes that the following tuples always have the same length:
- `Base.project_names`
- `Base.manifest_names`
- `Base.preferences_names`
- `Artifacts.artifact_names`

So we should have tests to make sure that this always stays the case.