### PR TITLE
Faster `dropdims`

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -88,13 +88,8 @@ function _dropdims(A::AbstractArray, dims::Dims)
             dims[j] == dims[i] && throw(ArgumentError("dropped dims must be unique"))
         end
     end
-    d = ()
-    for i = 1:ndims(A)
-        if !in(i, dims)
-            d = tuple(d..., axes(A, i))
-        end
-    end
-    reshape(A, d::typeof(_sub(axes(A), dims)))
+    ax = _foldoneto((ds, d) -> d in dims ? ds : (ds..., axes(A,d)), (), Val(ndims(A)))
+    reshape(A, ax::typeof(_sub(axes(A), dims)))
 end
 _dropdims(A::AbstractArray, dim::Integer) = _dropdims(A, (Int(dim),))
 


### PR DESCRIPTION
This speeds up `dropdims`. With various variants, and trying two computers, I see these times:
```julia
julia> @btime dropdims($(rand(3,1,3,1)), dims=(2,4));  # Julia master
  681.124 ns (9 allocations: 224 bytes)  # xeon
  205.289 ns (9 allocations: 224 bytes)  # M1 mac

    # notdims = filter(d -> d ∉ dims, ntuple(identity, ndims(A)))  # first attempt
    # ax = map(d -> axes(A,d), notdims)::typeof(_sub(axes(A), dims))

  165.865 ns (5 allocations: 176 bytes)
  41.036 ns (5 allocations: 176 bytes)

    # ax = afoldl((ds, d) -> d in dims ? ds : (ds..., axes(A,d)), (), ntuple(identity, ndims(A))...)

  125.416 ns (3 allocations: 128 bytes)
  30.485 ns (3 allocations: 128 bytes)

    # ax = _foldoneto((ds, d) -> d in dims ? ds : (ds..., axes(A,d)), (), Val(ndims(A)))

  110.659 ns (3 allocations: 128 bytes)
  27.177 ns (3 allocations: 128 bytes)
```
And, for instance,
```julia
julia> @btime dropdims($(rand(ComplexF64, 3)'), dims=1)
  262.536 ns (3 allocations: 48 bytes)  # master, xeon
  83.592 ns (3 allocations: 48 bytes)   # master, M1 mac

    # ax = _foldoneto((ds, d) -> d in dims ? ds : (ds..., axes(A,d)), (), Val(ndims(A)))

  3.588 ns (0 allocations: 0 bytes)
  1.333 ns (0 allocations: 0 bytes)
```
I hope I'm not overlooking something! The PR is the last variant. It uses `_foldoneto` added for `isperm(::Tuple)` in #35234.