### PR TITLE
Prints symbols in `Tuple{:sym}` type with colons

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -993,10 +993,17 @@ function show_datatype(io::IO, @nospecialize(x::DataType), wheres::Vector=TypeVa
     # Print homogeneous tuples with more than 3 elements compactly as NTuple{N, T}
     if istuple
         if n > 3 && all(@nospecialize(i) -> (parameters[1] === i), parameters)
-            print(io, "NTuple{", n, ", ", repr(parameters[1]), "}")
+            print(io, "NTuple{", n, ", ")
+            show(io, parameters[1])
+            print(io, "}")
         else
             print(io, "Tuple{")
-            join(io, repr.(parameters), ", ")
+            # join(io, params, ", ") params but `show` it
+            first = true
+            for param in parameters
+                first ? (first = false) : print(io, ", ")
+                show(io, param)
+            end
             print(io, "}")
         end
     else

--- a/base/show.jl
+++ b/base/show.jl
@@ -993,10 +993,10 @@ function show_datatype(io::IO, @nospecialize(x::DataType), wheres::Vector=TypeVa
     # Print homogeneous tuples with more than 3 elements compactly as NTuple{N, T}
     if istuple
         if n > 3 && all(@nospecialize(i) -> (parameters[1] === i), parameters)
-            print(io, "NTuple{", n, ", ", parameters[1], "}")
+            print(io, "NTuple{", n, ", ", repr(parameters[1]), "}")
         else
             print(io, "Tuple{")
-            join(io, parameters, ", ")
+            join(io, repr.(parameters), ", ")
             print(io, "}")
         end
     else

--- a/test/show.jl
+++ b/test/show.jl
@@ -1347,6 +1347,14 @@ test_repr("(:).a")
 @test repr(Tuple{Float64, Float64, Float64, Float64}) == "NTuple{4, Float64}"
 @test repr(Tuple{Float32, Float32, Float32}) == "Tuple{Float32, Float32, Float32}"
 
+@testset "issue #42931" begin
+    @test repr(NTuple{4, :sym}) == "NTuple{4, :sym}"
+    @test repr(NTuple{3, :sym}) == "Tuple{:sym, :sym, :sym}"
+    @test repr(Tuple{:A, :B}) == "Tuple{:A, :B}"
+    @test repr(Tuple{:A}) == "Tuple{:A}"
+    @test repr(Tuple{}) == "Tuple{}"
+end
+
 # Test that REPL/mime display of invalid UTF-8 data doesn't throw an exception:
 @test isa(repr("text/plain", String(UInt8[0x00:0xff;])), String)
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1348,9 +1348,15 @@ test_repr("(:).a")
 @test repr(Tuple{Float32, Float32, Float32}) == "Tuple{Float32, Float32, Float32}"
 
 @testset "issue #42931" begin
-    @test repr(NTuple{4, :sym}) == "NTuple{4, :sym}"
-    @test repr(NTuple{3, :sym}) == "Tuple{:sym, :sym, :sym}"
-    @test repr(Tuple{:A, :B}) == "Tuple{:A, :B}"
+    @test repr(NTuple{4, :A}) == "NTuple{4, :A}"
+    @test repr(NTuple{3, :A}) == "Tuple{:A, :A, :A}"
+    @test repr(NTuple{2, :A}) == "Tuple{:A, :A}"
+    @test repr(NTuple{1, :A}) == "Tuple{:A}"
+    @test repr(NTuple{0, :A}) == "Tuple{}"
+
+    @test repr(Tuple{:A, :A, :A, :B}) == "Tuple{:A, :A, :A, :B}"
+    @test repr(Tuple{:A, :A, :A, :A}) == "NTuple{4, :A}"
+    @test repr(Tuple{:A, :A, :A}) == "Tuple{:A, :A, :A}"
     @test repr(Tuple{:A}) == "Tuple{:A}"
     @test repr(Tuple{}) == "Tuple{}"
 end


### PR DESCRIPTION
fix #42931 

old master
```julia
julia> versioninfo()
Julia Version 1.8.0-DEV.801
Commit 59aa3ed324 (2021-10-22 13:27 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, skylake)

julia> repr(NTuple{4, :sym})
"NTuple{4, sym}"

julia> repr(NTuple{3, :sym})
"Tuple{sym, sym, sym}"

julia> repr(Tuple{:A, :B})
"Tuple{A, B}"

julia> repr(Tuple{:A})
"Tuple{A}"

julia> repr(Tuple{})
"Tuple{}"
```

With proposed improvements: 
```julia
julia> versioninfo()
Julia Version 1.8.0-DEV.881
Commit cd3eba867c (2021-11-08 11:27 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, skylake)

julia> repr(NTuple{4, :sym})
"NTuple{4, :sym}"

julia> repr(NTuple{3, :sym})
"Tuple{:sym, :sym, :sym}"

julia> repr(Tuple{:A, :B})
"Tuple{:A, :B}"

julia> repr(Tuple{:A})
"Tuple{:A}"

julia> repr(Tuple{})
"Tuple{}"
```