### PR TITLE
Add ndims for AbstractArray types with an unspecified eltype

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -234,7 +234,7 @@ julia> ndims(A)
 ```
 """
 ndims(::AbstractArray{T,N}) where {T,N} = N
-ndims(::Type{<:AbstractArray{T,N}}) where {T,N} = N
+ndims(::Type{<:AbstractArray{<:Any,N}}) where {N} = N
 
 """
     length(collection) -> Integer

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -835,6 +835,11 @@ end
 @testset "ndims and friends" begin
     @test ndims(Diagonal(rand(1:5,5))) == 2
     @test ndims(Diagonal{Float64}) == 2
+    @test ndims(Diagonal) == 2
+    @test ndims(Vector) == 1
+    @test ndims(Matrix) == 2
+    @test ndims(Array{<:Any, 0}) == 0
+    @test_throws MethodError ndims(Array)
 end
 
 @testset "Issue #17811" begin


### PR DESCRIPTION
Currently 

```julia
julia> ndims(Vector{Int})
1

julia> ndims(Vector)
ERROR: MethodError: no method matching ndims(::Type{Vector})
```

After this PR:

```julia
julia> ndims(Vector)
1
```