### PR TITLE
Clarify AbstractRNG documentation

### DIFF
--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -13,7 +13,7 @@ The PRNGs (pseudorandom number generators) exported by the `Random` package are:
 * `TaskLocalRNG`: a token that represents use of the currently active Task-local stream, deterministically seeded from the parent task, or by `RandomDevice` (with system randomness) at program start
 * `Xoshiro`: generates a high-quality stream of random numbers with a small state vector and high performance using the Xoshiro256++ algorithm
 * `RandomDevice`: for OS-provided entropy. This may be used for cryptographically secure random numbers (CS(P)RNG).
-* `MersenneTwister`: for backward compatibility (usually slower and worse quality than Xoshiro).
+* `MersenneTwister`: an alternate high-quality PRNG which was the default in older versions of Julia, and is also quite fast, but requires much more space to store the state vector and generate a random sequence.
 
 Most functions related to random generation accept an optional `AbstractRNG` object as first argument.
 Some also accept dimension specifications `dims...` (which can also be given as a tuple) to generate

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -13,7 +13,7 @@ The types exported by the `Random` package are:
 * `TaskLocalRNG`: the default with 1 stream per task.
 * `Xoshiro`: for explicitly-managed Xoshiro256++ streams.
 * `RandomDevice`: for OS-provided entropy. This should be used for cryptographically secure random numbers (CPR.
-* `MersenneTwister`: for backward compatibility (slower and worse quality than Xoshiro).
+* `MersenneTwister`: for backward compatibility (usually slower and worse quality than Xoshiro).
 
 Most functions related to random generation accept an optional `AbstractRNG` object as first argument.
 Some also accept dimension specifications `dims...` (which can also be given as a tuple) to generate

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -10,7 +10,7 @@ Other RNG types can be plugged in by inheriting the `AbstractRNG` type; they can
 obtain multiple streams of random numbers.
 
 The PRNGs (pseudorandom number generators) exported by the `Random` package are:
-* `TaskLocalRNG`: a token that represents use of the currently active Task-local stream, deterministically seeded from the parent task, or by RandomDevice (with system randomness) at program start
+* `TaskLocalRNG`: a token that represents use of the currently active Task-local stream, deterministically seeded from the parent task, or by `RandomDevice` (with system randomness) at program start
 * `Xoshiro`: for explicitly-managed Xoshiro256++ streams.
 * `RandomDevice`: for OS-provided entropy. This may be used for cryptographically secure random numbers (CS(P)RNG).
 * `MersenneTwister`: for backward compatibility (usually slower and worse quality than Xoshiro).

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -12,7 +12,7 @@ obtain multiple streams of random numbers.
 The types exported by the `Random` package are:
 * `TaskLocalRNG`: the default with 1 stream per task.
 * `Xoshiro`: for explicitly-managed Xoshiro256++ streams.
-* `RandomDevice`: for OS-provided entropy. This should be used for cryptographically secure random numbers (CPR.
+* `RandomDevice`: for OS-provided entropy. This may be used for cryptographically secure random numbers (CS(P)RNG).
 * `MersenneTwister`: for backward compatibility (usually slower and worse quality than Xoshiro).
 
 Most functions related to random generation accept an optional `AbstractRNG` object as first argument.

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -9,7 +9,7 @@ by default, with per-`Task` state.
 Other RNG types can be plugged in by inheriting the `AbstractRNG` type; they can then be used to
 obtain multiple streams of random numbers.
 
-The types exported by the `Random` package are:
+The PRNGs (pseudorandom number generators) exported by the `Random` package are:
 * `TaskLocalRNG`: the default with 1 stream per task.
 * `Xoshiro`: for explicitly-managed Xoshiro256++ streams.
 * `RandomDevice`: for OS-provided entropy. This may be used for cryptographically secure random numbers (CS(P)RNG).

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -11,7 +11,7 @@ obtain multiple streams of random numbers.
 
 The PRNGs (pseudorandom number generators) exported by the `Random` package are:
 * `TaskLocalRNG`: a token that represents use of the currently active Task-local stream, deterministically seeded from the parent task, or by `RandomDevice` (with system randomness) at program start
-* `Xoshiro`: for explicitly-managed Xoshiro256++ streams.
+* `Xoshiro`: generates a high-quality stream of random numbers with a small state vector and high performance using the Xoshiro256++ algorithm
 * `RandomDevice`: for OS-provided entropy. This may be used for cryptographically secure random numbers (CS(P)RNG).
 * `MersenneTwister`: for backward compatibility (usually slower and worse quality than Xoshiro).
 

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -8,9 +8,12 @@ Random number generation in Julia uses the [Xoshiro256++](https://prng.di.unimi.
 by default, with per-`Task` state.
 Other RNG types can be plugged in by inheriting the `AbstractRNG` type; they can then be used to
 obtain multiple streams of random numbers.
-Besides the default `TaskLocalRNG` type, the `Random` package also provides `MersenneTwister`,
-`RandomDevice` (which exposes OS-provided entropy), and `Xoshiro` (for explicitly-managed
-Xoshiro256++ streams).
+
+The types exported by the `Random` package are:
+* `TaskLocalRNG`: the default with 1 stream per task.
+* `Xoshiro`: for explicitly-managed Xoshiro256++ streams.
+* `RandomDevice`: for OS-provided entropy. This should be used for cryptographically secure random numbers (CPR.
+* `MersenneTwister`: for backward compatibility (slower and worse quality than Xoshiro).
 
 Most functions related to random generation accept an optional `AbstractRNG` object as first argument.
 Some also accept dimension specifications `dims...` (which can also be given as a tuple) to generate

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -10,7 +10,7 @@ Other RNG types can be plugged in by inheriting the `AbstractRNG` type; they can
 obtain multiple streams of random numbers.
 
 The PRNGs (pseudorandom number generators) exported by the `Random` package are:
-* `TaskLocalRNG`: the default with 1 stream per task.
+* `TaskLocalRNG`: a token that represents use of the currently active Task-local stream, deterministically seeded from the parent task, or by RandomDevice (with system randomness) at program start
 * `Xoshiro`: for explicitly-managed Xoshiro256++ streams.
 * `RandomDevice`: for OS-provided entropy. This may be used for cryptographically secure random numbers (CS(P)RNG).
 * `MersenneTwister`: for backward compatibility (usually slower and worse quality than Xoshiro).


### PR DESCRIPTION
clean up the section a bit.
* make the exported types a bulleted list
* point out that `MersenneTwister` shouldn't be used except for backwards compatability
* explicitly mention `DeviceRandom` is what to use as a secure random generator.