### PR TITLE
Clarify `mkpath` docstring

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -193,10 +193,13 @@ end
 """
     mkpath(path::AbstractString; mode::Unsigned = 0o777)
 
-Creates a directory `path` along with any intermediate directories on the path,
-with permissions `mode`. `mode` defaults to `0o777`, modified by the current
-file creation mask. Unlike [`mkdir`](@ref), `mkpath` does not error if `path`
-(or parts of it) already exists. Return `path`.
+Create all intermediate directories in the `path` as required. Directories are created with
+the permissions `mode` which defaults to `0o777` and is modified by the current file
+creation mask. Unlike [`mkdir`](@ref), `mkpath` does not error if `path` (or parts of it)
+already exists. Return `path`.
+
+If `path` includes a filename you will probably want to use `mkpath(dirname(path))` to
+avoid creating a directory using the filename.
 
 # Examples
 ```julia-repl

--- a/base/file.jl
+++ b/base/file.jl
@@ -222,10 +222,10 @@ julia> readdir("test")
 1-element Array{String,1}:
  "dir"
 
-julia> mkpath("test/actually_a_directory.txt") # creates two directories
-"test/actually_a_directory.txt"
+julia> mkpath("intermediate_dir/actually_a_directory.txt") # creates two directories
+"intermediate_dir/actually_a_directory.txt"
 
-julia> isdir("test/actually_a_directory.txt")
+julia> isdir("intermediate_dir/actually_a_directory.txt")
 true
 
 ```

--- a/base/file.jl
+++ b/base/file.jl
@@ -193,22 +193,16 @@ end
 """
     mkpath(path::AbstractString; mode::Unsigned = 0o777)
 
-Create all directories in the given `path`, with permissions `mode`. `mode` defaults to
-`0o777`, modified by the current file creation mask. Unlike [`mkdir`](@ref), `mkpath`
-does not error if `path` (or parts of it) already exists.
-Return `path`.
+Creates a directory `path` along with any intermediate directories on the path,
+with permissions `mode`. `mode` defaults to `0o777`, modified by the current
+file creation mask. Unlike [`mkdir`](@ref), `mkpath` does not error if `path`
+(or parts of it) already exists. Return `path`.
 
 # Examples
 ```julia-repl
-julia> mkdir("testingdir")
-"testingdir"
+julia> cd(mktempdir())
 
-julia> cd("testingdir")
-
-julia> pwd()
-"/home/JuliaUser/testingdir"
-
-julia> mkpath("my/test/dir")
+julia> mkpath("my/test/dir") # creates three directories
 "my/test/dir"
 
 julia> readdir()
@@ -224,6 +218,13 @@ julia> readdir()
 julia> readdir("test")
 1-element Array{String,1}:
  "dir"
+
+julia> mkpath("test/actually_a_directory.txt") # creates two directories
+"test/actually_a_directory.txt"
+
+julia> isdir("test/actually_a_directory.txt")
+true
+
 ```
 """
 function mkpath(path::AbstractString; mode::Integer = 0o777)


### PR DESCRIPTION
I had thought `mkpath("test/file.txt")` would make a directory `test` and that's it (https://github.com/rofinn/FilePathsBase.jl/issues/129#issuecomment-915197193). But it also creates `file.txt` as a directory. @omus pointed out this could be clarified in the `mkpath` docstring so this is my attempt.

I removed the first bit of the example with `mkdir` because I felt that it was confusing. `mkdir` and `mkpath` are similar and if you are on the `mkpath` docstring and it starts with `mkdir` it could be easy to get mixed up. The point of that code was to start in an empty directory I believe, so I just did `cd(mktempdir())` instead.