### PR TITLE
MINSIGSTKSZ is no longer constant in glibc

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
+#include <unistd.h>
 #include <errno.h>
 #include <inttypes.h>
 #include "julia.h"
@@ -67,8 +68,8 @@ static inline void tsan_switch_to_ctx(void *state)  {
 
 // empirically, jl_finish_task needs about 64k stack space to infer/run
 // and additionally, gc-stack reserves 64k for the guard pages
-#if defined(MINSIGSTKSZ) && MINSIGSTKSZ > 131072
-#define MINSTKSZ MINSIGSTKSZ
+#if defined(MINSIGSTKSZ)
+#define MINSTKSZ (MINSIGSTKSZ > 131072 ? MINSIGSTKSZ : 131072)
 #else
 #define MINSTKSZ 131072
 #endif


### PR DESCRIPTION
`MINSIGSTKSZ` is redefined to `sysconf(_SC_MINSIGSTKSZ)` starting from glibc 2.34.

Fix https://github.com/JuliaLang/julia/issues/41806.