### PR TITLE
make precompile files writable

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1435,8 +1435,8 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
             open(tmppath, "a+") do f
                 write(f, _crc32c(seekstart(f)))
             end
-            # inherit permission from the source file
-            chmod(tmppath, filemode(path) & 0o777)
+            # inherit permission from the source file (and make them writable)
+            chmod(tmppath, filemode(path) & 0o777 | 0o200)
 
             # Read preferences hash back from .ji file (we can't precompute because
             # we don't actually know what the list of compile-time preferences are without compiling)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -823,6 +823,10 @@ precompile_test_harness("Issue #25971") do load_path
     chmod(sourcefile, 0o600)
     cachefile = Base.compilecache(Base.PkgId("Foo25971"))
     @test filemode(sourcefile) == filemode(cachefile)
+    chmod(sourcefile, 0o444)
+    cachefile = Base.compilecache(Base.PkgId("Foo25971"))
+    # Check writable
+    @test touch(cachefile) == cachefile
 end
 
 precompile_test_harness("Issue #38312") do load_path


### PR DESCRIPTION
The combination of https://github.com/JuliaLang/julia/pull/34573 and https://github.com/JuliaLang/Pkg.jl/pull/785 means that the precompile files are currently not writable. This means that our way of updating the use time of precompile filkes in 

https://github.com/JuliaLang/julia/blob/2893de764f86e3990e74a3cefdd46e13eb93a676/base/loading.jl#L835

which is then used for sorting:

https://github.com/JuliaLang/julia/blob/2893de764f86e3990e74a3cefdd46e13eb93a676/base/loading.jl#L739-L742

is no longer functional.

Fix this by making sure the precompile file is writable.