### PR TITLE
change `julia` to `julia-repl` in docstrings

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -992,7 +992,7 @@ then their contents are vertically concatenated together.
 In the standard REPL, typing `;` on an empty line will switch to shell mode.
 
 # Examples
-```julia-repl
+```jldoctest
 julia> function foo()
            x = "Hello, "; x *= "World!"
            return x

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -992,7 +992,7 @@ then their contents are vertically concatenated together.
 In the standard REPL, typing `;` on an empty line will switch to shell mode.
 
 # Examples
-```julia
+```julia-repl
 julia> function foo()
            x = "Hello, "; x *= "World!"
            return x

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -358,7 +358,7 @@ or `nothing` if `m` was not imported from a package. Optionally further
 path component strings can be provided to construct a path within the
 package root.
 
-```julia
+```julia-repl
 julia> pkgdir(Foo)
 "/path/to/Foo.jl"
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -552,7 +552,7 @@ julia> withenv("LINES" => 30, "COLUMNS" => 100) do
 
 To get your TTY size,
 
-```julia
+```julia-repl
 julia> displaysize(stdout)
 (34, 147)
 ```
@@ -1328,7 +1328,7 @@ Possible values for each stream are:
 * `io` an `IOStream`, `TTY`, `Pipe`, socket, or `devnull`.
 
 # Examples
-```julia
+```julia-repl
 julia> redirect_stdio(stdout="stdout.txt", stderr="stderr.txt") do
            print("hello stdout")
            print(stderr, "hello stderr")
@@ -1344,14 +1344,14 @@ julia> read("stderr.txt", String)
 # Edge cases
 
 It is possible to pass the same argument to `stdout` and `stderr`:
-```julia
+```julia-repl
 julia> redirect_stdio(stdout="log.txt", stderr="log.txt", stdin=devnull) do
     ...
 end
 ```
 
 However it is not supported to pass two distinct descriptors of the same file.
-```julia
+```julia-repl
 julia> io1 = open("same/path", "w")
 
 julia> io2 = open("same/path", "w")
@@ -1359,7 +1359,7 @@ julia> io2 = open("same/path", "w")
 julia> redirect_stdio(f, stdout=io1, stderr=io2) # not suppored
 ```
 Also the `stdin` argument may not be the same descriptor as `stdout` or `stderr`.
-```julia
+```julia-repl
 julia> io = open(...)
 
 julia> redirect_stdio(f, stdout=io, stdin=io) # not supported

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -63,7 +63,7 @@ representation, even though it is exact from the standpoint of binary
 representation.
 
 Example:
-```julia
+```julia-repl
 julia> 1.0 + 1.0001e-15
 1.000000000000001
 
@@ -94,7 +94,7 @@ numbers. Mathematically, `zhi + zlo = x * y`, where `zhi` contains the
 most significant bits and `zlo` the least significant.
 
 Example:
-```julia
+```julia-repl
 julia> x = Float32(π)
 3.1415927f0
 
@@ -126,7 +126,7 @@ numbers. Mathematically, `zhi + zlo ≈ x / y`, where `zhi` contains the
 most significant bits and `zlo` the least significant.
 
 Example:
-```julia
+```julia-repl
 julia> x, y = Float32(π), 3.1f0
 (3.1415927f0, 3.1f0)
 

--- a/doc/src/devdocs/boundscheck.md
+++ b/doc/src/devdocs/boundscheck.md
@@ -54,7 +54,7 @@ end
 Which quietly assumes 1-based indexing and therefore exposes unsafe memory access when used
 with [`OffsetArrays`](@ref man-custom-indice):
 
-```julia
+```julia-repl
 julia> using OffsetArrays
 julia> sum(OffsetArray([1,2,3], -10))
 9164911648 # inconsistent results or segfault

--- a/doc/src/devdocs/boundscheck.md
+++ b/doc/src/devdocs/boundscheck.md
@@ -56,6 +56,7 @@ with [`OffsetArrays`](@ref man-custom-indice):
 
 ```julia-repl
 julia> using OffsetArrays
+
 julia> sum(OffsetArray([1,2,3], -10))
 9164911648 # inconsistent results or segfault
 ```

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -481,7 +481,7 @@ Instead of destructuring based on iteration, the right side of assignments can a
 This follows the syntax for NamedTuples, and works by assigning to each variable on the left a
 property of the right side of the assignment with the same name using `getproperty`:
 
-```julia-repl
+```jldoctest
 julia> (; b, a) = (a=1, b=2, c=3)
 (a = 1, b = 2, c = 3)
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -481,7 +481,7 @@ Instead of destructuring based on iteration, the right side of assignments can a
 This follows the syntax for NamedTuples, and works by assigning to each variable on the left a
 property of the right side of the assignment with the same name using `getproperty`:
 
-```julia
+```julia-repl
 julia> (; b, a) = (a=1, b=2, c=3)
 (a = 1, b = 2, c = 3)
 
@@ -498,7 +498,7 @@ The destructuring feature can also be used within a function argument.
 If a function argument name is written as a tuple (e.g. `(x, y)`) instead of just
 a symbol, then an assignment `(x, y) = argument` will be inserted for you:
 
-```julia
+```julia-repl
 julia> minmax(x, y) = (y < x) ? (y, x) : (x, y)
 
 julia> gap((min, max)) = max - min
@@ -512,7 +512,7 @@ would be a two-argument function, and this example would not work.
 
 Similarly, property destructuring can also be used for function arguments:
 
-```julia
+```julia-repl
 julia> foo((; x, y)) = x + y
 foo (generic function with 1 method)
 

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -205,7 +205,7 @@ For example, `Base` exports the function name `read`, but the CSV.jl package als
 If we are going to invoke CSV reading many times, it would be convenient to drop the `CSV.` qualifier.
 But then it is ambiguous whether we are referring to `Base.read` or `CSV.read`:
 
-```julia
+```julia-repl
 julia> read;
 
 julia> import CSV: read
@@ -214,7 +214,7 @@ WARNING: ignoring conflicting import of CSV.read into Main
 
 Renaming provides a solution:
 
-```julia
+```julia-repl
 julia> import CSV: read as rd
 ```
 

--- a/doc/src/manual/workflow-tips.md
+++ b/doc/src/manual/workflow-tips.md
@@ -104,7 +104,7 @@ the following modifications:
 
      Navigate to your temporary directory and launch Julia, then do the following:
 
-     ```julia
+     ```julia-repl
      pkg> generate MyPkg            # type ] to enter pkg mode
      julia> push!(LOAD_PATH, pwd())   # hit backspace to exit pkg mode
      ```
@@ -123,7 +123,7 @@ the following modifications:
    Then navigate to the directory containing your test file (here
    assumed to be `"runtests.jl"`) and do the following:
 
-   ```julia
+   ```julia-repl
    julia> using MyPkg
 
    julia> include("runtests.jl")

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -248,7 +248,7 @@ distinct payload. Each callback, when called, will receive `Dict` which will hol
 callback's custom payload which can be accessed using the callback name.
 
 # Examples
-```julia
+```julia-repl
 julia> c = LibGit2.Callbacks(:credentials => (LibGit2.credentials_cb(), LibGit2.CredentialPayload()));
 
 julia> LibGit2.clone(url, callbacks=c);

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -669,7 +669,7 @@ v  [ ] blueberry
 
 can instead be rendered with Unicode selection and navigation characters with
 
-```julia
+```julia-repl
 julia> menu = MultiSelectMenu(options, pagesize=5, charset=:unicode);
 
 julia> request(menu)
@@ -683,7 +683,7 @@ julia> request(menu)
 
 More fine-grained configuration is also possible:
 
-```julia
+```julia-repl
 julia> menu = MultiSelectMenu(options, pagesize=5, charset=:unicode, checked="YEP!", unchecked="NOPE", cursor='⧐');
 
 julia> request(menu)

--- a/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
@@ -8,7 +8,7 @@ A menu that allows a user to select a multiple options from a list.
 
 # Sample Output
 
-```julia
+```julia-repl
 julia> request(MultiSelectMenu(options))
 Select the fruits you like:
 [press: d=done, a=all, n=none]

--- a/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/RadioMenu.jl
@@ -8,7 +8,7 @@ A menu that allows a user to select a single option from a list.
 
 # Sample Output
 
-```julia
+```julia-repl
 julia> request(RadioMenu(options, pagesize=4))
 Choose your favorite fruit:
 ^  grape


### PR DESCRIPTION
changes code blocks in docstrings from `julia` to `julia-repl` when appropriate
some of them should maybe be changed to `jldoctest`, feel free to change them

this is visible when using `OhMyREPL`, where they are not rendered properly:

![Capture](https://user-images.githubusercontent.com/35898736/139058561-4280b61b-f366-4af1-b49b-071373dadecb.PNG)

hopefully I got them all (I searched with `r"```julia\n[ ]*julia>"`)
