### PR TITLE
pinv now works for hermitian matrices.

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1439,7 +1439,7 @@ function pinv(A::AbstractMatrix{T}; atol::Real = 0.0, rtol::Real = (eps(real(flo
         B[ind] .= (x -> abs(x) > tol ? pinv(x) : zero(x)).(dA)
         return B
     end
-    SVD         = svd(A, full = false)
+    SVD         = svd(A)
     tol         = max(rtol*maximum(SVD.S), atol)
     Stype       = eltype(SVD.S)
     Sinv        = fill!(similar(A, Stype, length(SVD.S)), 0)

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -676,7 +676,7 @@ end
 inv(A::Hermitian{<:Any,<:StridedMatrix}) = Hermitian(_inv(A), sym_uplo(A.uplo))
 inv(A::Symmetric{<:Any,<:StridedMatrix}) = Symmetric(_inv(A), sym_uplo(A.uplo))
 
-function svd(A::RealHermSymComplexHerm, full::Bool=false)
+function svd(A::RealHermSymComplexHerm; full::Bool=false)
     vals, vecs = eigen(A)
     I = sortperm(vals; by=abs, rev=true)
     permute!(vals, I)

--- a/stdlib/LinearAlgebra/test/pinv.jl
+++ b/stdlib/LinearAlgebra/test/pinv.jl
@@ -157,7 +157,13 @@ end
         @test a.diag[1] ≈ 0.0
         @test a.diag[2] ≈ 0.0
     end
-
+    
+    @testset "hermitian matrices" begin
+        Q=ones(2,2)
+        C=pinv(Hermitian(Q))/0.25
+        @test C≈ones(2,2)
+    end
+        
     if eltya <: LinearAlgebra.BlasReal
         @testset "sub-normal numbers/vectors/matrices" begin
             a = pinv(floatmin(eltya)/100)

--- a/stdlib/LinearAlgebra/test/pinv.jl
+++ b/stdlib/LinearAlgebra/test/pinv.jl
@@ -157,13 +157,13 @@ end
         @test a.diag[1] ≈ 0.0
         @test a.diag[2] ≈ 0.0
     end
-    
+
     @testset "hermitian matrices" begin
-        Q=ones(2,2)
-        C=pinv(Hermitian(Q))/0.25
-        @test C≈ones(2,2)
+        Q = ones(2,2)
+        C = pinv(Hermitian(Q))/0.25
+        @test C ≈ ones(2,2)
     end
-        
+
     if eltya <: LinearAlgebra.BlasReal
         @testset "sub-normal numbers/vectors/matrices" begin
             a = pinv(floatmin(eltya)/100)

--- a/stdlib/LinearAlgebra/test/svd.jl
+++ b/stdlib/LinearAlgebra/test/svd.jl
@@ -23,7 +23,6 @@ using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, QRPivoted
     @test F.U'F.U ≊ Matrix(I, 2, 2)
     @test F.Vt'*F.Vt ≊ [1]
     @test @inferred(svdvals(3:4)) ≊ [5]
-    
     A = Matrix(1.0I, 2, 2)
     Z = svd(Hermitian(A); full=true)
     @test Z.S ≈ ones(2)

--- a/stdlib/LinearAlgebra/test/svd.jl
+++ b/stdlib/LinearAlgebra/test/svd.jl
@@ -23,6 +23,11 @@ using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, QRPivoted
     @test F.U'F.U ≊ Matrix(I, 2, 2)
     @test F.Vt'*F.Vt ≊ [1]
     @test @inferred(svdvals(3:4)) ≊ [5]
+    
+    A = Matrix(1.0I, 2, 2)
+    Z = svd(Hermitian(A); full=true)
+    @test Z.S ≈ ones(2)
+    @test Z.U'Z.U ≈ I(2)
 
     m1 = [2 0; 0 0]
     m2 = [2 -2; 1 1]/sqrt(2)


### PR DESCRIPTION
Fixes #40911. 

**Before**

```
julia> Q = randn(2,2); Q = Q'Q; pinv(Hermitian(Q))
ERROR: MethodError: no method matching svd(::Hermitian{Float64, Matrix{Float64}}; full=false)
Closest candidates are:
  svd(::Union{Hermitian{T, S}, Hermitian{Complex{T}, S}, Symmetric{T, S}} where {T<:Real, S}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/symmetric.jl:843 got unsupported keyword argument "full"
  svd(::Union{Hermitian{T, S}, Hermitian{Complex{T}, S}, Symmetric{T, S}} where {T<:Real, S}, ::Bool) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/symmetric.jl:843 got unsupported keyword argument "full"
  svd(::StridedMatrix{T}, ::StridedMatrix{T}) where T<:Union{Float32, Float64, ComplexF32, ComplexF64} at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/svd.jl:370 got unsupported keyword argument "full"
  ...
Stacktrace:
 [1] pinv(A::Hermitian{Float64, Matrix{Float64}}; atol::Float64, rtol::Float64)
   @ LinearAlgebra /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/dense.jl:1388
 [2] pinv(A::Hermitian{Float64, Matrix{Float64}})
   @ LinearAlgebra /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/dense.jl:1367
 [3] top-level scope
   @ REPL[219]:1
```
```
julia> A = randn(3,3); svd(Hermitian(A),full=true)
MethodError: no method matching svd(::Hermitian{Float64, Matrix{Float64}}; full=true)
Closest candidates are:
  svd(::Union{Hermitian{T, S}, Hermitian{Complex{T}, S}, Symmetric{T, S}} where {T<:Real, S}) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/symmetric.jl:843 got unsupported keyword argument "full"
  svd(::Union{Hermitian{T, S}, Hermitian{Complex{T}, S}, Symmetric{T, S}} where {T<:Real, S}, !Matched::Bool) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/symmetric.jl:843 got unsupported keyword argument "full"
  svd(!Matched::StridedMatrix{T}, !Matched::StridedMatrix{T}) where T<:Union{Float32, Float64, ComplexF32, ComplexF64} at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/svd.jl:370 got unsupported keyword argument "full"
  ...
top-level scope at untitled-caf8cf46142215c9cc05f796bc9cc619:3
eval at boot.jl:360 [inlined]
```

**After**

```
julia> Q = randn(2,2); Q = Q'Q; pinv(Hermitian(Q))
2×2 Matrix{Float64}:
 39.4657    -0.425089
 -0.425089   0.76294
```
```
julia> A = randn(3,3); svd(Hermitian(A),full=true)
SVD{Float64, Float64, Matrix{Float64}}
U factor:
3×3 Matrix{Float64}:
  0.617115   0.184267  0.764994
 -0.399113  -0.764557  0.506124
 -0.678143   0.617655  0.398276
singular values:
3-element Vector{Float64}:
 3.01828539776972
 2.24865206964243
 0.5683700735641573
Vt factor:
3×3 Matrix{Float64}:
  0.617115  -0.399113  -0.678143
 -0.184267   0.764557  -0.617655
 -0.764994  -0.506124  -0.398276
```

