### PR TITLE
Throw `CapturedException`s from asyncmap to avoid dropping the stacktrace

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -236,6 +236,7 @@ function start_worker_task!(worker_tasks, exec_func, chnl, batch_size=nothing)
             end
         catch e
             close(chnl)
+            display_error(stderr, catch_stack())
             retval = e
         end
         retval

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -236,8 +236,7 @@ function start_worker_task!(worker_tasks, exec_func, chnl, batch_size=nothing)
             end
         catch e
             close(chnl)
-            display_error(stderr, catch_stack())
-            retval = e
+            retval = CapturedException(e, catch_backtrace())
         end
         retval
     end

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -236,7 +236,7 @@ function start_worker_task!(worker_tasks, exec_func, chnl, batch_size=nothing)
             end
         catch e
             close(chnl)
-            retval = CapturedException(e, catch_backtrace())
+            retval = capture_exception(e, catch_backtrace())
         end
         retval
     end

--- a/base/task.jl
+++ b/base/task.jl
@@ -25,6 +25,10 @@ function showerror(io::IO, ce::CapturedException)
     showerror(io, ce.ex, ce.processed_bt, backtrace=true)
 end
 
+# wraps `CapturedException` but can be overloaded to be a no-op
+# when a stacktrace is already captured (e.g. `Distributed.RemoteException`).
+capture_exception(ex, bt) = CapturedException(ex, bt)
+
 """
     CompositeException
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -25,8 +25,14 @@ function showerror(io::IO, ce::CapturedException)
     showerror(io, ce.ex, ce.processed_bt, backtrace=true)
 end
 
-# wraps `CapturedException` but can be overloaded to be a no-op
-# when a stacktrace is already captured (e.g. `Distributed.RemoteException`).
+"""
+    capture_exception(ex, bt) -> Exception
+
+Returns an exception, possibly incorporating information from a backtrace `bt`. Defaults to returning [`CapturedException(ex, bt)`](@ref).
+
+Used in [`asyncmap`](@ref) and [`asyncmap!`](@ref) to capture exceptions thrown during
+the user-supplied function call.
+"""
 capture_exception(ex, bt) = CapturedException(ex, bt)
 
 """

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -44,6 +44,8 @@ struct RemoteException <: Exception
     captured::CapturedException
 end
 
+Base.capture_exception(ex::RemoteException, bt) = ex
+
 """
     RemoteException(captured)
 

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -45,9 +45,9 @@ struct RemoteException <: Exception
 end
 
 """
-    capture_exception(ex::RemoteException, bt) = ex
+    capture_exception(ex::RemoteException, bt)
 
-Returns `ex` which has already captured a backtrace (via it's [`CapturedException`](@ref)).
+Returns `ex::RemoteException` which has already captured a backtrace (via it's [`CapturedException`](@ref) field `captured`).
 """
 Base.capture_exception(ex::RemoteException, bt) = ex
 

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -44,6 +44,11 @@ struct RemoteException <: Exception
     captured::CapturedException
 end
 
+"""
+    capture_exception(ex::RemoteException, bt) = ex
+
+Returns `ex` which has already captured a backtrace (via it's [`CapturedException`](@ref)).
+"""
 Base.capture_exception(ex::RemoteException, bt) = ex
 
 """

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -634,7 +634,7 @@ let error_thrown = false
     try
         pmap(x -> x == 50 ? error("foobar") : x, 1:100)
     catch e
-        @test e.captured.ex.msg == "foobar"
+        @test e.ex.captured.ex.msg == "foobar"
         error_thrown = true
     end
     @test error_thrown
@@ -1723,7 +1723,7 @@ let (h, t) = Distributed.head_and_tail(Int[], 0)
 end
 
 # issue #35937
-let e = @test_throws RemoteException pmap(1) do _
+let e = @test_throws CapturedException pmap(1) do _
             wait(@async error(42))
         end
     # check that the inner TaskFailedException is correctly formed & can be printed

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1726,6 +1726,7 @@ end
 let e = @test_throws CapturedException pmap(1) do _
             wait(@async error(42))
         end
+    @test e.value.ex isa RemoteException
     # check that the inner TaskFailedException is correctly formed & can be printed
     es = sprint(showerror, e.value)
     @test contains(es, ":\nTaskFailedException\nStacktrace:\n")

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -634,7 +634,7 @@ let error_thrown = false
     try
         pmap(x -> x == 50 ? error("foobar") : x, 1:100)
     catch e
-        @test e.ex.captured.ex.msg == "foobar"
+        @test e.captured.ex.msg == "foobar"
         error_thrown = true
     end
     @test error_thrown
@@ -1723,10 +1723,9 @@ let (h, t) = Distributed.head_and_tail(Int[], 0)
 end
 
 # issue #35937
-let e = @test_throws CapturedException pmap(1) do _
+let e = @test_throws RemoteException pmap(1) do _
             wait(@async error(42))
         end
-    @test e.value.ex isa RemoteException
     # check that the inner TaskFailedException is correctly formed & can be printed
     es = sprint(showerror, e.value)
     @test contains(es, ":\nTaskFailedException\nStacktrace:\n")

--- a/test/asyncmap.jl
+++ b/test/asyncmap.jl
@@ -54,6 +54,19 @@ len_only_iterable = (1,2,3,4,5)
 @test_throws ArgumentError asyncmap(identity, 1:10; batch_size="10")
 @test_throws ArgumentError asyncmap(identity, 1:10; ntasks="10")
 
+# Check that we throw a `CapturedException` holding the stacktrace if `f` throws
+f42105(i) = i == 5 ? error("captured") :  i
+let
+    e = try
+        asyncmap(f42105, 1:5)
+    catch e
+        e
+    end
+    @test e isa CapturedException
+    @test e.ex == ErrorException("captured")
+    @test e.processed_bt[2][1].func == :f42105
+end
+
 include("generic_map_tests.jl")
 generic_map_tests(asyncmap, asyncmap!)
 


### PR DESCRIPTION
Edit: see https://github.com/JuliaLang/julia/pull/42105#issuecomment-1002240027

---

Original OP:

Currently, we don't get stacktraces from errors that occur inside a function being `asyncmap`'d. We get the exceptions but not the stacktrace (https://github.com/JuliaLang/julia/issues/41030). This PR just adds the print statement from https://github.com/JuliaLang/julia/issues/36709#issuecomment-672992250.

A simple example:
```julia
julia> f(i) = (sleep(i); i == 5 && error("5"))
f (generic function with 1 method)

julia> asyncmap(f, 1:5) # master
ERROR: 5
Stacktrace:
 [1] (::Base.var"#881#883")(x::Task)
   @ Base ./asyncmap.jl:177
 [2] foreach(f::Base.var"#881#883", itr::Vector{Any})
   @ Base ./abstractarray.jl:2606
 [3] maptwice(wrapped_f::Function, chnl::Channel{Any}, worker_tasks::Vector{Any}, c::UnitRange{Int64})
   @ Base ./asyncmap.jl:177
 [4] wrap_n_exec_twice
   @ ./asyncmap.jl:153 [inlined]
 [5] async_usemap(f::typeof(f), c::UnitRange{Int64}; ntasks::Int64, batch_size::Nothing)
   @ Base ./asyncmap.jl:103
 [6] #asyncmap#865
   @ ./asyncmap.jl:81 [inlined]
 [7] asyncmap(f::Function, c::UnitRange{Int64})
   @ Base ./asyncmap.jl:81
 [8] top-level scope
   @ REPL[4]:1

julia> function Base.start_worker_task!(worker_tasks, exec_func, chnl, batch_size=nothing) # monkeypatch
           t = @async begin
               retval = nothing

               try
                   if isa(batch_size, Number)
                       while isopen(chnl)
                           # The mapping function expects an array of input args, as it processes
                           # elements in a batch.
                           batch_collection=Any[]
                           n = 0
                           for exec_data in chnl
                               push!(batch_collection, exec_data)
                               n += 1
                               (n == batch_size) && break
                           end
                           if n > 0
                               exec_func(batch_collection)
                           end
                       end
                   else
                       for exec_data in chnl
                           exec_func(exec_data...)
                       end
                   end
               catch e
                   close(chnl)
                   Base.display_error(stderr, Base.catch_stack())
                   retval = e
               end
               retval
           end
           push!(worker_tasks, t)
       end

julia> asyncmap(f, 1:5) # post-patch
ERROR: 5
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] f
   @ ./REPL[3]:1 [inlined]
 [3] (::Base.var"#871#876"{typeof(f)})(r::Base.RefValue{Any}, args::Tuple{Int64})
   @ Base ./asyncmap.jl:100
 [4] macro expansion
   @ ./REPL[5]:23 [inlined]
 [5] (::var"#1#2"{Base.var"#871#876"{typeof(f)}, Channel{Any}, Nothing})()
   @ Main ./task.jl:411
ERROR: 5
Stacktrace:
 [1] (::Base.var"#881#883")(x::Task)
   @ Base ./asyncmap.jl:177
 [2] foreach(f::Base.var"#881#883", itr::Vector{Any})
   @ Base ./abstractarray.jl:2606
 [3] maptwice(wrapped_f::Function, chnl::Channel{Any}, worker_tasks::Vector{Any}, c::UnitRange{Int64})
   @ Base ./asyncmap.jl:177
 [4] wrap_n_exec_twice
   @ ./asyncmap.jl:153 [inlined]
 [5] async_usemap(f::typeof(f), c::UnitRange{Int64}; ntasks::Int64, batch_size::Nothing)
   @ Base ./asyncmap.jl:103
 [6] #asyncmap#865
   @ ./asyncmap.jl:81 [inlined]
 [7] asyncmap(f::Function, c::UnitRange{Int64})
   @ Base ./asyncmap.jl:81
 [8] top-level scope
   @ REPL[6]:1
```

The stacktrace isn't so interesting in this example, but since pmap uses `asyncmap` under the hood, this comes up there too. For me, I was working on concurrency with AWS.jl and was missing a retry statement somewhere, so my job failed after several hours without a usable stacktrace-- very frustating. So I very much think we should print the stacktrace.