### PR TITLE
Fix a markdown link syntax error

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -717,7 +717,7 @@ the woken task.
 
 !!! warning
     It is incorrect to use `schedule` on an arbitrary `Task` that has already been started.
-    See [the API reference](@id low-level-schedule-wait) for more information.
+    See [the API reference](@ref low-level-schedule-wait) for more information.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Fix the following issue:

The following warning appeared on win64 during building after this PR:
```julia
┌ Warning: invalid local link: unresolved path in base\parallel.md
│   link.text =
│    1-element Vector{Any}:
│     "the API reference"
│   link.url = "@id low-level-schedule-wait"
└ @ Documenter.Writers.HTMLWriter C:\Users\MYJ\Documents\GitHub\julia\doc\deps\packages\Documenter\qdbx6\src\Writers\HTML
Writer.jl:2074
```

_Originally posted by @N5N3 in https://github.com/JuliaLang/julia/issues/41270#issuecomment-1000885805_