### PR TITLE
cat: remove incorrect inbounds/inline annotations

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -15,7 +15,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, sqrt,
     strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
-using Base: hvcat_fill, IndexLinear, promote_op, promote_typeof,
+using Base: IndexLinear, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_vcat, require_one_based_indexing
 using Base.Broadcast: Broadcasted, broadcasted
 import Libdl

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1388,6 +1388,8 @@ end
     for v = (1, "test")
         @test [v v;;; fill(v, 1, 2)] == fill(v, 1, 2, 2)
     end
+
+    @test_throws BoundsError hvncat(((1, 2), (3,)), false, zeros(Int, 0, 0, 0), 7, 8)
 end
 
 @testset "keepat!" begin


### PR DESCRIPTION
There are no boundschecks in these cat functions so these lead to problems such as #41047. This does not #41047, as the computed shape is still wrong, it just makes sure that Julia is still memory-safe, even if you call the function incorrectly.