### PR TITLE
CI (Buildbot): As soon as a PR is created or updated, create pending (yellow) commit statuses for all Buildbot jobs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
-CODEOWNERS @JuliaLang/github-actions 
-/.github/ @JuliaLang/github-actions 
+CODEOWNERS @JuliaLang/github-actions
+/.github/ @JuliaLang/github-actions
 /.buildkite/ @JuliaLang/github-actions
+
+/.github/workflows/statuses.yml @DilumAluthge

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -1,0 +1,97 @@
+# Please ping @DilumAluthge when making any changes to this file.
+
+# This is just a short-term solution until we have migrated all of CI to Buildkite.
+#
+# 1. TODO: delete this file once we have migrated all of CI to Buildkite.
+#
+# 2. TODO: disable GitHub Actions on the `JuliaLang/julia` repository once we have migrated all
+# of CI to Buildkite.
+
+# Here are some steps that we take in this workflow file for security reasons:
+# 1. We do not checkout any code.
+# 2. We do not run any external actions.
+
+name: Statuses
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-*'
+  # When using the `pull_request_target` event, all PRs will get a `GITHUB_TOKEN` that has
+  # write permissions, even if the PR is from a fork.
+  # Therefore, for security reasons, we do not checkout any code in this workflow.
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-*'
+
+# These are the permissions for the `GITHUB_TOKEN` token.
+# We should only give the token the minimum necessary set of permissions.
+permissions:
+  statuses:            write
+  actions:             none
+  checks:              none
+  contents:            none
+  deployments:         none
+  issues:              none
+  discussions:         none
+  packages:            none
+  pull-requests:       none
+  repository-projects: none
+  security-events:     none
+
+jobs:
+  statuses:
+    name: statuses
+    runs-on: ubuntu-latest
+    if: github.repository == 'JuliaLang/julia'
+    strategy:
+      fail-fast: false
+    steps:
+      - run: echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+
+      - run: echo "SHA=${{ env.GITHUB_SHA }}" >> $GITHUB_ENV
+        if: github.event_name != 'pull_request'
+
+      - run: echo "The SHA is ${{ env.SHA }}"
+
+      # As we incrementally migrate individual jobs from Buildbot to Buildkite, we should
+      # remove them from the `context_list`.
+      - run: |
+          declare -a CONTEXT_LIST=(
+                "buildbot/package_freebsd64"
+                "buildbot/package_linux32"
+                "buildbot/package_linuxaarch64"
+                "buildbot/package_linuxarmv7l"
+                "buildbot/package_linuxppc64le"
+                "buildbot/package_macos64"
+                "buildbot/package_macosaarch64"
+                "buildbot/package_musl64"
+                "buildbot/package_win32"
+                "buildbot/package_win64"
+                "buildbot/tester_freebsd64"
+                "buildbot/tester_linux32"
+                "buildbot/tester_linux64"
+                "buildbot/tester_linuxaarch64"
+                "buildbot/tester_linuxarmv7l"
+                "buildbot/tester_linuxppc64le"
+                "buildbot/tester_macos64"
+                "buildbot/tester_macosaarch64"
+                "buildbot/tester_musl64"
+                "buildbot/tester_win32"
+                "buildbot/tester_win64"
+                )
+          for CONTEXT in "${CONTEXT_LIST[@]}"
+          do
+            curl \
+              -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "{\"context\": \"$CONTEXT\", \"state\": \"$STATE\"}" \
+            https://api.github.com/repos/JuliaLang/julia/statuses/${{ env.SHA }}
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATE: "pending"


### PR DESCRIPTION
## Summary

When a PR is created or updated, this GitHub Actions workflow will create pending (yellow) commit statuses for all of the Buildbot jobs.

For example, this workflow will run when:
- A new PR is created.
- A new commit is pushed to an existing PR.

## Motivation

Buildbot does not create the pending commit status until a job has actually started on a worker. Therefore, if a job is waiting to be scheduled, and has not yet started, Buildbot will not create a commit status for the job.

As a result, a PR may be "all green" with a message that all CI jobs are passing, but in reality, there are still some jobs that have not yet started because all of the relevant workers are busy. This can lead to PRs being accidentally merged before all of the CI jobs have finished running on that PR.

This workflow tries to prevent this situation by immediately creating pending commit statuses for all of the Buildbot jobs that will eventually be run on the PR.

## Future

This problem is unique to Buildbot, because of the following two reasons:
1. Buildbot does not create a commit status for an individual job until that job has started on a worker.
2. There is no "overall" or "summary" commit status for Buildbot.

We will not have this problem when we switch over to Buildkite. With Buildkite, there is an "overall" commit status. You can see it on this PR - it is called `buildkite/julia-master`. This commit status is created by Buildkite immediately, and it remains pending (yellow) until all of the Buildkite jobs have completed.

Therefore, we will not need this workflow once we have completed our migration to Buildkite. Once the migration is complete, we will do the following:
1. Delete this workflow file.
2. Disable all GitHub Actions on the `JuliaLang/julia` repository.
