### PR TITLE
Display help message upon UndefVarError(:help) using REPL.REPLCompletitions.UndefVarError_hint

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -831,6 +831,10 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
         print(io, "\nsuggestion: Use `||` for short-circuiting boolean OR.")
     elseif var === :and
         print(io, "\nsuggestion: Use `&&` for short-circuiting boolean AND.")
+    elseif var === :help
+        println(io)
+        # Show friendly help message when user types help or help() and help is undefined
+        show(io, MIME("text/plain"), Base.Docs.parsedoc(Base.Docs.keywords[:help]))
     end
 end
 


### PR DESCRIPTION
This is an alternate implementation of #41749 to display a useful help message when the user types "help" or "help()" into the REPL. Rather than creating a new type in InteractiveUtils, this PR modifies the REPL error display by expanding `REPL.REPLCompletitions.UndefVarError_hint`

In contrast to #41749, this allows the user to create a variable named `help`. Upon doing so, the help message will not be displayed.

```julia
julia> help
ERROR: UndefVarError: help not defined
  Welcome to Julia 1.8.0-DEV.288. The full manual is available at

  https://docs.julialang.org

  as well as many great tutorials and learning resources:

  https://julialang.org/learning/

  For help on a specific function or macro, type ? followed by its name, e.g. ?cos, or ?@time, and press enter. Type ; to enter shell mode, ] to enter package mode.

julia> help()
ERROR: UndefVarError: help not defined
  Welcome to Julia 1.8.0-DEV.288. The full manual is available at

  https://docs.julialang.org

  as well as many great tutorials and learning resources:

  https://julialang.org/learning/

  For help on a specific function or macro, type ? followed by its name, e.g. ?cos, or ?@time, and press enter. Type ; to enter shell mode, ] to enter package mode.
Stacktrace:
 [1] top-level scope
   @ REPL[5]:1

julia> help = 5
5

julia> help
5
```

This follows the suggestion of @vtjnash to intercept the `UnderVarError` for `help` and of @DilumAluthge to [implement this functionality in the REPL code](https://github.com/JuliaLang/julia/pull/41749#issuecomment-890570173).

As shown above, this iteration still shows `ERROR: UndefVarError: help not defined` upon entering "help" and also shows a stacktrace for `help()`. A mechanism to hide the error would be nice, but is beyond the scope of this pull request.