### PR TITLE
restore performance of `hash` for `BigInt` and `Rational{BigInt}`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -10,7 +10,7 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, 
              sum, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
-             sign, hastypemax, isodd, iseven, digits!
+             sign, hastypemax, isodd, iseven, digits!, hash, hash_integer
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -769,8 +769,11 @@ end
 
 if Limb === UInt
     # this condition is true most (all?) of the time, and in this case we can define
-    # an optimized version of the above hash_integer(::Integer, ::UInt) method for BigInt
-    # used e.g. for Rational{BigInt}
+    # an optimized version for BigInt of hash_integer (used e.g. for Rational{BigInt}),
+    # and of hash
+
+    using .Base: hash_uint
+
     function hash_integer(n::BigInt, h::UInt)
         GC.@preserve n begin
             s = n.size
@@ -800,7 +803,7 @@ if Limb === UInt
                 limb <= typemin(Int) % UInt && return hash(-(limb % Int), h)
             end
             pow = trailing_zeros(x)
-            nd = ndigits0z(x, 2)
+            nd = Base.ndigits0z(x, 2)
             idx = _divLimb(pow) + 1
             shift = _modLimb(pow) % UInt
             upshift = BITS_PER_LIMB - shift


### PR DESCRIPTION
When the code was moved out of hashing2.jl, some imports where missed,
cancelling the benefits of #33790.

