### PR TITLE
Distributed test suite: mark another test as thread-unsafe

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -293,7 +293,9 @@ let wid1 = workers()[1],
     end
     finalize(rr) # finalize locally
     yield() # flush gc msgs
-    @test remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid) == true
+    if include_thread_unsafe()
+        @test remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid) == true
+    end
     remotecall_fetch(r -> (finalize(take!(r)); yield(); nothing), wid2, fstore) # finalize remotely
     sleep(0.5) # to ensure that wid2 messages have been executed on wid1
     @test remotecall_fetch(k -> haskey(Distributed.PGRP.refs, k), wid1, rrid) == false


### PR DESCRIPTION
Follow-up to #42764

This test is thread-unsafe, as seen in e.g. https://buildkite.com/julialang/julia-master/builds/5449#e5eb4ce9-c42e-417d-8992-d7f7a789178b