### PR TITLE
Fix cfg_simplify! for empty preds and succs

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -137,6 +137,9 @@ include("compiler/optimize.jl") # TODO: break this up further + extract utilitie
 include("compiler/bootstrap.jl")
 ccall(:jl_set_typeinf_func, Cvoid, (Any,), typeinf_ext_toplevel)
 
+const _COMPILER_WORLD_AGE = ccall(:jl_get_tls_world_age, UInt, ())
+compiler_world_age() = _COMPILER_WORLD_AGE
+
 include("compiler/parsing.jl")
 Core.eval(Core, :(_parse = Compiler.fl_parse))
 

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1207,12 +1207,12 @@ function cfg_simplify!(ir::IRCode)
         # Compute (renamed) successors and predecessors given (renamed) block
         function compute_succs(i)
             orig_bb = follow_merged_succ(result_bbs[i])
-            return map(i -> bb_rename_succ[i], bbs[orig_bb].succs)
+            return Int[bb_rename_succ[i] for i in bbs[orig_bb].succs]
         end
         function compute_preds(i)
             orig_bb = result_bbs[i]
             preds = bbs[orig_bb].preds
-            return map(pred -> bb_rename_pred[pred], preds)
+            return Int[bb_rename_pred[pred] for pred in preds]
         end
 
         BasicBlock[


### PR DESCRIPTION
Before this patch, `cfg_simplify!` relied on the conversion for handling empty preds and succs

```
julia> Vector{Int}(Union{}[])
Int64[]
```

which is not available inside the compiler:

```
julia> Base.invoke_in_world(UInt(4526), Vector{Int}, Union{}[])
ERROR: MethodError: no method matching Vector{Int64}(::Vector{Union{}})
The applicable method may be too new: running in world age 4526, while current world is 31202.
```

(I get `4526` via `gdb`)

This PR fixes it and also calls `cfg_simplify!` in the compiler's world age during the test. I think it's also good for improving inferrability. This is extracted from #39773.
