### PR TITLE
Fixes for overlay tables

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -282,7 +282,7 @@ macro overlay(mt, def)
 end
 
 let new_mt(name::Symbol, mod::Module) = begin
-        ccall(:jl_check_top_level_effect, Cvoid, (Any, Cstring), mod, name)
+        ccall(:jl_check_top_level_effect, Cvoid, (Any, Cstring), mod, "@MethodTable")
         ccall(:jl_new_method_table, Any, (Any, Any), name, mod)
     end
     @eval macro MethodTable(name::Symbol)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -268,10 +268,16 @@ method tables (e.g., using [`Core.Compiler.OverlayMethodTable`](@ref)).
 """
 macro overlay(mt, def)
     def = macroexpand(__module__, def) # to expand @inline, @generated, etc
-    if !isexpr(def, [:function, :(=)]) || !isexpr(def.args[1], :call)
+    if !isexpr(def, [:function, :(=)])
         error("@overlay requires a function Expr")
     end
-    def.args[1].args[1] = Expr(:overlay, mt, def.args[1].args[1])
+    if isexpr(def.args[1], :call)
+        def.args[1].args[1] = Expr(:overlay, mt, def.args[1].args[1])
+    elseif isexpr(def.args[1], :where)
+        def.args[1].args[1].args[1] = Expr(:overlay, mt, def.args[1].args[1].args[1])
+    else
+        error("@overlay requires a function Expr")
+    end
     esc(def)
 end
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -922,7 +922,7 @@ static void jl_check_open_for(jl_module_t *m, const char* funcname)
     }
 }
 
-JL_DLLEXPORT void jl_check_top_level_effect(jl_value_t *m, char *fname)
+JL_DLLEXPORT void jl_check_top_level_effect(jl_module_t *m, char *fname)
 {
     if (jl_current_task->ptls->in_pure_callback)
         jl_errorf("%s cannot be used in a generated function", fname);

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -153,6 +153,9 @@ end
 # short function def
 @overlay mt cos(x::Float64) = 2
 
+# parametric function def
+@overlay mt tan(x::T) where {T} = 3
+
 end
 
 methods = Base._methods_by_ftype(Tuple{typeof(sin), Float64}, nothing, 1, typemax(UInt))


### PR DESCRIPTION
Re https://github.com/JuliaLang/julia/pull/41137#discussion_r647946546

@vtjnash I wanted to do https://github.com/JuliaLang/julia/pull/41137#discussion_r647945401, but the checks from `jl_check_open_for` fail up during precompilation tests when `kwftype` ends up calling `jl_new_method_table`:

```
ERROR: LoadError: Evaluation into the closed module `Base` breaks incremental compilation because
the side effects will not be permanent. This is likely due to some other module mutating `Base` with
`jl_new_method_table` during precompilation - don't do this.

jl_check_open_for at /home/tim/Julia/src/julia/src/toplevel.c:916
jl_new_method_table at /home/tim/Julia/src/julia/src/datatype.c:49
jl_new_datatype at /home/tim/Julia/src/julia/src/datatype.c:598
jl_new_generic_function_with_supertype at /home/tim/Julia/src/julia/src/gf.c:2540
jl_get_kwsorter at /home/tim/Julia/src/julia/src/gf.c:2578
kwftype at ./boot.jl:377
```