### PR TITLE
Make argument mismatch in opaque closure a MethodError

### DIFF
--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -76,7 +76,7 @@ JL_CALLABLE(jl_f_opaque_closure_call)
     jl_opaque_closure_t* oc = (jl_opaque_closure_t*)F;
     jl_value_t *argt = jl_tparam0(jl_typeof(oc));
     if (!jl_tupletype_length_compat(argt, nargs))
-        jl_error("Incorrect argument count for OpaqueClosure");
+        jl_method_error(F, args, nargs + 1, oc->world);
     argt = jl_unwrap_unionall(argt);
     assert(jl_is_datatype(argt));
     jl_svec_t *types = jl_get_fieldtypes((jl_datatype_t*)argt);

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -204,3 +204,5 @@ function f_oc_noinline_call(x, y)
     return f_oc_noinline(x)(y)
 end
 @test f_oc_noinline_call(1, 2) == 3
+
+@test_throws MethodError (@opaque x->x+1)(1, 2)


### PR DESCRIPTION
This at least shows the argument types. In the future we may want
to add some logic to the errorshow code to improve this even further,
but good enough for now.