### PR TITLE
Nothing comparison improvement in `stdlib/Distributed/src/managers.jl`

### DIFF
--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -183,7 +183,7 @@ function parse_machine(machine::AbstractString)
 
     if machine[begin] == '['  # ipv6 bracket notation (RFC 2732)
         ipv6_end = findlast(']', machine)
-        if ipv6_end == nothing
+        if ipv6_end === nothing
             throw(ArgumentError("invalid machine definition format string: invalid port format \"$machine_def\""))
         end
         hoststr = machine[begin+1 : prevind(machine,ipv6_end)]
@@ -201,7 +201,7 @@ function parse_machine(machine::AbstractString)
         portstr = machine_def[2]
 
         portnum = tryparse(Int, portstr)
-        if portnum == nothing
+        if portnum === nothing
             msg = "invalid machine definition format string: invalid port format \"$machine_def\""
             throw(ArgumentError(msg))
         end


### PR DESCRIPTION
I'm not sure this is intended or not, but some codes in `stdlib/Distributed/src/managers.jl` are using equality comparison (==) for nothing, not identical comparison (===).
If this is not intended, I think later one should be used for small performance improvement.