### PR TITLE
remove testset from a test in `boundscheck_exec.jl`

### DIFF
--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -259,17 +259,15 @@ if bc_opt == bc_default || bc_opt == bc_off
     @test !occursin("arrayref(true", typed_40281)
 end
 
-@testset "pass inbounds meta to getindex on CartesianIndices (#42115)" begin
-    @inline getindex_42115(r, i, j) = @inbounds getindex(r, i, j)
+@inline getindex_42115(r, i, j) = @inbounds getindex(r, i, j)
 
-    R = CartesianIndices((5, 5))
-    if bc_opt == bc_on
-        @test_throws BoundsError getindex_42115(R, -1, -1)
-        @test_throws BoundsError getindex_42115(R, 1, -1)
-    else
-        @test getindex_42115(R, -1, -1) == CartesianIndex(-1, -1)
-        @test getindex_42115(R, 1, -1) == CartesianIndex(1, -1)
-    end
+R_42115 = CartesianIndices((5, 5))
+if bc_opt == bc_on
+    @test_throws BoundsError getindex_42115(R_42115, -1, -1)
+    @test_throws BoundsError getindex_42115(R_42115, 1, -1)
+else
+    @test getindex_42115(R_42115, -1, -1) == CartesianIndex(-1, -1)
+    @test getindex_42115(R_42115, 1, -1) == CartesianIndex(1, -1)
 end
 
-end
+end # module


### PR DESCRIPTION
otherwise, this prints testset status to the console when running the base tests

Can be seen in e.g. https://build.julialang.org/#/builders/65/builds/3404/steps/5/logs/stdio

```
      From worker 9:	Test Summary:                                               | Pass  Total
      From worker 9:	pass inbounds meta to getindex on CartesianIndices (#42115) |    2      2
      From worker 9:	Test Summary:                                               | Pass  Total
      From worker 9:	pass inbounds meta to getindex on CartesianIndices (#42115) |    2      2
      From worker 9:	Test Summary:                                               | Pass  Total
      From worker 9:	pass inbounds meta to getindex on CartesianIndices (#42115) |    2      2
```