### PR TITLE
Distributed test suite: add an additional use of the `poll_while` function

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -267,7 +267,7 @@ let wid1 = workers()[1],
     fstore = RemoteChannel(wid2)
 
     put!(fstore, rr)
-    @test remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid) == true
+    @test poll_while(() -> !remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid))
     finalize(rr) # finalize locally
     yield() # flush gc msgs
     @test remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid) == true


### PR DESCRIPTION
Follow-up to #42499

---

This pull request is intended to fix the following test failure, which I am seeing very rarely in the `tester_linux64_mt` Buildkite job:

```
Distributed                         (1) |        started at 2021-10-22T10:10:08.433
Test Failed at /cache/build/amdci7-2/julialang/julia-master/julia-609a4a0a1e/share/julia/stdlib/v1.8/Distributed/test/distributed_exec.jl:270
  Expression: remotecall_fetch((k->begin
                haskey(Distributed.PGRP.refs, k)
            end), wid1, rrid) == true
   Evaluated: false == true
ERROR: LoadError: There was an error during testing
in expression starting at /cache/build/amdci7-2/julialang/julia-master/julia-609a4a0a1e/share/julia/stdlib/v1.8/Distributed/test/distributed_exec.jl:263
Distributed                         (1) |         failed at 2021-10-22T10:10:33.207
```

Full log: https://buildkite.com/julialang/julia-master/builds/5028#dfdf3a45-5510-402b-99d4-9daa860f0f09