### PR TITLE
FAQ entry on shell metacharacters in run

### DIFF
--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -153,7 +153,7 @@ You can still do globbing and pipelines using Julia features, however.  For exam
 [`pipeline`](@ref) function allows you to chain external programs and files, similar to shell pipes, and
 the [Glob.jl package](https://github.com/vtjnash/Glob.jl) implements POSIX-compatible globbing.
 
-You can, of course run programs through the shell by explicitly passing a shell and a command string to `run`,
+You can, of course, run programs through the shell by explicitly passing a shell and a command string to `run`,
 e.g. ``` run(`sh -c "ls > files.txt"`) ``` to use the Unix [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell),
 but you should generally prefer pure-Julia code like ```run(pipeline(`ls`, "files.txt"))```.
 The reason why we avoid the shell by default is that [shelling out sucks](https://julialang.org/blog/2012/03/shelling-out-sucks/):

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -150,7 +150,7 @@ That means that `run` does not perform wildcard expansion of `*` (["globbing"](h
 nor does it interpret [shell pipelines](https://en.wikipedia.org/wiki/Pipeline_(Unix)) like `|` or `>`.
 
 You can still do globbing and pipelines using Julia features, however.  For example, the built-in
-[`pipeline`](@ref)` function allows you to chain external programs and files, similar to shell pipes, and
+[`pipeline`](@ref) function allows you to chain external programs and files, similar to shell pipes, and
 the [Glob.jl package](https://github.com/vtjnash/Glob.jl) implements POSIX-compatible globbing.
 
 Alternatively, you can run programs through the shell simply by passing a shell and a command string to `run`,

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -153,12 +153,12 @@ You can still do globbing and pipelines using Julia features, however.  For exam
 [`pipeline`](@ref) function allows you to chain external programs and files, similar to shell pipes, and
 the [Glob.jl package](https://github.com/vtjnash/Glob.jl) implements POSIX-compatible globbing.
 
-Alternatively, you can run programs through the shell simply by passing a shell and a command string to `run`,
-e.g. ``` run(`sh -c "ls * > files.txt"`) ``` to use the Unix [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell).
-The reason why we don't do this by default, and generally prefer pure-Julia scripting to relying on the shell, is
-that [shelling out sucks](https://julialang.org/blog/2012/03/shelling-out-sucks/): launching processes via the shell is
-slow, fragile to quoting of special characters, has poor error handling, and is problematic for portability.  (The Python
-developers came to a [similar conclusion](https://www.python.org/dev/peps/pep-0324/#motivation).)
+You can, of course run programs through the shell by explicitly passing a shell and a command string to `run`,
+e.g. ``` run(`sh -c "ls > files.txt"`) ``` to use the Unix [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell),
+but you should generally prefer pure-Julia code like ```run(pipeline(`ls`, "files.txt"))```.
+The reason why we avoid the shell by default is that [shelling out sucks](https://julialang.org/blog/2012/03/shelling-out-sucks/):
+launching processes via the shell is slow, fragile to quoting of special characters,  has poor error handling, and is
+problematic for portability.  (The Python developers came to a [similar conclusion](https://www.python.org/dev/peps/pep-0324/#motivation).)
 
 ## Functions
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -140,6 +140,25 @@ parsing the file once it reaches to the `exec` statement.
     @show ARGS  # put any Julia code here
     ```
     instead. Note that with this strategy [`PROGRAM_FILE`](@ref) will not be set.
+    
+### Why doesn't `run` support `*` or pipes for scripting external programs?
+
+Julia's [`run`](@ref) function launches external programs *directly*, without
+invoking an [operating-system shell](https://en.wikipedia.org/wiki/Shell_(computing))
+(unlike the `system("...")` function in other languages like Python, R, or C).
+That means that `run` does not perform wildcard expansion of `*` (["globbing"](https://en.wikipedia.org/wiki/Glob_(programming))),
+nor does it interpret [shell pipelines](https://en.wikipedia.org/wiki/Pipeline_(Unix)) like `|` or `>`.
+
+You can still do globbing and pipelines using Julia features, however.  For example, the built-in
+[`pipeline`](@ref)` function allows you to chain external programs and files, similar to shell pipes, and
+the [Glob.jl package](https://github.com/vtjnash/Glob.jl) implements POSIX-compatible globbing.
+
+Alternatively, you can run programs through the shell simply by passing a shell and a command string to `run`,
+e.g. ``` run(`sh -c "ls * > files.txt"`) ``` to use the Unix [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell).
+The reason why we don't do this by default, and generally prefer pure-Julia scripting to relying on the shell, is
+that [shelling out sucks](https://julialang.org/blog/2012/03/shelling-out-sucks/): launching processes via the shell is
+slow, fragile to quoting of special characters, has poor error handling, and is problematic for portability.  (The Python
+developers came to a [similar conclusion](https://www.python.org/dev/peps/pep-0324/#motivation).)
 
 ## Functions
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -140,7 +140,7 @@ parsing the file once it reaches to the `exec` statement.
     @show ARGS  # put any Julia code here
     ```
     instead. Note that with this strategy [`PROGRAM_FILE`](@ref) will not be set.
-    
+
 ### Why doesn't `run` support `*` or pipes for scripting external programs?
 
 Julia's [`run`](@ref) function launches external programs *directly*, without

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -154,8 +154,8 @@ You can still do globbing and pipelines using Julia features, however.  For exam
 the [Glob.jl package](https://github.com/vtjnash/Glob.jl) implements POSIX-compatible globbing.
 
 You can, of course, run programs through the shell by explicitly passing a shell and a command string to `run`,
-e.g. ``` run(`sh -c "ls > files.txt"`) ``` to use the Unix [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell),
-but you should generally prefer pure-Julia code like ```run(pipeline(`ls`, "files.txt"))```.
+e.g. ```run(`sh -c "ls > files.txt"`)``` to use the Unix [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell),
+but you should generally prefer pure-Julia scripting like ```run(pipeline(`ls`, "files.txt"))```.
 The reason why we avoid the shell by default is that [shelling out sucks](https://julialang.org/blog/2012/03/shelling-out-sucks/):
 launching processes via the shell is slow, fragile to quoting of special characters,  has poor error handling, and is
 problematic for portability.  (The Python developers came to a [similar conclusion](https://www.python.org/dev/peps/pep-0324/#motivation).)


### PR DESCRIPTION
I feel like we are answering the same question over and over on support for shell characters like `*` and `|` in `run` (see e.g. [here](https://discourse.julialang.org/t/better-support-for-running-external-commands/44933) and [here](https://discourse.julialang.org/t/is-there-any-way-to-run-an-external-command-with-in-it/73926) and [here](https://discourse.julialang.org/t/using-as-a-wildcard-in-backtick-commands/6094) and [here](https://discourse.julialang.org/t/delete-a-file-from-script-using-wildcards/7022), and it would be nice to have a succinct FAQ entry to point people to.