### PR TITLE
Make section on returned function pointer say to use ccall

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -721,7 +721,8 @@ For translating a C return type to Julia:
           * `Ptr{T}`, where `T` is the Julia type corresponding to `T`
   * `T (*)(...)` (e.g. a pointer to a function)
 
-      * `Ptr{Cvoid}` (you may need to use [`@cfunction`](@ref) explicitly to create this pointer)
+      * `Ptr{Cvoid}` to call this directly from Julia you will need to pass this as the first argument to [`ccall`](@ref).
+        See [Indirect Calls](@ref).
 
 ### Passing Pointers for Modifying Inputs
 


### PR DESCRIPTION
I was looking for how to call a returned function pointer.
I looked in the docs for what to do with returned values.
And it was telling me how to create one -- which is already in the section above for arguments, and is not applicable for returned values since you don't need to create them