### PR TITLE
Partitionby itererator

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1220,7 +1220,7 @@ Iterate over a collection in chunks where `pred` returns the same value.
 # Examples
 ```jldoctest
 julia> map(collect, Iterators.partitionby([1,2,3,4,5], x->x>2))
-3-element Vector{Vector{Int64}}:
+2-element Vector{Vector{Int64}}:
  [1, 2]
  [3, 4, 5]
 ```

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -512,7 +512,7 @@ end
 
 let v = map(collect, partitionby([1,2,3,4,5], x->x>2))
     @test v[1] == [1,2]
-    @test v[2] == [3,4,3]
+    @test v[2] == [3,4,5]
 end
 
 let v = map(collect, partitionby(enumerate([1,2,3,4,5]), ((i, x),)->i>3))
@@ -522,7 +522,7 @@ end
 
 for n in [5,6]
     @test map(collect, partitionby([1,2,3,4,5], x->x>n))[1] == [1,2,3,4,5]
-    @test map(collect, partition(enumerate([1,2,3,4,5]), x->x[1]>n))[1] ==
+    @test map(collect, partitionby(enumerate([1,2,3,4,5]), x->x[1]>n))[1] ==
           [(1,1),(2,2),(3,3),(4,4),(5,5)]
 end
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -499,6 +499,33 @@ for n in [5,6]
           [(1,1),(2,2),(3,3),(4,4),(5,5)]
 end
 
+# partitionby(c, pred)
+let v = map(collect, partitionby([1,2,3,4,5], identity))
+    @test all(i->v[i][1] == i, v)
+end
+
+let v1 = map(collect, partitionby([1,2,3,4,5], x->x>2)),
+    v2 = map(collect, partitionby(flatten([[1,2],[3,4],5]), x->x>2)) # collecting partition with SizeUnkown
+    @test v1[1] == v2[1] == [1,2]
+    @test v1[2] == v2[2] == [3,4,5]
+end
+
+let v = map(collect, partitionby([1,2,3,4,5], x->x>2))
+    @test v[1] == [1,2]
+    @test v[2] == [3,4,3]
+end
+
+let v = map(collect, partitionby(enumerate([1,2,3,4,5]), ((i, x),)->i>3))
+    @test v[1] == [(1,1),(2,2),(3,3)]
+    @test v[2] == [(4,4),(5,5)]
+end
+
+for n in [5,6]
+    @test map(collect, partitionby([1,2,3,4,5], x->x>n))[1] == [1,2,3,4,5]
+    @test map(collect, partition(enumerate([1,2,3,4,5]), x->x[1]>n))[1] ==
+          [(1,1),(2,2),(3,3),(4,4),(5,5)]
+end
+
 function iterate_length(iter)
     n=0
     for i in iter


### PR DESCRIPTION
This PR aims to add a new iterator called `partitionby`, which is in short the `takewhile` equivalent of `partition`: it iterates in chunks grouped by function return value. This functionality is inspired by Clojure's `partition-by`: https://clojuredocs.org/clojure.core/partition-by

I have found it to be a very versatile utility and think it'd be a great addition to the `Iterators` module.

I'm sure this PR will take a few commits and some feedback to get in good shape, but here is a first stab at it. (My laptop with 16GB ram crashed on running `make test`)

I found it's not trivial to write new iterators. My first attempt implemented this function with nested `takewhile` and `dropwhile` but this results in a quadratic runtime where every step along the way will evaluate a ton of `dropwhile` comparisons. So then I took a more low-level approach.

A fundamental difference between `partition` and `partitionby` is that the size of the chunks is not known. I also wanted to avoid allocating new arrays for each chunk, which in my use case can be quite big. So unlike `partition` which seems to just allocate an array for each chunk, I added a `Tee` operator, after the unix `tee` command. This iterator allows you to "tap" another iterator by storing current state, so that it will start iterating right from that point. These are then used to make efficient chunk iterators.