### PR TITLE
Add documentation refs for argmax and argmin

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -900,7 +900,7 @@ Values are compared with `isless`.
 !!! compat "Julia 1.7"
     This method requires Julia 1.7 or later.
 
-See also: [`argmin`](@ref), [`findmax`](@ref).
+See also [`argmin`](@ref), [`findmax`](@ref).
 
 # Examples
 ```jldoctest
@@ -952,7 +952,7 @@ If there are multiple minimal values for `f(x)` then the first one will be found
 !!! compat "Julia 1.7"
     This method requires Julia 1.7 or later.
 
-See also: [`argmax`](@ref), [`findmin`](@ref).
+See also [`argmax`](@ref), [`findmin`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -900,6 +900,8 @@ Values are compared with `isless`.
 !!! compat "Julia 1.7"
     This method requires Julia 1.7 or later.
 
+See also: [`argmin`](@ref), [`findmax`](@ref).
+
 # Examples
 ```jldoctest
 julia> argmax(abs, -10:5)
@@ -949,6 +951,8 @@ If there are multiple minimal values for `f(x)` then the first one will be found
 
 !!! compat "Julia 1.7"
     This method requires Julia 1.7 or later.
+
+See also: [`argmax`](@ref), [`findmin`](@ref).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
These were missing on some methods, so I added them.

Doesn't really need to be backported to 1.7, would be a nice to have though.

[no-ci]