### PR TITLE
Generate memset and memmove intrinsics from ccalls

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1723,9 +1723,11 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const jl_cgval_t &val = argv[1];
         const jl_cgval_t &n = argv[2];
         Value *destp = emit_unbox(ctx, T_size, dst, (jl_value_t*)jl_voidpointer_type);
+        Value *val32 = emit_unbox(ctx, T_int32, val, (jl_value_t*)jl_uint32_type);
+        Value *val8 = ctx.builder.CreateTrunc(val32, T_int8, "memset_val");
         ctx.builder.CreateMemSet(
             emit_inttoptr(ctx, destp, T_pint8),
-            emit_unbox(ctx, T_int32, val, (jl_value_t*)jl_uint32_type),
+            val8,
             emit_unbox(ctx, T_size, n, (jl_value_t*)jl_ulong_type),
             MaybeAlign(1)
         );

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1743,7 +1743,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
 
         ctx.builder.CreateMemMove(
                 emit_inttoptr(ctx, destp, T_pint8),
-                MaybeAlign(1),
+                MaybeAlign(0),
                 emit_inttoptr(ctx,
                     emit_unbox(ctx, T_size, src, (jl_value_t*)jl_voidpointer_type),
                     T_pint8),


### PR DESCRIPTION
Memset and memmove are recognized LLVM builtins and should be generated as such, since LLVM can run store->load forwarding on small calls of known size. Furthermore, for arrays LLVM builtin memset instructions do not cause escapes, but direct calls to memset in the IR will escape. 

---

Initially this PR only supported memset, but now supports memmove as well.