### PR TITLE
Allow `X.@x() do; end` syntax

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1509,6 +1509,16 @@ let ex = Meta.parse("@test27521(2) do y; y; end")
     @test macroexpand(@__MODULE__, ex) == Expr(:tuple, fex, 2)
 end
 
+# issue #43018
+module M43018
+    macro test43018(fn)
+        quote $(fn)() end
+    end
+end
+@test :(@M43018.test43018() do; end) == :(M43018.@test43018() do; end)
+@test @macroexpand(@M43018.test43018() do; end) == @macroexpand(M43018.@test43018() do; end)
+@test @M43018.test43018() do; 43018 end == 43018
+
 # issue #27129
 f27129(x = 1) = (@inline; x)
 for meth in methods(f27129)


### PR DESCRIPTION
Fix for https://github.com/JuliaLang/julia/issues/43018

Apply the same "fix" that makes `X.@x()` work by transforming it into `@X.x()`,
now does the same for `X.@x() do; end` -> `@X.x() do; end`.