### PR TITLE
Profile stdlib: add the ability to suppress the "Requested profile buffer limited..." warning by setting an environment variable

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -72,7 +72,10 @@ function init(n::Integer, delay::Real)
         buffer_samples_per_thread = floor(Int, buffer_size_bytes_per_thread / sample_size_bytes)
         buffer_samples = buffer_samples_per_thread * nthreads
         buffer_size_bytes = buffer_samples * sample_size_bytes
-        @warn "Requested profile buffer limited to 512MB (n = $buffer_samples_per_thread per thread) given that this system is 32-bit"
+        # To suppress this warning, do e.g. `export JULIA_SUPPRESS_PROFILE_WARNINGS=true` in bash
+        if tryparse(Bool, get(ENV, "JULIA_SUPPRESS_PROFILE_WARNINGS", "")) !== true
+            @warn "Requested profile buffer limited to 512MB (n = $buffer_samples_per_thread per thread) given that this system is 32-bit"
+        end
     end
     status = ccall(:jl_profile_init, Cint, (Csize_t, UInt64), buffer_samples, round(UInt64,10^9*delay))
     if status == -1


### PR DESCRIPTION
## Summary

This PR adds the ability to suppress the "Requested profile buffer limited..."  warning by doing e.g. `export JULIA_SUPPRESS_PROFILE_WARNINGS=true` in Bash.

## Motivation

1. The Buildkite logs are getting spammed by this warning.
2. On Buildkite, when running the Linux x86 (32-bit) tests, some of the tests are actually failing because they don't expect to see this warning in the log output.