### PR TITLE
Document that cfunctions should not throw errors

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -188,8 +188,7 @@ Julia function. The arguments to [`@cfunction`](@ref) are:
 
 !!! note
     Callback functions exposed via `@cfunction` should not throw errors, as that will
-    return control to the Julia runtime and may leave the library invoking the function in
-    an undefined state.
+    return control to the Julia runtime unexpectedly and may leave the program in an undefined state.
 
 A classic example is the standard C library `qsort` function, declared as:
 

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -186,6 +186,11 @@ Julia function. The arguments to [`@cfunction`](@ref) are:
     function on 32-bit Windows, but can be used on WIN64 (where `stdcall` is unified with the
     C calling convention).
 
+!!! note
+    Callback functions exposed via `@cfunction` should not throw errors, as that will
+    return control to the Julia runtime and may leave the library invoking the function in
+    an undefined state.
+
 A classic example is the standard C library `qsort` function, declared as:
 
 ```c


### PR DESCRIPTION
This was not documented, see https://discourse.julialang.org/t/what-happens-when-you-throw-an-error-from-a-cfunction/71510?u=simonbyrne