### PR TITLE
Fix inference of max_values(::Union)

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -83,7 +83,11 @@ end
 max_values(::Type) = typemax(Int)
 max_values(T::Union{map(X -> Type{X}, BitIntegerSmall_types)...}) = 1 << (8*sizeof(T))
 # saturated addition to prevent overflow with typemax(Int)
-max_values(T::Union) = max(max_values(T.a), max_values(T.b), max_values(T.a) + max_values(T.b))
+function max_values(T::Union)
+    a = max_values(T.a)::Int
+    b = max_values(T.b)::Int
+    return max(a, b, a + b)
+end
 max_values(::Type{Bool}) = 2
 max_values(::Type{Nothing}) = 1
 


### PR DESCRIPTION
This is a cause of [method invalidation in JuMP](https://github.com/jump-dev/JuMP.jl/issues/2273). 

It gets called when constructing a dictionary:
https://github.com/JuliaLang/julia/blob/79b8af2f51317fd554b44a19ee6bf694e6bf19e4/base/dict.jl#L235

But during `Pkg` operations, it gets called as:
```Julia
julia> @code_warntype Base.max_values(Union{Nothing,VersionNumber})
Variables
  #self#::Core.Const(Base.max_values)
  T::Type{Union{Nothing, VersionNumber}}

Body::Any
1 ─ %1  = Base.getproperty(T, :a)::Any
│   %2  = Base.max_values(%1)::Any
│   %3  = Base.getproperty(T, :b)::Any
│   %4  = Base.max_values(%3)::Any
│   %5  = Base.getproperty(T, :a)::Any
│   %6  = Base.max_values(%5)::Any
│   %7  = Base.getproperty(T, :b)::Any
│   %8  = Base.max_values(%7)::Any
│   %9  = (%6 + %8)::Any
│   %10 = Base.max(%2, %4, %9)::Any
└──       return %10
```