### PR TITLE
Manual: anonymous function in pipeline needs parentheses

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -912,7 +912,7 @@ julia> (sqrt ∘ sum)(1:10)
 7.416198487095663
 ```
 
-The pipe operator can also be used with broadcasting, as `.|>`, to provide a useful combination of the chaining/piping and dot vectorization syntax (described next).
+The pipe operator can also be used with broadcasting, as `.|>`, to provide a useful combination of the chaining/piping and dot vectorization syntax (described below).
 
 ```jldoctest
 julia> ["a", "list", "of", "strings"] .|> [uppercase, reverse, titlecase, length]
@@ -921,6 +921,19 @@ julia> ["a", "list", "of", "strings"] .|> [uppercase, reverse, titlecase, length
   "tsil"
   "Of"
  7
+```
+
+When combining pipes with anonymous functions, parentheses must be used if subsequent pipes are not to parsed as part of the anonymous function's body. Compare:
+
+```jldoctest
+julia> 1:3 .|> (x -> x^2) |> sum |> sqrt
+3.7416573867739413
+
+julia> 1:3 .|> x -> x^2 |> sum |> sqrt
+3-element Vector{Float64}:
+ 1.0
+ 2.0
+ 3.0
 ```
 
 ## [Dot Syntax for Vectorizing Functions](@id man-vectorized)


### PR DESCRIPTION
Consider:
```julia
sos = (1:10 
      .|> x -> x^2
       |> sum
)
```
This seems to compute a sum of squares.
But it does not. It outputs a vector of squares. (Because `|> sum` is parsed as being part of the anonymous function's body).
Parentheses are needed for the desired (expected?) behaviour:
```julia
sos = (1:10 
      .|> (x -> x^2)
       |> sum
)
```

This PR adds a small note and example to the "Function composition and piping" section of the manual to flag this.

The goal is to avoid befuddlement of users who expect the syntax of the first example to mean that of the second.

<br>

---

As an aside, this confusion is also present in the [docstring](https://docs.julialang.org/en/v1/base/base/#Base.:|%3E) for `|>`: 
> Applies a function to the preceding argument. This allows for easy function chaining.
> ```julia
> [1:5;] |> x->x.^2 |> sum |> inv
> ```
This is parsed as
```julia
[1:5;] |> x -> (x.^2 |> sum |> inv)
```
but it feels like the author meant
```julia
[1:5;] |> (x->x.^2) |> sum |> inv
```
.