### PR TITLE
simplify seeding for Xoshiro/TaskLocalRNG/GLOBAL_RNG

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -377,15 +377,15 @@ copy(::_GLOBAL_RNG) = copy(default_rng())
 
 GLOBAL_SEED = 0
 
-seed!(::_GLOBAL_RNG, seed) = (global GLOBAL_SEED = seed; seed!(default_rng(), seed))
-
-function seed!(rng::_GLOBAL_RNG)
-    seed!(rng, (rand(RandomDevice(), UInt64), rand(RandomDevice(), UInt64),
-                rand(RandomDevice(), UInt64), rand(RandomDevice(), UInt64)))
+function seed!(::_GLOBAL_RNG, seed=rand(RandomDevice(), UInt64, 4))
+    global GLOBAL_SEED = seed
+    seed!(default_rng(), seed)
 end
-seed!() = seed!(GLOBAL_RNG)
+
 seed!(rng::_GLOBAL_RNG, ::Nothing) = seed!(rng)  # to resolve ambiguity
-seed!(seed::Union{Integer,Vector{UInt32},Vector{UInt64},NTuple{4,UInt64}}) = seed!(GLOBAL_RNG, seed)
+
+seed!(seed::Union{Nothing,Integer,Vector{UInt32},Vector{UInt64},NTuple{4,UInt64}}=nothing) =
+    seed!(GLOBAL_RNG, seed)
 
 rng_native_52(::_GLOBAL_RNG) = rng_native_52(default_rng())
 rand(::_GLOBAL_RNG, sp::SamplerBoolBitInteger) = rand(default_rng(), sp)

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -698,6 +698,40 @@ end
     end
 end
 
+@testset "Random.seed!(seed) sets Random.GLOBAL_SEED" begin
+    seeds = Any[0, rand(UInt128), rand(UInt64, 4), Tuple(rand(UInt64, 4))]
+
+    for seed=seeds
+        Random.seed!(seed)
+        @test Random.GLOBAL_SEED === seed
+    end
+    # two separate loops as otherwise we are no sure that the second call (with GLOBAL_RNG)
+    # actually sets GLOBAL_SEED
+    for seed=seeds
+        Random.seed!(Random.GLOBAL_RNG, seed)
+        @test Random.GLOBAL_SEED === seed
+    end
+
+    Random.seed!(nothing)
+    seed1 = Random.GLOBAL_SEED
+    @test seed1 isa Vector{UInt64} # could change, but must not be nothing
+
+    Random.seed!(Random.GLOBAL_RNG, nothing)
+    seed2 = Random.GLOBAL_SEED
+    @test seed2 isa Vector{UInt64}
+    @test seed2 != seed1
+
+    Random.seed!()
+    seed3 = Random.GLOBAL_SEED
+    @test seed3 isa Vector{UInt64}
+    @test seed3 != seed2
+
+    Random.seed!(Random.GLOBAL_RNG)
+    seed4 = Random.GLOBAL_SEED
+    @test seed4 isa Vector{UInt64}
+    @test seed4 != seed3
+end
+
 struct RandomStruct23964 end
 @testset "error message when rand not defined for a type" begin
     @test_throws ArgumentError rand(nothing)


### PR DESCRIPTION
1. `seed!(rng::Xoshiro, seed::NTuple{4,UInt64})` and
   `seed!(rng::TaskLocalRNG, seed::NTuple{4,UInt64})` were doing almost the same thing;
   factor out what was identical;
2. `seed!(rng::Union{TaskLocalRNG, Xoshiro})` was calling the above methods passing
   a random tuple generated by `RandomDevice`: in this case, we don't really need
   to hash the seed, as it's presumably random enough; so use the same algorithm
   as in `Xoshiro()` constructor, and let `Xoshiro()` re-use this new implementation
   of `seed!`.