### PR TITLE
REPL: fix #40247, improve `getfield` type completion

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -392,6 +392,7 @@ function get_type_getfield(ex::Expr, fn::Module)
     length(ex.args) == 3 || return Any, false # should never happen, but just for safety
     obj, x = ex.args[2:3]
     objt, found = get_type(obj, fn)
+    objt isa DataType || return Any, false
     found || return Any, false
     if x isa QuoteNode
         fld = x.value
@@ -401,6 +402,7 @@ function get_type_getfield(ex::Expr, fn::Module)
         fld = nothing # we don't know how to get the value of variable `x` here
     end
     fld isa Symbol || return Any, false
+    hasfield(objt, fld) || return Any, false
     return fieldtype(objt, fld), true
 end
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -401,7 +401,6 @@ function get_type_getfield(ex::Expr, fn::Module)
         fld = nothing # we don't know how to get the value of variable `x` here
     end
     fld isa Symbol || return Any, false
-    isdefined(objt, fld) || return Any, false
     return fieldtype(objt, fld), true
 end
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -393,7 +393,14 @@ function get_type_getfield(ex::Expr, fn::Module)
     obj, x = ex.args[2:3]
     objt, found = get_type(obj, fn)
     found || return Any, false
-    fld = isa(x, QuoteNode) ? x.value : x
+    if x isa QuoteNode
+        fld = x.value
+    elseif isexpr(x, :quote) || isexpr(x, :inert)
+        fld = x.args[1]
+    else
+        fld = nothing # we don't know how to get the value of variable `x` here
+    end
+    fld isa Symbol || return Any, false
     isdefined(objt, fld) || return Any, false
     return fieldtype(objt, fld), true
 end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -391,7 +391,7 @@ get_value(sym, fn) = (sym, true)
 function get_type_getfield(ex::Expr, fn::Module)
     length(ex.args) == 3 || return Any, false # should never happen, but just for safety
     obj, x = ex.args[2:3]
-    objt, found = get_type_getfield(obj, fn)
+    objt, found = get_type(obj, fn)
     found || return Any, false
     fld = isa(x, QuoteNode) ? x.value : x
     isdefined(objt, fld) || return Any, false

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -397,7 +397,6 @@ function get_type_getfield(ex::Expr, fn::Module)
     isdefined(objt, fld) || return Any, false
     return fieldtype(objt, fld), true
 end
-get_type_getfield(@nospecialize(sym), fn) = get_type(sym, fn)
 
 # Determines the return type with Base.return_types of a function call using the type information of the arguments.
 function get_type_call(expr::Expr)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -97,10 +97,11 @@ function map_completion_text(completions)
     return map(completion_text, c), r, res
 end
 
-test_complete(s) = map_completion_text(@inferred(completions(s,lastindex(s))))
-test_scomplete(s) =  map_completion_text(@inferred(shell_completions(s,lastindex(s))))
-test_bslashcomplete(s) =  map_completion_text(@inferred(bslash_completions(s,lastindex(s)))[2])
-test_complete_context(s) =  map_completion_text(@inferred(completions(s,lastindex(s),Main.CompletionFoo)))
+test_complete(s) = map_completion_text(@inferred(completions(s, lastindex(s))))
+test_scomplete(s) =  map_completion_text(@inferred(shell_completions(s, lastindex(s))))
+test_bslashcomplete(s) =  map_completion_text(@inferred(bslash_completions(s, lastindex(s)))[2])
+test_complete_context(s, m) =  map_completion_text(@inferred(completions(s,lastindex(s), m)))
+test_complete_foo(s) = test_complete_context(s, Main.CompletionFoo)
 
 module M32377 end
 test_complete_32377(s) = map_completion_text(completions(s,lastindex(s), M32377))
@@ -297,7 +298,7 @@ end
 
 # test latex symbol completion in getindex expressions (#24705)
 let s = "tuple[\\alpha"
-    c, r, res = test_complete_context(s)
+    c, r, res = test_complete_foo(s)
     @test c[1] == "α"
     @test r == 7:12
     @test length(c) == 1
@@ -987,13 +988,13 @@ end
 
 # No CompletionFoo.CompletionFoo
 let s = ""
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test !("CompletionFoo" in c)
 end
 
 # Can see `rand()` after `using Random`
 let s = "r"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "rand" in c
     @test r == 1:1
     @test s[r] == "r"
@@ -1001,7 +1002,7 @@ end
 
 # Can see `Test.AbstractTestSet` after `import Test`
 let s = "Test.A"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "AbstractTestSet" in c
     @test r == 6:6
     @test s[r] == "A"
@@ -1009,21 +1010,21 @@ end
 
 # Can complete relative import
 let s = "import ..M"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test_broken "Main" in c
     @test r == 10:10
     @test s[r] == "M"
 end
 
 let s = ""
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "bar" in c
     @test r === 1:0
     @test s[r] == ""
 end
 
 let s = "f"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "foo" in c
     @test r == 1:1
     @test s[r] == "f"
@@ -1031,7 +1032,7 @@ let s = "f"
 end
 
 let s = "@f"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "@foobar" in c
     @test r == 1:2
     @test s[r] == "@f"
@@ -1039,48 +1040,48 @@ let s = "@f"
 end
 
 let s = "type_test.x"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "xx" in c
     @test r == 11:11
     @test s[r] == "x"
 end
 
 let s = "bar.no_val_available"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test length(c)==0
 end
 
 let s = "type_test.xx.y"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "yy" in c
     @test r == 14:14
     @test s[r] == "y"
 end
 
 let s = ":(function foo(::Int) end).args[1].args[2]."
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test c == Any[]
 end
 
 let s = "log(log.(x),"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test !isempty(c)
 end
 
 let s = "Base.return_types(getin"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test "getindex" in c
     @test r == 19:23
     @test s[r] == "getin"
 end
 
 let s = "using Test, Random"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test !("RandomDevice" in c)
 end
 
 let s = "test(1,1, "
-    c, r, res = test_complete_context(s)
+    c, r, res = test_complete_foo(s)
     @test !res
     @test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Int, Int})))
     @test length(c) == 3
@@ -1089,7 +1090,7 @@ let s = "test(1,1, "
 end
 
 let s = "test.(1,1, "
-    c, r, res = test_complete_context(s)
+    c, r, res = test_complete_foo(s)
     @test !res
     @test length(c) == 4
     @test r == 1:4
@@ -1097,7 +1098,7 @@ let s = "test.(1,1, "
 end
 
 let s = "prevind(\"θ\",1,"
-    c, r, res = test_complete_context(s)
+    c, r, res = test_complete_foo(s)
     @test c[1] == string(first(methods(prevind, Tuple{String, Int})))
     @test r == 1:7
     @test s[r] == "prevind"
@@ -1105,12 +1106,12 @@ end
 
 # Issue #32840
 let s = "typeof(+)."
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test length(c) == length(fieldnames(DataType))
 end
 
 let s = "test_dict[\"ab"
-    c, r = test_complete_context(s)
+    c, r = test_complete_foo(s)
     @test c == Any["\"abc\"", "\"abcd\""]
 end
 
@@ -1119,4 +1120,45 @@ let
     (test_complete("@noexist."); @test true)
     (test_complete("Main.@noexist."); @test true)
     (test_complete("@Main.noexist."); @test true)
+end
+
+@testset "https://github.com/JuliaLang/julia/issues/40247" begin
+    # getfield type completion can work for complicated expression
+
+    let
+        m = Module()
+        @eval m begin
+            struct Rs
+                rs::Vector{Regex}
+            end
+            var = nothing
+            function foo()
+                global var = 1
+                return Rs([r"foo"])
+            end
+        end
+
+        c, r = test_complete_context("foo().rs[1].", m)
+        @test m.var ≠ 1 # getfield type completion should never execute `foo()`
+        @test length(c) == fieldcount(Regex)
+    end
+
+    let
+        m = Module()
+        @eval m begin
+            struct R
+                r::Regex
+            end
+            var = nothing
+            function foo()
+                global var = 1
+                return R(r"foo")
+            end
+        end
+
+        c, r = test_complete_context("foo().r.", m)
+        # the current implementation of `REPL.REPLCompletions.completions(::String, ::Int, ::Module)`
+        # cuts off "foo().r." to `.r.`, and the getfield type completion doesn't work for this simpler case
+        @test_broken length(c) == fieldcount(Regex)
+    end
 end


### PR DESCRIPTION
This PR makes field completions work for complex expression case, which is reported in #40247 .

One thing I noticed while working on this was that the current implementation of 
`REPL.REPLCompletions.completions(::String, ::Int, ::Module)` doesn't work for 
simpler cases.
For example, with this PR we can get completions for this complex case
```julia
struct Rs
    rs::Vector{Regex}
end
foo() = Rs([r"foo"])

foo().rs[1]. # completes to `.regex`, etc.
```

while we can't get completions for this simpler one:
```julia
struct R
    r::Regex
end
foo() = R(r"foo")

foo().r. # no completion happens
```

Well, in this PR I just focused on fixing #40247, and leave a fix for the problem described above
to another PR.