### PR TITLE
add eabi half conversion functions

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1461,6 +1461,11 @@ extern "C" JL_DLLEXPORT float __gnu_h2f_ieee(uint16_t param)
     return half_to_float(param);
 }
 
+extern "C" JL_DLLEXPORT float __aeabi_h2f(uint16_t param)
+{
+    return half_to_float(param);
+}
+
 extern "C" JL_DLLEXPORT float __extendhfsf2(uint16_t param)
 {
     return half_to_float(param);
@@ -1471,9 +1476,25 @@ extern "C" JL_DLLEXPORT uint16_t __gnu_f2h_ieee(float param)
     return float_to_half(param);
 }
 
+extern "C" JL_DLLEXPORT uint16_t __aeabi_f2h(float param)
+{
+    return float_to_half(param);
+}
+
 extern "C" JL_DLLEXPORT uint16_t __truncdfhf2(double param)
 {
     return float_to_half((float)param);
+}
+
+extern "C" JL_DLLEXPORT uint16_t __aeabi_d2h(double param)
+{
+    return float_to_half((float)param);
+}
+
+// Not yet used, https://reviews.llvm.org/D84877
+extern "C" JL_DLLEXPORT double __aeabi_h2d(uint16_t param)
+{
+    return (double)half_to_float(param);
 }
 
 #endif

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -45,9 +45,13 @@
 
     /* compiler run-time intrinsics */
     __gnu_h2f_ieee;
+    __aeabi_h2f;
     __extendhfsf2;
     __gnu_f2h_ieee;
+    __aeabi_f2h;
     __truncdfhf2;
+    __aeabi_d2h;
+    __aeabi_h2d;
 
   local:
     *;


### PR DESCRIPTION
Should fix #40638, but I do need to figure out if we need to set:

```
#define AEABI_RTABI __attribute__((__pcs__("aapcs")))
```

on these functions like compiler-rt does.
