### PR TITLE
apply unicode normalization in help mode

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -312,7 +312,7 @@ astname(@nospecialize(other), ismacro::Bool) = other
 macroname(s::Symbol) = Symbol('@', s)
 macroname(x::Expr)   = Expr(x.head, x.args[1], macroname(x.args[end].value))
 
-isfield(@nospecialize x) = isexpr(x, :.) && length(x.args) == 2 &&
+isfield(@nospecialize x) = isexpr(x, :., 2) &&
     (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
     (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
 

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -312,7 +312,7 @@ astname(@nospecialize(other), ismacro::Bool) = other
 macroname(s::Symbol) = Symbol('@', s)
 macroname(x::Expr)   = Expr(x.head, x.args[1], macroname(x.args[end].value))
 
-isfield(@nospecialize x) = isexpr(x, :.) &&
+isfield(@nospecialize x) = isexpr(x, :.) && length(x.args) == 2 &&
     (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
     (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
 

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -32,11 +32,13 @@ import Markdown
     @test all(duplicates .∈ Ref(keys(REPLCompletions.symbols_latex_canonical)))
 end
 
-@testset "unicode normalization" begin
+@testset "unicode operators" begin
     @test contains(let buf = IOBuffer()
             Core.eval(Main, REPL.helpmode(buf, "\u2212"))
             String(take!(buf))
         end, "\nsearch: - ")
+
+    @test REPL.lookup_doc(:⊻=) == Markdown.parse("`x ⊻= y` is a synonym for `x = x ⊻ y`")
 end
 
 @testset "quoting in doc search" begin

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -20,10 +20,23 @@ import Markdown
             String(take!(buf))
         end, "\"ᵞ₁₂₃¹²³α\" can be typed by \\^gamma<tab>\\_123<tab>\\^123<tab>\\alpha<tab>\n")
 
+    # Check symbol completion for a symbol that gets normalized by the parser
+    @test startswith(let buf = IOBuffer()
+            Core.eval(Main, REPL.helpmode(buf, "\u2212"))
+            String(take!(buf))
+        end, "\"−\" can be typed by \\minus<tab>\n")
+
     # Check that all symbols with several completions have a canonical mapping (#39148)
     symbols = values(REPLCompletions.latex_symbols)
     duplicates = [v for v in unique(symbols) if count(==(v), symbols) > 1]
     @test all(duplicates .∈ Ref(keys(REPLCompletions.symbols_latex_canonical)))
+end
+
+@testset "unicode normalization" begin
+    @test contains(let buf = IOBuffer()
+            Core.eval(Main, REPL.helpmode(buf, "\u2212"))
+            String(take!(buf))
+        end, "\nsearch: - ")
 end
 
 @testset "quoting in doc search" begin

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1100,8 +1100,34 @@ for (line, expr) in Pair[
     "r\"...\""     => Expr(:macrocall, Symbol("@r_str"), LineNumberNode(1, :none), "..."),
     "using Foo"    => :using,
     "import Foo"   => :import,
+    "# comment"    => Symbol("#"),
+    "#= foo\n=#"   => Symbol("#="),
+    "=#"           => Symbol("=#"),
+    "+"            => :+,
+    "+="           => :+=,
+    ".+"           => :.+,
+    ".+="          => :.+=,
+    "⊻"            => :⊻,
+    "⊻="           => :⊻=,
+    ".⊻"           => :.⊻,
+    ".⊻="          => :.⊻=,
+    "\u2212"       => :-,
+    "\u2212="      => :-=,
+    ".\u2212"      => :.-,
+    ".\u2212="     => :.-=,
+    "1+2"          => :(1 + 2),
+    "1⊻2"          => :(1 ⊻ 2),
+    "1\u22122"     => :(1 - 2),
+    "+ 1"          => :(+ 1),
+    "\u2212 1"     => :(- 1),
+    "+1"           => +1,
+    "\u22121"      => -1,
+    "2e-2"         => 2e-2,
+    "2e\u22122"    => 2e-2,
+    "\ub5"         => Symbol("\u03bc"), # µ (U+00B5 micro) -> μ (U+03BC greek small letter mu)
+    "\ub7"         => Symbol("\u22c5"), # \cdotp -> \cdot
     ]
-    @test REPL._helpmode(line).args[4] == expr
+    @test REPL._helpmode_parse(line) == expr
     @test help_result(line) isa Union{Markdown.MD,Nothing}
 end
 


### PR DESCRIPTION
This adapts the help mode to recent changes from #40948 and #25157.

Before:
```
help?> −
"−" can be typed by \minus<tab>

search:

  No documentation found.

  Binding − does not exist.
```

Now:
```
help?> −
"−" can be typed by \minus<tab>

search: - ->

  -(x)

  Unary minus operator.
  ...
```

Same for `help?> \cdotp<tab>` when `\cdot` has been bound.

Note that `help?> 1e−2` already worked.