### PR TITLE
Support missing values in `dot`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -904,6 +904,9 @@ function dot(x, y) # arbitrary iterables
 end
 
 dot(x::Number, y::Number) = conj(x) * y
+dot(::Missing, ::Number) = missing
+dot(::Number, ::Missing) = missing
+dot(::Missing, ::Missing) = missing
 
 function dot(x::AbstractArray, y::AbstractArray)
     lx = length(x)

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -456,6 +456,11 @@ dot2(x,y) = invoke(dot, Tuple{AbstractArray,AbstractArray}, x,y)
     end
 end
 
+@testset "dot with missings" begin
+    @test dot(1, missing) === dot(missing, 1) === dot(missing, missing) === missing
+    @test dot([1, missing], [1, 2]) === dot([1, 2], [1, missing]) === missing
+end
+
 @testset "Issue 11978" begin
     A = Matrix{Matrix{Float64}}(undef, 2, 2)
     A[1,1] = Matrix(1.0I, 3, 3)


### PR DESCRIPTION
This is more consistent with matrix product, which propagates `missing` automatically since `*` and `+` are defined for it.

This is needed to avoid a regression in `Statistics.cov` in Julia 1.7 compared with 1.6. https://github.com/JuliaLang/Statistics.jl/pull/85 replaced a call to `sum(conj(y[i])*x[i] for i in eachindex(y, x))` with `dot(y, x)`, which is numerically more stable and was originally used before Statistics was moved to the stdlib (at the time LinearAlgebra was still in Base so `dot` could not be used from an stdlib). But this change currently makes `cov` throw an error when the input contains `missing`, which was not the case in Julia 1.6. This currently makes StatsBase tests fail on Julia 1.7.

EDIT: a solution in Statistics is to use `adjoint(y) * x` instead of `dot(y, x)`, as the former falls back to the latter for arrays of `Number`s but to `sum(uu*vv for (uu, vv) in zip(u, v))` for other types. See https://github.com/JuliaLang/Statistics.jl/pull/94. Though it can still be useful to support missing values with `dot`.