### PR TITLE
RFC: allow `isapprox` for tuples

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1661,6 +1661,30 @@ function isapprox(x::AbstractArray, y::AbstractArray;
 end
 
 """
+    (a, b, c...) ≈ (a′, b′, c′...)
+
+!!! compat "Julia 1.7"
+    Applying `isapprox` to tuples requires Julia 1.7 or later.
+
+```jldoctest
+julia> (1, [2,3]) ≈ (1.0, [2.0, 3+10eps()])
+true
+
+julia> (a=1, b=2) ≈ (b=2.0, a=nextfloat(1.0))
+true
+```
+"""
+function isapprox(xs::Union{Tuple,NamedTuple}, ys::Union{Tuple,NamedTuple}; kwargs...)
+    length(xs) == length(ys) || throw(ArgumentError("lengths must match"))
+    all(xy -> (xy[1], xy[2]; kwargs...), zip(xs, ys))
+end
+
+function isapprox(xs::NamedTuple, ys::NamedTuple; kwargs...)
+    sort(collect(keys(xs))) == sort(collect(keys(ys))) || throw(ArgumentError("keys must match"))
+    all(isapprox(xs[k], ys[k]; kwargs...) for k in keys(xs))
+end
+
+"""
     normalize!(a::AbstractArray, p::Real=2)
 
 Normalize the array `a` in-place so that its `p`-norm equals unity,

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1661,16 +1661,19 @@ function isapprox(x::AbstractArray, y::AbstractArray;
 end
 
 """
-    (a, b, c...) ≈ (a′, b′, c′...)
+    isapprox(xs::Tuple, ys::Tuple; kwargs...)
+    (x, x2, x3...) ≈ (y, y2, y3...)
+
+Check that each element `x` of the first tuple is approximately equal to
+the corresponding element `y` of the second: `all(x ≈ y for (x,y) in zip(xs,ys))`.
+
+Any keyword arguments apply to every comparison.
 
 !!! compat "Julia 1.7"
     Applying `isapprox` to tuples requires Julia 1.7 or later.
 
 ```jldoctest
 julia> (1, [2,3]) ≈ (1.0, [2.0, 3+10eps()])
-true
-
-julia> (a=1, b=2) ≈ (b=2.0, a=nextfloat(1.0))
 true
 ```
 """
@@ -1679,7 +1682,7 @@ function isapprox(xs::Union{Tuple,NamedTuple}, ys::Union{Tuple,NamedTuple}; kwar
     all(xy -> (xy[1], xy[2]; kwargs...), zip(xs, ys))
 end
 
-function isapprox(xs::NamedTuple, ys::NamedTuple; kwargs...)
+function isapprox(xs::NamedTuple, ys::NamedTuple; kwargs...) # not sure this is a good idea!
     sort(collect(keys(xs))) == sort(collect(keys(ys))) || throw(ArgumentError("keys must match"))
     all(isapprox(xs[k], ys[k]; kwargs...) for k in keys(xs))
 end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -517,4 +517,10 @@ end
     @test condskeel(A) ≈ condskeel(A, [8,8,8])
 end
 
+@testset "isapprox allows Tuples" begin
+    @test (1, [2,3]) ≈ (1.0, [2.0, 3+10eps()])
+    @test [1, [2,3]] ≈ (1.0, [2.0, 3+10eps()])
+    @test_throws Exception (1, [2,3]) ≈ (1.0, 2.0, 3)
+end
+
 end # module TestGeneric


### PR DESCRIPTION
In tests I think it would be useful to be able to compare tuples of arrays (or numbers) with `isapprox`. Is this a good idea, or was it decided against somewhere?

~~Sketch below also allows NamedTuples, and in any order, which I'm less sure about.~~ [removed]
