### PR TITLE
Fix overflow when rounding

### DIFF
--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -119,6 +119,23 @@ end
     @test round(Float32(1.2), sigdigits=5) === Float32(1.2)
     @test round(Float16(0.6), sigdigits=2) === Float16(0.6)
     @test round(Float16(1.1), sigdigits=70) === Float16(1.1)
+
+    # issue 37171
+    @test round(9.87654321e-308, sigdigits = 1) ≈ 1.0e-307
+    @test round(9.87654321e-308, sigdigits = 2) ≈ 9.9e-308
+    @test round(9.87654321e-308, sigdigits = 3) ≈ 9.88e-308
+    @test round(9.87654321e-308, sigdigits = 4) ≈ 9.877e-308
+    @test round(9.87654321e-308, sigdigits = 5) ≈ 9.8765e-308
+    @test round(9.87654321e-308, sigdigits = 6) ≈ 9.87654e-308
+    @test round(9.87654321e-308, sigdigits = 7) ≈ 9.876543e-308
+    @test round(9.87654321e-308, sigdigits = 8) ≈ 9.8765432e-308
+    @test round(9.87654321e-308, sigdigits = 9) ≈ 9.87654321e-308
+    @test round(9.87654321e-308, sigdigits = 10) ≈ 9.87654321e-308
+    @test round(9.87654321e-308, sigdigits = 11) ≈ 9.87654321e-308
+
+    @inferred round(Float16(1.), sigdigits=2)
+    @inferred round(Float32(1.), sigdigits=2)
+    @inferred round(Float64(1.), sigdigits=2)
 end
 
 @testset "literal pow matches runtime pow matches optimized pow" begin


### PR DESCRIPTION
This PR aims to fix #37171. It simply uses a smaller step (square root of it) twice if it overflows. Otherwise, the computation remains exactly the same as before (and thus should not break any code).

Cc to the original author: @simonbyrne

The performance remains almost the same. Tested on i5-1035G1 by
```julia
for dig=1:7
    @btime round($(rand()), sigdigits = $dig)
end
```
Master:
```
  13.995 ns (0 allocations: 0 bytes)
  14.338 ns (0 allocations: 0 bytes)
  14.582 ns (0 allocations: 0 bytes)
  23.895 ns (0 allocations: 0 bytes)
  125.770 ns (0 allocations: 0 bytes)
  125.735 ns (0 allocations: 0 bytes)
  125.771 ns (0 allocations: 0 bytes)
```
This PR:
```
  14.233 ns (0 allocations: 0 bytes)
  14.536 ns (0 allocations: 0 bytes)
  15.044 ns (0 allocations: 0 bytes)
  24.183 ns (0 allocations: 0 bytes)
  126.037 ns (0 allocations: 0 bytes)
  126.018 ns (0 allocations: 0 bytes)
  126.134 ns (0 allocations: 0 bytes)
```

(The performance drop for 5+ digits is caused by the exponent while computing the step, see #42031)