### PR TITLE
bugfix: properly import Base.cis into LinearAlgebra

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -9,7 +9,7 @@ module LinearAlgebra
 
 import Base: \, /, *, ^, +, -, ==
 import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, asec, asech,
-    asin, asinh, atan, atanh, axes, big, broadcast, ceil, conj, convert, copy, copyto!, cos,
+    asin, asinh, atan, atanh, axes, big, broadcast, ceil, cis, conj, convert, copy, copyto!, cos,
     cosh, cot, coth, csc, csch, eltype, exp, fill!, floor, getindex, hcat,
     getproperty, imag, inv, isapprox, isequal, isone, iszero, IndexStyle, kron, kron!, length, log, map, ndims,
     oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -576,8 +576,8 @@ julia> cis([π 0; 0 π]) ≈ -I
 true
 ```
 """
-Base.cis(A::AbstractMatrix) = exp(im * A)  # fallback
-Base.cis(A::AbstractMatrix{<:Base.HWNumber}) = exp_maybe_inplace(float.(im .* A))
+cis(A::AbstractMatrix) = exp(im * A)  # fallback
+cis(A::AbstractMatrix{<:Base.HWNumber}) = exp_maybe_inplace(float.(im .* A))
 
 exp_maybe_inplace(A::StridedMatrix{<:Union{ComplexF32, ComplexF64}}) = exp!(A)
 exp_maybe_inplace(A) = exp(A)


### PR DESCRIPTION
This fixes JuliaLang/LinearAlgebra.jl#865 (`cis(::Union{RealHermSymComplexHerm,SymTridiagonal{<:Real}})` not properly exported from `LinearAlgebra`.)

For the changes to take effect,  `Revise.revise()` seemed to be insufficient, but rebuilding julia with `make` worked. Perhaps it has something to do with the sysimage?

Also not sure if additional regression tests should be added, or if this kind of bug should be avoided by checking the coverage reports?