### PR TITLE
Refinements to `hvncat`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2386,7 +2386,7 @@ function _typed_hvncat(::Type{T}, shape::NTuple{N, Tuple}, row_first::Bool, as..
     lengthas = length(as)
     shapelength == lengthas ||
         throw(ArgumentError("number of elements does not match shape; expected $(shapelength), got $lengthas)"))
-    
+
     for i ∈ eachindex(as)
         wasstartblock = false
         for d ∈ 1:nd

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2254,7 +2254,7 @@ function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as...) 
 
     currentdims = zeros(Int, nd)
     blockcount = 0
-    for i ∈ eachindex(as)
+    @inbounds for i ∈ eachindex(as)
         currentdims[d1] += cat_size(as[i], d1)
         if currentdims[d1] == outdims[d1]
             currentdims[d1] = 0

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2374,7 +2374,6 @@ function _typed_hvncat(::Type{T}, shape::Tuple{Vararg{Tuple, N}}, row_first::Boo
     # @assert all(==(0), blockcounts)
 
     # copy into final array
-    # A = Array{T, nd}(undef, outdims...)
     A = cat_similar(as[1], T, outdims)
     hvncat_fill!(A, currentdims, blockcounts, d1, d2, as)
     return A

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2121,7 +2121,6 @@ _hvncat(dimsshape::Union{Tuple, Int}, row_first::Bool, xs::Number...) = _typed_h
 _hvncat(dimsshape::Union{Tuple, Int}, row_first::Bool, xs::AbstractArray...) = _typed_hvncat(promote_eltype(xs...), dimsshape, row_first, xs...)
 _hvncat(dimsshape::Union{Tuple, Int}, row_first::Bool, xs::AbstractArray{T}...) where T = _typed_hvncat(T, dimsshape, row_first, xs...)
 
-typed_hvncat(T::Type, dimsshape::NTuple{1}, row_first::Bool, xs...) = _typed_hvncat(T, dimsshape, row_first, xs...)
 typed_hvncat(T::Type, dimsshape::Tuple, row_first::Bool, xs...) = _typed_hvncat(T, dimsshape, row_first, xs...)
 typed_hvncat(T::Type, dim::Int, xs...) = _typed_hvncat(T, Val(dim), xs...)
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2339,7 +2339,9 @@ function _typed_hvncat(::Type{T}, shape::NTuple{N, Tuple}, row_first::Bool, as..
     lengthas = length(as)
     shapelength == lengthas || throw(ArgumentError("number of elements does not match shape; expected $(shapelength), got $lengthas)"))
     all(!isempty, shapev) || throw(ArgumentError("each level of `shape` argument must have at least one value"))
-    sum(tuple((shape...)...)) == N * shapelength || throw(ArgumentError("all levels of `shape` argument must sum to the same value"))
+    for i ∈ eachindex(shapev)
+        sum(shapev[i]) == shapelength || throw(ArgumentError("all levels of `shape` argument must sum to the same value"))
+    end
 
     for i ∈ eachindex(as)
         wasstartblock = false
@@ -2366,6 +2368,9 @@ function _typed_hvncat(::Type{T}, shape::NTuple{N, Tuple}, row_first::Bool, as..
                 currentdims[d] = 0
                 blockcounts[d] = 0
                 shapepos[d] += 1
+                d > 1 && (blockcounts[d - 1] == 0 ||
+                    throw(ArgumentError("shape in level $d is inconsistent; level counts must nest \
+                                         evenly into each other")))
             end
         end
     end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2219,6 +2219,7 @@ end
 
 _typed_hvncat(::Type{T}, ::Tuple{}, ::Bool) where T = Vector{T}()
 _typed_hvncat(::Type{T}, ::Tuple{}, ::Bool, x) where T = fill(T(x))
+_typed_hvncat(::Type{T}, ::Tuple{}, ::Bool, x::Number) where T = fill(T(x))
 _typed_hvncat(::Type{T}, ::Tuple{}, ::Bool, x::AbstractArray) where T = T.(x) # could reduce broadcast overhead?
 _typed_hvncat(::Type, ::Tuple{}, ::Bool, ::Any...) =
     throw(ArgumentError("a 0-dimensional array may not have more than one element"))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2144,7 +2144,7 @@ _typed_hvncat(T::Type, dim::Int, ::Bool, xs...) = _typed_hvncat(T, Val(dim), xs.
 
 _typed_hvncat(::Type{T}, ::Val{0}) where T = Vector{T}()
 _typed_hvncat(::Type{T}, ::Val{0}, x) where T = fill(T(x))
-_typed_hvncat(::Type{T}, ::Val{0}, x::AbstractArray) where T = T.(x) # could reduce broadcast overhead?
+_typed_hvncat(::Type{T}, ::Val{0}, x::AbstractArray) where T = T.(x)
 _typed_hvncat(::Type, ::Val{0}, ::Any...) =
     throw(ArgumentError("a 0-dimensional array may not have more than one element"))
 
@@ -2220,7 +2220,7 @@ end
 _typed_hvncat(::Type{T}, ::Tuple{}, ::Bool) where T = Vector{T}()
 _typed_hvncat(::Type{T}, ::Tuple{}, ::Bool, x) where T = fill(T(x))
 _typed_hvncat(::Type{T}, ::Tuple{}, ::Bool, x::Number) where T = fill(T(x))
-_typed_hvncat(::Type{T}, ::Tuple{}, ::Bool, x::AbstractArray) where T = T.(x) # could reduce broadcast overhead?
+_typed_hvncat(::Type{T}, ::Tuple{}, ::Bool, x::AbstractArray) where T = T.(x)
 _typed_hvncat(::Type, ::Tuple{}, ::Bool, ::Any...) =
     throw(ArgumentError("a 0-dimensional array may not have more than one element"))
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2134,6 +2134,8 @@ julia> hvncat(((3, 3), (3, 3), (6,)), true, a, b, c, d, e, f)
 """
 function hvncat end
 
+# if any methods seem redundant here, it is to resolve a multiple dispatch ambiguity
+
 # top-level methods
 
 hvncat(dimsshape::Tuple, row_first::Bool, xs...) = _hvncat(dimsshape, row_first, xs...)
@@ -2165,6 +2167,8 @@ _typed_hvncat(T::Type, dim::Int, ::Bool, xs...) = _typed_hvncat(T, Val(dim), xs.
 _typed_hvncat(::Type{T}, ::Val{0}) where T = Vector{T}()
 _typed_hvncat(::Type{T}, ::Val{0}, x) where T = fill(T(x))
 _typed_hvncat(::Type{T}, ::Val{0}, x::AbstractArray) where T = T.(x)
+_typed_hvncat(::Type, ::Val{0}, ::AbstractArray...) =
+    throw(ArgumentError("a 0-dimensional array may not have more than one element"))
 _typed_hvncat(::Type, ::Val{0}, ::Any...) =
     throw(ArgumentError("a 0-dimensional array may not have more than one element"))
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2227,6 +2227,7 @@ _typed_hvncat(::Type, ::Tuple{}, ::Bool, ::Any...) =
 # balanced dimensions hvncat methods
 
 _typed_hvncat(T::Type, dims::Tuple{Int}, ::Bool, as...) = _typed_hvncat_1d(T, dims[1], Val(false), as...)
+_typed_hvncat(T::Type, dims::Tuple{Int}, ::Bool, as::Number...) = _typed_hvncat_1d(T, dims[1], Val(false), as...)
 
 function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, xs::Number...) where {T, N}
     length(xs) > 0 || throw(ArgumentError("must have at least one element"))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2258,12 +2258,12 @@ function _typed_hvncat(::Type{T}, dims::Tuple{Vararg{Int, N}}, row_first::Bool, 
                     elseif currentdims[d] < outdims[d] # dimension in progress
                         break
                     else # exceeded dimension
-                        ArgumentError("argument $i has too many elements along axis $d") |> throw
+                        throw(ArgumentError("argument $i has too many elements along axis $d"))
                     end
                 end
             end
         elseif currentdims[d1] > outdims[d1] # exceeded dimension
-            ArgumentError("argument $i has too many elements along axis $d1") |> throw
+            throw(ArgumentError("argument $i has too many elements along axis $d1"))
         end
     end
 
@@ -2273,8 +2273,8 @@ function _typed_hvncat(::Type{T}, dims::Tuple{Vararg{Int, N}}, row_first::Bool, 
         len += cat_length(a)
     end
     outlen = prod(outdims)
-    outlen == 0 && ArgumentError("too few elements in arguments, unable to infer dimensions") |> throw
-    len == outlen || ArgumentError("too many elements in arguments; expected $(outlen), got $(len)") |> throw
+    outlen == 0 && throw(ArgumentError("too few elements in arguments, unable to infer dimensions"))
+    len == outlen || throw(ArgumentError("too many elements in arguments; expected $(outlen), got $(len)"))
 
     # copy into final array
     A = cat_similar(as[1], T, outdims)
@@ -2315,7 +2315,7 @@ function _typed_hvncat(::Type{T}, shape::Tuple{Vararg{Tuple, N}}, row_first::Boo
             if d == 1 || i == 1 || wasstartblock
                 currentdims[d] += dsize
             elseif dsize != cat_size(as[i - 1], ad)
-                ArgumentError("argument $i has a mismatched number of elements along axis $ad; expected $(cat_size(as[i - 1], ad)), got $dsize") |> throw
+                throw(ArgumentError("argument $i has a mismatched number of elements along axis $ad; expected $(cat_size(as[i - 1], ad)), got $dsize"))
             end
 
             wasstartblock = blockcounts[d] == 1 # remember for next dimension
@@ -2325,7 +2325,7 @@ function _typed_hvncat(::Type{T}, shape::Tuple{Vararg{Tuple, N}}, row_first::Boo
                 if outdims[d] == 0
                     outdims[d] = currentdims[d]
                 elseif outdims[d] != currentdims[d]
-                    ArgumentError("argument $i has a mismatched number of elements along axis $ad; expected $(abs(outdims[d] - (currentdims[d] - dsize))), got $dsize") |> throw
+                    throw(ArgumentError("argument $i has a mismatched number of elements along axis $ad; expected $(abs(outdims[d] - (currentdims[d] - dsize))), got $dsize"))
                 end
                 currentdims[d] = 0
                 blockcounts[d] = 0

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2290,7 +2290,7 @@ _typed_hvncat(T::Type, shape::Tuple{Tuple}, row_first::Bool, xs...) =
 
 function _typed_hvncat(::Type{T}, shape::NTuple{N, Tuple}, row_first::Bool, as...) where {T, N}
     all(>(0), tuple((shape...)...)) || throw(ArgumentError("`shape` argument must consist of positive integers"))
-    
+
     d1 = row_first ? 2 : 1
     d2 = row_first ? 1 : 2
 
@@ -2376,7 +2376,7 @@ function hvncat_fill!(A::Array, row_first::Bool, xs::Tuple)
         nrc = nr * nc
         na = prod(size(A)[3:end])
         len = length(xs)
-        
+
         k = 1
         @inbounds for d ∈ 1:na
             dd = nrc * (d - 1)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2239,6 +2239,7 @@ function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, xs::Num
 end
 
 function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as...) where {T, N}
+    all(>(0), dims) || throw(ArgumentError("`dims` argument must contain positive integers"))
     d1 = row_first ? 2 : 1
     d2 = row_first ? 1 : 2
 
@@ -2393,14 +2394,12 @@ function hvncat_fill!(A::Array, row_first::Bool, xs::Tuple)
         nr, nc = size(A, 1), size(A, 2)
         nrc = nr * nc
         na = prod(size(A)[3:end])
-        len = length(xs)
-
         k = 1
         @inbounds for d ∈ 1:na
             dd = nrc * (d - 1)
             for i ∈ 1:nr
                 Ai = dd + i
-                for j ∈ 1:nc
+                for _ ∈ 1:nc
                     A[Ai] = xs[k]
                     k += 1
                     Ai += nr

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2254,7 +2254,7 @@ function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as...) 
 
     currentdims = zeros(Int, nd)
     blockcount = 0
-    @inbounds for i ∈ eachindex(as)
+    for i ∈ eachindex(as)
         currentdims[d1] += cat_size(as[i], d1)
         if currentdims[d1] == outdims[d1]
             currentdims[d1] = 0
@@ -2334,7 +2334,7 @@ function _typed_hvncat(::Type{T}, shape::NTuple{N, Tuple}, row_first::Bool, as..
     all(!isempty, shapev) || throw(ArgumentError("each level of `shape` argument must have at least one value"))
     sum(tuple((shape...)...)) == N * shapelength || throw(ArgumentError("all levels of `shape` argument must sum to the same value"))
 
-    @inbounds for i ∈ eachindex(as)
+    for i ∈ eachindex(as)
         wasstartblock = false
         for d ∈ 1:nd
             ad = (d < 3 && row_first) ? (d == 1 ? 2 : 1) : d
@@ -2424,7 +2424,7 @@ end
     for a ∈ as
         if isa(a, AbstractArray)
             for ai ∈ a
-                Ai = hvncat_calcindex(offsets, inneroffsets, outdims, N)
+                @inbounds Ai = hvncat_calcindex(offsets, inneroffsets, outdims, N)
                 A[Ai] = ai
 
                 @inbounds for j ∈ 1:N
@@ -2434,7 +2434,7 @@ end
                 end
             end
         else
-            Ai = hvncat_calcindex(offsets, inneroffsets, outdims, N)
+            @inbounds Ai = hvncat_calcindex(offsets, inneroffsets, outdims, N)
             A[Ai] = a
         end
 
@@ -2446,9 +2446,9 @@ end
     end
 end
 
-@inline function hvncat_calcindex(offsets::Vector{Int}, inneroffsets::Vector{Int}, outdims::Tuple{Vararg{Int}}, nd::Int)
+@propagate_inbounds function hvncat_calcindex(offsets::Vector{Int}, inneroffsets::Vector{Int}, outdims::Tuple{Vararg{Int}}, nd::Int)
     Ai = inneroffsets[1] + offsets[1] + 1
-    @inbounds for j ∈ 2:nd
+    for j ∈ 2:nd
         increment = inneroffsets[j] + offsets[j]
         for k ∈ 1:j-1
             increment *= outdims[k]

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2368,12 +2368,17 @@ end
 
 function hvncat_fill!(A::Array, row_first::Bool, xs::Tuple)
     # putting these in separate functions leads to unnecessary allocations
+    lenxs = length(xs)
+    lena = length(A)
+    lenxs == lena || throw(ArgumentError("number of elements don't match specified shape"))
     if row_first
         nr, nc = size(A, 1), size(A, 2)
         nrc = nr * nc
         na = prod(size(A)[3:end])
+        len = length(xs)
+        
         k = 1
-        for d ∈ 1:na
+        @inbounds for d ∈ 1:na
             dd = nrc * (d - 1)
             for i ∈ 1:nr
                 Ai = dd + i
@@ -2392,6 +2397,10 @@ function hvncat_fill!(A::Array, row_first::Bool, xs::Tuple)
 end
 
 function hvncat_fill!(A::AbstractArray{T, N}, scratch1::Vector{Int}, scratch2::Vector{Int}, d1::Int, d2::Int, as::Tuple{Vararg}) where {T, N}
+    length(scratch1) == length(scratch2) == N ||
+        throw(ArgumentError("scratch vectors must have as many elements as the destination array has dimensions"))
+    0 < d1 < 3 && 0 < d2 < 3 && d1 != d2 ||
+        throw(ArgumentError("d1 and d2 must be either 1 or 2, exclusive."))
     outdims = size(A)
     offsets = scratch1
     inneroffsets = scratch2

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2155,6 +2155,7 @@ _typed_hvncat(::Type{T}, ::Val{N}) where {T, N} =
 function _typed_hvncat(::Type{T}, ::Val{N}, as::AbstractArray...) where {T, N}
     # optimization for arrays that can be concatenated by copying them linearly into the destination
     # conditions: the elements must all have 1- or 0-length dimensions above N
+    length(as) > 0 || throw(ArgumentError("must have at least one element"))
     N < 0 && throw(ArgumentError("concatenation dimension must be nonnegative"))
     for a ∈ as
         ndims(a) <= N || all(x -> size(a, x) == 1, (N + 1):ndims(a)) ||
@@ -2185,6 +2186,7 @@ end
 function _typed_hvncat(::Type{T}, ::Val{N}, as...) where {T, N}
     # optimization for scalars and 1-length arrays that can be concatenated by copying them linearly
     # into the destination
+    length(as) > 0 || throw(ArgumentError("must have at least one element"))
     N < 0 && throw(ArgumentError("concatenation dimension must be nonnegative"))
     nd = N
     Ndim = 0
@@ -2227,6 +2229,7 @@ _typed_hvncat(::Type, ::Tuple{}, ::Bool, ::Any...) =
 _typed_hvncat(T::Type, dims::Tuple{Int}, ::Bool, as...) = _typed_hvncat_1d(T, dims[1], Val(false), as...)
 
 function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, xs::Number...) where {T, N}
+    length(xs) > 0 || throw(ArgumentError("must have at least one element"))
     all(>(0), dims) || throw(ArgumentError("`dims` argument must contain positive integers"))
     A = Array{T, N}(undef, dims...)
     lengtha = length(A)  # Necessary to store result because throw blocks are being deoptimized right now, which leads to excessive allocations
@@ -2239,6 +2242,7 @@ function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, xs::Num
 end
 
 function _typed_hvncat(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as...) where {T, N}
+    length(as) > 0 || throw(ArgumentError("must have at least one element"))
     all(>(0), dims) || throw(ArgumentError("`dims` argument must contain positive integers"))
     d1 = row_first ? 2 : 1
     d2 = row_first ? 1 : 2
@@ -2308,6 +2312,7 @@ _typed_hvncat(T::Type, shape::Tuple{Tuple}, row_first::Bool, xs...) =
         _typed_hvncat_1d(T, shape[1][1], Val(row_first), xs...)
 
 function _typed_hvncat(::Type{T}, shape::NTuple{N, Tuple}, row_first::Bool, as...) where {T, N}
+    length(as) > 0 || throw(ArgumentError("must have at least one element"))
     all(>(0), tuple((shape...)...)) || throw(ArgumentError("`shape` argument must consist of positive integers"))
 
     d1 = row_first ? 2 : 1

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2392,8 +2392,6 @@ function _typed_hvncat(::Type{T}, shape::NTuple{N, Tuple}, row_first::Bool, as..
 
             if d == 1 || i == 1 || wasstartblock
                 currentdims[d] += dsize
-            # elseif blockcounts[d - 1] == 0
-            #     throw(1)
             elseif dsize != cat_size(as[i - 1], ad)
                 throw(ArgumentError("""argument $i has a mismatched number of elements along axis $ad; \
                                     expected $(cat_size(as[i - 1], ad)), got $dsize"""))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1470,6 +1470,25 @@ import Base.typed_hvncat
         @test_throws ArgumentError hvncat(((2, 1), (1, 1, 1)), true, v...)
     end
 
+    # output dimensions are maximum of input dimensions and concatenation dimension
+    begin
+        v1 = fill(1, 1, 1)
+        v2 = fill(1, 1, 1, 1, 1)
+        v3 = fill(1, 1, 2, 1, 1)
+        @test [v1 ;;; v2] == [1 ;;; 1 ;;;;]
+        @test [v2 ;;; v1] == [1 ;;; 1 ;;;;]
+        @test [v3 ;;; v1 v1] == [1 1 ;;; 1 1 ;;;;]
+        @test [v1 v1 ;;; v3] == [1 1 ;;; 1 1 ;;;;]
+        @test [v2 v1 ;;; v1 v1] == [1 1 ;;; 1 1 ;;;;]
+        @test [v1 v1 ;;; v1 v2] == [1 1 ;;; 1 1 ;;;;]
+        @test [v1 ;;; 1] == [1 ;;; 1 ;;;;]
+        @test [1 ;;; v1] == [1 ;;; 1 ;;;;]
+        @test [v3 ;;; 1 v1] == [1 1 ;;; 1 1 ;;;;]
+        @test [v1 1 ;;; v3] == [1 1 ;;; 1 1 ;;;;]
+        @test [v2 1 ;;; v1 v1] == [1 1 ;;; 1 1 ;;;;]
+        @test [v1 1 ;;; v1 v2] == [1 1 ;;; 1 1 ;;;;]
+    end
+
     # reject shapes that don't nest evenly between levels (e.g. 1 + 2 does not fit into 2)
     @test_throws ArgumentError hvncat(((1, 2, 1), (2, 2), (4,)), true, [1 2], [3], [4], [1 2; 3 4])
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1472,7 +1472,7 @@ end
         end
     end
 
-    @test_throws BoundsError hvncat(((1, 2), (3,)), false, zeros(Int, 0, 0, 0), 7, 8)
+    @test_throws ArgumentError hvncat(((1, 2), (3,)), false, zeros(Int, 0, 0, 0), 7, 8)
 end
 
 @testset "keepat!" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1398,7 +1398,7 @@ end
     @test typed_hvncat(Float64, 0) == Float64[]
     @test typed_hvncat(Float64, 0, 1) == fill(1.0)
     @test typed_hvncat(Float64, 0, [1]) == Float64[1.0]
-    @test_throws ArgumentError hvncat(0, 1, 1)
+    @test_throws ArgumentError typed_hvncat(Float64, 0, 1, 1)
     @test hvncat((), true) == []
     @test hvncat((), true, 1) == fill(1)
     @test hvncat((), true, [1]) == [1]
@@ -1432,20 +1432,20 @@ end
     # shape form
     @test hvncat(((2,),), true, 1, 1) == [1 1]
     @test hvncat(((2,),), true, [1], [1]) == [1 1]
-    @test_throws ArgumentError hvncat((2,), true, 1)
+    @test_throws ArgumentError hvncat(((2,),), true, 1)
     @test hvncat(((2,),), false, 1, 1) == [1; 1]
     @test hvncat(((2,),), false, [1], [1]) == [1; 1]
     @test typed_hvncat(Float64, ((2,),), true, 1, 1) == Float64[1.0 1.0]
     @test typed_hvncat(Float64, ((2,),), true, [1], [1]) == Float64[1.0 1.0]
-    @test_throws ArgumentError typed_hvncat(Float64, (2,), true, 1)
+    @test_throws ArgumentError typed_hvncat(Float64, ((2,),), true, 1)
     @test typed_hvncat(Float64, ((2,),), false, 1, 1) == Float64[1.0; 1.0]
     @test typed_hvncat(Float64, ((2,),), false, [1], [1]) == Float64[1.0; 1.0]
 
     # reject dimension < 0
-    @test hvncat(-1) == []
+    @test_throws ArgumentError hvncat(-1)
     @test_throws ArgumentError hvncat(-1, 1)
     @test_throws ArgumentError hvncat(-1, [1])
-    @test typed_hvncat(Float64, -1) == []
+    @test_throws ArgumentError typed_hvncat(Float64, -1)
     @test_throws ArgumentError typed_hvncat(Float64, -1, 1)
     @test_throws ArgumentError typed_hvncat(Float64, -1, [1])
 
@@ -1465,10 +1465,11 @@ end
 
     # reject shape with negative values
     for v1 ∈ (-1, 0, 1)
-    for v2 ∈ (-1, 0, 1)
-        v1 == v2 == 1 && continue
-        @test_throws ArgumentError hvncat(((v1,), (v2,)), true, 1)
-        @test_throws ArgumentError typed_hvncat(Float64, ((v1,), (v2,)), true, 1)
+        for v2 ∈ (-1, 0, 1)
+            v1 == v2 == 1 && continue
+            @test_throws ArgumentError hvncat(((v1,), (v2,)), true, 1)
+            @test_throws ArgumentError typed_hvncat(Float64, ((v1,), (v2,)), true, 1)
+        end
     end
 
     @test_throws BoundsError hvncat(((1, 2), (3,)), false, zeros(Int, 0, 0, 0), 7, 8)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1,4 +1,3 @@
-using Core: Argument
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Random, LinearAlgebra, SparseArrays

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1481,8 +1481,8 @@ import Base.typed_hvncat
         @test [v1 v1 ;;; v3] == [1 1 ;;; 1 1 ;;;;]
         @test [v2 v1 ;;; v1 v1] == [1 1 ;;; 1 1 ;;;;]
         @test [v1 v1 ;;; v1 v2] == [1 1 ;;; 1 1 ;;;;]
-        @test [v1 ;;; 1] == [1 ;;; 1 ;;;;]
-        @test [1 ;;; v1] == [1 ;;; 1 ;;;;]
+        @test [v2 ;;; 1] == [1 ;;; 1 ;;;;]
+        @test [1 ;;; v2] == [1 ;;; 1 ;;;;]
         @test [v3 ;;; 1 v1] == [1 1 ;;; 1 1 ;;;;]
         @test [v1 1 ;;; v3] == [1 1 ;;; 1 1 ;;;;]
         @test [v2 1 ;;; v1 v1] == [1 1 ;;; 1 1 ;;;;]
@@ -1492,7 +1492,28 @@ import Base.typed_hvncat
     # reject shapes that don't nest evenly between levels (e.g. 1 + 2 does not fit into 2)
     @test_throws ArgumentError hvncat(((1, 2, 1), (2, 2), (4,)), true, [1 2], [3], [4], [1 2; 3 4])
 
-    @test_throws ArgumentError hvncat(((1, 2), (3,)), false, zeros(Int, 0, 0, 0), 7, 8)
+    # zero-length arrays are handled appropriately
+    @test [zeros(Int, 1, 2, 0) ;;; 1 3] == [1 3;;;]
+    @test [[] ;;; [] ;;; []] == Array{Any}(undef, 0, 1, 3)
+    @test [[] ; 1 ;;; 2 ; []] == [1 ;;; 2]
+    @test [[] ; [] ;;; [] ; []] == Array{Any}(undef, 0, 1, 2)
+    @test [[] ; 1 ;;; 2] == [1 ;;; 2]
+    @test [[] ; [] ;;; [] ;;; []] == Array{Any}(undef, 0, 1, 3)
+    z = zeros(Int, 0, 0, 0)
+    [z z ; z ;;; z ;;; z] == Array{Int}(undef, 0, 0, 0)
+
+    for v1 ∈ (zeros(Int, 0, 0), zeros(Int, 0, 0, 0), zeros(Int, 0, 0, 0, 0), zeros(Int, 0, 0, 0, 0, 0, 0, 0))
+        for v2 ∈ (1, [1])
+            for v3 ∈ (2, [2])
+                @test_throws ArgumentError [v1 ;;; v2]
+                @test_throws ArgumentError [v1 ;;; v2 v3]
+                @test_throws ArgumentError [v1 v1 ;;; v2 v3]
+            end
+        end
+    end
+
+    @test_throws ArgumentError [zeros(Int, 0, 0, 0) ;;; 1 3]    # fails
+    @test_throws ArgumentError [zeros(Int, 0, 0, 0) ;;; [1] [3]]     # fails
 end
 
 @testset "keepat!" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1430,16 +1430,16 @@ end
     @test hvncat((2,), false, 1, 1) == [1; 1]
     @test typed_hvncat(Float64, (2,), false, 1, 1) == Float64[1.0; 1.0]
     # shape form
-    @test hvncat((2,), true, 1, 1) == [1 1]
-    @test hvncat((2,), true, [1], [1]) == [1 1]
+    @test hvncat(((2,),), true, 1, 1) == [1 1]
+    @test hvncat(((2,),), true, [1], [1]) == [1 1]
     @test_throws ArgumentError hvncat((2,), true, 1)
-    @test hvncat((2,), false, 1, 1) == [1; 1]
-    @test hvncat((2,), false, [1], [1]) == [1; 1]
-    @test typed_hvncat(Float64, (2,), true, 1, 1) == Float64[1.0 1.0]
-    @test typed_hvncat(Float64, (2,), true, [1], [1]) == Float64[1.0 1.0]
+    @test hvncat(((2,),), false, 1, 1) == [1; 1]
+    @test hvncat(((2,),), false, [1], [1]) == [1; 1]
+    @test typed_hvncat(Float64, ((2,),), true, 1, 1) == Float64[1.0 1.0]
+    @test typed_hvncat(Float64, ((2,),), true, [1], [1]) == Float64[1.0 1.0]
     @test_throws ArgumentError typed_hvncat(Float64, (2,), true, 1)
-    @test typed_hvncat(Float64, (2,), false, 1, 1) == Float64[1.0; 1.0]
-    @test typed_hvncat(Float64, (2,), false, [1], [1]) == Float64[1.0; 1.0]
+    @test typed_hvncat(Float64, ((2,),), false, 1, 1) == Float64[1.0; 1.0]
+    @test typed_hvncat(Float64, ((2,),), false, [1], [1]) == Float64[1.0; 1.0]
 
     # reject dimension < 0
     @test hvncat(-1) == []

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1,3 +1,4 @@
+using Core: Argument
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Random, LinearAlgebra, SparseArrays
@@ -1387,6 +1388,87 @@ end
     # mixed scalars and arrays work, for numbers and strings
     for v = (1, "test")
         @test [v v;;; fill(v, 1, 2)] == fill(v, 1, 2, 2)
+    end
+
+    # 0-dimension behaviors
+    @test hvncat(0) == []
+    @test hvncat(0, 1) == fill(1)
+    @test hvncat(0, [1]) == [1]
+    @test_throws ArgumentError hvncat(0, 1, 1)
+    @test typed_hvncat(Float64, 0) == Float64[]
+    @test typed_hvncat(Float64, 0, 1) == fill(1.0)
+    @test typed_hvncat(Float64, 0, [1]) == Float64[1.0]
+    @test_throws ArgumentError hvncat(0, 1, 1)
+    @test hvncat((), true) == []
+    @test hvncat((), true, 1) == fill(1)
+    @test hvncat((), true, [1]) == [1]
+    @test_throws ArgumentError hvncat((), true, 1, 1)
+    @test typed_hvncat(Float64, (), true) == Float64[]
+    @test typed_hvncat(Float64, (), true, 1) == fill(1.0)
+    @test typed_hvncat(Float64, (), true, [1]) == [1.0]
+    @test_throws ArgumentError typed_hvncat(Float64, (), true, 1, 1)
+
+    # 1-dimension behaviors
+    # int form
+    @test hvncat(1) == []
+    @test hvncat(1, 1) == [1]
+    @test hvncat(1, [1]) == [1]
+    @test hvncat(1, 1, 1) == [1 ; 1]
+    @test typed_hvncat(Float64, 1) == Float64[]
+    @test typed_hvncat(Float64, 1, 1) == Float64[1.0]
+    @test typed_hvncat(Float64, 1, [1]) == Float64[1.0]
+    @test typed_hvncat(Float64, 1, 1, 1) == Float64[1.0 ; 1.0]
+    # dims form
+    @test_throws ArgumentError hvncat((1,), true)
+    @test hvncat((2,), true, 1, 1) == [1; 1]
+    @test hvncat((2,), true, [1], [1]) == [1; 1]
+    @test_throws ArgumentError hvncat((2,), true, 1)
+    @test typed_hvncat(Float64, (2,), true, 1, 1) == Float64[1.0; 1.0]
+    @test typed_hvncat(Float64, (2,), true, [1], [1]) == Float64[1.0; 1.0]
+    @test_throws ArgumentError typed_hvncat(Float64, (2,), true, 1)
+    # row_first has no effect with just one dimension of the dims form
+    @test hvncat((2,), false, 1, 1) == [1; 1]
+    @test typed_hvncat(Float64, (2,), false, 1, 1) == Float64[1.0; 1.0]
+    # shape form
+    @test hvncat((2,), true, 1, 1) == [1 1]
+    @test hvncat((2,), true, [1], [1]) == [1 1]
+    @test_throws ArgumentError hvncat((2,), true, 1)
+    @test hvncat((2,), false, 1, 1) == [1; 1]
+    @test hvncat((2,), false, [1], [1]) == [1; 1]
+    @test typed_hvncat(Float64, (2,), true, 1, 1) == Float64[1.0 1.0]
+    @test typed_hvncat(Float64, (2,), true, [1], [1]) == Float64[1.0 1.0]
+    @test_throws ArgumentError typed_hvncat(Float64, (2,), true, 1)
+    @test typed_hvncat(Float64, (2,), false, 1, 1) == Float64[1.0; 1.0]
+    @test typed_hvncat(Float64, (2,), false, [1], [1]) == Float64[1.0; 1.0]
+
+    # reject dimension < 0
+    @test hvncat(-1) == []
+    @test_throws ArgumentError hvncat(-1, 1)
+    @test_throws ArgumentError hvncat(-1, [1])
+    @test typed_hvncat(Float64, -1) == []
+    @test_throws ArgumentError typed_hvncat(Float64, -1, 1)
+    @test_throws ArgumentError typed_hvncat(Float64, -1, [1])
+
+    # reject shape tuple with no elements
+    @test_throws ArgumentError hvncat(((),), true)
+    @test_throws ArgumentError hvncat(((),), true, 1)
+    @test_throws ArgumentError hvncat(((),), true, 1, 1)
+    @test_throws ArgumentError typed_hvncat(Float64, ((),), true)
+    @test_throws ArgumentError typed_hvncat(Float64, ((),), true, 1)
+    @test_throws ArgumentError typed_hvncat(Float64, ((),), true, 1, 1)
+
+    # reject dims with negative or zero values
+    for v ∈ ((-1, 1), (1, -1), (0, 1), (1, 0))
+        @test_throws ArgumentError hvncat(v, true, 1)
+        @test_throws ArgumentError typed_hvncat(Float64, v, true, 1)
+    end
+
+    # reject shape with negative values
+    for v1 ∈ (-1, 0, 1)
+    for v2 ∈ (-1, 0, 1)
+        v1 == v2 == 1 && continue
+        @test_throws ArgumentError hvncat(((v1,), (v2,)), true, 1)
+        @test_throws ArgumentError typed_hvncat(Float64, ((v1,), (v2,)), true, 1)
     end
 
     @test_throws BoundsError hvncat(((1, 2), (3,)), false, zeros(Int, 0, 0, 0), 7, 8)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1342,6 +1342,7 @@ end
     end
 end
 
+import Base.typed_hvncat
 @testset "hvncat" begin
     a = fill(1, (2,3,2,4,5))
     b = fill(2, (1,1,2,4,5))
@@ -1443,11 +1444,9 @@ end
     for v ∈ ((), (1,), ([1],), (1, [1]), ([1], 1), ([1], [1]))
         # reject dimension < 0
         @test_throws ArgumentError hvncat(-1, v...)
-        @test_throws ArgumentError typed_hvncat(Float64, -1, v...)
 
         # reject shape tuple with no elements
         @test_throws ArgumentError hvncat(((),), true, v...)
-        @test_throws ArgumentError typed_hvncat(Float64, ((),), true, v...)
     end
 
     # reject dims or shape with negative or zero values
@@ -1456,9 +1455,7 @@ end
             v1 == v2 == 1 && continue
             for v3 ∈ ((), (1,), ([1],), (1, [1]), ([1], 1), ([1], [1]))
                 @test_throws ArgumentError hvncat((v1, v2), true, v3...)
-                @test_throws ArgumentError typed_hvncat(Float64, (v1, v2), true, v3...)
                 @test_throws ArgumentError hvncat(((v1,), (v2,)), true, v3...)
-                @test_throws ArgumentError typed_hvncat(Float64, ((v1,), (v2,)), true, v3...)
             end
         end
     end
@@ -1466,13 +1463,11 @@ end
     for v ∈ ((1, [1]), ([1], 1), ([1], [1]))
         # reject shape with more than one end value
         @test_throws ArgumentError hvncat(((1, 1),), true, v...)
-        @test_throws ArgumentError typed_hvncat(Float64, ((1, 1),), true, v...)
     end
 
     for v ∈ ((1, 2, 3), (1, 2, [3]), ([1], [2], [3]))
         # reject shape with more values in later level
         @test_throws ArgumentError hvncat(((2, 1), (1, 1, 1)), true, v...)
-        @test_throws ArgumentError typed_hvncat(Float64, ((2, 1), (1, 1, 1)), true, v...)
     end
 
     # reject bad shapes and accept valid ones
@@ -1506,8 +1501,6 @@ end
                             if isbad
                                 @test_throws ArgumentError hvncat(shape, true, 1:6...)
                                 @test_throws ArgumentError hvncat(shape, true, Base.vect.(1:6)...)
-                                @test_throws ArgumentError typed_hvncat(Float64, shape, true, 1:6...)
-                                @test_throws ArgumentError typed_hvncat(Float64, shape, true, Base.vect.(1:6)...)
                             end
                         end
                     end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1470,44 +1470,8 @@ import Base.typed_hvncat
         @test_throws ArgumentError hvncat(((2, 1), (1, 1, 1)), true, v...)
     end
 
-    # reject bad shapes and accept valid ones
-    # valid shapes have:
-    #   - each level sum to the same value,
-    #   - the number of elements in a higher level is equal to or less than the lower level,
-    #   - the counts in a lower level must evenly split into the counts in the higher levels
-    #     e.g. (1, 2, 1), (2, 2) is not valid because the first two elements of level 1 cannot
-    #     fit in the first element of level 2.
-    for s1 ∈ 1:5
-        for s2 ∈ 1:5
-            for s3 ∈ 1:5
-                for s4 ∈ 1:5
-                    for s5 ∈ 1:5
-                        for s6 ∈ 1:5
-                            shape = ((s1, s2, s3), (s4, s5), (s6,))
-                            shapetest = collect(collect.(shape))
-                            isbad = false
-                            if all(>(0), tuple((shape...)...)) && all(x -> sum(x) == s6, shape)
-                                for i ∈ length(shapetest) - 1
-                                    while length(shapetest[i]) > 1 && (s = popfirst!(shapetest[i])) < shapetest[i + 1][1]
-                                        shapetest[i][1] += s
-                                    end
-                                    if shapetest[i][1] != shapetest[i + 1][1]
-                                        isbad = true
-                                    end
-                                end
-                            else
-                                isbad = true
-                            end
-                            if isbad
-                                @test_throws ArgumentError hvncat(shape, true, 1:6...)
-                                @test_throws ArgumentError hvncat(shape, true, Base.vect.(1:6)...)
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
+    # reject shapes that don't nest evenly between levels (e.g. 1 + 2 does not fit into 2)
+    @test_throws ArgumentError hvncat(((1, 2, 1), (2, 2), (4,)), true, [1 2], [3], [4], [1 2; 3 4])
 
     @test_throws ArgumentError hvncat(((1, 2), (3,)), false, zeros(Int, 0, 0, 0), 7, 8)
 end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1704,3 +1704,10 @@ end
     @check_bit_operation all!(falses(100), trues(100, 100))
     @check_bit_operation all!(falses(1000), trues(1000, 100))
 end
+
+@testset "multidimensional concatenation returns BitArrays" begin
+    a = BitVector(ones(5))
+    typeof([a ;;; a]) <: BitArray
+    typeof([a a ;;; a a]) <: BitArray
+    typeof([a a ;;; [a a]]) <: BitArray
+end


### PR DESCRIPTION
This PR is collecting changes based on feedback on the functions, including #41111, #41107, and #41047.

* Adds robustness through stronger input checking, so that the functions are safe to call on their own
* More consistent behavior for 0- and 1-dimension forms, as suggested by @matthias314 .
* Added back some judicious `@inbounds` and `@inline` hints. Hopefully someone can ensure they're proper this time 😅
* More comprehensive tests
* Added Int form to documentation
* Performance of unbalanced concatenations (e.g. `const a = fill(1); const b = [a a]; [a a ;;; b]`) improved to ~2x faster and 10 allocations 784, compared with `cat([a a], b, dims = 3)`'s 32 allocations and 1.12 KiB.
* Realized dimensionality of result was not looking at all the input arguments; now it uses the maximum of the input arguments and the concatenation dimension