### PR TITLE
[LLVM] Convert more passes to NewPM

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -911,6 +911,16 @@ static void registerCallbacks(PassBuilder &PB) {
             }
             return false;
         });
+
+    PB.registerPipelineParsingCallback(
+        [](StringRef Name, LoopPassManager &PM,
+           ArrayRef<PassBuilder::PipelineElement> InnerPipeline) {
+            if (Name == "JuliaLICM") {
+                PM.addPass(JuliaLICMPass());
+                return true;
+            }
+            return false;
+        });
 }
 
 extern "C" JL_DLLEXPORT ::llvm::PassPluginLibraryInfo

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -879,33 +879,37 @@ static void registerCallbacks(PassBuilder &PB) {
     PB.registerPipelineParsingCallback(
         [](StringRef Name, FunctionPassManager &PM,
            ArrayRef<PassBuilder::PipelineElement> InnerPipeline) {
-          if (Name == "DemoteFloat16") {
-            PM.addPass(DemoteFloat16());
-            return true;
-          }
-          if (Name == "CombineMulAdd") {
-            PM.addPass(CombineMulAdd());
-            return true;
-          }
-          return false;
+            if (Name == "DemoteFloat16") {
+                PM.addPass(DemoteFloat16());
+                return true;
+            }
+            if (Name == "CombineMulAdd") {
+              PM.addPass(CombineMulAdd());
+              return true;
+            }
+            if (Name == "LateLowerGCFrame") {
+                PM.addPass(LateLowerGC());
+                return true;
+            }
+            return false;
         });
 
     PB.registerPipelineParsingCallback(
         [](StringRef Name, ModulePassManager &PM,
            ArrayRef<PassBuilder::PipelineElement> InnerPipeline) {
-          if (Name == "CPUFeatures") {
-            PM.addPass(CPUFeatures());
-            return true;
-          }
-          if (Name == "RemoveNI") {
-            PM.addPass(RemoveNI());
-            return true;
-          }
-          if (Name == "LowerSIMDLoop") {
-            PM.addPass(LowerSIMDLoop());
-            return true;
-          }
-          return false;
+            if (Name == "CPUFeatures") {
+              PM.addPass(CPUFeatures());
+              return true;
+            }
+            if (Name == "RemoveNI") {
+              PM.addPass(RemoveNI());
+              return true;
+            }
+            if (Name == "LowerSIMDLoop") {
+              PM.addPass(LowerSIMDLoop());
+              return true;
+            }
+            return false;
         });
 }
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -909,6 +909,10 @@ static void registerCallbacks(PassBuilder &PB) {
               PM.addPass(LowerSIMDLoop());
               return true;
             }
+            if (Name == "FinalLowerGC") {
+                PM.addPass(FinalLowerGCPass());
+                return true;
+            }
             return false;
         });
 

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include "llvm-version.h"
+#include "passes.h"
 
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Function.h>
@@ -28,20 +29,17 @@ using namespace llvm;
 // This pass targets typical back-ends for which the standard Julia
 // runtime library is available. Atypical back-ends should supply
 // their own lowering pass.
-struct FinalLowerGC: public FunctionPass, private JuliaPassContext {
-    static char ID;
-    FinalLowerGC() : FunctionPass(ID)
-    { }
+
+struct FinalLowerGC: private JuliaPassContext {
+    bool runOnFunction(Function &F);
+    bool doInitialization(Module &M);
+    bool doFinalization(Module &M);
 
 private:
     Function *queueRootFunc;
     Function *poolAllocFunc;
     Function *bigAllocFunc;
     Instruction *pgcstack;
-
-    bool doInitialization(Module &M) override;
-    bool doFinalization(Module &M) override;
-    bool runOnFunction(Function &F) override;
 
     // Lowers a `julia.new_gc_frame` intrinsic.
     Value *lowerNewGCFrame(CallInst *target, Function &F);
@@ -325,12 +323,55 @@ bool FinalLowerGC::runOnFunction(Function &F)
     return true;
 }
 
-char FinalLowerGC::ID = 0;
-static RegisterPass<FinalLowerGC> X("FinalLowerGC", "Final GC intrinsic lowering pass", false, false);
+struct FinalLowerGCLegacy: public FunctionPass {
+    static char ID;
+    FinalLowerGCLegacy() : FunctionPass(ID), finalLowerGC(FinalLowerGC()) {}
+
+protected:
+    void getAnalysisUsage(AnalysisUsage &AU) const override {
+        FunctionPass::getAnalysisUsage(AU);
+    }
+
+private:
+    bool runOnFunction(Function &F) override;
+    bool doInitialization(Module &M) override;
+    bool doFinalization(Module &M) override;
+
+    FinalLowerGC finalLowerGC;
+};
+
+bool FinalLowerGCLegacy::runOnFunction(Function &F) {
+    return finalLowerGC.runOnFunction(F);
+}
+
+bool FinalLowerGCLegacy::doInitialization(Module &M) {
+    return finalLowerGC.doInitialization(M);
+}
+
+bool FinalLowerGCLegacy::doFinalization(Module &M) {
+    return finalLowerGC.doFinalization(M);
+}
+
+
+PreservedAnalyses FinalLowerGCPass::run(Module &M, ModuleAnalysisManager &AM)
+{
+    auto finalLowerGC = FinalLowerGC();
+    finalLowerGC.doInitialization(M);
+    for (auto &F : M.functions()) {
+        if (F.isDeclaration())
+            continue;
+        finalLowerGC.runOnFunction(F);
+    }
+    finalLowerGC.doFinalization(M);
+    return PreservedAnalyses::all();
+}
+
+char FinalLowerGCLegacy::ID = 0;
+static RegisterPass<FinalLowerGCLegacy> X("FinalLowerGC", "Final GC intrinsic lowering pass", false, false);
 
 Pass *createFinalLowerGCPass()
 {
-    return new FinalLowerGC();
+    return new FinalLowerGCLegacy();
 }
 
 extern "C" JL_DLLEXPORT void LLVMExtraAddFinalLowerGCPass_impl(LLVMPassManagerRef PM)

--- a/src/passes.h
+++ b/src/passes.h
@@ -4,6 +4,7 @@
 #define JL_PASSES_H
 
 #include <llvm/IR/PassManager.h>
+#include <llvm/Transforms/Scalar/LoopPassManager.h>
 
 using namespace llvm;
 
@@ -31,6 +32,12 @@ struct RemoveNI : PassInfoMixin<RemoveNI> {
 
 struct LowerSIMDLoop : PassInfoMixin<LowerSIMDLoop> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
+
+// Loop Passes
+struct JuliaLICMPass : PassInfoMixin<JuliaLICMPass> {
+    PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                          LoopStandardAnalysisResults &AR, LPMUpdater &U);
 };
 
 #endif

--- a/src/passes.h
+++ b/src/passes.h
@@ -16,6 +16,10 @@ struct CombineMulAdd : PassInfoMixin<CombineMulAdd> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
+struct LateLowerGC : PassInfoMixin<LateLowerGC> {
+    PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+};
+
 // Module Passes
 struct CPUFeatures : PassInfoMixin<CPUFeatures> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);

--- a/src/passes.h
+++ b/src/passes.h
@@ -11,6 +11,7 @@ using namespace llvm;
 // Function Passes
 struct DemoteFloat16 : PassInfoMixin<DemoteFloat16> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+    static bool isRequired() { return true; }
 };
 
 struct CombineMulAdd : PassInfoMixin<CombineMulAdd> {
@@ -19,11 +20,13 @@ struct CombineMulAdd : PassInfoMixin<CombineMulAdd> {
 
 struct LateLowerGC : PassInfoMixin<LateLowerGC> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+    static bool isRequired() { return true; }
 };
 
 // Module Passes
 struct CPUFeatures : PassInfoMixin<CPUFeatures> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+    static bool isRequired() { return true; }
 };
 
 struct RemoveNI : PassInfoMixin<RemoveNI> {
@@ -32,6 +35,11 @@ struct RemoveNI : PassInfoMixin<RemoveNI> {
 
 struct LowerSIMDLoop : PassInfoMixin<LowerSIMDLoop> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
+
+struct FinalLowerGCPass : PassInfoMixin<LateLowerGC> {
+    PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+    static bool isRequired() { return true; }
 };
 
 // Loop Passes

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -1,4 +1,6 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -FinalLowerGC -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='FinalLowerGC' -S %s | FileCheck %s
+
 
 @tag = external addrspace(10) global {}
 

--- a/test/llvmpasses/gcroots.ll
+++ b/test/llvmpasses/gcroots.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -LateLowerGCFrame -FinalLowerGC -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame),FinalLowerGC' -S %s | FileCheck %s
 
 
 declare void @boxed_simple({} addrspace(10)*, {} addrspace(10)*)

--- a/test/llvmpasses/julia-licm.ll
+++ b/test/llvmpasses/julia-licm.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -JuliaLICM -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='JuliaLICM' -S %s | FileCheck %s
 
 @tag = external addrspace(10) global {}, align 16
 

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -LateLowerGCFrame -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame)' -S %s | FileCheck %s
 
 @tag = external addrspace(10) global {}, align 16
 

--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -LateLowerGCFrame -FinalLowerGC -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame),FinalLowerGC' -S %s | FileCheck %s
 
 
 declare {}*** @julia.ptls_states()

--- a/test/llvmpasses/returnstwicegc.ll
+++ b/test/llvmpasses/returnstwicegc.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -LateLowerGCFrame -FinalLowerGC -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame),FinalLowerGC' -S %s | FileCheck %s
 
 
 declare void @boxed_simple({} addrspace(10)*, {} addrspace(10)*)

--- a/test/llvmpasses/safepoint_stress.jl
+++ b/test/llvmpasses/safepoint_stress.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # RUN: julia --startup-file=no %s | opt -enable-new-pm=0 -load libjulia-codegen%shlibext -LateLowerGCFrame -FinalLowerGC -S - | FileCheck %s
+# RUN: julia --startup-file=no %s | opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame),FinalLowerGC' -S - | FileCheck %s
+
 
 println("""
 declare {} addrspace(10)* @alloc()


### PR DESCRIPTION
I need to come up with a better way to handle JuliaPassContext.

IIRC from my last discussion with @vtjnash on this it's current implementation is not that helpful
since it attempts to cache function pointers and type pointers that depend on the current module
and current context. Given that we are moving away from a shared global context and that we are not
gurantueed to run over the same module the state cached in JuliaPassContext requires constant re-initalisation.
