### PR TITLE
optimize: attempt to refine inlining costs

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -464,7 +464,7 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
                 # we might like to penalize non-inferrability, but
                 # tuple iteration/destructuring makes that impossible
                 # return plus_saturate(argcost, isknowntype(extyp) ? 1 : params.inline_nonleaf_penalty)
-                return 0
+                return 1
             elseif (f === Core.arrayref || f === Core.const_arrayref || f === Core.arrayset) && length(ex.args) >= 3
                 atyp = argextype(ex.args[3], src, sptypes, slottypes)
                 return isknowntype(atyp) ? 4 : error_path ? params.inline_error_path_cost : params.inline_nonleaf_penalty
@@ -488,17 +488,29 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
         end
         extyp = line == -1 ? Any : argextype(SSAValue(line), src, sptypes, slottypes)
         if extyp === Union{}
-            return 0
+            return 1
         end
         return error_path ? params.inline_error_path_cost : params.inline_nonleaf_penalty
-    elseif head === :foreigncall || head === :invoke || head == :invoke_modify
+    elseif head === :foreigncall
+        call = ex.args[1]
+        if call isa QuoteNode
+            if call.value === :jl_array_ptr || call.value === :jl_value_ptr
+                return 1 # getting the pointer is very cheap: these could just be intrinsics
+            end
+        end
+        extyp = line == -1 ? Any : argextype(SSAValue(line), src, sptypes, slottypes)
+        error_path && return params.inline_error_path_cost
+        return extyp === Union{} ? 1 : 20
+    elseif head === :invoke || head == :invoke_modify
         # Calls whose "return type" is Union{} do not actually return:
         # they are errors. Since these are not part of the typical
         # run-time of the function, we omit them from
         # consideration. This way, non-inlined error branches do not
         # prevent inlining.
         extyp = line == -1 ? Any : argextype(SSAValue(line), src, sptypes, slottypes)
-        return extyp === Union{} ? 0 : 20
+        extyp === Union{} && return 1
+        error_path && return params.inline_error_path_cost
+        return 20
     elseif head === :(=)
         if ex.args[1] isa GlobalRef
             cost = 20
@@ -533,9 +545,9 @@ function statement_or_branch_cost(@nospecialize(stmt), line::Int, src::Union{Cod
         # loops are generally always expensive
         # but assume that forward jumps are already counted for from
         # summing the cost of the not-taken branch
-        thiscost = dst(stmt.label) < line ? 40 : 0
+        thiscost = dst(stmt.label) < line ? 40 : 1
     elseif stmt isa GotoIfNot
-        thiscost = dst(stmt.dest) < line ? 40 : 0
+        thiscost = dst(stmt.dest) < line ? 40 : 1
     end
     return thiscost
 end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -58,7 +58,7 @@ function add_tfunc(f::Function, minarg::Int, maxarg::Int, @nospecialize(tfunc), 
     push!(T_FFUNC_COST, cost)
 end
 
-add_tfunc(throw, 1, 1, (@nospecialize(x)) -> Bottom, 0)
+add_tfunc(throw, 1, 1, (@nospecialize(x)) -> Bottom, 1)
 
 # the inverse of typeof_tfunc
 # returns (type, isexact, isconcrete, istype)
@@ -1187,7 +1187,7 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
     end
     return Type{<:ft}
 end
-add_tfunc(fieldtype, 2, 3, fieldtype_tfunc, 0)
+add_tfunc(fieldtype, 2, 3, fieldtype_tfunc, 20)
 
 # Like `valid_tparam`, but in the type domain.
 function valid_tparam_type(T::DataType)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -62,10 +62,10 @@ struct OptimizationParams
 
     function OptimizationParams(;
             inlining::Bool = inlining_enabled(),
-            inline_cost_threshold::Int = 100,
+            inline_cost_threshold::Int = 110,
             inline_nonleaf_penalty::Int = 1000,
             inline_tupleret_bonus::Int = 250,
-            inline_error_path_cost::Int = 20,
+            inline_error_path_cost::Int = 10,
             max_methods::Int = 3,
             tuple_splat::Int = 32,
             union_splitting::Int = 4,

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -263,17 +263,17 @@ end
     P
 end
 
-function Base._mapreduce_dim(f, op, init::Base._InitialValue, A::PermutedDimsArray, dims::Colon)
+function Base._mapreduce_dim(f::F, op, init::Base._InitialValue, A::PermutedDimsArray, dims::Colon) where {F}
     Base._mapreduce_dim(f, op, init, parent(A), dims)
 end
 
-function Base.mapreducedim!(f, op, B::AbstractArray{T,N}, A::PermutedDimsArray{T,N,perm,iperm}) where {T,N,perm,iperm}
+function Base.mapreducedim!(f::F, op, B::AbstractArray{T,N}, A::PermutedDimsArray{T,N,perm,iperm}) where {F,T,N,perm,iperm}
     C = PermutedDimsArray{T,N,iperm,perm,typeof(B)}(B) # make the inverse permutation for the output
     Base.mapreducedim!(f, op, C, parent(A))
     B
 end
 
-function Base.showarg(io::IO, A::PermutedDimsArray{T,N,perm}, toplevel) where {T,N,perm}
+function Base.showarg(io::IO, A::PermutedDimsArray{<:Any,<:Any,perm}, toplevel) where {perm}
     print(io, "PermutedDimsArray(")
     Base.showarg(io, parent(A), false)
     print(io, ", ", perm, ')')

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -96,17 +96,17 @@ Each statement gets analyzed for its total cost in a function called
 as follows:
 ```jldoctest; filter=r"tuple.jl:\d+"
 julia> Base.print_statement_costs(stdout, map, (typeof(sqrt), Tuple{Int},)) # map(sqrt, (2,))
-map(f, t::Tuple{Any}) in Base at tuple.jl:179
-  0 1 ─ %1  = Base.getfield(_3, 1, true)::Int64
+map(f, t::Tuple{Any}) in Base at tuple.jl:221
+  1 1 ─ %1  = Base.getfield(_3, 1, true)::Int64
   1 │   %2  = Base.sitofp(Float64, %1)::Float64
   2 │   %3  = Base.lt_float(%2, 0.0)::Bool
-  0 └──       goto #3 if not %3
-  0 2 ─       invoke Base.Math.throw_complex_domainerror(:sqrt::Symbol, %2::Float64)::Union{}
+  1 └──       goto #3 if not %3
+  1 2 ─       invoke Base.Math.throw_complex_domainerror(:sqrt::Symbol, %2::Float64)::Union{}
   0 └──       unreachable
  20 3 ─ %7  = Base.Math.sqrt_llvm(%2)::Float64
-  0 └──       goto #4
-  0 4 ─       goto #5
-  0 5 ─ %10 = Core.tuple(%7)::Tuple{Float64}
+  1 └──       goto #4
+  1 4 ─       goto #5
+  1 5 ─ %10 = Core.tuple(%7)::Tuple{Float64}
   0 └──       return %10
 ```
 


### PR DESCRIPTION
Try to reflect that each statement has a cost, however tiny, but increase the overall threshold to balance it.

@nanosoldier `runbenchmarks(ALL, vs=":master")`