### PR TITLE
Add type assertion in deepcopy_internal for Arrays

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -87,7 +87,7 @@ end
 
 function deepcopy_internal(x::Array, stackdict::IdDict)
     if haskey(stackdict, x)
-        return stackdict[x]
+        return stackdict[x]::typeof(x)
     end
     _deepcopy_array_t(x, eltype(x), stackdict)
 end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -234,3 +234,7 @@ end
     @test copyto!(s, Float64[]) == [1, 2]
     @test copyto!(s, String[]) == [1, 2] # No error
 end
+
+@testset "deepcopy_internal arrays" begin
+    @test (@inferred Base.deepcopy_internal(zeros(), IdDict())) == zeros()
+end


### PR DESCRIPTION
On master:
```julia
julia> @code_warntype Base.deepcopy_internal(zeros(2), IdDict())
MethodInstance for Base.deepcopy_internal(::Vector{Float64}, ::IdDict{Any, Any})
  from deepcopy_internal(x::Array, stackdict::IdDict) in Base at /home/jishnu/julia/base/deepcopy.jl:88
Arguments
  #self#::Core.Const(Base.deepcopy_internal)
  x::Vector{Float64}
  stackdict::IdDict{Any, Any}
Body::Any
1 ─ %1 = Base.haskey(stackdict, x)::Bool
└──      goto #3 if not %1
2 ─ %3 = Base.getindex(stackdict, x)::Any
└──      return %3
3 ─ %5 = Base.eltype(x)::Core.Const(Float64)
│   %6 = Base._deepcopy_array_t(x, %5, stackdict)::Vector{Float64}
└──      return %6
```

After this PR:
```julia
julia> @code_warntype Base.deepcopy_internal(zeros(2), IdDict())
MethodInstance for Base.deepcopy_internal(::Vector{Float64}, ::IdDict{Any, Any})
  from deepcopy_internal(x::Array, stackdict::IdDict) in Base at /home/jishnu/julia/base/deepcopy.jl:88
Arguments
  #self#::Core.Const(Base.deepcopy_internal)
  x::Vector{Float64}
  stackdict::IdDict{Any, Any}
Body::Vector{Float64}
1 ─ %1 = Base.haskey(stackdict, x)::Bool
└──      goto #3 if not %1
2 ─ %3 = Base.getindex(stackdict, x)::Any
│   %4 = Base.typeof(x)::Core.Const(Vector{Float64})
│   %5 = Core.typeassert(%3, %4)::Vector{Float64}
└──      return %5
3 ─ %7 = Base.eltype(x)::Core.Const(Float64)
│   %8 = Base._deepcopy_array_t(x, %7, stackdict)::Vector{Float64}
└──      return %8
```