### PR TITLE
export `jl_timing_data` for separate codegen lib

### DIFF
--- a/src/timing.c
+++ b/src/timing.c
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 static uint64_t t0;
-uint64_t jl_timing_data[(int)JL_TIMING_LAST] = {0};
+JL_DLLEXPORT uint64_t jl_timing_data[(int)JL_TIMING_LAST] = {0};
 const char *jl_timing_names[(int)JL_TIMING_LAST] =
     {
 #define X(name) #name


### PR DESCRIPTION
ENABLE_TIMINGS has been broken on master due to separating libjulia-codegen.