### PR TITLE
Garbage profiler

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -106,6 +106,8 @@ Control whether garbage collection is enabled using a boolean argument (`true` f
 """
 enable(on::Bool) = ccall(:jl_gc_enable, Int32, (Int32,), on) != 0
 
+# TODO: maybe merge profiling & logging funcions?
+
 function start_garbage_profile(io)
     ccall(:jl_start_garbage_profile, Cvoid, (Ptr{Cvoid},), io.handle)
 end
@@ -114,12 +116,12 @@ function stop_garbage_profile()
     ccall(:jl_stop_garbage_profile, Cvoid, ())
 end
 
-function enable_gc_logging(io)
-    ccall(:jl_enable_gc_logging, Cvoid, (Ptr{Cvoid},), io.handle)
+function start_logging(io)
+    ccall(:jl_start_logging, Cvoid, (Ptr{Cvoid},), io.handle)
 end
 
-function disable_gc_logging()
-    ccall(:jl_disable_gc_logging, Cvoid, ())
+function stop_logging()
+    ccall(:jl_stop_logging, Cvoid, ())
 end
 
 """

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -106,6 +106,14 @@ Control whether garbage collection is enabled using a boolean argument (`true` f
 """
 enable(on::Bool) = ccall(:jl_gc_enable, Int32, (Int32,), on) != 0
 
+function start_garbage_profile(io)
+    ccall(:jl_start_garbage_profile, Cvoid, (Ptr{Cvoid},), io.handle)
+end
+
+function stop_garbage_profile()
+    ccall(:jl_stop_garbage_profile, Cvoid, ())
+end
+
 """
     GC.enable_finalizers(on::Bool)
 

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -114,6 +114,14 @@ function stop_garbage_profile()
     ccall(:jl_stop_garbage_profile, Cvoid, ())
 end
 
+function enable_gc_logging(io)
+    ccall(:jl_enable_gc_logging, Cvoid, (Ptr{Cvoid},), io.handle)
+end
+
+function disable_gc_logging()
+    ccall(:jl_disable_gc_logging, Cvoid, ())
+end
+
 """
     GC.enable_finalizers(on::Bool)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,7 +46,7 @@ RUNTIME_SRCS := \
 	dlload sys init task array dump staticdata toplevel jl_uv datatype \
 	simplevector runtime_intrinsics precompile \
 	threading partr stackwalk gc gc-debug gc-pages gc-stacks method \
-	jlapi signal-handling safepoint timing subtype \
+	gc-garbage-profiler jlapi signal-handling safepoint timing subtype \
 	crc32c APInt-C processor ircode opaque_closure codegen-stubs
 SRCS := jloptions runtime_ccall rtutils
 ifeq ($(OS),WINNT)
@@ -284,7 +284,7 @@ $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/debuginfo.h $(SRCDIR)
 $(BUILDDIR)/dump.o $(BUILDDIR)/dump.dbg.obj: $(addprefix $(SRCDIR)/,common_symbols1.inc common_symbols2.inc builtin_proto.h serialize.h)
 $(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-pages.o $(BUILDDIR)/gc-pages.dbg.obj: $(SRCDIR)/gc.h
-$(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h
+$(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h $(SRCDIR)/gc-garbage-profiler.h
 $(BUILDDIR)/init.o $(BUILDDIR)/init.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/interpreter.o $(BUILDDIR)/interpreter.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/codegen_shared.h

--- a/src/gc-garbage-profiler.cpp
+++ b/src/gc-garbage-profiler.cpp
@@ -1,0 +1,156 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "gc-garbage-profiler.h"
+
+#include "julia_internal.h"
+#include "gc.h"
+
+#include <string>
+#include <unordered_map>
+
+using std::string;
+using std::unordered_map;
+
+// == utility functions ==
+
+void print_str_escape_csv(ios_t *stream, const std::string &s) {
+    ios_printf(stream, "\"");
+    for (auto c = s.cbegin(); c != s.cend(); c++) {
+        switch (*c) {
+        case '"': ios_printf(stream, "\"\""); break;
+        default:
+            ios_printf(stream, "%c", *c);
+        }
+    }
+    ios_printf(stream, "\"");
+}
+
+string _type_as_string(jl_datatype_t *type) {
+    if ((uintptr_t)type < 4096U) {
+        return "<corrupt>";
+    } else if (type == (jl_datatype_t*)jl_buff_tag) {
+        return "<buffer>";
+    } else if (type == (jl_datatype_t*)jl_malloc_tag) {
+        return "<malloc>";
+    } else if (type == jl_string_type) {
+        return "<string>";
+    } else if (type == jl_symbol_type) {
+        return "<symbol>";
+    } else if (jl_is_datatype(type)) {
+        ios_t str_;
+        ios_mem(&str_, 10024);
+        JL_STREAM* str = (JL_STREAM*)&str_;
+
+        jl_static_show(str, (jl_value_t*)type);
+
+        string type_str = string((const char*)str_.buf, str_.size);
+        ios_close(&str_);
+
+        return type_str;
+    } else {
+        return "<missing>";
+    }
+}
+
+// == global variables manipulated by callbacks ==
+// TODO: wrap these up into a struct
+
+ios_t *garbage_profile_out = nullptr;
+int gc_epoch = 0;
+// for each type, the index in mem_event where the type
+// event appears.
+unordered_map<size_t, string> g_type_name_by_address;
+unordered_map<size_t, size_t> g_type_address_by_value_address;
+unordered_map<size_t, size_t> g_frees_by_type_address;
+
+// == exported interface ==
+
+JL_DLLEXPORT void jl_start_garbage_profile(ios_t *stream) {
+    garbage_profile_out = stream;
+    ios_printf(garbage_profile_out, "gc_epoch,type,num_freed\n");
+}
+
+bool pair_cmp(std::pair<size_t, size_t> a, std::pair<size_t, size_t> b) {
+    return a.second > b.second;
+}
+
+JL_DLLEXPORT void jl_stop_garbage_profile() {
+    // TODO: flush file?
+    garbage_profile_out = nullptr;
+    g_type_name_by_address.clear();
+    g_type_address_by_value_address.clear();
+    g_frees_by_type_address.clear();
+}    
+
+// == callbacks called into by the outside ==
+
+void _report_gc_started() {
+    g_frees_by_type_address.clear();
+}
+
+// TODO: figure out how to pass all of these in as a struct
+void _report_gc_finished(uint64_t pause, uint64_t freed, uint64_t allocd) {
+    // TODO: figure out how to put in commas
+    jl_printf(
+        JL_STDERR,
+        "GC: pause %fms. collected %fMB. %lld allocs total\n",
+        pause/1e6, freed/1e6, allocd
+    );
+
+    // sort frees
+    for (auto const &pair : g_frees_by_type_address) {
+        auto type_str = g_type_name_by_address.find(pair.first);
+        if (type_str != g_type_name_by_address.end()) {
+            ios_printf(garbage_profile_out, "%d,", gc_epoch);
+            print_str_escape_csv(garbage_profile_out, type_str->second);
+            ios_printf(garbage_profile_out, ",%d\n", pair.second);
+        } else {
+            jl_printf(JL_STDERR, "couldn't find type %p\n", pair.first);
+            // TODO: warn about missing type
+        }
+    }
+    gc_epoch++;
+}
+
+void register_type_string(jl_datatype_t *type) {
+    auto id = g_type_name_by_address.find((size_t)type);
+    if (id != g_type_name_by_address.end()) {
+        return;
+    }
+
+    string type_str = _type_as_string(type);
+    g_type_name_by_address[(size_t)type] = type_str;
+}
+
+void _record_allocated_value(jl_value_t *val) {
+    if (garbage_profile_out == nullptr) {
+        return;
+    }
+
+    auto type = (jl_datatype_t*)jl_typeof(val);
+    register_type_string(type);
+
+    g_type_address_by_value_address[(size_t)val] = (size_t)type;
+}
+
+void _record_freed_value(jl_taggedvalue_t *tagged_val) {
+    if (garbage_profile_out == nullptr) {
+        return;
+    }
+
+    jl_value_t *val = jl_valueof(tagged_val);
+    
+    auto value_address = (size_t)val;
+    auto type_address = g_type_address_by_value_address.find(value_address);
+    if (type_address == g_type_address_by_value_address.end()) {
+        return; // TODO: warn
+    }
+    auto frees = g_frees_by_type_address.find(type_address->second);
+
+    if (frees == g_frees_by_type_address.end()) {
+        g_frees_by_type_address[type_address->second] = 1;
+    } else {
+        g_frees_by_type_address[type_address->second] = frees->second + 1;
+    }
+}
+

--- a/src/gc-garbage-profiler.cpp
+++ b/src/gc-garbage-profiler.cpp
@@ -90,7 +90,7 @@ JL_DLLEXPORT void jl_stop_garbage_profile() {
     g_type_name_by_address.clear();
     g_type_address_by_value_address.clear();
     g_frees_by_type_address.clear();
-}    
+}
 
 // == callbacks called into by the outside ==
 
@@ -157,7 +157,7 @@ void _record_allocated_value(jl_value_t *val) {
 
 void _record_freed_value(jl_taggedvalue_t *tagged_val) {
     jl_value_t *val = jl_valueof(tagged_val);
-    
+
     auto value_address = (size_t)val;
     auto type_address = g_type_address_by_value_address.find(value_address);
     if (type_address == g_type_address_by_value_address.end()) {
@@ -171,4 +171,3 @@ void _record_freed_value(jl_taggedvalue_t *tagged_val) {
         g_frees_by_type_address[type_address->second] = frees->second + 1;
     }
 }
-

--- a/src/gc-garbage-profiler.cpp
+++ b/src/gc-garbage-profiler.cpp
@@ -70,10 +70,6 @@ JL_DLLEXPORT void jl_start_garbage_profile(ios_t *stream) {
     ios_printf(garbage_profile_out, "gc_epoch,type,num_freed\n");
 }
 
-bool pair_cmp(std::pair<size_t, size_t> a, std::pair<size_t, size_t> b) {
-    return a.second > b.second;
-}
-
 JL_DLLEXPORT void jl_stop_garbage_profile() {
     // TODO: flush file?
     garbage_profile_out = nullptr;

--- a/src/gc-garbage-profiler.cpp
+++ b/src/gc-garbage-profiler.cpp
@@ -67,12 +67,12 @@ unordered_map<size_t, size_t> g_frees_by_type_address;
 
 // == exported interface ==
 
-JL_DLLEXPORT void jl_enable_gc_logging(ios_t *stream) {
+JL_DLLEXPORT void jl_start_logging(ios_t *stream) {
     g_gc_log_stream = stream;
     ios_printf(g_gc_log_stream, "gc_epoch,duration_ms,bytes_freed\n");
 }
 
-JL_DLLEXPORT void jl_disable_gc_logging() {
+JL_DLLEXPORT void jl_stop_logging() {
     g_gc_log_stream = nullptr;
 }
 

--- a/src/gc-garbage-profiler.cpp
+++ b/src/gc-garbage-profiler.cpp
@@ -103,19 +103,23 @@ void _report_gc_finished(uint64_t pause, uint64_t freed, uint64_t allocd) {
             "%d,%d,%d\n",
             gc_epoch, pause/1e6, freed
         );
+        ios_flush(g_gc_log_stream);
     }
 
     // sort frees
-    for (auto const &pair : g_frees_by_type_address) {
-        auto type_str = g_type_name_by_address.find(pair.first);
-        if (type_str != g_type_name_by_address.end()) {
-            ios_printf(g_garbage_profile_stream, "%d,", gc_epoch);
-            print_str_escape_csv(g_garbage_profile_stream, type_str->second);
-            ios_printf(g_garbage_profile_stream, ",%d\n", pair.second);
-        } else {
-            jl_printf(JL_STDERR, "couldn't find type %p\n", pair.first);
-            // TODO: warn about missing type
+    if (g_garbage_profile_stream != nullptr) {
+        for (auto const &pair : g_frees_by_type_address) {
+            auto type_str = g_type_name_by_address.find(pair.first);
+            if (type_str != g_type_name_by_address.end()) {
+                ios_printf(g_garbage_profile_stream, "%d,", gc_epoch);
+                print_str_escape_csv(g_garbage_profile_stream, type_str->second);
+                ios_printf(g_garbage_profile_stream, ",%d\n", pair.second);
+            } else {
+                jl_printf(JL_STDERR, "couldn't find type %p\n", pair.first);
+                // TODO: warn about missing type
+            }
         }
+        ios_flush(g_garbage_profile_stream);
     }
     gc_epoch++;
 }

--- a/src/gc-garbage-profiler.cpp
+++ b/src/gc-garbage-profiler.cpp
@@ -101,7 +101,7 @@ void _report_gc_finished(uint64_t pause, uint64_t freed, uint64_t allocd) {
         ios_printf(
             g_gc_log_stream,
             "%d,%d,%d\n",
-            gc_epoch, pause/1e6, freed
+            gc_epoch, (int)(pause/1e6), freed
         );
         ios_flush(g_gc_log_stream);
     }

--- a/src/gc-garbage-profiler.h
+++ b/src/gc-garbage-profiler.h
@@ -11,13 +11,13 @@ extern "C" {
 #endif
 
 JL_DLLEXPORT void jl_start_logging(ios_t *stream);
-JL_DLLEXPORT void jl_stop_logging();
+JL_DLLEXPORT void jl_stop_logging(void);
 
 JL_DLLEXPORT void jl_start_garbage_profile(ios_t *stream);
 JL_DLLEXPORT void jl_stop_garbage_profile(void);
 
 void _report_gc_started(void);
-void _report_gc_finished(uint64_t pause, uint64_t freed, uint64_t allocd);
+void _report_gc_finished(jl_gc_collection_t collection, uint64_t pause, uint64_t freed, uint64_t allocd);
 void _record_allocated_value(jl_value_t *val);
 void _record_freed_value(jl_taggedvalue_t *tagged_val);
 

--- a/src/gc-garbage-profiler.h
+++ b/src/gc-garbage-profiler.h
@@ -10,8 +10,8 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT void jl_enable_gc_logging(ios_t *stream);
-JL_DLLEXPORT void jl_disable_gc_logging();
+JL_DLLEXPORT void jl_start_logging(ios_t *stream);
+JL_DLLEXPORT void jl_stop_logging();
 
 JL_DLLEXPORT void jl_start_garbage_profile(ios_t *stream);
 JL_DLLEXPORT void jl_stop_garbage_profile(void);

--- a/src/gc-garbage-profiler.h
+++ b/src/gc-garbage-profiler.h
@@ -10,6 +10,9 @@
 extern "C" {
 #endif
 
+JL_DLLEXPORT void jl_enable_gc_logging(ios_t *stream);
+JL_DLLEXPORT void jl_disable_gc_logging();
+
 JL_DLLEXPORT void jl_start_garbage_profile(ios_t *stream);
 JL_DLLEXPORT void jl_stop_garbage_profile(void);
 
@@ -22,16 +25,17 @@ void _record_freed_value(jl_taggedvalue_t *tagged_val);
 // functions to call from GC when garbage profiling is enabled
 // ---------------------------------------------------------------------
 
-extern ios_t *garbage_profile_out; // TODO: replace w/ bool?
+extern ios_t *g_garbage_profile_stream; // TODO: replace w/ bool?
+extern ios_t *g_gc_log_stream;
 
 static inline void record_allocated_value(jl_value_t *val) {
-    if (__unlikely(garbage_profile_out != 0)) {
+    if (__unlikely(g_garbage_profile_stream != 0)) {
         _record_allocated_value(val);
     }
 }
 
 static inline void record_freed_value(jl_taggedvalue_t *tagged_val) {
-    if (__unlikely(garbage_profile_out != 0)) {
+    if (__unlikely(g_garbage_profile_stream != 0)) {
         _record_freed_value(tagged_val);
     }
 }

--- a/src/gc-garbage-profiler.h
+++ b/src/gc-garbage-profiler.h
@@ -1,0 +1,44 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#ifndef JL_GC_GARBAGE_PROFILER_H
+#define JL_GC_GARBAGE_PROFILER_H
+
+#include "julia.h"
+#include "ios.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JL_DLLEXPORT void jl_start_garbage_profile(ios_t *stream);
+JL_DLLEXPORT void jl_stop_garbage_profile(void);
+
+void _report_gc_started(void);
+void _report_gc_finished(uint64_t pause, uint64_t freed, uint64_t allocd);
+void _record_allocated_value(jl_value_t *val);
+void _record_freed_value(jl_taggedvalue_t *tagged_val);
+
+// ---------------------------------------------------------------------
+// functions to call from GC when garbage profiling is enabled
+// ---------------------------------------------------------------------
+
+extern ios_t *garbage_profile_out; // TODO: replace w/ bool?
+
+static inline void record_allocated_value(jl_value_t *val) {
+    if (__unlikely(garbage_profile_out != 0)) {
+        _record_allocated_value(val);
+    }
+}
+
+static inline void record_freed_value(jl_taggedvalue_t *tagged_val) {
+    if (__unlikely(garbage_profile_out != 0)) {
+        _record_freed_value(tagged_val);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif  // JL_GC_GARBAGE_PROFILER_H

--- a/src/gc.c
+++ b/src/gc.c
@@ -3199,7 +3199,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     uint64_t gc_end_t = jl_hrtime();
     uint64_t pause = gc_end_t - t0;
 
-    _report_gc_finished(pause, gc_num.freed, gc_num.allocd);
+    _report_gc_finished(collection, pause, gc_num.freed, gc_num.allocd);
 
     gc_final_pause_end(t0, gc_end_t);
     gc_time_sweep_pause(gc_end_t, actual_allocd, live_bytes,

--- a/src/gc.h
+++ b/src/gc.h
@@ -26,6 +26,7 @@
 #endif
 #endif
 #include "julia_assert.h"
+#include "gc-garbage-profiler.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -365,6 +365,9 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
         v = jl_gc_big_alloc(ptls, allocsz);
     }
     jl_set_typeof(v, ty);
+
+    record_allocated_value(v);
+
     return v;
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -5,6 +5,7 @@
 
 #include "options.h"
 #include "julia_locks.h"
+#include "gc-garbage-profiler.h"
 #include <uv.h>
 #if !defined(_WIN32)
 #include <unistd.h>


### PR DESCRIPTION
Ever seen a `@time` printout like this:
```
5091.986425 seconds (5.59 G allocations: 324.011 GiB, 57.83% gc time, 5.70% compilation time)
```
…and wondered what the types are of all those objects which are being allocated and collected? This PR is for you…

It generates a report of how many objects of each type are being freed during each garbage collection.

## Usage

```julia
file = open("gc-profile.csv", "w")
GC.start_garbage_profile(file)

# ... the code you want to profile ...

GC.stop_garbage_profile()
flush(file) # TODO: figure out how to do this from C...
```

## Output

A CSV file with these columns:
* `gc_epoch`: an integer that starts at 0 and increases each time the garbage collector runs
* `type`: type of julia object being freed
* `num_freed` number of that type freed during that GC epoch

e.g.:
```csv
gc_epoch,type,num_freed
1,Foo,5
1,Bar,6
2,Foo,3
2,Bar,2
```

Output is streamed to this file as the program runs.

To aggregate this over all GC epochs, I've been using [`csvsql`](https://csvkit.readthedocs.io/en/latest/scripts/csvsql.html) to run do a group by:

```sh
$ csvsql --query 'select type, sum(num_freed) from "gc-profile" group by type order by sum(num_freed) desc' gc-profile.csv > gc-profile-agg.csv
```

## Notes

- mimics the callback approach of https://github.com/JuliaLang/julia/pull/42286

## issues / improvements
- [ ] is this threadsafe? i.e. can the allocator be called into from multiple threads, which might lead to mutating the hash map concurrently?
- [x] put a timestamp on each log line
- [x] put GC type (full vs. incremental) on each log line
- [ ] enable logging & profiling with one function call? can be defined in Julia

## Future work

- get stack traces of allocations (especially useful to attribute generic types like `Array{UInt8, 1}`)
- maybe output as PProf memory profile format, like in this article (scroll down to see graphviz output): https://www.freecodecamp.org/news/how-i-investigated-memory-leaks-in-go-using-pprof-on-a-large-codebase-4bec4325e192/