### PR TITLE
CI (Buildkite): remove the individual commit statuses, and only have a single Buildkite commit status

### DIFF
--- a/.buildkite/pipelines/experimental/misc/sanitizers.yml
+++ b/.buildkite/pipelines/experimental/misc/sanitizers.yml
@@ -21,9 +21,6 @@ steps:
       - JuliaCI/julia#v1:
           version: 1.6
     timeout_in_minutes: 120
-    # notify:
-    #   - github_commit_status:
-    #       context: "asan"
     commands: |
       echo "--- Build julia-debug with ASAN"
       contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_NUM_CORES} debug

--- a/.buildkite/pipelines/main/misc/doctest.yml
+++ b/.buildkite/pipelines/main/misc/doctest.yml
@@ -31,6 +31,3 @@ steps:
       echo "--- Run Julia doctests"
       JULIA_NUM_THREADS=1 make -C doc doctest=true
     timeout_in_minutes: 45
-    notify:
-      - github_commit_status:
-          context: "doctest"

--- a/.buildkite/pipelines/main/misc/embedding.yml
+++ b/.buildkite/pipelines/main/misc/embedding.yml
@@ -29,6 +29,3 @@ steps:
       make -j$${JULIA_NUM_CORES} -C test/embedding JULIA="$${prefix}/bin/julia" BIN="$${embedding_output}"
 
     timeout_in_minutes: 60
-    notify:
-      - github_commit_status:
-          context: "embedding"

--- a/.buildkite/pipelines/main/misc/llvmpasses.yml
+++ b/.buildkite/pipelines/main/misc/llvmpasses.yml
@@ -23,9 +23,6 @@ steps:
       make -j$${JULIA_NUM_CORES} -C test/clangsa
       make -j$${JULIA_NUM_CORES} -C src analyzegc
     timeout_in_minutes: 60
-    notify:
-      - github_commit_status:
-          context: "analyzegc"
 
   - label: "llvmpasses"
     key: "llvmpasses"
@@ -47,6 +44,3 @@ steps:
       echo "+++ make test/llvmpasses"
       make -j$${JULIA_NUM_CORES} -C test/llvmpasses
     timeout_in_minutes: 60
-    notify:
-      - github_commit_status:
-          context: "llvmpasses"

--- a/.buildkite/pipelines/main/platforms/linux64.yml
+++ b/.buildkite/pipelines/main/platforms/linux64.yml
@@ -52,9 +52,6 @@ steps:
       echo "--- Upload build artifacts"
       buildkite-agent artifact upload $$ARTIFACT_FILENAME
     timeout_in_minutes: 60
-    notify:
-      - github_commit_status:
-          context: "package_linux64"
 
   # TODO: uncomment the following lines in order to enable the `tester_linux64` builder
   # - label: "tester_linux64"
@@ -90,6 +87,3 @@ steps:
   #     unset JULIA_DEPOT_PATH
   #     julia-artifact/bin/julia .buildkite/utilities/rr/rr_capture.jl julia-artifact/bin/julia -e 'Base.runtests(["all"]; ncores = Sys.CPU_THREADS)'
   #   timeout_in_minutes: 120
-  #   notify:
-  #     - github_commit_status:
-  #         context: "tester_linux64"


### PR DESCRIPTION
With this PR, we will only have two commit statuses for Buildkite:
1. The overall Buildkite commit status, named `buildkite/julia-master`
2. The `whitespace` commit status (so that we can have `whitespace` as a required status check in the GitHub branch protection settings for the `master` branch; this prevents people from accidentally committing or pushing directly to `master`)