### PR TITLE
Profile: fix metadata skip logic

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -555,7 +555,7 @@ function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict,
     skip = false
     nsleeping = 0
     for i in startframe:-1:1
-        startframe - 1 <= i <= startframe - (nmeta + 1) && continue # skip metadata (it's read ahead below) and extra block-end NULL IP
+        (startframe - 1) >= i >= (startframe - (nmeta + 1)) && continue # skip metadata (its read ahead below) and extra block end NULL IP
         ip = data[i]
         if is_block_end(data, i)
             # read metadata
@@ -803,7 +803,7 @@ function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineI
     skip = false
     nsleeping = 0
     for i in startframe:-1:1
-        startframe - 1 <= i <= startframe - (nmeta + 1) && continue # skip metadata (its read ahead below) and extra block end NULL IP
+        (startframe - 1) >= i >= (startframe - (nmeta + 1)) && continue # skip metadata (its read ahead below) and extra block end NULL IP
         ip = all[i]
         if is_block_end(all, i)
             # read metadata


### PR DESCRIPTION
I should've caught this in https://github.com/JuliaLang/julia/pull/41742.
The metadata fields weren't being skipped properly during print causing multiple `[unknown stackframe]`s on each block that showed up when `C = true`

Master
```julia
julia> using Profile

julia> @profile sleep(2)

julia> Profile.clear()

julia> @profile sleep(2)

julia> Profile.print(C = true)
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
    ╎8886 [unknown stackframe]
    ╎ 8886 [unknown stackframe]
    ╎  8886 [unknown stackframe]
    ╎   8886 [unknown stackframe]
    ╎    8886 [unknown stackframe]
7404╎     7405 ...tem/libsystem_kernel.dylib:?; __psynch_cvwait
1481╎     1481 ...tem/libsystem_kernel.dylib:?; kevent
Total snapshots: 8886 (0% utilization across all threads and tasks. Use the `groupby` kwarg to break down by thread and/or task)

```

This PR
```julia
...
julia> Profile.print(C = true)
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
7439╎7439 /usr/lib/system/libsystem_kernel.dylib:?; __psynch_cvwait
1486╎1487 /usr/lib/system/libsystem_kernel.dylib:?; kevent
Total snapshots: 8926 (0% utilization across all threads and tasks. Use the `groupby` kwarg to break down by thread and/or task)
```