### PR TITLE
Get rid of unnecessary use of static parameter in ccall

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -62,7 +62,7 @@ unsafe_convert(::Type{Ptr{Int8}}, s::String) = ccall(:jl_string_ptr, Ptr{Int8}, 
 cconvert(::Type{Ptr{UInt8}}, s::AbstractString) = String(s)
 cconvert(::Type{Ptr{Int8}}, s::AbstractString) = String(s)
 
-unsafe_convert(::Type{Ptr{T}}, a::Array{T}) where {T} = ccall(:jl_array_ptr, Ptr{T}, (Any,), a)
+unsafe_convert(::Type{Ptr{T}}, a::Array{T}) where {T} = Ptr{T}(ccall(:jl_array_ptr, Ptr{Cvoid}, (Any,), a))
 unsafe_convert(::Type{Ptr{S}}, a::AbstractArray{T}) where {S,T} = convert(Ptr{S}, unsafe_convert(Ptr{T}, a))
 unsafe_convert(::Type{Ptr{T}}, a::AbstractArray{T}) where {T} = error("conversion to pointer not defined for $(typeof(a))")
 


### PR DESCRIPTION
`ccall` has some special magic to instantiate type parameters in argument
and return types. However, this is not particularly robust. It is the only place
that doesn't use `Expr(:static_parameter)` to access type parameters and
the applicability is limited. Moreover, it has semantic problems, because the
C signature doesn't actually change depending on the static parameter type
and the ccall should really represent the C signature.

Get rid of one unnecessary instance of this pattern I happened to stumble over
(though there's a couple more in the codebase).