### PR TITLE
Remove mention of Rational in convert

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -181,7 +181,7 @@ Stacktrace:
 [...]
 ```
 
-If `T` is a [`AbstractFloat`](@ref) or [`Rational`](@ref) type,
+If `T` is a [`AbstractFloat`](@ref) type,
 then it will return the closest value to `x` representable by `T`.
 
 ```jldoctest

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -191,11 +191,8 @@ julia> x = 1/3
 julia> convert(Float32, x)
 0.33333334f0
 
-julia> convert(Rational{Int32}, x)
-1//3
-
-julia> convert(Rational{Int64}, x)
-6004799503160661//18014398509481984
+julia> convert(BigFloat, x)
+0.333333333333333314829616256247390992939472198486328125
 ```
 
 If `T` is a collection type and `x` a collection, the result of


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/40226.

I recommend to just remove the mention of `Rational` in the docstring. The reason is that explaining when conversion fails and when it works seems complex to me (as it depends on several factors). Therefore I think, given `Rational` is not so commonly used in conversion, that just avoiding mentioning it is OK.