### PR TITLE
Fix constructing TCPSocket from RawFD

### DIFF
--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -97,7 +97,7 @@ end
 function TCPSocket(fd::OS_HANDLE)
     tcp = TCPSocket()
     iolock_begin()
-    err = ccall(:uv_tcp_open, Int32, (Ptr{Cvoid}, OS_HANDLE), pipe.handle, fd)
+    err = ccall(:uv_tcp_open, Int32, (Ptr{Cvoid}, OS_HANDLE), tcp.handle, fd)
     uv_error("tcp_open", err)
     tcp.status = StatusOpen
     iolock_end()

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -590,6 +590,18 @@ end
     end
 end
 
+@testset "TCPSocket RawFD constructor" begin
+    if Sys.islinux()
+        let fd = ccall(:socket, Int32, (Int32, Int32, Int32),
+                       2, # AF_INET
+                       1, # SOCK_STREAM
+                       0)
+            s = Sockets.TCPSocket(RawFD(fd))
+            close(s)
+        end
+    end
+end
+
 @testset "TCPServer constructor" begin
     s = Sockets.TCPServer(; delay=false)
     if ccall(:jl_has_so_reuseport, Int32, ()) == 1


### PR DESCRIPTION
Without this, an attempt to call this function ends with:
```
ERROR: LoadError: UndefVarError: pipe not defined
Stacktrace:
 [1] TCPSocket(fd::RawFD)
   @ Sockets /nix/store/w0xq12x4gb3ng0pdh1r9ir4z14pmr3pp-julia-bin-1.7.0/share/julia/stdlib/v1.7/Sockets/src/Sockets.jl:100
 [2] top-level scope
```
Also add a test for this function. It designed only for Linux, because
I don't know whether it would work on other platforms.