### PR TITLE
Use correct delimiter for inline code in DelimitedFiles.

### DIFF
--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -190,7 +190,7 @@ Specifying `skipstart` will ignore the corresponding number of initial lines fro
 If `skipblanks` is `true`, blank lines in the input will be ignored.
 
 If `use_mmap` is `true`, the file specified by `source` is memory mapped for potential
-speedups if the file is large. Default is `false'. On a Windows filesystem, `use_mmap` should not be set
+speedups if the file is large. Default is `false`. On a Windows filesystem, `use_mmap` should not be set
 to `true` unless the file is only read once and is also not written to.
 Some edge cases exist where an OS is Unix-like but the filesystem is Windows-like.
 


### PR DESCRIPTION
Happened upon this mistake today while checking the docs for `readdlm`, originally ' had been used to close an inline code section, but it should be \`.