### PR TITLE
faster findfirst(iszero) for byte arrays

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -68,6 +68,9 @@ findlast(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a:
 findprev(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray, i::Integer) =
     nothing_sentinel(_rsearch(a, pred.x, i))
 
+findlast(::typeof(iszero), a::ByteArray) = nothing_sentinel(_rsearch(a, zero(UInt8)))
+findprev(::typeof(iszero), a::ByteArray, i::Integer) = nothing_sentinel(_rsearch(a, zero(UInt8), i))
+
 function _rsearch(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = sizeof(a))
     if i < 1
         return i == 0 ? 0 : throw(BoundsError(a, i))

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -25,6 +25,9 @@ findfirst(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a
 findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray, i::Integer) =
     nothing_sentinel(_search(a, pred.x, i))
 
+findfirst(::typeof(iszero), a::ByteArray) = nothing_sentinel(_search(a, zero(UInt8)))
+findnext(::typeof(iszero), a::ByteArray, i::Integer) = nothing_sentinel(_search(a, zero(UInt8), i))
+
 function _search(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = 1)
     if i < 1
         throw(BoundsError(a, i))

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -25,7 +25,7 @@ function Base.showerror(io::IO, exc::StringIndexError)
     end
 end
 
-const ByteArray = Union{Vector{UInt8},Vector{Int8}}
+const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, FastContiguousSubArray{UInt8,1,CodeUnits{UInt8,String}}, FastContiguousSubArray{Int8,1,Vector{Int8}}}
 
 @inline between(b::T, lo::T, hi::T) where {T<:Integer} = (lo ≤ b) & (b ≤ hi)
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -25,7 +25,7 @@ function Base.showerror(io::IO, exc::StringIndexError)
     end
 end
 
-const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, FastContiguousSubArray{UInt8,1,CodeUnits{UInt8,String}}, FastContiguousSubArray{Int8,1,Vector{Int8}}}
+const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, FastContiguousSubArray{UInt8,1,CodeUnits{UInt8,String}}, FastContiguousSubArray{UInt8,1,Vector{UInt8}}, FastContiguousSubArray{Int8,1,Vector{Int8}}}
 
 @inline between(b::T, lo::T, hi::T) where {T<:Integer} = (lo ≤ b) & (b ≤ hi)
 

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -398,14 +398,18 @@ end
 # issue 37280
 @testset "UInt8, Int8 vector" begin
     for T in [Int8, UInt8], VT in [Int8, UInt8]
-        A = T[0x40, 0x52, 0x62, 0x52, 0x62]
+        A = T[0x40, 0x52, 0x00, 0x52, 0x00]
 
-        @test findfirst(VT[0x30], A) === nothing
+        @test findfirst(VT[0x30], A) === findfirst(==(VT(0x30)), A) == nothing
         @test findfirst(VT[0x52], A) === 2:2
-        @test findlast(VT[0x30], A) === nothing
+        @test findfirst(==(VT(0x52)), A) === 2
+        @test findlast(VT[0x30], A) === findlast(==(VT(0x30)), A) === nothing
         @test findlast(VT[0x52], A) === 4:4
+        @test findlast(==(VT(0x52)), A) === 4
+        @test findfirst(iszero, A) === 3 === findprev(iszero, A, 4)
+        @test findlast(iszero, A) === 5 === findnext(iszero, A, 4)
 
-        pattern = VT[0x52, 0x62]
+        pattern = VT[0x52, 0x00]
 
         @test findfirst(pattern, A) === 2:3
         @test findnext(pattern, A, 2) === 2:3

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -400,32 +400,34 @@ end
     for T in [Int8, UInt8], VT in [Int8, UInt8]
         A = T[0x40, 0x52, 0x00, 0x52, 0x00]
 
-        @test findfirst(VT[0x30], A) === findfirst(==(VT(0x30)), A) == nothing
-        @test findfirst(VT[0x52], A) === 2:2
-        @test findfirst(==(VT(0x52)), A) === 2
-        @test findlast(VT[0x30], A) === findlast(==(VT(0x30)), A) === nothing
-        @test findlast(VT[0x52], A) === 4:4
-        @test findlast(==(VT(0x52)), A) === 4
-        @test findfirst(iszero, A) === 3 === findprev(iszero, A, 4)
-        @test findlast(iszero, A) === 5 === findnext(iszero, A, 4)
+        for A in (A, @view(A[1:end]), codeunits(String(copyto!(Vector{UInt8}(undef,5), A))))
+            @test findfirst(VT[0x30], A) === findfirst(==(VT(0x30)), A) == nothing
+            @test findfirst(VT[0x52], A) === 2:2
+            @test findfirst(==(VT(0x52)), A) === 2
+            @test findlast(VT[0x30], A) === findlast(==(VT(0x30)), A) === nothing
+            @test findlast(VT[0x52], A) === 4:4
+            @test findlast(==(VT(0x52)), A) === 4
+            @test findfirst(iszero, A) === 3 === findprev(iszero, A, 4)
+            @test findlast(iszero, A) === 5 === findnext(iszero, A, 4)
 
-        pattern = VT[0x52, 0x00]
+            pattern = VT[0x52, 0x00]
 
-        @test findfirst(pattern, A) === 2:3
-        @test findnext(pattern, A, 2) === 2:3
-        @test findnext(pattern, A, 3) === 4:5
-        # 1 idx too far is allowed
-        @test findnext(pattern, A, length(A)+1) === nothing
-        @test_throws BoundsError findnext(pattern, A, -3)
-        @test_throws BoundsError findnext(pattern, A, length(A)+2)
+            @test findfirst(pattern, A) === 2:3
+            @test findnext(pattern, A, 2) === 2:3
+            @test findnext(pattern, A, 3) === 4:5
+            # 1 idx too far is allowed
+            @test findnext(pattern, A, length(A)+1) === nothing
+            @test_throws BoundsError findnext(pattern, A, -3)
+            @test_throws BoundsError findnext(pattern, A, length(A)+2)
 
-        @test findlast(pattern, A) === 4:5
-        @test findprev(pattern, A, 3) === 2:3
-        @test findprev(pattern, A, 5) === 4:5
-        @test findprev(pattern, A, 2) === nothing
-        @test findprev(pattern, A, length(A)+1) == findlast(pattern, A)
-        @test findprev(pattern, A, length(A)+2) == findlast(pattern, A)
-        @test_throws BoundsError findprev(pattern, A, -3)
+            @test findlast(pattern, A) === 4:5
+            @test findprev(pattern, A, 3) === 2:3
+            @test findprev(pattern, A, 5) === 4:5
+            @test findprev(pattern, A, 2) === nothing
+            @test findprev(pattern, A, length(A)+1) == findlast(pattern, A)
+            @test findprev(pattern, A, length(A)+2) == findlast(pattern, A)
+            @test_throws BoundsError findprev(pattern, A, -3)
+        end
     end
 end
 


### PR DESCRIPTION
Uses `memchr` for searching `Vector{UInt8}` for `iszero` with `findfirst` or `findnext`.  Almost 8x faster on my machine for `x = [fill(0x01,100); 0x00)]`, for example.  Similarly for `findlast` and `findprev` with `memrchr`.

Also, I expanded the definition of `Base.ByteArray` (which is used for these fast byte-search routines) to include contiguous subarrays of `Vector{UInt8}` as well as `CodeUnits{UInt8,String}`.