### PR TITLE
avoid loading duplicate libraries

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -551,3 +551,4 @@
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
     XX(jl_yield) \
+


### PR DESCRIPTION
We will not use the duplicate, so best to try to avoid loading it.