### PR TITLE
Remove fast_unwind_on_malloc and malloc_context_size restrictions in ASAN CI

### DIFF
--- a/contrib/asan/Make.user.asan
+++ b/contrib/asan/Make.user.asan
@@ -18,6 +18,3 @@ override WITH_GC_DEBUG_ENV=1
 
 # default to a debug build for better line number reporting
 override JULIA_BUILD_MODE=debug
-
-# make ASAN consume less memory
-export ASAN_OPTIONS=detect_leaks=0:allow_user_segv_handler=1

--- a/contrib/asan/Make.user.asan
+++ b/contrib/asan/Make.user.asan
@@ -20,4 +20,4 @@ override WITH_GC_DEBUG_ENV=1
 override JULIA_BUILD_MODE=debug
 
 # make ASAN consume less memory
-export ASAN_OPTIONS=detect_leaks=0:fast_unwind_on_malloc=0:allow_user_segv_handler=1:malloc_context_size=2
+export ASAN_OPTIONS=detect_leaks=0:allow_user_segv_handler=1


### PR DESCRIPTION
This implements @maleadt's suggestion https://github.com/JuliaLang/julia/issues/42498#issuecomment-934248231

A quick benchmark (https://github.com/JuliaLang/julia/issues/42498#issuecomment-935111691) suggests the peak memory consumption is about 5GB. I think the CI machines can handle this.