### PR TITLE
Make `IndexStyle(::AbstractVector)` return `IndexLinear()` by default

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -77,7 +77,7 @@ type:
 
     Base.IndexStyle(::Type{<:MyArray}) = IndexLinear()
 
-The default is [`IndexCartesian()`](@ref).
+The default is [`IndexCartesian()`](@ref), unless the input's dimension is explicitly less than 2.
 
 Julia's internal indexing machinery will automatically (and invisibly)
 recompute all indexing operations into the preferred style. This allows users
@@ -90,12 +90,19 @@ methods check this trait on their inputs, and dispatch to different
 algorithms depending on the most efficient access pattern. In
 particular, [`eachindex`](@ref) creates an iterator whose type depends
 on the setting of this trait.
+
+!!! note
+    It is recommended to only set [`IndexLinear()`](@ref) for needed cases.
+    Arbitrary dimensional definition might make vector-like types treated as
+    [`IndexCartesian()`](@ref).
+
 """
 IndexStyle(A::AbstractArray) = IndexStyle(typeof(A))
 IndexStyle(::Type{Union{}}) = IndexLinear()
-IndexStyle(::Type{<:AbstractArray}) = IndexCartesian()
+_islinear(::Type{<:AbstractArray}) = false
+_islinear(::Type{<:Union{AbstractVector, AbstractZeroDimArray}}) = true
+IndexStyle(::Type{T}) where {T<:AbstractArray} = _islinear(T) ? IndexLinear() : IndexCartesian()
 IndexStyle(::Type{<:Array}) = IndexLinear()
-IndexStyle(::Type{<:AbstractRange}) = IndexLinear()
 
 IndexStyle(A::AbstractArray, B::AbstractArray) = IndexStyle(IndexStyle(A), IndexStyle(B))
 IndexStyle(A::AbstractArray, B::AbstractArray...) = IndexStyle(IndexStyle(A), IndexStyle(B...))

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -100,7 +100,8 @@ on the setting of this trait.
 IndexStyle(A::AbstractArray) = IndexStyle(typeof(A))
 IndexStyle(::Type{Union{}}) = IndexLinear()
 _islinear(::Type{<:AbstractArray}) = false
-_islinear(::Type{<:Union{AbstractVector, AbstractZeroDimArray}}) = true
+_islinear(::Type{<:AbstractArray{<:Any, 0}}) = true
+_islinear(::Type{<:AbstractArray{<:Any, 1}}) = true
 IndexStyle(::Type{T}) where {T<:AbstractArray} = _islinear(T) ? IndexLinear() : IndexCartesian()
 IndexStyle(::Type{<:Array}) = IndexLinear()
 

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -77,7 +77,7 @@ type:
 
     Base.IndexStyle(::Type{<:MyArray}) = IndexLinear()
 
-The default is [`IndexCartesian()`](@ref), unless the input's dimension is explicitly less than 2.
+The default is [`IndexCartesian()`](@ref), unless the input's dimension is explicitly 1.
 
 Julia's internal indexing machinery will automatically (and invisibly)
 recompute all indexing operations into the preferred style. This allows users
@@ -99,10 +99,8 @@ on the setting of this trait.
 """
 IndexStyle(A::AbstractArray) = IndexStyle(typeof(A))
 IndexStyle(::Type{Union{}}) = IndexLinear()
-_islinear(::Type{<:AbstractArray}) = false
-_islinear(::Type{<:AbstractArray{<:Any, 0}}) = true
-_islinear(::Type{<:AbstractArray{<:Any, 1}}) = true
-IndexStyle(::Type{T}) where {T<:AbstractArray} = _islinear(T) ? IndexLinear() : IndexCartesian()
+IndexStyle(::Type{<:AbstractArray}) = IndexCartesian()
+IndexStyle(::Type{<:AbstractArray{<:Any, 1}}) = IndexLinear()
 IndexStyle(::Type{<:Array}) = IndexLinear()
 
 IndexStyle(A::AbstractArray, B::AbstractArray) = IndexStyle(IndexStyle(A), IndexStyle(B))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -350,7 +350,6 @@ module IteratorsMD
 
     # AbstractArray implementation
     Base.axes(iter::CartesianIndices{N,R}) where {N,R} = map(Base.axes1, iter.indices)
-    Base.IndexStyle(::Type{CartesianIndices{N,R}}) where {N,R} = IndexCartesian()
     # getindex for a 0D CartesianIndices is necessary for disambiguation
     @propagate_inbounds function Base.getindex(iter::CartesianIndices{0,R}) where {R}
         CartesianIndex()

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -349,7 +349,6 @@ function setindex!(V::FastContiguousSubArray{<:Any, 1}, x, i::Int)
 end
 
 IndexStyle(::Type{<:FastSubArray}) = IndexLinear()
-IndexStyle(::Type{<:SubArray}) = IndexCartesian()
 
 # Strides are the distance in memory between adjacent elements in a given dimension
 # which we determine from the strides of the parent

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -174,7 +174,6 @@ size(A::AdjOrTransAbsMat) = reverse(size(A.parent))
 axes(v::AdjOrTransAbsVec) = (Base.OneTo(1), axes(v.parent)...)
 axes(A::AdjOrTransAbsMat) = reverse(axes(A.parent))
 IndexStyle(::Type{<:AdjOrTransAbsVec}) = IndexLinear()
-IndexStyle(::Type{<:AdjOrTransAbsMat}) = IndexCartesian()
 @propagate_inbounds getindex(v::AdjOrTransAbsVec{T}, i::Int) where {T} = wrapperop(v)(v.parent[i-1+first(axes(v.parent)[1])])::T
 @propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, i::Int, j::Int) where {T} = wrapperop(A)(A.parent[j, i])::T
 @propagate_inbounds setindex!(v::AdjOrTransAbsVec, x, i::Int) = (setindex!(v.parent, wrapperop(v)(x), i-1+first(axes(v.parent)[1])); v)

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -32,8 +32,8 @@ SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
 
 # Define an alias for a view of a whole column of a SparseMatrixCSC. Many methods can be written for the
 # union of such a view and a SparseVector so we define an alias for such a union as well
-const SparseColumnView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
-const SparseVectorView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}}},false}
+const SparseColumnView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}},Int}}
+const SparseVectorView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}}}}
 const SparseVectorUnion{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
 const AdjOrTransSparseVectorUnion{Tv,Ti} = LinearAlgebra.AdjOrTrans{Tv, <:SparseVectorUnion{Tv,Ti}}
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1054,7 +1054,7 @@ end
     @test IndexStyle(MyArray) == IndexCartesian()
     @test IndexStyle(MyArray{Real}) == IndexCartesian()
     @test IndexStyle(MyArray{Real, 1}) == IndexLinear()
-    @test IndexStyle(MyArray{Real, 0}()) == IndexLinear()
+    @test IndexStyle(MyArray{Real, 1}()) == IndexLinear()
     @test Base.IndexStyle(UpperTriangular) == IndexCartesian() # subtype of AbstractArray, not of Array
     @test Base.IndexStyle(Vector) == IndexLinear()
     @test Base.IndexStyle(UnitRange) == IndexLinear()

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1050,6 +1050,11 @@ end
 end
 
 @testset "IndexStyle for various types" begin
+    struct MyArray{T,N} <: AbstractArray{T,N} end
+    @test IndexStyle(MyArray) == IndexCartesian()
+    @test IndexStyle(MyArray{Real}) == IndexCartesian()
+    @test IndexStyle(MyArray{Real, 1}) == IndexLinear()
+    @test IndexStyle(MyArray{Real, 0}()) == IndexLinear()
     @test Base.IndexStyle(UpperTriangular) == IndexCartesian() # subtype of AbstractArray, not of Array
     @test Base.IndexStyle(Vector) == IndexLinear()
     @test Base.IndexStyle(UnitRange) == IndexLinear()


### PR DESCRIPTION
This PR attempts to make `IndexStyle` return `IndexLinear()` by default if the input's dimension is known to be ~less than 2~ 1.
`IndexStyle` in `Base` that always return `IndexCartesian()` is removed (to fallback to the default method).

The motivations to do such change includeing:
1. `eachindex(a::AbstractVector)` returns `axes(a, 1)` by default.
2. Some functions, like `Base.copyto_unaliased` is dispatched based on IndexStyle.

Test added.