### PR TITLE
Mention const field of mutable struct

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -464,6 +464,9 @@ one can declare these fields as such using `const` as shown below. This enables 
 but not all of the optimizations of immutable structs, and can be used to enforce invariants
 on the particular fields marked as `const`.
 
+!!! compat "Julia 1.8"
+    `const` annotating fields of mutable structs requires at least Julia 1.8.
+
 ```jldoctest baztype
 julia> mutable struct Baz
            a::Int

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -459,6 +459,27 @@ To recap, two essential properties define immutability in Julia:
       functions as pointers to heap-allocated values except in cases where the compiler
       is sure that there's no way to tell that this is not what is happening.
 
+In cases where one or more fields of an otherwise mutable struct is known to be immutable,
+one can declare these fields as such using `const` as shown below. This enables some,
+but not all of the optimizations of immutable structs, and can be used to enforce invariants
+on the particular fields marked as `const`.
+
+```jldoctest baztype
+julia> mutable struct Baz
+           a::Int
+           const b::Float64
+       end
+
+julia> baz = Baz(1, 1.5);
+
+julia> baz.a = 2
+2
+
+julia> baz.b = 2.0
+ERROR: setfield!: const field .b of type Baz cannot be changed
+[...]
+```
+
 ## [Declared Types](@id man-declared-types)
 
 The three kinds of types (abstract, primitive, composite) discussed in the previous


### PR DESCRIPTION
Mention the new feature of #43305 in the manual.
If merged, the "needs docs" label on the parent PR can be removed.