### PR TITLE
`===` Optimization: Defer recursion into pointees

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -86,11 +86,9 @@ static int NOINLINE compare_fields(const jl_value_t *a, const jl_value_t *b, jl_
         char *ao = (char*)a + offs;
         char *bo = (char*)b + offs;
         if (jl_field_isptr(dt, f)) {
-            jl_value_t *af = *(jl_value_t**)ao;
-            jl_value_t *bf = *(jl_value_t**)bo;
-            if (af != bf && (af == NULL || bf == NULL))
-                return 0;
             // Save ptr recursion until the end -- only recurse if otherwise equal
+            // Note that we also skip comparing the pointers for null here, because
+            // null fields are rare so it can save CPU to delay this read too.
             continue;
         }
         else {
@@ -131,6 +129,8 @@ static int NOINLINE compare_fields(const jl_value_t *a, const jl_value_t *b, jl_
         jl_value_t *af = ((jl_value_t**)a)[offs];
         jl_value_t *bf = ((jl_value_t**)b)[offs];
         if (af != bf) {
+            if (af == NULL || bf == NULL)
+                return 0;
             if (!jl_egal(af, bf))
                 return 0;
         }


### PR DESCRIPTION
Immutable struct comparisons with `===` can be arbitrarily expensive for
deeply recursive but (almost) equal objects. Whenever possible, it's
valuable to defer the potentially expensive recursion by first comparing
the struct fields for bitwise equality.

Before this commit, two structs are compare elementwise, in the order of
the struct definition, recursing when pointer fields are encountered.

This commit defers the recursion into pointed-to fields until after all
other non-pointer fields of the struct are compared.

This has two advantages:
1. It defers the expensive part of === comparison as long as possible,
   in the hopes that we can exit early from dissimilarities discovered
   elsewhere in the struct instances.
2. It improves cache-locality by scanning the whole struct before
   jumping into any new places in memory (and reducing comparisons
   needed on the current cache line after returning from the recursive
   call).

The drawback is that you'll have to scan the pointer fields again, which
means potentially more cache misses if the struct is very large.

The best way to tell if this is helpful or harmful is benchmarking.

Here is the motivating benchmark, which indeed improves by 10x with this
commit, compared to master:
```julia
julia> using BenchmarkTools

julia> struct VN
           val::Float32
           next::Union{VN, Array}  # put a mutable thing at the end, to prevent runtime from sharing instances
       end

julia> struct NV
           next::Union{NV, Array}  # put a mutable thing at the end, to prevent runtime from sharing instances
           val::Float32
       end

julia> function make_chain_vn(n, sentinal)
           head = VN(1, sentinal)
           for i in 2:n
               head = VN(rand(Int), head)
           end
           return head
       end
make_chain_vn (generic function with 1 method)

julia> function make_chain_nv(n, sentinal)
           head = NV(sentinal, 1)
           for i in 2:n
               head = NV(head, rand(Int))
           end
           return head
       end
make_chain_nv (generic function with 1 method)

julia> vn1, vn2 = make_chain_vn(10000, []), make_chain_vn(10000, []);

julia> nv1, nv2 = make_chain_nv(10000, []), make_chain_nv(10000, []);
```
Master:
```
julia> @btime $vn1 === $vn2
  7.562 ns (0 allocations: 0 bytes)
false

julia> @btime $nv1 === $nv2  # slower, since it recurses pointers unnecessarily
  76.952 μs (0 allocations: 0 bytes)
false
```
After this commit:
```
julia> @btime $vn1 === $vn2
  8.597 ns (0 allocations: 0 bytes)
false

julia> @btime $nv1 === $nv2  # We get to skip the recursion and exit early. :)
  10.280 ns (0 allocations: 0 bytes)
false
```

However, I think that there are probably other benchmarks where it
harms performance, so we'll have to see...

For example, here's one: In the exact opposite case as above, if the two
objects _are_ (almost) equal, necessitating checking every object, the
`NV` comparisons could have exited after all the recursive pointer
checks, and never compare the fields, whereas now the fields are checked
first, so this gets slower.

I'm not exactly sure why the `VN` comparisons get somewhat slower too,
but it's maybe because of the second scan mentioned above.

```julia
julia> function make_chain_nv(n, sentinal)
           head = NV(sentinal, 1)
           for i in 2:n
               head = NV(head, i)
           end
           return head
       end
make_chain_nv (generic function with 1 method)

julia> function make_chain_vn(n, sentinal)
           head = VN(1, sentinal)
           for i in 2:n
               head = VN(i, head)
           end
           return head
       end
make_chain_vn (generic function with 1 method)

julia> vn1, vn2 = make_chain_vn(10000, []), make_chain_vn(10000, []);

julia> nv1, nv2 = make_chain_nv(10000, []), make_chain_nv(10000, []);
```
Master:
```
julia> @btime $vn1 === $vn2
  95.996 μs (0 allocations: 0 bytes)
false

julia> @btime $nv1 === $nv2
  82.192 μs (0 allocations: 0 bytes)
false
```
This commit:
```
julia> @btime $vn1 === $vn2
  127.512 μs (0 allocations: 0 bytes)
false

julia> @btime $nv1 === $nv2
  126.837 μs (0 allocations: 0 bytes)
```

------------------------------

We stumbled across this potential optimization while reading through the code for `compare_fields()`. Hopefully it's beneficial, but we'll see! :)

Co-Authored-By: @nystrom