### PR TITLE
Document UInt return type of objectid

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -293,7 +293,7 @@ macro locals()
 end
 
 """
-    objectid(x)
+    objectid(x) -> UInt
 
 Get a hash value for `x` based on object identity. `objectid(x)==objectid(y)` if `x === y`.
 


### PR DESCRIPTION
It took me some time to figure out that `objectid` returns a `UInt`. `typeof(objectid(123))` gave me the false belief that the return type is `UInt64`.

Is the return type for `hash` also fixed to `UInt`?