### PR TITLE
remove type specification in the generic __normalize!

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1724,7 +1724,7 @@ function normalize!(a::AbstractArray, p::Real=2)
     __normalize!(a, nrm)
 end
 
-@inline function __normalize!(a::AbstractArray, nrm)
+@inline function __normalize!(a::AbstractArray, nrm::Real)
     # The largest positive floating point number whose inverse is less than infinity
     δ = inv(prevfloat(typemax(nrm)))
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1724,7 +1724,7 @@ function normalize!(a::AbstractArray, p::Real=2)
     __normalize!(a, nrm)
 end
 
-@inline function __normalize!(a::AbstractArray, nrm::AbstractFloat)
+@inline function __normalize!(a::AbstractArray, nrm)
     # The largest positive floating point number whose inverse is less than infinity
     δ = inv(prevfloat(typemax(nrm)))
 


### PR DESCRIPTION
It will solve the following issue of differentiating `normalize!` with `ForwardDiff`. It does not make much sense to specify types in a "private" function.

```julia
julia> using ForwardDiff: Dual
julia> using LinearAlgebra

julia> normalize!(Dual.(randn(13), randn(13)))
ERROR: MethodError: no method matching __normalize!(::Vector{Dual{Nothing, Float64, 1}}, ::Dual{Nothing, Float64, 1})
Closest candidates are:
  __normalize!(::AbstractArray, ::AbstractFloat) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/generic.jl:1678
Stacktrace:
 [1] normalize!(a::Vector{Dual{Nothing, Float64, 1}}, p::Int64)
   @ LinearAlgebra /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/generic.jl:1675
 [2] normalize!(a::Vector{Dual{Nothing, Float64, 1}})
   @ LinearAlgebra /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/generic.jl:1674
 [3] top-level scope
   @ REPL[6]:1
```