### PR TITLE
Test sort_int_range! for reverse sorting of large unsigned types

### DIFF
--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -53,7 +53,7 @@ end
     @test issorted([1,2,3])
     @test reverse([2,3,1]) == [1,3,2]
     @test sum(randperm(6)) == 21
-    @test issorted(sort(rand(UInt64(1):UInt64(2), 7); rev=true); rev=true) # PR #?????
+    @test issorted(sort(rand(UInt64(1):UInt64(2), 7); rev=true); rev=true) # issue #43034
 end
 
 @testset "partialsort" begin

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -53,6 +53,7 @@ end
     @test issorted([1,2,3])
     @test reverse([2,3,1]) == [1,3,2]
     @test sum(randperm(6)) == 21
+    @test issorted(sort(rand(UInt64(1):UInt64(2), 7); rev=true); rev=true) # PR #?????
 end
 
 @testset "partialsort" begin


### PR DESCRIPTION
Fixes #43034
```julia
v = rand(UInt64(1):UInt64(2), 7)
issorted(sort(v; rev=true); rev=true) # false
```

The bug was in iterating over a reversed unsigned range (which is not possible). It only comes up for 'UInt`, `UInt64` & `UInt128` because the signed `1::Int` promotes to a signed result if the `UInt` is smaller in `1:rangelen`.

This came up in the process of building a comprehensive sorting test suite which may or may not ever end up suitable for merging into SortingAlgorithms or Base. It tests on many input types, which catches things like this, but results in very long compilation times (~30s) and a lot of compiled code (GBs).