### PR TITLE
Change Profile buffer into a ring buffer

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -55,12 +55,12 @@ extern "C" void jl_init_debuginfo(void)
     uv_rwlock_init(&threadsafe);
 }
 
-extern "C" void jl_lock_profile(void)
+extern "C" JL_DLLEXPORT void jl_profile_lock(void)
 {
     uv_rwlock_rdlock(&threadsafe);
 }
 
-extern "C" void jl_unlock_profile(void)
+extern "C" JL_DLLEXPORT void jl_profile_unlock(void)
 {
     uv_rwlock_rdunlock(&threadsafe);
 }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -409,9 +409,11 @@
     XX(jl_profile_init) \
     XX(jl_profile_is_running) \
     XX(jl_profile_len_data) \
+    XX(jl_profile_lock) \
     XX(jl_profile_maxlen_data) \
     XX(jl_profile_start_timer) \
     XX(jl_profile_stop_timer) \
+    XX(jl_profile_unlock) \
     XX(jl_ptrarrayref) \
     XX(jl_ptr_to_array) \
     XX(jl_ptr_to_array_1d) \

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -31,15 +31,9 @@ static volatile uint64_t *profile_round_robin_thread_order = NULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
-void jl_lock_profile(void);
-void jl_unlock_profile(void);
+JL_DLLEXPORT void jl_profile_lock(void);
+JL_DLLEXPORT void jl_profile_unlock(void);
 void jl_shuffle_int_array_inplace(volatile uint64_t *carray, size_t size, uint64_t *seed);
-
-JL_DLLEXPORT int jl_profile_is_buffer_full(void)
-{
-    // the `+ 6` is for the two block terminators `0` plus 4 metadata entries
-    return bt_size_cur + (JL_BT_MAX_ENTRY_SIZE + 1) + 6 > bt_size_max;
-}
 
 static uint64_t jl_last_sigint_trigger = 0;
 static uint64_t jl_disable_sigint_time = 0;
@@ -343,6 +337,7 @@ JL_DLLEXPORT uint64_t jl_profile_delay_nsec(void)
 
 JL_DLLEXPORT void jl_profile_clear_data(void)
 {
+    memset(bt_data_prof, 0, bt_size_max);
     bt_size_cur = 0;
 }
 

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -776,8 +776,8 @@ static void *signal_listener(void *arg)
                     jl_safe_printf("WARNING: profiler attempt to access an invalid memory location\n");
                 } else {
                     // Get backtrace data
-                    bt_size_cur += rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
-                            bt_size_max - bt_size_cur - 1, signal_context, NULL);
+                    bt_size_cur = (bt_size_cur + rec_backtrace_ctx((jl_bt_element_t*)bt_data_prof + bt_size_cur,
+                            bt_size_max - bt_size_cur - 1, signal_context, NULL)) % bt_size_max;
                 }
                 jl_set_safe_restore(old_buf);
 


### PR DESCRIPTION
Users of Profile may be interested in running the profiler continuously and without stopping. In the case of Dagger, it's possible that multiple tasks may all want the profiler running during their execution, so we only stop the profiler if Dagger isn't running any tasks. It's thus possible that we want the profiler running for longer than it would take to fill up the profile buffer. In the old implementation, the buffer would fill up, profiling would stop, and new traces would be lost. Additionally, sampling from the profiler with `Profile.fetch` while the profiler is running would often produce partially-written frames, requiring such continuously-profiling users to clean up such frames manually.

The new implementation treats the profile buffer as a ring buffer instead. `Profile.fetch` will now start at the `len_data()` pointer offset, read until the end of the buffer, and then read the rest from the beginning to just before `len_data()`. Any zero frames at the beginning of the copied buffer are truncated, so we end up with the result we would expect without a ring buffer.

Additionally, `Profile.fetch` now takes the same locks as the profiler while copying out data from the buffer, so sampling while profiling is running should now work correctly, without broken frames.

Marking this as a draft since I still need to test this locally with Dagger.