### PR TITLE
strings: add compat annotation for `eachsplit()`.

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -399,6 +399,9 @@ The default of `limit=0` implies no maximum.
 
 See also [`split`](@ref).
 
+!!! compat "Julia 1.8"
+    The `eachsplit` function requires at least Julia 1.8.
+
 # Examples
 ```jldoctest
 julia> a = "Ma.rch"


### PR DESCRIPTION
Forgot about this in dba8a0821306f0e9ae1917be925d39af894713f2.

Might also be a good time to discuss the `eachsplit` vs `Iterators.split` naming for this, as brought up by @sostock in https://github.com/JuliaLang/julia/pull/39245#issuecomment-915801633. Which does triage prefer?