### PR TITLE
Add missing optimization for `iterate(::LogicalIndex{<:CartesianIndex,<:BitArray})`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -795,7 +795,7 @@ end
 @inline function iterate(L::LogicalIndex{Int,<:BitArray})
     L.sum == 0 && return nothing
     Bc = L.mask.chunks
-    iterate(L, (1, 1, (), @inbounds Bc[1]))
+    return iterate(L, (1, 1, (), @inbounds Bc[1]))
 end
 @inline function iterate(L::LogicalIndex{<:CartesianIndex,<:BitArray})
     L.sum == 0 && return nothing

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -762,6 +762,8 @@ LogicalIndex{Int}(mask::AbstractArray) = LogicalIndex{Int, typeof(mask)}(mask)
 size(L::LogicalIndex) = (L.sum,)
 length(L::LogicalIndex) = L.sum
 collect(L::LogicalIndex) = [i for i in L]
+collect(L::LogicalIndex{Int,<:BitArray}) = findall(vec(L.mask))
+collect(L::LogicalIndex{CartesianIndex{N},BitArray{N}}) where {N} = N >= 2 ? findall(L.mask) : [i for i in L]
 show(io::IO, r::LogicalIndex) = print(io,collect(r))
 print_array(io::IO, X::LogicalIndex) = print_array(io, collect(X))
 # Iteration over LogicalIndex is very performance-critical, but it also must


### PR DESCRIPTION
This PR aims to make `view(A, A .> 0)` faster when `IndexStyle(A) isa IndexCartesian`.
Some benchmark:
```julia
a = randn(128, 32);
A = view(a, axes(a)...);
A2 = view(reshape(a,32,32,4),1:32,1:32,1:4);
p = a .> 0;

@btime view($a, $p); # 1.780 μs (4 allocations: 16.56 KiB)
@btime view($A, $p); # 16.700 μs (2 allocations: 32.92 KiB)
@btime view($A2, reshape($p, size($A2))); # 13.500 μs (4 allocations: 49.47 KiB)

# After This PR
Base.collect(L::Base.LogicalIndex{Int,<:BitArray}) = findall(vec(L.mask))
Base.collect(L::Base.LogicalIndex{CartesianIndex{N},BitArray{N}}) where {N} = N >= 2 ? findall(L.mask) : [i for i in L]

@btime view($a, $p); # 1.710 μs (6 allocations: 16.66 KiB)
@btime view($A, $p); # 2.522 μs (2 allocations: 32.92 KiB)
@btime view($A2, reshape($p, size($A2))); # 3.638 μs (4 allocations: 49.47 KiB)
```