### PR TITLE
inference: use `ssa_def_slot` for `InterConditional` propagation

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -280,7 +280,7 @@ function from_interprocedural!(@nospecialize(rt), sv::InferenceState, arginfo::A
         if maybecondinfo === nothing
             rt = widenconditional(rt)
         else
-            rt = from_interconditional(rt, arginfo, maybecondinfo)
+            rt = from_interconditional(rt, sv, arginfo, maybecondinfo)
         end
     end
     @assert !(rt isa InterConditional) "invalid lattice element returned from inter-procedural context"
@@ -295,7 +295,7 @@ function collect_limitations!(@nospecialize(typ), sv::InferenceState)
     return typ
 end
 
-function from_interconditional(@nospecialize(typ), (; fargs, argtypes)::ArgInfo, @nospecialize(maybecondinfo))
+function from_interconditional(@nospecialize(typ), sv::InferenceState, (; fargs, argtypes)::ArgInfo, @nospecialize(maybecondinfo))
     fargs === nothing && return widenconditional(typ)
     slot = 0
     vtype = elsetype = Any
@@ -303,7 +303,7 @@ function from_interconditional(@nospecialize(typ), (; fargs, argtypes)::ArgInfo,
     for i in 1:length(fargs)
         # find the first argument which supports refinement,
         # and intersect all equivalent arguments with it
-        arg = fargs[i]
+        arg = ssa_def_slot(fargs[i], sv)
         arg isa SlotNumber || continue # can't refine
         old = argtypes[i]
         old isa Type || continue # unlikely to refine
@@ -590,7 +590,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter, resul
                 return nothing
             end
         end
-        inf_result = InferenceResult(mi, arginfo, va_override)
+        inf_result = InferenceResult(mi, (arginfo, sv), va_override)
         if !any(inf_result.overridden_by_const)
             add_remark!(interp, sv, "[constprop] Could not handle constant info in matching_cache_argtypes")
             return nothing
@@ -630,7 +630,7 @@ function maybe_get_const_prop_profitable(interp::AbstractInterpreter, result::Me
         add_remark!(interp, sv, "[constprop] Disabled by argument and rettype heuristics")
         return nothing
     end
-    all_overridden = is_all_overridden(arginfo)
+    all_overridden = is_all_overridden(arginfo, sv)
     if !force && !const_prop_function_heuristic(interp, f, arginfo, nargs, all_overridden, sv)
         add_remark!(interp, sv, "[constprop] Disabled by function heuristic")
         return nothing
@@ -682,11 +682,11 @@ end
 
 # determines heuristically whether if constant propagation can be worthwhile
 # by checking if any of given `argtypes` is "interesting" enough to be propagated
-function const_prop_argument_heuristic(_::AbstractInterpreter, (; fargs, argtypes)::ArgInfo, _::InferenceState)
+function const_prop_argument_heuristic(_::AbstractInterpreter, (; fargs, argtypes)::ArgInfo, sv::InferenceState)
     for i in 1:length(argtypes)
         a = argtypes[i]
         if isa(a, Conditional) && fargs !== nothing
-            is_const_prop_profitable_conditional(a, fargs) && return true
+            is_const_prop_profitable_conditional(a, fargs, sv) && return true
         else
             a = widenconditional(a)
             has_nontrivial_const_info(a) && is_const_prop_profitable_arg(a) && return true
@@ -710,8 +710,8 @@ function is_const_prop_profitable_arg(@nospecialize(arg))
     return isa(val, Symbol) || isa(val, Type) || (!isa(val, String) && !ismutable(val))
 end
 
-function is_const_prop_profitable_conditional(cnd::Conditional, fargs::Vector{Any})
-    slotid = find_constrained_arg(cnd, fargs)
+function is_const_prop_profitable_conditional(cnd::Conditional, fargs::Vector{Any}, sv::InferenceState)
+    slotid = find_constrained_arg(cnd, fargs, sv)
     if slotid !== nothing
         return true
     end
@@ -721,18 +721,22 @@ function is_const_prop_profitable_conditional(cnd::Conditional, fargs::Vector{An
     return isa(widenconditional(cnd), Const)
 end
 
-function find_constrained_arg(cnd::Conditional, fargs::Vector{Any})
-    slot = cnd.var
-    return findfirst(fargs) do @nospecialize(x)
-        x === slot
+function find_constrained_arg(cnd::Conditional, fargs::Vector{Any}, sv::InferenceState)
+    slot = slot_id(cnd.var)
+    for i in 1:length(fargs)
+        arg = ssa_def_slot(fargs[i], sv)
+        if isa(arg, SlotNumber) && slot_id(arg) == slot
+            return i
+        end
     end
+    return nothing
 end
 
 # checks if all argtypes has additional information other than what `Type` can provide
-function is_all_overridden((; fargs, argtypes)::ArgInfo)
+function is_all_overridden((; fargs, argtypes)::ArgInfo, sv::InferenceState)
     for a in argtypes
         if isa(a, Conditional) && fargs !== nothing
-            is_const_prop_profitable_conditional(a, fargs) || return false
+            is_const_prop_profitable_conditional(a, fargs, sv) || return false
         else
             a = widenconditional(a)
             is_forwardable_argtype(a) || return false

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -21,7 +21,8 @@ end
 # to return a valid value for `cache_lookup(linfo, argtypes, cache).argtypes`,
 # so that we can construct cache-correct `InferenceResult`s in the first place.
 function matching_cache_argtypes(
-    linfo::MethodInstance, (; fargs, argtypes)::ArgInfo, va_override::Bool)
+    linfo::MethodInstance, (arginfo, sv)#=::Tuple{ArgInfo,InferenceState}=#, va_override::Bool)
+    (; fargs, argtypes) = arginfo
     @assert isa(linfo.def, Method) # ensure the next line works
     nargs::Int = linfo.def.nargs
     cache_argtypes, overridden_by_const = matching_cache_argtypes(linfo, nothing, va_override)
@@ -32,7 +33,7 @@ function matching_cache_argtypes(
         # forward `Conditional` if it conveys a constraint on any other argument
         if isa(argtype, Conditional) && fargs !== nothing
             cnd = argtype
-            slotid = find_constrained_arg(cnd, fargs)
+            slotid = find_constrained_arg(cnd, fargs, sv)
             if slotid !== nothing
                 # using union-split signature, we may be able to narrow down `Conditional`
                 sigt = widenconst(slotid > nargs ? argtypes[slotid] : cache_argtypes[slotid])

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -35,7 +35,7 @@ mutable struct InferenceResult
     src #::Union{CodeInfo, OptimizationState, Nothing} # if inferred copy is available
     valid_worlds::WorldRange # if inference and optimization is finished
     function InferenceResult(linfo::MethodInstance,
-                             arginfo::Union{Nothing,ArgInfo} = nothing,
+                             arginfo#=::Union{Nothing,Tuple{ArgInfo,InferenceState}}=# = nothing,
                              va_override::Bool = false)
         argtypes, overridden_by_const = matching_cache_argtypes(linfo, arginfo, va_override)
         return new(linfo, argtypes, overridden_by_const, Any, nothing, WorldRange())

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1841,6 +1841,16 @@ end
         0
     end == Any[Int]
 
+    # slot as SSA
+    isaT(x, T) = isa(x, T)
+    @test Base.return_types((Any,Int)) do a, b
+        c = a
+        if isaT(c, typeof(b))
+            return c # c::Int
+        end
+        return 0
+    end |> only === Int
+
     # with Base functions
     @test Base.return_types((Any,)) do a
         Base.Fix2(isa, Int)(a) && return a # a::Int
@@ -2121,6 +2131,12 @@ end
     @test Base.return_types((Any,Int,)) do x, y
         ifelse(isa(x, Int), x, y)
     end |> only == Int
+
+    # slot as SSA
+    @test Base.return_types((Any,Vector{Any})) do x, y
+        z = x
+        ifelselike(isa(z, Int), z, length(y))
+    end |> only === Int
 end
 
 # Equivalence of Const(T.instance) and T for singleton types


### PR DESCRIPTION
This tweak should allow constraint propagation in following kind of cases:
```julia
julia> isaT(x, T) = isa(x, T);

# backward propagation
julia> @test Base.return_types((Any,Int)) do a, b
           c = a
           if isaT(c, typeof(b))
               return c # c::Int
           end
           return 0
       end |> only === Int;

# forward propagation
julia> @test Base.return_types((Any,Vector{Any})) do x, y
           z = x
           ifelse(isa(z, Int), z, length(y))
       end |> only === Int;
```