### PR TITLE
Remove backtrace entirely in shell mode

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -88,6 +88,13 @@ function scrub_repl_backtrace(bt)
         # remove REPL-related frames from interactive printing
         eval_ind = findlast(frame -> !frame.from_c && frame.func === :eval, bt)
         eval_ind === nothing || deleteat!(bt, eval_ind:length(bt))
+        if length(bt) > 1
+            topframe = bt[end - 1]
+            # scrub whole backtrace if it's shell mode
+            if topframe.func === :repl_cmd && topframe.linfo.def.module === Base
+                bt = StackTraces.StackFrame[]
+            end
+        end
     end
     return bt
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -92,7 +92,7 @@ function scrub_repl_backtrace(bt)
             topframe = bt[end - 1]
             # scrub whole backtrace if it's shell mode
             if topframe.func === :repl_cmd && topframe.linfo.def.module === Base
-                bt = StackTraces.StackFrame[]
+                empty!(bt)
             end
         end
     end

--- a/base/client.jl
+++ b/base/client.jl
@@ -69,8 +69,8 @@ function repl_cmd(cmd, out)
         try
             run(ignorestatus(cmd))
         catch
-            # strip backtrace and display error
-            # mainly for Windows
+            # Windows doesn't shell out right now (complex issue), so Julia tries to run the program itself
+            # Julia throws an exception if it can't find the program, but the stack trace isn't useful
             lasterr = current_exceptions()
             lasterr = ExceptionStack([(exception = e[1], backtrace = [] ) for e in lasterr])
             invokelatest(display_error, lasterr)


### PR DESCRIPTION
Resolves #40958

With this PR, as suggested by @simeonschaub, the REPL scrubs all stack frames when the shell mode produces an error, and just displays the error itself.