### PR TITLE
External stdlibs:  Move `*_URL` stdlib definitions into `.version` files

### DIFF
--- a/contrib/new-stdlib.sh
+++ b/contrib/new-stdlib.sh
@@ -50,14 +50,14 @@ UNAME=$(echo "$NAME" | tr [a-z] [A-Z])
 
 sed -e "/^STDLIBS_EXT =/,/^\$/s!^\$!\\
 STDLIBS_EXT += $NAME\\
-${UNAME}_GIT_URL := git://github.com/$USER/$NAME.jl.git\\
-${UNAME}_TAR_URL = https://api.github.com/repos/$USER/$NAME.jl/tarball/\$1\\
 !" "$ROOT/Makefile" >"$ROOT/Makefile.tmp"
 mv "$ROOT/Makefile.tmp" "$ROOT/Makefile"
 
 cat >"$ROOT/$NAME.version" <<EOF
 ${UNAME}_BRANCH = master
 ${UNAME}_SHA1 = $SHA1
+${UNAME}_GIT_URL := git://github.com/$USER/$NAME.jl.git
+${UNAME}_TAR_URL = https://api.github.com/repos/$USER/$NAME.jl/tarball/\$1
 EOF
 
 git add "$ROOT/$NAME.version"

--- a/stdlib/ArgTools.version
+++ b/stdlib/ArgTools.version
@@ -1,2 +1,4 @@
 ARGTOOLS_BRANCH = master
 ARGTOOLS_SHA1 = fa878696ff2ae4ba7ca9942bf9544556c0d86ce4
+ARGTOOLS_GIT_URL := git://github.com/JuliaIO/ArgTools.jl.git
+ARGTOOLS_TAR_URL = https://api.github.com/repos/JuliaIO/ArgTools.jl/tarball/$1

--- a/stdlib/Downloads.version
+++ b/stdlib/Downloads.version
@@ -1,2 +1,4 @@
 DOWNLOADS_BRANCH = master
 DOWNLOADS_SHA1 = 5f1509da10cf22bb4fc59de707cb3455b6807d99
+DOWNLOADS_GIT_URL := git://github.com/JuliaLang/Downloads.jl.git
+DOWNLOADS_TAR_URL = https://api.github.com/repos/JuliaLang/Downloads.jl/tarball/$1

--- a/stdlib/LibCURL.version
+++ b/stdlib/LibCURL.version
@@ -1,2 +1,4 @@
 LIBCURL_BRANCH = master
 LIBCURL_SHA1 = cddeb7f4a7d5718a4a1be602ffcbe68299a1a37e
+LIBCURL_GIT_URL := git://github.com/JuliaWeb/LibCURL.jl.git
+LIBCURL_TAR_URL = https://api.github.com/repos/JuliaWeb/LibCURL.jl/tarball/$1

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -45,24 +45,6 @@ STDLIBS = Artifacts Base64 CRC32c Dates DelimitedFiles Distributed FileWatching 
           $(JLL_NAMES)
 
 STDLIBS_EXT = Pkg Statistics LibCURL Downloads ArgTools Tar NetworkOptions SuiteSparse SHA
-PKG_GIT_URL := git://github.com/JuliaLang/Pkg.jl.git
-PKG_TAR_URL = https://api.github.com/repos/JuliaLang/Pkg.jl/tarball/$1
-STATISTICS_GIT_URL := git://github.com/JuliaLang/Statistics.jl.git
-STATISTICS_TAR_URL = https://api.github.com/repos/JuliaLang/Statistics.jl/tarball/$1
-LIBCURL_GIT_URL := git://github.com/JuliaWeb/LibCURL.jl.git
-LIBCURL_TAR_URL = https://api.github.com/repos/JuliaWeb/LibCURL.jl/tarball/$1
-DOWNLOADS_GIT_URL := git://github.com/JuliaLang/Downloads.jl.git
-DOWNLOADS_TAR_URL = https://api.github.com/repos/JuliaLang/Downloads.jl/tarball/$1
-ARGTOOLS_GIT_URL := git://github.com/JuliaIO/ArgTools.jl.git
-ARGTOOLS_TAR_URL = https://api.github.com/repos/JuliaIO/ArgTools.jl/tarball/$1
-TAR_GIT_URL := git://github.com/JuliaIO/Tar.jl.git
-TAR_TAR_URL = https://api.github.com/repos/JuliaIO/Tar.jl/tarball/$1
-NETWORKOPTIONS_GIT_URL := git://github.com/JuliaLang/NetworkOptions.jl.git
-NETWORKOPTIONS_TAR_URL = https://api.github.com/repos/JuliaLang/NetworkOptions.jl/tarball/$1
-SUITESPARSE_GIT_URL := git://github.com/JuliaLang/SuiteSparse.jl.git
-SUITESPARSE_TAR_URL = https://api.github.com/repos/JuliaLang/SuiteSparse.jl/tarball/$1
-SHA_GIT_URL := git://github.com/JuliaCrypto/SHA.jl.git
-SHA_TAR_URL = https://api.github.com/repos/JuliaCrypto/SHA.jl/tarball/$1
 
 $(foreach module, $(STDLIBS_EXT), $(eval $(call stdlib-external,$(module),$(shell echo $(module) | tr a-z A-Z))))
 

--- a/stdlib/NetworkOptions.version
+++ b/stdlib/NetworkOptions.version
@@ -1,2 +1,4 @@
 NETWORKOPTIONS_BRANCH = master
 NETWORKOPTIONS_SHA1 = 42a0b5fcb7edb8ed5b0ae699f15ca6aedc0098ca
+NETWORKOPTIONS_GIT_URL := git://github.com/JuliaLang/NetworkOptions.jl.git
+NETWORKOPTIONS_TAR_URL = https://api.github.com/repos/JuliaLang/NetworkOptions.jl/tarball/$1

--- a/stdlib/Pkg.version
+++ b/stdlib/Pkg.version
@@ -1,2 +1,4 @@
 PKG_BRANCH = master
 PKG_SHA1 = 13b7861518dcfceebfc01566c329a2b2faa62623
+PKG_GIT_URL := git://github.com/JuliaLang/Pkg.jl.git
+PKG_TAR_URL = https://api.github.com/repos/JuliaLang/Pkg.jl/tarball/$1

--- a/stdlib/SHA.version
+++ b/stdlib/SHA.version
@@ -1,2 +1,4 @@
 SHA_BRANCH = master
 SHA_SHA1 = c5dd533520393b9dea34ad25287f222dc28fe07a
+SHA_GIT_URL := git://github.com/JuliaCrypto/SHA.jl.git
+SHA_TAR_URL = https://api.github.com/repos/JuliaCrypto/SHA.jl/tarball/$1

--- a/stdlib/Statistics.version
+++ b/stdlib/Statistics.version
@@ -1,2 +1,4 @@
 STATISTICS_BRANCH = master
 STATISTICS_SHA1 = 74897fed33700dba92578aa0fefef5b99ba16086
+STATISTICS_GIT_URL := git://github.com/JuliaLang/Statistics.jl.git
+STATISTICS_TAR_URL = https://api.github.com/repos/JuliaLang/Statistics.jl/tarball/$1

--- a/stdlib/SuiteSparse.version
+++ b/stdlib/SuiteSparse.version
@@ -1,2 +1,4 @@
 SUITESPARSE_BRANCH = master
 SUITESPARSE_SHA1 = b15c39be53f7823c721c1f8a7c036105e2baa04a
+SUITESPARSE_GIT_URL := git://github.com/JuliaLang/SuiteSparse.jl.git
+SUITESPARSE_TAR_URL = https://api.github.com/repos/JuliaLang/SuiteSparse.jl/tarball/$1

--- a/stdlib/Tar.version
+++ b/stdlib/Tar.version
@@ -1,2 +1,4 @@
 TAR_BRANCH = master
 TAR_SHA1 = 67f004d2af9570c7c19e679e4469bb77e918f0fc
+TAR_GIT_URL := git://github.com/JuliaIO/Tar.jl.git
+TAR_TAR_URL = https://api.github.com/repos/JuliaIO/Tar.jl/tarball/$1


### PR DESCRIPTION
This was originally part of #41370.

Once this PR is merged, the BumpStdlibs bot (https://github.com/JuliaLang/BumpStdlibs.jl) will be broken until I update it to account for this change.