### PR TITLE
reshape may accept AbstractUnitRanges that begin at 1 as arguments

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -188,7 +188,7 @@ julia> transpose(V)
  [1 3; 2 4]  [5 7; 6 8]
 ```
 """
-permutedims(v::AbstractVector) = reshape(v, (1, length(v)))
+permutedims(v::AbstractVector) = reshape(v, (1, axes(v,1)))
 
 """
     permutedims!(dest, src, perm)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -107,8 +107,10 @@ julia> reshape(1:6, 2, 3)
 """
 reshape
 
-reshape(parent::AbstractArray, dims::IntOrInd...) = reshape(parent, dims)
+reshape(parent::AbstractArray, dims::Union{Integer, AbstractUnitRange{<:Integer}}...) = reshape(parent, dims)
 reshape(parent::AbstractArray, shp::Tuple{Union{Integer,OneTo}, Vararg{Union{Integer,OneTo}}}) = reshape(parent, to_shape(shp))
+reshape(parent::AbstractArray, shp::Tuple{Union{Integer, AbstractUnitRange{<:Integer}}, Vararg{Union{Integer, AbstractUnitRange{<:Integer}}}}) =
+    reshape(parent, map(OneTo, shp))
 reshape(parent::AbstractArray, dims::Dims)        = _reshape(parent, dims)
 
 # Allow missing dimensions with Colon():

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1389,5 +1389,11 @@ end
 @testset "reshape with Integers" begin
     @test reshape(1:2, 1, 1:2) == reshape(1:2, 1, 2)
     @test reshape(1:2, 1, Int32(2)) == reshape(1:2, 1, 2)
+    @test reshape(1:2, 1, :, Base.OneTo(Int32(2))) == reshape(1:2, 1, 1, 2)
     @test reshape(reshape(1:2, Int32(2), 1), 1, Int32(2)) == reshape(1:2, 1, 2)
+    @test reshape(reshape(1:2, Int32(2), 1), :, Int32(2)) == reshape(1:2, 1, 2)
+    @test reshape(reshape(1:2, Int32(2), 1), :, Int32(2), Base.OneTo(1)) == reshape(1:2, 1, 2, 1)
+    @test_throws Exception reshape(1:2, 1, "a")
+    @test_throws Exception reshape(1:2, (1, "a"))
+    @test_throws Exception reshape(1:2, (1, :, "a"))
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1385,3 +1385,9 @@ end
     @test_throws ArgumentError keepat!(a, [2, 1])
     @test isempty(keepat!(a, []))
 end
+
+@testset "reshape with Integers" begin
+    @test reshape(1:2, 1, 1:2) == reshape(1:2, 1, 2)
+    @test reshape(1:2, 1, Int32(2)) == reshape(1:2, 1, 2)
+    @test reshape(reshape(1:2, Int32(2), 1), 1, Int32(2)) == reshape(1:2, 1, 2)
+end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -795,3 +795,7 @@ end
     @test Iterators.partition(OffsetArray(reshape(collect(1:9),3,3), (3,3)), 5) |> collect == [1:5,6:9] #OffsetMatrix
     @test Iterators.partition(IdOffsetRange(2:7,10), 5) |> collect == [12:16,17:17] # IdOffsetRange
 end
+
+@testset "permutedims" begin
+    @test axes(permutedims(ones(2:3))) == (1:1, 2:3)
+end

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -132,7 +132,7 @@ _indexoffset(r::AbstractRange) = first(r) - 1
 _indexoffset(i::Integer) = 0
 _indexoffset(i::Colon) = 0
 _indexlength(r::AbstractRange) = length(r)
-_indexlength(i::Integer) = i
+_indexlength(i::Integer) = Int(i)
 _indexlength(i::Colon) = Colon()
 
 _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -136,7 +136,7 @@ _indexlength(i::Integer) = Int(i)
 _indexlength(i::Colon) = Colon()
 
 _offset(axparent::AbstractUnitRange, ax::AbstractUnitRange) = first(ax) - first(axparent)
-_offset(axparent::AbstractUnitRange, ax::Integer) = 1 - first(axparent)
+_offset(axparent::AbstractUnitRange, ::Union{Integer, Colon}) = 1 - first(axparent)
 
 abstract type AxisConversionStyle end
 struct SingleRange <: AxisConversionStyle end


### PR DESCRIPTION
Currently this works:

```julia
julia> reshape(1:2, 1, Base.OneTo(2))
1×2 reshape(::UnitRange{Int64}, 1, 2) with eltype Int64:
 1  2
```

but this doesn't

```julia
julia> reshape(1:2, 1, 1:2)
ERROR: MethodError: no method matching reshape(::UnitRange{Int64}, ::Tuple{Int64, UnitRange{Int64}})
Closest candidates are:
  reshape(::AbstractVector, ::Colon) at reshapedarray.jl:115
  reshape(::AbstractArray, ::Int64...) at reshapedarray.jl:116
  reshape(::AbstractArray, ::Union{Int64, AbstractUnitRange}...) at reshapedarray.jl:110
  ...
Stacktrace:
 [1] reshape(::UnitRange{Int64}, ::Int64, ::UnitRange{Int64})
   @ Base ./reshapedarray.jl:110
 [2] top-level scope
   @ REPL[2]:1
```

After this PR the latter will work:

```julia
julia> reshape(1:2, 1, 1:2)
1×2 reshape(::UnitRange{Int64}, 1, 2) with eltype Int64:
 1  2
```

Performance seems identical:

```julia
julia> @btime reshape($(Ref(1:2))[], 1, :, Base.OneTo(2));
  36.971 ns (0 allocations: 0 bytes)

julia> @btime reshape($(Ref(1:2))[], 1, :, 1:2);
  36.971 ns (0 allocations: 0 bytes)
```

Aside from this, these now behave correctly:

```julia
julia> reshape(1:2, 1, :, Base.OneTo(2))
1×1×2 reshape(::UnitRange{Int64}, 1, 1, 2) with eltype Int64:
[:, :, 1] =
 1

[:, :, 2] =
 2

julia> reshape(1:2, 1, Int32(2))
1×2 reshape(::UnitRange{Int64}, 1, 2) with eltype Int64:
 1  2
```

These added methods to `reshape` also ensure that `permutedims` works correctly for `OffsetVector`s:

```julia
julia> permutedims(OffsetArray(1:2, 3:4))
1×2 OffsetArray(reshape(::UnitRange{Int64}, 1, 2), 1:1, 3:4) with eltype Int64 with indices 1:1×3:4:
 1  2
```