### PR TITLE
[WIP] enhancement of Eigen API (revision of #38483)

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -550,7 +550,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     if any(!isfinite, D.diag)
         throw(ArgumentError("matrix contains Infs or NaNs"))
     end
-    Eigen(sorteig!(eigvals(D), eigvecs(D), sortby)...)
+    Eigen(sorteig!(eigvals(D), eigvecs(D), sortby)...; normal=true)
 end
 
 #Singular system

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -17,7 +17,7 @@ Iterating the decomposition produces the components `F.values` and `F.vectors`.
 # Examples
 ```jldoctest
 julia> F = eigen([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
-Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}}
+Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}, Vector{Float64}}
 values:
 3-element Vector{Float64}:
   1.0
@@ -47,14 +47,18 @@ julia> vals == F.values && vecs == F.vectors
 true
 ```
 """
-struct Eigen{T,V,S<:AbstractMatrix,U<:AbstractVector} <: Factorization{T}
+struct Eigen{T,V,S<:AbstractMatrix,U<:AbstractVector,R<:AbstractVector} <: Factorization{T}
     values::U
     vectors::S
-    Eigen{T,V,S,U}(values::AbstractVector{V}, vectors::AbstractMatrix{T}) where {T,V,S,U} =
-        new(values, vectors)
+    vectorsl::S
+    unitary::Bool
+    rconde::R
+    rcondv::R
+    Eigen{T,V,S,U,R}(values::AbstractVector{V}, vectors::AbstractMatrix{T}, vectorsl::AbstractMatrix{T}, unitary::Bool, rconde::R, rcondv::R) where {T,V,S,U,R} =
+        new(values, vectors, vectorsl, unitary, rconde, rcondv)
 end
-Eigen(values::AbstractVector{V}, vectors::AbstractMatrix{T}) where {T,V} =
-    Eigen{T,V,typeof(vectors),typeof(values)}(values, vectors)
+Eigen(values::AbstractVector{V}, vectors::AbstractMatrix{T}, vectorsl=vectors, uni=true, rce=zeros(real(T),0), rcv=zeros(real(T), 0)) where {T,V} =
+    Eigen{T,V,typeof(vectors),typeof(values),typeof(rce)}(values, vectors, vectorsl, uni, rce, rcv)
 
 # Generalized eigenvalue problem.
 """
@@ -133,9 +137,20 @@ function sorteig!(λ::AbstractVector, X::AbstractMatrix, sortby::Union{Function,
     if sortby !== nothing && !issorted(λ, by=sortby)
         p = sortperm(λ; alg=QuickSort, by=sortby)
         permute!(λ, p)
-        Base.permutecols!!(X, p)
+        !isempty(X) && Base.permutecols!!(X, copy(p))
     end
     return λ, X
+end
+function sorteig!(λ::AbstractVector, X::AbstractMatrix, sortby::Union{Function,Nothing}, Y::AbstractMatrix, rconde::AbstractVector, rcondv::AbstractVector)
+    if sortby !== nothing && !issorted(λ, by=sortby)
+        p = sortperm(λ; alg=QuickSort, by=sortby)
+        permute!(λ, p)
+        !isempty(rconde) && permute!(rconde, p)
+        !isempty(rcondv) && permute!(rcondv, p)
+        !isempty(X) && Base.permutecols!!(X, copy(p))
+        !isempty(Y) && X !== Y && Base.permutecols!!(Y, p)
+    end
+    return λ, X, Y, false, rconde, rcondv
 end
 sorteig!(λ::AbstractVector, sortby::Union{Function,Nothing}=eigsortby) = sortby === nothing ? λ : sort!(λ, by=sortby)
 
@@ -145,12 +160,32 @@ sorteig!(λ::AbstractVector, sortby::Union{Function,Nothing}=eigsortby) = sortby
 Same as [`eigen`](@ref), but saves space by overwriting the input `A` (and
 `B`), instead of creating a copy.
 """
-function eigen!(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where T<:BlasReal
+function eigen!(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby, jvl::Bool=false, jvr::Bool=true, jce::Bool=false, jcv::Bool=false) where T<:BlasReal
     n = size(A, 2)
     n == 0 && return Eigen(zeros(T, 0), zeros(T, 0, 0))
     issymmetric(A) && return eigen!(Symmetric(A), sortby=sortby)
-    A, WR, WI, VL, VR, _ = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)
-    iszero(WI) && return Eigen(sorteig!(WR, VR, sortby)...)
+
+    balance = permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N')
+    jobvl = jvl || jce ? 'V' : 'N'
+    jobvr = jvr || jce ? 'V' : 'N'
+    sense = jce && jcv ? 'B' : jce ? 'E' : jcv ? 'V' : 'N'
+    A, WR, WI, VL, VR, _, _, scale, abnrm, rconde, rcondv = LAPACK.geevx!(balance, jobvl, jobvr, sense, A)
+    if iszero(WI)
+        evecr = VR
+        evecl = VL
+        evals = WR
+    else
+        evecr = complexeig(WI, VR)
+        evecl = complexeig(WI, VL)
+        evals = complex.(WR, WI)
+    end
+    rconde = jce ? inv.(rconde) : zeros(T, 0)
+    rcondv = jcv ? inv.(rcondv) : zeros(T, 0)
+    return Eigen(sorteig!(evals, evecr, sortby, evecl, rconde, rcondv)...)
+end
+
+function complexeig(WI::Vector{T}, VR::Matrix{T}) where T
+    n = min(size(VR)...)
     evec = zeros(Complex{T}, n, n)
     j = 1
     while j <= n
@@ -165,15 +200,19 @@ function eigen!(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true, sortb
         end
         j += 1
     end
-    return Eigen(sorteig!(complex.(WR, WI), evec, sortby)...)
+    evec
 end
 
-function eigen!(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where T<:BlasComplex
+function eigen!(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby, jvl::Bool=false, jvr::Bool=true, jce::Bool=false, jcv::Bool=false) where T<:BlasComplex
     n = size(A, 2)
     n == 0 && return Eigen(zeros(T, 0), zeros(T, 0, 0))
     ishermitian(A) && return eigen!(Hermitian(A), sortby=sortby)
-    eval, evec = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)[[2,4]]
-    return Eigen(sorteig!(eval, evec, sortby)...)
+    balance = permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N')
+    jobvl = jvl || jce ? 'V' : 'N'
+    jobvr = jvr || jce ? 'V' : 'N'
+    sense = jce && jcv ? 'B' : jce ? 'E' : jcv ? 'V' : 'N'
+    A, W, VL, VR, _, _, scale, abnrm, rconde, rcondv = LAPACK.geevx!(balance, jobvl, jobvr, sense, A)
+    return Eigen(sorteig!(W, VR, sortby, VL, rconde, rcondv)...)
 end
 
 """
@@ -201,7 +240,7 @@ accept a `sortby` keyword.
 # Examples
 ```jldoctest
 julia> F = eigen([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
-Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}}
+Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}, Vector{Float64}}
 values:
 3-element Vector{Float64}:
   1.0
@@ -231,10 +270,10 @@ julia> vals == F.values && vecs == F.vectors
 true
 ```
 """
-function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where T
+function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby, jvl::Bool=false, jvr::Bool=true, jce::Bool=false, jcv::Bool=false) where T
     AA = copy_oftype(A, eigtype(T))
     isdiag(AA) && return eigen(Diagonal(AA); permute=permute, scale=scale, sortby=sortby)
-    return eigen!(AA; permute=permute, scale=scale, sortby=sortby)
+    return eigen!(AA; permute=permute, scale=scale, sortby=sortby, jvl=jvl, jvr=jvr, jce=jce, jcv=jcv)
 end
 function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T <: Union{Float16,Complex{Float16}}}
     AA = copy_oftype(A, eigtype(T))
@@ -242,7 +281,10 @@ function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortb
     A = eigen!(AA; permute, scale, sortby)
     values = convert(AbstractVector{isreal(A.values) ? Float16 : Complex{Float16}}, A.values)
     vectors = convert(AbstractMatrix{isreal(A.vectors) ? Float16 : Complex{Float16}}, A.vectors)
-    return Eigen(values, vectors)
+    vectorsl = convert(AbstractMatrix{isreal(A.vectors) ? Float16 : Complex{Float16}}, A.vectorsl)
+    rconde = convert(Vector{Float16}, A.rconde)
+    rcondv = convert(Vector{Float16}, A.rcondv)
+    return Eigen(values, vectors, vectorsl, A.unitary, rconde, rcondv)
 end
 eigen(x::Number) = Eigen([x], fill(one(x), 1, 1))
 
@@ -428,7 +470,19 @@ function eigmin(A::Union{Number, AbstractMatrix};
     minimum(v)
 end
 
-inv(A::Eigen) = A.vectors * inv(Diagonal(A.values)) / A.vectors
+"""
+    spectral(f, F::Eigen)
+
+Construct a matrix from an eigen-decomposition `F` by applying the function to
+the spectrum (diagonal) of `F`.
+"""
+function spectral(f, A::Eigen)
+    d = Diagonal(f.(A.values))
+    v = A.vectors
+    vd = v * d
+    A.unitary ? vd * v' : vd / v
+end
+inv(A::Eigen) = spectral(inv, A)
 det(A::Eigen) = prod(A.values)
 
 # Generalized eigenproblem
@@ -618,8 +672,28 @@ function show(io::IO, mime::MIME{Symbol("text/plain")}, F::Union{Eigen,Generaliz
     summary(io, F); println(io)
     println(io, "values:")
     show(io, mime, F.values)
-    println(io, "\nvectors:")
-    show(io, mime, F.vectors)
+    if !isdefined(F, :vectorsl) || (!isempty(F.vectors) && (F.vectors === F.vectorsl || isempty(F.vectorsl)))
+        println(io, "\nvectors:")
+        show(io, mime, F.vectors)
+    else
+        if !isempty(F.vectors)
+            println(io, "\nright vectors:")
+            show(io, mime, F.vectors)
+        end
+        if !isempty(F.vectorsl)
+            println(io, "\nleft vectors:")
+            show(io, mime, F.vectorsl)
+        end
+    end
+    if isdefined(F, :rconde) && !isempty(F.rconde)
+        println(io, "\ncondition values:")
+        show(io, mime, F.rconde)
+    end
+    if isdefined(F, :rcondv) && !isempty(F.rcondv)
+        println(io, "\ncondition vectors:")
+        show(io, mime, F.rcondv)
+    end
+    nothing
 end
 
 function Base.hash(F::Eigen, h::UInt)
@@ -635,7 +709,7 @@ end
 # Conversion methods
 
 ## Can we determine the source/result is Real?  This is not stored in the type Eigen
-AbstractMatrix(F::Eigen) = F.vectors * Diagonal(F.values) / F.vectors
+AbstractMatrix(F::Eigen) = spectral(identity, F)
 AbstractArray(F::Eigen) = AbstractMatrix(F)
 Matrix(F::Eigen) = Array(AbstractArray(F))
 Array(F::Eigen) = Matrix(F)

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Eigensolvers for symmetric and Hermitian matrices
-eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing) = Eigen(sorteig!(LAPACK.syevr!('V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)..., sortby)...)
+eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing) = Eigen(sorteig!(LAPACK.syevr!('V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)..., sortby)...; normal=true)
 
 function eigen(A::RealHermSymComplexHerm; sortby::Union{Function,Nothing}=nothing)
     T = eltype(A)
@@ -9,7 +9,7 @@ function eigen(A::RealHermSymComplexHerm; sortby::Union{Function,Nothing}=nothin
     eigen!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), sortby=sortby)
 end
 
-eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, irange::UnitRange) = Eigen(LAPACK.syevr!('V', 'I', A.uplo, A.data, 0.0, 0.0, irange.start, irange.stop, -1.0)...)
+eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, irange::UnitRange) = Eigen(LAPACK.syevr!('V', 'I', A.uplo, A.data, 0.0, 0.0, irange.start, irange.stop, -1.0)...; normal=true)
 
 """
     eigen(A::Union{SymTridiagonal, Hermitian, Symmetric}, irange::UnitRange) -> Eigen
@@ -35,7 +35,7 @@ function eigen(A::RealHermSymComplexHerm, irange::UnitRange)
 end
 
 eigen!(A::RealHermSymComplexHerm{T,<:StridedMatrix}, vl::Real, vh::Real) where {T<:BlasReal} =
-    Eigen(LAPACK.syevr!('V', 'V', A.uplo, A.data, convert(T, vl), convert(T, vh), 0, 0, -1.0)...)
+    Eigen(LAPACK.syevr!('V', 'V', A.uplo, A.data, convert(T, vl), convert(T, vh), 0, 0, -1.0)...; normal=true)
 
 """
     eigen(A::Union{SymTridiagonal, Hermitian, Symmetric}, vl::Real, vu::Real) -> Eigen

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -283,16 +283,16 @@ end
 ldiv!(A::SymTridiagonal, B::AbstractVecOrMat; shift::Number=false) = ldiv!(ldlt(A, shift=shift), B)
 rdiv!(B::AbstractVecOrMat, A::SymTridiagonal; shift::Number=false) = rdiv!(B, ldlt(A, shift=shift))
 
-eigen!(A::SymTridiagonal{<:BlasReal}) = Eigen(LAPACK.stegr!('V', A.dv, A.ev)...)
+eigen!(A::SymTridiagonal{<:BlasReal}) = Eigen(LAPACK.stegr!('V', A.dv, A.ev)...; normal=true)
 eigen(A::SymTridiagonal{T}) where T = eigen!(copy_oftype(A, eigtype(T)))
 
 eigen!(A::SymTridiagonal{<:BlasReal}, irange::UnitRange) =
-    Eigen(LAPACK.stegr!('V', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)...)
+    Eigen(LAPACK.stegr!('V', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)...; normal=true)
 eigen(A::SymTridiagonal{T}, irange::UnitRange) where T =
     eigen!(copy_oftype(A, eigtype(T)), irange)
 
 eigen!(A::SymTridiagonal{<:BlasReal}, vl::Real, vu::Real) =
-    Eigen(LAPACK.stegr!('V', 'V', A.dv, A.ev, vl, vu, 0, 0)...)
+    Eigen(LAPACK.stegr!('V', 'V', A.dv, A.ev, vl, vu, 0, 0)...; normal=true)
 eigen(A::SymTridiagonal{T}, vl::Real, vu::Real) where T =
     eigen!(copy_oftype(A, eigtype(T)), vl, vu)
 

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -186,21 +186,27 @@ end
     D32 = eigen(Float32.(C))
     F = eigen(complex(C))
     F32 = eigen(complex(Float32.(C)))
-    @test B isa Eigen{Float16, Float16, Matrix{Float16}, Vector{Float16}}
+    @test B isa Eigen{Float16, Float16, Matrix{Float16}, Vector{Float16}, Vector{Float16}}
     @test B.values isa Vector{Float16}
     @test B.vectors isa Matrix{Float16}
+    @test B.vectorsl isa Matrix{Float16}
     @test B.values ≈ B32.values
     @test B.vectors ≈ B32.vectors
-    @test D isa Eigen{ComplexF16, ComplexF16, Matrix{ComplexF16}, Vector{ComplexF16}}
+    @test B.vectorsl ≈ B32.vectorsl
+    @test D isa Eigen{ComplexF16, ComplexF16, Matrix{ComplexF16}, Vector{ComplexF16}, Vector{Float16}}
     @test D.values isa Vector{ComplexF16}
     @test D.vectors isa Matrix{ComplexF16}
+    @test D.vectorsl isa Matrix{ComplexF16}
     @test D.values ≈ D32.values
     @test D.vectors ≈ D32.vectors
-    @test F isa Eigen{ComplexF16, ComplexF16, Matrix{ComplexF16}, Vector{ComplexF16}}
+    @test D.vectorsl ≈ D32.vectorsl
+    @test F isa Eigen{ComplexF16, ComplexF16, Matrix{ComplexF16}, Vector{ComplexF16}, Vector{Float16}}
     @test F.values isa Vector{ComplexF16}
     @test F.vectors isa Matrix{ComplexF16}
+    @test F.vectorsl isa Matrix{ComplexF16}
     @test F.values ≈ F32.values
     @test F.vectors ≈ F32.vectors
+    @test F.vectorsl ≈ F32.vectorsl
 end
 
 end # module TestEigen


### PR DESCRIPTION
Adds left eigenvectors and reciprocal condition numbers as optional results from `eigen()`.
This PR cleans up some loose ends from earlier work by @KlausC (#38483), which was reverted.