### PR TITLE
fix #40964, bad kwarg lowering for vararg with default value

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -431,7 +431,9 @@
          (body  (blockify body))
          (ftype (decl-type (car pargl)))
          ;; 1-element list of vararg argument, or empty if none
-         (vararg (let ((l (if (null? pargl) '() (last pargl))))
+         (vararg (let* ((l (if (null? pargl) '() (last pargl)))
+                        ;; handle vararg with default value
+                        (l (if (kwarg? l) (cadr l) l)))
                    (if (or (vararg? l) (varargexpr? l))
                        (list l) '())))
          ;; positional args with vararg

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -374,3 +374,9 @@ using InteractiveUtils
 no_kw_args(x::Int) = 0
 @test_throws MethodError no_kw_args(1, k=1)
 @test_throws MethodError no_kw_args("", k=1)
+
+# issue #40964
+f40964(xs::Int...=1; k = 2) = (xs, k)
+@test f40964() === ((1,), 2)
+@test f40964(7, 8) === ((7,8), 2)
+@test f40964(7, 8, k=0) === ((7,8), 0)


### PR DESCRIPTION
It's not clear if vararg and optional arg syntax should be allowed on the same argument, but it does work so might as well fix it for now.