### PR TITLE
add Xoshiro(seed) constructor, and extend some tests to Xoshiro

### DIFF
--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -23,6 +23,9 @@ mutable struct Xoshiro <: AbstractRNG
     s1::UInt64
     s2::UInt64
     s3::UInt64
+
+    Xoshiro(s0::Integer, s1::Integer, s2::Integer, s3::Integer) = new(s0, s1, s2, s3)
+    Xoshiro(seed) = seed!(new(), seed)
 end
 
 Xoshiro(::Nothing) = Xoshiro()


### PR DESCRIPTION
Usually, a seed should be equally valid for an RNG constructor or for
a call to `seed!`, as `seed!`'s docstring mentions:

> After the call to seed!, rng is equivalent to a newly created object
> initialized with the same seed.