### PR TITLE
Restore some and remove some declarations for GC API in julia.h

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -852,7 +852,6 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc_3w(void);
 JL_DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz);
 JL_DLLEXPORT void *jl_malloc_stack(size_t *bufsz, struct _jl_task_t *owner) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_free_stack(void *stkbuf, size_t bufsz);
-JL_DLLEXPORT void jl_gc_use(jl_value_t *a);
 
 JL_DLLEXPORT void jl_clear_malloc_data(void);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -829,6 +829,9 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT int jl_gc_enable(int on);
 JL_DLLEXPORT int jl_gc_is_enabled(void);
+JL_DLLEXPORT void jl_gc_get_total_bytes(int64_t *bytes) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void);
+JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void) JL_NOTSAFEPOINT;
 
 typedef enum {
     JL_GC_AUTO = 0,         // use heuristics to determine the collection type


### PR DESCRIPTION
Access to statistics was removed but the implementation is still present and useful. `jl_gc_use` was removed but declaration remained.