### PR TITLE
Add `one(::AbstractArray)` method analogous to `zero`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1135,7 +1135,7 @@ copymutable(itr) = collect(itr)
 
 zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
 
-one(x::AbstractArray{T}) where {T} = fill!(similar(x), one(T))
+one(x::AbstractArray{T,1}) where {T} = fill!(similar(x), one(T))
 
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both IndexLinear and IndexCartesian arrays

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1135,6 +1135,8 @@ copymutable(itr) = collect(itr)
 
 zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
 
+one(x::AbstractArray{T}) where {T} = fill!(similar(x), one(T))
+
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both IndexLinear and IndexCartesian arrays
 


### PR DESCRIPTION
Currently:

```julia
julia> x = rand(3)
3-element Vector{Float64}:
 0.8156498244883958
 0.3661008180358507
 0.6820950478057413

julia> zero(x)
3-element Vector{Float64}:
 0.0
 0.0
 0.0

julia> one(x)
ERROR: MethodError: no method matching one(::Vector{Float64})
Closest candidates are:
  one(::Union{Type{T}, T}) where T<:AbstractString at strings/basic.jl:262
  one(::Union{Type{P}, P}) where P<:Dates.Period at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Dates/src/periods.jl:54
  one(::LinearAlgebra.Bidiagonal{T, V} where V<:AbstractVector{T}) where T at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/special.jl:306
  ...
Stacktrace:
 [1] top-level scope
   @ REPL[4]:1

```

After this PR:
```julia
julia> x = rand(3)
3-element Vector{Float64}:
 0.8156498244883958
 0.3661008180358507
 0.6820950478057413

julia> zero(x)
3-element Vector{Float64}:
 0.0
 0.0
 0.0

julia> one(x)
3-element Vector{Float64}:
 1.0
 1.0
 1.0

```