### PR TITLE
Distributed: improve some of the tests in the Distributed test suite when multithreading is enabled

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -134,7 +134,7 @@ testf(id_other)
 
 function poll_while(f::Function; timeout_seconds::Integer = 60)
     start_time = time_ns()
-    while f() != false
+    while f()
         sleep(1)
         if ( ( time_ns() - start_time )/1e9 ) > timeout_seconds
             @error "Timed out" timeout_seconds

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -132,16 +132,16 @@ end
 testf(id_me)
 testf(id_other)
 
-function loop_until_false(f::Function; timeout_seconds::Integer = 60)
+function poll_while(f::Function; timeout_seconds::Integer = 60)
     start_time = time_ns()
     while f() != false
         sleep(1)
         if ( ( time_ns() - start_time )/1e9 ) > timeout_seconds
             @error "Timed out" timeout_seconds
-            return nothing
+            return false
         end
     end
-    return nothing
+    return true
 end
 
 # Distributed GC tests for Futures
@@ -155,8 +155,7 @@ function test_futures_dgc(id)
     @test fetch(f) == id
     @test f.v !== nothing
     yield(); # flush gc msgs
-    loop_until_false(() -> remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, fid))
-    @test remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, fid) == false
+    @test poll_while(() -> remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, fid))
 
     # if unfetched, it should be deleted after a finalize
     f = remotecall(myid, id)
@@ -165,8 +164,7 @@ function test_futures_dgc(id)
     @test f.v === nothing
     finalize(f)
     yield(); # flush gc msgs
-    loop_until_false(() -> remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, fid))
-    @test remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, fid) == false
+    @test poll_while(() -> remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, fid))
 end
 
 test_futures_dgc(id_me)
@@ -256,8 +254,7 @@ function test_remoteref_dgc(id)
     @test remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, rrid) == true
     finalize(rr)
     yield(); # flush gc msgs
-    loop_until_false(() -> remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, rrid))
-    @test remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, rrid) == false
+    @test poll_while(() -> remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, rrid))
 end
 test_remoteref_dgc(id_me)
 test_remoteref_dgc(id_other)


### PR DESCRIPTION
Ref #42479

This patch improves the reliability of the relevant tests when multithreading is enabled.