### PR TITLE
fix #40814, fix type inference regression introduced in #40379

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3289,6 +3289,9 @@ end == [Union{Some{Float64}, Some{Int}, Some{UInt8}}]
     end
 end
 
+# https://github.com/JuliaLang/julia/issues/40814
+@test Base.return_types(NTuple{3,Int}, (Vector{Int},)) == Any[NTuple{3,Int}]
+
 # Make sure that const prop doesn't fall into cycles that aren't problematic
 # in the type domain
 f_recurse(x) = x > 1000000 ? x : f_recurse(x+1)


### PR DESCRIPTION
Fixes the inference regression, while retaining the cases addressed by
<https://github.com/JuliaLang/julia/pull/40379>.

The same `Type`-name comparison pass (i.e. a branch of `isa(c, DataType) && t.name === c.name`)
can lead to more accurate result by recursive comparison than `isType`
check pass (i.e. a branch of `isType(t)`), and preferring the former
over the latter fixes the regression.

But just swapping the branch will lead to <https://github.com/JuliaLang/julia/issues/40336>,
and so this PR also implements additional check to make sure `type_more_complex`
still detects a single-level nesting correctly (especially, the `tt === c` parts).