### PR TITLE
Set ModFlag for `Debug Info Version` to Warning

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1689,7 +1689,7 @@ static void jl_setup_module(Module *m, const jl_cgparams_t *params = &jl_default
         m->addModuleFlag(llvm::Module::Warning, "Dwarf Version", dwarf_version);
     }
     if (!m->getModuleFlag("Debug Info Version"))
-        m->addModuleFlag(llvm::Module::Error, "Debug Info Version",
+        m->addModuleFlag(llvm::Module::Warning, "Debug Info Version",
             llvm::DEBUG_METADATA_VERSION);
     m->setDataLayout(jl_data_layout);
     m->setTargetTriple(jl_TargetMachine->getTargetTriple().str());


### PR DESCRIPTION
Other producers like Clang, set this to warning instead of error,
which can cause spurious failures when linking in bitcode files.

Julia module:

```
!llvm.module.flags = !{!0, !1}

!0 = !{i32 2, !"Dwarf Version", i32 4}
!1 = !{i32 1, !"Debug Info Version", i32 3}

```

Bitcode file produced by Clang:

```
!386 = !{i32 2, !"Debug Info Version", i32 3}
```

Leading to the fun:

```
error: linking module flags 'Debug Info Version': IDs have conflicting behaviors in 'usr/lib/libopencilk-abi.bc' and 'test_loop'
```

cc: @neboat @tkf

