### PR TITLE
Doc Update: Compatible shells for SSHManager

### DIFF
--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -84,6 +84,8 @@ Keyword arguments:
 
     + `shell=:posix`: a POSIX-compatible Unix/Linux shell (bash, sh, etc.). The default.
 
+        + NOTE: Csh style shells (csh, tcsh, etc.) are not supported
+
     + `shell=:wincmd`: Microsoft Windows `cmd.exe`.
 
 * `dir`: specifies the working directory on the workers. Defaults to the host's current


### PR DESCRIPTION
Original Post below. Kept to provide context to the final resolution.

------------------------
This PR resolves an issue that I had using SSHManager (v1.6.1) under the tcsh shell in Linux. The problem was that the shell command that spawns the worker on the remote machine wasn’t working.  

I determined that the problem was that the ssh shell command included two commands to be executed on the remote machine
  1) Launch a shell
  2) Launch Julia 

These two commands are currently delimited by a “\n” which works for many shells, but not for tcsh for some reason. As a result, the worker never launches and addproc() fails.

I fixed this by replacing the “\n” with a “; ”.  This allowed the worker process to spawn.  I also tested it with zsh on an M1 MacBook and that worked as well.

To the best of my knowledge about shell commands, I don’t think that this change would break any other shells. But feedback from others more knowledgeable than myself is appreciated.