### PR TITLE
Add hint for :quit to REPL.REPLCompletions.UndefVarError_hint

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -911,6 +911,8 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
         println(io)
         # Show friendly help message when user types help or help() and help is undefined
         show(io, MIME("text/plain"), Base.Docs.parsedoc(Base.Docs.keywords[:help]))
+    elseif var === :quit
+        print(io, "\nsuggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.")
     end
 end
 


### PR DESCRIPTION
This addresses https://github.com/JuliaLang/julia/pull/38522#discussion_r533695883 by providing a hint when a user types `quit` or `quit()` into the REPL.

It follows on the heels of #41754 that added support for when the user types `help`.

```julia
julia> using Revise, REPL

julia> Revise.track(REPL)

julia> quit
ERROR: UndefVarError: quit not defined
suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.

julia> quit()
ERROR: UndefVarError: quit not defined
suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.
Stacktrace:
 [1] top-level scope
   @ REPL[4]:1

julia> quit = 2
2

julia> quit
2

julia> quit()
ERROR: MethodError: objects of type Int64 are not callable
Maybe you forgot to use an operator such as *, ^, %, / etc. ?
Stacktrace:
 [1] top-level scope
   @ REPL[7]:1
```