### PR TITLE
Correctly compute field path for the heap snapshot, taking struct inlining into account

### DIFF
--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -253,14 +253,6 @@ void record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT {
 }
 
 typedef pair<jl_datatype_t*, const char*> inlineallocd_field_type_t;
-vector<inlineallocd_field_type_t> _fieldpath_for_slot(jl_value_t *obj, jl_value_t *slot) {
-    jl_datatype_t *vt = (jl_datatype_t*)jl_typeof(obj);
-
-    vector<inlineallocd_field_type_t> result;
-    bool found = _fieldpath_for_slot_helper(result, vt, obj, slot);
-    // NOTE THE RETURNED VECTOR IS REVERSED
-    return result;
-}
 
 bool _fieldpath_for_slot_helper(
     vector<inlineallocd_field_type_t>& out, jl_datatype_t *objtype,
@@ -278,7 +270,7 @@ bool _fieldpath_for_slot_helper(
             return true;
         }
         if (jl_stored_inline((jl_value_t*)field_type)) {
-            bool found = _fieldpath_for_slot_helper(out, field_name, field_type, fieldaddr, slot);
+            bool found = _fieldpath_for_slot_helper(out, field_type, fieldaddr, slot);
             if (found) {
                 out.push_back(inlineallocd_field_type_t(field_type, field_name));
                 return true;
@@ -286,6 +278,28 @@ bool _fieldpath_for_slot_helper(
         }
     }
     return false;
+}
+
+vector<inlineallocd_field_type_t> _fieldpath_for_slot(jl_value_t *obj, jl_value_t *slot) {
+    jl_datatype_t *vt = (jl_datatype_t*)jl_typeof(obj);
+
+    vector<inlineallocd_field_type_t> result;
+    bool found = _fieldpath_for_slot_helper(result, vt, obj, slot);
+    // TODO: maybe don't need the return value here actually...?
+    if (!found) {
+        // TODO: Debug these failures. Some of them seem really wrong, like with the slot
+        // being _kilobytes_ past the start of the object for an object with 1 pointer and 1
+        // field...
+        // jl_printf(JL_STDERR, "WARNING: No fieldpath found for obj: %p slot: %p ", (void*)obj, (void*)slot);
+        // jl_datatype_t* type = (jl_datatype_t*)jl_typeof(obj);
+        // if (jl_is_datatype(type)) {
+        //     jl_printf(JL_STDERR, "typeof: ");
+        //     jl_static_show(JL_STDERR, (jl_value_t*)type);
+        // }
+        // jl_printf(JL_STDERR, "\n");
+    }
+    // NOTE THE RETURNED VECTOR IS REVERSED
+    return result;
 }
 
 
@@ -341,12 +355,22 @@ void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, size
     // Build the new field name by joining the strings, and/or use the struct + field names
     // to create a bunch of edges + nodes
     // (iterate the vector in reverse - the last element is the first path)
+    // TODO: Prefer to create intermediate edges and nodes instead of a combined string path.
+    if (field_paths.size() > 1) {
+        jl_printf(JL_STDERR, "count: %lu\n", field_paths.size());
+    }
+
+    string path;
     for (auto it = field_paths.rbegin(); it != field_paths.rend(); ++it) {
         // ...
+        path += it->second;
+        if ( it + 1 != field_paths.rend() ) {
+            path += ".";
+        }
     }
 
     _record_gc_edge("object", "property", from, to,
-                    g_snapshot->names.find_or_create_string_id(field_name));
+                    g_snapshot->names.find_or_create_string_id(path));
 }
 void _gc_heap_snapshot_record_internal_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT {
     // TODO: probably need to inline this here and make some changes

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -289,17 +289,12 @@ bool _fieldpath_for_slot_helper(
     }
     return false;
 }
-JL_DLLEXPORT void jl_breakpoint(jl_value_t *v)
-{
-    // put a breakpoint in your debugger here
-}
-
 
 vector<inlineallocd_field_type_t> _fieldpath_for_slot(jl_value_t *obj, void *slot) {
     jl_datatype_t *vt = (jl_datatype_t*)jl_typeof(obj);
+    // TODO(PR): Remove this debugging code
     if (vt->name->module == jl_main_module) {
-        // jl_breakpoint(obj);
-        debug_log = true;
+        // debug_log = true;
     }
 
     vector<inlineallocd_field_type_t> result;
@@ -312,13 +307,13 @@ vector<inlineallocd_field_type_t> _fieldpath_for_slot(jl_value_t *obj, void *slo
         // TODO: Debug these failures. Some of them seem really wrong, like with the slot
         // being _kilobytes_ past the start of the object for an object with 1 pointer and 1
         // field...
-        // jl_printf(JL_STDERR, "WARNING: No fieldpath found for obj: %p slot: %p ", (void*)obj, (void*)slot);
-        // jl_datatype_t* type = (jl_datatype_t*)jl_typeof(obj);
-        // if (jl_is_datatype(type)) {
-        //     jl_printf(JL_STDERR, "typeof: ");
-        //     jl_static_show(JL_STDERR, (jl_value_t*)type);
-        // }
-        // jl_printf(JL_STDERR, "\n");
+        jl_printf(JL_STDERR, "WARNING: No fieldpath found for obj: %p slot: %p ", (void*)obj, (void*)slot);
+        jl_datatype_t* type = (jl_datatype_t*)jl_typeof(obj);
+        if (jl_is_datatype(type)) {
+            jl_printf(JL_STDERR, "typeof: ");
+            jl_static_show(JL_STDERR, (jl_value_t*)type);
+        }
+        jl_printf(JL_STDERR, "\n");
     }
     // NOTE THE RETURNED VECTOR IS REVERSED
     return result;
@@ -363,25 +358,11 @@ void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void
         _record_gc_edge("object", "element", from, to, /* TODO */0);
         return;
     }
-    // if (field_index < 0 || jl_datatype_nfields(type) <= field_index) {
-    //     // TODO: We're getting -1 in some cases
-    //     //jl_printf(JL_STDERR, "WARNING - incorrect field index (%zu) for type\n", field_index);
-    //     //jl_(type);
-    //     _record_gc_edge("object", "element", from, to, field_index);
-    //     return;
-    // }
-    // jl_svec_t *field_names = jl_field_names(type);
-    // jl_sym_t *name = (jl_sym_t*)jl_svecref(field_names, field_index);
-    // const char *field_name = jl_symbol_name(name);
     auto field_paths = _fieldpath_for_slot(from, slot);
     // Build the new field name by joining the strings, and/or use the struct + field names
     // to create a bunch of edges + nodes
     // (iterate the vector in reverse - the last element is the first path)
     // TODO: Prefer to create intermediate edges and nodes instead of a combined string path.
-    if (field_paths.size() > 1) {
-        jl_printf(JL_STDERR, "count: %lu\n", field_paths.size());
-    }
-
     string path;
     for (auto it = field_paths.rbegin(); it != field_paths.rend(); ++it) {
         // ...

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -258,7 +258,7 @@ static bool debug_log = false;
 
 bool _fieldpath_for_slot_helper(
     vector<inlineallocd_field_type_t>& out, jl_datatype_t *objtype,
-    void *obj, jl_value_t *slot)
+    void *obj, void *slot)
 {
     int nf = (int)jl_datatype_nfields(objtype);
     jl_svec_t *field_names = jl_field_names(objtype);
@@ -295,7 +295,7 @@ JL_DLLEXPORT void jl_breakpoint(jl_value_t *v)
 }
 
 
-vector<inlineallocd_field_type_t> _fieldpath_for_slot(jl_value_t *obj, jl_value_t *slot) {
+vector<inlineallocd_field_type_t> _fieldpath_for_slot(jl_value_t *obj, void *slot) {
     jl_datatype_t *vt = (jl_datatype_t*)jl_typeof(obj);
     if (vt->name->module == jl_main_module) {
         // jl_breakpoint(obj);
@@ -355,12 +355,12 @@ void _gc_heap_snapshot_record_module_edge(jl_module_t *from, jl_value_t *to, cha
     _record_gc_edge("object", "property", (jl_value_t *)from, to,
                     g_snapshot->names.find_or_create_string_id(name));
 }
-void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, size_t field_index) JL_NOTSAFEPOINT {
+void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT {
     jl_datatype_t *type = (jl_datatype_t*)jl_typeof(from);
     // TODO: It seems like NamedTuples should have field names? Maybe there's another way to get them?
     if (jl_is_tuple_type(type) || jl_is_namedtuple_type(type)) {
         // TODO: Maybe not okay to match element and object
-        _record_gc_edge("object", "element", from, to, field_index);
+        _record_gc_edge("object", "element", from, to, /* TODO */0);
         return;
     }
     // if (field_index < 0 || jl_datatype_nfields(type) <= field_index) {
@@ -373,7 +373,7 @@ void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, size
     // jl_svec_t *field_names = jl_field_names(type);
     // jl_sym_t *name = (jl_sym_t*)jl_svecref(field_names, field_index);
     // const char *field_name = jl_symbol_name(name);
-    auto field_paths = _fieldpath_for_slot(from, to);
+    auto field_paths = _fieldpath_for_slot(from, slot);
     // Build the new field name by joining the strings, and/or use the struct + field names
     // to create a bunch of edges + nodes
     // (iterate the vector in reverse - the last element is the first path)

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -254,21 +254,31 @@ void record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT {
 
 typedef pair<jl_datatype_t*, const char*> inlineallocd_field_type_t;
 
+static bool debug_log = false;
+
 bool _fieldpath_for_slot_helper(
     vector<inlineallocd_field_type_t>& out, jl_datatype_t *objtype,
     void *obj, jl_value_t *slot)
 {
     int nf = (int)jl_datatype_nfields(objtype);
     jl_svec_t *field_names = jl_field_names(objtype);
+    if (debug_log) {
+        jl_((jl_value_t*)objtype);
+        jl_printf(JL_STDERR, "obj: %p, slot: %p, nf: %d\n", obj, (void*)slot, nf);
+    }
     for (int i = 0; i < nf; i++) {
         jl_datatype_t *field_type = (jl_datatype_t*)jl_field_type(objtype, i);
         void *fieldaddr = (char*)obj + jl_field_offset(objtype, i);
         jl_sym_t *name = (jl_sym_t*)jl_svecref(field_names, i);
         const char *field_name = jl_symbol_name(name);
+        if (debug_log) {
+            jl_printf(JL_STDERR, "%d - field_name: %s fieldaddr: %p\n", i, field_name, fieldaddr);
+        }
         if (fieldaddr >= slot) {
             out.push_back(inlineallocd_field_type_t(objtype, field_name));
             return true;
         }
+        // If the field is an inline-allocated struct
         if (jl_stored_inline((jl_value_t*)field_type)) {
             bool found = _fieldpath_for_slot_helper(out, field_type, fieldaddr, slot);
             if (found) {
@@ -279,12 +289,24 @@ bool _fieldpath_for_slot_helper(
     }
     return false;
 }
+JL_DLLEXPORT void jl_breakpoint(jl_value_t *v)
+{
+    // put a breakpoint in your debugger here
+}
+
 
 vector<inlineallocd_field_type_t> _fieldpath_for_slot(jl_value_t *obj, jl_value_t *slot) {
     jl_datatype_t *vt = (jl_datatype_t*)jl_typeof(obj);
+    if (vt->name->module == jl_main_module) {
+        // jl_breakpoint(obj);
+        debug_log = true;
+    }
 
     vector<inlineallocd_field_type_t> result;
     bool found = _fieldpath_for_slot_helper(result, vt, obj, slot);
+
+    debug_log = false;
+
     // TODO: maybe don't need the return value here actually...?
     if (!found) {
         // TODO: Debug these failures. Some of them seem really wrong, like with the slot

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -17,7 +17,7 @@ extern "C" {
 void _gc_heap_snapshot_record_root(jl_value_t *root, char *name);
 void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_module_edge(jl_module_t *from, jl_value_t *to, char *name) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, size_t field_index) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT;
 // Used for objects managed by GC, but which aren't exposed in the julia object, so have no
 // field or index.  i.e. they're not reacahable from julia code, but we _will_ hit them in
 // the GC mark phase (so we can check their type tag to get the size).
@@ -44,9 +44,9 @@ static inline void gc_heap_snapshot_record_module_edge(jl_module_t *from, jl_val
         _gc_heap_snapshot_record_module_edge(from, to, name);
     }
 }
-static inline void gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, size_t field_index) JL_NOTSAFEPOINT {
+static inline void gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT {
     if (__unlikely(gc_heap_snapshot_enabled)) {
-        _gc_heap_snapshot_record_object_edge(from, to, field_index);
+        _gc_heap_snapshot_record_object_edge(from, to, slot);
     }
 }
 static inline void gc_heap_snapshot_record_internal_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT {

--- a/src/gc.c
+++ b/src/gc.c
@@ -1959,8 +1959,7 @@ STATIC_INLINE int gc_mark_scan_obj8(jl_ptls_t ptls, jl_gc_mark_sp_t *sp, gc_mark
         if (*pnew_obj) {
             verify_parent2("object", parent, slot, "field(%d)",
                            gc_slot_to_fieldidx(parent, slot));
-            gc_heap_snapshot_record_object_edge(parent, *slot,
-                           gc_slot_to_fieldidx(parent, slot));
+            gc_heap_snapshot_record_object_edge(parent, *slot, slot);
         }
         if (!gc_try_setmark(*pnew_obj, &obj8->nptr, ptag, pbits))
             continue;
@@ -1996,8 +1995,7 @@ STATIC_INLINE int gc_mark_scan_obj16(jl_ptls_t ptls, jl_gc_mark_sp_t *sp, gc_mar
             verify_parent2("object", parent, slot, "field(%d)",
                            gc_slot_to_fieldidx(parent, slot));
             // TODO: Should this be *parent? Given the way it's used above?
-            gc_heap_snapshot_record_object_edge(parent, *slot,
-                           gc_slot_to_fieldidx(parent, slot));
+            gc_heap_snapshot_record_object_edge(parent, *slot, slot);
         }
         if (!gc_try_setmark(*pnew_obj, &obj16->nptr, ptag, pbits))
             continue;
@@ -2032,8 +2030,7 @@ STATIC_INLINE int gc_mark_scan_obj32(jl_ptls_t ptls, jl_gc_mark_sp_t *sp, gc_mar
         if (*pnew_obj) {
             verify_parent2("object", parent, slot, "field(%d)",
                            gc_slot_to_fieldidx(parent, slot));
-            gc_heap_snapshot_record_object_edge(parent, *slot,
-                           gc_slot_to_fieldidx(parent, slot));
+            gc_heap_snapshot_record_object_edge(parent, *slot, slot);
         }
         if (!gc_try_setmark(*pnew_obj, &obj32->nptr, ptag, pbits))
             continue;


### PR DESCRIPTION
The existing debug code for computing field name from a slot pointer is not working: `gc_slot_to_fieldidx(parent, slot)`.

I think this is because that code was written before the optimization that was added in julia 1.3 or 1.4 to allow inlining immutable structs with heap references.

This PR creates a new function, `_fieldpath_for_slot(from, slot)` which returns a vector of `type, field` pairs, that give the full path to a slot's field from a given object.

For example, for the following struct:
```julia
struct B
    x::Int
    y::Any
end
mutable struct A
    a::Int
    b::B
end

ga = A(1, B(2, []))
```
The only pointer field in `ga` is: `b.y :: Vector{Any}`, which is returned as `[(B, :y), (A, :b)]` (in reverse order because of silly implementation reasons, since C++ vectors aren't efficient for push_front).
