### PR TITLE
fix `break` outside of loop in gc-debug

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -315,7 +315,6 @@ static void gc_verify_tags_page(jl_gc_pagemeta_t *pg)
         char *cur_page = gc_page_data((char*)halfpages - 1);
         if (cur_page == data) {
             lim = (char*)halfpages - 1;
-            break;
         }
     }
     // compute the freelist_map


### PR DESCRIPTION
The loop was changed to an `if` in 840ecac5f54c3b3bd2a9764fecfe5f5c79137cf5. I think this is correct?