### PR TITLE
Type assertion in take!(::RemoteChannel)

### DIFF
--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -544,7 +544,7 @@ fetch_ref(rid, args...) = fetch(lookup_ref(rid).c, args...)
 Wait for and get a value from a [`RemoteChannel`](@ref). Exceptions raised are the
 same as for a [`Future`](@ref). Does not remove the item fetched.
 """
-fetch(r::RemoteChannel, args...) = call_on_owner(fetch_ref, r, args...)
+fetch(r::RemoteChannel, args...) = call_on_owner(fetch_ref, r, args...)::eltype(r)
 
 isready(rv::RemoteValue, args...) = isready(rv.c, args...)
 
@@ -623,7 +623,7 @@ end
 Fetch value(s) from a [`RemoteChannel`](@ref) `rr`,
 removing the value(s) in the process.
 """
-take!(rr::RemoteChannel, args...) = call_on_owner(take_ref, rr, myid(), args...)
+take!(rr::RemoteChannel, args...) = call_on_owner(take_ref, rr, myid(), args...)::eltype(rr)
 
 # close and isopen are not supported on Future
 


### PR DESCRIPTION
Since the `eltype` of a `RemoteChannel` is known, the result of `fetch` or `take!` on a `RemoteChannel` may be asserted to be of the correct type. This might help with type-inference in subsequent code.

On nightly/master
```julia
julia> r = RemoteChannel(() -> Channel{Int}(1))
RemoteChannel{Channel{Int64}}(1, 1, 1)

julia> @code_warntype fetch(r)
MethodInstance for fetch(::RemoteChannel{Channel{Int64}})
  from fetch(r::RemoteChannel, args...) in Distributed at /home/jishnu/Downloads/julia/julia-d1145d4569/share/julia/stdlib/v1.8/Distributed/src/remotecall.jl:547
Arguments
  #self#::Core.Const(fetch)
  r::RemoteChannel{Channel{Int64}}
  args::Tuple{}
Body::Any
1 ─ %1 = Core.tuple(Distributed.fetch_ref, r)::Tuple{typeof(Distributed.fetch_ref), RemoteChannel{Channel{Int64}}}
│   %2 = Core._apply_iterate(Base.iterate, Distributed.call_on_owner, %1, args)::Any
└──      return %2

julia> @code_warntype take!(r)
MethodInstance for take!(::RemoteChannel{Channel{Int64}})
  from take!(rr::RemoteChannel, args...) in Distributed at /home/jishnu/Downloads/julia/julia-d1145d4569/share/julia/stdlib/v1.8/Distributed/src/remotecall.jl:626
Arguments
  #self#::Core.Const(take!)
  rr::RemoteChannel{Channel{Int64}}
  args::Tuple{}
Body::Any
1 ─ %1 = Distributed.myid()::Int64
│   %2 = Core.tuple(Distributed.take_ref, rr, %1)::Tuple{typeof(Distributed.take_ref), RemoteChannel{Channel{Int64}}, Int64}
│   %3 = Core._apply_iterate(Base.iterate, Distributed.call_on_owner, %2, args)::Any
└──      return %3
```

After this PR:
```julia
julia> @code_warntype fetch(r)
MethodInstance for fetch(::RemoteChannel{Channel{Int64}})
  from fetch(r::RemoteChannel, args...) in Distributed at /home/jishnu/julia/stdlib/Distributed/src/remotecall.jl:547
Arguments
  #self#::Core.Const(fetch)
  r::RemoteChannel{Channel{Int64}}
  args::Tuple{}
Body::Int64
1 ─ %1 = Core.tuple(Distributed.fetch_ref, r)::Tuple{typeof(Distributed.fetch_ref), RemoteChannel{Channel{Int64}}}
│   %2 = Core._apply_iterate(Base.iterate, Distributed.call_on_owner, %1, args)::Any
│   %3 = Distributed.eltype(r)::Core.Const(Int64)
│   %4 = Core.typeassert(%2, %3)::Int64
└──      return %4

julia> @code_warntype take!(r)
MethodInstance for take!(::RemoteChannel{Channel{Int64}})
  from take!(rr::RemoteChannel, args...) in Distributed at /home/jishnu/julia/stdlib/Distributed/src/remotecall.jl:626
Arguments
  #self#::Core.Const(take!)
  rr::RemoteChannel{Channel{Int64}}
  args::Tuple{}
Body::Int64
1 ─ %1 = Distributed.myid()::Int64
│   %2 = Core.tuple(Distributed.take_ref, rr, %1)::Tuple{typeof(Distributed.take_ref), RemoteChannel{Channel{Int64}}, Int64}
│   %3 = Core._apply_iterate(Base.iterate, Distributed.call_on_owner, %2, args)::Any
│   %4 = Distributed.eltype(rr)::Core.Const(Int64)
│   %5 = Core.typeassert(%3, %4)::Int64
└──      return %5
```