### PR TITLE
[CLI] ensure error on not finding symbol

### DIFF
--- a/cli/jl_exports.h
+++ b/cli/jl_exports.h
@@ -10,13 +10,19 @@
 JL_EXPORTED_DATA_POINTERS(XX)
 #undef XX
 
-// Define symbol data as `$type) $(name);`
+// Define symbol data as `$(type) $(name);`
 #define XX(name, type)    JL_DLLEXPORT type name;
 JL_EXPORTED_DATA_SYMBOLS(XX)
 #undef XX
 
-// Define holder locations for function addresses as `const void * $(name)_addr`
-#define XX(name)    JL_HIDDEN const void * name##_addr;
+// Declare list of exported functions (sans type)
+#define XX(name)    JL_DLLEXPORT void name(void);
+typedef void (anonfunc)(void);
+JL_EXPORTED_FUNCS(XX)
+#undef XX
+
+// Define holder locations for function addresses as `const void * $(name)_addr = & $(name);`
+#define XX(name)    JL_HIDDEN anonfunc * name##_addr = (anonfunc*)&name;
 JL_EXPORTED_FUNCS(XX)
 #undef XX
 
@@ -29,7 +35,7 @@ static const char *const jl_exported_func_names[] = {
 #undef XX
 
 #define XX(name)    &name##_addr,
-static const void ** jl_exported_func_addrs[] = {
+static anonfunc **const jl_exported_func_addrs[] = {
     JL_EXPORTED_FUNCS(XX)
     NULL
 };

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -161,7 +161,7 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
     // Once we have libjulia-internal loaded, re-export its symbols:
     for (unsigned int symbol_idx=0; jl_exported_func_names[symbol_idx] != NULL; ++symbol_idx) {
         void *addr = lookup_symbol(libjulia_internal, jl_exported_func_names[symbol_idx]);
-        if (addr == NULL) {
+        if (addr == NULL || addr == *jl_exported_func_addrs[symbol_idx]) {
             jl_loader_print_stderr3("ERROR: Unable to load ", jl_exported_func_names[symbol_idx], " from libjulia-internal");
             exit(1);
         }


### PR DESCRIPTION
This sanity check was attempted in #38994, but dlsym is often also okay
with finding the trampoline, so we want to also check that it does not
use that to resolve the trampoline ad infinitum.