### PR TITLE
inference: wrap constant-prop' result directly within `OpaqueClosureCallInfo`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1420,18 +1420,18 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter, closure::Part
     tt = closure.typ
     sigT = (unwrap_unionall(tt)::DataType).parameters[1]
     match = MethodMatch(sig, Core.svec(), closure.source, sig <: rewrap_unionall(sigT, tt))
-    info = OpaqueClosureCallInfo(match)
+    res = nothing
     if !result.edgecycle
         const_result = abstract_call_method_with_const_args(interp, result, closure,
             arginfo, match, sv, closure.isva)
         if const_result !== nothing
             const_rettype, const_result = const_result
             if const_rettype ⊑ rt
-               rt = const_rettype
+               rt, res = const_rettype, const_result
             end
-            info = ConstCallInfo(info, Union{Nothing,InferenceResult}[const_result])
         end
     end
+    info = OpaqueClosureCallInfo(match, res)
     return CallMeta(from_interprocedural!(rt, sv, arginfo, match.spec_types), info)
 end
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1009,19 +1009,19 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
     nargs = length(aargtypes)
     splitunions = 1 < unionsplitcost(aargtypes) <= InferenceParams(interp).MAX_APPLY_UNION_ENUM
     ctypes = [Any[aft]]
-    infos = [Union{Nothing, AbstractIterationInfo}[]]
+    infos = Vector{MaybeAbstractIterationInfo}[MaybeAbstractIterationInfo[]]
     for i = 1:nargs
         ctypes´ = Vector{Any}[]
-        infos′ = Vector{Union{Nothing, AbstractIterationInfo}}[]
+        infos′ = Vector{MaybeAbstractIterationInfo}[]
         for ti in (splitunions ? uniontypes(aargtypes[i]) : Any[aargtypes[i]])
             if !isvarargtype(ti)
                 cti_info = precise_container_type(interp, itft, ti, sv)
                 cti = cti_info[1]::Vector{Any}
-                info = cti_info[2]::Union{Nothing,AbstractIterationInfo}
+                info = cti_info[2]::MaybeAbstractIterationInfo
             else
                 cti_info = precise_container_type(interp, itft, unwrapva(ti), sv)
                 cti = cti_info[1]::Vector{Any}
-                info = cti_info[2]::Union{Nothing,AbstractIterationInfo}
+                info = cti_info[2]::MaybeAbstractIterationInfo
                 # We can't represent a repeating sequence of the same types,
                 # so tmerge everything together to get one type that represents
                 # everything.

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1045,7 +1045,6 @@ end
 
 function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info), state::InliningState)
     if isa(info, OpaqueClosureCreateInfo)
-        isa(info.unspec.info, OpaqueClosureCallInfo) || return
         lbt = argextype(stmt.args[3], ir, ir.sptypes)
         lb, exact = instanceof_tfunc(lbt)
         exact || return
@@ -1053,7 +1052,6 @@ function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info), sta
         ub, exact = instanceof_tfunc(ubt)
         exact || return
         # Narrow opaque closure type
-
         newT = widenconst(tmeet(tmerge(lb, info.unspec.rt), ub))
         if newT != ub
             # N.B.: Narrowing the ub requires a backdge on the mi whose type

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -89,30 +89,39 @@ struct UnionSplitApplyCallInfo
 end
 
 """
-    struct ConstCallInfo
+    call::ConstCallInfo
 
-Precision for this call was improved using constant information. This info
-keeps a reference to the result that was used (or created for these)
-constant information.
+The precision of this call was improved using constant information.
+In addition to the original call information `call.call`, `call` also keeps
+the inference results with constant information `call.results::Vector{Union{Nothing,InferenceResult}}`.
 """
 struct ConstCallInfo
-    call::Any
+    call::Union{MethodMatchInfo,UnionSplitInfo}
     results::Vector{Union{Nothing,InferenceResult}}
 end
 
 """
-    struct InvokeCallInfo
+    call::InvokeCallInfo
 
-Represents a resolved call to `invoke`, carrying the Method match of the
-method being processed.
+Represents a resolved call to `invoke`, carrying the `call.match::MethodMatch` of the
+method that has been processed.
+Optionally keeps `result::InferenceResult` that carries constant information.
 """
 struct InvokeCallInfo
     match::MethodMatch
     result::Union{Nothing,InferenceResult}
 end
 
+"""
+    call::OpaqueClosureCallInfo
+
+Represents a resolved call of opaque closure, carrying the `call.match::MethodMatch` of the
+method that has been processed.
+Optionally keeps `result::InferenceResult` that carries constant information.
+"""
 struct OpaqueClosureCallInfo
     match::MethodMatch
+    result::Union{Nothing,InferenceResult}
 end
 
 struct OpaqueClosureCreateInfo

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -1,10 +1,23 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-"""
-    struct MethodMatchInfo
+@nospecialize
 
-Captures the result of a `method_matches` lookup for the given call. This
-info may then be used by the optimizer to inline the matches, without having
+"""
+    call::CallMeta
+
+A simple struct that captures both the return type (`call.rt`)
+and any additional information (`call.info`) for a given generic call.
+"""
+struct CallMeta
+    rt::Any
+    info::Any
+end
+
+"""
+    info::MethodMatchInfo
+
+Captures the result of a `:jl_matching_methods` lookup for the given call (`info.results`).
+This info may then be used by the optimizer to inline the matches, without having
 to re-consult the method table. This info is illegal on any statement that is
 not a call to a generic function.
 """
@@ -13,14 +26,27 @@ struct MethodMatchInfo
 end
 
 """
-    struct MethodResultPure
+    info::UnionSplitInfo
+
+If inference decides to partition the method search space by splitting unions,
+it will issue a method lookup query for each such partition. This info indicates
+that such partitioning happened and wraps the corresponding `MethodMatchInfo` for
+each partition (`info.matches::Vector{MethodMatchInfo}`).
+This info is illegal on any statement that is not a call to a generic function.
+"""
+struct UnionSplitInfo
+    matches::Vector{MethodMatchInfo}
+end
+
+"""
+    info::MethodResultPure
 
 This struct represents a method result constant was proven to be
 effect-free, including being no-throw (typically because the value was computed
 by calling an `@pure` function).
 """
 struct MethodResultPure
-    info::Any
+    info::Union{MethodMatchInfo,UnionSplitInfo,Bool}
 end
 let instance = MethodResultPure(false)
     global MethodResultPure
@@ -28,46 +54,24 @@ let instance = MethodResultPure(false)
 end
 
 """
-    struct UnionSplitInfo
-
-If inference decides to partition the method search space by splitting unions,
-it will issue a method lookup query for each such partition. This info indicates
-that such partitioning happened and wraps the corresponding MethodMatchInfo for
-each partition. This info is illegal on any statement that is not a call to a
-generic function.
-"""
-struct UnionSplitInfo
-    matches::Vector{MethodMatchInfo}
-end
-
-"""
-    struct CallMeta
-
-A simple struct that captures both the return type (`rt`) and any additional information
-(`info`) for a given generic call.
-"""
-struct CallMeta
-    rt::Any
-    info::Any
-end
-
-"""
-    struct AbstractIterationInfo
+    info::AbstractIterationInfo
 
 Captures all the information for abstract iteration analysis of a single value.
-Each (abstract) call to `iterate`, corresponds to one entry in `each`.
+Each (abstract) call to `iterate`, corresponds to one entry in `info.each::Vector{CallMeta}`.
 """
 struct AbstractIterationInfo
     each::Vector{CallMeta}
 end
 
+const MaybeAbstractIterationInfo = Union{Nothing, AbstractIterationInfo}
+
 """
-    struct ApplyCallInfo
+    info::ApplyCallInfo
 
 This info applies to any call of `_apply_iterate(...)` and captures both the
 info of the actual call being applied and the info for any implicit call
 to the `iterate` function. Note that it is possible for the call itself
-to be yet another `_apply_iterate`, in which case the `.call` field will
+to be yet another `_apply_iterate`, in which case the `info.call` field will
 be another `ApplyCallInfo`. This info is illegal on any statement that is
 not an `_apply_iterate` call.
 """
@@ -75,13 +79,13 @@ struct ApplyCallInfo
     # The info for the call itself
     call::Any
     # AbstractIterationInfo for each argument, if applicable
-    arginfo::Vector{Union{Nothing, AbstractIterationInfo}}
+    arginfo::Vector{MaybeAbstractIterationInfo}
 end
 
 """
-    struct UnionSplitApplyCallInfo
+    info::UnionSplitApplyCallInfo
 
-Like `UnionSplitInfo`, but for `ApplyCallInfo` rather than MethodMatchInfo.
+Like `UnionSplitInfo`, but for `ApplyCallInfo` rather than `MethodMatchInfo`.
 This info is illegal on any statement that is not an `_apply_iterate` call.
 """
 struct UnionSplitApplyCallInfo
@@ -89,11 +93,11 @@ struct UnionSplitApplyCallInfo
 end
 
 """
-    call::ConstCallInfo
+    info::ConstCallInfo
 
 The precision of this call was improved using constant information.
-In addition to the original call information `call.call`, `call` also keeps
-the inference results with constant information `call.results::Vector{Union{Nothing,InferenceResult}}`.
+In addition to the original call information `info.call`, this info also keeps
+the inference results with constant information `info.results::Vector{Union{Nothing,InferenceResult}}`.
 """
 struct ConstCallInfo
     call::Union{MethodMatchInfo,UnionSplitInfo}
@@ -101,11 +105,11 @@ struct ConstCallInfo
 end
 
 """
-    call::InvokeCallInfo
+    info::InvokeCallInfo
 
-Represents a resolved call to `invoke`, carrying the `call.match::MethodMatch` of the
-method that has been processed.
-Optionally keeps `result::InferenceResult` that carries constant information.
+Represents a resolved call to `Core.invoke`, carrying the `info.match::MethodMatch` of
+the method that has been processed.
+Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
 struct InvokeCallInfo
     match::MethodMatch
@@ -113,27 +117,46 @@ struct InvokeCallInfo
 end
 
 """
-    call::OpaqueClosureCallInfo
+    info::OpaqueClosureCallInfo
 
-Represents a resolved call of opaque closure, carrying the `call.match::MethodMatch` of the
-method that has been processed.
-Optionally keeps `result::InferenceResult` that carries constant information.
+Represents a resolved call of opaque closure, carrying the `info.match::MethodMatch` of
+the method that has been processed.
+Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
 struct OpaqueClosureCallInfo
     match::MethodMatch
     result::Union{Nothing,InferenceResult}
 end
 
+"""
+    info::OpaqueClosureCreateInfo
+
+This info may be constructed upon opaque closure construction, with `info.unspec::CallMeta`
+carrying out inference result of an unreal, partially specialized call (i.e. specialized on
+the closure environment, but not on the argument types of the opaque closure) in order to
+allow the optimizer to rewrite the return type parameter of the `OpaqueClosure` based on it.
+"""
 struct OpaqueClosureCreateInfo
     unspec::CallMeta
+    function OpaqueClosureCreateInfo(unspec::CallMeta)
+        @assert isa(unspec.info, OpaqueClosureCallInfo)
+        return new(unspec)
+    end
 end
 
 # Stmt infos that are used by external consumers, but not by optimization.
 # These are not produced by default and must be explicitly opted into by
 # the AbstractInterpreter.
 
+"""
+    info::ReturnTypeCallInfo
+
+Represents a resolved call of `Core.Compiler.return_type`.
+`info.call` wraps the info corresponding to the call that `Core.Compiler.return_type` call
+was supposed to analyze.
+"""
 struct ReturnTypeCallInfo
-    # The info corresponding to the call that return_type was supposed to
-    # analyze.
     info::Any
 end
+
+@specialize


### PR DESCRIPTION
This is more consistent with the arrangement of `InvokeCallInfo`, and
will make succeeding processing a bit cleaner.

This change also avoids unnecessary specializations in callinfo constructions.