### PR TITLE
enhance Threads.Events with ordering and (auto)reset

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -1095,7 +1095,7 @@ isdone(itr::ReadEachIterator, state...) = eof(itr.stream)
 # not in base.
 
 """
-    mark(s)
+    mark(s::IO)
 
 Add a mark at the current position of stream `s`. Return the marked position.
 
@@ -1106,7 +1106,7 @@ function mark(io::IO)
 end
 
 """
-    unmark(s)
+    unmark(s::IO)
 
 Remove a mark from stream `s`. Return `true` if the stream was marked, `false` otherwise.
 
@@ -1119,7 +1119,7 @@ function unmark(io::IO)
 end
 
 """
-    reset(s)
+    reset(s::IO)
 
 Reset a stream `s` to a previously marked position, and remove the mark. Return the
 previously marked position. Throw an error if the stream is not marked.
@@ -1135,7 +1135,7 @@ function reset(io::T) where T<:IO
 end
 
 """
-    ismarked(s)
+    ismarked(s::IO)
 
 Return `true` if stream `s` is marked.
 

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -29,7 +29,7 @@ Base.seekend
 Base.skip
 Base.mark
 Base.unmark
-Base.reset
+Base.reset(::IO)
 Base.ismarked
 Base.eof
 Base.isreadonly

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -39,6 +39,7 @@ Base.Condition
 Base.Threads.Condition
 Base.Threads.Event
 Base.notify
+Base.reset(::Base.Threads.Event)
 
 Base.Semaphore
 Base.acquire

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -253,6 +253,10 @@ void jl_critical_error(int sig, bt_context_t *context, jl_task_t *ct)
             ct->gcstack = NULL;
             ct->eh = NULL;
             ct->excstack = NULL;
+            ct->ptls->locks.len = 0;
+            ct->ptls->in_pure_callback = 0;
+            ct->ptls->in_finalizer = 1;
+            ct->world_age = 1;
         }
 #ifndef _OS_WINDOWS_
         sigset_t sset;

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -586,21 +586,6 @@ function test_thread_too_few_iters()
 end
 test_thread_too_few_iters()
 
-let e = Event(), started = Event()
-    done = false
-    t = @async (notify(started); wait(e); done = true)
-    wait(started)
-    sleep(0.1)
-    @test done == false
-    notify(e)
-    wait(t)
-    @test done == true
-    blocked = true
-    wait(@async (wait(e); blocked = false))
-    @test !blocked
-end
-
-
 @testset "InvasiveLinkedList" begin
     @test eltype(Base.InvasiveLinkedList{Integer}) == Integer
     @test eltype(Base.LinkedList{Integer}) == Integer


### PR DESCRIPTION
Previously, this was using memory-order relaxed, though that is unlikely
to be useful. Instead guarantee it will have memory-order
acquire-release (similar to a Lock).