### PR TITLE
Enable conversion of `CompoundPeriod` to `Period`

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -357,6 +357,9 @@ function Base.string(x::CompoundPeriod)
 end
 Base.show(io::IO,x::CompoundPeriod) = print(io, string(x))
 
+Base.convert(::Type{T}, x::CompoundPeriod) where T<:Period =
+    isconcretetype(T) ? sum(T, x.periods) : throw(MethodError(convert,(T,x)))
+
 # E.g. Year(1) + Day(1)
 (+)(x::Period,y::Period) = CompoundPeriod(Period[x, y])
 (+)(x::CompoundPeriod, y::Period) = CompoundPeriod(vcat(x.periods, y))

--- a/stdlib/Dates/test/periods.jl
+++ b/stdlib/Dates/test/periods.jl
@@ -519,5 +519,18 @@ end
     #Test combined Fixed and Other Periods
     @test (1m + 1d < 1m + 1s) == false
 end
+
+@testset "Convert CompoundPeriod to Period" begin
+    @test convert(Month, Year(1) + Month(1)) === Month(13)
+    @test convert(Second, Minute(1) + Second(30)) === Second(90)
+    @test convert(Minute, Minute(1) + Second(60)) === Minute(2)
+    @test convert(Millisecond, Minute(1) + Second(30)) === Millisecond(90_000)
+    @test_throws InexactError convert(Minute, Minute(1) + Second(30))
+    @test_throws MethodError convert(Month, Minute(1) + Second(30))
+    @test_throws MethodError convert(Second, Month(1) + Second(30))
+    @test_throws MethodError convert(Period, Minute(1) + Second(30))
+    @test_throws MethodError convert(Dates.FixedPeriod, Minute(1) + Second(30))
+end
+
 end
 


### PR DESCRIPTION
This enables `convert(::Type{<:Period}, ::CompoundPeriod)`.

I did not add support for constructors, because I thought something like `Minute(::CompoundPeriod)` could be confusing (one could think that it extracts the `Minute` component from the `CompoundPeriod`).

This came up in [this discourse thread](https://discourse.julialang.org/t/how-can-i-convert-a-compoundperiod-type-object-to-period-type-in-julia/60930).