### PR TITLE
Fix shell `cd` error when working dir has been deleted

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -41,7 +41,6 @@ function repl_cmd(cmd, out)
     if isempty(cmd.exec)
         throw(ArgumentError("no cmd to execute"))
     elseif cmd.exec[1] == "cd"
-        new_oldpwd = pwd()
         if length(cmd.exec) > 2
             throw(ArgumentError("cd method only takes one argument"))
         elseif length(cmd.exec) == 2
@@ -52,11 +51,15 @@ function repl_cmd(cmd, out)
                 end
                 dir = ENV["OLDPWD"]
             end
+            try
+                ENV["OLDPWD"] = pwd()
+                catch # if current dir has been deleted, then pwd() will throw an IOError: pwd(): no such file or directory (ENOENT)
+                delete!(ENV, "OLDPWD")
+            end
             cd(dir)
         else
             cd()
         end
-        ENV["OLDPWD"] = new_oldpwd
         println(out, pwd())
     else
         @static if !Sys.iswindows()

--- a/base/client.jl
+++ b/base/client.jl
@@ -53,7 +53,9 @@ function repl_cmd(cmd, out)
             end
             try
                 ENV["OLDPWD"] = pwd()
-                catch # if current dir has been deleted, then pwd() will throw an IOError: pwd(): no such file or directory (ENOENT)
+            catch ex
+                ex isa IOError || rethrow()
+                # if current dir has been deleted, then pwd() will throw an IOError: pwd(): no such file or directory (ENOENT)
                 delete!(ENV, "OLDPWD")
             end
             cd(dir)

--- a/base/client.jl
+++ b/base/client.jl
@@ -51,17 +51,17 @@ function repl_cmd(cmd, out)
                 end
                 dir = ENV["OLDPWD"]
             end
-            try
-                ENV["OLDPWD"] = pwd()
-            catch ex
-                ex isa IOError || rethrow()
-                # if current dir has been deleted, then pwd() will throw an IOError: pwd(): no such file or directory (ENOENT)
-                delete!(ENV, "OLDPWD")
-            end
-            cd(dir)
         else
-            cd()
+            dir = homedir()
         end
+        try
+            ENV["OLDPWD"] = pwd()
+        catch ex
+            ex isa IOError || rethrow()
+            # if current dir has been deleted, then pwd() will throw an IOError: pwd(): no such file or directory (ENOENT)
+            delete!(ENV, "OLDPWD")
+        end
+        cd(dir)
         println(out, pwd())
     else
         @static if !Sys.iswindows()

--- a/test/file.jl
+++ b/test/file.jl
@@ -1911,15 +1911,15 @@ end
 @testset "pwd tests" begin
     mktempdir() do dir
         cd(dir) do
-            withenv("OLDPWD" => nothing do
+            withenv("OLDPWD" => nothing) do
                 io = IOBuffer()
                 Base.repl_cmd(@cmd("cd"), io)
                 Base.repl_cmd(@cmd("cd -"), io)
-                @test pwd() == dir
+                @test realpath(pwd()) == realpath(dir)
                 rm(dir)
                 @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
                 # pwd() throwing was causing this to error
-                Base.repl_cmd(@cmd("cd \~"), io)
+                Base.repl_cmd(@cmd("cd \\~"), io)
             end
         end
     end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1911,14 +1911,16 @@ end
 @testset "pwd tests" begin
     mktempdir() do dir
         cd(dir) do
-            io = IOBuffer()
-            Base.repl_cmd(@cmd("cd"), io)
-            Base.repl_cmd(@cmd("cd -"), io)
-            @test pwd() == dir
-            rm(dir)
-            @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
-            # pwd() throwing was causing this to error
-            Base.repl_cmd(@cmd("cd \~"), io)
+            withenv("OLDPWD" => nothing do
+                io = IOBuffer()
+                Base.repl_cmd(@cmd("cd"), io)
+                Base.repl_cmd(@cmd("cd -"), io)
+                @test pwd() == dir
+                rm(dir)
+                @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
+                # pwd() throwing was causing this to error
+                Base.repl_cmd(@cmd("cd \~"), io)
+            end
         end
     end
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1911,10 +1911,12 @@ end
 @testset "pwd tests" begin
     mktempdir() do dir
         cd(dir) do
+            io = IOBuffer()
+            Base.repl_cmd(@cmd("cd"), io)
+            Base.repl_cmd(@cmd("cd -"), io)
             @test pwd() == dir
             rm(dir)
             @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
-            io = IOBuffer()
             # pwd() throwing was causing this to error
             Base.repl_cmd(@cmd("cd ~"), io)
         end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1916,10 +1916,13 @@ end
                 Base.repl_cmd(@cmd("cd"), io)
                 Base.repl_cmd(@cmd("cd -"), io)
                 @test realpath(pwd()) == realpath(dir)
-                rm(dir)
-                @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
-                # pwd() throwing was causing this to error
-                Base.repl_cmd(@cmd("cd \\~"), io)
+                if !Sys.iswindows()
+                    # Delete the working directory and check we can cd out of it
+                    # Cannot delete the working directory on Windows
+                    rm(dir)
+                    @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
+                    Base.repl_cmd(@cmd("cd \\~"), io)
+                end
             end
         end
     end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1918,7 +1918,7 @@ end
             rm(dir)
             @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
             # pwd() throwing was causing this to error
-            Base.repl_cmd(@cmd("cd ~"), io)
+            Base.repl_cmd(@cmd("cd \~"), io)
         end
     end
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1908,6 +1908,19 @@ end
     end
 end
 
+@testset "pwd tests" begin
+    mktempdir() do dir
+        cd(dir) do
+            @test pwd() == dir
+            rm(dir)
+            @test_throws Base._UVError("pwd()", Base.UV_ENOENT) pwd()
+            io = IOBuffer()
+            # pwd() throwing was causing this to error
+            Base.repl_cmd(@cmd("cd ~"), io)
+        end
+    end
+end
+
 @testset "readdir tests" begin
     ≛(a, b) = sort(a) == sort(b)
     mktempdir() do dir


### PR DESCRIPTION
root cause:
if current dir has been deleted, then pwd() will throw an IOError: pwd(): no such file or directory (ENOENT)

