### PR TITLE
Broaden array constructor to allow any fill value

### DIFF
--- a/base/baseext.jl
+++ b/base/baseext.jl
@@ -39,8 +39,6 @@ Vector() = Vector{Any}(undef, 0)
 
 # Array constructors for nothing and missing
 # type and dimensionality specified
-Array{T,N}(::Nothing, d...) where {T,N} = fill!(Array{T,N}(undef, d...), nothing)
-Array{T,N}(::Missing, d...) where {T,N} = fill!(Array{T,N}(undef, d...), missing)
+Array{T,N}(x::T, d...) where {T,N} = fill!(Array{T,N}(undef, d...), x)
 # type but not dimensionality specified
-Array{T}(::Nothing, d...) where {T} = fill!(Array{T}(undef, d...), nothing)
-Array{T}(::Missing, d...) where {T} = fill!(Array{T}(undef, d...), missing)
+Array{T}(x::T, d...) where {T} = fill!(Array{T}(undef, d...), x)


### PR DESCRIPTION
It seems odd to me that `Array{Union{Missing, T}}(missing, n...)` and `Array{Union{Nothing, T}}(nothing, n...)` exist but the more general case `Array{T}(x::T, n...)` does not. 

There are some potential issues I'm sure. For one it makes `Array{T}(undef, n...)` seem even more of an odd one out, rather than just the only strange one out of three options (the other two being `nothing` and `missing`). But I'm inclined to think this reduces the inconsistency since there are only two options, `x::UndefInitializer` and `x::T` after the change.