### PR TITLE
compiler: speed up bootstrapping time by 25%

### DIFF
--- a/base/compiler/bootstrap.jl
+++ b/base/compiler/bootstrap.jl
@@ -5,10 +5,20 @@
 # especially try to make sure any recursive and leaf functions have concrete signatures,
 # since we won't be able to specialize & infer them at runtime
 
-let fs = Any[typeinf_ext, typeinf, typeinf_edge, pure_eval_call, run_passes],
-    world = get_world_counter(),
+time() = ccall(:jl_clock_now, Float64, ())
+
+let
+    world = get_world_counter()
     interp = NativeInterpreter(world)
 
+    fs = Any[
+        # we first create caches for the optimizer, because they contain many loop constructions
+        # and they're better to not run in interpreter even during bootstrapping
+        run_passes,
+        # then we create caches for inference entries
+        typeinf_ext, typeinf, typeinf_edge,
+    ]
+    # tfuncs can't be inferred from the inference entries above, so here we infer them manually
     for x in T_FFUNC_VAL
         push!(fs, x[3])
     end
@@ -20,6 +30,7 @@ let fs = Any[typeinf_ext, typeinf, typeinf_edge, pure_eval_call, run_passes],
             println(stderr, "WARNING: tfunc missing for ", reinterpret(IntrinsicFunction, Int32(i)))
         end
     end
+    starttime = time()
     for f in fs
         for m in _methods_by_ftype(Tuple{typeof(f), Vararg{Any}}, 10, typemax(UInt))
             # remove any TypeVars from the intersection
@@ -32,4 +43,6 @@ let fs = Any[typeinf_ext, typeinf, typeinf_edge, pure_eval_call, run_passes],
             typeinf_type(interp, m.method, Tuple{typ...}, m.sparams)
         end
     end
+    endtime = time()
+    println("Core.Compiler ──── ", sub_float(endtime,starttime), " seconds")
 end


### PR DESCRIPTION
The optimizer code is full of loop constructions and I found they're
really better to not run in interpreter.

With this PR, we create the caches of the optimizer code first and
it speeds up the succeeding bootstrapping to create the caches for
the overall inference code.

On my machine, the bootstrapping took about 80 seconds previously,
but on this PR the time is reduced to about 60 seconds.