### PR TITLE
Normalize indices in promote_shape error messages (take 2)

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -114,7 +114,7 @@ function throw_promote_shape_mismatch(a::Tuple{T,Vararg{T}},
     _has_axes = T <: AbstractUnitRange
     _normalize(d) = map(x -> _has_axes ? (firstindex(x):lastindex(x)) : x, d)
     _things = _has_axes ? "axes" : "size"
-    msg = "dimensions must match: a has $(_things) $(_normalize(a))"
+    msg = "a has $(_things) $(_normalize(a))"
     if b ≢ nothing
         msg *= ", b has $(_things) $(_normalize(b))"
     end

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -108,8 +108,8 @@ promote_shape(::Tuple{}, ::Tuple{}) = ()
 
 # Consistent error message for promote_shape mismatch, hiding implementation details like
 # OneTo. When b ≡ nothing, it is omitted; i can be supplied for an index.
-function throw_promote_shape_mismatch(a::Tuple{Vararg{T}},
-                                      b::Union{Nothing,Tuple{Vararg{T}}},
+function throw_promote_shape_mismatch(a::Tuple{T,Vararg{T}},
+                                      b::Union{Nothing,Tuple{T,Vararg{T}}},
                                       i = nothing) where {T}
     _has_axes = T <: AbstractUnitRange
     _normalize(d) = map(x -> _has_axes ? (firstindex(x):lastindex(x)) : x, d)

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -108,11 +108,15 @@ promote_shape(::Tuple{}, ::Tuple{}) = ()
 
 # Consistent error message for promote_shape mismatch, hiding implementation details like
 # OneTo. When b ≡ nothing, it is omitted; i can be supplied for an index.
-function throw_promote_shape_mismatch(a, b, i = nothing)
-    _normalize(d) = map(x -> x isa AbstractUnitRange ? (firstindex(x):lastindex(x)) : x, d)
-    msg = "dimensions must match: a has dims $(_normalize(a))"
+function throw_promote_shape_mismatch(a::Tuple{Vararg{T}},
+                                      b::Union{Nothing,Tuple{Vararg{T}}},
+                                      i = nothing) where {T}
+    _has_axes = T <: AbstractUnitRange
+    _normalize(d) = map(x -> _has_axes ? (firstindex(x):lastindex(x)) : x, d)
+    _things = _has_axes ? "axes" : "size"
+    msg = "dimensions must match: a has $(_things) $(_normalize(a))"
     if b ≢ nothing
-        msg *= ", b has dims $(_normalize(b))"
+        msg *= ", b has $(_things) $(_normalize(b))"
     end
     if i ≢ nothing
         msg *= ", mismatch at $(i)"

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -184,7 +184,7 @@ function Base.muladd(A::AbstractMatrix, y::AbstractVecOrMat, z::Union{Number, Ab
     end
     for d in ndims(Ay)+1:ndims(z)
         # Similar error to what Ay + z would give, to match (Any,Any,Any) method:
-        size(z,d) > 1 && throw(DimensionMismatch(string("dimensions must match: z has dims ",
+        size(z,d) > 1 && throw(DimensionMismatch(string("z has dims ",
             axes(z), ", must have singleton at dim ", d)))
     end
     Ay .+ z
@@ -197,7 +197,7 @@ function Base.muladd(u::AbstractVector, v::AdjOrTransAbsVec, z::Union{Number, Ab
     end
     for d in 3:ndims(z)
         # Similar error to (u*v) + z:
-        size(z,d) > 1 && throw(DimensionMismatch(string("dimensions must match: z has dims ",
+        size(z,d) > 1 && throw(DimensionMismatch(string("z has dims ",
             axes(z), ", must have singleton at dim ", d)))
     end
     (u .* v) .+ z

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -251,6 +251,8 @@ end
 # We can also implement `map` and its promotion in terms of broadcast with a stricter dimension check
 function map(f, A::StructuredMatrix, Bs::StructuredMatrix...)
     sz = size(A)
-    all(map(B->size(B)==sz, Bs)) || throw(DimensionMismatch("dimensions must match"))
+    for B in Bs
+        size(B) == sz || Base.throw_promote_shape_mismatch(sz, size(B))
+    end
     return f.(A, Bs...)
 end

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -142,6 +142,11 @@ end
             @test map!(*, Z, X, Y) == broadcast(*, fX, fY)
         end
     end
+    # these would be valid for broadcast, but not for map
+    @test_throws DimensionMismatch map(+, D, Diagonal(rand(1)))
+    @test_throws DimensionMismatch map(+, D, Diagonal(rand(1)), D)
+    @test_throws DimensionMismatch map(+, D, D, Diagonal(rand(1)))
+    @test_throws DimensionMismatch map(+, Diagonal(rand(1)), D, D)
 end
 
 @testset "Issue #33397" begin


### PR DESCRIPTION
Seeing implementation like `Base.OneTo` in error messages may be confusing to some users (cf discussion in #39242,
[discourse](https://discourse.julialang.org/t/promote-shape-dimension-mismatch/57529/)).

This PR turns
```julia
julia> ones(2, 3) + ones(3, 2)
ERROR: DimensionMismatch("dimensions must match: a has dims (Base.OneTo(2), Base.OneTo(3)), b has dims (Base.OneTo(3), Base.OneTo(2)), mismatch at 1")
```
into
```julia
julia> ones(2, 3) + ones(3, 2)
ERROR: DimensionMismatch("dimensions must match: a has axes (1:2, 1:3), b has axes (1:3, 1:2), mismatch at 1")
```

Fixes #40118. 

(This is basically #40124, but redone because I made a mess rebasing).