### PR TITLE
add kwarg to test for approximate symmetric/hermitian matrices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,7 @@ Standard library changes
 #### Package Manager
 
 #### LinearAlgebra
+* `issymmetric` and `ishermitian` can now test for approximate equality
 
 #### Markdown
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1184,9 +1184,10 @@ end
 issymmetric(A::AbstractMatrix{<:Real}) = ishermitian(A)
 
 """
-    issymmetric(A) -> Bool
+    issymmetric(A; eq=(==)) -> Bool
 
-Test whether a matrix is symmetric.
+Test whether a matrix is symmetric.  Use the optional keyword argument to
+specify a function to test element equality.
 
 # Examples
 ```jldoctest
@@ -1205,15 +1206,18 @@ julia> b = [1 im; -im 1]
 
 julia> issymmetric(b)
 false
+
+julia> issymmetric([1 2; 2.00000000000001 1], eq=isapprox)
+true
 ```
 """
-function issymmetric(A::AbstractMatrix)
+function issymmetric(A::AbstractMatrix; eq=(==))
     indsm, indsn = axes(A)
     if indsm != indsn
         return false
     end
     for i = first(indsn):last(indsn), j = (i):last(indsn)
-        if A[i,j] != transpose(A[j,i])
+        if !eq(A[i,j], transpose(A[j,i]))
             return false
         end
     end
@@ -1223,9 +1227,10 @@ end
 issymmetric(x::Number) = x == x
 
 """
-    ishermitian(A) -> Bool
+    ishermitian(A; eq=(==)) -> Bool
 
-Test whether a matrix is Hermitian.
+Test whether a matrix is Hermitian.  Use the optional keyword argument to
+specify a function to test element equality.
 
 # Examples
 ```jldoctest
@@ -1244,15 +1249,18 @@ julia> b = [1 im; -im 1]
 
 julia> ishermitian(b)
 true
+
+julia> ishermitian([1 im; -1.0000000002im 1], eq=isapprox)
+true
 ```
 """
-function ishermitian(A::AbstractMatrix)
+function ishermitian(A::AbstractMatrix; eq=(==))
     indsm, indsn = axes(A)
     if indsm != indsn
         return false
     end
     for i = indsn, j = i:last(indsn)
-        if A[i,j] != adjoint(A[j,i])
+        if !eq(A[i,j], adjoint(A[j,i]))
             return false
         end
     end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -530,4 +530,11 @@ end
     @test condskeel(A) ≈ condskeel(A, [8,8,8])
 end
 
+@testset "approximate hermitian #28885" begin
+    @test !issymmetric([1 2; 2+eps(2.0) 1])
+    @test issymmetric([1 2; 2+eps(2.0) 1], eq=isapprox)
+    @test !ishermitian([1 im; im+eps(2.0) 1])
+    @test ishermitian([1 im; -(1+eps(1.0))im 1], eq=isapprox)
+end
+
 end # module TestGeneric


### PR DESCRIPTION
closes JuliaLang/LinearAlgebra.jl#558.  see [recent comments](https://github.com/JuliaLang/LinearAlgebra.jl/issues/558)