### PR TITLE
REPL install hook: Exclude special non-package modules when checking for installed packages

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -191,6 +191,7 @@ function modules_to_be_loaded(ast, mods = Symbol[])
     for arg in ast.args
         arg isa Expr && modules_to_be_loaded(arg, mods)
     end
+    filter!(mod -> !in(String(mod), ["Base", "Main", "Core"]), mods) # Exclude special non-package modules
     return mods
 end
 modules_to_be_loaded(::Nothing) = Symbol[] # comments are parsed as nothing

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1346,6 +1346,14 @@ end
         @test mods == [:Foo]
         mods = REPL.modules_to_be_loaded(Base.parse_input_line("using .Foo"))
         @test isempty(mods)
+        mods = REPL.modules_to_be_loaded(Base.parse_input_line("using Base"))
+        @test isempty(mods)
+        mods = REPL.modules_to_be_loaded(Base.parse_input_line("using Base: nope"))
+        @test isempty(mods)
+        mods = REPL.modules_to_be_loaded(Base.parse_input_line("using Main"))
+        @test isempty(mods)
+        mods = REPL.modules_to_be_loaded(Base.parse_input_line("using Core"))
+        @test isempty(mods)
 
         mods = REPL.modules_to_be_loaded(Base.parse_input_line("# comment"))
         @test isempty(mods)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/40981

This wasn't the cause of the error in https://github.com/JuliaLang/julia/issues/40981 but it highlighted that the install hook Pkg search was being triggered thinking `Base` couldn't be found, so highlighted a bug