### PR TITLE
Warn `@inbounds @threads for` pattern etc. during macro expansion

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -563,12 +563,17 @@ end
     that all accesses are in bounds.
 """
 macro inbounds(blk)
+    inbounds_warning(__source__, __module__, blk)
     return Expr(:block,
         Expr(:inbounds, true),
         Expr(:local, Expr(:(=), :val, esc(blk))),
         Expr(:inbounds, :pop),
         :val)
 end
+
+# `inbounds_warning` is defined elsewhere on `Expr` so that we can use features
+# that are not available inside `Core.Compiler`.
+inbounds_warning(::Any, ::Any, ::Any) = nothing
 
 """
     @label name

--- a/base/util.jl
+++ b/base/util.jl
@@ -603,11 +603,6 @@ end
 Called from `@inbounds` macro to warn some known pitfalls.
 """
 function inbounds_warning(__source__::LineNumberNode, __module__::Module, blk::Expr)
-    hint = """
-    HINT: It is recommended to avoid using `@inbounds` around the code you don't write.
-    A macro can introduce arbitrary code which may not satisfy the requirement of
-    `@inbounds`.
-    """
     if Meta.isexpr(blk, :macrocall) && length(blk.args) > 1
         f = @something(maybe_resolve_global(__module__, blk.args[1]), return)
         if f === Threads.var"@threads"
@@ -624,9 +619,8 @@ function inbounds_warning(__source__::LineNumberNode, __module__::Module, blk::E
             return
         end
         msg = replace(msg, "\n" => " ")
-        hint = replace(hint, "\n" => " ")
         @warn(
-            "$msg\n\n$hint",
+            msg,
             maxlog = 1,
             _line = __source__.line,
             _file = String(something(__source__.file, @__FILE__)),

--- a/base/util.jl
+++ b/base/util.jl
@@ -591,7 +591,7 @@ function maybe_resolve_global(m::Module, ex)
     c isa Symbol || return nothing
     obj = @something(maybe_resolve_global(m, a), return nothing)
     if obj isa Module
-        return  maybe_resolve_global(obj, c)
+        return maybe_resolve_global(obj, c)
     else
         return nothing
     end

--- a/test/boundscheck.jl
+++ b/test/boundscheck.jl
@@ -16,3 +16,8 @@ cmd = `$(Base.julia_cmd()) --check-bounds=no --startup-file=no --depwarn=error b
 if !success(pipeline(cmd; stdout=stdout, stderr=stderr))
     error("boundscheck test failed, cmd : $cmd")
 end
+
+@testset "@inbounds warnings" begin
+    @test_logs (:warn, r"@threads") @eval @inbounds Threads.@threads for _ in 1:0 end
+    @test_logs (:warn, r"@spawn") @eval @inbounds Threads.@spawn begin end
+end


### PR DESCRIPTION
I've seen users trying `@inbounds @threads for` and `@inbounds @spawn` for their attempt to improve performance [1]. Since `@inbounds` does not work across function boundaries, these annotations are useless and people can be confused by the performance of the code. So, it is rather tempting to just warn the users while expanding `@inbounds` which is much more efficient than keep paying attention in discourse/slack/zulip. What do people think about this kind of approach? Would it be too noisy?

Here's an example output:

![image](https://user-images.githubusercontent.com/29282/129489714-c6e5c30f-9645-4e0e-a28e-68bcdcfcdc4b.png)

(with https://github.com/JuliaLogging/TerminalLoggers.jl)

[1] Examples:
* https://discourse.julialang.org/t/what-is-the-cause-of-this-performance-difference-between-julia-and-cython/58886/4
* https://discourse.julialang.org/t/i-just-decided-to-migrate-from-python-fortran-to-julia-as-julia-was-faster-in-my-test/61188/11
* https://discourse.julialang.org/t/julia-beginner-from-python-numba-outperforms-julia-in-rewrite-any-tips-to-improve-performance/66414/2