### PR TITLE
explicitly propagate displaysize in sprint

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -108,6 +108,9 @@ function sprint(f::Function, args...; context=nothing, sizehint::Integer=0)
     s = IOBuffer(sizehint=sizehint)
     if context isa Tuple
         f(IOContext(s, context...), args...)
+    elseif context isa IO
+        # Add an explicit displaysize entry, see #42649
+        f(IOContext(IOContext(s, context), :displaysize=>displaysize(context)), args...)
     elseif context !== nothing
         f(IOContext(s, context), args...)
     else


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/42649, closes #34721

```jl
julia> displaysize(stdout)
(20, 68)

julia> displaysize(IOContext(stdout))
(20, 68)

julia> sprint(; context=stdout) do io
           print(io, displaysize(io))
       end
"(20, 68)"
```

This also fixes a bug in Pkg where the progress bar has support for shrinking its size when the terminal gets too narrow, but `Pkg.precompile` uses `sprint` so it doesn't work there.

It is a bit unclear where to add a test for this...