### PR TITLE
fix preference loading for non string value

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1765,9 +1765,9 @@ function get_preferences_hash(uuid::Union{UUID, Nothing}, prefs_list::Vector{Str
 
     # Walk through each name that's called out as a compile-time preference
     for name in prefs_list
-        prefs_name = get(prefs, name, nothing)::Union{String, Nothing}
-        if prefs_name !== nothing
-            h = hash(prefs_name, h)
+        prefs_value = get(prefs, name, nothing)
+        if prefs_value !== nothing
+            h = hash(prefs_value, h)
         end
     end
     # We always return a `UInt64` so that our serialization format is stable


### PR DESCRIPTION
this fix https://github.com/JuliaPackaging/Preferences.jl/issues/16 kinda revert the type annotation added in #38285 since we don't know the type of a value IIUC unless we want to restrict the preference value to be `String` only.

I'm not sure where to add a test for this, or `get_preferences_hash` wasn't tested at all?

guess cc: @staticfloat 