### PR TITLE
[Distributed] Ref counter thread safety

### DIFF
--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -84,15 +84,15 @@ function _require_callback(mod::Base.PkgId)
     end
 end
 
-const REF_ID = Ref(1)
-next_ref_id() = (id = REF_ID[]; REF_ID[] = id+1; id)
+const REF_ID = Threads.Atomic{Int}(1)
+next_ref_id() = Threads.atomic_add!(REF_ID, 1)
 
 struct RRID
     whence::Int
     id::Int
 
-    RRID() = RRID(myid(),next_ref_id())
-    RRID(whence, id) = new(whence,id)
+    RRID() = RRID(myid(), next_ref_id())
+    RRID(whence, id) = new(whence, id)
 end
 
 hash(r::RRID, h::UInt) = hash(r.whence, hash(r.id, h))


### PR DESCRIPTION
In various Dagger use cases, especially in an env with threads, issues have been observed where Future's were being set more than once. 
Stacktraces, MWE and some investigation here https://github.com/JuliaParallel/Dagger.jl/issues/267

So overall the suspicion was that Futures are being created with the same ids and are effectively being set twice when tasks are completed. 
With this fix applied this is no longer happening as the refcounter is now threadsafe

However, we are still observing hangs and some other Dagger related issues in the same examples that were causing this future set twice issue, so we still need to investigate what is causing these.

Example stacktrace
```julia
Error in eager listener:
Future can be set only once
Stacktrace:
 [1] error(s::String)
   @ Base .\error.jl:33
 [2] put_future(rid::Distributed.RRID, v::MemPool.DRef, caller::Int64)
   @ Distributed C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.8\Distributed\src\remotecall.jl:590
 [3] call_on_owner(::Function, ::Distributed.Future, ::MemPool.DRef, ::Vararg{Any})
   @ Distributed C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.8\Distributed\src\remotecall.jl:514
 [4] put!(rr::Distributed.Future, v::MemPool.DRef)
   @ Distributed C:\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.8\Distributed\src\remotecall.jl:584
 [5] eager_thunk()
   @ Dagger.Sch c:\Users\krynjupc\.julia\dev\Dagger\src\sch\eager.jl:84
 [6] macro expansion
   @ c:\Users\krynjupc\.julia\dev\Dagger\src\processor.jl:154 [inlined]
 [7] (::Dagger.var"#53#54"{typeof(Dagger.Sch.eager_thunk), Tuple{}, NamedTuple{(:sch_uid, :sch_handle, :processor, :utilization), Tuple{UInt64, Dagger.Sch.SchedulerHandle, Dagger.ThreadProc, UInt64}}})()
   @ Dagger .\threadingconstructs.jl:178

```

@jpsamaroo 