### PR TITLE
Add a hint about `exit()` to the help message when the user types `?` and presses enter

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -23,6 +23,9 @@ as well as many great tutorials and learning resources:
 For help on a specific function or macro, type `?` followed
 by its name, e.g. `?cos`, or `?@time`, and press enter.
 Type `;` to enter shell mode, `]` to enter package mode.
+
+To exit the interactive session, type `CTRL-D` (press the
+control key together with the `d` key), or type `exit()`.
 """
 kw"help", kw"Julia", kw"julia", kw""
 


### PR DESCRIPTION
Closes #41978

This is an alternative to #41978.

I think this PR is less disruptive than #41978. #41978 makes a change to the REPL startup banner. In contrast, this PR does not modify the REPL startup banner. Instead, this PR simply adds the following text to the bottom of the help message that comes up when the user types `?` and presses enter:
> To exit the interactive session, type `CTRL-D` (press the
Control/`^` key together with the `d` key), or type `exit()`.

This text is exactly the same as the corresponding text on the Getting Started page: https://docs.julialang.org/en/v1/manual/getting-started/

The REPL startup banner already includes the following hint:
> Type "?" for help, "]?" for Pkg help.

So this help message is already pretty easy to discover.