### PR TITLE
Make `broadcastable` treat `Char` like `Number`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -699,7 +699,7 @@ Base.RefValue{String}("hello")
 """
 broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair}) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
-broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x
+broadcastable(x::Union{AbstractArray,Number,Char,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables
 broadcastable(x) = collect(x)
 broadcastable(::Union{AbstractDict, NamedTuple}) = throw(ArgumentError("broadcasting over dictionaries and `NamedTuple`s is reserved"))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -828,7 +828,7 @@ uncolon(inds::Tuple{},    I::Tuple{Colon, Vararg{Any}}) = Slice(OneTo(1))
 uncolon(inds::Tuple,      I::Tuple{Colon, Vararg{Any}}) = Slice(inds[1])
 
 ### From abstractarray.jl: Internal multidimensional indexing definitions ###
-getindex(x::Number, i::CartesianIndex{0}) = x
+getindex(x::Union{Number,Char}, ::CartesianIndex{0}) = x
 getindex(t::Tuple,  i::CartesianIndex{1}) = getindex(t, i.I[1])
 
 # These are not defined on directly on getindex to avoid

--- a/test/char.jl
+++ b/test/char.jl
@@ -99,6 +99,7 @@ end
     #getindex(c::Char) = c
     for x in testarrays
         @test getindex(x) == x
+        @test getindex(x, CartesianIndex()) == x
     end
 
     #first(c::Char) = c

--- a/test/char.jl
+++ b/test/char.jl
@@ -291,6 +291,7 @@ end
 
 @testset "broadcasting of Char" begin
     @test identity.('a') == 'a'
+    @test 'a' .* ['b', 'c'] == ["ab", "ac"]
 end
 
 @testset "code point format of U+ syntax (PR 33291)" begin


### PR DESCRIPTION
This is my very first PR, so I hope I'm doing things right. It's motivated by a thread on Discourse, see [here](https://discourse.julialang.org/t/char-and-broadcastable/61221). stevengj suggested that I file this issue on GitHub.

Starting point is the observation that `Char` seems to be the only plain-bits type for which `broadcastable` calls `collect` (the default method, meant for collecting iterables). stevengj mentioned on Discourse that `Char` once was a subtype of `Number`, so maybe it was just forgotten to align the treatment for `Char` with `Number` when `Char` ceased to be a subtype. This PR proposes to make this alignment.

 It turns out that it's not enough to define `broadcastable(x::Char) = x` (same method as for `Number`). One also needs `getindex(x, CartesianIndex())`, which is not defined for `Char` (maybe again an omission). If one adds this, then everything seems to work. The entire test suite runs without problems. I've also added a test for the `getindex` call mentioned above. Note that there is already a `@testset "broadcasting of Char"` in `test/char.jl`.