### PR TITLE
Add `get` for numbers

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -816,6 +816,8 @@ iterate(A::Array, i=1) = (@_inline_meta; (i % UInt) - 1 < length(A) ? (@inbounds
 Retrieve the value(s) stored at the given key or index within a collection. The syntax
 `a[i,j,...]` is converted by the compiler to `getindex(a, i, j, ...)`.
 
+See also [`get`](@ref), [`keys`](@ref), [`eachindex`](@ref).
+
 # Examples
 ```jldoctest
 julia> A = Dict("a" => 1, "b" => 2)
@@ -869,6 +871,8 @@ end
 
 Store the given value at the given key or index within a collection. The syntax `a[i,j,...] =
 x` is converted by the compiler to `(setindex!(a, x, i, j, ...); x)`.
+
+See also [`get!`](@ref), [`setindex`](@ref).
 """
 function setindex! end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -871,8 +871,6 @@ end
 
 Store the given value at the given key or index within a collection. The syntax `a[i,j,...] =
 x` is converted by the compiler to `(setindex!(a, x, i, j, ...); x)`.
-
-See also [`get!`](@ref), [`setindex`](@ref).
 """
 function setindex! end
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -488,6 +488,9 @@ end
 Return the value stored for the given key, or the given default value if no mapping for the
 key is present.
 
+!!! compat "Julia 1.7"
+    For tuples and numbers, this function requires at least Julia 1.7.
+
 # Examples
 ```jldoctest
 julia> d = Dict("a"=>1, "b"=>2);

--- a/base/number.jl
+++ b/base/number.jl
@@ -103,8 +103,10 @@ function getindex(x::Number, I::Integer...)
     @boundscheck all(isone, I) || throw(BoundsError())
     x
 end
-get(x::Number, i::Integer, default) = i == 1 ? x : default
-get(f::Callable, x::Number, i::Integer) = i == 1 ? x : f()
+get(x::Number, i::Integer, default) = isone(i) ? x : default
+get(x::Number, ind::Tuple, default) = all(isone, ind) ? x : default
+get(f::Callable, x::Number, i::Integer) = isone(i) ? x : f()
+get(f::Callable, x::Number, ind::Tuple) = all(isone, ind) ? x : f()
 
 first(x::Number) = x
 last(x::Number) = x

--- a/base/number.jl
+++ b/base/number.jl
@@ -103,6 +103,9 @@ function getindex(x::Number, I::Integer...)
     @boundscheck all(isone, I) || throw(BoundsError())
     x
 end
+get(x::Number, i::Integer, default) = i == 1 ? x : default
+get(f::Callable, x::Number, i::Integer) = i == 1 ? x : f()
+
 first(x::Number) = x
 last(x::Number) = x
 copy(x::Number) = x # some code treats numbers as collection-like

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2310,12 +2310,18 @@ end
 @testset "get(x::Number, ...)" begin
     for x in [1.23, 7, ℯ, 4//5] #[FP, Int, Irrational, Rat]
         @test get(x, 1, 99) == x
+        @test get(x, (), 99) == x
+        @test get(x, (1,), 99) == x
         @test get(x, 2, 99) == 99
         @test get(x, 0, pi) == pi
+        @test get(x, (1,2), pi) == pi
         c = Ref(0)
         @test get(() -> c[]+=1, x, 1) == x
+        @test get(() -> c[]+=1, x, ()) == x
+        @test get(() -> c[]+=1, x, (1,1,1)) == x
         @test get(() -> c[]+=1, x, 2) == 1
         @test get(() -> c[]+=1, x, -1) == 2
+        @test get(() -> c[]+=1, x, (3,2,1)) == 3
     end
 end
 @testset "copysign and flipsign" begin

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2307,6 +2307,17 @@ end
         @test_throws BoundsError getindex(x, 1, 0)
     end
 end
+@testset "get(x::Number, ...)" begin
+    for x in [1.23, 7, ℯ, 4//5] #[FP, Int, Irrational, Rat]
+        @test get(x, 1, 99) == x
+        @test get(x, 2, 99) == 99
+        @test get(x, 0, pi) == pi
+        c = Ref(0)
+        @test get(() -> c[]+=1, x, 1) == x
+        @test get(() -> c[]+=1, x, 2) == 1
+        @test get(() -> c[]+=1, x, -1) == 2
+    end
+end
 @testset "copysign and flipsign" begin
     # copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, x)
     # flipsign(x::Real, y::Real) = ifelse(signbit(y), -x, x)


### PR DESCRIPTION
This is a companion to #41007, adding `get` to numbers. Since they are indexable, probably this makes sense?

I had a real live use for this, in extending `repeat([1,2,3]; inner)`, which accepts both `inner=2` and `inner=(1,2)`.