### PR TITLE
Explain properties of the `lt` keyword for sorting

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -674,6 +674,10 @@ options are independent and can be used together in all possible combinations: i
 and `lt` are specified, the `lt` function is applied to the result of the `by` function;
 `rev=true` reverses whatever ordering specified via the `by` and `lt` keywords.
 
+!!! warn
+    The `lt` function must be a "less than" function (as opposed to a "less than or equal" function),
+    i.e., for every `x` and `y`, only one of `lt(x,y)` and `lt(y,x)` can return `true`.
+
 # Examples
 ```jldoctest
 julia> v = [3, 1, 2]; sort!(v); v

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -669,14 +669,11 @@ Sort the vector `v` in place. [`QuickSort`](@ref) is used by default for numeric
 [`MergeSort`](@ref) is used for other arrays. You can specify an algorithm to use via the `alg`
 keyword (see [Sorting Algorithms](@ref) for available algorithms). The `by` keyword lets you provide
 a function that will be applied to each element before comparison; the `lt` keyword allows
-providing a custom "less than" function; use `rev=true` to reverse the sorting order. These
+providing a custom "less than" function (note that for every `x` and `y`, only one of `lt(x,y)`
+and `lt(y,x)` can return `true`); use `rev=true` to reverse the sorting order. These
 options are independent and can be used together in all possible combinations: if both `by`
 and `lt` are specified, the `lt` function is applied to the result of the `by` function;
 `rev=true` reverses whatever ordering specified via the `by` and `lt` keywords.
-
-!!! warn
-    The `lt` function must be a "less than" function (as opposed to a "less than or equal" function),
-    i.e., for every `x` and `y`, only one of `lt(x,y)` and `lt(y,x)` can return `true`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The `sort!` docstring does not explain what kind of properties the function `lt` needs to have (mainly that it must be irreflexive, like < and unlike ≤). This can lead to confusion (see [this discourse thread](https://discourse.julialang.org/t/understanding-issorteds-lt-keyword/60918) for example), so it would be good to add a note.

I tried to avoid technical terms like “strict total order”, but maybe the note could be more precise?