### PR TITLE
Make Diagonal(1:3) .* (1:3) return a Diagonal

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -132,6 +132,9 @@ fzeropreserving(bc) = (v = fzero(bc); !ismissing(v) && (iszerodefined(typeof(v))
 # expression is stable.  We can test the zero-preservability by applying the function
 # in cases where all other arguments are known scalars against a zero from the structured
 # matrix. If any non-structured matrix argument is not a known scalar, we give up.
+fzero(f, x) = fzero(x) #General fallback
+fzero(::typeof(*), x::AbstractArray) = one(eltype(x)) #This can return any number except 0
+fzero(::typeof(*), x::StructuredMatrix) = fzero(x) #Return 0
 fzero(x::Number) = x
 fzero(::Type{T}) where T = T
 fzero(r::Ref) = r[]
@@ -139,7 +142,7 @@ fzero(t::Tuple{Any}) = t[1]
 fzero(S::StructuredMatrix) = zero(eltype(S))
 fzero(x) = missing
 function fzero(bc::Broadcast.Broadcasted)
-    args = map(fzero, bc.args)
+    args = map(arg -> fzero(bc.f, arg), bc.args)
     return any(ismissing, args) ? missing : bc.f(args...)
 end
 

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -26,7 +26,7 @@ using Test, LinearAlgebra
         @test broadcast!(*, Z, s, X) == broadcast(*, s, fX)
         @test (Q = broadcast(+, fV, fA, X); Q isa Matrix && Q == broadcast(+, fV, fA, fX))
         @test broadcast!(+, Z, fV, fA, X) == broadcast(+, fV, fA, fX)
-        @test (Q = broadcast(*, s, fV, fA, X); Q isa Matrix && Q == broadcast(*, s, fV, fA, fX))
+        @test (Q = broadcast(*, s, fV, fA, X); typeof(Q) == typeof(X) && Q == broadcast(*, s, fV, fA, fX)) # (.*) can preserve zero structure
         @test broadcast!(*, Z, s, fV, fA, X) == broadcast(*, s, fV, fA, fX)
 
         @test X .* 2.0 == X .* (2.0,) == fX .* 2.0


### PR DESCRIPTION
This PR tries to retain more zero structure after (.*).
Since `0 * anynumber == 0`, `AbstractArray` can be viewed as 1 during zero preserving check if `bc.f == (*)`.
Before this PR:
```julia
julia> Diagonal(1:3) .* (1:3)
3×3 Matrix{Int64}:
 1  0  0
 0  4  0
 0  0  9
```
After this PR:
```julia
julia> Diagonal(1:3) .* (1:3)
3×3 Diagonal{Int64, Vector{Int64}}:
 1  ⋅  ⋅
 ⋅  4  ⋅
 ⋅  ⋅  9
```
BTW, this should also accelerate `x::LowerTriangular .= a::LowerTriangular .* b::AbstractVecOrMat`.