### PR TITLE
workaround for #40048, stack overflow in type intersection

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1597,6 +1597,8 @@ static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **is
     *isect = jl_type_intersection_env_s(t1, t2, NULL, &is_subty);
     if (*isect == jl_bottom_type)
         return 0;
+    // TODO: This extra call to intersection sometimes hits bad cases, e.g. issue #40048.
+    /*
     if (is_subty)
         return 1;
     // TODO: sometimes type intersection returns types with free variables
@@ -1613,6 +1615,7 @@ static int jl_type_intersection2(jl_value_t *t1, jl_value_t *t2, jl_value_t **is
     if (jl_types_egal(*isect2, *isect)) {
         *isect2 = NULL;
     }
+    */
     return 1;
 }
 


### PR DESCRIPTION
This is yet another case where we end up creating circular variable constraints inside intersection. I have tried some approaches to fixing it, but so far it is proving tricky to both fully avoid the problem and preserve precision.

For some reason this call site has tended to lead to these sorts of tricky intersection cases, and does not seem to be 100% necessary, so I propose disabling it for now.