### PR TITLE
Use the module specific names in `names()` instead of the binding

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -833,9 +833,10 @@ JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
                  (imported && b->imported) ||
                  (b->owner == m && !b->imported && (all || m == jl_main_module))) &&
                 (all || (!b->deprecated && !hidden))) {
+                jl_sym_t *in_module_name = (jl_sym_t*)table[i-1]; // the name in the module may not be b->name, use the httable key instead
                 jl_array_grow_end(a, 1);
                 //XXX: change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:
-                jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)b->name);
+                jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)in_module_name);
             }
         }
     }

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2493,6 +2493,10 @@ import .Mod: x as x2
 @test x2 == 1
 @test !@isdefined(x)
 
+module_names = names(@__MODULE__; all=true, imported=true)
+@test :x2 ∈ module_names
+@test :x ∉ module_names
+
 import .Mod2.y as y2
 
 @test y2 == 2


### PR DESCRIPTION
As reported in #42527, the imported values that are aliased have their original name as `binding->name` (unlike the modules). However, the key of the binding table has the relevant name so this can be used in the `names` function to always get the aliased version.

Fixes #42527