### PR TITLE
CI (Buildkite, GHA): Remove the label trigger for the "Retry" workflow, which will prevent "retry" commit statuses from being created on PRs

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,12 +27,7 @@ on:
   # the PR is from a fork. Therefore, for security reasons, we do not checkout any code in
   # this workflow.
   pull_request_target:
-
-    # TODO: delete the following line (once we have completely transitioned from Buildbot to Buildkite)
-    types: [ reopened, labeled ]
-
-    # TODO: uncomment the following line (once we have completely transitioned from Buildbot to Buildkite)
-    # types: [ reopened ]
+    types: [ reopened ]
 
 # We do not give the `GITHUB_TOKEN` any permissions.
 permissions:


### PR DESCRIPTION
These "retry" commit statuses are causing too much confusion. So let's remove the label trigger, which will get rid of the "retry" commit statuses.

In a follow-up PR, I'll add a comment-based trigger. Comment triggers don't create commit statuses on the PR, so we won't have the same problem.