### PR TITLE
Profile: use more heuristics to identify block ends

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -521,12 +521,7 @@ function fetch(;include_meta = false)
     if include_meta || isempty(data)
         return data
     else
-        nblocks = 0
-        for i = 2:length(data)
-            if is_block_end(data, i) # detect block ends and count them
-                nblocks += 1
-            end
-        end
+        nblocks = count(i -> is_block_end(data, i), eachindex(data))
         data_stripped = Vector{UInt}(undef, length(data) - (nblocks * (nmeta + 1)))
         j = length(data_stripped)
         i = length(data)
@@ -538,7 +533,7 @@ function fetch(;include_meta = false)
             i -= 1
             j -= 1
         end
-        @assert i == j == 0 "metadata stripping failed i=$i j=$j data[1:i]=$(data[1:i])"
+        i == j == 0 || @warn "Unexpected block ends found while stripping profiling metadata. Stack traces may be malformed"
         return data_stripped
     end
 end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -291,9 +291,13 @@ end
 
 function is_block_end(data, i)
     i < nmeta + 1 && return false
-    # 32-bit linux has been seen to have rogue NULL ips, so we use two to indicate block end, where the 2nd is the
-    # actual end index
-    return data[i] == 0 && data[i - 1] == 0
+    # double nulls have been seen to occur in the stack ips (#42292)
+    # so check for double nulls and two other narrow heuristics
+    data[i] != 0 && return false
+    data[i - 1] != 0 && return false
+    !in(data[i - 2], 1:2) && return false
+    !in(data[i - 5], 1:Threads.nthreads()) && return false
+    return true
 end
 
 """


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/42292

```
julia> using PropCheck, Profile

julia> iExample = igen(UInt8(100));

julia> l = PropCheck.vector(11, iExample);

julia> @profile check(issorted, l);
┌ Info: Found counterexample for 'issorted', beginning shrinking...
└   t = Tree(UInt8[0x3a, 0x0a, 0x31, 0x02, 0x0f, 0x20, 0x64, 0x2c, 0x1f, 0x62, 0x21])

julia> Profile.fetch()
681627-element Vector{UInt64}:
 0x00007f13eab2e374
 0x00007f13ea2cfcc7
 0x00007f13ea1d9af3
 0x00007f13d5bb6f23
 0x00007f13d5c06fae
...
```

Performance doesn't seem significantly affected by this
Master
```
julia> @profile sleep(4)

julia> @btime Profile.fetch();
  1.568 ms (4 allocations: 10.94 MiB)

julia> length(Profile.fetch())
607253
```
This PR
```
julia> @profile sleep(4)

julia> @btime Profile.fetch();
  1.667 ms (4 allocations: 11.59 MiB)

julia> length(Profile.fetch())
642937
```
cc. @Seelengrab