### PR TITLE
faster `hypot` for `Float32` and `Float16`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -294,9 +294,6 @@ include("secretbuffer.jl")
 
 # core math functions
 include("floatfuncs.jl")
-# Fast math
-include("fastmath.jl")
-using .FastMath
 include("math.jl")
 using .Math
 const (√)=sqrt
@@ -332,6 +329,10 @@ using .Order
 # Combinatorics
 include("sort.jl")
 using .Sort
+
+# Fast math
+include("fastmath.jl")
+using .FastMath
 
 function deepcopy_internal end
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -294,6 +294,9 @@ include("secretbuffer.jl")
 
 # core math functions
 include("floatfuncs.jl")
+# Fast math
+include("fastmath.jl")
+using .FastMath
 include("math.jl")
 using .Math
 const (√)=sqrt
@@ -329,10 +332,6 @@ using .Order
 # Combinatorics
 include("sort.jl")
 using .Sort
-
-# Fast math
-include("fastmath.jl")
-using .FastMath
 
 function deepcopy_internal end
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -697,10 +697,16 @@ function _hypot(x, y)
     return h*scale*oneunit(axu)
 end
 @inline function _hypot(x::Float32, y::Float32)
+    if isinf(x) || isinf(y)
+        return Inf32
+    end
     _x, _y = Float64(x), Float64(y)
     return Float32(sqrt(muladd(_x, _x, _y*_y)))
 end
 @inline function _hypot(x::Float16, y::Float16)
+    if isinf(x) || isinf(y)
+        return Inf16
+    end
     _x, _y = Float32(x), Float32(y)
     return Float16(sqrt(muladd(_x, _x, _y*_y)))
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -697,12 +697,18 @@ function _hypot(x, y)
     return h*scale*oneunit(axu)
 end
 @inline function _hypot(x::Float32, y::Float32)
+    if isinf(x) || isinf(y)
+        return Inf32
+    end
     _x, _y = Float64(x), Float64(y)
-    return Float32(sqrt(@fastmath _x*_x + _y*_y))
+    return Float32(sqrt(muladd(_x, _x, _y*_y)))
 end
 @inline function _hypot(x::Float16, y::Float16)
+    if isinf(x) || isinf(y)
+        return Inf16
+    end
     _x, _y = Float32(x), Float32(y)
-    return Float16(sqrt(@fastmath _x*_x + _y*_y))
+    return Float16(sqrt(muladd(_x, _x, _y*_y)))
 end
 _hypot(x::ComplexF16, y::ComplexF16) = Float16(_hypot(ComplexF32(x), ComplexF32(y)))
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -697,16 +697,10 @@ function _hypot(x, y)
     return h*scale*oneunit(axu)
 end
 @inline function _hypot(x::Float32, y::Float32)
-    if isinf(x) || isinf(y)
-        return Inf32
-    end
     _x, _y = Float64(x), Float64(y)
     return Float32(sqrt(muladd(_x, _x, _y*_y)))
 end
 @inline function _hypot(x::Float16, y::Float16)
-    if isinf(x) || isinf(y)
-        return Inf16
-    end
     _x, _y = Float32(x), Float32(y)
     return Float16(sqrt(muladd(_x, _x, _y*_y)))
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -696,8 +696,14 @@ function _hypot(x, y)
     end
     return h*scale*oneunit(axu)
 end
-_hypot(x::Float32, y::Float32) = Float32(sqrt((Float64(x)^2 + Float64(y)^2)))
-_hypot(x::Float16, y::Float16) = Float16(sqrt((Float32(x)^2 + Float32(y)^2)))
+@inline function _hypot(x::Float32, y::Float32)
+    _x, _y = Float64(x), Float64(y)
+    return Float32(sqrt(@fastmath _x*_x + _y*_y))
+end
+@inline function _hypot(x::Float16, y::Float16)
+    _x, _y = Float32(x), Float32(y)
+    return Float16(sqrt(@fastmath _x*_x + _y*_y))
+end
 _hypot(x::ComplexF16, y::ComplexF16) = Float16(_hypot(ComplexF32(x), ComplexF32(y)))
 
 function _hypot(x...)

--- a/base/math.jl
+++ b/base/math.jl
@@ -696,7 +696,8 @@ function _hypot(x, y)
     end
     return h*scale*oneunit(axu)
 end
-_hypot(x::Float16, y::Float16) = Float16(_hypot(Float32(x), Float32(y)))
+_hypot(x::Float32, y::Float32) = Float32(sqrt((Float64(x)^2 + Float64(y)^2)))
+_hypot(x::Float16, y::Float16) = Float16(sqrt((Float32(x)^2 + Float32(y)^2)))
 _hypot(x::ComplexF16, y::ComplexF16) = Float16(_hypot(ComplexF32(x), ComplexF32(y)))
 
 function _hypot(x...)


### PR DESCRIPTION
Before:
```julia
julia> @benchmark hypot(x,y) setup=(begin x,y = rand(Float32, 2) end) evals=10000
BenchmarkTools.Trial: 10000 samples with 10000 evaluations.
 Range (min … max):  3.051 ns … 8.185 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.700 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.616 ns ± 0.208 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                          ▁▇▇  ▂▇█▅▁▂▂▂     ▂
  ▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁████▇█████████████ █
  3.05 ns     Histogram: log(frequency) by time     6.27 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark hypot(x,y) setup=(begin x,y = rand(Float16, 2) end) evals=10000
BenchmarkTools.Trial: 10000 samples with 10000 evaluations.
 Range (min … max):  3.133 ns … 10.518 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.265 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.229 ns ±  0.280 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                          ▇▆▃▆▁▁█▄▇▂▄▂▁▁▁    ▂
  ▆▅▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄█████████████████▇ █
  3.13 ns      Histogram: log(frequency) by time     7.06 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

After:
```julia
julia> @benchmark _hypot(x,y) setup=(begin x,y = rand(Float32, 2) end) evals=10000
BenchmarkTools.Trial: 10000 samples with 10000 evaluations.
 Range (min … max):  2.161 ns … 5.114 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.188 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.197 ns ± 0.082 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂ ▂ ▇█ ▂                                                  ▁
  █▁█▃██▁█▄▃█▃▁▄▃▁▁▁▁▅▃▁▃▁▃▃▄▄▁▁▁▃▁▃▁▄▄▄▃▅▃▄▄▄▄▄▅▃▄▄▆▅▄▄▄▁▅ █
  2.16 ns     Histogram: log(frequency) by time     2.47 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark _hypot(x,y) setup=(begin x,y = rand(Float16, 2) end) evals=10000
BenchmarkTools.Trial: 10000 samples with 10000 evaluations.
 Range (min … max):  2.547 ns … 3.631 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.620 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.630 ns ± 0.070 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▁ ▆ ▄ █ ▆   ▃                                          ▂
  ▇▇▃█▁█▆█▃█▄█▁▇▄██▅▄▅▄▄▃▄▅▅▅▅▄▄▅▅▅▅▆▃▆▅▆▇▇▇▆▆▆▃▅▃▅▅▅▅▄▅▅▄▆ █
  2.55 ns     Histogram: log(frequency) by time        3 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```