### PR TITLE
inference: add missing `LimitedAccuracy` handlings

### DIFF
--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -96,8 +96,18 @@ end
 struct LimitedAccuracy
     typ
     causes::IdSet{InferenceState}
-    LimitedAccuracy(@nospecialize(typ), causes::IdSet{InferenceState}) =
-        new(typ, causes)
+    function LimitedAccuracy(@nospecialize(typ), causes::IdSet{InferenceState})
+        @assert !isa(typ, LimitedAccuracy) "malformed LimitedAccuracy"
+        return new(typ, causes)
+    end
+end
+
+@inline function collect_limitations!(@nospecialize(typ), sv::InferenceState)
+    if isa(typ, LimitedAccuracy)
+        union!(sv.pclimitations, typ.causes)
+        return typ.typ
+    end
+    return typ
 end
 
 struct NotFound end


### PR DESCRIPTION
I found we need to handle `LimitedAccuracy` (i.e. collect its
limitations into the current frame and unwrap its type) whenever
we do inter-procedural inference. Especially, we need to handle
it where we use `abstract_call_method` and `abstract_call_method_with_const_args`.
Otherwise we may encounter nested `LimitedAccuracy`, which is really not
expected to exist. So this commit also adds the assertion that checks we never
form nested `LimitedAccuracy`.

I encountered errors due to this when analyzing JET by JET itself,
probably because its codebase makes heavy use of `invoke`.
I couldn't pack them up as simple test cases though.