### PR TITLE
Faster polynomials for higher degrees

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -155,7 +155,7 @@ function evalpoly(x, p::Tuple)
     leftover = N - mod(N, 4) + 1
     x2=x*x
     x4=x2*x2
-    ex = _evalpoly(x, x2, p[leftover:N])
+    ex = _evalpoly(x, p[leftover:N])
     for i in end_length-4:-4:1
         part = muladd(x2, muladd(x, p[i+3], p[i+2]), muladd(x, p[i+1], p[i]))
         ex = muladd(x4, ex, part)

--- a/base/math.jl
+++ b/base/math.jl
@@ -149,18 +149,24 @@ julia> evalpoly(2, (1, 2, 3))
 17
 ```
 """
-function evalpoly(x, p::Tuple)
+@inline function evalpoly(x, p::Tuple)
     N = length(p)
     N < 7 && return _evalpoly(x, p)
-    leftover = N - mod(N, 4) + 1
+    nmod4 = mod(N, 4)
+    leftover = N - nmod4 + 1
     x2=x*x
     x4=x2*x2
-    ex = _evalpoly(x, p[leftover:N])
-    for i in end_length-4:-4:1
-        part = muladd(x2, muladd(x, p[i+3], p[i+2]), muladd(x, p[i+1], p[i]))
-        ex = muladd(x4, ex, part)
+    if nmod4 == 0
+        res = muladd(x2, muladd(x, p[end], p[end-1]), muladd(x, p[end-2], p[end-3]))
+        leftover -= 4
+    else
+        res = _evalpoly(x, p[leftover:N])
     end
-    ex
+    for i in leftover-4:-4:1
+        part = muladd(x2, muladd(x, p[i+3], p[i+2]), muladd(x, p[i+1], p[i]))
+        res = muladd(x4, res, part)
+    end
+    res
 end
 evalpoly(x, p::AbstractVector) = _evalpoly(x, p)
 

--- a/doc/src/manual/complex-and-rational-numbers.md
+++ b/doc/src/manual/complex-and-rational-numbers.md
@@ -130,7 +130,7 @@ julia> exp(1 + 2im)
 -1.1312043837568135 + 2.4717266720048188im
 
 julia> sinh(1 + 2im)
--0.4890562590412937 + 1.4031192506220405im
+-0.4890562590412937 + 1.4031192506220407im
 ```
 
 Note that mathematical functions typically return real values when applied to real numbers and


### PR DESCRIPTION
Based on discussion from https://github.com/JuliaLang/julia/pull/40870. TLDR is this switches the implementation from `horner` to instead precompute `x^2` and `x^4`, to  increase the instruction level parallelism that can be extracted. I'm seeing this benchmarking about 20% faster for a degree 14 polynomial.

```
julia> x64 = randn(Float64, 1024); y64 = similar(x64);
julia> c = Tuple(randn(15));
julia> @btime @. $y64=evalpoly_new($x64, ($c,));
  634.471 ns (0 allocations: 0 bytes)
  
julia> @btime @. $y64=evalpoly($x64, ($c,));
  866.111 ns (0 allocations: 0 bytes)
```