### PR TITLE
Relax constraints on inlining for some single calls

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1192,6 +1192,9 @@ function analyze_single_call!(
         item === nothing && return
         push!(cases, InliningCase(match.spec_types, item))
         fully_covered = atype <: match.spec_types
+    else
+        fully_covered &= atype <: signature_union
+    end
     end
 
     # If we only have one case and that case is fully covered, we may either

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1195,7 +1195,6 @@ function analyze_single_call!(
     else
         fully_covered &= atype <: signature_union
     end
-    end
 
     # If we only have one case and that case is fully covered, we may either
     # be able to do the inlining now (for constant cases), or push it directly

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1176,26 +1176,22 @@ function analyze_single_call!(
         end
     end
 
-    # if the signature is fully covered and there is only one applicable method,
+    # if the signature is fully or mostly covered and there is only one applicable method,
     # we can try to inline it even if the signature is not a dispatch tuple
-    if atype <: signature_union
-        if length(cases) == 0 && only_method isa Method
-            if length(infos) > 1
-                (metharg, methsp) = ccall(:jl_type_intersection_with_env, Any, (Any, Any),
-                    atype, only_method.sig)::SimpleVector
-                match = MethodMatch(metharg, methsp::SimpleVector, only_method, true)
-            else
-                meth = meth::MethodLookupResult
-                @assert length(meth) == 1
-                match = meth[1]
-            end
-            item = analyze_method!(match, argtypes, flag, state)
-            item === nothing && return
-            push!(cases, InliningCase(match.spec_types, item))
-            fully_covered = true
+    if length(cases) == 0 && only_method isa Method
+        if length(infos) > 1
+            (metharg, methsp) = ccall(:jl_type_intersection_with_env, Any, (Any, Any),
+                atype, only_method.sig)::SimpleVector
+            match = MethodMatch(metharg, methsp::SimpleVector, only_method, true)
+        else
+            meth = meth::MethodLookupResult
+            @assert length(meth) == 1
+            match = meth[1]
         end
-    else
-        fully_covered = false
+        item = analyze_method!(match, argtypes, flag, state)
+        item === nothing && return
+        push!(cases, InliningCase(match.spec_types, item))
+        fully_covered = atype <: match.spec_types
     end
 
     # If we only have one case and that case is fully covered, we may either

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -822,11 +822,11 @@ end
 
 @inline isGoodType(@nospecialize x::Type) =
     x !== Any && !(@noinline Base.has_free_typevars(x))
-let # aggressive static dispatch of single, abstract method match
+let # aggressive inlining of single, abstract method match
     src = code_typed((Type, Any,)) do x, y
         isGoodType(x), isGoodType(y)
     end |> only |> first
-    # both callsite should be inlined
+    # both callsites should be inlined
     @test count(isinvoke(:has_free_typevars), src.code) == 2
     # `isGoodType(y::Any)` isn't fully covered, thus a runtime type check and fallback dynamic dispatch should be inserted
     @test count(iscall((src,isGoodType)), src.code) == 1
@@ -838,11 +838,11 @@ end
     end
     return nothing
 end
-let # aggressive inlining of single, abstract method match
+let # aggressive static dispatch of single, abstract method match
     src = code_typed((Type, Any,)) do x, y
         checkBadType!(x), checkBadType!(y)
     end |> only |> first
-    # both callsite should be resolved statically
+    # both callsites should be resolved statically
     @test count(isinvoke(:checkBadType!), src.code) == 2
     # `checkBadType!(y::Any)` isn't fully covered, thus a runtime type check and fallback dynamic dispatch should be inserted
     @test count(iscall((src,checkBadType!)), src.code) == 1


### PR DESCRIPTION
Fixes #43104

I'm not sure if this is the correct condition, but it seems to pass all relevant tests. My first real look into the inlining logic, so I could certainly be missing something here.

CC @aviatesk 