### PR TITLE
remove trailing whitespace from #41448

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -876,8 +876,8 @@ Modulus after flooring division, returning a value `r` such that `mod(r, y) == m
 in the range ``(0, y]`` for positive `y` and in the range ``[y,0)`` for negative `y`.
 
 With integer arguments and positive `y`, this is equal to `mod(x, 1:y)`, and hence natural
-for 1-based indexing. By comparison, `mod(x, y) == mod(x, 0:y-1)` is natural for computations with 
-offsets or strides. 
+for 1-based indexing. By comparison, `mod(x, y) == mod(x, 0:y-1)` is natural for computations with
+offsets or strides.
 
 See also [`mod`](@ref), [`fld1`](@ref), [`fldmod1`](@ref).
 


### PR DESCRIPTION
This currently causes the whitespace check to fail.
