### PR TITLE
Enable "Test spawning a lot of tasks" on non-Linux

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -149,7 +149,7 @@ end
 close(proc.in)
 
 # https://github.com/JuliaLang/julia/pull/42973
-Sys.islinux() && @testset "spawn and wait *a lot* of tasks in @profile" begin
+@testset "spawn and wait *a lot* of tasks in @profile" begin
     # Not using threads_exec.jl for better isolation, reproducibility, and a
     # tighter timeout.
     script = "profile_spawnmany_exec.jl"


### PR DESCRIPTION
This re-enables the bug reproducer test #42975 `spawn and wait *a lot* of tasks in @profile` (fixed in #42978) for non-Linux platforms so that people using Windows, macOS, and FreeBSD can pick it up.

Ref: https://github.com/JuliaLang/julia/pull/42978#discussion_r748609090
