### PR TITLE
Restrict REPL method completion to ignore strictly less specific ones

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -605,9 +605,10 @@ function complete_methods!(out::Vector{Completion}, @nospecialize(func), args_ex
             most_specific = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), intersec, typemax(UInt))
             # `most_specific == method` indicates that there is no strictly more specific
             # method signature for these input types.
-            # `isnothing(most_specific)` indicates that the completed function call will
-            # not actually work. This can happen in case of method ambiguity.
-            # The completion is kept since it can be helpful to debug such ambiguity errors
+            # `isnothing(most_specific)` indicates that the completed function invoke will
+            # not actually work. This can happen in case of method ambiguity, or if the
+            # inferred argument types are not tight enough, which would make an invoke
+            # error because of the ambiguity, but the concrete function call still work.
             if isnothing(most_specific) || (most_specific::Method) == method
                 push!(out, MethodCompletion(func, t_in, method, orig_method))
             end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -89,6 +89,13 @@ let ex = quote
         test8() = Any[1][1]
         test9(x::Char) = pass
         test9(x::Char, i::Int) = pass
+
+        test10(a, x::Int...) = pass
+        test10(a::Integer, b::Integer, c) = pass
+        test10(a, y::Bool...) = pass
+        test10(a, d::Integer, z::Signed...) = pass
+        test10(s::String...) = pass
+
         kwtest(; x=1, y=2, w...) = pass
         kwtest2(a; x=1, y=2, w...) = pass
 
@@ -380,11 +387,14 @@ let
 end
 
 # Test completion of methods with input concrete args and args where typeinference determine their type
-let s = "CompletionFoo.test(1,1, "
+let s = "CompletionFoo.test(1, 1, "
     c, r, res = test_complete(s)
     @test !res
     @test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Int, Int})))
-    @test length(c) == 3
+    @test c[2] == string(first(methods(Main.CompletionFoo.test, Tuple{}))) # corresponding to the vararg
+    @test length(c) == 2
+    # In particular, this checks that test(x::Real, y::Real) is not a valid completion
+    # since it is strictly less specific than test(x::T, y::T) where T
     @test r == 1:18
     @test s[r] == "CompletionFoo.test"
 end
@@ -402,6 +412,7 @@ let s = "CompletionFoo.test(1,1,1,"
     c, r, res = test_complete(s)
     @test !res
     @test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Any, Any, Any})))
+    @test length(c) == 1
     @test r == 1:18
     @test s[r] == "CompletionFoo.test"
 end
@@ -548,6 +559,15 @@ end
 let s = "CompletionFoo.?([1,2,3], 2.0)"
     c, r, res = test_complete(s)
     @test !res
+    @test length(c) == 1
+    @test occursin("test(x::AbstractArray{T}, y) where T<:Real", c[1])
+    # In particular, this checks that test(args...) is not a valid completion
+    # since it is strictly less specific than test(x::AbstractArray{T}, y)
+end
+
+let s = "CompletionFoo.?([1,2,3], 2.0"
+    c, r, res = test_complete(s)
+    @test !res
     @test  any(str->occursin("test(x::AbstractArray{T}, y) where T<:Real", str), c)
     @test  any(str->occursin("test(args...)", str), c)
     @test !any(str->occursin("test3(x::AbstractArray{Int", str), c)
@@ -558,6 +578,7 @@ let s = "CompletionFoo.?('c')"
     c, r, res = test_complete(s)
     @test !res
     @test  any(str->occursin("test9(x::Char)", str), c)
+    @test  any(str->occursin("test10(a, ", str), c)
     @test !any(str->occursin("test9(x::Char, i::Int", str), c)
 end
 
@@ -565,6 +586,7 @@ let s = "CompletionFoo.?('c'"
     c, r, res = test_complete(s)
     @test !res
     @test  any(str->occursin("test9(x::Char)", str), c)
+    @test  any(str->occursin("test10(a, ", str), c)
     @test  any(str->occursin("test9(x::Char, i::Int", str), c)
 end
 
@@ -581,6 +603,14 @@ let s = "CompletionFoo.?(false, \"a\", 3, "
     @test isempty(c)
 end
 
+let s = "CompletionFoo.?(\"a\", 3, "
+    c, r, res = test_complete(s)
+    @test !res
+    @test  any(str->occursin("test10(a, x::$Int...)", str), c)
+    @test !any(str->occursin("test10(a, y::Bool...)", str), c)
+    @test !any(str->occursin("test10(s::String...)", str), c)
+end
+
 let s = "CompletionFoo.?()"
     c, r, res = test_complete(s)
     @test !res
@@ -592,10 +622,67 @@ end
 let s = "CompletionFoo.?()"
     c, r, res = test_complete_noshift(s)
     @test !res
-    @test isempty(c)
+    @test length(c) == 1
+    @test occursin("test10(s::String...)", c[1])
 end
 
 #################################################################
+
+# Test method completion with varargs
+let s = "CompletionFoo.test10(z, Integer[]...,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 5
+    @test all(startswith("test10("), c)
+    @test allunique(c)
+end
+
+let s = "CompletionFoo.test10(3, Integer[]...,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 4
+    @test all(startswith("test10("), c)
+    @test allunique(c)
+    @test !any(str->occursin("test10(s::String...)", str), c)
+end
+
+let s = "CompletionFoo.test10(3, 4,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 3
+    @test any(str->occursin("test10(a, x::$Int...)", str), c)
+    @test any(str->occursin("test10(a::Integer, b::Integer, c)", str), c)
+    @test any(str->occursin("test10(a, d::Integer, z::Signed...)", str), c)
+end
+
+let s = "CompletionFoo.test10(3, 4, 5,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 3
+    @test any(str->occursin("test10(a, x::$Int...)", str), c)
+    @test any(str->occursin("test10(a::Integer, b::Integer, c)", str), c) # show it even though the call would result in an ambiguity error
+    @test any(str->occursin("test10(a, d::Integer, z::Signed...)", str), c)
+    # the last one is not eliminated by specificity since the complete call could be
+    # test10(3, 4, 5, Int8(6)) for instance
+end
+
+let s = "CompletionFoo.test10(z, z, 0, "
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 3
+    @test any(str->occursin("test10(a, x::$Int...)", str), c)
+    @test any(str->occursin("test10(a::Integer, b::Integer, c)", str), c) # show it even though the call would result in an ambiguity error
+    @test any(str->occursin("test10(a, d::Integer, z::Signed...)", str), c)
+end
+
+let s = "CompletionFoo.test10(\"a\", Union{Signed,Bool,String}[3][1], "
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 4
+    @test all(startswith("test10("), c)
+    @test allunique(c)
+    @test !any(str->occursin("test10(a::Integer, b::Integer, c)", str), c)
+end
 
 # Test of inference based getfield completion
 let s = "(1+2im)."
@@ -1204,7 +1291,10 @@ let s = "test(1,1, "
     c, r, res = test_complete_foo(s)
     @test !res
     @test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Int, Int})))
-    @test length(c) == 3
+    @test c[2] == string(first(methods(Main.CompletionFoo.test, Tuple{})))  # corresponding to the vararg
+    @test length(c) == 2
+    # In particular, this checks that test(x::Real, y::Real) is not a valid completion
+    # since it is strictly less specific than test(x::T, y::T) where T
     @test r == 1:4
     @test s[r] == "test"
 end


### PR DESCRIPTION
Spurred by (and solves) "the inevitable edge-case" of #43536.
To copy-paste the issue I described there, we currently have:
```julia
julia> foo(x::Int, y) = x+y
foo (generic function with 1 method)

julia> foo(x::Integer, z) = x-z
foo (generic function with 2 methods)

julia> foo(3, #TAB
foo(x::Int64, y) in Main at REPL[4]:1
foo(x::Integer, z) in Main at REPL[5]:1
```
Both methods are suggested, while only the first one is any relevant since the type of `x` is known to be `Int`, which means that in this context, `foo(3, a)` will always call the first method, independently of the type of `a`.

This PR fixes that by removing suggestions of methods that are strictly less specific than other ones:
```julia
julia> foo(3, #TAB
foo(x::Int64, y) in Main at REPL[50]:1
```
It also happens when using the `?(x,y)TAB` syntax of #38791 since I believe that's desired as well there.

A note on method ambiguities: I chose to keep ambiguous method calls, even though they can only result in error, since I think it can help debug those ambiguity errors. To continue with the same example, in this PR:
```julia
julia> foo(x, t::Integer) = t
foo (generic function with 3 methods)

julia> foo(3, 4, #TAB
foo(x, t::Integer) in Main at REPL[52]:1
foo(x::Int64, y) in Main at REPL[50]:1
foo(x::Integer, z) in Main at REPL[51]:1
julia> foo(3, 4)
ERROR: MethodError: foo(::Int64, ::Int64) is ambiguous. Candidates:
  foo(x, t::Integer) in Main at REPL[52]:1
  foo(x::Int64, y) in Main at REPL[50]:1
  foo(x::Integer, z) in Main at REPL[51]:1
Possible fix, define
  foo(::Int64, ::Integer)
```