### PR TITLE
`Base.runtests`: unset `JULIA_PROJECT` and `JULIA_LOAD_PATH`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -571,6 +571,8 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
     ENV2["JULIA_DEPOT_PATH"] = mktempdir(; cleanup = true)
+    delete!(ENV2, "JULIA_LOAD_PATH")
+    delete!(ENV2, "JULIA_PROJECT")
     try
         run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR::String,
             Base.DATAROOTDIR, "julia", "test", "runtests.jl")) $tests`, ENV2))


### PR DESCRIPTION
Closes #43574

This is a follow-up to #42358.