### PR TITLE
Feature to stop accepting new tasks on existing threads

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -592,7 +592,11 @@ function enq_work(t::Task)
         tid = 0
         if ccall(:jl_enqueue_task, Cint, (Any,), t) != 0
             # if multiq is full, give to a random thread (TODO fix)
-            tid = mod(time_ns() % Int, Threads.nthreads() -1) + 2
+            if Threads.nthreads() > 1
+                tid = mod(time_ns() % Int, Threads.nthreads() - 1) + 2
+            else
+                tid = 1
+            end
             ccall(:jl_set_task_tid, Cvoid, (Any, Cint), t, tid-1)
             push!(Workqueues[tid], t)
         end

--- a/base/task.jl
+++ b/base/task.jl
@@ -591,7 +591,7 @@ function enq_work(t::Task)
     else
         tid = 0
         if ccall(:jl_enqueue_task, Cint, (Any,), t) != 0
-            tid = ccall(:jl_get_random_thread_for_new_task, Cint, ())
+            tid = ccall(:jl_get_random_thread_for_spawned_task, Cint, ())
             ccall(:jl_set_task_tid, Cvoid, (Any, Cint), t, tid)
 
             # Note that tid is obtained from c, and is therefore 0-indexed.

--- a/base/task.jl
+++ b/base/task.jl
@@ -592,7 +592,7 @@ function enq_work(t::Task)
         tid = 0
         if ccall(:jl_enqueue_task, Cint, (Any,), t) != 0
             # if multiq is full, give to a random thread (TODO fix)
-            tid = mod(time_ns() % Int, Threads.nthreads()) + 1
+            tid = mod(time_ns() % Int, Threads.nthreads() -1) + 2
             ccall(:jl_set_task_tid, Cvoid, (Any, Cint), t, tid-1)
             push!(Workqueues[tid], t)
         end

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -181,6 +181,14 @@ macro spawn(expr)
     end
 end
 
+function disable_spawning_on_this_thread()
+    ccall(:jl_accept_spawned_tasks, Cint, (Cint, Cint), threadid() - 1, 0)
+end
+
+function enable_spawning_on_this_thread()
+    ccall(:jl_accept_spawned_tasks, Cint, (Cint, Cint), threadid() - 1, 0)
+end
+
 # This is a stub that can be overloaded for downstream structures like `Channel`
 function foreach end
 

--- a/src/partr.c
+++ b/src/partr.c
@@ -409,12 +409,7 @@ static jl_task_t *get_next_task(jl_value_t *trypoptask, jl_value_t *q)
         return task;
     }
     jl_gc_safepoint();
-    if (self_tid == 0 && jl_n_threads != 1) {
-        return NULL;
-    } else {
-        // fprintf(stderr, "tid=%d: grabbing work from shared heaps\n", self_tid);
-        return multiq_deletemin();
-    }
+    return thread_accepts_new_tasks[self_tid] ? multiq_deletemin() : NULL;
 }
 
 static int may_sleep(jl_ptls_t ptls)

--- a/src/partr.c
+++ b/src/partr.c
@@ -88,8 +88,8 @@ static inline void multiq_init(void)
 {
     heap_p = heap_c * jl_n_threads;
     heaps = (taskheap_t *)calloc(heap_p, sizeof(taskheap_t));
-    thread_accepts_spawned_tasks = (uint8_t*)realloc(thread_accepts_new_tasks, jl_n_threads * sizeof(*thread_accepts_new_tasks));
-    memset(thread_accepts_spawned_tasks, 1, jl_n_threads * sizeof(*thread_accepts_new_tasks));
+    thread_accepts_spawned_tasks = (uint8_t*)realloc(thread_accepts_spawned_tasks, jl_n_threads * sizeof(*thread_accepts_spawned_tasks));
+    memset(thread_accepts_spawned_tasks, 1, jl_n_threads * sizeof(*thread_accepts_spawned_tasks));
 
     for (int32_t i = 0; i < heap_p; ++i) {
         jl_mutex_init(&heaps[i].lock);
@@ -441,7 +441,7 @@ JL_DLLEXPORT int jl_accept_spawned_tasks(int tid, int accept)
     JL_LOCK(&thread_scheduling_lock);
     if (accept) {
         thread_accepts_spawned_tasks[tid] = 1;
-    } else if (thread_accepts_spanwed_tasks[tid]) {
+    } else if (thread_accepts_spawned_tasks[tid]) {
         // Ensure that there is at least one more thread that still
         // accepts spawned tasks.
         int other_available = 0;

--- a/src/partr.c
+++ b/src/partr.c
@@ -432,7 +432,7 @@ JL_DLLEXPORT int jl_get_random_thread_for_spawned_task()
 }
 
 
-JL_DLLEXPORT int jl_accept_spawned_tasks(int16_t tid, bool accept)
+JL_DLLEXPORT int jl_accept_spawned_tasks(int tid, int accept)
 {
     if (tid < 0 || tid >= jl_n_threads)
         return 1;


### PR DESCRIPTION
This feature allows operators to stop scheduling of new tasks on specific threads which will make those threads high priority and only handle either explicitly scheduled tasks or tasks that are already running on those high priority threads.

This feature can be used to guarantee responsiveness on certain critical low-latency tasks by isolating them from the bulk of the julia workload that will run on other threads. We have observed that this eliminates most of the scheduling issues and slowdowns due to tasks occupying threads for excessive amounts of time (this is particularly problematic with sticky tasks in 1.6 where single long-running task that gets scheduled on the same thread as critical periodic task can cause major delays).

That said, low-latency is still subject to occasional hiccup as a result of stop-the-world behaviors that happen during garbage collection and compilation.