### PR TITLE
[release-1.6] Backport "Unbreak source distribution tarball construction" for 1.6.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,10 @@ endif
 	-ls stdlib/srccache/*.tar.gz >> light-source-dist.tmp
 	-ls stdlib/*/StdlibArtifacts.toml >> light-source-dist.tmp
 
+	# Include all git-tracked filenames
+	git ls-files >> light-source-dist.tmp
+	
+	# Include documentation filenames
 	find doc/_build/html >> light-source-dist.tmp
 
 # Make tarball with only Julia code + stdlib tarballs


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/43003 broke source distribution tarball construction. https://github.com/JuliaLang/julia/pull/43096 fixed it. The former was backported for 1.6.5 but not the latter. This pull request backports the latter to fix source distribution tarball construction on release-1.6 for 1.6.5. Thanks and best!