### PR TITLE
Init codegen during sysimg restore.

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -734,12 +734,13 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     if (jl_options.cpu_target == NULL)
         jl_options.cpu_target = "native";
 
-    if (jl_options.image_file)
+    if (jl_options.image_file) {
         jl_restore_system_image(jl_options.image_file);
-    else
+    } else {
         jl_init_types();
+        jl_init_codegen();
+    }
 
-    jl_init_codegen();
     jl_init_common_symbols();
     jl_init_flisp();
     jl_init_serializer();

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1839,6 +1839,7 @@ static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
     }
 
     s.s = &sysimg;
+    jl_init_codegen();
     jl_update_all_fptrs(&s); // fptr relocs and registration
     // reinit ccallables, which require codegen to be initialized
     s.s = f;


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/41670. Restores the old order of jl_init->jl_load_sysimg->jl_init_codegen, which was changed in https://github.com/JuliaLang/julia/pull/40715/files#diff-0e5a5cdf744ddbc1c815bf0a767bc9988e37d88792e8acc95c7ed9863491f2afL1797, because deserializing a system image might require the code generator to be initialized (deserializing ccallables calls jl_compile_extern_c).