### PR TITLE
Allow AbstractUnitRange for string getindex

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -254,7 +254,7 @@ end
 
 getindex(s::String, r::AbstractUnitRange{<:Integer}) = s[Int(first(r)):Int(last(r))]
 
-@inline function getindex(s::String, r::AbstractUnitRange{Int})
+@inline function getindex(s::String, r::UnitRange{Int})
     isempty(r) && return ""
     i, j = first(r), last(r)
     @boundscheck begin

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -252,9 +252,9 @@ function getindex_continued(s::String, i::Int, u::UInt32)
     return reinterpret(Char, u)
 end
 
-getindex(s::String, r::UnitRange{<:Integer}) = s[Int(first(r)):Int(last(r))]
+getindex(s::String, r::AbstractUnitRange{<:Integer}) = s[Int(first(r)):Int(last(r))]
 
-@inline function getindex(s::String, r::UnitRange{Int})
+@inline function getindex(s::String, r::AbstractUnitRange{Int})
     isempty(r) && return ""
     i, j = first(r), last(r)
     @boundscheck begin

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -252,4 +252,4 @@ function filter(f, s::Union{String, SubString{String}})
     return String(out)
 end
 
-getindex(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, r)
+getindex(s::AbstractString, r::AbstractUnitRange{<:Integer}) = SubString(s, r)


### PR DESCRIPTION
Several methods could be generalized to work with `AbstractUnitRange` rather than just `UnitRange`. There are now several `AbstractUnitRange` subtypes:

```julia
julia> subtypes(AbstractUnitRange)
4-element Vector{Any}:
 Base.IdentityUnitRange
 Base.OneTo
 Base.Slice
 UnitRange
```

This pull request allows `AbstractUnitRange` for `getindex` on a `String`.

_There seem to be some ambiguous method errors associated with the current change._