### PR TITLE
Initialize n_uninitialized for Symbol and SimpleVector

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2016,6 +2016,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_symbol_type->name->mt = jl_nonfunction_mt;
     jl_symbol_type->super = jl_any_type;
     jl_symbol_type->parameters = jl_emptysvec;
+    jl_symbol_type->name->n_uninitialized = 0;
     jl_symbol_type->name->names = jl_emptysvec;
     jl_symbol_type->types = jl_emptysvec;
     jl_symbol_type->size = 0;
@@ -2026,6 +2027,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_simplevector_type->name->mt = jl_nonfunction_mt;
     jl_simplevector_type->super = jl_any_type;
     jl_simplevector_type->parameters = jl_emptysvec;
+    jl_simplevector_type->name->n_uninitialized = 0;
     jl_simplevector_type->name->names = jl_emptysvec;
     jl_simplevector_type->types = jl_emptysvec;
     jl_precompute_memoized_dt(jl_simplevector_type, 1);


### PR DESCRIPTION
When I try to build `julia` with ASAN, I get

> ```julia-debug: /.../src/datatype.c:353: void jl_compute_field_offsets(jl_datatype_t *): Assertion `st->name->n_uninitialized <= nfields' failed.```

This assertion was tweaked in https://github.com/JuliaLang/julia/commit/de6f62ac78f8923eaaec09529506896cb781173a#diff-e21748de252a5b69a0efe2c249a4c2cf4f844b9cd86503cc0c7e25fb654fc34cR353  in PR #41018. Bisection points to this commit.

Looking at the PR and how `->name->n_uninitialized` is initialized for `jl_datatype_type`, `jl_typename_type` and `jl_methtable_type`, it seems that we'd want to to add `jl_symbol_type->name->n_uninitialized = 0` and `jl_simplevector_type->name->n_uninitialized = 0` as well?
