### PR TITLE
inference: forward `Conditional` inter-procedurally

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1238,10 +1238,10 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     # try constant propagation with manual inlinings of some of the heuristics
     # since some checks within `abstract_call_method_with_const_args` seem a bit costly
     const_prop_entry_heuristic(interp, result, sv) || return CallMeta(rt, InvokeCallInfo(match, nothing))
-    argtypes′ = argtypes[4:end]
-    pushfirst!(argtypes′, ft)
-    fargs′ = fargs[4:end]
-    pushfirst!(fargs′, fargs[1])
+    argtypes′ = argtypes[3:end]
+    argtypes′[1] = ft
+    fargs′ = fargs[3:end]
+    fargs′[1] = fargs[1]
     arginfo = ArgInfo(fargs′, argtypes′)
     const_prop_argument_heuristic(interp, arginfo, sv) || return CallMeta(rt, InvokeCallInfo(match, nothing))
     # # typeintersect might have narrowed signature, but the accuracy gain doesn't seem worth the cost involved with the lattice comparisons

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -547,7 +547,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter, resul
                 return nothing
             end
         end
-        inf_result = InferenceResult(mi; arginfo, va_override)
+        inf_result = InferenceResult(mi, arginfo, va_override)
         if !any(inf_result.overridden_by_const)
             add_remark!(interp, sv, "[constprop] Could not handle constant info in matching_cache_argtypes")
             return nothing

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -37,13 +37,14 @@ function matching_cache_argtypes(
                     condargs = Tuple{Int,Int}[]
                 end
                 # using union-split signature, we may be able to narrow down `Conditional` to `Const`
-                (; vtype, elsetype) = cnd
-                if tmeet(vtype, widenconst(argtypes[slotid])) === Bottom
+                vtype = tmeet(cnd.vtype, widenconst(argtypes[slotid]))
+                elsetype = tmeet(cnd.elsetype, widenconst(argtypes[slotid]))
+                if vtype === Bottom
                     given_argtypes[i] = Const(false)
                     # union-split should never find a more precise information about `fargs[slotid]` than `Conditional`,
                     # otherwise there should have been a bug around `Conditional` construction or maintainance
-                    @assert tmeet(elsetype, widenconst(argtypes[slotid])) !== Bottom "invalid Conditional element"
-                elseif tmeet(elsetype, widenconst(argtypes[slotid])) === Bottom
+                    @assert elsetype !== Bottom "invalid Conditional element"
+                elseif elsetype === Bottom
                     given_argtypes[i] = Const(true)
                 else
                     push!(condargs, (slotid, i))

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -3,11 +3,17 @@
 function is_argtype_match(@nospecialize(given_argtype),
                           @nospecialize(cache_argtype),
                           overridden_by_const::Bool)
-    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct) ||
-       isa(given_argtype, PartialOpaque) || isa(given_argtype, Conditional)
+    if is_forwardable_argtype(given_argtype)
         return is_lattice_equal(given_argtype, cache_argtype)
     end
     return !overridden_by_const
+end
+
+function is_forwardable_argtype(@nospecialize x)
+    return isa(x, Const) ||
+           isa(x, Conditional) ||
+           isa(x, PartialStruct) ||
+           isa(x, PartialOpaque)
 end
 
 # In theory, there could be a `cache` containing a matching `InferenceResult`
@@ -77,7 +83,7 @@ function matching_cache_argtypes(
     for i in 1:nargs
         given_argtype = given_argtypes[i]
         cache_argtype = cache_argtypes[i]
-        if !is_argtype_match(given_argtype, cache_argtype, overridden_by_const[i])
+        if !is_argtype_match(given_argtype, cache_argtype, false)
             # prefer the argtype we were given over the one computed from `linfo`
             cache_argtypes[i] = given_argtype
             overridden_by_const[i] = true

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -964,7 +964,7 @@ function abstract_modifyfield!(interp::AbstractInterpreter, argtypes::Vector{Any
         v = unwrapva(argtypes[5])
         TF = getfield_tfunc(o, f)
         push!(sv.ssavalue_uses[sv.currpc], sv.currpc) # temporarily disable `call_result_unused` check for this call
-        callinfo = abstract_call(interp, nothing, Any[op, TF, v], sv, #=max_methods=# 1)
+        callinfo = abstract_call(interp, ArgInfo(nothing, Any[op, TF, v]), sv, #=max_methods=# 1)
         pop!(sv.ssavalue_uses[sv.currpc], sv.currpc)
         TF2 = tmeet(callinfo.rt, widenconst(TF))
         if TF2 === Bottom
@@ -1747,7 +1747,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                     if contains_is(argtypes_vec, Union{})
                         return CallMeta(Const(Union{}), false)
                     end
-                    call = abstract_call(interp, nothing, argtypes_vec, sv, -1)
+                    call = abstract_call(interp, ArgInfo(nothing, argtypes_vec), sv, -1)
                     info = verbose_stmt_info(interp) ? ReturnTypeCallInfo(call.info) : false
                     rt = widenconditional(call.rt)
                     if isa(rt, Const)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -17,6 +17,11 @@ If `interp` is an `AbstractInterpreter`, it is expected to provide at least the 
 """
 abstract type AbstractInterpreter end
 
+struct ArgInfo
+    fargs::Union{Nothing,Vector{Any}}
+    argtypes::Vector{Any}
+end
+
 """
     InferenceResult
 
@@ -29,8 +34,10 @@ mutable struct InferenceResult
     result # ::Type, or InferenceState if WIP
     src #::Union{CodeInfo, OptimizationState, Nothing} # if inferred copy is available
     valid_worlds::WorldRange # if inference and optimization is finished
-    function InferenceResult(linfo::MethodInstance, given_argtypes = nothing, va_override=false)
-        argtypes, overridden_by_const = matching_cache_argtypes(linfo, given_argtypes, va_override)
+    function InferenceResult(linfo::MethodInstance;
+                             arginfo::Union{Nothing,ArgInfo} = nothing,
+                             va_override::Bool = false)
+        argtypes, overridden_by_const = matching_cache_argtypes(linfo, arginfo, va_override)
         return new(linfo, argtypes, overridden_by_const, Any, nothing, WorldRange())
     end
 end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -34,7 +34,7 @@ mutable struct InferenceResult
     result # ::Type, or InferenceState if WIP
     src #::Union{CodeInfo, OptimizationState, Nothing} # if inferred copy is available
     valid_worlds::WorldRange # if inference and optimization is finished
-    function InferenceResult(linfo::MethodInstance;
+    function InferenceResult(linfo::MethodInstance,
                              arginfo::Union{Nothing,ArgInfo} = nothing,
                              va_override::Bool = false)
         argtypes, overridden_by_const = matching_cache_argtypes(linfo, arginfo, va_override)

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -259,15 +259,6 @@ unioncomplexity(u::UnionAll) = max(unioncomplexity(u.body)::Int, unioncomplexity
 unioncomplexity(t::TypeofVararg) = isdefined(t, :T) ? unioncomplexity(t.T)::Int : 0
 unioncomplexity(@nospecialize(x)) = 0
 
-function improvable_via_constant_propagation(@nospecialize(t))
-    if isconcretetype(t) && t <: Tuple
-        for p in t.parameters
-            p === DataType && return true
-        end
-    end
-    return false
-end
-
 # convert a Union of Tuple types to a Tuple of Unions
 function unswitchtupleunion(u::Union)
     ts = uniontypes(u)


### PR DESCRIPTION
The PR #38905 only "back-propagates" conditional constraint
(from callee to caller), but currently we don't "forward" it
(caller to callee), and so inter-procedural constraint propagation
won't happen for e.g.:
```julia
ifelselike(cnd, x, y) = cnd ? x : y
@test Base.return_types((Any,Int,)) do x, y
    ifelselike(isa(x, Int), x, y)
end |> only == Int
```

This commit complements #38905 and enables further inter-procedural
conditional constraint propagation by forwarding `Conditional` to
callees when it imposes a constraint on any other argument,
during constant propagation.

---

- IIUC, this PR will be a requirement of #37343 ?
- /cc @c42f @chriselrod 