### PR TITLE
fix `-Inf16 < typemin(Int)`

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -467,7 +467,7 @@ end
 #  b. unsafe_convert undefined behaviour if fy == Tf(typemax(Ti))
 #     (but consequently x == fy > y)
 for Ti in (Int64,UInt64,Int128,UInt128)
-    for Tf in (Float16,Float32,Float64)
+    for Tf in (Float32,Float64)
         @eval begin
             function ==(x::$Tf, y::$Ti)
                 fy = ($Tf)(y)

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -21,6 +21,20 @@ g = Float16(1.)
     @test isequal(Float16(0.0), Float16(0.0))
     @test !isequal(Float16(-0.0), Float16(0.0))
     @test !isequal(Float16(0.0), Float16(-0.0))
+
+    for T = Base.BitInteger_types
+        @test -Inf16 < typemin(T)
+        @test -Inf16 <= typemin(T)
+        @test typemin(T) > -Inf16
+        @test typemin(T) >= -Inf16
+        @test typemin(T) != -Inf16
+
+        @test Inf16 > typemax(T)
+        @test Inf16 >= typemax(T)
+        @test typemax(T) < Inf16
+        @test typemax(T) <= Inf16
+        @test typemax(T) != Inf16
+    end
 end
 
 @testset "convert" begin

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -171,6 +171,10 @@ end
     # halfway between and last bit is 0
     ff = reinterpret(Float32,                           0b00111110101010100001000000000000)
     @test Float32(Float16(ff)) === reinterpret(Float32, 0b00111110101010100000000000000000)
+
+    for x = (typemin(Int64), typemin(Int128)), R = (RoundUp, RoundToZero)
+        @test Float16(x, R) == nextfloat(-Inf16)
+    end
 end
 
 # issue #5948


### PR DESCRIPTION
A new method was added in 3851ac55 which was seemingly violating the
stated assumption that `typemin(Int)` can be exactly represented by `Float16`.
And a more corrected method was shadowed.
Idem for `Int128`.

This was added at https://github.com/JuliaLang/julia/commit/3851ac553d74d8274558f7dc3467601f33a7270f#diff-c3db136e74f578ae79362a8baac0b81980be1dff769a05f2eb1a3c288b3550ccR397, cc @vchuravy (BTW, I couldn't find a corresponding PR, was there one?).