### PR TITLE
RFC: yield after `require`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1037,7 +1037,7 @@ function require(into::Module, mod::Symbol)
     finally
         LOADING_CACHE[] = nothing
     end
-    end
+    end #= @lock unlock_expr =# yield()
 end
 
 mutable struct PkgOrigin
@@ -1067,7 +1067,7 @@ function require(uuidkey::PkgId)
               module `$(uuidkey.name)`, check for typos in package module name")
     end
     return root_module(uuidkey)
-    end
+    end #= @lock unlock_expr =# yield()
 end
 
 const loaded_modules = Dict{PkgId,Module}()

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -198,7 +198,7 @@ function trylock(f, l::AbstractLock)
 end
 
 """
-    @lock l expr
+    @lock l expr [unlock_expr=nothing]
 
 Macro version of `lock(f, l::AbstractLock)` but with `expr` instead of `f` function.
 Expands to:
@@ -208,12 +208,16 @@ try
     expr
 finally
     unlock(l)
+    unlock_expr
 end
 ```
 This is similar to using [`lock`](@ref) with a `do` block, but avoids creating a closure
 and thus can improve the performance.
+
+!!! compat "Julia 1.8"
+    `unlock_expr` requires at least Julia 1.8
 """
-macro lock(l, expr)
+macro lock(l, expr, unlock_expr=nothing)
     quote
         temp = $(esc(l))
         lock(temp)
@@ -221,6 +225,7 @@ macro lock(l, expr)
             $(esc(expr))
         finally
             unlock(temp)
+            $(esc(unlock_expr))
         end
     end
 end


### PR DESCRIPTION
Under specific circumstances (package callbacks that run under
`@async`), this can change the ordering of operations:
some may miss a `yield` window due to locking. This adds
a `yield` when the lock is freed.

It's worth showing how this new `@testset` behaves under Julia 1.6 and current nightly (see the diff for explanation). This comparison is done adding a `yield()` after the `@eval using Outer41602`. For Julia 1.6, `@show cti cto` yields
```julia
cti = Any[1.638712255575944e9, (Inner41602, 0.4309260845184326), (Outer41602, 0.4384500980377197)]
cto = Any[(Outer41602, 0.447174072265625)]
```
implying that `Inner`'s callback runs first for both `Inner` and `Outer` (in that order). On current nightly, one gets
```julia
cti = Any[1.638712268409791e9, (Outer41602, 0.11697912216186523), (Inner41602, 0.40651607513427734)]
cto = Any[(Outer41602, 0.12539410591125488)]
```
implying that `Inner`'s callback runs first for `Outer`, followed by `Outer`'s callback, and much later by `Inner`'s callback for itself. Presumably, this occurs because when it initially tries to run its own callback, `Base.require_lock` is still being held for `Outer`, and hence it blocks the callback until the next `yield`. This PR restores the original ordering.

As mentioned in https://github.com/JuliaLang/julia/pull/41602#issuecomment-986115131, #41602 triggered failures in Revise. There's an alternative way to fix this in Revise itself, by getting rid of one or two forms of asynchronous processing. The one that *must* go is the asynchronous processing of the `@require` blocks; this is the first commit in https://github.com/timholy/Revise.jl/pull/657. The one that's optional is the asynchronous handling of `watch_package`: it would be nice to leave that one asynchronous because it defers Revise's work until after Julia returns to the REPL. If we drop that commit, I can manually add a `yield()` in a couple of places in Revise's tests.

In other words, we don't *have* to change anything in Base (in which case this can be closed) if it's viewed as better being fixed in Revise: perhaps the ideal fix is to not make this change, take only the first commit of https://github.com/timholy/Revise.jl/pull/657, and add a couple of `yield`s in Revise's own tests. But, having finally understood where the breakage came from, I thought it was worth explaining the consequences of recent changes in case this proves to be the kind of breakage we want to avoid.