### PR TITLE
`string(::BigInt)`: fix under-allocation for string result

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -699,8 +699,10 @@ function string(n::BigInt; base::Integer = 10, pad::Integer = 1)
     iszero(n) && pad < 1 && return ""
     nd1 = ndigits(n, base=base)
     nd  = max(nd1, pad)
-    sv  = Base.StringVector(nd + isneg(n))
+    sv  = Base.StringVector(nd + isneg(n) + 1) # +1 for final '\0'
     GC.@preserve sv MPZ.get_str!(pointer(sv) + nd - nd1, base, n)
+    null = pop!(sv) # '\0' terminator
+    @assert iszero(null)
     @inbounds for i = (1:nd-nd1) .+ isneg(n)
         sv[i] = '0' % UInt8
     end


### PR DESCRIPTION
GMP's `mpz_get_str` routine adds a null-terminator `'\0'` to the
passed byte vector, so we must account for it.