### PR TITLE
Fix sparse constructor when `Tridiagonal`/`SymTridiagonal` are empty

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -563,6 +563,7 @@ SparseMatrixCSC(M::Matrix) = sparse(M)
 SparseMatrixCSC(T::Tridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::Tridiagonal) where {Tv,Ti}
     m = length(T.d)
+    m == 0 && return SparseMatrixCSC{Tv,Ti}(zeros(Tv, 0, 0))
 
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1
@@ -593,6 +594,7 @@ end
 SparseMatrixCSC(T::SymTridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::SymTridiagonal) where {Tv,Ti}
     m = length(T.dv)
+    m == 0 && return SparseMatrixCSC{Tv,Ti}(zeros(Tv, 0, 0))
 
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -656,7 +656,7 @@ end
 SparseMatrixCSC(D::Diagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(D)
 function SparseMatrixCSC{Tv,Ti}(D::Diagonal) where {Tv,Ti}
     m = length(D.diag)
-    return SparseMatrixCSC(m, m, Vector(1:(m+1)), Vector(1:m), Vector{Tv}(D.diag))
+    return SparseMatrixCSC(m, m, Vector(Ti(1):Ti(m+1)), Vector(Ti(1):Ti(m)), Vector{Tv}(D.diag))
 end
 SparseMatrixCSC(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 SparseMatrixCSC{Tv}(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -563,7 +563,7 @@ SparseMatrixCSC(M::Matrix) = sparse(M)
 SparseMatrixCSC(T::Tridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::Tridiagonal) where {Tv,Ti}
     m = length(T.d)
-    m == 0 && return SparseMatrixCSC{Tv,Ti}(zeros(Tv, 0, 0))
+    m == 0 && return SparseMatrixCSC{Tv,Ti}(0, 0, ones(Ti, 1), Ti[], Tv[])
     m == 1 && return SparseMatrixCSC{Tv,Ti}(fill(T[1,1], (1,1)))
 
     colptr = Vector{Ti}(undef, m+1)
@@ -595,9 +595,9 @@ end
 SparseMatrixCSC(T::SymTridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::SymTridiagonal) where {Tv,Ti}
     m = length(T.dv)
-    m == 0 && return SparseMatrixCSC{Tv,Ti}(zeros(Tv, 0, 0))
+    m == 0 && return SparseMatrixCSC{Tv,Ti}(0, 0, ones(Ti, 1), Ti[], Tv[])
     m == 1 && return SparseMatrixCSC{Tv,Ti}(fill(T[1,1], (1,1)))
-    
+
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1
     @inbounds for i=1:m-1
@@ -627,7 +627,7 @@ end
 SparseMatrixCSC(B::Bidiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(B)
 function SparseMatrixCSC{Tv,Ti}(B::Bidiagonal) where {Tv,Ti}
     m = length(B.dv)
-    m == 0 && return SparseMatrixCSC{Tv,Ti}(zeros(Tv, 0, 0))
+    m == 0 && return SparseMatrixCSC{Tv,Ti}(0, 0, ones(Ti, 1), Ti[], Tv[])
 
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -564,6 +564,7 @@ SparseMatrixCSC(T::Tridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::Tridiagonal) where {Tv,Ti}
     m = length(T.d)
     m == 0 && return SparseMatrixCSC{Tv,Ti}(zeros(Tv, 0, 0))
+    m == 1 && return SparseMatrixCSC{Tv,Ti}(fill(T[1,1], (1,1)))
 
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1
@@ -595,7 +596,8 @@ SparseMatrixCSC(T::SymTridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::SymTridiagonal) where {Tv,Ti}
     m = length(T.dv)
     m == 0 && return SparseMatrixCSC{Tv,Ti}(zeros(Tv, 0, 0))
-
+    m == 1 && return SparseMatrixCSC{Tv,Ti}(fill(T[1,1], (1,1)))
+    
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1
     @inbounds for i=1:m-1

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -564,7 +564,7 @@ SparseMatrixCSC(T::Tridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::Tridiagonal) where {Tv,Ti}
     m = length(T.d)
     m == 0 && return SparseMatrixCSC{Tv,Ti}(0, 0, ones(Ti, 1), Ti[], Tv[])
-    m == 1 && return SparseMatrixCSC{Tv,Ti}(fill(T[1,1], (1,1)))
+    m == 1 && return SparseMatrixCSC{Tv,Ti}(1, 1, Ti[1, 2], Ti[1], Tv[T.d[1]])
 
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1
@@ -596,7 +596,7 @@ SparseMatrixCSC(T::SymTridiagonal{Tv}) where Tv = SparseMatrixCSC{Tv,Int}(T)
 function SparseMatrixCSC{Tv,Ti}(T::SymTridiagonal) where {Tv,Ti}
     m = length(T.dv)
     m == 0 && return SparseMatrixCSC{Tv,Ti}(0, 0, ones(Ti, 1), Ti[], Tv[])
-    m == 1 && return SparseMatrixCSC{Tv,Ti}(fill(T[1,1], (1,1)))
+    m == 1 && return SparseMatrixCSC{Tv,Ti}(1, 1, Ti[1, 2], Ti[1], Tv[T.dv[1]])
 
     colptr = Vector{Ti}(undef, m+1)
     colptr[1] = 1

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1697,6 +1697,12 @@ end
     S2 = SparseMatrixCSC(D)
     @test Array(D) == Array(S) == Array(S2)
     @test S == S2
+
+    # An issue discovered in #42574 where
+    # SparseMatrixCSC{Tv, Ti}(::Diagonal) ignored Ti
+    D = Diagonal(rand(3))
+    S = SparseMatrixCSC{Float64, Int8}(D)
+    @test S isa SparseMatrixCSC{Float64, Int8}
 end
 
 @testset "Sparse construction with empty/1x1 structured matrices" begin

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1699,6 +1699,16 @@ end
     @test S == S2
 end
 
+@testset "Sparse construction with empty structured matrices" begin
+    empty = sparse(zeros(0, 0))
+
+    @test sparse(Diagonal(zeros(0, 0))) == empty
+    @test sparse(Bidiagonal(zeros(0, 0), :U)) == empty
+    @test sparse(Bidiagonal(zeros(0, 0), :L)) == empty
+    @test sparse(SymTridiagonal(zeros(0, 0))) == empty
+    @test sparse(Tridiagonal(zeros(0, 0))) == empty
+end
+
 @testset "error conditions for reshape, and dropdims" begin
     local A = sprand(Bool, 5, 5, 0.2)
     @test_throws DimensionMismatch reshape(A,(20, 2))

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1699,7 +1699,7 @@ end
     @test S == S2
 end
 
-@testset "Sparse construction with empty structured matrices" begin
+@testset "Sparse construction with empty/1x1 structured matrices" begin
     empty = spzeros(0, 0)
 
     @test sparse(Diagonal(zeros(0, 0))) == empty
@@ -1707,6 +1707,17 @@ end
     @test sparse(Bidiagonal(zeros(0, 0), :L)) == empty
     @test sparse(SymTridiagonal(zeros(0, 0))) == empty
     @test sparse(Tridiagonal(zeros(0, 0))) == empty
+
+    one_by_one = rand(1,1)
+    sp_one_by_one = sparse(one_by_one)
+
+    @test sparse(Diagonal(one_by_one)) == sp_one_by_one
+    @test sparse(Bidiagonal(one_by_one, :U)) == sp_one_by_one
+    @test sparse(Bidiagonal(one_by_one, :L)) == sp_one_by_one
+    @test sparse(Tridiagonal(one_by_one)) == sp_one_by_one
+
+    s = SymTridiagonal(rand(1), rand(0))
+    @test sparse(s) == s
 end
 
 @testset "error conditions for reshape, and dropdims" begin

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1700,7 +1700,7 @@ end
 end
 
 @testset "Sparse construction with empty structured matrices" begin
-    empty = sparse(zeros(0, 0))
+    empty = spzeros(0, 0)
 
     @test sparse(Diagonal(zeros(0, 0))) == empty
     @test sparse(Bidiagonal(zeros(0, 0), :U)) == empty


### PR DESCRIPTION
Constructing a sparse matrix from empty structured matrices works for some, but not all, structured matrix types. This PR fixes the cases of `Tridiagonal` and `SymTridiagonal`. `Diagonal` and `Bidiagonal` already work as expected.

---------------------------------------------------------------------------------------------------------------

Currently:
```julia
julia> sparse(Diagonal(zeros(0, 0)))
0×0 SparseMatrixCSC{Float64, Int64} with 0 stored entries

julia> sparse(Bidiagonal(zeros(0, 0), :U))
0×0 SparseMatrixCSC{Float64, Int64} with 0 stored entries

julia> sparse(Tridiagonal(zeros(0, 0)))
ERROR: ArgumentError: invalid Array dimensions
Stacktrace:
 [1] Array
   @ ./boot.jl:452 [inlined]
 [2] SparseMatrixCSC{Float64, Int64}(T::Tridiagonal{Float64, Vector{Float64}})
   @ SparseArrays ~/github/julia-dev/stdlib/SparseArrays/src/sparsematrix.jl:575
 [3] SparseMatrixCSC
   @ ~/github/julia-dev/usr/share/julia/stdlib/v1.8/SparseArrays/src/sparsematrix.jl:563 [inlined]
 [4] sparse(T::Tridiagonal{Float64, Vector{Float64}})
   @ SparseArrays ~/github/julia-dev/stdlib/SparseArrays/src/sparsematrix.jl:760
 [5] top-level scope
   @ REPL[10]:1

julia> sparse(SymTridiagonal(zeros(0, 0)))
ERROR: ArgumentError: invalid Array dimensions
Stacktrace:
 [1] Array
   @ ./boot.jl:452 [inlined]
 [2] SparseMatrixCSC{Float64, Int64}(T::SymTridiagonal{Float64, Vector{Float64}})
   @ SparseArrays ~/github/julia-dev/stdlib/SparseArrays/src/sparsematrix.jl:606
 [3] SparseMatrixCSC
   @ ~/github/julia-dev/usr/share/julia/stdlib/v1.8/SparseArrays/src/sparsematrix.jl:594 [inlined]
 [4] sparse(T::SymTridiagonal{Float64, Vector{Float64}})
   @ SparseArrays ~/github/julia-dev/stdlib/SparseArrays/src/sparsematrix.jl:758
 [5] top-level scope
   @ REPL[11]:1
```


This PR:
```julia
julia> sparse(Diagonal(zeros(0, 0)))
0×0 SparseMatrixCSC{Float64, Int64} with 0 stored entries

julia> sparse(Bidiagonal(zeros(0, 0), :U))
0×0 SparseMatrixCSC{Float64, Int64} with 0 stored entries

julia> sparse(Tridiagonal(zeros(0, 0)))
0×0 SparseMatrixCSC{Float64, Int64} with 0 stored entries

julia> sparse(SymTridiagonal(zeros(0, 0)))
0×0 SparseMatrixCSC{Float64, Int64} with 0 stored entries
```

