### PR TITLE
fix #41157, unnecessary assertion on `Tuple{Union{}}`

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -284,7 +284,6 @@ static Value *emit_unboxed_coercion(jl_codectx_t &ctx, Type *to, Value *unboxed)
     Type *ty = unboxed->getType();
     if (ty == to)
         return unboxed;
-    assert(to->isIntOrPtrTy() || to->isFloatingPointTy());
     bool frompointer = ty->isPointerTy();
     bool topointer = to->isPointerTy();
     const DataLayout &DL = jl_data_layout;

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -593,3 +593,7 @@ f41438(y) = y[].x
 @test B41438.body.layout === C_NULL
 @test f41438(Ref{A41438}(A41438(C_NULL))) === C_NULL
 @test f41438(Ref{B41438}(B41438(C_NULL))) === C_NULL
+
+# issue #41157
+f41157(a, b) = a[1] = b[1]
+@test_throws BoundsError f41157(Tuple{Int}[], Tuple{Union{}}[])


### PR DESCRIPTION
fix #41157