### PR TITLE
`InteractiveUtils.versioninfo`: if this is a tagged commit, print the tagged release banner

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -92,6 +92,12 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     if !isempty(Base.GIT_VERSION_INFO.commit_short)
         println(io, "Commit $(Base.GIT_VERSION_INFO.commit_short) ($(Base.GIT_VERSION_INFO.date_string))")
     end
+    if Base.GIT_VERSION_INFO.tagged_commit
+        # If this is a tagged commit, print the tagged release banner.
+        # For example, for official release binaries, the tagged release banner is
+        # something like "Official https://julialang.org/ release".
+        println(io, Base.TAGGED_RELEASE_BANNER)
+    end
     if ccall(:jl_is_debugbuild, Cint, ())!=0
         println(io, "DEBUG build")
     end


### PR DESCRIPTION
With this PR, if the Julia binary was built from a tagged commit, then `InteractiveUtils.versioninfo` will print the tagged release banner.

For example, for the official release binaries, the tagged release banner is:
- `Official https://julialang.org/ release`.

## Motivation

Currently, when people post (e.g. on Discourse) about a problem that they are having, we ask them to post the output of `import InteractiveUtils; InteractiveUtils.versioninfo()` so that we know what version of Julia they are using.

Another common question that we ask is "are you using the official binaries from the Julia website?"

By printing the contents of the tagged release banner as part of the output from `InteractiveUtils.versioninfo()`, we can easily figure out whether someone is using the official binaries, or if they installed Julia some other way.