### PR TITLE
^(::Float, ::Integer)

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -950,7 +950,7 @@ end
 		return muladd(x, y, muladd(y, xnlo, x*ynlo))
 	end
 	n < 0 && return inv(x)^(-n)
-	return one(n) # n == 0
+	return one(x) # n == 0
 end
 @inline function ^(x::Float32, y::Integer)
     y < 0 && return inv(x^(-y))

--- a/base/math.jl
+++ b/base/math.jl
@@ -935,11 +935,10 @@ end
     n == 0 && return one(x)
     y = 1.0
     xnlo = ynlo = 0.0
-    
     if n < 0
         rx = inv(x)
-        x = rx
         xnlo = fma(x, rx, -1.) * rx
+        x = rx
         n = -n
     end
     n==3 && return x*x*x #keep compatability with literal_pow
@@ -957,9 +956,10 @@ end
     !isfinite(x) && return x*y
     return muladd(x, y, muladd(y, xnlo, x*ynlo))
 end
-@inline function ^(x::Float32, y::Integer)
-    y < 0 && return inv(x^(-y))
-    Float32(Base.power_by_squaring(Float64(x),y))
+@inline function ^(x::Float32, n::Integer)
+    n < 0 && return inv(x)^(-n)
+    n==3 && return x*x*x #keep compatability with literal_pow
+    Float32(Base.power_by_squaring(Float64(x),n))
 end
 @inline ^(x::Float16, y::Integer) = Float16(Float32(x) ^ y)
 @inline literal_pow(::typeof(^), x::Float16, ::Val{p}) where {p} = Float16(literal_pow(^,Float32(x),Val(p)))

--- a/base/math.jl
+++ b/base/math.jl
@@ -911,8 +911,8 @@ function modf(x::Float64)
 end
 
 @inline function ^(x::Float64, y::Float64)
-	yint = round(Int, y)
-	y == yint && return x^yint
+    yint = round(Int, y)
+    y == yint && return x^yint
     z = ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, y)
     if isnan(z) & !isnan(x+y)
         throw_exp_domainerror(x)
@@ -920,8 +920,8 @@ end
     z
 end
 @inline function ^(x::Float32, y::Float32)
-	yint = round(Int, y)
-	y == yint && return x^yint
+    yint = round(Int, y)
+    y == yint && return x^yint
     z = ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, y)
     if isnan(z) & !isnan(x+y)
         throw_exp_domainerror(x)
@@ -932,25 +932,25 @@ end
 
 # compensated power by squaring
 @inline function ^(x::Float64, n::Integer)
-	if n > 0
-		y = 1.0
-		xnlo = ynlo = 0.0
-		while n > 1
-			if n&1 > 0
-				yn = x*y
-				ynlo = fma(x, y , -yn) + muladd(y, xnlo, x*ynlo)
-				y = yn
-			end
-			xn = x * x
-			xnlo = muladd(x, 2*xnlo, fma(x, x, -xn))
-			x = xn
-			n >>>= 1
-		end
-		!isfinite(x) && return x*y
-		return muladd(x, y, muladd(y, xnlo, x*ynlo))
-	end
-	n < 0 && return inv(x)^(-n)
-	return one(x) # n == 0
+    if n > 0
+        y = 1.0
+        xnlo = ynlo = 0.0
+        while n > 1
+            if n&1 > 0
+                yn = x*y
+                ynlo = fma(x, y , -yn) + muladd(y, xnlo, x*ynlo)
+                y = yn
+            end
+            xn = x * x
+            xnlo = muladd(x, 2*xnlo, fma(x, x, -xn))
+            x = xn
+            n >>>= 1
+        end
+        !isfinite(x) && return x*y
+        return muladd(x, y, muladd(y, xnlo, x*ynlo))
+    end
+    n < 0 && return inv(x)^(-n)
+    return one(x) # n == 0
 end
 @inline function ^(x::Float32, y::Integer)
     y < 0 && return inv(x^(-y))

--- a/base/math.jl
+++ b/base/math.jl
@@ -928,7 +928,7 @@ end
 
 # compensated power by squaring
 @inline function ^(x::Float64, y::Integer)
-    n < 0 && return inv(myintpow(x,-n))
+    n < 0 && return inv(x^(-n))
     y = 1.0
     xnlo = ynlo = 0.0
     while n > 1
@@ -946,7 +946,7 @@ end
     return muladd(x, y, muladd(y, xnlo, x*ynlo))
 end
 @inline function ^(x::Float32, y::Integer)
-    y < 0 && return inv(myintpow(x,-y))
+    y < 0 && return inv(x^(-y))
     Float32(Base.power_by_squaring(Float64(x),y))
 end
 @inline ^(x::Float16, y::Integer) = Float16(Float32(x) ^ y)

--- a/base/math.jl
+++ b/base/math.jl
@@ -911,10 +911,8 @@ function modf(x::Float64)
 end
 
 @inline function ^(x::Float64, y::Float64)
-    if isfinite(x)
-        yint = round(Int, y)
-        y == yint && return x^yint
-    end
+    yint = unsafe_trunc(Int, y)
+    y == yint && return x^yint
     z = ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, y)
     if isnan(z) & !isnan(x+y)
         throw_exp_domainerror(x)
@@ -922,10 +920,8 @@ end
     z
 end
 @inline function ^(x::Float32, y::Float32)
-    if isfinite(x)
-        yint = round(Int, y)
-        y == yint && return x^yint
-    end
+    yint = unsafe_trunc(Int, y)
+    y == yint && return x^yint
     z = ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, y)
     if isnan(z) & !isnan(x+y)
         throw_exp_domainerror(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -911,8 +911,10 @@ function modf(x::Float64)
 end
 
 @inline function ^(x::Float64, y::Float64)
-    yint = round(Int, y)
-    y == yint && return x^yint
+    if isfinite(x)
+        yint = round(Int, y)
+        y == yint && return x^yint
+    end
     z = ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, y)
     if isnan(z) & !isnan(x+y)
         throw_exp_domainerror(x)
@@ -920,8 +922,10 @@ end
     z
 end
 @inline function ^(x::Float32, y::Float32)
-    yint = round(Int, y)
-    y == yint && return x^yint
+    if isfinite(x)
+        yint = round(Int, y)
+        y == yint && return x^yint
+    end
     z = ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, y)
     if isnan(z) & !isnan(x+y)
         throw_exp_domainerror(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -911,7 +911,7 @@ function modf(x::Float64)
 end
 
 @inline function ^(x::Float64, y::Float64)
-    yint = unsafe_trunc(Int, y)
+    yint = unsafe_trunc(Int, y) # Note, this is actually safe since julia freezes the result
     y == yint && return x^yint
     z = ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, y)
     if isnan(z) & !isnan(x+y)
@@ -920,7 +920,7 @@ end
     z
 end
 @inline function ^(x::Float32, y::Float32)
-    yint = unsafe_trunc(Int, y)
+    yint = unsafe_trunc(Int, y) # Note, this is actually safe since julia freezes the result
     y == yint && return x^yint
     z = ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, y)
     if isnan(z) & !isnan(x+y)
@@ -932,25 +932,30 @@ end
 
 # compensated power by squaring
 @inline function ^(x::Float64, n::Integer)
-    if n > 0
-        y = 1.0
-        xnlo = ynlo = 0.0
-        while n > 1
-            if n&1 > 0
-                yn = x*y
-                ynlo = fma(x, y , -yn) + muladd(y, xnlo, x*ynlo)
-                y = yn
-            end
-            xn = x * x
-            xnlo = muladd(x, 2*xnlo, fma(x, x, -xn))
-            x = xn
-            n >>>= 1
-        end
-        !isfinite(x) && return x*y
-        return muladd(x, y, muladd(y, xnlo, x*ynlo))
+    n == 0 && return one(x)
+    y = 1.0
+    xnlo = ynlo = 0.0
+    
+    if n < 0
+        rx = inv(x)
+        x = rx
+        xnlo = fma(x, rx, -1.) * rx
+        n = -n
     end
-    n < 0 && return inv(x)^(-n)
-    return one(x) # n == 0
+    n==3 && return x*x*x #keep compatability with literal_pow
+    while n > 1
+        if n&1 > 0
+            yn = x*y
+            ynlo = fma(x, y , -yn) + muladd(y, xnlo, x*ynlo)
+            y = yn
+        end
+        xn = x * x
+        xnlo = muladd(x, 2*xnlo, fma(x, x, -xn))
+        x = xn
+        n >>>= 1
+    end
+    !isfinite(x) && return x*y
+    return muladd(x, y, muladd(y, xnlo, x*ynlo))
 end
 @inline function ^(x::Float32, y::Integer)
     y < 0 && return inv(x^(-y))

--- a/base/math.jl
+++ b/base/math.jl
@@ -927,7 +927,7 @@ end
 @inline ^(x::Float16, y::Float16) = Float16(Float32(x)^Float32(y))  # TODO: optimize
 
 # compensated power by squaring
-@inline function ^(x::Float64, y::Integer)
+@inline function ^(x::Float64, n::Integer)
     n < 0 && return inv(x^(-n))
     y = 1.0
     xnlo = ynlo = 0.0

--- a/base/math.jl
+++ b/base/math.jl
@@ -937,7 +937,7 @@ end
     xnlo = ynlo = 0.0
     if n < 0
         rx = inv(x)
-        xnlo = fma(x, rx, -1.) * rx
+        isfinite(x) && (xnlo = fma(x, rx, -1.) * rx)
         x = rx
         n = -n
     end

--- a/base/math.jl
+++ b/base/math.jl
@@ -949,7 +949,7 @@ end
 		!isfinite(x) && return x*y
 		return muladd(x, y, muladd(y, xnlo, x*ynlo))
 	end
-	n < 0 && return inv(x^(-n))
+	n < 0 && return inv(x)^(-n)
 	return one(n) # n == 0
 end
 @inline function ^(x::Float32, y::Integer)


### PR DESCRIPTION
uses compensated power by squaring for Float64. For Float32, this just using power by squaring with Float64. .5 ULP accuracy for both types.
```
x32 = randn(Float32, 1024); y32 = similar(x32);
x64 = 10 .* randn(Float64, 1024); y64 = similar(x64);
```
Old timings:
```
@btime @. $y32 = $x32^101;
  52.840 μs (0 allocations: 0 bytes)
@btime @. $y64 = $x64^101);
  66.471 μs (0 allocations: 0 bytes)
```
New timings:
```
@btime @. $y32 = $x32^101;
4.619 μs (0 allocations: 0 bytes)

@btime @. $y64 = $x64^101;
  8.520 μs (0 allocations: 0 bytes)
```
Furthermore, this gets .5 ULP accuracy on all inputs I've tested so far, and is even faster than what I've shown for smaller powers.