### PR TITLE
export `jl_resolve_globals_in_ir`

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -150,6 +150,7 @@
     XX(jl_exit_on_sigint) \
     XX(jl_exit_threaded_region) \
     XX(jl_expand) \
+    XX(jl_resolve_globals_in_ir) \
     XX(jl_expand_and_resolve) \
     XX(jl_expand_stmt) \
     XX(jl_expand_stmt_with_loc) \
@@ -550,4 +551,3 @@
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
     XX(jl_yield) \
-

--- a/src/method.c
+++ b/src/method.c
@@ -243,7 +243,7 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
     return expr;
 }
 
-void jl_resolve_globals_in_ir(jl_array_t *stmts, jl_module_t *m, jl_svec_t *sparam_vals,
+JL_DLLEXPORT void jl_resolve_globals_in_ir(jl_array_t *stmts, jl_module_t *m, jl_svec_t *sparam_vals,
                               int binding_effects)
 {
     size_t i, l = jl_array_len(stmts);


### PR DESCRIPTION
This would be very useful for external `AbstractInterpreter`s
to infer (and possibly even optimize) toplevel thunks.
(like https://github.com/aviatesk/JET.jl/pull/241)

/cc @timholy we may be able to use this to eliminate some special casings within JuliaInterpreter (like resolving toplevel `Symbol`s as `GlobalRef`s). The code may end up being more complex on the contrary because of the compatibility with older Julia versions though. 