### PR TITLE
test/errorshow: Disable infinite recursion tests on aarch64-darwin

### DIFF
--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -779,7 +779,7 @@ end
 
 # issue #37587
 # TODO: enable on more platforms
-if Sys.isapple() || (Sys.islinux() && Sys.ARCH === :x86_64)
+if (Sys.isapple() || Sys.islinux()) && Sys.ARCH === :x86_64
     single_repeater() = single_repeater()
     pair_repeater_a() = pair_repeater_b()
     pair_repeater_b() = pair_repeater_a()
@@ -803,7 +803,7 @@ if Sys.isapple() || (Sys.islinux() && Sys.ARCH === :x86_64)
             @test occursin(r"the last 2 lines are repeated \d+ more times", bt_str)
         end
     end
-end  # Sys.isapple()
+end
 
 @testset "ScheduledAfterSyncException" begin
     t = :DummyTask


### PR DESCRIPTION
We just don't get more than a couple frames back from libunwind
on stack overflow when running on aarch64-darwin, so restrict the
test to x64_64 also on macOS.

This test also fails using the official 1.7.0 release binary.
