### PR TITLE
Add section on additional spurious warnings to the Valgrind devdocs

### DIFF
--- a/doc/src/devdocs/valgrind.md
+++ b/doc/src/devdocs/valgrind.md
@@ -16,7 +16,7 @@ memory pools disabled.  The compile-time flag `MEMDEBUG` disables memory pools i
 `MEMDEBUG2` disables memory pools in FemtoLisp.  To build `julia` with both flags, add the following
 line to `Make.user`:
 
-```julia
+```make
 CFLAGS = -DMEMDEBUG -DMEMDEBUG2
 ```
 

--- a/doc/src/devdocs/valgrind.md
+++ b/doc/src/devdocs/valgrind.md
@@ -55,6 +55,46 @@ valgrind --smc-check=all-non-file --trace-children=yes --suppressions=$PWD/../co
 If you would like to see a report of "definite" memory leaks, pass the flags `--leak-check=full --show-leak-kinds=definite`
 to `valgrind` as well.
 
+## Additional spurious warnings
+
+This section covers Valgrind warnings which cannot be added to the
+suppressions file yet are nonetheless safe to ignore.
+
+### Unhandled rr system calls
+
+Valgrind will emit a warning if it encounters any of the [system calls
+that are specific to
+rr](https://github.com/rr-debugger/rr/blob/master/src/preload/rrcalls.h),
+the [Record and Replay Framework](https://rr-project.org/).  In
+particular, a warning about an unhandled `1008` syscall will be shown
+when julia tries to detect whether it is running under rr:
+
+```
+--xxxxxx-- WARNING: unhandled amd64-linux syscall: 1008
+--xxxxxx-- You may be able to write your own handler.
+--xxxxxx-- Read the file README_MISSING_SYSCALL_OR_IOCTL.
+--xxxxxx-- Nevertheless we consider this a bug.  Please report
+--xxxxxx-- it at http://valgrind.org/support/bug_reports.html.
+```
+
+This issue
+[has been reported](https://bugs.kde.org/show_bug.cgi?id=446401)
+to the Valgrind developers as they have requested.
+
+### Invalid file descriptors used by libunwind
+
+The following double warning can also be ignored:
+
+```
+==xxxxxx== Warning: invalid file descriptor -1 in syscall close()
+==xxxxxx== Warning: invalid file descriptor -1 in syscall close()
+```
+
+The code that causes this warning [has been fixed in recent versions of
+libunwind](https://github.com/libunwind/libunwind/commit/b256722d49a63719c69c0416eba9163a4d069584),
+but all supported Julia versions at the time of writing (1.6 LTS and
+1.7) are built with an older libunwind which does not contain this fix.
+
 ## Caveats
 
 Valgrind currently [does not support multiple rounding modes](https://bugs.kde.org/show_bug.cgi?id=136779),

--- a/doc/src/devdocs/valgrind.md
+++ b/doc/src/devdocs/valgrind.md
@@ -81,20 +81,6 @@ This issue
 [has been reported](https://bugs.kde.org/show_bug.cgi?id=446401)
 to the Valgrind developers as they have requested.
 
-### Invalid file descriptors used by libunwind
-
-The following double warning can also be ignored:
-
-```
-==xxxxxx== Warning: invalid file descriptor -1 in syscall close()
-==xxxxxx== Warning: invalid file descriptor -1 in syscall close()
-```
-
-The code that causes this warning [has been fixed in recent versions of
-libunwind](https://github.com/libunwind/libunwind/commit/b256722d49a63719c69c0416eba9163a4d069584),
-but all supported Julia versions at the time of writing (1.6 LTS and
-1.7) are built with an older libunwind which does not contain this fix.
-
 ## Caveats
 
 Valgrind currently [does not support multiple rounding modes](https://bugs.kde.org/show_bug.cgi?id=136779),


### PR DESCRIPTION
This adds a section on spurious warnings to the Valgrind devdocs with the following subsections:
- Unhandled rr system calls
- Invalid file descriptors used by libunwind