### PR TITLE
Updated Version for Git Checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Julia. However, most users should use the most recent stable version
 of Julia. You can get this version by changing to the Julia directory
 and running:
 
-    git checkout v1.6.0
+    git checkout v1.6.1
 
 Now run `make` to build the `julia` executable.
 


### PR DESCRIPTION
Updated the version for "git checkout" to the latest stable version (1.6.1).