### PR TITLE
Explain how to enable debug for multiple modules

### DIFF
--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -217,6 +217,9 @@ julia> foo()
 
 ```
 
+Use a comma separator to enable debug for multiple
+modules: `JULIA_DEBUG=loading,Main`.
+
 ## Examples
 
 ### Example: Writing log events to a file


### PR DESCRIPTION
Explain how to enable debug for multiple modules using a comma as in `JULIA_DEBUG=loading,Main`.