### PR TITLE
Validate CodeInstances with no external edges

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -46,6 +46,7 @@ static jl_value_t *deser_symbols[256];
 static htable_t backref_table;
 static int backref_table_numel;
 static arraylist_t backref_list;
+static arraylist_t new_code_instances;
 
 // list of (jl_value_t **loc, size_t pos) entries
 // for anything that was flagged by the deserializer for later
@@ -1587,8 +1588,11 @@ static jl_value_t *jl_deserialize_value_method_instance(jl_serializer_state *s, 
     if (mi->callbacks)
         jl_gc_wb(mi, mi->callbacks);
     mi->cache = (jl_code_instance_t*)jl_deserialize_value(s, (jl_value_t**)&mi->cache);
-    if (mi->cache)
+    if (mi->cache) {
         jl_gc_wb(mi, mi->cache);
+        if (internal)
+            arraylist_push(&new_code_instances, mi->cache);
+    }
     return (jl_value_t*)mi;
 }
 
@@ -2036,6 +2040,7 @@ static void jl_insert_backedges(jl_array_t *list, jl_array_t *targets)
             int32_t idx = idxs[j];
             valid = jl_array_uint8_ref(valids, idx);
         }
+        size_t ci_world;
         if (valid) {
             // if this callee is still valid, add all the backedges
             for (j = 0; j < jl_array_len(idxs_array); j++) {
@@ -2051,24 +2056,38 @@ static void jl_insert_backedges(jl_array_t *list, jl_array_t *targets)
                 }
             }
             // then enable it
-            jl_code_instance_t *codeinst = caller->cache;
-            while (codeinst) {
-                if (codeinst->min_world > 0)
-                    codeinst->max_world = ~(size_t)0;
-                codeinst = jl_atomic_load_relaxed(&codeinst->next);
-            }
+            ci_world = ~(size_t)0;
         }
         else {
+            ci_world = jl_world_counter > 1 ? jl_world_counter - 1 : 1;
             if (_jl_debug_method_invalidation) {
                 jl_array_ptr_1d_push(_jl_debug_method_invalidation, (jl_value_t*)caller);
                 loctag = jl_cstr_to_string("insert_backedges");
                 jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
             }
         }
+        jl_code_instance_t *codeinst = caller->cache;
+        while (codeinst) {
+            if (codeinst->min_world > 0)
+                codeinst->max_world = ci_world;
+            codeinst = jl_atomic_load_relaxed(&codeinst->next);
+        }
     }
     JL_GC_POP();
 }
 
+static void validate_new_code_instances(void)
+{
+    size_t i;
+    for (i = 0; i < new_code_instances.len; i++) {
+        jl_code_instance_t *codeinst = (jl_code_instance_t*)new_code_instances.items[i];
+        while (codeinst) {
+            if (codeinst->min_world > 0 && codeinst->max_world == 0) // lacks external edges
+                codeinst->max_world = ~(size_t)0;
+            codeinst = jl_atomic_load_relaxed(&codeinst->next);
+        }
+    }
+}
 
 static jl_value_t *read_verify_mod_list(ios_t *s, jl_array_t *mod_list)
 {
@@ -2636,6 +2655,7 @@ static jl_value_t *_jl_restore_incremental(ios_t *f, jl_array_t *mod_array)
     arraylist_new(&backref_list, 4000);
     arraylist_push(&backref_list, jl_main_module);
     arraylist_new(&flagref_list, 0);
+    arraylist_new(&new_code_instances, 0);
     arraylist_new(&ccallable_list, 0);
     htable_new(&uniquing_table, 0);
 
@@ -2671,7 +2691,11 @@ static jl_value_t *_jl_restore_incremental(ios_t *f, jl_array_t *mod_array)
 
     jl_insert_backedges((jl_array_t*)external_backedges, (jl_array_t*)external_edges); // restore external backedges (needs to be last)
 
+    // check new CodeInstances and validate any that lack external backedges
+    validate_new_code_instances();
+
     serializer_worklist = NULL;
+    arraylist_free(&new_code_instances);
     arraylist_free(&flagref_list);
     arraylist_free(&backref_list);
     ios_close(f);


### PR DESCRIPTION
In #38983 and #41872, it was discovered that only CodeInstances with
external backedges get validated after deserialization.
This stores new CodeInstances in a list, and if they have neither been
validated nor invalidated, it validates them.

Closes #41872

CC @martinholters 