### PR TITLE
LinearAlgebra: ignore S.ev[length(S.dv)] in ishermitian(S:SymTridiagonal)

### DIFF
--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -170,7 +170,7 @@ adjoint(S::SymTridiagonal) = Adjoint(S)
 Base.copy(S::Adjoint{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(adjoint.(x)), (S.parent.dv, S.parent.ev))...)
 Base.copy(S::Transpose{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(transpose.(x)), (S.parent.dv, S.parent.ev))...)
 
-ishermitian(S::SymTridiagonal) = isreal(S.dv) && isreal(S.ev)
+ishermitian(S::SymTridiagonal) = isreal(S.dv) && isreal(@view S.ev[begin:length(S.dv) - 1])
 issymmetric(S::SymTridiagonal) = true
 
 function diag(M::SymTridiagonal{<:Number}, n::Integer=0)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -635,8 +635,8 @@ end
     # https://github.com/JuliaLang/julia/pull/41037#discussion_r645524081
     S = SymTridiagonal(randn(5) .+ 0im, randn(5) .+ 0im)
     S.ev[end] = im
-    @test issymmetric(A)
-    @test ishermitian(A)
+    @test issymmetric(S)
+    @test ishermitian(S)
 
     S = SymTridiagonal(randn(5) .+ 1im, randn(4) .+ 1im)
     @test issymmetric(S)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -632,6 +632,12 @@ end
     @test !ishermitian(A)
 
     # complex
+    # https://github.com/JuliaLang/julia/pull/41037#discussion_r645524081
+    S = SymTridiagonal(randn(5) .+ 0im, randn(5) .+ 0im)
+    S.ev[end] = im
+    @test issymmetric(A)
+    @test ishermitian(A)
+
     S = SymTridiagonal(randn(5) .+ 1im, randn(4) .+ 1im)
     @test issymmetric(S)
     @test !ishermitian(S)


### PR DESCRIPTION
SymTridiagonal allows `dv` and `ev` to have the same length, in which case the last element of `ev` isn't part of the matrix. Thus it doesn't matter, and should be ignored when checking if `ev` is real.

Thanks to @sostock for pointing this out in https://github.com/JuliaLang/julia/pull/41037#discussion_r645524081.
