### PR TITLE
Range construction with colon, one, and zero

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -376,3 +376,32 @@ Complex{BigInt}
 ```
 """
 big(::Type{T}) where {T<:Number} = typeof(big(zero(T)))
+
+# Range construction with colon, one, and zero
+
+# start isa typeof(zero)
+(:)(::typeof(zero), stop::T) where {T<:Real} = zero(stop):stop
+(:)(::typeof(zero), step, stop::T) where {T<:Real} = zero(stop):step:stop
+(:)(::typeof(zero), ::typeof(one), stop::T) where {T<:Real} = zero(stop):stop
+
+# start isa typeof(one)
+(:)(::typeof(one), stop::T) where {T<:Integer} = Base.OneTo(stop)
+(:)(::typeof(one), stop::T) where {T<:Real} = one(stop):stop
+(:)(::typeof(one), step, stop::T) where {T<:Real} = one(stop):step:stop
+(:)(::typeof(one), ::typeof(one), stop::T) where {T<:Real} = one(stop):stop
+
+# step isa typeof(one), also see above
+(:)(start::A, ::typeof(one), stop::C) where {A<:Real,C<:Real} = start:stop
+(:)(a::T, b::typeof(one), c::T) where {T<:Real} = a:c
+(:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
+(:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
+
+# stop isa typeof(zero)
+(:)(start::T, ::typeof(zero)) where {T<:Real} = start:zero(start)
+(:)(start::T, step, ::typeof(zero)) where {T<:Real} = start:step:zero(start)
+(:)(start::T, ::typeof(one), ::typeof(zero)) where {T<:Real} = start:zero(start)
+
+# stop isa typeof(one)
+(:)(start::T, ::typeof(one)) where {T<:Real} = start:one(start)
+(:)(start::T, step, ::typeof(one)) where {T<:Real} = start:step:one(start)
+(:)(start::T, ::typeof(one), ::typeof(one)) where {T<:Real} = start:one(start)

--- a/base/range.jl
+++ b/base/range.jl
@@ -31,7 +31,7 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
 """
     (:)(start, [step], stop)
 
-Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1 (a [`UnitRange`](@ref))
+Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1 (a [`AbstractUnitRange`](@ref))
 , and `a:s:b` is similar but uses a step size of `s` (a [`StepRange`](@ref)).
 
 `:` is also used in indexing to select whole dimensions
@@ -45,6 +45,23 @@ function _colon(start::T, step, stop::T) where T
     T′ = typeof(start+zero(step))
     StepRange(convert(T′,start), step, convert(T′,stop))
 end
+
+# start isa typeof(zero)
+(:)(::typeof(zero), stop::T) where {T<:Real} = zero(stop):stop
+(:)(::typeof(zero), step, stop::T) where {T<:Real} = zero(stop):step:stop
+(:)(::typeof(zero), ::typeof(one), stop::T) where {T<:Real} = zero(stop):stop
+
+# start isa typeof(one)
+(:)(::typeof(one), stop::T) where {T<:Integer} = Base.OneTo(stop)
+(:)(::typeof(one), stop::T) where {T<:Real} = one(stop):stop
+(:)(::typeof(one), step, stop::T) where {T<:Real} = one(stop):step:stop
+(:)(::typeof(one), ::typeof(one), stop::T) where {T<:Real} = one(stop):stop
+
+# step isa typeof(one), also see above
+(:)(start::A, ::typeof(one), stop::C) where {A<:Real,C<:Real} = start:stop
+(:)(a::T, b::typeof(one), c::T) where {T<:Real} = a:c
+(:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
+(:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
 
 """
     range(start, stop, length)

--- a/base/range.jl
+++ b/base/range.jl
@@ -46,33 +46,6 @@ function _colon(start::T, step, stop::T) where T
     StepRange(convert(T′,start), step, convert(T′,stop))
 end
 
-# start isa typeof(zero)
-(:)(::typeof(zero), stop::T) where {T<:Real} = zero(stop):stop
-(:)(::typeof(zero), step, stop::T) where {T<:Real} = zero(stop):step:stop
-(:)(::typeof(zero), ::typeof(one), stop::T) where {T<:Real} = zero(stop):stop
-
-# start isa typeof(one)
-(:)(::typeof(one), stop::T) where {T<:Integer} = Base.OneTo(stop)
-(:)(::typeof(one), stop::T) where {T<:Real} = one(stop):stop
-(:)(::typeof(one), step, stop::T) where {T<:Real} = one(stop):step:stop
-(:)(::typeof(one), ::typeof(one), stop::T) where {T<:Real} = one(stop):stop
-
-# step isa typeof(one), also see above
-(:)(start::A, ::typeof(one), stop::C) where {A<:Real,C<:Real} = start:stop
-(:)(a::T, b::typeof(one), c::T) where {T<:Real} = a:c
-(:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
-(:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
-
-# stop isa typeof(zero)
-(:)(start::T, ::typeof(zero)) where {T<:Real} = start:zero(start)
-(:)(start::T, step, ::typeof(zero)) where {T<:Real} = start:step:zero(start)
-(:)(start::T, ::typeof(one), ::typeof(zero)) where {T<:Real} = start:zero(start)
-
-# stop isa typeof(one)
-(:)(start::T, ::typeof(one)) where {T<:Real} = start:one(start)
-(:)(start::T, step, ::typeof(one)) where {T<:Real} = start:step:one(start)
-(:)(start::T, ::typeof(one), ::typeof(one)) where {T<:Real} = start:one(start)
-
 """
     range(start, stop, length)
     range(start, stop; length, step)

--- a/base/range.jl
+++ b/base/range.jl
@@ -63,6 +63,16 @@ end
 (:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
 (:)(a::T, b::typeof(one), c::T) where {T<:AbstractFloat} = a:c
 
+# stop isa typeof(zero)
+(:)(start::T, ::typeof(zero)) where {T<:Real} = start:zero(start)
+(:)(start::T, step, ::typeof(zero)) where {T<:Real} = start:step:zero(start)
+(:)(start::T, ::typeof(one), ::typeof(zero)) where {T<:Real} = start:zero(start)
+
+# stop isa typeof(one)
+(:)(start::T, ::typeof(one)) where {T<:Real} = start:one(start)
+(:)(start::T, step, ::typeof(one)) where {T<:Real} = start:step:one(start)
+(:)(start::T, ::typeof(one), ::typeof(one)) where {T<:Real} = start:one(start)
+
 """
     range(start, stop, length)
     range(start, stop; length, step)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -232,6 +232,51 @@ end
         @inferred((:)(0.0, -0.5))
     end
 
+    @testset "one:?step:stop" begin
+        @inferred((:)(one, 1, 0))
+        @inferred((:)(one, .2, 2))
+        @inferred((:)(one, .2, 2.))
+        @inferred((:)(one, -.2, 1))
+        @inferred((:)(one, 0))
+        @inferred((:)(one, -0.5))
+    end
+
+    @testset "zero:?step:stop" begin
+        @inferred((:)(zero, 1, 0))
+        @inferred((:)(zero, .2, 2))
+        @inferred((:)(zero, .2, 2.))
+        @inferred((:)(zero, -.2, 1))
+        @inferred((:)(zero, 0))
+        @inferred((:)(zero, -0.5))
+    end
+
+    @testset "start:one:stop" begin
+        @inferred((:)(10, one, 0))
+        @inferred((:)(1, one, 2))
+        @inferred((:)(1., one, 2.))
+        @inferred((:)(2, one, 1))
+        @inferred((:)(1, one, 0))
+        @inferred((:)(0.0, one, -0.5))
+    end
+
+    @testset "one:one:stop" begin
+        @inferred((:)(one, one, 0))
+        @inferred((:)(one, one, 2))
+        @inferred((:)(one, one, 2.))
+        @inferred((:)(one, one, 1))
+        @inferred((:)(one, one, 0))
+        @inferred((:)(one, one, -0.5))
+    end
+
+    @testset "zero:one:stop" begin
+        @inferred((:)(zero, one, 0))
+        @inferred((:)(zero, one, 2))
+        @inferred((:)(zero, one, 2.))
+        @inferred((:)(zero, one, 1))
+        @inferred((:)(zero, one, 0))
+        @inferred((:)(zero, one, -0.5))
+    end
+
     @testset "indexing" begin
         L32 = @inferred(range(Int32(1), stop=Int32(4), length=4))
         L64 = @inferred(range(Int64(1), stop=Int64(4), length=4))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -277,6 +277,30 @@ end
         @inferred((:)(zero, one, -0.5))
     end
 
+    @testset "start:?step:one" begin
+        @inferred((:)(-5, 1, one))
+        @inferred((:)(-3.2, .2, one))
+        @inferred((:)(0., .2, one))
+        @inferred((:)(-3, -.2, one))
+        @inferred((:)(1, one))
+        @inferred((:)(0.0, one))
+        @inferred((:)(0, one, one))
+        @inferred((:)(-3., one, one))
+    end
+
+    @testset "start:?step:zero" begin
+        @inferred((:)(-5, 1, zero))
+        @inferred((:)(-3.2, .2, zero))
+        @inferred((:)(0., .2, zero))
+        @inferred((:)(-3, -.2, zero))
+        @inferred((:)(1, zero))
+        @inferred((:)(0.0, zero))
+        @inferred((:)(-3, one, zero))
+        @inferred((:)(-3.2, one, zero))
+    end
+
+
+
     @testset "indexing" begin
         L32 = @inferred(range(Int32(1), stop=Int32(4), length=4))
         L64 = @inferred(range(Int64(1), stop=Int64(4), length=4))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -299,8 +299,6 @@ end
         @inferred((:)(-3.2, one, zero))
     end
 
-
-
     @testset "indexing" begin
         L32 = @inferred(range(Int32(1), stop=Int32(4), length=4))
         L64 = @inferred(range(Int64(1), stop=Int64(4), length=4))


### PR DESCRIPTION
Currently in `Base`, we have the methods `one` and `zero`. Implicitly, we also then have the types `typeof(one)` and `typeof(zero)`. In this pull request, we dispatch `(:)` on `typeof(one)` and `typeof(zero)`.

When `one` is used as `start`, `start` is `one(stop)`. Likewise for `zero`.
When `one` is used as `stop`, `stop` is `one(start)`. Likewise for `zero`.
When `one` is used as `step`, it is equivalent to `start:stop`.

`one:(stop::T) where {T <: Integer}` returns a `Base.OneTo`.

It's not clear to me where the best place to document this behavior is at the moment.

Concepts here were developed in during a [conversation](https://github.com/JuliaLang/julia/pull/39241#issuecomment-826388100) with @oschulz .

