### PR TITLE
inference: form conditional constraint from non-`Conditional` object

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1833,6 +1833,24 @@ end
     end == Any[Tuple{Int,Int}]
 end
 
+@testset "conditional constraint propagation from non-`Conditional` object" begin
+    @test Base.return_types((Bool,)) do b
+        if b
+            return !b ? nothing : 1 # ::Int
+        else
+            return 0
+        end
+    end == Any[Int]
+
+    @test Base.return_types((Any,)) do b
+        if b
+            return b # ::Bool
+        else
+            return nothing
+        end
+    end == Any[Union{Bool,Nothing}]
+end
+
 function f25579(g)
     h = g[]
     t = (h === nothing)


### PR DESCRIPTION
We can form a conditional constraint from a branch condition itself
when its type isn't already `Conditional` but can be refined as
`Conditional(condx, Const(true), Const(false))`.