### PR TITLE
Distributed test suite: increase the timeout in the `poll_while` function from 60 seconds to 120 seconds

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -132,7 +132,7 @@ end
 testf(id_me)
 testf(id_other)
 
-function poll_while(f::Function; timeout_seconds::Integer = 60)
+function poll_while(f::Function; timeout_seconds::Integer = 120)
     start_time = time_ns()
     while f()
         sleep(1)


### PR DESCRIPTION
Follow-up to #42499