### PR TITLE
Don't hide output from spawnmany test script

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -174,9 +174,11 @@ close(proc.in)
     # Not using threads_exec.jl for better isolation, reproducibility, and a
     # tighter timeout.
     script = "profile_spawnmany_exec.jl"
-    cmd = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no $script`
+    cmd_base = `$(Base.julia_cmd()) --depwarn=error --rr-detach --startup-file=no $script`
     @testset for n in [20000, 200000, 2000000]
-        proc = run(ignorestatus(setenv(cmd, "NTASKS" => n; dir = @__DIR__)); wait = false)
+        cmd = ignorestatus(setenv(cmd_base, "NTASKS" => n; dir = @__DIR__))
+        cmd = pipeline(cmd; stdout = stderr, stderr)
+        proc = run(cmd; wait = false)
         done = Threads.Atomic{Bool}(false)
         timeout = false
         timer = Timer(100) do _


### PR DESCRIPTION
I forgot to redirect stderr from the test script I added in #42978 (and enabled in #43072). This is required for solving #43124.