### PR TITLE
`dlopen()` our `libblas` and `liblapack` within `libjulia-internal`

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -576,8 +576,13 @@ function __init__()
     try
         libblas_path = find_library_path(Base.libblas_name)
         liblapack_path = find_library_path(Base.liblapack_name)
+        # We manually `dlopen()` these libraries here, so that we search with `libjulia-internal`'s
+        # `RPATH` and not `libblastrampoline's`.  Once it's been opened, when LBT tries to open it,
+        # it will find the library already loaded.
+        libblas_path = Libdl.dlpath(Libdl.dlopen(libblas_path))
         BLAS.lbt_forward(libblas_path; clear=true)
         if liblapack_path != libblas_path
+            liblapack_path = Libdl.dlpath(Libdl.dlopen(liblapack_path))
             BLAS.lbt_forward(liblapack_path)
         end
         BLAS.check()


### PR DESCRIPTION
Fixes #41388

When loading our `libblas` and `liblapack` for the first time, we may
need to rely upon an `RPATH` that has been embedded within
`libjulia-internal`.  If we use `libblastrampoline` to perform the
actual `dlopen()`, however, we don't have that `RPATH` at hand.

To fix this, we instead `dlopen()` the library first, to force the
proper loading of the library (which loads the library and its `SONAME`
into our process), which allows `libblastrampoline`'s `dlopen()` to
immediately succeed, along the happy path of finding the library already
loaded.