### PR TITLE
add method to replace that takes a function RegexMatch -> String

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -70,6 +70,7 @@ export
     Rational,
     Regex,
     RegexMatch,
+    RegexReplacer,
     Returns,
     RoundFromZero,
     RoundDown,

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -532,6 +532,8 @@ end
 Stores the given string `substr` as a `SubstitutionString`, for use in regular expression
 substitutions. Most commonly constructed using the [`@s_str`](@ref) macro.
 
+See also [`RegexReplacer`](@ref).
+
 ```jldoctest
 julia> SubstitutionString("Hello \\\\g<name>, it's \\\\1")
 s"Hello \\g<name>, it's \\1"
@@ -567,6 +569,8 @@ end
 Construct a substitution string, used for regular expression substitutions.  Within the
 string, sequences of the form `\\N` refer to the Nth capture group in the regex, and
 `\\g<groupname>` refers to a named capture group with name `groupname`.
+
+See also [`RegexReplacer`](@ref).
 
 ```jldoctest
 julia> msg = "#Hello# from Julia";
@@ -672,6 +676,33 @@ function _replace(io, repl_s::SubstitutionString, str, r, re)
     end
 end
 
+"""
+    RegexReplacer(f::Function)
+
+Create a `RegexReplacer` that can be used to
+[`replace`](@ref replace(::AbstractString, ::Pair))
+[`Regex`](@ref)-matched text using the given function `f`
+with access to the current match and capture groups.
+
+`f` must be callable with a [`RegexMatch`](@ref) and return a [`print`](@ref)-able object.
+
+See also [`SubstitutionString`](@ref), [`@s_str`](@ref).
+
+# Examples
+```jldoctest
+julia> s = "ax ay az bx by bz";
+
+julia> replace(s, r"([ab])([xy])" => RegexReplacer(match -> uppercase(match[1]) * match[2]))
+"Ax Ay az Bx By bz"
+
+julia> template = "the {animal} is {activity}";
+
+julia> variables = Dict("animal" => "fox", "activity" => "running");
+
+julia> replace(template, r"{(.*?)}" => RegexReplacer(match -> variables[match[1]]))
+"the fox is running"
+```
+"""
 struct RegexReplacer
     f::Function
 end

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -604,6 +604,8 @@ where `s` is the matched substring (when `pat` is a `AbstractPattern` or `Abstra
 character (when `pat` is an `AbstractChar` or a collection of `AbstractChar`).
 If `pat` is a regular expression and `r` is a [`SubstitutionString`](@ref), then capture group
 references in `r` are replaced with the corresponding matched text.
+If `pat` is a regular expression and `r` is a [`RegexReplacer`](@ref),
+then the matched substring is replaced with `r.f(m)` where `m` is a [`RegexMatch`](@ref).
 To remove instances of `pat` from `string`, set `r` to the empty `String` (`""`).
 
 Multiple patterns can be specified, and they will be applied left-to-right

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -35,6 +35,7 @@ Base.match
 Base.eachmatch
 Base.RegexMatch
 Base.keys(::RegexMatch)
+Base.RegexReplacer
 Base.isless(::AbstractString, ::AbstractString)
 Base.:(==)(::AbstractString, ::AbstractString)
 Base.cmp(::AbstractString, ::AbstractString)

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -484,6 +484,14 @@ end
         @test_throws ErrorException("PCRE error: unknown substring") replace(s, r"q" => s"a\1b")
         @test_throws ErrorException("Bad replacement string: pattern is not a Regex") replace(s, "q" => s"a\1b")
     end
+
+    # test replace with a RegexReplacer
+    @test replace("ax ay bx by",
+        "ay" => "cy",
+        r"([ab])([xy])" => RegexReplacer(m -> uppercase(m[1]) * m[2])) === "Ax cy Bx By"
+    @test replace("ax ay bx by",
+        r"([a])([xy])" => RegexReplacer(m -> uppercase(m[1]) * m[2]),
+        r"([ab])([xy])" => RegexReplacer(m -> "<" * m[1] * ">" * m[2]), count=3) === "Ax Ay <b>x by"
 end
 
 @testset "chomp/chop" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -310,6 +310,8 @@ end
     # Issue 36953
     @test replace("abc", "" => "_", count=1) == "_abc"
 
+    # test replace with a RegexReplacer
+    @test replace("ax ay bx by", r"([ab])([xy])" => RegexReplacer(m -> uppercase(m[1]) * m[2])) === "Ax Ay Bx By"
 end
 
 @testset "replace many" begin


### PR DESCRIPTION
This adds the possibility to perform regex string replacements with an arbitrary function of the matching string and the capture groups as proposed in #36293:
```julia
replace("ax ay bx by", r"([ab])([xy])" =>
    RegexReplacer(m -> uppercase(m[1]) * m[2]))
# Ax Ay Bx By
```

I chose the name `RegexReplacer` for consistency with the related types `Regex` and `RegexMatch` and because I find it easy to remember that `replace` takes a "replacer". See also Rust's trait [regex::Replacer](https://docs.rs/regex/1.4.2/regex/trait.Replacer.html). But this is of course up for debate and other names have been proposed.

I proposed a different API in #24598 which would solve both issues at the same time:
```julia
replace("ax ay bx by", r"([ab])([xy])") do m
    uppercase(m[1]) * m[2]
end
```
But this hasn't gotten any feedback yet. I tried to give some pros and cons for both variants in [#36293](https://github.com/JuliaLang/julia/issues/36293#issuecomment-851609358) and I'm happy with either/both solutions. **Update:** in light of #40484, I don't think the `do`-block variant makes sense anymore as an alternative.

TODO:
- [x] Documentation

Fixes #36293