### PR TITLE
optimizer: compute side-effect-freeness for array allocations

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -193,17 +193,17 @@ end
 
 
 """
-    Base.bitsunionsize(U::Union)
+    Base.bitsunionsize(U::Union) -> Int
 
 For a `Union` of [`isbitstype`](@ref) types, return the size of the largest type; assumes `Base.isbitsunion(U) == true`.
 
 # Examples
 ```jldoctest
 julia> Base.bitsunionsize(Union{Float64, UInt8})
-0x0000000000000008
+8
 
 julia> Base.bitsunionsize(Union{Float64, UInt8, Int128})
-0x0000000000000010
+16
 ```
 """
 function bitsunionsize(u::Union)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -444,7 +444,6 @@ unsafe_convert(::Type{T}, x::T) where {T} = x
 
 const NTuple{N,T} = Tuple{Vararg{T,N}}
 
-
 ## primitive Array constructors
 struct UndefInitializer end
 const undef = UndefInitializer()

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -45,6 +45,7 @@
     XX(jl_array_to_string) \
     XX(jl_array_typetagdata) \
     XX(jl_arrayunset) \
+    XX(jl_array_validate_dims) \
     XX(jl_atexit_hook) \
     XX(jl_atomic_bool_cmpswap_bits) \
     XX(jl_atomic_cmpswap_bits) \
@@ -564,4 +565,3 @@
     YY(LLVMExtraAddGCInvariantVerifierPass) \
     YY(LLVMExtraAddDemoteFloat16Pass) \
     YY(LLVMExtraAddCPUFeaturesPass) \
-

--- a/src/julia.h
+++ b/src/julia.h
@@ -1530,6 +1530,7 @@ JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz);
 JL_DLLEXPORT void jl_array_ptr_1d_push(jl_array_t *a, jl_value_t *item);
 JL_DLLEXPORT void jl_array_ptr_1d_append(jl_array_t *a, jl_array_t *a2);
 JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_value_t *type, size_t dim);
+JL_DLLEXPORT int jl_array_validate_dims(size_t *nel, size_t *tot, uint32_t ndims, size_t *dims, size_t elsz);
 // property access
 JL_DLLEXPORT void *jl_array_ptr(jl_array_t *a);
 JL_DLLEXPORT void *jl_array_eltype(jl_value_t *a);

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -344,11 +344,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         rm(memfile)
         @test popfirst!(got) == "        0 g(x) = x + 123456"
         @test popfirst!(got) == "        - function f(x)"
-        if Sys.WORD_SIZE == 64
-            @test popfirst!(got) == "       48     []"
-        else
-            @test popfirst!(got) == "       32     []"
-        end
+        @test popfirst!(got) == "        -     []"
         if Sys.WORD_SIZE == 64
             # P64 pools with 64 bit tags
             @test popfirst!(got) == "       16     Base.invokelatest(g, 0)"

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -151,12 +151,13 @@ end
 end
 
 function fully_eliminated(f, args)
+    @nospecialize f args
     let code = code_typed(f, args)[1][1].code
         return length(code) == 1 && isa(code[1], ReturnNode)
     end
 end
-
 function fully_eliminated(f, args, retval)
+    @nospecialize f args
     let code = code_typed(f, args)[1][1].code
         return length(code) == 1 && isa(code[1], ReturnNode) && code[1].val == retval
     end


### PR DESCRIPTION
This would be useful for future Julia-level optimizations on arrays.
Initially I want to have this in order to add array primitives support
in EscapeAnalysis.jl, which should help us implement a variety of array
optimizations including dead array allocation elimination, copy-elision
from `Array` to `ImmutableArray` conversion (#42465), etc., but I found
this might be already useful for us since this enables some DCE in very
simple cases for free:
```julia
julia> function simple!(x::T) where T
           d = IdDict{T,T}() # dead alloc
           # ... computations that don't use `d` at all
           return nothing
       end
simple! (generic function with 1 method)

julia> @code_typed simple!("foo")
CodeInfo(
1 ─     return Main.nothing
) => Nothing
```

This enhancement is super limited though, e.g. DCE won't happen when
array allocation involves other primitive operations like `arrayset`:
```julia
julia> code_typed() do
           a = Int[0,1,2]
           nothing
       end

1-element Vector{Any}:
 CodeInfo(
1 ─ %1 = $(Expr(:foreigncall, :(:jl_alloc_array_1d), Vector{Int64}, svec(Any, Int64), 0, :(:ccall), Vector{Int64}, 3, 3))::Vector{Int64}
│        Base.arrayset(false, %1, 0, 1)::Vector{Int64}
│        Base.arrayset(false, %1, 1, 2)::Vector{Int64}
│        Base.arrayset(false, %1, 2, 3)::Vector{Int64}
└──      return Main.nothing
) => Nothing
```

Further enhancement o optimize cases like above will be based on top of
incoming EA.jl (Julia-level escape analysis) or LLVM-level escape analysis.

---

@pchintalapudi So we're working more and more similar kinds of optimizations (e.g. this could be considered as a very limited version of #43548).
Maybe we want to have some meeting to discuss which parts should be done on Julia-level or LLVM-level?