### PR TITLE
InteractiveUtils: escape macro keywords

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -187,7 +187,7 @@ function gen_call_with_extracted_types_and_kwargs(__module__, fcn, ex0)
             if length(x.args) != 2
                 return Expr(:call, :error, "Invalid keyword argument: $x")
             end
-            push!(kws, Expr(:kw, x.args[1], x.args[2]))
+            push!(kws, Expr(:kw, esc(x.args[1]), esc(x.args[2])))
         else
             return Expr(:call, :error, "@$fcn expects only one non-keyword argument")
         end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -580,3 +580,9 @@ end
     ms = methodswith(A41010, @__MODULE__) |> collect
     @test ms[1].name == :B41010
 end
+
+# macro options should accept both literals and variables
+let
+    opt = false
+    @test !(first(@code_typed optimize=opt sum(1:10)).inferred)
+end


### PR DESCRIPTION
Previously `@code_typed` and its family can't accept variables as
keyword options since they're not escaped:
```julia
julia> let
           opt = false
           @code_typed optimize=opt sum(1:10)
       end
ERROR: UndefVarError: opt not defined
Stacktrace:
 [1] macro expansion
   @ ~/julia/julia/usr/share/julia/stdlib/v1.7/InteractiveUtils/src/macros.jl:222 [inlined]
 [2] top-level scope
   @ REPL[2]:3
```