### PR TITLE
RFC: Enable `Base.mod1` to support `Missing` input

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -116,7 +116,7 @@ for f in (:(Base.float), :(Base.complex))
 end
 
 # Binary operators/functions
-for f in (:(+), :(-), :(*), :(/), :(^), :(mod), :(rem))
+for f in (:(+), :(-), :(*), :(/), :(^), :(mod), :(rem), :(mod1))
     @eval begin
         # Scalar with missing
         ($f)(::Missing, ::Missing) = missing

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -83,7 +83,7 @@ end
 end
 
 @testset "arithmetic operators" begin
-    arithmetic_operators = [+, -, *, /, ^, Base.div, Base.mod, Base.fld, Base.rem]
+    arithmetic_operators = [+, -, *, /, ^, Base.div, Base.mod, Base.fld, Base.rem, Base.mod1]
 
     # All unary operators return missing when evaluating missing
     for f in [!, ~, +, -, *, &, |, xor, nand, nor]


### PR DESCRIPTION
I enabled `Base.mod1` to support `Missing` input to fix a part of #10585.
I think it is a good first step for API consistency between `Base.mod` and `Base.mod1`.

Before:
```
julia> mod(missing, missing)
missing

julia> mod(missing, 1)
missing

julia> mod(1, missing)
missing

julia> mod1(1, missing)
ERROR: MethodError: no method matching mod1(::Int64, ::Missing)
Closest candidates are:
  mod1(::T, ::T) where T<:Real at operators.jl:781
  mod1(::Real, ::Real) at promotion.jl:367
Stacktrace:
 [1] top-level scope
   @ REPL[24]:1

julia> mod1(missing, 1)
ERROR: MethodError: no method matching mod1(::Missing, ::Int64)
Closest candidates are:
  mod1(::T, ::T) where T<:Real at operators.jl:781
  mod1(::Real, ::Real) at promotion.jl:367
Stacktrace:
 [1] top-level scope
   @ REPL[25]:1

julia> mod1(missing, missing)
ERROR: MethodError: no method matching mod1(::Missing, ::Missing)
Stacktrace:
 [1] top-level scope
   @ REPL[26]:1
```

After:
```
julia> mod1(missing, missing)
missing

julia> mod1(1, missing)
missing

julia> mod1(missing, 1)
missing
```