### PR TITLE
See also & docstrings for `foldl`, `accumulate`

### DIFF
--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -251,41 +251,34 @@ there are specialized variants of `accumulate`, see: [`cumsum`](@ref), [`cumprod
 
 # Examples
 ```jldoctest
-julia> accumulate(+, [1,2,3])
-3-element Vector{Int64}:
+julia> accumulate(+, Int8[1,2,3])
+3-element Vector{Int8}:
  1
  3
  6
 
-julia> accumulate(*, [1,2,3])
-3-element Vector{Int64}:
- 1
- 2
- 6
+julia> accumulate(*, (1,2,3,4))
+(1, 2, 6, 24)
 
-julia> accumulate(+, [1,2,3]; init=100)
-3-element Vector{Int64}:
- 101
- 103
- 106
+julia> accumulate(min, (1, -2, 3, -4, 5), init=0)
+(0, -2, -2, -4, -4)
 
-julia> accumulate(min, [1,2,-1]; init=0)
-3-element Vector{Int64}:
-  0
-  0
- -1
+julia> accumulate(+, i^2 for i in 1:3; init=100.0)
+3-element Vector{Float64}:
+ 101.0
+ 105.0
+ 114.0
 
-julia> accumulate(+, fill(1, 3, 3), dims=1)
-3×3 Matrix{Int64}:
- 1  1  1
- 2  2  2
- 3  3  3
+julia> accumulate(+, fill(1, 3, 4))
+3×4 Matrix{Int64}:
+ 1  4  7  10
+ 2  5  8  11
+ 3  6  9  12
 
-julia> accumulate(+, fill(1, 3, 3), dims=2)
-3×3 Matrix{Int64}:
- 1  2  3
- 1  2  3
- 1  2  3
+julia> accumulate(+, fill(1, 2, 5), dims=2, init=100)
+2×5 Matrix{Int64}:
+ 101  102  103  104  105
+ 101  102  103  104  105
 ```
 """
 function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
@@ -318,41 +311,39 @@ end
 
 Cumulative operation `op` on `A` along the dimension `dims`, storing the result in `B`.
 Providing `dims` is optional for vectors.  If the keyword argument `init` is given, its
-value is used to instantiate the accumulation. See also [`accumulate`](@ref).
+value is used to instantiate the accumulation. 
+
+See also [`accumulate`](@ref), [`cumsum!`](@ref), [`cumprod!`](@ref).
 
 # Examples
 ```jldoctest
 julia> x = [1, 0, 2, 0, 3];
 
-julia> y = [0, 0, 0, 0, 0];
+julia> y = rand(5);
 
 julia> accumulate!(+, y, x);
 
 julia> y
-5-element Vector{Int64}:
- 1
- 1
- 3
- 3
- 6
+5-element Vector{Float64}:
+ 1.0
+ 1.0
+ 3.0
+ 3.0
+ 6.0
 
-julia> A = [1 2; 3 4];
+julia> A = [1 2 3; 4 5 6];
 
-julia> B = [0 0; 0 0];
+julia> B = similar(A);
 
-julia> accumulate!(-, B, A, dims=1);
+julia> accumulate!(-, B, A, dims=1)
+2×3 Matrix{Int64}:
+  1   2   3
+ -3  -3  -3
 
-julia> B
-2×2 Matrix{Int64}:
-  1   2
- -2  -2
-
-julia> accumulate!(-, B, A, dims=2);
-
-julia> B
-2×2 Matrix{Int64}:
- 1  -1
- 3  -1
+julia> accumulate!(*, B, A, dims=2, init=10)
+2×3 Matrix{Int64}:
+ 10   20    60
+ 40  200  1200
 ```
 """
 function accumulate!(op, B, A; dims::Union{Integer, Nothing} = nothing, kw...)

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -118,7 +118,7 @@ end
 
 Cumulative sum of an iterator.
 
-See also [`accumulate`](@ref) to apply functions other than `+`
+See also [`accumulate`](@ref) to apply functions other than `+`.
 
 !!! compat "Julia 1.5"
     `cumsum` on a non-array iterator requires at least Julia 1.5.

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -116,7 +116,7 @@ end
 """
     cumsum(itr)
 
-Cumulative sum an iterator.
+Cumulative sum of an iterator.
 
 See also [`accumulate`](@ref) to apply functions other than `+`
 

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -228,10 +228,10 @@ cumprod(itr) = accumulate(mul_prod, itr)
 Cumulative operation `op` along the dimension `dims` of `A` (providing `dims` is optional
 for vectors). An initial value `init` may optionally be provided by a keyword argument. See
 also [`accumulate!`](@ref) to use a preallocated output array, both for performance and
-to control the precision of the output (e.g. to avoid overflow). 
+to control the precision of the output (e.g. to avoid overflow).
 
-For common operations there are specialized variants of `accumulate`, 
-see [`cumsum`](@ref), [`cumprod`](@ref). For a lazy version, see 
+For common operations there are specialized variants of `accumulate`,
+see [`cumsum`](@ref), [`cumprod`](@ref). For a lazy version, see
 [`Iterators.accumulate`](@ref).
 
 !!! compat "Julia 1.5"
@@ -248,14 +248,14 @@ julia> accumulate(+, Int8[1,2,3])
 julia> accumulate(min, (1, -2, 3, -4, 5), init=0)
 (0, -2, -2, -4, -4)
 
-julia> accumulate(/, (1, 2, 4, 8))
-(1, 0.5, 0.125, 0.015625)
+julia> accumulate(/, (2, 4, Inf), init=100)
+(50.0, 12.5, 0.0)
 
-julia> accumulate(+, i^2 for i in 1:3; init=100.0)
-3-element Vector{Float64}:
- 101.0
- 105.0
- 114.0
+julia> accumulate(=>, i^2 for i in 1:3)
+3-element Vector{Any}:
+          1
+        1 => 4
+ (1 => 4) => 9
 
 julia> accumulate(+, fill(1, 3, 4))
 3×4 Matrix{Int64}:
@@ -263,10 +263,10 @@ julia> accumulate(+, fill(1, 3, 4))
  2  5  8  11
  3  6  9  12
 
-julia> accumulate(+, fill(1, 2, 5), dims=2, init=100)
-2×5 Matrix{Int64}:
- 101  102  103  104  105
- 101  102  103  104  105
+julia> accumulate(+, fill(1, 2, 5), dims=2, init=100.0)
+2×5 Matrix{Float64}:
+ 101.0  102.0  103.0  104.0  105.0
+ 101.0  102.0  103.0  104.0  105.0
 ```
 """
 function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
@@ -299,7 +299,7 @@ end
 
 Cumulative operation `op` on `A` along the dimension `dims`, storing the result in `B`.
 Providing `dims` is optional for vectors.  If the keyword argument `init` is given, its
-value is used to instantiate the accumulation. 
+value is used to instantiate the accumulation.
 
 See also [`accumulate`](@ref), [`cumsum!`](@ref), [`cumprod!`](@ref).
 

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -116,35 +116,29 @@ end
 """
     cumsum(itr)
 
-Cumulative sum an iterator. See also [`cumsum!`](@ref)
-to use a preallocated output array, both for performance and to control the precision of the
-output (e.g. to avoid overflow).
+Cumulative sum an iterator.
+
+See also [`accumulate`](@ref) to apply functions other than `+`
 
 !!! compat "Julia 1.5"
     `cumsum` on a non-array iterator requires at least Julia 1.5.
 
 # Examples
 ```jldoctest
-julia> cumsum([1, 1, 1])
+julia> cumsum(1:3)
 3-element Vector{Int64}:
  1
- 2
  3
+ 6
 
-julia> cumsum([fill(1, 2) for i in 1:3])
+julia> cumsum((true, false, true, false, true))
+(1, 1, 2, 2, 3)
+
+julia> cumsum(fill(1, 2) for i in 1:3)
 3-element Vector{Vector{Int64}}:
  [1, 1]
  [2, 2]
  [3, 3]
-
-julia> cumsum((1, 1, 1))
-(1, 2, 3)
-
-julia> cumsum(x^2 for x in 1:3)
-3-element Vector{Int64}:
-  1
-  5
- 14
 ```
 """
 cumsum(x::AbstractVector) = cumsum(x, dims=1)
@@ -177,10 +171,7 @@ to control the precision of the output (e.g. to avoid overflow).
 
 # Examples
 ```jldoctest
-julia> a = [1 2 3; 4 5 6]
-2×3 Matrix{Int64}:
- 1  2  3
- 4  5  6
+julia> a = Int8[1 2 3; 4 5 6];
 
 julia> cumprod(a, dims=1)
 2×3 Matrix{Int64}:
@@ -217,20 +208,16 @@ julia> cumprod(fill(1//2, 3))
  1//4
  1//8
 
-julia> cumprod([fill(1//3, 2, 2) for i in 1:3])
-3-element Vector{Matrix{Rational{Int64}}}:
- [1//3 1//3; 1//3 1//3]
- [2//9 2//9; 2//9 2//9]
- [4//27 4//27; 4//27 4//27]
+julia> cumprod((1, 2, 1, 3, 1))
+(1, 2, 2, 6, 6)
 
-julia> cumprod((1, 2, 1))
-(1, 2, 2)
-
-julia> cumprod(x^2 for x in 1:3)
-3-element Vector{Int64}:
-  1
-  4
- 36
+julia> cumprod("julia")
+5-element Vector{String}:
+ "j"
+ "ju"
+ "jul"
+ "juli"
+ "julia"
 ```
 """
 cumprod(x::AbstractVector) = cumprod(x, dims=1)

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -191,9 +191,7 @@ end
 """
     cumprod(itr)
 
-Cumulative product of an iterator. See also
-[`cumprod!`](@ref) to use a preallocated output array, both for performance and
-to control the precision of the output (e.g. to avoid overflow).
+Cumulative product of an iterator.
 
 See also [`cumprod!`](@ref), [`accumulate`](@ref), [`cumsum`](@ref).
 
@@ -230,8 +228,11 @@ cumprod(itr) = accumulate(mul_prod, itr)
 Cumulative operation `op` along the dimension `dims` of `A` (providing `dims` is optional
 for vectors). An initial value `init` may optionally be provided by a keyword argument. See
 also [`accumulate!`](@ref) to use a preallocated output array, both for performance and
-to control the precision of the output (e.g. to avoid overflow). For common operations
-there are specialized variants of `accumulate`, see: [`cumsum`](@ref), [`cumprod`](@ref)
+to control the precision of the output (e.g. to avoid overflow). 
+
+For common operations there are specialized variants of `accumulate`, 
+see [`cumsum`](@ref), [`cumprod`](@ref). For a lazy version, see 
+[`Iterators.accumulate`](@ref).
 
 !!! compat "Julia 1.5"
     `accumulate` on a non-array iterator requires at least Julia 1.5.
@@ -244,11 +245,11 @@ julia> accumulate(+, Int8[1,2,3])
  3
  6
 
-julia> accumulate(*, (1,2,3,4))
-(1, 2, 6, 24)
-
 julia> accumulate(min, (1, -2, 3, -4, 5), init=0)
 (0, -2, -2, -4, -4)
+
+julia> accumulate(/, (1, 2, 4, 8))
+(1, 0.5, 0.125, 0.015625)
 
 julia> accumulate(+, i^2 for i in 1:3; init=100.0)
 3-element Vector{Float64}:

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -239,8 +239,8 @@ see [`cumsum`](@ref), [`cumprod`](@ref). For a lazy version, see
 
 # Examples
 ```jldoctest
-julia> accumulate(+, Int8[1,2,3])
-3-element Vector{Int8}:
+julia> accumulate(+, [1,2,3])
+3-element Vector{Int64}:
  1
  3
  6

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -488,13 +488,14 @@ julia> foreach(println, a)
 6
 10
 
-julia> b = Iterators.accumulate(/, (1,2,4); init = 100);
+julia> b = Iterators.accumulate(/, (2, 5, 2, 5); init = 100);
 
 julia> collect(b)
-3-element Vector{Float64}:
- 100.0
-  50.0
-  12.5
+4-element Vector{Float64}:
+ 50.0
+ 10.0
+  5.0
+  1.0
 ```
 """
 accumulate(f, itr; init = Base._InitialValue()) = Accumulate(f, itr, init)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -480,20 +480,21 @@ This is effectively a lazy version of [`Base.accumulate`](@ref).
 
 # Examples
 ```jldoctest
-julia> f = Iterators.accumulate(+, [1,2,3,4]);
+julia> a = Iterators.accumulate(+, [1,2,3,4]);
 
-julia> foreach(println, f)
+julia> foreach(println, a)
 1
 3
 6
 10
 
-julia> f = Iterators.accumulate(+, [1,2,3]; init = 100);
+julia> b = Iterators.accumulate(/, (1,2,4); init = 100);
 
-julia> foreach(println, f)
-101
-103
-106
+julia> collect(b)
+3-element Vector{Float64}:
+ 100.0
+  50.0
+  12.5
 ```
 """
 accumulate(f, itr; init = Base._InitialValue()) = Accumulate(f, itr, init)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -168,6 +168,8 @@ Like [`reduce`](@ref), but with guaranteed left associativity. If provided, the 
 argument `init` will be used exactly once. In general, it will be necessary to provide
 `init` to work with empty collections.
 
+See also [`mapfoldl`](@ref), [`foldr`](@ref), [`accumulate`](@ref).
+
 # Examples
 ```jldoctest
 julia> foldl(=>, 1:4)
@@ -175,6 +177,9 @@ julia> foldl(=>, 1:4)
 
 julia> foldl(=>, 1:4; init=0)
 (((0 => 1) => 2) => 3) => 4
+
+julia> accumulate(=>, (1,2,3,4))
+(1, 1 => 2, (1 => 2) => 3, ((1 => 2) => 3) => 4)
 ```
 """
 foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)


### PR DESCRIPTION
The original goal was to make this link, since someone asked yesterday:
```
julia> foldl(=>, 1:4; init=0)
(((0 => 1) => 2) => 3) => 4

julia> accumulate(=>, (1,2,3,4))
(1, 1 => 2, (1 => 2) => 3, ((1 => 2) => 3) => 4)
```
Perhaps I got carried away trying to improve the doc examples for accumulate. They should be a little shorter than before, and explain more cases, e.g. that `init` is the first argument. Could probably be made shorter. 
```
julia> b = Iterators.accumulate(/, (2, 5, 2, 5); init = 100);

julia> collect(b)
4-element Vector{Float64}:
 50.0
 10.0
  5.0
  1.0
```