### PR TITLE
Add method `split(str, dlm, ::Val{N})` for allocation-free splitting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@ New library functions
 * `diskstat(path=pwd())` can be used to return statistics about the disk. ([#42248])
 * `copyuntil(out, io, delim)` and `copyline(out, io)` copy data into an `out::IO` stream ([#48273]).
 * `eachrsplit(string, pattern)` iterates split substrings right to left.
+* `split(string, dlm, ::Val{N})` splits to a `Tuple` generally without allocating.
 
 New library features
 --------------------

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -727,6 +727,40 @@ split(str::AbstractString;
     split(str, isspace; limit, keepempty)
 
 """
+    split(str, dlm, ::Val{N}; keepempty=true)
+    split(str, ::Val{N}; keepempty=false)
+
+Return an `NTuple{N, SubString}` obtained from the splitting at the first `N-1`
+occurrences of `dlm`. Will throw an error if `dlm` occurs fewer than `N-1` times in `str`.
+
+To check if `dlm` occurs more than `N-1` times, check for the presence of `dlm` in the last
+element of the result.
+The `keepempty` argument is the same as for [`split`](@ref).
+
+!!! compat "Julia 1.11"
+    This method requires Julia 1.11 or later.
+
+# Examples
+```jldoctest
+julia> split("abc  γβ  ακ xyz", Val(3))
+("abc", "γβ", " ακ xyz")
+
+julia> split("a.b.c.d.e", '.', Val(4))
+("a", "b", "c", "d.e")
+
+julia> split("a.b", '.', Val(3))
+ERROR: ArgumentError: too few elements for tuple type Tuple{T} where T
+[...]
+```
+"""
+function split(str::AbstractString, dlm, ::Val{N}; keepempty=true) where N
+    n = Int(N)
+    NTuple{n}(eachsplit(str, dlm; limit=n, keepempty))
+end
+
+split(str::AbstractString, n::Val; keepempty=false) = split(str, isspace, n; keepempty)
+
+"""
     rsplit(s::AbstractString; limit::Integer=0, keepempty::Bool=false)
     rsplit(s::AbstractString, chars; limit::Integer=0, keepempty::Bool=true)
 
@@ -764,6 +798,41 @@ end
 rsplit(str::AbstractString;
       limit::Integer=0, keepempty::Bool=false) =
     rsplit(str, isspace; limit, keepempty)
+
+"""
+    rsplit(str, dlm, ::Val{N}; keepempty=true)
+    rsplit(str, ::Val{N}; keepempty=false)
+
+Return an `NTuple{N, SubString}` obtained from the splitting at the last `N-1`
+occurrences of `dlm`. Will throw an error if `dlm` occurs fewer than `N-1` times in `str`.
+
+To check if `dlm` occurs more than `N-1` times, check for the presence of `dlm` in the last
+element of the result.
+The `keepempty` argument is the same as for [`rsplit`](@ref).
+
+!!! compat "Julia 1.11"
+    This method requires Julia 1.11 or later.
+
+# Examples
+```jldoctest
+julia> rsplit("abc  γβ  ακ xyz", Val(3))
+("abc  γβ ", "ακ", "xyz")
+
+julia> rsplit("a.b.c.d.e", '.', Val(4))
+("a.b", "c", "d", "e")
+
+julia> rsplit("a.b", '.', Val(3))
+ERROR: ArgumentError: too few elements for tuple type Tuple{T} where T
+[...]
+```
+"""
+function rsplit(str::AbstractString, dlm, ::Val{N}; keepempty=true) where N
+    n = Int(N)
+    # eachrsplit iterates from right to left, but rsplit returns its elements left to right
+    reverse(NTuple{n}(eachrsplit(str, dlm; limit=n, keepempty)))
+end
+
+rsplit(str::AbstractString, n::Val; keepempty=false) = rsplit(str, isspace, n; keepempty)
 
 _replace(io, repl, str, r, pattern) = print(io, repl)
 _replace(io, repl::Function, str, r, pattern) =

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -234,6 +234,31 @@ end
     @test collect(eachrsplit("  a  b  c  d"; limit=3)) == ["d", "c", "  a  b "]
 end
 
+@testset "split to tuple" begin
+    # Cases where all elements are split, so they behave equivalently
+    @test split("a b c", Val(3)) == split("a b c", Val(3)) == ("a", "b", "c")
+    @test split("a b c d", Val(4)) == rsplit("a b c d", Val(4)) == ("a", "b", "c", "d")
+    @test split("a.:.b", ".:.", Val(2)) == rsplit("a.:.b", ".:.", Val(2)) == ("a", "b")
+    @test split(" a b  c", Val(5); keepempty = true) ==
+          split(" a b  c", Val(5); keepempty = true) ==
+          ("", "a", "b", "", "c")
+    @test split("", isascii, Val(1)) == rsplit("", isascii, Val(1)) == ("",)
+
+    # Cases where not all elements are split
+    @test  split("abc1def12", isnumeric, Val(3)) == ("abc", "def", "2")
+    @test rsplit("abc1def12", isnumeric, Val(3)) == ("abc1def", "", "")
+    @test  split("ab  cde  fg", Val(4); keepempty=true) == ("ab", "", "cde", " fg")
+    @test rsplit("ab  cde  fg", Val(4); keepempty=true) == ("ab ", "cde", "", "fg")
+
+
+    # Too few elements for the tuple
+    @test_throws ArgumentError split("a b", Val(3))
+    @test_throws ArgumentError rsplit("a b", Val(3))
+    @test_throws ArgumentError rsplit("a.:.b.:.c.:.d", ".:.", Val(5))
+    @test_throws ArgumentError split("", "abce", Val(2))
+    @test_throws ArgumentError split("a..b..c", '.', Val(6))
+end
+
 @testset "replace" begin
     @test replace("\u2202", '*' => '\0') == "\u2202"
 


### PR DESCRIPTION
Often, when processing text, you run into the need to split some string at a delimiter. Julia already provides the `eachsplit` iterator, as well as the `split` function. However, the `split` function returns an array and hence forces an allocation, which makes it unsuitable in performance sensitive code. Working directly with a `eachsplit` iterator is possible in v1.8, but it's bothersome to call `iterate(itr, state)` multiple times to split a line in say, 5 parts.

This issue is not unique to Julia. Python provides the method `str.partition`, which splits a string exactly once and returns the result as a tuple. Rust provides the similar `str::split_once`. Convenience methods like this are _very_ useful when text processing. In Julia, however, we can generalize it to N splits, while still avoiding allocations.

This PR adds a new method to `split`: `split(::AbstractString, dlm, ::Val{N})`. I believe this is worth adding another export to Base because
* Splitting is a common task with strings
* The API provided by the new method is both convenient and can be implemented fast enough that users won't have to roll their own
* It is not completely trivial to figure out how to correctly write this function.

Note that this PR is based on #51646, which needs to be merged first.