### PR TITLE
Covariance support for @NamedTuple

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -398,7 +398,7 @@ NamedTuple{(:a, :b), Tuple{Float64, String}}
 """
 macro NamedTuple(x)
     Meta.isexpr(x, (:braces, :block)) || throw(ArgumentError("@NamedTuple expects {...} or begin...end"))
-    covar = length(x.args)==1 && Meta.isexpr(x.args[1], :<:)
+    covar = Meta.isexpr(x,:braces,1) && Meta.isexpr(x.args[1], :<:)
     covar && (x = x.args[1])
     xdecls = filter(xa -> !(xa isa LineNumberNode), x.args)
     all(xa -> xa isa Symbol || Meta.isexpr(xa, :(::)), xdecls) ||

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -314,6 +314,10 @@ end
     @test @NamedTuple{a::Int, b} === NamedTuple{(:a, :b),Tuple{Int,Any}}
     @test_throws LoadError include_string(Main, "@NamedTuple{a::Int, b, 3}")
     @test_throws LoadError include_string(Main, "@NamedTuple(a::Int, b)")
+    @test (a=1,b=true) isa @NamedTuple{a::Int, b::Bool}
+    @test (a=1,b=true) isa @NamedTuple{<:(a::Int, b::Bool)}
+    @test (a=1,b=true) isa @NamedTuple{<:(a::Int, b::Union{Bool,Nothing})}
+    @test (a=1,b=nothing) isa @NamedTuple{<:(a::Int, b::Union{Bool,Nothing})}
 end
 
 # issue #29333, implicit names


### PR DESCRIPTION
With @NamedTuple, one can code
```julia
using Test
@test (a=1,b=true) isa NamedTuple{(:a,:b),Tuple{Int,Bool}}
```
by shortening it with
```julia
@test (a=1,b=true) isa @NamedTuple{a::Int, b::Bool}
```
but this fails with, for example, a nullable type
```julia
@test_broken (a=1,b=true) isa @NamedTuple{a::Int, b::Union{Bool,Nothing}}
# logical since it expands to :
@test_broken (a=1,b=true) isa NamedTuple{(:a,:b),Tuple{Int,Union{Bool,Nothing}}}
# namedtuple covariance is not handled. this is what we are looking for
@test (a=1,b=true) isa NamedTuple{(:a,:b),<:Tuple{Int,Union{Bool,Nothing}}}
```
This PR propose to make it work, by adding a `<:` recognition
```julia
@test (a=1,b=true) isa @NamedTuple{<:(a::Int, b::Union{Bool,Nothing})}
```
nota i do not code the `@NamedTuple <: begin ... end` form since i consider it less natural.