### PR TITLE
Support LLVM 14 (upstream Git `main`)

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -8,7 +8,11 @@
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/DataLayout.h>
+#if JL_LLVM_VERSION >= 140000
+#include <llvm/MC/TargetRegistry.h>
+#else
 #include <llvm/Support/TargetRegistry.h>
+#endif
 #include <llvm/Target/TargetMachine.h>
 
 // analysis passes

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -30,7 +30,11 @@
 
 // target machine computation
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
+#if JL_LLVM_VERSION >= 140000
+#include <llvm/MC/TargetRegistry.h>
+#else
 #include <llvm/Support/TargetRegistry.h>
+#endif
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/TargetSelect.h>
@@ -867,11 +871,6 @@ extern "C" {
         jl_rettype_inferred, NULL };
 }
 
-template<typename T>
-static void add_return_attr(T *f, Attribute::AttrKind Kind)
-{
-    f->addAttribute(AttributeList::ReturnIndex, Kind);
-}
 
 static MDNode *best_tbaa(jl_value_t *jt) {
     jt = jl_unwrap_unionall(jt);
@@ -1822,7 +1821,7 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(T_size, (uintptr_t)ptr),
         T_pint64);
-    Value *v = ctx.builder.CreateLoad(pv, true, name);
+    Value *v = ctx.builder.CreateLoad(T_int64, pv, true, name);
     v = ctx.builder.CreateAdd(v, addend);
     ctx.builder.CreateStore(v, pv, true); // volatile, not atomic, so this might be an underestimate,
                                           // but it's faster this way
@@ -2961,7 +2960,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         Value *idx = emit_unbox(ctx, T_size, fld, (jl_value_t*)jl_long_type);
                         idx = emit_bounds_check(ctx, va_ary, NULL, idx, valen, boundscheck);
                         idx = ctx.builder.CreateAdd(idx, ConstantInt::get(T_size, ctx.nReqArgs));
-                        Instruction *v = ctx.builder.CreateAlignedLoad(T_prjlvalue, ctx.builder.CreateInBoundsGEP(ctx.argArray, idx), Align(sizeof(void*)));
+                        Instruction *v = ctx.builder.CreateAlignedLoad(T_prjlvalue, ctx.builder.CreateInBoundsGEP(T_prjlvalue, ctx.argArray, idx), Align(sizeof(void*)));
                         // if we know the result type of this load, we will mark that information here too
                         tbaa_decorate(tbaa_value, maybe_mark_load_dereferenceable(v, false, rt));
                         *ret = mark_julia_type(ctx, v, /*boxed*/ true, rt);
@@ -3278,7 +3277,7 @@ static CallInst *emit_jlcall(jl_codectx_t &ctx, Function *theFptr, Value *theF,
     CallInst *result = ctx.builder.CreateCall(FTy,
         ctx.builder.CreateBitCast(theFptr, FTy->getPointerTo()),
         theArgs);
-    add_return_attr(result, Attribute::NonNull);
+    addRetAttr(result, Attribute::NonNull);
     result->setCallingConv(cc);
     return result;
 }
@@ -3409,7 +3408,7 @@ static jl_cgval_t emit_call_specfun_boxed(jl_codectx_t &ctx, jl_value_t *jlretty
 {
     auto theFptr = cast<Function>(
         jl_Module->getOrInsertFunction(specFunctionObject, jl_func_sig).getCallee());
-    add_return_attr(theFptr, Attribute::NonNull);
+    addRetAttr(theFptr, Attribute::NonNull);
     theFptr->addFnAttr(Thunk);
     Value *ret = emit_jlcall(ctx, theFptr, nullptr, argv, nargs, JLCALL_F_CC);
     return update_julia_type(ctx, mark_julia_type(ctx, ret, true, jlretty), inferred_retty);
@@ -4285,7 +4284,8 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
     else {
         if (!jl_is_method(ctx.linfo->def.method) && !ctx.is_opaque_closure) {
             // TODO: inference is invalid if this has any effect (which it often does)
-            LoadInst *world = ctx.builder.CreateAlignedLoad(prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
+            LoadInst *world = ctx.builder.CreateAlignedLoad(T_size,
+                prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
             world->setOrdering(AtomicOrdering::Acquire);
             ctx.builder.CreateAlignedStore(world, ctx.world_age_field, Align(sizeof(size_t)));
         }
@@ -4659,7 +4659,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
 
             jl_cgval_t world_age = mark_julia_type(ctx,
                 tbaa_decorate(tbaa_gcframe,
-                    ctx.builder.CreateAlignedLoad(ctx.world_age_field, Align(sizeof(size_t)))),
+                    ctx.builder.CreateAlignedLoad(T_size, ctx.world_age_field, Align(sizeof(size_t)))),
                     false,
                     jl_long_type);
 
@@ -4823,8 +4823,7 @@ static Value *get_current_signal_page(jl_codectx_t &ctx)
     // return ctx.builder.CreateCall(prepare_call(reuse_signal_page_func));
     auto ptls = get_current_ptls(ctx);
     int nthfield = offsetof(jl_tls_states_t, safepoint) / sizeof(void *);
-    return emit_nthptr_recast(ctx, ptls, nthfield, tbaa_const,
-                              PointerType::get(T_psize, 0));
+    return emit_nthptr_recast(ctx, ptls, nthfield, tbaa_const, T_psize);
 }
 
 static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Module *M, jl_codegen_params_t &params)
@@ -4927,7 +4926,7 @@ static void emit_cfunc_invalidate(
         }
         else {
             gf_ret = emit_bitcast(ctx, gf_ret, gfrt->getPointerTo());
-            ctx.builder.CreateRet(ctx.builder.CreateAlignedLoad(gf_ret, Align(julia_alignment(rettype))));
+            ctx.builder.CreateRet(ctx.builder.CreateAlignedLoad(gfrt, gf_ret, Align(julia_alignment(rettype))));
         }
         break;
     }
@@ -5033,7 +5032,13 @@ static Function* gen_cfun_wrapper(
         // we are adding the extra nest parameter after sret arg.
         std::vector<std::pair<unsigned, AttributeSet>> newAttributes;
         newAttributes.reserve(attributes.getNumAttrSets() + 1);
+#if JL_LLVM_VERSION >= 140000
+        auto it = *attributes.indexes().begin();
+        const auto it_end = *attributes.indexes().end();
+#else
         auto it = attributes.index_begin();
+        const auto it_end = attributes.index_end();
+#endif
 
         // Skip past FunctionIndex
         if (it == AttributeList::AttrIndex::FunctionIndex) {
@@ -5042,7 +5047,7 @@ static Function* gen_cfun_wrapper(
 
         // Move past ReturnValue and parameter return value
         for (;it < AttributeList::AttrIndex::FirstArgIndex + sig.sret; ++it) {
-            if (attributes.hasAttributes(it)) {
+            if (hasAttributesAtIndex(attributes, it)) {
                 newAttributes.emplace_back(it, attributes.getAttributes(it));
             }
         }
@@ -5054,17 +5059,17 @@ static Function* gen_cfun_wrapper(
 
         // Shift forward the rest of the attributes
         if (attributes.getNumAttrSets() > 0) { // without this check the loop range below is invalid
-            for(;it < attributes.index_end(); ++it) {
-                if (attributes.hasAttributes(it)) {
+            for(; it != it_end; ++it) {
+                if (hasAttributesAtIndex(attributes, it)) {
                     newAttributes.emplace_back(it + 1, attributes.getAttributes(it));
                 }
             }
         }
 
         // Remember to add back FunctionIndex
-        if (attributes.hasAttributes(AttributeList::AttrIndex::FunctionIndex)) {
+        if (hasAttributesAtIndex(attributes, AttributeList::AttrIndex::FunctionIndex)) {
             newAttributes.emplace_back(AttributeList::AttrIndex::FunctionIndex,
-                                       attributes.getAttributes(AttributeList::AttrIndex::FunctionIndex));
+                                       getFnAttrs(attributes));
         }
 
         // Create the new AttributeList
@@ -5098,8 +5103,9 @@ static Function* gen_cfun_wrapper(
     // TODO: in the future, try to initialize a full TLS context here
     // for now, just use a dummy field to avoid a branch in this function
     ctx.world_age_field = ctx.builder.CreateSelect(have_tls, ctx.world_age_field, dummy_world);
-    Value *last_age = tbaa_decorate(tbaa_gcframe, ctx.builder.CreateAlignedLoad(ctx.world_age_field, Align(sizeof(size_t))));
-    Value *world_v = ctx.builder.CreateAlignedLoad(prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
+    Value *last_age = tbaa_decorate(tbaa_gcframe, ctx.builder.CreateAlignedLoad(T_size, ctx.world_age_field, Align(sizeof(size_t))));
+    Value *world_v = ctx.builder.CreateAlignedLoad(T_size,
+        prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
     cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Acquire);
 
     Value *age_ok = NULL;
@@ -5180,7 +5186,7 @@ static Function* gen_cfun_wrapper(
                 }
                 else {
                     val = emit_bitcast(ctx, val, T->getPointerTo());
-                    val = ctx.builder.CreateAlignedLoad(val, Align(1)); // make no alignment assumption about pointer from C
+                    val = ctx.builder.CreateAlignedLoad(T, val, Align(1)); // make no alignment assumption about pointer from C
                     inputarg = mark_julia_type(ctx, val, false, jargty);
                 }
             }
@@ -5241,7 +5247,7 @@ static Function* gen_cfun_wrapper(
                 assert(jl_is_datatype(jargty));
                 if (sig.byRefList.at(i)) {
                     assert(cast<PointerType>(val->getType())->getElementType() == sig.fargt[i]);
-                    val = ctx.builder.CreateAlignedLoad(val, Align(1)); // unknown alignment from C
+                    val = ctx.builder.CreateAlignedLoad(sig.fargt[i], val, Align(1)); // unknown alignment from C
                 }
                 else {
                     bool issigned = jl_signed_type && jl_subtype(jargty_proper, (jl_value_t*)jl_signed_type);
@@ -5298,7 +5304,7 @@ static Function* gen_cfun_wrapper(
             else {
                 assert(theFptr->getFunctionType() == jl_func_sig);
             }
-            add_return_attr(theFptr, Attribute::NonNull);
+            addRetAttr(theFptr, Attribute::NonNull);
             theFptr->addFnAttr(Thunk);
         }
         BasicBlock *b_generic, *b_jlcall, *b_after;
@@ -5721,7 +5727,7 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
         Module *M, jl_codegen_params_t &params)
 {
     Function *w = Function::Create(jl_func_sig, GlobalVariable::ExternalLinkage, funcName, M);
-    add_return_attr(w, Attribute::NonNull);
+    addRetAttr(w, Attribute::NonNull);
     w->addFnAttr(Thunk);
     jl_init_function(w);
     Function::arg_iterator AI = w->arg_begin();
@@ -5795,7 +5801,7 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
         if (!isboxed) {
             theArg = decay_derived(ctx, emit_bitcast(ctx, theArg, PointerType::get(lty, 0)));
             if (!lty->isAggregateType()) // keep "aggregate" type values in place as pointers
-                theArg = ctx.builder.CreateAlignedLoad(theArg, Align(julia_alignment(ty)));
+                theArg = ctx.builder.CreateAlignedLoad(lty, theArg, Align(julia_alignment(ty)));
         }
         assert(dyn_cast<UndefValue>(theArg) == NULL);
         args[idx] = theArg;
@@ -5905,22 +5911,22 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
         (void)srt; // silence unused variable error
 #else
         Attribute sret = Attribute::getWithStructRetType(jl_LLVMContext, srt);
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, sret);
+        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, sret);
 #endif
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::NoAlias);
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::NoCapture);
+        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoAlias);
+        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoCapture);
     }
     if (props.cc == jl_returninfo_t::Union) {
         unsigned argno = 1;
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::NoAlias);
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::NoCapture);
+        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoAlias);
+        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoCapture);
     }
 
     if (props.return_roots) {
         fsig.push_back(ArrayType::get(T_prjlvalue, props.return_roots)->getPointerTo(0));
         unsigned argno = fsig.size();
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::NoAlias);
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::NoCapture);
+        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoAlias);
+        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoCapture);
     }
 
     for (size_t i = 0; i < jl_nparams(sig); i++) {
@@ -5962,7 +5968,7 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
         assert(f->getFunctionType() == ftype);
     }
     if (rt == T_prjlvalue)
-        add_return_attr(f, Attribute::NonNull);
+        addRetAttr(f, Attribute::NonNull);
     props.decl = f;
     return props;
 }
@@ -6210,7 +6216,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                              GlobalVariable::ExternalLinkage,
                              declarations.specFunctionObject, M);
         jl_init_function(f);
-        add_return_attr(f, Attribute::NonNull);
+        addRetAttr(f, Attribute::NonNull);
         f->addFnAttr(Thunk);
         // TODO: (if needsparams) add attributes: dereferenceable<sizeof(void*) * length(sp)>, readonly, nocapture
         // TODO: add attributes: dereferenceable<sizeof(ft)>, readonly, nocapture - e.g. maybe_mark_argument_dereferenceable(Arg, argType);
@@ -6233,8 +6239,8 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     }
 
     if (returninfo.cc == jl_returninfo_t::Union) {
-        f->addAttribute(1, Attribute::getWithDereferenceableBytes(jl_LLVMContext, returninfo.union_bytes));
-        f->addAttribute(1, Attribute::getWithAlignment(jl_LLVMContext, Align(returninfo.union_align)));
+        addAttributeAtIndex(f, 1, Attribute::getWithDereferenceableBytes(jl_LLVMContext, returninfo.union_bytes));
+        addAttributeAtIndex(f, 1, Attribute::getWithAlignment(jl_LLVMContext, Align(returninfo.union_align)));
     }
 
 #ifdef JL_DEBUG_BUILD
@@ -6388,7 +6394,8 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     Value *last_age = NULL;
     emit_last_age_field(ctx);
     if (toplevel || ctx.is_opaque_closure) {
-        last_age = tbaa_decorate(tbaa_gcframe, ctx.builder.CreateAlignedLoad(ctx.world_age_field, Align(sizeof(size_t))));
+        last_age = tbaa_decorate(tbaa_gcframe, ctx.builder.CreateAlignedLoad(
+            T_size, ctx.world_age_field, Align(sizeof(size_t))));
     }
 
     // step 7. allocate local variables slots

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -133,13 +133,14 @@ static inline llvm::Value *get_current_ptls_from_task(llvm::IRBuilder<> &builder
 {
     using namespace llvm;
     auto T_ppjlvalue = JuliaType::get_ppjlvalue_ty(builder.getContext());
+    auto T_pjlvalue = JuliaType::get_pjlvalue_ty(builder.getContext());
     auto T_size = builder.GetInsertBlock()->getModule()->getDataLayout().getIntPtrType(builder.getContext());
     const int ptls_offset = offsetof(jl_task_t, ptls);
     llvm::Value *pptls = builder.CreateInBoundsGEP(
-        JuliaType::get_pjlvalue_ty(builder.getContext()), current_task,
+        T_pjlvalue, current_task,
         ConstantInt::get(T_size, ptls_offset / sizeof(void *)),
         "ptls_field");
-    LoadInst *ptls_load = builder.CreateAlignedLoad(
+    LoadInst *ptls_load = builder.CreateAlignedLoad(T_pjlvalue,
         emit_bitcast_with_builder(builder, pptls, T_ppjlvalue), Align(sizeof(void *)), "ptls_load");
     // Note: Corresponding store (`t->ptls = ptls`) happens in `ctx_switch` of tasks.c.
     tbaa_decorate(tbaa, ptls_load);
@@ -147,4 +148,127 @@ static inline llvm::Value *get_current_ptls_from_task(llvm::IRBuilder<> &builder
     auto ptls = CastInst::Create(Instruction::BitCast, ptls_load, T_ppjlvalue, "ptls");
     builder.Insert(ptls);
     return ptls;
+}
+
+// Compatibility shims for LLVM attribute APIs that were renamed in LLVM 14.
+//
+// Once we no longer support LLVM < 14, these can be mechanically removed by
+// translating foo(Bar, …) into Bar->foo(…) resp. Bar.foo(…).
+namespace {
+using namespace llvm;
+
+inline void addFnAttr(CallInst *Target, Attribute::AttrKind Attr)
+{
+#if JL_LLVM_VERSION >= 140000
+    Target->addFnAttr(Attr);
+#else
+    Target->addAttribute(AttributeList::FunctionIndex, Attr);
+#endif
+}
+
+template<class T, class A>
+inline void addRetAttr(T *Target, A Attr)
+{
+#if JL_LLVM_VERSION >= 140000
+    Target->addRetAttr(Attr);
+#else
+    Target->addAttribute(AttributeList::ReturnIndex, Attr);
+#endif
+}
+
+inline void addAttributeAtIndex(Function *F, unsigned Index, Attribute Attr)
+{
+#if JL_LLVM_VERSION >= 140000
+    F->addAttributeAtIndex(Index, Attr);
+#else
+    F->addAttribute(Index, Attr);
+#endif
+}
+
+inline AttributeSet getFnAttrs(const AttributeList &Attrs)
+{
+#if JL_LLVM_VERSION >= 140000
+    return Attrs.getFnAttrs();
+#else
+    return Attrs.getFnAttributes();
+#endif
+}
+
+inline AttributeSet getRetAttrs(const AttributeList &Attrs)
+{
+#if JL_LLVM_VERSION >= 140000
+    return Attrs.getRetAttrs();
+#else
+    return Attrs.getRetAttributes();
+#endif
+}
+
+inline bool hasFnAttr(const AttributeList &L, Attribute::AttrKind Kind)
+{
+#if JL_LLVM_VERSION >= 140000
+    return L.hasFnAttr(Kind);
+#else
+    return L.hasAttribute(AttributeList::FunctionIndex, Kind);
+#endif
+}
+
+inline AttributeList addAttributeAtIndex(const AttributeList &L, LLVMContext &C,
+                                         unsigned Index, Attribute::AttrKind Kind)
+{
+#if JL_LLVM_VERSION >= 140000
+    return L.addAttributeAtIndex(C, Index, Kind);
+#else
+    return L.addAttribute(C, Index, Kind);
+#endif
+}
+
+inline AttributeList addAttributeAtIndex(const AttributeList &L, LLVMContext &C,
+                                         unsigned Index, Attribute Attr)
+{
+#if JL_LLVM_VERSION >= 140000
+    return L.addAttributeAtIndex(C, Index, Attr);
+#else
+    return L.addAttribute(C, Index, Attr);
+#endif
+}
+
+inline AttributeList addAttributesAtIndex(const AttributeList &L, LLVMContext &C,
+                                          unsigned Index, const AttrBuilder &Builder)
+{
+#if JL_LLVM_VERSION >= 140000
+    return L.addAttributesAtIndex(C, Index, Builder);
+#else
+    return L.addAttributes(C, Index, Builder);
+#endif
+}
+
+inline AttributeList addFnAttribute(const AttributeList &L, LLVMContext &C,
+                                    Attribute::AttrKind Kind)
+{
+#if JL_LLVM_VERSION >= 140000
+    return L.addFnAttribute(C, Kind);
+#else
+    return L.addAttribute(C, AttributeList::FunctionIndex, Kind);
+#endif
+}
+
+inline AttributeList addRetAttribute(const AttributeList &L, LLVMContext &C,
+                                     Attribute::AttrKind Kind)
+{
+#if JL_LLVM_VERSION >= 140000
+    return L.addRetAttribute(C, Kind);
+#else
+    return L.addAttribute(C, AttributeList::ReturnIndex, Kind);
+#endif
+}
+
+inline bool hasAttributesAtIndex(const AttributeList &L, unsigned Index)
+{
+#if JL_LLVM_VERSION >= 140000
+    return L.hasAttributesAtIndex(Index);
+#else
+    return L.hasAttributes(Index);
+#endif
+}
+
 }

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -92,7 +92,11 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/NativeFormatting.h>
 #include <llvm/Support/SourceMgr.h>
+#if JL_LLVM_VERSION >= 140000
+#include <llvm/MC/TargetRegistry.h>
+#else
 #include <llvm/Support/TargetRegistry.h>
+#endif
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -912,7 +916,11 @@ static void jl_dump_asm_internal(
                                          IP.release(),
                                          std::move(CE), std::move(MAB),
                                          /*ShowInst*/ false));
+#if JL_LLVM_VERSION >= 140000
+    Streamer->initSections(true, *STI);
+#else
     Streamer->InitSections(true);
+#endif
 
     // Make the MemoryObject wrapper
     ArrayRef<uint8_t> memoryObject(const_cast<uint8_t*>((const uint8_t*)Fptr),Fsize);

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -16,7 +16,11 @@
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/FormattedStream.h>
 #include <llvm/Support/SmallVectorMemoryBuffer.h>
+#if JL_LLVM_VERSION >= 140000
+#include <llvm/MC/TargetRegistry.h>
+#else
 #include <llvm/Support/TargetRegistry.h>
+#endif
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Transforms/Utils/Cloning.h>
@@ -578,7 +582,7 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
         raw_string_ostream OS(Buf);
         logAllUnhandledErrors(Obj.takeError(), OS, "");
         OS.flush();
-        llvm::report_fatal_error("FATAL: Unable to compile LLVM Module: '" + Buf + "'\n"
+        llvm::report_fatal_error(llvm::Twine("FATAL: Unable to compile LLVM Module: '") + Buf + "'\n"
                                  "The module's content was printed above. Please file a bug report");
     }
 
@@ -647,7 +651,7 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM, LLVMContext *LLVMCtx)
     // tells DynamicLibrary to load the program, not a library.
     std::string ErrorStr;
     if (sys::DynamicLibrary::LoadLibraryPermanently(nullptr, &ErrorStr))
-        report_fatal_error("FATAL: unable to dlopen self\n" + ErrorStr);
+        report_fatal_error(llvm::Twine("FATAL: unable to dlopen self\n") + ErrorStr);
 
     GlobalJD.addGenerator(
       cantFail(orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -168,7 +168,7 @@ void GCInvariantVerifier::visitGetElementPtrInst(GetElementPtrInst &GEP) {
 void GCInvariantVerifier::visitCallInst(CallInst &CI) {
     CallingConv::ID CC = CI.getCallingConv();
     if (CC == JLCALL_F_CC || CC == JLCALL_F2_CC) {
-        for (Value *Arg : CI.arg_operands()) {
+        for (Value *Arg : CI.args()) {
             Type *Ty = Arg->getType();
             Check(Ty->isPointerTy() && cast<PointerType>(Ty)->getAddressSpace() == AddressSpace::Tracked,
                 "Invalid derived pointer in jlcall", &CI);

--- a/src/llvm-julia-licm.cpp
+++ b/src/llvm-julia-licm.cpp
@@ -81,7 +81,7 @@ struct JuliaLICMPass : public LoopPass, public JuliaPassContext {
                 // corresponding `end` can be moved to the loop exit.
                 if (callee == gc_preserve_begin_func) {
                     bool canhoist = true;
-                    for (Use &U : call->arg_operands()) {
+                    for (Use &U : call->args()) {
                         // Check if all arguments are generated outside the loop
                         auto origin = dyn_cast<Instruction>(U.get());
                         if (!origin)

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -129,8 +129,8 @@ namespace jl_intrinsics {
     // The allocation size is set to the first argument.
     static Function *addGCAllocAttributes(Function *target, LLVMContext &context)
     {
-        target->addAttribute(AttributeList::ReturnIndex, Attribute::NoAlias);
-        target->addAttribute(AttributeList::ReturnIndex, Attribute::NonNull);
+        addRetAttr(target, Attribute::NoAlias);
+        addRetAttr(target, Attribute::NonNull);
         target->addFnAttr(Attribute::getWithAllocSizeArgs(context, 1, None)); // returns %1 bytes
         return target;
     }
@@ -168,8 +168,8 @@ namespace jl_intrinsics {
                 FunctionType::get(PointerType::get(context.T_prjlvalue, 0), {context.T_int32}, false),
                 Function::ExternalLinkage,
                 NEW_GC_FRAME_NAME);
-            intrinsic->addAttribute(AttributeList::ReturnIndex, Attribute::NoAlias);
-            intrinsic->addAttribute(AttributeList::ReturnIndex, Attribute::NonNull);
+            addRetAttr(intrinsic, Attribute::NoAlias);
+            addRetAttr(intrinsic, Attribute::NonNull);
 
             return intrinsic;
         });

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -67,8 +67,8 @@ private:
 
 void LowerPTLS::set_pgcstack_attrs(CallInst *pgcstack) const
 {
-    pgcstack->addAttribute(AttributeList::FunctionIndex, Attribute::ReadNone);
-    pgcstack->addAttribute(AttributeList::FunctionIndex, Attribute::NoUnwind);
+    addFnAttr(pgcstack, Attribute::ReadNone);
+    addFnAttr(pgcstack, Attribute::NoUnwind);
 }
 
 Instruction *LowerPTLS::emit_pgcstack_tp(Value *offset, Instruction *insertBefore) const

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -394,9 +394,19 @@ bool RemoveAddrspacesPass::runOnModule(Module &M)
         for (unsigned i = 0; i < Attrs.getNumAttrSets(); ++i) {
             for (Attribute::AttrKind TypedAttr :
                  {Attribute::ByVal, Attribute::StructRet, Attribute::ByRef}) {
-                if (Type *Ty = Attrs.getAttribute(i, TypedAttr).getValueAsType()) {
-                    Attrs = Attrs.replaceAttributeType(C, i, TypedAttr,
-                                                       TypeRemapper.remapType(Ty));
+#if JL_LLVM_VERSION >= 140000
+                auto Attr = Attrs.getAttributeAtIndex(i, TypedAttr);
+#else
+                auto Attr = Attrs.getAttribute(i, TypedAttr);
+#endif
+                if (Type *Ty = Attr.getValueAsType()) {
+#if JL_LLVM_VERSION >= 140000
+                    Attrs = Attrs.replaceAttributeTypeAtIndex(
+                        C, i, TypedAttr, TypeRemapper.remapType(Ty));
+#else
+                    Attrs = Attrs.replaceAttributeType(
+                        C, i, TypedAttr, TypeRemapper.remapType(Ty));
+#endif
                     break;
                 }
             }


### PR DESCRIPTION
Compiles against llvm/llvm-project@2ec3ca747732, with some of our unmerged local patches from 13.x still required to fix some miscompilations, etc.

Unfortunately, there is quite a bit of fallout from the various attribute API renames. I chose to introduce some function shims to separate out all the preprocessor #if clutter.

Some small refactorings were also necessary as some LLVM APIs now explicitly require the pointer element type in preparation for opaque pointers.

---

There should be no functional changes on older versions; compilation checked against the BinaryBuilder LLVM 12 that the Makefiles pull in by default.

I ported Julia to LLVM `main` for my work on darwin-aarch64, but even if we might end up back-porting all the components required for that, @vchuravy mentioned on Slack that having `main` support in the main repository would still be interesting.