### PR TITLE
fix verifier to allow GlobalRef as assignment RHS

### DIFF
--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -202,6 +202,10 @@ function verify_ir(ir::IRCode, print::Bool=true)
                         @verify_error "SSAValue as assignment LHS"
                         error("")
                     end
+                    if stmt.args[2] isa GlobalRef
+                        # undefined GlobalRef as assignment RHS is OK
+                        continue
+                    end
                 elseif stmt.head === :gc_preserve_end
                     # We allow gc_preserve_end tokens to span across try/catch
                     # blocks, which isn't allowed for regular SSA values, so


### PR DESCRIPTION
Found while working on JuliaLang/julia#42409. The verifier treats an assignment RHS as a normal value use, which is typically correct, but I believe it is ok for an undefined GlobalRef to be present there, unlike other value contexts.