### PR TITLE
[Distributed] Return value obtained from `call_on_owner` directly

### DIFF
--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -631,7 +631,15 @@ function fetch(r::Future)
         # why? local put! performs caching and putting into channel under r.lock
 
         # for local put! use the cached value, for call_on_owner cases just take the v_local as it was just cached in r.v
-        v_cache = status ? v_local : v_old
+
+        # remote calls getting the value from `call_on_owner` used to return the value directly without wrapping it in `Some(x)`
+        # so we're doing the same thing here
+        if status
+            send_del_client(r)
+            return v_local
+        else # this `v_cache` is returned at the end of the function
+            v_cache = v_old
+        end
     end
 
     send_del_client(r)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -841,6 +841,16 @@ v15406 = remotecall_wait(() -> 1, id_other)
 fetch(v15406)
 remotecall_wait(fetch, id_other, v15406)
 
+
+# issue #43396
+# Covers the remote fetch where the value returned is `nothing`
+# May be caused by attempting to unwrap a non-`Some` type with `something`
+# `call_on_owner` ref fetches return values not wrapped in `Some`
+# and have to be returned directly
+@test nothing === fetch(remotecall(() -> nothing, workers()[1]))
+@test 10 === fetch(remotecall(() -> 10, workers()[1]))
+
+
 # Test various forms of remotecall* invocations
 
 @everywhere f_args(v1, v2=0; kw1=0, kw2=0) = v1+v2+kw1+kw2


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/43396
Caused by this: https://github.com/JuliaLang/julia/pull/42339

`v_local` stores the value obtained through `call_on_owner`.

I forgot this value is not wrapped in `Some` and the code was attemptingto unwrap it with `something` at the end of the function.

Worked well for non-`nothing` values, but when `fetch` was actually returning a `nothing` value then an error was thrown due to `something(nothing)` being illegal

2nd test case is not related to the issue, but added it for safety in case there's any further work done on this part of code