### PR TITLE
Prevent TOCTTOU race in finalize_ref

### DIFF
--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -86,6 +86,7 @@ IteratorSize(::Type{<:WeakKeyDict}) = SizeUnknown()
 islocked(wkh::WeakKeyDict) = islocked(wkh.lock)
 lock(wkh::WeakKeyDict) = lock(wkh.lock)
 unlock(wkh::WeakKeyDict) = unlock(wkh.lock)
+trylock(wkh::WeakKeyDict) = trylock(wkh.lock)
 lock(f, wkh::WeakKeyDict) = lock(f, wkh.lock)
 trylock(f, wkh::WeakKeyDict) = trylock(f, wkh.lock)
 

--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -262,7 +262,7 @@ end
 
 function send_del_client(rr)
     if rr.where == myid()
-        del_client(rr)
+        Threads.@spawn del_client(rr)
     elseif id_in_procs(rr.where) # process only if a valid worker
         w = worker_from_id(rr.where)::Worker
         push!(w.del_msgs, (remoteref_id(rr), myid()))


### PR DESCRIPTION
Just because we check `islocked` is `false`, doesn't mean that it won't be locked in the next instant when we check again. Manually deletes the WKD entry if the lock can be taken, otherwise defer the finalizer.

Should prevent cases like https://github.com/JuliaParallel/Dagger.jl/issues/243#issuecomment-890483831.

Please let me know if there's a better way to fix this race!