### PR TITLE
fix #42604, export `jl_field_isdefined`

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -145,6 +145,7 @@
     XX(jl_expand_with_loc) \
     XX(jl_expand_with_loc_warn) \
     XX(jl_field_index) \
+    XX(jl_field_isdefined) \
     XX(jl_gc_add_finalizer) \
     XX(jl_gc_add_finalizer_th) \
     XX(jl_gc_add_ptr_finalizer) \


### PR DESCRIPTION
fix #42604

`jl_setjmp` is already in the backport queue.
