### PR TITLE
inference: Add some basic inference for PhiNode

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1421,6 +1421,13 @@ end
 
 function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), vtypes::VarTable, sv::InferenceState)
     if !isa(e, Expr)
+        if isa(e, PhiNode)
+            rt = Union{}
+            for val in e.values
+                rt = tmerge(rt, abstract_eval_special_value(interp, val, vtypes, sv))
+            end
+            return rt
+        end
         return abstract_eval_special_value(interp, e, vtypes, sv)
     end
     e = e::Expr

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -672,9 +672,7 @@ function type_annotate!(sv::InferenceState, run_optimizer::Bool)
                 deleteat!(src.codelocs, i)
                 deleteat!(sv.stmt_info, i)
                 nexpr -= 1
-                if oldidx < length(changemap)
-                    changemap[oldidx + 1] = -1
-                end
+                changemap[oldidx] = -1
                 continue
             else
                 body[i] = Const(expr) # annotate that this statement actually is dead

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -267,6 +267,8 @@ function find_ssavalue_uses(body::Vector{Any}, nvals::Int)
             push!(uses[e.id], line)
         elseif isa(e, Expr)
             find_ssavalue_uses(e, uses, line)
+        elseif isa(e, PhiNode)
+            find_ssavalue_uses(e, uses, line)
         end
     end
     return uses
@@ -283,6 +285,14 @@ function find_ssavalue_uses(e::Expr, uses::Vector{BitSet}, line::Int)
             push!(uses[a.id], line)
         elseif isa(a, Expr)
             find_ssavalue_uses(a, uses, line)
+        end
+    end
+end
+
+function find_ssavalue_uses(e::PhiNode, uses::Vector{BitSet}, line::Int)
+    for val in e.values
+        if isa(val, SSAValue)
+            push!(uses[val.id], line)
         end
     end
 end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4087,9 +4087,13 @@ static void emit_vi_assignment_unboxed(jl_codectx_t &ctx, jl_varinfo_t &vi, Valu
 static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
 {
     jl_value_t *ssavalue_types = (jl_value_t*)ctx.source->ssavaluetypes;
-    assert(jl_is_array(ssavalue_types));
+    jl_value_t *phiType = NULL;
+    if (jl_is_array(ssavalue_types)) {
+        phiType = jl_array_ptr_ref(ssavalue_types, idx);
+    } else {
+        phiType = (jl_value_t*)jl_any_type;
+    }
     jl_array_t *edges = (jl_array_t*)jl_fieldref_noalloc(r, 0);
-    jl_value_t *phiType = jl_array_ptr_ref(ssavalue_types, idx);
     BasicBlock *BB = ctx.builder.GetInsertBlock();
     auto InsertPt = BB->getFirstInsertionPt();
     if (phiType == jl_bottom_type) {


### PR DESCRIPTION
PhiNode isn't really supported in lowered IR, but it is convenient
to be able to emit it, particularly for code that is designed to
perform transformations both on typed and on lowered IR (such as
Diffractor). Moreover, we do actually supported phinodes in untyped
IR both in the interpreter and in the compiler. At the moment,
inference assumes that PhiNodes get treated as embedded constants,
which is just not what the actual implementation does. At the very
least, it should just leave PhiNodes alone in case they accidentally
end up in lowered IR (rather than causing crashes), but we might
as well give them some basic support.