### PR TITLE
avoid `Any32` type in `filter` for tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -356,10 +356,10 @@ end
 
 ## filter ##
 
-filter(f, xs::Tuple) = afoldl((ys, x) -> f(x) ? (ys..., x) : ys, (), xs...)
+filter_rec(f, xs::Tuple) = afoldl((ys, x) -> f(x) ? (ys..., x) : ys, (), xs...)
 
 # use Array for long tuples
-filter(f, t::Any32) = Tuple(filter(f, collect(t)))
+filter(f, t::Tuple) = length(t) < 32 ? filter_rec(f, t) : Tuple(filter(f, collect(t)))
 
 ## comparison ##
 


### PR DESCRIPTION
This is sufficient to fix the case in that issue, but we should probably stop using these types. After intersection, they tend to blow up into more complex long tuple types (tuples of many unions) that are intractable for subtyping. With some quick experiments, so far it looks to me like we can replace these with length checks now with no regressions.

fixes #42236
