### PR TITLE
codegen: add missing initialization for PhiC nodes

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6436,8 +6436,11 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
             Type *vtype = julia_type_to_llvm(ctx, jt, &isboxed);
             assert(!isboxed);
             assert(!type_is_ghost(vtype) && "constants should already be handled");
-            // CreateAlloca is OK during prologue setup
-            Value *lv = ctx.builder.CreateAlloca(vtype, NULL, jl_symbol_name(s));
+            Value *lv = new AllocaInst(vtype, 0, jl_symbol_name(s), /*InsertBefore*/ctx.pgcstack);
+            if (CountTrackedPointers(vtype).count) {
+                StoreInst *SI = new StoreInst(Constant::getNullValue(vtype), lv, false, Align(sizeof(void*)));
+                SI->insertAfter(ctx.pgcstack);
+            }
             varinfo.value = mark_julia_slot(lv, jt, NULL, tbaa_stack);
             alloc_def_flag(ctx, varinfo);
             if (ctx.debug_enabled && varinfo.dinfo) {


### PR DESCRIPTION
Our Phi handling assumes that it can references undefined memory, and
get back legal results, but our PhiC nodes were not initialized, so the
Phi node might see uninitialized results, and then cause the GC to
crash. This was observed in PkgEval on the PoreMatMod.jl package to
occur in recent Julia versions and master.