### PR TITLE
REPL: Don't look for missing packages in code that isn't going to be run

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -178,6 +178,7 @@ function check_for_missing_packages_and_run_hooks(ast)
 end
 
 function modules_to_be_loaded(ast, mods = Symbol[])
+    ast.head == :quote && return mods # don't search if it's not going to be run during this eval
     if ast.head in [:using, :import]
         for arg in ast.args
             if first(arg.args) isa Symbol # i.e. `Foo`

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1355,6 +1355,11 @@ end
         mods = REPL.modules_to_be_loaded(Base.parse_input_line("using Core"))
         @test isempty(mods)
 
+        mods = REPL.modules_to_be_loaded(Base.parse_input_line(":(using Foo)"))
+        @test isempty(mods)
+        mods = REPL.modules_to_be_loaded(Base.parse_input_line("ex = :(using Foo)"))
+        @test isempty(mods)
+
         mods = REPL.modules_to_be_loaded(Base.parse_input_line("# comment"))
         @test isempty(mods)
         mods = REPL.modules_to_be_loaded(Base.parse_input_line("Foo"))


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/41879

@timholy seem reasonable?

```
julia> ex = :(using ImageCore)
:(using ImageCore)

julia> if true using ImageCore end
 │ Package ImageCore not found, but a package named ImageCore is available from a registry. 
 │ Install package?
 │   (@v1.8) pkg> add ImageCore 
 └ (y/n/o) [y]: n
```