### PR TITLE
Refuse to serialize instances of foreign types

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -685,6 +685,12 @@ JL_DLLEXPORT jl_datatype_t * jl_new_foreign_type(jl_sym_t *name,
     return bt;
 }
 
+JL_DLLEXPORT int jl_is_foreign_type(jl_datatype_t *dt)
+{
+    return jl_is_datatype(dt) && dt->layout && dt->layout->fielddesc_type == 3;
+}
+
+
 // bits constructors ----------------------------------------------------------
 
 JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, void *data)

--- a/src/dump.c
+++ b/src/dump.c
@@ -8,6 +8,7 @@
 
 #include "julia.h"
 #include "julia_internal.h"
+#include "julia_gcext.h"
 #include "builtin_proto.h"
 #include "serialize.h"
 
@@ -817,6 +818,10 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
                 ios_write(s->s, (char*)&tn->hash, sizeof(tn->hash));
             }
             return;
+        }
+
+        if (jl_is_foreign_type(t)) {
+            jl_error("Cannot serialize instances of foreign datatypes");
         }
 
         char *data = (char*)jl_data_ptr(v);

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -49,6 +49,8 @@ JL_DLLEXPORT jl_datatype_t *jl_new_foreign_type(
         int haspointers,
         int large);
 
+JL_DLLEXPORT int jl_is_foreign_type(jl_datatype_t *dt);
+
 JL_DLLEXPORT size_t jl_gc_max_internal_obj_size(void);
 JL_DLLEXPORT size_t jl_gc_external_obj_hdr_size(void);
 


### PR DESCRIPTION
This will simply not work; those types are foreign, after all, so we know
nothing about how to serialize them.

In principle, it'd be nice if people implementing and using foreign types (is there anybody other than us?) could also provide (de)serialization support for them; and I might look into that at some point; but for now, just having a helpful error message instead of crashing would be helpful, and is simple enough.