### PR TITLE
CI (Buildkite): do not allow the `asan` job to fail

### DIFF
--- a/.buildkite/pipelines/main/misc/sanitizers.yml
+++ b/.buildkite/pipelines/main/misc/sanitizers.yml
@@ -21,7 +21,6 @@ steps:
     timeout_in_minutes: 120
     if: | # We only run the `asan` job on Julia 1.8 and later.
       (pipeline.slug != "julia-release-1-dot-6") && (pipeline.slug != "julia-release-1-dot-7")
-    soft_fail: true # TODO: delete this line (and thus disallow failures) once JuliaLang/julia#42540 is fixed
     commands: |
       echo "--- Build julia-debug with ASAN"
       contrib/asan/build.sh ./tmp/test-asan -j$${JULIA_CPU_THREADS:?} debug


### PR DESCRIPTION
This PR should not be merged until #42540 is fixed.