### PR TITLE
More efficient `mapreduce(f, op, A, B, C; init)`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2931,6 +2931,7 @@ map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 mapany(f, A::AbstractArray) = map!(f, Vector{Any}(undef, length(A)), A)
 mapany(f, itr) = Any[f(x) for x in itr]
 
+# default to returning an Array for `map` on general iterators
 """
     map(f, c...) -> collection
 
@@ -2954,36 +2955,6 @@ julia> map(+, [1, 2, 3], [10, 20, 30, 400, 5000])
  33
 ```
 """
-map
-
-"""
-    map(f, A::AbstractArray...) -> N-array
-
-When acting on multi-dimensional arrays of the same [`ndims`](@ref),
-they must all have the same [`axes`](@ref), and the answer will too.
-
-See also [`broadcast`](@ref), which allows mismatched sizes.
-
-# Examples
-```
-julia> map(//, [1 2; 3 4], [4 3; 2 1])
-2×2 Matrix{Rational{$Int}}:
- 1//4  2//3
- 3//2  4//1
-
-julia> map(+, [1 2; 3 4], zeros(2,1))
-ERROR: DimensionMismatch
-
-julia> map(+, [1 2; 3 4], [1,10,100,1000], zeros(3,1))  # iterates until 3rd is exhausted
-3-element Vector{Float64}:
-   2.0
-  13.0
- 102.0
-```
-"""
-map
-
-# default to returning an Array for `map` on general iterators
 map(f, A) = collect(Generator(f,A))
 
 map(f, ::AbstractDict) = error("map is not defined on dictionaries")

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2954,7 +2954,37 @@ julia> map(+, [1, 2, 3], [10, 20, 30, 400, 5000])
  33
 ```
 """
-map(f, A) = collect(Generator(f,A)) # default to returning an Array for `map` on general iterators
+map
+
+"""
+    map(f, A::AbstractArray...) -> N-array
+
+When acting on multi-dimensional arrays of the same [`ndims`](@ref),
+they must all have the same [`axes`](@ref), and the answer will too.
+
+See also [`broadcast`](@ref), which allows mismatched sizes.
+
+# Examples
+```
+julia> map(//, [1 2; 3 4], [4 3; 2 1])
+2×2 Matrix{Rational{$Int}}:
+ 1//4  2//3
+ 3//2  4//1
+
+julia> map(+, [1 2; 3 4], zeros(2,1))
+ERROR: DimensionMismatch
+
+julia> map(+, [1 2; 3 4], [1,10,100,1000], zeros(3,1))  # iterates until 3rd is exhausted
+3-element Vector{Float64}:
+   2.0
+  13.0
+ 102.0
+```
+"""
+map
+
+# default to returning an Array for `map` on general iterators
+map(f, A) = collect(Generator(f,A))
 
 map(f, ::AbstractDict) = error("map is not defined on dictionaries")
 map(f, ::AbstractSet) = error("map is not defined on sets")

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -385,14 +385,14 @@ _mapreduce_dim_vararg(f, op, init, As::Tuple, ::Colon) =
     only(_mapreduce_dim_vararg(f, op, init, As, 1:maximum(ndims, As)))
 
 _mapreduce_dim_vararg(f, op, ::_InitialValue, As::Tuple, ::Colon) =
-    mapreduce(splat(f), op, zip(As...)) # fallback -- but extending _mapreduce may not be hard
+    mapreduce(splat(f), op, zip(As...)) # fallback, without init -- needs vararg _mapreduce
 
 mapreduce_empty(f::typeof(splat(+)).name.wrapper, op, ::Type{T}) where {T<:Tuple} =
     reduce_empty(op, Core.Compiler.return_type(op, T))  # for mapreduce(+, +, Int[], Int[])
 
 
 _mapreduce_dim_vararg(f, op, ::_InitialValue, As::Tuple, dims) =
-    _mapreduce_dim(identity, op, _InitialValue(), map(f, As...), dims) # fallback -- no vararg reducedim_init
+    _mapreduce_dim(identity, op, _InitialValue(), map(f, As...), dims) # fallback, without init -- no vararg reducedim_init
 
 _mapreduce_dim_vararg(f, op, init, As::Tuple, dims) =
     _mapreduce_dim_vararg(f, op, init, As, dims, IteratorSize(Generator(f, As...)))

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -377,6 +377,9 @@ _mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, ::Colon) =
 _mapreduce_dim(f, op, ::_InitialValue, A::AbstractArrayOrBroadcasted, ::Colon) =
     _mapreduce(f, op, IndexStyle(A), A)
 
+_mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, dims) =
+    mapreducedim!(f, op, reducedim_initarray(A, dims, nt), A)
+
 _mapreduce_dim(f, op, ::_InitialValue, A::AbstractArrayOrBroadcasted, dims) =
     mapreducedim!(f, op, reducedim_init(f, op, A, dims), A)
 


### PR DESCRIPTION
This is an attempt to make at least some cases of `mapreduce(f, op, A, B C)` faster. At present all cases just call `reduce(op, map(f, A, B C))`. 

This PR generalises `_mapreducedim!` to allow several arrays, which is enough to make reductions with `init` fast. When `init` is not given, generalising `reducedim_init` looks delicate & largely orthogonal, so is left for future work.

For the case of scalar reductions, it appears to be faster to call `only(_mapreducedim!(...))` when `init` is given. When `init` is not given, it uses `zip` exactly as in #39053. That isn't as fast, it saves memory but not always time compared to existing `reduce(op, map(f, ...`. More could be done here too.

Times, with `dims`:
```julia
julia> @btime reduce(+, map(+, $(rand(100,100)), $(rand(100,100))), dims=1);
  4.315 μs (3 allocations: 79.08 KiB)

julia> @btime mapreduce(/, +, $(rand(100,100)), $(rand(100,100)), dims=1); # dims=1 uses fast linear path
  4.202 μs (3 allocations: 79.08 KiB)  # unchanged, without init
  9.708 μs (3 allocations: 79.08 KiB)  # test without mapreduce_impl option, to compare

julia> @btime mapreduce(/, +, $(rand(100,100)), $(rand(100,100)), dims=1, init=0.0);
  266.750 μs (40090 allocations: 627.27 KiB)  # with vararg mapreduce_impl, first attempt
  4.869 μs (301 allocations: 5.56 KiB)        # with explicit N==2 version of mapreduce_impl
  2.273 μs (1 allocation: 896 bytes)          # with ith_all --  this PR

julia> @btime mapreduce(/, +, $(rand(100,100)), $(rand(100,100)), dims=2); # dims=2 uses a CartesianIndices path
  5.910 μs (7 allocations: 79.16 KiB)

julia> @btime mapreduce(/, +, $(rand(100,100)), $(rand(100,100)), dims=2, init=0.0);
  2.755 μs (5 allocations: 976 bytes)       # with explicit if N==2 ...
  2.750 μs (5 allocations: 976 bytes)       # with ith_all --  this PR
```

Times, scalar reduction:
```julia
julia> @btime reduce(+, map(/, $(rand(100,100)), $(rand(100,100))));  # behaviour on master
  5.736 μs (2 allocations: 78.20 KiB)

julia> @btime mapreduce(/, +, $(rand(100,100)), $(rand(100,100)));
  9.291 μs (0 allocations: 0 bytes)    # with zip --  this PR, or #39053
  5.340 μs (1 allocation: 16 bytes)    # with _mapreduce, ultimately mapreduce_impl, removed for now

julia> @btime mapreduce(/, +, $(rand(100,100)), $(rand(100,100)); init=0.0);
  2.713 μs (9 allocations: 368 bytes)  # with only(..., dims=all), ultimately mapreduce_impl
```
Times on the example from #38558, on my computer:
```julia
julia> summary(x)
"10240-element Vector{Float64}"

julia> @btime reduce(+, map(==, $x, $y));  # behaviour of f(x,y) on master
  5.423 μs (1 allocation: 10.19 KiB)

julia> @btime f($x,$y);  # mapreduce, turned into zip by this PR (or #39053)
  5.028 μs (0 allocations: 0 bytes)

julia> @btime f2($x,$y);  # explicit loop
  1.975 μs (0 allocations: 0 bytes)

julia> @btime f3($x,$y);  # using MappedArrays
  2.042 μs (0 allocations: 0 bytes)

julia> @btime f4($x,$y);  # with zip
  5.028 μs (0 allocations: 0 bytes)

julia> @btime mapreduce(==, +, $x, $y, init=0);  # with init, for this PR
  2.528 μs (6 allocations: 288 bytes)
```
I haven't checked tests closely, nor thought about whether more are needed.