### PR TITLE
Revert "inference: improve the robustness of `getfield_tfunc`"

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -883,7 +883,6 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
         return Bottom # can't index fields with Bool
     end
     if !isa(name, Const)
-        name = widenconst(name)
         if !(Int <: name || Symbol <: name)
             return Bottom
         end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -241,15 +241,6 @@ barTuple2() = fooTuple{tuple(:y)}()
           Dict{Int64,Tuple{UnitRange{Int64},UnitRange{Int64}}},
           Core.Compiler.Const(:vals)) == Array{Tuple{UnitRange{Int64},UnitRange{Int64}},1}
 
-# assert robustness of `getfield_tfunc`
-struct GetfieldRobustness
-    field::String
-end
-@test Base.return_types((GetfieldRobustness,String,)) do obj, s
-    t = (10, s) # to form `PartialStruct`
-    getfield(obj, t)
-end |> only === Union{}
-
 # issue #12476
 function f12476(a)
     (k, v) = a


### PR DESCRIPTION
Reverts JuliaLang/julia#42378

---

I'm making this PR to see whether it fixes the CI failures that I'm seeing on master.