### PR TITLE
Fix linear indexing for ReshapedArray if the parent has offset axes 

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -238,7 +238,8 @@ offset_if_vec(i::Integer, axs::Tuple) = i
 
 @inline function isassigned(A::ReshapedArrayLF, index::Int)
     @boundscheck checkbounds(Bool, A, index) || return false
-    @inbounds ret = isassigned(parent(A), index)
+    indexparent = index - firstindex(A) + firstindex(parent(A))
+    @inbounds ret = isassigned(parent(A), indexparent)
     ret
 end
 @inline function isassigned(A::ReshapedArray{T,N}, indices::Vararg{Int, N}) where {T,N}

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -183,6 +183,7 @@ function _reshape(v::AbstractVector, dims::Dims{1})
 end
 # General reshape
 function _reshape(parent::AbstractArray, dims::Dims)
+    require_one_based_indexing(parent)
     n = length(parent)
     prod(dims) == n || _throw_dmrs(n, "size", dims)
     __reshape((parent, IndexStyle(parent)), dims)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -183,7 +183,6 @@ function _reshape(v::AbstractVector, dims::Dims{1})
 end
 # General reshape
 function _reshape(parent::AbstractArray, dims::Dims)
-    require_one_based_indexing(parent)
     n = length(parent)
     prod(dims) == n || _throw_dmrs(n, "size", dims)
     __reshape((parent, IndexStyle(parent)), dims)
@@ -252,7 +251,8 @@ end
 
 @inline function getindex(A::ReshapedArrayLF, index::Int)
     @boundscheck checkbounds(A, index)
-    @inbounds ret = parent(A)[index]
+    indexparent = index - firstindex(A) + firstindex(parent(A))
+    @inbounds ret = parent(A)[indexparent]
     ret
 end
 @inline function getindex(A::ReshapedArray{T,N}, indices::Vararg{Int,N}) where {T,N}
@@ -276,7 +276,8 @@ end
 
 @inline function setindex!(A::ReshapedArrayLF, val, index::Int)
     @boundscheck checkbounds(A, index)
-    @inbounds parent(A)[index] = val
+    indexparent = index - firstindex(A) + firstindex(parent(A))
+    @inbounds parent(A)[indexparent] = val
     val
 end
 @inline function setindex!(A::ReshapedArray{T,N}, val, indices::Vararg{Int,N}) where {T,N}

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2050,3 +2050,7 @@ end
     test_unsetindex(MyMatrixUnsetIndexCartInds)
     test_unsetindex(MyMatrixUnsetIndexLinInds)
 end
+
+@testset "reshape for offset arrays" begin
+    @test_throws ArgumentError reshape(Base.IdentityUnitRange(0:1), (2,1))
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2052,8 +2052,10 @@ end
 end
 
 @testset "reshape for offset arrays" begin
-    r = reshape(Base.IdentityUnitRange(0:1), (2,1))
-    @test r[eachindex(r)] == [0:1;]
+    p = Base.IdentityUnitRange(3:4)
+    r = reshape(p, :, 1)
+    @test r[eachindex(r)] == UnitRange(p)
+    @test collect(r) == r
 
     struct ZeroBasedArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
         a :: A
@@ -2069,7 +2071,7 @@ end
     Base.setindex!(z::ZeroBasedArray{<:Any, N}, val, i::Vararg{Int,N}) where {N} = parent(z)[map(x -> x + 1, i)...] = val
 
     z = ZeroBasedArray(collect(1:4))
-    r2 = reshape(z, (4, 1))
+    r2 = reshape(z, :, 1)
     @test r2[CartesianIndices(r2)] == r2[LinearIndices(r2)]
     r2[firstindex(r2)] = 34
     @test z[0] == 34

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2052,5 +2052,29 @@ end
 end
 
 @testset "reshape for offset arrays" begin
-    @test_throws ArgumentError reshape(Base.IdentityUnitRange(0:1), (2,1))
+    r = reshape(Base.IdentityUnitRange(0:1), (2,1))
+    @test r[eachindex(r)] == [0:1;]
+
+    struct ZeroBasedArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
+        a :: A
+        function ZeroBasedArray(a::AbstractArray)
+            Base.require_one_based_indexing(a)
+            new{eltype(a), ndims(a), typeof(a)}(a)
+        end
+    end
+    Base.parent(z::ZeroBasedArray) = z.a
+    Base.size(z::ZeroBasedArray) = size(parent(z))
+    Base.axes(z::ZeroBasedArray) = map(x -> Base.IdentityUnitRange(0:x - 1), size(parent(z)))
+    Base.getindex(z::ZeroBasedArray{<:Any, N}, i::Vararg{Int,N}) where {N} = parent(z)[map(x -> x + 1, i)...]
+    Base.setindex!(z::ZeroBasedArray{<:Any, N}, val, i::Vararg{Int,N}) where {N} = parent(z)[map(x -> x + 1, i)...] = val
+
+    z = ZeroBasedArray(collect(1:4))
+    r2 = reshape(z, (4, 1))
+    @test r2[CartesianIndices(r2)] == r2[LinearIndices(r2)]
+    r2[firstindex(r2)] = 34
+    @test z[0] == 34
+    r2[eachindex(r2)] = r2 .* 2
+    for (i, j) in zip(eachindex(r2), eachindex(z))
+        @test r2[i] == z[j]
+    end
 end


### PR DESCRIPTION
Fixes #39953

Currently a `ReshapedArray` is too permissive, and it acts as an offset-free wrapper if the parent is an offset array.

```julia
julia> r = Base.IdentityUnitRange(0:1)
Base.IdentityUnitRange(0:1)

julia> reshape(r, (2,1))
2×1 reshape(::Base.IdentityUnitRange{UnitRange{Int64}}, 2, 1) with eltype Int64:
 0
 1
```

This causes multiple problems -- firstly linear indexing is broken for such an array (#39953). Secondly, if a 1D offset array is wrapped in a 2D `ReshapedArray`, calling `vec` on it fails, as the operation is a reshape on the parent which does not have 1-based indices.

```julia
julia> reshape(r, (2,1)) |> vec
ERROR: ArgumentError: offset arrays are not supported but got an array with index other than 1
Stacktrace:
 [1] require_one_based_indexing
   @ ./abstractarray.jl:110 [inlined]
 [2] _reshape
   @ ./reshapedarray.jl:168 [inlined]
 [3] _reshape
   @ ./reshapedarray.jl:186 [inlined]
 [4] reshape
   @ ./reshapedarray.jl:112 [inlined]
 [5] reshape
   @ ./reshapedarray.jl:116 [inlined]
 [6] vec
   @ ./abstractarraymath.jl:41 [inlined]
 [7] |>(x::Base.ReshapedArray{Int64, 2, Base.IdentityUnitRange{UnitRange{Int64}}, Tuple{}}, f::typeof(vec))
   @ Base ./operators.jl:966
 [8] top-level scope
   @ REPL[6]:1
```

While the linear indexing may be fixed by adding appropriate offsets to the indices, fixing all the problems associated with this might be more difficult.

~~This PR makes reshaping an offset array illegal. A custom offset array type should define its own `reshape` method to specify what's to be done with the axes offsets. Often, eg. in `OffsetArrays`, the reshape may be translated to the parent, and new offsets may be wrapped around the result.~~

This PR fixes the linear indexing issue. The `vec` one is not resolved. 