### PR TITLE
In nested macros, ignore locals in the outer macro when gensym-ing the inner macro

### DIFF
--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -438,7 +438,7 @@
              (let ((parent-scope (cons (list env m) parent-scope))
                    (body (cadr e))
                    (m (caddr e)))
-              (resolve-expansion-vars-with-new-env body env m parent-scope inarg #t)))
+              (resolve-expansion-vars-with-new-env body '() m parent-scope inarg #t)))
            ((tuple)
             (cons (car e)
                   (map (lambda (x)

--- a/test/core.jl
+++ b/test/core.jl
@@ -2056,6 +2056,32 @@ end
 x6074 = 6074
 @test @X6074() == 6074
 
+# issue #43151
+macro X43151_nested()
+    quote my_value = "from_nested_macro" end
+end
+macro X43151_parent()
+    quote
+        my_value = "from_parent_macro"
+        @X43151_nested()
+        my_value
+    end
+end
+@test @X43151_parent() == "from_parent_macro"
+
+# also issue #43151
+macro X43151_nested_escaping()
+    quote $(esc(:my_value)) = "from_nested_macro" end
+end
+macro X43151_parent_escaping()
+    quote
+        my_value = "from_parent_macro"
+        @X43151_nested_escaping()
+        my_value
+    end
+end
+@test @X43151_parent_escaping() == "from_nested_macro"
+
 # issue #5536
 test5536(a::Union{Real, AbstractArray}...) = "Splatting"
 test5536(a::Union{Real, AbstractArray}) = "Non-splatting"


### PR DESCRIPTION
Currently, nested macros are macro-hygiene-ed like they are in the same scope as the outer macro.
Not sure if that is intentional, but it feels like it shouldn't.

Example:

```julia
macro assigns_to_my_value()
	quote my_value = :from_nested_macro end
end

macro has_my_value()
	quote
		my_value = :from_outer_macro
		@assigns_to_my_value()
		my_value
	end
end

@has_my_value()
```

`@has_my_value()` currently yields `:from_nested_macro`, as it is expands to:

```julia
begin
    var"#1#my_value" = :from_outer_macro
    begin
        var"#1#my_value" = :from_nested_macro
    end
    var"#1#my_value"
end
```

---

This PR makes it so nested `hygienic-scope` will get their own "env" for assigning gensym variables.
This way `@has_my_value()` returns `:from_outer_macro` as I was expecting.
`esc(...)` in `@assigns_to_my_value` does put it in the `@has_my_value` scope, returning `:from_nested_macro`, also as expected.

Should I also make a backport PR for this?