### PR TITLE
Fix a precision issue in `abstract_iteration`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -873,16 +873,25 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
     # (widened) stateordonet, which has not yet been fully analyzed in the loop above
     statetype = Bottom
     valtype = Bottom
+    may_have_terminated = Nothing <: stateordonet
     while valtype !== Any
-        nounion = typesubtract(stateordonet, Nothing, 0)
-        if !isa(nounion, DataType) || !(nounion <: Tuple) || isvatuple(nounion) || length(nounion.parameters) != 2
+        nounion = typeintersect(stateordonet, Tuple{Any,Any})
+        if nounion !== Union{} && !isa(nounion, DataType)
+            # nounion is of a type we cannot handle
             valtype = Any
             break
         end
-        if nounion.parameters[1] <: valtype && nounion.parameters[2] <: statetype
+        if nounion === Union{} || (nounion.parameters[1] <: valtype && nounion.parameters[2] <: statetype)
+            # reached a fixpoint or iterator failed/gave invalid answer
             if typeintersect(stateordonet, Nothing) === Union{}
-                # Reached a fixpoint, but Nothing is not possible => iterator is infinite or failing
-                return Any[Bottom], nothing
+                # ... but cannot terminate
+                if !may_have_terminated
+                    #  ... and cannot have terminated prior to this loop
+                    return Any[Bottom], nothing
+                else
+                    # iterator may have terminated prior to this loop, but not during it
+                    valtype = Bottom
+                end
             end
             break
         end
@@ -891,7 +900,9 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
         stateordonet = abstract_call_known(interp, iteratef, nothing, Any[Const(iteratef), itertype, statetype], sv).rt
         stateordonet = widenconst(stateordonet)
     end
-    push!(ret, Vararg{valtype})
+    if valtype !== Union{}
+        push!(ret, Vararg{valtype})
+    end
     return ret, nothing
 end
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -867,13 +867,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
     end
     # From here on, we start asking for results on the widened types, rather than
     # the precise (potentially const) state type
-    statetype = widenconst(statetype)
     valtype = widenconst(valtype)
-    if statetype === Bottom
-        stateordonet = abstract_call_known(interp, iteratef, nothing, Any[Const(iteratef), itertype], sv).rt
-    else
-        stateordonet = abstract_call_known(interp, iteratef, nothing, Any[Const(iteratef), itertype, statetype], sv).rt
-    end
     while valtype !== Any
         stateordonet = widenconst(stateordonet)
         nounion = typesubtract(stateordonet, Nothing, 0)
@@ -881,7 +875,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
             valtype = Any
             break
         end
-        if nounion.parameters[1] <: valtype && nounion.parameters[2] <: statetype
+        if nounion.parameters[1] <: valtype && nounion.parameters[2] ⊑ statetype
             if typeintersect(stateordonet, Nothing) === Union{}
                 # Reached a fixpoint, but Nothing is not possible => iterator is infinite or failing
                 return Any[Bottom], nothing

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2875,6 +2875,7 @@ partial_return_2(x) = Val{partial_return_1(x)[2]}
 # Precision of abstract_iteration
 f_splat(x) = (x...,)
 @test Base.return_types(f_splat, (Pair{Int,Int},)) == Any[Tuple{Int, Int}]
+@test Base.return_types(f_splat, (UnitRange{Int},)) == Any[Tuple{Vararg{Int}}]
 
 # issue #32699
 f32699(a) = (id = a[1],).id

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2878,6 +2878,18 @@ f41839() = (1:100...,)
 f_splat(x) = (x...,)
 @test Base.return_types(f_splat, (Pair{Int,Int},)) == Any[Tuple{Int, Int}]
 @test Base.return_types(f_splat, (UnitRange{Int},)) == Any[Tuple{Vararg{Int}}]
+struct Itr41839_1 end # empty or infinite
+Base.iterate(::Itr41839_1) = rand(Bool) ? (nothing, nothing) : nothing
+Base.iterate(::Itr41839_1, ::Nothing) = (nothing, nothing)
+@test Base.return_types(f_splat, (Itr41839_1,)) == Any[Tuple{}]
+struct Itr41839_2 end # empty or failing
+Base.iterate(::Itr41839_2) = rand(Bool) ? (nothing, nothing) : nothing
+Base.iterate(::Itr41839_2, ::Nothing) = error()
+@test Base.return_types(f_splat, (Itr41839_2,)) == Any[Tuple{}]
+struct Itr41839_3 end
+Base.iterate(::Itr41839_3 ) = rand(Bool) ? nothing : (nothing, 1)
+Base.iterate(::Itr41839_3 , i) = i < 16 ? (i, i + 1) : nothing
+@test only(Base.return_types(f_splat, (Itr41839_3,))) <: Tuple{Vararg{Union{Nothing, Int}}}
 
 # issue #32699
 f32699(a) = (id = a[1],).id

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2872,7 +2872,9 @@ partial_return_2(x) = Val{partial_return_1(x)[2]}
 
 @test Base.return_types(partial_return_2, (Int,)) == Any[Type{Val{1}}]
 
-# Precision of abstract_iteration
+# Soundness and precision of abstract_iteration
+f41839() = (1:100...,)
+@test NTuple{100,Int} <: only(Base.return_types(f41839, ())) <: Tuple{Vararg{Int}}
 f_splat(x) = (x...,)
 @test Base.return_types(f_splat, (Pair{Int,Int},)) == Any[Tuple{Int, Int}]
 @test Base.return_types(f_splat, (UnitRange{Int},)) == Any[Tuple{Vararg{Int}}]


### PR DESCRIPTION
The first loop is left before `valtype` and `statetype` are updated from the current `stateordonet`, so the second loop should first process it before obtaining a new one instead of vice versa.

Fixes #41022.