### PR TITLE
`Base.runtests`: always print the list of all test sets that we ran at the end, even if all of the tests passed

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -398,6 +398,15 @@ cd(@__DIR__) do
         Test.pop_testset()
     end
     Test.TESTSET_PRINT_ENABLE[] = true
+    if !o_ts.anynonpass
+        # We want to print the names of all of the top-level test sets,
+        # even if all of the tests passed.
+        original_verbose_value = o_ts.verbose
+        o_ts.verbose = true
+        println()
+        Test.print_test_results(o_ts, 1)
+        o_ts.verbose = original_verbose_value
+    end
     println()
     Test.print_test_results(o_ts, 1)
     if !o_ts.anynonpass


### PR DESCRIPTION
Before this pull request:
- If all of the tests passed, we do not print the list of all test sets that we ran.
- If one or more tests failed, we print the list of all test sets that we ran.

After this pull request:
- If all of the tests passed, we print the list of all test sets that we ran.
- If one or more tests failed, we print the list of all test sets that we ran.