### PR TITLE
relaxed eltype for ldiv! and rdiv! methods

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -446,9 +446,9 @@ mul!(C::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:Rea
 
 ldiv!(x::AbstractArray, A::Diagonal, b::AbstractArray) = (x .= A.diag .\ b)
 
-ldiv!(adjD::Adjoint{<:Any,<:Diagonal{T}}, B::AbstractVecOrMat{T}) where {T} =
+ldiv!(adjD::Adjoint{<:Any,<:Diagonal}, B::AbstractVecOrMat) =
     (D = adjD.parent; ldiv!(conj(D), B))
-ldiv!(transD::Transpose{<:Any,<:Diagonal{T}}, B::AbstractVecOrMat{T}) where {T} =
+ldiv!(transD::Transpose{<:Any,<:Diagonal}, B::AbstractVecOrMat) =
     (D = transD.parent; ldiv!(D, B))
 
 function ldiv!(D::Diagonal, A::Union{LowerTriangular,UpperTriangular})
@@ -480,9 +480,9 @@ function rdiv!(A::Union{LowerTriangular,UpperTriangular}, D::Diagonal)
     A
 end
 
-rdiv!(A::AbstractMatrix{T}, adjD::Adjoint{<:Any,<:Diagonal{T}}) where {T} =
+rdiv!(A::AbstractMatrix, adjD::Adjoint{<:Any,<:Diagonal}) =
     (D = adjD.parent; rdiv!(A, conj(D)))
-rdiv!(A::AbstractMatrix{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
+rdiv!(A::AbstractMatrix, transD::Transpose{<:Any,<:Diagonal}) =
     (D = transD.parent; rdiv!(A, D))
 
 (/)(A::Union{StridedMatrix, AbstractTriangular}, D::Diagonal) =

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -796,5 +796,4 @@ end
         @test rdiv!(A, trans(I(3))) == A
     end
 end
-                                           
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -789,4 +789,11 @@ end
     @test dot(A, B) ≈ conj(dot(B, A))
 end
 
+@testset "eltype relaxation(#41015)" begin
+    A = rand(3,3)
+    for trans in (identity, Adjoint, Transpose)
+    @test ldiv!(trans(I(3)), A) == A
+    @test rdiv!(A, trans(I(3))) == A
+end
+                                           
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -792,8 +792,9 @@ end
 @testset "eltype relaxation(#41015)" begin
     A = rand(3,3)
     for trans in (identity, Adjoint, Transpose)
-    @test ldiv!(trans(I(3)), A) == A
-    @test rdiv!(A, trans(I(3))) == A
+        @test ldiv!(trans(I(3)), A) == A
+        @test rdiv!(A, trans(I(3))) == A
+    end
 end
                                            
 end # module TestDiagonal


### PR DESCRIPTION
updated diagonal.jl to relax eltype for ldiv! and rdiv! methods as suggested by @dkarrasch (https://github.com/JuliaLang/julia/pull/40942#issuecomment-850997515).

ref: JuliaLang/LinearAlgebra.jl#849 , JuliaLang/julia#40942

