### PR TITLE
Add compat to docstring for single-arg `isapprox`

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -295,6 +295,9 @@ end
 Create a function that compares its argument to `x` using `≈`, i.e. a function equivalent to `y -> y ≈ x`.
 
 The keyword arguments supported here are the same as those in the 2-argument `isapprox`.
+
+!!! compat "Julia 1.5"
+    This function requires Julia 1.5 or later.
 """
 isapprox(y; kwargs...) = x -> isapprox(x, y; kwargs...)
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -297,7 +297,7 @@ Create a function that compares its argument to `x` using `≈`, i.e. a function
 The keyword arguments supported here are the same as those in the 2-argument `isapprox`.
 
 !!! compat "Julia 1.5"
-    This function requires Julia 1.5 or later.
+    This method requires Julia 1.5 or later.
 """
 isapprox(y; kwargs...) = x -> isapprox(x, y; kwargs...)
 


### PR DESCRIPTION
This single-arg version was added in https://github.com/JuliaLang/julia/commit/ab5b40a3fa7be1cb9a261cc57b628764c86b2c1c which first appeared in 1.5
