### PR TITLE
some optimizations for `Array{Symbol}`

### DIFF
--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -140,7 +140,7 @@ function (ss::SummarySize)(obj::Array)
             dsize += length(obj)
         end
         size += dsize
-        if !isempty(obj) && (!Base.allocatedinline(T) || (T isa DataType && !Base.datatype_pointerfree(T)))
+        if !isempty(obj) && T !== Symbol && (!Base.allocatedinline(T) || (T isa DataType && !Base.datatype_pointerfree(T)))
             push!(ss.frontier_x, obj)
             push!(ss.frontier_i, 1)
         end

--- a/src/gc.c
+++ b/src/gc.c
@@ -2564,6 +2564,8 @@ mark: {
             if (a->data == NULL || jl_array_len(a) == 0)
                 goto pop;
             if (flags.ptrarray) {
+                if (jl_tparam0(vt) == jl_symbol_type)
+                    goto pop;
                 size_t l = jl_array_len(a);
                 uintptr_t nptr = (l << 2) | (bits & GC_OLD);
                 objary_begin = (jl_value_t**)a->data;


### PR DESCRIPTION
- skip GC marking
- skip recursion in `summarysize`