### PR TITLE
fix lpad/rpad for zero-textwidth padding

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -327,7 +327,7 @@ strip(f, s::AbstractString) = lstrip(f, rstrip(f, s))
     lpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') -> String
 
 Stringify `s` and pad the resulting string on the left with `p` to make it `n`
-characters (in [`textwidth`](@ref)) long. If `s` is already `n` characters long, an equal
+characters long (in [`textwidth`](@ref), or in [`length`](@ref) if `p` has zero `textwidth`). If `s` is already `n` characters long, an equal
 string is returned. Pad with spaces by default.
 
 # Examples
@@ -346,9 +346,15 @@ function lpad(
     p::Union{AbstractChar,AbstractString}=' ',
 ) :: String
     n = Int(n)::Int
-    m = signed(n) - Int(textwidth(s))::Int
-    m ≤ 0 && return string(s)
     l = textwidth(p)
+    if iszero(l)
+        l = length(p)
+        w = length(s)
+    else
+        w = textwidth(s)
+    end
+    m = n - w
+    m ≤ 0 && return string(s)
     q, r = divrem(m, l)
     r == 0 ? string(p^q, s) : string(p^q, first(p, r), s)
 end
@@ -357,7 +363,7 @@ end
     rpad(s, n::Integer, p::Union{AbstractChar,AbstractString}=' ') -> String
 
 Stringify `s` and pad the resulting string on the right with `p` to make it `n`
-characters (in [`textwidth`](@ref)) long. If `s` is already `n` characters long, an equal
+characters long (in [`textwidth`](@ref), or in [`length`](@ref) if `p` has zero `textwidth`). If `s` is already `n` characters long, an equal
 string is returned. Pad with spaces by default.
 
 # Examples
@@ -376,7 +382,14 @@ function rpad(
     p::Union{AbstractChar,AbstractString}=' ',
 ) :: String
     n = Int(n)::Int
-    m = signed(n) - Int(textwidth(s))::Int
+    l = textwidth(p)
+    if iszero(l)
+        l = length(p)
+        w = length(s)
+    else
+        w = textwidth(s)
+    end
+    m = n - w
     m ≤ 0 && return string(s)
     l = textwidth(p)
     q, r = divrem(m, l)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -391,7 +391,6 @@ function rpad(
     end
     m = n - w
     m ≤ 0 && return string(s)
-    l = textwidth(p)
     q, r = divrem(m, l)
     r == 0 ? string(s, p^q) : string(s, p^q, first(p, r))
 end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -49,6 +49,9 @@
     @test rpad("⟨k|H₁|k̃⟩", 12) |> textwidth == 12
     @test lpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
     @test rpad("⟨k|H₁|k⟩", 12) |> textwidth == 12
+    # lpad/rpad with zero-textwidth padding:
+    @test lpad("foo", 6, '\0') == "\0\0\0foo"
+    @test rpad("foo", 6, '\0') == "foo\0\0\0"
 end
 
 # string manipulation


### PR DESCRIPTION
Hopefully fixes test failure caused by backwards-incompatible change in #39044.  Alternative to #41131.