### PR TITLE
Add full stops to documentation strings for int128_str/uint128_str macros

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -647,8 +647,8 @@ floor(::Type{T}, x::Integer) where {T<:Integer} = convert(T, x)
     @int128_str str
     @int128_str(str)
 
-`@int128_str` parses a string into a Int128
-Throws an `ArgumentError` if the string is not a valid integer
+`@int128_str` parses a string into a Int128.
+Throws an `ArgumentError` if the string is not a valid integer.
 """
 macro int128_str(s)
     return parse(Int128, s)
@@ -658,8 +658,8 @@ end
     @uint128_str str
     @uint128_str(str)
 
-`@uint128_str` parses a string into a UInt128
-Throws an `ArgumentError` if the string is not a valid integer
+`@uint128_str` parses a string into a UInt128.
+Throws an `ArgumentError` if the string is not a valid integer.
 """
 macro uint128_str(s)
     return parse(UInt128, s)


### PR DESCRIPTION
Was reading through the docs and thought these read a little bit awkwardly. Added the missing full stops to make it easier to read.

![Screen Shot 2021-09-10 at 3 03 03 pm](https://user-images.githubusercontent.com/5206120/132802264-e5b85016-7ba5-4606-8757-59960c99d551.png)
