### PR TITLE
prevent precompilation from breaking if Base.PkgId is imported

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1356,8 +1356,8 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_d
     for (pkg, build_id) in concrete_deps
         push!(deps_strs, "$(pkg_str(pkg)) => $(repr(build_id))")
     end
-    deps = repr(eltype(concrete_deps)) * "[" * join(deps_strs, ",") * "]"
-
+    deps_eltype = sprint(show, eltype(concrete_deps); context = :module=>nothing)
+    deps = deps_eltype * "[" * join(deps_strs, ",") * "]"
     trace = isassigned(PRECOMPILE_TRACE_COMPILE) ? `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[])` : ``
     io = open(pipeline(`$(julia_cmd()::Cmd) -O0
                        --output-ji $output --output-incremental=yes


### PR DESCRIPTION
Problem:

```jl
julia> using Base: PkgId

julia> using Example
[ Info: Precompiling Example [7876af07-990d-54b4-ab0e-23690620f79a]
ERROR: UndefVarError: PkgId not defined
Stacktrace:
 [1] top-level scope
   @ none:1
 [2] eval
   @ ./boot.jl:368 [inlined]
 [3] eval(x::Expr)
   @ Base.MainInclude ./client.jl:453
 [4] top-level scope
   @ none:1
ERROR: Failed to precompile Example [7876af07-990d-54b4-ab0e-23690620f79a] to /home/kc/.julia/compiled/v1.8/Example/jl_lTKLYS.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] compilecache(pkg::PkgId, path::String, internal_stderr::IO, internal_stdout::IO, ignore_loaded_modules::Bool)
   @ Base ./loading.jl:1483
 [3] compilecache(pkg::PkgId, path::String)
   @ Base ./loading.jl:1427
 [4] _require(pkg::PkgId)
   @ Base ./loading.jl:1137
 [5] require(uuidkey::PkgId)
   @ Base ./loading.jl:1030
 [6] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:1014
```

`repr` will only print a module prefix if the symbol is not existing in Main but the module prefix is unconditionally needed here since the code will be evaluated in another process.

Fixes https://github.com/JuliaLang/julia/issues/40888