### PR TITLE
update expression size rules

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2949,3 +2949,13 @@ end
     @test x == 1
     @test f() == (2, 3)
 end
+
+@testset "long function bodies" begin
+    ex = Expr(:block)
+    ex.args = fill!(Vector{Any}(undef, 700000), 1)
+    f = eval(Expr(:function, :(), ex))
+    @test f() == 1
+    ex = Expr(:vcat)
+    ex.args = fill!(Vector{Any}(undef, 600000), 1)
+    @test_throws ErrorException("syntax: expression too large") eval(ex)
+end


### PR DESCRIPTION
- allow any-length blocks
- other expressions seem to need a slightly lower limit due to stack overflow in calls

This is intended to fix some issues in ModelingToolkit, which sometimes generates large functions.

In general, we seem to handle big expressions better now; particularly the front-end seems to be "iterative enough" for most cases. Very long argument lists tend to cause stack overflows during execution, but long function bodies seem to be ok. The only problems tend to be long compile times or memory use, but that's unavoidable so I think we can just allow anything here now.
