### PR TITLE
Disable "Test spawning a lot of tasks" on Windows

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -205,7 +205,7 @@ close(proc.in)
         if ( !success(proc) ) || ( timeout )
             @error "A \"spawn and wait lots of tasks\" test failed" n proc.exitcode proc.termsignal success(proc) timeout
         end
-        if Sys.iswindows() && (n >= 2000000)
+        if Sys.iswindows()
             # Known failure: https://github.com/JuliaLang/julia/issues/43124
             @test_skip success(proc)
         else

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -206,7 +206,9 @@ close(proc.in)
             # Known failure https://github.com/JuliaLang/julia/issues/43124
             @test_skip success(proc)
         else
-            @test success(proc)
+            # Not using `@test success(proc)` to get more information upon failure
+            @test proc.exitcode == 0
+            @test proc.termsignal == 0
         end
         @test !timeout
     end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -203,10 +203,11 @@ close(proc.in)
             close(timer)
         end
         if Sys.iswindows() && (n >= 2000000)
-            # Known failure https://github.com/JuliaLang/julia/issues/43124
+            # https://github.com/JuliaLang/julia/issues/43124
+            @test_skip proc.exitcode == 0
+            @test_skip proc.termsignal == 0
             @test_skip success(proc)
         else
-            # Not using `@test success(proc)` to get more information upon failure
             @test proc.exitcode == 0
             @test proc.termsignal == 0
             @test success(proc)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -202,16 +202,9 @@ close(proc.in)
             done[] = true
             close(timer)
         end
-        if Sys.iswindows()
-            if !success(proc)
-                @error """
-                Failed test: "spawn and wait *a lot* of tasks in @profile" (n = $n)
-
-                If you notice this error message, please share the test output in
-                https://github.com/JuliaLang/julia/issues/43124.  The error and
-                backtrace should be printed above.
-                """ proc.exitcode proc.termsignal
-            end
+        if Sys.iswindows() && (n >= 2000000)
+            # Known failure https://github.com/JuliaLang/julia/issues/43124
+            @test_skip success(proc)
         else
             @test success(proc)
         end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -174,9 +174,11 @@ close(proc.in)
     # Not using threads_exec.jl for better isolation, reproducibility, and a
     # tighter timeout.
     script = "profile_spawnmany_exec.jl"
-    cmd = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no $script`
+    cmd_base = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no $script`
     @testset for n in [20000, 200000, 2000000]
-        proc = run(ignorestatus(setenv(cmd, "NTASKS" => n; dir = @__DIR__)); wait = false)
+        cmd = ignorestatus(setenv(cmd_base, "NTASKS" => n; dir = @__DIR__))
+        cmd = pipeline(cmd; stdout = stderr, stderr)
+        proc = run(cmd; wait = false)
         done = Threads.Atomic{Bool}(false)
         timeout = false
         timer = Timer(100) do _

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -209,6 +209,7 @@ close(proc.in)
             # Not using `@test success(proc)` to get more information upon failure
             @test proc.exitcode == 0
             @test proc.termsignal == 0
+            @test success(proc)
         end
         @test !timeout
     end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -202,7 +202,19 @@ close(proc.in)
             done[] = true
             close(timer)
         end
-        @test success(proc)
+        if Sys.iswindows()
+            if !success(proc)
+                @error """
+                Failed test: "spawn and wait *a lot* of tasks in @profile" (n = $n)
+
+                If you notice this error message, please share the test output in
+                https://github.com/JuliaLang/julia/issues/43124.  The error and
+                backtrace should be printed above.
+                """ proc.exitcode proc.termsignal
+            end
+        else
+            @test success(proc)
+        end
         @test !timeout
     end
 end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -202,14 +202,13 @@ close(proc.in)
             done[] = true
             close(timer)
         end
+        if ( !success(proc) ) || ( timeout )
+            @error "A \"spawn and wait lots of tasks\" test failed" n proc.exitcode proc.termsignal success(proc) timeout
+        end
         if Sys.iswindows() && (n >= 2000000)
-            # https://github.com/JuliaLang/julia/issues/43124
-            @test_skip proc.exitcode == 0
-            @test_skip proc.termsignal == 0
+            # Known failure: https://github.com/JuliaLang/julia/issues/43124
             @test_skip success(proc)
         else
-            @test proc.exitcode == 0
-            @test proc.termsignal == 0
             @test success(proc)
         end
         @test !timeout


### PR DESCRIPTION
This patch disables the known failure #43124 on Windows for now.

Ref: https://github.com/JuliaLang/julia/pull/43072#issuecomment-972569162