### PR TITLE
improve line number merging for reflection tools

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -382,7 +382,7 @@ function DILineInfoPrinter(linetable::Vector, showtypes::Bool=false)
                     # if so, drop all existing calls to it from the top of the context
                     # AND check if instead the context was previously printed that way
                     # but now has removed the recursive frames
-                    let method = method_name(context[nctx])
+                    let method = method_name(context[nctx]) # last matching frame
                         if (nctx < nframes && method_name(DI[nframes - nctx]) === method) ||
                            (nctx < length(context) && method_name(context[nctx + 1]) === method)
                             update_line_only = true
@@ -391,8 +391,15 @@ function DILineInfoPrinter(linetable::Vector, showtypes::Bool=false)
                             end
                         end
                     end
-                elseif length(context) > 0
-                    update_line_only = true
+                end
+                # look at the first non-matching element to see if we are only changing the line number
+                if !update_line_only && nctx < length(context) && nctx < nframes
+                    let CtxLine = context[nctx + 1],
+                        FrameLine = DI[nframes - nctx]
+                        if method_name(CtxLine) === method_name(FrameLine)
+                            update_line_only = true
+                        end
+                    end
                 end
             elseif nctx < length(context) && nctx < nframes
                 # look at the first non-matching element to see if we are only changing the line number

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -229,17 +229,21 @@ void DILineInfoPrinter::emit_lineinfo(raw_ostream &Out, std::vector<DILineInfo> 
             // if so, drop all existing calls to it from the top of the context
             // AND check if instead the context was previously printed that way
             // but now has removed the recursive frames
-            StringRef method = StringRef(context.at(nctx - 1).FunctionName).rtrim(';');
+            StringRef method = StringRef(context.at(nctx - 1).FunctionName).rtrim(';'); // last matching frame
             if ((nctx < nframes && StringRef(DI.at(nframes - nctx - 1).FunctionName).rtrim(';') == method) ||
                 (nctx < context.size() && StringRef(context.at(nctx).FunctionName).rtrim(';') == method)) {
                 update_line_only = true;
-                while (nctx > 0 && StringRef(context.at(nctx - 1).FunctionName).rtrim(';') == method) {
+                // transform nctx to exclude the combined frames
+                while (nctx > 0 && StringRef(context.at(nctx - 1).FunctionName).rtrim(';') == method)
                     nctx -= 1;
-                }
             }
         }
-        else if (context.size() > 0) {
-            update_line_only = true;
+        if (!update_line_only && nctx < context.size() && nctx < nframes) {
+            // look at the first non-matching element to see if we are only changing the line number
+            const DILineInfo &CtxLine = context.at(nctx);
+            const DILineInfo &FrameLine = DI.at(nframes - 1 - nctx);
+            if (StringRef(CtxLine.FunctionName).rtrim(';') == StringRef(FrameLine.FunctionName).rtrim(';'))
+                update_line_only = true;
         }
     }
     else if (nctx < context.size() && nctx < nframes) {


### PR DESCRIPTION
We were representing some frames as discontiguous that were clearly the same frame, but the detection logic for it was off-by-one. Note how the outer bracket was broken, and it now solid.

before:
```
julia> g() = peek(@noinline(IOBuffer("a")), UInt8)

julia> @code_typed g()
CodeInfo(
    @ REPL[1]:1 within `g`
1 ─ %1  = invoke Main.IOBuffer("a"::String)::IOBuffer
│  ┌ @ iobuffer.jl:225 within `peek`
│  │┌ @ Base.jl:38 within `getproperty`
│  ││ %2  = Base.getfield(%1, :readable)::Bool
│  │└
└──│       goto #5 if not %2
   └
   ┌ @ iobuffer.jl:226 within `peek`
   │┌ @ Base.jl:38 within `getproperty`
2 ─││ %4  = Base.getfield(%1, :ptr)::Int64
│  ││ %5  = Base.getfield(%1, :size)::Int64
│  │└
│  │┌ @ operators.jl:378 within `>`
│  ││┌ @ int.jl:83 within `<`
│  │││ %6  = Base.slt_int(%5, %4)::Bool
│  │└└
└──│       goto #4 if not %6
   └
   ┌ @ iobuffer.jl:227 within `peek`
3 ─│ %8  = Base.EOFError()::Any
│  │       Base.throw(%8)::Union{}
└──│       unreachable
   └
   ┌ @ iobuffer.jl:229 within `peek`
   │┌ @ Base.jl:38 within `getproperty`
4 ─││ %11 = Base.getfield(%1, :data)::Vector{UInt8}
│  ││ %12 = Base.getfield(%1, :ptr)::Int64
│  │└
│  │┌ @ array.jl:921 within `getindex`
│  ││ %13 = Base.arrayref(true, %11, %12)::UInt8
│  │└
└──│       goto #6
   └
   ┌ @ iobuffer.jl:225 within `peek`
5 ─│       invoke Base._throw_not_readable()::Union{}
└──│       unreachable
   └
6 ─       return %13
) => UInt8

```
after:
```
julia> @code_typed g()
CodeInfo(
    @ REPL[1]:1 within `g`
1 ─ %1  = invoke Main.IOBuffer("a"::String)::IOBuffer
│  ┌ @ iobuffer.jl:225 within `peek`
│  │┌ @ Base.jl:38 within `getproperty`
│  ││ %2  = Base.getfield(%1, :readable)::Bool
│  │└
└──│       goto #5 if not %2
   │ @ iobuffer.jl:226 within `peek`
   │┌ @ Base.jl:38 within `getproperty`
2 ─││ %4  = Base.getfield(%1, :ptr)::Int64
│  ││ %5  = Base.getfield(%1, :size)::Int64
│  │└
│  │┌ @ operators.jl:378 within `>`
│  ││┌ @ int.jl:83 within `<`
│  │││ %6  = Base.slt_int(%5, %4)::Bool
│  │└└
└──│       goto #4 if not %6
   │ @ iobuffer.jl:227 within `peek`
3 ─│ %8  = Base.EOFError()::Any
│  │       Base.throw(%8)::Union{}
└──│       unreachable
   │ @ iobuffer.jl:229 within `peek`
   │┌ @ Base.jl:38 within `getproperty`
4 ─││ %11 = Base.getfield(%1, :data)::Vector{UInt8}
│  ││ %12 = Base.getfield(%1, :ptr)::Int64
│  │└
│  │┌ @ array.jl:904 within `getindex`
│  ││ %13 = Base.arrayref(true, %11, %12)::UInt8
│  │└
└──│       goto #6
   │ @ iobuffer.jl:225 within `peek`
5 ─│       invoke Base._throw_not_readable()::Union{}
└──│       unreachable
   └
6 ─       return %13
) => UInt8

```