### PR TITLE
Add iterate(::Timer) for constructing simple timed loops

### DIFF
--- a/test/channels.jl
+++ b/test/channels.jl
@@ -477,6 +477,13 @@ end
     end
 end
 
+@testset "Timer loop" begin
+    te = @elapsed for t in Timer(1)
+       sleep(0.1)
+    end
+    @test te < 2
+end
+
 @testset "check_channel_state" begin
     c = Channel(1)
     close(c)


### PR DESCRIPTION
As a simplification of
```julia
t = Timer(2)
while isopen(t)
    foo()
end
```
this PR introduces iteration of a Timer to give
```julia
for t in Timer(2)
    foo()
end
```
which also exposes the elapsed time:
```julia
julia> for t in Timer(2)
            @show t
            sleep(0.5)
        end
t = 0.0
t = 0.5017449855804443
t = 1.0032310485839844
t = 1.5049281120300293
```

`collect(::Timer)` is explicitly disallowed (the lack of delay in collection would in most cases make huge arrays, and it's not very meaningful)