### PR TITLE
Avoid un-necessary reconfigure step on deps/gmp

### DIFF
--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -39,12 +39,13 @@ $(SRCCACHE)/gmp-$(GMP_VER)/gmp_alloc_overflow_func.patch-applied: $(SRCCACHE)/gm
 		patch -p1 < $(SRCDIR)/patches/gmp_alloc_overflow_func.patch
 	echo 1 > $@
 
-$(SRCCACHE)/gmp-$(GMP_VER)/build-patched: \
+$(SRCCACHE)/gmp-$(GMP_VER)/source-patched: \
 	$(SRCCACHE)/gmp-$(GMP_VER)/gmp-HG-changeset.patch-applied \
 	$(SRCCACHE)/gmp-$(GMP_VER)/gmp-exception.patch-applied \
 	$(SRCCACHE)/gmp-$(GMP_VER)/gmp_alloc_overflow_func.patch-applied
+	echo 1 > $@
 
-$(BUILDDIR)/gmp-$(GMP_VER)/build-configured: $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted $(SRCCACHE)/gmp-$(GMP_VER)/build-patched
+$(BUILDDIR)/gmp-$(GMP_VER)/build-configured: $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted $(SRCCACHE)/gmp-$(GMP_VER)/source-patched
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CONFIGURE_COMMON) F77= --enable-cxx --enable-shared --disable-static $(GMP_CONFIGURE_OPTS)


### PR DESCRIPTION
Following https://github.com/JuliaLang/julia/pull/42539, re-running `make` on `1.7.0` un-necessarily reconfigures `gmp` even if all other targets are up to date.

Renamed `build-patched` to `source-patched` for consistency.