### PR TITLE
Limit use of `llvm-config` with `USE_SYSTEM_LLVM` on Darwin

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -232,7 +232,11 @@ endif # WINNT
 
 symlink_libLLVM: $(build_private_libdir)/libLLVM.$(SHLIB_EXT)
 ifneq ($(USE_SYSTEM_LLVM),0)
+ifeq ($(OS), Darwin)
+LLVM_CONFIG_HOST_LIBS := $(shell $(LLVM_CONFIG_HOST) --libdir)/libLLVM.$(SHLIB_EXT)
+else
 LLVM_CONFIG_HOST_LIBS := $(shell $(LLVM_CONFIG_HOST) --libfiles)
+endif
 # HACK: llvm-config doesn't correctly point to shared libs on all platforms
 #       https://github.com/JuliaLang/julia/issues/29981
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,7 +100,11 @@ LLVM_CXXFLAGS := $(shell $(LLVM_CONFIG_HOST) --cxxflags)
 
 ifeq ($(JULIACODEGEN),LLVM)
 ifneq ($(USE_SYSTEM_LLVM),0)
+ifeq ($(OS), Darwin)
+LLVMLINK += $(LLVM_LDFLAGS) -lLLVM $(shell $(LLVM_CONFIG_HOST) --system-libs)
+else
 LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs --system-libs)
+endif
 # HACK: llvm-config doesn't correctly point to shared libs on all platforms
 #       https://github.com/JuliaLang/julia/issues/29981
 else


### PR DESCRIPTION
As noted in #29981 and #30459, `llvm-config` is broken on Darwin, and
sadly hasn't been fixed since then.

Building Julia on Darwin with `USE_SYSTEM_LLVM` doesn't currently work,
as calls to `llvm-config` produce the wrong flags. This PR fixes that.

For reference, `llvm-config --libfiles` still prints out a long string of static
libraries, and `llvm-config --libs` returns a long string of linker flags to
individual LLVM libraries. Attempting to use those linker flags (e.g. `-lLLVMXRay`)
leads to a linker failure about missing symbols.