### PR TITLE
improve `@something` hygine

### DIFF
--- a/base/some.jl
+++ b/base/some.jl
@@ -138,8 +138,7 @@ true
 macro something(args...)
     expr = :(nothing)
     for arg in reverse(args)
-        expr = :((val = $arg) !== nothing ? val : $expr)
+        expr = :(val = $(esc(arg)); val === nothing ? $expr : val)
     end
-    return esc(:(something(let val; $expr; end)))
+    return :(($(GlobalRef(Base, :something)))(let val; $expr; end))
 end
-

--- a/base/some.jl
+++ b/base/some.jl
@@ -140,5 +140,6 @@ macro something(args...)
     for arg in reverse(args)
         expr = :(val = $(esc(arg)); val === nothing ? $expr : val)
     end
-    return :(($(GlobalRef(Base, :something)))(let val; $expr; end))
+    something = GlobalRef(Base, :something)
+    return :($something(let val; $expr; end))
 end

--- a/base/some.jl
+++ b/base/some.jl
@@ -138,7 +138,7 @@ true
 macro something(args...)
     expr = :(nothing)
     for arg in reverse(args)
-        expr = :(val = $(esc(arg)); val === nothing ? $expr : val)
+        expr = :(val = $(esc(arg)); val !== nothing ? val : ($expr))
     end
     something = GlobalRef(Base, :something)
     return :($something($expr))

--- a/base/some.jl
+++ b/base/some.jl
@@ -141,5 +141,5 @@ macro something(args...)
         expr = :(val = $(esc(arg)); val === nothing ? $expr : val)
     end
     something = GlobalRef(Base, :something)
-    return :($something(let val; $expr; end))
+    return :($something($expr))
 end

--- a/test/some.jl
+++ b/test/some.jl
@@ -87,6 +87,11 @@ end
 
     @test @something(1, error("failed")) === 1
     @test_throws ErrorException @something(nothing, error("failed"))
+
+    @test let
+        val = 1
+        @something(val)
+    end == 1
 end
 
 # issue #26927

--- a/test/some.jl
+++ b/test/some.jl
@@ -88,8 +88,8 @@ end
     @test @something(1, error("failed")) === 1
     @test_throws ErrorException @something(nothing, error("failed"))
 
-    @test let
-        val = 1
+    # Ensure that the internal variable doesn't conflict with a user defined variable
+    @test let val = 1
         @something(val)
     end == 1
 end


### PR DESCRIPTION
By using `val = x; val !== nothing` instead of `(val = x) !== nothing`.

```julia
let x::Union{T,Nothing}
    if (val = x) !== nothing
        # can't narrow down to `val::T` here because the type constraint
        # is imposed on `x`
        return val
    end
end
```