### PR TITLE
Add firstindex method for Enumerator objects

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -151,7 +151,7 @@ julia> for (index, value) in enumerate(a)
 ```
 """
 enumerate(iter) = Enumerate(iter)
-
+firstindex(e::Enumerate) = firstindex(e.itr)
 length(e::Enumerate) = length(e.itr)
 size(e::Enumerate) = size(e.itr)
 @propagate_inbounds function iterate(e::Enumerate, state=(1,))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -153,6 +153,8 @@ julia> for (index, value) in enumerate(a)
 enumerate(iter) = Enumerate(iter)
 
 firstindex(e::Enumerate) = firstindex(e.itr)
+getindex(e::Enumerate,i::Int) = (i,getindex(e.itr,i))
+
 length(e::Enumerate) = length(e.itr)
 size(e::Enumerate) = size(e.itr)
 @propagate_inbounds function iterate(e::Enumerate, state=(1,))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -158,7 +158,7 @@ size(e::Enumerate) = size(e.itr)
 @propagate_inbounds function iterate(e::Enumerate, state=(1,))
     i, rest = state[1], tail(state)
     n = iterate(e.itr, rest...)
-    n === nothing && return N
+    n === nothing && return n
     (i, n[1]), (i+1, n[2])
 end
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -151,13 +151,14 @@ julia> for (index, value) in enumerate(a)
 ```
 """
 enumerate(iter) = Enumerate(iter)
+
 firstindex(e::Enumerate) = firstindex(e.itr)
 length(e::Enumerate) = length(e.itr)
 size(e::Enumerate) = size(e.itr)
 @propagate_inbounds function iterate(e::Enumerate, state=(1,))
     i, rest = state[1], tail(state)
     n = iterate(e.itr, rest...)
-    n === nothing && return n
+    n === nothing && return N
     (i, n[1]), (i+1, n[2])
 end
 


### PR DESCRIPTION
Added method to get `firstindex` from an `Enumerator` object.
Fixes #40704

I believe a discussion is warranted on Iterators as a whole to make them to be compatible with `AbstractArray`.