### PR TITLE
Reduce invalidations in deserialization

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -827,6 +827,7 @@ jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi JL_PROPAGATES_RO
 JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *type, size_t world);
 JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(
     jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams);
+void jl_invalidate_method_instance(jl_method_instance_t *replaced, size_t max_world, int depth);
 JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, jl_method_instance_t *caller);
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_value_t *caller);
 


### PR DESCRIPTION
This is more of an issue than a PR perhaps, but I had to try to fix it to get a handle on it. So let me take my attempt and turn it into a PR for the sake of discussion.

So here is the issue (ref. https://github.com/JuliaLang/julia/issues/38983#issuecomment-896843258): We start from a package with the followeing (pathological) content:
```julia
module Foo

foo(x=1) = hcat(x)

@assert precompile(foo, ())

end # module
```
Now, in a fresh session (after `using Foo` once in another session to trigger precompilation):
```julia
julia> using SnoopCompile, AbstractTrees

julia> @snoopr using Foo
Any[] # we precompiled Foo.foo() and it wasn't invalidated, so ...

julia> print_tree(@snoopi_deep(Foo.foo()), maxdepth=3) # this shows inference don't doing anything, right?
InferenceTimingNode: 0.015228/0.061387 on Core.Compiler.Timings.ROOT() with 1 direct children
└─ InferenceTimingNode: 0.000138/0.046158 on Foo.foo() with 1 direct children
   └─ InferenceTimingNode: 0.000199/0.046021 on Foo.foo(1::Int64) with 2 direct children
      ├─ InferenceTimingNode: 0.000840/0.045254 on hcat(::Int64) with 13 direct children
      │  ⋮
      │  
      └─ InferenceTimingNode: 0.000526/0.000568 on hcat((1,)::Int64) with 1 direct children
         ⋮
```
So why does inference basically start over here? Here is my analysis:
Upon deserialization, we first mark all `CodeInstance`s invalid. Then we go and check all methods whether they have been invalidated by external callees. If not, we mark them valid. But we only do this for methods which actually have external callees. In this case, that means we check `foo(::Int)` and find it is still valid. But we never check `foo()`, leaving it marked as invalid. And as it is never actually invalidated by anything, `@snoopr` cannot report it. But then it needs to be re-inferred when called, which thanks to constant propagation and omission of the inlined `hcat(::Int)` method from the cache becomes relatively heavy.

So what I try to achieve with this change is to reverse that logic and first consider everything valid until it gets detected as invalidated. For methods with external callees this is pretty straight-forward, but we need to consider that if one of these gets invalidated, we have to propagate the invalidation to its callers (which might not have external callees themselves). Luckily, we have the backedges recorded to do just this. So with this patch I get the expected:

```julia
julia> using SnoopCompile, AbstractTrees

julia> @snoopr using Foo
Any[]

julia> print_tree(@snoopi_deep(Foo.foo()), maxdepth=3)
InferenceTimingNode: 0.016345/0.016345 on Core.Compiler.Timings.ROOT() with 0 direct children
```
Invalidation still seems to be working:
```julia
julia> Base.hcat(::Int) = "oops"

julia> using SnoopCompile, AbstractTrees

julia> @snoopr using Foo
4-element Vector{Any}:
  MethodInstance for Foo.foo()
 1
  MethodInstance for Foo.foo(::Int64)
  "insert_backedges"

julia> print_tree(@snoopi_deep(Foo.foo()), maxdepth=3)
InferenceTimingNode: 0.015316/0.015540 on Core.Compiler.Timings.ROOT() with 1 direct children
└─ InferenceTimingNode: 0.000078/0.000224 on Foo.foo() with 1 direct children
   └─ InferenceTimingNode: 0.000095/0.000146 on Foo.foo(::Int64) with 1 direct children
      └─ InferenceTimingNode: 0.000051/0.000051 on hcat(::Int64) with 0 direct children
         ⋮
  ```

@vtjnash is that reasoning valid and if so, does the implementation strategy look reasonable? Also cc @timholy.

One thing I should add is that the effect on real-world packages seems to be rather limited. But would still be nice to have this sorted out, if only too avoid distraction when trying to figure out why one's precompile statements don't have the desired effect---which is what brought me here...