### PR TITLE
Fix bug in schur for zero dimension matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -5963,9 +5963,9 @@ for (gees, gges, elty) in
             alphar = similar(A, $elty, n)
             alphai = similar(A, $elty, n)
             beta = similar(A, $elty, n)
-            ldvsl = jobvsl == 'V' ? n : 1
+            ldvsl = jobvsl == 'V' ? max(1, n) : 1
             vsl = similar(A, $elty, ldvsl, n)
-            ldvsr = jobvsr == 'V' ? n : 1
+            ldvsr = jobvsr == 'V' ? max(1, n) : 1
             vsr = similar(A, $elty, ldvsr, n)
             work = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -6058,9 +6058,9 @@ for (gees, gges, elty, relty) in
             sdim = BlasInt(0)
             alpha = similar(A, $elty, n)
             beta = similar(A, $elty, n)
-            ldvsl = jobvsl == 'V' ? n : 1
+            ldvsl = jobvsl == 'V' ? max(1, n) : 1
             vsl = similar(A, $elty, ldvsl, n)
-            ldvsr = jobvsr == 'V' ? n : 1
+            ldvsr = jobvsr == 'V' ? max(1, n) : 1
             vsr = similar(A, $elty, ldvsr, n)
             work = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)

--- a/stdlib/LinearAlgebra/test/schur.jl
+++ b/stdlib/LinearAlgebra/test/schur.jl
@@ -132,6 +132,17 @@ aimg  = randn(n,n)/2
         @test Z == A
         @test λ == zeros(0)
     end
+    @testset "0x0 $eltya matrices" begin
+        A = zeros(eltya, 0, 0)
+        B = zeros(eltya, 0, 0)
+        S = LinearAlgebra.schur(A, B)
+        @test S.S == A
+        @test S.T == A
+        @test S.Q == A
+        @test S.Z == A
+        @test S.alpha == zeros(0)
+        @test S.beta == zeros(0)
+    end
 end
 
 @testset "Generalized Schur convergence" begin


### PR DESCRIPTION
Fix JuliaLang/LinearAlgebra.jl#752
As described in the associated issue, the `ldvsl` and `ldvsr` parameters for the lapack `gges` function must be set to `max(1, n)` to account for zero dimension matrices.