### PR TITLE
Propagate indices in vector indexing of ranges with ranges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1029,6 +1029,7 @@ function getindex(r::LinRange{T}, s::OrdinalRange{S}) where {T, S<:Integer}
     else
         vfirst = unsafe_getindex(r, first(s))
         vlast  = unsafe_getindex(r, last(s))
+        ret = LinRange{T}(vfirst, vlast, len)
         return withindices(ret, axes(s))
     end
 end

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -511,10 +511,11 @@ function getindex(r::StepRangeLen{T,<:TwicePrecision,<:TwicePrecision}, s::Ordin
         end
         soffset = max(oneunit(L), soffset)
         if ioffset == r.offset
-            return StepRangeLen{T}(r.ref, newstep, len, soffset)
+            ret = StepRangeLen{T}(r.ref, newstep, len, soffset)
         else
-            return StepRangeLen{T}(r.ref + (ioffset-r.offset)*rstep, newstep, len, soffset)
+            ret = StepRangeLen{T}(r.ref + (ioffset-r.offset)*rstep, newstep, len, soffset)
         end
+        return withindices(ret, axes(s))
     end
 end
 

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -757,6 +757,25 @@ end
     for i in axes(ax,1)
         @test a[ax[i]] == a[ax][i]
     end
+
+    @testset "propagate indices in vector indexing" begin
+        ur = 5:12
+        idur = Base.IdentityUnitRange(ur)
+        ior = OffsetArrays.IdOffsetRange(ur .- 2, 2)
+        for r in Any[10.0:10.0:1000.0, StepRangeLen(Float64(10), Float64(1000), 1000), LinRange(10, 1000, 991),
+                Base.IdentityUnitRange(0:1000)]
+            rur = r[ur]
+            ridur = r[idur]
+            rior = r[ior]
+            @test all(((x,y,z),) -> x == y == z, zip(rur, ridur, rior))
+            @test axes(rur) == axes(ur)
+            @test all(i -> r[ur][i] == rur[i], eachindex(ur))
+            @test axes(ridur) == axes(idur)
+            @test all(i -> r[idur][i] == ridur[i], eachindex(idur))
+            @test axes(rior) == axes(ior)
+            @test all(i -> r[ior][i] == rior[i], eachindex(ior))
+        end
+    end
 end
 
 @testset "show OffsetMatrix" begin

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -442,9 +442,9 @@ no_offset_view(a::Array) = a
 no_offset_view(i::Number) = i
 no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)
 _no_offset_view(::Tuple{}, A::AbstractArray{T,0}) where T = A
-_no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractArray) = A
+_no_offset_view(::Tuple{Base.OneTo, Vararg{Base.OneTo}}, A::AbstractArray) = A
 # the following method is needed for ambiguity resolution
-_no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractUnitRange) = A
+_no_offset_view(::Tuple{Base.OneTo, Vararg{Base.OneTo}}, A::AbstractUnitRange) = A
 _no_offset_view(::Any, A::AbstractArray) = OffsetArray(A, Origin(1))
 _no_offset_view(::Any, A::AbstractUnitRange) = UnitRange(A)
 

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -158,6 +158,24 @@ function _checkindices(N::Integer, indices, label)
     N == length(indices) || throw_argumenterror(N, indices, label)
 end
 
+@inline _indexedby(r::AbstractVector, ax::Tuple{Any}) = _indexedby(r, ax[1])
+@inline _indexedby(r::AbstractUnitRange{<:Integer}, ::Base.OneTo) = no_offset_view(r)
+@inline _indexedby(r::AbstractUnitRange{Bool}, ::Base.OneTo) = no_offset_view(r)
+@inline _indexedby(r::AbstractVector, ::Base.OneTo) = no_offset_view(r)
+@inline function _indexedby(r::AbstractUnitRange{<:Integer}, ax::AbstractUnitRange)
+    of = convert(eltype(r), first(ax) - 1)
+    IdOffsetRange(_subtractoffset(r, of), of)
+end
+@inline _indexedby(r::AbstractUnitRange{Bool}, ax::AbstractUnitRange) = OffsetArray(r, ax)
+@inline _indexedby(r::AbstractVector, ax::AbstractUnitRange) = OffsetArray(r, ax)
+
+# These functions are equivalent to the broadcasted operation r .- of
+# However these ensure that the result is an AbstractRange even if a specific
+# broadcasting behavior is not defined for a custom type
+_subtractoffset(r::AbstractUnitRange, of) = UnitRange(first(r) - of, last(r) - of)
+_subtractoffset(r::AbstractRange, of) = range(first(r) - of, stop = last(r) - of, step = step(r))
+
+Base.withindices(r, ax::Tuple{AbstractUnitRange, Vararg{AbstractUnitRange}}) = _indexedby(r, ax)
 
 # Technically we know the length of CartesianIndices but we need to convert it first, so here we
 # don't put it in OffsetAxisKnownLength.
@@ -375,22 +393,6 @@ end
 @propagate_inbounds Base.getindex(a::OffsetRange, r::AbstractRange) = a.parent[r .- a.offsets[1]]
 @propagate_inbounds Base.getindex(a::AbstractRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)
 
-@propagate_inbounds Base.getindex(r::UnitRange, s::IIUR) =
-    OffsetArray(r[s.indices], s)
-
-@propagate_inbounds Base.getindex(r::StepRange, s::IIUR) =
-    OffsetArray(r[s.indices], s)
-
-# this method is needed for ambiguity resolution
-@propagate_inbounds Base.getindex(r::StepRangeLen{T,<:Base.TwicePrecision,<:Base.TwicePrecision}, s::IIUR) where T =
-    OffsetArray(r[s.indices], s)
-
-@propagate_inbounds Base.getindex(r::StepRangeLen{T}, s::IIUR) where {T} =
-    OffsetArray(r[s.indices], s)
-
-@propagate_inbounds Base.getindex(r::LinRange, s::IIUR) =
-    OffsetArray(r[s.indices], s)
-
 function Base.show(io::IO, r::OffsetRange)
     show(io, r.parent)
     o = r.offsets[1]
@@ -429,14 +431,21 @@ function Base.replace_in_print_matrix(A::OffsetArray{<:Any,1}, i::Integer, j::In
     Base.replace_in_print_matrix(parent(A), ip, j, s)
 end
 
-function no_offset_view(A::AbstractArray)
-    if Base.has_offset_axes(A)
-        OffsetArray(A, map(r->1-first(r), axes(A)))
-    else
-        A
-    end
-end
-
 no_offset_view(A::OffsetArray) = no_offset_view(parent(A))
+if isdefined(Base, :IdentityUnitRange)
+    # valid only if Slice is distinguished from IdentityUnitRange
+    no_offset_view(a::Base.Slice{<:Base.OneTo}) = a
+    no_offset_view(a::Base.Slice) = Base.Slice(UnitRange(a))
+    no_offset_view(S::SubArray) = view(parent(S), map(no_offset_view, parentindices(S))...)
+end
+no_offset_view(a::Array) = a
+no_offset_view(i::Number) = i
+no_offset_view(A::AbstractArray) = _no_offset_view(axes(A), A)
+_no_offset_view(::Tuple{}, A::AbstractArray{T,0}) where T = A
+_no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractArray) = A
+# the following method is needed for ambiguity resolution
+_no_offset_view(::Tuple{<:Base.OneTo,Vararg{<:Base.OneTo}}, A::AbstractUnitRange) = A
+_no_offset_view(::Any, A::AbstractArray) = OffsetArray(A, Origin(1))
+_no_offset_view(::Any, A::AbstractUnitRange) = UnitRange(A)
 
 end # module


### PR DESCRIPTION
Julia's vector indexing (with OffsetArrays in the mix) follows the rule that `axes(r[s]) == axes(s)`. However, the various `getindex` methods defined for ranges do not follow this rule, as the result may not be expressed as a range in general if the indices are preserved. `OffsetArrays` currently carries out extensive type-piracy to "fix" this.

Julia Base:
```julia
julia> (1:3)[Base.IdentityUnitRange(2:2)]
2:2
```

After loading `OffsetArrays`
```julia
julia> (1:3)[Base.IdentityUnitRange(2:2)]
OffsetArrays.IdOffsetRange(values=2:2, indices=2:2)
```

However this type-piracy of `getindex` is fragile, since `Base` (and several packages) dispatch on the first argument of `getindex` (ie, they define `getindex(r::AbstractRange, s)`), while `OffsetArrays` dispatches on the second argument (ie. it defines `getindex(r, s::AbstractUnitRange{<:Integer})`. This is a minefield of ambiguities, as witnessed recently in https://github.com/JuliaArrays/ArrayInterface.jl/issues/170#issuecomment-863704754.

This PR tries to get around this whole issue by changing how the indices of the indices are propagated. It introduces a function `withindices` that wraps the result of an indexing operation with the correct axes: `withindices(r, axes(s))` has the values of `r` but the axes of `s`. Now `OffsetArrays` only needs to pirate `withindices`, since the package does not need to compute the values of the result of an indexing operation, only its indices. This implies firstly that fixes to `getindex` in `Base` get propagated immediately to `OffsetArrays`, and secondly `OffsetArrays` does not introduce ambiguities by dispatching on the second argument.

Currently `withindices` in `Base` is a no-op, so it does not change any result and is not a breaking change. The definition of the function really only makes sense if `OffsetArrays` is loaded, in which case one obtains the correct indices.

Some of the changes in this PR are copied from #41213 as it introduced some fixes for offset ranges. If this PR is merged then the other one might not be necessary. If the other one is merged then this can be rebased on that.

Aside from this there is also a bugfix:

on master:
```julia
julia> r = StepRangeLen(Float64(1), Float64(1000), 1000)
1.0:1000.0:999001.0

julia> s = Base.IdentityUnitRange(5:8)
Base.IdentityUnitRange(5:8)

julia> r[s]
ERROR: ArgumentError: StepRangeLen: offset must be in [1,4], got 5
```

After this PR:
```julia
julia> r = StepRangeLen(Float64(1), Float64(1000), 1000)
1.0:1000.0:999001.0

julia> s = Base.IdentityUnitRange(5:8)
Base.IdentityUnitRange(5:8)

julia> r[s]
4001.0:1000.0:7001.0
```