### PR TITLE
Mention `norm` in docstring of `hypot`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -639,6 +639,8 @@ The article is available online at ArXiv at the link
 
 Compute the hypotenuse ``\\sqrt{\\sum |x_i|^2}`` avoiding overflow and underflow.
 
+See also `norm` in the [`LinearAlgebra`](@ref man-linalg) standard library.
+
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
 julia> a = Int64(10)^10;
@@ -660,6 +662,11 @@ julia> hypot(-5.7)
 
 julia> hypot(3, 4im, 12.0)
 13.0
+
+julia> using LinearAlgebra
+
+julia> norm([a, a, a, a]) == hypot(a, a, a, a)
+true
 ```
 """
 hypot(x::Number) = abs(float(x))

--- a/base/math.jl
+++ b/base/math.jl
@@ -639,7 +639,7 @@ The article is available online at ArXiv at the link
 
 Compute the hypotenuse ``\\sqrt{\\sum |x_i|^2}`` avoiding overflow and underflow.
 
-See also [`LinearAlgebra.norm`](@ref).
+See also `norm` in the [`LinearAlgebra`](@ref man-linalg) standard library.
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"

--- a/base/math.jl
+++ b/base/math.jl
@@ -639,7 +639,7 @@ The article is available online at ArXiv at the link
 
 Compute the hypotenuse ``\\sqrt{\\sum |x_i|^2}`` avoiding overflow and underflow.
 
-See also `norm` in the [`LinearAlgebra`](@ref man-linalg) standard library.
+See also [`norm`](@ref) in the [`LinearAlgebra`](@ref man-linalg) standard library.
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"

--- a/base/math.jl
+++ b/base/math.jl
@@ -639,7 +639,7 @@ The article is available online at ArXiv at the link
 
 Compute the hypotenuse ``\\sqrt{\\sum |x_i|^2}`` avoiding overflow and underflow.
 
-See also [`norm`](@ref) in the [`LinearAlgebra`](@ref man-linalg) standard library.
+See also [`LinearAlgebra.norm`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"

--- a/base/math.jl
+++ b/base/math.jl
@@ -639,7 +639,7 @@ The article is available online at ArXiv at the link
 
 Compute the hypotenuse ``\\sqrt{\\sum |x_i|^2}`` avoiding overflow and underflow.
 
-See also [`norm`](@ref) in the [`LinearAlgebra`](@ref man-linalg) standard library.
+See also `norm` in the [`LinearAlgebra`](@ref man-linalg) standard library.
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"


### PR DESCRIPTION
From this thread: https://discourse.julialang.org/t/splatting-a-vector-into-hypot/71049 
```
julia> x = randn(1000);

julia> @time hypot(x...)
  1.649448 seconds (7.60 M allocations: 429.521 MiB, 5.20% gc time, 99.81% compilation time)
33.163190321961245

julia> @time norm(x)
  0.092692 seconds (173.81 k allocations: 8.835 MiB, 28.06% gc time, 97.75% compilation time)
33.16319032196123
```