### PR TITLE
Add `@threads :dynamic`

### DIFF
--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -724,16 +724,28 @@ let a = zeros(nthreads())
     @test a == [1:nthreads();]
 end
 
-# static schedule
-function _atthreads_static_schedule()
-    ids = zeros(Int, nthreads())
-    Threads.@threads :static for i = 1:nthreads()
-        ids[i] = Threads.threadid()
+@testset "@threads schedule option" begin
+    # static schedule
+    function _atthreads_static_schedule()
+        ids = zeros(Int, nthreads())
+        Threads.@threads :static for i = 1:nthreads()
+            ids[i] = Threads.threadid()
+        end
+        return ids
     end
-    return ids
+    @test _atthreads_static_schedule() == [1:nthreads();]
+    @test_throws TaskFailedException @threads for i = 1:1; _atthreads_static_schedule(); end
+
+    # dynamic schedule
+    function _atthreads_dynamic_schedule()
+        ids = zeros(Int, nthreads())
+        Threads.@threads :dynamic for i = 1:nthreads()
+            ids[i] = i
+        end
+        return ids
+    end
+    @test _atthreads_dynamic_schedule() == [1:nthreads();]
 end
-@test _atthreads_static_schedule() == [1:nthreads();]
-@test_throws TaskFailedException @threads for i = 1:1; _atthreads_static_schedule(); end
 
 try
     @macroexpand @threads(for i = 1:10, j = 1:10; end)


### PR DESCRIPTION
Better balance if tasks in iteration have different time costs.

```julia
julia> Threads.nthreads()
8

julia> function foo(x)
       if x <= 8
           sleep(1)
       end
   end
foo (generic function with 1 method)

julia> @time Threads.@threads for i in 1:16
       foo(i)
   end

  2.055390 seconds (17.37 k allocations: 1023.688 KiB, 0.00% compilation time)

julia> @time Threads.@threads :dynamic for i in 1:16
       foo(i)
   end
  1.052706 seconds (70.21 k allocations: 3.986 MiB, 0.39% compilation time)
```