### PR TITLE
[Serialization] support AbstractLock and GenericCondition

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -126,3 +126,21 @@ function deepcopy_internal(x::Union{Dict,IdDict}, stackdict::IdDict)
     end
     dest
 end
+
+function deepcopy_internal(x::AbstractLock, stackdict::IdDict)
+    if haskey(stackdict, x)
+        return stackdict[x]
+    end
+    y = typeof(x)()
+    stackdict[x] = y
+    return y
+end
+
+function deepcopy_internal(x::GenericCondition, stackdict::IdDict)
+    if haskey(stackdict, x)
+        return stackdict[x]
+    end
+    y = typeof(x)(deepcopy_internal(x.lock))
+    stackdict[x] = y
+    return y
+end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -624,3 +624,21 @@ end
         @test_broken f(1) == 2
     end
 end
+
+let c1 = Threads.Condition()
+    c2 = Threads.Condition(c1.lock)
+    lock(c2)
+    t = @task nothing
+    Base._wait2(c1, t)
+    c3, c4 = deserialize(IOBuffer(sprint(serialize, [c1, c2])))::Vector{Threads.Condition}
+    @test c3.lock === c4.lock
+    @test islocked(c1)
+    @test !islocked(c3)
+    @test !isempty(c1.waitq)
+    @test isempty(c2.waitq)
+    @test isempty(c3.waitq)
+    @test isempty(c4.waitq)
+    notify(c1)
+    unlock(c2)
+    wait(t)
+end


### PR DESCRIPTION
Locks should be unlocked when serialized, and GenericCondition should
drop their waiters.

Otherwise, we may try to serialize a running Task (the user should
normally be holding the lock around the data they are intending to
serialize), which will fail and error.

Discovered in trying to make https://github.com/JuliaLang/julia/pull/42339 work