### PR TITLE
Allow negative `stride(A,2)` in `gemv!`

### DIFF
--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -414,38 +414,38 @@ Random.seed!(100)
         @test all(BLAS.gemv('N', U4, o4) .== v41)
         @test all(BLAS.gemv('N', U4, o4) .== v41)
         @testset "non-standard strides" begin
-            if elty <: Complex
-                A = elty[1+2im 3+4im 5+6im 7+8im; 2+3im 4+5im 6+7im 8+9im; 3+4im 5+6im 7+8im 9+10im]
-                v = elty[1+2im, 2+3im, 3+4im, 4+5im, 5+6im]
-                dest = view(ones(elty, 7), 6:-2:2)
-                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[-31+154im, -35+178im, -39+202im]
-                @test BLAS.gemv('N', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[15-41im, 17-49im]
-                @test BLAS.gemv('N', view(A, 1:0, 1:2), view(v, 1:2)) == elty[]
-                dest = view(ones(elty, 5), 4:-2:2)
-                @test BLAS.gemv!('T', elty(2), view(A, :, 2:2:4), view(v, 1:2:5), elty(3), dest) == elty[-45+202im, -69+370im]
-                @test BLAS.gemv('T', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[14-38im, 18-54im]
-                @test BLAS.gemv('T', view(A, 2:3, 2:1), view(v, 1:2)) == elty[]
-                dest = view(ones(elty, 5), 4:-2:2)
-                @test BLAS.gemv!('C', elty(2), view(A, :, 2:2:4), view(v, 5:-2:1), elty(3), dest) == elty[179+6im, 347+30im]
-                @test BLAS.gemv('C', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[-40-6im, -56-10im]
-                @test BLAS.gemv('C', view(A, 2:3, 2:1), view(v, 1:2)) == elty[]
-            else
-                A = elty[1 2 3 4; 5 6 7 8; 9 10 11 12]
-                v = elty[1, 2, 3, 4, 5]
-                dest = view(ones(elty, 7), 6:-2:2)
-                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(v, 1:3:4), elty(3), dest) == elty[39, 79, 119]
-                @test BLAS.gemv('N', elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[-19, -31]
-                @test BLAS.gemv('N', view(A, 1:0, 1:2), view(v, 1:2)) == elty[]
-                for trans = ('T', 'C')
-                    dest = view(ones(elty, 5), 4:-2:2)
-                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(v, 1:2:5), elty(3), dest) == elty[143, 179]
-                    @test BLAS.gemv(trans, elty(-1), view(A, 2:3, 2:3), view(v, 2:-1:1)) == elty[-22, -25]
-                    @test BLAS.gemv(trans, view(A, 2:3, 2:1), view(v, 1:2)) == elty[]
+            A = rand(elty, 3, 4)
+            x = rand(elty, 5)
+            for y = (view(ones(elty, 5), 1:2:5), view(ones(elty, 7), 6:-2:2))
+                ycopy = copy(y)
+                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(x, 1:3:4), elty(3), y) == 2*A[:,2:2:4]*x[1:3:4] + 3*ycopy
+                ycopy = copy(y)
+                @test BLAS.gemv!('N', elty(2), view(A, :, 4:-2:2), view(x, 1:3:4), elty(3), y) == 2*A[:,4:-2:2]*x[1:3:4] + 3*ycopy
+                ycopy = copy(y)
+                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(x, 4:-3:1), elty(3), y) == 2*A[:,2:2:4]*x[4:-3:1] + 3*ycopy
+                ycopy = copy(y)
+                @test BLAS.gemv!('N', elty(2), view(A, :, 4:-2:2), view(x, 4:-3:1), elty(3), y) == 2*A[:,4:-2:2]*x[4:-3:1] + 3*ycopy
+                ycopy = copy(y)
+                @test BLAS.gemv!('N', elty(2), view(A, :, StepRangeLen(1,0,1)), view(x, 1:1), elty(3), y) == 2*A[:,1:1]*x[1:1] + 3*ycopy # stride(A,2) == 0
+            end
+            @test BLAS.gemv!('N', elty(1), zeros(elty, 0, 5), zeros(elty, 5), elty(1), zeros(elty, 0)) == elty[] # empty matrix, stride(A,2) == 0
+            @test BLAS.gemv('N', elty(-1), view(A, 2:3, 1:2:3), view(x, 2:-1:1)) == -1*A[2:3,1:2:3]*x[2:-1:1]
+            @test BLAS.gemv('N', view(A, 2:3, 3:-2:1), view(x, 1:2:3)) == A[2:3,3:-2:1]*x[1:2:3]
+            for (trans, f) = (('T',transpose), ('C',adjoint))
+                for y = (view(ones(elty, 3), 1:2:3), view(ones(elty, 5), 4:-2:2))
+                    ycopy = copy(y)
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(x, 1:2:5), elty(3), y) == 2*f(A[:,2:2:4])*x[1:2:5] + 3*ycopy
+                    ycopy = copy(y)
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 4:-2:2), view(x, 1:2:5), elty(3), y) == 2*f(A[:,4:-2:2])*x[1:2:5] + 3*ycopy
+                    ycopy = copy(y)
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(x, 5:-2:1), elty(3), y) == 2*f(A[:,2:2:4])*x[5:-2:1] + 3*ycopy
+                    ycopy = copy(y)
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 4:-2:2), view(x, 5:-2:1), elty(3), y) == 2*f(A[:,4:-2:2])*x[5:-2:1] + 3*ycopy
                 end
+                @test BLAS.gemv!(trans, elty(2), view(A, :, StepRangeLen(1,0,1)), view(x, 1:2:5), elty(3), elty[1]) == 2*f(A[:,1:1])*x[1:2:5] + elty[3] # stride(A,2) == 0
             end
             for trans = ('N', 'T', 'C')
-                @test_throws ErrorException BLAS.gemv(trans, view(A, 1:2:3, 1:2), view(v, 1:2))
-                @test_throws ErrorException BLAS.gemv(trans, view(A, 1:2, 2:-1:1), view(v, 1:2))
+                @test_throws ErrorException BLAS.gemv(trans, view(A, 1:2:3, 1:2), view(x, 1:2)) # stride(A,1) must be 1
             end
         end
     end

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -418,31 +418,31 @@ Random.seed!(100)
             x = rand(elty, 5)
             for y = (view(ones(elty, 5), 1:2:5), view(ones(elty, 7), 6:-2:2))
                 ycopy = copy(y)
-                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(x, 1:3:4), elty(3), y) == 2*A[:,2:2:4]*x[1:3:4] + 3*ycopy
+                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(x, 1:3:4), elty(3), y) ≈ 2*A[:,2:2:4]*x[1:3:4] + 3*ycopy
                 ycopy = copy(y)
-                @test BLAS.gemv!('N', elty(2), view(A, :, 4:-2:2), view(x, 1:3:4), elty(3), y) == 2*A[:,4:-2:2]*x[1:3:4] + 3*ycopy
+                @test BLAS.gemv!('N', elty(2), view(A, :, 4:-2:2), view(x, 1:3:4), elty(3), y) ≈ 2*A[:,4:-2:2]*x[1:3:4] + 3*ycopy
                 ycopy = copy(y)
-                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(x, 4:-3:1), elty(3), y) == 2*A[:,2:2:4]*x[4:-3:1] + 3*ycopy
+                @test BLAS.gemv!('N', elty(2), view(A, :, 2:2:4), view(x, 4:-3:1), elty(3), y) ≈ 2*A[:,2:2:4]*x[4:-3:1] + 3*ycopy
                 ycopy = copy(y)
-                @test BLAS.gemv!('N', elty(2), view(A, :, 4:-2:2), view(x, 4:-3:1), elty(3), y) == 2*A[:,4:-2:2]*x[4:-3:1] + 3*ycopy
+                @test BLAS.gemv!('N', elty(2), view(A, :, 4:-2:2), view(x, 4:-3:1), elty(3), y) ≈ 2*A[:,4:-2:2]*x[4:-3:1] + 3*ycopy
                 ycopy = copy(y)
-                @test BLAS.gemv!('N', elty(2), view(A, :, StepRangeLen(1,0,1)), view(x, 1:1), elty(3), y) == 2*A[:,1:1]*x[1:1] + 3*ycopy # stride(A,2) == 0
+                @test BLAS.gemv!('N', elty(2), view(A, :, StepRangeLen(1,0,1)), view(x, 1:1), elty(3), y) ≈ 2*A[:,1:1]*x[1:1] + 3*ycopy # stride(A,2) == 0
             end
             @test BLAS.gemv!('N', elty(1), zeros(elty, 0, 5), zeros(elty, 5), elty(1), zeros(elty, 0)) == elty[] # empty matrix, stride(A,2) == 0
-            @test BLAS.gemv('N', elty(-1), view(A, 2:3, 1:2:3), view(x, 2:-1:1)) == -1*A[2:3,1:2:3]*x[2:-1:1]
-            @test BLAS.gemv('N', view(A, 2:3, 3:-2:1), view(x, 1:2:3)) == A[2:3,3:-2:1]*x[1:2:3]
+            @test BLAS.gemv('N', elty(-1), view(A, 2:3, 1:2:3), view(x, 2:-1:1)) ≈ -1*A[2:3,1:2:3]*x[2:-1:1]
+            @test BLAS.gemv('N', view(A, 2:3, 3:-2:1), view(x, 1:2:3)) ≈ A[2:3,3:-2:1]*x[1:2:3]
             for (trans, f) = (('T',transpose), ('C',adjoint))
                 for y = (view(ones(elty, 3), 1:2:3), view(ones(elty, 5), 4:-2:2))
                     ycopy = copy(y)
-                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(x, 1:2:5), elty(3), y) == 2*f(A[:,2:2:4])*x[1:2:5] + 3*ycopy
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(x, 1:2:5), elty(3), y) ≈ 2*f(A[:,2:2:4])*x[1:2:5] + 3*ycopy
                     ycopy = copy(y)
-                    @test BLAS.gemv!(trans, elty(2), view(A, :, 4:-2:2), view(x, 1:2:5), elty(3), y) == 2*f(A[:,4:-2:2])*x[1:2:5] + 3*ycopy
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 4:-2:2), view(x, 1:2:5), elty(3), y) ≈ 2*f(A[:,4:-2:2])*x[1:2:5] + 3*ycopy
                     ycopy = copy(y)
-                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(x, 5:-2:1), elty(3), y) == 2*f(A[:,2:2:4])*x[5:-2:1] + 3*ycopy
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 2:2:4), view(x, 5:-2:1), elty(3), y) ≈ 2*f(A[:,2:2:4])*x[5:-2:1] + 3*ycopy
                     ycopy = copy(y)
-                    @test BLAS.gemv!(trans, elty(2), view(A, :, 4:-2:2), view(x, 5:-2:1), elty(3), y) == 2*f(A[:,4:-2:2])*x[5:-2:1] + 3*ycopy
+                    @test BLAS.gemv!(trans, elty(2), view(A, :, 4:-2:2), view(x, 5:-2:1), elty(3), y) ≈ 2*f(A[:,4:-2:2])*x[5:-2:1] + 3*ycopy
                 end
-                @test BLAS.gemv!(trans, elty(2), view(A, :, StepRangeLen(1,0,1)), view(x, 1:2:5), elty(3), elty[1]) == 2*f(A[:,1:1])*x[1:2:5] + elty[3] # stride(A,2) == 0
+                @test BLAS.gemv!(trans, elty(2), view(A, :, StepRangeLen(1,0,1)), view(x, 1:2:5), elty(3), elty[1]) ≈ 2*f(A[:,1:1])*x[1:2:5] + elty[3] # stride(A,2) == 0
             end
             for trans = ('N', 'T', 'C')
                 @test_throws ErrorException BLAS.gemv(trans, view(A, 1:2:3, 1:2), view(x, 1:2)) # stride(A,1) must be 1


### PR DESCRIPTION
This replaces #42012 as another attempt at fixing https://github.com/JuliaLang/julia/pull/41513#issuecomment-905238030. It implements the idea from https://github.com/JuliaLang/julia/pull/41513#issuecomment-906962477.

Instead of just allowing `stride(A,2) < 1` in trivial cases, the requirement `stride(A,2) ≥ max(1, size(A,1))` is relaxed to `abs(stride(A,2)) ≥ size(A,1) || size(A,2) ≤ 1`.

We could also think about relaxing the requirement `stride(A,1) == 1` to `abs(stride(A,1)) == 1`.

Closes  #42012.