### PR TITLE
Make TAB-completion behave as SHIFT-TAB in REPL except for ?(x,y) syntax

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -492,15 +492,7 @@ beforecursor(buf::IOBuffer) = String(buf.data[1:buf.ptr-1])
 function complete_line(c::REPLCompletionProvider, s::PromptState)
     partial = beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
-    ret, range, should_complete = completions(full, lastindex(partial))
-    if !c.modifiers.shift
-        # Filter out methods where all arguments are `Any`
-        filter!(ret) do c
-            isa(c, REPLCompletions.MethodCompletion) || return true
-            sig = Base.unwrap_unionall(c.method.sig)::DataType
-            return !all(T -> T === Any || T === Vararg{Any}, sig.parameters[2:end])
-        end
-    end
+    ret, range, should_complete = completions(full, lastindex(partial), Main, c.modifiers.shift)
     c.modifiers = LineEdit.Modifiers()
     return unique!(map(completion_text, ret)), partial[range], should_complete
 end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -127,6 +127,7 @@ test_scomplete(s) =  map_completion_text(@inferred(shell_completions(s, lastinde
 test_bslashcomplete(s) =  map_completion_text(@inferred(bslash_completions(s, lastindex(s)))[2])
 test_complete_context(s, m) =  map_completion_text(@inferred(completions(s,lastindex(s), m)))
 test_complete_foo(s) = test_complete_context(s, Main.CompletionFoo)
+test_complete_noshift(s) = map_completion_text(@inferred(completions(s, lastindex(s), Main, false)))
 
 module M32377 end
 test_complete_32377(s) = map_completion_text(completions(s,lastindex(s), M32377))
@@ -565,6 +566,33 @@ let s = "CompletionFoo.?('c'"
     @test !res
     @test  any(str->occursin("test9(x::Char)", str), c)
     @test  any(str->occursin("test9(x::Char, i::Int", str), c)
+end
+
+let s = "CompletionFoo.?(false, \"a\", 3, "
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 1
+    @test occursin("test(args...)", c[1])
+end
+
+let s = "CompletionFoo.?(false, \"a\", 3, "
+    c, r, res = test_complete_noshift(s)
+    @test !res
+    @test isempty(c)
+end
+
+let s = "CompletionFoo.?()"
+    c, r, res = test_complete(s)
+    @test !res
+    @test any(str->occursin("foo()", str), c)
+    @test any(str->occursin("kwtest(;", str), c)
+    @test any(str->occursin("test(args...)", str), c)
+end
+
+let s = "CompletionFoo.?()"
+    c, r, res = test_complete_noshift(s)
+    @test !res
+    @test isempty(c)
 end
 
 #################################################################


### PR DESCRIPTION
#38791 introduced the `?(x,y)TAB` syntax in REPL for discovering methods accepting given argument types. To avoid showing irrelevant suggestions, it was decided that only methods having at least one of their argument annotated by a non-`Any` type would be shown when using a simple TAB, and all methods would only be shown when using SHIFT-TAB. For reference, check [the NEWS entry](https://github.com/JuliaLang/julia/pull/38791/files#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR60-R64) or [the documentation](https://docs.julialang.org/en/v1.8-dev/stdlib/REPL/#Tab-completion).

However, this behavior of TAB vs SHIFT-TAB affects not only the `?(x,y)TAB` syntax, but also the usual REPL method completion. Consider:
```julia
julia> foo(a; kwarg) = kwarg - a;

julia> foo( #TAB -> nothing

julia> foo( #SHIFT-TAB
foo(a; kwarg) in Main at REPL[1]:1
```

I'm not sure this behavior is desired, nor actually intentional. In particular, [the docs](https://docs.julialang.org/en/v1.8-dev/stdlib/REPL/#Tab-completion) were not updated: the entry on `max([1, 2], #TAB` completion currently does not show any of the proposed suggestions since they don't have a non-`Any` argument type.

This PR restores the previous behavior of simple TAB (identical to the current SHIFT-TAB) for everything but the `?(x,y)` syntax, where the distinction is kept. Alternatively, if the current behavior is preferred, at least the docs should be updated to make people think of using SHIFT-TAB instead of TAB. In any case, I think it's good to have this PR open to weigh the opinions of everyone.