### PR TITLE
CI (Buildkite): move the `asan` job from "experimental" to "main"

### DIFF
--- a/.buildkite/pipelines/experimental/launch_unsigned_builders.yml
+++ b/.buildkite/pipelines/experimental/launch_unsigned_builders.yml
@@ -1,6 +1,6 @@
 steps:
   - label: ":buildkite: Launch unsigned pipelines"
     commands: |
-      buildkite-agent pipeline upload .buildkite/pipelines/experimental/misc/sanitizers.yml
+      true
     agents:
       queue: julia

--- a/.buildkite/pipelines/main/launch_unsigned_builders.yml
+++ b/.buildkite/pipelines/main/launch_unsigned_builders.yml
@@ -22,6 +22,7 @@ steps:
       buildkite-agent pipeline upload .buildkite/pipelines/main/misc/doctest.yml
       buildkite-agent pipeline upload .buildkite/pipelines/main/misc/embedding.yml
       buildkite-agent pipeline upload .buildkite/pipelines/main/misc/llvmpasses.yml
+      buildkite-agent pipeline upload .buildkite/pipelines/main/misc/sanitizers.yml
 
       # Launch all of the platform builders.
       bash .buildkite/pipelines/main/platforms/platforms.sh package_linux

--- a/.buildkite/pipelines/main/misc/sanitizers.yml
+++ b/.buildkite/pipelines/main/misc/sanitizers.yml
@@ -18,11 +18,6 @@ steps:
           gid: 1000
           workspaces:
             - "/cache/repos:/cache/repos"
-      # `contrib/asan/check.jl` needs a `julia` binary inside the inner sandbox:
-      - JuliaCI/julia#v1:
-          # Drop default "registries" directory, so it is not persisted from execution to execution
-          persist_depot_dirs: packages,artifacts,compiled
-          version: '1.6'
     timeout_in_minutes: 120
     if: | # We only run the `asan` job on Julia 1.8 and later.
       (pipeline.slug != "julia-release-1-dot-6") && (pipeline.slug != "julia-release-1-dot-7")

--- a/.buildkite/pipelines/main/misc/sanitizers.yml
+++ b/.buildkite/pipelines/main/misc/sanitizers.yml
@@ -18,12 +18,14 @@ steps:
           gid: 1000
           workspaces:
             - "/cache/repos:/cache/repos"
-      # `contrib/check-asan.jl` needs a `julia` binary inside the inner sandbox:
+      # `contrib/asan/check.jl` needs a `julia` binary inside the inner sandbox:
       - JuliaCI/julia#v1:
           # Drop default "registries" directory, so it is not persisted from execution to execution
           persist_depot_dirs: packages,artifacts,compiled
           version: '1.6'
     timeout_in_minutes: 120
+    if: | # We only run the `asan` job on Julia 1.8 and later.
+      (pipeline.slug != "julia-release-1-dot-6") && (pipeline.slug != "julia-release-1-dot-7")
     commands: |
       echo "--- Build julia-debug with ASAN"
       contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_CPU_THREADS:?} debug


### PR DESCRIPTION
The `asan job` has:

1. Been consistently passing on master.
2. Caught at least one bug.