### PR TITLE
Remove some trailing whitespace

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -405,7 +405,7 @@ end
 function repl_latex(io::IO, s0::String)
     # This has rampant `Core.Box` problems (#15276). Use the tricks of
     # https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured
-    # We're changing some of the values so the `let` trick isn't applicable. 
+    # We're changing some of the values so the `let` trick isn't applicable.
     s::String = s0
     latex::String = symbol_latex(s)
     if isempty(latex)


### PR DESCRIPTION
The `whitespace` check is currently failing on master. This PR fixes the `whitespace` check by removing the trailing whitespace.