### PR TITLE
WIP: Clarify performance penalty of global

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -13,7 +13,7 @@ The functions should take arguments, instead of operating directly on global var
 
 ## Avoid global variables
 
-A global variable might have its value, and therefore its type, change at any point. This makes
+A global variable might change its value, and by that possibly its type, at any point. This makes
 it difficult for the compiler to optimize code using global variables. Variables should be local,
 or passed as arguments to functions, whenever possible.
 


### PR DESCRIPTION
I've slightly changed the wording for why a global creates a penalty in performance, as it raised confusion [such as here](https://discourse.julialang.org/t/global-variables-const-by-default/33138/3?) and I think the current wording was wrong (changing the value does not need to change the type, correct?)

However, I am still not quite convinced as a variable *doesn't* has a type and therefore "it's type changes" seems a bit weird, doesn't it?