### PR TITLE
Make loop-idiom useful

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -709,7 +709,6 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createAllocOptPass());
     PM->add(createLoopRotatePass());
     // moving IndVarSimplify here prevented removing the loop in perf_sumcartesian(10:-1:1)
-    PM->add(createLoopIdiomPass());
 #ifdef USE_POLLY
     // LCSSA (which has already run at this point due to the dependencies of the
     // above passes) introduces redundant phis that hinder Polly. Therefore we
@@ -729,6 +728,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(createInductiveRangeCheckEliminationPass());
     // Subsequent passes not stripping metadata from terminator
     PM->add(createInstSimplifyLegacyPass());
+    PM->add(createLoopIdiomPass());
     PM->add(createIndVarSimplifyPass());
     PM->add(createLoopDeletionPass());
     PM->add(createSimpleLoopUnrollPass());


### PR DESCRIPTION
The loop idiom pass currently fails to optimize zeros() calls to use memset instead of an explicit loop. This PR moves the loop-idiom pass to allow such loop idioms to be recognized.

Compilation reports:
Master:
```
Sysimage built. Summary:
Total ───────  61.639983 seconds
Base: ───────  24.926984 seconds 40.4396%
Stdlibs: ────  36.711467 seconds 59.5579%
    JULIA usr/lib/julia/sys-o.a
Generating REPL precompile statements... 36/36
Executing precompile statements... 1393/1428
Precompilation complete. Summary:
Total ─────── 115.848746 seconds
Generation ──  89.879481 seconds 77.5835%
Execution ───  25.969266 seconds 22.4165%
```

PR:
```
Sysimage built. Summary:
Total ───────  59.881385 seconds
Base: ───────  24.343976 seconds 40.6537%
Stdlibs: ────  35.535908 seconds 59.3438%
    JULIA usr/lib/julia/sys-o.a
Generating REPL precompile statements... 36/36
Executing precompile statements... 1394/1429
Precompilation complete. Summary:
Total ─────── 115.805180 seconds
Generation ──  86.971557 seconds 75.1016%
Execution ───  28.833622 seconds 24.8984%
```

Godbolt LLVM IR comparison:
Master: https://godbolt.org/z/vTs8YPPa1
PR: https://godbolt.org/z/a8T8xjTv9