### PR TITLE
Unify `nullspace` for VecOrMat

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1491,19 +1491,13 @@ julia> nullspace(M, atol=0.95)
  1.0
 ```
 """
-function nullspace(A::AbstractMatrix; atol::Real = 0.0, rtol::Real = (min(size(A)...)*eps(real(float(one(eltype(A))))))*iszero(atol))
-    m, n = size(A)
-    (m == 0 || n == 0) && return Matrix{eltype(A)}(I, n, n)
-    SVD = svd(A, full=true)
+function nullspace(A::AbstractVecOrMat; atol::Real = 0.0, rtol::Real = (min(size(A, 1), size(A, 2))*eps(real(float(one(eltype(A))))))*iszero(atol))
+    m, n = size(A, 1), size(A, 2)
+    (m == 0 || n == 0) && return Matrix{eigtype(eltype(A))}(I, n, n)
+    SVD = svd(A; full=true)
     tol = max(atol, SVD.S[1]*rtol)
     indstart = sum(s -> s .> tol, SVD.S) + 1
     return copy(SVD.Vt[indstart:end,:]')
-end
-
-nullspace(A::AbstractVector; kws...) = nullspace(reshape(A, length(A), 1); kws...)
-function nullspace(A::Union{Transpose{<:Any, <:AbstractVector},
-                            Adjoint{<:Any, <:AbstractVector}}; kws...)
-    return nullspace(Matrix(A); kws...)
 end
 
 """

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1500,7 +1500,11 @@ function nullspace(A::AbstractMatrix; atol::Real = 0.0, rtol::Real = (min(size(A
     return copy(SVD.Vt[indstart:end,:]')
 end
 
-nullspace(A::AbstractVector; atol::Real = 0.0, rtol::Real = (min(size(A)...)*eps(real(float(one(eltype(A))))))*iszero(atol)) = nullspace(reshape(A, length(A), 1), rtol= rtol, atol= atol)
+nullspace(A::AbstractVector; kws...) = nullspace(reshape(A, length(A), 1); kws...)
+function nullspace(A::Union{Transpose{<:Any, <:AbstractVector},
+                            Adjoint{<:Any, <:AbstractVector}}; kws...)
+    return nullspace(Matrix(A); kws...)
+end
 
 """
     cond(M, p::Real=2)

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -90,6 +90,11 @@ bimg  = randn(n,2)/2
                 # test empty cases
                 @test nullspace(zeros(n, 0)) == Matrix(I, 0, 0)
                 @test nullspace(zeros(0, n)) == Matrix(I, n, n)
+                # test vector cases
+                @test size(nullspace(a[:, 1])') == (n, n - 1)
+                @test size(nullspace(b[1, :])') == (n, n - 1)
+                @test size(transpose(nullspace(a[:, 1]))) == (n, n - 1)
+                @test size(transpose(nullspace(b[1, :]))) == (n, n - 1)
             end
         end
     end # for eltyb

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -88,13 +88,19 @@ bimg  = randn(n,2)/2
                 @test nullspace(zeros(eltya,n)) == Matrix(I, 1, 1)
                 @test nullspace(zeros(eltya,n), 0.1) == Matrix(I, 1, 1)
                 # test empty cases
-                @test nullspace(zeros(n, 0)) == Matrix(I, 0, 0)
-                @test nullspace(zeros(0, n)) == Matrix(I, n, n)
+                @test @inferred(nullspace(zeros(n, 0))) == Matrix(I, 0, 0)
+                @test @inferred(nullspace(zeros(0, n))) == Matrix(I, n, n)
                 # test vector cases
-                @test size(nullspace(a[:, 1])') == (n, n - 1)
-                @test size(nullspace(b[1, :])') == (n, n - 1)
-                @test size(transpose(nullspace(a[:, 1]))) == (n, n - 1)
-                @test size(transpose(nullspace(b[1, :]))) == (n, n - 1)
+                @test size(@inferred nullspace(a[:, 1])) == (1, 0)
+                @test size(@inferred nullspace(zero(a[:, 1]))) == (1, 1)
+                @test nullspace(zero(a[:, 1]))[1,1] == 1
+                # test adjortrans vectors, including empty ones
+                @test size(@inferred nullspace(a[:, 1]')) == (n, n - 1)
+                @test @inferred(nullspace(a[1:0, 1]')) == Matrix(I, 0, 0)
+                @test size(@inferred nullspace(b[1, :]')) == (2, 1)
+                @test @inferred(nullspace(b[1, 1:0]')) == Matrix(I, 0, 0)
+                @test size(@inferred nullspace(transpose(a[:, 1]))) == (n, n - 1)
+                @test size(@inferred nullspace(transpose(b[1, :]))) == (2, 1)
             end
         end
     end # for eltyb


### PR DESCRIPTION
I pushed to the wrong place, so this is a rebase of #33385. Closes #33385.