### PR TITLE
Fix `length(::OrdinalRange)` for empty ranges of dimensionful numbers

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -665,7 +665,7 @@ function length(r::OrdinalRange{T}) where T
     # s != 0, by construction, but avoids the division error later
     start = first(r)
     if s == zero(s) || isempty(r)
-        return Integer(start - start + zero(s))
+        return Integer(div(start-start, oneunit(s)))
     end
     stop = last(r)
     if isless(s, zero(s))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1443,6 +1443,7 @@ using .Main.Furlongs
 @testset "dimensional correctness" begin
     @test length(Vector(Furlong(2):Furlong(10))) == 9
     @test length(range(Furlong(2), length=9)) == checked_length(range(Furlong(2), length=9)) == 9
+    @test @inferred(length(StepRange(Furlong(2), Furlong(1), Furlong(1)))) == 0
     @test Vector(Furlong(2):Furlong(1):Furlong(10)) == Vector(range(Furlong(2), step=Furlong(1), length=9)) == Furlong.(2:10)
     @test Vector(Furlong(1.0):Furlong(0.5):Furlong(10.0)) ==
           Vector(Furlong(1):Furlong(0.5):Furlong(10)) == Furlong.(1:0.5:10)

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -14,7 +14,7 @@ struct Furlong{p,T<:Number} <: Number
 end
 Furlong(x::T) where {T<:Number} = Furlong{1,T}(x)
 Furlong(x::Furlong) = x
-(::Type{T})(x::Furlong) where {T<:Number} = T(x.val)::T
+(::Type{T})(x::Furlong{0}) where {T<:Number} = T(x.val)::T
 Furlong{p}(v::Number) where {p} = Furlong{p,typeof(v)}(v)
 Furlong{p}(x::Furlong{q}) where {p,q} = (@assert(p==q); Furlong{p,typeof(x.val)}(x.val))
 Furlong{p,T}(x::Furlong{q}) where {T,p,q} = (@assert(p==q); Furlong{p,T}(T(x.val)))


### PR DESCRIPTION
As mentioned in https://github.com/JuliaLang/julia/pull/41479#issuecomment-877717101, this fix is needed for empty `OrdinalRange`s of dimensionful numbers.