### PR TITLE
continue #41123, more missing methods for `rand(::_GLOBAL_RNG, x)`

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -388,25 +388,24 @@ seed!(seed::Union{Nothing,Integer,Vector{UInt32},Vector{UInt64},NTuple{4,UInt64}
     seed!(GLOBAL_RNG, seed)
 
 rng_native_52(::_GLOBAL_RNG) = rng_native_52(default_rng())
-rand(::_GLOBAL_RNG, sp::SamplerBoolBitInteger) = rand(default_rng(), sp)
-for T in (:(SamplerTrivial{UInt52Raw{UInt64}}),
-          :(SamplerTrivial{UInt2x52Raw{UInt128}}),
-          :(SamplerTrivial{UInt104Raw{UInt128}}),
-          :(SamplerTrivial{CloseOpen01_64}),
-          :(SamplerTrivial{CloseOpen12_64}),
-          :(SamplerUnion(Int64, UInt64, Int128, UInt128)),
-          :(SamplerUnion(Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32)),
+
+for T in (:(SamplerBoolBitInteger),
+          :(SamplerTrivial{UInt52Raw{UInt64}}),
+          :(SamplerTrivial{UInt52{UInt64}}),
+          :(SamplerTrivial{UInt104{UInt128}}),
+          :(SamplerTrivial{CloseOpen01{Float16}}),
+          :(SamplerTrivial{CloseOpen01{Float32}}),
+          :(SamplerTrivial{CloseOpen01{Float64}}),
          )
     @eval rand(::_GLOBAL_RNG, x::$T) = rand(default_rng(), x)
 end
-
 rand!(::_GLOBAL_RNG, A::AbstractArray{Float64}, I::SamplerTrivial{<:FloatInterval_64}) = rand!(default_rng(), A, I)
 rand!(::_GLOBAL_RNG, A::Array{Float64}, I::SamplerTrivial{<:FloatInterval_64}) = rand!(default_rng(), A, I)
 for T in (Float16, Float32)
     @eval rand!(::_GLOBAL_RNG, A::Array{$T}, I::SamplerTrivial{CloseOpen12{$T}}) = rand!(default_rng(), A, I)
     @eval rand!(::_GLOBAL_RNG, A::Array{$T}, I::SamplerTrivial{CloseOpen01{$T}}) = rand!(default_rng(), A, I)
 end
-for T in BitInteger_types
+for T in (BitInteger_types..., Bool)
     @eval rand!(::_GLOBAL_RNG, A::Array{$T}, I::SamplerType{$T}) = rand!(default_rng(), A, I)
 end
 

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -179,7 +179,7 @@ end
 
 @inline function rand(rng::Union{TaskLocalRNG, Xoshiro}, ::SamplerType{UInt128})
     first = rand(rng, UInt64)
-    second = rand(rng,UInt64)
+    second = rand(rng, UInt64)
     second + UInt128(first)<<64
 end
 

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -809,9 +809,18 @@ end
         x = Random.SamplerTrivial(T())
         @test rand(GLOBAL_RNG, x) === rand(xo, x)
     end
-    for T in (Int64, UInt64, Int128, UInt128, Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32)
-        x = Random.SamplerType{T}()
-        @test rand(GLOBAL_RNG, x) === rand(xo, x)
+    for T in (Int64, UInt64, Int128, UInt128, Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32,
+              Float16, Float32, Float64)
+        if T <: Integer
+            x = Random.SamplerType{T}()
+            @test rand(GLOBAL_RNG, x) === rand(xo, x)
+            @test rand(GLOBAL_RNG, x) === rand(xo, x)
+        end
+        @test rand(GLOBAL_RNG, T) === rand(xo, T)
+        @test rand(GLOBAL_RNG, T) === rand(xo, T)
+        @test rand(GLOBAL_RNG, T) === rand(xo, T)
+        @test rand(GLOBAL_RNG, T) === rand(xo, T)
+        @test rand(GLOBAL_RNG, T, 10) == rand(xo, T, 10)
     end
 
     A = fill(0.0, 100, 100)


### PR DESCRIPTION
`rand(GLOBAL_RNG, Float32)` and `rand(copy(GLOBAL_RNG), Float32)` were still giving different results, idem for `Float16` and for array generation of `Bools`. 

For scalar generation, I chose here to remove the loop with `@eval rand(GLOBAL_RNG) and rand(copy(GLOBAL_RNG))`, as it has shown to be somewhat difficult to keep up to date (also it eval'ed too much, with a duplication for types in `SamplerBoolBitInteger`). And instead,  define directly `rand` methods on `Union{Xoshiro, TaskLocalRNG, _GLOBAL_RNG}`, I can revert this choice if preferred. For array generation, this is slightly more tricky as some methods use the internals of the RNGs, so I left it as is.