### PR TITLE
CI: Add rootfs definitions for `buildkite-agent`, `package_linux64`, and `package_musl64`

### DIFF
--- a/.buildkite/rootfs_images/README.md
+++ b/.buildkite/rootfs_images/README.md
@@ -7,23 +7,3 @@ Most images are based on Debian, making use of `debootstrap` to provide a quick 
 ## Testing out a rootfs image
 
 If you want to test a rootfs image locally, you can use the `test_roofs.jl` script, passing in the URL of the rootfs you want to test.  It will drop you into a shell within the build environment, where you can recreate build failures more reliably.
-
-## Building a rootfs image with Docker
-
-On your local machine:
-```
-$ git clone git@github.com:JuliaLang/julia.git
-$ docker run --privileged --rm -it -v $(pwd):/root/workspace julia:buster /bin/bash
-```
-
-Now, inside the Docker container:
-```
-# cd
-# apt-get update && apt-get -y install debootstrap sudo
-# cd /root/workspace/julia/.buildkite/rootfs_images/
-# rm -rf ~/.julia
-# julia -e 'using Pkg; Pkg.add(["Scratch", "ghr_jll"]); Pkg.update()'
-# julia -e 'using Pkg; Pkg.precompile()'
-# export GITHUB_TOKEN="my-github-token-goes-here"
-# julia llvm-passes.jl
-```

--- a/.buildkite/rootfs_images/README.md
+++ b/.buildkite/rootfs_images/README.md
@@ -3,3 +3,7 @@
 Our CI setup makes use of rootfs images that contain our build tools.
 These rootfs images are built using the fairly simple scripts held within this directory.
 Most images are based on Debian, making use of `debootstrap` to provide a quick and easy rootfs with packages installed through an initial `apt` invocation.
+
+## Testing out a rootfs image
+
+If you want to test a rootfs image locally, you can use the `test_roofs.jl` script, passing in the URL of the rootfs you want to test.  It will drop you into a shell within the build environment, where you can recreate build failures more reliably.

--- a/.buildkite/rootfs_images/README.md
+++ b/.buildkite/rootfs_images/README.md
@@ -7,3 +7,23 @@ Most images are based on Debian, making use of `debootstrap` to provide a quick 
 ## Testing out a rootfs image
 
 If you want to test a rootfs image locally, you can use the `test_roofs.jl` script, passing in the URL of the rootfs you want to test.  It will drop you into a shell within the build environment, where you can recreate build failures more reliably.
+
+## Building a rootfs image with Docker
+
+On your local machine:
+```
+$ git clone git@github.com:JuliaLang/julia.git
+$ docker run --privileged --rm -it -v $(pwd):/root/workspace julia:buster /bin/bash
+```
+
+Now, inside the Docker container:
+```
+# cd
+# apt-get update && apt-get -y install debootstrap sudo
+# cd /root/workspace/julia/.buildkite/rootfs_images/
+# rm -rf ~/.julia
+# julia -e 'using Pkg; Pkg.add(["Scratch", "ghr_jll"]); Pkg.update()'
+# julia -e 'using Pkg; Pkg.precompile()'
+# export GITHUB_TOKEN="my-github-token-goes-here"
+# julia llvm-passes.jl
+```

--- a/.buildkite/rootfs_images/buildkite-agent.jl
+++ b/.buildkite/rootfs_images/buildkite-agent.jl
@@ -1,0 +1,42 @@
+#!/usr/bin/env julia
+
+## This rootfs includes just enough of the tools for our buildkite agent
+## to run inside of.  Most CI steps will be run within a different image
+## nested inside of this one.
+
+if length(ARGS) != 1
+    throw(ArgumentError("Usage: buildkite-agent.jl [tag_name]"))
+end
+const tag_name = convert(String, strip(ARGS[1]))::String
+include("rootfs_utils.jl")
+
+# Build debian-based image with the following extra packages:
+packages = [
+    # General package getting/installing packages
+    "apt-transport-https",
+    "curl",
+    "gnupg2",
+    "openssh-client",
+    "wget",
+    # We use these in our buildkite plugins a lot
+    "git",
+    "jq",
+    "openssl",
+    "python3",
+    # Debugging
+    "vim",
+]
+tarball_path = debootstrap("buildkite-agent"; packages) do rootfs
+    # Also download buildkite-agent
+    @info("Installing buildkite-agent...")
+    buildkite_install_cmd = """
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' >> /etc/apt/sources.list && \\
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x32A37959C2FA5C3C99EFBC32A79206696452D198" | apt-key add - && \\
+    apt-get update && \\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y buildkite-agent
+    """
+    chroot(rootfs, "bash", "-c", buildkite_install_cmd; uid=0, gid=0)
+end
+
+# Upload it
+upload_rootfs_image(tarball_path; tag_name)

--- a/.buildkite/rootfs_images/package_linux64.jl
+++ b/.buildkite/rootfs_images/package_linux64.jl
@@ -1,0 +1,54 @@
+#!/usr/bin/env julia
+
+## This rootfs includes enough of a host toolchain to build the LLVM passes.
+## Eventually, this image will probably be replaced with the actual builder image,
+## as that will have the necessary toolchains as well, but that image is not built yet.
+
+if length(ARGS) != 1
+    throw(ArgumentError("Usage: package_linux64.jl [tag_name]"))
+end
+const tag_name = convert(String, strip(ARGS[1]))::String
+
+include("rootfs_utils.jl")
+
+# Build debian-based image with the following extra packages:
+packages = [
+    "automake",
+    "bash",
+    "bison",
+    "cmake",
+    "curl",
+    "flex",
+    "gdb",
+    "git",
+    "less",
+    "libatomic1",
+    "libtool",
+    "m4",
+    "make",
+    "perl",
+    "pkg-config",
+    "python3",
+    "wget",
+    "vim",
+]
+tarball_path = debootstrap("package_linux64"; packages) do rootfs
+    # Install GCC 9, specifically
+    @info("Installing gcc-9")
+    gcc_install_cmd = """
+    echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \\
+    apt-get update && \\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \\
+        gcc-9 g++-9 gfortran-9
+
+    # Create symlinks for `gcc` -> `gcc-9`, etc...
+    for tool_path in /usr/bin/*-9; do
+        tool="\$(basename "\${tool_path}" | sed -e 's/-9//')"
+        ln -sf "\${tool}-9" "/usr/bin/\${tool}"
+    done
+    """
+    chroot(rootfs, "bash", "-c", gcc_install_cmd; uid=0, gid=0)
+end
+
+# Upload it
+upload_rootfs_image(tarball_path; tag_name)

--- a/.buildkite/rootfs_images/package_linux64.jl
+++ b/.buildkite/rootfs_images/package_linux64.jl
@@ -1,15 +1,11 @@
 #!/usr/bin/env julia
 
-## This rootfs includes enough of a host toolchain to build the LLVM passes.
-## Eventually, this image will probably be replaced with the actual builder image,
-## as that will have the necessary toolchains as well, but that image is not built yet.
-
-if length(ARGS) != 1
-    throw(ArgumentError("Usage: package_linux64.jl [tag_name]"))
-end
-const tag_name = convert(String, strip(ARGS[1]))::String
+## This rootfs includes everything that must be installed to build Julia
+## within a debian-based environment with GCC 9.
 
 include("rootfs_utils.jl")
+
+const tag_name, force_overwrite = get_arguments(ARGS, @__FILE__)
 
 # Build debian-based image with the following extra packages:
 packages = [
@@ -51,4 +47,4 @@ tarball_path = debootstrap("package_linux64"; packages) do rootfs
 end
 
 # Upload it
-upload_rootfs_image(tarball_path; tag_name)
+upload_rootfs_image(tarball_path; tag_name, force_overwrite)

--- a/.buildkite/rootfs_images/package_musl64.jl
+++ b/.buildkite/rootfs_images/package_musl64.jl
@@ -1,0 +1,24 @@
+#!/usr/bin/env julia
+
+include("rootfs_utils.jl")
+
+packages = [
+    AlpinePackage("bash"),
+    AlpinePackage("cmake"),
+    AlpinePackage("curl"),
+    AlpinePackage("git"),
+    AlpinePackage("less"),
+    AlpinePackage("m4"),
+    AlpinePackage("perl"),
+    AlpinePackage("python3"),
+    AlpinePackage("wget"),
+
+    # Install gcc/g++/gfortran v9, which comes from the Alpine v3.11 line
+    AlpinePackage("g++~9", "v3.11"),
+    AlpinePackage("gcc~9", "v3.11"),
+    AlpinePackage("gfortran~9", "v3.11"),
+]
+tarball_path = alpine_bootstrap("package_musl64"; packages)
+
+# Upload the alpine rootfs
+upload_rootfs_image(tarball_path; tag_name = "v1")

--- a/.buildkite/rootfs_images/package_musl64.jl
+++ b/.buildkite/rootfs_images/package_musl64.jl
@@ -1,7 +1,13 @@
 #!/usr/bin/env julia
 
+## This rootfs includes everything that must be installed to build Julia
+## within an alpine-based environment with GCC 9.
+
 include("rootfs_utils.jl")
 
+const tag_name, force_overwrite = get_arguments(ARGS, @__FILE__)
+
+# Build alpine-based image with the following extra packages:
 packages = [
     AlpinePackage("bash"),
     AlpinePackage("cmake"),
@@ -20,5 +26,5 @@ packages = [
 ]
 tarball_path = alpine_bootstrap("package_musl64"; packages)
 
-# Upload the alpine rootfs
-upload_rootfs_image(tarball_path; tag_name = "v1")
+# Upload it
+upload_rootfs_image(tarball_path; tag_name, force_overwrite)

--- a/.buildkite/rootfs_images/rootfs_utils.jl
+++ b/.buildkite/rootfs_images/rootfs_utils.jl
@@ -6,8 +6,39 @@ using Scratch, Pkg, Pkg.Artifacts, ghr_jll, SHA, Dates
 # Utility functions
 getuid() = ccall(:getuid, Cint, ())
 getgid() = ccall(:getgid, Cint, ())
+chroot(rootfs, cmds...; uid=getuid(), gid=getgid()) = run(`sudo chroot --userspec=$(uid):$(gid) $(rootfs) $(cmds)`)
 
-function cleanup_dev_perms_resolv(rootfs)
+# Sometimes rootfs images have absolute symlinks within them; this
+# is very bad for us as it breaks our ability to look at a rootfs
+# without `chroot`'ing into it; so we fix up all the links to be
+# relative here.
+function force_relative(link, rootfs)
+    target = readlink(link)
+    if !isabspath(target)
+        return
+    end
+    target = joinpath(rootfs, target[2:end])
+    rm(link; force=true)
+    symlink(relpath(target, dirname(link)), link)
+end
+function force_relative(rootfs)
+    for (root, dirs, files) in walkdir(rootfs)
+        for f in files
+            f = joinpath(root, f)
+            if islink(f)
+                force_relative(f, rootfs)
+            end
+        end
+        for d in dirs
+            d = joinpath(root, d)
+            if islink(d)
+                force_relative(d, rootfs)
+            end
+        end
+    end
+end
+
+function cleanup_rootfs(rootfs; rootfs_info=nothing)
     # Remove special `dev` files
     @info("Cleaning up `/dev`")
     for f in readdir(joinpath(rootfs, "dev"); join=true)
@@ -20,7 +51,7 @@ function cleanup_dev_perms_resolv(rootfs)
     # take ownership of the entire rootfs
     @info("Chown'ing rootfs")
     run(`sudo chown $(getuid()):$(getgid()) -R "$(rootfs)"`)
-    
+
     # Write out a reasonable default resolv.conf
     open(joinpath(rootfs, "etc", "resolv.conf"), write=true) do io
         write(io, """
@@ -28,6 +59,17 @@ function cleanup_dev_perms_resolv(rootfs)
         nameserver 8.8.8.8
         """)
     end
+
+    # If we've been given a `rootfs_info` parameter, write it out as /etc/rootfs-info
+    if rootfs_info !== nothing
+        open(io -> write(io, rootfs_info),
+             joinpath(rootfs, "etc", "rootfs-info"),
+             write=true,
+        )
+    end
+    
+    @info("Forcing all symlinks to be relative")
+    force_relative(rootfs)
 end
 
 function create_rootfs(f::Function, name::String; force::Bool=false)
@@ -45,7 +87,7 @@ function create_rootfs(f::Function, name::String; force::Bool=false)
     return tarball_path
 end
 
-function debootstrap(name::String; release::String="buster", variant::String="minbase",
+function debootstrap(f::Function, name::String; release::String="buster", variant::String="minbase",
                      packages::Vector{String}=String[], force::Bool=false)
     if Sys.which("debootstrap") === nothing
         error("Must install `debootstrap`!")
@@ -56,19 +98,18 @@ function debootstrap(name::String; release::String="buster", variant::String="mi
         @info("Running debootstrap", release, variant, packages)
         run(`sudo debootstrap --variant=$(variant) --include=$(packages_string) $(release) "$(rootfs)"`)
 
-        # Remove special `dev` files, take ownership and write out some standard files
-        cleanup_dev_perms_resolv(rootfs)
+        # Call user callback, if requested
+        f(rootfs)
 
-        # Write out rootfs-info to contain a minimally-identifying string
-        open(joinpath(rootfs, "etc", "rootfs-info"), write=true) do io
-            write(io, """
-            rootfs_type=debootstrap
-            release=$(release)
-            variant=$(variant)
-            packages=$(packages_string)
-            build_date=$(Dates.now())
-            """)
-        end
+        # Remove special `dev` files, take ownership, force symlinks to be relative, etc...
+        rootfs_info="""
+                    rootfs_type=debootstrap
+                    release=$(release)
+                    variant=$(variant)
+                    packages=$(packages_string)
+                    build_date=$(Dates.now())
+                    """
+        cleanup_rootfs(rootfs; rootfs_info)
 
         # Remove `_apt` user so that `apt` doesn't try to `setgroups()`
         @info("Removing `_apt` user")
@@ -86,9 +127,13 @@ function debootstrap(name::String; release::String="buster", variant::String="mi
         open(joinpath(rootfs, "etc", "locale.gen"), "a") do io
             println(io, "en_US.UTF-8 UTF-8")
         end
-        run(`sudo chroot --userspec=$(getuid()):$(getgid()) $(rootfs) locale-gen`)
+        chroot(rootfs, "locale-gen")
     end
 end
+# If no user callback is provided, default to doing nothing
+debootstrap(name::String; kwargs...) = debootstrap(p -> nothing, name; kwargs...)
+
+
 
 # Helper structure for installing alpine packages that may or may not be part of an older Alpine release
 struct AlpinePackage
@@ -104,7 +149,7 @@ function repository_arg(repo)
     return "--repository=http://dl-cdn.alpinelinux.org/alpine/$(repo)/main"
 end
 
-function alpine_bootstrap(name::String; release::VersionNumber=v"3.13.5", variant="minirootfs",
+function alpine_bootstrap(f::Function, name::String; release::VersionNumber=v"3.13.5", variant="minirootfs",
                           packages::Vector{AlpinePackage}=AlpinePackage[], force::Bool=false)
     return create_rootfs(name; force) do rootfs
         rootfs_url = "https://github.com/alpinelinux/docker-alpine/raw/v$(release.major).$(release.minor)/x86_64/alpine-$(variant)-$(release)-x86_64.tar.gz"
@@ -112,19 +157,18 @@ function alpine_bootstrap(name::String; release::VersionNumber=v"3.13.5", varian
         rm(rootfs)
         Pkg.Artifacts.download_verify_unpack(rootfs_url, nothing, rootfs; verbose=true)
 
-        # Remove special `dev` files, take ownership and write out some standard files
-        cleanup_dev_perms_resolv(rootfs)
+        # Call user callback, if requested
+        f(rootfs)
 
-        # Write out rootfs-info to contain a minimally-identifying string
-        open(joinpath(rootfs, "etc", "rootfs-info"), write=true) do io
-            write(io, """
-            rootfs_type=alpine
-            release=$(release)
-            variant=$(variant)
-            packages=$(join([pkg.name for pkg in packages], ","))
-            build_date=$(Dates.now())
-            """)
-        end
+        # Remove special `dev` files, take ownership, force symlinks to be relative, etc...
+        rootfs_info = """
+                    rootfs_type=alpine
+                    release=$(release)
+                    variant=$(variant)
+                    packages=$(join([pkg.name for pkg in packages], ","))
+                    build_date=$(Dates.now())
+                    """
+        cleanup_rootfs(rootfs; rootfs_info)
 
         # Generate one `apk` invocation per repository
         repos = unique([pkg.repo for pkg in packages])
@@ -136,10 +180,12 @@ function alpine_bootstrap(name::String; release::VersionNumber=v"3.13.5", varian
             for pkg in filter(pkg -> pkg.repo == repo, packages)
                 push!(apk_args, pkg.name)
             end
-            run(`sudo chroot --userspec=$(getuid()):$(getgid()) $(rootfs) $(apk_args...)`)
+            chroot(rootfs, apk_args...)
         end
     end
 end
+# If no user callback is provided, default to doing nothing
+alpine_bootstrap(name::String; kwargs...) = alpine_bootstrap(p -> nothing, name; kwargs...)
 
 function upload_rootfs_image(tarball_path::String;
                              github_repo::String="JuliaCI/rootfs-images",

--- a/.buildkite/rootfs_images/rootfs_utils.jl
+++ b/.buildkite/rootfs_images/rootfs_utils.jl
@@ -52,6 +52,16 @@ function cleanup_rootfs(rootfs; rootfs_info=nothing)
     @info("Chown'ing rootfs")
     run(`sudo chown $(getuid()):$(getgid()) -R "$(rootfs)"`)
 
+    # Add `juliaci` user and group
+    @info("Adding 'juliaci' user and group as 1000:1000")
+    open(joinpath(rootfs, "etc", "passwd"), append=true) do io
+        println(io, "juliaci:x:1000:1000:juliaci:/home/juliaci:/bin/sh")
+    end
+    open(joinpath(rootfs, "etc", "group"), append=true) do io
+        println(io, "juliaci:x:1000:juliaci")
+    end
+    mkpath(joinpath(rootfs, "home", "juliaci"))
+
     # Write out a reasonable default resolv.conf
     open(joinpath(rootfs, "etc", "resolv.conf"), write=true) do io
         write(io, """

--- a/.buildkite/rootfs_images/rootfs_utils.jl
+++ b/.buildkite/rootfs_images/rootfs_utils.jl
@@ -77,7 +77,7 @@ function cleanup_rootfs(rootfs; rootfs_info=nothing)
              write=true,
         )
     end
-    
+
     @info("Forcing all symlinks to be relative")
     force_relative(rootfs)
 end

--- a/.buildkite/rootfs_images/test_rootfs.jl
+++ b/.buildkite/rootfs_images/test_rootfs.jl
@@ -1,0 +1,39 @@
+#!/usr/bin/env julia
+using Sandbox, Pkg.Artifacts
+
+if length(ARGS) < 1 || length(ARGS) > 2
+    println("Usage: test_rootfs.jl <url> [gitsha]")
+    exit(1)
+end
+
+url = ARGS[1]
+hash = Base.SHA1(get(ARGS, 2, nothing))
+
+if hash === nothing
+    @warn("hash not provided; this will download the tarball, then fail, so you can see the true hash")
+    hash = Base.SHA1("0000000000000000000000000000000000000000")
+end
+
+# If the artifact is not locally existent, download it
+if !artifact_exists(hash)
+    @info("Artifact did not exist, downloading")
+    download_artifact(hash, url; verbose=true)
+end
+
+config = SandboxConfig(
+    Dict("/" => artifact_path(hash)),
+    Dict{String,String}(),
+    Dict(
+        "PATH" => "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
+        "HOME" => "/home/juliaci",
+        "USER" => "juliaci",
+    );
+    stdin,
+    stdout,
+    stderr,
+    uid=Sandbox.getuid(),
+    gid=Sandbox.getgid(),
+)
+with_executor() do exe
+    run(exe, config, `/bin/bash`)
+end


### PR DESCRIPTION
This adds an Alpine-based rootfs image for packaging jobs on `musl64`.
It purposefully installs GCC 9, expecting that we will standardize on GCC 9 as our buildbot GCC version for as many platforms as possible.