### PR TITLE
NFC: remove unnecessary const before type aliases

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -20,7 +20,7 @@ DimensionMismatch() = DimensionMismatch("")
 Supertype for one-dimensional arrays (or array-like types) with
 elements of type `T`. Alias for [`AbstractArray{T,1}`](@ref).
 """
-const AbstractVector{T} = AbstractArray{T,1}
+AbstractVector{T} = AbstractArray{T,1}
 
 """
     AbstractMatrix{T}
@@ -28,18 +28,18 @@ const AbstractVector{T} = AbstractArray{T,1}
 Supertype for two-dimensional arrays (or array-like types) with
 elements of type `T`. Alias for [`AbstractArray{T,2}`](@ref).
 """
-const AbstractMatrix{T} = AbstractArray{T,2}
+AbstractMatrix{T} = AbstractArray{T,2}
 
 """
     AbstractVecOrMat{T}
 
 Union type of [`AbstractVector{T}`](@ref) and [`AbstractMatrix{T}`](@ref).
 """
-const AbstractVecOrMat{T} = Union{AbstractVector{T}, AbstractMatrix{T}}
+AbstractVecOrMat{T} = Union{AbstractVector{T}, AbstractMatrix{T}}
 const RangeIndex = Union{Int, AbstractRange{Int}, AbstractUnitRange{Int}}
 const DimOrInd = Union{Integer, AbstractUnitRange}
 const IntOrInd = Union{Int, AbstractUnitRange}
-const DimsOrInds{N} = NTuple{N,DimOrInd}
+DimsOrInds{N} = NTuple{N,DimOrInd}
 const NeedsShaping = Union{Tuple{Integer,Vararg{Integer}}, Tuple{OneTo,Vararg{OneTo}}}
 
 """
@@ -57,7 +57,7 @@ a mathematical vector. Alias for [`Array{T,1}`](@ref).
 
 See also [`empty`](@ref), [`similar`](@ref) and [`zero`](@ref) for creating vectors.
 """
-const Vector{T} = Array{T,1}
+Vector{T} = Array{T,1}
 
 """
     Matrix{T} <: AbstractMatrix{T}
@@ -68,7 +68,7 @@ a mathematical matrix. Alias for [`Array{T,2}`](@ref).
 See also [`fill`](@ref), [`zeros`](@ref), [`undef`](@ref) and [`similar`](@ref)
 for creating matrices.
 """
-const Matrix{T} = Array{T,2}
+Matrix{T} = Array{T,2}
 
 """
     VecOrMat{T}
@@ -87,7 +87,7 @@ julia> Array{Float64, 3} <: VecOrMat{Float64}
 false
 ```
 """
-const VecOrMat{T} = Union{Vector{T}, Matrix{T}}
+VecOrMat{T} = Union{Vector{T}, Matrix{T}}
 
 """
     DenseArray{T, N} <: AbstractArray{T,N}
@@ -102,21 +102,21 @@ DenseArray
 
 One-dimensional [`DenseArray`](@ref) with elements of type `T`. Alias for `DenseArray{T,1}`.
 """
-const DenseVector{T} = DenseArray{T,1}
+DenseVector{T} = DenseArray{T,1}
 
 """
     DenseMatrix{T}
 
 Two-dimensional [`DenseArray`](@ref) with elements of type `T`. Alias for `DenseArray{T,2}`.
 """
-const DenseMatrix{T} = DenseArray{T,2}
+DenseMatrix{T} = DenseArray{T,2}
 
 """
     DenseVecOrMat{T}
 
 Union type of [`DenseVector{T}`](@ref) and [`DenseMatrix{T}`](@ref).
 """
-const DenseVecOrMat{T} = Union{DenseVector{T}, DenseMatrix{T}}
+DenseVecOrMat{T} = Union{DenseVector{T}, DenseMatrix{T}}
 
 ## Basic functions ##
 
@@ -1626,7 +1626,7 @@ function cmp(a::Array{UInt8,1}, b::Array{UInt8,1})
     return c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
 end
 
-const BitIntegerArray{N} = Union{map(T->Array{T,N}, BitInteger_types)...} where N
+BitIntegerArray{N} = Union{map(T->Array{T,N}, BitInteger_types)...} where N
 # use memcmp for == on bit integer types
 ==(a::Arr, b::Arr) where {Arr <: BitIntegerArray} =
     size(a) == size(b) && 0 == _memcmp(a, b, sizeof(eltype(Arr)) * length(a))

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -443,7 +443,7 @@ convert(::Type{T}, x::T) where {T} = x
 cconvert(::Type{T}, x) where {T} = convert(T, x)
 unsafe_convert(::Type{T}, x::T) where {T} = x
 
-const NTuple{N,T} = Tuple{Vararg{T,N}}
+NTuple{N,T} = Tuple{Vararg{T,N}}
 
 
 ## primitive Array constructors

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1042,7 +1042,7 @@ end
 # requires very careful consideration of all the edge effects.
 const ChunkableOp = Union{typeof(&), typeof(|), typeof(xor), typeof(~), typeof(identity),
     typeof(!), typeof(*), typeof(==)} # these are convertible to chunkable ops by liftfuncs
-const BroadcastedChunkableOp{Style<:Union{Nothing,BroadcastStyle}, Axes, F<:ChunkableOp, Args<:Tuple} = Broadcasted{Style,Axes,F,Args}
+BroadcastedChunkableOp{Style<:Union{Nothing,BroadcastStyle}, Axes, F<:ChunkableOp, Args<:Tuple} = Broadcasted{Style,Axes,F,Args}
 ischunkedbroadcast(R, bc::BroadcastedChunkableOp) = ischunkedbroadcast(R, bc.args)
 ischunkedbroadcast(R, args) = false
 ischunkedbroadcast(R, args::Tuple{<:BitArray,Vararg{Any}}) = size(R) == size(args[1]) && ischunkedbroadcast(R, tail(args))

--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -129,7 +129,7 @@ mutable struct LinkedListItem{T}
     value::T
     LinkedListItem{T}(value::T) where {T} = new{T}(nothing, nothing, value)
 end
-const LinkedList{T} = InvasiveLinkedList{LinkedListItem{T}}
+LinkedList{T} = InvasiveLinkedList{LinkedListItem{T}}
 
 # delegate methods, as needed
 eltype(::Type{<:LinkedList{T}}) where {T} = @isdefined(T) ? T : Any

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -10,7 +10,7 @@ end
 ReshapedArray(parent::AbstractArray{T}, dims::NTuple{N,Int}, mi) where {T,N} = ReshapedArray{T,N,typeof(parent),typeof(mi)}(parent, dims, mi)
 
 # IndexLinear ReshapedArray
-const ReshapedArrayLF{T,N,P<:AbstractArray} = ReshapedArray{T,N,P,Tuple{}}
+ReshapedArrayLF{T,N,P<:AbstractArray} = ReshapedArray{T,N,P,Tuple{}}
 
 # Fast iteration on ReshapedArrays: use the parent iterator
 struct ReshapedArrayIterator{I,M}
@@ -271,7 +271,7 @@ end
 end
 
 # helpful error message for a common failure case
-const ReshapedRange{T,N,A<:AbstractRange} = ReshapedArray{T,N,A,Tuple{}}
+ReshapedRange{T,N,A<:AbstractRange} = ReshapedArray{T,N,A,Tuple{}}
 setindex!(A::ReshapedRange, val, index::Int) = _rs_setindex!_err()
 setindex!(A::ReshapedRange{T,N}, val, indices::Vararg{Int,N}) where {T,N} = _rs_setindex!_err()
 setindex!(A::ReshapedRange, val, index::ReshapedIndex) = _rs_setindex!_err()
@@ -281,7 +281,7 @@ setindex!(A::ReshapedRange, val, index::ReshapedIndex) = _rs_setindex!_err()
 unsafe_convert(::Type{Ptr{T}}, a::ReshapedArray{T}) where {T} = unsafe_convert(Ptr{T}, parent(a))
 
 # Add a few handy specializations to further speed up views of reshaped ranges
-const ReshapedUnitRange{T,N,A<:AbstractUnitRange} = ReshapedArray{T,N,A,Tuple{}}
+ReshapedUnitRange{T,N,A<:AbstractUnitRange} = ReshapedArray{T,N,A,Tuple{}}
 viewindexing(I::Tuple{Slice, ReshapedUnitRange, Vararg{ScalarIndex}}) = IndexLinear()
 viewindexing(I::Tuple{ReshapedRange, Vararg{ScalarIndex}}) = IndexLinear()
 compute_stride1(s, inds, I::Tuple{ReshapedRange, Vararg{Any}}) = s*step(I[1].parent)

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -275,7 +275,7 @@ ParserError(type) = ParserError(type, nothing)
 #ParserError(type, data) = error(type,data)
 
 # Many functions return either a T or a ParserError
-const Err{T} = Union{T, ParserError}
+Err{T} = Union{T, ParserError}
 
 function format_error_message_for_err_type(error::ParserError)
     msg = err_message[error.type]

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -220,12 +220,12 @@ map(f, t::Tuple{Any, Any})      = (@_inline_meta; (f(t[1]), f(t[2])))
 map(f, t::Tuple{Any, Any, Any}) = (@_inline_meta; (f(t[1]), f(t[2]), f(t[3])))
 map(f, t::Tuple)                = (@_inline_meta; (f(t[1]), map(f,tail(t))...))
 # stop inlining after some number of arguments to avoid code blowup
-const Any32{N} = Tuple{Any,Any,Any,Any,Any,Any,Any,Any,
+Any32{N} = Tuple{Any,Any,Any,Any,Any,Any,Any,Any,
                        Any,Any,Any,Any,Any,Any,Any,Any,
                        Any,Any,Any,Any,Any,Any,Any,Any,
                        Any,Any,Any,Any,Any,Any,Any,Any,
                        Vararg{Any,N}}
-const All32{T,N} = Tuple{T,T,T,T,T,T,T,T,
+All32{T,N} = Tuple{T,T,T,T,T,T,T,T,
                          T,T,T,T,T,T,T,T,
                          T,T,T,T,T,T,T,T,
                          T,T,T,T,T,T,T,T,

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -183,13 +183,13 @@ function Base.showarg(io::IO, v::Transpose, toplevel)
 end
 
 # some aliases for internal convenience use
-const AdjOrTrans{T,S} = Union{Adjoint{T,S},Transpose{T,S}} where {T,S}
-const AdjointAbsVec{T} = Adjoint{T,<:AbstractVector}
-const AdjointAbsMat{T} = Adjoint{T,<:AbstractMatrix}
-const TransposeAbsVec{T} = Transpose{T,<:AbstractVector}
-const TransposeAbsMat{T} = Transpose{T,<:AbstractMatrix}
-const AdjOrTransAbsVec{T} = AdjOrTrans{T,<:AbstractVector}
-const AdjOrTransAbsMat{T} = AdjOrTrans{T,<:AbstractMatrix}
+AdjOrTrans{T,S} = Union{Adjoint{T,S},Transpose{T,S}} where {T,S}
+AdjointAbsVec{T} = Adjoint{T,<:AbstractVector}
+AdjointAbsMat{T} = Adjoint{T,<:AbstractMatrix}
+TransposeAbsVec{T} = Transpose{T,<:AbstractVector}
+TransposeAbsMat{T} = Transpose{T,<:AbstractMatrix}
+AdjOrTransAbsVec{T} = AdjOrTrans{T,<:AbstractVector}
+AdjOrTransAbsMat{T} = AdjOrTrans{T,<:AbstractMatrix}
 
 # for internal use below
 wrapperop(A::Adjoint) = adjoint

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1614,7 +1614,7 @@ end
 
 logdet(A) = log(det(A))
 
-const NumberArray{T<:Number} = AbstractArray{T}
+NumberArray{T<:Number} = AbstractArray{T}
 
 """
     promote_leaf_eltypes(itr)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -540,7 +540,7 @@ Base.propertynames(F::Hessenberg, private::Bool=false) =
     (:Q, :H, :μ, (private ? (:τ, :factors, :uplo) : ())...)
 
 # HessenbergQ from LAPACK/BLAS (as opposed to Julia libraries like GenericLinearAlgebra)
-const BlasHessenbergQ{T,sym} = HessenbergQ{T,<:StridedMatrix{T},<:StridedVector{T},sym} where {T<:BlasFloat,sym}
+BlasHessenbergQ{T,sym} = HessenbergQ{T,<:StridedMatrix{T},<:StridedVector{T},sym} where {T<:BlasFloat,sym}
 
 ## reconstruct the original matrix
 Matrix{T}(Q::BlasHessenbergQ{<:Any,false}) where {T} = convert(Matrix{T}, LAPACK.orghr!(1, size(Q.factors, 1), copy(Q.factors), Q.τ))

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -193,10 +193,10 @@ end
 convert(T::Type{<:Symmetric}, m::Union{Symmetric,Hermitian}) = m isa T ? m : T(m)
 convert(T::Type{<:Hermitian}, m::Union{Symmetric,Hermitian}) = m isa T ? m : T(m)
 
-const HermOrSym{T,        S} = Union{Hermitian{T,S}, Symmetric{T,S}}
-const RealHermSym{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}}
-const RealHermSymComplexHerm{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}, Hermitian{Complex{T},S}}
-const RealHermSymComplexSym{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}, Symmetric{Complex{T},S}}
+HermOrSym{T,        S} = Union{Hermitian{T,S}, Symmetric{T,S}}
+RealHermSym{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}}
+RealHermSymComplexHerm{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}, Hermitian{Complex{T},S}}
+RealHermSymComplexSym{T<:Real,S} = Union{Hermitian{T,S}, Symmetric{T,S}, Symmetric{Complex{T},S}}
 
 size(A::HermOrSym, d) = size(A.data, d)
 size(A::HermOrSym) = size(A.data)

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -280,13 +280,13 @@ end
 
 A one-dimensional [`SharedArray`](@ref).
 """
-const SharedVector{T} = SharedArray{T,1}
+SharedVector{T} = SharedArray{T,1}
 """
     SharedMatrix
 
 A two-dimensional [`SharedArray`](@ref).
 """
-const SharedMatrix{T} = SharedArray{T,2}
+SharedMatrix{T} = SharedArray{T,2}
 
 SharedVector(A::Vector) = SharedArray(A)
 SharedMatrix(A::Matrix) = SharedArray(A)

--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -15,14 +15,14 @@ abstract type AbstractSparseArray{Tv,Ti,N} <: AbstractArray{Tv,N} end
 Supertype for one-dimensional sparse arrays (or array-like types) with elements
 of type `Tv` and index type `Ti`. Alias for `AbstractSparseArray{Tv,Ti,1}`.
 """
-const AbstractSparseVector{Tv,Ti} = AbstractSparseArray{Tv,Ti,1}
+AbstractSparseVector{Tv,Ti} = AbstractSparseArray{Tv,Ti,1}
 """
     AbstractSparseMatrix{Tv,Ti}
 
 Supertype for two-dimensional sparse arrays (or array-like types) with elements
 of type `Tv` and index type `Ti`. Alias for `AbstractSparseArray{Tv,Ti,2}`.
 """
-const AbstractSparseMatrix{Tv,Ti} = AbstractSparseArray{Tv,Ti,2}
+AbstractSparseMatrix{Tv,Ti} = AbstractSparseArray{Tv,Ti,2}
 
 """
     AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}

--- a/stdlib/SparseArrays/src/higherorderfns.jl
+++ b/stdlib/SparseArrays/src/higherorderfns.jl
@@ -98,11 +98,11 @@ can_skip_sparsification(f, rest...) = false
 can_skip_sparsification(::typeof(*), ::SparseVectorUnion, ::AdjOrTransSparseVectorUnion) = true
 
 # Dispatch on broadcast operations by number of arguments
-const Broadcasted0{Style<:Union{Nothing,BroadcastStyle},Axes,F} =
+Broadcasted0{Style<:Union{Nothing,BroadcastStyle},Axes,F} =
     Broadcasted{Style,Axes,F,Tuple{}}
-const SpBroadcasted1{Style<:SPVM,Axes,F,Args<:Tuple{SparseVecOrMat}} =
+SpBroadcasted1{Style<:SPVM,Axes,F,Args<:Tuple{SparseVecOrMat}} =
     Broadcasted{Style,Axes,F,Args}
-const SpBroadcasted2{Style<:SPVM,Axes,F,Args<:Tuple{SparseVecOrMat,SparseVecOrMat}} =
+SpBroadcasted2{Style<:SPVM,Axes,F,Args<:Tuple{SparseVecOrMat,SparseVecOrMat}} =
     Broadcasted{Style,Axes,F,Args}
 
 # (1) The definitions below provide a common interface to sparse vectors and matrices

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -157,8 +157,8 @@ end
 # Sparse matrix multiplication as described in [Gustavson, 1978]:
 # http://dl.acm.org/citation.cfm?id=355796
 
-const SparseTriangular{Tv,Ti} = Union{UpperTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}},LowerTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}}
-const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti},SparseTriangular{Tv,Ti}}
+SparseTriangular{Tv,Ti} = Union{UpperTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}},LowerTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}}
+SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti},SparseTriangular{Tv,Ti}}
 
 *(A::SparseOrTri, B::AbstractSparseVector) = spmatmulv(A, B)
 *(A::SparseOrTri, B::SparseColumnView) = spmatmulv(A, B)
@@ -376,7 +376,7 @@ function dot(x::SparseVector, A::AbstractSparseMatrixCSC, y::SparseVector)
     r
 end
 
-const WrapperMatrixTypes{T,MT} = Union{
+WrapperMatrixTypes{T,MT} = Union{
     SubArray{T,2,MT},
     Adjoint{T,MT},
     Transpose{T,MT},
@@ -419,33 +419,33 @@ possible_adjoint(adj::Bool, a) = adj ? adjoint(a) : a
 
 const UnitDiagonalTriangular = Union{UnitUpperTriangular,UnitLowerTriangular}
 
-const LowerTriangularPlain{T} = Union{
+LowerTriangularPlain{T} = Union{
             LowerTriangular{T,<:SparseMatrixCSCUnion{T}},
             UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}}
 
-const LowerTriangularWrapped{T} = Union{
+LowerTriangularWrapped{T} = Union{
             Adjoint{T,<:UpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
             Adjoint{T,<:UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
             Transpose{T,<:UpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
             Transpose{T,<:UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}}} where T
 
-const UpperTriangularPlain{T} = Union{
+UpperTriangularPlain{T} = Union{
             UpperTriangular{T,<:SparseMatrixCSCUnion{T}},
             UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}}
 
-const UpperTriangularWrapped{T} = Union{
+UpperTriangularWrapped{T} = Union{
             Adjoint{T,<:LowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
             Adjoint{T,<:UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
             Transpose{T,<:LowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
             Transpose{T,<:UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}}} where T
 
-const UpperTriangularSparse{T} = Union{
+UpperTriangularSparse{T} = Union{
             UpperTriangularWrapped{T}, UpperTriangularPlain{T}} where T
 
-const LowerTriangularSparse{T} = Union{
+LowerTriangularSparse{T} = Union{
             LowerTriangularWrapped{T}, LowerTriangularPlain{T}} where T
 
-const TriangularSparse{T} = Union{
+TriangularSparse{T} = Union{
             LowerTriangularSparse{T}, UpperTriangularSparse{T}} where T
 
 ## triangular multipliers

--- a/stdlib/SparseArrays/src/sparseconvert.jl
+++ b/stdlib/SparseArrays/src/sparseconvert.jl
@@ -7,10 +7,10 @@ import LinearAlgebra: AbstractTriangular
 
 `Symmetric` or `Hermitian` of a `SparseMatrixCSC` or `SparseMatrixCSCView`.
 """
-const SparseMatrixCSCSymmHerm{Tv,Ti} = Union{Symmetric{Tv,<:SparseMatrixCSCUnion{Tv,Ti}},
+SparseMatrixCSCSymmHerm{Tv,Ti} = Union{Symmetric{Tv,<:SparseMatrixCSCUnion{Tv,Ti}},
                                             Hermitian{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}}
 
-const AbstractTriangularSparse{Tv,Ti} = AbstractTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
+AbstractTriangularSparse{Tv,Ti} = AbstractTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
 
 # converting Symmetric/Hermitian/AbstractTriangular/SubArray of SparseMatrixCSC
 # and Transpose/Adjoint of AbstractTriangular of SparseMatrixCSC to SparseMatrixCSC

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -93,10 +93,10 @@ end
 # this union by extracting the fields via the get function: getcolptr, getrowval, and getnzval. The key
 # insight is that getcolptr on a SparseMatrixCSCView returns an offset view of the colptr of the
 # underlying SparseMatrixCSC
-const SparseMatrixCSCView{Tv,Ti} =
+SparseMatrixCSCView{Tv,Ti} =
     SubArray{Tv,2,<:AbstractSparseMatrixCSC{Tv,Ti},
         Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractUnitRange}
-const SparseMatrixCSCUnion{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
+SparseMatrixCSCUnion{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
 
 getcolptr(S::SparseMatrixCSC)     = getfield(S, :colptr)
 getcolptr(S::SparseMatrixCSCView) = view(getcolptr(parent(S)), first(axes(S, 2)):(last(axes(S, 2)) + 1))

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -34,8 +34,8 @@ SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
 # union of such a view and a SparseVector so we define an alias for such a union as well
 const SparseColumnView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
 const SparseVectorView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}}},false}
-const SparseVectorUnion{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
-const AdjOrTransSparseVectorUnion{Tv,Ti} = LinearAlgebra.AdjOrTrans{Tv, <:SparseVectorUnion{Tv,Ti}}
+SparseVectorUnion{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
+AdjOrTransSparseVectorUnion{Tv,Ti} = LinearAlgebra.AdjOrTrans{Tv, <:SparseVectorUnion{Tv,Ti}}
 
 ### Basic properties
 
@@ -1072,20 +1072,20 @@ const _SparseArrays = Union{SparseVector, AbstractSparseMatrixCSC, Adjoint{<:Any
 const _SpecialArrays = Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}
 const _SparseConcatArrays = Union{_SpecialArrays, _SparseArrays}
 
-const _Symmetric_SparseConcatArrays{T,A<:_SparseConcatArrays} = Symmetric{T,A}
-const _Hermitian_SparseConcatArrays{T,A<:_SparseConcatArrays} = Hermitian{T,A}
-const _Triangular_SparseConcatArrays{T,A<:_SparseConcatArrays} = LinearAlgebra.AbstractTriangular{T,A}
+_Symmetric_SparseConcatArrays{T,A<:_SparseConcatArrays} = Symmetric{T,A}
+_Hermitian_SparseConcatArrays{T,A<:_SparseConcatArrays} = Hermitian{T,A}
+_Triangular_SparseConcatArrays{T,A<:_SparseConcatArrays} = LinearAlgebra.AbstractTriangular{T,A}
 const _Annotated_SparseConcatArrays = Union{_Triangular_SparseConcatArrays, _Symmetric_SparseConcatArrays, _Hermitian_SparseConcatArrays}
 
-const _Symmetric_DenseArrays{T,A<:Matrix} = Symmetric{T,A}
-const _Hermitian_DenseArrays{T,A<:Matrix} = Hermitian{T,A}
-const _Triangular_DenseArrays{T,A<:Matrix} = LinearAlgebra.AbstractTriangular{T,A}
+_Symmetric_DenseArrays{T,A<:Matrix} = Symmetric{T,A}
+_Hermitian_DenseArrays{T,A<:Matrix} = Hermitian{T,A}
+_Triangular_DenseArrays{T,A<:Matrix} = LinearAlgebra.AbstractTriangular{T,A}
 const _Annotated_DenseArrays = Union{_Triangular_DenseArrays, _Symmetric_DenseArrays, _Hermitian_DenseArrays}
-const _Annotated_Typed_DenseArrays{T} = Union{_Triangular_DenseArrays{T}, _Symmetric_DenseArrays{T}, _Hermitian_DenseArrays{T}}
+_Annotated_Typed_DenseArrays{T} = Union{_Triangular_DenseArrays{T}, _Symmetric_DenseArrays{T}, _Hermitian_DenseArrays{T}}
 
 const _SparseConcatGroup = Union{Vector, Adjoint{<:Any,<:Vector}, Transpose{<:Any,<:Vector}, Matrix, _SparseConcatArrays, _Annotated_SparseConcatArrays, _Annotated_DenseArrays}
 const _DenseConcatGroup = Union{Vector, Adjoint{<:Any,<:Vector}, Transpose{<:Any,<:Vector}, Matrix, _Annotated_DenseArrays}
-const _TypedDenseConcatGroup{T} = Union{Vector{T}, Adjoint{T,Vector{T}}, Transpose{T,Vector{T}}, Matrix{T}, _Annotated_Typed_DenseArrays{T}}
+_TypedDenseConcatGroup{T} = Union{Vector{T}, Adjoint{T,Vector{T}}, Transpose{T,Vector{T}}, Matrix{T}, _Annotated_Typed_DenseArrays{T}}
 
 # Concatenations involving un/annotated sparse/special matrices/vectors should yield sparse arrays
 function Base._cat(dims, Xin::_SparseConcatGroup...)
@@ -1557,7 +1557,7 @@ end
 
 # * and mul!
 
-const _StridedOrTriangularMatrix{T} = Union{StridedMatrix{T}, LowerTriangular{T}, UnitLowerTriangular{T}, UpperTriangular{T}, UnitUpperTriangular{T}}
+_StridedOrTriangularMatrix{T} = Union{StridedMatrix{T}, LowerTriangular{T}, UnitLowerTriangular{T}, UpperTriangular{T}, UnitUpperTriangular{T}}
 
 function (*)(A::_StridedOrTriangularMatrix{Ta}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
     require_one_based_indexing(A, x)

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1073,7 +1073,7 @@ end
 
 # SIMD Registers
 
-const VecReg{N,T} = NTuple{N,VecElement{T}}
+VecReg{N,T} = NTuple{N,VecElement{T}}
 const V2xF32 = VecReg{2,Float32}
 const V4xF32 = VecReg{4,Float32}
 const V2xF64 = VecReg{2,Float64}

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -388,8 +388,8 @@ let g() = Int <: Real ? 1 : ""
     @test Base.return_types(g, Tuple{}) == [Int]
 end
 
-const NInt{N} = Tuple{Vararg{Int, N}}
-const NInt1{N} = Tuple{Int, Vararg{Int, N}}
+NInt{N} = Tuple{Vararg{Int, N}}
+NInt1{N} = Tuple{Int, Vararg{Int, N}}
 @test Base.eltype(NInt) === Int
 @test Base.eltype(NInt1) === Int
 @test Base.eltype(NInt{0}) === Union{}

--- a/test/core.jl
+++ b/test/core.jl
@@ -6676,7 +6676,7 @@ let a = Foo17149()
 end
 
 # issue #21004
-const PTuple_21004{N,T} = NTuple{N,VecElement{T}}
+PTuple_21004{N,T} = NTuple{N,VecElement{T}}
 @test_throws ArgumentError("too few elements for tuple type $PTuple_21004") PTuple_21004(1)
 @test_throws UndefVarError(:T) PTuple_21004_2{N,T} = NTuple{N, VecElement{T}}(1)
 
@@ -7539,8 +7539,8 @@ end
 
 # Redefining types with Vararg
 abstract type RedefineVararg; end
-const RedefineVarargN{N} = Tuple{Vararg{RedefineVararg, N}}
-const RedefineVarargN{N} = Tuple{Vararg{RedefineVararg, N}}
+RedefineVarargN{N} = Tuple{Vararg{RedefineVararg, N}}
+RedefineVarargN{N} = Tuple{Vararg{RedefineVararg, N}}
 
 # NTuples with non-types
 @test NTuple{3, 2} == Tuple{2, 2, 2}

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -845,7 +845,7 @@ const ut7 = Union{st5, mt6}
 
 const ut8 = Union{at1, pt2, st3, st4}
 
-const ut9{T} = Union{at1{T}, pt2{T}, st3{T}, st4{T}}
+ut9{T} = Union{at1{T}, pt2{T}, st3{T}, st4{T}}
 
 f = () -> nothing
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2164,9 +2164,9 @@ module M37012
 export AValue, B2, SimpleU
 struct AnInteger{S<:Integer} end
 struct AStruct{N} end
-const AValue{S} = Union{AStruct{S}, AnInteger{S}}
+AValue{S} = Union{AStruct{S}, AnInteger{S}}
 struct BStruct{T,S} end
-const B2{S,T} = BStruct{T,S}
+B2{S,T} = BStruct{T,S}
 const SimpleU = Union{AnInteger, AStruct, BStruct}
 end
 @test Base.make_typealias(M37012.AStruct{1}) === nothing

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1600,17 +1600,17 @@ struct Ones{T, N, Axes} end
 const RestrictionMatrix = BandedMatrix{<:Int, <:Ones}
 struct Applied{Style, Args<:Tuple} end
 const Mul = Applied{Style,Factors} where Factors<:Tuple where Style
-const RestrictedBasis{B} = Mul{<:Any,<:Tuple{B, <:RestrictionMatrix}}
+RestrictedBasis{B} = Mul{<:Any,<:Tuple{B, <:RestrictionMatrix}}
 struct ApplyQuasiArray{T, N, App<:Applied} end
 const MulQuasiArray = ApplyQuasiArray{T,N,MUL} where MUL<:(Applied{Style,Factors} where Factors<:Tuple where Style) where N where T
-const RestrictedQuasiArray{T,N,B} = MulQuasiArray{T,N,<:RestrictedBasis{B}}
-const BasisOrRestricted{B} = Union{B,RestrictedBasis{<:B},<:RestrictedQuasiArray{<:Any,<:Any,<:B}}
+RestrictedQuasiArray{T,N,B} = MulQuasiArray{T,N,<:RestrictedBasis{B}}
+BasisOrRestricted{B} = Union{B,RestrictedBasis{<:B},<:RestrictedQuasiArray{<:Any,<:Any,<:B}}
 struct QuasiAdjoint{T,S} end
-const AdjointRestrictedBasis{B} = Mul{<:Any,<:Tuple{<:Adjoint{<:Any,<:RestrictionMatrix}, <:QuasiAdjoint{<:Any,B}}}
-const AdjointRestrictedQuasiArray{T,N,B} = MulQuasiArray{T,N,<:AdjointRestrictedBasis{B}}
-const AdjointBasisOrRestricted{B} = Union{<:QuasiAdjoint{<:Any,B},AdjointRestrictedBasis{<:B},<:AdjointRestrictedQuasiArray{<:Any,<:Any,<:B}}
-const RadialOperator{T,B,M<:AbstractMatrix{T}} = Mul{<:Any,<:Tuple{<:BasisOrRestricted{B},M,<:AdjointBasisOrRestricted{B}}}
-const HFPotentialOperator{T,B} = RadialOperator{T,B,Diagonal{T,Vector{T}}}
+AdjointRestrictedBasis{B} = Mul{<:Any,<:Tuple{<:Adjoint{<:Any,<:RestrictionMatrix}, <:QuasiAdjoint{<:Any,B}}}
+AdjointRestrictedQuasiArray{T,N,B} = MulQuasiArray{T,N,<:AdjointRestrictedBasis{B}}
+AdjointBasisOrRestricted{B} = Union{<:QuasiAdjoint{<:Any,B},AdjointRestrictedBasis{<:B},<:AdjointRestrictedQuasiArray{<:Any,<:Any,<:B}}
+RadialOperator{T,B,M<:AbstractMatrix{T}} = Mul{<:Any,<:Tuple{<:BasisOrRestricted{B},M,<:AdjointBasisOrRestricted{B}}}
+HFPotentialOperator{T,B} = RadialOperator{T,B,Diagonal{T,Vector{T}}}
 struct HFPotential{kind,T,B,RO<:HFPotentialOperator{T,B},P<:Integer} end
 
 T = HFPotential{_A,Float64,Any,Applied{Int,Tuple{ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Any,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}}}},Diagonal{Float64,Array{Float64,1}},ApplyQuasiArray{Float64,2,Applied{Int,Tuple{Adjoint{Int,BandedMatrix{Int,Ones{Int,2,Tuple{OneTo{Int},OneTo{Int}}},OneTo{Int}}},QuasiAdjoint{Float64,Any}}}}}},_B} where _B where _A

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -176,9 +176,9 @@ struct OffsetArray{T,N,AA<:AbstractArray} <: AbstractArray{T,N}
     end
 end
 
-const OffsetVector{T,AA <: AbstractArray} = OffsetArray{T,1,AA}
+OffsetVector{T,AA <: AbstractArray} = OffsetArray{T,1,AA}
 
-const OffsetMatrix{T,AA <: AbstractArray} = OffsetArray{T,2,AA}
+OffsetMatrix{T,AA <: AbstractArray} = OffsetArray{T,2,AA}
 
 function overflow_check(r, offset::T) where T
     # This gives some performance boost https://github.com/JuliaLang/julia/issues/33273
@@ -361,7 +361,7 @@ Broadcast.broadcast_unalias(dest::OffsetArray, src::OffsetArray) = parent(dest) 
 
 ### Special handling for AbstractRange
 
-const OffsetRange{T} = OffsetArray{T,1,<:AbstractRange{T}}
+OffsetRange{T} = OffsetArray{T,1,<:AbstractRange{T}}
 const IIUR = IdentityUnitRange{S} where S<:AbstractUnitRange{T} where T<:Integer
 
 Base.step(a::OffsetRange) = step(parent(a))

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -3,7 +3,7 @@
 make_value(::Type{T}, i::Integer) where {T<:Integer} = 3*i%T
 make_value(::Type{T},i::Integer) where {T<:AbstractFloat} = T(3*i)
 
-const Vec{N,T} = NTuple{N,Base.VecElement{T}}
+Vec{N,T} = NTuple{N,Base.VecElement{T}}
 
 # Crash report for #15244 motivated this test.
 @generated function thrice_iota(::Type{Vec{N,T}}) where {N,T}


### PR DESCRIPTION
This is a pretty useless PR, but I noticed this in https://discourse.julialang.org/t/how-is-matrix-defined/60325. Seems like this is just a relic from older versions of Julia, since type alias declarations should be declared as const automatically.

These changes were generated using the following command: `perl -i -p -e 's/^const (.+\{.+\} =)/\1/g' **/*.jl`.