### PR TITLE
show: improve typeinfo handling

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -28,19 +28,19 @@ function show(io::IO, t::AbstractDict{K,V}) where V where K
     limit = get(io, :limit, false)::Bool
     # show in a Julia-syntax-like form: Dict(k=>v, ...)
     print(io, typeinfo_prefix(io, t)[1])
-    print(io, '(')
+    print(io, "(")
     if !isempty(t) && !show_circular(io, t)
         first = true
         n = 0
         for pair in t
             first || print(io, ", ")
             first = false
-            show(recur_io, pair)
-            n+=1
+            show(recur_io, pair, typeinfo=eltype(t))
+            n += 1
             limit && n >= 10 && (print(io, "…"); break)
         end
     end
-    print(io, ')')
+    print(io, ")")
 end
 
 # Dict

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -200,10 +200,10 @@ big(x::AbstractIrrational) = BigFloat(x)
 big(::Type{<:AbstractIrrational}) = BigFloat
 
 # align along = for nice Array printing
-function alignment(io::IO, x::AbstractIrrational)
-    m = match(r"^(.*?)(=.*)$", sprint(show, x, context=io, sizehint=0))
-    m === nothing ? (length(sprint(show, x, context=io, sizehint=0)), 0) :
-    (length(something(m.captures[1])), length(something(m.captures[2])))
+function alignment(io::IO, x::AbstractIrrational, typeinfo::Type)
+    s = stringshow(io, x, typeinfo)
+    m = match(r"^(.*?)(=.*)$", s)
+    m === nothing ? (length(s), 0) : (length(something(m.captures[1])), length(something(m.captures[2])))
 end
 
 # inv

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -763,7 +763,7 @@ size(L::LogicalIndex) = (L.sum,)
 length(L::LogicalIndex) = L.sum
 collect(L::LogicalIndex) = [i for i in L]
 show(io::IO, r::LogicalIndex) = print(io,collect(r))
-print_array(io::IO, X::LogicalIndex) = print_array(io, collect(X))
+print_array(io::IO, X::LogicalIndex, typeinfo::Type) = print_array(io, collect(X), typeinfo)
 # Iteration over LogicalIndex is very performance-critical, but it also must
 # support arbitrary AbstractArray{Bool}s with both Int and CartesianIndex.
 # Thus the iteration state contains an index iterator and its state. We also

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -44,7 +44,7 @@ macro MIME_str(s)
 end
 
 # fallback text/plain representation of any type:
-show(io::IO, ::MIME"text/plain", x) = show(io, x)
+show(io::IO, ::MIME"text/plain", x) = haskey(io, :typeinfo) ? show(io, x; typeinfo=io[:typeinfo]) : show(io, x) # TODO
 
 MIME(s) = MIME{Symbol(s)}()
 show(io::IO, ::MIME{mime}) where {mime} = print(io, "MIME type ", string(mime))

--- a/base/range.jl
+++ b/base/range.jl
@@ -599,6 +599,7 @@ function print_range(io::IO, r::AbstractRange,
                      hdots::AbstractString = ",\u2026,") # horiz ellipsis
     # This function borrows from print_matrix() in show.jl
     # and should be called by show and display
+    typeinfo = eltype(r)
     sz = displaysize(io)
     if !haskey(io, :compact)
         io = IOContext(io, :compact => true)
@@ -613,25 +614,25 @@ function print_range(io::IO, r::AbstractRange,
     # left and right edge columns, as many as could conceivably fit on the
     # screen, with the middle columns summarized by horz, vert, or diag ellipsis
     maxpossiblecols = div(screenwidth, 1+sepsize) # assume each element is at least 1 char + 1 separator
-    colsr = n <= maxpossiblecols ? (1:n) : [1:div(maxpossiblecols,2)+1; (n-div(maxpossiblecols,2)):n]
+    colsr = n <= maxpossiblecols ? (1:n) : [1:div(maxpossiblecols, 2)+1; (n-div(maxpossiblecols, 2)):n]
     rowmatrix = reshape(r[colsr], 1, length(colsr)) # treat the range as a one-row matrix for print_matrix_row
     nrow, idxlast = size(rowmatrix, 2), last(axes(rowmatrix, 2))
-    A = alignment(io, rowmatrix, 1:m, 1:length(rowmatrix), screenwidth, screenwidth, sepsize, nrow) # how much space range takes
+    A = alignment(io, rowmatrix, typeinfo, 1:m, 1:length(rowmatrix), screenwidth, screenwidth, sepsize, nrow) # how much space range takes
     if n <= length(A) # cols fit screen, so print out all elements
         print(io, pre) # put in pre chars
-        print_matrix_row(io,rowmatrix,A,1,1:n,sep,idxlast) # the entire range
+        print_matrix_row(io, rowmatrix, typeinfo, A, 1, 1:n, sep, idxlast) # the entire range
         print(io, post) # add the post characters
     else # cols don't fit so put horiz ellipsis in the middle
         # how many chars left after dividing width of screen in half
         # and accounting for the horiz ellipsis
-        c = div(screenwidth-length(hdots)+1,2)+1 # chars remaining for each side of rowmatrix
-        alignR = reverse(alignment(io, rowmatrix, 1:m, length(rowmatrix):-1:1, c, c, sepsize, nrow)) # which cols of rowmatrix to put on the right
-        c = screenwidth - sum(map(sum,alignR)) - (length(alignR)-1)*sepsize - length(hdots)
-        alignL = alignment(io, rowmatrix, 1:m, 1:length(rowmatrix), c, c, sepsize, nrow) # which cols of rowmatrix to put on the left
+        c = div(screenwidth-length(hdots)+1, 2)+1 # chars remaining for each side of rowmatrix
+        alignR = reverse(alignment(io, rowmatrix, typeinfo, 1:m, length(rowmatrix):-1:1, c, c, sepsize, nrow)) # which cols of rowmatrix to put on the right
+        c = screenwidth - sum(map(sum, alignR)) - (length(alignR)-1)*sepsize - length(hdots)
+        alignL = alignment(io, rowmatrix, typeinfo, 1:m, 1:length(rowmatrix), c, c, sepsize, nrow) # which cols of rowmatrix to put on the left
         print(io, pre)   # put in pre chars
-        print_matrix_row(io, rowmatrix,alignL,1,1:length(alignL),sep,idxlast) # left part of range
+        print_matrix_row(io, rowmatrix, typeinfo, alignL, 1, 1:length(alignL), sep, idxlast) # left part of range
         print(io, hdots) # horizontal ellipsis
-        print_matrix_row(io, rowmatrix,alignR,1,length(rowmatrix)-length(alignR)+1:length(rowmatrix),sep,idxlast) # right part of range
+        print_matrix_row(io, rowmatrix, typeinfo, alignR, 1, length(rowmatrix)-length(alignR)+1:length(rowmatrix), sep, idxlast) # right part of range
         print(io, post)  # post chars
     end
 end

--- a/base/ryu/Ryu.jl
+++ b/base/ryu/Ryu.jl
@@ -108,10 +108,10 @@ function writeexp(x::T,
     return String(resize!(buf, pos - 1))
 end
 
-function Base.show(io::IO, x::T, forceuntyped::Bool=false, fromprint::Bool=false) where {T <: Base.IEEEFloat}
+function Base.show(io::IO, x::T; forceuntyped::Bool=false, fromprint::Bool=false, typeinfo::Type=Any, opt_kwargs...) where {T <: Base.IEEEFloat}
     compact = get(io, :compact, false)::Bool
     buf = Base.StringVector(neededdigits(T))
-    typed = !forceuntyped && !compact && get(io, :typeinfo, Any) != typeof(x)
+    typed = !forceuntyped && !compact && typeinfo !== typeof(x)
     pos = writeshortest(buf, 1, x, false, false, true, -1,
         (x isa Float32 && !fromprint) ? UInt8('f') : UInt8('e'), false, UInt8('.'), typed, compact)
     write(io, resize!(buf, pos - 1))
@@ -125,6 +125,6 @@ function Base.string(x::T) where {T <: Base.IEEEFloat}
     return String(resize!(buf, pos - 1))
 end
 
-Base.print(io::IO, x::Union{Float16, Float32}) = show(io, x, true, true)
+Base.print(io::IO, x::Union{Float16, Float32}) = show(io, x, forceuntyped=true, fromprint=true)
 
 end # module

--- a/base/set.jl
+++ b/base/set.jl
@@ -46,18 +46,15 @@ emptymutable(s::AbstractSet{T}, ::Type{U}=T) where {T,U} = Set{U}()
 
 _similar_for(c::AbstractSet, ::Type{T}, itr, isz, len) where {T} = empty(c, T)
 
-function show(io::IO, s::Set)
+function show(io::IO, s::Set; opt_kwargs...)
     if isempty(s)
-        if get(io, :typeinfo, Any) == typeof(s)
-            print(io, "Set()")
-        else
-            show(io, typeof(s))
-            print(io, "()")
-        end
+        typeinfo = get(opt_kwargs, :typeinfo, Any)
+        show_typeof(io, typeof(s), typeinfo)
+        print(io, "()")
     else
         print(io, "Set(")
         show_vector(io, s)
-        print(io, ')')
+        print(io, ")")
     end
 end
 

--- a/base/some.jl
+++ b/base/some.jl
@@ -39,13 +39,20 @@ convert(::Type{Nothing}, ::Nothing) = nothing
 convert(::Type{Some{T}}, x::Some{T}) where {T} = x
 convert(::Type{Some{T}}, x::Some) where {T} = Some{T}(convert(T, x.value))
 
-function show(io::IO, x::Some)
-    if get(io, :typeinfo, Any) == typeof(x)
+function show(io::IO, x::Some; opt_kwargs...)
+    typeinfo = get(opt_kwargs, :typeinfo, Any)
+    if typeinfo === typeof(x)
         show(io, x.value)
     else
-        print(io, "Some(")
-        show(io, x.value)
-        print(io, ')')
+        v = getfield(x, :value)
+        ft = fieldtype(typeof(x), 1)
+        if typeof(v) === ft
+            print(io, "Some(")
+        else
+            show_typeof(io, typeof(x), typeinfo)
+        end
+        show(io, v; typeinfo=ft)
+        print(io, ")")
     end
 end
 

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -58,7 +58,7 @@ Base.IOContext(::IO, ::IOContext)
 ## Text I/O
 
 ```@docs
-Base.show(::IO, ::Any)
+Base.show(::Any)
 Base.summary
 Base.print
 Base.println

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -131,7 +131,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
         println(io, "  Memory: $(Sys.total_memory()/2^30) GB ($(Sys.free_memory()/2^20) MB free)")
         try println(io, "  Uptime: $(Sys.uptime()) sec"); catch; end
         print(io, "  Load Avg: ")
-        Base.print_matrix(io, Sys.loadavg()')
+        Base.print_matrix(io, Sys.loadavg()', Float64)
         println(io)
     end
     println(io, "  WORD_SIZE: ", Sys.WORD_SIZE)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -232,11 +232,12 @@ end
 
 function show(io::IO, M::Bidiagonal)
     # TODO: make this readable and one-line
-    summary(io, M); println(io, ":")
+    summary(io, M)
+    println(io, ":")
     print(io, " diag:")
-    print_matrix(io, (M.dv)')
+    print_matrix(io, (M.dv)', eltype(M))
     print(io, M.uplo == 'U' ? "\n super:" : "\n sub:")
-    print_matrix(io, (M.ev)')
+    print_matrix(io, (M.ev)', eltype(M))
 end
 
 size(M::Bidiagonal) = (length(M.dv), length(M.dv))

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -110,11 +110,11 @@ Random.seed!(1)
 
     @testset "show" begin
         BD = Bidiagonal(dv, ev, :U)
-        dstring = sprint(Base.print_matrix,BD.dv')
-        estring = sprint(Base.print_matrix,BD.ev')
-        @test sprint(show,BD) == "$(summary(BD)):\n diag:$dstring\n super:$estring"
-        BD = Bidiagonal(dv,ev,:L)
-        @test sprint(show,BD) == "$(summary(BD)):\n diag:$dstring\n sub:$estring"
+        dstring = sprint(Base.print_matrix, BD.dv', eltype(BD))
+        estring = sprint(Base.print_matrix, BD.ev', eltype(BD))
+        @test sprint(show, BD) == "$(summary(BD)):\n diag:$dstring\n super:$estring"
+        BD = Bidiagonal(dv, ev, :L)
+        @test sprint(show, BD) == "$(summary(BD)):\n diag:$dstring\n sub:$estring"
     end
 
     @testset for uplo in (:U, :L)

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -185,7 +185,7 @@ end
 @test sprint(show,MIME"text/plain"(),UniformScaling(one(ComplexF64))) == "LinearAlgebra.UniformScaling{ComplexF64}\n(1.0 + 0.0im)*I"
 @test sprint(show,MIME"text/plain"(),UniformScaling(one(Float32))) == "LinearAlgebra.UniformScaling{Float32}\n1.0*I"
 @test sprint(show,UniformScaling(one(ComplexF64))) == "LinearAlgebra.UniformScaling{ComplexF64}(1.0 + 0.0im)"
-@test sprint(show,UniformScaling(one(Float32))) == "LinearAlgebra.UniformScaling{Float32}(1.0f0)"
+@test sprint(show,UniformScaling(one(Float32))) == "LinearAlgebra.UniformScaling{Float32}(1.0)"
 
 let
     λ = complex(randn(),randn())

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -499,8 +499,9 @@ function show(io::IO, mime::MIME"text/plain", S::SharedArray)
         invoke(show, Tuple{IO,MIME"text/plain",DenseArray}, io, MIME"text/plain"(), S)
     else
         # retrieve from the first worker mapping the array.
-        summary(io, S); println(io, ":")
-        Base.print_array(io, remotecall_fetch(sharr->sharr.s, S.pids[1], S))
+        summary(io, S)
+        println(io, ":")
+        Base.print_array(io, remotecall_fetch(sharr->sharr.s, S.pids[1], S), eltype(S))
     end
 end
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -251,9 +251,9 @@ function Base.array_summary(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTran
 end
 
 # called by `show(io, MIME("text/plain"), ::AbstractSparseMatrixCSCInclAdjointAndTranspose)`
-function Base.print_array(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTranspose)
+function Base.print_array(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTranspose, typeinfo::Type)
     if max(size(S)...) < 16
-        Base.print_matrix(io, S)
+        Base.print_matrix(io, S, typeinfo)
     else
         _show_with_braille_patterns(io, S)
     end

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -889,12 +889,12 @@ function show(io::IO, ::MIME"text/plain", x::AbstractSparseVector)
            " stored ", xnnz == 1 ? "entry" : "entries")
     if xnnz != 0
         println(io, ":")
-        show(IOContext(io, :typeinfo => eltype(x)), x)
+        show(io, x)
     end
 end
 
-show(io::IO, x::AbstractSparseVector) = show(convert(IOContext, io), x)
-function show(io::IOContext, x::AbstractSparseVector)
+show(io::IO, x::AbstractSparseVector; opt_kwargs...) = show(convert(IOContext, io), x; opt_kwargs...)
+function show(io::IOContext, x::AbstractSparseVector; opt_kwargs...)
     # TODO: make this a one-line form
     n = length(x)
     nzind = nonzeroinds(x)
@@ -908,11 +908,12 @@ function show(io::IOContext, x::AbstractSparseVector)
     if !haskey(io, :compact)
         io = IOContext(io, :compact => true)
     end
+    typeinfo = eltype(x)
     for k = eachindex(nzind)
         if k < half_screen_rows || k > length(nzind) - half_screen_rows
             print(io, "  ", '[', rpad(nzind[k], pad), "]  =  ")
             if isassigned(nzval, Int(k))
-                show(io, nzval[k])
+                show(io, nzval[k]; typeinfo)
             else
                 print(io, Base.undef_ref_str)
             end


### PR DESCRIPTION
I was trying to figure out if our typeinfo handling was correct, or if it could be improved (obviously, yes), so I added optional kwarg support to all `show` methods, and then tried to fix our usages of typeinfo based on that change. But I don't really like adding all of these kwargs, so I am thinking of changing this again to take a different approach, but keeping the fixes to the places that we are generating and using the information. Posting this now to get early feedback, if any.

Ensures also that showing a `Bool` respects the compact flag.