### PR TITLE
apply_by_to_key keyword for searchsorted

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -174,7 +174,7 @@ _Val(x) = _Val{x}()
 # If the 4th argument to _ord is _Val{false}, then the `by` function
 # is skipped for any element a of the form maybe_skip_by(a)
 
-_ord(lt::typeof(isless), by::typeof(identity), order::Ordering, ::_Val{true}) = 
+_ord(lt::typeof(isless), by::typeof(identity), order::Ordering, ::_Val{true}) =
     order
 _ord(lt::typeof(isless), by::typeof(identity), order::Ordering, ::_Val{false}) =
     order
@@ -204,10 +204,10 @@ function _ord(lt, by, order::Ordering, ::_Val{true})
 end
 
 
- 
+
 
 """
-    ord(lt, by, rev::Union{Bool, Nothing}, 
+    ord(lt, by, rev::Union{Bool, Nothing},
         order::Ordering=Forward, require_by=true)
 
 Construct an [`Ordering`](@ref) object from the same arguments used by
@@ -223,7 +223,7 @@ Passing an `lt` other than `isless` along with an `order` other than
 otherwise all options are independent and can be used together in all possible
 combinations.
 
-If `require_by` is true, then function `maybe_skip_by(a)` 
+If `require_by` is true, then function `maybe_skip_by(a)`
 is the same as `identity(a)` and therefore
 `by` is  applied in all cases.
 If `require_by` is false then the `by` function is

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -86,7 +86,11 @@ end
                 Float16, Float32, Float64, BigInt, BigFloat]
 
     @test searchsorted([1:10;], 1, by=(x -> x >= 5)) == 1:4
+    @test searchsorted([1:10;], false, by=(x -> x >= 5),
+                       apply_by_to_key=false) == 1:4
     @test searchsorted([1:10;], 10, by=(x -> x >= 5)) == 5:10
+    @test searchsorted([1:10;], true, by=(x -> x >= 5),
+                       apply_by_to_key=false) == 5:10
     @test searchsorted([1:5; 1:5; 1:5], 1, 6, 10, Forward) == 6:6
     @test searchsorted(fill(1, 15), 1, 6, 10, Forward) == 6:10
 
@@ -346,6 +350,7 @@ end
 
     @test insorted(1, collect(1:10), by=(>=(5)))
     @test insorted(10, collect(1:10), by=(>=(5)))
+    @test insorted(true, collect(1:10), by=(>=(5)), apply_by_to_key=false)
 
     for R in numTypes, T in numTypes
         @test !insorted(T(0), R[1, 1, 2, 2, 3, 3])
@@ -393,6 +398,7 @@ end
     @test !insorted(0, [1,2,3])
     @test !insorted(4, [1,2,3])
     @test insorted(3, [10,8,6,9,4,7,2,5,3,1], by=(x -> iseven(x) ? x+5 : x), rev=true)
+    @test insorted(4, [10,8,6,9,4,7,2,5,3,1], by=(x -> iseven(x) ? x+6 : x+1), rev=true, apply_by_to_key=false)
 end
 @testset "PartialQuickSort" begin
     a = rand(1:10000, 1000)


### PR DESCRIPTION
This update to ordering.jl and sort.jl adds a new keyword apply_by_to_key to the searchsorted family of functions and
and insorted.  This commit address an issue that trips up many users: the
"by" keyword is unexpectedly applied to the search key.  This makes
the functions particularly awkward if the "by" function extracts part
of a larger object.  This patch is meant to address issue https://github.com/JuliaLang/julia/issues/9429 as
well as repeats including https://github.com/JuliaLang/julia/issues/33997 and https://github.com/JuliaLang/julia/pull/35418