### PR TITLE
done todo at the latex code block function

### DIFF
--- a/stdlib/Markdown/src/render/latex.jl
+++ b/stdlib/Markdown/src/render/latex.jl
@@ -33,8 +33,8 @@ function latex(io::IO, header::Header{l}) where l
 end
 
 function latex(io::IO, code::Code)
+    occursin("\\end{verbatim}", code.code) && error("Cannot include \"\\end{verbatim}\" in a latex code block")
     wrapblock(io, "verbatim") do
-        # TODO latex escape
         println(io, code.code)
     end
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1230,3 +1230,24 @@ end
     @test sprint(show, MIME("text/plain"), s) == "  Misc:\n  - line"
 end
 
+@testset "pullrequest #41552: a code block has \\end{verbatim}" begin
+    s1 = md"""
+         ```tex
+         \begin{document}
+         \end{document}
+         ```
+         """
+    s2 = md"""
+         ```tex
+         \begin{verbatim}
+         \end{verbatim}
+         ```
+         """
+    @test Markdown.latex(s1) == """
+                                \\begin{verbatim}
+                                \\begin{document}
+                                \\end{document}
+                                \\end{verbatim}
+                                """
+    @test_throws ErrorException Markdown.latex(s2)
+end


### PR DESCRIPTION
This is the process of replacing Markdown code blocks with LaTeX's verbatim environment.
In this comment, it is assumed that escaping of LaTeX special characters is required to replace the verbatim environment, but in fact, no escaping is required.
However, if the string \end{verbatim} appears in the code, the verbatim environment is terminated, and inconsistent LaTeX code is output.
So, I added an error message if \end{verbatim} is included.