### PR TITLE
Fix suitesparse checksum refresh naming mismatch

### DIFF
--- a/contrib/refresh_checksums.mk
+++ b/contrib/refresh_checksums.mk
@@ -103,6 +103,10 @@ pack-checksum-llvm: | checksum-llvm-tools
 pack-checksum-csl: | pack-checksum-compilersupportlibraries
 pack-checksum-compilersupportlibraries: | checksum-csl
 
+# We need to adjust to the fact that the checksum files are called `suitesparse`
+pack-checksum-libsuitesparse:
+	@$(MAKE) $(QUIET_MAKE) -C "$(JULIAHOME)" -f "$(JULIAHOME)/contrib/refresh_checksums.mk" pack-checksum-suitesparse
+
 # define how to pack parallel checksums into a single file format
 pack-checksum-%: FORCE
 	@echo making "$(JULIAHOME)/deps/checksums/$*"

--- a/contrib/refresh_checksums.mk
+++ b/contrib/refresh_checksums.mk
@@ -104,8 +104,8 @@ pack-checksum-csl: | pack-checksum-compilersupportlibraries
 pack-checksum-compilersupportlibraries: | checksum-csl
 
 # We need to adjust to the fact that the checksum files are called `suitesparse`
-pack-checksum-libsuitesparse:
-	@$(MAKE) $(QUIET_MAKE) -C "$(JULIAHOME)" -f "$(JULIAHOME)/contrib/refresh_checksums.mk" pack-checksum-suitesparse
+pack-checksum-libsuitesparse: | pack-checksum-suitesparse
+	@# nothing to do but disable the prefix rule
 
 # define how to pack parallel checksums into a single file format
 pack-checksum-%: FORCE

--- a/contrib/refresh_checksums.mk
+++ b/contrib/refresh_checksums.mk
@@ -106,6 +106,7 @@ pack-checksum-compilersupportlibraries: | checksum-csl
 # We need to adjust to the fact that the checksum files are called `suitesparse`
 pack-checksum-libsuitesparse: | pack-checksum-suitesparse
 	@# nothing to do but disable the prefix rule
+pack-checksum-suitesparse: | checksum-libsuitesparse
 
 # define how to pack parallel checksums into a single file format
 pack-checksum-%: FORCE


### PR DESCRIPTION
Without this change, suitesparse checksum files don't get packed
properly