### PR TITLE
Base: fix `tryparse(Bool, " ")`

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -194,10 +194,10 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString{String}},
     orig_end   = endpos
 
     # Ignore leading and trailing whitespace
-    while isspace(sbuff[startpos]) && startpos <= endpos
+    while startpos <= endpos && isspace(sbuff[startpos])
         startpos = nextind(sbuff, startpos)
     end
-    while isspace(sbuff[endpos]) && endpos >= startpos
+    while endpos >= startpos && isspace(sbuff[endpos])
         endpos = prevind(sbuff, endpos)
     end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -236,6 +236,13 @@ end
     @test_throws ArgumentError parse(Int, "2", base = 63)
 end
 
+@testset "issue #42616" begin
+    @test tryparse(Bool, "") === nothing
+    @test tryparse(Bool, " ") === nothing
+    @test_throws ArgumentError parse(Bool, "")
+    @test_throws ArgumentError parse(Bool, " ")
+end
+
 # issue #17333: tryparse should still throw on invalid base
 for T in (Int32, BigInt), base in (0,1,100)
     @test_throws ArgumentError tryparse(T, "0", base = base)


### PR DESCRIPTION
The `while` conditions were incorrectly ordered, resulting in `BoundsError`.

Fixes #42616.