### PR TITLE
fix memory corruption in `deleteat!`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1119,7 +1119,7 @@ STATIC_INLINE void jl_array_del_at_beg(jl_array_t *a, size_t idx, size_t dec,
         // Move the rest of the data if the offset changed
         if (newoffs != offset) {
             memmove_safe(a->flags.hasptr, newdata + nb1, olddata + nb1 + nbdec, nbtotal - nb1);
-            if (isbitsunion) memmove(newtypetagdata + idx, typetagdata + idx + dec, n - idx);
+            if (isbitsunion) memmove(newtypetagdata + idx, typetagdata + idx + dec, a->nrows - idx);
         }
         a->data = newdata;
     }


### PR DESCRIPTION
n.b. `n == a->nrows + dec`, so we overwrote `dec` bytes of unrelated memory here

Fixes https://github.com/JuliaData/DataFrames.jl/issues/2819

Hard to test for memory corruption mechanically, but we can trigger the failure via:

```
julia> a = Vector{Union{Bool,Missing}}(missing, 10^4);                                                                                                                                                   
julia> deleteat!(a, 2:(length(a) - 5));                                                                                                                                                                  
julia> a                                                                                                                                                                                                 
corrupted double-linked list                                                                                                                                                                             
```