### PR TITLE
Add `unfoldr` to Iterators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,7 +59,7 @@ New library functions
 
 * `hardlink(src, dst)` can be used to create hard links. ([#41639])
 * `diskstat(path=pwd())` can be used to return statistics about the disk. ([#42248])
-* `Iterators.unfoldr(f, init)` can be used to quickly write iterators or as a kind of lazy `while` loop ([#43203])
+* `Iterators.unfold(f, init)` can be used to quickly write iterators or as a kind of lazy `while` loop ([#43203])
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@ New library functions
 
 * `hardlink(src, dst)` can be used to create hard links. ([#41639])
 * `diskstat(path=pwd())` can be used to return statistics about the disk. ([#42248])
+* `Iterators.unfoldr(f, init)` can be used to quickly write iterators or as a kind of lazy `while` loop ([#43203])
 
 New library features
 --------------------

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -22,7 +22,7 @@ import .Base:
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek
 
-export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, partition, unfoldr
+export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, partition, unfold
 
 """
     Iterators.map(f, iterators...)
@@ -1429,20 +1429,20 @@ only(x::NamedTuple) = throw(
 )
 
 """
-    unfoldr(f, init)
+    unfold(f, init)
 
 Iterate values generated from an initial state and a function.
 
 `f` takes a single value and returns `nothing` if it is done emitting elements or `(element, nextstate)` if it is not.
 
-The "dual" of `foldr`: `foldr` reduces an iterable to a summary value, `unfoldr` builds an iterable from an initial value.
+The "dual" of `foldr`: `foldr` reduces an iterable to a summary value, `unfold` builds an iterable from an initial value.
 
 # Examples
 
 ```jldoctest
-julia> using Base.Iterators: unfoldr
+julia> using Base.Iterators: unfold
 
-julia> collect(unfoldr(x -> x > 0 ? (x, x-1) : nothing, 5))
+julia> collect(unfold(x -> x > 0 ? (x, x-1) : nothing, 5))
 5-element Vector{Int64}:
  5
  4
@@ -1452,7 +1452,7 @@ julia> collect(unfoldr(x -> x > 0 ? (x, x-1) : nothing, 5))
 
 julia> # Same output as digits(6, base=2):
 
-julia> unfoldr(6) do n
+julia> unfold(6) do n
            n ≠ 0 ? reverse(divrem(n, 2)) : nothing
        end |> collect
 3-element Vector{Int64}:
@@ -1461,7 +1461,7 @@ julia> unfoldr(6) do n
  1
 ```
 """
-unfoldr(f, init) = Unfold(f, init)
+unfold(f, init) = Unfold(f, init)
 
 struct Unfold{F, T}
     f::F

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1433,7 +1433,10 @@ only(x::NamedTuple) = throw(
 
 Iterate values generated from an initial state and a function.
 
-`f` takes a single value and returns `nothing` if it is done emitting elements or `(element, nextstate)` if it is not.
+`f` takes a single value (the state) and returns `(element, nextstate)` or, if it has finished emitting elements, `nothing`.
+
+`Iterators.map` or a generator like `(√x + 2 for x in 1:10)` are iterable or lazy analogs of `for` loops.
+`unfold` is the iterable or lazy analog of the `while` loop.
 
 The "dual" of `foldr`: `foldr` reduces an iterable to a summary value, `unfold` builds an iterable from an initial value.
 
@@ -1460,6 +1463,35 @@ julia> unfold(6) do n
  1
  1
 ```
+
+# Extended help
+
+The interface for `f` is very similar to the interface required by `iterate`, but `unfold` is simpler to use because it does not require you to define a type.
+You can use this to your advantage when prototyping or writing one-off iterators.
+You may want to define an iterator type instead if you'd like to define `IteratorSize` or `IteratorEltype`; for readability; or if you want to dispatch on the type of your iterator.
+
+`unfold` is related to a `while` loop because:
+
+```julia
+collect(unfold(f, initialstate))
+```
+
+is roughly the same as:
+
+```julia
+acc = []
+state = initialstate
+while true
+    x = f(state)
+    x ≡ nothing && break
+    element, state = x
+    push!(acc, element)
+end
+```
+
+But the `unfold` version may produce a more strictly typed vector and can be easily modified to return a lazy collection by removing `collect()`.
+
+In Haskell and some other functional programming environments, this function is known as `unfoldr`.
 """
 unfold(f, init) = Unfold(f, init)
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -899,3 +899,13 @@ end
     @test last(Iterators.map(identity, 1:3)) == 3
     @test last(Iterators.filter(iseven, (Iterators.map(identity, 1:3)))) == 2
 end
+
+@testset "unfoldr" begin
+    @test collect(unfoldr(x -> x < 5 ? (x, x+1) : nothing, 0)) == 0:4
+    @test collect(unfoldr(("some words in a string", 1)) do (str, start)
+                start ≥ lastindex(str) && return nothing
+                idx = findnext(==(' '), str, start)
+                isnothing(idx) && return (str[start:end], (str, lastindex(str)))
+                return str[start:idx-1], (str, idx+1)
+            end) == split("some words in a string")
+end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -900,9 +900,9 @@ end
     @test last(Iterators.filter(iseven, (Iterators.map(identity, 1:3)))) == 2
 end
 
-@testset "unfoldr" begin
-    @test collect(unfoldr(x -> x < 5 ? (x, x+1) : nothing, 0)) == 0:4
-    @test collect(unfoldr(("some words in a string", 1)) do (str, start)
+@testset "unfold" begin
+    @test collect(unfold(x -> x < 5 ? (x, x+1) : nothing, 0)) == 0:4
+    @test collect(unfold(("some words in a string", 1)) do (str, start)
                 start ≥ lastindex(str) && return nothing
                 idx = findnext(==(' '), str, start)
                 isnothing(idx) && return (str[start:end], (str, lastindex(str)))


### PR DESCRIPTION
I didn't stop to ask if I should.

Inspired by Tamas_Papp's work here: https://discourse.julialang.org/t/julia-equivalence-of-haskells-unfoldr/17834 and a student on exercism.

Searching github, the string `unfoldr` is not used in any Julia code on github before this, so the name doesn't clash. We could also use `unfold`, but that's more likely to clash with something.

In other languages, Elm and Haskell use `unfoldr`. [Elixir](https://hexdocs.pm/elixir/1.12/Stream.html#unfold/2), [Ocaml](https://ocaml.org/api/Seq.html#VALunfold) and [Rust](https://docs.rs/itertools/0.7.8/itertools/fn.unfold.html) (and [this](https://docs.rs/futures/0.2.0-beta/futures/stream/fn.unfold.html)) use `unfold`. Clojure doesn't have it, but a third-party library uses `unfold`.