### PR TITLE
make the spacing between suggested completions consistent

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -326,7 +326,7 @@ function show_completions(s::PromptState, completions::Vector{String})
         for col = 0:num_cols
             idx = row + col*entries_per_col
             if idx <= length(completions)
-                cmove_col(terminal(s), (colmax+2)*col)
+                cmove_col(terminal(s), (colmax+2)*col+1)
                 print(terminal(s), completions[idx])
             end
         end


### PR DESCRIPTION
The spacing between the first two completions is only one space, while the spacing between the remaining completions is two spaces: Ex
```aaa<space>bbb<space><space>ccc ...```

This PR makes the spacing two spaces between all completions. Ex
```aaa<space><space>bbb<space><space>ccc ...```
