### PR TITLE
allocate small strings in 8-byte-aligned pools

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3286,9 +3286,6 @@ void jl_init_thread_heap(jl_ptls_t ptls)
     jl_thread_heap_t *heap = &ptls->heap;
     jl_gc_pool_t *p = heap->norm_pools;
     for (int i = 0; i < JL_GC_N_POOLS; i++) {
-        assert((jl_gc_sizeclasses[i] < 16 &&
-                jl_gc_sizeclasses[i] % sizeof(void*) == 0) ||
-               (jl_gc_sizeclasses[i] % 16 == 0));
         p[i].osize = jl_gc_sizeclasses[i];
         p[i].freelist = NULL;
         p[i].newpages = NULL;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -141,11 +141,11 @@ typedef struct {
 
     // variables for allocating objects from pools
 #ifdef _P64
-#  define JL_GC_N_POOLS 41
+#  define JL_GC_N_POOLS 49
 #elif MAX_ALIGN == 8
-#  define JL_GC_N_POOLS 42
+#  define JL_GC_N_POOLS 50
 #else
-#  define JL_GC_N_POOLS 43
+#  define JL_GC_N_POOLS 51
 #endif
     jl_gc_pool_t norm_pools[JL_GC_N_POOLS];
 


### PR DESCRIPTION
This is a less-disruptive alternative to #40727 that keeps the representation the same and just uses less alignment padding.

Before:
```
function example()
    for j = 1:20, i = 1:1_000_000
        string(i)
    end
end

julia> @btime example()
  598.121 ms (40000000 allocations: 1.79 GiB)

julia> @btime for i = 1:2^24
    "a"*"b"
end
  247.768 ms (16777216 allocations: 512.00 MiB)
```

after:
```
julia> @btime example()
  607.298 ms (40000000 allocations: 1.64 GiB)

julia> @btime for i = 1:2^24
    "a"*"b"
end
  247.473 ms (16777216 allocations: 384.00 MiB)
```

@nanosoldier `runbenchmarks("string", vs=":master")`