### PR TITLE
Add `missing` support to `hypot` and `log(b,x)`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1318,9 +1318,12 @@ for f in (:sin, :cos, :tan, :asin, :atan, :acos,
     end
     @eval $(f)(::Missing) = missing
 end
-atan(::Missing, ::Missing) = missing
-atan(::Number, ::Missing) = missing
-atan(::Missing, ::Number) = missing
+
+for f in (:atan, :hypot, :log)
+    @eval $(f)(::Missing, ::Missing) = missing
+    @eval $(f)(::Number, ::Missing) = missing
+    @eval $(f)(::Missing, ::Number) = missing
+end
 
 exp2(x::AbstractFloat) = 2^x
 exp10(x::AbstractFloat) = 10^x

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -110,7 +110,7 @@ end
 end
 
 @testset "two-argument functions" begin
-    two_argument_functions = [atan]
+    two_argument_functions = [atan, hypot, log]
 
     # All two-argument functions return missing when operating on two missing's
     # All two-argument functions return missing when operating on a scalar and an missing


### PR DESCRIPTION
This is in the spirit of #43523, which added `missing` support for the two-argument form of `atan`.