### PR TITLE
CI (Buildkite): temporarily allow the `llvmpasses` job to fail

### DIFF
--- a/.buildkite/pipelines/main/misc/llvmpasses.yml
+++ b/.buildkite/pipelines/main/misc/llvmpasses.yml
@@ -26,6 +26,7 @@ steps:
     timeout_in_minutes: 60
   - label: "llvmpasses"
     key: "llvmpasses"
+    soft_fail: true # TODO: delete this line
     plugins:
       - JuliaCI/julia#v1:
           # Drop default "registries" directory, so it is not persisted from execution to execution


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/43415#issuecomment-1001104952