### PR TITLE
fix julia_asserts to depend only on julia build mode

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1,9 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 // --- the ccall, cglobal, and llvm intrinsics ---
-#include "llvm/Support/Path.h" // for llvm::sys::path
-#include <llvm/Bitcode/BitcodeReader.h>
-#include <llvm/Linker/Linker.h>
 
 #ifdef _OS_WINDOWS_
 extern const char jl_crtdll_basename[];

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -84,6 +84,10 @@
 #endif
 #include <llvm/Target/TargetMachine.h>
 
+#include "llvm/Support/Path.h" // for llvm::sys::path
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/Linker/Linker.h>
+
 using namespace llvm;
 
 typedef Instruction TerminatorInst;

--- a/src/julia_assert.h
+++ b/src/julia_assert.h
@@ -21,7 +21,10 @@
 #  endif
 #else
 #  ifdef JL_NDEBUG
-#    undef JL_NDEBUG
+#    define NDEBUG
+#    include <assert.h>
+#    undef NDEBUG
+#  else
+#    include <assert.h>
 #  endif
-#  include <assert.h>
 #endif


### PR DESCRIPTION
Assertions in parts of our C++ code seemed to always be enabled; for example in #41157 where the assertion happens in all builds. This moves some includes and fixes the logic in julia_assert.h to make assertions in our code depend only on JL_NDEBUG.
A couple remaining questions about assertions:

- Should we inspect `llvm-config --assertion-mode` and pass -DNDEBUG (in addition to the existing -DJL_NDEBUG) if LLVM assertions are off?
- We could look into using EnableABIBreakingChecksin LLVM, which adds more checks at the cost of requiring the flag to match in callers.
