### PR TITLE
Improve performance of Symbol concatenation

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -227,6 +227,7 @@ Vector{T}(s::AbstractString) where {T<:AbstractChar} = collect(T, s)
 
 Symbol(s::AbstractString) = Symbol(String(s))
 Symbol(x...) = Symbol(string(x...))
+Symbol(x::Symbol, y::Symbol) = Symbol(string(x), string(y)) # 2-arg form improves performance
 
 convert(::Type{T}, s::T) where {T<:AbstractString} = s
 convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -227,7 +227,6 @@ Vector{T}(s::AbstractString) where {T<:AbstractChar} = collect(T, s)
 
 Symbol(s::AbstractString) = Symbol(String(s))
 Symbol(x...) = Symbol(string(x...))
-Symbol(x::Symbol, y::Symbol) = Symbol(string(x), string(y)) # 2-arg form improves performance
 
 convert(::Type{T}, s::T) where {T<:AbstractString} = s
 convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -205,7 +205,13 @@ end
     return n
 end
 
-function string(a::Union{Char, String, SubString{String}}...)
+@inline function __unsafe_string!(out, s::Symbol, offs::Integer)
+    n = sizeof(s)
+    GC.@preserve s out unsafe_copyto!(pointer(out, offs), unsafe_convert(Ptr{UInt8},s), n)
+    return n
+end
+
+function string(a::Union{Char, String, SubString{String}, Symbol}...)
     n = 0
     for v in a
         if v isa Char


### PR DESCRIPTION
```
# current: Symbol(x...) = Symbol(string(x...))
@btime Symbol(:test, :me)
  111.024 ns (3 allocations: 176 bytes)

Symbol(x::Symbol, y::Symbol) = Symbol(string(x), string(y))
@btime Symbol(:test, :me)
  84.826 ns (3 allocations: 96 bytes) - 25% better in time, 45% better in memory space
```

This concatenation method is used a lot in Plots.jl and has a material impact on performance: https://github.com/JuliaPlots/Plots.jl/issues/3763