### PR TITLE
Revert "add stream shutdown and support half-duplex operation"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,6 @@ Standard library changes
   overflow in most cases. The new function `checked_length` is now available, which will try to use checked
   arithmetic to error if the result may be wrapping. Or use a package such as SaferIntegers.jl when
   constructing the range. ([#40382])
-* TCP socket objects now expose `shutdown` functionality and support half-open mode usage ([#40783]).
 
 #### InteractiveUtils
 * A new macro `@time_imports` for reporting any time spent importing packages and their dependencies ([#41612])

--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -13,7 +13,6 @@ write(::DevNull, ::UInt8) = 1
 unsafe_write(::DevNull, ::Ptr{UInt8}, n::UInt)::Int = n
 close(::DevNull) = nothing
 wait_close(::DevNull) = wait()
-bytesavailable(io::DevNull) = 0
 
 let CoreIO = Union{Core.CoreSTDOUT, Core.CoreSTDERR}
     global write(io::CoreIO, x::UInt8) = Core.write(io, x)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -803,7 +803,6 @@ export
 
 # I/O and events
     close,
-    shutdown,
     countlines,
     eachline,
     readeach,

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -334,12 +334,6 @@ end
 
 eof(io::GenericIOBuffer) = (io.ptr-1 == io.size)
 
-function shutdown(io::GenericIOBuffer)
-    io.writable = false
-    # OR throw(_UVError("shutdown", UV_ENOTSOCK))
-    nothing
-end
-
 @noinline function close(io::GenericIOBuffer{T}) where T
     io.readable = false
     io.writable = false

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -107,7 +107,6 @@ end
 function uv_alloc_buf end
 function uv_readcb end
 function uv_writecb_task end
-function uv_shutdowncb_task end
 function uv_return_spawn end
 function uv_asynccb end
 function uv_timercb end

--- a/base/process.jl
+++ b/base/process.jl
@@ -275,7 +275,6 @@ function setup_stdio(stdio::Union{IOBuffer, BufferStream}, child_readable::Bool)
                 @warn "Process error" exception=(ex, catch_backtrace())
             finally
                 close(parent)
-                child_readable || shutdown(stdio)
             end
         end
     catch ex

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -13,7 +13,6 @@ Base.take!(::Base.GenericIOBuffer)
 Base.fdio
 Base.flush
 Base.close
-Base.shutdown
 Base.write
 Base.read
 Base.read!

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -230,8 +230,8 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
             deregister_worker(wpid)
         end
 
-        close(r_stream)
-        close(w_stream)
+        isopen(r_stream) && close(r_stream)
+        isopen(w_stream) && close(w_stream)
 
         if (myid() == 1) && (wpid > 1)
             if oldstate != W_TERMINATING

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -551,42 +551,17 @@ end
         r = @async close(s)
         @test_throws Base._UVError("connect", Base.UV_ECANCELED) Sockets.wait_connected(s)
         fetch(r)
-        close(srv)
     end
 end
 
 @testset "iswritable" begin
     let addr = Sockets.InetAddr(ip"127.0.0.1", 4445)
         srv = listen(addr)
-        let s = Sockets.TCPSocket()
-            Sockets.connect!(s, addr)
-            @test iswritable(s) broken=Sys.iswindows()
-            close(s)
-            @test !iswritable(s)
-        end
-        let s = Sockets.connect(addr)
-            @test iswritable(s)
-            shutdown(s)
-            @test !iswritable(s)
-            close(s)
-        end
-        close(srv)
-        srv = listen(addr)
-        let s = Sockets.connect(addr)
-            let c = accept(srv)
-                Base.errormonitor(@async try; write(c, c); finally; close(c); end)
-            end
-            @test iswritable(s)
-            write(s, "hello world\n")
-            shutdown(s)
-            @test !iswritable(s)
-            @test isreadable(s)
-            @test read(s, String) == "hello world\n"
-            @test !isreadable(s)
-            @test !isopen(s)
-            close(s)
-        end
-        close(srv)
+        s = Sockets.TCPSocket()
+        Sockets.connect!(s, addr)
+        @test iswritable(s)
+        close(s)
+        @test !iswritable(s)
     end
 end
 

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -9,7 +9,7 @@ bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
 @testset "Read/write empty IOBuffer" begin
     io = IOBuffer()
     @test eof(io)
-    @test_throws EOFError read(io, UInt8)
+    @test_throws EOFError read(io,UInt8)
     @test write(io,"abc") === 3
     @test isreadable(io)
     @test iswritable(io)
@@ -18,7 +18,7 @@ bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
     @test position(io) == 3
     @test eof(io)
     seek(io, 0)
-    @test read(io, UInt8) == convert(UInt8, 'a')
+    @test read(io,UInt8) == convert(UInt8, 'a')
     a = Vector{UInt8}(undef, 2)
     @test read!(io, a) == a
     @test a == UInt8['b','c']
@@ -34,24 +34,22 @@ bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
     truncate(io, 10)
     @test position(io) == 0
     @test all(io.data .== 0)
-    @test write(io, Int16[1, 2, 3, 4, 5, 6]) === 12
+    @test write(io,Int16[1,2,3,4,5,6]) === 12
     seek(io, 2)
     truncate(io, 10)
     @test ioslength(io) == 10
     io.readable = false
-    @test_throws ArgumentError read!(io, UInt8[0])
+    @test_throws ArgumentError read!(io,UInt8[0])
     truncate(io, 0)
     @test write(io,"boston\ncambridge\n") > 0
     @test String(take!(io)) == "boston\ncambridge\n"
     @test String(take!(io)) == ""
     @test write(io, ComplexF64(0)) === 16
     @test write(io, Rational{Int64}(1//2)) === 16
-    @test shutdown(io) === nothing
-    @test_throws ArgumentError write(io, UInt8[0])
+    close(io)
+    @test_throws ArgumentError write(io,UInt8[0])
+    @test_throws ArgumentError seek(io,0)
     @test eof(io)
-    @test close(io) === nothing
-    @test_throws ArgumentError write(io, UInt8[0])
-    @test_throws ArgumentError seek(io, 0)
 end
 
 @testset "Read/write readonly IOBuffer" begin
@@ -239,7 +237,7 @@ end
     @test isreadable(bstream)
     @test iswritable(bstream)
     @test bytesavailable(bstream) == 0
-    @test sprint(show, bstream) == "BufferStream(bytes waiting=$(bytesavailable(bstream.buffer)), isopen=true)"
+    @test sprint(show, bstream) == "BufferStream() bytes waiting:$(bytesavailable(bstream.buffer)), isopen:true"
     a = rand(UInt8,10)
     write(bstream,a)
     @test !eof(bstream)
@@ -253,10 +251,9 @@ end
     @test !eof(bstream)
     read!(bstream,c)
     @test c == a[3:10]
-    @test shutdown(bstream) === nothing
+    @test close(bstream) === nothing
     @test eof(bstream)
     @test bytesavailable(bstream) == 0
-    @test close(bstream) === nothing
     flag = Ref{Bool}(false)
     event = Base.Event()
     bstream = Base.BufferStream()

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -765,15 +765,7 @@ let text = "input-test-text"
     @test read(proc, String) == string(length(text), '\n')
     @test success(proc)
     @test String(take!(b)) == text
-
-    out = Base.BufferStream()
-    proc = run(catcmd, IOBuffer(text), out, wait=false)
-    @test proc.out === out
-    @test read(out, String) == text
-    @test success(proc)
 end
-
-
 @test repr(Base.CmdRedirect(``, devnull, 0, false)) == "pipeline(``, stdin>Base.DevNull())"
 @test repr(Base.CmdRedirect(``, devnull, 1, true)) == "pipeline(``, stdout<Base.DevNull())"
 @test repr(Base.CmdRedirect(``, devnull, 11, true)) == "pipeline(``, 11<Base.DevNull())"


### PR DESCRIPTION
Reverts JuliaLang/julia#40783

This pull request reverts JuliaLang/julia#40783. JuliaLang/julia#40783 has introduced bugs on at least two platforms:
1. FreeBSD x86_64
2. Linux x86_64

For FreeBSD x86_64, it breaks the Sockets tests - see #41942 for details.

For Linux x86_64, it has introduced a bug in HTTP.jl in which certain HTTP.jl functions will hang indefinitely. Bisect shows that this PR introduced the bug. Reverting this PR fixes the bug. For details of the bisect, see https://github.com/JuliaLang/BumpStdlibs.jl/pull/53. To see a demonstration of the revert fixing the bug, see https://github.com/JuliaLang/BumpStdlibs.jl/pull/54.

Because two platforms are broken, I think the best course of action is to revert #41942, and then reland a different version with the bugs fixed.