### PR TITLE
[Distributed] Remove (now) unnecessary copy of the Future in its serializer

### DIFF
--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -370,8 +370,7 @@ function serialize(s::ClusterSerializer, f::Future)
         p = worker_id_from_socket(s.io)
         (p !== f.where) && send_add_client(f, p)
     end
-    fc = Future((f.where, f.whence, f.id, v_cache)) # copy to be used for serialization (contains a reset lock)
-    invoke(serialize, Tuple{ClusterSerializer, Any}, s, fc)
+    invoke(serialize, Tuple{ClusterSerializer, Any}, s, f)
 end
 
 function serialize(s::ClusterSerializer, rr::RemoteChannel)


### PR DESCRIPTION
This was introduced in https://github.com/JuliaLang/julia/pull/42339 as a workaround in order to safely serialize a `Future`, which now contains a `lock`
But now that https://github.com/JuliaLang/julia/pull/43325 is merged this is no longer necessary
