### PR TITLE
call `reverse(o::Base.Ordering)` to reverse ordering specified by `o`

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -6,7 +6,7 @@ module Order
 import ..@__MODULE__, ..parentmodule
 const Base = parentmodule(@__MODULE__)
 import .Base:
-    AbstractVector, @propagate_inbounds, isless, identity, getindex,
+    AbstractVector, @propagate_inbounds, isless, identity, getindex, reverse,
     +, -, !, &, <, |
 
 ## notions of element ordering ##
@@ -45,6 +45,14 @@ end
 ReverseOrdering(rev::ReverseOrdering) = rev.fwd
 ReverseOrdering(fwd::Fwd) where {Fwd} = ReverseOrdering{Fwd}(fwd)
 ReverseOrdering() = ReverseOrdering(ForwardOrdering())
+
+"""
+    reverse(o::Base.Ordering)
+
+reverses ordering specified by `o`.
+
+"""
+reverse(o::Ordering) = ReverseOrdering(o)
 
 const DirectOrdering = Union{ForwardOrdering,ReverseOrdering{ForwardOrdering}}
 

--- a/test/ordering.jl
+++ b/test/ordering.jl
@@ -38,3 +38,5 @@ struct SomeOtherOrder <: Base.Order.Ordering end
 
 @test_throws ErrorException sort([1, 2, 3], lt=(a, b) -> a - b < 0, order=SomeOtherOrder())
 
+@test reverse(Forward) === Reverse
+@test reverse(Reverse) === Forward


### PR DESCRIPTION
The simple simple change may be useful.