### PR TITLE
Document Pkg and NetworkOptions environment variables

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -156,6 +156,34 @@ The absolute path `REPL.find_hist_file()` of the REPL's history file. If
 $(DEPOT_PATH[1])/logs/repl_history.jl
 ```
 
+## Pkg.jl
+
+### `JULIA_NUM_PRECOMPILE_TASKS`
+
+The number of parallel tasks to use when precompiling packages. See [`Pkg.precompile`](https://pkgdocs.julialang.org/v1/api/#Pkg.precompile).
+
+### `JULIA_PKG_DEVDIR`
+
+The default directory used by [`Pkg.develop`](https://pkgdocs.julialang.org/v1/api/#Pkg.develop) for downloading packages.
+
+### `JULIA_PKG_IGNORE_HASHES`
+
+If set to `1`, this will ignore incorrect hashes in artifacts. This should be used carefully, as it disables verification of downloads, but can resolve issues when moving files across different types of file systems. See [Pkg.jl issue #2317](https://github.com/JuliaLang/Pkg.jl/issues/2317) for more details.
+
+!!! compat "Julia 1.6"
+    This is only supported in Julia 1.6 and above.
+
+### `JULIA_PKG_OFFLINE`
+
+If set to `true`, this will enable offline mode: see [`Pkg.offline`](https://pkgdocs.julialang.org/dev/api/#Pkg.offline).
+
+!!! compat "Julia 1.5"
+    Pkg's offline mode requires Julia 1.5 or later.
+
+### `JULIA_PKG_PRECOMPILE_AUTO`
+
+If set to `0`, this will disable automatic precompilation by package actions which change the manifest. See [`Pkg.precompile`](https://pkgdocs.julialang.org/v1/api/#Pkg.precompile).
+
 ### `JULIA_PKG_SERVER`
 
 Used by `Pkg.jl`, for downloading packages and updating the registry. By default, `Pkg` uses `https://pkg.julialang.org` to
@@ -164,6 +192,34 @@ PkgServer protocol, and instead access the packages directly from their hosts (G
 ```
 export JULIA_PKG_SERVER=""
 ```
+
+### `JULIA_PKG_UNPACK_REGISTRY`
+
+If set to `true`, this will unpack the registry instead of storing it as a compressed tarball.
+
+!!! compat "Julia 1.7"
+    This only affects Julia 1.7 and above. Earlier versions will always unpack the registry.
+
+### `JULIA_PKG_USE_CLI_GIT`
+
+If set to `true`, Pkg operations which use the git protocol will use an external `git` executable instead of the default libgit2 library.
+
+!!! compat "Julia 1.7"
+    Use of the `git` executable is only supported on Julia 1.7 and above.
+
+### `JULIA_PKGRESOLVE_ACCURACY`
+
+The accuracy of the package resolver. This should be a positive integer, the default is `1`.
+
+## Network transport
+
+### `JULIA_NO_VERIFY_HOSTS` / `JULIA_SSL_NO_VERIFY_HOSTS` / `JULIA_SSH_NO_VERIFY_HOSTS` / `JULIA_ALWAYS_VERIFY_HOSTS`
+
+Specify hosts whose identity should or should not be verified for specific transport layers. See [`NetworkOptions.verify_host`](https://github.com/JuliaLang/NetworkOptions.jl#verify_host)
+
+### `JULIA_SSL_CA_ROOTS_PATH`
+
+Specify the file or directory containing the certificate authority roots. See [`NetworkOptions.ca_roots`](https://github.com/JuliaLang/NetworkOptions.jl#ca_roots)
 
 ## External applications
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -202,9 +202,11 @@ by setting: ``` export JULIA_PKG_SERVER="" ```
 ### `JULIA_PKG_SERVER_REGISTRY_PREFERENCE`
 
 Specifies the preferred registry flavor. Currently supported values are `conservative`
-(the default), which will only publish resources that have been processed, and `eager`,
-which will closely track the upstream repository, but may not have all resources
-available.
+(the default), which will only publish resources that have been processed by the storage
+server (and thereby have a higher probability of being available from the PkgServers),
+whereas `eager` will publish registries whose resources have not necessarily been
+processed by the storage servers.  Users behind restrictive firewalls that do not allow
+downloading from arbitrary servers should not use the `eager` flavor.
 
 !!! compat "Julia 1.7"
     This only affects Julia 1.7 and above.

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -162,6 +162,10 @@ Sets the maximum number of different instances of a single package that are to b
 
 ## Pkg.jl
 
+### `JULIA_CI`
+
+If set to `true`, this indicates to the package server that any package operations are part of a continuous integration (CI) system for the purposes of gathering package usage statistics.
+
 ### `JULIA_NUM_PRECOMPILE_TASKS`
 
 The number of parallel tasks to use when precompiling packages. See [`Pkg.precompile`](https://pkgdocs.julialang.org/v1/api/#Pkg.precompile).

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -175,7 +175,7 @@ If set to `1`, this will ignore incorrect hashes in artifacts. This should be us
 
 ### `JULIA_PKG_OFFLINE`
 
-If set to `true`, this will enable offline mode: see [`Pkg.offline`](https://pkgdocs.julialang.org/dev/api/#Pkg.offline).
+If set to `true`, this will enable offline mode: see [`Pkg.offline`](https://pkgdocs.julialang.org/v1/api/#Pkg.offline).
 
 !!! compat "Julia 1.5"
     Pkg's offline mode requires Julia 1.5 or later.

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -156,6 +156,10 @@ The absolute path `REPL.find_hist_file()` of the REPL's history file. If
 $(DEPOT_PATH[1])/logs/repl_history.jl
 ```
 
+### `JULIA_MAX_NUM_PRECOMPILE_FILES`
+
+Sets the maximum number of different instances of a single package that are to be stored in the precompile cache (default = 10).
+
 ## Pkg.jl
 
 ### `JULIA_NUM_PRECOMPILE_TASKS`

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -194,12 +194,20 @@ If set to `0`, this will disable automatic precompilation by package actions whi
 
 ### `JULIA_PKG_SERVER`
 
-Used by `Pkg.jl`, for downloading packages and updating the registry. By default, `Pkg` uses `https://pkg.julialang.org` to
-fetch Julia packages. You can use this environment variable to select a different server. In addition, you can disable the use of the
-PkgServer protocol, and instead access the packages directly from their hosts (GitHub, GitLab, etc.) by setting:
-```
-export JULIA_PKG_SERVER=""
-```
+Specifies the URL of the package registry to use. By default, `Pkg` uses
+`https://pkg.julialang.org` to fetch Julia packages. In addition, you can disable the use of the PkgServer
+protocol, and instead access the packages directly from their hosts (GitHub, GitLab, etc.)
+by setting: ``` export JULIA_PKG_SERVER="" ```
+
+### `JULIA_PKG_SERVER_REGISTRY_PREFERENCE`
+
+Specifies the preferred registry flavor. Currently supported values are `conservative`
+(the default), which will only publish resources that have been processed, and `eager`,
+which will closely track the upstream repository, but may not have all resources
+available.
+
+!!! compat "Julia 1.7"
+    This only affects Julia 1.7 and above.
 
 ### `JULIA_PKG_UNPACK_REGISTRY`
 


### PR DESCRIPTION
I added these to the Julia docs instead of Pkg.jl so that they would all be in one place.

Fixes https://github.com/JuliaLang/Pkg.jl/issues/2453