### PR TITLE
Fix `gemv!` bug introduced in #41513

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -669,7 +669,7 @@ for (fname, elty) in ((:dgemv_,:Float64),
             sX = stride(X,1)
             pX = pointer(X, sX > 0 ? firstindex(X) : lastindex(X))
             sY = stride(Y,1)
-            pY = pointer(Y, sY > 0 ? firstindex(X) : lastindex(X))
+            pY = pointer(Y, sY > 0 ? firstindex(Y) : lastindex(Y))
             GC.@preserve X Y ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
                  Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -373,29 +373,29 @@ Random.seed!(100)
         @testset "non-standard strides" begin
             if elty <: Complex
                 A = elty[1+2im 3+4im 5+6im 7+8im; 2+3im 4+5im 6+7im 8+9im; 3+4im 5+6im 7+8im 9+10im]
-                v = elty[1+2im, 2+3im, 3+4im, 4+5im]
-                dest = view(ones(elty, 5), 4:-2:2)
-                @test BLAS.gemv!('N', elty(2), view(A, 2:3, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[-35+178im, -39+202im]
+                v = elty[1+2im, 2+3im, 3+4im, 4+5im, 5+6im]
+                dest = view(ones(elty, 7), 6:-2:2)
+                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[-31+154im, -35+178im, -39+202im]
                 @test BLAS.gemv('N', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[15-41im, 17-49im]
                 @test BLAS.gemv('N', view(A, 1:0, 1:2), view(v, 1:2)) == elty[]
                 dest = view(ones(elty, 5), 4:-2:2)
-                @test BLAS.gemv!('T', elty(2), view(A, 2:3, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[-29+124im, -45+220im]
+                @test BLAS.gemv!('T', elty(2), view(A, :, 2:2:4), view(v, 1:2:5), elty(3), dest) == elty[-45+202im, -69+370im]
                 @test BLAS.gemv('T', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[14-38im, 18-54im]
                 @test BLAS.gemv('T', view(A, 2:3, 2:1), view(v, 1:2)) == elty[]
                 dest = view(ones(elty, 5), 4:-2:2)
-                @test BLAS.gemv!('C', elty(2), view(A, 2:3, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[131+8im, 227+24im]
+                @test BLAS.gemv!('C', elty(2), view(A, :, 2:2:4), view(v, 5:-2:1), elty(3), dest) == elty[179+6im, 347+30im]
                 @test BLAS.gemv('C', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[-40-6im, -56-10im]
                 @test BLAS.gemv('C', view(A, 2:3, 2:1), view(v, 1:2)) == elty[]
             else
                 A = elty[1 2 3 4; 5 6 7 8; 9 10 11 12]
-                v = elty[1, 2, 3, 4]
-                dest = view(ones(elty, 5), 4:-2:2)
-                @test BLAS.gemv!('N', elty(2), view(A, 2:3, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[79, 119]
+                v = elty[1, 2, 3, 4, 5]
+                dest = view(ones(elty, 7), 6:-2:2)
+                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[39, 79, 119]
                 @test BLAS.gemv('N', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[-19, -31]
                 @test BLAS.gemv('N', view(A, 1:0, 1:2), view(v, 1:2)) == elty[]
                 for trans = ('T', 'C')
                     dest = view(ones(elty, 5), 4:-2:2)
-                    @test BLAS.gemv!(trans, elty(2), view(A, 2:3, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[95, 115]
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(v, 1:2:5), elty(3), dest) == elty[143, 179]
                     @test BLAS.gemv(trans, elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[-22, -25]
                     @test BLAS.gemv(trans, view(A, 2:3, 2:1), view(v, 1:2)) == elty[]
                 end


### PR DESCRIPTION
Due to a copy&paste error, the pointer to `y` was calculated with the indices of `x`.

The tests are adapted to catch this bug (by using a non-square matrix in some cases).