### PR TITLE
REPL-only: Print a hint if the user types exit in the REPL using an AST transform

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1354,14 +1354,6 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     nothing
 end
 
-function start_repl_server(port::Int)
-    return listen(port) do server, status
-        client = accept(server)
-        run_repl(client)
-        nothing
-    end
-end
-
 print_exit_hint(repl::AbstractREPL, line) = print_exit_hint(outstream(repl), line)
 function print_exit_hint(io::IO, line)
     if lowercase(strip(line)) == "exit"

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -133,7 +133,7 @@ To remove this functionality, use
 `filter!(!=(REPL.print_exit_hint), Base.active_repl_backend.ast_transforms)`
 
 # Example
-```jldoctest
+```julia
 julia> exit
 suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.
 exit (generic function with 2 methods)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -124,7 +124,24 @@ end
 # Temporary alias until Documenter updates
 const softscope! = softscope
 
-const repl_ast_transforms = Any[softscope] # defaults for new REPL backends
+"""
+    print_exit_hint(ex)
+
+Print a hint about how to exit Julia if the user just types "exit" while using the REPL.
+"""
+function print_exit_hint(@nospecialize ex)
+    if ex isa Expr && ex.head === :toplevel && length(ex.args) == 2 && ex.args[2] === :exit
+        quote
+            println("suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.")
+            # Return the method exit
+            exit
+        end
+    else
+        return ex
+    end
+end
+
+const repl_ast_transforms = Any[softscope, print_exit_hint] # defaults for new REPL backends
 
 # Allows an external package to add hooks into the code loading.
 # The hook should take a Vector{Symbol} of package names and
@@ -417,7 +434,6 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
         if !isempty(line)
             response = eval_with_backend(ast, backend)
             print_response(repl, response, !ends_with_semicolon(line), false)
-            print_exit_hint(repl, line)
         end
         write(repl.terminal, '\n')
         ((!interrupted && isempty(line)) || hit_eof) && break
@@ -858,7 +874,6 @@ function respond(f, repl, main; pass_empty::Bool = false, suppress_on_semicolon:
             end
             hide_output = suppress_on_semicolon && ends_with_semicolon(line)
             print_response(repl, response, !hide_output, hascolor(repl))
-            print_exit_hint(repl, line)
         end
         prepare_next(repl)
         reset_state(s)
@@ -1345,7 +1360,6 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
             end
             response = eval_with_backend(ast, backend)
             print_response(repl, response, !ends_with_semicolon(line), have_color)
-            print_exit_hint(repl, line)
         end
     end
     # Terminate Backend
@@ -1354,12 +1368,5 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     nothing
 end
 
-print_exit_hint(repl::AbstractREPL, line) = print_exit_hint(outstream(repl), line)
-function print_exit_hint(io::IO, line)
-    if lowercase(strip(line)) == "exit"
-        println(io, "\nTo exit Julia, use Ctrl-D, or type exit() and press enter.")
-    end
-    return nothing
-end
 
 end # module

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -128,11 +128,33 @@ const softscope! = softscope
     print_exit_hint(ex)
 
 Print a hint about how to exit Julia if the user just types "exit" while using the REPL.
+
+To remove this functionality, use
+`filter!(!=(REPL.print_exit_hint), Base.active_repl_backend.ast_transforms)`
+
+# Example
+```jldoctest
+julia> exit
+suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.
+exit (generic function with 2 methods)
+
+julia> using REPL
+
+julia> filter!(!=(REPL.print_exit_hint), Base.active_repl_backend.ast_transforms)
+1-element Vector{Any}:
+ softscope (generic function with 1 method)
+
+julia> exit
+exit (generic function with 2 methods)
+```
 """
 function print_exit_hint(@nospecialize ex)
+    # Look to see if user just typed "exit". ex.args[1] is a LineNumberNode
     if ex isa Expr && ex.head === :toplevel && length(ex.args) == 2 && ex.args[2] === :exit
         quote
-            println("suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.")
+            if Main.exit === Base.exit
+                println("suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.")
+            end
             # Return the method exit
             exit
         end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1390,5 +1390,4 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
     nothing
 end
 
-
 end # module


### PR DESCRIPTION
Closes #38522

This is an updated version of #38522 (and also succeeds #21362, #38307), that uses a REPL backend Abstract Syntax Tree transform in order to implement the hint if the user just types `exit`.

One advantage of using an AST transform is that the hint and its small overhead can be removed if desired. Another is that the line string entered does not need to be parsed again.

```julia
julia> exit
suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.
exit (generic function with 2 methods)

julia> using REPL

# Remove hint and associated overhead
julia> filter!(!=(REPL.print_exit_hint), Base.active_repl_backend.ast_transforms) 
1-element Vector{Any}:
 softscope (generic function with 1 method)

julia> exit
exit (generic function with 2 methods)
```

The hint is conscious of if `Main.exit` has been redefined. It will not print the hint in that case.

```julia
julia> exit = 2
2

julia> exit
2

julia> exit()
ERROR: MethodError: objects of type Int64 are not callable
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1

julia> exit = Base.exit
exit (generic function with 2 methods)

julia> exit
suggestion: To exit Julia, use Ctrl-D, or type exit() and press enter.
exit (generic function with 2 methods)
```

An implementation note is that this does not use `Base.isbindingresolved(Main, :exit) && isdefined(Main, :exit)` per https://github.com/JuliaLang/julia/pull/38522#discussion_r533695883. Compiling `isdefined(Main, :exit)` will result in the `:exit` binding being resolved in `Main`, which defeats the purpose. It is also insufficient since what we really want to know is if `Main.exit` is `Base.exit`. Therefore, the `if Main.exit === Base.exit` statement is returned as part of the AST transform. This allows `Main.exit` to be redefined as above while checking if `exit` is what we expect it to be.

This pull request has been rebased on afc504bfc6ddfe315530e1dac6d98e83e19c5d02.

To handle the situation where the user types `quit` or `quit()` see #41990.

