### PR TITLE
handle the condition in `in` when `step(r::AbstractRange)` equals 0 

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1371,11 +1371,13 @@ in(x::T, r::AbstractRange{T}) where {T} = _in_range(x, r)
 in(x::Integer, r::AbstractUnitRange{<:Integer}) = (first(r) <= x) & (x <= last(r))
 
 in(x::Real, r::AbstractRange{T}) where {T<:Integer} =
-    isinteger(x) && !isempty(r) && x >= minimum(r) && x <= maximum(r) &&
-        (mod(convert(T,x),step(r))-mod(first(r),step(r)) == 0)
+    isinteger(x) && !isempty(r) &&
+    (iszero(step(r)) ? x == first(r) : (x >= minimum(r) && x <= maximum(r) &&
+        (mod(convert(T,x),step(r))-mod(first(r),step(r)) == 0)))
 in(x::AbstractChar, r::AbstractRange{<:AbstractChar}) =
-    !isempty(r) && x >= minimum(r) && x <= maximum(r) &&
-        (mod(Int(x) - Int(first(r)), step(r)) == 0)
+    !isempty(r) &&
+    (iszero(step(r)) ? x == first(r) : (x >= minimum(r) && x <= maximum(r) &&
+        (mod(Int(x) - Int(first(r)), step(r)) == 0)))
 
 # Addition/subtraction of ranges
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2112,3 +2112,20 @@ end
 @test length(range(1, 100, length=big(100)^100)) == big(100)^100
 @test length(range(big(1), big(100)^100, length=big(100)^100)) == big(100)^100
 @test length(0 * (1:big(100)^100)) == big(100)^100
+
+@testset "issue #41784" begin
+    # tests `in` when step equals 0
+    # test for Int
+    x = 41784
+    @test (x in StepRangeLen(x, 0, 0)) == false
+    @test (x in StepRangeLen(x, 0, rand(1:100))) == true
+    @test ((x - 1) in StepRangeLen(x, 0, rand(1:100))) == false
+    @test ((x + 1) in StepRangeLen(x, 0, rand(1:100))) == false
+
+    # test for Char
+    x = 'z'
+    @test (x in StepRangeLen(x, 0, 0)) == false
+    @test (x in StepRangeLen(x, 0, rand(1:100))) == true
+    @test ((x - 1) in StepRangeLen(x, 0, rand(1:100))) == false
+    @test ((x + 1) in StepRangeLen(x, 0, rand(1:100))) == false
+end


### PR DESCRIPTION
Fixes #41784.

Before:

```julia
julia> r = StepRangeLen(3, 0, 5)
StepRangeLen(3, 0, 5)

julia> 3 in r
ERROR: DivideError: integer division error
Stacktrace:
 [1] div
   @ ./int.jl:278 [inlined]
 [2] div
   @ ./div.jl:257 [inlined]
 [3] div
   @ ./div.jl:302 [inlined]
 [4] fld
   @ ./div.jl:268 [inlined]
 [5] mod
   @ ./int.jl:270 [inlined]
 [6] in(x::Int64, r::StepRangeLen{Int64, Int64, Int64, Int64})
   @ Base ./range.jl:1346
 [7] top-level scope
   @ REPL[23]:1
```

After:
```julia
julia> StepRangeLen(3, 0, 5)
StepRangeLen(3, 0, 5)

julia> 3 in r
true

julia> 4 in r
false
```
```julia
julia> rc = StepRangeLen('a', 0, 5)
StepRangeLen('a', 0, 5)

julia> 'a' in rc
true

julia> 'b' in rc
false
```