### PR TITLE
jl_gc_calloc_aligned and friends: obtaining aligned zero initialized memory efficiently

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3473,7 +3473,7 @@ static inline void *_unchecked_calloc(size_t nm, size_t sz) {
 
 JL_DLLEXPORT void *jl_calloc(size_t nm, size_t sz)
 {
-    if (nm > SIZE_MAX/sz)
+    if (nm > SSIZE_MAX/sz - JL_SMALL_BYTE_ALIGNMENT)
         return NULL;
     return _unchecked_calloc(nm, sz);
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -3462,7 +3462,7 @@ JL_DLLEXPORT void *jl_malloc(size_t sz)
 }
 
 //_unchecked_calloc does not check for potential overflow of nm*sz
-static inline void *_unchecked_calloc(size_t nm, size_t sz) {
+STATIC_INLINE void *_unchecked_calloc(size_t nm, size_t sz) {
     size_t nmsz = nm*sz;
     int64_t *p = (int64_t *)jl_gc_counted_calloc(nmsz + JL_SMALL_BYTE_ALIGNMENT, 1);
     if (p == NULL)

--- a/src/gc.c
+++ b/src/gc.c
@@ -3578,7 +3578,7 @@ JL_DLLEXPORT void *jl_gc_malloc_aligned(size_t sz, size_t align)
 JL_DLLEXPORT void *jl_gc_calloc_aligned(size_t nm, size_t sz, size_t align)
 {
 #if defined(__APPLE__)
-    return jl_calloc(sz);
+    return jl_calloc(nm, sz);
 #endif
     size_t offset = align - 1 + sizeof(void *) + sizeof(size_t);
     if (nm > (SIZE_MAX-offset)/sz)

--- a/src/julia.h
+++ b/src/julia.h
@@ -891,8 +891,13 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
 }
 
 JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
+JL_DLLEXPORT void *jl_gc_managed_calloc(size_t sz);
 JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
                                          int isaligned, jl_value_t *owner);
+JL_DLLEXPORT void *jl_gc_malloc_aligned(size_t sz, size_t align);
+JL_DLLEXPORT void *jl_gc_calloc_aligned(size_t nm, size_t sz, size_t align);
+JL_DLLEXPORT void *jl_gc_realloc_aligned(void *p, size_t sz, size_t oldsz, size_t align);
+JL_DLLEXPORT void  jl_gc_free_aligned(void *p);
 
 // object accessors -----------------------------------------------------------
 


### PR DESCRIPTION
This is a rebase, revision, and squash of #22953. The main objective was to develop an aligned and GC tracked `calloc` to obtain zero initialized memory efficiently. I took out the tagged bit and the renaming of public API functions, and simplified such that the current PR is mainly just adding new code rather than modifying existing code. 

My main motivation is that a `calloc` based `zeros` improves performances on Windows:
https://discourse.julialang.org/t/faster-zeros-with-calloc/69860

The main new contribution here is adding an offset to make space for saving the original pointer and the alignment. This hopefully addresses the issue in https://github.com/JuliaLang/julia/pull/22953#discussion_r129396419 by @JeffBezanson . I suspect better space usage is possible in retrospect. 

This could be used to address #130 or #9147. At the moment though, no actual change is made except to catch a potential overflow situation in `jl_calloc`.

An important mechanism is where to put a tagged bit such that arrays created using these new functions can be correctly freed by `jl_gc_free_aligned` from `jl_gc_free_array`. Previously, it was proposed that the `aligned` bit in `jl_array_flags_t` could be removed and possibly reused for this purpose. 

An alternative approach suggested by https://github.com/stevengj/julia/commit/7c9ab1d88a2b4950a9b889f6b20c522ca50a090c#r58133599 is to develop internal `calloc` and/or `posix_memalign` implementations based upon [musl](https://git.musl-libc.org/cgit/musl/tree/src/malloc) (MIT License). However, after studying the implementations, I am not sure if they take full advantage of newly zeroed pages from the operating system.

I would appreciate any comments and thoughts about future directions.

# Demonstration

```julia
julia> p = ccall(:jl_gc_calloc_aligned, Ptr{Int64}, (Csize_t, Csize_t, Csize_t), 2048, sizeof(Int64), 64);

julia> A = unsafe_wrap(Array, p, 2048; own = false)
2048-element Vector{Int64}:
 0
 0
 ⋮
 0
 0

julia> sum(A)
0

julia> UInt(p) % 64 # pointer is aligned
0x0000000000000000

julia> p
Ptr{Int64} @0x000000000ace2100

julia> Int(p)
181281024

julia> unsafe_load(p, 0) #p0, original pointer from jl_calloc
181280992

julia> unsafe_load(p, -1) # alignment
64

julia> p - unsafe_load(p, 0)
Ptr{Int64} @0x0000000000000020

julia> unsafe_load(Ptr{Int}(unsafe_load(p,0)),-1) # Number of bytes allocated by jl_calloc / _unchecked_calloc
16463

julia> sizeof(A) + 64 + 8 + 8 - 1  # data + alignment + sizeof(Csize_t) + sizeof(Ptr{Nothing}) - 1
16463

julia> p2 = ccall(:jl_gc_calloc_aligned, Ptr{Int64}, (Csize_t, Csize_t, Csize_t), 8192*8192, sizeof(Int64), 64)
Ptr{Int64} @0x000000009fff4080

julia> A2 = unsafe_wrap(Array, p2, 8192*8192; own = false);

julia> @btime fill!($A2, 0);
  31.866 ms (0 allocations: 0 bytes)

julia> @btime unsafe_wrap(Array, ccall(:jl_gc_calloc_aligned, Ptr{Int64}, (Csize
_t, Csize_t, Csize_t), 8192*8192, sizeof(Int64), 64), (8192,8192); own = false)
  12.414 ms (2 allocations: 512.00 MiB)

julia> @btime zeros(8192, 8192);
  128.934 ms (2 allocations: 512.00 MiB)

julia> versioninfo()
Julia Version 1.8.0-DEV.756
Commit ce011a82cb* (2021-10-18 17:13 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, skylake)
```


# Squashed Commit Log (edited for what remains)

commit 927da5f067f51700c1d5ffb22304382710b1643b
Author: Mark Kittisopikul <kittisopikulm@janelia.hhmi.org>
Date:   Tue Oct 19 05:52:50 2021 -0400

    Export jl_gc_*_aligned, jl_gc_managed_calloc

...

Fix #42673 by checking for unsigned integer wrapping for jl_*calloc*
Reused former isaligned tagged bit for howtofree tagged bit
Retained all existing functions
jl_gc_*_aligned defaults to jl_* since macOS guarantees page alignment
offset alignment to hold original (void *) p0, and size_t align

commit 842bf06e785d3be97558083abe181505c6840549
Author: Mark Kittisopikul <kittisopikulm@janelia.hhmi.org>
Date:   Sun Oct 17 02:20:11 2021 -0400

    Undo renaming of jl_calloc, jl_free, and jl_realloc

commit 4bb083a5f6b44766632dd394397257ebafc91726
Author: Daniel Matz <daniel.matz@gmail.com>
Date:   Fri Nov 4 08:59:43 2016 -0500

    Disambiguate jl_malloc from jl_malloc_aligned

    Add gc counted, aligned malloc