### PR TITLE
Force type stability of `_invoked_shouldlog` & friends for non-concrete loggers

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -79,15 +79,15 @@ function _invoked_shouldlog(logger, level, _module, group, id)
         shouldlog,
         Tuple{typeof(logger), typeof(level), typeof(_module), typeof(group), typeof(id)},
         logger, level, _module, group, id
-    )
+    )::Bool
 end
 
 function _invoked_min_enabled_level(@nospecialize(logger))
-    return invoke(min_enabled_level, Tuple{typeof(logger)}, logger)
+    return invoke(min_enabled_level, Tuple{typeof(logger)}, logger)::LogLevel
 end
 
 function _invoked_catch_exceptions(@nospecialize(logger))
-    return invoke(catch_exceptions, Tuple{typeof(logger)}, logger)
+    return invoke(catch_exceptions, Tuple{typeof(logger)}, logger)::Bool
 end
 
 """


### PR DESCRIPTION
I noticed `_invoked_shouldlog` appearing in some type-instabilities/inference-triggers for some `@test`-code I ran (via SnoopCompile).
It seems that `_invoked_shouldlog` & friends can get called with a `logger` that is not inferred at the call-site (e.g., because it is derived from a `LogState` whose `logger`-field is abstractly typed as `AbstractLogger`) which causes the output of `_invoked_shouldlog` to be inferred as `Any`, cf. 
```jl
julia> code_warntype(Base.CoreLogging._invoked_shouldlog, (Base.CoreLogging.AbstractLogger, Base.CoreLogging.LogLevel, Module, Symbol, Symbol))
  [... omitted ...]
Arguments
  #self#::Core.Const(Base.CoreLogging._invoked_shouldlog)
  logger::Base.CoreLogging.AbstractLogger
  level::Base.CoreLogging.LogLevel
  _module::Module
  group::Symbol
  id::Symbol
Body::Any
  [... omitted ...]
│   %8 = Base.CoreLogging.invoke(Base.CoreLogging.shouldlog, %7, logger, level, _module, group, id)::Any
└──      return %8
```
From the descriptions and use of `shouldlog`, `min_enabled_level`, and `catch_exceptions`, it seems their output actually must be `Bool`, `LogLevel`, and `Bool`, respectively. So I just added type-assertions to that effect, which should then halt the inference-issues at the call-site (and have no effect if called with an inferred logger).

Maybe @timholy would have a good idea whether this is reasonable cf. https://github.com/JuliaLang/julia/pull/35714?