### PR TITLE
Indexing OneTo with IdentityUnitRange preserves axes

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -400,6 +400,10 @@ getindex(S::IdentityUnitRange, i::StepRange{<:Integer}) = (@_inline_meta; @bound
 show(io::IO, r::IdentityUnitRange) = print(io, "Base.IdentityUnitRange(", r.indices, ")")
 iterate(S::IdentityUnitRange, s...) = iterate(S.indices, s...)
 
+# For OneTo, the values and indices of the values are identical, so this may be defined in Base.
+# In general such an indexing operation would produce offset ranges
+getindex(S::OneTo, I::IdentityUnitRange{<:AbstractUnitRange{<:Integer}}) = (@_inline_meta; @boundscheck checkbounds(S, I); I)
+
 """
     LinearIndices(A::AbstractArray)
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1933,3 +1933,13 @@ end
     @test (10:-1:1) * 0.1 == 1:-0.1:0.1
     @test 0.2 * (-2:2:2) == [-0.4, 0, 0.4]
 end
+
+@testset "Indexing OneTo with IdentityUnitRange" begin
+    for endpt in Any[10, big(10), UInt(10)]
+        r = Base.OneTo(endpt)
+        inds = Base.IdentityUnitRange(3:5)
+        rs = r[inds]
+        @test rs === inds
+        @test_throws BoundsError r[Base.IdentityUnitRange(-1:100)]
+    end
+end


### PR DESCRIPTION
On master:
```julia
julia> Base.OneTo(10)[Base.IdentityUnitRange(2:7)]
2:7
```

After this PR:
```julia
julia> Base.OneTo(10)[Base.IdentityUnitRange(2:7)]
Base.IdentityUnitRange(2:7)
```