### PR TITLE
Add tests for allunique with large input size

### DIFF
--- a/test/sets.jl
+++ b/test/sets.jl
@@ -510,6 +510,8 @@ end
              LinRange(1, 2, 3), LinRange(1, 1, 0), LinRange(1, 1, 1), LinRange(1, 1, 10))
         @test allunique(r) == invoke(allunique, Tuple{Any}, r)
     end
+    @test allunique([1:2000;])
+    @test !allunique([1:2000; 500])
 end
 @testset "filter(f, ::$S)" for S = (Set, BitSet)
     s = S([1,2,3,4])


### PR DESCRIPTION
PR #37208 added a branch to `allunique`, such that there is a separate code path when the input contains more than 1000 elements.  However, this branch remained untested prior to now, as none of the existing tests exceeded that threshold.