### PR TITLE
fix #41654, layout of 0-field structs with circular supertypes

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1557,9 +1557,9 @@ JL_CALLABLE(jl_f__typebody)
             // able to compute the layout of the object before needing to
             // publish it, so we must assume it cannot be inlined, if that
             // check passes, then we also still need to check the fields too.
-            if (!dt->name->mutabl && !references_name((jl_value_t*)dt->super, dt->name, 1)) {
+            if (!dt->name->mutabl && (nf == 0 || !references_name((jl_value_t*)dt->super, dt->name, 1))) {
                 int mayinlinealloc = 1;
-                size_t i, nf = jl_svec_len(ft);
+                size_t i;
                 for (i = 0; i < nf; i++) {
                     jl_value_t *fld = jl_svecref(ft, i);
                     if (references_name(fld, dt->name, 1)) {

--- a/test/core.jl
+++ b/test/core.jl
@@ -7236,6 +7236,12 @@ end
 @test string((B40050(),)) == "($B40050(),)"
 @test_broken isbitstype(Tuple{B40050})
 
+# issue #41654
+struct X41654 <: Ref{X41654}
+end
+@test isbitstype(X41654)
+@test ('a'=>X41654(),)[1][2] isa X41654
+
 # Issue #34206/34207
 function mre34206(a, n)
     va = view(a, :)


### PR DESCRIPTION
I think (hope?) this should be ok, since we should always be able to determine the layout of a 0-field struct.

fix #41654
