### PR TITLE
Improve inference for fallback TerminalMenu config access

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -388,27 +388,27 @@ end
 scroll_wrap(m::ConfiguredMenu) = scroll_wrap(m.config)
 scroll_wrap(c::AbstractConfig) = scroll_wrap(c.config)
 scroll_wrap(c::Config) = c.scroll_wrap
-scroll_wrap(::AbstractMenu)::Bool = CONFIG[:scroll_wrap]
+scroll_wrap(::AbstractMenu) = CONFIG[:scroll_wrap]::Bool
 
 ctrl_c_interrupt(m::ConfiguredMenu) = ctrl_c_interrupt(m.config)
 ctrl_c_interrupt(c::AbstractConfig) = ctrl_c_interrupt(c.config)
 ctrl_c_interrupt(c::Config) = c.ctrl_c_interrupt
-ctrl_c_interrupt(::AbstractMenu)::Bool = CONFIG[:ctrl_c_interrupt]
+ctrl_c_interrupt(::AbstractMenu) = CONFIG[:ctrl_c_interrupt]::Bool
 
 up_arrow(m::ConfiguredMenu) = up_arrow(m.config)
 up_arrow(c::AbstractConfig) = up_arrow(c.config)
 up_arrow(c::Config) = c.up_arrow
-up_arrow(::AbstractMenu)::Char = CONFIG[:up_arrow]
+up_arrow(::AbstractMenu) = CONFIG[:up_arrow]::Char
 
 down_arrow(m::ConfiguredMenu) = down_arrow(m.config)
 down_arrow(c::AbstractConfig) = down_arrow(c.config)
 down_arrow(c::Config) = c.down_arrow
-down_arrow(::AbstractMenu)::Char = CONFIG[:down_arrow]
+down_arrow(::AbstractMenu) = CONFIG[:down_arrow]::Char
 
 updown_arrow(m::ConfiguredMenu) = updown_arrow(m.config)
 updown_arrow(c::AbstractConfig) = updown_arrow(c.config)
 updown_arrow(c::Config) = c.updown_arrow
-updown_arrow(::AbstractMenu)::Char = CONFIG[:updown_arrow]
+updown_arrow(::AbstractMenu) = CONFIG[:updown_arrow]::Char
 
 printcursor(buf, m::ConfiguredMenu, iscursor::Bool) = print(buf, iscursor ? cursor(m.config) : ' ', ' ')
 cursor(c::AbstractConfig) = cursor(c.config)

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -388,27 +388,27 @@ end
 scroll_wrap(m::ConfiguredMenu) = scroll_wrap(m.config)
 scroll_wrap(c::AbstractConfig) = scroll_wrap(c.config)
 scroll_wrap(c::Config) = c.scroll_wrap
-scroll_wrap(::AbstractMenu) = CONFIG[:scroll_wrap]
+scroll_wrap(::AbstractMenu)::Bool = CONFIG[:scroll_wrap]
 
 ctrl_c_interrupt(m::ConfiguredMenu) = ctrl_c_interrupt(m.config)
 ctrl_c_interrupt(c::AbstractConfig) = ctrl_c_interrupt(c.config)
 ctrl_c_interrupt(c::Config) = c.ctrl_c_interrupt
-ctrl_c_interrupt(::AbstractMenu) = CONFIG[:ctrl_c_interrupt]
+ctrl_c_interrupt(::AbstractMenu)::Bool = CONFIG[:ctrl_c_interrupt]
 
 up_arrow(m::ConfiguredMenu) = up_arrow(m.config)
 up_arrow(c::AbstractConfig) = up_arrow(c.config)
 up_arrow(c::Config) = c.up_arrow
-up_arrow(::AbstractMenu) = CONFIG[:up_arrow]
+up_arrow(::AbstractMenu)::Char = CONFIG[:up_arrow]
 
 down_arrow(m::ConfiguredMenu) = down_arrow(m.config)
 down_arrow(c::AbstractConfig) = down_arrow(c.config)
 down_arrow(c::Config) = c.down_arrow
-down_arrow(::AbstractMenu) = CONFIG[:down_arrow]
+down_arrow(::AbstractMenu)::Char = CONFIG[:down_arrow]
 
 updown_arrow(m::ConfiguredMenu) = updown_arrow(m.config)
 updown_arrow(c::AbstractConfig) = updown_arrow(c.config)
 updown_arrow(c::Config) = c.updown_arrow
-updown_arrow(::AbstractMenu) = CONFIG[:updown_arrow]
+updown_arrow(::AbstractMenu)::Char = CONFIG[:updown_arrow]
 
 printcursor(buf, m::ConfiguredMenu, iscursor::Bool) = print(buf, iscursor ? cursor(m.config) : ' ', ' ')
 cursor(c::AbstractConfig) = cursor(c.config)


### PR DESCRIPTION
Default terminal menus use the global dict `CONFIG` to get its values. Since this dict has the valtype `Union{String, Char, Bool}`, it leads to unnecessary type instability when loading from it.
This PR adds typeasserts. It does not reduce generalizability, since only the fallback methods are affected. The non-fallback methods already use type-stable code and is more extensible.