### PR TITLE
use has_fma intrinsic

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -358,7 +358,7 @@ end
     return hi, x-hi
 end
 
-@inline function twomul(a::Float64, b::Float64)
+function twomul(a::Float64, b::Float64)
     ahi, alo = splitbits(a)
     bhi, blo = splitbits(b)
     abhi = a*b
@@ -368,7 +368,7 @@ end
 end
 
 function fma_emulated(a::Float64, b::Float64,c::Float64)
-    abhi, ablo = twomul(a,b)
+    abhi, ablo = @inline twomul(a,b)
     if !isfinite(abhi+c) || isless(abs(abhi), nextfloat(0x1p-969)) || issubnormal(a) || issubnormal(b)
         aandbfinite = isfinite(a) && isfinite(b)
         if !(isfinite(c) && aandbfinite)

--- a/base/math.jl
+++ b/base/math.jl
@@ -1011,9 +1011,9 @@ function ^(x::Float64, n::Integer)
             y, ynlo = two_mul(x,y)
             ynlo += err
         end
-        xn, xnlo = two_mul(x, x)
-        xnlo = muladd(x, 2*xnlo, xnlo)
-        x = xn
+        err = x*2*xnlo
+        x, xnlo = two_mul(x, x)
+        xnlo += err
         n >>>= 1
     end
     !isfinite(x) && return x*y

--- a/base/math.jl
+++ b/base/math.jl
@@ -703,7 +703,7 @@ function _hypot(x, y)
     end
     h = sqrt(muladd(ax, ax, ay*ay))
     # This branch is correctly rounded but requires a native hardware fma.
-    if Core.Compiler.has_fma(typeof(h))
+    if Core.Intrinsics.have_fma(typeof(h))
         hsquared = h*h
         axsquared = ax*ax
         h -= (fma(-ay, ay, hsquared-axsquared) + fma(h, h,-hsquared) - fma(ax, ax, -axsquared))/(2*h)

--- a/base/math.jl
+++ b/base/math.jl
@@ -1007,7 +1007,7 @@ function ^(x::Float64, n::Integer)
     n == 3 && return x*x*x # keep compatibility with literal_pow
     while n > 1
         if n&1 > 0
-            err = muladd(x*y, xnlo, x*ynlo)
+            err = muladd(y, xnlo, x*ynlo)
             y, ynlo = two_mul(x,y)
             ynlo += err
         end

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -32,8 +32,7 @@ SINH_SMALL_X(::Type{Float32}) = 3.0f0
 
 # For Float64, use DoubleFloat scheme for extra accuracy
 function sinh_kernel(x::Float64)
-    x2 = x*x
-    x2lo = fma(x,x,-x2)
+    x2, x2lo = two_mul(x,x)
     hi_order = evalpoly(x2, (8.333333333336817e-3, 1.9841269840165435e-4,
                              2.7557319381151335e-6, 2.5052096530035283e-8,
                              1.6059550718903307e-10, 7.634842144412119e-13,

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -405,8 +405,8 @@ end
                                 0.153846227114512262845736, 0.13332981086846273921509,
                                 0.117754809412463995466069, 0.103239680901072952701192,
                                 0.116255524079935043668677))
-    res_hi = hi_order * x_hi
-    res_lo = fma(x_lo, hi_order, fma(hi_order, x_hi, -res_hi))
+    res_hi, res_lo = two_mul(hi_order, x_hi)
+    res_lo = fma(x_lo, hi_order, res_lo)
     ans_hi = c1hi + res_hi
     ans_lo = ((c1hi - ans_hi) + res_hi) + (res_lo + 3.80554962542412056336616e-17)
     return ans_hi, ans_lo
@@ -428,8 +428,8 @@ function _log_ext(d::Float64)
     invy = inv(mp1hi)
     xhi = (m - 1.0) * invy
     xlo = fma(-xhi, mp1lo, fma(-xhi, mp1hi, m - 1.0)) * invy
-    x2hi = xhi * xhi
-    x2lo = muladd(xhi, xlo * 2.0, fma(xhi, xhi, -x2hi))
+    x2hi, x2lo = two_mul(xhi, xhi)
+    x2lo = muladd(xhi, xlo * 2.0, x2lo)
     thi, tlo  = log_ext_kernel(x2hi, x2lo)
 
     shi = 0.6931471805582987 * e
@@ -437,10 +437,10 @@ function _log_ext(d::Float64)
     shinew = muladd(xhi, 2.0, shi)
     slo = muladd(1.6465949582897082e-12, e, muladd(xlo, 2.0, (((shi - shinew) + xhi2))))
     shi = shinew
-    x3hi = x2hi * xhi
-    x3lo = muladd(x2hi, xlo, muladd(xhi, x2lo,fma(x2hi, xhi, -x3hi)))
-    x3thi = x3hi * thi
-    x3tlo = muladd(x3hi, tlo, muladd(x3lo, thi, fma(x3hi, thi, -x3thi)))
+    x3hi, x3lo = two_mul(x2hi, xhi)
+    x3lo = muladd(x2hi, xlo, muladd(xhi, x2lo,x3lo))
+    x3thi, x3tlo = two_mul(x3hi, thi)
+    x3tlo = muladd(x3hi, tlo, muladd(x3lo, thi, x3tlo))
     anshi = x3thi + shi
     anslo = slo + x3tlo - ((anshi - shi) - x3thi)
     return anshi, anslo


### PR DESCRIPTION
This removes all bad `fma` checks in `Base` and replaces them with fma multiversioned ones. It also adds `Base.Math.two_mul` which gives the fastest compensated multiplication available regardless of whether the user has `fma` hardware. This is what should be used when possible for compensated multiplication in the future.