### PR TITLE
add generic fallback for `eachindex`/`keys`

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -565,16 +565,17 @@ end
 
 ## string index iteration type ##
 
-struct EachStringIndex{T<:AbstractString}
+struct EachIndex{T}
     s::T
 end
-keys(s::AbstractString) = EachStringIndex(s)
+keys(s) = EachIndex(s)
+keytype(::Type{<:AbstractString}) = Int
 
-length(e::EachStringIndex) = length(e.s)
-first(::EachStringIndex) = 1
-last(e::EachStringIndex) = lastindex(e.s)
-iterate(e::EachStringIndex, state=firstindex(e.s)) = state > ncodeunits(e.s) ? nothing : (state, nextind(e.s, state))
-eltype(::Type{<:EachStringIndex}) = Int
+length(e::EachIndex) = length(e.s)
+first(e::EachIndex) = firstindex(e.s)
+last(e::EachIndex) = lastindex(e.s)
+iterate(e::EachIndex, state=firstindex(e.s)) = state > lastindex(e.s) ? nothing : (state, nextind(e.s, state))
+eltype(::Type{EachIndex{T}}) where {T} = keytype(T)
 
 """
     isascii(c::Union{AbstractChar,AbstractString}) -> Bool
@@ -731,7 +732,7 @@ julia> "Test "^3
 
 # reverse-order iteration for strings and indices thereof
 iterate(r::Iterators.Reverse{<:AbstractString}, i=lastindex(r.itr)) = i < firstindex(r.itr) ? nothing : (r.itr[i], prevind(r.itr, i))
-iterate(r::Iterators.Reverse{<:EachStringIndex}, i=lastindex(r.itr.s)) = i < firstindex(r.itr.s) ? nothing : (i, prevind(r.itr.s, i))
+iterate(r::Iterators.Reverse{<:EachIndex}, i=lastindex(r.itr.s)) = i < firstindex(r.itr.s) ? nothing : (i, prevind(r.itr.s, i))
 
 ## code unit access ##
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -885,3 +885,29 @@ end
     @test Iterators.peel(x^2 for x in 2:4)[1] == 4
     @test Iterators.peel(x^2 for x in 2:4)[2] |> collect == [9, 16]
 end
+
+struct FibonacciIndices
+    last::NTuple{2, Int}
+    length::Int
+end
+Base.length((; length)::FibonacciIndices) = length
+Base.keytype(::Type{FibonacciIndices}) = NTuple{2, Int}
+Base.firstindex(::FibonacciIndices) = (1, 1)
+Base.lastindex((; last)::FibonacciIndices) = last
+Base.nextind(::FibonacciIndices, (i, j)) = (j, i+j)
+Base.prevind(::FibonacciIndices, (i, j)) = (j-i, i)
+
+@testset "generic eachindex" begin
+    f = FibonacciIndices((5, 8), 5)
+    @test length(eachindex(f)) == 5
+    @test eltype(eachindex(f)) == NTuple{2, Int}
+
+    expected = [(1, 1), (1, 2), (2, 3), (3, 5), (5, 8)]
+    fwd = collect(eachindex(f))
+    @test fwd == expected
+    @test fwd isa Vector{NTuple{2, Int}}
+
+    bwd = collect(Iterators.reverse(eachindex(f)))
+    @test bwd == reverse(expected)
+    @test bwd isa Vector{NTuple{2, Int}}
+end


### PR DESCRIPTION
This basically just widens the allowed types for what was previously
`EachStringIndex` since the way it works is not really specific to
strings. I needed something like this for my own collection type and
half expected `eachindex` to work like that already.

If people don't like the generic fallback method for `keys` here
though, we could also require people to opt into it explicitly by
defining `Base.keys(x::T) = Base.EachIndex(x)` themselves instead.
