### PR TITLE
Add logabsdet method for UmfpackLU

### DIFF
--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -406,8 +406,7 @@ for itype in UmfpackIndexTypes
                         mx, mz, C_NULL, lu.numeric, umf_info)
             complex(mx[], mz[])
         end
-
-        function logabsdet(F::UmfpackLU{Float64, $itype})  # return log(abs(det)) and sign(det)
+        function logabsdet(F::UmfpackLU{T, $itype}) where T # return log(abs(det)) and sign(det)
             n = checksquare(F)
             issuccess(F) || return log(zero(real(T))), log(one(T))
             U = diag(F.U)
@@ -431,7 +430,6 @@ for itype in UmfpackIndexTypes
             s = ifelse(isodd(c), -one(real(T)), one(real(T))) * P
             return abs_det, s
         end
-
         function umf_lunz(lu::UmfpackLU{Float64,$itype})
             lnz = Ref{$itype}()
             unz = Ref{$itype}()

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -413,7 +413,7 @@ for itype in UmfpackIndexTypes
             Rs = F.Rs
             p = F.p
             q = F.q
-            c = 0
+            c = false
             P = one(T)
             abs_det = zero(real(T))
             @inbounds for i in 1:n
@@ -421,15 +421,15 @@ for itype in UmfpackIndexTypes
                 P *= sign(dg_ii)
                 for j in i+1:n
                     if p[i] > p[j]
-                        c += 1
+                        c = ! c
                     end
                     if q[i] > q[j]
-                        c += 1
+                        c = ! c
                     end
                 end
                 abs_det += log(abs(dg_ii))
             end
-            s = ifelse(isodd(c), -one(real(T)), one(real(T))) * P
+            s = ifelse(c, -one(real(T)), one(real(T))) * P
             return abs_det, s
         end
         function umf_lunz(lu::UmfpackLU{Float64,$itype})

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -429,7 +429,7 @@ for itype in UmfpackIndexTypes
         function logabsdet(F::UmfpackLU{T, $itype}) where {T} # return log(abs(det)) and sign(det)
             n = checksquare(F)
             issuccess(F) || return log(zero(real(T))), log(one(T))
-            U = diag(F.U)
+            U = F.U
             Rs = F.Rs
             p = F.p
             q = F.q
@@ -437,7 +437,7 @@ for itype in UmfpackIndexTypes
             P = one(T)
             abs_det = zero(real(T))
             @inbounds for i in 1:n
-                dg_ii = U[i] / Rs[i]
+                dg_ii = U[i, 1] / Rs[i]
                 P *= sign(dg_ii)
                 abs_det += log(abs(dg_ii))
             end

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -428,7 +428,7 @@ for itype in UmfpackIndexTypes
         end
         function logabsdet(F::UmfpackLU{T, $itype}) where {T} # return log(abs(det)) and sign(det)
             n = checksquare(F)
-            issuccess(F) || return log(zero(real(T))), log(one(T))
+            issuccess(F) || return log(zero(real(T))), zero(T)
             U = F.U
             Rs = F.Rs
             p = F.p

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -406,6 +406,32 @@ for itype in UmfpackIndexTypes
                         mx, mz, C_NULL, lu.numeric, umf_info)
             complex(mx[], mz[])
         end
+
+        function logabsdet(F::UmfpackLU{Float64, $itype})  # return log(abs(det)) and sign(det)
+            n = checksquare(F)
+            issuccess(F) || return log(zero(real(T))), log(one(T))
+            U = diag(F.U)
+            Rs = F.Rs
+            p = F.p
+            q = F.q
+            c = 0
+            P = one(T)
+            abs_det = zero(real(T))
+            @inbounds for i in 1:n
+                dg_ii = U[i] / Rs[i]
+                P *= sign(dg_ii)
+                if p[i] != i
+                    c += 1
+                end
+                if q[i] != i
+                    c += 1
+                end
+                abs_det += log(abs(dg_ii))
+            end
+            s = ifelse(isodd(c), -one(real(T)), one(real(T))) * P
+            return abs_det, s
+        end
+
         function umf_lunz(lu::UmfpackLU{Float64,$itype})
             lnz = Ref{$itype}()
             unz = Ref{$itype}()

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -437,7 +437,7 @@ for itype in UmfpackIndexTypes
             P = one(T)
             abs_det = zero(real(T))
             @inbounds for i in 1:n
-                dg_ii = U[i, 1] / Rs[i]
+                dg_ii = U[i, i] / Rs[i]
                 P *= sign(dg_ii)
                 abs_det += log(abs(dg_ii))
             end

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -419,11 +419,13 @@ for itype in UmfpackIndexTypes
             @inbounds for i in 1:n
                 dg_ii = U[i] / Rs[i]
                 P *= sign(dg_ii)
-                if p[i] != i
-                    c += 1
-                end
-                if q[i] != i
-                    c += 1
+                for j in i+1:n
+                    if p[i] > p[j]
+                        c += 1
+                    end
+                    if q[i] > q[j]
+                        c += 1
+                    end
                 end
                 abs_det += log(abs(dg_ii))
             end

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -426,7 +426,7 @@ for itype in UmfpackIndexTypes
                         mx, mz, C_NULL, lu.numeric, umf_info)
             complex(mx[], mz[])
         end
-        function logabsdet(F::UmfpackLU{T, $itype}) where {T} # return log(abs(det)) and sign(det)
+        function logabsdet(F::UmfpackLU{T, $itype}) where {T<:Union{Float64,ComplexF64}} # return log(abs(det)) and sign(det)
             n = checksquare(F)
             issuccess(F) || return log(zero(real(T))), zero(T)
             U = F.U

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -6,7 +6,7 @@ export UmfpackLU
 
 import Base: (\), getproperty, show, size
 using LinearAlgebra
-import LinearAlgebra: Factorization, det, lu, lu!, ldiv!
+import LinearAlgebra: Factorization, checksquare, det, logabsdet, lu, lu!, ldiv!
 
 using SparseArrays
 using SparseArrays: getcolptr

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -34,7 +34,11 @@ using SparseArrays: nnz, sparse, sprand, sprandn, SparseMatrixCSC
             @test Rs == lua.Rs
             @test (Diagonal(Rs) * A)[p,q] ≈ L * U
 
-            det(lua) ≈ det(Array(A))
+            @test det(lua) ≈ det(Array(A))
+            logdet_lua, sign_lua = logabsdet(lua)
+            logdet_A, sign_A = logabsdet(Array(A))
+            @test logdet_lua ≈ logdet_A
+            @test sign_lua ≈ sign_A
 
             b = [8., 45., -3., 3., 19.]
             x = lua\b


### PR DESCRIPTION
Replacement for https://github.com/JuliaLang/julia/pull/38476 after I borked a rebase.  Will fix https://github.com/JuliaLang/LinearAlgebra.jl/issues/788.  This new method is a direct translation of the dense `logabsdet(::LU)` method in LinearAlgebra:https://github.com/JuliaLang/julia/blob/3365b4e903d61b628e2070e25c643cdfcf03c600/stdlib/LinearAlgebra/src/lu.jl#L457

Performance problems mentioned in the previous PR should have been fixed by https://github.com/JuliaLang/julia/pull/40663.