### PR TITLE
[1.7] [stdlib/SHA] [bugfix] cherry pick patch from SHA.jl

### DIFF
--- a/stdlib/SHA/src/sha3.jl
+++ b/stdlib/SHA/src/sha3.jl
@@ -71,7 +71,7 @@ function digest!(context::T) where {T<:SHA3_CTX}
         context.buffer[end] = 0x06
         transform!(context)
 
-        context.buffer[1:end-1] = 0x0
+        context.buffer[1:end-1] .= 0x0
         context.buffer[end] = 0x80
     end
 

--- a/stdlib/SHA/test/runtests.jl
+++ b/stdlib/SHA/test/runtests.jl
@@ -302,3 +302,13 @@ else
     println("Failed with $nerrors failures")
 end
 @test nerrors == 0
+
+@testset "SHA3" begin
+    @test sha3_512("0" ^ 70) |> bytes2hex == 
+        "1ec3e5ebb442c09e7ab7a1ee18edfa1a9ec771ad243e3e3d65cad1730416109a0890e29f9314babd7ab018a246b2f9639af29ee09aec2352a2f94dc12a2f6109"
+    # test `digest!` branch: @assert  usedspace == blocklen(T) - 1
+    @test sha3_512("0" ^ 71) |> bytes2hex ==
+        "e6bb5d7cdde31df695c20516581127d9dab6e8d6c5196203d96a55251ce886b4824538baeaa519add156fd61633fec1ecffcc3e5d6c5a6d5da0f1c4d4e6f405e"
+    @test sha3_512("0" ^ 72) |> bytes2hex == 
+        "69eb8ccde4eec57d5e78512bf29081dc15d3ca650d5bf15cc9c0dfd7d7c477c067504fb99c7c787df248a9897cbeaeafeae563e855205660363dd700e1d43eee"
+end

--- a/stdlib/SHA/test/runtests.jl
+++ b/stdlib/SHA/test/runtests.jl
@@ -304,11 +304,11 @@ end
 @test nerrors == 0
 
 @testset "SHA3" begin
-    @test sha3_512("0" ^ 70) |> bytes2hex == 
+    @test sha3_512("0" ^ 70) |> bytes2hex ==
         "1ec3e5ebb442c09e7ab7a1ee18edfa1a9ec771ad243e3e3d65cad1730416109a0890e29f9314babd7ab018a246b2f9639af29ee09aec2352a2f94dc12a2f6109"
     # test `digest!` branch: @assert  usedspace == blocklen(T) - 1
     @test sha3_512("0" ^ 71) |> bytes2hex ==
         "e6bb5d7cdde31df695c20516581127d9dab6e8d6c5196203d96a55251ce886b4824538baeaa519add156fd61633fec1ecffcc3e5d6c5a6d5da0f1c4d4e6f405e"
-    @test sha3_512("0" ^ 72) |> bytes2hex == 
+    @test sha3_512("0" ^ 72) |> bytes2hex ==
         "69eb8ccde4eec57d5e78512bf29081dc15d3ca650d5bf15cc9c0dfd7d7c477c067504fb99c7c787df248a9897cbeaeafeae563e855205660363dd700e1d43eee"
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -168,7 +168,7 @@ end
             t = i % 2 == 0 ? mktempfile() : mktempdir()
             push!(temps, t)
             @test ispath(t)
-            @test length(TEMP_CLEANUP) == i 
+            @test length(TEMP_CLEANUP) == i
             @test TEMP_CLEANUP_MAX[] == n
             # delete 1/3 of the temp paths
             i % 3 == 0 && rm(t, recursive=true, force=true)


### PR DESCRIPTION
This is a bug:

```julia
sha3_512("0" ^ 70)
sha3_512("0" ^ 71)  # error
sha3_512("0" ^ 72)
```

1.8-dev works fine. 1.6.3 & 1.7 throw an error:

```
julia> sha3_512("0" ^ 71)
ERROR: ArgumentError: indexed assignment with a single value to many locations is not supported; perhaps use broadcasting `.=` instead?
Stacktrace:
...
```

original commit: JuliaCrypto/SHA.jl@97b17a7
