### PR TITLE
export spawn macro from Threads

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-export threadid, nthreads, @threads
+export threadid, nthreads, @threads, @spawn
 
 """
     Threads.threadid()


### PR DESCRIPTION
This PR exports `@spawn` from `Base.Threads` like other multithreading-related tools. If this is not intentional, I think this macro should be exported as well.