### PR TITLE
rename Base.Filesystem to FS module

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-## File Operations (Libuv-based) ##
+## File Operations ##
 
-module Filesystem
+module FS
 
 const S_IFDIR  = 0o040000  # directory
 const S_IFCHR  = 0o020000  # character device

--- a/contrib/new-stdlib.sh
+++ b/contrib/new-stdlib.sh
@@ -29,11 +29,15 @@ uuid = "$UUID"
 EOF
 
 cat >"$ROOT/$NAME/src/$NAME.jl" <<EOF
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module $NAME
 end
 EOF
 
 cat >"$ROOT/$NAME/test/runtests.jl" <<EOF
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using $NAME
 using Test
 @test "your tests here"

--- a/stdlib/FS/Project.toml
+++ b/stdlib/FS/Project.toml
@@ -1,0 +1,2 @@
+name = "FS"
+uuid = "5ced1c9f-5be2-431c-86bc-18f6fd327a93"

--- a/stdlib/FS/src/FS.jl
+++ b/stdlib/FS/src/FS.jl
@@ -1,0 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+__precompile__(false)
+# this code is actually pre-loaded as part of Base, so this file isn't used
+const FS = Base.Filesystem

--- a/stdlib/FS/test/runtests.jl
+++ b/stdlib/FS/test/runtests.jl
@@ -1,0 +1,8 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using FS
+using Test
+
+# just test that we can import this, since the tests are generally already part
+# of Base's suite
+@test FS === Base.Filesystem

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -38,7 +38,7 @@ endef
 $(foreach jll,$(JLLS),$(eval $(call download-artifacts-toml,$(jll))))
 
 
-STDLIBS = Artifacts Base64 CRC32c Dates DelimitedFiles Distributed FileWatching \
+STDLIBS = Artifacts Base64 CRC32c Dates DelimitedFiles Distributed FileWatching FS \
           Future InteractiveUtils LazyArtifacts Libdl LibGit2 LinearAlgebra Logging \
           Markdown Mmap Printf Profile Random REPL Serialization SHA \
           SharedArrays Sockets SparseArrays SuiteSparse Test TOML Unicode UUIDs \


### PR DESCRIPTION
It seemed like we should promote Base.Filesystem to an easier toplevel name. I picked `FS`.