### PR TITLE
FMA multiversioning.

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -416,6 +416,7 @@ function is_pure_intrinsic_infer(f::IntrinsicFunction)
              f === Intrinsics.arraylen ||   # this one is volatile
              f === Intrinsics.sqrt_llvm ||  # this one may differ at runtime (by a few ulps)
              f === Intrinsics.sqrt_llvm_fast ||  # this one may differ at runtime (by a few ulps)
+             f === Intrinsics.have_fma ||  # this one depends on the runtime environment
              f === Intrinsics.cglobal)  # cglobal lookup answer changes at runtime
 end
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -10,7 +10,7 @@ const _NAMEDTUPLE_NAME = NamedTuple.body.body.name
 
 const INT_INF = typemax(Int) # integer infinity
 
-const N_IFUNC = reinterpret(Int32, arraylen) + 1
+const N_IFUNC = reinterpret(Int32, have_fma) + 1
 const T_IFUNC = Vector{Tuple{Int, Int, Any}}(undef, N_IFUNC)
 const T_IFUNC_COST = Vector{Int}(undef, N_IFUNC)
 const T_FFUNC_KEY = Vector{Any}()
@@ -214,6 +214,7 @@ cglobal_tfunc(@nospecialize(fptr)) = Ptr{Cvoid}
 cglobal_tfunc(@nospecialize(fptr), @nospecialize(t)) = (isType(t) ? Ptr{t.parameters[1]} : Ptr)
 cglobal_tfunc(@nospecialize(fptr), t::Const) = (isa(t.val, Type) ? Ptr{t.val} : Ptr)
 add_tfunc(Core.Intrinsics.cglobal, 1, 2, cglobal_tfunc, 5)
+add_tfunc(Core.Intrinsics.have_fma, 1, 1, @nospecialize(x)->Bool, 1)
 
 function ifelse_tfunc(@nospecialize(cnd), @nospecialize(x), @nospecialize(y))
     if isa(cnd, Const)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -412,11 +412,8 @@ fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
 
 # Disable LLVM's fma if it is incorrect, e.g. because LLVM falls back
 # onto a broken system libm; if so, use a software emulated fma
-have_fma(::Type) = false
-have_fma(::Type{Float32}) = ccall("extern julia.cpu.have_fma.f32", llvmcall, Int, ()) == 1
-have_fma(::Type{Float64}) = ccall("extern julia.cpu.have_fma.f64", llvmcall, Int, ()) == 1
-fma(x::Float32, y::Float32, z::Float32) = have_fma(Float32) ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
-fma(x::Float64, y::Float64, z::Float64) = have_fma(Float64) ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
+fma(x::Float32, y::Float32, z::Float32) = Core.Intrinsics.have_fma(Float32) ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
+fma(x::Float64, y::Float64, z::Float64) = Core.Intrinsics.have_fma(Float64) ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
 
 function fma(a::Float16, b::Float16, c::Float16)
     Float16(muladd(Float32(a), Float32(b), Float32(c))) #don't use fma if the hardware doesn't have it.

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -412,9 +412,11 @@ fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
 
 # Disable LLVM's fma if it is incorrect, e.g. because LLVM falls back
 # onto a broken system libm; if so, use a software emulated fma
-have_fma() = ccall("extern julia.cpu.have_fma", llvmcall, Int, ()) == 1
-fma(x::Float32, y::Float32, z::Float32) = have_fma() ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
-fma(x::Float64, y::Float64, z::Float64) = have_fma() ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
+have_fma(::Type) = false
+have_fma(::Type{Float32}) = ccall("extern julia.cpu.have_fma.f32", llvmcall, Int, ()) == 1
+have_fma(::Type{Float64}) = ccall("extern julia.cpu.have_fma.f64", llvmcall, Int, ()) == 1
+fma(x::Float32, y::Float32, z::Float32) = have_fma(Float32) ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
+fma(x::Float64, y::Float64, z::Float64) = have_fma(Float64) ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
 
 function fma(a::Float16, b::Float16, c::Float16)
     Float16(muladd(Float32(a), Float32(b), Float32(c))) #don't use fma if the hardware doesn't have it.

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -409,22 +409,13 @@ function fma_emulated(a::Float64, b::Float64,c::Float64)
 end
 fma_llvm(x::Float32, y::Float32, z::Float32) = fma_float(x, y, z)
 fma_llvm(x::Float64, y::Float64, z::Float64) = fma_float(x, y, z)
+
 # Disable LLVM's fma if it is incorrect, e.g. because LLVM falls back
 # onto a broken system libm; if so, use a software emulated fma
-# 1.0000305f0 = 1 + 1/2^15
-# 1.0000000009313226 = 1 + 1/2^30
-# If fma_llvm() clobbers the rounding mode, the result of 0.1 + 0.2 will be 0.3
-# instead of the properly-rounded 0.30000000000000004; check after calling fma
-# TODO actually detect fma in hardware and switch on that.
-if (Sys.ARCH !== :i686 && fma_llvm(1.0000305f0, 1.0000305f0, -1.0f0) == 6.103609f-5 &&
-    (fma_llvm(1.0000000009313226, 1.0000000009313226, -1.0) ==
-     1.8626451500983188e-9) && 0.1 + 0.2 == 0.30000000000000004)
-    fma(x::Float32, y::Float32, z::Float32) = fma_llvm(x,y,z)
-    fma(x::Float64, y::Float64, z::Float64) = fma_llvm(x,y,z)
-else
-    fma(x::Float32, y::Float32, z::Float32) = fma_emulated(x,y,z)
-    fma(x::Float64, y::Float64, z::Float64) = fma_emulated(x,y,z)
-end
+have_fma() = ccall("extern julia.cpu.have_fma", llvmcall, Int, ()) == 1
+fma(x::Float32, y::Float32, z::Float32) = have_fma() ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
+fma(x::Float64, y::Float64, z::Float64) = have_fma() ? fma_llvm(x,y,z) : fma_emulated(x,y,z)
+
 function fma(a::Float16, b::Float16, c::Float16)
     Float16(muladd(Float32(a), Float32(b), Float32(c))) #don't use fma if the hardware doesn't have it.
 end

--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ RUNTIME_CODEGEN_SRCS := jitlayers aotcompile debuginfo disasm llvm-simdloop llvm
 	llvm-final-gc-lowering llvm-pass-helpers llvm-late-gc-lowering \
 	llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces \
 	llvm-multiversioning llvm-alloc-opt cgmemmgr llvm-remove-addrspaces \
-	llvm-remove-ni llvm-julia-licm llvm-demote-float16
+	llvm-remove-ni llvm-julia-licm llvm-demote-float16 llvm-cpufeatures
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 CG_LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -645,6 +645,10 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
         PM->add(createLowerSimdLoopPass()); // Annotate loop marked with "loopinfo" as LLVM parallel loop
         if (dump_native)
             PM->add(createMultiVersioningPass());
+        PM->add(createCPUFeaturesPass());
+        // minimal clean-up to get rid of CPU feature checks
+        PM->add(createInstSimplifyLegacyPass());
+        PM->add(createCFGSimplificationPass(simplifyCFGOptions));
 #if defined(_COMPILER_ASAN_ENABLED_)
         PM->add(createAddressSanitizerFunctionPass());
 #endif
@@ -680,6 +684,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createCFGSimplificationPass(simplifyCFGOptions));
     if (dump_native)
         PM->add(createMultiVersioningPass());
+    PM->add(createCPUFeaturesPass());
     PM->add(createSROAPass());
     PM->add(createInstSimplifyLegacyPass());
     PM->add(createJumpThreadingPass());

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -103,6 +103,8 @@
     ALIAS(llvmcall, llvmcall) \
     /*  object access */ \
     ADD_I(arraylen, 1) \
+    /*  cpu feature tests */ \
+    ADD_I(have_fma, 1) \
     /*  hidden intrinsics */ \
     ADD_HIDDEN(cglobal_auto, 1)
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -243,6 +243,7 @@ Pass *createJuliaLICMPass();
 Pass *createMultiVersioningPass();
 Pass *createAllocOptPass();
 Pass *createDemoteFloat16Pass();
+Pass *createCPUFeaturesPass();
 // Whether the Function is an llvm or julia intrinsic.
 static inline bool isIntrinsicFunction(Function *F)
 {

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -32,6 +32,7 @@
     XX(jl_array_grow_end) \
     XX(jl_array_isassigned) \
     XX(jl_arraylen) \
+    XX(jl_have_fma) \
     XX(jl_array_ptr) \
     XX(jl_array_ptr_1d_append) \
     XX(jl_array_ptr_1d_push) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1240,6 +1240,7 @@ JL_DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
 
 JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a);
 JL_DLLEXPORT int jl_stored_inline(jl_value_t *el_type);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -5,7 +5,10 @@
 // specific CPU features.
 //
 // The following intrinsics are supported:
-// - julia.cpu.have_fma.$typ: returns 1 if the platform supports hardware-accelerated FMA
+// - julia.cpu.have_fma.$typ: returns 1 if the platform supports hardware-accelerated FMA.
+//
+// Some of these intrinsics are overloaded, i.e., they are suffixed with a type name.
+// To extend support, make sure codegen (in intrinsics.cpp) knows how to emit them.
 //
 // XXX: can / do we want to make this a codegen pass to enable querying TargetPassConfig
 //      instead of using the global target machine?

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -36,7 +36,10 @@ Optional<bool> always_have_fma(Function &intr) {
     auto intr_name = intr.getName();
     auto typ = intr_name.substr(strlen("julia.cpu.have_fma."));
 
-#ifdef _CPU_AARCH64_
+#if defined(_OS_WINDOWS_)
+    // FMA on Windows is weirdly broken (#43088)
+    return false;
+#elif defined(_CPU_AARCH64_)
     return typ == "f32" || typ == "f64";
 #else
     (void)typ;

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -1,0 +1,110 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+//
+// Lower intrinsics that expose subtarget information to the language. This makes it
+// possible to write code that changes behavior based on, e.g., the availability of
+// specific CPU features.
+//
+// The following intrinsics are supported:
+// - julia.cpu.have_fma: returns 1 if the platform supports hardware-accelerated FMA
+//
+// XXX: can / do we want to make this a codegen pass to enable querying TargetPassConfig?
+
+#include "llvm-version.h"
+
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/Support/Debug.h>
+
+#include "julia.h"
+
+#define DEBUG_TYPE "cpufeatures"
+
+using namespace llvm;
+
+extern TargetMachine *jl_TargetMachine;
+
+namespace {
+
+static void lowerHaveFMA(Function &F, Instruction *I) {
+    Triple TheTriple = Triple(jl_TargetMachine->getTargetTriple());
+
+    Attribute CPUAttr = F.getFnAttribute("target-cpu");
+    Attribute FSAttr = F.getFnAttribute("target-features");
+
+    StringRef CPU =
+        CPUAttr.isValid() ? CPUAttr.getValueAsString() : jl_TargetMachine->getTargetCPU();
+    StringRef FS =
+        FSAttr.isValid() ? FSAttr.getValueAsString() : jl_TargetMachine->getTargetFeatureString();
+
+    if (TheTriple.getArch() == Triple::x86_64 && FS.find("+fma") != StringRef::npos)
+        I->replaceAllUsesWith(ConstantInt::get(I->getType(), 1));
+    else
+        I->replaceAllUsesWith(ConstantInt::get(I->getType(), 0));
+
+    return;
+}
+
+static bool lowerCPUFeatures(Module &M)
+{
+    SmallVector<Instruction*,6> Materialized;
+    if (auto have_fma = M.getFunction("julia.cpu.have_fma")) {
+        for (Use &U: have_fma->uses()) {
+            User *RU = U.getUser();
+            Instruction *I = cast<Instruction>(RU);
+            lowerHaveFMA(*I->getParent()->getParent(), I);
+            Materialized.push_back(I);
+        }
+    }
+
+    if (!Materialized.empty()) {
+        for (auto I: Materialized) {
+            I->eraseFromParent();
+        }
+        return true;
+    } else {
+        return false;
+    }
+}
+}
+
+struct CPUFeatures : PassInfoMixin<CPUFeatures> {
+    PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
+
+PreservedAnalyses CPUFeatures::run(Module &M, ModuleAnalysisManager &AM)
+{
+    lowerCPUFeatures(M);
+    return PreservedAnalyses::all();
+}
+
+namespace {
+struct CPUFeaturesLegacy : public ModulePass {
+    static char ID;
+    CPUFeaturesLegacy() : ModulePass(ID) {};
+
+    bool runOnModule(Module &M)
+    {
+        return lowerCPUFeatures(M);
+    }
+};
+
+char CPUFeaturesLegacy::ID = 0;
+static RegisterPass<CPUFeaturesLegacy>
+        Y("CPUFeatures",
+          "Lower calls to CPU feature testing intrinsics.",
+          false,
+          false);
+}
+
+Pass *createCPUFeaturesPass()
+{
+    return new CPUFeaturesLegacy();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddCPUFeaturesPass_impl(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createCPUFeaturesPass());
+}

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -43,6 +43,8 @@ using namespace llvm;
 extern std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *parent=nullptr,
                                                   bool isConstant=false);
 
+extern Optional<bool> always_have_fma();
+
 namespace {
 
 // These are valid detail cloning conditions in the target flags.
@@ -470,7 +472,14 @@ uint32_t CloneCtx::collect_func_info(Function &F)
                         flag |= JL_TARGET_CLONE_MATH;
                     }
                     else if (name.startswith("julia.cpu.")) {
-                        flag |= JL_TARGET_CLONE_CPU;
+                        if (name == "julia.cpu.have_fma") {
+                            // for some platforms we know they always do (or don't) support
+                            // FMA. in those cases we don't need to clone the function.
+                            if (!always_have_fma().hasValue())
+                                flag |= JL_TARGET_CLONE_CPU;
+                        } else {
+                            flag |= JL_TARGET_CLONE_CPU;
+                        }
                     }
                 }
             }

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -43,7 +43,7 @@ using namespace llvm;
 extern std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *parent=nullptr,
                                                   bool isConstant=false);
 
-extern Optional<bool> always_have_fma();
+extern Optional<bool> always_have_fma(Function&);
 
 namespace {
 
@@ -472,10 +472,10 @@ uint32_t CloneCtx::collect_func_info(Function &F)
                         flag |= JL_TARGET_CLONE_MATH;
                     }
                     else if (name.startswith("julia.cpu.")) {
-                        if (name == "julia.cpu.have_fma") {
+                        if (name.startswith("julia.cpu.have_fma.")) {
                             // for some platforms we know they always do (or don't) support
                             // FMA. in those cases we don't need to clone the function.
-                            if (!always_have_fma().hasValue())
+                            if (!always_have_fma(*callee).hasValue())
                                 flag |= JL_TARGET_CLONE_CPU;
                         } else {
                             flag |= JL_TARGET_CLONE_CPU;

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -47,7 +47,7 @@ namespace {
 
 // These are valid detail cloning conditions in the target flags.
 constexpr uint32_t clone_mask =
-    JL_TARGET_CLONE_LOOP | JL_TARGET_CLONE_SIMD | JL_TARGET_CLONE_MATH;
+    JL_TARGET_CLONE_LOOP | JL_TARGET_CLONE_SIMD | JL_TARGET_CLONE_MATH | JL_TARGET_CLONE_CPU;
 
 struct MultiVersioning;
 
@@ -468,6 +468,9 @@ uint32_t CloneCtx::collect_func_info(Function &F)
                     auto name = callee->getName();
                     if (name.startswith("llvm.muladd.") || name.startswith("llvm.fma.")) {
                         flag |= JL_TARGET_CLONE_MATH;
+                    }
+                    else if (name.startswith("julia.cpu.")) {
+                        flag |= JL_TARGET_CLONE_CPU;
                     }
                 }
             }

--- a/src/processor.h
+++ b/src/processor.h
@@ -107,6 +107,8 @@ enum {
     JL_TARGET_OPTSIZE = 1 << 6,
     // Only optimize for size for this target
     JL_TARGET_MINSIZE = 1 << 7,
+    // Clone when the function queries CPU features
+    JL_TARGET_CLONE_CPU = 1 << 8,
 };
 
 #define JL_FEATURE_DEF_NAME(name, bit, llvmver, str) JL_FEATURE_DEF(name, bit, llvmver)

--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -1562,6 +1562,8 @@ static void ensure_jit_target(bool imaging)
         auto &t = jit_targets[i];
         if (t.en.flags & JL_TARGET_CLONE_ALL)
             continue;
+        // Always clone when code checks CPU features
+        t.en.flags |= JL_TARGET_CLONE_CPU;
         // The most useful one in general...
         t.en.flags |= JL_TARGET_CLONE_LOOP;
 #ifdef _CPU_ARM_

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -877,6 +877,8 @@ static void ensure_jit_target(bool imaging)
         auto &t = jit_targets[i];
         if (t.en.flags & JL_TARGET_CLONE_ALL)
             continue;
+        // Always clone when code checks CPU features
+        t.en.flags |= JL_TARGET_CLONE_CPU;
         // The most useful one in general...
         t.en.flags |= JL_TARGET_CLONE_LOOP;
         auto &features0 = jit_targets[t.base].en.features;

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1349,3 +1349,10 @@ JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a)
     JL_TYPECHK(arraylen, array, a);
     return jl_box_long(jl_array_len((jl_array_t*)a));
 }
+
+JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
+{
+    JL_TYPECHK(have_fma, datatype, typ);
+    // TODO: run-time feature check?
+    return jl_false;
+}

--- a/test/llvmpasses/cpu-features.ll
+++ b/test/llvmpasses/cpu-features.ll
@@ -1,0 +1,42 @@
+; RUN: opt -load libjulia-internal%shlibext -CPUFeatures -simplifycfg -S %s | FileCheck %s
+
+declare i1 @julia.cpu.have_fma.f64()
+declare double @with_fma(double %0, double %1, double %2)
+declare double @without_fma(double %0, double %1, double %2)
+
+; CHECK: @fma1
+define double @fma1(double %0, double %1, double %2) #0 {
+top:
+  %3 = call i1 @julia.cpu.have_fma.f64()
+  br i1 %3, label %L1, label %L2
+
+; CHECK-NOT: @julia.cpu.have_fma
+; CHECK: @with_fma
+L1:                                               ; preds = %top
+  %4 = call double @with_fma(double %0, double %1, double %2)
+  ret double %4
+
+L2:                                               ; preds = %top
+  %5 = call double @without_fma(double %0, double %1, double %2)
+  ret double %5
+}
+
+; CHECK: @fma2
+define double @fma2(double %0, double %1, double %2) #1 {
+top:
+  %3 = call i1 @julia.cpu.have_fma.f64()
+  br i1 %3, label %L1, label %L2
+
+; CHECK-NOT: @julia.cpu.have_fma
+; CHECK: @without_fma
+L1:                                               ; preds = %top
+  %4 = call double @with_fma(double %0, double %1, double %2)
+  ret double %4
+
+L2:                                               ; preds = %top
+  %5 = call double @without_fma(double %0, double %1, double %2)
+  ret double %5
+}
+
+attributes #0 = { "target-features"="+fma" }
+attributes #1 = { "target-features"="-fma" }


### PR DESCRIPTION
Adds a `julia.cpu.have_fma` intrinsic that gets detected by multiversioning (cloning the function) and lowered afterwards, replacing the calls with simple constants that can then be trivially optimized away. Very ad-hoc implementation as a starting point, but it also seems tricky to generalize this so that CUDA.jl can reuse the mechanism (i.e. adding it to `CodegenParams` wouldn't work with how CPU multiversioning currently works).

Demo:

```
$ ./julia
julia> @code_native fma(1.,2.,3.)
        .text
        .file   "fma"
        .globl  julia_fma_84                    # -- Begin function julia_fma_84
        .p2align        4, 0x90
        .type   julia_fma_84,@function
julia_fma_84:                           # @julia_fma_84
; ┌ @ floatfuncs.jl:414 within `fma`
        .cfi_startproc
# %bb.0:                                # %L4
; │┌ @ floatfuncs.jl:408 within `fma_llvm`
        vfmadd213sd     %xmm2, %xmm1, %xmm0     # xmm0 = (xmm1 * xmm0) + xmm2
; │└
        retq
.Lfunc_end0:
        .size   julia_fma_84, .Lfunc_end0-julia_fma_84
        .cfi_endproc
; └
                                        # -- End function
        .section        ".note.GNU-stack","",@progbits
```

```
$ ./julia -C sandybridge
julia> @code_native fma(1.,2.,3.)
        .text
        .file   "fma"
        .globl  julia_fma_49                    # -- Begin function julia_fma_49
        .p2align        4, 0x90
        .type   julia_fma_49,@function
julia_fma_49:                           # @julia_fma_49
; ┌ @ floatfuncs.jl:414 within `fma`
        .cfi_startproc
# %bb.0:                                # %L6
        subq    $8, %rsp
        .cfi_def_cfa_offset 16
        movabsq $j_fma_emulated_51, %rax
        callq   *%rax
        popq    %rax
        .cfi_def_cfa_offset 8
        retq
.Lfunc_end0:
        .size   julia_fma_49, .Lfunc_end0-julia_fma_49
        .cfi_endproc
; └
                                        # -- End function
        .section        ".note.GNU-stack","",@progbits
```

I've also included https://github.com/JuliaLang/julia/pull/42942, but somebody will have to fine-tune the condition when FMA emulation is used.