### PR TITLE
Export jl_field_index from libjulia

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -149,6 +149,7 @@
     XX(jl_expand_with_loc) \
     XX(jl_expand_with_loc_warn) \
     XX(jl_extern_c) \
+    XX(jl_field_index) \
     XX(jl_gc_add_finalizer) \
     XX(jl_gc_add_finalizer_th) \
     XX(jl_gc_add_ptr_finalizer) \


### PR DESCRIPTION
Fixes #41464 (well, at least the last bit that isn't already fixed in `master`).

Should be backported to 1.7