### PR TITLE
Mark stack as non-executable

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1251,6 +1251,8 @@ JLIBLDFLAGS := -Wl,-Bsymbolic-functions
 else
 JLIBLDFLAGS :=
 endif
+# Linker doesn't detect automatically that Julia doesn't need executable stack
+JLIBLDFLAGS += -Wl,-z,noexecstack
 else ifneq ($(OS), Darwin)
 JLIBLDFLAGS :=
 endif

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+using Libdl
 
 @testset "Operating system predicates" begin
     @test !Sys.isunix(:Windows)
@@ -53,6 +54,18 @@ if Sys.iswindows()
                      Base.LIBDIR, Base.PRIVATE_LIBDIR, Base.INCLUDEDIR, Base.LIBEXECDIR)
             @test !occursin("/", path)
             @test !occursin("\\\\", path)
+        end
+    end
+end
+
+if Sys.islinux() && Sys.which("readelf") !== nothing
+    @testset "stack is not marked as executable" begin
+        for f in intersect(dllist(),
+                           [readdir(joinpath(Sys.BINDIR, Base.LIBDIR), join=true);
+                            readdir(joinpath(Sys.BINDIR, Base.LIBDIR, "julia"), join=true)])
+            for l in eachline(open(`readelf -l $f`))
+                @test !(contains(l, "GNU_STACK") && contains(l, 'E'))
+            end
         end
     end
 end


### PR DESCRIPTION
The linker is unable to detect that executable stack is not required and so marks libjulia.so as requiring it
Pass `-Wl,-z,noexecstack` to ensure that the stack is marked as not executable.
This improves security and allows Julia to run on systems where SELinux has been configured to disallow executable stacks.

AFAIK no change is needed on OSes other than Linux as they do not allow executable stacks by default.

Tests will fail until https://github.com/JuliaLinearAlgebra/libblastrampoline/pull/51 is merged and libblatrampoline is updated, as libblastrampoline.so is also affected by the same problem.