### PR TITLE
Print `LineNumberNode` lightly

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1477,8 +1477,8 @@ emphasize(io, str::AbstractString, col = Base.error_color()) = get(io, :color, f
     printstyled(io, str; color=col, bold=true) :
     print(io, uppercase(str))
 
-show_linenumber(io::IO, line)       = print(io, "#= line ", line, " =#")
-show_linenumber(io::IO, line, file) = print(io, "#= ", file, ":", line, " =#")
+show_linenumber(io::IO, line)       = printstyled(io, "#= line ", line, " =#", color=:light_black)
+show_linenumber(io::IO, line, file) = printstyled(io, "#= ", file, ":", line, " =#", color=:light_black)
 show_linenumber(io::IO, line, file::Nothing) = show_linenumber(io, line)
 
 # show a block, e g if/for/etc


### PR DESCRIPTION
Since `error` and `@error` print line numbers in `:light_black`, perhaps expressions should too?

Before and after:

<img width="600" alt="Screenshot 2021-05-24 at 18 31 26" src="https://user-images.githubusercontent.com/32575566/119416952-c897c900-bcc2-11eb-9073-fddf50005283.png">
