### PR TITLE
When giving - as the program, read code from standard in.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ Command-line option changes
 * New option `--strip-ir` to remove the compiler's IR (intermediate representation) of source
   code when building a system image. The resulting image will only work if `--compile=all` is
   used, or if all needed code is precompiled ([#42925]).
+* When the program file is `-` the code to be executed is read from standard in ([#43191]).
 
 Multi-threading changes
 -----------------------

--- a/base/client.jl
+++ b/base/client.jl
@@ -301,7 +301,11 @@ function exec_options(opts)
             exit_on_sigint(true)
         end
         try
-            include(Main, PROGRAM_FILE)
+            if PROGRAM_FILE == "-"
+                include_string(Main, read(stdin, String), "stdin")
+            else
+                include(Main, PROGRAM_FILE)
+            end
         catch
             invokelatest(display_error, scrub_repl_backtrace(current_exceptions()))
             if !is_interactive::Bool


### PR DESCRIPTION
I couldn't figure out another way of passing args while reading from stdin. This seems to be what python does (for example):
```
$ julia - foo bar <<EOF
println(ARGS)
EOF
["foo", "bar"]

$ python - foo bar <<EOF
import sys; print(sys.argv)
EOF
['-', 'foo', 'bar']
```

It is perhaps a bit strange that this takes another code path compared to
```
julia <<EOF
...
EOF
```
since that ends up all the way in here: https://github.com/JuliaLang/julia/blob/ae336abc0ed7e63ab933d0073df28c51e981d8fc/base/client.jl#L412 but not sure it matters much.