### PR TITLE
Add basic help "command" to InteractiveUtils

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -6,7 +6,7 @@ Base.Experimental.@optlevel 1
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard
+    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard, help
 
 import Base.Docs.apropos
 
@@ -19,6 +19,7 @@ include("editless.jl")
 include("codeview.jl")
 include("macros.jl")
 include("clipboard.jl")
+include("help.jl")
 
 """
     varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name)

--- a/stdlib/InteractiveUtils/src/help.jl
+++ b/stdlib/InteractiveUtils/src/help.jl
@@ -8,8 +8,7 @@ struct Help
 end
 
 const help = Help()
-Base.show(io::IO, m::MIME"text/plain", ::Help) = show(io, m, Base.Docs.parsedoc(Base.Docs.keywords[:help]))
-Base.show(io::IO, ::Help) = show(io, Base.Docs.parsedoc(Base.Docs.keywords[:help]))
+Base.show(io::IO, m::MIME"text/plain", h::Help) = show(io, m, h())
+Base.show(io::IO, h::Help) = show(io, h())
 
-(::Help)() = Base.Docs.parsedoc(Base.Docs.keywords[:help])
-
+(::Help)() = @doc(help)

--- a/stdlib/InteractiveUtils/src/help.jl
+++ b/stdlib/InteractiveUtils/src/help.jl
@@ -11,4 +11,4 @@ const help = Help()
 Base.show(io::IO, m::MIME"text/plain", h::Help) = show(io, m, h())
 Base.show(io::IO, h::Help) = show(io, h())
 
-(::Help)() = @doc(help)
+(::Help)() = Base.Docs.parsedoc(Base.Docs.keywords[:help])

--- a/stdlib/InteractiveUtils/src/help.jl
+++ b/stdlib/InteractiveUtils/src/help.jl
@@ -1,0 +1,15 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+"""
+This singleton struct provides the help "command" during interactive mode which
+redirects the user to the "?" help REPL mode.
+"""
+struct Help
+end
+
+const help = Help()
+Base.show(io::IO, m::MIME"text/plain", ::Help) = show(io, m, Base.Docs.parsedoc(Base.Docs.keywords[:help]))
+Base.show(io::IO, ::Help) = show(io, Base.Docs.parsedoc(Base.Docs.keywords[:help]))
+
+(::Help)() = Base.Docs.parsedoc(Base.Docs.keywords[:help])
+


### PR DESCRIPTION
# Add basic help "command" to InteractiveUtils

Typing "help" into an interactive command line program is an intuitive step to take when working with a new program. This pull request creates a "help" command by creating a singleton `Help` object in InteractiveUtils and a constant instance `help`.

```julia
julia> help
  Welcome to Julia 1.8.0-DEV.289. The full manual is available at

  https://docs.julialang.org

  as well as many great tutorials and learning resources:

  https://julialang.org/learning/

  For help on a specific function or macro, type ? followed by its name, e.g. ?cos, or ?@time, and press enter. Type ; to
  enter shell mode, ] to enter package mode.

julia> help()
  Welcome to Julia 1.8.0-DEV.289. The full manual is available at

  https://docs.julialang.org

  as well as many great tutorials and learning resources:

  https://julialang.org/learning/

  For help on a specific function or macro, type ? followed by its name, e.g. ?cos, or ?@time, and press enter. Type ; to
  enter shell mode, ] to enter package mode.
```

While this has some redundancy with `?` (mentioned in the banner) and `@doc`, the redundancy is worthwhile to make Julia user friendly and assists the users when the banner may not be visible after executing several commands.

# Background

## Julia before this pull request

Currently, typing "help" into the Julia REPL results in an error message.

```julia
julia> help
ERROR: UndefVarError: help not defined

julia> help()
ERROR: UndefVarError: help not defined
Stacktrace:
 [1] top-level scope
   @ REPL[1]:1
```

### Pkg help

In contrast, the Pkg mode:
```
(@v1.6) pkg> help
  Welcome to the Pkg REPL-mode. To return to the julia> prompt, either press
  backspace when the input line is empty or press Ctrl+C.

  Synopsis
...
```

## Python

Compare this to Python/ipython:
```python
In [1]: help
Out[1]: Type help() for interactive help, or help(object) for help about object.

In [2]: help()

Welcome to Python 3.7's help utility!

If this is your first time using Python, you should definitely check out
the tutorial on the Internet at https://docs.python.org/3.7/tutorial/.

Enter the name of any module, keyword, or topic to get help on writing
Python programs and using Python modules.  To quit this help utility and
return to the interpreter, just type "quit".

To get a list of available modules, keywords, symbols, or topics, type
"modules", "keywords", "symbols", or "topics".  Each module also comes
with a one-line summary of what it does; to list the modules whose name
or summary contain a given string such as "spam", type "modules spam".

help>  # interactive prompt
```

## R

```R
> help()
# paginated ...
help                   package:utils                   R Documentation

Documentation

Description:

     ‘help’ is the primary interface to the help systems.

Usage:

     help(topic, package = NULL, lib.loc = NULL,
          verbose = getOption("verbose"),
          try.all.packages = getOption("help.try.all.packages"),
          help_type = getOption("help_type"))
```

While `Base.banner()` does direct users to `?`

# Implementation Notes

* The help "command" is added to the InteractiveUtils stdlib as a singleton instance of a `Help` struct.
* `Base.show` is implemented for `Help` by showing the result of `Base.Docs.parsedoc(Base.Docs.keywords[:help])`
   * Changing this `@doc(help)` seems to fail
* The struct is callable and results in showing the same text.
* Currently calling the struct takes no arguments. We don't want to reimplement help mode or `@doc`.