### PR TITLE
Add `@inline` for `Diagonal`'s 2-arg `l/rdiv!` to enable auto vectorization

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -357,7 +357,7 @@ end
 
 /(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(similar(A, promote_op(/, eltype(A), eltype(D)), size(A)), A, D)
 
-rdiv!(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(A, A, D)
+rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
 function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     require_one_based_indexing(A)
@@ -378,7 +378,7 @@ end
 
 \(D::Diagonal, B::AbstractVecOrMat) = ldiv!(similar(B, promote_op(\, eltype(D), eltype(B)), size(B)), D, B)
 
-ldiv!(D::Diagonal, B::AbstractVecOrMat) = ldiv!(B, D, B)
+ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
     require_one_based_indexing(A, B)
     d = length(D.diag)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -381,14 +381,18 @@ end
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
     require_one_based_indexing(A, B)
-    d = length(D.diag)
+    dd = D.diag
+    d = length(dd)
     m, n = size(A, 1), size(A, 2)
     m′, n′ = size(B, 1), size(B, 2)
     m == d || throw(DimensionMismatch("right hand side has $m rows but D is $d by $d"))
     (m, n) == (m′, n′) || throw(DimensionMismatch("expect output to be $m by $n, but got $m′ by $n′"))
     j = findfirst(iszero, D.diag)
     isnothing(j) || throw(SingularException(j))
-    B .= D.diag .\ A
+    @inbounds for j = 1:n, i = 1:m
+        B[i, j] = dd[i] \ A[i, j]
+    end
+    B
 end
 
 # Optimizations for \, / between Diagonals


### PR DESCRIPTION
On master, `Diagnal`'s 2-arg `l/rdiv!` call their 3-arg version for code reuse.
But as shown in #43153, non-inlined code blocks LLVM's auto vectorization, so the 2-arg `l/rdiv!` should be slower than before.
This PR first add `@inline` at the call side to fix the regression. But it turns out that `broadcast` based `ldiv!` still blocks vectorization. So I have to replace it with a for loop version.
Some benchmark:
```julia
julia> A = randn(128, 128); D = Diagonal(ones(128));
julia> @btime rdiv!($A, $D);
  7.275 μs (0 allocations: 0 bytes) # about 14 μs on master
julia> @btime ldiv!($D, $A);
  7.350 μs (0 allocations: 0 bytes) # about 14 μs on master
```