### PR TITLE
Make `dot` handle `missing`s

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -903,8 +903,8 @@ function dot(x, y) # arbitrary iterables
 end
 
 dot(x::Number, y::Number) = conj(x) * y
-dot(::Any, ::Missing) = missing
-dot(::Missing, ::Any) = missing
+dot(::Number, ::Missing) = missing
+dot(::Missing, ::Number) = missing
 dot(::Missing, ::Missing) = missing
 
 function dot(x::AbstractArray, y::AbstractArray)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -903,6 +903,9 @@ function dot(x, y) # arbitrary iterables
 end
 
 dot(x::Number, y::Number) = conj(x) * y
+dot(::Any, ::Missing) = missing
+dot(::Missing, ::Any) = missing
+dot(::Missing, ::Missing) = missing
 
 function dot(x::AbstractArray, y::AbstractArray)
     lx = length(x)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -512,6 +512,14 @@ end
     end
 end
 
+@testset "dot with missing" begin
+    x = [5, 6, missing]
+    y = [missing, 5, 6]
+    @test ismissing(dot(x, x))
+    @test ismissing(dot(x, y))
+    @test ismissing(dot(y, x))
+end
+
 @testset "condskeel #34512" begin
     A = rand(3, 3)
     @test condskeel(A) ≈ condskeel(A, [8,8,8])


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#844.