### PR TITLE
only visit nonfunction_mt once when traversing method tables

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -442,7 +442,7 @@ static void foreach_mtable_in_module(
                     jl_typename_t *tn = ((jl_datatype_t*)v)->name;
                     if (tn->module == m && tn->name == b->name) {
                         jl_methtable_t *mt = tn->mt;
-                        if (mt != NULL && (jl_value_t*)mt != jl_nothing && mt != jl_type_type_mt) {
+                        if (mt != NULL && (jl_value_t*)mt != jl_nothing && mt != jl_type_type_mt && mt != jl_nonfunction_mt) {
                             visit(mt, env);
                         }
                     }
@@ -467,6 +467,7 @@ void jl_foreach_reachable_mtable(void (*visit)(jl_methtable_t *mt, void *env), v
     JL_GC_PUSH2(&visited, &mod_array);
     mod_array = jl_get_loaded_modules();
     visit(jl_type_type_mt, env);
+    visit(jl_nonfunction_mt, env);
     if (mod_array) {
         int i;
         for (i = 0; i < jl_array_len(mod_array); i++) {


### PR DESCRIPTION
This was causing us to insert many copies of MethodInstances in the precompile array, for example. That is probably harmless, but might as well avoid visiting the same object many times.