### PR TITLE
Add `uplo` check to `Bidiagonal`, `Symmetric`, and `Hermitian` base constructors

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -262,8 +262,7 @@ function sym_uplo(uplo::Char)
     end
 end
 
-
-@noinline throw_uplo() = throw(ArgumentError("uplo argument must be either :U (upper) or :L (lower)"))
+@noinline throw_uplo() = throw(ArgumentError("uplo argument must be either :U/'U' (upper) or :L/'L' (lower)"))
 
 
 """

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -10,6 +10,7 @@ struct Bidiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
         if length(ev) != max(length(dv)-1, 0)
             throw(DimensionMismatch("length of diagonal vector is $(length(dv)), length of off-diagonal vector is $(length(ev))"))
         end
+        (uplo != 'U' && uplo != 'L') && throw_uplo()
         new{T,V}(dv, ev, uplo)
     end
 end
@@ -62,7 +63,7 @@ julia> Bl = Bidiagonal(dv, ev, :L) # ev is on the first subdiagonal
 ```
 """
 function Bidiagonal(dv::V, ev::V, uplo::Symbol) where {T,V<:AbstractVector{T}}
-    Bidiagonal{T,V}(dv, ev, char_uplo(uplo))
+    Bidiagonal{T,V}(dv, ev, uplo)
 end
 function Bidiagonal(dv::V, ev::V, uplo::AbstractChar) where {T,V<:AbstractVector{T}}
     Bidiagonal{T,V}(dv, ev, uplo)
@@ -108,6 +109,7 @@ julia> Bidiagonal(A, :L) # contains the main diagonal and first subdiagonal of A
 function Bidiagonal(A::AbstractMatrix, uplo::Symbol)
     Bidiagonal(diag(A, 0), diag(A, uplo === :U ? 1 : -1), uplo)
 end
+
 
 Bidiagonal(A::Bidiagonal) = A
 Bidiagonal{T}(A::Bidiagonal{T}) where {T} = A

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -7,6 +7,7 @@ struct Symmetric{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
 
     function Symmetric{T,S}(data, uplo) where {T,S<:AbstractMatrix{<:T}}
         require_one_based_indexing(data)
+        (uplo != 'U' && uplo != 'L') && throw_uplo()
         new{T,S}(data, uplo)
     end
 end
@@ -88,6 +89,7 @@ struct Hermitian{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
 
     function Hermitian{T,S}(data, uplo) where {T,S<:AbstractMatrix{<:T}}
         require_one_based_indexing(data)
+        (uplo != 'U' && uplo != 'L') && throw_uplo()
         new{T,S}(data, uplo)
     end
 end

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -43,6 +43,7 @@ Random.seed!(1)
             @test ubd.dv === x
             @test lbd.ev === y
             @test_throws ArgumentError Bidiagonal(x, y, :R)
+            @test_throws ArgumentError Bidiagonal(x, y, 'R')
             x == dv0 || @test_throws DimensionMismatch Bidiagonal(x, x, :U)
             @test_throws MethodError Bidiagonal(x, y)
             # from matrix

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -60,6 +60,10 @@ end
                 @test Hermitian(Hermitian(aherm, :U), :U) === Hermitian(aherm, :U)
                 @test_throws ArgumentError Symmetric(Symmetric(asym, :U), :L)
                 @test_throws ArgumentError Hermitian(Hermitian(aherm, :U), :L)
+
+                @test_throws ArgumentError Symmetric(asym, :R)
+                @test_throws ArgumentError Hermitian(asym, :R)
+
                 # mixed cases with Hermitian/Symmetric
                 if eltya <: Real
                     @test Symmetric(Hermitian(aherm, :U))     === Symmetric(aherm, :U)


### PR DESCRIPTION
Currently, most, but not all, constructors for `Bidiagonal`, `Symmetric`, and `Hermitian` matrices perform an `uplo` check to see if it is valid (`U`/`:U` or `L`/`:L`). However, the base constructors do not.

This PR adds an uplo check to the base constructors and slightly expands the `throw_uplo` error message.

----------------------------------------------------------------------
For example,

At HEAD:
```julia
julia> Bidiagonal(rand(2), rand(1), 'U')
2×2 Bidiagonal{Float64,Array{Float64,1}}:
 0.792414  0.848267
  ⋅        0.0463521

julia> Bidiagonal(rand(2), rand(1), 'X')
2×2 Bidiagonal{Float64,Array{Float64,1}}:
 0.916971   ⋅ 
 0.0       0.27176

julia> Bidiagonal(rand(2), rand(1), :U)
2×2 Bidiagonal{Float64,Array{Float64,1}}:
 0.810733  0.828368
  ⋅        0.628955

julia> Bidiagonal(rand(2), rand(1), :X)
ERROR: ArgumentError: uplo argument must be either :U (upper) or :L (lower)
Stacktrace:
 [1] throw_uplo() at /home/mc/github/julia/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:257
 [2] char_uplo at /home/mc/github/julia/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/LinearAlgebra.jl:242 [inlined]
 [3] Bidiagonal(::Array{Float64,1}, ::Array{Float64,1}, ::Symbol) at /home/mc/github/julia/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/bidiag.jl:65
 [4] top-level scope at REPL[6]:1
```

This PR:

```julia
julia> Bidiagonal(rand(2), rand(1), 'U')
2×2 Bidiagonal{Float64, Vector{Float64}}:
 0.970627  0.828208
  ⋅        0.265786

julia> Bidiagonal(rand(2), rand(1), 'X')
ERROR: ArgumentError: uplo argument must be either :U/'U' (upper) or :L/'L' (lower)
Stacktrace:
 [1] throw_uplo()
   @ LinearAlgebra ~/github/julia-dev/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/LinearAlgebra.jl:265
 [2] Bidiagonal{Float64, Vector{Float64}}(dv::Vector{Float64}, ev::Vector{Float64}, uplo::Char)
   @ LinearAlgebra ~/github/julia-dev/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/bidiag.jl:13
 [3] Bidiagonal(dv::Vector{Float64}, ev::Vector{Float64}, uplo::Char)
   @ LinearAlgebra ~/github/julia-dev/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/bidiag.jl:69
 [4] top-level scope
   @ REPL[3]:1

julia> Bidiagonal(rand(2), rand(1), :U)
2×2 Bidiagonal{Float64, Vector{Float64}}:
 0.768898  0.461265
  ⋅        0.409974

julia> Bidiagonal(rand(2), rand(1), :X)
ERROR: ArgumentError: uplo argument must be either :U/'U' (upper) or :L/'L' (lower)
Stacktrace:
 [1] throw_uplo()
   @ LinearAlgebra ~/github/julia-dev/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/LinearAlgebra.jl:265
 [2] char_uplo
   @ ~/github/julia-dev/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/LinearAlgebra.jl:251 [inlined]
 [3] Bidiagonal
   @ ~/github/julia-dev/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/bidiag.jl:18 [inlined]
 [4] Bidiagonal(dv::Vector{Float64}, ev::Vector{Float64}, uplo::Symbol)
   @ LinearAlgebra ~/github/julia-dev/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/bidiag.jl:76
 [5] top-level scope
   @ REPL[5]:1
```

And likewise for `Symmetric` and `Hermitian`.