### PR TITLE
Clean-up of blas.jl w/o functional changes

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -75,7 +75,7 @@ const libblas = libblastrampoline
 const liblapack = libblastrampoline
 
 import LinearAlgebra
-using LinearAlgebra: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, stride1, chkstride1, axpy!
+using LinearAlgebra: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, stride1, chkstride1
 
 include("lbt.jl")
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -8,7 +8,6 @@ module BLAS
 import ..axpy!, ..axpby!
 import Base: copyto!
 using Base: require_one_based_indexing, USE_BLAS64
-using ..LinearAlgebra.LAPACK.chk_uplo
 
 export
 # Level 1
@@ -76,7 +75,7 @@ const libblas = libblastrampoline
 const liblapack = libblastrampoline
 
 import LinearAlgebra
-import LinearAlgebra: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, stride1, chkstride1, axpy!
+using LinearAlgebra: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, stride1, chkstride1, axpy!
 
 include("lbt.jl")
 
@@ -159,6 +158,13 @@ function check()
     end
 end
 
+"Check that upper/lower (for special matrices) is correctly specified"
+function chkuplo(uplo::AbstractChar)
+    if !(uplo == 'U' || uplo == 'L')
+        throw(ArgumentError("uplo argument must be 'U' (upper) or 'L' (lower), got $uplo"))
+    end
+    uplo
+end
 
 # Level 1
 ## copy

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -12,12 +12,10 @@ const libblastrampoline = "libblastrampoline"
 # of BLAS.get_config()
 const liblapack = libblastrampoline
 
-import ..LinearAlgebra.BLAS.@blasfunc
+using ..LinearAlgebra.BLAS: @blasfunc, chkuplo
 
-import ..LinearAlgebra: BlasFloat, BlasInt, LAPACKException,
-    DimensionMismatch, SingularException, PosDefException, chkstride1, checksquare
-
-using ..LinearAlgebra: triu, tril, dot
+using ..LinearAlgebra: BlasFloat, BlasInt, LAPACKException, DimensionMismatch,
+    SingularException, PosDefException, chkstride1, checksquare,triu, tril, dot
 
 using Base: iszero, require_one_based_indexing
 
@@ -54,14 +52,6 @@ function chkposdef(ret::BlasInt)
     if ret > 0
         throw(PosDefException(ret))
     end
-end
-
-"Check that upper/lower (for special matrices) is correctly specified"
-function chkuplo(uplo::AbstractChar)
-    if !(uplo == 'U' || uplo == 'L')
-        throw(ArgumentError("uplo argument must be 'U' (upper) or 'L' (lower), got $uplo"))
-    end
-    uplo
 end
 
 "Check that {c}transpose is correctly specified"


### PR DESCRIPTION
This PR intends to make our BLAS code a little more consistent and safe. It adds some early checks on meaningful arguments for `uplo` and some `ckstride1` when it seemed necessary.