### PR TITLE
One and oneunit for triangular matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -315,6 +315,10 @@ one(D::Diagonal) = Diagonal(one.(D.diag))
 one(A::Bidiagonal{T}) where T = Bidiagonal(fill!(similar(A.dv, typeof(one(T))), one(T)), fill!(similar(A.ev, typeof(one(T))), zero(one(T))), A.uplo)
 one(A::Tridiagonal{T}) where T = Tridiagonal(fill!(similar(A.du, typeof(one(T))), zero(one(T))), fill!(similar(A.d, typeof(one(T))), one(T)), fill!(similar(A.dl, typeof(one(T))), zero(one(T))))
 one(A::SymTridiagonal{T}) where T = SymTridiagonal(fill!(similar(A.dv, typeof(one(T))), one(T)), fill!(similar(A.ev, typeof(one(T))), zero(one(T))))
+for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular, :UnitUpperTriangular)
+    @eval one(A::$t) = $t(one(parent(A)))
+    @eval oneunit(A::$t) = $t(oneunit(parent(A)))
+end
 
 zero(D::Diagonal) = Diagonal(zero.(D.diag))
 oneunit(D::Diagonal) = Diagonal(oneunit.(D.diag))

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -808,6 +808,8 @@ end
         @test (@inferred a^1) == b^1
         @test (@inferred a^-1) == b^-1
         @test one(a) == one(b)
+        @test one(a)*a == a
+        @test a*one(a) == a
         @test oneunit(a) == oneunit(b)
         @test oneunit(a) isa typeof(a)
     end

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -800,4 +800,26 @@ let A = [0.9999999999999998 4.649058915617843e-16 -1.3149405273715513e-16 9.9959
     B = [0.09648289218436859 0.023497875751503007 0.0 0.0; 0.023497875751503007 0.045787575150300804 0.0 0.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0]
     @test sqrt(A*B*A')^2 ≈ A*B*A'
 end
+
+@testset "one and oneunit for triangular" begin
+    m = rand(4,4)
+    function test_one_oneunit_triangular(a)
+        b = Matrix(a)
+        @test (@inferred a^1) == b^1
+        @test (@inferred a^-1) == b^-1
+        @test one(a) == one(b)
+        @test oneunit(a) == oneunit(b)
+        @test oneunit(a) isa typeof(a)
+    end
+    for T in [UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular]
+        a = T(m)
+        test_one_oneunit_triangular(a)
+    end
+    # more complicated examples
+    b = UpperTriangular(LowerTriangular(m))
+    test_one_oneunit_triangular(b)
+    c = UpperTriangular(Diagonal(rand(2)))
+    test_one_oneunit_triangular(c)
+end
+
 end # module TestTriangular


### PR DESCRIPTION
Specializing `one` for triangular matrix types makes literal exponentiation type-stable. I've also added `oneunit` as this seemed reasonable.

On master:
```julia
julia> a = UpperTriangular(rand(2,2))
2×2 UpperTriangular{Float64, Matrix{Float64}}:
 0.9534  0.432785
  ⋅      0.863873

julia> @inferred a^1
ERROR: return type UpperTriangular{Float64, Matrix{Float64}} does not match inferred return type Union{UpperTriangular{Float64, Matrix{Float64}}, Matrix{Float64}}
[...]

julia> one(a)
2×2 Matrix{Float64}:
 1.0  0.0
 0.0  1.0
```

After this PR:
```julia
julia> a = UpperTriangular(rand(2,2))
2×2 UpperTriangular{Float64, Matrix{Float64}}:
 0.167314  0.506274
  ⋅        0.844261

julia> @inferred a^1
2×2 UpperTriangular{Float64, Matrix{Float64}}:
 0.167314  0.506274
  ⋅        0.844261

julia> one(a)
2×2 UpperTriangular{Float64, Matrix{Float64}}:
 1.0  0.0
  ⋅   1.0
```