### PR TITLE
Fix alignment in abstract type example

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -171,11 +171,11 @@ Let's consider some of the abstract types that make up Julia's numerical hierarc
 
 ```julia
 abstract type Number end
-abstract type Real     <: Number end
+abstract type Real          <: Number end
 abstract type AbstractFloat <: Real end
-abstract type Integer  <: Real end
-abstract type Signed   <: Integer end
-abstract type Unsigned <: Integer end
+abstract type Integer       <: Real end
+abstract type Signed        <: Integer end
+abstract type Unsigned      <: Integer end
 ```
 
 The [`Number`](@ref) type is a direct child type of `Any`, and [`Real`](@ref) is its child.


### PR DESCRIPTION
The alignment makes no sense:
```
abstract type Number end
abstract type Real     <: Number end
abstract type AbstractFloat <: Real end
abstract type Integer  <: Real end
abstract type Signed   <: Integer end
abstract type Unsigned <: Integer end
```
This PR aligns the `<:`:
```
abstract type Number end
abstract type Real          <: Number end
abstract type AbstractFloat <: Real end
abstract type Integer       <: Real end
abstract type Signed        <: Integer end
abstract type Unsigned      <: Integer end
```

Alternatively, it would probably be more idiomatic to just remove the extra spaces, that is, to not align the text. However, there is an example on the same page where alignment does improve readability (https://docs.julialang.org/en/v1.8-dev/manual/types/#Primitive-Types), so let's keep it consistent.