### PR TITLE
reenable the precompile generation for Distributed

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -121,16 +121,13 @@ if Distributed !== nothing
     precompile(Tuple{typeof(Distributed.procs)})
     precompile(Tuple{typeof(Distributed.finalize_ref), Distributed.Future})
     """
-# This is disabled because it doesn't give much benefit
-# and the code in Distributed is poorly typed causing many invalidations
-#=
     precompile_script *= """
     using Distributed
     addprocs(2)
     pmap(x->iseven(x) ? 1 : 0, 1:4)
     @distributed (+) for i = 1:100 Int(rand(Bool)) end
+    @everywhere 1+1
     """
-=#
 end
 
 


### PR DESCRIPTION
This was disabled in https://github.com/JuliaLang/julia/pull/37816 with the reason that latency for Distributed should not be crucial and that there was a lot of badly typed code in Distributed leading to invalidations in other code when this was precompiled into the sysimage.

However, it is becoming apparent that this had a significantly larger effect than intended, see https://github.com/JuliaLang/julia/issues/39291 and https://discourse.julialang.org/t/why-does-julia-use-thousands-of-cpu-hours-to-compute-1-2/66041.

Therefore, I think it is best to reenable this.

Some timings:

Master:

```
julia -p 64 -e 'using Distributed; @everywhere 1+1'  285.89s user 9.65s system 604% cpu 48.914 total
```

PR:

```
./julia -p 64 -e 'using Distributed; @everywhere 1+1'  29.68s user 2.21s system 174% cpu 18.256 total
```

cc @moble, @vancleve, @algorithmx 