### PR TITLE
Remove stale `cglobal(:jl_tls_states)` test

### DIFF
--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -11,8 +11,6 @@ const options = [
     "--framework"
 ];
 
-threadingOn() = ccall(:jl_threading_enabled, Cint, ()) != 0
-
 function shell_escape(str)
     str = replace(str, "'" => "'\''")
     return "'$str'"

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -460,7 +460,6 @@
     XX(jl_task_stack_buffer) \
     XX(jl_test_cpu_feature) \
     XX(jl_threadid) \
-    XX(jl_threading_enabled) \
     XX(jl_throw) \
     XX(jl_throw_out_of_memory_error) \
     XX(jl_too_few_args) \

--- a/src/sys.c
+++ b/src/sys.c
@@ -916,11 +916,6 @@ JL_DLLEXPORT size_t jl_maxrss(void)
 #endif
 }
 
-JL_DLLEXPORT int jl_threading_enabled(void)
-{
-    return 1;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -517,15 +517,6 @@ if cfunction_closure
     test_thread_cfunction()
 end
 
-# Compare the two ways of checking if threading is enabled.
-# `jl_tls_states` should only be defined on non-threading build.
-if ccall(:jl_threading_enabled, Cint, ()) == 0
-    @test nthreads() == 1
-    cglobal(:jl_tls_states) != C_NULL
-else
-    @test_throws ErrorException cglobal(:jl_tls_states)
-end
-
 function test_thread_range()
     a = zeros(Int, nthreads())
     @threads for i in 1:threadid()


### PR DESCRIPTION
It looks like the test

https://github.com/JuliaLang/julia/blob/22a192c197883b0e08df51e2e04b1ed35763d410/test/threads_exec.jl#L520-L527

is stale because there are no `jl_tls_states` anymore except in this test file:

```console
$ git grep '\bjl_tls_states\b'
test/threads_exec.jl:# `jl_tls_states` should only be defined on non-threading build.
test/threads_exec.jl:    cglobal(:jl_tls_states) != C_NULL
test/threads_exec.jl:    @test_throws ErrorException cglobal(:jl_tls_states)
```

Skipping the trivial patch #32284, it looks like the above test is 5-year old #17454.

It also looks like `jl_threading_enabled` can only return `1` nowadays. So I guess we can just delete this test?

cc @yuyichao