### PR TITLE
make locks fast

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -28,10 +28,9 @@ end
 mutable struct Lock <: AbstractLock
     @atomic locked_by::Union{Task, Nothing}
     cond_wait::ThreadSynchronizer
-    @atomic reentrancy_cnt::Int32
-    @atomic havewaiting::Bool
+    @atomic reentrancy_cnt::UInt32 # high bit is has-waiter
 
-    Lock() = new(nothing, ThreadSynchronizer(), 0, false)
+    Lock() = new(nothing, ThreadSynchronizer(), 0x0000_0000)
 end
 const ReentrantLock = Lock
 
@@ -59,18 +58,17 @@ Each successful `trylock` must be matched by an [`unlock`](@ref).
 """
 function trylock(rl::ReentrantLock)
     ct = current_task()
-    locked_by = @atomic :monotonic rl.locked_by
-    if locked_by === ct
-        @atomic :monotonic rl.reentrancy_cnt = rl.reentrancy_cnt + Int32(1)
+    if rl.locked_by === ct
+        @atomic rl.reentrancy_cnt += 0x0000_0001
         return true
-    elseif locked_by === nothing
-        GC.disable_finalizers()
-        if (@atomicreplace :acquire rl.locked_by nothing => ct).success
-            @atomic :monotonic rl.reentrancy_cnt = Int32(1)
-            return true
-        end
-        GC.enable_finalizers()
     end
+    GC.disable_finalizers()
+    if (@atomicreplace :acquire rl.reentrancy_cnt 0x0000_0000 => 0x0000_0001).success
+        #@assert rl.locked_by === nothing
+        @atomic :release rl.locked_by = ct
+        return true
+    end
+    GC.enable_finalizers()
     return false
 end
 
@@ -89,12 +87,15 @@ function lock(rl::ReentrantLock)
 end
 @noinline function slowlock(rl::ReentrantLock)
     while true
-        @atomic :sequentially_consistent rl.havewaiting = true
+        new = @atomic :sequentially_consistent rl.reentrancy_cnt |= 0x1000_0000 # set havewaiters
+        if new === 0x1000_0000 # clear havewaiters if no locks currently held
+            @atomicreplace :sequentially_consistent rl.reentrancy_cnt 0x1000_0000 => 0x0000_0000
+        end
         trylock(rl) && return
         c = rl.cond_wait
         lock(c.lock)
         try
-            if @atomic :sequentially_consistent rl.havewaiting
+            if (@atomic :sequentially_consistent rl.reentrancy_cnt) & 0x1000_0000 != 0
                 wait(c)
             end
         finally
@@ -113,16 +114,15 @@ internal counter and return immediately.
 """
 function unlock(rl::ReentrantLock)
     ct = current_task()
-    n = rl.reentrancy_cnt
-    rl.locked_by === ct || error(n == 0 ? "unlock count must match lock count" : "unlock from wrong thread")
+    old = @atomic :monotonic rl.reentrancy_cnt
+    rl.locked_by === ct || error(rl.reentrancy_cnt == 0 ? "unlock count must match lock count" : "unlock from wrong thread")
     # n == 0 && error("unlock count must match lock count") # impossible
-    @atomic :monotonic rl.reentrancy_cnt = n - Int32(1)
-    if n == Int32(1)
-        # either our thread will release locked_by first,
-        # or the other thread will be added to waitq first
-        # so we avoid the race, and usually the lock
-        @atomic :release rl.locked_by = nothing
-        if @atomicswap :sequentially_consistent rl.havewaiting = false
+    if old & 0x7fff_ffff != 0x0000_0001
+        @atomic :sequentially_consistent rl.reentrancy_cnt -= 0x0000_0001
+    else
+        @atomic :monotonic rl.locked_by = nothing
+        new = @atomic :sequentially_consistent rl.reentrancy_cnt -= 0x0000_0001
+        if new & 0x1000_0000 != 0 # havewaiters
             (@noinline function notifywaiters(rl)
                 cond_wait = rl.cond_wait
                 lock(cond_wait)
@@ -139,17 +139,16 @@ function unlock(rl::ReentrantLock)
 end
 
 function unlockall(rl::ReentrantLock)
-    n = rl.reentrancy_cnt
-    @atomic :monotonic rl.reentrancy_cnt = Int32(1)
+    n = @atomic :monotonic rl.reentrancy_cnt
+    @atomic :monotonic rl.reentrancy_cnt -= (n - 0x0000_0001)
     unlock(rl)
-    return n
+    return n & 0x7fff_ffff
 end
 
-function relockall(rl::ReentrantLock, n::Int32)
+function relockall(rl::ReentrantLock, n::UInt32)
     lock(rl)
-    n1 = rl.reentrancy_cnt
-    @atomic :monotonic rl.reentrancy_cnt = n
-    n1 == Int32(1) || concurrency_violation()
+    new = @atomic :monotonic rl.reentrancy_cnt += (n - 0x0000_0001)
+    new & 0x7ffff_ffff == n || concurrency_violation()
     return
 end
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -96,7 +96,7 @@ end
         c = rl.cond_wait
         lock(c.lock)
         try
-            if (@atomic rl.havelock) == 0x01 # :sequentially_consistent ?
+            if (@atomic rl.havelock) == 0x02 # :sequentially_consistent ?
                 wait(c)
             end
         finally

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -160,8 +160,8 @@ end
 
 function relockall(rl::ReentrantLock, n::UInt32)
     lock(rl)
-    new = @atomic :not_atomic rl.reentrancy_cnt += n - UInt32(1)
-    new == n || concurrency_violation()
+    old = @atomicswap :not_atomic rl.reentrancy_cnt = n
+    old == 0x0000_0001 || concurrency_violation()
     return
 end
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -4,7 +4,7 @@ const ThreadSynchronizer = GenericCondition{Threads.SpinLock}
 
 # Advisory reentrant lock
 """
-    Lock()
+    ReentrantLock()
 
 Creates a re-entrant lock for synchronizing [`Task`](@ref)s. The same task can
 acquire the lock as many times as required. Each [`lock`](@ref) must be matched
@@ -25,7 +25,7 @@ finally
 end
 ```
 """
-mutable struct Lock <: AbstractLock
+mutable struct ReentrantLock <: AbstractLock
     # offset = 16
     @atomic locked_by::Union{Task, Nothing}
     # offset32 = 20, offset64 = 24
@@ -41,9 +41,8 @@ mutable struct Lock <: AbstractLock
     # offset32 = 44, offset64 = 72 == sizeof+offset
     # sizeof32 = 28, sizeof64 = 56
 
-    Lock() = new(nothing, 0x0000_0000, 0x00, ThreadSynchronizer())
+    ReentrantLock() = new(nothing, 0x0000_0000, 0x00, ThreadSynchronizer())
 end
-const ReentrantLock = Lock
 
 assert_havelock(l::ReentrantLock) = assert_havelock(l, l.locked_by)
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -37,7 +37,7 @@ mutable struct ReentrantLock <: AbstractLock
     # offset32 = 36, offset64 = 48
     # sizeof32 = 20, sizeof64 = 32
     # now add padding to make this a full cache line to minimize false sharing between objects
-    _::NTuple{Int == Int32 ? 2 : 3, Int}
+    _::NTuple{Int === Int32 ? 2 : 3, Int}
     # offset32 = 44, offset64 = 72 == sizeof+offset
     # sizeof32 = 28, sizeof64 = 56
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -26,15 +26,15 @@ end
 ```
 """
 mutable struct Lock <: AbstractLock
-    @atomic locked_by::Ptr{Nothing} # Task or NULL, but without the write barrier
+    @atomic locked_by::Union{Task, Nothing}
     cond_wait::ThreadSynchronizer
     @atomic reentrancy_cnt::Int
 
-    Lock() = new(C_NULL, ThreadSynchronizer(), 0)
+    Lock() = new(nothing, ThreadSynchronizer(), 0)
 end
 const ReentrantLock = Lock
 
-assert_havelock(l::ReentrantLock) = (l.locked_by === pointer_from_objref(current_task())) ? nothing : concurrency_violation()
+assert_havelock(l::ReentrantLock) = assert_havelock(l, l.locked_by)
 
 """
     islocked(lock) -> Status (Boolean)
@@ -57,9 +57,9 @@ return `false`.
 Each successful `trylock` must be matched by an [`unlock`](@ref).
 """
 @inline function trylock(rl::ReentrantLock)
-    ct = pointer_from_objref(current_task())
+    ct = current_task()
     GC.disable_finalizers()
-    locked_by, success = @atomicreplace :acquire rl.locked_by C_NULL => ct
+    locked_by, success = @atomicreplace :acquire rl.locked_by nothing => ct
     if success | (ct === locked_by)
         @atomic :monotonic rl.reentrancy_cnt = rl.reentrancy_cnt + 1
         return true
@@ -127,7 +127,7 @@ If this is a recursive lock which has been acquired before, decrement an
 internal counter and return immediately.
 """
 function unlock(rl::ReentrantLock)
-    ct = pointer_from_objref(current_task())
+    ct = current_task()
     n = rl.reentrancy_cnt
     rl.locked_by === ct || error(n == 0 ? "unlock count must match lock count" : "unlock from wrong thread")
     # n == 0 && error("unlock count must match lock count") # impossible
@@ -136,7 +136,7 @@ function unlock(rl::ReentrantLock)
         # either our thread will release locked_by first,
         # or the other thread will be added to waitq first
         # so we avoid the race, and usually the lock
-        @atomic rl.locked_by = C_NULL # TODO: make this :release?
+        @atomic rl.locked_by = nothing # TODO: make this :release?
         # FIXME: Core.Intrinsics.atomic_fence(:acquire)
         if !isempty(rl.cond_wait.waitq) # TODO: make this :acquire?
             (@noinline function notifywaiters(rl)

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -28,8 +28,8 @@ end
 mutable struct Lock <: AbstractLock
     @atomic locked_by::Union{Task, Nothing}
     cond_wait::ThreadSynchronizer
-    @atomic reentrancy_cnt::Int32
-    @atomic havewaiting::Bool
+    reentrancy_cnt::Int32
+    @atomic havelock::Bool
 
     Lock() = new(nothing, ThreadSynchronizer(), 0, false)
 end
@@ -44,7 +44,7 @@ Check whether the `lock` is held by any task/thread.
 This should not be used for synchronization (see instead [`trylock`](@ref)).
 """
 function islocked(rl::ReentrantLock)
-    return rl.reentrancy_cnt != 0
+    return rl.locked_by !== nothing
 end
 
 """
@@ -61,12 +61,12 @@ function trylock(rl::ReentrantLock)
     ct = current_task()
     locked_by = @atomic :monotonic rl.locked_by
     if locked_by === ct
-        @atomic :monotonic rl.reentrancy_cnt = rl.reentrancy_cnt + Int32(1)
+        rl.reentrancy_cnt += Int32(1)
         return true
     elseif locked_by === nothing
         GC.disable_finalizers()
         if (@atomicreplace :acquire rl.locked_by nothing => ct).success
-            @atomic :monotonic rl.reentrancy_cnt = Int32(1)
+            rl.reentrancy_cnt += Int32(1)
             return true
         end
         GC.enable_finalizers()
@@ -116,18 +116,18 @@ function unlock(rl::ReentrantLock)
     n = rl.reentrancy_cnt
     rl.locked_by === ct || error(n == 0 ? "unlock count must match lock count" : "unlock from wrong thread")
     # n == 0 && error("unlock count must match lock count") # impossible
-    @atomic :monotonic rl.reentrancy_cnt = n - Int32(1)
+    rl.reentrancy_cnt = n - Int32(1)
     if n == Int32(1)
         # either our thread will release locked_by first,
         # or the other thread will be added to waitq first
         # so we avoid the race, and usually the lock
-        @atomic :release rl.locked_by = nothing
+        @atomic :monotonic rl.locked_by = nothing
         if @atomicswap :sequentially_consistent rl.havewaiting = false
             (@noinline function notifywaiters(rl)
                 cond_wait = rl.cond_wait
                 lock(cond_wait)
                 try
-                    notify(cond_wait)
+                    notify(cond_wait) # TODO: all=false, and set havewaiting if !isempty(cond_wait) after
                 finally
                     unlock(cond_wait)
                 end
@@ -139,16 +139,14 @@ function unlock(rl::ReentrantLock)
 end
 
 function unlockall(rl::ReentrantLock)
-    n = rl.reentrancy_cnt
-    @atomic :monotonic rl.reentrancy_cnt = Int32(1)
+    n = @atomicswap :notatomic rl.reentrancy_cnt = Int32(1)
     unlock(rl)
     return n
 end
 
 function relockall(rl::ReentrantLock, n::Int32)
     lock(rl)
-    n1 = rl.reentrancy_cnt
-    @atomic :monotonic rl.reentrancy_cnt = n
+    n1 = @atomicswap :notatomic rl.reentrancy_cnt = n
     n1 == Int32(1) || concurrency_violation()
     return
 end

--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -38,7 +38,7 @@ Base.assert_havelock(l::SpinLock) = islocked(l) ? nothing : Base.concurrency_vio
 
 function lock(l::SpinLock)
     while true
-        if trylock(l)
+        if @inline trylock(l)
             return
         end
         ccall(:jl_cpu_pause, Cvoid, ())
@@ -50,7 +50,7 @@ end
 function trylock(l::SpinLock)
     if l.owned == 0
         GC.disable_finalizers()
-        p = @atomicswap :acquire_release l.owned = 1
+        p = @atomicswap :acquire l.owned = 1
         if p == 0
             return true
         end

--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -27,32 +27,10 @@ contending threads. If you have more contention than that, different
 synchronization approaches should be considered.
 """
 mutable struct SpinLock <: AbstractLock
-    owned::Int
+    # we make this much larger than necessary to minimize false-sharing
+    @atomic owned::Int
     SpinLock() = new(0)
 end
-
-import Base.Sys.WORD_SIZE
-
-@eval _xchg!(x::SpinLock, v::Int) =
-    llvmcall($"""
-             %ptr = inttoptr i$WORD_SIZE %0 to i$WORD_SIZE*
-             %rv = atomicrmw xchg i$WORD_SIZE* %ptr, i$WORD_SIZE %1 acq_rel
-             ret i$WORD_SIZE %rv
-             """, Int, Tuple{Ptr{Int}, Int}, unsafe_convert(Ptr{Int}, pointer_from_objref(x)), v)
-
-@eval _get(x::SpinLock) =
-    llvmcall($"""
-             %ptr = inttoptr i$WORD_SIZE %0 to i$WORD_SIZE*
-             %rv = load atomic i$WORD_SIZE, i$WORD_SIZE* %ptr monotonic, align $(gc_alignment(Int))
-             ret i$WORD_SIZE %rv
-             """, Int, Tuple{Ptr{Int}}, unsafe_convert(Ptr{Int}, pointer_from_objref(x)))
-
-@eval _set!(x::SpinLock, v::Int) =
-    llvmcall($"""
-             %ptr = inttoptr i$WORD_SIZE %0 to i$WORD_SIZE*
-             store atomic i$WORD_SIZE %1, i$WORD_SIZE* %ptr release, align $(gc_alignment(Int))
-             ret void
-             """, Cvoid, Tuple{Ptr{Int}, Int}, unsafe_convert(Ptr{Int}, pointer_from_objref(x)), v)
 
 # Note: this cannot assert that the lock is held by the correct thread, because we do not
 # track which thread locked it. Users beware.
@@ -60,13 +38,8 @@ Base.assert_havelock(l::SpinLock) = islocked(l) ? nothing : Base.concurrency_vio
 
 function lock(l::SpinLock)
     while true
-        if _get(l) == 0
-            GC.disable_finalizers()
-            p = _xchg!(l, 1)
-            if p == 0
-                return
-            end
-            GC.enable_finalizers()
+        if trylock(l)
+            return
         end
         ccall(:jl_cpu_pause, Cvoid, ())
         # Temporary solution before we have gc transition support in codegen.
@@ -75,9 +48,9 @@ function lock(l::SpinLock)
 end
 
 function trylock(l::SpinLock)
-    if _get(l) == 0
+    if l.owned == 0
         GC.disable_finalizers()
-        p = _xchg!(l, 1)
+        p = @atomicswap :acquire_release l.owned = 1
         if p == 0
             return true
         end
@@ -87,13 +60,13 @@ function trylock(l::SpinLock)
 end
 
 function unlock(l::SpinLock)
-    _get(l) == 0 && error("unlock count must match lock count")
-    _set!(l, 0)
+    l.owned == 0 && error("unlock count must match lock count")
+    @atomic :release l.owned = 0
     GC.enable_finalizers()
     ccall(:jl_cpu_wake, Cvoid, ())
     return
 end
 
 function islocked(l::SpinLock)
-    return _get(l) != 0
+    return l.owned != 0
 end

--- a/doc/src/base/multi-threading.md
+++ b/doc/src/base/multi-threading.md
@@ -9,14 +9,6 @@ Base.Threads.nthreads
 ```
 
 See also [Multi-Threading](@ref man-multithreading).
-## Synchronization
-
-```@docs
-Base.Threads.Condition
-Base.Threads.Event
-```
-
-See also [Synchronization](@ref lib-task-sync).
 
 ## Atomic operations
 

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -49,7 +49,7 @@ Base.lock
 Base.unlock
 Base.trylock
 Base.islocked
-Base.Lock
+Base.ReentrantLock
 ```
 
 ## Channels

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -26,6 +26,8 @@ Base.schedule
 
 ## [Synchronization](@id lib-task-sync)
 
+## Synchronization
+
 ```@docs
 Base.errormonitor
 Base.@sync
@@ -34,6 +36,8 @@ Base.fetch(t::Task)
 Base.timedwait
 
 Base.Condition
+Base.Threads.Condition
+Base.Threads.Event
 Base.notify
 
 Base.Semaphore
@@ -45,7 +49,7 @@ Base.lock
 Base.unlock
 Base.trylock
 Base.islocked
-Base.ReentrantLock
+Base.Lock
 ```
 
 ## Channels


### PR DESCRIPTION
Now that we have the ability to express atomics (particularly the write barrier of the Task object), it is time for us to speed up and simplify our locks.

This PR does need someone to verify the synchronizations are correct, but I think this version is actually quite simple. There is a single byte that represents the state of the lock:
 - 0x0 : unlocked
 - 0x1 : locked (without other waiters)
 - 0x2 : locked with waiters

And then when we have the locked bit set, we can manipulate any of the other data (e.g. owner and reentrancy) without needing any atomic work, and if we don't hold that bit, we should not write to any other field.

after:
```
julia> using BenchmarkTools

julia> const lk = ReentrantLock()
Base.Lock(nothing, 0x00000000, 0x00, Base.GenericCondition{Base.Threads.SpinLock}(Base.InvasiveLinkedList{Task}(nothing, nothing), Base.Threads.SpinLock(0)), (0, 0, 0))

julia> const lk2 = Base.ThreadSynchronizer()
Base.GenericCondition{Base.Threads.SpinLock}(Base.InvasiveLinkedList{Task}(nothing, nothing), Base.Threads.SpinLock(0))

julia> @btime (lock(lk); unlock(lk))
  24.414 ns (0 allocations: 0 bytes)

julia> lock(lk); @btime (lock(lk); unlock(lk)); unlock(lk)
  5.378 ns (0 allocations: 0 bytes)

julia> @btime (lock(lk2); unlock(lk2))
  21.072 ns (0 allocations: 0 bytes)
```

before:
```
julia> const lk = ReentrantLock()
ReentrantLock(nothing, Base.GenericCondition{Base.Threads.SpinLock}(Base.InvasiveLinkedList{Task}(nothing, nothing), Base.Threads.SpinLock(0)), 0)

julia> const lk2 = Base.ThreadSynchronizer()
Base.GenericCondition{Base.Threads.SpinLock}(Base.InvasiveLinkedList{Task}(nothing, nothing), Base.Threads.SpinLock(0))

julia> @btime (lock(lk); unlock(lk))
  56.492 ns (0 allocations: 0 bytes)

julia> lock(lk); @btime (lock(lk); unlock(lk)); unlock(lk)
  12.392 ns (0 allocations: 0 bytes)

julia> @btime (lock(lk2); unlock(lk2))
  20.071 ns (0 allocations: 0 bytes)
```

and when being used in a larger context:
```
# with lock=false (baseline)
julia> @time open("../julia-1.6.2-linux-x86_64.tar.gz", lock=false) do f; lock(f.lock); try; while true; read(f, UInt8); end; catch; end; unlock(f.lock); end;
  0.881976 seconds (7.82 k allocations: 433.968 KiB, 1.81% compilation time)

# with lock=true (baseline)
julia> @time open("../julia-1.6.2-linux-x86_64.tar.gz", lock=true) do f; lock(f.lock); while !eof(f); read(f, UInt8); end; unlock(f.lock); end;
  3.822013 seconds (8.04 k allocations: 433.238 KiB, 0.56% compilation time)

# with lock=true (WIP)
julia> @time open("../julia-1.6.2-linux-x86_64.tar.gz", lock=true) do f; lock(f.lock); try; while true; read(f, UInt8); end; catch; end; unlock(f.lock); end;
  1.296815 seconds (7.81 k allocations: 433.577 KiB, 1.52% compilation time)

# with lock option deleted
julia> @time open("../julia-1.6.2-linux-x86_64.tar.gz") do f; lock(f.lock); try; while true; read(f, UInt8); end; catch; end; unlock(f.lock); end;
  1.060876 seconds (7.81 k allocations: 433.578 KiB, 1.97% compilation time)

note: don’t ask me why println(xs::String) got recompiled every time I ran that, as I don’t know, and I am not sure I want to know

and for completeness:

# baseline
julia> @time open("../julia-1.6.2-linux-x86_64.tar.gz", lock=true) do f; try; while true; read(f, UInt8); end; catch; end; end;
  7.587580 seconds (5.74 k allocations: 318.546 KiB, 0.25% compilation time)

# WIP
julia> @time open("../julia-1.6.2-linux-x86_64.tar.gz", lock=true) do f; try; while true; read(f, UInt8); end; catch; end; end;
  3.314802 seconds (4.35 k allocations: 255.397 KiB, 0.35% compilation time)

and for reference:

julia> @time open("../julia-1.6.2-linux-x86_64.tar.gz", lock=true) do f; read(f); end;
  0.077435 seconds (4.19 k allocations: 107.953 MiB, 9.44% compilation time)
```