### PR TITLE
optimizer: more improve the idempotency of callsite inlining

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -53,6 +53,7 @@ function inlining_policy(interp::AbstractInterpreter, @nospecialize(src), stmt_f
             return nothing
         end
     end
+    return nothing
 end
 
 include("compiler/ssair/driver.jl")


### PR DESCRIPTION
We need to force constant propagation for a call that is going to be
inlined, since the inliner will try to find this constant result if
these constant arguments arrive there.

The added test case should describe the motivation.