### PR TITLE
[TOML stdlib] Copy the latest version of the code from the `JuliaLang/TOML.jl` repository

### DIFF
--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -242,7 +242,7 @@ const err_message = Dict(
     ErrExpectedEqualAfterKey                => "expected equal sign after key",
     ErrNoTrailingDigitAfterDot              => "expected digit after dot",
     ErrOverflowError                        => "overflowed when parsing integer",
-    ErrInvalidUnicodeScalar                 => "invalid unicode scalar",
+    ErrInvalidUnicodeScalar                 => "invalid Unicode scalar",
     ErrInvalidEscapeCharacter               => "invalid escape character",
     ErrUnexpectedEofExpectedValue           => "unexpected end of file, expected a value"
 )
@@ -484,7 +484,6 @@ end
 
 function recurse_dict!(l::Parser, d::Dict, dotted_keys::AbstractVector{String}, check=true)::Err{TOMLDict}
     for i in 1:length(dotted_keys)
-        d = d::TOMLDict
         key = dotted_keys[i]
         d = get!(TOMLDict, d, key)
         if d isa Vector
@@ -933,21 +932,21 @@ ok_end_value(c::Char) = iswhitespace(c) || c == '#' || c == EOF_CHAR || c == ']'
 accept_two(l, f::F) where {F} = accept_n(l, 2, f) || return(ParserError(ErrParsingDateTime))
 function parse_datetime(l)
     # Year has already been eaten when we reach here
-    year = @try parse_int(l, false)
+    year = parse_int(l, false)::Int64
     year in 0:9999 || return ParserError(ErrParsingDateTime)
 
     # Month
     accept(l, '-') || return ParserError(ErrParsingDateTime)
     set_marker!(l)
     @try accept_two(l, isdigit)
-    month = @try parse_int(l, false)
+    month = parse_int(l, false)
     month in 1:12 || return ParserError(ErrParsingDateTime)
     accept(l, '-') || return ParserError(ErrParsingDateTime)
 
     # Day
     set_marker!(l)
     @try accept_two(l, isdigit)
-    day = @try parse_int(l, false)
+    day = parse_int(l, false)
     # Verify the real range in the constructor below
     day in 1:31 || return ParserError(ErrParsingDateTime)
 
@@ -984,10 +983,9 @@ function parse_datetime(l)
 end
 
 function try_return_datetime(p, year, month, day, h, m, s, ms)
-    Dates = p.Dates
-    if Dates !== nothing
+    if p.Dates !== nothing
         try
-            return Dates.DateTime(year, month, day, h, m, s, ms)
+            return p.Dates.DateTime(year, month, day, h, m, s, ms)
         catch
             return ParserError(ErrParsingDateTime)
         end
@@ -997,10 +995,9 @@ function try_return_datetime(p, year, month, day, h, m, s, ms)
 end
 
 function try_return_date(p, year, month, day)
-    Dates = p.Dates
-    if Dates !== nothing
+    if p.Dates !== nothing
         try
-            return Dates.Date(year, month, day)
+            return p.Dates.Date(year, month, day)
         catch
             return ParserError(ErrParsingDateTime)
         end
@@ -1010,7 +1007,7 @@ function try_return_date(p, year, month, day)
 end
 
 function parse_local_time(l::Parser)
-    h = @try parse_int(l, false)
+    h = parse_int(l, false)
     h in 0:23 || return ParserError(ErrParsingDateTime)
     _, m, s, ms = @try _parse_local_time(l, true)
     # TODO: Could potentially parse greater accuracy for the
@@ -1019,10 +1016,9 @@ function parse_local_time(l::Parser)
 end
 
 function try_return_time(p, h, m, s, ms)
-    Dates = p.Dates
-    if Dates !== nothing
+    if p.Dates !== nothing
         try
-            return Dates.Time(h, m, s, ms)
+            return p.Dates.Time(h, m, s, ms)
         catch
             return ParserError(ErrParsingDateTime)
         end
@@ -1181,4 +1177,4 @@ function take_chunks(l::Parser, unescape::Bool)::String
     return unescape ? unescape_string(str) : str
 end
 
-end
+end # module TOML

--- a/stdlib/TOML/docs/Manifest.toml
+++ b/stdlib/TOML/docs/Manifest.toml
@@ -1,5 +1,11 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -7,21 +13,27 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "c5714d9bcdba66389612dc4c47ed827c64112997"
+git-tree-sha1 = "9d4f64f79012636741cf01133158a54b24924c32"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.2"
+version = "0.8.4"
 
 [[Documenter]]
-deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "1c593d1efa27437ed9dd365d1143c594b563e138"
+deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "3ebb967819b284dc1e3c0422229b58a40a255649"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.25.1"
+version = "0.26.3"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[IOCapture]]
+deps = ["Logging"]
+git-tree-sha1 = "377252859f740c217b936cebcd918a44f9b53b59"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.1.1"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -29,12 +41,25 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.0"
+version = "0.21.1"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
 [[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -46,17 +71,27 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
 [[Parsers]]
-deps = ["Dates", "Test"]
-git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
+deps = ["Dates"]
+git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.10"
+version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -64,7 +99,7 @@ deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
@@ -84,10 +119,13 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 deps = ["Dates"]
 path = ".."
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "0.1.0"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[UUIDs]]
@@ -96,3 +134,15 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/stdlib/TOML/docs/make.jl
+++ b/stdlib/TOML/docs/make.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 using Documenter
 import TOML
 
@@ -13,4 +11,4 @@ makedocs(
         ]
     )
 
-deploydocs(repo = "github.com/KristofferC/TOML.jl.git")
+deploydocs(repo = "github.com/JuliaLang/TOML.jl.git")

--- a/stdlib/TOML/docs/src/index.md
+++ b/stdlib/TOML/docs/src/index.md
@@ -36,7 +36,7 @@ none:1:16 error: failed to parse value
 ```
 
 There are other versions of the parse functions ([`TOML.tryparse`](@ref)
-and [`TOML.tryparsefile`]) that instead of throwing exceptions on parser error
+and [`TOML.tryparsefile`](@ref) that instead of throwing exceptions on parser error
 returns a [`TOML.ParserError`](@ref) with information:
 
 ```jldoctest
@@ -78,7 +78,7 @@ julia> fname = tempname();
 
 julia> open(fname, "w") do io
            TOML.print(io, data)
-       end
+        end
 
 julia> TOML.parsefile(fname)
 Dict{String, Any} with 2 entries:

--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -3,22 +3,23 @@
 module TOML
 
 module Internals
+
     # The parser is defined in Base
     using Base.TOML: Parser, parse, tryparse, ParserError, isvalid_barekey_char, reinit!
+
     # Put the error instances in this module
     for errtype in instances(Base.TOML.ErrorType)
         @eval using Base.TOML: $(Symbol(errtype))
     end
+
     # We put the printing functionality in a separate module since It
     # defines a function `print` and we don't want that to collide with normal
     # usage of `(Base.)print` in other files
     module Printer
         include("print.jl")
-    end
-end
+    end # module TOML.Internals.Printer
 
-# https://github.com/JuliaLang/julia/issues/36605
-readstring(f::AbstractString) = isfile(f) ? read(f, String) : error(repr(f), ": No such file")
+end # module TOML.Internals
 
 """
     Parser()
@@ -38,12 +39,12 @@ const Parser = Internals.Parser
 Parse file `f` and return the resulting table (dictionary). Throw a
 [`ParserError`](@ref) upon failure.
 
-See also [`TOML.tryparsefile`](@ref).
+See also: [`TOML.tryparsefile`](@ref)
 """
 parsefile(f::AbstractString) =
-    Internals.parse(Parser(readstring(f); filepath=abspath(f)))
+    Internals.parse(Parser(read(f, String); filepath=abspath(f)))
 parsefile(p::Parser, f::AbstractString) =
-    Internals.parse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
+    Internals.parse(Internals.reinit!(p, read(f, String); filepath=abspath(f)))
 
 """
     tryparsefile(f::AbstractString)
@@ -52,12 +53,12 @@ parsefile(p::Parser, f::AbstractString) =
 Parse file `f` and return the resulting table (dictionary). Return a
 [`ParserError`](@ref) upon failure.
 
-See also [`TOML.parsefile`](@ref).
+See also: [`TOML.parsefile`](@ref)
 """
 tryparsefile(f::AbstractString) =
-    Internals.tryparse(Parser(readstring(f); filepath=abspath(f)))
+    Internals.tryparse(Parser(read(f, String); filepath=abspath(f)))
 tryparsefile(p::Parser, f::AbstractString) =
-    Internals.tryparse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
+    Internals.tryparse(Internals.reinit!(p, read(f, String); filepath=abspath(f)))
 
 """
     parse(x::Union{AbstractString, IO})
@@ -66,7 +67,7 @@ tryparsefile(p::Parser, f::AbstractString) =
 Parse the string  or stream `x`, and return the resulting table (dictionary).
 Throw a [`ParserError`](@ref) upon failure.
 
-See also [`TOML.tryparse`](@ref).
+See also: [`TOML.tryparse`](@ref)
 """
 parse(str::AbstractString) =
     Internals.parse(Parser(String(str)))
@@ -82,7 +83,7 @@ parse(p::Parser, io::IO) = parse(p, read(io, String))
 Parse the string or stream `x`, and return the resulting table (dictionary).
 Return a [`ParserError`](@ref) upon failure.
 
-See also [`TOML.parse`](@ref).
+See also: [`TOML.parse`](@ref)
 """
 tryparse(str::AbstractString) =
     Internals.tryparse(Parser(String(str)))
@@ -105,10 +106,11 @@ const ParserError = Internals.ParserError
 
 
 """
-    print([to_toml::Function], io::IO [=stdout], data::AbstractDict; sorted=false, by=identity)
+    print([to_toml::Function], io::IO [=stdout], data::AbstractDict; sort=false, by=identity)
 
-Write `data` as TOML syntax to the stream `io`. If the keyword argument `sorted` is set to `true`,
-sort tables according to the function given by the keyword argument `by`.
+Writes `data` as TOML syntax to the stream `io`. The keyword argument `sort`
+sorts the output on the keys of the tables with the top level tables are
+sorted according to the keyword argument `by`.
 
 The following data types are supported: `AbstractDict`, `Integer`, `AbstractFloat`, `Bool`,
 `Dates.DateTime`, `Dates.Time`, `Dates.Date`. Note that the integers and floats
@@ -118,4 +120,4 @@ supported type.
 """
 const print = Internals.Printer.print
 
-end
+end # module TOML

--- a/stdlib/TOML/test/.gitattributes
+++ b/stdlib/TOML/test/.gitattributes
@@ -1,0 +1,1 @@
+*.toml  -text

--- a/stdlib/TOML/test/error_printing.jl
+++ b/stdlib/TOML/test/error_printing.jl
@@ -1,11 +1,13 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 using Test
 import TOML: tryparsefile
 
 # These tests need to be updated if the error strings change
 
 tmp = tempname()
+
+if !isdefined(Base, :contains)
+    contains(x, y) = occursin(y, x)
+end
 
 @testset "error printing" begin
 

--- a/stdlib/TOML/test/invalids.jl
+++ b/stdlib/TOML/test/invalids.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 @testset "errors" begin
 
 str = """

--- a/stdlib/TOML/test/parse.jl
+++ b/stdlib/TOML/test/parse.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 using TOML, Test
 using TOML: ParserError
 
@@ -38,8 +36,6 @@ using TOML: ParserError
     @test_throws ParserError TOML.parsefile(SubString(invalid_path))
     @test_throws ParserError TOML.parsefile(p, invalid_path)
     @test_throws ParserError TOML.parsefile(p, SubString(invalid_path))
-    @test_throws ErrorException TOML.parsefile(homedir())
-    @test_throws ErrorException TOML.parsefile(p, homedir())
     # TOML.tryparsefile
     @test TOML.tryparsefile(path) == TOML.tryparsefile(SubString(path)) ==
           TOML.tryparsefile(p, path) == TOML.tryparsefile(p, SubString(path)) == dict
@@ -47,6 +43,4 @@ using TOML: ParserError
     @test TOML.tryparsefile(SubString(invalid_path)) isa ParserError
     @test TOML.tryparsefile(p, invalid_path) isa ParserError
     @test TOML.tryparsefile(p, SubString(invalid_path)) isa ParserError
-    @test_throws ErrorException TOML.tryparsefile(homedir())
-    @test_throws ErrorException TOML.tryparsefile(p, homedir())
 end

--- a/stdlib/TOML/test/print.jl
+++ b/stdlib/TOML/test/print.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 toml_str(a; kwargs...) = sprint(io -> TOML.print(io, a; kwargs...))
 toml_str(f, a; kwargs...) = sprint(io -> TOML.print(f, io, a; kwargs...))
 
@@ -69,5 +67,5 @@ end
     @test roundtrip(s)
 
     d = Dict("str" => string(Char(0xd800)))
-    @test_throws ErrorException TOML.print(devnull, d)
+    @test_throws ErrorException TOML.print(Base.devnull, d)
 end

--- a/stdlib/TOML/test/readme.jl
+++ b/stdlib/TOML/test/readme.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 # This test stuff in the TOML README at https://github.com/toml-lang/toml
 @testset "README" begin
 

--- a/stdlib/TOML/test/runtests.jl
+++ b/stdlib/TOML/test/runtests.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 using Test
 using Dates
 

--- a/stdlib/TOML/test/toml_test.jl
+++ b/stdlib/TOML/test/toml_test.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 using TOML
 
 using Test
@@ -9,7 +7,10 @@ const jsnval = Dict{String,Function}(
     "string" =>identity,
     "float"    => (s -> Base.parse(Float64, s)),
     "integer"  => (s -> Base.parse(Int64, s)),
-    "datetime" => (s -> Base.parse(DateTime, s, dateformat"yyyy-mm-ddTHH:MM:SSZ")),
+    "datetime" => (s -> Base.parse(DateTime, endswith(s, 'Z') ? chop(s) : s)),
+    "datetime-local" => (s -> Base.parse(DateTime, endswith(s, 'Z') ? chop(s) : s)),
+    "date-local" => (s -> Base.parse(DateTime, endswith(s, 'Z') ? chop(s) : s)),
+    "time-local" => (s -> Base.parse(Time, s)),
     "array"    => (a -> map(jsn2data, a)),
     "bool"     => (b -> b == "true")
 )
@@ -29,163 +30,118 @@ end
 # Valid #
 #########
 
-valid_test_folder = joinpath(@__DIR__, "testfiles", "valid")
-
 function check_valid(f)
-    fp = joinpath(valid_test_folder, f)
-    jsn = jsn2data(@eval include($fp * ".jl"))
-    tml = TOML.parsefile(fp * ".toml")
+    jsn = try jsn2data(@eval include($f * ".jl"))
+    # Some files cannot be reprsented with julias DateTime (timezones)
+    catch
+        return false
+    end
+    tml = TOML.tryparsefile(f * ".toml")
+    tml isa TOML.Internals.ParserError && return false
     return isequal(tml, jsn)
 end
 
 @testset "valid" begin
 
-@test check_valid("array-empty")
-@test check_valid("array-nospaces")
-@test check_valid("array-string-quote-comma-2")
-@test check_valid("array-string-quote-comma")
-@test check_valid("array-string-with-comma")
-@test check_valid("array-table-array-string-backslash")
-@test check_valid("arrays-hetergeneous")
-@test check_valid("arrays-nested")
-@test check_valid("arrays")
-@test check_valid("bool")
-@test check_valid("comments-at-eof")
-@test check_valid("comments-at-eof2")
-@test check_valid("comments-everywhere")
-@test_broken check_valid("datetime-timezone")
-@test_broken check_valid("datetime")
-@test check_valid("double-quote-escape")
-@test check_valid("empty")
-@test check_valid("escaped-escape")
-@test check_valid("example")
-@test check_valid("exponent-part-float")
-@test check_valid("float-exponent")
-@test check_valid("float-underscore")
-@test check_valid("float")
-@test check_valid("implicit-and-explicit-after")
-@test check_valid("implicit-and-explicit-before")
-@test check_valid("implicit-groups")
-@test check_valid("inline-table-array")
-@test check_valid("inline-table")
-@test check_valid("integer-underscore")
-@test check_valid("integer")
-@test check_valid("key-equals-nospace")
-@test check_valid("key-numeric")
-@test check_valid("key-space")
-@test check_valid("key-special-chars")
-@test check_valid("keys-with-dots")
-@test check_valid("long-float")
-@test check_valid("long-integer")
-@test check_valid("multiline-string")
-@test check_valid("nested-inline-table-array")
-@test check_valid("newline-crlf")
-@test check_valid("newline-lf")
-if Sys.iswindows() &&
-    # Sometimes git normalizes the line endings
-    contains(read(joinpath(valid_test_folder, "raw-multiline-string-win.toml"), String), '\r')
-    @test check_valid("raw-multiline-string-win")
-else
-    @test check_valid("raw-multiline-string")
-end
-@test check_valid("raw-string")
-@test check_valid("right-curly-brace-after-boolean")
-@test check_valid("string-empty")
-@test check_valid("string-escapes")
-@test check_valid("string-nl")
-@test check_valid("string-simple")
-@test check_valid("string-with-pound")
-@test check_valid("table-array-implicit")
-@test check_valid("table-array-many")
-@test check_valid("table-array-nest")
-@test check_valid("table-array-one")
-@test check_valid("table-array-table-array")
-@test check_valid("table-empty")
-@test check_valid("table-no-eol")
-@test check_valid("table-sub-empty")
-@test check_valid("table-whitespace")
-@test check_valid("table-with-literal-string")
-@test check_valid("table-with-pound")
-@test check_valid("table-with-single-quotes")
-@test check_valid("underscored-float")
-@test check_valid("underscored-integer")
-@test check_valid("unicode-escape")
-@test check_valid("unicode-literal")
+failures = [
+    "testfiles/valid/spec-example-1-compact.toml",
+    "testfiles/valid/spec-example-1.toml",
+    "testfiles/valid/comment/tricky.toml",
+    "testfiles/valid/datetime/datetime.toml",
+    "testfiles/valid/datetime/milliseconds.toml",
+    "testfiles/valid/datetime/timezone.toml",
+    "testfiles/valid/float/zero.toml",
+    "testfiles/valid/string/multiline-quotes.toml",
+]
 
+valid_test_folder = joinpath(@__DIR__, "testfiles", "valid")
+for (root, dirs, files) in walkdir(valid_test_folder)
+    for f in files
+        if endswith(f, ".toml")
+            file = joinpath(root, f)
+            rel = relpath(file, @__DIR__)
+            if Sys.iswindows()
+                rel = replace(rel, '\\' => '/')
+            end
+            v = check_valid(splitext(file)[1])
+            if rel in failures
+                @test_broken v
+            else
+                @test v
+            end
+        end
+    end
 end
+
+end # testset
 
 
 ###########
 # Invalid #
 ###########
 
-invalid_test_folder = joinpath(@__DIR__, "testfiles", "invalid")
-
 # TODO: Check error type
 function check_invalid(f)
-    fp = joinpath(invalid_test_folder, f)
-    tml = TOML.tryparsefile(fp * ".toml")
+    tml = try TOML.tryparsefile(f)
+    catch
+        return false
+    end
     return tml isa TOML.Internals.ParserError
 end
 
-@test check_invalid("datetime-malformed-no-leads")
-@test check_invalid("datetime-malformed-no-secs")
-@test check_invalid("datetime-malformed-no-t")
-@test check_invalid("datetime-malformed-with-milli")
-@test check_invalid("duplicate-key-table")
-@test check_invalid("duplicate-keys")
-@test check_invalid("duplicate-tables")
-@test check_invalid("empty-implicit-table")
-@test check_invalid("empty-table")
-@test check_invalid("float-leading-zero-neg")
-@test check_invalid("float-leading-zero-pos")
-@test check_invalid("float-leading-zero")
-@test check_invalid("float-no-leading-zero")
-@test check_invalid("float-no-trailing-digits")
-@test check_invalid("float-underscore-after-point")
-@test check_invalid("float-underscore-after")
-@test check_invalid("float-underscore-before-point")
-@test check_invalid("float-underscore-before")
-@test check_invalid("inline-table-linebreak")
-@test check_invalid("integer-leading-zero-neg")
-@test check_invalid("integer-leading-zero-pos")
-@test check_invalid("integer-leading-zero")
-@test check_invalid("integer-underscore-after")
-@test check_invalid("integer-underscore-before")
-@test check_invalid("integer-underscore-double")
-@test check_invalid("key-after-array")
-@test check_invalid("key-after-table")
-@test check_invalid("key-empty")
-@test check_invalid("key-hash")
-@test check_invalid("key-newline")
-@test check_invalid("key-no-eol")
-@test check_invalid("key-open-bracket")
-@test check_invalid("key-single-open-bracket")
-@test check_invalid("key-space")
-@test check_invalid("key-start-bracket")
-@test check_invalid("key-two-equals")
-@test check_invalid("llbrace")
-@test check_invalid("multi-line-inline-table")
-@test check_invalid("multi-line-string-no-close")
-@test check_invalid("rrbrace")
-@test check_invalid("string-bad-byte-escape")
-@test check_invalid("string-bad-codepoint")
-@test check_invalid("string-bad-escape")
-@test check_invalid("string-bad-slash-escape")
-@test check_invalid("string-bad-uni-esc")
-@test check_invalid("string-byte-escapes")
-@test check_invalid("string-no-close")
-@test check_invalid("table-array-implicit")
-@test check_invalid("table-array-malformed-bracket")
-@test check_invalid("table-array-malformed-empty")
-@test check_invalid("table-empty")
-@test check_invalid("table-nested-brackets-close")
-@test check_invalid("table-nested-brackets-open")
-@test check_invalid("table-whitespace")
-@test check_invalid("table-with-pound")
-@test check_invalid("text-after-array-entries")
-@test check_invalid("text-after-integer")
-@test check_invalid("text-after-string")
-@test check_invalid("text-after-table")
-@test check_invalid("text-before-array-separator")
-@test check_invalid("text-in-array")
+@testset "invalid" begin
+
+failures = [
+    "testfiles/invalid/control/comment-del.toml",
+    "testfiles/invalid/control/comment-lf.toml",
+    "testfiles/invalid/control/comment-null.toml",
+    "testfiles/invalid/control/comment-us.toml",
+    "testfiles/invalid/control/multi-del.toml",
+    "testfiles/invalid/control/multi-lf.toml",
+    "testfiles/invalid/control/multi-null.toml",
+    "testfiles/invalid/control/multi-us.toml",
+    "testfiles/invalid/control/rawmulti-del.toml",
+    "testfiles/invalid/control/rawmulti-lf.toml",
+    "testfiles/invalid/control/rawmulti-null.toml",
+    "testfiles/invalid/control/rawmulti-us.toml",
+    "testfiles/invalid/control/rawstring-del.toml",
+    "testfiles/invalid/control/rawstring-lf.toml",
+    "testfiles/invalid/control/rawstring-null.toml",
+    "testfiles/invalid/control/rawstring-us.toml",
+    "testfiles/invalid/control/string-bs.toml",
+    "testfiles/invalid/control/string-del.toml",
+    "testfiles/invalid/control/string-lf.toml",
+    "testfiles/invalid/control/string-null.toml",
+    "testfiles/invalid/control/string-us.toml",
+    "testfiles/invalid/encoding/bad-utf8-in-comment.toml",
+    "testfiles/invalid/encoding/bad-utf8-in-string.toml",
+    "testfiles/invalid/integer/negative-bin.toml",
+    "testfiles/invalid/integer/negative-hex.toml",
+    "testfiles/invalid/integer/negative-hex.toml",
+    "testfiles/invalid/integer/negative-oct.toml",
+    "testfiles/invalid/integer/positive-bin.toml",
+    "testfiles/invalid/integer/positive-hex.toml",
+    "testfiles/invalid/integer/positive-oct.toml",
+    "testfiles/invalid/key/multiline.toml",
+]
+
+invalid_test_folder = joinpath(@__DIR__, "testfiles", "invalid")
+for (root, dirs, files) in walkdir(invalid_test_folder)
+    for f in files
+        if endswith(f, ".toml")
+            file = joinpath(root, f)
+            rel = relpath(file, @__DIR__)
+            if Sys.iswindows()
+                rel = replace(rel, '\\' => '/')
+            end
+            v = check_invalid(file)
+            if rel in failures
+                @test_broken v
+            else
+                @test v
+            end
+        end
+    end
+end
+
+end # testset

--- a/stdlib/TOML/test/utils/convert_json_to_jl.jl
+++ b/stdlib/TOML/test/utils/convert_json_to_jl.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 # This converts the ground-truth JSON files to the Julia repr format so
 # we can use that without requiring a JSON parser during testing.
 
@@ -8,12 +6,16 @@ using JSON
 const testfiles =  joinpath(@__DIR__, "..", "testfiles")
 
 function convert_json_files()
-    for folder in ("invalid", "valid")
-        for file in readdir(joinpath(testfiles, folder); join=true)
+    for (root, dirs, files) in walkdir(testfiles)
+        for f in files
+            file = joinpath(root, f)
             endswith(file, ".json") || continue
             d_json = open(JSON.parse, file)
             d_jl = repr(d_json)
             write(splitext(file)[1] * ".jl", d_jl)
+            rm(file)
         end
     end
 end
+
+convert_json_files()

--- a/stdlib/TOML/test/values.jl
+++ b/stdlib/TOML/test/values.jl
@@ -1,5 +1,3 @@
-# This file is a part of Julia. License is MIT: https://julialang.org/license
-
 using Test
 using TOML
 using TOML: Internals
@@ -39,8 +37,8 @@ end
     @test testval("1.0e0"       , 1.0)
     @test testval("1.0e+0"      , 1.0)
     @test testval("1.0e-0"      , 1.0)
-    @test testval("0e-3"        , 0.0)
     @test testval("1.001e-0"    , 1.001)
+    @test testval("0e-3"        , 0.0)
     @test testval("2e10"        , 2e10)
     @test testval("2e+10"       , 2e10)
     @test testval("2e-10"       , 2e-10)


### PR DESCRIPTION
Refs https://github.com/JuliaLang/TOML.jl/issues/36

## Description

It is getting very inconvenient to have to maintain two different copies of the TOML stdlib. For example, it's really annoying to have to keep the two copies of the code base in sync with each other.

This pull request copies the latest version of the code in the `JuliaLang/TOML.jl` repository into the appropriate places in the `JuliaLang/julia` repository.

Once this pull request is merged, I will archive the https://github.com/JuliaLang/TOML.jl repository. Then, all future work on the TOML stdlib will happen directly. 