### PR TITLE
[build] Automatically set `USE_BINARYBUILDER_CSL=0` when local CSL is new

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1168,7 +1168,10 @@ BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out libgfortran%,$(s
 LIBGFORTRAN_VERSION := $(subst libgfortran,,$(filter libgfortran%,$(subst -,$(SPACE),$(BB_TRIPLET_LIBGFORTRAN))))
 
 # This is the set of projects that BinaryBuilder dependencies are hooked up for.
-BB_PROJECTS := BLASTRAMPOLINE OPENBLAS LLVM LIBSUITESPARSE OPENLIBM GMP MBEDTLS LIBSSH2 NGHTTP2 MPFR CURL LIBGIT2 PCRE LIBUV LIBUNWIND DSFMT OBJCONV ZLIB P7ZIP CSL
+# Note: we explicitly _do not_ define `CSL` here, since it requires some more
+# advanced techniques to decide whether it should be installed from a BB source
+# or not.  See `deps/csl.mk` for more detail.
+BB_PROJECTS := BLASTRAMPOLINE OPENBLAS LLVM LIBSUITESPARSE OPENLIBM GMP MBEDTLS LIBSSH2 NGHTTP2 MPFR CURL LIBGIT2 PCRE LIBUV LIBUNWIND DSFMT OBJCONV ZLIB P7ZIP
 define SET_BB_DEFAULT
 # First, check to see if BB is disabled on a global setting
 ifeq ($$(USE_BINARYBUILDER),0)

--- a/stdlib/CompilerSupportLibraries_jll/Project.toml
+++ b/stdlib/CompilerSupportLibraries_jll/Project.toml
@@ -1,5 +1,9 @@
 name = "CompilerSupportLibraries_jll"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+# NOTE: When updating this, also make sure to update the value
+# `CSL_NEXT_GLIBCXX_VERSION` in `deps/csl.mk`, to properly disable
+# automatic usage of BB-built CSLs on extremely up-to-date systems!
 version = "0.5.0+0"
 
 [deps]


### PR DESCRIPTION
We ship our own compiler support libraries to ensure a minimum level of
support for BB-built libraries, however certain distros provide very
bleeding-edge compilers.  This can be a problem if we download an
_older_ `libstdc++.so` and forcibly link against that when launching
Julia, as when Julia itself is built with the local `g++`, it may use
symbols that don't exist in the BB-sourced `libstdc++.so`.

To address this, we default to not using BB-sourced CSLs if the
`libstdc++.so` that the native compiler would use contains a symbol that
our BB-sourced CSLs do not have.  We use the monotonically-climbing
`GLIBCXX_3.4.XX` version symbols for this purpose; encoding the "next"
version number within `deps/csl.mk`, and triggering the BB-avoidance if
that version exists within the system-provided `libstdc++.so`.