### PR TITLE
Slight improvement to type-stability of `StackTraces.lookup`

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -133,7 +133,7 @@ function lookup(ip::Union{Base.InterpreterIP,Core.Compiler.InterpreterIP})
     else
         func = top_level_scope_sym
         file = empty_sym
-        line = 0
+        line = Int32(0)
     end
     i = max(ip.stmt+1, 1)  # ip.stmt is 0-indexed
     if i > length(codeinfo.codelocs) || codeinfo.codelocs[i] == 0


### PR DESCRIPTION
I was playing around with SnoopCompile and came across the `StackTraces.lookup` function (that I don't really know what is doing - but it featured non-negligibly in PyCall precompile time). 
I noticed that there was a slight type-instability in the `line` variable since the if-else statement in one cases branches to `line = meth.line` where `meth::Method` and `fieldtype(Method, :line) == Int32` and in the other case branches to `0::Int`. This fixes that.