### PR TITLE
Update to account for better @static

### DIFF
--- a/doc/src/manual/handling-operating-system-variation.md
+++ b/doc/src/manual/handling-operating-system-variation.md
@@ -34,7 +34,7 @@ else
 end
 ```
 
-When nesting conditionals, the `@static` must be repeated for each level 
+When nesting conditionals, the `@static` must be repeated for each level
 (parentheses optional, but recommended for readability):
 
 ```julia

--- a/doc/src/manual/handling-operating-system-variation.md
+++ b/doc/src/manual/handling-operating-system-variation.md
@@ -27,13 +27,15 @@ Complex blocks:
 ```julia
 @static if Sys.islinux()
     linux_specific_thing(a)
+elseif Sys.isapple()
+    apple_specific_thing(a)
 else
     generic_thing(a)
 end
 ```
 
-When chaining conditionals (not including `if`/`elseif`/`end`), the `@static` must be repeated 
-for each level (parentheses optional, but recommended for readability):
+When nesting conditionals, the `@static` must be repeated for each level 
+(parentheses optional, but recommended for readability):
 
 ```julia
 @static Sys.iswindows() ? :a : (@static Sys.isapple() ? :b : :c)

--- a/doc/src/manual/handling-operating-system-variation.md
+++ b/doc/src/manual/handling-operating-system-variation.md
@@ -32,8 +32,8 @@ else
 end
 ```
 
-When chaining conditionals (including `if`/`elseif`/`end`), the `@static` must be repeated for
-each level (parentheses optional, but recommended for readability):
+When chaining conditionals (not including `if`/`elseif`/`end`), the `@static` must be repeated 
+for each level (parentheses optional, but recommended for readability):
 
 ```julia
 @static Sys.iswindows() ? :a : (@static Sys.isapple() ? :b : :c)


### PR DESCRIPTION
This is why I think @static works for `if`/`elseif`/`end`:
```
julia> if Sys.iswindows()
           $6
       elseif Sys.isapple()
           println("Apple.")
       else
           $9
       end
ERROR: syntax: "$" expression outside quote
Stacktrace:
 [1] top-level scope
   @ none:1

julia> @static if Sys.iswindows()
           $6
       elseif Sys.isapple()
           println("Apple.")
       else
           $9
       end
Apple.
```