### PR TITLE
Preserve pretty-printing of structured matrices in wrappers

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1501,7 +1501,12 @@ get(A::AbstractArray, I::RangeVecIntList, default) =
     get!(similar(A, typeof(default), index_shape(I...)), A, I, default)
 
 ## structured matrix methods ##
-isnonzeroindex(A::AbstractArray, inds...) = true
+isnonzeroindex(A::AbstractArray{<:Any, N}, inds::Vararg{Integer, N}) where {N} = true
+function isnonzeroindex(A::AbstractArray, inds...)
+    indsint = Tuple(CartesianIndices(A)[inds...])
+    isnonzeroindex(A, indsint...)
+end
+
 replace_in_print_matrix(A::AbstractMatrix,i::Integer,j::Integer,s::AbstractString) = s
 replace_in_print_matrix(A::AbstractVector,i::Integer,j::Integer,s::AbstractString) = s
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1503,7 +1503,8 @@ get(A::AbstractArray, I::RangeVecIntList, default) =
 ## structured matrix methods ##
 isnonzeroindex(A::AbstractArray{<:Any, N}, inds::Vararg{Integer, N}) where {N} = true
 function isnonzeroindex(A::AbstractArray, inds...)
-    indsint = Tuple(CartesianIndices(A)[inds...])
+    Ainds = to_indices(A, inds)
+    indsint = Tuple(CartesianIndices(A)[Ainds...])
     isnonzeroindex(A, indsint...)
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1501,7 +1501,7 @@ get(A::AbstractArray, I::RangeVecIntList, default) =
     get!(similar(A, typeof(default), index_shape(I...)), A, I, default)
 
 ## structured matrix methods ##
-nonzeroindex(A::AbstractArray, inds...) = true
+isnonzeroindex(A::AbstractArray, inds...) = true
 replace_in_print_matrix(A::AbstractMatrix,i::Integer,j::Integer,s::AbstractString) = s
 replace_in_print_matrix(A::AbstractVector,i::Integer,j::Integer,s::AbstractString) = s
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1501,6 +1501,7 @@ get(A::AbstractArray, I::RangeVecIntList, default) =
     get!(similar(A, typeof(default), index_shape(I...)), A, I, default)
 
 ## structured matrix methods ##
+nonzeroindex(A::AbstractArray, inds...) = true
 replace_in_print_matrix(A::AbstractMatrix,i::Integer,j::Integer,s::AbstractString) = s
 replace_in_print_matrix(A::AbstractVector,i::Integer,j::Integer,s::AbstractString) = s
 

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -14,7 +14,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     getproperty, imag, inv, isapprox, isequal, isone, iszero, IndexStyle, kron, kron!, length, log, map, ndims,
     one, oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, sqrt,
-    strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec, zero
+    strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec, zero, nonzeroindex
 using Base: IndexLinear, promote_eltype, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_hvcat, typed_vcat, require_one_based_indexing,
     splat
@@ -405,6 +405,12 @@ copy_to_array(A::AbstractArray, ::Type{T}) where {T} = copyto!(Array{T}(undef, s
 # more efficient to use:
 # convert(AbstractArray{T}, A)
 
+# Common function used in displaying structured matrices.
+# Typically this is called within replace_in_print_matrix,
+# which is specialized for each matrix type
+function _replace_in_print_matrix(A, i, j, s)
+    return nonzeroindex(A, i, j) ? s : Base.replace_with_centered_mark(s)
+end
 
 include("adjtrans.jl")
 include("transpose.jl")

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -409,7 +409,7 @@ copy_to_array(A::AbstractArray, ::Type{T}) where {T} = copyto!(Array{T}(undef, s
 # Typically this is called within replace_in_print_matrix,
 # which is specialized for each matrix type
 function _replace_in_print_matrix(A, i, j, s)
-    return nonzeroindex(A, i, j) ? s : Base.replace_with_centered_mark(s)
+    return isnonzeroindex(A, i, j) ? s : Base.replace_with_centered_mark(s)
 end
 
 include("adjtrans.jl")

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -14,7 +14,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     getproperty, imag, inv, isapprox, isequal, isone, iszero, IndexStyle, kron, kron!, length, log, map, ndims,
     one, oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, sqrt,
-    strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec, zero, nonzeroindex
+    strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec, zero, isnonzeroindex
 using Base: IndexLinear, promote_eltype, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_hvcat, typed_vcat, require_one_based_indexing,
     splat

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -330,8 +330,8 @@ conj(A::Transpose) = adjoint(A.parent)
 conj(A::Adjoint) = transpose(A.parent)
 
 # Structured matrix display
-isnonzeroindex(A::AdjOrTransAbsMat, i, j) = isnonzeroindex(parent(A), j, i)
-isnonzeroindex(A::AdjOrTransAbsVec, i, j) = isnonzeroindex(parent(A), j)
+isnonzeroindex(A::AdjOrTransAbsMat, i::Integer, j::Integer) = isnonzeroindex(parent(A), j, i)
+isnonzeroindex(A::AdjOrTransAbsVec, i::Integer, j::Integer) = isnonzeroindex(parent(A), j)
 function Base.replace_in_print_matrix(A::AdjOrTrans,
         i::Integer, j::Integer, s::AbstractString)
     return Base.replace_in_print_matrix(A.parent, j, i, s)

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -330,9 +330,9 @@ conj(A::Transpose) = adjoint(A.parent)
 conj(A::Adjoint) = transpose(A.parent)
 
 # Structured matrix display
-nonzeroindex(A::AdjOrTransAbsMat, i, j) = nonzeroindex(parent(A), j, i)
-nonzeroindex(A::AdjOrTransAbsVec, i, j) = nonzeroindex(parent(A), j)
+isnonzeroindex(A::AdjOrTransAbsMat, i, j) = isnonzeroindex(parent(A), j, i)
+isnonzeroindex(A::AdjOrTransAbsVec, i, j) = isnonzeroindex(parent(A), j)
 function Base.replace_in_print_matrix(A::AdjOrTrans,
         i::Integer, j::Integer, s::AbstractString)
-    return _replace_in_print_matrix(A, i, j, s)
+    return Base.replace_in_print_matrix(A.parent, j, i, s)
 end

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -328,3 +328,11 @@ pinv(v::TransposeAbsVec, tol::Real = 0) = pinv(conj(v.parent)).parent
 ## complex conjugate
 conj(A::Transpose) = adjoint(A.parent)
 conj(A::Adjoint) = transpose(A.parent)
+
+# Structured matrix display
+nonzeroindex(A::AdjOrTransAbsMat, i, j) = nonzeroindex(parent(A), j, i)
+nonzeroindex(A::AdjOrTransAbsVec, i, j) = nonzeroindex(parent(A), j)
+function Base.replace_in_print_matrix(A::AdjOrTrans,
+        i::Integer, j::Integer, s::AbstractString)
+    return _replace_in_print_matrix(A, i, j, s)
+end

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -146,12 +146,9 @@ function setindex!(A::Bidiagonal, x, i::Integer, j::Integer)
 end
 
 ## structured matrix methods ##
+nonzeroindex(A::Bidiagonal, i, j) = (i == j) || (A.uplo == 'U' ? (i == j-1) : (i == j+1))
 function Base.replace_in_print_matrix(A::Bidiagonal,i::Integer,j::Integer,s::AbstractString)
-    if A.uplo == 'U'
-        i==j || i==j-1 ? s : Base.replace_with_centered_mark(s)
-    else
-        i==j || i==j+1 ? s : Base.replace_with_centered_mark(s)
-    end
+    return _replace_in_print_matrix(A, i, j, s)
 end
 
 #Converting from Bidiagonal to dense Matrix

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -146,7 +146,7 @@ function setindex!(A::Bidiagonal, x, i::Integer, j::Integer)
 end
 
 ## structured matrix methods ##
-isnonzeroindex(A::Bidiagonal, i, j) = (i == j) || (A.uplo == 'U' ? (i == j-1) : (i == j+1))
+isnonzeroindex(A::Bidiagonal, i::Integer, j::Integer) = (i == j) || (A.uplo == 'U' ? (i == j-1) : (i == j+1))
 function Base.replace_in_print_matrix(A::Bidiagonal,i::Integer,j::Integer,s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -146,7 +146,7 @@ function setindex!(A::Bidiagonal, x, i::Integer, j::Integer)
 end
 
 ## structured matrix methods ##
-nonzeroindex(A::Bidiagonal, i, j) = (i == j) || (A.uplo == 'U' ? (i == j-1) : (i == j+1))
+isnonzeroindex(A::Bidiagonal, i, j) = (i == j) || (A.uplo == 'U' ? (i == j-1) : (i == j+1))
 function Base.replace_in_print_matrix(A::Bidiagonal,i::Integer,j::Integer,s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -121,8 +121,9 @@ end
 
 
 ## structured matrix methods ##
+nonzeroindex(::Diagonal, i, j) = i == j
 function Base.replace_in_print_matrix(A::Diagonal,i::Integer,j::Integer,s::AbstractString)
-    i==j ? s : Base.replace_with_centered_mark(s)
+    return _replace_in_print_matrix(A, i, j, s)
 end
 
 parent(D::Diagonal) = D.diag

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -121,7 +121,7 @@ end
 
 
 ## structured matrix methods ##
-nonzeroindex(::Diagonal, i, j) = i == j
+isnonzeroindex(::Diagonal, i, j) = i == j
 function Base.replace_in_print_matrix(A::Diagonal,i::Integer,j::Integer,s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -121,7 +121,7 @@ end
 
 
 ## structured matrix methods ##
-isnonzeroindex(::Diagonal, i, j) = i == j
+isnonzeroindex(::Diagonal, i::Integer, j::Integer) = i == j
 function Base.replace_in_print_matrix(A::Diagonal,i::Integer,j::Integer,s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -85,7 +85,7 @@ function setindex!(A::UpperHessenberg, x, i::Integer, j::Integer)
     return A
 end
 
-nonzeroindex(::UpperHessenberg, i, j) = i <= j+1
+isnonzeroindex(::UpperHessenberg, i, j) = i <= j+1
 function Base.replace_in_print_matrix(A::UpperHessenberg, i::Integer, j::Integer, s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -85,8 +85,9 @@ function setindex!(A::UpperHessenberg, x, i::Integer, j::Integer)
     return A
 end
 
+nonzeroindex(::UpperHessenberg, i, j) = i <= j+1
 function Base.replace_in_print_matrix(A::UpperHessenberg, i::Integer, j::Integer, s::AbstractString)
-    return i <= j+1 ? s : Base.replace_with_centered_mark(s)
+    return _replace_in_print_matrix(A, i, j, s)
 end
 
 Base.copy(A::Adjoint{<:Any,<:UpperHessenberg}) = tril!(adjoint!(similar(A.parent.data), A.parent.data), 1)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -85,7 +85,7 @@ function setindex!(A::UpperHessenberg, x, i::Integer, j::Integer)
     return A
 end
 
-isnonzeroindex(::UpperHessenberg, i, j) = i <= j+1
+isnonzeroindex(::UpperHessenberg, i::Integer, j::Integer) = i <= j+1
 function Base.replace_in_print_matrix(A::UpperHessenberg, i::Integer, j::Integer, s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -276,13 +276,11 @@ end
 
 
 ## structured matrix methods ##
-function Base.replace_in_print_matrix(A::Union{UpperTriangular,UnitUpperTriangular},
+nonzeroindex(::Union{UpperTriangular,UnitUpperTriangular}, i, j) = i <= j
+nonzeroindex(::Union{LowerTriangular,UnitLowerTriangular}, i, j) = i >= j
+function Base.replace_in_print_matrix(A::AbstractTriangular,
                                       i::Integer, j::Integer, s::AbstractString)
-    return i <= j ? s : Base.replace_with_centered_mark(s)
-end
-function Base.replace_in_print_matrix(A::Union{LowerTriangular,UnitLowerTriangular},
-                                      i::Integer, j::Integer, s::AbstractString)
-    return i >= j ? s : Base.replace_with_centered_mark(s)
+    return _replace_in_print_matrix(A, i, j, s)
 end
 
 function istril(A::Union{LowerTriangular,UnitLowerTriangular}, k::Integer=0)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -276,8 +276,8 @@ end
 
 
 ## structured matrix methods ##
-isnonzeroindex(::Union{UpperTriangular,UnitUpperTriangular}, i, j) = i <= j
-isnonzeroindex(::Union{LowerTriangular,UnitLowerTriangular}, i, j) = i >= j
+isnonzeroindex(::Union{UpperTriangular,UnitUpperTriangular}, i::Integer, j::Integer) = i <= j
+isnonzeroindex(::Union{LowerTriangular,UnitLowerTriangular}, i::Integer, j::Integer) = i >= j
 function Base.replace_in_print_matrix(A::AbstractTriangular,
                                       i::Integer, j::Integer, s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -276,8 +276,8 @@ end
 
 
 ## structured matrix methods ##
-nonzeroindex(::Union{UpperTriangular,UnitUpperTriangular}, i, j) = i <= j
-nonzeroindex(::Union{LowerTriangular,UnitLowerTriangular}, i, j) = i >= j
+isnonzeroindex(::Union{UpperTriangular,UnitUpperTriangular}, i, j) = i <= j
+isnonzeroindex(::Union{LowerTriangular,UnitLowerTriangular}, i, j) = i >= j
 function Base.replace_in_print_matrix(A::AbstractTriangular,
                                       i::Integer, j::Integer, s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -667,7 +667,7 @@ function setindex!(A::Tridiagonal, x, i::Integer, j::Integer)
 end
 
 ## structured matrix methods ##
-isnonzeroindex(::Union{SymTridiagonal, Tridiagonal}, i, j) = i==j-1||i==j||i==j+1
+isnonzeroindex(::Union{SymTridiagonal, Tridiagonal}, i::Integer, j::Integer) = i==j-1||i==j||i==j+1
 function Base.replace_in_print_matrix(A::Tridiagonal,i::Integer,j::Integer,s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -667,7 +667,7 @@ function setindex!(A::Tridiagonal, x, i::Integer, j::Integer)
 end
 
 ## structured matrix methods ##
-nonzeroindex(::Union{SymTridiagonal, Tridiagonal}, i, j) = i==j-1||i==j||i==j+1
+isnonzeroindex(::Union{SymTridiagonal, Tridiagonal}, i, j) = i==j-1||i==j||i==j+1
 function Base.replace_in_print_matrix(A::Tridiagonal,i::Integer,j::Integer,s::AbstractString)
     return _replace_in_print_matrix(A, i, j, s)
 end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -420,7 +420,7 @@ end
 
 ## structured matrix methods ##
 function Base.replace_in_print_matrix(A::SymTridiagonal, i::Integer, j::Integer, s::AbstractString)
-    i==j-1||i==j||i==j+1 ? s : Base.replace_with_centered_mark(s)
+    return _replace_in_print_matrix(A, i, j, s)
 end
 
 # Implements the determinant using principal minors
@@ -667,8 +667,9 @@ function setindex!(A::Tridiagonal, x, i::Integer, j::Integer)
 end
 
 ## structured matrix methods ##
+nonzeroindex(::Union{SymTridiagonal, Tridiagonal}, i, j) = i==j-1||i==j||i==j+1
 function Base.replace_in_print_matrix(A::Tridiagonal,i::Integer,j::Integer,s::AbstractString)
-    i==j-1||i==j||i==j+1 ? s : Base.replace_with_centered_mark(s)
+    return _replace_in_print_matrix(A, i, j, s)
 end
 
 

--- a/stdlib/LinearAlgebra/test/structureddisplay.jl
+++ b/stdlib/LinearAlgebra/test/structureddisplay.jl
@@ -15,7 +15,7 @@ end
 Base.getindex(M::MyArrayWrapper, i::Int...) = parent(M)[i...]
 Base.replace_in_print_matrix(M::MyArrayWrapper, i::Integer, j::Integer, s::AbstractString) =
     Base.replace_in_print_matrix(parent(M), i, j, s)
-Base.nonzeroindex(M::MyArrayWrapper{<:Any,N}, i::Vararg{Int,N}) where {N} = Base.nonzeroindex(parent(M), i...)
+Base.isnonzeroindex(M::MyArrayWrapper{<:Any,N}, i::Vararg{Int,N}) where {N} = Base.isnonzeroindex(parent(M), i...)
 
 function print_array_str(io::IO, a)
     Base.print_array(io, a)
@@ -48,7 +48,7 @@ end
 function Base.replace_in_print_matrix(::Zeros, ::Integer, ::Integer, s::AbstractString)
     Base.replace_with_centered_mark(s)
 end
-Base.nonzeroindex(z::Zeros{<:Any,N}, i::Vararg{Int,N}) where {N} = false
+Base.isnonzeroindex(z::Zeros{<:Any,N}, i::Vararg{Int,N}) where {N} = false
 
 @testset "Display of structured matrices" begin
     @testset "Diagonal" begin

--- a/stdlib/LinearAlgebra/test/structureddisplay.jl
+++ b/stdlib/LinearAlgebra/test/structureddisplay.jl
@@ -1,0 +1,92 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module TestStructuredDisplay
+
+using Test
+using LinearAlgebra
+
+struct MyArrayWrapper{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
+    a :: A
+end
+Base.parent(M::MyArrayWrapper) = M.a
+for f in [:size, :length, :axes]
+    @eval Base.$f(M::MyArrayWrapper) = $f(parent(M))
+end
+Base.getindex(M::MyArrayWrapper, i::Int...) = parent(M)[i...]
+Base.replace_in_print_matrix(M::MyArrayWrapper, i::Integer, j::Integer, s::AbstractString) =
+    Base.replace_in_print_matrix(parent(M), i, j, s)
+Base.nonzeroindex(M::MyArrayWrapper{<:Any,N}, i::Vararg{Int,N}) where {N} = Base.nonzeroindex(parent(M), i...)
+
+function print_array_str(io::IO, a)
+    Base.print_array(io, a)
+    String(take!(io))
+end
+function test_print_array(A)
+    io = IOBuffer()
+    for B in Any[A, adjoint(A), transpose(A)]
+        M = MyArrayWrapper(B)
+        for f in [identity, adjoint, transpose]
+            s1 = print_array_str(io, f(B))
+            s2 = print_array_str(io, f(M))
+            @test s1 == s2
+        end
+    end
+end
+
+struct Zeros{T,N} <: AbstractArray{T,N}
+    s :: NTuple{N,Int}
+end
+Zeros(n::Vararg{Int,N}) where {N} = Zeros(Float64, n)
+Zeros(n::NTuple{N,Int}) where {N} = Zeros(Float64, n)
+Zeros(::Type{T}, n::Vararg{Int,N}) where {T,N} = Zeros{T,N}(n)
+Zeros(::Type{T}, n::NTuple{N,Int}) where {T,N} = Zeros{T,N}(n)
+Base.size(z::Zeros) = z.s
+function Base.getindex(z::Zeros{T,N}, i::Vararg{Int,N}) where {T,N}
+    @boundscheck checkbounds(z, i...)
+    zero(T)
+end
+function Base.replace_in_print_matrix(::Zeros, ::Integer, ::Integer, s::AbstractString)
+    Base.replace_with_centered_mark(s)
+end
+Base.nonzeroindex(z::Zeros{<:Any,N}, i::Vararg{Int,N}) where {N} = false
+
+@testset "Display of structured matrices" begin
+    @testset "Diagonal" begin
+        for r in Any[3:2, 3:3, 3:6, LinRange(0, 1, 7), LinRange(0, 1, 7)*im]
+            test_print_array(Diagonal(r))
+        end
+    end
+    @testset "BiDiagonal" begin
+        for r in Any[1:4, LinRange(0, 1, 7), LinRange(0, 1, 7)*im], uplo in [:U, :L]
+            test_print_array(Bidiagonal(r, r[2:end], uplo))
+        end
+    end
+    @testset "TriDiagonal" begin
+        test_print_array(Tridiagonal(1:3, 1:4, 1:3))
+        @testset "SymTridiagonal" begin
+            test_print_array(SymTridiagonal(1:4, 1:3))
+        end
+    end
+    @testset "Triangular" begin
+        for A in Any[reshape(1:1, 1, 1), reshape(1:16, 4, 4), reshape(LinRange(0, 3, 16), 4, 4)]
+            @testset "UpperTriangular" begin
+                test_print_array(UpperTriangular(A))
+            end
+            @testset "LowerTriangular" begin
+                test_print_array(LowerTriangular(A))
+            end
+        end
+    end
+    @testset "Hessenberg" begin
+        for A in Any[reshape(1:1, 1, 1), reshape(1:16, 4, 4), reshape(LinRange(0, 3, 16), 4, 4)]
+            test_print_array(UpperHessenberg(A))
+        end
+    end
+    @testset "Zeros" begin
+        for T in [Int, Float64], s in Any[(2,), (2,2)]
+            test_print_array(Zeros(T, s))
+        end
+    end
+end
+
+end

--- a/stdlib/LinearAlgebra/test/structureddisplay.jl
+++ b/stdlib/LinearAlgebra/test/structureddisplay.jl
@@ -53,7 +53,20 @@ Base.isnonzeroindex(z::Zeros{<:Any,N}, i::Vararg{Int,N}) where {N} = false
 @testset "Display of structured matrices" begin
     @testset "Diagonal" begin
         for r in Any[3:2, 3:3, 3:6, LinRange(0, 1, 7), LinRange(0, 1, 7)*im]
-            test_print_array(Diagonal(r))
+            D = Diagonal(r)
+            test_print_array(D)
+            if length(D) > 0
+                for i in Any[(1,), (1,1), (1,1,1)]
+                    @test Base.isnonzeroindex(D, i...)
+                    @test Base.isnonzeroindex(D, CartesianIndex(i...))
+                end
+            end
+            if length(D) > 1
+                for i in Any[(2,), (2,1), (2,1,1)]
+                    @test !Base.isnonzeroindex(D, i...)
+                    @test !Base.isnonzeroindex(D, CartesianIndex(i...))
+                end
+            end
         end
     end
     @testset "BiDiagonal" begin
@@ -84,7 +97,20 @@ Base.isnonzeroindex(z::Zeros{<:Any,N}, i::Vararg{Int,N}) where {N} = false
     end
     @testset "Zeros" begin
         for T in [Int, Float64], s in Any[(2,), (2,2)]
-            test_print_array(Zeros(T, s))
+            z = Zeros(T, s)
+            test_print_array(z)
+            if length(z) > 0
+                for i in Any[(1,), (1,1), (1,1,1)]
+                    @test !Base.isnonzeroindex(z, i...)
+                    @test !Base.isnonzeroindex(z, CartesianIndex(i...))
+                end
+            end
+            if length(z) > 1
+                for i in Any[(2,), (2,1), (2,1,1)]
+                    @test !Base.isnonzeroindex(z, i...)
+                    @test !Base.isnonzeroindex(z, CartesianIndex(i...))
+                end
+            end
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/testgroups
+++ b/stdlib/LinearAlgebra/test/testgroups
@@ -26,3 +26,4 @@ structuredbroadcast
 addmul
 ldlt
 factorization
+structureddisplay


### PR DESCRIPTION
Currently various structured matrices defined in `LinearAlgebra`, when displayed, replace the structurally known zero elements by dots, eg.

```julia
julia> Diagonal(1:3)
3×3 Diagonal{Int64, UnitRange{Int64}}:
 1  ⋅  ⋅
 ⋅  2  ⋅
 ⋅  ⋅  3
```

This pretty-printing behavior, however, is not preserved in types that wrap these matrices, so, for example, if we define a wrapper type `MyArrayWrapper` with the basic `size` and indexing-related functions defined, we obtain

```julia
julia> struct MyArrayWrapper{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
           a :: A
       end

julia> Base.parent(M::MyArrayWrapper) = M.a

julia> for f in [:size, :length, :axes]
           @eval Base.$f(M::MyArrayWrapper) = $f(parent(M))
       end

julia> Base.getindex(M::MyArrayWrapper, i::Int...) = parent(M)[i...]

julia> MyArrayWrapper(Diagonal(3:4))
2×2 MyArrayWrapper{Int64, 2, Diagonal{Int64, UnitRange{Int64}}}:
 3  0
 0  4
```

It's possible to extend the pretty-printing behavior to `MyArrayWrapper` by defining `Base.replace_in_print_matrix` for it, so 

```julia
julia> Base.replace_in_print_matrix(M::MyArrayWrapper, i::Integer, j::Integer, s::AbstractString) = Base.replace_in_print_matrix(parent(M), i, j, s)

julia> MyArrayWrapper(Diagonal(3:4))
2×2 MyArrayWrapper{Int64, 2, Diagonal{Int64, UnitRange{Int64}}}:
 3  ⋅
 ⋅  4
```

So far so good. What happens if we transpose this matrix?

```julia
julia> MyArrayWrapper(Diagonal(3:4))'
2×2 adjoint(::MyArrayWrapper{Int64, 2, Diagonal{Int64, UnitRange{Int64}}}) with eltype Int64:
 3  0
 0  4
```

Oops. In general this pretty-printing is not preserved across layers. That's because each type currently defines  `replace_in_print_matrix` for themselves making use of their own structure information, which is lost downstream in general. This PR aims to change this by adding a function `isnonzeroindex` to `Base`, which, given the type of the array and the indices, returns if the value at that index is known to be non-zero based on the structure of the array. Wrapper types may now use this for their parent arrays to determine what to display. This is more powerful than simply passing on the indices to the parent in `replace_in_print_matrix`, as such a direct translation might not always be possible for types that wrap multiple structured arrays (eg. a kronecker product). Having access to the zero elements of the parents, however, makes it easy to evaluate if the index of the wrapper is also known to be zero based on the structures of the parents.

After this PR, we not only obtain

```julia
julia> MyArrayWrapper(Diagonal(3:4))'
2×2 adjoint(::MyArrayWrapper{Int64, 2, Diagonal{Int64, UnitRange{Int64}}}) with eltype Int64:
 3  ⋅
 ⋅  4
```

by forwarding the replacement to the parent of the adjoint wrapper, we also obtain the non-trivial kronecker product display by patching eg. [Kronecker.jl](https://github.com/MichielStock/Kronecker.jl):

```julia
julia> function Base.replace_in_print_matrix(K::Kronecker.AbstractKroneckerProduct, i1::Integer, i2::Integer, s::AbstractString)
           A, B = getmatrices(K)
           k, l = size(B)
           Ainds = (cld(i1, k), cld(i2, l))
           Binds = ((i1 - 1) % k + 1, (i2 - 1) % l + 1)
           nz = Base.isnonzeroindex(A, Ainds...) && Base.isnonzeroindex(B, Binds...)
           nz ? s : Base.replace_with_centered_mark(s)
       end

julia> D
3×3 Diagonal{Int64, UnitRange{Int64}}:
 1  ⋅  ⋅
 ⋅  2  ⋅
 ⋅  ⋅  3

julia> K = kronecker(D, D)
9×9 Kronecker.KroneckerProduct{Int64, Diagonal{Int64, UnitRange{Int64}}, Diagonal{Int64, UnitRange{Int64}}}:
 1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  3  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  2  ⋅  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  4  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  6  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  3  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  6  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  9
```

Now the information about the non-zero elements is pushed up through the layers of wrappers.

I've added an extra file in the tests as otherwise I would have had to duplicate the tests across various sub-modules.

~~I'm not sure if the name `nonzeroindex` is the best choice, or if `isnonzeroindex` would be better to clarify that the function should return a `Bool`.~~ I've renamed the function to  `isnonzeroindex` to avoid confusions with `nonzeroinds` from `SparseArrays`.  