### PR TITLE
correct pointing in "@projectname --project" testing

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -140,8 +140,6 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     let expanded = abspath(Base.load_path_expand("@foo"))
         @test expanded == readchomp(`$exename --project='@foo' -e 'println(Base.active_project())'`)
         @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => "$(Base.DEPOT_PATH[1])"))
-        
-        
     end
 
     # --quiet, --banner

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -139,15 +139,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # handling of @projectname in --project and JULIA_PROJECT
     let expanded = abspath(Base.load_path_expand("@foo"))
         @test expanded == readchomp(`$exename --project='@foo' -e 'println(Base.active_project())'`)
-        let
-            env = Dict{String, String}()
-            env["JULIA_PROJECT"] = "@foo"
-            env["HOME"] = homedir()
-            if haskey(ENV, "JULIA_DEPOT_PATH")
-                env["JULIA_DEPOT_PATH"] = ENV["JULIA_DEPOT_PATH"]
-            end
-            @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, env))
-        end
+        @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
     end
 
     # --quiet, --banner

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -139,7 +139,9 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # handling of @projectname in --project and JULIA_PROJECT
     let expanded = abspath(Base.load_path_expand("@foo"))
         @test expanded == readchomp(`$exename --project='@foo' -e 'println(Base.active_project())'`)
-        @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
+        @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => "$(Base.DEPOT_PATH[1])"))
+        
+        
     end
 
     # --quiet, --banner

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -139,7 +139,15 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # handling of @projectname in --project and JULIA_PROJECT
     let expanded = abspath(Base.load_path_expand("@foo"))
         @test expanded == readchomp(`$exename --project='@foo' -e 'println(Base.active_project())'`)
-        @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
+        let
+            env = Dict{String, String}()
+            env["JULIA_PROJECT"] = "@foo"
+            env["HOME"] = homedir()
+            if haskey(ENV, "JULIA_DEPOT_PATH")
+                env["JULIA_DEPOT_PATH"] = ENV["JULIA_DEPOT_PATH"]
+            end
+            @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, env))
+        end
     end
 
     # --quiet, --banner

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -132,7 +132,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     if !Sys.iswindows()
         let expanded = abspath(expanduser("~/foo/Project.toml"))
             @test expanded == readchomp(`$exename --project='~/foo' -e 'println(Base.active_project())'`)
-            @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir()))
+            @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir(), , "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
         end
     end
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -132,7 +132,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     if !Sys.iswindows()
         let expanded = abspath(expanduser("~/foo/Project.toml"))
             @test expanded == readchomp(`$exename --project='~/foo' -e 'println(Base.active_project())'`)
-            @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
+            @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir()))
         end
     end
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -139,7 +139,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # handling of @projectname in --project and JULIA_PROJECT
     let expanded = abspath(Base.load_path_expand("@foo"))
         @test expanded == readchomp(`$exename --project='@foo' -e 'println(Base.active_project())'`)
-        @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir()))
+        @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
     end
 
     # --quiet, --banner

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -132,7 +132,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     if !Sys.iswindows()
         let expanded = abspath(expanduser("~/foo/Project.toml"))
             @test expanded == readchomp(`$exename --project='~/foo' -e 'println(Base.active_project())'`)
-            @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir(), , "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
+            @test expanded == readchomp(setenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "~/foo", "HOME" => homedir(), "JULIA_DEPOT_PATH" => ENV["JULIA_DEPOT_PATH"]))
         end
     end
 


### PR DESCRIPTION
- ran into this while customizing conda-forge build of julia
- with @mkitti

Originally, the test as written would always default to home. However, if someone sets a different `JULIA_DEPOT_PATH`, then the test would fail. This slight edit ensures it passes. 

xref: https://github.com/conda-forge/julia-feedstock/pull/157

A simple test to confirm the problem:

```bash
JULIA_DEPOT_PATH="/some/path/of/choice:$JULIA_DEPOT_PATH" julia -E 'Base.runtests(["cmdlineargs"]; ncores=ceil(Int, Sys.CPU_THREADS))'
```