### PR TITLE
wip: REPLCompletions: allow completions for `using`-ed names

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -77,13 +77,15 @@ function fullname(m::Module)
 end
 
 """
-    names(x::Module; all::Bool = false, imported::Bool = false)
+    names(x::Module; all::Bool=false, imported::Bool=false, usings::Bool=false)
 
 Get a vector of the public names of a `Module`, excluding deprecated names.
 If `all` is true, then the list also includes non-public names defined in the module,
 deprecated names, and compiler-generated names.
 If `imported` is true, then names explicitly imported from other modules
-are also included. Names are returned in sorted order.
+are also included.
+If `usings` is true, then names explicitly imported via `using` are also included.
+Names are returned in sorted order.
 
 As a special case, all names defined in `Main` are considered \"public\",
 since it is not idiomatic to explicitly mark names from `Main` as public.
@@ -95,10 +97,9 @@ since it is not idiomatic to explicitly mark names from `Main` as public.
 
 See also: [`Base.isexported`](@ref), [`Base.ispublic`](@ref), [`Base.@locals`](@ref), [`@__MODULE__`](@ref).
 """
-names(m::Module; all::Bool = false, imported::Bool = false) =
-    sort!(unsorted_names(m; all, imported))
-unsorted_names(m::Module; all::Bool = false, imported::Bool = false) =
-    ccall(:jl_module_names, Array{Symbol,1}, (Any, Cint, Cint), m, all, imported)
+names(m::Module; kwargs...) = sort!(unsorted_names(m; kwargs...))
+unsorted_names(m::Module; all::Bool=false, imported::Bool=false, usings::Bool=false) =
+    ccall(:jl_module_names, Array{Symbol,1}, (Any, Cint, Cint, Cint), m, all, imported, usings)
 
 """
     isexported(m::Module, s::Symbol) -> Bool

--- a/src/module.c
+++ b/src/module.c
@@ -991,10 +991,22 @@ JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
     return (jl_value_t*)a;
 }
 
-JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
+uint8_t _binding_is_from_explicit_using(jl_binding_t *b) {
+    return (jl_atomic_load_relaxed(&b->owner) != NULL && b->owner != b && !b->imported &&
+            // Modules implicitly get all exported names from Base and Core as if they had
+            // written `using Base`, but we don't show those via `names()`.
+            // b->owner->value != (jl_value_t*)jl_base_module && b->owner->value != (jl_value_t*)jl_core_module);
+            b->globalref->mod != jl_base_module && b->globalref->mod != jl_core_module);
+}
+
+void _append_symbol_to_bindings_array(jl_array_t* a, jl_sym_t *name) {
+    jl_array_grow_end(a, 1);
+    //XXX: change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:
+    jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)name);
+}
+
+void _jl_module_names_into_array(jl_array_t* a, jl_module_t *m, int all, int imported, int usings)
 {
-    jl_array_t *a = jl_alloc_array_1d(jl_array_symbol_type, 0);
-    JL_GC_PUSH1(&a);
     jl_svec_t *table = jl_atomic_load_relaxed(&m->bindings);
     for (size_t i = 0; i < jl_svec_len(table); i++) {
         jl_binding_t *b = (jl_binding_t*)jl_svecref(table, i);
@@ -1003,15 +1015,39 @@ JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
         jl_sym_t *asname = b->globalref->name;
         int hidden = jl_symbol_name(asname)[0]=='#';
         int main_public = (m == jl_main_module && !(asname == jl_eval_sym || asname == jl_include_sym));
-        if ((b->publicp ||
+        if (b->value != (jl_value_t*)m &&
+            (b->publicp ||
              (imported && b->imported) ||
+             (usings && _binding_is_from_explicit_using(b)) ||
              (jl_atomic_load_relaxed(&b->owner) == b && !b->imported && (all || main_public))) &&
             (all || (!b->deprecated && !hidden))) {
-            jl_array_grow_end(a, 1);
-            // n.b. change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:
-            jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)asname);
+            _append_symbol_to_bindings_array(a, asname);
         }
         table = jl_atomic_load_relaxed(&m->bindings);
+    }
+}
+
+JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported, int usings)
+{
+    jl_array_t *a = jl_alloc_array_1d(jl_array_symbol_type, 0);
+    JL_GC_PUSH1(&a);
+    // First, encode the module's name
+    _append_symbol_to_bindings_array(a, m->name);
+    _jl_module_names_into_array(a, m, all, imported, usings);
+    if (usings) {
+        for(int i=(int)m->usings.len-1; i >= 0; --i) {
+            jl_module_t *imp = module_usings_getidx(m, i);
+            if (imp != jl_base_module && imp != jl_core_module) {
+                // Add all the _exported_ names from imp into a.
+                _jl_module_names_into_array(a, imp, 0, 0, 0);
+                // Add the name of imp itself, unless the user requested `all=true` and it's
+                // a submodule of `m`, since then its name would have already been added by
+                // `all=true`, since it's a binding in `m`.
+                if (!all || imp->parent != m) {
+                    _append_symbol_to_bindings_array(a, imp->name);
+                }
+            }
+        }
     }
     JL_GC_POP();
     return (jl_value_t*)a;

--- a/src/module.c
+++ b/src/module.c
@@ -992,7 +992,8 @@ JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
 }
 
 uint8_t _binding_is_from_explicit_using(jl_binding_t *b) {
-    return (jl_atomic_load_relaxed(&b->owner) != NULL && b->owner != b && !b->imported);
+    jl_binding_t *owner = jl_atomic_load_relaxed(&b->owner);
+    return (owner != NULL && owner != b && !b->imported);
 }
 
 void _append_symbol_to_bindings_array(jl_array_t* a, jl_sym_t *name) {
@@ -1011,7 +1012,7 @@ void _jl_module_names_into_array(jl_array_t* a, jl_module_t *m, int all, int imp
         jl_sym_t *asname = b->globalref->name;
         int hidden = jl_symbol_name(asname)[0]=='#';
         int main_public = (m == jl_main_module && !(asname == jl_eval_sym || asname == jl_include_sym));
-        if ((b->value != (jl_value_t*)m) &&
+        if ((jl_atomic_load_relaxed(&b->value) != (jl_value_t*)m) &&
             ((exported ? b->exportp : b->publicp) ||
              (imported && b->imported) ||
              (usings && _binding_is_from_explicit_using(b)) ||

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -135,9 +135,9 @@ function appendmacro!(syms, macros, needle, endchar)
     end
 end
 
-function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString, all::Bool = false, imported::Bool = false)
-    ssyms = names(mod, all = all, imported = imported)
-    all || filter!(Base.Fix1(Base.isexported, mod), ssyms)
+function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString; kwargs...)
+    ssyms = names(mod; kwargs...)
+    # all || filter!(Base.Fix1(Base.isexported, mod), ssyms) # TODO revisit
     filter!(ffunc, ssyms)
     macros = filter(x -> startswith(String(x), "@" * name), ssyms)
     syms = String[sprint((io,s)->Base.show_sym(io, s; allow_macroname=true), s) for s in ssyms if completes_global(String(s), name)]
@@ -181,14 +181,14 @@ function complete_symbol(@nospecialize(ex), name::String, @nospecialize(ffunc), 
         end
         # Looking for a binding in a module
         if mod == context_module
-            # Also look in modules we got through `using`
-            mods = ccall(:jl_module_usings, Any, (Any,), context_module)::Vector
-            for m in mods
-                append!(suggestions, filtered_mod_names(p, m::Module, name))
-            end
-            append!(suggestions, filtered_mod_names(p, mod, name, true, true))
-        else
-            append!(suggestions, filtered_mod_names(p, mod, name, true, false))
+            # special case `Core` and `Base` bindings
+            # - `Core` bindings should be added to every modules
+            # - `Base` bindings should be added to non-bare modules
+            append!(suggestions, filtered_mod_names(p, Core, name))
+            isdefined(mod, :Base) && append!(suggestions, filtered_mod_names(p, Base, name))
+            append!(suggestions, filtered_mod_names(p, mod, name; all=true, imported=true, usings=true))
+        else # dot-accessed module context
+            append!(suggestions, filtered_mod_names(p, mod, name; all=true, usings=true))
         end
     elseif val !== nothing # looking for a property of an instance
         try

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2138,8 +2138,11 @@ for (s, compl) in (("2*CompletionFoo.nam", "named"),
                    ("CompletionFoo.type_test + CompletionFoo.unicode_αβγ.", "yy"),
                    ("(CompletionFoo.type_test + CompletionFoo.unicode_αβγ).", "xx"),
                    ("foo'CompletionFoo.test!1", "test!12"))
-    c, r = test_complete(s)
-    @test only(c) == compl
+    @testset let s=s, compl=compl
+        c, r = test_complete_noshift(s)
+        @test length(c) == 1
+        @test only(c) == compl
+    end
 end
 
 # allows symbol completion within incomplete :macrocall

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -125,10 +125,17 @@ not_const = 1
 # For curmod_*
 include("testenv.jl")
 
+module TestMod36529
+    x36529 = 0
+    y36529 = 1
+    export y36529
+end
+
 module TestMod7648
 using Test
 import Base.convert
 import ..curmod_name, ..curmod
+using ..TestMod36529: x36529   # doesn't import TestMod36529 or y36529, even though it's exported
 export a9475, foo9475, c7648, foo7648, foo7648_nomethods, Foo7648
 
 const c7648 = 8
@@ -177,8 +184,62 @@ let
                                                       :foo7648, Symbol("#foo7648"), :foo7648_nomethods, Symbol("#foo7648_nomethods"),
                                                       :Foo7648, :eval, Symbol("#eval"), :include, Symbol("#include"),
                                                       :convert, :curmod_name, :curmod])
+    @test Set(names(TestMod7648, usings = true)) == Set([:x36529, :Test,  Symbol("@inferred"), Symbol("@test"), Symbol("@test_broken"),
+                                        Symbol("@test_deprecated"), Symbol("@test_logs"), Symbol("@test_nowarn"), Symbol("@test_skip"),
+                                        Symbol("@test_throws"), Symbol("@test_warn"), Symbol("@testset"), :GenericArray, :GenericDict,
+                                        :GenericOrder, :GenericSet, :GenericString, :Test, :TestSetException, :detect_ambiguities, :detect_unbound_args,
+                                        :TestMod7648, :TestModSub9475, :TestMod7648, :a9475, :foo9475, :c7648, :foo7648, :foo7648_nomethods,
+                                        :Foo7648, Symbol("@__MODULE__"), :Base, :LogRecord, :(==), :(===), :TestLogger])
+    @test Set(names(TestMod7648, all = true, usings = true)) == Set([:x36529, :Test,  Symbol("@inferred"), Symbol("@test"), Symbol("@test_broken"),
+                                        Symbol("@test_deprecated"), Symbol("@test_logs"), Symbol("@test_nowarn"), Symbol("@test_skip"),
+                                        Symbol("@test_throws"), Symbol("@test_warn"), Symbol("@testset"), :GenericArray, :GenericDict,
+                                        :GenericOrder, :GenericSet, :GenericString, :Test, :TestSetException, :detect_ambiguities, :detect_unbound_args,
+                                        :TestMod7648, :TestModSub9475, :a9475, :foo9475, :c7648, :d7648, :f7648,
+                                        :foo7648, Symbol("#foo7648"), :foo7648_nomethods, Symbol("#foo7648_nomethods"),
+                                        :Foo7648, :eval, Symbol("#eval"), :include, Symbol("#include"), Symbol("@__MODULE__"), :Base,
+                                        :LogRecord, :(==), :(===), :TestLogger])
     @test isconst(TestMod7648, :c7648)
     @test !isconst(TestMod7648, :d7648)
+end
+
+module TestMod42092
+module M1
+    const m1_x = 1
+    export m1_x
+end
+module M2
+    const m2_x = 1
+    export m2_x
+end
+module A
+    module B
+        f(x) = 1
+        secret = 1
+        module Inner2 end
+    end
+    module C
+        x = 1
+        y = 2
+        export y
+    end
+    using .B: f
+    using .C
+    using ..M1
+    import ..M2
+end
+end # module TestMod42092
+
+let defaultset = Set((:A,))
+    imported = Set((:M2,))
+    usings = Set((:A, :f, :C, :y, :M1, :m1_x))
+    allset = Set((:A, :B, :C, :eval, :include, Symbol("#eval"), Symbol("#include")))
+    @test Set(names(TestMod42092.A)) == defaultset
+    @test Set(names(TestMod42092.A, imported=true)) == defaultset ∪ imported
+    @test Set(names(TestMod42092.A, usings=true)) == defaultset ∪ usings
+    @test Set(names(TestMod42092.A, all=true)) == allset
+    @test Set(names(TestMod42092.A, all=true, usings=true)) == allset ∪ usings
+    @test Set(names(TestMod42092.A, imported=true, usings=true)) == defaultset ∪ imported ∪ usings
+    @test Set(names(TestMod42092.A, all=true, imported=true, usings=true)) == allset ∪ imported ∪ usings
 end
 
 let


### PR DESCRIPTION
Add parameter to `names(m::Module)` to return the bindings that come from `using` statements inside that module.

This was actually a bit trickier than I expected it to be, because there are a few oddities to consider:
- Bindings that are exported from `Foo`, which come from `using Foo`, are added to `m`'s bindings table _lazily_, whenever they're first referenced.
    - This means that it's not enough to allow returning names that have a different parent module, but weren't `->imported`, because it means the names returned from `names(m::Module, usings=true)` would _change over time_ as functions are called that perform the binding lookup!
    - So instead, I added logic to walk over all the modules in the `m->usings` list, and fetch all of their exported names.
- We have to take special care not to return names exported from Base and Core, to keep consistent with how `names()` currently works.
    - Though we could consider allowing these if `all=true`? i.e. should `names(m, all=true, usings=true)` return names that come from Base and Core? We _did_ write `all=true`, and we're _not_ returning all the names... but also, it's very noisy / probably useless to return all of them.
- We don't want to print submodules that are also usings twice

Here's a nice example that I think showcases all the edgecases:
```julia
julia> module M1
           const m1_x = 1
           export m1_x
       end
Main.M1

julia> module A
           module B
               f(x) = 1
               secret = 1
               module Inner2 end
           end
           module C
               x = 1
               y = 2
               export y
           end
           using .B: f
           using .C
           using ..M1
       end
Main.A

julia> names(A)
1-element Vector{Symbol}:
 :A

julia> names(A, imported=true)
1-element Vector{Symbol}:
 :A

julia> names(A, usings=true)
6-element Vector{Symbol}:
 :A
 :C
 :M1
 :f
 :m1_x
 :y

julia> names(A, all=true)
7-element Vector{Symbol}:
 Symbol("#eval")
 Symbol("#include")
 :A
 :B
 :C
 :eval
 :include

julia> names(A, all=true, usings=true)
11-element Vector{Symbol}:
 Symbol("#eval")
 Symbol("#include")
 :A
 :B
 :C
 :M1
 :eval
 :f
 :include
 :m1_x
 :y
```


Fixes https://github.com/JuliaLang/julia/issues/36529.

---

- closes #49109
- closes #53524