### PR TITLE
Make explicit that r in _cut_B(x, r) starts at 1

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -451,8 +451,8 @@ export ⋅, ×
 ## convenience methods
 ## return only the solution of a least squares problem while avoiding promoting
 ## vectors to matrices.
-_cut_B(x::AbstractVector, r::UnitRange) = length(x)  > length(r) ? x[r]   : x
-_cut_B(X::AbstractMatrix, r::UnitRange) = size(X, 1) > length(r) ? X[r,:] : X
+_cut_B(x::AbstractVector, r::OneTo) = length(x)  > length(r) ? x[r]   : x
+_cut_B(X::AbstractMatrix, r::OneTo) = size(X, 1) > length(r) ? X[r,:] : X
 
 ## append right hand side with zeros if necessary
 _zeros(::Type{T}, b::AbstractVector, n::Integer) where {T} = zeros(T, max(length(b), n))
@@ -499,7 +499,7 @@ function (\)(F::Union{<:LAPACKFactorizations,Adjoint{<:Any,<:LAPACKFactorization
     # For tall problems, we compute a least squares solution so only part
     # of the rhs should be returned from \ while ldiv! uses (and returns)
     # the complete rhs
-    return _cut_B(BB, 1:n)
+    return _cut_B(BB, OneTo(n))
 end
 # disambiguate
 (\)(F::LAPACKFactorizations{T}, B::VecOrMat{Complex{T}}) where {T<:BlasReal} =

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -194,7 +194,7 @@ function lmul!(A::LQ, B::StridedVecOrMat)
 end
 function *(A::LQ{TA}, B::StridedVecOrMat{TB}) where {TA,TB}
     TAB = promote_type(TA, TB)
-    _cut_B(lmul!(convert(Factorization{TAB}, A), copy_oftype(B, TAB)), 1:size(A,1))
+    _cut_B(lmul!(convert(Factorization{TAB}, A), copy_oftype(B, TAB)), OneTo(size(A,1)))
 end
 
 ## Multiplication by Q

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -1031,7 +1031,7 @@ function (\)(A::Union{QR{T},QRCompactWY{T},QRPivoted{T}}, BIn::VecOrMat{Complex{
 #                                                 |x3|y3|
 #                                                 |x4|y4|
     XX = reshape(collect(reinterpret(Complex{T}, copy(transpose(reshape(X, div(length(X), 2), 2))))), _ret_size(A, BIn))
-    return _cut_B(XX, 1:n)
+    return _cut_B(XX, OneTo(n))
 end
 
 ##TODO:  Add methods for rank(A::QRP{T}) and adjust the (\) method accordingly

--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -248,7 +248,7 @@ svdvals(S::SVD{<:Any,T}) where {T} = (S.S)::Vector{T}
 function ldiv!(A::SVD{T}, B::StridedVecOrMat) where T
     m, n = size(A)
     k = searchsortedlast(A.S, eps(real(T))*A.S[1], rev=true)
-    mul!(view(B, 1:n, :), view(A.Vt, 1:k, :)', view(A.S, 1:k) .\ (view(A.U, :, 1:k)' * _cut_B(B, 1:m)))
+    mul!(view(B, 1:n, :), view(A.Vt, 1:k, :)', view(A.S, 1:k) .\ (view(A.U, :, 1:k)' * _cut_B(B, OneTo(m)))
     return B
 end
 


### PR DESCRIPTION
The definition of `_cut_B` is confusing as it restricts the type to `UnitRange` but only actually makes sense if the first index is `1`. This PR makes it explicit via requiring `r::OneTo`.