### PR TITLE
Fix ⊊, ⊋ on non-Set arguments

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -338,8 +338,8 @@ false
 """
 ⊊, ⊋
 
-⊊(a::AbstractSet, b) = length(a) < length(b) && a ⊆ b
-⊊(a, b) = Set(a) ⊊ b
+⊊(a::AbstractSet, b::AbstractSet) = length(a) < length(b) && a ⊆ b
+⊊(a, b) = Set(a) ⊊ Set(b)
 ⊋(a, b) = b ⊊ a
 
 function ⊈ end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -803,3 +803,8 @@ end
     A = empty!(A)
     @test isempty(A)
 end
+
+@testset "⊊, ⊋" begin
+    @test !((1, 2) ⊊ (1, 2, 2))
+    @test !((1, 2, 2) ⊋ (1, 2))
+end


### PR DESCRIPTION
These have been broken since at least 84da967df4a (2018), but probably forever (I didn't follow the blame past the renaming of the file).

Here's an example of getting the wrong answer:

```julia
julia> issetequal((1, 2), (1, 2, 2)) # correct
true

julia> issubset((1, 2), (1, 2, 2)) # correct
true

julia> (1, 2) ⊊ (1, 2, 2) # incorrect
true
```

