### PR TITLE
Add a check to the `SIGSEGV` handler that prints a warning if the `LD_LIBRARY_PATH` environment variable is set

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -833,6 +833,20 @@ static void post_boot_hooks(void)
     }
 }
 
+volatile int ld_library_path_is_set;
+
+static int check_ld_library_path(void)
+{
+    if ( getenv("LD_LIBRARY_PATH") ) {
+        ld_library_path_is_set = 1;
+    }
+    else {
+        ld_library_path_is_set = 0;
+    }
+}
+
+check_ld_library_path();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -221,8 +221,14 @@ static void jl_throw_in_thread(int tid, mach_port_t thread, jl_value_t *exceptio
     HANDLE_MACH_ERROR("thread_set_state", ret);
 }
 
+extern volatile int ld_library_path_is_set;
+
 static void segv_handler(int sig, siginfo_t *info, void *context)
 {
+    if(ld_library_path_is_set) {
+      jl_safe_printf("WARN: LD_LIBRARY_PATH environment variable is set.\n");
+      jl_safe_printf("WARN: You may want to try unsetting the LD_LIBRARY_PATH environment variable.\n");
+    }
     assert(sig == SIGSEGV || sig == SIGBUS);
     if (jl_get_safe_restore()) { // restarting jl_ or jl_unwind_stepn
         jl_task_t *ct = jl_get_current_task();

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -311,8 +311,14 @@ static int jl_is_on_sigstack(jl_ptls_t ptls, void *ptr, void *context)
             is_addr_on_sigstack(ptls, (void*)jl_get_rsp_from_ctx(context)));
 }
 
+extern volatile int ld_library_path_is_set;
+
 static void segv_handler(int sig, siginfo_t *info, void *context)
 {
+    if(ld_library_path_is_set) {
+      jl_safe_printf("WARN: LD_LIBRARY_PATH environment variable is set.\n");
+      jl_safe_printf("WARN: You may want to try unsetting the LD_LIBRARY_PATH environment variable.\n");
+    }
     if (jl_get_safe_restore()) { // restarting jl_ or profile
         jl_call_in_ctx(NULL, &jl_sig_throw, sig, context);
         return;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -778,10 +778,11 @@ end
         @test !success(proc)
         @test Base.process_signaled(proc)
         str = read(err, String)::String
-        segfault_text = occursin("signal (11): Segmentation fault", str)
-        buserror_text = occursin("signal (10): Bus error", str)
-        windows_eav_text = occursin("Exception: EXCEPTION_ACCESS_VIOLATION", str)
-        @test segfault_text || buserror_text || windows_eav_text
+        @test(
+            occursin("signal (11): Segmentation fault", str) ||
+            occursin("signal (10): Bus error", str) ||
+            occursin("Exception: EXCEPTION_ACCESS_VIOLATION", str)
+        )
         return str
     end
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -778,7 +778,10 @@ end
         @test !success(proc)
         @test Base.process_signaled(proc)
         str = read(err, String)::String
-        @test occursin("Segmentation fault", str)
+        segfault_text = occursin("signal (11): Segmentation fault", str)
+        buserror_text = occursin("signal (10): Bus error", str)
+        windows_eav_text = occursin("Exception: EXCEPTION_ACCESS_VIOLATION", str)
+        @test segfault_text || buserror_text || windows_eav_text
         return str
     end
 


### PR DESCRIPTION
## Summary

This pull request adds a check to the `SIGSEGV` handler that prints a warning if the `LD_LIBRARY_PATH` environment variable is set.

## Motivation

As reported by @storopoli on Slack, if you have the `LD_LIBRARY_PATH` environment variable set, this can lead to a segfault when trying to run `] st` with the official binaries.

```
❯ julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.7.1 (2021-12-22)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.7) pkg> st
[1]    20182 segmentation fault (core dumped)  julia
```

```
❯ echo $LD_LIBRARY_PATH
/usr/lib/
```

```
❯ yay -Q | rg libunwind
libunwind 1.6.2-1
```