### PR TITLE
don't print field names in static_show of structs

### DIFF
--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1092,10 +1092,6 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
             if (vt == jl_typemap_entry_type)
                 i = 1;
             for (; i < tlen; i++) {
-                if (!istuple) {
-                    n += jl_printf(out, "%s", jl_symbol_name(jl_field_name(vt, i)));
-                    n += jl_printf(out, "=");
-                }
                 size_t offs = jl_field_offset(vt, i);
                 char *fld_ptr = (char*)v + offs;
                 if (jl_field_isptr(vt, i)) {


### PR DESCRIPTION
We don't use this as the default format for `show`, so it seems like a pretty spurious (even if rare) reason for a precompile statement not to work. Of course it still won't be 100% right, but is much more likely to work.

fixes #38902