### PR TITLE
Fix mutex unlock during signal handling.

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -817,10 +817,10 @@ static void *signal_listener(void *arg)
                         bt_data_prof[bt_size_cur++].uintptr = 0;
                         bt_data_prof[bt_size_cur++].uintptr = 0;
                     }
-
-                    // notify thread to resume
-                    jl_thread_resume(i, sig);
                 }
+
+                // notify thread to resume
+                jl_thread_resume(i, sig);
             }
             jl_unlock_profile();
         }


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/43103. Caused by bad rebase of https://github.com/JuliaLang/julia/commit/ad607a225b0691f17bbac406fc59d426dabaabe0 in https://github.com/JuliaLang/julia/commit/75961b229862fac9ae9dbc621145a181bd5ac092.

@KristofferC I've targeted `release-1.7` here; feel free to change the target branch or cherry-pick this in your backports branch if you prefer.