### PR TITLE
Reduce allocation in indexing an AbstractQ matrix

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -568,11 +568,10 @@ size(Q::AbstractQ, dim::Integer) = size(getfield(Q, :factors), dim == 2 ? 1 : di
 size(Q::AbstractQ) = size(Q, 1), size(Q, 2)
 
 function getindex(Q::AbstractQ, i::Integer, j::Integer)
-    x = zeros(eltype(Q), size(Q, 1))
-    x[i] = 1
     y = zeros(eltype(Q), size(Q, 2))
     y[j] = 1
-    return dot(x, lmul!(Q, y))
+    lmul!(Q, y)
+    return y[i]
 end
 
 # specialization avoiding the fallback using slow `getindex`

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -567,8 +567,9 @@ size(F::Union{QR,QRCompactWY,QRPivoted}) = size(getfield(F, :factors))
 size(Q::AbstractQ, dim::Integer) = size(getfield(Q, :factors), dim == 2 ? 1 : dim)
 size(Q::AbstractQ) = size(Q, 1), size(Q, 2)
 
-getindex(Q::AbstractQ, inds...) = Matrix(Q)[inds...]
-getindex(Q::AbstractQ, ::Colon, ::Colon) = Matrix(Q)
+copy(Q::AbstractQ) = I(size(Q, 1)) * Q
+getindex(Q::AbstractQ, inds...) = copy(Q)[inds...]
+getindex(Q::AbstractQ, ::Colon, ::Colon) = copy(Q)
 
 function getindex(Q::AbstractQ, ::Colon, j::Int)
     y = zeros(eltype(Q), size(Q, 2))

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -567,12 +567,23 @@ size(F::Union{QR,QRCompactWY,QRPivoted}) = size(getfield(F, :factors))
 size(Q::AbstractQ, dim::Integer) = size(getfield(Q, :factors), dim == 2 ? 1 : dim)
 size(Q::AbstractQ) = size(Q, 1), size(Q, 2)
 
-function getindex(Q::AbstractQ, i::Integer, j::Integer)
+getindex(Q::AbstractQ, C::Colon...) = Matrix(Q)[C...]
+getindex(Q::AbstractQ, ::Colon, ::Colon) = Matrix(Q)
+
+function getindex(Q::AbstractQ, ::Colon, j::Int)
     y = zeros(eltype(Q), size(Q, 2))
     y[j] = 1
     lmul!(Q, y)
-    return y[i]
 end
+
+function getindex(Q::AbstractQ, i::Int, ::Colon)
+    x = zeros(eltype(Q), size(Q, 1))
+    x[i] = 1
+    lmul!(Q', x)
+    vec(x')
+end
+
+getindex(Q::AbstractQ, i::Int, j::Int) = Q[:, j][i]
 
 # specialization avoiding the fallback using slow `getindex`
 function copyto!(dest::AbstractMatrix, src::AbstractQ)

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -576,13 +576,6 @@ function getindex(Q::AbstractQ, ::Colon, j::Int)
     lmul!(Q, y)
 end
 
-function getindex(Q::AbstractQ, i::Int, ::Colon)
-    x = zeros(eltype(Q), size(Q, 1))
-    x[i] = 1
-    lmul!(Q', x)
-    vec(x')
-end
-
 getindex(Q::AbstractQ, i::Int, j::Int) = Q[:, j][i]
 
 # specialization avoiding the fallback using slow `getindex`

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -567,7 +567,7 @@ size(F::Union{QR,QRCompactWY,QRPivoted}) = size(getfield(F, :factors))
 size(Q::AbstractQ, dim::Integer) = size(getfield(Q, :factors), dim == 2 ? 1 : dim)
 size(Q::AbstractQ) = size(Q, 1), size(Q, 2)
 
-getindex(Q::AbstractQ, C::Colon...) = Matrix(Q)[C...]
+getindex(Q::AbstractQ, inds...) = Matrix(Q)[inds...]
 getindex(Q::AbstractQ, ::Colon, ::Colon) = Matrix(Q)
 
 function getindex(Q::AbstractQ, ::Colon, j::Int)

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -567,7 +567,7 @@ size(F::Union{QR,QRCompactWY,QRPivoted}) = size(getfield(F, :factors))
 size(Q::AbstractQ, dim::Integer) = size(getfield(Q, :factors), dim == 2 ? 1 : dim)
 size(Q::AbstractQ) = size(Q, 1), size(Q, 2)
 
-copy(Q::AbstractQ) = I(size(Q, 1)) * Q
+copy(Q::AbstractQ{T}) where {T} = lmul!(Q, Matrix{T}(I, size(Q)))
 getindex(Q::AbstractQ, inds...) = copy(Q)[inds...]
 getindex(Q::AbstractQ, ::Colon, ::Colon) = copy(Q)
 

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -440,7 +440,7 @@ end
         for j in axes(M, 2)
             @test Q2[:, j] == M[:, j]
             for i in axes(M, 1)
-                @test Q2[i, :] ≈ M[i, :]
+                @test Q2[i, :] == M[i, :]
                 @test Q2[i, j] == M[i, j]
             end
         end

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -432,4 +432,19 @@ end
     @test eltype(qrnonblas.factors) == eltype(qrnonblas.τ) == ComplexF16
 end
 
+@testset "optimized getindex for an AbstractQ" begin
+    for T in [Float64, ComplexF64]
+        Q = qr(rand(T, 4, 4))
+        Q2 = Q.Q
+        M = Matrix(Q2)
+        for j in axes(M, 2)
+            @test Q2[:, j] == M[:, j]
+            for i in axes(M, 1)
+                @test Q2[i, :] ≈ M[i, :]
+                @test Q2[i, j] == M[i, j]
+            end
+        end
+    end
+end
+
 end # module TestQR

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -444,6 +444,9 @@ end
                 @test Q2[i, j] == M[i, j]
             end
         end
+        @test Q2[:] == M[:]
+        @test Q2[:, :] == M[:, :]
+        @test Q2[:, :, :] == M[:, :, :]
     end
 end
 


### PR DESCRIPTION
Currently the indexing operation `Q[i,j]` is computed as `ei ⋅ Q ⋅ ej`, where `ei` and `ej` are unit vectors. Both the unit vectors were allocated as `Vector`s. This PR changes the indexing to `(Q ⋅ ej)[i]`, which eliminates the allocation of `ei`. Since the result of `Q ⋅ ej` is overwritten into `ej`, the indexing `ej[i]` should be fast.

Some benchmarks:
```julia
julia> function getindex2(Q, i::Integer, j::Integer) # the updated method definition in this PR
           y = zeros(eltype(Q), size(Q, 2))
           y[j] = 1
           lmul!(Q, y)
           return y[i]
       end
getindex2 (generic function with 1 method)

julia> Q = qr(rand(30,30));

julia> @btime $Q.Q[1,1]
  2.044 μs (4 allocations: 944 bytes)
-0.07734152668340077

julia> @btime getindex2($Q.Q, 1, 1)
  1.958 μs (3 allocations: 640 bytes)
-0.07734152668340077
```

The performance improves marginally, and allocations go down.