### PR TITLE
Export jl_get_pgcstack from libjulia

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -540,4 +540,5 @@
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
     XX(jl_yield) \
-    XX(jl_print_backtrace)
+    XX(jl_print_backtrace) \
+    XX(jl_get_pgcstack)


### PR DESCRIPTION
The pgcstack symbol is special because embedders are supposed to
define it themselves in localexec tls, and then access it that way.
However, there is another case of of libraries that link against
julia, but are not embedders, but rather plugins to be loaded later
(e.g. CxxWrap). These do need access to the pgcstack, but do not
have a priori access to the localexec of the embedder. Thus,
re-export the `jl_get_pgcstack` function that provides access
to our internal getter for the pgcstack.