### PR TITLE
Fix read! for types with size not a power of 2

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -738,7 +738,8 @@ function read!(s::IO, a::Array{UInt8})
 end
 
 function read!(s::IO, a::AbstractArray{T}) where T
-    if isbitstype(T) && (a isa Array || a isa FastContiguousSubArray{T,<:Any,<:Array{T}})
+    if isbitstype(T) && sizeof(T) == aligned_sizeof(T) &&
+       (a isa Array || a isa FastContiguousSubArray{T,<:Any,<:Array{T}})
         GC.@preserve a unsafe_read(s, pointer(a), sizeof(a))
     else
         for i in eachindex(a)

--- a/test/read.jl
+++ b/test/read.jl
@@ -621,3 +621,15 @@ end
     first(itr) # consume the iterator
     @test  isempty(itr) # now it is empty
 end
+
+@testset "read! with non-power-of-2 types" begin
+    primitive type Int24 <: Integer 24 end
+    Base.read(io::IO, ::Type{Int24}) = only(reinterpret(Int24, read(io, sizeof(Int24))))
+    bytes = [0xa4, 0x01, 0x0, 0x45, 0x0, 0x0]
+    io = IOBuffer()
+    write(io, bytes)
+    seekstart(io)
+    x = Vector{Int24}(undef, 2)
+    read!(io, x)
+    @test x == reinterpret(Int24, bytes)
+end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -588,6 +588,7 @@ end
 primitive type UInt48 48 end
 UInt48(x::UInt64) = Core.Intrinsics.trunc_int(UInt48, x)
 UInt48(x::UInt32) = Core.Intrinsics.zext_int(UInt48, x)
+Base.read(io::IO, ::Type{UInt48}) = only(reinterpret(UInt48, read(io, sizeof(UInt48))))
 
 @testset "sizeof" begin
     @test sizeof(view(zeros(UInt8, 10), 1:4)) == 4


### PR DESCRIPTION
Currently, the fast path in `read!(::IO, ::AbstractArray{T})` checks for `isbitstype(T)` and whether the array is some nice type, then calls `unsafe_read` with `sizeof` for the number of bytes. This works great in the majority of cases, unless `sizeof(T)` is not a power of 2. The aligned size is what's used in `sizeof`, which overestimates the number of bytes required to read from the stream. To fix this, we can adjust the condition of the fast path to also determine whether `sizeof` matches the aligned size.

Note that I've marked this for backport to 1.6 and 1.7.