### PR TITLE
[clangsa] write a checker for implicit seq_cst atomics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: debug release
 # sort is used to remove potential duplicates
 DIRS := $(sort $(build_bindir) $(build_depsbindir) $(build_libdir) $(build_private_libdir) $(build_libexecdir) $(build_includedir) $(build_includedir)/julia $(build_sysconfdir)/julia $(build_datarootdir)/julia $(build_datarootdir)/julia/stdlib $(build_man1dir))
 ifneq ($(BUILDROOT),$(JULIAHOME))
-BUILDDIRS := $(BUILDROOT) $(addprefix $(BUILDROOT)/,base src src/flisp src/support src/clangsa cli doc deps stdlib test test/embedding test/llvmpasses)
+BUILDDIRS := $(BUILDROOT) $(addprefix $(BUILDROOT)/,base src src/flisp src/support src/clangsa cli doc deps stdlib test test/clangsa test/embedding test/llvmpasses)
 BUILDDIRMAKE := $(addsuffix /Makefile,$(BUILDDIRS)) $(BUILDROOT)/sysimage.mk
 DIRS := $(DIRS) $(BUILDDIRS)
 $(BUILDDIRMAKE): | $(BUILDDIRS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -355,7 +355,7 @@ clean-support:
 
 cleanall: clean clean-flisp clean-support clean-analyzegc
 
-$(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/GCChecker.cpp $(LLVM_CONFIG_ABSOLUTE)
+$(build_shlibdir)/lib%Plugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/%.cpp $(LLVM_CONFIG_ABSOLUTE)
 	@$(call PRINT_CC, $(CXX) -g $(fPIC) -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) -L$(build_libdir) \
 		$(LLVM_CXXFLAGS) $(CLANG_LDFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(CXXLDFLAGS) $<)
 
@@ -374,26 +374,36 @@ ifneq ($(BUILD_LLVM_CLANG),1)
 endif
 endif
 
-clangsa: $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
+clangsa: $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
 
 clang-sagc-%: $(SRCDIR)/%.c $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
-	@$(call PRINT_ANALYZE, $(build_bindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) $(CLANGSA_FLAGS) $(JCPPFLAGS) $(JCFLAGS) $(DEBUGFLAGS)  -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $<)
+	@$(call PRINT_ANALYZE, $(build_bindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text --analyzer-no-default-checks \
+		-Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
+		$(CLANGSA_FLAGS) $(JCPPFLAGS) $(JCFLAGS) $(DEBUGFLAGS) -fcolor-diagnostics -Werror -x c $<)
 clang-sagc-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
-	@$(call PRINT_ANALYZE, $(build_bindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) $(CLANGSA_FLAGS) $(CLANGSA_CXXFLAGS) $(LLVM_CXXFLAGS) $(JCPPFLAGS) $(JCXXFLAGS) $(DEBUGFLAGS) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c++ $<)
+	@$(call PRINT_ANALYZE, $(build_bindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text --analyzer-no-default-checks \
+		-Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
+		$(CLANGSA_FLAGS) $(CLANGSA_CXXFLAGS) $(LLVM_CXXFLAGS) $(JCPPFLAGS) $(JCXXFLAGS) $(DEBUGFLAGS) -fcolor-diagnostics -Werror -x c++ $<)
 
  # optarg is a required_argument for these
 SA_EXCEPTIONS-jloptions.c                   := -Xanalyzer -analyzer-disable-checker=core.NonNullParamChecker,unix.cstring.NullArg
  # clang doesn't understand that e->vars has the same value in save_env (NULL) and restore_env (assumed non-NULL)
 SA_EXCEPTIONS-subtype.c                     := -Xanalyzer -analyzer-disable-checker=core.uninitialized.Assign,core.UndefinedBinaryOperatorResult
+ # these need to be annotated (and possibly fixed)
+SKIP_IMPLICIT_ATOMICS := dump.c gf.c jitlayers.cpp module.c precompile.c rtutils.c staticdata.c toplevel.c codegen.cpp
 
-clang-sa-%: $(SRCDIR)/%.c .FORCE | analyzegc-deps-check
+clang-sa-%: $(SRCDIR)/%.c $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_bindir)/clang --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text \
+		$(if $(findstring $(notdir $<),$(SKIP_IMPLICIT_ATOMICS)),,-Xclang -load -Xclang $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=julia.ImplicitAtomics) \
 		-Xanalyzer -analyzer-disable-checker=deadcode.DeadStores \
+		 --analyzer-no-default-checks  \
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANGSA_FLAGS) $(JCPPFLAGS) $(JCFLAGS) $(DEBUGFLAGS) -fcolor-diagnostics -Werror -x c $<)
-clang-sa-%: $(SRCDIR)/%.cpp .FORCE | analyzegc-deps-check
+clang-sa-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_bindir)/clang --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text \
+		$(if $(findstring $(notdir $<),$(SKIP_IMPLICIT_ATOMICS)),,-Xclang -load -Xclang $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=julia.ImplicitAtomics) \
 		-Xanalyzer -analyzer-disable-checker=deadcode.DeadStores \
+		 --analyzer-no-default-checks  \
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANGSA_FLAGS) $(CLANGSA_CXXFLAGS) $(LLVM_CXXFLAGS) $(JCPPFLAGS) $(JCXXFLAGS) $(DEBUGFLAGS) -fcolor-diagnostics -Werror -x c++ $<)
 
@@ -404,6 +414,7 @@ analyzegc: analyzesrc $(addprefix clang-sagc-,$(RUNTIME_SRCS))
 
 clean-analyzegc:
 	rm -f $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
+	rm -f $(build_shlibdir)/libImplicitAtomicsPlugin.$(SHLIB_EXT)
 
 .FORCE:
 .PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony analyzegc analyzesrc .FORCE

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1761,7 +1761,9 @@ static void add_builtin(const char *name, jl_value_t *v)
 jl_fptr_args_t jl_get_builtin_fptr(jl_value_t *b)
 {
     assert(jl_isa(b, (jl_value_t*)jl_builtin_type));
-    return ((jl_typemap_entry_t*)jl_gf_mtable(b)->cache)->func.linfo->cache->specptr.fptr1;
+    jl_typemap_entry_t *entry = (jl_typemap_entry_t*)jl_atomic_load_relaxed(&jl_gf_mtable(b)->cache);
+    jl_code_instance_t *ci = jl_atomic_load_relaxed(&entry->func.linfo->cache);
+    return jl_atomic_load_relaxed(&ci->specptr.fptr1);
 }
 
 static jl_value_t *add_builtin_func(const char *name, jl_fptr_args_t fptr)

--- a/src/clangsa/ImplicitAtomics.cpp
+++ b/src/clangsa/ImplicitAtomics.cpp
@@ -1,0 +1,215 @@
+//===-- ImplicitAtomicsChecker.cpp - Null dereference checker -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This defines NullDerefChecker, a builtin check in ExprEngine that performs
+// checks for null pointers at loads and stores.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ExprObjC.h"
+#include "clang/AST/ExprOpenMP.h"
+#include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerHelpers.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/raw_ostream.h"
+#include "clang/StaticAnalyzer/Frontend/CheckerRegistry.h"
+
+
+using namespace clang;
+using namespace ento;
+
+namespace {
+class ImplicitAtomicsChecker
+    : public Checker< check::PreStmt<CastExpr>,
+                      check::PreStmt<BinaryOperator>,
+                      check::PreStmt<UnaryOperator>,
+                      check::PreCall> {
+                      //check::Bind
+                      //check::Location
+  BugType ImplicitAtomicsBugType{this, "Implicit Atomic seq_cst synchronization", "Atomics"};
+
+  void reportBug(const Stmt *S, CheckerContext &C) const;
+  void reportBug(const Stmt *S, CheckerContext &C, StringRef desc) const;
+  void reportBug(const CallEvent &S, CheckerContext &C, StringRef desc="") const;
+
+public:
+  //void checkLocation(SVal location, bool isLoad, const Stmt* S,
+  //                   CheckerContext &C) const;
+  //void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
+  void checkPreStmt(const CastExpr *CE, CheckerContext &C) const;
+  void checkPreStmt(const UnaryOperator *UOp, CheckerContext &C) const;
+  void checkPreStmt(const BinaryOperator *BOp, CheckerContext &C) const;
+  void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
+};
+} // end anonymous namespace
+
+// Checks if RD has name in Names and is in std namespace
+static bool hasStdClassWithName(const CXXRecordDecl *RD,
+                                ArrayRef<llvm::StringLiteral> Names) {
+  // or could check ASTContext::getQualifiedTemplateName()->isDerivedFrom() ?
+  if (!RD || !RD->getDeclContext()->isStdNamespace())
+    return false;
+  if (RD->getDeclName().isIdentifier()) {
+    StringRef Name = RD->getName();
+    return llvm::any_of(Names, [&Name](StringRef GivenName) -> bool {
+      return Name == GivenName;
+    });
+  }
+  return false;
+}
+
+constexpr llvm::StringLiteral STD_PTR_NAMES[] = {"atomic", "atomic_ref"};
+
+static bool isStdAtomic(const CXXRecordDecl *RD) {
+  return hasStdClassWithName(RD, STD_PTR_NAMES);
+}
+
+static bool isStdAtomicCall(const Expr *E) {
+  return E && isStdAtomic(E->IgnoreImplicit()->getType()->getAsCXXRecordDecl());
+}
+
+static bool isStdAtomic(const Expr *E) {
+  return E->getType()->isAtomicType();
+}
+
+void ImplicitAtomicsChecker::reportBug(const CallEvent &S, CheckerContext &C, StringRef desc) const {
+    reportBug(S.getOriginExpr(), C, desc);
+}
+
+// try to find the "best" node to attach this to, so we generate fewer duplicate reports
+void ImplicitAtomicsChecker::reportBug(const Stmt *S, CheckerContext &C) const {
+  while (1) {
+    const auto *expr = dyn_cast<Expr>(S);
+    if (!expr)
+      break;
+    expr = expr->IgnoreParenCasts();
+    if (const auto *UO = dyn_cast<UnaryOperator>(expr))
+      S = UO->getSubExpr();
+    else if (const auto *BO = dyn_cast<BinaryOperator>(expr))
+      S = isStdAtomic(BO->getLHS()) ? BO->getLHS() :
+             isStdAtomic(BO->getRHS()) ? BO->getRHS() :
+             BO->getLHS();
+    else
+      break;
+  }
+  reportBug(S, C, "");
+}
+
+void ImplicitAtomicsChecker::reportBug(const Stmt *S, CheckerContext &C, StringRef desc) const {
+  SmallString<100> buf;
+  llvm::raw_svector_ostream os(buf);
+  os << ImplicitAtomicsBugType.getDescription() << desc;
+  PathDiagnosticLocation N = PathDiagnosticLocation::createBegin(
+    S, C.getSourceManager(), C.getLocationContext());
+  auto report = std::make_unique<BasicBugReport>(ImplicitAtomicsBugType, buf.str(), N);
+  C.emitReport(std::move(report));
+}
+
+void ImplicitAtomicsChecker::checkPreStmt(const CastExpr *CE, CheckerContext &C) const {
+  //if (isStdAtomic(CE) != isStdAtomic(CE->getSubExpr())) { // AtomicToNonAtomic or NonAtomicToAtomic CastExpr
+  if (CE->getCastKind() == CK_AtomicToNonAtomic) {
+    reportBug(CE, C);
+  }
+}
+
+void ImplicitAtomicsChecker::checkPreStmt(const UnaryOperator *UOp,
+                                          CheckerContext &C) const {
+  if (UOp->getOpcode() == UO_AddrOf)
+    return;
+  const Expr *Sub = UOp->getSubExpr();
+  if (isStdAtomic(UOp) || isStdAtomic(Sub))
+    reportBug(UOp, C);
+}
+
+void ImplicitAtomicsChecker::checkPreStmt(const BinaryOperator *BOp,
+                                          CheckerContext &C) const {
+  const Expr *Lhs = BOp->getLHS();
+  const Expr *Rhs = BOp->getRHS();
+  if (isStdAtomic(Lhs) || isStdAtomic(Rhs) || isStdAtomic(BOp))
+    reportBug(BOp, C);
+}
+
+void ImplicitAtomicsChecker::checkPreCall(const CallEvent &Call,
+                                          CheckerContext &C) const {
+  const auto *MC = dyn_cast<CXXInstanceCall>(&Call);
+  if (!MC || !isStdAtomicCall(MC->getCXXThisExpr()))
+    return;
+  if (const auto *OC = dyn_cast<CXXMemberOperatorCall>(&Call)) {
+    OverloadedOperatorKind OOK = OC->getOverloadedOperator();
+    if (CXXOperatorCallExpr::isAssignmentOp(OOK) || OOK == OO_PlusPlus || OOK == OO_MinusMinus) {
+      reportBug(Call, C, " (std::atomic)");
+    }
+  }
+  else if (const auto *Convert = dyn_cast<CXXConversionDecl>(MC->getDecl())) {
+    reportBug(Call, C, " (std::atomic)");
+  }
+}
+
+
+//// These seem probably unnecessary:
+//
+//static const Expr *getDereferenceExpr(const Stmt *S, bool IsBind=false) {
+//  const Expr *E = nullptr;
+//
+//  // Walk through lvalue casts to get the original expression
+//  // that syntactically caused the load.
+//  if (const Expr *expr = dyn_cast<Expr>(S))
+//    E = expr->IgnoreParenLValueCasts();
+//
+//  if (IsBind) {
+//    const VarDecl *VD;
+//    const Expr *Init;
+//    std::tie(VD, Init) = parseAssignment(S);
+//    if (VD && Init)
+//      E = Init;
+//  }
+//  return E;
+//}
+//
+//// load or bare symbol
+//void ImplicitAtomicsChecker::checkLocation(SVal l, bool isLoad, const Stmt* S,
+//                                           CheckerContext &C) const {
+//  const Expr *expr = getDereferenceExpr(S);
+//  assert(expr);
+//  if (isStdAtomic(expr))
+//    reportBug(S, C);
+//}
+//
+//// auto &r = *l, or store
+//void ImplicitAtomicsChecker::checkBind(SVal L, SVal V, const Stmt *S,
+//                                       CheckerContext &C) const {
+//  const Expr *expr = getDereferenceExpr(S, /*IsBind=*/true);
+//  assert(expr);
+//  if (isStdAtomic(expr))
+//    reportBug(S, C, " (bind)");
+//}
+
+namespace clang {
+namespace ento {
+void registerImplicitAtomicsChecker(CheckerManager &mgr) {
+  mgr.registerChecker<ImplicitAtomicsChecker>();
+}
+bool shouldRegisterImplicitAtomicsChecker(const CheckerManager &mgr) {
+  return true;
+}
+} // namespace ento
+} // namespace clang
+
+#ifdef CLANG_PLUGIN
+extern "C" const char clang_analyzerAPIVersionString[] =
+    CLANG_ANALYZER_API_VERSION_STRING;
+extern "C" void clang_registerCheckers(CheckerRegistry &registry) {
+  registry.addChecker<ImplicitAtomicsChecker>(
+      "julia.ImplicitAtomics", "Flags implicit atomic operations", ""
+  );
+}
+#endif

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -202,7 +202,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     */
     if (!abspath && jl_base_module != NULL) {
         jl_binding_t *b = jl_get_module_binding(jl_base_module, jl_symbol("DL_LOAD_PATH"));
-        jl_array_t *DL_LOAD_PATH = (jl_array_t*)(b ? b->value : NULL);
+        jl_array_t *DL_LOAD_PATH = (jl_array_t*)(b ? jl_atomic_load_relaxed(&b->value) : NULL);
         if (DL_LOAD_PATH != NULL) {
             size_t j;
             for (j = 0; j < jl_array_len(DL_LOAD_PATH); j++) {

--- a/src/init.c
+++ b/src/init.c
@@ -854,7 +854,7 @@ static void post_boot_hooks(void)
     for (i = 1; i < jl_core_module->bindings.size; i += 2) {
         if (table[i] != HT_NOTFOUND) {
             jl_binding_t *b = (jl_binding_t*)table[i];
-            jl_value_t *v = b->value;
+            jl_value_t *v = jl_atomic_load_relaxed(&b->value);
             if (v) {
                 if (jl_is_unionall(v))
                     v = jl_unwrap_unionall(v);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -208,7 +208,7 @@ JL_DLLEXPORT int jl_process_events(void)
     jl_task_t *ct = jl_current_task;
     uv_loop_t *loop = jl_io_loop;
     jl_gc_safepoint_(ct->ptls);
-    if (loop && (_threadedregion || ct->tid == 0)) {
+    if (loop && (_threadedregion || jl_atomic_load_relaxed(&ct->tid) == 0)) {
         if (jl_atomic_load(&jl_uv_n_waiters) == 0 && jl_mutex_trylock(&jl_uv_mutex)) {
             loop->stop_flag = 0;
             int r = uv_run(loop, UV_RUN_NOWAIT);
@@ -414,7 +414,7 @@ JL_DLLEXPORT int jl_fs_write(uv_os_fd_t handle, const char *data, size_t len,
 {
     jl_task_t *ct = jl_get_current_task();
     // TODO: fix this cheating
-    if (jl_get_safe_restore() || ct == NULL || ct->tid != 0)
+    if (jl_get_safe_restore() || ct == NULL || jl_atomic_load_relaxed(&ct->tid) != 0)
 #ifdef _OS_WINDOWS_
         return WriteFile(handle, data, len, NULL, NULL);
 #else
@@ -514,7 +514,7 @@ JL_DLLEXPORT void jl_uv_puts(uv_stream_t *stream, const char *str, size_t n)
 
     // TODO: Hack to make CoreIO thread-safer
     jl_task_t *ct = jl_get_current_task();
-    if (ct == NULL || ct->tid != 0) {
+    if (ct == NULL || jl_atomic_load_relaxed(&ct->tid) != 0) {
         if (stream == JL_STDOUT) {
             fd = UV_STDOUT_FD;
         }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -732,9 +732,9 @@ static jl_value_t *lookup_typevalue(jl_typename_t *tn, jl_value_t *key1, jl_valu
     }
 }
 
-static int cache_insert_type_set_(jl_svec_t *a, jl_datatype_t *val, uint_t hv)
+static int cache_insert_type_set_(jl_svec_t *a, jl_datatype_t *val, uint_t hv, int atomic)
 {
-    _Atomic(jl_datatype_t*) *tab = (_Atomic(jl_datatype_t*)*)jl_svec_data(a);
+    _Atomic(jl_value_t*) *tab = (_Atomic(jl_value_t*)*)jl_svec_data(a);
     size_t sz = jl_svec_len(a);
     if (sz <= 1)
         return 0;
@@ -744,9 +744,12 @@ static int cache_insert_type_set_(jl_svec_t *a, jl_datatype_t *val, uint_t hv)
     orig = index;
     size_t maxprobe = max_probe(sz);
     do {
-        jl_value_t *tab_i = (jl_value_t*)tab[index];
+        jl_value_t *tab_i = jl_atomic_load_relaxed(&tab[index]);
         if (tab_i == NULL || tab_i == jl_nothing) {
-            jl_atomic_store_release(&tab[index], val);
+            if (atomic)
+                jl_atomic_store_release(&tab[index], (jl_value_t*)val);
+            else
+                jl_atomic_store_relaxed(&tab[index], (jl_value_t*)val);
             jl_gc_wb(a, val);
             return 1;
         }
@@ -761,10 +764,10 @@ static jl_svec_t *cache_rehash_set(jl_svec_t *a, size_t newsz);
 
 static void cache_insert_type_set(jl_datatype_t *val, uint_t hv)
 {
-    jl_svec_t *a = val->name->cache;
+    jl_svec_t *a = jl_atomic_load_relaxed(&val->name->cache);
     while (1) {
         JL_GC_PROMISE_ROOTED(a);
-        if (cache_insert_type_set_(a, val, hv))
+        if (cache_insert_type_set_(a, val, hv, 1))
             return;
 
         /* table full */
@@ -787,17 +790,17 @@ static void cache_insert_type_set(jl_datatype_t *val, uint_t hv)
 
 static jl_svec_t *cache_rehash_set(jl_svec_t *a, size_t newsz)
 {
-    jl_datatype_t **ol = (jl_datatype_t**)jl_svec_data(a);
+    jl_value_t **ol = jl_svec_data(a);
     size_t sz = jl_svec_len(a);
     while (1) {
         size_t i;
         jl_svec_t *newa = jl_alloc_svec(newsz);
         JL_GC_PUSH1(&newa);
         for (i = 0; i < sz; i += 1) {
-            jl_datatype_t *val = ol[i];
-            if (val != NULL && (jl_value_t*)val != jl_nothing) {
-                uint_t hv = val->hash;
-                if (!cache_insert_type_set_(newa, val, hv)) {
+            jl_value_t *val = ol[i];
+            if (val != NULL && val != jl_nothing) {
+                uint_t hv = ((jl_datatype_t*)val)->hash;
+                if (!cache_insert_type_set_(newa, (jl_datatype_t*)val, hv, 0)) {
                     break;
                 }
             }
@@ -811,7 +814,7 @@ static jl_svec_t *cache_rehash_set(jl_svec_t *a, size_t newsz)
 
 static void cache_insert_type_linear(jl_datatype_t *type, ssize_t insert_at)
 {
-    jl_svec_t *cache = type->name->linearcache;
+    jl_svec_t *cache = jl_atomic_load_relaxed(&type->name->linearcache);
     assert(jl_is_svec(cache));
     size_t n = jl_svec_len(cache);
     if (n == 0 || jl_svecref(cache, n - 1) != NULL) {
@@ -848,7 +851,7 @@ void jl_cache_type_(jl_datatype_t *type)
         cache_insert_type_set(type, hv);
     }
     else {
-        ssize_t idx = lookup_type_idx_linear(type->name->linearcache, key, n);
+        ssize_t idx = lookup_type_idx_linear(jl_atomic_load_relaxed(&type->name->linearcache), key, n);
         assert(idx < 0);
         cache_insert_type_linear(type, ~idx);
     }
@@ -2237,8 +2240,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_array_uint8_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_uint8_type, jl_box_long(1));
     jl_array_int32_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_int32_type, jl_box_long(1));
     jl_an_empty_vec_any = (jl_value_t*)jl_alloc_vec_any(0); // used internally
-    jl_nonfunction_mt->leafcache = (jl_array_t*)jl_an_empty_vec_any;
-    jl_type_type_mt->leafcache = (jl_array_t*)jl_an_empty_vec_any;
+    jl_atomic_store_relaxed(&jl_nonfunction_mt->leafcache, (jl_array_t*)jl_an_empty_vec_any);
+    jl_atomic_store_relaxed(&jl_type_type_mt->leafcache, (jl_array_t*)jl_an_empty_vec_any);
 
     jl_expr_type =
         jl_new_datatype(jl_symbol("Expr"), core,

--- a/src/julia_locks.h
+++ b/src/julia_locks.h
@@ -115,7 +115,7 @@ static inline int jl_mutex_trylock(jl_mutex_t *lock)
 static inline void jl_mutex_unlock_nogc(jl_mutex_t *lock) JL_NOTSAFEPOINT
 {
 #ifndef __clang_gcanalyzer__
-    assert(lock->owner == jl_thread_self() &&
+    assert(jl_atomic_load_relaxed(&lock->owner) == jl_thread_self() &&
            "Unlocking a lock in a different thread.");
     if (--lock->count == 0) {
         jl_atomic_store_release(&lock->owner, (jl_thread_t)0);
@@ -136,7 +136,7 @@ static inline void jl_mutex_unlock(jl_mutex_t *lock)
 
 static inline void jl_mutex_init(jl_mutex_t *lock) JL_NOTSAFEPOINT
 {
-    lock->owner = (jl_thread_t)0;
+    jl_atomic_store_relaxed(&lock->owner, (jl_thread_t)0);
     lock->count = 0;
 }
 

--- a/src/partr.c
+++ b/src/partr.c
@@ -86,7 +86,7 @@ static inline void multiq_init(void)
         jl_mutex_init(&heaps[i].lock);
         heaps[i].tasks = (jl_task_t **)calloc(tasks_per_heap, sizeof(jl_task_t*));
         heaps[i].ntasks = 0;
-        heaps[i].prio = INT16_MAX;
+        jl_atomic_store_relaxed(&heaps[i].prio, INT16_MAX);
     }
     unbias_cong(heap_p, &cong_unbias);
 }
@@ -113,7 +113,7 @@ static inline void sift_down(taskheap_t *heap, int32_t idx)
                 child < tasks_per_heap && child <= heap_d*idx + heap_d;
                 ++child) {
             if (heap->tasks[child]
-                    &&  heap->tasks[child]->prio < heap->tasks[idx]->prio) {
+                    && heap->tasks[child]->prio < heap->tasks[idx]->prio) {
                 jl_task_t *t = heap->tasks[idx];
                 heap->tasks[idx] = heap->tasks[child];
                 heap->tasks[child] = t;
@@ -142,9 +142,9 @@ static inline int multiq_insert(jl_task_t *task, int16_t priority)
 
     heaps[rn].tasks[heaps[rn].ntasks++] = task;
     sift_up(&heaps[rn], heaps[rn].ntasks-1);
-    int16_t prio = jl_atomic_load(&heaps[rn].prio);
+    int16_t prio = jl_atomic_load_relaxed(&heaps[rn].prio);
     if (task->prio < prio)
-        jl_atomic_store(&heaps[rn].prio, task->prio);
+        jl_atomic_store_relaxed(&heaps[rn].prio, task->prio);
     jl_mutex_unlock_nogc(&heaps[rn].lock);
 
     return 0;
@@ -163,8 +163,8 @@ static inline jl_task_t *multiq_deletemin(void)
     for (i = 0; i < heap_p; ++i) {
         rn1 = cong(heap_p, cong_unbias, &ptls->rngseed);
         rn2 = cong(heap_p, cong_unbias, &ptls->rngseed);
-        prio1 = jl_atomic_load(&heaps[rn1].prio);
-        prio2 = jl_atomic_load(&heaps[rn2].prio);
+        prio1 = jl_atomic_load_relaxed(&heaps[rn1].prio);
+        prio2 = jl_atomic_load_relaxed(&heaps[rn2].prio);
         if (prio1 > prio2) {
             prio1 = prio2;
             rn1 = rn2;
@@ -172,7 +172,7 @@ static inline jl_task_t *multiq_deletemin(void)
         else if (prio1 == prio2 && prio1 == INT16_MAX)
             continue;
         if (jl_mutex_trylock_nogc(&heaps[rn1].lock)) {
-            if (prio1 == heaps[rn1].prio)
+            if (prio1 == jl_atomic_load_relaxed(&heaps[rn1].prio))
                 break;
             jl_mutex_unlock_nogc(&heaps[rn1].lock);
         }
@@ -192,7 +192,7 @@ static inline jl_task_t *multiq_deletemin(void)
         sift_down(&heaps[rn1], 0);
         prio1 = heaps[rn1].tasks[0]->prio;
     }
-    jl_atomic_store(&heaps[rn1].prio, prio1);
+    jl_atomic_store_relaxed(&heaps[rn1].prio, prio1);
     jl_mutex_unlock_nogc(&heaps[rn1].lock);
 
     return task;
@@ -394,7 +394,7 @@ static jl_task_t *get_next_task(jl_value_t *trypoptask, jl_value_t *q)
     jl_value_t *args[2] = { trypoptask, q };
     jl_task_t *task = (jl_task_t*)jl_apply(args, 2);
     if (jl_typeis(task, jl_task_type)) {
-        int self = jl_current_task->tid;
+        int self = jl_atomic_load_relaxed(&jl_current_task->tid);
         jl_set_task_tid(task, self);
         return task;
     }

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -111,7 +111,7 @@ void jl_safepoint_init(void)
 int jl_safepoint_start_gc(void)
 {
     if (jl_n_threads == 1) {
-        jl_gc_running = 1;
+        jl_atomic_store_relaxed(&jl_gc_running, 1);
         return 1;
     }
     // The thread should have set this already
@@ -135,9 +135,9 @@ int jl_safepoint_start_gc(void)
 
 void jl_safepoint_end_gc(void)
 {
-    assert(jl_gc_running);
+    assert(jl_atomic_load_relaxed(&jl_gc_running));
     if (jl_n_threads == 1) {
-        jl_gc_running = 0;
+        jl_atomic_store_relaxed(&jl_gc_running, 0);
         return;
     }
     jl_mutex_lock_nogc(&safepoint_lock);

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -336,7 +336,7 @@ JL_DLLEXPORT jl_value_t *jl_get_excstack(jl_task_t* task, int include_bt, int ma
 {
     JL_TYPECHK(current_exceptions, task, (jl_value_t*)task);
     jl_task_t *ct = jl_current_task;
-    if (task != ct && task->_state == JL_TASK_STATE_RUNNABLE) {
+    if (task != ct && jl_atomic_load_relaxed(&task->_state) == JL_TASK_STATE_RUNNABLE) {
         jl_error("Inspecting the exception stack of a task which might "
                  "be running concurrently isn't allowed.");
     }

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -41,7 +41,8 @@ static jl_sym_t *mk_symbol(const char *str, size_t len) JL_NOTSAFEPOINT
     sym = (jl_sym_t*)jl_valueof(tag);
     // set to old marked so that we won't look at it in the GC or write barrier.
     tag->header = ((uintptr_t)jl_symbol_type) | GC_OLD_MARKED;
-    sym->left = sym->right = NULL;
+    jl_atomic_store_relaxed(&sym->left, NULL);
+    jl_atomic_store_relaxed(&sym->right, NULL);
     sym->hash = hash_symbol(str, len);
     memcpy(jl_symbol_name(sym), str, len);
     jl_symbol_name(sym)[len] = 0;
@@ -89,7 +90,7 @@ jl_sym_t *_jl_symbol(const char *str, size_t len) JL_NOTSAFEPOINT // (or throw)
     if (node == NULL) {
         JL_LOCK_NOGC(&gc_perm_lock);
         // Someone might have updated it, check and look up again
-        if (*slot != NULL && (node = symtab_lookup(slot, str, len, &slot))) {
+        if (jl_atomic_load_relaxed(slot) != NULL && (node = symtab_lookup(slot, str, len, &slot))) {
             JL_UNLOCK_NOGC(&gc_perm_lock);
             return node;
         }
@@ -119,12 +120,12 @@ JL_DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, size_t len)
 
 JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void)
 {
-    return symtab;
+    return jl_atomic_load_relaxed(&symtab);
 }
 
 static _Atomic(uint32_t) gs_ctr = 0;  // TODO: per-module?
-uint32_t jl_get_gs_ctr(void) { return gs_ctr; }
-void jl_set_gs_ctr(uint32_t ctr) { gs_ctr = ctr; }
+uint32_t jl_get_gs_ctr(void) { return jl_atomic_load_relaxed(&gs_ctr); }
+void jl_set_gs_ctr(uint32_t ctr) { jl_atomic_store_relaxed(&gs_ctr, ctr); }
 
 JL_DLLEXPORT jl_sym_t *jl_gensym(void)
 {

--- a/src/task.c
+++ b/src/task.c
@@ -195,7 +195,7 @@ void JL_NORETURN jl_finish_task(jl_task_t *t)
 {
     jl_task_t *ct = jl_current_task;
     JL_SIGATOMIC_BEGIN();
-    if (t->_isexception)
+    if (jl_atomic_load_relaxed(&t->_isexception))
         jl_atomic_store_release(&t->_state, JL_TASK_STATE_FAILED);
     else
         jl_atomic_store_release(&t->_state, JL_TASK_STATE_DONE);
@@ -240,7 +240,7 @@ JL_DLLEXPORT void *jl_task_stack_buffer(jl_task_t *task, size_t *size, int *ptid
     jl_ptls_t ptls2 = task->ptls;
     *ptid = -1;
     if (ptls2) {
-        *ptid = task->tid;
+        *ptid = jl_atomic_load_relaxed(&task->tid);
 #ifdef COPY_STACKS
         if (task->copy_stack) {
             *size = ptls2->stacksize;
@@ -345,7 +345,7 @@ static void ctx_switch(jl_task_t *lastt)
     }
 #endif
 
-    int killed = lastt->_state != JL_TASK_STATE_RUNNABLE;
+    int killed = jl_atomic_load_relaxed(&lastt->_state) != JL_TASK_STATE_RUNNABLE;
     if (!t->started && !t->copy_stack) {
         // may need to allocate the stack
         if (t->stkbuf == NULL) {
@@ -482,7 +482,7 @@ JL_DLLEXPORT void jl_switch(void)
         jl_error("task switch not allowed from inside gc finalizer");
     if (ptls->in_pure_callback)
         jl_error("task switch not allowed from inside staged nor pure functions");
-    if (!jl_set_task_tid(t, ptls->tid)) // manually yielding to a task
+    if (!jl_set_task_tid(t, jl_atomic_load_relaxed(&ct->tid))) // manually yielding to a task
         jl_error("cannot switch to task running on another thread");
 
     // Store old values on the stack and reset
@@ -505,7 +505,7 @@ JL_DLLEXPORT void jl_switch(void)
     t = ptls->previous_task;
     ptls->previous_task = NULL;
     assert(t != ct);
-    assert(t->tid == ptls->tid);
+    assert(jl_atomic_load_relaxed(&t->tid) == ptls->tid);
     if (!t->sticky && !t->copy_stack)
         jl_atomic_store_release(&t->tid, -1);
 #else
@@ -740,7 +740,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->start = start;
     t->result = jl_nothing;
     t->donenotify = completion_future;
-    t->_isexception = 0;
+    jl_atomic_store_relaxed(&t->_isexception, 0);
     // Inherit logger state from parent task
     t->logstate = ct->logstate;
     // Fork task-local random state from parent
@@ -752,7 +752,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->excstack = NULL;
     t->started = 0;
     t->prio = -1;
-    jl_atomic_store_relaxed(&t->tid, t->copy_stack ? ct->tid : -1); // copy_stacks are always pinned since they can't be moved
+    jl_atomic_store_relaxed(&t->tid, t->copy_stack ? jl_atomic_load_relaxed(&ct->tid) : -1); // copy_stacks are always pinned since they can't be moved
     t->ptls = NULL;
     t->world_age = ct->world_age;
 
@@ -867,7 +867,7 @@ CFI_NORETURN
 #endif
 
     ct->started = 1;
-    if (ct->_isexception) {
+    if (jl_atomic_load_relaxed(&ct->_isexception)) {
         record_backtrace(ptls, 0);
         jl_push_excstack(&ct->excstack, ct->result,
                          ptls->bt_data, ptls->bt_size);
@@ -884,7 +884,7 @@ CFI_NORETURN
         }
         JL_CATCH {
             res = jl_current_exception();
-            ct->_isexception = 1;
+            jl_atomic_store_relaxed(&ct->_isexception, 1);
             goto skip_pop_exception;
         }
 skip_pop_exception:;
@@ -1301,7 +1301,7 @@ void jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->start = NULL;
     ct->result = jl_nothing;
     ct->donenotify = jl_nothing;
-    ct->_isexception = 0;
+    jl_atomic_store_relaxed(&ct->_isexception, 0);
     ct->logstate = jl_nothing;
     ct->eh = NULL;
     ct->gcstack = NULL;
@@ -1349,7 +1349,7 @@ JL_DLLEXPORT int jl_is_task_started(jl_task_t *t) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT int16_t jl_get_task_tid(jl_task_t *t) JL_NOTSAFEPOINT
 {
-    return t->tid;
+    return jl_atomic_load_relaxed(&t->tid);
 }
 
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -295,7 +295,7 @@ _Atomic(uint64_t) jl_cumulative_compile_time = 0;
 // type of the thread id.
 JL_DLLEXPORT int16_t jl_threadid(void)
 {
-    return jl_current_task->tid;
+    return jl_atomic_load_relaxed(&jl_current_task->tid);
 }
 
 jl_ptls_t jl_init_threadtls(int16_t tid)
@@ -314,7 +314,7 @@ jl_ptls_t jl_init_threadtls(int16_t tid)
     }
 #endif
     ptls->tid = tid;
-    ptls->gc_state = 0; // GC unsafe
+    jl_atomic_store_relaxed(&ptls->gc_state, 0); // GC unsafe
     // Conditionally initialize the safepoint address. See comment in
     // `safepoint.c`
     if (tid == 0) {

--- a/test/clangsa/GCPushPop.cpp
+++ b/test/clangsa/GCPushPop.cpp
@@ -1,6 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-// RUN: clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang libGCCheckerPlugin%shlibext -Xclang -verify -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CPPFLAGS} ${CFLAGS} -Xclang -analyzer-checker=core,julia.GCChecker -x c++ %s
+// RUN: clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang libGCCheckerPlugin%shlibext -Xclang -verify -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CPPFLAGS} ${CFLAGS} -Xclang -analyzer-checker=core,julia.GCChecker --analyzer-no-default-checks -x c++ %s
 
 #include "julia.h"
 

--- a/test/clangsa/ImplicitAtomicsTest.c
+++ b/test/clangsa/ImplicitAtomicsTest.c
@@ -1,0 +1,99 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// RUN: clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang libImplicitAtomicsPlugin%shlibext -Xclang -verify -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CPPFLAGS} ${CFLAGS} ${CXXFLAGS} -Xclang -analyzer-checker=core,julia.ImplicitAtomics --analyzer-no-default-checks -x c++ -std=c++11 %s -v
+// RUN: clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang libImplicitAtomicsPlugin%shlibext -Xclang -verify -I%julia_home/src -I%julia_home/src/support -I%julia_home/usr/include ${CLANGSA_FLAGS} ${CPPFLAGS} ${CFLAGS} -Xclang -analyzer-checker=core,julia.ImplicitAtomics --analyzer-no-default-checks -x c -std=c11 %s -v
+
+#include "julia_atomics.h"
+
+_Atomic(int) x, *px;
+struct Atomic_xy_t {
+    _Atomic(int) x;
+    _Atomic(int) *px;
+    int y;
+} y, *py;
+_Atomic(int) z[2];
+
+
+// jwn: add tests for casts, and *py = y;
+
+void hiddenAtomics(void) {
+    px = &x;
+    py = &y;
+    y.px = &y.x;
+    ++x; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    --x; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    x++; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    x--; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    x += 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    x -= 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+#ifndef __cplusplus // invalid C++ code
+    x *= 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    x = // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+        x; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+#endif
+    x = 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    x + 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+
+    ++*px; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    --*px; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    px++;
+    px--;
+    1 + *px++; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    1 + *px--; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    (*px)++; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    (*px)--; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *px += 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *px -= 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+#ifndef __cplusplus // invalid C++ code
+    *px *= 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *px = // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+        x; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    x = // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+        *px; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+#endif
+    *px = 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *px + 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+
+    *(int*)&x = 3;
+    *(int*)px = 3;
+
+    y.y = 2;
+    py->y = 2;
+#ifndef __cplusplus // invalid C++ code
+    *py = // TODO
+        y; // TODO
+    y = // TODO
+       *py; // TODO
+#endif
+    *(_Atomic(int)*)&y.y = 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *(_Atomic(int)*)&py->y = 2; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+
+    y.x = 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *y.px = 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+
+    py->x = 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *py->px = 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+
+    z[1] = 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *z = 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    *z += 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+
+#ifdef __cplusplus // check initialization / finalization
+    _Atomic(int) lx{2};
+    lx = 3; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    lx += 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+
+    struct large_type { int x[16]; };
+    auto *ly = new std::atomic<struct large_type>();
+    *ly =    // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+        ly->load();
+    struct large_type a = *ly; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    delete ly;
+
+#if 0 // enable for C++2a
+    std::atomic_ref<int> lz(*(int*)px);
+    lz = 3; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+    lz += 1; // expected-warning{{Implicit Atomic seq_cst synchronization}} expected-note{{Implicit Atomic seq_cst synchronization}}
+#endif
+#endif
+}

--- a/test/clangsa/Makefile
+++ b/test/clangsa/Makefile
@@ -3,11 +3,11 @@ JULIAHOME := $(abspath $(SRCDIR)/../..)
 BUILDDIR := .
 include $(JULIAHOME)/Make.inc
 
-check: $(SRCDIR)
+check: .
 
 TESTS = $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.c) $(wildcard $(SRCDIR)/*.cpp))
 
-$(SRCDIR) $(TESTS):
+. $(TESTS):
 	@$(MAKE) -C $(BUILDDIR)/../../src $(build_includedir)/julia/julia_version.h
 	@$(MAKE) -C $(BUILDDIR)/../../src clangsa
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
@@ -17,6 +17,6 @@ $(SRCDIR) $(TESTS):
 	CPPFLAGS_FLAGS="${CPPFLAGS_FLAGS}" \
 	CFLAGS_FLAGS="${CFLAGS_FLAGS}" \
 	CXXFLAGS_FLAGS="${CXXFLAGS_FLAGS}" \
-	$(build_depsbindir)/lit/lit.py -v $@
+	$(build_depsbindir)/lit/lit.py -v $(addprefix $(SRCDIR)/,$@)
 
-.PHONY: $(TESTS) $(SRCDIR) check all
+.PHONY: $(TESTS) check all .

--- a/test/clangsa/lit.cfg.py
+++ b/test/clangsa/lit.cfg.py
@@ -14,8 +14,6 @@ config.substitutions.append(('%shlibext', '.dylib' if platform.system() == 'Darw
     platform.system() == 'Windows' else '.so'))
 config.substitutions.append(("%julia_home", os.path.join(os.path.dirname(__file__), "../..")))
 
-path = os.path.pathsep.join((os.path.join(os.path.dirname(__file__),"../../usr/tools"), os.path.join(os.path.dirname(__file__),"../../usr/bin"), config.environment['PATH']))
-config.environment['PATH'] = path
 config.environment['HOME'] = "/tmp"
 config.environment['CLANGSA_FLAGS'] = os.environ.get('CLANGSA_FLAGS', "")
 config.environment['CLANGSA_CXXFLAGS'] = os.environ.get('CLANGSA_CXXFLAGS', "")

--- a/test/llvmpasses/Makefile
+++ b/test/llvmpasses/Makefile
@@ -2,13 +2,13 @@ SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME := $(abspath $(SRCDIR)/../..)
 include $(JULIAHOME)/Make.inc
 
-check: $(SRCDIR)
+check: .
 
 TESTS = $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.jl $(SRCDIR)/*.ll))
 
-$(SRCDIR) $(TESTS):
+. $(TESTS):
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
 	LD_LIBRARY_PATH=${build_libdir}:$$LD_LIBRARY_PATH \
-	$(build_depsbindir)/lit/lit.py -v $@
+	$(build_depsbindir)/lit/lit.py -v $(addprefix $(SRCDIR)/,$@)
 
-.PHONY: $(TESTS) $(SRCDIR) check all
+.PHONY: $(TESTS) check all .

--- a/test/llvmpasses/lit.cfg.py
+++ b/test/llvmpasses/lit.cfg.py
@@ -13,8 +13,6 @@ config.test_format = lit.formats.ShTest(True)
 config.substitutions.append(('%shlibext', '.dylib' if platform.system() == 'Darwin' else '.dll' if
     platform.system() == 'Windows' else '.so'))
 
-path = os.path.pathsep.join((os.path.join(os.path.dirname(__file__),"../../usr/tools"), os.path.join(os.path.dirname(__file__),"../../usr/bin"), config.environment['PATH']))
-config.environment['PATH'] = path
 config.environment['HOME'] = "/tmp"
 
 if platform.machine() == "x86_64":


### PR DESCRIPTION
Prior to #42152, some of these were too weakly ordered, now many are too strongly ordered. But slowly we get closer to our goal. This adds a checker that prohibits reading or writing to an atomic without explicitly specifying the memory ordering. In principle, that also makes it much closer to our Julia atomics model.