### PR TITLE
do not trim trailing zeros of integral part

### DIFF
--- a/base/ryu/Ryu.jl
+++ b/base/ryu/Ryu.jl
@@ -64,7 +64,7 @@ Various options for the output format include:
   * `hash`: whether the decimal point should be written, even if no additional digits are needed for precision
   * `precision`: minimum number of significant digits to be included in the decimal string; extra `'0'` characters will be added for padding if necessary
   * `decchar`: decimal point character to be used
-  * `trimtrailingzeros`: whether trailing zeros should be removed
+  * `trimtrailingzeros`: whether trailing zeros of fractional part should be removed
 """
 function writefixed(x::T,
     precision::Integer,

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -69,9 +69,11 @@ function writefixed(buf, pos, v::T,
         buf[pos] = UInt8('0')
         pos += 1
     end
+    hasfractional = false
     if precision > 0 || hash
         buf[pos] = decchar
         pos += 1
+        hasfractional = true
     end
     if e2 < 0
         idx = div(-e2, 16)
@@ -139,6 +141,7 @@ function writefixed(buf, pos, v::T,
                     if dotPos > 1
                         buf[dotPos] = UInt8('0')
                         buf[dotPos + 1] = decchar
+                        hasfractional = true
                     end
                     buf[pos] = UInt8('0')
                     pos += 1
@@ -167,7 +170,7 @@ function writefixed(buf, pos, v::T,
             pos += 1
         end
     end
-    if trimtrailingzeros
+    if trimtrailingzeros && hasfractional
         while buf[pos - 1] == UInt8('0')
             pos -= 1
         end

--- a/test/ryu.jl
+++ b/test/ryu.jl
@@ -544,10 +544,14 @@ end # Float16
         @test Ryu.writefixed(7.018232e-82, 6) == "0.000000"
     end
 
-    @testset "Consistency of trimtrailingzeros" begin
+    @testset "Trimming of trailing zeros" begin
         @test Ryu.writefixed(0.0, 1, false, false, false, UInt8('.'), true) == "0"
         @test Ryu.writefixed(1.0, 1, false, false, false, UInt8('.'), true) == "1"
         @test Ryu.writefixed(2.0, 1, false, false, false, UInt8('.'), true) == "2"
+
+        @show Ryu.writefixed(1.25e+5, 0, false, false, false, UInt8('.'), true) == "125000"
+        @show Ryu.writefixed(1.25e+5, 1, false, false, false, UInt8('.'), true) == "125000"
+        @show Ryu.writefixed(1.25e+5, 2, false, false, false, UInt8('.'), true) == "125000"
     end
 end # fixed
 


### PR DESCRIPTION
Currently, setting `trimtrailingzeros = true` of `Ryu.writefixed` may trim trailing zeros of integral part if `precision = 0`, which is surprising because it changes the scale of the value:
```julia
using Base: Ryu

@show Ryu.writefixed(1.25e+5, 0, false, false, false, UInt8('.'), true)
@show Ryu.writefixed(1.25e+5, 1, false, false, false, UInt8('.'), true)
@show Ryu.writefixed(1.25e+5, 2, false, false, false, UInt8('.'), true)
```

```
Ryu.writefixed(125000.0, 0, false, false, false, UInt8('.'), true) = "125"
Ryu.writefixed(125000.0, 1, false, false, false, UInt8('.'), true) = "125000"
Ryu.writefixed(125000.0, 2, false, false, false, UInt8('.'), true) = "125000"
```

This PR fixes the problem so that only trailing zeros of fractional part are trimmed. I think this change is not breaking because Ryu is not a part of the official API.