### PR TITLE
docs: Fix stale description

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -130,7 +130,7 @@ kw"__init__"
     baremodule
 
 `baremodule` declares a module that does not contain `using Base` or local definitions of
-[`eval`](@ref Base.eval) and [`include`](@ref Base.include). It does still import `Core`. In other words,
+[`eval`](@ref Base.Main.include) and [`include`](@ref Base.include). It does still import `Core`. In other words,
 
 ```julia
 module Mod
@@ -182,8 +182,8 @@ kw"primitive type"
 A macro maps a sequence of argument expressions to a returned expression, and the
 resulting expression is substituted directly into the program at the point where
 the macro is invoked.
-Macros are a way to run generated code without calling [`eval`](@ref Base.eval), since the generated
-code instead simply becomes part of the surrounding program.
+Macros are a way to run generated code without calling [`eval`](@ref Base.MainInclude.eval),
+since the generated code instead simply becomes part of the surrounding program.
 Macro arguments may include expressions, literal values, and symbols. Macros can be defined for
 variable number of arguments (varargs), but do not accept keyword arguments.
 Every macro also implicitly gets passed the arguments `__source__`, which contains the line number

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -130,7 +130,7 @@ kw"__init__"
     baremodule
 
 `baremodule` declares a module that does not contain `using Base` or local definitions of
-[`eval`](@ref Base.Main.include) and [`include`](@ref Base.include). It does still import `Core`. In other words,
+[`eval`](@ref Base.MainInclude.eval) and [`include`](@ref Base.include). It does still import `Core`. In other words,
 
 ```julia
 module Mod

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -158,7 +158,7 @@ executes it.
 
 [`Base._start`](https://github.com/JuliaLang/julia/blob/master/base/client.jl) calls [`Base.exec_options`](https://github.com/JuliaLang/julia/blob/master/base/client.jl)
 which calls [`jl_parse_input_line("println("Hello World!")")`](https://github.com/JuliaLang/julia/blob/master/src/ast.c)
-to create an expression object and [`Core.eval(Main, ex)`](@ref Core.eval) to execute the parsed expression `ex` in the module context of `Main`.
+to create an expression object and [`Core.eval(Main, ex)`](@ref eval) to execute the parsed expression `ex` in the module context of `Main`.
 
 ## `Core.eval`
 

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -14,7 +14,7 @@ and [Legacy `ios.c` library](@ref)).
 
 Next [`jl_parse_opts()`](https://github.com/JuliaLang/julia/blob/master/src/jloptions.c) is called to process
 command line options. Note that `jl_parse_opts()` only deals with options that affect code generation
-or early initialization. Other options are handled later by [`process_options()` in `base/client.jl`](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
+or early initialization. Other options are handled later by [`exec_options()` in `base/client.jl`](https://github.com/JuliaLang/julia/blob/master/base/client.jl).
 
 `jl_parse_opts()` stores command line options in the [global `jl_options` struct](https://github.com/JuliaLang/julia/blob/master/src/julia.h).
 
@@ -156,7 +156,7 @@ executes it.
 
 ## `Base._start`
 
-[`Base._start`](https://github.com/JuliaLang/julia/blob/master/base/client.jl) calls [`Base.process_options`](https://github.com/JuliaLang/julia/blob/master/base/client.jl)
+[`Base._start`](https://github.com/JuliaLang/julia/blob/master/base/client.jl) calls [`Base.exec_options`](https://github.com/JuliaLang/julia/blob/master/base/client.jl)
 which calls [`jl_parse_input_line("println("Hello World!")")`](https://github.com/JuliaLang/julia/blob/master/src/ast.c)
 to create an expression object and [`Core.eval(Main, ex)`](@ref Core.eval) to execute the parsed expression `ex` in the module context of `Main`.
 

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -158,11 +158,11 @@ executes it.
 
 [`Base._start`](https://github.com/JuliaLang/julia/blob/master/base/client.jl) calls [`Base.exec_options`](https://github.com/JuliaLang/julia/blob/master/base/client.jl)
 which calls [`jl_parse_input_line("println("Hello World!")")`](https://github.com/JuliaLang/julia/blob/master/src/ast.c)
-to create an expression object and [`Core.eval(Main, ex)`](@ref eval) to execute the parsed expression `ex` in the module context of `Main`.
+to create an expression object and [`Core.eval(Main, ex)`](@ref Core.eval) to execute the parsed expression `ex` in the module context of `Main`.
 
 ## `Core.eval`
 
-[`Core.eval(Main, ex)`](@ref eval) calls [`jl_toplevel_eval_in(m, ex)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c),
+[`Core.eval(Main, ex)`](@ref Core.eval) calls [`jl_toplevel_eval_in(m, ex)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c),
 which calls [`jl_toplevel_eval_flex`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c).
 `jl_toplevel_eval_flex` implements a simple heuristic to decide whether to compile a given code thunk or run it by interpreter.
 When given `println("Hello World!")`, it would usually decide to run the code by interpreter, in which case it calls
@@ -210,7 +210,7 @@ Hello World!
 | `jl_interpret_toplevel_thunk`  | `interpreter.c` |                                                      |
 | `jl_toplevel_eval_flex`        | `toplevel.c`    |                                                      |
 | `jl_toplevel_eval_in`          | `toplevel.c`    |                                                      |
-| `eval`                         | `boot.jl`       |                                                      |
+| `Core.eval`                    | `boot.jl`       |                                                      |
 
 Since our example has just one function call, which has done its job of printing "Hello World!",
 the stack now rapidly unwinds back to `main()`.

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -170,7 +170,7 @@ where `ex` is the parsed expression `println("Hello World!")`.
 
 [`jl_toplevel_eval_in()`](https://github.com/JuliaLang/julia/blob/master/src/builtins.c) calls
 [`jl_toplevel_eval_flex()`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c) which
-calls [`eval()` in `interpreter.c`](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
+calls [`eval_body()` in `interpreter.c`](https://github.com/JuliaLang/julia/blob/master/src/interpreter.c).
 
 The stack dump below shows how the interpreter works its way through various methods of [`Base.println()`](@ref)
 and [`Base.print()`](@ref) before arriving at [`write(s::IO, a::Array{T}) where T`](https://github.com/JuliaLang/julia/blob/master/base/stream.jl)
@@ -209,7 +209,7 @@ Hello World!
 | `jl_apply_generic()`           | `gf.c`          | `Base.println(String,)`                              |
 | `jl_apply()`                   | `julia.h`       |                                                      |
 | `do_call()`                    | `interpreter.c` |                                                      |
-| `eval()`                       | `interpreter.c` |                                                      |
+| `eval_body()`                  | `interpreter.c` |                                                      |
 | `jl_interpret_toplevel_expr()` | `interpreter.c` |                                                      |
 | `jl_toplevel_eval_flex()`      | `toplevel.c`    |                                                      |
 | `jl_toplevel_eval()`           | `toplevel.c`    |                                                      |

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -209,7 +209,7 @@ Hello World!
 | `eval_body()`                  | `interpreter.c` |                                                      |
 | `jl_interpret_toplevel_thunk`  | `interpreter.c` |                                                      |
 | `jl_toplevel_eval_flex`        | `toplevel.c`    |                                                      |
-| `jl_toplevel_eval_in`          | `builtins.c`    |                                                      |
+| `jl_toplevel_eval_in`          | `toplevel.c`    |                                                      |
 | `eval`                         | `boot.jl`       |                                                      |
 
 Since our example has just one function call, which has done its job of printing "Hello World!",

--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -162,7 +162,7 @@ to create an expression object and [`Core.eval(Main, ex)`](@ref eval) to execute
 
 ## `Core.eval`
 
-[`Core.eval(Main, ex)`](@ref Core.eval) calls [`jl_toplevel_eval_in(m, ex)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c),
+[`Core.eval(Main, ex)`](@ref eval) calls [`jl_toplevel_eval_in(m, ex)`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c),
 which calls [`jl_toplevel_eval_flex`](https://github.com/JuliaLang/julia/blob/master/src/toplevel.c).
 `jl_toplevel_eval_flex` implements a simple heuristic to decide whether to compile a given code thunk or run it by interpreter.
 When given `println("Hello World!")`, it would usually decide to run the code by interpreter, in which case it calls


### PR DESCRIPTION
I found `eval()` function is deleted and replaced with `eval_body()` now.