### PR TITLE
Remove some other uses of the unauthenticated `git://` protocol in Git URLs

### DIFF
--- a/contrib/new-stdlib.sh
+++ b/contrib/new-stdlib.sh
@@ -56,7 +56,7 @@ mv "$ROOT/Makefile.tmp" "$ROOT/Makefile"
 cat >"$ROOT/$NAME.version" <<EOF
 ${UNAME}_BRANCH = master
 ${UNAME}_SHA1 = $SHA1
-${UNAME}_GIT_URL := git://github.com/$USER/$NAME.jl.git
+${UNAME}_GIT_URL := https://github.com/$USER/$NAME.jl.git
 ${UNAME}_TAR_URL = https://api.github.com/repos/$USER/$NAME.jl/tarball/\$1
 EOF
 

--- a/deps/blastrampoline.mk
+++ b/deps/blastrampoline.mk
@@ -2,7 +2,7 @@
 
 ifneq ($(USE_BINARYBUILDER_BLASTRAMPOLINE),1)
 
-BLASTRAMPOLINE_GIT_URL := git://github.com/JuliaLinearAlgebra/libblastrampoline.git
+BLASTRAMPOLINE_GIT_URL := https://github.com/JuliaLinearAlgebra/libblastrampoline.git
 BLASTRAMPOLINE_TAR_URL = https://api.github.com/repos/JuliaLinearAlgebra/libblastrampoline/tarball/$1
 $(eval $(call git-external,blastrampoline,BLASTRAMPOLINE,,,$(BUILDDIR)))
 

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -1,7 +1,7 @@
 ## libgit2
 ifneq ($(USE_BINARYBUILDER_LIBGIT2),1)
 
-LIBGIT2_GIT_URL := git://github.com/libgit2/libgit2.git
+LIBGIT2_GIT_URL := https://github.com/libgit2/libgit2.git
 LIBGIT2_TAR_URL = https://api.github.com/repos/libgit2/libgit2/tarball/$1
 $(eval $(call git-external,libgit2,LIBGIT2,CMakeLists.txt,,$(SRCCACHE)))
 

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -1,6 +1,6 @@
 ## libssh2
 ifneq ($(USE_BINARYBUILDER_LIBSSH2), 1)
-LIBSSH2_GIT_URL := git://github.com/libssh2/libssh2.git
+LIBSSH2_GIT_URL := https://github.com/libssh2/libssh2.git
 LIBSSH2_TAR_URL = https://api.github.com/repos/libssh2/libssh2/tarball/$1
 $(eval $(call git-external,libssh2,LIBSSH2,CMakeLists.txt,,$(SRCCACHE)))
 

--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -1,6 +1,6 @@
 ## LIBUV ##
 ifneq ($(USE_BINARYBUILDER_LIBUV),1)
-LIBUV_GIT_URL:=git://github.com/JuliaLang/libuv.git
+LIBUV_GIT_URL:=https://github.com/JuliaLang/libuv.git
 LIBUV_TAR_URL=https://api.github.com/repos/JuliaLang/libuv/tarball/$1
 $(eval $(call git-external,libuv,LIBUV,configure,,$(SRCCACHE)))
 

--- a/deps/libwhich.mk
+++ b/deps/libwhich.mk
@@ -1,5 +1,5 @@
 ## LIBWHICH ##
-LIBWHICH_GIT_URL := git://github.com/vtjnash/libwhich.git
+LIBWHICH_GIT_URL := https://github.com/vtjnash/libwhich.git
 LIBWHICH_TAR_URL = https://api.github.com/repos/vtjnash/libwhich/tarball/$1
 $(eval $(call git-external,libwhich,LIBWHICH,,,$(BUILDDIR)))
 

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -3,7 +3,7 @@ include $(SRCDIR)/llvm-ver.make
 include $(SRCDIR)/llvm-options.mk
 
 ifneq ($(USE_BINARYBUILDER_LLVM), 1)
-LLVM_GIT_URL:=git://github.com/JuliaLang/llvm-project.git
+LLVM_GIT_URL:=https://github.com/JuliaLang/llvm-project.git
 LLVM_TAR_URL=https://api.github.com/repos/JuliaLang/llvm-project/tarball/$1
 $(eval $(call git-external,llvm,LLVM,CMakeLists.txt,,$(SRCCACHE)))
 

--- a/deps/openblas.mk
+++ b/deps/openblas.mk
@@ -1,7 +1,7 @@
 ## OpenBLAS ##
 ifneq ($(USE_BINARYBUILDER_OPENBLAS), 1)
 # LAPACK is built into OpenBLAS by default
-OPENBLAS_GIT_URL := git://github.com/xianyi/OpenBLAS.git
+OPENBLAS_GIT_URL := https://github.com/xianyi/OpenBLAS.git
 OPENBLAS_TAR_URL = https://api.github.com/repos/xianyi/OpenBLAS/tarball/$1
 $(eval $(call git-external,openblas,OPENBLAS,,,$(BUILDDIR)))
 

--- a/deps/openlibm.mk
+++ b/deps/openlibm.mk
@@ -1,6 +1,6 @@
 ## openlibm ##
 ifneq ($(USE_BINARYBUILDER_OPENLIBM), 1)
-OPENLIBM_GIT_URL := git://github.com/JuliaMath/openlibm.git
+OPENLIBM_GIT_URL := https://github.com/JuliaMath/openlibm.git
 OPENLIBM_TAR_URL = https://api.github.com/repos/JuliaMath/openlibm/tarball/$1
 $(eval $(call git-external,openlibm,OPENLIBM,,,$(BUILDDIR)))
 

--- a/deps/utf8proc.mk
+++ b/deps/utf8proc.mk
@@ -1,5 +1,5 @@
 ## UTF8PROC ##
-UTF8PROC_GIT_URL := git://github.com/JuliaLang/utf8proc.git
+UTF8PROC_GIT_URL := https://github.com/JuliaLang/utf8proc.git
 UTF8PROC_TAR_URL = https://api.github.com/repos/JuliaLang/utf8proc/tarball/$1
 $(eval $(call git-external,utf8proc,UTF8PROC,,,$(BUILDDIR)))
 

--- a/deps/zlib.mk
+++ b/deps/zlib.mk
@@ -1,6 +1,6 @@
 ## Zlib ##
 ifneq ($(USE_BINARYBUILDER_ZLIB), 1)
-ZLIB_GIT_URL := git://github.com/madler/zlib.git
+ZLIB_GIT_URL := https://github.com/madler/zlib.git
 ZLIB_TAR_URL = https://api.github.com/repos/madler/zlib/tarball/$1
 $(eval $(call git-external,zlib,ZLIB,,,$(SRCCACHE)))
 


### PR DESCRIPTION
GitHub has disabled support for the unauthenticated `git://` protocol, so we should stop using it in the URLs for the external stdlibs.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

---

Note: you'll notice that I made this PR separately from #42906. This is intentional. I'm pretty sure that #42906 won't backport cleanly, which is why I kept those changes separate. In contrast, this PR should be able to be automatically backported without any issues.