### PR TITLE
patch:Fedora julia package link ( fix 404 )

### DIFF
--- a/doc/src/devdocs/build/distributing.md
+++ b/doc/src/devdocs/build/distributing.md
@@ -71,7 +71,7 @@ package such as a `.deb`, or `.rpm`, some extra effort is needed. See the
 [julia-debian](https://github.com/staticfloat/julia-debian) repository
 for an example of what metadata is needed for creating `.deb` packages
 for Debian and Ubuntu-based systems. See the
-[Fedora package](https://admin.fedoraproject.org/pkgdb/package/julia/)
+[Fedora package](https://src.fedoraproject.org/rpms/julia)
 for RPM-based distributions. Although we have not yet experimented
 with it, [Alien](https://wiki.debian.org/Alien) could be used to
 generate Julia packages for various Linux distributions.


### PR DESCRIPTION
Patch/Replace:   The Fedora package links in the https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/distributing.md

* now:  https://admin.fedoraproject.org/pkgdb/package/julia/  ( 404: "The requested URL was not found on this server." )
* to:  https://src.fedoraproject.org/rpms/julia 

this is the same source link as referenced in https://koji.fedoraproject.org/koji/buildinfo?buildID=1869490
