### PR TITLE
Fix world age issue with custom streams for Distributed workers

### DIFF
--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -270,7 +270,10 @@ function start_gc_msgs_task()
                     # this might miss events
                     wait(any_gc_flag)
                 end
-                flush_gc_msgs() # handles throws internally
+                # Use invokelatest() so that custom message transport streams
+                # for workers can be defined in a newer world age than the Task
+                # which runs the loop here.
+                invokelatest(flush_gc_msgs) # handles throws internally
             end
         end
     )


### PR DESCRIPTION
If `connect(::CustomClusterManager, ...)` returns a custom transport
stream, use of that stream by the task in `start_gc_msgs_task()` may fail
due to the task executing in an old world age. Add an `invokelatest()` to
prevent this problem.

CC @tanmaykm 