### PR TITLE
`choosetests`: return a `NamedTuple` (instead of a `Tuple`), to make it easier to add more information in the future

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -33,7 +33,7 @@ const TESTNAMES = [
 
 """
 
-`tests, net_on, exit_on_error, seed = choosetests(choices)` selects a set of tests to be
+`(; tests, net_on, exit_on_error, seed) = choosetests(choices)` selects a set of tests to be
 run. `choices` should be a vector of test names; if empty or set to
 `["all"]`, all tests are selected.
 
@@ -41,7 +41,7 @@ This function also supports "test collections": specifically, "linalg"
  refers to collections of tests in the correspondingly-named
 directories.
 
-Upon return:
+The function returns a named tuple with the following elements:
   - `tests` is a vector of fully-expanded test names,
   - `net_on` is true if networking is available (required for some tests),
   - `exit_on_error` is true if an error in one test should cancel
@@ -205,5 +205,5 @@ function choosetests(choices = [])
         empty!(tests)
     end
 
-    tests, net_on, exit_on_error, use_revise, seed
+    return (; tests, net_on, exit_on_error, use_revise, seed)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Base: Experimental
 include("choosetests.jl")
 include("testenv.jl")
 
-tests, net_on, exit_on_error, use_revise, seed = choosetests(ARGS)
+(; tests, net_on, exit_on_error, use_revise, seed) = choosetests(ARGS)
 tests = unique(tests)
 
 if Sys.islinux()


### PR DESCRIPTION
Currently, the `choosetests` function returns a `Tuple`.

This pull request modifies the `choosetests` function so that it returns a `NamedTuple` instead. With this change, if in the future we decide to add more return values, we can do so without breaking existing uses of the `choosetets` function.