### PR TITLE
[build] Rename `checksum-libunwind` -> `checksum-unwind`

### DIFF
--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -13,7 +13,7 @@ $(SRCCACHE)/libunwind-$(UNWIND_VER)/source-extracted: $(SRCCACHE)/libunwind-$(UN
 	touch -c $(SRCCACHE)/libunwind-$(UNWIND_VER)/configure # old target
 	echo 1 > $@
 
-checksum-libunwind: $(SRCCACHE)/libunwind-$(UNWIND_VER).tar.gz
+checksum-unwind: $(SRCCACHE)/libunwind-$(UNWIND_VER).tar.gz
 	$(JLCHECKSUM) $<
 
 $(SRCCACHE)/libunwind-$(UNWIND_VER)/libunwind-prefer-extbl.patch-applied: $(SRCCACHE)/libunwind-$(UNWIND_VER)/source-extracted


### PR DESCRIPTION
This makefile target did not get renamed properly along with the rest of
the targets in this file.