### PR TITLE
fix bug in fma_emulated

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -370,7 +370,9 @@ end
 function fma_emulated(a::Float64, b::Float64,c::Float64)
     abhi, ablo = twomul(a,b)
     if !isfinite(abhi+c) || isless(abs(abhi), nextfloat(0x1p-969)) || issubnormal(a) || issubnormal(b)
-        (isfinite(a) && isfinite(b) && isfinite(c)) || return abhi+c
+        if !isfinite(c)
+            return (isfinite(a) && isfinite(b)) ? c : abhi+c
+        end
         (iszero(a) || iszero(b)) && return abhi+c
         bias = exponent(a) + exponent(b)
         c_denorm = ldexp(c, -bias)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -370,8 +370,9 @@ end
 function fma_emulated(a::Float64, b::Float64,c::Float64)
     abhi, ablo = twomul(a,b)
     if !isfinite(abhi+c) || isless(abs(abhi), nextfloat(0x1p-969)) || issubnormal(a) || issubnormal(b)
-        if !isfinite(c)
-            return (isfinite(a) && isfinite(b)) ? c : abhi+c
+        aandbfinite = isfinite(a) && isfinite(b)
+        if !(isfinite(c) && aandbfinite)
+            return aandbfinite ? c : abhi+c
         end
         (iszero(a) || iszero(b)) && return abhi+c
         bias = exponent(a) + exponent(b)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1296,6 +1296,8 @@ end
                 @test func(floatmax(T), T(2), -floatmax(T)) === floatmax(T)
                 @test func(floatmax(T), T(1), eps(floatmax((T)))) === T(Inf)
                 @test func(T(Inf), T(Inf), T(Inf)) === T(Inf)
+                @test func(floatmax(T), floatmax(T), -T(Inf)) === -T(Inf)
+                @test func(floatmax(T), -floatmax(T), T(Inf)) === T(Inf)
                 @test isnan_type(T, func(T(Inf), T(1), -T(Inf)))
                 @test isnan_type(T, func(T(Inf), T(0), -T(0)))
                 @test func(-zero(T), zero(T), -zero(T)) === -zero(T)


### PR DESCRIPTION
previously `Base.fma_emulated(floatmax(Float64), floatmax(Float64), -Inf)` returned `NaN` instead of `-Inf`