### PR TITLE
Fix documentation for searchsortedfirst/last w/ generalized indexing.

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -332,7 +332,7 @@ julia> searchsorted([1, 2, 4, 5, 5, 7], 0) # no match, insert at start
     searchsortedfirst(a, x; by=<transform>, lt=<comparison>, rev=false)
 
 Return the index of the first value in `a` greater than or equal to `x`, according to the
-specified order. Return `length(a) + 1` if `x` is greater than all values in `a`.
+specified order. Return `lastindex(a) + 1` if `x` is greater than all values in `a`.
 `a` is assumed to be sorted.
 
 See also: [`searchsortedlast`](@ref), [`searchsorted`](@ref), [`findfirst`](@ref).
@@ -360,8 +360,8 @@ julia> searchsortedfirst([1, 2, 4, 5, 5, 7], 0) # no match, insert at start
     searchsortedlast(a, x; by=<transform>, lt=<comparison>, rev=false)
 
 Return the index of the last value in `a` less than or equal to `x`, according to the
-specified order. Return `0` if `x` is less than all values in `a`. `a` is assumed to
-be sorted.
+specified order. Return `firstindex(a) - 1` if `x` is less than all values in `a`. `a` is
+assumed to be sorted.
 
 # Examples
 ```jldoctest

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -672,4 +672,12 @@ end
     end
 end
 
+@testset "searchsortedfirst/last with generalized indexing" begin
+    o = OffsetVector(1:3, -2)
+    @test searchsortedfirst(o, 4) == lastindex(o) + 1
+    @test searchsortedfirst(o, 1.5) == 0
+    @test searchsortedlast(o, 0) == firstindex(o) - 1
+    @test searchsortedlast(o, 1.5) == -1
+end
+
 end


### PR DESCRIPTION
While the code now correctly handles generalized indexing, documentation for `searchsortedfirst` and `searchsortedlast` still
assume that indices are `1:length(a)`. This PR fixes that.

Also add tests while at it. No behavior is changed.