### PR TITLE
Dispatch on traits in iterate for AbstractArrays and types that wrap AbstractArrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1135,9 +1135,12 @@ zero(x::AbstractArray{T}) where {T} = fill!(similar(x, typeof(zero(T))), zero(T)
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both IndexLinear and IndexCartesian arrays
 
-# Subtypes of AbstractArray (such as AbstractRanges) may define custom iteration
-# behavior. Wrapper types may opt into the behavior of the parent through the trait
-# IterationStyle
+# Subtypes of AbstractArray (such as AbstractRanges) may have their own iteration
+# implementation defined that might be more performant than the default implementation.
+# A wrapper AbstractArray type may opt into the iteration implementation of the parent
+# by extending the trait IterationStyle.
+# This is disabled by default, and wrapper types fall back to the default
+# iteration implementation for AbstractArrays defined below, which uses indexing.
 
 # While the definitions for IndexLinear are all simple enough to inline on their
 # own, IndexCartesian's CartesianIndices is more complicated and requires explicit

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1135,10 +1135,15 @@ zero(x::AbstractArray{T}) where {T} = fill!(similar(x, typeof(zero(T))), zero(T)
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both IndexLinear and IndexCartesian arrays
 
+# Subtypes of AbstractArray (such as AbstractRanges) may define custom iteration
+# behavior. Wrapper types may opt into the behavior of the parent through the trait
+# IterationStyle
+
 # While the definitions for IndexLinear are all simple enough to inline on their
 # own, IndexCartesian's CartesianIndices is more complicated and requires explicit
 # inlining.
-function iterate(A::AbstractArray, state=(eachindex(A),))
+iterate(A::AbstractArray, state...) = _iterate(A, IterationStyle(A), state...)
+function _iterate(A::AbstractArray, ::IterationStyle{<:AbstractArray}, state = (eachindex(A),))
     y = iterate(state...)
     y === nothing && return nothing
     A[y[1]], (state[1], tail(y)...)

--- a/base/array.jl
+++ b/base/array.jl
@@ -870,7 +870,9 @@ end
 
 ## Iteration ##
 
-iterate(A::Array, i=1) = (@inline; (i % UInt) - 1 < length(A) ? (@inbounds A[i], i + 1) : nothing)
+_iterate_array(A, i) = (@inline; (i % UInt) - 1 < length(A) ? (@inbounds A[i - 1 + firstindex(A)], i + 1) : nothing)
+iterate(A::Array, i=1) = _iterate_array(A, i)
+_iterate(A::AbstractArray, ::IterationStyle{<:Array}, i=1) = _iterate_array(A, i)
 
 ## Indexing: getindex ##
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -856,10 +856,9 @@ copy(r::AbstractRange) = r
 
 ## iteration
 
-# The trait IterationStyle is used to dispatch on the appropriate iterate method.
-# This is especially important for wrapper types, as they may choose the
-# use the parent's iterate method instead of the fallback implementation by defining
-# their IterationStyle to be the same as their parents'.
+# The trait IterationStyle is used to dispatch on the appropriate `iterate` method.
+# Wrapper types may choose to use the parents' iteration implementation instead of
+# the default fallback one by defining their IterationStyle to be the same as their parents'.
 struct IterationStyle{T} end
 IterationStyle(x) = IterationStyle{typeof(x)}()
 

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -822,3 +822,17 @@ end
     @test (@view x[end, -y[end]])[] == 3
     @test (@view x[y[end], end])[] == 4
 end
+
+@testset "iteration" begin
+    for r in Any[1:5, 1:1:5, UnitRange(1.0, 5.0), 1.0:5.0, LinRange(1, 5, 5),
+            Base.IdentityUnitRange(4:5), Base.OneTo(4), view(1:5, :)]
+        ro = OffsetArray(r, 0)
+        for (a, b) in zip(r, ro)
+            @test a == b
+        end
+        s = collect(r); so = collect(ro)
+        for (a, b) in zip(s, so)
+            @test a == b
+        end
+    end
+end

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -355,6 +355,8 @@ end
     A
 end
 
+Base.IterationStyle(A::OffsetArray) = Base.IterationStyle(parent(A))
+
 # For fast broadcasting: ref https://discourse.julialang.org/t/why-is-there-a-performance-hit-on-broadcasting-with-offsetarrays/32194
 Base.dataids(A::OffsetArray) = Base.dataids(parent(A))
 Broadcast.broadcast_unalias(dest::OffsetArray, src::OffsetArray) = parent(dest) === parent(src) ? src : Broadcast.unalias(dest, src)


### PR DESCRIPTION
An attempt at using traits in `iterate` for `AbstractArray`s (Fixes https://github.com/JuliaLang/julia/issues/41945), which makes iteration for wrapper types (eg. `OffsetArray`s) use the same `iterate` method used for the parent array, consequently obtaining the same performance. Array wrapper types may opt-in to the iteration behavior of the parent through the trait `IterationStyle`, for example as

```julia
Base.IterationStyle(A::OffsetArray) = Base.IterationStyle(parent(A))
```

By default they will fall back to the `iterate` method for `AbstractArray`s, which is the present behavior.

A comparison of the performance without using the trait and with it (see #41945 for other examples):

Without defining the trait for `OffsetArray`s:
```julia
julia> r = 1:1:1000; ro = OffsetArray(r);

julia> @btime Float64[i for i in $r];
  1.621 μs (1 allocation: 7.94 KiB)

julia> @btime Float64[i for i in $ro];
  25.306 μs (1 allocation: 7.94 KiB)
```

With the trait defined:
```julia
julia> @btime Float64[i for i in $r];
  1.677 μs (1 allocation: 7.94 KiB)

julia> @btime Float64[i for i in $ro];
  1.609 μs (1 allocation: 7.94 KiB)
```

I would love some feedback on this as it is a somewhat large change, although there seems to be a significant performance benefit to this.