### PR TITLE
CI (Buildbot, GHA): Simplify the `permissions` key in the workflow file for the "Statuses" workflow

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -31,16 +31,6 @@ on:
 # We should only give the token the minimum necessary set of permissions.
 permissions:
   statuses:            write
-  actions:             none
-  checks:              none
-  contents:            none
-  deployments:         none
-  issues:              none
-  discussions:         none
-  packages:            none
-  pull-requests:       none
-  repository-projects: none
-  security-events:     none
 
 jobs:
   statuses:

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -30,7 +30,7 @@ on:
 # These are the permissions for the `GITHUB_TOKEN` token.
 # We should only give the token the minimum necessary set of permissions.
 permissions:
-  statuses:            write
+  statuses: write
 
 jobs:
   statuses:


### PR DESCRIPTION
According to the GitHub documentation (https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token):

> You can use the `permissions` key in your workflow file to modify permissions for the `GITHUB_TOKEN` for an entire workflow or for individual jobs. This allows you to configure the minimum required permissions for a workflow or job. When the `permissions` key is used, all unspecified permissions are set to no access, with the exception of the `metadata` scope, which always gets read access.

Therefore, if we just set `statuses: write`, all of the other permissions will automatically be set to no access. 