### PR TITLE
`file` tests: in the `"tempname with parent"` test, temporarily unset the `TMPDIR` environment variable while running the test

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -106,13 +106,15 @@ using Random
 end
 
 @testset "tempname with parent" begin
-    t = tempname()
-    @test dirname(t) == tempdir()
-    mktempdir() do d
-        t = tempname(d)
-        @test dirname(t) == d
+    withenv("TMPDIR" => nothing) do
+        t = tempname()
+        @test dirname(t) == tempdir()
+        mktempdir() do d
+            t = tempname(d)
+            @test dirname(t) == d
+        end
+        @test_throws ArgumentError tempname(randstring())
     end
-    @test_throws ArgumentError tempname(randstring())
 end
 
 child_eval(code::String) = eval(Meta.parse(readchomp(`$(Base.julia_cmd()) -E $code`)))


### PR DESCRIPTION
See also: #42995
See also: #43011

This pull request is needed for #42995.