### PR TITLE
faster `iseven(::BigInt)`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -10,7 +10,7 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, 
              sum, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
-             sign, hastypemax, isodd, digits!
+             sign, hastypemax, isodd, iseven, digits!
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -343,6 +343,7 @@ end
 rem(x::Integer, ::Type{BigInt}) = BigInt(x)
 
 isodd(x::BigInt) = MPZ.tstbit(x, 0)
+iseven(x::BigInt) = !isodd(x)
 
 function (::Type{T})(x::BigInt) where T<:Base.BitUnsigned
     if sizeof(T) < sizeof(Limb)


### PR DESCRIPTION
This method was depending on the generic implementation
`iseven(x::Integer) = !isodd(x)` for its efficiency, but this was removed
in #38976, making `iseven(::BigInt)` 30 times slower.