### PR TITLE
Artifacts stdlib: add Pkg to the list of test-only dependencies

### DIFF
--- a/stdlib/Artifacts/Project.toml
+++ b/stdlib/Artifacts/Project.toml
@@ -2,7 +2,8 @@ name = "Artifacts"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Pkg", "Test"]


### PR DESCRIPTION
The Artifacts test suite uses Pkg:
https://github.com/JuliaLang/julia/blob/c366be54b6871d813ccbc5cd75764aa1bf93ab5d/stdlib/Artifacts/test/refresh_artifacts.jl#L4

However, currently Artifacts does not list Pkg as a test-only dependency.

This PR adds Pkg as a test-only dependency for the Artifacts stdlib.