### PR TITLE
[base] fix generic `findall`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2324,7 +2324,9 @@ julia> findall(falses(3))
 Int64[]
 ```
 """
-findall(A) = findall(identity, A)
+function findall(A)
+    collect(first(p) for p in pairs(A) if last(p))
+end
 
 # Allocating result upfront is faster (possible only when collection can be iterated twice)
 function findall(A::AbstractArray{Bool})

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -594,6 +594,10 @@ end
         @test findprev(b, T(1)) isa keytype(b)
         @test findprev(b, T(2)) isa keytype(b)
     end
+
+    @testset "issue 43078" begin
+        @test_throws TypeError findall([1])
+    end
 end
 @testset "find with Matrix" begin
     A = [1 2 0; 3 4 0]


### PR DESCRIPTION
fix #43078

Should we add more pairs-related tests?
```
findall((; a=false, b=true)) == [:a]
findall((true, false, false, true)) == [1, 4]
```