### PR TITLE
Fix type constructor broadcasting for SparseArrays

### DIFF
--- a/stdlib/SparseArrays/src/higherorderfns.jl
+++ b/stdlib/SparseArrays/src/higherorderfns.jl
@@ -166,6 +166,10 @@ function _noshapecheck_map(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseVecOrMat,N
     fpreszeros = _iszero(fofzeros)
     maxnnzC = Int(fpreszeros ? min(widelength(A), _sumnnzs(A, Bs...)) : widelength(A))
     entrytypeC = Base.Broadcast.combine_eltypes(f, (A, Bs...))
+    # handle the case where inference fails (#35454), but try not to hit a zero
+    if entrytypeC == Any && length(nonzeros(A)) > 0
+        entrytypeC = typeof(f(first(nonzeros(A))))
+    end
     indextypeC = _promote_indtype(A, Bs...)
     C = _allocres(size(A), indextypeC, entrytypeC, maxnnzC)
     return fpreszeros ? _map_zeropres!(f, C, A, Bs...) :

--- a/stdlib/SparseArrays/test/higherorderfns.jl
+++ b/stdlib/SparseArrays/test/higherorderfns.jl
@@ -736,4 +736,10 @@ end
     @test A * C == B * C == spzeros(Int, 4, 6)
 end
 
+@testset "#35454 - broadcasting type constructor over sparse array results in Any sparse array" begin
+    for T in (Float64, Float32, ComplexF64, ComplexF32, Int64, Int32)
+        @test T.(sprand(4,5,0.4) .> 0.5) isa SparseMatrixCSC{T, Int64}
+    end
+end
+
 end # module


### PR DESCRIPTION
Fixes #35454

Went looking for inference bugs and found this low-hanging fruit. As discussed in #19595, SparseArrays and inference still don't get along very well, which I'll also be looking into, but this is a quick fix for the time being.