### PR TITLE
Fix eltype of zero(::AbstractVector)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1133,7 +1133,7 @@ function copymutable(a::AbstractArray)
 end
 copymutable(itr) = collect(itr)
 
-zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
+zero(x::AbstractArray{T}) where {T} = fill!(similar(x, typeof(zero(T))), zero(T))
 
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both IndexLinear and IndexCartesian arrays

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2908,3 +2908,13 @@ end
     @test [fill(1); fill(2, (2,1,1))] == reshape([1; 2; 2], (3, 1, 1))
     @test_throws DimensionMismatch [fill(1); rand(2, 2, 2)]
 end
+
+@testset "eltype of zero for arrays (issue #41348)" begin
+    for a in Any[[DateTime(2020), DateTime(2021)], [Date(2000), Date(2001)], [Time(1), Time(2)]]
+        @test a + zero(a) == a
+        b = reshape(a, :, 1)
+        @test b + zero(b) == b
+        c = view(b, 1:1, 1:1)
+        @test c + zero(c) == c
+    end
+end


### PR DESCRIPTION
Fixes #41348. Now

```julia
julia> a = [DateTime(2020), DateTime(2021)];

julia> a + zero(a) == a
true

julia> zero(a)
2-element Vector{Millisecond}:
 0 milliseconds
 0 milliseconds

julia> zero(a[1]) == zero(a)[1]
true
```