### PR TITLE
Disallow space-separated semicolons in array expression

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1919,6 +1919,8 @@
            (parse-array-inner s a is-row-first semicolon-count max-level closer #f gotlinesep)))
         ((#\;)
          (or gotnewline (take-token s))
+         (if (and (> semicolon-count 0) (ts:space? s)) ; disallow [a; ;b]
+             (error "multiple semicolons must be adjacent in an array expression"))
          (let ((next (peek-token s)))
            (let ((is-line-sep
                  (if (and (not (null? is-row-first)) is-row-first (= semicolon-count 1))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2717,6 +2717,7 @@ end
     @test Meta.parse("[1\n;]") == :([1;]) # semicolons following a linebreak are fine
     @test Meta.parse("[1\n;;; 2]") == :([1;;; 2])
     @test_throws ParseError Meta.parse("[1;\n;2]") # semicolons cannot straddle a line break
+    @test_throws ParseError Meta.parse("[1; ;2]") # semicolons cannot be separated by a space
 end
 
 # issue #25652


### PR DESCRIPTION
```
[1 ;; 2] # good
[1 ; ; 2] # error
```

As suggested by @simeonschaub 