### PR TITLE
Faster `min`, `max`, `minmax`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -750,12 +750,12 @@ atan(y::Real, x::Real) = atan(promote(float(y),float(x))...)
 atan(y::T, x::T) where {T<:AbstractFloat} = Base.no_op_err("atan", T)
 
 max(x::T, y::T) where {T<:AbstractFloat} = ifelse((y > x) | (signbit(y) < signbit(x)),
-                                    ifelse(isnan(x), x, y), ifelse(isnan(y), y, x))
-
+                                    y, ifelse(isnan(y), y, x))
 
 min(x::T, y::T) where {T<:AbstractFloat} = ifelse((y < x) | (signbit(y) > signbit(x)),
-                                    ifelse(isnan(x), x, y), ifelse(isnan(y), y, x))
+                                    y, ifelse(isnan(y), y, x))
 
+minmax(x::T, y::T) where {T<:Union{Float32, Float64}} = min(x, y), max(x, y)
 minmax(x::T, y::T) where {T<:AbstractFloat} =
     ifelse(isnan(x) | isnan(y), ifelse(isnan(x), (x,x), (y,y)),
            ifelse((y > x) | (signbit(x) > signbit(y)), (x,y), (y,x)))


### PR DESCRIPTION
I think that one `isnan` check in `min` / `max` is redundant, as `y < x` will be false if `x` is NaN. This can be removed without altering the following table, and the result is faster:
```julia
julia> table(max, vals=[-0.0, 0.0, 1, NaN, Inf, -Inf]) = [max(x,y) for x in vals, y in vals]

julia> table(max)
6×6 Matrix{Float64}:
  -0.0    0.0    1.0  NaN   Inf   -0.0
   0.0    0.0    1.0  NaN   Inf    0.0
   1.0    1.0    1.0  NaN   Inf    1.0
 NaN    NaN    NaN    NaN  NaN   NaN
  Inf    Inf    Inf   NaN   Inf   Inf
  -0.0    0.0    1.0  NaN   Inf  -Inf
```
It also seems faster to replace `minmax` with just `min(x, y), max(x, y)`. Times:
```julia
julia> maxM(x::T, y::T) where {T<:AbstractFloat} = ifelse((y > x) | (signbit(y) < signbit(x)),
                                           y, ifelse(isnan(y), y, x));

julia> all(isequal.(table(maxM), table(max)))
true

julia> minmaxM(x, y) = min(x, y), max(x, y);

julia> T = Float32; x = rand(T, 1000); y = rand(T, 1000); z = similar(x); zz = tuple.(x, y);

julia> @btime $z .= max.($x, $y);  @btime $zz .= minmax.($x, $y);
  281.106 ns (0 allocations: 0 bytes)
  1.558 μs (0 allocations: 0 bytes)

julia> @btime $z .= maxM.($x, $y);  @btime $zz .= minmaxM.($x, $y);
  203.632 ns (0 allocations: 0 bytes)
  437.712 ns (0 allocations: 0 bytes)

julia> @btime $z .= maxPR.($x, $y);  @btime $zz .= minmaxPR.($x, $y);
  222.865 ns (0 allocations: 0 bytes)
  437.500 ns (0 allocations: 0 bytes)
```  
I see now that #41709 also proposes modifications, which are timed as `maxPR` here. But I open this anyway as it gets similar speed with less code. That PR saw extra allocations for BigFloat, which I see here too for `minmaxM` only. So to be safe this simpler method is used only for `Float32, Float64`.