### PR TITLE
Relax `stride(A,2)` requirements in `BLAS.gemv!`

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -664,8 +664,8 @@ for (fname, elty) in ((:dgemv_,:Float64),
                 throw(DimensionMismatch("the transpose of A has dimensions $n, $m, X has length $(length(X)) and Y has length $(length(Y))"))
             end
             chkstride1(A)
-            lda = stride(A,2)
-            lda >= max(1, size(A,1)) || error("`stride(A,2)` must be at least `max(1, size(A,1))`")
+            stride(A,2) >= size(A,1) || size(A,1) == 0 || size(A,2) <= 1 || error("`lda` must be at least `max(1, size(A,1))`")
+            lda = max(1, size(A,1), stride(A,2))
             sX = stride(X,1)
             pX = pointer(X, sX > 0 ? firstindex(X) : lastindex(X))
             sY = stride(Y,1)

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -404,6 +404,9 @@ Random.seed!(100)
                 @test_throws ErrorException BLAS.gemv(trans, view(A, 1:2:3, 1:2), view(v, 1:2))
                 @test_throws ErrorException BLAS.gemv(trans, view(A, 1:2, 2:-1:1), view(v, 1:2))
             end
+            # Cases that should work despite stride(A,2) < 1
+            @test BLAS.gemv!('N', elty(1), zeros(elty, 0, 5), zeros(elty, 5), elty(1), zeros(elty, 0)) == elty[] # stride(A,2) == 0
+            @test BLAS.gemv!('N', elty(1), view(A, :, 2:-1:2), elty[3], elty(2), elty[1,2,3]) == 3.0*A[:,2] + elty[2,4,6] # stride(A,2) == -3
         end
     end
     @testset "gemm" begin


### PR DESCRIPTION
This fixes the regression noted in https://github.com/JuliaLang/julia/pull/41513#issuecomment-905238030. All cases that worked correctly before #41513 should now work again.

There is still a case that could be made to work, but errors. I didn’t change it because it also errored before #41513: the case of a matrix `A` with `stride(A,1) < 1 && (size(A,1) <= 1 || size(A,2) == 0)`.