### PR TITLE
Convenience Functions for `isweekend` or `isweekday`

### DIFF
--- a/stdlib/Dates/src/query.jl
+++ b/stdlib/Dates/src/query.jl
@@ -199,6 +199,79 @@ isfriday(dt::TimeType) = dayofweek(dt) == Fri
 issaturday(dt::TimeType) = dayofweek(dt) == Sat
 issunday(dt::TimeType) = dayofweek(dt) == Sun
 
+# Convenience methods for checking weekdays and weekends
+"""
+    isweekday(dt::TimeType; locale::Int = 1) -> Bool
+
+Return `true` if the day of `dt` falls on a locale's weekday. Contains four
+locales that define weekdays for different regions of the world:
+
+1: Monday - Friday
+
+2: Sunday - Thursday
+
+3: Monday - Saturday
+
+4: Saturday - Thursday
+
+# Examples
+```jldoctest
+julia> Dates.isweekday(Date("2021-1-1"))
+true
+
+julia> Dates.isweekday(Date("2021-1-1"; locale = 2))
+false
+```
+"""
+function isweekday(dt::TimeType; locale::Int64 = 1)
+	day = dayofweek(dt)
+	if locale == 1
+		return 1 <= day <= 5
+	elseif locale == 2
+		return day == 7 ? true : 1 <= day <= 4
+	elseif locale == 3
+		return 1 <= day <= 6
+	elseif locale == 4
+		return 6 <= day <= 7 || 1 <= day <= 4
+	end
+end
+
+"""
+    isweekend(dt::TimeType; locale::Int = 1) -> Bool
+
+Return `true` if the day of `dt` falls on a locale's weekend. Contains four
+locales that define weekends for different regions of the world:
+
+1: Saturday - Sunday
+
+2: Sunday - Monday
+
+3: Saturday
+
+4: Friday
+
+# Examples
+```jldoctest
+julia> Dates.isweekend(Date("2021-1-1"))
+false
+
+julia> Dates.isweekend(Date("2021-1-1"; locale = 2))
+true
+```
+"""
+function isweekend(dt::TimeType; locale::Int64 = 1)
+	day = dayofweek(dt)
+	if locale == 1
+		return 6 <= day <= 7
+	elseif locale == 2
+		return  5 <= day <= 6
+	elseif locale == 3
+		return day == 7
+	elseif locale == 4
+		return day == 5
+	end
+end
+
 # i.e. 1st Monday? 2nd Monday? 3rd Wednesday? 5th Sunday?
 """
     dayofweekofmonth(dt::TimeType) -> Int

--- a/stdlib/Dates/test/query.jl
+++ b/stdlib/Dates/test/query.jl
@@ -214,5 +214,74 @@ end
         @test Dates.dayofquarter(Dates.DateTime(y, 12, 31)) == 92
     end
 end
+@testset "isweekday" begin
+	@test Dates.isweekday(Nov; locale = 1) == true
+	@test Dates.isweekday(Jan; locale = 1) == true
+	@test Dates.isweekday(Dec; locale = 1) == true
+	@test Dates.isweekday(Apr; locale = 1) == true
+	@test Dates.isweekday(Jun; locale = 1) == true
+	@test Dates.isweekday(Feb; locale = 1) == false
+	@test Dates.isweekday(Mar; locale = 1) == false
+	
+	@test Dates.isweekday(Nov; locale = 2) == true
+	@test Dates.isweekday(Jan; locale = 2) == true
+	@test Dates.isweekday(Dec; locale = 2) == true
+	@test Dates.isweekday(Apr; locale = 2) == true
+	@test Dates.isweekday(Jun; locale = 2) == false
+	@test Dates.isweekday(Feb; locale = 2) == false
+	@test Dates.isweekday(Mar; locale = 2) == true
+	
+	@test Dates.isweekday(Nov; locale = 3) == true
+	@test Dates.isweekday(Jan; locale = 3) == true
+	@test Dates.isweekday(Dec; locale = 3) == true
+	@test Dates.isweekday(Apr; locale = 3) == true
+	@test Dates.isweekday(Jun; locale = 3) == true
+	@test Dates.isweekday(Feb; locale = 3) == true
+	@test Dates.isweekday(Mar; locale = 3) == false
+	
+	@test Dates.isweekday(Nov; locale = 4) == true
+	@test Dates.isweekday(Jan; locale = 4) == true
+	@test Dates.isweekday(Dec; locale = 4) == true
+	@test Dates.isweekday(Apr; locale = 4) == true
+	@test Dates.isweekday(Jun; locale = 4) == false
+	@test Dates.isweekday(Feb; locale = 4) == true
+	@test Dates.isweekday(Mar; locale = 4) == true
+	
+end
+
+@testset "isweekend" begin
+	@test Dates.isweekend(Nov; locale = 1) == false 
+	@test Dates.isweekend(Jan; locale = 1) == false 
+	@test Dates.isweekend(Dec; locale = 1) == false 
+	@test Dates.isweekend(Apr; locale = 1) == false 
+	@test Dates.isweekend(Jun; locale = 1) == false 
+	@test Dates.isweekend(Feb; locale = 1) == true 
+	@test Dates.isweekend(Mar; locale = 1) == true 
+	
+	@test Dates.isweekend(Nov; locale = 2) == false 
+	@test Dates.isweekend(Jan; locale = 2) == false 
+	@test Dates.isweekend(Dec; locale = 2) == false 
+	@test Dates.isweekend(Apr; locale = 2) == false 
+	@test Dates.isweekend(Jun; locale = 2) == true 
+	@test Dates.isweekend(Feb; locale = 2) == true 
+	@test Dates.isweekend(Mar; locale = 2) == false 
+	
+	@test Dates.isweekend(Nov; locale = 3) == false 
+	@test Dates.isweekend(Jan; locale = 3) == false 
+	@test Dates.isweekend(Dec; locale = 3) == false 
+	@test Dates.isweekend(Apr; locale = 3) == false 
+	@test Dates.isweekend(Jun; locale = 3) == false 
+	@test Dates.isweekend(Feb; locale = 3) == false 
+	@test Dates.isweekend(Mar; locale = 3) == true
+	
+	@test Dates.isweekend(Nov; locale = 4) == false 
+	@test Dates.isweekend(Jan; locale = 4) == false 
+	@test Dates.isweekend(Dec; locale = 4) == false 
+	@test Dates.isweekend(Apr; locale = 4) == false 
+	@test Dates.isweekend(Jun; locale = 4) == true
+	@test Dates.isweekend(Feb; locale = 4) == false 
+	@test Dates.isweekend(Mar; locale = 4) == false 
+	
+end
 
 end


### PR DESCRIPTION
Based off of issue #41058 , I created the following PR which adds in two functions to determine whether a day of the week falls on a weekday or weekend. This also contains the four most common locales for when these days occur. 

Closes #41058 