### PR TITLE
Fix undefined current task variable from #42750

### DIFF
--- a/base/condition.jl
+++ b/base/condition.jl
@@ -89,7 +89,7 @@ function _wait2(c::GenericCondition, waiter::Task)
         # the parent task. If the parent (current_task) is not sticky we must
         # set it to be sticky.
         # XXX: Ideally we would be able to unset this
-        ct.sticky = true
+        current_task().sticky = true
         tid = Threads.threadid()
         ccall(:jl_set_task_tid, Cvoid, (Any, Cint), waiter, tid-1)
     end


### PR DESCRIPTION
This has caused flaky tests (presumably since #42750 was merged?). For example in

https://buildkite.com/julialang/julia-master/builds/5592#ecf7463c-ed99-41f5-be22-5b665f48c7a1

we have

```
Error During Test at /cache/build/amdci5-7/julialang/julia-master/julia-89e19a9c8c/share/julia/stdlib/v1.8/Dates/test/types.jl:277
Test threw exception
Expression: timedwait((()->begin
              false
          end), Second(0); pollint = Millisecond(1)) === :timed_out
UndefVarError: ct not defined
Stacktrace:
 [1] _wait2(c::Base.GenericCondition{Base.Threads.SpinLock}, waiter::Task)
   @ Base ./condition.jl:91
 [2] Timer(cb::Base.var"#timercb#647"{Main.Test27Main_Dates_types.TypesTest.var"#1#2", Channel{Any}, Float64, UInt64}, timeout::Float64; interval::Float64)
   @ Base ./asyncevent.jl:265
 [3] timedwait(testcb::Main.Test27Main_Dates_types.TypesTest.var"#1#2", timeout::Float64; pollint::Float64)
   @ Base ./asyncevent.jl:305
 [4] #timedwait#2
   @ /cache/build/amdci5-7/julialang/julia-master/julia-89e19a9c8c/share/julia/stdlib/v1.8/Dates/src/types.jl:479 [inlined]
 [5] macro expansion
   @ /cache/build/amdci5-7/julialang/julia-master/julia-89e19a9c8c/share/julia/stdlib/v1.8/Test/src/Test.jl:479 [inlined]
 [6] macro expansion
   @ /cache/build/amdci5-7/julialang/julia-master/julia-89e19a9c8c/share/julia/stdlib/v1.8/Dates/test/types.jl:277 [inlined]
 [7] macro expansion
   @ /cache/build/amdci5-7/julialang/julia-master/julia-89e19a9c8c/share/julia/stdlib/v1.8/Test/src/Test.jl:1347 [inlined]
 [8] top-level scope
   @ /cache/build/amdci5-7/julialang/julia-master/julia-89e19a9c8c/share/julia/stdlib/v1.8/Dates/test/types.jl:277
```

I'm not sure how better to test this without calling `_wait2` directly. Tests for `Timer` in `channels.jl` look like they should have covered it (without this they seem to hang on my machine).