### PR TITLE
GMP: fix warning in init

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -94,10 +94,10 @@ const ALLOC_OVERFLOW_FUNCTION = Ref(false)
 function __init__()
     try
         if version().major != VERSION.major || bits_per_limb() != BITS_PER_LIMB
-            msg = bits_per_limb() != BITS_PER_LIMB ? error : warn
-            msg("The dynamically loaded GMP library (v\"$(version())\" with __gmp_bits_per_limb == $(bits_per_limb()))\n",
-                "does not correspond to the compile time version (v\"$VERSION\" with __gmp_bits_per_limb == $BITS_PER_LIMB).\n",
-                "Please rebuild Julia.")
+            msg = """The dynamically loaded GMP library (v\"$(version())\" with __gmp_bits_per_limb == $(bits_per_limb()))
+                     does not correspond to the compile time version (v\"$VERSION\" with __gmp_bits_per_limb == $BITS_PER_LIMB).
+                     Please rebuild Julia."""
+            bits_per_limb() != BITS_PER_LIMB ? @error(msg) : @warn(msg)
         end
 
         ccall((:__gmp_set_memory_functions, :libgmp), Cvoid,


### PR DESCRIPTION
The `warn` function does not exist, and `error` has no effect here (it is wrapped in try/catch)

```
julia> @eval Base.GMP VERSION = v"1.2.3"
WARNING: redefinition of constant VERSION. This may fail, cause incorrect answers, or produce other errors.
v"1.2.3"

julia> @eval Base.GMP BITS_PER_LIMB = 32
WARNING: redefinition of constant BITS_PER_LIMB. This may fail, cause incorrect answers, or produce other errors.
32

julia> Base.GMP.__init__()
┌ Error: The dynamically loaded GMP library (v"6.2.1" with __gmp_bits_per_limb == 64)
│ does not correspond to the compile time version (v"1.2.3" with __gmp_bits_per_limb == 32).
│ Please rebuild Julia.
└ @ Base.GMP /data/vtjnash/julia1/base/gmp.jl:100
true

julia> @edit Base.GMP.__init__()

julia> Base.GMP.__init__()
WARNING: Error during initialization of module GMP:
ErrorException("could not load library "xlibgmp"
xlibgmp.so: cannot open shared object file: No such file or directory")
true
```