### PR TITLE
Adding two functions to the LinearAlgebra package

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -95,6 +95,7 @@ export
     ishermitian,
     isposdef,
     isposdef!,
+    ispos_sdef,
     issuccess,
     issymmetric,
     istril,

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1666,4 +1666,4 @@ true
 ```
 """
 ispos_sdef(A::AbstractMatrix) = ishermitian(A) && isposdef(cholesky(Hermitian(A) + eps() * I(size(A)[1]); check = false))
-ispos_sdef(x::Number) = imag(x)==0 && real(x) >=0
+ispos_sdef(x::Number) = imag(x) == 0 && real(x) >= 0

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1646,3 +1646,22 @@ function lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:BlasFloat}
 end
 lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:Integer} = lyap(float(A), float(C))
 lyap(a::Union{Real,Complex}, c::Union{Real,Complex}) = -c/(2real(a))
+
+"""
+    ispos_sdef(A) -> Bool
+
+Test whether a matrix is positive semidefinite (and Hermitian) by calling isposdef, which trys to perform a
+Cholesky factorization of `A`.
+See also [`isposdef`](@ref), [`cholesky`](@ref).
+# Examples
+```jldoctest
+julia> A = [9 -15; -15 25]
+2×2 Matrix{Int64}:
+ 9   -15
+ -15  25
+julia> ispos_sdef(A)
+true
+```
+"""
+ispos_sdef(A::AbstractMatrix) = ishermitian(A) && isposdef(cholesky(Hermitian(A) + eps() * I(size(A)[1]); check = false))
+ispos_sdef(x::Number) = imag(x)==0 && real(x) >=0

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1648,7 +1648,7 @@ lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:Integer} = lyap(float(A
 lyap(a::Union{Real,Complex}, c::Union{Real,Complex}) = -c/(2real(a))
 
 """
-    ispos_sdef(A) -> Bool
+    ispos_sdef(A, atol) -> Bool
 
 Test whether a matrix is positive semidefinite (and Hermitian) by calling isposdef, which trys to perform a
 Cholesky factorization of `A`.
@@ -1658,12 +1658,12 @@ See also [`isposdef`](@ref), [`cholesky`](@ref).
 ```jldoctest
 julia> A = [9 -15; -15 25]
 2×2 Matrix{Int64}:
- 9   -15
- -15  25
+   9  -15
+ -15   25
 
 julia> ispos_sdef(A)
 true
 ```
 """
-ispos_sdef(A::AbstractMatrix) = ishermitian(A) && isposdef(cholesky(Hermitian(A) + eps() * I(size(A)[1]); check = false))
+ispos_sdef(A::AbstractMatrix, atol::Real=1e-8) = ishermitian(A) && isposdef(cholesky(Hermitian(A) + atol * I(size(A)[1]); check = false))
 ispos_sdef(x::Number) = imag(x) == 0 && real(x) >= 0

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1653,12 +1653,14 @@ lyap(a::Union{Real,Complex}, c::Union{Real,Complex}) = -c/(2real(a))
 Test whether a matrix is positive semidefinite (and Hermitian) by calling isposdef, which trys to perform a
 Cholesky factorization of `A`.
 See also [`isposdef`](@ref), [`cholesky`](@ref).
+
 # Examples
 ```jldoctest
 julia> A = [9 -15; -15 25]
 2×2 Matrix{Int64}:
  9   -15
  -15  25
+
 julia> ispos_sdef(A)
 true
 ```

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1817,7 +1817,7 @@ julia> B = [1 3;2 4;3 6]
  3  6
 
 julia> cross(A, B)
-3×2 Array{Int64}:
+3×2 Matrix{Int64}:
  -1   0
   2   6
  -1  -4

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1817,7 +1817,7 @@ julia> B = [1 3;2 4;3 6]
  3  6
 
 julia> cross(A, B)
-3×2 Array{Int64,2}:
+3×2 Array{Int64}:
  -1   0
   2   6
  -1  -4

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1795,3 +1795,42 @@ function normalize(a::AbstractArray, p::Real = 2)
         return T[]
     end
 end
+
+"""
+    cross(A, B)
+    ×(A,B)
+
+Compute the cross product of two matrices.
+
+# Examples
+```jldoctest
+julia> a = [1 2;3 4;5 6]
+3×2 Matrix{Int64}:
+ 1  2
+ 3  4
+ 5  6
+julia> b = [1 3;2 4;3 6]
+3×2 Matrix{Int64}:
+ 1  3
+ 2  4
+ 3  6
+julia> cross(a,b)
+3-element Vector{Int64}:
+ -1.0   0.0
+  2.0   6.0
+ -1.0  -4.0
+```
+"""
+function cross(A::AbstractMatrix, B::AbstractMatrix)
+    if !(size(A)[1] == size(B)[1] == 3)
+        throw(DimensionMismatch("cross product is only defined for matrices with column length of 3"))
+    elseif  !(size(A)[2] == size(B)[2])
+        throw(DimensionMismatch("A and B must have same dimensions"))
+    end
+    cols = size(A)[2]
+    c = zeros(3, cols)
+    for i in 1:cols
+        c[:,i] = cross(A[:,i], B[:,i])
+    end
+    c
+end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1804,21 +1804,23 @@ Compute the cross product of two matrices.
 
 # Examples
 ```jldoctest
-julia> a = [1 2;3 4;5 6]
+julia> A = [1 2;3 4;5 6]
 3×2 Matrix{Int64}:
  1  2
  3  4
  5  6
-julia> b = [1 3;2 4;3 6]
+
+julia> B = [1 3;2 4;3 6]
 3×2 Matrix{Int64}:
  1  3
  2  4
  3  6
-julia> cross(a,b)
-3-element Vector{Int64}:
- -1.0   0.0
-  2.0   6.0
- -1.0  -4.0
+
+julia> cross(A, B)
+3×2 Array{Int64,2}:
+ -1   0
+  2   6
+ -1  -4
 ```
 """
 function cross(A::AbstractMatrix, B::AbstractMatrix)
@@ -1828,9 +1830,9 @@ function cross(A::AbstractMatrix, B::AbstractMatrix)
         throw(DimensionMismatch("A and B must have same dimensions"))
     end
     cols = size(A)[2]
-    c = zeros(3, cols)
+    C = zeros(eltype(A), 3, cols)
     for i in 1:cols
-        c[:,i] = cross(A[:,i], B[:,i])
+        C[:,i] = cross(A[:,i], B[:,i])
     end
-    c
+    C
 end


### PR DESCRIPTION
Added some functions to the LinearAlgebra package.

- dense.jl
    - ispos_sdef(A::AbstractMatrix): This function inputs an ::AbstractMatrix and returns true, if the input is positive semi-definite; false, otherwise.
    - ispos_sdef(x::Number): This function inputs a ::Number and returns true, if it is positive semi-definite; false, otherwise.

- generic.jl
    - cross(A::AbstractMatrix, B::AbstractMatrix): This function inputs two 3×n matrices of type ::AbstractMatrix and returns a 3×n matrix, which it's i-th column is the cross product of i-th columns of A and B.