### PR TITLE
Use `open` to open Julia REPL in macOS default terminal

### DIFF
--- a/contrib/mac/app/startup.applescript
+++ b/contrib/mac/app/startup.applescript
@@ -1,5 +1,4 @@
-set RootPath to POSIX path of (path to me)
-tell application id "com.apple.terminal"
-  do script ("exec '" & RootPath & "Contents/Resources/julia/bin/julia'")
-  activate
-end tell
+set RootPath to (path to me)
+set JuliaPath to POSIX path of ((RootPath as text) & "Contents:Resources:julia:bin:julia")
+set JuliaFile to POSIX file JuliaPath
+tell application id "com.apple.finder" to open JuliaFile


### PR DESCRIPTION
Most macOS developers use third-party terminal apps (e.g. iTerm2) to replace macOS's default terminal. Current implementation will always open built-in terminal to execute Julia REPL, which is not good enough. By using `open` command, macOS will automatically use the user-default terminal to execute Julia executable