### PR TITLE
fix consistency of trimtrailingzeros (Ryu)

### DIFF
--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -10,7 +10,7 @@ function writeexp(buf, pos, v::T,
     if x == 0
         buf[pos] = UInt8('0')
         pos += 1
-        if precision > 0
+        if precision > 0 && !trimtrailingzeros
             buf[pos] = decchar
             pos += 1
             for _ = 1:precision

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -10,12 +10,9 @@ function writefixed(buf, pos, v::T,
     if x == 0
         buf[pos] = UInt8('0')
         pos += 1
-        if precision > 0
+        if precision > 0 && !trimtrailingzeros
             buf[pos] = decchar
             pos += 1
-            if trimtrailingzeros
-                precision = 1
-            end
             for _ = 1:precision
                 buf[pos] = UInt8('0')
                 pos += 1

--- a/test/ryu.jl
+++ b/test/ryu.jl
@@ -544,6 +544,11 @@ end # Float16
         @test Ryu.writefixed(7.018232e-82, 6) == "0.000000"
     end
 
+    @testset "Consistency of trimtrailingzeros" begin
+        Ryu.writefixed(0.0, 1, false, false, false, UInt8('.'), true) == "0"
+        Ryu.writefixed(1.0, 1, false, false, false, UInt8('.'), true) == "1"
+        Ryu.writefixed(2.0, 1, false, false, false, UInt8('.'), true) == "2"
+    end
 end # fixed
 
 @testset "Ryu.writeexp" begin

--- a/test/ryu.jl
+++ b/test/ryu.jl
@@ -545,9 +545,9 @@ end # Float16
     end
 
     @testset "Consistency of trimtrailingzeros" begin
-        Ryu.writefixed(0.0, 1, false, false, false, UInt8('.'), true) == "0"
-        Ryu.writefixed(1.0, 1, false, false, false, UInt8('.'), true) == "1"
-        Ryu.writefixed(2.0, 1, false, false, false, UInt8('.'), true) == "2"
+        @test Ryu.writefixed(0.0, 1, false, false, false, UInt8('.'), true) == "0"
+        @test Ryu.writefixed(1.0, 1, false, false, false, UInt8('.'), true) == "1"
+        @test Ryu.writefixed(2.0, 1, false, false, false, UInt8('.'), true) == "2"
     end
 end # fixed
 
@@ -739,6 +739,12 @@ end
     @test Ryu.writeexp(1e-63, 1) == "1.0e-63"
     @test Ryu.writeexp(1e+83, 0) == "1e+83"
     @test Ryu.writeexp(1e+83, 1) == "1.0e+83"
+end
+
+@testset "Consistency of trimtrailingzeros" begin
+    @test Ryu.writeexp(0.0, 1, false, false, false, UInt8('e'), UInt8('.'), true) == "0e+00"
+    @test Ryu.writeexp(1.0, 1, false, false, false, UInt8('e'), UInt8('.'), true) == "1e+00"
+    @test Ryu.writeexp(2.0, 1, false, false, false, UInt8('e'), UInt8('.'), true) == "2e+00"
 end
 
 end # exp


### PR DESCRIPTION
I discovered that `Ryu.writefixed` with `trimtrailingzeros = true` (the last argument) does not trim trailing zeros if the given value is zero:
```
julia> Ryu.writefixed(0.0, 1, false, false, false, UInt8('.'), true)
"0.0"

julia> Ryu.writefixed(1.0, 1, false, false, false, UInt8('.'), true)
"1"

julia> Ryu.writefixed(2.0, 1, false, false, false, UInt8('.'), true)
"2"
```

There may be a reason for this behavior, but I think it is inconsistent. This PR fixes that.