### PR TITLE
Make `Base.prompt`, `Base.getpass`, and `Base.winprompt` part of the public API (by adding their docstrings to a manual page)

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -292,7 +292,8 @@ Displays the `message` then waits for user input. Input is terminated when a new
 is encountered or EOF (^D) character is entered on a blank line. If a `default` is provided
 then the user can enter just a newline character to select the `default`.
 
-See also `Base.getpass` and `Base.winprompt` for secure entry of passwords.
+Do not use this function for entering passwords. See `Base.getpass` and `Base.winprompt` for
+secure entry of passwords.
 
 # Example
 

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -72,6 +72,9 @@ Base.readuntil
 Base.readlines
 Base.eachline
 Base.displaysize
+Base.prompt
+Base.getpass
+Base.winprompt
 ```
 
 ## [Multimedia I/O](@id Multimedia-I/O)


### PR DESCRIPTION
1. Make the following three functions part of the public API (by adding their docstring to a manual page):
    - `Base.prompt`
    - `Base.getpass`
    - `Base.winprompt`
2. In the `Base.prompt` docstring, explicitly say that `Base.prompt` should not be used for entering passwords.