### PR TITLE
Use `unwrapva` in MethodError candidates

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -419,7 +419,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                 # If isvarargtype then it checks whether the rest of the input arguments matches
                 # the varargtype
                 if Base.isvarargtype(sig[i])
-                    sigstr = (unwrap_unionall(sig[i]).T, "...")
+                    sigstr = (unwrapva(unwrap_unionall(sig[i])), "...")
                     j = length(t_i)
                 else
                     sigstr = (sig[i],)
@@ -456,7 +456,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                 # It ensures that methods like f(a::AbstractString...) gets the correct
                 # number of right_matches
                 for t in arg_types_param[length(sig):end]
-                    if t <: rewrap_unionall(unwrap_unionall(sig[end]).T, method.sig)
+                    if t <: rewrap_unionall(unwrapva(unwrap_unionall(sig[end])), method.sig)
                         right_matches += 1
                     end
                 end
@@ -469,7 +469,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                     for (k, sigtype) in enumerate(sig[length(t_i)+1:end])
                         sigtype = isvarargtype(sigtype) ? unwrap_unionall(sigtype) : sigtype
                         if Base.isvarargtype(sigtype)
-                            sigstr = ((sigtype::Core.TypeofVararg).T, "...")
+                            sigstr = (unwrapva(sigtype::Core.TypeofVararg), "...")
                         else
                             sigstr = (sigtype,)
                         end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -184,6 +184,11 @@ addConstraint_15639(c::Int64; uncset=nothing) = addConstraint_15639(Int32(c), un
 Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), pairs((uncset = nothing,)))
 @test String(take!(buf)) == "\nClosest candidates are:\n  addConstraint_15639(::Int32)$cfile$(ac15639line + 1) got unsupported keyword argument \"uncset\"\n  addConstraint_15639(!Matched::Int64; uncset)$cfile$(ac15639line + 2)"
 
+# Busted Vararg method definitions
+bad_vararg_decl(x::Int, y::Vararg) = 1   # don't do this, instead use (x::Int, y...)
+Base.show_method_candidates(buf, try bad_vararg_decl("hello", 3) catch e e end)
+@test occursin("bad_vararg_decl(!Matched::Int64, ::Any...)", String(take!(buf)))
+
 macro except_str(expr, err_type)
     return quote
         let err = nothing

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -187,7 +187,7 @@ Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), 
 # Busted Vararg method definitions
 bad_vararg_decl(x::Int, y::Vararg) = 1   # don't do this, instead use (x::Int, y...)
 Base.show_method_candidates(buf, try bad_vararg_decl("hello", 3) catch e e end)
-@test occursin("bad_vararg_decl(!Matched::Int64, ::Any...)", String(take!(buf)))
+@test occursin("bad_vararg_decl(!Matched::$Int, ::Any...)", String(take!(buf)))
 
 macro except_str(expr, err_type)
     return quote


### PR DESCRIPTION
I found an example of a method declaration with an argument
typed as `a::Vararg`, and this triggered an error in showing method
candidates. It's always bad when there's an error triggered when handling
an error. This PR makes the code more robust against such problems.

It's worth noting that this type of method declaration
shouldn't be used:  it is better as `a...`. The only time you should
explicitly use `Vararg` is when you are specifying both `T` and
`N` in `Vararg{T,N}`.