### PR TITLE
RFC: Fix "definite" leaks of `JuliaFunctions`s and `JuliaVariable`s in codegen init

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7712,16 +7712,16 @@ static std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *pare
     return std::make_pair(n, scalar);
 }
 
-std::vector<std::pair<jl_value_t**, JuliaVariable*>> gv_for_global;
+std::vector<std::pair<jl_value_t**, std::unique_ptr<JuliaVariable>>> gv_for_global;
 static void global_jlvalue_to_llvm(JuliaVariable *var, jl_value_t **addr)
 {
-    gv_for_global.push_back(std::make_pair(addr, var));
+    gv_for_global.push_back(std::make_pair(addr, std::unique_ptr<JuliaVariable>(var)));
 }
 static JuliaVariable *julia_const_gv(jl_value_t *val)
 {
     for (auto &kv : gv_for_global) {
         if (*kv.first == val)
-            return kv.second;
+            return kv.second.get();
     }
     return nullptr;
 }


### PR DESCRIPTION
This "fixes" the memory management of several allocations in codegen of both `JuliaFunction`s (first commit) and `JuliaVariable`s (second commit).  Each of these allocations is identified by Valgrind as "definitely lost" because the allocations are otherwise never freed.

Specifically, I've used `std::unique_ptr` to manage these allocations to ensure that the memory is freed just before the data structures that hold the pointers are destructed.  One implication of this change is that I've had to move away from using `std::initializer_list` to initialize `builtin_func_map`, as (from everything I have been able to [find](https://stackoverflow.com/a/25827463/1558890) on the subject), `std::initializer_list` does not work with objects that require move semantics.

The full output of unpatched julia `master` running under Valgrind is [in this gist](https://gist.github.com/garrison/d974aaeda947a0674c3012391fcb9970).  (Alternatively, [here is a view where I have highlighted](https://gist.github.com/garrison/d974aaeda947a0674c3012391fcb9970#file-gistfile1-txt-L55-L522) the many lines that would vanish upon merging this PR.)

I've marked this as RFC because it's not entirely clear that these "leaks" are worth fixing, considering that their identification as leaks is only a technicality, i.e. these objects are not meant to be freed until the program is exiting anyway.  On the other hand, as can be seen from the highlighted gist above, the ratio of useful information coming from the leak checker can be vastly improved by the changes in this patch series.  That said, there might be other ways to silence these warnings if the code changes are considered too drastic; one alternative approach might be to add additional entries to the [suppressions file](https://github.com/JuliaLang/julia/blob/master/contrib/valgrind-julia.supp).