### PR TITLE
CI (GHA): For the `Retry Failed Buildkite Jobs` workflow, remove the `labeled` trigger and add the workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,12 +27,14 @@ on:
   # the PR is from a fork. Therefore, for security reasons, we do not checkout any code in
   # this workflow.
   pull_request_target:
+    types: [ reopened ]
 
-    # TODO: delete the following line (once we have completely transitioned from Buildbot to Buildkite)
-    types: [ reopened, labeled ]
-
-    # TODO: uncomment the following line (once we have completely transitioned from Buildbot to Buildkite)
-    # types: [ reopened ]
+  # TODO: delete the following `workflow_dispatch` section (once we have completely transitioned from Buildbot to Buildkite)
+  workflow_dispatch:
+    inputs:
+      PULL_REQUEST_NUMBER:
+        description: 'The number of the pull request:'
+        required: true
 
 # We do not give the `GITHUB_TOKEN` any permissions.
 permissions:
@@ -42,18 +44,23 @@ jobs:
   retry:
     name: retry
     runs-on: ubuntu-latest
-
-    # TODO: delete the following line (once we have completely transitioned from Buildbot to Buildkite)
-    if: github.repository == 'JuliaLang/julia' && (github.event.label.name == 'Buildkite - retry failed jobs' || github.event.action == 'reopened')
-
-    # TODO: uncomment the following line (once we have completely transitioned from Buildbot to Buildkite)
-    # if: github.repository == 'JuliaLang/julia'
-
+    if: github.repository == 'JuliaLang/julia'
     steps:
       # For security reasons, we do not checkout any code in this workflow.
+      - if: github.event_name == 'pull_request_target'
+        run: |
+          echo "pr_number=${{ github.event.number }}" >> $GITHUB_ENV
+
+      # TODO: delete the following three lines (once we have completely transitioned from Buildbot to Buildkite)
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "pr_number=${{ github.event.inputs.PULL_REQUEST_NUMBER }}" >> $GITHUB_ENV
+
+      - run: |
+          echo "The pull request number is: ${{ env.pr_number }}"
       - uses: JuliaLang/retry-buildkite@057f6f2d37aa29a57b7679fd2af0df1d9f9188b4
         with:
           buildkite_api_token: ${{ secrets.BUILDKITE_API_TOKEN_RETRY }}
           buildkite_organization_slug: 'julialang'
           buildkite_pipeline_slug: 'julia-master'
-          pr_number: ${{github.event.number}}
+          pr_number: ${{ env.pr_number }}


### PR DESCRIPTION
## Description

### Before this PR

Before this PR, if a committer wants to retry the failed Buildkite jobs on a PR, they do the following steps:
1. Go to the relevant PR on GitHub.
2. Add the `Buildkite - retry failed jobs` label to the PR.

(If the PR in question already has the `Buildkite - retry failed jobs` label, you need to first remove the `Buildkite - retry failed jobs` label, and then re-add the `Buildkite - retry failed jobs` label.)

### After this PR

After this PR, if a committer wants to retry the failed Buildkite jobs, they do the following steps:
1. Go to this URL: https://github.com/JuliaLang/julia/actions/workflows/retry.yml
2. In the section that says "This workflow has a `workflow_dispatch` event trigger", click on the `Run workflow` button.
3. Under "Use workflow from", make sure that you have selected the `master` branch.
4. Under "The number of the pull request:", enter the number of the PR for which you want to retry the failed Buildkite jobs. E.g. `12345`
5. Click on the green `Run workflow` button.

## Pros and cons

Pros of this PR:
- GitHub will no longer create a "skipped" `Retry` commit status every time someone adds a label to a PR.

Cons of this PR:
- It takes more steps for a user to trigger a retry.