### PR TITLE
Add `Expr(:ivdepscope)` to support not marking the entire loop body as `ivdep`

### DIFF
--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -28,6 +28,7 @@ const VALID_EXPR_HEADS = IdDict{Symbol,UnitRange{Int}}(
     :isdefined => 1:1,
     :code_coverage_effect => 0:0,
     :loopinfo => 0:typemax(Int),
+    :ivdepscope => 1:1,
     :gc_preserve_begin => 0:typemax(Int),
     :gc_preserve_end => 0:typemax(Int),
     :thunk => 1:1,
@@ -145,7 +146,7 @@ function validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo, is_top_
                 head === :inbounds || head === :foreigncall || head === :cfunction ||
                 head === :const || head === :enter || head === :leave || head === :pop_exception ||
                 head === :method || head === :global || head === :static_parameter ||
-                head === :new || head === :splatnew || head === :thunk || head === :loopinfo ||
+                head === :new || head === :splatnew || head === :thunk || head === :loopinfo || head === :ivdepscope ||
                 head === :throw_undef_if_not || head === :code_coverage_effect || head === :inline || head === :noinline
                 validate_val!(x)
             else

--- a/src/ast.c
+++ b/src/ast.c
@@ -68,6 +68,7 @@ JL_DLLEXPORT jl_sym_t *jl_copyast_sym;
 JL_DLLEXPORT jl_sym_t *jl_cfunction_sym;
 JL_DLLEXPORT jl_sym_t *jl_pure_sym;
 JL_DLLEXPORT jl_sym_t *jl_loopinfo_sym;
+JL_DLLEXPORT jl_sym_t *jl_ivdepscope_sym;
 JL_DLLEXPORT jl_sym_t *jl_meta_sym;
 JL_DLLEXPORT jl_sym_t *jl_inert_sym;
 JL_DLLEXPORT jl_sym_t *jl_polly_sym;
@@ -317,6 +318,7 @@ void jl_init_common_symbols(void)
     jl_newvar_sym = jl_symbol("newvar");
     jl_copyast_sym = jl_symbol("copyast");
     jl_loopinfo_sym = jl_symbol("loopinfo");
+    jl_ivdepscope_sym = jl_symbol("ivdepscope");
     jl_pure_sym = jl_symbol("pure");
     jl_meta_sym = jl_symbol("meta");
     jl_list_sym = jl_symbol("list");

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -296,7 +296,7 @@
 ;; predicates and accessors
 
 (define (quoted? e)
-  (memq (car e) '(quote top core globalref outerref line break inert meta inbounds inline noinline loopinfo)))
+  (memq (car e) '(quote top core globalref outerref line break inert meta inbounds inline noinline loopinfo ivdepscope)))
 (define (quotify e) `',e)
 (define (unquote e)
   (if (and (pair? e) (memq (car e) '(quote inert)))

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -314,7 +314,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
     else if (head == jl_boundscheck_sym) {
         return jl_true;
     }
-    else if (head == jl_meta_sym || head == jl_coverageeffect_sym || head == jl_inbounds_sym || head == jl_loopinfo_sym ||
+    else if (head == jl_meta_sym || head == jl_coverageeffect_sym || head == jl_inbounds_sym || head == jl_loopinfo_sym || head == jl_ivdepscope_sym ||
              head == jl_aliasscope_sym || head == jl_popaliasscope_sym || head == jl_inline_sym || head == jl_noinline_sym) {
         return jl_nothing;
     }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -472,6 +472,7 @@
     XX(jl_tty_set_mode) \
     XX(jl_tupletype_fill) \
     XX(jl_typeassert) \
+    XX(jl_ivdepscope_error) \
     XX(jl_type_equality_is_identity) \
     XX(jl_type_error) \
     XX(jl_type_error_rt) \

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3516,7 +3516,7 @@ f(x) = yt(x)
 
 (define lambda-opt-ignored-exprs
   (Set '(quote top core line inert local-def unnecessary copyast
-         meta inbounds boundscheck loopinfo decl aliasscope popaliasscope
+         meta inbounds boundscheck loopinfo ivdepscope decl aliasscope popaliasscope
          thunk with-static-parameters toplevel-only
          global globalref outerref const-if-global thismodule
          const atomic null true false ssavalue isdefined toplevel module lambda
@@ -4625,7 +4625,7 @@ f(x) = yt(x)
                (cons (car e) args)))
 
             ;; metadata expressions
-            ((line meta inbounds loopinfo gc_preserve_end aliasscope popaliasscope inline noinline)
+            ((line meta inbounds loopinfo ivdepscope gc_preserve_end aliasscope popaliasscope inline noinline)
              (let ((have-ret? (and (pair? code) (pair? (car code)) (eq? (caar code) 'return))))
                (cond ((eq? (car e) 'line)
                       (set! current-loc e)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -534,6 +534,7 @@ JL_DLLEXPORT jl_value_t *jl_get_exceptionf(jl_datatype_t *exception_type, const 
 
 JL_DLLEXPORT jl_value_t *jl_get_keyword_sorter(jl_value_t *f);
 JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t);
+JL_DLLEXPORT void jl_ivdepscope_error(void);
 
 #define JL_CALLABLE(name)                                               \
     JL_DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)
@@ -1408,6 +1409,7 @@ extern JL_DLLEXPORT jl_sym_t *jl_copyast_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_cfunction_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_pure_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_loopinfo_sym;
+extern JL_DLLEXPORT jl_sym_t *jl_ivdepscope_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_meta_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_inert_sym;
 extern JL_DLLEXPORT jl_sym_t *jl_polly_sym;

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -354,7 +354,7 @@
                                    ,(resolve-expansion-vars-with-new-env (caddr arg) env m parent-scope inarg))))
                              (else
                               `(global ,(resolve-expansion-vars-with-new-env arg env m parent-scope inarg))))))
-           ((using import export meta line inbounds boundscheck loopinfo inline noinline) (map unescape e))
+           ((using import export meta line inbounds boundscheck loopinfo ivdepscope inline noinline) (map unescape e))
            ((macrocall) e) ; invalid syntax anyways, so just act like it's quoted.
            ((symboliclabel) e)
            ((symbolicgoto) e)

--- a/src/method.c
+++ b/src/method.c
@@ -84,6 +84,7 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
             e->head == jl_quote_sym || e->head == jl_inert_sym ||
             e->head == jl_meta_sym || e->head == jl_inbounds_sym ||
             e->head == jl_boundscheck_sym || e->head == jl_loopinfo_sym ||
+            e->head == jl_ivdepscope_sym ||
             e->head == jl_aliasscope_sym || e->head == jl_popaliasscope_sym ||
             e->head == jl_inline_sym || e->head == jl_noinline_sym) {
             // ignore these

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -214,6 +214,11 @@ JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t)
         jl_type_error("typeassert", t, x);
 }
 
+JL_DLLEXPORT void jl_ivdepscope_error(void)
+{
+    jl_errorf("Found ivdepscope outside @simd.");
+}
+
 #ifndef HAVE_SSP
 JL_DLLEXPORT uintptr_t __stack_chk_guard = (uintptr_t)0xBAD57ACCBAD67ACC; // 0xBADSTACKBADSTACK
 

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -161,3 +161,10 @@ Base.SimdLoop.simd_index(v::iter31113, j, i) = j
 Base.SimdLoop.simd_inner_length(v::iter31113, j) = 1
 Base.SimdLoop.simd_outer_range(v::iter31113) = v
 @test 2001000 == simd_sum_over_array(iter31113(Vector(1:2000)))
+
+#@ivdep thrown
+ivdep_out_simd(x) = @inbounds for i in eachindex(x)
+    Base.@ivdep x[i] += 1
+end
+@test_throws "Found ivdepscope outside @simd." ivdep_out_simd([1,2,3,4])
+@test_throws MethodError ivdep_out_simd((1,2,3,4))


### PR DESCRIPTION
- **Motivation:**
Currently, `@simd ivdep` assumes the entire loop is free of "no loop-carried memory dependencies", which limits its usage in our broadcast system.
This PR tries to split `julia.ivdep` into 2 meta: `julia.ivdep.begin` and `julia.ivdep.end`, and makes the simd-loop pass only marks the access within a `begin/end` block as `MD_mem_parallel_loop_access`.
With this PR, if we find that all the args in a flat `bc::Broadcasted` are safe to parallelly loaded, and the `dest::AbstractArray` is safe to parallelly strored.
Then we can implement the `copyto!` kernal as:
```julia
@eval function copyto!(dest::AbstractArray, bc::Broadcasted)
    @inbounds @simd for I in eachindex(bc)
        $(Expr(:loopinfo, Symbol("julia.ivdep.begin")))    # args are safe to load
        args = _getindex(bc.args, I)
        $(Expr(:loopinfo, Symbol("julia.ivdep.end")))
        temp = bc.f(args...)                                   # bc.f might have side effect
        $(Expr(:loopinfo, Symbol("julia.ivdep.begin")))    # result is safe to store
        dest[I] = temp
        $(Expr(:loopinfo, Symbol("julia.ivdep.end")))
    end
end
```
If `bc.f` is free of memory access, then LLVM should FIND this loop vectorlizable and add no runtime check. (and we can make `a .+= 1` vectorlized more easily)
If not, then let LLVM checks whether `bc.f` might have side effect.

- **Changes in this PR:**
This PR only changes the pass inplementation.
And makes `@simd ivdep` generates a `julia.ivdep.begin/end` block instead of a single `julia.ivdep`
The usage and effect of `@simd` and `@simd ivdep` are not changed.

I'm not familiar with LLVM and I'm not sure this change is the correct way to make self-inplace broadcast vectorlizable.
All suggestions and comments are welcome.