### PR TITLE
Add CheckIndexStyle trait for bounds-checking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,7 @@ New library features
   contains "some message" regardless of the specific exception type.
   Regular expressions, lists of strings, and matching functions are also supported. ([#41888)
 * A new `CheckIndexStyle` trait allows one to dispatch to efficient
-  forms of bounds-checking without overloading `Base.checkindex`. ([#?????])
+  forms of bounds-checking without overloading `Base.checkindex`. ([#42029])
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,8 @@ New library features
 * `@test_throws "some message" triggers_error()` can now be used to check whether the displayed error text
   contains "some message" regardless of the specific exception type.
   Regular expressions, lists of strings, and matching functions are also supported. ([#41888)
+* A new `CheckIndexStyle` trait allows one to dispatch to efficient
+  forms of bounds-checking without overloading `Base.checkindex`. ([#?????])
 
 Standard library changes
 ------------------------

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -715,13 +715,18 @@ checkindex(::Type{Bool}, inds::AbstractUnitRange, i) =
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Real) = (first(inds) <= i) & (i <= last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
-function checkindex(::Type{Bool}, inds::AbstractUnitRange, r::AbstractRange)
+checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractArray{Bool}) = false
+checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractVector{Bool}) =
+    _checkindex(Bool, inds, CheckIndexStyle(typeof(I)), I)
+checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractArray) =
+    _checkindex(Bool, inds, CheckIndexStyle(typeof(I)), I)
+
+function _checkindex(::Type{Bool}, inds::AbstractUnitRange, ::CheckIndexFirstLast, r)
     @_propagate_inbounds_meta
     isempty(r) | (checkindex(Bool, inds, first(r)) & checkindex(Bool, inds, last(r)))
 end
-checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractVector{Bool}) = indx == axes1(I)
-checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractArray{Bool}) = false
-function checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractArray)
+_checkindex(::Type{Bool}, inds::AbstractUnitRange, ::CheckIndexAxes, I) = inds == axes1(I)  # TODO: comparison should be values-only
+function _checkindex(::Type{Bool}, inds::AbstractUnitRange, ::CheckIndexAll, I)
     @inline
     b = true
     for i in I

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -183,6 +183,7 @@ CheckIndexStyle(A::AbstractArray) = CheckIndexStyle(typeof(A))
 CheckIndexStyle(::Type{Union{}}) = CheckIndexAll()
 CheckIndexStyle(::Type{<:AbstractArray{T}}) where T = T === Bool ? CheckIndexAxes() : CheckIndexAll()
 CheckIndexStyle(::Type{<:AbstractRange{T}}) where T = T === Bool ? CheckIndexAxes() : CheckIndexFirstLast()
+CheckIndexStyle(::Type{<:FastContiguousSubArray{T,N,P}} where {T, N, P} = CheckIndexStyle(P)
 
 # array shape rules
 

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -183,7 +183,7 @@ CheckIndexStyle(A::AbstractArray) = CheckIndexStyle(typeof(A))
 CheckIndexStyle(::Type{Union{}}) = CheckIndexAll()
 CheckIndexStyle(::Type{<:AbstractArray{T}}) where T = T === Bool ? CheckIndexAxes() : CheckIndexAll()
 CheckIndexStyle(::Type{<:AbstractRange{T}}) where T = T === Bool ? CheckIndexAxes() : CheckIndexFirstLast()
-CheckIndexStyle(::Type{<:FastContiguousSubArray{T,N,P}} where {T, N, P} = CheckIndexStyle(P)
+CheckIndexStyle(::Type{<:FastContiguousSubArray{T,N,P}}) where {T, N, P} = CheckIndexStyle(P)
 
 # array shape rules
 

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -57,6 +57,10 @@ Base.eachindex
 Base.IndexStyle
 Base.IndexLinear
 Base.IndexCartesian
+Base.CheckIndexStyle
+Base.CheckIndexAll
+Base.CheckIndexFirstLast
+Base.CheckIndexAxes
 Base.conj!
 Base.stride
 Base.strides

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -22,6 +22,10 @@ A = rand(5,4,3)
     @test checkbounds(Bool, A, 5, 12) == false
     @test checkbounds(Bool, A, 1, 13) == false
     @test checkbounds(Bool, A, 6, 12) == false
+
+    x = [1.0, 2.0]
+    @test x[false:true] == [2.0]
+    @test checkindex(Bool, axes(x, 1), false:true) == true
 end
 
 @testset "single CartesianIndex" begin

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -277,6 +277,13 @@ v = view(A0, i1, 1)
 v = view(A0, 1:1, i1)
 @test axes(v) === (Base.OneTo(1), OffsetArrays.IdOffsetRange(Base.OneTo(2), -5))
 
+@test  checkindex(Bool, 1:2, OffsetArray(1:2, (0,)))
+@test  checkindex(Bool, 1:2, OffsetArray([1,2], (0,)))
+@test  checkindex(Bool, 1:2, OffsetArray(false:true, (0,)))
+@test !checkindex(Bool, 1:2, OffsetArray(1:3, (0,)))
+@test !checkindex(Bool, 1:2, OffsetArray([1,3], (0,)))
+@test !checkindex(Bool, 1:3, OffsetArray(false:true, (0,)))
+
 # copyto! and fill!
 a = OffsetArray{Int}(undef, (-3:-1,))
 fill!(a, -1)

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -364,6 +364,8 @@ Broadcast.broadcast_unalias(dest::OffsetArray, src::OffsetArray) = parent(dest) 
 const OffsetRange{T} = OffsetArray{T,1,<:AbstractRange{T}}
 const IIUR = IdentityUnitRange{S} where S<:AbstractUnitRange{T} where T<:Integer
 
+Base.CheckIndexStyle(::Type{<:OffsetRange{T}}) where T = T === Bool ? Base.CheckIndexAxes() : Base.CheckIndexFirstLast()
+
 Base.step(a::OffsetRange) = step(parent(a))
 
 @propagate_inbounds Base.getindex(a::OffsetRange, r::OffsetRange) = OffsetArray(a[parent(r)], r.offsets)


### PR DESCRIPTION
The motivation here is to allow wrapper-types to exploit the same short-
circuits of bounds-checking used for `AbstractRange`.

This also fixes a previously-undiscovered bug in `checkindex` for
`AbstractRange{Bool}` indices. It was hidden by the fact that
`checkbounds` itself short-circuits before calling `checkindex` in
this case. But since `checkindex` is an exported function, it should
also give the correct result.

Example usage: `Wrapper(1:5)` is not necessarily an `AbstractRange` (`Wrapper` may also be able to handle other array types that aren't ranges), yet when used as an index vector it would be nice to be able to short-circuit the bounds checking to just the endpoints. You can specialize `checkindex`, but that can be specialized on *axis* types rather than *index* types, so the trait is the way to go (xref https://github.com/JuliaArrays/OffsetArrays.jl/pull/255).

At the JuliaCon BoF on arrays there was discussion about adding more array traits. This might be viewed as a downpayment on that, but it will be interesting to see whether we think we get to a point of having too many. So imagine this is the first of several and see if you think it's worth it. An alternative would be to put this in ArrayInterface, but we'd have to duplicate a lot of stuff (there's already a fair amount of that in its "src/indexing.jl" file), and since `checkindex` is defined in Base it seems this is the right place.

CC/review request @mbauman, @jishnub, @oxinabox, @tokazama, @ChrisRackauckas, @chriselrod.