### PR TITLE
allow pwd take paths as argument

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -64,6 +64,27 @@ function pwd()
     end
 end
 
+"""
+    pwd(paths...) -> AbstractString
+
+Get the current working directory joined with `paths`.
+
+# Examples
+
+```julia-repl
+julia> pwd("mypath")
+"/home/JuliaUser/mypath"
+
+julia> cd("/home/JuliaUser/Projects/julia")
+
+julia> pwd("mypath", "dir")
+"/home/JuliaUser/Projects/julia/mypath/dir"
+```
+"""
+function pwd(path::String, paths::String...)
+    joinpath(pwd(), path, paths...)
+end
+
 
 """
     cd(dir::AbstractString=homedir())

--- a/test/file.jl
+++ b/test/file.jl
@@ -1695,3 +1695,7 @@ end
         @test !isnothing(Base.Filesystem.getgroupname(s.gid))
     end
 end
+
+@testset "pwd(paths...)" begin
+    @test pwd("mypath") == joinpath(pwd(), "mypath")
+end


### PR DESCRIPTION
just find this seems quite convenient when accessing subdir of current working directory (similar to the `pkgdir` interface)