### PR TITLE
Add space after dot in `checkfor_mv_cp_cptree` error msg

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -321,7 +321,7 @@ function checkfor_mv_cp_cptree(src::AbstractString, dst::AbstractString, txt::Ab
             if Base.samefile(src, dst)
                 abs_src = islink(src) ? abspath(readlink(src)) : abspath(src)
                 abs_dst = islink(dst) ? abspath(readlink(dst)) : abspath(dst)
-                throw(ArgumentError(string("'src' and 'dst' refer to the same file/dir.",
+                throw(ArgumentError(string("'src' and 'dst' refer to the same file/dir. ",
                                            "This is not supported.\n  ",
                                            "`src` refers to: $(abs_src)\n  ",
                                            "`dst` refers to: $(abs_dst)\n")))


### PR DESCRIPTION
At the moment the error message reads
```
ERROR: ArgumentError: 'src' and 'dst' refer to the same file/dir.This is not supported.
```