### PR TITLE
Manual: Move introduction about command line arguments from "Getting Started" to "Command-line options"

### DIFF
--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -1,6 +1,79 @@
 # [Command-line Options](@id command-line-options)
 
-The following is a complete list of command-line switches available when launching julia:
+## Using arguments inside scripts
+
+When running a script using `julia`, you can pass additional arguments to your script:
+
+```
+$ julia script.jl arg1 arg2...
+```
+
+These additional command-line arguments are passed in the global constant `ARGS`. The
+name of the script itself is passed in as the global `PROGRAM_FILE`. Note that `ARGS` is
+also set when a Julia expression is given using the `-e` option on the command line (see the
+`julia` help output below) but `PROGRAM_FILE` will be empty. For example, to just print the
+arguments given to a script, you could do this:
+
+```
+$ julia -e 'println(PROGRAM_FILE); for x in ARGS; println(x); end' foo bar
+
+foo
+bar
+```
+
+Or you could put that code into a script and run it:
+
+```
+$ echo 'println(PROGRAM_FILE); for x in ARGS; println(x); end' > script.jl
+$ julia script.jl foo bar
+script.jl
+foo
+bar
+```
+
+The `--` delimiter can be used to separate command-line arguments intended for the script file from arguments intended for Julia:
+
+```
+$ julia --color=yes -O -- script.jl arg1 arg2..
+```
+
+See also [Scripting](@ref man-scripting) for more information on writing Julia scripts.
+
+Julia can be started in parallel mode with either the `-p` or the `--machine-file` options. `-p n`
+will launch an additional `n` worker processes, while `--machine-file file` will launch a worker
+for each line in file `file`. The machines defined in `file` must be accessible via a password-less
+`ssh` login, with Julia installed at the same location as the current host. Each machine definition
+takes the form `[count*][user@]host[:port] [bind_addr[:port]]`. `user` defaults to current user,
+`port` to the standard ssh port. `count` is the number of workers to spawn on the node, and defaults
+to 1. The optional `bind-to bind_addr[:port]` specifies the IP address and port that other workers
+should use to connect to this worker.
+
+If you have code that you want executed whenever Julia is run, you can put it in
+`~/.julia/config/startup.jl`:
+
+```
+$ echo 'println("Greetings! 你好! 안녕하세요?")' > ~/.julia/config/startup.jl
+$ julia
+Greetings! 你好! 안녕하세요?
+
+...
+```
+
+Note that although you should have a `~/.julia` directory once you've run Julia for the
+first time, you may need to create the `~/.julia/config` folder and the
+`~/.julia/config/startup.jl` file if you use it.
+
+## Command-line switches for Julia
+
+There are various ways to run Julia code and provide options, similar to those available for the
+`perl` and `ruby` programs:
+
+```
+julia [switches] -- [programfile] [args...]
+```
+
+The following is a complete list of command-line switches available when launching julia, e.g.
+
 
 |Switch                                 |Description|
 |:---                                   |:---|

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -31,73 +31,10 @@ To run code in a file non-interactively, you can give it as the first argument t
 command:
 
 ```
-$ julia script.jl arg1 arg2...
+$ julia script.jl
 ```
 
-As the example implies, the following command-line arguments to `julia` are interpreted as
-command-line arguments to the program `script.jl`, passed in the global constant `ARGS`. The
-name of the script itself is passed in as the global `PROGRAM_FILE`. Note that `ARGS` is
-also set when a Julia expression is given using the `-e` option on the command line (see the
-`julia` help output below) but `PROGRAM_FILE` will be empty. For example, to just print the
-arguments given to a script, you could do this:
-
-```
-$ julia -e 'println(PROGRAM_FILE); for x in ARGS; println(x); end' foo bar
-
-foo
-bar
-```
-
-Or you could put that code into a script and run it:
-
-```
-$ echo 'println(PROGRAM_FILE); for x in ARGS; println(x); end' > script.jl
-$ julia script.jl foo bar
-script.jl
-foo
-bar
-```
-
-The `--` delimiter can be used to separate command-line arguments intended for the script file from arguments intended for Julia:
-
-```
-$ julia --color=yes -O -- script.jl arg1 arg2..
-```
-
-See also [Scripting](@ref man-scripting) for more information on writing Julia scripts.
-
-Julia can be started in parallel mode with either the `-p` or the `--machine-file` options. `-p n`
-will launch an additional `n` worker processes, while `--machine-file file` will launch a worker
-for each line in file `file`. The machines defined in `file` must be accessible via a password-less
-`ssh` login, with Julia installed at the same location as the current host. Each machine definition
-takes the form `[count*][user@]host[:port] [bind_addr[:port]]`. `user` defaults to current user,
-`port` to the standard ssh port. `count` is the number of workers to spawn on the node, and defaults
-to 1. The optional `bind-to bind_addr[:port]` specifies the IP address and port that other workers
-should use to connect to this worker.
-
-If you have code that you want executed whenever Julia is run, you can put it in
-`~/.julia/config/startup.jl`:
-
-```
-$ echo 'println("Greetings! 你好! 안녕하세요?")' > ~/.julia/config/startup.jl
-$ julia
-Greetings! 你好! 안녕하세요?
-
-...
-```
-
-Note that although you should have a `~/.julia` directory once you've run Julia for the
-first time, you may need to create the `~/.julia/config` folder and the
-`~/.julia/config/startup.jl` file if you use it.
-
-There are various ways to run Julia code and provide options, similar to those available for the
-`perl` and `ruby` programs:
-
-```
-julia [switches] -- [programfile] [args...]
-```
-
-A detailed list of all the available switches can be found at [Command-line Options](@ref
+You can pass additional arguments to Julia, and to your program `script.jl`. A detailed list of all the available switches can be found at [Command-line Options](@ref
 command-line-options).
 
 ## Resources


### PR DESCRIPTION
I think that the information about command-line options should be presented *later on* in the manual, not in the very first section: we want people to start learning and get excited about the Julia *programming language* as quickly as possible.

Also important to consider is that beginners to Julia might not launch julia from the command line, but use the desktop shortcut, `julia-vscode` or a cloud service to launch it. In their case, this information is unusable and distracting.

---

I moved most of this discussion from the "Getting Started" section to the "Command-line options" section. The content is mostly unchanged, except for changes to the beginning and end, to make it work in its new home.