### PR TITLE
Mention integers in `mod1` docstring

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -873,17 +873,25 @@ const ÷ = div
     mod1(x, y)
 
 Modulus after flooring division, returning a value `r` such that `mod(r, y) == mod(x, y)`
-in the range ``(0, y]`` for positive `y` and in the range ``[y,0)`` for negative `y`.
+in the range ``(0, y]`` for positive `y`, and in the range ``[y,0)`` for negative `y`.
 
-See also [`fld1`](@ref), [`fldmod1`](@ref).
+With integer arguments and positive `y`, this is equal to `mod(x, 1:y)`, and hence natural
+for 1-based indexing. By comparison, `mod(x, y) == mod(x, 0:y-1)` fits 0-based indices.
+
+See also [`mod`](@ref), [`fld1`](@ref), [`fldmod1`](@ref).
 
 # Examples
 ```jldoctest
 julia> mod1(4, 2)
 2
 
-julia> mod1(4, 3)
-1
+julia> mod1.(-5:5, 3)'
+1×11 adjoint(::Vector{Int64}) with eltype Int64:
+ 1  2  3  1  2  3  1  2  3  1  2
+
+julia> mod1.([-0.1, 0, 0.1, 1, 2, 2.9, 3, 3.1]', 3)
+1×8 Matrix{Float64}:
+ 2.9  3.0  0.1  1.0  2.0  2.9  3.0  0.1
 ```
 """
 mod1(x::T, y::T) where {T<:Real} = (m = mod(x, y); ifelse(m == 0, y, m))

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -873,10 +873,11 @@ const ÷ = div
     mod1(x, y)
 
 Modulus after flooring division, returning a value `r` such that `mod(r, y) == mod(x, y)`
-in the range ``(0, y]`` for positive `y`, and in the range ``[y,0)`` for negative `y`.
+in the range ``(0, y]`` for positive `y` and in the range ``[y,0)`` for negative `y`.
 
 With integer arguments and positive `y`, this is equal to `mod(x, 1:y)`, and hence natural
-for 1-based indexing. By comparison, `mod(x, y) == mod(x, 0:y-1)` fits 0-based indices.
+for 1-based indexing. By comparison, `mod(x, y) == mod(x, 0:y-1)` is natural for computations with 
+offsets or strides. 
 
 See also [`mod`](@ref), [`fld1`](@ref), [`fldmod1`](@ref).
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -1288,10 +1288,10 @@ See also [`mod1`](@ref).
 
 # Examples
 ```jldoctest
-julia> mod(0, Base.OneTo(3))
+julia> mod(0, Base.OneTo(3))  # mod1(0, 3)
 3
 
-julia> mod(3, 0:2)
+julia> mod(3, 0:2)  # mod(3, 3)
 0
 ```
 


### PR DESCRIPTION
The present docstring for `mod1` explains it as giving a result in the closed-right interval ``(0, y]``, instead of ``[0, y)`` for `mod`. That's focused on the real numbers, but it's then a bit of a mystery why this is called `mod1`. I think that comes from the integers, where it returns something in `1:y` instead of in `0:y-1`, thus matching `OneTo(y)`. So I added a paragraph saying that.

And I've extended the examples to, I hope, make them explain what it does even if you didn't read the formal version.