### PR TITLE
Fix RPATH of libLLVM.so on FreeBSD and Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,11 @@ ifeq ($(BUNDLE_DEBUG_LIBS),1)
 endif
 endif
 
+	# Set rpath for LLVM.so which is `$ORIGIN/../lib` moving from `../lib` to `../lib/julia`.  We only need to do this for Linux/FreeBSD
+ifneq (,$(findstring $(OS),Linux FreeBSD))
+	$(PATCHELF) --set-rpath '$$ORIGIN:$$ORIGIN/$(reverse_private_libdir_rel)' $(DESTDIR)$(private_libdir)/libLLVM.$(SHLIB_EXT)
+endif
+
 
 ifneq ($(LOADER_BUILD_DEP_LIBS),$(LOADER_INSTALL_DEP_LIBS))
 	# Next, overwrite relative path to libjulia-internal in our loader if $$(LOADER_BUILD_DEP_LIBS) != $$(LOADER_INSTALL_DEP_LIBS)


### PR DESCRIPTION
The RPATH of LLVM is wrong (https://github.com/JuliaPackaging/Yggdrasil/issues/3703) after we move it to `lib/julia`.
This causes us to not find `libz.so`.

I see three options:
1. Fix RPATH on installation
2. Fix RPATH on build (time consuming)
3. Preload libz in the loader (more invasive)

I went with `1.` since that fixes the wrong RPATH, without requiring a rebuild of LLVM or changing the loader.
