### PR TITLE
SROA: Ensure that unused structs are preserved in ccall

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -928,7 +928,14 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
             end
         end
         preserve_uses === nothing && continue
-        push!(intermediaries, newidx)
+        preserve_newidx = false
+        for use in defuse.ccall_preserve_uses
+            if isempty(preserve_uses[use])
+                preserve_newidx = true
+                break
+            end
+        end
+        preserve_newidx || push!(intermediaries, newidx)
         # Insert the new preserves
         for (use, new_preserves) in preserve_uses
             ir[SSAValue(use)] = form_new_preserves(ir[SSAValue(use)]::Expr, intermediaries, new_preserves)

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -672,3 +672,30 @@ let
         return Core.Compiler.widenconst(ft) !== typeof(typeassert)
     end
 end
+
+let
+    # Test for https://github.com/JuliaLang/julia/issues/43402
+    # Ensure that structs required not used outside of the ccall,
+    # still get listed in the ccall_preserves
+
+    src = @eval Module() begin
+        @inline function effectful()
+            s1 = Ref{Csize_t}()
+            s2 = Ref{Csize_t}()
+            ccall(:some_ccall, Cvoid,
+                  (Ref{Csize_t},Ref{Csize_t}),
+                  s1, s2)
+            return s1[], s2[]
+        end
+
+        code_typed() do
+            s1, s2 = effectful()
+            return s1
+        end |> only |> first
+    end
+
+    ccall = findfirst(x -> x isa Expr && x.head == :foreigncall && x.args[1] == :(:some_ccall), src.code)
+    @test ccall !== nothing
+    ccall = src.code[ccall]
+    @test length(ccall.args) == 9
+end


### PR DESCRIPTION
Should fix #43402
