### PR TITLE
RFC: represent length of short strings using 1 byte instead of 8

### DIFF
--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -91,7 +91,7 @@ end
 function (ss::SummarySize)(obj::String)
     key = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), obj)
     haskey(ss.seen, key) ? (return 0) : (ss.seen[key] = true)
-    return Core.sizeof(Int) + Core.sizeof(obj)
+    return Int(pointer(obj) - key) + Core.sizeof(obj)
 end
 
 function (ss::SummarySize)(obj::DataType)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3150,33 +3150,41 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         const jl_cgval_t &obj = argv[1];
         jl_datatype_t *sty = (jl_datatype_t*)jl_unwrap_unionall(obj.typ);
         assert(jl_string_type->mutabl);
-        if (sty == jl_string_type || sty == jl_simplevector_type) {
+        if (sty == jl_string_type) {
             if (obj.constant) {
                 size_t sz;
-                if (sty == jl_string_type) {
-                    sz = jl_string_len(obj.constant);
-                }
-                else {
-                    sz = (1 + jl_svec_len(obj.constant)) * sizeof(void*);
-                }
+                sz = jl_string_len(obj.constant);
                 *ret = mark_julia_type(ctx, ConstantInt::get(T_size, sz), false, jl_long_type);
                 return true;
             }
-            // String and SimpleVector's length fields have the same layout
             auto ptr = emit_bitcast(ctx, boxed(ctx, obj), T_psize);
             Value *len = tbaa_decorate(tbaa_const, ctx.builder.CreateAlignedLoad(T_size, ptr, Align(sizeof(size_t))));
             MDBuilder MDB(jl_LLVMContext);
-            if (sty == jl_simplevector_type) {
-                auto rng = MDB.createRange(
-                    V_size0, ConstantInt::get(T_size, INTPTR_MAX / sizeof(void*) - 1));
-                cast<LoadInst>(len)->setMetadata(LLVMContext::MD_range, rng);
-                len = ctx.builder.CreateMul(len, ConstantInt::get(T_size, sizeof(void*)));
-                len = ctx.builder.CreateAdd(len, ConstantInt::get(T_size, sizeof(void*)));
+            auto rng = MDB.createRange(V_size0, ConstantInt::get(T_size, INTPTR_MAX));
+            cast<LoadInst>(len)->setMetadata(LLVMContext::MD_range, rng);
+            Value *lowbit = ctx.builder.CreateTrunc(len, T_int1);
+            Value *shifted = ctx.builder.CreateLShr(len, ConstantInt::get(T_size, 1));
+            len = ctx.builder.CreateSelect(lowbit, shifted,
+                ctx.builder.CreateLShr(ctx.builder.CreateAnd(len, ConstantInt::get(T_size, 0xff)),
+                    ConstantInt::get(T_size, 1)));
+            *ret = mark_julia_type(ctx, len, false, jl_long_type);
+            return true;
+        }
+        else if (sty == jl_simplevector_type) {
+            if (obj.constant) {
+                size_t sz;
+                sz = (1 + jl_svec_len(obj.constant)) * sizeof(void*);
+                *ret = mark_julia_type(ctx, ConstantInt::get(T_size, sz), false, jl_long_type);
+                return true;
             }
-            else {
-                auto rng = MDB.createRange(V_size0, ConstantInt::get(T_size, INTPTR_MAX));
-                cast<LoadInst>(len)->setMetadata(LLVMContext::MD_range, rng);
-            }
+            auto ptr = emit_bitcast(ctx, boxed(ctx, obj), T_psize);
+            Value *len = tbaa_decorate(tbaa_const, ctx.builder.CreateAlignedLoad(T_size, ptr, Align(sizeof(size_t))));
+            MDBuilder MDB(jl_LLVMContext);
+            auto rng = MDB.createRange(
+                V_size0, ConstantInt::get(T_size, INTPTR_MAX / sizeof(void*) - 1));
+            cast<LoadInst>(len)->setMetadata(LLVMContext::MD_range, rng);
+            len = ctx.builder.CreateMul(len, ConstantInt::get(T_size, sizeof(void*)));
+            len = ctx.builder.CreateAdd(len, ConstantInt::get(T_size, sizeof(void*)));
             *ret = mark_julia_type(ctx, len, false, jl_long_type);
             return true;
         }

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1352,7 +1352,6 @@ let r = Ref{Any}("123456789")
         @test Ptr{Cvoid}(pa) != pv
         @test unsafe_load(pa) === r[]
         @test unsafe_load(Ptr{Ptr{Cvoid}}(pa)) === pv
-        @test unsafe_load(Ptr{Int}(pv)) === length(r[])
     end
 end
 

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -91,7 +91,7 @@ if opt_level > 0
     @test !occursin(" call ", get_llvm(jl_string_ptr, Tuple{String}))
     # Make sure `Core.sizeof` call is inlined
     s = "aaa"
-    @test jl_string_ptr(s) == pointer_from_objref(s) + sizeof(Int)
+    @test jl_string_ptr(s) == pointer_from_objref(s) + 1
     # String
     test_loads_no_call(get_llvm(core_sizeof, Tuple{String}), [Iptr])
     # String


### PR DESCRIPTION
Since the dawn of time, mankind has sought to make things smaller. Currently a `String` on 64-bit is at least 32 bytes: type tag, length, data, plus alignment to the next multiple of 16. This PR uses a 1-byte length with the low bit as a discriminator for short strings, allowing <= 6 byte strings to fit in 16 bytes.

- Might be slower due to more complex representation; obviously need to run all string benchmarks
- Beginning of small string data is no longer aligned, causing problems for potential SIMD optimizations
