### PR TITLE
Cleanup `RPATH` settings

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1196,12 +1196,12 @@ else ifeq ($(OS), Darwin)
   RPATH := -Wl,-rpath,'@executable_path/$(build_libdir_rel)'
   RPATH_ORIGIN := -Wl,-rpath,'@loader_path/'
   RPATH_ESCAPED_ORIGIN := $(RPATH_ORIGIN)
-  RPATH_LIB := -Wl,-rpath,'@loader_path/julia/' -Wl,-rpath,'@loader_path/'
+  RPATH_LIB := -Wl,-rpath,'@loader_path/'
 else
-  RPATH := -Wl,-rpath,'$$ORIGIN/$(build_libdir_rel)' -Wl,-rpath,'$$ORIGIN/$(build_private_libdir_rel)' -Wl,-rpath-link,$(build_shlibdir) -Wl,-z,origin
+  RPATH := -Wl,-rpath,'$$ORIGIN/$(build_libdir_rel)' -Wl,-rpath-link,$(build_shlibdir) -Wl,-z,origin
   RPATH_ORIGIN := -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
   RPATH_ESCAPED_ORIGIN := -Wl,-rpath,'\$$\$$ORIGIN' -Wl,-z,origin -Wl,-rpath-link,$(build_shlibdir)
-  RPATH_LIB := -Wl,-rpath,'$$ORIGIN/julia' -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
+  RPATH_LIB := -Wl,-rpath,'$$ORIGIN/' -Wl,-z,origin
 endif
 
 # --whole-archive


### PR DESCRIPTION
Previously, we needed to provide both `usr/lib` and `usr/lib/julia` as
elements on the `RPATH`, because `libjulia` lived in `usr/lib`, and
needed to be able to find dependent libraries both within a build tree
(when most libraries live in `usr/lib`) and within an install tree (when
most libraries live in `usr/lib/julia`).

Nowadays, everything is either in `usr/lib` or in `usr/lib/julia` with
the exception of `libjulia`, but since it's really `libjulia-internal`
that does all the `dlopen()`'ing, we can simply use `$$ORIGIN` (or the
equivalent `@loader_path/` on macOS) and completely ignore the rest of
the RPATH shenanigans we do.