### PR TITLE
Move compile timing to inside `@time`'s main timing block. Fixes >100% compilation time reports

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -210,11 +210,11 @@ macro time(ex)
         precompile(cumulative_compile_time_ns_after, ())
 
         local stats = gc_num()
-        local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
+        local compile_elapsedtime = cumulative_compile_time_ns_before()
         local val = $(esc(ex))
-        elapsedtime = time_ns() - elapsedtime
         compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+        elapsedtime = time_ns() - elapsedtime
         local diff = GC_Diff(gc_num(), stats)
         time_print(elapsedtime, diff.allocd, diff.total_time, gc_alloc_count(diff), compile_elapsedtime, true)
         val
@@ -261,11 +261,11 @@ macro timev(ex)
         precompile(cumulative_compile_time_ns_after, ())
 
         local stats = gc_num()
-        local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
+        local compile_elapsedtime = cumulative_compile_time_ns_before()
         local val = $(esc(ex))
-        elapsedtime = time_ns() - elapsedtime
         compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+        elapsedtime = time_ns() - elapsedtime
         local diff = GC_Diff(gc_num(), stats)
         timev_print(elapsedtime, diff, compile_elapsedtime)
         val

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -204,11 +204,6 @@ julia> @time begin
 macro time(ex)
     quote
         while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
-
-        ## ensure these are compiled as they are first called within the compilation-timed region
-        precompile(time_ns, ())
-        precompile(cumulative_compile_time_ns_after, ())
-
         local stats = gc_num()
         local elapsedtime = time_ns()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
@@ -255,11 +250,6 @@ pool allocs:       1
 macro timev(ex)
     quote
         while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
-
-        ## ensure these are compiled as they are first called within the compilation-timed region
-        precompile(time_ns, ())
-        precompile(cumulative_compile_time_ns_after, ())
-
         local stats = gc_num()
         local elapsedtime = time_ns()
         local compile_elapsedtime = cumulative_compile_time_ns_before()

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -207,6 +207,12 @@ macro time(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
+        ## ensure time samplers are compiled
+        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+        elapsedtime = time_ns() - elapsedtime
+        ## reset timers
+        compile_elapsedtime = cumulative_compile_time_ns_before()
+        elapsedtime = time_ns()
         local val = $(esc(ex))
         elapsedtime = time_ns() - elapsedtime
         compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
@@ -253,6 +259,12 @@ macro timev(ex)
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
+        ## ensure time samplers are compiled
+        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
+        elapsedtime = time_ns() - elapsedtime
+        ## reset timers
+        compile_elapsedtime = cumulative_compile_time_ns_before()
+        elapsedtime = time_ns()
         local val = $(esc(ex))
         elapsedtime = time_ns() - elapsedtime
         compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -204,15 +204,14 @@ julia> @time begin
 macro time(ex)
     quote
         while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
+
+        ## ensure these are compiled as they are first called within the compilation-timed region
+        precompile(time_ns, ())
+        precompile(cumulative_compile_time_ns_after, ())
+
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        ## ensure time samplers are compiled
-        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
-        elapsedtime = time_ns() - elapsedtime
-        ## reset timers
-        compile_elapsedtime = cumulative_compile_time_ns_before()
-        elapsedtime = time_ns()
         local val = $(esc(ex))
         elapsedtime = time_ns() - elapsedtime
         compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
@@ -256,15 +255,14 @@ pool allocs:       1
 macro timev(ex)
     quote
         while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
+
+        ## ensure these are compiled as they are first called within the compilation-timed region
+        precompile(time_ns, ())
+        precompile(cumulative_compile_time_ns_after, ())
+
         local stats = gc_num()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
         local elapsedtime = time_ns()
-        ## ensure time samplers are compiled
-        compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime
-        elapsedtime = time_ns() - elapsedtime
-        ## reset timers
-        compile_elapsedtime = cumulative_compile_time_ns_before()
-        elapsedtime = time_ns()
         local val = $(esc(ex))
         elapsedtime = time_ns() - elapsedtime
         compile_elapsedtime = cumulative_compile_time_ns_after() - compile_elapsedtime


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/41281

It seems like the case in https://github.com/JuliaLang/julia/issues/41281 that results in `@time` reporting >100% compilation time is fixed by pre-running the timing sampling lines within `@time` to ensure they're compiled(?)

Perhaps instead of this PR, I wondered if there's some type instability/invalidation going on that could be fixed, given that `@time 1+1` is already baked into the sysimage? 
Or, perhaps this PR is a failsafe solution?

## Master
```julia
julia> @time map(x -> 2x, 1:3);
  0.035300 seconds (52.03 k allocations: 3.258 MiB, 107.03% compilation time)

julia> @time map(x -> 2x, 1:3);
  0.028745 seconds (49.72 k allocations: 3.057 MiB, 99.36% compilation time)
```
```julia
julia> x = rand(2,2);

julia> @time x * x;
  0.651758 seconds (2.54 M allocations: 140.827 MiB, 5.07% gc time, 99.95% compilation time)

julia> @time x * x;
  0.000006 seconds (1 allocation: 112 bytes)

```

## This PR
```julia
julia> @time map(x -> 2x, 1:3);
  0.032076 seconds (52.04 k allocations: 3.241 MiB, 98.54% compilation time)

julia> @time map(x -> 2x, 1:3);
  0.029221 seconds (49.72 k allocations: 3.057 MiB, 99.45% compilation time)
```
```julia
julia> x = rand(2,2);

julia> @time x * x;
  0.632906 seconds (2.54 M allocations: 140.827 MiB, 7.51% gc time, 99.94% compilation time)

julia> @time x * x;
  0.000005 seconds (1 allocation: 112 bytes)
```

If anyone has any other `@time` calls that result in >100% I'd happily test them with this