### PR TITLE
make "Add information to passing tests" a bit more backwards compatible

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -86,7 +86,7 @@ struct Pass <: Result
     data
     value
     source::Union{Nothing,LineNumberNode}
-    function Pass(test_type::Symbol, orig_expr, data, thrown, source)
+    function Pass(test_type::Symbol, orig_expr, data, thrown, source=nothing)
         return new(test_type, orig_expr, data, thrown isa String ? "String" : thrown, source)
     end
 end


### PR DESCRIPTION
Helps people creating `Pass` instances manually (e.g. https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/aa3a19f_vs_dd12291/Expect.1.7.0-beta1-ef3861cb06.log).

From https://github.com/JuliaLang/julia/pull/36879