### PR TITLE
Add `indmin`/`indmax`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ Build system changes
 New library functions
 ---------------------
 
+ * `indmax(f, col)` and `indmin(f, col)` have been added, returning the index maximizing/minimizing a given function (or `identity`, if none is given) over an indexable collection.
 
 New library features
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -469,6 +469,8 @@ export
     searchsortedlast,
     insorted,
     startswith,
+    indmax,
+    indmin,
 
 # linear algebra
     var"'", # to enable syntax a' for adjoint

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -965,6 +965,32 @@ julia> argmin(acos, 0:0.1:1)
 argmin(f, domain) = mapfoldl(x -> (f(x), x), _rf_findmin, domain)[2]
 
 """
+    argmin(itr)
+
+Return the index or key of the minimal element in a collection.
+If there are multiple minimal elements, then the first one will be returned.
+
+The collection must not be empty.
+
+`NaN` is treated as less than all other values except `missing`.
+
+See also: [`argmax`](@ref), [`findmin`](@ref).
+
+# Examples
+```jldoctest
+julia> argmin([8, 0.1, -9, pi])
+3
+
+julia> argmin([7, 1, 1, 6])
+2
+
+julia> argmin([7, 1, 1, NaN])
+4
+```
+"""
+argmin(itr) = findmin(itr)[2]
+
+"""
     indmin(itr) -> idx
 
 Return the index of the minimal element of the collection `itr`.

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -768,7 +768,7 @@ Inf
 """
 minimum(a; kw...) = mapreduce(identity, min, a; kw...)
 
-## findmax, findmin, argmax & argmin
+## findmax, findmin, argmax, argmin, indmax & indmin
 
 """
     findmax(f, domain) -> (f(x), index)
@@ -965,30 +965,116 @@ julia> argmin(acos, 0:0.1:1)
 argmin(f, domain) = mapfoldl(x -> (f(x), x), _rf_findmin, domain)[2]
 
 """
-    argmin(itr)
+    indmin(itr) -> idx
 
-Return the index or key of the minimal element in a collection.
-If there are multiple minimal elements, then the first one will be returned.
-
-The collection must not be empty.
-
+Return the index of the minimal element of the collection `itr`.
+If there are multiple minimal elements, then the first index will be returned.
 `NaN` is treated as less than all other values except `missing`.
 
-See also: [`argmax`](@ref), [`findmin`](@ref).
+!!! compat "Julia 1.8"
+    This method requires Julia 1.8 or later.
+
+See also: [`indmax`](@ref), [`findmin`](@ref).
 
 # Examples
 ```jldoctest
-julia> argmin([8, 0.1, -9, pi])
+julia> indmin([8, 0.1, -9, pi])
 3
 
-julia> argmin([7, 1, 1, 6])
-2
+julia> indmin([1, 7, 7, 6])
+1
 
-julia> argmin([7, 1, 1, NaN])
+julia> indmin([1, 7, 7, NaN])
 4
 ```
 """
-argmin(itr) = findmin(itr)[2]
+indmin(itr) = findmin(itr)[2]
+
+"""
+    indmin(f, itr) -> idx
+
+Return the index of an `x` of the collection `itr` such that `f(x)` is minimised.
+If there are multiple minimal elements, then the first index will be returned.
+`NaN` is treated as less than all other values except `missing`.
+
+!!! compat "Julia 1.8"
+    This method requires Julia 1.8 or later.
+
+See also: [`indmax`](@ref), [`findmin`](@ref).
+
+# Examples
+```jldoctest
+julia> indmin(identity, 5:9)
+1
+
+julia> indmin(-, 1:10)
+10
+
+julia> indmin(first, [(2, :a), (2, :b), (3, :c)])
+1
+
+julia> indmin(cos, 0:π/2:2π)
+3
+```
+"""
+indmin(f, itr) = findmin(f, itr)[2]
+
+"""
+    indmax(itr) -> idx
+
+Return the index of the maximal element of the collection `itr`.
+If there are multiple maximal elements, then the first index will be returned.
+
+Values are compared using `isless`.
+
+!!! compat "Julia 1.8"
+    This method requires Julia 1.8 or later.
+
+See also: [`indmin`](@ref), [`findmax`](@ref).
+
+# Examples
+```jldoctest
+julia> indmax([8, 0.1, -9, pi])
+1
+
+julia> indmax([1, 7, 7, 6])
+2
+
+julia> indmax([1, 7, 7, NaN])
+4
+```
+"""
+indmax(itr) = findmax(itr)[2]
+
+"""
+    indmax(f, itr) -> idx
+
+Return the index of an `x` of the collection `itr` such that `f(x)` is maximised.
+If there are multiple maximal elements, then the first index will be returned.
+
+Values are compared using `isless`.
+
+!!! compat "Julia 1.8"
+    This method requires Julia 1.8 or later.
+
+See also: [`indmin`](@ref), [`findmax`](@ref).
+
+# Examples
+```jldoctest
+julia> indmax(identity, 5:9)
+5
+
+julia> indmax(-, 1:10)
+1
+
+julia> indmax(first, [(1, :a), (3, :b), (3, :c)])
+2
+
+julia> indmax(cos, 0:π/2:2π)
+1
+```
+"""
+indmax(f, itr) = findmax(f, itr)[2]
 
 ## all & any
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -397,7 +397,7 @@ end
     @test findmin(identity, [1, NaN, 3]) === (NaN, 2)
     @test findmin(identity, [1, 3, NaN]) === (NaN, 3)
     @test findmin(cos, 0:π/2:2π) == (-1.0, 3)
-    @test findmin(sum, Iterators.product(1:5, 1:5) |> collect) == ((1, 1), CartesianIndex(1, 1))
+    @test findmin(sum, Iterators.product(1:5, 1:5) |> collect) == (2, CartesianIndex(1, 1))
 end
 
 @testset "findmax(f, domain)" begin
@@ -408,7 +408,7 @@ end
     @test findmax(identity, [1, NaN, 3]) === (NaN, 2)
     @test findmax(identity, [1, 3, NaN]) === (NaN, 3)
     @test findmax(cos, 0:π/2:2π) == (1.0, 1)
-    @test findmin(sum, Iterators.product(1:5, 1:5) |> collect) == ((5, 5), CartesianIndex(5, 5))
+    @test findmax(sum, Iterators.product(1:5, 1:5) |> collect) == (10, CartesianIndex(5, 5))
 end
 
 @testset "argmin(f, domain)" begin

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -387,7 +387,7 @@ A = circshift(reshape(1:24,2,3,4), (0,1,1))
     end
 end
 
-# findmin, findmax, argmin, argmax
+# findmin, findmax, argmin, argmax, indmin, indmax
 
 @testset "findmin(f, domain)" begin
     @test findmin(-, 1:10) == (-10, 10)
@@ -397,6 +397,7 @@ end
     @test findmin(identity, [1, NaN, 3]) === (NaN, 2)
     @test findmin(identity, [1, 3, NaN]) === (NaN, 3)
     @test findmin(cos, 0:π/2:2π) == (-1.0, 3)
+    @test findmin(sum, Iterators.product(1:5, 1:5) |> collect) == ((1, 1), CartesianIndex(1, 1))
 end
 
 @testset "findmax(f, domain)" begin
@@ -407,6 +408,7 @@ end
     @test findmax(identity, [1, NaN, 3]) === (NaN, 2)
     @test findmax(identity, [1, 3, NaN]) === (NaN, 3)
     @test findmax(cos, 0:π/2:2π) == (1.0, 1)
+    @test findmin(sum, Iterators.product(1:5, 1:5) |> collect) == ((5, 5), CartesianIndex(5, 5))
 end
 
 @testset "argmin(f, domain)" begin
@@ -417,6 +419,20 @@ end
 @testset "argmax(f, domain)" begin
     @test argmax(-, 1:10) == 1
     @test argmax(sum, Iterators.product(1:5, 1:5)) == (5, 5)
+end
+
+@testset "indmin(f, itr)" begin
+    @test indmin(-, 1:10) == 10
+    @test indmin(cos, 0:π/2:2π) == 3
+    @test indmin(identity, [1, 2, 3, missing]) === 4
+    @test indmin(sum, Iterators.product(1:5, 1:5) |> collect) == CartesianIndex(1, 1)
+end
+
+@testset "indmax(f, itr)" begin
+    @test indmax(-, 1:10) == 1
+    @test indmax(cos, 0:π/2:2π) == 1
+    @test indmax(identity, [1, 2, 3, missing]) == 4
+    @test indmax(sum, Iterators.product(1:5, 1:5) |> collect) == CartesianIndex(5, 5)
 end
 
 # any & all

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -425,8 +425,8 @@ end
     @test indmin(-, 1:10) == 10
     @test indmin(cos, 0:π/2:2π) == 3
     @test indmin(identity, [1, 2, 3, missing]) === 4
-    
-    prod_test = collect(Iterators.product(1:5, 1:5))
+
+    prodtest = collect(Iterators.product(1:5, 1:5))
     @test indmin(sum, prodtest) == CartesianIndex(1, 1)
     @test indmin(identity, prodtest) == indmin(prodtest)
     @test indmin(identity, prodtest) == CartesianIndex(1, 1)
@@ -437,7 +437,7 @@ end
     @test indmax(cos, 0:π/2:2π) == 1
     @test indmax(identity, [1, 2, 3, missing]) == 4
 
-    prod_test = collect(Iterators.product(1:5, 1:5))
+    prodtest = collect(Iterators.product(1:5, 1:5))
     @test indmax(sum, prodtest) == CartesianIndex(5, 5)
     @test indmax(identity, prodtest) == indmax(prodtest)
     @test indmax(identity, prodtest) == CartesianIndex(5, 5)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -425,14 +425,22 @@ end
     @test indmin(-, 1:10) == 10
     @test indmin(cos, 0:π/2:2π) == 3
     @test indmin(identity, [1, 2, 3, missing]) === 4
-    @test indmin(sum, Iterators.product(1:5, 1:5) |> collect) == CartesianIndex(1, 1)
+    
+    prod_test = collect(Iterators.product(1:5, 1:5))
+    @test indmin(sum, prodtest) == CartesianIndex(1, 1)
+    @test indmin(identity, prodtest) == indmin(prodtest)
+    @test indmin(identity, prodtest) == CartesianIndex(1, 1)
 end
 
 @testset "indmax(f, itr)" begin
     @test indmax(-, 1:10) == 1
     @test indmax(cos, 0:π/2:2π) == 1
     @test indmax(identity, [1, 2, 3, missing]) == 4
-    @test indmax(sum, Iterators.product(1:5, 1:5) |> collect) == CartesianIndex(5, 5)
+
+    prod_test = collect(Iterators.product(1:5, 1:5))
+    @test indmax(sum, prodtest) == CartesianIndex(5, 5)
+    @test indmax(identity, prodtest) == indmax(prodtest)
+    @test indmax(identity, prodtest) == CartesianIndex(5, 5)
 end
 
 # any & all


### PR DESCRIPTION
Adds `indmin` and `indmax` methods which return the index into a collection, minimizing/maximizing a given function (or `identity` if none is given). 

This came out of the discussion surrounding #39203.