### PR TITLE
[Do not Merge] Remove implicit pinvs of vectors

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1113,7 +1113,6 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
     return qr(A, ColumnNorm()) \ B
 end
 
-(\)(a::AbstractVector, b::AbstractArray) = pinv(a) * b
 """
     A / B
 
@@ -1142,9 +1141,6 @@ function (/)(A::AbstractVecOrMat, B::AbstractVecOrMat)
     size(A,2) != size(B,2) && throw(DimensionMismatch("Both inputs should have the same number of columns"))
     return copy(adjoint(adjoint(B) \ adjoint(A)))
 end
-# \(A::StridedMatrix,x::Number) = inv(A)*x Should be added at some point when the old elementwise version has been deprecated long enough
-# /(x::Number,A::StridedMatrix) = x*inv(A)
-/(x::Number, v::AbstractVector) = x*pinv(v)
 
 cond(x::Number) = iszero(x) ? Inf : 1.0
 cond(x::Number, p) = cond(x)

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -261,7 +261,7 @@ Random.seed!(1)
                         b = bb
                         c = cc
                     else
-                        b = view(bb, 1:n)
+                        b = view(bb, 1:n, 1:1)
                         c = view(cc, 1:n, 1:2)
                     end
                 end

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -85,7 +85,6 @@ bimg  = randn(n,2)/2
                 @test_throws DimensionMismatch b'\b
                 @test_throws DimensionMismatch b\b'
                 @test norm(a*x - b, 1)/norm(b) < ε*κ*n*2 # Ad hoc, revisit!
-                @test zeros(eltya,n)\fill(eltya(1),n) ≈ (zeros(eltya,n,1)\fill(eltya(1),n,1))[1,1]
             end
 
             @testset "Test nullspace" begin
@@ -1104,43 +1103,6 @@ end
 
         # symmetric, indefinite
         @test inv(convert(Matrix{elty}, [1. 2; 2 1])) ≈ convert(Matrix{elty}, [-1. 2; 2 -1]/3)
-    end
-end
-
-function test_rdiv_pinv_consistency(a, b)
-    @test (a*b)/b ≈ a*(b/b) ≈ (a*b)*pinv(b) ≈ a*(b*pinv(b))
-    @test typeof((a*b)/b) == typeof(a*(b/b)) == typeof((a*b)*pinv(b)) == typeof(a*(b*pinv(b)))
-end
-function test_ldiv_pinv_consistency(a, b)
-    @test a\(a*b) ≈ (a\a)*b ≈ (pinv(a)*a)*b ≈ pinv(a)*(a*b)
-    @test typeof(a\(a*b)) == typeof((a\a)*b) == typeof((pinv(a)*a)*b) == typeof(pinv(a)*(a*b))
-end
-function test_div_pinv_consistency(a, b)
-    test_rdiv_pinv_consistency(a, b)
-    test_ldiv_pinv_consistency(a, b)
-end
-
-@testset "/ and \\ consistency with pinv for vectors" begin
-    @testset "Tests for type $elty" for elty in (Float32, Float64, ComplexF32, ComplexF64)
-        c = rand(elty, 5)
-        r = (elty <: Complex ? adjoint : transpose)(rand(elty, 5))
-        cm = rand(elty, 5, 1)
-        rm = rand(elty, 1, 5)
-        @testset "dot products" begin
-            test_div_pinv_consistency(r, c)
-            test_div_pinv_consistency(rm, c)
-            test_div_pinv_consistency(r, cm)
-            test_div_pinv_consistency(rm, cm)
-        end
-        @testset "outer products" begin
-            test_div_pinv_consistency(c, r)
-            test_div_pinv_consistency(cm, rm)
-        end
-        @testset "matrix/vector" begin
-            m = rand(5, 5)
-            test_ldiv_pinv_consistency(m, c)
-            test_rdiv_pinv_consistency(r, m)
-        end
     end
 end
 

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -234,15 +234,6 @@ end
     end
 end
 
-@testset "QR on Ints" begin
-    # not sure what to do about this edge case now that we build decompositions
-    # for qr(...), so for now just commenting this out
-    # @test qr(Int[]) == (Int[],1)
-
-    B = rand(7,2)
-    @test (1:7)\B ≈ Vector(1:7)\B
-end
-
 @testset "Issue 16520" begin
     @test_throws DimensionMismatch Matrix{Float64}(undef,3,2)\(1:5)
 end


### PR DESCRIPTION
Fix https://github.com/JuliaLang/LinearAlgebra.jl/issues/1165

This is breaking so should not be merged yet, I'm putting it up as suggested by @ViralBShah so PkgEval can be run to see if anybody actually uses this.