### PR TITLE
Bump Statistics.jl version

### DIFF
--- a/stdlib/Statistics.version
+++ b/stdlib/Statistics.version
@@ -1,4 +1,4 @@
 STATISTICS_BRANCH = master
-STATISTICS_SHA1 = 74897fed33700dba92578aa0fefef5b99ba16086
+STATISTICS_SHA1 = 52998f2c611f69d1ff49aebbb8208328775334f4
 STATISTICS_GIT_URL := git://github.com/JuliaLang/Statistics.jl.git
 STATISTICS_TAR_URL = https://api.github.com/repos/JuliaLang/Statistics.jl/tarball/$1


### PR DESCRIPTION
#42692 makes some changes to boundscheck emission which allows better constant folding by LLVM. This interacts poorly with some Statistics.jl tests which checked for === 0/0. Those tests have been fixed during this version bump. 