### PR TITLE
Fix the `contrib/refresh_checksums.mk` script by changing a single `>` to `>>`

### DIFF
--- a/contrib/refresh_checksums.mk
+++ b/contrib/refresh_checksums.mk
@@ -125,7 +125,7 @@ pack-checksum-%: FORCE
 				done; \
 				rmdir "$$each"; \
 			fi; \
-		done > '$*'
+		done >> '$*'
 	@cd "$(JULIAHOME)/deps/checksums" && \
 		sort '$*' > '$*.tmp' && \
 		mv '$*.tmp' '$*'


### PR DESCRIPTION
Fixes #42727

This pull request fixes the `contrib/refresh_checksums.mk` script by changing a single `>` to `>>`. 

The bug was originally introduced in #42643.