### PR TITLE
Fix assumption about underflow on `AbstractUnitrange{<:Unsigned}`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -734,9 +734,14 @@ end
 
 function length(r::AbstractUnitRange{T}) where T
     @inline
-    last(r) < first(r) && return Integer(zero(first(r) - last(r)))
-    a = last(r) - first(r) # not all types overflow
-    return Integer(a + oneunit(a))
+    start, stop = first(r), last(r)
+    a = oneunit(zero(stop) - zero(start))
+    if a isa Signed || stop >= start
+        a += stop - start # Signed are allowed to go negative
+    else
+        a = zero(a) # Unsigned don't necessarily underflow
+    end
+    return Integer(a)
 end
 
 length(r::OneTo) = Integer(r.stop - zero(r.stop))

--- a/base/range.jl
+++ b/base/range.jl
@@ -393,10 +393,8 @@ end
 UnitRange(start::T, stop::T) where {T<:Real} = UnitRange{T}(start, stop)
 
 unitrange_last(::Bool, stop::Bool) = stop
-unitrange_last(start::T, stop::T) where {T<:Unsigned} =
-    stop >= start ? stop : convert(T,start-oneunit(start-stop))
 unitrange_last(start::T, stop::T) where {T<:Integer} =
-    stop >= start ? stop : convert(T,start-oneunit(stop-start))
+    stop >= start ? stop : convert(T,start-oneunit(start-stop))
 unitrange_last(start::T, stop::T) where {T} =
     stop >= start ? convert(T,start+floor(stop-start)) :
                     convert(T,start-oneunit(stop-start))

--- a/base/range.jl
+++ b/base/range.jl
@@ -393,6 +393,8 @@ end
 UnitRange(start::T, stop::T) where {T<:Real} = UnitRange{T}(start, stop)
 
 unitrange_last(::Bool, stop::Bool) = stop
+unitrange_last(start::T, stop::T) where {T<:Unsigned} =
+    stop >= start ? stop : convert(T,start-oneunit(start-stop))
 unitrange_last(start::T, stop::T) where {T<:Integer} =
     stop >= start ? stop : convert(T,start-oneunit(stop-start))
 unitrange_last(start::T, stop::T) where {T} =
@@ -734,7 +736,8 @@ end
 
 function length(r::AbstractUnitRange{T}) where T
     @inline
-    a = last(r) - first(r) # even when isempty, by construction (with overflow)
+    last(r) < first(r) && return Integer(zero(first(r) - last(r)))
+    a = last(r) - first(r) # not all types overflow
     return Integer(a + oneunit(a))
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -582,6 +582,8 @@ struct OverflowingReal <: Real
     val::UInt8
 end
 OverflowingReal(x::OverflowingReal) = x
+Base.:<(x::OverflowingReal, y::OverflowingReal) = x.val < y.val
+Base.:(==)(x::OverflowingReal, y::OverflowingReal) = x.val == y.val
 Base.:<=(x::OverflowingReal, y::OverflowingReal) = x.val <= y.val
 Base.:+(x::OverflowingReal, y::OverflowingReal) = OverflowingReal(x.val + y.val)
 Base.:-(x::OverflowingReal, y::OverflowingReal) = OverflowingReal(x.val - y.val)
@@ -2204,5 +2206,6 @@ end
     end
     Base.one(::Type{Fix42528}) = Fix42528(0x1)
     @test Fix42528(0x0):Fix42528(0x1) == [Fix42528(0x0), Fix42528(0x01)]
+    @test iszero(length(Fix42528(0x1):Fix42528(0x0)))
     @test_throws DomainError Fix42528(0x0) - Fix42528(0x1)
 end


### PR DESCRIPTION
As mentioned in #42528 after the initial PR, just removing `ifelse` is not enough. This fixes the behavior for creating empty UnitRanges of unsigned integers that don't underflow.