### PR TITLE
Fix `in(x, ::AbstractRange)` for `NaN`/`Inf`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1217,7 +1217,9 @@ function sum(r::AbstractRange{<:Real})
 end
 
 function _in_range(x, r::AbstractRange)
-    if step(r) == 0
+    if !isfinite(x)
+        return false
+    elseif iszero(step(r))
         return !isempty(r) && first(r) == x
     else
         n = round(Integer, (x - first(r)) / step(r)) + 1

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -459,6 +459,11 @@ end
 
         @test !(1 in 1:0)
         @test !(1.0 in 1.0:0.0)
+
+        for r = (1:10, 1//1:10//1, 1:2:5, 1//2:1//2:5//2, 1.0:5.0, LinRange(1.5, 5.5, 9)),
+            x = (NaN16, Inf32, -Inf64, 1//0, -1//0)
+            @test !(x in r)
+        end
     end
     @testset "in() works across types, including non-numeric types (#21728)" begin
         @test 1//1 in 1:3


### PR DESCRIPTION
Fixes #26689.

Before:
```
julia> Inf in 1.0:5.0
ERROR: InexactError: trunc(Int64, Inf)
[...]

julia> NaN in 1.0:5.0
ERROR: InexactError: trunc(Int64, NaN)
[...]
```
After:
```
julia> Inf in 1.0:5.0
false

julia> NaN in 1.0:5.0
false
```