### PR TITLE
Add compat note for `printstyled`

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -15,7 +15,7 @@ avoid Julia-specific details.
 For example, `show` displays strings with quotes, and `print` displays strings
 without quotes.
 
-See also [`println`](@ref), [`string`](@ref).
+See also [`println`](@ref), [`string`](@ref), [`printstyled`](@ref).
 
 # Examples
 ```jldoctest
@@ -56,6 +56,8 @@ end
 
 Print (using [`print`](@ref)) `xs` to `io` followed by a newline.
 If `io` is not supplied, prints to the default output stream [`stdout`](@ref).
+
+See also [`printstyled`](@ref) to add colors etc.
 
 # Examples
 ```jldoctest

--- a/base/util.jl
+++ b/base/util.jl
@@ -124,7 +124,7 @@ These properties can be used in any combination.
 See also [`print`](@ref), [`println`](@ref), [`show`](@ref). 
 
 !!! compat "Julia 1.7"
-    Keywords except `color` were added in Julia 1.7.
+    Keywords except `color` and `bold` were added in Julia 1.7.
 """
 printstyled(io::IO, msg...; bold::Bool=false, underline::Bool=false, blink::Bool=false, reverse::Bool=false, hidden::Bool=false, color::Union{Int,Symbol}=:normal) =
     with_output_color(print, color, io, msg...; bold=bold, underline=underline, blink=blink, reverse=reverse, hidden=hidden)

--- a/base/util.jl
+++ b/base/util.jl
@@ -121,6 +121,8 @@ Keyword `reverse=true` prints with foreground and background colors exchanged,
 and `hidden=true` should be invisibe in the terminal but can still be copied.
 These properties can be used in any combination.
 
+See also [`print`](@ref), [`println`](@ref), [`show`](@ref). 
+
 !!! compat "Julia 1.7"
     Keywords except `color` were added in Julia 1.7.
 """

--- a/base/util.jl
+++ b/base/util.jl
@@ -113,14 +113,13 @@ end
 
 Print `xs` in a color specified as a symbol or integer, optionally in bold.
 
-`color` may take any of the values $(Base.available_text_colors_docstring)
+Keyword `color` may take any of the values $(Base.available_text_colors_docstring)
 or an integer between 0 and 255 inclusive. Note that not all terminals support 256 colors.
-If the keyword `bold` is given as `true`, the result will be printed in bold.
-If the keyword `underline` is given as `true`, the result will be printed underlined.
-If the keyword `blink` is given as `true`, the result will blink.
-If the keyword `reverse` is given as `true`, the result will have foreground and background colors inversed.
-If the keyword `hidden` is given as `true`, the result will be hidden.
-Keywords can be given in any combination.
+
+Keywords `bold=true`, `underline=true`, `blink=true` are self-explanatory.
+Keyword `reverse=true` prints with foreground and background colors exchanged,
+and `hidden=true` should be invisibe in the terminal but can still be copied.
+These properties can be used in any combination.
 
 !!! compat "Julia 1.7"
     Keywords except `color` were added in Julia 1.7.

--- a/base/util.jl
+++ b/base/util.jl
@@ -121,6 +121,9 @@ If the keyword `blink` is given as `true`, the result will blink.
 If the keyword `reverse` is given as `true`, the result will have foreground and background colors inversed.
 If the keyword `hidden` is given as `true`, the result will be hidden.
 Keywords can be given in any combination.
+
+!!! compat "Julia 1.7"
+    Keywords except `color` were added in Julia 1.7.
 """
 printstyled(io::IO, msg...; bold::Bool=false, underline::Bool=false, blink::Bool=false, reverse::Bool=false, hidden::Bool=false, color::Union{Int,Symbol}=:normal) =
     with_output_color(print, color, io, msg...; bold=bold, underline=underline, blink=blink, reverse=reverse, hidden=hidden)

--- a/base/util.jl
+++ b/base/util.jl
@@ -121,7 +121,7 @@ Keyword `reverse=true` prints with foreground and background colors exchanged,
 and `hidden=true` should be invisibe in the terminal but can still be copied.
 These properties can be used in any combination.
 
-See also [`print`](@ref), [`println`](@ref), [`show`](@ref). 
+See also [`print`](@ref), [`println`](@ref), [`show`](@ref).
 
 !!! compat "Julia 1.7"
     Keywords except `color` and `bold` were added in Julia 1.7.


### PR DESCRIPTION
The keywords `underline=true, blink=true` etc. added to `printstyled` in #40288 don't exist before Julia 1.7, so this adds a note.

It also tries to tidy up the docstring, as too many sentences like "If the keyword `underline` is given as `true`, the result will be printed underlined" one after another start to get redundant. And adds a few "see also" links.

Should there also be a note in https://github.com/JuliaLang/julia/blob/master/HISTORY.md#standard-library-changes ? 