### PR TITLE
faster `prod(::Array{BigInt})`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -7,7 +7,7 @@ export BigInt
 import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, nand, nor,
              binomial, cmp, convert, div, divrem, factorial, cld, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, powermod,
-             sum, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
+             sum, prod, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
              sign, hastypemax, isodd, iseven, digits!, hash, hash_integer
@@ -635,12 +635,17 @@ end
 +(x::BigInt, y::BigInt, rest::BigInt...) = sum(tuple(x, y, rest...))
 sum(arr::Union{AbstractArray{BigInt}, Tuple{BigInt, Vararg{BigInt}}}) =
     foldl(MPZ.add!, arr; init=BigInt(0))
-# Note: a similar implementation for `prod` won't be efficient:
-# 1) the time complexity of the allocations is negligible compared to the multiplications
-# 2) assuming arr contains similarly sized BigInts, the multiplications are much more
-# performant when doing e.g. ((a1*a2)*(a3*a4))*(...) rather than a1*(a2*(a3*(...))),
-# which is exactly what the default implementation of `prod` does, via `mapreduce`
-# (which maybe could be slightly optimized for BigInt).
+
+function prod(arr::AbstractArray{BigInt})
+    # compute first the needed number of limbs for the result,
+    # to avoid re-allocations
+    nlimbs = sum(arr; init=0) do x
+        abs(x.size)
+    end
+    init = BigInt(; nbits=BITS_PER_LIMB*nlimbs)
+    MPZ.set_si!(init, 1)
+    foldl(MPZ.mul!, arr; init)
+end
 
 factorial(x::BigInt) = isneg(x) ? BigInt(0) : MPZ.fac_ui(x)
 

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -224,6 +224,9 @@ let a, b
     a = rand(1:100, 10000)
     b = map(BigInt, a)
     @test sum(a) == sum(b)
+    @test 0 == sum(BigInt[]) isa BigInt
+    @test prod(b) == foldl(*, b)
+    @test 1 == prod(BigInt[]) isa BigInt
 end
 
 @testset "Iterated arithmetic" begin


### PR DESCRIPTION
By having a first pass on the array to compute the size of the result
(this avoids re-allocations).

Example:
```julia
julia> xs = rand(1:big(2)^20, 20);

julia> @btime prod($xs); # master
  2.050 μs (57 allocations: 1.23 KiB)

julia> @btime prod($xs); # PR
  310.413 ns (2 allocations: 192 bytes)
```