### PR TITLE
Test spawning a lot of tasks

### DIFF
--- a/test/profile_spawnmany_exec.jl
+++ b/test/profile_spawnmany_exec.jl
@@ -1,0 +1,14 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Profile
+
+function spawnmany(n)
+    if n > 2
+        m = n ÷ 2
+        t = Threads.@spawn spawnmany(m)
+        spawnmany(m)
+        wait(t)
+    end
+end
+
+@profile spawnmany(parse(Int, get(ENV, "NTASKS", "2000000")))

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -147,3 +147,39 @@ end
 
 # We don't need the watchdog anymore
 close(proc.in)
+
+# https://github.com/JuliaLang/julia/pull/42973
+@testset "spawn and wait *a lot* of tasks in @profile" begin
+    # Not using threads_exec.jl for better isolation, reproducibility, and a
+    # tighter timeout.
+    script = "profile_spawnmany_exec.jl"
+    cmd = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no $script`
+    @testset for n in [20000, 200000, 2000000]
+        proc = run(ignorestatus(setenv(cmd, "NTASKS" => n; dir = @__DIR__)); wait = false)
+        done = Threads.Atomic{Bool}(false)
+        timeout = false
+        timer = Timer(10) do _
+            timeout = true
+            for sig in [Base.SIGTERM, Base.SIGHUP, Base.SIGKILL]
+                for _ in 1:1000
+                    kill(proc, sig)
+                    if done[]
+                        if sig != Base.SIGTERM
+                            @warn "Terminating `$script` required signal $sig"
+                        end
+                        return
+                    end
+                    sleep(0.001)
+                end
+            end
+        end
+        try
+            wait(proc)
+        finally
+            done[] = true
+            close(timer)
+        end
+        @test success(proc)
+        @test !timeout
+    end
+end


### PR DESCRIPTION
This patch adds a reproducer for #42973. As I mentioned in #42973, there's still a deadlock issue with this. So, I'm posting this as a different PR so that we can pull it later once everything is fixed.