### PR TITLE
Stop stripping git, github, and CI config files from source distributions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,8 +456,6 @@ endif
 	-ls stdlib/srccache/*.tar.gz >> light-source-dist.tmp
 	-ls stdlib/*/StdlibArtifacts.toml >> light-source-dist.tmp
 
-	# Exclude git, github and CI config files
-	git ls-files | sed -E -e '/^\..+/d' -e '/\/\..+/d' -e '/appveyor.yml/d' >> light-source-dist.tmp
 	find doc/_build/html >> light-source-dist.tmp
 
 # Make tarball with only Julia code + stdlib tarballs


### PR DESCRIPTION
Stripping these files from source distributions makes it difficult to, e.g., apply the diff between backports-release-1.x and release-1.x branches to release-1.x source distributions. (Parts of the diff that touch the stripped files must themselves be stripped, which can be done with e.g. filterdiff but not reliably.)

I guess that once this patch lands on master, the change will immediately propagate to the -latest source distributions, but will need to be backported to release-1.x branches to take effect there?

Best!