### PR TITLE
Restore some ABI compatibility with Julia 1.6

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -275,6 +275,8 @@
     XX(jl_init_restored_modules) \
     XX(jl_init) \
     XX(jl_init_with_image) \
+    XX(jl_init__threading) \
+    XX(jl_init_with_image__threading) \
     XX(jl_install_sigint_handler) \
     XX(jl_instantiate_type_in_env) \
     XX(jl_instantiate_unionall) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -91,6 +91,19 @@ JL_DLLEXPORT void jl_init(void)
     free(libbindir);
 }
 
+// HACK: remove this for Julia 1.8 (see <https://github.com/JuliaLang/julia/issues/40730>)
+JL_DLLEXPORT void jl_init__threading(void)
+{
+    jl_init();
+}
+
+// HACK: remove this for Julia 1.8 (see <https://github.com/JuliaLang/julia/issues/40730>)
+JL_DLLEXPORT void jl_init_with_image__threading(const char *julia_bindir,
+                                     const char *image_relative_path)
+{
+    jl_init_with_image(julia_bindir, image_relative_path);
+}
+
 JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
 {
     jl_value_t *r;


### PR DESCRIPTION
In Julia <= 1.6, the C API function `jl_init` and `jl_init_with_image` were
exported on the ABI level under the names `jl_init__threading` and
`jl_init_with_image__threading`. This was changed during development of Julia
1.7, but unfortunately that broke ABI compatibility with binaries build
against Julia <= 1.6.

Add back and export two simple wrapper functions to restore this aspect of ABI
compatibility. This way, people gain some time to migrate existing code bases,
and have an easier time supporting both released Julia versions and nightly
Julia builds.

Once Julia 1.7 is out, which exports both the old and new symbol names, these
wrappers could be removed for Julia 1.8 development (or they could also be
left in, given that they don't seem to cost us anything?)

Resolves #40730 

Resolves https://github.com/oscar-system/GAP.jl/issues/646

Might help (partially?) with issue #40246.