### PR TITLE
fix #43040, crash when a concrete method sig has an unused static parameter

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3151,7 +3151,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt, int offs,
             jl_method_t *meth = env.matc->method;
             jl_svec_t *tpenv = env.matc->sparams;
             JL_LOCK(&mt->writelock);
-            cache_method(mt, &mt->cache, (jl_value_t*)mt, type, meth, world, env.min_valid, env.max_valid, tpenv);
+            cache_method(mt, &mt->cache, (jl_value_t*)mt, (jl_tupletype_t*)unw, meth, world, env.min_valid, env.max_valid, tpenv);
             JL_UNLOCK(&mt->writelock);
         }
     }

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -386,4 +386,12 @@ end
 @test_throws MethodError B12814{3, Float64}([1, 2, 3]) # ambiguous
 @test B12814{3,Float64}((1, 2, 3)).x === (1.0, 2.0, 3.0)
 
+# issue #43040
+module M43040
+   struct C end
+   stripType(::Type{C}) where {T} = C # where {T} is intentionally incorrect
+end
+
+@test isempty(detect_ambiguities(M43040; recursive=true))
+
 nothing


### PR DESCRIPTION
fix #43040