### PR TITLE
make failure to precompile a method return a value instead of a unconditionally warn

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1926,7 +1926,14 @@ function precompile(@nospecialize(f), args::Tuple)
     precompile(Tuple{Core.Typeof(f), args...})
 end
 
-precompile(argt::Type) = ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
+const ENABLE_PRECOMPILE_WARNINGS = Ref(false)
+function precompile(argt::Type)
+    ret = ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
+    if !ret && ENABLE_PRECOMPILE_WARNINGS[]
+        @warn "Inactive precompile statement" maxlog=100 form=argt _module=nothing _file=nothing _line=0
+    end
+    return ret
+end
 
 precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing))
 precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), String))

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1926,13 +1926,7 @@ function precompile(@nospecialize(f), args::Tuple)
     precompile(Tuple{Core.Typeof(f), args...})
 end
 
-function precompile(argt::Type)
-    success = ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
-    if !success
-        @debug "Inactive precompile statement" maxlog=10 form=argt _module=nothing _file=nothing _line=0
-    end
-    return success
-end
+precompile(argt::Type) = ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
 
 precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing))
 precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), String))

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1928,7 +1928,7 @@ end
 
 function precompile(argt::Type)
     if ccall(:jl_compile_hint, Int32, (Any,), argt) == 0
-        @warn "Inactive precompile statement" maxlog=100 form=argt _module=nothing _file=nothing _line=0
+        @debug "Inactive precompile statement" form=argt _module=nothing _file=nothing _line=0
     end
     true
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1928,7 +1928,7 @@ end
 
 function precompile(argt::Type)
     if ccall(:jl_compile_hint, Int32, (Any,), argt) == 0
-        @debug "Inactive precompile statement" form=argt _module=nothing _file=nothing _line=0
+        @debug "Inactive precompile statement" maxlog=10 form=argt _module=nothing _file=nothing _line=0
     end
     true
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1927,10 +1927,11 @@ function precompile(@nospecialize(f), args::Tuple)
 end
 
 function precompile(argt::Type)
-    if ccall(:jl_compile_hint, Int32, (Any,), argt) == 0
+    success = ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
+    if !success
         @debug "Inactive precompile statement" maxlog=10 form=argt _module=nothing _file=nothing _line=0
     end
-    true
+    return success
 end
 
 precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing))

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -66,7 +66,7 @@ end
 ## Other ways of accessing functions
 # Test that non-ambiguous cases work
 let io = IOBuffer()
-    @test @test_logs precompile(ambig, (Int, Int))
+    @test precompile(ambig, (Int, Int))
     cf = @eval @cfunction(ambig, Int, (Int, Int))
     @test ccall(cf, Int, (Int, Int), 1, 2) == 4
     @test length(code_lowered(ambig, (Int, Int))) == 1
@@ -75,7 +75,7 @@ end
 
 # Test that ambiguous cases fail appropriately
 let io = IOBuffer()
-    @test @test_logs (:warn,) precompile(ambig, (UInt8, Int))
+    @test !precompile(ambig, (UInt8, Int))
     cf = @eval @cfunction(ambig, Int, (UInt8, Int))  # test for a crash (doesn't throw an error)
     @test_throws(MethodError(ambig, (UInt8(1), Int(2)), get_world_counter()),
                  ccall(cf, Int, (UInt8, Int), 1, 2))


### PR DESCRIPTION
Seeing this get spammed in the console as a user looks scary and is kinda annoying.
It is also annoying when looking through logs, here is a zoomed out view of a typical PkgEval log (these are all precompile warnings):

![bild](https://user-images.githubusercontent.com/1282691/124272249-c84ee100-db3e-11eb-8d7a-5d1d5d3f8ed5.png)

If someone wants to opt into showing these unconditionally, one can do something like https://github.com/JuliaLang/julia/pull/39922 (which I thing was a better idea in the first place rather than unconditionally logging).