### PR TITLE
optimizer: slightly improve callsite annotation handling

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -814,6 +814,9 @@ function const_prop_methodinstance_heuristic(
             # since the inliner will try to find this constant result
             # if these constant arguments arrive there
             return true
+        elseif is_stmt_noinline(flag)
+            # this call won't be inlined, thus this constant-prop' will most likely be unfruitful
+            return false
         else
             code = get(code_cache(interp), mi, nothing)
             if isdefined(code, :inferred) && inlining_policy(

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1302,7 +1302,7 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
         if isa(info, OpaqueClosureCallInfo)
             # ignore the `@noinline` annotation for opaque closure call as we force the constant-prop'
             # for this opaque closure call in `const_prop_methodinstance_heuristic` ?
-            # flag &= ~IR_FLAG_NOINLINEe
+            # flag &= ~IR_FLAG_NOINLINE
             result = info.result
             if isa(result, InferenceResult)
                 handle_const_opaque_closure_call!(

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1300,9 +1300,6 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
         end
 
         if isa(info, OpaqueClosureCallInfo)
-            # ignore the `@noinline` annotation for opaque closure call as we force the constant-prop'
-            # for this opaque closure call in `const_prop_methodinstance_heuristic` ?
-            # flag &= ~IR_FLAG_NOINLINE
             result = info.result
             if isa(result, InferenceResult)
                 handle_const_opaque_closure_call!(


### PR DESCRIPTION
Also make sure to respect `state.params.inlining` configuration in special analyses.