### PR TITLE
Improve inference for some regex captures

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -203,7 +203,7 @@ big(::Type{<:AbstractIrrational}) = BigFloat
 function alignment(io::IO, x::AbstractIrrational)
     m = match(r"^(.*?)(=.*)$", sprint(show, x, context=io, sizehint=0))
     m === nothing ? (length(sprint(show, x, context=io, sizehint=0)), 0) :
-    (length(m.captures[1]::SubString), length(m.captures[2]::SubString))
+    (length(something(m.captures[1])), length(something(m.captures[2])))
 end
 
 # inv

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -203,7 +203,7 @@ big(::Type{<:AbstractIrrational}) = BigFloat
 function alignment(io::IO, x::AbstractIrrational)
     m = match(r"^(.*?)(=.*)$", sprint(show, x, context=io, sizehint=0))
     m === nothing ? (length(sprint(show, x, context=io, sizehint=0)), 0) :
-    (length(m.captures[1]), length(m.captures[2]))
+    (length(m.captures[1]::SubString), length(m.captures[2]::SubString))
 end
 
 # inv

--- a/base/path.jl
+++ b/base/path.jl
@@ -36,7 +36,7 @@ elseif Sys.iswindows()
 
     function splitdrive(path::String)
         m = match(r"^([^\\]+:|\\\\[^\\]+\\[^\\]+|\\\\\?\\UNC\\[^\\]+\\[^\\]+|\\\\\?\\[^\\]+:|)(.*)$"s, path)
-        String(m.captures[1]::SubString), String(m.captures[2]::SubString)
+        String(something(m.captures[1])), String(something(m.captures[2]))
     end
 else
     error("path primitives for this OS need to be defined")
@@ -208,7 +208,7 @@ function splitext(path::String)
     a, b = splitdrive(path)
     m = match(path_ext_splitter, b)
     m === nothing && return (path,"")
-    (a*m.captures[1]::SubString), String(m.captures[2]::SubString)
+    (a*something(m.captures[1])), String(something(m.captures[2]))
 end
 
 # NOTE: deprecated in 1.4

--- a/base/path.jl
+++ b/base/path.jl
@@ -36,7 +36,7 @@ elseif Sys.iswindows()
 
     function splitdrive(path::String)
         m = match(r"^([^\\]+:|\\\\[^\\]+\\[^\\]+|\\\\\?\\UNC\\[^\\]+\\[^\\]+|\\\\\?\\[^\\]+:|)(.*)$"s, path)
-        String(m.captures[1]), String(m.captures[2])
+        String(m.captures[1]::SubString), String(m.captures[2]::SubString)
     end
 else
     error("path primitives for this OS need to be defined")
@@ -208,7 +208,7 @@ function splitext(path::String)
     a, b = splitdrive(path)
     m = match(path_ext_splitter, b)
     m === nothing && return (path,"")
-    a*m.captures[1], String(m.captures[2])
+    (a*m.captures[1]::SubString), String(m.captures[2]::SubString)
 end
 
 # NOTE: deprecated in 1.4


### PR DESCRIPTION
Add some typeasserts to places where an element of a `m.captures` is loaded, and it's known that it's a match. This prevents useless union-splitting, which shows up in static analysis.

There are more places in Base where the same pattern of `m.captures[1]` occurs, but many of these are in places where it's unlikely people are hitting them doing static analysis, such as in TerminalMenus, InteractiveUtils, Markdown and so on.