### PR TITLE
Add parallel marking to GC

### DIFF
--- a/src/partr.c
+++ b/src/partr.c
@@ -202,9 +202,14 @@ static inline jl_task_t *multiq_deletemin(void)
 void jl_gc_mark_enqueued_tasks(jl_gc_mark_cache_t *gc_cache, jl_gc_mark_sp_t *sp)
 {
     int32_t i, j;
-    for (i = 0; i < heap_p; ++i)
-        for (j = 0; j < heaps[i].ntasks; ++j)
-            jl_gc_mark_queue_obj_explicit(gc_cache, sp, (jl_value_t *)heaps[i].tasks[j]);
+    int tid = jl_threadid();
+    for (i = 0; i < heap_p; ++i) {
+        for (j = 0; j < heaps[i].ntasks; ++j) {
+            jl_task_t *task = heaps[i].tasks[j];
+            if ((task->tid == tid) || (task->tid < 0 && tid == 0))
+                jl_gc_mark_queue_obj_explicit(gc_cache, sp, (jl_value_t *)task);
+        }
+    }
 }
 
 
@@ -510,7 +515,8 @@ JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *trypoptask, jl_value_t *q)
             uv_mutex_lock(&ptls->sleep_lock);
             while (may_sleep(ptls)) {
                 uv_cond_wait(&ptls->wake_signal, &ptls->sleep_lock);
-                // TODO: help with gc work here, if applicable
+                // TODO: Do we need to unlock?
+                jl_gc_try_recruit(ptls);
             }
             assert(ptls->sleep_check_state == not_sleeping);
             uv_mutex_unlock(&ptls->sleep_lock);


### PR DESCRIPTION
This is a first pass at multithreading parts of GC marking. The intended approach is simple: Store a "recruitment location" (function address) into a global, and have non-leader threads (those not running `_jl_gc_collect` directly) check for this global to be set to non-`NULL`. Threads that encounter a valid recruitment location will set their GC state to the new `JL_GC_STATE_PARALLEL` (name subject to change), and will call into the recruitment location. The only available recruitment function, `gc_mark_loop_recruited`, will put the thread to work in `gc_mark_loop`, assuming that the GC leader thread setup some work for this thread to do.

I'm posting this PR early because I need some help figuring out what I'm doing wrong. So far, the recruitment mechanism seems to work well, but I haven't figured out what things I need to setup for each thread before letting them enter the mark loop.

I've also got some code commented out, which would (presumably, if it worked) allow threads to steal work from each other. That's probably not required for this PR, but I started on it in case it might be useful.

N.B. I am bad at atomics, thread safety, and GC semantics, so please point out what terrible things I have done here!

@vchuravy @vtjnash 