### PR TITLE
document getindex() with range of length 1.

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -695,6 +695,12 @@ julia> A[:, 3]
  13
  15
  17
+
+julia> A[:, 3:3]
+3×1 Matrix{Int64}:
+ 13
+ 15
+ 17
 ```
 
 ### Cartesian indices


### PR DESCRIPTION
Added an example with a range of length=1 instead of an Integer (`A[:, 3:3]`) which returns a Matrix instead of a vector. Somebody made me aware of this behavior on [stackoverflow](https://stackoverflow.com/questions/67889148/let-indexing-return-a-matrix-instead-of-a-vector-in-julia), but I couldn't find an example of it in the documentation. I thought it might be an improvement. 