### PR TITLE
Implement `rem(float, float, RoundNearest)` in Julia

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -892,21 +892,18 @@ end
 function rem(x::T, p::T, ::RoundingMode{:Nearest}) where T<:IEEEFloat
     (iszero(p) || !isfinite(x) || isnan(p)) && return T(NaN)
     x == p && return copysign(zero(T), x)
-    sx = sign(x)
-    if p <= floatmax(T) / 2  # Ensure p+p won't overflow
-        x = rem(x, p + p)  # now x < 2p
-    end
-    x = abs(x)
+    oldx = x
+    x = abs(rem(x, 2p))  # 2p may overflow but that's okay
     p = abs(p)
     if p < 2 * floatmin(T)  # Check whether dividing p by 2 will underflow
-        if x + x > p
+        if 2x > p
             x -= p
-            if x + x >= p
+            if 2x >= p
                 x -= p
             end
         end
     else
-        p_half = T(0.5) * p
+        p_half = p / 2
         if x > p_half
             x -= p
             if x >= p_half
@@ -914,7 +911,7 @@ function rem(x::T, p::T, ::RoundingMode{:Nearest}) where T<:IEEEFloat
             end
         end
     end
-    return flipsign(x, sx)
+    return flipsign(x, oldx)
 end
 
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -880,11 +880,42 @@ function frexp(x::T) where T<:IEEEFloat
     return reinterpret(T, xu), k
 end
 
-rem(x::Float64, y::Float64, ::RoundingMode{:Nearest}) =
-    ccall((:remainder, libm),Float64,(Float64,Float64),x,y)
-rem(x::Float32, y::Float32, ::RoundingMode{:Nearest}) =
-    ccall((:remainderf, libm),Float32,(Float32,Float32),x,y)
-rem(x::Float16, y::Float16, r::RoundingMode{:Nearest}) = Float16(rem(Float32(x), Float32(y), r))
+# NOTE: This `rem` method is adapted from the msun `remainder` and `remainderf`
+# functions, which are under the following license:
+#
+# Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+#
+# Developed at SunSoft, a Sun Microsystems, Inc. business.
+# Permission to use, copy, modify, and distribute this
+# software is freely granted, provided that this notice
+# is preserved.
+function rem(x::T, p::T, ::RoundingMode{:Nearest}) where T<:IEEEFloat
+    (iszero(p) || !isfinite(x) || isnan(p)) && return T(NaN)
+    x == p && return copysign(zero(T), x)
+    sx = sign(x)
+    if p <= floatmax(T) / 2  # Ensure p+p won't overflow
+        x = rem(x, p + p)  # now x < 2p
+    end
+    x = abs(x)
+    p = abs(p)
+    if p < 2 * floatmin(T)  # Check whether dividing p by 2 will underflow
+        if x + x > p
+            x -= p
+            if x + x >= p
+                x -= p
+            end
+        end
+    else
+        p_half = T(0.5) * p
+        if x > p_half
+            x -= p
+            if x >= p_half
+                x -= p
+            end
+        end
+    end
+    return flipsign(x, sx)
+end
 
 
 """

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2527,14 +2527,13 @@ end
         @test isnan(rem(T(1), T(0), mode))
         @test isnan(rem(T(Inf), T(2), mode))
         @test isnan(rem(T(1), T(NaN), mode))
-        if !(T == BigFloat && mode == RoundUp)  # FIXME: Erroneously returns -Inf
-            @test rem(T(4), floatmin(T) * 2, mode) == 0
-        end
+        # FIXME: The broken case erroneously returns -Inf
+        @test rem(T(4), floatmin(T) * 2, mode) == 0 broken=(T == BigFloat && mode == RoundUp)
     end
-    @test rem(nextfloat(typemin(T)), T(2), RoundToZero)  == -0.0
-    @test rem(nextfloat(typemin(T)), T(2), RoundNearest) == -0.0
-    @test rem(nextfloat(typemin(T)), T(2), RoundDown)    == 0.0
-    @test rem(nextfloat(typemin(T)), T(2), RoundUp)      == 0.0
+    @test isequal(rem(nextfloat(typemin(T)), T(2), RoundToZero),  -0.0)
+    @test isequal(rem(nextfloat(typemin(T)), T(2), RoundNearest), -0.0)
+    @test isequal(rem(nextfloat(typemin(T)), T(2), RoundDown),    0.0)
+    @test isequal(rem(nextfloat(typemin(T)), T(2), RoundUp),      0.0)
 end
 
 @testset "rem for $T RoundNearest" for T in (Int8, Int16, Int32, Int64, Int128)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2523,6 +2523,18 @@ end
     @test rem(T(-1.5), T(2), RoundNearest) == 0.5
     @test rem(T(-1.5), T(2), RoundDown)    == 0.5
     @test rem(T(-1.5), T(2), RoundUp)      == -1.5
+    for mode in [RoundToZero, RoundNearest, RoundDown, RoundUp]
+        @test isnan(rem(T(1), T(0), mode))
+        @test isnan(rem(T(Inf), T(2), mode))
+        @test isnan(rem(T(1), T(NaN), mode))
+        if !(T == BigFloat && mode == RoundUp)  # FIXME: Erroneously returns -Inf
+            @test rem(T(4), floatmin(T) * 2, mode) == 0
+        end
+    end
+    @test rem(nextfloat(typemin(T)), T(2), RoundToZero)  == -0.0
+    @test rem(nextfloat(typemin(T)), T(2), RoundNearest) == -0.0
+    @test rem(nextfloat(typemin(T)), T(2), RoundDown)    == 0.0
+    @test rem(nextfloat(typemin(T)), T(2), RoundUp)      == 0.0
 end
 
 @testset "rem for $T RoundNearest" for T in (Int8, Int16, Int32, Int64, Int128)


### PR DESCRIPTION
One of the few remaining uses of openlibm is implementing `rem` with `RoundNearest` for `Float32` and `Float64`. This commit translates the msun libm implementations of [`remainder`](https://github.com/freebsd/freebsd-src/blob/373ffc62c158e52cde86a5b934ab4a51307f9f2e/lib/msun/src/e_remainder.c) and [`remainderf`](https://github.com/freebsd/freebsd-src/blob/373ffc62c158e52cde86a5b934ab4a51307f9f2e/lib/msun/src/e_remainderf.c) to Julia to avoid relying on openlibm or the local system libm.

The implementations of the `Float32` and `Float64` methods are quite similar and could be combined with a bit more work. I'd be happy to do that but would need some guidance for some of the less obvious magic numbers.

Checks off the `rem` box in https://github.com/JuliaLang/julia/issues/26434.