### PR TITLE
Fix no-codegen test on musl64 tester

### DIFF
--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -640,7 +640,7 @@ U41096 = Term41096{:U}(Modulate41096(:U, false))
 
 # test that we can start julia with libjulia-codegen removed; PR #41936
 mktempdir() do pfx
-    run(`cp -r $(Sys.BINDIR)/.. $pfx`)
+    cp(dirname(Sys.BINDIR), pfx; force=true)
     run(`rm -rf $pfx/lib/julia/libjulia-codegen\*`)
     @test readchomp(`$pfx/bin/$(Base.julia_exename()) -e 'println("no codegen!")'`) == "no codegen!"
 end

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -4,6 +4,7 @@
 
 using Random
 using InteractiveUtils
+using Libdl
 
 const opt_level = Base.JLOptions().opt_level
 const coverage = (Base.JLOptions().code_coverage > 0) || (Base.JLOptions().malloc_log > 0)
@@ -641,7 +642,13 @@ U41096 = Term41096{:U}(Modulate41096(:U, false))
 # test that we can start julia with libjulia-codegen removed; PR #41936
 mktempdir() do pfx
     cp(dirname(Sys.BINDIR), pfx; force=true)
-    run(`rm -rf $pfx/lib/julia/libjulia-codegen\*`)
+    libpath = relpath(dirname(dlpath("libjulia-codegen")), dirname(Sys.BINDIR))
+    libs_deleted = 0
+    for f in filter(f -> startswith(f, "libjulia-codegen"), readdir(joinpath(pfx, libpath)))
+        rm(f; force=true, recursive=true)
+        libs_deleted += 1
+    end
+    @test libs_deleted > 0
     @test readchomp(`$pfx/bin/$(Base.julia_exename()) -e 'println("no codegen!")'`) == "no codegen!"
 end
 


### PR DESCRIPTION
Apparently, busybox has strange behavior when you copy `$pfx/..` and the destination directory exists:

```
$ docker run -ti alpine
# mkdir -p /tmp/foo/bar; touch /tmp/foo/bar/a /tmp/foo/bar/b
# cp -vr /tmp/foo/bar/.. /tmp/foo2
'/tmp/foo/bar/../bar/a' -> '/tmp/foo2/bar/a'
'/tmp/foo/bar/../bar/b' -> '/tmp/foo2/bar/b'
'/tmp/foo/bar/../bar' -> '/tmp/foo2/bar'
'/tmp/foo/bar/..' -> '/tmp/foo2'
# cp -vr /tmp/foo/bar/.. /tmp/foo2
'/tmp/foo/bar/../bar/a' -> '/tmp/foo2/../bar/a'
'/tmp/foo/bar/../bar/b' -> '/tmp/foo2/../bar/b'
'/tmp/foo/bar/../bar' -> '/tmp/foo2/../bar'
'/tmp/foo/bar/..' -> '/tmp/foo2/..'
```

We'll dodge this by using Julia's `cp()` function.