### PR TITLE
CI (Buildbot): temporarily skip almost all of the tests on FreeBSD if we are on CI and the Julia version is 1.8+

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,16 @@ include("testenv.jl")
 (; tests, net_on, exit_on_error, use_revise, seed) = choosetests(ARGS)
 tests = unique(tests)
 
+if Sys.isfreebsd() && Base.VERSION >= v"1.8.0-"
+    if get(ENV, "CI", "false") == "true"
+        @error "This is FreeBSD, on Julia 1.8+, on CI. Tests are known to be broken, so we will skip almost all of the tests."
+        empty!(tests)
+        
+        # We will actually run a single test set, just as a sanity check to make sure that Julia can be run.
+        push!(tests, "sysinfo")
+    end
+end
+
 if Sys.islinux()
     const SYS_rrcall_check_presence = 1008
     global running_under_rr() = 0 == ccall(:syscall, Int,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ if Sys.isfreebsd() && Base.VERSION >= v"1.8.0-"
     if get(ENV, "CI", "false") == "true"
         @error "This is FreeBSD, on Julia 1.8+, on CI. Tests are known to be broken, so we will skip almost all of the tests."
         empty!(tests)
-        
+
         # We will actually run a single test set, just as a sanity check to make sure that Julia can be run.
         push!(tests, "sysinfo")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,8 +18,10 @@ if Sys.isfreebsd() && Base.VERSION >= v"1.8.0-"
         @error "This is FreeBSD, on Julia 1.8+, on CI. Tests are known to be broken, so we will skip almost all of the tests."
         empty!(tests)
 
-        # We will actually run a single test set, just as a sanity check to make sure that Julia can be run.
+        # We will actually run a few quick test sets, just as a sanity check.
         push!(tests, "sysinfo")
+        push!(tests, "triplequote")
+        push!(tests, "vecelement")
     end
 end
 


### PR DESCRIPTION
Because the `tester_freebsd64` Buildbot job is always failing, every single commit on master has an ❌, which is really noisy and unhelpful.

Until https://github.com/JuliaLang/julia/pull/41955 is ready, let's temporarily skip almost all of the tests if all three of the following conditions hold:
1. We are on FreeBSD.
2. We are running on CI, as evidenced by the value of the `CI` environment variable.
3. The Julia version is 1.8+. (FreeBSD tests are only broken on 1.8+. We expect the FreeBSD tests to be passing on 1.6 and 1.7.)

If all three of those conditions hold, we will skip almost all of the tests. That is, we will run a few test sets, just as a sanity check, But we will skip all other test sets.

This is just a short-term temporary solution. When https://github.com/JuliaLang/julia/pull/41955 is ready to go, we will revert this change.