### PR TITLE
don't use pipe operator for `throw`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2300,8 +2300,8 @@ function _typed_hvncat(::Type{T}, dims::Tuple{Vararg{Int, N}}, row_first::Bool, 
         len += cat_length(a)
     end
     outlen = prod(outdims)
-    outlen == 0 && ArgumentError("too few elements in arguments, unable to infer dimensions") |> throw
-    len == outlen || ArgumentError("too many elements in arguments; expected $(outlen), got $(len)") |> throw
+    outlen == 0 && throw(ArgumentError("too few elements in arguments, unable to infer dimensions"))
+    len == outlen || throw(ArgumentError("too many elements in arguments; expected $(outlen), got $(len)"))
 
     # copy into final array
     A = cat_similar(as[1], T, outdims)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -141,7 +141,7 @@ StridedVecOrMat{T} = Union{StridedVector{T}, StridedMatrix{T}}
 stride(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}, i::Int) = _stride(a, i)
 
 function stride(a::ReinterpretArray, i::Int)
-    a.parent isa StridedArray || ArgumentError("Parent must be strided.") |> throw
+    a.parent isa StridedArray || throw(ArgumentError("Parent must be strided."))
     return _stride(a, i)
 end
 
@@ -157,7 +157,7 @@ function _stride(a, i)
 end
 
 function strides(a::ReinterpretArray)
-    a.parent isa StridedArray || ArgumentError("Parent must be strided.") |> throw
+    a.parent isa StridedArray || throw(ArgumentError("Parent must be strided."))
     size_to_strides(1, size(a)...)
 end
 strides(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}) = size_to_strides(1, size(a)...)


### PR DESCRIPTION
I have nothing against `|>`, but this seems like a strange use of it and is not consistent with most code in Base. It's also handy to be able to grep for e.g. `throw(ArgumentError`.