### PR TITLE
Add Irrational support to rem2pi

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1202,9 +1202,13 @@ end
 rem2pi(x::Float32, r::RoundingMode) = Float32(rem2pi(Float64(x), r))
 rem2pi(x::Float16, r::RoundingMode) = Float16(rem2pi(Float64(x), r))
 rem2pi(x::Int32, r::RoundingMode) = rem2pi(Float64(x), r)
-function rem2pi(x::Int64, r::RoundingMode)
+function rem2pi(x::Integer, r::RoundingMode)
     fx = Float64(x)
-    fx == x || throw(ArgumentError("Int64 argument to rem2pi is too large: $x"))
+    fx == x || throw(ArgumentError("Integer argument to rem2pi is too large: $x"))
+    rem2pi(fx, r)
+end
+function rem2pi(x::Real, r::RoundingMode)
+    fx = Float64(x)
     rem2pi(fx, r)
 end
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -1208,7 +1208,8 @@ function rem2pi(x::Integer, r::RoundingMode)
     rem2pi(fx, r)
 end
 function rem2pi(x::Real, r::RoundingMode)
-    fx = Float64(x)
+    fx = float(x)
+    x === fx && throw(MethodError(rem2pi, (x, r)))
     rem2pi(fx, r)
 end
 

--- a/base/mathconstants.jl
+++ b/base/mathconstants.jl
@@ -129,4 +129,9 @@ Base.sincos(::Irrational{:π}) = (0.0, -1.0)
 Base.tan(::Irrational{:π}) = 0.0
 Base.cot(::Irrational{:π}) = -1/0
 
+Base.rem2pi(::Irrational{:π}, ::RoundingMode{:Nearest}) = π
+Base.rem2pi(::Irrational{:π}, ::RoundingMode{:ToZero}) = π
+Base.rem2pi(::Irrational{:π}, ::RoundingMode{:Down}) = π
+Base.rem2pi(::Irrational{:π}, ::RoundingMode{:Up}) = -π
+
 end # module

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2611,6 +2611,14 @@ end
     @test rem2pi(T(-8), RoundUp)      ≈ -8+2pi
 end
 
+@testset "rem2pi irrational" begin
+    @test rem2pi(π, RoundNearest) ≈ rem2pi(float(π), RoundNearest)
+    @test rem2pi(π, RoundToZero) ≈ rem2pi(float(π), RoundToZero)
+    @test rem2pi(π, RoundDown) ≈ rem2pi(float(π), RoundDown)
+    @test rem2pi(π, RoundUp) ≈ rem2pi(float(π), RoundUp)
+    @test rem2pi(ℯ, RoundNearest) ≈ rem2pi(float(ℯ), RoundNearest)
+end
+
 import Base.^
 struct PR20530; end
 struct PR20889; x; end


### PR DESCRIPTION
This adds `Irrational` support to `rem2pi` and thus fixes #42799.  One thing that is a bit awkward is that `rem2pi(π, r)` returns `π` in the form of an `Irrational` for each rounding mode _except_ `RoundUp`, where it instead returns the `Float64` equivalent of `-π`.  I don't expect this will lead to type instability in practice, as typically the rounding mode is fixed in the code and is thus known at compile time.

I also added a version that accepts any `Real`, so that e.g. the exponential constant ℯ can be passed.  Admittedly, I don't see any real use case for calling with that constant in particular, but at least it works as expected now, and there are likely other, more useful, cases that will benefit from this.  It also follows the practice of other methods (e.g. `sin`, `cos`), which do indeed accept this constant by converting it to a `float`.  While making this change, I also changed the existing method specializing on `Int64` to specialize on `Integer` instead, as that method will work for any `Integer` that can be exactly converted to a `Float64`, whether it is an `Int16`, `Int32`, `Int64`, or even a `BigInt`. 