### PR TITLE
increase specialization of `_totuple`

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -322,7 +322,7 @@ function _totuple_err(@nospecialize T)
     throw(ArgumentError("too few elements for tuple type $T"))
 end
 
-function _totuple(T, itr, s...)
+function _totuple(::Type{T}, itr, s::Vararg{Any,N}) where {T,N}
     @_inline_meta
     y = iterate(itr, s...)
     y === nothing && _totuple_err(T)


### PR DESCRIPTION
Helps #41512

After:
```
julia> @time doit(itr)
  0.000285 seconds (10.00 k allocations: 312.500 KiB)
```

so almost 100x speedup, but I'm not sure where the remaining allocation is coming from.