### PR TITLE
fix atomic `getfield` with boundcheck on interpreter

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -867,9 +867,9 @@ JL_CALLABLE(jl_f_getfield)
     enum jl_memory_order order = jl_memory_order_unspecified;
     JL_NARGS(getfield, 2, 4);
     if (nargs == 4) {
-        JL_TYPECHK(getfield, symbol, args[3]);
-        JL_TYPECHK(getfield, bool, args[4]);
-        order = jl_get_atomic_order_checked((jl_sym_t*)args[3], 1, 0);
+        JL_TYPECHK(getfield, symbol, args[2]);
+        JL_TYPECHK(getfield, bool, args[3]);
+        order = jl_get_atomic_order_checked((jl_sym_t*)args[2], 1, 0);
     }
     else if (nargs == 3) {
         if (!jl_is_bool(args[2])) {

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -370,3 +370,14 @@ let a = ARefxy(1, -1)
     @test_throws ConcurrencyViolationError @atomicreplace :not_atomic a.x xchg
     @test_throws ConcurrencyViolationError @atomicreplace :monotonic :acquire a.x xchg
 end
+
+# atomic getfield with boundcheck
+# via codegen
+getx(a, boundcheck) = getfield(a, :x, :sequentially_consistent, boundcheck)
+@test getx(ARefxy{Any}(42, 42), true) == 42
+@test getx(ARefxy{Any}(42, 42), false) == 42
+# via interpreter
+ans = getfield(ARefxy{Any}(42, 42), :x, :sequentially_consistent, true)
+@test ans == 42
+ans = getfield(ARefxy{Any}(42, 42), :x, :sequentially_consistent, false)
+@test ans == 42


### PR DESCRIPTION
~~Also introduces some error checks for atomic `getfield` with boundscheck in inference.~~ Separated to #43651.