### PR TITLE
Add support for printing Evaluated for <: and >:

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -516,6 +516,12 @@ function get_test_result(ex, source)
         first(string(ex.args[1])) != '.' && !is_splat(ex.args[2]) && !is_splat(ex.args[3]) &&
         (ex.args[1] === :(==) || Base.operator_precedence(ex.args[1]) == comparison_prec)
         ex = Expr(:comparison, ex.args[2], ex.args[1], ex.args[3])
+
+    # Mark <: and >: as :comparison expressions
+    elseif isa(ex, Expr) && length(ex.args) == 2 &&
+        !is_splat(ex.args[1]) && !is_splat(ex.args[2]) &&
+        Base.operator_precedence(ex.head) == comparison_prec
+        ex = Expr(:comparison, ex.args[1], ex.head, ex.args[2])
     end
     if isa(ex, Expr) && ex.head === :comparison
         # pass all terms of the comparison to `eval_comparison`, as an Expr

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -146,6 +146,8 @@ let fails = @testset NoThrowTestSet begin
         @test endswith(str1, str2)
         # 21 - Fail - contains
         @test contains(str1, str2)
+        # 22 - Fail - Type Comparison
+        @test typeof(1) <: typeof("julia")
     end
     for fail in fails
         @test fail isa Test.Fail
@@ -254,6 +256,11 @@ let fails = @testset NoThrowTestSet begin
     let str = sprint(show, fails[21])
         @test occursin("Expression: contains(str1, str2)", str)
         @test occursin("Evaluated: contains(\"Hello\", \"World\")", str)
+    end
+
+    let str = sprint(show, fails[22])
+        @test occursin("Expression: typeof(1) <: typeof(\"julia\")", str)
+        @test occursin("Evaluated: $(typeof(1)) <: $(typeof("julia"))", str)
     end
 end
 


### PR DESCRIPTION
Fixes: #39243

This pull request adds an additional branch to `get_test_result` in `Test` to handle `<:` and `>:`

Previously:

```
julia> using Test
julia> @test typeof(1) <: typeof("apple")
Test Failed at REPL[75]:1
  Expression: typeof(1) <: typeof("apple")
ERROR: There was an error during testing

```

Now:

```
julia> using Test
julia> @test typeof(1) <: typeof("apple")
Test Failed at REPL[2]:1
  Expression: typeof(1) <: typeof("apple")
   Evaluated: Int64 <: String
ERROR: There was an error during testing
```

Best,

Alex