### PR TITLE
last(itr) should use Iterators.reverse

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -476,7 +476,8 @@ julia> last([1; 2; 3; 4])
 4
 ```
 """
-last(a) = a[end]
+last(a) = first(Iterators.reverse(itr))
+last(a::Union{AbstractArray,Tuple}) = a[end]
 
 """
     last(itr, n::Integer)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -478,7 +478,7 @@ julia> last([1; 2; 3; 4])
 ```
 """
 last(a) = first(Iterators.reverse(itr))
-last(a::Union{AbstractArray,Tuple}) = a[end]
+last(a::Union{AbstractArray,Tuple,Cmd}) = a[end]
 
 """
     last(itr, n::Integer)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -459,11 +459,12 @@ function first(v::AbstractVector, n::Integer)
 end
 
 """
-    last(coll)
+    last(itr)
 
-Get the last element of an ordered collection, if it can be computed in O(1) time. This is
-accomplished by calling [`lastindex`](@ref) to get the last index. Return the end
-point of an [`AbstractRange`](@ref) even if it is empty.
+Get the last element of an ordered collection `itr`, if it can be computed
+in O(1) time. This is accomplished for general iterable collections by
+calling [`first`](@ref) on [`Iterators.reverse(itr)`](@ref Iterators.reverse).
+(Returns the end point of an [`AbstractRange`](@ref) even if it is empty.)
 
 See also [`first`](@ref), [`endswith`](@ref).
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -1167,9 +1167,6 @@ end
 isdone(r::Iterators.Reverse{<:EachLine}, state) = isempty(state.chunks)
 isdone(r::Iterators.Reverse{<:EachLine}) = isdone(r.itr)
 
-# use reverse iteration to get end of EachLines (if possible)
-last(itr::EachLine) = first(Iterators.reverse(itr))
-
 struct ReadEachIterator{T, IOT <: IO}
     stream::IOT
 end


### PR DESCRIPTION
As I commented in #42225, we should really default to `first(Iterators.reverse(itr))` for `last(itr)`, rather than defaulting to `itr[end]`, similar to how #34868 implemented `last(itr, n)`.

This way you automatically get `last` for any iterable object that supports reverse iteration — otherwise, `last(itr, n)` would work but `last(itr)` will fail, which is weird.

I put in an `last(a) = a[end]` fast path for `AbstractArray` and `Tuple`.

In principle, this could be a breaking, if an object is indexable but doesn't support reverse iteration, but this seems like it should be uncommon?

PS. Currently, `Cmd` supports iteration and indexing but not reverse iteration, so I added an explicit fix for that type here.  I'll make a separate PR that adds reverse iteration for `Cmd`, which is a cleaner fix.