### PR TITLE
add default "auto" as option to --check-bounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ New language features
 
 * `Module(:name, false, false)` can be used to create a `module` that does not import `Core`. ([#40110])
 * `@inline` and `@noinline` annotations may now be used in function bodies. ([#41312])
+* The default behavior of observing `@inbounds` declarations is now an option via `auto` in `--check-bounds=yes|no|auto` ([#41551])
 
 Language changes
 ----------------

--- a/base/util.jl
+++ b/base/util.jl
@@ -174,7 +174,7 @@ function julia_cmd(julia=joinpath(Sys.BINDIR::String, julia_exename()))
                   elseif opts.check_bounds == 2
                       "no" # off
                   else
-                      "" # "default"
+                      "" # default = "auto"
                   end
         isempty(check_bounds) || push!(addflags, "--check-bounds=$check_bounds")
     end

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -162,8 +162,8 @@ Set the level of debug info generation to <n>
 Control whether inlining is permitted (overrides functions declared as @inline)
 
 .TP
---check-bounds={yes|no}
-Emit bounds checks always or never (ignoring declarations)
+--check-bounds={yes|no|auto}
+Emit bounds checks always, never, or respect @inbounds declarations
 
 .TP
 --math-mode={ieee|user}

--- a/doc/src/devdocs/boundscheck.md
+++ b/doc/src/devdocs/boundscheck.md
@@ -92,4 +92,4 @@ the last argument).
 
 ## Emit bounds checks
 
-Julia can be launched with `--check-bounds={yes|no}` to emit bounds checks always or never (ignoring declarations).
+Julia can be launched with `--check-bounds={yes|no|auto}` to emit bounds checks always, never, or respect @inbounds declarations.

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -31,7 +31,7 @@ The following is a complete list of command-line switches available when launchi
 |`--min-optlevel={0,1,2,3}`             |Set the lower bound on per-module optimization (default is 0)|
 |`-g`, `-g <level>`                     |Enable / Set the level of debug info generation (default level is 1 if unspecified or 2 if used without a level)|
 |`--inline={yes\|no}`                   |Control whether inlining is permitted, including overriding `@inline` declarations|
-|`--check-bounds={yes\|no}`             |Emit bounds checks always or never (ignoring declarations)|
+|`--check-bounds={yes\|no\|auto}`       |Emit bounds checks always, never, or respect @inbounds declarations|
 |`--math-mode={ieee,fast}`              |Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)|
 |`--code-coverage={none\|user\|all}`    |Count executions of source lines|
 |`--code-coverage`                      |equivalent to `--code-coverage=user`|

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -131,7 +131,8 @@ static const char opts[]  =
         " (default level is 1 if unspecified or 2 if used without a level)\n"
 #endif
     " --inline={yes|no}         Control whether inlining is permitted, including overriding @inline declarations\n"
-    " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring @inbounds declarations)\n"
+    " --check-bounds={yes|no|auto}\n"
+    "                           Emit bounds checks always, never, or respect @inbounds declarations\n"
 #ifdef USE_POLLY
     " --polly={yes|no}          Enable or disable the polyhedral optimizer Polly (overrides @polly declaration)\n"
 #endif
@@ -565,8 +566,10 @@ restart_switch:
                 jl_options.check_bounds = JL_OPTIONS_CHECK_BOUNDS_ON;
             else if (!strcmp(optarg,"no"))
                 jl_options.check_bounds = JL_OPTIONS_CHECK_BOUNDS_OFF;
+            else if (!strcmp(optarg,"auto"))
+                jl_options.check_bounds = JL_OPTIONS_CHECK_BOUNDS_DEFAULT;
             else
-                jl_errorf("julia: invalid argument to --check-bounds={yes|no} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --check-bounds={yes|no|auto} (%s)", optarg);
             break;
         case opt_output_bc:
             jl_options.outputbc = optarg;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -397,6 +397,8 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         @test parse(Int, readchomp(`$exename_default_checkbounds -E "Int(Base.JLOptions().check_bounds)"`)) ==
             JL_OPTIONS_CHECK_BOUNDS_DEFAULT
         @test parse(Int, readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"
+            --check-bounds=auto`)) == JL_OPTIONS_CHECK_BOUNDS_DEFAULT
+        @test parse(Int, readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"
             --check-bounds=yes`)) == JL_OPTIONS_CHECK_BOUNDS_ON
         @test parse(Int, readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"
             --check-bounds=no`)) == JL_OPTIONS_CHECK_BOUNDS_OFF


### PR DESCRIPTION
It seems to be unusual that neither of the `--check-bounds={yes|no}` options are the default state, so this adds "auto" to make it `--check-bounds={yes|no|auto}`

It would make overruling this arg back to default state possible, for instance in https://github.com/JuliaLang/Pkg.jl/pull/2668 (although that can be fixed in other ways)