### PR TITLE
Fix documentation snippet

### DIFF
--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -37,9 +37,8 @@ m = first(mths)
 interp = Core.Compiler.NativeInterpreter()
 sparams = Core.svec()      # this particular method doesn't have type-parameters
 optimize = true            # run all inference optimizations
-cached = false             # force inference to happen (do not use cached results)
 types = Tuple{typeof(convert), atypes.parameters...} # Tuple{typeof(convert), Type{Int}, UInt}
-Core.Compiler.typeinf_code(interp, types, sparams, optimize, cached)
+Core.Compiler.typeinf_code(interp, m, types, sparams, optimize)
 ```
 
 If your debugging adventures require a `MethodInstance`, you can look it up by


### PR DESCRIPTION
Small fix to a documentation snippet in type inference where `typeinf_code` was called with the wrong signature.
The valid signature is `typeinf_code(interp::AbstractInterpreter, method::Method, @nospecialize(atypes), sparams::SimpleVector, run_optimizer::Bool)`.