### PR TITLE
improve hashing performance for uuid

### DIFF
--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -31,6 +31,8 @@ end
 
 UInt128(u::UUID) = u.value
 
+hash(uuid::UUID, h::UInt) = hash(0x2e9d5a7e9fca58d3, hash(convert(NTuple{2, UInt64}, uuid), h))
+
 let
 @inline function uuid_kernel(s, i, u)
     _c = UInt32(@inbounds codeunit(s, i))

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -33,7 +33,7 @@ UInt128(u::UUID) = u.value
 
 let
     uuid_hash_seed = UInt === UInt64 ? 0xd06fa04f86f11b53 : 0x96a1f36d
-    hash(uuid::UUID, h::UInt) = hash(uuid_hash_seed, hash(convert(NTuple{2, UInt64}, uuid), h))
+    Base.hash(uuid::UUID, h::UInt) = hash(uuid_hash_seed, hash(convert(NTuple{2, UInt64}, uuid), h))
 end
 
 let

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -31,7 +31,10 @@ end
 
 UInt128(u::UUID) = u.value
 
-hash(uuid::UUID, h::UInt) = hash(0x2e9d5a7e9fca58d3, hash(convert(NTuple{2, UInt64}, uuid), h))
+let
+    uuid_hash_seed = UInt === UInt64 ? 0xd06fa04f86f11b53 : 0x96a1f36d
+    hash(uuid::UUID, h::UInt) = hash(uuid_hash_seed, hash(convert(NTuple{2, UInt64}, uuid), h))
+end
 
 let
 @inline function uuid_kernel(s, i, u)


### PR DESCRIPTION
I was working with some dicts that has `UUID`s for keys and they felt kind of slow. This helps a bit:

Example benchmark:

```jl
using UUIDs, BenchmarkTools

function bench(uuids, numbers)
    d = Dict{UUID, Int}()
    sizehint!(d, length(uuids))
    for (uuid, number) in zip(uuids, numbers)
        d[uuid] = number
    end
    return d
end

N = 10^4
uuids = [uuid4() for i in 1:N]
numbers = rand(Int, N)
@btime bench(uuids, numbers)
```

Master:

```
 264.006 μs (7 allocations: 400.97 KiB)
```

PR:

```
 190.882 μs (7 allocations: 400.97 KiB)
```

