### PR TITLE
Correct the error in doc of workers()

### DIFF
--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -851,7 +851,7 @@ julia> nprocs()
 3
 
 julia> workers()
-5-element Array{Int64,1}:
+2-element Array{Int64,1}:
  2
  3
 ```


### PR DESCRIPTION
Dear maintainers,

In the doc of function `workers`, number of workers of the example should be 2 instead of 5.
I have corrected it and hope able to help a little bit.

Yours,
Yu

