### PR TITLE
add a missing `transpose` in `LinearAlgebra.copy_transpose!` to handle matmul of isbits array-elements with non-identity transpose

### DIFF
--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -194,7 +194,7 @@ function copy_transpose!(B::AbstractVecOrMat, ir_dest::AbstractRange{Int}, jr_de
     for jsrc in jr_src
         jdest = first(jr_dest)
         for isrc in ir_src
-            B[idest,jdest] = A[isrc,jsrc]
+            B[idest,jdest] = transpose(A[isrc,jsrc])
             jdest += step(jr_dest)
         end
         idest += step(ir_dest)


### PR DESCRIPTION
Fixes the issue reported in https://github.com/JuliaLang/LinearAlgebra.jl/issues/500

```jl
julia> using StaticArrays

julia> A = @SMatrix [1 2; 3 4]
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  2
 3  4

julia> blockA = fill(A, 1, 1)
1×1 Matrix{SMatrix{2, 2, Int64, 4}}:
 [1 2; 3 4]

julia> blockA * transpose(blockA) - blockA * collect(transpose(blockA))
1×1 Matrix{SMatrix{2, 2, Int64, 4}}:
 [0 0; 0 0]
```

Should probably add a test but it is a bit it requires quite a bit of scaffolding to set up. Maybe someone has that already available? cc @thchr