### PR TITLE
Add the ability to use function calls in `@testset` directly.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,9 @@ New library features
 * `@test_throws "some message" triggers_error()` can now be used to check whether the displayed error text
   contains "some message" regardless of the specific exception type.
   Regular expressions, lists of strings, and matching functions are also supported. ([#41888])
+* `@testset foo()` can now be used to create a test set from a given function. The name of the test set
+  is the name of the called function. The called function can contain `@test` and other `@testset`
+  definitions, including to other function calls, while recording all intermediate test results. ([#42518])
 
 Standard library changes
 ------------------------

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -151,7 +151,10 @@ f             |    1      1
 Test.DefaultTestSet("f", Any[], 1, false, false)
 ```
 
-Note that in the case of functions, the test set will be given the name of the called function. In the event that a nested test set has no failures, as happened here, it will be hidden in the
+This can be used to allow for factorization of test sets, making it easier to run individual
+test sets by running the associated functions instead.
+Note that in the case of functions, the test set will be given the name of the called function.
+In the event that a nested test set has no failures, as happened here, it will be hidden in the
 summary, unless the `verbose=true` option is passed:
 
 ```jldoctest testfoo

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -139,6 +139,18 @@ Test Summary: | Pass  Total
 Foo Tests     |    8      8
 ```
 
+As well as call functions:
+
+```jldoctest testfoo
+julia> f(x) = @test isone(x)
+f (generic function with 1 method)
+
+julia> @testset f(1)
+Test Summary: | Pass  Total
+test set      |    1      1
+Test.DefaultTestSet("test set", Any[], 1, false, false)
+```
+
 In the event that a nested test set has no failures, as happened here, it will be hidden in the
 summary, unless the `verbose=true` option is passed:
 

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -147,8 +147,8 @@ f (generic function with 1 method)
 
 julia> @testset f(1)
 Test Summary: | Pass  Total
-test set      |    1      1
-Test.DefaultTestSet("test set", Any[], 1, false, false)
+f             |    1      1
+Test.DefaultTestSet("f", Any[], 1, false, false)
 ```
 
 In the event that a nested test set has no failures, as happened here, it will be hidden in the

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -151,7 +151,7 @@ f             |    1      1
 Test.DefaultTestSet("f", Any[], 1, false, false)
 ```
 
-In the event that a nested test set has no failures, as happened here, it will be hidden in the
+Note that in the case of functions, the test set will be given the name of the called function. In the event that a nested test set has no failures, as happened here, it will be hidden in the
 summary, unless the `verbose=true` option is passed:
 
 ```jldoctest testfoo

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1225,6 +1225,7 @@ end
     @testset [CustomTestSet] [option=val  ...] ["description"] begin ... end
     @testset [CustomTestSet] [option=val  ...] ["description \$v"] for v in (...) ... end
     @testset [CustomTestSet] [option=val  ...] ["description \$v, \$w"] for v in (...), w in (...) ... end
+    @testset [CustomTestSet] [option=val  ...] ["description \$v, \$w"] foo()
 
 Starts a new test set, or multiple test sets if a `for` loop is provided.
 
@@ -1241,6 +1242,7 @@ nested testsets is shown even when they all pass (the default is `false`).
 
 The description string accepts interpolation from the loop indices.
 If no description is provided, one is constructed based on the variables.
+If a function call is provided, its name will be used. Explicit description strings override this behavior.
 
 By default the `@testset` macro will return the testset object itself, though
 this behavior can be customized in other testset types. If a `for` loop is used
@@ -1293,10 +1295,11 @@ Generate the code for a `@testset` with a function call or `begin`/`end` argumen
 function testset_beginend_call(args, tests, source)
     desc, testsettype, options = parse_testset_args(args[1:end-1])
     if desc === nothing
-        desc = "test set"
-    end
-    if tests.head === :call
-        desc = string(tests.args[1]) # use the function name as test name
+        if tests.head === :call
+            desc = string(tests.args[1]) # use the function name as test name
+        else
+            desc = "test set"
+        end
     end
     # If we're at the top level we'll default to DefaultTestSet. Otherwise
     # default to the type of the parent testset

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1275,24 +1275,28 @@ macro testset(args...)
     tests = args[end]
 
     # Determine if a single block or for-loop style
-    if !isa(tests,Expr) || (tests.head !== :for && tests.head !== :block)
-        error("Expected begin/end block or for loop as argument to @testset")
+    if !isa(tests,Expr) || (tests.head !== :for && tests.head !== :block && tests.head != :call)
+
+        error("Expected function call, begin/end block or for loop as argument to @testset")
     end
 
     if tests.head === :for
         return testset_forloop(args, tests, __source__)
     else
-        return testset_beginend(args, tests, __source__)
+        return testset_beginend_call(args, tests, __source__)
     end
 end
 
 """
-Generate the code for a `@testset` with a `begin`/`end` argument
+Generate the code for a `@testset` with a function call or `begin`/`end` argument
 """
-function testset_beginend(args, tests, source)
+function testset_beginend_call(args, tests, source)
     desc, testsettype, options = parse_testset_args(args[1:end-1])
     if desc === nothing
         desc = "test set"
+    end
+    if tests.head === :call
+        desc = string(tests.args[1]) # use the function name as test name
     end
     # If we're at the top level we'll default to DefaultTestSet. Otherwise
     # default to the type of the parent testset

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1239,3 +1239,25 @@ Test.finish(ts::PassInformationTestSet) = ts
     @test ts.results[2].value == ErrorException("Msg")
     @test ts.results[2].source == LineNumberNode(test_throws_line_number, @__FILE__)
 end
+
+let
+    f(x) = @test isone(x)
+    function h(x)
+        @testset f(x)
+        @testset "success" begin @test true end
+        @testset for i in 1:3
+            @test !iszero(i)
+        end
+    end
+    tret = @testset h(1)
+    @testset "Function calls" begin
+        @test tret.description == "h"
+        @test length(tret.results) == 5
+        @test tret.results[1].description == "f"
+        @test tret.results[2].description == "success"
+        for i in 1:3
+            @test tret.results[2+i].description == "i = $i"
+        end
+    end
+end
+

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1250,8 +1250,10 @@ let
         end
     end
     tret = @testset h(1)
+    tdesc = @testset "description" h(1)
     @testset "Function calls" begin
         @test tret.description == "h"
+        @test tdesc.description == "description"
         @test length(tret.results) == 5
         @test tret.results[1].description == "f"
         @test tret.results[2].description == "success"


### PR DESCRIPTION
This allows for easier factoring of tests into functions, making it possible to `include` a `test/runtests.jl` file without running tests directly (should it be written with this in mind) and enabling running of specific testsets explicitly by calling the functions they're defined in instead.

For example, this PR makes the following work:

```julia
f(x) = @test isone(x)
function g(x)
    @test x > 0
    @testset f(x)
end
@testset g(1)
```

with output:

```julia
Test Summary: | Pass  Total
g             |    2      2
Test.DefaultTestSet("g", Any[Test.DefaultTestSet("f", Any[], 1, false, false)], 1, false, false)
```

If a description string is provided, it will be used instead of the function name.
In case of a failure (e.g. by running `@testset g(0)`):

```julia
g: Test Failed at REPL[11]:2
  Expression: x > 0
   Evaluated: 0 > 0
Stacktrace:
 [1] macro expansion
   @ ~/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:460 [inlined]
 [2] g(x::Int64)
   @ Main ./REPL[11]:2
f: Test Failed at REPL[10]:1
  Expression: isone(x)
Stacktrace:
 [1] macro expansion
   @ ~/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:460 [inlined]
 [2] f(x::Int64)
   @ Main ./REPL[10]:1
Test Summary: | Fail  Total
g             |    2      2
  f           |    1      1
ERROR: Some tests did not pass: 0 passed, 2 failed, 0 errored, 0 broken.
```

The change was surprisingly minimal and I think it just.. works? Rudimentary testing in the REPL as well as those written tests included here didn't provide any obvious footguns, so I'm inclined to say this is a good idea.

Nevertheless, this is still missing a NEWS.md entry, docs could/should be more extensive and I may have missed something, so I'm opening this as a draft.