### PR TITLE
Minor change of filename in getting-started.md

### DIFF
--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -61,7 +61,7 @@ bar
 The `--` delimiter can be used to separate command-line arguments intended for the script file from arguments intended for Julia:
 
 ```
-$ julia --color=yes -O -- foo.jl arg1 arg2..
+$ julia --color=yes -O -- script.jl arg1 arg2..
 ```
 
 See also [Scripting](@ref man-scripting) for more information on writing Julia scripts.


### PR DESCRIPTION
I feel foo.jl should cahnge to script.jl as we have already have a script.jl from the previous command. If I am running `julia --color=yes -O -- foo.jl arg1 arg2..` by copy-pasting, julia complain about file not found.