### PR TITLE
Symlink 7z when USE_SYSTEM_P7ZIP

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -185,6 +185,21 @@ SYMLINK_SYSTEM_LIBRARIES += symlink_$2
 endif
 endef
 
+# libexec executables
+symlink_p7zip: $(build_bindir)/7z$(EXE)
+
+ifneq ($(USE_SYSTEM_P7ZIP),0)
+SYMLINK_SYSTEM_LIBRARIES += symlink_p7zip
+7Z_PATH := $(shell which 7z$(EXE))
+endif
+
+$(build_bindir)/7z$(EXE):
+	exepath=$(7Z_PATH) && \
+	[ -e "$$exepath" ] && \
+	([ ! -e "$@" ] || rm "$@") && \
+	echo ln -sf "$$exepath" "$@" && \
+	ln -sf "$$exepath" "$@"
+
 # the following excludes: libuv.a, libutf8proc.a
 
 ifneq ($(USE_SYSTEM_LIBM),0)

--- a/base/Makefile
+++ b/base/Makefile
@@ -194,11 +194,9 @@ SYMLINK_SYSTEM_LIBRARIES += symlink_p7zip
 endif
 
 $(build_bindir)/7z$(EXE):
-	exepath=$(7Z_PATH) && \
-	[ -e "$$exepath" ] && \
+	[ -e "$(7Z_PATH)" ] && \
 	([ ! -e "$@" ] || rm "$@") && \
-	echo ln -sf "$$exepath" "$@" && \
-	ln -sf "$$exepath" "$@"
+	ln -svf "$(7Z_PATH)" "$@"
 
 # the following excludes: libuv.a, libutf8proc.a
 


### PR DESCRIPTION
It seems like a symlink to 7z was missing from `<julia prefix>/libexec/` upon install with system p7zip. Normally it's installed from `build_bindir`, so this PR creates a symlink to system 7z in that build dir.

In any case, it seems convenient to have a symlinked 7z like we symlink system libs, so that 7z doesn't have to be in the PATH when running julia.

I'm pretty sure this PR needs some improvement, I have no clue if `$(shell which 7z...)` is OK (in particular with `$(EXE)` :D).

I did not add code to follow symlinks like is done for shared libs (it seems resolve_path is intended for libraries)