### PR TITLE
Emulated `fma`

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -385,7 +385,9 @@ function fma_emulated(a::Float64, b::Float64,c::Float64)
             r = abhi+c
             s = (abs(abhi) > abs(c)) ? (abhi-r+c+ablo) : (c-r+abhi+ablo)
             sumhi = r+s
-            if issubnormal(ldexp(sumhi, bias)) #black magic don't worry about it.
+            # If result is subnormal, ldexp will cause double rounding because subnormals have fewer mantisa bits.
+            # As such, we need to check whether round to even would lead to double rounding and manually round sumhi to avoid it.
+            if issubnormal(ldexp(sumhi, bias))
                 sumlo = r-sumhi+s
                 bits_lost = -bias-exponent(sumhi)-1022
                 sumhiInt = reinterpret(UInt64, sumhi)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1288,25 +1288,25 @@ end
 end
 
 @testset "fma" begin
-    for fma in (fma, Base.fma_emulated)
-        @test fma(nextfloat(1.),nextfloat(1.),-1.0) === 4.440892098500626e-16
-        @test fma(nextfloat(1f0),nextfloat(1f0),-1f0) === 2.3841858f-7
+    for func in (fma, Base.fma_emulated)
+        @test func(nextfloat(1.),nextfloat(1.),-1.0) === 4.440892098500626e-16
+        @test func(nextfloat(1f0),nextfloat(1f0),-1f0) === 2.3841858f-7
         @testset "$T" for T in (Float32, Float64)
-            @test fma(floatmax(T), T(2), -floatmax(T)) === floatmax(T)
-            @test fma(floatmax(T), T(1), eps(floatmax((T)))) === T(Inf)
-            @test fma(T(Inf), T(Inf), T(Inf)) === T(Inf)
-            @test isnan_type(T, fma(T(Inf), T(1), -T(Inf)))
-            @test isnan_type(T, fma(T(Inf), T(0), -T(0)))
-            @test fma(-zero(T), zero(T), -zero(T)) === -zero(T)
+            @test func(floatmax(T), T(2), -floatmax(T)) === floatmax(T)
+            @test func(floatmax(T), T(1), eps(floatmax((T)))) === T(Inf)
+            @test func(T(Inf), T(Inf), T(Inf)) === T(Inf)
+            @test isnan_type(T, func(T(Inf), T(1), -T(Inf)))
+            @test isnan_type(T, func(T(Inf), T(0), -T(0)))
+            @test func(-zero(T), zero(T), -zero(T)) === -zero(T)
             for _ in 1:2^18
                 a, b, c = reinterpret.(T, rand(Base.uinttype(T), 3))
-                @test isequal(Base.fma_emulated(a, b, c), fma(a, b, c)) || (a,b,c)
+                @test isequal(func(a, b, c), fma(a, b, c)) || (a,b,c)
             end
         end
-        @test fma(floatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
-        @test fma(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
-        @test fma(1.6341681540852291e308, -2., floatmax(Float64)) == -1.4706431733081426e308 # case where inv(a)*c*a == Inf
-        @test fma(-2., 1.6341681540852291e308, floatmax(Float64)) == -1.4706431733081426e308 # case where inv(b)*c*b == Inf
-        @test fma(-1.9369631f13, 2.1513551f-7, -1.7354427f-24) == -4.1670958f6
+        @test fmafuncfloatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
+        @test func(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
+        @test func(1.6341681540852291e308, -2., floatmax(Float64)) == -1.4706431733081426e308 # case where inv(a)*c*a == Inf
+        @test func(-2., 1.6341681540852291e308, floatmax(Float64)) == -1.4706431733081426e308 # case where inv(b)*c*b == Inf
+        @test func(-1.9369631f13, 2.1513551f-7, -1.7354427f-24) == -4.1670958f6
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1307,5 +1307,6 @@ end
         @test fma(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
         @test fma(1.6341681540852291e308, -2., floatmax(Float64)) == -1.4706431733081426e308 # case where inv(a)*c*a == Inf
         @test fma(-2., 1.6341681540852291e308, floatmax(Float64)) == -1.4706431733081426e308 # case where inv(b)*c*b == Inf
+        @test fma(-1.9369631f13, 2.1513551f-7, -1.7354427f-24) == -4.1670958f6
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1303,7 +1303,7 @@ end
                 @test isequal(func(a, b, c), fma(a, b, c)) || (a,b,c)
             end
         end
-        @test fmafuncfloatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
+        @test func(floatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
         @test func(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
         @test func(1.6341681540852291e308, -2., floatmax(Float64)) == -1.4706431733081426e308 # case where inv(a)*c*a == Inf
         @test func(-2., 1.6341681540852291e308, floatmax(Float64)) == -1.4706431733081426e308 # case where inv(b)*c*b == Inf

--- a/test/math.jl
+++ b/test/math.jl
@@ -1299,7 +1299,7 @@ end
             @test isnan_type(T, fma(T(Inf), T(0), -T(0)))
             @test fma(-zero(T), zero(T), -zero(T)) === -zero(T)
             for _ in 1:2^18
-                a, b, c = reinterpret.(T, rand(uinttype(T), 3))
+                a, b, c = reinterpret.(T, rand(Base.uinttype(T), 3))
                 @test isequal(Base.fma_emulated(a, b, c), fma(a, b, c)) || (a,b,c)
             end
         end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1286,3 +1286,16 @@ end
         @test_throws MethodError f(x)
     end
 end
+
+@testset "fma" begin
+    @test fma(nextfloat(1.),nextfloat(1.),-1.0) === 4.440892098500626e-16
+    @test fma(nextfloat(1f0),nextfloat(1f0),-1f0) === 2.3841858f-7
+    for T in (Float32, Float64)
+        @test fma(floatmax(T), T(2), -floatmax(T)) === floatmax(T)
+        @test fma(floatmax(T), T(1), eps(floatmax((T)))) === T(Inf)
+        @test isnan_type(T, fma(T(Inf), T(1), -T(Inf)))
+        @test isnan_type(T, fma(T(Inf), T(0), -T(0)))
+    end
+    @test fma(floatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
+    @test fma(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
+end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1288,14 +1288,24 @@ end
 end
 
 @testset "fma" begin
-    @test fma(nextfloat(1.),nextfloat(1.),-1.0) === 4.440892098500626e-16
-    @test fma(nextfloat(1f0),nextfloat(1f0),-1f0) === 2.3841858f-7
-    for T in (Float32, Float64)
-        @test fma(floatmax(T), T(2), -floatmax(T)) === floatmax(T)
-        @test fma(floatmax(T), T(1), eps(floatmax((T)))) === T(Inf)
-        @test isnan_type(T, fma(T(Inf), T(1), -T(Inf)))
-        @test isnan_type(T, fma(T(Inf), T(0), -T(0)))
+    for fma in (fma, Base.fma_emulated)
+        @test fma(nextfloat(1.),nextfloat(1.),-1.0) === 4.440892098500626e-16
+        @test fma(nextfloat(1f0),nextfloat(1f0),-1f0) === 2.3841858f-7
+        for T in (Float32, Float64)
+            @test fma(floatmax(T), T(2), -floatmax(T)) === floatmax(T)
+            @test fma(floatmax(T), T(1), eps(floatmax((T)))) === T(Inf)
+            @test fma(T(Inf), T(Inf), T(Inf)) === T(Inf)
+            @test isnan_type(T, fma(T(Inf), T(1), -T(Inf)))
+            @test isnan_type(T, fma(T(Inf), T(0), -T(0)))
+
+        end
+        @test fma(floatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
+        @test fma(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
+        @test fma(1.6341681540852291e308, -2., floatmax(Float64)) == -1.4706431733081426e308 # case where inv(a)*c*a == Inf
+        @test fma(-2., 1.6341681540852291e308, floatmax(Float64)) == -1.4706431733081426e308 # case where inv(b)*c*b == Inf
+        for _ in 1:2^18
+            a, b, c = reinterpret.(Float64, rand(-4503599627370497:9218868437227405311, 3))
+            @test Base.fma_emulated(a, b, c) === fma(a, b, c) || a,b,c
+        end
     end
-    @test fma(floatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
-    @test fma(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1297,7 +1297,7 @@ end
             @test fma(T(Inf), T(Inf), T(Inf)) === T(Inf)
             @test isnan_type(T, fma(T(Inf), T(1), -T(Inf)))
             @test isnan_type(T, fma(T(Inf), T(0), -T(0)))
-
+            @test fma(-zero(T), zero(T), -zero(T)) === -zero(T)
         end
         @test fma(floatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
         @test fma(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
@@ -1305,7 +1305,7 @@ end
         @test fma(-2., 1.6341681540852291e308, floatmax(Float64)) == -1.4706431733081426e308 # case where inv(b)*c*b == Inf
         for _ in 1:2^18
             a, b, c = reinterpret.(Float64, rand(-4503599627370497:9218868437227405311, 3))
-            @test Base.fma_emulated(a, b, c) === fma(a, b, c) || a,b,c
+            @test Base.fma_emulated(a, b, c) === fma(a, b, c) || (a,b,c)
         end
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -1291,21 +1291,21 @@ end
     for fma in (fma, Base.fma_emulated)
         @test fma(nextfloat(1.),nextfloat(1.),-1.0) === 4.440892098500626e-16
         @test fma(nextfloat(1f0),nextfloat(1f0),-1f0) === 2.3841858f-7
-        for T in (Float32, Float64)
+        @testset "$T" for T in (Float32, Float64)
             @test fma(floatmax(T), T(2), -floatmax(T)) === floatmax(T)
             @test fma(floatmax(T), T(1), eps(floatmax((T)))) === T(Inf)
             @test fma(T(Inf), T(Inf), T(Inf)) === T(Inf)
             @test isnan_type(T, fma(T(Inf), T(1), -T(Inf)))
             @test isnan_type(T, fma(T(Inf), T(0), -T(0)))
             @test fma(-zero(T), zero(T), -zero(T)) === -zero(T)
+            for _ in 1:2^18
+                a, b, c = reinterpret.(T, rand(uinttype(T), 3))
+                @test isequal(Base.fma_emulated(a, b, c), fma(a, b, c)) || (a,b,c)
+            end
         end
         @test fma(floatmax(Float64), nextfloat(1.0), -floatmax(Float64)) === 3.991680619069439e292
         @test fma(floatmax(Float32), nextfloat(1f0), -floatmax(Float32)) === 4.0564817f31
         @test fma(1.6341681540852291e308, -2., floatmax(Float64)) == -1.4706431733081426e308 # case where inv(a)*c*a == Inf
         @test fma(-2., 1.6341681540852291e308, floatmax(Float64)) == -1.4706431733081426e308 # case where inv(b)*c*b == Inf
-        for _ in 1:2^18
-            a, b, c = reinterpret.(Float64, rand(-4503599627370497:9218868437227405311, 3))
-            @test Base.fma_emulated(a, b, c) === fma(a, b, c) || (a,b,c)
-        end
     end
 end


### PR DESCRIPTION
This is about 10x slower than hardware (30x when a*b overflows).  On my machine, openlibm is around 75x slower, so this is a pretty major improvement (although admittedly, benchmarking this on modern hardware has limited value). This PR has tests for all the obvious edge cases I could think of, but it probably should have more. Thanks to everyone on the livestream who helped with this!