### PR TITLE
An API for unsafe_store!-ing GC-managed objects

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -431,6 +431,7 @@ Base.GC.gc
 Base.GC.enable
 Base.GC.@preserve
 Base.GC.safepoint
+Base.Experimental.gc_compatible_pointer
 Meta.lower
 Meta.@lower
 Meta.parse(::AbstractString, ::Int)

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -531,6 +531,7 @@
     XX(jl_undefined_var_error) \
     XX(jl_valueof) \
     XX(jl_value_ptr) \
+    XX(jl__gc_compatible_pointer) \
     XX(jl_ver_is_release) \
     XX(jl_ver_major) \
     XX(jl_ver_minor) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1488,6 +1488,7 @@ JL_DLLEXPORT void        jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *r
 JL_DLLEXPORT int         jl_field_isdefined(jl_value_t *v, size_t i) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld);
 JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl__gc_compatible_pointer(jl_value_t *a);
 int jl_uniontype_size(jl_value_t *ty, size_t *sz) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_islayout_inline(jl_value_t *eltype, size_t *fsz, size_t *al) JL_NOTSAFEPOINT;
 

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -356,6 +356,11 @@ JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a)
 {
     return a;
 }
+JL_DLLEXPORT jl_value_t *jl__gc_compatible_pointer(jl_value_t *a)
+{
+    assert("jl__gc_compatible_pointer must be ccall'ed" && 0);
+    return a;
+}
 
 // optimization of setfield which bypasses boxing of the idx (and checking field type validity)
 JL_DLLEXPORT void jl_set_nth_field(jl_value_t *v, size_t idx0, jl_value_t *rhs)

--- a/test/llvmpasses/gc_compatible_pointer.jl
+++ b/test/llvmpasses/gc_compatible_pointer.jl
@@ -1,0 +1,75 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t -O && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+using Base.Experimental: gc_compatible_pointer
+
+donothing() = nothing
+@noinline opaquecall() = (_dont_inline_; Int64(0))
+
+function set1!(xs, T, x, pre_store)
+    handle, ptr = gc_compatible_pointer(T(x))
+    pre_store()
+    GC.@preserve xs handle begin
+        unsafe_store!(Ptr{Ptr{Cvoid}}(pointer(xs, 1)), ptr)
+    end
+    return Int64(123456789)
+end
+# Following examples check that:
+# * An opaque call at `pre_store` should introduce a GC frame.
+# * Only one allocation per call.
+
+# CHECK-LABEL: @julia_set1_int_donothing
+set1_int_donothing(xs, x) = set1!(xs, identity, x, donothing)
+# CHECK: call {{.*}} @jl_box_int
+# CHECK-NOT: %gcframe
+# CHECK: ret i64 123456789
+
+# CHECK-LABEL: @julia_set1_int_opaquecall
+set1_int_opaquecall(xs, x) = set1!(xs, identity, x, opaquecall)
+# CHECK: call {{.*}} @jl_box_int
+# CHECK: %gcframe
+# CHECK: call i64 @j_opaquecall
+# CHECK: ret i64 123456789
+
+# CHECK-LABEL: @julia_set1_someint_donothing
+set1_someint_donothing(xs, x) = set1!(xs, Some, x, donothing)
+# CHECK: call {{.*}} @jl_gc_pool_alloc
+# CHECK-NOT: @jl_gc_pool_alloc
+# CHECK-NOT: %gcframe
+# CHECK: ret i64 123456789
+
+# CHECK-LABEL: @julia_set1_someint_opaquecall
+set1_someint_opaquecall(xs, x) = set1!(xs, Some, x, opaquecall)
+# CHECK: call {{.*}} @jl_gc_pool_alloc
+# CHECK-NOT: @jl_gc_pool_alloc
+# CHECK: %gcframe
+# CHECK: call i64 @j_opaquecall
+# CHECK-NOT: @jl_gc_pool_alloc
+# CHECK: ret i64 123456789
+
+# CHECK-LABEL: @julia_set1_refint_donothing
+set1_refint_donothing(xs, x) = set1!(xs, Ref, x, donothing)
+# CHECK: call {{.*}} @jl_gc_pool_alloc
+# CHECK-NOT: @jl_gc_pool_alloc
+# CHECK-NOT: %gcframe
+# CHECK: ret i64 123456789
+
+# CHECK-LABEL: @julia_set1_refint_opaquecall
+set1_refint_opaquecall(xs, x) = set1!(xs, Ref, x, opaquecall)
+# CHECK: call {{.*}} @jl_gc_pool_alloc
+# CHECK-NOT: @jl_gc_pool_alloc
+# CHECK: %gcframe
+# CHECK: call i64 @j_opaquecall
+# CHECK-NOT: @jl_gc_pool_alloc
+# CHECK: ret i64 123456789
+
+emit(set1_int_donothing, Vector{Any}, Int)
+emit(set1_int_opaquecall, Vector{Any}, Int)
+emit(set1_someint_donothing, Vector{Any}, Int)
+emit(set1_someint_opaquecall, Vector{Any}, Int)
+emit(set1_refint_donothing, Vector{Any}, Int)
+emit(set1_refint_opaquecall, Vector{Any}, Int)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -964,6 +964,19 @@ end
     GC.safepoint()
 end
 
+@testset "gc_compatible_pointer" begin
+    @testset for T in [Ref, Ref{Any}, Some, Some{Any}, identity]
+        value = T(123)
+        xs = Any[nothing]
+        handle, ptr = Base.Experimental.gc_compatible_pointer(value)
+        GC.gc()
+        GC.@preserve xs handle begin
+            unsafe_store!(Ptr{Ptr{Cvoid}}(pointer(xs, 1)), ptr)
+        end
+        @test xs[1] === value
+    end
+end
+
 @testset "fieldtypes Module" begin
     @test fieldtypes(Module) === ()
 end


### PR DESCRIPTION
Accessing pointer representation of mutable objects in a GC-compatible manner would be highly useful. Motivating examples include:

* [Completing `StructArrays.MArray`'s `setindex!` implementation](https://github.com/JuliaArrays/StaticArrays.jl/blob/c29a9e23b541eb0ea5f67ebbb814a01c6c9a2bc0/src/MArray.jl#L90-L103)
* Aligned and/or padded allocation of a group of mutable objects (for optimizing parallel mutation). It can be done by storing immutable struct in a vector (e.g., [RecordArrays.jl](https://github.com/tkf/RecordArrays.jl)).
* Shuffling heap allocating objects in vectors using SIMD instructions. Useful for, e.g., radix sort.

As a possible solution, this PR tries to implement the following experimental API:

>     Experimental.gc_compatible_pointer(value) -> (handle, ptr::Ptr{Cvoid})
>
> Return a pointer `ptr` of a `value` that can be stored into locations of GC-managed object using `unsafe_store!(_::Ptr{Ptr{Cvoid}}, ptr)`.  The caller is responsible for preserving the opaque object `handle` during `unsafe_store!`.
>
> This is equivalent to `value -> (value, pointer_from_objref(value))` for mutable `value`s.  However, this function also works when `value` is an immutable type. See also: [`unsafe_store!`](@ref), [`GC.@preserve`](@ref)
>
> **Examples**
> ```julia
> julia> handle, ptr = Base.Experimental.gc_compatible_pointer(Some(1));
>
> julia> xs = Any[nothing];
>
> julia> GC.@preserve xs handle begin
>            unsafe_store!(Ptr{Ptr{Cvoid}}(pointer(xs, 1)), ptr)
>        end;
>
> julia> xs[1]
> Some(1)
> ```

