### PR TITLE
a bit of cleanup to init/loading

### DIFF
--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -196,9 +196,9 @@ JL_DLLEXPORT int jl_load_repl(int argc, char * argv[]) {
 #endif
 
     // Load the repl entrypoint symbol and jump into it!
-    int (*entrypoint)(int, char **) = (int (*)(int, char **))lookup_symbol(libjulia_internal, "repl_entrypoint");
+    int (*entrypoint)(int, char **) = (int (*)(int, char **))lookup_symbol(libjulia_internal, "jl_repl_entrypoint");
     if (entrypoint == NULL) {
-        jl_loader_print_stderr("ERROR: Unable to find `repl_entrypoint()` within libjulia-internal!\n");
+        jl_loader_print_stderr("ERROR: Unable to find `jl_repl_entrypoint()` within libjulia-internal!\n");
         exit(1);
     }
     return entrypoint(argc, (char **)argv);

--- a/src/init.c
+++ b/src/init.c
@@ -628,7 +628,7 @@ static void restore_fp_env(void)
     }
 }
 
-void _julia_init(JL_IMAGE_SEARCH rel)
+JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 {
     jl_init_timing();
     // Make sure we finalize the tls callback before starting any threads.

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -273,8 +273,8 @@
     XX(jl_idtable_rehash) \
     XX(jl_infer_thunk) \
     XX(jl_init_restored_modules) \
-    XX(jl_init__threading) \
-    XX(jl_init_with_image__threading) \
+    XX(jl_init) \
+    XX(jl_init_with_image) \
     XX(jl_install_sigint_handler) \
     XX(jl_instantiate_type_in_env) \
     XX(jl_instantiate_unionall) \
@@ -538,4 +538,5 @@
     XX(jl_vexceptionf) \
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
-    XX(jl_yield)
+    XX(jl_yield) \
+    XX(jl_print_backtrace)

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -37,7 +37,6 @@
     _IO_stdin_used;
     __ZN4llvm23createLowerSimdLoopPassEv;
     LLVMExtra*;
-    repl_entrypoint;
 
     /* freebsd */
     environ;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1639,10 +1639,6 @@ typedef enum {
     JL_IMAGE_JULIA_HOME = 1,
     //JL_IMAGE_LIBJULIA = 2,
 } JL_IMAGE_SEARCH;
-// this helps turn threading compilation mismatches into linker errors
-#define julia_init julia_init__threading
-#define jl_init jl_init__threading
-#define jl_init_with_image jl_init_with_image__threading
 
 JL_DLLEXPORT const char *jl_get_libdir(void);
 JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
@@ -1965,7 +1961,8 @@ JL_DLLEXPORT jl_value_t *jl_stdout_obj(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_stderr_obj(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT;
-JL_DLLEXPORT void jlbacktrace(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jlbacktrace(void) JL_NOTSAFEPOINT; // deprecated
 // Mainly for debugging, use `void*` so that no type cast is needed in C++.
 JL_DLLEXPORT void jl_(void *jl_value) JL_NOTSAFEPOINT;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -676,8 +676,6 @@ void jl_init_int32_int64_cache(void);
 
 void jl_teardown_codegen(void);
 
-void _julia_init(JL_IMAGE_SEARCH rel);
-
 void jl_set_base_ctx(char *__stk);
 
 extern ssize_t jl_tls_offset;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -774,6 +774,11 @@ JL_DLLEXPORT void jlbacktracet(jl_task_t *t)
     }
 }
 
+JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT
+{
+    jlbacktrace();
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/task.c
+++ b/src/task.c
@@ -312,11 +312,6 @@ NOINLINE static void record_backtrace(jl_ptls_t ptls, int skip) JL_NOTSAFEPOINT
     ptls->bt_size = rec_backtrace(ptls->bt_data, JL_MAX_BT_SIZE, skip + 1);
 }
 
-JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
-{
-    _julia_init(rel);
-}
-
 JL_DLLEXPORT void jl_set_next_task(jl_task_t *task) JL_NOTSAFEPOINT
 {
     jl_get_ptls_states()->next_task = task;


### PR DESCRIPTION
Did a bit of "clearn up" on the new loading stuff :)

- add some jl_ prefixes
- rm `__threading` suffix
- rm some unused code
- prefer normal exported runtime functions in fallback repl