### PR TITLE
CI (rootfs_utils): Require that the user explicitly specify the `tag_name`

### DIFF
--- a/.buildkite/rootfs_images/llvm-passes.jl
+++ b/.buildkite/rootfs_images/llvm-passes.jl
@@ -4,6 +4,11 @@
 ## Eventually, this image will probably be replaced with the actual builder image,
 ## as that will have the necessary toolchains as well, but that image is not built yet.
 
+if length(ARGS) != 1
+    throw(ArgumentError("Usage: llvm-passes.jl [tag_name]"))
+end
+const tag_name = convert(String, strip(ARGS[1]))::String
+
 include("rootfs_utils.jl")
 
 # Build debian-based image with the following extra packages:
@@ -26,4 +31,4 @@ packages = [
 tarball_path = debootstrap("llvm-passes"; packages)
 
 # Upload it
-upload_rootfs_image(tarball_path; tag_name = "v1")
+upload_rootfs_image(tarball_path; tag_name)

--- a/.buildkite/rootfs_images/rootfs_utils.jl
+++ b/.buildkite/rootfs_images/rootfs_utils.jl
@@ -84,7 +84,7 @@ end
 
 function upload_rootfs_image(tarball_path::String;
                              github_repo::String="JuliaCI/rootfs-images",
-                             tag_name::String="v1")
+                             tag_name::String)
     # Upload it to `github_repo`
     tarball_url = "https://github.com/$(github_repo)/releases/download/$(tag_name)/$(basename(tarball_path))"
     @info("Uploading to $(github_repo)@$(tag_name)", tarball_url)


### PR DESCRIPTION
This will help prevent users from accidentally overwriting an existing tag.