### PR TITLE
Move PTLS load emission from codegen to late-gc-lowering

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -293,7 +293,7 @@ $(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/codegen_shared.h $(BUI
 $(BUILDDIR)/llvm-alloc-opt.o $(BUILDDIR)/llvm-alloc-opt.dbg.obj: $(SRCDIR)/codegen_shared.h $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/llvm-final-gc-lowering.o $(BUILDDIR)/llvm-final-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/llvm-gc-invariant-verifier.o $(BUILDDIR)/llvm-gc-invariant-verifier.dbg.obj: $(SRCDIR)/codegen_shared.h
-$(BUILDDIR)/llvm-late-gc-lowering.o $(BUILDDIR)/llvm-late-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
+$(BUILDDIR)/llvm-late-gc-lowering.o $(BUILDDIR)/llvm-late-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-lower-handlers.o $(BUILDDIR)/llvm-lower-handlers.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-multiversioning.o $(BUILDDIR)/llvm-multiversioning.dbg.obj: $(SRCDIR)/codegen_shared.h $(SRCDIR)/processor.h
 $(BUILDDIR)/llvm-pass-helpers.o $(BUILDDIR)/llvm-pass-helpers.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/codegen_shared.h

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2,7 +2,7 @@
 
 // utility procedures used in code generation
 
-static Instruction *tbaa_decorate(MDNode *md, Instruction *inst)
+Instruction *tbaa_decorate(MDNode *md, Instruction *inst)
 {
     inst->setMetadata(llvm::LLVMContext::MD_tbaa, md);
     if (isa<LoadInst>(inst) && md == tbaa_const)
@@ -3215,9 +3215,10 @@ static void emit_cpointercheck(jl_codectx_t &ctx, const jl_cgval_t &x, const std
 // allocation for known size object
 static Value *emit_allocobj(jl_codectx_t &ctx, size_t static_size, Value *jt)
 {
-    Value *ptls_ptr = emit_bitcast(ctx, get_current_ptls(ctx), T_pint8);
+    // Value *ptls_ptr = emit_bitcast(ctx, get_current_ptls(ctx), T_pint8);
+    Value *current_task = get_current_task(ctx);
     Function *F = prepare_call(jl_alloc_obj_func);
-    auto call = ctx.builder.CreateCall(F, {ptls_ptr, ConstantInt::get(T_size, static_size), maybe_decay_untracked(ctx, jt)});
+    auto call = ctx.builder.CreateCall(F, {current_task, ConstantInt::get(T_size, static_size), maybe_decay_untracked(ctx, jt)});
     call->setAttributes(F->getAttributes());
     return call;
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2,14 +2,6 @@
 
 // utility procedures used in code generation
 
-Instruction *tbaa_decorate(MDNode *md, Instruction *inst)
-{
-    inst->setMetadata(llvm::LLVMContext::MD_tbaa, md);
-    if (isa<LoadInst>(inst) && md == tbaa_const)
-        inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(md->getContext(), None));
-    return inst;
-}
-
 static Value *track_pjlvalue(jl_codectx_t &ctx, Value *V)
 {
     assert(V->getType() == T_pjlvalue);
@@ -3215,7 +3207,6 @@ static void emit_cpointercheck(jl_codectx_t &ctx, const jl_cgval_t &x, const std
 // allocation for known size object
 static Value *emit_allocobj(jl_codectx_t &ctx, size_t static_size, Value *jt)
 {
-    // Value *ptls_ptr = emit_bitcast(ctx, get_current_ptls(ctx), T_pint8);
     Value *current_task = get_current_task(ctx);
     Function *F = prepare_call(jl_alloc_obj_func);
     auto call = ctx.builder.CreateCall(F, {current_task, ConstantInt::get(T_size, static_size), maybe_decay_untracked(ctx, jt)});

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4804,14 +4804,6 @@ static Value *get_current_ptls(jl_codectx_t &ctx)
     return get_current_ptls_from_task(ctx.builder, get_current_task(ctx));
 }
 
-llvm::MDNode *get_tbaa_gcframe() {
-    return tbaa_gcframe;
-}
-
-llvm::MDNode *get_tbaa_const() {
-    return tbaa_const;
-}
-
 // Store world age at the entry block of the function. This function should be
 // called right after `allocate_gc_frame` and there should be no context switch.
 static void emit_last_age_field(jl_codectx_t &ctx)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4801,24 +4801,15 @@ static Value *get_current_task(jl_codectx_t &ctx)
 // Get PTLS through current task.
 static Value *get_current_ptls(jl_codectx_t &ctx)
 {
-    // const int ptls_offset = offsetof(jl_task_t, ptls);
-    // Value *pptls = ctx.builder.CreateInBoundsGEP(
-    //     T_pjlvalue, get_current_task(ctx),
-    //     ConstantInt::get(T_size, ptls_offset / sizeof(void *)),
-    //     "ptls_field");
-    // LoadInst *ptls_load = ctx.builder.CreateAlignedLoad(
-    //     emit_bitcast(ctx, pptls, T_ppjlvalue), Align(sizeof(void *)), "ptls_load");
-    // // Note: Corresponding store (`t->ptls = ptls`) happens in `ctx_switch` of tasks.c.
-    // tbaa_decorate(tbaa_gcframe, ptls_load);
-    // // Using `CastInst::Create` to get an `Instruction*` without explicit cast:
-    // auto ptls = CastInst::Create(Instruction::BitCast, ptls_load, T_ppjlvalue, "ptls");
-    // ctx.builder.Insert(ptls);
-    // return ptls;
     return get_current_ptls_from_task(ctx.builder, get_current_task(ctx));
 }
 
 llvm::MDNode *get_tbaa_gcframe() {
     return tbaa_gcframe;
+}
+
+llvm::MDNode *get_tbaa_const() {
+    return tbaa_const;
 }
 
 // Store world age at the entry block of the function. This function should be

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -634,7 +634,7 @@ static const auto jlegalx_func = new JuliaFunction{
 static const auto jl_alloc_obj_func = new JuliaFunction{
     "julia.gc_alloc_obj",
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
-                {T_pint8, T_size, T_prjlvalue}, false); },
+                {T_ppjlvalue, T_size, T_prjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet::get(C, makeArrayRef({Attribute::getWithAllocSizeArgs(C, 1, None)})), // returns %1 bytes
             Attributes(C, {Attribute::NoAlias, Attribute::NonNull}),
@@ -1131,7 +1131,7 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, const 
 
 static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p);
 static GlobalVariable *prepare_global_in(Module *M, GlobalVariable *G);
-static Instruction *tbaa_decorate(MDNode *md, Instruction *inst);
+Instruction *tbaa_decorate(MDNode *md, Instruction *inst);
 
 static GlobalVariable *prepare_global_in(Module *M, JuliaVariable *G)
 {
@@ -4801,19 +4801,24 @@ static Value *get_current_task(jl_codectx_t &ctx)
 // Get PTLS through current task.
 static Value *get_current_ptls(jl_codectx_t &ctx)
 {
-    const int ptls_offset = offsetof(jl_task_t, ptls);
-    Value *pptls = ctx.builder.CreateInBoundsGEP(
-        T_pjlvalue, get_current_task(ctx),
-        ConstantInt::get(T_size, ptls_offset / sizeof(void *)),
-        "ptls_field");
-    LoadInst *ptls_load = ctx.builder.CreateAlignedLoad(
-        emit_bitcast(ctx, pptls, T_ppjlvalue), Align(sizeof(void *)), "ptls_load");
-    // Note: Corresponding store (`t->ptls = ptls`) happens in `ctx_switch` of tasks.c.
-    tbaa_decorate(tbaa_gcframe, ptls_load);
-    // Using `CastInst::Create` to get an `Instruction*` without explicit cast:
-    auto ptls = CastInst::Create(Instruction::BitCast, ptls_load, T_ppjlvalue, "ptls");
-    ctx.builder.Insert(ptls);
-    return ptls;
+    // const int ptls_offset = offsetof(jl_task_t, ptls);
+    // Value *pptls = ctx.builder.CreateInBoundsGEP(
+    //     T_pjlvalue, get_current_task(ctx),
+    //     ConstantInt::get(T_size, ptls_offset / sizeof(void *)),
+    //     "ptls_field");
+    // LoadInst *ptls_load = ctx.builder.CreateAlignedLoad(
+    //     emit_bitcast(ctx, pptls, T_ppjlvalue), Align(sizeof(void *)), "ptls_load");
+    // // Note: Corresponding store (`t->ptls = ptls`) happens in `ctx_switch` of tasks.c.
+    // tbaa_decorate(tbaa_gcframe, ptls_load);
+    // // Using `CastInst::Create` to get an `Instruction*` without explicit cast:
+    // auto ptls = CastInst::Create(Instruction::BitCast, ptls_load, T_ppjlvalue, "ptls");
+    // ctx.builder.Insert(ptls);
+    // return ptls;
+    return get_current_ptls_from_task(ctx.builder, get_current_task(ctx));
+}
+
+llvm::MDNode *get_tbaa_gcframe() {
+    return tbaa_gcframe;
 }
 
 // Store world age at the entry block of the function. This function should be

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -88,8 +88,16 @@ static inline void llvm_dump(llvm::DebugLoc *dbg)
     llvm::dbgs() << "\n";
 }
 
-llvm::Instruction *tbaa_decorate(llvm::MDNode *md, llvm::Instruction *inst);
 llvm::MDNode *get_tbaa_gcframe();
+llvm::MDNode *get_tbaa_const();
+
+static inline llvm::Instruction *tbaa_decorate(llvm::MDNode *md, llvm::Instruction *inst)
+{
+    inst->setMetadata(llvm::LLVMContext::MD_tbaa, md);
+    if (llvm::isa<llvm::LoadInst>(inst) && md == get_tbaa_const())
+        inst->setMetadata(llvm::LLVMContext::MD_invariant_load, llvm::MDNode::get(md->getContext(), llvm::None));
+    return inst;
+}
 
 // bitcast a value, but preserve its address space when dealing with pointer types
 static inline llvm::Value *emit_bitcast_with_builder(llvm::IRBuilder<> &builder, llvm::Value *v, llvm::Type *jl_value)

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -109,7 +109,7 @@ static inline llvm::MDNode *get_tbaa_const(llvm::LLVMContext &ctxt) {
 static inline llvm::Instruction *tbaa_decorate(llvm::MDNode *md, llvm::Instruction *inst)
 {
     inst->setMetadata(llvm::LLVMContext::MD_tbaa, md);
-    if (llvm::isa<llvm::LoadInst>(inst) && md == get_tbaa_const(md->getContext()))
+    if (llvm::isa<llvm::LoadInst>(inst) && md && md == get_tbaa_const(md->getContext()))
         inst->setMetadata(llvm::LLVMContext::MD_invariant_load, llvm::MDNode::get(md->getContext(), llvm::None));
     return inst;
 }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2296,10 +2296,12 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                 // Create a call to the `julia.gc_alloc_bytes` intrinsic, which is like
                 // `julia.gc_alloc_obj` except it doesn't set the tag.
                 auto allocBytesIntrinsic = getOrDeclare(jl_intrinsics::GCAllocBytes);
+                auto ptlsLoad = get_current_ptls_from_task(builder, CI->getArgOperand(0));
+                auto ptls = builder.CreateBitCast(ptlsLoad, Type::getInt8PtrTy(builder.getContext()));
                 auto newI = builder.CreateCall(
                     allocBytesIntrinsic,
                     {
-                        CI->getArgOperand(0),
+                        ptls,
                         builder.CreateIntCast(
                             CI->getArgOperand(1),
                             allocBytesIntrinsic->getFunctionType()->getParamType(1),

--- a/test/llvmpasses/alloc-opt-gcframe.jl
+++ b/test/llvmpasses/alloc-opt-gcframe.jl
@@ -12,14 +12,19 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 # CHECK-LABEL: @return_obj
 # CHECK-NOT: @julia.gc_alloc_obj
-# CHECK: %v = call noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc
-# CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !0
+# CHECK: %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+# CHECK-NEXT: [[ptls_field:%.*]] = getelementptr inbounds {}*, {}** %current_task, i64 14
+# CHECK-NEXT: [[ptls_load:%.*]] = load {}*, {}** [[ptls_field]], align 8, !tbaa !0
+# CHECK-NEXT: [[ppjl_ptls:%.*]] = bitcast {}* [[ptls_load]] to {}**
+# CHECK-NEXT: [[ptls_i8:%.*]] = bitcast {}** [[ppjl_ptls]] to i8*
+# CHECK-NEXT: %v = call noalias nonnull {} addrspace(10)* @ijl_gc_pool_alloc(i8* [[ptls_i8]], i32 [[SIZE_T:[0-9]+]], i32 16)
+# CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !4
 println("""
 define {} addrspace(10)* @return_obj() {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   ret {} addrspace(10)* %v
 }
 """)
@@ -35,9 +40,9 @@ define {} addrspace(10)* @return_obj() {
 println("""
 define i64 @return_load(i64 %i) {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   %v64 = bitcast {} addrspace(10)* %v to i64 addrspace(10)*
   %v64a11 = addrspacecast i64 addrspace(10)* %v64 to i64 addrspace(11)*
   store i64 %i, i64 addrspace(11)* %v64a11, align 16, !tbaa !4
@@ -50,16 +55,15 @@ define i64 @return_load(i64 %i) {
 
 # CHECK-LABEL: @ccall_obj
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK: @ijl_gc_pool_alloc
-# CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !0
+# CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !4
 println("""
 define void @ccall_obj(i8* %fptr) {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   %f = bitcast i8* %fptr to void ({} addrspace(10)*)*
   call void %f({} addrspace(10)* %v)
   ret void
@@ -70,7 +74,6 @@ define void @ccall_obj(i8* %fptr) {
 # CHECK-LABEL: @ccall_ptr
 # CHECK: alloca i64
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
 # CHECK: call void @llvm.lifetime.start{{.*}}(i64 8, i8*
@@ -81,9 +84,9 @@ define void @ccall_obj(i8* %fptr) {
 println("""
 define void @ccall_ptr(i8* %fptr) {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   %va = addrspacecast {} addrspace(10)* %v to {} addrspace(11)*
   %ptrj = call {}* @julia.pointer_from_objref({} addrspace(11)* %va)
   %ptr = bitcast {}* %ptrj to i8*
@@ -96,16 +99,15 @@ define void @ccall_ptr(i8* %fptr) {
 
 # CHECK-LABEL: @ccall_unknown_bundle
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK: @ijl_gc_pool_alloc
-# CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !0
+# CHECK: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}} unordered, align 8, !tbaa !4
 println("""
 define void @ccall_unknown_bundle(i8* %fptr) {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   %va = addrspacecast {} addrspace(10)* %v to {} addrspace(11)*
   %ptrj = call {}* @julia.pointer_from_objref({} addrspace(11)* %va)
   %ptr = bitcast {}* %ptrj to i8*
@@ -119,7 +121,6 @@ define void @ccall_unknown_bundle(i8* %fptr) {
 # CHECK-LABEL: @lifetime_branches
 # CHECK: alloca i64
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK: L1:
 # CHECK-NEXT: call void @llvm.lifetime.start{{.*}}(i64 8,
 # CHECK: %f = bitcast i8* %fptr to void (i8*)*
@@ -136,12 +137,12 @@ define void @ccall_unknown_bundle(i8* %fptr) {
 println("""
 define void @lifetime_branches(i8* %fptr, i1 %b, i1 %b2) {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
   br i1 %b, label %L1, label %L3
 
 L1:
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   %va = addrspacecast {} addrspace(10)* %v to {} addrspace(11)*
   %ptrj = call {}* @julia.pointer_from_objref({} addrspace(11)* %va)
   %ptr = bitcast {}* %ptrj to i8*
@@ -162,16 +163,15 @@ L3:
 
 # CHECK-LABEL: @object_field
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
-# CHECK-NOT: store {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}}, align 8, !tbaa !0
+# CHECK-NOT: store {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* {{.*}}, align 8, !tbaa !4
 println("""
 define void @object_field({} addrspace(10)* %field) {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   %va = addrspacecast {} addrspace(10)* %v to {} addrspace(11)*
   %vab = bitcast {} addrspace(11)* %va to {} addrspace(10)* addrspace(11)*
   store {} addrspace(10)* %field, {} addrspace(10)* addrspace(11)* %vab, align 8
@@ -183,7 +183,6 @@ define void @object_field({} addrspace(10)* %field) {
 # CHECK-LABEL: @memcpy_opt
 # CHECK: alloca [16 x i8], align 16
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
 # CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
@@ -191,9 +190,9 @@ println("""
 define void @memcpy_opt(i8* %v22) {
 top:
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %v6 = call {}*** @julia.ptls_states()
-  %v18 = bitcast {}*** %v6 to i8*
-  %v19 = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %v18, $isz 16, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v19 = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 16, {} addrspace(10)* @tag)
   %v20 = bitcast {} addrspace(10)* %v19 to i8 addrspace(10)*
   %v21 = addrspacecast i8 addrspace(10)* %v20 to i8 addrspace(11)*
   call void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(11)* %v21, i8* %v22, i64 16, i32 8, i1 false)
@@ -204,7 +203,6 @@ top:
 
 # CHECK-LABEL: @preserve_opt
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
 # CHECK-NOT: @llvm.lifetime.end
@@ -213,9 +211,9 @@ println("""
 define void @preserve_opt(i8* %v22) {
 top:
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %v6 = call {}*** @julia.ptls_states()
-  %v18 = bitcast {}*** %v6 to i8*
-  %v19 = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %v18, $isz 16, {} addrspace(10)* @tag)
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
+  %v19 = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 16, {} addrspace(10)* @tag)
   %v20 = bitcast {} addrspace(10)* %v19 to i8 addrspace(10)*
   %v21 = addrspacecast i8 addrspace(10)* %v20 to i8 addrspace(11)*
   %tok = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %v19)
@@ -229,7 +227,6 @@ top:
 
 # CHECK-LABEL: @preserve_branches
 # CHECK: call {}*** @julia.get_pgcstack()
-# CHECK: call {}*** @julia.ptls_states()
 # CHECK: L1:
 # CHECK-NEXT: @external_function()
 # CHECK-NEXT: br i1 %b2, label %L2, label %L3
@@ -242,12 +239,12 @@ top:
 println("""
 define void @preserve_branches(i8* %fptr, i1 %b, i1 %b2) {
   %pgcstack = call {}*** @julia.get_pgcstack()
-  %ptls = call {}*** @julia.ptls_states()
-  %ptls_i8 = bitcast {}*** %ptls to i8*
+  %gcstack = bitcast {}*** %pgcstack to {}**
+  %current_task = getelementptr inbounds {}*, {}** %gcstack, i64 -12
   br i1 %b, label %L1, label %L3
 
 L1:
-  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
+  %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, $isz 8, {} addrspace(10)* @tag)
   %tok = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %v)
   call void @external_function()
   br i1 %b2, label %L2, label %L3
@@ -266,9 +263,8 @@ L3:
 # CHECK: declare noalias nonnull {} addrspace(10)* @ijl_gc_big_alloc(i8*,
 println("""
 declare void @external_function()
-declare {}*** @julia.ptls_states()
 declare {}*** @julia.get_pgcstack()
-declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj(i8*, $isz, {} addrspace(10)*)
+declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}**, $isz, {} addrspace(10)*)
 declare {}* @julia.pointer_from_objref({} addrspace(11)*)
 declare void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(11)* nocapture writeonly, i8* nocapture readonly, i64, i32, i1)
 declare token @llvm.julia.gc_preserve_begin(...)

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -4,11 +4,10 @@
 
 declare void @boxed_simple({} addrspace(10)*, {} addrspace(10)*)
 declare {} addrspace(10)* @jl_box_int64(i64)
-declare {}*** @julia.ptls_states()
 declare {}*** @julia.get_pgcstack()
 declare void @jl_safepoint()
 declare {} addrspace(10)* @jl_apply_generic({} addrspace(10)*, {} addrspace(10)**, i32)
-declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj(i8*, i64, {} addrspace(10)*)
+declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}**, i64, {} addrspace(10)*)
 declare i32 @rooting_callee({} addrspace(12)*, {} addrspace(12)*)
 
 define void @gc_frame_lowering(i64 %a, i64 %b) {
@@ -39,13 +38,18 @@ define {} addrspace(10)* @gc_alloc_lowering() {
 top:
 ; CHECK-LABEL: @gc_alloc_lowering
     %pgcstack = call {}*** @julia.get_pgcstack()
-    %ptls = call {}*** @julia.ptls_states()
-    %ptls_i8 = bitcast {}*** %ptls to i8*
-; CHECK: %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, [[SIZE_T:i.[0-9]+]] 8)
+    %0 = bitcast {}*** %pgcstack to {}**
+    %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK: %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK-NEXT: [[ptls_field:%.*]] = getelementptr inbounds {}*, {}** %current_task, i64 14
+; CHECK-NEXT: [[ptls_load:%.*]] = load {}*, {}** [[ptls_field]], align 8, !tbaa !0
+; CHECK-NEXT: [[ppjl_ptls:%.*]] = bitcast {}* [[ptls_load]] to {}**
+; CHECK-NEXT: [[ptls_i8:%.*]] = bitcast {}** [[ppjl_ptls]] to i8*
+; CHECK-NEXT: %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* [[ptls_i8]], [[SIZE_T:i.[0-9]+]] 8)
 ; CHECK-NEXT: [[V2:%.*]] = bitcast {} addrspace(10)* %v to {} addrspace(10)* addrspace(10)*
 ; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(10)* [[V2]], i64 -1
-; CHECK-NEXT: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* [[V_HEADROOM]] unordered, align 8, !tbaa !0
-    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, i64 8, {} addrspace(10)* @tag)
+; CHECK-NEXT: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* [[V_HEADROOM]] unordered, align 8, !tbaa !4
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 8, {} addrspace(10)* @tag)
 ; CHECK-NEXT: ret {} addrspace(10)* %v
     ret {} addrspace(10)* %v
 }
@@ -59,20 +63,25 @@ define void @gc_drop_aliasing() {
 top:
 ; CHECK-LABEL: @gc_drop_aliasing
     %pgcstack = call {}*** @julia.get_pgcstack()
-    %ptls = call {}*** @julia.ptls_states()
-    %ptls_i8 = bitcast {}*** %ptls to i8*
-; CHECK: %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, [[SIZE_T:i.[0-9]+]] 8)
+    %0 = bitcast {}*** %pgcstack to {}**
+    %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK: %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK-NEXT: [[ptls_field:%.*]] = getelementptr inbounds {}*, {}** %current_task, i64 14
+; CHECK-NEXT: [[ptls_load:%.*]] = load {}*, {}** [[ptls_field]], align 8, !tbaa !0
+; CHECK-NEXT: [[ppjl_ptls:%.*]] = bitcast {}* [[ptls_load]] to {}**
+; CHECK-NEXT: [[ptls_i8:%.*]] = bitcast {}** [[ppjl_ptls]] to i8*
+; CHECK-NEXT: %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* [[ptls_i8]], [[SIZE_T:i.[0-9]+]] 8)
 ; CHECK-NEXT: [[V2:%.*]] = bitcast {} addrspace(10)* %v to {} addrspace(10)* addrspace(10)*
 ; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(10)* [[V2]], i64 -1
-; CHECK-NEXT: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* [[V_HEADROOM]] unordered, align 8, !tbaa !0
-    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, i64 8, {} addrspace(10)* @tag)
+; CHECK-NEXT: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* [[V_HEADROOM]] unordered, align 8, !tbaa !4
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 8, {} addrspace(10)* @tag)
 ; CHECK-NEXT: %v64 = bitcast {} addrspace(10)* %v to i64 addrspace(10)*
     %v64 = bitcast {} addrspace(10)* %v to i64 addrspace(10)*
-; CHECK-NEXT: %loadedval = load i64, i64 addrspace(10)* %v64, align 8, !range !5
+; CHECK-NEXT: %loadedval = load i64, i64 addrspace(10)* %v64, align 8, !range !9
     %loadedval = load i64, i64 addrspace(10)* %v64, align 8, !range !0, !invariant.load !1
-; CHECK-NEXT: store i64 %loadedval, i64 addrspace(10)* %v64, align 8, !noalias !6
+; CHECK-NEXT: store i64 %loadedval, i64 addrspace(10)* %v64, align 8, !noalias !10
     store i64 %loadedval, i64 addrspace(10)* %v64, align 8, !noalias !2
-; CHECK-NEXT: %lv2 = load i64, i64 addrspace(10)* %v64, align 8, !tbaa !7, !range !5
+; CHECK-NEXT: %lv2 = load i64, i64 addrspace(10)* %v64, align 8, !tbaa !11, !range !9
     %lv2 = load i64, i64 addrspace(10)* %v64, align 8, !range !0, !tbaa !4
 ; CHECK-NEXT: ret void
     ret void
@@ -104,12 +113,13 @@ top:
 !5 = !{!"jtbaa"}
 
 ; CHECK:      !0 = !{!1, !1, i64 0}
-; CHECK-NEXT: !1 = !{!"jtbaa_tag", !2, i64 0}
-; CHECK-NEXT: !2 = !{!"jtbaa_data", !3, i64 0}
-; CHECK-NEXT: !3 = !{!"jtbaa", !4, i64 0}
-; CHECK-NEXT: !4 = !{!"jtbaa"}
-; CHECK-NEXT: !5 = !{i64 0, i64 23}
-; CHECK-NEXT: !6 = distinct !{!6}
-; CHECK-NEXT: !7 = !{!8, !8, i64 0}
-; CHECK-NEXT: !8 = !{!"jtbaa_const", !9}
-; CHECK-NEXT: !9 = !{!"jtbaa"}
+; CHECK-NEXT: !1 = !{!"jtbaa_gcframe", !2, i64 0}
+; CHECK-NEXT: !2 = !{!"jtbaa", !3, i64 0}
+; CHECK-NEXT: !3 = !{!"jtbaa"}
+; CHECK-NEXT: !4 = !{!5, !5, i64 0}
+; CHECK-NEXT: !5 = !{!"jtbaa_tag", !6, i64 0}
+; CHECK-NEXT: !6 = !{!"jtbaa_data", !7, i64 0}
+; CHECK-NEXT: !7 = !{!"jtbaa", !8, i64 0}
+; CHECK-NEXT: !8 = !{!"jtbaa"}
+; CHECK-NEXT: !9 = !{i64 0, i64 23}
+; CHECK-NEXT: !10 = distinct !{!10}


### PR DESCRIPTION
PTLS load instructions can interfere with optimizing allocations due to being unhoistable and inseparable from their corresponding gc_alloc_obj call. By moving their generation to late-gc-lowering, we can optimize allocation function calls directly without worry about the PTLS load. 