### PR TITLE
Sort list of exported data/funcs again

### DIFF
--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -5,11 +5,11 @@
     XX(jl_abstractstring_type) \
     XX(jl_an_empty_string) \
     XX(jl_an_empty_vec_any) \
-    XX(jl_any_type) \
     XX(jl_anytuple_type) \
     XX(jl_anytuple_type_type) \
-    XX(jl_argument_type) \
+    XX(jl_any_type) \
     XX(jl_argumenterror_type) \
+    XX(jl_argument_type) \
     XX(jl_array_any_type) \
     XX(jl_array_int32_type) \
     XX(jl_array_symbol_type) \
@@ -25,8 +25,8 @@
     XX(jl_char_type) \
     XX(jl_code_info_type) \
     XX(jl_code_instance_type) \
-    XX(jl_core_module) \
     XX(jl_const_type) \
+    XX(jl_core_module) \
     XX(jl_datatype_type) \
     XX(jl_densearray_type) \
     XX(jl_diverror_exception) \
@@ -49,6 +49,7 @@
     XX(jl_int32_type) \
     XX(jl_int64_type) \
     XX(jl_int8_type) \
+    XX(jl_interconditional_type) \
     XX(jl_interrupt_exception) \
     XX(jl_intrinsic_type) \
     XX(jl_lineinfonode_type) \
@@ -58,10 +59,10 @@
     XX(jl_loaderror_type) \
     XX(jl_main_module) \
     XX(jl_memory_exception) \
+    XX(jl_methoderror_type) \
     XX(jl_method_instance_type) \
     XX(jl_method_match_type) \
     XX(jl_method_type) \
-    XX(jl_methoderror_type) \
     XX(jl_methtable_type) \
     XX(jl_module_type) \
     XX(jl_namedtuple_type) \
@@ -71,9 +72,10 @@
     XX(jl_nothing) \
     XX(jl_nothing_type) \
     XX(jl_number_type) \
-    XX(jl_partial_struct_type) \
+    XX(jl_opaque_closure_type) \
+    XX(jl_opaque_closure_typename) \
     XX(jl_partial_opaque_type) \
-    XX(jl_interconditional_type) \
+    XX(jl_partial_struct_type) \
     XX(jl_phicnode_type) \
     XX(jl_phinode_type) \
     XX(jl_pinode_type) \
@@ -95,20 +97,20 @@
     XX(jl_true) \
     XX(jl_tuple_typename) \
     XX(jl_tvar_type) \
-    XX(jl_type_type) \
-    XX(jl_type_type_mt) \
-    XX(jl_type_typename) \
     XX(jl_typedslot_type) \
     XX(jl_typeerror_type) \
     XX(jl_typemap_entry_type) \
     XX(jl_typemap_level_type) \
     XX(jl_typename_type) \
     XX(jl_typeofbottom_type) \
+    XX(jl_type_type) \
+    XX(jl_type_type_mt) \
+    XX(jl_type_typename) \
     XX(jl_uint16_type) \
     XX(jl_uint32_type) \
     XX(jl_uint64_type) \
-    XX(jl_uint8_type) \
     XX(jl_uint8pointer_type) \
+    XX(jl_uint8_type) \
     XX(jl_undefref_exception) \
     XX(jl_undefvarerror_type) \
     XX(jl_unionall_type) \
@@ -116,11 +118,9 @@
     XX(jl_upsilonnode_type) \
     XX(jl_vararg_type) \
     XX(jl_vecelement_typename) \
-    XX(jl_void_type) \
     XX(jl_voidpointer_type) \
+    XX(jl_void_type) \
     XX(jl_weakref_type) \
-    XX(jl_opaque_closure_type) \
-    XX(jl_opaque_closure_typename)
 
 // Data symbols that are defined inside the public libjulia
 #define JL_EXPORTED_DATA_SYMBOLS(XX) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -247,6 +247,7 @@
     XX(jl_get_nth_field_checked) \
     XX(jl_get_nth_field_noalloc) \
     XX(jl_getpagesize) \
+    XX(jl_get_pgcstack) \
     XX(jl_getpid) \
     XX(jl_get_ptls_states) \
     XX(jl_get_root_symbol) \
@@ -273,10 +274,10 @@
     XX(jl_id_start_char) \
     XX(jl_idtable_rehash) \
     XX(jl_infer_thunk) \
-    XX(jl_init_restored_modules) \
     XX(jl_init) \
-    XX(jl_init_with_image) \
     XX(jl_init__threading) \
+    XX(jl_init_restored_modules) \
+    XX(jl_init_with_image) \
     XX(jl_init_with_image__threading) \
     XX(jl_install_sigint_handler) \
     XX(jl_instantiate_type_in_env) \
@@ -391,6 +392,7 @@
     XX(jl_pop_handler) \
     XX(jl_preload_sysimg_so) \
     XX(jl_prepend_cwd) \
+    XX(jl_print_backtrace) \
     XX(jl_printf) \
     XX(jl_process_events) \
     XX(jl_profile_clear_data) \
@@ -541,5 +543,3 @@
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
     XX(jl_yield) \
-    XX(jl_print_backtrace) \
-    XX(jl_get_pgcstack)


### PR DESCRIPTION
Some recent additions were not placed into the "correct" spot.

Note: empirically, the sort ordering employed here ignores underscores,
so I am doing this here, too. A script performed the sorting.
