### PR TITLE
Add recursive findfirst method for tuples.

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -354,7 +354,8 @@ _totuple(::Type{Tuple}, itr::NamedTuple) = (itr...,)
 
 end
 
-## findfirst ##
+## find ##
+
 _findfirst_rec(f, i::Int, ::Tuple{}) = nothing
 _findfirst_rec(f, i::Int, t::Tuple) = (@inline; f(first(t)) ? i : _findfirst_rec(f, i+1, tail(t)))
 function _findfirst_loop(f::Function, t)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -354,6 +354,16 @@ _totuple(::Type{Tuple}, itr::NamedTuple) = (itr...,)
 
 end
 
+## findfirst ##
+_findfirst(f, i::Int, ::Tuple{}) = nothing
+_findfirst(f, i::Int, x::Tuple) = (@inline; f(first(x)) ? i : _findfirst(f, i+1, tail(x)))
+findfirst(f::Function, x::Tuple) = _findfirst(f, 1, x)
+function findfirst(f::Function, x::Any32)
+  for i in 1:length(x)
+    f(x[i]) && return i
+  end
+end
+
 ## filter ##
 
 filter_rec(f, xs::Tuple) = afoldl((ys, x) -> f(x) ? (ys..., x) : ys, (), xs...)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -362,6 +362,7 @@ function _findfirst_loop(f::Function, t)
     for i in 1:length(t)
         f(t[i]) && return i
     end
+    return nothing
 end
 findfirst(f::Function, t::Tuple) = length(t) < 32 ? _findfirst_rec(f, 1, t) : _findfirst_loop(f, t)
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -356,7 +356,7 @@ end
 
 ## findfirst ##
 _findfirst_rec(f, i::Int, ::Tuple{}) = nothing
-_findfirst_rec(f, i::Int, t::Tuple) = (@inline; f(first(t)) ? i : _findfirst(f, i+1, tail(t)))
+_findfirst_rec(f, i::Int, t::Tuple) = (@inline; f(first(t)) ? i : _findfirst_rec(f, i+1, tail(t)))
 function _findfirst_loop(f::Function, t)
     for i in 1:length(t)
         f(t[i]) && return i

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -525,9 +525,19 @@ end
         @test findprev(isequal(1), (1, 1), UInt(1)) isa Int
     end
 
+    # recursive implementation should allow constant-folding for small tuples
     @test Base.return_types() do
         findfirst(==(2), (1.0,2,3f0))
     end == Any[Int]
+    @test Base.return_types() do
+        findfirst(==(0), (1.0,2,3f0))
+    end == Any[Nothing]
+    @test Base.return_types() do
+        findlast(==(2), (1.0,2,3f0))
+    end == Any[Int]
+    @test Base.return_types() do
+        findlast(==(0), (1.0,2,3f0))
+    end == Any[Nothing]
 end
 
 @testset "properties" begin

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -524,6 +524,10 @@ end
         @test findnext(isequal(1), (1, 1), UInt(2)) isa Int
         @test findprev(isequal(1), (1, 1), UInt(1)) isa Int
     end
+
+    @test Base.return_types() do
+        findfirst(==(2), (1.0,2,3f0))
+    end == Any[Int]
 end
 
 @testset "properties" begin


### PR DESCRIPTION
https://discourse.julialang.org/t/why-does-findfirst-t-on-a-tuple-of-typed-only-constant-fold-for-the-first/68893

With this PR:
```julia
julia> position(::T) where T = findfirst(==(T), (Int, Float64, Char))
position (generic function with 1 method)

julia> @code_typed position(10)
CodeInfo(
1 ─     return 1
) => Int64

julia> @code_typed position(10.0)
CodeInfo(
1 ─     return 2
) => Int64

julia> @code_typed position('j')
CodeInfo(
1 ─     return 3
) => Int64

julia> @code_typed position(10f0)
CodeInfo(
1 ─     return nothing
) => Nothing
```