### PR TITLE
Document include path separator normalization via normpath

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -472,7 +472,7 @@ Returns the result of the last evaluated expression of the input file. During in
 a task-local include path is set to the directory containing the file. Nested calls to
 `include` will search relative to that path. This function is typically used to load source
 interactively, or to combine files in packages that are broken into multiple source files.
-The argument `path` is normalized using [`Base.Filesystem.normpath`](@ref) which will resolve
+The argument `path` is normalized using [`normpath`](@ref) which will resolve
 relative path tokens such as `..` and convert `/` to the appropriate path separator.
 
 The optional first argument `mapexpr` can be used to transform the included code before

--- a/base/client.jl
+++ b/base/client.jl
@@ -472,6 +472,9 @@ Returns the result of the last evaluated expression of the input file. During in
 a task-local include path is set to the directory containing the file. Nested calls to
 `include` will search relative to that path. This function is typically used to load source
 interactively, or to combine files in packages that are broken into multiple source files.
+        
+The argument `path` is normalized using [`Base.Filesystem.normpath`](@ref) which will resolve
+relative path tokens such as `..` and convert `/` to the appropriate path separator.
 
 The optional first argument `mapexpr` can be used to transform the included code before
 it is evaluated: for each parsed expression `expr` in `path`, the `include` function

--- a/base/client.jl
+++ b/base/client.jl
@@ -472,7 +472,6 @@ Returns the result of the last evaluated expression of the input file. During in
 a task-local include path is set to the directory containing the file. Nested calls to
 `include` will search relative to that path. This function is typically used to load source
 interactively, or to combine files in packages that are broken into multiple source files.
-        
 The argument `path` is normalized using [`Base.Filesystem.normpath`](@ref) which will resolve
 relative path tokens such as `..` and convert `/` to the appropriate path separator.
 

--- a/base/path.jl
+++ b/base/path.jl
@@ -356,12 +356,17 @@ joinpath
 """
     normpath(path::AbstractString) -> String
 
-Normalize a path, removing "." and ".." entries.
+Normalize a path, removing "." and ".." entries and changing "/" to the canonical path separator
+for the system.
 
 # Examples
 ```jldoctest
 julia> normpath("/home/myuser/../example.jl")
 "/home/example.jl"
+                                            
+julia> normpath("Documents/Julia") == joinpath("Documents", "Julia")
+true
+
 ```
 """
 function normpath(path::String)

--- a/base/path.jl
+++ b/base/path.jl
@@ -363,7 +363,6 @@ for the system.
 ```jldoctest
 julia> normpath("/home/myuser/../example.jl")
 "/home/example.jl"
-                                            
 julia> normpath("Documents/Julia") == joinpath("Documents", "Julia")
 true
 ```

--- a/base/path.jl
+++ b/base/path.jl
@@ -363,6 +363,7 @@ for the system.
 ```jldoctest
 julia> normpath("/home/myuser/../example.jl")
 "/home/example.jl"
+
 julia> normpath("Documents/Julia") == joinpath("Documents", "Julia")
 true
 ```

--- a/base/path.jl
+++ b/base/path.jl
@@ -366,7 +366,6 @@ julia> normpath("/home/myuser/../example.jl")
                                             
 julia> normpath("Documents/Julia") == joinpath("Documents", "Julia")
 true
-
 ```
 """
 function normpath(path::String)


### PR DESCRIPTION
This documents the path normalization introduced to `include` by #26656. This includes resolving ".." and changing the path separator to the canonical path separator.