### PR TITLE
MPFR tests: skip the `log2(x) == log2(42)` test

### DIFF
--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -606,11 +606,8 @@ end
         @test log(x) == log(42)
         @test isinf(log(BigFloat(0)))
         @test_throws DomainError log(BigFloat(-1))
-        if Sys.iswindows()
-            @test_broken log2(x) == log2(42)
-        else
-            @test log2(x) == log2(42)
-        end
+        # issue #41450
+        @test_skip log2(x) == log2(42)
         @test isinf(log2(BigFloat(0)))
         @test_throws DomainError log2(BigFloat(-1))
         @test log10(x) == log10(42)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -606,7 +606,11 @@ end
         @test log(x) == log(42)
         @test isinf(log(BigFloat(0)))
         @test_throws DomainError log(BigFloat(-1))
-        @test log2(x) == log2(42)
+        if Sys.iswindows()
+            @test_broken log2(x) == log2(42)
+        else
+            @test log2(x) == log2(42)
+        end
         @test isinf(log2(BigFloat(0)))
         @test_throws DomainError log2(BigFloat(-1))
         @test log10(x) == log10(42)


### PR DESCRIPTION
Closes #41417 

See also: #41450