### PR TITLE
tweak the type of quotes for functions in llvm code output

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -249,7 +249,7 @@ void DILineInfoPrinter::emit_lineinfo(raw_ostream &Out, std::vector<DILineInfo> 
         if (frame.Line != UINT_MAX && frame.Line != 0)
             Out << ":" << frame.Line;
         StringRef method = StringRef(frame.FunctionName).rtrim(';');
-        Out << " within `" << method << "'";
+        Out << " within `" << method << "`";
         if (collapse_recursive) {
             while (nctx < nframes) {
                 const DILineInfo &frame = DI.at(nframes - 1 - nctx);


### PR DESCRIPTION
It is quite common to include parts of `@code_llvm` in julia code blocks. For example:

```jl
julia> x = 2.0
2.0

julia> @code_llvm exp(x)
;  @ special/exp.jl:206 within `exp'
define double @julia_exp_193(double %0) {
top:
;  @ special/exp.jl:207 within `exp'
; ┌ @ float.jl:339 within `muladd'
   %1 = fmul contract double %0, 0x40771547652B82FE
   %2 = fadd contract double %1, 0x4338000000000000
; └
;  @ special/exp.jl:208 within `exp'
; ┌ @ essentials.jl:422 within `reinterpret'
   %3 = bitcast double %2 to i64
; └
; ┌ @ int.jl:472 within `rem'
   %4 = trunc i64 %3 to i32
; └
;  @ special/exp.jl:209 within `exp'
; ┌ @ float.jl:329 within `-'
   %5 = fadd double %2, 0xC338000000000000
; └
;  @ special/exp.jl:210 within `exp'
```

The problem here is that the way functions are quoted: ``` `exp' ``` means that code highlighting gets confused. This changes it to use the same delimiter:

```jl
julia> x = 2.0
2.0

julia> @code_llvm exp(x)
;  @ special/exp.jl:292 within `exp`
define double @julia_exp_128(double %0) #0 {
top:
; ┌ @ special/exp.jl:206 within `exp_impl`
; │┌ @ float.jl:402 within `muladd`
    %1 = fmul contract double %0, 0x40771547652B82FE
    %2 = fadd contract double %1, 0x4338000000000000
; └└
; ┌ @ special/exp.jl:207 within `exp_impl`
; │┌ @ essentials.jl:453 within `reinterpret`
    %3 = bitcast double %2 to i64
; │└
; │┌ @ int.jl:501 within `rem`
    %4 = trunc i64 %3 to i32
; └└
; ┌ @ special/exp.jl:208 within `exp_impl`
; │┌ @ float.jl:392 within `-`
    %5 = fadd double %2, 0xC338000000000000
; └└
; ┌ @ special/exp.jl:209 within `exp_impl`
...
```
