### PR TITLE
RFC: Reduce atomics macro API contracts for future extensions

### DIFF
--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -285,6 +285,9 @@ test_field_undef(ARefxy{UndefComplex{Any}})
 test_field_undef(ARefxy{UndefComplex{UndefComplex{Any}}})
 
 @test_throws ErrorException @macroexpand @atomic foo()
+@test_throws ErrorException @macroexpand @atomic foo.bar.baz
+@test_throws ErrorException @macroexpand @atomic foo[:bar].baz
+@test_throws ErrorException @macroexpand @atomic foo().bar
 @test_throws ErrorException @macroexpand @atomic foo += bar
 @test_throws ErrorException @macroexpand @atomic foo += bar
 @test_throws ErrorException @macroexpand @atomic foo = bar
@@ -292,7 +295,11 @@ test_field_undef(ARefxy{UndefComplex{UndefComplex{Any}}})
 @test_throws ErrorException @macroexpand @atomic foo(bar)
 @test_throws ErrorException @macroexpand @atomic foo(bar, baz)
 @test_throws ErrorException @macroexpand @atomic foo(bar, baz, bax)
+@test_throws ErrorException @macroexpand @atomicswap foo.bar.baz bar
+@test_throws ErrorException @macroexpand @atomicswap foo[:bar].baz bar
+@test_throws ErrorException @macroexpand @atomicswap foo().bar bar
 @test_throws ErrorException @macroexpand @atomicreplace foo bar
+@test_throws ErrorException @macroexpand @atomicreplace foo.bar.baz bar
 
 # test macroexpansions
 let a = ARefxy(1, -1)


### PR DESCRIPTION
Currently, `@atomicreplace a[1].x expected => desired` is equivalent to

```julia
tmp = a[1]
@atomicreplace tmp.x expected => desired
```

However, it forbids future extensions such as lowering

```julia
@assert sizeof(K) == sizeof(V) == sizeof(UInt64)
xs = Vector{@NamedTuple{key::K, value::V}}(...)
k = @atomic xs[i].key
```

to a 64 bit (not 128 bit) load.

As I explained in #37847, this kind of "torn read" is a common technique when dealing with 128 bit entries (e.g., https://doi.org/10.1145/3309206 p.6 and https://doi.org/10.1145/2442516.2442527 Fig. 3, line 37). It looks like this is discussed as "Tearable Atomics" in C++ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0690r1.html

Other expressions such as `x.y.z` and `f(x).y` also have a possible well-defined interpretation as a memory location using the notion of _lens_ a la [Accessors.jl](https://github.com/JuliaObjects/Accessors.jl).

The point of this PR is not for discussing if the above suggestions are adequate (although I understand that dismissing them as out of the scope of Julia is an unfortunate but possible outcome).

Rather, I suggest avoid expanding API contracts prematurely and leaving these expressions unsupported, for possible extensions in the future.
