### PR TITLE
CI (Buildkite): fix the timeout for the `tester_linux` job that runs under `rr`

### DIFF
--- a/.buildkite/pipelines/main/platforms/tester_linux.arches
+++ b/.buildkite/pipelines/main/platforms/tester_linux.arches
@@ -3,7 +3,7 @@
 # linux       _armv7l     false         _armv7l     armv7l         none           60         no       no       no       v3.2          fb359370b052a47ce5c84cc6b4a7a03ed7053b25
 linux         32          false         32          i686           none           60         no       no       no       v3.2          209c4db679a515befd7fb50ecc6bfbecf7ec3d32
 # linux       _ppc64le    false         _ppc64le    powerpc64le    none           60         no       no       no       v3.2          c03a0158b19d48ac84b426834fce0d3584cdd0c7
-linux         64_rr       false         64          x86_64         none           60         yes      no       no       v3.2          474bf61a926b2d7fcf202284d59d4b11a04601d7
+linux         64_rr       false         64          x86_64         none           180        yes      no       no       v3.2          474bf61a926b2d7fcf202284d59d4b11a04601d7
 linux         64_st       false         64          x86_64         none           60         no       yes      no       v3.2          474bf61a926b2d7fcf202284d59d4b11a04601d7
 linux         64_mt       false         64          x86_64         none           60         no       no       yes      v3.2          474bf61a926b2d7fcf202284d59d4b11a04601d7
 musl          64          true          64          x86_64         none           60         no       no       no       v3.19         e6a2730e37c386c46915b2650d6aaaa398195152


### PR DESCRIPTION
This was always supposed to be 180, but I unintentionally changed it to 60 in a recent commit. This pull request changes it back to the correct value of 180.