### PR TITLE
eigensolvers for Hessenberg matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -396,6 +396,16 @@ function dot(x::AbstractVector, H::UpperHessenberg, y::AbstractVector)
     return r
 end
 
+function eigvals!(H::UpperHessenberg{<:BlasComplex, <:StridedMatrix{<:BlasComplex}}; sortby::Union{Function,Nothing}=eigsortby)
+    ilo, ihi, _ = LAPACK.gebal!('S', triu!(H.data, -1))
+    return sorteig!(LAPACK.hseqr!('E', H.data)[2], sortby)
+end
+function eigvals!(H::UpperHessenberg{<:BlasReal, <:StridedMatrix{<:BlasReal}}; sortby::Union{Function,Nothing}=eigsortby)
+    ilo, ihi, _ = LAPACK.gebal!('S', triu!(H.data, -1))
+    _, valsre, valsim = LAPACK.hseqr!('E', H.data)
+    return sorteig!(iszero(valsim) ? valsre : complex.(valsre, valsim), sortby)
+end
+
 ######################################################################################
 # Hessenberg factorizations Q(H+μI)Q' of A+μI:
 

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -1901,6 +1901,67 @@ versions prior to 3.6.0.
 ggsvd!(jobu::AbstractChar, jobv::AbstractChar, jobq::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
 
 
+for (hseqr, elty) in ((:dhseqr_,:Float64), (:shseqr_,:Float32))
+    @eval begin
+        function hseqr!(job::AbstractChar,  H::AbstractMatrix{$elty})
+            require_one_based_indexing(H)
+            chkstride1(H)
+            n = checksquare(H)
+            ilo, ihi = 1, n
+            compz = 'N' # not computing Schur vectors
+            ldh = max(1, stride(H, 2))
+            Wr = Vector{$elty}(undef, n)
+            Wi = Vector{$elty}(undef, n)
+            work = Vector{$elty}(undef, 1)
+            lwork = BlasInt(-1)
+            info = Ref{BlasInt}()
+            for i = 1:2  # first call returns lwork as work[1]
+                ccall((@blasfunc($hseqr), libblastrampoline), Cvoid,
+                    (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt},
+                     Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ref{BlasInt},
+                     Ptr{$elty}, Ref{BlasInt}, Ref{BlasInt}),
+                    job, compz, n, ilo, ihi, H, ldh, Wr, Wi, C_NULL, 1, work, lwork, info)
+                chklapackerror(info[])
+                if i == 1
+                    lwork = BlasInt(work[1])
+                    resize!(work, lwork)
+                end
+            end
+            return H, Wr, Wi
+        end
+    end
+end
+
+for (hseqr, elty) in ((:zhseqr_,:ComplexF64), (:chseqr_,:ComplexF32))
+    @eval begin
+        function hseqr!(job::AbstractChar,  H::AbstractMatrix{$elty})
+            require_one_based_indexing(H)
+            chkstride1(H)
+            n = checksquare(H)
+            ilo, ihi = 1, n
+            compz = 'N' # not computing Schur vectors
+            ldh = max(1, stride(H, 2))
+            W = Vector{$elty}(undef, n)
+            work = Vector{$elty}(undef, 1)
+            lwork = BlasInt(-1)
+            info = Ref{BlasInt}()
+            for i = 1:2  # first call returns lwork as work[1]
+                ccall((@blasfunc($hseqr), libblastrampoline), Cvoid,
+                    (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt},
+                     Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ref{BlasInt},
+                     Ptr{$elty}, Ref{BlasInt}, Ref{BlasInt}),
+                    job, compz, n, ilo, ihi, H, ldh, W, C_NULL, 1, work, lwork, info)
+                chklapackerror(info[])
+                if i == 1
+                    lwork = BlasInt(work[1])
+                    resize!(work, lwork)
+                end
+            end
+            return H, W
+        end
+    end
+end
+
 for (f, elty) in ((:dggsvd3_, :Float64),
                   (:sggsvd3_, :Float32))
     @eval begin


### PR DESCRIPTION
WIP to fix JuliaLang/LinearAlgebra.jl#858.

To do:
- [x] `eigvals(H)`
- [ ] `eigvals(H,U)` where `U` is upper-triangular
- [ ] `eigvecs` and `eigen`
- [ ] `schur`
- [ ] tests
- [ ] documentation

Currently very incomplete, but the `eigvals` alone might be useful to some folks so I thought it would be worth posting.