### PR TITLE
Widen RangeIndex from Int to BitInteger

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -36,7 +36,7 @@ const AbstractMatrix{T} = AbstractArray{T,2}
 Union type of [`AbstractVector{T}`](@ref) and [`AbstractMatrix{T}`](@ref).
 """
 const AbstractVecOrMat{T} = Union{AbstractVector{T}, AbstractMatrix{T}}
-const RangeIndex = Union{Int, AbstractRange{Int}, AbstractUnitRange{Int}}
+const RangeIndex = Union{<:BitInteger, AbstractRange{<:BitInteger}}
 const DimOrInd = Union{Integer, AbstractUnitRange}
 const IntOrInd = Union{Int, AbstractUnitRange}
 const DimsOrInds{N} = NTuple{N,DimOrInd}

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -112,6 +112,8 @@ struct RefArray{T,A<:AbstractArray{T},R} <: Ref{T}
 end
 RefArray(x::AbstractArray{T}, i::Int, roots::Any) where {T} = RefArray{T,typeof(x),Any}(x, i, roots)
 RefArray(x::AbstractArray{T}, i::Int=1, roots::Nothing=nothing) where {T} = RefArray{T,typeof(x),Nothing}(x, i, nothing)
+RefArray(x::AbstractArray{T}, i::Integer, roots::Any) where {T} = RefArray{T,typeof(x),Any}(x, Int(i), roots)
+RefArray(x::AbstractArray{T}, i::Integer=1, roots::Nothing=nothing) where {T} = RefArray{T,typeof(x),Nothing}(x, Int(i), nothing)
 convert(::Type{Ref{T}}, x::AbstractArray{T}) where {T} = RefArray(x, 1)
 
 function unsafe_convert(P::Union{Type{Ptr{T}},Type{Ptr{Cvoid}}}, b::RefArray{T})::P where T

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -288,7 +288,8 @@ if testfull
 end
 
 let B = copy(reshape(1:13^3, 13, 13, 13))
-    @testset "spot checks: $oind" for oind in ((:,:,:),
+    @testset "spot checks: $oind" for oind in (
+                 (:,:,:),
                  (:,:,6),
                  (:,6,:),
                  (6,:,:),
@@ -296,7 +297,6 @@ let B = copy(reshape(1:13^3, 13, 13, 13))
                  (3:7,:,:),
                  (3:7,6,:),
                  (3:7,6,0x6),
-                 (6,UInt(3):UInt(7),3:7),
                  (13:-2:1,:,:),
                  ([8,4,6,12,5,7],:,3:7),
                  (6,CartesianIndex.(6,[8,4,6,12,5,7])),
@@ -307,7 +307,29 @@ let B = copy(reshape(1:13^3, 13, 13, 13))
                  (3,reshape(2:11,5,2),4),
                  (3,reshape(2:2:13,3,2),4),
                  (view(1:13,[9,12,4,13,1]),2:6,4),
-                 ([1:5 2:6 3:7 4:8 5:9], :, 3))
+                 ([1:5 2:6 3:7 4:8 5:9], :, 3),
+        )
+        runsubarraytests(B, oind...)
+        viewB = view(B, oind...)
+        runviews(viewB, index5, index25, index125)
+    end
+end
+
+let B = copy(reshape(1:13^3, 13, 13, 13))
+    @testset "spot checks (other BitIntegers): $oind" for oind in (
+                 (:,:,0x6),
+                 (:,0x00000006,:),
+                 (0x0006,:,:),
+                 (:,0x00000003:0x00000007,:),
+                 (0x0000000000000003:0x0000000000000007,:,:),
+                 (0x0003:0x0007,0x6,:),
+                 (6,UInt(3):UInt(7),3:7),
+                 (Int16(3):Int16(7),Int16(6),:),
+                 (CartesianIndex(0xD,0x6),UInt8[8,4,6,12,5,7]),
+                 (Int8(1),:,view(1:13,[9,12,4,13,1])),
+                 (view(1:13,Int16[9,12,4,13,1]),UInt8(2):UInt16(6),Int8(4)),
+                 (Int8[1:5 2:6 3:7 4:8 5:9],:,UInt64(3)),
+        )
         runsubarraytests(B, oind...)
         viewB = view(B, oind...)
         runviews(viewB, index5, index25, index125)


### PR DESCRIPTION
Could we widen `RangeIndex` to include indices that are a `BitInteger`?