### PR TITLE
Update references to tsan state

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -234,9 +234,9 @@ void sweep_stack_pools(void)
                     _jl_free_stack(ptls2, stkbuf, bufsz);
                 }
 #ifdef _COMPILER_TSAN_ENABLED_
-                if (t->ctx.tsan_state) {
-                    __tsan_destroy_fiber(t->ctx.tsan_state);
-                    t->ctx.tsan_state = NULL;
+                if (t->tsan_state) {
+                    __tsan_destroy_fiber(t->tsan_state);
+                    t->tsan_state = NULL;
                 }
 #endif
             }


### PR DESCRIPTION
The tsan state got moved into the task struct, but references
to it were not updated. This fixed the build, though the exectuable
itself crashes in LLVM when run. I haven't looked into that yet.

cc @ianatol 