### PR TITLE
Fix inability to find support/{platform,dirpath}.h from julia_fasttls.h.

### DIFF
--- a/src/julia_fasttls.h
+++ b/src/julia_fasttls.h
@@ -10,8 +10,8 @@ extern "C" {
 #endif
 
 /* Bring in definitions for `_OS_X_`, `PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
-#include "support/platform.h"
-#include "support/dirpath.h"
+#include "platform.h"
+#include "dirpath.h"
 
 typedef struct _jl_gcframe_t jl_gcframe_t;
 


### PR DESCRIPTION
During PackageCompiler.jl system image creation under Julia 1.7, gcc complains that it cannot find `support/{platform,dirpath}.h` included from `julia_fasttls.h` (while looking in `usr/include/julia`). My (potentially incorrect) working understanding is that all of `julia_fasttls.h` and `{platform,dirpath}.h` end up directly in `usr/include/julia` --- i.e. the `support/` qualification of `support/{platform,dirpath}.h` effectively gets flattened away when `{platform,dirpath}.h` are copied from `src/support/{platform,dirpath}.h` to `usr/include/julia`. This patch drops the `support/` qualification in the include in `julia_fasttls.h`, which locally seems to make everything happy (though I imagine this may not be the best or even a generally correct approach). Best! :)