### PR TITLE
Tweak bounds check elimination

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -148,8 +148,7 @@ function vect(X...)
 end
 
 size(a::Array, d::Integer) = arraysize(a, convert(Int, d))
-size(a::Vector) = (arraylen(a),)
-# size(a::Vector) = (arraysize(a,1),)
+size(a::Vector) = (arraylen(a),) # arraylen is equivalent, but slightly nicer, to `arraysize(a, 1)`
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))
 size(a::Array{<:Any,N}) where {N} = (@inline; ntuple(M -> size(a, M), Val(N))::Dims)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -148,7 +148,7 @@ function vect(X...)
 end
 
 size(a::Array, d::Integer) = arraysize(a, convert(Int, d))
-size(a::Vector) = (arraylen(a),) # arraylen is equivalent, but slightly nicer, to `arraysize(a, 1)`
+size(a::Vector) = (arraysize(a,1),)
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))
 size(a::Array{<:Any,N}) where {N} = (@inline; ntuple(M -> size(a, M), Val(N))::Dims)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -148,7 +148,8 @@ function vect(X...)
 end
 
 size(a::Array, d::Integer) = arraysize(a, convert(Int, d))
-size(a::Vector) = (arraysize(a,1),)
+size(a::Vector) = (arraylen(a),)
+# size(a::Vector) = (arraysize(a,1),)
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))
 size(a::Array{<:Any,N}) where {N} = (@inline; ntuple(M -> size(a, M), Val(N))::Dims)
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -742,6 +742,11 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createGVNPass());
     PM->add(createMemCpyOptPass());
     PM->add(createSCCPPass());
+
+    //These next two passes must come before IRCE to eliminate the bounds check in #43308
+    PM->add(createCorrelatedValuePropagationPass());
+    PM->add(createDeadCodeEliminationPass());
+
     PM->add(createInductiveRangeCheckEliminationPass()); // Must come between the two GVN passes
 
     // Run instcombine after redundancy elimination to exploit opportunities
@@ -753,7 +758,6 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     if (opt_level >= 3) {
         PM->add(createGVNPass()); // Must come after JumpThreading and before LoopVectorize
     }
-    PM->add(createCorrelatedValuePropagationPass());
     PM->add(createDeadStoreEliminationPass());
 
     // More dead allocation (store) deletion before loop optimization

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -724,6 +724,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createLoopUnswitchPass());
     PM->add(createLICMPass());
     PM->add(createJuliaLICMPass());
+    PM->add(createInductiveRangeCheckEliminationPass()); // Must come before indvars
     // Subsequent passes not stripping metadata from terminator
     PM->add(createInstSimplifyLegacyPass());
     PM->add(createIndVarSimplifyPass());

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -597,8 +597,6 @@ void addMachinePasses(legacy::PassManagerBase *PM, TargetMachine *TM, int optlev
         PM->add(createGVNPass());
 }
 
-
-
 // this defines the set of optimization passes defined for Julia at various optimization levels.
 // it assumes that the TLI and TTI wrapper passes have already been added.
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
@@ -726,7 +724,6 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createLoopUnswitchPass());
     PM->add(createLICMPass());
     PM->add(createJuliaLICMPass());
-    PM->add(createInductiveRangeCheckEliminationPass());
     // Subsequent passes not stripping metadata from terminator
     PM->add(createInstSimplifyLegacyPass());
     PM->add(createIndVarSimplifyPass());
@@ -744,6 +741,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createGVNPass());
     PM->add(createMemCpyOptPass());
     PM->add(createSCCPPass());
+    PM->add(createInductiveRangeCheckEliminationPass()); // Must come between the two GVN passes
 
     // Run instcombine after redundancy elimination to exploit opportunities
     // opened up by them.
@@ -751,6 +749,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     // loops over Union-typed arrays to vectorize.
     PM->add(createInstructionCombiningPass());
     PM->add(createJumpThreadingPass());
+    PM->add(createGVNPass()); // Must come after JumpThreading and before LoopVectorize
     PM->add(createCorrelatedValuePropagationPass());
     PM->add(createDeadStoreEliminationPass());
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -750,7 +750,9 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     // loops over Union-typed arrays to vectorize.
     PM->add(createInstructionCombiningPass());
     PM->add(createJumpThreadingPass());
-    PM->add(createGVNPass()); // Must come after JumpThreading and before LoopVectorize
+    if (opt_level >= 3) {
+        PM->add(createGVNPass()); // Must come after JumpThreading and before LoopVectorize
+    }
     PM->add(createCorrelatedValuePropagationPass());
     PM->add(createDeadStoreEliminationPass());
 


### PR DESCRIPTION
This is a combination of two changes:
1. Move the IRCE pass further down the pass pipeline and add an extra GVN pass
   1. This allows some additional functions to become vectorizable without an inbounds macro.
2. Change size(Vector) to delegate to arraylen instead of arraysize
   1. This converts `gep inbounds {}*, {}**` instructions to instead use `gep inbounds { i8*, i64, i16, i16, i32 }, { i8*, i64, i16, i16, i32 }*` to get the array length. 
   2. Without this, LLVM does not see that the two geps are equivalent, and therefore fails to eliminate one of the loads. This has implications on whether or not some functions vectorize as well as overall code size (a useless loop in`Statistics._mean(identity, Int[], :)` was completely eliminated after this change). 