### PR TITLE
RFC: Allow and preserve non-Int array indices.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1237,9 +1237,9 @@ _getindex(::IndexStyle, A::AbstractArray, I...) =
     error("getindex for $(typeof(A)) with types $(typeof(I)) is not supported")
 
 ## IndexLinear Scalar indexing: canonical method is one Int
-_getindex(::IndexLinear, A::AbstractVector, i::Int) = (@_propagate_inbounds_meta; getindex(A, i))  # ambiguity resolution in case packages specialize this (to be avoided if at all possible, but see Interpolations.jl)
-_getindex(::IndexLinear, A::AbstractArray, i::Int) = (@_propagate_inbounds_meta; getindex(A, i))
-function _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int,M}) where M
+_getindex(::IndexLinear, A::AbstractVector, i::Integer) = (@_propagate_inbounds_meta; getindex(A, i))  # ambiguity resolution in case packages specialize this (to be avoided if at all possible, but see Interpolations.jl)
+_getindex(::IndexLinear, A::AbstractArray, i::Integer) = (@_propagate_inbounds_meta; getindex(A, i))
+function _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Integer,M}) where M
     @inline
     @boundscheck checkbounds(A, I...) # generally _to_linear_index requires bounds checking
     @inbounds r = getindex(A, _to_linear_index(A, I...))
@@ -1251,13 +1251,13 @@ _to_linear_index(A::AbstractArray) = first(LinearIndices(A))
 _to_linear_index(A::AbstractArray, I::Integer...) = (@inline; _sub2ind(A, I...))
 
 ## IndexCartesian Scalar indexing: Canonical method is full dimensionality of Ints
-function _getindex(::IndexCartesian, A::AbstractArray, I::Vararg{Int,M}) where M
+function _getindex(::IndexCartesian, A::AbstractArray, I::Vararg{Integer,M}) where M
     @inline
     @boundscheck checkbounds(A, I...) # generally _to_subscript_indices requires bounds checking
     @inbounds r = getindex(A, _to_subscript_indices(A, I...)...)
     r
 end
-function _getindex(::IndexCartesian, A::AbstractArray{T,N}, I::Vararg{Int, N}) where {T,N}
+function _getindex(::IndexCartesian, A::AbstractArray{T,N}, I::Vararg{Integer, N}) where {T,N}
     @_propagate_inbounds_meta
     getindex(A, I...)
 end
@@ -1279,7 +1279,7 @@ function __to_subscript_indices(A::AbstractArray,
     (J..., map(first, tail(_remaining_size(J, axes(A))))...)
 end
 _to_subscript_indices(A, J::Tuple, Jrem::Tuple) = J # already bounds-checked, safe to drop
-_to_subscript_indices(A::AbstractArray{T,N}, I::Vararg{Int,N}) where {T,N} = I
+_to_subscript_indices(A::AbstractArray{T,N}, I::Vararg{Integer,N}) where {T,N} = I
 _remaining_size(::Tuple{Any}, t::Tuple) = t
 _remaining_size(h::Tuple, t::Tuple) = (@inline; _remaining_size(tail(h), tail(t)))
 _unsafe_ind2sub(::Tuple{}, i) = () # _ind2sub may throw(BoundsError()) in this case
@@ -1331,8 +1331,8 @@ _setindex!(::IndexStyle, A::AbstractArray, v, I...) =
     error("setindex! for $(typeof(A)) with types $(typeof(I)) is not supported")
 
 ## IndexLinear Scalar indexing
-_setindex!(::IndexLinear, A::AbstractArray, v, i::Int) = (@_propagate_inbounds_meta; setindex!(A, v, i))
-function _setindex!(::IndexLinear, A::AbstractArray, v, I::Vararg{Int,M}) where M
+_setindex!(::IndexLinear, A::AbstractArray, v, i::Integer) = (@_propagate_inbounds_meta; setindex!(A, v, i))
+function _setindex!(::IndexLinear, A::AbstractArray, v, I::Vararg{Integer,M}) where M
     @inline
     @boundscheck checkbounds(A, I...)
     @inbounds r = setindex!(A, v, _to_linear_index(A, I...))
@@ -1340,11 +1340,11 @@ function _setindex!(::IndexLinear, A::AbstractArray, v, I::Vararg{Int,M}) where 
 end
 
 # IndexCartesian Scalar indexing
-function _setindex!(::IndexCartesian, A::AbstractArray{T,N}, v, I::Vararg{Int, N}) where {T,N}
+function _setindex!(::IndexCartesian, A::AbstractArray{T,N}, v, I::Vararg{Integer, N}) where {T,N}
     @_propagate_inbounds_meta
     setindex!(A, v, I...)
 end
-function _setindex!(::IndexCartesian, A::AbstractArray, v, I::Vararg{Int,M}) where M
+function _setindex!(::IndexCartesian, A::AbstractArray, v, I::Vararg{Integer,M}) where M
     @inline
     @boundscheck checkbounds(A, I...)
     @inbounds r = setindex!(A, v, _to_subscript_indices(A, I...)...)

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -272,7 +272,7 @@ special indexing behaviors. Note that some index types (like `Colon`) require
 more context in order to transform them into an array of indices; those get
 converted in the more complicated `to_indices` function. By default, this
 simply calls the generic `to_index(i)`. This must return either a subtype of `Integer`
-or an k`AbstractArray` of scalar indices that are supported by `A`.
+or an `AbstractArray` of scalar indices that are supported by `A`.
 """
 to_index(A, i) = to_index(i)
 

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -271,8 +271,8 @@ Custom array types may specialize `to_index(::CustomArray, i)` to provide
 special indexing behaviors. Note that some index types (like `Colon`) require
 more context in order to transform them into an array of indices; those get
 converted in the more complicated `to_indices` function. By default, this
-simply calls the generic `to_index(i)`. This must return either an `Int` or an
-`AbstractArray` of scalar indices that are supported by `A`.
+simply calls the generic `to_index(i)`. This must return either a subtype of `Integer`
+or an k`AbstractArray` of scalar indices that are supported by `A`.
 """
 to_index(A, i) = to_index(i)
 


### PR DESCRIPTION
Julia generally uses 1-based `Int` indices for arrays. CUDA GPUs however use 0-based 32-bit hardware incides, which are then typically used to compute an index into an array. To avoid superfluous conversions and `-1`/`+1` instructions, we've been eagerly converting those 32-bit hardware indices to `Int` since https://github.com/JuliaGPU/CUDAnative.jl/pull/182.

However, turns out we can do even better by keeping the indices as 32-bit and making sure all `-1`/`+1` offsets preserve that integer width (it would be nice if we had Rust-style literals that infer their type based on the context). Alas, redefining `Base.to_index` for `CuDeviceArray` to preserve any `::Integer` does not work, since some of our abstract array code assumes `::Int` indices. This PR tries to improve that, by allowing `Integer` indices. Note that it also requires adjustments to the underlying intrinsics, but with the GPU stack we have those implemented in Julia (https://github.com/maleadt/LLVM.jl/pull/268).

Demo of improved generated code quality:

```julia
function vadd(a, b, c)
    i = (blockIdx().x-0x1) * blockDim().x + threadIdx().x
    @inbounds c[i] = a[i] + b[i]
    return
end
```

Before (extending the hardware indices to 64-bit and then applying the 1-based offset):

```llvm
%3 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
%4 = zext i32 %3 to i64
%5 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
%6 = zext i32 %5 to i64
%7 = mul nuw nsw i64 %6, %4
%8 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
%narrow = add nuw nsw i32 %8, 1
%9 = zext i32 %narrow to i64
%10 = add nuw nsw i64 %7, %9
%11 = add nsw i64 %10, -1
%12 = bitcast i8 addrspace(1)* %.fca.0.extract9 to float addrspace(1)*
%13 = getelementptr inbounds float, float addrspace(1)* %12, i64 %11
%14 = load float, float addrspace(1)* %13, align 4
%15 = bitcast i8 addrspace(1)* %.fca.0.extract1 to float addrspace(1)*
%16 = getelementptr inbounds float, float addrspace(1)* %15, i64 %11
%17 = load float, float addrspace(1)* %16, align 4
%18 = fadd float %14, %17
%19 = bitcast i8 addrspace(1)* %.fca.0.extract to float addrspace(1)*
%20 = getelementptr inbounds float, float addrspace(1)* %19, i64 %11
store float %18, float addrspace(1)* %20, align 4
```

```
mov.u32         %r1, %ctaid.x;
mov.u32         %r2, %ntid.x;
mul.wide.u32    %rd4, %r2, %r1;
mov.u32         %r3, %tid.x;
cvt.u64.u32     %rd5, %r3;
add.s64         %rd6, %rd4, %rd5;
shl.b64         %rd7, %rd6, 2;
add.s64         %rd8, %rd7, -4;
add.s64         %rd9, %rd1, %rd8;
ld.global.f32   %f1, [%rd9+4];
add.s64         %rd10, %rd2, %rd8;
ld.global.f32   %f2, [%rd10+4];
add.f32         %f3, %f1, %f2;
add.s64         %rd11, %rd3, %rd8;
st.global.f32   [%rd11+4], %f3;
```

After (preserving 32-bit indices and also doing the 1-based offsetting in 32-bits):

```llvm
%3 = call i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
%4 = call i32 @llvm.nvvm.read.ptx.sreg.ntid.x()
%5 = mul i32 %4, %3
%6 = call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
%7 = add i32 %5, %6
%8 = zext i32 %7 to i64
%9 = bitcast i8 addrspace(1)* %.fca.0.extract9 to float addrspace(1)*
%10 = getelementptr inbounds float, float addrspace(1)* %9, i64 %8
%11 = load float, float addrspace(1)* %10, align 4
%12 = bitcast i8 addrspace(1)* %.fca.0.extract1 to float addrspace(1)*
%13 = getelementptr inbounds float, float addrspace(1)* %12, i64 %8
%14 = load float, float addrspace(1)* %13, align 4
%15 = fadd float %11, %14
%16 = bitcast i8 addrspace(1)* %.fca.0.extract to float addrspace(1)*
%17 = getelementptr inbounds float, float addrspace(1)* %16, i64 %8
store float %15, float addrspace(1)* %17, align 4
```

```
mov.u32         %r1, %ctaid.x;
mov.u32         %r2, %ntid.x;
mov.u32         %r3, %tid.x;
mad.lo.s32      %r4, %r2, %r1, %r3;
mul.wide.u32    %rd4, %r4, 4;
add.s64         %rd5, %rd1, %rd4;
ld.global.f32   %f1, [%rd5];
add.s64         %rd6, %rd2, %rd4;
ld.global.f32   %f2, [%rd6];
add.f32         %f3, %f1, %f2;
add.s64         %rd7, %rd3, %rd4;
st.global.f32   [%rd7], %f3;
```

This doesn't only use fewer instructions, but also significantly lowers register pressure.

Since I've naively updated a 'for ambiguity reasons'-method definition here, this probably needs a PkgEval run to make sure it doesn't break anything.