### PR TITLE
See also `summarysize` from docstring for `sizeof` 

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -447,7 +447,7 @@ reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
     sizeof(obj)
 
 Size, in bytes, of the canonical binary representation of the given `DataType` `T`, if any.
-Or the size, in bytes, of object `obj` if it is not `DataType`.
+Or the size, in bytes, of object `obj` if it is not a `DataType`.
 
 See also [`summarysize`](@ref).
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -447,7 +447,9 @@ reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
     sizeof(obj)
 
 Size, in bytes, of the canonical binary representation of the given `DataType` `T`, if any.
-Size, in bytes, of object `obj` if it is not `DataType`.
+Or the size, in bytes, of object `obj` if it is not `DataType`.
+
+See also [`summarysize`](@ref).
 
 # Examples
 ```jldoctest
@@ -460,7 +462,7 @@ julia> sizeof(ComplexF64)
 julia> sizeof(1.0)
 8
 
-julia> sizeof([1.0:10.0;])
+julia> sizeof(collect(1.0:10.0))
 80
 ```
 

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -17,6 +17,20 @@ Compute the amount of memory, in bytes, used by all unique objects reachable fro
 - `exclude`: specifies the types of objects to exclude from the traversal.
 - `chargeall`: specifies the types of objects to always charge the size of all of their
   fields, even if those fields would normally be excluded.
+
+See also [`sizeof`](@ref).
+
+# Examples
+```jldoctest
+julia> Base.summarysize(1.0)
+8
+
+julia> Base.summarysize(Ref(rand(100)))
+848
+
+julia> sizeof(Ref(rand(100)))
+8
+```
 """
 function summarysize(obj;
                      exclude = Union{DataType, Core.TypeName, Core.MethodInstance},


### PR DESCRIPTION
This adds "see also" links between `sizeof` and `summarysize`. The latter is not exported, but is useful. 

Also adds some examples for `summarysize`, far from exhaustive.