### PR TITLE
Replace llvm::sys::fs::F_None with llvm::sys::fs::OF_None

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8092,12 +8092,12 @@ extern "C" void jl_dump_llvm_mfunction(void *v)
 
 extern void jl_write_bitcode_func(void *F, char *fname) {
     std::error_code EC;
-    raw_fd_ostream OS(fname, EC, sys::fs::F_None);
+    raw_fd_ostream OS(fname, EC, sys::fs::OF_None);
     llvm::WriteBitcodeToFile(*((llvm::Function*)F)->getParent(), OS);
 }
 
 extern void jl_write_bitcode_module(void *M, char *fname) {
     std::error_code EC;
-    raw_fd_ostream OS(fname, EC, sys::fs::F_None);
+    raw_fd_ostream OS(fname, EC, sys::fs::OF_None);
     llvm::WriteBitcodeToFile(*(llvm::Module*)M, OS);
 }


### PR DESCRIPTION
The former is deprecated.
OF_None has been available in LLVM since 2018-06.

-----

OF_None (https://reviews.llvm.org/rG1f67a3cba9b09636c56e2109d8a35ae96dc15782) exists in LLVM 9.
https://reviews.llvm.org/D101506 may drop F_None support.