### PR TITLE
FileWatching: fix typo on #42926 (2539a679ab)

### DIFF
--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -563,7 +563,7 @@ function wait(fdw::FDWatcher)
         events = GC.@preserve fdw _wait(fdw.watcher, fdw.mask)
         isopen(fdw) || throw(EOFError())
         if !events.timedout
-            @lock fdw.notify fdw.events &= ~events.events
+            @lock fdw.watcher.notify fdw.watcher.events &= ~events.events
             return events
         end
     end


### PR DESCRIPTION
FileWatching: fix typo on #42926 (2539a679ab)

(cherry picked from commit 067ac5e03c0b6674966cc7a1b2075499f4e6cdea)