### PR TITLE
add test for trying to create BitArray from infinite iter

### DIFF
--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -203,6 +203,15 @@ timesofar("utils")
         @test_throws DimensionMismatch BitMatrix((isodd(i) for i in 1:3))
     end
 
+    @testset "constructor from infinite iterable" begin
+        struct InfiniteIter; state::Bool; end
+        Base.iterate(i::InfiniteIter, state=1) = (state, !state)
+        Base.IteratorSize(i::InfiniteIter) = Base.IsInfinite()
+
+        inf_iter = InfiniteIter(1)
+        @test_throws ArgumentError BitArray(inf_iter)
+    end
+
     @testset "constructor from NTuple" begin
         for nt in ((true, false, false), NTuple{0,Bool}(), (false,), (true,))
             @test BitVector(nt) == BitVector(collect(nt))

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -203,12 +203,8 @@ timesofar("utils")
         @test_throws DimensionMismatch BitMatrix((isodd(i) for i in 1:3))
     end
 
-    @testset "constructor from infinite iterable" begin
-        struct InfiniteIter; state::Bool; end
-        Base.iterate(i::InfiniteIter, state=1) = (state, !state)
-        Base.IteratorSize(i::InfiniteIter) = Base.IsInfinite()
-
-        inf_iter = InfiniteIter(1)
+    @testset "constructor from infinite iterator" begin
+        inf_iter = Base.Iterators.cycle([true])
         @test_throws ArgumentError BitArray(inf_iter)
     end
 


### PR DESCRIPTION
_[My first PR]_ 
Improve the [code coverage](https://coveralls.io/builds/42489547/source?filename=base%2Fbitarray.jl#L602) by testing that the `BitArray` constructor throws a `MethodError` when passing an iterator with `IsInfinite` size.