### PR TITLE
Deserialization: check for non-NULL value in datatype globalref

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1787,7 +1787,12 @@ static jl_value_t *jl_deserialize_value_any(jl_serializer_state *s, uint8_t tag,
             }
         }
         else {
-            jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(jl_get_global(m, sym));
+            jl_value_t *rawdt = jl_get_global(m, sym);
+            if (rawdt == NULL) {
+                jl_errorf("During deserialization, symbol %s was not found in module %s.",
+                    jl_symbol_name(sym), jl_symbol_name(m->name));
+            }
+            jl_datatype_t *dt = (jl_datatype_t*)jl_unwrap_unionall(rawdt);
             assert(jl_is_datatype(dt));
             tn = dt->name;
             backref_list.items[pos] = tn;

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -923,7 +923,7 @@ precompile_test_harness("Undefined types") do load_path
         end
         """)
     Base.compilecache(Base.PkgId("UndefTypesB"))
-    @eval using UndefTypesB  # no segfault
+    @test_throws ErrorException @eval using UndefTypesB  # no segfault
 end
 
 @testset "issue 38149" begin


### PR DESCRIPTION
Fixes #40698

This may not be the best fix (it would be better to cache the type somewhere, presumably in `Bar`), but at least this prevents the segfault:
```julia
julia> using Bar
ERROR: During deserialization, symbol #bar was not found in module Foo.
Stacktrace:
 [1] _include_from_serialized(path::String, depmods::Vector{Any})
   @ Base ./loading.jl:752
 [2] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, depth::Int64)
   @ Base ./loading.jl:858
 [3] _require_search_from_serialized
   @ ./loading.jl:831 [inlined]
 [4] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:1108
 [5] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:1024
 [6] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:1008
```

Question: does it need more of a hint about how to work around it? Obviously these "misses" might be for multiple causes, not just the missing function-type in #40698.