### PR TITLE
reshape for offset AbstractVectors with Tuple{Colon} as indices

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -113,6 +113,7 @@ reshape(parent::AbstractArray, dims::Dims)        = _reshape(parent, dims)
 
 # Allow missing dimensions with Colon():
 reshape(parent::AbstractVector, ::Colon) = parent
+reshape(parent::AbstractVector, ::Tuple{Colon}) = parent
 reshape(parent::AbstractArray, dims::Int...) = reshape(parent, dims)
 reshape(parent::AbstractArray, dims::Union{Int,Colon}...) = reshape(parent, dims)
 reshape(parent::AbstractArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = reshape(parent, _reshape_uncolon(parent, dims))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1483,3 +1483,8 @@ end
     @test_throws ArgumentError keepat!(a, [2, 1])
     @test isempty(keepat!(a, []))
 end
+
+@testset "reshape methods for AbstractVectors" begin
+    r = Base.IdentityUnitRange(3:4)
+    @test reshape(r, :) === reshape(r, (:,)) === r
+end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -795,3 +795,9 @@ end
     @test Iterators.partition(OffsetArray(reshape(collect(1:9),3,3), (3,3)), 5) |> collect == [1:5,6:9] #OffsetMatrix
     @test Iterators.partition(IdOffsetRange(2:7,10), 5) |> collect == [12:16,17:17] # IdOffsetRange
 end
+
+@testset "reshape" begin
+    a = OffsetArray(4:5, 5:6)
+    @test reshape(a, :) === a
+    @test reshape(a, (:,)) === a
+end

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -297,6 +297,7 @@ Base.reshape(A::OffsetArray, inds::Tuple{Union{Integer,Base.OneTo},Vararg{Union{
 Base.reshape(A::OffsetArray, inds::Dims) = reshape(parent(A), inds)
 Base.reshape(A::OffsetArray, ::Colon) = reshape(parent(A), Colon())
 Base.reshape(A::OffsetVector, ::Colon) = A
+Base.reshape(A::OffsetVector, ::Tuple{Colon}) = A
 Base.reshape(A::OffsetArray, inds::Union{Int,Colon}...) = reshape(parent(A), inds)
 Base.reshape(A::OffsetArray, inds::Tuple{Vararg{Union{Int,Colon}}}) = reshape(parent(A), inds)
 


### PR DESCRIPTION
On master
```julia
julia> reshape(Base.IdentityUnitRange(3:4), :)
Base.IdentityUnitRange(3:4)

julia> reshape(Base.IdentityUnitRange(3:4), (:,))
ERROR: ArgumentError: offset arrays are not supported but got an array with index other than 1
```

After this PR
```julia
julia> reshape(Base.IdentityUnitRange(3:4), (:,))
Base.IdentityUnitRange(3:4)
```

This makes the `Vararg` and `Tuple` methods behave identically.