### PR TITLE
mention typeof functions in types docs

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1132,20 +1132,23 @@ true
 
 Types of functions defined at top-level are singletons. When necessary, you can compare them with [`===`](@ref).
 
-[Closures](@ref Closures) also have their own type, which is usually printed with names that end in `#<number>`. Names and types for separately defined closures are distinct, but not guaranteed to be the same across sessions.
+[Anonymous functions](@id man-anonymous-functions) also have their own type, which is usually printed with names that end in `#<number>`. Names and types for functions defined at different locations are distinct, but not guaranteed to be printed the same way across sessions.
 
 ```jldoctest; filter = r"[0-9\.]+"
 julia> typeof(x -> x + 1)
 var"#9#10"
 ```
 
-Types of closures are not necessarily singletons, for example in cases where a variable is captured.
+Types of [closures](@ref Closures) are not necessarily singletons.
 
 ```jldoctest
 julia> addy(y) = x -> x + y
 addy (generic function with 1 method)
 
 julia> Base.issingletontype(addy(1))
+false
+
+julia> addy(1) === addy(2)
 false
 ```
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1139,7 +1139,7 @@ julia> typeof(x -> x + 1)
 var"#9#10"
 ```
 
-Types of anonymous function are not necessarily singletons, for example in cases where a variable is captured.
+Types of closures are not necessarily singletons, for example in cases where a variable is captured.
 
 ```jldoctest
 julia> addy(y) = x -> x + y

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1112,7 +1112,7 @@ true
 
 Each function has its own type, which is a subtype of `Function`.
 
-```jldoctest
+```jldoctest foo41
 julia> foo41(x) = x + 1
 foo41 (generic function with 1 method)
 
@@ -1122,7 +1122,7 @@ typeof(foo41) (singleton type of function foo41, subtype of Function)
 
 Note how `typeof(foo41)` prints as itself. This is merely a convention for printing, as it is a first-class object that can be used like any other value:
 
-```jldoctest
+```jldoctest foo41
 julia> T = typeof(foo41)
 typeof(foo41) (singleton type of function foo41, subtype of Function)
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1130,7 +1130,7 @@ julia> T <: Function
 true
 ```
 
-Types of functions are singletons. When necessary, you can compare them with [`===`](@ref).
+Types of functions defined at top-level are singletons. When necessary, you can compare them with [`===`](@ref).
 
 [Anonymous functions](@ref man-anonymous-functions) also have their own type, which is printed with names that include `#<number>`. Numbers for different function types are distinct, but not guaranteed to be the same across sessions.
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1132,14 +1132,14 @@ true
 
 Types of functions defined at top-level are singletons. When necessary, you can compare them with [`===`](@ref).
 
-[Anonymous functions](@id man-anonymous-functions) also have their own type, which is usually printed with names that end in `#<number>`. Names and types for functions defined at different locations are distinct, but not guaranteed to be printed the same way across sessions.
+[Closures](@id man-anonymous-functions) also have their own type, which is usually printed with names that end in `#<number>`. Names and types for functions defined at different locations are distinct, but not guaranteed to be printed the same way across sessions.
 
 ```jldoctest; filter = r"[0-9\.]+"
 julia> typeof(x -> x + 1)
 var"#9#10"
 ```
 
-Types of [closures](@ref Closures) are not necessarily singletons.
+Types of closures are not necessarily singletons.
 
 ```jldoctest
 julia> addy(y) = x -> x + y

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1132,7 +1132,7 @@ true
 
 Types of functions defined at top-level are singletons. When necessary, you can compare them with [`===`](@ref).
 
-[Anonymous functions](@ref man-anonymous-functions) also have their own type, which is printed with names that include `#<number>`. Numbers for different function types are distinct, but not guaranteed to be the same across sessions.
+[Closures](@ref Closures) also have their own type, which is usually printed with names that end in `#<number>`. Names and types for separately defined closures are distinct, but not guaranteed to be the same across sessions.
 
 ```jldoctest; filter = r"[0-9\.]+"
 julia> typeof(x -> x + 1)

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1108,7 +1108,7 @@ julia> NoFieldsParam{Int}() === NoFieldsParam{Int}()
 true
 ```
 
-## Types of functions and closures (anonymous functions)
+## Types of functions
 
 Each function has its own type, which is a subtype of `Function`.
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1114,7 +1114,7 @@ Each function has its own type, which is a subtype of `Function`.
 
 ```jldoctest
 julia> foo41(x) = x + 1
-foo (generic function with 1 method)
+foo41 (generic function with 1 method)
 
 julia> typeof(foo41)
 typeof(foo41) (singleton type of function foo41, subtype of Function)

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1108,6 +1108,47 @@ julia> NoFieldsParam{Int}() === NoFieldsParam{Int}()
 true
 ```
 
+## Types of functions and closures (anonymous functions)
+
+Each function has its own type, which is a subtype of `Function`.
+
+```jldoctest
+julia> foo41(x) = x + 1
+foo (generic function with 1 method)
+
+julia> typeof(foo41)
+typeof(foo41) (singleton type of function foo41, subtype of Function)
+```
+
+Note how `typeof(foo41)` prints as itself. This is merely a convention for printing, as it is a first-class object that can be used like any other value:
+
+```jldoctest
+julia> T = typeof(foo41)
+typeof(foo41) (singleton type of function foo41, subtype of Function)
+
+julia> T <: Function
+true
+```
+
+Types of functions are singletons. When necessary, you can compare them with [`===`](@ref).
+
+[Anonymous functions](@ref man-anonymous-functions) also have their own type, which is printed with names that include `#<number>`. Numbers for different function types are distinct, but not guaranteed to be the same across sessions.
+
+```jldoctest; filter = r"[0-9\.]+"
+julia> typeof(x -> x + 1)
+var"#9#10"
+```
+
+Types of anonymous function are not necessarily singletons, for example in cases where a variable is captured.
+
+```jldoctest
+julia> addy(y) = x -> x + y
+addy (generic function with 1 method)
+
+julia> Base.issingletontype(addy(1))
+false
+```
+
 ## [`Type{T}` type selectors](@id man-typet-type)
 
 For each type `T`, `Type{T}` is an abstract parametric type whose only instance is the


### PR DESCRIPTION
- mention `typeof` functions in the types section of the manual, with an example
- explain that `typeof(foo)` is merely how it is printed
- also add examples for `typeof` anonymous functions, add an example which is not a singleton