### PR TITLE
Running `make testall` should run all of the tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -7,7 +7,7 @@ STDLIBDIR := $(build_datarootdir)/julia/stdlib/$(VERSDIR)
 # TODO: this Makefile ignores BUILDDIR, except for computing JULIA_EXECUTABLE
 
 TESTGROUPS = unicode strings compiler
-TESTS = all stdlib $(TESTGROUPS) \
+TESTS = all default stdlib $(TESTGROUPS) \
 		$(patsubst $(STDLIBDIR)/%/,%,$(dir $(wildcard $(STDLIBDIR)/*/.))) \
 		$(filter-out runtests testdefs, \
 			$(patsubst $(SRCDIR)/%.jl,%,$(wildcard $(SRCDIR)/*.jl))) \
@@ -19,7 +19,7 @@ EMBEDDING_ARGS := "JULIA=$(JULIA_EXECUTABLE)" "BIN=$(SRCDIR)/embedding" "CC=$(CC
 
 GCEXT_ARGS := "JULIA=$(JULIA_EXECUTABLE)" "BIN=$(SRCDIR)/gcext" "CC=$(CC)"
 
-default: all
+default:
 
 $(TESTS):
 	@cd $(SRCDIR) && \

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -110,9 +110,13 @@ function choosetests(choices = [])
 
     unhandled = copy(skip_tests)
 
-    if tests == ["all"] || isempty(tests)
-        tests = TESTNAMES
+    requested_all     = "all"     in tests
+    requested_default = "default" in tests
+    if isempty(tests) || requested_all || requested_default
+        append!(tests, TESTNAMES)
     end
+    filter!(x -> x != "all",     tests)
+    filter!(x -> x != "default", tests)
 
     function filtertests!(tests, name, files=[name])
        flt = x -> (x != name && !(x in files))
@@ -125,7 +129,7 @@ function choosetests(choices = [])
        end
     end
 
-    explicit_pkg3    = "Pkg"            in tests
+    explicit_pkg     = "Pkg"            in tests
     explicit_libgit2 = "LibGit2/online" in tests
 
     filtertests!(tests, "unicode", ["unicode/utf8"])
@@ -189,8 +193,9 @@ function choosetests(choices = [])
     end
     filter!(x -> (x != "stdlib" && !(x in STDLIBS)) , tests)
     append!(tests, new_tests)
-    explicit_pkg3    || filter!(x -> x != "Pkg",            tests)
-    explicit_libgit2 || filter!(x -> x != "LibGit2/online", tests)
+
+    requested_all || explicit_pkg     || filter!(x -> x != "Pkg",            tests)
+    requested_all || explicit_libgit2 || filter!(x -> x != "LibGit2/online", tests)
 
     # Filter out tests from the test groups in the stdlibs
     filter!(!in(tests), unhandled)


### PR DESCRIPTION
## Description

Before this pull request:
1. `make test` will run all tests except `Pkg` and `LibGit2/online`.
2. `make testall` will run all tests except `Pkg` and `LibGit2/online`.

After this pull request:
1. `make test` will run all tests except `Pkg` and `LibGit2/online`.
2. `make testall` will run all tests.

## Motivation

If you do `make testall`, don't you expect it to run all of the tests?