### PR TITLE
CI (Buildbot, GHA): in the "Statuses" workflow, remove the `macosaarch64` and `musl64` statuses

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -68,8 +68,6 @@ jobs:
                 "buildbot/tester_linuxarmv7l"
                 "buildbot/tester_linuxppc64le"
                 "buildbot/tester_macos64"
-                "buildbot/tester_macosaarch64"
-                "buildbot/tester_musl64"
                 "buildbot/tester_win32"
                 "buildbot/tester_win64"
                 )


### PR DESCRIPTION
If I understand correctly, the `macosaarch64` and `musl64` workers are only turned on to make release binaries.