### PR TITLE
Set default exeflags to start procs using active project

### DIFF
--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -527,7 +527,7 @@ default_addprocs_params() = Dict{Symbol,Any}(
     :topology => :all_to_all,
     :dir      => pwd(),
     :exename  => joinpath(Sys.BINDIR::String, julia_exename()),
-    :exeflags => "--project=$(Base.active_project())",
+    :exeflags => `--project=$(Base.active_project())`,
     :enable_threaded_blas => false,
     :lazy => true)
 

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -527,7 +527,7 @@ default_addprocs_params() = Dict{Symbol,Any}(
     :topology => :all_to_all,
     :dir      => pwd(),
     :exename  => joinpath(Sys.BINDIR::String, julia_exename()),
-    :exeflags => ``,
+    :exeflags => "--project=$(Base.active_project())",
     :enable_threaded_blas => false,
     :lazy => true)
 


### PR DESCRIPTION
Maybe a breaking change, also probably not the best way to implement this. Someone setting `exeflag` may find it surprising that doing so suddenly no longer sets the project to be the active one.

However, I think most people will find this to be the expected behavior, so I'd like at least some discussion on this behavior. It can be surprising to `addprocs` and suddenly have `using` error or load different versions than from your current session.

Perhaps there already was some discussion on the desired behavior here?

EDIT:
I tested this locally. I'm willing to bet that this won't work when the procs don't share a filesystem, unless they all happen to have a project at the same path.

So maybe I should edit `addprocs(np::Integer, kwargs...)`, having it forward to something like `addprocs(manager; exeflags = get(kwargs, :exeflags, "--project=$(Base.active_project())"), kwargs...)` instead, to set the exeflags this way).