### PR TITLE
Add indexing and other array operations to MethodList

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -295,6 +295,7 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
 end
 
 show(io::IO, ms::MethodList) = show_method_table(io, ms)
+show(io::IO, ::MIME"text/plain", ms::MethodList) = show_method_table(io, ms)
 show(io::IO, mt::Core.MethodTable) = show_method_table(io, MethodList(mt))
 
 function inbase(m::Module)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -915,15 +915,13 @@ end
 # high-level, more convenient method lookup functions
 
 # type for reflecting and pretty-printing a subset of methods
-mutable struct MethodList
+mutable struct MethodList <: AbstractArray{Method,1}
     ms::Array{Method,1}
     mt::Core.MethodTable
 end
 
-length(m::MethodList) = length(m.ms)
-isempty(m::MethodList) = isempty(m.ms)
-iterate(m::MethodList, s...) = iterate(m.ms, s...)
-eltype(::Type{MethodList}) = Method
+size(m::MethodList) = size(m.ms)
+getindex(m::MethodList, i) = m.ms[i]
 
 function MethodList(mt::Core.MethodTable)
     ms = Method[]


### PR DESCRIPTION
This PR makes `MethodList` a subtype of `AbstractArray{Method,1}`. Instead of defining `length`, `isempty`, `iterate`, and `eltype`, only `size` and `getindex` are defined, and the remaining functions follow from those defined for `AbstractArray`.

The main use-case for this change is making it convenient to call `edit`, `less`, and others on the result of `methods` or `methodswith` (instead of accessing the internal `ms` array, which is a bit obscure and undocumented). For example:
```
julia> m = methods(println)
[1] println(io::IO) in Base at coreio.jl:5
[2] println(io::IO, xs...) in Base at strings/io.jl:73
[3] println(xs...) in Base at coreio.jl:4

julia> less(m[2])
```