### PR TITLE
Fix `-Wnon-c-typedef-for-linkage` from `jl_codegen_params_t`

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -52,7 +52,7 @@ struct jl_returninfo_t {
 typedef std::vector<std::tuple<jl_code_instance_t*, jl_returninfo_t::CallingConv, unsigned, llvm::Function*, bool>> jl_codegen_call_targets_t;
 typedef std::tuple<std::unique_ptr<Module>, jl_llvm_functions_t> jl_compile_result_t;
 
-typedef struct {
+typedef struct _jl_codegen_params_t {
     typedef StringMap<GlobalVariable*> SymMapGV;
     // outputs
     jl_codegen_call_targets_t workqueue;


### PR DESCRIPTION
Currently `jl_codegen_params_t` is defined as `typedef struct {...}` without a tag name. If we give it an underscore-prefixed tag name (as is the convention used in our other type declarations), Clang will stop complaining about having to assume what the name should be for linkage.

I am apparently on a quest to silence Clang warnings.