### PR TITLE
Fix #41299 - Dropped error case in :> special case inliner

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1410,7 +1410,7 @@ function late_inline_special_case!(ir::IRCode, sig::Signature, idx::Int, stmt::E
     elseif params.inlining && length(atypes) == 3 && istopfunction(f, :(>:))
         # special-case inliner for issupertype
         # that works, even though inference generally avoids inferring the `>:` Method
-        if isa(typ, Const)
+        if isa(typ, Const) && _builtin_nothrow(<:, Any[atypes[3], atypes[2]], typ)
             ir[SSAValue(idx)] = quoted(typ.val)
             return true
         end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -497,3 +497,7 @@ end
         end
     end
 end
+
+# Issue #41299 - inlining deletes error check in :>
+g41299(f::Tf, args::Vararg{Any,N}) where {Tf,N} = f(args...)
+@test_throws TypeError g41299(>:, 1, 2)


### PR DESCRIPTION
We have custom inference for :>, which prevents the :> method
itself from being inferred. As a result, it needs to be inlined
manually. However, this inlining was overeager and was dropping
an error check when the result was inferred to `Const`. Fix that
by verifying that the inlined <: call would have been nothrow.