### PR TITLE
add `fma`/`muladd` for `BigInt`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -166,8 +166,12 @@ invert(a::BigInt, b::BigInt) = invert!(BigInt(), a, b)
 invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
 
 fma!(x::BigInt, a::BigInt, b::BigInt) = ccall((:__gmpz_addmul, :libgmp), Cvoid, (mpz_t, mpz_t, mpz_t), x, a, b)
-fma(a::BigInt, b::BigInt, c::BigInt) = fma!(copy(c), a, b)
-muladd(a::BigInt, b::BigInt, c::BigInt) = fma!(copy(c), a, b)
+function Base.fma(a::BigInt, b::BigInt, c::BigInt)
+    res = copy(c)
+    fma!(res, a, b)
+    res
+end
+Base.muladd(a::BigInt, b::BigInt, c::BigInt) = fma(copy(c), a, b)
 
 for op in (:add_ui, :sub_ui, :mul_ui, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
     op! = Symbol(op, :!)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -165,6 +165,10 @@ invert!(x::BigInt, a::BigInt, b::BigInt) =
 invert(a::BigInt, b::BigInt) = invert!(BigInt(), a, b)
 invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
 
+fma!(x::BigInt, a::BigInt, b::BigInt) = ccall((:__gmpz_addmul, :libgmp), Cvoid, (mpz_t, mpz_t, mpz_t), x, a, b)
+fma(a::BigInt, b::BigInt, c::BigInt) = fma!(copy(c), a, b)
+muladd(a::BigInt, b::BigInt, c::BigInt) = fma!(copy(c), a, b)
+
 for op in (:add_ui, :sub_ui, :mul_ui, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
     op! = Symbol(op, :!)
     @eval begin

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -167,11 +167,11 @@ invert!(x::BigInt, b::BigInt) = invert!(x, x, b)
 
 fma!(x::BigInt, a::BigInt, b::BigInt) = ccall((:__gmpz_addmul, :libgmp), Cvoid, (mpz_t, mpz_t, mpz_t), x, a, b)
 function Base.fma(a::BigInt, b::BigInt, c::BigInt)
-    res = copy(c)
+    res = set(c)
     fma!(res, a, b)
     res
 end
-Base.muladd(a::BigInt, b::BigInt, c::BigInt) = fma(copy(c), a, b)
+Base.muladd(a::BigInt, b::BigInt, c::BigInt) = fma(a, b, c)
 
 for op in (:add_ui, :sub_ui, :mul_ui, :mul_2exp, :fdiv_q_2exp, :pow_ui, :bin_ui)
     op! = Symbol(op, :!)


### PR DESCRIPTION
GMP has a function to return `a*b+c` which saves an allocation, so we should use this for `fma` and `muladd` of `BigInt` values. The timings look about the same because the multiplication is roughly quadratic, but in a loop, using this version will put less pressure on GC.