### PR TITLE
CI (Buildbot, GHA): in the "Statuses" workflow, remove the `tester_linuxppc64le` status

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -66,7 +66,6 @@ jobs:
                 "buildbot/tester_linux64"
                 "buildbot/tester_linuxaarch64"
                 "buildbot/tester_linuxarmv7l"
-                "buildbot/tester_linuxppc64le"
                 "buildbot/tester_macos64"
                 "buildbot/tester_win32"
                 "buildbot/tester_win64"


### PR DESCRIPTION
The `tester_linuxppc64le` buildbot does not create a GitHub commit status. As @vchuravy explained on Slack, this is intentional.

Therefore, the "Statuses" GHA workflow does not need to create a `buildbot/tester_linuxppc64le` commit status. We only need to create commit statuses for the statuses that Buildbot will later come in and update.