### PR TITLE
Drop parens from JULIA_DEFINE_FAST_TLS in embedding.{c,md} to match recent redefinition.

### DIFF
--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -16,7 +16,7 @@ We start with a simple C program that initializes Julia and calls some Julia cod
 
 ```c
 #include <julia.h>
-JULIA_DEFINE_FAST_TLS() // only define this once, in an executable (not in a shared library) if you want fast code.
+JULIA_DEFINE_FAST_TLS // only define this once, in an executable (not in a shared library) if you want fast code.
 
 int main(int argc, char *argv[])
 {

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <math.h>
 
-JULIA_DEFINE_FAST_TLS() // only define this once, in an executable
+JULIA_DEFINE_FAST_TLS // only define this once, in an executable
 
 #ifdef _OS_WINDOWS_
 __declspec(dllexport) __cdecl


### PR DESCRIPTION
Trailing parens were recently dropped from JULIA_DEFINE_FAST_TLS, but it looks like two instances in embedding.{c,md} might've been missed. Best! :)