### PR TITLE
CI (Buildkite): make sure to gitignore any unencrypted repo keys, regardless of where they are located in the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@
 .DS_Store
 .idea/*
 .vscode/*
+
+# Buildkite: cryptic plugin
+# Ignore the unencrypted repo_key
+repo_key
+# Ignore any agent keys (public or private) we have stored
+agent_key*


### PR DESCRIPTION
This will prevent the user from accidentally checking the repo keys into source control, even if the user puts the repo key in the wrong folder.