### PR TITLE
add an inductive range check elimination pass

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -593,7 +593,6 @@ void jl_dump_native(void *native_code,
     delete data;
 }
 
-
 void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM)
 {
     PM->add(new TargetLibraryInfoWrapperPass(Triple(TM->getTargetTriple())));
@@ -722,6 +721,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createLoopUnswitchPass());
     PM->add(createLICMPass());
     PM->add(createJuliaLICMPass());
+    PM->add(createInductiveRangeCheckEliminationPass());
     // Subsequent passes not stripping metadata from terminator
     PM->add(createInstSimplifyLegacyPass());
     PM->add(createIndVarSimplifyPass());

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -968,7 +968,6 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
                 if (DebugInfo) {
                     errorobj = std::move(DebugInfo);
                     // Yes, we've checked, and yes LLVM want us to check again.
-                    static_cast<bool>(errorobj);
                     assert(errorobj);
                     debugobj = errorobj->getBinary();
                 }

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -968,6 +968,7 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
                 if (DebugInfo) {
                     errorobj = std::move(DebugInfo);
                     // Yes, we've checked, and yes LLVM want us to check again.
+                    static_cast<bool>(errorobj);
                     assert(errorobj);
                     debugobj = errorobj->getBinary();
                 }


### PR DESCRIPTION
As stated in #42521, using `@inbounds` to denote areas where bounds checks are necessary is dangerous.  LLVM provides an InductiveRangeCheckElimination pass which can extract some bounds checks which are known to be safe.

Godbolt Links:
```
@noinline function f!(ys, xs)
                       for i in eachindex(ys, xs)
                         x = xs[i]
                         if -0.5 < x < 0.5
                           ys[i] = 2*x
                         end
                      end
              end
```
Original: https://godbolt.org/z/YY3WrYThh
With `@inbounds`: https://godbolt.org/z/cEW9GTsT3
Original+IRCE: https://godbolt.org/z/j1YndbzrE


The pass makes the control flow graph a little messier than `@inbounds `does, but does allow vectorization that is not allowable when bounds checks are present.