### PR TITLE
[docs] Add an example of doing `str = readline()` to read a single line in from `stdin`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -513,7 +513,6 @@ line.
 ```jldoctest
 julia> print("Enter your name: ")
 Enter your name:
-    
 julia> your_name = readline()
 Logan
 "Logan"

--- a/base/io.jl
+++ b/base/io.jl
@@ -510,13 +510,15 @@ line before it is returned. When `keep` is true, they are returned as part of th
 line.
 
 # Examples
-```jldoctest
+```julia-repl
 julia> print("Enter your name: ")
 Enter your name:
+
 julia> your_name = readline()
 Logan
-"Logan"
-
+"Logan"  
+```   
+```jldoctest
 julia> open("my_file.txt", "w") do io
            write(io, "JuliaLang is a GitHub organization.\\nIt has many members.\\n");
        end

--- a/base/io.jl
+++ b/base/io.jl
@@ -510,14 +510,6 @@ line before it is returned. When `keep` is true, they are returned as part of th
 line.
 
 # Examples
-```julia-repl
-julia> print("Enter your name: ")
-Enter your name:
-
-julia> your_name = readline()
-Logan
-"Logan"
-```
 ```jldoctest
 julia> open("my_file.txt", "w") do io
            write(io, "JuliaLang is a GitHub organization.\\nIt has many members.\\n");
@@ -531,6 +523,14 @@ julia> readline("my_file.txt", keep=true)
 "JuliaLang is a GitHub organization.\\n"
 
 julia> rm("my_file.txt")
+```
+```julia-repl
+julia> print("Enter your name: ")
+Enter your name:
+
+julia> your_name = readline()
+Logan
+"Logan"
 ```
 """
 function readline(filename::AbstractString; keep::Bool=false)

--- a/base/io.jl
+++ b/base/io.jl
@@ -516,7 +516,7 @@ Enter your name:
 
 julia> your_name = readline()
 Logan
-"Logan"  
+"Logan"
 ```   
 ```jldoctest
 julia> open("my_file.txt", "w") do io

--- a/base/io.jl
+++ b/base/io.jl
@@ -511,6 +511,13 @@ line.
 
 # Examples
 ```jldoctest
+julia> print("Enter your name: ")
+Enter your name: 
+        
+julia> your_name = readline()
+Logan
+"Logan"
+        
 julia> open("my_file.txt", "w") do io
            write(io, "JuliaLang is a GitHub organization.\\nIt has many members.\\n");
        end

--- a/base/io.jl
+++ b/base/io.jl
@@ -512,12 +512,12 @@ line.
 # Examples
 ```jldoctest
 julia> print("Enter your name: ")
-Enter your name: 
-        
+Enter your name:
+    
 julia> your_name = readline()
 Logan
 "Logan"
-        
+
 julia> open("my_file.txt", "w") do io
            write(io, "JuliaLang is a GitHub organization.\\nIt has many members.\\n");
        end

--- a/base/io.jl
+++ b/base/io.jl
@@ -517,7 +517,7 @@ Enter your name:
 julia> your_name = readline()
 Logan
 "Logan"
-```   
+```
 ```jldoctest
 julia> open("my_file.txt", "w") do io
            write(io, "JuliaLang is a GitHub organization.\\nIt has many members.\\n");


### PR DESCRIPTION
I would assume that this might lead to doctest issues but having an example of the io readline interface seems like it is something we should do so I added this simple example.