### PR TITLE
inference: implement type-based alias analysis to refine constrained field

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -435,7 +435,7 @@ eval(Core, quote
     end
     Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))
     # NOTE the main constructor is defined within `Core.Compiler`
-    _PartialStruct(typ::DataType, fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))
+    _PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))
     PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))
     InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :thentype, :elsetype))
     MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) = $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1306,8 +1306,11 @@ end
 # returns an array of types
 function precise_container_type(interp::AbstractInterpreter, @nospecialize(itft), @nospecialize(typ),
                                 sv::Union{InferenceState, IRCode})
-    if isa(typ, PartialStruct) && typ.typ.name === Tuple.name
-        return typ.fields, nothing
+    if isa(typ, PartialStruct)
+        widet = typ.typ
+        if isa(widet, DataType) && widet.name === Tuple.name
+            return typ.fields, nothing
+        end
     end
 
     if isa(typ, Const)

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -178,7 +178,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             any_const_result |= const_result !== nothing
             edge === nothing || push!(edges, edge)
         end
-        @assert !(this_conditional isa Conditional) "invalid lattice element returned from inter-procedural context"
+        @assert !(this_conditional isa Conditional || this_rt isa MustAlias) "invalid lattice element returned from inter-procedural context"
         seen += 1
         rettype = tmerge(𝕃ₚ, rettype, this_rt)
         if has_conditional(𝕃ₚ) && this_conditional !== Bottom && is_lattice_bool(𝕃ₚ, rettype) && fargs !== nothing
@@ -371,14 +371,16 @@ When we deal with multiple `MethodMatch`es, it's better to precompute `maybecond
 """
 function from_interprocedural!(𝕃ₚ::AbstractLattice, @nospecialize(rt), sv::InferenceState, arginfo::ArgInfo, @nospecialize(maybecondinfo))
     rt = collect_limitations!(rt, sv)
-    if is_lattice_bool(𝕃ₚ, rt)
+    if isa(rt, InterMustAlias)
+        rt = from_intermustalias(rt, arginfo)
+    elseif is_lattice_bool(𝕃ₚ, rt)
         if maybecondinfo === nothing
             rt = widenconditional(rt)
         else
             rt = from_interconditional(𝕃ₚ, rt, sv, arginfo, maybecondinfo)
         end
     end
-    @assert !(rt isa InterConditional) "invalid lattice element returned from inter-procedural context"
+    @assert !(rt isa InterConditional || rt isa InterMustAlias) "invalid lattice element returned from inter-procedural context"
     return rt
 end
 
@@ -390,22 +392,53 @@ function collect_limitations!(@nospecialize(typ), sv::InferenceState)
     return typ
 end
 
+function from_intermustalias(rt::InterMustAlias, arginfo::ArgInfo)
+    fargs = arginfo.fargs
+    if fargs !== nothing && 1 ≤ rt.slot ≤ length(fargs)
+        arg = fargs[rt.slot]
+        if isa(arg, SlotNumber)
+            argtyp = widenslotwrapper(arginfo.argtypes[rt.slot])
+            if rt.vartyp ⊑ argtyp
+                return MustAlias(arg, rt.vartyp, rt.fldidx, rt.fldtyp)
+            else
+                # TODO optimize this case?
+            end
+        end
+    end
+    return widenmustalias(rt)
+end
+
 function from_interconditional(𝕃ₚ::AbstractLattice, @nospecialize(typ),
         sv::InferenceState, (; fargs, argtypes)::ArgInfo, @nospecialize(maybecondinfo))
     𝕃 = widenlattice(𝕃ₚ)
     has_conditional(𝕃ₚ) || return widenconditional(typ)
     fargs === nothing && return widenconditional(typ)
     slot = 0
+    alias = nothing
     thentype = elsetype = Any
     condval = maybe_extract_const_bool(typ)
     for i in 1:length(fargs)
         # find the first argument which supports refinement,
         # and intersect all equivalent arguments with it
-        arg = ssa_def_slot(fargs[i], sv)
-        arg isa SlotNumber || continue # can't refine
-        old = argtypes[i]
-        old isa Type || continue # unlikely to refine
-        id = slot_id(arg)
+        argtyp = argtypes[i]
+        if alias === nothing
+            if argtyp isa MustAlias
+                old = argtyp.fldtyp
+                id = argtyp.slot
+            elseif alias === nothing && argtyp isa Type
+                arg = ssa_def_slot(fargs[i], sv)
+                arg isa SlotNumber || continue # can't refine
+                old = argtyp
+                id = slot_id(arg)
+            else
+                continue # unlikely to refine
+            end
+        elseif argtyp isa MustAlias && issubalias(argtyp, alias)
+            old = alias.fldtyp
+            id = alias.slot
+        else
+            continue
+        end
         if slot == 0 || id == slot
             if isa(maybecondinfo, Tuple{Vector{Any},Vector{Any}})
                 # if we have already computed argument refinement information, apply that now to get the result
@@ -433,19 +466,27 @@ function from_interconditional(𝕃ₚ::AbstractLattice, @nospecialize(typ),
             end
             if (slot > 0 || condval !== false) && ⋤(𝕃, thentype, old)
                 slot = id
+                if argtyp isa MustAlias
+                    alias = argtyp
+                end
             elseif (slot > 0 || condval !== true) && ⋤(𝕃, elsetype, old)
                 slot = id
-            else # reset: no new useful information for this slot
-                thentype = elsetype = Any
-                if slot > 0
-                    slot = 0
+                if argtyp isa MustAlias
+                    alias = argtyp
                 end
+            else # reset: no new useful information for this slot
+                slot = 0
+                alias = nothing
+                thentype = elsetype = Any
             end
         end
     end
     if thentype === Bottom && elsetype === Bottom
         return Bottom # accidentally proved this call to be dead / throw !
     elseif slot > 0
+        if alias !== nothing
+            return form_mustalias_conditional(alias, thentype, elsetype)
+        end
         return Conditional(slot, thentype, elsetype) # record a Conditional improvement to this slot
     end
     return widenconditional(typ)
@@ -455,7 +496,7 @@ function conditional_argtype(@nospecialize(rt), @nospecialize(sig), argtypes::Ve
     if isa(rt, InterConditional) && rt.slot == i
         return rt
     else
-        thentype = elsetype = tmeet(widenconditional(argtypes[i]), fieldtype(sig, i))
+        thentype = elsetype = tmeet(widenslotwrapper(argtypes[i]), fieldtype(sig, i))
         condval = maybe_extract_const_bool(rt)
         condval === true && (elsetype = Bottom)
         condval === false && (thentype = Bottom)
@@ -802,7 +843,7 @@ end
 is_all_const_arg(arginfo::ArgInfo, start::Int) = is_all_const_arg(arginfo.argtypes, start::Int)
 function is_all_const_arg(argtypes::Vector{Any}, start::Int)
     for i = start:length(argtypes)
-        a = widenconditional(argtypes[i])
+        a = widenslotwrapper(argtypes[i])
         isa(a, Const) || isconstType(a) || issingletontype(a) || return false
     end
     return true
@@ -810,7 +851,7 @@ end
 
 collect_const_args(arginfo::ArgInfo, start::Int) = collect_const_args(arginfo.argtypes, start)
 function collect_const_args(argtypes::Vector{Any}, start::Int)
-    return Any[ let a = widenconditional(argtypes[i])
+    return Any[ let a = widenslotwrapper(argtypes[i])
                     isa(a, Const) ? a.val :
                     isconstType(a) ? (a::DataType).parameters[1] :
                     (a::DataType).instance
@@ -920,7 +961,7 @@ function matching_cache_argtypes(linfo::MethodInstance, argtypes::ConditionalArg
                 continue
             end
         end
-        given_argtypes[i] = widenconditional(argtype)
+        given_argtypes[i] = widenslotwrapper(argtype)
     end
     if condargs !== nothing
         given_argtypes = let condargs=condargs
@@ -964,6 +1005,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
             if isa(ir, IRCode)
                 irsv = IRInterpretationState(interp, ir, mi, sv.world, arginfo.argtypes)
                 rt = ir_abstract_constant_propagation(interp, irsv)
+                @assert !(rt isa Conditional || rt isa MustAlias) "invalid lattice element returned from IR interpretation"
                 if !isa(rt, Type) || typeintersect(rt, Bool) === Union{}
                     return ConstCallResults(rt, SemiConcreteResult(mi, ir, result.effects), result.effects, mi)
                 end
@@ -1064,7 +1106,7 @@ function const_prop_entry_heuristic(interp::AbstractInterpreter, result::MethodC
         else
             return true
         end
-    elseif isa(rt, PartialStruct) || isa(rt, InterConditional)
+    elseif isa(rt, PartialStruct) || isa(rt, InterConditional) || isa(rt, InterMustAlias)
         # could be improved to `Const` or a more precise wrapper
         return true
     elseif isa(rt, LimitedAccuracy)
@@ -1092,7 +1134,7 @@ function const_prop_argument_heuristic(interp::AbstractInterpreter, (; fargs, ar
         if isa(a, Conditional) && fargs !== nothing
             is_const_prop_profitable_conditional(a, fargs, sv) && return true
         else
-            a = widenconditional(a)
+            a = widenslotwrapper(a)
             has_nontrivial_const_info(typeinf_lattice(interp), a) && is_const_prop_profitable_arg(a) && return true
         end
     end
@@ -1138,11 +1180,12 @@ end
 
 # checks if all argtypes has additional information other than what `Type` can provide
 function is_all_overridden((; fargs, argtypes)::ArgInfo, sv::InferenceState)
-    for a in argtypes
+    for i in 1:length(argtypes)
+        a = argtypes[i]
         if isa(a, Conditional) && fargs !== nothing
             is_const_prop_profitable_conditional(a, fargs, sv) || return false
         else
-            a = widenconditional(a)
+            a = widenslotwrapper(a)
             is_forwardable_argtype(a) || return false
         end
     end
@@ -1575,6 +1618,65 @@ function argtype_tail(argtypes::Vector{Any}, i::Int)
     return argtypes[i:n]
 end
 
+struct ConditionalTypes
+    thentype
+    elsetype
+    ConditionalTypes(thentype, elsetype) = (@nospecialize; new(thentype, elsetype))
+end
+
+@inline function isa_condition(@nospecialize(xt), @nospecialize(ty), max_union_splitting::Int,
+    @nospecialize(rt))
+    if isa(rt, Const)
+        xt = widenslotwrapper(xt)
+        if rt.val === false
+            return ConditionalTypes(Bottom, xt)
+        elseif rt.val === true
+            return ConditionalTypes(xt, Bottom)
+        end
+    end
+    return isa_condition(xt, ty, max_union_splitting)
+end
+@inline function isa_condition(@nospecialize(xt), @nospecialize(ty), max_union_splitting::Int)
+    tty_ub, isexact_tty = instanceof_tfunc(ty)
+    tty = widenconst(xt)
+    if isexact_tty && !isa(tty_ub, TypeVar)
+        tty_lb = tty_ub # TODO: this would be wrong if !isexact_tty, but instanceof_tfunc doesn't preserve this info
+        if !has_free_typevars(tty_lb) && !has_free_typevars(tty_ub)
+            thentype = typeintersect(tty, tty_ub)
+            if iskindtype(tty_ub) && thentype !== Bottom
+                # `typeintersect` may be unable narrow down `Type`-type
+                thentype = tty_ub
+            end
+            valid_as_lattice(thentype) || (thentype = Bottom)
+            elsetype = typesubtract(tty, tty_lb, max_union_splitting)
+            return ConditionalTypes(thentype, elsetype)
+        end
+    end
+    return nothing
+end
+
+@inline function egal_condition(c::Const, @nospecialize(xt), max_union_splitting::Int,
+    @nospecialize(rt))
+    thentype = c
+    elsetype = widenslotwrapper(xt)
+    if rt === Const(false)
+        thentype = Bottom
+    elseif rt === Const(true)
+        elsetype = Bottom
+    elseif elsetype isa Type && isdefined(typeof(c.val), :instance) # can only widen a if it is a singleton
+        elsetype = typesubtract(elsetype, typeof(c.val), max_union_splitting)
+    end
+    return ConditionalTypes(thentype, elsetype)
+end
+@inline function egal_condition(c::Const, @nospecialize(xt), max_union_splitting::Int)
+    thentype = c
+    elsetype = widenslotwrapper(xt)
+    if elsetype isa Type && isdefined(typeof(c.val), :instance) # can only widen a if it is a singleton
+        elsetype = typesubtract(elsetype, typeof(c.val), max_union_splitting)
+    end
+    return ConditionalTypes(thentype, elsetype)
+end
+
 function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs, argtypes)::ArgInfo,
                                sv::Union{InferenceState, IRCode}, max_methods::Int)
     @nospecialize f
@@ -1605,29 +1707,37 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
         end
     end
     rt = builtin_tfunction(interp, f, argtypes[2:end], sv)
-    if has_conditional(𝕃ᵢ) && (rt === Bool || (isa(rt, Const) && isa(rt.val, Bool))) && isa(fargs, Vector{Any})
+    if has_mustalias(𝕃ᵢ) && f === getfield && isa(fargs, Vector{Any}) && la ≥ 3
+        a3 = argtypes[3]
+        if isa(a3, Const)
+            if rt !== Bottom && !isalreadyconst(rt)
+                var = fargs[2]
+                if isa(var, SlotNumber)
+                    vartyp = widenslotwrapper(argtypes[2])
+                    fldidx = maybe_const_fldidx(vartyp, a3.val)
+                    if fldidx !== nothing
+                        # wrap this aliasable field into `MustAlias` for possible constraint propagations
+                        return MustAlias(var, vartyp, fldidx, rt)
+                    end
+                end
+            end
+        end
+    elseif has_conditional(𝕃ᵢ) && (rt === Bool || (isa(rt, Const) && isa(rt.val, Bool))) && isa(fargs, Vector{Any})
         # perform very limited back-propagation of type information for `is` and `isa`
         if f === isa
             a = ssa_def_slot(fargs[2], sv)
+            a2 = argtypes[2]
             if isa(a, SlotNumber)
-                aty = widenconst(argtypes[2])
-                if rt === Const(false)
-                    return Conditional(a, Union{}, aty)
-                elseif rt === Const(true)
-                    return Conditional(a, aty, Union{})
+                cndt = isa_condition(a2, argtypes[3], InferenceParams(interp).MAX_UNION_SPLITTING, rt)
+                if cndt !== nothing
+                    return Conditional(a, cndt.thentype, cndt.elsetype)
                 end
-                tty_ub, isexact_tty = instanceof_tfunc(argtypes[3])
-                if isexact_tty && !isa(tty_ub, TypeVar)
-                    tty_lb = tty_ub # TODO: this would be wrong if !isexact_tty, but instanceof_tfunc doesn't preserve this info
-                    if !has_free_typevars(tty_lb) && !has_free_typevars(tty_ub)
-                        ifty = typeintersect(aty, tty_ub)
-                        if iskindtype(tty_ub) && ifty !== Bottom
-                            # `typeintersect` may be unable narrow down `Type`-type
-                            ifty = tty_ub
-                        end
-                        valid_as_lattice(ifty) || (ifty = Union{})
-                        elty = typesubtract(aty, tty_lb, InferenceParams(interp).MAX_UNION_SPLITTING)
-                        return Conditional(a, ifty, elty)
+            end
+            if isa(a2, MustAlias)
+                if !isa(rt, Const) # skip refinement when the field is known precisely (just optimization)
+                    cndt = isa_condition(a2, argtypes[3], InferenceParams(interp).MAX_UNION_SPLITTING)
+                    if cndt !== nothing
+                        return form_mustalias_conditional(a2, cndt.thentype, cndt.elsetype)
                     end
                 end
             end
@@ -1637,50 +1747,60 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
             aty = argtypes[2]
             bty = argtypes[3]
             # if doing a comparison to a singleton, consider returning a `Conditional` instead
-            if isa(aty, Const) && isa(b, SlotNumber)
-                if rt === Const(false)
-                    aty = Union{}
-                    bty = widenconditional(bty)
-                elseif rt === Const(true)
-                    bty = Union{}
-                elseif bty isa Type && isdefined(typeof(aty.val), :instance) # can only widen a if it is a singleton
-                    bty = typesubtract(bty, typeof(aty.val), InferenceParams(interp).MAX_UNION_SPLITTING)
-                else
-                    bty = widenconditional(bty)
+            if isa(aty, Const)
+                if isa(b, SlotNumber)
+                    cndt = egal_condition(aty, bty, InferenceParams(interp).MAX_UNION_SPLITTING, rt)
+                    return Conditional(b, cndt.thentype, cndt.elsetype)
+                elseif isa(bty, MustAlias) && !isa(rt, Const) # skip refinement when the field is known precisely (just optimization)
+                    cndt = egal_condition(aty, bty.fldtyp, InferenceParams(interp).MAX_UNION_SPLITTING)
+                    return form_mustalias_conditional(bty, cndt.thentype, cndt.elsetype)
                 end
-                return Conditional(b, aty, bty)
+            elseif isa(bty, Const)
+                if isa(a, SlotNumber)
+                    cndt = egal_condition(bty, aty, InferenceParams(interp).MAX_UNION_SPLITTING, rt)
+                    return Conditional(a, cndt.thentype, cndt.elsetype)
+                elseif isa(aty, MustAlias) && !isa(rt, Const) # skip refinement when the field is known precisely (just optimization)
+                    cndt = egal_condition(bty, aty.fldtyp, InferenceParams(interp).MAX_UNION_SPLITTING)
+                    return form_mustalias_conditional(aty, cndt.thentype, cndt.elsetype)
+                end
             end
-            if isa(bty, Const) && isa(a, SlotNumber)
-                if rt === Const(false)
-                    bty = Union{}
-                    aty = widenconditional(aty)
-                elseif rt === Const(true)
-                    aty = Union{}
-                elseif aty isa Type && isdefined(typeof(bty.val), :instance) # same for b
-                    aty = typesubtract(aty, typeof(bty.val), InferenceParams(interp).MAX_UNION_SPLITTING)
-                else
-                    aty = widenconditional(aty)
+            # TODO enable multiple constraints propagation here, there are two possible improvements:
+            # 1. propagate constraints for both lhs and rhs
+            # 2. we can propagate both constraints on aliased fields and slots
+            # As for 2, for now, we prioritize constraints on aliased fields, since currently
+            # different slots that represent the same object can't share same field constraint,
+            # and thus binding `MustAlias` to the other slot is less likely useful
+            if !isa(rt, Const) # skip refinement when the field is known precisely (just optimization)
+                if isa(bty, MustAlias)
+                    thentype = widenslotwrapper(aty)
+                    elsetype = bty.fldtyp
+                    if thentype ⊏ elsetype
+                        return form_mustalias_conditional(bty, thentype, elsetype)
+                    end
+                elseif isa(aty, MustAlias)
+                    thentype = widenslotwrapper(bty)
+                    elsetype = aty.fldtyp
+                    if thentype ⊏ elsetype
+                        return form_mustalias_conditional(aty, thentype, elsetype)
+                    end
                 end
-                return Conditional(a, bty, aty)
             end
             # narrow the lattice slightly (noting the dependency on one of the slots), to promote more effective smerge
             if isa(b, SlotNumber)
-                return Conditional(b, rt === Const(false) ? Union{} : bty, rt === Const(true) ? Union{} : bty)
-            end
-            if isa(a, SlotNumber)
-                return Conditional(a, rt === Const(false) ? Union{} : aty, rt === Const(true) ? Union{} : aty)
+                thentype = rt === Const(false) ? Bottom : widenslotwrapper(bty)
+                elsetype = rt === Const(true)  ? Bottom : widenslotwrapper(bty)
+                return Conditional(b, thentype, elsetype)
+            elseif isa(a, SlotNumber)
+                thentype = rt === Const(false) ? Bottom : widenslotwrapper(aty)
+                elsetype = rt === Const(true)  ? Bottom : widenslotwrapper(aty)
+                return Conditional(a, thentype, elsetype)
             end
         elseif f === Core.Compiler.not_int
             aty = argtypes[2]
             if isa(aty, Conditional)
-                ifty = aty.elsetype
-                elty = aty.thentype
-                if rt === Const(false)
-                    ifty = Union{}
-                elseif rt === Const(true)
-                    elty = Union{}
-                end
-                return Conditional(aty.slot, ifty, elty)
+                thentype = rt === Const(false) ? Bottom : aty.elsetype
+                elsetype = rt === Const(true)  ? Bottom : aty.thentype
+                return Conditional(aty.slot, thentype, elsetype)
             end
         elseif f === isdefined
             uty = argtypes[2]
@@ -1963,7 +2083,7 @@ end
 function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo,
                        sv::Union{InferenceState, IRCode}, max_methods::Union{Int, Nothing} = isa(sv, IRCode) ? 0 : nothing)
     argtypes = arginfo.argtypes
-    ft = argtypes[1]
+    ft = widenslotwrapper(argtypes[1])
     f = singleton_type(ft)
     if isa(ft, PartialOpaque)
         newargtypes = copy(argtypes)
@@ -2138,7 +2258,7 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
             local anyrefine = false
             local allconst = true
             for i = 1:nargs
-                at = widenconditional(abstract_eval_value(interp, e.args[i+1], vtypes, sv))
+                at = widenslotwrapper(abstract_eval_value(interp, e.args[i+1], vtypes, sv))
                 ft = fieldtype(t, i)
                 nothrow && (nothrow = at ⊑ᵢ ft)
                 at = tmeet(typeinf_lattice(interp), at, ft)
@@ -2437,6 +2557,18 @@ function widenreturn_noslotwrapper(𝕃ᵢ::AbstractLattice, @nospecialize(rt), 
     return widenreturn_noslotwrapper(widenlattice(𝕃ᵢ), rt, info)
 end
 
+function widenreturn(𝕃ᵢ::MustAliasesLattice, @nospecialize(rt), info::BestguessInfo)
+    if isa(rt, MustAlias)
+        if 1 ≤ rt.slot ≤ info.nargs
+            rt = InterMustAlias(rt)
+        else
+            rt = widenmustalias(rt)
+        end
+    end
+    isa(rt, InterMustAlias) && return rt
+    return widenreturn(widenlattice(𝕃ᵢ), rt, info)
+end
+
 function widenreturn(𝕃ᵢ::ConditionalsLattice, @nospecialize(rt), info::BestguessInfo)
     ⊑ᵢ = ⊑(𝕃ᵢ)
     if !(⊑(ipo_lattice(info.interp), info.bestguess, Bool)) || info.bestguess === Bool
@@ -2468,7 +2600,9 @@ function widenreturn(𝕃ᵢ::ConditionalsLattice, @nospecialize(rt), info::Best
             rt = bool_rt_to_conditional(rt, info)
         end
     end
-    isa(rt, Conditional) && return InterConditional(rt)
+    if isa(rt, Conditional)
+        rt = InterConditional(rt)
+    end
     isa(rt, InterConditional) && return rt
     return widenreturn(widenlattice(𝕃ᵢ), rt, info)
 end
@@ -2493,7 +2627,7 @@ end
 function bool_rt_to_conditional(@nospecialize(rt), slot_id::Int, info::BestguessInfo)
     ⊑ᵢ = ⊑(typeinf_lattice(info.interp))
     old = info.slottypes[slot_id]
-    new = widenconditional(info.changes[slot_id].typ) # avoid nested conditional
+    new = widenslotwrapper(info.changes[slot_id].typ) # avoid nested conditional
     if new ⊑ᵢ old && !(old ⊑ᵢ new)
         if isa(rt, Const)
             val = rt.val

--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -49,7 +49,30 @@ end
 widenlattice(L::InterConditionalsLattice) = L.parent
 is_valid_lattice_norec(lattice::InterConditionalsLattice, @nospecialize(elem)) = isa(elem, InterConditional)
 
-const AnyConditionalsLattice{L} = Union{ConditionalsLattice{L}, InterConditionalsLattice{L}}
+"""
+    struct MustAliasesLattice{𝕃}
+
+A lattice extending lattice `𝕃` and adjoining `MustAlias`.
+"""
+struct MustAliasesLattice{𝕃 <: AbstractLattice} <: AbstractLattice
+    parent::𝕃
+end
+widenlattice(𝕃::MustAliasesLattice) = 𝕃.parent
+is_valid_lattice_norec(𝕃::MustAliasesLattice, @nospecialize(elem)) = isa(elem, MustAlias)
+
+"""
+    struct InterMustAliasesLattice{𝕃}
+
+A lattice extending lattice `𝕃` and adjoining `InterMustAlias`.
+"""
+struct InterMustAliasesLattice{𝕃 <: AbstractLattice} <: AbstractLattice
+    parent::𝕃
+end
+widenlattice(𝕃::InterMustAliasesLattice) = 𝕃.parent
+is_valid_lattice_norec(𝕃::InterMustAliasesLattice, @nospecialize(elem)) = isa(elem, InterMustAlias)
+
+const AnyConditionalsLattice{𝕃} = Union{ConditionalsLattice{𝕃}, InterConditionalsLattice{𝕃}}
+const AnyMustAliasesLattice{𝕃} = Union{MustAliasesLattice{𝕃}, InterMustAliasesLattice{𝕃}}
 
 const SimpleInferenceLattice = typeof(PartialsLattice(ConstsLattice()))
 const BaseInferenceLattice = typeof(ConditionalsLattice(SimpleInferenceLattice.instance))
@@ -158,6 +181,10 @@ has_nontrivial_const_info(::JLTypeLattice, @nospecialize(t)) = false
 has_conditional(𝕃::AbstractLattice) = has_conditional(widenlattice(𝕃))
 has_conditional(::AnyConditionalsLattice) = true
 has_conditional(::JLTypeLattice) = false
+
+has_mustalias(𝕃::AbstractLattice) = has_mustalias(widenlattice(𝕃))
+has_mustalias(::AnyMustAliasesLattice) = true
+has_mustalias(::JLTypeLattice) = false
 
 # Curried versions
 ⊑(lattice::AbstractLattice) = (@nospecialize(a), @nospecialize(b)) -> ⊑(lattice, a, b)

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -44,7 +44,7 @@ function matching_cache_argtypes(linfo::MethodInstance, simple_argtypes::SimpleA
     (; argtypes) = simple_argtypes
     given_argtypes = Vector{Any}(undef, length(argtypes))
     for i = 1:length(argtypes)
-        given_argtypes[i] = widenconditional(argtypes[i])
+        given_argtypes[i] = widenslotwrapper(argtypes[i])
     end
     given_argtypes = va_process_argtypes(given_argtypes, linfo)
     return pick_const_args(linfo, given_argtypes)
@@ -78,6 +78,7 @@ function is_argtype_match(lattice::AbstractLattice,
     return !overridden_by_const
 end
 
+# TODO MustAlias forwarding
 function is_forwardable_argtype(@nospecialize x)
     return isa(x, Const) ||
            isa(x, Conditional) ||
@@ -223,7 +224,7 @@ function cache_lookup(lattice::AbstractLattice, linfo::MethodInstance, given_arg
         cache_argtypes = cached_result.argtypes
         cache_overridden_by_const = cached_result.overridden_by_const
         for i in 1:nargs
-            if !is_argtype_match(lattice, given_argtypes[i],
+            if !is_argtype_match(lattice, widenmustalias(given_argtypes[i]),
                                  cache_argtypes[i],
                                  cache_overridden_by_const[i])
                 cache_match = false

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -418,7 +418,7 @@ function finish(interp::AbstractInterpreter, opt::OptimizationState,
     # compute inlining and other related optimizations
     result = caller.result
     @assert !(result isa LimitedAccuracy)
-    result = isa(result, InterConditional) ? widenconditional(result) : result
+    result = widenslotwrapper(result)
     if (isa(result, Const) || isconstType(result))
         proven_pure = false
         # must be proven pure to use constant calling convention;

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -95,6 +95,9 @@ struct IRInterpretationState
     function IRInterpretationState(interp::AbstractInterpreter,
         ir::IRCode, mi::MethodInstance, world::UInt, argtypes::Vector{Any})
         argtypes = va_process_argtypes(argtypes, mi)
+        for i = 1:length(argtypes)
+            argtypes[i] = widenslotwrapper(argtypes[i])
+        end
         argtypes_refined = Bool[!⊑(typeinf_lattice(interp), ir.argtypes[i], argtypes[i]) for i = 1:length(argtypes)]
         empty!(ir.argtypes)
         append!(ir.argtypes, argtypes)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -321,6 +321,9 @@ function CodeInstance(
         elseif isa(result_type, InterConditional)
             rettype_const = result_type
             const_flags = 0x2
+        elseif isa(result_type, InterMustAlias)
+            rettype_const = result_type
+            const_flags = 0x2
         else
             rettype_const = nothing
             const_flags = 0x00
@@ -526,8 +529,8 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
     end
     # inspect whether our inference had a limited result accuracy,
     # else it may be suitable to cache
-    me.bestguess = cycle_fix_limited(me.bestguess, me)
-    limited_ret = me.bestguess isa LimitedAccuracy
+    bestguess = me.bestguess = cycle_fix_limited(me.bestguess, me)
+    limited_ret = bestguess isa LimitedAccuracy
     limited_src = false
     if !limited_ret
         gt = me.ssavaluetypes
@@ -564,7 +567,7 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
         end
     end
     me.result.valid_worlds = me.valid_worlds
-    me.result.result = me.bestguess
+    me.result.result = bestguess
     me.ipo_effects = me.result.ipo_effects = adjust_effects(me)
     validate_code_in_debug_mode(me.linfo, me.src, "inferred")
     nothing
@@ -640,7 +643,7 @@ function annotate_slot_load!(undefs::Vector{Bool}, idx::Int, sv::InferenceState,
             state = sv.bb_vartables[block]::VarTable
             vt = state[id]
             undefs[id] |= vt.undef
-            typ = widenconditional(ignorelimited(vt.typ))
+            typ = widenslotwrapper(ignorelimited(vt.typ))
         else
             typ = sv.ssavaluetypes[pc]
             @assert typ !== NOT_FOUND "active slot in unreached region"
@@ -719,7 +722,7 @@ function type_annotate!(interp::AbstractInterpreter, sv::InferenceState, run_opt
     # 1. introduce temporary `TypedSlot`s that are supposed to be replaced with π-nodes later
     # 2. mark used-undef slots (required by the `slot2reg` conversion)
     # 3. mark unreached statements for a bulk code deletion (see issue #7836)
-    # 4. widen `Conditional`s and remove `NOT_FOUND` from `ssavaluetypes`
+    # 4. widen slot wrappers (`Conditional` and `MustAlias`) and remove `NOT_FOUND` from `ssavaluetypes`
     #    NOTE because of this, `was_reached` will no longer be available after this point
     # 5. eliminate GotoIfNot if either branch target is unreachable
     changemap = nothing # initialized if there is any dead region
@@ -739,7 +742,7 @@ function type_annotate!(interp::AbstractInterpreter, sv::InferenceState, run_opt
                 end
             end
             body[i] = annotate_slot_load!(undefs, i, sv, expr) # 1&2
-            ssavaluetypes[i] = widenconditional(ssavaluetypes[i]) # 4
+            ssavaluetypes[i] = widenslotwrapper(ssavaluetypes[i]) # 4
         else # i.e. any runtime execution will never reach this statement
             if is_meta_expr(expr) # keep any lexically scoped expressions
                 ssavaluetypes[i] = Any # 4
@@ -893,13 +896,15 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
             rettype = code.rettype
             if isdefined(code, :rettype_const)
                 rettype_const = code.rettype_const
-                # the second subtyping conditions are necessary to distinguish usual cases
+                # the second subtyping/egal conditions are necessary to distinguish usual cases
                 # from rare cases when `Const` wrapped those extended lattice type objects
                 if isa(rettype_const, Vector{Any}) && !(Vector{Any} <: rettype)
                     rettype = PartialStruct(rettype, rettype_const)
                 elseif isa(rettype_const, PartialOpaque) && rettype <: Core.OpaqueClosure
                     rettype = rettype_const
-                elseif isa(rettype_const, InterConditional) && !(InterConditional <: rettype)
+                elseif isa(rettype_const, InterConditional) && rettype !== InterConditional
+                    rettype = rettype_const
+                elseif isa(rettype_const, InterMustAlias) && rettype !== InterMustAlias
                     rettype = rettype_const
                 else
                     rettype = Const(rettype_const)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -81,6 +81,70 @@ const AnyConditional = Union{Conditional,InterConditional}
 Conditional(cnd::InterConditional) = Conditional(cnd.slot, cnd.thentype, cnd.elsetype)
 InterConditional(cnd::Conditional) = InterConditional(cnd.slot, cnd.thentype, cnd.elsetype)
 
+"""
+    alias::MustAlias
+
+This lattice element wraps a reference to object field while recoding the identity of the
+parent object. It allows certain constraints that can be imposed on the object field type
+by built-in functions like `isa` and `===` to be propagated to another reference to the
+same object field.
+One important note is that this lattice element assumes the invariant that the field of
+wrapped slot object never changes until the slot object is re-assigned. This means, the
+wrapped object field should be constant as inference currently doesn't track any memory
+effects on per-object basis. Particularly `maybe_const_fldidx` takes the lift to check if
+a given lattice element is eligible to be wrapped by `MustAlias`. Example:
+```juila
+let alias = getfield(x::Some{Union{Nothing,String}}, :value)::MustAlias(x, Some{Union{Nothing,String}}, 1, Union{Nothing,String})
+    if alias === nothing
+        # May assume `getfield(x, :value)` is `nothing` now
+    else
+        # May assume `getfield(x, :value)` is `::String` now
+    end
+end
+```
+N.B. currently this lattice element is only used in abstractinterpret, not in optimization
+"""
+struct MustAlias
+    slot::Int
+    vartyp::Any
+    fldidx::Int
+    fldtyp::Any
+    function MustAlias(slot::Int, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp))
+        assert_nested_slotwrapper(vartyp)
+        assert_nested_slotwrapper(fldtyp)
+        # @assert !isalreadyconst(vartyp) "vartyp is already const"
+        # @assert !isalreadyconst(fldtyp) "fldtyp is already const"
+        return new(slot, vartyp, fldidx, fldtyp)
+    end
+end
+MustAlias(var::SlotNumber, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp)) =
+    MustAlias(slot_id(var), vartyp, fldidx, fldtyp)
+
+"""
+    alias::InterMustAlias
+
+This lattice element used in a very similar way as `InterConditional`, but corresponds to `MustAlias`.
+"""
+struct InterMustAlias
+    slot::Int
+    vartyp::Any
+    fldidx::Int
+    fldtyp::Any
+    function InterMustAlias(slot::Int, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp))
+        assert_nested_slotwrapper(vartyp)
+        assert_nested_slotwrapper(fldtyp)
+        # @assert !isalreadyconst(vartyp) "vartyp is already const"
+        # @assert !isalreadyconst(fldtyp) "fldtyp is already const"
+        return new(slot, vartyp, fldidx, fldtyp)
+    end
+end
+InterMustAlias(var::SlotNumber, @nospecialize(vartyp), fldidx::Int, @nospecialize(fldtyp)) =
+    InterMustAlias(slot_id(var), vartyp, fldidx, fldtyp)
+
+const AnyMustAlias = Union{MustAlias,InterMustAlias}
+MustAlias(alias::InterMustAlias) = MustAlias(alias.slot, alias.vartyp, alias.fldidx, alias.fldtyp)
+InterMustAlias(alias::MustAlias) = InterMustAlias(alias.slot, alias.vartyp, alias.fldidx, alias.fldtyp)
+
 struct PartialTypeVar
     tv::TypeVar
     # N.B.: Currently unused, but would allow turning something back
@@ -130,7 +194,7 @@ struct NotFound end
 
 const NOT_FOUND = NotFound()
 
-const CompilerTypes = Union{MaybeUndef, Const, Conditional, NotFound, PartialStruct}
+const CompilerTypes = Union{MaybeUndef, Const, Conditional, MustAlias, NotFound, PartialStruct}
 ==(x::CompilerTypes, y::CompilerTypes) = x === y
 ==(x::Type, y::CompilerTypes) = false
 ==(x::CompilerTypes, y::Type) = false
@@ -145,13 +209,26 @@ const CompilerTypes = Union{MaybeUndef, Const, Conditional, NotFound, PartialStr
 function assert_nested_slotwrapper(@nospecialize t)
     @assert !(t isa Conditional)      "found nested Conditional"
     @assert !(t isa InterConditional) "found nested InterConditional"
+    @assert !(t isa MustAlias)        "found nested MustAlias"
+    @assert !(t isa InterMustAlias)   "found nested InterMustAlias"
     return t
 end
 
-widenslotwrapper(@nospecialize typ) = typ
-widenslotwrapper(typ::AnyConditional) = widenconditional(typ)
-widenwrappedslotwrapper(@nospecialize typ) = widenslotwrapper(typ)
-widenwrappedslotwrapper(typ::LimitedAccuracy) = LimitedAccuracy(widenslotwrapper(typ.typ), typ.causes)
+function widenslotwrapper(@nospecialize typ)
+    if isa(typ, AnyConditional)
+        return widenconditional(typ)
+    elseif isa(typ, AnyMustAlias)
+        return widenmustalias(typ)
+    end
+    return typ
+end
+
+function widenwrappedslotwrapper(@nospecialize typ)
+    if isa(typ, LimitedAccuracy)
+        return LimitedAccuracy(widenslotwrapper(typ.typ), typ.causes)
+    end
+    return widenslotwrapper(typ)
+end
 
 # Conditional
 # ===========
@@ -165,12 +242,17 @@ function widenconditional(@nospecialize typ)
         else
             return Bool
         end
+    elseif isa(typ, LimitedAccuracy)
+        error("unhandled LimitedAccuracy")
     end
     return typ
 end
-widenconditional(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
-widenwrappedconditional(@nospecialize typ) = widenconditional(typ)
-widenwrappedconditional(typ::LimitedAccuracy) = LimitedAccuracy(widenconditional(typ.typ), typ.causes)
+function widenwrappedconditional(@nospecialize typ)
+    if isa(typ, LimitedAccuracy)
+        return LimitedAccuracy(widenconditional(typ.typ), typ.causes)
+    end
+    return widenconditional(typ)
+end
 
 # `Conditional` and `InterConditional` are valid in opposite contexts
 # (i.e. local inference and inter-procedural call), as such they will never be compared
@@ -196,6 +278,81 @@ function maybe_extract_const_bool(c::AnyConditional)
     nothing
 end
 maybe_extract_const_bool(@nospecialize c) = nothing
+
+# MustAlias
+# =========
+
+function widenmustalias(@nospecialize typ)
+    if isa(typ, AnyMustAlias)
+        return typ.fldtyp
+    elseif isa(typ, LimitedAccuracy)
+        error("unhandled LimitedAccuracy")
+    end
+    return typ
+end
+
+function isalreadyconst(@nospecialize t)
+    isa(t, Const) && return true
+    isa(t, DataType) && isdefined(t, :instance) && return true
+    return isconstType(t)
+end
+
+function maybe_const_fldidx(@nospecialize(objtyp), @nospecialize(fldval))
+    t = widenconst(objtyp)
+    if isa(fldval, Int)
+        fldidx = fldval
+    elseif isa(fldval, Symbol)
+        isa(t, DataType) || isa(t, UnionAll) || return nothing
+        fldidx = fieldindex(t, fldval, false)
+    else
+        return nothing
+    end
+    fldidx == 0 && return nothing
+    isconst(t, fldidx) || return nothing
+    fldcnt = fieldcount_noerror(t)
+    (fldcnt === nothing || fldcnt == 0) && return nothing
+    return fldidx
+end
+
+function form_mustalias_conditional(alias::MustAlias, @nospecialize(thentype), @nospecialize(elsetype))
+    (; slot, vartyp, fldidx) = alias
+    if isa(vartyp, PartialStruct)
+        fields = vartyp.fields
+        thenfields = thentype === Bottom ? nothing : copy(fields)
+        elsefields = elsetype === Bottom ? nothing : copy(fields)
+        for i in 1:length(fields)
+            if i == fldidx
+                thenfields === nothing || (thenfields[i] = thentype)
+                elsefields === nothing || (elsefields[i] = elsetype)
+            end
+        end
+        return Conditional(slot,
+            thenfields === nothing ? Bottom : PartialStruct(vartyp.typ, thenfields),
+            elsefields === nothing ? Bottom : PartialStruct(vartyp.typ, elsefields))
+    else
+        vartyp_widened = widenconst(vartyp)
+        thenfields = thentype === Bottom ? nothing : Any[]
+        elsefields = elsetype === Bottom ? nothing : Any[]
+        for i in 1:fieldcount(vartyp_widened)
+            if i == fldidx
+                thenfields === nothing || push!(thenfields, thentype)
+                elsefields === nothing || push!(elsefields, elsetype)
+            else
+                t = fieldtype(vartyp_widened, i)
+                thenfields === nothing || push!(thenfields, t)
+                elsefields === nothing || push!(elsefields, t)
+            end
+        end
+        return Conditional(slot,
+            thenfields === nothing ? Bottom : PartialStruct(vartyp_widened, thenfields),
+            elsefields === nothing ? Bottom : PartialStruct(vartyp_widened, elsefields))
+    end
+end
+
+function issubalias(a::AnyMustAlias, b::AnyMustAlias)
+    return a.slot == b.slot && a.fldidx == b.fldidx &&
+        a.vartyp ⊑ b.vartyp && a.fldtyp ⊑ b.fldtyp
+end
 
 # LimitedAccuracy
 # ===============
@@ -248,6 +405,19 @@ function ⊑(lattice::AnyConditionalsLattice, @nospecialize(a), @nospecialize(b)
         return false
     end
     return ⊑(widenlattice(lattice), a, b)
+end
+
+function ⊑(𝕃::AnyMustAliasesLattice, @nospecialize(a), @nospecialize(b))
+    MustAliasT = isa(𝕃, MustAliasesLattice) ? MustAlias : InterMustAlias
+    if isa(a, MustAliasT)
+        if isa(b, MustAliasT)
+            return issubalias(a, b)
+        end
+        a = widenmustalias(a)
+    elseif isa(b, MustAliasT)
+        return ⊏(widenlattice(𝕃), a, widenmustalias(b))
+    end
+    return ⊑(widenlattice(𝕃), a, b)
 end
 
 function ⊑(lattice::PartialsLattice, @nospecialize(a), @nospecialize(b))
@@ -466,6 +636,13 @@ function tmeet(lattice::ConditionalsLattice, @nospecialize(v), @nospecialize(t::
     tmeet(widenlattice(lattice), v, t)
 end
 
+function tmeet(𝕃::MustAliasesLattice, @nospecialize(v), @nospecialize(t::Type))
+    if isa(v, MustAlias)
+        v = widenmustalias(v)
+    end
+    return tmeet(widenlattice(𝕃), v, t)
+end
+
 function tmeet(lattice::InferenceLattice, @nospecialize(v), @nospecialize(t::Type))
     # TODO: This can probably happen and should be handled
     @assert !isa(v, LimitedAccuracy)
@@ -476,6 +653,13 @@ function tmeet(lattice::InterConditionalsLattice, @nospecialize(v), @nospecializ
     # TODO: This can probably happen and should be handled
     @assert !isa(v, AnyConditional)
     tmeet(widenlattice(lattice), v, t)
+end
+
+function tmeet(𝕃::InterMustAliasesLattice, @nospecialize(v), @nospecialize(t::Type))
+    if isa(v, InterMustAlias)
+        v = widenmustalias(v)
+    end
+    return tmeet(widenlattice(𝕃), v, t)
 end
 
 function tmeet(lattice::OptimizerLattice, @nospecialize(v), @nospecialize(t::Type))
@@ -490,6 +674,7 @@ end
 Widens extended lattice element `x` to native `Type` representation.
 """
 widenconst(::AnyConditional) = Bool
+widenconst(a::AnyMustAlias) = widenconst(widenmustalias(a))
 widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
 widenconst(m::MaybeUndef) = widenconst(m.typ)
 widenconst(::PartialTypeVar) = TypeVar
@@ -524,8 +709,9 @@ end
 # remove any lattice elements that wrap the reassigned slot object from the vartable
 function invalidate_slotwrapper(vt::VarState, changeid::Int, ignore_conditional::Bool)
     newtyp = ignorelimited(vt.typ)
-    if (!ignore_conditional && isa(newtyp, Conditional) && newtyp.slot == changeid)
-        newtyp = widenwrappedslotwrapper(vt.typ)
+    if (!ignore_conditional && isa(newtyp, Conditional) && newtyp.slot == changeid) ||
+       (isa(newtyp, MustAlias) && newtyp.slot == changeid)
+        newtyp = @noinline widenwrappedslotwrapper(vt.typ)
         return VarState(newtyp, vt.undef)
     end
     return nothing

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -343,6 +343,16 @@ function issimplertype(lattice::AbstractLattice, @nospecialize(typea), @nospecia
         is_same_conditionals(typea, typeb) || return false
         issimplertype(lattice, typea.thentype, typeb.thentype) || return false
         issimplertype(lattice, typea.elsetype, typeb.elsetype) || return false
+    elseif typea isa MustAlias
+        typeb isa MustAlias || return false
+        issubalias(typeb, typea) || return false
+        issimplertype(lattice, typea.vartyp, typeb.vartyp) || return false
+        issimplertype(lattice, typea.fldtyp, typeb.fldtyp) || return false
+    elseif typea isa InterMustAlias
+        typeb isa InterMustAlias || return false
+        issubalias(typeb, typea) || return false
+        issimplertype(lattice, typea.vartyp, typeb.vartyp) || return false
+        issimplertype(lattice, typea.fldtyp, typeb.fldtyp) || return false
     elseif typea isa PartialOpaque
         # TODO
     end
@@ -471,6 +481,12 @@ function tmerge(lattice::InterConditionalsLattice, @nospecialize(typea), @nospec
     typea = widenconditional(typea)
     typeb = widenconditional(typeb)
     return tmerge(widenlattice(lattice), typea, typeb)
+end
+
+function tmerge(𝕃::AnyMustAliasesLattice, @nospecialize(typea), @nospecialize(typeb))
+    typea = widenmustalias(typea)
+    typeb = widenmustalias(typeb)
+    return tmerge(widenlattice(𝕃), typea, typeb)
 end
 
 function tmerge(lattice::PartialsLattice, @nospecialize(typea), @nospecialize(typeb))

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -245,6 +245,10 @@ function unionsplitcost(argtypes::Union{SimpleVector,Vector{Any}})
     nu = 1
     max = 2
     for ti in argtypes
+        # TODO remove this to implement callsite refinement of MustAlias
+        if isa(ti, MustAlias) && isa(widenconst(ti), Union)
+            ti = widenconst(ti)
+        end
         if isa(ti, Union)
             nti = unionlen(ti)
             if nti > max
@@ -276,13 +280,17 @@ function _switchtupleunion(t::Vector{Any}, i::Int, tunion::Vector{Any}, @nospeci
             push!(tunion, tpl)
         end
     else
-        ti = t[i]
+        origti = ti = t[i]
+        # TODO remove this to implement callsite refinement of MustAlias
+        if isa(ti, MustAlias) && isa(widenconst(ti), Union)
+            ti = widenconst(ti)
+        end
         if isa(ti, Union)
             for ty in uniontypes(ti::Union)
                 t[i] = ty
                 _switchtupleunion(t, i - 1, tunion, origt)
             end
-            t[i] = ti
+            t[i] = origti
         else
             _switchtupleunion(t, i - 1, tunion, origt)
         end

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -291,6 +291,7 @@ end
 #########
 
 function singleton_type(@nospecialize(ft))
+    ft = widenslotwrapper(ft)
     if isa(ft, Const)
         return ft.val
     elseif isconstType(ft)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -769,7 +769,8 @@ end
 function fieldindex(t::UnionAll, name::Symbol, err::Bool=true)
     t = argument_datatype(t)
     if t === nothing
-        throw(ArgumentError("type does not have definite fields"))
+        err && throw(ArgumentError("type does not have definite fields"))
+        return 0
     end
     return fieldindex(t, name, err)
 end

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2581,7 +2581,7 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_partial_struct_type = jl_new_datatype(jl_symbol("PartialStruct"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(2, "typ", "fields"),
-                                       jl_svec2(jl_datatype_type, jl_array_any_type),
+                                       jl_svec2(jl_any_type, jl_array_any_type),
                                        jl_emptysvec, 0, 0, 2);
 
     jl_interconditional_type = jl_new_datatype(jl_symbol("InterConditional"), core, jl_any_type, jl_emptysvec,

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1,3 +1,4 @@
+
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 /*

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -7,8 +7,12 @@ import .CC: WorldRange, WorldView
 
 include("irutils.jl")
 
-# define new `AbstractInterpreter` that satisfies the minimum interface requirements
-# while managing its cache independently
+"""
+    @newinterp NewInterpreter
+
+Defines new `NewInterpreter <: AbstractInterpreter` whose cache is separated
+from the native code cache, satisfying the minimum interface requirements.
+"""
 macro newinterp(name)
     cachename = Symbol(string(name, "Cache"))
     name = esc(name)
@@ -19,10 +23,12 @@ macro newinterp(name)
         struct $name <: CC.AbstractInterpreter
             interp::CC.NativeInterpreter
             cache::$cachename
+            meta # additional information
             $name(world = Base.get_world_counter();
                 interp = CC.NativeInterpreter(world),
-                cache = $cachename(IdDict{MethodInstance,CodeInstance}())
-                ) = new(interp, cache)
+                cache = $cachename(IdDict{MethodInstance,CodeInstance}()),
+                meta = nothing,
+                ) = new(interp, cache, meta)
         end
         CC.InferenceParams(interp::$name) = CC.InferenceParams(interp.interp)
         CC.OptimizationParams(interp::$name) = CC.OptimizationParams(interp.interp)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2185,6 +2185,338 @@ end
     end |> only === Int
 end
 
+# type-based alias analysis
+# =========================
+# `MustAlias` propagates constraints imposed on aliased fields
+
+import Core: MethodInstance, CodeInstance
+const CC = Core.Compiler
+import .CC: WorldRange, WorldView
+
+"""
+    @newinterp NewInterpreter
+
+Defines new `NewInterpreter <: AbstractInterpreter` whose cache is separated
+from the native code cache, satisfying the minimum interface requirements.
+"""
+macro newinterp(name)
+    cachename = Symbol(string(name, "Cache"))
+    name = esc(name)
+    quote
+        struct $cachename
+            dict::IdDict{MethodInstance,CodeInstance}
+        end
+        struct $name <: CC.AbstractInterpreter
+            interp::CC.NativeInterpreter
+            cache::$cachename
+            meta # additional information
+            $name(world = Base.get_world_counter();
+                interp = CC.NativeInterpreter(world),
+                cache = $cachename(IdDict{MethodInstance,CodeInstance}()),
+                meta = nothing,
+                ) = new(interp, cache, meta)
+        end
+        CC.InferenceParams(interp::$name) = CC.InferenceParams(interp.interp)
+        CC.OptimizationParams(interp::$name) = CC.OptimizationParams(interp.interp)
+        CC.get_world_counter(interp::$name) = CC.get_world_counter(interp.interp)
+        CC.get_inference_cache(interp::$name) = CC.get_inference_cache(interp.interp)
+        CC.code_cache(interp::$name) = WorldView(interp.cache, WorldRange(CC.get_world_counter(interp)))
+        CC.get(wvc::WorldView{<:$cachename}, mi::MethodInstance, default) = get(wvc.cache.dict, mi, default)
+        CC.getindex(wvc::WorldView{<:$cachename}, mi::MethodInstance) = getindex(wvc.cache.dict, mi)
+        CC.haskey(wvc::WorldView{<:$cachename}, mi::MethodInstance) = haskey(wvc.cache.dict, mi)
+        CC.setindex!(wvc::WorldView{<:$cachename}, ci::CodeInstance, mi::MethodInstance) = setindex!(wvc.cache.dict, ci, mi)
+    end
+end
+
+struct AliasableField{T}
+    f::T
+end
+struct AliasableFields{S,T}
+    f1::S
+    f2::T
+end
+mutable struct AliasableConstField{S,T}
+    const f1::S
+    f2::T
+end
+
+# lattice
+# -------
+
+import Core.Compiler:
+    AbstractLattice, ConstsLattice, PartialsLattice, InferenceLattice, OptimizerLattice,
+    MustAliasesLattice, InterMustAliasesLattice, BaseInferenceLattice, IPOResultLattice,
+    typeinf_lattice, ipo_lattice, optimizer_lattice
+
+@newinterp MustAliasInterpreter
+CC.typeinf_lattice(::MustAliasInterpreter) = InferenceLattice(MustAliasesLattice(BaseInferenceLattice.instance))
+CC.ipo_lattice(::MustAliasInterpreter) = InferenceLattice(InterMustAliasesLattice(IPOResultLattice.instance))
+CC.optimizer_lattice(::MustAliasInterpreter) = OptimizerLattice()
+
+import Core.Compiler: MustAlias, Const, PartialStruct, ⊑, tmerge
+let 𝕃ᵢ = InferenceLattice(MustAliasesLattice(BaseInferenceLattice.instance))
+    ⊑(@nospecialize(a), @nospecialize(b)) = Core.Compiler.:⊑(𝕃ᵢ, a, b)
+    tmerge(@nospecialize(a), @nospecialize(b)) = Core.Compiler.tmerge(𝕃ᵢ, a, b)
+
+    @test (MustAlias(2, AliasableField{Any}, 1, Int) ⊑ Int)
+    @test !(Int ⊑ MustAlias(2, AliasableField{Any}, 1, Int))
+    @test (Int ⊑ MustAlias(2, AliasableField{Any}, 1, Any))
+    @test (Const(42) ⊑ MustAlias(2, AliasableField{Any}, 1, Int))
+    @test !(MustAlias(2, AliasableField{Any}, 1, Any) ⊑ Int)
+    @test tmerge(MustAlias(2, AliasableField{Any}, 1, Any), Const(nothing)) === Any
+    @test tmerge(MustAlias(2, AliasableField{Any}, 1, Int), Const(nothing)) === Union{Int,Nothing}
+    @test tmerge(Const(nothing), MustAlias(2, AliasableField{Any}, 1, Any)) === Any
+    @test tmerge(Const(nothing), MustAlias(2, AliasableField{Any}, 1, Int)) === Union{Int,Nothing}
+    @test Core.Compiler.isa_tfunc(𝕃ᵢ, MustAlias(2, AliasableField{Any}, 1, Bool), Const(Bool)) === Const(true)
+    @test Core.Compiler.isa_tfunc(𝕃ᵢ, MustAlias(2, AliasableField{Any}, 1, Bool), Type{Bool}) === Const(true)
+    @test Core.Compiler.isa_tfunc(𝕃ᵢ, MustAlias(2, AliasableField{Any}, 1, Int), Type{Bool}) === Const(false)
+    @test Core.Compiler.ifelse_tfunc(MustAlias(2, AliasableField{Any}, 1, Bool), Int, Int) === Int
+    @test Core.Compiler.ifelse_tfunc(MustAlias(2, AliasableField{Any}, 1, Int), Int, Int) === Union{}
+end
+
+maybeget_mustalias_tmerge(x::AliasableField) = x.f
+maybeget_mustalias_tmerge(x) = x
+@test Base.return_types((Union{Nothing,AliasableField{Any}},); interp=MustAliasInterpreter()) do x
+    isa(maybeget_mustalias_tmerge(x)#=::Any, not MustAlias=#, Int) && throw()
+    x
+end |> only === Union{Nothing,AliasableField{Any}}
+
+# isa constraint
+# --------------
+
+# simple intra-procedural case
+@test Base.return_types((AliasableField,); interp=MustAliasInterpreter()) do a
+    if isa(getfield(a, :f), Int)
+        return getfield(a, :f)
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((AliasableField,); interp=MustAliasInterpreter()) do a
+    if isa(getfield(a, 1), Int)
+        return getfield(a, 1)
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((AliasableField{Union{Some{Int},Nothing}},); interp=MustAliasInterpreter()) do a
+    if isa(getfield(a, 1), Some)
+        return getfield(a, 1)
+    end
+    throw()
+end |> only === Some{Int}
+@test Base.return_types((Tuple{Any},); interp=MustAliasInterpreter()) do t
+    if isa(getfield(t, 1), Int)
+        return getfield(t, 1)
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((Any,); interp=MustAliasInterpreter()) do a
+    x = AliasableFields(a, 0)     # x::PartialStruct(AliasableFields, Any[Any, Const(0)])
+    if isa(getfield(x, :f1), Int) # x::PartialStruct(AliasableFields, Any[Int, Const(0)])
+        return getfield(x, :f1)
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((Any,Any); interp=MustAliasInterpreter()) do a, b
+    x = AliasableFields(a, b)         # x::AliasableFields
+    if isa(getfield(x, :f1), Int)     # x::PartialStruct(AliasableFields, Any[Int, Any])
+        if isa(getfield(x, :f2), Int) # x::PartialStruct(AliasableFields, Any[Int, Int])
+            return getfield(x, :f1), getfield(x, :f2)
+        end
+    end
+    return 0, 0
+end |> only === Tuple{Int,Int}
+@test Base.return_types((Any,); interp=MustAliasInterpreter()) do a
+    x = AliasableConstField(a, 0)
+    if isa(getfield(x, :f1), Int)
+        return getfield(x, :f1)
+    end
+    return 0
+end |> only === Int
+
+# shouldn't use refinement information when not worthwhile
+@test Base.return_types((AliasableField{Int},); interp=MustAliasInterpreter()) do a
+    if isa(getfield(a, :f), Any)
+        return getfield(a, :f) # shouldn't be ::Any
+    end
+    return 0
+end |> only === Int
+# shouldn't assume anything about mutable field
+@test Base.return_types((Any,Any); interp=MustAliasInterpreter()) do a, b
+    x = AliasableConstField{Any,Any}(a, b)
+    if isa(getfield(x, :f2), Int)
+        setfield!(x, :f2, z::Any)
+        return getfield(x, :f2) # shouldn't be ::Int
+    end
+    return 0
+end |> only === Any
+# when abstract type, we shouldn't assume anything
+@test Base.return_types((Any,); interp=MustAliasInterpreter()) do a
+    if isa(getfield(a, :mayexist), Int)
+        return getfield(a, :mayexist)
+    end
+    return 0
+end |> only === Any
+
+# works inter-procedurally
+@test Base.return_types((AliasableField,); interp=MustAliasInterpreter()) do a
+    if isa(a.f, Int)
+        return a.f
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((Tuple{Any},); interp=MustAliasInterpreter()) do t
+    if isa(t[1], Int)
+        return t[1]
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((Any,); interp=MustAliasInterpreter()) do a
+    x = AliasableFields(a, 0) # x::PartialStruct(AliasableFields, Any[Any, Const(0)])
+    if isa(x.f1, Int)         # x::PartialStruct(AliasableFields, Any[Int, Const(0)])
+        return x.f1
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((Any,Any); interp=MustAliasInterpreter()) do a, b
+    x = AliasableFields(a, b) # x::AliasableFields
+    if isa(x.f1, Int)         # x::PartialStruct(AliasableFields, Any[Int, Any])
+        if isa(x.f2, Int)     # x::PartialStruct(AliasableFields, Any[Int, Int])
+            return x.f1, x.f2
+        end
+    end
+    return 0, 0
+end |> only === Tuple{Int,Int}
+@test Base.return_types((Any,); interp=MustAliasInterpreter()) do a
+    x = AliasableConstField(a, 0)
+    if isa(x.f1, Int)
+        return x.f1
+    end
+    return 0
+end |> only === Int
+getf(a) = a.f
+@test Base.return_types((AliasableField,); interp=MustAliasInterpreter()) do a
+    if isa(getf(a), Int)
+        return getf(a)
+    end
+    return 0
+end |> only === Int
+
+# merge of same `MustAlias`s
+merge_same_aliases(b, a) = b ? _merge_same_aliases1(a) : _merge_same_aliases2(a) # MustAlias(a, Const(:f1), Union{Int,Nothing})
+_merge_same_aliases1(a) = (@assert isa(a.f, Int); a.f) # ::MustAlias(a, Const(:f1), Int)
+_merge_same_aliases2(a) = (@assert isa(a.f, Nothing); a.f) # ::MustAlias(a, Const(:f1), Nothing)
+@test Base.return_types((Bool,AliasableField,); interp=MustAliasInterpreter()) do b, a
+    return merge_same_aliases(b, a) # ::Union{Int,Nothing}
+end |> only === Union{Nothing,Int}
+
+# call-site refinement
+isaint(a) = isa(a, Int)
+@test Base.return_types((AliasableField,); interp=MustAliasInterpreter()) do a
+    if isaint(a.f)
+        return a.f
+    end
+    return 0
+end |> only === Int
+# handle multiple call-site refinment targets
+isasome(_) = true
+isasome(::Nothing) = false
+@test Base.return_types((AliasableField{Union{Int,Nothing}},); interp=MustAliasInterpreter()) do a
+    if isasome(a.f)
+        return a.f
+    end
+    return 0
+end |> only === Int
+
+# appropriate lattice order
+@test Base.return_types((AliasableField{Any},); interp=MustAliasInterpreter()) do x
+    v = x.f        # ::MustAlias(2, AliasableField{Any}, 1, Any)
+    if isa(v, Int) # ::Conditional(3, Int, Any)
+        v = v      # ::Int (∵ Int ⊑ MustAlias(2, AliasableField{Any}, 1, Any))
+    else
+        v = 42
+    end
+    return v
+end |> only === Int
+
+# complicated callsite refinement cases
+from_interconditional_check11(y::Int, ::AliasableField) = y > 0
+@test Base.return_types((AliasableField{Any},); interp=MustAliasInterpreter()) do x
+    if from_interconditional_check11(x.f, x)
+        return x.f
+    end
+    return 0
+end |> only === Int
+from_interconditional_check12(::AliasableField, y::Int) = y > 0
+@test Base.return_types((AliasableField{Any},); interp=MustAliasInterpreter()) do x
+    if from_interconditional_check12(x, x.f)
+        return x.f
+    end
+    return 0
+end |> only === Int
+from_interconditional_check21(y, ::Union{Int,String}) = isa(y, Int)
+@test Base.return_types((AliasableField{Any},); interp=MustAliasInterpreter()) do x
+    if from_interconditional_check21(x.f, x.f)
+        return x.f
+    end
+    return 0
+end |> only === Int
+from_interconditional_check22(::Union{Int,String}, y) = isa(y, Int)
+@test Base.return_types((AliasableField{Any},); interp=MustAliasInterpreter()) do x
+    if from_interconditional_check22(x.f, x.f)
+        return x.f
+    end
+    return 0
+end |> only === Int
+
+# === constraint
+# --------------
+
+# simple symmetric tests
+@test Base.return_types((AliasableField,); interp=MustAliasInterpreter()) do x
+    if x.f === 0
+        return x.f
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((AliasableField,); interp=MustAliasInterpreter()) do x
+    if 0 === x.f
+        return x.f
+    end
+    return 0
+end |> only === Int
+# NOTE we prioritize constraints on aliased field over those on slots themselves
+@test Base.return_types((AliasableField,Int,); interp=MustAliasInterpreter()) do x, a
+    if x.f === a
+        return x.f
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((AliasableField,Int,); interp=MustAliasInterpreter()) do x, a
+    if a === x.f
+        return x.f
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((AliasableField{Union{Nothing,Int}},); interp=MustAliasInterpreter()) do x
+    if !isnothing(x.f)
+        return x.f
+    end
+    return 0
+end |> only === Int
+@test Base.return_types((AliasableField{Union{Some{Int},Nothing}},); interp=MustAliasInterpreter()) do x
+    if !isnothing(x.f)
+        return x.f
+    end
+    throw()
+end |> only === Some{Int}
+
+# handle the edge case
+@eval intermustalias_edgecase(_) = $(Core.Compiler.InterMustAlias(2, Some{Any}, 1, Int))
+Base.return_types(intermustalias_edgecase, (Any,); interp=MustAliasInterpreter()) # create cache
+@test Base.return_types((Any,); interp=MustAliasInterpreter()) do x
+    intermustalias_edgecase(x)
+end |> only === Core.Compiler.InterMustAlias
+
 function f25579(g)
     h = g[]
     t = (h === nothing)
@@ -4286,6 +4618,17 @@ end
         ccall(0, Cvoid, (Nothing,), b)
     end)[2] === Nothing
 end
+
+# singleton_type on slot wrappers
+@test Base.return_types((Int,)) do x
+    c = isa(x, Int) # ::Conditional
+    c(false)        # ::Union{}
+end |> only === Union{}
+@test Base.return_types((Tuple{typeof(typeof),Float64},)) do args
+    f = args[1] # ::MustAlias
+    v = args[2] # ::MustAlias
+    f(v)        # ::Type{Float64}
+end |> only === Type{Float64}
 
 # Issue #46839: `abstract_invoke` should handle incorrect call type
 @test only(Base.return_types(()->invoke(BitSet, Any, x), ())) === Union{}


### PR DESCRIPTION
This commit tries to propagate constraints imposed on object fields, e.g.:
```julia
struct SomeX{T}
    x::Union{Nothing,T}
end
mutable struct MutableSomeX{T}
    const x::Union{Nothing,T}
end

let # o1::SomeX{T}, o2::MutableSomeX{T}
    if !isnothing(o1.x)
        # now inference knows `o1.x::T` here
        ...
        if !isnothing(o2.x)
            # now inference knows `o2.x::T` here
            ...
        end
    end
end
```

The idea is that we can make `isa` and `===` propagate constraint
imposed on an object field if the _identity_ of that object.
We can have such a lattice element that wraps return type of abstract
`getfield` call together with the object _identity_, and then we can
form a conditional constraint that propagates the refinement information
imposed on the object field when we see `isa`/`===` applied the return
value of the preceding `getfield` call.

So this PR defines the new lattice element called `MustAlias` (and also
`InterMustAlias`, which just works in a similar way to `InterConditional`),
which may be formed upon `getfield` inference to hold the retrieved type
of the field and track the _identity_ of the object (in inference,
"object identity" can be represented as a `SlotNumber`).
This PR also implements the new logic in `abstract_call_builtin` so that
`isa` and `===` can form a conditional constraint (i.e. `Conditional`)
from `MustAlias`-argument that may later refine the wrapped object to
`PartialStruct` that holds the refined field type information.

One important note here is, `MustAlias` expects the invariant that the
field of wrapped slot object never changes. The obvious limitation with
this invariant is that it can't propagate constraints imposed on mutable
fields, because inference currently doesn't have a precise (per-object)
knowledge of memory effect.