### PR TITLE
Trying to support OpaqueClosure in code_llvm/native

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -150,8 +150,14 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
     end
     # get the MethodInstance for the method match
     world = typemax(UInt)
-    match = Base._which(signature_type(f, t), world)
-    linfo = Core.Compiler.specialize_method(match)
+    if f isa Core.OpaqueClosure
+        m = f.source
+        m isa Method || error("invalid Core.OpaqueClosure")
+        linfo = Core.Compiler.specialize_method(m, signature_type(f, t), Core.svec())
+    else
+        match = Base._which(signature_type(f, t), world)
+        linfo = Core.Compiler.specialize_method(match)
+    end
     # get the code for it
     if native
         str = _dump_function_linfo_native(linfo, world, wrapper, syntax, debuginfo, binary)

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -388,6 +388,7 @@ A36261 = Float64[1.0, 2.0, 3.0]
 
 
 module ReflectionTest
+using Base.Experimental: @opaque
 using Test, Random, InteractiveUtils
 
 function test_ast_reflection(freflect, f, types)
@@ -418,6 +419,7 @@ function test_code_reflections(tester, freflect)
     test_code_reflection(freflect, Module, Tuple{}, tester) # Module() constructor (transforms to call)
     test_code_reflection(freflect, Array{Int64}, Tuple{Array{Int32}}, tester) # with incomplete types
     test_code_reflection(freflect, muladd, Tuple{Float64, Float64, Float64}, tester)
+    test_code_reflection(freflect, @opaque(() -> 1), Tuple{}, tester)
 end
 
 test_code_reflections(test_bin_reflection, code_llvm)


### PR DESCRIPTION
With this patch, `@code_llvm` prints _something_ when it sees an opaque closure. But I'm not entirely sure if this is the right way to do it. Is it wrong to recompile opaque closure like this, isolated from the surroundings? Or does it still keep enough information in the method?