### PR TITLE
clarify ArgumentError docstring

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2414,7 +2414,7 @@ julia> 4.5/2
     ArgumentError(msg)
 
 The arguments passed to a function are invalid.
-`msg` is a descriptive error string.
+`msg` is a descriptive error message.
 """
 ArgumentError
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2413,8 +2413,8 @@ julia> 4.5/2
 """
     ArgumentError(msg)
 
-The parameters to a function call do not match a valid signature. Argument `msg` is a
-descriptive error string.
+One or more arguments in a function call have invalid values (and/or types).
+`msg` is a descriptive error string.
 """
 ArgumentError
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2413,7 +2413,7 @@ julia> 4.5/2
 """
     ArgumentError(msg)
 
-One or more arguments in a function call have invalid values (and/or types).
+The arguments passed to a function are invalid.
 `msg` is a descriptive error string.
 """
 ArgumentError


### PR DESCRIPTION
As discussed recently [on discourse](https://discourse.julialang.org/t/does-julia-have-the-python-equivalent-of-valueerror/62684/9?u=stevengj), the docstring for `ArgumentError` talks about "parameters not matching valid signatures" which sounds like it is about argument *types*, but in practice this exception type is more commonly thrown for invalid *values*.

(In contrast invalid *types* are usually filtered by function signatures, and can also be indicated by throwing `MethodError` explicitly.)