### PR TITLE
inference: follow up #42529, handle an edge case in `abstract_invoke`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1240,8 +1240,12 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     const_prop_entry_heuristic(interp, result, sv) || return CallMeta(rt, InvokeCallInfo(match, nothing))
     argtypes′ = argtypes[3:end]
     argtypes′[1] = ft
-    fargs′ = fargs[3:end]
-    fargs′[1] = fargs[1]
+    if fargs === nothing
+        fargs′ = nothing
+    else
+        fargs′ = fargs[3:end]
+        fargs′[1] = fargs[1]
+    end
     arginfo = ArgInfo(fargs′, argtypes′)
     const_prop_argument_heuristic(interp, arginfo, sv) || return CallMeta(rt, InvokeCallInfo(match, nothing))
     # # typeintersect might have narrowed signature, but the accuracy gain doesn't seem worth the cost involved with the lattice comparisons

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3285,6 +3285,11 @@ function splat_lotta_unions()
 end
 @test Core.Compiler.return_type(splat_lotta_unions, Tuple{}) >: Tuple{Int,Int,Int}
 
+# handle `fargs = nothing` edge cases
+@test (code_typed(; optimize=false) do
+    Core.Compiler.return_type(invoke, Tuple{typeof(sin), Type{Tuple{Integer}}, Int})
+end; true)
+
 # Bare Core.Argument in IR
 @eval f_bare_argument(x) = $(Core.Argument(2))
 @test Base.return_types(f_bare_argument, (Int,))[1] == Int


### PR DESCRIPTION
JET reported:
```julia
julia> report_package(JET)
...
[toplevel-info] analyzing from top-level definitions ... 671/671
═════ 12 possible errors found ═════
...
│││││││││┌ @ compiler/abstractinterpretation.jl:1243 Core.Compiler.lastindex(fargs)
││││││││││ for 1 of union split cases, no matching method found for call signatures (Tuple{typeof(Core.Compiler.lastindex), Nothing})): Core.Compiler.lastindex(fargs::Union{Nothing, Vector{Any}})
│││││││││└───────────────────────────────────────────
│││││││││┌ @ compiler/abstractinterpretation.jl:1243 fargs′ = Core.Compiler.getindex(fargs, Core.Compiler.:(3, Core.Compiler.lastindex(fargs)))
││││││││││ for 1 of union split cases, no matching method found for call signatures (Tuple{typeof(Core.Compiler.getindex), Nothing, Core.Compiler.UnitRange{Int64}})): fargs′ = Core.Compiler.getindex(fargs::Union{Nothing, Vector{Any}}, Core.Compiler.:(3, Core.Compiler.lastindex(fargs::Union{Nothing, Vector{Any}})::Int64)::Core.Compiler.UnitRange{Int64})
│││││││││└───────────────────────────────────────────
│││││││││┌ @ compiler/abstractinterpretation.jl:1244 Core.Compiler.getindex(fargs, 1)
││││││││││ for 1 of union split cases, no matching method found for call signatures (Tuple{typeof(Core.Compiler.getindex), Nothing, Int64})): Core.Compiler.getindex(fargs::Union{Nothing, Vector{Any}}, 1)
│││││││││└───────────────────────────────────────────
...
```