### PR TITLE
Switch off contextual alternates for the Julia manual

### DIFF
--- a/doc/src/assets/julia-manual.css
+++ b/doc/src/assets/julia-manual.css
@@ -1,3 +1,7 @@
+pre, code {
+    font-variant-ligatures: no-contextual;
+}
+
 nav.toc h1 {
     display: none;
 }


### PR DESCRIPTION
Switch off contextual alternates (aka "ligatures") for this document. (https://github.com/JuliaDocs/Documenter.jl/issues/1610)