### PR TITLE
Fix SnoopCompile's `snoopl` macro and add test.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -103,7 +103,7 @@ typedef Instruction TerminatorInst;
 
 JL_STREAM *dump_emitted_mi_name_stream = NULL;
 extern "C" JL_DLLEXPORT
-void jl_dump_emitted_mi_name(void *s)
+void jl_dump_emitted_mi_name_impl(void *s)
 {
     dump_emitted_mi_name_stream = (JL_STREAM*)s;
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -43,7 +43,7 @@ void jl_dump_compiles_impl(void *s)
 }
 JL_STREAM *dump_llvm_opt_stream = NULL;
 extern "C" JL_DLLEXPORT
-void jl_dump_llvm_opt(void *s)
+void jl_dump_llvm_opt_impl(void *s)
 {
     dump_llvm_opt_stream = (JL_STREAM*)s;
 }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -545,6 +545,8 @@
     YY(jl_unlock_profile) \
     YY(jl_create_native) \
     YY(jl_dump_compiles) \
+    YY(jl_dump_emitted_mi_name) \
+    YY(jl_dump_llvm_opt) \
     YY(jl_dump_fptr_asm) \
     YY(jl_get_function_id) \
     YY(jl_type_to_llvm) \

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -53,57 +53,55 @@ end
 # Have to go through pains with recursive function (eval probably not required) to make sure
 # that inlining won't happen. (Tests SnoopCompile.jl's @snoopc.)
 function test_jl_dump_compiles()
-    tfile = tempname()
-    io = open(tfile, "w")
-    @eval(test_jl_dump_compiles_internal(x) = x)
-    ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), io.handle)
-    @eval test_jl_dump_compiles_internal(1)
-    ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), C_NULL)
-    close(io)
-    tstats = stat(tfile)
-    tempty = tstats.size == 0
-    rm(tfile)
-    @test tempty == false
+    mktemp() do tfile, io
+        @eval(test_jl_dump_compiles_internal(x) = x)
+        ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), io.handle)
+        @eval test_jl_dump_compiles_internal(1)
+        ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), C_NULL)
+        close(io)
+        tstats = stat(tfile)
+        tempty = tstats.size == 0
+        @test tempty == false
+    end
 end
 
 # This function tests if a toplevel thunk is output if jl_dump_compiles is enabled.
 # The eval statement creates the toplevel thunk. (Tests SnoopCompile.jl's @snoopc.)
 function test_jl_dump_compiles_toplevel_thunks()
-    tfile = tempname()
-    io = open(tfile, "w")
-    # Make sure to cause compilation of the eval function
-    # before calling it below.
-    Core.eval(Main, Any[:(nothing)][1])
-    GC.enable(false)  # avoid finalizers to be compiled
-    topthunk = Meta.lower(Main, :(for i in 1:10; end))
-    ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), io.handle)
-    Core.eval(Main, topthunk)
-    ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), C_NULL)
-    close(io)
-    GC.enable(true)
-    tstats = stat(tfile)
-    tempty = tstats.size == 0
-    rm(tfile)
-    @test tempty == true
+    mktemp() do tfile, io
+        # Make sure to cause compilation of the eval function
+        # before calling it below.
+        Core.eval(Main, Any[:(nothing)][1])
+        GC.enable(false)  # avoid finalizers to be compiled
+        topthunk = Meta.lower(Main, :(for i in 1:10; end))
+        ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), io.handle)
+        Core.eval(Main, topthunk)
+        ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), C_NULL)
+        close(io)
+        GC.enable(true)
+        tstats = stat(tfile)
+        tempty = tstats.size == 0
+        @test tempty == true
+    end
 end
 
 # This function tests if LLVM optimization info is dumped when enabled (Tests
 # SnoopCompile.jl's @snoopl.)
 function test_jl_dump_llvm_opt()
-    func_file, llvm_file = tempname(), tempname()
-    func_io, llvm_io = open(func_file, "w"), open(llvm_file, "w")
-    @eval(test_jl_dump_compiles_internal(x) = x)
-    ccall(:jl_dump_emitted_mi_name, Cvoid, (Ptr{Cvoid},), func_io.handle)
-    ccall(:jl_dump_llvm_opt, Cvoid, (Ptr{Cvoid},), llvm_io.handle)
-    @eval test_jl_dump_compiles_internal(1)
-    ccall(:jl_dump_emitted_mi_name, Cvoid, (Ptr{Cvoid},), C_NULL)
-    ccall(:jl_dump_llvm_opt, Cvoid, (Ptr{Cvoid},), C_NULL)
-    close(func_io)
-    close(llvm_io)
-    @test stat(func_file).size !== 0
-    @test stat(llvm_file).size !== 0
-    rm(func_file)
-    rm(llvm_file)
+    mktemp() do func_file, func_io
+        mktemp() do llvm_file, llvm_io
+            @eval(test_jl_dump_compiles_internal(x) = x)
+            ccall(:jl_dump_emitted_mi_name, Cvoid, (Ptr{Cvoid},), func_io.handle)
+            ccall(:jl_dump_llvm_opt, Cvoid, (Ptr{Cvoid},), llvm_io.handle)
+            @eval test_jl_dump_compiles_internal(1)
+            ccall(:jl_dump_emitted_mi_name, Cvoid, (Ptr{Cvoid},), C_NULL)
+            ccall(:jl_dump_llvm_opt, Cvoid, (Ptr{Cvoid},), C_NULL)
+            close(func_io)
+            close(llvm_io)
+            @test stat(func_file).size !== 0
+            @test stat(llvm_file).size !== 0
+        end
+    end
 end
 
 if opt_level > 0


### PR DESCRIPTION
> Fix SnoopCompile's `snoopl` macro and add test.
> 
> Previously the `@snoopl` functionality from SnoopCompile wasn't unit
> tested at all, and so it was broken in https://github.com/JuliaLang/julia/pull/38160,
> which changed the requirements for exporting C functions from the
> julia-internal shared lib.
> 
> This commit restores the functionality by exporting it correctly, and
> also adds a unit test for snoopl, to make sure it isn't broken in the
> future. Sorry that we didn't test it in the first place! :)

Thanks for pointing this out, @timholy. Fixes https://github.com/timholy/SnoopCompile.jl/issues/270.