### PR TITLE
win32: Fix SEH frame sentinel

### DIFF
--- a/src/win32_ucontext.c
+++ b/src/win32_ucontext.c
@@ -71,7 +71,7 @@ void jl_makecontext(win32_ucontext_t *ucp, void (*func)(void))
     jmpbuf->Rip = (unsigned long long)func;
     jmpbuf->Rsp = (unsigned long long)stack_top;
     jmpbuf->Rbp = 0;
-    jmpbuf->Frame = 0; // SEH frame
+    jmpbuf->Frame = ~0L; // SEH frame
 #elif defined(_CPU_X86_)
     jmpbuf->Eip = (unsigned long)func;
     jmpbuf->Esp = (unsigned long)stack_top;


### PR DESCRIPTION
The last entry sentinel for Win64 SEH is `~0L` not NULL. Apparently
this doesn't cause issues on windows proper, but does crash wine.
Arguably if Windows doesn't have issues then we should just fix
this in wine, but since we control the source and nobody else
ever seems to have run into this, let's just fix it and save
the good Wine folks some headache. Fixes #43569.