### PR TITLE
Eliminate `@loader_path/julia` element of `DL_LOAD_PATH`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -212,8 +212,6 @@ let os = ccall(:jl_get_UNAME, Any, ())
     if os === :Darwin || os === :Apple
         if Base.DARWIN_FRAMEWORK
             push!(DL_LOAD_PATH, "@loader_path/Frameworks")
-        else
-            push!(DL_LOAD_PATH, "@loader_path/julia")
         end
         push!(DL_LOAD_PATH, "@loader_path")
     end


### PR DESCRIPTION
Analogous to https://github.com/JuliaLang/julia/commit/236523ffc2b0493e8e519a721ec030b7c3a64f83, we don't need to search in `@loader_path/julia` anymore, as `libjulia-internal` is now consistently within the same directory as our other dependencies.