### PR TITLE
Add `copy(::KeySet)` method and specialized `Set{T}(::KeySet)` method

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -66,6 +66,8 @@ function iterate(v::Union{KeySet,ValueIterator}, state...)
     return (y[1][isa(v, KeySet) ? 1 : 2], y[2])
 end
 
+copy(v::KeySet) = copymutable(v)
+
 in(k, v::KeySet) = get(v.dict, k, secret_table_token) !== secret_table_token
 
 """

--- a/base/set.jl
+++ b/base/set.jl
@@ -3,13 +3,21 @@
 struct Set{T} <: AbstractSet{T}
     dict::Dict{T,Nothing}
 
-    Set{T}() where {T} = new(Dict{T,Nothing}())
-    Set{T}(s::Set{T}) where {T} = new(Dict{T,Nothing}(s.dict))
+    global unsafe_set(dict::Dict{T,Nothing}) where {T} = new{T}(dict)
 end
 
+Set{T}() where {T} = unsafe_set(Dict{T,Nothing}())
+Set{T}(s::Set{T}) where {T} = unsafe_set(Dict{T,Nothing}(s.dict))
 Set{T}(itr) where {T} = union!(Set{T}(), itr)
 Set() = Set{Any}()
 
+function Set{T}(s::KeySet) where {T}
+    d = s.dict
+    slots = copy(d.slots)
+    keys = copyto!(similar(d.keys, T), d.keys)
+    vals = similar(d.vals, Nothing)
+    unsafe_set(Dict{T,Nothing}(slots, keys, vals, d.ndel, d.count, d.age, d.idxfloor, d.maxprobe))
+end
 
 """
     Set([itr])

--- a/base/set.jl
+++ b/base/set.jl
@@ -3,11 +3,11 @@
 struct Set{T} <: AbstractSet{T}
     dict::Dict{T,Nothing}
 
-    global unsafe_set(dict::Dict{T,Nothing}) where {T} = new{T}(dict)
+    global _Set(dict::Dict{T,Nothing}) where {T} = new{T}(dict)
 end
 
-Set{T}() where {T} = unsafe_set(Dict{T,Nothing}())
-Set{T}(s::Set{T}) where {T} = unsafe_set(Dict{T,Nothing}(s.dict))
+Set{T}() where {T} = _Set(Dict{T,Nothing}())
+Set{T}(s::Set{T}) where {T} = _Set(Dict{T,Nothing}(s.dict))
 Set{T}(itr) where {T} = union!(Set{T}(), itr)
 Set() = Set{Any}()
 
@@ -16,7 +16,7 @@ function Set{T}(s::KeySet{T, <:Dict{T}}) where {T}
     slots = copy(d.slots)
     keys = copy(d.keys)
     vals = similar(d.vals, Nothing)
-    unsafe_set(Dict{T,Nothing}(slots, keys, vals, d.ndel, d.count, d.age, d.idxfloor, d.maxprobe))
+    _Set(Dict{T,Nothing}(slots, keys, vals, d.ndel, d.count, d.age, d.idxfloor, d.maxprobe))
 end
 
 """

--- a/base/set.jl
+++ b/base/set.jl
@@ -14,7 +14,7 @@ Set() = Set{Any}()
 function Set{T}(s::KeySet{T, <:Dict{T}}) where {T}
     d = s.dict
     slots = copy(d.slots)
-    keys = copyto!(similar(d.keys, T), d.keys)
+    keys = copy(d.keys)
     vals = similar(d.vals, Nothing)
     unsafe_set(Dict{T,Nothing}(slots, keys, vals, d.ndel, d.count, d.age, d.idxfloor, d.maxprobe))
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -11,7 +11,7 @@ Set{T}(s::Set{T}) where {T} = unsafe_set(Dict{T,Nothing}(s.dict))
 Set{T}(itr) where {T} = union!(Set{T}(), itr)
 Set() = Set{Any}()
 
-function Set{T}(s::KeySet) where {T}
+function Set{T}(s::KeySet{T, <:Dict{T}}) where {T}
     d = s.dict
     slots = copy(d.slots)
     keys = copyto!(similar(d.keys, T), d.keys)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -138,6 +138,10 @@ end
     @test !in(200,s)
 end
 
+@testset "copy(::KeySet) (issue #41537)" begin
+    @test union(keys(Dict(1=>2, 3=>4))) == copy(keys(Dict(1=>2, 3=>4))) == Set([1,3])
+end
+
 @testset "copy!" begin
     for S = (Set, BitSet)
         s = S([1, 2])


### PR DESCRIPTION
~Fixes #41537.~ Fixes #30307.

This adds `copy(::KeySet)` which is currently not defined. With this PR, it returns a `Set`.

In order to speed it up, a specialized `Set{T}(::KeySet)` constructor is added. To make this possible, the inner constructors of `Set` are replaced by an `unsafe_set` function.