### PR TITLE
Skip timeout check of "spawn many" test on Windows

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -210,7 +210,7 @@ close(proc.in)
             @test_skip success(proc)
         else
             @test success(proc)
+            @test !timeout
         end
-        @test !timeout
     end
 end


### PR DESCRIPTION
It turned out #43125 was not enough as a workaround:

> ```
> Error in testset threads:
> Test Failed at C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\test\threads.jl:214
>   Expression: !timeout
> ```
> 
> https://build.julialang.org/#/builders/65/builds/5821
> 
> --- https://github.com/JuliaLang/julia/issues/43124#issuecomment-980790520

So, I think it's better to disable `@test !timeout` on Windows until someone fixes issue #43124.
