### PR TITLE
`Base.runtests`: add environment variables for overriding the automatic networking detection

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,15 @@ cd(@__DIR__) do
     #   * https://github.com/JuliaLang/julia/pull/29384
     #   * https://github.com/JuliaLang/julia/pull/40348
     n = 1
-    if net_on
+    JULIA_TEST_USE_MULTIPLE_WORKERS = get(ENV, "JULIA_TEST_USE_MULTIPLE_WORKERS", "") |>
+                                      strip |>
+                                      lowercase |>
+                                      s -> tryparse(Bool, s) |>
+                                      x -> x === true
+    # If the `JULIA_TEST_USE_MULTIPLE_WORKERS` environment variable is set to `true`, we use
+    # multiple worker processes regardless of the value of `net_on`.
+    # Otherwise, we use multiple worker processes if and only if `net_on` is true.
+    if net_on || JULIA_TEST_USE_MULTIPLE_WORKERS
         n = min(Sys.CPU_THREADS, length(tests))
         n > 1 && addprocs_with_testenv(n)
         LinearAlgebra.BLAS.set_num_threads(1)


### PR DESCRIPTION
Closes #43211

### Description

This pull request adds two environment variables for overriding the automatic networking detection that we perform before we run the test suite.

To force Julia to use multiple worker processes, even if `Sockets.getipaddr()` throws an exception, set the `JULIA_TEST_USE_MULTIPLE_WORKERS` environment variable to `true`.

To force Julia to use multiple worker processes AND to force Julia to run the tests that require network connectivity, even if `Sockets.getipaddr()` throws an exception, set the `JULIA_TEST_NETWORKING_AVAILABLE` environment variable to `true`.

## Examples

### Example 1

Suppose that:
1. `Sockets.getipaddr()` throws an exception when run in your build environment.
2. You want to use multiple worker processes to run the tests.
3. You do not want to run the tests that require network connectivity (`Artifacts`, `Downloads`, etc.).

To accomplish this, you would run the following commands:

```
export JULIA_TEST_USE_MULTIPLE_WORKERS=true
make testall
```

### Example 2

Suppose that:
1. `Sockets.getipaddr()` throws an exception when run in your build environment.
2. You want to use multiple worker processes to run the tests.
3. You want to force Julia to run the tests that require network connectivity (`Artifacts`, `Downloads`, etc.).

To accomplish this, you would run the following commands:

```
export JULIA_TEST_NETWORKING_AVAILABLE=true
make testall
```