### PR TITLE
Update punctuation.md to fix missing pipe

### DIFF
--- a/doc/src/base/punctuation.md
+++ b/doc/src/base/punctuation.md
@@ -56,5 +56,5 @@ Extended documentation for mathematical symbols & functions is [here](@ref math-
 | [`===`](@ref) | triple equals sign is programmatically identical equality comparison                      |
 | [`=>`](@ref Pair) | right arrow using an equals sign defines a [`Pair`](@ref) typically used to populate [dictionaries](@ref Dictionaries) |
 | `->`        | right arrow using a hyphen defines an [anonymous function](@ref man-anonymous-functions) on a single line |
-| `\|>`        | pipe operator passes output from the left argument to input of the right argument, usually a [function](@ref Function-composition-and-piping) |
+| [`\|>`](@ref)       | pipe operator passes output from the left argument to input of the right argument, usually a [function](@ref Function-composition-and-piping) |
 | `∘`         | function composition operator (typed with \circ{tab}) combines two functions as though they are a single larger [function](@ref Function-composition-and-piping) |


### PR DESCRIPTION
The pipe in the ` is what is causing the markdown table to escape early. Adding the ref syntax seems like it will fix this since we are already using the pipe in some of the other rows. 

Closes #43342