### PR TITLE
while loop -> for loop in _simplify_include_frames (fixes #41566)

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -773,10 +773,9 @@ end
 # For improved user experience, filter out frames for include() implementation
 # - see #33065. See also #35371 for extended discussion of internal frames.
 function _simplify_include_frames(trace)
-    i = length(trace)
-    kept_frames = trues(i)
+    kept_frames = trues(length(trace))
     first_ignored = nothing
-    while i >= 1
+    for i in length(trace):-1:1
         frame::StackFrame, _ = trace[i]
         mod = parentmodule(frame)
         if first_ignored === nothing
@@ -801,7 +800,7 @@ function _simplify_include_frames(trace)
         i -= 1
     end
     if first_ignored !== nothing
-        kept_frames[i:first_ignored] .= false
+        kept_frames[1:first_ignored] .= false
     end
     return trace[kept_frames]
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -797,7 +797,6 @@ function _simplify_include_frames(trace)
                 first_ignored = nothing
             end
         end
-        i -= 1
     end
     if first_ignored !== nothing
         kept_frames[1:first_ignored] .= false


### PR DESCRIPTION
prevents the possibility of a bounds error when i = 0