### PR TITLE
Fix typo in iterate(itr::AsyncCollector)

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -313,7 +313,7 @@ function iterate(itr::AsyncCollector)
             # and the args tuple....
             batched_args = map(x->x[2], batch)
 
-            results = f(batched_args)
+            results = itr.f(batched_args)
             foreach(x -> (itr.results[batch_idxs[x[1]]] = x[2]), enumerate(results))
         end
     else

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -305,20 +305,7 @@ end
 function iterate(itr::AsyncCollector)
     itr.ntasks = verify_ntasks(itr.enumerator, itr.ntasks)
     itr.batch_size = verify_batch_size(itr.batch_size)
-    if itr.batch_size !== nothing
-        exec_func = batch -> begin
-            # extract indices from the input tuple
-            batch_idxs = map(x->x[1], batch)
 
-            # and the args tuple....
-            batched_args = map(x->x[2], batch)
-
-            results = itr.f(batched_args...)
-            foreach(x -> (itr.results[batch_idxs[x[1]]] = x[2]), enumerate(results))
-        end
-    else
-        exec_func = (i,args) -> (itr.results[i]=itr.f(args...))
-    end
     chnl, worker_tasks = setup_chnl_and_tasks((i,args) -> (itr.results[i]=itr.f(args...)), itr.ntasks, itr.batch_size)
     return iterate(itr, AsyncCollectorState(chnl, worker_tasks))
 end

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -313,7 +313,7 @@ function iterate(itr::AsyncCollector)
             # and the args tuple....
             batched_args = map(x->x[2], batch)
 
-            results = itr.f(batched_args)
+            results = itr.f(batched_args...)
             foreach(x -> (itr.results[batch_idxs[x[1]]] = x[2]), enumerate(results))
         end
     else


### PR DESCRIPTION
No idea how to test this, I just stumbled over a linter warning for the undeclared `f`.