### PR TITLE
updating diagonal.jl wref #40887

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -484,7 +484,9 @@ rdiv!(A::AbstractMatrix{T}, adjD::Adjoint{<:Any,<:Diagonal{T}}) where {T} =
     (D = adjD.parent; rdiv!(A, conj(D)))
 rdiv!(A::AbstractMatrix{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
     (D = transD.parent; rdiv!(A, D))
-
+rdiv!(A::Matrix{T}, B::Diagonal{Bool, Vector{Bool}}) where {T<:Number} = 
+    rdiv!(A, Diagonal{T}(B))
+                                                
 (/)(A::Union{StridedMatrix, AbstractTriangular}, D::Diagonal) =
     rdiv!((typeof(oneunit(eltype(D))/oneunit(eltype(A)))).(A), D)
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -456,8 +456,7 @@ function ldiv!(D::Diagonal, A::Union{LowerTriangular,UpperTriangular})
     A
 end
 
-function rdiv!(A::AbstractMatrix{T}, D::Diagonal{T}) where {T}
-    require_one_based_indexing(A)
+function rdiv!(A::AbstractMatrix, D::Diagonal)
     dd = D.diag
     m, n = size(A)
     if (k = length(dd)) ≠ n
@@ -484,9 +483,7 @@ rdiv!(A::AbstractMatrix{T}, adjD::Adjoint{<:Any,<:Diagonal{T}}) where {T} =
     (D = adjD.parent; rdiv!(A, conj(D)))
 rdiv!(A::AbstractMatrix{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
     (D = transD.parent; rdiv!(A, D))
-rdiv!(A::Matrix{T}, B::Diagonal{Bool, Vector{Bool}}) where {T<:Number} = 
-    rdiv!(A, Diagonal{T}(B))
-                                                
+                                            
 (/)(A::Union{StridedMatrix, AbstractTriangular}, D::Diagonal) =
     rdiv!((typeof(oneunit(eltype(D))/oneunit(eltype(A)))).(A), D)
 


### PR DESCRIPTION
Added a method so that there is no error while computing rdiv! without explicitly specifying type as mentioned in the example in JuliaLang/LinearAlgebra.jl#849 .