### PR TITLE
Strip address information from byval type parameters.

### DIFF
--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -325,7 +325,7 @@ bool RemoveAddrspacesPass::runOnModule(Module &M)
 
         Function *NF = Function::Create(
                 NFTy, F->getLinkage(), F->getAddressSpace(), Name, &M);
-        NF->copyAttributesFrom(F);
+        // no need to copy attributes here, that's done by CloneFunctionInto
         VMap[F] = NF;
     }
 
@@ -386,6 +386,22 @@ bool RemoveAddrspacesPass::runOnModule(Module &M)
                 nullptr,
                 &TypeRemapper,
                 &Materializer);
+
+        // CloneFunctionInto unconditionally copies the attributes from F to NF,
+        // without considering e.g. the byval attribute type.
+        AttributeList Attrs = F->getAttributes();
+        LLVMContext &C = F->getContext();
+        for (unsigned i = 0; i < Attrs.getNumAttrSets(); ++i) {
+            for (Attribute::AttrKind TypedAttr :
+                 {Attribute::ByVal, Attribute::StructRet, Attribute::ByRef}) {
+                if (Type *Ty = Attrs.getAttribute(i, TypedAttr).getValueAsType()) {
+                    Attrs = Attrs.replaceAttributeType(C, i, TypedAttr,
+                                                       TypeRemapper.remapType(Ty));
+                    break;
+                }
+            }
+        }
+        NF->setAttributes(Attrs);
 
         if (F->hasPersonalityFn())
             NF->setPersonalityFn(MapValue(F->getPersonalityFn(), VMap));

--- a/test/llvmpasses/remove-addrspaces.ll
+++ b/test/llvmpasses/remove-addrspaces.ll
@@ -101,3 +101,10 @@ loop:
 exit:
   ret i64 %sum
 }
+
+
+; COM: check that address spaces in byval types are processed correctly
+define void @byval_type([1 x {} addrspace(10)*] addrspace(11)* byval([1 x {} addrspace(10)*]) %0) {
+; CHECK: define void @byval_type([1 x {}*]* byval([1 x {}*]) %0)
+  ret void
+}


### PR DESCRIPTION
LLVM 12 introduced typed byval, but CloneFunctionInto does [a plain copyAttributesFrom](https://github.com/llvm/llvm-project/blob/66d9d1012b031e7f7559e8f0e03b9e7bfb6c20a1/llvm/lib/Transforms/Utils/CloneFunction.cpp#L99-L103) without rewriting contained types. The ValueMapper does [the correct thing](https://github.com/llvm/llvm-project/blob/66d9d1012b031e7f7559e8f0e03b9e7bfb6c20a1/llvm/lib/Transforms/Utils/ValueMapper.cpp#L944-L960) for calls though, so this looks like an oversight. But it's easy enough to fix that locally for now.