### PR TITLE
External stdlibs: stop using the unauthenticated `git://` protocol in the external stdlib URLs

### DIFF
--- a/stdlib/ArgTools.version
+++ b/stdlib/ArgTools.version
@@ -1,4 +1,4 @@
 ARGTOOLS_BRANCH = master
 ARGTOOLS_SHA1 = 08b11b2707593d4d7f92e5f1b9dba7668285ff82
-ARGTOOLS_GIT_URL := git://github.com/JuliaIO/ArgTools.jl.git
+ARGTOOLS_GIT_URL := https://github.com/JuliaIO/ArgTools.jl.git
 ARGTOOLS_TAR_URL = https://api.github.com/repos/JuliaIO/ArgTools.jl/tarball/$1

--- a/stdlib/Downloads.version
+++ b/stdlib/Downloads.version
@@ -1,4 +1,4 @@
 DOWNLOADS_BRANCH = master
 DOWNLOADS_SHA1 = c91876a38f42d9a899b6ec10493d144bb59281eb
-DOWNLOADS_GIT_URL := git://github.com/JuliaLang/Downloads.jl.git
+DOWNLOADS_GIT_URL := https://github.com/JuliaLang/Downloads.jl.git
 DOWNLOADS_TAR_URL = https://api.github.com/repos/JuliaLang/Downloads.jl/tarball/$1

--- a/stdlib/LibCURL.version
+++ b/stdlib/LibCURL.version
@@ -1,4 +1,4 @@
 LIBCURL_BRANCH = master
 LIBCURL_SHA1 = 04c450c17024d5b49cb30013f1409306efd35203
-LIBCURL_GIT_URL := git://github.com/JuliaWeb/LibCURL.jl.git
+LIBCURL_GIT_URL := https://github.com/JuliaWeb/LibCURL.jl.git
 LIBCURL_TAR_URL = https://api.github.com/repos/JuliaWeb/LibCURL.jl/tarball/$1

--- a/stdlib/NetworkOptions.version
+++ b/stdlib/NetworkOptions.version
@@ -1,4 +1,4 @@
 NETWORKOPTIONS_BRANCH = master
 NETWORKOPTIONS_SHA1 = 01e6ec17aa4ef74b4a0ea19c193dacf8d2cfc353
-NETWORKOPTIONS_GIT_URL := git://github.com/JuliaLang/NetworkOptions.jl.git
+NETWORKOPTIONS_GIT_URL := https://github.com/JuliaLang/NetworkOptions.jl.git
 NETWORKOPTIONS_TAR_URL = https://api.github.com/repos/JuliaLang/NetworkOptions.jl/tarball/$1

--- a/stdlib/Pkg.version
+++ b/stdlib/Pkg.version
@@ -1,4 +1,4 @@
 PKG_BRANCH = master
 PKG_SHA1 = 570b605870ea9e6645c68e6be5f98c1adc9925d8
-PKG_GIT_URL := git://github.com/JuliaLang/Pkg.jl.git
+PKG_GIT_URL := https://github.com/JuliaLang/Pkg.jl.git
 PKG_TAR_URL = https://api.github.com/repos/JuliaLang/Pkg.jl/tarball/$1

--- a/stdlib/SHA.version
+++ b/stdlib/SHA.version
@@ -1,4 +1,4 @@
 SHA_BRANCH = master
 SHA_SHA1 = d30dbf6f75b30b84c678208bb93438bd75a5f3ef
-SHA_GIT_URL := git://github.com/JuliaCrypto/SHA.jl.git
+SHA_GIT_URL := https://github.com/JuliaCrypto/SHA.jl.git
 SHA_TAR_URL = https://api.github.com/repos/JuliaCrypto/SHA.jl/tarball/$1

--- a/stdlib/Statistics.version
+++ b/stdlib/Statistics.version
@@ -1,4 +1,4 @@
 STATISTICS_BRANCH = master
 STATISTICS_SHA1 = 5256d570d0a554780ed80949c79116f47eac6382
-STATISTICS_GIT_URL := git://github.com/JuliaLang/Statistics.jl.git
+STATISTICS_GIT_URL := https://github.com/JuliaLang/Statistics.jl.git
 STATISTICS_TAR_URL = https://api.github.com/repos/JuliaLang/Statistics.jl/tarball/$1

--- a/stdlib/SuiteSparse.version
+++ b/stdlib/SuiteSparse.version
@@ -1,4 +1,4 @@
 SUITESPARSE_BRANCH = master
 SUITESPARSE_SHA1 = e4df734c3e0b54cd2275adbd923b5afaf0f7e3d0
-SUITESPARSE_GIT_URL := git://github.com/JuliaLang/SuiteSparse.jl.git
+SUITESPARSE_GIT_URL := https://github.com/JuliaLang/SuiteSparse.jl.git
 SUITESPARSE_TAR_URL = https://api.github.com/repos/JuliaLang/SuiteSparse.jl/tarball/$1

--- a/stdlib/Tar.version
+++ b/stdlib/Tar.version
@@ -1,4 +1,4 @@
 TAR_BRANCH = master
 TAR_SHA1 = e65daff574387ec936371c11ceb3ae93907645a1
-TAR_GIT_URL := git://github.com/JuliaIO/Tar.jl.git
+TAR_GIT_URL := https://github.com/JuliaIO/Tar.jl.git
 TAR_TAR_URL = https://api.github.com/repos/JuliaIO/Tar.jl/tarball/$1


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/BumpStdlibs.jl/issues/69

---

GitHub has disabled support for the unauthenticated `git://` protocol, so we should stop using it in the URLs for the external stdlibs.

https://github.blog/2021-09-01-improving-git-protocol-security-github/