### PR TITLE
Replace use of jl_array_copy with direct allocate and copy

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1529,7 +1529,7 @@ end
 
 # approximate static parameters due to unions
 let T1 = Array{Float64}, T2 = Array{_1,2} where _1
-    inference_test_copy(a::T) where {T<:Array} = ccall(:jl_array_copy, Ref{T}, (Any,), a)
+    inference_test_copy(a::T) where {T<:Array} = ccall(:any_function_name, Ref{T}, (Any,), a)
     rt = Base.return_types(inference_test_copy, (Union{T1,T2},))[1]
     @test rt >: T1 && rt >: T2
 


### PR DESCRIPTION
Doing so simplifies Julia's ABI as it doesn't appear that `jl_copy_array` is used elsewhere (and similarly simplifies things by both having this done in Julia and separates allocation from memory copying).

It is presently unclear what impact this will have on performance. On the potential downside, `jl_copy_array` may be microoptimized in a way Julia cannot emulate. On the potential upside, the internal implementation of `copyto!` appears to use similar memcpy style intrinsics for data transfer. Moreover, by having the actual copy done in a way accessible to the compilation unit being optimized (e.g. not hidden behind a runtime call), subsequent code may take advantage of this to be able to forward a store to its location and may enable better optimization as the library call will not read (or potentially capture) the array passed to it.

This should certainly be run by nanosoldier.

cc @vchuravy 