### PR TITLE
Improve docstrings for `union` & `intersect`

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -18,8 +18,9 @@ If this is an array, it maintains the order in which elements first appear.
 Elements are compared using [`==`](@ref).
 
 Unicode `∪` can be typed by writing `\cup` then pressing tab in the Julia REPL, and in many editors.
+This is an infix operator, `s ∪ itr`.
 
-See also [`intersect`](@ref), [`isdisjoint`](@ref), [`vcat`](@ref), [`Iterators.flatten`](@ref).
+See also [`unique`](@ref), [`intersect`](@ref), [`isdisjoint`](@ref), [`vcat`](@ref), [`Iterators.flatten`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -109,10 +109,16 @@ end
     intersect(s, itrs...)
     ∩(s, itrs...)
 
-Construct the intersection of sets.
-Maintain order with arrays.
+Construct the set containing those elements which appear in all of the arguments.
 
-See also: [`setdiff`](@ref), [`isdisjoint`](@ref), [`issubset`](@ref Base.issubset), [`issetequal`](@ref).
+The first argument controls what kind of container is returned.
+If this is an array, it maintains the order in which elements first appear.
+Elements are compared using [`isequal`](@ref).
+
+Unicode `∩` can be typed by writing `\cap` then pressing tab in the Julia REPL, and in many editors.
+This is an infix operator, allowing `s ∩ itr`.
+
+See also [`setdiff`](@ref), [`isdisjoint`](@ref), [`issubset`](@ref Base.issubset), [`issetequal`](@ref).
 
 !!! compat "Julia 1.8"
     As of Julia 1.8 intersect returns a result with the eltype of the
@@ -124,14 +130,21 @@ julia> intersect([1, 2, 3], [3, 4, 5])
 1-element Vector{Int64}:
  3
 
-julia> intersect([1, 4, 4, 5, 6], [4, 6, 6, 7, 8])
+julia> intersect([1, 4, 4, 5, 6], [6, 4, 6, 7, 8])
 2-element Vector{Int64}:
  4
  6
 
-julia> intersect(Set([1, 2]), BitSet([2, 3]))
-Set{Int64} with 1 element:
-  2
+julia> intersect(1:16, 7:99)
+7:16
+
+julia> (0, 0.0) ∩ (-0.0, 0) 
+1-element Vector{Real}:
+ 0
+
+julia> intersect(Set([1, 2]), BitSet([2, 3]), 1.0:10.0)
+Set{Float64} with 1 element:
+  2.0
 ```
 """
 function intersect(s::AbstractSet, itr, itrs...)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -11,30 +11,36 @@ copy!(dst::AbstractSet, src::AbstractSet) = union!(empty!(dst), src)
     union(s, itrs...)
     ∪(s, itrs...)
 
-Construct the union of sets. Maintain order with arrays.
+Construct an object containing all elements from all of the arguments.
 
-See also: [`intersect`](@ref), [`isdisjoint`](@ref), [`vcat`](@ref), [`Iterators.flatten`](@ref).
+The first argument controls what kind of container is returned.
+If this is an array, it maintains the order in which elements first appear.
+Elements are compared using [`==`](@ref).
+
+Unicode `∪` can be typed by writing `\cup` then pressing tab in the Julia REPL, and in many editors.
+
+See also [`intersect`](@ref), [`isdisjoint`](@ref), [`vcat`](@ref), [`Iterators.flatten`](@ref).
 
 # Examples
 ```jldoctest
-julia> union([1, 2], [3, 4])
-4-element Vector{Int64}:
+julia> union([1, 2], [3])
+3-element Vector{Int64}:
  1
  2
  3
- 4
 
-julia> union([1, 2], [2, 4])
-3-element Vector{Int64}:
- 1
- 2
- 4
+julia> union([4 2 3], 1:3, 3.0)
+4-element Vector{Float64}:
+ 4.0
+ 2.0
+ 3.0
+ 1.0
 
-julia> union([4, 2], 1:2)
-3-element Vector{Int64}:
- 4
- 2
- 1
+julia> (0, 0.0) ∪ (-0.0, NaN)
+3-element Vector{Real}:
+   0
+  -0.0
+ NaN
 
 julia> union(Set([1, 2]), 2:3)
 Set{Int64} with 3 elements:
@@ -53,14 +59,14 @@ const ∪ = union
 """
     union!(s::Union{AbstractSet,AbstractVector}, itrs...)
 
-Construct the union of passed in sets and overwrite `s` with the result.
+Construct the [`union`](@ref) of passed in sets and overwrite `s` with the result.
 Maintain order with arrays.
 
 # Examples
 ```jldoctest
-julia> a = Set([1, 3, 4, 5]);
+julia> a = Set([3, 4, 5]);
 
-julia> union!(a, 1:2:8);
+julia> union!(a, 1:2:7);
 
 julia> a
 Set{Int64} with 5 elements:

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -11,14 +11,13 @@ copy!(dst::AbstractSet, src::AbstractSet) = union!(empty!(dst), src)
     union(s, itrs...)
     ∪(s, itrs...)
 
-Construct an object containing all elements from all of the arguments.
+Construct an object containing all distinct elements from all of the arguments.
 
 The first argument controls what kind of container is returned.
 If this is an array, it maintains the order in which elements first appear.
-Elements are compared using [`==`](@ref).
 
-Unicode `∪` can be typed by writing `\cup` then pressing tab in the Julia REPL, and in many editors.
-This is an infix operator, `s ∪ itr`.
+Unicode `∪` can be typed by writing `\\cup` then pressing tab in the Julia REPL, and in many editors.
+This is an infix operator, allowing `s ∪ itr`.
 
 See also [`unique`](@ref), [`intersect`](@ref), [`isdisjoint`](@ref), [`vcat`](@ref), [`Iterators.flatten`](@ref).
 
@@ -113,9 +112,8 @@ Construct the set containing those elements which appear in all of the arguments
 
 The first argument controls what kind of container is returned.
 If this is an array, it maintains the order in which elements first appear.
-Elements are compared using [`isequal`](@ref).
 
-Unicode `∩` can be typed by writing `\cap` then pressing tab in the Julia REPL, and in many editors.
+Unicode `∩` can be typed by writing `\\cap` then pressing tab in the Julia REPL, and in many editors.
 This is an infix operator, allowing `s ∩ itr`.
 
 See also [`setdiff`](@ref), [`isdisjoint`](@ref), [`issubset`](@ref Base.issubset), [`issetequal`](@ref).

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -29,7 +29,7 @@ julia> union([1, 2], [3])
  2
  3
 
-julia> union([4 2 3], 1:3, 3.0)
+julia> union([4 2 3 4 4], 1:3, 3.0)
 4-element Vector{Float64}:
  4.0
  2.0
@@ -136,7 +136,7 @@ julia> intersect([1, 4, 4, 5, 6], [6, 4, 6, 7, 8])
 julia> intersect(1:16, 7:99)
 7:16
 
-julia> (0, 0.0) ∩ (-0.0, 0) 
+julia> (0, 0.0) ∩ (-0.0, 0)
 1-element Vector{Real}:
  0
 


### PR DESCRIPTION
Saying "Construct the union" seems redundant if you know exactly what a union is, and is no help at all if you don't. So this tries to explain, and also to provide examples which illustrate more features.

Then I added `intersect` too.

Notice this difference:
```julia
julia> (0, 0.0) ∪ (-0.0, NaN) 
3-element Vector{Real}:
   0
  -0.0
 NaN

julia> (0, 0.0) ∩ (-0.0, NaN) 
Real[]
```
Is it correct to state that `union` will always use `==`, and intersect always `isequal`? On second thought, I guess not, else the first example would not contain `0`. What is it doing?