### PR TITLE
Docs: `TwicePrecision` is an internal type

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -162,7 +162,7 @@ div12(x, y) = div12(promote(x, y)...)
     TwicePrecision{T}((num, denom))
 
 A number with twice the precision of `T`, e.g., quad-precision if `T =
-Float64`. 
+Float64`.
 
 !!! warn
     `TwicePrecision` is an internal type used to increase the

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -162,7 +162,18 @@ div12(x, y) = div12(promote(x, y)...)
     TwicePrecision{T}((num, denom))
 
 A number with twice the precision of `T`, e.g., quad-precision if `T =
-Float64`. `hi` represents the high bits (most significant bits) and
+Float64`. 
+
+!!! warn
+    `TwicePrecision` is an internal type used to increase the
+    precision of floating-point ranges, and not intended for external use.
+    If you encounter them in real code, the most likely explanation is
+    that you are directly accessing the fields of a range. Use
+    the function interface instead, `step(r)` rather than `r.step`
+
+# Extended help
+
+`hi` represents the high bits (most significant bits) and
 `lo` the low bits (least significant bits). Rational values
 `num//denom` can be approximated conveniently using the syntax
 `TwicePrecision{T}((num, denom))`.


### PR DESCRIPTION
Fixes #42857

CC @imyxh