### PR TITLE
RFC: unsafe_bitcast

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -43,11 +43,11 @@ pairs(::Type{NamedTuple}) = Pairs{Symbol, V, NTuple{N, Symbol}, NamedTuple{names
 #export NamedTuplePair
 
 macro _gc_preserve_begin(arg1)
-    Expr(:gc_preserve_begin, esc(arg1))
+    Expr(:gc_preserve_begin, Expr(:escape, arg1))
 end
 
 macro _gc_preserve_end(token)
-    Expr(:gc_preserve_end, esc(token))
+    Expr(:gc_preserve_end, Expr(:escape, token))
 end
 
 """


### PR DESCRIPTION
This PR tries to add (hopefully) well-defined low-level [type punning](https://en.wikipedia.org/wiki/Type_punning) facility usable for arbitrary pointer-free immutable objects.

The main use case is to support converting an arbitrary pointer-free immutable object to an opaque chunk of bytes (e.g., `NTuple{N,UInt8}`) and back.  For example, this will be useful for using a rich set of immutable objects on GPU API like `CUDA.shfl_sync` etc. which are [currently defined by `reinterpret`ing some small subset of types to integers](https://github.com/JuliaGPU/CUDA.jl/blob/91db76efc7ccb4125c1f5e98b7fb7a5ad8c50c5e/src/device/intrinsics/warp_shuffle.jl#L55-L73). If we can cast nested structs with `Union` fields, we can correctly execute [various transducers with complex state transitions](https://juliafolds.github.io/Transducers.jl/dev/explanation/state_machines/) on GPU. Another important use case is an emulation of [tearable atomics](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0690r1.html) which is useful for efficient concurrent algorithms such as work-stealing dequeue and seqlock.

However, casting one type to another (aka type punning) is known to be hard when the compiler wants to infer something from the type system. If you can find various one-hour technical talks (e.g., [CppCon 2019: Timur Doumler “Type punning in modern C++” - YouTube](https://www.youtube.com/watch?v=_qzMpk-22cc)) on how to do it correctly, it's a good indication that we need to have an API in `Base` with a clear definition of when and how it can be used.  For example, C++20 now has [`std::bit_cast`](https://en.cppreference.com/w/cpp/numeric/bit_cast) as a similar API.

I haven't had time to dig deep into this to convince myself that the API I came up with was OK.  But given the recent discussion (#32660, #42968, #43035) in expanding what `reinterpret` does, I think it's worth opening it as an alternative take at it; i.e., unsafe (narrow contract) API with wider use cases but weaker guarantee (no cross-process roundtrip). So, I'd appreciate it if people who know Julia and LLVM compiler can look at it.

One aspect of the API that I'm still worried about is what we can say about the returned object when the input type contains some padding. I wonder if we should rather create an "asymmetric" API `unsafe_bitembed(T, x::S) -> y::T` and `unsafe_bitextract(S, y::T) -> x::S` where `S` can contain padding but `T` must not. We can then clearly document that `T` is a chunk of opaque bytes that can only be usable in a meaningful way after `unsafe_bitextract`.  I don't know if it helps the compiler, though.

ping @vtjnash @JeffBezanson @Keno @vchuravy @maleadt
