### PR TITLE
[CAPI] Add alias for LLVMExtraAddCPUFeaturesPass

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -132,3 +132,5 @@ JL_DLLEXPORT void LLVMExtraAddRemoveNIPass_fallback(void *PM) UNAVAILABLE
 JL_DLLEXPORT void LLVMExtraAddGCInvariantVerifierPass_fallback(void *PM, bool_t Strong) UNAVAILABLE
 
 JL_DLLEXPORT void LLVMExtraAddDemoteFloat16Pass_fallback(void *PM) UNAVAILABLE
+
+JL_DLLEXPORT void LLVMExtraAddCPUFeaturesPass_impl(void *PM) UNAVAILABLE

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -563,4 +563,5 @@
     YY(LLVMExtraAddRemoveNIPass) \
     YY(LLVMExtraAddGCInvariantVerifierPass) \
     YY(LLVMExtraAddDemoteFloat16Pass) \
+    YY(LLVMExtraAddCPUFeaturesPass) \
 


### PR DESCRIPTION
Missing from #43085
