### PR TITLE
Do not error when showing invalid enums (#40042)

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -25,10 +25,16 @@ Base.isless(x::T, y::T) where {T<:Enum} = isless(basetype(T)(x), basetype(T)(y))
 
 Base.Symbol(x::Enum) = namemap(typeof(x))[Integer(x)]::Symbol
 
-Base.print(io::IO, x::Enum) = print(io, Symbol(x))
+function _symbol(x::Enum)
+    names = namemap(typeof(x))
+    x = Integer(x)
+    get(() -> Symbol("<invalid #$x>"), names, x)::Symbol
+end
+
+Base.print(io::IO, x::Enum) = print(io, _symbol(x))
 
 function Base.show(io::IO, x::Enum)
-    sym = Symbol(x)
+    sym = _symbol(x)
     if !(get(io, :compact, false)::Bool)
         from = get(io, :module, Main)
         def = typeof(x).name.module

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -143,6 +143,10 @@ let io = IOBuffer()
     @test String(take!(io)) == sprint(print, Fruit)
 end
 
+# Test printing of invalid enums
+@test repr("text/plain", reinterpret(Fruit, Int32(11))) == "<invalid #11>::Fruit = 11"
+@test repr("text/plain", reinterpret(Fruit, Int32(-5))) == "<invalid #-5>::Fruit = -5"
+
 @enum LogLevel DEBUG INFO WARN ERROR CRITICAL
 @test DEBUG < CRITICAL
 
@@ -159,6 +163,9 @@ end
 @test repr("text/plain", thr)   == "$(string(thr))::UI8 = 0x03"
 @test repr("text/plain", sevn)  == "$(string(sevn))::UI8 = 0x07"
 @test repr("text/plain", fiftn) == "$(string(fiftn))::UI8 = 0xf0"
+
+@test repr("text/plain", reinterpret(UI8, 0x01)) == "<invalid #1>::UI8 = 0x01"
+@test repr("text/plain", reinterpret(UI8, 0xff)) == "<invalid #255>::UI8 = 0xff"
 
 # test block form
 @enum BritishFood begin


### PR DESCRIPTION
Fix #40042 using the code that @vtjnash suggested. I have not added tests due to the principle of not testing printing, but it does solve the problem when manually testing it out.