### PR TITLE
Use iteration instead of indexing in `Threads.@threads`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -67,21 +67,10 @@ function _threadsfor(iter, lbody, schedule)
                 len, rem = 1, 0
             end
             # compute this thread's iterations
-            f = firstindex(r) + ((tid-1) * len)
-            l = f + len - 1
-            # distribute remaining iterations evenly
-            if rem > 0
-                if tid <= rem
-                    f = f + (tid-1)
-                    l = l + tid
-                else
-                    f = f + rem
-                    l = l + rem
-                end
-            end
+            dropvals = (tid-1)*len + min(rem, tid-1)
+            chunklen = len + (tid <= rem)
             # run this thread's iterations
-            for i = f:l
-                local $(esc(lidx)) = @inbounds r[i]
+            for $(esc(lidx)) = Iterators.take(Iterators.drop(r, dropvals), chunklen)
                 $(esc(lbody))
             end
         end

--- a/base/threads.jl
+++ b/base/threads.jl
@@ -5,6 +5,8 @@ Multithreading support.
 """
 module Threads
 
+import ..Iterators
+
 global Condition # we'll define this later, make sure we don't import Base.Condition
 
 include("threadingconstructs.jl")

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -874,3 +874,11 @@ end
     end
     @test sort!(collect(ys)) == 1:3
 end
+
+# issue 40704
+@test begin
+    @threads for (i,j) = enumerate(2:5)
+        @assert i + 1 == j
+    end
+    true
+end


### PR DESCRIPTION
The code created by `Threads.@threads for x = y; ...; end` currently indexes into `y`. Therefore, it does not work for iterators which do not support indexing. This PR changes that by using `Iterators.drop` and `Iterators.take` to pick the correct chunk of `y` for each thread.

Fixes #40704.