### PR TITLE
Fix ~370 invalidations from Expr(:ncat, ...) pretty-printing

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1832,7 +1832,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
         elseif head === :hcat || head === :row
             sep = " "
         elseif head === :ncat || head === :nrow
-            sep = ";"^args[1] * " "
+            sep = ";"^args[1]::Int * " "
             args = args[2:end]
             nargs = nargs - 1
         else


### PR DESCRIPTION
These get invalidated by loading Static.jl, specifically the method
```
Base.convert(::Type{T}, ::StaticInt{N}) where {T<:Number,N} = convert(T, N)
```

CC @ChrisRackauckas