### PR TITLE
Replace deprecated VectorType::getNumElements with new APIs

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -396,13 +396,14 @@ CountTrackedPointers::CountTrackedPointers(Type *T) {
         }
         if (isa<ArrayType>(T))
             count *= cast<ArrayType>(T)->getNumElements();
-        else if (isa<VectorType>(T))
+        else if (isa<VectorType>(T)) {
 #if JL_LLVM_VERSION >= 120000
             ElementCount EC = cast<VectorType>(T)->getElementCount();
             count *= EC.getKnownMinValue();
 #else
             count *= cast<VectorType>(T)->getNumElements();
 #endif
+        }
     }
     if (count == 0)
         all = false;
@@ -413,13 +414,14 @@ unsigned getCompositeNumElements(Type *T) {
         return ST->getNumElements();
     else if (auto *AT = dyn_cast<ArrayType>(T))
         return AT->getNumElements();
-    else
+    else {
 #if JL_LLVM_VERSION >= 120000
         ElementCount EC = cast<VectorType>(T)->getElementCount();
         return EC.getKnownMinValue();
 #else
         return cast<VectorType>(T)->getNumElements();
 #endif
+    }
 }
 
 // Walk through a Type, and record the element path to every tracked value inside
@@ -635,13 +637,14 @@ void LateLowerGCFrame::LiftSelect(State &S, SelectInst *SI) {
     }
     std::vector<int> Numbers;
     unsigned NumRoots = 1;
-    if (auto VTy = dyn_cast<VectorType>(SI->getType()))
+    if (auto VTy = dyn_cast<VectorType>(SI->getType())) {
 #if JL_LLVM_VERSION >= 120000
         ElementCount EC = VTy->getElementCount();
         Numbers.resize(EC.getKnownMinValue(), -1);
 #else
         Numbers.resize(VTy->getNumElements(), -1);
 #endif
+    }
     else
         assert(isa<PointerType>(SI->getType()) && "unimplemented");
     assert(!isTrackedValue(SI));

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -397,7 +397,12 @@ CountTrackedPointers::CountTrackedPointers(Type *T) {
         if (isa<ArrayType>(T))
             count *= cast<ArrayType>(T)->getNumElements();
         else if (isa<VectorType>(T))
+#if JL_LLVM_VERSION >= 120000
+            ElementCount EC = cast<VectorType>(T)->getElementCount();
+            count *= EC.getKnownMinValue();
+#else
             count *= cast<VectorType>(T)->getNumElements();
+#endif
     }
     if (count == 0)
         all = false;
@@ -409,7 +414,12 @@ unsigned getCompositeNumElements(Type *T) {
     else if (auto *AT = dyn_cast<ArrayType>(T))
         return AT->getNumElements();
     else
+#if JL_LLVM_VERSION >= 120000
+        ElementCount EC = cast<VectorType>(T)->getElementCount();
+        return EC.getKnownMinValue();
+#else
         return cast<VectorType>(T)->getNumElements();
+#endif
 }
 
 // Walk through a Type, and record the element path to every tracked value inside
@@ -626,7 +636,12 @@ void LateLowerGCFrame::LiftSelect(State &S, SelectInst *SI) {
     std::vector<int> Numbers;
     unsigned NumRoots = 1;
     if (auto VTy = dyn_cast<VectorType>(SI->getType()))
+#if JL_LLVM_VERSION >= 120000
+        ElementCount EC = VTy->getElementCount();
+        Numbers.resize(EC.getKnownMinValue(), -1);
+#else
         Numbers.resize(VTy->getNumElements(), -1);
+#endif
     else
         assert(isa<PointerType>(SI->getType()) && "unimplemented");
     assert(!isTrackedValue(SI));
@@ -686,7 +701,12 @@ void LateLowerGCFrame::LiftSelect(State &S, SelectInst *SI) {
             assert(NumRoots == 1);
             int Number = Numbers[0];
             Numbers.resize(0);
+#if JL_LLVM_VERSION >= 120000
+            ElementCount EC = VTy->getElementCount();
+            Numbers.resize(EC.getKnownMinValue(), Number);
+#else
             Numbers.resize(VTy->getNumElements(), Number);
+#endif
         }
     }
     if (!isa<PointerType>(SI->getType()))


### PR DESCRIPTION
`VectorType::getNumElements` is first marked as deprecated (https://reviews.llvm.org/rG867de151a52b6d0750485ac1cf9b3bc012ee51fd) and is now deleted from LLVM's main branch (https://reviews.llvm.org/rG49a6502cd5c2361d9c6f49ae1ee36940afbdeb0a). So this PR replaces `VectorType::getNumElements` with newer APIs, following existing practice in `cgutils.cpp`: https://github.com/JuliaLang/julia/blob/f442e4230a41d0d40f81346c1707f946f743cbcf/src/cgutils.cpp#L1372-L1377