### PR TITLE
non-power-of-two atomic handling

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1488,7 +1488,7 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
     if (type_is_ghost(elty))
         return ghostValue(jltype);
     AllocaInst *intcast = NULL;
-    if (!isboxed && Order != AtomicOrdering::NotAtomic && !elty->isIntOrPtrTy() && !elty->isFloatingPointTy()) {
+    if (!isboxed && Order != AtomicOrdering::NotAtomic && !elty->isIntOrPtrTy()) {
         const DataLayout &DL = jl_data_layout;
         unsigned nb = DL.getTypeSizeInBits(elty);
         intcast = ctx.builder.CreateAlloca(elty);
@@ -1563,7 +1563,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
     if (type_is_ghost(elty))
         return oldval;
     Value *intcast = nullptr;
-    if (!isboxed && Order != AtomicOrdering::NotAtomic && !elty->isIntOrPtrTy() && !elty->isFloatingPointTy()) {
+    if (!isboxed && Order != AtomicOrdering::NotAtomic && !elty->isIntOrPtrTy()) {
         const DataLayout &DL = jl_data_layout;
         unsigned nb = DL.getTypeSizeInBits(elty);
         if (!issetfield)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -719,7 +719,53 @@ JL_DLLEXPORT int jl_is_foreign_type(jl_datatype_t *dt)
 #error MAX_POINTERATOMIC_SIZE too large
 #endif
 #if MAX_POINTERATOMIC_SIZE >= 16
+#ifndef _P64
+#error 12 byte GC pool size not implemented for 32-bit
+#endif
 typedef __uint128_t uint128_t;
+typedef uint128_t jl_uatomicmax_t;
+#else
+typedef uint64_t jl_uatomicmax_t;
+#endif
+
+#if BYTE_ORDER != LITTLE_ENDIAN
+#error using masks for atomics (instead of memcpy like nb == 16) assumes little endian
+#endif
+
+static inline uint32_t zext_read32(const jl_value_t *x, size_t nb) JL_NOTSAFEPOINT
+{
+    uint32_t y = *(uint32_t*)x;
+    if (nb == 4)
+        return y;
+    else // if (nb == 3)
+        return 0xffffffu & y;
+}
+
+#if MAX_POINTERATOMIC_SIZE >= 8
+static inline uint64_t zext_read64(const jl_value_t *x, size_t nb) JL_NOTSAFEPOINT
+{
+    uint64_t y = *(uint64_t*)x;
+    if (nb == 8)
+        return y;
+    else if (nb == 7)
+        return 0xffffffffffffffu & y;
+    else if (nb == 6)
+        return 0xffffffffffffu & y;
+    else // if (nb == 5)
+        return 0xffffffffffu & y;
+}
+#endif
+
+#if MAX_POINTERATOMIC_SIZE >= 16
+static inline uint128_t zext_read128(const jl_value_t *x, size_t nb) JL_NOTSAFEPOINT
+{
+    uint128_t y = 0;
+    if (nb == 16)
+        y = *(uint128_t*)x;
+    else
+        memcpy(&y, x, nb);
+    return y;
+}
 #endif
 
 JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, const void *data)
@@ -744,16 +790,7 @@ JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, const void *data)
 
     jl_task_t *ct = jl_current_task;
     jl_value_t *v = jl_gc_alloc(ct->ptls, nb, bt);
-    switch (nb) {
-    case  1: *(uint8_t*) v = *(uint8_t*)data;    break;
-    case  2: *(uint16_t*)v = jl_load_unaligned_i16(data);   break;
-    case  4: *(uint32_t*)v = jl_load_unaligned_i32(data);   break;
-    case  8: *(uint64_t*)v = jl_load_unaligned_i64(data);   break;
-    case 16:
-        memcpy(jl_assume_aligned(v, 16), data, 16);
-        break;
-    default: memcpy(v, data, nb);
-    }
+    memcpy(jl_assume_aligned(v, sizeof(void*)), data, nb);
     return v;
 }
 
@@ -778,19 +815,24 @@ JL_DLLEXPORT jl_value_t *jl_atomic_new_bits(jl_value_t *dt, const char *data)
 
     jl_task_t *ct = jl_current_task;
     jl_value_t *v = jl_gc_alloc(ct->ptls, nb, bt);
-    switch (nb) {
-    case  1: *(uint8_t*) v = jl_atomic_load((uint8_t*)data);    break;
-    case  2: *(uint16_t*)v = jl_atomic_load((uint16_t*)data);   break;
-    case  4: *(uint32_t*)v = jl_atomic_load((uint32_t*)data);   break;
+    // data is aligned to the power of two,
+    // we will write too much of v, but the padding should exist
+    if (nb == 1)
+        *(uint8_t*) v = jl_atomic_load((uint8_t*)data);
+    else if (nb <= 2)
+        *(uint16_t*)v = jl_atomic_load((uint16_t*)data);
+    else if (nb <= 4)
+        *(uint32_t*)v = jl_atomic_load((uint32_t*)data);
 #if MAX_POINTERATOMIC_SIZE >= 8
-    case  8: *(uint64_t*)v = jl_atomic_load((uint64_t*)data);   break;
+    else if (nb <= 8)
+        *(uint64_t*)v = jl_atomic_load((uint64_t*)data);
 #endif
 #if MAX_POINTERATOMIC_SIZE >= 16
-    case 16: *(uint128_t*)v = jl_atomic_load((uint128_t*)data);        break;
+    else if (nb <= 16)
+        *(uint128_t*)v = jl_atomic_load((uint128_t*)data);
 #endif
-    default:
+    else
         abort();
-    }
     return v;
 }
 
@@ -798,20 +840,26 @@ JL_DLLEXPORT void jl_atomic_store_bits(char *dst, const jl_value_t *src, int nb)
 {
     // dst must have the required alignment for an atomic of the given size
     // src must be aligned by the GC
-    switch (nb) {
-    case  0:                                                   break;
-    case  1: jl_atomic_store((uint8_t*)dst, *(uint8_t*)src);   break;
-    case  2: jl_atomic_store((uint16_t*)dst, *(uint16_t*)src); break;
-    case  4: jl_atomic_store((uint32_t*)dst, *(uint32_t*)src); break;
+    // we may therefore read too much from src, but will zero the excess bits
+    // before the store (so that we can get faster cmpswap later)
+    if (nb == 0)
+        ;
+    else if (nb == 1)
+        jl_atomic_store((uint8_t*)dst, *(uint8_t*)src);
+    else if (nb == 2)
+        jl_atomic_store((uint16_t*)dst, *(uint16_t*)src);
+    else if (nb <= 4)
+        jl_atomic_store((uint32_t*)dst, zext_read32(src, nb));
 #if MAX_POINTERATOMIC_SIZE >= 8
-    case  8: jl_atomic_store((uint64_t*)dst, *(uint64_t*)src); break;
+    else if (nb <= 8)
+        jl_atomic_store((uint64_t*)dst, zext_read64(src, nb));
 #endif
 #if MAX_POINTERATOMIC_SIZE >= 16
-    case 16: jl_atomic_store((uint128_t*)dst, *(uint128_t*)src); break;
+    else if (nb <= 16)
+        jl_atomic_store((uint128_t*)dst, zext_read128(src, nb));
 #endif
-    default:
+    else
         abort();
-    }
 }
 
 JL_DLLEXPORT jl_value_t *jl_atomic_swap_bits(jl_value_t *dt, char *dst, const jl_value_t *src, int nb)
@@ -834,19 +882,22 @@ JL_DLLEXPORT jl_value_t *jl_atomic_swap_bits(jl_value_t *dt, char *dst, const jl
 
     jl_task_t *ct = jl_current_task;
     jl_value_t *v = jl_gc_alloc(ct->ptls, jl_datatype_size(bt), bt);
-    switch (nb) {
-    case  1: *(uint8_t*) v = jl_atomic_exchange((uint8_t*)dst, *(uint8_t*)src);    break;
-    case  2: *(uint16_t*)v = jl_atomic_exchange((uint16_t*)dst, *(uint16_t*)src);   break;
-    case  4: *(uint32_t*)v = jl_atomic_exchange((uint32_t*)dst, *(uint32_t*)src);   break;
+    if (nb == 1)
+        *(uint8_t*)v = jl_atomic_exchange((uint8_t*)dst, *(uint8_t*)src);
+    else if (nb == 2)
+        *(uint16_t*)v = jl_atomic_exchange((uint16_t*)dst, *(uint16_t*)src);
+    else if (nb <= 4)
+        *(uint32_t*)v = jl_atomic_exchange((uint32_t*)dst, zext_read32(src, nb));
 #if MAX_POINTERATOMIC_SIZE >= 8
-    case  8: *(uint64_t*)v = jl_atomic_exchange((uint64_t*)dst, *(uint64_t*)src);   break;
+    else if (nb <= 8)
+        *(uint64_t*)v = jl_atomic_exchange((uint64_t*)dst, zext_read64(src, nb));
 #endif
 #if MAX_POINTERATOMIC_SIZE >= 16
-    case 16: *(uint128_t*)v = jl_atomic_exchange((uint128_t*)dst, *(uint128_t*)src);   break;
+    else if (nb <= 16)
+        *(uint128_t*)v = jl_atomic_exchange((uint128_t*)dst, zext_read128(src, nb));
 #endif
-    default:
+    else
         abort();
-    }
     return v;
 }
 
@@ -855,41 +906,37 @@ JL_DLLEXPORT int jl_atomic_bool_cmpswap_bits(char *dst, const jl_value_t *expect
     // dst must have the required alignment for an atomic of the given size
     // n.b.: this can spuriously fail if there are padding bits, the caller should deal with that
     int success;
-    switch (nb) {
-    case  0: {
+    if (nb == 0) {
         success = 1;
-        break;
     }
-    case  1: {
+    else if (nb == 1) {
         uint8_t y = *(uint8_t*)expected;
         success = jl_atomic_cmpswap((uint8_t*)dst, &y, *(uint8_t*)src);
-        break;
     }
-    case  2: {
+    else if (nb == 2) {
         uint16_t y = *(uint16_t*)expected;
         success = jl_atomic_cmpswap((uint16_t*)dst, &y, *(uint16_t*)src);
-        break;
     }
-    case  4: {
-        uint32_t y = *(uint32_t*)expected;
-        success = jl_atomic_cmpswap((uint32_t*)dst, &y, *(uint32_t*)src);
-        break;
+    else if (nb <= 4) {
+        uint32_t y = zext_read32(expected, nb);
+        uint32_t z = zext_read32(src, nb);
+        success = jl_atomic_cmpswap((uint32_t*)dst, &y, z);
     }
 #if MAX_POINTERATOMIC_SIZE >= 8
-    case  8: {
-        uint64_t y = *(uint64_t*)expected;
-        success = jl_atomic_cmpswap((uint64_t*)dst, &y, *(uint64_t*)src);
-        break;
+    else if (nb <= 8) {
+        uint64_t y = zext_read64(expected, nb);
+        uint64_t z = zext_read64(src, nb);
+        success = jl_atomic_cmpswap((uint64_t*)dst, &y, z);
     }
 #endif
 #if MAX_POINTERATOMIC_SIZE >= 16
-    case 16: {
-        uint128_t y = *(uint128_t*)expected;
-        success = jl_atomic_cmpswap((uint128_t*)dst, &y, *(uint128_t*)src);
-        break;
+    else if (nb <= 16) {
+        uint128_t y = zext_read128(expected, nb);
+        uint128_t z = zext_read128(src, nb);
+        success = jl_atomic_cmpswap((uint128_t*)dst, &y, z);
     }
 #endif
-    default:
+    else {
         abort();
     }
     return success;
@@ -909,45 +956,42 @@ JL_DLLEXPORT jl_value_t *jl_atomic_cmpswap_bits(jl_datatype_t *dt, char *dst, co
     jl_value_t *y = jl_gc_alloc(ct->ptls, isptr ? nb : tuptyp->size, isptr ? dt : tuptyp);
     int success;
     jl_datatype_t *et = (jl_datatype_t*)jl_typeof(expected);
-    switch (nb) {
-    case  0: {
+    if (nb == 0) {
         success = (dt == et);
-        break;
     }
-    case  1: {
+    else if (nb == 1) {
         uint8_t *y8 = (uint8_t*)y;
+        assert(!dt->layout->haspadding);
         if (dt == et) {
             *y8 = *(uint8_t*)expected;
-            success = jl_atomic_cmpswap((uint8_t*)dst, y8, *(uint8_t*)src);
+            uint8_t z8 = *(uint8_t*)src;
+            success = jl_atomic_cmpswap((uint8_t*)dst, y8, z8);
         }
         else {
             *y8 = jl_atomic_load((uint8_t*)dst);
             success = 0;
         }
-        break;
     }
-    case  2: {
+    else if (nb == 2) {
         uint16_t *y16 = (uint16_t*)y;
+        assert(!dt->layout->haspadding);
         if (dt == et) {
             *y16 = *(uint16_t*)expected;
-            while (1) {
-                success = jl_atomic_cmpswap((uint16_t*)dst, y16, *(uint16_t*)src);
-                if (success || !dt->layout->haspadding || !jl_egal__bits(y, expected, dt))
-                    break;
-            }
+            uint16_t z16 = *(uint16_t*)src;
+            success = jl_atomic_cmpswap((uint16_t*)dst, y16, z16);
         }
         else {
             *y16 = jl_atomic_load((uint16_t*)dst);
             success = 0;
         }
-        break;
     }
-    case  4: {
+    else if (nb <= 4) {
         uint32_t *y32 = (uint32_t*)y;
         if (dt == et) {
-            *y32 = *(uint32_t*)expected;
+            *y32 = zext_read32(expected, nb);
+            uint32_t z32 = zext_read32(src, nb);
             while (1) {
-                success = jl_atomic_cmpswap((uint32_t*)dst, y32, *(uint32_t*)src);
+                success = jl_atomic_cmpswap((uint32_t*)dst, y32, z32);
                 if (success || !dt->layout->haspadding || !jl_egal__bits(y, expected, dt))
                     break;
             }
@@ -956,15 +1000,15 @@ JL_DLLEXPORT jl_value_t *jl_atomic_cmpswap_bits(jl_datatype_t *dt, char *dst, co
             *y32 = jl_atomic_load((uint32_t*)dst);
             success = 0;
         }
-        break;
     }
 #if MAX_POINTERATOMIC_SIZE >= 8
-    case  8: {
+    else if (nb <= 8) {
         uint64_t *y64 = (uint64_t*)y;
         if (dt == et) {
-            *y64 = *(uint64_t*)expected;
+            *y64 = zext_read64(expected, nb);
+            uint64_t z64 = zext_read64(src, nb);
             while (1) {
-                success = jl_atomic_cmpswap((uint64_t*)dst, y64, *(uint64_t*)src);
+                success = jl_atomic_cmpswap((uint64_t*)dst, y64, z64);
                 if (success || !dt->layout->haspadding || !jl_egal__bits(y, expected, dt))
                     break;
             }
@@ -973,16 +1017,16 @@ JL_DLLEXPORT jl_value_t *jl_atomic_cmpswap_bits(jl_datatype_t *dt, char *dst, co
             *y64 = jl_atomic_load((uint64_t*)dst);
             success = 0;
         }
-        break;
     }
 #endif
 #if MAX_POINTERATOMIC_SIZE >= 16
-    case 16: {
+    else if (nb <= 16) {
         uint128_t *y128 = (uint128_t*)y;
         if (dt == et) {
-            *y128 = *(uint128_t*)expected;
+            *y128 = zext_read128(expected, nb);
+            uint128_t z128 = zext_read128(src, nb);
             while (1) {
-                success = jl_atomic_cmpswap((uint128_t*)dst, y128, *(uint128_t*)src);
+                success = jl_atomic_cmpswap((uint128_t*)dst, y128, z128);
                 if (success || !dt->layout->haspadding || !jl_egal__bits(y, expected, dt))
                     break;
             }
@@ -991,10 +1035,9 @@ JL_DLLEXPORT jl_value_t *jl_atomic_cmpswap_bits(jl_datatype_t *dt, char *dst, co
             *y128 = jl_atomic_load((uint128_t*)dst);
             success = 0;
         }
-        break;
     }
 #endif
-    default:
+    else {
         abort();
     }
     if (isptr) {
@@ -1406,16 +1449,12 @@ static inline void memassign_safe(int hasptr, jl_value_t *parent, char *dst, con
     else {
         // src must be a heap box.
         assert(nb == jl_datatype_size(jl_typeof(src)));
+        if (nb >= 16) {
+            memcpy(dst, jl_assume_aligned(src, 16), nb);
+            return;
+        }
     }
-    switch (nb) {
-    case  0:                                               break;
-    case  1: *(uint8_t*)dst            = *(uint8_t*)src;   break;
-    case  2: jl_store_unaligned_i16(dst, *(uint16_t*)src); break;
-    case  4: jl_store_unaligned_i32(dst, *(uint32_t*)src); break;
-    case  8: jl_store_unaligned_i64(dst, *(uint64_t*)src); break;
-    case 16: memcpy(dst, jl_assume_aligned(src, 16), 16);  break;
-    default: memcpy(dst, src, nb);                         break;
-    }
+    memcpy(dst, jl_assume_aligned(src, sizeof(void*)), nb);
 }
 
 void set_nth_field(jl_datatype_t *st, jl_value_t *v, size_t i, jl_value_t *rhs, int isatomic) JL_NOTSAFEPOINT

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -401,6 +401,8 @@ static inline std::vector<uint8_t> serialize_target_data(llvm::StringRef name,
 {
     std::vector<uint8_t> res;
     auto add_data = [&] (const void *data, size_t sz) {
+        if (sz == 0)
+            return;
         size_t old_sz = res.size();
         res.resize(old_sz + sz);
         memcpy(&res[old_sz], data, sz);

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -115,7 +115,7 @@ test_field_operators(ARefxy{Complex{Int128}}(123_10, 123_20))
 test_field_operators(ARefxy{PadIntA}(123_10, 123_20))
 test_field_operators(ARefxy{PadIntB}(123_10, 123_20))
 #FIXME: test_field_operators(ARefxy{Int24}(123_10, 123_20))
-#FIXME: test_field_operators(ARefxy{Float64}(123_10, 123_20))
+test_field_operators(ARefxy{Float64}(123_10, 123_20))
 
 @noinline function _test_field_orderings(r, x, y)
     @nospecialize x y
@@ -277,8 +277,8 @@ test_field_orderings(ARefxy{Any}(true, false), true, false)
 test_field_orderings(ARefxy{Union{Nothing,Missing}}(nothing, missing), nothing, missing)
 test_field_orderings(ARefxy{Union{Nothing,Int}}(nothing, 123_1), nothing, 123_1)
 test_field_orderings(Complex{Int128}(10, 30), Complex{Int128}(20, 40))
-#FIXME: test_field_orderings(10.0, 20.0)
-#FIXME: test_field_orderings(NaN, Inf)
+test_field_orderings(10.0, 20.0)
+test_field_orderings(NaN, Inf)
 
 struct UndefComplex{T}
     re::T


### PR DESCRIPTION
We were not handling non-power-of-two sizes, which is now fixed here. We always write trailing padding as zeros to minimize cmpswap failures (though we are tolerant of other values being present). In the future, we could consider potentially also extending that to all padding bytes being zeroed, but typically zeroinit is not the default, so it may not suffice to work.