### PR TITLE
Add @inbounds in push!

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -965,7 +965,7 @@ function push!(a::Array{T,1}, item) where T
     # convert first so we don't grow the array if the assignment won't work
     itemT = convert(T, item)
     _growend!(a, 1)
-    a[end] = itemT
+    @inbounds a[end] = itemT
     return a
 end
 


### PR DESCRIPTION
I am making it a PR as it is simpler to discuss with the concrete proposal. It seems that adding `@inbounds` should be safe and it saves ~5-10% of time.

What was the reason of not having `@inbounds` here?