### PR TITLE
Emit safepoints at function entry 

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1097,6 +1097,7 @@ struct CodegenParams
     prefer_specsig::Cint
     gnu_pubnames::Cint
     debug_info_kind::Cint
+    safepoint_on_entry::Cint
 
     lookup::Ptr{Cvoid}
 
@@ -1105,12 +1106,14 @@ struct CodegenParams
     function CodegenParams(; track_allocations::Bool=true, code_coverage::Bool=true,
                    prefer_specsig::Bool=false,
                    gnu_pubnames=true, debug_info_kind::Cint = default_debug_info_kind(),
+                   safepoint_on_entry::Bool=true,
                    lookup::Ptr{Cvoid}=cglobal(:jl_rettype_inferred),
                    generic_context = nothing)
         return new(
             Cint(track_allocations), Cint(code_coverage),
             Cint(prefer_specsig),
             Cint(gnu_pubnames), debug_info_kind,
+            Cint(safepoint_on_entry),
             lookup, generic_context)
     end
 end

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3890,6 +3890,67 @@ static Value *emit_defer_signal(jl_codectx_t &ctx)
     return ctx.builder.CreateInBoundsGEP(ctx.types().T_sigatomic, ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
 }
 
+static void emit_gc_safepoint(jl_codectx_t &ctx)
+{
+    ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
+    emit_signal_fence(ctx);
+    ctx.builder.CreateLoad(getSizeTy(ctx.builder.getContext()), get_current_signal_page(ctx), true);
+    emit_signal_fence(ctx);
+}
+
+static Value *emit_gc_state_set(jl_codectx_t &ctx, Value *state, Value *old_state)
+{
+    Type *T_int8 = state->getType();
+    Value *ptls = emit_bitcast(ctx, get_current_ptls(ctx), getInt8PtrTy(ctx.builder.getContext()));
+    Constant *offset = ConstantInt::getSigned(getInt32Ty(ctx.builder.getContext()), offsetof(jl_tls_states_t, gc_state));
+    Value *gc_state = ctx.builder.CreateInBoundsGEP(T_int8, ptls, ArrayRef<Value*>(offset), "gc_state");
+    if (old_state == nullptr) {
+        old_state = ctx.builder.CreateLoad(T_int8, gc_state);
+        cast<LoadInst>(old_state)->setOrdering(AtomicOrdering::Monotonic);
+    }
+    ctx.builder.CreateAlignedStore(state, gc_state, Align(sizeof(void*)))->setOrdering(AtomicOrdering::Release);
+    if (auto *C = dyn_cast<ConstantInt>(old_state))
+        if (C->isZero())
+            return old_state;
+    if (auto *C = dyn_cast<ConstantInt>(state))
+        if (!C->isZero())
+            return old_state;
+    BasicBlock *passBB = BasicBlock::Create(ctx.builder.getContext(), "safepoint", ctx.f);
+    BasicBlock *exitBB = BasicBlock::Create(ctx.builder.getContext(), "after_safepoint", ctx.f);
+    Constant *zero8 = ConstantInt::get(T_int8, 0);
+    ctx.builder.CreateCondBr(ctx.builder.CreateAnd(ctx.builder.CreateICmpNE(old_state, zero8), // if (old_state && !state)
+                                                   ctx.builder.CreateICmpEQ(state, zero8)),
+                             passBB, exitBB);
+    ctx.builder.SetInsertPoint(passBB);
+    emit_gc_safepoint(ctx);
+    ctx.builder.CreateBr(exitBB);
+    ctx.builder.SetInsertPoint(exitBB);
+    return old_state;
+}
+
+static Value *emit_gc_unsafe_enter(jl_codectx_t &ctx)
+{
+    Value *state = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0);
+    return emit_gc_state_set(ctx, state, nullptr);
+}
+
+static Value *emit_gc_unsafe_leave(jl_codectx_t &ctx, Value *state)
+{
+    Value *old_state = ConstantInt::get(state->getType(), 0);
+    return emit_gc_state_set(ctx, state, old_state);
+}
+
+//static Value *emit_gc_safe_enter(jl_codectx_t &ctx)
+//{
+//    Value *state = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), JL_GC_STATE_SAFE);
+//    return emit_gc_state_set(ctx, state, nullptr);
+//}
+//
+//static Value *emit_gc_safe_leave(jl_codectx_t &ctx, Value *state)
+//{
+//    Value *old_state = ConstantInt::get(state->getType(), JL_GC_STATE_SAFE);
+//    return emit_gc_state_set(ctx, state, old_state);
+//}
 
 #ifndef JL_NDEBUG
 static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3890,15 +3890,6 @@ static Value *emit_defer_signal(jl_codectx_t &ctx)
     return ctx.builder.CreateInBoundsGEP(ctx.types().T_sigatomic, ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
 }
 
-static void emit_gc_safepoint(jl_codectx_t &ctx)
-{
-    ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
-    Value* signal_page = get_current_signal_page(ctx);
-    emit_signal_fence(ctx);
-    ctx.builder.CreateLoad(getSizeTy(ctx.builder.getContext()), signal_page, true);
-    emit_signal_fence(ctx);
-}
-
 #ifndef JL_NDEBUG
 static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)
 {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3893,8 +3893,9 @@ static Value *emit_defer_signal(jl_codectx_t &ctx)
 static void emit_gc_safepoint(jl_codectx_t &ctx)
 {
     ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
+    Value* signal_page = get_current_signal_page(ctx);
     emit_signal_fence(ctx);
-    ctx.builder.CreateLoad(getSizeTy(ctx.builder.getContext()), get_current_signal_page(ctx), true);
+    ctx.builder.CreateLoad(getSizeTy(ctx.builder.getContext()), signal_page, true);
     emit_signal_fence(ctx);
 }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3899,60 +3899,6 @@ static void emit_gc_safepoint(jl_codectx_t &ctx)
     emit_signal_fence(ctx);
 }
 
-static Value *emit_gc_state_set(jl_codectx_t &ctx, Value *state, Value *old_state)
-{
-    Type *T_int8 = state->getType();
-    Value *ptls = emit_bitcast(ctx, get_current_ptls(ctx), getInt8PtrTy(ctx.builder.getContext()));
-    Constant *offset = ConstantInt::getSigned(getInt32Ty(ctx.builder.getContext()), offsetof(jl_tls_states_t, gc_state));
-    Value *gc_state = ctx.builder.CreateInBoundsGEP(T_int8, ptls, ArrayRef<Value*>(offset), "gc_state");
-    if (old_state == nullptr) {
-        old_state = ctx.builder.CreateLoad(T_int8, gc_state);
-        cast<LoadInst>(old_state)->setOrdering(AtomicOrdering::Monotonic);
-    }
-    ctx.builder.CreateAlignedStore(state, gc_state, Align(sizeof(void*)))->setOrdering(AtomicOrdering::Release);
-    if (auto *C = dyn_cast<ConstantInt>(old_state))
-        if (C->isZero())
-            return old_state;
-    if (auto *C = dyn_cast<ConstantInt>(state))
-        if (!C->isZero())
-            return old_state;
-    BasicBlock *passBB = BasicBlock::Create(ctx.builder.getContext(), "safepoint", ctx.f);
-    BasicBlock *exitBB = BasicBlock::Create(ctx.builder.getContext(), "after_safepoint", ctx.f);
-    Constant *zero8 = ConstantInt::get(T_int8, 0);
-    ctx.builder.CreateCondBr(ctx.builder.CreateAnd(ctx.builder.CreateICmpNE(old_state, zero8), // if (old_state && !state)
-                                                   ctx.builder.CreateICmpEQ(state, zero8)),
-                             passBB, exitBB);
-    ctx.builder.SetInsertPoint(passBB);
-    emit_gc_safepoint(ctx);
-    ctx.builder.CreateBr(exitBB);
-    ctx.builder.SetInsertPoint(exitBB);
-    return old_state;
-}
-
-static Value *emit_gc_unsafe_enter(jl_codectx_t &ctx)
-{
-    Value *state = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0);
-    return emit_gc_state_set(ctx, state, nullptr);
-}
-
-static Value *emit_gc_unsafe_leave(jl_codectx_t &ctx, Value *state)
-{
-    Value *old_state = ConstantInt::get(state->getType(), 0);
-    return emit_gc_state_set(ctx, state, old_state);
-}
-
-//static Value *emit_gc_safe_enter(jl_codectx_t &ctx)
-//{
-//    Value *state = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), JL_GC_STATE_SAFE);
-//    return emit_gc_state_set(ctx, state, nullptr);
-//}
-//
-//static Value *emit_gc_safe_leave(jl_codectx_t &ctx, Value *state)
-//{
-//    Value *old_state = ConstantInt::get(state->getType(), JL_GC_STATE_SAFE);
-//    return emit_gc_state_set(ctx, state, old_state);
-//}
-
 #ifndef JL_NDEBUG
 static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)
 {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7456,8 +7456,10 @@ static jl_llvm_functions_t
 
     Instruction &prologue_end = ctx.builder.GetInsertBlock()->back();
 
+    // step 11a. Emit the entry safepoint
+    emit_safepoint(ctx);
 
-    // step 11. Do codegen in control flow order
+    // step 11b. Do codegen in control flow order
     std::vector<int> workstack;
     std::map<int, BasicBlock*> BB;
     std::map<size_t, BasicBlock*> come_from_bb;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7459,7 +7459,7 @@ static jl_llvm_functions_t
 
     // step 11a. Emit the entry safepoint
     if (JL_FEAT_TEST(ctx, safepoint_on_entry))
-        emit_safepoint(ctx);
+        emit_gc_safepoint(ctx.builder, get_current_ptls(ctx), ctx.tbaa().tbaa_const);
 
     // step 11b. Do codegen in control flow order
     std::vector<int> workstack;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1209,6 +1209,7 @@ extern "C" {
         1,
 #endif
         (int) DICompileUnit::DebugEmissionKind::FullDebug,
+        1,
         jl_rettype_inferred, NULL };
 }
 
@@ -7457,7 +7458,8 @@ static jl_llvm_functions_t
     Instruction &prologue_end = ctx.builder.GetInsertBlock()->back();
 
     // step 11a. Emit the entry safepoint
-    emit_safepoint(ctx);
+    if (JL_FEAT_TEST(ctx, safepoint_on_entry))
+        emit_safepoint(ctx);
 
     // step 11b. Do codegen in control flow order
     std::vector<int> workstack;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2221,8 +2221,10 @@ typedef struct {
 
     // controls the emission of debug-info. mirrors the clang options
     int gnu_pubnames;       // can we emit the gnu pubnames debuginfo
-    int debug_info_kind; // Enum for line-table-only, line-directives-only,
+    int debug_info_kind;    // Enum for line-table-only, line-directives-only,
                             // limited, standalone
+
+    int safepoint_on_entry; // Emit a safepoint on entry to each function
 
     // Cache access. Default: jl_rettype_inferred.
     jl_codeinstance_lookup_t lookup;

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -15,9 +15,12 @@ function libjulia_codegen_name()
     is_debug_build ? "libjulia-codegen-debug" : "libjulia-codegen"
 end
 
-# `_dump_function` might be more efficient but it doesn't really matter here...
-get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true) =
-    sprint(code_llvm, f, t, raw, dump_module, optimize)
+# The tests below assume a certain format and safepoint_on_entry=true breaks that.
+function get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true)
+    params = Base.CodegenParams(safepoint_on_entry=false)
+    d = InteractiveUtils._dump_function(f, t, false, false, !raw, dump_module, :att, optimize, :none, false, params)
+    sprint(print, d)
+end
 
 if !is_debug_build && opt_level > 0
     # Make sure getptls call is removed at IR level with optimization on


### PR DESCRIPTION
Otherwise non-allocating functions like:

`fib(x) = x <= 1 ? 1 : fib(x-1) + fib(x-2)` will block GC from make progress.

This now inserts a safepoint at the beginning of every function.

Note:
Initially I wanted to insert these safepoints late and also into back-branches. That is currently not legal since at a safepoint we must gurantuee that all objects are rooted and legal. Legal means that the typetag is set correctly, and thus we shall not sink a store of a typetag past a safepoint, and rooting requires that stores of an object to a field shall not be sunk past a safepoint. 
We can't currently gurantuee these properties after we already started optimizing the code.

@vtjnash had the idea that we could insert safepoints at the exit blocks of outer loops, that might be an idea for the future.

Besides inserting a safepoint here this has the additional overhead of requiring a lookup from a thread local variable + a load from the current ptls. In c76459cc0fb4bf238257d3f0b5b11c13c2491ff4 I hoisted the signal_page pointer load outside the fence.

@maleadt I made the emission a codegen feature so that we can turn it off for GPU code.

