### PR TITLE
Improve documentation for JULIA_NUM_THREADS=auto

### DIFF
--- a/doc/src/base/multi-threading.md
+++ b/doc/src/base/multi-threading.md
@@ -8,7 +8,7 @@ Base.Threads.threadid
 Base.Threads.nthreads
 ```
 
-Check out [multi-threading](https://docs.julialang.org/en/v1/manual/multi-threading/#Starting-Julia-with-multiple-threads).
+See also [Multi-Threading](@ref man-multithreading).
 ## Synchronization
 
 ```@docs

--- a/doc/src/base/multi-threading.md
+++ b/doc/src/base/multi-threading.md
@@ -8,6 +8,7 @@ Base.Threads.threadid
 Base.Threads.nthreads
 ```
 
+Check out [multi-threading](https://docs.julialang.org/en/v1/manual/multi-threading/#Starting-Julia-with-multiple-threads).
 ## Synchronization
 
 ```@docs

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -18,11 +18,16 @@ The number of execution threads is controlled either by using the
 [`JULIA_NUM_THREADS`](@ref JULIA_NUM_THREADS) environment variable. When both are
 specified, then `-t`/`--threads` takes precedence.
 
-`--threads {N|auto}` Enable N threads; `auto` chooses a number based on the number of detected CPUs.
+The number of threads can either be specified as an integer (`--threads=4`) or as `auto`
+(`--threads=auto`), where `auto` sets the number of threads to the number of local CPU
+threads.
 
+!!! compat "Julia 1.5"
     The `-t`/`--threads` command line argument requires at least Julia 1.5.
     In older versions you must use the environment variable instead.
 
+!!! compat "Julia 1.7"
+    Using `auto` together with the environment variable `JULIA_NUM_THREADS` requires at least Julia 1.7.
 Lets start Julia with 4 threads:
 
 ```bash

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -18,7 +18,8 @@ The number of execution threads is controlled either by using the
 [`JULIA_NUM_THREADS`](@ref JULIA_NUM_THREADS) environment variable. When both are
 specified, then `-t`/`--threads` takes precedence.
 
-!!! compat "Julia 1.5"
+--threads {N\|auto`} Enable N threads; `auto` currently sets N to the number of local CPU threads but this might change in the future.
+
     The `-t`/`--threads` command line argument requires at least Julia 1.5.
     In older versions you must use the environment variable instead.
 

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -18,7 +18,7 @@ The number of execution threads is controlled either by using the
 [`JULIA_NUM_THREADS`](@ref JULIA_NUM_THREADS) environment variable. When both are
 specified, then `-t`/`--threads` takes precedence.
 
---threads {N\|auto`} Enable N threads; `auto` currently sets N to the number of local CPU threads but this might change in the future.
+`--threads {N|auto}` Enable N threads; `auto` chooses a number based on the number of detected CPUs.
 
     The `-t`/`--threads` command line argument requires at least Julia 1.5.
     In older versions you must use the environment variable instead.


### PR DESCRIPTION
Fixed issue #42435 
Added info about multi-threading in both base and manual docs.
Added a link in base section for [Starting with multiple threads](https://docs.julialang.org/en/v1/manual/multi-threading/#Starting-Julia-with-multiple-threads).