### PR TITLE
Add the `CITATION.cff` file to take advantage of GitHub's new support for the Citation File Format

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 - family-names: "Shah"
   given-names: "Viral B."
 title: "Julia: A fresh approach to numerical computing"
-version: 1.6.2
+version: 1.8.0-DEV
 doi: 10.1137/141000671
 date-released: 2017-02-07
 url: "https://github.com/JuliaLang/julia"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Bezanson"
+  given-names: "Jeff"
+- family-names: "Edelman"
+  given-names: "Alan"
+- family-names: "Karpinski"
+  given-names: "Stefan"
+- family-names: "Shah"
+  given-names: "Viral B"
+title: "Julia: A fresh approach to numerical computing"
+version: 1.6.2
+doi: 10.1137/141000671
+date-released: 2017-02-07
+url: "https://github.com/JuliaLang/julia"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ version: "v1"
 license: "MIT"
 doi: "10.1137/141000671"
 date-released: 2017-02-07
-url: "https://github.com/JuliaLang/julia"
+url: "https://julialang.org"
 references:
   - scope: "Cite this paper whenever you use Julia"
     type: article
@@ -38,6 +38,6 @@ references:
     start: 65
     end: 98
     year: 2017
-    url: "https://epubs.siam.org/doi/10.1137/141000671"
+    url: "https://dx.doi.org/10.1137/141000671"
     publisher:
       - name: "SIAM"  

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,12 +32,10 @@ references:
         given-names: "Viral"
     doi: "10.1137/141000671"
     journal: "SIAM Review"
-    voume: 59
+    volume: 59
     number: 1
     pages: 13
     year: 2017
     url: "https://epubs.siam.org/doi/10.1137/141000671"
     publisher:
-      - name: "SIAM"
-        
-    
+      - name: "SIAM"  

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,8 +28,7 @@ references:
       - family-names: "Karpinski"
         given-names: "Stefan"
       - family-names: "Shah"
-        name-particle: "B"
-        given-names: "Viral"
+        given-names: "Viral B."
     doi: "10.1137/141000671"
     journal: "SIAM Review"
     volume: 59

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
 - family-names: "Karpinski"
   given-names: "Stefan"
 - family-names: "Shah"
-  given-names: "Viral B"
+  given-names: "Viral B."
 title: "Julia: A fresh approach to numerical computing"
 version: 1.6.2
 doi: 10.1137/141000671

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
   name-particle: "B"
   given-names: "Viral"
 title: "Julia: A fresh approach to numerical computing"
-version: 1.8.0-DEV
+version: v1
 license: "MIT"
 doi: "10.1137/141000671"
 date-released: 2017-02-07

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,7 +34,9 @@ references:
     journal: "SIAM Review"
     volume: 59
     number: 1
-    pages: 13
+    pages: 33
+    start: 65
+    end: 98
     year: 2017
     url: "https://epubs.siam.org/doi/10.1137/141000671"
     publisher:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: "Cite this paper whenever you use Julia"
 authors:
 - family-names: "Bezanson"
   given-names: "Jeff"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,36 @@ authors:
 - family-names: "Karpinski"
   given-names: "Stefan"
 - family-names: "Shah"
-  given-names: "Viral B."
+  name-particle: "B"
+  given-names: "Viral"
 title: "Julia: A fresh approach to numerical computing"
 version: 1.8.0-DEV
-doi: 10.1137/141000671
+license: "MIT"
+doi: "10.1137/141000671"
 date-released: 2017-02-07
 url: "https://github.com/JuliaLang/julia"
+references:
+  - scope: "Cite this paper whenever you use Julia"
+    type: article
+    title: "Julia: A fresh approach to numerical computing"
+    authors:
+      - family-names: "Bezanson"
+        given-names: "Jeff"
+      - family-names: "Edelman"
+        given-names: "Alan"
+      - family-names: "Karpinski"
+        given-names: "Stefan"
+      - family-names: "Shah"
+        name-particle: "B"
+        given-names: "Viral"
+    doi: "10.1137/141000671"
+    journal: "SIAM Review"
+    voume: 59
+    number: 1
+    pages: 13
+    year: 2017
+    url: "https://epubs.siam.org/doi/10.1137/141000671"
+    publisher:
+      - name: "SIAM"
+        
+    

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
   name-particle: "B"
   given-names: "Viral"
 title: "Julia: A fresh approach to numerical computing"
-version: v1
+version: "v1"
 license: "MIT"
 doi: "10.1137/141000671"
 date-released: 2017-02-07


### PR DESCRIPTION
This PR creates the initial draft for the CITATION.cff new file format.

Some resources for discussion:

* [CFF Documentation](https://citation-file-format.github.io/)
* [CFF documentation at GitHub](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files)

Note that with every Julia new release the `version` value should be updated. I briefly scanned for a GitHub Actions that could automatically do that but could not find (maybe since CFF are a new thing we should have new actions becoming available in the near future).

EDIT: I think we should leave the `.bib` also in the repo for now.