### PR TITLE
add faster implementation for `findall(::AbstractVector{Bool})`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2366,7 +2366,7 @@ function findall(A::AbstractArray{Bool})
     end
     I
 end
-findall(A::AbstractVector{Bool}) = (1:length(A))[A]
+findall(A::AbstractVector{Bool}) = eachindex(A)[A]
 
 findall(x::Bool) = x ? [1] : Vector{Int}()
 findall(testf::Function, x::Number) = testf(x) ? [1] : Vector{Int}()

--- a/base/array.jl
+++ b/base/array.jl
@@ -2366,6 +2366,7 @@ function findall(A::AbstractArray{Bool})
     end
     I
 end
+findall(A::AbstractVector{Bool}) = (1:length(A))[A]
 
 findall(x::Bool) = x ? [1] : Vector{Int}()
 findall(testf::Function, x::Number) = testf(x) ? [1] : Vector{Int}()


### PR DESCRIPTION
```julia
julia> a = rand(Bool, 10000);

julia> @btime findall($a);
  40.073 μs (2 allocations: 38.95 KiB)

julia> function myfindall(a)
           return (1:length(a))[a]
       end

julia> @btime myfindall($a);
  33.978 μs (2 allocations: 38.95 KiB)
```

though seems to be somewhat slower with BitArrays

```julia
julia> b = BitArray(rand(Bool, 10_000));

julia> @btime findall($b);
  6.113 μs (2 allocations: 39.89 KiB)

julia> @btime myfindall($b);
  6.224 μs (2 allocations: 39.89 KiB)
```

Thanks to @eperim  for finding this 