### PR TITLE
eagerly do boundscheck when indexing into CartesianIndices

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -382,6 +382,7 @@ module IteratorsMD
         C::CartesianIndices{N}) where {N}
         getindex(iter, C.indices...)
     end
+    @inline Base.getindex(iter::CartesianIndices{0}, ::CartesianIndices{0}) = iter
 
     # If dimensions permit, we may index into a CartesianIndices directly instead of constructing a SubArray wrapper
     @propagate_inbounds function Base.view(c::CartesianIndices{N}, r::Vararg{Union{OrdinalRange{<:Integer, <:Integer}, Colon},N}) where {N}

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -358,8 +358,12 @@ module IteratorsMD
         CartesianIndex()
     end
     @propagate_inbounds function Base.getindex(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R}
-        CartesianIndex(getindex.(iter.indices, I))
+        CartesianIndex(_get_cartesianindex.(iter.indices, I))
     end
+    # specialize to gives better hint to compiler to enable SIMD (#42115)
+    @inline _get_cartesianindex(::OneTo, i::Int) = i
+    @inline _get_cartesianindex(::Base.IdentityUnitRange, i::Int) = i
+    @inline _get_cartesianindex(r, i) = getindex(r, i)
 
     # CartesianIndices act as a multidimensional range, so cartesian indexing of CartesianIndices
     # with compatible dimensions may be seen as indexing into the component ranges.

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -370,19 +370,14 @@ module IteratorsMD
     # CartesianIndices act as a multidimensional range, so cartesian indexing of CartesianIndices
     # with compatible dimensions may be seen as indexing into the component ranges.
     # This may use the special indexing behavior implemented for ranges to return another CartesianIndices
-    @inline function Base.getindex(iter::CartesianIndices{N,R},
+    @propagate_inbounds function Base.getindex(iter::CartesianIndices{N,R},
         I::Vararg{Union{OrdinalRange{<:Integer, <:Integer}, Colon}, N}) where {N,R}
-        @boundscheck checkbounds(iter, I...)
-        indices = map(iter.indices, I) do r, i
-            @inbounds getindex(r, i)
-        end
-        CartesianIndices(indices)
+        CartesianIndices(getindex.(iter.indices, I))
     end
     @propagate_inbounds function Base.getindex(iter::CartesianIndices{N},
         C::CartesianIndices{N}) where {N}
-        getindex(iter, C.indices...)
+        CartesianIndices(getindex.(iter.indices, C.indices))
     end
-    @inline Base.getindex(iter::CartesianIndices{0}, ::CartesianIndices{0}) = iter
 
     # If dimensions permit, we may index into a CartesianIndices directly instead of constructing a SubArray wrapper
     @propagate_inbounds function Base.view(c::CartesianIndices{N}, r::Vararg{Union{OrdinalRange{<:Integer, <:Integer}, Colon},N}) where {N}

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -259,4 +259,26 @@ if bc_opt == bc_default || bc_opt == bc_off
     @test !occursin("arrayref(true", typed_40281)
 end
 
+@testset "pass inbounds meta to getindex on CartesianIndices (#42115)" begin
+    @inline getindex_42115(r, i) = @inbounds getindex(r, i)
+    @inline getindex_42115(r, i, j) = @inbounds getindex(r, i, j)
+
+    R = CartesianIndices((5, 5))
+    if bc_opt == bc_on
+        @test_throws BoundsError getindex_42115(R, -1, -1)
+        @test_throws BoundsError getindex_42115(R, 1, -1)
+    else
+        @test getindex_42115(R, -1, -1) == CartesianIndex(-1, -1)
+        @test getindex_42115(R, 1, -1) == CartesianIndex(1, -1)
+    end
+
+    if bc_opt == bc_on
+        @test_throws BoundsError getindex_42115(R, CartesianIndices((6, 6)))
+        @test_throws BoundsError getindex_42115(R, -1:3, :)
+    else
+        @test getindex_42115(R, CartesianIndices((6, 6))) == CartesianIndices((6, 6))
+        @test getindex_42115(R, -1:3, :) == CartesianIndices((-1:3, 1:5))
+    end
+end
+
 end

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -260,7 +260,6 @@ if bc_opt == bc_default || bc_opt == bc_off
 end
 
 @testset "pass inbounds meta to getindex on CartesianIndices (#42115)" begin
-    @inline getindex_42115(r, i) = @inbounds getindex(r, i)
     @inline getindex_42115(r, i, j) = @inbounds getindex(r, i, j)
 
     R = CartesianIndices((5, 5))
@@ -270,14 +269,6 @@ end
     else
         @test getindex_42115(R, -1, -1) == CartesianIndex(-1, -1)
         @test getindex_42115(R, 1, -1) == CartesianIndex(1, -1)
-    end
-
-    if bc_opt == bc_on
-        @test_throws BoundsError getindex_42115(R, CartesianIndices((6, 6)))
-        @test_throws BoundsError getindex_42115(R, -1:3, :)
-    else
-        @test getindex_42115(R, CartesianIndices((6, 6))) == CartesianIndices((6, 6))
-        @test getindex_42115(R, -1:3, :) == CartesianIndices((-1:3, 1:5))
     end
 end
 


### PR DESCRIPTION
This PR eagerly does boundscheck when doing `getindex(::CartesianIndices, ...)`, this generates simpler inlined codes and furthermore enables SIMD

```julia
julia> versioninfo()
Julia Version 1.8.0-DEV.473
Commit fce2daff16* (2021-09-04 09:37 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin20.6.0)
  CPU: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, skylake)
```

```julia
function sumcart_oneto(X)
    out = zero(eltype(X))
    R = CartesianIndices(X) # OneTo
    @inbounds @simd for i in eachindex(X)
        out += X[R[i]]
    end
    return out
end

function sumcart_iur(X)
    out = zero(eltype(X))
    R = CartesianIndices(map(i->Base.IdentityUnitRange(1:i), size(X))) # IdentityUnitRange
    @inbounds @simd for i in eachindex(X)
        out += X[R[i]]
    end
    return out
end

function sumcart_unitrange(X)
    out = zero(eltype(X))
    R = CartesianIndices(map(i->1:i, size(X))) # UnitRange
    @inbounds @simd for i in eachindex(X)
        out += X[R[i]]
    end
    return out
end

X = rand(64, 64);

@btime sumcart_oneto($X);
# PR: 241.691 ns (0 allocations: 0 bytes)
# master: 10.526 μs (0 allocations: 0 bytes)
@btime sumcart_iur($X);
# PR: 236.788 ns (0 allocations: 0 bytes)
# master: 10.950 μs (0 allocations: 0 bytes)
@btime sumcart_unitrange($X);
# PR: 234.622 ns (0 allocations: 0 bytes)
# master: 10.529 μs (0 allocations: 0 bytes)
```

The earliest version that I obverse this performance regression is in Julia 1.4.0

A related benchmark:

```julia
function sumcart_linear(X)
    out = zero(eltype(X))
    @inbounds @simd for i in 1:length(X)
        out += X[i]
    end
    return out
end

@btime sumcart_linear($X);
# master: 219.778 ns (0 allocations: 0 bytes)
```

fixes #42115