### PR TITLE
fix exp of large negative Float16

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -304,9 +304,9 @@ end
     N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogB(base, Float16), x)
     small_part = expb_kernel(base, r)
-    if !(abs(x) <= SUBNORM_EXP(base, T))
-        x > MAX_EXP(base, T) && return Inf16
-        x < MIN_EXP(base, T) && return zero(Float16)
+    if !(abs(x) <= 25)
+        x > 16 && return Inf16
+        x < 25 && return zero(Float16)
     end
     twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
     return Float16(twopk*small_part)

--- a/test/math.jl
+++ b/test/math.jl
@@ -316,7 +316,8 @@ end
             X = Iterators.flatten((minval:T(.1):maxval,
                                    minval/100:T(.0021):maxval/100,
                                    minval/10000:T(.000021):maxval/10000,
-                                   nextfloat(zero(T)) ))
+                                   nextfloat(zero(T)),
+                                   T(-100):T(1):T(100) ))
             for x in X
                 y, yb = func(x), func(widen(x))
                 @test abs(y-yb) <= 1.2*eps(T(yb))

--- a/test/math.jl
+++ b/test/math.jl
@@ -320,7 +320,9 @@ end
                                    T(-100):T(1):T(100) ))
             for x in X
                 y, yb = func(x), func(widen(x))
-                @test abs(y-yb) <= 1.2*eps(T(yb))
+                if T(y-yb) !== T(NaN)
+                    @test abs(y-yb) <= 1.2*eps(T(yb))
+                end
             end
         end
         @testset "$T $func edge cases" begin

--- a/test/math.jl
+++ b/test/math.jl
@@ -320,7 +320,7 @@ end
                                    T(-100):T(1):T(100) ))
             for x in X
                 y, yb = func(x), func(widen(x))
-                if T(y-yb) !== T(NaN)
+                if isfinite(eps(T(yb)))
                     @test abs(y-yb) <= 1.2*eps(T(yb))
                 end
             end


### PR DESCRIPTION
While fixing https://github.com/JuliaLang/julia/pull/42555, I broke `exp(Float16(-100))`. TLDR is that with the change there, we weren't always correctly hitting the branch to return 0 when we should have. This time I promise I've actually tested `exp2` `exp` and `exp10` on my computer on all Float16 values before making the PR.