### PR TITLE
fix #41489: inference of `+(::Rational, Rational)`

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -279,8 +279,8 @@ function -(x::Rational{T}) where T<:Unsigned
     x
 end
 
-function +(x::Rational, y::Rational)::Rational
-    xp, yp = promote(x, y)
+function +(x::Rational, y::Rational)
+    xp, yp = promote(x, y)::NTuple{2,Rational}
     if isinf(x) && x == y
         return xp
     end
@@ -288,8 +288,8 @@ function +(x::Rational, y::Rational)::Rational
     Rational(checked_add(checked_mul(x.num,yd), checked_mul(y.num,xd)), checked_mul(x.den,yd))
 end
 
-function -(x::Rational, y::Rational)::Rational
-    xp, yp = promote(x, y)
+function -(x::Rational, y::Rational)
+    xp, yp = promote(x, y)::NTuple{2,Rational}
     if isinf(x) && x == -y
         return xp
     end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -279,7 +279,7 @@ function -(x::Rational{T}) where T<:Unsigned
     x
 end
 
-function +(x::Rational, y::Rational)
+function +(x::Rational, y::Rational)::Rational
     xp, yp = promote(x, y)
     if isinf(x) && x == y
         return xp
@@ -288,7 +288,7 @@ function +(x::Rational, y::Rational)
     Rational(checked_add(checked_mul(x.num,yd), checked_mul(y.num,xd)), checked_mul(x.den,yd))
 end
 
-function -(x::Rational, y::Rational)
+function -(x::Rational, y::Rational)::Rational
     xp, yp = promote(x, y)
     if isinf(x) && x == -y
         return xp

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -622,3 +622,11 @@ end
 @testset "Rational{T} with non-concrete T (issue #41222)" begin
     @test @inferred(Rational{Integer}(2,3)) isa Rational{Integer}
 end
+
+@testset "issue #41489" begin
+    @test Core.Compiler.return_type(+, NTuple{2, Rational}) == Rational
+    @test Core.Compiler.return_type(-, NTuple{2, Rational}) == Rational
+
+    A=Rational[1 1 1; 2 2 2; 3 3 3]
+    @test @inferred(A*A) isa Matrix{Rational}
+end


### PR DESCRIPTION
Fixes #41489.