### PR TITLE
add `Base.length(::SkipMissing)` for `AbstractArray`

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -235,6 +235,8 @@ IteratorSize(::Type{<:SkipMissing}) = SizeUnknown()
 IteratorEltype(::Type{SkipMissing{T}}) where {T} = IteratorEltype(T)
 eltype(::Type{SkipMissing{T}}) where {T} = nonmissingtype(eltype(T))
 
+length(s::SkipMissing) = count(!ismissing, s.x)
+
 function iterate(itr::SkipMissing, state...)
     y = iterate(itr.x, state...)
     y === nothing && return nothing

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -235,7 +235,7 @@ IteratorSize(::Type{<:SkipMissing}) = SizeUnknown()
 IteratorEltype(::Type{SkipMissing{T}}) where {T} = IteratorEltype(T)
 eltype(::Type{SkipMissing{T}}) where {T} = nonmissingtype(eltype(T))
 
-length(s::SkipMissing) = count(!ismissing, s.x)
+length(s::SkipMissing{T}) where T <: AbstractArray = count(!ismissing, s.x)
 
 function iterate(itr::SkipMissing, state...)
     y = iterate(itr.x, state...)

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -442,6 +442,17 @@ end
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
 
+    @testset "length" begin
+        allmiss = Vector{Union{Int,Missing}}(missing, 10)
+        @test (length∘skipmissing)(allmiss) == 0
+
+        somemiss = [1, missing, 2, 3, 4, missing, 5, 6, 7, 8, 9, 10]
+        @test (length∘skipmissing)(somemiss) == 10
+
+        nomiss = rand(1:10, 10)
+        @test (length∘skipmissing)(nomiss) == 10
+    end
+
     @testset "indexing" begin
         x = skipmissing([1, missing, 2, missing, missing])
         @test collect(eachindex(x)) == collect(keys(x)) == [1, 3]

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -451,6 +451,9 @@ end
 
         nomiss = rand(1:10, 10)
         @test (length∘skipmissing)(nomiss) == 10
+
+        itr = Iterators.Stateful([missing, 1, missing, 1])
+        @test_throws MethodError (length∘skipmissing)(itr)
     end
 
     @testset "indexing" begin


### PR DESCRIPTION
Add `Base.length` definition for `SkipMissing`.

Resolves #42672.

Before this change:
```julia
julia> x = [missing, 1, missing];

julia> (length∘skipmissing)(x)
ERROR: MethodError: no method matching length(::Base.SkipMissing{Vector{Union{Missing, Int64}}})
```

With this change:
```julia
julia> x = [missing, 1, missing];

julia> (length∘skipmissing)(x)
1
```