### PR TITLE
Make addprocs() safe for reuse (i.e. doesn't request more processes if re-called)

### DIFF
--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -413,7 +413,7 @@ end
 """
     addprocs(; kwargs...) -> List of process identifiers
 
-Equivalent to `addprocs(Sys.CPU_THREADS; kwargs...)` if processes have already not been launched,
+Equivalent to `addprocs(Sys.CPU_THREADS; kwargs...)` if processes have not been launched,
 otherwise it will add only the remaining processes to reach Sys.CPU_THREADS.
 
 Note that workers do not run a `.julia/config/startup.jl` startup script, nor do they synchronize

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -413,13 +413,14 @@ end
 """
     addprocs(; kwargs...) -> List of process identifiers
 
-Equivalent to `addprocs(Sys.CPU_THREADS; kwargs...)`
+Equivalent to `addprocs(Sys.CPU_THREADS; kwargs...)` if processes have already not been launched,
+otherwise it will add only the remaining processes to reach Sys.CPU_THREADS.
 
 Note that workers do not run a `.julia/config/startup.jl` startup script, nor do they synchronize
 their global state (such as global variables, new method definitions, and loaded modules) with any
 of the other running processes.
 """
-addprocs(; kwargs...) = addprocs(Sys.CPU_THREADS; kwargs...)
+addprocs(; kwargs...) = nprocs() < Sys.CPU_THREADS && addprocs(Sys.CPU_THREADS-nprocs()+1; kwargs...)
 
 """
     addprocs(np::Integer; restrict=true, kwargs...) -> List of process identifiers

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -420,7 +420,13 @@ Note that workers do not run a `.julia/config/startup.jl` startup script, nor do
 their global state (such as global variables, new method definitions, and loaded modules) with any
 of the other running processes.
 """
-addprocs(; kwargs...) = nprocs() < Sys.CPU_THREADS && addprocs(Sys.CPU_THREADS-nprocs()+1; kwargs...)
+function addprocs(; kwargs...)
+    if nprocs() <= Sys.CPU_THREADS 
+        addprocs(Sys.CPU_THREADS-nprocs()+1; kwargs...)
+    else
+        Int[] # make type-stable on the no-op branch
+    end
+end
 
 """
     addprocs(np::Integer; restrict=true, kwargs...) -> List of process identifiers


### PR DESCRIPTION
It seems common to say `addprocs()` to just get the number of processes to match the number of cores. And then you run the script again... and you get 2nprocs(). And 3nprocs()... I see this as a user trap with an easy fix. If `addprocs()` is "safe", then `addprocs()` at the top of a parallel script will always be smart and give you "the number of cores you probably want". This quick fix changes `addprocs()` to do just that.