### PR TITLE
Fix irrationals raised to negative integer exponents

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -158,6 +158,10 @@ for op in Symbol[:+, :-, :*, :/, :^]
     @eval $op(x::AbstractIrrational, y::AbstractIrrational) = $op(Float64(x),Float64(y))
 end
 *(x::Bool, y::AbstractIrrational) = ifelse(x, Float64(y), 0.0)
+function ^(x::AbstractIrrational, y::Integer)
+    (z, y) = y >= 0 ? (Float64(x), y) : (Float64(inv(x)), -y)
+    power_by_squaring(z, y)
+end
 
 round(x::Irrational, r::RoundingMode) = round(float(x), r)
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1089,6 +1089,22 @@ end
     @test @inferred(inv(π)) ≈ 0.3183098861837907
 end
 
+@testset "Irrationals exponentiated" begin
+    for T in (:pi, :ℯ, :γ, :catalan)
+        for m in -2:2
+            @eval (n = $m; @test (@inferred $T^$m) === (@inferred $T^n))
+            @eval (n = big($m); @test (@inferred $T^big($m)) == (@inferred $T^n))
+            @eval (n = Int8($m); @test (@inferred $T^Int8($m)) === (@inferred $T^n))
+        end
+    end
+    # We don't use ℯ in the general tests as it often gets lowered to exp
+    for T in (:pi, :γ, :catalan)
+        for n in Any[Float32(2), Float64(2), 2//3, im]
+            @eval @test (@inferred $T^n) == (@inferred Float64($T)^n)
+        end
+    end
+end
+
 @testset "Irrationals compared with Rationals and Floats" begin
     @test Float64(pi,RoundDown) < pi
     @test Float64(pi,RoundUp) > pi


### PR DESCRIPTION
While this works currently for literal integer exponents, it may be made to work in general for integer exponents in a type-stable way by converting the irrational value to `Float64`

On master
```julia
julia> pi^-2
0.10132118364233779

julia> n=-2; pi^n
ERROR: DomainError with -2:
Cannot raise an integer x to a negative power -2.
Convert input to float.
```

After this PR
```julia
julia> n=-2; pi^n
0.10132118364233779

julia> pi^n === pi^-2
true
```