### PR TITLE
Fix bug in `@time` compilation time measurement, using _tryfinally macro.

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -560,12 +560,6 @@ static void JL_NORETURN throw_internal(jl_task_t *ct, jl_value_t *exception JL_M
     assert(!jl_get_safe_restore());
     jl_ptls_t ptls = ct->ptls;
     ptls->io_wait = 0;
-    // @time needs its compile timer disabled on error,
-    // and cannot use a try-finally as it would break scope for assignments
-    // We blindly disable compilation time tracking here, for all running Tasks, even though
-    // it may cause some incorrect measurements. This is a known bug, and is being tracked
-    // here: https://github.com/JuliaLang/julia/pull/39138
-    jl_atomic_store_relaxed(&jl_measure_compile_time_enabled, 0);
     JL_GC_PUSH1(&exception);
     jl_gc_unsafe_enter(ptls);
     if (exception) {


### PR DESCRIPTION
This PR **reopens** @IanButterworth's PR https://github.com/JuliaLang/julia/pull/39138, because in the meantime we've discovered a bug in the `@time` macro that needs a mechanism like this in order to solve it.

I'll describe the bug below. But first, some context:
- #39138 was originally closed because `tryfinally` is an intermediate form that shouldn't be used in source ASTs.
- There is another PR, #39217, which is in-progress, which will provide the _correct_ way to solve that problem, but that PR is currently stalled.

Since the `@time` macro is currently broken without this change, and since we know that there _is_ a mechanism on the way (via #39217) that will replace this, it seems to me (and @Sacha0) that this is an expedient solution to the existing bug, without baking-in a reference to the internal intermediate form that we need to maintain. I've left a note in the code that directly states that this macro is deprecated and should not be used, and that a replacement is coming. I've renamed it to `@_tryfinally` to discourage its use. Hopefully that seems like a reasonable tradeoff to allow us to fix the bug in `@time` compilation measurement?

Thanks! :)

The PR description follows:

------------


Use a _tryfinally macro to ensure compile timer is closed, while maintaining scope.

This fixes a bug where an exception thrown _anywhere_, on any Task on
any thread, completely disables the compilation time measurement for any
concurrently executing `@time` blocks, without warning the user about it.

Here are some examples of the current, broken behavior:
- Throwing (and catching) an exception disables compilation time
  measurement, even though the exception didn't escape, without warning
  the user - note 0 compilation time reported:
    ```julia
    julia> @time begin
              # The following exception disables compilation time measurement
              try throw("ha HAH!") catch end
              @eval module M ; f(x) = 2*x ; end
              @eval M.f(2)
          end
      0.003950 seconds (2.17 k allocations: 170.093 KiB)
    4
    ```
- Throwing an exception while the first task is sleeping disables
  compilation time measurement, so this ends up incorrectly reporting 0
  compilation time:
    ```julia
    julia> f(n) = begin
              # while we're sleeping, someone throws an exception somewhere else :'(
              sleep(n)
              @eval module M ; f(x) = 2*x ; end
              @eval M.f(2)
          end
    f (generic function with 1 method)

    julia> f(0) # warmup
    WARNING: replacing module M.
    4

    julia> @async @time f(5)
    Task (runnable) @0x000000010f2c0780

    julia> throw("oh no sad")
    ERROR: "oh no sad"
    Stacktrace:
    [1] top-level scope
      @ REPL[9]:1

    WARNING: replacing module M.
      5.008401 seconds (1.92 k allocations: 120.515 KiB)
    ```

After this commit, both of those examples correctly report their
compilation time.
