### PR TITLE
Fix indexing boolean ranges with empty ranges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -968,6 +968,7 @@ function getindex(r::AbstractUnitRange, s::AbstractUnitRange{T}) where {T<:Integ
     if T === Bool
         return range(first(s) ? first(r) : last(r), length = last(s))
     else
+        isempty(s) && return range(first(r), length = 0)
         f = first(r)
         start = oftype(f, f + first(s) - firstindex(r))
         len = length(s)
@@ -989,6 +990,7 @@ function getindex(r::AbstractUnitRange, s::StepRange{T}) where {T<:Integer}
     if T === Bool
         return range(first(s) ? first(r) : last(r), step=oneunit(eltype(r)), length=last(s))
     else
+        isempty(s) && return range(first(r), step = step(s), length = 0)
         f = first(r)
         start = oftype(f, f + s.start - firstindex(r))
         st = step(s)
@@ -1003,19 +1005,9 @@ function getindex(r::StepRange, s::AbstractRange{T}) where {T<:Integer}
     @boundscheck checkbounds(r, s)
 
     if T === Bool
-        if length(s) == 0
-            start, len = first(r), 0
-        elseif length(s) == 1
-            if first(s)
-                start, len = first(r), 1
-            else
-                start, len = first(r), 0
-            end
-        else # length(s) == 2
-            start, len = last(r), 1
-        end
-        return range(start, step=step(r); length=len)
+        range(first(s) ? first(r) : last(r), step = step(r), length = Int(last(s)))
     else
+        isempty(s) && return range(first(r), step = step(r)*step(s), length = 0)
         f = r.start
         fs = first(s)
         st = r.step

--- a/base/range.jl
+++ b/base/range.jl
@@ -969,7 +969,7 @@ function getindex(r::AbstractUnitRange, s::AbstractUnitRange{T}) where {T<:Integ
         return range(first(s) ? first(r) : last(r), length = last(s))
     else
         f = first(r)
-        # hardcode output for empty ranges to overflow in stop for Bool
+        # hardcode output for empty ranges to avoid overflow in stop for Bool
         # this works as empty ranges are all equal
         isempty(s) && return range(oneunit(f), zero(f))
         start = oftype(f, f + first(s) - firstindex(r))

--- a/base/range.jl
+++ b/base/range.jl
@@ -968,8 +968,10 @@ function getindex(r::AbstractUnitRange, s::AbstractUnitRange{T}) where {T<:Integ
     if T === Bool
         return range(first(s) ? first(r) : last(r), length = last(s))
     else
-        isempty(s) && return range(first(r), length = 0)
         f = first(r)
+        # hardcode output for empty ranges to overflow in stop for Bool
+        # this works as empty ranges are all equal
+        isempty(s) && return range(oneunit(f), zero(f))
         start = oftype(f, f + first(s) - firstindex(r))
         len = length(s)
         stop = oftype(f, start + (len - oneunit(len)))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -631,10 +631,10 @@ end
     end
 end
 @testset "indexing range with empty range (#4309)" begin
-    @test (@inferred (3:6)[5:4]) === 1:0
+    @test (@inferred (3:6)[5:4]) === 4:3
     @test_throws BoundsError (3:6)[5:5]
     @test_throws BoundsError (3:6)[5]
-    @test (@inferred (0:2:10)[7:6]) === 0:2:-1
+    @test (@inferred (0:2:10)[7:6]) === 2:2:0
     @test_throws BoundsError (0:2:10)[7:7]
 
     for start in [true, false], stop in [true, false]
@@ -650,6 +650,12 @@ end
             @test (@inferred r[1:1:0]) isa AbstractRange
             @test r[1:1:0] == empty_range
         end
+    end
+    @testset "issue #40760" begin
+        r = (false:false)[1:0]
+        @test r isa UnitRange && first(r) == true && last(r) == false
+        r = range(false, length = 0)
+        @test r isa UnitRange && first(r) == 0 && last(r) == -1
     end
 end
 # indexing with negative ranges (#8351)
@@ -1022,6 +1028,7 @@ end
         end
         a = prevfloat(a)
     end
+    @test (1:2:3)[StepRangeLen{Bool}(true,-1,2)] == [1]
 end
 
 # issue #20380

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -631,31 +631,29 @@ end
     end
 end
 @testset "indexing range with empty range (#4309)" begin
-    @test (@inferred (3:6)[5:4]) === 4:3
+    @test (@inferred (3:6)[5:4]) === 7:6
     @test_throws BoundsError (3:6)[5:5]
     @test_throws BoundsError (3:6)[5]
-    @test (@inferred (0:2:10)[7:6]) === 2:2:0
+    @test (@inferred (0:2:10)[7:6]) === 12:2:11
     @test_throws BoundsError (0:2:10)[7:7]
 
-    for start in [true, false], stop in [true, false]
+    for start in [true], stop in [true, false]
         @test (@inferred (start:stop)[1:0]) === true:false
     end
     @test (@inferred (true:false)[true:false]) == true:false
 
     @testset "issue #40760" begin
         empty_range = 1:0
-        @testset for r in Any[false:false, false:true:false, 1:2, 1:1:2]
+        r = range(false, length = 0)
+        @test r isa UnitRange && first(r) == 0 && last(r) == -1
+        r = (true:true)[empty_range]
+        @test r isa UnitRange && first(r) == true && last(r) == false
+        @testset for r in Any[true:true, true:true:true, 1:2, 1:1:2]
             @test (@inferred r[1:0]) isa AbstractRange
             @test r[1:0] == empty_range
             @test (@inferred r[1:1:0]) isa AbstractRange
             @test r[1:1:0] == empty_range
         end
-    end
-    @testset "issue #40760" begin
-        r = (false:false)[1:0]
-        @test r isa UnitRange && first(r) == true && last(r) == false
-        r = range(false, length = 0)
-        @test r isa UnitRange && first(r) == 0 && last(r) == -1
     end
 end
 # indexing with negative ranges (#8351)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -631,11 +631,21 @@ end
     end
 end
 @testset "indexing range with empty range (#4309)" begin
-    @test (3:6)[5:4] === 7:6
+    @test (3:6)[5:4] === 3:2
     @test_throws BoundsError (3:6)[5:5]
     @test_throws BoundsError (3:6)[5]
-    @test (0:2:10)[7:6] === 12:2:10
+    @test (0:2:10)[7:6] === 0:2:-1
     @test_throws BoundsError (0:2:10)[7:7]
+
+    @testset "issue #40760" begin
+        empty_range = 1:0
+        for r in Any[false:false, false:true:false, 1:2, 1:1:2]
+            @test r[1:0] isa AbstractRange
+            @test r[1:0] == empty_range
+            @test r[1:1:0] isa AbstractRange
+            @test r[1:1:0] == empty_range
+        end
+    end
 end
 # indexing with negative ranges (#8351)
 for a=AbstractRange[3:6, 0:2:10], b=AbstractRange[0:1, 2:-1:0]
@@ -2305,6 +2315,7 @@ end
     @test_throws BoundsError r[true:true:false]
     @test_throws BoundsError r[true:true:true]
 end
+
 @testset "Non-Int64 endpoints that are identical (#39798)" begin
     for T in DataType[Float16,Float32,Float64,Bool,Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128],
         r in [ LinRange(1, 1, 10), StepRangeLen(7, 0, 5) ]

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -631,18 +631,23 @@ end
     end
 end
 @testset "indexing range with empty range (#4309)" begin
-    @test (3:6)[5:4] === 3:2
+    @test (@inferred (3:6)[5:4]) === 1:0
     @test_throws BoundsError (3:6)[5:5]
     @test_throws BoundsError (3:6)[5]
-    @test (0:2:10)[7:6] === 0:2:-1
+    @test (@inferred (0:2:10)[7:6]) === 0:2:-1
     @test_throws BoundsError (0:2:10)[7:7]
+
+    for start in [true, false], stop in [true, false]
+        @test (@inferred (start:stop)[1:0]) === true:false
+    end
+    @test (@inferred (true:false)[true:false]) == true:false
 
     @testset "issue #40760" begin
         empty_range = 1:0
-        for r in Any[false:false, false:true:false, 1:2, 1:1:2]
-            @test r[1:0] isa AbstractRange
+        @testset for r in Any[false:false, false:true:false, 1:2, 1:1:2]
+            @test (@inferred r[1:0]) isa AbstractRange
             @test r[1:0] == empty_range
-            @test r[1:1:0] isa AbstractRange
+            @test (@inferred r[1:1:0]) isa AbstractRange
             @test r[1:1:0] == empty_range
         end
     end


### PR DESCRIPTION
Fixes #40760 

Now
```julia
julia> (false:false)[1:0]
true:false

julia> (false:true:false)[1:1:0]
0:1:-1

julia> (false:true:false)[1:0]
0:1:-1
```