### PR TITLE
More detailed documentation of -i command line flag and isinteractive()

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -36,8 +36,8 @@ is_interactive = false
     isinteractive() -> Bool
 
 Determine whether Julia is running an interactive session. Returns `true` when the code
-is run from the REPL or when julia has been started with the `-i` command line flag. 
-Notably it returns `false` when called from the startup file in a REPL session started without 
+is run from the REPL or when julia has been started with the `-i` command line flag.
+Notably it returns `false` when called from the startup file in a REPL session started without
 the `-i` command line flag.
 """
 isinteractive() = (is_interactive::Bool)

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -35,7 +35,10 @@ is_interactive = false
 """
     isinteractive() -> Bool
 
-Determine whether Julia is running an interactive session.
+Determine whether Julia is running an interactive session. Returns `true` when the code
+is run from the REPL or when julia has been started with the `-i` command line flag. 
+Notably it returns `false` when called from the startup file in a REPL session started without 
+the `-i` command line flag.
 """
 isinteractive() = (is_interactive::Bool)
 

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -19,7 +19,7 @@ The following is a complete list of command-line switches available when launchi
 |`-t`, `--threads {N\|auto`}            |Enable N threads; `auto` currently sets N to the number of local CPU threads but this might change in the future|
 |`-p`, `--procs {N\|auto`}              |Integer value N launches N additional local worker processes; `auto` launches as many workers as the number of local CPU threads (logical cores)|
 |`--machine-file <file>`                |Run processes on hosts listed in `<file>`|
-|`-i`                                   |Interactive mode; REPL runs and `isinteractive()` is true|
+|`-i`                                   |Interactive mode; Run REPL after script execution and force `isinteractive()` to return true in all scripts including the startup file|
 |`-q`, `--quiet`                        |Quiet startup: no banner, suppress REPL warnings|
 |`--banner={yes\|no\|auto}`             |Enable or disable startup banner|
 |`--color={yes\|no\|auto}`              |Enable or disable color text|


### PR DESCRIPTION
From the documentation it is not really clear that  in startup.jl, isinteractive()  returns false even when a REPL session is started, unless the -i flag is given. So I tried to be more vebose on this.


