### PR TITLE
using BLAS.vendor() now shows warning.

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -91,7 +91,7 @@ get_config() = lbt_get_config()
 # We hard-lock `vendor()` to `openblas(64)` here to satisfy older code, but all new code should use
 # `get_config()` since it is now possible to have multiple vendors loaded at once.
 function vendor()
-    Base.depwarn("`vendor()` is deprecated, use `BLAS.get_config()` and inspect the output instead", :vendor)
+    Base.depwarn("`vendor()` is deprecated, use `BLAS.get_config()` and inspect the output instead", :vendor; force=true)
     if USE_BLAS64
         return :openblas64
     else


### PR DESCRIPTION
fixes JuliaLang/LinearAlgebra.jl#847.