### PR TITLE
Reinterpret code for tuples of bitstypes

### DIFF
--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -680,3 +680,10 @@ g42457(a, b) = Base.isequal(a, b) ? 1 : 2.0
 @test only(Base.return_types(g42457, (NTuple{3, Int}, Tuple))) === Union{Float64, Int}
 @test only(Base.return_types(g42457, (NTuple{3, Int}, NTuple))) === Union{Float64, Int}
 @test only(Base.return_types(g42457, (NTuple{3, Int}, NTuple{4}))) === Float64
+
+# reinterpret tuples
+@test_throws ArgumentError reinterpret(Int64, (Int32(45),))
+@test reinterpret(Int64, (Int32(45), Int32(0))) == (45,)
+@test reinterpret(Int16, (Int32(45), Int32(0))) == (Int16(45), Int16(0), Int16(0), Int16(0))
+@test reinterpret(Int64, (Int32(45), Int16(0), Int16(0))) == (45,)
+@test_throws ArgumentError reinterpret(Int64, ([4],))


### PR DESCRIPTION
Patterned on the `getindex` code for `ReinterpretArray`s and spurred on by #42968 , this PR implements reinterpreting arbitrary tuples of bitstypes to an `NTuple` of a bitstype.

```julia
@btime reinterpret(Int64, (Int32(1), Int16(1), Int8(1), Int8(1)))
#= 
  1.500 ns (0 allocations: 0 bytes)
(72339073309605889,)
=#

@code_native reinterpret(Int64, (Int32(1), Int16(1), Int8(1), Int8(1)))
#=
        movq    (%rdi), %rax
        retq
=#

const aaaa = ntuple(x -> Int8(1), 56)

@btime reinterpret(Int64, aaaa)
#=
  1.700 ns (0 allocations: 0 bytes)
(72340172838076673, 72340172838076673, 72340172838076673, 72340172838076673, 72340172838076673, 72340172838076673, 72340172838076673)
=#

@code_native reinterpret(Int64, aaaa)
#=
        movq    %rdi, %rax
        movq    48(%rsi), %rcx
        vmovups (%rsi), %xmm0
        vmovups 16(%rsi), %ymm1
        vmovups %xmm0, (%rdi)
        vmovups %ymm1, 16(%rdi)
        movq    %rcx, 48(%rdi)
        vzeroupper
        retq
=#
```

May interact with this draft PR to reinterpret structs #32660 ?