### PR TITLE
Remove STORE_ARRAY_LEN option and associated dead code

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -146,9 +146,7 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
     a->data = data;
     if (JL_ARRAY_IMPL_NUL && elsz == 1)
         ((char*)data)[tot - 1] = '\0';
-#ifdef STORE_ARRAY_LEN
     a->length = nel;
-#endif
     a->flags.ndims = ndims;
     a->flags.ptrarray = !isunboxed;
     a->flags.hasptr = hasptr;
@@ -250,9 +248,7 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
 
     if (ndims == 1) {
         size_t l = dims[0];
-#ifdef STORE_ARRAY_LEN
         a->length = l;
-#endif
         a->nrows = l;
         a->maxsize = l;
     }
@@ -270,9 +266,7 @@ JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
                 jl_exceptionf(jl_argumenterror_type, "invalid Array dimensions");
             l = prod;
         }
-#ifdef STORE_ARRAY_LEN
         a->length = l;
-#endif
     }
 
     return a;
@@ -298,9 +292,7 @@ JL_DLLEXPORT jl_array_t *jl_string_to_array(jl_value_t *str)
     a->flags.how = 3;
     a->flags.isshared = 1;
     size_t l = jl_string_len(str);
-#ifdef STORE_ARRAY_LEN
     a->length = l;
-#endif
     a->nrows = a->maxsize = l;
     return a;
 }
@@ -336,9 +328,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
     // No allocation or safepoint allowed after this
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
     a->data = data;
-#ifdef STORE_ARRAY_LEN
     a->length = nel;
-#endif
     a->elsize = LLT_ALIGN(elsz, align);
     a->flags.ptrarray = !isunboxed;
     a->flags.hasptr = isunboxed && (jl_is_datatype(eltype) && ((jl_datatype_t*)eltype)->layout->npointers > 0);
@@ -403,9 +393,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
     // No allocation or safepoint allowed after this
     a->flags.pooled = tsz <= GC_MAX_SZCLASS;
     a->data = data;
-#ifdef STORE_ARRAY_LEN
     a->length = nel;
-#endif
     a->elsize = LLT_ALIGN(elsz, align);
     a->flags.ptrarray = !isunboxed;
     a->flags.hasptr = isunboxed && (jl_is_datatype(eltype) && ((jl_datatype_t*)eltype)->layout->npointers > 0);
@@ -479,17 +467,13 @@ JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
             a->flags.isshared = 1;
             *(size_t*)o = len;
             a->nrows = 0;
-#ifdef STORE_ARRAY_LEN
             a->length = 0;
-#endif
             a->maxsize = 0;
             return o;
         }
     }
     a->nrows = 0;
-#ifdef STORE_ARRAY_LEN
     a->length = 0;
-#endif
     a->maxsize = 0;
     return jl_pchar_to_string((const char*)jl_array_data(a), len);
 }
@@ -550,16 +534,6 @@ JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_value_t *type, size_t dim)
 }
 
 // array primitives -----------------------------------------------------------
-
-#ifndef STORE_ARRAY_LEN
-JL_DLLEXPORT size_t jl_array_len_(jl_array_t *a)
-{
-    size_t l = 1;
-    for(size_t i=0; i < jl_array_ndims(a); i++)
-        l *= jl_array_dim(a, i);
-    return l;
-}
-#endif
 
 JL_DLLEXPORT jl_value_t *jl_ptrarrayref(jl_array_t *a JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT
 {
@@ -864,9 +838,7 @@ STATIC_INLINE void jl_array_grow_at_beg(jl_array_t *a, size_t idx, size_t inc,
             }
         }
     }
-#ifdef STORE_ARRAY_LEN
     a->length = newnrows;
-#endif
     a->nrows = newnrows;
     a->data = newdata;
     if (jl_is_array_zeroinit(a)) {
@@ -945,9 +917,7 @@ STATIC_INLINE void jl_array_grow_at_end(jl_array_t *a, size_t idx,
             memset(typetagdata + idx, 0, inc);
     }
     size_t newnrows = n + inc;
-#ifdef STORE_ARRAY_LEN
     a->length = newnrows;
-#endif
     a->nrows = newnrows;
     if (jl_is_array_zeroinit(a)) {
         memset(data + idx * elsz, 0, inc * elsz);
@@ -1067,9 +1037,7 @@ STATIC_INLINE void jl_array_del_at_beg(jl_array_t *a, size_t idx, size_t dec,
     size_t offset = a->offset;
     int isbitsunion = jl_array_isbitsunion(a);
     offset += dec;
-#ifdef STORE_ARRAY_LEN
     a->length = n - dec;
-#endif
     a->nrows = n - dec;
     size_t newoffs = jl_array_limit_offset(a, offset);
     assert(newoffs <= offset);
@@ -1127,9 +1095,7 @@ STATIC_INLINE void jl_array_del_at_end(jl_array_t *a, size_t idx, size_t dec,
     if (elsz == 1 && !isbitsunion)
         data[n] = 0;
     a->nrows = n;
-#ifdef STORE_ARRAY_LEN
     a->length = n;
-#endif
 }
 
 JL_DLLEXPORT void jl_array_del_at(jl_array_t *a, ssize_t idx, size_t dec)
@@ -1193,9 +1159,7 @@ JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
         jl_array_grow_end(a, inc);
 
         a->nrows = n;
-#ifdef STORE_ARRAY_LEN
         a->length = n;
-#endif
     }
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7849,9 +7849,7 @@ static void init_julia_llvm_env(Module *m)
     assert(jl_func_sig_sparams != NULL);
 
     Type *vaelts[] = {PointerType::get(T_int8, AddressSpace::Loaded)
-#ifdef STORE_ARRAY_LEN
                       , T_size
-#endif
                       , T_int16
                       , T_int16
                       , T_int32

--- a/src/julia.h
+++ b/src/julia.h
@@ -9,12 +9,6 @@
 #undef jl_longjmp
 #endif
 
-//** Configuration options that affect the Julia ABI **//
-// if this is not defined, only individual dimension sizes are
-// stored and not total length, to save space.
-#define STORE_ARRAY_LEN
-//** End Configuration options **//
-
 #include "julia_fasttls.h"
 #include "libsupport.h"
 #include <stdint.h>
@@ -174,9 +168,7 @@ typedef struct {
 JL_EXTENSION typedef struct {
     JL_DATA_TYPE
     void *data;
-#ifdef STORE_ARRAY_LEN
     size_t length;
-#endif
     jl_array_flags_t flags;
     uint16_t elsize;  // element size including alignment (dim 1 memory stride)
     uint32_t offset;  // for 1-d only. does not need to get big.
@@ -920,12 +912,7 @@ STATIC_INLINE jl_value_t *jl_svecset(
 }
 #endif
 
-#ifdef STORE_ARRAY_LEN
 #define jl_array_len(a)   (((jl_array_t*)(a))->length)
-#else
-JL_DLLEXPORT size_t jl_array_len_(jl_array_t *a);
-#define jl_array_len(a)   jl_array_len_((jl_array_t*)(a))
-#endif
 #define jl_array_data(a)  ((void*)((jl_array_t*)(a))->data)
 #define jl_array_dim(a,i) ((&((jl_array_t*)(a))->nrows)[i])
 #define jl_array_dim0(a)  (((jl_array_t*)(a))->nrows)

--- a/src/sys.c
+++ b/src/sys.c
@@ -530,9 +530,7 @@ JL_DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim, uint8_t str, uint
             a = jl_take_buffer(&dest);
         }
         else {
-#ifdef STORE_ARRAY_LEN
             a->length = n;
-#endif
             a->nrows = n;
             ((char*)a->data)[n] = '\0';
         }


### PR DESCRIPTION
The code dealing with STORE_ARRAY_LEN appears to be several years old (almost a decade in some places), and is likely unused/unsupported/untested. Removing it cleans up the codebase and makes future array work easier.