### PR TITLE
Fix `get-task-allow` entitlement

### DIFF
--- a/contrib/mac/app/Entitlements.plist
+++ b/contrib/mac/app/Entitlements.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
-	<key>com.apple.security.cs.get-task-allow</key>
+	<key>com.apple.security.get-task-allow</key>
 	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>


### PR DESCRIPTION
We had apparently misspelled this entitlement, not allowing `lldb` to attach to official macOS builds.