### PR TITLE
Support `zero` for arrays with heterogeneous eltypes

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1130,7 +1130,8 @@ function copymutable(a::AbstractArray)
 end
 copymutable(itr) = collect(itr)
 
-zero(x::AbstractArray{T}) where {T} = fill!(similar(x, typeof(zero(T))), zero(T))
+zero(x::AbstractArray{T}) where {T<:DataType} = fill!(similar(x, typeof(zero(T))), zero(T))
+zero(x::AbstractArray{T}) where {T} = map(zero,x) #In case T is a TypeUnion b/c elements of x are heterogeneous types
 
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both IndexLinear and IndexCartesian arrays

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1287,6 +1287,14 @@ end
     @test [1:BigInt(5); 1] == [1:5; 1]
 end
 
+@testset "zero for heterogeneous eltypes" begin
+    struct Numlike{T<:Number} <: Number
+        val::T
+    end
+    x = [Numlike(1), Numlike(1im)]
+    @test zero(x) == [Numlike(0), Numlike(0im)]
+end
+
 @testset "Base.isstored" begin
     a = rand(3, 4, 5)
     @test Base.isstored(a, 1, 2, 3)


### PR DESCRIPTION
The motivation for this is to allow `zero` to work correctly for arrays of `Unitful.Quantity` that have different units. Cf. [this issue at Unitful](https://github.com/PainterQubits/Unitful.jl/pull/472) where it was suggested to make the fix in `Base`.