### PR TITLE
Use labelchangemap for PhiNode edges

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -635,12 +635,12 @@ function renumber_ir_elements!(body::Vector{Any}, ssachangemap::Vector{Int}, lab
             edges = el.edges
             values = el.values
             while i <= length(edges)
-                was_deleted = ssachangemap[edges[i]] == typemin(Int)
+                was_deleted = labelchangemap[edges[i]] == typemin(Int)
                 if was_deleted
                     deleteat!(edges, i)
                     deleteat!(values, i)
                 else
-                    edges[i] += ssachangemap[edges[i]]
+                    edges[i] += labelchangemap[edges[i]]
                     val = values[i]
                     if isa(val, SSAValue)
                         values[i] = SSAValue(val.id + ssachangemap[val.id])


### PR DESCRIPTION
I just noticed this by reading #41115 and I don't know if there are any problems with this. But it seems to be more appropriate to use `labelchangemap` for renaming `PhiNode` edges, considering how other goto labels are renamed? Although I guess we normally have `ssachangemap === labelchangemap`.

Also, since #41115 is backported, this needs to be backported if merged?
