### PR TITLE
inference: propagate variable changes to all exception frames

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1919,10 +1919,11 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                         ssavaluetypes[pc] = t
                     end
                 end
-                cur_hand = frame.handler_at[pc]
                 if isa(changes, StateUpdate)
-                    while cur_hand != 0
-                        let l = frame.handler_at[cur_hand + 1]
+                    let cur_hand = frame.handler_at[pc], l, enter
+                        while cur_hand != 0
+                            enter = frame.src.code[cur_hand]
+                            l = (enter::Expr).args[1]::Int
                             # propagate new type info to exception handler
                             # the handling for Expr(:enter) propagates all changes from before the try/catch
                             # so this only needs to propagate any changes
@@ -1932,8 +1933,8 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                                 end
                                 push!(W, l)
                             end
+                            cur_hand = frame.handler_at[cur_hand]
                         end
-                        cur_hand = frame.handler_at[cur_hand]
                     end
                 end
             end

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -28,9 +28,7 @@ mutable struct InferenceState
     pc´´::LineNum
     nstmts::Int
     # current exception handler info
-    cur_hand #::Union{Nothing, Pair{LineNum, prev_handler}}
-    handler_at::Vector{Any}
-    n_handlers::Int
+    handler_at::Vector{LineNum}
     # ssavalue sparsity and restart info
     ssavalue_uses::Vector{BitSet}
     throw_blocks::BitSet
@@ -86,25 +84,21 @@ mutable struct InferenceState
         throw_blocks = find_throw_blocks(code)
 
         # exception handlers
-        cur_hand = nothing
-        handler_at = Any[ nothing for i=1:n ]
-        n_handlers = 0
-
-        W = BitSet()
-        push!(W, 1) #initial pc to visit
+        ip = BitSet()
+        handler_at = compute_trycatch(src.code, ip)
+        push!(ip, 1)
 
         mod = isa(def, Method) ? def.module : def
-
         valid_worlds = WorldRange(src.min_world,
             src.max_world == typemax(UInt) ? get_world_counter() : src.max_world)
+
         frame = new(
             InferenceParams(interp), result, linfo,
             sp, slottypes, mod, 0,
             IdSet{InferenceState}(), IdSet{InferenceState}(),
             src, get_world_counter(interp), valid_worlds,
             nargs, s_types, s_edges, stmt_info,
-            Union{}, W, 1, n,
-            cur_hand, handler_at, n_handlers,
+            Union{}, ip, 1, n, handler_at,
             ssavalue_uses, throw_blocks,
             Vector{Tuple{InferenceState,LineNum}}(), # cycle_backedges
             Vector{InferenceState}(), # callers_in_cycle
@@ -117,6 +111,91 @@ mutable struct InferenceState
         return frame
     end
 end
+
+function compute_trycatch(code::Vector{Any}, ip::BitSet)
+    # The goal initially is to record the frame like this for the state at exit:
+    # 1: (enter 3) # == 0
+    # 3: (expr)    # == 1
+    # 3: (leave 1) # == 1
+    # 4: (expr)    # == 0
+    # then we can find all trys by walking backwards from :enter statements,
+    # and all catches by looking at the statement after the :enter
+    n = length(code)
+    empty!(ip)
+    ip.offset = 0 # for _bits_findnext
+    push!(ip, n + 1)
+    handler_at = fill(0, n)
+
+    # start from all :enter statements and record the location of the try
+    for pc = 1:n
+        stmt = code[pc]
+        if isexpr(stmt, :enter)
+            l = stmt.args[1]::Int
+            handler_at[pc + 1] = pc
+            push!(ip, pc + 1)
+            handler_at[l] = pc
+            push!(ip, l)
+        end
+    end
+
+    # now forward those marks to all :leave statements
+    pc´´ = 0
+    while true
+        # make progress on the active ip set
+        pc = _bits_findnext(ip.bits, pc´´)::Int
+        pc > n && break
+        while true # inner loop optimizes the common case where it can run straight from pc to pc + 1
+            pc´ = pc + 1 # next program-counter (after executing instruction)
+            if pc == pc´´
+                pc´´ = pc´
+            end
+            delete!(ip, pc)
+            cur_hand = handler_at[pc]
+            @assert cur_hand != 0 "unbalanced try/catch"
+            stmt = code[pc]
+            if isa(stmt, GotoNode)
+                pc´ = stmt.label
+            elseif isa(stmt, GotoIfNot)
+                l = stmt.dest::Int
+                if handler_at[l] != cur_hand
+                    @assert handler_at[l] == 0 "unbalanced try/catch"
+                    handler_at[l] = cur_hand
+                    if l < pc´´
+                        pc´´ = l
+                    end
+                    push!(ip, l)
+                end
+            elseif isa(stmt, ReturnNode)
+                @assert !isdefined(stmt, :val) "unbalanced try/catch"
+                break
+            elseif isa(stmt, Expr)
+                head = stmt.head
+                if head === :enter
+                    cur_hand = pc
+                elseif head === :leave
+                    l = stmt.args[1]::Int
+                    for i = 1:l
+                        cur_hand = handler_at[cur_hand]
+                    end
+                    cur_hand == 0 && break
+                end
+            end
+
+            pc´ > n && break # can't proceed with the fast-path fall-through
+            if handler_at[pc´] != cur_hand
+                @assert handler_at[pc´] == 0 "unbalanced try/catch"
+                handler_at[pc´] = cur_hand
+            elseif !in(pc´, ip)
+                break  # already visited
+            end
+            pc = pc´
+        end
+    end
+
+    @assert first(ip) == n + 1
+    return handler_at
+end
+
 
 """
     Iterate through all callers of the given InferenceState in the abstract

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3430,32 +3430,32 @@ g41908() = f41908(Any[1][1])
 @test only(Base.return_types(g41908, ())) <: Int
 
 # issue #42022
-let x = Any[
-        Expr(:(=), Core.SlotNumber(3), 1)
-        Expr(:enter, 18)
-        Expr(:(=), Core.SlotNumber(3), 2.0)
-        Expr(:enter, 12)
-        Expr(:(=), Core.SlotNumber(3), '3')
-        Core.GotoIfNot(Core.SlotNumber(2), 9)
-        Expr(:leave, 2)
-        Core.ReturnNode(1)
-        Expr(:call, GlobalRef(Main, :throw))
-        Expr(:leave, 1)
-        Core.GotoNode(16)
-        Expr(:leave, 1)
-        Expr(:(=), Core.SlotNumber(4), Expr(:the_exception))
-        Expr(:call, GlobalRef(Main, :rethrow))
-        Expr(:pop_exception, Core.SSAValue(4))
-        Expr(:leave, 1)
-        Core.GotoNode(22)
-        Expr(:leave, 1)
-        Expr(:(=), Core.SlotNumber(5), Expr(:the_exception))
-        nothing
-        Expr(:pop_exception, Core.SSAValue(2))
-        Core.ReturnNode(Core.SlotNumber(3))
+let x = Tuple{Int,Any}[
+        #= 1=# (0, Expr(:(=), Core.SlotNumber(3), 1))
+        #= 2=# (0, Expr(:enter, 18))
+        #= 3=# (2, Expr(:(=), Core.SlotNumber(3), 2.0))
+        #= 4=# (2, Expr(:enter, 12))
+        #= 5=# (4, Expr(:(=), Core.SlotNumber(3), '3'))
+        #= 6=# (4, Core.GotoIfNot(Core.SlotNumber(2), 9))
+        #= 7=# (4, Expr(:leave, 2))
+        #= 8=# (0, Core.ReturnNode(1))
+        #= 9=# (4, Expr(:call, GlobalRef(Main, :throw)))
+        #=10=# (4, Expr(:leave, 1))
+        #=11=# (2, Core.GotoNode(16))
+        #=12=# (4, Expr(:leave, 1))
+        #=13=# (2, Expr(:(=), Core.SlotNumber(4), Expr(:the_exception)))
+        #=14=# (2, Expr(:call, GlobalRef(Main, :rethrow)))
+        #=15=# (2, Expr(:pop_exception, Core.SSAValue(4)))
+        #=16=# (2, Expr(:leave, 1))
+        #=17=# (0, Core.GotoNode(22))
+        #=18=# (2, Expr(:leave, 1))
+        #=19=# (0, Expr(:(=), Core.SlotNumber(5), Expr(:the_exception)))
+        #=20=# (0, nothing)
+        #=21=# (0, Expr(:pop_exception, Core.SSAValue(2)))
+        #=22=# (0, Core.ReturnNode(Core.SlotNumber(3)))
     ]
-    handler_at = Core.Compiler.compute_trycatch(x, Core.Compiler.BitSet())
-    @test handler_at == [0, 0, 2, 2, 4, 4, 4, 0, 4, 4, 2, 4, 2, 2, 2, 2, 0, 2, 0, 0, 0, 0]
+    handler_at = Core.Compiler.compute_trycatch(last.(x), Core.Compiler.BitSet())
+    @test handler_at == first.(x)
 end
 
 @test only(Base.return_types((Bool,)) do y

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3472,4 +3472,4 @@ end
             nothing
         end
         return x
-    end) === Union{Int64, Float64, Char}
+    end) === Union{Int, Float64, Char}


### PR DESCRIPTION
Switch to precomputing the handler_at for each statement, instead of copying around a linked list for more efficiency, and chain backwards on that linked list to update all places the exception might get thrown to.

Fix #42022