### PR TITLE
inference: introduce more error/throwness checks for array primitives

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -155,7 +155,7 @@ const _PURE_BUILTINS = Any[tuple, svec, ===, typeof, nfields]
 # known to be effect-free if the are nothrow
 const _PURE_OR_ERROR_BUILTINS = [
     fieldtype, apply_type, isa, UnionAll,
-    getfield, arrayref, const_arrayref, isdefined, Core.sizeof,
+    getfield, arrayref, const_arrayref, arraysize, isdefined, Core.sizeof,
     Core.kwfunc, Core.ifelse, Core._typevar, (<:)
 ]
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1471,19 +1471,17 @@ add_tfunc(const_arrayref, 3, INT_INF, arrayref_tfunc, 20)
 
 function arrayset_tfunc(@nospecialize(boundcheck), @nospecialize(ary), @nospecialize(item),
     @nospecialize idxs...)
-    isempty(idxs) && return Bottom
-    array_builtin_common_errorcheck(boundcheck, ary, idxs) || return Bottom
-    hasintersect(widenconst(item), array_elmtype(ary)) || return Bottom
+    hasintersect(widenconst(item), arrayref_tfunc(boundcheck, ary, idxs...)) || return Bottom
     return ary
 end
 add_tfunc(arrayset, 4, INT_INF, arrayset_tfunc, 20)
 
 function array_builtin_common_errorcheck(@nospecialize(boundcheck), @nospecialize(ary),
-    @nospecialize idxs)
+    @nospecialize idxs::Tuple)
     hasintersect(widenconst(boundcheck), Bool) || return false
     hasintersect(widenconst(ary), Array) || return false
     for i = 1:length(idxs)
-        idx = idxs[i]
+        idx = getfield(idxs, i)
         idx = isvarargtype(idx) ? unwrapva(idx) : widenconst(idx)
         hasintersect(idx, Int) || return false
     end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1534,6 +1534,34 @@ using Core.Compiler: typeof_tfunc
 f_typeof_tfunc(x) = typeof(x)
 @test Base.return_types(f_typeof_tfunc, (Union{<:T, Int} where T<:Complex,)) == Any[Union{Type{Int}, Type{Complex{T}} where T<:Real}]
 
+# arrayref / arrayset / arraysize
+import Core.Compiler: Const, arrayref_tfunc, arrayset_tfunc, arraysize_tfunc
+@test arrayref_tfunc(Const(true), Vector{Int}, Int) === Int
+@test arrayref_tfunc(Const(true), Vector{<:Integer}, Int) === Integer
+@test arrayref_tfunc(Const(true), Vector, Int) === Any
+@test arrayref_tfunc(Const(true), Vector{Int}, Int, Vararg{Int}) === Int
+@test arrayref_tfunc(Const(true), Vector{Int}, Vararg{Int}) === Int
+@test arrayref_tfunc(Const(true), Vector{Int}) === Union{}
+@test arrayref_tfunc(Const(true), String, Int) === Union{}
+@test arrayref_tfunc(Const(true), Vector{Int}, Float64) === Union{}
+@test arrayref_tfunc(Int, Vector{Int}, Int) === Union{}
+@test arrayset_tfunc(Const(true), Vector{Int}, Int, Int) === Vector{Int}
+let ua = Vector{<:Integer}
+    @test arrayset_tfunc(Const(true), ua, Int, Int) === ua
+end
+@test arrayset_tfunc(Const(true), Vector, Int, Int) === Vector
+@test arrayset_tfunc(Const(true), Any, Int, Int) === Any
+@test arrayset_tfunc(Const(true), Vector{String}, String, Int, Vararg{Int}) === Vector{String}
+@test arrayset_tfunc(Const(true), Vector{String}, String, Vararg{Int}) === Vector{String}
+@test arrayset_tfunc(Const(true), Vector{String}, String) === Union{}
+@test arrayset_tfunc(Const(true), String, Char, Int) === Union{}
+@test arrayset_tfunc(Const(true), Vector{Int}, Int, Float64) === Union{}
+@test arrayset_tfunc(Int, Vector{Int}, Int, Int) === Union{}
+@test arrayset_tfunc(Const(true), Vector{Int}, Float64, Int) === Union{}
+@test arraysize_tfunc(Vector, Int) === Int
+@test arraysize_tfunc(Vector, Float64) === Union{}
+@test arraysize_tfunc(String, Int) === Union{}
+
 function f23024(::Type{T}, ::Int) where T
     1 + 1
 end


### PR DESCRIPTION
Obvious errors are usually caught in higher places like `convert`, but
it's better to have error checks at each builtin level in order to enable
early bail out from errorneous code compilation (when somehow it does not
rely on common abstractions). These checks are also useful for third
consumers like JET.