### PR TITLE
compute mayinlinealloc more accurately (for ccall)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1395,6 +1395,8 @@ JL_CALLABLE(jl_f__typebody)
                     break;
                 }
             }
+            if (!dt->name->mutabl && !dt->name->references_self)
+                dt->name->mayinlinealloc = 1;
         }
     }
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -493,7 +493,7 @@ static Value *julia_to_native(
         assert(!byRef); // don't expect any ABI to pass pointers by pointer
         return boxed(ctx, jvinfo);
     }
-    assert(jl_is_datatype(jlto) && julia_struct_has_layout((jl_datatype_t*)jlto, jlto_env));
+    assert(jl_is_datatype(jlto) && julia_struct_has_layout((jl_datatype_t*)jlto));
 
     typeassert_input(ctx, jvinfo, jlto, jlto_env, argn);
     if (!byRef)
@@ -1065,7 +1065,7 @@ std::string generate_func_sig(const char *fname)
                 }
             }
 
-            t = _julia_struct_to_llvm(ctx, tti, unionall_env, &isboxed, llvmcall);
+            t = _julia_struct_to_llvm(ctx, tti, &isboxed, llvmcall);
             if (t == NULL || t == T_void) {
                 return make_errmsg(fname, i + 1, " doesn't correspond to a C type");
             }
@@ -1211,7 +1211,7 @@ static const std::string verify_ccall_sig(jl_value_t *&rt, jl_value_t *at,
         rt = (jl_value_t*)jl_any_type;
     }
 
-    lrt = _julia_struct_to_llvm(ctx, rt, unionall_env, &retboxed, llvmcall);
+    lrt = _julia_struct_to_llvm(ctx, rt, &retboxed, llvmcall);
     if (lrt == NULL)
         return "return type doesn't correspond to a C type";
 
@@ -1405,7 +1405,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             isboxed = false;
         }
         else {
-            largty = _julia_struct_to_llvm(&ctx.emission_context, tti, unionall, &isboxed, llvmcall);
+            largty = _julia_struct_to_llvm(&ctx.emission_context, tti, &isboxed, llvmcall);
         }
         if (isboxed) {
             ary = boxed(ctx, argv[0]);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -149,7 +149,7 @@ static Constant *julia_const_to_llvm(jl_codectx_t &ctx, const void *ptr, jl_data
     if (bt == jl_bool_type)
         return ConstantInt::get(T_int8, (*(const uint8_t*)ptr) ? 1 : 0);
 
-    Type *lt = julia_struct_to_llvm(ctx, (jl_value_t*)bt, NULL, NULL);
+    Type *lt = julia_struct_to_llvm(ctx, (jl_value_t*)bt, NULL);
 
     if (jl_is_vecelement_type((jl_value_t*)bt) && !jl_is_uniontype(jl_tparam0(bt)))
         bt = (jl_datatype_t*)jl_tparam0(bt);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -264,8 +264,6 @@ int jl_compile_extern_c(void *llvmmod, void *p, void *sysimg, jl_value_t *declrt
     return success;
 }
 
-bool jl_type_mappable_to_c(jl_value_t *ty);
-
 // declare a C-callable entry point; called during code loading from the toplevel
 extern "C" JL_DLLEXPORT
 void jl_extern_c(jl_value_t *declrt, jl_tupletype_t *sigt)
@@ -292,7 +290,7 @@ void jl_extern_c(jl_value_t *declrt, jl_tupletype_t *sigt)
     size_t i, nargs = jl_nparams(sigt);
     for (i = 1; i < nargs; i++) {
         jl_value_t *ati = jl_tparam(sigt, i);
-        if (!jl_is_concrete_type(ati) || jl_is_kind(ati))
+        if (!jl_is_concrete_type(ati) || jl_is_kind(ati) || !jl_type_mappable_to_c(ati))
             jl_error("@ccallable: argument types must be concrete");
     }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -432,6 +432,7 @@ typedef struct {
     uint8_t abstract;
     uint8_t mutabl;
     uint8_t references_self;
+    uint8_t mayinlinealloc;
     struct _jl_methtable_t *mt;
     jl_array_t *partial;     // incomplete instantiations of this type
 } jl_typename_t;
@@ -498,7 +499,6 @@ typedef struct _jl_datatype_t {
     uint8_t isdispatchtuple; // aka isleaftupletype
     uint8_t isbitstype; // relevant query for C-api and type-parameters
     uint8_t zeroinit; // if one or more fields requires zero-initialization
-    uint8_t isinlinealloc; // if this is allocated inline
     uint8_t has_concrete_subtype; // If clear, no value will have this datatype
     uint8_t cached_by_hash; // stored in hash-based set cache (instead of linear cache)
 } jl_datatype_t;
@@ -1048,7 +1048,6 @@ STATIC_INLINE jl_value_t *jl_field_type_concrete(jl_datatype_t *st JL_PROPAGATES
 #define jl_datatype_align(t)   (((jl_datatype_t*)t)->layout->alignment)
 #define jl_datatype_nbits(t)   ((((jl_datatype_t*)t)->size)*8)
 #define jl_datatype_nfields(t) (((jl_datatype_t*)(t))->layout->nfields)
-#define jl_datatype_isinlinealloc(t) (((jl_datatype_t *)(t))->isinlinealloc)
 
 JL_DLLEXPORT void *jl_symbol_name(jl_sym_t *s);
 // inline version with strong type check to detect typos in a `->name` chain

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -499,6 +499,8 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
 jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED;
 int jl_obviously_unequal(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_array_t *jl_find_free_typevars(jl_value_t *v);
+int jl_has_fixed_layout(jl_datatype_t *t);
+int jl_type_mappable_to_c(jl_value_t *ty);
 jl_svec_t *jl_outer_unionall_vars(jl_value_t *u);
 jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, int *issubty);
 jl_value_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
@@ -532,6 +534,7 @@ void jl_foreach_reachable_mtable(void (*visit)(jl_methtable_t *mt, void *env), v
 void jl_init_main_module(void);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent) JL_NOTSAFEPOINT;
 jl_array_t *jl_get_loaded_modules(void);
+int jl_datatype_isinlinealloc(jl_datatype_t *ty, int pointerfree);
 
 jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded);
 

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -192,7 +192,7 @@ The fields represent:
     perfdata_cb::Ptr{Cvoid}      = C_NULL
     perfdata_payload::Any        = Nothing
 end
-@assert CheckoutOptions.isinlinealloc
+@assert Base.allocatedinline(CheckoutOptions)
 
 """
     LibGit2.TransferProgress
@@ -209,7 +209,7 @@ Matches the [`git_indexer_progress`](https://libgit2.org/libgit2/#HEAD/type/git_
     indexed_deltas::Cuint   = Cuint(0)
     received_bytes::Csize_t = Csize_t(0)
 end
-@assert TransferProgress.isinlinealloc
+@assert Base.allocatedinline(TransferProgress)
 
 """
     LibGit2.RemoteCallbacks
@@ -235,7 +235,7 @@ Matches the [`git_remote_callbacks`](https://libgit2.org/libgit2/#HEAD/type/git_
         resolve_url::Ptr{Cvoid}        = C_NULL
     end
 end
-@assert RemoteCallbacks.isinlinealloc
+@assert Base.allocatedinline(RemoteCallbacks)
 
 """
     LibGit2.Callbacks
@@ -313,7 +313,7 @@ julia> fetch(remote, "master", options=fo)
     certificate_cb::Ptr{Cvoid}   = certificate_cb()
     payload::Any                 = nothing
 end
-@assert ProxyOptions.isinlinealloc
+@assert Base.allocatedinline(ProxyOptions)
 
 """
     LibGit2.FetchOptions
@@ -347,7 +347,7 @@ The fields represent:
         custom_headers::StrArrayStruct = StrArrayStruct()
     end
 end
-@assert FetchOptions.isinlinealloc
+@assert Base.allocatedinline(FetchOptions)
 
 
 """
@@ -384,7 +384,7 @@ The fields represent:
     remote_cb::Ptr{Cvoid}               = C_NULL
     remote_cb_payload::Any              = nothing
 end
-@assert CloneOptions.isinlinealloc
+@assert Base.allocatedinline(CloneOptions)
 
 """
     LibGit2.DiffOptionsStruct
@@ -438,7 +438,7 @@ The fields represent:
     old_prefix::Cstring                      = Cstring(C_NULL)
     new_prefix::Cstring                      = Cstring(C_NULL)
 end
-@assert DiffOptionsStruct.isinlinealloc
+@assert Base.allocatedinline(DiffOptionsStruct)
 
 """
     LibGit2.DescribeOptions
@@ -468,7 +468,7 @@ The fields represent:
     only_follow_first_parent::Cint    = Cint(0)
     show_commit_oid_as_fallback::Cint = Cint(0)
 end
-@assert DescribeOptions.isinlinealloc
+@assert Base.allocatedinline(DescribeOptions)
 
 """
     LibGit2.DescribeFormatOptions
@@ -487,7 +487,7 @@ The fields represent:
     always_use_long_format::Cint = Cint(0)
     dirty_suffix::Cstring        = Cstring(C_NULL)
 end
-@assert DescribeFormatOptions.isinlinealloc
+@assert Base.allocatedinline(DescribeFormatOptions)
 
 """
     LibGit2.DiffFile
@@ -617,7 +617,7 @@ The fields represent:
     file_favor::GIT_MERGE_FILE_FAVOR  = Consts.MERGE_FILE_FAVOR_NORMAL
     file_flags::GIT_MERGE_FILE        = Consts.MERGE_FILE_DEFAULT
 end
-@assert MergeOptions.isinlinealloc
+@assert Base.allocatedinline(MergeOptions)
 
 """
     LibGit2.BlameOptions
@@ -647,7 +647,7 @@ The fields represent:
     min_line::Csize_t                 = Csize_t(1)
     max_line::Csize_t                 = Csize_t(0)
 end
-@assert BlameOptions.isinlinealloc
+@assert Base.allocatedinline(BlameOptions)
 
 
 """
@@ -678,7 +678,7 @@ The fields represent:
         custom_headers::StrArrayStruct = StrArrayStruct()
     end
 end
-@assert PushOptions.isinlinealloc
+@assert Base.allocatedinline(PushOptions)
 
 
 """
@@ -701,7 +701,7 @@ The fields represent:
     merge_opts::MergeOptions = MergeOptions()
     checkout_opts::CheckoutOptions = CheckoutOptions()
 end
-@assert CherrypickOptions.isinlinealloc
+@assert Base.allocatedinline(CherrypickOptions)
 
 
 """
@@ -771,7 +771,7 @@ The fields represent:
     end
     checkout_opts::CheckoutOptions = CheckoutOptions()
 end
-@assert RebaseOptions.isinlinealloc
+@assert Base.allocatedinline(RebaseOptions)
 
 """
     LibGit2.RebaseOperation
@@ -834,7 +834,7 @@ The fields represent:
         baseline::Ptr{Cvoid} = C_NULL
     end
 end
-@assert StatusOptions.isinlinealloc
+@assert Base.allocatedinline(StatusOptions)
 
 """
     LibGit2.StatusEntry
@@ -902,7 +902,7 @@ Matches the [`git_config_entry`](https://libgit2.org/libgit2/#HEAD/type/git_conf
     free::Ptr{Cvoid}    = C_NULL
     payload::Any        = nothing
 end
-@assert ConfigEntry.isinlinealloc
+@assert Base.allocatedinline(ConfigEntry)
 
 function Base.show(io::IO, ce::ConfigEntry)
     print(io, "ConfigEntry(\"", unsafe_string(ce.name), "\", \"", unsafe_string(ce.value), "\")")
@@ -1136,7 +1136,7 @@ The fields represent:
 
     boundary::Char                        = '\0'
 end
-@assert BlameHunk.isinlinealloc
+@assert Base.allocatedinline(BlameHunk)
 
 """
     with(f::Function, obj)

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1443,15 +1443,28 @@ end
              eval(:(f20835(x) = ccall(:fn, Cvoid, (Ptr{typeof(x)},), x))))
 @test_throws(UndefVarError(:Something_not_defined_20835),
              eval(:(f20835(x) = ccall(:fn, Something_not_defined_20835, (Ptr{typeof(x)},), x))))
+@test isempty(methods(f20835))
 
-@noinline f21104at(::Type{T}) where {T} = ccall(:fn, Cvoid, (Some{T},), Some(0))
-@noinline f21104rt(::Type{T}) where {T} = ccall(:fn, Some{T}, ())
-@test code_llvm(devnull, f21104at, (Type{Float64},)) === nothing
-@test code_llvm(devnull, f21104rt, (Type{Float64},)) === nothing
-@test_throws(ErrorException("ccall argument 1 doesn't correspond to a C type"),
-             f21104at(Float64))
-@test_throws(ErrorException("ccall return type doesn't correspond to a C type"),
-             f21104rt(Float64))
+@test_throws(ErrorException("ccall method definition: argument 1 type doesn't correspond to a C type"),
+             @eval f21104(::Type{T}) where {T} = ccall(:fn, Cvoid, (Some{T},), Some(0)))
+@test_throws(ErrorException("ccall method definition: return type doesn't correspond to a C type"),
+             @eval f21104(::Type{T}) where {T} = ccall(:fn, Some{T}, ()))
+@test isempty(methods(f21104))
+@test_throws(ErrorException("ccall method definition: argument 1 type doesn't correspond to a C type"),
+             @eval if false; ccall(:fn, Cvoid, (Some.body,), Some(0)); end)
+@test_throws(ErrorException("ccall method definition: return type doesn't correspond to a C type"),
+             @eval if false; ccall(:fn, Some.body, ()); end)
+@test_throws(ErrorException("ccall method definition: return type doesn't correspond to a C type"),
+             @eval if false; ccall(:fn, Tuple, ()); end)
+## TODO: lowering is broken on this (throws "syntax: ssavalue with no def")
+#@test_throws(ErrorException("ccall method definition: return type doesn't correspond to a C type"),
+#             @eval if false; ccall(:fn, Tuple{Val{T}} where T, ()); end)
+@test_throws(ErrorException("ccall method definition: return type doesn't correspond to a C type"),
+             @eval if false; ccall(:fn, Tuple{Val}, ()); end)
+@test_throws(TypeError, @eval if false; ccall(:fn, Some.var, ()); end)
+@test_throws(TypeError, @eval if false; ccall(:fn, Cvoid, (Some.var,), Some(0)); end)
+@test_throws(ErrorException("ccall method definition: Vararg not allowed for argument list"),
+             @eval ccall(+, Int, (Vararg{Int},), 1))
 
 # test for malformed syntax errors
 @test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (), x)))
@@ -1482,21 +1495,20 @@ end
 
 evalf_callback_19805(ci::callinfos_19805{FUNC_FT}) where {FUNC_FT} = ci.f(0.5)::Float64
 
-evalf_callback_c_19805(ci::callinfos_19805{FUNC_FT}) where {FUNC_FT} = @cfunction(
-    evalf_callback_19805, Float64, (callinfos_19805{FUNC_FT},))
-
-@test_throws(ErrorException("cfunction argument 1 doesn't correspond to a C type"),
-             evalf_callback_c_19805( callinfos_19805(sin) ))
-@test_throws(ErrorException("cfunction argument 2 doesn't correspond to a C type"),
-             @cfunction(+, Int, (Int, Nothing)))
-@test_throws(ErrorException("cfunction: Vararg syntax not allowed for argument list"),
-             @cfunction(+, Int, (Vararg{Int},)))
+@test_throws(ErrorException("cfunction method definition: argument 1 type doesn't correspond to a C type"),
+             @eval evalf_callback_c_19805(ci::callinfos_19805{FUNC_FT}) where {FUNC_FT} =
+                 @cfunction(evalf_callback_19805, Float64, (callinfos_19805{FUNC_FT},)))
+@test isempty(methods(evalf_callback_c_19805))
+@test_throws(ErrorException("cfunction method definition: Vararg not allowed for argument list"),
+             @eval if false; @cfunction(+, Int, (Vararg{Int},)); end)
 @test_throws(ErrorException("could not evaluate cfunction argument type (it might depend on a local variable)"),
              @eval () -> @cfunction(+, Int, (Ref{T}, Ref{T})) where T)
 @test_throws(ErrorException("could not evaluate cfunction return type (it might depend on a local variable)"),
              @eval () -> @cfunction(+, Ref{T}, (Int, Int)) where T)
+@test_throws(ErrorException("cfunction argument 2 doesn't correspond to a C type"),
+             @eval @cfunction(+, Int, (Int, Nothing)))
 @test_throws(ErrorException("cfunction return type Ref{Any} is invalid. Use Any or Ptr{Any} instead."),
-             @cfunction(+, Ref{Any}, (Int, Int)))
+             @eval @cfunction(+, Ref{Any}, (Int, Int)))
 
 # test Ref{abstract_type} calling parameter passes a heap box
 abstract type Abstract22734 end


### PR DESCRIPTION
This allows code to assume that `->layout` will be assigned when
analyzing a type in codegen if the type is mapped to C. The ABI code
often assumes this, and it is also just much generally easier that the
jl_struct_to_llvm code can share the jl_compute_field_offsets results.