### PR TITLE
wip: inference: fix #41450, replace constant-folded `muladd` with `fma`

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -111,6 +111,9 @@ using .Sort
 something(x::Nothing, y...) = something(y...)
 something(x::Any, y...) = x
 
+const ARCH = ccall(:jl_get_ARCH, Any, ())
+include("build_h.jl")
+
 ############
 # compiler #
 ############
@@ -142,4 +145,3 @@ Core.eval(Core, :(_parse = Compiler.fl_parse))
 
 end # baremodule Compiler
 ))
-

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -112,6 +112,7 @@ something(x::Nothing, y...) = something(y...)
 something(x::Any, y...) = x
 
 const ARCH = ccall(:jl_get_ARCH, Any, ())
+const KERNEL = ccall(:jl_get_UNAME, Any, ())
 include("build_h.jl")
 
 ############

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1521,7 +1521,7 @@ fma_libm(x::Float64, y::Float64, z::Float64) =
     ccall(("fma", libm_name), Float64, (Float64,Float64,Float64), x, y, z)
 fma_llvm(x::Float32, y::Float32, z::Float32) = fma_float(x, y, z)
 fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
-if ARCH !== :i686 &&
+if !(ARCH === :i686 || KERNEL === :Windows || KERNEL === :NT) &&
    fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
    fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) == 1.8626451500983188e-9 &&
    add_float(0.1, 0.2) == 0.30000000000000004

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -341,7 +341,8 @@ fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
 # If fma_llvm() clobbers the rounding mode, the result of 0.1 + 0.2 will be 0.3
 # instead of the properly-rounded 0.30000000000000004; check after calling fma
 # NOTE this system level check is also used in compiler/tfuncs.jl, make sure to sync them
-if Sys.ARCH !== :i686 &&
+
+if !(Sys.ARCH === :i686 || Sys.iswindows()) &&
    fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
    fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) == 1.8626451500983188e-9 &&
    0.1 + 0.2 == 0.30000000000000004

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -340,9 +340,11 @@ fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
 # 1.0000000009313226 = 1 + 1/2^30
 # If fma_llvm() clobbers the rounding mode, the result of 0.1 + 0.2 will be 0.3
 # instead of the properly-rounded 0.30000000000000004; check after calling fma
-if (Sys.ARCH !== :i686 && fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
-    (fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) ==
-     1.8626451500983188e-9) && 0.1 + 0.2 == 0.30000000000000004)
+# NOTE this system level check is also used in compiler/tfuncs.jl, make sure to sync them
+if Sys.ARCH !== :i686 &&
+   fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
+   fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) == 1.8626451500983188e-9 &&
+   0.1 + 0.2 == 0.30000000000000004
     fma(x::Float32, y::Float32, z::Float32) = fma_llvm(x,y,z)
     fma(x::Float64, y::Float64, z::Float64) = fma_llvm(x,y,z)
 else

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3395,3 +3395,9 @@ end
         x.x
     end) == Any[Int]
 end
+
+# https://github.com/JuliaLang/julia/issues/41450
+@test (@eval Module() begin
+    foo(x=1.0) = muladd(1 + eps(x), 1 - eps(x), -1)
+    foo() == foo(1.0)
+end)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -606,8 +606,7 @@ end
         @test log(x) == log(42)
         @test isinf(log(BigFloat(0)))
         @test_throws DomainError log(BigFloat(-1))
-        # issue #41450
-        @test_skip log2(x) == log2(42)
+        @test log2(x) == log2(42)
         @test isinf(log2(BigFloat(0)))
         @test_throws DomainError log2(BigFloat(-1))
         @test log10(x) == log10(42)


### PR DESCRIPTION
So that we can get more accurate results where performance doesn't matter.

---

Followed @Keno 's comment [here](https://github.com/JuliaLang/julia/issues/41450#issuecomment-873476898)