### PR TITLE
make `last` work on reversible any collection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ Language changes
 * `@time` and `@timev` now take an optional description to allow annotating the source of time reports.
   i.e. `@time "Evaluating foo" foo()` ([#42431])
 * New `@showtime` macro to show both the line being evaluated and the `@time` report ([#42431])
+* `last(collection)` will now work on any collection that supports `Iterators.reverse` and `first`, rather than being 
+  restricted to indexable collections.
 
 Compiler/Runtime improvements
 -----------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@ Language changes
 * `@time` and `@timev` now take an optional description to allow annotating the source of time reports.
   i.e. `@time "Evaluating foo" foo()` ([#42431])
 * New `@showtime` macro to show both the line being evaluated and the `@time` report ([#42431])
-* `last(collection)` will now work on any collection that supports `Iterators.reverse` and `first`, rather than being 
+* `last(collection)` will now work on any collection that supports `Iterators.reverse` and `first`, rather than being
   restricted to indexable collections.
 
 Compiler/Runtime improvements

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -462,8 +462,8 @@ end
     last(coll)
 
 Get the last element of an ordered collection, if it can be computed by reversing the collection. This is
-accomplished by calling [`Iterators.reverse`](@ref) and then [`first`](@ref) on that iterator. Return the end
-point of an [`AbstractRange`](@ref) even if it is empty.
+accomplished by calling [`Iterators.reverse`](@ref) and then [`first`](@ref) on that reversed iterator.
+Return the end point of an [`AbstractRange`](@ref) even if it is empty.
 
 See also [`first`](@ref), [`endswith`](@ref).
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -461,7 +461,7 @@ end
 """
     last(coll)
 
-Get the last element of an ordered collection, if it can be computed by reversing the collection. This is
+Get the last element of an ordered collection, if it can be computed in O(1) time. This is
 accomplished by calling [`Iterators.reverse`](@ref) and then [`first`](@ref) on that reversed iterator.
 Return the end point of an [`AbstractRange`](@ref) even if it is empty.
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -466,9 +466,9 @@ accomplished by calling [`Iterators.reverse`](@ref) and then [`first`](@ref) on 
 Return the end point of an [`AbstractRange`](@ref) even if it is empty.
 
 See also [`first`](@ref), [`endswith`](@ref).
-                                                                                    
+
 !!! compat "Julia 1.8"
-    For versions of julia older than 1.8, `last(x)` will only work on collections that support indexing and 
+    For versions of julia older than 1.8, `last(x)` will only work on collections that support indexing and
     [`lastindex`](@ref).
 
 # Examples

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -481,6 +481,7 @@ julia> last([1; 2; 3; 4])
 ```
 """
 last(a) = first(Iterators.reverse(a))
+last(a::AbstractArray) = a[end]
 
 """
     last(itr, n::Integer)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -466,6 +466,10 @@ accomplished by calling [`Iterators.reverse`](@ref) and then [`first`](@ref) on 
 Return the end point of an [`AbstractRange`](@ref) even if it is empty.
 
 See also [`first`](@ref), [`endswith`](@ref).
+                                                                                    
+!!! compat "Julia 1.8"
+    For versions of julia older than 1.8, `last(x)` will only work on collections that support indexing and 
+    [`lastindex`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -461,8 +461,8 @@ end
 """
     last(coll)
 
-Get the last element of an ordered collection, if it can be computed in O(1) time. This is
-accomplished by calling [`lastindex`](@ref) to get the last index. Return the end
+Get the last element of an ordered collection, if it can be computed by reversing the collection. This is
+accomplished by calling [`Iterators.reverse`](@ref) and then [`first`](@ref) on that iterator. Return the end
 point of an [`AbstractRange`](@ref) even if it is empty.
 
 See also [`first`](@ref), [`endswith`](@ref).
@@ -476,7 +476,7 @@ julia> last([1; 2; 3; 4])
 4
 ```
 """
-last(a) = a[end]
+last(a) = first(Iterators.reverse(a))
 
 """
     last(itr, n::Integer)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -481,7 +481,7 @@ julia> last([1; 2; 3; 4])
 ```
 """
 last(a) = first(Iterators.reverse(a))
-last(a::AbstractArray) = a[end]
+last(a::AbstractVector) = a[end]
 
 """
     last(itr, n::Integer)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -103,7 +103,6 @@ size(r::Reverse) = size(r.itr)
 IteratorSize(::Type{Reverse{T}}) where {T} = IteratorSize(T)
 IteratorEltype(::Type{Reverse{T}}) where {T} = IteratorEltype(T)
 last(r::Reverse) = first(r.itr) # the first shall be last
-first(r::Reverse) = last(r.itr) # and the last shall be first
 
 # reverse-order array iterators: assumes more-specialized Reverse for eachindex
 @propagate_inbounds function iterate(A::Reverse{<:AbstractArray}, state=(reverse(eachindex(A.itr)),))

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -883,3 +883,8 @@ end
     @test Iterators.peel(x^2 for x in 2:4)[1] == 4
     @test Iterators.peel(x^2 for x in 2:4)[2] |> collect == [9, 16]
 end
+
+@testset "last for iterators" begin
+    @test last(Iterators.map(identity, 1:3)) == 3
+    @test last(Iterators.filter(iseven, (Iterators.map(identity, 1:3))) == 2
+end 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -886,5 +886,5 @@ end
 
 @testset "last for iterators" begin
     @test last(Iterators.map(identity, 1:3)) == 3
-    @test last(Iterators.filter(iseven, (Iterators.map(identity, 1:3))) == 2
+    @test last(Iterators.filter(iseven, (Iterators.map(identity, 1:3)))) == 2
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -887,4 +887,4 @@ end
 @testset "last for iterators" begin
     @test last(Iterators.map(identity, 1:3)) == 3
     @test last(Iterators.filter(iseven, (Iterators.map(identity, 1:3))) == 2
-end 
+end


### PR DESCRIPTION
As suggested by @simeonschaub in https://github.com/JuliaLang/julia/issues/42943#issuecomment-962228222, this changes the default fallback of `last(x)` from `x[end]` to `first(Iterators.reverse(x))`, which allows it to work on any collection that supports being reversed, rather than just collections that have indexing. 

Before:
```julia
julia> last((x for x in 1:3))
ERROR: MethodError: no method matching lastindex(::Base.Generator{UnitRange{Int64}, typeof(identity)}
```
After:
```julia
julia> last((x for x in 1:3))
3

julia> last((x for x in 1:3 if iseven(x)))
2
```

Fixes #42943 