### PR TITLE
add compat annotations for `replace` on tuples

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -143,6 +143,8 @@ Standard library changes
 * `replace(::String)` now accepts multiple patterns, which will be applied left-to-right simultaneously,
   so only one pattern will be applied to any character, and the patterns will only be applied to the input
   text, not the replacements ([#40484]).
+* New `replace` methods to replace elements of a `Tuple`.
+
 
 #### Package Manager
 

--- a/base/set.jl
+++ b/base/set.jl
@@ -548,6 +548,9 @@ replaced.
 
 See also [`replace!`](@ref), [`splice!`](@ref), [`delete!`](@ref), [`insert!`](@ref).
 
+!!! compat "Julia 1.7"
+    Version 1.7 is required to replace elements of a `Tuple`.
+
 # Examples
 ```jldoctest
 julia> replace([1, 2, 1, 3], 1=>0, 2=>4, count=2)
@@ -595,6 +598,9 @@ subtract_singletontype(::Type{T}, x::Pair{K}, y::Pair...) where {T, K} =
 Return a copy of `A` where each value `x` in `A` is replaced by `new(x)`.
 If `count` is specified, then replace at most `count` values in total
 (replacements being defined as `new(x) !== x`).
+
+!!! compat "Julia 1.7"
+    Version 1.7 is required to replace elements of a `Tuple`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The methods were added in #38216.

This also updates HISTORY.md.
Maybe this should be backported? (I can make a PR against release-1.7, which touches NEWS.md instead).  