### PR TITLE
Revert "Relocate `llvm-version.h` in codegen to avoid a warning"

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,5 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include "llvm-version.h"
 #include "platform.h"
 #if defined(_OS_WINDOWS_)
 // use ELF because RuntimeDyld COFF i686 support didn't exist
@@ -62,9 +63,6 @@
 #include <llvm/IR/Verifier.h> // for llvmcall validation
 #include <llvm/IR/PassTimingInfo.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
-
-// Included after LLVM support to avoid redefinition warnings
-#include "llvm-version.h"
 
 // C API
 #include <llvm-c/Types.h>

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -13,14 +13,6 @@
     #error Only LLVM versions >= 11.0.0 are supported by Julia
 #endif
 
-#ifndef LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
-#define LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING 0
-#endif
-
-#ifndef LLVM_ENABLE_STATS
-#define LLVM_ENABLE_STATS 0
-#endif
-
 #ifdef __cplusplus
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 // Added in GCC 9, this warning is annoying


### PR DESCRIPTION
Reverts JuliaLang/julia#43181, because we need this header to know which headers to define