### PR TITLE
add Unicode.julia_chartransform Julia-parser normalization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -122,6 +122,11 @@ Standard library changes
 #### Unicode
 * Added function `isequal_normalized` to check for Unicode equivalence without
   explicitly constructing normalized strings ([#42493]).
+* The `Unicode.normalize` function now accepts a `charmap` keyword that can
+  be used to supply custom character mappings, and a `Unicode.julia_charmap`
+  function is provided to reproduce the mapping used in identifier normalization
+  by the Julia parser ([#42561]).
+
 
 Deprecated or removed
 ---------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -122,8 +122,8 @@ Standard library changes
 #### Unicode
 * Added function `isequal_normalized` to check for Unicode equivalence without
   explicitly constructing normalized strings ([#42493]).
-* The `Unicode.normalize` function now accepts a `charmap` keyword that can
-  be used to supply custom character mappings, and a `Unicode.julia_charmap`
+* The `Unicode.normalize` function now accepts a `chartransform` keyword that can
+  be used to supply custom character mappings, and a `Unicode.julia_chartransform`
   function is provided to reproduce the mapping used in identifier normalization
   by the Julia parser ([#42561]).
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -145,20 +145,41 @@ const UTF8PROC_STRIPMARK = (1<<13)
 
 utf8proc_error(result) = error(unsafe_string(ccall(:utf8proc_errmsg, Cstring, (Cssize_t,), result)))
 
-function utf8proc_map(str::Union{String,SubString{String}}, options::Integer)
-    nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
-                   str, sizeof(str), C_NULL, 0, options)
-    nwords < 0 && utf8proc_error(nwords)
+# static wrapper around user callback function
+utf8proc_custom_func(codepoint::UInt32, callback::Ptr{Cvoid}) = UInt32(unsafe_pointer_to_objref(callback)(codepoint))::UInt32
+
+function utf8proc_decompose(str, options, buffer, nwords, charmap)
+    if charmap === identity
+        ret = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
+                    str, sizeof(str), buffer, nwords, options)
+    else
+        ret = ccall(:utf8proc_decompose_custom, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint, Ptr{Cvoid}, Any),
+                    str, sizeof(str), buffer, nwords, options,
+                    @cfunction(utf8proc_custom_func, UInt32, (UInt32, Ptr{Cvoid})), charmap)
+    end
+    ret < 0 && utf8proc_error(ret)
+    return ret
+end
+
+function utf8proc_map(str::Union{String,SubString{String}}, options::Integer, charmap=identity)
+    nwords = utf8proc_decompose(str, options, C_NULL, 0, charmap)
     buffer = Base.StringVector(nwords*4)
-    nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
-                   str, sizeof(str), buffer, nwords, options)
-    nwords < 0 && utf8proc_error(nwords)
+    nwords = utf8proc_decompose(str, options, buffer, nwords, charmap)
     nbytes = ccall(:utf8proc_reencode, Int, (Ptr{UInt8}, Int, Cint), buffer, nwords, options)
     nbytes < 0 && utf8proc_error(nbytes)
     return String(resize!(buffer, nbytes))
 end
 
-utf8proc_map(s::AbstractString, flags::Integer) = utf8proc_map(String(s), flags)
+# from julia_charmap.h, used by julia_charmap in the Unicode stdlib
+const _julia_charmap = Dict{UInt32,UInt32}(
+    0x025B => 0x03B5,
+    0x00B5 => 0x03BC,
+    0x00B7 => 0x22C5,
+    0x0387 => 0x22C5,
+    0x2212 => 0x002D,
+)
+
+utf8proc_map(s::AbstractString, flags::Integer, charmap=identity) = utf8proc_map(String(s), flags, charmap)
 
 # Documented in Unicode module
 function normalize(
@@ -176,6 +197,7 @@ function normalize(
     casefold::Bool=false,
     lump::Bool=false,
     stripmark::Bool=false,
+    charmap=identity,
 )
     flags = 0
     stable && (flags = flags | UTF8PROC_STABLE)
@@ -198,7 +220,7 @@ function normalize(
     casefold && (flags = flags | UTF8PROC_CASEFOLD)
     lump && (flags = flags | UTF8PROC_LUMP)
     stripmark && (flags = flags | UTF8PROC_STRIPMARK)
-    utf8proc_map(s, flags)
+    utf8proc_map(s, flags, charmap)
 end
 
 function normalize(s::AbstractString, nf::Symbol)

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -146,7 +146,8 @@ const UTF8PROC_STRIPMARK = (1<<13)
 utf8proc_error(result) = error(unsafe_string(ccall(:utf8proc_errmsg, Cstring, (Cssize_t,), result)))
 
 # static wrapper around user callback function
-utf8proc_custom_func(codepoint::UInt32, callback::Ptr{Cvoid}) = UInt32(unsafe_pointer_to_objref(callback)(codepoint))::UInt32
+utf8proc_custom_func(codepoint::UInt32, callback::Ptr{Cvoid}) =
+    UInt32(unsafe_pointer_to_objref(callback)(codepoint))::UInt32
 
 function utf8proc_decompose(str, options, buffer, nwords, chartransform)
     if chartransform === identity

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -149,7 +149,6 @@ utf8proc_error(result) = error(unsafe_string(ccall(:utf8proc_errmsg, Cstring, (C
 utf8proc_custom_func(codepoint::UInt32, callback::Any) =
     UInt32(callback(codepoint))::UInt32
 
-
 function utf8proc_decompose(str, options, buffer, nwords, chartransform::typeof(identity))
     ret = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
                 str, sizeof(str), buffer, nwords, options)

--- a/src/flisp/julia_charmap.h
+++ b/src/flisp/julia_charmap.h
@@ -1,6 +1,9 @@
 /* Array of {original codepoint, replacement codepoint} normalizations
    to perform on Julia identifiers, to canonicalize characters that
-   are both easily confused and easily inputted by accident. */
+   are both easily confused and easily inputted by accident.
+
+   Important: when this table is updated, also update the corresponding table
+              in base/strings/unicode.jl */
 static const uint32_t charmap[][2] = {
     { 0x025B, 0x03B5 }, // latin small letter open e -> greek small letter epsilon
     { 0x00B5, 0x03BC }, // micro sign -> greek small letter mu

--- a/stdlib/Unicode/docs/src/index.md
+++ b/stdlib/Unicode/docs/src/index.md
@@ -1,6 +1,7 @@
 # Unicode
 
 ```@docs
+Unicode.julia_chartransform
 Unicode.isassigned
 Unicode.isequal_normalized
 Unicode.normalize

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -73,7 +73,7 @@ You can also use the `chartransform` keyword (which defaults to `identity`) to p
 character as it is processed, in order to perform arbitrary additional normalizations.
 For example, by passing `chartransform=Unicode.julia_custom_map`, you can apply a few Julia-specific
 character normalizations that are performed by Julia when parsing identifiers (in addition to
-NFC normalization: `compase=true, stable=true`).
+NFC normalization: `compose=true, stable=true`).
 
 For example, NFKC corresponds to the options `compose=true, compat=true, stable=true`.
 

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -87,8 +87,8 @@ options (which all default to `false` except for `compose`) are specified:
 * `stable=true`: enforce Unicode versioning stability (never introduce characters missing from earlier Unicode versions)
 
 You can also use the `chartransform` keyword (which defaults to `identity`) to pass an arbitrary
-*function* mapping `Integer` codepoints to codepoints, which is is called on each decomposed
-character as it is processed, in order to perform arbitrary additional normalizations.
+*function* mapping `Integer` codepoints to codepoints, which is is called on each
+character in `s` as it is processed, in order to perform arbitrary additional normalizations.
 For example, by passing `chartransform=Unicode.julia_chartransform`, you can apply a few Julia-specific
 character normalizations that are performed by Julia when parsing identifiers (in addition to
 NFC normalization: `compose=true, stable=true`).

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -15,14 +15,14 @@ For example, `'µ'` (U+00B5 micro) is treated as equivalent to `'μ'` (U+03BC mu
 Julia's parser, so `julia_chartransform` performs this transformation while leaving
 other characters unchanged:
 ```jldoctest
-julia> julia_chartransform('\u00B5')
+julia> Unicode.julia_chartransform('\u00B5')
 'μ': Unicode U+03BC (category Ll: Letter, lowercase)
 
-julia> julia_chartransform('x')
+julia> Unicode.julia_chartransform('x')
 'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 ```
 
-The `julia_chartransform` is mainly useful for passing to the [`Unicode.normalize`](@ref)
+`julia_chartransform` is mainly useful for passing to the [`Unicode.normalize`](@ref)
 function in order to mimic the normalization used by the Julia parser:
 ```jl
 julia> s = "\u00B5o\u0308"

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -71,7 +71,7 @@ options (which all default to `false` except for `compose`) are specified:
 You can also use the `chartransform` keyword (which defaults to `identity`) to pass an arbitrary
 *function* mapping `Integer` codepoints to codepoints, which is is called on each decomposed
 character as it is processed, in order to perform arbitrary additional normalizations.
-For example, by passing `chartransform=Unicode.julia_custom_map`, you can apply a few Julia-specific
+For example, by passing `chartransform=Unicode.julia_chartransform`, you can apply a few Julia-specific
 character normalizations that are performed by Julia when parsing identifiers (in addition to
 NFC normalization: `compose=true, stable=true`).
 

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -69,7 +69,7 @@ options (which all default to `false` except for `compose`) are specified:
 * `stable=true`: enforce Unicode versioning stability (never introduce characters missing from earlier Unicode versions)
 
 You can also use the `chartransform` keyword (which defaults to `identity`) to pass an arbitrary
-*function* mapping codepoints (integers) to codepoints, which is is called on each decomposed
+*function* mapping `Integer` codepoints to codepoints, which is is called on each decomposed
 character as it is processed, in order to perform arbitrary additional normalizations.
 For example, by passing `chartransform=Unicode.julia_custom_map`, you can apply a few Julia-specific
 character normalizations that are performed by Julia when parsing identifiers (in addition to

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -43,7 +43,7 @@ true
 !!! compat "Julia 1.8"
     This function was introduced in Julia 1.8.
 """
-function julia_chartransform end;
+function julia_chartransform end
 julia_chartransform(codepoint::UInt32) = get(Base.Unicode._julia_charmap, codepoint, codepoint)
 julia_chartransform(codepoint::Integer) = julia_chartransform(UInt32(codepoint))
 julia_chartransform(char::Char) = Char(julia_chartransform(UInt32(char)))

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -5,7 +5,7 @@ module Unicode
 export graphemes, isequal_normalized
 
 """
-    julia_chartransform(c::Union{Char,Integer})
+    Unicode.julia_chartransform(c::Union{Char,Integer})
 
 Map the Unicode character (`Char`) or codepoint (`Integer`) `c` to the corresponding
 "equivalent" character or codepoint, respectively, according to the custom equivalence
@@ -20,6 +20,24 @@ julia> julia_chartransform('\u00B5')
 
 julia> julia_chartransform('x')
 'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
+```
+
+The `julia_chartransform` is mainly useful for passing to the [`Unicode.normalize`](@ref)
+function in order to mimic the normalization used by the Julia parser:
+```jl
+julia> s = "\u00B5o\u0308"
+"µö"
+
+julia> s2 = Unicode.normalize(s, compose=true, stable=true, chartransform=Unicode.julia_chartransform)
+"μö"
+
+julia> collect(s2)
+2-element Vector{Char}:
+ 'μ': Unicode U+03BC (category Ll: Letter, lowercase)
+ 'ö': Unicode U+00F6 (category Ll: Letter, lowercase)
+
+ julia> s2 == string(Meta.parse(s))
+true
 ```
 
 !!! compat "Julia 1.8"

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -5,30 +5,30 @@ module Unicode
 export graphemes, isequal_normalized
 
 """
-    julia_charmap(c::Union{Char,Integer})
+    julia_chartransform(c::Union{Char,Integer})
 
 Map the Unicode character (`Char`) or codepoint (`Integer`) `c` to the corresponding
 "equivalent" character or codepoint, respectively, according to the custom equivalence
 used within the Julia parser (in addition to NFC normalization).
 
 For example, `'µ'` (U+00B5 micro) is treated as equivalent to `'μ'` (U+03BC mu) by
-Julia's parser, so `julia_charmap` performs this transformation while leaving
+Julia's parser, so `julia_chartransform` performs this transformation while leaving
 other characters unchanged:
 ```jldoctest
-julia> julia_charmap('\u00B5')
+julia> julia_chartransform('\u00B5')
 'μ': Unicode U+03BC (category Ll: Letter, lowercase)
 
-julia> julia_charmap('x')
+julia> julia_chartransform('x')
 'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 ```
 
 !!! compat "Julia 1.8"
     This function was introduced in Julia 1.8.
 """
-function julia_charmap end;
-julia_charmap(codepoint::UInt32) = get(Base.Unicode._julia_charmap, codepoint, codepoint)
-julia_charmap(codepoint::Integer) = julia_charmap(UInt32(codepoint))
-julia_charmap(char::Char) = Char(julia_charmap(UInt32(char)))
+function julia_chartransform end;
+julia_chartransform(codepoint::UInt32) = get(Base.Unicode._julia_charmap, codepoint, codepoint)
+julia_chartransform(codepoint::Integer) = julia_chartransform(UInt32(codepoint))
+julia_chartransform(char::Char) = Char(julia_chartransform(UInt32(char)))
 
 """
     Unicode.normalize(s::AbstractString; keywords...)
@@ -68,10 +68,10 @@ options (which all default to `false` except for `compose`) are specified:
 * `rejectna=true`: throw an error if unassigned code points are found
 * `stable=true`: enforce Unicode versioning stability (never introduce characters missing from earlier Unicode versions)
 
-You can also use the `charmap` keyword (which defaults to `identity`) to pass an arbitrary
+You can also use the `chartransform` keyword (which defaults to `identity`) to pass an arbitrary
 *function* mapping codepoints (integers) to codepoints, which is is called on each decomposed
 character as it is processed, in order to perform arbitrary additional normalizations.
-For example, by passing `charmap=Unicode.julia_custom_map`, you can apply a few Julia-specific
+For example, by passing `chartransform=Unicode.julia_custom_map`, you can apply a few Julia-specific
 character normalizations that are performed by Julia when parsing identifiers (in addition to
 NFC normalization: `compase=true, stable=true`).
 
@@ -93,7 +93,7 @@ julia> Unicode.normalize("JúLiA", stripmark=true)
 ```
 
 !!! compat "Julia 1.8"
-    The `charmap` keyword argument requires Julia 1.8.
+    The `chartransform` keyword argument requires Julia 1.8.
 """
 function normalize end
 normalize(s::AbstractString, nf::Symbol) = Base.Unicode.normalize(s, nf)

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -36,7 +36,7 @@ julia> collect(s2)
  'μ': Unicode U+03BC (category Ll: Letter, lowercase)
  'ö': Unicode U+00F6 (category Ll: Letter, lowercase)
 
- julia> s2 == string(Meta.parse(s))
+julia> s2 == string(Meta.parse(s))
 true
 ```
 

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -5,6 +5,32 @@ module Unicode
 export graphemes, isequal_normalized
 
 """
+    julia_charmap(c::Union{Char,Integer})
+
+Map the Unicode character (`Char`) or codepoint (`Integer`) `c` to the corresponding
+"equivalent" character or codepoint, respectively, according to the custom equivalence
+used within the Julia parser (in addition to NFC normalization).
+
+For example, `'µ'` (U+00B5 micro) is treated as equivalent to `'μ'` (U+03BC mu) by
+Julia's parser, so `julia_charmap` performs this transformation while leaving
+other characters unchanged:
+```jldoctest
+julia> julia_charmap('\u00B5')
+'μ': Unicode U+03BC (category Ll: Letter, lowercase)
+
+julia> julia_charmap('x')
+'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
+```
+
+!!! compat "Julia 1.8"
+    This function was introduced in Julia 1.8.
+"""
+function julia_charmap end;
+julia_charmap(codepoint::UInt32) = get(Base.Unicode._julia_charmap, codepoint, codepoint)
+julia_charmap(codepoint::Integer) = julia_charmap(UInt32(codepoint))
+julia_charmap(char::Char) = Char(julia_charmap(UInt32(char)))
+
+"""
     Unicode.normalize(s::AbstractString; keywords...)
     Unicode.normalize(s::AbstractString, normalform::Symbol)
 
@@ -42,6 +68,13 @@ options (which all default to `false` except for `compose`) are specified:
 * `rejectna=true`: throw an error if unassigned code points are found
 * `stable=true`: enforce Unicode versioning stability (never introduce characters missing from earlier Unicode versions)
 
+You can also use the `charmap` keyword (which defaults to `identity`) to pass an arbitrary
+*function* mapping codepoints (integers) to codepoints, which is is called on each decomposed
+character as it is processed, in order to perform arbitrary additional normalizations.
+For example, by passing `charmap=Unicode.julia_custom_map`, you can apply a few Julia-specific
+character normalizations that are performed by Julia when parsing identifiers (in addition to
+NFC normalization: `compase=true, stable=true`).
+
 For example, NFKC corresponds to the options `compose=true, compat=true, stable=true`.
 
 # Examples
@@ -58,6 +91,9 @@ julia> Unicode.normalize("JuLiA", casefold=true)
 julia> Unicode.normalize("JúLiA", stripmark=true)
 "JuLiA"
 ```
+
+!!! compat "Julia 1.8"
+    The `charmap` keyword argument requires Julia 1.8.
 """
 function normalize end
 normalize(s::AbstractString, nf::Symbol) = Base.Unicode.normalize(s, nf)

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -2,7 +2,7 @@
 
 using Test
 using Unicode
-using Unicode: normalize, isassigned
+using Unicode: normalize, isassigned, julia_charmap
 
 @testset "string normalization" begin
     # normalize (Unicode normalization etc.):
@@ -25,6 +25,10 @@ using Unicode: normalize, isassigned
     @test normalize("\t\r", stripcc=true) == "  "
     @test normalize("\t\r", stripcc=true, newline2ls=true) == " \u2028"
     @test normalize("\u0072\u0307\u0323", :NFC) == "\u1E5B\u0307" #26917
+
+    # julia_charmap identifier normalization
+    @test normalize("julia\u025B\u00B5\u00B7\u0387\u2212", charmap=julia_charmap) == "julia\u03B5\u03BC\u22C5\u22C5\u002D"
+    @test julia_charmap('\u00B5') === '\u03BC'
 end
 
 @testset "unicode sa#15" begin

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -2,7 +2,7 @@
 
 using Test
 using Unicode
-using Unicode: normalize, isassigned, julia_charmap
+using Unicode: normalize, isassigned, julia_chartransform
 
 @testset "string normalization" begin
     # normalize (Unicode normalization etc.):
@@ -26,9 +26,9 @@ using Unicode: normalize, isassigned, julia_charmap
     @test normalize("\t\r", stripcc=true, newline2ls=true) == " \u2028"
     @test normalize("\u0072\u0307\u0323", :NFC) == "\u1E5B\u0307" #26917
 
-    # julia_charmap identifier normalization
-    @test normalize("julia\u025B\u00B5\u00B7\u0387\u2212", charmap=julia_charmap) == "julia\u03B5\u03BC\u22C5\u22C5\u002D"
-    @test julia_charmap('\u00B5') === '\u03BC'
+    # julia_chartransform identifier normalization
+    @test normalize("julia\u025B\u00B5\u00B7\u0387\u2212", chartransform=julia_chartransform) == "julia\u03B5\u03BC\u22C5\u22C5\u002D"
+    @test julia_chartransform('\u00B5') === '\u03BC'
 end
 
 @testset "unicode sa#15" begin

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -27,7 +27,8 @@ using Unicode: normalize, isassigned, julia_chartransform
     @test normalize("\u0072\u0307\u0323", :NFC) == "\u1E5B\u0307" #26917
 
     # julia_chartransform identifier normalization
-    @test normalize("julia\u025B\u00B5\u00B7\u0387\u2212", chartransform=julia_chartransform) == "julia\u03B5\u03BC\u22C5\u22C5\u002D"
+    @test normalize("julia\u025B\u00B5\u00B7\u0387\u2212", chartransform=julia_chartransform) ==
+        "julia\u03B5\u03BC\u22C5\u22C5\u002D"
     @test julia_chartransform('\u00B5') === '\u03BC'
 end
 

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -433,4 +433,5 @@ end
     @test !isequal_normalized("no\u00EBl", "noel")
     @test isequal_normalized("no\u00EBl", "noel", stripmark=true)
     @test isequal_normalized("no\u00EBl", "NOEL", stripmark=true, casefold=true)
+    @test isequal_normalized("\u00B5\u0302m", "\u03BC\u0302m", chartransform=julia_chartransform)
 end


### PR DESCRIPTION
Finally addresses a request by @Keno in https://github.com/JuliaLang/julia/pull/19464#issuecomment-317515947: provides a `Unicode.julia_chartransform` function exporting the custom character normalization used by the Julia parser, which can be used as a `chartransform` keyword to `Unicode.normalize`. 

(More generally, the user can pass any custom codepoint mapping to `normalize` via the `chartransform` keyword.)

This should be useful for any package that needs to reproduce the normalization performed by the Julia parser: they can now do `Unicode.normalize(string, compose=true, stable=true, chartransformUnicode.julia_chartransform)`.