### PR TITLE
add `reinterpret` example for lazy array containers

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -515,8 +515,9 @@ julia> reinterpret(Float32, UInt32[1 2 3 4 5])
  1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
 ```
 
-For lazy array containers, the `reinterpret` works on an element-wise sense, so the memory
-might not reflect the actual memory storage:
+Additionally, `reinterpret` does not require the array `A` to have a dense block of memory;
+it can be "lazy" arrays. For instance, `reinterpret` on range `1:6` works the same as the
+dense vector `collect(1:6)`:
 
 ```jldoctest
 julia> reinterpret(Complex{Int}, 1:6) # `UnitRange` does not have a buffer holding array values

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -514,6 +514,19 @@ julia> reinterpret(Float32, UInt32[1 2 3 4 5])
 1×5 reinterpret(Float32, ::Matrix{UInt32}):
  1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
 ```
+
+For lazy array containers, the `reinterpret` works on an element-wise sense, so the memory
+might not reflect the actual memory storage:
+
+```jldoctest
+julia> reinterpret(Int, CartesianIndices((2, 2))) # `CartesianIndices` doesn't allocates memory
+4×2 reinterpret($Int, ::CartesianIndices{2, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}}}):
+ 1  1
+ 1  2
+ 2  2
+ 1  2
+```
+
 """
 reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -519,12 +519,11 @@ For lazy array containers, the `reinterpret` works on an element-wise sense, so 
 might not reflect the actual memory storage:
 
 ```jldoctest
-julia> reinterpret(Int, CartesianIndices((2, 2))) # `CartesianIndices` doesn't allocates memory
-4×2 reinterpret($Int, ::CartesianIndices{2, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}}}):
- 1  1
- 1  2
- 2  2
- 1  2
+julia> reinterpret(Complex{Int}, 1:6) # `UnitRange` does not have a buffer holding array values
+3-element reinterpret(Complex{$Int}, ::UnitRange{$Int}):
+ 1 + 2im
+ 3 + 4im
+ 5 + 6im
 ```
 
 """

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -498,35 +498,17 @@ unsafe_convert(::Type{P}, x::Ptr) where {P<:Ptr} = convert(P, x)
 """
     reinterpret(type, A)
 
-Change the type-interpretation of a block of memory.
-For arrays, this constructs a view of the array with the same binary data as the given
-array, but with the specified element type.
-For example,
-`reinterpret(Float32, UInt32(7))` interprets the 4 bytes corresponding to `UInt32(7)` as a
+Change the type-interpretation of the binary data in the primitive type `A`
+to that of the primitive type `type`.
+The size of `type` has to be the same as that of the type of `A`.
+For example, `reinterpret(Float32, UInt32(7))` interprets the 4 bytes corresponding to `UInt32(7)` as a
 [`Float32`](@ref).
 
 # Examples
 ```jldoctest
 julia> reinterpret(Float32, UInt32(7))
 1.0f-44
-
-julia> reinterpret(Float32, UInt32[1 2 3 4 5])
-1×5 reinterpret(Float32, ::Matrix{UInt32}):
- 1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
 ```
-
-Additionally, `reinterpret` does not require the array `A` to have a dense block of memory;
-it can just as well be a "lazy" array whose elements are not computed until they are explicitly retrieved.
-For instance, `reinterpret` on the range `1:6` works similarly as on the dense vector `collect(1:6)`:
-
-```jldoctest
-julia> reinterpret(Complex{Int}, 1:6)
-3-element reinterpret(Complex{$Int}, ::UnitRange{$Int}):
- 1 + 2im
- 3 + 4im
- 5 + 6im
-```
-
 """
 reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -516,8 +516,8 @@ julia> reinterpret(Float32, UInt32[1 2 3 4 5])
 ```
 
 Additionally, `reinterpret` does not require the array `A` to have a dense block of memory;
-it can be "lazy" arrays. For instance, `reinterpret` on range `1:6` works the same as the
-dense vector `collect(1:6)`:
+it can be "lazy" array whose elements are computed until the `getindex` call. For instance,
+`reinterpret` on range `1:6` works the same as the dense vector `collect(1:6)`:
 
 ```jldoctest
 julia> reinterpret(Complex{Int}, 1:6) # `UnitRange` does not have a buffer holding array values

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -521,11 +521,12 @@ it can be "lazy" array whose elements are computed until the `getindex` call. Fo
 
 ```jldoctest
 julia> reinterpret(Complex{Int}, 1:6) # `UnitRange` does not have a buffer holding array values
-3-element reinterpret(Complex{Int64}, ::UnitRange{Int64}):
+3-element reinterpret(Complex{$Int}, ::UnitRange{$Int}):
  1 + 2im
  3 + 4im
  5 + 6im
 ```
+
 """
 reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -516,11 +516,11 @@ julia> reinterpret(Float32, UInt32[1 2 3 4 5])
 ```
 
 Additionally, `reinterpret` does not require the array `A` to have a dense block of memory;
-it can be "lazy" array whose elements are computed until the `getindex` call. For instance,
-`reinterpret` on range `1:6` works the same as the dense vector `collect(1:6)`:
+it can just as well be a "lazy" array whose elements are not computed until they are explicitly retrieved.
+For instance, `reinterpret` on the range `1:6` works similarly as on the dense vector `collect(1:6)`:
 
 ```jldoctest
-julia> reinterpret(Complex{Int}, 1:6) # `UnitRange` does not have a buffer holding array values
+julia> reinterpret(Complex{Int}, 1:6)
 3-element reinterpret(Complex{$Int}, ::UnitRange{$Int}):
  1 + 2im
  3 + 4im

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -521,12 +521,11 @@ dense vector `collect(1:6)`:
 
 ```jldoctest
 julia> reinterpret(Complex{Int}, 1:6) # `UnitRange` does not have a buffer holding array values
-3-element reinterpret(Complex{$Int}, ::UnitRange{$Int}):
+3-element reinterpret(Complex{Int64}, ::UnitRange{Int64}):
  1 + 2im
  3 + 4im
  5 + 6im
 ```
-
 """
 reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
 

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -137,7 +137,7 @@ julia> M = LinearIndices((2, 3))
  2  4  6
 
 julia> reinterpret(reshape, Complex{Int}, M) # `LinearIndices` does not have a buffer holding array values
-3-element reinterpret(reshape, Complex{$Int}, ::$(typeof(M))) with eltype Complex{$Int}:
+3-element reinterpret(reshape, Complex{$Int}, ::LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}) with eltype Complex{$Int}:
  1 + 2im
  3 + 4im
  5 + 6im

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -111,7 +111,7 @@ of size `n` and `B` lacks `A`'s first dimension. Conversely, if `sizeof(S) = n*s
 
 ```jldoctest
 julia> A = [1 2; 3 4]
-2×2 Matrix{Int64}:
+2×2 Matrix{$Int}:
  1  2
  3  4
 
@@ -121,23 +121,23 @@ julia> reinterpret(reshape, Complex{Int}, A)    # the result is a vector
  2 + 4im
 
 julia> a = [(1,2,3), (4,5,6)]
-2-element Vector{Tuple{Int64, Int64, Int64}}:
+2-element Vector{Tuple{$Int, $Int, $Int}}:
  (1, 2, 3)
  (4, 5, 6)
 
 julia> reinterpret(reshape, Int, a)             # the result is a matrix
-3×2 reinterpret(reshape, Int64, ::Vector{Tuple{Int64, Int64, Int64}}) with eltype Int64:
+3×2 reinterpret(reshape, $Int, ::Vector{Tuple{$Int, $Int, $Int}}) with eltype $Int:
  1  4
  2  5
  3  6
 
 julia> M = LinearIndices((2, 3))
-2×3 LinearIndices{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
+2×3 LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}:
  1  3  5
  2  4  6
 
 julia> reinterpret(reshape, Complex{Int}, M) # `LinearIndices` does not have a buffer holding array values
-3-element reinterpret(reshape, Complex{Int64}, ::LinearIndices{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}) with eltype Complex{Int64}:
+3-element reinterpret(reshape, Complex{$Int}, ::LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}) with eltype Complex{$Int}:
  1 + 2im
  3 + 4im
  5 + 6im

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -131,18 +131,16 @@ julia> reinterpret(reshape, Int, a)             # the result is a matrix
  2  5
  3  6
 
-julia> R = CartesianIndices((2, 1, 1))
-2×1×1 CartesianIndices{3, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}, Base.OneTo{$Int}}}:
-[:, :, 1] =
- CartesianIndex(1, 1, 1)
- CartesianIndex(2, 1, 1)
+julia> M = LinearIndices((2, 3))
+2×3 LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}:
+ 1  3  5
+ 2  4  6
 
-julia> reinterpret(reshape, Int, R)
-3×2×1×1 reinterpret(reshape, $Int, ::CartesianIndices{3, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}, Base.OneTo{$Int}}}) with eltype $Int:
-[:, :, 1, 1] =
- 1  2
- 1  1
- 1  1
+julia> reinterpret(reshape, Complex{Int}, M) # `LinearIndices` does not have a buffer holding array values
+3-element reinterpret(reshape, Complex{$Int}, ::$(typeof(M))) with eltype Complex{$Int}:
+ 1 + 2im
+ 3 + 4im
+ 5 + 6im
 ```
 """
 reinterpret(::typeof(reshape), T::Type, a::AbstractArray)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -25,6 +25,28 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S},IsReshaped} <: AbstractArray{T
     end
 
     global reinterpret
+
+    """
+        reinterpret(T::DataType, A::AbstractArray)
+
+    Construct a view of the array with the same binary data as the given
+    array, but with `T` as element type.
+
+    This function also works on "lazy" array whose elements are not computed until they are explicitly retrieved.
+    For instance, `reinterpret` on the range `1:6` works similarly as on the dense vector `collect(1:6)`:
+
+    ```jldoctest
+    julia> reinterpret(Float32, UInt32[1 2 3 4 5])
+    1×5 reinterpret(Float32, ::Matrix{UInt32}):
+    1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
+
+    julia> reinterpret(Complex{Int}, 1:6)
+    3-element reinterpret(Complex{$Int}, ::UnitRange{$Int}):
+    1 + 2im
+    3 + 4im
+    5 + 6im
+    ```
+    """
     function reinterpret(::Type{T}, a::A) where {T,N,S,A<:AbstractArray{S, N}}
         function thrownonint(S::Type, T::Type, dim)
             @noinline
@@ -130,17 +152,6 @@ julia> reinterpret(reshape, Int, a)             # the result is a matrix
  1  4
  2  5
  3  6
-
-julia> M = LinearIndices((2, 3))
-2×3 LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}:
- 1  3  5
- 2  4  6
-
-julia> reinterpret(reshape, Complex{Int}, M) # `LinearIndices` does not have a buffer holding array values
-3-element reinterpret(reshape, Complex{$Int}, ::LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}) with eltype Complex{$Int}:
- 1 + 2im
- 3 + 4im
- 5 + 6im
 ```
 """
 reinterpret(::typeof(reshape), T::Type, a::AbstractArray)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -130,6 +130,19 @@ julia> reinterpret(reshape, Int, a)             # the result is a matrix
  1  4
  2  5
  3  6
+
+julia> R = CartesianIndices((2, 1, 1))
+2×1×1 CartesianIndices{3, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}, Base.OneTo{$Int}}}:
+[:, :, 1] =
+ CartesianIndex(1, 1, 1)
+ CartesianIndex(2, 1, 1)
+
+julia> reinterpret(reshape, Int, R)
+3×2×1×1 reinterpret(reshape, $Int, ::CartesianIndices{3, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}, Base.OneTo{$Int}}}) with eltype $Int:
+[:, :, 1, 1] =
+ 1  2
+ 1  1
+ 1  1
 ```
 """
 reinterpret(::typeof(reshape), T::Type, a::AbstractArray)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -111,7 +111,7 @@ of size `n` and `B` lacks `A`'s first dimension. Conversely, if `sizeof(S) = n*s
 
 ```jldoctest
 julia> A = [1 2; 3 4]
-2×2 Matrix{$Int}:
+2×2 Matrix{Int64}:
  1  2
  3  4
 
@@ -121,23 +121,23 @@ julia> reinterpret(reshape, Complex{Int}, A)    # the result is a vector
  2 + 4im
 
 julia> a = [(1,2,3), (4,5,6)]
-2-element Vector{Tuple{$Int, $Int, $Int}}:
+2-element Vector{Tuple{Int64, Int64, Int64}}:
  (1, 2, 3)
  (4, 5, 6)
 
 julia> reinterpret(reshape, Int, a)             # the result is a matrix
-3×2 reinterpret(reshape, $Int, ::Vector{Tuple{$Int, $Int, $Int}}) with eltype $Int:
+3×2 reinterpret(reshape, Int64, ::Vector{Tuple{Int64, Int64, Int64}}) with eltype Int64:
  1  4
  2  5
  3  6
 
 julia> M = LinearIndices((2, 3))
-2×3 LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}:
+2×3 LinearIndices{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
  1  3  5
  2  4  6
 
 julia> reinterpret(reshape, Complex{Int}, M) # `LinearIndices` does not have a buffer holding array values
-3-element reinterpret(reshape, Complex{$Int}, ::LinearIndices{2, Tuple{$(Base.OneTo{Int}), $(Base.OneTo{Int})}}) with eltype Complex{$Int}:
+3-element reinterpret(reshape, Complex{Int64}, ::LinearIndices{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}) with eltype Complex{Int64}:
  1 + 2im
  3 + 4im
  5 + 6im


### PR DESCRIPTION
There might be confusion and misunderstanding that `reinterpret` reflects the real memory storage of the array, so I add some examples here and hopefully explained this behavior.

Another example is https://github.com/JuliaArrays/StructArrays.jl/issues/197 where data is stored in the struct of array layout, but `reinterpret` interprets as the array of struct layout.

cc: @piever