### PR TITLE
Accelerate `minimum(A; dims = 1)` for cartesian indexed cases.

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -226,6 +226,11 @@ _axes(bc::Broadcasted{<:AbstractArrayStyle{0}}, ::Nothing) = ()
 
 @inline Base.axes(bc::Broadcasted{<:Any, <:NTuple{N}}, d::Integer) where N =
     d <= N ? axes(bc)[d] : OneTo(1)
+@inline Base.axes(bc::Broadcasted{<:Any, Nothing}, d::Integer) =
+    (ax = axes(bc); d <= length(ax) ? ax[d] : OneTo(1))
+
+Base.axes1(bc::Broadcasted) = axes(bc, 1)
+Base.axes1(bc::Broadcasted{<:AbstractArrayStyle{0}}) = OneTo(1)
 
 BroadcastStyle(::Type{<:Broadcasted{Style}}) where {Style} = Style()
 BroadcastStyle(::Type{<:Broadcasted{S}}) where {S<:Union{Nothing,Unknown}} =

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -911,9 +911,9 @@ end
     @test IndexStyle(bc) == IndexLinear()
     @test reduce(paren, bc) == reduce(paren, xs)
     # If `Broadcasted` does not have `IndexLinear` style, it should
-    # hit the `foldl` branch:
+    # behave like a cartesian-indexed Array (PR #43618)
     @test IndexStyle(bcraw) == IndexCartesian()
-    @test reduce(paren, bcraw) == foldl(paren, xs)
+    @test reduce(paren, bcraw) == reduce(paren, view(xs, 1:length(xs), 1:1))
 
     # issue #41055
     bc = Broadcast.instantiate(Broadcast.broadcasted(Base.literal_pow, Ref(^), [1,2], Ref(Val(2))))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1079,3 +1079,15 @@ end
     y = randn(2)
     @inferred(test(x, y)) == [0, 0]
 end
+
+@testset "axes1 and axes" begin
+    bc = Base.broadcasted(+, reshape(1:6,3,:), 1)
+    @test Base.axes(bc) == (Base.OneTo(3),Base.OneTo(2))
+    @test Base.axes1(bc) == axes(bc, 1) == Base.OneTo(3)
+    bc = Broadcast.instantiate(bc)
+    @test Base.axes(bc) == (Base.OneTo(3),Base.OneTo(2))
+    @test Base.axes1(bc) == axes(bc, 1) == Base.OneTo(3)
+    bc = Base.broadcasted(+, fill(1), 1)
+    @test Base.axes(bc) == ()
+    @test Base.axes1(bc) == axes(bc, 1) == Base.OneTo(1)
+end


### PR DESCRIPTION
Our `mapreduce` use `mapreduce_impl` for linear-indexable inputs to accelerate min/max related calls, which is critical to Float cases especially when dim1 is included in reduction. 
But the optimization is missing for cartesian cases.

This PR try to fuse more `mapreduce_impl` for free speed:
`minimum` Benchmark (combined with #43604, which widen the optimizaiton to much shorten length):
```julia
using Random, BenchmarkTools                   
Random.seed!(0);
a = view(rand(128,128),1:128,1:128);# PR 43604      This PR
@btime minimum($a, dims = 1);       #28.100 μs  --> 9.400 μs 
@btime minimum($a, dims = 2);       #4.071 μs   --> 4.086 μs 
@btime minimum($a, dims = (1,2));   #26.700 μs  --> 9.700 μs
@btime minimum($a);                 #30.400 μs  --> 9.100 μs
```