### PR TITLE
Relocate `llvm-version.h` in codegen to avoid a warning

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,6 +1,5 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#include "llvm-version.h"
 #include "platform.h"
 #if defined(_OS_WINDOWS_)
 // use ELF because RuntimeDyld COFF i686 support didn't exist
@@ -63,6 +62,9 @@
 #include <llvm/IR/Verifier.h> // for llvmcall validation
 #include <llvm/IR/PassTimingInfo.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
+
+// Included after LLVM support to avoid redefinition warnings
+#include "llvm-version.h"
 
 // C API
 #include <llvm-c/Types.h>


### PR DESCRIPTION
Our `llvm-version.h` defines `LLVM_ENABLE_STATS` if it's not already defined. However, we're `#include`ing that file in `codegen.cpp` before we `#include` the LLVM headers that define it. That means it gets defined twice, triggering a `-Wmacro-redefined` warning. If we move the inclusion of our file to below the inclusion of LLVM's headers, we just use their definition and avoid a warning.