### PR TITLE
Send AdjOrTrans(BlasMatrix) oop-products to BLAS

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -164,8 +164,9 @@ const AdjOrTransAbsVec{T} = AdjOrTrans{T,<:AbstractVector}
 const AdjOrTransAbsMat{T} = AdjOrTrans{T,<:AbstractMatrix}
 
 # for internal use below
-wrapperop(A::Adjoint) = adjoint
-wrapperop(A::Transpose) = transpose
+wrapperop(_) = identity
+wrapperop(::Adjoint) = adjoint
+wrapperop(::Transpose) = transpose
 
 # AbstractArray interface, basic definitions
 length(A::AdjOrTrans) = length(A.parent)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -116,7 +116,7 @@ end
 # Matrix-matrix multiplication
 
 AdjOrTransStridedMat{T} = Union{Adjoint{T, <:StridedMatrix}, Transpose{T, <:StridedMatrix}}
-StridedMaybeAdjOrTransMat{T} = Union{StridedMatrix{T}, AdjOrTransStridedMat{T, <:StridedMatrix}, Transpose{T, <:StridedMatrix}}
+StridedMaybeAdjOrTransMat{T} = Union{StridedMatrix{T}, Adjoint{T, <:StridedMatrix}, Transpose{T, <:StridedMatrix}}
 
 """
     *(A::AbstractMatrix, B::AbstractMatrix)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -140,11 +140,15 @@ end
 # which is better handled by reinterpreting rather than promotion
 function (*)(A::StridedMaybeAdjOrTransMat{<:BlasReal}, B::StridedMaybeAdjOrTransMat{<:BlasFloat})
     TS = promote_type(eltype(A), eltype(B))
-    mul!(similar(B, TS, (size(A,1), size(B,2))), convert(AbstractArray{TS}, A), convert(AbstractArray{TS}, B))
+    mul!(similar(B, TS, (size(A, 1), size(B, 2))),
+         wrapperop(A)(convert(AbstractArray{TS}, parent(A))),
+         wrapperop(B)(convert(AbstractArray{TS}, parent(B))))
 end
 function (*)(A::StridedMaybeAdjOrTransMat{<:BlasComplex}, B::StridedMaybeAdjOrTransMat{<:BlasComplex})
     TS = promote_type(eltype(A), eltype(B))
-    mul!(similar(B, TS, (size(A,1), size(B,2))), convert(AbstractArray{TS}, A), convert(AbstractArray{TS}, B))
+    mul!(similar(B, TS, (size(A, 1), size(B, 2))),
+         wrapperop(A)(convert(AbstractArray{TS}, parent(A))),
+         wrapperop(B)(convert(AbstractArray{TS}, parent(B))))
 end
 
 @inline function mul!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
@@ -155,11 +159,15 @@ end
 # first matrix as a real matrix and carry out real matrix matrix multiply
 function (*)(A::StridedMatrix{<:BlasComplex}, B::StridedMaybeAdjOrTransMat{<:BlasReal})
     TS = promote_type(eltype(A), eltype(B))
-    mul!(similar(B, TS, (size(A,1), size(B,2))), convert(AbstractArray{TS}, A), convert(AbstractArray{real(TS)}, B))
+    mul!(similar(B, TS, (size(A, 1), size(B, 2))),
+         convert(AbstractArray{TS}, A),
+         wrapperop(B)(convert(AbstractArray{real(TS)}, parent(B))))
 end
 function (*)(A::AdjOrTransStridedMat{<:BlasComplex}, B::StridedMaybeAdjOrTransMat{<:BlasReal})
     TS = promote_type(eltype(A), eltype(B))
-    mul!(similar(B, TS, (size(A,1), size(B,2))), copy_oftype(A, TS), convert(AbstractArray{real(TS)}, B))
+    mul!(similar(B, TS, (size(A, 1), size(B, 2))),
+         copy_oftype(A, TS), # remove AdjOrTrans to use reinterpret trick below
+         wrapperop(B)(convert(AbstractArray{real(TS)}, parent(B))))
 end
 for elty in (Float32,Float64)
     @eval begin

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -183,22 +183,22 @@ end
 # Complex Matrix times real matrix: We use that it is generally faster to reinterpret the
 # first matrix as a real matrix and carry out real matrix matrix multiply
 for wrapper in (Adjoint, Transpose)
-    @eval function (*)(A::$wrapper{<:BlasComplex,<:StridedVecOrMat}, B::StridedVecOrMat{<:BlasReal})
+    @eval function (*)(A::$wrapper{<:BlasComplex,<:StridedMatrix}, B::StridedMatrix{<:BlasReal})
         TS = promote_type(eltype(A), eltype(B))
         mul!(similar(B, TS, (size(A,1), size(B,2))), convert(AbstractArray{TS}, A), convert(AbstractArray{TS}, B))
     end
-    @eval function (*)(A::StridedVecOrMat{<:BlasComplex}, B::$wrapper{<:BlasReal,<:StridedVecOrMat})
+    @eval function (*)(A::StridedMatrix{<:BlasComplex}, B::$wrapper{<:BlasReal,<:StridedMatrix})
         TS = promote_type(eltype(A), eltype(B))
         mul!(similar(B, TS, (size(A,1), size(B,2))), convert(AbstractArray{TS}, A), convert(AbstractArray{TS}, B))
     end
     # when equal real(eltype), don't convert
     for T in (Float32, Float64)
-        @eval function (*)(A::StridedVecOrMat{Complex{$T}}, B::$wrapper{$T,<:StridedVecOrMat})
+        @eval function (*)(A::StridedMatrix{Complex{$T}}, B::$wrapper{$T,<:StridedMatrix})
             mul!(similar(B, complex($T), (size(A,1), size(B,2))), A, B)
         end
     end
     for wrapperB in (Adjoint, Transpose)
-        @eval function (*)(A::$wrapper{<:BlasComplex,<:StridedVecOrMat}, B::$wrapperB{<:BlasReal,<:StridedVecOrMat})
+        @eval function (*)(A::$wrapper{<:BlasComplex,<:StridedMatrix}, B::$wrapperB{<:BlasReal,<:StridedMatrix})
             TS = promote_type(eltype(A), eltype(B))
             mul!(similar(B, TS, (size(A,1), size(B,2))), convert(AbstractArray{TS}, A), convert(AbstractArray{TS}, B))
         end


### PR DESCRIPTION
This closes JuliaLang/LinearAlgebra.jl#894 and closes JuliaLang/julia#30811.

I have tested this with the following exhaustive script:
```julia
using LinearAlgebra, BenchmarkTools
N = 500
transforms = (identity, adjoint, transpose)
compl = (identity, complex)
Ts = (Float32, Float64)
i = 0
for T1 in Ts, T2 in Ts, c1 in compl, c2 in compl
    A = rand(c1(T1), N, N)
    B = rand(c2(T2), N, N)
    for t1 in transforms, t2 in transforms
        i += 1
        # @show i
        # @show T1, T2, c1, c2, t1, t2
        @btime $(t1(A)) * $(t2(B))
    end
end
```
It is not slower for any combination, and in the obvious combinations much, much faster at the expense of more memory usage, which we typically consider as acceptable for out-of-place/not memory-sensitive operations.