### PR TITLE
store `noinline` declaration in method source

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -195,7 +195,7 @@ function finish(interp::AbstractInterpreter, opt::OptimizationState, params::Opt
     (; src, linfo) = opt
     (; def, specTypes) = linfo
 
-    force_noinline = _any(@nospecialize(x) -> isexpr(x, :meta) && x.args[1] === :noinline, ir.meta)
+    force_noinline = isa(def, Method) && is_declared_noinline(def)
 
     # compute inlining and other related optimizations
     if (isa(result, Const) || isconstType(result))

--- a/src/method.c
+++ b/src/method.c
@@ -289,8 +289,11 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
                     li->propagate_inbounds = 1;
                 else if (ma == (jl_value_t*)aggressive_constprop_sym)
                     li->aggressive_constprop = 1;
-                else
+                else {
+                    if (ma == (jl_value_t*)noinline_sym)
+                        li->inlineable = 2;
                     jl_array_ptr_set(meta, ins++, ma);
+                }
             }
             if (ins == 0)
                 bd[j] = jl_nothing;


### PR DESCRIPTION
This will help us quickly query if a method is declared as `@noinline` or not.

---

Not strictly related to this PR:

I don't like the remaining asymmetry between `@inline` and `@noinline`
i.e. we store `Expr(:meta, :noinline)` in statements while discarding
`@inline` information, so I tried to store `Expr(:meta, :inline)` also
(and implement the symmetric version of `is_declared_noinline`), but it
turned out that it slows down bootstrapping a bit and even worse, it
causes suspicious errors while sysimg creation. Maybe the later implies
that some of `@inline` declared methods body hit an existing error ?

MRE: with the following diff:
```diff
diff --git a/src/method.c b/src/method.c
index 0ff265cc87..a883c68e79 100644
--- a/src/method.c
+++ b/src/method.c
@@ -283,14 +283,14 @@ static void jl_code_info_set_ir(jl_co
                 jl_value_t *ma = jl_array_ptr_ref(meta, k)
                 if (ma == (jl_value_t*)pure_sym)
                     li->pure = 1;
-                else if (ma == (jl_value_t*)inline_sym)
-                    li->inlineable = 1;
                 else if (ma == (jl_value_t*)propagate_inbo
                     li->propagate_inbounds = 1;
                 else if (ma == (jl_value_t*)aggressive_con
                     li->aggressive_constprop = 1;
                 else {
-                    if (ma == (jl_value_t*)noinline_sym)
+                    if (ma == (jl_value_t*)inline_sym)
+                        li->inlineable = 1;
+                    else if (ma == (jl_value_t*)noinline_s
                         li->inlineable = 2;
                     jl_array_ptr_set(meta, ins++, ma);
                 }
```
`make` will yield something like this at sysimg creation:
```
...
jl_bounds_error_ints at /home/aviatesk/julia/src/rtutils.c:194
getindex at ./array.jl:895 [inlined]
find_curblock at ./compiler/ssair/passes.jl:58
compute_value_for_block at ./compiler/ssair/passes.jl:75
getfield_elim_pass! at ./compiler/ssair/passes.jl:859
run_passes at ./compiler/optimize.jl:303
optimize at ./compiler/optimize.jl:288 [inlined]
...
```