### PR TITLE
Add defalg methods to resolve potential dispatch ambiguities

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -656,6 +656,8 @@ end
 
 defalg(v::AbstractArray) = DEFAULT_STABLE
 defalg(v::AbstractArray{<:Union{Number, Missing}}) = DEFAULT_UNSTABLE
+defalg(v::AbstractArray{Missing}) = DEFAULT_UNSTABLE
+defalg(v::AbstractArray{Union{}}) = DEFAULT_UNSTABLE
 
 function sort!(v::AbstractVector, alg::Algorithm, order::Ordering)
     inds = axes(v,1)


### PR DESCRIPTION
We could also consider adding `defalg(v::AbstractArray{<:Number}) = DEFAULT_UNSTABLE`, but it is unlikely that someone will want to do `Union` of `<:Number` and something other than `Missing` that still would support comparison.

Relevant for https://github.com/JuliaStrings/InlineStrings.jl/issues/21 (and other custom types that will want to add `defalg` support allowing for `Union` with `Missing`).

Preferably this should be backported I think.