### PR TITLE
add `@constprop` for compatibility to 1.7

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -262,4 +262,18 @@ end
 # This function was marked as experimental and not exported.
 @deprecate catch_stack(task=current_task(); include_bt=true) current_exceptions(task; backtrace=include_bt) false
 
+"""
+    @aggressive_constprop ex
+    @aggressive_constprop(ex)
+
+`@aggressive_constprop` requests more aggressive interprocedural constant
+propagation for the annotated function. For a method where the return type
+depends on the value of the arguments, this can yield improved inference results
+at the cost of additional compile time.
+"""
+macro aggressive_constprop(ex)
+    depwarn("use `@constprop :aggressive ex` instead of `@aggressive_constprop ex`", :var"@aggressive_constprop")
+    esc(isa(ex, Expr) ? pushmeta!(ex, :aggressive_constprop) : ex)
+end
+
 # END 1.7 deprecations

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -240,16 +240,25 @@ macro pure(ex)
 end
 
 """
-    @aggressive_constprop ex
-    @aggressive_constprop(ex)
+    @constprop setting ex
+    @constprop(setting, ex)
 
-`@aggressive_constprop` requests more aggressive interprocedural constant
-propagation for the annotated function. For a method where the return type
-depends on the value of the arguments, this can yield improved inference results
-at the cost of additional compile time.
+`@constprop` controls the mode of interprocedural constant propagation for the
+annotated function. Only `:aggressive` is supported in 1.7:
+
+- `@constprop :aggressive ex`: apply constant propagation aggressively.
+  For a method where the return type depends on the value of the arguments,
+  this can yield improved inference results at the cost of additional compile time.
+
+`@constprop :none ex` is a no-op, but is allowed for compatibility with Julia 1.8.
 """
-macro aggressive_constprop(ex)
-    esc(isa(ex, Expr) ? pushmeta!(ex, :aggressive_constprop) : ex)
+macro constprop(setting, ex)
+    if isa(setting, QuoteNode)
+        setting = setting.value
+    end
+    setting === :aggressive && return esc(isa(ex, Expr) ? pushmeta!(ex, :aggressive_constprop) : ex)
+    setting === :none && return esc(ex)
+    throw(ArgumentError("@constprop $setting not supported"))
 end
 
 """

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3171,21 +3171,18 @@ f_inf_error_bottom(x::Vector) = isempty(x) ? error(x[1]) : x
 
 # @aggressive_constprop
 @noinline g_nonaggressive(y, x) = Val{x}()
-@noinline @Base.aggressive_constprop g_aggressive(y, x) = Val{x}()
+@noinline @Base.constprop :aggressive g_aggressive(y, x) = Val{x}()
 @noinline @Base.constprop :none g_nonaggressive2(y, x) = Val{x}()
-@noinline @Base.constprop :aggressive g_aggressive2(y, x) = Val{x}()
 
 f_nonaggressive(x) = g_nonaggressive(x, 1)
 f_aggressive(x) = g_aggressive(x, 1)
 f_nonaggressive2(x) = g_nonaggressive2(x, 1)
-f_aggressive2(x) = g_aggressive2(x, 1)
 
 # The first test just makes sure that improvements to the compiler don't
 # render the annotation effectless.
 @test Base.return_types(f_nonaggressive, Tuple{Int})[1] == Val
 @test Base.return_types(f_aggressive, Tuple{Int})[1] == Val{1}
 @test Base.return_types(f_nonaggressive2, Tuple{Int})[1] == Val
-@test Base.return_types(f_aggressive2, Tuple{Int})[1] == Val{1}
 
 function splat_lotta_unions()
     a = Union{Tuple{Int},Tuple{String,Vararg{Int}},Tuple{Int,Vararg{Int}}}[(2,)][1]

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3172,14 +3172,20 @@ f_inf_error_bottom(x::Vector) = isempty(x) ? error(x[1]) : x
 # @aggressive_constprop
 @noinline g_nonaggressive(y, x) = Val{x}()
 @noinline @Base.aggressive_constprop g_aggressive(y, x) = Val{x}()
+@noinline @Base.constprop :none g_nonaggressive2(y, x) = Val{x}()
+@noinline @Base.constprop :aggressive g_aggressive2(y, x) = Val{x}()
 
 f_nonaggressive(x) = g_nonaggressive(x, 1)
 f_aggressive(x) = g_aggressive(x, 1)
+f_nonaggressive2(x) = g_nonaggressive2(x, 1)
+f_aggressive2(x) = g_aggressive2(x, 1)
 
 # The first test just makes sure that improvements to the compiler don't
 # render the annotation effectless.
 @test Base.return_types(f_nonaggressive, Tuple{Int})[1] == Val
 @test Base.return_types(f_aggressive, Tuple{Int})[1] == Val{1}
+@test Base.return_types(f_nonaggressive2, Tuple{Int})[1] == Val
+@test Base.return_types(f_aggressive2, Tuple{Int})[1] == Val{1}
 
 function splat_lotta_unions()
     a = Union{Tuple{Int},Tuple{String,Vararg{Int}},Tuple{Int,Vararg{Int}}}[(2,)][1]

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -120,3 +120,15 @@ global_logger(prev_logger)
 end
 
 # END 0.7 deprecations
+
+# @aggressive_constprop
+@noinline g_nonaggressive(y, x) = Val{x}()
+@noinline @Base.aggressive_constprop g_aggressive(y, x) = Val{x}()
+
+f_nonaggressive(x) = g_nonaggressive(x, 1)
+f_aggressive(x) = g_aggressive(x, 1)
+
+# The first test just makes sure that improvements to the compiler don't
+# render the annotation effectless.
+@test Base.return_types(f_nonaggressive, Tuple{Int})[1] == Val
+@test Base.return_types(f_aggressive, Tuple{Int})[1] == Val{1}


### PR DESCRIPTION
This also adds a depwarn for `@aggressive_constprop`, which seemed
sensible to me, given that it will be removed in 1.8.

replaces #42280 
