### PR TITLE
supports `@inline`/`@noinline` annotations within a function body

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ New language features
 ---------------------
 
 * `Module(:name, false, false)` can be used to create a `module` that does not import `Core`. ([#40110])
+* `@inline` and `@noinline` annotations may now be used in function bodies. ([#40754])
 
 Language changes
 ----------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ New language features
 ---------------------
 
 * `Module(:name, false, false)` can be used to create a `module` that does not import `Core`. ([#40110])
-* `@inline` and `@noinline` annotations may now be used in function bodies. ([#40754])
+* `@inline` and `@noinline` annotations may now be used in function bodies. ([#41312])
 
 Language changes
 ----------------

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -188,19 +188,32 @@ Give a hint to the compiler that this function is worth inlining.
 Small functions typically do not need the `@inline` annotation,
 as the compiler does it automatically. By using `@inline` on bigger functions,
 an extra nudge can be given to the compiler to inline it.
-This is shown in the following example:
+
+`@inline` can be applied immediately before the definition or in its function body.
 
 ```julia
-@inline function bigfunction(x)
-    #=
-        Function Definition
-    =#
+# annotate long-form definition
+@inline function longdef(x)
+    ...
+end
+
+# annotate short-form definition
+@inline shortdef(x) = ...
+
+# annotate anonymous function that a `do` block creates
+f() do
+    @inline
+    ...
 end
 ```
+
+!!! compat "Julia 1.7"
+    The usage within a function body requires at least Julia 1.7.
 """
 macro inline(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :inline) : ex)
 end
+macro inline() Expr(:meta, :inline) end
 
 """
     @noinline
@@ -209,15 +222,28 @@ Give a hint to the compiler that it should not inline a function.
 
 Small functions are typically inlined automatically.
 By using `@noinline` on small functions, auto-inlining can be
-prevented. This is shown in the following example:
+prevented.
+
+`@noinline` can be applied immediately before the definition or in its function body.
 
 ```julia
-@noinline function smallfunction(x)
-    #=
-        Function Definition
-    =#
+# annotate long-form definition
+@noinline function longdef(x)
+    ...
+end
+
+# annotate short-form definition
+@noinline shortdef(x) = ...
+
+# annotate anonymous function that a `do` block creates
+f() do
+    @noinline
+    ...
 end
 ```
+
+!!! compat "Julia 1.7"
+    The usage within a function body requires at least Julia 1.7.
 
 !!! note
     If the function is trivial (for example returning a constant) it might get inlined anyway.
@@ -225,6 +251,7 @@ end
 macro noinline(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :noinline) : ex)
 end
+macro noinline() Expr(:meta, :noinline) end
 
 """
     @pure ex

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -207,8 +207,8 @@ f() do
 end
 ```
 
-!!! compat "Julia 1.7"
-    The usage within a function body requires at least Julia 1.7.
+!!! compat "Julia 1.8"
+    The usage within a function body requires at least Julia 1.8.
 """
 macro inline(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :inline) : ex)

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -242,8 +242,8 @@ f() do
 end
 ```
 
-!!! compat "Julia 1.7"
-    The usage within a function body requires at least Julia 1.7.
+!!! compat "Julia 1.8"
+    The usage within a function body requires at least Julia 1.8.
 
 !!! note
     If the function is trivial (for example returning a constant) it might get inlined anyway.


### PR DESCRIPTION
Separated from #40754 in order to make the review/discussion more easier and clearer.

The primary motivation for this change is to annotate
`@inline`/`@noinline` to anonymous functions created from `do` block:
```julia
f() do
    @inline # makes this anonymous function to be inlined
    ... # function body
end
```

We can extend the grammar so that we have special "declaration-macro"
supports for `do`-block functions like:
```julia
f() @inline do # makes this anonymous function to be inlined
    ... # function body
end
```
but I'm not sure which one is better.

Following [the earlier discussion](https://github.com/JuliaLang/julia/pull/40754#issuecomment-839401667),
this commit implements the easiest solution.

---

/cc @dghosef , @tkf 