### PR TITLE
Construct ranges of CartesianIndexes

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -68,6 +68,7 @@ module IteratorsMD
 
     CartesianIndex(index::NTuple{N,Integer}) where {N} = CartesianIndex{N}(index)
     CartesianIndex(index::Integer...) = CartesianIndex(index)
+    CartesianIndex{N}(c::CartesianIndex{N}) where {N} = c
     CartesianIndex{N}(index::Vararg{Integer,N}) where {N} = CartesianIndex{N}(index)
     # Allow passing tuples smaller than N
     CartesianIndex{N}(index::Tuple) where {N} = CartesianIndex{N}(fill_to_length(index, 1, Val(N)))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -320,6 +320,12 @@ module IteratorsMD
     (:)(I::CartesianIndex{N}, S::CartesianIndex{N}, J::CartesianIndex{N}) where N =
         CartesianIndices(map((i,s,j) -> i:s:j, Tuple(I), Tuple(S), Tuple(J)))
 
+    function show(io::IO, r::Base.StepRangeLen{C,C,C,<:Integer}) where {C<:CartesianIndex}
+        # Since a:b:c with CartesianIndex arguments produces CartesianIndices instead of a StepRangeLen,
+        # the display of a StepRangeLen of CartesianIndexes should not use this notation
+        print(io, "StepRangeLen(", repr(first(r)), ", ", repr(step(r)), ", ", repr(length(r)), ")")
+    end
+
     promote_rule(::Type{CartesianIndices{N,R1}}, ::Type{CartesianIndices{N,R2}}) where {N,R1,R2} =
         CartesianIndices{N,Base.indices_promote_type(R1,R2)}
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -170,13 +170,13 @@ range_stop(stop::Integer) = range_length(stop)
 # Stop and length as the only argument
 range_stop_length(a::Real,          len::Integer) = UnitRange{typeof(a)}(oftype(a, a-len+1), a)
 range_stop_length(a::AbstractFloat, len::Integer) = range_step_stop_length(oftype(a, 1), a, len)
-range_stop_length(a,                len::Integer) = range_step_stop_length(oftype(a-a, oneunit(a)), a, len)
+range_stop_length(a,                len::Integer) = range_step_stop_length(oftype(a-a, 1), a, len)
 
 range_step_stop_length(step, stop, length) = reverse(range_start_step_length(stop, -step, length))
 
 range_start_length(a::Real,          len::Integer) = UnitRange{typeof(a)}(a, oftype(a, a+len-1))
 range_start_length(a::AbstractFloat, len::Integer) = range_start_step_length(a, oftype(a, 1), len)
-range_start_length(a,                len::Integer) = range_start_step_length(a, oftype(a-a, oneunit(a)), len)
+range_start_length(a,                len::Integer) = range_start_step_length(a, oftype(a-a, 1), len)
 
 range_start_stop(start, stop) = start:stop
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -170,13 +170,13 @@ range_stop(stop::Integer) = range_length(stop)
 # Stop and length as the only argument
 range_stop_length(a::Real,          len::Integer) = UnitRange{typeof(a)}(oftype(a, a-len+1), a)
 range_stop_length(a::AbstractFloat, len::Integer) = range_step_stop_length(oftype(a, 1), a, len)
-range_stop_length(a,                len::Integer) = range_step_stop_length(oftype(a-a, 1), a, len)
+range_stop_length(a,                len::Integer) = range_step_stop_length(oftype(a-a, oneunit(a)), a, len)
 
 range_step_stop_length(step, stop, length) = reverse(range_start_step_length(stop, -step, length))
 
 range_start_length(a::Real,          len::Integer) = UnitRange{typeof(a)}(a, oftype(a, a+len-1))
 range_start_length(a::AbstractFloat, len::Integer) = range_start_step_length(a, oftype(a, 1), len)
-range_start_length(a,                len::Integer) = range_start_step_length(a, oftype(a-a, 1), len)
+range_start_length(a,                len::Integer) = range_start_step_length(a, oftype(a-a, oneunit(a)), len)
 
 range_start_stop(start, stop) = start:stop
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2112,3 +2112,13 @@ end
 @test length(range(1, 100, length=big(100)^100)) == big(100)^100
 @test length(range(big(1), big(100)^100, length=big(100)^100)) == big(100)^100
 @test length(0 * (1:big(100)^100)) == big(100)^100
+
+@testset "ranges of CartesianIndexes" begin
+    a = CartesianIndex(1,1)
+    r1 = range(a, step = CartesianIndex(2,3), length = 3)
+    r2 = StepRangeLen(CartesianIndex(1,1), CartesianIndex(2,3), 3)
+    @test r1 == r2
+
+    @test range(a, length = 4) == StepRangeLen(a, a, 4)
+    @test range(stop = a, length = 4) == StepRangeLen(-2a, a, 4)
+end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2114,11 +2114,18 @@ end
 @test length(0 * (1:big(100)^100)) == big(100)^100
 
 @testset "ranges of CartesianIndexes" begin
-    a = CartesianIndex(1,1)
-    r1 = range(a, step = CartesianIndex(2,3), length = 3)
-    r2 = StepRangeLen(CartesianIndex(1,1), CartesianIndex(2,3), 3)
+    start = CartesianIndex(1,1)
+    step = CartesianIndex(2,3)
+    len = 3
+    r1 = StepRangeLen(start, step, len)
+    @test r1[1] == start
+    @test r1[2] == start + step
+    @test r1[3] == start + 2step
+    r2 = range(start, step = step, length = len)
     @test r1 == r2
 
-    @test range(a, length = 4) == StepRangeLen(a, a, 4)
-    @test range(stop = a, length = 4) == StepRangeLen(-2a, a, 4)
+    # Make sure that a StepRangeLen of CartesianIndexes does not use the a:b:c notation
+    # while displayed
+    s = repr(r1)
+    @test s == "StepRangeLen($start, $step, $len)"
 end


### PR DESCRIPTION
This PR adds the ability to construct `StepRangeLen`s of `CartesianIndex`es. This works if start/stop, step and length are specified. Methods with `step` unspecified are not added, and these error as before. The display of a `StepRangeLen` of `CartesianIndex`es is also changed to not use the `a:b:c` spelling, as this produces a `CartesianIndices` instead.

```julia
julia> a = CartesianIndex(1,1)
CartesianIndex(1, 1)

julia> b = StepRangeLen(a, a, 4)
StepRangeLen(CartesianIndex(1, 1), CartesianIndex(1, 1), 4)

julia> b |> collect
4-element Vector{CartesianIndex{2}}:
 CartesianIndex(1, 1)
 CartesianIndex(2, 2)
 CartesianIndex(3, 3)
 CartesianIndex(4, 4)
```

This is complementary to #37829 that introduced the start-step-stop pattern to produce `CartesianIndices` that are the iterator product of multiple ranges.

This PR currently also allows one to construct such a range using `range` as 

```julia
julia> range(CartesianIndex(1,1), step = CartesianIndex(2,3), length = 3)
StepRangeLen(CartesianIndex(1, 1), CartesianIndex(2, 3), 3)
```

This will be removed, as it is quite confusing to have `range(start; stop, length)` mean something else from `range(start; stop, step)`. To illustrate why this should be removed:

```julia
julia> range(CartesianIndex(1,1), step = CartesianIndex(2,3), stop = CartesianIndex(3,4))
2×2 CartesianIndices{2, Tuple{StepRange{Int64, Int64}, StepRange{Int64, Int64}}}:
 CartesianIndex(1, 1)  CartesianIndex(1, 4)
 CartesianIndex(3, 1)  CartesianIndex(3, 4)

julia> range(CartesianIndex(1,1), step = CartesianIndex(2,3), length = 2)
StepRangeLen(CartesianIndex(1, 1), CartesianIndex(2, 3), 2)
```