### PR TITLE
speed up `hash(::Symbol)`

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -24,6 +24,8 @@ hash(w::WeakRef, h::UInt) = hash(w.value, h)
 
 hash(@nospecialize(x), h::UInt) = hash_uint(3h - objectid(x))
 
+hash(x::Symbol) = objectid(x)
+
 ## core data hashing functions ##
 
 function hash_64_64(n::UInt64)

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -21,7 +21,9 @@ static jl_sym_t *symtab = NULL;
 
 static uintptr_t hash_symbol(const char *str, size_t len) JL_NOTSAFEPOINT
 {
-    return memhash(str, len) ^ ~(uintptr_t)0/3*2;
+    uintptr_t oid = memhash(str, len) ^ ~(uintptr_t)0/3*2;
+    // compute the same hash value as v1.6 and earlier, which used `hash_uint(3h - objectid(sym))`
+    return inthash(-oid);
 }
 
 static size_t symbol_nbytes(size_t len) JL_NOTSAFEPOINT


### PR DESCRIPTION
Since symbols are pre-hashed, add a fast path to return the value directly.

Before:
```
julia> @btime hash(:x)
  3.902 ns (0 allocations: 0 bytes)
julia> d = Dict(Symbol("x",i)=>i for i = 1:10000);
julia> @btime ($d)[:x6275]
  8.280 ns (0 allocations: 0 bytes)
```

After:
```
julia> @btime hash(:x)
  1.307 ns (0 allocations: 0 bytes)
julia> d = Dict(Symbol("x",i)=>i for i = 1:10000);
julia> @btime ($d)[:x6275]
  3.259 ns (0 allocations: 0 bytes)
```

Not sure why it speeds up dict lookup so much, but I'll take it.
