### PR TITLE
Fix GMP build-patched def.

### DIFF
--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -39,10 +39,10 @@ $(SRCCACHE)/gmp-$(GMP_VER)/gmp_alloc_overflow_func.patch-applied: $(SRCCACHE)/gm
 		patch -p1 < $(SRCDIR)/patches/gmp_alloc_overflow_func.patch
 	echo 1 > $@
 
-$(SRCCACHE)/gmp-$(GMP_VER)/build-patched:
-	$(SRCCACHE)/gmp-$(GMP_VER)/gmp-HG-changeset.patch-applied
-	$(SRCCACHE)/gmp-$(GMP_VER)/gmp-exception.patch-applied
-	$(SRCCACHE)/gmp-$(GMP_VER)/gmp_alloc_overflow_func.patch-applied	
+$(SRCCACHE)/gmp-$(GMP_VER)/build-patched: \
+	$(SRCCACHE)/gmp-$(GMP_VER)/gmp-HG-changeset.patch-applied \
+	$(SRCCACHE)/gmp-$(GMP_VER)/gmp-exception.patch-applied \
+	$(SRCCACHE)/gmp-$(GMP_VER)/gmp_alloc_overflow_func.patch-applied
 
 $(BUILDDIR)/gmp-$(GMP_VER)/build-configured: $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted $(SRCCACHE)/gmp-$(GMP_VER)/build-patched
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Title says it all. Also impacts backports-release-1.7 as https://github.com/JuliaLang/julia/pull/42293 was backported there. Best! :)