### PR TITLE
AbstractInterpreter: introduce `OptimizationState` only when the optimization is turned on

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -105,7 +105,7 @@ function OptimizationState(linfo::MethodInstance, params::OptimizationParams, in
 end
 
 function ir_to_codeinf!(opt::OptimizationState)
-    replace_code_newstyle!(opt.src, opt.ir, opt.nargs - 1)
+    replace_code_newstyle!(opt.src, opt.ir::IRCode, opt.nargs - 1)
     opt.ir = nothing
     let src = opt.src::CodeInfo
         widen_all_consts!(src)
@@ -198,7 +198,7 @@ function stmt_affects_purity(@nospecialize(stmt), ir)
 end
 
 # Convert IRCode back to CodeInfo and compute inlining cost and sideeffects
-function finish(interp::AbstractInterpreter, opt::OptimizationState, params::OptimizationParams, ir, @nospecialize(result))
+function finish(interp::AbstractInterpreter, opt::OptimizationState, params::OptimizationParams, ir::IRCode, @nospecialize(result))
     def = opt.linfo.def
     nargs = Int(opt.nargs) - 1
 


### PR DESCRIPTION
Currently `OptimizationState` can be introduced even when `may_optimize`
returns `false`, and it can lead to a problem in `ir_to_codeinf!` call,
that takes `OptimizationState` and expects it to hold optimized `IRCode`,
which doesn't necessarily happen when the optimization passes are turned
off by an external `AbstractInterpreter`.

With this PR, `OptimizationState` is introduced only when the optimization
is turned on, and the problem described above won't happen anymore.