### PR TITLE
"fixed" static linking of libllvm and julia

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -105,7 +105,7 @@ LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs --system-libs)
 #       https://github.com/JuliaLang/julia/issues/29981
 else
 ifneq ($(USE_LLVM_SHLIB),1)
-LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs $(LLVM_LIBS)) $($(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --system-libs 2> /dev/null)
+LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs $(LLVM_LIBS) --link-static) $($(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --system-libs 2> /dev/null)
 else
 LLVMLINK += $(LLVM_LDFLAGS) -lLLVM
 endif
@@ -211,7 +211,7 @@ endif
 	$(INSTALL_NAME_CMD)libccalltest.$(SHLIB_EXT) $@
 
 $(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvmcalltest.cpp $(LLVM_CONFIG_ABSOLUTE)
-	@$(call PRINT_CC, $(CXX) $(LLVM_CXXFLAGS) $(JCXXFLAGS) $(JCPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@ $(JLDFLAGS) -L$(build_shlibdir) -L$(build_libdir) $(NO_WHOLE_ARCHIVE) $(LLVMLINK))
+	@$(call PRINT_CC, $(CXX) $(LLVM_CXXFLAGS) $(JCXXFLAGS) $(JCPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@ $(JLDFLAGS) -L$(build_shlibdir) -L$(build_libdir) $(NO_WHOLE_ARCHIVE) $(LLVMLINK)) -lpthread
 
 julia_flisp.boot.inc.phony: $(BUILDDIR)/julia_flisp.boot.inc
 


### PR DESCRIPTION
Hi,

I'm not a professional make file creator, so this will be a not optimal solution. But it worked in my case: I had the problem running julia together with python + numba. Which always died with a seg fault. Since julia's version of llvm isn't compatible with the versions of numba (llvmlite); Even when you use the exact same versions, at least on linux.
I tested: numba 0.53 + llvmlite 0.36 (libllvm10) and julia 1.6.1 -> seg fault.
Next try: numba 0.50.1 + llvmlite 0.33 (libllvm9 9.0.1) and julia 1.5.4 (libllvm9 9.0.1jl) -> seg fault.

Only solution, static compilation of julia 1.5.4 which is broken, but this pr fixed it for my setup (similar to #32665).

BR