### PR TITLE
RFC: during `using`, define module before include, to solve a minor data-race on UUID

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -199,7 +199,7 @@ export
     # method reflection
     applicable, invoke,
     # constants
-    nothing, Main
+    nothing, Main, __precompile__
 
 const getproperty = getfield
 const setproperty! = setfield!
@@ -819,5 +819,7 @@ struct Pair{A, B}
     Pair{A, B}(a::A, b::B) where {A, B} = new(a, b)
     Pair{Any, Any}(@nospecialize(a::Any), @nospecialize(b::Any)) = new(a, b)
 end
+
+function __precompile__ end
 
 ccall(:jl_set_istopmod, Cvoid, (Any, Bool), Core, true)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -387,8 +387,6 @@ end
 # options #
 ###########
 
-is_root_module(m::Module) = false
-
 inlining_enabled() = (JLOptions().can_inline == 1)
 function coverage_enabled(m::Module)
     ccall(:jl_generating_output, Cint, ()) == 0 || return false # don't alter caches

--- a/base/pkgid.jl
+++ b/base/pkgid.jl
@@ -9,11 +9,6 @@ struct PkgId
 end
 PkgId(name::AbstractString) = PkgId(nothing, name)
 
-function PkgId(m::Module, name::String = String(nameof(moduleroot(m))))
-    uuid = UUID(ccall(:jl_module_uuid, NTuple{2, UInt64}, (Any,), m))
-    UInt128(uuid) == 0 ? PkgId(name) : PkgId(uuid, name)
-end
-
 ==(a::PkgId, b::PkgId) = a.uuid == b.uuid && a.name == b.name
 
 function hash(pkg::PkgId, h::UInt)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -33,6 +33,8 @@ Base
 """
 parentmodule(m::Module) = ccall(:jl_module_parent, Ref{Module}, (Any,), m)
 
+is_root_module(m::Module) = m === Base || parentmodule(m) === m
+
 """
     moduleroot(m::Module) -> Module
 

--- a/src/module.c
+++ b/src/module.c
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT jl_module_t *jl_new_module_(jl_sym_t *name, uint8_t default_names)
+jl_module_t *jl_new_module_(jl_sym_t *name, uint8_t default_names)
 {
     jl_task_t *ct = jl_current_task;
     const jl_uuid_t uuid_zero = {0, 0};
@@ -56,20 +56,6 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 uint32_t jl_module_next_counter(jl_module_t *m)
 {
     return jl_atomic_fetch_add(&m->counter, 1);
-}
-
-JL_DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports, uint8_t default_names)
-{
-    // TODO: should we prohibit this during incremental compilation?
-    jl_module_t *m = jl_new_module_(name, default_names);
-    JL_GC_PUSH1(&m);
-    m->parent = jl_main_module; // TODO: this is a lie
-    jl_gc_wb(m, m->parent);
-    if (std_imports)
-        jl_add_standard_imports(m);
-    JL_GC_POP();
-    // TODO: should we somehow try to gc-root this correctly?
-    return (jl_value_t*)m;
 }
 
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on)

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -363,7 +363,7 @@ end
 function serialize_mod_names(s::AbstractSerializer, m::Module)
     p = parentmodule(m)
     if p === m || m === Base
-        key = Base.root_module_key(m)
+        key = Base.PkgId(m)
         serialize(s, key.uuid === nothing ? nothing : key.uuid.value)
         serialize(s, Symbol(key.name))
     else

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -687,9 +687,10 @@ append!(empty!(DEPOT_PATH), saved_depot_path)
 Base.ACTIVE_PROJECT[] = saved_active_project
 
 # issue #28190
-module Foo; import Libdl; end
-import .Foo.Libdl; import Libdl
-@test Foo.Libdl === Libdl
+@show Foo
+module Foo28190; import Libdl; end
+import .Foo28190.Libdl; import Libdl
+@test Foo28190.Libdl === Libdl
 
 @testset "include with mapexpr" begin
     let exprs = Any[]
@@ -743,19 +744,5 @@ end
         raw_manifest = Base.parsed_toml(manifest_file)
         @test Base.is_v1_format_manifest(raw_manifest) == false
         @test Base.get_deps(raw_manifest) == deps
-    end
-end
-
-@testset "error message loading pkg bad module name" begin
-    mktempdir() do tmp
-        old_loadpath = copy(LOAD_PATH)
-        try
-            push!(LOAD_PATH, tmp)
-            write(joinpath(tmp, "BadCase.jl"), "module badcase end")
-            @test_throws ErrorException("package `BadCase` did not define the expected module `BadCase`, \
-                                        check for typos in package module name") (@eval using BadCase)
-        finally
-            copy!(LOAD_PATH, old_loadpath)
-        end
     end
 end


### PR DESCRIPTION
Passing the UUID via global state can be a data-race, and passing it via
TLS seems more awkward than necessary. Instead, we define that `require`
implicitly makes the module it expects. We make the module a baremodule
initially, until the user calls `module Name` (or `using Base` and
defines `include` and `eval`). The module call also (re)sets the scope
of the `__init__` call, to preserve the prior behavior and order of it.