### PR TITLE
RFC: fix #41349: more accurate `references_name`

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1502,11 +1502,20 @@ static int references_name(jl_value_t *p, jl_typename_t *name, int affects_layou
         jl_datatype_t *dp = (jl_datatype_t*)p;
         if (affects_layout && dp->name == name)
             return 1;
-        affects_layout = dp->types == NULL || jl_svec_len(dp->types) != 0;
-        size_t i, l = jl_nparams(p);
-        for (i = 0; i < l; i++) {
-            if (references_name(jl_tparam(p, i), name, affects_layout))
-                return 1;
+        jl_svec_t *ft = dp->types;
+        if (ft && dp->name->mayinlinealloc) {
+            size_t i, l = jl_svec_len(ft);
+            for (i = 0; i < l; i++) {
+                if (references_name(jl_svecref(ft, i), name, 1))
+                    return 1;
+            }
+        }
+        else {
+            size_t i, l = jl_nparams(p);
+            for (i = 0; i < l; i++) {
+                if (references_name(jl_tparam(p, i), name, 1))
+                    return 1;
+            }
         }
     }
     return 0;

--- a/test/core.jl
+++ b/test/core.jl
@@ -7219,8 +7219,8 @@ end
 struct B33954
     x::Q33954{B33954}
 end
-@test_broken isbitstype(Tuple{B33954})
-@test_broken isbitstype(B33954)
+@test isbitstype(Tuple{B33954})
+@test isbitstype(B33954)
 
 struct B40050 <: Ref{Tuple{B40050}}
 end
@@ -7564,3 +7564,13 @@ const T35130 = Tuple{Vector{Int}, <:Any}
 end
 h35130(x) = A35130(Any[x][1]::Vector{T35130})
 @test h35130(T35130[([1],1)]) isa A35130
+
+# issue #41349
+struct A41349{T}
+    x::Ptr{T}
+end
+struct B41349
+    x::A41349{B41349}
+end
+@test isbitstype(B41349)
+@test isbitstype(Tuple{B41349})


### PR DESCRIPTION
Marking this as RFC, since I am not certain that this is actually
correct.