### PR TITLE
fix #40814, improve type stability of `_totuple`

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -327,7 +327,11 @@ function _totuple(T, itr, s...)
     @_inline_meta
     y = iterate(itr, s...)
     y === nothing && _totuple_err(T)
-    return (convert(fieldtype(T, 1), y[1]), _totuple(tuple_type_tail(T), itr, y[2])...)
+    t1 = convert(fieldtype(T, 1), y[1])
+    # inference may give up in recursive calls, so annotate here to force accurate return type to be propagated
+    rT = tuple_type_tail(T)
+    ts = _totuple(rT, itr, y[2])::rT
+    return (t1, ts...)
 end
 
 # use iterative algorithm for long tuples

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -631,3 +631,6 @@ f38837(xs) = map((F,x)->F(x), (Float32, Float64), xs)
     @test_throws BoundsError (1, 2)[0:2]
     @test_throws ArgumentError (1, 2)[OffsetArrays.IdOffsetRange(1:2, -1)]
 end
+
+# https://github.com/JuliaLang/julia/issues/40814
+@test Base.return_types(NTuple{3,Int}, (Vector{Int},)) == Any[NTuple{3,Int}]


### PR DESCRIPTION
Replaces #40987, as suggested by #40814.

We can simply add an annotation to force the return type to be propagated to a caller,
even when inference gives up anywhere in recursed calls.