### PR TITLE
Remove buffer pool for tiled GEMM

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -586,9 +586,6 @@ function __init__()
             BLAS.lbt_forward(liblapack_path)
         end
         BLAS.check()
-        Threads.resize_nthreads!(Abuf)
-        Threads.resize_nthreads!(Bbuf)
-        Threads.resize_nthreads!(Cbuf)
     catch ex
         Base.showerror_nostdio(ex, "WARNING: Error during initialization of module LinearAlgebra")
     end

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -726,10 +726,6 @@ function generic_matmatmul(tA, tB, A::AbstractVecOrMat{T}, B::AbstractMatrix{S})
 end
 
 const tilebufsize = 10800  # Approximately 32k/3
-# per-thread arrays of buffers resized by __init__ if needed
-const Abuf = [Vector{UInt8}(undef, tilebufsize)]
-const Bbuf = [Vector{UInt8}(undef, tilebufsize)]
-const Cbuf = [Vector{UInt8}(undef, tilebufsize)]
 
 function generic_matmatmul!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
                             _add::MulAddMul=MulAddMul())
@@ -775,9 +771,8 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
     @inbounds begin
     if tile_size > 0
         sz = (tile_size, tile_size)
-        # FIXME: This code is completely invalid!!!
-        Atile = unsafe_wrap(Array, convert(Ptr{T}, pointer(Abuf[Threads.threadid()])), sz)
-        Btile = unsafe_wrap(Array, convert(Ptr{S}, pointer(Bbuf[Threads.threadid()])), sz)
+        Atile = Array{T}(undef, sz)
+        Btile = Array{S}(undef, sz)
 
         z1 = zero(A[1, 1]*B[1, 1] + A[1, 1]*B[1, 1])
         z = convert(promote_type(typeof(z1), R), z1)
@@ -797,8 +792,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                 end
             end
         else
-            # FIXME: This code is completely invalid!!!
-            Ctile = unsafe_wrap(Array, convert(Ptr{R}, pointer(Cbuf[Threads.threadid()])), sz)
+            Ctile = Array{R}(undef, sz)
             for jb = 1:tile_size:nB
                 jlim = min(jb+tile_size-1,nB)
                 jlen = jlim-jb+1


### PR DESCRIPTION
This PR is an RFC for removing the pooled buffer for the generic tiled matrix multiplication. The current implementation has several issues and a quick benchmark does not suggest that allocation and/or GC are the bottleneck.

### Issue 1: Reentrancy

Inside of `_generic_matmatmul!`, we have the check

https://github.com/JuliaLang/julia/blob/eb83c4d25b9c4a3696c08d2b5c7debfa9cc1a5ae/stdlib/LinearAlgebra/src/matmul.jl#L771-L776

which then uses pre-allocated arrays

https://github.com/JuliaLang/julia/blob/eb83c4d25b9c4a3696c08d2b5c7debfa9cc1a5ae/stdlib/LinearAlgebra/src/matmul.jl#L728-L732

via

https://github.com/JuliaLang/julia/blob/eb83c4d25b9c4a3696c08d2b5c7debfa9cc1a5ae/stdlib/LinearAlgebra/src/matmul.jl#L779-L780

I think the major and practical issue here is that `isbitstype` is not enough for ensuring no-reentrancy of `*` (so that the buffers are not re-used by multiple functions). I can quite easily define arbitrary large matrix with small `isbitstype`

```julia
struct LargeMatrix <: AbstractMatrix{Flaot64}
    id::UInt64
end

const MTARICES = Dict{UInt64,Matrix{Float64}}()

Base.getindex(m::LargeMatrix, i::Int, j::Int) = MATRICES[m.id][i, j]
```

This example is rather silly but it's conceivable to have a Julia wrapper of externally managed matrices that is just a `Ptr{Cvoid}` as a Julia object. If these `isbits`-but-large matrices are used in nested/blocked matrices, the current implementation can corrupt the result.

### Issue 2: `@async`- and `@spawn`-safety

A method of `*` can `yield` (e.g., a wrapper type that dumps all operations in a file). We then have the same problem as the reentrancy.

Furthermore, if the current task is a `@spawn`ed task, it can be migrated to another worker thread upon a `yield`.

### Issue 3: `nthreads` may not be constant in the future

After a change in the scheduler like #42302, it will be impossible to rely on that `nthreads` does not change after `julia` is started. Supporting a pattern like this would also require a proper "static" initialization API (e.g., using the double checked locking pattern).

### Issue 4: GC

Also, as noted in #23914, this code also has a problem due to missing `GC.@preserve`.

### Performance impact

It also seems that the allocation is not the bottleneck. For large enough input that the tiling matters, the effect of allocation/GC is not observable. For small matrices where you can see the effect of GC, it's faster to not use the tiled version.

```julia
A = randn(n, n)
B = randn(n, n)
C = similar(A)
@btime LinearAlgebra.generic_matmatmul!(C, 'N', 'N', A, B)
```

shows

|         | After PR | No tile  | Before PR |
| --- | --- | --- | --- |
| n = 500 | 82.1 ms | 109.9 ms | 81.3 ms |
| n = 10 | 1.070 μs | 510.361 ns | 770.266 ns |

"No tile" means applying this diff

```diff
diff --git a/stdlib/LinearAlgebra/src/matmul.jl b/stdlib/LinearAlgebra/src/matmul.jl
index 0cbfeaf9ed..b4ff0c0c5a 100644
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -768,6 +768,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
     if isbitstype(R) && isbitstype(T) && isbitstype(S) && (tA == 'N' || tB != 'N')
         tile_size = floor(Int, sqrt(tilebufsize / max(sizeof(R), sizeof(S), sizeof(T), 1)))
     end
+    tile_size = 0
     @inbounds begin
     if tile_size > 0
         sz = (tile_size, tile_size)
```
