### PR TITLE
CI: Work around registry corruption issues

### DIFF
--- a/.buildkite/pipelines/main/platforms/linux64.yml
+++ b/.buildkite/pipelines/main/platforms/linux64.yml
@@ -9,6 +9,8 @@ steps:
     key: package_linux64
     plugins:
       - JuliaCI/julia#v1:
+          # Drop default "registries" directory, so it is not persisted from execution to execution
+          persist_depot_dirs: packages,artifacts,compiled
           version: 1.6
       - staticfloat/sandbox#v1:
           rootfs_url: https://github.com/JuliaCI/rootfs-images/releases/download/v3.1/package_linux.x86_64.tar.gz


### PR DESCRIPTION
Because our jobs get interrupted, it seems that incomplete registry trees are created pretty often.  Let's just not persist them for now.