### PR TITLE
`Base.runtests`: rename the `--force-net` option to `--ci`

### DIFF
--- a/.buildkite/pipelines/main/platforms/tester_linux.yml
+++ b/.buildkite/pipelines/main/platforms/tester_linux.yml
@@ -69,21 +69,21 @@ steps:
       export NETWORK_RELATED_TESTS="Artifacts Downloads download LazyArtifacts LibGit2/online Pkg"
 
       if [[   "${GROUP?}" == "all" ]]; then
-        export TESTS="all LibGit2/online --force-net"
+        export TESTS="all LibGit2/online --ci"
       elif [[   "${GROUP?}" == "all_except_pkg" ]]; then
-        export TESTS="all LibGit2/online --force-net --skip Pkg"
+        export TESTS="all LibGit2/online --ci --skip Pkg"
       elif [[   "${GROUP?}" == "g1" ]]; then
         # Group 1: ALL tests EXCEPT the network-related tests.
-        export TESTS="all --force-net --skip $${NETWORK_RELATED_TESTS:?}"
+        export TESTS="all --ci --skip $${NETWORK_RELATED_TESTS:?}"
       elif [[ "${GROUP?}" == "g2" ]]; then
         # Group 2: ONLY the network-related tests.
         # In Group 2, we use whatever the default setting is with regards to the Pkg server.
-        export TESTS="$${NETWORK_RELATED_TESTS:?} --force-net"
+        export TESTS="$${NETWORK_RELATED_TESTS:?} --ci"
       elif [[ "${GROUP?}" == "g3" ]]; then
         # Group 3: only Pkg.
         # In Group 3, we explicitly opt-out of the Pkg server.
         # The purpose of group 3 is to test the non-Pkg-server codepaths of Pkg.
-        export TESTS="Pkg --force-net"
+        export TESTS="Pkg --ci"
         export JULIA_PKG_SERVER=""
       else
         echo "Invalid value for GROUP: ${GROUP?}"

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -97,12 +97,11 @@ function choosetests(choices = [])
 
                   Or prefix a name with `-` (such as `-core`) to skip a particular test.
                 """)
-            tests = []
-            net_on = false
-            exit_on_error = false
-            use_revise = false
-            seed = UInt128(0)
-            return (; tests, net_on, exit_on_error, use_revise, seed)
+            return (; tests = [],
+                      net_on = false,
+                      exit_on_error = false,
+                      use_revise = false,
+                      seed = UInt128(0))
         elseif startswith(t, "--")
             error("unknown option: $t")
         elseif startswith(t, "-")

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -28,11 +28,10 @@ const TESTNAMES = [
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
         "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
-        "smallarrayshrink", "opaque_closure", "filesystem", "download"
+        "smallarrayshrink", "opaque_closure", "filesystem", "download",
 ]
 
 """
-
 `(; tests, net_on, exit_on_error, seed) = choosetests(choices)` selects a set of tests to be
 run. `choices` should be a vector of test names; if empty or set to
 `["all"]`, all tests are selected.
@@ -65,7 +64,7 @@ function choosetests(choices = [])
     exit_on_error = false
     use_revise = false
     seed = rand(RandomDevice(), UInt128)
-    force_net = false
+    ci_option_passed = false
     dryrun = false
 
     for (i, t) in enumerate(choices)
@@ -77,9 +76,9 @@ function choosetests(choices = [])
         elseif t == "--revise"
             use_revise = true
         elseif startswith(t, "--seed=")
-            seed = parse(UInt128, t[8:end])
-        elseif t == "--force-net"
-            force_net = true
+            seed = parse(UInt128, t[(length("--seed=") + 1):end])
+        elseif t == "--ci"
+            ci_option_passed = true
         elseif t == "--help-list"
             dryrun = true
         elseif t == "--help"
@@ -98,7 +97,12 @@ function choosetests(choices = [])
 
                   Or prefix a name with `-` (such as `-core`) to skip a particular test.
                 """)
-            return [], false, false, false, UInt128(0)
+            tests = []
+            net_on = false
+            exit_on_error = false
+            use_revise = false
+            seed = UInt128(0)
+            return (; tests, net_on, exit_on_error, use_revise, seed)
         elseif startswith(t, "--")
             error("unknown option: $t")
         elseif startswith(t, "-")
@@ -129,8 +133,8 @@ function choosetests(choices = [])
        end
     end
 
-    explicit_pkg     = "Pkg"            in tests
-    explicit_libgit2 = "LibGit2/online" in tests
+    explicit_pkg            = "Pkg"            in tests
+    explicit_libgit2_online = "LibGit2/online" in tests
 
     filtertests!(tests, "unicode", ["unicode/utf8"])
     filtertests!(tests, "strings", ["strings/basic", "strings/search", "strings/util",
@@ -151,22 +155,25 @@ function choosetests(choices = [])
         filter!(x -> (x != "Profile"), tests)
     end
 
-    net_required_for = ["download", "Sockets", "LibGit2", "LibCURL", "Downloads",
-                        "Artifacts", "LazyArtifacts"]
+    net_required_for = [
+        "Artifacts",
+        "Downloads",
+        "LazyArtifacts",
+        "LibCURL",
+        "LibGit2",
+        "Sockets",
+        "download",
+    ]
     net_on = true
     try
         ipa = getipaddr()
-    catch ex
-        if force_net
-            msg = "Networking is unavailable, and the `--force-net` option was passed"
-            @error msg
+    catch
+        if ci_option_passed
+            @error("Networking unavailable, but `--ci` was passed")
             rethrow()
         end
-        @warn "Networking unavailable: Skipping tests [" * join(net_required_for, ", ") * "]"
         net_on = false
-    end
-
-    if !net_on
+        @warn "Networking unavailable: Skipping tests [" * join(net_required_for, ", ") * "]"
         filter!(!in(net_required_for), tests)
     end
 
@@ -194,8 +201,8 @@ function choosetests(choices = [])
     filter!(x -> (x != "stdlib" && !(x in STDLIBS)) , tests)
     append!(tests, new_tests)
 
-    requested_all || explicit_pkg     || filter!(x -> x != "Pkg",            tests)
-    requested_all || explicit_libgit2 || filter!(x -> x != "LibGit2/online", tests)
+    requested_all || explicit_pkg            || filter!(x -> x != "Pkg",            tests)
+    requested_all || explicit_libgit2_online || filter!(x -> x != "LibGit2/online", tests)
 
     # Filter out tests from the test groups in the stdlibs
     filter!(!in(tests), unhandled)


### PR DESCRIPTION
Right now, we have the `--force-net` flag. When the `--force-net` flag is passed, if networking is not available, we throw an error. The motivation for the `--force-net` flag is CI environments, where we want CI to fail immediately if networking is not available.

It occurs to me that we might want to use this flag for more things in the future, in addition to just networking.

So this PR renames the `--force-net` flag to `--ci`.

The `--force-net` flag is not part of the public API, so this change is fine to make.