### PR TITLE
Add `convert` for IPAddr using `parse`

### DIFF
--- a/stdlib/Sockets/src/IPAddr.jl
+++ b/stdlib/Sockets/src/IPAddr.jl
@@ -236,9 +236,9 @@ function parse(::Type{IPv6}, str::AbstractString)
         return IPv6(parseipv6fields(fields))
     end
 end
-                                            
+
 # Conversion
-                                            
+
 Base.convert(::Type{IPAddr}, str::AbstractString) = parse(IPAddr, str)
 
 #

--- a/stdlib/Sockets/src/IPAddr.jl
+++ b/stdlib/Sockets/src/IPAddr.jl
@@ -236,6 +236,10 @@ function parse(::Type{IPv6}, str::AbstractString)
         return IPv6(parseipv6fields(fields))
     end
 end
+                                            
+# Conversion
+                                            
+Base.convert(::Type{IPAddr}, str::AbstractString) = parse(IPAddr, str)
 
 #
 # This supports IP addresses in the common dot (IPv4) or colon (IPv6)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -87,12 +87,12 @@ end
     end
     
     let test_struct = IPAddrTestStruct("127.0.0.1")
-        @test isa(test_struct, IPv4)
+        @test isa(test_struct.ip, IPv4)
         @test test_struct.ip == ip"127.0.0.1"
     end
     
     let test_struct = IPAddrTestStruct("0:0:0:0:0:ffff:127.0.0.1")
-        @test isa(test_struct, IPv6)
+        @test isa(test_struct.ip, IPv6)
         @test test_struct.ip == ip"0:0:0:0:0:ffff:127.0.0.1"
     end
 end

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -85,12 +85,12 @@ end
     struct IPAddrTestStruct
         ip::IPAddr
     end
-    
+
     let test_struct = IPAddrTestStruct("127.0.0.1")
         @test isa(test_struct.ip, IPv4)
         @test test_struct.ip == ip"127.0.0.1"
     end
-    
+
     let test_struct = IPAddrTestStruct("0:0:0:0:0:ffff:127.0.0.1")
         @test isa(test_struct.ip, IPv6)
         @test test_struct.ip == ip"0:0:0:0:0:ffff:127.0.0.1"

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -81,6 +81,22 @@ sockets_watchdog_timer = Timer(t -> killjob("KILLING BY SOCKETS TEST WATCHDOG\n"
     @test_throws BoundsError Sockets.ipv6_field(IPv6(0xffff7f000001), 9)
 end
 
+@testset "conversion" begin
+    struct IPAddrTestStruct
+        ip::IPAddr
+    end
+    
+    let test_struct = IPAddrTestStruct("127.0.0.1")
+        @test isa(test_struct, IPv4)
+        @test test_struct.ip == ip"127.0.0.1"
+    end
+    
+    let test_struct = IPAddrTestStruct("0:0:0:0:0:ffff:127.0.0.1")
+        @test isa(test_struct, IPv6)
+        @test test_struct.ip == ip"0:0:0:0:0:ffff:127.0.0.1"
+    end
+end
+
 @testset "InetAddr constructor" begin
     inet = Sockets.InetAddr(IPv4(127,0,0,1), 1024)
     @test inet.host == ip"127.0.0.1"


### PR DESCRIPTION
IP addresses are often created from strings which is already reflected in the Sockets package by implementing a `parse` function. However, the benefits of automatic conversion using `convert` can not yet be exploited, since `convert` is not implemented for `IPAddr`. This PR adds the `convert` function and matching tests.