### PR TITLE
Add some Profile compatibility routines

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -546,13 +546,13 @@ function strip_meta(data)
 end
 
 """
-    Profile.add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0f0f0f0f0) -> data_with_meta
+    Profile.add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0) -> data_with_meta
 
 The converse of `Profile.fetch(;include_meta = false)`; this will add fake metadata, and can be used
 for compatibility and by packages (e.g., FlameGraphs.jl) that would rather not depend on the internal
 details of the metadata format.
 """
-function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0f0f0f0f0)
+function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
     any(Base.Fix1(is_block_end, data), eachindex(data)) && error("input already has metadata")
     cpu_clock_cycle = UInt64(99)
     data_with_meta = similar(data, 0)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -553,7 +553,13 @@ for compatibility and by packages (e.g., FlameGraphs.jl) that would rather not d
 details of the metadata format.
 """
 function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
-    any(Base.Fix1(is_block_end, data), eachindex(data)) && error("input already has metadata")
+    if any(Base.Fix1(is_block_end, data), eachindex(data))
+        n_meta_blockends = count(Base.Fix1(is_block_end, data), eachindex(data))
+        n_zeros = count(iszero, data)
+        @show n_meta_blockends n_zeros
+        println.(data)
+        error("input already has metadata")
+    end
     cpu_clock_cycle = UInt64(99)
     data_with_meta = similar(data, 0)
     for i = 1:length(data)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -296,7 +296,13 @@ function is_block_end(data, i)
     # and we could have (though very unlikely):
     # 1:<stack><metadata><null><null><NULL><metadata><null><null>:end
     # and we want to ignore the triple NULL (which is an ip).
-    return data[i] == 0 && data[i - 1] == 0 && data[i - 2] != 0
+    data[i] == 0 || return false        # first block end null
+    data[i - 1] == 0 || return false    # second block end null
+    data[i - 2] in 1:2 || return false  # sleep state
+    data[i - 3] != 0 || return false    # cpu_cycle_clock
+    data[i - 4] != 0 || return false    # taskid
+    data[i - 5] != 0 || return false    # threadid
+    return true
 end
 
 """

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -553,13 +553,7 @@ for compatibility and by packages (e.g., FlameGraphs.jl) that would rather not d
 details of the metadata format.
 """
 function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
-    if any(Base.Fix1(is_block_end, data), eachindex(data))
-        n_meta_blockends = count(Base.Fix1(is_block_end, data), eachindex(data))
-        n_zeros = count(iszero, data)
-        @show n_meta_blockends n_zeros
-        println.(data)
-        error("input already has metadata")
-    end
+    any(Base.Fix1(is_block_end, data), eachindex(data)) && error("input already has metadata")
     cpu_clock_cycle = UInt64(99)
     data_with_meta = similar(data, 0)
     for i = 1:length(data)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -530,12 +530,7 @@ function fetch(;include_meta = false)
 end
 
 function strip_meta(data)
-    nblocks = 0
-    for i = 2:length(data)
-        if is_block_end(data, i) # detect block ends and count them
-            nblocks += 1
-        end
-    end
+    nblocks = count(Base.Fix1(is_block_end, data), eachindex(data))
     data_stripped = Vector{UInt}(undef, length(data) - (nblocks * (nmeta + 1)))
     j = length(data_stripped)
     i = length(data)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -554,6 +554,8 @@ for compatibility and by packages (e.g., FlameGraphs.jl) that would rather not d
 details of the metadata format.
 """
 function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
+    threadid == 0 && error("Fake threadid cannot be 0")
+    taskid == 0 && error("Fake taskid cannot be 0")
     any(Base.Fix1(is_block_end, data), eachindex(data)) && error("input already has metadata")
     cpu_clock_cycle = UInt64(99)
     data_with_meta = similar(data, 0)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -86,7 +86,10 @@ end
     @test_throws "input already has metadata" Profile.add_fake_meta(data_with)
     data_stripped = Profile.strip_meta(data_with_fake)
     @test data_stripped == data_without
-    @test length(data_with_fake) == length(data_with)
+    # ideally the test below would be a test for equality, but real sample ips can be nulls, and thus
+    # adding metadata back in can convert those ips to new block ends, and the length is then longer
+    @test length(data_with_fake) >= length(data_with)
+
 end
 
 Profile.clear()


### PR DESCRIPTION
This makes it easier for external packages like FlameGraphs to continue
to support Profile by hiding some of the details of the internal
metadata format.

It also fixes a couple of typos in docstrings and comments.
