### PR TITLE
CI (rootfs images): when uploading a tarball, don't allow it to override an existing tarball (unless the user provides the `--force-overwrite` command-line flag)

### DIFF
--- a/.buildkite/rootfs_images/llvm-passes.jl
+++ b/.buildkite/rootfs_images/llvm-passes.jl
@@ -4,12 +4,9 @@
 ## Eventually, this image will probably be replaced with the actual builder image,
 ## as that will have the necessary toolchains as well, but that image is not built yet.
 
-if length(ARGS) != 1
-    throw(ArgumentError("Usage: llvm-passes.jl [tag_name]"))
-end
-const tag_name = convert(String, strip(ARGS[1]))::String
-
 include("rootfs_utils.jl")
+
+const tag_name, force_overwrite = get_arguments(ARGS, @__FILE__)
 
 # Build debian-based image with the following extra packages:
 packages = [
@@ -31,4 +28,4 @@ packages = [
 tarball_path = debootstrap("llvm-passes"; packages)
 
 # Upload it
-upload_rootfs_image(tarball_path; tag_name)
+upload_rootfs_image(tarball_path; tag_name, force_overwrite)

--- a/.buildkite/rootfs_images/rootfs_utils.jl
+++ b/.buildkite/rootfs_images/rootfs_utils.jl
@@ -84,10 +84,37 @@ end
 
 function upload_rootfs_image(tarball_path::String;
                              github_repo::String="JuliaCI/rootfs-images",
-                             tag_name::String)
+                             tag_name::String,
+                             force_overwrite::Bool)
     # Upload it to `github_repo`
     tarball_url = "https://github.com/$(github_repo)/releases/download/$(tag_name)/$(basename(tarball_path))"
     @info("Uploading to $(github_repo)@$(tag_name)", tarball_url)
-    run(`$(ghr_jll.ghr()) -u $(dirname(github_repo)) -r $(basename(github_repo)) -replace $(tag_name) $(tarball_path)`)
+    replace_flag = force_overwrite ? "-replace" : ""
+    run(`$(ghr_jll.ghr()) -u $(dirname(github_repo)) -r $(basename(github_repo)) $(replace_flag) $(tag_name) $(tarball_path)`)
     return tarball_url
+end
+
+# process command-line arguments
+
+function get_arguments(args::AbstractVector, script_file::AbstractString)
+    usage = "Usage: $(basename(script_file)) <tag_name> [--force-overwrite]"
+    length(args) < 1 && throw(ArgumentError(usage))
+    length(args) > 2 && throw(ArgumentError(usage))
+    tag_name        = get_tag_name(args; usage)
+    force_overwrite = get_force_overwrite(args; usage)
+    return (; tag_name, force_overwrite)
+end
+
+function get_tag_name(args::AbstractVector; usage::AbstractString)
+    tag_name = convert(String, strip(args[1]))::String
+    isempty(tag_name)          && throw(ArgumentError(usage))
+    startswith(tag_name, "--") && throw(ArgumentError(usage))
+    return tag_name
+end
+
+function get_force_overwrite(args::AbstractVector; usage::AbstractString)
+    force_overwrite_string = strip(get(args, 2, ""))
+    force_overwrite_string == ""                  && return false
+    force_overwrite_string == "--force-overwrite" && return true
+    throw(ArgumentError(usage))
 end


### PR DESCRIPTION
Fixes #41590 