### PR TITLE
Add missing optimization for `*`,`/` between Diagonal and Triangular

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -240,6 +240,7 @@ end
 rmul!(A::AbstractMatrix, D::Diagonal) = mul!(A, A, D)
 lmul!(D::Diagonal, B::AbstractVecOrMat) = mul!(B, D, B)
 
+#TODO: It seems better to call (D' * adjA')' directly?
 function *(adjA::Adjoint{<:Any,<:AbstractMatrix}, D::Diagonal)
     A = adjA.parent
     Ac = similar(A, promote_op(*, eltype(A), eltype(D.diag)), (size(A, 2), size(A, 1)))
@@ -379,6 +380,7 @@ end
 ldiv!(x::AbstractVecOrMat, A::Diagonal, b::AbstractVecOrMat) = (x .= A.diag .\ b)
 
 function ldiv!(D::Diagonal, B::AbstractVecOrMat)
+    require_one_based_indexing(B)
     m, n = size(B, 1), size(B, 2)
     if m != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $m rows"))
@@ -442,7 +444,7 @@ end
 kron(A::Diagonal{<:Number}, B::Diagonal{<:Number}) = Diagonal(kron(A.diag, B.diag))
 
 @inline function kron!(C::AbstractMatrix, A::Diagonal, B::AbstractMatrix)
-    Base.require_one_based_indexing(B)
+    require_one_based_indexing(B)
     (mA, nA) = size(A)
     (mB, nB) = size(B)
     (mC, nC) = size(C)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -422,17 +422,17 @@ for Tri in (:UpperTriangular, :LowerTriangular)
     # 3-arg mul!: invoke 5-arg mul! rather than lmul!
     @eval mul!(out::$Tri, A::Union{$Tri,$UTri}, D::Diagonal) = mul!(out, A, D, true, false)
     # 5-arg mul!
-    @eval @inline mul!(out::$Tri, D::Diagonal, A::$Tri, α::Number, β::Number) = 
+    @eval @inline mul!(out::$Tri, D::Diagonal, A::$Tri, α::Number, β::Number) =
         $Tri(mul!(out.data, D, A.data, α, β))
     @eval @inline function mul!(out::$Tri, D::Diagonal, A::$UTri, α::Number, β::Number)
         diag′ = iszero(β) ? D.diag : diag(out)
         data = mul!(out.data, D, A.data, α, β)
         $Tri(_setdiag!(data, MulAddMul(α, β), D.diag, diag′))
     end
-    @eval @inline mul!(out::$Tri, A::$Tri, D::Diagonal, α::Number, β::Number) = 
+    @eval @inline mul!(out::$Tri, A::$Tri, D::Diagonal, α::Number, β::Number) =
         $Tri(mul!(out.data, A.data, D, α, β))
     @eval @inline function mul!(out::$Tri, A::$UTri, D::Diagonal, α::Number, β::Number)
-        diag′ = iszero(β) ? D.diag : diag(out) 
+        diag′ = iszero(β) ? D.diag : diag(out)
         data = mul!(out.data, A.data, D, α, β)
         $Tri(_setdiag!(data, MulAddMul(α, β), D.diag, diag′))
     end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -393,12 +393,12 @@ for Tri in (:UpperTriangular, :LowerTriangular)
         @eval $fun(D::Diagonal, A::$UTri) = $Tri(_set_diag!($fun(D, A.data), D.diag, $f))
     end
     # 3 args
-    @eval ldiv!(out::$Tri, D::Diagonal, A::$Tri) = $Tri(ldiv!(out.data, D, A.Data))
-    @eval ldiv!(out::$Tri, D::Diagonal, A::$UTri) = $Tri(_set_diag!(ldiv!(out.data, D, A.Data), D.diag, inv))
-    @eval mul!(out::$Tri, D::Diagonal, A::$Tri) = $Tri(mul!(out.data, D, A.Data))
-    @eval mul!(out::$Tri, D::Diagonal, A::$UTri) = $Tri(_set_diag!(mul!(out.data, D, A.Data), D.diag))
-    @eval mul!(out::$Tri, A::$Tri, D::Diagonal) = $Tri(mul!(out.data, A.Data, D))
-    @eval mul!(out::$Tri, A::$UTri, D::Diagonal) = $Tri(_set_diag!(mul!(out.data, A.Data, D), D.diag))
+    @eval ldiv!(out::$Tri, D::Diagonal, A::$Tri) = $Tri(ldiv!(out.data, D, A.data))
+    @eval ldiv!(out::$Tri, D::Diagonal, A::$UTri) = $Tri(_set_diag!(ldiv!(out.data, D, A.data), D.diag, inv))
+    @eval mul!(out::$Tri, D::Diagonal, A::$Tri) = $Tri(mul!(out.data, D, A.data))
+    @eval mul!(out::$Tri, D::Diagonal, A::$UTri) = $Tri(_set_diag!(mul!(out.data, D, A.data), D.diag))
+    @eval mul!(out::$Tri, A::$Tri, D::Diagonal) = $Tri(mul!(out.data, A.data, D))
+    @eval mul!(out::$Tri, A::$UTri, D::Diagonal) = $Tri(_set_diag!(mul!(out.data, A.data, D), D.diag))
 end
 
 @inline function kron!(C::AbstractMatrix, A::Diagonal, B::Diagonal)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -368,12 +368,14 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     end
     B
 end
+# Optimization for Diagonal / Diagonal
 function _rdiv!(Dc::Diagonal, Db::Diagonal, Da::Diagonal)
     n, k = length(Db.diag), length(Db.diag)
     n == k || throw(DimensionMismatch("left hand side has $n columns but D is $k by $k"))
-    j = findfirst(iszero, D.diag)
+    j = findfirst(iszero, Da.diag)
     isnothing(j) || throw(SingularException(j))
     Dc.diag .= Db.diag ./ Da.diag
+    Dc
 end
 
 (\)(D::Diagonal, B::AbstractVecOrMat) =

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -396,12 +396,12 @@ function _rdiv!(Dc::Diagonal, Db::Diagonal, Da::Diagonal)
 end
 ldiv!(Dc::Diagonal, Da::Diagonal, Db::Diagonal) = Diagonal(ldiv!(Dc.diag, Da, Db.diag))
 
-# Optimizations for [l/r]mul!, l/rdiv!, *, / and \  between AbstractTriangular and Diagonal.
+# Optimizations for [l/r]mul!, l/rdiv!, *, / and \ between Triangular and Diagonal.
 # These functions are generally more efficient if we calculate the whole data field.
 # The following code implements them in a unified pattern to avoid missing.
-function _setdiag!(data, f, diag, diag′...)
-    for i in 1:length(diag)
-        data[i,i] = f(map(x -> x[i], (diag, diag′...))...)
+@inline function _setdiag!(data, f, diag, diag′ = nothing)
+    @inbounds for i in 1:length(diag)
+        data[i,i] = isnothing(diag′) ? f(diag[i]) : f(diag[i],diag′[i])
     end
     data
 end
@@ -419,20 +419,20 @@ for Tri in (:UpperTriangular, :LowerTriangular)
     # 3-arg ldiv!
     @eval ldiv!(C::$Tri, D::Diagonal, A::$Tri) = $Tri(ldiv!(C.data, D, A.data))
     @eval ldiv!(C::$Tri, D::Diagonal, A::$UTri) = $Tri(_setdiag!(ldiv!(C.data, D, A.data), inv, D.diag))
-    # 3-arg mul!: fallback to 5-arg mul! rather than lmul!
+    # 3-arg mul!: invoke 5-arg mul! rather than lmul!
     @eval mul!(C::$Tri, A::Union{$Tri,$UTri}, D::Diagonal) = mul!(C, A, D, true, false)
     # 5-arg mul!
     @eval @inline mul!(C::$Tri, D::Diagonal, A::$Tri, α::Number, β::Number) = $Tri(mul!(C.data, D, A.data, α, β))
     @eval @inline function mul!(C::$Tri, D::Diagonal, A::$UTri, α::Number, β::Number)
         iszero(α) && return _rmul_or_fill!(C, β)
-        diag′ = iszero(β) ? D.diag : diag(C)
+        diag′ = iszero(β) ? nothing : diag(C)
         data = mul!(C.data, D, A.data, α, β)
         $Tri(_setdiag!(data, MulAddMul(α, β), D.diag, diag′))
     end
     @eval @inline mul!(C::$Tri, A::$Tri, D::Diagonal, α::Number, β::Number) = $Tri(mul!(C.data, A.data, D, α, β))
     @eval @inline function mul!(C::$Tri, A::$UTri, D::Diagonal, α::Number, β::Number)
-        iszero(α) && return rmul!(C, β)
-        diag′ = iszero(β) ? D.diag : diag(C) 
+        iszero(α) && return _rmul_or_fill!(C, β)
+        diag′ = iszero(β) ? nothing : diag(C)
         data = mul!(C.data, A.data, D, α, β)
         $Tri(_setdiag!(data, MulAddMul(α, β), D.diag, diag′))
     end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -370,7 +370,7 @@ function rdiv!(A::AbstractVecOrMat, D::Diagonal)
     A
 end
 
-(\)(D::Diagonal, B::AbstractVecOrMat) = 
+(\)(D::Diagonal, B::AbstractVecOrMat) =
     ldiv!(similar(B, promote_op(\, eltype(D), eltype(B)), size(B)), D, B)
 (\)(Da::Diagonal, Db::Diagonal) = Diagonal(Da \ Db.diag)
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -349,8 +349,7 @@ end
 
 _promote_dotop(f, args...) = promote_op(f, eltype.(args)...)
 
-(/)(A::AbstractVecOrMat, D::Diagonal) =
-    _rdiv!(similar(A, _promote_dotop(/, A, D), size(A)), A, D)
+/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(similar(A, _promote_dotop(/, A, D), size(A)), A, D)
 
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
@@ -371,8 +370,7 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-(\)(D::Diagonal, B::AbstractVecOrMat) =
-    ldiv!(similar(B, _promote_dotop(\, D, B), size(B)), D, B)
+\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(similar(B, _promote_dotop(\, D, B), size(B)), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
@@ -387,7 +385,7 @@ function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
     B .= D.diag .\ A
 end
 
-#Optimizations for \ / between Diagonals
+# Optimizations for \, / between Diagonals
 \(D::Diagonal, B::Diagonal) = ldiv!(similar(B, _promote_dotop(\, D, B)), D, B)
 /(A::Diagonal, D::Diagonal) = _rdiv!(similar(A, _promote_dotop(/, A, D)), A, D)
 function _rdiv!(Dc::Diagonal, Db::Diagonal, Da::Diagonal)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -204,8 +204,8 @@ Random.seed!(1)
         @test D2*D' ≈ Array(D2)*Array(D)'
 
         #division of two Diagonals
-        @test D/D2 ≈ Diagonal(D.diag./D2.diag)
-        @test D\D2 ≈ Diagonal(D2.diag./D.diag)
+        @test (D/D2)::Diagonal ≈ Diagonal(D.diag./D2.diag)
+        @test (D\D2)::Diagonal ≈ Diagonal(D2.diag./D.diag)
 
         # QR \ Diagonal
         A = rand(elty, n, n)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -921,12 +921,17 @@ end
         @test fun(D, copy(UTriA))::Tri == fun(D, Matrix(UTriA))
     end
     # 3 args
-    @test outTri === ldiv!(outTri, D, TriA::Tri == ldiv!(out, D, Matrix(TriA))
+    @test outTri === ldiv!(outTri, D, TriA)::Tri == ldiv!(out, D, Matrix(TriA))
     @test outTri === ldiv!(outTri, D, UTriA)::Tri == ldiv!(out, D, Matrix(UTriA))
     @test outTri === mul!(outTri, D, TriA)::Tri == mul!(out, D, Matrix(TriA))
     @test outTri === mul!(outTri, D, UTriA)::Tri == mul!(out, D, Matrix(UTriA))
     @test outTri === mul!(outTri, TriA, D)::Tri == mul!(out, Matrix(TriA), D)
     @test outTri === mul!(outTri, UTriA, D)::Tri == mul!(out, Matrix(UTriA), D)
+    # 5 args
+    @test outTri === mul!(outTri, D, TriA, 2, 1)::Tri == mul!(out, D, Matrix(TriA), 2, 1)
+    @test outTri === mul!(outTri, D, UTriA, 2, 1)::Tri == mul!(out, D, Matrix(UTriA), 2, 1)
+    @test outTri === mul!(outTri, TriA, D, 2, 1)::Tri == mul!(out, Matrix(TriA), D, 2, 1)
+    @test outTri === mul!(outTri, UTriA, D, 2, 1)::Tri == mul!(out, Matrix(UTriA), D, 2, 1)
 end
 
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -902,4 +902,31 @@ end
     @test oneunit(D3) isa typeof(D3)
 end
 
+@testset "AbstractTriangular" for (Tri, UTri) in ((UpperTriangular, UnitUpperTriangular), (LowerTriangular, UnitLowerTriangular))
+    A = randn(4, 4)
+    TriA = Tri(A)
+    UTriA = UTri(A)
+    D = Diagonal(1.0:4.0)
+    DM = Matrix(D)
+    DMF = factorize(DM)
+    outTri = similar(TriA)
+    out = similar(A)
+    # 2 args
+    for fun in (*, rmul!, rdiv!, /)
+        @test fun(copy(TriA), D)::Tri == fun(Matrix(TriA), D)
+        @test fun(copy(UTriA), D)::Tri == fun(Matrix(UTriA), D)
+    end
+    for fun in (*, lmul!, ldiv!, \)
+        @test fun(D, copy(TriA))::Tri == fun(D, Matrix(TriA))
+        @test fun(D, copy(UTriA))::Tri == fun(D, Matrix(UTriA))
+    end
+    # 3 args
+    @test outTri === ldiv!(outTri, D, TriA)::Tri == ldiv!(out, D, Matrix(TriA))
+    @test outTri === ldiv!(outTri, D, UTriA)::Tri == ldiv!(out, D, Matrix(UTriA))
+    @test outTri === mul!(outTri, D, TriA)::Tri == mul!(out, D, Matrix(TriA))
+    @test outTri === mul!(outTri, D, UTriA)::Tri == mul!(out, D, Matrix(UTriA))
+    @test outTri === mul!(outTri, TriA, D)::Tri == mul!(out, Matrix(TriA), D)
+    @test outTri === mul!(outTri, UTriA, D)::Tri == mul!(out, Matrix(UTriA), D)
+end
+
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -204,8 +204,8 @@ Random.seed!(1)
         @test D2*D' ≈ Array(D2)*Array(D)'
 
         #division of two Diagonals
-        @test (D/D2)::Diagonal ≈ Diagonal(D.diag./D2.diag)
-        @test (D\D2)::Diagonal ≈ Diagonal(D2.diag./D.diag)
+        @test D/D2 ≈ Diagonal(D.diag./D2.diag)
+        @test D\D2 ≈ Diagonal(D2.diag./D.diag)
 
         # QR \ Diagonal
         A = rand(elty, n, n)
@@ -921,7 +921,7 @@ end
         @test fun(D, copy(UTriA))::Tri == fun(D, Matrix(UTriA))
     end
     # 3 args
-    @test outTri === ldiv!(outTri, D, TriA)::Tri == ldiv!(out, D, Matrix(TriA))
+    @test outTri === ldiv!(outTri, D, TriA::Tri == ldiv!(out, D, Matrix(TriA))
     @test outTri === ldiv!(outTri, D, UTriA)::Tri == ldiv!(out, D, Matrix(UTriA))
     @test outTri === mul!(outTri, D, TriA)::Tri == mul!(out, D, Matrix(TriA))
     @test outTri === mul!(outTri, D, UTriA)::Tri == mul!(out, D, Matrix(UTriA))

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -90,12 +90,10 @@ let n = 10
                 @testset "Multiplication/division" begin
                     for x = (5, 5I, Diagonal(d), Bidiagonal(d,dl,:U),
                              UpperTriangular(A), UnitUpperTriangular(A))
-                        @test H*x == Array(H)*x broken = eltype(H) <: Furlong && x isa Bidiagonal
-                        @test x*H == x*Array(H) broken = eltype(H) <: Furlong && x isa Bidiagonal
+                        @test (H*x)::UpperHessenberg == Array(H)*x broken = eltype(H) <: Furlong && x isa Bidiagonal
+                        @test (x*H)::UpperHessenberg == x*Array(H) broken = eltype(H) <: Furlong && x isa Bidiagonal
                         @test H/x == Array(H)/x broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, UpperTriangular}
                         @test x\H == x\Array(H) broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, UpperTriangular}
-                        @test H*x isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
-                        @test x*H isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
                         @test H/x isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
                         @test x\H isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
                     end

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -92,12 +92,12 @@ let n = 10
                              UpperTriangular(A), UnitUpperTriangular(A))
                         @test H*x == Array(H)*x broken = eltype(H) <: Furlong && x isa Bidiagonal
                         @test x*H == x*Array(H) broken = eltype(H) <: Furlong && x isa Bidiagonal
-                        @test H/x == Array(H)/x broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, Diagonal, UpperTriangular}
-                        @test x\H == x\Array(H) broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, Diagonal, UpperTriangular}
+                        @test H/x == Array(H)/x broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, UpperTriangular}
+                        @test x\H == x\Array(H) broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, UpperTriangular}
                         @test H*x isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
                         @test x*H isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
-                        @test H/x isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, Diagonal}
-                        @test x\H isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, Diagonal}
+                        @test H/x isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
+                        @test x\H isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
                     end
                     x = Bidiagonal(d, dl, :L)
                     @test H*x == Array(H)*x

--- a/stdlib/SparseArrays/test/higherorderfns.jl
+++ b/stdlib/SparseArrays/test/higherorderfns.jl
@@ -626,7 +626,8 @@ end
     @test 2 .* ((1:5) .+ A) == 2:2:10
     @test 2 .* (A .+ (1:5)) == 2:2:10
 
-    @test Diagonal(spzeros(5)) \ view(rand(10), 1:5) == [Inf,Inf,Inf,Inf,Inf]
+    # lu(zeros(5,5)) throw SingularException, see #42343
+    @test_throws SingularException Diagonal(spzeros(5)) \ view(rand(10), 1:5)
 end
 
 @testset "Issue #27836" begin


### PR DESCRIPTION
This PR tries to add missing optimization for `*`, `/` related fuctions between `Diagonal` and `AbstractTriangular`.
It was first discussed in https://github.com/JuliaLang/julia/pull/42321#issuecomment-924581684, and I notice that such patten also applies to `/`, `ldiv!`, `\` and `rdiv!`.
I believe that unified implement help us cover all possible optimization.
For example, `lmul!` has been missing for years.

Test has been added. 

(I hope I didn't ignore anything.)