### PR TITLE
Style parameter not needed in `materialize!(dest, bc::Broadcasted)`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -908,7 +908,7 @@ materialize(x) = x
     return materialize!(dest, instantiate(Broadcasted(identity, (x,), axes(dest))))
 end
 
-@inline function materialize!(dest, bc::Broadcasted{Style}) where {Style}
+@inline function materialize!(dest, bc::Broadcasted)
     return materialize!(combine_styles(dest, bc), dest, bc)
 end
 @inline function materialize!(::BroadcastStyle, dest, bc::Broadcasted{Style}) where {Style}


### PR DESCRIPTION
PR title is self-explanatory