### PR TITLE
several small changes to documentation for multi-dimensional arrays

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -8,7 +8,8 @@ other code written in Julia. As such, it's also possible to define custom array 
 from [`AbstractArray`](@ref). See the [manual section on the AbstractArray interface](@ref man-interface-array)
 for more details on implementing a custom array type.
 
-An array is a collection of objects stored in a multi-dimensional grid. In the most general case,
+An array is a collection of objects stored in a multi-dimensional grid. Zero-dimensional arrays
+are allowed, see [this FAQ entry](@ref faq-array-0dim). In the most general case,
 an array may contain objects of type [`Any`](@ref). For most computational purposes, arrays should contain
 objects of a more specific type, such as [`Float64`](@ref) or [`Int32`](@ref).
 
@@ -67,9 +68,9 @@ omitted it will default to [`Float64`](@ref).
 | [`rand(T, dims...)`](@ref)                     | an `Array` with random, iid [^1] and uniformly distributed values in the half-open interval ``[0, 1)``                                                                                                                                       |
 | [`randn(T, dims...)`](@ref)                    | an `Array` with random, iid and standard normally distributed values                                                                                                                                                                         |
 | [`Matrix{T}(I, m, n)`](@ref)                   | `m`-by-`n` identity matrix. Requires `using LinearAlgebra` for [`I`](@ref).                                                                                                                                                                                                                   |
-| [`range(start, stop=stop, length=n)`](@ref)    | range of `n` linearly spaced elements from `start` to `stop`                                                                                                                                                                                 |
+| [`range(start, stop, n)`](@ref)                | a range of `n` linearly spaced elements from `start` to `stop` |
 | [`fill!(A, x)`](@ref)                          | fill the array `A` with the value `x`                                                                                                                                                                                                        |
-| [`fill(x, dims...)`](@ref)                     | an `Array` filled with the value `x`                                                                                                                                                                                                         |
+| [`fill(x, dims...)`](@ref)                     | an `Array` filled with the value `x`. In particular, `fill(x)` constructs a zero-dimensional `Array` containing `x`. |
 
 [^1]: *iid*, independently and identically distributed.
 
@@ -95,7 +96,7 @@ Here, `(2, 3)` is a [`Tuple`](@ref) and the first argument — the element type 
 ## [Array literals](@id man-array-literals)
 
 Arrays can also be directly constructed with square braces; the syntax `[A, B, C, ...]`
-creates a one dimensional array (i.e., a vector) containing the comma-separated arguments as
+creates a one-dimensional array (i.e., a vector) containing the comma-separated arguments as
 its elements. The element type ([`eltype`](@ref)) of the resulting array is automatically
 determined by the types of the arguments inside the braces. If all the arguments are the
 same type, then that is its `eltype`. If they all have a common
@@ -240,7 +241,7 @@ julia> [1; 2;; 3; 4;; 5; 6;;;
 ```
 
 Like before, spaces (and tabs) for horizontal concatenation have a higher precedence than
-any number of semicolons. Thus, higher dimensional arrays can also be written by specifying
+any number of semicolons. Thus, higher-dimensional arrays can also be written by specifying
 their rows first, with their elements textually arranged in a manner similar to their layout:
 
 ```jldoctest

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -922,7 +922,7 @@ julia> @sync for i in 1:3
 
 ## Arrays
 
-### What are the differences between zero-dimensional arrays and scalars?
+### [What are the differences between zero-dimensional arrays and scalars?](@id faq-array-0dim)
 
 Zero-dimensional arrays are arrays of the form `Array{T,0}`. They behave similar
 to scalars, but there are important differences. They deserve a special mention


### PR DESCRIPTION
The visible changes are to the file `arrays.md`:

* added comments and reference for zero-dimensional arrays. Zero-dimensional arrays were not mentioned before in this section. Now it explains how to create them and also refers to the corresponding FAQ entry.

* updated table entry for `range` to reflect #39228

* made spelling of "one-dimensional" etc. uniform throughout the documentation (always with hyphen). This make it easier to search for such a term on an HTML page or in the PDF documentation.