### PR TITLE
`@something`: a short-circuiting `something`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,7 +46,7 @@ New library functions
 * Two arguments method `lock(f, lck)` now accepts a `Channel` as the second argument. ([#39312])
 * New functor `Returns(value)`, which returns `value` for any arguments ([#39794])
 * New macro `Base.@invoke f(arg1::T1, arg2::T2; kwargs...)` provides an easier syntax to call `invoke(f, Tuple{T1,T2}, arg1, arg2; kwargs...)` ([#38438])
-* New macro `@something` which is a short-circuiting version of `something` ([#40729])
+* New macros `@something` and `@coalesce` which are short-circuiting versions of `something` and `coalesce`, respectively ([#40729])
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@ New library functions
 * Two arguments method `lock(f, lck)` now accepts a `Channel` as the second argument. ([#39312])
 * New functor `Returns(value)`, which returns `value` for any arguments ([#39794])
 * New macro `Base.@invoke f(arg1::T1, arg2::T2; kwargs...)` provides an easier syntax to call `invoke(f, Tuple{T1,T2}, arg1, arg2; kwargs...)` ([#38438])
+* New macro `@something` which is a short-circuiting version of `something` ([#40729])
 
 New library features
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -699,6 +699,7 @@ export
 
 # missing values
     coalesce,
+    @coalesce,
     ismissing,
     missing,
     skipmissing,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -702,6 +702,7 @@ export
     ismissing,
     missing,
     skipmissing,
+    @something,
     something,
     isnothing,
     nonmissingtype,

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -401,7 +401,7 @@ function filter(f, itr::SkipMissing{<:AbstractArray})
 end
 
 """
-    coalesce(x, y...)
+    coalesce(x...)
 
 Return the first value in the arguments which is not equal to [`missing`](@ref),
 if any. Otherwise return `missing`.
@@ -431,7 +431,7 @@ coalesce(x::Any, y...) = x
 
 
 """
-    @coalesce(x, y...)
+    @coalesce(x...)
 
 Short-circuiting version of [`coalesce`](@ref).
 

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -406,7 +406,7 @@ end
 Return the first value in the arguments which is not equal to [`missing`](@ref),
 if any. Otherwise return `missing`.
 
-See also [`skipmissing`](@ref), [`something`](@ref).
+See also [`skipmissing`](@ref), [`something`](@ref), [`@coalesce`](@ref).
 
 # Examples
 
@@ -428,3 +428,36 @@ function coalesce end
 coalesce() = missing
 coalesce(x::Missing, y...) = coalesce(y...)
 coalesce(x::Any, y...) = x
+
+
+"""
+    @coalesce(x, y...)
+
+Short-circuiting version of [`coalesce`](@ref).
+
+# Examples
+```jldoctest
+julia> f(x) = (println("f(\$x)"); missing);
+
+julia> a = 1;
+
+julia> a = @coalesce a f(2) f(3) error("`a` is still missing")
+1
+
+julia> b = missing;
+
+julia> b = @coalesce b f(2) f(3) error("`b` is still missing")
+f(2)
+f(3)
+ERROR: `b` is still missing
+[...]
+```
+"""
+macro coalesce(args...)
+    expr = :(missing)
+    for arg in reverse(args)
+        expr = :((val = $arg) !== missing ? val : $expr)
+    end
+    return esc(:(let val; $expr; end))
+end
+

--- a/base/some.jl
+++ b/base/some.jl
@@ -71,7 +71,7 @@ isnothing(x) = x === nothing
 
 
 """
-    something(x, y...)
+    something(x...)
 
 Return the first value in the arguments which is not equal to [`nothing`](@ref),
 if any. Otherwise throw an error.
@@ -103,7 +103,7 @@ something(x::Any, y...) = x
 
 
 """
-    @something(x, y...)
+    @something(x...)
 
 Short-circuiting version of [`something`](@ref).
 

--- a/base/some.jl
+++ b/base/some.jl
@@ -77,7 +77,7 @@ Return the first value in the arguments which is not equal to [`nothing`](@ref),
 if any. Otherwise throw an error.
 Arguments of type [`Some`](@ref) are unwrapped.
 
-See also [`coalesce`](@ref), [`skipmissing`](@ref).
+See also [`coalesce`](@ref), [`skipmissing`](@ref), [`@something`](@ref).
 
 # Examples
 ```jldoctest
@@ -100,3 +100,43 @@ something() = throw(ArgumentError("No value arguments present"))
 something(x::Nothing, y...) = something(y...)
 something(x::Some, y...) = x.value
 something(x::Any, y...) = x
+
+
+"""
+    @something(x, y...)
+
+Short-circuiting version of [`something`](@ref).
+
+# Examples
+```jldoctest
+julia> f(x) = (println("f(\$x)"); nothing);
+
+julia> a = 1;
+
+julia> a = @something a f(2) f(3) error("Unable to find default for `a`")
+1
+
+julia> b = nothing;
+
+julia> b = @something b f(2) f(3) error("Unable to find default for `b`")
+f(2)
+f(3)
+ERROR: Unable to find default for `b`
+[...]
+
+julia> b = @something b f(2) f(3) Some(nothing)
+f(2)
+f(3)
+
+julia> b === nothing
+true
+```
+"""
+macro something(args...)
+    expr = :(nothing)
+    for arg in reverse(args)
+        expr = :((val = $arg) !== nothing ? val : $expr)
+    end
+    return esc(:(something(let val; $expr; end)))
+end
+

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -229,6 +229,7 @@ Base.isnothing
 Base.notnothing
 Base.Some
 Base.something
+Base.@something
 Base.Enums.Enum
 Base.Enums.@enum
 Core.Expr

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -288,6 +288,7 @@ Base.@deprecate
 Base.Missing
 Base.missing
 Base.coalesce
+Base.@coalesce
 Base.ismissing
 Base.skipmissing
 Base.nonmissingtype

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -575,6 +575,16 @@ end
     @test coalesce(missing, nothing) === nothing
 end
 
+@testset "@coalesce" begin
+    @test @coalesce() === missing
+    @test @coalesce(1) === 1
+    @test @coalesce(nothing) === nothing
+    @test @coalesce(missing) === missing
+
+    @test @coalesce(1, error("failed")) === 1
+    @test_throws ErrorException @coalesce(missing, error("failed"))
+end
+
 mutable struct Obj; x; end
 @testset "weak references" begin
     @noinline function mk_wr(r, wr)

--- a/test/some.jl
+++ b/test/some.jl
@@ -79,6 +79,16 @@
     @test something(missing, nothing, missing) === missing
 end
 
+@testset "@something" begin
+    @test_throws ArgumentError @something()
+    @test_throws ArgumentError @something(nothing)
+    @test @something(1) === 1
+    @test @something(Some(nothing)) === nothing
+
+    @test @something(1, error("failed")) === 1
+    @test_throws ErrorException @something(nothing, error("failed"))
+end
+
 # issue #26927
 a = [missing, nothing, Some(nothing), Some(missing)]
 @test a isa Vector{Union{Missing, Nothing, Some}}


### PR DESCRIPTION
In the AWS.jl package I was noticing a pattern where if an argument was undefined a series of fallbacks would be tried. The code was similar to:

```julia 
if region === nothing
    region === nothing && (region = get(ENV, "AWS_REGION", nothing)
    region === nothing && (region = get_profile_region())
    region === nothing && (region = get_ec2_instance_region())
    region === nothing && (region = DEFAULT_REGION)
end
``` 
Since the code above makes use of `nothing` using the `something` function is a natural fit:

```julia
something(
    region,
    get(ENV, "AWS_REGION", nothing),
    get_profile_region(),
    get_ec2_instance_region(),
    DEFAULT_REGION,
)
```
This is much easier to read but unfortunately evaluates all arguments even if they aren't used. The `@something` macro is equivalent to `something` but skips evaluating all argument after the first non-`nothing` value. 