### PR TITLE
Fix #42670 - error in sparsevec outer product with stored zeros

### DIFF
--- a/stdlib/SparseArrays/src/higherorderfns.jl
+++ b/stdlib/SparseArrays/src/higherorderfns.jl
@@ -840,13 +840,19 @@ function _outer(trans::Tf, x, y) where Tf
     @inbounds colptrC[1] = 1
     @inbounds for jj = 1:nnzy
         yval = nzvalsy[jj]
-        iszero(yval) && continue
+        if iszero(yval)
+            nnzC -= nnzx
+            continue
+        end
         col = rowvaly[jj]
         yval = trans(yval)
 
         for ii = 1:nnzx
             xval = nzvalsx[ii]
-            iszero(xval) && continue
+            if iszero(xval)
+                nnzC -= 1
+                continue
+            end
             idx += 1
             colptrC[col+1] += 1
             rowvalC[idx] = rowvalx[ii]
@@ -854,6 +860,8 @@ function _outer(trans::Tf, x, y) where Tf
         end
     end
     cumsum!(colptrC, colptrC)
+    resize!(rowvalC, nnzC)
+    resize!(nzvalsC, nnzC)
 
     return SparseMatrixCSC(nx, ny, colptrC, rowvalC, nzvalsC)
 end

--- a/stdlib/SparseArrays/test/higherorderfns.jl
+++ b/stdlib/SparseArrays/test/higherorderfns.jl
@@ -726,4 +726,13 @@ end
     @test extrema(x; dims=[]) == extrema(y; dims=[])
 end
 
+@testset "issue #42670 - error in sparsevec outer product" begin
+    A = spzeros(Int, 4)
+    B = copy(A)
+    C = sparsevec([0 0 1 1 0 0])'
+    A[2] = 1
+    A[2] = 0
+    @test A * C == B * C == spzeros(Int, 4, 6)
+end
+
 end # module


### PR DESCRIPTION
The SparseMatrixCSC constructor checks that the passed in buffers
have length matching the expected number of non-zeros, but the
_outer constructor allocated buffers of the number of structural
non-zeros, not actual non-zeros. Fix this by shrinking the buffers
once the outer product is fully computed.

Fixes #42670.