### PR TITLE
Add support for "bat" pager

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -246,7 +246,7 @@ if Sys.iswindows()
         end
         return push!(pager, "+$(line)$(goto)")
     end
-    
+
     function less(file::AbstractString, line::Integer)
         pager = shell_split(get(ENV, "PAGER", "more"))
         if pager[1] == "bat"
@@ -258,7 +258,7 @@ if Sys.iswindows()
             run(Cmd(`$pager \"$file\"`; windows_verbatim=true))
         end
         nothing
-    end 
+    end
 else
     function less(file::AbstractString, line::Integer)
         pager = shell_split(get(ENV, "PAGER", "less"))


### PR DESCRIPTION
`bat` outsources display to another pager. As such, if `$PAGER` is `bat`, we locally modify `$BATPAGER` to skip to the specified line. This change has yet to be tested by hand.