### PR TITLE
Include sysimage output time in precompilation report

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -490,6 +490,8 @@ function _start()
     if ccall(:jl_generating_output, Cint, ()) != 0 && JLOptions().incremental == 0
         # clear old invalid pointers
         PCRE.__init__()
+        # clear any afteroutput hooks that were saved in the sysimage
+        empty!(Base.afteroutput_hooks)
     end
     try
         exec_options(JLOptions())

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -356,6 +356,25 @@ function _atexit()
     end
 end
 
+## afteroutput: like atexit, but runs at the end of sysimage output
+## any hooks saved in the sysimage are cleared in Base._start
+const afteroutput_hooks = Callable[]
+
+afteroutput(f::Function) = (pushfirst!(afteroutput_hooks, f); nothing)
+
+function _afteroutput()
+    while !isempty(afteroutput_hooks)
+        f = popfirst!(afteroutput_hooks)
+        try
+            f()
+        catch ex
+            showerror(stderr, ex)
+            Base.show_backtrace(stderr, catch_backtrace())
+            println(stderr)
+        end
+    end
+end
+
 ## hook for disabling threaded libraries ##
 
 library_threading_enabled = true

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -406,14 +406,21 @@ function generate_precompile_statements()
         n_succeeded > 1200 || @warn "Only $n_succeeded precompile statements"
     end
 
-    tot_time = time_ns() - start_time
     include_time *= 1e9
-    gen_time = tot_time - include_time
-    println("Precompilation complete. Summary:")
-    print("Total ─────── "); Base.time_print(tot_time); println()
-    print("Generation ── "); Base.time_print(gen_time);     print(" "); show(IOContext(stdout, :compact=>true), gen_time / tot_time * 100); println("%")
-    print("Execution ─── "); Base.time_print(include_time); print(" "); show(IOContext(stdout, :compact=>true), include_time / tot_time * 100); println("%")
+    gen_time = (time_ns() - start_time) - include_time
 
+    println("Outputting sysimage file...")
+
+    # Print report after sysimage has been saved so to include all time spent
+    Base.afteroutput() do
+        tot_time = time_ns() - start_time
+        output_time = tot_time - gen_time - include_time
+        println("Precompilation complete. Summary:")
+        print("Total ─────── "); Base.time_print(tot_time);     println()
+        print("Generation ── "); Base.time_print(gen_time);     print(" "); show(IOContext(stdout, :compact=>true), gen_time / tot_time * 100);     println("%")
+        print("Execution ─── "); Base.time_print(include_time); print(" "); show(IOContext(stdout, :compact=>true), include_time / tot_time * 100); println("%")
+        print("Output ────── "); Base.time_print(output_time);  print(" "); show(IOContext(stdout, :compact=>true), output_time / tot_time * 100);  println("%")
+    end
     return
 end
 

--- a/src/init.c
+++ b/src/init.c
@@ -200,6 +200,32 @@ static void jl_close_item_atexit(uv_handle_t *handle)
     }
 }
 
+JL_DLLEXPORT void jl_afteroutput_hook(void)
+{
+    if (jl_all_tls_states == NULL)
+        return;
+
+    jl_task_t *ct = jl_current_task;
+    if (jl_base_module) {
+        jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_afteroutput"));
+        if (f != NULL) {
+            JL_TRY {
+                size_t last_age = ct->world_age;
+                ct->world_age = jl_get_world_counter();
+                jl_apply(&f, 1);
+                ct->world_age = last_age;
+            }
+            JL_CATCH {
+                jl_printf((JL_STREAM*)STDERR_FILENO, "\nafteroutput hook threw an error: ");
+                jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
+                jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
+                jlbacktrace(); // written to STDERR_FILENO
+            }
+        }
+    }
+    return;
+}
+
 JL_DLLEXPORT void jl_atexit_hook(int exitcode)
 {
     if (jl_all_tls_states == NULL)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1665,6 +1665,7 @@ JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
                                      const char *image_relative_path);
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
+JL_DLLEXPORT void jl_afteroutput_hook(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);
 JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
 JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -97,6 +97,7 @@ void jl_write_compiler_output(void)
                            jl_options.outputo,
                            jl_options.outputasm,
                            (const char*)s->buf, (size_t)s->size);
+            jl_afteroutput_hook();
         }
     }
     for (size_t i = 0; i < jl_current_modules.size; i += 2) {


### PR DESCRIPTION
Currently the `make` process output hangs for quite a long time after the precompilation timing report while the sysimage is outputted, which hides a lot of the time spent:
```
Generating REPL precompile statements... 31/31
Executing precompile statements... 1230/1264
Precompilation complete. Summary:
Total ───────  95.019263 seconds
Generation ──  69.012756 seconds 72.6303%
Execution ───  26.006507 seconds 27.3697%     ## LONG WAIT HERE
    LINK usr/lib/julia/sys.dylib

```

This uses a new post output hook to wait until the sysimage has been saved and then includes the output time in the report
```
Generating REPL precompile statements... 31/31
Executing precompile statements... 1231/1265
Outputting sysimage file...                   ## LONG WAIT HERE
Precompilation complete. Summary:
Total ─────── 207.266757 seconds
Generation ──  68.614190 seconds 33.1043%
Execution ───  25.922133 seconds 12.5067%
Output ────── 112.730434 seconds 54.3891%
    LINK usr/lib/julia/sys.dylib
```