### PR TITLE
Use a valid atomic ordering in docstring

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -600,7 +600,7 @@ Mark `var` or `ex` as being performed atomically, if `ex` is a supported express
 
     @atomic a.b.x = new
     @atomic a.b.x += addend
-    @atomic :acquire_release a.b.x = new
+    @atomic :release a.b.x = new
     @atomic :acquire_release a.b.x += addend
 
 Perform the store operation expressed on the right atomically and return the


### PR DESCRIPTION
`:acquire_release` is valid only for RMW. So, for an example of the atomic store, we better use something like `:release`.