### PR TITLE
Keep ABI breaking checks for assert builds.

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -175,10 +175,6 @@ ifeq ($(fPIC),)
 LLVM_CMAKE += -DLLVM_ENABLE_PIC=OFF
 endif
 
-# disable ABI breaking checks: by default only enabled for asserts build, in which case
-# it is then impossible to call non-asserts LLVM libraries (like out-of-tree backends)
-LLVM_CMAKE += -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF
-
 LLVM_CMAKE += -DCMAKE_C_FLAGS="$(LLVM_CPPFLAGS) $(LLVM_CFLAGS)" \
 	-DCMAKE_CXX_FLAGS="$(LLVM_CPPFLAGS) $(LLVM_CXXFLAGS)"
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
The ABIs aren't compatible (between release and asserts builds), so my change in https://github.com/JuliaLang/julia/pull/35896 was invalid. This never got applied to Yggdrasil though.

Closes https://github.com/JuliaPackaging/Yggdrasil/issues/1041