### PR TITLE
THIRDPARTY.md cleanup

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -23,4 +23,4 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 end of terms and conditions
 
-Please see THIRDPARTY.md for license information for other software used in this project.
+Please see [THIRDPARTY.md](./THIRDPARTY.md) for license information for other software used in this project.

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -40,6 +40,7 @@ Julia's `stdlib` uses the following external libraries, which have their own lic
 - [PCRE](https://www.pcre.org/licence.txt) [BSD-3]
 - [SUITESPARSE](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/LICENSE.txt) [mix of LGPL2+ and GPL2+; see individual module licenses]
 - [LIBBLASTRAMPOLINE](https://github.com/staticfloat/libblastrampoline/blob/main/LICENSE) [MIT]
+- [LIBWHICH](https://github.com/vtjnash/libwhich/blob/master/LICENSE) [MIT]
 
 Julia's build process uses the following external tools:
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -38,7 +38,7 @@ Julia's `stdlib` uses the following external libraries, which have their own lic
 - [OPENBLAS](https://raw.github.com/xianyi/OpenBLAS/master/LICENSE) [BSD-3]
 - [LAPACK](https://netlib.org/lapack/LICENSE.txt) [BSD-3]
 - [PCRE](https://www.pcre.org/licence.txt) [BSD-3]
-- [SUITESPARSE](http://suitesparse.com) [mix of LGPL2+ and GPL2+; see individual module licenses]
+- [SUITESPARSE](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/LICENSE.txt) [mix of LGPL2+ and GPL2+; see individual module licenses]
 
 Julia's build process uses the following external tools:
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -41,6 +41,7 @@ Julia's `stdlib` uses the following external libraries, which have their own lic
 - [SUITESPARSE](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/LICENSE.txt) [mix of LGPL2+ and GPL2+; see individual module licenses]
 - [LIBBLASTRAMPOLINE](https://github.com/staticfloat/libblastrampoline/blob/main/LICENSE) [MIT]
 - [LIBWHICH](https://github.com/vtjnash/libwhich/blob/master/LICENSE) [MIT]
+- [NGHTTP2](https://github.com/nghttp2/nghttp2/blob/master/COPYING) [MIT]
 
 Julia's build process uses the following external tools:
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -27,7 +27,7 @@ own licenses:
 
 Julia's `stdlib` uses the following external libraries, which have their own licenses:
 
-- [DSFMT](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/LICENSE.txt) [BSD-3]
+- [DSFMT](https://github.com/MersenneTwister-Lab/dSFMT/blob/master/LICENSE.txt) [BSD-3]
 - [OPENLIBM](https://github.com/JuliaMath/openlibm/blob/master/LICENSE.md) [MIT, BSD-2, ISC]
 - [GMP](https://gmplib.org/manual/Copying.html#Copying) [LGPL3+ or GPL2+]
 - [LIBGIT2](https://github.com/libgit2/libgit2/blob/development/COPYING) [GPL2+ with unlimited linking exception]

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -9,7 +9,7 @@ for exceptions.
 - [MUSL](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) (for src/getopt.c and src/getopt.h) [MIT]
 - [MINGW](https://sourceforge.net/p/mingw/mingw-org-wsl/ci/legacy/tree/mingwrt/mingwex/dirname.c) (for dirname implementation on Windows) [MIT]
 - [NetBSD](https://www.netbsd.org/about/redistribution.html) (for setjmp, longjmp, and strptime implementations on Windows) [BSD-3]
-- [Python](https://docs.python.org/3/license.html) (for strtod and joinpath implementation on Windows) [BSD-3, effectively]
+- [Python](https://docs.python.org/3/license.html) (for strtod implementation on Windows) [PSF]
 - [Google Benchmark](https://github.com/google/benchmark) (for cyclecount implementation) [Apache 2.0]
 
 The following components included in Julia `Base` have their own separate licenses:

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -14,7 +14,6 @@ for exceptions.
 The following components included in Julia `Base` have their own separate licenses:
 
 - base/ryu/* [Boost] (see [ryu](https://github.com/ulfjack/ryu/blob/master/LICENSE-Boost))
-- base/grisu/* [BSD-3] (see [double-conversion](https://github.com/google/double-conversion/blob/master/LICENSE))
 - base/special/{exp,rem_pio2,hyperbolic}.jl [Freely distributable with preserved copyright notice] (see [FDLIBM](https://www.netlib.org/fdlibm))
 
 The Julia language links to the following external libraries, which have their

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -10,7 +10,6 @@ for exceptions.
 - [MINGW](https://sourceforge.net/p/mingw/mingw-org-wsl/ci/legacy/tree/mingwrt/mingwex/dirname.c) (for dirname implementation on Windows) [MIT]
 - [NetBSD](https://www.netbsd.org/about/redistribution.html) (for setjmp, longjmp, and strptime implementations on Windows) [BSD-3]
 - [Python](https://docs.python.org/3/license.html) (for strtod implementation on Windows) [PSF]
-- [Google Benchmark](https://github.com/google/benchmark) (for cyclecount implementation) [Apache 2.0]
 
 The following components included in Julia `Base` have their own separate licenses:
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -1,4 +1,4 @@
-The Julia language is licensed under the MIT License (see `LICENSE.md`). The "language" consists
+The Julia language is licensed under the MIT License (see [LICENSE.md](./LICENSE.md) ). The "language" consists
 of the compiler (the contents of src/), most of the standard library (base/),
 and some utilities (most of the rest of the files in this repository). See below
 for exceptions.

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -20,7 +20,7 @@ The following components included in Julia `Base` have their own separate licens
 The Julia language links to the following external libraries, which have their
 own licenses:
 
-- [LIBUNWIND](https://git.savannah.gnu.org/gitweb/?p=libunwind.git;a=blob_plain;f=LICENSE;hb=master) [MIT]
+- [LIBUNWIND](https://github.com/libunwind/libunwind/blob/master/LICENSE) [MIT]
 - [LIBUV](https://github.com/joyent/libuv/blob/master/LICENSE) [MIT]
 - [LLVM](https://releases.llvm.org/6.0.0/LICENSE.TXT) [BSD-3, effectively]
 - [UTF8PROC](https://github.com/JuliaStrings/utf8proc) [MIT]

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -5,7 +5,7 @@ for exceptions.
 
 - [crc32c.c](https://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software) (CRC-32c checksum code by Mark Adler) [[ZLib](https://opensource.org/licenses/Zlib)].
 - [LDC](https://github.com/ldc-developers/ldc/blob/master/LICENSE) (for ccall/cfunction ABI definitions) [BSD-3]. The portion of code that Julia uses from LDC is [BSD-3] licensed.
-- [LLVM](https://releases.llvm.org/3.9.0/LICENSE.TXT) (for parts of src/jitlayers.cpp and src/disasm.cpp) [BSD-3, effectively]
+- [LLVM](https://releases.llvm.org/3.9.0/LICENSE.TXT) (for parts of src/disasm.cpp) [BSD-3]
 - [MUSL](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) (for getopt implementation on Windows) [MIT]
 - [MINGW](https://sourceforge.net/p/mingw/mingw-org-wsl/ci/legacy/tree/mingwrt/mingwex/dirname.c) (for dirname implementation on Windows) [MIT]
 - [NetBSD](https://www.netbsd.org/about/redistribution.html) (for setjmp, longjmp, and strptime implementations on Windows) [BSD-3]

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -21,7 +21,7 @@ The Julia language links to the following external libraries, which have their
 own licenses:
 
 - [LIBUNWIND](https://github.com/libunwind/libunwind/blob/master/LICENSE) [MIT]
-- [LIBUV](https://github.com/joyent/libuv/blob/master/LICENSE) [MIT]
+- [LIBUV](https://github.com/JuliaLang/libuv/blob/julia-uv2-1.39.0/LICENSE) [MIT]
 - [LLVM](https://releases.llvm.org/6.0.0/LICENSE.TXT) [BSD-3, effectively]
 - [UTF8PROC](https://github.com/JuliaStrings/utf8proc) [MIT]
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -33,7 +33,7 @@ Julia's `stdlib` uses the following external libraries, which have their own lic
 - [LIBGIT2](https://github.com/libgit2/libgit2/blob/development/COPYING) [GPL2+ with unlimited linking exception]
 - [CURL](https://curl.haxx.se/docs/copyright.html) [MIT/X derivative]
 - [LIBSSH2](https://github.com/libssh2/libssh2/blob/master/COPYING) [BSD-3]
-- [MBEDTLS](https://tls.mbed.org/how-to-get) [either GPLv2 or Apache 2.0]
+- [MBEDTLS](https://github.com/ARMmbed/mbedtls/blob/development/LICENSE) [Apache 2.0]
 - [MPFR](https://www.mpfr.org/mpfr-current/mpfr.html#Copying) [LGPL3+]
 - [OPENBLAS](https://raw.github.com/xianyi/OpenBLAS/master/LICENSE) [BSD-3]
 - [LAPACK](https://netlib.org/lapack/LICENSE.txt) [BSD-3]

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -40,13 +40,13 @@ Julia's `stdlib` uses the following external libraries, which have their own lic
 - [PCRE](https://www.pcre.org/licence.txt) [BSD-3]
 - [SUITESPARSE](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/LICENSE.txt) [mix of LGPL2+ and GPL2+; see individual module licenses]
 - [LIBBLASTRAMPOLINE](https://github.com/staticfloat/libblastrampoline/blob/main/LICENSE) [MIT]
-- [LIBWHICH](https://github.com/vtjnash/libwhich/blob/master/LICENSE) [MIT]
 - [NGHTTP2](https://github.com/nghttp2/nghttp2/blob/master/COPYING) [MIT]
 
 Julia's build process uses the following external tools:
 
 - [PATCHELF](https://nixos.org/patchelf.html)
 - [OBJCONV](https://www.agner.org/optimize/#objconv)
+- [LIBWHICH](https://github.com/vtjnash/libwhich/blob/master/LICENSE) [MIT]
 
 Julia bundles the following external programs and libraries:
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -14,7 +14,7 @@ for exceptions.
 The following components included in Julia `Base` have their own separate licenses:
 
 - base/ryu/* [Boost] (see [ryu](https://github.com/ulfjack/ryu/blob/master/LICENSE-Boost))
-- base/special/{exp,rem_pio2,hyperbolic}.jl [Freely distributable with preserved copyright notice] (see [FDLIBM](https://www.netlib.org/fdlibm))
+- base/special/{rem_pio2,hyperbolic}.jl [Freely distributable with preserved copyright notice] (see [FDLIBM](https://www.netlib.org/fdlibm))
 
 The Julia language links to the following external libraries, which have their
 own licenses:

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -5,7 +5,7 @@ for exceptions.
 
 - [crc32c.c](https://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software) (CRC-32c checksum code by Mark Adler) [[ZLib](https://opensource.org/licenses/Zlib)].
 - [LDC](https://github.com/ldc-developers/ldc/blob/master/LICENSE) (for ccall/cfunction ABI definitions) [BSD-3]. The portion of code that Julia uses from LDC is [BSD-3] licensed.
-- [LLVM](https://releases.llvm.org/3.9.0/LICENSE.TXT) (for parts of src/disasm.cpp) [BSD-3]
+- [LLVM](https://releases.llvm.org/3.9.0/LICENSE.TXT) (for parts of src/disasm.cpp) [UIUC]
 - [MUSL](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) (for src/getopt.c and src/getopt.h) [MIT]
 - [MINGW](https://sourceforge.net/p/mingw/mingw-org-wsl/ci/legacy/tree/mingwrt/mingwex/dirname.c) (for dirname implementation on Windows) [MIT]
 - [NetBSD](https://www.netbsd.org/about/redistribution.html) (for setjmp, longjmp, and strptime implementations on Windows) [BSD-3]
@@ -22,7 +22,7 @@ own licenses:
 
 - [LIBUNWIND](https://github.com/libunwind/libunwind/blob/master/LICENSE) [MIT]
 - [LIBUV](https://github.com/JuliaLang/libuv/blob/julia-uv2-1.39.0/LICENSE) [MIT]
-- [LLVM](https://releases.llvm.org/6.0.0/LICENSE.TXT) [BSD-3, effectively]
+- [LLVM](https://releases.llvm.org/6.0.0/LICENSE.TXT) [UIUC]
 - [UTF8PROC](https://github.com/JuliaStrings/utf8proc) [MIT]
 
 Julia's `stdlib` uses the following external libraries, which have their own licenses:

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -6,7 +6,7 @@ for exceptions.
 - [crc32c.c](https://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software) (CRC-32c checksum code by Mark Adler) [[ZLib](https://opensource.org/licenses/Zlib)].
 - [LDC](https://github.com/ldc-developers/ldc/blob/master/LICENSE) (for ccall/cfunction ABI definitions) [BSD-3]. The portion of code that Julia uses from LDC is [BSD-3] licensed.
 - [LLVM](https://releases.llvm.org/3.9.0/LICENSE.TXT) (for parts of src/disasm.cpp) [BSD-3]
-- [MUSL](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) (for getopt implementation on Windows) [MIT]
+- [MUSL](https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT) (for src/getopt.c and src/getopt.h) [MIT]
 - [MINGW](https://sourceforge.net/p/mingw/mingw-org-wsl/ci/legacy/tree/mingwrt/mingwex/dirname.c) (for dirname implementation on Windows) [MIT]
 - [NetBSD](https://www.netbsd.org/about/redistribution.html) (for setjmp, longjmp, and strptime implementations on Windows) [BSD-3]
 - [Python](https://docs.python.org/3/license.html) (for strtod and joinpath implementation on Windows) [BSD-3, effectively]

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -39,6 +39,7 @@ Julia's `stdlib` uses the following external libraries, which have their own lic
 - [LAPACK](https://netlib.org/lapack/LICENSE.txt) [BSD-3]
 - [PCRE](https://www.pcre.org/licence.txt) [BSD-3]
 - [SUITESPARSE](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/LICENSE.txt) [mix of LGPL2+ and GPL2+; see individual module licenses]
+- [LIBBLASTRAMPOLINE](https://github.com/staticfloat/libblastrampoline/blob/main/LICENSE) [MIT]
 
 Julia's build process uses the following external tools:
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -10,6 +10,7 @@ for exceptions.
 - [MINGW](https://sourceforge.net/p/mingw/mingw-org-wsl/ci/legacy/tree/mingwrt/mingwex/dirname.c) (for dirname implementation on Windows) [MIT]
 - [NetBSD](https://www.netbsd.org/about/redistribution.html) (for setjmp, longjmp, and strptime implementations on Windows) [BSD-3]
 - [Python](https://docs.python.org/3/license.html) (for strtod implementation on Windows) [PSF]
+- [FEMTOLISP](https://github.com/JeffBezanson/femtolisp) [BSD-3]
 
 The following components included in Julia `Base` have their own separate licenses:
 
@@ -19,7 +20,6 @@ The following components included in Julia `Base` have their own separate licens
 The Julia language links to the following external libraries, which have their
 own licenses:
 
-- [FEMTOLISP](https://github.com/JeffBezanson/femtolisp) [BSD-3]
 - [LIBUNWIND](https://git.savannah.gnu.org/gitweb/?p=libunwind.git;a=blob_plain;f=LICENSE;hb=master) [MIT]
 - [LIBUV](https://github.com/joyent/libuv/blob/master/LICENSE) [MIT]
 - [LLVM](https://releases.llvm.org/6.0.0/LICENSE.TXT) [BSD-3, effectively]

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # magic rounding constant: 1.5*2^52 Adding, then subtracting it from a float rounds it to an Int.
 # This works because eps(MAGIC_ROUND_CONST(T)) == one(T), so adding it to a smaller number aligns the lsb to the 1s place.
 # Values for which this trick doesn't work are going to have outputs of 0 or Inf.

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -5,6 +5,8 @@
 //
 // Original copyright:
 //
+// University of Illinois/NCSA
+// Open Source License
 // Copyright (c) 2003-2016 University of Illinois at Urbana-Champaign.
 // All rights reserved.
 //

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -5,11 +5,43 @@
 //
 // Original copyright:
 //
-//                     The LLVM Compiler Infrastructure
+// Copyright (c) 2003-2016 University of Illinois at Urbana-Champaign.
+// All rights reserved.
 //
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
+//  Developed by:
 //
+//    LLVM Team
+//
+//    University of Illinois at Urbana-Champaign
+//
+//    http://llvm.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal with
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+//    * Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimers.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice,
+//      this list of conditions and the following disclaimers in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the names of the LLVM Team, University of Illinois at
+//      Urbana-Champaign, nor the names of its contributors may be used to
+//      endorse or promote products derived from this Software without specific
+//      prior written permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+// SOFTWARE.
 //===----------------------------------------------------------------------===//
 //
 // This class implements a disassembler of a memory block, given a function

--- a/src/flisp/LICENSE
+++ b/src/flisp/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2009 Jeff Bezanson
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the author nor the names of any contributors may be used to
+      endorse or promote products derived from this software without specific
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1,7 +1,5 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-// Except for parts of this file which were copied from LLVM, under the UIUC license (marked below).
-
 #include "llvm-version.h"
 #include "platform.h"
 


### PR DESCRIPTION
This purpose of this PR is to review THIRDPARTY.md and determine where it needs to be updated. 

During the review of of #41095 a few instances of out-of-date information were determined, but this list was not exhaustive. This PR will review all of the entries in THIRDPARTY.md and validate each one. This PR will not attempt major reformatting of THIRDPARTY or refactoring of the third party code to make it more obvious. That exercise will be left for future PRs.

Most of the changes are clearly explained in the commit log and don't require repetition here. Below are listed items where I would like reviews from the core dev team.

**Third Party Code in src**    
- [LLVM]
    + src/jitlayers.c - The file header says that portions of the code are copied from the LLVM project and marked below. But in searching the file, I could not find a single such marking. In the absence of such markings, I chose to remove references to jitlayers.c from THIRDPARTY.md.    
- [Python]
    + Removed reference to joinpath from THIRDPARTY.md because I could not find a function with that name. 
- [Google Benchmark]
    + In #41095 @vtjnash said that cyclecount should not have been listed at all.  I can't find any evidence that cyclecount exists in the codebase, so I removed references from THIRDPARTY.md

**Third Party Code in Base**   
- base/grisu/*    
    + Deleted reference per comment from vtjnash in #41095

**Standard Library Dependencies**
- [FEMTOLISP] 
    + I feel that FEMTOLISP does not belong in the dependencies section of THIRDPARTY.md.  Everything else in this section exists in the deps/ directory and pulls its code from an outside repository. But the femtolisp code exists in src/flisp.  Since the code was first added to Julia in the early days, it has gone substantial revision within this repository. At the same time @JeffBezanson has been making updates to the code in the original repository in parallel with Julia.  A quick diff indicates that the two code bases are not identical. As a result, I have moved the femtolisp reference to the third party code in src/ section of the document.  I have also added the BSD-3 license to the src/flisp directory.

- I found three dependencies in deps/ that were not listed in THIRDPARTY.md.  I added all three to the list of stdlib dependencies. Can the dev team comment if this is the appropriate location?