### PR TITLE
make sure sortperm on Vector{Float64} is precompiled

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -426,6 +426,9 @@ for match = _methods(+, (Int, Int), -1, get_world_counter())
     Core.svec(1, 2) == Core.svec(3, 4)
     any(t->t[1].line > 1, [(LineNumberNode(2,:none), :(1+1))])
 
+    # Code loading uses this
+    sortperm(mtime.(readdir(".")), rev=true)
+
     break   # only actually need to do this once
 end
 


### PR DESCRIPTION
This is used by code loading here:

https://github.com/JuliaLang/julia/blob/e9ef2805bbd7f2c46e569fe3e6cdea8e9554c862/base/loading.jl#L647

It doesn't take a very long time to precompile but when profiling package loading it brings up a huge number of stack frames which is kinda noisy, so getting rid of them is nice:

<details>
  <summary>Profile trace from loading a package</summary>

```
7╎    ╎    ╎    ╎  35 @Base/sort.jl:905; sortperm##kw
  ╎    ╎    ╎    ╎   25 @Base/compiler/typeinfer.jl:921; typeinf_ext_toplevel(mi::Core.MethodInstance, world::UInt64)
  ╎    ╎    ╎    ╎    25 @Base/compiler/typeinfer.jl:925; typeinf_ext_toplevel(interp::Core.Compiler.NativeInterpreter, linfo::Core.MethodInstance)
  ╎    ╎    ╎    ╎     25 @Base/compiler/typeinfer.jl:892; typeinf_ext(interp::Core.Compiler.NativeInterpreter, mi::Core.MethodInstance)
  ╎    ╎    ╎    ╎    ╎ 25 @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎  24 @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎   24 @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    3  @Base/compiler/abstractinterpretation.jl:1447; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎     3  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::Core.Compiler.Infere...
  ╎    ╎    ╎    ╎    ╎    ╎ 3  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Compiler.I...
  ╎    ╎    ╎    ╎    ╎    ╎  3  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Compiler.I...
  ╎    ╎    ╎    ╎    ╎    ╎   3  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vector{Any}, sv::...
  ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, sv::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams::Core.SimpleVector,...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typeinfer.jl:797; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.SimpleVector, call...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/inferencestate.jl:131; Core.Compiler.InferenceState(result::Core.Compiler.InferenceResult, cached::Bool, interp::Core.Compiler.NativeInte...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/utilities.jl:127; retrieve_code_info
  ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.SimpleVector, call...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/typeinfer.jl:272; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/typeinfer.jl:377; cache_result!(interp::Core.Compiler.NativeInterpreter, result::Core.Compiler.InferenceResult)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/cicache.jl:69; setindex!
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/cicache.jl:14; setindex!
  ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:168; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, sv::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:330; abstract_call_method_with_const_args(interp::Core.Compiler.NativeInterpreter, rettype::Any, f::Any, argtypes::Vecto...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/driver.jl:129; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:68; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, state::Core.Compiler.InliningS...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:1203; assemble_inline_todo!(ir::Core.Compiler.IRCode, state::Core.Compiler.InliningState{Core.Compiler.EdgeTracker, C...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/inlining.jl:1102; analyze_single_call!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, stmt::...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/inlining.jl:758; analyze_method!(match::Core.MethodMatch, atypes::Vector{Any}, et::Core.Compiler.EdgeTracker, caches::Core.Compi...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/inlining.jl:704; resolve_todo(todo::Core.Compiler.InliningTodo, et::Core.Compiler.EdgeTracker, caches::Core.Compiler.InferenceC...
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:767; Core.Compiler.InliningTodo(mi::Core.MethodInstance, src::Vector{UInt8})
  ╎    ╎    ╎    ╎    ╎    21 @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎     21 @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::Core.Compiler.Infere...
  ╎    ╎    ╎    ╎    ╎    ╎ 21 @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Compiler.I...
  ╎    ╎    ╎    ╎    ╎    ╎  21 @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Compiler.I...
  ╎    ╎    ╎    ╎    ╎    ╎   21 @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vector{Any}, sv::...
  ╎    ╎    ╎    ╎    ╎    ╎    19 @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, sv::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎     19 @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams::Core.SimpleVector,...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎ 19 @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.SimpleVector, call...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎  19 @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎   19 @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    19 @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎     19 @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 19 @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::Core.Compiler...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  19 @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Comp...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   3  @Base/compiler/abstractinterpretation.jl:1054; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Com...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:84; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, s...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/methodtable.jl:65; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, ::typeof(Core.Compiler.findall), si...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/methodtable.jl:66; #findall#217
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/iddict.jl:163; get!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/methodtable.jl:67; (::Core.Compiler.var"#218#219"{Int64, Core.Compiler.CachedMethodTable{Core.Compiler.InternalMethodTable}, Co...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/methodtable.jl:54; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, ::typeof(Core.Compiler.findall), ...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/methodtable.jl:57; #findall#216
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/reflection.jl:867; _methods_by_ftype
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, s...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams::Core.SimpleV...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 2  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.SimpleVector...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  2  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::Core.Co...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Co...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vect...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:84; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/methodtable.jl:65; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, ::typeof(Core.Compiler.finda...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/methodtable.jl:66; #findall#217
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/iddict.jl:163; get!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/methodtable.jl:67; (::Core.Compiler.var"#218#219"{Int64, Core.Compiler.CachedMethodTable{Core.Compiler.InternalMethodTabl...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/methodtable.jl:54; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, ::typeof(Core.Compiler.fin...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/methodtable.jl:57; #findall#216
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/reflection.jl:867; _methods_by_ftype
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/typeinfer.jl:269; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/typeinfer.jl:478; store_backedges
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/typeinfer.jl:493; store_backedges(caller::Core.MethodInstance, edges::Vector{Any})
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   16 @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Com...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    16 @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vector{Any...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     16 @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, ...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 16 @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams::Core.SimpleV...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  16 @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.SimpleVecto...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   16 @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    14 @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     14 @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 2  @Base/compiler/abstractinterpretation.jl:1447; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  2  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::Core.Co...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   2  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Co...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::C...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vect...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 2  @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  2  @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams::Core....
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   2  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.Simpl...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 2  @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:1447; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtype...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/driver.jl:129; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/inlining.jl:71; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, state::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:567; batch_inline!(todo::Vector{Core.Compiler.Pair{Int64, Any}}, ir::Core.Compiler.IRCode, linet...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/ir.jl:1198; iterate(compact::Core.Compiler.IncrementalCompact, ::Tuple{Int64, Int64})
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/ir.jl:1081; resize!(compact::Core.Compiler.IncrementalCompact, nnewnodes::Int64)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/ir.jl:191; resize!(stmts::Core.Compiler.InstructionStream, len::Int64)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/array.jl:1104; resize!
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/array.jl:884; _growend!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtype...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:168; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:330; abstract_call_method_with_const_args(interp::Core.Compiler.NativeInterpreter, rettype::Any, f::A...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/driver.jl:124; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/driver.jl:107; convert_to_ircode(ci::Core.CodeInfo, code::Vector{Any}, coverage::Bool, nargs::Int64, sv::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/ir.jl:92; compute_basic_blocks(stmts::Vector{Any})
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/basicblock.jl:25; BasicBlock
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/array.jl:391; getindex
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/boot.jl:467; Array
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/boot.jl:448; Array
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 12 @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  12 @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::Core.Co...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   12 @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Co...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    12 @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::C...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     12 @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vect...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/abstractinterpretation.jl:84; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/methodtable.jl:65; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, ::typeof(Core.Compiler.finda...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/methodtable.jl:66; #findall#217
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/iddict.jl:163; get!
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/methodtable.jl:67; (::Core.Compiler.var"#218#219"{Int64, Core.Compiler.CachedMethodTable{Core.Compiler.InternalMethodTab...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 11 @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  11 @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams::Core....
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   2  @Base/compiler/typeinfer.jl:769; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.Simpl...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/utilities.jl:178; specialize_method
 2╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/utilities.jl:191; specialize_method(method::Method, atypes::Any, sparams::Core.SimpleVector, preexisting::Bool, compil...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   9  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Core.Simpl...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    9  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     8  @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 8  @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  8  @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   8  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    8  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     8  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 8  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtype...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  7  @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   7  @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, sparams:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    7  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, sparams::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     7  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 6  @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  6  @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   6  @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    6  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     6  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 6  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vecto...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  6  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, a...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:84; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/methodtable.jl:65; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, ::typeof(Core.C...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/methodtable.jl:66; #findall#217
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/iddict.jl:163; get!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/methodtable.jl:67; (::Core.Compiler.var"#218#219"{Int64, Core.Compiler.CachedMethodTable{Core.Compiler.Inte...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/methodtable.jl:54; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, ::typeof(Cor...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/methodtable.jl:57; #findall#216
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/reflection.jl:867; _methods_by_ftype
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   5  @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    5  @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig::Any, s...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     5  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any, spara...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 5  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  3  @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   3  @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.Inferenc...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    3  @Base/compiler/abstractinterpretation.jl:1447; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.Inference...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     3  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vect...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 3  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  3  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   3  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    3  @Base/compiler/abstractinterpretation.jl:143; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     3  @Base/compiler/abstractinterpretation.jl:490; abstract_call_method(interp::Core.Compiler.NativeInterpreter, method::Method, sig:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 3  @Base/compiler/typeinfer.jl:806; typeinf_edge(interp::Core.Compiler.NativeInterpreter, method::Method, atypes::Any,...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  3  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceSt...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceS...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.I...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.Inf...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtype...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, arg...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, ar...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:84; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, arg...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/methodtable.jl:65; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}}, :...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/methodtable.jl:66; #findall#217
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/iddict.jl:163; get!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/methodtable.jl:67; (::Core.Compiler.var"#218#219"{Int64, Core.Compiler.CachedMethodTable{Core....
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/methodtable.jl:54; (::Core.Compiler.var"#findall##kw")(::NamedTuple{(:limit,), Tuple{Int64}},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/methodtable.jl:57; #findall#216
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/reflection.jl:867; _methods_by_ftype
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   2  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceS...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/ssair/driver.jl:129; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:68; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNod...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/inlining.jl:1203; assemble_inline_todo!(ir::Core.Compiler.IRCode, state::Core.Compiler.InliningS...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/inlining.jl:1129; analyze_single_call!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pai...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/inlining.jl:758; analyze_method!(match::Core.MethodMatch, atypes::Vector{Any}, et::Core.Compil...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:704; resolve_todo(todo::Core.Compiler.InliningTodo, et::Core.Compiler.EdgeTracker...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:771; Core.Compiler.InliningTodo(mi::Core.MethodInstance, src::Core.CodeInfo)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/legacy.jl:10; inflate_ir(ci::Core.CodeInfo, linfo::Core.MethodInstance)
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/legacy.jl:36; inflate_ir(ci::Core.CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:71; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNod...
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/inlining.jl:544; batch_inline!(todo::Vector{Core.Compiler.Pair{Int64, Any}}, ir::Core.Compiler....
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  2  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   2  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/driver.jl:129; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:71; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, sta...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:549; batch_inline!(todo::Vector{Core.Compiler.Pair{Int64, Any}}, ir::Core.Compiler.IRCode,...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/inlining.jl:333; ir_inline_item!(compact::Core.Compiler.IncrementalCompact, idx::Int64, argexprs::Vec...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/ir.jl:1191; iterate
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/ir.jl:1248; iterate(compact::Core.Compiler.IncrementalCompact, ::Tuple{Int64, Int64})
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/ir.jl:975; process_node!(compact::Core.Compiler.IncrementalCompact, result_idx::Int64, inst::...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/ir.jl:855; renumber_ssa2!(stmt::Any, ssanums::Vector{Any}, used_ssas::Vector{Int64}, late_fix...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/ir.jl:432; iterate
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/ir.jl:438; iterate(it::Core.Compiler.UseRefIterator, #unused#::Nothing)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/ir.jl:346; getindex(x::Core.Compiler.UseRef)
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/array.jl:801; getindex
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/driver.jl:133; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/passes.jl:534; getfield_elim_pass!(ir::Core.Compiler.IRCode)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/queries.jl:85; is_known_call(e::Expr, func::Any, src::Core.Compiler.IncrementalCompact)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/queries.jl:76; compact_exprtype
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/utilities.jl:220; argextype
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/utilities.jl:242; argextype(x::Any, src::Core.Compiler.IRCode, sptypes::Vector{Any}, slottypes::Vecto...
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:1289; abstract_eval_global
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/driver.jl:129; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/inlining.jl:68; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, state::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:1203; assemble_inline_todo!(ir::Core.Compiler.IRCode, state::Core.Compiler.InliningState{Core.Com...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:1129; analyze_single_call!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/inlining.jl:758; analyze_method!(match::Core.MethodMatch, atypes::Vector{Any}, et::Core.Compiler.EdgeTracke...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/inlining.jl:681; resolve_todo(todo::Core.Compiler.InliningTodo, et::Core.Compiler.EdgeTracker, caches::Core...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/inlining.jl:1395; find_inferred(mi::Core.MethodInstance, atypes::Vector{Any}, caches::Core.Compiler.Infere...
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/typeutils.jl:39; has_nontrivial_const_info
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:168; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any},...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:330; abstract_call_method_with_const_args(interp::Core.Compiler.NativeInterpreter, rettype::Any, f::A...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/typeinfer.jl:227; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typeinfer.jl:455; finish(me::Core.Compiler.InferenceState, interp::Core.Compiler.NativeInterpreter)
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/typeinfer.jl:603; type_annotate!(sv::Core.Compiler.InferenceState, run_optimizer::Bool)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/driver.jl:133; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/passes.jl:665; getfield_elim_pass!(ir::Core.Compiler.IRCode)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/passes.jl:312; lift_leaves(compact::Core.Compiler.IncrementalCompact, stmt::Any, result_t::Any, field::Int64, lea...
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/passes.jl:26; try_compute_fieldidx_expr(typ::Any, use_expr::Any)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/driver.jl:124; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/driver.jl:110; convert_to_ircode(ci::Core.CodeInfo, code::Vector{Any}, coverage::Bool, nargs::Int64, sv::Core.Compiler.O...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/array.jl:561; collect(#unused#::Type{Core.LineInfoNode}, itr::Vector{Any})
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/array.jl:564; _collect
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/array.jl:325; copyto!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/array.jl:299; copyto!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/array.jl:313; _copyto_impl!
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/array.jl:289; unsafe_copyto!
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/array.jl:235; _unsafe_copyto!(dest::Vector{Core.LineInfoNode}, doffs::Int64, src::Vector{Any}, soffs::Int64, n::Int64)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/driver.jl:129; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/inlining.jl:68; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, state::Core.Compiler.In...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/inlining.jl:1203; assemble_inline_todo!(ir::Core.Compiler.IRCode, state::Core.Compiler.InliningState{Core.Compiler.EdgeTra...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/inlining.jl:1102; analyze_single_call!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:758; analyze_method!(match::Core.MethodMatch, atypes::Vector{Any}, et::Core.Compiler.EdgeTracker, caches::Co...
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:704; resolve_todo(todo::Core.Compiler.InliningTodo, et::Core.Compiler.EdgeTracker, caches::Core.Compiler.Inf...
  ╎    ╎    ╎    ╎    ╎    ╎    2  @Base/compiler/abstractinterpretation.jl:168; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, sv::Cor...
  ╎    ╎    ╎    ╎    ╎    ╎     2  @Base/compiler/abstractinterpretation.jl:330; abstract_call_method_with_const_args(interp::Core.Compiler.NativeInterpreter, rettype::Any, f::Any, argtypes::Vecto...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎ 2  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/typeinfer.jl:214; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:1520; typeinf_nocycle(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:1462; typeinf_local(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:1167; abstract_eval_statement(interp::Core.Compiler.NativeInterpreter, e::Any, vtypes::Vector{Any}, sv::Core.Compiler....
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/abstractinterpretation.jl:1040; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Comp...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/abstractinterpretation.jl:1056; abstract_call(interp::Core.Compiler.NativeInterpreter, fargs::Vector{Any}, argtypes::Vector{Any}, sv::Core.Comp...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/abstractinterpretation.jl:1033; abstract_call_known(interp::Core.Compiler.NativeInterpreter, f::Any, fargs::Vector{Any}, argtypes::Vector{Any}...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/abstractinterpretation.jl:168; abstract_call_gf_by_type(interp::Core.Compiler.NativeInterpreter, f::Any, argtypes::Vector{Any}, atype::Any, s...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/abstractinterpretation.jl:330; abstract_call_method_with_const_args(interp::Core.Compiler.NativeInterpreter, rettype::Any, f::Any, argtypes:...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typeinfer.jl:209; typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/driver.jl:124; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/driver.jl:110; convert_to_ircode(ci::Core.CodeInfo, code::Vector{Any}, coverage::Bool, nargs::Int64, sv::Core.Compiler.Op...
  ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/driver.jl:136; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/passes.jl:871; adce_pass!(ir::Core.Compiler.IRCode)
  ╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/ir.jl:537; IncrementalCompact
 1╎    ╎    ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/ir.jl:584; Core.Compiler.IncrementalCompact(code::Core.Compiler.IRCode, allow_cfg_transforms::Bool)
  ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/typeinfer.jl:244; _typeinf(interp::Core.Compiler.NativeInterpreter, frame::Core.Compiler.InferenceState)
  ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/optimize.jl:272; optimize
  ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/ssair/driver.jl:129; run_passes(ci::Core.CodeInfo, nargs::Int64, sv::Core.Compiler.OptimizationState)
  ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/ssair/inlining.jl:68; ssa_inlining_pass!(ir::Core.Compiler.IRCode, linetable::Vector{Core.LineInfoNode}, state::Core.Compiler.InliningState{C...
  ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/ssair/inlining.jl:1155; assemble_inline_todo!(ir::Core.Compiler.IRCode, state::Core.Compiler.InliningState{Core.Compiler.EdgeTracker, Core.Co...
  ╎    ╎    ╎    ╎    ╎    ╎  1  @Base/compiler/ssair/inlining.jl:1039; process_simple!(ir::Core.Compiler.IRCode, todo::Vector{Core.Compiler.Pair{Int64, Any}}, idx::Int64, state::Core.Compi...
  ╎    ╎    ╎    ╎    ╎    ╎   1  @Base/compiler/ssair/inlining.jl:20; with_atype
  ╎    ╎    ╎    ╎    ╎    ╎    1  @Base/compiler/typeutils.jl:50; argtypes_to_type
  ╎    ╎    ╎    ╎    ╎    ╎     1  @Base/compiler/utilities.jl:39; anymap(f::typeof(Core.Compiler.widenconst), a::Vector{Any})
 1╎    ╎    ╎    ╎    ╎    ╎    ╎ 1  @Base/compiler/typelattice.jl:234; widenconst(c::Core.Const)
```
</details>