### PR TITLE
Add exact results for trig fcns on π

### DIFF
--- a/base/mathconstants.jl
+++ b/base/mathconstants.jl
@@ -123,4 +123,10 @@ Base.literal_pow(::typeof(^), ::Irrational{:ℯ}, ::Val{p}) where {p} = exp(p)
 Base.log(::Irrational{:ℯ}) = 1 # use 1 to correctly promote expressions like log(x)/log(ℯ)
 Base.log(::Irrational{:ℯ}, x::Number) = log(x)
 
+Base.sin(::Irrational{:π}) = 0.0
+Base.cos(::Irrational{:π}) = -1.0
+Base.sincos(::Irrational{:π}) = (0.0, -1.0)
+Base.tan(::Irrational{:π}) = 0.0
+Base.cot(::Irrational{:π}) = -1/0
+
 end # module

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -333,7 +333,7 @@ See also [`exp2`](@ref), [`exp10`](@ref) and [`cis`](@ref).
 julia> exp(1.0)
 2.718281828459045
 
-julia> exp(im * pi) == cis(pi)
+julia> exp(im * pi) ≈ cis(pi)
 true
 ```
 """ exp(x::Real)

--- a/test/math.jl
+++ b/test/math.jl
@@ -53,6 +53,11 @@ end
     @test occursin("3.14159", sprint(show, MIME"text/plain"(), π))
     @test repr(Any[pi ℯ; ℯ pi]) == "Any[π ℯ; ℯ π]"
     @test string(pi) == "π"
+
+    @test sin(π) === sinpi(1) == tan(π) == sinpi(1 // 1) == 0
+    @test cos(π) === cospi(1) == sec(π) == cospi(1 // 1) == -1
+    @test csc(π) == 1/0 && cot(π) == -1/0
+    @test sincos(π) === sincospi(1) == (0, -1)
 end
 
 @testset "frexp,ldexp,significand,exponent" begin


### PR DESCRIPTION
The argument in favor here is that since Julia  has  already gone to the
trouble to encode π exactly, and trig functions are defined in terms of
π, they should give exact answers for this particular constant. `log(ℯ)`
has a similar definition and test that `log(ℯ) === 1`. I decided here
not to require a specific return type as long as it was numerically
exact. (Arguably, we could also have chosen `log(::typeof(ℯ)) = true`.)
I chose `Int` because there is no obvious reason to impose a particular
precision.

Potential concerns: how this will play with autodiff. But the same issue applies to `log(ℯ)`,
and my guess is that it will be a non-issue.