### PR TITLE
CI: Add more Debian packages to the `llvm-passes` rootfs image

### DIFF
--- a/.buildkite/rootfs_images/llvm-passes.jl
+++ b/.buildkite/rootfs_images/llvm-passes.jl
@@ -9,17 +9,18 @@ include("rootfs_utils.jl")
 # Build debian-based image with the following extra packages:
 packages = [
     "build-essential",
+    "cmake",
+    "curl",
+    "gfortran",
+    "git",
+    "less",
     "libatomic1",
+    "m4",
+    "perl",
+    "pkg-config",
     "python",
     "python3",
-    "gfortran",
-    "perl",
     "wget",
-    "m4",
-    "cmake",
-    "pkg-config",
-    "curl",
-    "git",
 ]
 tarball_path = debootstrap("llvm-passes"; packages)
 

--- a/.buildkite/rootfs_images/llvm-passes.jl
+++ b/.buildkite/rootfs_images/llvm-passes.jl
@@ -8,6 +8,7 @@ include("rootfs_utils.jl")
 
 # Build debian-based image with the following extra packages:
 packages = [
+    "bash",
     "build-essential",
     "cmake",
     "curl",


### PR DESCRIPTION
- We need `bash` for the test suite.
- We need `less` for the doctests.
- Also, sort the entries of `packages` in alphabetical order to make it easier to find specific entries in the list.