### PR TITLE
Spell out ~0L literal

### DIFF
--- a/src/win32_ucontext.c
+++ b/src/win32_ucontext.c
@@ -71,7 +71,7 @@ void jl_makecontext(win32_ucontext_t *ucp, void (*func)(void))
     jmpbuf->Rip = (unsigned long long)func;
     jmpbuf->Rsp = (unsigned long long)stack_top;
     jmpbuf->Rbp = 0;
-    jmpbuf->Frame = ~0L; // SEH frame
+    jmpbuf->Frame = ~(uint64_t)0; // SEH frame
 #elif defined(_CPU_X86_)
     jmpbuf->Eip = (unsigned long)func;
     jmpbuf->Esp = (unsigned long)stack_top;


### PR DESCRIPTION
To avoid the compiler potentially picking the wrong size depending on standards versions.