### PR TITLE
Fix libgit2 error throw

### DIFF
--- a/stdlib/LibGit2/src/rebase.jl
+++ b/stdlib/LibGit2/src/rebase.jl
@@ -83,7 +83,7 @@ function commit(rb::GitRebase, sig::GitSignature)
                       oid_ptr, rb.ptr, C_NULL, sig.ptr, C_NULL, C_NULL)
     catch err
         # TODO: return current HEAD instead
-        err.code === Error.EAPPLIED && return nothing
+        err isa GitError && err.code === Error.EAPPLIED && return nothing
         rethrow()
     end
     return oid_ptr[]


### PR DESCRIPTION
Fixes #42575

@giordano I think there was more to your issue, but the main problem reported was the `type ReadOnlyMemoryError has no field code`, so this fixes that