### PR TITLE
Add `@repeat` as shorthand `for` and `while` loops

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -590,6 +590,33 @@ macro goto(name::Symbol)
     return esc(Expr(:symbolicgoto, name))
 end
 
+"""
+    @repeat n call
+    @repeat bool_expr call
+
+Repeat `call` `n` times and discard the output.
+If an expression that returns a boolean is given as a first argument, repeat while true and disregard output.
+"""
+macro repeat(terms, ex)
+    if isa(terms, Integer)
+        quote
+            for _ = 1:$(esc(terms))
+                $(esc(ex))
+            end
+            return nothing
+        end
+    elseif isa(terms, Expr)
+        quote
+            while $(esc(terms))
+                $(esc(ex))
+            end
+            return nothing
+        end
+    else
+        throw(ArgumentError("@repeat first argument must be an Integer or an expression that returns a boolean"))
+    end
+end
+
 # SimpleVector
 
 function getindex(v::SimpleVector, i::Int)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1025,6 +1025,7 @@ export
     @enum,
     @label,
     @goto,
+    @repeat,
     @view,
     @views,
     @static


### PR DESCRIPTION
I'd be surprised if this hadn't been suggested before but I couldn't find an issue/PR.

Just introduces the form
```julia
julia> @repeat 2 println("hello")
hello
hello

julia> @repeat 10 move_robot()

julia> @repeat Dates.now() < Dates.DateTime(2029) move_robot()

```
in place of
```julia
julia> for _ in 1:2
           println("hello")
       end
hello
hello

julia> for _ in 1:10
           move_robot()
       end

julia> while Dates.now() < Dates.DateTime(2029)
           move_robot()
       end
```

or
```julia
julia> for _ in 1:10 println("hello"); end
hello
hello

julia> for _ in 1:10 move_robot(); end

julia> while Dates.now() < Dates.DateTime(2029) move_robot(); end

```

I wondered if `@loop` would be a better name?