### PR TITLE
Add missing constructors for `Bidiagonal`, `Symmetric`, and `Hermitian`

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -76,10 +76,10 @@ function LinearAlgebra.Bidiagonal(dv::Vector{T}, ev::Vector{S}, uplo::Symbol) wh
 end
 
 """
-    Bidiagonal(A, uplo::Symbol)
+    Bidiagonal(A, uplo::Union{Symbol, Char})
 
 Construct a `Bidiagonal` matrix from the main diagonal of `A` and
-its first super- (if `uplo=:U`) or sub-diagonal (if `uplo=:L`).
+its first super- (if `uplo=:U` or `'U'`) or sub-diagonal (if `uplo=:L` or `'L'`).
 
 # Examples
 ```jldoctest
@@ -97,7 +97,7 @@ julia> Bidiagonal(A, :U) # contains the main diagonal and first superdiagonal of
  ⋅  ⋅  3  3
  ⋅  ⋅  ⋅  4
 
-julia> Bidiagonal(A, :L) # contains the main diagonal and first subdiagonal of A
+julia> Bidiagonal(A, 'L') # contains the main diagonal and first subdiagonal of A
 4×4 Bidiagonal{Int64, Vector{Int64}}:
  1  ⋅  ⋅  ⋅
  2  2  ⋅  ⋅
@@ -107,6 +107,10 @@ julia> Bidiagonal(A, :L) # contains the main diagonal and first subdiagonal of A
 """
 function Bidiagonal(A::AbstractMatrix, uplo::Symbol)
     Bidiagonal(diag(A, 0), diag(A, uplo === :U ? 1 : -1), uplo)
+end
+
+function Bidiagonal(A::AbstractMatrix, uplo::Char)
+    Bidiagonal(diag(A, 0), diag(A, uplo == 'U' ? 1 : -1), uplo)
 end
 
 Bidiagonal(A::Bidiagonal) = A

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -60,10 +60,10 @@ function Symmetric(A::AbstractMatrix, uplo::Char)
 end
 
 """
-    symmetric(A, uplo=:U)
+    symmetric(A, uplo)
 
 Construct a symmetric view of `A`. If `A` is a matrix, `uplo` controls whether the upper
-(if `uplo = :U`) or lower (if `uplo = :L`) triangle of `A` is used to implicitly fill the
+(if `uplo = :U`/`'U'`) or lower (if `uplo = :L`/`'L'`) triangle of `A` is used to implicitly fill the
 other one. If `A` is a `Number`, it is returned as is.
 
 If a symmetric view of a matrix is to be constructed of which the elements are neither
@@ -72,6 +72,8 @@ case, `symmetric_type` has to be implemented, too.
 """
 symmetric(A::AbstractMatrix, uplo::Symbol) = Symmetric(A, uplo)
 symmetric(A::Number, ::Symbol) = A
+symmetric(A::AbstractMatrix, uplo::Char) = Symmetric(A, uplo)
+symmetric(A::Number, ::Char) = A
 
 """
     symmetric_type(T::Type)
@@ -150,10 +152,10 @@ function Hermitian(A::AbstractMatrix, uplo::Char)
 end
 
 """
-    hermitian(A, uplo=:U)
+    hermitian(A, uplo)
 
 Construct a hermitian view of `A`. If `A` is a matrix, `uplo` controls whether the upper
-(if `uplo = :U`) or lower (if `uplo = :L`) triangle of `A` is used to implicitly fill the
+(if `uplo = :U`/`'U'`) or lower (if `uplo = :L`/`'L'``) triangle of `A` is used to implicitly fill the
 other one. If `A` is a `Number`, its real part is returned converted back to the input
 type.
 
@@ -163,6 +165,8 @@ case, `hermitian_type` has to be implemented, too.
 """
 hermitian(A::AbstractMatrix, uplo::Symbol) = Hermitian(A, uplo)
 hermitian(A::Number, ::Symbol) = convert(typeof(A), real(A))
+hermitian(A::AbstractMatrix, uplo::Char) = Hermitian(A, uplo)
+hermitian(A::Number, ::Char) = convert(typeof(A), real(A))
 
 """
     hermitian_type(T::Type)

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -45,9 +45,18 @@ julia> Slower = Symmetric(A, :L)
 
 Note that `Supper` will not be equal to `Slower` unless `A` is itself symmetric (e.g. if `A == transpose(A)`).
 """
-function Symmetric(A::AbstractMatrix, uplo::Symbol=:U)
+function Symmetric(A::AbstractMatrix, uplo::Symbol)
     checksquare(A)
     return symmetric_type(typeof(A))(A, char_uplo(uplo))
+end
+
+# suppress method overwritten warning while preserving
+# the historical default argument `uplo=:U`
+Symmetric(A::AbstractArray) = Symmetric(A, :U)
+
+function Symmetric(A::AbstractMatrix, uplo::Char)
+    checksquare(A)
+    return symmetric_type(typeof(A))(A, uplo)
 end
 
 """
@@ -92,9 +101,9 @@ struct Hermitian{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
     end
 end
 """
-    Hermitian(A, uplo=:U)
+    Hermitian(A, uplo::Union{Symbol, Char})
 
-Construct a `Hermitian` view of the upper (if `uplo = :U`) or lower (if `uplo = :L`)
+Construct a `Hermitian` view of the upper (if `uplo = :U` or `'U'`) or lower (if `uplo = :L` or `'L'`)
 triangle of the matrix `A`.
 
 # Examples
@@ -126,9 +135,18 @@ All non-real parts of the diagonal will be ignored.
 Hermitian(fill(complex(1,1), 1, 1)) == fill(1, 1, 1)
 ```
 """
-function Hermitian(A::AbstractMatrix, uplo::Symbol=:U)
+function Hermitian(A::AbstractMatrix, uplo::Symbol)
     n = checksquare(A)
     return hermitian_type(typeof(A))(A, char_uplo(uplo))
+end
+
+# suppress method overwritten warning while preserving
+# the historical default argument `uplo=:U`
+Hermitian(A::AbstractMatrix) = Hermitian(A, :U)
+
+function Hermitian(A::AbstractMatrix, uplo::Char)
+    n = checksquare(A)
+    return hermitian_type(typeof(A))(A, uplo)
 end
 
 """

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -50,8 +50,8 @@ Random.seed!(1)
             @test Bidiagonal(lbd, :L) == Bidiagonal(Matrix(lbd), :L) == lbd
 
             z = rand(elty, 3, 3)
-            @test Bidiagonal(z, 'U') === Bidiagonal(z, :U)
-            @test Bidiagonal(z, 'L') === Bidiagonal(z, :L)
+            @test Bidiagonal(z, 'U') == Bidiagonal(z, :U)
+            @test Bidiagonal(z, 'L') == Bidiagonal(z, :L)
         end
         @test eltype(Bidiagonal{elty}([1,2,3,4], [1.0f0,2.0f0,3.0f0], :U)) == elty
         @test eltype(Bidiagonal([1,2,3,4], [1.0f0,2.0f0,3.0f0], :U)) == Float32 # promotion test

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -48,6 +48,10 @@ Random.seed!(1)
             # from matrix
             @test Bidiagonal(ubd, :U) == Bidiagonal(Matrix(ubd), :U) == ubd
             @test Bidiagonal(lbd, :L) == Bidiagonal(Matrix(lbd), :L) == lbd
+
+            z = rand(elty, 3, 3)
+            @test Bidiagonal(z, 'U') === Bidiagonal(z, :U)
+            @test Bidiagonal(z, 'L') === Bidiagonal(z, :L)
         end
         @test eltype(Bidiagonal{elty}([1,2,3,4], [1.0f0,2.0f0,3.0f0], :U)) == elty
         @test eltype(Bidiagonal([1,2,3,4], [1.0f0,2.0f0,3.0f0], :U)) == Float32 # promotion test

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -60,6 +60,12 @@ end
                 @test Hermitian(Hermitian(aherm, :U), :U) === Hermitian(aherm, :U)
                 @test_throws ArgumentError Symmetric(Symmetric(asym, :U), :L)
                 @test_throws ArgumentError Hermitian(Hermitian(aherm, :U), :L)
+
+                @test Symmetric(asym, 'U') === Symmetric(asym, :U)
+                @test Symmetric(asym, 'L') === Symmetric(asym, :L)
+                @test Hermitian(aherm, 'U') === Hermitian(aherm, :U)
+                @test Hermitian(aherm, 'L') === Hermitian(aherm, :L)
+
                 # mixed cases with Hermitian/Symmetric
                 if eltya <: Real
                     @test Symmetric(Hermitian(aherm, :U))     === Symmetric(aherm, :U)


### PR DESCRIPTION
 `Bidiagonal`, `Symmetric`, and `Hermitian` are currently all missing the `X(A::Matrix, uplo::Char)` constructor but have the  `X(A::Matrix, uplo::Symbol)` constructor. This PR adds the `Char` constructor.

Two additional methods `Symmetric(A::AbstractArray) = Symmetric(A, :U)` and `Hermitian(A::AbstractMatrix) = Hermitian(A, :U)` were also added to avoid the method overwriting warning (due to the previous implementation having default arguments) and to preserve the historical default argument.

**NOTE:** This PR should be submitted after #42466, which adds better `uplo` checks to the constructors.

-------------------------------------------------------------------------------

HEAD:

```julia
julia> Bidiagonal(rand(3,3), :U)
3×3 Bidiagonal{Float64,Array{Float64,1}}:
 0.971135  0.423251   ⋅ 
  ⋅        0.528393  0.696667
  ⋅         ⋅        0.343728

julia> Bidiagonal(rand(3,3), 'U')
ERROR: MethodError: no method matching Bidiagonal(::Array{Float64,2}, ::Char)
Closest candidates are:
  Bidiagonal(::AbstractArray{T,2} where T, ::Symbol) at /home/mc/github/julia/usr/share/julia/stdlib/v1.5/LinearAlgebra/src/bidiag.jl:101
Stacktrace:
 [1] top-level scope at REPL[3]:1
```

This PR:

```julia
julia> Bidiagonal(rand(3,3), :U)
3×3 Bidiagonal{Float64, Vector{Float64}}:
 0.87165  0.860882   ⋅ 
  ⋅       0.539619  0.278167
  ⋅        ⋅        0.4687

julia> Bidiagonal(rand(3,3), 'U')
3×3 Bidiagonal{Float64, Vector{Float64}}:
 0.499547  0.862715   ⋅ 
  ⋅        0.556194  0.751918
  ⋅         ⋅        0.706695
```

and likewise for `Symmetric`, and `Hermitian`.