### PR TITLE
Indexing arrays with AbstractUnitRanges retains indices

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -838,9 +838,9 @@ function getindex(A::Array, I::AbstractUnitRange{<:Integer})
     @_inline_meta
     @boundscheck checkbounds(A, I)
     lI = length(I)
-    X = similar(A, lI)
+    X = similar(A, axes(I))
     if lI > 0
-        unsafe_copyto!(X, 1, A, first(I), lI)
+        copyto!(X, firstindex(X), A, first(I), lI)
     end
     return X
 end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -776,3 +776,13 @@ end
     strY = String(take!(io))
     @test strX == strY
 end
+
+@testset "vector indexing (issue #39896)" begin
+    a = collect(1:10)
+    r = Base.IdentityUnitRange(2:3)
+    b = a[r]
+    @test axes(b) == axes(r)
+    for i in r
+        @test b[i] == a[r[i]]
+    end
+end


### PR DESCRIPTION
In v1.6

```julia
julia> using OffsetArrays

julia> ones(10)[Base.IdentityUnitRange(2:3)]
2-element OffsetArray(::Vector{Float64}, 2:3) with eltype Float64 with indices 2:3:
 1.0
 1.0
```

On master:
```julia
julia> ones(10)[Base.IdentityUnitRange(2:3)]
2-element Vector{Float64}:
 1.0
 1.0
```

This happens because #39896 changed the behavior of `getindex`, and it now uses the length of the indices instead of the axes to generate the output array. This PR reverts this to make the result account for the axes again. After this:

```julia
julia> ones(10)[Base.IdentityUnitRange(2:3)]
2-element OffsetArray(::Vector{Float64}, 2:3) with eltype Float64 with indices 2:3:
 1.0
 1.0
```

Also,

on master
```julia
julia> using StaticArrays

julia> ones(10)[SOneTo(2)]
2-element Vector{Float64}:
 1.0
 1.0
```

After this PR (back to v1.6 behavior):
```julia
julia> ones(10)[SOneTo(2)]
2-element SizedVector{2, Float64, Vector{Float64}} with indices SOneTo(2):
 1.0
 1.0
```

The performance impact on changing `unsafe_copyto!` to `copyto!` appears to be minimal.

with `copyto!`
```julia
julia> a = ones(20000);

julia> @btime $a[$ax];
  19.084 μs (2 allocations: 156.33 KiB)
```

with `unsafe_copyto!`
```julia
julia> @btime $a[$ax];
  18.968 μs (2 allocations: 156.33 KiB)
```
The difference is within the noise level.