### PR TITLE
Add get method, tests for Tuple and AbstractArrays :: Take 2 (#40809)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1469,12 +1469,9 @@ RangeVecIntList{A<:AbstractVector{Int}} = Union{Tuple{Vararg{Union{AbstractRange
 get(A::AbstractArray, i::Integer, default) = checkbounds(Bool, A, i) ? A[i] : default
 get(A::AbstractArray, I::Tuple{}, default) = checkbounds(Bool, A) ? A[] : default
 get(A::AbstractArray, I::Dims, default) = checkbounds(Bool, A, I...) ? A[I...] : default
-
-# get(A::AbstractArray, I::CartesianIndex, default) = checkbounds(Bool, A, I) ? A[I] : default
 get(f::Callable, A::AbstractArray, i::Integer) = checkbounds(Bool, A, i) ? A[i] : f()
 get(f::Callable, A::AbstractArray, I::Tuple{}) = checkbounds(Bool, A) ? A[] : f()
 get(f::Callable, A::AbstractArray, I::Dims) = checkbounds(Bool, A, I...) ? A[I...] : f()
-# get(f::Callable, A::AbstractArray, I::CartesianIndex) = checkbounds(Bool, A, I) ? A[I] : f()
 
 function get!(X::AbstractVector{T}, A::AbstractVector, I::Union{AbstractRange,AbstractVector{Int}}, default::T) where T
     # 1d is not linear indexing

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1470,6 +1470,12 @@ get(A::AbstractArray, i::Integer, default) = checkbounds(Bool, A, i) ? A[i] : de
 get(A::AbstractArray, I::Tuple{}, default) = checkbounds(Bool, A) ? A[] : default
 get(A::AbstractArray, I::Dims, default) = checkbounds(Bool, A, I...) ? A[I...] : default
 
+# get(A::AbstractArray, I::CartesianIndex, default) = checkbounds(Bool, A, I) ? A[I] : default
+get(f::Callable, A::AbstractArray, i::Integer) = checkbounds(Bool, A, i) ? A[i] : f()
+get(f::Callable, A::AbstractArray, I::Tuple{}) = checkbounds(Bool, A) ? A[] : f()
+get(f::Callable, A::AbstractArray, I::Dims) = checkbounds(Bool, A, I...) ? A[I...] : f()
+# get(f::Callable, A::AbstractArray, I::CartesianIndex) = checkbounds(Bool, A, I) ? A[I] : f()
+
 function get!(X::AbstractVector{T}, A::AbstractVector, I::Union{AbstractRange,AbstractVector{Int}}, default::T) where T
     # 1d is not linear indexing
     ind = findall(in(axes1(A)), I)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -32,6 +32,9 @@ getindex(t::Tuple, r::AbstractArray{<:Any,1}) = (eltype(t)[t[ri] for ri in r]...
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t, findall(b)) : throw(BoundsError(t, b))
 getindex(t::Tuple, c::Colon) = t
 
+get(t::Tuple, i::Integer, default) = i in 1:length(t) ? getindex(t, i) : default
+get(f::Callable, t::Tuple, i::Integer) = i in 1:length(t) ? getindex(t, i) : f()
+
 # returns new tuple; N.B.: becomes no-op if i is out-of-bounds
 
 """

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -599,20 +599,30 @@ function test_get(::Type{TestAbstractArray})
     @test get(TSlow([1]), (), 0) == 1
     @test get(TSlow(fill(1)), (), 0) == 1
 
-    @test get(()-> A .+ 1, A, ()) == A .+ 1
-    @test get(()->0, B, ()) == 0
-    @test get(()->0, A, (1,)) == get(()->0, A, 1) == A[1] == 1
-    @test get(()->0, B, (1,)) == get(()->0, B, 1) == B[1] == 1
-    @test get(()-> A .+ 1, A, (25,)) == get(()-> A .+ 1, A, 25) == A .+ 1
-    @test get(()->0, B, (25,)) == get(()->0, B, 25) == 0
-    @test get(()->0, A, (1,1,1)) == A[1,1,1] == 1
-    @test get(()->0, B, (1,1,1)) == B[1,1,1] == 1
-    @test get(()-> A .+ 1 , A, (1,1,3)) == A .+ 1
-    @test get(()->0, B, (1,1,3)) == 0
-
-    @test get(()->0, TSlow([]), ()) == 0
-    @test get(()->0, TSlow([1]), ()) == 1
-    @test get(()->0, TSlow(fill(1)), ()) == 1
+    global c = 0
+    f() = (global c = c+1; 0)
+    @test get(f, A, ()) == 0
+    @test c == 1
+    @test get(f, B, ()) == 0
+    @test c == 2
+    @test get(f, A, (1,)) == get(f, A, 1) == A[1] == 1
+    @test c == 2
+    @test get(f, B, (1,)) == get(f, B, 1) == B[1] == 1
+    @test c == 2
+    @test get(f, A, (25,)) == get(f, A, 25) == 0
+    @test c == 4
+    @test get(f, B, (25,)) == get(f, B, 25) == 0
+    @test c == 6
+    @test get(f, A, (1,1,1)) == A[1,1,1] == 1
+    @test get(f, B, (1,1,1)) == B[1,1,1] == 1
+    @test get(f, A, (1,1,3)) == 0
+    @test c == 7
+    @test get(f, B, (1,1,3)) == 0
+    @test c == 8
+    @test get(f, TSlow([]), ()) == 0
+    @test c == 9
+    @test get(f, TSlow([1]), ()) == 1
+    @test get(f, TSlow(fill(1)), ()) == 1
 end
 
 function test_cat(::Type{TestAbstractArray})

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -598,6 +598,21 @@ function test_get(::Type{TestAbstractArray})
     @test get(TSlow([]), (), 0) == 0
     @test get(TSlow([1]), (), 0) == 1
     @test get(TSlow(fill(1)), (), 0) == 1
+
+    @test get(()-> A .+ 1, A, ()) == A .+ 1
+    @test get(()->0, B, ()) == 0
+    @test get(()->0, A, (1,)) == get(()->0, A, 1) == A[1] == 1
+    @test get(()->0, B, (1,)) == get(()->0, B, 1) == B[1] == 1
+    @test get(()-> A .+ 1, A, (25,)) == get(()-> A .+ 1, A, 25) == A .+ 1
+    @test get(()->0, B, (25,)) == get(()->0, B, 25) == 0
+    @test get(()->0, A, (1,1,1)) == A[1,1,1] == 1
+    @test get(()->0, B, (1,1,1)) == B[1,1,1] == 1
+    @test get(()-> A .+ 1 , A, (1,1,3)) == A .+ 1
+    @test get(()->0, B, (1,1,3)) == 0
+
+    @test get(()->0, TSlow([]), ()) == 0
+    @test get(()->0, TSlow([1]), ()) == 1
+    @test get(()->0, TSlow(fill(1)), ()) == 1
 end
 
 function test_cat(::Type{TestAbstractArray})

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -179,6 +179,15 @@ end
         @test_throws MethodError (1,)[]
         @test_throws MethodError (1,1,1)[1,1]
     end
+
+    @testset "get() method for Tuple (Issue #40809)" begin
+        @test get((5, 6, 7), 1, 0) == 5
+        @test get((), 5, 0) == 0
+        @test get((1,), 3, 0) == 0
+        @test get(()->0, (5, 6, 7), 1) == 5
+        @test get(()->0, (), 4) == 0
+        @test get(()->0, (1,), 3) == 0
+    end
 end
 
 @testset "fill to length" begin


### PR DESCRIPTION
As specified in the PR with the same name (#40856 ), I had messed up my fork and had to start with a fresh fork. Sorry for this, I'm trying to improve :) . 
I added tests that were mutating, but I couldn't add `CartesianIndex`(cc: @mcabbott ). I was getting this error while `make` ing `julia`. I would be glad to fix this if someone could guide me through it.
```
error during bootstrap:
LoadError(at "compiler/compiler.jl" line 3: LoadError(at "abstractarray.jl" line 1473: UndefVarError(var=:CartesianIndex)))
jl_undefined_var_error at /home/learnedfool/github_repos/julia/src/rtutils.c:132
jl_eval_global_var at /home/learnedfool/github_repos/julia/src/interpreter.c:141 [inlined]
eval_value at /home/learnedfool/github_repos/julia/src/interpreter.c:187
do_call at /home/learnedfool/github_repos/julia/src/interpreter.c:116
eval_value at /home/learnedfool/github_repos/julia/src/interpreter.c:206
eval_stmt_value at /home/learnedfool/github_repos/julia/src/interpreter.c:157 [inlined]
eval_body at /home/learnedfool/github_repos/julia/src/interpreter.c:575
jl_interpret_toplevel_thunk at /home/learnedfool/github_repos/julia/src/interpreter.c:718
top-level scope at abstractarray.jl:1473
jl_toplevel_eval_flex at /home/learnedfool/github_repos/julia/src/toplevel.c:884
jl_parse_eval_all at /home/learnedfool/github_repos/julia/src/toplevel.c:1010
jl_load_ at /home/learnedfool/github_repos/julia/src/toplevel.c:1057
include at ./boot.jl:367
include at ./compiler/compiler.jl:19
jl_apply at /home/learnedfool/github_repos/julia/src/julia.h:1760 [inlined]
do_call at /home/learnedfool/github_repos/julia/src/interpreter.c:117
eval_value at /home/learnedfool/github_repos/julia/src/interpreter.c:206
eval_stmt_value at /home/learnedfool/github_repos/julia/src/interpreter.c:157 [inlined]
eval_body at /home/learnedfool/github_repos/julia/src/interpreter.c:575
jl_interpret_toplevel_thunk at /home/learnedfool/github_repos/julia/src/interpreter.c:718
top-level scope at compiler/compiler.jl:68
jl_toplevel_eval_flex at /home/learnedfool/github_repos/julia/src/toplevel.c:884
jl_eval_module_expr at /home/learnedfool/github_repos/julia/src/toplevel.c:195 [inlined]
jl_toplevel_eval_flex at /home/learnedfool/github_repos/julia/src/toplevel.c:672
jl_toplevel_eval_in at /home/learnedfool/github_repos/julia/src/toplevel.c:936
eval at ./boot.jl:369
jl_apply at /home/learnedfool/github_repos/julia/src/julia.h:1760 [inlined]
do_call at /home/learnedfool/github_repos/julia/src/interpreter.c:117
eval_value at /home/learnedfool/github_repos/julia/src/interpreter.c:206
eval_stmt_value at /home/learnedfool/github_repos/julia/src/interpreter.c:157 [inlined]
eval_body at /home/learnedfool/github_repos/julia/src/interpreter.c:575
jl_interpret_toplevel_thunk at /home/learnedfool/github_repos/julia/src/interpreter.c:718
top-level scope at compiler/compiler.jl:3
jl_toplevel_eval_flex at /home/learnedfool/github_repos/julia/src/toplevel.c:884
jl_parse_eval_all at /home/learnedfool/github_repos/julia/src/toplevel.c:1010
jl_load_ at /home/learnedfool/github_repos/julia/src/toplevel.c:1057
jl_load at /home/learnedfool/github_repos/julia/src/toplevel.c:1070
exec_program at /home/learnedfool/github_repos/julia/src/jlapi.c:513
true_main at /home/learnedfool/github_repos/julia/src/jlapi.c:565
jl_repl_entrypoint at /home/learnedfool/github_repos/julia/src/jlapi.c:695
main at /home/learnedfool/github_repos/julia/cli/loader_exe.c:51
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
_start at /home/learnedfool/github_repos/julia/usr/bin/julia (unknown line)

make[1]: *** [sysimage.mk:61: /home/learnedfool/github_repos/julia/usr/lib/julia/corecompiler.ji] Error 1
make: *** [Makefile:82: julia-sysimg-ji] Error 2
```