### PR TITLE
Generalize storage of factorizations.

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -60,7 +60,7 @@ julia> A = [1.5 2 -4; 3 -1 -6; -10 2.3 4]
  -10.0   2.3   4.0
 
 julia> factorize(A)
-LU{Float64, Matrix{Float64}}
+LU{Float64, Matrix{Float64}, Vector{Int64}}
 L factor:
 3×3 Matrix{Float64}:
   1.0    0.0       0.0
@@ -84,7 +84,7 @@ julia> B = [1.5 2 -4; 2 -1 -3; -4 -3 5]
  -4.0  -3.0   5.0
 
 julia> factorize(B)
-BunchKaufman{Float64, Matrix{Float64}}
+BunchKaufman{Float64, Matrix{Float64}, Vector{Int64}}
 D factor:
 3×3 Tridiagonal{Float64, Vector{Float64}}:
  -1.64286   0.0   ⋅

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -28,7 +28,7 @@ julia> A = [1 2; 2 3]
  2  3
 
 julia> S = bunchkaufman(A) # A gets wrapped internally by Symmetric(A)
-BunchKaufman{Float64, Matrix{Float64}}
+BunchKaufman{Float64, Matrix{Float64}, Vector{Int64}}
 D factor:
 2×2 Tridiagonal{Float64, Vector{Float64}}:
  -0.333333  0.0
@@ -48,7 +48,7 @@ julia> d == S.D && u == S.U && p == S.p
 true
 
 julia> S = bunchkaufman(Symmetric(A, :L))
-BunchKaufman{Float64, Matrix{Float64}}
+BunchKaufman{Float64, Matrix{Float64}, Vector{Int64}}
 D factor:
 2×2 Tridiagonal{Float64, Vector{Float64}}:
  3.0   0.0
@@ -63,22 +63,25 @@ permutation:
  1
 ```
 """
-struct BunchKaufman{T,S<:AbstractMatrix} <: Factorization{T}
+struct BunchKaufman{T,S<:AbstractMatrix,P<:AbstractVector{<:Integer}} <: Factorization{T}
     LD::S
-    ipiv::Vector{BlasInt}
+    ipiv::P
     uplo::Char
     symmetric::Bool
     rook::Bool
     info::BlasInt
 
-    function BunchKaufman{T,S}(LD, ipiv, uplo, symmetric, rook, info) where {T,S<:AbstractMatrix}
+    function BunchKaufman{T,S,P}(LD, ipiv, uplo, symmetric, rook, info) where {T,S<:AbstractMatrix,P<:AbstractVector}
         require_one_based_indexing(LD)
-        new(LD, ipiv, uplo, symmetric, rook, info)
+        new{T,S,P}(LD, ipiv, uplo, symmetric, rook, info)
     end
 end
-BunchKaufman(A::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::AbstractChar, symmetric::Bool,
-             rook::Bool, info::BlasInt) where {T} =
-        BunchKaufman{T,typeof(A)}(A, ipiv, uplo, symmetric, rook, info)
+BunchKaufman(A::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer}, uplo::AbstractChar,
+             symmetric::Bool, rook::Bool, info::BlasInt) where {T} =
+        BunchKaufman{T,typeof(A),typeof(ipiv)}(A, ipiv, uplo, symmetric, rook, info)
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(BunchKaufman(LD, ipiv, uplo, symmetric, rook, info) where {T,S},
+           BunchKaufman{T,S,typeof(ipiv)}(LD, ipiv, uplo, symmetric, rook, info))
 
 # iteration for destructuring into components
 Base.iterate(S::BunchKaufman) = (S.D, Val(:UL))
@@ -148,7 +151,7 @@ julia> A = [1 2; 2 3]
  2  3
 
 julia> S = bunchkaufman(A) # A gets wrapped internally by Symmetric(A)
-BunchKaufman{Float64, Matrix{Float64}}
+BunchKaufman{Float64, Matrix{Float64}, Vector{Int64}}
 D factor:
 2×2 Tridiagonal{Float64, Vector{Float64}}:
  -0.333333  0.0
@@ -173,7 +176,7 @@ julia> S.U*S.D*S.U' - S.P*A*S.P'
  0.0  0.0
 
 julia> S = bunchkaufman(Symmetric(A, :L))
-BunchKaufman{Float64, Matrix{Float64}}
+BunchKaufman{Float64, Matrix{Float64}, Vector{Int64}}
 D factor:
 2×2 Tridiagonal{Float64, Vector{Float64}}:
  3.0   0.0

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -28,7 +28,7 @@ julia> A = [4 3; 6 3]
  6  3
 
 julia> F = lu(A)
-LU{Float64, Matrix{Float64}}
+LU{Float64, Matrix{Float64}, Vector{Int64}}
 L factor:
 2×2 Matrix{Float64}:
  1.0       0.0
@@ -47,24 +47,24 @@ julia> l == F.L && u == F.U && p == F.p
 true
 ```
 """
-struct LU{T,S<:AbstractMatrix{T}} <: Factorization{T}
+struct LU{T,S<:AbstractMatrix{T},P<:AbstractVector{<:Integer}} <: Factorization{T}
     factors::S
-    ipiv::Vector{BlasInt}
+    ipiv::P
     info::BlasInt
 
-    function LU{T,S}(factors, ipiv, info) where {T,S<:AbstractMatrix{T}}
+    function LU{T,S,P}(factors, ipiv, info) where {T, S<:AbstractMatrix{T}, P<:AbstractVector{<:Integer}}
         require_one_based_indexing(factors)
-        new{T,S}(factors, ipiv, info)
+        new{T,S,P}(factors, ipiv, info)
     end
 end
-function LU(factors::AbstractMatrix{T}, ipiv::Vector{BlasInt}, info::BlasInt) where {T}
-    LU{T,typeof(factors)}(factors, ipiv, info)
-end
-function LU{T}(factors::AbstractMatrix, ipiv::AbstractVector{<:Integer}, info::Integer) where {T}
-    LU(convert(AbstractMatrix{T}, factors),
-       convert(Vector{BlasInt}, ipiv),
-       BlasInt(info))
-end
+LU(factors::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer}, info::BlasInt) where {T} =
+    LU{T,typeof(factors),typeof(ipiv)}(factors, ipiv, info)
+LU{T}(factors::AbstractMatrix, ipiv::AbstractVector{<:Integer}, info::Integer) where {T} =
+    LU(convert(AbstractMatrix{T}, factors), ipiv, BlasInt(info))
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(LU{T,S}(factors::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer},
+                   info::BlasInt) where {T,S},
+           LU{T,S,typeof(ipiv)}(factors, ipiv, info))
 
 # iteration for destructuring into components
 Base.iterate(S::LU) = (S.L, Val(:U))
@@ -80,7 +80,7 @@ lu!(A::StridedMatrix{<:BlasFloat}; check::Bool = true) = lu!(A, RowMaximum(); ch
 function lu!(A::StridedMatrix{T}, ::RowMaximum; check::Bool = true) where {T<:BlasFloat}
     lpt = LAPACK.getrf!(A)
     check && checknonsingular(lpt[3])
-    return LU{T,typeof(A)}(lpt[1], lpt[2], lpt[3])
+    return LU{T,typeof(lpt[1]),typeof(lpt[2])}(lpt[1], lpt[2], lpt[3])
 end
 function lu!(A::StridedMatrix{<:BlasFloat}, pivot::NoPivot; check::Bool = true)
     return generic_lufact!(A, pivot; check = check)
@@ -111,7 +111,7 @@ julia> A = [4. 3.; 6. 3.]
  6.0  3.0
 
 julia> F = lu!(A)
-LU{Float64, Matrix{Float64}}
+LU{Float64, Matrix{Float64}, Vector{Int64}}
 L factor:
 2×2 Matrix{Float64}:
  1.0       0.0
@@ -184,7 +184,7 @@ function generic_lufact!(A::StridedMatrix{T}, pivot::Union{RowMaximum,NoPivot} =
         end
     end
     check && checknonsingular(info, pivot)
-    return LU{T,typeof(A)}(A, ipiv, convert(BlasInt, info))
+    return LU{T,typeof(A),typeof(ipiv)}(A, ipiv, convert(BlasInt, info))
 end
 
 function lutype(T::Type)
@@ -256,7 +256,7 @@ julia> A = [4 3; 6 3]
  6  3
 
 julia> F = lu(A)
-LU{Float64, Matrix{Float64}}
+LU{Float64, Matrix{Float64}, Vector{Int64}}
 L factor:
 2×2 Matrix{Float64}:
  1.0       0.0
@@ -295,13 +295,13 @@ end
 
 function LU{T}(F::LU) where T
     M = convert(AbstractMatrix{T}, F.factors)
-    LU{T,typeof(M)}(M, F.ipiv, F.info)
+    LU{T,typeof(M),typeof(F.ipiv)}(M, F.ipiv, F.info)
 end
-LU{T,S}(F::LU) where {T,S} = LU{T,S}(convert(S, F.factors), F.ipiv, F.info)
+LU{T,S,P}(F::LU) where {T,S,P} = LU{T,S,P}(convert(S, F.factors), convert(P, F.ipiv), F.info)
 Factorization{T}(F::LU{T}) where {T} = F
 Factorization{T}(F::LU) where {T} = LU{T}(F)
 
-copy(A::LU{T,S}) where {T,S} = LU{T,S}(copy(A.factors), copy(A.ipiv), A.info)
+copy(A::LU{T,S,P}) where {T,S,P} = LU{T,S,P}(copy(A.factors), copy(A.ipiv), A.info)
 
 size(A::LU)    = size(getfield(A, :factors))
 size(A::LU, i) = size(getfield(A, :factors), i)
@@ -564,7 +564,7 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(
     end
     B = Tridiagonal{T,V}(dl, d, du, du2)
     check && checknonsingular(info, pivot)
-    return LU{T,Tridiagonal{T,V}}(B, ipiv, convert(BlasInt, info))
+    return LU{T,Tridiagonal{T,V},typeof(ipiv)}(B, ipiv, convert(BlasInt, info))
 end
 
 factorize(A::Tridiagonal) = lu(A)
@@ -664,7 +664,7 @@ function ldiv!(transA::Transpose{<:Any,<:LU{T,Tridiagonal{T,V}}}, B::AbstractVec
 end
 
 # Ac_ldiv_B!(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat) where {T<:Real} = At_ldiv_B!(A,B)
-function ldiv!(adjA::Adjoint{<:Any,LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat) where {T,V}
+function ldiv!(adjA::Adjoint{<:Any,<:LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat) where {T,V}
     require_one_based_indexing(B)
     A = adjA.parent
     n = size(A,1)

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -34,19 +34,22 @@ The object has two fields:
 * `τ` is a vector  of length `min(m,n)` containing the coefficients ``\tau_i``.
 
 """
-struct QR{T,S<:AbstractMatrix{T}} <: Factorization{T}
+struct QR{T,S<:AbstractMatrix{T},C<:AbstractVector{T}} <: Factorization{T}
     factors::S
-    τ::Vector{T}
+    τ::C
 
-    function QR{T,S}(factors, τ) where {T,S<:AbstractMatrix{T}}
+    function QR{T,S,C}(factors, τ) where {T,S<:AbstractMatrix{T},C<:AbstractVector{T}}
         require_one_based_indexing(factors)
-        new{T,S}(factors, τ)
+        new{T,S,C}(factors, τ)
     end
 end
-QR(factors::AbstractMatrix{T}, τ::Vector{T}) where {T} = QR{T,typeof(factors)}(factors, τ)
-function QR{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
-    QR(convert(AbstractMatrix{T}, factors), convert(Vector{T}, τ))
-end
+QR(factors::AbstractMatrix{T}, τ::AbstractVector{T}) where {T} =
+    QR{T,typeof(factors),typeof(τ)}(factors, τ)
+QR{T}(factors::AbstractMatrix, τ::AbstractVector) where {T} =
+    QR(convert(AbstractMatrix{T}, factors), convert(AbstractVector{T}, τ))
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(QR{T,S}(factors::AbstractMatrix{T}, τ::AbstractVector{T}) where {T,S},
+           QR{T,S,typeof(τ)}(factors, τ))
 
 # iteration for destructuring into components
 Base.iterate(S::QR) = (S.Q, Val(:R))
@@ -108,19 +111,22 @@ The object has two fields:
 
 [^Schreiber1989]: R Schreiber and C Van Loan, "A storage-efficient WY representation for products of Householder transformations", SIAM J Sci Stat Comput 10 (1989), 53-57. [doi:10.1137/0910005](https://doi.org/10.1137/0910005)
 """
-struct QRCompactWY{S,M<:AbstractMatrix{S}} <: Factorization{S}
+struct QRCompactWY{S,M<:AbstractMatrix{S},C<:AbstractMatrix{S}} <: Factorization{S}
     factors::M
-    T::Matrix{S}
+    T::C
 
-    function QRCompactWY{S,M}(factors, T) where {S,M<:AbstractMatrix{S}}
+    function QRCompactWY{S,M,C}(factors, T) where {S,M<:AbstractMatrix{S},C<:AbstractMatrix{S}}
         require_one_based_indexing(factors)
-        new{S,M}(factors, T)
+        new{S,M,C}(factors, T)
     end
 end
-QRCompactWY(factors::AbstractMatrix{S}, T::Matrix{S}) where {S} = QRCompactWY{S,typeof(factors)}(factors, T)
-function QRCompactWY{S}(factors::AbstractMatrix, T::AbstractMatrix) where {S}
-    QRCompactWY(convert(AbstractMatrix{S}, factors), convert(Matrix{S}, T))
-end
+QRCompactWY(factors::AbstractMatrix{S}, T::AbstractMatrix{S}) where {S} =
+    QRCompactWY{S,typeof(factors),typeof(T)}(factors, T)
+QRCompactWY{S}(factors::AbstractMatrix, T::AbstractMatrix) where {S} =
+    QRCompactWY(convert(AbstractMatrix{S}, factors), convert(AbstractMatrix{S}, T))
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(QRCompactWY{S,M}(factors::AbstractMatrix{S}, T::AbstractMatrix{S}) where {S,M},
+           QRCompactWY{S,M,typeof(T)}(factors, T))
 
 # iteration for destructuring into components
 Base.iterate(S::QRCompactWY) = (S.Q, Val(:R))
@@ -194,23 +200,26 @@ The object has three fields:
 
 * `jpvt` is an integer vector of length `n` corresponding to the permutation ``P``.
 """
-struct QRPivoted{T,S<:AbstractMatrix{T}} <: Factorization{T}
+struct QRPivoted{T,S<:AbstractMatrix{T},C<:AbstractVector{T},P<:AbstractVector{<:Integer}} <: Factorization{T}
     factors::S
-    τ::Vector{T}
-    jpvt::Vector{BlasInt}
+    τ::C
+    jpvt::P
 
-    function QRPivoted{T,S}(factors, τ, jpvt) where {T,S<:AbstractMatrix{T}}
+    function QRPivoted{T,S,C,P}(factors, τ, jpvt) where {T,S<:AbstractMatrix{T},C<:AbstractVector{T},P<:AbstractVector{<:Integer}}
         require_one_based_indexing(factors, τ, jpvt)
-        new{T,S}(factors, τ, jpvt)
+        new{T,S,C,P}(factors, τ, jpvt)
     end
 end
-QRPivoted(factors::AbstractMatrix{T}, τ::Vector{T}, jpvt::Vector{BlasInt}) where {T} =
-    QRPivoted{T,typeof(factors)}(factors, τ, jpvt)
-function QRPivoted{T}(factors::AbstractMatrix, τ::AbstractVector, jpvt::AbstractVector) where {T}
-    QRPivoted(convert(AbstractMatrix{T}, factors),
-              convert(Vector{T}, τ),
-              convert(Vector{BlasInt}, jpvt))
-end
+QRPivoted(factors::AbstractMatrix{T}, τ::AbstractVector{T},
+          jpvt::AbstractVector{<:Integer}) where {T} =
+    QRPivoted{T,typeof(factors),typeof(τ),typeof(jpvt)}(factors, τ, jpvt)
+QRPivoted{T}(factors::AbstractMatrix, τ::AbstractVector,
+             jpvt::AbstractVector{<:Integer}) where {T} =
+    QRPivoted(convert(AbstractMatrix{T}, factors), convert(AbstractVector{T}, τ), jpvt)
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(QRPivoted{T,S}(factors::AbstractMatrix{T}, τ::AbstractVector{T},
+                          jpvt::AbstractVector{<:Integer}) where {T,S},
+           QRPivoted{T,S,typeof(τ),typeof(jpvt)}(factors, τ, jpvt))
 
 # iteration for destructuring into components
 Base.iterate(S::QRPivoted) = (S.Q, Val(:R))
@@ -276,7 +285,7 @@ function qrfactPivotedUnblocked!(A::AbstractMatrix)
         # Update trailing submatrix with reflector
         reflectorApply!(x, τj, view(A, j:m, j+1:n))
     end
-    return QRPivoted{eltype(A), typeof(A)}(A, τ, piv)
+    return QRPivoted{eltype(A), typeof(A), typeof(τ), typeof(piv)}(A, τ, piv)
 end
 
 # LAPACK version
@@ -305,9 +314,9 @@ julia> a = [1. 2.; 3. 4.]
  3.0  4.0
 
 julia> qr!(a)
-LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}}
+QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}
 Q factor:
-2×2 LinearAlgebra.QRCompactWYQ{Float64, Matrix{Float64}}:
+2×2 QRCompactWYQ{Float64, Matrix{Float64}, Matrix{Float64}}:
  -0.316228  -0.948683
  -0.948683   0.316228
 R factor:
@@ -392,9 +401,9 @@ julia> A = [3.0 -6.0; 4.0 -8.0; 0.0 1.0]
  0.0   1.0
 
 julia> F = qr(A)
-LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}}
+QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}
 Q factor:
-3×3 LinearAlgebra.QRCompactWYQ{Float64, Matrix{Float64}}:
+3×3 QRCompactWYQ{Float64, Matrix{Float64}, Matrix{Float64}}:
  -0.6   0.0   0.8
  -0.8   0.0  -0.6
   0.0  -1.0   0.0
@@ -517,19 +526,22 @@ inv(Q::AbstractQ) = Q'
 The orthogonal/unitary ``Q`` matrix of a QR factorization stored in [`QR`](@ref) or
 [`QRPivoted`](@ref) format.
 """
-struct QRPackedQ{T,S<:AbstractMatrix{T}} <: AbstractQ{T}
+struct QRPackedQ{T,S<:AbstractMatrix{T},C<:AbstractVector{T}} <: AbstractQ{T}
     factors::S
-    τ::Vector{T}
+    τ::C
 
-    function QRPackedQ{T,S}(factors, τ) where {T,S<:AbstractMatrix{T}}
+    function QRPackedQ{T,S,C}(factors, τ) where {T,S<:AbstractMatrix{T},C<:AbstractVector{T}}
         require_one_based_indexing(factors)
-        new{T,S}(factors, τ)
+        new{T,S,C}(factors, τ)
     end
 end
-QRPackedQ(factors::AbstractMatrix{T}, τ::Vector{T}) where {T} = QRPackedQ{T,typeof(factors)}(factors, τ)
-function QRPackedQ{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
-    QRPackedQ(convert(AbstractMatrix{T}, factors), convert(Vector{T}, τ))
-end
+QRPackedQ(factors::AbstractMatrix{T}, τ::AbstractVector{T}) where {T} =
+    QRPackedQ{T,typeof(factors),typeof(τ)}(factors, τ)
+QRPackedQ{T}(factors::AbstractMatrix, τ::AbstractVector) where {T} =
+    QRPackedQ(convert(AbstractMatrix{T}, factors), convert(AbstractVector{T}, τ))
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(QRPackedQ{T,S}(factors::AbstractMatrix{T}, τ::AbstractVector{T}) where {T,S},
+           QRPackedQ{T,S,typeof(τ)}(factors, τ))
 
 """
     QRCompactWYQ <: AbstractMatrix
@@ -537,19 +549,22 @@ end
 The orthogonal/unitary ``Q`` matrix of a QR factorization stored in [`QRCompactWY`](@ref)
 format.
 """
-struct QRCompactWYQ{S, M<:AbstractMatrix{S}} <: AbstractQ{S}
+struct QRCompactWYQ{S, M<:AbstractMatrix{S}, C<:AbstractMatrix{S}} <: AbstractQ{S}
     factors::M
-    T::Matrix{S}
+    T::C
 
-    function QRCompactWYQ{S,M}(factors, T) where {S,M<:AbstractMatrix{S}}
+    function QRCompactWYQ{S,M,C}(factors, T) where {S,M<:AbstractMatrix{S},C<:AbstractMatrix{S}}
         require_one_based_indexing(factors)
-        new{S,M}(factors, T)
+        new{S,M,C}(factors, T)
     end
 end
-QRCompactWYQ(factors::AbstractMatrix{S}, T::Matrix{S}) where {S} = QRCompactWYQ{S,typeof(factors)}(factors, T)
-function QRCompactWYQ{S}(factors::AbstractMatrix, T::AbstractMatrix) where {S}
-    QRCompactWYQ(convert(AbstractMatrix{S}, factors), convert(Matrix{S}, T))
-end
+QRCompactWYQ(factors::AbstractMatrix{S}, T::AbstractMatrix{S}) where {S} =
+    QRCompactWYQ{S,typeof(factors),typeof(T)}(factors, T)
+QRCompactWYQ{S}(factors::AbstractMatrix, T::AbstractMatrix) where {S} =
+    QRCompactWYQ(convert(AbstractMatrix{S}, factors), convert(AbstractMatrix{S}, T))
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(QRCompactWYQ{S,M}(factors::AbstractMatrix{S}, T::AbstractMatrix{S}) where {S,M},
+           QRCompactWYQ{S,M,typeof(T)}(factors, T))
 
 QRPackedQ{T}(Q::QRPackedQ) where {T} = QRPackedQ(convert(AbstractMatrix{T}, Q.factors), convert(Vector{T}, Q.τ))
 AbstractMatrix{T}(Q::QRPackedQ{T}) where {T} = Q

--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -23,7 +23,7 @@ julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
  0.0  2.0  0.0  0.0  0.0
 
 julia> F = svd(A)
-SVD{Float64, Float64, Matrix{Float64}}
+SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}
 U factor:
 4×4 Matrix{Float64}:
  0.0  1.0  0.0   0.0
@@ -56,21 +56,24 @@ julia> u == F.U && s == F.S && v == F.V
 true
 ```
 """
-struct SVD{T,Tr,M<:AbstractArray{T}} <: Factorization{T}
+struct SVD{T,Tr,M<:AbstractArray{T},C<:AbstractVector{Tr}} <: Factorization{T}
     U::M
-    S::Vector{Tr}
+    S::C
     Vt::M
-    function SVD{T,Tr,M}(U, S, Vt) where {T,Tr,M<:AbstractArray{T}}
+    function SVD{T,Tr,M,C}(U, S, Vt) where {T,Tr,M<:AbstractArray{T},C<:AbstractVector{Tr}}
         require_one_based_indexing(U, S, Vt)
-        new{T,Tr,M}(U, S, Vt)
+        new{T,Tr,M,C}(U, S, Vt)
     end
 end
-SVD(U::AbstractArray{T}, S::Vector{Tr}, Vt::AbstractArray{T}) where {T,Tr} = SVD{T,Tr,typeof(U)}(U, S, Vt)
-function SVD{T}(U::AbstractArray, S::AbstractVector{Tr}, Vt::AbstractArray) where {T,Tr}
+SVD(U::AbstractArray{T}, S::AbstractVector{Tr}, Vt::AbstractArray{T}) where {T,Tr} =
+    SVD{T,Tr,typeof(U),typeof(S)}(U, S, Vt)
+SVD{T}(U::AbstractArray, S::AbstractVector{Tr}, Vt::AbstractArray) where {T,Tr} =
     SVD(convert(AbstractArray{T}, U),
-        convert(Vector{Tr}, S),
+        convert(AbstractVector{Tr}, S),
         convert(AbstractArray{T}, Vt))
-end
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(SVD{T,Tr,M}(U::AbstractArray{T}, S::AbstractVector{Tr}, Vt::AbstractArray{T}) where {T,Tr,M},
+           SVD{T,Tr,M,typeof(S)}(U, S, Vt))
 
 SVD{T}(F::SVD) where {T} = SVD(
     convert(AbstractMatrix{T}, F.U),
@@ -267,7 +270,7 @@ function adjoint(F::SVD)
     return SVD(F.Vt', F.S, F.U')
 end
 
-function show(io::IO, mime::MIME{Symbol("text/plain")}, F::SVD{<:Any,<:Any,<:AbstractArray})
+function show(io::IO, mime::MIME{Symbol("text/plain")}, F::SVD{<:Any,<:Any,<:AbstractArray,<:AbstractVector})
     summary(io, F); println(io)
     println(io, "U factor:")
     show(io, mime, F.U)
@@ -319,7 +322,7 @@ julia> B = [0. 1.; 1. 0.]
  1.0  0.0
 
 julia> F = svd(A, B)
-GeneralizedSVD{Float64, Matrix{Float64}}
+GeneralizedSVD{Float64, Matrix{Float64}, Float64, Vector{Float64}}
 U factor:
 2×2 Matrix{Float64}:
  1.0  0.0
@@ -356,24 +359,26 @@ julia> F.V*F.D2*F.R0*F.Q'
   1.0  0.0
 ```
 """
-struct GeneralizedSVD{T,S} <: Factorization{T}
+struct GeneralizedSVD{T,S<:AbstractMatrix,Tr,C<:AbstractVector{Tr}} <: Factorization{T}
     U::S
     V::S
     Q::S
-    a::Vector
-    b::Vector
+    a::C
+    b::C
     k::Int
     l::Int
     R::S
-    function GeneralizedSVD{T,S}(U::AbstractMatrix{T}, V::AbstractMatrix{T}, Q::AbstractMatrix{T},
-                                 a::Vector, b::Vector, k::Int, l::Int, R::AbstractMatrix{T}) where {T,S}
-        new(U, V, Q, a, b, k, l, R)
+    function GeneralizedSVD{T,S,Tr,C}(U, V, Q, a, b, k, l, R) where {T,S<:AbstractMatrix{T},Tr,C<:AbstractVector{Tr}}
+        new{T,S,Tr,C}(U, V, Q, a, b, k, l, R)
     end
 end
-function GeneralizedSVD(U::AbstractMatrix{T}, V::AbstractMatrix{T}, Q::AbstractMatrix{T},
-                        a::Vector, b::Vector, k::Int, l::Int, R::AbstractMatrix{T}) where T
-    GeneralizedSVD{T,typeof(U)}(U, V, Q, a, b, k, l, R)
-end
+GeneralizedSVD(U::AbstractMatrix{T}, V::AbstractMatrix{T}, Q::AbstractMatrix{T},
+              a::AbstractVector{Tr}, b::AbstractVector{Tr}, k::Int, l::Int,
+              R::AbstractMatrix{T}) where {T, Tr} =
+    GeneralizedSVD{T,typeof(U),Tr,typeof(a)}(U, V, Q, a, b, k, l, R)
+# backwards-compatible constructors (remove with Julia 2.0)
+@deprecate(GeneralizedSVD{T,S}(U, V, Q, a, b, k, l, R) where {T, S},
+           GeneralizedSVD{T,S,real(T),typeof(a)}(U, V, Q, a, b, k, l, R))
 
 # iteration for destructuring into components
 Base.iterate(S::GeneralizedSVD) = (S.U, Val(:V))

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -410,9 +410,6 @@ end
     factors, uplo, piv, rank, tol, info =
         cholp.factors, cholp.uplo, cholp.piv, cholp.rank, cholp.tol, cholp.info
 
-    @test CholeskyPivoted(factors, uplo, Vector{Int32}(piv), rank, tol, info) == cholp
-    @test CholeskyPivoted(factors, uplo, Vector{Int64}(piv), rank, tol, info) == cholp
-
     @test CholeskyPivoted(factors, uplo, piv, Int32(rank), tol, info) == cholp
     @test CholeskyPivoted(factors, uplo, piv, Int64(rank), tol, info) == cholp
 

--- a/stdlib/LinearAlgebra/test/lq.jl
+++ b/stdlib/LinearAlgebra/test/lq.jl
@@ -205,7 +205,7 @@ end
     show(bf, "text/plain", lq(Matrix(I, 4, 4)))
     seekstart(bf)
     @test String(take!(bf)) == """
-LinearAlgebra.LQ{Float64, Matrix{Float64}}
+LinearAlgebra.LQ{Float64, Matrix{Float64}, Vector{Float64}}
 L factor:
 4×4 Matrix{Float64}:
  1.0  0.0  0.0  0.0
@@ -213,7 +213,7 @@ L factor:
  0.0  0.0  1.0  0.0
  0.0  0.0  0.0  1.0
 Q factor:
-4×4 LinearAlgebra.LQPackedQ{Float64, Matrix{Float64}}:
+4×4 LinearAlgebra.LQPackedQ{Float64, Matrix{Float64}, Vector{Float64}}:
  1.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0
  0.0  0.0  1.0  0.0

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -296,7 +296,7 @@ end
         show(bf, "text/plain", lu(Matrix(I, 4, 4)))
         seekstart(bf)
         @test String(take!(bf)) == """
-LinearAlgebra.LU{Float64, Matrix{Float64}}
+LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{$Int}}
 L factor:
 4×4 Matrix{Float64}:
  1.0  0.0  0.0  0.0


### PR DESCRIPTION
Our current Factorization structures often hard-code the storage of indices, coefficients, ... resulting in downstream packages like CUDA.jl or StaticArrays.jl having to re-implement these structures for compatibility. For example, https://github.com/JuliaArrays/StaticArrays.jl/blob/559134c9edda3b8ee9a71938386d2904338d7cc9/src/qr.jl#L1-L6 or https://github.com/JuliaGPU/CUDA.jl/blob/43e0f48b135325b97415cd1c8802e47732de85c6/lib/cusolver/linalg.jl#L77-L81. This is unfortunate, since it requires duplicating a lot of functionality, and requires special-casing in packages like ChainRules.jl.

This PR explores adding additional type parameters to a couple of factorization structures (more to be added) to explore the fallout such a change. It's unlikely that we can do this in Julia 1.x, but maybe PkgEval tells otherwise...

cc @andreasnoack, ref https://github.com/JuliaGPU/CUDA.jl/pull/1194#issuecomment-937870692.