### PR TITLE
Test: Fix indenting on verbose no-failure report

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1114,8 +1114,8 @@ end
 function get_alignment(ts::DefaultTestSet, depth::Int)
     # The minimum width at this depth is
     ts_width = 2*depth + length(ts.description)
-    # If all passing, no need to look at children
-    !ts.anynonpass && return ts_width
+    # If not verbose and all passing, no need to look at children
+    !ts.verbose && !ts.anynonpass && return ts_width
     # Return the maximum of this width and the minimum width
     # for all children (if they exist)
     isempty(ts.results) && return ts_width

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1079,17 +1079,17 @@ end
 
 @testset "verbose option" begin
     expected = """
-    Test Summary: | Pass  Total
-    Parent        |    9      9
-      Child 1     |    3      3
-        Child 1.1 |    1      1
-        Child 1.2 |    1      1
-        Child 1.3 |    1      1
-      Child 2     |    3      3
-      Child 3     |    3      3
-        Child 3.1 |    1      1
-        Child 3.2 |    1      1
-        Child 3.3 |    1      1
+    Test Summary:             | Pass  Total
+    Parent                    |    9      9
+      Child 1                 |    3      3
+        Child 1.1 (long name) |    1      1
+        Child 1.2             |    1      1
+        Child 1.3             |    1      1
+      Child 2                 |    3      3
+      Child 3                 |    3      3
+        Child 3.1             |    1      1
+        Child 3.2             |    1      1
+        Child 3.3             |    1      1
     """
 
     mktemp() do f, _
@@ -1099,7 +1099,7 @@ end
 
         @testset "Parent" verbose = true begin
             @testset "Child 1" verbose = true begin
-                @testset "Child 1.1" begin
+                @testset "Child 1.1 (long name)" begin
                     @test 1 == 1
                 end
 


### PR DESCRIPTION
Fixes the indenting in verbose `@testset` printing when no failures/errors occur

## Master
```
julia> @testset "Foo" verbose = true begin
           @testset "Barbarbarbarbar" begin
               @test true
           end
           @testset "Baz" begin
               @test true
           end
       end
Test Summary: | Pass  Total
Foo           |    2      2
  Barbarbarbarbar |    1      1
  Baz         |    1      1
```

## This PR
```
julia> @testset "Foo" verbose = true begin
           @testset "Barbarbarbarbar" begin
               @test true
           end
           @testset "Baz" begin
               @test true
           end
       end
Test Summary:     | Pass  Total
Foo               |    2      2
  Barbarbarbarbar |    1      1
  Baz             |    1      1
```