### PR TITLE
fix `exp` in `--math-mode=fast`

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -203,8 +203,8 @@ end
 
 @inline function exp_impl(x::Float64, base)
     T = Float64
-    N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
-    N = reinterpret(UInt64, N_float) % Int32
+    N_float = round(x*LogBo256INV(base, T))
+    N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
     k = N >> 8

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -205,7 +205,6 @@ end
     T = Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
     N = reinterpret(UInt64, N_float) % Int32
-    N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
     k = N >> 8
@@ -227,9 +226,8 @@ end
 end
 @inline function exp_impl_fast(x::Float64, base)
     T = Float64
-    N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
-    N = reinterpret(UInt64, N_float) % Int32
-    N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
+    N_float = round(x*LogBo256INV(base, T))
+    N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogBo256U(base, T), x)
     r = muladd(N_float, LogBo256L(base, T), r)
     k = N >> 8


### PR DESCRIPTION
don't rely on `muladd` fusing. Performance impact is minimal (max 1 cycle regression)

Closes #41592