### PR TITLE
Updating latest stable version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Julia. However, most users should use the [most recent stable version](https://g
 of Julia. You can get this version by changing to the Julia directory
 and running:
 
-    git checkout v1.6.2
+    git checkout v1.6.3
 
 Now run `make` to build the `julia` executable.
 


### PR DESCRIPTION
Per #42542: Changing the latest stable version number in the "Building Julia" section of the REAMDE from `v1.6.2` to `v1.6.3` (according to [the downloads page](https://julialang.org/downloads/#current_stable_release)).