### PR TITLE
Infer eltype explicitly in LinRange

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -562,7 +562,7 @@ end
 
 range_start_stop_length(start, stop, len::Integer) =
     range_start_stop_length(promote(start, stop)..., len)
-range_start_stop_length(start::T, stop::T, len::Integer) where {T} = LinRange{T}(start, stop, len)
+range_start_stop_length(start::T, stop::T, len::Integer) where {T} = LinRange(start, stop, len)
 range_start_stop_length(start::T, stop::T, len::Integer) where {T<:Integer} =
     _linspace(float(T), start, stop, len)
 ## for Float16, Float32, and Float64 we hit twiceprecision.jl to lift to higher precision StepRangeLen


### PR DESCRIPTION
The `eltype` of `LinRange(start::T, stop::T, length)` may not be `T` in general, although it is for floating point types. While integers are handled as a special case, types that wrap integers were not dealt with consistently. This PR fixes that.

define a wrapper type
```julia
struct RealWrapper{T <: Real} <: Real
    x :: T
end
Base.promote_rule(::Type{S}, ::Type{RealWrapper{T}}) where {T,S<:Real} = RealWrapper{promote_type(S, T)}
Base.:(-)(w::RealWrapper) = RealWrapper(-w.x)
for f in [:(+), :(-), :(*), :(/)]
    @eval Base.$f(w::RealWrapper, y::RealWrapper) = RealWrapper($f(w.x, y.x))
end
for f in [:(<), :(==), :(<=)]
    @eval Base.$f(w::RealWrapper, y::RealWrapper) = $f(w.x, y.x)
end
for T in [:Float32, :Float64]
    @eval Base.$T(w::RealWrapper) = $T(w.x)
end
(::Type{RealWrapper{T}})(w::RealWrapper) where {T<:Real} = RealWrapper{T}(T(w.x))
(::Type{T})(w::RealWrapper{T}) where {T<:Real} = T(w.x)
Base.:(==)(w::RealWrapper, y::RealWrapper) = w.x == y.x
Base.isfinite(w::RealWrapper) = isfinite(w.x)
Base.signbit(w::RealWrapper) = signbit(w.x)
```

On master

```julia
julia> x = RealWrapper(2);

julia> range(x, stop = 2x, length = 3)  # works as eltype is preserved
3-element LinRange{RealWrapper{Int64}, Int64}:
 RealWrapper{Int64}(2),RealWrapper{Int64}(3),RealWrapper{Int64}(4)

julia> range(x, stop = 2x, length = 5) # doesn't work
5-element LinRange{RealWrapper{Int64}, Int64}:
Error showing value of type LinRange{RealWrapper{Int64}, Int64}:
ERROR: InexactError: Int64(2.5)
```

This PR
```julia
julia> range(x, 2x, length = 3)
3-element LinRange{RealWrapper{Float64}, Int64}:
 RealWrapper{Float64}(2.0),RealWrapper{Float64}(3.0),RealWrapper{Float64}(4.0)

julia> range(x, 2x, length = 5)
5-element LinRange{RealWrapper{Float64}, Int64}:
 RealWrapper{Float64}(2.0),RealWrapper{Float64}(2.5),RealWrapper{Float64}(3.0),RealWrapper{Float64}(3.5),RealWrapper{Float64}(4.0)
```

There are certain floating-point precision-related differences with the integer case though that I haven't looked into:

```julia
julia> range(Int(x), 2Int(x), length = 7)[3]
2.6666666666666665

julia> range(x, 2x, length = 7)[3]
RealWrapper{Float64}(2.666666666666667)

julia> range(Int(x), 2Int(x), length = 7)[3] |> nextfloat
2.666666666666667
```

Perhaps this may be fixed in another PR?