### PR TITLE
Fix vector indexing of offset ranges with other ranges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -831,7 +831,7 @@ function getindex(r::AbstractUnitRange, s::AbstractUnitRange{T}) where {T<:Integ
         range(first(s) ? first(r) : last(r), length = Int(last(s)))
     else
         f = first(r)
-        st = oftype(f, f + first(s)-1)
+        st = oftype(f, f + first(s)-firstindex(r))
         return range(st, length=length(s))
     end
 end
@@ -849,7 +849,7 @@ function getindex(r::AbstractUnitRange, s::StepRange{T}) where {T<:Integer}
     if T === Bool
         range(first(s) ? first(r) : last(r), step=oneunit(eltype(r)), length = Int(last(s)))
     else
-        st = oftype(first(r), first(r) + s.start-1)
+        st = oftype(first(r), first(r) + s.start-firstindex(r))
         return range(st, step=step(s), length=length(s))
     end
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1943,3 +1943,31 @@ end
         @test_throws BoundsError r[Base.IdentityUnitRange(-1:100)]
     end
 end
+
+@testset "non 1-based ranges indexing" begin
+    struct ZeroBasedUnitRange{T,A<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
+        a :: A
+        function ZeroBasedUnitRange(a::AbstractUnitRange{T}) where {T}
+            @assert !Base.has_offset_axes(a)
+            new{T, typeof(a)}(a)
+        end
+    end
+
+    Base.parent(A::ZeroBasedUnitRange) = A.a
+    Base.first(A::ZeroBasedUnitRange) = first(parent(A))
+    Base.length(A::ZeroBasedUnitRange) = length(parent(A))
+    Base.last(A::ZeroBasedUnitRange) = last(parent(A))
+    Base.size(A::ZeroBasedUnitRange) = size(parent(A))
+    Base.axes(A::ZeroBasedUnitRange) = map(x -> Base.IdentityUnitRange(0:x-1), size(parent(A)))
+    Base.getindex(A::ZeroBasedUnitRange, i::Int) = parent(A)[i + 1]
+    Base.getindex(A::ZeroBasedUnitRange, i::Integer) = parent(A)[i + 1]
+    Base.firstindex(A::ZeroBasedUnitRange) = 0
+    function Base.show(io::IO, A::ZeroBasedUnitRange)
+        show(io, parent(A))
+        print(io, " with indices $(axes(A,1))")
+    end
+
+    r = ZeroBasedUnitRange(5:8)
+    @test r[0:2] == r[0]:r[2]
+    @test r[0:1:2] == r[0]:1:r[2]
+end


### PR DESCRIPTION
From the test:

On nightly:
```julia
julia> struct ZeroBasedUnitRange{T,A<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
               a :: A
               function ZeroBasedUnitRange(a::AbstractUnitRange{T}) where {T}
                   @assert !Base.has_offset_axes(a)
                   new{T, typeof(a)}(a)
               end
           end

julia> Base.parent(A::ZeroBasedUnitRange) = A.a

julia> Base.length(A::ZeroBasedUnitRange) = length(parent(A))

julia> Base.first(A::ZeroBasedUnitRange) = first(parent(A))

julia> Base.last(A::ZeroBasedUnitRange) = last(parent(A))

julia> Base.size(A::ZeroBasedUnitRange) = size(parent(A))

julia> Base.axes(A::ZeroBasedUnitRange) = map(x -> Base.IdentityUnitRange(0:x-1), size(parent(A)))

julia> Base.getindex(A::ZeroBasedUnitRange, i::Int) = parent(A)[i + 1]

julia> Base.getindex(A::ZeroBasedUnitRange, i::Integer) = parent(A)[i + 1]

julia> Base.firstindex(A::ZeroBasedUnitRange) = 0

julia> function Base.show(io::IO, A::ZeroBasedUnitRange)
               show(io, parent(A))
               print(io, " with indices $(axes(A,1))")
           end

julia> r = ZeroBasedUnitRange(5:8)
5:8 with indices Base.IdentityUnitRange(0:3)

julia> r[0:2]
4:6
```

After this PR:
```julia
julia> r[0:2]
5:7
```