### PR TITLE
Rename shutdown() to closewrite()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@ Standard library changes
   overflow in most cases. The new function `checked_length` is now available, which will try to use checked
   arithmetic to error if the result may be wrapping. Or use a package such as SaferIntegers.jl when
   constructing the range. ([#40382])
-* TCP socket objects now expose `shutdown` functionality and support half-open mode usage ([#40783]).
+* TCP socket objects now expose `closewrite` functionality and support half-open mode usage ([#40783]).
 
 #### InteractiveUtils
 * A new macro `@time_imports` for reporting any time spent importing packages and their dependencies ([#41612])

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -803,7 +803,7 @@ export
 
 # I/O and events
     close,
-    shutdown,
+    closewrite,
     countlines,
     eachline,
     readeach,

--- a/base/io.jl
+++ b/base/io.jl
@@ -62,7 +62,7 @@ Close an I/O stream. Performs a [`flush`](@ref) first.
 function close end
 
 """
-    shutdown(stream)
+    closewrite(stream)
 
 Shutdown the write half of a full-duplex I/O stream. Performs a [`flush`](@ref)
 first. Notify the other end that no more data will be written to the underlying
@@ -76,12 +76,12 @@ julia> write(io, "request");
 
 julia> # calling `read(io)` here would block forever
 
-julia> shutdown(io);
+julia> closewrite(io);
 
 julia> read(io, String)
 "request"
 """
-function shutdown end
+function closewrite end
 
 """
     flush(stream)
@@ -410,7 +410,7 @@ end
 function pipe_reader end
 function pipe_writer end
 
-for f in (:flush, :shutdown, :iswritable)
+for f in (:flush, :closewrite, :iswritable)
     @eval $(f)(io::AbstractPipe) = $(f)(pipe_writer(io)::IO)
 end
 write(io::AbstractPipe, byte::UInt8) = write(pipe_writer(io)::IO, byte)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -334,9 +334,9 @@ end
 
 eof(io::GenericIOBuffer) = (io.ptr-1 == io.size)
 
-function shutdown(io::GenericIOBuffer)
+function closewrite(io::GenericIOBuffer)
     io.writable = false
-    # OR throw(_UVError("shutdown", UV_ENOTSOCK))
+    # OR throw(_UVError("closewrite", UV_ENOTSOCK))
     nothing
 end
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -275,7 +275,7 @@ function setup_stdio(stdio::Union{IOBuffer, BufferStream}, child_readable::Bool)
                 @warn "Process error" exception=(ex, catch_backtrace())
             finally
                 close(parent)
-                child_readable || shutdown(stdio)
+                child_readable || closewrite(stdio)
             end
         end
     catch ex

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -433,7 +433,7 @@ function wait_readnb(x::LibuvStream, nb::Int)
     nothing
 end
 
-function shutdown(s::LibuvStream)
+function closewrite(s::LibuvStream)
     iolock_begin()
     check_open(s)
     req = Libc.malloc(_sizeof_uv_shutdown)
@@ -1476,7 +1476,7 @@ end
 
 isopen(s::BufferStream) = s.status != StatusClosed
 
-shutdown(s::BufferStream) = close(s)
+closewrite(s::BufferStream) = close(s)
 
 function close(s::BufferStream)
     lock(s.cond) do

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -13,7 +13,7 @@ Base.take!(::Base.GenericIOBuffer)
 Base.fdio
 Base.flush
 Base.close
-Base.shutdown
+Base.closewrite
 Base.write
 Base.read
 Base.read!

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -566,7 +566,7 @@ end
         end
         let s = Sockets.connect(addr)
             @test iswritable(s)
-            shutdown(s)
+            closewrite(s)
             @test !iswritable(s)
             close(s)
         end
@@ -578,7 +578,7 @@ end
             end
             @test iswritable(s)
             write(s, "hello world\n")
-            shutdown(s)
+            closewrite(s)
             @test !iswritable(s)
             @test isreadable(s)
             @test read(s, String) == "hello world\n"

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -46,7 +46,7 @@ bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
     @test String(take!(io)) == ""
     @test write(io, ComplexF64(0)) === 16
     @test write(io, Rational{Int64}(1//2)) === 16
-    @test shutdown(io) === nothing
+    @test closewrite(io) === nothing
     @test_throws ArgumentError write(io, UInt8[0])
     @test eof(io)
     @test close(io) === nothing
@@ -253,7 +253,7 @@ end
     @test !eof(bstream)
     read!(bstream,c)
     @test c == a[3:10]
-    @test shutdown(bstream) === nothing
+    @test closewrite(bstream) === nothing
     @test eof(bstream)
     @test bytesavailable(bstream) == 0
     @test close(bstream) === nothing


### PR DESCRIPTION
`shutdown()` was introduced in https://github.com/JuliaLang/julia/pull/40783. It's exported from `Base`, but has not yet been released so renaming is fair game.

The name `closewrite()` was suggested in #24526 and

* Has a good analogy to close(), so people are likely to be able to
  guess what it means.
* Is more specific to IO (conversely, it's easy to imagine shutdown()
  being wanted for any number of things unrelated to closing the write
  side of an IO stream).

See also discussion at https://github.com/JuliaLang/julia/pull/40783