### PR TITLE
`contrib/refresh_checksums.mk`: automatically delete old checksums before adding new checksums

### DIFF
--- a/contrib/refresh_checksums.mk
+++ b/contrib/refresh_checksums.mk
@@ -51,7 +51,7 @@ endef
 # note that `"src"` is a special triplet value.
 # if $(3) is "assert", we set BINARYBUILDER_LLVM_ASSERTS=1
 define checksum_dep
-checksum-$(1)-$(2)-$(3):
+checksum-$(1)-$(2)-$(3): clean-$(1)
 	-+$(MAKE) $(QUIET_MAKE) -C "$(JULIAHOME)/deps" $(call make_flags,$(1),$(2),$(3)) checksum-$(1)
 .PHONY: checksum-$(1)-$(2)-$(3)
 
@@ -112,6 +112,9 @@ pack-checksum-llvm pack-checksum-unwind: | pack-checksum-llvmunwind
 # and the name for LLVMLibUnwind is awkward, so handle that with a regex
 pack-checksum-llvmunwind: | pack-checksum-llvm.*unwind
 	cd "$(JULIAHOME)/deps/checksums" && mv 'llvm.*unwind' llvmunwind
+
+clean-%: FORCE
+	-rm "$(JULIAHOME)/deps/checksums"/'$*'
 
 # define how to pack parallel checksums into a single file format
 pack-checksum-%: FORCE


### PR DESCRIPTION
Fixes #43140
Extracted from part of 223ebd58cc97bf948617c4ae6f13eee60fca8d31

I tested this out a little bit locally, and it seems to work correctly.