### PR TITLE
Reduced number of allocations for dense matrix exp

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -674,7 +674,7 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
         tmp2 .= CC[8].*A6 .+ CC[6].*A4 .+ CC[4].*A2
         mul!(tmp2, true,CC[2]*I, true, true) # tmp2 .+= CC[2]*I
         U = mul!(tmp2, A6, tmp1, true, true)
-        U = A*U
+        U, tmp1 = mul!(tmp1, A, U), A # U = A * U0
 
         # Allocation economical version of:
         # V  = A6 * (CC[13].*A6 .+ CC[11].*A4 .+ CC[9].*A2) .+

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -638,22 +638,24 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
         P = A2
         U = mul!(C[4]*P, true, C[2]*I, true, true) #U = C[2]*I + C[4]*P
         V = mul!(C[3]*P, true, C[1]*I, true, true) #V = C[1]*I + C[3]*P
-        for k in 2:(div(size(C, 1), 2) - 1)
-            k2 = 2 * k
+        for k in 2:(div(length(C), 2) - 1)
             P *= A2
-            mul!(U, C[k2 + 2], P, true, true) # U += C[k2+2]*P
-            mul!(V, C[k2 + 1], P, true, true) # V += C[k2+1]*P
+            mul!(U, C[2k + 2], P, true, true) # U += C[2k+2]*P
+            mul!(V, C[2k + 1], P, true, true) # V += C[2k+1]*P
         end
 
         U = A * U
-        X = V + U
+
         # Padé approximant:  (V-U)\(V+U)
-        LAPACK.gesv!(V-U, X)
+        tmp1, tmp2 = A, A2 # Reuse already allocated arrays
+        tmp1 .= V .- U
+        tmp2 .= V .+ U
+        X = LAPACK.gesv!(tmp1, tmp2)[1]
     else
         s  = log2(nA/5.4)               # power of 2 later reversed by squaring
         if s > 0
             si = ceil(Int,s)
-            A /= convert(T,2^si)
+            A ./= convert(T,2^si)
         end
         CC = T[64764752532480000.,32382376266240000.,7771770303897600.,
                 1187353796428800.,  129060195264000.,  10559470521600.,
@@ -663,32 +665,35 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
         A2 = A * A
         A4 = A2 * A2
         A6 = A2 * A4
-        Ut = mul!(CC[4]*A2, true,CC[2]*I, true, true); # Ut = CC[4]*A2+CC[2]*I
+        tmp1, tmp2 = similar(A6), similar(A6)
+
         # Allocation economical version of:
-        #U  = A * (A6 * (CC[14].*A6 .+ CC[12].*A4 .+ CC[10].*A2) .+
-        #          CC[8].*A6 .+ CC[6].*A4 .+ Ut)
-        U = mul!(CC[8].*A6 .+ CC[6].*A4 .+ Ut,
-                 A6,
-                 CC[14].*A6 .+ CC[12].*A4 .+ CC[10].*A2,
-                 true, true)
+        # U  = A * (A6 * (CC[14].*A6 .+ CC[12].*A4 .+ CC[10].*A2) .+
+        #           CC[8].*A6 .+ CC[6].*A4 .+ CC[4]*A2+CC[2]*I)
+        tmp1 .= CC[14].*A6 .+ CC[12].*A4 .+ CC[10].*A2
+        tmp2 .= CC[8].*A6 .+ CC[6].*A4 .+ CC[4].*A2
+        mul!(tmp2, true,CC[2]*I, true, true) # tmp2 .+= CC[2]*I
+        U = mul!(tmp2, A6, tmp1, true, true)
         U = A*U
 
-        # Allocation economical version of: Vt = CC[3]*A2 (recycle Ut)
-        Vt = mul!(Ut, CC[3], A2, true, false)
-        mul!(Vt, true, CC[1]*I, true, true); # Vt += CC[1]*I
         # Allocation economical version of:
-        #V  = A6 * (CC[13].*A6 .+ CC[11].*A4 .+ CC[9].*A2) .+
-        #           CC[7].*A6 .+ CC[5].*A4 .+ Vt
-        V = mul!(CC[7].*A6 .+ CC[5].*A4 .+ Vt,
-                 A6,
-                 CC[13].*A6 .+ CC[11].*A4 .+ CC[9].*A2,
-                 true, true)
+        # V  = A6 * (CC[13].*A6 .+ CC[11].*A4 .+ CC[9].*A2) .+
+        #           CC[7].*A6 .+ CC[5].*A4 .+ CC[3]*A2 .+ CC[1]*I
+        tmp1 .= CC[13].*A6 .+ CC[11].*A4 .+ CC[9].*A2
+        tmp2 .= CC[7].*A6 .+ CC[5].*A4 .+ CC[3].*A2
+        mul!(tmp2, true, CC[1]*I, true, true) # tmp2 .+= CC[1]*I
+        V = mul!(tmp2, A6, tmp1, true, true)
 
-        X = V + U
-        LAPACK.gesv!(V-U, X)
+        tmp1 .= V .+ U
+        tmp2 .= V .- U # tmp2 aleady contained V but this seems more readable
+        X = LAPACK.gesv!(tmp2, tmp1)[1] # X now contains r_13 in Higham 2008
 
-        if s > 0            # squaring to reverse dividing by power of 2
-            for t=1:si; X *= X end
+        if s > 0
+            # Repeated squaring to compute X = r_13^(2^si)
+            for t=1:si
+                mul!(tmp2, X, X)
+                X, tmp2 = tmp2, X
+            end
         end
     end
 


### PR DESCRIPTION
This PR reduces the number of allocations by the dense matrix exponential `exp(A)` by about half for the case of `opnorm(A,1)` > 2.1. It also removes two allocations for the case of `opnorm(A,1)` <= 2.1.

There are still a few allocations that could be removed, i.e., by replacing
`U = U*A` with `U, tmp1 = mul!(tmp1, A, U), A`, not sure about the weighting in the readability/performance trade-off? 


```julia
for n in [10,30,100,300]
    A = randn(n,n)
    A = 6A/opnorm(A,1)
    @btime exp($A)
end
```
Before:
```
  15.159 μs (17 allocations: 12.70 KiB)
  82.787 μs (17 allocations: 101.39 KiB)
  572.812 μs (31 allocations: 1.07 MiB)
  9.999 ms (31 allocations: 9.62 MiB)
```
After:
```
  14.063 μs (10 allocations: 6.58 KiB)
  77.001 μs (10 allocations: 51.08 KiB)
  537.138 μs (17 allocations: 549.12 KiB)
  8.962 ms (17 allocations: 4.81 MiB)
```