### PR TITLE
Add `stack(array_of_arrays)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,9 @@ New library functions
   inspecting which function `f` was originally wrapped. ([#42717])
 * New `pkgversion(m::Module)` function to get the version of the package that loaded
   a given module, similar to `pkgdir(m::Module)`. ([#45607])
+* New function `stack(x)` which generalises `reduce(hcat, x::Vector{<:Vector})` to any dimensionality,
+  and allows any iterators of iterators. Method `stack(f, x)` generalises `mapreduce(f, hcat, x)` and
+  is efficient. ([#43334])
 
 Library changes
 ---------------

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2790,7 +2790,7 @@ _vec_axis(A, ax=_iterator_axes(A)) = length(ax) == 1 ? only(ax) : OneTo(prod(len
     x1, xrest = xit
     ax1 = _iterator_axes(x1)
     N1 = length(ax1)+1
-    dims in 1:N1 || throw(ArgumentError("cannot stack slices ndims(x) = $(N1-1) along dims = $dims"))
+    dims in 1:N1 || throw(ArgumentError(LazyString("cannot stack slices ndims(x) = ", N1-1, " along dims = ", dims)))
 
     newaxis = _vec_axis(A)
     outax = ntuple(d -> d==dims ? newaxis : ax1[d - (d>dims)], N1)
@@ -2825,7 +2825,7 @@ end
         uax1 = map(UnitRange, ax1)
         uaxN = map(UnitRange, axes(x))
         throw(DimensionMismatch(
-            "stack expects uniform slices, got axes(x) = $uaxN while first had $uax1"))
+            LazyString("stack expects uniform slices, got axes(x) == ", uaxN, " while first had ", uax1)))
     end
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2661,6 +2661,43 @@ true
 stack(itr) = _stack_iter(IteratorSize(itr), itr)
 stack(A::AbstractArray{<:AbstractArray}) = _typed_stack(mapreduce(eltype, promote_type, A), A)
 
+"""
+    stack(f, args)
+
+Apply `f` to each element of `args`, and `stack` the result.
+
+See also [`mapslices`](@ref), [`mapreduce`](@ref).
+
+# Examples
+```jldoctest
+julia> stack("julia") do c
+         (c, c-32)
+       end
+2×5 Matrix{Char}:
+ 'j'  'u'  'l'  'i'  'a'
+ 'J'  'U'  'L'  'I'  'A'
+
+julia> ans == mapreduce(c -> [c, c-32], hcat, "julia")
+true
+
+julia> stack(x -> x*x', eachcol([1 2; 10 20; 100 200]))
+3×3×2 Array{Int64, 3}:
+[:, :, 1] =
+   1    10    100
+  10   100   1000
+ 100  1000  10000
+
+[:, :, 2] =
+   4    40    400
+  40   400   4000
+ 400  4000  40000
+
+julia> ans == cat([1,10,100] * [1,10,100]', [2,20,200] * [2,20,200]'; dims=3)
+true
+```
+"""
+stack(f, itr) = stack(Iterators.map(f, itr))
+
 function _stack_iter(::HasShape, itr)
     w, val = _vstack_plus(itr)
     reshape(w, axes(val)..., axes(itr)...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2697,14 +2697,14 @@ function _stack_rest!(v::AbstractVector, i, n, axe, itr, state)
         axes(val) == axe || throw(DimensionMismatch(
             "expected a consistent size, got axes $(UnitRange.(axes(val))) compared to $(UnitRange.(axe)) for the first"))
         i += 1
-        if eltype(val) <: eltype(v)
+        T′ = promote_type(eltype(v), eltype(val))
+        if T′ <: eltype(v)
             if n isa Integer
                 copyto!(v, i*len+1, val, firstindex(val), len)
             else
                 append!(v, val)
             end
         else
-            T′ = promote_type(eltype(v), eltype(val))
             v′ = similar(v, T′)
             copyto!(v′, v)
             if n isa Integer
@@ -2717,7 +2717,7 @@ function _stack_rest!(v::AbstractVector, i, n, axe, itr, state)
     end
 end
 
-# this implementation is largely copied from typed_hcat, could combine them
+# this implementation is largely copied from typed_hcat
 function _typed_stack(::Type{T}, A::AbstractArray{<:AbstractArray}) where {T}
     axe = axes(first(A))
     dense = true

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2681,7 +2681,7 @@ function _vstack_plus(itr)
     len = length(val)
     n = haslength(itr) ? len*length(itr) : nothing
 
-    v = similar(val isa Tuple ? (1:0) : val, something(n, len))
+    v = similar(val isa Tuple ? (1:0) : val, eltype(val), something(n, len))
     copyto!(v, 1, val, firstindex(val), len)
 
     w = _stack_rest!(v, 0, n, axe, itr, state)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2708,7 +2708,7 @@ The function should return arrays (or tuples, or other iterators) all of the sam
 These become slices of the result, each separated along `dims` (if given) or by default
 along the last dimensions.
 
-See also [`mapslices`](@ref), [`eachcol`](@ref), [`Iterators.flatmap`](@ref).
+See also [`mapslices`](@ref), [`eachcol`](@ref).
 
 # Examples
 ```jldoctest
@@ -2716,9 +2716,6 @@ julia> stack(c -> (c, c-32), "julia")
 2×5 Matrix{Char}:
  'j'  'u'  'l'  'i'  'a'
  'J'  'U'  'L'  'I'  'A'
-
-julia> Iterators.flatmap(c -> (c, '_'), "julia") |> collect |> String
-"j_u_l_i_a_"
 
 julia> stack(eachrow([1 2 3; 4 5 6]), (10, 100); dims=1) do row, n
          vcat(row, row .* n, row ./ n)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2617,14 +2617,14 @@ This has the same order of elements as [`Iterators.flatten`](@ref)`(iter)`.
 
 With keyword `dims::Integer`, instead the `i`th element of `iter` becomes the slice
 [`selectdim`](@ref)`(result, dims, i)`, so that `size(result, dims) == length(iter)`.
-This reverses the action of [`eachslice`](@ref) with the same `dims`.
+In this case `stack` reverses the action of [`eachslice`](@ref) with the same `dims`.
 
 Functions [`vcat`](@ref) and [`hvcat`](@ref) also combine arrays, but work
 mostly by extending their existing dimensions, rather than placing the arrays
 along new dimensions.
 
-!!! compat "Julia 1.8"
-    This function requires at least Julia 1.8.
+!!! compat "Julia 1.9"
+    This function requires at least Julia 1.9.
 
 # Examples
 ```jldoctest

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2677,7 +2677,7 @@ The function should return arrays (or tuples, or other iterators) all of the sam
 These become slices of the result, each separated along `dims` (if given) or by default
 along the last dimensions.
 
-See also [`mapslices`](@ref), [`eachcol`](@ref).
+See also [`mapslices`](@ref), [`eachcol`](@ref), [`Iterators.flatmap`](@ref).
 
 # Examples
 ```jldoctest
@@ -2685,6 +2685,9 @@ julia> stack(c -> (c, c-32), "julia")
 2×5 Matrix{Char}:
  'j'  'u'  'l'  'i'  'a'
  'J'  'U'  'L'  'I'  'A'
+
+julia> Iterators.flatmap(c -> (c, '_'), "julia") |> collect |> String
+"j_u_l_i_a_"
 
 julia> stack(eachcol([1 2 3; 4 5 6]), eachrow([1 -1; 10 -10; 100 -100]); dims=1) do col, row
          vcat(col .* row, 0, col ./ row)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2834,33 +2834,7 @@ _first_array(x::AbstractArray, ys...) = x
 _first_array(x, ys...) = _first_array(ys...)
 _first_array() = 1:0
 
-# With tuple elements, we can make the empty array the right size:
-function _empty_stack(::Colon, ::Type{T}, ::Type{S}, A) where {T, S<:Tuple}
-    similar(_first_array(A), T, OneTo(length(fieldtypes(S))), axes(A)...)
-end
-function _empty_stack(dims::Integer, ::Type{T}, ::Type{S}, A) where {T, S<:Tuple}
-    ax1 = OneTo(length(fieldtypes(S)))
-    dims in 1:2 || throw(ArgumentError("cannot stack tuples along dims = $dims"))
-    similar(_first_array(A), T, ntuple(d -> d==dims ? OneTo(0) : ax1, 2))
-end
-# but with arrays of arrays, we must settle for the right ndims:
-_empty_stack(dims, ::Type{T}, ::Type{S}, A) where {T,S} = _empty_stack(dims, T, IteratorSize(S), A)
-_empty_stack(dims, ::Type{T}, ::HasLength, A) where {T} = _empty_stack(dims, T, HasShape{1}(), A)
-_empty_stack(dims, ::Type{T}, ::IteratorSize, A) where {T} = _empty_stack(dims, T, HasShape{0}(), A)
-
-function _empty_stack(::Colon, ::Type{T}, ::HasShape{N}, A) where {T,N}
-    similar(_first_array(A), T, ntuple(_->OneTo(1), N)..., _axes(A)...)
-end
-function _empty_stack(dims::Integer, ::Type{T}, ::HasShape{N}, A) where {T,N}
-    # Not sure we should check dims here, e.g. stack(Vector[]; dims=2) is an error
-    dims in 1:N+1 || throw(ArgumentError("cannot stack slices ndims(x) = $N along dims = $dims"))
-    ax = ntuple(d -> d==dims ? _vec_axis(A) : OneTo(1), N+1)
-    similar(_first_array(A), T, ax...)
-end
-
-# These make stack(()) work like stack([])
-_empty_stack(::Colon, ::Type{T}, ::Type{Union{}}, A) where {T} = _empty_stack(:, T, Array{T,0}, A)
-_empty_stack(dims::Integer, ::Type{T}, ::Type{Union{}}, A) where {T} = _empty_stack(dims, T, Array{T,0}, A)
+_empty_stack(_...) = throw(ArgumentError("`stack` on an empty collection is not allowed"))
 
 
 ## Reductions and accumulates ##

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2721,7 +2721,7 @@ function _typed_stack(::Colon, ::Type{T}, ::Type{S}, A, Aax=_axes(A)) where {T, 
     x1, _ = xit
     ax1 = _axes(x1)
     B = similar(_prototype(x1, A), T, ax1..., Aax...)
-    off = 1
+    off = firstindex(B)
     len = length(x1)
     while xit !== nothing
         x, state = xit

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -445,6 +445,7 @@ export
     sortperm!,
     sortslices,
     dropdims,
+    stack,
     step,
     stride,
     strides,

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1212,7 +1212,7 @@ julia> Iterators.flatmap(n -> -n:2:n, 1:3) |> collect
   3
 
 julia> stack(n -> -n:2:n, 1:3)
-ERROR: DimensionMismatch: stack expects uniform slices, got axes(x) = (1:3,) while first had (1:2,)
+ERROR: DimensionMismatch: stack expects uniform slices, got axes(x) == (1:3,) while first had (1:2,)
 [...]
 
 julia> Iterators.flatmap(n -> (-n, 10n), 1:2) |> collect

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1199,7 +1199,7 @@ See also [`Iterators.flatten`](@ref), [`Iterators.map`](@ref).
 
 # Examples
 ```jldoctest
-julia> Iterators.flatmap(n->-n:2:n, 1:3) |> collect
+julia> Iterators.flatmap(n -> -n:2:n, 1:3) |> collect
 9-element Vector{Int64}:
  -1
   1
@@ -1210,6 +1210,20 @@ julia> Iterators.flatmap(n->-n:2:n, 1:3) |> collect
  -1
   1
   3
+
+julia> stack(n -> -n:2:n, 1:3)
+ERROR: DimensionMismatch: stack expects uniform slices, got axes(x) = (1:3,) while first had (1:2,)
+[...]
+
+julia> Iterators.flatmap(n -> (-n, 10n), 1:2) |> collect
+4-element Vector{Int64}:
+ -1
+ 10
+ -2
+ 20
+
+julia> ans == vec(stack(n -> (-n, 10n), 1:2))
+true
 ```
 """
 flatmap(f, c...) = flatten(map(f, c...))

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -145,6 +145,7 @@ Base.vcat
 Base.hcat
 Base.hvcat
 Base.hvncat
+Base.stack
 Base.vect
 Base.circshift
 Base.circshift!

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1581,6 +1581,10 @@ end
     @test size(stack(Iterators.product(1:3, 1:4))) == (2,3,4)
     @test stack([('a', 'b'), ('c', 'd')]) == ['a' 'c'; 'b' 'd']
 
+    # stack(f, iter)
+    @test stack(x -> [x, 2x], 3:5) == [3 4 5; 6 8 10]
+    @test stack(x -> x*x'/2, [1:2, 3:4]) == [0.5 1.0; 1.0 2.0;;; 4.5 6.0; 6.0 8.0]
+
     # Mismatched sizes
     @test_throws DimensionMismatch stack([1:2, 1:3])
     @test_throws DimensionMismatch stack(x for x in [1:2, 1:3])

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1628,13 +1628,13 @@ end
     xt = Tuple.(xv)
     for dims in (1, 2, :)
         @test stack(xv; dims) == stack(xt; dims)
-        @test 9000 > @allocated stack(xv; dims)
-        @test 9000 > @allocated stack(xt; dims)
+        @test_skip 9000 > @allocated stack(xv; dims)
+        @test_skip 9000 > @allocated stack(xt; dims)
     end
     xr = (reshape(1:1000,10,10,10) for _ = 1:1000)
     for dims in (1, 2, 3, :)
         stack(xr; dims)
-        @test 8.1e6 > @allocated stack(xr; dims)
+        @test_skip 8.1e6 > @allocated stack(xr; dims)
     end
 
     # Mismatched sizes

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1623,6 +1623,20 @@ end
     # Trivial, because numbers are iterable:
     @test stack(abs2, 1:3) == [1, 4, 9] == collect(Iterators.flatten(abs2(x) for x in 1:3))
 
+    # Allocation tests
+    xv = [rand(10) for _ in 1:100]
+    xt = Tuple.(xv)
+    for dims in (1, 2, :)
+        @test stack(xv; dims) == stack(xt; dims)
+        @test 9000 > @allocated stack(xv; dims)
+        @test 9000 > @allocated stack(xt; dims)
+    end
+    xr = (reshape(1:1000,10,10,10) for _ = 1:1000)
+    for dims in (1, 2, 3, :)
+        stack(xr; dims)
+        @test 8.1e6 > @allocated stack(xr; dims)
+    end
+
     # Mismatched sizes
     @test_throws DimensionMismatch stack([1:2, 1:3])
     @test_throws DimensionMismatch stack([1:2, 1:3]; dims=1)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1656,14 +1656,9 @@ end
     @test_throws ArgumentError stack(abs2, 1:3; dims=2)
 
     # Empty
-    @test size(stack([])) == (0,)
-    @test size(stack(())) == (0,)
-    @test size(stack(x for x in 1:3 if false)) == (0,)
-    @test size(stack(empty!([1:3, 4:6]))) == (1, 0)
-    @test size(stack(empty!([1:3, 4:6]); dims=1)) == (0, 1)
-    @test size(stack(empty!([1:3, 4:6]); dims=2)) == (1, 0)
-    @test size(stack(empty!([(1,2,3), (4,5,6)]))) == (3, 0)
-    @test size(stack(empty!([(1,2,3), (4,5,6)]); dims=1)) == (0, 3)
+    @test_throws ArgumentError stack(())
+    @test_throws ArgumentError stack([])
+    @test_throws ArgumentError stack(x for x in 1:3 if false)
 end
 
 @testset "tests from PR 31644" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1569,6 +1569,11 @@ end
         X3 = stack(x for x in args if true)
         @test X3 == Y
         @test typeof(X3) === typeof(Y)
+
+        if isconcretetype(eltype(args))
+            @inferred stack(args)
+            @inferred stack(x for x in args)
+        end
     end
     # Higher dims
     @test size(stack([rand(2,3) for _ in 1:4, _ in 1:5])) == (2,3,4,5)
@@ -1578,12 +1583,13 @@ end
     # Tuples
     @test stack([(1,2), (3,4)]) == [1 3; 2 4]
     @test stack(((1,2), (3,4))) == [1 3; 2 4]
-    @test size(stack(Iterators.product(1:3, 1:4))) == (2,3,4)
-    @test stack([('a', 'b'), ('c', 'd')]) == ['a' 'c'; 'b' 'd']
+    @test size(@inferred stack(Iterators.product(1:3, 1:4))) == (2,3,4)
+    @test @inferred(stack([('a', 'b'), ('c', 'd')])) == ['a' 'c'; 'b' 'd']
+    @test @inferred(stack([(1,2+3im), (4, 5+6im)])) isa Matrix{Complex{Int}}
 
     # stack(f, iter)
-    @test stack(x -> [x, 2x], 3:5) == [3 4 5; 6 8 10]
-    @test stack(x -> x*x'/2, [1:2, 3:4]) == [0.5 1.0; 1.0 2.0;;; 4.5 6.0; 6.0 8.0]
+    @test @inferred(stack(x -> [x, 2x], 3:5)) == [3 4 5; 6 8 10]
+    @test @inferred(stack(x -> x*x'/2, [1:2, 3:4])) == [0.5 1.0; 1.0 2.0;;; 4.5 6.0; 6.0 8.0]
 
     # Mismatched sizes
     @test_throws DimensionMismatch stack([1:2, 1:3])

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1579,6 +1579,7 @@ end
     @test stack([(1,2), (3,4)]) == [1 3; 2 4]
     @test stack(((1,2), (3,4))) == [1 3; 2 4]
     @test size(stack(Iterators.product(1:3, 1:4))) == (2,3,4)
+    @test stack([('a', 'b'), ('c', 'd')]) == ['a' 'c'; 'b' 'd']
 
     # Mismatched sizes
     @test_throws DimensionMismatch stack([1:2, 1:3])

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -815,12 +815,13 @@ end
     ten = OffsetArray([1,10,100,1000], 10:13)
 
     @test stack(ten) == ten
+    @test stack(ten .+ nought') == ten .+ nought'
     @test stack(x^2 for x in ten) == ten.^2
 
     @test axes(stack(nought for _ in ten)) == (0:2, 10:13)
     @test axes(stack([nought for _ in ten])) == (0:2, 10:13)
     @test axes(stack(nought for _ in ten; dims=1)) == (10:13, 0:2)
-    @test axes(stack((x, x^2) for x in nought)) == 1:2, 0:2
+    @test axes(stack((x, x^2) for x in nought)) == (1:2, 0:2)
     @test axes(stack(x -> x[end-1:end], ten for _ in nought, _ in nought)) == (1:2, 0:2, 0:2)
     @test axes(stack([ten[end-1:end] for _ in nought, _ in nought])) == (1:2, 0:2, 0:2)
 end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -810,6 +810,21 @@ end
     @test reshape(a, (:,)) === a
 end
 
+@testset "stack" begin
+    nought = OffsetArray([0, 0.1, 0.01], 0:2)
+    ten = OffsetArray([1,10,100,1000], 10:13)
+
+    @test stack(ten) == ten
+    @test stack(x^2 for x in ten) == ten.^2
+
+    @test axes(stack(nought for _ in ten)) == (0:2, 10:13)
+    @test axes(stack([nought for _ in ten])) == (0:2, 10:13)
+    @test axes(stack(nought for _ in ten; dims=1)) == (10:13, 0:2)
+    @test axes(stack((x, x^2) for x in nought)) == 1:2, 0:2
+    @test axes(stack(x -> x[end-1:end], ten for _ in nought, _ in nought)) == (1:2, 0:2, 0:2)
+    @test axes(stack([ten[end-1:end] for _ in nought, _ in nought])) == (1:2, 0:2, 0:2)
+end
+
 @testset "issue #41630: replace_ref_begin_end!/@view on offset-like arrays" begin
     x = OffsetArray([1 2; 3 4], -10:-9, 9:10)  # 2×2 OffsetArray{...} with indices -10:-9×9:10
 


### PR DESCRIPTION
This adds a ~~simple~~ version of the function `stack` described in #21672. It generalises `reduce(hcat, vector_of_vectors)` to handle more dimensions, and to handle iterators efficiently.

~~For iterators, like #31644 this handles only cases for which repeated `append!` is the fallback, except that it will also widen the type if necessary. You would need quite a different implementation to handle things like `reduce(vcat, ([1 i i^2] for i in 1:10 if i>pi))`, probably collecting first to know where to write the first slice. Because of that, it does not take a `dims` keyword.~~ Thus it can be the inverse of `eachcol(::Matrix)` or `eachslice(::Array{T,3}; dims=3)` ~~but not of `eachrow`.~~

Edit: The current implementation introduced [in this message below](https://github.com/JuliaLang/julia/pull/43334#pullrequestreview-835887585) takes a `dims` keyword. With this, `stack(eachslice(A; dims); dims) == A`. Without the `dims` keyword, the dimensions of the slice always come first, thus it should obey `vec(stack(xs)) == collect(Iterators.flatten(xs))`. Iterators of unknown length are collected first, as this seems quicker than falling back to `append!`-and-`reshape`.

Handling iterators also makes it trivial to allow `stack(f, xs) = stack(f(x) for x in xs)`, as suggested [below](https://github.com/JuliaLang/julia/pull/43334#issuecomment-986102052). This seems nice to have with a `do` block.

It does not currently handle the empty case ~~, as I'm not sure what it should do. Ideally `stack(empty!([1:5]))` would make a 5×0 Matrix, but that's impossible. At present it makes a 1×0 Matrix. The empty handling might be more complicated than ideal, see below.~~ Reverted to an error because handling weird array types is hard, and my attempt produced type instabilities.

Should work fine with OffsetArrays, it preserves all axes. Should mostly work with CUDA. 

The name unfortunately clashes with ` DataFrames.stack`. Other names suggested in #21672 include `pack` or `nested`; perhaps seeing it as the inverse of `eachslice` might suggest others?