### PR TITLE
`hvncat`: enable concatenations to return an array of the same kind

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2347,7 +2347,7 @@ function _typed_hvncat(::Type{T}, shape::Tuple{Vararg{Tuple, N}}, row_first::Boo
     return A
 end
 
-function hvncat_fill!(A::Array{T, N}, scratch1::Vector{Int}, scratch2::Vector{Int}, d1::Int, d2::Int, as::Tuple{Vararg}) where {T, N}
+function hvncat_fill!(A::AbstractArray{T, N}, scratch1::Vector{Int}, scratch2::Vector{Int}, d1::Int, d2::Int, as::Tuple{Vararg}) where {T, N}
     outdims = size(A)
     offsets = scratch1
     inneroffsets = scratch2

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1640,13 +1640,10 @@ cat_indices(A::AbstractArray, d) = axes(A, d)
 
 cat_similar(A, ::Type{T}, shape::Tuple) where T = Array{T}(undef, shape)
 cat_similar(A, ::Type{T}, shape::Vector) where T = Array{T}(undef, shape...)
-cat_similar(A, ::Type{T}, shape::Int...) where T = Array{T}(undef, shape...)
 cat_similar(A::Array, ::Type{T}, shape::Tuple) where T = Array{T}(undef, shape)
 cat_similar(A::Array, ::Type{T}, shape::Vector) where T = Array{T}(undef, shape...)
-cat_similar(A::Array, ::Type{T}, shape::Int...) where T = Array{T}(undef, shape...)
-cat_similar(A::AbstractArray, ::Type{T}, shape::Tuple) where T = similar(A, T, shape)
-cat_similar(A::AbstractArray, ::Type{T}, shape::Vector) where T = similar(A, T, shape...)
-cat_similar(A::AbstractArray, ::Type{T}, shape::Int...) where T = similar(A, T, shape...)
+cat_similar(A::AbstractArray, T::Type, shape::Tuple) where T = similar(A, T, shape)
+cat_similar(A::AbstractArray, T::Type, shape::Vector) where T = similar(A, T, shape...)
 
 # These are for backwards compatibility (even though internal)
 cat_shape(dims, shape::Tuple{Vararg{Int}}) = shape
@@ -2184,7 +2181,7 @@ function _typed_hvncat(::Type{T}, ::Val{N}, as::AbstractArray...) where {T, N}
         end
     end
 
-    A = cat_similar(as[1], T, ntuple(d -> size(as[1], d), N - 1)..., Ndim, ntuple(x -> 1, nd - N)...)
+    A = cat_similar(as[1], T, (ntuple(d -> size(as[1], d), N - 1)..., Ndim, ntuple(x -> 1, nd - N)...))
     k = 1
     for a ∈ as
         for i ∈ eachindex(a)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1642,8 +1642,8 @@ cat_similar(A, ::Type{T}, shape::Tuple) where T = Array{T}(undef, shape)
 cat_similar(A, ::Type{T}, shape::Vector) where T = Array{T}(undef, shape...)
 cat_similar(A::Array, ::Type{T}, shape::Tuple) where T = Array{T}(undef, shape)
 cat_similar(A::Array, ::Type{T}, shape::Vector) where T = Array{T}(undef, shape...)
-cat_similar(A::AbstractArray, T::Type, shape::Tuple) where T = similar(A, T, shape)
-cat_similar(A::AbstractArray, T::Type, shape::Vector) where T = similar(A, T, shape...)
+cat_similar(A::AbstractArray, T::Type, shape::Tuple) = similar(A, T, shape)
+cat_similar(A::AbstractArray, T::Type, shape::Vector) = similar(A, T, shape...)
 
 # These are for backwards compatibility (even though internal)
 cat_shape(dims, shape::Tuple{Vararg{Int}}) = shape

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1704,3 +1704,10 @@ end
     @check_bit_operation all!(falses(100), trues(100, 100))
     @check_bit_operation all!(falses(1000), trues(1000, 100))
 end
+
+@testset "multidimensional concatenation returns BitArrays" begin
+    a = BitVector(ones(5))
+    typeof([a ;;; a]) <: BitArray
+    typeof([a a ;;; a a]) <: BitArray
+    typeof([a a ;;; [a a]]) <: BitArray
+end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1707,7 +1707,7 @@ end
 
 @testset "multidimensional concatenation returns BitArrays" begin
     a = BitVector(ones(5))
-    typeof([a ;;; a]) <: BitArray
-    typeof([a a ;;; a a]) <: BitArray
-    typeof([a a ;;; [a a]]) <: BitArray
+    @test typeof([a ;;; a]) <: BitArray
+    @test typeof([a a ;;; a a]) <: BitArray
+    @test typeof([a a ;;; [a a]]) <: BitArray
 end


### PR DESCRIPTION
Breaking down #41143 into smaller pieces.

This PR relies on `similar` to return specialty array types when possible, just like `hvcat` already does.

The several specific `cat_similar` methods cut down allocations.