### PR TITLE
restrict getindex on `MethodList` to `Integer`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -925,7 +925,7 @@ mutable struct MethodList <: AbstractArray{Method,1}
 end
 
 size(m::MethodList) = size(m.ms)
-getindex(m::MethodList, i) = m.ms[i]
+getindex(m::MethodList, i::Integer) = m.ms[i]
 
 function MethodList(mt::Core.MethodTable)
     ms = Method[]


### PR DESCRIPTION
This method was added in https://github.com/JuliaLang/julia/pull/40863 but the open type on the index easily creates ambiguity situations, see e.g. https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/aa3a19f_vs_dd12291/AbstractTrees.1.7.0-beta1-ef3861cb06.log