### PR TITLE
in ascii(s) docs, note how to discard non-ascii chars

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -596,6 +596,15 @@ true
 julia> isascii("αβγ")
 false
 ```
+For example, `isascii` can be used as a predicate function for [`filter`](@ref) or [`replace`](@ref)
+to remove or replace non-ASCII characters, respectively:
+```jldoctest
+julia> filter(isascii, "abcdeγfgh") # discard non-ASCII chars
+"abcdefgh"
+
+julia> replace("abcdeγfgh", !isascii=>' ') # replace non-ASCII chars with spaces
+"abcde fgh"
+```
 """
 isascii(c::Char) = bswap(reinterpret(UInt32, c)) < 0x80
 isascii(s::AbstractString) = all(isascii, s)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -788,8 +788,7 @@ end
 Convert a string to `String` type and check that it contains only ASCII data, otherwise
 throwing an `ArgumentError` indicating the position of the first non-ASCII byte.
 
-If you instead want to *silently discard* non-ASCII data, you can use `filter(isascii, s)`,
-via the [`isascii`](@ref) and [`filter`](@ref) functions.
+See also the [`isascii`](@ref) predicate to filter or replace non-ASCII characters.
 
 # Examples
 ```jldoctest
@@ -797,9 +796,6 @@ julia> ascii("abcdeγfgh")
 ERROR: ArgumentError: invalid ASCII at index 6 in "abcdeγfgh"
 Stacktrace:
 [...]
-
-julia> filter(isascii, "abcdeγfgh") # discard non-ASCII chars
-"abcdefgh"
 
 julia> ascii("abcdefgh")
 "abcdefgh"

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -788,12 +788,18 @@ end
 Convert a string to `String` type and check that it contains only ASCII data, otherwise
 throwing an `ArgumentError` indicating the position of the first non-ASCII byte.
 
+If you instead want to *silently discard* non-ASCII data, you can use `filter(isascii, s)`,
+via the [`isascii`](@ref) and [`filter`](@ref) functions.
+
 # Examples
 ```jldoctest
 julia> ascii("abcdeγfgh")
 ERROR: ArgumentError: invalid ASCII at index 6 in "abcdeγfgh"
 Stacktrace:
 [...]
+
+julia> filter(isascii, "abcdeγfgh") # discard non-ASCII chars
+"abcdefgh"
 
 julia> ascii("abcdefgh")
 "abcdefgh"


### PR DESCRIPTION
[On discourse](https://discourse.julialang.org/t/replace-non-ascii-char/64358) someone was asking how to discard non-ASCII characters from a string.  It seemed like the `ascii(s)` function would be a logical place to point out that you can use `filter(isascii, s)` for this.