### PR TITLE
Make `methods(join)` a bit more self documenting (accepts iterators)

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -305,7 +305,7 @@ IOBuffer(s::SubString{String}) = IOBuffer(view(unsafe_wrap(Vector{UInt8}, s.stri
 
 Join any `iterator` into a single string, inserting the given delimiter (if any) between
 adjacent items.  If `last` is given, it will be used instead of `delim` between the last
-two items.  Each item of the iterator is converted to a string via `print(io::IOBuffer, x)`.
+two items.  Each item of `iterator` is converted to a string via `print(io::IOBuffer, x)`.
 If `io` is given, the result is written to `io` rather than returned as a `String`.
 
 # Examples

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -306,7 +306,7 @@ IOBuffer(s::SubString{String}) = IOBuffer(view(unsafe_wrap(Vector{UInt8}, s.stri
 Join any `iterator` into a single string, inserting the given delimiter (if any) between
 adjacent items.  If `last` is given, it will be used instead of `delim` between the last
 two items.  Each item of the iterator is converted to a string via `print(io::IOBuffer, x)`.
-If `io` is given, the result is written to `io` rather than returned as a `String`.  
+If `io` is given, the result is written to `io` rather than returned as a `String`.
 
 # Examples
 ```jldoctest

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -320,10 +320,10 @@ julia> join([1,2,3,4,5])
 "12345"
 ```
 """
-function join(io::IO, strings, delim, last)
+function join(io::IO, string_iterator, delim, last)
     first = true
     local prev
-    for str in strings
+    for str in string_iterator
         if @isdefined prev
             first ? (first = false) : print(io, delim)
             print(io, prev)
@@ -336,19 +336,19 @@ function join(io::IO, strings, delim, last)
     end
     nothing
 end
-function join(io::IO, strings, delim="")
+function join(io::IO, string_iterator, delim="")
     # Specialization of the above code when delim==last,
     # which lets us emit (compile) less code
     first = true
-    for str in strings
+    for str in string_iterator
         first ? (first = false) : print(io, delim)
         print(io, str)
     end
 end
 
-join(strings) = sprint(join, strings)
-join(strings, delim) = sprint(join, strings, delim)
-join(strings, delim, last) = sprint(join, strings, delim, last)
+join(string_iterator) = sprint(join, string_iterator)
+join(string_iterator, delim) = sprint(join, string_iterator, delim)
+join(string_iterator, delim, last) = sprint(join, string_iterator, delim, last)
 
 ## string escaping & unescaping ##
 

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -301,15 +301,12 @@ IOBuffer(s::SubString{String}) = IOBuffer(view(unsafe_wrap(Vector{UInt8}, s.stri
 # join is implemented using IO
 
 """
-    join([io::IO,] strings [, delim [, last]])
+    join([io::IO,] iterator [, delim [, last]])
 
-Join an array of `strings` into a single string, inserting the given delimiter (if any) between
-adjacent strings. If `last` is given, it will be used instead of `delim` between the last
-two strings. If `io` is given, the result is written to `io` rather than returned
-as a `String`.
-
-`strings` can be any iterable over elements `x` which are convertible to strings
-via `print(io::IOBuffer, x)`. `strings` will be printed to `io`.
+Join any `iterator` into a single string, inserting the given delimiter (if any) between
+adjacent items.  If `last` is given, it will be used instead of `delim` between the last
+two items.  Each item of the iterator is converted to a string via `print(io::IOBuffer, x)`.
+If `io` is given, the result is written to `io` rather than returned as a `String`.  
 
 # Examples
 ```jldoctest
@@ -320,15 +317,15 @@ julia> join([1,2,3,4,5])
 "12345"
 ```
 """
-function join(io::IO, string_iterator, delim, last)
+function join(io::IO, iterator, delim, last)
     first = true
     local prev
-    for str in string_iterator
+    for item in iterator
         if @isdefined prev
             first ? (first = false) : print(io, delim)
             print(io, prev)
         end
-        prev = str
+        prev = item
     end
     if @isdefined prev
         first || print(io, last)
@@ -336,19 +333,19 @@ function join(io::IO, string_iterator, delim, last)
     end
     nothing
 end
-function join(io::IO, string_iterator, delim="")
+function join(io::IO, iterator, delim="")
     # Specialization of the above code when delim==last,
     # which lets us emit (compile) less code
     first = true
-    for str in string_iterator
+    for item in iterator
         first ? (first = false) : print(io, delim)
-        print(io, str)
+        print(io, item)
     end
 end
 
-join(string_iterator) = sprint(join, string_iterator)
-join(string_iterator, delim) = sprint(join, string_iterator, delim)
-join(string_iterator, delim, last) = sprint(join, string_iterator, delim, last)
+join(iterator) = sprint(join, iterator)
+join(iterator, delim) = sprint(join, iterator, delim)
+join(iterator, delim, last) = sprint(join, iterator, delim, last)
 
 ## string escaping & unescaping ##
 


### PR DESCRIPTION
A simple renaming of the function arguments for `join` so it is more obvious it accepts any string iterator:

```
julia> methods(join)
# 6 methods for generic function "join":
[1] join(io::IO, string_iterator) in Base at strings/io.jl:339
[2] join(io::IO, string_iterator, delim) in Base at strings/io.jl:339
[3] join(io::IO, string_iterator, delim, last) in Base at strings/io.jl:323
[4] join(string_iterator) in Base at strings/io.jl:349
[5] join(string_iterator, delim) in Base at strings/io.jl:350
[6] join(string_iterator, delim, last) in Base at strings/io.jl:351

julia> join(("$name=$val" for (name, val) in zip(["a", "b", "c"], 1:3)), " ")
"a=1 b=2 c=3"
```

I did not reword the inline docs thinking that maybe they are clear enough...but not sure.