### PR TITLE
Export standard log levels from Logging stdlib.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,10 @@ Standard library changes
 
 #### DelimitedFiles
 
+#### Logging
+* The standard log levels `BelowMinLevel`, `Debug`, `Info`, `Warn`, `Error`,
+  and `AboveMaxLevel` are now exported from the Logging stdlib ([#40980]).
+
 
 Deprecated or removed
 ---------------------

--- a/base/show.jl
+++ b/base/show.jl
@@ -1020,7 +1020,7 @@ show_supertypes(typ::DataType) = show_supertypes(stdout, typ)
 
 Prints one or more expressions, and their results, to `stdout`, and returns the last result.
 
-See also: [`show`](@ref), [`@info`](@ref Logging), [`println`](@ref).
+See also: [`show`](@ref), [`@info`](@ref man-logging), [`println`](@ref).
 
 # Examples
 ```jldoctest

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -272,7 +272,7 @@ should have at the terminal.
 
 ### `JULIA_DEBUG`
 
-Enable debug logging for a file or module, see [`Logging`](@ref Logging) for more information.
+Enable debug logging for a file or module, see [`Logging`](@ref man-logging) for more information.
 
 ### `JULIA_GC_ALLOC_POOL`, `JULIA_GC_ALLOC_OTHER`, `JULIA_GC_ALLOC_PRINT`
 

--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -1,4 +1,4 @@
-# Logging
+# [Logging](@id man-logging)
 
 The [`Logging`](@ref Logging.Logging) module provides a way to record the history and progress of a
 computation as a log of events.  Events are created by inserting a logging

--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -72,7 +72,13 @@ export
     global_logger,
     disable_logging,
     SimpleLogger,
-    ConsoleLogger
+    ConsoleLogger,
+    BelowMinLevel,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    AboveMaxLevel
 
 include("ConsoleLogger.jl")
 

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -259,4 +259,20 @@ end
 
 end
 
+@testset "exported names" begin
+    m = Module(:ExportedLoggingNames)
+    include_string(m, """
+        using Logging
+        function run()
+            BelowMinLevel === Logging.BelowMinLevel &&
+            Debug === Logging.Debug &&
+            Info === Logging.Info &&
+            Warn === Logging.Warn &&
+            Error === Logging.Error &&
+            AboveMaxLevel === Logging.AboveMaxLevel
+        end
+        """)
+    @test m.run()
+end
+
 end

--- a/stdlib/Test/src/logging.jl
+++ b/stdlib/Test/src/logging.jl
@@ -1,8 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Logging
-import Logging: Info,
-    shouldlog, handle_message, min_enabled_level, catch_exceptions
+using Logging: Logging, AbstractLogger, LogLevel, Info, with_logger
 import Base: occursin
 
 #-------------------------------------------------------------------------------
@@ -30,22 +28,23 @@ mutable struct TestLogger <: AbstractLogger
     shouldlog_args
 end
 
-TestLogger(; min_level=Info, catch_exceptions=false) = TestLogger(LogRecord[], min_level, catch_exceptions, nothing)
-min_enabled_level(logger::TestLogger) = logger.min_level
+TestLogger(; min_level=Info, catch_exceptions=false) =
+    TestLogger(LogRecord[], min_level, catch_exceptions, nothing)
+Logging.min_enabled_level(logger::TestLogger) = logger.min_level
 
-function shouldlog(logger::TestLogger, level, _module, group, id)
+function Logging.shouldlog(logger::TestLogger, level, _module, group, id)
     logger.shouldlog_args = (level, _module, group, id)
     true
 end
 
-function handle_message(logger::TestLogger, level, msg, _module,
-                        group, id, file, line; kwargs...)
+function Logging.handle_message(logger::TestLogger, level, msg, _module,
+                                group, id, file, line; kwargs...)
     @nospecialize
     push!(logger.logs, LogRecord(level, msg, _module, group, id, file, line, kwargs))
 end
 
 # Catch exceptions for the test logger only if specified
-catch_exceptions(logger::TestLogger) = logger.catch_exceptions
+Logging.catch_exceptions(logger::TestLogger) = logger.catch_exceptions
 
 function collect_test_logs(f; kwargs...)
     logger = TestLogger(; kwargs...)


### PR DESCRIPTION
Is there a reason these are not exported?