### PR TITLE
`Base.runtests`: add the ability to write the list of failed test sets to a file

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -571,6 +571,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
     ENV2["JULIA_DEPOT_PATH"] = mktempdir(; cleanup = true)
+    ENV2["JULIA_TEST_FAILED_TESTSET_FILE"] = joinpath(mktempdir(; cleanup = true), "myfile.txt") # TODO: delete this line
     try
         run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR::String,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Base: Experimental
 
 include("choosetests.jl")
 include("testenv.jl")
+include("testutils.jl")
 
 tests, net_on, exit_on_error, use_revise, seed = choosetests(ARGS)
 tests = unique(tests)
@@ -408,6 +409,7 @@ cd(@__DIR__) do
             println("$skipped test", skipped > 1 ? "s were" : " was", " skipped due to failure.")
         println("The global RNG seed was 0x$(string(seed, base = 16)).\n")
         Test.print_test_errors(o_ts)
+        TestUtils.write_failed_testsets_if_requested(o_ts)
         throw(Test.FallbackTestSetException("Test run finished with errors"))
     end
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,0 +1,79 @@
+module TestUtils
+
+import Test
+
+function write_failed_testsets_if_requested(ts::Test.DefaultTestSet)
+    failed_testset_file = get_failed_testset_filename()
+
+    if failed_testset_file !== nothing
+        touch(failed_testset_file)
+        print_failed_testsets(failed_testset_file, ts)
+        @info "Wrote the list of failed test sets to file" failed_testset_file
+
+        @info "" read(failed_testset_file, String) # TODO: delete this line
+        flush(stdout) # TODO: delete this line
+        flush(stderr) # TODO: delete this line
+        println("### BEGIN contents of the failed_testset_file") # TODO: delete this line
+        println(read(failed_testset_file, String)) # TODO: delete this line
+        println("### END contents of the failed_testset_file") # TODO: delete this line
+        flush(stdout) # TODO: delete this line
+        flush(stderr) # TODO: delete this line
+    end
+
+    return failed_testset_file
+end
+
+function get_failed_testset_filename()
+    environment_variable_name = "JULIA_TEST_FAILED_TESTSET_FILE"
+    environment_variable_value = strip(get(ENV, environment_variable_name, ""))
+    if isempty(environment_variable_value)
+        return nothing
+    end
+    filename = convert(String, environment_variable_value)::String
+    return filename
+end
+
+function print_failed_testsets(filename::String, ts::Test.DefaultTestSet)
+    open(filename, "w") do io
+        print_failed_testsets(io, ts)
+    end
+    return nothing
+end
+
+function print_failed_testsets(io::IO, ts::Test.DefaultTestSet)
+    failed_testsets = get_failed_testsets(ts)
+    for name in failed_testsets
+        println(io, name)
+    end
+    return nothing
+end
+
+function get_failed_testsets(ts::Test.DefaultTestSet)::Vector{String}
+    if ts.description != "Overall"
+        msg = "Expected the testset name to be \"Overall\", but got \"$(ts.description)\" instead"
+        throw(ErrorException(msg))
+    end
+
+    if isempty(ts.results)
+        msg = "Did not find any testset results"
+        throw(ErrorException(msg))
+    end
+
+    failed_testsets = String[]
+
+    for t in ts.results
+        t::Test.DefaultTestSet
+        if t.anynonpass
+            push!(failed_testsets, strip(t.description))
+        end
+    end
+
+    if length(failed_testsets) != length(unique(failed_testsets))
+        msg = "Duplicate testset names"
+        throw(ErrorException(msg))
+    end
+
+    return failed_testsets
+end
+
+end # module


### PR DESCRIPTION
## TODO

- [ ] Remove the debugging lines before merging

## Description

This pull request adds the ability for the Base Julia test suite to write the list of failed testsets to file.

To use this feature, simply set the `JULIA_TEST_FAILED_TESTSET_FILE` environment variable equal to the name of the file.

If the `JULIA_TEST_FAILED_TESTSET_FILE` environment variable is set, then after the tests have been run, if one or more testsets failed, the names of those testsets will be written to the file with filename `JULIA_TEST_FAILED_TESTSET_FILE`. The names will be separated by newlines, with one testset name per line.

If the `JULIA_TEST_FAILED_TESTSET_FILE` environment variable is not set, then nothing will be done.

## Example usage

### Example 1

```
export JULIA_TEST_FAILED_TESTSET_FILE=/path/to/my/file.txt
./julia -e 'Base.runtests("all")'
```

### Example 2

```
export JULIA_TEST_FAILED_TESTSET_FILE=/path/to/my/file.txt
./julia test/runtests.jl all
```

## Motivation

The goal here is to be able to run the `Base.runtests` function and get back the list of failed testsets in a format that can be processed programmatically.