### PR TITLE
Improve getdict performance

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -218,7 +218,7 @@ function getdict(data::Vector{UInt})
     return getdict!(dict, data)
 end
 
-function getdict!(dict::LineInfoDict(), data::Vector{UInt})
+function getdict!(dict::LineInfoDict, data::Vector{UInt})
     for ip in udata
         # Lookup is expensive, so do it only once per ip.
         haskey(dict, UInt64(ip)) && continue

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -214,10 +214,14 @@ function retrieve()
 end
 
 function getdict(data::Vector{UInt})
-    # Lookup is expensive, so do it only once per ip.
-    udata = unique(data)
     dict = LineInfoDict()
+    return getdict!(dict, data)
+end
+
+function getdict!(dict::LineInfoDict(), data::Vector{UInt})
     for ip in udata
+        # Lookup is expensive, so do it only once per ip.
+        haskey(dict, UInt64(ip)) && continue
         st = lookup(convert(Ptr{Cvoid}, ip))
         # To correct line numbers for moving code, put it in the form expected by
         # Base.update_stackframes_callback[]

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -219,7 +219,7 @@ function getdict(data::Vector{UInt})
 end
 
 function getdict!(dict::LineInfoDict, data::Vector{UInt})
-    for ip in udata
+    for ip in data
         # Lookup is expensive, so do it only once per ip.
         haskey(dict, UInt64(ip)) && continue
         st = lookup(convert(Ptr{Cvoid}, ip))


### PR DESCRIPTION
1. Allow users like Dagger to keep one lidict around instead of recomputing all the time
2. Instead of doing a linear pass to unique the dataset, check existance in dictonary

