### PR TITLE
wip: compiler-plugin: prototype builtin Cassette.jl-like overdubbing mechanism

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -126,9 +126,12 @@ include("compiler/typelattice.jl")
 include("compiler/tfuncs.jl")
 include("compiler/stmtinfo.jl")
 
+include("compiler/optimize.jl") # TODO: break this up further + extract utilities
+
+include("compiler/plugin.jl")
+
 include("compiler/abstractinterpretation.jl")
 include("compiler/typeinfer.jl")
-include("compiler/optimize.jl") # TODO: break this up further + extract utilities
 
 include("compiler/bootstrap.jl")
 ccall(:jl_set_typeinf_func, Cvoid, (Any,), typeinf_ext_toplevel)

--- a/base/compiler/plugin.jl
+++ b/base/compiler/plugin.jl
@@ -1,0 +1,304 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# # those primitive defined in types.jl
+#
+# struct _PluginContext{plugins} end
+#
+# const PluginContext = Type{<:_PluginContext}
+#
+# abstract type AbstractCompilerPlugin end
+
+# plugin management
+# =================
+
+PluginContext(plugins::Vector{Any}) = _PluginContext{to_tuple_type(plugins)}
+
+get_plugins(@nospecialize(ctx::PluginContext)) = first(ctx.parameters).parameters::SimpleVector
+
+"""
+    (::Type{<:AbstractCompilerPlugin})(f) = f()
+
+The entry into a plugin context
+Enter a plugin context from the entry call `f()`.
+
+!!! warning
+    This functor shouldn't be overloaded, the whole system will be broken otherwise.
+"""
+(::Type{<:AbstractCompilerPlugin})(f) = f()
+# (::Type{<:AbstractCompilerPlugin})(f, args...; kwargs...) = f(args...; kwargs...)
+
+const PLUGIN_ENTRY_METHOD = first(methods(AbstractCompilerPlugin))
+
+# overdubbing
+# ===========
+
+(::PluginContext)(args...) = return # a dummy method body
+
+const NULL_CONTEXT  = PluginContext(Any[])
+const SHADOW_METHOD = let
+    ms = methods(NULL_CONTEXT, (Tuple{Any,Vararg{Any}}))
+    @assert length(ms) == 1
+    first(ms)
+end
+
+is_shadow((; linfo)::Union{InferenceState,OptimizationState}) = is_shadow(linfo)
+is_shadow((; def, specTypes)::MethodInstance) = isa(def, Method) && _is_shadow(def, specTypes)
+is_shadow((; method, spec_types)::MethodMatch) = _is_shadow(method, spec_types)
+function _is_shadow(def::Method, @nospecialize(spec_types))
+    def === SHADOW_METHOD || return false
+    ft = unwrap_unionall(spec_types).parameters[1]
+    return is_plugin_ft(ft)
+end
+
+function is_overdubbing_call(argtypes::Vector{Any})
+    length(argtypes) < 1 && return false
+    ft = widenconst(argtypes[1])
+    return is_plugin_ft(ft)
+end
+
+function is_plugin_ft(@nospecialize(ft))
+    isType(ft) || return false
+    t = ft.parameters[1]
+    (t !== Bottom && t <: _PluginContext) || return false
+    @assert t !== NULL_CONTEXT "invalid plugin context introduced"
+    return true
+end
+
+# a runtime mapping of shadow method instance to overdubbed method instance
+const OVERDUB_CACHE_TABLE = IdDict{MethodInstance,MethodInstance}()
+
+function maybe_get_overdubbed(sv::Union{InferenceState,OptimizationState})
+    is_shadow(sv) || return sv.linfo # fast pass
+    return maybe_get_overdubbed(sv.linfo)
+end
+maybe_get_overdubbed(mi::MethodInstance) = get(OVERDUB_CACHE_TABLE, mi, mi)
+
+struct CallSig
+    argtypes::Vector{Any}
+    atype
+    CallSig(argtypes::Vector{Any}, @nospecialize(atype)) = new(argtypes, atype)
+end
+
+struct OverdubCallSig
+    shadow::CallSig
+    overdub::CallSig
+end
+
+const AnyCallSig = Union{CallSig,OverdubCallSig}
+
+struct OverdubMethodMatch
+    shadow::MethodMatch
+    overdub::MethodMatch
+    function OverdubMethodMatch(shadow::MethodMatch, overdub::MethodMatch)
+        @assert shadow.sparams === svec()
+        @assert is_shadow(shadow)
+        return new(shadow, overdub)
+    end
+end
+
+const AnyMethodMatch = Union{MethodMatch,OverdubMethodMatch}
+
+unwrap_shadow(callsig::AnyCallSig) = isa(callsig, CallSig) ? callsig : callsig.shadow
+unwrap_overdub(callsig::AnyCallSig) = isa(callsig, CallSig) ? callsig : callsig.overdub
+unwrap_shadow(match::AnyMethodMatch) = isa(match, MethodMatch) ? match : match.shadow
+unwrap_overdub(match::AnyMethodMatch) = isa(match, MethodMatch) ? match : match.overdub
+
+function specialize_method(match::OverdubMethodMatch; kwargs...)
+    shadow = specialize_method(unwrap_shadow(match); kwargs...)::MethodInstance
+    if !haskey(OVERDUB_CACHE_TABLE, shadow)
+        overdub = specialize_method(unwrap_overdub(match); kwargs...)::MethodInstance
+        OVERDUB_CACHE_TABLE[shadow] = overdub
+    end
+    return shadow
+end
+
+function retrieve_code_info_overdubbed(shadow::MethodInstance)
+    overdub = OVERDUB_CACHE_TABLE[shadow]
+    overdub.def.isva && throw("TODO: support vararg splatting")
+    return _retrieve_code_info_overdubbed(overdub)
+end
+
+"""
+    _retrieve_code_info_overdubbed(overdub::MethodInstance)
+
+Retrieves the source of `overdub`bed method, and transforms it so that it can fit into the
+execution with `SHADOW_METHOD`'s call signature. The transformation take the following procedures:
+1. prepend SSA statements so that they can be referred in place of the overdubbed call arguments
+2. fix up all the references to call argument or SSA values according to the step 1.
+3. replace the references to static parameters with quoted type
+4. fix up some other meta information accordingly
+5. modify all the `:call` expressions so that it will be overdubbed again by context,
+   which is propagated as the first argument of `SHADOW_METHOD`
+
+Note that the step 4. modifies all the `:call`s whatever it can be overdubbed or not.
+`fixup_no_overdubs!` will re-transform those calls if inference reveals out they can't be overdubbed.
+"""
+function _retrieve_code_info_overdubbed(overdub::MethodInstance)
+    # retrieve the original source
+    src = retrieve_code_info(overdub)
+    src === nothing && return nothing
+    src = copy(src) # make sure not to modify the original
+
+    # fixup slot information
+    src.slotnames = Symbol[Symbol("#self#"), :args, Symbol("#overdub#"), src.slotnames[2:end]...]
+    src.slotflags = UInt8[0x00, 0x00, src.slotflags...]
+
+    # transform statements
+    code = src.code
+    ssavaluetypes0 = length(code)
+    ssaoffset = nargs = overdub.def.nargs
+    function transform_overdub_value(@nospecialize(x))
+        if isa(x, SlotNumber)
+            slot = slot_id(x)
+            if 1 ≤ slot ≤ nargs
+                return SSAValue(slot) # refer to the overdubbed call arguments as a SSA value
+            else
+                return SlotNumber(slot+2) # non-call arguments are now offset by 2
+            end
+        elseif isa(x, SSAValue)
+            return SSAValue(x.id + ssaoffset)
+        end
+        return x
+    end
+    function transform_overdub_code(@nospecialize(stmt))
+        if isa(stmt, NewvarNode)
+            return NewvarNode(transform_overdub_value(stmt.slot))
+        elseif isa(stmt, Expr)
+            head = stmt.head
+            if head === :call
+                return Expr(:call, SlotNumber(1), anymap(transform_overdub_code, stmt.args)...)
+            elseif head === :static_parameter
+                return quoted(overdub.sparam_vals[stmt.args[1]::Int])
+            end
+            return Expr(head, anymap(transform_overdub_code, stmt.args)...)
+        elseif isa(stmt, GotoNode)
+            return GotoNode(stmt.label+ssaoffset)
+        elseif isa(stmt, GotoIfNot)
+            return GotoIfNot(transform_overdub_value(stmt.cond), stmt.dest+ssaoffset)
+        elseif isa(stmt, ReturnNode)
+            return ReturnNode(transform_overdub_code(stmt.val))
+        end
+        return transform_overdub_value(stmt)
+    end
+    code = anymap(transform_overdub_code, code)
+    # splat the overdubbed arguments so that they can be referred as SSA values
+    prepend!(code, Any[Expr(:call, GlobalRef(Core, :getfield), SlotNumber(2), i) for i in 1:nargs])
+    src.code = code
+
+    # fix up SSA information
+    ssavaluetypes = src.ssavaluetypes = length(code)
+    push!(src.linetable, LineInfoNode(@__MODULE__, :transform_overdub_src!, Symbol("compiler/plugin.jl"), @__LINE__, 0))
+    codeloc = length(src.linetable)
+    prepend!(src.codelocs, [codeloc for _ in 1:(ssavaluetypes-ssavaluetypes0)])
+
+    return src
+end
+
+# TODO allow general function call, not limited to a call to nullary lambda
+# for i in 1:length(ir.stmts)
+#     stmt = ir.stmts.inst[i]
+#     if isexpr(stmt, :call) && length(stmt.args) > 2
+#         a1, a2 = stmt.args[1], stmt.args[2]
+#         if widenconst(argextype(a1, ir, ir.sptypes, ir.argtypes)) === typeof(Core._apply_iterate) &&
+#            widenconst(argextype(a2, ir, ir.sptypes, ir.argtypes)) === typeof(Core.Compiler.iterate)
+#             args = Expr(:call, GlobalRef(Core, :tuple))
+#             argtypes = Any[]
+#             for arg in stmt.args[3:end]
+#                 push!(args.args, arg)
+#                 push!(argtypes, widenconst(argextype(arg, ir, ir.sptypes, ir.argtypes)))
+#             end
+#             argtypes = Tuple{argtypes...}
+#             argsssa = insert_node!(ir, i, NewInstruction(args, argtypes))
+#             ir[SSAValue(i)] = Expr(:call, a1, a2, opt.context, argsssa)
+#        end
+#     end
+# end
+# TODO allow non sigleton plugin context
+function transform_plugin_entry!(src::CodeInfo, @nospecialize(ctx))
+    @assert length(src.code) == 2
+    entry, ret = src.code
+    @assert isexpr(entry, :call, 1) && isa(ret, ReturnNode)
+    src.code[1] = Expr(:call, QuoteNode(ctx), entry.args[1])
+end
+
+# record the call at the current program counter isn't eligible to be overloaded
+function no_overdub!((; no_overdubbing_calls, currpc)::InferenceState)
+    no_overdubbing_calls === nothing && return
+    push!(no_overdubbing_calls, currpc)
+end
+
+# we overdub whatever call within `transform_overdub_src!`, but those handled within
+# `abstract_call_known` aren't eligible to be overdubbed so fix those calls here
+fixup_no_overdubs!(::Nothing, ::CodeInfo) = return
+function fixup_no_overdubs!(no_overdub_calls::BitSet, src::CodeInfo)
+    code = src.code
+    for i in 1:length(code)
+        if i in no_overdub_calls
+            stmt = code[i]
+            newstmt = nothing
+            if isexpr(stmt, :call)
+                f = first(stmt.args)
+                if f === SlotNumber(1)
+                    newstmt = Expr(:call, stmt.args[2:end]...)
+                else
+                    @assert f === GlobalRef(Core, :getfield)
+                end
+            elseif isexpr(stmt, :(=))
+                lhs, rhs = stmt.args
+                @assert isexpr(rhs, :call)
+                f = first(rhs.args)
+                if f === SlotNumber(1)
+                    newstmt = Expr(:(=), lhs, Expr(:call, rhs.args[2:end]...))
+                else
+                    @assert f === GlobalRef(Core, :getfield)
+                end
+            else
+                Core.eval(Main, :(no_overdub_calls = $no_overdub_calls; src = $src))
+                @assert false "invalid source"
+            end
+            if newstmt !== nothing
+                code[i] = newstmt
+            end
+        end
+    end
+    return src.code = code
+end
+
+# hooks
+# =====
+
+function preinf_hook!(frame::InferenceState)
+    ctx = frame.context
+    ctx === NULL_CONTEXT && return # fast pass
+    for plugin in get_plugins(ctx)
+        @invokelatest preinf_hook!(plugin, frame)
+    end
+end
+preinf_hook!(::Type{<:AbstractCompilerPlugin}, frame::InferenceState) = return
+
+function postinf_hook!(frame::InferenceState)
+    ctx = frame.context
+    ctx === NULL_CONTEXT && return # fast pass
+    for plugin in get_plugins(ctx)
+        @invokelatest postinf_hook!(plugin, frame)
+    end
+end
+postinf_hook!(::Type{<:AbstractCompilerPlugin}, frame::InferenceState) = return
+
+function preopt_hook!(opt::OptimizationState)
+    ctx = opt.context
+    ctx === NULL_CONTEXT && return # fast pass
+    for plugin in get_plugins(ctx)
+        @invokelatest preopt_hook!(plugin, opt)
+    end
+end
+preopt_hook!(::Type{<:AbstractCompilerPlugin}, opt::OptimizationState) = return
+
+function postopt_hook!(opt::OptimizationState)
+    ctx = opt.context
+    ctx === NULL_CONTEXT && return # fast pass
+    for plugin in get_plugins(ctx)
+        @invokelatest postopt_hook!(plugin, opt)
+    end
+end
+postopt_hook!(::Type{<:AbstractCompilerPlugin}, opt::OptimizationState) = return

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1700,6 +1700,11 @@ end
 # since abstract_call_gf_by_type is a very inaccurate model of _method and of typeinf_type,
 # while this assumes that it is an absolutely precise and accurate and exact model of both
 function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::InferenceState)
+    is_overdub = is_overdubbing_call(argtypes)
+    if is_overdub
+        argtypes = copy(argtypes)
+        ctx = popfirst!(argtypes)
+    end
     if length(argtypes) == 3
         tt = argtypes[3]
         if isa(tt, Const) || (isType(tt) && !has_free_typevars(tt))
@@ -1709,6 +1714,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                 af_argtype = isa(tt, Const) ? tt.val : (tt::DataType).parameters[1]
                 if isa(af_argtype, DataType) && af_argtype <: Tuple
                     argtypes_vec = Any[aft, af_argtype.parameters...]
+                    is_overdub && pushfirst!(argtypes_vec, ctx)
                     if contains_is(argtypes_vec, Union{})
                         return CallMeta(Const(Union{}), false)
                     end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -1,5 +1,18 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+# # this is very clumsy but make it easier to know where we need to handle overdubbing
+# struct OverdubMethodInstance
+#     overdub::MethodInstance
+#     shadow::MethodInstance
+# end
+# const MethodInstance2 = Union{MethodInstance, OverdubMethodInstance}
+
+struct _PluginContext{plugins} end
+
+const PluginContext = Type{<:_PluginContext}
+
+abstract type AbstractCompilerPlugin end
+
 """
     AbstractInterpreter
 
@@ -29,8 +42,10 @@ mutable struct InferenceResult
     result # ::Type, or InferenceState if WIP
     src #::Union{CodeInfo, OptimizationState, Nothing} # if inferred copy is available
     valid_worlds::WorldRange # if inference and optimization is finished
-    function InferenceResult(linfo::MethodInstance, given_argtypes = nothing, va_override=false)
-        argtypes, overridden_by_const = matching_cache_argtypes(linfo, given_argtypes, va_override)
+    function InferenceResult(linfo::MethodInstance;
+                             argtypes::Union{Nothing,Vector{Any}} = nothing,
+                             va_override::Bool = false)
+        argtypes, overridden_by_const = matching_cache_argtypes(linfo, argtypes, va_override)
         return new(linfo, argtypes, overridden_by_const, Any, nothing, WorldRange())
     end
 end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -100,7 +100,7 @@ function choosetests(choices = [])
     filtertests!(tests, "subarray")
     filtertests!(tests, "compiler", ["compiler/inference", "compiler/validation",
         "compiler/ssair", "compiler/irpasses", "compiler/codegen",
-        "compiler/inline", "compiler/contextual"])
+        "compiler/inline", "compiler/contextual", "compiler/plugin"])
     filtertests!(tests, "stdlib", STDLIBS)
     # do ambiguous first to avoid failing if ambiguities are introduced by other tests
     filtertests!(tests, "ambiguous")

--- a/test/compiler/plugin.jl
+++ b/test/compiler/plugin.jl
@@ -1,0 +1,305 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test
+const CC = Core.Compiler
+import .CC:
+    AbstractCompilerPlugin,
+    InferenceState,
+    OptimizationState
+
+@testset "hook invocations" begin
+    M = Module()
+
+    @eval M begin
+        const CC = Core.Compiler
+        import .CC:
+            AbstractCompilerPlugin,
+            InferenceState,
+            OptimizationState
+        using Test
+
+        const REWRITE_COUNTER = Ref(0)
+        get_counter() = REWRITE_COUNTER[]
+        increment_counter!() = REWRITE_COUNTER[] += 1
+        reset_counter!() = REWRITE_COUNTER[] = 0
+
+        struct HookCounter <: AbstractCompilerPlugin end
+        CC.preinf_hook!(::Type{HookCounter}, frame::InferenceState) = increment_counter!()
+        CC.postinf_hook!(::Type{HookCounter}, frame::InferenceState) = increment_counter!()
+        CC.preopt_hook!(::Type{HookCounter}, opt::OptimizationState) = increment_counter!()
+        CC.postopt_hook!(::Type{HookCounter}, opt::OptimizationState) = increment_counter!()
+    end
+
+    @eval M begin # simplest
+        @assert (reset_counter!(); get_counter() == 0)
+        @test HookCounter() do
+            return 42
+        end == 42
+        @test get_counter() == 8 # 4 × (HookCounter(λ), λ())
+    end
+
+    @eval M begin # simple inter-procedural
+        @assert (reset_counter!(); get_counter() == 0)
+
+        g = 42 # unable to constant prop'
+        @test_broken HookCounter() do
+            return foo(g::Int)
+        end == 42
+        # FIXME (how to deal with :invoke expressions)
+        @test_broken get_counter() == 12 # 4 × (HookCounter(λ), λ(), foo())
+    end
+
+    @eval M begin # constant prop'
+        @assert (reset_counter!(); get_counter() == 0)
+
+        Base.@aggressive_constprop bar(a) = a
+
+        @test HookCounter() do
+            return bar(42)
+        end == 42
+        @test get_counter() == 16 # 4 × (HookCounter(λ), λ(), bar(::Int), bar(::Const(42)))
+    end
+
+    @eval M begin # `_apply_iterate`
+        @assert (reset_counter!(); get_counter() == 0)
+
+        @noinline foo(a, b, c) = (a, b, c)
+
+        gtpl = (0,1,2)
+        @test HookCounter() do
+            tpl = gtpl::Tuple{Int,Int,Int}
+            return foo(tpl...)
+        end == gtpl
+        @test get_counter() == 12 # 4 × (HookCounter(λ), λ(), foo(::Int, ::Int, ::Int))
+    end
+end
+
+# super simple rewrite
+# --------------------
+
+struct IdentityRewriter <: AbstractCompilerPlugin end
+function CC.preinf_hook!(::Type{IdentityRewriter}, frame::InferenceState)
+    linfo = frame.linfo
+    if CC.is_shadow(linfo)
+        if CC.getindex(CC.OVERDUB_CACHE_TABLE, linfo).def.name === :identity
+            frame.src.code[1] = Core.ReturnNode(QuoteNode("42"))
+        end
+    end
+end
+
+# basic
+call_identity_basic(a) = identity(a)
+@test call_identity_basic(42) == 42
+@test IdentityRewriter() do
+    call_identity_basic(42)
+end == "42"
+
+# # args for context hook
+# @test IdentityRewriter(42) do a
+#     call_identity_basic(a)
+# end == "42"
+
+# dynamic
+call_identity_dynamic(a) = identity(Base.inferencebarrier(a))
+@test call_identity_dynamic(42) == 42
+@test IdentityRewriter() do
+    call_identity_dynamic(42)
+end == "42"
+# code transformation works even if signature isn't fully concrete
+@test Base.return_types() do
+    IdentityRewriter() do
+        call_identity_dynamic(42)
+    end
+end == Any[String]
+
+# # to see the difference from Cassette.jl
+# using Cassette
+# Cassette.@context ChangeIdentity
+# function change_identity_pass(::Type{<:ChangeIdentity}, ref::Cassette.Reflection)
+#     if ref.method.name === :identity
+#         ref.code_info.code[1] = Core.ReturnNode(QuoteNode("42"))
+#     end
+#     return ref.code_info
+# end
+# const context = ChangeIdentity(; pass = Cassette.@pass change_identity_pass)
+# function change_identity_dynamic_cassette(a)
+#     function nullary_lambda(); identity(Base.inferencebarrier(a)); end
+#     return Cassette.overdub(context, nullary_lambda)
+# end
+# change_identity_dynamic_cassette(42)
+# @test Base.return_types(change_identity_dynamic_cassette, (Int,)) == Any[Any]
+
+# no rewrite
+myidentity(a) = a
+call_myidentity(a) = myidentity(a)
+@test call_myidentity(42) == 42
+@test IdentityRewriter() do
+    call_myidentity(42)
+end == 42
+
+# invalidations
+# -------------
+
+struct CheckInvalidation <: AbstractCompilerPlugin end
+callee(a) = a # whose definition will be changed later
+caller(a) = callee(a)
+@test caller(42) == 42
+@test CheckInvalidation() do
+    caller(42)
+end == 42
+@noinline callee(a) = typeof(a)
+@test caller(42) == Int
+@test_broken CheckInvalidation() do # FIXME this is obvious bug
+    caller(42)
+end == Int
+
+# # adapted from https://gist.github.com/Keno/d0c2df947f67be543036238a0caeb1c6
+# module FastSinCompiler
+#
+# # this compiler-plugin will rewrite all the `sin(::Float64)` calls into `fast_sin(::Float64)` calls:
+# # - it will work on post-inf IR
+# # - it shouldn't rewrite `sin(::Float64)` within `fast_sin(::Float64)`
+# # - it should handle dynamic dispatches correctly
+#
+# # setup
+# # -----
+#
+# import Core:
+#     MethodInstance
+# const CC = Core.Compiler
+# import .CC:
+#     InferenceState,
+#     OptimizationState,
+#     OptimizationParams,
+#     IRCode,
+#     optimize,
+#     argextype,
+#     widenconst,
+#     AbstractCompilerPlugin,
+#     preinf_hook!,
+#     postinf_hook!,
+#     preopt_hook!
+# import Base:
+#     @invoke,
+#     get_world_counter,
+#     to_tuple_type
+# import Base.Meta: isexpr
+# using Test
+#
+# let counter = 0
+#     global fast_sin, get_fast_sin_counter, reset_counter
+#     fast_sin(x::Float64) = (counter += 1; sin(x::Float64))
+#     get_fast_sin_counter() = counter
+#     reset_counter() = (counter = 0)
+# end
+#
+# # impl
+# # ----
+#
+# struct FastSinRewriter2 <: AbstractCompilerPlugin end
+#
+# function postinf_hook!(::Type{FastSinRewriter2}, frame::InferenceState)
+#     for (i,x) in enumerate(frame.src.code)
+#         if isexpr(x, :call)
+#             if isexpr(x, :call) && length(x.args) == 2 &&
+#                widenconst(argextype(x.args[1], frame)) === typeof(sin) &&
+#                widenconst(argextype(x.args[2], frame)) === Float64
+#                 frame.src.code[i] = Expr(:call, GlobalRef(@__MODULE__, :fast_sin), x.args[2])
+#                 frame.stmt_info[i] = nothing
+#                 global rewritecounter += 1
+#             end
+#         end
+#     end
+# end
+# rewritecounter = 0
+#
+# function preopt_hook!(::Type{FastSinRewriter}, opt::OptimizationState)
+#     ir = opt.ir
+#     @assert isa(ir, IRCode)
+#     (; sptypes, argtypes) = ir
+#     for (i, s) in enumerate(ir.stmts)
+#         stmt = s[:inst]
+#         if isexpr(stmt, :call) && length(stmt.args) == 2 &&
+#            widenconst(argextype(stmt.args[1], ir, sptypes, argtypes)) === typeof(sin) &&
+#            widenconst(argextype(stmt.args[2], ir, sptypes, argtypes)) === Float64
+#             ir.stmts.inst[i] = Expr(:call, GlobalRef(@__MODULE__, :fast_sin), stmt.args[2])
+#             ir.stmts.info[i] = false
+#             global rewritecounter += 1
+#         end
+#     end
+# end
+# rewritecounter = 0
+#
+# function foo()
+#     FastSinRewriter2() do
+#         sin(10)
+#     end
+# end
+# @code_typed FastSinRewriter2(sin, 10)
+# rewritecounter
+# foo()
+# get_fast_sin_counter()
+#
+# let
+#     tme = first(methods(fast_sin, (Float64,)))
+#     ttt = to_tuple_type((typeof(fast_sin), Float64,))
+#
+#     function CC.optimize(interp::FastSinInterpreter, opt::OptimizationState, params::OptimizationParams, @nospecialize(result))
+#         @assert isnothing(opt.ir)
+#
+#         linfo = opt.linfo
+#         if !(linfo.def === tme && linfo.specTypes === ttt)
+#             (; src, sptypes, slottypes) = opt
+#             for (i, x) in enumerate(src.code)
+#                 if isexpr(x, :call) && length(x.args) == 2
+#                     ft = widenconst(argextype(x.args[1], src, sptypes, slottypes))
+#                     if ft === typeof(sin)
+#                         at = widenconst(argextype(x.args[2], src, sptypes, slottypes))
+#                         if at === Float64
+#                             src.code[i] = Expr(:call, GlobalRef(@__MODULE__, :fast_sin), x.args[2])
+#                         end
+#                     end
+#                 end
+#             end
+#         end
+#
+#         return optimize(native(interp), opt, params, result)
+#     end
+# end
+#
+# # test
+# # ----
+#
+# get_sin() = sin
+# function f(x, replace)
+#     reset_counter()
+#
+#     @testset "simple" begin
+#         sin(x)
+#         @test get_fast_sin_counter() == (replace ? 1 : 0)
+#     end
+#
+#     @testset "a bit complex, still inferred" begin
+#         get_sin()(x)
+#         @test get_fast_sin_counter() == (replace ? 2 : 0)
+#     end
+#
+#     @testset "dynamic dispatch" begin
+#         get_sin()(Base.inferencebarrier(x))
+#         @test get_fast_sin_counter() == (replace ? 3 : 0) # fail, we can't hijack the dynamic dispatch
+#     end
+# end
+#
+# @testset "testset" begin
+#     @testset "customized compilation" begin
+#         FastSinRewriter() do
+#             f(1.0, true)
+#         end
+#     end
+#
+#     @testset "don't affect native code cache" begin
+#         f(1.0, false) # fail, since code cache can be inserted outside of `CC.code_cache`
+#     end
+# end
+#
+# end # module FastSinCompiler


### PR DESCRIPTION
This is the initial prototyping of [the compiler-plugin](https://hackmd.io/bVhb97Q4QTWeBQw8Rq4IFw?view).

The proposed compiler-plugin infrastructure will consist of 3 main parts:
1. [Cassette.jl](https://github.com/JuliaLabs/Cassette.jl)-like code overdubbing mechanism
2. code transformation hooks
3. `AbstractInterpreter` delegation hook

A compiler plugin will customize compiler behavior via the mechanisms
provided by the part 2. and 3., i.e.:
- code transformation hooks allow a plugin to transform code at various
  stages of compilation pipeline from pre-inference to post-optimization
- `AbstractInterpreter` delegation hook will enable further specialized
  compilation based on a customized abstract interpretation

Actually this PR doesn't implement the part 3. at all yet, because it
turns out the part 1. itself could be really tricky and very challenging,
and so I'd like to get feedback at this point.

The whole purpose of the part 1. is to separate a plugin's code execution
context from those of the native execution and other plugin's contexts.
A plugin should be able to transform sources of arbitrary methods and
execute arbitrary Julia code under its own semantics, but its codegen
should not influence the code cache of those original methods
(I will refer to them as "overdubbed method"). To enable the separation,
code generated by a plugin will be associated to a dedicated method
(I will refer to this method as "shadow method") so that its cache is
just separated from that of overdubbed method.

The main difference between Cassette and this PR is, while Cassette uses
`@generated` function, this PR doesn't. In other word, this PR tries to
implement Cassette without the issue of `@generated`, _**limited inference**_;
`@generated` can only be inferred when a call signature is fully concrete
and it leads to the problem where Cassette.jl's code transformation can't
be applied well statically when used for real-world programs, which can
contain various forms of type instabilities.
Instead of using `@generated`, this PR implements the overdubbing mechanism
within inference directly in a way that the overdubbing can be applied
once inference enters a plugin's context no matter how inference goes
successful. Essentially, we can make `InferenceState` manage plugin's
contexts and then the overdubbing mechanism can be separated from the
dispatch system that `@generated` relies on.

Here is how the part 1. and 2. works under the current implementation:
1. (part 1.) when the first argument is a subtype of `AbstractCompilerPlugin`,
   `InferenceState` will _compose_ a new plugin context and then succeeding
   inference will be done in the context
2. (part 1.) when in a plugin context, a compiler will perform Cassette-like
   code transformation _before inference_ so that the retrieved source
   of the original method can fit with the signature of the shadow method
   and also all the calls within the source will be overdubbed with the
   current plugin context
3. (part 1.) when a call is overdubbed, inference will first find
   matching methods for the original signature, and then it also forms
   the equivalent method matches for the shadow method
4. (part 1.) when inferring an overdubbed call edge, inference will
   retrieve the sources of the overdubbed matching methods, but the 
   generated code will be associated with the shadow matching methods 
5. (part 2.) when in a plugin context, we apply the hooks provided by each
   plugin at each "interesting" point of the compilation pipeline

This PR comes with significant changes and still very WIP.
I really need feedbacks on this approach since I'm still not sure what
is the best way to implement the overdubbing mechanism. Any suggestion
for solving remaning issues or cleaner implementations would be very welcomed.

Here are main remaining TODOs, but there are bunch of other TODOs that I
left as comments...
- [ ] overdubbing support
  * [ ] source retrieval from a `isva` method
  * [ ] overdubbing on `Core._apply_iterate`
  * [ ] overdubbing on opaque closure
  * [ ] make plugin entry accept arguments (rather than just accepting nullary lambda)
- [ ] support backedges
  * [ ] add backedge from overdubbed method instance to shadow method instance;
        I tried to add the support, but couldn't make it work
  * [ ] add backedge from code transformers to shadow method instance:
        I simply didn't add this support since overdubbing is the primary
        issue at this moment
- [ ] support non-singleton plugin context
