### PR TITLE
Fix regression in `map` and `collect`

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -195,7 +195,7 @@ function typejoin_union_tuple(T::Type)
         elseif U isa Union
             ci = typejoin(U.a, U.b)
         else
-            ci = U
+            ci = promote_typejoin_union(U)
         end
         if i == lr && Core.Compiler.isvarargtype(pi)
             c[i] = isdefined(pi, :N) ? Vararg{ci, pi.N} : Vararg{ci}

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1011,6 +1011,8 @@ end
     @test typeof.([iszero, iszero]) == [typeof(iszero), typeof(iszero)]
     @test isequal(identity.(Vector{<:Union{Int, Missing}}[[1, 2],[missing, 1]]),
                   [[1, 2],[missing, 1]])
+    @test broadcast(i -> ((x=i, y=(i==1 ? 1 : "a")), 3), 1:4) isa
+        Vector{Tuple{NamedTuple{(:x, :y)}, Int64}}
 end
 
 @testset "Issue #28382: eltype inconsistent with getindex" begin

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1012,7 +1012,7 @@ end
     @test isequal(identity.(Vector{<:Union{Int, Missing}}[[1, 2],[missing, 1]]),
                   [[1, 2],[missing, 1]])
     @test broadcast(i -> ((x=i, y=(i==1 ? 1 : "a")), 3), 1:4) isa
-        Vector{Tuple{NamedTuple{(:x, :y)}, Int64}}
+        Vector{Tuple{NamedTuple{(:x, :y)}, Int}}
 end
 
 @testset "Issue #28382: eltype inconsistent with getindex" begin

--- a/test/generic_map_tests.jl
+++ b/test/generic_map_tests.jl
@@ -76,7 +76,7 @@ function generic_map_tests(mapf, inplace_mapf=nothing)
                   [[1, 2],[missing, 1]])
     @test map(x -> x < 0 ? false : x, Int[]) isa Vector{Integer}
     @test map(i -> ((x=i, y=(i==1 ? 1 : "a")), 3), 1:4) isa
-        Vector{Tuple{NamedTuple{(:x, :y)}, Int64}}
+        Vector{Tuple{NamedTuple{(:x, :y)}, Int}}
 end
 
 function testmap_equivalence(mapf, f, c...)

--- a/test/generic_map_tests.jl
+++ b/test/generic_map_tests.jl
@@ -75,6 +75,8 @@ function generic_map_tests(mapf, inplace_mapf=nothing)
     @test isequal(map(identity, Vector{<:Union{Int, Missing}}[[1, 2],[missing, 1]]),
                   [[1, 2],[missing, 1]])
     @test map(x -> x < 0 ? false : x, Int[]) isa Vector{Integer}
+    @test map(i -> ((x=i, y=(i==1 ? 1 : "a")), 3), 1:4) isa
+        Vector{Tuple{NamedTuple{(:x, :y)}, Int64}}
 end
 
 function testmap_equivalence(mapf, f, c...)


### PR DESCRIPTION
`promote_typejoin_tuple` returned a type which was more precise than the one which `map` and `collect` actually use via `promote_type`, triggering an assertion error in corner cases.

This is an attempt at fixing #43112.