### PR TITLE
optimizer: inline union-split, abstract callsite

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -5,7 +5,7 @@ module Sort
 import ..@__MODULE__, ..parentmodule
 const Base = parentmodule(@__MODULE__)
 using .Base.Order
-using .Base: copymutable, LinearIndices, length, (:),
+using .Base: copymutable, LinearIndices, length, (:), iterate,
     eachindex, axes, first, last, similar, zip, OrdinalRange,
     AbstractVector, @inbounds, AbstractRange, @eval, @inline, Vector, @noinline,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,


### PR DESCRIPTION
Currently we can inline (or `:invoke`) abstract callsite only when there
is a single dispatch candidate, and inlining and static-dispatch will
fail when the callsite is union-split (in other word, our inlinear can
handle union-split callsite only when all the dispatch candidates are concrete):
```julia
julia> @inline isType(@nospecialize t) = isa(t, DataType) && t.name === Type.body.name
isType (generic function with 1 method)

julia> code_typed((Any,)) do x # very abstract, successful inlining
           isType(x)
       end |> only
CodeInfo(
1 ─ %1 = (x isa Main.DataType)::Bool
└──      goto #3 if not %1
2 ─ %3 = π (x, DataType)
│   %4 = Base.getfield(%3, :name)::Core.TypeName
│   %5 = Base.getfield(Type{T}, :name)::Core.TypeName
│   %6 = (%4 === %5)::Bool
└──      goto #4
3 ─      goto #4
4 ┄ %9 = φ (#2 => %6, #3 => false)::Bool
└──      return %9
) => Bool

julia> code_typed((Union{Type,Nothing},)) do x # union-split, unsuccessful inlining
           isType(x)
       end |> only
CodeInfo(
1 ─ %1 = (isa)(x, Nothing)::Bool
└──      goto #3 if not %1
2 ─      goto #4
3 ─ %4 = Main.isType(x)::Bool
└──      goto #4
4 ┄ %6 = φ (#2 => false, #3 => %4)::Bool
└──      return %6
) => Bool
```
Note that this is a limitation of inlinear and so user-provided hints
(like callsite inlining) doesn't help here.

This commit enables inlining and static dispatch for union-split,
abstract callsite. The key insight is that we can simulate the dispatch
semantics by generating `isa` checks by sorting dispatch candidates by
their signature specialities and processing them in that order.
```julia
julia> code_typed((Union{Type,Nothing},)) do x # union-split, unsuccessful inlining
                  isType(x)
              end |> only
CodeInfo(
1 ─ %1  = (isa)(x, Nothing)::Bool
└──       goto #3 if not %1
2 ─       goto #9
3 ─ %4  = (isa)(x, Type)::Bool
└──       goto #8 if not %4
4 ─ %6  = π (x, Type)
│   %7  = (%6 isa Main.DataType)::Bool
└──       goto #6 if not %7
5 ─ %9  = π (%6, DataType)
│   %10 = Base.getfield(%9, :name)::Core.TypeName
│   %11 = Base.getfield(Type{T}, :name)::Core.TypeName
│   %12 = (%10 === %11)::Bool
└──       goto #7
6 ─       goto #7
7 ┄ %15 = φ (#5 => %12, #6 => false)::Bool
└──       goto #9
8 ─       Core.throw(ErrorException("fatal error in type inference (type bound)"))::Union{}
└──       unreachable
9 ┄ %19 = φ (#2 => false, #7 => %15)::Bool
└──       return %19
) => Bool
```

Inlined and/or statically-resolved union-split abstract callsite will
hopefully improve the performance in general, and also, it seems to help
us avoid some excessive specializations by statically-resolving `@nospecialize`d
callsites. Especially, the # of precompiled statements is reduced to `1385`
(this commit) from `1517` ([`master`](021a6b5ec99639a38a639b0df993259d58cdd57b)),
probably because this commit eliminates some specializations in `Core.Compiler` code.
And also as a side effect, the implementation of inlinear gets a bit
simplified since now we no longer need the special casing for abstract callsites.

On the other hand, one of the obvious possible drawback is code size. 
This change certainly increases the size of sysimage:
- `du -sh usr/lib/julia/*`:
  * [`master`](https://github.com/JuliaLang/julia/tree/021a6b5ec99639a38a639b0df993259d58cdd57b): 
    ```
    14M    usr/lib/julia/corecompiler.ji
    168M    usr/lib/julia/sys-o.a
    147M    usr/lib/julia/sys.dylib
    20M    usr/lib/julia/sys.dylib.dSYM
    92M    usr/lib/julia/sys.ji
    ```
  * this PR: 
    ```
    17M    usr/lib/julia/corecompiler.ji
    172M    usr/lib/julia/sys-o.a
    150M    usr/lib/julia/sys.dylib
    21M    usr/lib/julia/sys.dylib.dSYM
    95M    usr/lib/julia/sys.ji
    ```
- `@time using Plots; @time plot(rand(10,3));`:
  * [`master`](https://github.com/JuliaLang/julia/tree/021a6b5ec99639a38a639b0df993259d58cdd57b): 
    ```
    4.876865 seconds (9.28 M allocations: 621.216 MiB, 4.59% gc time, 15.95% compilation time)
    2.925683 seconds (3.78 M allocations: 212.344 MiB, 7.43% gc time, 99.76% compilation time)
    ```
  * this PR: 
    ```
    4.920593 seconds (9.34 M allocations: 624.358 MiB, 4.49% gc time, 16.14% compilation time)
    2.928010 seconds (3.75 M allocations: 209.238 MiB, 7.53% gc time, 99.77% compilation time)
    ```
And so if there is not much performance benefit, we may want to just keep
the current status (i.e. only inline if there is a single abstract dispatch candidate).