### PR TITLE
Slightly loosen a test so that linalg tests pass when using MKL

### DIFF
--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -152,7 +152,7 @@ end
     for vf in (copy(vvf), view(vvf, 1:3)), C in (copy(CC), view(CC, 1:3, 1:3))
         @test mul!(C, vf, transpose(vf)) == vf*vf'
         C .= C0 = rand(eltype(C), size(C))
-        @test mul!(C, vf, transpose(vf), 2, 3) == 2vf*vf' .+ 3C0
+        @test mul!(C, vf, transpose(vf), 2, 3) ≈ 2vf*vf' .+ 3C0
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLinearAlgebra/MKL.jl/issues/88

The MKL.jl tests have now been updated to run the entire LinearAlgebra test suite. Thus, when PkgEval runs its tests, it will be nice to see that MKL.jl tests fully pass. In order for that to happen, we want to have this PR merged and included in 1.7 as well (in the next RC).