### PR TITLE
Fix `Rational{T}` constructor for abstract `T`

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -18,21 +18,22 @@ unsafe_rational(num::T, den::T) where {T<:Integer} = unsafe_rational(T, num, den
 unsafe_rational(num::Integer, den::Integer) = unsafe_rational(promote(num, den)...)
 
 @noinline __throw_rational_argerror_typemin(T) = throw(ArgumentError("invalid rational: denominator can't be typemin($T)"))
-function checked_den(num::T, den::T) where T<:Integer
+function checked_den(::Type{T}, num::T, den::T) where T<:Integer
     if signbit(den)
         den = -den
-        signbit(den) && __throw_rational_argerror_typemin(T)
+        signbit(den) && __throw_rational_argerror_typemin(typeof(den))
         num = -num
     end
     return unsafe_rational(T, num, den)
 end
+checked_den(num::T, den::T) where T<:Integer = checked_den(T, num, den)
 checked_den(num::Integer, den::Integer) = checked_den(promote(num, den)...)
 
 @noinline __throw_rational_argerror_zero(T) = throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
 function Rational{T}(num::Integer, den::Integer) where T<:Integer
     iszero(den) && iszero(num) && __throw_rational_argerror_zero(T)
     num, den = divgcd(num, den)
-    return checked_den(T(num), T(den))
+    return checked_den(T, T(num), T(den))
 end
 
 Rational(n::T, d::T) where {T<:Integer} = Rational{T}(n, d)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -618,3 +618,7 @@ end
 @testset "checked_den with different integer types" begin
     @test Base.checked_den(Int8(4), Int32(8)) == Base.checked_den(Int32(4), Int32(8))
 end
+
+@testset "Rational{T} with non-concrete T (issue #41222)" begin
+    @test @inferred(Rational{Integer}(2,3)) isa Rational{Integer}
+end


### PR DESCRIPTION
This makes `Rational{T}(::Integer, ::Integer)` always return a value of type `Rational{T}`, even when `T` is abstract. Fixes #41222.