### PR TITLE
Add a `@compile` directive to disable interpreter

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -375,6 +375,13 @@ macro propagate_inbounds(ex)
 end
 
 """
+    @compile
+
+Force compilation of the block or function (Julia's built-in interpreter is blocked from executing it).
+"""
+macro compile() Expr(:meta, :compile) end
+
+"""
     @polly
 
 Tells the compiler to apply the polyhedral optimizer Polly to a function.

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -203,7 +203,7 @@ julia> @time begin
 """
 macro time(ex)
     quote
-        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
+        @compile
         local stats = gc_num()
         local elapsedtime = time_ns()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
@@ -249,7 +249,7 @@ pool allocs:       1
 """
 macro timev(ex)
     quote
-        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
+        @compile
         local stats = gc_num()
         local elapsedtime = time_ns()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
@@ -282,7 +282,7 @@ julia> @elapsed sleep(0.3)
 """
 macro elapsed(ex)
     quote
-        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
+        @compile
         local t0 = time_ns()
         $(esc(ex))
         (time_ns() - t0) / 1e9
@@ -314,7 +314,7 @@ julia> @allocated rand(10^6)
 """
 macro allocated(ex)
     quote
-        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
+        @compile
         local b0 = Ref{Int64}(0)
         local b1 = Ref{Int64}(0)
         gc_bytes(b0)
@@ -362,7 +362,7 @@ julia> stats.gcstats.total_time
 """
 macro timed(ex)
     quote
-        while false; end # compiler heuristic: compile this block (alter this if the heuristic changes)
+        @compile
         local stats = gc_num()
         local elapsedtime = time_ns()
         local val = $(esc(ex))


### PR DESCRIPTION
We currently use a `while false; end` hack to disable to interpreter,
and this is getting more widely used outside of base. Unfortunately,
improvements to the interpreter that would allow us to interpret loops
would defeat the intention. This allows developers to annotate blocks
with `@compile` to specify that they want to force the compiler to run
on this block.