### PR TITLE
Don't set HAVE_SSP unconditionally on aarch64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -891,7 +891,6 @@ OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
 USE_BLAS64:=1
 BINARY:=64
-HAVE_SSP:=1
 ifeq ($(OS),Darwin)
 # Apple Chips are all at least A12Z
 MCPU:=apple-a12


### PR DESCRIPTION
There is no plausible reason for this. And indeed, this patch [fixes compilation for the libjulia_jll builder on Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/pull/4053) which currently fails due to the absence of libssp. Apparently also issue #43071 was caused by this.

The removed line was introduced in PR #41936 (by @JeffBezanson) but without any justification that I could discern, so it might have just slipped in there accidentally.

CC @giordano 