### PR TITLE
inference: improve the robustness of `getfield_tfunc`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -883,6 +883,7 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
         return Bottom # can't index fields with Bool
     end
     if !isa(name, Const)
+        name = widenconst(name)
         if !(Int <: name || Symbol <: name)
             return Bottom
         end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -241,6 +241,15 @@ barTuple2() = fooTuple{tuple(:y)}()
           Dict{Int64,Tuple{UnitRange{Int64},UnitRange{Int64}}},
           Core.Compiler.Const(:vals)) == Array{Tuple{UnitRange{Int64},UnitRange{Int64}},1}
 
+# assert robustness of `getfield_tfunc`
+struct GetfieldRobustness
+    field::String
+end
+@test Base.return_types((GetfieldRobustness,String,)) do obj, s
+    t = (10, s) # to form `PartialStruct`
+    getfield(obj, t)
+end |> only === Union{}
+
 # issue #12476
 function f12476(a)
     (k, v) = a


### PR DESCRIPTION
I found `getfield_tfunc` can easily throw on this code path.
In the added test case, I intentionally formed `PartialStruct` as an
example target that can cause an error, but the same thing can happen
for other arbitrary `CompilerTypes` objects.