### PR TITLE
Make tests with work JULIA_PROJECT and JULIA_LOAD_PATH env variable

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -571,6 +571,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
     ENV2["JULIA_DEPOT_PATH"] = mktempdir(; cleanup = true)
+    ENV2["JULIA_PROJECT"] = mktempdir(; cleanup = true)
     try
         run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR::String,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -599,7 +599,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             @test Base.current_project() === nothing
             @test success(`$exename -e "exit(0)"`)
             for load_path in ["", "@", "@."]
-                withenv("JULIA_LOAD_PATH" => load_path, "JULIA_PROJECT" => "") do
+                withenv("JULIA_LOAD_PATH" => load_path, "JULIA_PROJECT" => nothing) do
                     @test success(`$exename -e "exit(!(Base.load_path() == []))"`)
                 end
             end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -599,7 +599,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             @test Base.current_project() === nothing
             @test success(`$exename -e "exit(0)"`)
             for load_path in ["", "@", "@."]
-                withenv("JULIA_LOAD_PATH" => load_path) do
+                withenv("JULIA_LOAD_PATH" => load_path, "JULIA_PROJECT" => "") do
                     @test success(`$exename -e "exit(!(Base.load_path() == []))"`)
                 end
             end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -671,7 +671,7 @@ mktempdir() do dir
     vdir = vdir[2:end] # remove @
     vpath = joinpath(dir, "environments", vdir)
     mkpath(vpath)
-    withenv("JULIA_DEPOT_PATH" => dir) do
+    withenv("JULIA_DEPOT_PATH" => dir, "JULIA_PROJECT" => nothing, "JULIA_LOAD_PATH" => nothing) do
         script = "@assert startswith(Base.active_project(), $(repr(vpath)))"
         @test success(`$(Base.julia_cmd()) --startup-file=no -e $(script)`)
     end


### PR DESCRIPTION
When testing Julia master with `JULIA_PROJECT` and/or `JULIA_LOAD_PATH` environmental variables set, two test failures occur.

```
$ JULIA_PROJECT="@foobar" JULIA_LOAD_PATH="@:@foobar:@stdlib" usr/bin/julia -e 'Base.runtests(["loading","cmdlineargs"])'
...
Test Summary: |   Pass  Fail  Broken   Total     Time
  Overall     | 146283     2       3  146288  3m55.2s
    loading   | 146022     1          146023    28.6s
    cmdlineargs |    261     1       3     265  3m49.2s
    FAILURE

The global RNG seed was 0x3cf856286339b4438035358c5d76b3dd.

Error in testset loading:
Test Failed at /home/mkitti/src/julia/usr/share/julia/test/loading.jl:676
  Expression: success(`$(Base.julia_cmd()) --startup-file=no -e $(script)`)
Error in testset cmdlineargs:
Test Failed at /home/mkitti/src/julia/usr/share/julia/test/cmdlineargs.jl:603
  Expression: success(`$exename -e "exit(!(Base.load_path() == []))"`)
ERROR: LoadError: Test run finished with errors
in expression starting at /home/mkitti/src/julia/usr/share/julia/test/runtests.jl:93
ERROR: A test has failed. Please submit a bug report (https://github.com/JuliaLang/julia/issues)
including error messages above and the output of versioninfo():
Julia Version 1.8.0-DEV.1182
Commit c79093821d* (2021-12-27 10:25 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: AMD FX(tm)-8350 Eight-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, bdver1)
Environment:
  JULIA_LOAD_PATH = @:@foobar:@stdlib
  JULIA_PROJECT = @foobar
  JULIA_CPU_TARGET = generic;native
```

The changes do the following:
1. Unset `JULIA_PROJECT` and `JULIA_LOAD_PATH` for two tests which assume these are at their default values.
2. Creates a temporary directory to serve as `JULIA_PROJECT` when using `Base.runtests`