### PR TITLE
Profile: metadata handling tweaks

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -563,7 +563,7 @@ details of the metadata format.
 function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
     threadid == 0 && error("Fake threadid cannot be 0")
     taskid == 0 && error("Fake taskid cannot be 0")
-    has_meta(data) && error("input already has metadata")
+    !isempty(data) && has_meta(data) && error("input already has metadata")
     cpu_clock_cycle = UInt64(99)
     data_with_meta = similar(data, 0)
     for i = 1:length(data)
@@ -583,6 +583,7 @@ end
 # Merging multiple equivalent entries and recursive calls
 function parse_flat(::Type{T}, data::Vector{UInt64}, lidict::Union{LineInfoDict, LineInfoFlatDict}, C::Bool,
                     threads::Union{Int,AbstractVector{Int}}, tasks::Union{UInt,AbstractVector{UInt}}) where {T}
+    !isempty(data) && !has_meta(data) && error("Profile data is missing required metadata")
     lilist = StackFrame[]
     n = Int[]
     m = Int[]
@@ -835,6 +836,7 @@ end
 # turn a list of backtraces into a tree (implicitly separated by NULL markers)
 function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineInfoFlatDict, LineInfoDict}, C::Bool, recur::Symbol,
                 threads::Union{Int,AbstractVector{Int},Nothing}=nothing, tasks::Union{UInt,AbstractVector{UInt},Nothing}=nothing) where {T}
+    !isempty(all) && !has_meta(all) && error("Profile data is missing required metadata")
     parent = root
     tops = Vector{StackFrameTree{T}}()
     build = Vector{StackFrameTree{T}}()

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -512,15 +512,15 @@ error_codes = Dict(
 
 
 """
-    fetch(;include_meta = false) -> data
+    fetch(;include_meta = true) -> data
 
 Returns a copy of the buffer of profile backtraces. Note that the
 values in `data` have meaning only on this machine in the current session, because it
 depends on the exact memory addresses used in JIT-compiling. This function is primarily for
 internal use; [`retrieve`](@ref) may be a better choice for most users.
-By default metadata such as threadid and taskid will be stripped. Set `include_meta` to `true` to include metadata.
+By default metadata such as threadid and taskid is included. Set `include_meta` to `false` to strip metadata.
 """
-function fetch(;include_meta = false)
+function fetch(;include_meta = true)
     maxlen = maxlen_data()
     len = len_data()
     if is_buffer_full()

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -296,13 +296,7 @@ function is_block_end(data, i)
     # and we could have (though very unlikely):
     # 1:<stack><metadata><null><null><NULL><metadata><null><null>:end
     # and we want to ignore the triple NULL (which is an ip).
-    data[i] == 0 || return false        # first block end null
-    data[i - 1] == 0 || return false    # second block end null
-    data[i - 2] in 1:2 || return false  # sleep state
-    data[i - 3] != 0 || return false    # cpu_cycle_clock
-    data[i - 4] != 0 || return false    # taskid
-    data[i - 5] != 0 || return false    # threadid
-    return true
+    return data[i] == 0 && data[i - 1] == 0 && data[i - 2] != 0
 end
 
 """

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -549,7 +549,7 @@ function strip_meta(data)
         i -= 1
         j -= 1
     end
-    @assert i == j == 0 "metadata stripping failed i=$i j=$j data[1:i]=$(data[1:i])"
+    @assert i == j == 0 "metadata stripping failed"
     return data_stripped
 end
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -299,6 +299,19 @@ function is_block_end(data, i)
     return data[i] == 0 && data[i - 1] == 0 && data[i - 2] != 0
 end
 
+function has_meta(data)
+    for i in 6:length(data)
+        data[i] == 0 || continue            # first block end null
+        data[i - 1] == 0 || continue        # second block end null
+        data[i - 2] in 1:2 || continue      # sleep state
+        data[i - 3] != 0 || continue        # cpu_cycle_clock
+        data[i - 4] != 0 || continue        # taskid
+        data[i - 5] != 0 || continue        # threadid
+        return true
+    end
+    return false
+end
+
 """
     print([io::IO = stdout,] data::Vector, lidict::LineInfoDict; kwargs...)
 
@@ -550,7 +563,7 @@ details of the metadata format.
 function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
     threadid == 0 && error("Fake threadid cannot be 0")
     taskid == 0 && error("Fake taskid cannot be 0")
-    any(Base.Fix1(is_block_end, data), eachindex(data)) && error("input already has metadata")
+    has_meta(data) && error("input already has metadata")
     cpu_clock_cycle = UInt64(99)
     data_with_meta = similar(data, 0)
     for i = 1:length(data)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -75,8 +75,8 @@ end
 end
 
 @testset "Profile.fetch() with and without meta" begin
-    data_without = Profile.fetch()
-    data_with = Profile.fetch(include_meta = true)
+    data_without = Profile.fetch(include_meta = false)
+    data_with = Profile.fetch()
     @test data_without[1] == data_with[1]
     @test data_without[end] == data_with[end]
     nblocks = count(Base.Fix1(Profile.is_block_end, data_with), eachindex(data_with))

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -9,7 +9,7 @@ Profile.init()
 let iobuf = IOBuffer()
     for fmt in (:tree, :flat)
         Test.@test_logs (:warn, r"^There were no samples collected\.") Profile.print(iobuf, format=fmt, C=true)
-        Test.@test_logs (:warn, r"^There were no samples collected\.") Profile.print(iobuf, [0x0000000000000001], Dict(0x0000000000000001 => [Base.StackTraces.UNKNOWN]), format=fmt, C=false)
+        Test.@test_logs (:warn, r"^There were no samples collected\.") Profile.print(iobuf, Profile.add_fake_meta([0x0000000000000001, 0x0000000000000000]), Dict(0x0000000000000001 => [Base.StackTraces.UNKNOWN]), format=fmt, C=false)
     end
 end
 


### PR DESCRIPTION
As was discussed in https://github.com/JuliaLang/julia/pull/42482 after merge, there's some things that could be done better:

- Reverts the `is_block_end` logic, given it should only be run on data that includes metadata, so can afford to be more efficient
- Adds `has_meta` for identifying when profile data has metadata
- Adds metadata checks to functions that expect metadata to be present
- Changes `Profile.fetch` to by default include metadata. The reason for this is that it was previously made to strip metadata to avoid breaking existing downstream Profile data consumers, but it turns out that they use Profile internals like `tree!` that require the metadata to be present, so this ended up causing an unintended breakage anyway
- Adds consts for the metadata field offsets, for consumers to use