### PR TITLE
fix overflow bug in prevpow

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -499,7 +499,7 @@ function prevpow(a::Real, x::T) where T <: Real
     p = T(a)^n
     if a isa Integer && x isa Integer
         wp, overflow = mul_with_overflow(T(a), x)
-        return overflow ? T(wp) : p
+        return overflow ? p : T(wp)
     end
     wp = p*a
     return wp <= x ? T(wp) : p

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -490,14 +490,15 @@ julia> prevpow(4, 16)
 16
 ```
 """
-function prevpow(a::Real, x::Real)
+function prevpow(a::Real, x::T) where T <: Real
     x < 1 && throw(DomainError(x, "`x` must be ≥ 1."))
     # See comment in nextpos() for a == special case.
     a == 2 && isa(x, Integer) && return _prevpow2(x)
     a <= 1 && throw(DomainError(a, "`a` must be greater than 1."))
     n = floor(Integer,log(a, x))
-    p = a^(n+1)
-    p <= x ? p : a^n
+    p = a^n
+    wp = widemul(p,a)
+    wp <= x ? T(wp) : p
 end
 
 ## ndigits (number of digits) in base 10 ##

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -496,7 +496,7 @@ function prevpow(a::Real, x::T) where T <: Real
     a == 2 && isa(x, Integer) && return _prevpow2(x)
     a <= 1 && throw(DomainError(a, "`a` must be greater than 1."))
     n = floor(Integer,log(a, x))
-    p = a^n
+    p = T(a)^n
     wp = widemul(p,a)
     wp <= x ? T(wp) : p
 end

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -490,19 +490,19 @@ julia> prevpow(4, 16)
 16
 ```
 """
-function prevpow(a::Real, x::T) where T <: Real
+function prevpow(a::T, x::Real) where T <: Real
     x < 1 && throw(DomainError(x, "`x` must be ≥ 1."))
     # See comment in nextpos() for a == special case.
     a == 2 && isa(x, Integer) && return _prevpow2(x)
     a <= 1 && throw(DomainError(a, "`a` must be greater than 1."))
     n = floor(Integer,log(a, x))
-    p = T(a)^n
-    if a isa Integer && x isa Integer
-        wp, overflow = mul_with_overflow(T(a), x)
-        return overflow ? p : T(wp)
+    p = a^n
+    if a isa Integer
+        wp, overflow = mul_with_overflow(a, p)
+        return overflow ? p : wp
     end
     wp = p*a
-    return wp <= x ? T(wp) : p
+    return wp <= x ? wp : p
 end
 
 ## ndigits (number of digits) in base 10 ##

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -499,7 +499,7 @@ function prevpow(a::T, x::Real) where T <: Real
     p = a^n
     if a isa Integer
         wp, overflow = mul_with_overflow(a, p)
-        return overflow ? p : wp
+        return (wp <= x && !overflow) ? wp : p
     end
     wp = p*a
     return wp <= x ? wp : p

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -497,8 +497,12 @@ function prevpow(a::Real, x::T) where T <: Real
     a <= 1 && throw(DomainError(a, "`a` must be greater than 1."))
     n = floor(Integer,log(a, x))
     p = T(a)^n
-    wp = widemul(p,a)
-    wp <= x ? T(wp) : p
+    if a isa Integer && x isa Integer
+        wp, overflow = mul_with_overflow(T(a), x)
+        return overflow ? T(wp) : p
+    end
+    wp = p*a
+    return wp <= x ? T(wp) : p
 end
 
 ## ndigits (number of digits) in base 10 ##

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -264,7 +264,7 @@ end
     @test prevpow(2, 3) == 2
     @test prevpow(2, 4) == 4
     @test prevpow(2, 5) == 4
-    @test prevpow(10, 1234567890123456789)) == 1000000000000000000
+    @test prevpow(10, 1234567890123456789) == 1000000000000000000
     @test_throws DomainError prevpow(0, 3)
     @test_throws DomainError prevpow(0, 3)
 end

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -264,6 +264,7 @@ end
     @test prevpow(2, 3) == 2
     @test prevpow(2, 4) == 4
     @test prevpow(2, 5) == 4
+    @test prevpow(10, 1234567890123456789)) == 1000000000000000000
     @test_throws DomainError prevpow(0, 3)
     @test_throws DomainError prevpow(0, 3)
 end

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -264,7 +264,9 @@ end
     @test prevpow(2, 3) == 2
     @test prevpow(2, 4) == 4
     @test prevpow(2, 5) == 4
-    @test prevpow(10, 1234567890123456789) == 1000000000000000000
+    @test prevpow(Int64(10), Int64(1234567890123456789)) === Int64(1000000000000000000)
+    @test prevpow(10, 101.0) === 100
+    @test prevpow(10.0, 101) === 100.0
     @test_throws DomainError prevpow(0, 3)
     @test_throws DomainError prevpow(0, 3)
 end


### PR DESCRIPTION
Previously `prevpow(10, 1234567890123456789)` gave `-8446744073709551616` due to integer overflow.