### PR TITLE
Streamline buildkite configuration a bit

### DIFF
--- a/.buildkite/embedding.yml
+++ b/.buildkite/embedding.yml
@@ -18,6 +18,9 @@ steps:
           rootfs_treehash: "f3ed53f159e8f13edfba8b20ebdb8ece73c1b8a8"
           uid: 1000
           gid: 1000
+          workspaces:
+            # Include `/cache/repos` so that our `git` version introspection works.
+            - "/cache/repos:/cache/repos"
     commands: |
       prefix="/tmp/prefix"
       echo "+++ Build julia, deploy to $${prefix}"

--- a/.buildkite/llvm_passes.yml
+++ b/.buildkite/llvm_passes.yml
@@ -16,6 +16,9 @@ steps:
       - staticfloat/sandbox#v1:
           rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v1/llvm-passes.tar.gz
           rootfs_treehash: "f3ed53f159e8f13edfba8b20ebdb8ece73c1b8a8"
+          workspaces:
+            # Include `/cache/repos` so that our `git` version introspection works.
+            - "/cache/repos:/cache/repos"
     commands: |
       echo "--- Install in-tree LLVM dependencies"
       make -j$${JULIA_NUM_CORES} -C deps install-llvm install-clang install-llvm-tools install-libuv install-utf8proc install-unwind
@@ -37,6 +40,8 @@ steps:
           rootfs_treehash: "f3ed53f159e8f13edfba8b20ebdb8ece73c1b8a8"
           uid: 1000
           gid: 1000
+          workspaces:
+            - "/cache/repos:/cache/repos"
     commands: |
       echo "+++ run llvmpasses"
       make -j$${JULIA_NUM_CORES} release JULIA_PRECOMPILE=0

--- a/.buildkite/llvm_passes.yml
+++ b/.buildkite/llvm_passes.yml
@@ -43,9 +43,11 @@ steps:
           workspaces:
             - "/cache/repos:/cache/repos"
     commands: |
-      echo "+++ run llvmpasses"
+      echo "--- make release"
       make -j$${JULIA_NUM_CORES} release JULIA_PRECOMPILE=0
+      echo "--- make src/install-analysis-deps"
       make -j$${JULIA_NUM_CORES} -C src install-analysis-deps
+      echo "+++ make test/llvmpasses"
       make -j$${JULIA_NUM_CORES} -C test/llvmpasses
     timeout_in_minutes: 60
     notify:

--- a/.buildkite/whitespace.yml
+++ b/.buildkite/whitespace.yml
@@ -16,6 +16,8 @@ steps:
       - staticfloat/sandbox#v1:
           rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v1/llvm-passes.tar.gz
           rootfs_treehash: "f3ed53f159e8f13edfba8b20ebdb8ece73c1b8a8"
+          workspaces:
+            - "/cache/repos:/cache/repos"
     commands: |
       make -j$${JULIA_NUM_CORES} check-whitespace
     timeout_in_minutes: 10

--- a/contrib/check-whitespace.sh
+++ b/contrib/check-whitespace.sh
@@ -35,3 +35,5 @@ if git --no-pager grep --color -n --full-name -e ' $' -- $file_patterns; then
     echo "and then a forced push of the correct branch"
     exit 1
 fi
+
+echo "Whitespace check found no issues"


### PR DESCRIPTION
* Fix missing git version information
* Break up `llvmpasses` output a bit
* Give a positive message if `whitespace` check passes