### PR TITLE
Improve docstring for `digits`

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -390,6 +390,9 @@ Number of ones in the binary representation of `x`.
 ```jldoctest
 julia> count_ones(7)
 3
+
+julia> count_ones(Int32(-1))
+32
 ```
 """
 count_ones(x::BitInteger) = (ctpop_int(x) % Int)::Int
@@ -429,6 +432,9 @@ Number of zeros in the binary representation of `x`.
 ```jldoctest
 julia> count_zeros(Int32(2 ^ 16 - 1))
 16
+
+julia> count_zeros(-1)
+0
 ```
 """
 count_zeros(x::Integer) = count_ones(~x)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -387,6 +387,8 @@ _prevpow2(x::Integer) = reinterpret(typeof(x),x < 0 ? -_prevpow2(unsigned(-x)) :
 
 Test whether `n` is an integer power of two.
 
+See also [`count_ones`](@ref), [`prevpow`](@ref), [`nextpow`](@ref).
+
 # Examples
 ```jldoctest
 julia> ispow2(4)
@@ -418,6 +420,8 @@ ispow2(x::Integer) = x > 0 && count_ones(x) == 1
 The smallest `a^n` not less than `x`, where `n` is a non-negative integer. `a` must be
 greater than 1, and `x` must be greater than 0.
 
+See also [`prevpow`](@ref).
+
 # Examples
 ```jldoctest
 julia> nextpow(2, 7)
@@ -432,8 +436,6 @@ julia> nextpow(5, 20)
 julia> nextpow(4, 16)
 16
 ```
-
-See also [`prevpow`](@ref).
 """
 function nextpow(a::Real, x::Real)
     x <= 0 && throw(DomainError(x, "`x` must be positive."))
@@ -455,6 +457,8 @@ end
 The largest `a^n` not greater than `x`, where `n` is a non-negative integer.
 `a` must be greater than 1, and `x` must not be less than 1.
 
+See also [`nextpow`](@ref), [`isqrt`](@ref).
+
 # Examples
 ```jldoctest
 julia> prevpow(2, 7)
@@ -469,7 +473,6 @@ julia> prevpow(5, 20)
 julia> prevpow(4, 16)
 16
 ```
-See also [`nextpow`](@ref).
 """
 function prevpow(a::Real, x::Real)
     x < 1 && throw(DomainError(x, "`x` must be ≥ 1."))
@@ -611,6 +614,8 @@ Compute the number of digits in integer `n` written in base `base`
 (`base` must not be in `[-1, 0, 1]`), optionally padded with zeros
 to a specified size (the result will never be less than `pad`).
 
+See also [`digits`](@ref), [`count_ones`](@ref).
+
 # Examples
 ```jldoctest
 julia> ndigits(12345)
@@ -624,6 +629,9 @@ julia> string(1022, base=16)
 
 julia> ndigits(123, pad=5)
 5
+
+julia> ndigits(-123)
+3
 ```
 """
 ndigits(x::Integer; base::Integer=10, pad::Integer=1) = max(pad, ndigits0z(x, base))
@@ -748,7 +756,7 @@ split_sign(n::Unsigned) = n, false
 Convert an integer `n` to a string in the given `base`,
 optionally specifying a number of digits to pad to.
 
-See also [`digits`](@ref), [`bitstring`](@ref).
+See also [`digits`](@ref), [`bitstring`](@ref), [`count_zeros`](@ref).
 
 # Examples
 ```jldoctest
@@ -785,7 +793,7 @@ string(b::Bool) = b ? "true" : "false"
 
 A string giving the literal bit representation of a number.
 
-See also [`count_ones`](@ref), [`digits`](@ref).
+See also [`count_ones`](@ref), [`count_zeros`](@ref), [`digits`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -806,9 +806,12 @@ Return an array with element type `T` (default `Int`) of the digits of `n` in th
 base, optionally padded with zeros to a specified size. More significant digits are at
 higher indices, such that `n == sum(digits[k]*base^(k-1) for k=1:length(digits))`.
 
+See also [`ndigits`](@ref), [`digits!`](@ref),
+and for base 2 also [`bitstring`](@ref), [`count_ones`](@ref).
+
 # Examples
 ```jldoctest
-julia> digits(10, base = 10)
+julia> digits(10)
 2-element Vector{Int64}:
  0
  1
@@ -820,14 +823,18 @@ julia> digits(10, base = 2)
  0
  1
 
-julia> digits(10, base = 2, pad = 6)
-6-element Vector{Int64}:
- 0
- 1
- 0
- 1
- 0
- 0
+julia> digits(-256, base = 10, pad = 5)
+5-element Vector{Int64}:
+ -6
+ -5
+ -2
+  0
+  0
+
+julia> n = rand(-999:999);
+
+julia> n == evalpoly(13, digits(n, base = 13))
+true
 ```
 """
 digits(n::Integer; base::Integer = 10, pad::Integer = 1) =

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -748,12 +748,15 @@ split_sign(n::Unsigned) = n, false
 Convert an integer `n` to a string in the given `base`,
 optionally specifying a number of digits to pad to.
 
+See also [`digits`](@ref), [`bitstring`](@ref).
+
+# Examples
 ```jldoctest
 julia> string(5, base = 13, pad = 4)
 "0005"
 
-julia> string(13, base = 5, pad = 4)
-"0023"
+julia> string(-13, base = 5, pad = 4)
+"-0023"
 ```
 """
 function string(n::Integer; base::Integer = 10, pad::Integer = 1)
@@ -782,10 +785,12 @@ string(b::Bool) = b ? "true" : "false"
 
 A string giving the literal bit representation of a number.
 
+See also [`count_ones`](@ref), [`digits`](@ref).
+
 # Examples
 ```jldoctest
-julia> bitstring(4)
-"0000000000000000000000000000000000000000000000000000000000000100"
+julia> bitstring(Int32(4))
+"00000000000000000000000000000100"
 
 julia> bitstring(2.2)
 "0100000000000001100110011001100110011001100110011001100110011010"

--- a/base/math.jl
+++ b/base/math.jl
@@ -495,7 +495,7 @@ log(x::Number)
 Compute the logarithm of `x` to base 2. Throws [`DomainError`](@ref) for negative
 [`Real`](@ref) arguments.
 
-See also: [`exp2`](@ref), [`ldexp`](@ref).
+See also: [`exp2`](@ref), [`ldexp`](@ref), [`ispow2`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"


### PR DESCRIPTION
This adds some `see also` links & other tweaks to the docstring for `digits`, and a few nearby functions. No functional changes.

Xref https://github.com/JuliaLang/julia/pull/40670 (sum of digits) and #40393 (inverse function, noted that `evalpoly` does this).