### PR TITLE
Profile: Shuffle profile round robin thread order before taking every sample

### DIFF
--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -25,11 +25,15 @@ static volatile size_t bt_size_cur = 0;
 static volatile uint64_t nsecprof = 0;
 static volatile int running = 0;
 static const    uint64_t GIGA = 1000000000ULL;
+static uint64_t profile_cong_rng_seed = 0;
+static uint64_t profile_cong_rng_unbias = 0;
+static volatile uint64_t *profile_round_robin_thread_order = NULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
 void jl_lock_profile(void);
 void jl_unlock_profile(void);
+void jl_shuffle_int_array_inplace(volatile uint64_t *carray, size_t size, uint64_t *seed);
 
 JL_DLLEXPORT int jl_profile_is_buffer_full(void)
 {
@@ -288,11 +292,33 @@ JL_DLLEXPORT int jl_profile_init(size_t maxsize, uint64_t delay_nsec)
     nsecprof = delay_nsec;
     if (bt_data_prof != NULL)
         free((void*)bt_data_prof);
+    if (profile_round_robin_thread_order == NULL) {
+        // NOTE: We currently only allocate this once, since jl_n_threads cannot change
+        // during execution of a julia process. If/when this invariant changes in the
+        // future, this will have to be adjusted.
+        profile_round_robin_thread_order = (uint64_t*) calloc(jl_n_threads, sizeof(uint64_t));
+        for (int i = 0; i < jl_n_threads; i++) {
+            profile_round_robin_thread_order[i] = i;
+        }
+    }
+    seed_cong(&profile_cong_rng_seed);
+    unbias_cong(jl_n_threads, &profile_cong_rng_unbias);
     bt_data_prof = (jl_bt_element_t*) calloc(maxsize, sizeof(jl_bt_element_t));
     if (bt_data_prof == NULL && maxsize > 0)
         return -1;
     bt_size_cur = 0;
     return 0;
+}
+
+void jl_shuffle_int_array_inplace(volatile uint64_t *carray, size_t size, uint64_t *seed) {
+    // The "modern Fisher–Yates shuffle" - O(n) algorithm
+    // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+    for (size_t i = size - 1; i >= 1; --i) {
+        size_t j = cong(i, profile_cong_rng_unbias, seed);
+        uint64_t tmp = carray[j];
+        carray[j] = carray[i];
+        carray[i] = tmp;
+    }
 }
 
 JL_DLLEXPORT uint8_t *jl_profile_get_data(void)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -745,7 +745,10 @@ static void *signal_listener(void *arg)
         // (so that thread zero gets notified last)
         if (critical || profile)
             jl_lock_profile();
-        for (int i = jl_n_threads; i-- > 0; ) {
+        jl_shuffle_int_array_inplace(profile_round_robin_thread_order, jl_n_threads, &profile_cong_rng_seed);
+        for (int idx = jl_n_threads; idx-- > 0; ) {
+            // Stop the threads in the random round-robin order.
+            int i = profile_round_robin_thread_order[idx];
             // notify thread to stop
             jl_thread_suspend_and_get_state(i, &signal_context);
 


### PR DESCRIPTION
One approach at addressing https://github.com/JuliaLang/julia/issues/33490.

As described here: https://github.com/JuliaLang/julia/issues/9224#issuecomment-889549789, this PR has Profile.jl randomly permute the order in which it samples the threads for profiling. It still samples all threads on every pause, but it maintains an array with the order for which to sample the threads, and shuffles that array before each sample, then samples the threads according to that order.

The hope is that this will reduce the likelihood of introducing artificial contention into the program, by avoiding pausing the threads in a consistent order, which can cause a pileup of threads if they share a mutex, as described here:
https://github.com/JuliaLang/julia/issues/33490#issue-503572179


--------------------------

We seem to think that the best approach is to change the profiler to:
 - use a random sample interval
 - only sample one thread each time, chosen randomly

But this PR is a good step in the right direction.


One potential concern is that it will unacceptably reduce performance of profiling, so that remains to be seen.

I did some small measurements, and shuffling the array seems _reasonably_ fast:
```julia
julia> const x = [1,2,3]
3-element Vector{Int64}:
 1
 2
 3

julia> const seed = Ref(0)
Base.RefValue{Int64}(0)

julia> @btime @ccall jl_shuffle_int_array_inplace(pointer(x)::Ptr{Int}, length(x)::Csize_t, seed::Ptr{Int})::Cvoid
  17.172 ns (0 allocations: 0 bytes)
```
```julia
julia> const x = collect(1:100)
100-element Vector{Int64}:
   1
   ⋮
 100

julia> const seed = Ref(0)
Base.RefValue{Int64}(0)

julia> @btime @ccall jl_shuffle_int_array_inplace(pointer(x)::Ptr{Int}, length(x)::Csize_t, seed::Ptr{Int})::Cvoid
  710.507 ns (0 allocations: 0 bytes)
```