### PR TITLE
only Text and HTML *exports* should be deprecated

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -21,7 +21,7 @@ You can also use a stream for large amounts of data:
 
 !!! warning
     `HTML` is currently exported to maintain
-    backwards-compatibility, but this export
+    backwards compatibility, but this export
     is deprecated. It is recommended to use
     this type as `Docs.HTML` or to explicitly
     import it from `Docs`.
@@ -79,7 +79,7 @@ You can also use a stream for large amounts of data:
 
 !!! warning
     `Text` is currently exported to maintain
-    backwards-compatibility, but this export
+    backwards compatibility, but this export
     is deprecated. It is recommended to use
     this type as `Docs.Text` or to explicitly
     import it from `Docs`.

--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -21,8 +21,10 @@ You can also use a stream for large amounts of data:
 
 !!! warning
     `HTML` is currently exported to maintain
-    backwards-compatibility, but is considered
-    to be deprecated and should not be used.
+    backwards-compatibility, but this export
+    is deprecated. It is recommended to use
+    this type as `Docs.HTML` or to explicitly
+    import it from `Docs`.
 """
 mutable struct HTML{T}
     content::T
@@ -77,8 +79,10 @@ You can also use a stream for large amounts of data:
 
 !!! warning
     `Text` is currently exported to maintain
-    backwards-compatibility, but is considered
-    to be deprecated and should not be used.
+    backwards-compatibility, but this export
+    is deprecated. It is recommended to use
+    this type as `Docs.Text` or to explicitly
+    import it from `Docs`.
 """
 mutable struct Text{T}
     content::T


### PR DESCRIPTION
#38909 added a deprecation warning for the `HTML` and `Text` exports.   However, I think that PR went too far in recommending that these types "should not be used", because there is no alternative type to `Text` (e.g. for plain-text documentation, which can easily arise from non-Julia API docs, such as in PyCall).

Instead, I think we should merely recommend that people use `Docs.Text` and `Docs.HTML`, or import these symbols explicitly from `Docs`, rather than relying on the exports.   This paves the way for removing the exports in 2.0 (which can easily conflict with other types since the names are so generic), while making it clear that they are still usable for the narrow purpose of text/plain and text/html documentation.