### PR TITLE
RFC: Add `norm(A, p; dims)`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -658,7 +658,7 @@ end
 norm(::Missing, p::Real=2) = missing
 
 # With dims keyword
-norm0_dims(B, A, dims) = count!(!iszero, B, A)
+norm0_dims!(B, A, dims) = count!(!iszero, B, A)
 norm1_dims!(B, A, dims) = Base.mapreducedim!(norm, +, B, A)
 normInf_dims!(B, A, dims) = Base.mapreducedim!(norm, max, B, A)
 normMinusInf_dims!(B, A, dims) = Base.mapreducedim!(norm, min, B, A)
@@ -713,6 +713,10 @@ Find the vector `norm`s of slices of a given array.
 The result has the same size as `sum(A; dims)`, containing `norm(A[i,:,j,...], p)`
 for each possible `i,j,...`, with colons at dimensions `d ∈ dims`.
 
+The result is always a floating point array. To avoid this when `eltype(A) <: Integer`,
+0-norm is `count(!iszero, A; dims)`, 1-norm is `sum(abs, A; dims)`,
+and the `Inf`-norm is `maximum(abs, A; dims)`.
+
 !!! compat "Julia 1.8"
     Methods taking keyword `dims` require Julia 1.8.
 
@@ -738,8 +742,8 @@ julia> map(norm, eachcol(m))  # same contents as dims=1
  3.0
  6.928203230275509
 
-julia> norm(v, 1), norm(m, 1; dims=1)
-(11.0, [11.0 11.0 3.0 12.0])
+julia> norm(v, 1), norm(m, 1; dims=1), sum(abs, m; dims=1)
+(11.0, [11.0 11.0 3.0 12.0], [11 11 3 12])
 
 julia> norm(m, 1; dims=2)
 3×1 Matrix{Float64}:
@@ -747,8 +751,11 @@ julia> norm(m, 1; dims=2)
   8.0
  16.0
 
-julia> norm(v, Inf), norm(m, Inf; dims=1)
-(6.0, [6.0 6.0 3.0 4.0])
+julia> norm(v, Inf), norm(m, Inf; dims=1), maximum(abs, m; dims=1)
+(6.0, [6.0 6.0 3.0 4.0], [6 6 3 4])
+
+julia> norm(m, 0; dims=2), count(!iszero, m; dims=2)
+([4.0; 3.0; 3.0;;], [4; 3; 3;;])
 
 julia> norm([1e-200, 0, 1e-300]; dims=1)  # avoids underflow & overflow
 1-element Vector{Float64}:

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -723,8 +723,8 @@ The result is always a floating point array. To avoid this when `eltype(A) <: In
 0-norm is `count(!iszero, A; dims)`, 1-norm is `sum(abs, A; dims)`,
 and the `Inf`-norm is `maximum(abs, A; dims)`.
 
-!!! compat "Julia 1.9"
-    Methods taking keyword `dims` require Julia 1.9.
+!!! compat "Julia 1.10"
+    Methods taking keyword `dims` require at least Julia 1.10.
 
 # Examples
 ```jldoctest
@@ -1990,7 +1990,7 @@ end
 
 Normalize `a` so that its `p`-norm equals unity,
 i.e. `norm(a, p) == 1`. For scalars, this is similar to `sign(a)`,
-except `normalize(0) == NaN`. 
+except `normalize(0) == NaN`.
 
 See also [`normalize!`](@ref), [`norm`](@ref), and [`sign`](@ref).
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -723,8 +723,8 @@ The result is always a floating point array. To avoid this when `eltype(A) <: In
 0-norm is `count(!iszero, A; dims)`, 1-norm is `sum(abs, A; dims)`,
 and the `Inf`-norm is `maximum(abs, A; dims)`.
 
-!!! compat "Julia 1.8"
-    Methods taking keyword `dims` require Julia 1.8.
+!!! compat "Julia 1.9"
+    Methods taking keyword `dims` require Julia 1.9.
 
 # Examples
 ```jldoctest
@@ -2033,30 +2033,39 @@ normalize(x, p::Real) = x / norm(x, p)
     normalize(A::AbstractArray, p::Real=2; dims)
 
 Return a similar array for which `norm(result, p; dims)` is everywhere 1.
+Equivalent to `mapslices(x -> normalize(x, p), mat; dims)`, but usually more efficient.
 
 !!! compat "Julia 1.11"
     The `dims` keyword requires at least Julia 1.11.
 
 # Examples
 ```jldoctest
-julia> d = [1 2 5 ; 1 2 5]
+julia> mat = [1 2 5 ; 1 2 5]
 2×3 Matrix{Int64}:
  1  2  5
  1  2  5
 
-julia> e = normalize(d; dims=1)
+julia> cols2 = normalize(mat; dims=1)
 2×3 Matrix{Float64}:
  0.707107  0.707107  0.707107
  0.707107  0.707107  0.707107
 
-julia> norm(e; dims=1)
+julia> norm(cols2; dims=1)
 1×3 Matrix{Float64}:
  1.0  1.0  1.0
 
-julia> normalize(d, 1; dims=2)
+julia> rows1 = normalize(mat, 1; dims=2)
 2×3 Matrix{Float64}:
  0.125  0.25  0.625
  0.125  0.25  0.625
+
+julia> sum(rows1, dims=2)
+2×1 Matrix{Float64}:
+ 1.0
+ 1.0
+
+julia> rows1 == mapslices(x -> normalize(x, 1), mat; dims=2)
+true
 ```
 """
 function normalize(a::AbstractArray, p::Real = 2; dims=:)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -425,6 +425,33 @@ end
                        [0.0 + 0.0im, 0.0 - 0.0im, NaN + NaN*im]))
 end
 
+@testset "normalize(array; dims)" begin
+    v = randn(10)
+    @test normalize(v) ≈ normalize(v; dims=1)
+    @test sign.(v) ≈ normalize(v; dims=2)
+
+    @testset for p in [-Inf,-1.5,-1,0,1,1.5,2,3,Inf]
+        @test normalize(v, p) ≈ normalize(v, p; dims=1)  broken=(p==-Inf)
+        @test_broken normalize(fill(-2pi), p) ≈ normalize(fill(-2pi), p; dims=1)  broken=(p==-Inf)
+        # TODO fix zero-arrays
+    end
+
+    x = randn(3, 5, 2)
+    @testset for p in [-1.5,-1,0,1,1.5,2,3,Inf]
+        for dims in (2, (1,3))
+            y = normalize(x, p; dims)  # error for p = -Inf
+            z = norm(y, p; dims)
+            if p==0
+                @test z ≈ zero.(z) .+ prod(size(x, d) for d in dims)
+            else
+                @test z ≈ one.(z)
+            end
+        end
+    end
+
+    # TODO test Inf, NaN, overflow cases
+end
+
 @testset "Issue 14657" begin
     @test det([true false; false true]) == det(Matrix(1I, 2, 2))
 end


### PR DESCRIPTION
Closes JuliaLang/LinearAlgebra.jl#697. RFC, I guess?

One motivation is that this can be faster than making slices:
```julia
julia> @btime map(norm, eachrow($(rand(100, 100))));
  12.625 μs (1 allocation: 896 bytes)

julia> @btime norm($(rand(100, 100)), 2, dims=2);  # with PR
  1.771 μs (5 allocations: 976 bytes)
  1.650 μs (1 allocation: 896 bytes)
```
Here, "5 allocations" is sometimes 1 as you'd expect, I don't know why, seems to depend on load order? I think there was an issue about this which I can't find again.

The 0,1,Inf norm implementations are trivial. 

For the 2-norm, I initially made it check whether values in `A` are in the goldilocks zone, as `norm(A)` does. But this check alone takes longer than the happy path of `sum(abs2, A; dims)`. Instead, the present PR does that and then checks the answer, and re-does any slices which are dangerous. I hope this is correct. I presume the typical case would not have many such zero/Inf answers, in which case this will be fast. It's a bit awkward that `eachslice` doesn't do what is needed here, so instead I taped something together, trying to make the common cases fast. It is a bit ugly but is there a better way?

The p-norm is much slower, ~~and for now it just slices. It could probably be done the same way, though.~~ [Edit: now works like 2-norm]