### PR TITLE
Profile: Thread and task-specific profiling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,13 @@ Standard library changes
 #### Printf
 * Now uses `textwidth` for formatting `%s` and `%c` widths ([#41085]).
 
+#### Profile
+* Profiling now records sample metadata including thread and task. `Profile.print()` has a new `groupby` kwarg that allows
+  grouping by thread, task, or nested thread/task, task/thread, and `threads` and `tasks` kwargs to allow filtering.
+  Further, percent utilization is now reported as a total or per-thread, based on whether the thread is idle or not at
+  each sample. `Profile.fetch()` by default strips out the new metadata to ensure backwards compatibility with external
+  profiling data consumers, but can be included with the `include_meta` kwarg. ([#41742])
+
 #### Random
 
 #### REPL

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -222,7 +222,11 @@ Profile = get(Base.loaded_modules,
           nothing)
 if Profile !== nothing
     hardcoded_precompile_statements *= """
-    precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol})
+    precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Int, UInt})
+    precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Int, UnitRange{UInt}})
+    precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, UnitRange{Int}, UInt})
+    precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, UnitRange{Int}, UnitRange{UInt}})
+    precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Vector{Int}, Vector{UInt}})
     """
 end
 

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -37,8 +37,8 @@ void jl_shuffle_int_array_inplace(volatile uint64_t *carray, size_t size, uint64
 
 JL_DLLEXPORT int jl_profile_is_buffer_full(void)
 {
-    // the latter `+ 1` is for the block terminator `0`.
-    return bt_size_cur + (JL_BT_MAX_ENTRY_SIZE + 1) + 1 > bt_size_max;
+    // the `+ 5` is for the block terminator `0` plus 4 metadata entries
+    return bt_size_cur + (JL_BT_MAX_ENTRY_SIZE + 1) + 5 > bt_size_max;
 }
 
 static uint64_t jl_last_sigint_trigger = 0;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -596,8 +596,8 @@ void *mach_profile_listener(void *arg)
                 // store task id
                 bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
 
-                // store time
-                bt_data_prof[bt_size_cur++].uintptr = jl_hrtime();
+                // store cpu cycle clock
+                bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
                 // Mark the end of this block with 0
                 bt_data_prof[bt_size_cur++].uintptr = 0;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -588,6 +588,13 @@ void *mach_profile_listener(void *arg)
 #else
                 bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur, bt_size_max - bt_size_cur - 1, uc, NULL);
 #endif
+                jl_ptls_t ptls = jl_all_tls_states[i];
+
+                // store threadid but add 1 as 0 is preserved to indicate end of block
+                bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
+
+                // store task id
+                bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
 
                 // Mark the end of this block with 0
                 bt_data_prof[bt_size_cur++].uintptr = 0;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -599,6 +599,9 @@ void *mach_profile_listener(void *arg)
                 // store cpu cycle clock
                 bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
+                // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+                bt_data_prof[bt_size_cur++].uintptr = ptls->sleep_check_state + 1;
+
                 // Mark the end of this block with 0
                 bt_data_prof[bt_size_cur++].uintptr = 0;
             }

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -596,6 +596,9 @@ void *mach_profile_listener(void *arg)
                 // store task id
                 bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
 
+                // store time
+                bt_data_prof[bt_size_cur++].uintptr = jl_hrtime();
+
                 // Mark the end of this block with 0
                 bt_data_prof[bt_size_cur++].uintptr = 0;
             }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -794,6 +794,9 @@ static void *signal_listener(void *arg)
                     // store task id
                     bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
 
+                    // store time
+                    bt_data_prof[bt_size_cur++].uintptr = jl_hrtime();
+
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -794,8 +794,8 @@ static void *signal_listener(void *arg)
                     // store task id
                     bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
 
-                    // store time
-                    bt_data_prof[bt_size_cur++].uintptr = jl_hrtime();
+                    // store cpu cycle clock
+                    bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -786,6 +786,14 @@ static void *signal_listener(void *arg)
                     }
                     jl_set_safe_restore(old_buf);
 
+                    jl_ptls_t ptls = jl_all_tls_states[i];
+
+                    // store threadid but add 1 as 0 is preserved to indicate end of block
+                    bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
+
+                    // store task id
+                    bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
+
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -797,6 +797,9 @@ static void *signal_listener(void *arg)
                     // store cpu cycle clock
                     bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
+                    // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+                    bt_data_prof[bt_size_cur++].uintptr = ptls->sleep_check_state + 1;
+
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -369,8 +369,8 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     // store task id
                     bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
 
-                    // store time
-                    bt_data_prof[bt_size_cur++].uintptr = jl_hrtime();
+                    // store cpu cycle clock
+                    bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -372,6 +372,9 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     // store cpu cycle clock
                     bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
+                    // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+                    bt_data_prof[bt_size_cur++].uintptr = ptls->sleep_check_state + 1;
+
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -360,6 +360,15 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     // Get backtrace data
                     bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
                             bt_size_max - bt_size_cur - 1, &ctxThread, NULL);
+
+                    jl_ptls_t ptls = jl_all_tls_states[0]; // given only profiling hMainThread
+
+                    // store threadid but add 1 as 0 is preserved to indicate end of block
+                    bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
+
+                    // store task id
+                    bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
+
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -369,6 +369,9 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     // store task id
                     bt_data_prof[bt_size_cur++].uintptr = ptls->current_task;
 
+                    // store time
+                    bt_data_prof[bt_size_cur++].uintptr = jl_hrtime();
+
                     // Mark the end of this block with 0
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }

--- a/stdlib/Profile/Project.toml
+++ b/stdlib/Profile/Project.toml
@@ -5,8 +5,9 @@ uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Serialization"]
+test = ["Logging", "Serialization", "Test"]

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1083,6 +1083,15 @@ function _intersect(v::AbstractVector, r::AbstractRange)
     return Base.vectorfilter(Base._shrink_filter!(seen), common)
 end
 _intersect(r::AbstractRange, v::AbstractVector) = _intersect(v, r)
+function _intersect(r1::AbstractRange, r2::AbstractRange)
+    # To iterate over the shorter range
+    length(r1) > length(r2) && return _intersect(r2, r1)
+
+    r1 = Base.unique(r1)
+    T = Base.promote_eltype(r1, r2)
+
+    return T[x for x in r1 if x ∈ r2]
+end
 _intersect(a, b) = Base.intersect(a, b)
 
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -508,7 +508,7 @@ function fetch(;include_meta = false)
         data_stripped = Vector{UInt}(undef, length(data) - (nblocks * nmeta))
         j = length(data_stripped)
         i = length(data)
-        while i > 0
+        while i > 0 && j > 0
             data_stripped[j] = data[i]
             if data[i] == 0
                 i -= nmeta
@@ -516,6 +516,7 @@ function fetch(;include_meta = false)
             i -= 1
             j -= 1
         end
+        @assert i == j == 0 "metadata stripping failed i=$i j=$j"
         return data_stripped
     end
 end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -503,7 +503,7 @@ function fetch(;include_meta = false)
         return data
     else
         nblocks = count(iszero, data)
-        nmeta = 2 # number of metadata fields (threadid, taskid)
+        nmeta = 3 # number of metadata fields (threadid, taskid, time)
         data_stripped = Vector{UInt}(undef, length(data) - (nblocks * nmeta))
         j = length(data_stripped)
         i = length(data)
@@ -750,12 +750,13 @@ function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineI
     startframe = length(all)
     skip = false
     for i in startframe:-1:1
-        startframe - 1 <= i <= startframe - 2 && continue # skip metadata (its read ahead below)
+        startframe - 1 <= i <= startframe - 3 && continue # skip metadata (its read ahead below)
         ip = all[i]
         if ip == 0
             # read metadata
-            taskid = all[i - 1]
-            threadid = all[i - 2]
+            # time = all[i - 1]
+            taskid = all[i - 2]
+            threadid = all[i - 3]
             if !in(threadid, threads) || !in(taskid, tasks)
                 skip = true
                 continue

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -516,7 +516,7 @@ function fetch(;include_meta = false)
             i -= 1
             j -= 1
         end
-        @assert i == j == 0 "metadata stripping failed i=$i j=$j"
+        @assert i == j == 0 "metadata stripping failed i=$i j=$j data[1:i]=$(data[1:i])"
         return data_stripped
     end
 end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -41,9 +41,9 @@ end
 
 Configure the `delay` between backtraces (measured in seconds), and the number `n` of instruction pointers that may be
 stored per thread. Each instruction pointer corresponds to a single line of code; backtraces generally consist of a long
-list of instruction pointers. Note that 3 instruction pointers per backtrace are used to store metadata. Current settings can be
-obtained by calling this function with no arguments, and each can be set independently using keywords or in the order
-`(n, delay)`.
+list of instruction pointers. Note that 4 instruction pointers per backtrace are used to store metadata and markers. Current
+settings can be obtained by calling this function with no arguments, and each can be set independently using keywords or
+in the order `(n, delay)`.
 
 !!! compat "Julia 1.8"
     As of Julia 1.8, this function allocates space for `n` instruction pointers per thread being profiled.
@@ -504,7 +504,7 @@ function fetch(;include_meta = false)
         return data
     else
         nblocks = count(iszero, data)
-        nmeta = 3 # number of metadata fields (threadid, taskid, time)
+        nmeta = 3 # number of metadata fields (threadid, taskid, cpu_cycle_clock)
         data_stripped = Vector{UInt}(undef, length(data) - (nblocks * nmeta))
         j = length(data_stripped)
         i = length(data)
@@ -540,7 +540,7 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
         ip = data[i]
         if ip == 0
             # read metadata
-            # time = data[i - 1]
+            # cpu_cycle_clock = data[i - 1]
             taskid = data[i - 2]
             threadid = data[i - 3]
             if !in(threadid, threads) || !in(taskid, tasks)
@@ -776,7 +776,7 @@ function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineI
         ip = all[i]
         if ip == 0
             # read metadata
-            # time = all[i - 1]
+            # cpu_cycle_clock = all[i - 1]
             taskid = all[i - 2]
             threadid = all[i - 3]
             if !in(threadid, threads) || !in(taskid, tasks)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1067,7 +1067,7 @@ function warning_empty(;summary = false)
         or adjust the delay between samples with `Profile.init()`."""
     else
         @warn """
-        There were no samples collected in one or more groups.
+        There were no samples collected.
         Run your program longer (perhaps by running it multiple times),
         or adjust the delay between samples with `Profile.init()`."""
     end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -59,6 +59,26 @@ let iobuf = IOBuffer()
     truncate(iobuf, 0)
 end
 
+@testset "Profile.print() groupby options" begin
+    for tasks in [typemin(UInt):typemax(UInt), UInt(0), UInt(0):UInt(1), [UInt(0), UInt(3)]]
+        for threads in [1:Threads.nthreads(), 1, 1:1, 1:2, [1,3]]
+            for groupby in [:none, :thread, :task, [:thread, :task], [:task, :thread]]
+                @testset "tasks = $tasks threads = $threads groupby = $groupby" begin
+                    Profile.print(devnull; groupby, threads, tasks)
+                end
+            end
+        end
+    end
+end
+
+@testset "Profile.fetch() with and without meta" begin
+    data_without = Profile.fetch()
+    data_with = Profile.fetch(include_meta = true)
+    @test data_without[1] == data_with[1]
+    @test data_without[end] == data_with[end]
+    @test length(data_without) < length(data_with)
+end
+
 Profile.clear()
 @test isempty(Profile.fetch())
 


### PR DESCRIPTION
Aims to fix #41713

- Adds thread information into the profile samples and adds grouping options to Profile.print
  `Profile.print(groupby = [:threads, :tasks])` to group first by threads, then tasks
  or `Profile.print(groupby = :threads)` or `:tasks` to group by those respectively
  or default behavior via `Profile.print(groupby = :none)`

Todo:
- [x] extend to MacOS 
- [x] extend to Windows
- [x] add special handling given windows doesn't have multithread profiling
- [x] Add task id
- [x] Change kwarg to `groupby = :threads` `groupby = :tasks` `groupby = [:threads, :tasks]` Thanks @felixcremer!
- [x] Move buffer count nthreads factoring into another PR https://github.com/JuliaLang/julia/pull/41821
- [x] Figure out what format to export the data as for external consumers (vscode profiling, ProfileView etc.) - `Profile.fetch` by default now strips the metadata out to ensure backwards compat with external consumers. They can enable and handle when ready
- [x] Add % utilization per thread
- [x] Add sample clock time
- [x] Test flat printing
- [x] Add to news

Edit: See latest examples below