### PR TITLE
Add a hint when failing to import a module in cases where a user might want to use a relative import

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -976,9 +976,9 @@ function require(into::Module, mod::Symbol)
             where = PkgId(into)
             if where.uuid === nothing
                 hint, dots = begin
-                    if isdefined(into, mod)
+                    if isdefined(into, mod) && getfield(into, mod) isa Module
                         true, "."
-                    elseif isdefined(parentmodule(into), mod)
+                    elseif isdefined(parentmodule(into), mod) && getfield(parentmodule(into), mod) isa Module
                         true, ".."
                     else
                         false, ""
@@ -987,7 +987,8 @@ function require(into::Module, mod::Symbol)
                 hint_message = hint ? ", maybe you meant `import/using $(dots)$(mod)`" : ""
                 start_sentence = hint ? "Otherwise, run" : "Run"
                 throw(ArgumentError("""
-                    Package $mod not found in current path$hint_message. $start_sentence `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package."""))
+                    Package $mod not found in current path$hint_message.
+                    - $start_sentence `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package."""))
             else
                 s = """
                 Package $(where.name) does not have $mod in its dependencies:

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -975,10 +975,19 @@ function require(into::Module, mod::Symbol)
         if uuidkey === nothing
             where = PkgId(into)
             if where.uuid === nothing
+                hint, dots = begin
+                    if isdefined(into, mod)
+                        true, "."
+                    elseif isdefined(parentmodule(into), mod)
+                        true, ".."
+                    else
+                        false, ""
+                    end
+                end
+                hint_message = hint ? ", maybe you meant `import/using $(dots)$(mod)`" : ""
+                start_sentence = hint ? "Otherwise, run" : "Run"
                 throw(ArgumentError("""
-                    Package $mod not found in current path:
-                    - Run `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package.
-                    """))
+                    Package $mod not found in current path$hint_message. $start_sentence `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package."""))
             else
                 s = """
                 Package $(where.name) does not have $mod in its dependencies:

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -815,6 +815,19 @@ end  # Sys.isapple()
 
     m = Module()
     expr = :(module Foo
+        Bar = 3
+
+        using Bar
+    end)
+    try
+        Base.eval(m, expr)
+    catch err
+        err_str = sprint(showerror, err)
+        @test !contains(err_str, "maybe you meant `import/using .Bar`")
+    end
+
+    m = Module()
+    expr = :(module Foo
         using Bar
     end)
     try
@@ -836,6 +849,20 @@ end  # Sys.isapple()
     catch err
         err_str = sprint(showerror, err)
         @test contains(err_str, "maybe you meant `import/using ..Bar`")
+    end
+
+    m = Module()
+    expr = :(module Foo
+        Bar = 3
+        module Buzz
+            using Bar
+        end
+    end)
+    try
+        Base.eval(m, expr)
+    catch err
+        err_str = sprint(showerror, err)
+        @test !contains(err_str, "maybe you meant `import/using ..Bar`")
     end
 
     m = Module()

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -797,3 +797,59 @@ if Sys.isapple() || (Sys.islinux() && Sys.ARCH === :x86_64)
         end
     end
 end  # Sys.isapple()
+
+@testset "error message hints relative modules #40959" begin
+    m = Module()
+    expr = :(module Foo
+        module Bar
+        end
+
+        using Bar
+    end)
+    try
+        Base.eval(m, expr)
+    catch err
+        err_str = sprint(showerror, err)
+        @test contains(err_str, "maybe you meant `import/using .Bar`")
+    end
+
+    m = Module()
+    expr = :(module Foo
+        using Bar
+    end)
+    try
+        Base.eval(m, expr)
+    catch err
+        err_str = sprint(showerror, err)
+        @test !contains(err_str, "maybe you meant `import/using .Bar`")
+    end
+
+    m = Module()
+    expr = :(module Foo
+        module Bar end
+        module Buzz
+            using Bar
+        end
+    end)
+    try
+        Base.eval(m, expr)
+    catch err
+        err_str = sprint(showerror, err)
+        @test contains(err_str, "maybe you meant `import/using ..Bar`")
+    end
+
+    m = Module()
+    expr = :(module Foo
+        module Bar end
+        module Buzz
+            module Bar end
+            using Bar
+        end
+    end)
+    try
+        Base.eval(m, expr)
+    catch err
+        err_str = sprint(showerror, err)
+        @test contains(err_str, "maybe you meant `import/using .Bar`")
+    end
+end


### PR DESCRIPTION
Fixes #40959 

```jl
julia> module Foo
           a = 5
           export a
       end
Main.Foo

julia> using Foo
ERROR: ArgumentError: Package Foo not found in current path, maybe you meant `import/using .Foo`. Otherwise, run `import Pkg; Pkg.add("Foo")` to install the Foo package.
Stacktrace:
 [1] require(into::Module, mod::Symbol)
   @ Base ./REPL[1]:19

