### PR TITLE
[doc] Add `@id` for doc title - Part 1

### DIFF
--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -8,12 +8,12 @@ to figure out why your script is running slower than expected.
 If you've been directed to this page, find the symptom that best matches what you're experiencing
 and follow the instructions to generate the debugging information requested.  Table of symptoms:
 
-  * [Segfaults during bootstrap (`sysimg.jl`)](@ref)
-  * [Segfaults when running a script](@ref)
-  * [Errors during Julia startup](@ref)
-  * [Other generic segfaults or unreachables reached](@ref)
+  * [Segfaults during bootstrap (`sysimg.jl`)](@ref dev-bt-bootstrap)
+  * [Segfaults when running a script](@ref dev-bt-script)
+  * [Errors during Julia startup](@ref dev-bt-startup)
+  * [Other generic segfaults or unreachables reached](@ref dev-bt-others)
 
-## [Version/Environment info](@id dev-version-info)
+## [Version/Environment info](@id dev-bt-version-info)
 
 No matter the error, we will always need to know what version of Julia you are running. When Julia
 first starts up, a header is printed out with a version number and date. Please also include the output of `versioninfo()` (exported from the [`InteractiveUtils`](@ref InteractiveUtils.versioninfo) standard library) in any report you create:
@@ -23,7 +23,7 @@ using InteractiveUtils
 versioninfo()
 ```
 
-## Segfaults during bootstrap (`sysimg.jl`)
+## [Segfaults during bootstrap (`sysimg.jl`)](@id dev-bt-bootstrap)
 
 Segfaults toward the end of the `make` process of building Julia are a common symptom of something
 going wrong while Julia is preparsing the corpus of code in the `base/` folder.  Many factors
@@ -49,13 +49,13 @@ $ gdb -x ../contrib/debug_bootstrap.gdb
 
 This will start `gdb`, attempt to run the bootstrap process using the debug build of Julia, and
 print out a backtrace if (when) it segfaults.  You may need to hit `<enter>` a few times to get
-the full backtrace.  Create a [gist](https://gist.github.com) with the backtrace, the [version info](@ref dev-version-info),
+the full backtrace.  Create a [gist](https://gist.github.com) with the backtrace, the [version info](@ref dev-bt-version-info),
 and any other pertinent information you can think of and open a new [issue](https://github.com/JuliaLang/julia/issues?q=is%3Aopen)
 on Github with a link to the gist.
 
-## Segfaults when running a script
+## [Segfaults when running a script](@id dev-bt-script)
 
-The procedure is very similar to [Segfaults during bootstrap (`sysimg.jl`)](@ref).  Create a debug
+The procedure is very similar to [Segfaults during bootstrap (`sysimg.jl`)](@ref dev-bt-bootstrap).  Create a debug
 build of Julia, and run your script inside of a debugged Julia process:
 
 ```
@@ -74,11 +74,11 @@ Starting program: /home/sabae/src/julia/usr/bin/julia-debug ./test.jl
 (gdb) bt
 ```
 
-Create a [gist](https://gist.github.com) with the backtrace, the [version info](@ref dev-version-info), and any
+Create a [gist](https://gist.github.com) with the backtrace, the [version info](@ref dev-bt-version-info), and any
 other pertinent information you can think of and open a new [issue](https://github.com/JuliaLang/julia/issues?q=is%3Aopen)
 on Github with a link to the gist.
 
-## Errors during Julia startup
+## [Errors during Julia startup](@id dev-bt-startup)
 
 Occasionally errors occur during Julia's startup process (especially when using binary distributions,
 as opposed to compiling from source) such as the following:
@@ -103,11 +103,11 @@ the disk activity of the `julia` process:
     $ dtruss -f julia
     ```
 
-Create a [gist](https://gist.github.com) with the `strace`/ `dtruss` output, the [version info](@ref dev-version-info),
+Create a [gist](https://gist.github.com) with the `strace`/ `dtruss` output, the [version info](@ref dev-bt-version-info),
 and any other pertinent information and open a new [issue](https://github.com/JuliaLang/julia/issues?q=is%3Aopen)
 on Github with a link to the gist.
 
-## Other generic segfaults or unreachables reached
+## [Other generic segfaults or unreachables reached](@id dev-bt-others)
 
 As mentioned elsewhere, `julia` has good integration with `rr` for generating traces; this includes, on Linux, the ability to automatically run `julia` under `rr` and share the trace after a crash. This can be immensely helpful when debugging such crashes and is strongly encouraged when reporting crash issues to the JuliaLang/julia repo. To run `julia` under `rr` automatically, do:
 

--- a/doc/src/devdocs/backtraces.md
+++ b/doc/src/devdocs/backtraces.md
@@ -8,10 +8,10 @@ to figure out why your script is running slower than expected.
 If you've been directed to this page, find the symptom that best matches what you're experiencing
 and follow the instructions to generate the debugging information requested.  Table of symptoms:
 
-  * [Segfaults during bootstrap (`sysimg.jl`)](@ref dev-bt-bootstrap)
-  * [Segfaults when running a script](@ref dev-bt-script)
-  * [Errors during Julia startup](@ref dev-bt-startup)
-  * [Other generic segfaults or unreachables reached](@ref dev-bt-others)
+  * [Segfaults during bootstrap (`sysimg.jl`)](@ref Segfaults-during-bootstrap-(sysimg.jl))
+  * [Segfaults when running a script](@ref Segfaults-when-running-a-script)
+  * [Errors during Julia startup](@ref Errors-during-Julia-startup)
+  * [Other generic segfaults or unreachables reached](@ref Glossary)
 
 ## [Version/Environment info](@id dev-bt-version-info)
 
@@ -23,7 +23,7 @@ using InteractiveUtils
 versioninfo()
 ```
 
-## [Segfaults during bootstrap (`sysimg.jl`)](@id dev-bt-bootstrap)
+## [Segfaults during bootstrap (`sysimg.jl`)](@id Segfaults-during-bootstrap-(sysimg.jl))
 
 Segfaults toward the end of the `make` process of building Julia are a common symptom of something
 going wrong while Julia is preparsing the corpus of code in the `base/` folder.  Many factors
@@ -53,9 +53,9 @@ the full backtrace.  Create a [gist](https://gist.github.com) with the backtrace
 and any other pertinent information you can think of and open a new [issue](https://github.com/JuliaLang/julia/issues?q=is%3Aopen)
 on Github with a link to the gist.
 
-## [Segfaults when running a script](@id dev-bt-script)
+## [Segfaults when running a script](@id Segfaults-when-running-a-script)
 
-The procedure is very similar to [Segfaults during bootstrap (`sysimg.jl`)](@ref dev-bt-bootstrap).  Create a debug
+The procedure is very similar to [Segfaults during bootstrap (`sysimg.jl`)](@ref Segfaults-during-bootstrap-(sysimg.jl)).  Create a debug
 build of Julia, and run your script inside of a debugged Julia process:
 
 ```
@@ -78,7 +78,7 @@ Create a [gist](https://gist.github.com) with the backtrace, the [version info](
 other pertinent information you can think of and open a new [issue](https://github.com/JuliaLang/julia/issues?q=is%3Aopen)
 on Github with a link to the gist.
 
-## [Errors during Julia startup](@id dev-bt-startup)
+## [Errors during Julia startup](@id Errors-during-Julia-startup)
 
 Occasionally errors occur during Julia's startup process (especially when using binary distributions,
 as opposed to compiling from source) such as the following:
@@ -107,7 +107,7 @@ Create a [gist](https://gist.github.com) with the `strace`/ `dtruss` output, the
 and any other pertinent information and open a new [issue](https://github.com/JuliaLang/julia/issues?q=is%3Aopen)
 on Github with a link to the gist.
 
-## [Other generic segfaults or unreachables reached](@id dev-bt-others)
+## [Other generic segfaults or unreachables reached](@id Glossary)
 
 As mentioned elsewhere, `julia` has good integration with `rr` for generating traces; this includes, on Linux, the ability to automatically run `julia` under `rr` and share the trace after a crash. This can be immensely helpful when debugging such crashes and is strongly encouraged when reporting crash issues to the JuliaLang/julia repo. To run `julia` under `rr` automatically, do:
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -395,7 +395,7 @@ Float32[ 0.25*x[i-1] + 0.5*x[i] + 0.25*x[i+1] for i=2:length(x)-1 ]
 
 Comprehensions can also be written without the enclosing square brackets, producing an object
 known as a generator. This object can be iterated to produce values on demand, instead of allocating
-an array and storing them in advance (see [Iteration](@ref)). For example, the following expression
+an array and storing them in advance (see [Iteration](@id man-array-iteration)). For example, the following expression
 sums a series without allocating memory:
 
 ```jldoctest
@@ -723,7 +723,7 @@ Considered alone, this may seem relatively trivial; `CartesianIndex` simply
 gathers multiple integers together into one object that represents a single
 multidimensional index. When combined with other indexing forms and iterators
 that yield `CartesianIndex`es, however, this can produce very elegant
-and efficient code. See [Iteration](@ref) below, and for some more advanced
+and efficient code. See [Iteration](@id man-array-iteration) below, and for some more advanced
 examples, see [this blog post on multidimensional algorithms and
 iteration](https://julialang.org/blog/2016/02/iteration).
 
@@ -933,7 +933,7 @@ julia> A[2,1]
 6
 ```
 
-## Iteration
+## [Iteration](@id man-array-iteration)
 
 The recommended ways to iterate over a whole array are
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -395,7 +395,7 @@ Float32[ 0.25*x[i-1] + 0.5*x[i] + 0.25*x[i+1] for i=2:length(x)-1 ]
 
 Comprehensions can also be written without the enclosing square brackets, producing an object
 known as a generator. This object can be iterated to produce values on demand, instead of allocating
-an array and storing them in advance (see [Iteration](@id man-array-iteration)). For example, the following expression
+an array and storing them in advance (see [Iteration](@id Iteration)). For example, the following expression
 sums a series without allocating memory:
 
 ```jldoctest
@@ -723,7 +723,7 @@ Considered alone, this may seem relatively trivial; `CartesianIndex` simply
 gathers multiple integers together into one object that represents a single
 multidimensional index. When combined with other indexing forms and iterators
 that yield `CartesianIndex`es, however, this can produce very elegant
-and efficient code. See [Iteration](@id man-array-iteration) below, and for some more advanced
+and efficient code. See [Iteration](@id Iteration) below, and for some more advanced
 examples, see [this blog post on multidimensional algorithms and
 iteration](https://julialang.org/blog/2016/02/iteration).
 
@@ -933,7 +933,7 @@ julia> A[2,1]
 6
 ```
 
-## [Iteration](@id man-array-iteration)
+## [Iteration](@id Iteration)
 
 The recommended ways to iterate over a whole array are
 

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -54,7 +54,7 @@ to [`ccall`](@ref) are:
 
 !!! note
     The `(:function, "library")` pair, return type, and input types must be literal constants
-    (i.e., they can't be variables, but see [Non-constant Function Specifications](@ref) below).
+    (i.e., they can't be variables, but see [Non-constant Function Specifications](@ref man-call-c-non-const-func) below).
 
     The remaining parameters are evaluated at compile time, when the containing method is defined.
 
@@ -722,7 +722,7 @@ For translating a C return type to Julia:
   * `T (*)(...)` (e.g. a pointer to a function)
 
       * `Ptr{Cvoid}` to call this directly from Julia you will need to pass this as the first argument to [`ccall`](@ref).
-        See [Indirect Calls](@ref).
+        See [Indirect Calls](@ref man-call-c-indirect).
 
 ### Passing Pointers for Modifying Inputs
 
@@ -883,7 +883,7 @@ a reference to `b` and both `a` and `b` are due for garbage collection, there is
 that `b` would be finalized after `a`. If proper finalization of `a` depends on `b` being valid,
 it must be handled in other ways.
 
-## Non-constant Function Specifications
+## [Non-constant Function Specifications](@id man-call-c-non-const-func)
 
 In some cases, the exact name or path of the needed library is not known in advance and must
 be computed at run time. To handle such cases, the library component of a `(name, library)`
@@ -911,7 +911,7 @@ However, doing this will also be very slow and leak memory, so you should usuall
 reading.
 The next section discusses how to use indirect calls to efficiently achieve a similar effect.
 
-## Indirect Calls
+## [Indirect Calls](@id man-call-c-indirect)
 
 The first argument to [`ccall`](@ref) can also be an expression evaluated at run time. In this
 case, the expression must evaluate to a `Ptr`, which will be used as the address of the native

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -54,7 +54,7 @@ to [`ccall`](@ref) are:
 
 !!! note
     The `(:function, "library")` pair, return type, and input types must be literal constants
-    (i.e., they can't be variables, but see [Non-constant Function Specifications](@ref man-call-c-non-const-func) below).
+    (i.e., they can't be variables, but see [Non-constant Function Specifications](@ref Non-constant-Function-Specifications) below).
 
     The remaining parameters are evaluated at compile time, when the containing method is defined.
 
@@ -722,7 +722,7 @@ For translating a C return type to Julia:
   * `T (*)(...)` (e.g. a pointer to a function)
 
       * `Ptr{Cvoid}` to call this directly from Julia you will need to pass this as the first argument to [`ccall`](@ref).
-        See [Indirect Calls](@ref man-call-c-indirect).
+        See [Indirect Calls](@ref Indirect-Calls).
 
 ### Passing Pointers for Modifying Inputs
 
@@ -883,7 +883,7 @@ a reference to `b` and both `a` and `b` are due for garbage collection, there is
 that `b` would be finalized after `a`. If proper finalization of `a` depends on `b` being valid,
 it must be handled in other ways.
 
-## [Non-constant Function Specifications](@id man-call-c-non-const-func)
+## [Non-constant Function Specifications](@id Non-constant-Function-Specifications)
 
 In some cases, the exact name or path of the needed library is not known in advance and must
 be computed at run time. To handle such cases, the library component of a `(name, library)`
@@ -911,7 +911,7 @@ However, doing this will also be very slow and leak memory, so you should usuall
 reading.
 The next section discusses how to use indirect calls to efficiently achieve a similar effect.
 
-## [Indirect Calls](@id man-call-c-indirect)
+## [Indirect Calls](@id Indirect-Calls)
 
 The first argument to [`ccall`](@ref) can also be an expression evaluated at run time. In this
 case, the expression must evaluate to a `Ptr`, which will be used as the address of the native

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -777,8 +777,7 @@ simply declared as `(Csize_t,)` without any `Ref` or `Ptr` necessary. (If the
 wrapper was calling a Fortran function instead, the corresponding function input
 signature would instead be `(Ref{Csize_t},)`, since Fortran variables are
 passed by pointers.) Furthermore, `n` can be any type that is convertible to a
-`Csize_t` integer; the [`ccall`](@ref) implicitly calls [`Base.cconvert(Csize_t,
-n)`](@ref).
+`Csize_t` integer; the [`ccall`](@ref) implicitly calls [`Base.cconvert(Csize_t, n)`](@ref).
 
 Here is a second example wrapping the corresponding destructor:
 

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -6,7 +6,7 @@ Julia provides a variety of control flow constructs:
   * [Conditional Evaluation](@ref man-conditional-evaluation): `if`-`elseif`-`else` and `?:` (ternary operator).
   * [Short-Circuit Evaluation](@ref): logical operators `&&` (“and”) and `||` (“or”), and also chained comparisons.
   * [Repeated Evaluation: Loops](@ref man-loops): `while` and `for`.
-  * [Exception Handling](@ref): `try`-`catch`, [`error`](@ref) and [`throw`](@ref).
+  * [Exception Handling](@ref man-control-flow-exception): `try`-`catch`, [`error`](@ref) and [`throw`](@ref).
   * [Tasks (aka Coroutines)](@ref man-tasks): [`yieldto`](@ref).
 
 The first five control flow mechanisms are standard to high-level programming languages. [`Task`](@ref)s
@@ -569,7 +569,7 @@ Using [`zip`](@ref) will create an iterator that is a tuple containing the subit
 The `zip` iterator will iterate over all subiterators in order, choosing the ``i``th element of each subiterator in the
 ``i``th iteration of the `for` loop. Once any of the subiterators run out, the `for` loop will stop.
 
-## Exception Handling
+## [Exception Handling](@id man-control-flow-exception)
 
 When an unexpected condition occurs, a function may be unable to return a reasonable value to
 its caller. In such cases, it may be best for the exceptional condition to either terminate the

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -6,7 +6,7 @@ Julia provides a variety of control flow constructs:
   * [Conditional Evaluation](@ref man-conditional-evaluation): `if`-`elseif`-`else` and `?:` (ternary operator).
   * [Short-Circuit Evaluation](@ref): logical operators `&&` (“and”) and `||` (“or”), and also chained comparisons.
   * [Repeated Evaluation: Loops](@ref man-loops): `while` and `for`.
-  * [Exception Handling](@ref man-control-flow-exception): `try`-`catch`, [`error`](@ref) and [`throw`](@ref).
+  * [Exception Handling](@ref Exception-Handling): `try`-`catch`, [`error`](@ref) and [`throw`](@ref).
   * [Tasks (aka Coroutines)](@ref man-tasks): [`yieldto`](@ref).
 
 The first five control flow mechanisms are standard to high-level programming languages. [`Task`](@ref)s
@@ -569,7 +569,7 @@ Using [`zip`](@ref) will create an iterator that is a tuple containing the subit
 The `zip` iterator will iterate over all subiterators in order, choosing the ``i``th element of each subiterator in the
 ``i``th iteration of the `for` loop. Once any of the subiterators run out, the `for` loop will stop.
 
-## [Exception Handling](@id man-control-flow-exception)
+## [Exception Handling](@id Exception-Handling)
 
 When an unexpected condition occurs, a function may be unable to return a reasonable value to
 its caller. In such cases, it may be best for the exceptional condition to either terminate the

--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -271,7 +271,7 @@ of the other running processes. You may use `addprocs(exeflags="--project")` to 
 a particular environment, and then `@everywhere using <modulename>` or `@everywhere include("file.jl")`.
 
 Other types of clusters can be supported by writing your own custom `ClusterManager`, as described
-below in the [ClusterManagers](@ref) section.
+below in the [Cluster Managers](@ref man-distributed-cluster) section.
 
 ## Data Movement
 
@@ -465,7 +465,7 @@ end
 ```
 
 This code will not initialize all of `a`, since each process will have a separate copy of it.
-Parallel for loops like these must be avoided. Fortunately, [Shared Arrays](@ref man-shared-arrays) can be used
+Parallel for loops like these must be avoided. Fortunately, [Shared Arrays](@ref man-distributed-shared-arrays) can be used
 to get around this limitation:
 
 ```julia
@@ -743,7 +743,7 @@ will always operate on copies of arguments.
 
 
 
-## [Shared Arrays](@id man-shared-arrays)
+## [Shared Arrays](@id man-distributed-shared-arrays)
 
 Shared Arrays use system shared memory to map the same array across many processes. While there
 are some similarities to a [`DArray`](https://github.com/JuliaParallel/DistributedArrays.jl), the
@@ -950,7 +950,7 @@ node to release references from all participating workers. Code which creates ma
 shared array objects would benefit from explicitly finalizing these objects as soon as possible.
 This results in both memory and file handles mapping the shared segment being released sooner.
 
-## ClusterManagers
+## [Cluster Managers](@id man-distributed-cluster)
 
 The launching, management and networking of Julia processes into a logical cluster is done via
 cluster managers. A `ClusterManager` is responsible for
@@ -1259,7 +1259,8 @@ in future releases.
 
 Outside of Julia parallelism there are plenty of external packages that should be mentioned.
 For example [MPI.jl](https://github.com/JuliaParallel/MPI.jl) is a Julia wrapper for the `MPI` protocol, or
-[DistributedArrays.jl](https://github.com/JuliaParallel/Distributedarrays.jl), as presented in [Shared Arrays](@ref).
+[DistributedArrays.jl](https://github.com/JuliaParallel/Distributedarrays.jl), as presented in
+[Shared Arrays](@ref man-distributed-shared-arrays).
 A mention must be made of Julia's GPU programming ecosystem, which includes:
 
 1. Low-level (C kernel) based operations [OpenCL.jl](https://github.com/JuliaGPU/OpenCL.jl) and [CUDAdrv.jl](https://github.com/JuliaGPU/CUDAdrv.jl) which are respectively an OpenCL interface and a CUDA wrapper.

--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -271,7 +271,7 @@ of the other running processes. You may use `addprocs(exeflags="--project")` to 
 a particular environment, and then `@everywhere using <modulename>` or `@everywhere include("file.jl")`.
 
 Other types of clusters can be supported by writing your own custom `ClusterManager`, as described
-below in the [Cluster Managers](@ref man-distributed-cluster) section.
+below in the [Cluster Managers](@ref Cluster-Managers) section.
 
 ## Data Movement
 
@@ -465,7 +465,7 @@ end
 ```
 
 This code will not initialize all of `a`, since each process will have a separate copy of it.
-Parallel for loops like these must be avoided. Fortunately, [Shared Arrays](@ref man-distributed-shared-arrays) can be used
+Parallel for loops like these must be avoided. Fortunately, [Shared Arrays](@ref Shared-Arrays) can be used
 to get around this limitation:
 
 ```julia
@@ -743,7 +743,7 @@ will always operate on copies of arguments.
 
 
 
-## [Shared Arrays](@id man-distributed-shared-arrays)
+## [Shared Arrays](@id Shared-Arrays)
 
 Shared Arrays use system shared memory to map the same array across many processes. While there
 are some similarities to a [`DArray`](https://github.com/JuliaParallel/DistributedArrays.jl), the
@@ -950,7 +950,7 @@ node to release references from all participating workers. Code which creates ma
 shared array objects would benefit from explicitly finalizing these objects as soon as possible.
 This results in both memory and file handles mapping the shared segment being released sooner.
 
-## [Cluster Managers](@id man-distributed-cluster)
+## [Cluster Managers](@id Cluster-Managers)
 
 The launching, management and networking of Julia processes into a logical cluster is done via
 cluster managers. A `ClusterManager` is responsible for
@@ -1260,7 +1260,7 @@ in future releases.
 Outside of Julia parallelism there are plenty of external packages that should be mentioned.
 For example [MPI.jl](https://github.com/JuliaParallel/MPI.jl) is a Julia wrapper for the `MPI` protocol, or
 [DistributedArrays.jl](https://github.com/JuliaParallel/Distributedarrays.jl), as presented in
-[Shared Arrays](@ref man-distributed-shared-arrays).
+[Shared Arrays](@ref Shared-Arrays).
 A mention must be made of Julia's GPU programming ecosystem, which includes:
 
 1. Low-level (C kernel) based operations [OpenCL.jl](https://github.com/JuliaGPU/OpenCL.jl) and [CUDAdrv.jl](https://github.com/JuliaGPU/CUDAdrv.jl) which are respectively an OpenCL interface and a CUDA wrapper.

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -10,7 +10,7 @@ Julia provides a broad range of primitive numeric types, and a full complement o
 bitwise operators as well as standard mathematical functions are defined over them. These map
 directly onto numeric types and operations that are natively supported on modern computers, thus
 allowing Julia to take full advantage of computational resources. Additionally, Julia provides
-software support for [Arbitrary Precision Arithmetic](@ref man-integers-arbitrary-precision), which can handle operations on numeric
+software support for [Arbitrary Precision Arithmetic](@ref Arbitrary-Precision-Arithmetic), which can handle operations on numeric
 values that cannot be represented effectively in native hardware representations, but at the cost
 of relatively slower performance.
 
@@ -245,7 +245,7 @@ Thus, arithmetic with Julia integers is actually a form of [modular arithmetic](
 This reflects the characteristics of the underlying arithmetic of integers as implemented on modern
 computers. In applications where overflow is possible, explicit checking for wraparound produced
 by overflow is essential; otherwise, the [`BigInt`](@ref) type in
-[Arbitrary Precision Arithmetic](@ref man-integers-arbitrary-precision) is recommended instead.
+[Arbitrary Precision Arithmetic](@ref Arbitrary-Precision-Arithmetic) is recommended instead.
 
 An example of overflow behavior and how to potentially resolve it is as follows:
 
@@ -550,7 +550,7 @@ most books on scientific computation, and also in the following references:
     of [William Kahan](https://en.wikipedia.org/wiki/William_Kahan), commonly known as the "Father
     of Floating-Point". Of particular interest may be [An Interview with the Old Man of Floating-Point](https://people.eecs.berkeley.edu/~wkahan/ieee754status/754story.html).
 
-## [Arbitrary Precision Arithmetic](@id man-integers-arbitrary-precision)
+## [Arbitrary Precision Arithmetic](@id Arbitrary-Precision-Arithmetic)
 
 To allow computations with arbitrary-precision integers and floating point numbers, Julia wraps
 the [GNU Multiple Precision Arithmetic Library (GMP)](https://gmplib.org) and the [GNU MPFR Library](https://www.mpfr.org),

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -10,7 +10,7 @@ Julia provides a broad range of primitive numeric types, and a full complement o
 bitwise operators as well as standard mathematical functions are defined over them. These map
 directly onto numeric types and operations that are natively supported on modern computers, thus
 allowing Julia to take full advantage of computational resources. Additionally, Julia provides
-software support for [Arbitrary Precision Arithmetic](@ref), which can handle operations on numeric
+software support for [Arbitrary Precision Arithmetic](@ref man-integers-arbitrary-precision), which can handle operations on numeric
 values that cannot be represented effectively in native hardware representations, but at the cost
 of relatively slower performance.
 
@@ -244,8 +244,8 @@ true
 Thus, arithmetic with Julia integers is actually a form of [modular arithmetic](https://en.wikipedia.org/wiki/Modular_arithmetic).
 This reflects the characteristics of the underlying arithmetic of integers as implemented on modern
 computers. In applications where overflow is possible, explicit checking for wraparound produced
-by overflow is essential; otherwise, the [`BigInt`](@ref) type in [Arbitrary Precision Arithmetic](@ref)
-is recommended instead.
+by overflow is essential; otherwise, the [`BigInt`](@ref) type in
+[Arbitrary Precision Arithmetic](@ref man-integers-arbitrary-precision) is recommended instead.
 
 An example of overflow behavior and how to potentially resolve it is as follows:
 
@@ -550,7 +550,7 @@ most books on scientific computation, and also in the following references:
     of [William Kahan](https://en.wikipedia.org/wiki/William_Kahan), commonly known as the "Father
     of Floating-Point". Of particular interest may be [An Interview with the Old Man of Floating-Point](https://people.eecs.berkeley.edu/~wkahan/ieee754status/754story.html).
 
-## Arbitrary Precision Arithmetic
+## [Arbitrary Precision Arithmetic](@id man-integers-arbitrary-precision)
 
 To allow computations with arbitrary-precision integers and floating point numbers, Julia wraps
 the [GNU Multiple Precision Arithmetic Library (GMP)](https://gmplib.org) and the [GNU MPFR Library](https://www.mpfr.org),

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -465,8 +465,8 @@ conversions.
   * `x % T` converts an integer `x` to a value of integer type `T` congruent to `x` modulo `2^n`,
     where `n` is the number of bits in `T`. In other words, the binary representation is truncated
     to fit.
-  * The [Rounding functions](@ref) take a type `T` as an optional argument. For example, `round(Int,x)`
-    is a shorthand for `Int(round(x))`.
+  * The [Rounding functions](@ref man-math-ops-round) take a type `T` as an optional argument.
+    For example, `round(Int,x)` is a shorthand for `Int(round(x))`.
 
 The following examples show the different forms.
 
@@ -509,7 +509,7 @@ Stacktrace:
 
 See [Conversion and Promotion](@ref conversion-and-promotion) for how to define your own conversions and promotions.
 
-### Rounding functions
+### [Rounding functions](@id man-math-ops-round)
 
 | Function              | Description                      | Return type |
 |:--------------------- |:-------------------------------- |:----------- |

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -465,7 +465,7 @@ conversions.
   * `x % T` converts an integer `x` to a value of integer type `T` congruent to `x` modulo `2^n`,
     where `n` is the number of bits in `T`. In other words, the binary representation is truncated
     to fit.
-  * The [Rounding functions](@ref man-math-ops-round) take a type `T` as an optional argument.
+  * The [Rounding functions](@ref Rounding-functions) take a type `T` as an optional argument.
     For example, `round(Int,x)` is a shorthand for `Int(round(x))`.
 
 The following examples show the different forms.
@@ -509,7 +509,7 @@ Stacktrace:
 
 See [Conversion and Promotion](@ref conversion-and-promotion) for how to define your own conversions and promotions.
 
-### [Rounding functions](@id man-math-ops-round)
+### [Rounding functions](@id Rounding-functions)
 
 | Function              | Description                      | Return type |
 |:--------------------- |:-------------------------------- |:----------- |

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1436,8 +1436,8 @@ julia> show(stdout, "text/html", Polar(3.0,4.0))
 As a rule of thumb, the single-line `show` method should print a valid Julia expression for creating
 the shown object.  When this `show` method contains infix operators, such as the multiplication
 operator (`*`) in our single-line `show` method for `Polar` above, it may not parse correctly when
-printed as part of another object.  To see this, consider the expression object (see [Program
-representation](@ref)) which takes the square of a specific instance of our `Polar` type:
+printed as part of another object.  To see this, consider the expression object
+(see [Program representation](@ref)) which takes the square of a specific instance of our `Polar` type:
 
 ```jldoctest polartype
 julia> a = Polar(3, 4.0)


### PR DESCRIPTION
xref: #23951 

This pr only add internal links.

"Internal links" mean that the `@id` and all `@ref` are in the same md file.
So you can review the changes in each file individually.

----

Useful tools: https://github.dev/inkydragon/julia/tree/doc-title-id
Open and search.
