### PR TITLE
Simplify minimum/maximum on sparse vectors

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1372,7 +1372,7 @@ end
 
 ### Reduction
 
-function _sum(f, x::AbstractSparseVector)
+function sum(f, x::AbstractSparseVector)
     n = length(x)
     n > 0 || return sum(f, nonzeros(x)) # return zero() of proper type
     m = nnz(x)
@@ -1381,11 +1381,9 @@ function _sum(f, x::AbstractSparseVector)
      Base.add_sum((n - m) * f(zero(eltype(x))), sum(f, nonzeros(x))))
 end
 
-sum(f::Union{Function, Type}, x::AbstractSparseVector) = _sum(f, x) # resolve ambiguity
-sum(f, x::AbstractSparseVector) = _sum(f, x)
 sum(x::AbstractSparseVector) = sum(nonzeros(x))
 
-function _maximum(f, x::AbstractSparseVector)
+function maximum(f, x::AbstractSparseVector)
     n = length(x)
     if n == 0
         if f === abs || f === abs2
@@ -1400,11 +1398,9 @@ function _maximum(f, x::AbstractSparseVector)
      max(f(zero(eltype(x))), maximum(f, nonzeros(x))))
 end
 
-maximum(f::Union{Function, Type}, x::AbstractSparseVector) = _maximum(f, x) # resolve ambiguity
-maximum(f, x::AbstractSparseVector) = _maximum(f, x)
 maximum(x::AbstractSparseVector) = maximum(identity, x)
 
-function _minimum(f, x::AbstractSparseVector)
+function minimum(f, x::AbstractSparseVector)
     n = length(x)
     n > 0 || throw(ArgumentError("minimum over an empty array is not allowed."))
     m = nnz(x)
@@ -1413,8 +1409,6 @@ function _minimum(f, x::AbstractSparseVector)
      min(f(zero(eltype(x))), minimum(f, nonzeros(x))))
 end
 
-minimum(f::Union{Function, Type}, x::AbstractSparseVector) = _minimum(f, x) # resolve ambiguity
-minimum(f, x::AbstractSparseVector) = _minimum(f, x)
 minimum(x::AbstractSparseVector) = minimum(identity, x)
 
 norm(x::SparseVectorUnion, p::Real=2) = norm(nonzeros(x), p)


### PR DESCRIPTION
I couldn't detect an ambiguity, and also this didn't avoid ambiguities. If there was one, it would still exist for callable objects  of type different then `Function` or `Type`. 

@alyst Do you remember what type of ambiguity you found back then? It could be that by the time #29884 got merged (2.5 years after first commit), the ambiguity was already resolved.