### PR TITLE
Fix Base.isinteractive() for startup files

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -252,6 +252,9 @@ function exec_options(opts)
         invokelatest(Main.Distributed.process_opts, opts)
     end
 
+    interactiveinput = (repl || is_interactive) && isa(stdin, TTY)
+    is_interactive |= interactiveinput
+
     # load ~/.julia/config/startup.jl file
     if startup
         try
@@ -299,9 +302,7 @@ function exec_options(opts)
     end
     repl |= is_interactive::Bool
     if repl
-        interactiveinput = isa(stdin, TTY)
         if interactiveinput
-            global is_interactive = true
             banner = (opts.banner != 0) # --banner!=no
         else
             banner = (opts.banner == 1) # --banner=yes

--- a/base/client.jl
+++ b/base/client.jl
@@ -252,7 +252,7 @@ function exec_options(opts)
         invokelatest(Main.Distributed.process_opts, opts)
     end
 
-    interactiveinput = (repl || is_interactive) && isa(stdin, TTY)
+    interactiveinput = (repl || is_interactive::Bool) && isa(stdin, TTY)
     is_interactive |= interactiveinput
 
     # load ~/.julia/config/startup.jl file

--- a/base/client.jl
+++ b/base/client.jl
@@ -261,7 +261,7 @@ function exec_options(opts)
             load_julia_startup()
         catch
             invokelatest(display_error, current_exceptions())
-            !(repl || is_interactive) && exit(1)
+            !(repl || is_interactive::Bool) && exit(1)
         end
     end
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -253,7 +253,7 @@ function exec_options(opts)
     end
 
     interactiveinput = (repl || is_interactive::Bool) && isa(stdin, TTY)
-    is_interactive |= interactiveinput
+    is_interactive::Bool |= interactiveinput
 
     # load ~/.julia/config/startup.jl file
     if startup

--- a/base/client.jl
+++ b/base/client.jl
@@ -300,8 +300,7 @@ function exec_options(opts)
             end
         end
     end
-    repl |= is_interactive::Bool
-    if repl
+    if repl || is_interactive::Bool
         if interactiveinput
             banner = (opts.banner != 0) # --banner!=no
         else


### PR DESCRIPTION
This PR aims to fix #10779 by deciding whether the session is interactive before the startup file is executed. PR also enables hot-fix to set interactivity for `PyPlot` in the startup file when using `PackageCompiler`, see #42425.
```
$cat ~/.julia/config/startup.jl
@show Base.isinteractive()
```
Before PR:
```
$ julia -q
Base.isinteractive() = false
```
After this PR:
```
$ julia -q
Base.isinteractive() = true
```