### PR TITLE
allow pkgdir accept paths

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -329,6 +329,7 @@ julia> pkgdir(Foo)
 
 julia> pkgdir(Foo, "src", "file.jl")
 "/path/to/Foo.jl/src/file.jl"
+```
 
 !!! compat "Julia 1.7"
     The optional argument `paths` requires at least Julia 1.7.

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -318,9 +318,13 @@ end
 """
     pkgdir(m::Module[, paths::String...])
 
- Return the root directory of the package that imported module `m`,
- or `nothing` if `m` was not imported from a package.
- """
+Return the root directory of the package that imported module `m`,
+or `nothing` if `m` was not imported from a package. The optional
+argument `paths` can be used to access subdirs of the module root.
+
+!!! compat "Julia 1.7"
+    This function requires at least Julia 1.7.
+"""
 function pkgdir(m::Module, paths::String...)
     rootmodule = Base.moduleroot(m)
     path = pathof(rootmodule)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -316,16 +316,16 @@ function pathof(m::Module)
 end
 
 """
-    pkgdir(m::Module)
+    pkgdir(m::Module[, paths::String...])
 
  Return the root directory of the package that imported module `m`,
  or `nothing` if `m` was not imported from a package.
  """
-function pkgdir(m::Module)
+function pkgdir(m::Module, paths::String...)
     rootmodule = Base.moduleroot(m)
     path = pathof(rootmodule)
     path === nothing && return nothing
-    return dirname(dirname(path))
+    return joinpath(dirname(dirname(path)), paths...)
 end
 
 ## generic project & manifest API ##

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -320,7 +320,7 @@ end
 
 Return the root directory of the package that imported module `m`,
 or `nothing` if `m` was not imported from a package. Optionally further
-path component strings can be provided to construct a path within the 
+path component strings can be provided to construct a path within the
 package root.
 
 ```julia

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -319,8 +319,16 @@ end
     pkgdir(m::Module[, paths::String...])
 
 Return the root directory of the package that imported module `m`,
-or `nothing` if `m` was not imported from a package. The optional
-argument `paths` can be used to access subdirs of the module root.
+or `nothing` if `m` was not imported from a package. Optionally further
+path component strings can be provided to construct a path within the 
+package root.
+
+```julia
+julia> pkgdir(Foo)
+"/path/to/Foo.jl"
+
+julia> pkgdir(Foo, "src", "file.jl")
+"/path/to/Foo.jl/src/file.jl"
 
 !!! compat "Julia 1.7"
     The optional argument `paths` requires at least Julia 1.7.

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -323,7 +323,7 @@ or `nothing` if `m` was not imported from a package. The optional
 argument `paths` can be used to access subdirs of the module root.
 
 !!! compat "Julia 1.7"
-    This function requires at least Julia 1.7.
+    The optional argument `paths` requires at least Julia 1.7.
 """
 function pkgdir(m::Module, paths::String...)
     rootmodule = Base.moduleroot(m)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -314,6 +314,11 @@ module NotPkgModule; end
         @test pkgdir(Foo.SubFoo1) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
         @test pkgdir(Foo.SubFoo2) == normpath(abspath(@__DIR__, "project/deps/Foo1"))
         @test pkgdir(NotPkgModule) === nothing
+
+        @test pkgdir(Foo, "src") == normpath(abspath(@__DIR__, "project/deps/Foo1/src"))
+        @test pkgdir(Foo.SubFoo1, "src") == normpath(abspath(@__DIR__, "project/deps/Foo1/src"))
+        @test pkgdir(Foo.SubFoo2, "src") == normpath(abspath(@__DIR__, "project/deps/Foo1/src"))
+        @test pkgdir(NotPkgModule, "src") === nothing
     end
 
 end


### PR DESCRIPTION
I find it's quite often that when one uses `pkgdir` one actually wants to get the path of some subdir of the package directory, which as a result doing something like

```julia
joinpath(pkgdir(Foo), "src", "subdir")
```

this PR allows `pkgdir` to take a vararg `paths`, so if one wants to do something like above, can now just write

```julia
pkgdir(Foo, "src", "subdir")
```

and it preserves the original behaviour that you can still just put a module to get the root of a module path.
