### PR TITLE
CI (Buildkite): `llvmpasses`: use the latest rootfs image

### DIFF
--- a/.buildkite/pipelines/main/misc/llvmpasses.yml
+++ b/.buildkite/pipelines/main/misc/llvmpasses.yml
@@ -33,8 +33,8 @@ steps:
       - JuliaCI/julia#v1:
           version: 1.6
       - staticfloat/sandbox#v1:
-          rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v3.1/package_linux.x86_64.tar.gz
-          rootfs_treehash: "8c33c341a864852629b8aac01a6eb6a79b73570e"
+          rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v3.8/package_linux.x86_64.tar.gz
+          rootfs_treehash: "84a323ae8fcc724f8ea5aca5901bbbf4bda3e519"
           uid: 1000
           gid: 1000
           workspaces:


### PR DESCRIPTION
This should fix the broken `llvmpasses` job on the `release-1.6` branch.