### PR TITLE
Fix `fieldtype_tfunc` for union types

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1025,7 +1025,7 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
         if istypea && istypeb
             return Type{<:Union{ta, tb}}
         end
-        return tmerge(ta0, tb0)
+        return Any
     end
     u isa DataType || return Any
     if isabstracttype(u)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1015,8 +1015,17 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
     exact = exact && !has_free_typevars(s)
     u = unwrap_unionall(s)
     if isa(u, Union)
-        return tmerge(_fieldtype_tfunc(rewrap(u.a, s), exact, name),
-                      _fieldtype_tfunc(rewrap(u.b, s), exact, name))
+        ta0 = _fieldtype_tfunc(rewrap(u.a, s), exact, name)
+        tb0 = _fieldtype_tfunc(rewrap(u.b, s), exact, name)
+        ta, exacta, _, istypea = instanceof_tfunc(ta0)
+        tb, exactb, _, istypeb = instanceof_tfunc(tb0)
+        if exact && exacta && exactb
+            return Const(Union{ta, tb})
+        end
+        if istypea && istypeb
+            return Type{<:Union{ta, tb}}
+        end
+        return tmerge(ta0, tb0)
     end
     u isa DataType || return Any
     if isabstracttype(u)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1017,6 +1017,8 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
     if isa(u, Union)
         ta0 = _fieldtype_tfunc(rewrap(u.a, s), exact, name)
         tb0 = _fieldtype_tfunc(rewrap(u.b, s), exact, name)
+        ta0 ⊑ tb0 && return tb0
+        tb0 ⊑ ta0 && return ta0
         ta, exacta, _, istypea = instanceof_tfunc(ta0)
         tb, exactb, _, istypeb = instanceof_tfunc(tb0)
         if exact && exacta && exactb

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3395,3 +3395,14 @@ end
         x.x
     end) == Any[Int]
 end
+
+@testset "fieldtype for unions" begin # e.g. issue #40177
+    f40177(::Type{T}) where {T} = fieldtype(T, 1)
+    for T in [
+        Union{Tuple{Val}, Tuple{Tuple}},
+        Union{Base.RefValue{T}, Type{Int32}} where T<:Real,
+        Union{Tuple{Vararg{Symbol}}, Tuple{Float64, Vararg{Float32}}},
+    ]
+        @test @inferred(f40177(T)) == fieldtype(T, 1)
+    end
+end


### PR DESCRIPTION
On master:
```julia
julia> T = Union{Tuple{Val}, Tuple{Tuple}}
Union{Tuple{Val}, Tuple{Tuple}}

julia> fieldtype(T, 1)
Union{Tuple, Val}

julia> Core.Compiler.fieldtype_tfunc(Core.Const(T), Core.Const(1))
Union{Type{Val}, Type{Tuple}} # should be Type{Union{Tuple, Val}}
```
I tried to be conservative here in the sense that in cases where this PR changes the result, it is actually for the better, but there may be cases left where `fieldtype_tfunc` remains unsound for `Type{Union{...}}` input.

Fixes #40177.