### PR TITLE
use separate names for internal and exported functions

### DIFF
--- a/cli/jl_exports.h
+++ b/cli/jl_exports.h
@@ -24,8 +24,8 @@ JL_EXPORTED_FUNCS_WIN(XX)
 #endif
 #undef XX
 
-// Define holder locations for function addresses as `const void * $(name)_addr = & $(name);`
-#define XX(name)    JL_HIDDEN anonfunc * name##_addr = (anonfunc*)&name;
+// Define holder locations for function addresses as `const void * $(name)_addr = NULL;
+#define XX(name)    JL_HIDDEN anonfunc * name##_addr = NULL;
 JL_EXPORTED_FUNCS(XX)
 #ifdef _OS_WINDOWS_
 JL_EXPORTED_FUNCS_WIN(XX)
@@ -33,7 +33,7 @@ JL_EXPORTED_FUNCS_WIN(XX)
 #undef XX
 
 // Generate lists of function names and addresses
-#define XX(name)    #name,
+#define XX(name)    "i" #name,
 static const char *const jl_exported_func_names[] = {
     JL_EXPORTED_FUNCS(XX)
 #ifdef _OS_WINDOWS_

--- a/cli/loader.h
+++ b/cli/loader.h
@@ -53,7 +53,7 @@
 # endif
 #define JL_HIDDEN
 #else
-# if defined(LIBRARY_EXPORTS) && defined(_OS_LINUX)
+# if defined(LIBRARY_EXPORTS) && defined(_OS_LINUX_)
 #  define JL_DLLEXPORT __attribute__ ((visibility("protected")))
 # else
 #  define JL_DLLEXPORT __attribute__ ((visibility("default")))

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -176,8 +176,8 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
     // Once we have libjulia-internal loaded, re-export its symbols:
     for (unsigned int symbol_idx=0; jl_exported_func_names[symbol_idx] != NULL; ++symbol_idx) {
         void *addr = lookup_symbol(libjulia_internal, jl_exported_func_names[symbol_idx]);
-        if (addr == NULL || addr == *jl_exported_func_addrs[symbol_idx]) {
-            jl_loader_print_stderr3("ERROR: Unable to load ", jl_exported_func_names[symbol_idx], " from libjulia-internal");
+        if (addr == NULL) {
+            jl_loader_print_stderr3("ERROR: Unable to load ", jl_exported_func_names[symbol_idx], " from libjulia-internal\n");
             exit(1);
         }
         (*jl_exported_func_addrs[symbol_idx]) = addr;

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -10,6 +10,7 @@
 /julia_flisp.boot
 /julia_flisp.boot.inc
 /flisp.boot.inc
+/jl_internal_funcs.inc
 
 /libjulia-debug.a
 /libjulia-debug.so

--- a/src/Makefile
+++ b/src/Makefile
@@ -369,7 +369,7 @@ $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/GCChecker.c
 install-analysis-deps:
 	$(MAKE) -C $(JULIAHOME)/deps install-llvm install-clang install-llvm-tools install-libuv install-utf8proc install-unwind
 
-analyzegc-deps-check: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc
+analyzegc-deps-check: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc $(BUILDDIR)/jl_internal_funcs.inc
 ifeq ($(USE_BINARYBUILDER_LLVM),0)
 ifneq ($(BUILD_LLVM_CLANG),1)
 	$(error Clang must be available to use the clang analyzer. Either build it (BUILD_LLVM_CLANG=1) or use BinaryBuilder)

--- a/src/Makefile
+++ b/src/Makefile
@@ -267,6 +267,7 @@ $(BUILDDIR)/llvm-alloc-opt.o $(BUILDDIR)/llvm-alloc-opt.dbg.obj: $(SRCDIR)/codeg
 $(BUILDDIR)/llvm-final-gc-lowering.o $(BUILDDIR)/llvm-final-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/llvm-gc-invariant-verifier.o $(BUILDDIR)/llvm-gc-invariant-verifier.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-late-gc-lowering.o $(BUILDDIR)/llvm-late-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
+$(BUILDDIR)/llvm-lower-handlers.o $(BUILDDIR)/llvm-lower-handlers.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-multiversioning.o $(BUILDDIR)/llvm-multiversioning.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-pass-helpers.o $(BUILDDIR)/llvm-pass-helpers.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-ptls.o $(BUILDDIR)/llvm-ptls.dbg.obj: $(SRCDIR)/codegen_shared.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ JLDFLAGS += $(LDFLAGS)
 FLAGS := \
 	-D_GNU_SOURCE -I$(BUILDDIR) -I$(SRCDIR) \
 	-I$(SRCDIR)/flisp -I$(SRCDIR)/support \
-	-I$(LIBUV_INC) -I$(build_includedir) -DLIBRARY_EXPORTS \
+	-I$(LIBUV_INC) -I$(build_includedir) \
 	-I$(JULIAHOME)/deps/valgrind
 ifneq ($(USEMSVC), 1)
 FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer -fvisibility=hidden -fno-common \
@@ -95,8 +95,7 @@ endif
 
 # headers are used for dependency tracking, while public headers will be part of the dist
 UV_HEADERS :=
-HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h julia_internal.h options.h timing.h) $(addprefix $(BUILDDIR)/, $(DTRACE_HEADERS))
-PUBLIC_HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h julia_gcext.h)
+HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h julia_internal.h options.h timing.h) $(addprefix $(BUILDDIR)/, $(DTRACE_HEADERS) jl_internal_funcs.inc)
 ifeq ($(USE_SYSTEM_LIBUV),0)
 UV_HEADERS += uv.h
 UV_HEADERS += uv/*.h
@@ -135,8 +134,8 @@ RELEASE_LIBS := $(COMMON_LIBPATHS) $(WHOLE_ARCHIVE) $(BUILDDIR)/flisp/libflisp.a
 
 OBJS := $(SRCS:%=$(BUILDDIR)/%.o)
 DOBJS := $(SRCS:%=$(BUILDDIR)/%.dbg.obj)
-DEBUGFLAGS += $(FLAGS)
-SHIPFLAGS += $(FLAGS)
+DEBUGFLAGS += $(FLAGS) -DLIBRARY_EXPORTS
+SHIPFLAGS += $(FLAGS) -DLIBRARY_EXPORTS
 
 # if not absolute, then relative to the directory of the julia executable
 SHIPFLAGS  += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\""
@@ -178,6 +177,9 @@ $(BUILDDIR)/%.h.gen : $(SRCDIR)/%.d
 	sed 's/JULIA_/JL_PROBE_/' $@ > $@.tmp
 	mv $@.tmp $@
 
+$(BUILDDIR)/jl_internal_funcs.inc: $(SRCDIR)/jl_exported_funcs.inc
+	grep 'XX(.\+)' $< | sed -E 's/.*XX\((.+)\).*/#define \1 i\1/g' >$@
+
 # source file rules
 $(BUILDDIR)/%.o: $(SRCDIR)/%.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(JCPPFLAGS) $(JCFLAGS) $(SHIPFLAGS) $(DISABLE_ASSERTIONS) -c $< -o $@)
@@ -213,7 +215,7 @@ else
 JULIA_SPLITDEBUG := 0
 endif
 $(build_shlibdir)/libccalltest.$(SHLIB_EXT): $(SRCDIR)/ccalltest.c
-	@$(call PRINT_CC, $(CC) $(JCFLAGS) $(JCPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@.tmp $(JLDFLAGS))
+	@$(call PRINT_CC, $(CC) $(JCFLAGS) $(JCPPFLAGS) $(FLAGS) -O3 $< $(fPIC) -shared -o $@.tmp $(LDFLAGS))
 	$(INSTALL_NAME_CMD)libccalltest.$(SHLIB_EXT) $@.tmp
 ifeq ($(JULIA_SPLITDEBUG),1)
 	@# Create split debug info file for libccalltest stacktraces test
@@ -230,7 +232,7 @@ endif
 	$(INSTALL_NAME_CMD)libccalltest.$(SHLIB_EXT) $@
 
 $(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvmcalltest.cpp $(LLVM_CONFIG_ABSOLUTE)
-	@$(call PRINT_CC, $(CXX) $(LLVM_CXXFLAGS) $(JCXXFLAGS) $(JCPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@ $(JLDFLAGS) -L$(build_shlibdir) -L$(build_libdir) $(NO_WHOLE_ARCHIVE) $(LLVMLINK)) -lpthread
+	@$(call PRINT_CC, $(CXX) $(LLVM_CXXFLAGS) $(FLAGS) $(CPPFLAGS) $(CXXFLAGS) -O3 $< $(fPIC) -shared -o $@ $(LDFLAGS) $(COMMON_LIBPATHS) $(NO_WHOLE_ARCHIVE) $(LLVMLINK)) -lpthread
 
 julia_flisp.boot.inc.phony: $(BUILDDIR)/julia_flisp.boot.inc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -95,11 +95,13 @@ endif
 
 # headers are used for dependency tracking, while public headers will be part of the dist
 UV_HEADERS :=
-HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h julia_internal.h options.h timing.h) $(addprefix $(BUILDDIR)/, $(DTRACE_HEADERS) jl_internal_funcs.inc)
 ifeq ($(USE_SYSTEM_LIBUV),0)
 UV_HEADERS += uv.h
 UV_HEADERS += uv/*.h
 endif
+PUBLIC_HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h)
+HEADERS := $(PUBLIC_HEADERS) $(addprefix $(SRCDIR)/,julia_internal.h options.h timing.h) $(addprefix $(BUILDDIR)/,$(DTRACE_HEADERS) jl_internal_funcs.inc)
+PUBLIC_HEADERS += $(addprefix $(SRCDIR)/,julia_gcext.h)
 PUBLIC_HEADER_TARGETS := $(addprefix $(build_includedir)/julia/,$(notdir $(PUBLIC_HEADERS)) $(UV_HEADERS))
 
 LLVM_LDFLAGS := $(shell $(LLVM_CONFIG_HOST) --ldflags)

--- a/src/Makefile
+++ b/src/Makefile
@@ -180,6 +180,10 @@ $(BUILDDIR)/%.h.gen : $(SRCDIR)/%.d
 	mv $@.tmp $@
 
 $(BUILDDIR)/jl_internal_funcs.inc: $(SRCDIR)/jl_exported_funcs.inc
+	# Generate `.inc` file that contains a list of `#define` macros to rename functions defined in `libjulia-internal`
+	# to have a `ijl_` prefix instead of `jl_`, to denote that they are coming from `libjulia-internal`.  This avoids
+	# potential confusion with debugging tools, when inspecting a process that has both `libjulia` and `libjulia-internal`
+	# loaded at the same time.
 	grep 'XX(.\+)' $< | sed -E 's/.*XX\((.+)\).*/#define \1 i\1/g' >$@
 
 # source file rules

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1270,8 +1270,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         if (f_lib) {
 #ifdef _OS_WINDOWS_
             if ((f_lib == JL_EXE_LIBNAME) || // preventing invalid pointer access
-                (f_lib == JL_LIBJULIA_DL_LIBNAME) ||
                 (f_lib == JL_LIBJULIA_INTERNAL_DL_LIBNAME) ||
+                (!strcmp(f_lib, JL_LIBJULIA_DL_LIBNAME)) ||
                 (!strcmp(f_lib, jl_crtdll_basename))) {
                 // libjulia-like
             }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1264,12 +1264,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         return args[6 + i];
     };
 
-    auto _is_libjulia_func = [&] (uintptr_t ptr, const char *name) {
+    auto _is_libjulia_func = [&] (uintptr_t ptr, StringRef name) {
         if ((uintptr_t)fptr == ptr)
             return true;
         if (f_lib) {
 #ifdef _OS_WINDOWS_
             if ((f_lib == JL_EXE_LIBNAME) || // preventing invalid pointer access
+                (f_lib == JL_LIBJULIA_DL_LIBNAME) ||
                 (f_lib == JL_LIBJULIA_INTERNAL_DL_LIBNAME) ||
                 (!strcmp(f_lib, jl_crtdll_basename))) {
                 // libjulia-like
@@ -1280,9 +1281,9 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             return false;
 #endif
         }
-        return f_name && !strcmp(f_name, name);
+        return f_name && (f_name == name || (name[0] == 'i' && f_name == name.drop_front()));
     };
-#define is_libjulia_func(name) _is_libjulia_func((uintptr_t)&(name), #name)
+#define is_libjulia_func(name) _is_libjulia_func((uintptr_t)&(name), StringRef(XSTR(#name)))
 
     // emit arguments
     jl_cgval_t *argv = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nccallargs);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1281,9 +1281,9 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             return false;
 #endif
         }
-        return f_name && (f_name == name || (name[0] == 'i' && f_name == name.drop_front()));
+        return f_name && f_name == name;
     };
-#define is_libjulia_func(name) _is_libjulia_func((uintptr_t)&(name), StringRef(XSTR(#name)))
+#define is_libjulia_func(name) _is_libjulia_func((uintptr_t)&(name), StringRef(#name))
 
     // emit arguments
     jl_cgval_t *argv = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nccallargs);

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -9,6 +9,18 @@
 #include "../src/support/platform.h"
 #include "../src/support/dtypes.h"
 
+// Borrow definition from `support/dtypes.h`
+#ifdef _OS_WINDOWS_
+#  define DLLEXPORT __declspec(dllexport)
+#else
+# if defined(_OS_LINUX_)
+#  define DLLEXPORT __attribute__ ((visibility("protected")))
+# else
+#  define DLLEXPORT __attribute__ ((visibility("default")))
+# endif
+#endif
+
+
 #ifdef _P64
 #define jint int64_t
 #define PRIjint PRId64
@@ -33,7 +45,7 @@ int __declspec(noinline)
 #else
 int __attribute__((noinline))
 #endif
-JL_DLLEXPORT testUcharX(unsigned char x) {
+DLLEXPORT testUcharX(unsigned char x) {
     return xs[x];
 }
 
@@ -47,41 +59,41 @@ typedef struct {
     jint imag;
 } complex_t;
 
-JL_DLLEXPORT complex_t ctest(complex_t a) {
+DLLEXPORT complex_t ctest(complex_t a) {
     a.real += 1;
     a.imag -= 2;
     return a;
 }
 
-JL_DLLEXPORT complex double cgtest(complex double a) {
+DLLEXPORT complex double cgtest(complex double a) {
     //Unpack a ComplexPair{Float64} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(a), cimag(a));
     a += 1 - (2.0*I);
     return a;
 }
 
-JL_DLLEXPORT complex double *cgptest(complex double *a) {
+DLLEXPORT complex double *cgptest(complex double *a) {
     //Unpack a ComplexPair{Float64} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(*a), cimag(*a));
     *a += 1 - (2.0*I);
     return a;
 }
 
-JL_DLLEXPORT complex float cftest(complex float a) {
+DLLEXPORT complex float cftest(complex float a) {
     //Unpack a ComplexPair{Float32} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(a), cimag(a));
     a += 1 - (2.0*I);
     return a;
 }
 
-JL_DLLEXPORT complex float *cfptest(complex float *a) {
+DLLEXPORT complex float *cfptest(complex float *a) {
     //Unpack a ComplexPair{Float64} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(*a), cimag(*a));
     *a += 1 - (2.0*I);
     return a;
 }
 
-JL_DLLEXPORT complex_t *cptest(complex_t *a) {
+DLLEXPORT complex_t *cptest(complex_t *a) {
     //Unpack a ComplexPair{Int} struct pointer
     if (verbose) fprintf(stderr,"%" PRIjint " + %" PRIjint " i\n", a->real, a->imag);
     a->real += 1;
@@ -89,7 +101,7 @@ JL_DLLEXPORT complex_t *cptest(complex_t *a) {
     return a;
 }
 
-JL_DLLEXPORT complex_t *cptest_static(complex_t *a) {
+DLLEXPORT complex_t *cptest_static(complex_t *a) {
     if (verbose) fprintf(stderr,"%" PRIjint " + %" PRIjint " i\n", a->real, a->imag);
     complex_t *b = (complex_t*)malloc_s(sizeof(complex_t));
     b->real = a->real;
@@ -331,7 +343,7 @@ typedef struct {
 #endif // _COMPILER_INTEL_
 
 
-JL_DLLEXPORT struct1 test_1(struct1 a, float b) {
+DLLEXPORT struct1 test_1(struct1 a, float b) {
     //Unpack a "small" struct { float, double }
     if (verbose) fprintf(stderr,"%g + %g i & %g\n", a.x, a.y, b);
     a.x += b * 1;
@@ -339,7 +351,7 @@ JL_DLLEXPORT struct1 test_1(struct1 a, float b) {
     return a;
 }
 
-JL_DLLEXPORT struct1 test_1long_a(jint x1, jint x2, jint x3, struct1 a, float b) {
+DLLEXPORT struct1 test_1long_a(jint x1, jint x2, jint x3, struct1 a, float b) {
     //Unpack a "small" struct { float, double }
     if (verbose) fprintf(stderr,"(%" PRIjint ", %" PRIjint ", %" PRIjint ") & %g + %g i & %g\n", x1, x2, x3, a.x, a.y, b);
     a.x += b + x1 + x2 + x3;
@@ -347,7 +359,7 @@ JL_DLLEXPORT struct1 test_1long_a(jint x1, jint x2, jint x3, struct1 a, float b)
     return a;
 }
 
-JL_DLLEXPORT struct1 test_1long_b(jint x1, double x2, jint x3, struct1 a, float b) {
+DLLEXPORT struct1 test_1long_b(jint x1, double x2, jint x3, struct1 a, float b) {
     //Unpack a "small" struct { float, double }
     if (verbose) fprintf(stderr,"(%" PRIjint ", %g, %" PRIjint ") & %g + %g i & %g\n", x1, x2, x3, a.x, a.y, b);
     a.x += b + x1 + x2 + x3;
@@ -355,7 +367,7 @@ JL_DLLEXPORT struct1 test_1long_b(jint x1, double x2, jint x3, struct1 a, float 
     return a;
 }
 
-JL_DLLEXPORT struct1 test_1long_c(jint x1, double x2, jint x3, jint x4, struct1 a, float b) {
+DLLEXPORT struct1 test_1long_c(jint x1, double x2, jint x3, jint x4, struct1 a, float b) {
     //Unpack a "small" struct { float, double }
     if (verbose) fprintf(stderr,"(%" PRIjint ", %g, %" PRIjint ", %" PRIjint ") & %g + %g i & %g\n", x1, x2, x3, x4, a.x, a.y, b);
     a.x += b + x1 + x2 + x3 + x4;
@@ -363,7 +375,7 @@ JL_DLLEXPORT struct1 test_1long_c(jint x1, double x2, jint x3, jint x4, struct1 
     return a;
 }
 
-JL_DLLEXPORT struct2a test_2a(struct2a a, int32_t b) {
+DLLEXPORT struct2a test_2a(struct2a a, int32_t b) {
     //Unpack a ComplexPair{Int32} struct
     if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i & %" PRId32 "\n", a.x.x, a.y.y, b);
     a.x.x += b*1;
@@ -371,7 +383,7 @@ JL_DLLEXPORT struct2a test_2a(struct2a a, int32_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct2b test_2b(struct2b a, int32_t b) {
+DLLEXPORT struct2b test_2b(struct2b a, int32_t b) {
     //Unpack a ComplexPair{Int32} struct
     if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i & %" PRId32 "\n", a.x, a.y, b);
     a.x += b*1;
@@ -379,7 +391,7 @@ JL_DLLEXPORT struct2b test_2b(struct2b a, int32_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct3a test_3a(struct3a a, int64_t b) {
+DLLEXPORT struct3a test_3a(struct3a a, int64_t b) {
     //Unpack a ComplexPair{Int64} struct
     if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i & %" PRId64 "\n", a.x.x, a.y.y, b);
     a.x.x += b*1;
@@ -387,7 +399,7 @@ JL_DLLEXPORT struct3a test_3a(struct3a a, int64_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct3b test_3b(struct3b a, int64_t b) {
+DLLEXPORT struct3b test_3b(struct3b a, int64_t b) {
     //Unpack a ComplexPair{Int64} struct
     if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i & %" PRId64 "\n", a.x, a.y, b);
     a.x += b*1;
@@ -395,7 +407,7 @@ JL_DLLEXPORT struct3b test_3b(struct3b a, int64_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct4 test_4(struct4 a, int32_t b) {
+DLLEXPORT struct4 test_4(struct4 a, int32_t b) {
     if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId32 ",%" PRId32 " & %" PRId32 "\n", a.x, a.y, a.z, b);
     a.x += b*1;
     a.y -= b*2;
@@ -403,7 +415,7 @@ JL_DLLEXPORT struct4 test_4(struct4 a, int32_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct5 test_5(struct5 a, int32_t b) {
+DLLEXPORT struct5 test_5(struct5 a, int32_t b) {
     if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 " & %" PRId32 "\n", a.x, a.y, a.z, a.a, b);
     a.x += b*1;
     a.y -= b*2;
@@ -413,7 +425,7 @@ JL_DLLEXPORT struct5 test_5(struct5 a, int32_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct6 test_6(struct6 a, int64_t b) {
+DLLEXPORT struct6 test_6(struct6 a, int64_t b) {
     if (verbose) fprintf(stderr,"%" PRId64 ",%" PRId64 ",%" PRId64 " & %" PRId64 "\n", a.x, a.y, a.z, b);
     a.x += b*1;
     a.y -= b*2;
@@ -421,28 +433,28 @@ JL_DLLEXPORT struct6 test_6(struct6 a, int64_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct7 test_7(struct7 a, int8_t b) {
+DLLEXPORT struct7 test_7(struct7 a, int8_t b) {
     if (verbose) fprintf(stderr,"%" PRId64 ",%" PRId8 " & %" PRId8 "\n", a.x, a.y, b);
     a.x += b*1;
     a.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct8 test_8(struct8 a, int8_t b) {
+DLLEXPORT struct8 test_8(struct8 a, int8_t b) {
     if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId8 " & %" PRId8 "\n", a.x, a.y, b);
     a.x += b*1;
     a.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct9 test_9(struct9 a, int16_t b) {
+DLLEXPORT struct9 test_9(struct9 a, int16_t b) {
     if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId16 " & %" PRId16 "\n", a.x, a.y, b);
     a.x += b*1;
     a.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct10 test_10(struct10 a, int8_t b) {
+DLLEXPORT struct10 test_10(struct10 a, int8_t b) {
     if (verbose) fprintf(stderr,"%" PRId8 ",%" PRId8 ",%" PRId8 ",%" PRId8 " & %" PRId8 "\n", a.x, a.y, a.z, a.a, b);
     a.x += b*1;
     a.y -= b*2;
@@ -452,14 +464,14 @@ JL_DLLEXPORT struct10 test_10(struct10 a, int8_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct11 test_11(struct11 a, float b) {
+DLLEXPORT struct11 test_11(struct11 a, float b) {
     //Unpack a nested ComplexPair{Float32} struct
     if (verbose) fprintf(stderr,"%g + %g i & %g\n", creal(a.x), cimag(a.x), b);
     a.x += b*1 - (b*2.0*I);
     return a;
 }
 
-JL_DLLEXPORT struct12 test_12(struct12 a, float b) {
+DLLEXPORT struct12 test_12(struct12 a, float b) {
     //Unpack two nested ComplexPair{Float32} structs
     if (verbose) fprintf(stderr,"%g + %g i & %g + %g i & %g\n",
                          creal(a.x), cimag(a.x), creal(a.y), cimag(a.y), b);
@@ -468,14 +480,14 @@ JL_DLLEXPORT struct12 test_12(struct12 a, float b) {
     return a;
 }
 
-JL_DLLEXPORT struct13 test_13(struct13 a, double b) {
+DLLEXPORT struct13 test_13(struct13 a, double b) {
     //Unpack a nested ComplexPair{Float64} struct
     if (verbose) fprintf(stderr,"%g + %g i & %g\n", creal(a.x), cimag(a.x), b);
     a.x += b*1 - (b*2.0*I);
     return a;
 }
 
-JL_DLLEXPORT struct14 test_14(struct14 a, float b) {
+DLLEXPORT struct14 test_14(struct14 a, float b) {
     //The C equivalent of a  ComplexPair{Float32} struct (but without special complex ABI)
     if (verbose) fprintf(stderr,"%g + %g i & %g\n", a.x, a.y, b);
     a.x += b*1;
@@ -483,7 +495,7 @@ JL_DLLEXPORT struct14 test_14(struct14 a, float b) {
     return a;
 }
 
-JL_DLLEXPORT struct15 test_15(struct15 a, double b) {
+DLLEXPORT struct15 test_15(struct15 a, double b) {
     //The C equivalent of a  ComplexPair{Float64} struct (but without special complex ABI)
     if (verbose) fprintf(stderr,"%g + %g i & %g\n", a.x, a.y, b);
     a.x += b*1;
@@ -491,7 +503,7 @@ JL_DLLEXPORT struct15 test_15(struct15 a, double b) {
     return a;
 }
 
-JL_DLLEXPORT struct16 test_16(struct16 a, float b) {
+DLLEXPORT struct16 test_16(struct16 a, float b) {
     //Unpack a struct with non-obvious packing requirements
     if (verbose) fprintf(stderr,"%g %g %g %g %g %g & %g\n", a.x, a.y, a.z, a.a, a.b, a.c, b);
     a.x += b*1;
@@ -503,7 +515,7 @@ JL_DLLEXPORT struct16 test_16(struct16 a, float b) {
     return a;
 }
 
-JL_DLLEXPORT struct17 test_17(struct17 a, int8_t b) {
+DLLEXPORT struct17 test_17(struct17 a, int8_t b) {
     //Unpack a struct with non-obvious packing requirements
     if (verbose) fprintf(stderr,"%d %d & %d\n", (int)a.a, (int)a.b, (int)b);
     a.a += b*1;
@@ -511,7 +523,7 @@ JL_DLLEXPORT struct17 test_17(struct17 a, int8_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct18 test_18(struct18 a, int8_t b) {
+DLLEXPORT struct18 test_18(struct18 a, int8_t b) {
     //Unpack a struct with non-obvious packing requirements
     if (verbose) fprintf(stderr,"%d %d %d & %d\n",
                          (int)a.a, (int)a.b, (int)a.c, (int)b);
@@ -526,7 +538,7 @@ JL_DLLEXPORT struct18 test_18(struct18 a, int8_t b) {
 // However, it happens to have the same calling convention with `[2 x i64]`
 // when used as first argument or return value.
 #define int128_t struct3b
-JL_DLLEXPORT int128_t test_128(int128_t a, int64_t b) {
+DLLEXPORT int128_t test_128(int128_t a, int64_t b) {
     //Unpack a Int128
     if (verbose) fprintf(stderr,"0x%016" PRIx64 "%016" PRIx64 " & %" PRId64 "\n", a.y, a.x, b);
     a.x += b*1;
@@ -535,7 +547,7 @@ JL_DLLEXPORT int128_t test_128(int128_t a, int64_t b) {
     return a;
 }
 
-JL_DLLEXPORT struct_big test_big(struct_big a) {
+DLLEXPORT struct_big test_big(struct_big a) {
     //Unpack a "big" struct { int, int, char }
     if (verbose) fprintf(stderr,"%" PRIjint " %" PRIjint " %c\n", a.x, a.y, a.z);
     a.x += 1;
@@ -544,7 +556,7 @@ JL_DLLEXPORT struct_big test_big(struct_big a) {
     return a;
 }
 
-JL_DLLEXPORT struct_big test_big_long(jint x1, jint x2, jint x3, struct_big a) {
+DLLEXPORT struct_big test_big_long(jint x1, jint x2, jint x3, struct_big a) {
     //Unpack a "big" struct { int, int, char }
     if (verbose) fprintf(stderr,"(%" PRIjint ", %" PRIjint ", %" PRIjint ") %" PRIjint " %" PRIjint " %c\n", x1, x2, x3, a.x, a.y, a.z);
     a.x += 1 + x1 + x2 + x3;
@@ -554,7 +566,7 @@ JL_DLLEXPORT struct_big test_big_long(jint x1, jint x2, jint x3, struct_big a) {
 }
 
 #define test_huge(suffix, reg) \
-JL_DLLEXPORT struct_huge##suffix test_huge##suffix(char a, struct_huge##suffix b, char c) { \
+DLLEXPORT struct_huge##suffix test_huge##suffix(char a, struct_huge##suffix b, char c) { \
     if (verbose) fprintf(stderr,"%c-%c\n", a, c); \
     b.reg *= 39; \
     return b; \
@@ -577,7 +589,7 @@ test_huge(5b, r1);
 
 // Enough arguments for architectures that uses registers for integer or
 // floating point arguments to spill.
-JL_DLLEXPORT int test_long_args_intp(int *a1, int *a2, int *a3, int *a4,
+DLLEXPORT int test_long_args_intp(int *a1, int *a2, int *a3, int *a4,
                                      int *a5, int *a6, int *a7, int *a8,
                                      int *a9, int *a10, int *a11, int *a12,
                                      int *a13, int *a14)
@@ -586,7 +598,7 @@ JL_DLLEXPORT int test_long_args_intp(int *a1, int *a2, int *a3, int *a4,
             *a11 + *a12 + *a13 + *a14);
 }
 
-JL_DLLEXPORT int test_long_args_int(int a1, int a2, int a3, int a4,
+DLLEXPORT int test_long_args_int(int a1, int a2, int a3, int a4,
                                     int a5, int a6, int a7, int a8,
                                     int a9, int a10, int a11, int a12,
                                     int a13, int a14)
@@ -595,7 +607,7 @@ JL_DLLEXPORT int test_long_args_int(int a1, int a2, int a3, int a4,
             a11 + a12 + a13 + a14);
 }
 
-JL_DLLEXPORT float test_long_args_float(float a1, float a2, float a3,
+DLLEXPORT float test_long_args_float(float a1, float a2, float a3,
                                         float a4, float a5, float a6,
                                         float a7, float a8, float a9,
                                         float a10, float a11, float a12,
@@ -605,7 +617,7 @@ JL_DLLEXPORT float test_long_args_float(float a1, float a2, float a3,
             a11 + a12 + a13 + a14);
 }
 
-JL_DLLEXPORT double test_long_args_double(double a1, double a2, double a3,
+DLLEXPORT double test_long_args_double(double a1, double a2, double a3,
                                           double a4, double a5, double a6,
                                           double a7, double a8, double a9,
                                           double a10, double a11, double a12,
@@ -620,59 +632,59 @@ typedef struct {
     int *b;
 } struct_spill_pint;
 
-JL_DLLEXPORT int test_spill_int1(int *v1, struct_spill_pint s)
+DLLEXPORT int test_spill_int1(int *v1, struct_spill_pint s)
 {
     return *v1 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int2(int *v1, int *v2, struct_spill_pint s)
+DLLEXPORT int test_spill_int2(int *v1, int *v2, struct_spill_pint s)
 {
     return *v1 + *v2 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int3(int *v1, int *v2, int *v3, struct_spill_pint s)
+DLLEXPORT int test_spill_int3(int *v1, int *v2, int *v3, struct_spill_pint s)
 {
     return *v1 + *v2 + *v3 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int4(int *v1, int *v2, int *v3, int *v4,
+DLLEXPORT int test_spill_int4(int *v1, int *v2, int *v3, int *v4,
                                  struct_spill_pint s)
 {
     return *v1 + *v2 + *v3 + *v4 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int5(int *v1, int *v2, int *v3, int *v4, int *v5,
+DLLEXPORT int test_spill_int5(int *v1, int *v2, int *v3, int *v4, int *v5,
                                  struct_spill_pint s)
 {
     return *v1 + *v2 + *v3 + *v4 + *v5 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int6(int *v1, int *v2, int *v3, int *v4, int *v5,
+DLLEXPORT int test_spill_int6(int *v1, int *v2, int *v3, int *v4, int *v5,
                                  int *v6, struct_spill_pint s)
 {
     return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int7(int *v1, int *v2, int *v3, int *v4, int *v5,
+DLLEXPORT int test_spill_int7(int *v1, int *v2, int *v3, int *v4, int *v5,
                                  int *v6, int *v7, struct_spill_pint s)
 {
     return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int8(int *v1, int *v2, int *v3, int *v4, int *v5,
+DLLEXPORT int test_spill_int8(int *v1, int *v2, int *v3, int *v4, int *v5,
                                  int *v6, int *v7, int *v8, struct_spill_pint s)
 {
     return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *v8 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int9(int *v1, int *v2, int *v3, int *v4, int *v5,
+DLLEXPORT int test_spill_int9(int *v1, int *v2, int *v3, int *v4, int *v5,
                                  int *v6, int *v7, int *v8, int *v9,
                                  struct_spill_pint s)
 {
     return *v1 + *v2 + *v3 + *v4 + *v5 + *v6 + *v7 + *v8 + *v9 + *s.a + *s.b;
 }
 
-JL_DLLEXPORT int test_spill_int10(int *v1, int *v2, int *v3, int *v4, int *v5,
+DLLEXPORT int test_spill_int10(int *v1, int *v2, int *v3, int *v4, int *v5,
                                   int *v6, int *v7, int *v8, int *v9, int *v10,
                                   struct_spill_pint s)
 {
@@ -685,79 +697,79 @@ typedef struct {
     float b;
 } struct_spill_float;
 
-JL_DLLEXPORT float test_spill_float1(float v1, struct_spill_float s)
+DLLEXPORT float test_spill_float1(float v1, struct_spill_float s)
 {
     return v1 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float2(float v1, float v2, struct_spill_float s)
+DLLEXPORT float test_spill_float2(float v1, float v2, struct_spill_float s)
 {
     return v1 + v2 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float3(float v1, float v2, float v3,
+DLLEXPORT float test_spill_float3(float v1, float v2, float v3,
                                      struct_spill_float s)
 {
     return v1 + v2 + v3 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float4(float v1, float v2, float v3, float v4,
+DLLEXPORT float test_spill_float4(float v1, float v2, float v3, float v4,
                                      struct_spill_float s)
 {
     return v1 + v2 + v3 + v4 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float5(float v1, float v2, float v3, float v4,
+DLLEXPORT float test_spill_float5(float v1, float v2, float v3, float v4,
                                      float v5, struct_spill_float s)
 {
     return v1 + v2 + v3 + v4 + v5 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float6(float v1, float v2, float v3, float v4,
+DLLEXPORT float test_spill_float6(float v1, float v2, float v3, float v4,
                                      float v5, float v6, struct_spill_float s)
 {
     return v1 + v2 + v3 + v4 + v5 + v6 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float7(float v1, float v2, float v3, float v4,
+DLLEXPORT float test_spill_float7(float v1, float v2, float v3, float v4,
                                      float v5, float v6, float v7,
                                      struct_spill_float s)
 {
     return v1 + v2 + v3 + v4 + v5 + v6 + v7 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float8(float v1, float v2, float v3, float v4,
+DLLEXPORT float test_spill_float8(float v1, float v2, float v3, float v4,
                                      float v5, float v6, float v7, float v8,
                                      struct_spill_float s)
 {
     return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float9(float v1, float v2, float v3, float v4,
+DLLEXPORT float test_spill_float9(float v1, float v2, float v3, float v4,
                                      float v5, float v6, float v7, float v8,
                                      float v9, struct_spill_float s)
 {
     return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + s.a + s.b;
 }
 
-JL_DLLEXPORT float test_spill_float10(float v1, float v2, float v3, float v4,
+DLLEXPORT float test_spill_float10(float v1, float v2, float v3, float v4,
                                       float v5, float v6, float v7, float v8,
                                       float v9, float v10, struct_spill_float s)
 {
     return (v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + s.a + s.b);
 }
 
-JL_DLLEXPORT int get_c_int(void)
+DLLEXPORT int get_c_int(void)
 {
     return c_int;
 }
 
-JL_DLLEXPORT void set_c_int(int i)
+DLLEXPORT void set_c_int(int i)
 {
     c_int = i;
 }
 
-JL_DLLEXPORT void finalizer_cptr(void* v)
+DLLEXPORT void finalizer_cptr(void* v)
 {
     set_c_int(-1);
 }
@@ -766,7 +778,7 @@ JL_DLLEXPORT void finalizer_cptr(void* v)
 //////////////////////////////////
 // Turn off verbose for automated tests, leave on for debugging
 
-JL_DLLEXPORT void set_verbose(int level) {
+DLLEXPORT void set_verbose(int level) {
     verbose = level;
 }
 
@@ -774,7 +786,7 @@ JL_DLLEXPORT void set_verbose(int level) {
 //////////////////////////////////
 // Other tests
 
-JL_DLLEXPORT void *test_echo_p(void *p) {
+DLLEXPORT void *test_echo_p(void *p) {
     return p;
 }
 
@@ -782,7 +794,7 @@ JL_DLLEXPORT void *test_echo_p(void *p) {
 
 #include <xmmintrin.h>
 
-JL_DLLEXPORT __m128i test_m128i(__m128i a, __m128i b, __m128i c, __m128i d)
+DLLEXPORT __m128i test_m128i(__m128i a, __m128i b, __m128i c, __m128i d)
 {
     // 64-bit x86 has only level 2 SSE, which does not have a <4 x int32> multiplication,
     // so we use floating-point instead, and assume caller knows about the hack.
@@ -791,7 +803,7 @@ JL_DLLEXPORT __m128i test_m128i(__m128i a, __m128i b, __m128i c, __m128i d)
                                                     _mm_cvtepi32_ps(_mm_sub_epi32(c,d)))));
 }
 
-JL_DLLEXPORT __m128 test_m128(__m128 a, __m128 b, __m128 c, __m128 d)
+DLLEXPORT __m128 test_m128(__m128 a, __m128 b, __m128 c, __m128 d)
 {
     return _mm_add_ps(a, _mm_mul_ps(b, _mm_sub_ps(c, d)));
 }
@@ -800,7 +812,7 @@ JL_DLLEXPORT __m128 test_m128(__m128 a, __m128 b, __m128 c, __m128 d)
 
 #ifdef _CPU_AARCH64_
 
-JL_DLLEXPORT __int128 test_aa64_i128_1(int64_t v1, __int128 v2)
+DLLEXPORT __int128 test_aa64_i128_1(int64_t v1, __int128 v2)
 {
     return v1 * 2 - v2;
 }
@@ -810,7 +822,7 @@ typedef struct {
     __int128 v2;
 } struct_aa64_1;
 
-JL_DLLEXPORT struct_aa64_1 test_aa64_i128_2(int64_t v1, __int128 v2,
+DLLEXPORT struct_aa64_1 test_aa64_i128_2(int64_t v1, __int128 v2,
                                             struct_aa64_1 v3)
 {
     struct_aa64_1 x = {(int32_t)v1 / 2 + 1 - v3.v1, v2 * 2 - 1 - v3.v2};
@@ -822,12 +834,12 @@ typedef struct {
     double v2;
 } struct_aa64_2;
 
-JL_DLLEXPORT __fp16 test_aa64_fp16_1(int v1, float v2, double v3, __fp16 v4)
+DLLEXPORT __fp16 test_aa64_fp16_1(int v1, float v2, double v3, __fp16 v4)
 {
     return (__fp16)(v1 + v2 * 2 + v3 * 3 + v4 * 4);
 }
 
-JL_DLLEXPORT struct_aa64_2 test_aa64_fp16_2(int v1, float v2,
+DLLEXPORT struct_aa64_2 test_aa64_fp16_2(int v1, float v2,
                                             double v3, __fp16 v4)
 {
     struct_aa64_2 x = {v4 / 2 + 1, v1 * 2 + v2 * 4 - v3};
@@ -836,7 +848,7 @@ JL_DLLEXPORT struct_aa64_2 test_aa64_fp16_2(int v1, float v2,
 
 #include <arm_neon.h>
 
-JL_DLLEXPORT int64x2_t test_aa64_vec_1(int32x2_t v1, float _v2, int32x2_t v3)
+DLLEXPORT int64x2_t test_aa64_vec_1(int32x2_t v1, float _v2, int32x2_t v3)
 {
     int v2 = (int)_v2;
     return vmovl_s32(v1 * v2 + v3);
@@ -854,7 +866,7 @@ typedef struct {
     int16x8_t v1;
 } struct_aa64_4;
 
-JL_DLLEXPORT struct_aa64_3 test_aa64_vec_2(struct_aa64_3 v1, struct_aa64_4 v2)
+DLLEXPORT struct_aa64_3 test_aa64_vec_2(struct_aa64_3 v1, struct_aa64_4 v2)
 {
     // The cast below is to workaround GCC issue.
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96990
@@ -945,21 +957,21 @@ test_huge(3_ppc64_hva, vf1[0]);
 test_huge(4_ppc64_hva, v1[0]);
 test_huge(5_ppc64_hva, v1[0]);
 
-JL_DLLEXPORT int64_t test_ppc64_vec1long(
+DLLEXPORT int64_t test_ppc64_vec1long(
         int64_t d1, int64_t d2, int64_t d3, int64_t d4, int64_t d5, int64_t d6,
         int64_t d7, int64_t d8, int64_t d9, struct_huge1_ppc64 vs)
 {
     return d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8 + d9 + vs.m + vs.v[0] + vs.v[1] + vs.v[2] + vs.v[3];
 }
 
-JL_DLLEXPORT int64_t test_ppc64_vec1long_vec(
+DLLEXPORT int64_t test_ppc64_vec1long_vec(
         int64_t d1, int64_t d2, int64_t d3, int64_t d4, int64_t d5, int64_t d6,
         int64_t d7, int64_t d8, int64_t d9, float32x4_t vs)
 {
     return d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8 + d9 + vs[0] + vs[1] + vs[2] + vs[3];
 }
 
-JL_DLLEXPORT float32x4_t test_ppc64_vec2(int64_t d1, float32x4_t a, float32x4_t b, float32x4_t c, float32x4_t d,
+DLLEXPORT float32x4_t test_ppc64_vec2(int64_t d1, float32x4_t a, float32x4_t b, float32x4_t c, float32x4_t d,
                                          float32x4_t e, float32x4_t f, float32x4_t g, float32x4_t h, float32x4_t i,
                                          float32x4_t j, float32x4_t k, float32x4_t l, float32x4_t m, float32x4_t n)
 {
@@ -973,13 +985,13 @@ JL_DLLEXPORT float32x4_t test_ppc64_vec2(int64_t d1, float32x4_t a, float32x4_t 
 
 #endif
 
-JL_DLLEXPORT int threadcall_args(int a, int b) {
+DLLEXPORT int threadcall_args(int a, int b) {
     return a + b;
 }
 
-JL_DLLEXPORT void c_exit_finalizer(void* v) {
+DLLEXPORT void c_exit_finalizer(void* v) {
     printf("c_exit_finalizer: %d, %u", *(int*)v, (unsigned)((uintptr_t)v & (uintptr_t)1));
 }
 
 // global variable for cglobal testing
-JL_DLLEXPORT const int global_var = 1;
+DLLEXPORT const int global_var = 1;

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -744,8 +744,7 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.endswith_lower("jl_method_match_t") ||
                    Name.endswith_lower("jl_vararg_t") ||
                    Name.endswith_lower("jl_opaque_closure_t") ||
-                   // Probably not technically true for these, but let's allow
-                   // it
+                   // Probably not technically true for these, but let's allow it
                    Name.endswith_lower("typemap_intersection_env") ||
                    Name.endswith_lower("interpreter_state") ||
                    Name.endswith_lower("jl_typeenv_t") ||
@@ -775,7 +774,7 @@ bool GCChecker::isGCTracked(const Expr *E) {
 
 bool GCChecker::isGloballyRootedType(QualType QT) const {
   return isJuliaType(
-      [](StringRef Name) { return Name.endswith_lower("jl_sym_t"); }, QT);
+      [](StringRef Name) { return Name.endswith("jl_sym_t"); }, QT);
 }
 
 bool GCChecker::isSafepoint(const CallEvent &Call) const {
@@ -813,8 +812,8 @@ bool GCChecker::isSafepoint(const CallEvent &Call) const {
       if (FD->getBuiltinID() != 0 || FD->isTrivial())
         isCalleeSafepoint = false;
       else if (FD->getDeclName().isIdentifier() &&
-               (FD->getName().startswith_lower("uv_") ||
-                FD->getName().startswith_lower("unw_") ||
+               (FD->getName().startswith("uv_") ||
+                FD->getName().startswith("unw_") ||
                 FD->getName().startswith("_U")) &&
                FD->getName() != "uv_run")
         isCalleeSafepoint = false;
@@ -952,13 +951,13 @@ bool GCChecker::processAllocationOfResult(const CallEvent &Call,
         // global roots.
         StringRef FDName =
             FD->getDeclName().isIdentifier() ? FD->getName() : "";
-        if (FDName.startswith_lower("jl_box_")) {
+        if (FDName.startswith("jl_box_") || FDName.startswith("ijl_box_")) {
           SVal Arg = Call.getArgSVal(0);
           if (auto CI = Arg.getAs<nonloc::ConcreteInt>()) {
             const llvm::APSInt &Value = CI->getValue();
             bool GloballyRooted = false;
             const int64_t NBOX_C = 1024;
-            if (FDName.startswith_lower("jl_box_u")) {
+            if (FDName.startswith("jl_box_u") || FDName.startswith("ijl_box_u")) {
               if (Value < NBOX_C) {
                 GloballyRooted = true;
               }
@@ -1068,10 +1067,10 @@ void GCChecker::checkDerivingExpr(const Expr *Result, const Expr *Parent,
     // TODO: We may want to refine this. This is to track pointers through the
     // array list in jl_module_t.
     bool ParentIsModule = isJuliaType(
-        [](StringRef Name) { return Name.endswith_lower("jl_module_t"); },
+        [](StringRef Name) { return Name.endswith("jl_module_t"); },
         Parent->getType());
     bool ResultIsArrayList = isJuliaType(
-        [](StringRef Name) { return Name.endswith_lower("arraylist_t"); },
+        [](StringRef Name) { return Name.endswith("arraylist_t"); },
         Result->getType());
     if (!(ParentIsModule && ResultIsArrayList) && isGCTracked(Parent)) {
       ResultTracked = false;
@@ -1428,7 +1427,7 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
     C.addTransition(
         State->set<GCValueMap>(Sym, ValueState::getRooted(nullptr, -1)));
     return true;
-  } else if (name == "jl_gc_enable") {
+  } else if (name == "jl_gc_enable" || name == "ijl_gc_enable") {
     ProgramStateRef State = C.getState();
     // Check for a literal argument
     SVal Arg = C.getSVal(CE->getArg(0));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -103,9 +103,6 @@ typedef Instruction TerminatorInst;
 #include "processor.h"
 #include "julia_assert.h"
 
-#define STR(csym)           #csym
-#define XSTR(csym)          STR(csym)
-
 JL_STREAM *dump_emitted_mi_name_stream = NULL;
 extern "C" JL_DLLEXPORT
 void jl_dump_emitted_mi_name(void *s)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -103,6 +103,9 @@ typedef Instruction TerminatorInst;
 #include "processor.h"
 #include "julia_assert.h"
 
+#define STR(csym)           #csym
+#define XSTR(csym)          STR(csym)
+
 JL_STREAM *dump_emitted_mi_name_stream = NULL;
 extern "C" JL_DLLEXPORT
 void jl_dump_emitted_mi_name(void *s)
@@ -391,43 +394,43 @@ static AttributeList get_attrs_zext(LLVMContext &C)
 
 // global vars
 static const auto jlRTLD_DEFAULT_var = new JuliaVariable{
-    "jl_RTLD_DEFAULT_handle",
+    XSTR(jl_RTLD_DEFAULT_handle),
     true,
     [](LLVMContext &C) { return T_pint8; },
 };
 #ifdef _OS_WINDOWS_
 static const auto jlexe_var = new JuliaVariable{
-    "jl_exe_handle",
+    XSTR(jl_exe_handle),
     true,
     [](LLVMContext &C) { return T_pint8; },
 };
 static const auto jldll_var = new JuliaVariable{
-    "jl_libjulia_internal_handle",
+    XSTR(jl_libjulia_internal_handle),
     true,
     [](LLVMContext &C) { return T_pint8; },
 };
 #endif //_OS_WINDOWS_
 
 static const auto jlstack_chk_guard_var = new JuliaVariable{
-    "__stack_chk_guard",
+    XSTR(__stack_chk_guard),
     true,
     get_pjlvalue,
 };
 
 static const auto jlgetworld_global = new JuliaVariable{
-    "jl_world_counter",
+    XSTR(jl_world_counter),
     false,
     [](LLVMContext &C) { return (Type*)T_size; },
 };
 
 static const auto jlboxed_int8_cache = new JuliaVariable{
-    "jl_boxed_int8_cache",
+    XSTR(jl_boxed_int8_cache),
     true,
     [](LLVMContext &C) { return (Type*)ArrayType::get(T_pjlvalue, 256); },
 };
 
 static const auto jlboxed_uint8_cache = new JuliaVariable{
-    "jl_boxed_uint8_cache",
+    XSTR(jl_boxed_uint8_cache),
     true,
     [](LLVMContext &C) { return (Type*)ArrayType::get(T_pjlvalue, 256); },
 };
@@ -444,96 +447,96 @@ static const auto jlpgcstack_func = new JuliaFunction{
 // Symbols are not gc-tracked, but we'll treat them as callee rooted anyway,
 // because they may come from a gc-rooted location
 static const auto jlnew_func = new JuliaFunction{
-    "jl_new_structv",
+    XSTR(jl_new_structv),
     get_func_sig,
     get_func_attrs,
 };
 static const auto jlsplatnew_func = new JuliaFunction{
-    "jl_new_structt",
+    XSTR(jl_new_structt),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
             {T_prjlvalue, T_prjlvalue}, false); },
     get_func_attrs,
 };
 static const auto jlthrow_func = new JuliaFunction{
-    "jl_throw",
+    XSTR(jl_throw),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
     get_attrs_noreturn,
 };
 static const auto jlerror_func = new JuliaFunction{
-    "jl_error",
+    XSTR(jl_error),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_pint8}, false); },
     get_attrs_noreturn,
 };
 static const auto jlatomicerror_func = new JuliaFunction{
-    "jl_atomic_error",
+    XSTR(jl_atomic_error),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_pint8}, false); },
     get_attrs_noreturn,
 };
 static const auto jltypeerror_func = new JuliaFunction{
-    "jl_type_error",
+    XSTR(jl_type_error),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_pint8, T_prjlvalue, PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
     get_attrs_noreturn,
 };
 static const auto jlundefvarerror_func = new JuliaFunction{
-    "jl_undefined_var_error",
+    XSTR(jl_undefined_var_error),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
     get_attrs_noreturn,
 };
 static const auto jlboundserrorv_func = new JuliaFunction{
-    "jl_bounds_error_ints",
+    XSTR(jl_bounds_error_ints),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted), T_psize, T_size}, false); },
     get_attrs_noreturn,
 };
 static const auto jlboundserror_func = new JuliaFunction{
-    "jl_bounds_error_int",
+    XSTR(jl_bounds_error_int),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted), T_size}, false); },
     get_attrs_noreturn,
 };
 static const auto jlvboundserror_func = new JuliaFunction{
-    "jl_bounds_error_tuple_int",
+    XSTR(jl_bounds_error_tuple_int),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_pprjlvalue, T_size, T_size}, false); },
     get_attrs_noreturn,
 };
 static const auto jluboundserror_func = new JuliaFunction{
-    "jl_bounds_error_unboxed_int",
+    XSTR(jl_bounds_error_unboxed_int),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {PointerType::get(T_int8, AddressSpace::Derived), T_pjlvalue, T_size}, false); },
     get_attrs_noreturn,
 };
 static const auto jlcheckassign_func = new JuliaFunction{
-    "jl_checked_assignment",
+    XSTR(jl_checked_assignment),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_pjlvalue, PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
     nullptr,
 };
 static const auto jldeclareconst_func = new JuliaFunction{
-    "jl_declare_constant",
+    XSTR(jl_declare_constant),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_pjlvalue}, false); },
     nullptr,
 };
 static const auto jlgetbindingorerror_func = new JuliaFunction{
-    "jl_get_binding_or_error",
+    XSTR(jl_get_binding_or_error),
     [](LLVMContext &C) { return FunctionType::get(T_pjlvalue,
                 {T_pjlvalue, T_pjlvalue}, false); },
     nullptr,
 };
 static const auto jlboundp_func = new JuliaFunction{
-    "jl_boundp",
+    XSTR(jl_boundp),
     [](LLVMContext &C) { return FunctionType::get(T_int32,
                 {T_pjlvalue, T_pjlvalue}, false); },
     nullptr,
 };
 static const auto jltopeval_func = new JuliaFunction{
-    "jl_toplevel_eval",
+    XSTR(jl_toplevel_eval),
     [](LLVMContext &C) { return FunctionType::get(T_pjlvalue,
                 {T_pjlvalue, T_pjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -542,7 +545,7 @@ static const auto jltopeval_func = new JuliaFunction{
             None); },
 };
 static const auto jlcopyast_func = new JuliaFunction{
-    "jl_copy_ast",
+    XSTR(jl_copy_ast),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
                 {T_prjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -551,7 +554,7 @@ static const auto jlcopyast_func = new JuliaFunction{
             None); },
 };
 //static const auto jlnsvec_func = new JuliaFunction{
-//    "jl_svec",
+//    XSTR(jl_svec),
 //    [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
 //                {T_size}, true); },
 //    [](LLVMContext &C) { return AttributeList::get(C,
@@ -560,12 +563,12 @@ static const auto jlcopyast_func = new JuliaFunction{
 //            None); },
 //};
 static const auto jlapplygeneric_func = new JuliaFunction{
-    "jl_apply_generic",
+    XSTR(jl_apply_generic),
     get_func_sig,
     get_func_attrs,
 };
 static const auto jlinvoke_func = new JuliaFunction{
-    "jl_invoke",
+    XSTR(jl_invoke),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
                 {T_prjlvalue, T_pprjlvalue, T_uint32, T_prjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -575,19 +578,19 @@ static const auto jlinvoke_func = new JuliaFunction{
              Attributes(C, {Attribute::ReadOnly, Attribute::NoCapture})}); },
 };
 static const auto jlmethod_func = new JuliaFunction{
-    "jl_method_def",
+    XSTR(jl_method_def),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
                 {T_prjlvalue, T_prjlvalue, T_prjlvalue, T_pjlvalue}, false); },
     nullptr,
 };
 static const auto jlgenericfunction_func = new JuliaFunction{
-    "jl_generic_function_def",
+    XSTR(jl_generic_function_def),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
                 {T_pjlvalue, T_pjlvalue, T_pprjlvalue, T_pjlvalue, T_pjlvalue}, false); },
     nullptr,
 };
 static const auto jllockvalue_func = new JuliaFunction{
-    "jl_lock_value",
+    XSTR(jl_lock_value),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -596,7 +599,7 @@ static const auto jllockvalue_func = new JuliaFunction{
             {Attributes(C, {Attribute::NoCapture})}); },
 };
 static const auto jlunlockvalue_func = new JuliaFunction{
-    "jl_unlock_value",
+    XSTR(jl_unlock_value),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {PointerType::get(T_jlvalue, AddressSpace::CalleeRooted)}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -605,35 +608,35 @@ static const auto jlunlockvalue_func = new JuliaFunction{
             {Attributes(C, {Attribute::NoCapture})}); },
 };
 static const auto jlenter_func = new JuliaFunction{
-    "jl_enter_handler",
+    XSTR(jl_enter_handler),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_pint8}, false); },
     nullptr,
 };
 static const auto jl_current_exception_func = new JuliaFunction{
-    "jl_current_exception",
+    XSTR(jl_current_exception),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue, false); },
     nullptr,
 };
 static const auto jlleave_func = new JuliaFunction{
-    "jl_pop_handler",
+    XSTR(jl_pop_handler),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_int32}, false); },
     nullptr,
 };
 static const auto jl_restore_excstack_func = new JuliaFunction{
-    "jl_restore_excstack",
+    XSTR(jl_restore_excstack),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_size}, false); },
     nullptr,
 };
 static const auto jl_excstack_state_func = new JuliaFunction{
-    "jl_excstack_state",
+    XSTR(jl_excstack_state),
     [](LLVMContext &C) { return FunctionType::get(T_size, false); },
     nullptr,
 };
 static const auto jlegalx_func = new JuliaFunction{
-    "jl_egal__unboxed",
+    XSTR(jl_egal__unboxed),
     [](LLVMContext &C) {
         Type *T = PointerType::get(T_jlvalue, AddressSpace::Derived);
         return FunctionType::get(T_int32, {T, T, T_prjlvalue}, false); },
@@ -652,7 +655,7 @@ static const auto jl_alloc_obj_func = new JuliaFunction{
             None); },
 };
 static const auto jl_newbits_func = new JuliaFunction{
-    "jl_new_bits",
+    XSTR(jl_new_bits),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
                 {T_prjlvalue, T_pint8}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -690,20 +693,20 @@ static const auto jl_write_barrier_func = new JuliaFunction{
             {Attributes(C, {Attribute::ReadOnly})}); },
 };
 static const auto jlisa_func = new JuliaFunction{
-    "jl_isa",
+    XSTR(jl_isa),
     [](LLVMContext &C) { return FunctionType::get(T_int32,
             {T_prjlvalue, T_prjlvalue}, false); },
     nullptr,
 };
 
 static const auto jlsubtype_func = new JuliaFunction{
-    "jl_subtype",
+    XSTR(jl_subtype),
     [](LLVMContext &C) { return FunctionType::get(T_int32,
             {T_prjlvalue, T_prjlvalue}, false); },
     nullptr,
 };
 static const auto jlapplytype_func = new JuliaFunction{
-    "jl_instantiate_type_in_env",
+    XSTR(jl_instantiate_type_in_env),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
             {T_pjlvalue, T_pjlvalue, T_pprjlvalue}, false); },
     [](LLVMContext &C) {
@@ -715,7 +718,7 @@ static const auto jlapplytype_func = new JuliaFunction{
     },
 };
 static const auto jl_object_id__func = new JuliaFunction{
-    "jl_object_id_",
+    XSTR(jl_object_id_),
     [](LLVMContext &C) { return FunctionType::get(T_size,
             {T_prjlvalue, PointerType::get(T_int8, AddressSpace::Derived)}, false); },
     nullptr,
@@ -734,7 +737,7 @@ static const auto setjmp_func = new JuliaFunction{
             None); },
 };
 static const auto memcmp_func = new JuliaFunction{
-    "memcmp",
+    XSTR(memcmp),
     [](LLVMContext &C) { return FunctionType::get(T_int32,
             {T_pint8, T_pint8, T_size}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -744,25 +747,25 @@ static const auto memcmp_func = new JuliaFunction{
     // TODO: inferLibFuncAttributes(*memcmp_func, TLI);
 };
 static const auto jldlsym_func = new JuliaFunction{
-    "jl_load_and_lookup",
+    XSTR(jl_load_and_lookup),
     [](LLVMContext &C) { return FunctionType::get(T_pvoidfunc,
             {T_pint8, T_pint8, PointerType::get(T_pint8, 0)}, false); },
     nullptr,
 };
 static const auto jllazydlsym_func = new JuliaFunction{
-    "jl_lazy_load_and_lookup",
+    XSTR(jl_lazy_load_and_lookup),
     [](LLVMContext &C) { return FunctionType::get(T_pvoidfunc,
             {T_prjlvalue, T_pint8}, false); },
     nullptr,
 };
 static const auto jltypeassert_func = new JuliaFunction{
-    "jl_typeassert",
+    XSTR(jl_typeassert),
     [](LLVMContext &C) { return FunctionType::get(T_void,
             {T_prjlvalue, T_prjlvalue}, false); },
     nullptr,
 };
 static const auto jlgetnthfieldchecked_func = new JuliaFunction{
-    "jl_get_nth_field_checked",
+    XSTR(jl_get_nth_field_checked),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
             {T_prjlvalue, T_size}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -771,7 +774,7 @@ static const auto jlgetnthfieldchecked_func = new JuliaFunction{
             None); },
 };
 static const auto jlgetcfunctiontrampoline_func = new JuliaFunction{
-    "jl_get_cfunction_trampoline",
+    XSTR(jl_get_cfunction_trampoline),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
             {
                 T_prjlvalue, // f (object)
@@ -788,18 +791,18 @@ static const auto jlgetcfunctiontrampoline_func = new JuliaFunction{
             None); },
 };
 static const auto diff_gc_total_bytes_func = new JuliaFunction{
-    "jl_gc_diff_total_bytes",
+    XSTR(jl_gc_diff_total_bytes),
     [](LLVMContext &C) { return FunctionType::get(T_int64, false); },
     nullptr,
 };
 static const auto sync_gc_total_bytes_func = new JuliaFunction{
-    "jl_gc_sync_total_bytes",
+    XSTR(jl_gc_sync_total_bytes),
     [](LLVMContext &C) { return FunctionType::get(T_int64,
             {T_int64}, false); },
     nullptr,
 };
 static const auto jlarray_data_owner_func = new JuliaFunction{
-    "jl_array_data_owner",
+    XSTR(jl_array_data_owner),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
             {T_prjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -809,7 +812,7 @@ static const auto jlarray_data_owner_func = new JuliaFunction{
 };
 #define BOX_FUNC(ct,rt,at,attrs)                                              \
 static const auto box_##ct##_func = new JuliaFunction{                        \
-    "jl_box_"#ct,                                                             \
+    XSTR(jl_box_##ct),                                                        \
     [](LLVMContext &C) { return FunctionType::get(rt,                         \
             {at}, false); },                                                  \
     attrs,                                                                    \
@@ -861,42 +864,42 @@ static const auto pointer_from_objref_func = new JuliaFunction{
             None); },
 };
 
-static const auto jltuple_func = new JuliaFunction{"jl_f_tuple", get_func_sig, get_func_attrs};
+static const auto jltuple_func = new JuliaFunction{XSTR(jl_f_tuple), get_func_sig, get_func_attrs};
 static const std::map<jl_fptr_args_t, JuliaFunction*> builtin_func_map = {
-    { &jl_f_is,                 new JuliaFunction{"jl_f_is", get_func_sig, get_func_attrs} },
-    { &jl_f_typeof,             new JuliaFunction{"jl_f_typeof", get_func_sig, get_func_attrs} },
-    { &jl_f_sizeof,             new JuliaFunction{"jl_f_sizeof", get_func_sig, get_func_attrs} },
-    { &jl_f_issubtype,          new JuliaFunction{"jl_f_issubtype", get_func_sig, get_func_attrs} },
-    { &jl_f_isa,                new JuliaFunction{"jl_f_isa", get_func_sig, get_func_attrs} },
-    { &jl_f_typeassert,         new JuliaFunction{"jl_f_typeassert", get_func_sig, get_func_attrs} },
-    { &jl_f_ifelse,             new JuliaFunction{"jl_f_ifelse", get_func_sig, get_func_attrs} },
-    { &jl_f__apply_iterate,     new JuliaFunction{"jl_f__apply_iterate", get_func_sig, get_func_attrs} },
-    { &jl_f__apply_pure,        new JuliaFunction{"jl_f__apply_pure", get_func_sig, get_func_attrs} },
-    { &jl_f__call_latest,       new JuliaFunction{"jl_f__call_latest", get_func_sig, get_func_attrs} },
-    { &jl_f__call_in_world,     new JuliaFunction{"jl_f__call_in_world", get_func_sig, get_func_attrs} },
-    { &jl_f_throw,              new JuliaFunction{"jl_f_throw", get_func_sig, get_func_attrs} },
+    { &jl_f_is,                 new JuliaFunction{XSTR(jl_f_is), get_func_sig, get_func_attrs} },
+    { &jl_f_typeof,             new JuliaFunction{XSTR(jl_f_typeof), get_func_sig, get_func_attrs} },
+    { &jl_f_sizeof,             new JuliaFunction{XSTR(jl_f_sizeof), get_func_sig, get_func_attrs} },
+    { &jl_f_issubtype,          new JuliaFunction{XSTR(jl_f_issubtype), get_func_sig, get_func_attrs} },
+    { &jl_f_isa,                new JuliaFunction{XSTR(jl_f_isa), get_func_sig, get_func_attrs} },
+    { &jl_f_typeassert,         new JuliaFunction{XSTR(jl_f_typeassert), get_func_sig, get_func_attrs} },
+    { &jl_f_ifelse,             new JuliaFunction{XSTR(jl_f_ifelse), get_func_sig, get_func_attrs} },
+    { &jl_f__apply_iterate,     new JuliaFunction{XSTR(jl_f__apply_iterate), get_func_sig, get_func_attrs} },
+    { &jl_f__apply_pure,        new JuliaFunction{XSTR(jl_f__apply_pure), get_func_sig, get_func_attrs} },
+    { &jl_f__call_latest,       new JuliaFunction{XSTR(jl_f__call_latest), get_func_sig, get_func_attrs} },
+    { &jl_f__call_in_world,     new JuliaFunction{XSTR(jl_f__call_in_world), get_func_sig, get_func_attrs} },
+    { &jl_f_throw,              new JuliaFunction{XSTR(jl_f_throw), get_func_sig, get_func_attrs} },
     { &jl_f_tuple,              jltuple_func },
-    { &jl_f_svec,               new JuliaFunction{"jl_f_svec", get_func_sig, get_func_attrs} },
-    { &jl_f_applicable,         new JuliaFunction{"jl_f_applicable", get_func_sig, get_func_attrs} },
-    { &jl_f_invoke,             new JuliaFunction{"jl_f_invoke", get_func_sig, get_func_attrs} },
-    { &jl_f_invoke_kwsorter,    new JuliaFunction{"jl_f_invoke_kwsorter", get_func_sig, get_func_attrs} },
-    { &jl_f_isdefined,          new JuliaFunction{"jl_f_isdefined", get_func_sig, get_func_attrs} },
-    { &jl_f_getfield,           new JuliaFunction{"jl_f_getfield", get_func_sig, get_func_attrs} },
-    { &jl_f_setfield,           new JuliaFunction{"jl_f_setfield", get_func_sig, get_func_attrs} },
-    { &jl_f_swapfield,          new JuliaFunction{"jl_f_swapfield", get_func_sig, get_func_attrs} },
-    { &jl_f_modifyfield,        new JuliaFunction{"jl_f_modifyfield", get_func_sig, get_func_attrs} },
-    { &jl_f_fieldtype,          new JuliaFunction{"jl_f_fieldtype", get_func_sig, get_func_attrs} },
-    { &jl_f_nfields,            new JuliaFunction{"jl_f_nfields", get_func_sig, get_func_attrs} },
-    { &jl_f__expr,              new JuliaFunction{"jl_f__expr", get_func_sig, get_func_attrs} },
-    { &jl_f__typevar,           new JuliaFunction{"jl_f__typevar", get_func_sig, get_func_attrs} },
-    { &jl_f_arrayref,           new JuliaFunction{"jl_f_arrayref", get_func_sig, get_func_attrs} },
-    { &jl_f_const_arrayref,     new JuliaFunction{"jl_f_const_arrayref", get_func_sig, get_func_attrs} },
-    { &jl_f_arrayset,           new JuliaFunction{"jl_f_arrayset", get_func_sig, get_func_attrs} },
-    { &jl_f_arraysize,          new JuliaFunction{"jl_f_arraysize", get_func_sig, get_func_attrs} },
-    { &jl_f_apply_type,         new JuliaFunction{"jl_f_apply_type", get_func_sig, get_func_attrs} },
+    { &jl_f_svec,               new JuliaFunction{XSTR(jl_f_svec), get_func_sig, get_func_attrs} },
+    { &jl_f_applicable,         new JuliaFunction{XSTR(jl_f_applicable), get_func_sig, get_func_attrs} },
+    { &jl_f_invoke,             new JuliaFunction{XSTR(jl_f_invoke), get_func_sig, get_func_attrs} },
+    { &jl_f_invoke_kwsorter,    new JuliaFunction{XSTR(jl_f_invoke_kwsorter), get_func_sig, get_func_attrs} },
+    { &jl_f_isdefined,          new JuliaFunction{XSTR(jl_f_isdefined), get_func_sig, get_func_attrs} },
+    { &jl_f_getfield,           new JuliaFunction{XSTR(jl_f_getfield), get_func_sig, get_func_attrs} },
+    { &jl_f_setfield,           new JuliaFunction{XSTR(jl_f_setfield), get_func_sig, get_func_attrs} },
+    { &jl_f_swapfield,          new JuliaFunction{XSTR(jl_f_swapfield), get_func_sig, get_func_attrs} },
+    { &jl_f_modifyfield,        new JuliaFunction{XSTR(jl_f_modifyfield), get_func_sig, get_func_attrs} },
+    { &jl_f_fieldtype,          new JuliaFunction{XSTR(jl_f_fieldtype), get_func_sig, get_func_attrs} },
+    { &jl_f_nfields,            new JuliaFunction{XSTR(jl_f_nfields), get_func_sig, get_func_attrs} },
+    { &jl_f__expr,              new JuliaFunction{XSTR(jl_f__expr), get_func_sig, get_func_attrs} },
+    { &jl_f__typevar,           new JuliaFunction{XSTR(jl_f__typevar), get_func_sig, get_func_attrs} },
+    { &jl_f_arrayref,           new JuliaFunction{XSTR(jl_f_arrayref), get_func_sig, get_func_attrs} },
+    { &jl_f_const_arrayref,     new JuliaFunction{XSTR(jl_f_const_arrayref), get_func_sig, get_func_attrs} },
+    { &jl_f_arrayset,           new JuliaFunction{XSTR(jl_f_arrayset), get_func_sig, get_func_attrs} },
+    { &jl_f_arraysize,          new JuliaFunction{XSTR(jl_f_arraysize), get_func_sig, get_func_attrs} },
+    { &jl_f_apply_type,         new JuliaFunction{XSTR(jl_f_apply_type), get_func_sig, get_func_attrs} },
 };
 
-static const auto jl_new_opaque_closure_jlcall_func = new JuliaFunction{"jl_new_opaque_closure_jlcall", get_func_sig, get_func_attrs};
+static const auto jl_new_opaque_closure_jlcall_func = new JuliaFunction{XSTR(jl_new_opaque_closure_jlcall), get_func_sig, get_func_attrs};
 
 static int globalUnique = 0;
 
@@ -8160,7 +8163,7 @@ static void init_jit_functions(void)
 #endif
 #endif
 
-#define BOX_F(ct) add_named_global("jl_box_"#ct, &jl_box_##ct);
+#define BOX_F(ct) add_named_global(XSTR(jl_box_##ct), &jl_box_##ct);
     BOX_F(int8); BOX_F(uint8);
     BOX_F(int16); BOX_F(uint16);
     BOX_F(int32); BOX_F(uint32);

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -6,6 +6,9 @@
 #include <llvm/IR/DebugLoc.h>
 #include <llvm/IR/IRBuilder.h>
 
+#define STR(csym)           #csym
+#define XSTR(csym)          STR(csym)
+
 enum AddressSpace {
     Generic = 0,
     Tracked = 10,

--- a/src/flisp/print.c
+++ b/src/flisp/print.c
@@ -643,10 +643,10 @@ static void cvalue_printdata(fl_context_t *fl_ctx, ios_t *f, void *data,
             if (init == 0) {
 #if defined(RTLD_SELF)
                 jl_static_print = (size_t (*)(ios_t*, void*))
-                    (uintptr_t)dlsym(RTLD_SELF, "jl_static_show");
+                    (uintptr_t)dlsym(RTLD_SELF, "ijl_static_show");
 #elif defined(RTLD_DEFAULT)
                 jl_static_print = (size_t (*)(ios_t*, void*))
-                    (uintptr_t)dlsym(RTLD_DEFAULT, "jl_static_show");
+                    (uintptr_t)dlsym(RTLD_DEFAULT, "ijl_static_show");
 #elif defined(_OS_WINDOWS_)
                 HMODULE handle;
                 if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
@@ -654,7 +654,7 @@ static void cvalue_printdata(fl_context_t *fl_ctx, ios_t *f, void *data,
                                        (LPCWSTR)(&cvalue_printdata),
                                        &handle)) {
                     jl_static_print = (size_t (*)(ios_t*, void*))
-                        (uintptr_t)GetProcAddress(handle, "jl_static_show");
+                        (uintptr_t)GetProcAddress(handle, "ijl_static_show");
                 }
 #endif
                 init = 1;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -15,7 +15,7 @@ FunctionType *get_intr_args4(LLVMContext &C) { return FunctionType::get(T_prjlva
 FunctionType *get_intr_args5(LLVMContext &C) { return FunctionType::get(T_prjlvalue, {T_prjlvalue, T_prjlvalue, T_prjlvalue, T_prjlvalue, T_prjlvalue}, false); }
 
 static JuliaFunction *runtime_func[num_intrinsics] = {
-#define ADD_I(name, nargs) new JuliaFunction{"jl_"#name, get_intr_args##nargs, nullptr},
+#define ADD_I(name, nargs) new JuliaFunction{XSTR(jl_##name), get_intr_args##nargs, nullptr},
 #define ADD_HIDDEN ADD_I
 #define ALIAS(alias, base) nullptr,
     INTRINSICS

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -1,3 +1,5 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
 // Pointers that are exposed through the public libjulia
 #define JL_EXPORTED_DATA_POINTERS(XX) \
     XX(jl_abstractarray_type) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -1,3 +1,5 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
 #define JL_EXPORTED_FUNCS(XX) \
     XX(jl_active_task_stack) \
     XX(jl_add_optimization_passes) \
@@ -22,7 +24,6 @@
     XX(jl_argument_method_table) \
     XX(jl_array_cconvert_cstring) \
     XX(jl_array_copy) \
-    XX(jl_array_data_owner) \
     XX(jl_array_del_at) \
     XX(jl_array_del_beg) \
     XX(jl_array_del_end) \
@@ -44,7 +45,6 @@
     XX(jl_array_to_string) \
     XX(jl_array_typetagdata) \
     XX(jl_arrayunset) \
-    XX(jl_astaggedvalue) \
     XX(jl_atexit_hook) \
     XX(jl_atomic_bool_cmpswap_bits) \
     XX(jl_atomic_cmpswap_bits) \
@@ -95,7 +95,6 @@
     XX(jl_checked_assignment) \
     XX(jl_clear_implicit_imports) \
     XX(jl_clear_malloc_data) \
-    XX(jl_clock_now) \
     XX(jl_close_uv) \
     XX(jl_code_for_staged) \
     XX(jl_compile_hint) \
@@ -104,9 +103,7 @@
     XX(jl_compute_fieldtypes) \
     XX(jl_copy_ast) \
     XX(jl_copy_code_info) \
-    XX(jl_cpu_pause) \
     XX(jl_cpu_threads) \
-    XX(jl_cpu_wake) \
     XX(jl_crc32c_sw) \
     XX(jl_create_native) \
     XX(jl_create_system_image) \
@@ -125,7 +122,6 @@
     XX(jl_dump_function_ir) \
     XX(jl_dump_host_cpu) \
     XX(jl_dump_method_asm) \
-    XX(jl_egal) \
     XX(jl_egal__bits) \
     XX(jl_egal__special) \
     XX(jl_eh_restore_state) \
@@ -161,7 +157,6 @@
     XX(jl_gc_add_finalizer) \
     XX(jl_gc_add_finalizer_th) \
     XX(jl_gc_add_ptr_finalizer) \
-    XX(jl_gc_alloc) \
     XX(jl_gc_alloc_0w) \
     XX(jl_gc_alloc_1w) \
     XX(jl_gc_alloc_2w) \
@@ -196,9 +191,6 @@
     XX(jl_gc_pool_alloc) \
     XX(jl_gc_queue_multiroot) \
     XX(jl_gc_queue_root) \
-    XX(jl_gc_safe_enter) \
-    XX(jl_gc_safe_leave) \
-    XX(jl_gc_safepoint) \
     XX(jl_gc_schedule_foreign_sweepfunc) \
     XX(jl_gc_set_cb_notify_external_alloc) \
     XX(jl_gc_set_cb_notify_external_free) \
@@ -208,8 +200,6 @@
     XX(jl_gc_set_cb_task_scanner) \
     XX(jl_gc_sync_total_bytes) \
     XX(jl_gc_total_hrtime) \
-    XX(jl_gc_unsafe_enter) \
-    XX(jl_gc_unsafe_leave) \
     XX(jl_gdblookup) \
     XX(jl_generating_output) \
     XX(jl_generic_function_def) \
@@ -221,7 +211,6 @@
     XX(jl_get_binding_for_method_def) \
     XX(jl_get_binding_or_error) \
     XX(jl_get_binding_wr) \
-    XX(jl_get_cfunction_trampoline) \
     XX(jl_get_cpu_name) \
     XX(jl_get_current_task) \
     XX(jl_get_default_sysimg_path) \
@@ -229,7 +218,6 @@
     XX(jl_get_fenv_consts) \
     XX(jl_get_field) \
     XX(jl_get_field_offset) \
-    XX(jl_get_fieldtypes) \
     XX(jl_get_function_id) \
     XX(jl_get_global) \
     XX(jl_get_image_file) \
@@ -262,7 +250,6 @@
     XX(jl_get_safe_restore) \
     XX(jl_get_size) \
     XX(jl_get_task_tid) \
-    XX(jl_gettimeofday) \
     XX(jl_get_tls_world_age) \
     XX(jl_get_UNAME) \
     XX(jl_get_world_counter) \
@@ -278,8 +265,6 @@
     XX(jl_has_typevar) \
     XX(jl_has_typevar_from_unionall) \
     XX(jl_hrtime) \
-    XX(jl_id_char) \
-    XX(jl_id_start_char) \
     XX(jl_idtable_rehash) \
     XX(jl_infer_thunk) \
     XX(jl_init) \
@@ -386,7 +371,6 @@
     XX(jl_object_id_) \
     XX(jl_obvious_subtype) \
     XX(jl_operator_precedence) \
-    XX(jl_op_suffix_char) \
     XX(jl_parse) \
     XX(jl_parse_all) \
     XX(jl_parse_input_line) \
@@ -468,10 +452,6 @@
     XX(jl_stored_inline) \
     XX(jl_string_ptr) \
     XX(jl_string_to_array) \
-    XX(jl_strtod_c) \
-    XX(jl_strtof_c) \
-    XX(jl_substrtod) \
-    XX(jl_substrtof) \
     XX(jl_subtype) \
     XX(jl_subtype_env) \
     XX(jl_subtype_env_size) \
@@ -481,14 +461,12 @@
     XX(jl_svec_copy) \
     XX(jl_svec_fill) \
     XX(jl_svec_isassigned) \
-    XX(jl_svec_len) \
     XX(jl_svec_ref) \
     XX(jl_switch) \
     XX(jl_switchto) \
     XX(jl_symbol) \
     XX(jl_symbol_lookup) \
     XX(jl_symbol_n) \
-    XX(jl_symbol_name) \
     XX(jl_tagged_gensym) \
     XX(jl_take_buffer) \
     XX(jl_task_get_next) \
@@ -517,7 +495,6 @@
     XX(jl_type_morespecific) \
     XX(jl_type_morespecific_no_subtype) \
     XX(jl_typename_str) \
-    XX(jl_typeof) \
     XX(jl_typeof_str) \
     XX(jl_types_equal) \
     XX(jl_type_to_llvm) \
@@ -540,7 +517,6 @@
     XX(jl_uncompress_argnames) \
     XX(jl_uncompress_ir) \
     XX(jl_undefined_var_error) \
-    XX(jl_valueof) \
     XX(jl_value_ptr) \
     XX(jl_ver_is_release) \
     XX(jl_ver_major) \

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -15,6 +15,7 @@
     ios_*;
     iswprint;
     jl_*;
+    ijl_*;
     rec_backtrace;
     julia_*;
     libsupport_init;

--- a/src/julia.h
+++ b/src/julia.h
@@ -3,6 +3,10 @@
 #ifndef JULIA_H
 #define JULIA_H
 
+#ifdef LIBRARY_EXPORTS
+#include "jl_internal_funcs.inc"
+#endif
+
 //** Configuration options that affect the Julia ABI **//
 // if this is not defined, only individual dimension sizes are
 // stored and not total length, to save space.

--- a/src/julia.h
+++ b/src/julia.h
@@ -5,6 +5,8 @@
 
 #ifdef LIBRARY_EXPORTS
 #include "jl_internal_funcs.inc"
+#undef jl_setjmp
+#undef jl_longjmp
 #endif
 
 //** Configuration options that affect the Julia ABI **//
@@ -1885,14 +1887,25 @@ JL_DLLEXPORT void jl_restore_excstack(size_t state) JL_NOTSAFEPOINT;
 #if defined(_COMPILER_GCC_)
 JL_DLLEXPORT int __attribute__ ((__nothrow__,__returns_twice__)) (jl_setjmp)(jmp_buf _Buf);
 __declspec(noreturn) __attribute__ ((__nothrow__)) void (jl_longjmp)(jmp_buf _Buf, int _Value);
+JL_DLLEXPORT int __attribute__ ((__nothrow__,__returns_twice__)) (ijl_setjmp)(jmp_buf _Buf);
+__declspec(noreturn) __attribute__ ((__nothrow__)) void (ijl_longjmp)(jmp_buf _Buf, int _Value);
 #else
 JL_DLLEXPORT int (jl_setjmp)(jmp_buf _Buf);
 void (jl_longjmp)(jmp_buf _Buf, int _Value);
+JL_DLLEXPORT int (ijl_setjmp)(jmp_buf _Buf);
+void (ijl_longjmp)(jmp_buf _Buf, int _Value);
 #endif
+#ifdef LIBRARY_EXPORTS
+#define jl_setjmp_f ijl_setjmp
+#define jl_setjmp_name "ijl_setjmp"
+#define jl_setjmp(a,b) ijl_setjmp(a)
+#define jl_longjmp(a,b) ijl_longjmp(a,b)
+#else
 #define jl_setjmp_f jl_setjmp
 #define jl_setjmp_name "jl_setjmp"
 #define jl_setjmp(a,b) jl_setjmp(a)
 #define jl_longjmp(a,b) jl_longjmp(a,b)
+#endif
 #elif defined(_OS_EMSCRIPTEN_)
 #define jl_setjmp(a,b) setjmp(a)
 #define jl_longjmp(a,b) longjmp(a,b)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -418,6 +418,16 @@ jl_svec_t *jl_perm_symsvec(size_t n, ...);
                 "Number of passed arguments does not match expected number"); \
             n;                                                                \
         }), __VA_ARGS__)
+#ifdef jl_svec
+#undef jl_svec
+#define jl_svec(n, ...) \
+    (ijl_svec)(__extension__({                                                \
+            static_assert(                                                    \
+                n == sizeof((void *[]){ __VA_ARGS__ })/sizeof(void *),        \
+                "Number of passed arguments does not match expected number"); \
+            n;                                                                \
+        }), __VA_ARGS__)
+#else
 #define jl_svec(n, ...) \
     (jl_svec)(__extension__({                                                 \
             static_assert(                                                    \
@@ -425,6 +435,7 @@ jl_svec_t *jl_perm_symsvec(size_t n, ...);
                 "Number of passed arguments does not match expected number"); \
             n;                                                                \
         }), __VA_ARGS__)
+#endif
 #endif
 #endif
 

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1551,8 +1551,8 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                     // Known functions emitted in codegen that are not safepoints
                     if (callee == pointer_from_objref_func || callee == gc_preserve_begin_func ||
                         callee == gc_preserve_end_func || callee == typeof_func ||
-                        callee == pgcstack_getter || callee->getName() == "jl_egal__unboxed" ||
-                        callee->getName() == "jl_lock_value" || callee->getName() == "jl_unlock_value" ||
+                        callee == pgcstack_getter || callee->getName() == XSTR(jl_egal__unboxed) ||
+                        callee->getName() == XSTR(jl_lock_value) || callee->getName() == XSTR(jl_unlock_value) ||
                         callee == write_barrier_func || callee->getName() == "memcmp") {
                         continue;
                     }

--- a/src/llvm-lower-handlers.cpp
+++ b/src/llvm-lower-handlers.cpp
@@ -21,6 +21,7 @@
 
 #include "julia.h"
 #include "julia_assert.h"
+#include "codegen_shared.h"
 
 #define DEBUG_TYPE "lower_handlers"
 #undef DEBUG
@@ -95,11 +96,11 @@ static void ensure_enter_function(Module &M)
     auto T_pint8 = PointerType::get(T_int8, 0);
     auto T_void = Type::getVoidTy(M.getContext());
     auto T_int32 = Type::getInt32Ty(M.getContext());
-    if (!M.getNamedValue("jl_enter_handler")) {
+    if (!M.getNamedValue(XSTR(jl_enter_handler))) {
         std::vector<Type*> ehargs(0);
         ehargs.push_back(T_pint8);
         Function::Create(FunctionType::get(T_void, ehargs, false),
-                         Function::ExternalLinkage, "jl_enter_handler", &M);
+                         Function::ExternalLinkage, XSTR(jl_enter_handler), &M);
     }
     if (!M.getNamedValue(jl_setjmp_name)) {
         std::vector<Type*> args2(0);
@@ -118,8 +119,8 @@ bool LowerExcHandlers::doInitialization(Module &M) {
     if (!except_enter_func)
         return false;
     ensure_enter_function(M);
-    leave_func = M.getFunction("jl_pop_handler");
-    jlenter_func = M.getFunction("jl_enter_handler");
+    leave_func = M.getFunction(XSTR(jl_pop_handler));
+    jlenter_func = M.getFunction(XSTR(jl_enter_handler));
     setjmp_func = M.getFunction(jl_setjmp_name);
 
     auto T_pint8 = Type::getInt8PtrTy(M.getContext(), 0);

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -15,6 +15,7 @@
 #include "codegen_shared.h"
 #include "julia_assert.h"
 #include "llvm-pass-helpers.h"
+#include "jl_internal_funcs.inc"
 
 using namespace llvm;
 
@@ -209,9 +210,9 @@ namespace jl_intrinsics {
 }
 
 namespace jl_well_known {
-    static const char *GC_BIG_ALLOC_NAME = "jl_gc_big_alloc";
-    static const char *GC_POOL_ALLOC_NAME = "jl_gc_pool_alloc";
-    static const char *GC_QUEUE_ROOT_NAME = "jl_gc_queue_root";
+    static const char *GC_BIG_ALLOC_NAME = XSTR(jl_gc_big_alloc);
+    static const char *GC_POOL_ALLOC_NAME = XSTR(jl_gc_pool_alloc);
+    static const char *GC_QUEUE_ROOT_NAME = XSTR(jl_gc_queue_root);
 
     using jl_intrinsics::addGCAllocAttributes;
 

--- a/src/llvmcalltest.cpp
+++ b/src/llvmcalltest.cpp
@@ -13,9 +13,20 @@
 
 using namespace llvm;
 
+// Borrow definition from `support/dtypes.h`
+#ifdef _OS_WINDOWS_
+#  define DLLEXPORT __declspec(dllexport)
+#else
+# if defined(_OS_LINUX_)
+#  define DLLEXPORT __attribute__ ((visibility("protected")))
+# else
+#  define DLLEXPORT __attribute__ ((visibility("default")))
+# endif
+#endif
+
 extern "C" {
 
-JL_DLLEXPORT const char *MakeIdentityFunction(jl_value_t* jl_AnyTy) {
+DLLEXPORT const char *MakeIdentityFunction(jl_value_t* jl_AnyTy) {
     LLVMContext Ctx;
     PointerType *AnyTy = PointerType::get(StructType::get(Ctx), 0);
     // FIXME: get AnyTy via jl_type_to_llvm(Ctx, jl_AnyTy)
@@ -40,7 +51,7 @@ JL_DLLEXPORT const char *MakeIdentityFunction(jl_value_t* jl_AnyTy) {
     return strdup(buf.c_str());
 }
 
-JL_DLLEXPORT const char *MakeLoadGlobalFunction() {
+DLLEXPORT const char *MakeLoadGlobalFunction() {
     LLVMContext Ctx;
 
     auto M = new Module("shadow", Ctx);

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -7,7 +7,7 @@
 #include "julia_internal.h"
 #include "julia_assert.h"
 
-JL_DLLEXPORT jl_svec_t *(jl_svec)(size_t n, ...)
+JL_DLLEXPORT jl_svec_t *(ijl_svec)(size_t n, ...)
 {
     va_list args;
     if (n == 0) return jl_emptysvec;

--- a/src/support/END.h
+++ b/src/support/END.h
@@ -47,7 +47,6 @@ CNAME endp
 
 
 #undef CNAME
-#undef HIDENAME
 #undef STR
 #undef XSTR
 #undef _START_ENTRY

--- a/src/support/ENTRY.amd64.h
+++ b/src/support/ENTRY.amd64.h
@@ -41,7 +41,6 @@
 #define EXT_(csym)          csym
 #define EXT(csym)           EXT_(csym)
 #endif
-#define HIDENAME(asmsym)    .asmsym
 .text
 _START_ENTRY
 .globl EXT(CNAME)
@@ -51,7 +50,6 @@ EXT(CNAME):
 #elif defined(_WIN32)
 #define EXT_(csym)          csym
 #define EXT(csym)           EXT_(csym)
-#define HIDENAME(asmsym)    .asmsym
 
 #ifndef _MSC_VER
 .intel_syntax noprefix

--- a/src/support/ENTRY.i387.h
+++ b/src/support/ENTRY.i387.h
@@ -41,7 +41,6 @@
 #define EXT_(csym)          csym
 #define EXT(csym)           EXT_(csym)
 #endif
-#define HIDENAME(asmsym)    .asmsym
 .text
 _START_ENTRY
 .globl EXT(CNAME)
@@ -51,7 +50,6 @@ EXT(CNAME):
 #elif defined(_WIN32)
 #define EXT_(csym)          _##csym
 #define EXT(csym)           EXT_(csym)
-#define HIDENAME(asmsym)    .asmsym
 
 #ifndef _MSC_VER
 .intel_syntax

--- a/src/support/_setjmp.win32.S
+++ b/src/support/_setjmp.win32.S
@@ -56,8 +56,10 @@
  * and update fs:[0xEOC] to contain the address of the stack
  */
 
-#define CNAME jl_setjmp
+#define CNAME ijl_setjmp
 #include "ENTRY.i387.h"
+.globl _jl_setjmp
+_jl_setjmp:
     mov    eax,DWORD PTR [esp+4] // arg 1
     mov    edx,DWORD PTR [esp+0] // rta
     mov    DWORD PTR [eax+0],ebp
@@ -73,8 +75,10 @@
 #include "END.h"
 
 
-#define CNAME jl_longjmp
+#define CNAME ijl_longjmp
 #include "ENTRY.i387.h"
+.globl _jl_longjmp
+_jl_longjmp:
     mov    edx,DWORD PTR [esp+4] // arg 1
     mov    eax,DWORD PTR [esp+8] // arg 2
     mov    ebp,DWORD PTR [edx+24] // seh registration
@@ -87,14 +91,16 @@
     mov    ebp,DWORD PTR [edx+0]
     mov    DWORD PTR [esp],ecx
     test   eax,eax
-    jne    a
+    jne    1f
     inc    eax
-a:  ret    // jmp ecx
+1:  ret    // jmp ecx
 #include "END.h"
 
 
-#define CNAME jl_swapcontext
+#define CNAME ijl_swapcontext
 #include "ENTRY.i387.h"
+.globl _jl_swapcontext
+_jl_swapcontext:
     mov    eax,DWORD PTR [esp+4]
     // save stack registers
     mov    edx,DWORD PTR fs:[8] // stack top (low)
@@ -118,8 +124,10 @@ a:  ret    // jmp ecx
 #include "END.h"
 
 
-#define CNAME jl_setcontext
+#define CNAME ijl_setcontext
 #include "ENTRY.i387.h"
+.globl _jl_setcontext
+_jl_setcontext:
     mov    eax,DWORD PTR [esp+4]
     // restore stack registers
     mov    edx,DWORD PTR [eax+0]

--- a/src/support/_setjmp.win64.S
+++ b/src/support/_setjmp.win64.S
@@ -6,8 +6,10 @@
  * and update gs:[0x1478] to contain the address of the stack
  */
 
-#define CNAME jl_setjmp
+#define CNAME ijl_setjmp
 #include "ENTRY.amd64.h"
+.globl jl_setjmp
+jl_setjmp:
     mov    rdx,QWORD PTR [rsp] // rta
     mov    rax,QWORD PTR gs:[0] // SEH
     mov    QWORD PTR [rcx+0],rax
@@ -37,8 +39,10 @@
 #include "END.h"
 
 
-#define CNAME jl_longjmp
+#define CNAME ijl_longjmp
 #include "ENTRY.amd64.h"
+.globl jl_longjmp
+jl_longjmp:
     mov    rax,QWORD PTR [rcx+0]
     mov    rbx,QWORD PTR [rcx+8]
     mov    rsp,QWORD PTR [rcx+16]
@@ -63,15 +67,17 @@
     mov    QWORD PTR gs:[0],rax
     mov    eax,edx // move arg2 to return
     test   eax,eax
-    jne    a
+    jne    1f
     inc    eax
-a:  mov    QWORD PTR [rsp],r8
+1:  mov    QWORD PTR [rsp],r8
     ret
 #include "END.h"
 
 
-#define CNAME jl_swapcontext
+#define CNAME ijl_swapcontext
 #include "ENTRY.amd64.h"
+.globl jl_swapcontext
+jl_swapcontext:
     // save stack registers
     mov    r8,QWORD PTR gs:[16] // stack top (low)
     mov    rax,QWORD PTR gs:[8] // stack bottom (high)
@@ -109,8 +115,10 @@ a:  mov    QWORD PTR [rsp],r8
 #include "END.h"
 
 
-#define CNAME jl_setcontext
+#define CNAME ijl_setcontext
 #include "ENTRY.amd64.h"
+.globl jl_setcontext
+jl_setcontext:
     // restore stack registers
     mov    r8,QWORD PTR [rcx+0]
     mov    rax,QWORD PTR [rcx+8]

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -76,17 +76,6 @@
 #define JL_DLLIMPORT
 #endif
 
-/*
- * Debug builds include `-fstack-protector`, which adds a bit of extra prologue to
- * functions, even naked ones.  We don't want that, but we also don't want the
- * compiler warnings when `no_stack_protector` has no effect.
- */
-#ifdef JL_DEBUG_BUILD
-#define JL_NAKED __attribute__ ((naked,no_stack_protector))
-#else
-#define JL_NAKED __attribute__ ((naked))
-#endif
-
 #ifdef _OS_LINUX_
 #include <endian.h>
 #define LITTLE_ENDIAN  __LITTLE_ENDIAN

--- a/test/llvmpasses/alloc-opt-gcframe.jl
+++ b/test/llvmpasses/alloc-opt-gcframe.jl
@@ -12,7 +12,7 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 # CHECK-LABEL: @return_obj
 # CHECK-NOT: @julia.gc_alloc_obj
-# CHECK: %v = call noalias nonnull {} addrspace(10)* @jl_gc_pool_alloc
+# CHECK: %v = call noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc
 # CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !0
 println("""
 define {} addrspace(10)* @return_obj() {
@@ -52,7 +52,7 @@ define i64 @return_load(i64 %i) {
 # CHECK: call {}*** @julia.get_pgcstack()
 # CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
-# CHECK: @jl_gc_pool_alloc
+# CHECK: @ijl_gc_pool_alloc
 # CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !0
 println("""
 define void @ccall_obj(i8* %fptr) {
@@ -98,7 +98,7 @@ define void @ccall_ptr(i8* %fptr) {
 # CHECK: call {}*** @julia.get_pgcstack()
 # CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
-# CHECK: @jl_gc_pool_alloc
+# CHECK: @ijl_gc_pool_alloc
 # CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !0
 println("""
 define void @ccall_unknown_bundle(i8* %fptr) {
@@ -262,8 +262,8 @@ L3:
 """)
 # CHECK-LABEL: }{{$}}
 
-# CHECK: declare noalias nonnull {} addrspace(10)* @jl_gc_pool_alloc(i8*,
-# CHECK: declare noalias nonnull {} addrspace(10)* @jl_gc_big_alloc(i8*,
+# CHECK: declare noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc(i8*,
+# CHECK: declare noalias nonnull {} addrspace(10)* @ijl_gc_big_alloc(i8*,
 println("""
 declare void @external_function()
 declare {}*** @julia.ptls_states()

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -3,11 +3,9 @@
 @tag = external addrspace(10) global {}
 
 declare void @boxed_simple({} addrspace(10)*, {} addrspace(10)*)
-declare {} addrspace(10)* @jl_box_int64(i64)
+declare {} addrspace(10)* @ijl_box_int64(i64)
 declare {}*** @julia.ptls_states()
 declare {}*** @julia.get_pgcstack()
-declare void @jl_safepoint()
-declare {} addrspace(10)* @jl_apply_generic({} addrspace(10)*, {} addrspace(10)**, i32)
 
 declare noalias nonnull {} addrspace(10)** @julia.new_gc_frame(i32)
 declare void @julia.push_gc_frame({} addrspace(10)**, i32)
@@ -34,11 +32,11 @@ top:
 ; CHECK-DAG: [[GCFRAME_SLOT2:%.*]] = bitcast {}*** [[GCFRAME_SLOT]] to {} addrspace(10)***
 ; CHECK-NEXT: store {} addrspace(10)** %gcframe, {} addrspace(10)*** [[GCFRAME_SLOT2]], align 8
   call void @julia.push_gc_frame({} addrspace(10)** %gcframe, i32 2)
-  %aboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+  %aboxed = call {} addrspace(10)* @ijl_box_int64(i64 signext %a)
 ; CHECK: %frame_slot_1 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)** %gcframe, i32 3
   %frame_slot_1 = call {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)** %gcframe, i32 1)
   store {} addrspace(10)* %aboxed, {} addrspace(10)** %frame_slot_1, align 8
-  %bboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %b)
+  %bboxed = call {} addrspace(10)* @ijl_box_int64(i64 signext %b)
 ; CHECK: %frame_slot_2 = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)** %gcframe, i32 2
   %frame_slot_2 = call {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)** %gcframe, i32 0)
   store {} addrspace(10)* %bboxed, {} addrspace(10)** %frame_slot_2, align 8
@@ -59,7 +57,7 @@ top:
   %pgcstack = call {}*** @julia.get_pgcstack()
   %ptls = call {}*** @julia.ptls_states()
   %ptls_i8 = bitcast {}*** %ptls to i8*
-; CHECK: %v = call noalias nonnull {} addrspace(10)* @jl_gc_pool_alloc
+; CHECK: %v = call noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc
   %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, i64 8)
   %0 = bitcast {} addrspace(10)* %v to {} addrspace(10)* addrspace(10)*
   %1 = getelementptr {} addrspace(10)*, {} addrspace(10)* addrspace(10)* %0, i64 -1

--- a/test/llvmpasses/lower-handlers.ll
+++ b/test/llvmpasses/lower-handlers.ll
@@ -2,7 +2,7 @@
 
 attributes #1 = { returns_twice }
 declare i32 @julia.except_enter() #1
-declare void @jl_pop_handler(i32)
+declare void @ijl_pop_handler(i32)
 declare i8**** @julia.ptls_states()
 declare i8**** @julia.get_pgcstack()
 
@@ -10,7 +10,7 @@ define void @simple() {
 top:
     %pgcstack = call i8**** @julia.get_pgcstack()
 ; CHECK: call void @llvm.lifetime.start
-; CHECK: call void @jl_enter_handler
+; CHECK: call void @ijl_enter_handler
 ; CHECK: setjmp
     %r = call i32 @julia.except_enter()
     %cmp = icmp eq i32 %r, 0
@@ -20,7 +20,7 @@ try:
 catch:
     br label %after
 after:
-    call void @jl_pop_handler(i32 1)
+    call void @ijl_pop_handler(i32 1)
 ; CHECK: llvm.lifetime.end
     ret void
 }

--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -5,7 +5,7 @@ declare {}*** @julia.ptls_states()
 declare {}*** @julia.get_pgcstack()
 declare void @jl_safepoint()
 declare void @one_arg_boxed({} addrspace(10)*)
-declare {} addrspace(10)* @jl_box_int64(i64)
+declare {} addrspace(10)* @ijl_box_int64(i64)
 
 define void @argument_refinement({} addrspace(10)* %a) {
 ; CHECK-LABEL: @argument_refinement
@@ -26,7 +26,7 @@ define void @heap_refinement1(i64 %a) {
 ; CHECK:   %gcframe = alloca {} addrspace(10)*, i32 3
     %pgcstack = call {}*** @julia.get_pgcstack()
     %ptls = call {}*** @julia.ptls_states()
-    %aboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+    %aboxed = call {} addrspace(10)* @ijl_box_int64(i64 signext %a)
     %casted1 = bitcast {} addrspace(10)* %aboxed to {} addrspace(10)* addrspace(10)*
     %loaded1 = load {} addrspace(10)*, {} addrspace(10)* addrspace(10)* %casted1, !tbaa !1
 ; CHECK: store {} addrspace(10)* %aboxed
@@ -43,7 +43,7 @@ define void @heap_refinement2(i64 %a) {
 ; CHECK:   %gcframe = alloca {} addrspace(10)*, i32 3
     %pgcstack = call {}*** @julia.get_pgcstack()
     %ptls = call {}*** @julia.ptls_states()
-    %aboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+    %aboxed = call {} addrspace(10)* @ijl_box_int64(i64 signext %a)
     %casted1 = bitcast {} addrspace(10)* %aboxed to {} addrspace(10)* addrspace(10)*
     %loaded1 = load {} addrspace(10)*, {} addrspace(10)* addrspace(10)* %casted1, !tbaa !1
 ; CHECK: store {} addrspace(10)* %loaded1
@@ -211,7 +211,7 @@ declare void @julia.write_barrier({} addrspace(10)*, {} addrspace(10)*) #1
 define {} addrspace(10)* @setfield({} addrspace(10)* %p) {
 ; CHECK-LABEL: @setfield(
 ; CHECK-NOT: %gcframe
-; CHECK: call void @jl_gc_queue_root
+; CHECK: call void @ijl_gc_queue_root
   %pgcstack = call {}*** @julia.get_pgcstack()
   %ptls = call {}*** @julia.ptls_states()
   %c = call {} addrspace(10)* @allocate_some_value()


### PR DESCRIPTION
helps avoid linker errors and confusion