### PR TITLE
RFC: Make self-inplace broadcast vectorlizable based on our effect inference

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1556,6 +1556,8 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
     elseif is_return_type(f)
         tristate_merge!(sv, Effects()) # TODO
         return return_type_tfunc(interp, argtypes, sv)
+    elseif is_infer_effects(f)
+        return infer_effects_tfunc(interp, argtypes, sv)
     elseif la == 2 && istopfunction(f, :!)
         # handle Conditional propagation through !Bool
         aty = argtypes[2]

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -41,6 +41,8 @@ include("options.jl")
 # core operations & types
 function return_type end # promotion.jl expects this to exist
 is_return_type(@Core.nospecialize(f)) = f === return_type
+function infer_effects end
+is_infer_effects(@Core.nospecialize(f)) = f === infer_effects
 include("promotion.jl")
 include("tuple.jl")
 include("pair.jl")

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -202,7 +202,7 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src::Union{IRC
             f = argextype(args[1], src)
             f = singleton_type(f)
             f === nothing && return false
-            is_return_type(f) && return true
+            (is_return_type(f) || is_infer_effects(f)) && return true
             if isa(f, IntrinsicFunction)
                 intrinsic_effect_free_if_nothrow(f) || return false
                 return intrinsic_nothrow(f,

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1154,7 +1154,7 @@ function process_simple!(ir::IRCode, idx::Int, state::InliningState, todo::Vecto
         ir[SSAValue(idx)][:inst] = lateres.val
         check_effect_free!(ir, idx, lateres.val, rt)
         return nothing
-    elseif is_return_type(sig.f)
+    elseif is_return_type(sig.f) || is_infer_effects(sig.f)
         check_effect_free!(ir, idx, stmt, rt)
         return nothing
     end
@@ -1491,7 +1491,7 @@ function late_inline_special_case!(
         unionall_call = Expr(:foreigncall, QuoteNode(:jl_type_unionall), Any, svec(Any, Any),
             0, QuoteNode(:ccall), stmt.args[2], stmt.args[3])
         return SomeCase(unionall_call)
-    elseif is_return_type(f)
+    elseif is_return_type(f) || is_infer_effects(f)
         if isconstType(type)
             return SomeCase(quoted(type.parameters[1]))
         elseif isa(type, Const)

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -175,4 +175,15 @@ struct ReturnTypeCallInfo
     info::Any
 end
 
+"""
+    info::InferEffectsCallInfo
+
+Represents a resolved call of `Core.Compiler.infer_effects`.
+`info.call` wraps the info corresponding to the call that `Core.Compiler.infer_effects` call
+was supposed to analyze.
+"""
+struct InferEffectsCallInfo
+    info::Any
+end
+
 @specialize

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1079,3 +1079,23 @@ end
     y = randn(2)
     @inferred(test(x, y)) == [0, 0]
 end
+
+@testset "Inplace Broadcast vectorizaion" begin
+    bc = Broadcast.instantiate(Broadcast.broadcasted(+,[1],view([1],1:1)))
+    @test Broadcast.isivdepsafe(bc)
+    bc = Broadcast.preprocess(nothing, bc)
+    @test Broadcast.isivdepsafe(bc)
+    a = Ref(1)
+    f(x, y) = (a[i] = -a[i]; x + y + a[i];)
+    bc = Broadcast.instantiate(Broadcast.broadcasted(f,[1],view([1],1:1)))
+    bc = Broadcast.preprocess(nothing, bc)
+    @test !Broadcast.isivdepsafe(bc)
+    a = randn(3,3)
+    @test Broadcast.isivdepsafe(a)
+    a = view(a,:,1:3)
+    @test Broadcast.isivdepsafe(a)
+    a = reshape(a, :)
+    @test Broadcast.isivdepsafe(a)
+    a = reinterpret(Int, a)
+    @test Broadcast.isivdepsafe(a)
+end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1069,3 +1069,16 @@ end
 @test fully_eliminated() do
     issue41694(2)
 end
+
+# Make sure `isivdepsafe` for Broadcast is fully_eliminated after `instantiate`
+bc = Base.broadcasted(+,randn(1),randn(1))
+bc = Base.broadcasted(sin,bc)
+bc = Base.broadcasted(exp,bc)
+bc = Base.broadcasted(^,bc,randn(1))
+bc = Base.broadcasted(-,bc,randn(1))
+@test !fully_eliminated(Broadcast.isivdepsafe, Base.typesof(bc))
+bc = Broadcast.instantiate(bc)
+@test fully_eliminated(Broadcast.isivdepsafe, Base.typesof(bc))
+bc = Broadcast.preprocess(nothing, bc)
+@test fully_eliminated(Broadcast.isivdepsafe, Base.typesof(bc))
+@test Broadcast.isivdepsafe(bc)


### PR DESCRIPTION
As found by #43153, self-inplace broadcast with dimension larger than 1 won't be vectorlized by LLVM, as it fails to prove `a[I]` and `extrude(a)[I]` share the same access pattern.
#43852 makes it possible to fix it on julia side, as `@simd ivdep` should be safe if `bc[I]` is proven to be effect_free, and `dest` is not self-aliased.

Currently the self-aliasing check for `dest` is pure type-based to avoid binary bloat.
