### PR TITLE
Add/improve some compat admonitions for 1.7

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -142,7 +142,7 @@ arbitrary task. This is useful for inspecting tasks which have failed due to
 uncaught exceptions.
 
 !!! compat "Julia 1.7"
-    This function went by the experiemental name `catch_stack()` in Julia
+    This function went by the experimental name `catch_stack()` in Julia
     1.1–1.6, and had a plain Vector-of-tuples as a return type.
 """
 function current_exceptions(task::Task=current_task(); backtrace::Bool=true)

--- a/base/int.jl
+++ b/base/int.jl
@@ -97,6 +97,9 @@ inv(x::Integer) = float(one(x)) / float(x)
 
 Return `true` if `x` is an odd integer (that is, an integer not divisible by 2), and `false` otherwise.
 
+!!! compat "Julia 1.7"
+    Non-`Integer` arguments require Julia 1.7 or later.
+
 # Examples
 ```jldoctest
 julia> isodd(9)
@@ -113,6 +116,9 @@ isodd(n::Real) = isinteger(n) && !iszero(rem(Integer(n), 2))
     iseven(x::Number) -> Bool
 
 Return `true` if `x` is an even integer (that is, an integer divisible by 2), and `false` otherwise.
+
+!!! compat "Julia 1.7"
+    Non-`Integer` arguments require Julia 1.7 or later.
 
 # Examples
 ```jldoctest

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -180,6 +180,9 @@ available.
 
 When this function returns, the `lock` has been released, so the caller should
 not attempt to `unlock` it.
+
+!!! compat "Julia 1.7"
+    Using a [`Channel`](@ref) as the second argument requires Julia 1.7 or later.
 """
 function lock(f, l::AbstractLock)
     lock(l)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -995,7 +995,7 @@ julia> f.value
 ```
 
 !!! compat "Julia 1.7"
-    Returns requires at least Julia 1.7.
+    `Returns` requires at least Julia 1.7.
 """
 struct Returns{V} <: Function
     value::V

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1683,6 +1683,9 @@ Provides a convenient way to call [`invoke`](@ref);
 `@invoke f(arg1::T1, arg2::T2; kwargs...)` will be expanded into `invoke(f, Tuple{T1,T2}, arg1, arg2; kwargs...)`.
 When an argument's type annotation is omitted, it's specified as `Any` argument, e.g.
 `@invoke f(arg1::T, arg2)` will be expanded into `invoke(f, Tuple{T,Any}, arg1, arg2)`.
+
+!!! compat "Julia 1.7"
+    This macro requires Julia 1.7 or later.
 """
 macro invoke(ex)
     f, args, kwargs = destructure_callex(ex)
@@ -1699,6 +1702,9 @@ end
 Provides a convenient way to call [`Base.invokelatest`](@ref).
 `@invokelatest f(args...; kwargs...)` will simply be expanded into
 `Base.invokelatest(f, args...; kwargs...)`.
+
+!!! compat "Julia 1.7"
+    This macro requires Julia 1.7 or later.
 """
 macro invokelatest(ex)
     f, args, kwargs = destructure_callex(ex)

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1268,7 +1268,11 @@ for (fd, f, fn) in ((:sind, :sin, "sine"), (:cosd, :cos, "cosine"), (:tand, :tan
                 $($name)(x)
 
             Compute $($fn) of `x`, where `x` is in $($un).
-            If `x` is a matrix, `x` needs to be a square matrix. """ ($fd)(x) = ($f)(($fu).(x))
+            If `x` is a matrix, `x` needs to be a square matrix.
+
+            !!! compat "Julia 1.7"
+                Matrix arguments require Julia 1.7 or later.
+            """ ($fd)(x) = ($f)(($fu).(x))
         end
     end
 end
@@ -1283,7 +1287,11 @@ for (fd, f, fn) in ((:asind, :asin, "sine"), (:acosd, :acos, "cosine"),
                 $($name)(x)
 
             Compute the inverse $($fn) of `x`, where the output is in $($un).
-            If `x` is a matrix, `x` needs to be a square matrix. """ ($fd)(x) = ($fu).(($f)(x))
+            If `x` is a matrix, `x` needs to be a square matrix.
+
+            !!! compat "Julia 1.7"
+                Matrix arguments require Julia 1.7 or later.
+            """ ($fd)(x) = ($fu).(($f)(x))
         end
     end
 end
@@ -1293,6 +1301,9 @@ end
     atand(y,x)
 
 Compute the inverse tangent of `y` or `y/x`, respectively, where the output is in degrees.
+
+!!! compat "Julia 1.7"
+    The one-argument method supports square matrix arguments as of Julia 1.7.
 """
 atand(y)    = rad2deg.(atan(y))
 atand(y, x) = rad2deg.(atan(y,x))

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -690,9 +690,9 @@ The length of `itr` must be even, and the returned array has half of the length 
 See also [`hex2bytes!`](@ref) for an in-place version, and [`bytes2hex`](@ref) for the inverse.
 
 !!! compat "Julia 1.7"
-    Calling hex2bytes with iterables producing UInt8 requires
-    version 1.7. In earlier versions, you can collect the iterable
-    before calling instead.
+    Calling `hex2bytes` with iterators producing `UInt8` values requires
+    Julia 1.7 or later. In earlier versions, you can `collect` the iterator
+    before calling `hex2bytes`.
 
 # Examples
 ```jldoctest
@@ -777,9 +777,9 @@ returning a `String` via `bytes2hex(itr)` or writing the string to an `io` strea
 via `bytes2hex(io, itr)`.  The hexadecimal characters are all lowercase.
 
 !!! compat "Julia 1.7"
-    Calling bytes2hex with iterators producing UInt8 requires
-    version 1.7. In earlier versions, you can collect the iterable
-    before calling instead.
+    Calling `bytes2hex` with arbitrary iterators producing `UInt8` values requires
+    Julia 1.7 or later. In earlier versions, you can `collect` the iterator
+    before calling `bytes2hex`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
I went through the 1.7 release notes and added some compat notes to relevant docstrings. In some cases, I also improved (at least I hope so) the existing ones.