### PR TITLE
Always send log messages to stderr by default

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -670,7 +670,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     buf = IOBuffer()
     stream = logger.stream
     if !isopen(stream)
-        stream = level < Warn ? stdout : stderr
+        stream = stderr
     end
     iob = IOContext(buf, stream)
     levelstr = level == Warn ? "Warning" : string(level)

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -119,7 +119,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     msglines = [(indent=0, msg=l) for l in split(chomp(string(message)::String), '\n')]
     stream = logger.stream
     if !isopen(stream)
-        stream = level < Warn ? stdout : stderr
+        stream = stderr
     end
     dsize = displaysize(stream)::Tuple{Int,Int}
     nkwargs = length(kwargs)::Int

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -341,20 +341,6 @@ end
         String(take!(io))
     end
 
-    function genmsg_out(level, message, _module, filepath, line; kws...)
-        fname = tempname()
-        f = open(fname, "w")
-        logger = SimpleLogger()
-        redirect_stdout(f) do
-            handle_message(logger, level, message, _module, :group, :id,
-                           filepath, line; kws...)
-        end
-        close(f)
-        buf = read(fname)
-        rm(fname)
-        String(buf)
-    end
-
     function genmsg_err(level, message, _module, filepath, line; kws...)
         fname = tempname()
         f = open(fname, "w")
@@ -370,7 +356,7 @@ end
     end
 
     # Simple
-    @test genmsg_out(Info, "msg", Main, "some/path.jl", 101) ==
+    @test genmsg_err(Info, "msg", Main, "some/path.jl", 101) ==
     """
     ┌ Info: msg
     └ @ Main some/path.jl:101


### PR DESCRIPTION
Log messages should always be printed to stderr by default so programs can distinguish between actual output and diagnostics. In particular, this should not be predicated on the *log level*, as was introduced in https://github.com/JuliaLang/julia/pull/40423.

Just in case we *don't* want this PR, a workaround like
```
using Logging
global_logger(ConsoleLogger(stderr))
```
should be mentioned in HISTORY.md.

Edit: Would also be lovely if we could get either change into 1.7.