### PR TITLE
Fix `revise` option of `Base.runtests`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -570,7 +570,12 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
     seed !== nothing && push!(tests, "--seed=0x$(string(seed % UInt128, base=16))") # cast to UInt128 to avoid a minus sign
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
-    ENV2["JULIA_DEPOT_PATH"] = join([mktempdir(; cleanup = true); DEPOT_PATH], @static Sys.iswindows() ? ";" : ":")
+    tempdepot = mktempdir(; cleanup = true)
+    if revise
+        ENV2["JULIA_DEPOT_PATH"] = join([tempdepot; DEPOT_PATH], @static Sys.iswindows() ? ";" : ":")
+    else
+        ENV2["JULIA_DEPOT_PATH"] = tempdepot
+    end
     try
         run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR::String,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))

--- a/base/util.jl
+++ b/base/util.jl
@@ -572,7 +572,12 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
     tempdepot = mktempdir(; cleanup = true)
     if revise
-        ENV2["JULIA_DEPOT_PATH"] = join([tempdepot; DEPOT_PATH], @static Sys.iswindows() ? ";" : ":")
+        @static if Sys.iswindows()
+            path_env_sep = ";"
+        else
+            path_env_sep = ":"
+        end
+        ENV2["JULIA_DEPOT_PATH"] = join([tempdepot; DEPOT_PATH], path_env_sep)
     else
         ENV2["JULIA_DEPOT_PATH"] = tempdepot
     end

--- a/base/util.jl
+++ b/base/util.jl
@@ -570,7 +570,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
     seed !== nothing && push!(tests, "--seed=0x$(string(seed % UInt128, base=16))") # cast to UInt128 to avoid a minus sign
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
-    ENV2["JULIA_DEPOT_PATH"] = mktempdir(; cleanup = true)
+    ENV2["JULIA_DEPOT_PATH"] = join([mktempdir(; cleanup = true); DEPOT_PATH], @static Sys.iswindows() ? ";" : ":")
     try
         run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR::String,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/42358 broke the `revise=true` option of `Base.runtests`, since it replaces the depot path list by a temporary directory, so there is no depot from which `Revise` can be installed:
```
(@v1.8) pkg> st
Status `~/.julia/environments/v1.8/Project.toml`
  [6e4b80f9] BenchmarkTools v1.2.0
  [33e6dc65] MKL v0.4.2
  [295af30f] Revise v3.1.20

julia> Base.runtests("ranges", revise=true)
ERROR: LoadError: ArgumentError: Package Revise not found in current path.
- Run `import Pkg; Pkg.add("Revise")` to install the Revise package.
```
This PR instead prepends the temporary directory to the `DEPOT_PATH` list.

I’m not sure how to add tests for this.