### PR TITLE
generalize `show()` to be for all subtypes of `AbstractSet`

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -55,7 +55,7 @@ function summary(io::IO, iter::T) where {T<:Union{KeySet,ValueIterator}}
     summary(io, iter.dict)
 end
 
-show(io::IO, iter::Union{KeySet,ValueIterator}) = show_vector(io, iter)
+show(io::IO, iter::ValueIterator) = show_vector(io, iter)
 
 length(v::Union{KeySet,ValueIterator}) = length(v.dict)
 isempty(v::Union{KeySet,ValueIterator}) = isempty(v.dict)


### PR DESCRIPTION
Resolves #40188.

Update the error message displayed when something similar to `Code` is run.

Code -
```julia
using Test
d = Dict("hello" => "world")
@test keys(d) == ["hello"]
```

Old Output -
```julia
  Expression: keys(d) == ["hello"]
   Evaluated: ["hello"] == ["hello"]
```

New Output -
```julia
  Expression: keys(d) == ["hello"]
   Evaluated: Base.KeySet{String, Dict{String, String}}(Dict("hello" => "world")) == ["hello"]
```

Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>