### PR TITLE
Make math-mode=fast disabled, it's too dangerous

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -188,7 +188,6 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_inline,
            opt_polly,
            opt_trace_compile,
-           opt_math_mode,
            opt_worker,
            opt_bind_to,
            opt_handle_signals,
@@ -253,7 +252,6 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "inline",          required_argument, 0, opt_inline },
         { "polly",           required_argument, 0, opt_polly },
         { "trace-compile",   required_argument, 0, opt_trace_compile },
-        { "math-mode",       required_argument, 0, opt_math_mode },
         { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
         { "worker",          optional_argument, 0, opt_worker },
@@ -647,16 +645,6 @@ restart_switch:
             jl_options.trace_compile = strdup(optarg);
             if (!jl_options.trace_compile)
                 jl_errorf("fatal error: failed to allocate memory: %s", strerror(errno));
-            break;
-        case opt_math_mode:
-            if (!strcmp(optarg,"ieee"))
-                jl_options.fast_math = JL_OPTIONS_FAST_MATH_OFF;
-            else if (!strcmp(optarg,"fast"))
-                jl_options.fast_math = JL_OPTIONS_FAST_MATH_ON;
-            else if (!strcmp(optarg,"user"))
-                jl_options.fast_math = JL_OPTIONS_FAST_MATH_DEFAULT;
-            else
-                jl_errorf("julia: invalid argument to --math-mode (%s)", optarg);
             break;
         case opt_worker:
             jl_options.worker = 1;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -454,20 +454,6 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # --polly takes yes/no as argument
     @test !success(`$exename --polly=false`)
 
-    # --fast-math
-    let JL_OPTIONS_FAST_MATH_DEFAULT = 0,
-        JL_OPTIONS_FAST_MATH_ON = 1,
-        JL_OPTIONS_FAST_MATH_OFF = 2
-        @test parse(Int,readchomp(`$exename -E
-            "Int(Base.JLOptions().fast_math)"`)) == JL_OPTIONS_FAST_MATH_DEFAULT
-        @test parse(Int,readchomp(`$exename --math-mode=user -E
-            "Int(Base.JLOptions().fast_math)"`)) == JL_OPTIONS_FAST_MATH_DEFAULT
-        @test parse(Int,readchomp(`$exename --math-mode=ieee -E
-            "Int(Base.JLOptions().fast_math)"`)) == JL_OPTIONS_FAST_MATH_OFF
-        @test parse(Int,readchomp(`$exename --math-mode=fast -E
-            "Int(Base.JLOptions().fast_math)"`)) == JL_OPTIONS_FAST_MATH_ON
-    end
-
     # --worker takes default / custom as argument (default/custom arguments
     # tested in test/parallel.jl)
     @test !success(`$exename --worker=true`)


### PR DESCRIPTION
Given https://github.com/JuliaLang/julia/issues/41592#issuecomment-880483469 it's just too dangerous, and tempting for newbies to see. <s>Still not dropped entirely</s>, if this works should be backported to 1.7.

Fixes: #25028

Also note, the title of the former linked issue is wrong, with "fast-mode" incorrect, I just couldn't change the title.