### PR TITLE
add a GC safepoint in Task.wait

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -818,6 +818,7 @@ end
 end
 
 function wait()
+    GC.safepoint()
     W = Workqueues[Threads.threadid()]
     poptask(W)
     result = try_yieldto(ensure_rescheduled)


### PR DESCRIPTION
This gives GC a chance to run during a task switch,
in addition to being triggered by allocations.

Without this, non-allocating tasks may fail to stop for
a long time, even if they're doing IO or calling `yield`
explicitly, preventing us from stopping the world for GC.

Fixes #40972 (I think?)

cc @NHDaly @dewilson @vchuravy 