### PR TITLE
Optimize show(io::IO, m::Module)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1096,7 +1096,20 @@ function show(io::IO, m::Module)
     if is_root_module(m)
         print(io, nameof(m))
     else
-        print(io, join(fullname(m),"."))
+        print_fullname(io, m)
+    end
+end
+# The call to print_fullname above was originally `print(io, join(fullname(m),"."))`,
+# which allocates. The method below provides the same behavior without allocating.
+# See https://github.com/JuliaLang/julia/pull/42773 for perf information.
+function print_fullname(io::IO, m::Module)
+    mp = parentmodule(m)
+    if m === Main || m === Base || m === Core || mp === m
+        print(io, nameof(m))
+    else
+        print_fullname(io, mp)
+        print(io, '.')
+        print(io, nameof(m))
     end
 end
 


### PR DESCRIPTION
This method appeared as a hotspot in code that stringifies many types.
```
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0-DEV.702 (2021-10-10)
 _/ |\__'_|_|_|\__'_|  |  master/82257229c9 (fork: 1 commits, 12 days)
|__/                   |

julia> using BenchmarkTools

julia> module Foo
       module Bar
       module Baz
       module Qux
       end
       end
       end
       end
Main.Foo

julia> @benchmark show(devnull, Foo.Bar.Baz.Qux) # before replacement
BenchmarkTools.Trial: 10000 samples with 26 evaluations.
 Range (min … max):  889.500 ns …  59.991 μs  ┊ GC (min … max): 0.00% … 97.99%
 Time  (median):     978.615 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.052 μs ± 994.931 ns  ┊ GC (mean ± σ):  1.56% ±  1.70%

   ▇▆█▂
  ▆████▅▅▆▅▇▅▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▁▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  890 ns           Histogram: frequency by time         2.41 μs <

 Memory estimate: 640 bytes, allocs estimate: 17.

julia> @eval Base begin
           function show(io::IO, m::Module)
               if Base.is_root_module(m)
                   print(io, nameof(m))
               else
                   print_fullname(io, m)
               end
           end
           function print_fullname(io::IO, m::Module)
               _print_fullname(io, parentmodule(m))
               print(io, nameof(m))
           end
           function _print_fullname(io::IO, m::Module)
               mp = parentmodule(m)
               if m === Main || m === Base || m === Core || mp === m
                   print(io, nameof(m))
                   print(io, '.')
               else
                   _print_fullname(io, mp)
                   print(io, nameof(m))
                   print(io, '.')
               end
           end
       end
_print_fullname (generic function with 1 method)

julia> @benchmark show(devnull, Foo.Bar.Baz.Qux) # after replacement
BenchmarkTools.Trial: 10000 samples with 991 evaluations.
 Range (min … max):  39.268 ns … 227.557 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     44.397 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   45.804 ns ±   7.879 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂▆▆▁▁▄█▅ ▂▇▄
  █████████████▆▅▆▅▅▅▄▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▂▁▂▂▂▂▂▂▂▂▂▂ ▄
  39.3 ns         Histogram: frequency by time         80.1 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```