### PR TITLE
Use mul! in Diagonal*Matrix

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -12,9 +12,9 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     asin, asinh, atan, atanh, axes, big, broadcast, ceil, cis, conj, convert, copy, copyto!, cos,
     cosh, cot, coth, csc, csch, eltype, exp, fill!, floor, getindex, hcat,
     getproperty, imag, inv, isapprox, isequal, isone, iszero, IndexStyle, kron, kron!, length, log, map, ndims,
-    oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
+    one, oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, sqrt,
-    strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
+    strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec, zero
 using Base: IndexLinear, promote_eltype, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_hvcat, typed_vcat, require_one_based_indexing,
     splat

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -331,7 +331,7 @@ end
     if iszero(beta)
         out.diag .= (D1.diag .* D2.diag) .*ₛ alpha
     else
-        out.diag .= (D1.diag .* D2.diag) .*ₛ alpha .+ out .* beta
+        out.diag .= (D1.diag .* D2.diag) .*ₛ alpha .+ out.diag .* beta
     end
     return out
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -219,6 +219,11 @@ end
 (*)(D::Diagonal, B::AbstractTriangular) =
     lmul!(D, copy_oftype(B, promote_op(*, eltype(B), eltype(D.diag))))
 
+(*)(A::AbstractMatrix{<:Number}, D::Diagonal{<:Number}) =
+    mul!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A, D)
+(*)(D::Diagonal{<:Number}, A::AbstractMatrix{<:Number}) =
+    mul!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), D, A)
+
 (*)(A::AbstractMatrix, D::Diagonal) =
     rmul!(copy_similar(A, promote_op(*, eltype(A), eltype(D.diag))), D)
 (*)(D::Diagonal, A::AbstractMatrix) =

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -226,14 +226,22 @@ end
 function (*)(A::AbstractMatrix, D::Diagonal)
     Tdest = promote_op(*, eltype(A), eltype(D.diag))
     if eltype(A) <: Number && eltype(D) <: Number
-        return mul!(similar(A, Tdest), A, D)
+        nA, nD = size(A, 2), length(D.diag)
+        if nA != nD
+            throw(DimensionMismatch("second dimension of A, $nA, does not match the first of D, $nD"))
+        end
+        return mul!(similar(A, Tdest, size(A)), A, D)
     end
     return rmul!(copy_similar(A, Tdest), D)
 end
 function (*)(D::Diagonal, A::AbstractMatrix)
     Tdest = promote_op(*, eltype(A), eltype(D.diag))
     if eltype(A) <: Number && eltype(D) <: Number
-        return mul!(similar(A, Tdest), D, A)
+        nA, nD = size(A, 1), length(D.diag)
+        if nA != nD
+            throw(DimensionMismatch("second dimension of D, $nD, does not match the first of B, $nA"))
+        end
+        return mul!(similar(A, Tdest, size(A)), D, A)
     end
     return lmul!(D, copy_similar(A, Tdest))
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -232,7 +232,6 @@ function (*)(D::Diagonal, V::AbstractVector)
     return D.diag .* V
 end
 
-# These methods are needed for ambiguity resolution
 (*)(A::AbstractTriangular, D::Diagonal) =
     rmul!(copy_oftype(A, promote_op(*, eltype(A), eltype(D.diag))), D)
 (*)(D::Diagonal, B::AbstractTriangular) =
@@ -330,18 +329,18 @@ lmul!(A::Diagonal, B::Diagonal) = Diagonal(B.diag .= A.diag .* B.diag)
 
 @inline function __muldiag!(out, D::Diagonal, B, alpha, beta)
     if iszero(beta)
-        out .= D.diag .* B .* alpha
+        out .= (D.diag .* B) .*ₛ alpha
     else
-        out .= D.diag .* B .* alpha .+ out .* beta
+        out .= (D.diag .* B) .*ₛ alpha .+ out .* beta
     end
     return out
 end
 
 @inline function __muldiag!(out, A, D::Diagonal, alpha, beta)
     if iszero(beta)
-        out .= A .* permutedims(D.diag) .* alpha
+        out .= (A .* permutedims(D.diag)) .*ₛ alpha
     else
-        out .= A .* permutedims(D.diag) .* alpha .+ out .* beta
+        out .= (A .* permutedims(D.diag)) .*ₛ alpha .+ out .* beta
     end
     return out
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -140,10 +140,7 @@ real(D::Diagonal) = Diagonal(real(D.diag))
 imag(D::Diagonal) = Diagonal(imag(D.diag))
 
 iszero(D::Diagonal) = all(iszero, D.diag)
-zero(D::Diagonal) = Diagonal(zero.(D.diag))
 isone(D::Diagonal) = all(isone, D.diag)
-one(D::Diagonal) = Diagonal(one.(D.diag))
-oneunit(D::Diagonal) = Diagonal(oneunit.(D.diag))
 isdiag(D::Diagonal) = all(isdiag, D.diag)
 isdiag(D::Diagonal{<:Number}) = true
 istriu(D::Diagonal, k::Integer=0) = k <= 0 || iszero(D.diag) ? true : false

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -143,6 +143,7 @@ iszero(D::Diagonal) = all(iszero, D.diag)
 zero(D::Diagonal) = Diagonal(zero.(D.diag))
 isone(D::Diagonal) = all(isone, D.diag)
 one(D::Diagonal) = Diagonal(one.(D.diag))
+oneunit(D::Diagonal) = Diagonal(oneunit.(D.diag))
 isdiag(D::Diagonal) = all(isdiag, D.diag)
 isdiag(D::Diagonal{<:Number}) = true
 istriu(D::Diagonal, k::Integer=0) = k <= 0 || iszero(D.diag) ? true : false

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -208,15 +208,15 @@ function _muldiag_size_check(A, B)
 end
 function _muldiag_size_check(C, A, B)
     _muldiag_size_check(A, B)
-    @noinline throw_dimerr(::AbstractMatrix, szC, szA) = throw(DimensionMismatch("output matrix has size: $szC, but should have size $szA"))
-    @noinline throw_dimerr(::AbstractVector, szC, szA) = throw(DimensionMismatch("output matrix has size: $szC, but should have size $szA"))
+    # the output matrix should have the same size as the non-diagonal input matrix or vector
+    @noinline throw_dimerr(szC, szA) = throw(DimensionMismatch("output matrix has size: $szC, but should have size $szA"))
     _size_check_out(C, ::Diagonal, A) = _size_check_out(C, A)
     _size_check_out(C, A, ::Diagonal) = _size_check_out(C, A)
     _size_check_out(C, A::Diagonal, ::Diagonal) = _size_check_out(C, A)
     function _size_check_out(C, A)
         szA = size(A)
         szC = size(C)
-        szA == szC || throw_dimerr(B, szC, szA)
+        szA == szC || throw_dimerr(szC, szA)
         return nothing
     end
     _size_check_out(C, A, B)
@@ -345,7 +345,7 @@ end
     end
     return out
 end
-
+# only needed for ambiguity resolution, as mul! is explicitly defined for these arguments
 @inline __muldiag!(out, D1::Diagonal, D2::Diagonal, alpha, beta) =
     mul!(out, D1, D2, alpha, beta)
 
@@ -354,7 +354,6 @@ end
     __muldiag!(out, A, B, alpha, beta)
     return out
 end
-@inline _muldiag!(out, A::Diagonal, B::Diagonal, alpha, beta) = _muldiag!(out, A, B, alpha, beta)
 
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
 @inline mul!(out::AbstractVector, D::Diagonal, V::AbstractVector, alpha::Number, beta::Number) =

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -372,21 +372,21 @@ end
 @inline _muldiag!(out, A::Diagonal, B::Diagonal, alpha, beta) = _muldiag!(out, A, B, alpha, beta)
 
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
-@inline mul!(out::AbstractVector, A::Diagonal, in::AbstractVector, alpha::Number, beta::Number) =
-    _muldiag!(out, A, in, alpha, beta)
-@inline mul!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix, alpha::Number, beta::Number) =
-    _muldiag!(out, A, in, alpha, beta)
-@inline mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:AbstractVecOrMat},
-             alpha::Number, beta::Number) = _muldiag!(out, A, in, alpha, beta)
-@inline mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:AbstractVecOrMat},
-             alpha::Number, beta::Number) = _muldiag!(out, A, in, alpha, beta)
+@inline mul!(out::AbstractVector, D::Diagonal, V::AbstractVector, alpha::Number, beta::Number) =
+    _muldiag!(out, D, V, alpha, beta)
+@inline mul!(out::AbstractMatrix, D::Diagonal, B::AbstractMatrix, alpha::Number, beta::Number) =
+    _muldiag!(out, D, B, alpha, beta)
+@inline mul!(out::AbstractMatrix, D::Diagonal, B::Adjoint{<:Any,<:AbstractVecOrMat},
+             alpha::Number, beta::Number) = _muldiag!(out, D, B, alpha, beta)
+@inline mul!(out::AbstractMatrix, D::Diagonal, B::Transpose{<:Any,<:AbstractVecOrMat},
+             alpha::Number, beta::Number) = _muldiag!(out, D, B, alpha, beta)
 
-@inline mul!(out::AbstractMatrix, in::AbstractMatrix, A::Diagonal, alpha::Number, beta::Number) =
-    _muldiag!(out, in, A, alpha, beta)
-@inline mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:AbstractVecOrMat}, A::Diagonal,
-             alpha::Number, beta::Number) = _muldiag!(out, in, A, alpha, beta)
-@inline mul!(out::AbstractMatrix, in::Transpose{<:Any,<:AbstractVecOrMat}, A::Diagonal,
-             alpha::Number, beta::Number) = _muldiag!(out, in, A, alpha, beta)
+@inline mul!(out::AbstractMatrix, A::AbstractMatrix, D::Diagonal, alpha::Number, beta::Number) =
+    _muldiag!(out, A, D, alpha, beta)
+@inline mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:AbstractVecOrMat}, D::Diagonal,
+             alpha::Number, beta::Number) = _muldiag!(out, A, D, alpha, beta)
+@inline mul!(out::AbstractMatrix, A::Transpose{<:Any,<:AbstractVecOrMat}, D::Diagonal,
+             alpha::Number, beta::Number) = _muldiag!(out, A, D, alpha, beta)
 
 function mul!(C::AbstractMatrix, Da::Diagonal, Db::Diagonal, alpha::Number, beta::Number)
     mA = size(Da, 1)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -226,6 +226,7 @@ end
 function (*)(A::AbstractMatrix, D::Diagonal)
     Tdest = promote_op(*, eltype(A), eltype(D.diag))
     if eltype(A) <: Number && eltype(D) <: Number
+        Base.require_one_based_indexing(A)
         nA, nD = size(A, 2), length(D.diag)
         if nA != nD
             throw(DimensionMismatch("second dimension of A, $nA, does not match the first of D, $nD"))
@@ -237,6 +238,7 @@ end
 function (*)(D::Diagonal, A::AbstractMatrix)
     Tdest = promote_op(*, eltype(A), eltype(D.diag))
     if eltype(A) <: Number && eltype(D) <: Number
+        Base.require_one_based_indexing(A)
         nA, nD = size(A, 1), length(D.diag)
         if nA != nD
             throw(DimensionMismatch("second dimension of D, $nD, does not match the first of B, $nA"))

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -219,6 +219,9 @@ end
 (*)(D::Diagonal, B::AbstractTriangular) =
     lmul!(D, copy_oftype(B, promote_op(*, eltype(B), eltype(D.diag))))
 
+# Using mul! instead of (l/r)mul! provides a performance boost by avoiding a copy.
+# This is not possible in general, but works if the elements are numbers
+# See #42321
 (*)(A::AbstractMatrix{<:Number}, D::Diagonal{<:Number}) =
     mul!(similar(A, promote_op(*, eltype(A), eltype(D.diag))), A, D)
 (*)(D::Diagonal{<:Number}, A::AbstractMatrix{<:Number}) =

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -328,38 +328,23 @@ end
 rmul!(A::Diagonal, B::Diagonal) = Diagonal(A.diag .*= B.diag)
 lmul!(A::Diagonal, B::Diagonal) = Diagonal(B.diag .= A.diag .* B.diag)
 
-@inline __muldiag!(out, D::Diagonal, B) = out .= D.diag .* B
-@inline __muldiag!(out, A, D::Diagonal) = out .= A .* permutedims(D.diag)
-@inline __muldiag!(out, D1::Diagonal, D2::Diagonal) = mul!(out, D1, D2, true, false)
-@inline function _muldiag!(out, A, B)
-    _muldiag_size_check(out, A, B)
-    __muldiag!(out, A, B)
+@inline function __muldiag!(out, D::Diagonal, B, alpha, beta)
+    if iszero(beta)
+        out .= D.diag .* B .* alpha
+    else
+        out .= D.diag .* B .* alpha .+ out .* beta
+    end
     return out
 end
-@inline _muldiag!(out, D1::Diagonal, D2::Diagonal) = __muldiag!(out, D1, D2)
 
-@inline mul!(out::AbstractMatrix, Da::Diagonal, Db::Diagonal) = _muldiag!(out, Da, Db)
-
-@inline mul!(out::AbstractVector, A::Diagonal, B::AbstractVector) = _muldiag!(out, A, B)
-@inline mul!(out::AbstractMatrix, A::Diagonal, B::AbstractMatrix) = _muldiag!(out, A, B)
-@inline mul!(out::AbstractMatrix, A::Diagonal, B::Adjoint{<:Any,<:AbstractVecOrMat}) =
-    _muldiag!(out, A, B)
-@inline mul!(out::AbstractMatrix, A::Diagonal, B::Transpose{<:Any,<:AbstractVecOrMat}) =
-    _muldiag!(out, A, B)
-
-@inline mul!(out::AbstractMatrix, B::AbstractTriangular, D::Diagonal) =
-    _muldiag!(out, B, D)
-@inline mul!(out::AbstractMatrix, B::AbstractMatrix, D::Diagonal) = _muldiag!(out, B, D)
-@inline mul!(out::AbstractMatrix, B::Adjoint{<:Any,<:AbstractVecOrMat}, D::Diagonal) =
-    _muldiag!(out, B, D)
-@inline mul!(out::AbstractMatrix, B::Transpose{<:Any,<:AbstractVecOrMat}, D::Diagonal) =
-    _muldiag!(out, B, D)
-
-@inline __muldiag!(out, D::Diagonal, B, alpha, beta) =
-    out .= (D.diag .* B) .*ₛ alpha .+ out .*ₛ beta
-
-@inline __muldiag!(out, A, D::Diagonal, alpha, beta) =
-    out .= (A .* permutedims(D.diag)) .*ₛ alpha .+ out .*ₛ beta
+@inline function __muldiag!(out, A, D::Diagonal, alpha, beta)
+    if iszero(beta)
+        out .= A .* permutedims(D.diag) .* alpha
+    else
+        out .= A .* permutedims(D.diag) .* alpha .+ out .* beta
+    end
+    return out
+end
 
 @inline __muldiag!(out, D1::Diagonal, D2::Diagonal, alpha, beta) =
     mul!(out, D1, D2, alpha, beta)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -8,7 +8,8 @@
 # inside this function.
 function *ₛ end
 Broadcast.broadcasted(::typeof(*ₛ), out, beta) =
-    iszero(beta::Number) ? false : broadcasted(*, out, beta)
+    iszero(beta::Number) ? false :
+    isone(beta::Number) ? broadcasted(identity, out) : broadcasted(*, out, beta)
 
 """
     MulAddMul(alpha, beta)

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -308,12 +308,15 @@ function fill!(A::Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}, x)
     not be filled with $x, since some of its entries are constrained."))
 end
 
-one(A::Diagonal{T}) where T = Diagonal(fill!(similar(A.diag, typeof(one(T))), one(T)))
+one(D::Diagonal) = Diagonal(one.(D.diag))
 one(A::Bidiagonal{T}) where T = Bidiagonal(fill!(similar(A.dv, typeof(one(T))), one(T)), fill!(similar(A.ev, typeof(one(T))), zero(one(T))), A.uplo)
 one(A::Tridiagonal{T}) where T = Tridiagonal(fill!(similar(A.du, typeof(one(T))), zero(one(T))), fill!(similar(A.d, typeof(one(T))), one(T)), fill!(similar(A.dl, typeof(one(T))), zero(one(T))))
 one(A::SymTridiagonal{T}) where T = SymTridiagonal(fill!(similar(A.dv, typeof(one(T))), one(T)), fill!(similar(A.ev, typeof(one(T))), zero(one(T))))
 # equals and approx equals methods for structured matrices
 # SymTridiagonal == Tridiagonal is already defined in tridiag.jl
+
+zero(D::Diagonal) = Diagonal(zero.(D.diag))
+oneunit(D::Diagonal) = Diagonal(oneunit.(D.diag))
 
 # SymTridiagonal and Bidiagonal have the same field names
 ==(A::Diagonal, B::Union{SymTridiagonal, Bidiagonal}) = iszero(B.ev) && A.diag == B.dv

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -578,6 +578,23 @@ let D1 = Diagonal(rand(5)), D2 = Diagonal(rand(5))
     @test LinearAlgebra.lmul!(adjoint(D1),copy(D2)) == adjoint(D1)*D2
 end
 
+@testset "multiplication of a Diagonal with a Matrix" begin
+    A = collect(reshape(1:8, 4, 2));
+    B = BigFloat.(A);
+    DL = Diagonal(collect(axes(A, 1)));
+    DR = Diagonal(Float16.(collect(axes(A, 2))));
+
+    @test DL * A == collect(DL) * A
+    @test A * DR == A * collect(DR)
+    @test DL * B == collect(DL) * B
+    @test B * DR == B * collect(DR)
+
+    A = reshape([ones(2,2), ones(2,2)*2, ones(2,2)*3, ones(2,2)*4], 2, 2)
+    D = Diagonal([collect(reshape(1:4, 2, 2)), collect(reshape(5:8, 2, 2))])
+    @test A * D == collect(A) * collect(D)
+    @test D * A == collect(D) * collect(A)
+end
+
 @testset "multiplication of QR Q-factor and Diagonal (#16615 spot test)" begin
     D = Diagonal(randn(5))
     Q = qr(randn(5, 5)).Q

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -888,12 +888,18 @@ end
     D1 = Diagonal(rand(3))
     @test D1 + zero(D1) == D1
     @test D1 * one(D1) == D1
+    @test D1 * oneunit(D1) == D1
+    @test oneunit(D1) isa typeof(D1)
     D2 = Diagonal([collect(reshape(1:4, 2, 2)), collect(reshape(5:8, 2, 2))])
     @test D2 + zero(D2) == D2
     @test D2 * one(D2) == D2
+    @test D2 * oneunit(D2) == D2
+    @test oneunit(D2) isa typeof(D2)
     D3 = Diagonal([D2, D2]);
     @test D3 + zero(D3) == D3
     @test D3 * one(D3) == D3
+    @test D3 * oneunit(D3) == D3
+    @test oneunit(D3) isa typeof(D3)
 end
 
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -593,6 +593,10 @@ end
     D = Diagonal([collect(reshape(1:4, 2, 2)), collect(reshape(5:8, 2, 2))])
     @test A * D == collect(A) * collect(D)
     @test D * A == collect(D) * collect(A)
+
+    AS = similar(A)
+    mul!(AS, A, D, true, false)
+    @test AS == A * D
 end
 
 @testset "multiplication of QR Q-factor and Diagonal (#16615 spot test)" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -590,13 +590,27 @@ end
     @test B * DR == B * collect(DR)
 
     A = reshape([ones(2,2), ones(2,2)*2, ones(2,2)*3, ones(2,2)*4], 2, 2)
+    Ac = collect(A)
     D = Diagonal([collect(reshape(1:4, 2, 2)), collect(reshape(5:8, 2, 2))])
-    @test A * D == collect(A) * collect(D)
-    @test D * A == collect(D) * collect(A)
+    Dc = collect(D)
+    @test A * D == Ac * Dc
+    @test D * A == Dc * Ac
+    @test D * D == Dc * Dc
 
     AS = similar(A)
     mul!(AS, A, D, true, false)
     @test AS == A * D
+
+    D2 = similar(D)
+    mul!(D2, D, D)
+    @test D2 == D * D
+
+    D2[diagind(D2)] .= D[diagind(D)]
+    lmul!(D, D2)
+    @test D2 == D * D
+    D2[diagind(D2)] .= D[diagind(D)]
+    rmul!(D2, D)
+    @test D2 == D * D
 end
 
 @testset "multiplication of QR Q-factor and Diagonal (#16615 spot test)" begin
@@ -868,6 +882,18 @@ end
     B = Diagonal(rand(elty,5,5))
     x = rand(elty)
     @test \(x, B) == /(B, x)
+end
+
+@testset "zero and one" begin
+    D1 = Diagonal(rand(3))
+    @test D1 + zero(D1) == D1
+    @test D1 * one(D1) == D1
+    D2 = Diagonal([collect(reshape(1:4, 2, 2)), collect(reshape(5:8, 2, 2))])
+    @test D2 + zero(D2) == D2
+    @test D2 * one(D2) == D2
+    D3 = Diagonal([D2, D2]);
+    @test D3 + zero(D3) == D3
+    @test D3 * one(D3) == D3
 end
 
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -703,12 +703,35 @@ end
     xt = transpose(x)
     A = reshape([[1 2; 3 4], zeros(Int,2,2), zeros(Int, 2, 2), [5 6; 7 8]], 2, 2)
     D = Diagonal(A)
-    @test x'*D == x'*A == copy(x')*D == copy(x')*A
-    @test xt*D == xt*A == copy(xt)*D == copy(xt)*A
+    @test x'*D == x'*A == collect(x')*D == collect(x')*A
+    @test xt*D == xt*A == collect(xt)*D == collect(xt)*A
+    outadjxD = similar(x'*D); outtrxD = similar(xt*D);
+    mul!(outadjxD, x', D)
+    @test outadjxD == x'*D
+    mul!(outtrxD, xt, D)
+    @test outtrxD == xt*D
+
+    D1 = Diagonal([[1 2; 3 4]])
+    @test D1 * x' == D1 * collect(x') == collect(D1) * collect(x')
+    @test D1 * xt == D1 * collect(xt) == collect(D1) * collect(xt)
+    outD1adjx = similar(D1 * x'); outD1trx = similar(D1 * xt);
+    mul!(outadjxD, D1, x')
+    @test outadjxD == D1*x'
+    mul!(outtrxD, D1, xt)
+    @test outtrxD == D1*xt
+
     y = [x, x]
     yt = transpose(y)
     @test y'*D*y == (y'*D)*y == (y'*A)*y
     @test yt*D*y == (yt*D)*y == (yt*A)*y
+    outadjyD = similar(y'*D); outtryD = similar(yt*D);
+    outadjyD2 = similar(collect(y'*D)); outtryD2 = similar(collect(yt*D));
+    mul!(outadjyD, y', D)
+    mul!(outadjyD2, y', D)
+    @test outadjyD == outadjyD2 == y'*D
+    mul!(outtryD, yt, D)
+    mul!(outtryD2, yt, D)
+    @test outtryD == outtryD2 == yt*D
 end
 
 @testset "Multiplication of single element Diagonal (#36746, #40726)" begin


### PR DESCRIPTION
This provides a performance boost for matrices of numbers. See [the discourse post](https://discourse.julialang.org/t/possible-speedup-in-matrix-diagonal-products/68474)

On master
```julia
julia> A = ones(3000, 2000); DR = Diagonal(ones(size(A, 2))); DL = Diagonal(ones(size(A,1)));

julia> @btime $A * $DR;
  41.844 ms (4 allocations: 45.78 MiB)

julia> @btime $DL * $A;
  42.521 ms (2 allocations: 45.78 MiB)
```

After this PR

```julia
julia> @btime $A * $DR;
  28.670 ms (4 allocations: 45.78 MiB)

julia> @btime $DL * $A;
  29.377 ms (2 allocations: 45.78 MiB)
```