### PR TITLE
improve the inferrability of `isequal(::Any, ::Any)`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -137,7 +137,7 @@ julia> isequal(missing, missing)
 true
 ```
 """
-isequal(x, y) = x == y
+isequal(x, y) = (x == y)::Bool # all `missing` cases are handled in missing.jl
 
 signequal(x, y) = signbit(x)::Bool == signbit(y)::Bool
 signless(x, y) = signbit(x)::Bool & !signbit(y)::Bool

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -81,6 +81,14 @@ import Base.<
 @test isequal(minmax(TO23094(2), TO23094(1))[1], TO23094(1))
 @test isequal(minmax(TO23094(2), TO23094(1))[2], TO23094(2))
 
+let m = Module()
+    @eval m begin
+        struct Foo end
+        foo(xs) = isequal(xs[1], Foo())
+    end
+    @test !(@inferred m.foo(Any[42]))
+end
+
 @test isless('a','b')
 
 @testset "isgreater" begin


### PR DESCRIPTION
Currently, the return type of `isequal(::Any, ::Any)` is inferred as
`Union{Bool,Missing}` because it takes the possibilities of e.g.
`==(::Any, ::Missing) -> Missing` into account.
But actually `isequal` already handles every `missing` case by dispatch:
<https://github.com/JuliaLang/julia/blob/2f00c5f6e2211ed1588976dbbe7b022148716d95/base/missing.jl#L80-L82>
, and thus we can improve the inferrability by type annotation.