### PR TITLE
Define and export `undefs` similar to `zeros` and `ones`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -538,7 +538,7 @@ fill(v, dims::Tuple{}) = (a=Array{typeof(v),0}(undef, dims); fill!(a, v); a)
     zeros([T=Float64,] dims...)
 
 Create an `Array`, with element type `T`, of all zeros with size specified by `dims`.
-See also [`fill`](@ref), [`ones`](@ref), [`zero`](@ref).
+See also [`fill`](@ref), [`ones`](@ref), [`zero`](@ref), [`undefs`](@ref).
 
 # Examples
 ```jldoctest
@@ -559,7 +559,7 @@ function zeros end
     ones([T=Float64,] dims...)
 
 Create an `Array`, with element type `T`, of all ones with size specified by `dims`.
-See also [`fill`](@ref), [`zeros`](@ref).
+See also [`fill`](@ref), [`zeros`](@ref), [`undefs`](@ref).
 
 # Examples
 ```jldoctest
@@ -575,12 +575,31 @@ julia> ones(ComplexF64, 2, 3)
 """
 function ones end
 
-for (fname, felt) in ((:zeros, :zero), (:ones, :one))
+"""
+    undefs([T=Float64,] dims::Tuple)
+    undefs([T=Float64,] dims...)
+
+Create an `Array`, with element type `T`, with size specified by `dims`.
+The element values are undefined and are not initialized to any value.
+This is equivalent to `Array{T}(undef, dims)`.
+See also [`fill`](@ref), [`ones`](@ref), [`zeros`](@ref).
+
+!!! compat "Julia 1.8"
+    `undefs` is available as of Julia 1.8. Prior to Julia 1.8, use `Array{T}(undef, dims)`.
+
+"""
+function undefs end
+
+for fname in (:zeros, :ones, :undefs)
     @eval begin
         $fname(dims::DimOrInd...) = $fname(dims)
         $fname(::Type{T}, dims::DimOrInd...) where {T} = $fname(T, dims)
         $fname(dims::Tuple{Vararg{DimOrInd}}) = $fname(Float64, dims)
         $fname(::Type{T}, dims::NTuple{N, Union{Integer, OneTo}}) where {T,N} = $fname(T, map(to_dim, dims))
+    end
+end
+for (fname, felt) in ((:zeros, :zero), (:ones, :one))
+    @eval begin
         function $fname(::Type{T}, dims::NTuple{N, Integer}) where {T,N}
             a = Array{T,N}(undef, dims)
             fill!(a, $felt(T))
@@ -593,6 +612,9 @@ for (fname, felt) in ((:zeros, :zero), (:ones, :one))
         end
     end
 end
+
+undefs(::Type{T}, dims::NTuple{N, Integer}) where {T,N} = Array{T,N}(undef, dims)
+undefs(::Type{T}, dims::Tuple{}) where {T} = Array{T}(undef)
 
 function _one(unit::T, x::AbstractMatrix) where T
     require_one_based_indexing(x)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -444,6 +444,7 @@ export
     sum!,
     sum,
     to_indices,
+    undefs,
     vcat,
     vec,
     view,

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -33,6 +33,7 @@ Base.StridedVecOrMat
 Base.getindex(::Type, ::Any...)
 Base.zeros
 Base.ones
+Base.undefs
 Base.BitArray
 Base.BitArray(::UndefInitializer, ::Integer...)
 Base.BitArray(::Any)


### PR DESCRIPTION
Create an easy to use function, `undefs` that creates an uninitialized array using similar syntax to `zeros` and `ones`.

New users to Julia often use `zeros` or `ones` to initialize arrays even though initialization may not be needed. Part of the reason is that the syntax of `zeros` and `ones` is uncomplicated and reminiscent of similar functions in [other languages](https://www.mathworks.com/help/matlab/ref/ones.html) and [frameworks](https://numpy.org/doc/stable/reference/generated/numpy.zeros.html). Additionally, these functions also have a default type of `Float64`.

To make the creation of uninitialized arrays easier for users new to Julia, the method `undefs` is added that mimics the syntax and argument order of `ones` and `zeros`. Similar to `ones` and `zeros`, it also has a default type of `Float64`.

While the functionality is redundant with `Array{T}(undef, dims)`, except for the `Float64` default, or `similar`, the syntax is straightforward, does not require the use of curly braces, or the use of an existing array.

Let's make efficient Julia easier to use with `undefs`.

```julia
julia> Array{Float64}(undef, 5,5)
5×5 Matrix{Float64}:
 5.0e-324      2.5e-323      7.64061e-316  7.64062e-316  5.0e-323
 2.0e-323      7.64061e-316  7.64062e-316  4.4e-323      5.4e-323
 7.6406e-316   7.64061e-316  4.0e-323      4.4e-323      7.64063e-316
 7.64061e-316  3.0e-323      4.0e-323      7.64063e-316  7.64064e-316
 2.5e-323      3.5e-323      7.64062e-316  7.64063e-316  0.0

julia> undefs(5, 5)
5×5 Matrix{Float64}:
 7.63889e-316  1.22467e-315  5.99379e-316  7.63893e-316  7.64422e-316
 7.63889e-316  7.64418e-316  7.63891e-316  7.63893e-316  5.99388e-316
 7.63889e-316  7.63889e-316  7.63892e-316  7.64421e-316  5.99402e-316
 7.64418e-316  7.64418e-316  7.63892e-316  5.99387e-316  7.63894e-316
 5.99377e-316  7.64419e-316  7.63892e-316  7.63872e-316  0.0

julia> Array{Int}(undef, 5,5)
5×5 Matrix{Int64}:
 0  0  0  0  0
 0  0  0  0  0
 0  0  0  0  0
 0  0  0  0  0
 0  0  0  0  0

julia> undefs(Int, 5, 5)
5×5 Matrix{Int64}:
 0  0  0  0  0
 0  0  0  0  0
 0  0  0  0  0
 0  0  0  0  0
 0  0  0  0  0
```

See also [`numpy.empty`](https://numpy.org/doc/stable/reference/generated/numpy.empty.html)