### PR TITLE
support ordinal types in `diff(AbstractRange)`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -970,7 +970,7 @@ function diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
 end
 function diff(r::AbstractRange{T}; dims::Integer=1) where {T}
     dims == 1 || throw(ArgumentError("dimension $dims out of range (1:1)"))
-    return T[@inbounds r[i+1] - r[i] for i in firstindex(r):lastindex(r)-1]
+    return [@inbounds r[i+1] - r[i] for i in firstindex(r):lastindex(r)-1]
 end
 
 ### from abstractarray.jl

--- a/stdlib/Dates/test/arithmetic.jl
+++ b/stdlib/Dates/test/arithmetic.jl
@@ -508,4 +508,13 @@ end
     end
 end
 
+@testset "Diff of dates" begin
+    for t ∈ [Day, Week, Hour, Minute]
+        a = DateTime(2021,1,1):t(1):DateTime(2021,1,2)
+        d = diff(a)
+        @test d == diff(collect(a))
+        @test eltype(d) === typeof(a[1] - a[2])
+    end
+end
+
 end

--- a/stdlib/Dates/test/arithmetic.jl
+++ b/stdlib/Dates/test/arithmetic.jl
@@ -510,7 +510,7 @@ end
 
 @testset "Diff of dates" begin
     for t ∈ [Day, Week, Hour, Minute]
-        a = DateTime(2021,1,1):t(1):DateTime(2021,1,2)
+        a = DateTime(2021,1,1):t(1):DateTime(2021,2,1)
         d = diff(a)
         @test d == diff(collect(a))
         @test eltype(d) === typeof(a[1] - a[2])


### PR DESCRIPTION
fix #41336
