### PR TITLE
add cross-ref from readlines to eachline

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -548,7 +548,8 @@ end
 
 Read all lines of an I/O stream or a file as a vector of strings. Behavior is
 equivalent to saving the result of reading [`readline`](@ref) repeatedly with the same
-arguments and saving the resulting lines as a vector of strings.
+arguments and saving the resulting lines as a vector of strings.  See also
+[`eachline`](@ref) to iterate over the lines without reading them all at once.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
It seems like the `readlines` docstring should mention `eachline`, since the latter is often preferable.