### PR TITLE
Add check for buffer size of Profile.init on 32-bit systems, and fix bug

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -62,7 +62,7 @@ end
 
 function init(n::Integer, delay::Real)
     nthreads = Sys.iswindows() ? 1 : Threads.nthreads() # windows only profiles the main thread
-    sample_size_bytes = 1 # what should this be?
+    sample_size_bytes = sizeof(Ptr) # == Sys.WORD_SIZE / 8
     buffer_samples = n * nthreads
     buffer_size_bytes = buffer_samples * sample_size_bytes
     if buffer_size_bytes > 2^29 && Sys.WORD_SIZE == 32

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -55,8 +55,7 @@ function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} 
     if n === nothing && delay === nothing
         return Int(n_cur), delay_cur
     end
-    nthreads = Sys.iswindows() ? 1 : Threads.nthreads() # windows only profiles the main thread
-    nnew = (n === nothing) ? n_cur : n * nthreads
+    nnew = (n === nothing) ? n_cur : n
     delaynew = (delay === nothing) ? delay_cur : delay
     init(nnew, delaynew)
 end


### PR DESCRIPTION
Intended to fix the linux-32 failure introduced by https://github.com/JuliaLang/julia/pull/41821

Also corrects a bug in that PR https://github.com/JuliaLang/julia/pull/41821#discussion_r690445152

The correct value for `sample_size_bytes` needs adding