### PR TITLE
fix overflow and undeflow for @fastmath exp

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -253,6 +253,8 @@ end
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
 end
 @inline function exp_impl_fast(x::Float64, base)
+    x >= MAX_EXP(base, T) && return Inf
+    x <= -SUBNORM_EXP(base, T) && return 0.0
     T = Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
     N = reinterpret(UInt64, N_float) % Int32
@@ -287,6 +289,8 @@ end
 end
 
 @inline function exp_impl_fast(x::Float32, base)
+    x >= MAX_EXP(base, T) && return Inf32
+    x <= -SUBNORM_EXP(base, T) && return 0f0
     T = Float32
     N_float = round(x*LogBINV(base, T))
     N = unsafe_trunc(Int32, N_float)

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -253,9 +253,9 @@ end
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
 end
 @inline function exp_impl_fast(x::Float64, base)
+    T = Float64
     x >= MAX_EXP(base, T) && return Inf
     x <= -SUBNORM_EXP(base, T) && return 0.0
-    T = Float64
     N_float = muladd(x, LogBo256INV(base, T), MAGIC_ROUND_CONST(T))
     N = reinterpret(UInt64, N_float) % Int32
     N_float -=  MAGIC_ROUND_CONST(T) #N_float now equals round(x*LogBo256INV(base, T))
@@ -289,9 +289,9 @@ end
 end
 
 @inline function exp_impl_fast(x::Float32, base)
+    T = Float32
     x >= MAX_EXP(base, T) && return Inf32
     x <= -SUBNORM_EXP(base, T) && return 0f0
-    T = Float32
     N_float = round(x*LogBINV(base, T))
     N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogBU(base, T), x)

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -249,3 +249,13 @@ end
     @test (@fastmath "a" * "b") == "ab"
     @test (@fastmath "a" ^ 2) == "aa"
 end
+
+
+@testset "exp overflow and underflow" begin
+    for T in (Float32,Float64)
+        for func in (@fastmath exp2,exp,exp10)
+            @test func(T(2000)) == T(Inf)
+            @test func(T(-2000)) == T(0)
+        end
+    end
+end


### PR DESCRIPTION
Before
```
julia> @fastmath exp(1000.0)
-6.096081764721242e-183

julia> @fastmath exp(-1000.0)
-1.6403979450983092e182
```
After

```
julia> @fastmath exp(1000.0)
Inf

julia> @fastmath exp(-1000.0)
0.0
```