### PR TITLE
Accelerate `isless(::T,::T) where {T<:CartesianIndex}` by reusing `Tuple`'s fallback

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -124,13 +124,7 @@ module IteratorsMD
     @inline (*)(index::CartesianIndex, a::Integer) = *(a,index)
 
     # comparison
-    @inline isless(I1::CartesianIndex{N}, I2::CartesianIndex{N}) where {N} = _isless(0, I1.I, I2.I)
-    @inline function _isless(ret, I1::Tuple{Int,Vararg{Int}}, I2::Tuple{Int,Vararg{Int}})
-        newret = ifelse(ret==0, icmp(last(I1), last(I2)), ret)
-        return _isless(newret, Base.front(I1), Base.front(I2))
-    end
-    _isless(ret, ::Tuple{}, ::Tuple{}) = ifelse(ret==1, true, false)
-    icmp(a, b) = ifelse(isless(a,b), 1, ifelse(a==b, 0, -1))
+    isless(I1::CartesianIndex{N}, I2::CartesianIndex{N}) where {N} = isless(reverse(I1.I), reverse(I2.I))
 
     # conversions
     convert(::Type{T}, index::CartesianIndex{1}) where {T<:Number} = convert(T, index[1])


### PR DESCRIPTION
Use `sort` to benchmark:
On master:
```julia
a2 = [CartesianIndex(rand(1:10,2)...) for i in 1:100];
a3 = [CartesianIndex(rand(1:10,3)...) for i in 1:100];
a4 = [CartesianIndex(rand(1:10,4)...) for i in 1:100];
a5 = [CartesianIndex(rand(1:10,5)...) for i in 1:100];
@btime sort($a2) #1.330 μs (3 allocations: 2.62 KiB)
@btime sort($a3) #1.890 μs (3 allocations: 3.78 KiB)
@btime sort($a4) #2.567 μs (3 allocations: 4.91 KiB)
@btime sort($a5) #3.275 μs (3 allocations: 6.11 KiB)
```
With this PR
```julia
Revise.track(Base)
@btime sort($a2) #937.500 ns (3 allocations: 2.62 KiB)
@btime sort($a3) #1.070 μs (3 allocations: 3.78 KiB)
@btime sort($a4) #1.160 μs (3 allocations: 4.91 KiB)
@btime sort($a5) #1.550 μs (3 allocations: 6.11 KiB)
```