### PR TITLE
Make `to_indices` infered better for CartesianIndex/Indices

### DIFF
--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1580,8 +1580,11 @@ end
     end
 end
 
-@testset "to_indices inference #42001" begin
+@testset "to_indices inference (issue #42001 #44059)" begin
     @test (@inferred to_indices([], ntuple(Returns(CartesianIndex(1)), 32))) == ntuple(Returns(1), 32)
     @test (@inferred to_indices([], ntuple(Returns(CartesianIndices(1:1)), 32))) == ntuple(Returns(Base.OneTo(1)), 32)
     @test (@inferred to_indices([], (CartesianIndex(),1,CartesianIndex(1,1,1)))) == ntuple(Returns(1), 4)
+    A = randn(2,2,2,2,2,2);
+    i = CartesianIndex((1,1))
+    @test (@inferred A[i,i,i]) === A[1]
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1579,3 +1579,9 @@ end
         @test strides(reshape(b, 5, 6, 2)) == (-n, -5n, -30n)
     end
 end
+
+@testset "to_indices inference #42001" begin
+    @test (@inferred to_indices([], ntuple(Returns(CartesianIndex(1)), 32))) == ntuple(Returns(1), 32)
+    @test (@inferred to_indices([], ntuple(Returns(CartesianIndices(1:1)), 32))) == ntuple(Returns(Base.OneTo(1)), 32)
+    @test (@inferred to_indices([], (CartesianIndex(),1,CartesianIndex(1,1,1)))) == ntuple(Returns(1), 4)
+end


### PR DESCRIPTION
Fix #42001 by unfolding CartesianIndex/Indices outside the inner `to_indices`.
(This should also fix https://github.com/JuliaGPU/CUDA.jl/issues/1039)

- Before this PR

```julia
julia> @code_warntype to_indices([1], ntuple(_ -> CartesianIndex(1), 32))
MethodInstance for to_indices(::Vector{Int64}, ::NTuple{32, CartesianIndex{1}})
  from to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex}}}) in Base at multidimensional.jl:801
Arguments
  #self#::Core.Const(to_indices)
  A::Vector{Int64}
  I::NTuple{32, CartesianIndex{1}}
Body::Union{Tuple{Int64, Int64}, Tuple{Int64, Int64, Any, Vararg{Any}}}
1 ─      nothing
│   %2 = ()::Core.Const(())
│   %3 = Base.to_indices(A, %2, I)::Union{Tuple{Int64, Int64}, Tuple{Int64, Int64, Any, Vararg{Any}}}
└──      return %3

julia> @code_warntype to_indices([1], (CartesianIndex(),1,CartesianIndex(1,2,3)))
MethodInstance for to_indices(::Vector{Int64}, ::Tuple{CartesianIndex{0}, Int64, CartesianIndex{3}})
  from to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex}}}) in Base at multidimensional.jl:801
Arguments
  #self#::Core.Const(to_indices)
  A::Vector{Int64}
  I::Tuple{CartesianIndex{0}, Int64, CartesianIndex{3}}
Body::Tuple{Int64, Int64, Vararg{Int64}}
1 ─      nothing
│   %2 = ()::Core.Const(())
│   %3 = Base.to_indices(A, %2, I)::Tuple{Int64, Int64, Vararg{Int64}}
└──      return %3
```

- After this PR 
```julia
julia> @code_warntype to_indices([1], ntuple(_ -> CartesianIndex(1), 32))
MethodInstance for to_indices(::Vector{Int64}, ::NTuple{32, CartesianIndex{1}})
  from to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex}}}) in Base at multidimensional.jl:801
Arguments
  #self#::Core.Const(to_indices)
  A::Vector{Int64}
  I::NTuple{32, CartesianIndex{1}}
Body::NTuple{32, Int64}
1 ─      nothing
│   %2 = ()::Core.Const(())
│   %3 = Base.to_indices(A, %2, I)::NTuple{32, Int64}
└──      return %3

julia> @code_warntype to_indices([1], (CartesianIndex(),1,CartesianIndex(1,2,3)))
MethodInstance for to_indices(::Vector{Int64}, ::Tuple{CartesianIndex{0}, Int64, CartesianIndex{3}})
  from to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex}}}) in Base at multidimensional.jl:801
Arguments
  #self#::Core.Const(to_indices)
  A::Vector{Int64}
  I::Tuple{CartesianIndex{0}, Int64, CartesianIndex{3}}
Body::NTuple{4, Int64}
1 ─      nothing
│   %2 = ()::Core.Const(())
│   %3 = Base.to_indices(A, %2, I)::NTuple{4, Int64}
└──      return %3
```