### PR TITLE
flisp: remove support for and need for reentrancy

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -620,15 +620,6 @@
 (define (space-before-next-token? s)
   (or (skip-ws (ts:port s) #f) (eqv? #\newline (peek-char (ts:port s)))))
 
-;; --- misc ---
-
-; Log a syntax deprecation, attributing it to current-filename and the line
-; number of the stream `s`
-(define (parser-depwarn s what instead)
-  (let ((line (if (number? s) s (input-port-line (if (port? s) s (ts:port s)))))
-        (file current-filename))
-    (frontend-depwarn (format-syntax-deprecation what instead file line #t) file line)))
-
 ;; --- parser ---
 
 ;; parse left-to-right binary operator

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1368,27 +1368,6 @@ void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
     JL_GC_POP();
 }
 
-#if 0
-void jl_depwarn(const char *msg, jl_value_t *sym)
-{
-    static jl_value_t *depwarn_func = NULL;
-    if (!depwarn_func && jl_base_module) {
-        depwarn_func = jl_get_global(jl_base_module, jl_symbol("depwarn"));
-    }
-    if (!depwarn_func) {
-        jl_safe_printf("WARNING: %s\n", msg);
-        return;
-    }
-    jl_value_t **depwarn_args;
-    JL_GC_PUSHARGS(depwarn_args, 3);
-    depwarn_args[0] = depwarn_func;
-    depwarn_args[1] = jl_cstr_to_string(msg);
-    depwarn_args[2] = sym;
-    jl_apply(depwarn_args, 3);
-    JL_GC_POP();
-}
-#endif
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This was the only remaining case where we needed to be able to support calling back into flisp, creating a risk that we'd allocate as many flisp contexts as there are Tasks on the system. After this change, we should only need to allocate, at most, `nthreads` copies of flisp.