### PR TITLE
WIP: faster 1 and 2 arg atan methods

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -526,8 +526,8 @@ function atan(x::T) where T<:Union{Float32, Float64}
         end
     end
     # end of argument reduction
-    p, q = atan_pq(x)
-    z = hi - (muladd(x, (p + q), - lo) - x)
+    p = atan_pq(x)
+    z = hi - (muladd(x, p, - lo) - x)
     copysign(z, x_orig)
 end
 # atan2 methods
@@ -579,7 +579,7 @@ function atan(y::T, x::T) where T<:Union{Float32, Float64}
 		println((z,m))
 		m = 2 - (m&1)
     else #safe to do y/x
-        z = myatan(abs(y/x))
+        z = atan(abs(y/x))
     end
 
     if m == 1

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -572,8 +572,6 @@ function atan(y::T, x::T) where T<:Union{Float32, Float64}
     elseif y > x*ATAN2_RATIO_THRESHOLD(T) # |y/x| >  threshold
         z = T(0.5)*(T(pi) + ATAN2_PI_LO(T))
         m&=1;
-    elseif x<0 && y < -x*ATAN2_RATIO_THRESHOLD(T) # 0 > |y|/x > threshold
-        z = zero(T)
     else #safe to do y/x
         z = atan(abs(y/x))
     end

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -453,96 +453,73 @@ end
 # atan methods
 ATAN_1_O_2_HI(::Type{Float64}) = 4.63647609000806093515e-01 # atan(0.5).hi
 ATAN_2_O_2_HI(::Type{Float64}) = 7.85398163397448278999e-01 # atan(1.0).hi
-ATAN_3_O_2_HI(::Type{Float64}) = 9.82793723247329054082e-01 # atan(1.5).hi
 ATAN_INF_HI(::Type{Float64}) = 1.57079632679489655800e+00 # atan(Inf).hi
 
 ATAN_1_O_2_HI(::Type{Float32}) = 4.6364760399f-01 # atan(0.5).hi
 ATAN_2_O_2_HI(::Type{Float32}) = 7.8539812565f-01 # atan(1.0).hi
-ATAN_3_O_2_HI(::Type{Float32}) = 9.8279368877f-01 # atan(1.5).hi
 ATAN_INF_HI(::Type{Float32}) = 1.5707962513f+00 # atan(Inf).hi
 
 ATAN_1_O_2_LO(::Type{Float64}) = 2.26987774529616870924e-17 # atan(0.5).lo
 ATAN_2_O_2_LO(::Type{Float64}) = 3.06161699786838301793e-17 # atan(1.0).lo
-ATAN_3_O_2_LO(::Type{Float64}) = 1.39033110312309984516e-17 # atan(1.5).lo
 ATAN_INF_LO(::Type{Float64}) = 6.12323399573676603587e-17 # atan(Inf).lo
 
 ATAN_1_O_2_LO(::Type{Float32}) = 5.0121582440f-09  # atan(0.5).lo
 ATAN_2_O_2_LO(::Type{Float32}) = 3.7748947079f-08  # atan(1.0).lo
-ATAN_3_O_2_LO(::Type{Float32}) = 3.4473217170f-08  # atan(1.5).lo
 ATAN_INF_LO(::Type{Float32}) = 7.5497894159f-08  # atan(Inf).lo
 
-ATAN_LARGE_X(::Type{Float64}) = 2.0^66 # seems too large? 2.0^60 gives the same
-ATAN_SMALL_X(::Type{Float64}) = 2.0^-27
-ATAN_LARGE_X(::Type{Float32}) = 2.0f0^26
-ATAN_SMALL_X(::Type{Float32}) = 2.0f0^-12
-
-atan_p(z::Float64, w::Float64) = z*@horner(w,
+atan_p(w::Float64) = @horner(w,
      3.33333333333329318027e-01,
      1.42857142725034663711e-01,
      9.09088713343650656196e-02,
      6.66107313738753120669e-02,
      4.97687799461593236017e-02,
      1.62858201153657823623e-02)
-atan_q(w::Float64) = w*@horner(w,
+atan_q(w::Float64) = @horner(w,
      -1.99999999998764832476e-01,
      -1.11111104054623557880e-01,
      -7.69187620504482999495e-02,
      -5.83357013379057348645e-02,
      -3.65315727442169155270e-02)
-atan_p(z::Float32, w::Float32) = z*@horner(w, 3.3333328366f-01,  1.4253635705f-01, 6.1687607318f-02)
-atan_q(w::Float32) = w*@horner(w, -1.9999158382f-01, -1.0648017377f-01)
+atan_p(w::Float32) = @horner(w, 3.3333328366f-01,  1.4253635705f-01, 6.1687607318f-02)
+atan_q(w::Float32) = @horner(w, -1.9999158382f-01, -1.0648017377f-01)
 @inline function atan_pq(x)
     x² = x*x
     x⁴ = x²*x²
     # break sum from i=0 to 10 aT[i]z**(i+1) into odd and even poly
-    atan_p(x², x⁴), atan_q(x⁴)
+    x² * muladd(x², atan_q(x⁴), atan_p(x⁴))
 end
 
 function atan(x::T) where T<:Union{Float32, Float64}
     # Method
     #   1. Reduce x to positive by atan(x) = -atan(-x).
-    #   2. According to the integer k=4t+0.25 chopped, t=x, the argument
-    #      is further reduced to one of the following intervals and the
-    #      arctangent of t is evaluated by the corresponding formula:
+    #   2. The argument is further reduced to one of the following intervals 
+	#      and the arctangent of t is evaluated by the corresponding formula:
     #
-    #      [0,7/16]      atan(x) = t-t^3*(a1+t^2*(a2+...(a10+t^2*a11)...)
-    #      [7/16,11/16]  atan(x) = atan(1/2) + atan( (t-0.5)/(1+t/2) )
-    #      [11/16.19/16] atan(x) = atan( 1 ) + atan( (t-1)/(1+t) )
-    #      [19/16,39/16] atan(x) = atan(3/2) + atan( (t-1.5)/(1+1.5t) )
-    #      [39/16,INF]   atan(x) = atan(INF) + atan( -1/t )
+    #      [0,     7/16]   atan(x) = x-x^3*(a1+x^2*(a2+...(a10+x^2*a11)...)
+    #      [7/16,  11/16]  atan(x) = atan(1/2) + atan( (x-0.5)/(1+x/2) )
+    #      [11/16, 5/2]    atan(x) = atan( 1 ) + atan( (x-1)/(1+x) )
+    #      [5/2,   INF]    atan(x) = atan(INF) + atan( -1/x )
     #
     #  If isnan(x) is true, then the nan value will eventually be passed to
     #  atan_pq(x) and return the appropriate nan value.
 
     absx = abs(x)
-    if absx >= ATAN_LARGE_X(T)
-        return copysign(T(1.5707963267948966), x)
-    end
-    if absx < T(7/16)
-        # no reduction needed
-        if absx < ATAN_SMALL_X(T)
-            return x
-        end
-        p, q = atan_pq(x)
-        return x - x*(p + q)
-    end
-    xsign = sign(x)
-    if absx < T(19/16) # 7/16 <= |x| < 19/16
-        if absx < T(11/16) # 7/16 <= |x| <11/16
+    x_orig = x
+    if absx < T(11/16)
+		if absx < T(7/16)
+			# no reduction needed
+			hi = lo = zero(T)
+        else							# 7/16 <= |x| <11/16
             hi = ATAN_1_O_2_HI(T)
             lo = ATAN_1_O_2_LO(T)
             x = (T(2.0)*absx - T(1.0))/(T(2.0) + absx)
-        else # 11/16 <= |x| < 19/16
+        end
+    else
+        if absx < T(2.5)  				# 11/16 <= |x| < 5/2
             hi = ATAN_2_O_2_HI(T)
             lo = ATAN_2_O_2_LO(T)
             x  = (absx - T(1.0))/(absx + T(1.0))
-        end
-    else
-        if absx < T(39/16)  # 19/16 <= |x| < 39/16
-            hi = ATAN_3_O_2_HI(T)
-            lo = ATAN_3_O_2_LO(T)
-            x = (absx - T(1.5))/(T(1.0) + T(1.5)*absx)
-        else # 39/16 <= |x| < upper threshold (2.0^66 or 2.0f0^26)
+        else 							# 5.2 <= |x| 
             hi = ATAN_INF_HI(T)
             lo = ATAN_INF_LO(T)
             x  = -T(1.0)/absx
@@ -550,17 +527,14 @@ function atan(x::T) where T<:Union{Float32, Float64}
     end
     # end of argument reduction
     p, q = atan_pq(x)
-    z = hi - ((x*(p + q) - lo) - x)
-    copysign(z, xsign)
+    z = hi - (muladd(x, (p + q), - lo) - x)
+    copysign(z, x_orig)
 end
 # atan2 methods
 ATAN2_PI_LO(::Type{Float32}) = -8.7422776573f-08
-ATAN2_RATIO_BIT_SHIFT(::Type{Float32}) = 23
-ATAN2_RATIO_THRESHOLD(::Type{Float32}) = 26
-
 ATAN2_PI_LO(::Type{Float64}) = 1.2246467991473531772E-16
-ATAN2_RATIO_BIT_SHIFT(::Type{Float64}) = 20
-ATAN2_RATIO_THRESHOLD(::Type{Float64}) = 60
+ATAN2_RATIO_THRESHOLD(::Type{Float32}) = 1f7
+ATAN2_RATIO_THRESHOLD(::Type{Float64}) = 1e16
 
 function atan(y::T, x::T) where T<:Union{Float32, Float64}
     # Method :
@@ -581,76 +555,40 @@ function atan(y::T, x::T) where T<:Union{Float32, Float64}
     #    S8) ATAN2(+-INF,+INF ) is +-pi/4 ;
     #    S9) ATAN2(+-INF,-INF ) is +-3pi/4;
     #    S10) ATAN2(+-INF, (anything but,0,NaN, and INF)) is +-pi/2;
-    if isnan(x) || isnan(y) # S1 or S2
-        return T(NaN)
-    end
-
-    if x == T(1.0) # then y/x = y and x > 0, see M2
-        return atan(y)
-    end
     # generate an m ∈ {0, 1, 2, 3} to branch off of
-    m = 2*signbit(x) + 1*signbit(y)
+    m = 2*signbit(x) + 1*signbit(y)+1
 
     if iszero(y)
-        if m == 0 || m == 1
-            return y # atan(+-0, +anything) = +-0
-        elseif m == 2
-            return T(pi) # atan(+0, -anything) = pi
-        elseif m == 3
-            return -T(pi) # atan(-0, -anything) =-pi
-        end
+		return (y,y,T(pi),-T(pi))[m]
     elseif iszero(x)
         return flipsign(T(pi)/2, y)
     end
 
     if isinf(x)
         if isinf(y)
-            if m == 0
-                return T(pi)/4  # atan(+Inf), +Inf))
-            elseif m == 1
-                return -T(pi)/4 # atan(-Inf), +Inf))
-            elseif m == 2
-                return 3*T(pi)/4 # atan(+Inf, -Inf)
-            elseif m == 3
-                return -3*T(pi)/4 # atan(-Inf,-Inf)
-            end
+			return (T(pi)/4,-T(pi)/4,3*T(pi)/4,-3*T(pi)/4)[m]
         else
-            if m == 0
-                return zero(T)  # atan(+...,+Inf) */
-            elseif m == 1
-                return -zero(T) # atan(-...,+Inf) */
-            elseif m == 2
-                return T(pi)    # atan(+...,-Inf) */
-            elseif m == 3
-                return -T(pi)   # atan(-...,-Inf) */
-            end
+			return (zero(T),-zero(T),T(pi),-T(pi))[m]
         end
     end
-
     # x wasn't Inf, but y is
     isinf(y) && return copysign(T(pi)/2, y)
 
-    ypw = poshighword(y)
-    xpw = poshighword(x)
-    # compute y/x for Float32
-    k = reinterpret(Int32, ypw-xpw)>>ATAN2_RATIO_BIT_SHIFT(T)
-
-    if k > ATAN2_RATIO_THRESHOLD(T) # |y/x| >  threshold
+    if abs(y) > abs(x)*ATAN2_RATIO_THRESHOLD(T)
         z=T(pi)/2+T(0.5)*ATAN2_PI_LO(T)
-        m&=1;
-    elseif x<0 && k < -ATAN2_RATIO_THRESHOLD(T) # 0 > |y|/x > threshold
-        z = zero(T)
+		println((z,m))
+		m = 2 - (m&1)
     else #safe to do y/x
-        z = atan(abs(y/x))
+        z = myatan(abs(y/x))
     end
 
-    if m == 0
+    if m == 1
         return z # atan(+,+)
-    elseif m == 1
-        return -z # atan(-,+)
     elseif m == 2
+        return -z # atan(-,+)
+    elseif m == 3
         return T(pi)-(z-ATAN2_PI_LO(T)) # atan(+,-)
-    else # default case m == 3
+    else # default case m == 4
         return (z-ATAN2_PI_LO(T))-T(pi) # atan(-,-)
     end
 end


### PR DESCRIPTION
This removes a bunch of unnecessary branches that slowed down the code. The only functional difference is that it has slightly higher error for `atan(x)` when x is between 19/16 and 2.5 (increase form .83 ULP to .9ULP). In exchange this provides a 20% speedup for `Float32` and an 11% speedup for `Float64`. The atan2 code also sees a 10% improvement.

This is mainly WIP since I intend to hook `atand` into this code directly so that it doesn't have a speed and accuracy penalty.