### PR TITLE
Simplify comparison for AbstractUnitRange and OneTo

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -940,6 +940,11 @@ function ==(r::OrdinalRange, s::OrdinalRange)
     (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))
 end
 
+==(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) =
+    (isempty(r) & isempty(s)) | ((first(r) == first(s)) & (last(r) == last(s)))
+
+==(r::OneTo, s::OneTo) = last(r) == last(s)
+
 ==(r::T, s::T) where {T<:Union{StepRangeLen,LinRange}} =
     (isempty(r) & isempty(s)) | ((first(r) == first(s)) & (length(r) == length(s)) & (last(r) == last(s)))
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -940,7 +940,7 @@ function ==(r::OrdinalRange, s::OrdinalRange)
     (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))
 end
 
-==(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) =
+==(r::AbstractUnitRange, s::AbstractUnitRange) =
     (isempty(r) & isempty(s)) | ((first(r) == first(s)) & (last(r) == last(s)))
 
 ==(r::OneTo, s::OneTo) = last(r) == last(s)


### PR DESCRIPTION
Here is a small improvement to simplify comparisons for AbstractUnitRange and OneTo. It is used for example in broadcast expressions.