### PR TITLE
indexing involving IdentityUnitRanges may return the indices if possible

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -397,6 +397,8 @@ unsafe_length(S::IdentityUnitRange) = unsafe_length(S.indices)
 getindex(S::IdentityUnitRange, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::IdentityUnitRange, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::IdentityUnitRange, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
+getindex(S::AbstractUnitRange{<:Integer}, i::IdentityUnitRange) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
+getindex(S::IdentityUnitRange, i::IdentityUnitRange) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 show(io::IO, r::IdentityUnitRange) = print(io, "Base.IdentityUnitRange(", r.indices, ")")
 iterate(S::IdentityUnitRange, s...) = iterate(S.indices, s...)
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1312,6 +1312,15 @@ end
     end
 end
 
+@testset "indexing involving IdentityUnitRange" begin
+    r1 = 1:4
+    r2 = Base.IdentityUnitRange(2:3)
+    r3 = UnitRange(r2)
+    @test r1[r2] === r2
+    @test Base.IdentityUnitRange(r1)[r2] === r2
+    @test r2[r3] === r3
+end
+
 @testset "reduce(vcat, ...) inferrence #40277" begin
     x_vecs = ([5, ], [1.0, 2.0, 3.0])
     @test @inferred(reduce(vcat, x_vecs)) == [5.0, 1.0, 2.0, 3.0]

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1317,6 +1317,7 @@ end
     r2 = Base.IdentityUnitRange(2:3)
     r3 = UnitRange(r2)
     @test r1[r2] === r2
+    @test Base.OneTo(r1)[r2] === r2
     @test Base.IdentityUnitRange(r1)[r2] === r2
     @test r2[r3] === r3
 end


### PR DESCRIPTION
This changes the axes of the result when an `AbstractUnitRange{<:Integer}` is indexed with an `Base.IdentityUnitRange`:

Previously
```julia
julia> (1:4)[Base.IdentityUnitRange(2:3)]
2:3

julia> (1:4)[Base.IdentityUnitRange(2:3)] |> axes
(Base.OneTo(2),)
```
After this PR:
```julia
julia> (1:4)[Base.IdentityUnitRange(2:3)]
Base.IdentityUnitRange(2:3)
```

Choosing the returned type to be an `IdentityUnitRange` makes the property `r1[r2[i]] == r2[r2][i]` hold true for these cases. This also reduces the type-piracy necessary in `OffsetArrays`