### PR TITLE
fix #42590, long attribute loop compiling `cfunction`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5243,9 +5243,11 @@ static Function* gen_cfun_wrapper(
         newAttributes.emplace_back(it, AttributeSet::get(jl_LLVMContext, attrBuilder));
 
         // Shift forward the rest of the attributes
-        for(;it < attributes.index_end(); ++it) {
-            if (attributes.hasAttributes(it)) {
-                newAttributes.emplace_back(it + 1, attributes.getAttributes(it));
+        if (attributes.getNumAttrSets() > 0) { // without this check the loop range below is invalid
+            for(;it < attributes.index_end(); ++it) {
+                if (attributes.hasAttributes(it)) {
+                    newAttributes.emplace_back(it + 1, attributes.getAttributes(it));
+                }
             }
         }
 


### PR DESCRIPTION
fix #42590