### PR TITLE
add condition to use emulated fma

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -413,9 +413,11 @@ fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
 # If fma_llvm() clobbers the rounding mode, the result of 0.1 + 0.2 will be 0.3
 # instead of the properly-rounded 0.30000000000000004; check after calling fma
 # TODO actually detect fma in hardware and switch on that.
-if (Sys.ARCH !== :i686 && fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
-    (fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) ==
-     1.8626451500983188e-9) && 0.1 + 0.2 == 0.30000000000000004)
+if (Sys.ARCH !== :i686 &&
+    fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
+    fma_llvm(-0.05339717f0, -2.6319417f-26, -1.8926976f-33) == 1.4053805f-27
+    (fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) == 1.8626451500983188e-9) &&
+     0.1 + 0.2 == 0.30000000000000004)
     fma(x::Float32, y::Float32, z::Float32) = fma_llvm(x,y,z)
     fma(x::Float64, y::Float64, z::Float64) = fma_llvm(x,y,z)
 else

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -415,7 +415,7 @@ fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
 # TODO actually detect fma in hardware and switch on that.
 if (Sys.ARCH !== :i686 &&
     fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
-    fma_llvm(-0.05339717f0, -2.6319417f-26, -1.8926976f-33) == 1.4053805f-27
+    fma_llvm(-0.05339717f0, -2.6319417f-26, -1.8926976f-33) == 1.4053805f-27 &&
     (fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) == 1.8626451500983188e-9) &&
      0.1 + 0.2 == 0.30000000000000004)
     fma(x::Float32, y::Float32, z::Float32) = fma_llvm(x,y,z)


### PR DESCRIPTION
Testing has revealed that some old windows machines without fma were using broken emulated versions for Float32. This adds a test.