### PR TITLE
ccall docs: Fix typo in Indirect Calls section

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -928,7 +928,7 @@ macro dlsym(func, lib)
         let zlocal = $z[]
             if zlocal == C_NULL
                 zlocal = dlsym($(esc(lib))::Ptr{Cvoid}, $(esc(func)))::Ptr{Cvoid}
-                $z[] = $zlocal
+                $z[] = zlocal
             end
             zlocal
         end


### PR DESCRIPTION
Fixes a typo in the code example for a `dlsym` macro.
A very small fix, but this just cost me, a Julia novice, half an hour :)