### PR TITLE
faster `+(::BigInt...)` for more than 5 arguments

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -633,7 +633,7 @@ function gcdx(a::BigInt, b::BigInt)
 end
 
 +(x::BigInt, y::BigInt, rest::BigInt...) = sum(tuple(x, y, rest...))
-sum(arr::Union{AbstractArray{BigInt}, Tuple{Vararg{BigInt}}}) =
+sum(arr::Union{AbstractArray{BigInt}, Tuple{BigInt, Vararg{BigInt}}}) =
     foldl(MPZ.add!, arr; init=BigInt(0))
 # Note: a similar implementation for `prod` won't be efficient:
 # 1) the time complexity of the allocations is negligible compared to the multiplications

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -632,7 +632,9 @@ function gcdx(a::BigInt, b::BigInt)
     g, s, t
 end
 
-sum(arr::AbstractArray{BigInt}) = foldl(MPZ.add!, arr; init=BigInt(0))
++(x::BigInt, y::BigInt, rest::BigInt...) = sum(tuple(x, y, rest...))
+sum(arr::Union{AbstractArray{BigInt}, Tuple{Vararg{BigInt}}}) =
+    foldl(MPZ.add!, arr; init=BigInt(0))
 # Note: a similar implementation for `prod` won't be efficient:
 # 1) the time complexity of the allocations is negligible compared to the multiplications
 # 2) assuming arr contains similarly sized BigInts, the multiplications are much more

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -236,10 +236,15 @@ end
     g = parse(BigInt,"-1")
 
     @test +(a, b) == parse(BigInt,"327547")
+    @test 327547 == sum((a, b)) isa BigInt
     @test +(a, b, c) == parse(BigInt,"3426495623485904783805894")
+    @test 3426495623485904783805894 == sum((a, b, c)) isa BigInt
     @test +(a, b, c, d) == parse(BigInt,"3426495623485903384821764")
+    @test 3426495623485903384821764 == sum((a, b, c, d)) isa BigInt
     @test +(a, b, c, d, f) == parse(BigInt,"2413804710837418037418307081437318690130968843290370569228")
+    @test 2413804710837418037418307081437318690130968843290370569228 == sum((a, b, c, d, f)) isa BigInt
     @test +(a, b, c, d, f, g) == parse(BigInt,"2413804710837418037418307081437318690130968843290370569227")
+    @test 2413804710837418037418307081437318690130968843290370569227 == sum((a, b, c, d, f, g)) isa BigInt
 
     @test *(a, b) == parse(BigInt,"3911455620")
     @test *(a, b, c) == parse(BigInt,"13402585563389346256121263521460140")


### PR DESCRIPTION
Special versions already existed upto 5 arguments. For more than 5, let's
use sum, which is optimized for an arbitrary number of arguments, and which
we also extend to tuples here for the occasion.