### PR TITLE
optimizer: fix #42840, the performance regression introduced by #42766

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1340,9 +1340,8 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
                         ir, idx, stmt, info, sig,
                         state, flag, sig.f === Core.invoke, todo) && continue
                 end
-            else
-                info = info.call
             end
+            info = info.call # cascade to the non-constant handling
         end
 
         if isa(info, OpaqueClosureCallInfo)


### PR DESCRIPTION
Excited to tag the "embrassing-bugfix" label for the first time..

I will make a simple test case.

@nanosoldier `runbenchmarks("union" || "array", vs="@2e388e3731fcdd8d1db4c1aed5c6a39df3ef7153")`

