### PR TITLE
Fix sort! for multidimensional non 1-indexed arrays

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1098,7 +1098,7 @@ function sort!(A::AbstractArray;
 
     1 <= k <= nd || throw(ArgumentError("dimension out of range"))
 
-    remdims = ntuple(i -> i == k ? 1 : size(A, i), nd)
+    remdims = ntuple(i -> i == k ? 1 : axes(A, i), nd)
     for idx in CartesianIndices(remdims)
         Av = view(A, ntuple(i -> i == k ? Colon() : idx[i], nd)...)
         sort!(Av, alg, ordr)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -664,4 +664,12 @@ end
     @test issorted(a)
 end
 
+@testset "sort!(::OffsetMatrix; dims)" begin
+    x = OffsetMatrix(rand(5,5), 5, -5)
+    sort!(x; dims=1)
+    for i in axes(x, 2)
+        @test issorted(x[:,i])
+    end
+end
+
 end


### PR DESCRIPTION
This fixes
```julia
x = OffsetMatrix(rand(5,5), 5, -5)
sort!(x; dims=1)
```

I couldn't find tests anywhere in `test/sorting.jl` for sorting matrices (though the code is covered by doctests) so I tacked the new test on at the end.