### PR TITLE
Updating CITATION.cff to use preferred-citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,27 +15,26 @@ license: "MIT"
 doi: "10.1137/141000671"
 date-released: 2017-02-07
 url: "https://julialang.org"
-references:
-  - scope: "Cite this paper whenever you use Julia"
-    type: article
-    title: "Julia: A fresh approach to numerical computing"
-    authors:
-      - family-names: "Bezanson"
-        given-names: "Jeff"
-      - family-names: "Edelman"
-        given-names: "Alan"
-      - family-names: "Karpinski"
-        given-names: "Stefan"
-      - family-names: "Shah"
-        given-names: "Viral B."
-    doi: "10.1137/141000671"
-    journal: "SIAM Review"
-    volume: 59
-    number: 1
-    pages: 33
-    start: 65
-    end: 98
-    year: 2017
-    url: "https://dx.doi.org/10.1137/141000671"
-    publisher:
-      - name: "SIAM"
+preferred-citation:
+  authors:
+    - family-names: "Bezanson"
+      given-names: "Jeff"
+    - family-names: "Edelman"
+      given-names: "Alan"
+    - family-names: "Karpinski"
+      given-names: "Stefan"
+    - family-names: "Shah"
+      given-names: "Viral B."
+  doi: "10.1137/141000671"
+  journal: "SIAM Review"
+  month: 9
+  start: 65
+  end: 98
+  pages: 33
+  title: "Julia: A fresh approach to numerical computing"
+  type: article
+  volume: 59
+  issue: 1
+  year: 2017
+  publisher:
+    - name: "SIAM"


### PR DESCRIPTION
This PR modifies the `CITATION.cff` file to use the `preferred-citation` field introduced in CFF `v1.2.0`:

```
@article{Bezanson_Julia_A_fresh_2017,
    author = {Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B.},
    doi = {10.1137/141000671},
    journal = {SIAM Review},
    month = {9},
    number = {1},
    pages = {65--98},
    title = {{Julia: A fresh approach to numerical computing}},
    volume = {59},
    year = {2017}
}
```

/ cc https://github.com/citation-file-format/ruby-cff/issues/70