### PR TITLE
Code coverage: tell Codecov to ignore all external stdlibs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+ignore:
+  # ignore all external stdlibs (i.e. stdlibs that live in external repos)
+  - "stdlib/ArgTools"
+  - "stdlib/Downloads"
+  - "stdlib/LibCURL"
+  - "stdlib/NetworkOptions"
+  - "stdlib/Pkg"
+  - "stdlib/Statistics"
+  - "stdlib/SuiteSparse"
+  - "stdlib/Tar"


### PR DESCRIPTION
Fixes #41098 
Fixes https://github.com/JuliaCI/CoverageBase.jl/issues/36

This pull request tells Codecov to ignore all external stdlibs. (An external stdlib is a stdlib that lives in an external repository.)

Non-external stdlibs (i.e. stdlibs that live in the `JuliaLang/julia` repository) will continue to be included in Codecov.

A few notes:
1. Since we don't report code coverage on PRs, the benefit of this PR won't become visible until we merge it into `master`.
2. This PR covers all external stdlibs (including SuiteSparse), but it does not cover the stdlib JLLs. If this PR works out well, I can make a follow-up PR to handle the stdlib JLLs.
2. This PR takes care of Codecov, but it does not address Coveralls. If this PR works out well, I will make a follow-up PR to handle Coveralls.