### PR TITLE
Update supported data types in `TOML.print` docstring

### DIFF
--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -110,7 +110,7 @@ const ParserError = Internals.ParserError
 Write `data` as TOML syntax to the stream `io`. If the keyword argument `sorted` is set to `true`,
 sort tables according to the function given by the keyword argument `by`.
 
-The following data types are supported: `AbstractDict`, `Integer`, `AbstractFloat`, `Bool`,
+The following data types are supported: `AbstractDict`, `AbstractVector`, `AbstractString`, `Integer`, `AbstractFloat`, `Bool`,
 `Dates.DateTime`, `Dates.Time`, `Dates.Date`. Note that the integers and floats
 need to be convertible to `Float64` and `Int64` respectively. For other data types,
 pass the function `to_toml` that takes the data types and returns a value of a


### PR DESCRIPTION
`AbstractVector` and `AbstractString` are missing according to [this line](https://github.com/JuliaLang/julia/blob/bc3ce48636b700d153d2c84614aaea8cb8843d43/stdlib/TOML/src/print.jl#L54):

```julia
const TOMLValue = Union{AbstractVector, AbstractDict, Dates.DateTime, Dates.Time, Dates.Date, Bool, Integer, AbstractFloat, AbstractString}
```