### PR TITLE
REPL doc lookup assumed ASCII for the given string

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -221,7 +221,7 @@ function lookup_doc(ex)
         str = string(ex)
         isdotted = startswith(str, ".")
         if endswith(str, "=") && Base.operator_precedence(ex) == Base.prec_assignment && ex !== :(:=)
-            op = str[begin:prevind(str, lastindex(str))]
+            op = chop(str)
             eq = isdotted ? ".=" : "="
             return Markdown.parse("`x $op= y` is a synonym for `x $eq x $op y`")
         elseif isdotted && ex !== :(..)

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -221,7 +221,7 @@ function lookup_doc(ex)
         str = string(ex)
         isdotted = startswith(str, ".")
         if endswith(str, "=") && Base.operator_precedence(ex) == Base.prec_assignment && ex !== :(:=)
-            op = str[1:end-1]
+            op = str[begin:prevind(str, lastindex(str))]
             eq = isdotted ? ".=" : "="
             return Markdown.parse("`x $op= y` is a synonym for `x $eq x $op y`")
         elseif isdotted && ex !== :(..)

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -47,3 +47,9 @@ end
     # shouldn't throw when there is a space in a middle of query
     @test (REPL.matchinds("a ", "a file.txt"); true)
 end
+
+@testset "Unicode doc lookup" begin
+    # https://github.com/JuliaLang/julia/issues/41589
+    # assuming ASCII is bad, m'kay?
+    @test REPL.lookup_doc(:(÷=)) isa Markdown.MD
+end

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -48,8 +48,6 @@ end
     @test (REPL.matchinds("a ", "a file.txt"); true)
 end
 
-@testset "Unicode doc lookup" begin
-    # https://github.com/JuliaLang/julia/issues/41589
-    # assuming ASCII is bad, m'kay?
+@testset "Unicode doc lookup (#41589)" begin
     @test REPL.lookup_doc(:(÷=)) isa Markdown.MD
 end


### PR DESCRIPTION
Fix #41589

Original code assumed ASCII, but that's not true. There may be other places in Base or an Stdlib where this happens, I'll grep and possibly open another PR if I find more.

Also, is there a better way to check whether something just doesn't throw? Checking the type of the returned value certainly seems like a way, but is of limited use for other code paths and kind of feels wrong...