### PR TITLE
Better error message for convert(Type{Union{}}, ...)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -613,7 +613,7 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 
 convert(::Type{T}, a::AbstractArray) where {T<:Array} = a isa T ? a : T(a)
 convert(::Type{Union{}}, a::AbstractArray) = throw(MethodError(convert, (Union{}, a)))
-
+convert(::Type{Union{}}, a::Vector{T} where T) = throw(MethodError(convert, (Union{}, a)))
 promote_rule(a::Type{Array{T,n}}, b::Type{Array{S,n}}) where {T,n,S} = el_same(promote_type(T,S), a, b)
 
 ## Constructors ##

--- a/base/array.jl
+++ b/base/array.jl
@@ -613,7 +613,6 @@ oneunit(x::AbstractMatrix{T}) where {T} = _one(oneunit(T), x)
 
 convert(::Type{T}, a::AbstractArray) where {T<:Array} = a isa T ? a : T(a)
 convert(::Type{Union{}}, a::AbstractArray) = throw(MethodError(convert, (Union{}, a)))
-convert(::Type{Union{}}, a::Vector{T} where T) = throw(MethodError(convert, (Union{}, a)))
 promote_rule(a::Type{Array{T,n}}, b::Type{Array{S,n}}) where {T,n,S} = el_same(promote_type(T,S), a, b)
 
 ## Constructors ##

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -204,6 +204,10 @@ function show_convert_error(io::IO, ex::MethodError, arg_types_param)
     T = striptype(ex.args[1])
     if T === nothing
         print(io, "First argument to `convert` must be a Type, got ", ex.args[1])
+    elseif ex.args[1] <: Union{}
+        printstyled(io, "Converting to ")
+        printstyled(io, "Union{} "; color = :light_red)
+        printstyled(io, "is not possible, check the `convert` method.")
     else
         p2 = arg_types_param[2]
         print_one_line = isa(T, DataType) && isa(p2, DataType) && T.name != p2.name

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -207,7 +207,7 @@ function show_convert_error(io::IO, ex::MethodError, arg_types_param)
     elseif ex.args[1] <: Union{}
         printstyled(io, "Converting to ")
         printstyled(io, "Union{} "; color = :light_red)
-        printstyled(io, "is not possible, check the stacktrace for more information.")
+        printstyled(io, "is not possible.")
     else
         p2 = arg_types_param[2]
         print_one_line = isa(T, DataType) && isa(p2, DataType) && T.name != p2.name

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -207,7 +207,7 @@ function show_convert_error(io::IO, ex::MethodError, arg_types_param)
     elseif ex.args[1] <: Union{}
         printstyled(io, "Converting to ")
         printstyled(io, "Union{} "; color = :light_red)
-        printstyled(io, "is not possible, check the `convert` method.")
+        printstyled(io, "is not possible, check the stacktrace for more information.")
     else
         p2 = arg_types_param[2]
         print_one_line = isa(T, DataType) && isa(p2, DataType) && T.name != p2.name

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -227,7 +227,7 @@ function showerror(io::IO, ex::MethodError)
     arg_types = (is_arg_types ? ex.args : typesof(ex.args...))::DataType
     f = ex.f
     meth = methods_including_ambiguous(f, arg_types)
-    if isa(meth, MethodList) && length(meth) > 1
+    if isa(meth, MethodList) && length(meth) > 1 && f !== Base.convert
         return showerror_ambiguous(io, meth, f, arg_types)
     end
     arg_types_param::SimpleVector = arg_types.parameters

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -704,7 +704,7 @@ end
 #42735
 let buf = IOBuffer()
     Base.showerror(buf, Base.MethodError(convert, (Union{}, Float32[])))
-     @test occursin("MethodError: Converting to Union{} is not possible, check the stacktrace for more information.", String(take!(buf)))
+     @test occursin("MethodError: Converting to Union{} is not possible.", String(take!(buf)))
 end
 
 # pr #32814

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -701,6 +701,12 @@ let buf = IOBuffer()
     @test length(take!(buf)) !== 0
 end
 
+#42735
+let buf = IOBuffer()
+    Base.showerror(buf, Base.MethodError(convert, (Union{}, Float32[])))
+     @test occursin("MethodError: Converting to Union{} is not possible, check the stacktrace for more information.", String(take!(buf)))
+end
+
 # pr #32814
 let t1 = @async(error(1)),
     t2 = @async(wait(t1))


### PR DESCRIPTION
closes #40951 
cc: @Seelengrab 
Related PR: https://github.com/JuliaLang/julia/pull/41310 