### PR TITLE
Allow reinterpreting singleton types

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -437,13 +437,7 @@ julia> reinterpret(Float32, UInt32[1 2 3 4 5])
  1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
 ```
 """
-function reinterpret(::Type{T}, x::S) where {T,S}
-    if isdefined(T, :instance) && isdefined(S, :instance)
-        T.instance # singleton type conversion
-    else
-        bitcast(T, x)
-    end
-end
+reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
 
 """
     sizeof(T::DataType)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -437,7 +437,13 @@ julia> reinterpret(Float32, UInt32[1 2 3 4 5])
  1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
 ```
 """
-reinterpret(::Type{T}, x) where {T} = bitcast(T, x)
+function reinterpret(::Type{T}, x::S) where {T,S}
+    if isdefined(T, :instance) && isdefined(S, :instance)
+        T.instance # singleton type conversion
+    else
+        bitcast(T, x)
+    end
+end
 
 """
     sizeof(T::DataType)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -365,6 +365,10 @@ end
 @inline @propagate_inbounds function _getindex_ra(a::NonReshapedReinterpretArray{T,N,S}, i1::Int, tailinds::TT) where {T,N,S,TT}
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
+        if sizeof(T) == 0 # singleton types
+            @boundscheck checkbounds(a, i1, tailinds...)
+            return T.instance
+        end
         return reinterpret(T, a.parent[i1, tailinds...])
     else
         @boundscheck checkbounds(a, i1, tailinds...)
@@ -409,6 +413,10 @@ end
 @inline @propagate_inbounds function _getindex_ra(a::ReshapedReinterpretArray{T,N,S}, i1::Int, tailinds::TT) where {T,N,S,TT}
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
+        if sizeof(T) == 0 # singleton types
+            @boundscheck checkbounds(a, i1, tailinds...)
+            return T.instance
+        end
         return reinterpret(T, a.parent[i1, tailinds...])
     end
     @boundscheck checkbounds(a, i1, tailinds...)
@@ -489,6 +497,10 @@ end
     v = convert(T, v)::T
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
+        if sizeof(T) == 0 # singleton types
+            @boundscheck checkbounds(a, i1, tailinds...)
+            return T.instance # setindex! is a noop here
+        end
         return setindex!(a.parent, reinterpret(S, v), i1, tailinds...)
     else
         @boundscheck checkbounds(a, i1, tailinds...)
@@ -550,6 +562,10 @@ end
     v = convert(T, v)::T
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
+        if sizeof(T) == 0 # singleton types
+            @boundscheck checkbounds(a, i1, tailinds...)
+            return T.instance # setindex! is a noop here
+        end
         return setindex!(a.parent, reinterpret(S, v), i1, tailinds...)
     end
     @boundscheck checkbounds(a, i1, tailinds...)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -43,7 +43,7 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S},IsReshaped} <: AbstractArray{T
         if N != 0 && sizeof(S) != sizeof(T)
             ax1 = axes(a)[1]
             dim = length(ax1)
-            if sizeof(T) == 0
+            if isdefined(T, :instance)
                 dim == 0 || throwsingleton(S, T, "a non-empty")
             else
                 rem(dim*sizeof(S),sizeof(T)) == 0 || thrownonint(S, T, dim)
@@ -75,11 +75,11 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S},IsReshaped} <: AbstractArray{T
         if sizeof(S) == sizeof(T)
             N = ndims(a)
         elseif sizeof(S) > sizeof(T)
-            sizeof(T) == 0 && throwsingleton(S, T, "with reshape a")
+            isdefined(T, :instance) && throwsingleton(S, T, "with reshape a")
             rem(sizeof(S), sizeof(T)) == 0 || throwintmult(S, T)
             N = ndims(a) + 1
         else
-            sizeof(S) == 0 && throwfromsingleton(S, T)
+            isdefined(S, :instance) && throwfromsingleton(S, T)
             rem(sizeof(T), sizeof(S)) == 0 || throwintmult(S, T)
             N = ndims(a) - 1
             N > -1 || throwsize0(S, T, "larger")
@@ -300,7 +300,7 @@ unaliascopy(a::ReshapedReinterpretArray{T}) where {T} = reinterpret(reshape, T, 
 
 function size(a::NonReshapedReinterpretArray{T,N,S} where {N}) where {T,S}
     psize = size(a.parent)
-    size1 = sizeof(T) == 0 ? psize[1] : div(psize[1]*sizeof(S), sizeof(T))
+    size1 = isdefined(T, :instance) ? psize[1] : div(psize[1]*sizeof(S), sizeof(T))
     tuple(size1, tail(psize)...)
 end
 function size(a::ReshapedReinterpretArray{T,N,S} where {N}) where {T,S}
@@ -314,7 +314,7 @@ size(a::NonReshapedReinterpretArray{T,0}) where {T} = ()
 function axes(a::NonReshapedReinterpretArray{T,N,S} where {N}) where {T,S}
     paxs = axes(a.parent)
     f, l = first(paxs[1]), length(paxs[1])
-    size1 = sizeof(T) == 0 ? l : div(l*sizeof(S), sizeof(T))
+    size1 = isdefined(T, :instance) ? l : div(l*sizeof(S), sizeof(T))
     tuple(oftype(paxs[1], f:f+size1-1), tail(paxs)...)
 end
 function axes(a::ReshapedReinterpretArray{T,N,S} where {N}) where {T,S}
@@ -365,7 +365,7 @@ end
 @inline @propagate_inbounds function _getindex_ra(a::NonReshapedReinterpretArray{T,N,S}, i1::Int, tailinds::TT) where {T,N,S,TT}
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
-        if sizeof(T) == 0 # singleton types
+        if isdefined(T, :instance) # singleton types
             @boundscheck checkbounds(a, i1, tailinds...)
             return T.instance
         end
@@ -413,7 +413,7 @@ end
 @inline @propagate_inbounds function _getindex_ra(a::ReshapedReinterpretArray{T,N,S}, i1::Int, tailinds::TT) where {T,N,S,TT}
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
-        if sizeof(T) == 0 # singleton types
+        if isdefined(T, :instance) # singleton types
             @boundscheck checkbounds(a, i1, tailinds...)
             return T.instance
         end
@@ -497,7 +497,7 @@ end
     v = convert(T, v)::T
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
-        if sizeof(T) == 0 # singleton types
+        if isdefined(T, :instance) # singleton types
             @boundscheck checkbounds(a, i1, tailinds...)
             return T.instance # setindex! is a noop here
         end
@@ -562,7 +562,7 @@ end
     v = convert(T, v)::T
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
-        if sizeof(T) == 0 # singleton types
+        if isdefined(T, :instance) # singleton types
             @boundscheck checkbounds(a, i1, tailinds...)
             return T.instance # setindex! is a noop here
         end

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -499,9 +499,10 @@ end
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
         if Base.issingletontype(T) # singleton types
             @boundscheck checkbounds(a, i1, tailinds...)
-            return T.instance # setindex! is a noop here
+            # setindex! is a noop except for the index check
+        else
+            setindex!(a.parent, reinterpret(S, v), i1, tailinds...)
         end
-        return setindex!(a.parent, reinterpret(S, v), i1, tailinds...)
     else
         @boundscheck checkbounds(a, i1, tailinds...)
         ind_start, sidx = divrem((i1-1)*sizeof(T), sizeof(S))
@@ -564,9 +565,10 @@ end
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
         if Base.issingletontype(T) # singleton types
             @boundscheck checkbounds(a, i1, tailinds...)
-            return T.instance # setindex! is a noop here
+            # setindex! is a noop except for the index check
+        else
+            setindex!(a.parent, reinterpret(S, v), i1, tailinds...)
         end
-        return setindex!(a.parent, reinterpret(S, v), i1, tailinds...)
     end
     @boundscheck checkbounds(a, i1, tailinds...)
     t = Ref{T}(v)

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -66,18 +66,19 @@ for (_A, Ar, _B) in ((A, Ars, B), (As, Arss, Bs))
         @test Arsc == [1 -1; 2 -2]
         reinterpret(NTuple{3, Int64}, Bc)[2] = (4,5,6)
         @test Bc == Complex{Int64}[5+6im, 7+4im, 5+6im]
-        reinterpret(NTuple{3, Int64}, Bc)[1] = (1,2,3)
+        B2 = reinterpret(NTuple{3, Int64}, Bc)
+        @test setindex!(B2, (1,2,3), 1) == B2
         @test Bc == Complex{Int64}[1+2im, 3+4im, 5+6im]
         Bc = copy(_B)
         Brrs = reinterpret(reshape, Int64, Bc)
-        Brrs[2, 3] = -5
+        @test setindex!(Brrs, -5, 2, 3) == Brrs
         @test Bc == Complex{Int64}[5+6im, 7+8im, 9-5im]
         Brrs[last(eachindex(Brrs))] = 22
         @test Bc == Complex{Int64}[5+6im, 7+8im, 9+22im]
 
         A1 = reinterpret(Float64, _A)
         A2 = reinterpret(ComplexF64, _A)
-        A1[1] = 1.0
+        @test setindex!(A1, 1.0, 1) == A1
         @test real(A2[1]) == 1.0
         A1 = reinterpret(reshape, Float64, _A)
         A1[1] = 2.5
@@ -88,7 +89,7 @@ for (_A, Ar, _B) in ((A, Ars, B), (As, Arss, Bs))
         @test real(A2rs[1]) == 1.0
         A1rs = reinterpret(reshape, Float64, Ar)
         A2rs = reinterpret(reshape, ComplexF64, Ar)
-        A1rs[1, 1] = 2.5
+        @test setindex!(A1rs, 2.5, 1, 1) == A1rs
         @test real(A2rs[1]) == 2.5
     end
 end
@@ -427,7 +428,8 @@ end
     x = reinterpret(Tuple{}, t)
     @test x == reinterpret(reshape, Tuple{}, t)
     @test x[3,5] === ()
-    @test (x[1,1] = (); true)
+    x1 = fill((), 3, 5)
+    @test setindex!(x, (), 1, 1) == x1
     @test_throws BoundsError x[17]
     @test_throws BoundsError x[4,2]
     @test_throws BoundsError x[1,2,3]
@@ -438,7 +440,8 @@ end
     @test_throws BoundsError x[19]
     @test_throws BoundsError x[2,6] = SomeSingleton(0xa)
     @test x[2,3] === SomeSingleton(:x)
-    @test (x[3,5] = SomeSingleton(:); true)
-    @test x == fill(SomeSingleton(nothing), (3, 5))
+    x2 = fill(SomeSingleton(0.7), 3, 5)
+    @test x == x2
+    @test setindex!(x, SomeSingleton(:), 3, 5) == x2
     @test_throws MethodError x[2,4] = nothing
 end

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -390,6 +390,11 @@ end
     @test_throws ErrorException reinterpret(Missing, NotASingleton())
     @test_throws ErrorException reinterpret(NotASingleton, ())
 
+    @test_throws ArgumentError reinterpret(NotASingleton, fill(nothing, ()))
+    @test_throws ArgumentError reinterpret(reshape, NotASingleton, fill(missing, 3))
+    @test_throws ArgumentError reinterpret(Tuple{}, fill(NotASingleton(), 2))
+    @test_throws ArgumentError reinterpret(reshape, Nothing, fill(NotASingleton(), ()))
+
     t = fill(nothing, 3, 5)
     @test reinterpret(SomeSingleton, t) == reinterpret(reshape, SomeSingleton, t)
     @test reinterpret(SomeSingleton, t) == [SomeSingleton(i*j) for i in 1:3, j in 1:5]
@@ -429,11 +434,11 @@ end
     @test_throws BoundsError x[18] = ()
     @test_throws MethodError x[1,3] = missing
     @test x == fill((), (3, 5))
-    x = reinterpret(reshape, Tuple{}, t)
+    x = reinterpret(reshape, SomeSingleton, t)
     @test_throws BoundsError x[19]
-    @test_throws BoundsError x[2,6] = ()
-    @test x[2,3] === ()
-    @test (x[3,5] = (); true)
-    @test x == fill((), (3, 5))
+    @test_throws BoundsError x[2,6] = SomeSingleton(0xa)
+    @test x[2,3] === SomeSingleton(:x)
+    @test (x[3,5] = SomeSingleton(:); true)
+    @test x == fill(SomeSingleton(nothing), (3, 5))
     @test_throws MethodError x[2,4] = nothing
 end


### PR DESCRIPTION
Fix #43403. It does not actually allow reinterpreting all 0-sized types, only the immutable ones (aka singleton types), but I think that's what was intended anyway (see also #17149).

I'm not sure whether it should be merged, considering what @vtjnash said in https://github.com/JuliaLang/julia/issues/34865#issuecomment-590945279, but I'm opening the PR in case it is decided it is worth adding.

Since `reinterpret` is a fairly basic building block, there is also the potential issue of slowing down critical paths. I don't think there is any harm done in this regard since the `sizeof(T) == 0` and `isdefined(T, :instance)` conditions should all be eliminated at compilation I think, but I'm no expert on this.