### PR TITLE
Add percentage sign notation

### DIFF
--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -529,7 +529,7 @@ See [Conversion and Promotion](@ref conversion-and-promotion) for how to define 
 | [`div(x,y)`](@ref), `x÷y` | truncated division; quotient rounded towards zero                                                         |
 | [`fld(x,y)`](@ref)        | floored division; quotient rounded towards `-Inf`                                                         |
 | [`cld(x,y)`](@ref)        | ceiling division; quotient rounded towards `+Inf`                                                         |
-| [`rem(x,y)`](@ref)        | remainder; satisfies `x == div(x,y)*y + rem(x,y)`; sign matches `x`                                       |
+| [`rem(x,y)`](@ref), `x%y` | remainder; satisfies `x == div(x,y)*y + rem(x,y)`; sign matches `x`                                       |
 | [`mod(x,y)`](@ref)        | modulus; satisfies `x == fld(x,y)*y + mod(x,y)`; sign matches `y`                                         |
 | [`mod1(x,y)`](@ref)       | `mod` with offset 1; returns `r∈(0,y]` for `y>0` or `r∈[y,0)` for `y<0`, where `mod(r, y) == mod(x, y)`   |
 | [`mod2pi(x)`](@ref)       | modulus with respect to 2pi;  `0 <= mod2pi(x) < 2pi`                                                      |


### PR DESCRIPTION
The rem function should have the percentage sign notation beside it in the division functions table.