### PR TITLE
Implement `modf` in Julia

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -904,16 +904,12 @@ julia> modf(-3.5)
 """
 modf(x) = isinf(x) ? (flipsign(zero(x), x), x) : (rem(x, one(x)), trunc(x))
 
-function modf(x::Float32)
-    temp = Ref{Float32}()
-    f = ccall((:modff, libm), Float32, (Float32, Ptr{Float32}), x, temp)
-    f, temp[]
-end
-
-function modf(x::Float64)
-    temp = Ref{Float64}()
-    f = ccall((:modf, libm), Float64, (Float64, Ptr{Float64}), x, temp)
-    f, temp[]
+function modf(x::T) where T<:IEEEFloat
+    isnan(x) && return (x, x)
+    isinf(x) && return (copysign(zero(T), x), copysign(T(Inf), x))
+    ix = trunc(x)
+    rx = x - ix
+    return (rx, ix)
 end
 
 @inline function ^(x::Float64, y::Float64)

--- a/base/math.jl
+++ b/base/math.jl
@@ -908,7 +908,7 @@ function modf(x::T) where T<:IEEEFloat
     isnan(x) && return (x, x)
     isinf(x) && return (copysign(zero(T), x), copysign(T(Inf), x))
     ix = trunc(x)
-    rx = x - ix
+    rx = copysign(x - ix, x)
     return (rx, ix)
 end
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -905,8 +905,7 @@ julia> modf(-3.5)
 modf(x) = isinf(x) ? (flipsign(zero(x), x), x) : (rem(x, one(x)), trunc(x))
 
 function modf(x::T) where T<:IEEEFloat
-    isnan(x) && return (x, x)
-    isinf(x) && return (copysign(zero(T), x), copysign(T(Inf), x))
+    isinf(x) && return (copysign(zero(T), x), x)
     ix = trunc(x)
     rx = copysign(x - ix, x)
     return (rx, ix)

--- a/test/math.jl
+++ b/test/math.jl
@@ -652,14 +652,15 @@ end
 end
 
 @testset "modf" begin
-    @testset "$elty" for elty in (Float16, Float32, Float64)
-        @test modf( convert(elty,1.2) )[1] ≈ convert(elty,0.2)
-        @test modf( convert(elty,1.2) )[2] ≈ convert(elty,1.0)
-        @test modf( convert(elty,1.0) )[1] ≈ convert(elty,0.0)
-        @test modf( convert(elty,1.0) )[2] ≈ convert(elty,1.0)
-        @test isequal(modf( convert(elty,-Inf) ), (-0.0, -Inf))
-        @test isequal(modf( convert(elty,Inf) ), (0.0, Inf))
-        @test isequal(modf( convert(elty,NaN) ), (NaN, NaN))
+    @testset "$T" for T in (Float16, Float32, Float64)
+        @test modf(T(1.2))[1] ≈ T(0.2)
+        @test modf(T(1.2))[2] ≈ T(1.0)
+        @test modf(T(1.0))[1] ≈ T(0.0)
+        @test modf(T(1.0))[2] ≈ T(1.0)
+        @test isequal(modf(T(-Inf)), (-0.0, -Inf))
+        @test isequal(modf(T(Inf)), (0.0, Inf))
+        @test isequal(modf(T(NaN)), (NaN, NaN))
+        @test isequal(modf(T(-0.0)), (-0.0, -0.0))
     end
 end
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -653,14 +653,12 @@ end
 
 @testset "modf" begin
     @testset "$T" for T in (Float16, Float32, Float64)
-        @test modf(T(1.2))[1] ≈ T(0.2)
-        @test modf(T(1.2))[2] ≈ T(1.0)
-        @test modf(T(1.0))[1] ≈ T(0.0)
-        @test modf(T(1.0))[2] ≈ T(1.0)
-        @test isequal(modf(T(-Inf)), (-0.0, -Inf))
-        @test isequal(modf(T(Inf)), (0.0, Inf))
-        @test isequal(modf(T(NaN)), (NaN, NaN))
-        @test isequal(modf(T(-0.0)), (-0.0, -0.0))
+        @test modf(T(1.25)) === (T(0.25), T(1.0))
+        @test modf(T(1.0))  === (T(0.0), T(1.0))
+        @test modf(T(-Inf)) === (T(-0.0), T(-Inf))
+        @test modf(T(Inf))  === (T(0.0), T(Inf))
+        @test modf(T(NaN))  === (T(NaN), T(NaN))
+        @test modf(T(-0.0)) === (T(-0.0), T(-0.0))
     end
 end
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -659,6 +659,7 @@ end
         @test modf(T(Inf))  === (T(0.0), T(Inf))
         @test modf(T(NaN))  === (T(NaN), T(NaN))
         @test modf(T(-0.0)) === (T(-0.0), T(-0.0))
+        @test modf(T(-1.0)) === (T(-0.0), T(-1.0))
     end
 end
 


### PR DESCRIPTION
Currently `modf` calls into libm, and is one of the few remaining holdouts that use libm. This commit reimplements it in Julia ~~using the algorithm used by [musl libc](https://git.musl-libc.org/cgit/musl/tree/src/math/modf.c).~~

Checks off the `modf` box in https://github.com/JuliaLang/julia/issues/26434.

Performance (outdated):

- `Float64`:
   ```
   julia> @benchmark modf(y) setup=(y = randn(Float64))
   BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
    Range (min … max):  3.390 ns … 36.944 ns  ┊ GC (min … max): 0.00% … 0.00%
    Time  (median):     4.018 ns              ┊ GC (median):    0.00%
    Time  (mean ± σ):   4.079 ns ±  1.228 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       █             ▃   ▁
     █▁█▂▃▄▂▄▂▂▄▂▂▅▃▂█▃▂▄█▂▃▂▂▃▂▂▂▃▂▂▂▃▂▂▂▅▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
     3.39 ns        Histogram: frequency by time        6.05 ns <

    Memory estimate: 0 bytes, allocs estimate: 0.

   julia> @benchmark new_modf(y) setup=(y = randn(Float64))
   BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
    Range (min … max):  2.544 ns … 21.882 ns  ┊ GC (min … max): 0.00% … 0.00%
    Time  (median):     2.678 ns              ┊ GC (median):    0.00%
    Time  (mean ± σ):   2.845 ns ±  0.572 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ██                                           ▅▁
     ██▅▃▂▂▃▆▃▂▂▂▂▃▄▂▂▂▂▂▂▃▂▂▂▂▂▂▅▅▂▂▂▂▁▂▃▄▂▂▂▂▂▁▂██▃▂▂▂▂▂▁▃▄▂▂ ▃
     2.54 ns        Histogram: frequency by time        3.32 ns <

    Memory estimate: 0 bytes, allocs estimate: 0.
   ```

- `Float32`:
   ```
   julia> @benchmark modf(y) setup=(y = randn(Float32))
   BenchmarkTools.Trial: 10000 samples with 999 evaluations.
    Range (min … max):  5.804 ns … 379.941 ns  ┊ GC (min … max): 0.00% … 0.00%
    Time  (median):     6.615 ns               ┊ GC (median):    0.00%
    Time  (mean ± σ):   6.717 ns ±   4.115 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     █  ▇▁  ▅   ▂   ▃ ▇  ▄▆▁ ▃▄▂   ▇    ▃▂   ▂     ▃     ▅       ▂
     █▁▄██▅▅██▅▃█▅▃▁█▄█▆████▃███▄▁▃█▄▃▁▁██▁▆▆██▄▄▅▄█▃▁▁▁▄█▅▁▁▃▃█ █
     5.8 ns       Histogram: log(frequency) by time      8.88 ns <

    Memory estimate: 0 bytes, allocs estimate: 0.

   julia> @benchmark new_modf(y) setup=(y = randn(Float32))
   BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
    Range (min … max):  2.231 ns … 50.761 ns  ┊ GC (min … max): 0.00% … 0.00%
    Time  (median):     2.385 ns              ┊ GC (median):    0.00%
    Time  (mean ± σ):   2.485 ns ±  0.726 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

      █▂                                                  ▁
     ▅██▅▃▂▂▃▅▅▃▂▂▂▂▂▄▃▃▂▂▂▁▂▄▄▃▂▂▁▂▁▂▃▄▃▂▂▂▂▂▂▃▄▃▃▂▂▂▁▂▂▄█▇▅▃▂ ▃
     2.23 ns        Histogram: frequency by time        2.81 ns <

    Memory estimate: 0 bytes, allocs estimate: 0.
   ```

- `Float16`:
   ```
   julia> @benchmark modf(y) setup=(y = randn(Float16))
   BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
    Range (min … max):  4.902 ns … 57.827 ns  ┊ GC (min … max): 0.00% … 0.00%
    Time  (median):     5.450 ns              ┊ GC (median):    0.00%
    Time  (mean ± σ):   7.375 ns ±  3.338 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     █▆▄▂▂▃▄▅▂                   ▃▂▃▁▅▂▄▂▃▁▁ ▁  ▂ ▁  ▃          ▁
     █████████▆▅▂▄▇▃▅▂▄▅▄▅▂▃▅▅▆▅▆███████████▆█▇████▆▇█▄▇▇▅▅▄▂▂▄ █
     4.9 ns       Histogram: log(frequency) by time     15.3 ns <

    Memory estimate: 0 bytes, allocs estimate: 0.

   julia> @benchmark new_modf(y) setup=(y = randn(Float16))
   BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
    Range (min … max):  2.232 ns … 36.280 ns  ┊ GC (min … max): 0.00% … 0.00%
    Time  (median):     2.766 ns              ┊ GC (median):    0.00%
    Time  (mean ± σ):   2.960 ns ±  0.926 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     █ ▆▁▄ ▄ ▅ ▄▁▄▇ ▄▂             ▆▅ ▄  ▃ ▁▃▁ ▁▃  ▃   ▅▂  ▂▁   ▂
     █▇█████▆█▅████▃██▃▁▃▄▁▃▃▃▁▁▄▄▃██▄████████████▇███▇██▇▅███▇ █
     2.23 ns      Histogram: log(frequency) by time     4.62 ns <

    Memory estimate: 0 bytes, allocs estimate: 0.
   ```

Exact behavior matching with the current implementation:
```
julia> @testset "$T" for T in [Float16, Float32, Float64]
           for value in [zero(T), -zero(T), T(Inf), -T(Inf), T(NaN),
                         typemin(T), prevfloat(typemin(T)),
                         typemax(T), prevfloat(typemax(T))]
               @test modf(value) === new_modf(value)
           end
       end
Test Summary: | Pass  Total
Float16       |    9      9
Test Summary: | Pass  Total
Float32       |    9      9
Test Summary: | Pass  Total
Float64       |    9      9
```