### PR TITLE
add compat annotations for `replace` on tuples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -148,6 +148,7 @@ Standard library changes
   overflow in most cases. The new function `checked_length` is now available, which will try to use checked
   arithmetic to error if the result may be wrapping. Or use a package such as SaferIntegers.jl when
   constructing the range. ([#40382])
+* New `replace` methods to replace elements of a `Tuple` ([#38216]).
 
 #### Package Manager
 
@@ -316,6 +317,7 @@ Tooling Improvements
 [#37971]: https://github.com/JuliaLang/julia/issues/37971
 [#37978]: https://github.com/JuliaLang/julia/issues/37978
 [#38041]: https://github.com/JuliaLang/julia/issues/38041
+[#38216]: https://github.com/JuliaLang/julia/issues/38216
 [#38379]: https://github.com/JuliaLang/julia/issues/38379
 [#38438]: https://github.com/JuliaLang/julia/issues/38438
 [#38574]: https://github.com/JuliaLang/julia/issues/38574

--- a/base/set.jl
+++ b/base/set.jl
@@ -548,6 +548,9 @@ replaced.
 
 See also [`replace!`](@ref), [`splice!`](@ref), [`delete!`](@ref), [`insert!`](@ref).
 
+!!! compat "Julia 1.7"
+    Version 1.7 is required to replace elements of a `Tuple`.
+
 # Examples
 ```jldoctest
 julia> replace([1, 2, 1, 3], 1=>0, 2=>4, count=2)
@@ -595,6 +598,9 @@ subtract_singletontype(::Type{T}, x::Pair{K}, y::Pair...) where {T, K} =
 Return a copy of `A` where each value `x` in `A` is replaced by `new(x)`.
 If `count` is specified, then replace at most `count` values in total
 (replacements being defined as `new(x) !== x`).
+
+!!! compat "Julia 1.7"
+    Version 1.7 is required to replace elements of a `Tuple`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Backported version of https://github.com/JuliaLang/julia/pull/41701.