### PR TITLE
Restore valgrind suppressions file

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -23,3 +23,4 @@ Debugging
 | Name                           |  Description                                                |
 | ------------------------------ | ----------------------------------------------------------- |
 |[ debug_bootstrap.gdb ](https://github.com/JuliaLang/julia/blob/master/contrib/debug_bootstrap.gdb) | Bootstrap process using the debug build |
+|[ valgrind-julia.supp ](https://github.com/JuliaLang/julia/blob/master/contrib/valgrind-julia.supp) | Suppressions for Valgrind debugging tool |

--- a/contrib/valgrind-julia.supp
+++ b/contrib/valgrind-julia.supp
@@ -1,0 +1,10 @@
+# https://github.com/JuliaLang/julia/issues/4533
+{
+   msync unwind
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:validate_mem
+   ...
+   fun:rec_backtrace
+}


### PR DESCRIPTION
`contrib/valgrind-julia.supp` was removed in #38970, but it is still referenced [in the Valgrind devdocs](https://docs.julialang.org/en/v1/devdocs/valgrind/). Either the file should be restored, or the reference should be removed from the documentation.

Here, I have chosen the option of restoring the file, as I believe it provides some value if kept up to date.  I have also updated it such that it does indeed suppress the warning (#4533) on the latest `master`.

Here are the errors when the suppression file is not provided:

```
==130829== Syscall param write(buf) points to unaddressable byte(s)
==130829==    at 0x496FF5D: syscall (syscall.S:38)
==130829==    by 0x56594C0: mincore_validate (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x5659601: validate_mem (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x565973C: access_mem (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x565A144: dwarf_get (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x565A535: _ULx86_64_access_reg (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x5658E00: _ULx86_64_get_reg (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x566118F: apply_reg_state (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x5661A2C: _ULx86_64_dwarf_step (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x565AC52: _ULx86_64_step (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x516D27A: jl_unw_step (stackwalk.c:553)
==130829==    by 0x516D27A: jl_unw_stepn.constprop.0 (stackwalk.c:99)
==130829==    by 0x516D767: rec_backtrace (stackwalk.c:222)
==130829==  Address 0x1ffeff5000 is on thread 1's stack
==130829==  1512 bytes below stack pointer
==130829== 
==130829== Syscall param write(buf) points to uninitialised byte(s)
==130829==    at 0x496FF5D: syscall (syscall.S:38)
==130829==    by 0x56594C0: mincore_validate (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x5659601: validate_mem (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x565973C: access_mem (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x565F36D: dwarf_get (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x56615DA: apply_reg_state (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x5661A2C: _ULx86_64_dwarf_step (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x565AC52: _ULx86_64_step (in /home/garrison/julia/usr/lib/libunwind.so.8.0.1)
==130829==    by 0x516D27A: jl_unw_step (stackwalk.c:553)
==130829==    by 0x516D27A: jl_unw_stepn.constprop.0 (stackwalk.c:99)
==130829==    by 0x516D767: rec_backtrace (stackwalk.c:222)
==130829==    by 0x51417CF: record_backtrace (task.c:344)
==130829==    by 0x5141F7C: ijl_throw (task.c:649)
==130829==  Address 0x1ffeff7000 is on thread 1's stack
```

This seems similar enough to #4533 that I believe it is the same error.  (@Keno, please let me know if you disagree.)