### PR TITLE
add BLAS.with_num_threads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,9 @@ Standard library changes
 
 #### LinearAlgebra
 
+* A new unexported function `BLAS.with_num_threads` allows you to temporarily change the number of
+  BLAS threads. ([#41785])
+
 #### Markdown
 
 #### Printf

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -578,6 +578,7 @@ LinearAlgebra.BLAS.trsv!
 LinearAlgebra.BLAS.trsv
 LinearAlgebra.BLAS.set_num_threads
 LinearAlgebra.BLAS.get_num_threads
+LinearAlgebra.BLAS.with_num_threads
 ```
 
 ## LAPACK functions

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -120,6 +120,9 @@ Set the number of threads the BLAS library should use equal to `n::Integer`.
 
 Also accepts `nothing`, in which case julia tries to guess the default number of threads.
 Passing `nothing` is discouraged and mainly exists for historical reasons.
+
+See also [`with_num_threads`](@ref BLAS.with_num_threads) to temporarily change
+number of BLAS threads.
 """
 set_num_threads(nt::Integer)::Nothing = lbt_set_num_threads(Int32(nt))
 function set_num_threads(::Nothing)
@@ -168,7 +171,7 @@ restore to previous threads setting.
 
 # Example
 
-The result differs on different machines.
+Depending on the number of available CPU cores, the result can be different:
 
 ```julia
 julia> BLAS.get_num_threads()
@@ -188,6 +191,9 @@ julia> BLAS.get_num_threads()
     This function is not thread safe. If there are multiple
     threads calling BLAS routines, then the threads they are
     using will also be changed until this function finishes.
+
+See also [`set_num_threads`](@ref BLAS.set_num_threads) to permanently change
+number of BLAS threads.
 """
 function with_num_threads(f, num_threads::Integer)
     prev_num_threads = BLAS.get_num_threads()

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -157,6 +157,51 @@ function check()
     end
 end
 
+"""
+    with_num_threads(f, num_threads::Integer)
+
+Run function `f()` with BLAS threads `num_threads` and then
+restore to previous threads setting.
+
+!!! compat "Julia 1.8"
+    `with_num_threads` requires at least Julia 1.8.
+
+# Example
+
+The result differs on different machines.
+
+```julia
+julia> BLAS.get_num_threads()
+8
+
+julia> with_num_threads(4) do
+    BLAS.get_num_threads()
+    # or doing some basic BLAS computation
+end
+4
+
+julia> BLAS.get_num_threads()
+8
+```
+
+!!! warning
+    This function is not thread safe. If there are multiple
+    threads calling BLAS routines, then the threads they are
+    using will also be changed until this function finishes.
+"""
+function with_num_threads(f, num_threads::Integer)
+    prev_num_threads = BLAS.get_num_threads()
+    BLAS.set_num_threads(num_threads)
+    local retval
+    try
+        retval = f()
+    catch err
+        rethrow(err)
+    finally
+        BLAS.set_num_threads(prev_num_threads)
+    end
+    return retval
+end
 
 # Level 1
 ## copy

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -202,15 +202,13 @@ number of BLAS threads.
 function with_num_threads(f, num_threads::Integer)
     prev_num_threads = BLAS.get_num_threads()
     BLAS.set_num_threads(num_threads)
-    local retval
     try
-        retval = f()
-    catch err
-        rethrow(err)
+        return f()
+    catch
+        rethrow()
     finally
         BLAS.set_num_threads(prev_num_threads)
     end
-    return retval
 end
 
 # Level 1

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -192,6 +192,10 @@ julia> BLAS.get_num_threads()
     threads calling BLAS routines, then the threads they are
     using will also be changed until this function finishes.
 
+!!! warning
+    This interface is experimental and subject to change or
+    removal without notice.
+
 See also [`set_num_threads`](@ref BLAS.set_num_threads) to permanently change
 number of BLAS threads.
 """

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -641,6 +641,30 @@ end
     @test BLAS.get_num_threads() === default
 end
 
+@testset "with_num_threads" begin
+    prev_num_threads = BLAS.get_num_threads()
+    context_num_threads = BLAS.with_num_threads(1) do
+        BLAS.get_num_threads()
+    end
+    @test context_num_threads == 1
+    @test prev_num_threads == BLAS.get_num_threads()
+
+    @testset "thread unsafe" begin
+        prev_num_threads = BLAS.get_num_threads()
+        # thread unsafe
+        @async BLAS.with_num_threads(1) do
+            sleep(0.5)
+        end
+        sleep(0.1)
+
+        context_num_threads = BLAS.get_num_threads()
+        @test context_num_threads == 1
+
+        sleep(0.5) # wait for the task to finish
+        @test prev_num_threads == BLAS.get_num_threads()
+    end
+end
+
 # https://github.com/JuliaLang/julia/pull/39845
 @test LinearAlgebra.BLAS.libblas == "libblastrampoline"
 @test LinearAlgebra.BLAS.liblapack == "libblastrampoline"

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -651,16 +651,16 @@ end
 
     @testset "thread unsafe" begin
         prev_num_threads = BLAS.get_num_threads()
-        # thread unsafe
-        @async BLAS.with_num_threads(1) do
+        context_num_threads = 1
+        # task A
+        t = @async BLAS.with_num_threads(context_num_threads) do
             sleep(0.5)
         end
         sleep(0.1)
-
-        context_num_threads = BLAS.get_num_threads()
-        @test context_num_threads == 1
-
-        sleep(0.5) # wait for the task to finish
+        # check that main thread is affected by task A
+        @test BLAS.get_num_threads() == context_num_threads
+        # when the task finishes, the num threads get restored
+        wait(t)
         @test prev_num_threads == BLAS.get_num_threads()
     end
 end


### PR DESCRIPTION
I added this `BLAS.with_num_threads` as a convenient wrapper, but I'm not sure if we want it live in Base because it's not thread-safe.

In some cases, multi-threading could happen at a more efficient higher level instead of at the BLAS level. Thus we may want to temporarily disable BLAS threads during the julia threads execution.

As an example, SVD is one typical case: if there are a bunch of SVD operations and if we can do embarrassingly parallel at a higher level, then it's better to disable the BLAS threads.

```julia
using LinearAlgebra

function make_test_data(n)
    U = rand(n, n)
    S = rand(n)
    V = rand(n, n)
    U * Diagonal(S) * V'
end

function svd_solver(X, k=5)
    U, S, Vt = svd(X)
    S[k:end] .= 0
    U * Diagonal(S) * Vt
end

dataset = [make_test_data(64) for _ in 1:64]

function svd_with_blas_threads(dataset)
    losses = zeros(size(dataset))
    Threads.@threads for i in eachindex(dataset)
        X = dataset[i]
        losses[i] = norm(X - svd_solver(X))
    end
    return losses
end

function svd_without_blas_threads(dataset)
    losses = zeros(size(dataset))
    BLAS.with_num_threads(1) do 
        Threads.@threads for i in eachindex(dataset)
            X = dataset[i]
            losses[i] = norm(X - svd_solver(X))
        end
    end
    return losses
end

Threads.nthreads() # 8
BLAS.get_num_threads() # 8

@btime svd_with_blas_threads(dataset); # 15.149 ms (1194 allocations: 18.55 MiB)
@btime svd_without_blas_threads(dataset);# 10.411 ms (1194 allocations: 18.55 MiB)
```

Would need to add a news entry if approved.