### PR TITLE
Fix escaping of rhs for `@atomic a.x = y`

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -534,7 +534,7 @@ function make_atomic(order, ex)
         elseif isexpr(ex, :call, 3)
             return make_atomic(order, ex.args[2], ex.args[1], ex.args[3])
         elseif ex.head === :(=)
-            l, r = ex.args[1], ex.args[2]
+            l, r = ex.args[1], esc(ex.args[2])
             if is_expr(l, :., 2)
                 ll, lr = esc(l.args[1]), esc(l.args[2])
                 return :(setproperty!($ll, $lr, $r, $order))

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -299,6 +299,9 @@ let a = ARefxy(1, -1)
     @test 1 === @atomic a.x
     @test 2 === @atomic :sequentially_consistent a.x = 2
     @test 3 === @atomic :monotonic a.x = 3
+    local four = 4
+    @test 4 === @atomic :monotonic a.x = four
+    @test 3 === @atomic :monotonic a.x = four - 1
     @test_throws ConcurrencyViolationError @atomic :not_atomic a.x = 2
     @test_throws ConcurrencyViolationError @atomic :not_atomic a.x
     @test_throws ConcurrencyViolationError @atomic :not_atomic a.x += 1


### PR DESCRIPTION
This PR fixes escaping of atomic setproperty! syntax `@atomic a.x = y`. Before this PR:

```julia
julia> mutable struct A
           @atomic x::Int
       end

julia> f!(a, y) = @atomic a.x = y;

julia> f!(A(0), 1)
ERROR: UndefVarError: y not defined
```
