### PR TITLE
Avoid allocating large cache array when slicing some sparse matrices

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2295,13 +2295,15 @@ function getindex_I_sorted(A::AbstractSparseMatrixCSC{Tv,Ti}, I::AbstractVector,
     # Heuristics based on experiments discussed in:
     # https://github.com/JuliaLang/julia/issues/12860
     # https://github.com/JuliaLang/julia/pull/12934
-    alg = ((m > nzA) && (m > nI)) ? 0 :
-          ((nI - avgM) > 2^8) ? 1 :
-          ((avgM - nI) > 2^10) ? 0 : 2
-
-    (alg == 0) ? getindex_I_sorted_bsearch_A(A, I, J) :
-    (alg == 1) ? getindex_I_sorted_bsearch_I(A, I, J) :
-    getindex_I_sorted_linear(A, I, J)
+    alg = if m > nzA && m > nI
+        return getindex_I_sorted_bsearch_A(A, I, J)
+    elseif nI - avgM > 2 ^ 8
+        return getindex_I_sorted_bsearch_I(A, I, J)
+    elseif avgM - nI > 2 ^ 10
+        return getindex_I_sorted_bsearch_A(A, I, J)
+    else
+        return getindex_I_sorted_linear(A, I, J)
+    end
 end
 
 function getindex_I_sorted_bsearch_A(A::AbstractSparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector) where {Tv,Ti}


### PR DESCRIPTION
This came up when profiling some code for a customer. It was originally tracked in https://github.com/JuliaLang/julia/issues/12860 but then considered fixed by https://github.com/JuliaLang/julia/pull/12934 because very sparse matrices would no longer hit the methods that allocate large vectors. However, there can still be a significant overhead from the dense cache vector for typical sparse matrices. Currently, we have that
```julia
julia> A = spdiagm(ones(10^8));

julia> @btime A[[1], 1]
  260.925 ms (8 allocations: 762.94 MiB)
1-element SparseVector{Float64, Int64} with 1 stored entry:
  [1]  =  1.0
```
With this PR, it becomes
```julia
julia> @btime A[[1], 1]
  258.067 ns (8 allocations: 528 bytes)
1-element SparseVector{Float64, Int64} with 1 stored entry:
  [1]  =  1.0
```

Eventually, we should also change `getindex_I_sorted_bsearch_I` similarly to what I'm doing here it's also allocating the huge vector and therefore
```julia
julia> @time A[collect(1:(2^8+2)), 1]
  0.448473 seconds (8 allocations: 762.942 MiB, 11.40% gc time)
258-element SparseVector{Float64, Int64} with 1 stored entry:
  [1  ]  =  1.0
```

I don't have time for that right now so I'll file that in a new issue.

Finally, I'm also changing the code to avoid the nested ternary syntax when deciding sparse matrix slicing algorithm to make the code easier to read.