### PR TITLE
RFC: remove deprecation of getproperty on Pairs

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -244,12 +244,6 @@ cat_shape(dims, shape::Tuple{}) = () # make sure `cat_shape(dims, ())` do not re
 
 # BEGIN 1.7 deprecations
 
-# the plan is to eventually overload getproperty to access entries of the dict
-@noinline function getproperty(x::Pairs, s::Symbol)
-    depwarn("use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr", :getproperty, force=true)
-    return getfield(x, s)
-end
-
 # This function was marked as experimental and not exported.
 @deprecate catch_stack(task=current_task(); include_bt=true) current_exceptions(task; backtrace=include_bt) false
 


### PR DESCRIPTION
This causes hundred+ of packages (looking at https://github.com/JuliaLang/julia/pull/39448#issuecomment-771338937) to start giving deprecation warnings by default. The motivation for the feature (https://github.com/JuliaLang/julia/issues/25750) also seems highly speculative so making something disruptive based on that doesn't feel like it is a good tradeoff.