### PR TITLE
Force compilation with Expr(:meta, :compile, :force)

### DIFF
--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -162,6 +162,30 @@ macro compiler_options(args...)
     return opts
 end
 
+"""
+    Experimental.@compile
+
+Force compilation of the block or function (Julia's built-in interpreter is blocked from executing it).
+
+# Examples
+
+```
+module WithPrecompiles
+#=
+    code definitions
+=#
+
+if Sys.iswindows()
+    Experimental.@compile
+    compile_me()  # `compile_me` will be compiled before execution (not run in the interpreter)
+end
+
+end
+```
+"""
+macro compile() Expr(:meta, :compile, :force) end
+
+
 # UI features for errors
 
 """

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -385,13 +385,6 @@ macro propagate_inbounds(ex)
 end
 
 """
-    @compile
-
-Force compilation of the block or function (Julia's built-in interpreter is blocked from executing it).
-"""
-macro compile() Expr(:meta, :compile) end
-
-"""
     @polly
 
 Tells the compiler to apply the polyhedral optimizer Polly to a function.

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -213,7 +213,7 @@ julia> @time begin
 """
 macro time(ex)
     quote
-        @compile
+        Experimental.@compile
         local stats = gc_num()
         local elapsedtime = time_ns()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
@@ -260,7 +260,7 @@ pool allocs:       1
 """
 macro timev(ex)
     quote
-        @compile
+        Experimental.@compile
         local stats = gc_num()
         local elapsedtime = time_ns()
         local compile_elapsedtime = cumulative_compile_time_ns_before()
@@ -294,7 +294,7 @@ julia> @elapsed sleep(0.3)
 """
 macro elapsed(ex)
     quote
-        @compile
+        Experimental.@compile
         local t0 = time_ns()
         $(esc(ex))
         (time_ns() - t0) / 1e9
@@ -326,7 +326,7 @@ julia> @allocated rand(10^6)
 """
 macro allocated(ex)
     quote
-        @compile
+        Experimental.@compile
         local b0 = Ref{Int64}(0)
         local b1 = Ref{Int64}(0)
         gc_bytes(b0)
@@ -374,7 +374,7 @@ julia> stats.gcstats.total_time
 """
 macro timed(ex)
     quote
-        @compile
+        Experimental.@compile
         local stats = gc_num()
         local elapsedtime = time_ns()
         local val = $(esc(ex))

--- a/src/ast.c
+++ b/src/ast.c
@@ -68,7 +68,7 @@ jl_sym_t *coverageeffect_sym; jl_sym_t *escape_sym;
 jl_sym_t *aliasscope_sym; jl_sym_t *popaliasscope_sym;
 jl_sym_t *optlevel_sym; jl_sym_t *thismodule_sym;
 jl_sym_t *atom_sym; jl_sym_t *statement_sym; jl_sym_t *all_sym;
-jl_sym_t *compile_sym; jl_sym_t *infer_sym;
+jl_sym_t *compile_sym; jl_sym_t *infer_sym; jl_sym_t *force_sym;
 
 jl_sym_t *atomic_sym;
 jl_sym_t *not_atomic_sym;
@@ -406,6 +406,7 @@ void jl_init_common_symbols(void)
     optlevel_sym = jl_symbol("optlevel");
     compile_sym = jl_symbol("compile");
     infer_sym = jl_symbol("infer");
+    force_sym = jl_symbol("force");
     macrocall_sym = jl_symbol("macrocall");
     escape_sym = jl_symbol("escape");
     hygienicscope_sym = jl_symbol("hygienic-scope");

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1411,7 +1411,7 @@ extern jl_sym_t *throw_undef_if_not_sym; extern jl_sym_t *getfield_undefref_sym;
 extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
 extern jl_sym_t *coverageeffect_sym; extern jl_sym_t *escape_sym;
 extern jl_sym_t *optlevel_sym; extern jl_sym_t *compile_sym;
-extern jl_sym_t *infer_sym;
+extern jl_sym_t *infer_sym; extern jl_sym_t *force_sym;
 extern jl_sym_t *atom_sym; extern jl_sym_t *statement_sym; extern jl_sym_t *all_sym;
 
 extern jl_sym_t *atomic_sym;


### PR DESCRIPTION
This more explicit directive distinguishes `@compile`
(now moved to Experimental) from `@compiler_options`
(which uses the same `:compile` symbol). It eliminates
a collision between #42128 and #37041.

Fixes #42373
Closes #42379