### PR TITLE
Adding tests for the "linear algebra" package

### DIFF
--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -664,5 +664,30 @@ using .Main.ImmutableArrays
     @test convert(AbstractArray{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
     @test convert(AbstractMatrix{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
 end
+                    
+@testset "Tri/Bidiagonal conversion" begin
+    BidiagU = Bidiagonal([1, 2, 3, 4] , [1, 2, 3], :U)
+    BidiagL = Bidiagonal([1, 2, 3, 4] , [1, 2, 3], :L)
+    Tridiag = Tridiagonal([1, 2, 3] , [1, 2, 3,4], [1, 2, 3])           
+    @test Tridiagonal(BidiagU) == BidiagU
+    @test Tridiagonal(BidiagL) == BidiagL
+    @test Bidiagonal(Tridiag, :U)  == BidiagU
+    @test Bidiagonal(Tridiag, :L)  == BidiagL               
+    for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
+        v1 = rand(elty, 3)
+        v2 = rand(elty, 4)
+        v3 = zeros(elty, 3)       
+        B = Bidiagonal(v2 , v1, :U)
+        Bdiag = Bidiagonal(v2 , v3, :U)               
+        @test Bidiagonal(B)  == B 
+        @test Bidiagonal(B, :U)  == B
+        @test Bidiagonal(B, :L)  == Diagonal(v2)
+        @test isdiag(B) == (v1 == [0, 0, 0])
+        @test Bidiagonal(Bdiag)  == Bdiag
+        @test Bidiagonal(Bdiag, :U)  == Bdiag
+        @test Bidiagonal(Bdiag, :L)  == Diagonal(v2)
+        @test isdiag(Bdiag) == (v3 == [0, 0, 0])              
+     end
+end
 
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -664,29 +664,29 @@ using .Main.ImmutableArrays
     @test convert(AbstractArray{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
     @test convert(AbstractMatrix{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
 end
-                    
+
 @testset "Tri/Bidiagonal conversion" begin
     BidiagU = Bidiagonal([1, 2, 3, 4] , [1, 2, 3], :U)
     BidiagL = Bidiagonal([1, 2, 3, 4] , [1, 2, 3], :L)
-    Tridiag = Tridiagonal([1, 2, 3] , [1, 2, 3,4], [1, 2, 3])           
+    Tridiag = Tridiagonal([1, 2, 3] , [1, 2, 3,4], [1, 2, 3])
     @test Tridiagonal(BidiagU) == BidiagU
     @test Tridiagonal(BidiagL) == BidiagL
     @test Bidiagonal(Tridiag, :U)  == BidiagU
-    @test Bidiagonal(Tridiag, :L)  == BidiagL               
+    @test Bidiagonal(Tridiag, :L)  == BidiagL
     for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
         v1 = rand(elty, 3)
         v2 = rand(elty, 4)
-        v3 = zeros(elty, 3)       
+        v3 = zeros(elty, 3)
         B = Bidiagonal(v2 , v1, :U)
-        Bdiag = Bidiagonal(v2 , v3, :U)               
-        @test Bidiagonal(B)  == B 
+        Bdiag = Bidiagonal(v2 , v3, :U)
+        @test Bidiagonal(B)  == B
         @test Bidiagonal(B, :U)  == B
         @test Bidiagonal(B, :L)  == Diagonal(v2)
         @test isdiag(B) == (v1 == [0, 0, 0])
         @test Bidiagonal(Bdiag)  == Bdiag
         @test Bidiagonal(Bdiag, :U)  == Bdiag
         @test Bidiagonal(Bdiag, :L)  == Diagonal(v2)
-        @test isdiag(Bdiag) == (v3 == [0, 0, 0])              
+        @test isdiag(Bdiag) == (v3 == [0, 0, 0])
      end
 end
 

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -665,29 +665,4 @@ using .Main.ImmutableArrays
     @test convert(AbstractMatrix{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
 end
 
-@testset "Tri/Bidiagonal conversion" begin
-    BidiagU = Bidiagonal([1, 2, 3, 4] , [1, 2, 3], :U)
-    BidiagL = Bidiagonal([1, 2, 3, 4] , [1, 2, 3], :L)
-    Tridiag = Tridiagonal([1, 2, 3] , [1, 2, 3,4], [1, 2, 3])
-    @test Tridiagonal(BidiagU) == BidiagU
-    @test Tridiagonal(BidiagL) == BidiagL
-    @test Bidiagonal(Tridiag, :U)  == BidiagU
-    @test Bidiagonal(Tridiag, :L)  == BidiagL
-    for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
-        v1 = rand(elty, 3)
-        v2 = rand(elty, 4)
-        v3 = zeros(elty, 3)
-        B = Bidiagonal(v2 , v1, :U)
-        Bdiag = Bidiagonal(v2 , v3, :U)
-        @test Bidiagonal(B)  == B
-        @test Bidiagonal(B, :U)  == B
-        @test Bidiagonal(B, :L)  == Diagonal(v2)
-        @test isdiag(B) == (v1 == [0, 0, 0])
-        @test Bidiagonal(Bdiag)  == Bdiag
-        @test Bidiagonal(Bdiag, :U)  == Bdiag
-        @test Bidiagonal(Bdiag, :L)  == Diagonal(v2)
-        @test isdiag(Bdiag) == (v3 == [0, 0, 0])
-     end
-end
-
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -499,9 +499,9 @@ end
 @testset "det and logdet" begin
     A = [4083 3825 5876 2048 4470 5490;
          3825 3575 5520 1920 4200 5140;
-         5876 5520 8427 2940 6410 7903; 
-         2048 1920 2940 1008 2240 2740; 
-         4470 4200 6410 2240 4875 6015; 
+         5876 5520 8427 2940 6410 7903;
+         2048 1920 2940 1008 2240 2740;
+         4470 4200 6410 2240 4875 6015;
          5490 5140 7903 2740 6015 7370]
     A1 = [4 12 -16;
     12 37 -43;
@@ -509,19 +509,19 @@ end
     A2 = [ 6 15 55
     15 55 225
     55 225 979]
-    B = cholesky(A, Val(true), check=false) 
-    B1 = cholesky(A1, Val(true))     
-    B2 = cholesky(A2, Val(true))  
+    B = cholesky(A, Val(true), check=false)
+    B1 = cholesky(A1, Val(true))
+    B2 = cholesky(A2, Val(true))
     @test det(B)  ≈  0.0
-    @test det(B)  ≈  det(A)
+    @test det(B)  ≈  det(A) atol=eps()
     @test logdet(B)  ≈  -Inf
-    @test logdet(B)  ≈  log(det(A))
+    @test exp(logdet(B))  ≈  det(A) atol=eps()
     @test det(B1)  ≈  det(A1)
-    @test logdet(B1)  ≈  log(det(A1))                        
+    @test logdet(B1)  ≈  log(det(A1))
     @test det(B2)  ≈  det(A2)
-    @test logdet(B2)  ≈  log(det(A2))                                
+    @test logdet(B2)  ≈  log(det(A2))
  end
-                                
+
 @testset "cholesky factorization success, and failure errors" begin
     for T in (Float32, Float64, ComplexF64)
         A = T[  2 -1 0;
@@ -536,9 +536,9 @@ end
                 0 -1 -5 ]
         C = T[  2 -1 1;
                 -1 2 -1;
-                0 -1 2 ]  
-        @test Hermitian(B)==B                              
-        @test Hermitian(C)!=C                              
+                0 -1 2 ]
+        @test Hermitian(B)==B
+        @test Hermitian(C)!=C
         for M in (B, C)
             @test !isposdef(M)
             @test_throws PosDefException cholesky(M)

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -495,7 +495,7 @@ end
     @test B.L ≈ B32.L
     @test B.UL ≈ B32.UL
 end
-                                
+
 @testset "det and logdet" begin
     A = [4083 3825 5876 2048 4470 5490;
          3825 3575 5520 1920 4200 5140;

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -509,43 +509,4 @@ end
     @test logdet(B)  ==  -Inf
  end
 
-@testset "cholesky factorization success, and failure errors" begin
-    for T in (Float32, Float64, ComplexF64)
-        A = T[  2 -1 0;
-            -1 2 -1;
-            0 -1 2 ]
-        @test isposdef(A)
-        @test Hermitian(A)==A
-        @test LinearAlgebra.issuccess(cholesky(A; check = false))
-        @test LinearAlgebra.issuccess(cholesky!(copy(A); check = false))
-        B = T[  2 -1 0;
-                -1 2 -1;
-                0 -1 -5 ]
-        C = T[  2 -1 1;
-                -1 2 -1;
-                0 -1 2 ]
-        @test Hermitian(B)==B
-        @test Hermitian(C)!=C
-        for M in (B, C)
-            @test !isposdef(M)
-            @test_throws PosDefException cholesky(M)
-            @test_throws PosDefException cholesky!(copy(M))
-            @test_throws PosDefException cholesky(M; check = true)
-            @test_throws PosDefException cholesky!(copy(M); check = true)
-            @test !LinearAlgebra.issuccess(cholesky(M; check = false))
-            @test !LinearAlgebra.issuccess(cholesky!(copy(M); check = false))
-            @test_throws RankDeficientException cholesky(M, Val(true))
-            @test_throws RankDeficientException cholesky(M, Val(true); check = true)
-        end
-    end
-    D = ComplexF64[
-        5 2+3im 5im;
-        2-3im 7 1+7im;
-        -5im 1-7im 12]
-    @test isposdef(D)
-    @test Hermitian(D)==D
-    @test LinearAlgebra.issuccess(cholesky(D; check = false))
-    @test LinearAlgebra.issuccess(cholesky!(copy(D); check = false))
-end
-
 end # module TestCholesky

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -495,5 +495,70 @@ end
     @test B.L ≈ B32.L
     @test B.UL ≈ B32.UL
 end
+                                
+@testset "det and logdet" begin
+    A = [4083 3825 5876 2048 4470 5490;
+         3825 3575 5520 1920 4200 5140;
+         5876 5520 8427 2940 6410 7903; 
+         2048 1920 2940 1008 2240 2740; 
+         4470 4200 6410 2240 4875 6015; 
+         5490 5140 7903 2740 6015 7370]
+    A1 = [4 12 -16;
+    12 37 -43;
+    -16 -43 98]
+    A2 = [ 6 15 55
+    15 55 225
+    55 225 979]
+    B = cholesky(A, Val(true), check=false) 
+    B1 = cholesky(A1, Val(true))     
+    B2 = cholesky(A2, Val(true))  
+    @test det(B)  ≈  0.0
+    @test det(B)  ≈  det(A)
+    @test logdet(B)  ≈  -Inf
+    @test logdet(B)  ≈  log(det(A))
+    @test det(B1)  ≈  det(A1)
+    @test logdet(B1)  ≈  log(det(A1))                        
+    @test det(B2)  ≈  det(A2)
+    @test logdet(B2)  ≈  log(det(A2))                                
+ end
+                                
+@testset "cholesky factorization success, and failure errors" begin
+    for T in (Float32, Float64, ComplexF64)
+        A = T[  2 -1 0;
+            -1 2 -1;
+            0 -1 2 ]
+        @test isposdef(A)
+        @test Hermitian(A)==A
+        @test LinearAlgebra.issuccess(cholesky(A; check = false))
+        @test LinearAlgebra.issuccess(cholesky!(copy(A); check = false))
+        B = T[  2 -1 0;
+                -1 2 -1;
+                0 -1 -5 ]
+        C = T[  2 -1 1;
+                -1 2 -1;
+                0 -1 2 ]  
+        @test Hermitian(B)==B                              
+        @test Hermitian(C)!=C                              
+        for M in (B, C)
+            @test !isposdef(M)
+            @test_throws PosDefException cholesky(M)
+            @test_throws PosDefException cholesky!(copy(M))
+            @test_throws PosDefException cholesky(M; check = true)
+            @test_throws PosDefException cholesky!(copy(M); check = true)
+            @test !LinearAlgebra.issuccess(cholesky(M; check = false))
+            @test !LinearAlgebra.issuccess(cholesky!(copy(M); check = false))
+            @test_throws RankDeficientException cholesky(M, Val(true))
+            @test_throws RankDeficientException cholesky(M, Val(true); check = true)
+        end
+    end
+    D = ComplexF64[
+        5 2+3im 5im;
+        2-3im 7 1+7im;
+        -5im 1-7im 12]
+    @test isposdef(D)
+    @test Hermitian(D)==D
+    @test LinearAlgebra.issuccess(cholesky(D; check = false))
+    @test LinearAlgebra.issuccess(cholesky!(copy(D); check = false))
+end
 
 end # module TestCholesky

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -503,23 +503,10 @@ end
          2048 1920 2940 1008 2240 2740;
          4470 4200 6410 2240 4875 6015;
          5490 5140 7903 2740 6015 7370]
-    A1 = [4 12 -16;
-    12 37 -43;
-    -16 -43 98]
-    A2 = [ 6 15 55
-    15 55 225
-    55 225 979]
     B = cholesky(A, Val(true), check=false)
-    B1 = cholesky(A1, Val(true))
-    B2 = cholesky(A2, Val(true))
-    @test det(B)  ≈  0.0
+    @test det(B)  ==  0.0
     @test det(B)  ≈  det(A) atol=eps()
-    @test logdet(B)  ≈  -Inf
-    @test exp(logdet(B))  ≈  det(A) atol=eps()
-    @test det(B1)  ≈  det(A1)
-    @test logdet(B1)  ≈  log(det(A1))
-    @test det(B2)  ≈  det(A2)
-    @test logdet(B2)  ≈  log(det(A2))
+    @test logdet(B)  ==  -Inf
  end
 
 @testset "cholesky factorization success, and failure errors" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -819,5 +819,14 @@ using .Main.ImmutableArrays
     @test convert(AbstractArray{Float64}, D)::Diagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == D
     @test convert(AbstractMatrix{Float64}, D)::Diagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == D
 end
+                                            
+@testset "divisions, rmul! and lmul! functionality" for elty in (Int, Float64, ComplexF64)
+    B = Diagonal(rand(elty,5,5))
+    C = Diagonal(rand(elty,5,5))
+    x = rand(elty)                                  
+    @test \(x, B) == /(B, x)
+    @test rmul!(copy(B),C) == B*C
+    @test lmul!(B,copy(C)) == B*C
+end
 
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -820,13 +820,10 @@ using .Main.ImmutableArrays
     @test convert(AbstractMatrix{Float64}, D)::Diagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == D
 end
 
-@testset "divisions, rmul! and lmul! functionality" for elty in (Int, Float64, ComplexF64)
+@testset "divisions functionality" for elty in (Int, Float64, ComplexF64)
     B = Diagonal(rand(elty,5,5))
-    C = Diagonal(rand(elty,5,5))
     x = rand(elty)
     @test \(x, B) == /(B, x)
-    @test rmul!(copy(B),C) == B*C
-    @test lmul!(B,copy(C)) == B*C
 end
 
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -819,11 +819,11 @@ using .Main.ImmutableArrays
     @test convert(AbstractArray{Float64}, D)::Diagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == D
     @test convert(AbstractMatrix{Float64}, D)::Diagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == D
 end
-                                            
+
 @testset "divisions, rmul! and lmul! functionality" for elty in (Int, Float64, ComplexF64)
     B = Diagonal(rand(elty,5,5))
     C = Diagonal(rand(elty,5,5))
-    x = rand(elty)                                  
+    x = rand(elty)
     @test \(x, B) == /(B, x)
     @test rmul!(copy(B),C) == B*C
     @test lmul!(B,copy(C)) == B*C

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -668,21 +668,11 @@ end
 
 @testset "dot(x,A,y) for A::Tridiagonal or SymTridiagonal" begin
     for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
-        n = 4
-        v1 = rand(elty, n-1)
-        v2 = rand(elty, n)
-        v3 = rand(elty, n-1)
-        T = Tridiagonal(v1, v2, v3)
-        Tsym = SymTridiagonal(v2, v1)
-        x = fill(convert(elty, 1), n)
-        y = fill(convert(elty, 2), n)
-        x1 = fill(convert(elty, 1), 0)
-        T1 = Tridiagonal(x1, x1, x1)
-        Tsym1 = SymTridiagonal(x1, x1)
-        @test dot(x, T, y)  ≈ dot(x, T*y)
-        @test dot(x, Tsym, y)  ≈ dot(x, Tsym*y)
-        @test dot(x1, T1, x1)   ≈ 0.0
-        @test dot(x1, Tsym1, x1)   ≈ 0.0
+        x = fill(convert(elty, 1), 0)
+        T = Tridiagonal(x, x, x)
+        Tsym = SymTridiagonal(x, x)
+        @test dot(x, T, x)   ≈ 0.0
+        @test dot(x, Tsym, x)   ≈ 0.0
     end
 end
 

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -671,8 +671,8 @@ end
         x = fill(convert(elty, 1), 0)
         T = Tridiagonal(x, x, x)
         Tsym = SymTridiagonal(x, x)
-        @test dot(x, T, x)   ≈ 0.0
-        @test dot(x, Tsym, x)   ≈ 0.0
+        @test dot(x, T, x) == 0.0
+        @test dot(x, Tsym, x) == 0.0
     end
 end
 

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -665,5 +665,25 @@ using .Main.ImmutableArrays
     @test convert(AbstractArray{Float64}, Tsym)::SymTridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Tsym
     @test convert(AbstractMatrix{Float64}, Tsym)::SymTridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Tsym
 end
+    
+@testset "dot(x,A,y) for A::Tridiagonal or SymTridiagonal" begin
+    for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
+        n = 4
+        v1 = rand(elty, n-1)
+        v2 = rand(elty, n)
+        v3 = rand(elty, n-1)
+        T = Tridiagonal(v1, v2, v3)
+        Tsym = SymTridiagonal(v2, v1)
+        x = fill(convert(elty, 1), n)
+        y = fill(convert(elty, 2), n)   
+        x1 = fill(convert(elty, 1), 0)
+        T1 = Tridiagonal(x1, x1, x1)
+        Tsym1 = SymTridiagonal(x1, x1)
+        @test dot(x, T, y)  ≈ dot(x, T*y)
+        @test dot(x, Tsym, y)  ≈ dot(x, Tsym*y)   
+        @test dot(x1, T1, x1)   ≈ 0.0
+        @test dot(x1, Tsym1, x1)   ≈ 0.0   
+    end
+end
 
 end # module TestTridiagonal

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -665,7 +665,7 @@ using .Main.ImmutableArrays
     @test convert(AbstractArray{Float64}, Tsym)::SymTridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Tsym
     @test convert(AbstractMatrix{Float64}, Tsym)::SymTridiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Tsym
 end
-    
+
 @testset "dot(x,A,y) for A::Tridiagonal or SymTridiagonal" begin
     for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
         n = 4
@@ -675,14 +675,14 @@ end
         T = Tridiagonal(v1, v2, v3)
         Tsym = SymTridiagonal(v2, v1)
         x = fill(convert(elty, 1), n)
-        y = fill(convert(elty, 2), n)   
+        y = fill(convert(elty, 2), n)
         x1 = fill(convert(elty, 1), 0)
         T1 = Tridiagonal(x1, x1, x1)
         Tsym1 = SymTridiagonal(x1, x1)
         @test dot(x, T, y)  ≈ dot(x, T*y)
-        @test dot(x, Tsym, y)  ≈ dot(x, Tsym*y)   
+        @test dot(x, Tsym, y)  ≈ dot(x, Tsym*y)
         @test dot(x1, T1, x1)   ≈ 0.0
-        @test dot(x1, Tsym1, x1)   ≈ 0.0   
+        @test dot(x1, Tsym1, x1)   ≈ 0.0
     end
 end
 


### PR DESCRIPTION
Added test sets for some functions in the linear algebra package, which were not, or only once or twice, covered by tests.

- Bidiag.jl

    1. a test set for checking the conversion of Tri/Bidiagonal matrices to/from Tri/Bidiagonal matrices.

- cholesky.jl

    1. a test set for checking the functionality of det and logdet on ::Cholesky type.
    2. a test set for checking the success or failure of cholesky decomposition on different matrices.

- Diagonal.jl

    1. a test set for three functions, divisions, rmul! and lmul!, which were not properly covered by tests.

- Tridiag.jl

    1. a test set for checking the functionality of dot(x,A,y) for A::Tridiagonal or SymTridiagonal.