### PR TITLE
Efficiency improvement of exp(::StridedMatrix) with UniformScaling and mul!

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -672,7 +672,7 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
                  A6,
                  CC[14].*A6 .+ CC[12].*A4 .+ CC[10].*A2,
                  true, true)
-        U *= A
+        U = A*U
 
         # Allocation economical version of: Vt = CC[3]*A2 (recycle Ut)
         Vt = mul!(Ut, CC[3], A2, true, false)

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -617,7 +617,6 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
     end
     ilo, ihi, scale = LAPACK.gebal!('B', A)    # modifies A
     nA   = opnorm(A, 1)
-    Inn    = Matrix{T}(I, n, n)
     ## For sufficiently small nA, use lower order Padé-Approximations
     if (nA <= 2.1)
         if nA > 0.95
@@ -664,10 +663,14 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
         A2 = A * A
         A4 = A2 * A2
         A6 = A2 * A4
+        Ut = CC[4]*A2
+        Ut[diagind(Ut)] .+=  CC[2]
         U  = A * (A6 * (CC[14].*A6 .+ CC[12].*A4 .+ CC[10].*A2) .+
-                  CC[8].*A6 .+ CC[6].*A4 .+ CC[4].*A2 .+ CC[2].*Inn)
+                  CC[8].*A6 .+ CC[6].*A4 .+ Ut)
+        Vt = CC[3]*A2
+        Vt[diagind(Vt)] .+=  CC[1]
         V  = A6 * (CC[13].*A6 .+ CC[11].*A4 .+ CC[9].*A2) .+
-                   CC[7].*A6 .+ CC[5].*A4 .+ CC[3].*A2 .+ CC[1].*Inn
+                   CC[7].*A6 .+ CC[5].*A4 .+ Vt
 
         X = V + U
         LAPACK.gesv!(V-U, X)

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -641,8 +641,8 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
         for k in 2:(div(size(C, 1), 2) - 1)
             k2 = 2 * k
             P *= A2
-            U += C[k2 + 2] * P
-            V += C[k2 + 1] * P
+            mul!(U, C[k2 + 2], P, true, true) # U += C[k2+2]*P
+            mul!(V, C[k2 + 1], P, true, true) # V += C[k2+1]*P
         end
 
         U = A * U

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -634,17 +634,21 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
             C = T[120.,60.,12.,1.]
         end
         A2 = A * A
-        P  = copy(Inn)
-        U  = C[2] * P
-        V  = C[1] * P
-        for k in 1:(div(size(C, 1), 2) - 1)
+        # Compute U and V: Even/odd terms in Padé numerator & denom
+        # Expansion of k=1 in for loop
+        P = A2
+        U = C[2]*I + C[4]*P
+        V = C[1]*I + C[3]*P
+        for k in 2:(div(size(C, 1), 2) - 1)
             k2 = 2 * k
             P *= A2
             U += C[k2 + 2] * P
             V += C[k2 + 1] * P
         end
+
         U = A * U
         X = V + U
+        # Padé approximant:  (V-U)\(V+U)
         LAPACK.gesv!(V-U, X)
     else
         s  = log2(nA/5.4)               # power of 2 later reversed by squaring


### PR DESCRIPTION
Avoids the use of `Inn=Matrix{T}(I,n,n)`. This reduces the number of 
a) matrix-matrix products for `nA<=2.1`: commit  d94b513 
b) zero additions  for `nA>2.1`: commit  e6860a4 

This PR also has some memory allocation improvements by using `mul!`.

Two CPU-time illustrations
a) nA<2.1
```
Random.seed!(0);
A=randn(100,100); A=1e-13*A/opnorm(A,1);
```
Original vs new:
```
  884.357 μs (31 allocations: 1.07 MiB)
  741.872 μs (21 allocations: 705.69 KiB)
```
b) nA>2.1
```
A=randn(50,50);
A=100*A/opnorm(A,1);
```
Original vs new:
```
  657.075 μs (43 allocations: 393.97 KiB)
  614.814 μs (45 allocations: 355.81 KiB)
```

The most important improvement is case a) where the number of matrix-matrix products is reduced.


Solves JuliaLang/LinearAlgebra.jl#840.