### PR TITLE
CI (Buildbot, GHA): in the "Statuses" workflow, we only need to create pending (yellow) statuses for the `tester_` jobs

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -61,16 +61,6 @@ jobs:
       # remove them from the `context_list`.
       - run: |
           declare -a CONTEXT_LIST=(
-                "buildbot/package_freebsd64"
-                "buildbot/package_linux32"
-                "buildbot/package_linuxaarch64"
-                "buildbot/package_linuxarmv7l"
-                "buildbot/package_linuxppc64le"
-                "buildbot/package_macos64"
-                "buildbot/package_macosaarch64"
-                "buildbot/package_musl64"
-                "buildbot/package_win32"
-                "buildbot/package_win64"
                 "buildbot/tester_freebsd64"
                 "buildbot/tester_linux32"
                 "buildbot/tester_linux64"


### PR DESCRIPTION
We don't need to create the pending statuses for both the `package_` and `tester_` jobs.

We only need to create the pending statuses for the `tester_` jobs, since the `tester_X` job cannot start until the corresponding `package_X` job has completed successfully.

Therefore, if a `package_X` job has not yet completed, the corresponding `tester_X` commit status will be pending, thus alerting the user to the fact that CI has not yet completed on their PR.