### PR TITLE
Fix contiguous view `fill!` method for `BitArray`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1471,7 +1471,7 @@ end
 end
 
 ## fill! contiguous views of BitArrays with a single value
-function fill!(V::SubArray{Bool, <:Any, <:BitArray, Tuple{AbstractUnitRange{Int}}}, x)
+function fill!(V::SubArray{Bool, <:Any, <:BitArray, <:Tuple{AbstractUnitRange{Int}}}, x)
     B = V.parent
     I0 = V.indices[1]
     l0 = length(I0)
@@ -1480,7 +1480,7 @@ function fill!(V::SubArray{Bool, <:Any, <:BitArray, Tuple{AbstractUnitRange{Int}
     return V
 end
 
-fill!(V::SubArray{Bool, <:Any, <:BitArray, Tuple{AbstractUnitRange{Int}, Vararg{Union{Int,AbstractUnitRange{Int}}}}}, x) =
+fill!(V::SubArray{Bool, <:Any, <:BitArray, <:Tuple{AbstractUnitRange{Int}, Vararg{Union{Int,AbstractUnitRange{Int}}}}}, x) =
     _unsafe_fill_indices!(V.parent, x, V.indices...)
 
 @generated function _unsafe_fill_indices!(B::BitArray, x,

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1750,12 +1750,21 @@ end
 end
 
 @testset "fill! for BitArray with contiguous view (#42795)" begin
-    bitvector = trues(10)
-    bitarray  = trues(10, 10)
-    for range in (1:5, 5:10)
-        viewvector = view(bitvector, range)
-        viewarray  = view(bitarray, range, range)
+    # change values in range `rangein`, `rangeout` should stay unchanged
+    for (rangein, rangeout) in ((1:5, 6:10), (5:10, 1:4))
+        bitvector = trues(10)
+        bitarray  = trues(10, 10)
+        viewvector = view(bitvector, rangein)
+        viewarray  = view(bitarray, rangein, rangein)
         @test which(fill!, (typeof(viewvector), Bool)).sig == Tuple{typeof(fill!), SubArray{Bool, <:Any, <:BitArray, <:Tuple{AbstractUnitRange{Int}}}, Any}
         @test which(fill!, (typeof(viewarray), Bool)).sig == Tuple{typeof(fill!), SubArray{Bool, <:Any, <:BitArray, <:Tuple{AbstractUnitRange{Int}, Vararg{Union{Int,AbstractUnitRange{Int}}}}}, Any}
+        fill!(viewvector, false)
+        fill!(viewarray, false)
+        @test all(bitvector[rangein] .== false)
+        @test all(bitvector[rangeout] .== true)
+        @test all(bitarray[rangein, rangein] .== false)
+        @test all(bitarray[rangeout, rangeout] .== true)
+        @test all(bitarray[rangeout, rangein] .== true)
+        @test all(bitarray[rangein, rangeout] .== true)
     end
 end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1748,3 +1748,14 @@ end
         @test test_equivalence(n)
     end
 end
+
+@testset "fill! for BitArray with contiguous view (#42795)" begin
+    bitvector = trues(10)
+    bitarray  = trues(10, 10)
+    for range in (1:5, 5:10)
+        viewvector = view(bitvector, range)
+        viewarray  = view(bitarray, range, range)
+        @test which(fill!, (typeof(viewvector), Bool)).sig == Tuple{typeof(fill!), SubArray{Bool, <:Any, <:BitArray, <:Tuple{AbstractUnitRange{Int}}}, Any}
+        @test which(fill!, (typeof(viewarray), Bool)).sig == Tuple{typeof(fill!), SubArray{Bool, <:Any, <:BitArray, <:Tuple{AbstractUnitRange{Int}, Vararg{Union{Int,AbstractUnitRange{Int}}}}}, Any}
+    end
+end


### PR DESCRIPTION
This PR fixes wrong type signature in contiguous view `fill!` method for `BitArray` as well as adds tests (fixes #42795)