### PR TITLE
`Base.julia_cmd()`: correctly forward the `--sysimage-native-code=no` flag if it is provided

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -208,6 +208,9 @@ function julia_cmd(julia=joinpath(Sys.BINDIR::String, julia_exename()))
     if opts.startupfile == 2
         push!(addflags, "--startup-file=no")
     end
+    if opts.use_sysimage_native_code == 0
+        push!(addflags, "--sysimage-native-code=no")
+    end
     return `$julia -C$cpu_target -J$image_file $addflags`
 end
 


### PR DESCRIPTION
Closes #42173
Ref https://github.com/JuliaLang/julia/pull/41238#issuecomment-915668418

This is a replacement for #42173.