### PR TITLE
CI (Buildkite): in the experimental `asan` job, remove the "Test that ASAN is enabled" step (but keep the "Build julia-debug with ASAN" step)

### DIFF
--- a/.buildkite/pipelines/experimental/launch_unsigned_builders.yml
+++ b/.buildkite/pipelines/experimental/launch_unsigned_builders.yml
@@ -1,7 +1,6 @@
 steps:
   - label: ":buildkite: Launch unsigned pipelines"
     commands: |
-      # buildkite-agent pipeline upload .buildkite/pipelines/experimental/misc/sanitizers.yml
-      :
+      buildkite-agent pipeline upload .buildkite/pipelines/experimental/misc/sanitizers.yml
     agents:
       queue: julia

--- a/.buildkite/pipelines/experimental/launch_unsigned_builders.yml
+++ b/.buildkite/pipelines/experimental/launch_unsigned_builders.yml
@@ -1,6 +1,7 @@
 steps:
   - label: ":buildkite: Launch unsigned pipelines"
     commands: |
-      buildkite-agent pipeline upload .buildkite/pipelines/experimental/misc/sanitizers.yml
+      # buildkite-agent pipeline upload .buildkite/pipelines/experimental/misc/sanitizers.yml
+      :
     agents:
       queue: julia

--- a/.buildkite/pipelines/experimental/misc/sanitizers.yml
+++ b/.buildkite/pipelines/experimental/misc/sanitizers.yml
@@ -24,8 +24,6 @@ steps:
     # notify:
     #   - github_commit_status:
     #       context: "asan"
-    # soft_fail:
-    #   - exit_status: '*'
     commands: |
       echo "--- Build julia-debug with ASAN"
       contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_NUM_CORES} debug

--- a/.buildkite/pipelines/experimental/misc/sanitizers.yml
+++ b/.buildkite/pipelines/experimental/misc/sanitizers.yml
@@ -29,5 +29,3 @@ steps:
     commands: |
       echo "--- Build julia-debug with ASAN"
       contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_NUM_CORES} debug
-      echo "--- Test that ASAN is enabled"
-      contrib/asan/check.jl ./tmp/test-asan/asan/usr/bin/julia-debug

--- a/.buildkite/pipelines/experimental/misc/sanitizers.yml
+++ b/.buildkite/pipelines/experimental/misc/sanitizers.yml
@@ -20,12 +20,14 @@ steps:
       # `contrib/check-asan.jl` needs a `julia` binary:
       - JuliaCI/julia#v1:
           version: 1.6
+    timeout_in_minutes: 120
+    # notify:
+    #   - github_commit_status:
+    #       context: "asan"
+    soft_fail:
+      - exit_status: '*'
     commands: |
       echo "--- Build julia-debug with ASAN"
       contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_NUM_CORES} debug
       echo "--- Test that ASAN is enabled"
       contrib/asan/check.jl ./tmp/test-asan/asan/usr/bin/julia-debug
-    timeout_in_minutes: 120
-    # notify:                   # TODO: uncomment this line
-    #   - github_commit_status: # TODO: uncomment this line
-    #       context: "asan"     # TODO: uncomment this line

--- a/.buildkite/pipelines/experimental/misc/sanitizers.yml
+++ b/.buildkite/pipelines/experimental/misc/sanitizers.yml
@@ -24,8 +24,8 @@ steps:
     # notify:
     #   - github_commit_status:
     #       context: "asan"
-    soft_fail:
-      - exit_status: '*'
+    # soft_fail:
+    #   - exit_status: '*'
     commands: |
       echo "--- Build julia-debug with ASAN"
       contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_NUM_CORES} debug


### PR DESCRIPTION
Of the 20 most recent [`julia-master-experimental`](https://buildkite.com/julialang/julia-master-experimental) jobs on the `master` branch, 7 have passed and 13 have failed.

I don't think it's particularly useful to keep running a job that is this flaky. I would propose that we disable the `asan` job for now. Once we figure out how to get it to reliably pass, we can consider re-enabling it.