### PR TITLE
Speed up vect by delegating to getindex

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -142,9 +142,7 @@ julia> a = Base.vect(UInt8(1), 2.5, 1//2)
 """
 function vect(X...)
     T = promote_typeof(X...)
-    #T[ X[i] for i=1:length(X) ]
-    # TODO: this is currently much faster. should figure out why. not clear.
-    return copyto!(Vector{T}(undef, length(X)), X)
+    return T[X...]
 end
 
 size(a::Array, d::Integer) = arraysize(a, convert(Int, d))

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -399,9 +399,15 @@ let src = get_llvm(f33829, Tuple{Float64}, true, true)
     @test !occursin(r"call [^(]*\{}", src)
 end
 
+# Base.vect prior to PR 41696
+function oldvect(X...)
+    T = Base.promote_typeof(X...)
+    return copyto!(Vector{T}(undef, length(X)), X)
+end
+
 let io = IOBuffer()
     # Test for the f(args...) = g(args...) generic codegen optimization
-    code_llvm(io, Base.vect, Tuple{Vararg{Union{Float64, Int64}}})
+    code_llvm(io, oldvect, Tuple{Vararg{Union{Float64, Int64}}})
     @test !occursin("__apply", String(take!(io)))
 end
 


### PR DESCRIPTION
When analyzing https://github.com/JuliaMath/FixedPointDecimals.jl/pull/62 I discovered that while the tuple version was 10x faster than the untyped array version, it was only about 10% faster than the typed array version. And yet, the type of the resulting array was fully inferred. I concluded that `vect` could use some improvement. Here I have reimplemented `vect` in terms of `getindex` (the typed version), which achieved this speedup on the original code. 

Array tests pass, but I wonder what the benchmark suite says.