### PR TITLE
make TestLogger respect `maxlog`

### DIFF
--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -837,6 +837,8 @@ end
     @test occursin("Evaluated: 0.9 ≈ 0.1 (nans=true, atol=0.01)", msg)
 end
 
+erronce() = @error "an error" maxlog=1
+
 @testset "@test_logs" begin
     function foo(n)
         @info "Doing foo with n=$n"
@@ -864,6 +866,10 @@ end
     @test_logs (Info,"Doing foo with n=2") (Debug,"Iteration 1") (Debug,"Iteration 2") min_level=Debug foo(2)
 
     @test_logs (Debug,"Iteration 5") min_level=Debug match_mode=:any foo(10)
+
+    # Respect `maxlog`
+    @test_logs (:error, "an error") erronce()
+    @test_logs erronce()
 
     # Test failures
     fails = @testset NoThrowTestSet "check that @test_logs detects bad input" begin

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -867,9 +867,12 @@ erronce() = @error "an error" maxlog=1
 
     @test_logs (Debug,"Iteration 5") min_level=Debug match_mode=:any foo(10)
 
-    # Respect `maxlog`
-    @test_logs (:error, "an error") erronce()
-    @test_logs erronce()
+    # Respect `maxlog` (#41625)
+    logs, _ = Test.collect_test_logs() do
+        erronce()
+        erronce()
+    end
+    @test length(logs) == 1
 
     # Test failures
     fails = @testset NoThrowTestSet "check that @test_logs detects bad input" begin

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -867,12 +867,8 @@ erronce() = @error "an error" maxlog=1
 
     @test_logs (Debug,"Iteration 5") min_level=Debug match_mode=:any foo(10)
 
-    # Respect `maxlog` (#41625)
-    logs, _ = Test.collect_test_logs() do
-        erronce()
-        erronce()
-    end
-    @test length(logs) == 1
+    # Respect `maxlog` (#41625). We check we only find one logging message.
+    @test_logs (:error, "an error") (erronce(); erronce())
 
     # Test failures
     fails = @testset NoThrowTestSet "check that @test_logs detects bad input" begin


### PR DESCRIPTION
Fixes #41625, borrowing some code from SimpleLogger and ConsoleLogger.

Note that this still doesn't work:

```julia
julia> @test_logs (:error, "an error") erronce()

julia> @test_logs erronce()
```
since `@test_logs` creates a fresh logger each time (so they don't have a shared count for `maxlog`).

But at least there is a way to test `maxlog` logging statements (as shown in the diff, using `Test.collect_test_logs`). And `Test.collect_test_logs` is possibly part of the public API since it is referenced from `@test_logs`? Although it doesn't have a docstring and isn't in the manual.

Edit: actually a better way to test this using only `@test_logs` is just:
```julia
@test_logs (:error, "an error") (erronce(); erronce())
```
This errors on master but passes on this branch.