### PR TITLE
REPL.TerminalMenus: Allow keybindings in RadioMenu

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
@@ -21,6 +21,7 @@ Your favorite fruit is blueberry!
 """
 mutable struct RadioMenu{C} <: _ConfiguredMenu{C}
     options::Array{String,1}
+    keybindings::Vector{Char}
     pagesize::Int
     pageoffset::Int
     selected::Int
@@ -43,8 +44,9 @@ user.
 
 Any additional keyword arguments will be passed to [`TerminalMenus.Config`](@ref).
 """
-function RadioMenu(options::Array{String,1}; pagesize::Int=10, warn::Bool=true, kwargs...)
+function RadioMenu(options::Array{String,1}; pagesize::Int=10, warn::Bool=true, keybindings::Vector{Char}=Char[], kwargs...)
     length(options) < 1 && error("RadioMenu must have at least one option")
+    length(keybindings) in [0, length(options)] || error("RadioMenu must have either no keybindings, or one per option")
 
     # if pagesize is -1, use automatic paging
     pagesize = pagesize == -1 ? length(options) : pagesize
@@ -57,10 +59,10 @@ function RadioMenu(options::Array{String,1}; pagesize::Int=10, warn::Bool=true, 
     selected = -1 # none
 
     if !isempty(kwargs)
-        RadioMenu(options, pagesize, pageoffset, selected, Config(; kwargs...))
+        RadioMenu(options, keybindings, pagesize, pageoffset, selected, Config(; kwargs...))
     else
         warn && Base.depwarn("Legacy `RadioMenu` interface is deprecated, set a configuration option such as `RadioMenu(options; charset=:ascii)` to trigger the new interface.", :RadioMenu)
-        RadioMenu(options, pagesize, pageoffset, selected, CONFIG)
+        RadioMenu(options, keybindings, pagesize, pageoffset, selected, CONFIG)
     end
 end
 
@@ -81,6 +83,14 @@ end
 
 function writeline(buf::IOBuffer, menu::RadioMenu{Config}, idx::Int, iscursor::Bool)
     print(buf, replace(menu.options[idx], "\n" => "\\n"))
+end
+
+function keypress(m::RadioMenu, i::UInt32)
+    isempty(m.keybindings) && return false
+    i = findfirst(isequal(i), Int.(m.keybindings))
+    isnothing(i) && return false
+    m.selected = i
+    return true
 end
 
 # Legacy interface


### PR DESCRIPTION
Adds optional keybindings to `REPL.TerminalMenus.RadioMenu`
I decided not to automatically prepend the keybinding, to allow the user flexibility in formatting.

```julia
options = ["o: orange", "a: apple", "b: banana"]
keybindings = ['o', 'a', 'b']
menu = RadioMenu(options, pagesize=3, keybindings = keybindings)
choice = request("Choose your favorite fruit:", menu)
```
```
Choose your favorite fruit:
 > o: orange
   a: apple
   b: banana
2 # after pressing 'a'
```