### PR TITLE
note that rand(::BitSet, n) only fast when dense

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -352,7 +352,7 @@ julia> rand(Float64, (2, 3))
     The complexity of `rand(rng, s::Union{AbstractDict,AbstractSet})`
     is linear in the length of `s`, unless an optimized method with
     constant complexity is available, which is the case for `Dict`,
-    `Set` and `BitSet`. For more than a few calls, use `rand(rng,
+    `Set` and dense `BitSet`s. For more than a few calls, use `rand(rng,
     collect(s))` instead, or either `rand(rng, Dict(s))` or `rand(rng,
     Set(s))` as appropriate.
 """


### PR DESCRIPTION
`rand(bs::BitSet, n)` repeatedly chooses a random index and returns it if it is in the bitset. This runs in `O(n/density)` where `density = length(bs)/(maximum(bs)-minimum(bs)+1)`.

Empirically, 
```
using BenchmarkTools
@btime rand(bs, 100) setup=(bs=BitSet(1:10^6)) # 696.936 ns (1 allocation: 896 bytes)
@btime rand(bs, 100) setup=(bs=BitSet([1,10^6])) # 260.291 ms (1 allocation: 896 bytes)
@btime rand(collect(bs), 100) setup=(bs=BitSet([1,10^6])) # 12.302 μs (2 allocations: 992 bytes)
```
Shows that `rand(bs::BitSet, n)` slows down drastically for sparse BitSets, and employing `collect` first is a good idea. 
This isn't a huge problem because `BitSet` is typically used only for dense applications, but I still think it's worth noting.

It could also be fixed with a dynamic fallback to collect to vector after many misses. I suspect that if the number of tries per sample is more than about `2*sqrt((maximum(bs)-minimum(bs)+1)/n)` the fallback is advantageous.