### PR TITLE
Profile: Use two null block terminators

### DIFF
--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -37,8 +37,8 @@ void jl_shuffle_int_array_inplace(volatile uint64_t *carray, size_t size, uint64
 
 JL_DLLEXPORT int jl_profile_is_buffer_full(void)
 {
-    // the `+ 5` is for the block terminator `0` plus 4 metadata entries
-    return bt_size_cur + (JL_BT_MAX_ENTRY_SIZE + 1) + 5 > bt_size_max;
+    // the `+ 6` is for the two block terminators `0` plus 4 metadata entries
+    return bt_size_cur + (JL_BT_MAX_ENTRY_SIZE + 1) + 6 > bt_size_max;
 }
 
 static uint64_t jl_last_sigint_trigger = 0;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -602,7 +602,8 @@ void *mach_profile_listener(void *arg)
                 // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
                 bt_data_prof[bt_size_cur++].uintptr = ptls->sleep_check_state + 1;
 
-                // Mark the end of this block with 0
+                // Mark the end of this block with two 0's
+                bt_data_prof[bt_size_cur++].uintptr = 0;
                 bt_data_prof[bt_size_cur++].uintptr = 0;
             }
             // We're done! Resume the thread.

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -800,7 +800,8 @@ static void *signal_listener(void *arg)
                     // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
                     bt_data_prof[bt_size_cur++].uintptr = ptls->sleep_check_state + 1;
 
-                    // Mark the end of this block with 0
+                    // Mark the end of this block with two 0's
+                    bt_data_prof[bt_size_cur++].uintptr = 0;
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }
             }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -375,7 +375,8 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
                     // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
                     bt_data_prof[bt_size_cur++].uintptr = ptls->sleep_check_state + 1;
 
-                    // Mark the end of this block with 0
+                    // Mark the end of this block with two 0's
+                    bt_data_prof[bt_size_cur++].uintptr = 0;
                     bt_data_prof[bt_size_cur++].uintptr = 0;
                 }
                 jl_unlock_profile();


### PR DESCRIPTION
Fixes current failures on 32-bit linux.

It seems CI was lucky in passing in https://github.com/JuliaLang/julia/pull/41742
There was a couple more places that block end detection needed the new heuristic to ignore the rogue 0's on 32-bit linux

I also made block end detection a function given it's used in various places now
