### PR TITLE
specialize `hastypemax` on `Bool`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -882,6 +882,7 @@ end
 Return true if and only if the extrema `typemax(T)` and `typemin(T)` are defined.
 """
 hastypemax(::Base.BitIntegerType) = true
+hastypemax(::Type{Bool}) = true
 hastypemax(::Type{T}) where {T} = applicable(typemax, T) && applicable(typemin, T)
 
 """


### PR DESCRIPTION
Since `Bool` is not included in `Base.BitIntegerType`, `hastypemax(Bool)` falls back to the slow generic version. This reduces the performance of `digits!` with Boolean target vector (for `base=2`) significantly. Specializing `hastypemax` on `Bool` fixes this performance bug. 
In one of my applications, where `digits!` should only take a small fraction of the total runtime, fixing this improves the performance by more than 10%.