### PR TITLE
LinearAlgebra: Add bareiss det for BigInt Matrices (#40128) :: Take 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,7 @@ Standard library changes
 * The shape of an `UpperHessenberg` matrix is preserved under certain arithmetic operations, e.g. when multiplying or dividing by an `UpperTriangular` matrix. ([#40039])
 * `cis(A)` now supports matrix arguments ([#40194]).
 * `dot` now supports `UniformScaling` with `AbstractMatrix` ([#40250]).
+* `det(M::AbstractMatrix{BigInt})` now calls `det_bareiss(M)`, which uses the [Bareiss](https://en.wikipedia.org/wiki/Bareiss_algorithm) algorithm to calculate precise values.([#40868]).
 
 #### Markdown
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1559,12 +1559,7 @@ end
 det(x::Number) = x
 
 # Resolve Issue #40128
-function det(A::AbstractMatrix{BigInt})
-    m, n = size(A)
-    if m == n || throw(DimensionMismatch("matrix is not square: dimensions are $(size(A))"))
-        det_bareiss(A)
-    end
-end
+det(A::AbstractMatrix{BigInt}) = det_bareiss(A)
 
 """
     logabsdet(M)
@@ -1632,7 +1627,7 @@ exactdiv(a, b) = a/b
 exactdiv(a::Integer, b::Integer) = div(a, b)
 
 """
-    LinearAlgebra.det_bareiss!(M)
+    det_bareiss!(M)
 
 Calculates the determinant of a matrix using the
 [Bareiss Algorithm](https://en.wikipedia.org/wiki/Bareiss_algorithm) using
@@ -1650,13 +1645,14 @@ julia> LinearAlgebra.det_bareiss!(M)
 ```
 """
 function det_bareiss!(M)
-    n, sign, prev = size(M,1), Int8(1), one(eltype(M))
+    n = checksquare(M)
+    sign, prev = Int8(1), one(eltype(M))
     for i in 1:n-1
         if iszero(M[i,i]) # swap with another col to make nonzero
             swapto = findfirst(!iszero, @view M[i,i+1:end])
             isnothing(swapto) && return zero(prev)
             sign = -sign
-            Base.swapcols!(M, i, swapto)
+            Base.swapcols!(M, i, i + swapto)
         end
         for k in i+1:n, j in i+1:n
             M[j,k] = exactdiv(M[j,k]*M[i,i] - M[j,i]*M[i,k], prev)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1558,6 +1558,14 @@ function det(A::AbstractMatrix{T}) where T
 end
 det(x::Number) = x
 
+# Resolve Issue #40128
+function det(A::AbstractMatrix{BigInt})
+    m, n = size(A)
+    if m == n || throw(DimensionMismatch("matrix is not square: dimensions are $(size(A))"))
+        det_bareiss(A)
+    end
+end
+
 """
     logabsdet(M)
 
@@ -1619,6 +1627,54 @@ end
 logdet(A) = log(det(A))
 
 const NumberArray{T<:Number} = AbstractArray{T}
+
+exactdiv(a, b) = a/b
+exactdiv(a::Integer, b::Integer) = div(a, b)
+
+"""
+    LinearAlgebra.det_bareiss!(M)
+
+Calculates the determinant of a matrix using the
+[Bareiss Algorithm](https://en.wikipedia.org/wiki/Bareiss_algorithm) using
+inplace operations.
+
+# Examples
+```jldoctest
+julia> M = [1 0; 2 2]
+2×2 Matrix{Int64}:
+ 1  0
+ 2  2
+
+julia> LinearAlgebra.det_bareiss!(M)
+2
+```
+"""
+function det_bareiss!(M)
+    n, sign, prev = size(M,1), Int8(1), one(eltype(M))
+    for i in 1:n-1
+        if iszero(M[i,i]) # swap with another col to make nonzero
+            swapto = findfirst(!iszero, @view M[i,i+1:end])
+            isnothing(swapto) && return zero(prev)
+            sign = -sign
+            Base.swapcols!(M, i, swapto)
+        end
+        for k in i+1:n, j in i+1:n
+            M[j,k] = exactdiv(M[j,k]*M[i,i] - M[j,i]*M[i,k], prev)
+        end
+        prev = M[i,i]
+    end
+    return sign * M[end,end]
+end
+"""
+    LinearAlgebra.det_bareiss(M)
+
+Calculates the determinant of a matrix using the
+[Bareiss Algorithm](https://en.wikipedia.org/wiki/Bareiss_algorithm).
+Also refer to [`det_bareiss!`](@ref).
+"""
+det_bareiss(M) = det_bareiss!(copy(M))
+
+
 
 """
     promote_leaf_eltypes(itr)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -356,7 +356,8 @@ end
 end
 
 @testset "Issue 40128" begin
-               @test LinearAlgebra.det_bareiss(BigInt[1 2; 3 4]) == -2
+    @test det(BigInt[9 1 8 0; 0 0 8 7; 7 6 8 3; 2 9 7 7])::BigInt == -1
+    @test det(BigInt[1 big(2)^65+1; 3 4])::BigInt == (4 - 3*(big(2)^65+1))
 end
 
 # Minimal modulo number type - but not subtyping Number

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -355,6 +355,10 @@ end
     @test [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]] ≈ [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]]
 end
 
+@testset "Issue 40128" begin
+               @test LinearAlgebra.det_bareiss(BigInt[1 2; 3 4]) == -2
+end
+
 # Minimal modulo number type - but not subtyping Number
 struct ModInt{n}
     k


### PR DESCRIPTION
As said in the previous PR with the same name,  I messed up my julia fork trying to rebase and push clean code. 
This fixes JuliaLang/LinearAlgebra.jl#824
Do suggest ways to improve this PR.
cc: @simeonschaub 