### PR TITLE
Derive better name for methods with external method tables.

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -79,6 +79,7 @@ static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s)
 {
     jl_value_t **args = jl_array_ptr_data(ex->args);
 
+    // generic function definition
     if (jl_expr_nargs(ex) == 1) {
         jl_value_t **args = jl_array_ptr_data(ex->args);
         jl_sym_t *fname = (jl_sym_t*)args[0];

--- a/src/method.c
+++ b/src/method.c
@@ -831,7 +831,7 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
 
     // TODO: derive our debug name from the syntax instead of the type
     name = mt->name;
-    if (mt == jl_type_type_mt || mt == jl_nonfunction_mt) {
+    if (mt == jl_type_type_mt || mt == jl_nonfunction_mt || external_mt) {
         // our value for `name` is bad, try to guess what the syntax might have had,
         // like `jl_static_show_func_sig` might have come up with
         jl_datatype_t *dt = jl_first_argument_datatype(argtype);


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/229:

```julia
Base.Experimental.@MethodTable(my_method_table)
GPUCompiler.method_table(...) = my_method_table
Base.Experimental.@overlay my_method_table @noinline Base.sin(x::Float32) = x+1

kernel(x) = sin(x)
```

Before:

```llvm
; Function Attrs: noinline
define internal fastcc float @julia_my_method_table_519(float %0) unnamed_addr #0 !dbg !36 {
top:
  call void @llvm.dbg.value(metadata float %0, metadata !43, metadata !DIExpression()), !dbg !44
  %1 = fadd float %0, 1.000000e+00, !dbg !45
  ret float %1, !dbg !52
}

define float @julia_kernel_516(float %0) local_unnamed_addr #1 !dbg !53 {
top:
  call void @llvm.dbg.value(metadata float %0, metadata !59, metadata !DIExpression()), !dbg !60
  %1 = call fastcc float @julia_my_method_table_519(float %0) #1, !dbg !61
  ret float %1, !dbg !61
}
```

After

```llvm
; Function Attrs: noinline
define internal fastcc float @julia__sin_519(float %0) unnamed_addr #0 !dbg !36 {
top:
  %1 = fadd float %0, 1.000000e+00, !dbg !38
  ret float %1, !dbg !44
}

define float @julia_kernel_516(float %0) local_unnamed_addr #1 !dbg !45 {
top:
  %1 = call fastcc float @julia__sin_519(float %0) #1, !dbg !46
  ret float %1, !dbg !46
}
```