### PR TITLE
Code coverage: fix the code coverage pipeline

### DIFF
--- a/.buildkite/coverage-linux64/run_tests_base.jl
+++ b/.buildkite/coverage-linux64/run_tests_base.jl
@@ -30,8 +30,7 @@ const ncores = min(Sys.CPU_THREADS, Threads.nthreads())
 @info "" ncores Sys.CPU_THREADS Threads.nthreads()
 
 try
-    # Base.runtests(tests; ncores) # TODO: uncomment this line
-    Base.runtests(["compiler"]; ncores) # TODO: delete this line
+    Base.runtests(tests; ncores)
 catch ex
     @error "" exception=(ex, catch_backtrace())
 end

--- a/.buildkite/coverage-linux64/run_tests_base.jl
+++ b/.buildkite/coverage-linux64/run_tests_base.jl
@@ -30,7 +30,8 @@ const ncores = min(Sys.CPU_THREADS, Threads.nthreads())
 @info "" ncores Sys.CPU_THREADS Threads.nthreads()
 
 try
-    Base.runtests(tests; ncores)
+    # Base.runtests(tests; ncores) # TODO: uncomment this line
+    Base.runtests(["compiler"]; ncores) # TODO: delete this line
 catch ex
     @error "" exception=(ex, catch_backtrace())
 end


### PR DESCRIPTION
The uploads to Codecov and Coveralls are failing because we are in a "detached HEAD" situation.

This PR should fix the failures by getting the branch and commit information from the Buildkite environment variables.