### PR TITLE
Avoid `-Wunused-function` on macOS for some `Float16` intrinsics

### DIFF
--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -15,7 +15,9 @@
 const unsigned int host_char_bit = 8;
 
 // float16 intrinsics
-// TODO: use LLVM's compiler-rt
+// TODO: use LLVM's compiler-rt on all platforms (Xcode already links compiler-rt)
+
+#if !defined(_OS_DARWIN_)
 
 static inline float half_to_float(uint16_t ival) JL_NOTSAFEPOINT
 {
@@ -185,8 +187,6 @@ static inline uint16_t float_to_half(float param) JL_NOTSAFEPOINT
     }
     return h;
 }
-
-#if !defined(_OS_DARWIN_)   // xcode already links compiler-rt
 
 JL_DLLEXPORT float __gnu_h2f_ieee(uint16_t param)
 {


### PR DESCRIPTION
We're defining `half_to_float` and `float_to_half` unconditionally but only ever calling them on non-Mac platforms, so Clang produces unused function warnings during the build on macOS. To fix this, we can just move the platform check to encompass the definitions in addition to the uses.

These functions were added in https://github.com/JuliaLang/julia/pull/37510. Do let me know if having these outside of the platform check was intentional and/or would have adverse downstream effects. If not, this should be safe (but far from critical) to backport to 1.6 and 1.7.