### PR TITLE
Base: `intersect` keep the container type

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -129,7 +129,13 @@ Set{Int64} with 1 element:
 """
 function intersect(s::AbstractSet, itr, itrs...)
     T = promote_eltype(s, itr, itrs...)
-    return intersect!(Set{T}(s), itr, itrs...)
+    if T == promote_eltype(s, itr)
+        out = intersect(s, itr)
+    else
+        out = union!(emptymutable(s, T), s)
+        intersect!(out, itr)
+    end
+    return intersect!(out, itrs...)
 end
 intersect(s) = union(s)
 intersect(s::AbstractSet, itr) = mapfilter(in(s), push!, itr, emptymutable(s, promote_eltype(s, itr)))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -254,6 +254,8 @@ end
     end
     @test intersect(Set([1]), BitSet()) isa Set{Int}
     @test intersect(BitSet([1]), Set()) isa Set{Any}
+    @test intersect(BitSet([1]), Set([1])) isa BitSet
+    @test intersect(BitSet([1]), Set([1]), Set([1])) isa BitSet
     @test intersect([1], BitSet()) isa Vector{Int}
     # intersect must uniquify
     @test intersect([1, 2, 1]) == intersect!([1, 2, 1]) == [1, 2]
@@ -276,6 +278,10 @@ end
             @test eltype(intersect(a, a, b)) == Float64
         end
     end
+
+    # 3-argument version is correctly covered
+    @test intersect(Set([1,2]), Set([2]), Set([1,2,3])) == Set([2])
+    @test intersect(Set([1,2]), Set([2]), Set([1.,2,3])) == Set([2.])
 end
 
 @testset "setdiff" begin


### PR DESCRIPTION
A bug was introduced for 3 arguments version of `intersect` in #41769. The container type always changed to `Set`. See [this comment](https://github.com/JuliaLang/julia/pull/41769#discussion_r710425716).

master:

```julia
julia> intersect(BitSet([1,2]), [1,2], [2])
Set{Int64} with 1 element:
  2
```

After this PR:

```julia
julia> intersect(BitSet([1,2]), [1,2], [2])
BitSet with 1 element:
  2

julia> intersect(BitSet([1,2]), [1,2], [2.0])
Set{Float64} with 1 element:
  2.0
```

I kindly ask you to suggest improvements as this PR introduces a slow-down (compared to 1.6.2):
```julia
# 1.6.2
julia> @btime intersect(BitSet([1,2]), [1,2], [2])
  397.583 ns (12 allocations: 768 bytes)
BitSet with 1 element:
  2
# PR
julia> @btime intersect(BitSet([1,2]), [1,2], [2])
  516.840 ns (15 allocations: 928 bytes)
BitSet with 1 element:
  2
```

EDIT: cc @vtjnash who first noticed this bug