### PR TITLE
Add macro for timing package and dependency imports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,9 @@ Standard library changes
   arithmetic to error if the result may be wrapping. Or use a package such as SaferIntegers.jl when
   constructing the range. ([#40382])
 
+#### InteractiveUtils
+* A new macro `@time_imports` for reporting any time spent importing packages and their dependencies ([#41612])
+
 #### Package Manager
 
 #### LinearAlgebra

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -488,7 +488,6 @@ function __init__()
     if haskey(ENV, "JULIA_MAX_NUM_PRECOMPILE_FILES")
         MAX_NUM_PRECOMPILE_FILES[] = parse(Int, ENV["JULIA_MAX_NUM_PRECOMPILE_FILES"])
     end
-    append!(empty!(TIMING_IMPORTS), zeros(Int, Threads.nthreads()))
     nothing
 end
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -488,6 +488,7 @@ function __init__()
     if haskey(ENV, "JULIA_MAX_NUM_PRECOMPILE_FILES")
         MAX_NUM_PRECOMPILE_FILES[] = parse(Int, ENV["JULIA_MAX_NUM_PRECOMPILE_FILES"])
     end
+    append!(empty!(LOAD_TIMING), zeros(Int, Threads.nthreads()))
     nothing
 end
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -488,7 +488,7 @@ function __init__()
     if haskey(ENV, "JULIA_MAX_NUM_PRECOMPILE_FILES")
         MAX_NUM_PRECOMPILE_FILES[] = parse(Int, ENV["JULIA_MAX_NUM_PRECOMPILE_FILES"])
     end
-    append!(empty!(LOAD_TIMING), zeros(Int, Threads.nthreads()))
+    append!(empty!(TIMING_IMPORTS), zeros(Int, Threads.nthreads()))
     nothing
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -769,7 +769,7 @@ function _include_from_serialized(path::String, depmods::Vector{Any})
     return restored
 end
 
-function _tryrequire_from_serialized(modkey::PkgId, build_id::UInt64, modpath::Union{Nothing, String})
+function _tryrequire_from_serialized(modkey::PkgId, build_id::UInt64, modpath::Union{Nothing, String}, depth::Int = 0)
     if root_module_exists(modkey)
         M = root_module(modkey)
         if PkgId(M) == modkey && module_build_id(M) === build_id
@@ -780,7 +780,7 @@ function _tryrequire_from_serialized(modkey::PkgId, build_id::UInt64, modpath::U
             modpath = locate_package(modkey)
             modpath === nothing && return nothing
         end
-        mod = _require_search_from_serialized(modkey, String(modpath))
+        mod = _require_search_from_serialized(modkey, String(modpath), depth)
         get!(PkgOrigin, pkgorigins, modkey).path = modpath
         if !isa(mod, Bool)
             for callback in package_callbacks
@@ -821,10 +821,14 @@ function _require_from_serialized(path::String)
     return _include_from_serialized(path, depmods)
 end
 
+# use an Int counter so that nested @time_imports calls all remain open
+const LOAD_TIMING = Int[] # initialized in __init__
+
 # returns `true` if require found a precompile cache for this sourcepath, but couldn't load it
 # returns `false` if the module isn't known to be precompilable
 # returns the set of modules restored if the cache load succeeded
-function _require_search_from_serialized(pkg::PkgId, sourcepath::String)
+function _require_search_from_serialized(pkg::PkgId, sourcepath::String, depth::Int = 0)
+    t_before = time_ns()
     paths = find_all_in_cache_path(pkg)
     for path_to_try in paths::Vector{String}
         staledeps = stale_cachefile(sourcepath, path_to_try)
@@ -840,7 +844,7 @@ function _require_search_from_serialized(pkg::PkgId, sourcepath::String)
             dep = staledeps[i]
             dep isa Module && continue
             modpath, modkey, build_id = dep::Tuple{String, PkgId, UInt64}
-            dep = _tryrequire_from_serialized(modkey, build_id, modpath)
+            dep = _tryrequire_from_serialized(modkey, build_id, modpath, depth + 1)
             if dep === nothing
                 @debug "Required dependency $modkey failed to load from cache file for $modpath."
                 staledeps = true
@@ -855,6 +859,13 @@ function _require_search_from_serialized(pkg::PkgId, sourcepath::String)
         if isa(restored, Exception)
             @debug "Deserialization checks failed while attempting to load cache from $path_to_try" exception=restored
         else
+            if LOAD_TIMING[Threads.threadid()] > 0
+                elapsed = round((time_ns() - t_before) / 1e6, digits = 1)
+                tree_prefix = depth == 0 ? "" : "$("  "^(depth-1))┌ "
+                print("$(lpad(elapsed, 9)) ms  ")
+                printstyled(tree_prefix, color = :light_black)
+                println(pkg.name)
+            end
             return restored
         end
     end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -822,7 +822,7 @@ function _require_from_serialized(path::String)
 end
 
 # use an Int counter so that nested @time_imports calls all remain open
-const TIMING_IMPORTS = Int[] # initialized in __init__
+const TIMING_IMPORTS = Threads.Atomic{Int}(0)
 
 # returns `true` if require found a precompile cache for this sourcepath, but couldn't load it
 # returns `false` if the module isn't known to be precompilable
@@ -859,7 +859,7 @@ function _require_search_from_serialized(pkg::PkgId, sourcepath::String, depth::
         if isa(restored, Exception)
             @debug "Deserialization checks failed while attempting to load cache from $path_to_try" exception=restored
         else
-            if TIMING_IMPORTS[Threads.threadid()] > 0
+            if TIMING_IMPORTS[] > 0
                 elapsed = round((time_ns() - t_before) / 1e6, digits = 1)
                 tree_prefix = depth == 0 ? "" : "$("  "^(depth-1))┌ "
                 print("$(lpad(elapsed, 9)) ms  ")

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -822,7 +822,7 @@ function _require_from_serialized(path::String)
 end
 
 # use an Int counter so that nested @time_imports calls all remain open
-const LOAD_TIMING = Int[] # initialized in __init__
+const TIMING_IMPORTS = Int[] # initialized in __init__
 
 # returns `true` if require found a precompile cache for this sourcepath, but couldn't load it
 # returns `false` if the module isn't known to be precompilable
@@ -859,7 +859,7 @@ function _require_search_from_serialized(pkg::PkgId, sourcepath::String, depth::
         if isa(restored, Exception)
             @debug "Deserialization checks failed while attempting to load cache from $path_to_try" exception=restored
         else
-            if LOAD_TIMING[Threads.threadid()] > 0
+            if TIMING_IMPORTS[Threads.threadid()] > 0
                 elapsed = round((time_ns() - t_before) / 1e6, digits = 1)
                 tree_prefix = depth == 0 ? "" : "$("  "^(depth-1))┌ "
                 print("$(lpad(elapsed, 9)) ms  ")

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -26,5 +26,6 @@ InteractiveUtils.code_llvm
 InteractiveUtils.@code_llvm
 InteractiveUtils.code_native
 InteractiveUtils.@code_native
+InteractiveUtils.@time_imports
 InteractiveUtils.clipboard
 ```

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -6,7 +6,7 @@ Base.Experimental.@optlevel 1
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, clipboard
+    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard
 
 import Base.Docs.apropos
 

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -232,6 +232,17 @@ macro code_lowered(ex0...)
     end
 end
 
+macro time_imports(ex)
+    quote
+        try
+            Base.LOAD_TIMING[Threads.threadid()] += 1
+            $(esc(ex))
+        finally
+            Base.LOAD_TIMING[Threads.threadid()] -= 1
+        end
+    end
+end
+
 """
     @functionloc
 
@@ -332,3 +343,36 @@ Set the optional keyword argument `debuginfo` by putting it before the function 
 `debuginfo` may be one of `:source` (default) or `:none`, to specify the verbosity of code comments.
 """
 :@code_native
+
+"""
+    @time_imports
+
+A macro to execute an expression and produce a report of any time spent importing packages and their
+dependencies.
+
+If a package's dependencies have already been imported either globally or by another dependency they will
+not appear under that package and the package will accurately report a faster load time than if it were to
+be loaded in isolation.
+
+```julia-repl
+julia> @time_imports using CSV
+      3.5 ms    ┌ IteratorInterfaceExtensions
+     27.4 ms  ┌ TableTraits
+    614.0 ms  ┌ SentinelArrays
+    138.6 ms  ┌ Parsers
+      2.7 ms  ┌ DataValueInterfaces
+      3.4 ms    ┌ DataAPI
+     59.0 ms  ┌ WeakRefStrings
+     35.4 ms  ┌ Tables
+     49.5 ms  ┌ PooledArrays
+    972.1 ms  CSV
+```
+
+!!! note
+    During the load process a package sequentially imports where necessary all of its dependencies, not just
+    its direct dependencies. That is also true for the dependencies themselves so nested importing will likely
+    occur, but not always. Therefore the nesting shown in this output report is not equivalent to the dependency
+    tree, but does indicate where import time has accumulated.
+
+"""
+:@time_imports

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -235,10 +235,10 @@ end
 macro time_imports(ex)
     quote
         try
-            Base.TIMING_IMPORTS[Threads.threadid()] += 1
+            Base.TIMING_IMPORTS[] += 1
             $(esc(ex))
         finally
-            Base.TIMING_IMPORTS[Threads.threadid()] -= 1
+            Base.TIMING_IMPORTS[] -= 1
         end
     end
 end

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -235,10 +235,10 @@ end
 macro time_imports(ex)
     quote
         try
-            Base.LOAD_TIMING[Threads.threadid()] += 1
+            Base.TIMING_IMPORTS[Threads.threadid()] += 1
             $(esc(ex))
         finally
-            Base.LOAD_TIMING[Threads.threadid()] -= 1
+            Base.TIMING_IMPORTS[Threads.threadid()] -= 1
         end
     end
 end


### PR DESCRIPTION
Adds ~`@loadtime`~ `@time_imports` for reporting the import time of packages and all their dependencies (direct and indirect).

Edit: Updated to show dep nest indenting
```
julia> @time_imports using CSV
      0.6 ms    ┌ IteratorInterfaceExtensions
    115.4 ms  ┌ TableTraits
    365.8 ms  ┌ SentinelArrays
    102.0 ms  ┌ Parsers
      0.7 ms  ┌ DataValueInterfaces
      1.7 ms    ┌ DataAPI
     34.0 ms  ┌ WeakRefStrings
     16.7 ms  ┌ Tables
     28.0 ms  ┌ PooledArrays
    698.7 ms  CSV

julia> @time_imports using Flux
     58.9 ms    ┌ MacroTools
     61.8 ms  ┌ ZygoteRules
      3.0 ms    ┌ Zlib_jll
      7.4 ms  ┌ ZipFile
    649.3 ms    ┌ StaticArrays
    655.9 ms  ┌ DiffResults
      3.0 ms  ┌ Compat
    106.8 ms  ┌ DataStructures
      0.9 ms  ┌ NaNMath
      1.1 ms  ┌ Requires
      3.4 ms    ┌ TranscodingStreams
      8.5 ms  ┌ CodecZlib
     83.6 ms  ┌ FixedPointNumbers
     65.0 ms    ┌ ChainRulesCore
     92.4 ms  ┌ ChainRules
     11.5 ms    ┌ AbstractFFTs
      1.0 ms        ┌ Preferences
      4.0 ms      ┌ JLLWrappers
    290.5 ms    ┌ LLVMExtra_jll
      0.7 ms    ┌ Reexport
     25.9 ms      ┌ RandomNumbers
     35.6 ms    ┌ Random123
      1.0 ms      ┌ Adapt
   1083.4 ms    ┌ GPUArrays
      4.1 ms    ┌ DocStringExtensions
      5.2 ms      ┌ CEnum
    148.9 ms    ┌ LLVM
      0.8 ms    ┌ ExprTools
     52.3 ms    ┌ TimerOutputs
     16.8 ms    ┌ CompilerSupportLibraries_jll
      9.1 ms    ┌ BFloat16s
      4.0 ms      ┌ LogExpFunctions
      2.6 ms      ┌ OpenSpecFun_jll
     28.7 ms    ┌ SpecialFunctions
    242.4 ms    ┌ GPUCompiler
    153.6 ms    ┌ NNlib
    828.2 ms    ┌ CUDA
   3017.7 ms  ┌ NNlibCUDA
    176.0 ms  ┌ FillArrays
      5.3 ms  ┌ Media
      0.7 ms    ┌ CommonSubexpressions
      1.0 ms    ┌ DiffRules
    117.1 ms  ┌ ForwardDiff
     15.4 ms  ┌ AbstractTrees
      0.9 ms  ┌ Functors
     34.5 ms  ┌ IRTools
   3026.2 ms  ┌ Zygote
    292.5 ms  ┌ ColorTypes
    221.1 ms  ┌ Colors
     42.4 ms  ┌ Juno
   8241.7 ms  Flux

julia> @time_imports begin
       using BenchmarkTools
       using PNGFiles
       end
      5.4 ms  ┌ JSON
     16.1 ms  BenchmarkTools
     76.9 ms      ┌ OffsetArrays
     88.6 ms    ┌ PaddedViews
      6.5 ms      ┌ StackViews
      6.0 ms      ┌ MappedArrays
     20.4 ms    ┌ MosaicViews
      3.1 ms    ┌ Graphics
      1.7 ms    ┌ TensorCore
    180.4 ms    ┌ ColorVectorSpace
    920.3 ms  ┌ ImageCore
      2.0 ms  ┌ libpng_jll
      4.2 ms  ┌ IndirectArrays
   1099.6 ms  PNGFiles
```

Note that it's real load time, not isolated, so if a package's deps have been loaded by an earlier package it will accurately report a faster time than if it were to be loaded in isolation.