### PR TITLE
DiskStat: a few tweaks to the new functionality

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -1190,23 +1190,19 @@ struct DiskStat
 end
 
 function Base.getproperty(stats::DiskStat, field::Symbol)
-    total = getfield(stats, :bsize) * getfield(stats, :blocks)
-    available = getfield(stats, :bsize) * getfield(stats, :bavail)
-    field === :available && return available
+    total = Int64(getfield(stats, :bsize) * getfield(stats, :blocks))
+    available = Int64(getfield(stats, :bsize) * getfield(stats, :bavail))
     field === :total && return total
+    field === :available && return available
     field === :used && return total - available
     return getfield(stats, field)
 end
 
-@eval Base.propertynames(stats::DiskStat) = $((fieldnames(DiskStat)[1:end-1]..., :available, :total, :used))
+@eval Base.propertynames(stats::DiskStat) =
+    $((fieldnames(DiskStat)[1:end-1]..., :available, :total, :used))
 
-function Base.show(io::IO, x::DiskStat)
-    print(io, "DiskStat(")
-    for field in 1:(nfields(x) - 1)
-        print(io, "$(getfield(x, field)), ")
-    end
-    print(io, "available: $(x.available), total: $(x.total), used: $(x.used))")
-end
+Base.show(io::IO, x::DiskStat) =
+    print(io, "DiskStat(total=$(x.total), used=$(x.used), available=$(x.available))")
 
 """
     diskstat(path=pwd())

--- a/test/file.jl
+++ b/test/file.jl
@@ -1703,7 +1703,7 @@ end
     dstat = diskstat()
     @test dstat.total < 32PB
     @test dstat.used + dstat.available == dstat.total
-    @test occursin(r"^DiskStat\(.*, available: \d+, total: \d+, used: \d+\)$", sprint(show, dstat))
+    @test occursin(r"^DiskStat\(total=\d+, used=\d+, available=\d+\)$", sprint(show, dstat))
     # Test diskstat(::AbstractString)
     dstat = diskstat(pwd())
     @test dstat.total < 32PB


### PR DESCRIPTION
- Show only virtual fields: the mix of positional values and `key: value` printing was a bit confusing and nobody remembers what all those positional fields are;
- Return the virtual fields as `Int64` since that's what we use in Julia land for sizes of things. The raw fields remain `UInt64` because that's how they are actually represented.
