### PR TITLE
Speed up `mapslices`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2844,8 +2844,8 @@ function mapslices(f, A::AbstractArray; dims)
     isempty(dims) && return map(f, A)
 
     for d in dims
-        d isa Integer || throw(ArgumentError("dimension must be integers, got $d"))
-        d >= 1 || throw(ArgumentError("dimension must be ≥ 1, got $d"))
+        d isa Integer || throw(ArgumentError("mapslices: dimension must be an integer, got dims = $d"))
+        d >= 1 || throw(ArgumentError("mapslices: dimension must be ≥ 1, got dims = $d"))
         # Indexing a matrix M[:,1,:] produces a 1-column matrix, but dims=(1,3) here
         # would otherwise ignore 3, and slice M[:,i]. Previously this gave error:
         # BoundsError: attempt to access 2-element Vector{Any} at index [3]
@@ -2862,7 +2862,7 @@ function mapslices(f, A::AbstractArray; dims)
         n = sum(dim_mask)
         if ndims(r1) > n && any(ntuple(d -> size(r1,d+n)>1, ndims(r1)-n))
             s = size(r1)[1:n]
-            throw(DimensionMismatch("cannot assign slice f(x) of size $(size(r1)) into output of size $s"))
+            throw(DimensionMismatch("mapslices cannot assign slice f(x) of size $(size(r1)) into output of size $s"))
         end
         r1
     else

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2844,12 +2844,12 @@ function mapslices(f, A::AbstractArray; dims)
     isempty(dims) && return map(f, A)
 
     for d in dims
-        d isa Integer || throw(ArgumentError("mapslices: dimension must be an integer, got dims = $d"))
-        d >= 1 || throw(ArgumentError("mapslices: dimension must be ≥ 1, got dims = $d"))
+        d isa Integer || throw(ArgumentError("mapslices: dimension must be an integer, got $d"))
+        d >= 1 || throw(ArgumentError("mapslices: dimension must be ≥ 1, got $d"))
         # Indexing a matrix M[:,1,:] produces a 1-column matrix, but dims=(1,3) here
         # would otherwise ignore 3, and slice M[:,i]. Previously this gave error:
         # BoundsError: attempt to access 2-element Vector{Any} at index [3]
-        d > ndims(A) && throw(ArgumentError("mapslices does not accept dims > ndims(A)"))
+        d > ndims(A) && throw(ArgumentError("mapslices does not accept dimensions > ndims(A) = $(ndims(A)), got $d"))
     end
     dim_mask = ntuple(d -> d in dims, ndims(A))
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2839,6 +2839,7 @@ function mapslices(f, A::AbstractArray; dims)
     isempty(dims) && return map(f, A)
 
     for d in dims
+        d >= 1 || throw(ArgumentError("dimension must be ≥ 1, got $d"))
         # Indexing a matrix M[:,1,:] produces a 1-column matrix, but dims=(1,3) here
         # would otherwise ignore 3, and slice M[:,i]. Previously this gave error:
         # BoundsError: attempt to access 2-element Vector{Any} at index [3]

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2843,7 +2843,7 @@ function mapslices(f, A::AbstractArray; dims)
         res1[begin] = r1
     end
 
-    # Determine result size and allocate. We always pad ndims(res1) out to length(dims)    
+    # Determine result size and allocate. We always pad ndims(res1) out to length(dims):
     din = 0
     Rsize = ntuple(ndims(A)) do d
         if d in dims
@@ -2854,13 +2854,13 @@ function mapslices(f, A::AbstractArray; dims)
     end
     R = similar(res1, Rsize)
 
-    # Determine iteration space. It will be convenient in the loop to mask N-dimensional 
+    # Determine iteration space. It will be convenient in the loop to mask N-dimensional
     # CartesianIndices, with some trivial dimensions:
     dim_mask = ntuple(d -> d in dims, ndims(A))
     itershape = ifelse.(dim_mask, Ref(Base.OneTo(1)), axes(A))
     indices = Iterators.drop(CartesianIndices(itershape), 1)
 
-    # That skips the first element, which we already have: 
+    # That skips the first element, which we already have:
     ridx = ifelse.(dim_mask, Slice.(axes(R)), idx1)
     concatenate_setindex!(R, res1, ridx...)
 
@@ -2893,16 +2893,11 @@ end
             end
         end
     else
+        # we can't guarantee safety (#18524), so allocate new storage for each slice
         for I in indices
             idx = ifelse.(dim_mask, Slice.(axes(A)), Tuple(I))
-            r = f(A[idx...])
-            if r isa AbstractArray || must_extend
-                ridx = ifelse.(dim_mask, Slice.(axes(R)), Tuple(I))
-                concatenate_setindex!(R, r, ridx...)
-            else
-                ridx = ifelse.(dim_mask, first.(axes(R)), Tuple(I))
-                R[ridx...] = r
-            end
+            ridx = ifelse.(dim_mask, Slice.(axes(R)), Tuple(I))
+            concatenate_setindex!(R, f(A[idx...]), ridx...)
         end
     end
 end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2790,7 +2790,7 @@ See also [`eachcol`](@ref), [`eachslice`](@ref), [`mapreduce`](@ref).
 # Examples
 ```jldoctest
 julia> A = reshape(1:30,(2,5,3))
-2×5×3 reshape(::UnitRange{$Int}, 2, 5, 3) with eltype Int64:
+2×5×3 reshape(::UnitRange{$Int}, 2, 5, 3) with eltype $Int:
 [:, :, 1] =
  1  3  5  7   9
  2  4  6  8  10
@@ -2830,6 +2830,9 @@ julia> map(g, eachslice(A, dims=2))
  1//5
  7//27
  9//29
+
+julia> mapslices(sum, A; dims=(1,3)) == sum(A; dims=(1,3))
+true
 ```
 """
 function mapslices(f, A::AbstractArray; dims)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2778,47 +2778,58 @@ foreach(f, itrs...) = (for z in zip(itrs...); f(z...); end; nothing)
 """
     mapslices(f, A; dims)
 
-Transform the given dimensions of array `A` using function `f`. `f` is called on each slice
-of `A` of the form `A[...,:,...,:,...]`. `dims` is an integer vector specifying where the
-colons go in this expression. The results are concatenated along the remaining dimensions.
-For example, if `dims` is `[1,2]` and `A` is 4-dimensional, `f` is called on `A[:,:,i,j]`
-for all `i` and `j`.
+Transform the given dimensions of array `A` by applying a function `f` on each slice
+of the form `A[..., :, ..., :, ...]`, with a colon at each `d` in `dims`. The results are
+concatenated along the remaining dimensions.
 
-See also [`eachcol`](@ref), [`eachslice`](@ref).
+For example, if `dims = [1,2]` and `A` is 4-dimensional, then `f` is called on `x = A[:,:,i,j]`
+for all `i` and `j`, and `f(x)` becomes `R[:,:,i,j]` in the result `R`.
+
+See also [`eachcol`](@ref), [`eachslice`](@ref), [`mapreduce`](@ref).
 
 # Examples
 ```jldoctest
-julia> a = reshape(Vector(1:16),(2,2,2,2))
-2×2×2×2 Array{Int64, 4}:
-[:, :, 1, 1] =
- 1  3
- 2  4
+julia> A = reshape(1:30,(2,5,3))
+2×5×3 reshape(::UnitRange{$Int}, 2, 5, 3) with eltype Int64:
+[:, :, 1] =
+ 1  3  5  7   9
+ 2  4  6  8  10
 
-[:, :, 2, 1] =
- 5  7
- 6  8
+[:, :, 2] =
+ 11  13  15  17  19
+ 12  14  16  18  20
 
-[:, :, 1, 2] =
-  9  11
- 10  12
+[:, :, 3] =
+ 21  23  25  27  29
+ 22  24  26  28  30
 
-[:, :, 2, 2] =
- 13  15
- 14  16
+julia> f(x::Matrix) = fill(x[1,1], 1,4);  # returns a 1×4 matrix
 
-julia> mapslices(sum, a, dims = [1,2])
-1×1×2×2 Array{Int64, 4}:
-[:, :, 1, 1] =
- 10
+julia> mapslices(f, A, dims=(1,2))
+1×4×3 Array{$Int, 3}:
+[:, :, 1] =
+ 1  1  1  1
 
-[:, :, 2, 1] =
- 26
+[:, :, 2] =
+ 11  11  11  11
 
-[:, :, 1, 2] =
- 42
+[:, :, 3] =
+ 21  21  21  21
 
-[:, :, 2, 2] =
- 58
+julia> g(x) = x[begin] // x[end-1];  # returns a number
+
+julia> mapslices(g, A, dims=[1,3])
+1×5×1 Array{Rational{$Int}, 3}:
+[:, :, 1] =
+ 1//21  3//23  1//5  7//27  9//29
+
+julia> map(g, eachslice(A, dims=2))
+5-element Vector{Rational{$Int}}:
+ 1//21
+ 3//23
+ 1//5
+ 7//27
+ 9//29
 ```
 """
 function mapslices(f, A::AbstractArray; dims)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2834,6 +2834,11 @@ julia> map(g, eachslice(A, dims=2))
 julia> mapslices(sum, A; dims=(1,3)) == sum(A; dims=(1,3))
 true
 ```
+
+Notice that in `eachslice(A; dims=2)`, the specified dimension is the
+one *without* a colon in the slice. This is `view(A,:,i,:)`, whereas
+`mapslices(f, A; dims=(1,3))` uses `A[:,i,:]`. The function `f` may mutate
+values in the slice without affecting `A`.
 """
 function mapslices(f, A::AbstractArray; dims)
     isempty(dims) && return map(f, A)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2838,6 +2838,13 @@ true
 function mapslices(f, A::AbstractArray; dims)
     isempty(dims) && return map(f, A)
 
+    for d in dims
+        # Indexing a matrix M[:,1,:] produces a matrix, but dims=(1,3) here would 
+        # otherwise ignore 3. Previously this gave error:
+        # BoundsError: attempt to access 2-element Vector{Any} at index [3]
+        d > ndims(A) && throw(ArgumentError("mapslices does not accept dims > ndims(A)"))
+    end
+
     # Apply the function to the first slice in order to determine the next steps
     idx1 = ntuple(d -> d in dims ? (:) : firstindex(A,d), ndims(A))
     Aslice = A[idx1...]

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2853,19 +2853,20 @@ function mapslices(f, A::AbstractArray; dims)
     Aslice = A[idx1...]
     r1 = f(Aslice)
 
-    if r1 isa AbstractArray && ndims(r1) > 0
+    res1 = if r1 isa AbstractArray && ndims(r1) > 0
         n = sum(dim_mask)
         if ndims(r1) > n && any(ntuple(d -> size(r1,d+n)>1, ndims(r1)-n))
             s = size(r1)[1:n]
             throw(DimensionMismatch("cannot assign slice f(x) of size $(size(r1)) into output of size $s"))
         end
-        res1 = r1
+        r1
     else
         # If the result of f on a single slice is a scalar then we add singleton
         # dimensions. When adding the dimensions, we have to respect the
         # index type of the input array (e.g. in the case of OffsetArrays)
-        res1 = similar(Aslice, typeof(r1), reduced_indices(Aslice, 1:ndims(Aslice)))
-        res1[begin] = r1
+        _res1 = similar(Aslice, typeof(r1), reduced_indices(Aslice, 1:ndims(Aslice)))
+        _res1[begin] = r1
+        _res1
     end
 
     # Determine result size and allocate. We always pad ndims(res1) out to length(dims):

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2839,8 +2839,8 @@ function mapslices(f, A::AbstractArray; dims)
     isempty(dims) && return map(f, A)
 
     for d in dims
-        # Indexing a matrix M[:,1,:] produces a matrix, but dims=(1,3) here would 
-        # otherwise ignore 3. Previously this gave error:
+        # Indexing a matrix M[:,1,:] produces a 1-column matrix, but dims=(1,3) here
+        # would otherwise ignore 3, and slice M[:,i]. Previously this gave error:
         # BoundsError: attempt to access 2-element Vector{Any} at index [3]
         d > ndims(A) && throw(ArgumentError("mapslices does not accept dims > ndims(A)"))
     end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1202,12 +1202,14 @@ end
     # issue #21123
     @test mapslices(nnz, sparse(1.0I, 3, 3), dims=1) == [1 1 1]
 
-    # path which doesn't re-use Aslice
-    r = rand(Int8, 2,3,4)
+    r = rand(Int8, 4,5,2)
     @test mapslices(transpose, r, dims=(1,3)) == permutedims(r, (3,2,1))
     @test vec(mapslices(repr, r, dims=(2,1))) == map(repr, eachslice(r, dims=3))
+    @test mapslices(cumsum, sparse(r[:,:,1]), dims=1) == cumsum(r[:,:,1], dims=1)
+    @test mapslices(prod, sparse(r[:,:,1]), dims=1) == prod(r[:,:,1], dims=1)
 
     # re-write, #40996
+    @test_throws ArgumentError mapslices(identity, rand(2,3), dims=0) # previously BoundsError
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=(1,3)) # previously BoundsError
     @test_throws DimensionMismatch mapslices(x -> x * x', rand(2,3), dims=1) # explicitly caught
     @test mapslices(hcat, [1 2; 3 4], dims=1) == [1 2; 3 4] # previously an error, now allowed

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1199,6 +1199,12 @@ end
     m = mapslices(x->tuple(x), [1 2; 3 4], dims=1)
     @test m[1,1] == ([1,3],)
     @test m[1,2] == ([2,4],)
+
+    # issue #21123
+    @test mapslices(nnz, sparse(1.0I, 3, 3), dims=1) == [1 1 1]
+
+    # re-write, #40996
+    @test_throws ArgumentError mapslices(identity, rand(2,3), dims=(1,3)) # previously BoundsError
 end
 
 @testset "single multidimensional index" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1195,26 +1195,21 @@ end
     @test o == fill(1, 3, 4)
 
     # issue #18524
-    # m = mapslices(x->tuple(x), [1 2; 3 4], dims=1) # fails, see variations below
+    # m = mapslices(x->tuple(x), [1 2; 3 4], dims=1) # see variations of this below
+    # ERROR: fatal error in type inference (type bound), https://github.com/JuliaLang/julia/issues/43064
     # @test m[1,1] == ([1,3],)
     # @test m[1,2] == ([2,4],)
 
-    # issue #21123
-    @test mapslices(nnz, sparse(1.0I, 3, 3), dims=1) == [1 1 1]
-
     r = rand(Int8, 4,5,2)
     @test vec(mapslices(repr, r, dims=(2,1))) == map(repr, eachslice(r, dims=3))
-    @test mapslices(cumsum, sparse(r[:,:,1]), dims=1) == cumsum(r[:,:,1], dims=1)
-
     @test mapslices(tuple, [1 2; 3 4], dims=1) == [([1, 3],)  ([2, 4],)]
     @test mapslices(transpose, r, dims=(1,3)) == permutedims(r, (3,2,1))
 
     # failures
     @test_broken @inferred(mapslices(tuple, [1 2; 3 4], dims=1)) == [([1, 3],)  ([2, 4],)]
-    # https://github.com/JuliaLang/julia/issues/43064 -- "fatal error in type inference (type bound)"
+    # ERROR: fatal error in type inference (type bound), https://github.com/JuliaLang/julia/issues/43064
     @test_broken @inferred(mapslices(x -> tuple(x), [1 2; 3 4], dims=1)) == [([1, 3],)  ([2, 4],)]
     @test_broken @inferred(mapslices(transpose, r, dims=(1,3))) == permutedims(r, (3,2,1))
-    @test_broken mapslices(prod, sparse(r[:,:,1]), dims=1) == prod(r[:,:,1], dims=1)
 
     # re-write, #40996
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=0) # previously BoundsError

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1173,7 +1173,6 @@ end
     @test mapslices(prod,["1"],dims=1) == ["1"]
 
     # issue #5177
-
     c = fill(1,2,3,4)
     m1 = mapslices(_ -> fill(1,2,3), c, dims=[1,2])
     m2 = mapslices(_ -> fill(1,2,4), c, dims=[1,3])
@@ -1203,10 +1202,16 @@ end
     # issue #21123
     @test mapslices(nnz, sparse(1.0I, 3, 3), dims=1) == [1 1 1]
 
+    # path which doesn't re-use Aslice
+    r = rand(Int8, 2,3,4)
+    @test mapslices(transpose, r, dims=(1,3)) == permutedims(r, (3,2,1))
+    @test vec(mapslices(repr, r, dims=(2,1))) == map(repr, eachslice(r, dims=3))
+
     # re-write, #40996
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=(1,3)) # previously BoundsError
     @test_throws DimensionMismatch mapslices(x -> x * x', rand(2,3), dims=1) # explicitly caught
     @test mapslices(hcat, [1 2; 3 4], dims=1) == [1 2; 3 4] # previously an error, now allowed
+    @test mapslices(identity, [1 2; 3 4], dims=(2,2)) == [1 2; 3 4] # previously an error
 end
 
 @testset "single multidimensional index" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1205,6 +1205,8 @@ end
 
     # re-write, #40996
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=(1,3)) # previously BoundsError
+    @test_throws DimensionMismatch mapslices(x -> x * x', rand(2,3), dims=1) # explicitly caught
+    @test mapslices(hcat, [1 2; 3 4], dims=1) == [1 2; 3 4] # previously an error, now allowed
 end
 
 @testset "single multidimensional index" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1207,16 +1207,17 @@ end
 
     # failures
     @test_broken @inferred(mapslices(tuple, [1 2; 3 4], dims=1)) == [([1, 3],)  ([2, 4],)]
+    @test_broken @inferred(mapslices(transpose, r, dims=(1,3))) == permutedims(r, (3,2,1))
     # ERROR: fatal error in type inference (type bound), https://github.com/JuliaLang/julia/issues/43064
     @test_broken @inferred(mapslices(x -> tuple(x), [1 2; 3 4], dims=1)) == [([1, 3],)  ([2, 4],)]
-    @test_broken @inferred(mapslices(transpose, r, dims=(1,3))) == permutedims(r, (3,2,1))
 
     # re-write, #40996
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=0) # previously BoundsError
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=(1,3)) # previously BoundsError
     @test_throws DimensionMismatch mapslices(x -> x * x', rand(2,3), dims=1) # explicitly caught
     @test @inferred(mapslices(hcat, [1 2; 3 4], dims=1)) == [1 2; 3 4] # previously an error, now allowed
-    @test @inferred(mapslices(identity, [1 2; 3 4], dims=(2,2))) == [1 2; 3 4] # previously an error
+    @test mapslices(identity, [1 2; 3 4], dims=(2,2)) == [1 2; 3 4] # previously an error
+    @test_broken @inferred(mapslices(identity, [1 2; 3 4], dims=(2,2))) == [1 2; 3 4]
 end
 
 @testset "single multidimensional index" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1203,7 +1203,7 @@ end
     @test mapslices(nnz, sparse(1.0I, 3, 3), dims=1) == [1 1 1]
 
     r = rand(Int8, 4,5,2)
-    @test mapslices(transpose, r, dims=(1,3)) == permutedims(r, (3,2,1))
+    @test @inferred(mapslices(transpose, r, dims=(1,3))) == permutedims(r, (3,2,1))
     @test vec(mapslices(repr, r, dims=(2,1))) == map(repr, eachslice(r, dims=3))
     @test mapslices(cumsum, sparse(r[:,:,1]), dims=1) == cumsum(r[:,:,1], dims=1)
     @test mapslices(prod, sparse(r[:,:,1]), dims=1) == prod(r[:,:,1], dims=1)
@@ -1212,8 +1212,8 @@ end
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=0) # previously BoundsError
     @test_throws ArgumentError mapslices(identity, rand(2,3), dims=(1,3)) # previously BoundsError
     @test_throws DimensionMismatch mapslices(x -> x * x', rand(2,3), dims=1) # explicitly caught
-    @test mapslices(hcat, [1 2; 3 4], dims=1) == [1 2; 3 4] # previously an error, now allowed
-    @test mapslices(identity, [1 2; 3 4], dims=(2,2)) == [1 2; 3 4] # previously an error
+    @test @inferred(mapslices(hcat, [1 2; 3 4], dims=1)) == [1 2; 3 4] # previously an error, now allowed
+    @test @inferred(mapslices(identity, [1 2; 3 4], dims=(2,2))) == [1 2; 3 4] # previously an error
 end
 
 @testset "single multidimensional index" begin


### PR DESCRIPTION
This does a little tidying up of `mapslices`, to work internally with tuples instead of mutating arrays of indices, and to avoid broadcasting in the inner loop where possible. There should be no functional changes. It's still not type stable, but it is a bit faster:
```julia
julia> @btime mapslices(cumsum, $(rand(10,100)), dims=1);
  26.250 μs (631 allocations: 39.47 KiB)  # master
  4.756 μs (116 allocations: 22.45 KiB))  # this PR

julia> @btime reduce(hcat, map(cumsum, eachcol($(rand(10,100)))));  # perhaps preferred?
  2.898 μs (102 allocations: 22.88 KiB)

julia> @btime cumsum($(rand(10,100)), dims=1); # for reference, without slices
  409.091 ns (1 allocation: 7.94 KiB)

julia> @btime mapslices(prod, $(rand(100,10)), dims=2);
  25.500 μs (835 allocations: 23.25 KiB)  # master
  1.433 μs (21 allocations: 1.50 KiB)     # this PR

julia> @btime map(prod, eachrow($(rand(100,10))));  # certainly better!
  526.393 ns (1 allocation: 896 bytes)

julia> @btime prod($(rand(100,10)), dims=2); # for reference, without slices
  292.286 ns (5 allocations: 976 bytes)
``` 