### PR TITLE
fix race condition in mv where the file might get removed after we checked its existance

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -321,7 +321,7 @@ function checkfor_mv_cp_cptree(src::AbstractString, dst::AbstractString, txt::Ab
                                            "`src` refers to: $(abs_src)\n  ",
                                            "`dst` refers to: $(abs_dst)\n")))
             end
-            rm(dst; recursive=true)
+            rm(dst; recursive=true, force=true)
         else
             throw(ArgumentError(string("'$dst' exists. `force=true` ",
                                        "is required to remove '$dst' before $(txt).")))


### PR DESCRIPTION
We've observed an error with the following stacktrace:

```
IOError: unlink("home/kc/.julia/logs/manifest_usage.toml"): no such file or directory (ENOENT)
Stacktrace:
  [1] uv_error
    @ ./libuv.jl:97 [inlined]
  [2] unlink
    @ ./file.jl:958
  [3] #rm#12
    @ ./file.jl:276
  [4] #checkfor_mv_cp_cptree#13
    @ ./file.jl:323
  [5] #mv#17
    @ ./file.jl:411 [inlined]
...
```

In short, the `rm` in the line changed in this PR errors because the file does not exist, even though we checked its existence a while earlier. This could be because some other process deleted it. Therefore, pass `force=true` to `rm` so that it is not an error if the file has already been deleted.

cc @Sacha0, @NHDaly 